### PR TITLE
feat(audio): native EBU R128 normalization for the detection-save FLAC path

### DIFF
--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -5,12 +5,14 @@ package processor
 
 import (
 	"context"
+	"encoding/binary"
 	"os"
 	"path/filepath"
 	"strconv"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/analysis/species"
+	"github.com/tphakala/birdnet-go/internal/audiocore/audionorm"
 	"github.com/tphakala/birdnet-go/internal/audiocore/convert"
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/audiocore/flac"
@@ -537,15 +539,52 @@ func (a *SaveAudioAction) encodeClip(ctx context.Context, exportRate int, export
 		}
 		return encoderNativeFLAC, nil
 
+	case exportFormat == ffmpeg.FormatFLAC &&
+		flac.NativeEncoderEnabled() &&
+		exportSettings.Normalization.Enabled &&
+		flac.SupportedBitDepth(conf.BitDepth) &&
+		audionormSupportsTargets(exportSettings.Normalization.TargetLUFS, exportSettings.Normalization.TruePeak):
+		// Native FLAC + EBU R128 normalization via audionorm, no FFmpeg. The static
+		// Export.Gain is intentionally NOT applied here: the FFmpeg path gives
+		// normalization precedence over gain (buildExportAudioFilter), so applying
+		// only the loudness gain keeps behavior equivalent. audionorm normalizes to
+		// the configured integrated-loudness target under the true-peak ceiling; it
+		// does not consume LoudnessRange (no LRA/dynamic compression on this path).
+		gainDB, gainErr := a.planNativeNormalizationGain(ctx, exportRate,
+			exportSettings.Normalization.TargetLUFS, exportSettings.Normalization.TruePeak)
+		if gainErr != nil {
+			return "", gainErr
+		}
+		if err := flac.EncodePCM(ctx, &flac.Options{
+			PCMData:    a.pcmData,
+			OutputPath: outputPath,
+			SampleRate: exportRate,
+			Channels:   conf.NumChannels,
+			BitDepth:   conf.BitDepth,
+			GainDB:     gainDB,
+		}); err != nil {
+			return "", err
+		}
+		return encoderNativeFLAC, nil
+
 	default:
-		// Native FLAC was requested but EBU R128 normalization forces the FFmpeg
-		// path (loudnorm has no native equivalent). Logged so the fallback is
-		// visible while the gate exists.
+		// Native FLAC with normalization normally uses the audionorm path above.
+		// Reaching here for FLAC+normalization means the native encoder could not
+		// take the clip: either an unsupported bit depth or a target/ceiling
+		// outside audionorm's range. Neither happens for a validated config
+		// (capture is 16-bit and settings validation clamps the loudness targets
+		// into audionorm's range), so this is defense-in-depth for unvalidated or
+		// legacy settings; FFmpeg loudnorm tolerates the wider range. Logged with
+		// the actual reason so the fallback is visible while the gate exists.
 		if exportFormat == ffmpeg.FormatFLAC && flac.NativeEncoderEnabled() && exportSettings.Normalization.Enabled {
+			reason := "normalization_targets_out_of_native_range"
+			if !flac.SupportedBitDepth(conf.BitDepth) {
+				reason = "unsupported_bit_depth"
+			}
 			GetLogger().Debug("Native FLAC encoder requested but falling back to FFmpeg",
 				logger.String("component", "analysis.processor.actions"),
 				logger.String("detection_id", a.CorrelationID),
-				logger.String("reason", "normalization_enabled"),
+				logger.String("reason", reason),
 				logger.String("operation", "audio_export_flac_fallback"))
 		}
 		opts := &ffmpeg.ExportOptions{
@@ -570,6 +609,87 @@ func (a *SaveAudioAction) encodeClip(ctx context.Context, exportRate int, export
 		}
 		return encoderFFmpeg, nil
 	}
+}
+
+// maxNativeNormalizationGainDB bounds the loudness gain applied on the native
+// FLAC normalization path so a uniformly quiet clip is not over-amplified into
+// noise. Matches the +/-30 dB bound the BirdWeather native path uses; audionorm's
+// PlanGain already caps a boost at the true-peak ceiling, this is the secondary
+// guard for low-peak clips and for attenuation.
+const maxNativeNormalizationGainDB = 30.0
+
+// audionormMinTargetLUFS is the exclusive lower bound of audionorm's valid target
+// loudness range (audionorm rejects targets <= -70 LUFS, the absolute gate).
+const audionormMinTargetLUFS = -70.0
+
+// audionormSupportsTargets reports whether the configured integrated-loudness
+// target and true-peak ceiling fall within audionorm's valid range
+// (-70 < TargetLUFS < 0, ceiling <= 0). Out-of-range configs fall through to the
+// FFmpeg loudnorm path, which tolerates a wider range, rather than feeding
+// audionorm values it would mis-handle.
+func audionormSupportsTargets(targetLUFS, truePeakDBTP float64) bool {
+	return targetLUFS < 0 && targetLUFS > audionormMinTargetLUFS && truePeakDBTP <= 0
+}
+
+// planNativeNormalizationGain measures the clip's EBU R128 integrated loudness and
+// true peak with audionorm and returns the single linear gain (dB) that brings it
+// to targetLUFS without its true peak exceeding truePeakDBTP, clamped to
+// +/-maxNativeNormalizationGainDB. Silent or sub-400 ms input yields 0 (the clip
+// is left unchanged rather than boosted into noise), matching the BirdWeather
+// native path. The gain is applied by flac.EncodePCM during encoding; a.pcmData is
+// not modified here.
+func (a *SaveAudioAction) planNativeNormalizationGain(ctx context.Context, sampleRate int, targetLUFS, truePeakDBTP float64) (float64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	// audionorm reads a throwaway int16 view of the PCM; a.pcmData is not mutated.
+	meas, err := audionorm.MeasureInt16(pcmBytesToInt16(a.pcmData), sampleRate, conf.NumChannels)
+	if err != nil {
+		return 0, errors.New(err).
+			Component("analysis.processor").
+			Category(errors.CategoryAudio).
+			Context("operation", "native_flac_normalize_measure").
+			Context("detection_id", a.CorrelationID).
+			Build()
+	}
+
+	res := audionorm.PlanGain(meas, audionorm.Options{
+		SampleRate:   sampleRate,
+		Channels:     conf.NumChannels,
+		TargetLUFS:   targetLUFS,
+		TruePeakDBTP: truePeakDBTP,
+	})
+
+	gainDB := res.GainDB
+	switch {
+	case gainDB > maxNativeNormalizationGainDB:
+		gainDB = maxNativeNormalizationGainDB
+	case gainDB < -maxNativeNormalizationGainDB:
+		gainDB = -maxNativeNormalizationGainDB
+	}
+
+	GetLogger().Debug("Native FLAC loudness analysis (detection save)",
+		logger.Float64("measured_lufs", meas.IntegratedLUFS),
+		logger.Float64("true_peak_dbtp", meas.TruePeakDBTP),
+		logger.Float64("target_lufs", targetLUFS),
+		logger.Float64("gain_db", gainDB),
+		logger.Bool("peak_limited", res.PeakLimited),
+		logger.String("detection_id", a.CorrelationID))
+	return gainDB, nil
+}
+
+// pcmBytesToInt16 reinterprets interleaved little-endian 16-bit PCM bytes as
+// []int16 for loudness measurement. PCM samples are signed, so each pair is read
+// as a uint16 and bit-cast to int16 (a Uint16-only read would turn negative
+// samples into large positives and corrupt the measurement). A trailing odd byte
+// (not produced by real int16 PCM) is ignored. The returned slice is a copy; the
+// source bytes are not modified. Mirrors internal/birdweather pcmInt16FromBytes.
+func pcmBytesToInt16(b []byte) []int16 {
+	out := make([]int16, len(b)/2)
+	for i := range out {
+		out[i] = int16(binary.LittleEndian.Uint16(b[i*2:])) //nolint:gosec // G115: intentional uint16->int16 bit reinterpretation for signed PCM
+	}
+	return out
 }
 
 // resolveExportParams determines the export sample rate, format, and output

