### PR TITLE
ci: pin third-party actions to commit SHAs

### DIFF
--- a/.github/actions/setup-tensorflow/action.yml
+++ b/.github/actions/setup-tensorflow/action.yml
@@ -20,7 +20,7 @@ runs:
         key: ${{ runner.os }}-tensorflow-cache-${{ inputs.tflite-version }}
 
     - name: Install Task
-      uses: arduino/setup-task@v2
+      uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
       with:
         version: 3.x
         repo-token: ${{ github.token }}

--- a/.github/workflows/build-vm-images.yml
+++ b/.github/workflows/build-vm-images.yml
@@ -74,7 +74,7 @@ jobs:
           echo "  ARM64: $(qemu-system-aarch64 --version | head -1)"
 
       - name: Setup Packer
-        uses: hashicorp/setup-packer@main
+        uses: hashicorp/setup-packer@ce93c3c08a6c2ff2275bf4b54ff0d9a75f6c9789 # v3.4.0
         with:
           version: ${{ env.PACKER_VERSION }}
 
@@ -293,7 +293,7 @@ jobs:
           EOF
 
       - name: Create Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           tag_name: ${{ steps.version.outputs.version }}
           name: "BirdNET-Go VM Images ${{ steps.version.outputs.version }}"

--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -39,10 +39,10 @@ jobs:
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Build container image (amd64, load locally)
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           load: true
@@ -72,10 +72,10 @@ jobs:
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Build container image (arm64 ONNX-only, load locally)
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           load: true

--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -146,7 +146,7 @@ jobs:
       - run: go version
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -75,7 +75,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Generate repository names
         id: repo-names
@@ -181,7 +181,7 @@ jobs:
           echo "Generated tags: $TAGS"
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         id: build-push
         with:
           context: .

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -49,10 +49,10 @@ jobs:
           echo "REPO=${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Build and push container images
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           push: true

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -28,7 +28,7 @@ jobs:
           echo "VERSION_NO_V=${LATEST_TAG#v}" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Login to GitHub Container Registry
         run: |
@@ -49,7 +49,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           images: ghcr.io/${{ env.REPO }}
           tags: |
@@ -58,7 +58,7 @@ jobs:
             type=raw,value=latest-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           push: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: golangci-lint
         id: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.

--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -81,7 +81,7 @@ jobs:
         run: brew install ffmpeg sox
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -63,7 +63,7 @@ jobs:
           sudo ln -sf "$aarch64_gcc" /usr/bin/aarch64-linux-gnu-gcc
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -275,7 +275,7 @@ jobs:
       - name: Delete old releases
         # Non-critical cleanup - don't fail the workflow if this errors
         continue-on-error: true
-        uses: dev-drprasad/delete-older-releases@v0.3.4
+        uses: dev-drprasad/delete-older-releases@dfbe6be2a006e9475dfcbe5b8d201f1824c2a9fe # v0.3.4
         with:
           keep_latest: 14
           delete_tags: true

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -69,7 +69,7 @@ jobs:
           sudo ln -sf "$aarch64_gcc" /usr/bin/aarch64-linux-gnu-gcc
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -170,7 +170,7 @@ jobs:
           echo "latest_tag=${LATEST_TAG}" >> "${GITHUB_OUTPUT}"
       
       - name: Add Artifacts to GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           files: birdnet-go-${{ matrix.goos }}-${{ matrix.goarch }}-${{ github.ref_name }}.tar.gz
           # For release events, use the triggering release
@@ -211,7 +211,7 @@ jobs:
           echo "LATEST_TAG=${LATEST_TAG}" >> "${GITHUB_ENV}"
 
       - name: Add checksums to GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           files: checksums.txt
           # For release events, attach to the triggering release; for

--- a/.github/workflows/update-authors.yml
+++ b/.github/workflows/update-authors.yml
@@ -53,7 +53,7 @@ jobs:
           EOL
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'docs: update AUTHORS file with current contributors'

--- a/.github/workflows/update-licenses.yml
+++ b/.github/workflows/update-licenses.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Create Pull Request
         id: create-pr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'docs: update dependency licenses'
@@ -98,7 +98,7 @@ jobs:
 
       - name: Auto-approve PR
         if: steps.create-pr.outputs.pull-request-number
-        uses: hmarr/auto-approve-action@v4
+        uses: hmarr/auto-approve-action@8f929096a962e83ccdfa8afcf855f39f12d4dac7 # v4
         with:
           pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
           review-message: "Auto-approved dependency license update"

--- a/.github/workflows/virustotal.yml
+++ b/.github/workflows/virustotal.yml
@@ -22,7 +22,7 @@ jobs:
           RELEASE_ID=$(gh api repos/${{ github.repository }}/releases/latest --jq '.id')
           echo "id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
 
-      - uses: cssnr/virustotal-action@v2
+      - uses: cssnr/virustotal-action@5edfa4c982eb0caec6d568ea27cf715269f5c23b # v2
         with:
           vt_api_key: ${{ secrets.VT_API_KEY }}
           release_id: ${{ steps.release.outputs.id || '' }}


### PR DESCRIPTION
## What

Supply-chain hardening: pin every third-party (non `actions/*`) GitHub Action to a full commit SHA with a `# version` comment, matching the existing `cache-apt-pkgs-action` convention already used in the repo.

Pinned: `docker/setup-buildx-action`, `docker/build-push-action`, `docker/metadata-action`, `arduino/setup-task`, `softprops/action-gh-release`, `peter-evans/create-pull-request`, `hmarr/auto-approve-action`, `golangci/golangci-lint-action`, `dev-drprasad/delete-older-releases`, `cssnr/virustotal-action`. `hashicorp/setup-packer` moved off the floating `@main` branch to the v3.4.0 SHA.

## Why

A mutable tag (or a branch like `@main`) can be repointed at malicious code after a maintainer has reviewed the workflow. A commit SHA cannot. This matters most because community PRs execute this CI. The `# vX` comments keep the refs human-readable and let the already-configured Dependabot `github-actions` ecosystem bump the SHAs automatically.

## Scope decisions

- GitHub-owned `actions/*` (checkout, setup-go, cache, etc.) are left on major tags, consistent with the existing repo convention and also Dependabot-managed.
- `anthropics/claude-code-action` stays on `@beta`: it is a deliberately-tracked beta channel for an evolving tool, and Dependabot cannot bump a non-semver SHA pin (pinning would silently freeze it).

## Verification

CI-config only; no application code changes. SHAs were resolved programmatically via the GitHub API (the commit each tag points to), so the pins are correct by construction. Verified with actionlint (workflow structure) and a YAML parse of the composite action. The high-traffic pins (docker/*, arduino/setup-task, golangci-lint-action) are exercised by this PR's own `container-test` and `cross-platform-build` runs.

## Preflight Status

No application code; the relevant gates are actionlint (clean) + API-resolved SHA correctness + this PR's CI. Release/nightly-only workflows are not PR-triggered, but their pins use the same API-resolved SHAs and pass actionlint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned several GitHub Actions to fixed revisions across build, test, release, and maintenance workflows.
  * Improved workflow consistency by replacing floating version tags with specific commits for tools used in container builds, releases, linting, and automated PR updates.
  * No product behavior, build outputs, or test logic was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->