### PR TITLE
fix(analytics): per-route pages collapsed to one grid column + duplicate title + sidebar coming-soon chip

### DIFF
--- a/frontend/src/lib/desktop/features/analytics/components/AnalyticsComingSoon.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/AnalyticsComingSoon.svelte
@@ -22,11 +22,7 @@
   });
 </script>
 
-<section class="flex flex-col gap-4" aria-labelledby="analytics-page-title">
-  <h1 id="analytics-page-title" class="text-2xl font-bold text-[var(--color-base-content)]">
-    {t(titleKey)}
-  </h1>
-
+<section class="col-span-12 flex flex-col gap-4" aria-label={t(titleKey)}>
   <div
     class="flex flex-col items-center gap-4 rounded-xl border border-[var(--color-base-200)] bg-[var(--color-base-100)] p-8 text-center shadow-sm"
   >

--- a/frontend/src/lib/desktop/features/analytics/components/AnalyticsComingSoon.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/AnalyticsComingSoon.test.ts
@@ -39,9 +39,9 @@ describe('AnalyticsComingSoon', () => {
     cleanup();
   });
 
-  it('renders the title key and feature keys', () => {
+  it('renders the section with aria-label set to the title key and renders feature keys', () => {
     render(AnalyticsComingSoon, { props: defaultProps });
-    expect(screen.getByText('analytics.hub.tabs.weather')).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'analytics.hub.tabs.weather' })).toBeInTheDocument();
     expect(screen.getByText('analytics.comingSoon.weather.feature1')).toBeInTheDocument();
   });
 

--- a/frontend/src/lib/desktop/features/analytics/components/AnalyticsPageShell.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/AnalyticsPageShell.svelte
@@ -47,11 +47,7 @@
   });
 </script>
 
-<section class="flex flex-col gap-4" aria-labelledby="analytics-page-title">
-  <h1 id="analytics-page-title" class="text-2xl font-bold text-[var(--color-base-content)]">
-    {t(titleKey)}
-  </h1>
-
+<section class="col-span-12 flex flex-col gap-4" aria-label={t(titleKey)}>
   <AnalyticsControlBar
     params={analyticsControls.params}
     availableSpecies={analyticsControls.availableSpecies}

--- a/frontend/src/lib/desktop/features/analytics/components/AnalyticsPageShell.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/AnalyticsPageShell.test.ts
@@ -55,11 +55,11 @@ describe('AnalyticsPageShell', () => {
     cleanup();
   });
 
-  it('renders the title key and the slotted body', () => {
+  it('renders the section with aria-label set to the title key and renders the slotted body', () => {
     render(AnalyticsPageShell, {
       props: { ...defaultProps, children: makeBody() },
     });
-    expect(screen.getByText('analytics.hub.tabs.trends')).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'analytics.hub.tabs.trends' })).toBeInTheDocument();
     expect(screen.getByTestId('body')).toBeInTheDocument();
   });
 

--- a/frontend/src/lib/desktop/features/analytics/pages/AnalyticsPages.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/pages/AnalyticsPages.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, it, expect, vi } from 'vitest';
-import { render } from '@testing-library/svelte';
+import { render, screen } from '@testing-library/svelte';
 
 vi.mock('$lib/i18n', () => ({ t: (k: string) => k }));
 vi.mock('../registry/analyticsControls.svelte', () => ({
@@ -59,11 +59,10 @@ describe('analytics route pages render without throwing', () => {
     ['weather', WeatherPage, 'analytics.hub.tabs.weather'],
     ['soundscape', SoundscapePage, 'analytics.hub.tabs.soundscape'],
   ])('%s page mounts with the correct title', (_name, Comp, expectedTitleKey) => {
-    const { container } = render(Comp as never);
-    // The title is now in the section's aria-label (the h1 was removed to avoid
+    render(Comp as never);
+    // The title is in the section's aria-label (the h1 was removed to avoid
     // a duplicate title with the global Header). The t() mock echoes keys verbatim.
-    const section = container.querySelector('section[aria-label]');
-    expect(section).toBeTruthy();
-    expect(section?.getAttribute('aria-label')).toBe(expectedTitleKey);
+    // Use getByRole('region') to verify both the ARIA role and the label together.
+    expect(screen.getByRole('region', { name: expectedTitleKey })).toBeInTheDocument();
   });
 });

--- a/frontend/src/lib/desktop/features/analytics/pages/AnalyticsPages.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/pages/AnalyticsPages.test.ts
@@ -60,11 +60,10 @@ describe('analytics route pages render without throwing', () => {
     ['soundscape', SoundscapePage, 'analytics.hub.tabs.soundscape'],
   ])('%s page mounts with the correct title', (_name, Comp, expectedTitleKey) => {
     const { container } = render(Comp as never);
-    const titleEl = container.querySelector('#analytics-page-title');
-    // The t() mock echoes keys verbatim, so textContent equals the i18n key.
-    expect(titleEl).toBeTruthy();
-    // titleEl is the nullable querySelector result, so optional chaining keeps this lint-clean.
-    const text = (titleEl?.textContent ?? '').trim();
-    expect(text).toBe(expectedTitleKey);
+    // The title is now in the section's aria-label (the h1 was removed to avoid
+    // a duplicate title with the global Header). The t() mock echoes keys verbatim.
+    const section = container.querySelector('section[aria-label]');
+    expect(section).toBeTruthy();
+    expect(section?.getAttribute('aria-label')).toBe(expectedTitleKey);
   });
 });

