### PR TITLE
test(api): assert audioExportEnabled key is always present in app config

### DIFF
--- a/internal/api/v2/app/app_test.go
+++ b/internal/api/v2/app/app_test.go
@@ -186,6 +186,20 @@ func TestGetAppConfig_AudioExportEnabled(t *testing.T) {
 
 			assert.Equal(t, tt.exportEnabled, response.AudioExportEnabled,
 				"AudioExportEnabled should mirror Realtime.Audio.Export.Enabled")
+
+			// Also assert against the raw JSON payload, pinning the full wire
+			// contract independent of the struct's json tag. The typed unmarshal
+			// above cannot distinguish a present-but-false value from an omitted
+			// key (both decode to false), so an accidental `omitempty` on the field
+			// would silently drop the key when export is disabled and leave the
+			// frontend guessing. Comparing the raw value catches both an omitted
+			// key (decodes to nil, != false) and a wrong value.
+			var raw map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &raw))
+			require.Contains(t, raw, "audioExportEnabled",
+				"response must always include the audioExportEnabled key, even when false")
+			assert.Equal(t, tt.exportEnabled, raw["audioExportEnabled"],
+				"raw audioExportEnabled must carry the correct boolean value")
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up test hardening from the "clip export off" review (#3760, #3765). `TestGetAppConfig_AudioExportEnabled` previously asserted only the typed struct field, which cannot distinguish a present-but-false value from an omitted key (both decode to Go's `false`). If someone added `omitempty` to `AppConfigResponse.AudioExportEnabled`, the key would silently drop from the payload when export is disabled, and the typed test would stay green while the frontend lost the flag it gates on.

This adds a raw-JSON assertion (in both the enabled and disabled table cases) that the `audioExportEnabled` key is present and carries the correct boolean value, so the wire contract is pinned independent of the struct tag.

## Test Plan

- [x] `go test ./internal/api/v2/app/ -run TestGetAppConfig_AudioExportEnabled` passes (both enabled and disabled cases).
- [x] `golangci-lint run` clean on the package.
- [x] Confirmed the field currently has no `omitempty` (so the new assertion documents, and now enforces, the existing contract).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened API coverage for app configuration responses.
  * Verified the `audioExportEnabled` field is included in the raw JSON response even when it is `false`.
  * Confirmed the returned boolean value matches the expected setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->