### PR TITLE
fix(monitor): quiet disk and cleanup log noise when clip export is off

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -1650,6 +1650,29 @@ func clipCleanupMonitor(quitChan chan struct{}, dataStore datastore.Interface) {
 				continue
 			}
 
+			// Skip the pass when the export directory is inaccessible. When audio
+			// export is disabled the directory is never created (it is made lazily
+			// on the first clip save), and in Docker the clips volume may be
+			// unmounted. Without this guard the usage-based path below calls
+			// GetDiskUsage against a missing directory and warns on every interval.
+			// The check runs each iteration so re-enabling export (which recreates
+			// the directory) resumes cleanup without a restart. The DB reconcile
+			// crawler is a separate task that must run regardless of export state.
+			if _, statErr := os.Stat(exportCfg.Path); statErr != nil {
+				if os.IsNotExist(statErr) {
+					log.Debug("skipping clip cleanup: export directory does not exist",
+						logger.String("path", exportCfg.Path),
+						logger.Error(statErr),
+						logger.String("operation", "clip_cleanup_skip"))
+				} else {
+					log.Warn("skipping clip cleanup: export directory not accessible",
+						logger.String("path", exportCfg.Path),
+						logger.Error(statErr),
+						logger.String("operation", "clip_cleanup_skip"))
+				}
+				continue
+			}
+
 			log.Info("starting clip cleanup task",
 				logger.String("timestamp", t.Format(time.RFC3339)),
 				logger.String("policy", currentPolicy),

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -1609,6 +1609,41 @@ func (p *AudioPipelineService) startWeatherPolling(metrics *observability.Metric
 	})
 }
 