--- a/internal/analysis/processor/native_normalization_test.go
+++ b/internal/analysis/processor/native_normalization_test.go
@@ -1,0 +1,233 @@
+package processor
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	goflac "github.com/tphakala/go-flac/pcm"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore/audionorm"
+	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
+	"github.com/tphakala/birdnet-go/internal/audiocore/flac"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// sinePCMBytes builds a mono 16-bit LE PCM sine of the given peak amplitude,
+// duration, and frequency at conf.SampleRate. Duration must be >= 400 ms for the
+// EBU R128 integrated-loudness gate to yield a finite measurement.
+func sinePCMBytes(amp int16, seconds, freqHz float64) []byte {
+	n := int(float64(conf.SampleRate) * seconds)
+	buf := make([]byte, n*2)
+	for i := range n {
+		v := float64(amp) * math.Sin(2*math.Pi*freqHz*float64(i)/float64(conf.SampleRate))
+		//nolint:gosec // G115: rounded sine within int16 range, then LE bit-write
+		binary.LittleEndian.PutUint16(buf[i*2:], uint16(int16(math.Round(v))))
+	}
+	return buf
+}
+
+func measureLUFS(t *testing.T, pcm []byte) float64 {
+	t.Helper()
+	meas, err := audionorm.MeasureInt16(pcmBytesToInt16(pcm), conf.SampleRate, conf.NumChannels)
+	require.NoError(t, err)
+	return meas.IntegratedLUFS
+}
+
+const (
+	testTargetLUFS   = -23.0
+	testTruePeakDBTP = -2.0
+)
+
+// TestPlanNativeNormalizationGain_QuietClipReachesTarget verifies a quiet clip is
+// boosted by exactly (target - measured) when neither the true-peak ceiling nor
+// the +/-30 dB clamp binds, so applying the gain lands the clip on target.
+func TestPlanNativeNormalizationGain_QuietClipReachesTarget(t *testing.T) {
+	t.Parallel()
+	// ~-35 LUFS: wants ~+12 dB toward -23, well under the ceiling and the clamp.
+	pcm := sinePCMBytes(800, 1.0, 1000)
+	measured := measureLUFS(t, pcm)
+	require.Greater(t, measured, -50.0, "sanity: clip is quiet but well above the gate")
+	require.Less(t, measured, testTargetLUFS-5, "sanity: clip needs a real boost")
+
+	a := &SaveAudioAction{pcmData: pcm, CorrelationID: "test"}
+	gainDB, err := a.planNativeNormalizationGain(t.Context(), conf.SampleRate, testTargetLUFS, testTruePeakDBTP)
+	require.NoError(t, err)
+
+	assert.Positive(t, gainDB, "quiet clip must be boosted")
+	assert.InDelta(t, testTargetLUFS, measured+gainDB, 0.1,
+		"gain must bring the measured loudness onto the target (not peak-limited, not clamped)")
+	assert.Less(t, gainDB, maxNativeNormalizationGainDB, "this clip must not hit the clamp")
+}
+
+// TestPlanNativeNormalizationGain_Silence keeps silent input unchanged (gain 0)
+// rather than boosting the noise floor, matching the BirdWeather native path.
+func TestPlanNativeNormalizationGain_Silence(t *testing.T) {
+	t.Parallel()
+	pcm := make([]byte, conf.SampleRate*2) // 1 s of digital silence
+	a := &SaveAudioAction{pcmData: pcm, CorrelationID: "test"}
+	gainDB, err := a.planNativeNormalizationGain(t.Context(), conf.SampleRate, testTargetLUFS, testTruePeakDBTP)
+	require.NoError(t, err)
+	assert.Zero(t, gainDB, "silence must not be amplified")
+}
+
+// TestPlanNativeNormalizationGain_ClampsExtremeBoost bounds a near-silent (but
+// above the gate) clip to +maxNativeNormalizationGainDB instead of the full
+// target-driven gain.
+func TestPlanNativeNormalizationGain_ClampsExtremeBoost(t *testing.T) {
+	t.Parallel()
+	// ~-61 LUFS with a low peak: wants ~+38 dB, above the +30 clamp and below the
+	// true-peak ceiling, so the clamp (not the ceiling) binds.
+	pcm := sinePCMBytes(40, 1.0, 1000)
+	measured := measureLUFS(t, pcm)
+	require.Less(t, measured, testTargetLUFS-maxNativeNormalizationGainDB,
+		"sanity: uncapped gain would exceed the clamp")
+	require.Greater(t, measured, audionormMinTargetLUFS+3, "sanity: still above the absolute gate")
+
+	a := &SaveAudioAction{pcmData: pcm, CorrelationID: "test"}
+	gainDB, err := a.planNativeNormalizationGain(t.Context(), conf.SampleRate, testTargetLUFS, testTruePeakDBTP)
+	require.NoError(t, err)
+	assert.InDelta(t, maxNativeNormalizationGainDB, gainDB, 1e-9, "extreme boost must clamp to +30 dB")
+}
+
+// TestPlanNativeNormalizationGain_Attenuates reduces a loud clip toward the target
+// with a negative gain.
+func TestPlanNativeNormalizationGain_Attenuates(t *testing.T) {
+	t.Parallel()
+	pcm := sinePCMBytes(20000, 1.0, 1000) // loud, ~-7 LUFS
+	measured := measureLUFS(t, pcm)
+	require.Greater(t, measured, testTargetLUFS, "sanity: clip is louder than target")
+
+	a := &SaveAudioAction{pcmData: pcm, CorrelationID: "test"}
+	gainDB, err := a.planNativeNormalizationGain(t.Context(), conf.SampleRate, testTargetLUFS, testTruePeakDBTP)
+	require.NoError(t, err)
+	assert.Negative(t, gainDB, "loud clip must be attenuated")
+	assert.InDelta(t, testTargetLUFS, measured+gainDB, 0.1, "attenuation must land on target")
+}
+
+// TestPlanNativeNormalizationGain_ContextCancelled returns the context error
+// before doing any measurement work.
+func TestPlanNativeNormalizationGain_ContextCancelled(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	a := &SaveAudioAction{pcmData: sinePCMBytes(800, 1.0, 1000), CorrelationID: "test"}
+	_, err := a.planNativeNormalizationGain(ctx, conf.SampleRate, testTargetLUFS, testTruePeakDBTP)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// TestNativeNormalizationEndToEnd encodes a quiet clip through the real
+// plan-gain + flac.EncodePCM path, decodes the FLAC, and confirms the decoded
+// audio sits on the loudness target. This exercises the gain application done by
+// the encoder, not just the planning.
+func TestNativeNormalizationEndToEnd(t *testing.T) {
+	t.Parallel()
+	pcm := sinePCMBytes(800, 1.0, 1000)
+	a := &SaveAudioAction{pcmData: pcm, CorrelationID: "test"}
+
+	gainDB, err := a.planNativeNormalizationGain(t.Context(), conf.SampleRate, testTargetLUFS, testTruePeakDBTP)
+	require.NoError(t, err)
+
+	out := filepath.Join(t.TempDir(), "clip.flac")
+	require.NoError(t, flac.EncodePCM(t.Context(), &flac.Options{
+		PCMData:    pcm,
+		OutputPath: out,
+		SampleRate: conf.SampleRate,
+		Channels:   conf.NumChannels,
+		BitDepth:   conf.BitDepth,
+		GainDB:     gainDB,
+	}))
+
+	data, err := os.ReadFile(out) //nolint:gosec // test-controlled temp path
+	require.NoError(t, err)
+	dec, err := goflac.NewDecoder(bytes.NewReader(data))
+	require.NoError(t, err)
+	decoded, err := io.ReadAll(dec)
+	require.NoError(t, err)
+
+	got := measureLUFS(t, decoded)
+	assert.InDelta(t, testTargetLUFS, got, 1.0, "decoded clip loudness must sit near the target")
+}
+
+func TestAudionormSupportsTargets(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		target   float64
+		truePeak float64
+		want     bool
+	}{
+		{"typical -23/-2", -23, -2, true},
+		{"boundary near 0", -0.1, -1, true},
+		{"target zero rejected", 0, -1, false},
+		{"target positive rejected", 5, -1, false},
+		{"target at absolute gate rejected", -70, -1, false},
+		{"target below gate rejected", -75, -1, false},
+		{"positive true peak rejected", -23, 1, false},
+		{"zero true peak allowed", -23, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, audionormSupportsTargets(tt.target, tt.truePeak))
+		})
+	}
+}
+
+func TestPcmBytesToInt16(t *testing.T) {
+	t.Parallel()
+	// Round-trips signed values including negatives via LE bit layout.
+	in := []int16{0, 1, -1, 32767, -32768, 1234, -1234}
+	raw := make([]byte, len(in)*2)
+	for i, s := range in {
+		//nolint:gosec // G115: signed->LE bit-write for test fixture
+		binary.LittleEndian.PutUint16(raw[i*2:], uint16(s))
+	}
+	assert.Equal(t, in, pcmBytesToInt16(raw))
+
+	// A trailing odd byte is ignored (not produced by real int16 PCM).
+	assert.Len(t, pcmBytesToInt16([]byte{1, 2, 3}), 1)
+	assert.Empty(t, pcmBytesToInt16(nil))
+}
+
+// TestEncodeClipSelectsNativeNormalization drives the real encodeClip switch with
+// the native gate on and normalization enabled, proving it routes to the native
+// audionorm path (returns encoderNativeFLAC, not FFmpeg) AND that the static
+// Export.Gain is NOT applied on top of the loudness gain (FFmpeg gives
+// normalization precedence over gain, and the native path must match). Not
+// parallel: it toggles the process-global native-encoder gate override.
+func TestEncodeClipSelectsNativeNormalization(t *testing.T) {
+	t.Cleanup(flac.SetNativeEncoderEnabledForTest(true))
+
+	s := &conf.Settings{}
+	s.Realtime.Audio.Export.Normalization.Enabled = true
+	s.Realtime.Audio.Export.Normalization.TargetLUFS = testTargetLUFS
+	s.Realtime.Audio.Export.Normalization.TruePeak = testTruePeakDBTP
+	s.Realtime.Audio.Export.Gain = 12.0 // must be ignored while normalizing
+
+	pcm := sinePCMBytes(800, 1.0, 1000) // ~-35 LUFS, wants ~+12 dB toward target
+	a := &SaveAudioAction{Settings: s, pcmData: pcm, CorrelationID: "test"}
+
+	out := filepath.Join(t.TempDir(), "clip.flac")
+	enc, err := a.encodeClip(t.Context(), conf.SampleRate, ffmpeg.FormatFLAC, out)
+	require.NoError(t, err)
+	assert.Equal(t, encoderNativeFLAC, enc, "must select the native FLAC encoder, not FFmpeg")
+
+	data, err := os.ReadFile(out) //nolint:gosec // test-controlled temp path
+	require.NoError(t, err)
+	dec, err := goflac.NewDecoder(bytes.NewReader(data))
+	require.NoError(t, err)
+	decoded, err := io.ReadAll(dec)
+	require.NoError(t, err)
+
+	got := measureLUFS(t, decoded)
+	assert.InDelta(t, testTargetLUFS, got, 1.0,
+		"decoded clip must sit on the target; the +12 dB Export.Gain must NOT be added")
+}

