### PR TITLE
ci: pin ubuntu-24.04 runners and harden i18n workflow

### DIFF
--- a/.github/workflows/automated-support-engineer.yml
+++ b/.github/workflows/automated-support-engineer.yml
@@ -12,7 +12,7 @@ jobs:
     if: |
       (github.event_name == 'issues' && github.event.issue.user.login != 'tphakala' && !contains(github.event.issue.user.type, 'Bot')) ||
       (github.event_name == 'issue_comment' && github.event.comment.user.login != 'tphakala' && !contains(github.event.comment.user.type, 'Bot') && !contains(github.event.comment.body, '🤖 Automated Support'))
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/automated-test-engineer.yml
+++ b/.github/workflows/automated-test-engineer.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   create-issue-on-failure:
     if: github.event.workflow_run.conclusion == 'failure'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
       actions: read

--- a/.github/workflows/build-vm-images.yml
+++ b/.github/workflows/build-vm-images.yml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   build-vm-images:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -198,7 +198,7 @@ jobs:
   create-release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && github.event.inputs.create_release == 'true')
     needs: build-vm-images
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     
     steps:
       - name: Checkout code

--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   cleanup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Cleanup
         run: |

--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   arbitrary-uid-start:
     name: Arbitrary-UID startup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -26,7 +26,7 @@ jobs:
   # Lint is handled by golangci-test.yml workflow - no need to duplicate here
   build-and-push-docker-image:
     if: github.event_name == 'push' && github.ref_name == 'main'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout GitHub Action
         uses: actions/checkout@v7

--- a/.github/workflows/frontend-quality.yml
+++ b/.github/workflows/frontend-quality.yml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   lint:
     name: Lint & Type Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -62,7 +62,7 @@ jobs:
 
   test:
     name: Unit Tests & Security
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -97,7 +97,7 @@ jobs:
 
   build:
     name: Build & Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -137,7 +137,7 @@ jobs:
     name: Frontend Quality Gate
     needs: [lint, test, build]
     if: ${{ !cancelled() }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check results
         run: |

--- a/.github/workflows/i18n-validation.yml
+++ b/.github/workflows/i18n-validation.yml
@@ -14,6 +14,17 @@ on:
       - 'frontend/static/messages/*.json'
       - 'frontend/src/lib/i18n/**'
 
+permissions:
+  contents: read
+  # The "Comment on PR" step (actions/github-script -> issues.createComment)
+  # posts the i18n validation results on the PR, which needs pull-requests write.
+  pull-requests: write
+
+# Cancel superseded runs for the same ref so rapid pushes do not pile up.
+concurrency:
+  group: i18n-validation-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate-translations:
     runs-on: ubuntu-24.04

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -169,7 +169,7 @@ jobs:
   release:
     name: Create GitHub Release
     needs: nightly
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Get Build Version
         id: get_build_version
@@ -233,7 +233,7 @@ jobs:
       contents: write
 
   get-version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.get_version.outputs.version }}
     steps:
@@ -268,7 +268,7 @@ jobs:
   cleanup:
     name: Cleanup old nightly releases
     needs: release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # Run cleanup even if some builds failed, but not if cancelled
     if: ${{ !cancelled() }}
     steps:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -182,7 +182,7 @@ jobs:
   checksums:
     if: ${{ !contains(github.ref, 'nightly') && (github.event_name == 'release' || github.event_name == 'workflow_dispatch') }}
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -222,7 +222,7 @@ jobs:
 
   get-version:
     if: ${{ !contains(github.ref, 'nightly') && (github.event_name == 'release' || github.event_name == 'workflow_dispatch') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.get_version.outputs.version }}
     steps:

--- a/.github/workflows/release-manifest.yml
+++ b/.github/workflows/release-manifest.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   manifest:
     name: Generate and publish manifest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/update-authors.yml
+++ b/.github/workflows/update-authors.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   update-authors:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/update-licenses.yml
+++ b/.github/workflows/update-licenses.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   update-licenses:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/virustotal.yml
+++ b/.github/workflows/virustotal.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   scan:
     name: Scan Release Assets
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Get latest release ID
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   sync:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7


### PR DESCRIPTION
## What

A small CI hygiene pass:

- Replace `runs-on: ubuntu-latest` with `runs-on: ubuntu-24.04` across all workflows that still used the floating alias. The test workflows were already pinned; this brings the rest (docker, nightly, release, frontend-quality, automation, etc.) in line so a future GitHub bump of `ubuntu-latest` cannot silently change the build/test environment.
- Add a `concurrency` group (`cancel-in-progress`) and a top-level `permissions: contents: read` to `i18n-validation.yml`. It was the only PR-triggered workflow missing both.

## Why

`ubuntu-latest` is a moving target; pinning makes runs reproducible and matches the convention the Go test workflows already follow. The missing concurrency group meant superseded i18n runs ran to completion; the missing top-level permissions left the default token scope wider than needed.

Workflows that legitimately need write scope (the automation and license-update workflows) were intentionally left without a read-only top-level block.

## Verification

CI-config only; no application code changes. `actionlint` clean (pre-existing shellcheck style/info notes in untouched script blocks are unchanged).

## Preflight Status

No application code in this change; the relevant gate is actionlint, which is green.

## Scope

One concern: CI runner/permission hygiene.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated multiple automation and CI jobs to run on Ubuntu 24.04 for a more consistent build environment.
  * Pinned several scheduled and release-related workflows to the newer runner image.

* **Bug Fixes**
  * Added concurrency controls to i18n validation so newer runs cancel outdated ones.
  * Set read-only repository access for i18n validation to align with its required permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->