### PR TITLE
fix(birdweather): encode native FLAC uploads in memory again

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.43.0
 	github.com/testcontainers/testcontainers-go/modules/mysql v0.43.0
 	github.com/tphakala/go-audio-resampler v1.4.0
-	github.com/tphakala/go-flac v0.3.1
+	github.com/tphakala/go-flac v0.4.0
 	github.com/tphakala/go-tflite v0.2.2-0.20260514101223-29408e53fff7
 	github.com/tphakala/simd v1.4.0-rc.2
 	github.com/yalue/onnxruntime_go v1.30.1

--- a/go.sum
+++ b/go.sum
@@ -289,8 +289,8 @@ github.com/tklauser/numcpus v0.12.0 h1:NR85qdvHA9pFse3x3weVZ0r0ST8R6l5RHbZrlRaqo
 github.com/tklauser/numcpus v0.12.0/go.mod h1:ABHeXzJnr/qqwguhClkZKT1/8VABcYrsyUiUGobwWJg=
 github.com/tphakala/go-audio-resampler v1.4.0 h1:Iv71vuUVzH2apR9tw4TrWDRvjNOc1e8Qr58TKl6IaLo=
 github.com/tphakala/go-audio-resampler v1.4.0/go.mod h1:mDVvtgIkzupYeqTcxRIJeEED53yrCTu2BP3mAYpiYj0=
-github.com/tphakala/go-flac v0.3.1 h1:UtHQRyaq8pf7w0DAx/5JWVXBGNizYpS3RgOA9Tg88c8=
-github.com/tphakala/go-flac v0.3.1/go.mod h1:d6cu4zAcEOyHq1mHJHvKH92v8i7/MmreUtcPsx7FhNs=
+github.com/tphakala/go-flac v0.4.0 h1:aze0YFqJOPRRWEaDH5ek2yquDfPW/qxmMkLZFrx12S8=
+github.com/tphakala/go-flac v0.4.0/go.mod h1:d6cu4zAcEOyHq1mHJHvKH92v8i7/MmreUtcPsx7FhNs=
 github.com/tphakala/go-tflite v0.2.2-0.20260514101223-29408e53fff7 h1:fJtEs8rODoFDk8HDRwvNxIYEgsUUrEAvqPdllxF0cmg=
 github.com/tphakala/go-tflite v0.2.2-0.20260514101223-29408e53fff7/go.mod h1:xCgggryHiQ3nD0Sy0oCZESPWmzThLKKB28Vky5m6HCo=
 github.com/tphakala/goth v0.0.0-20260315123917-08c3db6a364a h1:BBvsu7Mes8McH6ikyagnU9y2N8hjoDxvDNCl162hwdA=

