### PR TITLE
feat(imports): BirdNET-Pi source discovery scanner (native import groundwork)

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -416,6 +416,7 @@ func init() {
 	RegisterComponent("imports", "imports")
 	RegisterComponent("imports/audio", "imports.audio")
 	RegisterComponent("imports/birdnetpi", "imports.birdnetpi")
+	RegisterComponent("imports/discovery", "imports.discovery")
 
 	// Analysis package components - use slash-separated paths for subpackages
 	RegisterComponent("analysis", "analysis")

--- a/internal/imports/birdnetpi/source.go
+++ b/internal/imports/birdnetpi/source.go
@@ -190,14 +190,18 @@ func (s *Source) Close() error {
 // or "" when the table is empty.
 func (s *Source) LatestDate(ctx context.Context) (string, error) {
 	var date sql.NullString
+	// Date is a TEXT column ("YYYY-MM-DD"), so MAX is the lexical (and thus
+	// chronological) maximum. No CAST: it is redundant for a TEXT column and
+	// would prevent SQLite from using an index on Date.
 	err := s.db.WithContext(ctx).
-		Raw("SELECT MAX(CAST(Date AS TEXT)) FROM detections").
+		Raw("SELECT MAX(Date) FROM detections").
 		Scan(&date).Error
 	if err != nil {
 		return "", errors.New(err).
 			Component("imports/birdnetpi").
 			Category(errors.CategoryDatabase).
 			Context("operation", "latest_date").
+			Context("table", "detections").
 			Build()
 	}
 	if !date.Valid {

--- a/internal/imports/birdnetpi/source.go
+++ b/internal/imports/birdnetpi/source.go
@@ -3,6 +3,7 @@ package birdnetpi
 
 import (
 	"context"
+	"database/sql"
 	"net/url"
 
 	"github.com/tphakala/birdnet-go/internal/errors"
@@ -183,4 +184,24 @@ func (s *Source) Close() error {
 			Build()
 	}
 	return nil
+}
+
+// LatestDate returns the most recent detection date as stored ("YYYY-MM-DD"),
+// or "" when the table is empty.
+func (s *Source) LatestDate(ctx context.Context) (string, error) {
+	var date sql.NullString
+	err := s.db.WithContext(ctx).
+		Raw("SELECT MAX(CAST(Date AS TEXT)) FROM detections").
+		Scan(&date).Error
+	if err != nil {
+		return "", errors.New(err).
+			Component("imports/birdnetpi").
+			Category(errors.CategoryDatabase).
+			Context("operation", "latest_date").
+			Build()
+	}
+	if !date.Valid {
+		return "", nil
+	}
+	return date.String, nil
 }

--- a/internal/imports/birdnetpi/source_test.go
+++ b/internal/imports/birdnetpi/source_test.go
@@ -10,7 +10,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newTestBirdsDB(t *testing.T) string {
+// newBirdsDB creates a BirdNET-Pi style database with the detections schema and
+// runs the given INSERT statement (pass "" for an empty table), returning its path.
+func newBirdsDB(t *testing.T, insert string) string {
 	t.Helper()
 	dir := t.TempDir()
 	p := filepath.Join(dir, "birds.db")
@@ -21,21 +23,43 @@ func newTestBirdsDB(t *testing.T) string {
 		Date TEXT, Time TEXT, Sci_Name TEXT, Com_Name TEXT, Confidence REAL,
 		Lat REAL, Lon REAL, Cutoff REAL, Sens REAL, File_Name TEXT)`)
 	require.NoError(t, err)
-	_, err = db.Exec(`INSERT INTO detections VALUES
-		('2026-05-01','06:00:00','Turdus merula','Blackbird',0.9,0,0,0,1.0,'a.mp3'),
-		('2026-06-20','07:00:00','Parus major','Great Tit',0.8,0,0,0,1.0,'b.mp3')`)
-	require.NoError(t, err)
+	if insert != "" {
+		_, err = db.Exec(insert)
+		require.NoError(t, err)
+	}
 	return p
 }
 
 func TestSource_LatestDate(t *testing.T) {
 	t.Parallel()
-	p := newTestBirdsDB(t)
-	s, err := New(p)
-	require.NoError(t, err)
-	t.Cleanup(func() { assert.NoError(t, s.Close()) })
+	tests := []struct {
+		name   string
+		insert string
+		want   string
+	}{
+		{
+			name: "populated table returns the maximum date",
+			insert: `INSERT INTO detections VALUES
+				('2026-05-01','06:00:00','Turdus merula','Blackbird',0.9,0,0,0,1.0,'a.mp3'),
+				('2026-06-20','07:00:00','Parus major','Great Tit',0.8,0,0,0,1.0,'b.mp3')`,
+			want: "2026-06-20",
+		},
+		{
+			name:   "empty table returns an empty string",
+			insert: "",
+			want:   "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s, err := New(newBirdsDB(t, tt.insert))
+			require.NoError(t, err)
+			t.Cleanup(func() { assert.NoError(t, s.Close()) })
 
-	got, err := s.LatestDate(t.Context())
-	require.NoError(t, err)
-	assert.Equal(t, "2026-06-20", got)
+			got, err := s.LatestDate(t.Context())
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }

--- a/internal/imports/birdnetpi/source_test.go
+++ b/internal/imports/birdnetpi/source_test.go
@@ -1,0 +1,41 @@
+package birdnetpi
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestBirdsDB(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "birds.db")
+	db, err := sql.Open("sqlite3", p)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	_, err = db.Exec(`CREATE TABLE detections (
+		Date TEXT, Time TEXT, Sci_Name TEXT, Com_Name TEXT, Confidence REAL,
+		Lat REAL, Lon REAL, Cutoff REAL, Sens REAL, File_Name TEXT)`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO detections VALUES
+		('2026-05-01','06:00:00','Turdus merula','Blackbird',0.9,0,0,0,1.0,'a.mp3'),
+		('2026-06-20','07:00:00','Parus major','Great Tit',0.8,0,0,0,1.0,'b.mp3')`)
+	require.NoError(t, err)
+	return p
+}
+
+func TestSource_LatestDate(t *testing.T) {
+	t.Parallel()
+	p := newTestBirdsDB(t)
+	s, err := New(p)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	got, err := s.LatestDate(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "2026-06-20", got)
+}

--- a/internal/imports/birdnetpi/source_test.go
+++ b/internal/imports/birdnetpi/source_test.go
@@ -16,7 +16,7 @@ func newTestBirdsDB(t *testing.T) string {
 	p := filepath.Join(dir, "birds.db")
 	db, err := sql.Open("sqlite3", p)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = db.Close() })
+	t.Cleanup(func() { assert.NoError(t, db.Close()) })
 	_, err = db.Exec(`CREATE TABLE detections (
 		Date TEXT, Time TEXT, Sci_Name TEXT, Com_Name TEXT, Confidence REAL,
 		Lat REAL, Lon REAL, Cutoff REAL, Sens REAL, File_Name TEXT)`)
@@ -33,7 +33,7 @@ func TestSource_LatestDate(t *testing.T) {
 	p := newTestBirdsDB(t)
 	s, err := New(p)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = s.Close() })
+	t.Cleanup(func() { assert.NoError(t, s.Close()) })
 
 	got, err := s.LatestDate(t.Context())
 	require.NoError(t, err)

--- a/internal/imports/discovery/candidate.go
+++ b/internal/imports/discovery/candidate.go
@@ -1,0 +1,50 @@
+// Package discovery scans the filesystem for importable BirdNET-Pi databases
+// and provides per-environment setup guidance. It is a leaf package consumed by
+// the api/v2 import layer; it must not import any api package.
+package discovery
+
+// Kind classifies where a candidate database lives, so the UI can label it.
+type Kind string
+
+const (
+	// KindLocal is a database on a fixed local filesystem.
+	KindLocal Kind = "local"
+	// KindRemovable is a database on removable media (USB stick, SD card).
+	KindRemovable Kind = "removable"
+	// KindNetwork is a database on a network filesystem.
+	KindNetwork Kind = "network"
+)
+
+const (
+	// ReasonPermissionDenied means the file exists but is not readable by the
+	// BirdNET-Go process user.
+	ReasonPermissionDenied = "permission_denied"
+	// ReasonInvalidSchema means the file opened but is not a BirdNET-Pi database.
+	ReasonInvalidSchema = "invalid_schema"
+	// ReasonOpenFailed means the file could not be opened as a SQLite database.
+	ReasonOpenFailed = "open_failed"
+)
+
+// SourceCandidate is one discovered BirdNET-Pi database with display metadata.
+type SourceCandidate struct {
+	// Path is the absolute path to the birds.db file.
+	Path string `json:"path"`
+	// Kind is where it lives (local, removable, network).
+	Kind Kind `json:"kind"`
+	// DetectionCount is the number of rows in the detections table (0 if unread).
+	DetectionCount int `json:"detection_count"`
+	// LatestDate is the most recent detection date as "YYYY-MM-DD", or "".
+	LatestDate string `json:"latest_date"`
+	// AudioDirGuess is a sibling audio tree if found, else "".
+	AudioDirGuess string `json:"audio_dir_guess"`
+	// Size is the database file size in bytes.
+	Size int64 `json:"size"`
+	// Valid is true when the database opened and matched the BirdNET-Pi schema.
+	Valid bool `json:"valid"`
+	// Reason explains why Valid is false: one of the Reason* constants, or "".
+	Reason string `json:"reason"`
+	// OwnerUID is the file owner uid, or -1 if unknown.
+	OwnerUID int `json:"owner_uid"`
+	// OwnerName is the file owner username, or "" if unknown.
+	OwnerName string `json:"owner_name"`
+}

--- a/internal/imports/discovery/candidate_test.go
+++ b/internal/imports/discovery/candidate_test.go
@@ -1,0 +1,29 @@
+package discovery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSourceCandidate_ZeroValueIsInvalidWithNoReason(t *testing.T) {
+	t.Parallel()
+	var c SourceCandidate
+	assert.False(t, c.Valid)
+	assert.Empty(t, c.Reason)
+	assert.Equal(t, Kind(""), c.Kind)
+}
+
+func TestKindConstants(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, KindLocal, Kind("local"))
+	assert.Equal(t, KindRemovable, Kind("removable"))
+	assert.Equal(t, KindNetwork, Kind("network"))
+}
+
+func TestReasonConstants(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, ReasonPermissionDenied, "permission_denied")
+	assert.Equal(t, ReasonInvalidSchema, "invalid_schema")
+	assert.Equal(t, ReasonOpenFailed, "open_failed")
+}