+// exportDirState classifies the clip export directory for a cleanup pass.
+type exportDirState int
+
+const (
+	// exportDirUsable means the path exists and is a directory: run cleanup.
+	exportDirUsable exportDirState = iota
+	// exportDirMissing means the path does not exist. This is the benign default
+	// when audio export is disabled (the directory is created lazily on the first
+	// clip save) or when a Docker clips volume is unmounted.
+	exportDirMissing
+	// exportDirBad means the path could not be stat-ed (permissions, I/O) or exists
+	// but is not a directory: an unexpected condition worth surfacing.
+	exportDirBad
+)
+
+// classifyExportDir reports whether the clip export directory at path is usable
+// for a cleanup pass. It mirrors the guard used by ReconcileClipOrphansPass
+// (missing or non-directory paths are skipped) so the two cleanup tasks agree on
+// what counts as a valid export directory. The returned error is the underlying
+// os.Stat error when one occurred (nil for a path that exists but is not a
+// directory), so the caller can include it in a diagnostic log.
+func classifyExportDir(path string) (exportDirState, error) {
+	info, err := os.Stat(path)
+	switch {
+	case err != nil && os.IsNotExist(err):
+		return exportDirMissing, err
+	case err != nil:
+		return exportDirBad, err
+	case !info.IsDir():
+		return exportDirBad, nil
+	default:
+		return exportDirUsable, nil
+	}
+}
+
 // clipCleanupMonitor monitors the database and deletes clips that meet the retention policy.
 func clipCleanupMonitor(quitChan chan struct{}, dataStore datastore.Interface) {
 	log := GetLogger()
@@ -1650,27 +1685,37 @@ func clipCleanupMonitor(quitChan chan struct{}, dataStore datastore.Interface) {
 				continue
 			}
 
-			// Skip the pass when the export directory is inaccessible. When audio
-			// export is disabled the directory is never created (it is made lazily
-			// on the first clip save), and in Docker the clips volume may be
-			// unmounted. Without this guard the usage-based path below calls
+			// Skip the pass when the export directory is not a usable directory.
+			// When audio export is disabled the directory is never created (it is
+			// made lazily on the first clip save), and in Docker the clips volume
+			// may be unmounted. Without this guard the usage-based path below calls
 			// GetDiskUsage against a missing directory and warns on every interval.
 			// The check runs each iteration so re-enabling export (which recreates
 			// the directory) resumes cleanup without a restart. The DB reconcile
 			// crawler is a separate task that must run regardless of export state.
-			if _, statErr := os.Stat(exportCfg.Path); statErr != nil {
-				if os.IsNotExist(statErr) {
-					log.Debug("skipping clip cleanup: export directory does not exist",
-						logger.String("path", exportCfg.Path),
-						logger.Error(statErr),
-						logger.String("operation", "clip_cleanup_skip"))
-				} else {
-					log.Warn("skipping clip cleanup: export directory not accessible",
-						logger.String("path", exportCfg.Path),
-						logger.Error(statErr),
-						logger.String("operation", "clip_cleanup_skip"))
-				}
+			switch state, statErr := classifyExportDir(exportCfg.Path); state {
+			case exportDirMissing:
+				// Benign default state when export is off: log at Debug and skip.
+				log.Debug("skipping clip cleanup: export directory does not exist",
+					logger.String("path", exportCfg.Path),
+					logger.Error(statErr),
+					logger.String("operation", "clip_cleanup_skip"))
 				continue
+			case exportDirBad:
+				// Genuine access failure or a non-directory path: log at Warn so a
+				// real misconfiguration still surfaces. statErr is nil when the path
+				// exists but is not a directory.
+				fields := []logger.Field{
+					logger.String("path", exportCfg.Path),
+					logger.String("operation", "clip_cleanup_skip"),
+				}
+				if statErr != nil {
+					fields = append(fields, logger.Error(statErr))
+				}
+				log.Warn("skipping clip cleanup: export path is not a usable directory", fields...)
+				continue
+			case exportDirUsable:
+				// Fall through to run the cleanup pass.
 			}
 
 			log.Info("starting clip cleanup task",

--- a/internal/analysis/audio_pipeline_service_test.go
+++ b/internal/analysis/audio_pipeline_service_test.go
@@ -1,6 +1,8 @@
 package analysis
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -171,4 +173,48 @@ func TestBuildLivenessConfig_PartialOverride(t *testing.T) {
 	assert.Equal(t, defaults.RetryBackoff, cfg.RetryBackoff, "unset field should use default")
 	assert.Equal(t, defaults.CooldownAfterRecov, cfg.CooldownAfterRecov, "unset field should use default")
 	assert.Equal(t, defaults.EscalationTimeout, cfg.EscalationTimeout, "unset field should use default")
+}
+
+// TestClassifyExportDir covers the clip cleanup guard's directory classification:
+// a usable directory runs cleanup, a missing directory is the benign export-off
+// default (Debug/skip), and a stat error or a non-directory path is unexpected
+// (Warn/skip).
+func TestClassifyExportDir(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+
+	realDir := filepath.Join(base, "clips")
+	require.NoError(t, os.Mkdir(realDir, 0o755))
+
+	regularFile := filepath.Join(base, "clips.txt")
+	require.NoError(t, os.WriteFile(regularFile, []byte("not a dir"), 0o600))
+
+	missing := filepath.Join(base, "does-not-exist")
+
+	tests := []struct {
+		name         string
+		path         string
+		wantState    exportDirState
+		wantErrIsNil bool
+	}{
+		{name: "existing directory is usable", path: realDir, wantState: exportDirUsable, wantErrIsNil: true},
+		{name: "missing directory is benign", path: missing, wantState: exportDirMissing, wantErrIsNil: false},
+		{name: "regular file is bad without error", path: regularFile, wantState: exportDirBad, wantErrIsNil: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			state, err := classifyExportDir(tt.path)
+			assert.Equal(t, tt.wantState, state)
+			if tt.wantErrIsNil {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.True(t, os.IsNotExist(err), "missing path should report a not-exist error")
+			}
+		})
+	}
 }

--- a/internal/monitor/system_monitor.go
+++ b/internal/monitor/system_monitor.go
@@ -258,7 +258,20 @@ func (m *SystemMonitor) checkDiskPath(path string) {
 // publishDiskMetric collects and publishes disk usage for a single path or mount point
 func (m *SystemMonitor) publishDiskMetric(path string) {
 	if _, err := os.Stat(path); err != nil {
-		m.log.Error("Disk path does not exist or is not accessible",
+		// A missing path is an expected, benign state rather than a fault: the
+		// audio clip export directory is never created while export is disabled
+		// (which is now the default for "clip export off" mode), and in Docker a
+		// bind-mounted volume such as /clips may be legitimately unmounted. Log
+		// those at Debug and skip. Only genuine access failures (permissions, I/O)
+		// remain at Error so real problems still surface.
+		if os.IsNotExist(err) {
+			m.log.Debug("Skipping disk metric for non-existent path",
+				logger.String("path", path),
+				logger.Error(err),
+			)
+			return
+		}
+		m.log.Error("Disk path is not accessible",
 			logger.String("path", path),
 			logger.Error(err),
 		)


### PR DESCRIPTION
## Summary

Follow-up to the "clip export off" work (#3760, #3765). When audio export is disabled the clip export directory is never created (it is made lazily on the first clip save), so two per-interval monitors kept running against a missing path and logging at Error/Warn every cycle, plus generating system-resource telemetry noise. With export off now being a clean, first-class mode, a missing clips directory is the default state, so this noise became common.

## Changes

- **`system_monitor.publishDiskMetric`**: a missing monitored path (ENOENT) is now logged at Debug and skipped. Only genuine access failures (permissions, I/O) stay at Error. In Docker a bind-mounted `/clips` volume can also be legitimately unmounted, which this covers.
- **`clipCleanupMonitor`**: skip the cleanup pass when the export directory is missing (Debug) or inaccessible (Warn), instead of calling the usage-based path against a missing directory and warning every interval. The check runs each loop iteration, so re-enabling export (which recreates the directory) resumes cleanup with no restart.

## Notes

- The DB reconcile crawler (`clipReconcileMonitor`) is a separate task that runs unconditionally regardless of export state, so orphaned `clip_name` references are still cleared; this change only gates the file-based cleanup pass.
- When export is disabled but the directory still holds leftover clips, `os.Stat` succeeds and age/usage cleanup runs normally. The guard only skips when the directory is genuinely absent (nothing to clean).
- Behavioral note: a user-configured disk-monitor path that is missing now logs at Debug rather than Error. This is intentional noise reduction; genuine access failures on such paths still log at Error.

## Testing

- `golangci-lint run` clean on the changed packages.
- `go test -race ./internal/monitor/...` passes.
- Verified against a live test instance: toggling audio export off at runtime no longer emits the per-interval "Disk path does not exist" Error logs or the cleanup warnings, and re-enabling export resumes normal disk metrics and cleanup with no restart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing or inaccessible export paths during clip cleanup, including safer directory validation before running retention cleanup.
  * Reduced noisy error logging when expected disk paths are missing by treating “not found” cases as benign and skipping metric publishing.
  * Cleanup and disk monitoring now skip unavailable paths gracefully while continuing normal processing elsewhere.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->