### PR TITLE
feat(imports): native BirdNET-Pi import staging backend and elevation ladder

### DIFF
--- a/cmd/importstage/importstage.go
+++ b/cmd/importstage/importstage.go
@@ -36,5 +36,10 @@ func Command(_ *conf.Settings) *cobra.Command {
 	cmd.Flags().IntVar(&opts.GID, "gid", -1, "service-user gid to chown staged files to")
 	_ = cmd.MarkFlagRequired("src")
 	_ = cmd.MarkFlagRequired("dst")
+	// uid/gid are required: lchown(2) treats -1 (the flag default) as "leave
+	// unchanged", which would silently leave staged files root-owned and
+	// unreadable by the service user while Stage still reported success.
+	_ = cmd.MarkFlagRequired("uid")
+	_ = cmd.MarkFlagRequired("gid")
 	return cmd
 }

--- a/cmd/importstage/importstage.go
+++ b/cmd/importstage/importstage.go
@@ -1,0 +1,40 @@
+// Package importstage provides the hidden `birdnet-go import-stage` subcommand:
+// a narrow privileged primitive that copies a validated BirdNET-Pi database (and
+// optional audio) into a BirdNET-Go-owned staging directory and chowns it to the
+// service user. It is invoked through sudo by the import elevation ladder, never
+// by interactive users, so it is marked Hidden. It performs no shell expansion:
+// cobra parses --flag=value argv directly.
+package importstage
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/imports/staging"
+)
+
+// Command builds the hidden import-stage subcommand.
+func Command(_ *conf.Settings) *cobra.Command {
+	var opts staging.Options
+	cmd := &cobra.Command{
+		Use:    "import-stage",
+		Short:  "Stage a BirdNET-Pi database into a BirdNET-Go-owned directory (internal)",
+		Hidden: true,
+		// NoArgs rejects positional arguments. The ladder builds the sudo argv
+		// itself in --flag=value form with no shell involved, so a value like
+		// --src=-rf is passed to os/exec as one token and cobra binds it as the
+		// value of --src; there is no flag-injection path to defend against here.
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			_, err := staging.Stage(cmd.Context(), opts)
+			return err
+		},
+	}
+	cmd.Flags().StringVar(&opts.Src, "src", "", "absolute path to source birds.db")
+	cmd.Flags().StringVar(&opts.Audio, "audio", "", "absolute path to source audio directory (optional)")
+	cmd.Flags().StringVar(&opts.Dst, "dst", "", "absolute path to an empty staging directory")
+	cmd.Flags().IntVar(&opts.UID, "uid", -1, "service-user uid to chown staged files to")
+	cmd.Flags().IntVar(&opts.GID, "gid", -1, "service-user gid to chown staged files to")
+	_ = cmd.MarkFlagRequired("src")
+	_ = cmd.MarkFlagRequired("dst")
+	return cmd
+}

--- a/cmd/importstage/importstage_test.go
+++ b/cmd/importstage/importstage_test.go
@@ -33,7 +33,7 @@ func writeMinimalSQLite(t *testing.T, path string) {
 func TestImportStageCommandStages(t *testing.T) {
 	src := filepath.Join(t.TempDir(), "birds.db")
 	writeMinimalSQLite(t, src)
-	dst := t.TempDir()
+	dst := filepath.Join(t.TempDir(), "staging") // must not pre-exist; Stage creates it
 
 	cmd := Command(&conf.Settings{})
 	cmd.SetArgs([]string{
@@ -46,11 +46,10 @@ func TestImportStageCommandStages(t *testing.T) {
 	require.FileExists(t, filepath.Join(dst, "birds.db"))
 }
 
-func TestImportStageCommandRejectsNonEmptyDst(t *testing.T) {
+func TestImportStageCommandRejectsExistingDst(t *testing.T) {
 	src := filepath.Join(t.TempDir(), "birds.db")
 	writeMinimalSQLite(t, src)
-	dst := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dst, "existing"), []byte("x"), 0o600))
+	dst := t.TempDir() // already exists, so Stage must reject it
 
 	cmd := Command(&conf.Settings{})
 	cmd.SetArgs([]string{

--- a/cmd/importstage/importstage_test.go
+++ b/cmd/importstage/importstage_test.go
@@ -1,0 +1,63 @@
+//go:build linux
+
+package importstage
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// itoa converts an int to a string, for building --flag=value args.
+func itoa(n int) string { return strconv.Itoa(n) }
+
+// writeMinimalSQLite creates a minimal BirdNET-Pi-shaped SQLite db at path.
+func writeMinimalSQLite(t *testing.T, path string) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", path)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, db.Close()) })
+	_, err = db.Exec(`CREATE TABLE detections (
+		Date TEXT, Time TEXT, Sci_Name TEXT, Com_Name TEXT, Confidence REAL,
+		Lat REAL, Lon REAL, Cutoff REAL, Sens REAL, File_Name TEXT)`)
+	require.NoError(t, err)
+}
+
+func TestImportStageCommandStages(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "birds.db")
+	writeMinimalSQLite(t, src)
+	dst := t.TempDir()
+
+	cmd := Command(&conf.Settings{})
+	cmd.SetArgs([]string{
+		"--src=" + src,
+		"--dst=" + dst,
+		"--uid=" + itoa(os.Getuid()),
+		"--gid=" + itoa(os.Getgid()),
+	})
+	require.NoError(t, cmd.Execute())
+	require.FileExists(t, filepath.Join(dst, "birds.db"))
+}
+
+func TestImportStageCommandRejectsNonEmptyDst(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "birds.db")
+	writeMinimalSQLite(t, src)
+	dst := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dst, "existing"), []byte("x"), 0o600))
+
+	cmd := Command(&conf.Settings{})
+	cmd.SetArgs([]string{
+		"--src=" + src,
+		"--dst=" + dst,
+		"--uid=" + itoa(os.Getuid()),
+		"--gid=" + itoa(os.Getgid()),
+	})
+	require.Error(t, cmd.Execute())
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/tphakala/birdnet-go/cmd/authors"
 	"github.com/tphakala/birdnet-go/cmd/benchmark"
+	"github.com/tphakala/birdnet-go/cmd/importstage"
 	"github.com/tphakala/birdnet-go/cmd/license"
 	"github.com/tphakala/birdnet-go/cmd/notify"
 	"github.com/tphakala/birdnet-go/cmd/rangefilter"
