### PR TITLE
fix(build): scope git describe to release tags to avoid "manifest-*" version

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -30,10 +30,12 @@ tmp_dir = "tmp"  # Temporary directory for build artifacts
 
     export CGO_LDFLAGS="-L${TFLITE_LIB_DIR} -ltensorflowlite_c"
 
-    # Build the Go application with version and build date
+    # Build the Go application with version and build date.
+    # Match only real release tags (v* and nightly-*) so the auto-update
+    # "manifest" prerelease tag is not picked as the nearest ancestor.
     go build -ldflags "-s -w -r /usr/local/lib \
       -X 'main.buildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)' \
-      -X 'main.version=$(git describe --tags --always)'" \
+      -X 'main.version=$(git describe --tags --always --match 'v*' --match 'nightly-*')'" \
       -o ./tmp/main .
 
     # On macOS, add the Homebrew library path to rpath since Go's -r flag

--- a/.air.toml
+++ b/.air.toml
@@ -33,9 +33,12 @@ tmp_dir = "tmp"  # Temporary directory for build artifacts
     # Build the Go application with version and build date.
     # Match only real release tags (v* and nightly-*) so the auto-update
     # "manifest" prerelease tag is not picked as the nearest ancestor.
+    # Resolve the version into a variable first to avoid nested quoting inside
+    # -ldflags, and fall back to "unknown" when git is unavailable.
+    app_version="$(git describe --tags --always --match 'v*' --match 'nightly-*' 2>/dev/null || echo unknown)"
     go build -ldflags "-s -w -r /usr/local/lib \
       -X 'main.buildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)' \
-      -X 'main.version=$(git describe --tags --always --match 'v*' --match 'nightly-*')'" \
+      -X main.version=$app_version" \
       -o ./tmp/main .
 
     # On macOS, add the Homebrew library path to rpath since Go's -r flag

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -23,7 +23,9 @@ jobs:
       - name: Get latest tag
         id: get_latest_tag
         run: |
-          LATEST_TAG=$(git describe --tags --abbrev=0)
+          # Restrict to stable release tags; the auto-update "manifest"
+          # prerelease tag would otherwise be picked as the nearest ancestor.
+          LATEST_TAG=$(git describe --tags --abbrev=0 --match 'v*')
           echo "VERSION=${LATEST_TAG}" >> $GITHUB_ENV
           echo "VERSION_NO_V=${LATEST_TAG#v}" >> $GITHUB_ENV
 
@@ -89,7 +91,9 @@ jobs:
       - name: Get latest tag
         id: get_latest_tag
         run: |
-          LATEST_TAG=$(git describe --tags --abbrev=0)
+          # Restrict to stable release tags; the auto-update "manifest"
+          # prerelease tag would otherwise be picked as the nearest ancestor.
+          LATEST_TAG=$(git describe --tags --abbrev=0 --match 'v*')
           echo "VERSION=${LATEST_TAG}" >> $GITHUB_ENV
           echo "VERSION_NO_V=${LATEST_TAG#v}" >> $GITHUB_ENV
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -165,7 +165,9 @@ jobs:
         id: latest_release
         run: |
           # Get the latest release tag
-          LATEST_TAG=$(git describe --tags --abbrev=0)
+          # Restrict to stable release tags; the auto-update "manifest"
+          # prerelease tag would otherwise be picked as the nearest ancestor.
+          LATEST_TAG=$(git describe --tags --abbrev=0 --match 'v*')
           echo "LATEST_TAG=${LATEST_TAG}" >> "${GITHUB_ENV}"
           echo "latest_tag=${LATEST_TAG}" >> "${GITHUB_OUTPUT}"
       
@@ -207,7 +209,9 @@ jobs:
       - name: Get latest release tag
         if: github.event_name == 'workflow_dispatch'
         run: |
-          LATEST_TAG=$(git describe --tags --abbrev=0)
+          # Restrict to stable release tags; the auto-update "manifest"
+          # prerelease tag would otherwise be picked as the nearest ancestor.
+          LATEST_TAG=$(git describe --tags --abbrev=0 --match 'v*')
           echo "LATEST_TAG=${LATEST_TAG}" >> "${GITHUB_ENV}"
 
       - name: Add checksums to GitHub Release
@@ -234,7 +238,9 @@ jobs:
       - name: Get version
         id: get_version
         run: |
-          VERSION=$(git describe --tags --always)
+          # Restrict to stable release tags so a workflow_dispatch from a
+          # non-tagged ref does not resolve to the "manifest" prerelease tag.
+          VERSION=$(git describe --tags --always --match 'v*')
           echo "VERSION=${VERSION}" >> ${GITHUB_ENV}
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -16,7 +16,11 @@ vars:
       if [ ! -z "$BUILD_VERSION" ]; then
         echo "$BUILD_VERSION"
       else
-        git describe --tags --always 2>/dev/null || echo "unknown"
+        # Describe only against real release tags (semver v* and nightly-*).
+        # The auto-update feature publishes a permanent "manifest" prerelease
+        # whose git tag would otherwise be the nearest ancestor, making local
+        # builds report a confusing "manifest-<n>-g<hash>" version.
+        git describe --tags --always --match 'v*' --match 'nightly-*' 2>/dev/null || echo "unknown"
       fi
   UNAME_S:
     sh: uname -s


### PR DESCRIPTION
## Summary

From-source builds started reporting a confusing version string like `manifest-97-g3699c7259` on the dashboard instead of the expected `nightly-...` / `v...` form.

Root cause: the auto-update feature (#3631) publishes a permanent GitHub prerelease whose git tag is literally named `manifest`, pinned well behind HEAD. `git describe` selects the nearest reachable tag of *any* name, so `manifest` became the closest ancestor tag and every unfiltered `git describe` picked it up. This affected:

- The baked binary version on local/dev builds (`task`, `task dev_server`).
- The `workflow_dispatch` release paths, where `git describe --abbrev=0` resolved to `manifest` and would silently attach release artifacts/images to the manifest prerelease.

Normal `release`-event builds were unaffected (HEAD sits exactly on the `v*` tag), and nightly builds were unaffected (they set `BUILD_VERSION` explicitly).

## Fix

Restrict every version-deriving `git describe` to real release tags:

- **Local/dev builds** (`Taskfile.yml`, `.air.toml`): `--match 'v*' --match 'nightly-*'` (local checkouts often sit on `main` after a nightly).
- **Stable-release CI** (`release-build.yml`, `docker-release.yml`): `--match 'v*'` only (a release must not derive its version from a nightly tag).

`.air.toml` resolves the version into a shell variable before the `-ldflags` string to avoid nested quoting, and `.air.toml`/`Taskfile.yml` fall back to `unknown` (suppressing git stderr) when git is unavailable.

Note: the deprecated `Makefile` also had this pattern, but it was removed from `main` separately, so this PR no longer touches it.

## Test Plan

- [x] `git describe --tags --always --match 'v*' --match 'nightly-*'` resolves to `nightly-...-g<hash>` (was `manifest-97-g<hash>`)
- [x] `git describe --tags --abbrev=0 --match 'v*'` resolves to `v0.6.4` (was `manifest`)
- [x] `.air.toml` ldflags string expands correctly under `sh` and `bash`, no glob expansion of `v*` against the tracked `vm-images/` dir
- [x] Confirmed no `git describe` version-derivation site left unfiltered
- [x] Confirmed no `internal/` consumer regex-parses `main.version` (format shape unchanged regardless)