### PR TITLE
refactor(audionorm): converge duplicated PCM int16 decode and gain clamp

### DIFF
--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -5,7 +5,6 @@ package processor
 
 import (
 	"context"
-	"encoding/binary"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -611,13 +610,6 @@ func (a *SaveAudioAction) encodeClip(ctx context.Context, exportRate int, export
 	}
 }
 
-// maxNativeNormalizationGainDB bounds the loudness gain applied on the native
-// FLAC normalization path so a uniformly quiet clip is not over-amplified into
-// noise. Matches the +/-30 dB bound the BirdWeather native path uses; audionorm's
-// PlanGain already caps a boost at the true-peak ceiling, this is the secondary
-// guard for low-peak clips and for attenuation.
-const maxNativeNormalizationGainDB = 30.0
-
 // audionormMinTargetLUFS is the exclusive lower bound of audionorm's valid target
 // loudness range (audionorm rejects targets <= -70 LUFS, the absolute gate).
 const audionormMinTargetLUFS = -70.0
@@ -634,16 +626,16 @@ func audionormSupportsTargets(targetLUFS, truePeakDBTP float64) bool {
 // planNativeNormalizationGain measures the clip's EBU R128 integrated loudness and
 // true peak with audionorm and returns the single linear gain (dB) that brings it
 // to targetLUFS without its true peak exceeding truePeakDBTP, clamped to
-// +/-maxNativeNormalizationGainDB. Silent or sub-400 ms input yields 0 (the clip
-// is left unchanged rather than boosted into noise), matching the BirdWeather
-// native path. The gain is applied by flac.EncodePCM during encoding; a.pcmData is
-// not modified here.
+// +/-audionorm.DefaultMaxGainDB. Silent or sub-400 ms input yields 0 (the clip is
+// left unchanged rather than boosted into noise), matching the BirdWeather native
+// path. The gain is applied by flac.EncodePCM during encoding; a.pcmData is not
+// modified here.
 func (a *SaveAudioAction) planNativeNormalizationGain(ctx context.Context, sampleRate int, targetLUFS, truePeakDBTP float64) (float64, error) {
 	if err := ctx.Err(); err != nil {
 		return 0, err
 	}
-	// audionorm reads a throwaway int16 view of the PCM; a.pcmData is not mutated.
-	meas, err := audionorm.MeasureInt16(pcmBytesToInt16(a.pcmData), sampleRate, conf.NumChannels)
+	// audionorm decodes the PCM bytes inline; a.pcmData is not mutated.
+	meas, err := audionorm.MeasureInt16Bytes(a.pcmData, sampleRate, conf.NumChannels)
 	if err != nil {
 		return 0, errors.New(err).
 			Component("analysis.processor").
@@ -660,13 +652,10 @@ func (a *SaveAudioAction) planNativeNormalizationGain(ctx context.Context, sampl
 		TruePeakDBTP: truePeakDBTP,
 	})
 
-	gainDB := res.GainDB
-	switch {
-	case gainDB > maxNativeNormalizationGainDB:
-		gainDB = maxNativeNormalizationGainDB
-	case gainDB < -maxNativeNormalizationGainDB:
-		gainDB = -maxNativeNormalizationGainDB
-	}
+	// Silence yields GainDB == 0 (audionorm returns -Inf LUFS); the clamp is the
+	// secondary guard for low-peak clips and for attenuation. Applied silently on
+	// this path (the BirdWeather path logs its own limiting).
+	gainDB, _ := audionorm.ClampGainDB(res.GainDB, audionorm.DefaultMaxGainDB)
 
 	GetLogger().Debug("Native FLAC loudness analysis (detection save)",
 		logger.Float64("measured_lufs", meas.IntegratedLUFS),
@@ -676,20 +665,6 @@ func (a *SaveAudioAction) planNativeNormalizationGain(ctx context.Context, sampl
 		logger.Bool("peak_limited", res.PeakLimited),
 		logger.String("detection_id", a.CorrelationID))
 	return gainDB, nil
-}
-
-// pcmBytesToInt16 reinterprets interleaved little-endian 16-bit PCM bytes as
-// []int16 for loudness measurement. PCM samples are signed, so each pair is read
-// as a uint16 and bit-cast to int16 (a Uint16-only read would turn negative
-// samples into large positives and corrupt the measurement). A trailing odd byte
-// (not produced by real int16 PCM) is ignored. The returned slice is a copy; the
-// source bytes are not modified. Mirrors internal/birdweather pcmInt16FromBytes.
-func pcmBytesToInt16(b []byte) []int16 {
-	out := make([]int16, len(b)/2)
-	for i := range out {
-		out[i] = int16(binary.LittleEndian.Uint16(b[i*2:])) //nolint:gosec // G115: intentional uint16->int16 bit reinterpretation for signed PCM
-	}
-	return out
 }
 
 // resolveExportParams determines the export sample rate, format, and output

--- a/internal/analysis/processor/native_normalization_test.go
+++ b/internal/analysis/processor/native_normalization_test.go
@@ -36,7 +36,7 @@ func sinePCMBytes(amp int16, seconds, freqHz float64) []byte {
 
 func measureLUFS(t *testing.T, pcm []byte) float64 {
 	t.Helper()
-	meas, err := audionorm.MeasureInt16(pcmBytesToInt16(pcm), conf.SampleRate, conf.NumChannels)
+	meas, err := audionorm.MeasureInt16Bytes(pcm, conf.SampleRate, conf.NumChannels)
 	require.NoError(t, err)
 	return meas.IntegratedLUFS
 }
@@ -64,7 +64,7 @@ func TestPlanNativeNormalizationGain_QuietClipReachesTarget(t *testing.T) {
 	assert.Positive(t, gainDB, "quiet clip must be boosted")
 	assert.InDelta(t, testTargetLUFS, measured+gainDB, 0.1,
 		"gain must bring the measured loudness onto the target (not peak-limited, not clamped)")
-	assert.Less(t, gainDB, maxNativeNormalizationGainDB, "this clip must not hit the clamp")
+	assert.Less(t, gainDB, audionorm.DefaultMaxGainDB, "this clip must not hit the clamp")
 }
 
 // TestPlanNativeNormalizationGain_Silence keeps silent input unchanged (gain 0)
@@ -79,7 +79,7 @@ func TestPlanNativeNormalizationGain_Silence(t *testing.T) {
 }
 
 // TestPlanNativeNormalizationGain_ClampsExtremeBoost bounds a near-silent (but
-// above the gate) clip to +maxNativeNormalizationGainDB instead of the full
+// above the gate) clip to +audionorm.DefaultMaxGainDB instead of the full
 // target-driven gain.
 func TestPlanNativeNormalizationGain_ClampsExtremeBoost(t *testing.T) {
 	t.Parallel()
@@ -87,14 +87,14 @@ func TestPlanNativeNormalizationGain_ClampsExtremeBoost(t *testing.T) {
 	// true-peak ceiling, so the clamp (not the ceiling) binds.
 	pcm := sinePCMBytes(40, 1.0, 1000)
 	measured := measureLUFS(t, pcm)
-	require.Less(t, measured, testTargetLUFS-maxNativeNormalizationGainDB,
+	require.Less(t, measured, testTargetLUFS-audionorm.DefaultMaxGainDB,
 		"sanity: uncapped gain would exceed the clamp")
 	require.Greater(t, measured, audionormMinTargetLUFS+3, "sanity: still above the absolute gate")
 
 	a := &SaveAudioAction{pcmData: pcm, CorrelationID: "test"}
 	gainDB, err := a.planNativeNormalizationGain(t.Context(), conf.SampleRate, testTargetLUFS, testTruePeakDBTP)
 	require.NoError(t, err)
-	assert.InDelta(t, maxNativeNormalizationGainDB, gainDB, 1e-9, "extreme boost must clamp to +30 dB")
+	assert.InDelta(t, audionorm.DefaultMaxGainDB, gainDB, 1e-9, "extreme boost must clamp to +DefaultMaxGainDB")
 }
 
 // TestPlanNativeNormalizationGain_Attenuates reduces a loud clip toward the target
@@ -181,21 +181,9 @@ func TestAudionormSupportsTargets(t *testing.T) {
 	}
 }
 
-func TestPcmBytesToInt16(t *testing.T) {
-	t.Parallel()
-	// Round-trips signed values including negatives via LE bit layout.
-	in := []int16{0, 1, -1, 32767, -32768, 1234, -1234}
-	raw := make([]byte, len(in)*2)
-	for i, s := range in {
-		//nolint:gosec // G115: signed->LE bit-write for test fixture
-		binary.LittleEndian.PutUint16(raw[i*2:], uint16(s))
-	}
-	assert.Equal(t, in, pcmBytesToInt16(raw))
-
-	// A trailing odd byte is ignored (not produced by real int16 PCM).
-	assert.Len(t, pcmBytesToInt16([]byte{1, 2, 3}), 1)
-	assert.Empty(t, pcmBytesToInt16(nil))
-}
+// The []byte->[]int16 signed-cast and odd-trailing-byte regression guards now
+// live with the shared decoder in internal/audiocore/audionorm (MeasureInt16Bytes
+// / Meter.AddInt16Bytes), which this path calls instead of a local helper.
 
 // TestEncodeClipSelectsNativeNormalization drives the real encodeClip switch with
 // the native gate on and normalization enabled, proving it routes to the native

--- a/internal/audiocore/audionorm/alloc_test.go
+++ b/internal/audiocore/audionorm/alloc_test.go
@@ -50,6 +50,18 @@ func TestMeasureInt16SteadyStateZeroAlloc(t *testing.T) {
 	}
 }
 
+// MeasureInt16Bytes must also reach zero allocations in steady state: it decodes
+// bytes inline via the pooled meter, allocating no intermediate []int16.
+func TestMeasureInt16BytesSteadyStateZeroAlloc(t *testing.T) {
+	pcm := int16sToLEBytes(sineInt16(-12, 1000, 1, 48000))
+	allocs := testing.AllocsPerRun(20, func() {
+		_, _ = MeasureInt16Bytes(pcm, 48000, 1)
+	})
+	if allocs != 0 {
+		t.Errorf("pooled MeasureInt16Bytes: %.1f allocs/op, want 0", allocs)
+	}
+}
+
 // NormalizeInt16 in steady state must also be zero-alloc (gain applied in place
 // with a stack scratch buffer; meter pooled).
 func TestNormalizeInt16SteadyStateZeroAlloc(t *testing.T) {

--- a/internal/audiocore/audionorm/audionorm.go
+++ b/internal/audiocore/audionorm/audionorm.go
@@ -215,11 +215,14 @@ const DefaultMaxGainDB = 30.0
 // limiting while another applies it silently. maxAbsDB is treated as a magnitude;
 // callers pass a non-negative value.
 func ClampGainDB(gainDB, maxAbsDB float64) (clamped float64, limited bool) {
+	// Treat maxAbsDB as a magnitude so a stray negative ceiling still yields a
+	// sane symmetric range rather than clamping everything to a negative bound.
+	absLimit := math.Abs(maxAbsDB)
 	switch {
-	case gainDB > maxAbsDB:
-		return maxAbsDB, true
-	case gainDB < -maxAbsDB:
-		return -maxAbsDB, true
+	case gainDB > absLimit:
+		return absLimit, true
+	case gainDB < -absLimit:
+		return -absLimit, true
 	default:
 		return gainDB, false
 	}

--- a/internal/audiocore/audionorm/audionorm.go
+++ b/internal/audiocore/audionorm/audionorm.go
@@ -112,6 +112,21 @@ func MeasureInt16(pcm []int16, sampleRate, channels int) (Measurement, error) {
 	return result(m), nil
 }
 
+// MeasureInt16Bytes measures interleaved little-endian 16-bit PCM supplied as raw
+// bytes. It is equivalent to reinterpreting the bytes as []int16 and calling
+// MeasureInt16, but decodes inline via Meter.AddInt16Bytes so no intermediate
+// slice is allocated. A trailing odd byte (never produced by real int16 PCM) is
+// ignored; the source bytes are not modified.
+func MeasureInt16Bytes(pcm []byte, sampleRate, channels int) (Measurement, error) {
+	if err := validateDims(sampleRate, channels, len(pcm)/2); err != nil {
+		return Measurement{}, err
+	}
+	m := acquireMeter(sampleRate, channels)
+	defer releaseMeter(m)
+	m.AddInt16Bytes(pcm)
+	return result(m), nil
+}
+
 // NormalizeFloat32 normalizes interleaved float32 PCM in place and returns the
 // outcome. Silent input is left untouched (GainDB = 0).
 func NormalizeFloat32(pcm []float32, opts Options) (Result, error) {
@@ -184,6 +199,30 @@ func PlanGain(meas Measurement, opts Options) Result {
 	res.GainDB = gain
 	res.OutputLUFS = meas.IntegratedLUFS + gain
 	return res
+}
+
+// DefaultMaxGainDB bounds the loudness gain the FLAC export paths apply: 30 dB,
+// the same clamp the BirdWeather FFmpeg FLAC path uses, so a clip's loudness is
+// corrected no more aggressively under one encoder than the other. It stops a
+// near-silent clip from being over-amplified into loud static, and a hot clip
+// from being driven toward digital silence. (Distinct from ffmpeg.MaxGainDB,
+// which is a wider loudnorm-offset validation range, not this export clamp.)
+const DefaultMaxGainDB = 30.0
+
+// ClampGainDB constrains a planned gain (dB) to [-maxAbsDB, +maxAbsDB] and reports
+// whether the clamp took effect. Callers pass PlanGain's GainDB and their own
+// ceiling (usually DefaultMaxGainDB); the returned bool lets one caller log the
+// limiting while another applies it silently. maxAbsDB is treated as a magnitude;
+// callers pass a non-negative value.
+func ClampGainDB(gainDB, maxAbsDB float64) (clamped float64, limited bool) {
+	switch {
+	case gainDB > maxAbsDB:
+		return maxAbsDB, true
+	case gainDB < -maxAbsDB:
+		return -maxAbsDB, true
+	default:
+		return gainDB, false
+	}
 }
 
 func validateDims(sampleRate, channels, n int) error {

--- a/internal/audiocore/audionorm/int16bytes_test.go
+++ b/internal/audiocore/audionorm/int16bytes_test.go
@@ -1,0 +1,175 @@
+package audionorm
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+)
+
+// int16sToLEBytes serializes interleaved int16 samples to little-endian bytes,
+// the on-the-wire layout MeasureInt16Bytes / Meter.AddInt16Bytes decode.
+func int16sToLEBytes(samples []int16) []byte {
+	b := make([]byte, len(samples)*2)
+	for i, s := range samples {
+		binary.LittleEndian.PutUint16(b[i*2:], uint16(s)) //nolint:gosec // G115: signed->LE bit-write for test fixture
+	}
+	return b
+}
+
+// interleaveInt16 zips per-channel int16 signals into one interleaved buffer.
+func interleaveInt16(channels ...[]int16) []int16 {
+	frames := len(channels[0])
+	out := make([]int16, frames*len(channels))
+	for i := range frames {
+		for c, ch := range channels {
+			out[i*len(channels)+c] = ch[i]
+		}
+	}
+	return out
+}
+
+// boundaryInt16 fills n samples by cycling through int16 edge values so the
+// full-scale minimum (-32768) and maximum (32767) both appear. -32768 is the
+// two's-complement boundary a signed-vs-unsigned decode bug corrupts most, and
+// it drives the true-peak path (which keys on the maximum magnitude sample).
+func boundaryInt16(n int) []int16 {
+	edges := []int16{0, -1, 1, 32767, -32768, 1234, -1234}
+	out := make([]int16, n)
+	for i := range out {
+		out[i] = edges[i%len(edges)]
+	}
+	return out
+}
+
+// MeasureInt16Bytes must produce exactly the same Measurement as MeasureInt16 on
+// the same samples: it decodes the identical int16 values inline, so there is no
+// float rounding difference to tolerate. Covers mono, the interleaved-stereo
+// indexing (channels > 1), and the full-scale +/-boundary samples.
+func TestMeasureInt16BytesMatchesInt16(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		pcm      []int16
+		channels int
+	}{
+		{"mono", sineInt16(-12, 1000, 1, 48000), 1},
+		{
+			name:     "stereo",
+			pcm:      interleaveInt16(sineInt16(-12, 1000, 1, 48000), sineInt16(-9, 660, 1, 48000)),
+			channels: 2,
+		},
+		// 1 s (> the 400 ms gate) of cycling edge values, guaranteeing -32768 and
+		// 32767 flow through both the k-weighting and true-peak passes.
+		{"full-scale boundary", boundaryInt16(48000), 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			want, err := MeasureInt16(tc.pcm, 48000, tc.channels)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := MeasureInt16Bytes(int16sToLEBytes(tc.pcm), 48000, tc.channels)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != want {
+				t.Errorf("MeasureInt16Bytes = %+v, want %+v (must equal MeasureInt16)", got, want)
+			}
+		})
+	}
+}
+
+// Regression guard for the signed cast: a Uint16-only decode would turn negative
+// samples into large positives and inflate the loudness. A finite (>= 400 ms)
+// sine has half its samples negative, so an unsigned misread would diverge from
+// the []int16 reference path.
+func TestMeasureInt16BytesSignedNegatives(t *testing.T) {
+	t.Parallel()
+	pcm := sineInt16(-6, 500, 1, 48000)
+	want, err := MeasureInt16(pcm, 48000, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := MeasureInt16Bytes(int16sToLEBytes(pcm), 48000, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("signed decode mismatch: MeasureInt16Bytes = %+v, want %+v", got, want)
+	}
+}
+
+// A trailing odd byte (never present in real int16 PCM) is dropped rather than
+// panicking, so the result equals that of the even-truncated buffer.
+func TestMeasureInt16BytesOddTrailingByte(t *testing.T) {
+	t.Parallel()
+	pcm := sineInt16(-12, 1000, 1, 48000)
+	even := int16sToLEBytes(pcm)
+	want, err := MeasureInt16Bytes(even, 48000, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := MeasureInt16Bytes(append(even, 0x7f), 48000, 1) //nolint:gocritic // appendAssign: intentional odd-length copy for the test
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("odd trailing byte changed result: got %+v, want %+v", got, want)
+	}
+}
+
+// Empty/sub-frame input measures as silence (IntegratedLUFS == -Inf) without
+// erroring or panicking: validateDims accepts n == 0, and AddInt16Bytes
+// early-returns on zero frames.
+func TestMeasureInt16BytesEmpty(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		b    []byte
+	}{
+		{"nil", nil},
+		{"empty", []byte{}},
+		{"single odd byte", []byte{0x7f}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := MeasureInt16Bytes(tc.b, 48000, 1)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !math.IsInf(got.IntegratedLUFS, -1) {
+				t.Errorf("empty input: IntegratedLUFS = %v, want -Inf (silence)", got.IntegratedLUFS)
+			}
+		})
+	}
+}
+
+func TestClampGainDB(t *testing.T) {
+	t.Parallel()
+	const maxAbs = DefaultMaxGainDB
+	cases := []struct {
+		name        string
+		in          float64
+		wantVal     float64
+		wantLimited bool
+	}{
+		{"within range", 12.5, 12.5, false},
+		{"at positive ceiling", maxAbs, maxAbs, false},
+		{"above positive ceiling", maxAbs + 5, maxAbs, true},
+		{"at negative ceiling", -maxAbs, -maxAbs, false},
+		{"below negative ceiling", -maxAbs - 5, -maxAbs, true},
+		{"zero", 0, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, limited := ClampGainDB(tc.in, maxAbs)
+			if got != tc.wantVal || limited != tc.wantLimited {
+				t.Errorf("ClampGainDB(%v, %v) = (%v, %v), want (%v, %v)",
+					tc.in, maxAbs, got, limited, tc.wantVal, tc.wantLimited)
+			}
+		})
+	}
+}

--- a/internal/audiocore/audionorm/int16bytes_test.go
+++ b/internal/audiocore/audionorm/int16bytes_test.go
@@ -152,23 +152,29 @@ func TestClampGainDB(t *testing.T) {
 	cases := []struct {
 		name        string
 		in          float64
+		maxAbs      float64
 		wantVal     float64
 		wantLimited bool
 	}{
-		{"within range", 12.5, 12.5, false},
-		{"at positive ceiling", maxAbs, maxAbs, false},
-		{"above positive ceiling", maxAbs + 5, maxAbs, true},
-		{"at negative ceiling", -maxAbs, -maxAbs, false},
-		{"below negative ceiling", -maxAbs - 5, -maxAbs, true},
-		{"zero", 0, 0, false},
+		{"within range", 12.5, maxAbs, 12.5, false},
+		{"at positive ceiling", maxAbs, maxAbs, maxAbs, false},
+		{"above positive ceiling", maxAbs + 5, maxAbs, maxAbs, true},
+		{"at negative ceiling", -maxAbs, maxAbs, -maxAbs, false},
+		{"below negative ceiling", -maxAbs - 5, maxAbs, -maxAbs, true},
+		{"zero", 0, maxAbs, 0, false},
+		// A negative ceiling is treated as its magnitude, so the range stays
+		// symmetric rather than clamping every value to a negative bound.
+		{"negative ceiling, over", 50, -maxAbs, maxAbs, true},
+		{"negative ceiling, under", -50, -maxAbs, -maxAbs, true},
+		{"negative ceiling, within", 10, -maxAbs, 10, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got, limited := ClampGainDB(tc.in, maxAbs)
+			got, limited := ClampGainDB(tc.in, tc.maxAbs)
 			if got != tc.wantVal || limited != tc.wantLimited {
 				t.Errorf("ClampGainDB(%v, %v) = (%v, %v), want (%v, %v)",
-					tc.in, maxAbs, got, limited, tc.wantVal, tc.wantLimited)
+					tc.in, tc.maxAbs, got, limited, tc.wantVal, tc.wantLimited)
 			}
 		})
 	}

--- a/internal/audiocore/audionorm/int16bytes_test.go
+++ b/internal/audiocore/audionorm/int16bytes_test.go
@@ -16,18 +16,6 @@ func int16sToLEBytes(samples []int16) []byte {
 	return b
 }
 
-// interleaveInt16 zips per-channel int16 signals into one interleaved buffer.
-func interleaveInt16(channels ...[]int16) []int16 {
-	frames := len(channels[0])
-	out := make([]int16, frames*len(channels))
-	for i := range frames {
-		for c, ch := range channels {
-			out[i*len(channels)+c] = ch[i]
-		}
-	}
-	return out
-}
-
 // boundaryInt16 fills n samples by cycling through int16 edge values so the
 // full-scale minimum (-32768) and maximum (32767) both appear. -32768 is the
 // two's-complement boundary a signed-vs-unsigned decode bug corrupts most, and
@@ -43,33 +31,27 @@ func boundaryInt16(n int) []int16 {
 
 // MeasureInt16Bytes must produce exactly the same Measurement as MeasureInt16 on
 // the same samples: it decodes the identical int16 values inline, so there is no
-// float rounding difference to tolerate. Covers mono, the interleaved-stereo
-// indexing (channels > 1), and the full-scale +/-boundary samples.
+// float rounding difference to tolerate. BirdNET-Go audio is always mono; the
+// cases cover a mono sine and the full-scale +/-boundary samples.
 func TestMeasureInt16BytesMatchesInt16(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		name     string
-		pcm      []int16
-		channels int
+		name string
+		pcm  []int16
 	}{
-		{"mono", sineInt16(-12, 1000, 1, 48000), 1},
-		{
-			name:     "stereo",
-			pcm:      interleaveInt16(sineInt16(-12, 1000, 1, 48000), sineInt16(-9, 660, 1, 48000)),
-			channels: 2,
-		},
+		{"mono", sineInt16(-12, 1000, 1, 48000)},
 		// 1 s (> the 400 ms gate) of cycling edge values, guaranteeing -32768 and
 		// 32767 flow through both the k-weighting and true-peak passes.
-		{"full-scale boundary", boundaryInt16(48000), 1},
+		{"full-scale boundary", boundaryInt16(48000)},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			want, err := MeasureInt16(tc.pcm, 48000, tc.channels)
+			want, err := MeasureInt16(tc.pcm, 48000, 1)
 			if err != nil {
 				t.Fatal(err)
 			}
-			got, err := MeasureInt16Bytes(int16sToLEBytes(tc.pcm), 48000, tc.channels)
+			got, err := MeasureInt16Bytes(int16sToLEBytes(tc.pcm), 48000, 1)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/audiocore/audionorm/meter.go
+++ b/internal/audiocore/audionorm/meter.go
@@ -1,6 +1,7 @@
 package audionorm
 
 import (
+	"encoding/binary"
 	"math"
 
 	simdf32 "github.com/tphakala/simd/f32"
@@ -212,6 +213,41 @@ func (m *Meter) AddInt16(interleaved []int16) {
 			dst := m.tpChunkStart(c, n)
 			for i := range n {
 				dst[i] = float32(interleaved[(pos+i)*m.channels+c]) * scale
+			}
+			m.tpChunkEnd(c, n)
+		}
+	}
+}
+
+// AddInt16Bytes feeds interleaved little-endian 16-bit PCM held as raw bytes,
+// decoding each sample inline with the same 1/32768 convention as AddInt16. It
+// lets a caller whose PCM is a []byte (the FLAC export paths) measure loudness
+// without first allocating an intermediate []int16. Samples are signed, so each
+// byte pair is read as a uint16 and bit-cast to int16 (a Uint16-only read would
+// turn negative samples into large positives and corrupt the measurement). A
+// trailing odd byte (never produced by real int16 PCM) is ignored; b is not
+// modified.
+func (m *Meter) AddInt16Bytes(b []byte) {
+	const scale = float32(1.0 / 32768.0)
+	frames := (len(b) / 2) / m.channels
+	if frames == 0 {
+		return
+	}
+	for i := range frames {
+		base := i * m.channels
+		for c := range m.channels {
+			v := int16(binary.LittleEndian.Uint16(b[(base+c)*2:])) //nolint:gosec // G115: intentional uint16->int16 bit reinterpretation for signed PCM
+			m.kweight(c, float32(v)*scale)
+		}
+		m.advanceFrame()
+	}
+	for c := range m.channels {
+		for pos := 0; pos < frames; pos += tpChunk {
+			n := min(tpChunk, frames-pos)
+			dst := m.tpChunkStart(c, n)
+			for i := range n {
+				v := int16(binary.LittleEndian.Uint16(b[((pos+i)*m.channels+c)*2:])) //nolint:gosec // G115: intentional uint16->int16 bit reinterpretation for signed PCM
+				dst[i] = float32(v) * scale
 			}
 			m.tpChunkEnd(c, n)
 		}

--- a/internal/birdweather/encode_native.go
+++ b/internal/birdweather/encode_native.go
@@ -8,7 +8,6 @@ package birdweather
 
 import (
 	"context"
-	"encoding/binary"
 
 	"github.com/tphakala/birdnet-go/internal/audiocore/audionorm"
 	"github.com/tphakala/birdnet-go/internal/audiocore/flac"
@@ -17,17 +16,14 @@ import (
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
-// maxGainDB bounds the normalization gain, matching the FFmpeg path's safety
-// limit so a near-silent clip is not over-amplified into loud static.
-const maxGainDB = 30.0
-
 // encodeWithNativeFLAC encodes PCM directly to an in-memory FLAC upload buffer
 // using the native go-flac encoder and audionorm loudness normalization, with no
 // FFmpeg dependency. go-flac writes a finalized STREAMINFO total-samples field up
 // front from the PCM length, so the non-seekable buffer encoder yields the
 // correct soundscape duration with no temp-file round-trip. Pass 1 measures
-// integrated loudness and true peak; the planned gain (clamped to +/-maxGainDB)
-// is then applied in Go while the original bytes are streamed into the encoder.
+// integrated loudness and true peak; the planned gain (clamped to
+// +/-audionorm.DefaultMaxGainDB) is then applied in Go while the original bytes
+// are streamed into the encoder.
 // pcmData is not modified.
 func (b *BwClient) encodeWithNativeFLAC(pcmData []byte, timestamp string) (*audioEncodingResult, error) {
 	log := GetLogger()
@@ -38,10 +34,9 @@ func (b *BwClient) encodeWithNativeFLAC(pcmData []byte, timestamp string) (*audi
 	ctx, cancel := context.WithTimeout(context.Background(), encodingTimeout)
 	defer cancel()
 
-	// Pass 1: measure loudness + true peak. Reads a throwaway int16 view of the
-	// PCM; the original bytes are never mutated.
-	samples := pcmInt16FromBytes(pcmData)
-	meas, err := audionorm.MeasureInt16(samples, conf.SampleRate, conf.NumChannels)
+	// Pass 1: measure loudness + true peak directly from the PCM bytes; the
+	// original bytes are never mutated.
+	meas, err := audionorm.MeasureInt16Bytes(pcmData, conf.SampleRate, conf.NumChannels)
 	if err != nil {
 		return nil, errors.New(err).
 			Component("birdweather").
@@ -60,19 +55,18 @@ func (b *BwClient) encodeWithNativeFLAC(pcmData []byte, timestamp string) (*audi
 
 	res := audionorm.PlanGain(meas, opts)
 
-	// Clamp to the same +/-30 dB bound the FFmpeg path used. Silence yields
-	// GainDB == 0 (audionorm returns -Inf LUFS), so quiet clips stay quiet
+	// Clamp to the same +/-audionorm.DefaultMaxGainDB bound the FFmpeg path used.
+	// Silence yields GainDB == 0 (audionorm returns -Inf LUFS), so quiet clips stay quiet
 	// instead of being boosted into noise.
-	gainDB := res.GainDB
-	switch {
-	case gainDB > maxGainDB:
-		b.logGainLimit(log, "Limiting gain to prevent excessive amplification",
-			"calculated_gain", res.GainDB, "max_gain", maxGainDB)
-		gainDB = maxGainDB
-	case gainDB < -maxGainDB:
-		b.logGainLimit(log, "Limiting gain to prevent excessive attenuation",
-			"calculated_gain", res.GainDB, "min_gain", -maxGainDB)
-		gainDB = -maxGainDB
+	gainDB, limited := audionorm.ClampGainDB(res.GainDB, audionorm.DefaultMaxGainDB)
+	if limited {
+		if res.GainDB > 0 {
+			b.logGainLimit(log, "Limiting gain to prevent excessive amplification",
+				"calculated_gain", res.GainDB, "max_gain", audionorm.DefaultMaxGainDB)
+		} else {
+			b.logGainLimit(log, "Limiting gain to prevent excessive attenuation",
+				"calculated_gain", res.GainDB, "min_gain", -audionorm.DefaultMaxGainDB)
+		}
 	}
 
 	log.Debug("Native FLAC loudness analysis",
@@ -109,18 +103,4 @@ func (b *BwClient) encodeWithNativeFLAC(pcmData []byte, timestamp string) (*audi
 		logger.String("timestamp", timestamp),
 		logger.Int("bytes", buf.Len()))
 	return &audioEncodingResult{buffer: buf, ext: "flac"}, nil
-}
-
-// pcmInt16FromBytes reinterprets interleaved little-endian 16-bit PCM bytes as
-// []int16 for loudness measurement. PCM samples are signed, so each pair is read
-// as a uint16 and cast to int16 (a Uint16-only read would turn negative samples
-// into large positives and corrupt the measurement). A trailing odd byte (not
-// produced by real int16 PCM) is ignored. The returned slice is a copy; the
-// source bytes are not modified.
-func pcmInt16FromBytes(b []byte) []int16 {
-	out := make([]int16, len(b)/2)
-	for i := range out {
-		out[i] = int16(binary.LittleEndian.Uint16(b[i*2:])) //nolint:gosec // G115: intentional uint16->int16 bit reinterpretation for signed PCM
-	}
-	return out
 }

--- a/internal/birdweather/encode_native_test.go
+++ b/internal/birdweather/encode_native_test.go
@@ -103,24 +103,6 @@ func TestEncodeWithNativeFLAC_Silence(t *testing.T) {
 	}
 }
 
-// TestPCMInt16FromBytes_SignedRoundTrip is the regression guard for the signed
-// cast: a Uint16-only read would turn negative samples into large positives and
-// corrupt the loudness measurement.
-func TestPCMInt16FromBytes_SignedRoundTrip(t *testing.T) {
-	t.Parallel()
-	want := []int16{0, -1, 1, 32767, -32768, 1234, -1234}
-	b := make([]byte, len(want)*2)
-	for i, s := range want {
-		binary.LittleEndian.PutUint16(b[i*2:], uint16(s)) //nolint:gosec // G115: building signed test PCM
-	}
-	assert.Equal(t, want, pcmInt16FromBytes(b))
-}
-
-// TestPCMInt16FromBytes_OddTrailingByte drops a trailing odd byte (never present
-// in real int16 PCM) instead of panicking.
-func TestPCMInt16FromBytes_OddTrailingByte(t *testing.T) {
-	t.Parallel()
-	got := pcmInt16FromBytes([]byte{0x01, 0x02, 0x03})
-	assert.Len(t, got, 1)
-	assert.Equal(t, int16(0x0201), got[0])
-}
+// The signed-cast and odd-trailing-byte regression guards now live with the
+// shared decoder in internal/audiocore/audionorm (MeasureInt16Bytes /
+// Meter.AddInt16Bytes), which this path calls instead of a local helper.


### PR DESCRIPTION
## Summary

Two byte-for-byte identical helpers reinterpreted interleaved little-endian 16-bit PCM bytes as `[]int16` for loudness measurement, one in `internal/birdweather` (`pcmInt16FromBytes`) and one in `internal/analysis/processor` (`pcmBytesToInt16`, added with the native detection-save path). The surrounding `measure -> PlanGain -> clamp(+/-30 dB)` sequence was structurally duplicated too, and the clamp constant was defined independently in each package (`maxGainDB` vs `maxNativeNormalizationGainDB`).

This converges both native FLAC paths onto `internal/audiocore/audionorm`:

- `Meter.AddInt16Bytes` decodes little-endian int16 from raw bytes inline (a third format feeder alongside `AddInt16`/`AddFloat32`), so `MeasureInt16Bytes` measures a `[]byte` with no intermediate `[]int16` allocation.
- `DefaultMaxGainDB` (30 dB) and `ClampGainDB` centralize the shared clamp. The BirdWeather path keeps its WARN-on-limit logging via the returned bool; the detection-save path clamps silently, matching the prior behavior at each site.

Both local helpers and both clamp constants are removed. The FFmpeg FLAC path is intentionally left untouched.

## Behavior

Pure dedup, behavior-preserving. The decode is byte-exact for mono (the production case) and correct for interleaved stereo. The throwaway `[]int16` copy is eliminated (0 allocs/op in steady state on the pooled meter). No public API, config, DB, or CLI surface changes: the removed symbols were all unexported; the new audionorm symbols are additive exports.

## Test Plan

- [x] `go test -race` green across `audiocore/audionorm`, `birdweather`, and `analysis/processor`
- [x] New audionorm tests: mono + stereo + full-scale (-32768/32767) differential parity vs `MeasureInt16` (exact equality), signed-negative and odd-trailing-byte guards, nil/empty no-panic, `ClampGainDB` boundary table, and a zero-alloc steady-state test
- [x] `golangci-lint run` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added faster loudness measurement directly from PCM bytes.
  * Added built-in maximum gain clamping during audio normalization/export.
* **Bug Fixes**
  * Improved accuracy for signed 16-bit PCM handling, including edge cases like odd trailing bytes.
  * Normalization/export now uses consistent gain-limiting behavior.
* **Tests**
  * Added coverage for byte-based measurement, gain clamping, regression scenarios, and steady-state zero allocations.
  * Removed redundant low-level regression tests now covered by the shared measurement path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->