--- a/internal/audiocore/flac/encode.go
+++ b/internal/audiocore/flac/encode.go
@@ -319,11 +319,12 @@ type BufferOptions struct {
 
 // EncodePCMToBuffer encodes opts.PCMData to a FLAC stream and returns it as an
 // in-memory buffer. Unlike EncodePCM it writes to a non-seekable bytes.Buffer,
-// so no SEEKTABLE is emitted and the STREAMINFO total-samples/MD5 fields are
-// left at their spec-legal "unknown" sentinels (the same result as FFmpeg
-// encoding to a pipe). A non-zero GainDB is applied in Go before encoding;
-// opts.PCMData itself is never modified. Intended for upload paths (e.g.
-// BirdWeather) that need FLAC bytes in memory rather than a file.
+// so no SEEKTABLE is emitted. The STREAMINFO total-samples field is finalized
+// up front from the PCM length (go-flac verifies it against the samples actually
+// written on Close), so consumers that read the sample count for duration get a
+// correct value without a seekable sink; the MD5 field is left at its spec-legal
+// "unknown" sentinel for this streaming path. A non-zero GainDB is applied in Go
+// before encoding; opts.PCMData itself is never modified.
 func EncodePCMToBuffer(ctx context.Context, opts *BufferOptions) (*bytes.Buffer, error) {
 	if opts == nil {
 		return nil, errors.Newf("flac encode: nil options").
@@ -339,11 +340,22 @@ func EncodePCMToBuffer(ctx context.Context, opts *BufferOptions) (*bytes.Buffer,
 		return nil, ctxErr
 	}
 
+	// Derive the inter-channel sample count (frames) from the PCM length so
+	// go-flac can write a finalized STREAMINFO.total_samples up front on a
+	// non-seekable sink. validateEncodeInput has already confirmed the length is
+	// a whole number of frames, so this division is exact.
+	bytesPerFrame := (opts.BitDepth / 8) * opts.Channels
+	totalSamples := uint64(len(opts.PCMData) / bytesPerFrame)
+
 	cfg := goflac.Config{
 		SampleRate:       opts.SampleRate,
 		BitDepth:         opts.BitDepth,
 		Channels:         opts.Channels,
 		CompressionLevel: defaultCompressionLevel,
+		// TotalSamples finalizes STREAMINFO.total_samples in the header without a
+		// seek-back, so a bytes.Buffer sink still reports the correct duration.
+		// go-flac verifies it against the samples written on Close.
+		TotalSamples: totalSamples,
 		// No SeekTableInterval: a bytes.Buffer is not an io.WriteSeeker, and
 		// go-flac rejects a seektable on a non-seekable sink. Short upload clips
 		// do not need one.

--- a/internal/audiocore/flac/encode_test.go
+++ b/internal/audiocore/flac/encode_test.go
@@ -445,6 +445,25 @@ func TestEncodePCMToBuffer_NoSeekTable(t *testing.T) {
 	assert.Equal(t, pcm, decodeFLACBytes(t, buf.Bytes()), "stream must still decode losslessly")
 }
 
+// TestEncodePCMToBuffer_FinalizesTotalSamples verifies the buffer path writes a
+// finalized STREAMINFO.total_samples up front rather than the zero "unknown"
+// sentinel, so a non-seekable sink still yields the correct sample count.
+// Consumers like BirdWeather derive the soundscape duration from this field.
+func TestEncodePCMToBuffer_FinalizesTotalSamples(t *testing.T) {
+	t.Parallel()
+	const sampleCount = 12345 // mono, so frames == samples
+	pcm := makeTestPCM(sampleCount)
+	buf, err := EncodePCMToBuffer(t.Context(), bufferBaseOpts(pcm))
+	require.NoError(t, err)
+
+	dec, err := goflac.NewDecoder(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	info := dec.Info()
+	assert.NotZero(t, info.TotalSamples, "total_samples must be finalized, not the unknown sentinel")
+	assert.Equal(t, uint64(sampleCount), info.TotalSamples,
+		"total_samples must equal the input frame count")
+}
+
 func TestEncodePCMToBuffer_Validation(t *testing.T) {
 	t.Parallel()
 	t.Run("nil options", func(t *testing.T) {

--- a/internal/audiocore/flac/gate.go
+++ b/internal/audiocore/flac/gate.go
@@ -12,10 +12,10 @@ import (
 // This is a temporary opt-in gate shared by every native FLAC path: the
 // detection save path (EncodePCM) and the BirdWeather soundscape upload path.
 // When the native encoder is trusted, the gate is removed and FLAC always routes
-// to the native path. The
-// detection save path still falls back to FFmpeg when EBU R128 normalization is
-// enabled; the BirdWeather path normalizes natively via audionorm. Keep the read
-// confined to NativeEncoderEnabled so the gate is a single deletion site.
+// to the native path. The detection save path still falls back to FFmpeg when
+// EBU R128 normalization is enabled; the BirdWeather path normalizes natively via
+// audionorm. Keep the read confined to NativeEncoderEnabled so the gate is a
+// single deletion site.
 const envFlacEncoder = "BIRDNET_FLAC_ENCODER"
 
 // nativeEncoderValue is the only env value that enables the native encoder.

--- a/internal/birdweather/README.md
+++ b/internal/birdweather/README.md
@@ -60,13 +60,18 @@ func encodeFlacUsingFFmpeg(pcmData []byte, settings *conf.Settings) (*bytes.Buff
 func encodePCMtoWAV(pcmData []byte) (*bytes.Buffer, error)
 ```
 
-BirdWeather FLAC uploads use a short-lived, disk-backed temporary file before
-the upload buffer is created. FLAC muxers need seekable output to finalize
-`STREAMINFO` metadata such as the total sample count; without that metadata
-BirdWeather can store the soundscape duration as `0.0`. The upload path creates
-the private temp directory with `os.MkdirTemp`, encodes the FLAC there, reads
-the finalized bytes with `os.ReadFile`, and removes the temporary file
+The FFmpeg FLAC path uses a short-lived, disk-backed temporary file before the
+upload buffer is created. FFmpeg cannot finalize `STREAMINFO` metadata such as
+the total sample count when it encodes to a non-seekable pipe; without that
+metadata BirdWeather can store the soundscape duration as `0.0`. That path
+creates a private temp directory with `os.MkdirTemp`, encodes the FLAC there,
+reads the finalized bytes with `os.ReadFile`, and removes the temporary file
 afterward.
+
+The native go-flac path (`BIRDNET_FLAC_ENCODER=native`) encodes directly to an
+in-memory buffer with no temp file. go-flac declares
+`STREAMINFO.total_samples` up front from the PCM length and verifies it against
+the samples written, so the duration is correct without a seekable sink.
 
 ### Loudness Normalization
 
@@ -198,7 +203,7 @@ Client connections are properly managed to prevent resource leaks:
 - HTTP client timeouts to prevent hanging connections
 - Proper cleanup of resources in the `Close()` method
 - Idle connection cleanup
-- **Seekable FLAC Uploads**: BirdWeather FLAC uploads use a short-lived temporary file so FFmpeg and the native FLAC encoder can finalize seek metadata before upload. The path creates the temporary workspace with `os.MkdirTemp`, reads the finalized bytes back with `os.ReadFile`, and then uploads through the existing in-memory HTTP path.
+- **Seekable FLAC Uploads (FFmpeg path)**: FFmpeg FLAC uploads use a short-lived temporary file so FFmpeg can finalize seek metadata before upload. The path creates the temporary workspace with `os.MkdirTemp`, reads the finalized bytes back with `os.ReadFile`, and then uploads through the existing in-memory HTTP path. The native go-flac path skips the temp file and encodes in memory.
 - Temporary files and directories are properly cleaned up
 
 ## Debug Capabilities
@@ -301,7 +306,7 @@ Comprehensive tests are provided for all key functionality:
 - **Location coordinates** are currently ignored by BirdWeather's API. Despite the location randomization feature, BirdWeather always uses the coordinates assigned to your station ID/token rather than the coordinates submitted with detections.
 - FLAC encoding requires **FFmpeg to be installed and configured correctly** on the host system (Linux, macOS, Windows).
 - Loudness normalization requires FFmpeg with the `loudnorm` filter (available in most modern FFmpeg builds).
-- **Memory Usage**: FFmpeg loudness analysis remains in memory, but finalized FLAC upload encoding uses a short-lived temp file so `STREAMINFO` duration metadata can be written.
+- **Memory Usage**: FFmpeg loudness analysis remains in memory, but finalized FFmpeg FLAC upload encoding uses a short-lived temp file so `STREAMINFO` duration metadata can be written. The native go-flac path encodes entirely in memory, declaring `STREAMINFO.total_samples` up front.
 
 ## Dependencies
 

--- a/internal/birdweather/encode_native.go
+++ b/internal/birdweather/encode_native.go
@@ -21,14 +21,14 @@ import (
 // limit so a near-silent clip is not over-amplified into loud static.
 const maxGainDB = 30.0
 
-// encodeWithNativeFLAC encodes PCM to a seekable temporary FLAC file, reads it
-// into an upload buffer, and uses the native go-flac encoder and audionorm
-// loudness normalization, with no FFmpeg dependency. The temp file round-trip is
-// handled by encodeUploadAudioToBuffer through os.MkdirTemp/os.ReadFile so
-// STREAMINFO total samples can be finalized. Pass 1 measures integrated loudness
-// and true peak; the planned gain (clamped to +/-maxGainDB) is then applied in
-// Go while the original bytes are streamed into the encoder. pcmData is not
-// modified.
+// encodeWithNativeFLAC encodes PCM directly to an in-memory FLAC upload buffer
+// using the native go-flac encoder and audionorm loudness normalization, with no
+// FFmpeg dependency. go-flac writes a finalized STREAMINFO total-samples field up
+// front from the PCM length, so the non-seekable buffer encoder yields the
+// correct soundscape duration with no temp-file round-trip. Pass 1 measures
+// integrated loudness and true peak; the planned gain (clamped to +/-maxGainDB)
+// is then applied in Go while the original bytes are streamed into the encoder.
+// pcmData is not modified.
 func (b *BwClient) encodeWithNativeFLAC(pcmData []byte, timestamp string) (*audioEncodingResult, error) {
 	log := GetLogger()
 
@@ -82,18 +82,16 @@ func (b *BwClient) encodeWithNativeFLAC(pcmData []byte, timestamp string) (*audi
 		logger.Float64("gain_db", gainDB),
 		logger.Bool("peak_limited", res.PeakLimited))
 
-	// Pass 2: apply the gain in Go and encode to seekable FLAC. BirdWeather
-	// derives soundscape duration from FLAC STREAMINFO, so uploads must not use
-	// the non-seekable buffer encoder that leaves total samples unknown.
-	buf, err := encodeUploadAudioToBuffer("flac", func(outputPath string) error {
-		return flac.EncodePCM(ctx, &flac.Options{
-			PCMData:    pcmData,
-			OutputPath: outputPath,
-			SampleRate: conf.SampleRate,
-			Channels:   conf.NumChannels,
-			BitDepth:   conf.BitDepth,
-			GainDB:     gainDB,
-		})
+	// Pass 2: apply the gain in Go and encode straight to an in-memory FLAC
+	// buffer. go-flac finalizes STREAMINFO.total_samples up front from the PCM
+	// length, so BirdWeather derives the correct soundscape duration without the
+	// temp-file round-trip the encoder needed before.
+	buf, err := flac.EncodePCMToBuffer(ctx, &flac.BufferOptions{
+		PCMData:    pcmData,
+		SampleRate: conf.SampleRate,
+		Channels:   conf.NumChannels,
+		BitDepth:   conf.BitDepth,
+		GainDB:     gainDB,
 	})
 	if err != nil {
 		// logFLACEncodingError downgrades timeout/cancel to WARN to avoid Sentry


### PR DESCRIPTION
## What

The native go-flac BirdWeather upload path was routed through a temp-file round-trip (`encodeUploadAudioToBuffer`) so the FLAC muxer could seek back and finalize `STREAMINFO.total_samples`. A `bytes.Buffer` is not seekable, so encoding straight to memory left `total_samples` at 0 and BirdWeather stored the soundscape duration as `0.0` (the bug PR #3764 worked around by forcing the temp file).

go-flac v0.4.0 adds `Config.TotalSamples`: the streaming encoder writes a finalized `total_samples` into the header up front and verifies it against the samples actually written on `Close`, so a non-seekable sink now yields the correct duration with no seek-back and no temp file.

## Changes

- Bump `github.com/tphakala/go-flac` v0.3.1 -> v0.4.0
- `EncodePCMToBuffer` derives `TotalSamples` from the PCM length (validated to be a whole number of 16-bit frames) and sets it on the encoder config; stale "total samples left unknown" doc comments rewritten
- Native BirdWeather path calls `flac.EncodePCMToBuffer` directly (in-memory), dropping the per-upload temp-file write. This is better on SD-card systems and avoids the double write (`EncodePCM` already did its own unique-temp + atomic-rename + fsync)
- FFmpeg FLAC path keeps its temp file (FFmpeg cannot finalize `STREAMINFO` on a pipe)
- Add `TestEncodePCMToBuffer_FinalizesTotalSamples`; the existing native-path STREAMINFO regression tests now guard the in-memory path directly

The native encoder remains opt-in behind `BIRDNET_FLAC_ENCODER=native`. Promoting it to primary and removing the FFmpeg FLAC path entirely is a separate, larger change and out of scope here.

## Release note

The native FLAC upload path (`BIRDNET_FLAC_ENCODER=native`) no longer writes a per-upload temporary file: it encodes in memory again with the correct soundscape duration. The FFmpeg FLAC path still uses a short-lived temp file. Note for existing native-path testers: the in-memory stream carries the spec-legal all-zero MD5 sentinel and no SEEKTABLE (the old temp-file path emitted both); the total-samples/duration is finalized and correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FLAC uploads now complete entirely in memory for the native encoding path, avoiding the extra temporary-file step.

* **Bug Fixes**
  * Duration metadata is now finalized correctly during in-memory FLAC encoding, so uploaded files report the right total sample count.
  * Improved consistency between native FLAC output and the documented behavior for audio processing.

* **Documentation**
  * Clarified how FLAC encoding differs between the native and fallback paths, including memory usage and metadata handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->