--- a/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
+++ b/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
@@ -277,7 +277,6 @@ Performance Optimizations:
     label: string;
     url: string;
     routeKey: string;
-    comingSoon?: boolean;
   }
   interface NavSection {
     id: string;
@@ -356,14 +355,12 @@ Performance Optimizations:
             label: t('analytics.hub.tabs.weather'),
             url: withQuery(navigationUrls.analyticsWeather),
             routeKey: 'analyticsWeather',
-            comingSoon: true,
           },
           {
             icon: AudioLines,
             label: t('analytics.hub.tabs.soundscape'),
             url: withQuery(navigationUrls.analyticsSoundscape),
             routeKey: 'analyticsSoundscape',
-            comingSoon: true,
           },
         ],
       },
@@ -685,7 +682,6 @@ Performance Optimizations:
                 onNavigate={navigate}
                 {showTooltip}
                 {hideTooltip}
-                comingSoon={item.comingSoon}
               />
             {/each}
           </div>

--- a/frontend/src/lib/desktop/layouts/DesktopSidebar.test.ts
+++ b/frontend/src/lib/desktop/layouts/DesktopSidebar.test.ts
@@ -263,6 +263,22 @@ describe('DesktopSidebar - flat task-grouped sections', () => {
     expect(patternsLabels[3]).toContain('analytics.hub.tabs.biodiversity');
   });
 
