### PR TITLE
feat(audio): make clip_name a truthful per-detection signal for export-off mode

### DIFF
--- a/frontend/src/lib/desktop/components/modals/ReviewModal.svelte
+++ b/frontend/src/lib/desktop/components/modals/ReviewModal.svelte
@@ -13,7 +13,6 @@
   import { t } from '$lib/i18n';
   import { safeArrayAccess } from '$lib/utils/security';
   import { isAuthenticated } from '$lib/utils/auth';
-  import { appState } from '$lib/stores/appState.svelte';
 
   interface Props {
     isOpen: boolean;
@@ -31,8 +30,6 @@
   let { isOpen = false, detection = null, isExcluded = false, onClose, onSave }: Props = $props();
 
   let clipExtractionEnabled = $derived($isAuthenticated);
-  // Hide the audio/spectrogram block when audio clip export is disabled.
-  let audioEnabled = $derived(appState.audioExportEnabled);
 
   let reviewStatus = $state<'correct' | 'false_positive'>('correct');
   let lockDetection = $state(false);
@@ -207,8 +204,8 @@
             </div>
           </div>
 
-          <!-- Audio and Spectrogram (hidden when audio clip export is disabled) -->
-          {#if audioEnabled}
+          <!-- Audio and Spectrogram (shown only when this detection has a clip) -->
+          {#if detection.clipName}
             <div class="relative bg-[var(--color-base-200)] rounded-lg p-4">
               <AudioPlayer
                 audioUrl={buildAppUrl(`/api/v2/audio/${detection.id}`)}

--- a/frontend/src/lib/desktop/features/dashboard/components/DetectionCard.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/DetectionCard.svelte
@@ -42,8 +42,6 @@
     detection: Detection;
     isNew?: boolean;
     isExcluded?: boolean;
-    /** When false (audio export disabled), the card hides the spectrogram and audio controls */
-    audioEnabled?: boolean;
     onFreezeStart?: () => void;
     onFreezeEnd?: () => void;
     onReview?: () => void;
@@ -58,7 +56,6 @@
     detection,
     isNew = false,
     isExcluded = false,
-    audioEnabled = true,
     onFreezeStart,
     onFreezeEnd,
     onReview,
@@ -110,10 +107,10 @@
     onFreezeEnd?.();
   }
 
-  // Start/stop loader based on visibility. Skip entirely when audio export is
-  // disabled: no clips exist, so there is no spectrogram to fetch.
+  // Start/stop loader based on visibility. Skip entirely when this detection has
+  // no clip: there is no spectrogram to fetch.
   $effect(() => {
-    if (audioEnabled && isVisible) {
+    if (detection.clipName && isVisible) {
       loader.start(detection.id);
     } else {
       loader.stop();
@@ -164,9 +161,9 @@
 >
   <!-- Inner container with overflow-hidden for spectrogram clipping -->
   <!-- Compact (shorter) layout when there is no spectrogram to display -->
-  <div class="detection-card-inner" class:compact={!audioEnabled}>
-    <!-- Spectrogram Background (hidden when audio export is disabled) -->
-    {#if audioEnabled}
+  <div class="detection-card-inner" class:compact={!detection.clipName}>
+    <!-- Spectrogram Background (hidden when this detection has no clip) -->
+    {#if detection.clipName}
       <div class="spectrogram-container">
         {#if loader.showSpinner}
           <div class="spectrogram-loading">
@@ -225,8 +222,8 @@
       <SourceBadge {detection} variant="overlay" />
     </div>
 
-    <!-- Center Play Button (hidden when audio export is disabled) -->
-    {#if audioEnabled}
+    <!-- Center Play Button (hidden when this detection has no clip) -->
+    {#if detection.clipName}
       <PlayOverlay
         detectionId={detection.id}
         {onFreezeStart}
@@ -244,7 +241,7 @@
 
   <!-- Top-Right Controls - OUTSIDE overflow-hidden container -->
   <div class="absolute top-2 right-2 z-50 flex items-center gap-1.5">
-    {#if audioEnabled}
+    {#if detection.clipName}
       <AudioSettingsButton
         gainValue={audioGainValue}
         filterFreq={audioFilterFreq}
@@ -268,7 +265,7 @@
       {onToggleSpecies}
       {onToggleLock}
       {onDelete}
-      onDownload={audioEnabled ? () => downloadDetectionAudio(detection) : undefined}
+      onDownload={detection.clipName ? () => downloadDetectionAudio(detection) : undefined}
       onMenuOpen={handleMenuOpen}
       onMenuClose={handleMenuClose}
     />

--- a/frontend/src/lib/desktop/features/dashboard/components/DetectionCardGrid.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/DetectionCardGrid.svelte
@@ -37,13 +37,11 @@
     setExcluded,
     hydrateExcludedSpecies,
   } from '$lib/stores/excludedSpecies.svelte';
-  import { appState } from '$lib/stores/appState.svelte';
 
   const logger = loggers.ui;
 
-  // When audio clip export is disabled, no clips/spectrograms exist, so the
-  // detection cards render in their compact (media-free) form.
-  let audioEnabled = $derived(appState.audioExportEnabled);
+  // Each DetectionCard renders its compact (media-free) form on its own when its
+  // detection has no clip, so no card-level audio flag is threaded through here.
 
   interface Props {
     data: Detection[];
@@ -276,7 +274,6 @@
           {#each data.slice(0, selectedLimit) as detection (detection.id)}
             <DetectionCard
               {detection}
-              {audioEnabled}
               isNew={newDetectionIds.has(detection.id)}
               isExcluded={isSpeciesExcluded(detection.commonName)}
               {onFreezeStart}

--- a/frontend/src/lib/desktop/features/detections/components/DetectionCardMobile.svelte
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionCardMobile.svelte
@@ -25,8 +25,6 @@
   // passes them in as callbacks plus the server-hydrated isExcluded state.
   interface Props {
     detection: Detection;
-    /** When false (audio export disabled), the card hides the spectrogram and play button */
-    audioEnabled?: boolean;
     isExcluded?: boolean;
     onDetailsClick?: (_id: number) => void;
     onReview?: () => void;
@@ -39,7 +37,6 @@
 
   let {
     detection,
-    audioEnabled = true,
     isExcluded = false,
     onDetailsClick,
     onReview,
@@ -61,7 +58,7 @@
   let audioPlaybackSpeed = $state(DEFAULT_PLAYBACK_SPEED);
 
   $effect(() => {
-    if (audioEnabled && isVisible) {
+    if (detection.clipName && isVisible) {
       loader.start(detection.id);
     } else {
       loader.stop();
@@ -114,9 +111,9 @@
 >
   <!-- Inner container with overflow-hidden for spectrogram clipping -->
   <!-- Compact (shorter) layout when there is no spectrogram to display -->
-  <div class="detection-card-inner" class:compact={!audioEnabled}>
-    <!-- Spectrogram Background (hidden when audio export is disabled) -->
-    {#if audioEnabled}
+  <div class="detection-card-inner" class:compact={!detection.clipName}>
+    <!-- Spectrogram Background (hidden when this detection has no clip) -->
+    {#if detection.clipName}
       <div class="spectrogram-container">
         {#if loader.showSpinner}
           <div class="spectrogram-loading">
@@ -175,8 +172,8 @@
       <SourceBadge {detection} variant="overlay" />
     </div>
 
-    <!-- Center Play Button (hidden when audio export is disabled) -->
-    {#if audioEnabled}
+    <!-- Center Play Button (hidden when this detection has no clip) -->
+    {#if detection.clipName}
       <PlayOverlay
         detectionId={detection.id}
         gainValue={audioGainValue}
@@ -208,7 +205,7 @@
       {onToggleSpecies}
       {onToggleLock}
       {onDelete}
-      onDownload={audioEnabled ? () => downloadDetectionAudio(detection) : undefined}
+      onDownload={detection.clipName ? () => downloadDetectionAudio(detection) : undefined}
       onMenuOpen={handleMenuOpen}
       onMenuClose={handleMenuClose}
     />

--- a/frontend/src/lib/desktop/features/detections/components/DetectionRow.svelte
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionRow.svelte
@@ -49,8 +49,13 @@
   // passes them in as callbacks plus the server-hydrated isExcluded state.
   interface Props {
     detection: Detection;
-    /** When false (audio export disabled), the Recording cell is omitted */
-    audioEnabled?: boolean;
+    /**
+     * Whether the Recording column exists in this table. The parent shows it when
+     * audio export is enabled or any visible row has a clip. The cell content is
+     * gated per-detection on detection.clipName, so rows without a clip render an
+     * empty cell to keep the table columns aligned.
+     */
+    showRecordingColumn?: boolean;
     isExcluded?: boolean;
     onDetailsClick?: (_id: number) => void;
     selectionActive?: boolean;
@@ -66,7 +71,7 @@
 
   let {
     detection,
-    audioEnabled = true,
+    showRecordingColumn = true,
     isExcluded = false,
     onDetailsClick,
     selectionActive = false,
@@ -280,14 +285,18 @@
   <VerificationBadges {detection} />
 </td>
 
-<!-- Recording/Spectrogram (omitted when audio export is disabled) -->
-{#if audioEnabled}
+<!-- Recording/Spectrogram column. The column is omitted entirely when no visible
+     row has a clip and export is disabled; within a shown column, the player is
+     rendered only for detections that actually have a clip. -->
+{#if showRecordingColumn}
   <td class="hidden md:table-cell">
-    <SpectrogramPlayer
-      audioUrl={buildAppUrl(`/api/v2/audio/${detection.id}`)}
-      detectionId={detection.id.toString()}
-      spectrogramSize="md"
-    />
+    {#if detection.clipName}
+      <SpectrogramPlayer
+        audioUrl={buildAppUrl(`/api/v2/audio/${detection.id}`)}
+        detectionId={detection.id.toString()}
+        spectrogramSize="md"
+      />
+    {/if}
   </td>
 {/if}
 

--- a/frontend/src/lib/desktop/features/detections/components/DetectionRow.test.ts
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionRow.test.ts
@@ -108,22 +108,39 @@ describe('DetectionRow action callbacks', () => {
   });
 });
 
-describe('DetectionRow recording cell gating (audioEnabled)', () => {
+describe('DetectionRow recording cell gating', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('renders the spectrogram/recording cell by default', () => {
+  it('renders the spectrogram player when the detection has a clip', () => {
     const { container } = render(DetectionRow, {
-      props: { detection: createMockDetection({ id: 600 }) },
+      props: { detection: createMockDetection({ id: 600, clipName: 'clip_600.wav' }) },
     });
 
     expect(container.querySelector('.spectrogram-player')).not.toBeNull();
   });
 
-  it('omits the spectrogram/recording cell when audioEnabled is false', () => {
+  // Per-detection gating: the widget must depend on the real clipName signal, not a
+  // global flag. An empty clipName means no clip exists, so no player must render
+  // even though the Recording column itself is shown.
+  it('omits the spectrogram player when the detection has no clip', () => {
     const { container } = render(DetectionRow, {
-      props: { detection: createMockDetection({ id: 601 }), audioEnabled: false },
+      props: {
+        detection: createMockDetection({ id: 601, clipName: '' }),
+        showRecordingColumn: true,
+      },
+    });
+
+    expect(container.querySelector('.spectrogram-player')).toBeNull();
+  });
+
+  it('omits the entire recording cell when the column is hidden', () => {
+    const { container } = render(DetectionRow, {
+      props: {
+        detection: createMockDetection({ id: 602, clipName: 'clip_602.wav' }),
+        showRecordingColumn: false,
+      },
     });
 
     expect(container.querySelector('.spectrogram-player')).toBeNull();

--- a/frontend/src/lib/desktop/features/detections/components/DetectionsCardView.svelte
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionsCardView.svelte
@@ -14,7 +14,6 @@
   import type { Detection } from '$lib/types/detection.types';
   import { isExcluded as isSpeciesExcluded, setExcluded } from '$lib/stores/excludedSpecies.svelte';
   import { useDetectionActions } from '../composables/useDetectionActions.svelte';
-  import { appState } from '$lib/stores/appState.svelte';
 
   interface Props {
     detections: Detection[];
@@ -23,8 +22,8 @@
 
   let { detections, onRefresh }: Props = $props();
 
-  // Hide spectrogram/audio on the cards when audio clip export is disabled.
-  let audioEnabled = $derived(appState.audioExportEnabled);
+  // Each DetectionCard gates its own spectrogram/audio on detection.clipName, so
+  // no card-level audio flag is threaded through here.
 
   // Exclusion state is the shared, server-hydrated excludedSpecies store
   // (hydrated by the parent DetectionsList).
@@ -39,7 +38,6 @@
   {#each detections as detection (detection.id)}
     <DetectionCard
       {detection}
-      {audioEnabled}
       isExcluded={isSpeciesExcluded(detection.commonName)}
       onMarkCorrect={() => actions.handleMarkCorrect(detection)}
       onMarkFalsePositive={() => actions.handleMarkFalsePositive(detection)}

--- a/frontend/src/lib/desktop/features/detections/components/DetectionsList.svelte
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionsList.svelte
@@ -69,10 +69,6 @@
   import DetectionsCardView from './DetectionsCardView.svelte';
   import { appState } from '$lib/stores/appState.svelte';
 
-  // When audio clip export is disabled there are no clips/spectrograms, so the
-  // Recording column (and the mobile/card spectrogram) is hidden.
-  let audioEnabled = $derived(appState.audioExportEnabled);
-
   type SortField = 'dateTime' | 'species' | 'confidence' | 'status';
   type SortDirection = 'asc' | 'desc';
 
@@ -99,6 +95,14 @@
     onSortChange,
     className = '',
   }: Props = $props();
+
+  // Show the Recording column when audio export is enabled (so it stays visible
+  // even for a page that happens to have no clips yet) OR when any visible row
+  // actually has a clip (so historical clips remain reachable after export is
+  // turned off). The per-row spectrogram is still gated on detection.clipName.
+  let showRecordingColumn = $derived(
+    appState.audioExportEnabled || (data?.notes ?? []).some(d => Boolean(d.clipName))
+  );
 
   // Generate title based on query type
   const title = $derived.by(() => {
@@ -623,7 +627,7 @@
                   direction={sortDirection}
                   onSort={handleSort}
                 />
-                {#if audioEnabled}
+                {#if showRecordingColumn}
                   <th scope="col" class="hidden md:table-cell"
                     >{t('detections.headers.recording')}</th
                   >
@@ -644,7 +648,7 @@
                 >
                   <DetectionRow
                     {detection}
-                    {audioEnabled}
+                    {showRecordingColumn}
                     {onDetailsClick}
                     isExcluded={isSpeciesExcluded(detection.commonName)}
                     selectionActive={selection.selectionActive}
@@ -671,7 +675,6 @@
         {#each data.notes as detection (detection.id)}
           <DetectionCardMobile
             {detection}
-            {audioEnabled}
             {onDetailsClick}
             isExcluded={isSpeciesExcluded(detection.commonName)}
             onReview={() => detectionActions.handleReview(detection)}

--- a/frontend/src/lib/desktop/views/DetectionDetail.svelte
+++ b/frontend/src/lib/desktop/views/DetectionDetail.svelte
@@ -29,7 +29,6 @@
   import { loggers } from '$lib/utils/logger';
   import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
   import SourceBadge from '$lib/desktop/features/dashboard/components/SourceBadge.svelte';
-  import { appState } from '$lib/stores/appState.svelte';
   import {
     Download,
     Camera,
@@ -106,8 +105,6 @@
   // Use the existing auth store pattern (same as DesktopSidebar)
   let canReview = $derived($hasReviewPermission);
   let clipExtractionEnabled = $derived($isAuthenticated);
-  // Hide the spectrogram/audio Media section when audio clip export is disabled.
-  let audioEnabled = $derived(appState.audioExportEnabled);
   let detection = $state<Detection | null>(null);
   let speciesInfo = $state<SpeciesInfo | null>(null);
   let taxonomyInfo = $state<TaxonomyInfo | null>(null);
@@ -851,8 +848,8 @@
     <!-- Hero Section -->
     {@render heroSection(detection)}
 
-    <!-- Media Section (hidden when audio clip export is disabled) -->
-    {#if audioEnabled}
+    <!-- Media Section (shown only when this detection has a clip) -->
+    {#if detection.clipName}
       <section class="surface-card" aria-labelledby="media-heading">
         <div class="p-5 md:p-6">
           <h2 id="media-heading" class="section-heading !mb-0">

--- a/frontend/src/lib/desktop/views/Search.svelte
+++ b/frontend/src/lib/desktop/views/Search.svelte
@@ -37,7 +37,6 @@
     PER_VISITOR_SPECIES_LOCALE_ENABLED,
   } from '$lib/stores/speciesDictionary.svelte';
   import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
-  import { appState } from '$lib/stores/appState.svelte';
 
   // SPINNER CONTROL: Set to false to disable loading spinners (reduces flickering)
   // Change back to true to re-enable spinners for testing
@@ -87,8 +86,6 @@
   type SortBy = 'date_desc' | 'date_asc' | 'species_asc' | 'confidence_desc';
 
   let clipExtractionEnabled = $derived($isAuthenticated);
-  // Hide audio players/triggers when audio clip export is disabled.
-  let audioEnabled = $derived(appState.audioExportEnabled);
   let canReview = $derived($hasReviewPermission);
 
   const logger = loggers.ui;
@@ -1144,8 +1141,8 @@
                             </div>
                           </div>
 
-                          <!-- Audio Player (hidden when audio clip export is disabled) -->
-                          {#if audioEnabled}
+                          <!-- Audio Player (shown only when this detection has a clip) -->
+                          {#if result.hasAudio}
                             <div class="bg-[var(--color-base-200)] rounded-box p-4">
                               <h3 class="text-lg font-semibold mb-2">
                                 {t('search.detailsPanel.audioPlayer')}
@@ -1308,7 +1305,7 @@
                         {/if}
                       </div>
                     {/if}
-                    {#if audioEnabled}
+                    {#if result.hasAudio}
                       <button
                         class="btn btn-primary btn-sm"
                         onclick={() => openMobilePlayer(result)}
@@ -1336,7 +1333,7 @@
             </section>
           {/each}
 
-          {#if audioEnabled && showMobilePlayer}
+          {#if showMobilePlayer}
             <div class="md:hidden">
               <MobileAudioPlayer
                 audioUrl={selectedAudioUrl}

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -353,6 +353,14 @@ func (p *AudioPipelineService) Start(_ context.Context) error {
 		})
 	}
 
+	// Start clip reconcile monitor. Runs unconditionally (regardless of retention
+	// policy and regardless of whether audio export is enabled) because orphaned
+	// clip_name references persist across runtime toggling of export, and clearing
+	// them keeps clip_name a truthful per-detection signal for the media API and UI.
+	p.wg.Go(func() {
+		clipReconcileMonitor(p.done, dataStore)
+	})
+
 	// Start weather polling.
 	if settings.Realtime.Weather.Provider != policyNone {
 		p.startWeatherPolling(metrics)

--- a/internal/analysis/clip_reconcile_monitor.go
+++ b/internal/analysis/clip_reconcile_monitor.go
@@ -29,7 +29,7 @@ const clipReconcilePassInterval = 1 * time.Hour
 // export path via conf.Setting() each pass so hot-reload takes effect, and the
 // underlying diskmanager pass applies fail-safe guards so a detached/unmounted
 // export volume never causes mass clearing.
-func clipReconcileMonitor(quitChan chan struct{}, dataStore datastore.Interface) {
+func clipReconcileMonitor(quitChan <-chan struct{}, dataStore datastore.Interface) {
 	log := GetLogger()
 	log.Info("clip reconcile monitor initialized",
 		logger.String("operation", "clip_reconcile_init"))
@@ -70,7 +70,7 @@ func clipReconcileMonitor(quitChan chan struct{}, dataStore datastore.Interface)
 
 // reconcileMonitorWait waits for d or until quitChan closes. It returns false if
 // quitChan closed (shutdown requested), true if the full duration elapsed.
-func reconcileMonitorWait(quitChan chan struct{}, d time.Duration) bool {
+func reconcileMonitorWait(quitChan <-chan struct{}, d time.Duration) bool {
 	timer := time.NewTimer(d)
 	defer timer.Stop()
 	select {

--- a/internal/analysis/clip_reconcile_monitor.go
+++ b/internal/analysis/clip_reconcile_monitor.go
@@ -1,0 +1,82 @@
+// clip_reconcile_monitor.go - background monitor that reconciles persisted
+// clip_name references against the audio files on disk.
+package analysis
+
+import (
+	"strings"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/diskmanager"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// clipReconcileStartupDelay defers the first reconcile pass so it does not contend
+// with boot-time I/O (model load, DB open, initial captures).
+const clipReconcileStartupDelay = 2 * time.Minute
+
+// clipReconcilePassInterval is the wait between full reconcile passes. Ghosts are
+// rare and not time-critical to clear, so a slow cadence keeps disk I/O negligible.
+const clipReconcilePassInterval = 1 * time.Hour
+
+// clipReconcileMonitor continuously reconciles persisted clip_name references
+// against the audio files on disk, clearing references to files that no longer
+// exist (ghosts from failed exports, or from detections created while export was
+// off). Unlike clipCleanupMonitor it runs regardless of the retention policy and
+// regardless of whether audio export is currently enabled, because orphaned
+// references persist across runtime toggling of the export setting. It reads the
+// export path via conf.Setting() each pass so hot-reload takes effect, and the
+// underlying diskmanager pass applies fail-safe guards so a detached/unmounted
+// export volume never causes mass clearing.
+func clipReconcileMonitor(quitChan chan struct{}, dataStore datastore.Interface) {
+	log := GetLogger()
+	log.Info("clip reconcile monitor initialized",
+		logger.String("operation", "clip_reconcile_init"))
+
+	// Defer the first pass; bail out immediately if shutdown arrives first.
+	if !reconcileMonitorWait(quitChan, clipReconcileStartupDelay) {
+		return
+	}
+
+	for {
+		baseDir := strings.TrimSpace(conf.Setting().Realtime.Audio.Export.Path)
+		if baseDir == "" {
+			log.Debug("skipping clip reconcile: export path not configured",
+				logger.String("operation", "clip_reconcile_skip"))
+		} else {
+			result := diskmanager.ReconcileClipOrphansPass(quitChan, dataStore, baseDir)
+			switch {
+			case result.ShutdownRequested:
+				return
+			case result.Aborted:
+				log.Debug("clip reconcile pass aborted",
+					logger.String("reason", result.AbortReason),
+					logger.Int("scanned", result.Scanned),
+					logger.String("operation", "clip_reconcile_pass"))
+			default:
+				log.Info("clip reconcile pass completed",
+					logger.Int("scanned", result.Scanned),
+					logger.Int64("cleared", result.Cleared),
+					logger.String("operation", "clip_reconcile_pass"))
+			}
+		}
+
+		if !reconcileMonitorWait(quitChan, clipReconcilePassInterval) {
+			return
+		}
+	}
+}
+
+// reconcileMonitorWait waits for d or until quitChan closes. It returns false if
+// quitChan closed (shutdown requested), true if the full duration elapsed.
+func reconcileMonitorWait(quitChan chan struct{}, d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-quitChan:
+		return false
+	case <-timer.C:
+		return true
+	}
+}

--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -357,6 +357,19 @@ func (a *SaveAudioAction) Execute(ctx context.Context, _ any) error {
 		return nil
 	}
 
+	// Hot-reload race guard: a detection created while export was disabled carries
+	// an empty ClipName. If export was enabled between createDetection and this
+	// action running, there is no valid output path to write to
+	// (filepath.Join(Export.Path, "") collapses to the export directory itself),
+	// so skip the export rather than encode a clip onto the directory path.
+	if a.ClipName == "" {
+		GetLogger().Debug("Skipping audio export: empty clip name",
+			logger.String("component", "analysis.processor.actions"),
+			logger.String("detection_id", a.CorrelationID),
+			logger.String("operation", "audio_export_empty_clipname"))
+		return nil
+	}
+
 	// Deferred-read path: Extended Capture may schedule an export whose tail
 	// still has not been written to the ring buffer. buildSaveAudioAction
 	// populates bufferMgr/sourceID/beginTime/duration/readyAt and leaves

--- a/internal/analysis/processor/clip_name_test.go
+++ b/internal/analysis/processor/clip_name_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
@@ -75,6 +76,55 @@ func newClipGatingProcessor(exportEnabled bool) *Processor {
 			},
 		},
 	}
+}
+
+// TestApplyBatFormatFallback verifies the shared bat WAV fallback used by both the
+// createDetection and extended-capture paths: a bat model above 48kHz exported to a
+// format that cannot carry that rate keeps the .wav extension the exporter writes.
+func TestApplyBatFormatFallback(t *testing.T) {
+	t.Parallel()
+
+	reg := audiocore.NewSourceRegistry(audiocore.GetLogger())
+	_, err := reg.Register(&audiocore.SourceConfig{
+		ID:               "bat_src",
+		Type:             audiocore.SourceTypeRTSP,
+		ConnectionString: "rtsp://cam/ultrasonic",
+		DisplayName:      "Bat mic",
+		SampleRate:       96000, // above 48kHz -> triggers the bat WAV fallback
+		BitDepth:         16,
+		Channels:         1,
+	})
+	require.NoError(t, err)
+
+	p := &Processor{
+		Settings: &conf.Settings{
+			Realtime: conf.RealtimeSettings{
+				Audio: conf.AudioSettings{
+					Export: conf.ExportSettings{Enabled: true, Type: "mp3"},
+				},
+			},
+		},
+	}
+	p.registry = reg
+	batSource := datastore.AudioSource{ID: "bat_src"}
+
+	t.Run("empty clip name is returned unchanged", func(t *testing.T) {
+		t.Parallel()
+		assert.Empty(t, p.applyBatFormatFallback(p.Settings, "", classifier.RegistryIDBat, batSource))
+	})
+
+	t.Run("bat model above 48kHz with mp3 export forces .wav", func(t *testing.T) {
+		t.Parallel()
+		got := p.applyBatFormatFallback(p.Settings, "2024/01/myotis_85p_x.mp3", classifier.RegistryIDBat, batSource)
+		assert.Equal(t, "2024/01/myotis_85p_x.wav", got,
+			"a bat detection above 48kHz must keep the .wav extension the exporter writes")
+	})
+
+	t.Run("non-bat model keeps the configured extension", func(t *testing.T) {
+		t.Parallel()
+		got := p.applyBatFormatFallback(p.Settings, "2024/01/parus_85p_x.mp3", "", batSource)
+		assert.Equal(t, "2024/01/parus_85p_x.mp3", got)
+	})
 }
 
 // TestResolveClipName_ExportGating verifies that a clip name is only generated

--- a/internal/analysis/processor/clip_name_test.go
+++ b/internal/analysis/processor/clip_name_test.go
@@ -5,7 +5,11 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/detection"
 )
 
 func TestGenerateClipNameWithDuration(t *testing.T) {
@@ -53,4 +57,119 @@ func TestGenerateClipNameWithDuration(t *testing.T) {
 			}
 		})
 	}
+}
+
+// newClipGatingProcessor builds a minimal Processor whose ClipName-generation
+// path (resolveClipName) can run without a real BirdNET instance or registry.
+func newClipGatingProcessor(exportEnabled bool) *Processor {
+	return &Processor{
+		Settings: &conf.Settings{
+			Realtime: conf.RealtimeSettings{
+				Audio: conf.AudioSettings{
+					Export: conf.ExportSettings{
+						Enabled: exportEnabled,
+						Type:    "wav",
+						Length:  15,
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestResolveClipName_ExportGating verifies that a clip name is only generated
+// when audio export is enabled. When export is off, ClipName must be empty so it
+// remains a truthful per-detection signal (issue: truthful clip_name).
+func TestResolveClipName_ExportGating(t *testing.T) {
+	t.Parallel()
+
+	item := &classifier.Results{
+		Source:  datastore.AudioSource{ID: "test_source"},
+		ModelID: "",
+	}
+
+	t.Run("export disabled yields empty clip name", func(t *testing.T) {
+		t.Parallel()
+		p := newClipGatingProcessor(false)
+		clipName := p.resolveClipName(p.Settings, item, "Parus major", 0.85)
+		assert.Empty(t, clipName,
+			"clip name must be empty when export is disabled so it stays a truthful signal")
+	})
+
+	t.Run("export enabled yields non-empty clip name", func(t *testing.T) {
+		t.Parallel()
+		p := newClipGatingProcessor(true)
+		clipName := p.resolveClipName(p.Settings, item, "Parus major", 0.85)
+		require.NotEmpty(t, clipName, "clip name must be generated when export is enabled")
+		assert.Contains(t, clipName, "parus_major")
+		assert.Contains(t, clipName, ".wav")
+	})
+}
+
+// TestNormalizeDetectionTimes_ExtendedCapture_ExportGating verifies the extended
+// capture path only regenerates the clip name when export is enabled, leaving a
+// truthful empty ClipName otherwise (even though EndTime is still recomputed).
+func TestNormalizeDetectionTimes_ExtendedCapture_ExportGating(t *testing.T) {
+	t.Parallel()
+
+	newItem := func() *PendingDetection {
+		firstDetected := time.Date(2026, 3, 7, 20, 0, 0, 0, time.UTC)
+		return &PendingDetection{
+			Detection: Detections{
+				Result: detection.Result{
+					BeginTime: firstDetected.Add(30 * time.Second),
+					EndTime:   firstDetected.Add(84 * time.Second),
+					Timestamp: firstDetected,
+					Species: detection.Species{
+						CommonName:     "lehtopöllö",
+						ScientificName: "Strix aluco",
+					},
+					ClipName: "",
+				},
+			},
+			Confidence:      0.92,
+			Source:          "test_source",
+			FirstDetected:   firstDetected,
+			LastUpdated:     firstDetected.Add(3 * time.Minute),
+			Count:           45,
+			ExtendedCapture: true,
+		}
+	}
+
+	t.Run("export disabled leaves clip name empty", func(t *testing.T) {
+		t.Parallel()
+		p := &Processor{
+			Settings: &conf.Settings{
+				Realtime: conf.RealtimeSettings{
+					Audio: conf.AudioSettings{
+						Export: conf.ExportSettings{Enabled: false, Length: 60, PreCapture: 6, Type: "wav"},
+					},
+					ExtendedCapture: conf.ExtendedCaptureSettings{Enabled: true, MaxDuration: 600},
+				},
+			},
+		}
+		item := newItem()
+		p.normalizeDetectionTimes(item)
+		assert.Empty(t, item.Detection.Result.ClipName,
+			"extended capture must not regenerate a clip name when export is disabled")
+	})
+
+	t.Run("export enabled regenerates clip name with duration", func(t *testing.T) {
+		t.Parallel()
+		p := &Processor{
+			Settings: &conf.Settings{
+				Realtime: conf.RealtimeSettings{
+					Audio: conf.AudioSettings{
+						Export: conf.ExportSettings{Enabled: true, Length: 60, PreCapture: 6, Type: "wav"},
+					},
+					ExtendedCapture: conf.ExtendedCaptureSettings{Enabled: true, MaxDuration: 600},
+				},
+			},
+		}
+		item := newItem()
+		p.normalizeDetectionTimes(item)
+		require.NotEmpty(t, item.Detection.Result.ClipName,
+			"extended capture must regenerate a clip name when export is enabled")
+		assert.Contains(t, item.Detection.Result.ClipName, "strix_aluco")
+	})
 }

--- a/internal/analysis/processor/extended_capture.go
+++ b/internal/analysis/processor/extended_capture.go
@@ -248,16 +248,21 @@ func (p *Processor) normalizeDetectionTimes(item *PendingDetection) {
 		// LastUpdated is always initialized (set on creation and every re-detection).
 		item.Detection.Result.EndTime = item.LastUpdated.Add(normalDetectionWindow)
 
-		// Regenerate clip name with actual duration (unknown at createDetection time)
-		preCapture := settings.Realtime.Audio.Export.PreCapture
-		durationSeconds := int(item.Detection.Result.EndTime.Sub(item.Detection.Result.BeginTime).Seconds()) + preCapture
-		item.Detection.Result.ClipName = p.generateClipNameWithDuration(
-			settings,
-			item.Detection.Result.Species.ScientificName,
-			float32(item.Confidence),
-			durationSeconds,
-			item.Detection.Result.Timestamp,
-		)
+		// Regenerate clip name with the actual duration (unknown at createDetection
+		// time), but only when export is enabled. When export is off the clip name
+		// stays empty so it remains a truthful per-detection signal (no file will be
+		// written); regenerating it here would reintroduce a ghost reference.
+		if settings.Realtime.Audio.Export.Enabled {
+			preCapture := settings.Realtime.Audio.Export.PreCapture
+			durationSeconds := int(item.Detection.Result.EndTime.Sub(item.Detection.Result.BeginTime).Seconds()) + preCapture
+			item.Detection.Result.ClipName = p.generateClipNameWithDuration(
+				settings,
+				item.Detection.Result.Species.ScientificName,
+				float32(item.Confidence),
+				durationSeconds,
+				item.Detection.Result.Timestamp,
+			)
+		}
 	} else {
 		// For non-extended detections, recalculate EndTime to maintain the configured
 		// capture window. BeginTime was backdated to FirstDetected, but EndTime may

--- a/internal/analysis/processor/extended_capture.go
+++ b/internal/analysis/processor/extended_capture.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/classifier"
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/openfauna"
 )
@@ -255,13 +256,18 @@ func (p *Processor) normalizeDetectionTimes(item *PendingDetection) {
 		if settings.Realtime.Audio.Export.Enabled {
 			preCapture := settings.Realtime.Audio.Export.PreCapture
 			durationSeconds := int(item.Detection.Result.EndTime.Sub(item.Detection.Result.BeginTime).Seconds()) + preCapture
-			item.Detection.Result.ClipName = p.generateClipNameWithDuration(
+			clipName := p.generateClipNameWithDuration(
 				settings,
 				item.Detection.Result.Species.ScientificName,
 				float32(item.Confidence),
 				durationSeconds,
 				item.Detection.Result.Timestamp,
 			)
+			// Reapply the bat WAV fallback so a bat detection above 48kHz keeps the
+			// .wav extension the exporter writes, instead of the configured
+			// MP3/Opus/AAC extension (matches createDetection's resolveClipName).
+			item.Detection.Result.ClipName = p.applyBatFormatFallback(
+				settings, clipName, item.BestModelID, datastore.AudioSource{ID: item.Source})
 		}
 	} else {
 		// For non-extended detections, recalculate EndTime to maintain the configured

--- a/internal/analysis/processor/mock_datastore_test.go
+++ b/internal/analysis/processor/mock_datastore_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/detection"
+	"github.com/tphakala/birdnet-go/internal/diskmanager"
 	"gorm.io/gorm"
 )
 
@@ -263,6 +264,9 @@ func (m *ActionMockDatastore) GetLockedNotesClipPaths() ([]string, error) {
 }
 func (m *ActionMockDatastore) ClearNoteClipPathsByNames(_ []string) (int64, error) {
 	return 0, nil
+}
+func (m *ActionMockDatastore) GetNoteClipReferences(_ uint, _ int) ([]diskmanager.ClipReference, error) {
+	return nil, nil
 }
 func (m *ActionMockDatastore) CountHourlyDetections(_, _ string, _ int) (int64, error) {
 	return 0, nil

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -1097,17 +1097,12 @@ func isSpeciesExcluded(commonName, scientificName string, excludeList []string) 
 //
 //nolint:gocritic // hugeParam: Pass by value is intentional - avoids pointer dereferencing in hot path
 func (p *Processor) createDetection(settings *conf.Settings, item classifier.Results, result datastore.Results, scientificName, commonName, speciesCode, rawScientificName string) Detections {
-	// Create file name for audio clip
-	clipName := p.generateClipName(settings, scientificName, result.Confidence)
-
-	// Bat models at high sample rates need WAV when the configured format
-	// (MP3/Opus/AAC) cannot carry rates above 48kHz. Override the extension
-	// now so the database stores the same filename the export will write.
-	mInfo := classifier.DetectionModelInfoForID(item.ModelID)
-	sourceRate := p.resolveAudioSource(item.Source).SampleRate
-	if needsBatFormatFallback(mInfo.Name, mInfo.Version, sourceRate, settings.Realtime.Audio.Export.Type) {
-		clipName = replaceExtension(clipName, ".wav")
-	}
+	// Create file name for audio clip. When audio export is disabled the clip
+	// name is left empty so it stays a truthful per-detection signal: no file
+	// is or will be written, so nothing must reference one. The media API and
+	// the UI gate on a non-empty ClipName, and no SaveAudioAction is scheduled
+	// when export is off, so there is no async-export race to preserve here.
+	clipName := p.resolveClipName(settings, &item, scientificName, result.Confidence)
 
 	// Get capture length and pre-capture length for detection end time calculation
 	captureLength := time.Duration(settings.Realtime.Audio.Export.Length) * time.Second
@@ -1363,6 +1358,29 @@ func (p *Processor) getBaseConfidenceThreshold(settings *conf.Settings, commonNa
 		return float32(settings.Bat.Threshold)
 	}
 	return float32(settings.BirdNET.Threshold)
+}
+
+// resolveClipName returns the clip filename to persist for a detection, or an
+// empty string when audio export is disabled. Keeping ClipName empty while
+// export is off makes it a truthful per-detection signal (no clip exists or is
+// being encoded), which the media endpoint and the frontend rely on to gate
+// audio playback per detection under runtime toggling of the export setting.
+func (p *Processor) resolveClipName(settings *conf.Settings, item *classifier.Results, scientificName string, confidence float32) string {
+	if !settings.Realtime.Audio.Export.Enabled {
+		return ""
+	}
+
+	clipName := p.generateClipName(settings, scientificName, confidence)
+
+	// Bat models at high sample rates need WAV when the configured format
+	// (MP3/Opus/AAC) cannot carry rates above 48kHz. Override the extension
+	// now so the database stores the same filename the export will write.
+	mInfo := classifier.DetectionModelInfoForID(item.ModelID)
+	sourceRate := p.resolveAudioSource(item.Source).SampleRate
+	if needsBatFormatFallback(mInfo.Name, mInfo.Version, sourceRate, settings.Realtime.Audio.Export.Type) {
+		clipName = replaceExtension(clipName, ".wav")
+	}
+	return clipName
 }
 
 // generateClipName generates a clip name for the given scientific name and confidence.

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -1371,14 +1371,23 @@ func (p *Processor) resolveClipName(settings *conf.Settings, item *classifier.Re
 	}
 
 	clipName := p.generateClipName(settings, scientificName, confidence)
+	return p.applyBatFormatFallback(settings, clipName, item.ModelID, item.Source)
+}
 
-	// Bat models at high sample rates need WAV when the configured format
-	// (MP3/Opus/AAC) cannot carry rates above 48kHz. Override the extension
-	// now so the database stores the same filename the export will write.
-	mInfo := classifier.DetectionModelInfoForID(item.ModelID)
-	sourceRate := p.resolveAudioSource(item.Source).SampleRate
+// applyBatFormatFallback overrides a clip name's extension to .wav when a bat model
+// at a high source sample rate is exported to a format (MP3/Opus/AAC) that cannot
+// carry rates above 48kHz, so the stored ClipName matches the file the exporter
+// actually writes. It is shared by the createDetection and extended-capture paths
+// so both persist the same fallback extension. An empty clip name is returned
+// unchanged.
+func (p *Processor) applyBatFormatFallback(settings *conf.Settings, clipName, modelID string, source datastore.AudioSource) string {
+	if clipName == "" {
+		return clipName
+	}
+	mInfo := classifier.DetectionModelInfoForID(modelID)
+	sourceRate := p.resolveAudioSource(source).SampleRate
 	if needsBatFormatFallback(mInfo.Name, mInfo.Version, sourceRate, settings.Realtime.Audio.Export.Type) {
-		clipName = replaceExtension(clipName, ".wav")
+		return replaceExtension(clipName, ".wav")
 	}
 	return clipName
 }

--- a/internal/analysis/processor/save_audio_action_test.go
+++ b/internal/analysis/processor/save_audio_action_test.go
@@ -117,6 +117,34 @@ func TestSaveAudioActionExecute_PropagatesBufferReadError(t *testing.T) {
 	assert.NotErrorIs(t, err, errAudioExportDeferred)
 }
 
+// TestSaveAudioActionExecute_SkipsEmptyClipName guards the hot-reload race where
+// a detection is created while export is disabled (empty ClipName) and export is
+// then enabled before the action runs. Without the guard, filepath.Join(Path, "")
+// collapses to the export directory and encoding would target the directory path.
+func TestSaveAudioActionExecute_SkipsEmptyClipName(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	settings := conftest.NewTestSettings().
+		WithAudioExport(tmpDir, "wav", "192k").
+		Build()
+
+	// pcmData is populated so, absent the empty-ClipName guard, Execute would
+	// proceed to encode; the guard must stop it first and return no error.
+	action := &SaveAudioAction{
+		Settings: settings,
+		ClipName: "",
+		pcmData:  []byte{0, 1, 2, 3},
+	}
+
+	require.NoError(t, action.Execute(t.Context(), nil))
+
+	// No file (and no stray directory-as-file) must be written to the export dir.
+	entries, err := os.ReadDir(tmpDir)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "no audio file should be written when ClipName is empty")
+}
+
 func TestGetJobQueueRetryConfig_SaveAudioDeferred(t *testing.T) {
 	t.Parallel()
 

--- a/internal/analysis/processor/threshold_persistence_test.go
+++ b/internal/analysis/processor/threshold_persistence_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/detection"
+	"github.com/tphakala/birdnet-go/internal/diskmanager"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"gorm.io/gorm"
 )
@@ -133,8 +134,11 @@ func (m *MockDatastore) SaveImageCache(*datastore.ImageCache) error { return nil
 func (m *MockDatastore) GetAllImageCaches(string) ([]datastore.ImageCache, error) {
 	return make([]datastore.ImageCache, 0), nil
 }
-func (m *MockDatastore) GetLockedNotesClipPaths() ([]string, error)               { return make([]string, 0), nil }
-func (m *MockDatastore) ClearNoteClipPathsByNames(_ []string) (int64, error)      { return 0, nil }
+func (m *MockDatastore) GetLockedNotesClipPaths() ([]string, error)          { return make([]string, 0), nil }
+func (m *MockDatastore) ClearNoteClipPathsByNames(_ []string) (int64, error) { return 0, nil }
+func (m *MockDatastore) GetNoteClipReferences(_ uint, _ int) ([]diskmanager.ClipReference, error) {
+	return nil, nil
+}
 func (m *MockDatastore) CountHourlyDetections(string, string, int) (int64, error) { return 0, nil }
 func (m *MockDatastore) GetSpeciesSummaryData(context.Context, string, string) ([]datastore.SpeciesSummaryData, error) {
 	return make([]datastore.SpeciesSummaryData, 0), nil

--- a/internal/api/v2/apicore/sse.go
+++ b/internal/api/v2/apicore/sse.go
@@ -97,9 +97,12 @@ type SSESoundLevelData struct {
 	EventType string `json:"eventType"`
 }
 
-// safeBaseName returns the filename component of a path, or empty string if the path is empty.
+// SafeBaseName returns the filename component of a path, or empty string if the path is empty.
 // Unlike filepath.Base("") which returns ".", this returns "" for empty inputs.
-func safeBaseName(path string) string {
+// It defines the clip-name privacy contract shared by the SSE feed and the REST
+// detection responses: only the basename is exposed, never the on-disk directory
+// layout, and an empty clip name stays empty (a truthful "no clip" signal).
+func SafeBaseName(path string) string {
 	if path == "" {
 		return ""
 	}
@@ -120,7 +123,7 @@ func NewSSEDetectionData(note *datastore.Note, birdImage *imageprovider.BirdImag
 		Confidence:     note.Confidence,
 		Latitude:       note.Latitude,
 		Longitude:      note.Longitude,
-		ClipName:       safeBaseName(note.ClipName),
+		ClipName:       SafeBaseName(note.ClipName),
 		Verified:       note.Verified,
 		Locked:         note.Locked,
 		Unlikely:       note.Unlikely,

--- a/internal/api/v2/app/app_test.go
+++ b/internal/api/v2/app/app_test.go
@@ -897,6 +897,7 @@ func TestGetAppConfig_NoExtraFields(t *testing.T) {
 		"customColors":       true,
 		"logoStyle":          true,
 		"liveSpectrogram":    true,
+		"audioExportEnabled": true,
 		"freshInstall":       true,
 		"newVersion":         true,
 		"projectLinks":       true,

--- a/internal/api/v2/detections/detections.go
+++ b/internal/api/v2/detections/detections.go
@@ -153,6 +153,7 @@ type DetectionResponse struct {
 	ScientificName     string            `json:"scientificName"`
 	CommonName         string            `json:"commonName"`
 	Confidence         float64           `json:"confidence"`
+	ClipName           string            `json:"clipName,omitempty"`  // Audio clip filename (basename only, no path); empty when no clip exists
 	ModelType          string            `json:"modelType,omitempty"` // AI model type (e.g. "bird", "bat"); drives the spectrogram frequency range
 	Verified           string            `json:"verified"`
 	Locked             bool              `json:"locked"`
@@ -689,8 +690,13 @@ func (c *Handler) noteToDetectionResponse(note *datastore.Note, includeWeather b
 		ScientificName: note.ScientificName,
 		CommonName:     note.CommonName,
 		Confidence:     note.Confidence,
-		Locked:         note.Locked,
-		Unlikely:       note.Unlikely,
+		// ClipName is the per-detection signal the frontend gates audio playback
+		// on. It is basename-stripped to match the SSE privacy contract
+		// (apicore.SafeBaseName): only the filename is exposed, never the on-disk
+		// directory layout, and an empty clip name stays empty (no clip exists).
+		ClipName: apicore.SafeBaseName(note.ClipName),
+		Locked:   note.Locked,
+		Unlikely: note.Unlikely,
 	}
 
 	// populate source info if available

--- a/internal/api/v2/detections/detections_test.go
+++ b/internal/api/v2/detections/detections_test.go
@@ -688,6 +688,113 @@ func TestGetDetection(t *testing.T) {
 	}
 }
 
+// TestGetDetection_ClipNameSerialized is a HANDLER-level guard for the REST
+// detection response contract: the JSON payload MUST carry a clipName field,
+// basename-stripped to match the SSE privacy contract, and MUST omit it when the
+// detection has no clip. The frontend gates per-detection audio playback on this
+// field; if the endpoint stops serializing it, every export-enabled user silently
+// loses media. Asserting on the raw JSON (not just an unmarshaled struct) makes
+// the test fail if the struct field or its json tag is ever removed.
+func TestGetDetection_ClipNameSerialized(t *testing.T) {
+	e, mockDS, controller := setupTestEnvironment(t)
+
+	const clipPath = "2025/03/corvus_brachyrhynchos_95p_20250307T081500Z.wav"
+	const clipBase = "corvus_brachyrhynchos_95p_20250307T081500Z.wav"
+
+	baseNote := datastore.Note{
+		ID:             7,
+		Date:           "2025-03-07",
+		Time:           "08:15:00",
+		Source:         testRealtimeSource(),
+		SpeciesCode:    "AMCRO",
+		ScientificName: "Corvus brachyrhynchos",
+		CommonName:     "American Crow",
+		Confidence:     0.95,
+		BeginTime:      time.Now().Add(-time.Hour),
+		EndTime:        time.Now(),
+	}
+
+	t.Run("clip present is serialized as basename", func(t *testing.T) {
+		note := baseNote
+		note.ClipName = clipPath
+		mockDS.ExpectedCalls = nil
+		mockDS.On("Get", "7").Return(note, nil)
+		mockDS.On("GetHourlyWeather", "2025-03-07").Return([]datastore.HourlyWeather{}, nil)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v2/detections/7", http.NoBody)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetParamNames("id")
+		c.SetParamValues("7")
+
+		require.NoError(t, controller.GetDetection(c))
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		// Raw JSON must contain the field so removing it from the struct fails here.
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &payload))
+		clip, ok := payload["clipName"]
+		require.True(t, ok, "response JSON must include clipName")
+		assert.Equal(t, clipBase, clip, "clipName must be basename-stripped (SSE privacy contract)")
+		assert.NotContains(t, rec.Body.String(), "2025/03",
+			"clipName must not leak the on-disk directory layout")
+	})
+
+	t.Run("empty clip is omitted", func(t *testing.T) {
+		note := baseNote
+		note.ClipName = ""
+		mockDS.ExpectedCalls = nil
+		mockDS.On("Get", "7").Return(note, nil)
+		mockDS.On("GetHourlyWeather", "2025-03-07").Return([]datastore.HourlyWeather{}, nil)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v2/detections/7", http.NoBody)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetParamNames("id")
+		c.SetParamValues("7")
+
+		require.NoError(t, controller.GetDetection(c))
+		require.Equal(t, http.StatusOK, rec.Code)
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &payload))
+		_, ok := payload["clipName"]
+		assert.False(t, ok, "clipName must be omitted when the detection has no clip")
+	})
+}
+
+// TestGetRecentDetections_ClipNameSerialized covers the list converter path so
+// the per-detection clipName signal is present in list responses too.
+func TestGetRecentDetections_ClipNameSerialized(t *testing.T) {
+	e, mockDS, controller := setupTestEnvironment(t)
+
+	notes := []datastore.Note{
+		{
+			ID:             1,
+			Date:           "2025-03-07",
+			Time:           "08:15:00",
+			Source:         testRealtimeSource(),
+			ScientificName: "Corvus brachyrhynchos",
+			CommonName:     "American Crow",
+			Confidence:     0.95,
+			ClipName:       "2025/03/corvus_brachyrhynchos_95p_20250307T081500Z.wav",
+		},
+	}
+	mockDS.On("GetLastDetections", 10).Return(notes, nil).Once()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/detections/recent", http.NoBody)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, controller.GetRecentDetections(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var payload []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &payload))
+	require.Len(t, payload, 1)
+	assert.Equal(t, "corvus_brachyrhynchos_95p_20250307T081500Z.wav", payload[0]["clipName"],
+		"list responses must carry the basename-stripped clipName")
+}
+
 // TestGetDetectionCommentFormat verifies that detection comments are returned
 // with full object format (id, entry, createdAt, updatedAt) as expected by the frontend.
 // This test was added to fix issue #1728 where comments displayed as "NaN-NaN-NaN NaN:NaN:NaN"

--- a/internal/api/v2/media/media.go
+++ b/internal/api/v2/media/media.go
@@ -18,9 +18,11 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/audiocore/audiotemp"
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/repository"
+	"github.com/tphakala/birdnet-go/internal/diskmanager"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -414,28 +416,7 @@ func (c *Handler) findEncodingTempPath(relClipPath string) (string, bool) {
 // and the pre-fix "<base>.temp" form, but NOT unrelated sidecar temps that merely
 // share the prefix and suffix, e.g. a spectrogram's "<base>.png.<pid>.<seq>.temp".
 func isExportTempFor(name, base string) bool {
-	// Pre-fix format: exactly "<base>.temp".
-	if name == base+ffmpeg.TempExt {
-		return true
-	}
-	// Unique format: "<base>.<pid>.<seq>.temp" with integer pid and seq.
-	middle, ok := strings.CutPrefix(name, base+".")
-	if !ok {
-		return false
-	}
-	middle, ok = strings.CutSuffix(middle, ffmpeg.TempExt)
-	if !ok {
-		return false
-	}
-	pidStr, seqStr, ok := strings.Cut(middle, ".")
-	if !ok {
-		return false
-	}
-	if _, err := strconv.Atoi(pidStr); err != nil {
-		return false
-	}
-	_, err := strconv.Atoi(seqStr)
-	return err == nil
+	return audiotemp.IsTempFor(name, base)
 }
 
 // isAudioBeingEncoded reports whether a recent in-progress export temp file
@@ -536,12 +517,37 @@ func (c *Handler) waitForAudioFileGrace(ctx echo.Context, relClipPath string) bo
 	}
 }
 
+// isRecentClipCompletion reports whether a detection whose capture completed at
+// endTime is recent enough that its audio clip may still be encoding. A zero
+// endTime is treated as recent (unknown age -> fail-safe: keep waiting) so a
+// missing timestamp never suppresses the grace wait for a genuinely live encode.
+// Recency is keyed on completion time (Note.EndTime), shared with the reconcile
+// crawler via diskmanager.ClipRecencyWindow.
+func isRecentClipCompletion(endTime time.Time) bool {
+	return endTime.IsZero() || time.Since(endTime) < diskmanager.ClipRecencyWindow
+}
+
+// noteCompletionTime returns the detection's capture completion time (Note.EndTime)
+// for the grace-poll recency decision, or the zero time if it cannot be determined
+// (nil datastore, lookup error, or unset). It is only called on the 404 slow path,
+// so the extra lookup does not affect normal audio serves.
+func (c *Handler) noteCompletionTime(noteID string) time.Time {
+	if c.DS == nil {
+		return time.Time{}
+	}
+	note, err := c.DS.Get(noteID)
+	if err != nil {
+		return time.Time{}
+	}
+	return note.EndTime
+}
+
 // handleAudio404WithWait handles a 404 error for an audio file that may still be
 // encoding. It checks for an active temp file and waits for encoding to complete,
 // then falls back to a brief grace period for the race window where FFmpeg hasn't
 // created the temp file yet or already renamed it. Returns nil if the file was
 // successfully served, or the original/translated error otherwise.
-func (c *Handler) handleAudio404WithWait(ctx echo.Context, relClipPath string, originalErr error, logFields ...logger.Field) error {
+func (c *Handler) handleAudio404WithWait(ctx echo.Context, relClipPath string, originalErr error, detectionEndTime time.Time, logFields ...logger.Field) error {
 	if tempPath, encoding := c.findEncodingTempPath(relClipPath); encoding {
 		// Wait server-side for the file to appear instead of immediately
 		// returning 503, reducing unnecessary client round-trips. Pass the
@@ -563,8 +569,19 @@ func (c *Handler) handleAudio404WithWait(ctx echo.Context, relClipPath string, o
 		return c.translateSecureFSError(ctx, originalErr, "Failed to serve audio clip due to an unexpected error")
 	}
 
-	// No temp file visible - brief grace wait for the race window where
-	// FFmpeg hasn't created the temp file yet or already renamed it.
+	// No temp file visible. For a detection whose capture completed long ago,
+	// skip the grace wait entirely and return 404 now: no export is in flight
+	// (the temp-file check above already ruled that out), so the file is a
+	// pre-reconcile ghost, not a live encode. Waiting would only pin an HTTP
+	// worker for the full grace period, and a page full of such ghosts would pin
+	// one worker each. Recent (or unknown-age) detections still get the brief
+	// grace wait for the FFmpeg race window.
+	if !isRecentClipCompletion(detectionEndTime) {
+		return c.translateSecureFSError(ctx, originalErr, "Failed to serve audio clip due to an unexpected error")
+	}
+
+	// Brief grace wait for the race window where FFmpeg hasn't created the temp
+	// file yet or already renamed it.
 	if c.waitForAudioFileGrace(ctx, relClipPath) {
 		if retryErr := c.SFS.ServeRelativeFile(ctx, relClipPath); retryErr != nil {
 			return c.translateSecureFSError(ctx, retryErr, "Failed to serve audio clip after grace wait")
@@ -615,7 +632,9 @@ func (c *Handler) ServeAudioClip(ctx echo.Context) error {
 		// frontend may request the file before it exists on disk.
 		var httpErr *echo.HTTPError
 		if errors.As(err, &httpErr) && httpErr.Code == http.StatusNotFound {
-			return c.handleAudio404WithWait(ctx, normalizedFilename, err,
+			// Filename-based serving has no note ID to resolve a completion time,
+			// so pass the zero time (unknown -> keep the grace wait, fail-safe).
+			return c.handleAudio404WithWait(ctx, normalizedFilename, err, time.Time{},
 				logger.String("filename", filename),
 				logger.String("path", ctx.Request().URL.Path),
 				logger.String("ip", ctx.RealIP()),
@@ -716,7 +735,9 @@ func (c *Handler) ServeAudioByID(ctx echo.Context) error {
 
 		var httpErr *echo.HTTPError
 		if errors.As(err, &httpErr) && httpErr.Code == http.StatusNotFound {
-			return c.handleAudio404WithWait(ctx, normalizedClipPath, err,
+			// Skip the grace wait for old detections whose clip is a pre-reconcile
+			// ghost. Completion time is looked up here on the 404 slow path only.
+			return c.handleAudio404WithWait(ctx, normalizedClipPath, err, c.noteCompletionTime(noteID),
 				logger.String("note_id", noteID),
 				logger.String("path", ctx.Request().URL.Path),
 				logger.String("ip", ctx.RealIP()),

--- a/internal/api/v2/media/media_test.go
+++ b/internal/api/v2/media/media_test.go
@@ -21,7 +21,9 @@ import (
 	"github.com/tphakala/birdnet-go/internal/api/middleware"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
+	"github.com/tphakala/birdnet-go/internal/diskmanager"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"gorm.io/gorm"
 )
@@ -1479,6 +1481,93 @@ func TestServeAudioClipNoTempFileReturns404(t *testing.T) {
 	} else {
 		assert.Equal(t, http.StatusNotFound, rec.Code,
 			"Should return 404 when no temp file exists")
+	}
+}
+
+// TestIsRecentClipCompletion covers the recency predicate shared with the
+// reconcile crawler: a zero completion time is treated as recent (fail-safe),
+// times inside the window are recent, and times older than the window are not.
+func TestIsRecentClipCompletion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		endTime time.Time
+		want    bool
+	}{
+		{name: "zero time is recent (unknown, fail-safe)", endTime: time.Time{}, want: true},
+		{name: "just now is recent", endTime: time.Now(), want: true},
+		{name: "inside window is recent", endTime: time.Now().Add(-diskmanager.ClipRecencyWindow / 2), want: true},
+		{name: "older than window is not recent", endTime: time.Now().Add(-2 * diskmanager.ClipRecencyWindow), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isRecentClipCompletion(tt.endTime))
+		})
+	}
+}
+
+// TestServeAudioByID_GraceSkippedForOldDetections verifies the defense-in-depth
+// grace-poll skip: a 404 for a detection whose capture completed long ago returns
+// immediately (no grace wait), while a recent detection still waits out the grace
+// period. Timing bounds around audioGracePeriod distinguish the two paths.
+func TestServeAudioByID_GraceSkippedForOldDetections(t *testing.T) {
+	// clipPath resolves but the file does not exist on disk, forcing the 404 path.
+	const missingClip = "2024/01/ghost_95p_20240101T000000Z.wav"
+
+	tests := []struct {
+		name       string
+		endTime    time.Time
+		maxElapsed time.Duration // set: proves grace was skipped
+		minElapsed time.Duration // set: proves grace ran
+	}{
+		{
+			name:       "old detection skips grace and 404s immediately",
+			endTime:    time.Now().Add(-time.Hour),
+			maxElapsed: audioGracePeriod,
+		},
+		{
+			name:       "recent detection still waits the grace period",
+			endTime:    time.Now(),
+			minElapsed: audioGracePeriod,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e, controller, _ := setupMediaTestEnvironment(t)
+
+			mockDS := mocks.NewMockInterface(t)
+			mockDS.On("GetNoteClipPath", "42").Return(missingClip, nil)
+			mockDS.On("Get", "42").Return(datastore.Note{ID: 42, EndTime: tc.endTime}, nil).Maybe()
+			controller.DS = mockDS
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v2/audio/42", http.NoBody)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetParamNames("id")
+			c.SetParamValues("42")
+
+			start := time.Now()
+			handlerErr := controller.ServeAudioByID(c)
+			elapsed := time.Since(start)
+
+			// The missing clip resolves to a 404, returned as an echo.HTTPError
+			// (the framework translates it to the HTTP response).
+			require.Error(t, handlerErr, "missing clip must error")
+			httpErr, ok := errors.AsType[*echo.HTTPError](handlerErr)
+			require.True(t, ok, "expected an echo.HTTPError")
+			assert.Equal(t, http.StatusNotFound, httpErr.Code, "missing clip must 404")
+			if tc.maxElapsed > 0 {
+				assert.Less(t, elapsed, tc.maxElapsed,
+					"old detection must skip the grace wait")
+			}
+			if tc.minElapsed > 0 {
+				assert.GreaterOrEqual(t, elapsed, tc.minElapsed,
+					"recent detection must wait out the grace period")
+			}
+		})
 	}
 }
 

--- a/internal/audiocore/audiotemp/audiotemp.go
+++ b/internal/audiocore/audiotemp/audiotemp.go
@@ -14,6 +14,8 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 )
@@ -49,6 +51,36 @@ var seq atomic.Uint64
 // happens to share the recordings directory.
 func UniquePath(outputPath string) string {
 	return fmt.Sprintf("%s.%d.%d%s", outputPath, os.Getpid(), seq.Add(1), Ext)
+}
+
+// IsTempFor reports whether name is an in-progress temp file for the clip whose
+// base filename is base. It is the single source of truth for the temp-file
+// grammar UniquePath writes, so callers that serve or reconcile clips (the media
+// handler and the reconcile crawler) recognize an actively-writing clip as
+// present rather than missing. It matches both the legacy fixed form
+// "<base>.temp" and the process-unique form "<base>.<pid>.<seq>.temp" (pid and
+// seq are integers).
+func IsTempFor(name, base string) bool {
+	if name == base+Ext {
+		return true
+	}
+	middle, ok := strings.CutPrefix(name, base+".")
+	if !ok {
+		return false
+	}
+	middle, ok = strings.CutSuffix(middle, Ext)
+	if !ok {
+		return false
+	}
+	pidStr, seqStr, ok := strings.Cut(middle, ".")
+	if !ok {
+		return false
+	}
+	if _, err := strconv.Atoi(pidStr); err != nil {
+		return false
+	}
+	_, err := strconv.Atoi(seqStr)
+	return err == nil
 }
 
 // Finalize atomically renames the unique temp file onto the final clip path. On

--- a/internal/audiocore/audiotemp/audiotemp_test.go
+++ b/internal/audiocore/audiotemp/audiotemp_test.go
@@ -148,3 +148,33 @@ func TestFinalizeWith_PropagatesRenameError(t *testing.T) {
 		assert.Equal(t, 1, calls, "non-Windows must not retry a failed rename")
 	}
 }
+
+func TestIsTempFor(t *testing.T) {
+	t.Parallel()
+
+	const base = "clip.wav"
+	tests := []struct {
+		name string
+		file string
+		want bool
+	}{
+		{"legacy fixed temp", "clip.wav" + audiotemp.Ext, true},
+		{"process-unique temp", "clip.wav.1234.5" + audiotemp.Ext, true},
+		{"final file is not a temp", "clip.wav", false},
+		{"temp for a different clip", "other.wav" + audiotemp.Ext, false},
+		{"non-integer pid", "clip.wav.abc.5" + audiotemp.Ext, false},
+		{"missing seq segment", "clip.wav.1234" + audiotemp.Ext, false},
+		{"unrelated suffix", "clip.wav.1234.5.bak", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, audiotemp.IsTempFor(tt.file, base))
+		})
+	}
+
+	// The real UniquePath output must be recognized for its own base.
+	unique := audiotemp.UniquePath("clip.wav")
+	assert.True(t, audiotemp.IsTempFor(filepath.Base(unique), "clip.wav"),
+		"UniquePath output must match IsTempFor for the same base")
+}

--- a/internal/datastore/clip_reconcile_query_test.go
+++ b/internal/datastore/clip_reconcile_query_test.go
@@ -1,0 +1,58 @@
+package datastore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetNoteClipReferences verifies the keyset-paginated read used by the clip
+// reconcile crawler: it returns only rows with a non-empty clip_name, ordered by
+// ID ascending, honors afterID and limit, and maps EndTime to CompletionTime.
+func TestGetNoteClipReferences(t *testing.T) {
+	ds := setupTestDB(t)
+
+	end1 := time.Date(2024, 1, 15, 8, 31, 0, 0, time.UTC)
+	end3 := time.Date(2024, 1, 16, 10, 1, 0, 0, time.UTC)
+	notes := []Note{
+		{ID: 1, Date: "2024-01-15", Time: "08:30:00", ClipName: "2024/01/a.wav", EndTime: end1},
+		{ID: 2, Date: "2024-01-15", Time: "09:15:00", ClipName: ""}, // no clip -> excluded
+		{ID: 3, Date: "2024-01-16", Time: "10:00:00", ClipName: "2024/01/c.wav", EndTime: end3},
+		{ID: 4, Date: "2024-01-16", Time: "11:00:00", ClipName: "2024/01/d.wav"},
+	}
+	require.NoError(t, ds.DB.Create(&notes).Error)
+
+	t.Run("filters empty clip_name and orders by id", func(t *testing.T) {
+		refs, err := ds.GetNoteClipReferences(0, 10)
+		require.NoError(t, err)
+		require.Len(t, refs, 3, "row with empty clip_name must be excluded")
+
+		assert.Equal(t, uint(1), refs[0].ID)
+		assert.Equal(t, "2024/01/a.wav", refs[0].ClipName)
+		assert.True(t, refs[0].CompletionTime.Equal(end1), "CompletionTime must be EndTime")
+		assert.Equal(t, uint(3), refs[1].ID)
+		assert.Equal(t, uint(4), refs[2].ID)
+	})
+
+	t.Run("honors afterID for keyset pagination", func(t *testing.T) {
+		refs, err := ds.GetNoteClipReferences(1, 10)
+		require.NoError(t, err)
+		require.Len(t, refs, 2)
+		assert.Equal(t, uint(3), refs[0].ID, "must return rows with id > afterID")
+		assert.Equal(t, uint(4), refs[1].ID)
+	})
+
+	t.Run("honors limit", func(t *testing.T) {
+		refs, err := ds.GetNoteClipReferences(0, 1)
+		require.NoError(t, err)
+		require.Len(t, refs, 1)
+		assert.Equal(t, uint(1), refs[0].ID)
+	})
+
+	t.Run("rejects non-positive limit", func(t *testing.T) {
+		_, err := ds.GetNoteClipReferences(0, 0)
+		assert.Error(t, err)
+	})
+}

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -26,6 +26,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/datastore/dbstats"
 	"github.com/tphakala/birdnet-go/internal/datastore/entities"
 	"github.com/tphakala/birdnet-go/internal/detection"
+	"github.com/tphakala/birdnet-go/internal/diskmanager"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/observability/metrics"
@@ -181,6 +182,7 @@ type Interface interface {
 	GetAllImageCaches(providerName string) ([]ImageCache, error)
 	GetLockedNotesClipPaths() ([]string, error)
 	ClearNoteClipPathsByNames(clipNames []string) (int64, error)
+	GetNoteClipReferences(afterID uint, limit int) ([]diskmanager.ClipReference, error)
 	CountHourlyDetections(date, hour string, duration int) (int64, error)
 	// Analytics methods
 	GetSpeciesSummaryData(ctx context.Context, startDate, endDate string) ([]SpeciesSummaryData, error)
@@ -2045,6 +2047,46 @@ func (ds *DataStore) ClearNoteClipPathsByNames(clipNames []string) (int64, error
 	}
 
 	return totalAffected, nil
+}
+
+// GetNoteClipReferences returns up to limit notes with a non-empty clip_name and
+// ID greater than afterID, ordered by ID ascending (keyset pagination, like
+// GetReviewsBatch). It is used by the clip reconcile crawler to walk clip
+// references in bounded chunks. CompletionTime is Note.EndTime, the capture
+// completion time used for the crawler's recency guard.
+func (ds *DataStore) GetNoteClipReferences(afterID uint, limit int) ([]diskmanager.ClipReference, error) {
+	if limit <= 0 {
+		return nil, validationError("limit must be positive", "limit", limit)
+	}
+
+	var rows []struct {
+		ID       uint
+		ClipName string
+		EndTime  time.Time
+	}
+	err := ds.DB.Model(&Note{}).
+		Select("id", "clip_name", "end_time").
+		Where("id > ? AND clip_name <> ''", afterID).
+		Order("id ASC").
+		Limit(limit).
+		Find(&rows).Error
+	if err != nil {
+		return nil, errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryDatabase).
+			Context("operation", "get_note_clip_references").
+			Build()
+	}
+
+	refs := make([]diskmanager.ClipReference, len(rows))
+	for i := range rows {
+		refs[i] = diskmanager.ClipReference{
+			ID:             rows[i].ID,
+			ClipName:       rows[i].ClipName,
+			CompletionTime: rows[i].EndTime,
+		}
+	}
+	return refs, nil
 }
 
 // CountHourlyDetections counts the number of detections for a specific date and hour.

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -2059,10 +2059,14 @@ func (ds *DataStore) GetNoteClipReferences(afterID uint, limit int) ([]diskmanag
 		return nil, validationError("limit must be positive", "limit", limit)
 	}
 
+	// EndTime is scanned as *time.Time: the end_time column is nullable, and a NULL
+	// (legacy/incomplete row) must scan as nil rather than erroring out and aborting
+	// the whole reconcile pass. A nil end time yields a zero CompletionTime, which
+	// the crawler treats as unknown-age and skips.
 	var rows []struct {
 		ID       uint
 		ClipName string
-		EndTime  time.Time
+		EndTime  *time.Time
 	}
 	err := ds.DB.Model(&Note{}).
 		Select("id", "clip_name", "end_time").
@@ -2080,10 +2084,14 @@ func (ds *DataStore) GetNoteClipReferences(afterID uint, limit int) ([]diskmanag
 
 	refs := make([]diskmanager.ClipReference, len(rows))
 	for i := range rows {
+		var completion time.Time
+		if rows[i].EndTime != nil {
+			completion = *rows[i].EndTime
+		}
 		refs[i] = diskmanager.ClipReference{
 			ID:             rows[i].ID,
 			ClipName:       rows[i].ClipName,
-			CompletionTime: rows[i].EndTime,
+			CompletionTime: completion,
 		}
 	}
 	return refs, nil

--- a/internal/datastore/mocks/mock_Interface.go
+++ b/internal/datastore/mocks/mock_Interface.go
@@ -8,6 +8,8 @@ import (
 	datastore "github.com/tphakala/birdnet-go/internal/datastore"
 	detection "github.com/tphakala/birdnet-go/internal/detection"
 
+	diskmanager "github.com/tphakala/birdnet-go/internal/diskmanager"
+
 	gorm "gorm.io/gorm"
 
 	metrics "github.com/tphakala/birdnet-go/internal/observability/metrics"
@@ -3168,6 +3170,65 @@ func (_c *MockInterface_GetNoteClipPath_Call) Return(_a0 string, _a1 error) *Moc
 }
 
 func (_c *MockInterface_GetNoteClipPath_Call) RunAndReturn(run func(string) (string, error)) *MockInterface_GetNoteClipPath_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetNoteClipReferences provides a mock function with given fields: afterID, limit
+func (_m *MockInterface) GetNoteClipReferences(afterID uint, limit int) ([]diskmanager.ClipReference, error) {
+	ret := _m.Called(afterID, limit)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetNoteClipReferences")
+	}
+
+	var r0 []diskmanager.ClipReference
+	var r1 error
+	if rf, ok := ret.Get(0).(func(uint, int) ([]diskmanager.ClipReference, error)); ok {
+		return rf(afterID, limit)
+	}
+	if rf, ok := ret.Get(0).(func(uint, int) []diskmanager.ClipReference); ok {
+		r0 = rf(afterID, limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]diskmanager.ClipReference)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(uint, int) error); ok {
+		r1 = rf(afterID, limit)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_GetNoteClipReferences_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetNoteClipReferences'
+type MockInterface_GetNoteClipReferences_Call struct {
+	*mock.Call
+}
+
+// GetNoteClipReferences is a helper method to define mock.On call
+//   - afterID uint
+//   - limit int
+func (_e *MockInterface_Expecter) GetNoteClipReferences(afterID interface{}, limit interface{}) *MockInterface_GetNoteClipReferences_Call {
+	return &MockInterface_GetNoteClipReferences_Call{Call: _e.mock.On("GetNoteClipReferences", afterID, limit)}
+}
+
+func (_c *MockInterface_GetNoteClipReferences_Call) Run(run func(afterID uint, limit int)) *MockInterface_GetNoteClipReferences_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(uint), args[1].(int))
+	})
+	return _c
+}
+
+func (_c *MockInterface_GetNoteClipReferences_Call) Return(_a0 []diskmanager.ClipReference, _a1 error) *MockInterface_GetNoteClipReferences_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_GetNoteClipReferences_Call) RunAndReturn(run func(uint, int) ([]diskmanager.ClipReference, error)) *MockInterface_GetNoteClipReferences_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/datastore/v2/entities/detection.go
+++ b/internal/datastore/v2/entities/detection.go
@@ -12,8 +12,8 @@ type Detection struct {
 
 	// Timestamps (consolidated - Unix timestamp is single source of truth)
 	DetectedAt int64  `gorm:"not null;index;index:idx_detection_label_date;index:idx_detection_confidence"`
-	BeginTime  *int64 // Milliseconds offset from source start
-	EndTime    *int64 // Milliseconds offset from source start
+	BeginTime  *int64 // Absolute capture begin time, Unix milliseconds (Save: BeginTime.UnixMilli)
+	EndTime    *int64 // Absolute capture completion time, Unix milliseconds (Save: EndTime.UnixMilli)
 
 	// Detection metadata
 	Confidence float64 `gorm:"not null;index:idx_detection_confidence"`

--- a/internal/datastore/v2/migration/testutil/setup.go
+++ b/internal/datastore/v2/migration/testutil/setup.go
@@ -16,6 +16,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/migration"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/repository"
 	"github.com/tphakala/birdnet-go/internal/detection"
+	"github.com/tphakala/birdnet-go/internal/diskmanager"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -730,6 +731,9 @@ func (s *testLegacyInterface) GetImageCacheBatch(_ string, _ []string) (map[stri
 func (s *testLegacyInterface) SaveImageCache(_ *datastore.ImageCache) error        { return nil }
 func (s *testLegacyInterface) GetLockedNotesClipPaths() ([]string, error)          { return nil, nil }
 func (s *testLegacyInterface) ClearNoteClipPathsByNames(_ []string) (int64, error) { return 0, nil }
+func (s *testLegacyInterface) GetNoteClipReferences(_ uint, _ int) ([]diskmanager.ClipReference, error) {
+	return nil, nil
+}
 func (s *testLegacyInterface) CountHourlyDetections(_, _ string, _ int) (int64, error) {
 	return 0, nil
 }

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -37,6 +37,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/repository"
 	"github.com/tphakala/birdnet-go/internal/detection"
+	"github.com/tphakala/birdnet-go/internal/diskmanager"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/labels/nonbird"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -2323,6 +2324,65 @@ func (ds *Datastore) ClearNoteClipPathsByNames(clipNames []string) (int64, error
 	}
 
 	return totalAffected, nil
+}
+
+// GetNoteClipReferences returns up to limit detections with a non-empty clip_name
+// and ID greater than afterID, ordered by ID ascending (keyset pagination). It is
+// used by the clip reconcile crawler to walk clip references in bounded chunks.
+//
+// CompletionTime keys on the end_time column, which stores the capture COMPLETION
+// time as an absolute Unix-millis value (Save writes note.EndTime.UnixMilli(); the
+// entity field's "offset from source start" comment is stale). This matches the v1
+// store's use of Note.EndTime and the media grace-poll, so the crawler's recency
+// guard protects a clip until its capture actually completes, even for extended
+// captures. When end_time is NULL, fall back to detected_at (detection time); such
+// rows are older detections without a recorded end, safe to treat as long-complete.
+func (ds *Datastore) GetNoteClipReferences(afterID uint, limit int) ([]diskmanager.ClipReference, error) {
+	if limit <= 0 {
+		return nil, fmt.Errorf("limit must be positive: %d", limit)
+	}
+
+	ctx := context.Background()
+	detectionsTable := ds.manager.TablePrefix() + "detections"
+
+	var rows []struct {
+		ID         uint
+		ClipName   *string
+		DetectedAt int64
+		EndTime    *int64
+	}
+	err := ds.manager.DB().WithContext(ctx).
+		Table(detectionsTable).
+		Select("id", "clip_name", "detected_at", "end_time").
+		Where("id > ? AND clip_name IS NOT NULL AND clip_name <> ''", afterID).
+		Order("id ASC").
+		Limit(limit).
+		Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to get clip references after id %d: %w", afterID, err)
+	}
+
+	refs := make([]diskmanager.ClipReference, 0, len(rows))
+	for i := range rows {
+		clip := ""
+		if rows[i].ClipName != nil {
+			clip = *rows[i].ClipName
+		}
+		// Prefer end_time (absolute completion, ms); fall back to detected_at (s).
+		var completion time.Time
+		switch {
+		case rows[i].EndTime != nil:
+			completion = time.UnixMilli(*rows[i].EndTime)
+		case rows[i].DetectedAt > 0:
+			completion = time.Unix(rows[i].DetectedAt, 0)
+		}
+		refs = append(refs, diskmanager.ClipReference{
+			ID:             rows[i].ID,
+			ClipName:       clip,
+			CompletionTime: completion,
+		})
+	}
+	return refs, nil
 }
 
 // ============================================================

--- a/internal/diskmanager/clip_reconcile.go
+++ b/internal/diskmanager/clip_reconcile.go
@@ -132,6 +132,18 @@ func ReconcileClipOrphansPass(quitChan <-chan struct{}, store ReconcileStore, ba
 		return result
 	}
 
+	// Resolve every clip lookup through an os.Root anchored at the export dir so a
+	// persisted clip_name can never escape it (absolute path, "..", or a symlink
+	// pointing outside): os.Root rejects such names, and the crawler treats the
+	// resulting error as indeterminate rather than as a missing/orphan file.
+	root, err := os.OpenRoot(baseDir)
+	if err != nil {
+		result.Aborted = true
+		result.AbortReason = "export directory inaccessible"
+		return result
+	}
+	defer func() { _ = root.Close() }()
+
 	var afterID uint
 	for {
 		select {
@@ -160,7 +172,7 @@ func ReconcileClipOrphansPass(quitChan <-chan struct{}, store ReconcileStore, ba
 
 		// Recompute now per chunk so the recency window tracks wall-clock across a
 		// long, throttled walk.
-		chunk := evaluateClipChunk(baseDir, refs, time.Now())
+		chunk := evaluateClipChunk(root, refs, time.Now())
 		candidates := chunk.positiveCount + len(chunk.orphans)
 
 		// Detached-storage guard.
@@ -205,14 +217,15 @@ type chunkResult struct {
 }
 
 // evaluateClipChunk classifies each non-recent clip reference in refs against the
-// files under baseDir at time now. Recent rows (within ClipRecencyWindow), rows
-// with an unknown completion time, and rows whose path escapes baseDir are skipped
-// entirely (neither cleared nor counted).
-func evaluateClipChunk(baseDir string, refs []ClipReference, now time.Time) chunkResult {
+// files under root at time now. Recent rows (within ClipRecencyWindow), rows with
+// an unknown completion time, and rows whose lookup is indeterminate (unreadable
+// directory, escaping symlink, transient I/O error) are skipped entirely (neither
+// cleared nor counted as evidence), so an ambiguous state never causes clearing.
+func evaluateClipChunk(root *os.Root, refs []ClipReference, now time.Time) chunkResult {
 	var res chunkResult
 	// Per-chunk cache of directory listings so a chunk of missing files sharing a
 	// directory does not re-read it once per file. A present map key means the dir
-	// was read (entries may be nil when unreadable or empty).
+	// was read (entries may be nil for an absent or empty directory).
 	dirCache := make(map[string][]os.DirEntry)
 
 	for i := range refs {
@@ -224,50 +237,64 @@ func evaluateClipChunk(baseDir string, refs []ClipReference, now time.Time) chun
 			continue // recent -> may still be encoding
 		}
 
-		relClean := filepath.Clean(filepath.FromSlash(ref.ClipName))
-		if filepath.IsAbs(relClean) || relClean == ".." ||
-			strings.HasPrefix(relClean, ".."+string(os.PathSeparator)) {
-			continue // path escapes the export root -> refuse to act on it
-		}
-
-		switch clipFileStateAt(baseDir, relClean, dirCache, now) {
+		switch clipFileStateAt(root, filepath.FromSlash(ref.ClipName), dirCache, now) {
 		case clipPresent, clipEncoding:
 			res.positiveCount++
 		case clipOrphan:
 			res.orphans = append(res.orphans, ref.ClipName)
 		case clipIndeterminate:
-			// Ambiguous (e.g. permission error) -> leave the reference untouched.
+			// Ambiguous (permission/IO error, or a name that escapes the export
+			// root) -> leave the reference untouched, never counted or cleared.
 		}
 	}
 	return res
 }
 
-// clipFileStateAt reports the on-disk state of a single clip whose cleaned relative
-// path is relClean under baseDir.
-func clipFileStateAt(baseDir, relClean string, dirCache map[string][]os.DirEntry, now time.Time) clipState {
-	fullPath := filepath.Join(baseDir, relClean)
-	if _, err := os.Stat(fullPath); err == nil {
+// clipFileStateAt reports the on-disk state of a single clip whose OS-native
+// relative path is rel, resolved inside root. A name that escapes the root or a
+// non-ErrNotExist stat error resolves to clipIndeterminate (never orphan).
+func clipFileStateAt(root *os.Root, rel string, dirCache map[string][]os.DirEntry, now time.Time) clipState {
+	if _, err := root.Stat(rel); err == nil {
 		return clipPresent
 	} else if !errors.Is(err, fs.ErrNotExist) {
 		return clipIndeterminate
 	}
 	// Final file missing: an active encode writes to a sibling temp file.
-	if hasFreshEncodingTemp(filepath.Dir(fullPath), filepath.Base(fullPath), dirCache, now) {
+	hasTemp, indeterminate := hasFreshEncodingTemp(root, filepath.Dir(rel), filepath.Base(rel), dirCache, now)
+	switch {
+	case indeterminate:
+		return clipIndeterminate
+	case hasTemp:
 		return clipEncoding
+	default:
+		return clipOrphan
 	}
-	return clipOrphan
 }
 
-// hasFreshEncodingTemp reports whether dir contains a not-yet-finalized export temp
-// file for the clip basename base, written within reconcileEncodingMaxAge.
-func hasFreshEncodingTemp(dir, base string, dirCache map[string][]os.DirEntry, now time.Time) bool {
+// hasFreshEncodingTemp reports whether dir (relative to root) contains a
+// not-yet-finalized export temp file for the clip basename base, written within
+// reconcileEncodingMaxAge. The second return value is true when the directory or a
+// temp entry could not be read (permission/IO error), which the caller must treat
+// as indeterminate rather than as "no temp" -> orphan. An absent directory is not
+// indeterminate: the final file is genuinely missing, so the clip is an orphan.
+func hasFreshEncodingTemp(root *os.Root, dir, base string, dirCache map[string][]os.DirEntry, now time.Time) (found, indeterminate bool) {
 	entries, seen := dirCache[dir]
 	if !seen {
-		read, err := os.ReadDir(dir)
-		if err == nil {
-			entries = read
+		d, err := root.Open(dir)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				dirCache[dir] = nil // absent dir -> no temp; cacheable
+				return false, false
+			}
+			return false, true // unreadable dir -> indeterminate (do not cache)
 		}
-		dirCache[dir] = entries // cache nil on error/empty so we do not re-read
+		read, readErr := d.ReadDir(0)
+		_ = d.Close()
+		if readErr != nil {
+			return false, true
+		}
+		entries = read
+		dirCache[dir] = entries
 	}
 	for _, entry := range entries {
 		if !isExportTempName(entry.Name(), base) {
@@ -275,13 +302,13 @@ func hasFreshEncodingTemp(dir, base string, dirCache map[string][]os.DirEntry, n
 		}
 		info, err := entry.Info()
 		if err != nil {
-			continue
+			return false, true // cannot age the temp -> indeterminate
 		}
 		if now.Sub(info.ModTime()) < reconcileEncodingMaxAge {
-			return true
+			return true, false
 		}
 	}
-	return false
+	return false, false
 }
 
 // isExportTempName reports whether name is an in-progress export temp file for the

--- a/internal/diskmanager/clip_reconcile.go
+++ b/internal/diskmanager/clip_reconcile.go
@@ -1,0 +1,309 @@
+// clip_reconcile.go - reconciles persisted clip_name references against the audio
+// files actually on disk, clearing references to files that no longer exist
+// (ghosts from failed exports, or from detections created while export was off).
+// It never deletes files; it only clears the DB reference so clip_name stays a
+// truthful per-detection signal.
+package diskmanager
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore/audiotemp"
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// ClipRecencyWindow is the age below which a detection's audio clip is treated as
+// possibly still being written by the encoder (FFmpeg). It is keyed on the
+// detection's COMPLETION time (Note.EndTime / LastUpdated), never its begin time:
+// an extended capture records its begin time many minutes before the tail of the
+// clip is written, so keying on begin time would treat an in-progress capture as
+// old. Two subsystems share this single window so their notions of "recent" stay
+// aligned:
+//
+//   - the media endpoint's grace-poll: a 404 for a detection whose completion
+//     time is older than this window returns immediately instead of blocking a
+//     worker waiting for an encode that will never happen (the file is a
+//     pre-reconcile ghost, not a live encode);
+//   - the reconcile crawler: rows whose completion time is younger than this
+//     window are skipped so a clip still being encoded is never cleared as an
+//     orphan.
+const ClipRecencyWindow = 10 * time.Minute
+
+// reconcileChunkSize is the number of clip references read per keyset-paginated
+// chunk. Small chunks keep the crawler's memory and per-iteration I/O bounded.
+const reconcileChunkSize = 200
+
+// reconcileEncodingMaxAge bounds how fresh an export temp file must be to count as
+// an active encode. It matches the media handler's audioEncodingMaxAge so both
+// subsystems treat a stale temp (failed export) the same way. A temp older than
+// this is ignored, so its clip resolves as an orphan.
+const reconcileEncodingMaxAge = 30 * time.Second
+
+// reconcileChunkPause is the delay between chunks, amortizing stat/readdir I/O on
+// slow media (SD cards, NAS, FUSE). It is a var so tests can shorten it.
+//
+//nolint:gochecknoglobals // test-tunable throttle, not configuration
+var reconcileChunkPause = 3 * time.Second
+
+// ClipReference is a minimal projection of a detection row used by the reconcile
+// crawler: the note ID (for keyset pagination), the persisted clip_name (in the
+// exact DB format, so it can be matched by ClearNoteClipPathsByNames), and the
+// capture completion time used for the recency guard.
+type ClipReference struct {
+	ID             uint
+	ClipName       string    // DB clip_name value (relative, forward-slash separated)
+	CompletionTime time.Time // capture completion time; zero when unknown
+}
+
+// ReconcileStore is the narrow datastore surface the clip reconcile crawler needs:
+// a keyset-paginated read of clip references and a batch clear of orphaned ones. It
+// is deliberately small so the crawler is decoupled from the full datastore
+// interface and easy to fake in tests. A datastore.Interface satisfies it.
+type ReconcileStore interface {
+	// GetNoteClipReferences returns up to limit detection rows with a non-empty
+	// clip_name and ID greater than afterID, ordered by ID ascending (keyset
+	// pagination). An empty result means the walk is complete.
+	GetNoteClipReferences(afterID uint, limit int) ([]ClipReference, error)
+	// ClearNoteClipPathsByNames clears clip_name for the notes whose clip_name
+	// exactly matches one of the given DB-format values. Returns the number of
+	// rows updated. It never touches files on disk.
+	ClearNoteClipPathsByNames(clipNames []string) (int64, error)
+}
+
+// ReconcileResult summarizes one reconcile pass for logging.
+type ReconcileResult struct {
+	Scanned           int    // clip references read across all chunks
+	Cleared           int64  // rows whose clip_name was cleared
+	Aborted           bool   // true when the pass stopped early (guard tripped, error, or shutdown)
+	AbortReason       string // human-readable reason when Aborted is true
+	ShutdownRequested bool   // true when the pass stopped because quitChan closed (not a data guard)
+}
+
+// clipState is the on-disk status of one clip reference.
+type clipState int
+
+const (
+	clipPresent       clipState = iota // final file exists on disk
+	clipEncoding                       // final file missing but a fresh export temp exists
+	clipOrphan                         // final file missing and no active encode
+	clipIndeterminate                  // could not be determined (e.g. permission error)
+)
+
+// ReconcileClipOrphansPass walks all clip references in keyset-paginated chunks and
+// clears those whose audio file is confirmed missing. It never deletes files.
+//
+// Safety guards (fail-safe = leave the stale reference rather than risk data loss):
+//
+//   - Directory-present guard: if baseDir is unconfigured or not an accessible
+//     directory, the pass aborts without clearing anything. An unmounted volume
+//     must never be read as "all clips gone".
+//   - Detached-storage guard: within a chunk, if every non-recent, evaluable row
+//     resolves as an orphan (no present file and no active encode anywhere), the
+//     pass aborts and clears nothing. Requiring at least one piece of positive
+//     evidence that storage is attached prevents a cleanly-unmounted share (an
+//     empty-but-present directory) from wiping the entire clip history. This is a
+//     deliberate safety-over-completeness tradeoff: a user who never enabled export
+//     has an all-orphan first chunk, so their pre-fix ghost references are left
+//     untouched rather than risk mass-clearing on a detached volume; the truthful
+//     empty-ClipName gating already prevents NEW ghosts, and the media/UI degrade
+//     safely for the old ones.
+//   - Recency guard: rows whose completion time is within ClipRecencyWindow (or is
+//     unknown) are skipped so a clip still being encoded is never cleared.
+//
+// The pass honors quitChan for prompt shutdown.
+func ReconcileClipOrphansPass(quitChan <-chan struct{}, store ReconcileStore, baseDir string) ReconcileResult {
+	log := GetLogger()
+	var result ReconcileResult
+
+	// Directory-present guard.
+	if strings.TrimSpace(baseDir) == "" {
+		result.Aborted = true
+		result.AbortReason = "export path not configured"
+		return result
+	}
+	if info, err := os.Stat(baseDir); err != nil || !info.IsDir() {
+		result.Aborted = true
+		result.AbortReason = "export directory inaccessible"
+		return result
+	}
+
+	var afterID uint
+	for {
+		select {
+		case <-quitChan:
+			result.Aborted = true
+			result.AbortReason = "shutdown"
+			result.ShutdownRequested = true
+			return result
+		default:
+		}
+
+		refs, err := store.GetNoteClipReferences(afterID, reconcileChunkSize)
+		if err != nil {
+			log.Warn("clip reconcile: failed to read clip references",
+				logger.Error(err),
+				logger.String("operation", "clip_reconcile_read"))
+			result.Aborted = true
+			result.AbortReason = "read error"
+			return result
+		}
+		if len(refs) == 0 {
+			return result // walk complete
+		}
+		result.Scanned += len(refs)
+		afterID = refs[len(refs)-1].ID
+
+		// Recompute now per chunk so the recency window tracks wall-clock across a
+		// long, throttled walk.
+		chunk := evaluateClipChunk(baseDir, refs, time.Now())
+		candidates := chunk.positiveCount + len(chunk.orphans)
+
+		// Detached-storage guard.
+		if candidates > 0 && chunk.positiveCount == 0 {
+			log.Warn("clip reconcile: aborting pass, no evidence storage is attached",
+				logger.Int("orphan_candidates", len(chunk.orphans)),
+				logger.String("operation", "clip_reconcile_abort"))
+			result.Aborted = true
+			result.AbortReason = "no attached-storage evidence"
+			return result
+		}
+
+		if len(chunk.orphans) > 0 {
+			cleared, clearErr := store.ClearNoteClipPathsByNames(chunk.orphans)
+			if clearErr != nil {
+				log.Warn("clip reconcile: failed to clear orphaned clip references",
+					logger.Error(clearErr),
+					logger.Int("orphans", len(chunk.orphans)),
+					logger.String("operation", "clip_reconcile_clear"))
+			} else {
+				result.Cleared += cleared
+				log.Info("clip reconcile: cleared orphaned clip references",
+					logger.Int64("cleared", cleared),
+					logger.String("operation", "clip_reconcile_clear"))
+			}
+		}
+
+		// Slow crawler: pause between chunks to amortize I/O on slow media.
+		if !reconcileSleep(quitChan, reconcileChunkPause) {
+			result.Aborted = true
+			result.AbortReason = "shutdown"
+			result.ShutdownRequested = true
+			return result
+		}
+	}
+}
+
+// chunkResult accumulates the on-disk evaluation of one chunk of clip references.
+type chunkResult struct {
+	orphans       []string // DB-format clip_name values confirmed orphaned
+	positiveCount int      // rows with a present file or an active encode (storage attached)
+}
+
+// evaluateClipChunk classifies each non-recent clip reference in refs against the
+// files under baseDir at time now. Recent rows (within ClipRecencyWindow), rows
+// with an unknown completion time, and rows whose path escapes baseDir are skipped
+// entirely (neither cleared nor counted).
+func evaluateClipChunk(baseDir string, refs []ClipReference, now time.Time) chunkResult {
+	var res chunkResult
+	// Per-chunk cache of directory listings so a chunk of missing files sharing a
+	// directory does not re-read it once per file. A present map key means the dir
+	// was read (entries may be nil when unreadable or empty).
+	dirCache := make(map[string][]os.DirEntry)
+
+	for i := range refs {
+		ref := &refs[i]
+		if ref.ClipName == "" || ref.CompletionTime.IsZero() {
+			continue // nothing to check, or unknown age -> leave untouched
+		}
+		if now.Sub(ref.CompletionTime) < ClipRecencyWindow {
+			continue // recent -> may still be encoding
+		}
+
+		relClean := filepath.Clean(filepath.FromSlash(ref.ClipName))
+		if filepath.IsAbs(relClean) || relClean == ".." ||
+			strings.HasPrefix(relClean, ".."+string(os.PathSeparator)) {
+			continue // path escapes the export root -> refuse to act on it
+		}
+
+		switch clipFileStateAt(baseDir, relClean, dirCache, now) {
+		case clipPresent, clipEncoding:
+			res.positiveCount++
+		case clipOrphan:
+			res.orphans = append(res.orphans, ref.ClipName)
+		case clipIndeterminate:
+			// Ambiguous (e.g. permission error) -> leave the reference untouched.
+		}
+	}
+	return res
+}
+
+// clipFileStateAt reports the on-disk state of a single clip whose cleaned relative
+// path is relClean under baseDir.
+func clipFileStateAt(baseDir, relClean string, dirCache map[string][]os.DirEntry, now time.Time) clipState {
+	fullPath := filepath.Join(baseDir, relClean)
+	if _, err := os.Stat(fullPath); err == nil {
+		return clipPresent
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return clipIndeterminate
+	}
+	// Final file missing: an active encode writes to a sibling temp file.
+	if hasFreshEncodingTemp(filepath.Dir(fullPath), filepath.Base(fullPath), dirCache, now) {
+		return clipEncoding
+	}
+	return clipOrphan
+}
+
+// hasFreshEncodingTemp reports whether dir contains a not-yet-finalized export temp
+// file for the clip basename base, written within reconcileEncodingMaxAge.
+func hasFreshEncodingTemp(dir, base string, dirCache map[string][]os.DirEntry, now time.Time) bool {
+	entries, seen := dirCache[dir]
+	if !seen {
+		read, err := os.ReadDir(dir)
+		if err == nil {
+			entries = read
+		}
+		dirCache[dir] = entries // cache nil on error/empty so we do not re-read
+	}
+	for _, entry := range entries {
+		if !isExportTempName(entry.Name(), base) {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if now.Sub(info.ModTime()) < reconcileEncodingMaxAge {
+			return true
+		}
+	}
+	return false
+}
+
+// isExportTempName reports whether name is an in-progress export temp file for the
+// clip basename base. It delegates to audiotemp.IsTempFor, the single source of
+// truth for the temp-file grammar the encoder writes, so the reconcile crawler and
+// the media handler stay in lockstep with the exporter.
+func isExportTempName(name, base string) bool {
+	return audiotemp.IsTempFor(name, base)
+}
+
+// reconcileSleep waits for d or until quitChan closes. It returns false if quitChan
+// closed (shutdown requested), true if the full duration elapsed.
+func reconcileSleep(quitChan <-chan struct{}, d time.Duration) bool {
+	if d <= 0 {
+		return true
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-quitChan:
+		return false
+	case <-timer.C:
+		return true
+	}
+}

--- a/internal/diskmanager/clip_reconcile_test.go
+++ b/internal/diskmanager/clip_reconcile_test.go
@@ -89,7 +89,10 @@ func TestEvaluateClipChunk(t *testing.T) {
 		{ID: 6, ClipName: "../../etc/passwd", CompletionTime: now.Add(testOld)}, // traversal -> skipped
 	}
 
-	res := evaluateClipChunk(baseDir, refs, now)
+	root, err := os.OpenRoot(baseDir)
+	require.NoError(t, err)
+	defer func() { _ = root.Close() }()
+	res := evaluateClipChunk(root, refs, now)
 
 	// present + encoding -> positive evidence storage is attached.
 	assert.Equal(t, 2, res.positiveCount, "present.wav and encoding.wav are positive evidence")
@@ -112,10 +115,44 @@ func TestEvaluateClipChunk_StaleTempIsOrphan(t *testing.T) {
 	refs := []ClipReference{
 		{ID: 1, ClipName: "2024/01/stale.wav", CompletionTime: now.Add(testOld)},
 	}
-	res := evaluateClipChunk(baseDir, refs, now)
+	root, err := os.OpenRoot(baseDir)
+	require.NoError(t, err)
+	defer func() { _ = root.Close() }()
+	res := evaluateClipChunk(root, refs, now)
 
 	assert.Zero(t, res.positiveCount, "a stale temp is not an active encode")
 	assert.Equal(t, []string{"2024/01/stale.wav"}, res.orphans)
+}
+
+// TestEvaluateClipChunk_SymlinkEscapeIsIndeterminate verifies that a persisted
+// clip_name resolving (via a symlink) outside the export root is treated as
+// indeterminate: os.Root rejects the escape, so it is neither counted as
+// attached-storage evidence nor cleared as an orphan.
+func TestEvaluateClipChunk_SymlinkEscapeIsIndeterminate(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	baseDir := t.TempDir()
+	outside := t.TempDir()
+	external := filepath.Join(outside, "external.wav")
+	require.NoError(t, os.WriteFile(external, []byte("audio"), 0o600))
+
+	require.NoError(t, os.MkdirAll(filepath.Join(baseDir, "2024", "01"), 0o750))
+	link := filepath.Join(baseDir, "2024", "01", "escape.wav")
+	if err := os.Symlink(external, link); err != nil {
+		t.Skipf("symlink not supported in this environment: %v", err)
+	}
+
+	refs := []ClipReference{
+		{ID: 1, ClipName: "2024/01/escape.wav", CompletionTime: now.Add(testOld)},
+	}
+	root, err := os.OpenRoot(baseDir)
+	require.NoError(t, err)
+	defer func() { _ = root.Close() }()
+	res := evaluateClipChunk(root, refs, now)
+
+	assert.Zero(t, res.positiveCount, "escaping symlink is not attached-storage evidence")
+	assert.Empty(t, res.orphans, "escaping symlink must not be cleared as an orphan")
 }
 
 // --- ReconcileClipOrphansPass tests ---

--- a/internal/diskmanager/clip_reconcile_test.go
+++ b/internal/diskmanager/clip_reconcile_test.go
@@ -1,0 +1,313 @@
+package diskmanager
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore/audiotemp"
+)
+
+// --- test helpers ---
+
+// fakeReconcileStore is a small in-memory ReconcileStore for the crawler tests.
+type fakeReconcileStore struct {
+	refs     []ClipReference // ordered by ID ascending
+	cleared  []string        // clip_names passed to ClearNoteClipPathsByNames
+	getErr   error
+	clearErr error
+}
+
+func (f *fakeReconcileStore) GetNoteClipReferences(afterID uint, limit int) ([]ClipReference, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	out := make([]ClipReference, 0, limit)
+	for _, r := range f.refs {
+		if r.ID <= afterID {
+			continue
+		}
+		out = append(out, r)
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeReconcileStore) ClearNoteClipPathsByNames(clipNames []string) (int64, error) {
+	if f.clearErr != nil {
+		return 0, f.clearErr
+	}
+	f.cleared = append(f.cleared, clipNames...)
+	return int64(len(clipNames)), nil
+}
+
+// writeClip creates baseDir/rel (with parent dirs) so it stats as present.
+func writeClip(t *testing.T, baseDir, rel string) {
+	t.Helper()
+	full := filepath.Join(baseDir, filepath.FromSlash(rel))
+	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o750))
+	require.NoError(t, os.WriteFile(full, []byte("audio"), 0o600))
+}
+
+// withNoChunkPause disables the inter-chunk sleep for a test and restores it after.
+func withNoChunkPause(t *testing.T) {
+	t.Helper()
+	orig := reconcileChunkPause
+	reconcileChunkPause = 0
+	t.Cleanup(func() { reconcileChunkPause = orig })
+}
+
+const testOld = -time.Hour // completion time well outside ClipRecencyWindow
+
+// --- evaluateClipChunk tests ---
+
+func TestEvaluateClipChunk(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	baseDir := t.TempDir()
+	// present.wav exists on disk; the others do not.
+	writeClip(t, baseDir, "2024/01/present.wav")
+	// A fresh encoding temp for encoding.wav (final file absent).
+	require.NoError(t, os.WriteFile(
+		filepath.Join(baseDir, "2024", "01", "encoding.wav"+audiotemp.Ext),
+		[]byte("temp"), 0o600))
+
+	refs := []ClipReference{
+		{ID: 1, ClipName: "2024/01/present.wav", CompletionTime: now.Add(testOld)},
+		{ID: 2, ClipName: "2024/01/ghost.wav", CompletionTime: now.Add(testOld)},
+		{ID: 3, ClipName: "2024/01/recent.wav", CompletionTime: now},          // within window -> skipped
+		{ID: 4, ClipName: "2024/01/unknown.wav", CompletionTime: time.Time{}}, // zero ts -> skipped
+		{ID: 5, ClipName: "2024/01/encoding.wav", CompletionTime: now.Add(testOld)},
+		{ID: 6, ClipName: "../../etc/passwd", CompletionTime: now.Add(testOld)}, // traversal -> skipped
+	}
+
+	res := evaluateClipChunk(baseDir, refs, now)
+
+	// present + encoding -> positive evidence storage is attached.
+	assert.Equal(t, 2, res.positiveCount, "present.wav and encoding.wav are positive evidence")
+	// only ghost.wav is a confirmed orphan.
+	assert.Equal(t, []string{"2024/01/ghost.wav"}, res.orphans)
+}
+
+func TestEvaluateClipChunk_StaleTempIsOrphan(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	baseDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(baseDir, "2024", "01"), 0o750))
+	tempPath := filepath.Join(baseDir, "2024", "01", "stale.wav"+audiotemp.Ext)
+	require.NoError(t, os.WriteFile(tempPath, []byte("temp"), 0o600))
+	// Age the temp beyond reconcileEncodingMaxAge so it no longer counts as encoding.
+	old := now.Add(-time.Hour)
+	require.NoError(t, os.Chtimes(tempPath, old, old))
+
+	refs := []ClipReference{
+		{ID: 1, ClipName: "2024/01/stale.wav", CompletionTime: now.Add(testOld)},
+	}
+	res := evaluateClipChunk(baseDir, refs, now)
+
+	assert.Zero(t, res.positiveCount, "a stale temp is not an active encode")
+	assert.Equal(t, []string{"2024/01/stale.wav"}, res.orphans)
+}
+
+// --- ReconcileClipOrphansPass tests ---
+
+func TestReconcileClipOrphansPass_ClearsOrphansWithPositiveEvidence(t *testing.T) {
+	withNoChunkPause(t)
+
+	baseDir := t.TempDir()
+	writeClip(t, baseDir, "2024/01/present.wav") // positive evidence storage attached
+
+	store := &fakeReconcileStore{refs: []ClipReference{
+		{ID: 1, ClipName: "2024/01/present.wav", CompletionTime: time.Now().Add(testOld)},
+		{ID: 2, ClipName: "2024/01/ghost.wav", CompletionTime: time.Now().Add(testOld)},
+	}}
+	quit := make(chan struct{})
+
+	result := ReconcileClipOrphansPass(quit, store, baseDir)
+
+	assert.False(t, result.Aborted, "should complete: storage evidence present")
+	assert.Equal(t, int64(1), result.Cleared)
+	assert.Equal(t, []string{"2024/01/ghost.wav"}, store.cleared)
+}
+
+func TestReconcileClipOrphansPass_DetachedStorageGuardAborts(t *testing.T) {
+	withNoChunkPause(t)
+
+	// baseDir exists but is empty: mimics a cleanly-unmounted volume where every
+	// clip resolves as missing. The pass must abort and clear nothing.
+	baseDir := t.TempDir()
+
+	store := &fakeReconcileStore{refs: []ClipReference{
+		{ID: 1, ClipName: "2024/01/a.wav", CompletionTime: time.Now().Add(testOld)},
+		{ID: 2, ClipName: "2024/01/b.wav", CompletionTime: time.Now().Add(testOld)},
+	}}
+	quit := make(chan struct{})
+
+	result := ReconcileClipOrphansPass(quit, store, baseDir)
+
+	assert.True(t, result.Aborted)
+	assert.Equal(t, "no attached-storage evidence", result.AbortReason)
+	assert.Empty(t, store.cleared, "must clear nothing when storage looks detached")
+	assert.Zero(t, result.Cleared)
+}
+
+func TestReconcileClipOrphansPass_DirectoryPresentGuard(t *testing.T) {
+	withNoChunkPause(t)
+
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	store := &fakeReconcileStore{refs: []ClipReference{
+		{ID: 1, ClipName: "2024/01/a.wav", CompletionTime: time.Now().Add(testOld)},
+	}}
+	quit := make(chan struct{})
+
+	result := ReconcileClipOrphansPass(quit, store, missing)
+
+	assert.True(t, result.Aborted)
+	assert.Equal(t, "export directory inaccessible", result.AbortReason)
+	assert.Empty(t, store.cleared)
+}
+
+func TestReconcileClipOrphansPass_EmptyBaseDirAborts(t *testing.T) {
+	withNoChunkPause(t)
+
+	store := &fakeReconcileStore{}
+	quit := make(chan struct{})
+
+	result := ReconcileClipOrphansPass(quit, store, "   ")
+
+	assert.True(t, result.Aborted)
+	assert.Equal(t, "export path not configured", result.AbortReason)
+}
+
+func TestReconcileClipOrphansPass_RecentRowsNotCleared(t *testing.T) {
+	withNoChunkPause(t)
+
+	baseDir := t.TempDir()
+	writeClip(t, baseDir, "2024/01/present.wav") // positive evidence
+
+	store := &fakeReconcileStore{refs: []ClipReference{
+		{ID: 1, ClipName: "2024/01/present.wav", CompletionTime: time.Now().Add(testOld)},
+		// Missing file but recent -> may still be encoding -> must NOT be cleared.
+		{ID: 2, ClipName: "2024/01/recent.wav", CompletionTime: time.Now()},
+	}}
+	quit := make(chan struct{})
+
+	result := ReconcileClipOrphansPass(quit, store, baseDir)
+
+	assert.False(t, result.Aborted)
+	assert.Empty(t, store.cleared, "recent missing clip must not be cleared")
+	assert.Zero(t, result.Cleared)
+}
+
+func TestReconcileClipOrphansPass_KeysetPaginationAcrossChunks(t *testing.T) {
+	withNoChunkPause(t)
+
+	baseDir := t.TempDir()
+
+	// More refs than one chunk to exercise keyset pagination and termination.
+	// Present files are interspersed (even IDs) so every chunk has positive
+	// evidence and the detached-storage guard never trips; odd IDs are ghosts.
+	refs := make([]ClipReference, 0, reconcileChunkSize+50)
+	wantCleared := 0
+	for i := uint(1); i <= reconcileChunkSize+50; i++ {
+		rel := filepath.ToSlash(filepath.Join("2024", "01", "clip"+strconv.FormatUint(uint64(i), 10)+".wav"))
+		refs = append(refs, ClipReference{ID: i, ClipName: rel, CompletionTime: time.Now().Add(testOld)})
+		if i%2 == 0 {
+			writeClip(t, baseDir, rel) // present
+		} else {
+			wantCleared++ // ghost
+		}
+	}
+	store := &fakeReconcileStore{refs: refs}
+	quit := make(chan struct{})
+
+	result := ReconcileClipOrphansPass(quit, store, baseDir)
+
+	assert.False(t, result.Aborted, "no chunk is all-orphan, so the pass must complete")
+	assert.Equal(t, len(refs), result.Scanned, "must scan every ref across chunks")
+	assert.Equal(t, int64(wantCleared), result.Cleared)
+}
+
+// TestReconcileClipOrphansPass_AbortsMidPassOnAllOrphanChunk documents the safety
+// property: a contiguous run of orphans large enough to fill a whole chunk (no
+// present file) aborts the pass even after earlier chunks cleared successfully.
+// This is the deliberate fail-safe against storage detaching mid-pass (an
+// unmounted volume presents every subsequent clip as missing). The cost is that a
+// very large contiguous ghost run is left untouched rather than risk data loss.
+func TestReconcileClipOrphansPass_AbortsMidPassOnAllOrphanChunk(t *testing.T) {
+	withNoChunkPause(t)
+
+	baseDir := t.TempDir()
+
+	// Chunk 1 (IDs 1..chunkSize): a present file gives positive evidence, rest are
+	// orphans -> cleared. Chunk 2 (IDs chunkSize+1..+50): all orphans -> abort.
+	refs := make([]ClipReference, 0, reconcileChunkSize+50)
+	writeClip(t, baseDir, "present.wav")
+	refs = append(refs, ClipReference{ID: 1, ClipName: "present.wav", CompletionTime: time.Now().Add(testOld)})
+	for i := uint(2); i <= reconcileChunkSize+50; i++ {
+		rel := filepath.ToSlash(filepath.Join("2024", "01", "ghost"+strconv.FormatUint(uint64(i), 10)+".wav"))
+		refs = append(refs, ClipReference{ID: i, ClipName: rel, CompletionTime: time.Now().Add(testOld)})
+	}
+	store := &fakeReconcileStore{refs: refs}
+	quit := make(chan struct{})
+
+	result := ReconcileClipOrphansPass(quit, store, baseDir)
+
+	assert.True(t, result.Aborted, "second, all-orphan chunk must abort the pass")
+	assert.Equal(t, "no attached-storage evidence", result.AbortReason)
+	// Chunk 1's orphans were cleared before the abort; chunk 2's were not.
+	assert.Equal(t, int64(reconcileChunkSize-1), result.Cleared)
+}
+
+func TestReconcileClipOrphansPass_HonorsQuitChannel(t *testing.T) {
+	withNoChunkPause(t)
+
+	baseDir := t.TempDir()
+	writeClip(t, baseDir, "present.wav")
+	store := &fakeReconcileStore{refs: []ClipReference{
+		{ID: 1, ClipName: "present.wav", CompletionTime: time.Now().Add(testOld)},
+	}}
+	quit := make(chan struct{})
+	close(quit) // already shutting down
+
+	result := ReconcileClipOrphansPass(quit, store, baseDir)
+
+	assert.True(t, result.Aborted)
+	assert.Equal(t, "shutdown", result.AbortReason)
+	assert.Empty(t, store.cleared)
+}
+
+// --- isExportTempName tests (mirrors media.isExportTempFor) ---
+
+func TestIsExportTempName(t *testing.T) {
+	t.Parallel()
+
+	base := "clip.wav"
+	tests := []struct {
+		name string
+		file string
+		want bool
+	}{
+		{"pre-fix temp", "clip.wav" + audiotemp.Ext, true},
+		{"unique temp", "clip.wav.1234.5" + audiotemp.Ext, true},
+		{"final file", "clip.wav", false},
+		{"other clip temp", "other.wav" + audiotemp.Ext, false},
+		{"non-numeric pid", "clip.wav.abc.5" + audiotemp.Ext, false},
+		{"missing seq", "clip.wav.1234" + audiotemp.Ext, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isExportTempName(tt.file, base))
+		})
+	}
+}

--- a/internal/imageprovider/imageprovider_test.go
+++ b/internal/imageprovider/imageprovider_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/conf/conftest"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/detection"
+	"github.com/tphakala/birdnet-go/internal/diskmanager"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/observability"
@@ -219,6 +220,9 @@ func (m *mockStore) GetNoteLock(noteID string) (*datastore.NoteLock, error) {
 func (m *mockStore) IsNoteLocked(noteID string) (bool, error)            { return false, nil }
 func (m *mockStore) GetLockedNotesClipPaths() ([]string, error)          { return nil, nil }
 func (m *mockStore) ClearNoteClipPathsByNames(_ []string) (int64, error) { return 0, nil }
+func (m *mockStore) GetNoteClipReferences(_ uint, _ int) ([]diskmanager.ClipReference, error) {
+	return nil, nil
+}
 func (m *mockStore) CountHourlyDetections(date, hour string, duration int) (int64, error) {
 	return 0, nil
 }


### PR DESCRIPTION
## Summary

Follows up #3760, which hid the audio player/spectrogram in the UI using a single global `audioExportEnabled` flag. That flag is a snapshot of the *current* setting while detections are *historical* and export is hot-reloadable, so it mishandled runtime toggling: turning export off hid media for historical clips that still exist on disk, and turning it back on rendered players that 404 for detections created while it was off.

This makes `clip_name != ""` reliably mean "the clip exists or is still encoding", so the UI can gate media per-detection and stay correct under runtime toggling.

### Backend
- **Truthful ClipName.** `createDetection` and the extended-capture path only generate a `ClipName` when export is enabled; otherwise it stays empty. `SaveAudioAction.Execute` skips an empty `ClipName` (hot-reload-enable race guard). Export-enabled behavior is unchanged.
- **REST serializes clipName.** `DetectionResponse` now carries `clipName` (basename-stripped, matching the SSE privacy contract via `apicore.SafeBaseName`) on the single, list, and search paths, with a handler-level test that fails if the endpoint omits it.
- **Media grace-poll skip.** On a 404 for a detection older than a shared 10-minute recency window (keyed on capture completion time, not begin time), the endpoint returns 404 immediately instead of burning a server-side grace-poll on a ghost reference.
- **Reconcile crawler.** A slow, chunked background crawler clears orphaned `clip_name` references (files that no longer exist), with fail-safe guards: it never deletes files, aborts when the export dir is unconfigured/inaccessible, and aborts a chunk whose non-recent rows all resolve as orphan, so it never mass-clears on a detached or unmounted volume. Recency keys on completion time; in-progress export temp files count as present.

### Frontend
- Each media widget (spectrogram, audio player, download) is gated on `detection.clipName` (or the server-derived `hasAudio` for search) instead of the global flag, across all detection surfaces. The detections "Recording" column shows when export is enabled or any visible row has a clip. Historical clips stay reachable after export is toggled off. Reuses the compact media-free layouts from #3760; only the gating signal changed.

### Notes
- No schema change. Empty `clip_name` was already a supported state, so downgrade is safe.
- Adds `GetNoteClipReferences` (keyset pagination) to the datastore interface, returning `diskmanager.ClipReference`, implemented for both stores. The temp-file matcher is hoisted to `audiotemp.IsTempFor` as the single source of truth.

## Test Plan
- [x] `go test -race` across analysis, processor, diskmanager, datastore, datastore/v2only, api/v2/media, api/v2/detections, apicore, audiotemp
- [x] `golangci-lint run` clean on all touched packages
- [x] Frontend `svelte-check`, eslint, prettier, ast-grep, and component tests green
- [ ] Manual: toggle export off at runtime, confirm historical clips stay playable and export-off detections show no media / no 404 players

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detection media and spectrogram UI is now shown per detection when a clip is available (with recording column visibility tied to clip availability).
  * API v2 detection responses now include an optional `clipName` field (basename only).

* **Bug Fixes**
  * Audio playback/export actions now skip safely when a detection has an empty clip name.
  * Reduced “missing audio” retry/grace behavior for older detections and improved handling of in-progress/temporary files.

* **Chores / Tests**
  * Added/updated reconciliation and UI/API gating test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->