### PR TITLE
fix(ui): remove dead Play stub from desktop Search results row

### DIFF
--- a/frontend/src/lib/desktop/views/Search.svelte
+++ b/frontend/src/lib/desktop/views/Search.svelte
@@ -18,7 +18,6 @@
     ChevronDown,
     Eye,
     FrownIcon,
-    Music,
     Search,
     SquarePen,
     Volume2,
@@ -1035,20 +1034,6 @@
                       {/if}
                       <button
                         class="btn btn-xs btn-square"
-                        onclick={e => {
-                          e.preventDefault();
-                          // TODO: Implement audio playback function
-                        }}
-                        disabled={!result.hasAudio}
-                        aria-label={t('search.detailsPanel.playAudio', {
-                          species: displayName || t('search.detailsPanel.unknownSpecies'),
-                        })}
-                        aria-pressed="false"
-                      >
-                        <Music class="size-4" />
-                      </button>
-                      <button
-                        class="btn btn-xs btn-square"
                         onclick={() => navigation.navigate(`/ui/detections/${result.id}`)}
                         aria-label={t('search.detailsPanel.viewDetails', {
                           species: displayName || t('search.detailsPanel.unknownSpecies'),
@@ -1309,7 +1294,6 @@
                       <button
                         class="btn btn-primary btn-sm"
                         onclick={() => openMobilePlayer(result)}
-                        disabled={!result.hasAudio}
                         aria-label={t('search.detailsPanel.playAudio', {
                           species: displayName || t('search.detailsPanel.unknownSpecies'),
                         })}


### PR DESCRIPTION
## Summary

The desktop Search results table had a compact-row Play button (Music icon) that never worked: its `onclick` was a no-op `// TODO: Implement audio playback function` stub, and it rendered permanently with `disabled={!result.hasAudio}` and no accessible explanation of why it was disabled.

It also could not simply be wired to the working `openMobilePlayer` handler, because that handler and its `MobileAudioPlayer` are mobile-only (`md:hidden`) while the compact result row lives in the desktop table (`hidden md:block`). The two never share a viewport, so the button could not play audio on desktop, tablet, or mobile.

This removes the dead button. Audio stays reachable from the same desktop row two ways, both unchanged:

- **Expand** (chevron) reveals the inline `AudioPlayer` (spectrogram, download, clip extraction) when the detection has a clip.
- **View** (eye) navigates to the detection detail page, which has its own player.

Also drops the now-unused `Music` import, and removes a redundant `disabled={!result.hasAudio}` on the mobile Play button that is already render-gated by `{#if result.hasAudio}` (so the attribute could never be truthy).

Net effect: one fewer broken, silently-disabled control, no loss of any working capability, and the ambiguous-disabled-state doctrine violation is resolved by removal.

## Test Plan

- [x] `npm run check:all` passes (prettier, eslint, stylelint, svelte-check 0 errors, ast-grep)
- [ ] Desktop/tablet: a search result row with a clip still reaches audio via Expand (inline player) and View (detail page)
- [ ] Desktop/tablet: rows without a clip no longer show a dead/disabled Play button
- [ ] Mobile: the Play button still opens the audio player overlay

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified the desktop/tablet search results actions by removing the unavailable audio play button and showing the details and expand/collapse controls more consistently.
  * Updated mobile search result controls so the audio button behavior matches availability more cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->