+  it('ENVIRONMENT section renders Weather and Soundscape items without a coming-soon chip', () => {
+    const { container } = sidebarTest.render({ currentRoute: '/ui/dashboard' });
+
+    // Both items must be accessible buttons (t() mock returns key verbatim).
+    const weatherBtn = screen.getByRole('button', { name: 'analytics.hub.tabs.weather' });
+    const soundscapeBtn = screen.getByRole('button', { name: 'analytics.hub.tabs.soundscape' });
+    expect(weatherBtn).toBeInTheDocument();
+    expect(soundscapeBtn).toBeInTheDocument();
+
+    // The ENVIRONMENT group must not contain any badge or chip element that
+    // would indicate a coming-soon state.
+    const envGroup = container.querySelector('#nav-section-environment')?.closest('[role="group"]');
+    expect(envGroup).not.toBeNull();
+    expect(envGroup?.querySelector('[class*="badge"], [class*="chip"]')).toBeNull();
+  });
+
   it('deep-link: analytics item URLs carry the active query while Search/Dashboard stay query-less', async () => {
     const onNavigate = vi.fn();
     // Set a non-default filter so queryString is non-empty.

--- a/frontend/src/lib/desktop/layouts/DesktopSidebar.test.ts
+++ b/frontend/src/lib/desktop/layouts/DesktopSidebar.test.ts
@@ -264,7 +264,7 @@ describe('DesktopSidebar - flat task-grouped sections', () => {
   });
 
   it('ENVIRONMENT section renders Weather and Soundscape items without a coming-soon chip', () => {
-    const { container } = sidebarTest.render({ currentRoute: '/ui/dashboard' });
+    sidebarTest.render({ currentRoute: '/ui/dashboard' });
 
     // Both items must be accessible buttons (t() mock returns key verbatim).
     const weatherBtn = screen.getByRole('button', { name: 'analytics.hub.tabs.weather' });
@@ -273,10 +273,10 @@ describe('DesktopSidebar - flat task-grouped sections', () => {
     expect(soundscapeBtn).toBeInTheDocument();
 
     // The ENVIRONMENT group must not contain any badge or chip element that
-    // would indicate a coming-soon state.
-    const envGroup = container.querySelector('#nav-section-environment')?.closest('[role="group"]');
-    expect(envGroup).not.toBeNull();
-    expect(envGroup?.querySelector('[class*="badge"], [class*="chip"]')).toBeNull();
+    // would indicate a coming-soon state. Resolve the group by its accessible
+    // name (aria-labelledby -> the section header) rather than a raw selector.
+    const envGroup = screen.getByRole('group', { name: 'navigation.sections.environment' });
+    expect(envGroup.querySelector('[class*="badge"], [class*="chip"]')).toBeNull();
   });
 
   it('deep-link: analytics item URLs carry the active query while Search/Dashboard stay query-less', async () => {

--- a/frontend/src/lib/desktop/layouts/DesktopSidebar.test.ts
+++ b/frontend/src/lib/desktop/layouts/DesktopSidebar.test.ts
@@ -219,19 +219,6 @@ describe('DesktopSidebar - flat task-grouped sections', () => {
     expect(screen.queryByLabelText('navigation.analyticsSubmenu')).toBeNull();
   });
 
-  it('shows the coming-soon chip for Weather and Soundscape (expanded) but not Nocturnal', () => {
-    sidebarTest.render({ currentRoute: '/ui/dashboard' });
-
-    const badge = 'analytics.comingSoon.badge';
-    const weatherBtn = getBtn('analytics.hub.tabs.weather');
-    const soundscapeBtn = getBtn('analytics.hub.tabs.soundscape');
-    const nocturnalBtn = getBtn('analytics.hub.tabs.nocturnal');
-
-    expect(weatherBtn.textContent).toContain(badge);
-    expect(soundscapeBtn.textContent).toContain(badge);
-    expect(nocturnalBtn.textContent).not.toContain(badge);
-  });
-
   it('does not render About as a top-level item; it lives under Help and activates the Help section on /ui/about', async () => {
     sidebarTest.render({ currentRoute: '/ui/about' });
 

--- a/frontend/src/lib/desktop/layouts/NavFlatItem.svelte
+++ b/frontend/src/lib/desktop/layouts/NavFlatItem.svelte
@@ -34,15 +34,20 @@
   const focusRingClasses =
     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--color-base-100)]';
 
-  let computedAriaLabel = $derived(ariaLabel ?? label);
+  // When expanded the visible <span>{label}</span> is the accessible name, so an
+  // identical aria-label would be a redundant (sometimes double-announced) name;
+  // set aria-label only when collapsed (icon-only) or when a caller overrides it.
+  let computedAriaLabel = $derived(isCollapsed ? (ariaLabel ?? label) : ariaLabel);
+  // Collapsed-only tooltip text; keep it equal to the collapsed accessible name.
+  let tooltipText = $derived(ariaLabel ?? label);
 </script>
 
 <button
   type="button"
   onclick={() => onNavigate(url)}
-  onmouseenter={e => isCollapsed && showTooltip(e, label)}
+  onmouseenter={e => isCollapsed && showTooltip(e, tooltipText)}
   onmouseleave={hideTooltip}
-  onfocus={e => isCollapsed && showTooltip(e, label)}
+  onfocus={e => isCollapsed && showTooltip(e, tooltipText)}
   onblur={hideTooltip}
   aria-label={computedAriaLabel}
   aria-current={active ? 'page' : undefined}

--- a/frontend/src/lib/desktop/layouts/NavFlatItem.svelte
+++ b/frontend/src/lib/desktop/layouts/NavFlatItem.svelte
@@ -35,16 +35,14 @@
     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--color-base-100)]';
 
   let computedAriaLabel = $derived(ariaLabel ?? label);
-
-  let tooltipText = $derived(label);
 </script>
 
 <button
   type="button"
   onclick={() => onNavigate(url)}
-  onmouseenter={e => isCollapsed && showTooltip(e, tooltipText)}
+  onmouseenter={e => isCollapsed && showTooltip(e, label)}
   onmouseleave={hideTooltip}
-  onfocus={e => isCollapsed && showTooltip(e, tooltipText)}
+  onfocus={e => isCollapsed && showTooltip(e, label)}
   onblur={hideTooltip}
   aria-label={computedAriaLabel}
   aria-current={active ? 'page' : undefined}

--- a/frontend/src/lib/desktop/layouts/NavFlatItem.svelte
+++ b/frontend/src/lib/desktop/layouts/NavFlatItem.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { cn } from '$lib/utils/cn';
-  import { t } from '$lib/i18n';
   import type { Component } from 'svelte';
 
   export interface NavFlatItemProps {
@@ -12,7 +11,6 @@
     onNavigate: (_url: string) => void;
     showTooltip: (_event: MouseEvent | FocusEvent, _text: string) => void;
     hideTooltip: () => void;
-    comingSoon?: boolean;
     ariaLabel?: string;
   }
 
@@ -25,7 +23,6 @@
     onNavigate,
     showTooltip,
     hideTooltip,
-    comingSoon = false,
     ariaLabel,
   }: NavFlatItemProps = $props();
 
@@ -37,11 +34,9 @@
   const focusRingClasses =
     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--color-base-100)]';
 
-  let badgeText = $derived(t('analytics.comingSoon.badge'));
+  let computedAriaLabel = $derived(ariaLabel ?? label);
 
-  let computedAriaLabel = $derived(ariaLabel ?? (comingSoon ? `${label} (${badgeText})` : label));
-
-  let tooltipText = $derived(comingSoon ? `${label} (${badgeText})` : label);
+  let tooltipText = $derived(label);
 </script>
 
 <button
@@ -63,8 +58,5 @@
   <Icon class="size-5 shrink-0" />
   {#if !isCollapsed}
     <span>{label}</span>
-    {#if comingSoon}
-      <span class="badge badge-primary badge-sm ml-auto">{badgeText}</span>
-    {/if}
   {/if}
 </button>

--- a/frontend/src/lib/desktop/layouts/NavFlatItem.test.ts
+++ b/frontend/src/lib/desktop/layouts/NavFlatItem.test.ts
@@ -76,53 +76,12 @@ describe('NavFlatItem', () => {
     expect(onNavigate).toHaveBeenCalledWith('/ui/search');
   });
 
-  it('shows comingSoon badge when expanded and comingSoon=true', () => {
-    itemTest.render({ ...defaultProps, isCollapsed: false, comingSoon: true, label: 'Weather' });
-    // The badge text is the i18n key (mocked to return the key)
-    expect(screen.getByText('analytics.comingSoon.badge')).toBeInTheDocument();
-    expect(screen.getByText('analytics.comingSoon.badge')).toHaveClass('badge');
-  });
-
-  it('does not show comingSoon badge when comingSoon=false', () => {
-    itemTest.render({ ...defaultProps, isCollapsed: false, comingSoon: false });
-    expect(screen.queryByText('analytics.comingSoon.badge')).not.toBeInTheDocument();
-  });
-
-  it('hides text label and badge in collapsed mode', () => {
-    itemTest.render({
-      ...defaultProps,
-      isCollapsed: true,
-      comingSoon: true,
-      label: 'Weather',
-    });
-    // Text span should not be visible (not rendered)
-    expect(screen.queryByText('Weather')).not.toBeInTheDocument();
-    // Badge should also be absent in collapsed mode
-    expect(screen.queryByText('analytics.comingSoon.badge')).not.toBeInTheDocument();
-  });
-
   it('keeps accessible name when collapsed (icon-only)', () => {
     itemTest.render({ ...defaultProps, isCollapsed: true, label: 'Search' });
     const button = screen.getByRole('button');
     expect(button).toHaveAttribute('aria-label', 'Search');
     // No visible text label rendered
     expect(screen.queryByText('Search')).not.toBeInTheDocument();
-  });
-
-  it('suffixes aria-label with coming-soon text when collapsed and comingSoon=true', () => {
-    itemTest.render({ ...defaultProps, isCollapsed: true, comingSoon: true, label: 'Weather' });
-    const button = screen.getByRole('button');
-    // aria-label should include the badge text suffix
-    expect(button.getAttribute('aria-label')).toContain('Weather');
-    expect(button.getAttribute('aria-label')).toContain('analytics.comingSoon.badge');
-  });
-
-  it('suffixes aria-label with coming-soon text when expanded and comingSoon=true', () => {
-    itemTest.render({ ...defaultProps, isCollapsed: false, comingSoon: true, label: 'Weather' });
-    const button = screen.getByRole('button');
-    // Screen readers must hear the coming-soon state in expanded mode too
-    expect(button.getAttribute('aria-label')).toContain('Weather');
-    expect(button.getAttribute('aria-label')).toContain('analytics.comingSoon.badge');
   });
 
   it('does NOT have role="menuitem"', () => {

--- a/frontend/src/lib/desktop/layouts/NavFlatItem.test.ts
+++ b/frontend/src/lib/desktop/layouts/NavFlatItem.test.ts
@@ -34,10 +34,12 @@ describe('NavFlatItem', () => {
     expect(button.querySelector('svg')).toBeInTheDocument();
   });
 
-  it('aria-label is always present (defaults to label)', () => {
+  it('exposes the label as the accessible name without a redundant aria-label when expanded', () => {
     itemTest.render({ ...defaultProps, isCollapsed: false });
-    const button = screen.getByRole('button');
-    expect(button).toHaveAttribute('aria-label', 'Search');
+    // Visible <span>{label}</span> provides the accessible name; aria-label is
+    // intentionally omitted when expanded to avoid a duplicate announcement.
+    const button = screen.getByRole('button', { name: 'Search' });
+    expect(button).not.toHaveAttribute('aria-label');
   });
 
   it('aria-label is present in collapsed icon-only mode', () => {

--- a/frontend/src/lib/desktop/layouts/NavFlatItem.test.ts
+++ b/frontend/src/lib/desktop/layouts/NavFlatItem.test.ts
@@ -3,11 +3,6 @@ import { createComponentTestFactory, screen, fireEvent } from '../../../test/ren
 import NavFlatItem from './NavFlatItem.svelte';
 import { Search } from '@lucide/svelte';
 
-vi.mock('$lib/i18n', () => ({
-  t: vi.fn((key: string) => key),
-  getLocale: vi.fn(() => 'en'),
-}));
-
 describe('NavFlatItem', () => {
   const itemTest = createComponentTestFactory(NavFlatItem);
 


### PR DESCRIPTION
## Summary

Fixes broken rendering of the per-route analytics pages introduced/surfaced by the sidebar IA redesign (#3744). Verified visually with Playwright at desktop width against a real backend (Summary, Activity Patterns, a coming-soon page, and the collapsed sidebar).

Three issues, all confirmed by live DOM inspection:

1. **Pages collapsed to a thin column.** `RootLayout` renders routed pages inside a `grid grid-cols-12` content area, so page roots must carry a `col-span-*` (the Species page already used `col-span-12`). `AnalyticsPageShell` and `AnalyticsComingSoon` rendered their root `<section>` with no col-span, so every analytics page occupied a single 1/12 column (~101px) and squished all charts into a narrow strip. Added `col-span-12` to both shells. This covers all nine analytics routes (verified they all funnel through these two shells or the already-correct Species page).

2. **Two titles per page.** The global header already renders the route title (e.g. "Analytics - Activity Patterns"); the shells also rendered their own `<h1>`, duplicating it. Removed the in-content `<h1>` and kept the section accessible via `aria-label={t(titleKey)}` (also resolves a duplicate-`id` risk from the shared `analytics-page-title` id).

3. **Sidebar "coming soon" chips overflowed.** Removed the coming-soon chip from the sidebar nav items (Weather/Soundscape); the chip didn't fit the narrow sidebar. The coming-soon state is still shown on the Weather/Soundscape pages themselves (card badge + description).

## Test plan

- [x] Visual verification with Playwright @ 1920px: Activity Patterns and Summary render full-width with a single title and real chart data; Weather coming-soon page renders full-width with its page badge; collapsed sidebar shows icons with no chip.
- [x] `npm run check:all` clean; `npm test` full suite green (2572 tests; added a test that the Weather/Soundscape sidebar items render without a chip, plus title-assertion updates).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screen-reader accessibility for analytics page titles by changing how titles are announced to users of assistive technologies.
  * Removed “coming soon” badges/badge text from analytics-related sidebar items so they render consistently.
  * Updated navigation button accessibility so labels are correctly exposed for both collapsed (icon-only) and expanded states.
* **Style**
  * Refined analytics page layout spacing/alignment in the desktop view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->