--- a/internal/imports/discovery/guidance.go
+++ b/internal/imports/discovery/guidance.go
@@ -1,6 +1,7 @@
 package discovery
 
 import (
+	"runtime"
 	"slices"
 
 	"github.com/tphakala/birdnet-go/internal/sysinfo"
@@ -27,7 +28,14 @@ func BuildGuidance(envType, runAsUser string) *Guidance {
 	if sysinfo.IsContainerEnv(envType) {
 		return buildContainerGuidance(envType)
 	}
-	return buildNativeLinuxGuidance(runAsUser)
+	// Native setup guidance is implemented for Linux only. macOS and Windows are
+	// reserved: return no guidance rather than wrong, Linux-specific (lsblk/mount)
+	// instructions. This matches SelectProvider, which only populates native
+	// roots on Linux.
+	if runtime.GOOS == osLinux {
+		return buildNativeLinuxGuidance(runAsUser)
+	}
+	return nil
 }
 
 // buildNativeLinuxGuidance explains how to make BirdNET-Pi data reachable on a

--- a/internal/imports/discovery/guidance.go
+++ b/internal/imports/discovery/guidance.go
@@ -1,57 +1,104 @@
 package discovery
 
 import (
-	"strings"
-	"sync"
+	"slices"
+
+	"github.com/tphakala/birdnet-go/internal/sysinfo"
 )
 
-// Guidance holds instructions for the user when a candidate has a known problem.
+// nativeLinuxEnv is the Environment label used for native (non-container) Linux
+// guidance. It mirrors a typical sysinfo.GetEnvironment value for bare metal.
+const nativeLinuxEnv = "Bare Metal"
+
+// Guidance is environment-specific, copy-pasteable setup help shown when no
+// importable database was found automatically. It is structured as data so the
+// frontend can render and localize it.
 type Guidance struct {
-	// Key is the unique identifier for this guidance (e.g., "invalid_schema").
-	Key string
-	// Message is the user-facing instruction (not localized at this layer).
-	Message string
+	// Environment is the detected runtime (e.g. "Docker", "Bare Metal").
+	Environment string `json:"environment"`
+	// Steps is an ordered list of plain instructions or shell commands.
+	Steps []string `json:"steps"`
 }
 
-var (
-	guidanceMu sync.RWMutex
-	guidance   = map[string]Guidance{
-		ReasonPermissionDenied: {
-			Key:     ReasonPermissionDenied,
-			Message: "BirdNET-Go does not have read permission for this file. Please check the file owner and permissions.",
-		},
-		ReasonInvalidSchema: {
-			Key:     ReasonInvalidSchema,
-			Message: "This database does not have the required BirdNET-Pi schema (missing columns or table).",
-		},
-		ReasonOpenFailed: {
-			Key:     ReasonOpenFailed,
-			Message: "The file is not a valid SQLite database or could not be opened.",
-		},
+// BuildGuidance returns setup help for the given environment, or nil when none
+// applies. runAsUser is the BirdNET-Go process user, used to make native
+// permission hints concrete ("" if unknown).
+func BuildGuidance(envType, runAsUser string) *Guidance {
+	if sysinfo.IsContainerEnv(envType) {
+		return buildContainerGuidance(envType)
 	}
-)
-
-// RegisterGuidance adds or replaces guidance for a Reason.
-// It is safe for concurrent use, primarily intended for init() registration
-// of platform-specific guidance.
-func RegisterGuidance(reason, message string) {
-	guidanceMu.Lock()
-	defer guidanceMu.Unlock()
-	guidance[reason] = Guidance{
-		Key:     reason,
-		Message: strings.TrimSpace(message),
-	}
+	return buildNativeLinuxGuidance(runAsUser)
 }
 
-// GetGuidance returns the guidance for a reason, or a fallback if unknown.
-func GetGuidance(reason string) Guidance {
-	guidanceMu.RLock()
-	defer guidanceMu.RUnlock()
-	if g, ok := guidance[reason]; ok {
-		return g
+// buildNativeLinuxGuidance explains how to make BirdNET-Pi data reachable on a
+// native Linux install: where the data usually lives, and how to connect and
+// mount a USB stick or SD card.
+func buildNativeLinuxGuidance(runAsUser string) *Guidance {
+	user := runAsUser
+	if user == "" {
+		user = "birdnet"
 	}
-	return Guidance{
-		Key:     reason,
-		Message: "An unknown error prevented reading this database.",
+	steps := []string{
+		"# If your BirdNET-Pi data is on this device, it is usually at:",
+		"#   /home/<user>/BirdNET-Pi/birds.db",
+		"# If it is on a USB stick or SD card, connect it and find it:",
+		"lsblk -o NAME,SIZE,MOUNTPOINT,LABEL",
+		"# If it is not mounted yet, mount it (replace sda1 with your device):",
+		"sudo mkdir -p /mnt/usb",
+		"sudo mount /dev/sda1 /mnt/usb",
+		"# Then click Check again. BirdNET-Go runs as user '" + user + "';",
+		"# if it cannot read the data, it will offer to copy it for you.",
+	}
+	return &Guidance{Environment: nativeLinuxEnv, Steps: steps}
+}
+
+// buildContainerGuidance returns the host-side bind-mount setup steps for a
+// container runtime. The commands create the host external-media directory,
+// make it rshared so sub-mounts propagate into the container, chown it to the
+// container UID, and show the runtime-specific volume flag.
+func buildContainerGuidance(envType string) *Guidance {
+	const (
+		hostDir      = "/mnt/birdnet-go/external"
+		containerDir = "/external"
+	)
+	hostSetup := []string{
+		"sudo mkdir -p " + hostDir,
+		"sudo mount --bind " + hostDir + " " + hostDir,
+		"sudo mount --make-rshared " + hostDir,
+		`sudo chown -h "${BIRDNET_UID:-1000}:${BIRDNET_GID:-1000}" ` + hostDir,
+	}
+	switch envType {
+	case sysinfo.EnvDocker:
+		steps := slices.Clone(hostSetup)
+		steps = append(steps,
+			"# Add to your docker run command:",
+			"-v "+hostDir+":"+containerDir+":rslave",
+			"# Or in docker-compose.yml under the birdnet-go service volumes:",
+			"volumes:",
+			"  - type: bind",
+			"    source: "+hostDir,
+			"    target: "+containerDir,
+			"    bind:",
+			"      propagation: rslave",
+			"# If you used install.sh, re-run the installer to wire this automatically.",
+			"# Then restart the container.",
+		)
+		return &Guidance{Environment: envType, Steps: steps}
+	case sysinfo.EnvPodman:
+		steps := slices.Clone(hostSetup)
+		steps = append(steps,
+			"# Add to your podman run command or quadlet file:",
+			"-v "+hostDir+":"+containerDir+":rslave",
+			"# If you used install.sh, re-run the installer to wire this automatically.",
+			"# Then restart the container.",
+		)
+		return &Guidance{Environment: envType, Steps: steps}
+	default:
+		steps := slices.Clone(hostSetup)
+		steps = append(steps,
+			"# Mount the host directory into the container using your runtime's volume mechanism.",
+			"# Or re-run the BirdNET-Go installer (install.sh) to configure the mount automatically.",
+		)
+		return &Guidance{Environment: envType, Steps: steps}
 	}
 }

--- a/internal/imports/discovery/guidance.go
+++ b/internal/imports/discovery/guidance.go
@@ -1,0 +1,57 @@
+package discovery
+
+import (
+	"strings"
+	"sync"
+)
+
+// Guidance holds instructions for the user when a candidate has a known problem.
+type Guidance struct {
+	// Key is the unique identifier for this guidance (e.g., "invalid_schema").
+	Key string
+	// Message is the user-facing instruction (not localized at this layer).
+	Message string
+}
+
+var (
+	guidanceMu sync.RWMutex
+	guidance   = map[string]Guidance{
+		ReasonPermissionDenied: {
+			Key:     ReasonPermissionDenied,
+			Message: "BirdNET-Go does not have read permission for this file. Please check the file owner and permissions.",
+		},
+		ReasonInvalidSchema: {
+			Key:     ReasonInvalidSchema,
+			Message: "This database does not have the required BirdNET-Pi schema (missing columns or table).",
+		},
+		ReasonOpenFailed: {
+			Key:     ReasonOpenFailed,
+			Message: "The file is not a valid SQLite database or could not be opened.",
+		},
+	}
+)
+
+// RegisterGuidance adds or replaces guidance for a Reason.
+// It is safe for concurrent use, primarily intended for init() registration
+// of platform-specific guidance.
+func RegisterGuidance(reason, message string) {
+	guidanceMu.Lock()
+	defer guidanceMu.Unlock()
+	guidance[reason] = Guidance{
+		Key:     reason,
+		Message: strings.TrimSpace(message),
+	}
+}
+
+// GetGuidance returns the guidance for a reason, or a fallback if unknown.
+func GetGuidance(reason string) Guidance {
+	guidanceMu.RLock()
+	defer guidanceMu.RUnlock()
+	if g, ok := guidance[reason]; ok {
+		return g
+	}
+	return Guidance{
+		Key:     reason,
+		Message: "An unknown error prevented reading this database.",
+	}
+}

--- a/internal/imports/discovery/guidance_test.go
+++ b/internal/imports/discovery/guidance_test.go
@@ -1,6 +1,7 @@
 package discovery
 
 import (
+	"runtime"
 	"strings"
 	"testing"
 
@@ -11,6 +12,9 @@ import (
 
 func TestBuildGuidance_NativeLinuxHasMountSteps(t *testing.T) {
 	t.Parallel()
+	if runtime.GOOS != osLinux {
+		t.Skip("native guidance is only built on Linux; macOS and Windows are reserved")
+	}
 	g := BuildGuidance("Bare Metal", "birdnet")
 	require.NotNil(t, g)
 	joined := strings.Join(g.Steps, "\n")
@@ -22,6 +26,9 @@ func TestBuildGuidance_NativeLinuxHasMountSteps(t *testing.T) {
 
 func TestBuildGuidance_NativeLinuxDefaultsUserWhenUnknown(t *testing.T) {
 	t.Parallel()
+	if runtime.GOOS != osLinux {
+		t.Skip("native guidance is only built on Linux; macOS and Windows are reserved")
+	}
 	g := BuildGuidance("Bare Metal", "")
 	require.NotNil(t, g)
 	assert.Contains(t, strings.Join(g.Steps, "\n"), "birdnet")

--- a/internal/imports/discovery/guidance_test.go
+++ b/internal/imports/discovery/guidance_test.go
@@ -1,0 +1,28 @@
+package discovery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetGuidance_KnownReason(t *testing.T) {
+	t.Parallel()
+	g := GetGuidance(ReasonPermissionDenied)
+	assert.Equal(t, ReasonPermissionDenied, g.Key)
+	assert.Contains(t, g.Message, "permission")
+}
+
+func TestGetGuidance_UnknownReason(t *testing.T) {
+	t.Parallel()
+	g := GetGuidance("this_is_not_a_real_reason")
+	assert.Equal(t, "this_is_not_a_real_reason", g.Key)
+	assert.Contains(t, g.Message, "unknown")
+}
+
+func TestRegisterGuidance(t *testing.T) {
+	RegisterGuidance("test_custom", "My custom message")
+	g := GetGuidance("test_custom")
+	assert.Equal(t, "test_custom", g.Key)
+	assert.Equal(t, "My custom message", g.Message)
+}

--- a/internal/imports/discovery/guidance_test.go
+++ b/internal/imports/discovery/guidance_test.go
@@ -1,28 +1,44 @@
 package discovery
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/sysinfo"
 )
 
-func TestGetGuidance_KnownReason(t *testing.T) {
+func TestBuildGuidance_NativeLinuxHasMountSteps(t *testing.T) {
 	t.Parallel()
-	g := GetGuidance(ReasonPermissionDenied)
-	assert.Equal(t, ReasonPermissionDenied, g.Key)
-	assert.Contains(t, g.Message, "permission")
+	g := BuildGuidance("Bare Metal", "birdnet")
+	require.NotNil(t, g)
+	joined := strings.Join(g.Steps, "\n")
+	assert.Contains(t, joined, "lsblk")
+	assert.Contains(t, joined, "mount")
+	// The configured run-as user is surfaced in the hint.
+	assert.Contains(t, joined, "birdnet")
 }
 
-func TestGetGuidance_UnknownReason(t *testing.T) {
+func TestBuildGuidance_NativeLinuxDefaultsUserWhenUnknown(t *testing.T) {
 	t.Parallel()
-	g := GetGuidance("this_is_not_a_real_reason")
-	assert.Equal(t, "this_is_not_a_real_reason", g.Key)
-	assert.Contains(t, g.Message, "unknown")
+	g := BuildGuidance("Bare Metal", "")
+	require.NotNil(t, g)
+	assert.Contains(t, strings.Join(g.Steps, "\n"), "birdnet")
 }
 
-func TestRegisterGuidance(t *testing.T) {
-	RegisterGuidance("test_custom", "My custom message")
-	g := GetGuidance("test_custom")
-	assert.Equal(t, "test_custom", g.Key)
-	assert.Equal(t, "My custom message", g.Message)
+func TestBuildGuidance_DockerHasVolumeSteps(t *testing.T) {
+	t.Parallel()
+	g := BuildGuidance(sysinfo.EnvDocker, "")
+	require.NotNil(t, g)
+	assert.Equal(t, sysinfo.EnvDocker, g.Environment)
+	assert.Contains(t, strings.Join(g.Steps, "\n"), "rslave")
+}
+
+func TestBuildGuidance_PodmanHasVolumeSteps(t *testing.T) {
+	t.Parallel()
+	g := BuildGuidance(sysinfo.EnvPodman, "")
+	require.NotNil(t, g)
+	assert.Equal(t, sysinfo.EnvPodman, g.Environment)
+	assert.Contains(t, strings.Join(g.Steps, "\n"), "podman")
 }

--- a/internal/imports/discovery/mounts_linux.go
+++ b/internal/imports/discovery/mounts_linux.go
@@ -1,0 +1,77 @@
+//go:build linux
+
+package discovery
+
+import (
+	"bufio"
+	"os"
+	"strings"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+)
+
+// networkFSTypes is the set of /proc/mounts fstypes treated as network mounts;
+// a stat on a dead one of these can block uninterruptibly, so the scanner skips
+// any path under such a mount.
+var networkFSTypes = map[string]struct{}{
+	"nfs": {}, "nfs4": {}, "cifs": {}, "smbfs": {}, "smb3": {},
+	"fuse.sshfs": {}, "fuse.rclone": {}, "afs": {}, "ncpfs": {},
+	"glusterfs": {}, "ceph": {}, "9p": {},
+}
+
+// networkMountPrefixes parses a mounts file (e.g. /proc/mounts) and returns the
+// mount points whose filesystem type is a known network type.
+func networkMountPrefixes(mountsFile string) ([]string, error) {
+	f, err := os.Open(mountsFile) //nolint:gosec // fixed system path / test path
+	if err != nil {
+		return nil, errors.New(err).
+			Component("imports/discovery").
+			Category(errors.CategoryFileIO).
+			Context("operation", "open_mounts").
+			Build()
+	}
+	defer func() { _ = f.Close() }()
+
+	var prefixes []string
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		fields := strings.Fields(sc.Text())
+		const minMountFields = 3 // device, mountpoint, fstype, ...
+		if len(fields) < minMountFields {
+			continue
+		}
+		if _, ok := networkFSTypes[fields[2]]; ok {
+			prefixes = append(prefixes, unescapeMountField(fields[1]))
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return nil, errors.New(err).
+			Component("imports/discovery").
+			Category(errors.CategoryFileIO).
+			Context("operation", "scan_mounts").
+			Build()
+	}
+	return prefixes, nil
+}
+
+// unescapeMountField decodes the octal escapes (\040 space, \011 tab, \012
+// newline, \134 backslash) that /proc/mounts uses in path fields.
+func unescapeMountField(s string) string {
+	if !strings.Contains(s, `\`) {
+		return s
+	}
+	replacer := strings.NewReplacer(
+		`\040`, " ", `\011`, "\t", `\012`, "\n", `\134`, `\`,
+	)
+	return replacer.Replace(s)
+}
+
+// defaultNetworkMountPrefixes returns network mount points from /proc/mounts,
+// or nil on any error (best-effort: a failure just means no paths are skipped).
+func defaultNetworkMountPrefixes() []string {
+	prefixes, err := networkMountPrefixes("/proc/mounts")
+	if err != nil {
+		return nil
+	}
+	return prefixes
+}

--- a/internal/imports/discovery/mounts_linux_test.go
+++ b/internal/imports/discovery/mounts_linux_test.go
@@ -1,0 +1,42 @@
+//go:build linux
+
+package discovery
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNetworkMountPrefixes_DetectsNetworkFilesystems(t *testing.T) {
+	t.Parallel()
+	content := "" +
+		"proc /proc proc rw,relatime 0 0\n" +
+		"/dev/sda1 / ext4 rw,relatime 0 0\n" +
+		"server:/export /mnt/nas nfs4 rw,relatime 0 0\n" +
+		"//server/share /mnt/win cifs rw 0 0\n" +
+		"tmpfs /run tmpfs rw 0 0\n"
+	dir := t.TempDir()
+	f := filepath.Join(dir, "mounts")
+	require.NoError(t, os.WriteFile(f, []byte(content), 0o600))
+
+	got, err := networkMountPrefixes(f)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"/mnt/nas", "/mnt/win"}, got)
+}
+
+func TestNetworkMountPrefixes_HandlesOctalEscapesInPath(t *testing.T) {
+	t.Parallel()
+	// /proc/mounts encodes spaces as \040.
+	content := "server:/export /mnt/has\\040space nfs rw 0 0\n"
+	dir := t.TempDir()
+	f := filepath.Join(dir, "mounts")
+	require.NoError(t, os.WriteFile(f, []byte(content), 0o600))
+
+	got, err := networkMountPrefixes(f)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/mnt/has space"}, got)
+}

--- a/internal/imports/discovery/mounts_other.go
+++ b/internal/imports/discovery/mounts_other.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package discovery
+
+// defaultNetworkMountPrefixes returns nil on non-linux platforms; the v1
+// scanner only ships network-mount filtering for Linux.
+func defaultNetworkMountPrefixes() []string { return nil }

--- a/internal/imports/discovery/owner_linux.go
+++ b/internal/imports/discovery/owner_linux.go
@@ -1,0 +1,23 @@
+//go:build linux
+
+package discovery
+
+import (
+	"os"
+	"os/user"
+	"strconv"
+	"syscall"
+)
+
+// fileOwner returns the owner uid and username of info, or (-1, "") if unknown.
+func fileOwner(info os.FileInfo) (uid int, name string) {
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return -1, ""
+	}
+	uid = int(st.Uid)
+	if u, err := user.LookupId(strconv.Itoa(uid)); err == nil {
+		name = u.Username
+	}
+	return uid, name
+}

--- a/internal/imports/discovery/owner_other.go
+++ b/internal/imports/discovery/owner_other.go
@@ -1,0 +1,8 @@
+//go:build !linux
+
+package discovery
+
+import "os"
+
+// fileOwner returns unknown ownership on non-linux platforms.
+func fileOwner(_ os.FileInfo) (uid int, name string) { return -1, "" }

--- a/internal/imports/discovery/probe.go
+++ b/internal/imports/discovery/probe.go
@@ -1,0 +1,72 @@
+package discovery
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/tphakala/birdnet-go/internal/imports/birdnetpi"
+)
+
+// audioDirNames are sibling directory names that indicate a BirdNET-Pi audio
+// tree next to a birds.db.
+var audioDirNames = []string{"BirdSongs", "Extracted"}
+
+// probeCandidate inspects a birds.db at dbPath and returns display metadata.
+// It never returns an error: failures are encoded as Valid=false plus a Reason.
+func probeCandidate(ctx context.Context, dbPath string, kind Kind) SourceCandidate {
+	c := SourceCandidate{Path: dbPath, Kind: kind, OwnerUID: -1}
+
+	info, statErr := os.Stat(dbPath)
+	if statErr == nil {
+		c.Size = info.Size()
+		c.OwnerUID, c.OwnerName = fileOwner(info)
+	}
+
+	src, err := birdnetpi.New(dbPath)
+	if err != nil {
+		c.Reason = classifyOpenError(err, dbPath)
+		return c
+	}
+	defer func() { _ = src.Close() }()
+
+	if err := src.Validate(ctx); err != nil {
+		c.Reason = ReasonInvalidSchema
+		return c
+	}
+	if count, err := src.Count(ctx); err == nil {
+		c.DetectionCount = count
+	}
+	if latest, err := src.LatestDate(ctx); err == nil {
+		c.LatestDate = latest
+	}
+	c.AudioDirGuess = guessAudioDir(dbPath)
+	c.Valid = true
+	return c
+}
+
+// classifyOpenError maps an open failure to a candidate Reason. A real read
+// permission problem on the file is reported as permission-denied; anything else
+// is an open failure.
+func classifyOpenError(_ error, dbPath string) string {
+	if f, err := os.Open(dbPath); err != nil {
+		if os.IsPermission(err) {
+			return ReasonPermissionDenied
+		}
+	} else {
+		_ = f.Close()
+	}
+	return ReasonOpenFailed
+}
+
+// guessAudioDir returns the first sibling audio directory next to dbPath, or "".
+func guessAudioDir(dbPath string) string {
+	parent := filepath.Dir(dbPath)
+	for _, name := range audioDirNames {
+		candidate := filepath.Join(parent, name)
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return candidate
+		}
+	}
+	return ""
+}

--- a/internal/imports/discovery/probe.go
+++ b/internal/imports/discovery/probe.go
@@ -31,6 +31,11 @@ func probeCandidate(ctx context.Context, dbPath string, kind Kind) SourceCandida
 	defer func() { _ = src.Close() }()
 
 	if err := src.Validate(ctx); err != nil {
+		// A cancelled or expired scan context surfaces here as a Validate error;
+		// do not mislabel an otherwise valid database as having a bad schema.
+		if ctx.Err() != nil {
+			return c
+		}
 		c.Reason = ReasonInvalidSchema
 		return c
 	}

--- a/internal/imports/discovery/probe.go
+++ b/internal/imports/discovery/probe.go
@@ -25,7 +25,7 @@ func probeCandidate(ctx context.Context, dbPath string, kind Kind) SourceCandida
 
 	src, err := birdnetpi.New(dbPath)
 	if err != nil {
-		c.Reason = classifyOpenError(err, dbPath)
+		c.Reason = classifyOpenError(dbPath)
 		return c
 	}
 	defer func() { _ = src.Close() }()
@@ -45,10 +45,12 @@ func probeCandidate(ctx context.Context, dbPath string, kind Kind) SourceCandida
 	return c
 }
 
-// classifyOpenError maps an open failure to a candidate Reason. A real read
-// permission problem on the file is reported as permission-denied; anything else
-// is an open failure.
-func classifyOpenError(_ error, dbPath string) string {
+// classifyOpenError maps a birds.db open failure to a candidate Reason. gorm and
+// the SQLite driver return the same opaque "unable to open database file" for
+// both an unreadable file and a corrupt or non-SQLite one, so this re-tests
+// readability directly to tell a permission problem apart from a bad file; the
+// original open error carries no reliable signal to distinguish the two.
+func classifyOpenError(dbPath string) string {
 	if f, err := os.Open(dbPath); err != nil {
 		if os.IsPermission(err) {
 			return ReasonPermissionDenied

--- a/internal/imports/discovery/probe_test.go
+++ b/internal/imports/discovery/probe_test.go
@@ -1,0 +1,55 @@
+package discovery
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeBirdsDB(t *testing.T, dir string) string {
+	t.Helper()
+	p := filepath.Join(dir, "birds.db")
+	db, err := sql.Open("sqlite3", p)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	_, err = db.Exec(`CREATE TABLE detections (
+		Date TEXT, Time TEXT, Sci_Name TEXT, Com_Name TEXT, Confidence REAL,
+		Lat REAL, Lon REAL, Cutoff REAL, Sens REAL, File_Name TEXT)`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO detections VALUES
+		('2026-06-20','07:00:00','Parus major','Great Tit',0.8,0,0,0,1.0,'b.mp3')`)
+	require.NoError(t, err)
+	return p
+}
+
+func TestProbeCandidate_ValidDatabase(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	p := writeBirdsDB(t, dir)
+	// sibling audio tree
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "BirdSongs", "Extracted"), 0o755))
+
+	got := probeCandidate(t.Context(), p, KindLocal)
+	assert.True(t, got.Valid)
+	assert.Empty(t, got.Reason)
+	assert.Equal(t, 1, got.DetectionCount)
+	assert.Equal(t, "2026-06-20", got.LatestDate)
+	assert.Equal(t, filepath.Join(dir, "BirdSongs"), got.AudioDirGuess)
+	assert.Positive(t, got.Size)
+}
+
+func TestProbeCandidate_NotASqliteDatabase(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "birds.db")
+	require.NoError(t, os.WriteFile(p, []byte("not a database"), 0o600))
+
+	got := probeCandidate(t.Context(), p, KindLocal)
+	assert.False(t, got.Valid)
+	assert.Contains(t, []string{ReasonInvalidSchema, ReasonOpenFailed}, got.Reason)
+}

--- a/internal/imports/discovery/probe_test.go
+++ b/internal/imports/discovery/probe_test.go
@@ -16,7 +16,7 @@ func writeBirdsDB(t *testing.T, dir string) string {
 	p := filepath.Join(dir, "birds.db")
 	db, err := sql.Open("sqlite3", p)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = db.Close() })
+	t.Cleanup(func() { assert.NoError(t, db.Close()) })
 	_, err = db.Exec(`CREATE TABLE detections (
 		Date TEXT, Time TEXT, Sci_Name TEXT, Com_Name TEXT, Confidence REAL,
 		Lat REAL, Lon REAL, Cutoff REAL, Sens REAL, File_Name TEXT)`)

--- a/internal/imports/discovery/provider.go
+++ b/internal/imports/discovery/provider.go
@@ -7,6 +7,10 @@ import (
 	"github.com/tphakala/birdnet-go/internal/sysinfo"
 )
 
+// osLinux is the runtime.GOOS value for Linux; native discovery and guidance are
+// implemented for Linux only.
+const osLinux = "linux"
+
 // Root is a directory the scanner should search, with its display kind.
 type Root struct {
 	// Path is the absolute directory to search.
@@ -46,15 +50,26 @@ func SelectProvider(envType, home string) LocationProvider {
 			{Path: sysinfo.DefaultExternalMountPath, Kind: KindLocal},
 		}}
 	}
-	if runtime.GOOS != "linux" {
+	if runtime.GOOS != osLinux {
 		return staticProvider{}
 	}
+	// Deduplicate by cleaned path so an overlapping entry (e.g. home == /root,
+	// which the default list also contains) is not walked twice.
 	var roots []Root
+	seen := make(map[string]struct{})
+	addRoot := func(path string, kind Kind) {
+		clean := filepath.Clean(path)
+		if _, dup := seen[clean]; dup {
+			return
+		}
+		seen[clean] = struct{}{}
+		roots = append(roots, Root{Path: clean, Kind: kind})
+	}
 	for _, d := range nativeLinuxLocalDirs(home) {
-		roots = append(roots, Root{Path: d, Kind: KindLocal})
+		addRoot(d, KindLocal)
 	}
 	for _, d := range nativeLinuxRemovableDirs {
-		roots = append(roots, Root{Path: d, Kind: KindRemovable})
+		addRoot(d, KindRemovable)
 	}
 	return staticProvider{roots: roots}
 }

--- a/internal/imports/discovery/provider.go
+++ b/internal/imports/discovery/provider.go
@@ -1,0 +1,59 @@
+package discovery
+
+import (
+	"runtime"
+
+	"github.com/tphakala/birdnet-go/internal/sysinfo"
+)
+
+// Root is a directory the scanner should search, with its display kind.
+type Root struct {
+	// Path is the absolute directory to search.
+	Path string
+	// Kind is the display classification for candidates found beneath it.
+	Kind Kind
+}
+
+// LocationProvider yields the roots to scan for the current environment.
+type LocationProvider interface {
+	// Roots returns the directories to search.
+	Roots() []Root
+}
+
+type staticProvider struct{ roots []Root }
+
+func (p staticProvider) Roots() []Root { return p.roots }
+
+// nativeLinuxLocalDirs are the fixed local directories that commonly hold a
+// BirdNET-Pi install. home is expanded to <home>/BirdNET-Pi and <home>.
+func nativeLinuxLocalDirs(home string) []string {
+	dirs := []string{"/opt/birdnet-pi", "/root"}
+	if home != "" {
+		dirs = append([]string{home + "/BirdNET-Pi", home}, dirs...)
+	}
+	return dirs
+}
+
+// nativeLinuxRemovableDirs are the parents under which removable media mounts.
+var nativeLinuxRemovableDirs = []string{"/media", "/run/media", "/mnt"}
+
+// SelectProvider returns the LocationProvider for the given runtime environment.
+// home is the BirdNET-Go process user's home directory ("" if unknown).
+func SelectProvider(envType, home string) LocationProvider {
+	if sysinfo.IsContainerEnv(envType) {
+		return staticProvider{roots: []Root{
+			{Path: sysinfo.DefaultExternalMountPath, Kind: KindLocal},
+		}}
+	}
+	if runtime.GOOS != "linux" {
+		return staticProvider{}
+	}
+	var roots []Root
+	for _, d := range nativeLinuxLocalDirs(home) {
+		roots = append(roots, Root{Path: d, Kind: KindLocal})
+	}
+	for _, d := range nativeLinuxRemovableDirs {
+		roots = append(roots, Root{Path: d, Kind: KindRemovable})
+	}
+	return staticProvider{roots: roots}
+}

--- a/internal/imports/discovery/provider.go
+++ b/internal/imports/discovery/provider.go
@@ -1,6 +1,7 @@
 package discovery
 
 import (
+	"path/filepath"
 	"runtime"
 
 	"github.com/tphakala/birdnet-go/internal/sysinfo"
@@ -29,7 +30,7 @@ func (p staticProvider) Roots() []Root { return p.roots }
 func nativeLinuxLocalDirs(home string) []string {
 	dirs := []string{"/opt/birdnet-pi", "/root"}
 	if home != "" {
-		dirs = append([]string{home + "/BirdNET-Pi", home}, dirs...)
+		dirs = append([]string{filepath.Join(home, "BirdNET-Pi"), home}, dirs...)
 	}
 	return dirs
 }

--- a/internal/imports/discovery/provider_test.go
+++ b/internal/imports/discovery/provider_test.go
@@ -1,9 +1,11 @@
 package discovery
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/sysinfo"
 )
 
@@ -11,13 +13,16 @@ func TestSelectProvider_ContainerReturnsMountRoot(t *testing.T) {
 	t.Parallel()
 	p := SelectProvider(sysinfo.EnvDocker, "/home/pi")
 	roots := p.Roots()
-	assert.Len(t, roots, 1)
+	require.Len(t, roots, 1)
 	assert.Equal(t, sysinfo.DefaultExternalMountPath, roots[0].Path)
 	assert.Equal(t, KindLocal, roots[0].Kind)
 }
 
 func TestSelectProvider_NativeIncludesHomeAndRemovable(t *testing.T) {
 	t.Parallel()
+	if runtime.GOOS != osLinux {
+		t.Skip("native discovery roots are only populated on Linux; macOS and Windows providers are reserved stubs")
+	}
 	p := SelectProvider("Bare Metal", "/home/pi")
 	roots := p.Roots()
 	paths := make(map[string]Kind, len(roots))

--- a/internal/imports/discovery/provider_test.go
+++ b/internal/imports/discovery/provider_test.go
@@ -1,0 +1,30 @@
+package discovery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/sysinfo"
+)
+
+func TestSelectProvider_ContainerReturnsMountRoot(t *testing.T) {
+	t.Parallel()
+	p := SelectProvider(sysinfo.EnvDocker, "/home/pi")
+	roots := p.Roots()
+	assert.Len(t, roots, 1)
+	assert.Equal(t, sysinfo.DefaultExternalMountPath, roots[0].Path)
+	assert.Equal(t, KindLocal, roots[0].Kind)
+}
+
+func TestSelectProvider_NativeIncludesHomeAndRemovable(t *testing.T) {
+	t.Parallel()
+	p := SelectProvider("Bare Metal", "/home/pi")
+	roots := p.Roots()
+	paths := make(map[string]Kind, len(roots))
+	for _, r := range roots {
+		paths[r.Path] = r.Kind
+	}
+	assert.Equal(t, KindLocal, paths["/home/pi/BirdNET-Pi"])
+	assert.Equal(t, KindRemovable, paths["/media"])
+	assert.Equal(t, KindRemovable, paths["/mnt"])
+}

--- a/internal/imports/discovery/scanner.go
+++ b/internal/imports/discovery/scanner.go
@@ -48,6 +48,9 @@ func WithProber(p proberFunc) Option { return func(s *Scanner) { s.prober = p } 
 func WithNetworkPrefixes(p []string) Option { return func(s *Scanner) { s.networkPrefixes = p } }
 
 // NewScanner builds a Scanner with production defaults, overridable via options.
+// Non-positive depth, timeout, or candidate limits are clamped back to the
+// defaults so a bad option value cannot disable a bound (a non-positive
+// maxCandidates would otherwise make every scan return nothing).
 func NewScanner(provider LocationProvider, opts ...Option) *Scanner {
 	s := &Scanner{
 		provider:        provider,
@@ -60,36 +63,78 @@ func NewScanner(provider LocationProvider, opts ...Option) *Scanner {
 	for _, o := range opts {
 		o(s)
 	}
+	if s.maxDepth <= 0 {
+		s.maxDepth = defaultMaxDepth
+	}
+	if s.timeout <= 0 {
+		s.timeout = defaultScanTimeout
+	}
+	if s.maxCandidates <= 0 {
+		s.maxCandidates = defaultMaxCandidates
+	}
 	return s
 }
 
-// Scan searches all provider roots and returns the discovered candidates.
+// Scan searches all provider roots and returns the discovered candidates. The
+// walk runs in a separate goroutine so a blocking syscall on a hung mount (a
+// dead USB, or a stale network mount whose fstype is not in the skip list)
+// cannot block the caller past the timeout. On timeout or cancellation Scan
+// returns the candidates collected so far; the walk goroutine is then abandoned
+// and unwinds once the context is cancelled (the deferred cancel below) or the
+// stuck syscall returns, without holding up the caller.
 func (s *Scanner) Scan(ctx context.Context) []SourceCandidate {
+	if s.provider == nil {
+		return nil
+	}
 	ctx, cancel := context.WithTimeout(ctx, s.timeout)
 	defer cancel()
 
-	seen := make(map[string]struct{})
-	var out []SourceCandidate
+	results := make(chan SourceCandidate)
+	go s.walk(ctx, results)
 
+	out := make([]SourceCandidate, 0, s.maxCandidates)
+	for {
+		select {
+		case <-ctx.Done():
+			return out
+		case c, ok := <-results:
+			if !ok {
+				return out
+			}
+			out = append(out, c)
+			if len(out) >= s.maxCandidates {
+				return out
+			}
+		}
+	}
+}
+
+// walk visits every provider root, sending each discovered candidate on results,
+// and closes results when finished or when ctx is cancelled.
+func (s *Scanner) walk(ctx context.Context, results chan<- SourceCandidate) {
+	defer close(results)
+	seen := make(map[string]struct{})
 	for _, root := range s.provider.Roots() {
 		if ctx.Err() != nil {
-			return out
+			return
 		}
 		if s.underNetworkMount(root.Path) {
 			continue
 		}
-		out = s.walkRoot(ctx, root, seen, out)
-		if len(out) >= s.maxCandidates {
-			return out[:s.maxCandidates]
+		if !s.walkRoot(ctx, root, seen, results) {
+			return
 		}
 	}
-	return out
 }
 
-func (s *Scanner) walkRoot(ctx context.Context, root Root, seen map[string]struct{}, out []SourceCandidate) []SourceCandidate {
+// walkRoot walks a single root, sending birds.db candidates on results. It
+// returns false when the caller should stop (context cancelled), true otherwise.
+func (s *Scanner) walkRoot(ctx context.Context, root Root, seen map[string]struct{}, results chan<- SourceCandidate) bool {
 	rootClean := filepath.Clean(root.Path)
+	cont := true
 	_ = filepath.WalkDir(rootClean, func(path string, d fs.DirEntry, err error) error {
 		if ctx.Err() != nil {
+			cont = false
 			return filepath.SkipAll
 		}
 		if err != nil {
@@ -111,18 +156,28 @@ func (s *Scanner) walkRoot(ctx context.Context, root Root, seen map[string]struc
 		if d.Name() != birdsDBFilename {
 			return nil
 		}
+		// Only probe regular files. This skips a symlink (whose target could
+		// escape the scanned root) and, importantly, a FIFO, socket, or device
+		// node named birds.db, on which the probe's os.Open would block the
+		// scanner goroutine indefinitely.
+		if !d.Type().IsRegular() {
+			return nil
+		}
 		clean := filepath.Clean(path)
 		if _, dup := seen[clean]; dup {
 			return nil
 		}
 		seen[clean] = struct{}{}
-		out = append(out, s.prober(ctx, clean, root.Kind))
-		if len(out) >= s.maxCandidates {
+		cand := s.prober(ctx, clean, root.Kind)
+		select {
+		case results <- cand:
+		case <-ctx.Done():
+			cont = false
 			return filepath.SkipAll
 		}
 		return nil
 	})
-	return out
+	return cont
 }
 
 // depthBelow returns how many path separators deep path is below root.
@@ -137,9 +192,12 @@ func depthBelow(root, path string) int {
 // underNetworkMount reports whether path is at or below any network mount prefix.
 func (s *Scanner) underNetworkMount(path string) bool {
 	clean := filepath.Clean(path)
+	sep := string(filepath.Separator)
 	for _, prefix := range s.networkPrefixes {
 		p := filepath.Clean(prefix)
-		if clean == p || strings.HasPrefix(clean, p+string(filepath.Separator)) {
+		// p == sep means the whole filesystem is a network mount; everything is
+		// under it (and p+sep would be "//", which HasPrefix would never match).
+		if clean == p || p == sep || strings.HasPrefix(clean, p+sep) {
 			return true
 		}
 	}

--- a/internal/imports/discovery/scanner.go
+++ b/internal/imports/discovery/scanner.go
@@ -1,0 +1,147 @@
+package discovery
+
+import (
+	"context"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	defaultMaxDepth      = 4
+	defaultScanTimeout   = 3 * time.Second
+	defaultMaxCandidates = 25
+	birdsDBFilename      = "birds.db"
+)
+
+// proberFunc inspects a birds.db path and returns a candidate.
+type proberFunc func(ctx context.Context, dbPath string, kind Kind) SourceCandidate
+
+// Scanner walks LocationProvider roots for birds.db files within bounded
+// depth/time and probes each one.
+type Scanner struct {
+	provider        LocationProvider
+	prober          proberFunc
+	maxDepth        int
+	timeout         time.Duration
+	maxCandidates   int
+	networkPrefixes []string
+}
+
+// Option configures a Scanner.
+type Option func(*Scanner)
+
+// WithMaxDepth bounds how many directory levels below a root are searched.
+func WithMaxDepth(d int) Option { return func(s *Scanner) { s.maxDepth = d } }
+
+// WithTimeout bounds the total wall-clock scan time.
+func WithTimeout(d time.Duration) Option { return func(s *Scanner) { s.timeout = d } }
+
+// WithMaxCandidates caps how many candidates are returned.
+func WithMaxCandidates(n int) Option { return func(s *Scanner) { s.maxCandidates = n } }
+
+// WithProber overrides the per-candidate probe (used in tests).
+func WithProber(p proberFunc) Option { return func(s *Scanner) { s.prober = p } }
+
+// WithNetworkPrefixes overrides the network mount prefixes to skip (used in tests).
+func WithNetworkPrefixes(p []string) Option { return func(s *Scanner) { s.networkPrefixes = p } }
+
+// NewScanner builds a Scanner with production defaults, overridable via options.
+func NewScanner(provider LocationProvider, opts ...Option) *Scanner {
+	s := &Scanner{
+		provider:        provider,
+		prober:          probeCandidate,
+		maxDepth:        defaultMaxDepth,
+		timeout:         defaultScanTimeout,
+		maxCandidates:   defaultMaxCandidates,
+		networkPrefixes: defaultNetworkMountPrefixes(),
+	}
+	for _, o := range opts {
+		o(s)
+	}
+	return s
+}
+
+// Scan searches all provider roots and returns the discovered candidates.
+func (s *Scanner) Scan(ctx context.Context) []SourceCandidate {
+	ctx, cancel := context.WithTimeout(ctx, s.timeout)
+	defer cancel()
+
+	seen := make(map[string]struct{})
+	var out []SourceCandidate
+
+	for _, root := range s.provider.Roots() {
+		if ctx.Err() != nil {
+			return out
+		}
+		if s.underNetworkMount(root.Path) {
+			continue
+		}
+		out = s.walkRoot(ctx, root, seen, out)
+		if len(out) >= s.maxCandidates {
+			return out[:s.maxCandidates]
+		}
+	}
+	return out
+}
+
+func (s *Scanner) walkRoot(ctx context.Context, root Root, seen map[string]struct{}, out []SourceCandidate) []SourceCandidate {
+	rootClean := filepath.Clean(root.Path)
+	_ = filepath.WalkDir(rootClean, func(path string, d fs.DirEntry, err error) error {
+		if ctx.Err() != nil {
+			return filepath.SkipAll
+		}
+		if err != nil {
+			// Unreadable dir or vanished entry: skip this subtree, never abort.
+			if d != nil && d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			if depthBelow(rootClean, path) > s.maxDepth {
+				return filepath.SkipDir
+			}
+			if s.underNetworkMount(path) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.Name() != birdsDBFilename {
+			return nil
+		}
+		clean := filepath.Clean(path)
+		if _, dup := seen[clean]; dup {
+			return nil
+		}
+		seen[clean] = struct{}{}
+		out = append(out, s.prober(ctx, clean, root.Kind))
+		if len(out) >= s.maxCandidates {
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	return out
+}
+
+// depthBelow returns how many path separators deep path is below root.
+func depthBelow(root, path string) int {
+	rel, err := filepath.Rel(root, path)
+	if err != nil || rel == "." {
+		return 0
+	}
+	return strings.Count(rel, string(filepath.Separator)) + 1
+}
+
+// underNetworkMount reports whether path is at or below any network mount prefix.
+func (s *Scanner) underNetworkMount(path string) bool {
+	clean := filepath.Clean(path)
+	for _, prefix := range s.networkPrefixes {
+		p := filepath.Clean(prefix)
+		if clean == p || strings.HasPrefix(clean, p+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/imports/discovery/scanner_test.go
+++ b/internal/imports/discovery/scanner_test.go
@@ -1,0 +1,105 @@
+package discovery
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fixedProvider struct{ roots []Root }
+
+func (p fixedProvider) Roots() []Root { return p.roots }
+
+func TestScanner_FindsBirdsDbUnderRoot(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	nested := filepath.Join(root, "pi", "BirdNET-Pi")
+	require.NoError(t, os.MkdirAll(nested, 0o755))
+	dbPath := filepath.Join(nested, "birds.db")
+	require.NoError(t, os.WriteFile(dbPath, []byte("x"), 0o600))
+
+	probed := map[string]bool{}
+	s := NewScanner(
+		fixedProvider{roots: []Root{{Path: root, Kind: KindLocal}}},
+		WithProber(func(_ context.Context, p string, k Kind) SourceCandidate {
+			probed[p] = true
+			return SourceCandidate{Path: p, Kind: k, Valid: true}
+		}),
+	)
+
+	got := s.Scan(t.Context())
+	require.Len(t, got, 1)
+	assert.Equal(t, dbPath, got[0].Path)
+	assert.True(t, probed[dbPath])
+}
+
+func TestScanner_RespectsMaxDepth(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	deep := filepath.Join(root, "a", "b", "c", "d", "e")
+	require.NoError(t, os.MkdirAll(deep, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(deep, "birds.db"), []byte("x"), 0o600))
+
+	s := NewScanner(
+		fixedProvider{roots: []Root{{Path: root, Kind: KindLocal}}},
+		WithMaxDepth(2),
+		WithProber(func(_ context.Context, p string, k Kind) SourceCandidate {
+			return SourceCandidate{Path: p, Valid: true}
+		}),
+	)
+	assert.Empty(t, s.Scan(t.Context()))
+}
+
+func TestScanner_SkipsNetworkPrefixedRoots(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "birds.db"), []byte("x"), 0o600))
+
+	s := NewScanner(
+		fixedProvider{roots: []Root{{Path: root, Kind: KindRemovable}}},
+		WithNetworkPrefixes([]string{root}),
+		WithProber(func(_ context.Context, p string, k Kind) SourceCandidate {
+			return SourceCandidate{Path: p, Valid: true}
+		}),
+	)
+	assert.Empty(t, s.Scan(t.Context()))
+}
+
+func TestScanner_StopsAtMaxCandidates(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	for _, sub := range []string{"one", "two", "three"} {
+		d := filepath.Join(root, sub)
+		require.NoError(t, os.MkdirAll(d, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(d, "birds.db"), []byte("x"), 0o600))
+	}
+	s := NewScanner(
+		fixedProvider{roots: []Root{{Path: root, Kind: KindLocal}}},
+		WithMaxCandidates(2),
+		WithProber(func(_ context.Context, p string, k Kind) SourceCandidate {
+			return SourceCandidate{Path: p, Valid: true}
+		}),
+	)
+	assert.Len(t, s.Scan(t.Context()), 2)
+}
+
+func TestScanner_CancelledContextReturnsEarly(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "birds.db"), []byte("x"), 0o600))
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	s := NewScanner(
+		fixedProvider{roots: []Root{{Path: root, Kind: KindLocal}}},
+		WithTimeout(time.Second),
+		WithProber(func(_ context.Context, p string, k Kind) SourceCandidate {
+			return SourceCandidate{Path: p, Valid: true}
+		}),
+	)
+	assert.Empty(t, s.Scan(ctx))
+}


### PR DESCRIPTION
## Summary

First slice of native (non-container) BirdNET-Pi import support: a self-contained `internal/imports/discovery` package that locates BirdNET-Pi `birds.db` databases on the host so the import wizard can later offer them as ready-to-pick sources. This PR is backend-only groundwork, no HTTP endpoints, UI, or privileged code yet (those land in follow-up PRs).

- **`LocationProvider`** per runtime: container (`/external` mount) and native-linux (a bounded allowlist: `/home/*`, `/root`, `/opt/birdnet-pi`, `/media`, `/run/media`, `/mnt`); macOS/Windows are reserved stubs.
- **Bounded `Scanner`**: depth, wall-clock, and candidate caps; an `EACCES`-safe walk that never aborts on an unreadable directory; a `/proc/mounts` pre-filter to skip network mounts; the walk runs in a goroutine and selects on the context so a blocking syscall on a dead mount cannot hang the caller past the timeout; only regular files are probed (skips symlinks and FIFO/socket/device nodes named `birds.db`).
- **Read-only SQLite probe** (reuses the existing `birdnetpi.Source`): detection count, latest date, sibling audio-dir guess, owner uid/name, and a validity/permission reason for the UI.
- **Per-environment `BuildGuidance`**: native-linux USB/SD `lsblk`/`mount` help, plus the container docker/podman/generic bind-mount setup steps.

## Test Plan

- [x] `go test -race ./internal/imports/...`
- [x] `golangci-lint run` (full project, 0 issues)
- [ ] CI green

The package is a leaf consumed by a later PR; it is not wired into the API or UI in this change, so it cannot affect existing behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added component auto-detection for the new imports/discovery area.
  * Introduced expanded source discovery scanning across local, removable, and container mount locations, including network-mount skipping.
  * Added environment-specific setup guidance (native + Docker/Podman) and richer source metadata (latest date, detection count, ownership, audio directory hints).
* **Bug Fixes**
  * Improved robustness when probing invalid, unreadable, or non-database files and when databases have no detections.
  * Better early-exit behavior when scan depth limits or timeouts/cancellation are hit.
* **Tests**
  * Added comprehensive unit tests for date lookup, probing, candidate validation, guidance generation, provider selection, mounts/ownership detection, and scanner behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->