--- a/internal/audiocore/flac/gate.go
+++ b/internal/audiocore/flac/gate.go
@@ -3,6 +3,7 @@ package flac
 import (
 	"os"
 	"sync"
+	"sync/atomic"
 )
 
 // envFlacEncoder names the environment variable that selects the FLAC export
@@ -12,10 +13,12 @@ import (
 // This is a temporary opt-in gate shared by every native FLAC path: the
 // detection save path (EncodePCM) and the BirdWeather soundscape upload path.
 // When the native encoder is trusted, the gate is removed and FLAC always routes
-// to the native path. The detection save path still falls back to FFmpeg when
-// EBU R128 normalization is enabled; the BirdWeather path normalizes natively via
-// audionorm. Keep the read confined to NativeEncoderEnabled so the gate is a
-// single deletion site.
+// to the native path. Both the detection save path and the BirdWeather path now
+// normalize natively via audionorm (EBU R128); FFmpeg loudnorm remains only as a
+// defensive fallback for a clip the native encoder cannot take (a non-16-bit
+// depth, or a target/ceiling outside audionorm's range), neither of which a
+// validated config reaches. Keep the read confined to NativeEncoderEnabled so the
+// gate is a single deletion site.
 const envFlacEncoder = "BIRDNET_FLAC_ENCODER"
 
 // nativeEncoderValue is the only env value that enables the native encoder.
@@ -24,14 +27,33 @@ const nativeEncoderValue = "native"
 var (
 	nativeOnce    sync.Once
 	nativeEnabled bool
+	// nativeEnabledOverride, when it holds a non-nil pointer, forces the gate
+	// value for tests in other packages that need to exercise the native path
+	// deterministically (see SetNativeEncoderEnabledForTest). It is atomic because
+	// NativeEncoderEnabled may be read from multiple goroutines. Empty in normal
+	// operation.
+	nativeEnabledOverride atomic.Pointer[bool]
 )
 
 // NativeEncoderEnabled reports whether the native go-flac export path is
 // selected via the BIRDNET_FLAC_ENCODER environment variable. The variable is
 // read once on first call; toggling it requires a restart.
 func NativeEncoderEnabled() bool {
+	if v := nativeEnabledOverride.Load(); v != nil {
+		return *v
+	}
 	nativeOnce.Do(func() {
 		nativeEnabled = os.Getenv(envFlacEncoder) == nativeEncoderValue
 	})
 	return nativeEnabled
+}
+
+// SetNativeEncoderEnabledForTest overrides the native-encoder gate for the
+// duration of a test and returns a restore function that clears the override.
+// It lets a test in another package drive the native FLAC path without depending
+// on the BIRDNET_FLAC_ENCODER environment variable or the sync.Once cache. It is
+// intended for tests only; production code must never call it.
+func SetNativeEncoderEnabledForTest(enabled bool) (restore func()) {
+	nativeEnabledOverride.Store(&enabled)
+	return func() { nativeEnabledOverride.Store(nil) }
 }


### PR DESCRIPTION
## What

When the native FLAC encoder is enabled (`BIRDNET_FLAC_ENCODER=native`) **and** export loudness normalization is on, the detection-clip save path now normalizes with the pure-Go `audiocore/audionorm` library and encodes with the native go-flac encoder, instead of falling back to FFmpeg loudnorm. This removes the last FFmpeg dependency on the native detection-save path (the remaining blocker to eventually dropping the FFmpeg FLAC code entirely).

Before this change, `encodeClip` used the native encoder only when normalization was **off**; with normalization on it always fell back to FFmpeg because loudnorm had no native equivalent. `audionorm` (shipped for BirdWeather uploads) is that equivalent.

## How

`encodeClip` gains a native-normalization case: measure integrated loudness + true peak with audionorm, plan a single linear gain to the configured target under the true-peak ceiling (clamped to +/-30 dB), and apply it during `flac.EncodePCM`.

- The static `Export.Gain` is intentionally **not** applied while normalizing, matching the FFmpeg path (`buildExportAudioFilter` gives normalization precedence over gain). A dispatch test proves this.
- A misconfigured target/ceiling outside audionorm's range, or a non-16-bit depth, falls through to the FFmpeg default. Both are defense-in-depth: neither is reachable for a validated config (validation clamps `TargetLUFS`/`TruePeak` into range, and capture is 16-bit).
- `exportRate` (not a hardcoded rate) is threaded into the measurement, so bat/downsampled clips are measured at their actual rate.

## Behavior note (native-encoder users only)

audionorm applies **integrated loudness + true peak only**; it does not consume `LoudnessRange`, so the native path does linear normalization with no LRA/dynamic compression (identical to what BirdWeather native uploads already ship). For short bird-call clips FFmpeg two-pass loudnorm already resolves to a near-linear gain, so the audible delta is small. Very quiet clips: audionorm boosts finite-but-quiet clips toward target up to the true-peak ceiling and the +/-30 dB clamp, and leaves truly silent (sub-gate) clips unchanged rather than amplifying the noise floor.

This is opt-in behind the existing `BIRDNET_FLAC_ENCODER=native` gate; the default FFmpeg path is completely unchanged.

## Release note

Native FLAC encoder (`BIRDNET_FLAC_ENCODER=native`): detection-clip saves with EBU R128 normalization enabled now normalize in pure Go via audionorm, with no FFmpeg dependency. Normalization is linear (integrated loudness + true peak, no loudness-range/dynamic compression). Default (FFmpeg) users are unaffected.

## Tests

- Gain planning: quiet clip reaches target, silence stays at 0, extreme boost clamps to +30 dB, loud clip attenuates, context cancellation observed.
- End-to-end encode -> decode -> re-measure loudness lands on target.
- Dispatch: `encodeClip` with the gate on selects the native path and ignores `Export.Gain`.
- Range guard and byte->int16 conversion unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Native FLAC exports can now apply loudness normalization directly, improving export speed and reducing reliance on fallback processing.
  * Loudness handling is now more consistent across quiet, loud, and near-silent audio clips.

* **Bug Fixes**
  * Fixed cases where normalized exports could fall back unnecessarily.
  * Improved handling of extreme gain adjustments so output stays within safe loudness limits.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->