### PR TITLE
feat(ui): hide audio player and spectrogram when clip export is off

### DIFF
--- a/frontend/src/lib/desktop/components/modals/ReviewModal.svelte
+++ b/frontend/src/lib/desktop/components/modals/ReviewModal.svelte
@@ -13,6 +13,7 @@
   import { t } from '$lib/i18n';
   import { safeArrayAccess } from '$lib/utils/security';
   import { isAuthenticated } from '$lib/utils/auth';
+  import { appState } from '$lib/stores/appState.svelte';
 
   interface Props {
     isOpen: boolean;
@@ -30,6 +31,8 @@
   let { isOpen = false, detection = null, isExcluded = false, onClose, onSave }: Props = $props();
 
   let clipExtractionEnabled = $derived($isAuthenticated);
+  // Hide the audio/spectrogram block when audio clip export is disabled.
+  let audioEnabled = $derived(appState.audioExportEnabled);
 
   let reviewStatus = $state<'correct' | 'false_positive'>('correct');
   let lockDetection = $state(false);
@@ -204,21 +207,23 @@
             </div>
           </div>
 
-          <!-- Audio and Spectrogram -->
-          <div class="relative bg-[var(--color-base-200)] rounded-lg p-4">
-            <AudioPlayer
-              audioUrl={buildAppUrl(`/api/v2/audio/${detection.id}`)}
-              detectionId={detection.id.toString()}
-              showSpectrogram={true}
-              spectrogramSize="lg"
-              spectrogramRaw={false}
-              responsive={true}
-              className="w-full mx-auto"
-              enableClipExtraction={clipExtractionEnabled}
-              clipLabel={`${detection.commonName}_${detection.date}_${detection.time.replace(/:/g, '-')}`}
-              modelType={detection.modelType}
-            />
-          </div>
+          <!-- Audio and Spectrogram (hidden when audio clip export is disabled) -->
+          {#if audioEnabled}
+            <div class="relative bg-[var(--color-base-200)] rounded-lg p-4">
+              <AudioPlayer
+                audioUrl={buildAppUrl(`/api/v2/audio/${detection.id}`)}
+                detectionId={detection.id.toString()}
+                showSpectrogram={true}
+                spectrogramSize="lg"
+                spectrogramRaw={false}
+                responsive={true}
+                className="w-full mx-auto"
+                enableClipExtraction={clipExtractionEnabled}
+                clipLabel={`${detection.commonName}_${detection.date}_${detection.time.replace(/:/g, '-')}`}
+                modelType={detection.modelType}
+              />
+            </div>
+          {/if}
         </div>
 
         <!-- Right Column: Review Controls -->

--- a/frontend/src/lib/desktop/features/dashboard/components/DetectionCard.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/DetectionCard.svelte
@@ -42,6 +42,8 @@
     detection: Detection;
     isNew?: boolean;
     isExcluded?: boolean;
+    /** When false (audio export disabled), the card hides the spectrogram and audio controls */
+    audioEnabled?: boolean;
     onFreezeStart?: () => void;
     onFreezeEnd?: () => void;
     onReview?: () => void;
@@ -56,6 +58,7 @@
     detection,
     isNew = false,
     isExcluded = false,
+    audioEnabled = true,
     onFreezeStart,
     onFreezeEnd,
     onReview,
@@ -107,9 +110,10 @@
     onFreezeEnd?.();
   }
 
-  // Start/stop loader based on visibility
+  // Start/stop loader based on visibility. Skip entirely when audio export is
+  // disabled: no clips exist, so there is no spectrogram to fetch.
   $effect(() => {
-    if (isVisible) {
+    if (audioEnabled && isVisible) {
       loader.start(detection.id);
     } else {
       loader.stop();
@@ -159,43 +163,49 @@
   )}
 >
   <!-- Inner container with overflow-hidden for spectrogram clipping -->
-  <div class="detection-card-inner">
-    <!-- Spectrogram Background -->
-    <div class="spectrogram-container">
-      {#if loader.showSpinner}
-        <div class="spectrogram-loading">
-          <span class="loading loading-spinner loading-md text-[var(--color-base-content)]/50"
-          ></span>
-          {#if loader.isQueued}
-            <span class="text-xs text-[var(--color-base-content)]/40 mt-1"
-              >{t('components.audio.waiting')}</span
-            >
-          {:else if loader.isGenerating}
-            <span class="text-xs text-[var(--color-base-content)]/40 mt-1"
-              >{t('components.audio.generating')}</span
-            >
-          {/if}
-        </div>
-      {/if}
+  <!-- Compact (shorter) layout when there is no spectrogram to display -->
+  <div class="detection-card-inner" class:compact={!audioEnabled}>
+    <!-- Spectrogram Background (hidden when audio export is disabled) -->
+    {#if audioEnabled}
+      <div class="spectrogram-container">
+        {#if loader.showSpinner}
+          <div class="spectrogram-loading">
+            <span class="loading loading-spinner loading-md text-[var(--color-base-content)]/50"
+            ></span>
+            {#if loader.isQueued}
+              <span class="text-xs text-[var(--color-base-content)]/40 mt-1"
+                >{t('components.audio.waiting')}</span
+              >
+            {:else if loader.isGenerating}
+              <span class="text-xs text-[var(--color-base-content)]/40 mt-1"
+                >{t('components.audio.generating')}</span
+              >
+            {/if}
+          </div>
+        {/if}
 
-      {#if loader.error}
-        <div class="spectrogram-error">
-          <span class="text-sm text-[var(--color-base-content)]/50"
-            >{t('components.audio.spectrogramUnavailable')}</span
-          >
-        </div>
-      {:else if loader.spectrogramUrl}
-        <img
-          src={loader.spectrogramUrl}
-          alt={t('components.audio.spectrogramForSpecies', { species: detection.commonName })}
-          class="spectrogram-image"
-          class:opacity-0={loader.state === 'loading'}
-          decoding="async"
-          onload={() => loader.handleImageLoad()}
-          onerror={() => loader.handleImageError()}
-        />
-      {/if}
-    </div>
+        {#if loader.error}
+          <div class="spectrogram-error">
+            <span class="text-sm text-[var(--color-base-content)]/50"
+              >{t('components.audio.spectrogramUnavailable')}</span
+            >
+          </div>
+        {:else if loader.spectrogramUrl}
+          <img
+            src={loader.spectrogramUrl}
+            alt={t('components.audio.spectrogramForSpecies', { species: detection.commonName })}
+            class="spectrogram-image"
+            class:opacity-0={loader.state === 'loading'}
+            decoding="async"
+            onload={() => loader.handleImageLoad()}
+            onerror={() => loader.handleImageError()}
+          />
+        {/if}
+      </div>
+    {:else}
+      <!-- Neutral background placeholder keeps the card's shape/aspect ratio -->
+      <div class="spectrogram-container spectrogram-placeholder"></div>
+    {/if}
 
     <!-- Top-Left Badges: Confidence + Weather -->
     <div class="absolute top-3 left-3 flex items-center gap-2 z-10">
@@ -215,16 +225,18 @@
       <SourceBadge {detection} variant="overlay" />
     </div>
 
-    <!-- Center Play Button -->
-    <PlayOverlay
-      detectionId={detection.id}
-      {onFreezeStart}
-      {onFreezeEnd}
-      gainValue={audioGainValue}
-      filterFreq={audioFilterFreq}
-      playbackSpeed={audioPlaybackSpeed}
-      onAudioContextAvailable={handleAudioContextAvailable}
-    />
+    <!-- Center Play Button (hidden when audio export is disabled) -->
+    {#if audioEnabled}
+      <PlayOverlay
+        detectionId={detection.id}
+        {onFreezeStart}
+        {onFreezeEnd}
+        gainValue={audioGainValue}
+        filterFreq={audioFilterFreq}
+        playbackSpeed={audioPlaybackSpeed}
+        onAudioContextAvailable={handleAudioContextAvailable}
+      />
+    {/if}
 
     <!-- Bottom Species Info Bar -->
     <SpeciesInfoBar {detection} />
@@ -232,18 +244,20 @@
 
   <!-- Top-Right Controls - OUTSIDE overflow-hidden container -->
   <div class="absolute top-2 right-2 z-50 flex items-center gap-1.5">
-    <AudioSettingsButton
-      gainValue={audioGainValue}
-      filterFreq={audioFilterFreq}
-      playbackSpeed={audioPlaybackSpeed}
-      defaultGainValue={getDefaultAudioGain()}
-      onGainChange={handleGainChange}
-      onFilterChange={handleFilterChange}
-      onSpeedChange={handleSpeedChange}
-      disabled={!audioContextAvailable}
-      onMenuOpen={handleAudioSettingsOpen}
-      onMenuClose={handleAudioSettingsClose}
-    />
+    {#if audioEnabled}
+      <AudioSettingsButton
+        gainValue={audioGainValue}
+        filterFreq={audioFilterFreq}
+        playbackSpeed={audioPlaybackSpeed}
+        defaultGainValue={getDefaultAudioGain()}
+        onGainChange={handleGainChange}
+        onFilterChange={handleFilterChange}
+        onSpeedChange={handleSpeedChange}
+        disabled={!audioContextAvailable}
+        onMenuOpen={handleAudioSettingsOpen}
+        onMenuClose={handleAudioSettingsClose}
+      />
+    {/if}
     <ActionMenu
       {detection}
       {isExcluded}
@@ -254,7 +268,7 @@
       {onToggleSpecies}
       {onToggleLock}
       {onDelete}
-      onDownload={() => downloadDetectionAudio(detection)}
+      onDownload={audioEnabled ? () => downloadDetectionAudio(detection) : undefined}
       onMenuOpen={handleMenuOpen}
       onMenuClose={handleMenuClose}
     />
@@ -271,6 +285,12 @@
     height: 15rem; /* ~240px - taller for better spectrogram visibility, especially low frequencies */
     border-radius: 0.75rem;
     overflow: hidden;
+  }
+
+  /* Without a spectrogram, the card only needs room for the top badges and the
+     bottom species-info bar, so collapse the reserved height. */
+  .detection-card-inner.compact {
+    height: 7rem; /* ~112px - fits badges + species-info bar without overlap */
   }
 
   /* Spectrogram container */
@@ -293,7 +313,8 @@
   }
 
   .spectrogram-loading,
-  .spectrogram-error {
+  .spectrogram-error,
+  .spectrogram-placeholder {
     position: absolute;
     inset: 0;
     display: flex;
@@ -309,7 +330,8 @@
 
   /* Dark theme spectrogram background */
   :global([data-theme='dark']) .spectrogram-loading,
-  :global([data-theme='dark']) .spectrogram-error {
+  :global([data-theme='dark']) .spectrogram-error,
+  :global([data-theme='dark']) .spectrogram-placeholder {
     background: linear-gradient(135deg, rgb(30 41 59 / 0.9) 0%, rgb(15 23 42 / 0.95) 100%);
   }
 

--- a/frontend/src/lib/desktop/features/dashboard/components/DetectionCardGrid.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/DetectionCardGrid.svelte
@@ -37,8 +37,13 @@
     setExcluded,
     hydrateExcludedSpecies,
   } from '$lib/stores/excludedSpecies.svelte';
+  import { appState } from '$lib/stores/appState.svelte';
 
   const logger = loggers.ui;
+
+  // When audio clip export is disabled, no clips/spectrograms exist, so the
+  // detection cards render in their compact (media-free) form.
+  let audioEnabled = $derived(appState.audioExportEnabled);
 
   interface Props {
     data: Detection[];
@@ -271,6 +276,7 @@
           {#each data.slice(0, selectedLimit) as detection (detection.id)}
             <DetectionCard
               {detection}
+              {audioEnabled}
               isNew={newDetectionIds.has(detection.id)}
               isExcluded={isSpeciesExcluded(detection.commonName)}
               {onFreezeStart}

--- a/frontend/src/lib/desktop/features/detections/components/DetectionCardMobile.svelte
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionCardMobile.svelte
@@ -25,6 +25,8 @@
   // passes them in as callbacks plus the server-hydrated isExcluded state.
   interface Props {
     detection: Detection;
+    /** When false (audio export disabled), the card hides the spectrogram and play button */
+    audioEnabled?: boolean;
     isExcluded?: boolean;
     onDetailsClick?: (_id: number) => void;
     onReview?: () => void;
@@ -37,6 +39,7 @@
 
   let {
     detection,
+    audioEnabled = true,
     isExcluded = false,
     onDetailsClick,
     onReview,
@@ -58,7 +61,7 @@
   let audioPlaybackSpeed = $state(DEFAULT_PLAYBACK_SPEED);
 
   $effect(() => {
-    if (isVisible) {
+    if (audioEnabled && isVisible) {
       loader.start(detection.id);
     } else {
       loader.stop();
@@ -110,43 +113,49 @@
   class={cn('detection-card group relative rounded-xl', isMenuOpen && 'z-[60]')}
 >
   <!-- Inner container with overflow-hidden for spectrogram clipping -->
-  <div class="detection-card-inner">
-    <!-- Spectrogram Background -->
-    <div class="spectrogram-container">
-      {#if loader.showSpinner}
-        <div class="spectrogram-loading">
-          <span class="loading loading-spinner loading-md text-[var(--color-base-content)]/50"
-          ></span>
-          {#if loader.isQueued}
-            <span class="text-xs text-[var(--color-base-content)]/40 mt-1"
-              >{t('components.audio.waiting')}</span
-            >
-          {:else if loader.isGenerating}
-            <span class="text-xs text-[var(--color-base-content)]/40 mt-1"
-              >{t('components.audio.generating')}</span
-            >
-          {/if}
-        </div>
-      {/if}
+  <!-- Compact (shorter) layout when there is no spectrogram to display -->
+  <div class="detection-card-inner" class:compact={!audioEnabled}>
+    <!-- Spectrogram Background (hidden when audio export is disabled) -->
+    {#if audioEnabled}
+      <div class="spectrogram-container">
+        {#if loader.showSpinner}
+          <div class="spectrogram-loading">
+            <span class="loading loading-spinner loading-md text-[var(--color-base-content)]/50"
+            ></span>
+            {#if loader.isQueued}
+              <span class="text-xs text-[var(--color-base-content)]/40 mt-1"
+                >{t('components.audio.waiting')}</span
+              >
+            {:else if loader.isGenerating}
+              <span class="text-xs text-[var(--color-base-content)]/40 mt-1"
+                >{t('components.audio.generating')}</span
+              >
+            {/if}
+          </div>
+        {/if}
 
-      {#if loader.error}
-        <div class="spectrogram-error">
-          <span class="text-sm text-[var(--color-base-content)]/50"
-            >{t('components.audio.spectrogramUnavailable')}</span
-          >
-        </div>
-      {:else if loader.spectrogramUrl}
-        <img
-          src={loader.spectrogramUrl}
-          alt={t('components.audio.spectrogramForSpecies', { species: detection.commonName })}
-          class="spectrogram-image"
-          class:opacity-0={loader.state === 'loading'}
-          decoding="async"
-          onload={() => loader.handleImageLoad()}
-          onerror={() => loader.handleImageError()}
-        />
-      {/if}
-    </div>
+        {#if loader.error}
+          <div class="spectrogram-error">
+            <span class="text-sm text-[var(--color-base-content)]/50"
+              >{t('components.audio.spectrogramUnavailable')}</span
+            >
+          </div>
+        {:else if loader.spectrogramUrl}
+          <img
+            src={loader.spectrogramUrl}
+            alt={t('components.audio.spectrogramForSpecies', { species: detection.commonName })}
+            class="spectrogram-image"
+            class:opacity-0={loader.state === 'loading'}
+            decoding="async"
+            onload={() => loader.handleImageLoad()}
+            onerror={() => loader.handleImageError()}
+          />
+        {/if}
+      </div>
+    {:else}
+      <!-- Neutral background placeholder keeps the card's shape/aspect ratio -->
+      <div class="spectrogram-container spectrogram-placeholder"></div>
+    {/if}
 
     <!-- Top-Left Badges: Confidence + Weather -->
     <div class="absolute top-3 left-3 flex items-center gap-2 z-10">
@@ -166,13 +175,15 @@
       <SourceBadge {detection} variant="overlay" />
     </div>
 
-    <!-- Center Play Button -->
-    <PlayOverlay
-      detectionId={detection.id}
-      gainValue={audioGainValue}
-      filterFreq={audioFilterFreq}
-      playbackSpeed={audioPlaybackSpeed}
-    />
+    <!-- Center Play Button (hidden when audio export is disabled) -->
+    {#if audioEnabled}
+      <PlayOverlay
+        detectionId={detection.id}
+        gainValue={audioGainValue}
+        filterFreq={audioFilterFreq}
+        playbackSpeed={audioPlaybackSpeed}
+      />
+    {/if}
 
     <!-- Bottom Species Info Bar: tappable for all auth levels to view details -->
     <button
@@ -197,7 +208,7 @@
       {onToggleSpecies}
       {onToggleLock}
       {onDelete}
-      onDownload={() => downloadDetectionAudio(detection)}
+      onDownload={audioEnabled ? () => downloadDetectionAudio(detection) : undefined}
       onMenuOpen={handleMenuOpen}
       onMenuClose={handleMenuClose}
     />
@@ -214,6 +225,11 @@
     height: 15rem;
     border-radius: 0.75rem;
     overflow: hidden;
+  }
+
+  /* Without a spectrogram, collapse to fit the badges + species-info bar only. */
+  .detection-card-inner.compact {
+    height: 7rem;
   }
 
   .spectrogram-container {
@@ -235,7 +251,8 @@
   }
 
   .spectrogram-loading,
-  .spectrogram-error {
+  .spectrogram-error,
+  .spectrogram-placeholder {
     position: absolute;
     inset: 0;
     display: flex;
@@ -250,7 +267,8 @@
   }
 
   :global([data-theme='dark']) .spectrogram-loading,
-  :global([data-theme='dark']) .spectrogram-error {
+  :global([data-theme='dark']) .spectrogram-error,
+  :global([data-theme='dark']) .spectrogram-placeholder {
     background: linear-gradient(135deg, rgb(30 41 59 / 0.9) 0%, rgb(15 23 42 / 0.95) 100%);
   }
 </style>

--- a/frontend/src/lib/desktop/features/detections/components/DetectionRow.svelte
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionRow.svelte
@@ -49,6 +49,8 @@
   // passes them in as callbacks plus the server-hydrated isExcluded state.
   interface Props {
     detection: Detection;
+    /** When false (audio export disabled), the Recording cell is omitted */
+    audioEnabled?: boolean;
     isExcluded?: boolean;
     onDetailsClick?: (_id: number) => void;
     selectionActive?: boolean;
@@ -64,6 +66,7 @@
 
   let {
     detection,
+    audioEnabled = true,
     isExcluded = false,
     onDetailsClick,
     selectionActive = false,
@@ -277,14 +280,16 @@
   <VerificationBadges {detection} />
 </td>
 
-<!-- Recording/Spectrogram -->
-<td class="hidden md:table-cell">
-  <SpectrogramPlayer
-    audioUrl={buildAppUrl(`/api/v2/audio/${detection.id}`)}
-    detectionId={detection.id.toString()}
-    spectrogramSize="md"
-  />
-</td>
+<!-- Recording/Spectrogram (omitted when audio export is disabled) -->
+{#if audioEnabled}
+  <td class="hidden md:table-cell">
+    <SpectrogramPlayer
+      audioUrl={buildAppUrl(`/api/v2/audio/${detection.id}`)}
+      detectionId={detection.id.toString()}
+      spectrogramSize="md"
+    />
+  </td>
+{/if}
 
 <!-- Action Menu -->
 <td onclick={e => e.stopPropagation()}>

--- a/frontend/src/lib/desktop/features/detections/components/DetectionRow.test.ts
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionRow.test.ts
@@ -107,3 +107,25 @@ describe('DetectionRow action callbacks', () => {
     expect(onMarkFalsePositive).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('DetectionRow recording cell gating (audioEnabled)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the spectrogram/recording cell by default', () => {
+    const { container } = render(DetectionRow, {
+      props: { detection: createMockDetection({ id: 600 }) },
+    });
+
+    expect(container.querySelector('.spectrogram-player')).not.toBeNull();
+  });
+
+  it('omits the spectrogram/recording cell when audioEnabled is false', () => {
+    const { container } = render(DetectionRow, {
+      props: { detection: createMockDetection({ id: 601 }), audioEnabled: false },
+    });
+
+    expect(container.querySelector('.spectrogram-player')).toBeNull();
+  });
+});

--- a/frontend/src/lib/desktop/features/detections/components/DetectionsCardView.svelte
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionsCardView.svelte
@@ -14,6 +14,7 @@
   import type { Detection } from '$lib/types/detection.types';
   import { isExcluded as isSpeciesExcluded, setExcluded } from '$lib/stores/excludedSpecies.svelte';
   import { useDetectionActions } from '../composables/useDetectionActions.svelte';
+  import { appState } from '$lib/stores/appState.svelte';
 
   interface Props {
     detections: Detection[];
@@ -21,6 +22,9 @@
   }
 
   let { detections, onRefresh }: Props = $props();
+
+  // Hide spectrogram/audio on the cards when audio clip export is disabled.
+  let audioEnabled = $derived(appState.audioExportEnabled);
 
   // Exclusion state is the shared, server-hydrated excludedSpecies store
   // (hydrated by the parent DetectionsList).
@@ -35,6 +39,7 @@
   {#each detections as detection (detection.id)}
     <DetectionCard
       {detection}
+      {audioEnabled}
       isExcluded={isSpeciesExcluded(detection.commonName)}
       onMarkCorrect={() => actions.handleMarkCorrect(detection)}
       onMarkFalsePositive={() => actions.handleMarkFalsePositive(detection)}

--- a/frontend/src/lib/desktop/features/detections/components/DetectionsList.svelte
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionsList.svelte
@@ -67,6 +67,11 @@
   import DetectionCardMobile from './DetectionCardMobile.svelte';
   import DetectionRow from './DetectionRow.svelte';
   import DetectionsCardView from './DetectionsCardView.svelte';
+  import { appState } from '$lib/stores/appState.svelte';
+
+  // When audio clip export is disabled there are no clips/spectrograms, so the
+  // Recording column (and the mobile/card spectrogram) is hidden.
+  let audioEnabled = $derived(appState.audioExportEnabled);
 
   type SortField = 'dateTime' | 'species' | 'confidence' | 'status';
   type SortDirection = 'asc' | 'desc';
@@ -618,8 +623,11 @@
                   direction={sortDirection}
                   onSort={handleSort}
                 />
-                <th scope="col" class="hidden md:table-cell">{t('detections.headers.recording')}</th
-                >
+                {#if audioEnabled}
+                  <th scope="col" class="hidden md:table-cell"
+                    >{t('detections.headers.recording')}</th
+                  >
+                {/if}
                 <th scope="col">{t('detections.headers.actions')}</th>
               </tr>
             </thead>
@@ -636,6 +644,7 @@
                 >
                   <DetectionRow
                     {detection}
+                    {audioEnabled}
                     {onDetailsClick}
                     isExcluded={isSpeciesExcluded(detection.commonName)}
                     selectionActive={selection.selectionActive}
@@ -662,6 +671,7 @@
         {#each data.notes as detection (detection.id)}
           <DetectionCardMobile
             {detection}
+            {audioEnabled}
             {onDetailsClick}
             isExcluded={isSpeciesExcluded(detection.commonName)}
             onReview={() => detectionActions.handleReview(detection)}

--- a/frontend/src/lib/desktop/views/DetectionDetail.svelte
+++ b/frontend/src/lib/desktop/views/DetectionDetail.svelte
@@ -29,6 +29,7 @@
   import { loggers } from '$lib/utils/logger';
   import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
   import SourceBadge from '$lib/desktop/features/dashboard/components/SourceBadge.svelte';
+  import { appState } from '$lib/stores/appState.svelte';
   import {
     Download,
     Camera,
@@ -105,6 +106,8 @@
   // Use the existing auth store pattern (same as DesktopSidebar)
   let canReview = $derived($hasReviewPermission);
   let clipExtractionEnabled = $derived($isAuthenticated);
+  // Hide the spectrogram/audio Media section when audio clip export is disabled.
+  let audioEnabled = $derived(appState.audioExportEnabled);
   let detection = $state<Detection | null>(null);
   let speciesInfo = $state<SpeciesInfo | null>(null);
   let taxonomyInfo = $state<TaxonomyInfo | null>(null);
@@ -848,42 +851,44 @@
     <!-- Hero Section -->
     {@render heroSection(detection)}
 
-    <!-- Media Section -->
-    <section class="surface-card" aria-labelledby="media-heading">
-      <div class="p-5 md:p-6">
-        <h2 id="media-heading" class="section-heading !mb-0">
-          {t('detections.media.title')}
-        </h2>
-        {#if clipExtractionEnabled}
-          <p class="text-sm text-[var(--color-base-content)]/60 mt-0.5 mb-4">
-            {t('detections.media.clipHint')}
-          </p>
-        {:else}
-          <div class="mb-3"></div>
-        {/if}
-        <div
-          role="region"
-          aria-label={t('detections.detail.aria.audioRecordingFor', {
-            name: localizeSpeciesName(detection.scientificName, detection.commonName),
-          })}
-        >
-          <div class="detail-audio-container">
-            <AudioPlayer
-              audioUrl={buildAppUrl(`/api/v2/audio/${detection.id}`)}
-              detectionId={detection.id.toString()}
-              showSpectrogram={true}
-              spectrogramSize="lg"
-              spectrogramRaw={false}
-              responsive={true}
-              className="w-full"
-              enableClipExtraction={clipExtractionEnabled}
-              clipLabel={`${detection.commonName}_${detection.date}_${detection.time.replace(/:/g, '-')}`}
-              modelType={detection.modelType}
-            />
+    <!-- Media Section (hidden when audio clip export is disabled) -->
+    {#if audioEnabled}
+      <section class="surface-card" aria-labelledby="media-heading">
+        <div class="p-5 md:p-6">
+          <h2 id="media-heading" class="section-heading !mb-0">
+            {t('detections.media.title')}
+          </h2>
+          {#if clipExtractionEnabled}
+            <p class="text-sm text-[var(--color-base-content)]/60 mt-0.5 mb-4">
+              {t('detections.media.clipHint')}
+            </p>
+          {:else}
+            <div class="mb-3"></div>
+          {/if}
+          <div
+            role="region"
+            aria-label={t('detections.detail.aria.audioRecordingFor', {
+              name: localizeSpeciesName(detection.scientificName, detection.commonName),
+            })}
+          >
+            <div class="detail-audio-container">
+              <AudioPlayer
+                audioUrl={buildAppUrl(`/api/v2/audio/${detection.id}`)}
+                detectionId={detection.id.toString()}
+                showSpectrogram={true}
+                spectrogramSize="lg"
+                spectrogramRaw={false}
+                responsive={true}
+                className="w-full"
+                enableClipExtraction={clipExtractionEnabled}
+                clipLabel={`${detection.commonName}_${detection.date}_${detection.time.replace(/:/g, '-')}`}
+                modelType={detection.modelType}
+              />
+            </div>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
+    {/if}
 
     <!-- Tabbed Content -->
     <section class="surface-card" aria-labelledby="tabs-heading">

--- a/frontend/src/lib/desktop/views/Search.svelte
+++ b/frontend/src/lib/desktop/views/Search.svelte
@@ -37,6 +37,7 @@
     PER_VISITOR_SPECIES_LOCALE_ENABLED,
   } from '$lib/stores/speciesDictionary.svelte';
   import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
+  import { appState } from '$lib/stores/appState.svelte';
 
   // SPINNER CONTROL: Set to false to disable loading spinners (reduces flickering)
   // Change back to true to re-enable spinners for testing
@@ -86,6 +87,8 @@
   type SortBy = 'date_desc' | 'date_asc' | 'species_asc' | 'confidence_desc';
 
   let clipExtractionEnabled = $derived($isAuthenticated);
+  // Hide audio players/triggers when audio clip export is disabled.
+  let audioEnabled = $derived(appState.audioExportEnabled);
   let canReview = $derived($hasReviewPermission);
 
   const logger = loggers.ui;
@@ -1141,23 +1144,25 @@
                             </div>
                           </div>
 
-                          <!-- Audio Player -->
-                          <div class="bg-[var(--color-base-200)] rounded-box p-4">
-                            <h3 class="text-lg font-semibold mb-2">
-                              {t('search.detailsPanel.audioPlayer')}
-                            </h3>
-                            <AudioPlayer
-                              audioUrl={buildAppUrl(`/api/v2/audio/${result.id}`)}
-                              detectionId={result.id}
-                              width={400}
-                              height={200}
-                              showDownload={true}
-                              showSpectrogram={true}
-                              enableClipExtraction={clipExtractionEnabled}
-                              clipLabel={`${result.commonName}_${result.timestamp.replace(/[: ]/g, '-')}`}
-                              modelType={result.modelType}
-                            />
-                          </div>
+                          <!-- Audio Player (hidden when audio clip export is disabled) -->
+                          {#if audioEnabled}
+                            <div class="bg-[var(--color-base-200)] rounded-box p-4">
+                              <h3 class="text-lg font-semibold mb-2">
+                                {t('search.detailsPanel.audioPlayer')}
+                              </h3>
+                              <AudioPlayer
+                                audioUrl={buildAppUrl(`/api/v2/audio/${result.id}`)}
+                                detectionId={result.id}
+                                width={400}
+                                height={200}
+                                showDownload={true}
+                                showSpectrogram={true}
+                                enableClipExtraction={clipExtractionEnabled}
+                                clipLabel={`${result.commonName}_${result.timestamp.replace(/[: ]/g, '-')}`}
+                                modelType={result.modelType}
+                              />
+                            </div>
+                          {/if}
                         </div>
                       </div>
                     </td>
@@ -1303,17 +1308,19 @@
                         {/if}
                       </div>
                     {/if}
-                    <button
-                      class="btn btn-primary btn-sm"
-                      onclick={() => openMobilePlayer(result)}
-                      disabled={!result.hasAudio}
-                      aria-label={t('search.detailsPanel.playAudio', {
-                        species: displayName || t('search.detailsPanel.unknownSpecies'),
-                      })}
-                    >
-                      <Volume2 class="size-4" />
-                      {t('common.actions.play')}
-                    </button>
+                    {#if audioEnabled}
+                      <button
+                        class="btn btn-primary btn-sm"
+                        onclick={() => openMobilePlayer(result)}
+                        disabled={!result.hasAudio}
+                        aria-label={t('search.detailsPanel.playAudio', {
+                          species: displayName || t('search.detailsPanel.unknownSpecies'),
+                        })}
+                      >
+                        <Volume2 class="size-4" />
+                        {t('common.actions.play')}
+                      </button>
+                    {/if}
                     <button
                       class="btn btn-outline btn-sm"
                       onclick={() => navigation.navigate(`/ui/detections/${result.id}`)}
@@ -1329,7 +1336,7 @@
             </section>
           {/each}
 
-          {#if showMobilePlayer}
+          {#if audioEnabled && showMobilePlayer}
             <div class="md:hidden">
               <MobileAudioPlayer
                 audioUrl={selectedAudioUrl}

--- a/frontend/src/lib/stores/appState.svelte.ts
+++ b/frontend/src/lib/stores/appState.svelte.ts
@@ -70,6 +70,8 @@ interface AppConfigResponse {
   customColors?: { primary: string; accent: string };
   logoStyle?: string;
   liveSpectrogram?: boolean;
+  /** Whether audio clip export is enabled; drives showing per-detection spectrogram/audio in the UI */
+  audioExportEnabled?: boolean;
   layout?: {
     elements: {
       id?: string;
@@ -132,6 +134,8 @@ interface AppState {
   previousVersion: string | null;
   /** Whether live spectrogram is enabled */
   liveSpectrogram: boolean;
+  /** Whether audio clip export is enabled; when false, per-detection spectrogram/audio UI is hidden */
+  audioExportEnabled: boolean;
   /** Dataset version for the per-locale species-name dictionary. Empty string when unknown. */
   speciesDictVersion: string;
   /** Dashboard layout from public config (available before auth) */
@@ -181,6 +185,7 @@ const DEFAULT_STATE: AppState = {
   newVersion: false,
   previousVersion: null,
   liveSpectrogram: false,
+  audioExportEnabled: true,
   speciesDictVersion: '',
   layout: null,
   projectLinks: DEFAULT_PROJECT_LINKS,
@@ -311,6 +316,7 @@ export async function initApp(): Promise<boolean> {
       appState.newVersion = config.newVersion ?? false;
       appState.previousVersion = config.previousVersion ?? null;
       appState.liveSpectrogram = config.liveSpectrogram ?? false;
+      appState.audioExportEnabled = config.audioExportEnabled ?? true;
       appState.speciesDictVersion = config.speciesDictVersion ?? '';
       appState.layout = config.layout ?? null;
       appState.projectLinks = config.projectLinks ?? DEFAULT_PROJECT_LINKS;

--- a/internal/api/v2/app/app.go
+++ b/internal/api/v2/app/app.go
@@ -40,6 +40,7 @@ type AppConfigResponse struct {
 	CustomColors       *conf.CustomColors    `json:"customColors,omitempty"`    // custom scheme hex colors (when colorScheme is "custom")
 	LogoStyle          string                `json:"logoStyle,omitempty"`       // admin-configured logo style: "gradient" or "solid"
 	LiveSpectrogram    bool                  `json:"liveSpectrogram"`           // auto-start live spectrogram on dashboard
+	AudioExportEnabled bool                  `json:"audioExportEnabled"`        // whether audio clip export is enabled; drives showing per-detection spectrogram/audio in the UI
 	Layout             *conf.DashboardLayout `json:"layout,omitempty"`          // dashboard element layout for guest/pre-auth rendering
 	FreshInstall       bool                  `json:"freshInstall"`              // true when this is a brand-new installation
 	NewVersion         bool                  `json:"newVersion"`                // true when the app was upgraded since last dismiss
@@ -200,6 +201,7 @@ func (c *Handler) GetAppConfig(ctx echo.Context) error {
 		CustomColors:       settings.Realtime.Dashboard.CustomColors,
 		LogoStyle:          settings.Realtime.Dashboard.LogoStyle,
 		LiveSpectrogram:    settings.Realtime.Dashboard.LiveSpectrogram,
+		AudioExportEnabled: settings.Realtime.Audio.Export.Enabled,
 		FreshInstall:       freshInstall,
 		NewVersion:         newVersion,
 		PreviousVersion:    previousVersion,

--- a/internal/api/v2/app/app_test.go
+++ b/internal/api/v2/app/app_test.go
@@ -150,6 +150,46 @@ func TestGetAppConfig_NoSecurity(t *testing.T) {
 	assert.Empty(t, response.Security.AuthConfig.EnabledProviders, "No OAuth providers should be enabled")
 }
 
+// TestGetAppConfig_AudioExportEnabled verifies the response surfaces
+// Realtime.Audio.Export.Enabled so the frontend can hide per-detection
+// spectrogram/audio UI when clip export is disabled.
+func TestGetAppConfig_AudioExportEnabled(t *testing.T) {
+	tests := []struct {
+		name          string
+		exportEnabled bool
+	}{
+		{name: "export enabled", exportEnabled: true},
+		{name: "export disabled", exportEnabled: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := echo.New()
+			settings := &conf.Settings{
+				Version: "1.0.0-test",
+			}
+			settings.Realtime.Audio.Export.Enabled = tt.exportEnabled
+			controller := newAppHandler(t, e, settings)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v2/app/config", http.NoBody)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetPath("/api/v2/app/config")
+
+			err := controller.GetAppConfig(c)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusOK, rec.Code)
+
+			var response AppConfigResponse
+			err = json.Unmarshal(rec.Body.Bytes(), &response)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.exportEnabled, response.AudioExportEnabled,
+				"AudioExportEnabled should mirror Realtime.Audio.Export.Enabled")
+		})
+	}
+}
+
 // TestGetAppConfig_ProjectLinks verifies the response always carries the
 // project identity/links (independent of telemetry), defaulting to the upstream
 // values with correctly derived issue URLs when nothing is overridden.


### PR DESCRIPTION
## Summary

When `realtime.audio.export.enabled` is off no clips are saved, so the
spectrograms and audio players render empty/broken. This hides them across all
detection surfaces.

## Changes

- Expose `audioExportEnabled` via the public `/api/v2/app/config` (available
  pre-auth, so guests get it too)
- Hide the spectrogram/audio and collapse cards to a compact layout on:
  dashboard Recent Detections, `/ui/detections` (table Recording column + card
  and mobile views), detection detail, search, and the review modal

## Testing

- [x] Frontend: `npm run check:all` + tests pass (added DetectionRow gating tests)
- [ ] Backend: added a test for the new flag (`go test ./internal/api/v2/app/...`)
- [x] Manually verified each surface with export on/off

Closes #3757


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audio/spectrogram controls now automatically hide when audio export is disabled, across detection, detail, search, and review screens.
  * Detection cards and tables now switch to a compact layout without recording/spectrogram UI when unavailable.

* **Bug Fixes**
  * Prevented audio player, play, download, and loading behavior from appearing when audio export is turned off.
  * Kept desktop and mobile detection views consistent with the available media options.

* **Tests**
  * Added coverage to verify the app configuration and detection rows respect the audio export setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->