### PR TITLE
ci: run native macOS/Windows tests on label and main, not every PR commit

### DIFF
--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -23,6 +23,9 @@ on:
       - '.github/workflows/macos-test.yml'
       - '.github/actions/**'
   pull_request:
+    # Include labeled/unlabeled so adding or removing the `full-ci` label
+    # re-evaluates the job gate immediately instead of waiting for the next push.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
       - '**/*.go'
       - 'go.mod'
@@ -41,6 +44,14 @@ concurrency:
 jobs:
   unit-tests-macos:
     name: unit-tests (macos-arm64)
+    # Demoted off the per-commit PR critical path: this native run is slow (~20m)
+    # and already advisory (continue-on-error). It still runs on every push to
+    # main and on workflow_dispatch; on a PR it runs only when the `full-ci`
+    # label is present. A skipped job reports as success, so adding it as a
+    # required check later will not deadlock label-less PRs.
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
     runs-on: macos-latest
     # Non-blocking until the pre-existing macOS test failures are fixed.
     continue-on-error: true

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -22,6 +22,9 @@ on:
       - '.github/workflows/windows-test.yml'
       - '.github/actions/**'
   pull_request:
+    # Include labeled/unlabeled so adding or removing the `full-ci` label
+    # re-evaluates the job gate immediately instead of waiting for the next push.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
       - '**/*.go'
       - 'go.mod'
@@ -40,6 +43,14 @@ concurrency:
 jobs:
   unit-tests-windows:
     name: unit-tests (windows-amd64)
+    # Demoted off the per-commit PR critical path: this native run is slow (~25m)
+    # and already advisory (continue-on-error). It still runs on every push to
+    # main and on workflow_dispatch; on a PR it runs only when the `full-ci`
+    # label is present. A skipped job reports as success, so adding it as a
+    # required check later will not deadlock label-less PRs.
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
     runs-on: windows-latest
     # Non-blocking until the native Windows CGO/DLL path is proven stable.
     continue-on-error: true


### PR DESCRIPTION
## What

Takes the native `macos-test` (~20m) and `windows-test` (~25m) jobs off the per-commit PR critical path.

Both jobs run a native `-race` unit subset and are already advisory (`continue-on-error: true`). They now run:

- on every push to `main` (post-merge coverage),
- on `workflow_dispatch`,
- and on a pull request **only when the `full-ci` label is present**.

A label-less PR skips the job, which reports as success, so promoting either to a required check later will not deadlock unlabeled PRs.

## Why

Running ~45 minutes of advisory native test runtime on every PR commit is slow and rarely catches PR-specific regressions. Keeping push-to-main coverage means a platform regression is still caught promptly (next merge), and the `full-ci` label gives per-PR opt-in when a change is platform-sensitive.

The cheap cross-compile smoke (`cross-platform-build`) is intentionally left running on every PR; it is fast and catches real cross-platform compile breakage.

## Verification

CI-config only; no application code changes. `actionlint` clean.

## Preflight Status

No application code in this change; the relevant gate is actionlint, which is green. The job-skip-as-success behavior is the documented GitHub semantics for job-level `if:` on required checks.

## Scope

One concern: change when native macOS/Windows tests run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS and Windows test jobs to run on pull requests only when the `full-ci` label is present.
  * Continued to run these checks for direct pushes and manual workflow runs.
  * Kept the jobs non-blocking, so they won’t fail the overall pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->