### PR TITLE
[codex] fix BirdWeather FLAC upload durations

### DIFF
--- a/internal/audiocore/flac/doc.go
+++ b/internal/audiocore/flac/doc.go
@@ -1,7 +1,7 @@
 // Package flac provides native, FFmpeg-free FLAC encoding of audio clips using
 // github.com/tphakala/go-flac. The native path is selected at runtime by the
 // BIRDNET_FLAC_ENCODER environment variable; when it is not selected the caller
-// keeps using the FFmpeg-based exporter. EncodePCM writes a FLAC file (the
-// detection save path); EncodePCMToBuffer returns FLAC bytes in memory (the
-// BirdWeather soundscape upload path).
+// keeps using the FFmpeg-based exporter. EncodePCM writes a seekable FLAC file;
+// EncodePCMToBuffer returns FLAC bytes in memory for callers that do not need
+// finalized seek metadata.
 package flac

--- a/internal/audiocore/flac/gate.go
+++ b/internal/audiocore/flac/gate.go
@@ -10,9 +10,9 @@ import (
 // unset) keeps the FFmpeg exporter.
 //
 // This is a temporary opt-in gate shared by every native FLAC path: the
-// detection save path (EncodePCM) and the BirdWeather soundscape upload path
-// (EncodePCMToBuffer + audionorm normalization). When the native encoder is
-// trusted, the gate is removed and FLAC always routes to the native path. The
+// detection save path (EncodePCM) and the BirdWeather soundscape upload path.
+// When the native encoder is trusted, the gate is removed and FLAC always routes
+// to the native path. The
 // detection save path still falls back to FFmpeg when EBU R128 normalization is
 // enabled; the BirdWeather path normalizes natively via audionorm. Keep the read
 // confined to NativeEncoderEnabled so the gate is a single deletion site.

--- a/internal/birdweather/README.md
+++ b/internal/birdweather/README.md
@@ -63,8 +63,10 @@ func encodePCMtoWAV(pcmData []byte) (*bytes.Buffer, error)
 BirdWeather FLAC uploads use a short-lived, disk-backed temporary file before
 the upload buffer is created. FLAC muxers need seekable output to finalize
 `STREAMINFO` metadata such as the total sample count; without that metadata
-BirdWeather can store the soundscape duration as `0.0`. The temporary file is
-removed after the finalized FLAC bytes are read into the upload buffer.
+BirdWeather can store the soundscape duration as `0.0`. The upload path creates
+the private temp directory with `os.MkdirTemp`, encodes the FLAC there, reads
+the finalized bytes with `os.ReadFile`, and removes the temporary file
+afterward.
 
 ### Loudness Normalization
 
@@ -196,7 +198,7 @@ Client connections are properly managed to prevent resource leaks:
 - HTTP client timeouts to prevent hanging connections
 - Proper cleanup of resources in the `Close()` method
 - Idle connection cleanup
-- **Seekable FLAC Uploads**: BirdWeather FLAC uploads use a short-lived temporary file so FFmpeg and the native FLAC encoder can finalize seek metadata before upload. The finalized bytes are then read into memory for the existing HTTP upload path.
+- **Seekable FLAC Uploads**: BirdWeather FLAC uploads use a short-lived temporary file so FFmpeg and the native FLAC encoder can finalize seek metadata before upload. The path creates the temporary workspace with `os.MkdirTemp`, reads the finalized bytes back with `os.ReadFile`, and then uploads through the existing in-memory HTTP path.
 - Temporary files and directories are properly cleaned up
 
 ## Debug Capabilities
@@ -270,7 +272,7 @@ When FFmpeg is available, bird call audio is processed using the `loudnorm` filt
 The normalization process involves:
 
 1.  **Pass 1 (Analysis)**: Reads raw PCM audio data and runs `loudnorm` in analysis mode (`print_format=json`) to measure the input audio's characteristics (I, LRA, TP, Threshold).
-2.  **Pass 2 (Normalization & Encoding)**: Reads the PCM data again, applies the `loudnorm` filter using the measured values from Pass 1 (`linear=true`, `measured_*` parameters), and encodes the normalized audio directly to FLAC format in a single step.
+2.  **Pass 2 (Normalization & Encoding)**: Reads the PCM data again, applies the `loudnorm` filter using the measured values from Pass 1 (`linear=true`, `measured_*` parameters), and encodes the normalized audio to a seekable temporary FLAC file before reading the finalized bytes for upload.
 
 Benefits:
 
@@ -299,7 +301,7 @@ Comprehensive tests are provided for all key functionality:
 - **Location coordinates** are currently ignored by BirdWeather's API. Despite the location randomization feature, BirdWeather always uses the coordinates assigned to your station ID/token rather than the coordinates submitted with detections.
 - FLAC encoding requires **FFmpeg to be installed and configured correctly** on the host system (Linux, macOS, Windows).
 - Loudness normalization requires FFmpeg with the `loudnorm` filter (available in most modern FFmpeg builds).
-- **Memory Usage**: The in-memory FFmpeg processing, while reducing disk writes, might consume significant memory for very long audio inputs.
+- **Memory Usage**: FFmpeg loudness analysis remains in memory, but finalized FLAC upload encoding uses a short-lived temp file so `STREAMINFO` duration metadata can be written.
 
 ## Dependencies
 

--- a/internal/birdweather/README.md
+++ b/internal/birdweather/README.md
@@ -60,6 +60,12 @@ func encodeFlacUsingFFmpeg(pcmData []byte, settings *conf.Settings) (*bytes.Buff
 func encodePCMtoWAV(pcmData []byte) (*bytes.Buffer, error)
 ```
 
+BirdWeather FLAC uploads use a short-lived, disk-backed temporary file before
+the upload buffer is created. FLAC muxers need seekable output to finalize
+`STREAMINFO` metadata such as the total sample count; without that metadata
+BirdWeather can store the soundscape duration as `0.0`. The temporary file is
+removed after the finalized FLAC bytes are read into the upload buffer.
+
 ### Loudness Normalization
 
 When FFmpeg is available, the package applies loudness normalization to FLAC audio files to ensure consistent playback quality:
@@ -190,7 +196,7 @@ Client connections are properly managed to prevent resource leaks:
 - HTTP client timeouts to prevent hanging connections
 - Proper cleanup of resources in the `Close()` method
 - Idle connection cleanup
-- **In-Memory Processing**: Audio export via FFmpeg now occurs entirely in memory to reduce disk I/O, especially beneficial for systems using SD cards. However, be mindful that very large audio inputs could lead to increased memory consumption during this process.
+- **Seekable FLAC Uploads**: BirdWeather FLAC uploads use a short-lived temporary file so FFmpeg and the native FLAC encoder can finalize seek metadata before upload. The finalized bytes are then read into memory for the existing HTTP upload path.
 - Temporary files and directories are properly cleaned up
 
 ## Debug Capabilities

--- a/internal/birdweather/audio.go
+++ b/internal/birdweather/audio.go
@@ -120,11 +120,11 @@ func saveBufferToFile(buffer *bytes.Buffer, filename string, startTime, endTime 
 	return nil
 }
 
-// encodeUploadAudioToBuffer lets encoders write to a seekable temporary file,
-// then reads the completed audio back into the in-memory upload buffer. FLAC
-// muxers need seekable output to patch STREAMINFO fields such as total samples;
-// when encoded directly to a pipe those fields remain unknown and BirdWeather
-// stores the soundscape duration as 0.
+// encodeUploadAudioToBuffer uses os.MkdirTemp to let encoders write to a
+// seekable temporary file, then os.ReadFile to load the completed audio back
+// into the in-memory upload buffer. FLAC muxers need seekable output to patch
+// STREAMINFO fields such as total samples; when encoded directly to a pipe those
+// fields remain unknown and BirdWeather stores the soundscape duration as 0.
 func encodeUploadAudioToBuffer(ext string, encode func(outputPath string) error) (*bytes.Buffer, error) {
 	dir, err := os.MkdirTemp("", "birdweather-upload-*")
 	if err != nil {

--- a/internal/birdweather/audio.go
+++ b/internal/birdweather/audio.go
@@ -119,3 +119,41 @@ func saveBufferToFile(buffer *bytes.Buffer, filename string, startTime, endTime 
 
 	return nil
 }
+
+// encodeUploadAudioToBuffer lets encoders write to a seekable temporary file,
+// then reads the completed audio back into the in-memory upload buffer. FLAC
+// muxers need seekable output to patch STREAMINFO fields such as total samples;
+// when encoded directly to a pipe those fields remain unknown and BirdWeather
+// stores the soundscape duration as 0.
+func encodeUploadAudioToBuffer(ext string, encode func(outputPath string) error) (*bytes.Buffer, error) {
+	dir, err := os.MkdirTemp("", "birdweather-upload-*")
+	if err != nil {
+		return nil, errors.New(err).
+			Component("birdweather").
+			Category(errors.CategoryFileIO).
+			Context("operation", "create_upload_temp_dir").
+			Build()
+	}
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			GetLogger().Warn("Failed to remove BirdWeather upload temp dir", logger.Error(err))
+		}
+	}()
+
+	outputPath := filepath.Join(dir, "soundscape."+ext)
+	if err := encode(outputPath); err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(outputPath) //nolint:gosec // path is created under a private temp directory above
+	if err != nil {
+		return nil, errors.New(err).
+			Component("birdweather").
+			Category(errors.CategoryFileIO).
+			FileContext(outputPath, 0).
+			Context("operation", "read_upload_audio").
+			Build()
+	}
+
+	return bytes.NewBuffer(data), nil
+}

--- a/internal/birdweather/audio_test.go
+++ b/internal/birdweather/audio_test.go
@@ -225,6 +225,10 @@ func TestEncodeFlacUsingFFmpeg(t *testing.T) {
 	// Check FLAC signature (should start with "fLaC")
 	assert.Equal(t, "fLaC", string(flacBytes[0:4]), "FLAC signature not found")
 
+	sampleRate, totalSamples := flacStreamInfo(t, flacBytes)
+	assert.Equal(t, uint64(conf.SampleRate), sampleRate, "FLAC STREAMINFO sample rate mismatch")
+	assert.Equal(t, uint64(sampleCount), totalSamples, "FLAC STREAMINFO total samples should be finalized")
+
 	// The FLAC data should be smaller than the raw PCM (compression)
 	if flacBuffer.Len() >= len(pcmData) {
 		t.Logf("Warning: FLAC data (%d bytes) is not smaller than PCM data (%d bytes)",

--- a/internal/birdweather/birdweather_client.go
+++ b/internal/birdweather/birdweather_client.go
@@ -596,6 +596,8 @@ func (b *BwClient) encodeFlacUsingFFmpeg(ctx context.Context, pcmData []byte, ff
 	return buffer, nil
 }
 
+// exportFlacFileToBuffer encodes through a seekable temporary FLAC file, then
+// reads the finalized bytes back into memory for the existing upload path.
 func (b *BwClient) exportFlacFileToBuffer(ctx context.Context, pcmData []byte, ffmpegPath string, gainDB float64) (*bytes.Buffer, error) {
 	return encodeUploadAudioToBuffer("flac", func(outputPath string) error {
 		return ffmpeg.ExportAudio(ctx, &ffmpeg.ExportOptions{

--- a/internal/birdweather/birdweather_client.go
+++ b/internal/birdweather/birdweather_client.go
@@ -535,16 +535,9 @@ func (b *BwClient) encodeFlacUsingFFmpeg(ctx context.Context, pcmData []byte, ff
 		// Fallback to a conservative fixed gain adjustment
 		// A fixed gain of 15dB is a reasonable middle ground for bird call recordings
 		gainValue := 15.0
-		volumeArgs := fmt.Sprintf("volume=%.1fdB", gainValue)
-		customArgs := []string{
-			"-af", volumeArgs, // Simple gain adjustment
-			"-c:a", "flac",
-			"-f", "flac",
-		}
-
 		// Use the provided context for the fallback export operation
 		log.Debug("Starting fallback FLAC export with fixed gain", logger.Float64("gain_db", gainValue))
-		buffer, err := ffmpeg.ExportAudioToBuffer(ctx, pcmData, ffmpegPath, conf.SampleRate, conf.NumChannels, conf.BitDepth, customArgs)
+		buffer, err := b.exportFlacFileToBuffer(ctx, pcmData, ffmpegPath, gainValue)
 		if err != nil {
 			log.Error("Fallback FLAC export with fixed gain failed",
 				logger.Float64("gain_db", gainValue),
@@ -588,17 +581,8 @@ func (b *BwClient) encodeFlacUsingFFmpeg(ctx context.Context, pcmData []byte, ff
 	// --- Pass 2: Apply simple gain adjustment and encode ---
 	log.Debug("Applying gain adjustment and encoding to FLAC (Pass 2)", logger.Float64("gain_db", gainNeeded))
 
-	// Use simple volume filter instead of loudnorm
-	volumeArgs := fmt.Sprintf("volume=%.2fdB", gainNeeded)
-
-	customArgs := []string{
-		"-af", volumeArgs, // Simple gain adjustment filter
-		"-c:a", "flac", // Output codec: FLAC
-		"-f", "flac", // Output format: FLAC
-	}
-
 	// Use the provided context for the final encoding operation
-	buffer, err := ffmpeg.ExportAudioToBuffer(ctx, pcmData, ffmpegPath, conf.SampleRate, conf.NumChannels, conf.BitDepth, customArgs)
+	buffer, err := b.exportFlacFileToBuffer(ctx, pcmData, ffmpegPath, gainNeeded)
 	if err != nil {
 		log.Error("FFmpeg FLAC encoding with gain adjustment failed",
 			logger.Float64("gain_db", gainNeeded),
@@ -610,6 +594,21 @@ func (b *BwClient) encodeFlacUsingFFmpeg(ctx context.Context, pcmData []byte, ff
 
 	// Return the buffer containing the FLAC data
 	return buffer, nil
+}
+
+func (b *BwClient) exportFlacFileToBuffer(ctx context.Context, pcmData []byte, ffmpegPath string, gainDB float64) (*bytes.Buffer, error) {
+	return encodeUploadAudioToBuffer("flac", func(outputPath string) error {
+		return ffmpeg.ExportAudio(ctx, &ffmpeg.ExportOptions{
+			PCMData:    pcmData,
+			OutputPath: outputPath,
+			Format:     ffmpeg.FormatFLAC,
+			SampleRate: conf.SampleRate,
+			Channels:   conf.NumChannels,
+			BitDepth:   conf.BitDepth,
+			GainDB:     gainDB,
+			FFmpegPath: ffmpegPath,
+		})
+	})
 }
 
 // parseDouble safely parses a string to float64, returning defaultValue on error.

--- a/internal/birdweather/birdweather_client.go
+++ b/internal/birdweather/birdweather_client.go
@@ -503,9 +503,10 @@ func handleHTTPResponse(resp *http.Response, expectedStatus int, operation, mask
 	return responseBody, nil
 }
 
-// encodeFlacUsingFFmpeg converts PCM data to FLAC format using FFmpeg directly into a bytes buffer.
-// It applies a simple gain adjustment instead of dynamic loudness normalization to avoid pumping effects.
-// This avoids writing temporary files to disk.
+// encodeFlacUsingFFmpeg converts PCM data to FLAC format using FFmpeg.
+// It applies a simple gain adjustment instead of dynamic loudness normalization
+// to avoid pumping effects. The final FLAC export uses a seekable temporary file
+// so FFmpeg can finalize STREAMINFO before the bytes are read into memory.
 // It accepts a context for timeout/cancellation control and the explicit path to the FFmpeg executable.
 func (b *BwClient) encodeFlacUsingFFmpeg(ctx context.Context, pcmData []byte, ffmpegPath string, settings *conf.Settings) (*bytes.Buffer, error) {
 	log := GetLogger()
@@ -598,6 +599,8 @@ func (b *BwClient) encodeFlacUsingFFmpeg(ctx context.Context, pcmData []byte, ff
 
 // exportFlacFileToBuffer encodes through a seekable temporary FLAC file, then
 // reads the finalized bytes back into memory for the existing upload path.
+// encodeUploadAudioToBuffer owns the os.MkdirTemp/os.ReadFile round-trip needed
+// for FFmpeg to patch STREAMINFO fields such as total samples.
 func (b *BwClient) exportFlacFileToBuffer(ctx context.Context, pcmData []byte, ffmpegPath string, gainDB float64) (*bytes.Buffer, error) {
 	return encodeUploadAudioToBuffer("flac", func(outputPath string) error {
 		return ffmpeg.ExportAudio(ctx, &ffmpeg.ExportOptions{
@@ -1182,7 +1185,8 @@ func (b *BwClient) encodeAudioForUpload(settings *conf.Settings, pcmData []byte,
 	return b.encodeWithFFmpeg(settings, pcmData, ffmpegPathForExec, timestamp)
 }
 
-// encodeWithFFmpeg encodes PCM to FLAC format using FFmpeg
+// encodeWithFFmpeg encodes PCM to FLAC format using FFmpeg. The final FLAC mux
+// step is disk-backed so the upload contains finalized STREAMINFO metadata.
 func (b *BwClient) encodeWithFFmpeg(settings *conf.Settings, pcmData []byte, ffmpegPath, timestamp string) (*audioEncodingResult, error) {
 	log := GetLogger()
 

--- a/internal/birdweather/encode_native.go
+++ b/internal/birdweather/encode_native.go
@@ -21,12 +21,14 @@ import (
 // limit so a near-silent clip is not over-amplified into loud static.
 const maxGainDB = 30.0
 
-// encodeWithNativeFLAC encodes PCM to a seekable FLAC file, reads it into an
-// upload buffer, and uses the native go-flac encoder and audionorm loudness
-// normalization, with no FFmpeg
-// dependency. Pass 1 measures integrated loudness and true peak; the planned
-// gain (clamped to +/-maxGainDB) is then applied in Go while the original bytes
-// are streamed into the encoder. pcmData is not modified.
+// encodeWithNativeFLAC encodes PCM to a seekable temporary FLAC file, reads it
+// into an upload buffer, and uses the native go-flac encoder and audionorm
+// loudness normalization, with no FFmpeg dependency. The temp file round-trip is
+// handled by encodeUploadAudioToBuffer through os.MkdirTemp/os.ReadFile so
+// STREAMINFO total samples can be finalized. Pass 1 measures integrated loudness
+// and true peak; the planned gain (clamped to +/-maxGainDB) is then applied in
+// Go while the original bytes are streamed into the encoder. pcmData is not
+// modified.
 func (b *BwClient) encodeWithNativeFLAC(pcmData []byte, timestamp string) (*audioEncodingResult, error) {
 	log := GetLogger()
 

--- a/internal/birdweather/encode_native.go
+++ b/internal/birdweather/encode_native.go
@@ -21,8 +21,9 @@ import (
 // limit so a near-silent clip is not over-amplified into loud static.
 const maxGainDB = 30.0
 
-// encodeWithNativeFLAC encodes PCM to an in-memory FLAC buffer using the native
-// go-flac encoder and audionorm loudness normalization, with no FFmpeg
+// encodeWithNativeFLAC encodes PCM to a seekable FLAC file, reads it into an
+// upload buffer, and uses the native go-flac encoder and audionorm loudness
+// normalization, with no FFmpeg
 // dependency. Pass 1 measures integrated loudness and true peak; the planned
 // gain (clamped to +/-maxGainDB) is then applied in Go while the original bytes
 // are streamed into the encoder. pcmData is not modified.
@@ -79,13 +80,18 @@ func (b *BwClient) encodeWithNativeFLAC(pcmData []byte, timestamp string) (*audi
 		logger.Float64("gain_db", gainDB),
 		logger.Bool("peak_limited", res.PeakLimited))
 
-	// Pass 2: apply the gain in Go and encode to FLAC in memory.
-	buf, err := flac.EncodePCMToBuffer(ctx, &flac.BufferOptions{
-		PCMData:    pcmData,
-		SampleRate: conf.SampleRate,
-		Channels:   conf.NumChannels,
-		BitDepth:   conf.BitDepth,
-		GainDB:     gainDB,
+	// Pass 2: apply the gain in Go and encode to seekable FLAC. BirdWeather
+	// derives soundscape duration from FLAC STREAMINFO, so uploads must not use
+	// the non-seekable buffer encoder that leaves total samples unknown.
+	buf, err := encodeUploadAudioToBuffer("flac", func(outputPath string) error {
+		return flac.EncodePCM(ctx, &flac.Options{
+			PCMData:    pcmData,
+			OutputPath: outputPath,
+			SampleRate: conf.SampleRate,
+			Channels:   conf.NumChannels,
+			BitDepth:   conf.BitDepth,
+			GainDB:     gainDB,
+		})
 	})
 	if err != nil {
 		// logFLACEncodingError downgrades timeout/cancel to WARN to avoid Sentry

--- a/internal/birdweather/encode_native_test.go
+++ b/internal/birdweather/encode_native_test.go
@@ -48,7 +48,8 @@ func TestEncodeWithNativeFLAC(t *testing.T) {
 	client := &BwClient{Settings: &conf.Settings{}}
 
 	// A quiet (-30 dBFS) 1 s sine; normalization should boost it toward -23 LUFS.
-	pcm := sinePCM(conf.SampleRate, -30)
+	sampleCount := conf.SampleRate
+	pcm := sinePCM(sampleCount, -30)
 
 	res, err := client.encodeWithNativeFLAC(pcm, testTimestamp)
 	require.NoError(t, err)
@@ -61,7 +62,7 @@ func TestEncodeWithNativeFLAC(t *testing.T) {
 	assert.Equal(t, "fLaC", string(flacBytes[:4]), "FLAC signature not found")
 	sampleRate, totalSamples := flacStreamInfo(t, flacBytes)
 	assert.Equal(t, uint64(conf.SampleRate), sampleRate, "FLAC STREAMINFO sample rate mismatch")
-	assert.Equal(t, uint64(conf.SampleRate), totalSamples, "FLAC STREAMINFO total samples should be finalized")
+	assert.Equal(t, uint64(sampleCount), totalSamples, "FLAC STREAMINFO total samples should be finalized")
 
 	// Re-measure the decoded output: it should sit near the target loudness.
 	out := decodeToInt16(t, flacBytes)

--- a/internal/birdweather/encode_native_test.go
+++ b/internal/birdweather/encode_native_test.go
@@ -59,6 +59,9 @@ func TestEncodeWithNativeFLAC(t *testing.T) {
 	flacBytes := res.buffer.Bytes()
 	require.GreaterOrEqual(t, len(flacBytes), 4)
 	assert.Equal(t, "fLaC", string(flacBytes[:4]), "FLAC signature not found")
+	sampleRate, totalSamples := flacStreamInfo(t, flacBytes)
+	assert.Equal(t, uint64(conf.SampleRate), sampleRate, "FLAC STREAMINFO sample rate mismatch")
+	assert.Equal(t, uint64(conf.SampleRate), totalSamples, "FLAC STREAMINFO total samples should be finalized")
 
 	// Re-measure the decoded output: it should sit near the target loudness.
 	out := decodeToInt16(t, flacBytes)

--- a/internal/birdweather/helpers_test.go
+++ b/internal/birdweather/helpers_test.go
@@ -3,6 +3,7 @@ package birdweather
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"fmt"
 	"net/http"
 	"os"
@@ -15,6 +16,21 @@ import (
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/notification"
 )
+
+func flacStreamInfo(t *testing.T, data []byte) (sampleRate, totalSamples uint64) {
+	t.Helper()
+	require.GreaterOrEqual(t, len(data), 42, "FLAC data too short for STREAMINFO")
+	require.Equal(t, "fLaC", string(data[:4]), "FLAC signature not found")
+	require.Equal(t, byte(0), data[4]&0x7f, "first FLAC metadata block must be STREAMINFO")
+
+	payloadLen := int(data[5])<<16 | int(data[6])<<8 | int(data[7])
+	require.Equal(t, 34, payloadLen, "unexpected STREAMINFO length")
+
+	fields := binary.BigEndian.Uint64(data[18:26])
+	sampleRate = (fields >> 44) & 0xfffff
+	totalSamples = fields & ((1 << 36) - 1)
+	return sampleRate, totalSamples
+}
 
 // TestParseSoundscapeResponse tests the JSON response parsing helper
 func TestParseSoundscapeResponse(t *testing.T) {

--- a/internal/birdweather/helpers_test.go
+++ b/internal/birdweather/helpers_test.go
@@ -17,18 +17,36 @@ import (
 	"github.com/tphakala/birdnet-go/internal/notification"
 )
 
+const (
+	flacMagic                  = "fLaC"
+	flacMagicLen               = 4
+	flacMetadataBlockHeaderLen = 4
+	flacStreamInfoPayloadLen   = 34
+	flacStreamInfoMinLen       = flacMagicLen + flacMetadataBlockHeaderLen + flacStreamInfoPayloadLen
+	flacMetadataBlockTypeMask  = 0x7f
+	flacStreamInfoBlockType    = 0
+	flacMetadataLengthOffset   = 5
+	flacStreamInfoFieldsStart  = 18
+	flacStreamInfoFieldsEnd    = 26
+	flacSampleRateShift        = 44
+	flacSampleRateMask         = 0xfffff
+	flacTotalSamplesBitCount   = 36
+)
+
 func flacStreamInfo(t *testing.T, data []byte) (sampleRate, totalSamples uint64) {
 	t.Helper()
-	require.GreaterOrEqual(t, len(data), 42, "FLAC data too short for STREAMINFO")
-	require.Equal(t, "fLaC", string(data[:4]), "FLAC signature not found")
-	require.Equal(t, byte(0), data[4]&0x7f, "first FLAC metadata block must be STREAMINFO")
+	require.GreaterOrEqual(t, len(data), flacStreamInfoMinLen, "FLAC data too short for STREAMINFO")
+	require.Equal(t, flacMagic, string(data[:flacMagicLen]), "FLAC signature not found")
+	require.Equal(t, byte(flacStreamInfoBlockType), data[flacMagicLen]&flacMetadataBlockTypeMask, "first FLAC metadata block must be STREAMINFO")
 
-	payloadLen := int(data[5])<<16 | int(data[6])<<8 | int(data[7])
-	require.Equal(t, 34, payloadLen, "unexpected STREAMINFO length")
+	payloadLen := int(data[flacMetadataLengthOffset])<<16 |
+		int(data[flacMetadataLengthOffset+1])<<8 |
+		int(data[flacMetadataLengthOffset+2])
+	require.Equal(t, flacStreamInfoPayloadLen, payloadLen, "unexpected STREAMINFO length")
 
-	fields := binary.BigEndian.Uint64(data[18:26])
-	sampleRate = (fields >> 44) & 0xfffff
-	totalSamples = fields & ((1 << 36) - 1)
+	fields := binary.BigEndian.Uint64(data[flacStreamInfoFieldsStart:flacStreamInfoFieldsEnd])
+	sampleRate = (fields >> flacSampleRateShift) & flacSampleRateMask
+	totalSamples = fields & ((1 << flacTotalSamplesBitCount) - 1)
 	return sampleRate, totalSamples
 }
 


### PR DESCRIPTION
## Summary

BirdWeather soundscape uploads were encoded as FLAC streams directly into an in-memory pipe/buffer. For FLAC, non-seekable output leaves `STREAMINFO.total_samples` unknown. BirdWeather then records the soundscape duration as `0.0`, which can leave the website audio panel stuck loading even though the media file exists.

This change makes BirdWeather upload encoding write to a private seekable temp file first, then reads the finalized FLAC bytes back into the existing upload buffer. That lets both the default FFmpeg path and the opt-in native encoder patch FLAC metadata before POSTing to BirdWeather.

## Changes

- Add a BirdWeather upload helper that encodes through a seekable temporary file and cleans it up after reading.
- Switch default FFmpeg BirdWeather FLAC uploads from `ExportAudioToBuffer` to the existing file-backed `ExportAudio` path.
- Switch native BirdWeather FLAC uploads to file-backed `flac.EncodePCM` for finalized `STREAMINFO` metadata.
- Add regression assertions that parse FLAC `STREAMINFO` and verify non-zero finalized total samples.
- Update FLAC package comments so BirdWeather is no longer described as using the non-seekable buffer encoder.

## Validation

- `PATH=/tmp/go1.26.1/bin:/opt/homebrew/bin:$PATH go test ./internal/birdweather`
- `PATH=/tmp/go1.26.1/bin:/opt/homebrew/bin:$PATH go test ./internal/audiocore/flac ./internal/audiocore/ffmpeg ./internal/birdweather`
- `PATH=/tmp/go1.26.1/bin:/opt/homebrew/bin:$PATH BIRDNET_FLAC_ENCODER=native go test ./internal/birdweather`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FLAC audio exports now preserve stream metadata (e.g., sample rate and total samples) by generating seekable FLAC before returning/uploading the final bytes.

* **Bug Fixes**
  * Improved FLAC encoding consistency across normal and fallback paths.
  * Fixed validation to ensure the encoded FLAC stream reports expected stream information.

* **Documentation**
  * Updated BirdWeather audio upload docs to reflect seekable FLAC temporary-file behavior.

* **Tests**
  * Expanded FLAC encoding tests to assert STREAMINFO sample rate and total sample counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->