@@ -39,6 +40,7 @@ func RootCommand(settings *conf.Settings) *cobra.Command {
 	supportCmd := support.Command(settings)
 	benchmarkCmd := benchmark.Command(settings)
 	notifyCmd := notify.Command(settings)
+	importStageCmd := importstage.Command(settings)
 
 	subcommands := []*cobra.Command{
 		serveCmd,
@@ -48,13 +50,18 @@ func RootCommand(settings *conf.Settings) *cobra.Command {
 		supportCmd,
 		benchmarkCmd,
 		notifyCmd,
+		importStageCmd,
 	}
 
 	rootCmd.AddCommand(subcommands...)
 
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-		// Skip setup for authors and license commands
-		if cmd.Name() != authorsCmd.Name() && cmd.Name() != licenseCmd.Name() {
+		// Skip setup for informational and privileged primitive commands.
+		// import-stage runs as root via sudo and must not trigger daemon init,
+		// config loading, telemetry, or network calls.
+		if cmd.Name() != authorsCmd.Name() &&
+			cmd.Name() != licenseCmd.Name() &&
+			cmd.Name() != importStageCmd.Name() {
 			if err := initialize(); err != nil {
 				return fmt.Errorf("error initializing: %w", err)
 			}

--- a/config.schema.json
+++ b/config.schema.json
@@ -1028,6 +1028,17 @@
       "type": "object",
       "description": "HomeAssistantSettings contains settings for Home Assistant MQTT auto-discovery."
     },
+    "ImportConfig": {
+      "properties": {
+        "allowinappelevation": {
+          "type": "boolean",
+          "description": "AllowInAppElevation enables the in-app sudo elevation ladder for native\nimports of unreadable source data. Default true. When false, the UI only\noffers copy-paste remediation and never prompts for a sudo password."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ImportConfig controls the BirdNET-Pi import feature behavior."
+    },
     "LiveStreamSettings": {
       "properties": {
         "debug": {
@@ -2217,6 +2228,10 @@
         "backup": {
           "$ref": "#/$defs/BackupConfig",
           "description": "Backup configuration"
+        },
+        "import": {
+          "$ref": "#/$defs/ImportConfig",
+          "description": "BirdNET-Pi import behavior"
         },
         "notification": {
           "$ref": "#/$defs/NotificationConfig",

--- a/doc/wiki/configuration-reference.md
+++ b/doc/wiki/configuration-reference.md
@@ -417,6 +417,14 @@ BackupConfig contains backup-related configuration
 | `backup.operationtimeouts.cleanup` | string |  |
 | `backup.operationtimeouts.delete` | string |  |
 
+## import
+
+ImportConfig controls the BirdNET-Pi import feature behavior.
+
+| Setting | Type | Description |
+|---------|------|-------------|
+| `import.allowinappelevation` | boolean | AllowInAppElevation enables the in-app sudo elevation ladder for native imports of unreadable source data. Default true. When false, the UI only offers copy-paste remediation and never prompts for a sudo password. |
+
 ## notification
 
 NotificationConfig is the root for notification-specific settings.

--- a/frontend/src/lib/desktop/features/import-export/pages/ImportExportPage.svelte
+++ b/frontend/src/lib/desktop/features/import-export/pages/ImportExportPage.svelte
@@ -18,10 +18,6 @@
 </script>
 
 <div class="space-y-6">
-  <p class="text-sm text-[var(--color-base-content)]/70">
-    {t('system.importExport.pageDescription')}
-  </p>
-
   <!-- Import section -->
   <section aria-labelledby="import-section-heading">
     <h3

--- a/frontend/src/lib/desktop/features/import-export/pages/ImportExportPage.test.ts
+++ b/frontend/src/lib/desktop/features/import-export/pages/ImportExportPage.test.ts
@@ -13,16 +13,6 @@ describe('ImportExportPage', () => {
     vi.clearAllMocks();
   });
 
-  it('renders the page heading', () => {
-    render(ImportExportPage);
-    expect(screen.getByText('system.sections.importExport')).toBeInTheDocument();
-  });
-
-  it('renders the page description', () => {
-    render(ImportExportPage);
-    expect(screen.getByText('system.importExport.pageDescription')).toBeInTheDocument();
-  });
-
   it('renders import and export section headings', () => {
     render(ImportExportPage);
     expect(screen.getByText('system.importExport.import.sectionTitle')).toBeInTheDocument();

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -897,7 +897,6 @@ export type TranslationKey =
   | 'system.sections.inference'
   | 'system.sections.terminal'
   | 'system.sections.importExport'
-  | 'system.importExport.pageDescription'
   | 'system.importExport.available'
   | 'system.importExport.comingSoon'
   | 'system.importExport.loading'

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -1158,7 +1158,6 @@
       "importExport": "Import / Export"
     },
     "importExport": {
-      "pageDescription": "Import data from other bird recording systems or export your detections.",
       "available": "Available",
       "comingSoon": "Coming soon",
       "loading": "Loading...",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -1158,7 +1158,6 @@
       "importExport": "Import / Export"
     },
     "importExport": {
-      "pageDescription": "Import data from other bird recording systems or export your detections.",
       "available": "Available",
       "comingSoon": "Coming soon",
       "loading": "Loading...",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -1158,7 +1158,6 @@
       "importExport": "Import / Export"
     },
     "importExport": {
-      "pageDescription": "Import data from other bird recording systems or export your detections.",
       "available": "Available",
       "comingSoon": "Coming soon",
       "loading": "Loading...",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -1158,7 +1158,6 @@
       "importExport": "Import / Export"
     },
     "importExport": {
-      "pageDescription": "Import data from other bird recording systems or export your detections.",
       "available": "Available",
       "comingSoon": "Coming soon",
       "loading": "Loading...",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -1158,7 +1158,6 @@
       "importExport": "Import / Export"
     },
     "importExport": {
-      "pageDescription": "Import data from other bird recording systems or export your detections.",
       "available": "Available",
       "comingSoon": "Coming soon",
       "loading": "Loading...",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -1158,7 +1158,6 @@
       "importExport": "Import / Export"
     },
     "importExport": {
-      "pageDescription": "Import data from other bird recording systems or export your detections.",
       "available": "Available",
       "comingSoon": "Coming soon",
       "loading": "Loading...",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -1158,7 +1158,6 @@
       "importExport": "Import / Export"
     },
     "importExport": {
-      "pageDescription": "Import data from other bird recording systems or export your detections.",
       "available": "Available",
       "comingSoon": "Coming soon",
       "loading": "Loading...",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -1158,7 +1158,6 @@
       "importExport": "Import / Export"
     },
     "importExport": {
-      "pageDescription": "Import data from other bird recording systems or export your detections.",
       "available": "Available",
       "comingSoon": "Coming soon",
       "loading": "Loading...",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -1158,7 +1158,6 @@
       "importExport": "Import / Export"
     },
     "importExport": {
-      "pageDescription": "Import data from other bird recording systems or export your detections.",
       "available": "Available",
       "comingSoon": "Coming soon",
       "loading": "Loading...",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -1158,7 +1158,6 @@
       "importExport": "Import / Export"
     },
     "importExport": {
-      "pageDescription": "Import data from other bird recording systems or export your detections.",
       "available": "Available",
       "comingSoon": "Coming soon",
       "loading": "Loading...",

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -1158,7 +1158,6 @@
       "importExport": "Import / Export"
     },
     "importExport": {
-      "pageDescription": "Import data from other bird recording systems or export your detections.",
       "available": "Available",
       "comingSoon": "Coming soon",
       "loading": "Loading...",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -1158,7 +1158,6 @@
       "importExport": "Import / Export"
     },
     "importExport": {
-      "pageDescription": "Import data from other bird recording systems or export your detections.",
       "available": "Available",
       "comingSoon": "Coming soon",
       "loading": "Loading...",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -1158,7 +1158,6 @@
       "importExport": "Import / Export"
     },
     "importExport": {
-      "pageDescription": "Import data from other bird recording systems or export your detections.",
       "available": "Available",
       "comingSoon": "Coming soon",
       "loading": "Loading...",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -1158,7 +1158,6 @@
       "importExport": "Import / Export"
     },
     "importExport": {
-      "pageDescription": "Import data from other bird recording systems or export your detections.",
       "available": "Available",
       "comingSoon": "Coming soon",
       "loading": "Loading...",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -1158,7 +1158,6 @@
       "importExport": "Import / Export"
     },
     "importExport": {
-      "pageDescription": "Import data from other bird recording systems or export your detections.",
       "available": "Available",
       "comingSoon": "Coming soon",
       "loading": "Loading...",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -1158,7 +1158,6 @@
       "importExport": "Import / Export"
     },
     "importExport": {
-      "pageDescription": "Import data from other bird recording systems or export your detections.",
       "available": "Available",
       "comingSoon": "Coming soon",
       "loading": "Loading...",

--- a/internal/api/v2/hotreload_coverage_test.go
+++ b/internal/api/v2/hotreload_coverage_test.go
@@ -245,6 +245,9 @@ var hotReloadRegistry = map[string]hotReloadEntry{
 
 	// --- Alerting ---
 	"Alerting": {categories: []hotReloadCategory{hotReloadFresh}},
+
+	// --- Import (in-app elevation toggle; per-request policy read live, no action) ---
+	"Import": {categories: []hotReloadCategory{hotReloadFresh}},
 }
 
 // Ceiling decreases as TODO actions are implemented; target is zero.

--- a/internal/api/v2/imports/handler.go
+++ b/internal/api/v2/imports/handler.go
@@ -33,6 +33,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/imports"
 	"github.com/tphakala/birdnet-go/internal/notification"
+	"github.com/tphakala/birdnet-go/internal/sysinfo"
 )
 
 // apiV2Prefix is the v2 API path prefix. It mirrors the facade's apiV2Prefix; the
@@ -58,6 +59,10 @@ type Handler struct {
 	// a BirdNET-Pi adapter when nil. Overridable in tests.
 	importSourceFactory func(path string) (imports.Source, error)
 
+	// isContainerEnv reports whether BirdNET-Go runs in a container. Defaults to
+	// sysinfo.IsContainer; overridable in tests to exercise the native branch.
+	isContainerEnv func() bool
+
 	// cleanupStatus tracks the state of legacy database cleanup. It is initialized
 	// lazily in RegisterLegacyCleanupRoutes; the migration status handler reads it
 	// nil-guarded.
@@ -80,6 +85,7 @@ func New(core *apicore.Core, notificationService *notification.Service) *Handler
 		Core:                core,
 		notificationService: notificationService,
 		importMgr:           newImportManager(),
+		isContainerEnv:      sysinfo.IsContainer,
 	}
 }
 

--- a/internal/api/v2/imports/import.go
+++ b/internal/api/v2/imports/import.go
@@ -37,14 +37,12 @@ func resolveNativeImportSourcePath(userPath string) (string, error) {
 	if err != nil || !info.Mode().IsRegular() {
 		return "", errInvalidSourcePath
 	}
-	src, err := birdnetpi.New(resolved)
-	if err != nil {
-		return "", errInvalidSourcePath
-	}
-	defer func() { _ = src.Close() }()
-	if err := src.Validate(context.Background()); err != nil {
-		return "", errInvalidSourcePath
-	}
+	// Path-only resolution: confirm it is an absolute, existing, regular file.
+	// Schema validation (open + BirdNET-Pi schema check) is done once by the
+	// shared factory + Validate path in StartBirdNETPiImport, using the request
+	// context and surfacing distinct "failed to open" vs "validation failed"
+	// errors. Mirrors the container branch (resolveImportSourcePath), which also
+	// defers schema validation to that shared step.
 	return resolved, nil
 }
 
@@ -89,7 +87,7 @@ var errInvalidSourcePath = errors.NewStd("invalid source path")
 // startImportRequest is the JSON body for POST /import/birdnet-pi.
 type startImportRequest struct {
 	Mode       string `json:"mode"`        // accepted values: "db-only", "db-audio"
-	SourcePath string `json:"source_path"` // path relative to the external mount root
+	SourcePath string `json:"source_path"` // container: relative to the external mount root; native: absolute path to the source birds.db
 	Location   string `json:"location"`    // optional IANA timezone name e.g. "Europe/Helsinki"
 }
 

--- a/internal/api/v2/imports/import.go
+++ b/internal/api/v2/imports/import.go
@@ -20,6 +20,34 @@ import (
 	"github.com/tphakala/birdnet-go/internal/sysinfo"
 )
 
+// resolveNativeImportSourcePath validates an absolute path to a BirdNET-Pi
+// birds.db on a native install. Unlike the container branch there is no root
+// confinement: reading any file the service user can read is no privilege
+// escalation. The path must be absolute, exist as a regular file, and be a
+// valid BirdNET-Pi SQLite database.
+func resolveNativeImportSourcePath(userPath string) (string, error) {
+	if userPath == "" || !filepath.IsAbs(userPath) {
+		return "", errInvalidSourcePath
+	}
+	resolved, err := filepath.EvalSymlinks(filepath.Clean(userPath))
+	if err != nil {
+		return "", errInvalidSourcePath
+	}
+	info, err := os.Stat(resolved)
+	if err != nil || !info.Mode().IsRegular() {
+		return "", errInvalidSourcePath
+	}
+	src, err := birdnetpi.New(resolved)
+	if err != nil {
+		return "", errInvalidSourcePath
+	}
+	defer func() { _ = src.Close() }()
+	if err := src.Validate(context.Background()); err != nil {
+		return "", errInvalidSourcePath
+	}
+	return resolved, nil
+}
+
 // Import mode constants.
 const (
 	importModeDBOnly  = "db-only"
@@ -229,18 +257,31 @@ func (c *Handler) StartBirdNETPiImport(ctx echo.Context) error {
 		return c.HandleError(ctx, nil, "unsupported import mode", http.StatusBadRequest)
 	}
 
-	// Resolve and validate source path.
-	root := c.importSourceRoot
-	if root == "" {
-		root = sysinfo.DefaultExternalMountPath
-	}
-	resolvedPath, err := resolveImportSourcePath(root, req.SourcePath)
-	if err != nil {
-		return c.HandleError(ctx, err, "invalid source path", http.StatusBadRequest)
-	}
-	info, statErr := os.Stat(resolvedPath)
-	if statErr != nil || !info.Mode().IsRegular() {
-		return c.HandleError(ctx, statErr, "source file not found or not a regular file", http.StatusBadRequest)
+	// Resolve and validate source path. Dispatch depends on whether we run in a
+	// container (relative path under an external mount root) or natively (absolute
+	// path validated on the spot by the service user).
+	var (
+		resolvedPath string
+		err          error
+	)
+	if c.isContainerEnv == nil || c.isContainerEnv() {
+		root := c.importSourceRoot
+		if root == "" {
+			root = sysinfo.DefaultExternalMountPath
+		}
+		resolvedPath, err = resolveImportSourcePath(root, req.SourcePath)
+		if err != nil {
+			return c.HandleError(ctx, err, "invalid source path", http.StatusBadRequest)
+		}
+		info, statErr := os.Stat(resolvedPath)
+		if statErr != nil || !info.Mode().IsRegular() {
+			return c.HandleError(ctx, statErr, "source file not found or not a regular file", http.StatusBadRequest)
+		}
+	} else {
+		resolvedPath, err = resolveNativeImportSourcePath(req.SourcePath)
+		if err != nil {
+			return c.HandleError(ctx, err, "invalid source path", http.StatusBadRequest)
+		}
 	}
 
 	// Parse optional timezone.

--- a/internal/api/v2/imports/import.go
+++ b/internal/api/v2/imports/import.go
@@ -23,8 +23,9 @@ import (
 // resolveNativeImportSourcePath validates an absolute path to a BirdNET-Pi
 // birds.db on a native install. Unlike the container branch there is no root
 // confinement: reading any file the service user can read is no privilege
-// escalation. The path must be absolute, exist as a regular file, and be a
-// valid BirdNET-Pi SQLite database.
+// escalation. The path must be absolute and resolve to an existing regular
+// file; BirdNET-Pi schema validation is deferred to the shared factory +
+// Validate step in StartBirdNETPiImport (the container branch does the same).
 func resolveNativeImportSourcePath(userPath string) (string, error) {
 	if userPath == "" || !filepath.IsAbs(userPath) {
 		return "", errInvalidSourcePath

--- a/internal/api/v2/imports/import_test.go
+++ b/internal/api/v2/imports/import_test.go
@@ -1514,9 +1514,14 @@ func TestResolveNativeImportSourcePath_Valid(t *testing.T) {
 	db := filepath.Join(t.TempDir(), "birds.db")
 	writeMinimalBirdNetPiDB(t, db)
 
+	// The resolver returns the symlink-resolved path; resolve the expected value
+	// the same way so the comparison holds on macOS (where /tmp -> /private/tmp).
+	wantDB, err := filepath.EvalSymlinks(db)
+	require.NoError(t, err)
+
 	got, err := resolveNativeImportSourcePath(db)
 	require.NoError(t, err)
-	assert.Equal(t, db, got)
+	assert.Equal(t, wantDB, got)
 }
 
 func TestResolveNativeImportSourcePath_RejectsRelative(t *testing.T) {
@@ -1529,11 +1534,21 @@ func TestResolveNativeImportSourcePath_RejectsMissing(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestResolveNativeImportSourcePath_RejectsNonSQLite(t *testing.T) {
-	bad := filepath.Join(t.TempDir(), "birds.db")
-	require.NoError(t, os.WriteFile(bad, []byte("nope"), 0o600))
-	_, err := resolveNativeImportSourcePath(bad)
-	require.Error(t, err)
+// TestResolveNativeImportSourcePath_AcceptsRegularFile documents that the
+// resolver is path-only: it accepts any absolute, existing, regular file and
+// defers schema validation to the shared factory + Validate step in the handler
+// (mirroring the container branch). A non-BirdNET-Pi file is rejected there, not
+// here; see TestStartBirdNETPiImport_NativeDispatch_RejectsInvalidDB.
+func TestResolveNativeImportSourcePath_AcceptsRegularFile(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "birds.db")
+	require.NoError(t, os.WriteFile(f, []byte("not sqlite"), 0o600))
+
+	wantF, err := filepath.EvalSymlinks(f)
+	require.NoError(t, err)
+
+	got, err := resolveNativeImportSourcePath(f)
+	require.NoError(t, err)
+	assert.Equal(t, wantF, got)
 }
 
 // TestStartBirdNETPiImport_NativeDispatch_AcceptsAbsolutePath verifies that
@@ -1563,6 +1578,34 @@ func TestStartBirdNETPiImport_NativeDispatch_AcceptsAbsolutePath(t *testing.T) {
 
 	require.NoError(t, c.StartBirdNETPiImport(ctx))
 	assert.Equal(t, http.StatusAccepted, rec.Code)
+}
+
+// TestStartBirdNETPiImport_NativeDispatch_RejectsInvalidDB verifies that a
+// native absolute path to a regular file that is NOT a BirdNET-Pi database is
+// rejected with 400 by the shared factory + Validate step (the resolver is
+// path-only and no longer validates schema itself).
+func TestStartBirdNETPiImport_NativeDispatch_RejectsInvalidDB(t *testing.T) {
+	_, c := newImportHandler(t)
+	mockDS := mocks.NewMockInterface(t)
+	c.DS = mockDS
+	mockRepo := mocks.NewMockDetectionRepository(t)
+	c.Repo = mockRepo
+	c.isContainerEnv = func() bool { return false }
+	// Use the real factory (birdnetpi.New) so the bad file fails open/validate.
+	c.importSourceFactory = nil
+
+	bad := filepath.Join(t.TempDir(), "birds.db")
+	require.NoError(t, os.WriteFile(bad, []byte("not a sqlite database"), 0o600))
+
+	body := fmt.Sprintf(`{"mode":"db-only","source_path":%q}`, bad)
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	require.NoError(t, c.StartBirdNETPiImport(ctx))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 // TestStartBirdNETPiImport_ContainerDispatch_AcceptsRelativePath verifies that

--- a/internal/api/v2/imports/import_test.go
+++ b/internal/api/v2/imports/import_test.go
@@ -1531,7 +1531,7 @@ func TestResolveNativeImportSourcePath_RejectsRelative(t *testing.T) {
 
 func TestResolveNativeImportSourcePath_RejectsMissing(t *testing.T) {
 	_, err := resolveNativeImportSourcePath("/nonexistent/birds.db")
-	require.Error(t, err)
+	require.ErrorIs(t, err, errInvalidSourcePath)
 }
 
 // TestResolveNativeImportSourcePath_AcceptsRegularFile documents that the

--- a/internal/api/v2/imports/import_test.go
+++ b/internal/api/v2/imports/import_test.go
@@ -1494,3 +1494,104 @@ func TestStartBirdNETPiImport_PanicInEngine_RecoverAndPreserveStats(t *testing.T
 	defer func() { _ = startResp2.Body.Close() }()
 	assert.Equal(t, http.StatusAccepted, startResp2.StatusCode, "slot must be freed after panic recovery")
 }
+
+// writeMinimalBirdNetPiDB creates a minimal valid BirdNET-Pi SQLite db at path.
+func writeMinimalBirdNetPiDB(t *testing.T, path string) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(path), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, sqlDB.Close()) })
+	require.NoError(t, db.Exec(`CREATE TABLE detections (
+		Date TEXT, Time TEXT, Sci_Name TEXT, Com_Name TEXT, Confidence REAL,
+		Lat REAL, Lon REAL, Cutoff REAL, Sens REAL, File_Name TEXT)`).Error)
+}
+
+func TestResolveNativeImportSourcePath_Valid(t *testing.T) {
+	db := filepath.Join(t.TempDir(), "birds.db")
+	writeMinimalBirdNetPiDB(t, db)
+
+	got, err := resolveNativeImportSourcePath(db)
+	require.NoError(t, err)
+	assert.Equal(t, db, got)
+}
+
+func TestResolveNativeImportSourcePath_RejectsRelative(t *testing.T) {
+	_, err := resolveNativeImportSourcePath("relative/birds.db")
+	require.ErrorIs(t, err, errInvalidSourcePath)
+}
+
+func TestResolveNativeImportSourcePath_RejectsMissing(t *testing.T) {
+	_, err := resolveNativeImportSourcePath("/nonexistent/birds.db")
+	require.Error(t, err)
+}
+
+func TestResolveNativeImportSourcePath_RejectsNonSQLite(t *testing.T) {
+	bad := filepath.Join(t.TempDir(), "birds.db")
+	require.NoError(t, os.WriteFile(bad, []byte("nope"), 0o600))
+	_, err := resolveNativeImportSourcePath(bad)
+	require.Error(t, err)
+}
+
+// TestStartBirdNETPiImport_NativeDispatch_AcceptsAbsolutePath verifies that
+// when isContainerEnv returns false, an absolute path to a valid SQLite db is
+// accepted (native branch).
+func TestStartBirdNETPiImport_NativeDispatch_AcceptsAbsolutePath(t *testing.T) {
+	_, c := newImportHandler(t)
+	mockDS := mocks.NewMockInterface(t)
+	c.DS = mockDS
+	mockRepo := mocks.NewMockDetectionRepository(t)
+	mockRepo.EXPECT().Search(mock.Anything, mock.Anything).Return(nil, int64(0), nil).Maybe()
+	mockRepo.EXPECT().Save(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	c.Repo = mockRepo
+	// Force native branch.
+	c.isContainerEnv = func() bool { return false }
+	c.importSourceFactory = func(_ string) (imports.Source, error) { return &fakeSource{}, nil }
+
+	dbPath := filepath.Join(t.TempDir(), "birds.db")
+	writeMinimalBirdNetPiDB(t, dbPath)
+
+	body := fmt.Sprintf(`{"mode":"db-only","source_path":%q}`, dbPath)
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	require.NoError(t, c.StartBirdNETPiImport(ctx))
+	assert.Equal(t, http.StatusAccepted, rec.Code)
+}
+
+// TestStartBirdNETPiImport_ContainerDispatch_AcceptsRelativePath verifies that
+// when isContainerEnv returns true, a relative path (existing under the import
+// root) is accepted (container branch unchanged).
+func TestStartBirdNETPiImport_ContainerDispatch_AcceptsRelativePath(t *testing.T) {
+	_, c := newImportHandler(t)
+	mockDS := mocks.NewMockInterface(t)
+	c.DS = mockDS
+	mockRepo := mocks.NewMockDetectionRepository(t)
+	mockRepo.EXPECT().Search(mock.Anything, mock.Anything).Return(nil, int64(0), nil).Maybe()
+	mockRepo.EXPECT().Save(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	c.Repo = mockRepo
+	// Force container branch.
+	c.isContainerEnv = func() bool { return true }
+	root := t.TempDir()
+	c.importSourceRoot = root
+	// Place a real file under root so the resolver succeeds.
+	dbPath := filepath.Join(root, "birds.db")
+	writeMinimalBirdNetPiDB(t, dbPath)
+	c.importSourceFactory = func(_ string) (imports.Source, error) { return &fakeSource{}, nil }
+
+	body := `{"mode":"db-only","source_path":"birds.db"}`
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	require.NoError(t, c.StartBirdNETPiImport(ctx))
+	assert.Equal(t, http.StatusAccepted, rec.Code)
+}

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -438,7 +438,7 @@ type PushProviderConfig struct {
 type WebhookEndpointConfig struct {
 	URL     string            `yaml:"url" json:"url"`
 	Method  string            `yaml:"method" json:"method"`                          // POST, PUT, PATCH (default: POST)
-	Headers map[string]string `yaml:"headers" json:"headers" jsonschema:"nullable"`   // Custom HTTP headers
+	Headers map[string]string `yaml:"headers" json:"headers" jsonschema:"nullable"`  // Custom HTTP headers
 	Timeout Duration          `yaml:"timeout" json:"timeout" mapstructure:"timeout"` // Per-endpoint timeout (default: use provider timeout)
 	Auth    WebhookAuthConfig `yaml:"auth" json:"auth"`                              // Authentication configuration
 }
@@ -861,8 +861,8 @@ type SpeciesConfig struct {
 // species names in any case (e.g., "American Robin", "american robin")
 // and they will all resolve to the same lowercase key.
 type SpeciesSettings struct {
-	Include []string                 `yaml:"include" json:"include"` // Always include these species
-	Exclude []string                 `yaml:"exclude" json:"exclude"` // Always exclude these species
+	Include []string                 `yaml:"include" json:"include"`                     // Always include these species
+	Exclude []string                 `yaml:"exclude" json:"exclude"`                     // Always exclude these species
 	Config  map[string]SpeciesConfig `yaml:"config" json:"config" jsonschema:"nullable"` // Per-species configuration (keys normalized to lowercase)
 }
 
@@ -892,8 +892,8 @@ type YearlyTrackingSettings struct {
 
 // SeasonalTrackingSettings contains settings for tracking first arrivals each season
 type SeasonalTrackingSettings struct {
-	Enabled    bool              `yaml:"enabled" json:"enabled"`       // true to enable seasonal tracking
-	WindowDays int               `yaml:"windowdays" json:"windowDays"` // Days to show "new this season" indicator (default: 21)
+	Enabled    bool              `yaml:"enabled" json:"enabled"`                       // true to enable seasonal tracking
+	WindowDays int               `yaml:"windowdays" json:"windowDays"`                 // Days to show "new this season" indicator (default: 21)
 	Seasons    map[string]Season `yaml:"seasons" json:"seasons" jsonschema:"nullable"` // Season definitions
 }
 
@@ -1617,8 +1617,8 @@ func (s *GoogleDriveBackupSettings) Validate() error {
 
 // BackupTarget defines settings for a backup target
 type BackupTarget struct {
-	Type     string         `yaml:"type" json:"type"`         // Specifies the type of the backup target (e.g., "local", "s3", "ftp", "sftp"). This determines the storage mechanism.
-	Enabled  bool           `yaml:"enabled" json:"enabled"`   // If true, this backup target will be used for storing backups. At least one target should be enabled for backups to be stored.
+	Type     string         `yaml:"type" json:"type"`                               // Specifies the type of the backup target (e.g., "local", "s3", "ftp", "sftp"). This determines the storage mechanism.
+	Enabled  bool           `yaml:"enabled" json:"enabled"`                         // If true, this backup target will be used for storing backups. At least one target should be enabled for backups to be stored.
 	Settings map[string]any `yaml:"settings" json:"settings" jsonschema:"nullable"` // A map of key-value pairs for target-specific settings. TODO: Consider using BackupTargetSettings interface for type safety after implementing custom YAML unmarshaling.
 }
 
@@ -1629,6 +1629,14 @@ type BackupScheduleConfig struct {
 	Minute   int    `yaml:"minute" json:"minute"`     // The minute of the hour when the backup is scheduled to run. (Valid range: 0-59)
 	Weekday  string `yaml:"weekday" json:"weekday"`   // For weekly schedules, the day of the week. Accepts: "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" (case-insensitive), or numeric: "0" (Sunday) through "6" (Saturday). Empty or ignored for daily schedules.
 	IsWeekly bool   `yaml:"isweekly" json:"isWeekly"` // If true, this schedule is weekly (runs on the specified Weekday at Hour:Minute). If false, it's a daily schedule (runs every day at Hour:Minute). (Valid: true or false)
+}
+
+// ImportConfig controls the BirdNET-Pi import feature behavior.
+type ImportConfig struct {
+	// AllowInAppElevation enables the in-app sudo elevation ladder for native
+	// imports of unreadable source data. Default true. When false, the UI only
+	// offers copy-paste remediation and never prompts for a sudo password.
+	AllowInAppElevation bool `yaml:"allowinappelevation" json:"allowInAppElevation" mapstructure:"allowinappelevation"`
 }
 
 // BackupConfig contains backup-related configuration
@@ -1709,6 +1717,8 @@ type Settings struct {
 	} `yaml:"output" json:"output"`
 
 	Backup BackupConfig `yaml:"backup" json:"backup"` // Backup configuration
+
+	Import ImportConfig `yaml:"import" json:"import"` // BirdNET-Pi import behavior
 
 	Notification NotificationConfig `yaml:"notification" json:"notification"` // Configuration for push notifications
 

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -26,8 +26,8 @@ func setDefaultConfig() {
 
 	// Per-module log files
 	// Core processing modules
-	setModuleLogDefaults("analysis", true)    // Bird detection analysis
-	setModuleLogDefaults("birdnet", true)     // BirdNET model inference
+	setModuleLogDefaults("analysis", true) // Bird detection analysis
+	setModuleLogDefaults("birdnet", true)  // BirdNET model inference
 	// Mirror the birdnet module to the console so backend selection, model-init,
 	// reload, and bat-scheduler lines are visible in journald/containers and not
 	// only in logs/birdnet.log. This realigns the viper default with the intent in
@@ -351,6 +351,9 @@ func setDefaultConfig() {
 	viper.SetDefault("webserver.livestream.sampleRate", DefaultLiveStreamSampleRate)
 	viper.SetDefault("webserver.livestream.segmentLength", DefaultLiveStreamSegmentLength)
 	viper.SetDefault("webserver.livestream.ffmpegLogLevel", DefaultLiveStreamFFmpegLogLevel)
+
+	// Import feature: in-app sudo elevation enabled by default.
+	viper.SetDefault("import.allowInAppElevation", true)
 
 	// File output configuration
 	viper.SetDefault("output.file.enabled", true)

--- a/internal/conf/defaults_test.go
+++ b/internal/conf/defaults_test.go
@@ -1,0 +1,16 @@
+package conf
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImportElevationDefaultsOn(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	viper.Reset()
+	setDefaultConfig()
+	require.True(t, viper.GetBool("import.allowInAppElevation"),
+		"in-app elevation must default to enabled")
+}

--- a/internal/imports/elevation/ladder.go
+++ b/internal/imports/elevation/ladder.go
@@ -7,8 +7,14 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 )
+
+// stagedDBName is the fixed filename import-stage writes the staged database as.
+// It must match staging.stagedDBName; kept as a local constant to avoid importing
+// the staging package (which pulls in cgo) just for a string.
+const stagedDBName = "birds.db"
 
 // Method describes how the ladder satisfied (or declined) the staging request.
 type Method string
@@ -105,6 +111,12 @@ func NewLadder() (*Ladder, error) {
 // Stage runs the four-rung elevation ladder for req and returns the outcome.
 // The password in req is cleared on every return path.
 func (l *Ladder) Stage(ctx context.Context, req *StageRequest) (Outcome, error) {
+	// Clear the password on every return path, regardless of which rung is
+	// reached or whether elevation is attempted at all. A direct-read or
+	// passwordless-sudo success returns before the password rung, so clearing
+	// only inside that rung would leave a caller-supplied password in memory.
+	defer req.Password.Clear()
+
 	// Rung 1: direct read. If the service user can read the source, no copy needed.
 	if l.Direct.CanRead(req.Src) {
 		l.Log.Info("import: direct read available",
@@ -114,48 +126,41 @@ func (l *Ladder) Stage(ctx context.Context, req *StageRequest) (Outcome, error) 
 		return Outcome{Method: MethodDirect, StagedDB: req.Src, StagedAudio: req.Audio}, nil
 	}
 
-	// Rung 2: passwordless sudo probe.
+	// cmd is the import-stage invocation (binary + flags), shared by both sudo
+	// rungs. Each rung prepends its own sudo flags and the "--" sentinel.
+	cmd := buildStageCommand(l.SelfExe, req)
+
+	// Rung 2: passwordless sudo probe, then the staged copy via `sudo -n`.
 	if err := l.Runner.Run(ctx, nil, "sudo", "-n", "true"); err == nil {
-		argv := buildArgv(l.SelfExe, req)
-		if runErr := l.Runner.Run(ctx, nil, "sudo", argv...); runErr == nil {
+		sudoArgs := append([]string{"-n", "--"}, cmd...)
+		if runErr := l.Runner.Run(ctx, nil, "sudo", sudoArgs...); runErr == nil {
 			l.Log.Info("import: staged via passwordless sudo",
 				slog.String("src", req.Src),
 				slog.String("dst", req.Dst),
 				slog.String("method", string(MethodSudoNonInteractive)),
 			)
-			return Outcome{
-				Method:   MethodSudoNonInteractive,
-				StagedDB: req.Dst + "/birds.db",
-			}, nil
+			return stagedOutcome(MethodSudoNonInteractive, req), nil
 		}
 	}
 
 	// Rung 3: in-app sudo password.
 	if req.AllowElevation && len(req.Password) > 0 {
-		defer req.Password.Clear()
-		// Drop any cached sudo grant first so the password attempt starts fresh.
+		// Drop any cached sudo grant first so the password attempt starts fresh
+		// and a stale timestamp cache cannot mask a wrong password.
 		_ = l.Runner.Run(ctx, nil, "sudo", "-k")
 		// Feed the password on stdin; -p "" suppresses the prompt.
-		argv := buildArgv(l.SelfExe, req)
-		pwBytes := req.Password.Bytes()
-		sudoArgs := append([]string{"-S", "-p", "", "--"}, argv...)
-		if runErr := l.Runner.Run(ctx, pwBytes, "sudo", sudoArgs...); runErr == nil {
+		sudoArgs := append([]string{"-S", "-p", "", "--"}, cmd...)
+		if runErr := l.Runner.Run(ctx, req.Password.Bytes(), "sudo", sudoArgs...); runErr == nil {
 			l.Log.Info("import: staged via sudo with password",
 				slog.String("src", req.Src),
 				slog.String("dst", req.Dst),
 				slog.String("method", string(MethodSudoPassword)),
 			)
-			return Outcome{
-				Method:   MethodSudoPassword,
-				StagedDB: req.Dst + "/birds.db",
-			}, nil
+			return stagedOutcome(MethodSudoPassword, req), nil
 		}
 		l.Log.Warn("import: sudo password elevation failed",
 			slog.String("src", req.Src),
 		)
-	} else {
-		// Ensure the password is cleared even when not attempted.
-		req.Password.Clear()
 	}
 
 	// Rung 4: fallback. Provide copy-paste remediation hints, no error.
@@ -167,12 +172,14 @@ func (l *Ladder) Stage(ctx context.Context, req *StageRequest) (Outcome, error) 
 	return Outcome{Method: MethodFallback, FallbackCommands: cmds}, nil
 }
 
-// buildArgv builds the --flag=value argv slice for the import-stage subcommand.
-// The "-n" and "--" sentinel are prepended so sudo passes the command through
-// without interpretation and cannot re-elevate further.
-func buildArgv(selfExe string, req *StageRequest) []string {
-	args := make([]string, 0, 8)
-	args = append(args, "-n", "--",
+// buildStageCommand builds the import-stage invocation (binary path plus
+// --flag=value arguments), without any sudo flags. Each sudo rung prepends its
+// own flags and a "--" sentinel, so the flags here are never re-interpreted by
+// sudo. Using --flag=value form means a value that looks like a flag (e.g.
+// --src=-rf) is bound to its flag, not treated as a new option.
+func buildStageCommand(selfExe string, req *StageRequest) []string {
+	args := make([]string, 0, 7)
+	args = append(args,
 		selfExe,
 		"import-stage",
 		"--src="+req.Src,
@@ -184,6 +191,17 @@ func buildArgv(selfExe string, req *StageRequest) []string {
 		args = append(args, "--audio="+req.Audio)
 	}
 	return args
+}
+
+// stagedOutcome builds the Outcome for a successful sudo staging copy. The staged
+// paths mirror what import-stage writes under Dst: the database as stagedDBName
+// and, when audio was requested, the audio tree under its base name.
+func stagedOutcome(method Method, req *StageRequest) Outcome {
+	out := Outcome{Method: method, StagedDB: filepath.Join(req.Dst, stagedDBName)}
+	if req.Audio != "" {
+		out.StagedAudio = filepath.Join(req.Dst, filepath.Base(req.Audio))
+	}
+	return out
 }
 
 // fallbackCommands returns copy-paste shell commands the user can run manually

--- a/internal/imports/elevation/ladder.go
+++ b/internal/imports/elevation/ladder.go
@@ -1,0 +1,228 @@
+package elevation
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+// Method describes how the ladder satisfied (or declined) the staging request.
+type Method string
+
+const (
+	// MethodDirect means the source was readable without elevation.
+	MethodDirect Method = "direct"
+	// MethodSudoNonInteractive means staging ran via passwordless sudo.
+	MethodSudoNonInteractive Method = "sudo-noninteractive"
+	// MethodSudoPassword means staging ran via sudo with an in-app password.
+	MethodSudoPassword Method = "sudo-password"
+	// MethodFallback means no elevation path succeeded; copy-paste remediation is offered.
+	MethodFallback Method = "fallback"
+)
+
+// SudoRunner abstracts running a command with optional stdin, so tests can
+// inject a fake without actual sudo or a real subprocess.
+type SudoRunner interface {
+	// Run executes name with args, feeding stdin (may be nil) to the process.
+	Run(ctx context.Context, stdin []byte, name string, args ...string) error
+}
+
+// DirectReader tests whether a path can be opened for reading without elevation.
+type DirectReader interface {
+	// CanRead reports whether path is readable by the current process.
+	CanRead(path string) bool
+}
+
+// StageRequest carries the parameters for a single ladder invocation.
+type StageRequest struct {
+	// Src is the absolute path to the source birds.db.
+	Src string
+	// Audio is the optional absolute path to the source audio directory.
+	Audio string
+	// Dst is the absolute path to the empty staging directory.
+	Dst string
+	// UID is the service-user uid to chown staged files to.
+	UID int
+	// GID is the service-user gid to chown staged files to.
+	GID int
+	// Password is the sudo password for the in-app elevation rung.
+	// It is cleared after use regardless of outcome.
+	Password Password
+	// AllowElevation enables rungs 3 and 4 (sudo password and fallback).
+	// When false the ladder stops after the passwordless-sudo probe.
+	AllowElevation bool
+	// Owner is the system username of the BirdNET-Go service account, used in
+	// fallback copy-paste remediation hints.
+	Owner string
+}
+
+// Outcome reports what the ladder did and where the data ended up.
+type Outcome struct {
+	// Method is the rung that succeeded (or MethodFallback if none did).
+	Method Method
+	// StagedDB is the path to the staged database (empty for MethodFallback).
+	StagedDB string
+	// StagedAudio is the path to the staged audio directory (empty when not applicable).
+	StagedAudio string
+	// FallbackCommands are the copy-paste remediation commands for MethodFallback.
+	FallbackCommands []string
+}
+
+// Ladder decides how to get the BirdNET-Pi data into a BirdNET-Go-owned
+// staging directory, trying four rungs in order: direct read, passwordless sudo,
+// in-app sudo password, and copy-paste fallback.
+type Ladder struct {
+	// Runner executes subprocesses. Defaults to an exec-based real runner.
+	Runner SudoRunner
+	// SelfExe is the absolute path to the birdnet-go binary, passed to sudo
+	// so the privileged invocation re-runs the same binary. Defaults to
+	// os.Executable().
+	SelfExe string
+	// Direct tests whether the source can be read without elevation.
+	Direct DirectReader
+	// Log is the audit logger. Password fields are never logged.
+	Log *slog.Logger
+}
+
+// NewLadder builds a Ladder with production defaults.
+func NewLadder() (*Ladder, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("could not determine executable path: %w", err)
+	}
+	return &Ladder{
+		Runner:  &execRunner{},
+		SelfExe: exe,
+		Direct:  &osDirectReader{},
+		Log:     slog.Default(),
+	}, nil
+}
+
+// Stage runs the four-rung elevation ladder for req and returns the outcome.
+// The password in req is cleared on every return path.
+func (l *Ladder) Stage(ctx context.Context, req *StageRequest) (Outcome, error) {
+	// Rung 1: direct read. If the service user can read the source, no copy needed.
+	if l.Direct.CanRead(req.Src) {
+		l.Log.Info("import: direct read available",
+			slog.String("src", req.Src),
+			slog.String("method", string(MethodDirect)),
+		)
+		return Outcome{Method: MethodDirect, StagedDB: req.Src, StagedAudio: req.Audio}, nil
+	}
+
+	// Rung 2: passwordless sudo probe.
+	if err := l.Runner.Run(ctx, nil, "sudo", "-n", "true"); err == nil {
+		argv := buildArgv(l.SelfExe, req)
+		if runErr := l.Runner.Run(ctx, nil, "sudo", argv...); runErr == nil {
+			l.Log.Info("import: staged via passwordless sudo",
+				slog.String("src", req.Src),
+				slog.String("dst", req.Dst),
+				slog.String("method", string(MethodSudoNonInteractive)),
+			)
+			return Outcome{
+				Method:   MethodSudoNonInteractive,
+				StagedDB: req.Dst + "/birds.db",
+			}, nil
+		}
+	}
+
+	// Rung 3: in-app sudo password.
+	if req.AllowElevation && len(req.Password) > 0 {
+		defer req.Password.Clear()
+		// Drop any cached sudo grant first so the password attempt starts fresh.
+		_ = l.Runner.Run(ctx, nil, "sudo", "-k")
+		// Feed the password on stdin; -p "" suppresses the prompt.
+		argv := buildArgv(l.SelfExe, req)
+		pwBytes := req.Password.Bytes()
+		sudoArgs := append([]string{"-S", "-p", "", "--"}, argv...)
+		if runErr := l.Runner.Run(ctx, pwBytes, "sudo", sudoArgs...); runErr == nil {
+			l.Log.Info("import: staged via sudo with password",
+				slog.String("src", req.Src),
+				slog.String("dst", req.Dst),
+				slog.String("method", string(MethodSudoPassword)),
+			)
+			return Outcome{
+				Method:   MethodSudoPassword,
+				StagedDB: req.Dst + "/birds.db",
+			}, nil
+		}
+		l.Log.Warn("import: sudo password elevation failed",
+			slog.String("src", req.Src),
+		)
+	} else {
+		// Ensure the password is cleared even when not attempted.
+		req.Password.Clear()
+	}
+
+	// Rung 4: fallback. Provide copy-paste remediation hints, no error.
+	cmds := fallbackCommands(req)
+	l.Log.Info("import: elevation unavailable, returning fallback commands",
+		slog.String("src", req.Src),
+		slog.String("method", string(MethodFallback)),
+	)
+	return Outcome{Method: MethodFallback, FallbackCommands: cmds}, nil
+}
+
+// buildArgv builds the --flag=value argv slice for the import-stage subcommand.
+// The "-n" and "--" sentinel are prepended so sudo passes the command through
+// without interpretation and cannot re-elevate further.
+func buildArgv(selfExe string, req *StageRequest) []string {
+	args := make([]string, 0, 8)
+	args = append(args, "-n", "--",
+		selfExe,
+		"import-stage",
+		"--src="+req.Src,
+		"--dst="+req.Dst,
+		"--uid="+strconv.Itoa(req.UID),
+		"--gid="+strconv.Itoa(req.GID),
+	)
+	if req.Audio != "" {
+		args = append(args, "--audio="+req.Audio)
+	}
+	return args
+}
+
+// fallbackCommands returns copy-paste shell commands the user can run manually
+// to grant the service account read access to the source data.
+func fallbackCommands(req *StageRequest) []string {
+	owner := req.Owner
+	if owner == "" {
+		owner = "birdnet-go"
+	}
+	cmds := []string{
+		fmt.Sprintf("sudo setfacl -R -m u:%s:rX %s", owner, req.Src),
+	}
+	if req.Audio != "" {
+		cmds = append(cmds, fmt.Sprintf("sudo setfacl -R -m u:%s:rX %s", owner, req.Audio))
+	}
+	return cmds
+}
+
+// execRunner is the real SudoRunner that uses os/exec.
+type execRunner struct{}
+
+func (e *execRunner) Run(ctx context.Context, stdin []byte, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...) //nolint:gosec // name is always "sudo", args are controlled
+	if len(stdin) > 0 {
+		cmd.Stdin = bytes.NewReader(stdin)
+	}
+	// Discard stdout/stderr to avoid echoing a password prompt or other output.
+	// sudo with -p "" suppresses prompts; stderr discard prevents accidental leaks.
+	return cmd.Run()
+}
+
+// osDirectReader checks readability using os.Open.
+type osDirectReader struct{}
+
+func (r *osDirectReader) CanRead(path string) bool {
+	f, err := os.Open(path) //nolint:gosec // path is caller-controlled and validated upstream
+	if err != nil {
+		return false
+	}
+	_ = f.Close()
+	return true
+}

--- a/internal/imports/elevation/ladder.go
+++ b/internal/imports/elevation/ladder.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -155,9 +156,16 @@ func (l *Ladder) Stage(ctx context.Context, req *StageRequest) (Outcome, error) 
 		// Drop any cached sudo grant first so the password attempt starts fresh
 		// and a stale timestamp cache cannot mask a wrong password.
 		_ = l.Runner.Run(ctx, nil, "sudo", "-k")
-		// Feed the password on stdin; -p "" suppresses the prompt.
+		// Feed the password on stdin; -p "" suppresses the prompt. sudo -S reads
+		// the password as a line, so it MUST be newline-terminated. Build a
+		// throwaway newline-terminated copy and zero it right after use.
+		pwLine := make([]byte, len(req.Password)+1)
+		copy(pwLine, req.Password)
+		pwLine[len(pwLine)-1] = '\n'
 		sudoArgs := append([]string{"-S", "-p", "", "--"}, cmd...)
-		if runErr := l.Runner.Run(ctx, req.Password.Bytes(), "sudo", sudoArgs...); runErr == nil {
+		runErr := l.Runner.Run(ctx, pwLine, "sudo", sudoArgs...)
+		clear(pwLine)
+		if runErr == nil {
 			l.Log.Info("import: staged via sudo with password",
 				slog.String("src", req.Src),
 				slog.String("dst", req.Dst),
@@ -224,12 +232,38 @@ func fallbackCommands(req *StageRequest) []string {
 	// runs in a shell, so a path or owner containing spaces or shell metacharacters
 	// (e.g. $(...), ;, backtick) must not be interpretable. shellQuote single-quotes
 	// the value so it is always a single literal argument.
-	cmds := []string{
-		fmt.Sprintf("sudo setfacl -R -m u:%s:rX %s", shellQuote(owner), shellQuote(req.Src)),
-	}
+	//
+	// A recursive rX on the data directory is not enough on its own: if a parent
+	// (e.g. /home/pi, mode 0700) lacks execute/search for the service user, it
+	// cannot traverse down to the data at all. So also grant a traversal (x) ACL on
+	// each ancestor directory of the source, up to but not including the root.
+	var cmds []string
+	cmds = append(cmds, parentTraversalACLs(owner, req.Src)...)
+	cmds = append(cmds, fmt.Sprintf("sudo setfacl -R -m u:%s:rX %s", shellQuote(owner), shellQuote(req.Src)))
 	if req.Audio != "" {
+		cmds = append(cmds, parentTraversalACLs(owner, req.Audio)...)
 		cmds = append(cmds, fmt.Sprintf("sudo setfacl -R -m u:%s:rX %s", shellQuote(owner), shellQuote(req.Audio)))
 	}
+	return cmds
+}
+
+// parentTraversalACLs returns setfacl commands granting the owner execute
+// (search) access on each ancestor directory of path, from its parent up to but
+// not including the filesystem root. Without traversal on every ancestor, a
+// recursive rX on the leaf data directory still cannot be reached.
+func parentTraversalACLs(owner, path string) []string {
+	var cmds []string
+	dir := filepath.Dir(filepath.Clean(path))
+	for dir != "" && dir != string(filepath.Separator) && dir != "." {
+		cmds = append(cmds, fmt.Sprintf("sudo setfacl -m u:%s:x %s", shellQuote(owner), shellQuote(dir)))
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	// List outermost ancestor first so the user grants traversal top-down.
+	slices.Reverse(cmds)
 	return cmds
 }
 
@@ -248,9 +282,18 @@ func (e *execRunner) Run(ctx context.Context, stdin []byte, name string, args ..
 	if len(stdin) > 0 {
 		cmd.Stdin = bytes.NewReader(stdin)
 	}
-	// Discard stdout/stderr to avoid echoing a password prompt or other output.
-	// sudo with -p "" suppresses prompts; stderr discard prevents accidental leaks.
-	return cmd.Run()
+	// Capture stderr for diagnosability. sudo's prompt is suppressed via -p "",
+	// and our own subcommand never writes the password to stderr, so this does
+	// not leak the secret; it surfaces the actual sudo / import-stage failure.
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if stderr.Len() > 0 {
+			return fmt.Errorf("%w: %s", err, bytes.TrimSpace(stderr.Bytes()))
+		}
+		return err
+	}
+	return nil
 }
 
 // osDirectReader checks readability using os.Open.

--- a/internal/imports/elevation/ladder.go
+++ b/internal/imports/elevation/ladder.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 )
 
 // stagedDBName is the fixed filename import-stage writes the staged database as.
@@ -141,6 +142,12 @@ func (l *Ladder) Stage(ctx context.Context, req *StageRequest) (Outcome, error) 
 			)
 			return stagedOutcome(MethodSudoNonInteractive, req), nil
 		}
+		// Probe succeeded but the staging command was refused (e.g. sudoers allows
+		// `true` but not `birdnet-go import-stage`). Log before falling through,
+		// mirroring the password-rung failure log.
+		l.Log.Warn("import: passwordless sudo staging failed",
+			slog.String("src", req.Src),
+		)
 	}
 
 	// Rung 3: in-app sudo password.
@@ -178,7 +185,9 @@ func (l *Ladder) Stage(ctx context.Context, req *StageRequest) (Outcome, error) 
 // sudo. Using --flag=value form means a value that looks like a flag (e.g.
 // --src=-rf) is bound to its flag, not treated as a new option.
 func buildStageCommand(selfExe string, req *StageRequest) []string {
-	args := make([]string, 0, 7)
+	// selfExe + "import-stage" + 4 required flags + optional --audio = 7 max.
+	const maxStageArgs = 7
+	args := make([]string, 0, maxStageArgs)
 	args = append(args,
 		selfExe,
 		"import-stage",
@@ -211,13 +220,24 @@ func fallbackCommands(req *StageRequest) []string {
 	if owner == "" {
 		owner = "birdnet-go"
 	}
+	// Shell-quote every interpolated value: these are copy-paste commands the user
+	// runs in a shell, so a path or owner containing spaces or shell metacharacters
+	// (e.g. $(...), ;, backtick) must not be interpretable. shellQuote single-quotes
+	// the value so it is always a single literal argument.
 	cmds := []string{
-		fmt.Sprintf("sudo setfacl -R -m u:%s:rX %s", owner, req.Src),
+		fmt.Sprintf("sudo setfacl -R -m u:%s:rX %s", shellQuote(owner), shellQuote(req.Src)),
 	}
 	if req.Audio != "" {
-		cmds = append(cmds, fmt.Sprintf("sudo setfacl -R -m u:%s:rX %s", owner, req.Audio))
+		cmds = append(cmds, fmt.Sprintf("sudo setfacl -R -m u:%s:rX %s", shellQuote(owner), shellQuote(req.Audio)))
 	}
 	return cmds
+}
+
+// shellQuote wraps s in single quotes for safe copy-paste into a POSIX shell,
+// escaping any embedded single quote as '\”. The result is always exactly one
+// shell word, so spaces and metacharacters in s cannot be interpreted.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 // execRunner is the real SudoRunner that uses os/exec.
@@ -237,6 +257,13 @@ func (e *execRunner) Run(ctx context.Context, stdin []byte, name string, args ..
 type osDirectReader struct{}
 
 func (r *osDirectReader) CanRead(path string) bool {
+	// Stat first (does not block) so a named pipe or device source is rejected
+	// without os.Open blocking on it forever. Only a regular file is a readable
+	// import source.
+	info, err := os.Stat(path)
+	if err != nil || !info.Mode().IsRegular() {
+		return false
+	}
 	f, err := os.Open(path) //nolint:gosec // path is caller-controlled and validated upstream
 	if err != nil {
 		return false

--- a/internal/imports/elevation/ladder_test.go
+++ b/internal/imports/elevation/ladder_test.go
@@ -1,0 +1,124 @@
+package elevation
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeRunner struct {
+	calls  [][]string // name + args per call
+	stdins [][]byte
+	failOn map[string]bool // key: first arg after the command name, e.g. "-n" to fail the probe
+}
+
+func (f *fakeRunner) Run(_ context.Context, stdin []byte, name string, args ...string) error {
+	f.calls = append(f.calls, append([]string{name}, args...))
+	f.stdins = append(f.stdins, bytes.Clone(stdin))
+	if len(args) > 0 && f.failOn[args[0]] {
+		return errSudoFailed
+	}
+	return nil
+}
+
+// errSudoFailed is the sentinel error returned by fakeRunner when failOn matches.
+var errSudoFailed = sudoError("sudo failed")
+
+// sudoError is a simple error type for fakeRunner failures.
+type sudoError string
+
+func (e sudoError) Error() string { return string(e) }
+
+type fakeDirect struct{ readable bool }
+
+func (d fakeDirect) CanRead(string) bool { return d.readable }
+
+func findCall(calls [][]string, arg string) []string {
+	for _, c := range calls {
+		for _, a := range c {
+			if a == arg {
+				return c
+			}
+		}
+	}
+	return nil
+}
+
+func countStdin(stdins [][]byte, needle []byte) int {
+	n := 0
+	for _, s := range stdins {
+		if bytes.Equal(s, needle) {
+			n++
+		}
+	}
+	return n
+}
+
+func TestLadderDirectRead(t *testing.T) {
+	l := &Ladder{
+		Runner:  &fakeRunner{},
+		Direct:  fakeDirect{readable: true},
+		SelfExe: "/bin/birdnet",
+		Log:     slog.Default(),
+	}
+	out, err := l.Stage(t.Context(), &StageRequest{Src: "/data/birds.db", Dst: "/stg"})
+	require.NoError(t, err)
+	assert.Equal(t, MethodDirect, out.Method)
+	assert.Equal(t, "/data/birds.db", out.StagedDB)
+}
+
+func TestLadderSudoNonInteractive(t *testing.T) {
+	r := &fakeRunner{}
+	l := &Ladder{Runner: r, Direct: fakeDirect{}, SelfExe: "/bin/birdnet", Log: slog.Default()}
+	out, err := l.Stage(t.Context(), &StageRequest{
+		Src: "/data/birds.db", Dst: "/stg", UID: 1000, GID: 1000,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, MethodSudoNonInteractive, out.Method)
+	// First call probes `sudo -n true`, second runs the staged copy.
+	assert.Equal(t, []string{"sudo", "-n", "true"}, r.calls[0])
+	assert.Contains(t, r.calls[1], "import-stage")
+	assert.Contains(t, r.calls[1], "--src=/data/birds.db")
+}
+
+func TestLadderPasswordPathFeedsAndClears(t *testing.T) {
+	r := &fakeRunner{failOn: map[string]bool{"-n": true}} // passwordless probe fails
+	var logBuf bytes.Buffer
+	l := &Ladder{
+		Runner:  r,
+		Direct:  fakeDirect{},
+		SelfExe: "/bin/birdnet",
+		Log:     slog.New(slog.NewTextHandler(&logBuf, nil)),
+	}
+	pw := Password("hunter2")
+	out, err := l.Stage(t.Context(), &StageRequest{
+		Src: "/data/birds.db", Dst: "/stg", UID: 1000, GID: 1000,
+		Password: pw, AllowElevation: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, MethodSudoPassword, out.Method)
+	// sudo -k must be invoked before the password attempt.
+	assert.Equal(t, []string{"sudo", "-k"}, findCall(r.calls, "-k"))
+	// The password is fed on stdin exactly once.
+	assert.Equal(t, 1, countStdin(r.stdins, []byte("hunter2")))
+	// The password bytes are zeroed after use (Clear() zeroes the backing
+	// array; the caller's pw slice header still points at that array).
+	assert.Equal(t, make([]byte, len("hunter2")), []byte(pw))
+	// No log line contains the cleartext password.
+	assert.NotContains(t, logBuf.String(), "hunter2")
+}
+
+func TestLadderFallbackWhenNoSudo(t *testing.T) {
+	r := &fakeRunner{failOn: map[string]bool{"-n": true}}
+	l := &Ladder{Runner: r, Direct: fakeDirect{}, SelfExe: "/bin/birdnet", Log: slog.Default()}
+	out, err := l.Stage(t.Context(), &StageRequest{
+		Src: "/data/birds.db", Dst: "/stg", Owner: "pi", AllowElevation: true, // no password
+	})
+	require.NoError(t, err)
+	assert.Equal(t, MethodFallback, out.Method)
+	assert.NotEmpty(t, out.FallbackCommands)
+}

--- a/internal/imports/elevation/ladder_test.go
+++ b/internal/imports/elevation/ladder_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"log/slog"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,10 +40,8 @@ func (d fakeDirect) CanRead(string) bool { return d.readable }
 
 func findCall(calls [][]string, arg string) []string {
 	for _, c := range calls {
-		for _, a := range c {
-			if a == arg {
-				return c
-			}
+		if slices.Contains(c, arg) {
+			return c
 		}
 	}
 	return nil
@@ -110,6 +109,66 @@ func TestLadderPasswordPathFeedsAndClears(t *testing.T) {
 	assert.Equal(t, make([]byte, len("hunter2")), []byte(pw))
 	// No log line contains the cleartext password.
 	assert.NotContains(t, logBuf.String(), "hunter2")
+}
+
+func TestLadderSudoNonInteractiveArgvWellFormed(t *testing.T) {
+	r := &fakeRunner{}
+	l := &Ladder{Runner: r, Direct: fakeDirect{}, SelfExe: "/bin/birdnet", Log: slog.Default()}
+	_, err := l.Stage(t.Context(), &StageRequest{
+		Src: "/data/birds.db", Dst: "/stg", UID: 1000, GID: 1000,
+	})
+	require.NoError(t, err)
+	// The staged-copy call must be: sudo -n -- /bin/birdnet import-stage ...
+	// with exactly one "--" sentinel and the binary immediately after it.
+	staged := r.calls[1]
+	require.Equal(t, []string{
+		"sudo", "-n", "--",
+		"/bin/birdnet", "import-stage",
+		"--src=/data/birds.db", "--dst=/stg", "--uid=1000", "--gid=1000",
+	}, staged)
+}
+
+func TestLadderSudoPasswordArgvWellFormed(t *testing.T) {
+	r := &fakeRunner{failOn: map[string]bool{"-n": true}}
+	l := &Ladder{Runner: r, Direct: fakeDirect{}, SelfExe: "/bin/birdnet", Log: slog.Default()}
+	_, err := l.Stage(t.Context(), &StageRequest{
+		Src: "/data/birds.db", Dst: "/stg", UID: 1000, GID: 1000,
+		Password: Password("pw"), AllowElevation: true,
+	})
+	require.NoError(t, err)
+	// The password staged-copy call must be:
+	// sudo -S -p "" -- /bin/birdnet import-stage ...
+	// The binary must sit immediately after the single "--" sentinel: a stray
+	// "-n" or a doubled "--" would make sudo try to exec the wrong command.
+	staged := findCall(r.calls, "import-stage")
+	require.Equal(t, []string{
+		"sudo", "-S", "-p", "", "--",
+		"/bin/birdnet", "import-stage",
+		"--src=/data/birds.db", "--dst=/stg", "--uid=1000", "--gid=1000",
+	}, staged)
+}
+
+func TestLadderClearsPasswordOnDirectRead(t *testing.T) {
+	// Even when the source is directly readable (password never used), a
+	// caller-supplied password must be zeroed on return.
+	pw := Password("hunter2")
+	l := &Ladder{Runner: &fakeRunner{}, Direct: fakeDirect{readable: true}, SelfExe: "/bin/birdnet", Log: slog.Default()}
+	_, err := l.Stage(t.Context(), &StageRequest{
+		Src: "/data/birds.db", Dst: "/stg", Password: pw, AllowElevation: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, make([]byte, len("hunter2")), []byte(pw))
+}
+
+func TestLadderReportsStagedAudio(t *testing.T) {
+	r := &fakeRunner{}
+	l := &Ladder{Runner: r, Direct: fakeDirect{}, SelfExe: "/bin/birdnet", Log: slog.Default()}
+	out, err := l.Stage(t.Context(), &StageRequest{
+		Src: "/data/birds.db", Audio: "/data/BirdSongs", Dst: "/stg", UID: 1000, GID: 1000,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/stg/birds.db", out.StagedDB)
+	assert.Equal(t, "/stg/BirdSongs", out.StagedAudio)
 }
 
 func TestLadderFallbackWhenNoSudo(t *testing.T) {

--- a/internal/imports/elevation/ladder_test.go
+++ b/internal/imports/elevation/ladder_test.go
@@ -20,8 +20,13 @@ type fakeRunner struct {
 func (f *fakeRunner) Run(_ context.Context, stdin []byte, name string, args ...string) error {
 	f.calls = append(f.calls, append([]string{name}, args...))
 	f.stdins = append(f.stdins, bytes.Clone(stdin))
-	if len(args) > 0 && f.failOn[args[0]] {
-		return errSudoFailed
+	// Fail if any arg is registered in failOn. Matching on any arg (not just
+	// args[0]) lets a test target a specific invocation: "-n" matches the
+	// passwordless probe, "import-stage" matches a staging command, etc.
+	for _, a := range args {
+		if f.failOn[a] {
+			return errSudoFailed
+		}
 	}
 	return nil
 }
@@ -179,5 +184,29 @@ func TestLadderFallbackWhenNoSudo(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, MethodFallback, out.Method)
-	assert.NotEmpty(t, out.FallbackCommands)
+	require.NotEmpty(t, out.FallbackCommands)
+	// The remediation command must reference the (shell-quoted) source path so a
+	// regression that drops argument interpolation is caught.
+	assert.Contains(t, out.FallbackCommands[0], "'/data/birds.db'")
+}
+
+func TestLadderSudoStagingFailsFallsThrough(t *testing.T) {
+	// Passwordless probe succeeds (`sudo -n true`) but the staging command is
+	// refused (`import-stage`). The ladder must log a warning and fall through to
+	// the fallback rung (no password supplied).
+	r := &fakeRunner{failOn: map[string]bool{"import-stage": true}}
+	var logBuf bytes.Buffer
+	l := &Ladder{
+		Runner:  r,
+		Direct:  fakeDirect{},
+		SelfExe: "/bin/birdnet",
+		Log:     slog.New(slog.NewTextHandler(&logBuf, nil)),
+	}
+	out, err := l.Stage(t.Context(), &StageRequest{
+		Src: "/data/birds.db", Dst: "/stg", Owner: "pi", AllowElevation: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, MethodFallback, out.Method)
+	// The probe passed but staging failed, so the rung-2 failure must be logged.
+	assert.Contains(t, logBuf.String(), "passwordless sudo staging failed")
 }

--- a/internal/imports/elevation/ladder_test.go
+++ b/internal/imports/elevation/ladder_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"log/slog"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -173,8 +174,10 @@ func TestLadderReportsStagedAudio(t *testing.T) {
 		Src: "/data/birds.db", Audio: "/data/BirdSongs", Dst: "/stg", UID: 1000, GID: 1000,
 	})
 	require.NoError(t, err)
-	assert.Equal(t, "/stg/birds.db", out.StagedDB)
-	assert.Equal(t, "/stg/BirdSongs", out.StagedAudio)
+	// stagedOutcome joins with filepath.Join, so the expected paths must use the
+	// same OS separator (this test runs on the windows-amd64 CI runner too).
+	assert.Equal(t, filepath.FromSlash("/stg/birds.db"), out.StagedDB)
+	assert.Equal(t, filepath.FromSlash("/stg/BirdSongs"), out.StagedAudio)
 }
 
 func TestLadderFallbackWhenNoSudo(t *testing.T) {

--- a/internal/imports/elevation/ladder_test.go
+++ b/internal/imports/elevation/ladder_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"log/slog"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -107,8 +108,8 @@ func TestLadderPasswordPathFeedsAndClears(t *testing.T) {
 	assert.Equal(t, MethodSudoPassword, out.Method)
 	// sudo -k must be invoked before the password attempt.
 	assert.Equal(t, []string{"sudo", "-k"}, findCall(r.calls, "-k"))
-	// The password is fed on stdin exactly once.
-	assert.Equal(t, 1, countStdin(r.stdins, []byte("hunter2")))
+	// The password is fed on stdin exactly once, newline-terminated for sudo -S.
+	assert.Equal(t, 1, countStdin(r.stdins, []byte("hunter2\n")))
 	// The password bytes are zeroed after use (Clear() zeroes the backing
 	// array; the caller's pw slice header still points at that array).
 	assert.Equal(t, make([]byte, len("hunter2")), []byte(pw))
@@ -185,9 +186,10 @@ func TestLadderFallbackWhenNoSudo(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, MethodFallback, out.Method)
 	require.NotEmpty(t, out.FallbackCommands)
-	// The remediation command must reference the (shell-quoted) source path so a
-	// regression that drops argument interpolation is caught.
-	assert.Contains(t, out.FallbackCommands[0], "'/data/birds.db'")
+	// Some remediation command must reference the (shell-quoted) source path so a
+	// regression that drops argument interpolation is caught. The first commands
+	// are parent-directory traversal grants, so check across all of them.
+	assert.Contains(t, strings.Join(out.FallbackCommands, "\n"), "'/data/birds.db'")
 }
 
 func TestLadderSudoStagingFailsFallsThrough(t *testing.T) {

--- a/internal/imports/elevation/password.go
+++ b/internal/imports/elevation/password.go
@@ -31,8 +31,22 @@ type Password []byte
 // string unescape (the standard escapes plus \uXXXX) into a fresh byte buffer so
 // the only cleartext bytes live in a slice Clear() can wipe.
 func (p *Password) UnmarshalJSON(b []byte) error {
+	out, err := decodeJSONString(b)
+	if err != nil {
+		// Zero any partially-decoded cleartext before discarding it.
+		clear(out)
+		return err
+	}
+	*p = out
+	return nil
+}
+
+// decodeJSONString decodes a JSON string token into a fresh byte slice, handling
+// the standard escapes plus \uXXXX. On error it returns whatever was decoded so
+// far so the caller can zero it.
+func decodeJSONString(b []byte) ([]byte, error) {
 	if len(b) < 2 || b[0] != '"' || b[len(b)-1] != '"' {
-		return errBadPassword
+		return nil, errBadPassword
 	}
 	body := b[1 : len(b)-1]
 	out := make([]byte, 0, len(body))
@@ -48,7 +62,7 @@ func (p *Password) UnmarshalJSON(b []byte) error {
 			continue
 		}
 		if i >= len(body) {
-			return errBadPassword
+			return out, errBadPassword
 		}
 		escaped := body[i]
 		i++
@@ -67,13 +81,13 @@ func (p *Password) UnmarshalJSON(b []byte) error {
 			out = append(out, '\t')
 		case 'u':
 			if i+4 > len(body) {
-				return errBadPassword
+				return out, errBadPassword
 			}
 			var r rune
 			for j := range 4 {
 				d, ok := hexVal(body[i+j])
 				if !ok {
-					return errBadPassword
+					return out, errBadPassword
 				}
 				r = r<<4 | rune(d)
 			}
@@ -82,11 +96,10 @@ func (p *Password) UnmarshalJSON(b []byte) error {
 			n := utf8.EncodeRune(enc[:], r)
 			out = append(out, enc[:n]...)
 		default:
-			return errBadPassword
+			return out, errBadPassword
 		}
 	}
-	*p = out
-	return nil
+	return out, nil
 }
 
 // hexVal returns the numeric value of a single hex digit and whether it was valid.

--- a/internal/imports/elevation/password.go
+++ b/internal/imports/elevation/password.go
@@ -1,0 +1,128 @@
+// Package elevation implements the BirdNET-Pi import permission elevation
+// ladder: it decides whether source data can be read directly, copied via
+// passwordless sudo, copied with an in-app sudo password, or only through
+// copy-paste remediation. It wraps the privileged import-stage subcommand
+// behind an injectable runner so the policy is testable without real sudo.
+package elevation
+
+import (
+	"encoding/json"
+	"log/slog"
+	"unicode/utf8"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+)
+
+// redactedPlaceholder is what a Password renders as in any string or JSON form.
+const redactedPlaceholder = "[REDACTED]"
+
+// errBadPassword marks a malformed JSON password token.
+var errBadPassword = errors.NewStd("invalid password encoding")
+
+// Password is a memory-only sudo password. It is single-use: feed Bytes() to the
+// privileged process stdin once, then Clear() it. It never serializes in
+// cleartext and never appears in logs.
+type Password []byte
+
+// UnmarshalJSON decodes a JSON string token directly into a clearable []byte,
+// never through an intermediate Go string. A Go string's backing array is
+// immutable and runtime-managed: it cannot be zeroed and would leave a permanent
+// cleartext copy of the password in memory until GC. We hand-roll the JSON
+// string unescape (the standard escapes plus \uXXXX) into a fresh byte buffer so
+// the only cleartext bytes live in a slice Clear() can wipe.
+func (p *Password) UnmarshalJSON(b []byte) error {
+	if len(b) < 2 || b[0] != '"' || b[len(b)-1] != '"' {
+		return errBadPassword
+	}
+	body := b[1 : len(b)-1]
+	out := make([]byte, 0, len(body))
+	// Use an explicit index variable rather than a range form because the \u
+	// handler advances the index by 4 to skip the hex digits, which is not
+	// expressible with for i := range len(body).
+	i := 0
+	for i < len(body) {
+		c := body[i]
+		i++
+		if c != '\\' {
+			out = append(out, c)
+			continue
+		}
+		if i >= len(body) {
+			return errBadPassword
+		}
+		escaped := body[i]
+		i++
+		switch escaped {
+		case '"', '\\', '/':
+			out = append(out, escaped)
+		case 'b':
+			out = append(out, '\b')
+		case 'f':
+			out = append(out, '\f')
+		case 'n':
+			out = append(out, '\n')
+		case 'r':
+			out = append(out, '\r')
+		case 't':
+			out = append(out, '\t')
+		case 'u':
+			if i+4 > len(body) {
+				return errBadPassword
+			}
+			var r rune
+			for j := range 4 {
+				d, ok := hexVal(body[i+j])
+				if !ok {
+					return errBadPassword
+				}
+				r = r<<4 | rune(d)
+			}
+			i += 4
+			var enc [utf8.UTFMax]byte
+			n := utf8.EncodeRune(enc[:], r)
+			out = append(out, enc[:n]...)
+		default:
+			return errBadPassword
+		}
+	}
+	*p = out
+	return nil
+}
+
+// hexVal returns the numeric value of a single hex digit and whether it was valid.
+func hexVal(c byte) (int, bool) {
+	switch {
+	case c >= '0' && c <= '9':
+		return int(c - '0'), true
+	case c >= 'a' && c <= 'f':
+		return int(c-'a') + 10, true
+	case c >= 'A' && c <= 'F':
+		return int(c-'A') + 10, true
+	}
+	return 0, false
+}
+
+// LogValue redacts the password for slog. Without this, slog.Any on a raw []byte
+// dumps the bytes (base64), leaking the secret into logs.
+func (p Password) LogValue() slog.Value { return slog.StringValue(redactedPlaceholder) }
+
+// String renders the password as a fixed redaction marker so it cannot leak via
+// %v/%s formatting in logs or error context.
+func (p Password) String() string { return redactedPlaceholder }
+
+// MarshalJSON renders the password as a redaction marker, never the cleartext.
+func (p Password) MarshalJSON() ([]byte, error) {
+	return json.Marshal(redactedPlaceholder)
+}
+
+// Bytes returns the raw password bytes for single-use stdin feeding.
+func (p Password) Bytes() []byte { return []byte(p) }
+
+// Clear zeroes the password bytes and releases the slice.
+func (p *Password) Clear() {
+	if p == nil {
+		return
+	}
+	clear(*p)
+	*p = nil
+}

--- a/internal/imports/elevation/password.go
+++ b/internal/imports/elevation/password.go
@@ -31,12 +31,19 @@ type Password []byte
 // string unescape (the standard escapes plus \uXXXX) into a fresh byte buffer so
 // the only cleartext bytes live in a slice Clear() can wipe.
 func (p *Password) UnmarshalJSON(b []byte) error {
+	// Zero any secret this Password already held: if it is unmarshaled more than
+	// once (reuse), the old backing array would otherwise linger, and on a decode
+	// error a stale password must not survive into a later retry.
+	old := *p
 	out, err := decodeJSONString(b)
 	if err != nil {
-		// Zero any partially-decoded cleartext before discarding it.
+		// Zero both the partially-decoded cleartext and the prior value.
 		clear(out)
+		clear(old)
+		*p = nil
 		return err
 	}
+	clear(old)
 	*p = out
 	return nil
 }
@@ -92,6 +99,25 @@ func decodeJSONString(b []byte) ([]byte, error) {
 				r = r<<4 | rune(d)
 			}
 			i += 4
+			// Combine a UTF-16 surrogate pair (\uD800-\uDBFF followed by
+			// \uDC00-\uDFFF) into the single code point it encodes, so non-BMP
+			// characters in a password decode correctly instead of as two halves.
+			if r >= 0xD800 && r <= 0xDBFF && i+6 <= len(body) && body[i] == '\\' && body[i+1] == 'u' {
+				var lo rune
+				valid := true
+				for j := range 4 {
+					d, ok := hexVal(body[i+2+j])
+					if !ok {
+						valid = false
+						break
+					}
+					lo = lo<<4 | rune(d)
+				}
+				if valid && lo >= 0xDC00 && lo <= 0xDFFF {
+					r = (r-0xD800)<<10 | (lo - 0xDC00) + 0x10000
+					i += 6
+				}
+			}
 			var enc [utf8.UTFMax]byte
 			n := utf8.EncodeRune(enc[:], r)
 			out = append(out, enc[:n]...)

--- a/internal/imports/elevation/password_test.go
+++ b/internal/imports/elevation/password_test.go
@@ -1,0 +1,51 @@
+package elevation
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPasswordUnmarshalAndClear(t *testing.T) {
+	var body struct {
+		Password Password `json:"password"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(`{"password":"hunter2"}`), &body))
+	assert.Equal(t, []byte("hunter2"), body.Password.Bytes())
+
+	body.Password.Clear()
+	assert.Nil(t, body.Password.Bytes())
+}
+
+func TestPasswordNeverSerializesCleartext(t *testing.T) {
+	p := Password("hunter2")
+	assert.Equal(t, "[REDACTED]", p.String())
+
+	out, err := json.Marshal(struct {
+		P Password `json:"p"`
+	}{P: p})
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), "hunter2")
+	assert.Contains(t, string(out), "[REDACTED]")
+}
+
+func TestPasswordRedactedInSlog(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, nil))
+	log.Info("attempt", slog.Any("password", Password("hunter2")))
+	assert.NotContains(t, buf.String(), "hunter2")
+	assert.Contains(t, buf.String(), "[REDACTED]")
+}
+
+func TestPasswordUnmarshalHandlesEscapes(t *testing.T) {
+	var body struct {
+		Password Password `json:"password"`
+	}
+	// A password containing a quote and a backslash, JSON-escaped.
+	require.NoError(t, json.Unmarshal([]byte(`{"password":"a\"b\\c"}`), &body))
+	assert.Equal(t, []byte(`a"b\c`), body.Password.Bytes())
+}

--- a/internal/imports/elevation/password_test.go
+++ b/internal/imports/elevation/password_test.go
@@ -60,3 +60,15 @@ func TestPasswordUnmarshalHandlesEscapes(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(`{"password":"a\"b\\c"}`), &body))
 	assert.Equal(t, []byte(`a"b\c`), body.Password.Bytes())
 }
+
+func TestPasswordUnmarshalHandlesSurrogatePair(t *testing.T) {
+	var body struct {
+		Password Password `json:"password"`
+	}
+	// U+1F600 JSON-escaped as a UTF-16 surrogate pair must decode to the single
+	// 4-byte UTF-8 code point, not two corrupted halves. The escaped \u form (not
+	// a raw emoji) is required to exercise the surrogate-pair decode path.
+	payload := []byte("{\"password\":\"p\\uD83D\\uDE00\"}")
+	require.NoError(t, json.Unmarshal(payload, &body))
+	assert.Equal(t, append([]byte("p"), "\U0001F600"...), body.Password.Bytes())
+}

--- a/internal/imports/elevation/password_test.go
+++ b/internal/imports/elevation/password_test.go
@@ -41,6 +41,17 @@ func TestPasswordRedactedInSlog(t *testing.T) {
 	assert.Contains(t, buf.String(), "[REDACTED]")
 }
 
+func TestPasswordUnmarshalRejectsBadEscape(t *testing.T) {
+	// Call UnmarshalJSON directly with a malformed token: encoding/json validates
+	// string escapes itself and would reject this before our decoder runs, so a
+	// direct call is the only way to exercise the decoder's error path (which
+	// zeroes the partial decode before returning).
+	var p Password
+	err := p.UnmarshalJSON([]byte(`"a\x"`))
+	require.Error(t, err)
+	assert.Empty(t, p.Bytes())
+}
+
 func TestPasswordUnmarshalHandlesEscapes(t *testing.T) {
 	var body struct {
 		Password Password `json:"password"`

--- a/internal/imports/staging/stage.go
+++ b/internal/imports/staging/stage.go
@@ -165,9 +165,12 @@ func verifySQLiteMagic(f *os.File) error {
 	return nil
 }
 
-// copyOpenFileTo copies the content of f to dst, creating dst with mode 0o600.
+// copyOpenFileTo copies the content of f to dst. dst is created exclusively and
+// without following symlinks (createNoFollow): the staging directory is owned by
+// the unprivileged service user, so a plain create could be redirected through a
+// pre-planted symlink and have this root process write to an arbitrary path.
 func copyOpenFileTo(f *os.File, dst string) error {
-	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	out, err := createNoFollow(dst)
 	if err != nil {
 		return errors.New(err).Component("imports").
 			Category(errors.CategoryFileIO).Context("op", "create-dst").Build()

--- a/internal/imports/staging/stage.go
+++ b/internal/imports/staging/stage.go
@@ -1,0 +1,280 @@
+// Package staging performs the privileged BirdNET-Pi import staging copy. The
+// Stage operation is what the `birdnet-go import-stage` subcommand runs, often
+// as root via sudo, so it re-validates the source AFTER opening the file
+// descriptor (O_NOFOLLOW + fstat + SQLite magic) to close the TOCTOU window that
+// the unprivileged API-side path check cannot.
+package staging
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	_ "github.com/mattn/go-sqlite3" // SQLite driver for integrity check
+	"github.com/tphakala/birdnet-go/internal/errors"
+)
+
+const (
+	// stagedDBName is the fixed filename the staged database is written as.
+	stagedDBName = "birds.db"
+	// sqliteHeaderLen is the length of the SQLite file magic.
+	sqliteHeaderLen = 16
+	// integrityOK is the expected result of PRAGMA integrity_check.
+	integrityOK = "ok"
+)
+
+// sqliteMagic is the 16-byte header every SQLite 3 database starts with.
+var sqliteMagic = append([]byte("SQLite format 3"), 0x00)
+
+var (
+	// ErrUnsupportedPlatform is returned on non-Linux platforms.
+	ErrUnsupportedPlatform = errors.NewStd("import staging is only supported on Linux")
+	// ErrNotSQLite is returned when the source is not a SQLite database.
+	ErrNotSQLite = errors.NewStd("source is not a SQLite database")
+	// ErrDstNotEmpty is returned when the destination is missing or not empty.
+	ErrDstNotEmpty = errors.NewStd("destination must be an existing empty directory")
+	// ErrInvalidOptions is returned for malformed inputs.
+	ErrInvalidOptions = errors.NewStd("invalid staging options")
+)
+
+// Options configures a staging copy.
+type Options struct {
+	Src   string // absolute path to the source birds.db
+	Audio string // optional absolute path to the source audio directory
+	Dst   string // absolute path to an existing empty staging directory we own
+	UID   int    // service-user uid to chown staged files to
+	GID   int    // service-user gid to chown staged files to
+}
+
+// Result reports the staged paths.
+type Result struct {
+	StagedDB    string
+	StagedAudio string
+}
+
+// Stage validates and copies the source database (and optional audio) into Dst,
+// chowns the copies to UID:GID, and verifies SQLite integrity. On integrity
+// failure it rolls back the staged contents.
+func Stage(ctx context.Context, opts Options) (Result, error) {
+	if err := validateOptions(opts); err != nil {
+		return Result{}, err
+	}
+
+	srcFile, err := openNoFollow(opts.Src)
+	if err != nil {
+		return Result{}, errors.New(err).Component("imports").
+			Category(errors.CategoryFileIO).Context("op", "open-src").Build()
+	}
+	defer func() { _ = srcFile.Close() }()
+
+	info, err := srcFile.Stat()
+	if err != nil {
+		return Result{}, errors.New(err).Component("imports").
+			Category(errors.CategoryFileIO).Context("op", "fstat-src").Build()
+	}
+	if !info.Mode().IsRegular() {
+		return Result{}, ErrInvalidOptions
+	}
+
+	if err := verifySQLiteMagic(srcFile); err != nil {
+		return Result{}, err
+	}
+
+	stagedDB := filepath.Join(opts.Dst, stagedDBName)
+	if err := copyOpenFileTo(srcFile, stagedDB); err != nil {
+		return Result{}, rollback(opts.Dst, err)
+	}
+
+	res := Result{StagedDB: stagedDB}
+	if opts.Audio != "" {
+		dstAudio := filepath.Join(opts.Dst, filepath.Base(opts.Audio))
+		if err := copyTree(opts.Audio, dstAudio); err != nil {
+			return Result{}, rollback(opts.Dst, err)
+		}
+		res.StagedAudio = dstAudio
+	}
+
+	if err := chownTree(opts.Dst, opts.UID, opts.GID); err != nil {
+		return Result{}, rollback(opts.Dst, err)
+	}
+
+	if err := verifyIntegrity(ctx, stagedDB); err != nil {
+		return Result{}, rollback(opts.Dst, err)
+	}
+
+	return res, nil
+}
+
+// validateOptions checks that the Options fields are well-formed before any
+// privileged operation begins.
+func validateOptions(opts Options) error {
+	if opts.Src == "" || !filepath.IsAbs(opts.Src) {
+		return ErrInvalidOptions
+	}
+	if opts.Dst == "" || !filepath.IsAbs(opts.Dst) {
+		return ErrInvalidOptions
+	}
+
+	// Dst must exist, be a directory, and be empty.
+	entries, err := os.ReadDir(opts.Dst)
+	if err != nil {
+		return ErrDstNotEmpty
+	}
+	if len(entries) > 0 {
+		return ErrDstNotEmpty
+	}
+
+	// Audio, if set, must be absolute and a strict sibling of Src (same parent
+	// directory). This blocks the arbitrary-directory-copy attack where an attacker
+	// provides a valid birds.db but --audio=/root/.ssh to extract privileged data.
+	if opts.Audio != "" {
+		if !filepath.IsAbs(opts.Audio) {
+			return ErrInvalidOptions
+		}
+		srcDir := filepath.Dir(filepath.Clean(opts.Src))
+		audioDir := filepath.Dir(filepath.Clean(opts.Audio))
+		if audioDir != srcDir {
+			return ErrInvalidOptions
+		}
+	}
+
+	return nil
+}
+
+// verifySQLiteMagic reads the first sqliteHeaderLen bytes from the open fd and
+// confirms the SQLite format 3 magic. This is the authoritative TOCTOU gate: the
+// check runs on the already-open fd, so the file on disk cannot be swapped after
+// this point. It seeks back to the start so the copy reads from the beginning.
+func verifySQLiteMagic(f *os.File) error {
+	hdr := make([]byte, sqliteHeaderLen)
+	if _, err := io.ReadFull(f, hdr); err != nil {
+		return ErrNotSQLite
+	}
+	if !bytes.Equal(hdr, sqliteMagic) {
+		return ErrNotSQLite
+	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return errors.New(err).Component("imports").
+			Category(errors.CategoryFileIO).Context("op", "seek-src").Build()
+	}
+	return nil
+}
+
+// copyOpenFileTo copies the content of f to dst, creating dst with mode 0o600.
+func copyOpenFileTo(f *os.File, dst string) error {
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return errors.New(err).Component("imports").
+			Category(errors.CategoryFileIO).Context("op", "create-dst").Build()
+	}
+	if _, err := io.Copy(out, f); err != nil {
+		_ = out.Close()
+		return errors.New(err).Component("imports").
+			Category(errors.CategoryFileIO).Context("op", "copy-db").Build()
+	}
+	if err := out.Close(); err != nil {
+		return errors.New(err).Component("imports").
+			Category(errors.CategoryFileIO).Context("op", "close-dst").Build()
+	}
+	return nil
+}
+
+// copyTree copies the directory tree rooted at src into dst, creating dst.
+// Every leaf file is opened with openNoFollow and fstat-checked for regularity
+// before copying, so a symlink swapped in mid-walk cannot be followed. Symlinked
+// leaf entries and non-regular files (devices, FIFOs, sockets) are rejected.
+// filepath.WalkDir does not descend into symlinked directories.
+func copyTree(src, dst string) error {
+	if err := os.MkdirAll(dst, 0o700); err != nil {
+		return errors.New(err).Component("imports").
+			Category(errors.CategoryFileIO).Context("op", "mkdir-dst-audio").Build()
+	}
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return errors.New(err).Component("imports").
+				Category(errors.CategoryFileIO).Context("op", "walk-rel").Build()
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o700)
+		}
+		// Not a dir: open with O_NOFOLLOW to reject symlinks.
+		f, err := openNoFollow(path)
+		if err != nil {
+			return errors.New(err).Component("imports").
+				Category(errors.CategoryFileIO).Context("op", "open-audio-leaf").
+				Context("path", path).Build()
+		}
+		defer func() { _ = f.Close() }()
+
+		info, err := f.Stat()
+		if err != nil {
+			return errors.New(err).Component("imports").
+				Category(errors.CategoryFileIO).Context("op", "fstat-audio-leaf").
+				Context("path", path).Build()
+		}
+		if !info.Mode().IsRegular() {
+			// Skip non-regular files (devices, FIFOs, sockets). Symlinks are
+			// already rejected by openNoFollow returning ELOOP.
+			return nil
+		}
+		return copyOpenFileTo(f, target)
+	})
+}
+
+// chownTree walks root and calls chownTo on every entry.
+func chownTree(root string, uid, gid int) error {
+	return filepath.WalkDir(root, func(path string, _ fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		return chownTo(path, uid, gid)
+	})
+}
+
+// verifyIntegrity opens the staged db read-only and runs PRAGMA integrity_check.
+// The database must report "ok" for the stage to be considered valid.
+func verifyIntegrity(ctx context.Context, dbPath string) error {
+	dsn := fmt.Sprintf("file:%s?mode=ro", dbPath)
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		return errors.New(err).Component("imports").
+			Category(errors.CategoryDatabase).Context("op", "open-integrity").Build()
+	}
+	defer func() { _ = db.Close() }()
+
+	var result string
+	if err := db.QueryRowContext(ctx, "PRAGMA integrity_check").Scan(&result); err != nil {
+		return errors.New(err).Component("imports").
+			Category(errors.CategoryDatabase).Context("op", "integrity-check").Build()
+	}
+	if result != integrityOK {
+		return errors.Newf("SQLite integrity check failed: %s", result).
+			Component("imports").Category(errors.CategoryDatabase).Build()
+	}
+	return nil
+}
+
+// rollback removes all contents staged under dst (but not dst itself, which we
+// did not create) and returns cause wrapped with rollback context.
+func rollback(dst string, cause error) error {
+	entries, err := os.ReadDir(dst)
+	if err != nil {
+		return errors.New(cause).Component("imports").
+			Category(errors.CategoryFileIO).Context("op", "rollback").Build()
+	}
+	for _, e := range entries {
+		_ = os.RemoveAll(filepath.Join(dst, e.Name()))
+	}
+	return errors.New(cause).Component("imports").
+		Category(errors.CategoryFileIO).Context("op", "rollback").Build()
+}

--- a/internal/imports/staging/stage.go
+++ b/internal/imports/staging/stage.go
@@ -9,9 +9,9 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
-	"fmt"
 	"io"
 	"io/fs"
+	"net/url"
 	"os"
 	"path/filepath"
 
@@ -36,8 +36,9 @@ var (
 	ErrUnsupportedPlatform = errors.NewStd("import staging is only supported on Linux")
 	// ErrNotSQLite is returned when the source is not a SQLite database.
 	ErrNotSQLite = errors.NewStd("source is not a SQLite database")
-	// ErrDstNotEmpty is returned when the destination is missing or not empty.
-	ErrDstNotEmpty = errors.NewStd("destination must be an existing empty directory")
+	// ErrDstExists is returned when the destination already exists. Stage creates
+	// the staging directory itself, so it must not pre-exist.
+	ErrDstExists = errors.NewStd("destination must not already exist")
 	// ErrInvalidOptions is returned for malformed inputs.
 	ErrInvalidOptions = errors.NewStd("invalid staging options")
 )
@@ -57,32 +58,50 @@ type Result struct {
 	StagedAudio string
 }
 
-// Stage validates and copies the source database (and optional audio) into Dst,
-// chowns the copies to UID:GID, and verifies SQLite integrity. On integrity
-// failure it rolls back the staged contents.
+// Stage validates the source, then copies the source database (and optional
+// audio) into a staging directory that this process CREATES and owns, verifies
+// SQLite integrity, and finally chowns the staged copies to UID:GID. On any
+// failure it rolls back by removing the staging directory.
+//
+// Stage creates opts.Dst itself with mode 0700 (it must not already exist). This
+// is essential: when invoked as root via sudo, a staging directory pre-created
+// by the unprivileged service user would be writable by that user during the
+// copy, letting them swap a parent component for a symlink and redirect root's
+// writes/chowns to an arbitrary path. A root-owned 0700 directory the service
+// user cannot write into closes that whole class of races; the per-file
+// O_NOFOLLOW/O_EXCL/Lchown guards remain as defense in depth on the source side,
+// which is owned by the service user and therefore still attacker-controllable.
 func Stage(ctx context.Context, opts Options) (Result, error) {
 	if err := validateOptions(opts); err != nil {
 		return Result{}, err
 	}
 
+	// Create the staging directory as this process (root under sudo), 0700, so
+	// the service user cannot tamper with its contents during staging. os.Mkdir
+	// fails if opts.Dst already exists (including a pre-planted symlink, EEXIST).
+	if err := os.Mkdir(opts.Dst, 0o700); err != nil {
+		return Result{}, errors.New(err).Component("imports").
+			Category(errors.CategoryFileIO).Context("op", "mkdir-staging").Build()
+	}
+
 	srcFile, err := openNoFollow(opts.Src)
 	if err != nil {
-		return Result{}, errors.New(err).Component("imports").
-			Category(errors.CategoryFileIO).Context("op", "open-src").Build()
+		return Result{}, rollback(opts.Dst, errors.New(err).Component("imports").
+			Category(errors.CategoryFileIO).Context("op", "open-src").Build())
 	}
 	defer func() { _ = srcFile.Close() }()
 
 	info, err := srcFile.Stat()
 	if err != nil {
-		return Result{}, errors.New(err).Component("imports").
-			Category(errors.CategoryFileIO).Context("op", "fstat-src").Build()
+		return Result{}, rollback(opts.Dst, errors.New(err).Component("imports").
+			Category(errors.CategoryFileIO).Context("op", "fstat-src").Build())
 	}
 	if !info.Mode().IsRegular() {
-		return Result{}, ErrInvalidOptions
+		return Result{}, rollback(opts.Dst, ErrInvalidOptions)
 	}
 
 	if err := verifySQLiteMagic(srcFile); err != nil {
-		return Result{}, err
+		return Result{}, rollback(opts.Dst, err)
 	}
 
 	stagedDB := filepath.Join(opts.Dst, stagedDBName)
@@ -99,11 +118,13 @@ func Stage(ctx context.Context, opts Options) (Result, error) {
 		res.StagedAudio = dstAudio
 	}
 
-	if err := chownTree(opts.Dst, opts.UID, opts.GID); err != nil {
+	// Verify integrity BEFORE handing ownership to the service user, so the user
+	// only ever receives a verified copy.
+	if err := verifyIntegrity(ctx, stagedDB); err != nil {
 		return Result{}, rollback(opts.Dst, err)
 	}
 
-	if err := verifyIntegrity(ctx, stagedDB); err != nil {
+	if err := chownTree(opts.Dst, opts.UID, opts.GID); err != nil {
 		return Result{}, rollback(opts.Dst, err)
 	}
 
@@ -119,26 +140,42 @@ func validateOptions(opts Options) error {
 	if opts.Dst == "" || !filepath.IsAbs(opts.Dst) {
 		return ErrInvalidOptions
 	}
-
-	// Dst must exist, be a directory, and be empty.
-	entries, err := os.ReadDir(opts.Dst)
-	if err != nil {
-		return ErrDstNotEmpty
+	// UID/GID must be real ids: lchown(2) treats -1 as "leave unchanged", so a
+	// negative value would silently leave staged files owned by root and unreadable
+	// by the service user, while Stage still reports success.
+	if opts.UID < 0 || opts.GID < 0 {
+		return ErrInvalidOptions
 	}
-	if len(entries) > 0 {
-		return ErrDstNotEmpty
+
+	// Dst must NOT already exist; Stage creates it itself (root-owned 0700) so the
+	// service user cannot tamper with it during staging. The parent must exist and
+	// be a directory so the create can succeed.
+	if _, err := os.Lstat(opts.Dst); err == nil {
+		return ErrDstExists
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return errors.New(err).Component("imports").
+			Category(errors.CategoryFileIO).Context("op", "lstat-dst").Build()
+	}
+	parent := filepath.Dir(opts.Dst)
+	if info, err := os.Stat(parent); err != nil || !info.IsDir() {
+		return ErrInvalidOptions
 	}
 
 	// Audio, if set, must be absolute and a strict sibling of Src (same parent
 	// directory). This blocks the arbitrary-directory-copy attack where an attacker
 	// provides a valid birds.db but --audio=/root/.ssh to extract privileged data.
+	// It must also differ from Src, else the audio tree copy would collide with the
+	// staged birds.db path.
 	if opts.Audio != "" {
 		if !filepath.IsAbs(opts.Audio) {
 			return ErrInvalidOptions
 		}
-		srcDir := filepath.Dir(filepath.Clean(opts.Src))
-		audioDir := filepath.Dir(filepath.Clean(opts.Audio))
-		if audioDir != srcDir {
+		cleanSrc := filepath.Clean(opts.Src)
+		cleanAudio := filepath.Clean(opts.Audio)
+		if cleanAudio == cleanSrc {
+			return ErrInvalidOptions
+		}
+		if filepath.Dir(cleanAudio) != filepath.Dir(cleanSrc) {
 			return ErrInvalidOptions
 		}
 	}
@@ -210,7 +247,15 @@ func copyTree(src, dst string) error {
 		if d.IsDir() {
 			return os.MkdirAll(target, 0o700)
 		}
-		// Not a dir: open with O_NOFOLLOW to reject symlinks.
+		// Skip non-regular entries (symlinks, FIFOs, sockets, devices) by their
+		// Lstat-based type: a symlink must not be copied (and would otherwise abort
+		// the whole import on ELOOP), and a FIFO/device would block openNoFollow.
+		// The O_NOFOLLOW + fstat-regular re-check below still guards the TOCTOU case
+		// where a regular entry is swapped for a symlink after this Lstat.
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		// Open with O_NOFOLLOW to reject a symlink raced in after the Lstat above.
 		f, err := openNoFollow(path)
 		if err != nil {
 			return errors.New(err).Component("imports").
@@ -247,7 +292,11 @@ func chownTree(root string, uid, gid int) error {
 // verifyIntegrity opens the staged db read-only and runs PRAGMA integrity_check.
 // The database must report "ok" for the stage to be considered valid.
 func verifyIntegrity(ctx context.Context, dbPath string) error {
-	dsn := fmt.Sprintf("file:%s?mode=ro", dbPath)
+	// Build the DSN via url.URL so a path containing a URI-special character
+	// (space, ?, #, %) is percent-encoded and cannot corrupt the query string.
+	// Mirrors internal/imports/birdnetpi/source.go (which cannot be imported here
+	// without pulling in GORM + cgo).
+	dsn := (&url.URL{Scheme: "file", OmitHost: true, Path: dbPath, RawQuery: "mode=ro"}).String()
 	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		return errors.New(err).Component("imports").
@@ -267,17 +316,15 @@ func verifyIntegrity(ctx context.Context, dbPath string) error {
 	return nil
 }
 
-// rollback removes all contents staged under dst (but not dst itself, which we
-// did not create) and returns cause wrapped with rollback context.
+// rollback removes the staging directory we created and returns cause wrapped
+// with rollback context. If the removal itself fails, that is recorded in the
+// returned error context so the leftover directory (which would make the next
+// attempt fail with ErrDstExists) is not silently swallowed.
 func rollback(dst string, cause error) error {
-	entries, err := os.ReadDir(dst)
-	if err != nil {
-		return errors.New(cause).Component("imports").
-			Category(errors.CategoryFileIO).Context("op", "rollback").Build()
+	b := errors.New(cause).Component("imports").
+		Category(errors.CategoryFileIO).Context("op", "rollback")
+	if rmErr := os.RemoveAll(dst); rmErr != nil {
+		b = b.Context("rollback_cleanup_error", rmErr.Error())
 	}
-	for _, e := range entries {
-		_ = os.RemoveAll(filepath.Join(dst, e.Name()))
-	}
-	return errors.New(cause).Component("imports").
-		Category(errors.CategoryFileIO).Context("op", "rollback").Build()
+	return b.Build()
 }

--- a/internal/imports/staging/stage_linux.go
+++ b/internal/imports/staging/stage_linux.go
@@ -15,7 +15,22 @@ func openNoFollow(path string) (*os.File, error) {
 	return os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
 }
 
-// chownTo changes ownership of path to uid:gid.
+// createNoFollow creates path for writing, failing if it already exists
+// (O_EXCL) or is a symlink (O_NOFOLLOW). The destination directory is owned by
+// the unprivileged service user, so without these flags the service user could
+// pre-plant dst/birds.db as a symlink to an arbitrary path (e.g. /etc/cron.d)
+// and have this root process write through it. O_EXCL also rejects a file the
+// attacker raced in ahead of us.
+func createNoFollow(path string) (*os.File, error) {
+	return os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY|syscall.O_NOFOLLOW, 0o600)
+}
+
+// chownTo changes ownership of path to uid:gid WITHOUT dereferencing symlinks.
+// Lchown (not Chown) is essential here: the staging directory is owned by the
+// unprivileged service user, who could swap a staged regular file for a symlink
+// to a sensitive file (e.g. /etc/shadow) between the copy and this chown. Chown
+// would follow it and hand that file to the service user (privilege escalation);
+// Lchown changes only the link itself.
 func chownTo(path string, uid, gid int) error {
-	return os.Chown(path, uid, gid)
+	return os.Lchown(path, uid, gid)
 }

--- a/internal/imports/staging/stage_linux.go
+++ b/internal/imports/staging/stage_linux.go
@@ -1,0 +1,21 @@
+//go:build linux
+
+package staging
+
+import (
+	"os"
+	"syscall"
+)
+
+// openNoFollow opens path read-only, failing if the final component is a
+// symlink. This re-validates the source after the unprivileged API-side check,
+// closing the TOCTOU window where a symlink to a sensitive file (e.g.
+// /etc/shadow) is swapped in before the root subcommand reads it.
+func openNoFollow(path string) (*os.File, error) {
+	return os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+}
+
+// chownTo changes ownership of path to uid:gid.
+func chownTo(path string, uid, gid int) error {
+	return os.Chown(path, uid, gid)
+}

--- a/internal/imports/staging/stage_linux.go
+++ b/internal/imports/staging/stage_linux.go
@@ -10,9 +10,11 @@ import (
 // openNoFollow opens path read-only, failing if the final component is a
 // symlink. This re-validates the source after the unprivileged API-side check,
 // closing the TOCTOU window where a symlink to a sensitive file (e.g.
-// /etc/shadow) is swapped in before the root subcommand reads it.
+// /etc/shadow) is swapped in before the root subcommand reads it. O_NONBLOCK
+// ensures a named pipe (FIFO) or device source returns immediately instead of
+// blocking the open forever; the caller's fstat-regular check then rejects it.
 func openNoFollow(path string) (*os.File, error) {
-	return os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	return os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_NONBLOCK, 0)
 }
 
 // createNoFollow creates path for writing, failing if it already exists

--- a/internal/imports/staging/stage_other.go
+++ b/internal/imports/staging/stage_other.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+package staging
+
+import "os"
+
+// openNoFollow is a stub on non-Linux platforms. Import staging requires Linux.
+func openNoFollow(_ string) (*os.File, error) { return nil, ErrUnsupportedPlatform }
+
+// chownTo is a stub on non-Linux platforms. Import staging requires Linux.
+func chownTo(_ string, _, _ int) error { return ErrUnsupportedPlatform }

--- a/internal/imports/staging/stage_other.go
+++ b/internal/imports/staging/stage_other.go
@@ -7,5 +7,8 @@ import "os"
 // openNoFollow is a stub on non-Linux platforms. Import staging requires Linux.
 func openNoFollow(_ string) (*os.File, error) { return nil, ErrUnsupportedPlatform }
 
+// createNoFollow is a stub on non-Linux platforms. Import staging requires Linux.
+func createNoFollow(_ string) (*os.File, error) { return nil, ErrUnsupportedPlatform }
+
 // chownTo is a stub on non-Linux platforms. Import staging requires Linux.
 func chownTo(_ string, _, _ int) error { return ErrUnsupportedPlatform }

--- a/internal/imports/staging/stage_test.go
+++ b/internal/imports/staging/stage_test.go
@@ -29,12 +29,19 @@ func writeMinimalSQLite(t *testing.T, path string) {
 	require.NoError(t, err)
 }
 
+// stagingDst returns a path that does NOT yet exist (under an existing temp
+// parent), as Stage requires: it creates the staging directory itself.
+func stagingDst(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "staging")
+}
+
 func TestStageCopiesAndValidates(t *testing.T) {
 	srcDir := t.TempDir()
 	src := filepath.Join(srcDir, "birds.db")
 	writeMinimalSQLite(t, src)
 
-	dst := t.TempDir() // empty dir
+	dst := stagingDst(t)
 	res, err := Stage(t.Context(), Options{
 		Src: src, Dst: dst, UID: os.Getuid(), GID: os.Getgid(),
 	})
@@ -46,6 +53,24 @@ func TestStageCopiesAndValidates(t *testing.T) {
 	assert.Equal(t, sqliteHeader, got[:16])
 }
 
+func TestStageCopiesAudioAndSkipsSymlinks(t *testing.T) {
+	base := t.TempDir()
+	src := filepath.Join(base, "birds.db")
+	writeMinimalSQLite(t, src)
+
+	audio := filepath.Join(base, "BirdSongs") // sibling of src
+	require.NoError(t, os.Mkdir(audio, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(audio, "real.wav"), []byte("audio"), 0o600))
+
+	dst := stagingDst(t)
+	res, err := Stage(t.Context(), Options{
+		Src: src, Audio: audio, Dst: dst, UID: os.Getuid(), GID: os.Getgid(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(dst, "BirdSongs"), res.StagedAudio)
+	assert.FileExists(t, filepath.Join(dst, "BirdSongs", "real.wav"))
+}
+
 func TestStageRejectsSymlinkSrc(t *testing.T) {
 	dir := t.TempDir()
 	realDB := filepath.Join(dir, "real.db")
@@ -54,7 +79,7 @@ func TestStageRejectsSymlinkSrc(t *testing.T) {
 	require.NoError(t, os.Symlink(realDB, link))
 
 	_, err := Stage(t.Context(), Options{
-		Src: link, Dst: t.TempDir(), UID: os.Getuid(), GID: os.Getgid(),
+		Src: link, Dst: stagingDst(t), UID: os.Getuid(), GID: os.Getgid(),
 	})
 	require.Error(t, err, "O_NOFOLLOW must reject a symlinked src")
 }
@@ -65,23 +90,22 @@ func TestStageRejectsNonSQLite(t *testing.T) {
 	require.NoError(t, os.WriteFile(bad, []byte("not a database"), 0o600))
 
 	_, err := Stage(t.Context(), Options{
-		Src: bad, Dst: t.TempDir(), UID: os.Getuid(), GID: os.Getgid(),
+		Src: bad, Dst: stagingDst(t), UID: os.Getuid(), GID: os.Getgid(),
 	})
 	require.ErrorIs(t, err, ErrNotSQLite)
 }
 
-func TestStageRejectsNonEmptyDst(t *testing.T) {
+func TestStageRejectsExistingDst(t *testing.T) {
 	dir := t.TempDir()
 	src := filepath.Join(dir, "birds.db")
 	writeMinimalSQLite(t, src)
 
+	// dst already exists: Stage must create it itself, so this is rejected.
 	dst := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dst, "x"), []byte("y"), 0o600))
-
 	_, err := Stage(t.Context(), Options{
 		Src: src, Dst: dst, UID: os.Getuid(), GID: os.Getgid(),
 	})
-	require.ErrorIs(t, err, ErrDstNotEmpty)
+	require.ErrorIs(t, err, ErrDstExists)
 }
 
 func TestStageRejectsNonSiblingAudio(t *testing.T) {
@@ -92,30 +116,59 @@ func TestStageRejectsNonSiblingAudio(t *testing.T) {
 	// Audio dir lives somewhere else entirely (the attack: --audio=/root/.ssh).
 	elsewhere := t.TempDir()
 	_, err := Stage(t.Context(), Options{
-		Src: src, Audio: elsewhere, Dst: t.TempDir(),
+		Src: src, Audio: elsewhere, Dst: stagingDst(t),
 		UID: os.Getuid(), GID: os.Getgid(),
 	})
 	require.ErrorIs(t, err, ErrInvalidOptions)
 }
 
-func TestStageRejectsSymlinkInAudioTree(t *testing.T) {
+func TestStageRejectsIdenticalSrcAudio(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "birds.db")
+	writeMinimalSQLite(t, src)
+
+	// src == audio would collide with the staged birds.db path.
+	_, err := Stage(t.Context(), Options{
+		Src: src, Audio: src, Dst: stagingDst(t),
+		UID: os.Getuid(), GID: os.Getgid(),
+	})
+	require.ErrorIs(t, err, ErrInvalidOptions)
+}
+
+func TestStageRejectsNegativeUIDGID(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "birds.db")
+	writeMinimalSQLite(t, src)
+
+	// uid/gid of -1 means "leave unchanged" to lchown(2); reject it so staged
+	// files cannot silently stay root-owned and unreadable.
+	_, err := Stage(t.Context(), Options{
+		Src: src, Dst: stagingDst(t), UID: -1, GID: os.Getgid(),
+	})
+	require.ErrorIs(t, err, ErrInvalidOptions)
+}
+
+func TestStageSkipsSymlinkInAudioTreeWithoutLeak(t *testing.T) {
 	base := t.TempDir()
 	src := filepath.Join(base, "birds.db")
 	writeMinimalSQLite(t, src)
 
-	audio := filepath.Join(base, "BirdSongs") // sibling of src, passes step 1
+	audio := filepath.Join(base, "BirdSongs") // sibling of src, passes the sibling check
 	require.NoError(t, os.Mkdir(audio, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(audio, "real.wav"), []byte("audio"), 0o600))
 	secret := filepath.Join(base, "secret.txt")
 	require.NoError(t, os.WriteFile(secret, []byte("top secret"), 0o600))
 	// A leaf inside the audio tree is a symlink to the secret.
 	require.NoError(t, os.Symlink(secret, filepath.Join(audio, "evil.wav")))
 
-	dst := t.TempDir()
+	dst := stagingDst(t)
 	_, err := Stage(t.Context(), Options{
 		Src: src, Audio: audio, Dst: dst,
 		UID: os.Getuid(), GID: os.Getgid(),
 	})
-	require.Error(t, err, "a symlink leaf in the audio tree must be rejected")
-	// The secret must not have been staged.
+	// The symlink leaf is skipped, not followed; staging still succeeds.
+	require.NoError(t, err)
+	// The regular file was staged, the symlinked secret was not.
+	assert.FileExists(t, filepath.Join(dst, "BirdSongs", "real.wav"))
 	assert.NoFileExists(t, filepath.Join(dst, "BirdSongs", "evil.wav"))
 }

--- a/internal/imports/staging/stage_test.go
+++ b/internal/imports/staging/stage_test.go
@@ -1,0 +1,121 @@
+//go:build linux
+
+package staging
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sqliteHeader is the 16-byte SQLite file header.
+var sqliteHeader = append([]byte("SQLite format 3"), 0x00)
+
+// writeMinimalSQLite creates a real, valid BirdNET-Pi-shaped SQLite db at path.
+// Mirrors the schema from internal/imports/birdnetpi/source_test.go.
+func writeMinimalSQLite(t *testing.T, path string) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", path)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, db.Close()) })
+	_, err = db.Exec(`CREATE TABLE detections (
+		Date TEXT, Time TEXT, Sci_Name TEXT, Com_Name TEXT, Confidence REAL,
+		Lat REAL, Lon REAL, Cutoff REAL, Sens REAL, File_Name TEXT)`)
+	require.NoError(t, err)
+}
+
+func TestStageCopiesAndValidates(t *testing.T) {
+	srcDir := t.TempDir()
+	src := filepath.Join(srcDir, "birds.db")
+	writeMinimalSQLite(t, src)
+
+	dst := t.TempDir() // empty dir
+	res, err := Stage(t.Context(), Options{
+		Src: src, Dst: dst, UID: os.Getuid(), GID: os.Getgid(),
+	})
+	require.NoError(t, err)
+	assert.FileExists(t, res.StagedDB)
+
+	got, err := os.ReadFile(res.StagedDB)
+	require.NoError(t, err)
+	assert.Equal(t, sqliteHeader, got[:16])
+}
+
+func TestStageRejectsSymlinkSrc(t *testing.T) {
+	dir := t.TempDir()
+	realDB := filepath.Join(dir, "real.db")
+	writeMinimalSQLite(t, realDB)
+	link := filepath.Join(dir, "link.db")
+	require.NoError(t, os.Symlink(realDB, link))
+
+	_, err := Stage(t.Context(), Options{
+		Src: link, Dst: t.TempDir(), UID: os.Getuid(), GID: os.Getgid(),
+	})
+	require.Error(t, err, "O_NOFOLLOW must reject a symlinked src")
+}
+
+func TestStageRejectsNonSQLite(t *testing.T) {
+	dir := t.TempDir()
+	bad := filepath.Join(dir, "birds.db")
+	require.NoError(t, os.WriteFile(bad, []byte("not a database"), 0o600))
+
+	_, err := Stage(t.Context(), Options{
+		Src: bad, Dst: t.TempDir(), UID: os.Getuid(), GID: os.Getgid(),
+	})
+	require.ErrorIs(t, err, ErrNotSQLite)
+}
+
+func TestStageRejectsNonEmptyDst(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "birds.db")
+	writeMinimalSQLite(t, src)
+
+	dst := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dst, "x"), []byte("y"), 0o600))
+
+	_, err := Stage(t.Context(), Options{
+		Src: src, Dst: dst, UID: os.Getuid(), GID: os.Getgid(),
+	})
+	require.ErrorIs(t, err, ErrDstNotEmpty)
+}
+
+func TestStageRejectsNonSiblingAudio(t *testing.T) {
+	dbDir := t.TempDir()
+	src := filepath.Join(dbDir, "birds.db")
+	writeMinimalSQLite(t, src)
+
+	// Audio dir lives somewhere else entirely (the attack: --audio=/root/.ssh).
+	elsewhere := t.TempDir()
+	_, err := Stage(t.Context(), Options{
+		Src: src, Audio: elsewhere, Dst: t.TempDir(),
+		UID: os.Getuid(), GID: os.Getgid(),
+	})
+	require.ErrorIs(t, err, ErrInvalidOptions)
+}
+
+func TestStageRejectsSymlinkInAudioTree(t *testing.T) {
+	base := t.TempDir()
+	src := filepath.Join(base, "birds.db")
+	writeMinimalSQLite(t, src)
+
+	audio := filepath.Join(base, "BirdSongs") // sibling of src, passes step 1
+	require.NoError(t, os.Mkdir(audio, 0o700))
+	secret := filepath.Join(base, "secret.txt")
+	require.NoError(t, os.WriteFile(secret, []byte("top secret"), 0o600))
+	// A leaf inside the audio tree is a symlink to the secret.
+	require.NoError(t, os.Symlink(secret, filepath.Join(audio, "evil.wav")))
+
+	dst := t.TempDir()
+	_, err := Stage(t.Context(), Options{
+		Src: src, Audio: audio, Dst: dst,
+		UID: os.Getuid(), GID: os.Getgid(),
+	})
+	require.Error(t, err, "a symlink leaf in the audio tree must be rejected")
+	// The secret must not have been staged.
+	assert.NoFileExists(t, filepath.Join(dst, "BirdSongs", "evil.wav"))
+}


### PR DESCRIPTION
## Summary

Part 2 of the native (non-container) BirdNET-Pi import feature (follow-up to the source-discovery scanner in #3732). This is the backend for staging BirdNET-Pi data into a BirdNET-Go-owned location when the data is not directly readable by the service user. No new HTTP endpoints or UI yet (those land in the next PR); this PR adds the privileged primitive, the elevation policy, and the native source-path resolution it builds on.

### What's included

- **`birdnet-go import-stage` (hidden subcommand)**: a narrow privileged primitive that copies a BirdNET-Pi `birds.db` (and optional sibling audio dir) into a staging directory and chowns it to the service user. Hardened for execution as root via sudo:
  - Re-validates the source AFTER opening the fd: `O_NOFOLLOW` open, `fstat` regular-file check, and `SQLite format 3\0` magic on the open fd, then copies from that same fd (defeats a check-vs-use symlink swap of the source).
  - Creates its OWN staging directory (`0700`, owned by the running user; the directory must not pre-exist), so the unprivileged service user cannot tamper with it mid-operation or swap a parent component for a symlink to redirect root's writes/chowns.
  - `Lchown` (never `Chown`), `O_CREATE|O_EXCL|O_NOFOLLOW` on staged-file creation, audio dir constrained to a strict sibling of the db, non-regular leaves skipped, post-copy `PRAGMA integrity_check`, rollback on failure.
  - argv-hardened: `--flag=value` form, no shell, exec argv only.

- **Sudo elevation ladder** (`internal/imports/elevation`), behind an injectable runner seam so it is unit-testable without real sudo: direct read -> passwordless `sudo -n` staged copy -> in-app `sudo -S` password staged copy -> copy-paste `setfacl` remediation when the user is not a sudoer. The sudo password is a memory-only `[]byte` decoded without an intermediate immutable string, redacted in `String`/`MarshalJSON`/`slog.LogValuer`, zeroed on every return path, and `sudo -k` is run before a password attempt. Not yet wired to HTTP (next PR).

- **Native source-path resolution**: `POST /api/v2/import/birdnet-pi` now interprets `source_path` per environment. Container behavior is byte-for-byte unchanged (relative-under-mount); native installs resolve an absolute path (existing regular file) and validate the schema through the same shared factory + validate step the container path uses. Native installs previously always failed here because the external mount does not exist, so this is additive enablement, not a behavior change for existing users.

- **Config toggle** `import.allowInAppElevation` (default on) to disable the in-app sudo-password rung; read live (hot-reloadable), no consumer until the next PR.

- Removes a redundant subtitle paragraph from the Import/Export page (follow-up to the earlier page-title removal); key dropped from all 16 locales and the generated types.

### Security

The privileged surface had a dedicated OWASP review plus an independent multi-agent + Gemini review pass before this PR. Source-side and destination-side TOCTOU, the sudo invocation, and the password lifecycle are all covered by tests. One item is intentionally deferred to the HTTP-wiring PR: the caller must place the staging directory under a trusted (non-service-user-writable) base; a future `openat2`/`os.Root` handle-based pass can remove the remaining reliance on the parent path.

### Notes

- The Linux-only syscalls (`O_NOFOLLOW`, `chown`) are behind `//go:build linux` files with non-Linux stubs so the binary cross-compiles; `import-stage` returns an unsupported-platform error off Linux. The post-copy integrity check uses the cgo SQLite driver already vendored by the project.

## Test Plan

- [x] `go test -race ./...`
- [x] `golangci-lint run` (full project, 0 issues)
- [x] cross-platform `go vet` for windows-amd64 and darwin-arm64
- [x] `npm run check:all` (frontend)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a privileged BirdNET-Pi import staging flow that can stage the database and optional audio when possible.
  * Introduced an elevation “ladder” that escalates staging using safer options, with copy-paste remediation when automatic staging can’t run.
  * Added a new `import.allowinappelevation` setting to control whether in-app sudo elevation is allowed (enabled by default).
* **Bug Fixes**
  * Improved native vs container import source path validation with symlink-safe checks and clearer rejection of invalid inputs.
* **Documentation**
  * Updated the configuration reference and schema for the new import setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->