### PR TITLE
ci: shard Go tests, add gotestsum reruns, and a consolidated failure report

### DIFF
--- a/.github/scripts/ci-test-report.sh
+++ b/.github/scripts/ci-test-report.sh
@@ -62,7 +62,9 @@ fi
 # Per (package, test): count fail/pass events and capture output. A regression
 # never passed (passes==0); a flaky test failed then passed (passes>0, fails>0).
 JQ_PROG='
-  [ inputs | try fromjson catch empty | select(.Test != null) ]
+  [ inputs | try fromjson catch empty
+    | select(.Action=="fail" or .Action=="pass" or .Action=="output")
+    | {Package, Test: (.Test // "(package)"), Action, Output} ]
   | group_by([.Package, .Test])
   | map({
       pkg:    .[0].Package,
@@ -74,8 +76,17 @@ JQ_PROG='
 '
 
 # -R reads each line as raw text so the per-line `try fromjson` above can skip a
-# corrupt line; without -R a single bad line aborts the whole parse.
-ALL=$(jq -R -n "$JQ_PROG" "${EXISTING[@]}" 2>/dev/null || echo "[]")
+# corrupt line; without -R a single bad line aborts the whole parse. Do NOT mask a
+# hard jq failure (e.g. OOM on a huge log) with a `|| echo "[]"` fallback: that
+# would report zero failures and turn a broken run green. Fail loudly instead.
+jq_err=$(mktemp)
+if ! ALL=$(jq -R -n "$JQ_PROG" "${EXISTING[@]}" 2>"$jq_err"); then
+  echo "ci-test-report: jq failed to parse test events (refusing to report a false pass):" >&2
+  cat "$jq_err" >&2
+  rm -f "$jq_err"
+  exit 3
+fi
+rm -f "$jq_err"
 
 # here-strings instead of `echo "$ALL" |`: avoids a subshell and any echo
 # backslash/leading-dash interpretation of the JSON payload.

--- a/.github/scripts/ci-test-report.sh
+++ b/.github/scripts/ci-test-report.sh
@@ -62,7 +62,7 @@ fi
 # Per (package, test): count fail/pass events and capture output. A regression
 # never passed (passes==0); a flaky test failed then passed (passes>0, fails>0).
 JQ_PROG='
-  [ inputs | select(.Test != null) ]
+  [ inputs | try fromjson catch empty | select(.Test != null) ]
   | group_by([.Package, .Test])
   | map({
       pkg:    .[0].Package,
@@ -73,10 +73,14 @@ JQ_PROG='
     })
 '
 
-ALL=$(jq -n "$JQ_PROG" "${EXISTING[@]}" 2>/dev/null || echo "[]")
+# -R reads each line as raw text so the per-line `try fromjson` above can skip a
+# corrupt line; without -R a single bad line aborts the whole parse.
+ALL=$(jq -R -n "$JQ_PROG" "${EXISTING[@]}" 2>/dev/null || echo "[]")
 
-echo "$ALL" | jq '[ .[] | select(.fails > 0 and .passes == 0) | {pkg, test, output} ]' > "$FAILURES_JSON"
-echo "$ALL" | jq '[ .[] | select(.fails > 0 and .passes > 0) | {pkg, test} ]' > "$FLAKY_JSON"
+# here-strings instead of `echo "$ALL" |`: avoids a subshell and any echo
+# backslash/leading-dash interpretation of the JSON payload.
+jq '[ .[] | select(.fails > 0 and .passes == 0) | {pkg, test, output} ]' <<< "$ALL" > "$FAILURES_JSON"
+jq '[ .[] | select(.fails > 0 and .passes > 0) | {pkg, test} ]' <<< "$ALL" > "$FLAKY_JSON"
 
 REG_COUNT=$(jq 'length' "$FAILURES_JSON")
 FLAKY_COUNT=$(jq 'length' "$FLAKY_JSON")

--- a/.github/scripts/ci-test-report.sh
+++ b/.github/scripts/ci-test-report.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# ci-test-report.sh - turn one or more gotestsum --jsonfile streams into a
+# compact, machine-readable failure report plus a human/LLM-friendly summary.
+#
+# Why this exists: raw CI logs are huge and an LLM agent (or a human) should not
+# have to parse thousands of lines to learn what actually broke. This script
+# emits a small `<out>-failures.json` artifact and appends a short Markdown
+# section to $GITHUB_STEP_SUMMARY, classifying every test as one of:
+#   - regression : failed and never passed, even after gotestsum reruns
+#   - flaky      : failed at least once but passed on a rerun (NOT a code bug)
+# Classification is order-independent: a test is a regression iff it has >=1
+# fail event and 0 pass events; it is flaky iff it has both. This holds no
+# matter how gotestsum interleaves rerun events in the JSON stream.
+#
+# Usage:
+#   ci-test-report.sh OUT_PREFIX TITLE JSONFILE [JSONFILE...]
+#
+# Outputs:
+#   <OUT_PREFIX>-failures.json  - JSON array of regressions (pkg, test, output)
+#   appends a Markdown summary to $GITHUB_STEP_SUMMARY (or stdout if unset)
+#
+# Exit code: 0 always (reporting is non-fatal; the test step's own exit code
+# is the gate). The caller decides what to do with the counts printed to stdout.
+
+set -uo pipefail
+
+if [ "$#" -lt 3 ]; then
+  echo "usage: $0 OUT_PREFIX TITLE JSONFILE [JSONFILE...]" >&2
+  exit 2
+fi
+
+OUT_PREFIX="$1"; shift
+TITLE="$1"; shift
+JSONFILES=("$@")
+
+FAILURES_JSON="${OUT_PREFIX}-failures.json"
+FLAKY_JSON="${OUT_PREFIX}-flaky.json"
+SUMMARY_FILE="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+
+# Merge only the JSON files that exist and are non-empty, so a missing shard
+# artifact does not abort the whole report.
+EXISTING=()
+for f in "${JSONFILES[@]}"; do
+  if [ -s "$f" ]; then EXISTING+=("$f"); fi
+done
+
+if [ "${#EXISTING[@]}" -eq 0 ]; then
+  echo "[]" > "$FAILURES_JSON"
+  echo "[]" > "$FLAKY_JSON"
+  {
+    echo "### ${TITLE}"
+    echo ""
+    echo "No test event data found (jsonfiles missing or empty)."
+    echo ""
+  } >> "$SUMMARY_FILE"
+  echo "regressions=0"
+  echo "flaky=0"
+  exit 0
+fi
+
+# Per (package, test): count fail/pass events and capture output. A regression
+# never passed (passes==0); a flaky test failed then passed (passes>0, fails>0).
+JQ_PROG='
+  [ inputs | select(.Test != null) ]
+  | group_by([.Package, .Test])
+  | map({
+      pkg:    .[0].Package,
+      test:   .[0].Test,
+      fails:  (map(select(.Action=="fail"))   | length),
+      passes: (map(select(.Action=="pass"))   | length),
+      output: (map(select(.Action=="output")) | map(.Output) | join("") )
+    })
+'
+
+ALL=$(jq -n "$JQ_PROG" "${EXISTING[@]}" 2>/dev/null || echo "[]")
+
+echo "$ALL" | jq '[ .[] | select(.fails > 0 and .passes == 0) | {pkg, test, output} ]' > "$FAILURES_JSON"
+echo "$ALL" | jq '[ .[] | select(.fails > 0 and .passes > 0) | {pkg, test} ]' > "$FLAKY_JSON"
+
+REG_COUNT=$(jq 'length' "$FAILURES_JSON")
+FLAKY_COUNT=$(jq 'length' "$FLAKY_JSON")
+
+{
+  echo "### ${TITLE}"
+  echo ""
+  if [ "$REG_COUNT" -eq 0 ] && [ "$FLAKY_COUNT" -eq 0 ]; then
+    echo ":white_check_mark: All tests passed."
+  else
+    echo "| Outcome | Count |"
+    echo "| --- | --- |"
+    echo "| :x: Regressions (failed after reruns) | ${REG_COUNT} |"
+    echo "| :recycle: Flaky (passed on rerun) | ${FLAKY_COUNT} |"
+    echo ""
+    if [ "$REG_COUNT" -gt 0 ]; then
+      echo "<details><summary>Regressions - real failures, fix these</summary>"
+      echo ""
+      echo '```'
+      jq -r '.[] | "FAIL  \(.pkg)  \(.test)"' "$FAILURES_JSON"
+      echo '```'
+      echo "</details>"
+      echo ""
+    fi
+    if [ "$FLAKY_COUNT" -gt 0 ]; then
+      echo "<details><summary>Flaky - failed then passed on rerun, NOT a regression</summary>"
+      echo ""
+      echo '```'
+      jq -r '.[] | "FLAKY \(.pkg)  \(.test)"' "$FLAKY_JSON"
+      echo '```'
+      echo "</details>"
+      echo ""
+    fi
+  fi
+} >> "$SUMMARY_FILE"
+
+echo "regressions=${REG_COUNT}"
+echo "flaky=${FLAKY_COUNT}"
+exit 0

--- a/.github/workflows/golangci-test.yml
+++ b/.github/workflows/golangci-test.yml
@@ -9,22 +9,47 @@ on:
       - 'go.mod'
       - 'go.sum'
       - '.golangci.yaml'
+      - '.github/workflows/golangci-test.yml'
+      - '.github/scripts/ci-test-report.sh'
   pull_request:
     paths:
       - '**/*.go'
       - 'go.mod'
       - 'go.sum'
       - '.golangci.yaml'
+      - '.github/workflows/golangci-test.yml'
+      - '.github/scripts/ci-test-report.sh'
 
 permissions:
   contents: read
+
+# Cancel superseded runs for the same ref so rapid pushes do not pile up full
+# test matrices behind each other.
+concurrency:
+  group: golangci-test-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # gotestsum gives us JSON + JUnit output and, crucially, --rerun-fails so an
+  # external/infra flake (a reaped container, a registry blip) is retried and
+  # classified as flaky instead of failing the gate. Pinned for reproducibility.
+  GOTESTSUM_VERSION: v1.13.0
+  # Number of parallel shards the portable unit suite is split across. Keep in
+  # sync with the matrix below and the `NR % <N>` modulo in the shard step.
+  UNIT_SHARDS: 4
 
 jobs:
   golangci:
     uses: ./.github/workflows/golangci-lint.yml
 
   unit-tests:
+    name: unit-tests (shard ${{ matrix.shard }})
     runs-on: ubuntu-24.04
+    strategy:
+      # Surface every shard's failures; do not cancel the rest when one fails.
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
     services:
       mosquitto:
         image: eclipse-mosquitto:1.6
@@ -54,12 +79,12 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/go/bin
-          key: ${{ runner.os }}-go-tools-gotestfmt-v2-${{ hashFiles('go.mod') }}
+          key: ${{ runner.os }}-go-tools-gotestsum-${{ env.GOTESTSUM_VERSION }}
 
-      - name: Set up gotestfmt
+      - name: Set up gotestsum
         run: |
-          if ! command -v gotestfmt &> /dev/null; then
-            go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
+          if ! command -v gotestsum &> /dev/null; then
+            go install "gotest.tools/gotestsum@${GOTESTSUM_VERSION}"
           fi
 
       - name: Wait for Mosquitto
@@ -73,106 +98,61 @@ jobs:
             echo "Attempt $i: Mosquitto not ready yet, waiting..."
             sleep 1
           done
-          # Final check
           nc -zv localhost 1883 || { echo "Mosquitto failed to start"; exit 1; }
+
+      - name: Compute shard package list
+        run: |
+          # Split the full package list across UNIT_SHARDS runners by line modulo.
+          # `go list` order is deterministic for a given checkout, so the split is
+          # stable, and new packages are picked up automatically (no hand-curated
+          # lists to maintain). noembed,skipfrontend skip model/frontend embedding.
+          go list -tags noembed,skipfrontend ./... \
+            | awk -v n="${UNIT_SHARDS}" -v s="${{ matrix.shard }}" 'NR % n == s' \
+            > shard_pkgs.txt
+          echo "Shard ${{ matrix.shard }} owns $(wc -l < shard_pkgs.txt) packages:"
+          cat shard_pkgs.txt
 
       - name: Run unit tests
         env:
           CI: true
           MQTT_TEST_BROKER: tcp://localhost:1883
         run: |
-          # Drop errexit (-e) but keep nounset + pipefail: a failing `go test`
-          # makes the pipeline non-zero, and with -e the shell would abort right
-          # here, before TEST_EXIT_CODE=${PIPESTATUS[0]} runs, so the failure
-          # summary below never renders. The explicit `exit $TEST_EXIT_CODE` still
-          # fails the step. (macos-test.yml / windows-test.yml use the same pattern.)
-          set -uo pipefail
-
-          # Run tests with JSON output
-          # Note: We must capture PIPESTATUS immediately after the pipeline
-          # gotestfmt may return non-zero even when tests pass, so we only check go test's exit code
-          # Use noembed,skipfrontend tags to skip model and frontend embedding requirement
-          go test -tags noembed,skipfrontend -race -json -v -short -timeout 300s ./... 2>&1 | tee /tmp/gotest.log | gotestfmt -ci github; TEST_EXIT_CODE=${PIPESTATUS[0]}
-
-          if [ $TEST_EXIT_CODE -ne 0 ]; then
-            echo "::error title=Test Failure::Unit tests failed - see job summary for details"
-
-            # Create initial summary
-            echo "## :x: Test Run Failed" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "Exit code: $TEST_EXIT_CODE" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-
-            # Quick preview of failures - parse JSON to extract test names
-            echo "### Quick Preview of Failures" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            grep '"Action":"fail"' /tmp/gotest.log | jq -r 'select(.Test) | (.Package + " " + .Test)' | head -20 >> $GITHUB_STEP_SUMMARY 2>&1 || echo "Failed to parse test failures" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "👇 See 'Generate test failure report' step below for detailed analysis" >> $GITHUB_STEP_SUMMARY
-
-            exit $TEST_EXIT_CODE
-          fi
-
-          echo "## :white_check_mark: All Tests Passed" >> $GITHUB_STEP_SUMMARY
-        timeout-minutes: 10
+          # gotestsum runs `go test -json` for us. --rerun-fails retries a failed
+          # test once; if it then passes it is reported as flaky (not a gate
+          # failure). --rerun-fails-abort-on-data-race keeps real data races fatal
+          # (a race must never be retried away). --rerun-fails-max-failures avoids
+          # masking a mass breakage by refusing to rerun when too much failed at
+          # once. The JSON stream feeds the consolidated test-report job below.
+          mapfile -t PKGS < shard_pkgs.txt
+          gotestsum \
+            --format pkgname \
+            --jsonfile "events-unit-${{ matrix.shard }}.json" \
+            --junitfile "junit-unit-${{ matrix.shard }}.xml" \
+            --rerun-fails=1 \
+            --rerun-fails-abort-on-data-race \
+            --rerun-fails-max-failures=15 \
+            --rerun-fails-report="rerun-unit-${{ matrix.shard }}.txt" \
+            --packages "${PKGS[*]}" \
+            -- -tags noembed,skipfrontend -race -short -timeout 300s
+        timeout-minutes: 12
 
       - name: Cleanup any remaining processes
         if: always()
         run: |
-          # Kill any remaining test processes to prevent resource leaks
           pkill -f "test://" || true
           pkill -f "sleep.*test" || true
           pkill -f "sh.*-c.*sleep" || true
 
-      - name: Generate test failure report
-        if: failure()
-        run: |
-          echo "# Test Failure Analysis" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          # Count failures from JSON (count test-level failures, not package-level)
-          FAIL_COUNT=$(grep '"Action":"fail"' /tmp/gotest.log | jq -s '[.[] | select(.Test)] | length' 2>/dev/null || echo "0")
-          echo "**Total Failed Tests: $FAIL_COUNT**" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          # Extract failed test details with error messages from JSON
-          echo "## Failed Test Details" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          # Get list of failed tests
-          FAILED_TESTS=$(grep '"Action":"fail"' /tmp/gotest.log | jq -r 'select(.Test) | (.Package + "|" + .Test)' 2>/dev/null | sort -u)
-
-          if [ -n "$FAILED_TESTS" ]; then
-            while IFS='|' read -r pkg test; do
-              echo "### ❌ \`$test\`" >> $GITHUB_STEP_SUMMARY
-              echo "**Package:** \`$pkg\`" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo '```' >> $GITHUB_STEP_SUMMARY
-              # Extract all output for this specific test from JSON, filtering out test framework lines
-              grep "\"Test\":\"$test\"" /tmp/gotest.log | jq -r 'select(.Action == "output") | .Output' 2>/dev/null | grep -v "^===" | grep -v "^---" >> $GITHUB_STEP_SUMMARY || echo "No error details found" >> $GITHUB_STEP_SUMMARY
-              echo '```' >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-            done <<< "$FAILED_TESTS"
-          else
-            echo "No test failures found in JSON output" >> $GITHUB_STEP_SUMMARY
-          fi
-
-          # Extract unique failing packages
-          echo "## Affected Packages" >> $GITHUB_STEP_SUMMARY
-          grep '"Action":"fail"' /tmp/gotest.log | jq -r 'select(.Package) | .Package' 2>/dev/null | sort -u >> $GITHUB_STEP_SUMMARY || echo "No packages identified" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          echo "---" >> $GITHUB_STEP_SUMMARY
-          echo "📥 Download the full test log artifact for complete details" >> $GITHUB_STEP_SUMMARY
-
-      - name: Upload test log
+      - name: Upload test events
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: test-log
-          path: /tmp/gotest.log
-          if-no-files-found: error
+          name: gotest-unit-${{ matrix.shard }}
+          path: |
+            events-unit-${{ matrix.shard }}.json
+            junit-unit-${{ matrix.shard }}.xml
+            rerun-unit-${{ matrix.shard }}.txt
+          if-no-files-found: warn
 
   testcontainer-tests:
     runs-on: ubuntu-24.04
@@ -192,19 +172,80 @@ jobs:
           packages: ffmpeg sox
         timeout-minutes: 3
 
-      - name: Run testcontainer integration tests
+      - name: Set up gotestsum
         run: |
-          # Run integration tests that use testcontainers and the integration build tag
-          # Testcontainers automatically manage MySQL, Mosquitto, and MediaMTX containers
-          go test -tags=integration -race -timeout 300s -v \
-            ./internal/datastore/v2 \
-            ./internal/datastore/v2/repository/... \
-            ./internal/datastore/v2only \
-            ./internal/mqtt/... \
-            ./internal/spectrogram/... \
-            ./internal/testutil/containers/... \
-            2>&1
+          if ! command -v gotestsum &> /dev/null; then
+            go install "gotest.tools/gotestsum@${GOTESTSUM_VERSION}"
+          fi
+
+      - name: Run MySQL-backed integration tests (serialized)
+        run: |
+          # Serialize package-level parallelism (-p 1) for the MySQL-backed
+          # packages. Running them in parallel spins up several MySQL 8 containers
+          # at once; under the runner's memory ceiling one gets OOM-reaped
+          # mid-test, surfacing as `connection refused` / `No such container` and
+          # looking like a logic bug. One container set at a time removes that
+          # race. gotestsum --rerun-fails still absorbs any residual flake.
+          gotestsum \
+            --format pkgname \
+            --jsonfile events-tc-mysql.json \
+            --junitfile junit-tc-mysql.xml \
+            --rerun-fails=1 \
+            --rerun-fails-max-failures=10 \
+            --rerun-fails-report=rerun-tc-mysql.txt \
+            --packages "./internal/datastore/v2 ./internal/datastore/v2/repository/... ./internal/datastore/v2only" \
+            -- -tags=integration -race -timeout 300s -p 1
         timeout-minutes: 10
+
+      - name: Run other container integration tests
+        if: ${{ !cancelled() }}
+        run: |
+          # Mosquitto / MediaMTX / spectrogram container tests are light enough to
+          # run with default package parallelism. Runs even if the MySQL step
+          # failed (!cancelled) so one flaky suite does not hide the others.
+          gotestsum \
+            --format pkgname \
+            --jsonfile events-tc-other.json \
+            --junitfile junit-tc-other.xml \
+            --rerun-fails=1 \
+            --rerun-fails-max-failures=10 \
+            --rerun-fails-report=rerun-tc-other.txt \
+            --packages "./internal/mqtt/... ./internal/spectrogram/... ./internal/testutil/containers/..." \
+            -- -tags=integration -race -timeout 300s
+        timeout-minutes: 10
+
+      - name: Container diagnostics on failure
+        if: failure()
+        run: |
+          # Capture the evidence needed to tell an infra flake (OOM-reaped
+          # container) from a real failure. Without this the run discards the one
+          # thing that makes a testcontainer failure diagnosable.
+          {
+            echo "## Testcontainer diagnostics"
+            echo '```'
+            echo "--- docker ps -a ---"
+            docker ps -a 2>&1 || true
+            echo "--- docker system df ---"
+            docker system df 2>&1 || true
+            echo "--- free -m ---"
+            free -m 2>&1 || true
+            echo "--- df -h ---"
+            df -h 2>&1 || true
+            echo "--- kernel OOM kills ---"
+            sudo dmesg 2>/dev/null | grep -iE "killed process|out of memory|oom-kill" | tail -20 || echo "none found / dmesg unavailable"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload test events
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: gotest-testcontainer
+          path: |
+            events-tc-*.json
+            junit-tc-*.xml
+            rerun-tc-*.txt
+          if-no-files-found: warn
 
   integration-tests:
     runs-on: ubuntu-24.04
@@ -215,16 +256,123 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
+      - name: Set up gotestsum
+        run: |
+          if ! command -v gotestsum &> /dev/null; then
+            go install "gotest.tools/gotestsum@${GOTESTSUM_VERSION}"
+          fi
+
       - name: Run quick integration tests
         run: |
-          # Run integration tests in short mode with race detection
-          # Short mode skips the large dataset test (10K records)
-          go test -tags=integration -short -race -timeout 180s -v ./internal/datastore/v2/migration/... 2>&1
+          # Short mode skips the large dataset test (10K records).
+          gotestsum \
+            --format pkgname \
+            --jsonfile events-integration.json \
+            --junitfile junit-integration.xml \
+            --rerun-fails=1 \
+            --rerun-fails-max-failures=10 \
+            --rerun-fails-report=rerun-integration.txt \
+            --packages "./internal/datastore/v2/migration/..." \
+            -- -tags=integration -short -race -timeout 180s
         timeout-minutes: 5
 
       - name: Run full integration tests (label-gated)
         if: contains(github.event.pull_request.labels.*.name, 'run-full-integration')
         run: |
-          # Run full integration tests including large dataset
-          go test -tags=integration -race -timeout 600s -v ./internal/datastore/v2/migration/... 2>&1
+          # Full integration tests including the large dataset.
+          gotestsum \
+            --format pkgname \
+            --jsonfile events-integration-full.json \
+            --junitfile junit-integration-full.xml \
+            --rerun-fails=1 \
+            --rerun-fails-max-failures=10 \
+            --packages "./internal/datastore/v2/migration/..." \
+            -- -tags=integration -race -timeout 600s
         timeout-minutes: 15
+
+      - name: Upload test events
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: gotest-integration
+          path: |
+            events-integration*.json
+            junit-integration*.xml
+            rerun-integration*.txt
+          if-no-files-found: warn
+
+  # Consolidated, machine-readable result. Runs regardless of upstream outcome so
+  # there is ONE place (a single job summary + a single ci-failures.json
+  # artifact) for a human or an LLM agent to read: it classifies every failure as
+  # a real regression vs a flaky-on-rerun infra blip, so an agent does not burn
+  # time "fixing" a test that is known to fail occasionally for external reasons.
+  test-report:
+    name: test-report
+    if: always()
+    needs: [unit-tests, testcontainer-tests, integration-tests]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download all test events
+        uses: actions/download-artifact@v8
+        with:
+          pattern: gotest-*
+          path: events
+          merge-multiple: true
+
+      - name: Build consolidated report
+        run: |
+          chmod +x .github/scripts/ci-test-report.sh
+          shopt -s nullglob
+          FILES=(events/events-*.json)
+          if [ "${#FILES[@]}" -eq 0 ]; then
+            echo "## CI Test Verdict: no-data" >> "$GITHUB_STEP_SUMMARY"
+            echo "No gotestsum event files were produced." >> "$GITHUB_STEP_SUMMARY"
+            echo '[]' > ci-failures.json
+            exit 0
+          fi
+
+          # First pass to /dev/null just to read the counts, so the verdict can be
+          # written at the TOP of the summary before the detail tables.
+          COUNTS=$(GITHUB_STEP_SUMMARY=/dev/null .github/scripts/ci-test-report.sh ci "counts" "${FILES[@]}")
+          REG=$(echo "$COUNTS" | sed -n 's/^regressions=//p')
+          FLAKY=$(echo "$COUNTS" | sed -n 's/^flaky=//p')
+
+          if [ "${REG:-0}" -gt 0 ]; then
+            echo "## CI Test Verdict: REGRESSION" >> "$GITHUB_STEP_SUMMARY"
+            echo "$REG test(s) failed even after reruns. These are real failures - fix them." >> "$GITHUB_STEP_SUMMARY"
+          elif [ "${FLAKY:-0}" -gt 0 ]; then
+            echo "## CI Test Verdict: PASS (with flakes)" >> "$GITHUB_STEP_SUMMARY"
+            echo "$FLAKY test(s) failed then passed on rerun. Treated as flaky/infra, NOT a code regression." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## CI Test Verdict: PASS" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          # Second pass writes the detail tables and the ci-failures.json artifact.
+          .github/scripts/ci-test-report.sh ci "Consolidated test results" "${FILES[@]}"
+
+      - name: Upload consolidated failure report
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: ci-failures
+          path: |
+            ci-failures.json
+            ci-flaky.json
+          if-no-files-found: warn
+
+      - name: Fail if regressions present
+        run: |
+          # The individual test jobs already fail on a real regression; this gate
+          # makes the consolidated verdict authoritative too. A run that only had
+          # flaky-on-rerun failures stays green here.
+          REG=$(jq 'length' ci-failures.json 2>/dev/null || echo 0)
+          if [ "${REG:-0}" -gt 0 ]; then
+            echo "::error::${REG} regression(s) failed after reruns - see the test-report summary and ci-failures.json artifact"
+            exit 1
+          fi
+          echo "No regressions."

--- a/.github/workflows/golangci-test.yml
+++ b/.github/workflows/golangci-test.yml
@@ -191,6 +191,7 @@ jobs:
             --jsonfile events-tc-mysql.json \
             --junitfile junit-tc-mysql.xml \
             --rerun-fails=1 \
+            --rerun-fails-abort-on-data-race \
             --rerun-fails-max-failures=10 \
             --rerun-fails-report=rerun-tc-mysql.txt \
             --packages "./internal/datastore/v2 ./internal/datastore/v2/repository/... ./internal/datastore/v2only" \
@@ -208,6 +209,7 @@ jobs:
             --jsonfile events-tc-other.json \
             --junitfile junit-tc-other.xml \
             --rerun-fails=1 \
+            --rerun-fails-abort-on-data-race \
             --rerun-fails-max-failures=10 \
             --rerun-fails-report=rerun-tc-other.txt \
             --packages "./internal/mqtt/... ./internal/spectrogram/... ./internal/testutil/containers/..." \
@@ -270,6 +272,7 @@ jobs:
             --jsonfile events-integration.json \
             --junitfile junit-integration.xml \
             --rerun-fails=1 \
+            --rerun-fails-abort-on-data-race \
             --rerun-fails-max-failures=10 \
             --rerun-fails-report=rerun-integration.txt \
             --packages "./internal/datastore/v2/migration/..." \
@@ -285,6 +288,7 @@ jobs:
             --jsonfile events-integration-full.json \
             --junitfile junit-integration-full.xml \
             --rerun-fails=1 \
+            --rerun-fails-abort-on-data-race \
             --rerun-fails-max-failures=10 \
             --packages "./internal/datastore/v2/migration/..." \
             -- -tags=integration -race -timeout 600s

--- a/.github/workflows/golangci-test.yml
+++ b/.github/workflows/golangci-test.yml
@@ -336,6 +336,7 @@ jobs:
             echo "## CI Test Verdict: no-data" >> "$GITHUB_STEP_SUMMARY"
             echo "No gotestsum event files were produced." >> "$GITHUB_STEP_SUMMARY"
             echo '[]' > ci-failures.json
+            echo '[]' > ci-flaky.json
             exit 0
           fi
 
@@ -369,14 +370,24 @@ jobs:
             ci-flaky.json
           if-no-files-found: warn
 
-      - name: Fail if regressions present
+      - name: Fail if regressions present or an upstream job failed
         run: |
-          # The individual test jobs already fail on a real regression; this gate
-          # makes the consolidated verdict authoritative too. A run that only had
-          # flaky-on-rerun failures stays green here.
+          # Make the consolidated verdict authoritative. Two ways it must go red:
+          # 1. A required test job did not succeed. A job that fails at setup
+          #    (before gotestsum runs) uploads no events, so the report would
+          #    otherwise see zero failures and falsely pass. The individual job is
+          #    already red, but this keeps the consolidated gate honest too.
+          # 2. A real regression survived reruns. Flaky-on-rerun failures stay green.
+          UNIT='${{ needs.unit-tests.result }}'
+          TC='${{ needs.testcontainer-tests.result }}'
+          INTEG='${{ needs.integration-tests.result }}'
+          if [ "$UNIT" != "success" ] || [ "$TC" != "success" ] || [ "$INTEG" != "success" ]; then
+            echo "::error::An upstream test job did not succeed (unit-tests=$UNIT, testcontainer-tests=$TC, integration-tests=$INTEG)"
+            exit 1
+          fi
           REG=$(jq 'length' ci-failures.json 2>/dev/null || echo 0)
           if [ "${REG:-0}" -gt 0 ]; then
             echo "::error::${REG} regression(s) failed after reruns - see the test-report summary and ci-failures.json artifact"
             exit 1
           fi
-          echo "No regressions."
+          echo "No regressions and all upstream test jobs succeeded."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,30 @@ PRs missing the preflight certification will require multiple review
 rounds. The gate catches the same issues reviewers find; running it
 locally saves a day of back-and-forth.
 
+## Interpreting CI Failures
+
+The `golangci-test` workflow runs Go tests through `gotestsum` with one
+automatic rerun of any failed test, then publishes a consolidated result in the
+`test-report` job. Before assuming a red run means your code is broken:
+
+1. Read the `test-report` job summary. It states one verdict:
+   - `REGRESSION` - real failures that persisted after a rerun. Fix these.
+   - `PASS (with flakes)` - tests that failed once then passed on rerun. These
+     are flaky/infra (a reaped container, a registry blip), NOT a code
+     regression. Do not "fix" them; re-run or report instead.
+   - `PASS` - all green.
+2. For machine-readable detail, download the `ci-failures` artifact:
+   - `ci-failures.json` - array of real regressions (`{pkg, test, output}`).
+   - `ci-flaky.json` - tests that passed on rerun (informational).
+   Prefer reading these small files over scrolling the raw multi-thousand-line
+   logs.
+3. If a testcontainer job failed, the job summary includes a "Testcontainer
+   diagnostics" block (docker state, memory, OOM kills) to distinguish an
+   infra flake from a logic bug.
+
+Do not spend time debugging a failure classified as flaky/infra. If a test is
+persistently flaky, raise it rather than patching around it.
+
 ## Project Context
 
 - Tech stack: Go 1.24+, Svelte 5, TypeScript, Tailwind v4.1


### PR DESCRIPTION
## What

Refactors the `golangci-test` pipeline so PR feedback is faster and failures are interpretable by humans and by LLM coding agents.

- **Shard the unit suite** across 4 parallel runners (`fail-fast: false`) using a deterministic `go list` modulo split, cutting wall-clock from ~8m toward ~3m. New packages are picked up automatically; no hand-maintained lists.
- **Run every Go test job through `gotestsum`** with one automatic rerun (`--rerun-fails=1`). A test that fails once then passes is reported as flaky, not a gate failure. `--rerun-fails-abort-on-data-race` keeps real data races fatal (a race is never retried away).
- **Fix the testcontainer MySQL flake at the source.** The MySQL-backed packages now run with `go test -p 1`. Running several MySQL 8 containers in parallel exhausted runner memory and got one reaped mid-test, surfacing as `connection refused` / `No such container` and reading like a logic bug. One container set at a time removes the race.
- **Capture diagnostics on testcontainer failure** (docker state, memory, kernel OOM kills) so an infra flake is diagnosable instead of a mystery `FAIL`.
- **Consolidated `test-report` job**: one job summary plus one `ci-failures.json` artifact that classifies every failure as a real regression vs a flaky-on-rerun blip. This is the "one place to look" for a human or an LLM agent.
- **Concurrency group** so superseded runs are cancelled.
- **AGENTS.md** documents how to read the new output.

## Why

A recent run on the dep-update PR failed with a batch of `--- FAIL: TestMySQL_*` errors that were pure testcontainer infra flake (`dial tcp ...: connect: connection refused`, `No such container`), not a code regression. There was no machine-readable signal saying "this is known-flaky infra," so an agent picking up the PR would burn tokens "fixing" healthy code. This change removes that failure mode at the source and makes the remaining flakes self-classifying.

## Verification

CI-config and one new bash helper; no application code changes.

- `actionlint` clean on the workflow.
- `shellcheck` clean on `.github/scripts/ci-test-report.sh`.
- Local smoke test of the classifier against synthetic pass / regression / flaky event streams (regressions and flakes classify correctly, output captured).
- `gotestsum` invocation (`--packages`, `--rerun-fails`, `--jsonfile`, `--junitfile`) verified locally.
- The real end-to-end validation is this PR's own CI run.

## Preflight Status

Standard preflight (`/preflight`) targets application code (reuse, correctness, i18n, integration wiring, regression). This change is CI configuration plus a small, shellcheck-clean, locally-tested reporting script, so the equivalent gates here are actionlint + shellcheck + the local functional test above, all green.

## Scope

One concern: modernize the Go test pipeline (speed + flake-resilience + interpretability). No application behavior changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced CI test reporting with consolidated artifacts for failures and flaky tests, including detailed summaries in the workflow results.
  * Improved CI efficiency and reliability by running tests with sharded `gotestsum` execution, standardized rerun handling, and reduced redundant run contention via concurrency.
  * Updated CI guidance in documentation to help interpret regressions vs flaky or infrastructure issues and to use the new artifacts and diagnostics effectively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->