### PR TITLE
fix(audio): make live audio reliable and add per-stream gain

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -2468,6 +2468,10 @@
           "type": "string",
           "description": "Channel handling: downmix, left, or right"
         },
+        "gain": {
+          "type": "number",
+          "description": "Input gain in dB (0 = no adjustment)"
+        },
         "equalizer": {
           "$ref": "#/$defs/EqualizerSettings",
           "description": "Per-stream EQ (nil = use global)"

--- a/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
@@ -55,7 +55,11 @@
     EqualizerFilterType,
     QuietHoursConfig,
   } from '$lib/stores/settings';
-  import { defaultQuietHoursConfig } from '$lib/stores/settings';
+  import {
+    defaultQuietHoursConfig,
+    AUDIO_GAIN_MIN_DB,
+    AUDIO_GAIN_MAX_DB,
+  } from '$lib/stores/settings';
 
   // Local EqualizerSettings type matching AudioEqualizerSettings component's interface
   // where filter.id is optional (assigned on save)
@@ -417,8 +421,8 @@
           label={t('settings.audio.soundCards.gainLabel')}
           value={editGain}
           onUpdate={value => (editGain = value)}
-          min={-40}
-          max={40}
+          min={AUDIO_GAIN_MIN_DB}
+          max={AUDIO_GAIN_MAX_DB}
           step={1}
           unit=" dB"
           {disabled}

--- a/frontend/src/lib/desktop/components/forms/SoundCardManager.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardManager.svelte
@@ -45,7 +45,11 @@
     EqualizerFilterType,
     QuietHoursConfig,
   } from '$lib/stores/settings';
-  import { defaultQuietHoursConfig } from '$lib/stores/settings';
+  import {
+    defaultQuietHoursConfig,
+    AUDIO_GAIN_MIN_DB,
+    AUDIO_GAIN_MAX_DB,
+  } from '$lib/stores/settings';
 
   // Local EqualizerSettings type matching AudioEqualizerSettings component's interface
   // where filter.id is optional (assigned on save)
@@ -465,8 +469,8 @@
               label={t('settings.audio.soundCards.gainLabel')}
               value={newGain}
               onUpdate={value => (newGain = value)}
-              min={-40}
-              max={40}
+              min={AUDIO_GAIN_MIN_DB}
+              max={AUDIO_GAIN_MAX_DB}
               step={1}
               unit=" dB"
               {disabled}

--- a/frontend/src/lib/desktop/components/forms/StreamCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamCard.svelte
@@ -11,6 +11,7 @@
   - Editable stream name and URL with credential masking
   - Stream type selector (RTSP, HTTP, HLS, RTMP, UDP)
   - Protocol selector (TCP/UDP) for RTSP and RTMP streams
+  - Gain slider (-40 to +40 dB)
   - Inline editing mode
   - Delete confirmation
   - Always-visible action buttons for accessibility
@@ -39,6 +40,7 @@
   import StatusPill, { type StatusVariant } from '$lib/desktop/components/ui/StatusPill.svelte';
   import Checkbox from './Checkbox.svelte';
   import SelectDropdown from './SelectDropdown.svelte';
+  import InlineSlider from './InlineSlider.svelte';
   import ModelCheckboxList from './ModelCheckboxList.svelte';
   import QuietHoursEditor from './QuietHoursEditor.svelte';
   import AudioEqualizerSettings from '$lib/desktop/features/settings/components/AudioEqualizerSettings.svelte';
@@ -186,6 +188,7 @@
   let editTransport = $state<'tcp' | 'udp'>('tcp');
   let editStreamType = $state<StreamType>('rtsp');
   let editEnabled = $state(true);
+  let editGain = $state(0);
   let editModels = $state<string[]>([]);
   let editEqualizer = $state<LocalEqualizerSettings>({ enabled: false, filters: [] });
   let editQuietHours = $state<QuietHoursConfig>({ ...defaultQuietHoursConfig });
@@ -315,6 +318,7 @@
     editChannelMode = normalizeChannelMode(stream.channelMode);
     editStreamType = stream.type;
     editEnabled = stream.enabled;
+    editGain = stream.gain ?? 0;
     editModels = stream.models?.length ? [...stream.models] : [DEFAULT_MODEL_ID];
     editEqualizer = stream.equalizer
       ? { ...stream.equalizer, filters: [...stream.equalizer.filters] }
@@ -364,6 +368,7 @@
         channelMode: editChannelMode,
         // Use selected transport for RTSP/RTMP, omit for others
         ...(showTransportInEdit ? { transport: editTransport } : {}),
+        gain: editGain,
         equalizer: transformedEqualizer,
         quietHours: editQuietHours,
       } as StreamConfig);
@@ -582,6 +587,18 @@
           size="sm"
         />
 
+        <!-- Gain -->
+        <InlineSlider
+          label={t('settings.audio.soundCards.gainLabel')}
+          value={editGain}
+          onUpdate={value => (editGain = value)}
+          min={-40}
+          max={40}
+          step={1}
+          unit=" dB"
+          {disabled}
+        />
+
         <!-- Model Selection -->
         <ModelCheckboxList
           models={availableModels}
@@ -731,6 +748,13 @@
         <div class="flex-shrink-0 flex items-center gap-2">
           <!-- Colored Protocol Tags -->
           <div class="hidden sm:flex items-center gap-1.5">
+            {#if stream.gain}
+              <span
+                class="px-2 py-0.5 rounded text-xs font-semibold bg-[var(--color-warning)]/15 text-[var(--color-warning)]"
+              >
+                {stream.gain > 0 ? '+' : ''}{stream.gain} dB
+              </span>
+            {/if}
             <span
               class="px-2 py-0.5 rounded text-xs font-semibold bg-[var(--color-info)]/15 text-[var(--color-info)]"
             >

--- a/frontend/src/lib/desktop/components/forms/StreamCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamCard.svelte
@@ -52,7 +52,11 @@
     ChannelMode,
     ChannelAnalysis,
   } from '$lib/stores/settings';
-  import { defaultQuietHoursConfig } from '$lib/stores/settings';
+  import {
+    defaultQuietHoursConfig,
+    AUDIO_GAIN_MIN_DB,
+    AUDIO_GAIN_MAX_DB,
+  } from '$lib/stores/settings';
   import type { StreamHealthResponse } from './StreamManager.svelte';
   import StreamTestButton from './StreamTestButton.svelte';
   import StreamTimeline from './StreamTimeline.svelte';
@@ -592,8 +596,8 @@
           label={t('settings.audio.soundCards.gainLabel')}
           value={editGain}
           onUpdate={value => (editGain = value)}
-          min={-40}
-          max={40}
+          min={AUDIO_GAIN_MIN_DB}
+          max={AUDIO_GAIN_MAX_DB}
           step={1}
           unit=" dB"
           {disabled}

--- a/frontend/src/lib/desktop/components/forms/StreamManager.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamManager.svelte
@@ -42,7 +42,11 @@
     ChannelMode,
   } from '$lib/stores/settings';
   import type { ChannelAnalysis } from '$lib/stores/settings';
-  import { defaultQuietHoursConfig } from '$lib/stores/settings';
+  import {
+    defaultQuietHoursConfig,
+    AUDIO_GAIN_MIN_DB,
+    AUDIO_GAIN_MAX_DB,
+  } from '$lib/stores/settings';
   import StreamTestButton from './StreamTestButton.svelte';
   import StreamChannelControls from './StreamChannelControls.svelte';
   import { streamTypeOptions, transportOptions, analyzeStreamChannels } from './streamOptions';
@@ -751,8 +755,8 @@
               label={t('settings.audio.soundCards.gainLabel')}
               value={newGain}
               onUpdate={value => (newGain = value)}
-              min={-40}
-              max={40}
+              min={AUDIO_GAIN_MIN_DB}
+              max={AUDIO_GAIN_MAX_DB}
               step={1}
               unit=" dB"
               {disabled}

--- a/frontend/src/lib/desktop/components/forms/StreamManager.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamManager.svelte
@@ -28,6 +28,7 @@
   import { quietHoursStore } from '$lib/stores/quietHours.svelte';
   import { getAvailableModels, DEFAULT_MODEL_ID, fetchModels } from '$lib/stores/models.svelte';
   import StreamCard, { type StreamStatus } from './StreamCard.svelte';
+  import InlineSlider from './InlineSlider.svelte';
   import ModelCheckboxList from './ModelCheckboxList.svelte';
   import StatusPill from '$lib/desktop/components/ui/StatusPill.svelte';
   import EmptyState from '$lib/desktop/features/settings/components/EmptyState.svelte';
@@ -130,6 +131,7 @@
   let newUrl = $state('');
   let newTransport = $state<'tcp' | 'udp'>('tcp');
   let newStreamType = $state<StreamType>('rtsp');
+  let newGain = $state(0);
   let newModels = $state<string[]>([DEFAULT_MODEL_ID]);
   let newQuietHours = $state<QuietHoursConfig>({ ...defaultQuietHoursConfig });
   let newChannelMode = $state<ChannelMode>('downmix');
@@ -393,6 +395,7 @@
     newTransport = 'tcp';
     newStreamType = 'rtsp';
     newChannelMode = 'downmix';
+    newGain = 0;
     newModels = [DEFAULT_MODEL_ID];
     newQuietHours = { ...defaultQuietHoursConfig };
     newTestResult = null;
@@ -453,6 +456,7 @@
       models: newModels,
       channelMode: newChannelMode,
       ...(showTransportInAdd ? { transport: newTransport } : {}),
+      gain: newGain,
       quietHours: newQuietHours,
     } as StreamConfig;
 
@@ -740,6 +744,18 @@
               {disabled}
               onChange={mode => (newChannelMode = mode)}
               onAnalyze={url => analyzeChannels(url)}
+            />
+
+            <!-- Gain -->
+            <InlineSlider
+              label={t('settings.audio.soundCards.gainLabel')}
+              value={newGain}
+              onUpdate={value => (newGain = value)}
+              min={-40}
+              max={40}
+              step={1}
+              unit=" dB"
+              {disabled}
             />
 
             <!-- Model Selection -->

--- a/frontend/src/lib/stores/settings.ts
+++ b/frontend/src/lib/stores/settings.ts
@@ -172,6 +172,12 @@ export interface SoundLevelSettings {
   interval: number;
 }
 
+// Audio gain bounds in dB, shared by the sound card, stream, and export gain
+// controls. Mirrors the backend MinAudioGain/MaxAudioGain validation range so
+// the frontend clamp and sliders stay in sync if the range ever changes.
+export const AUDIO_GAIN_MIN_DB = -40;
+export const AUDIO_GAIN_MAX_DB = 40;
+
 // Stream type constants
 export const StreamTypes = {
   RTSP: 'rtsp',

--- a/frontend/src/lib/stores/settings.ts
+++ b/frontend/src/lib/stores/settings.ts
@@ -220,6 +220,7 @@ export interface StreamConfig {
   models?: string[]; // Model IDs for this stream (e.g., ["birdnet", "perch_v2"])
   equalizer?: EqualizerSettings; // Per-stream EQ (undefined = use global)
   quietHours?: QuietHoursConfig; // Quiet hours configuration
+  gain?: number; // Input gain in dB (0 = no adjustment)
 }
 
 // ChannelEnergy represents the energy level of a single audio channel

--- a/frontend/src/lib/utils/settingsCoercion.test.ts
+++ b/frontend/src/lib/utils/settingsCoercion.test.ts
@@ -78,4 +78,68 @@ describe('settingsCoercion realtime rtsp streams', () => {
       },
     });
   });
+
+  it('preserves an explicit stream gain value on save round-trip', () => {
+    const result = coerceSettings('realtime', {
+      rtsp: {
+        streams: [
+          {
+            name: 'Gain Stream',
+            url: 'rtsp://cam4',
+            type: 'rtsp',
+            gain: 12,
+          },
+        ],
+      },
+    });
+
+    expect(result).toMatchObject({
+      rtsp: {
+        streams: [
+          {
+            name: 'Gain Stream',
+            url: 'rtsp://cam4',
+            gain: 12,
+          },
+        ],
+      },
+    });
+  });
+
+  it('clamps an out-of-range stream gain to the -40..+40 dB bounds', () => {
+    const result = coerceSettings('realtime', {
+      rtsp: {
+        streams: [
+          {
+            name: 'Loud Stream',
+            url: 'rtsp://cam5',
+            type: 'rtsp',
+            gain: 100,
+          },
+        ],
+      },
+    });
+
+    expect(result).toMatchObject({
+      rtsp: {
+        streams: [{ gain: 40 }],
+      },
+    });
+  });
+
+  it('leaves stream gain undefined when not provided', () => {
+    const result = coerceSettings('realtime', {
+      rtsp: {
+        streams: [
+          {
+            name: 'No Gain Stream',
+            url: 'rtsp://cam6',
+            type: 'rtsp',
+          },
+        ],
+      },
+    }) as { rtsp: { streams: Array<Record<string, unknown>> } };
+
+    expect(result.rtsp.streams[0]?.gain).toBeUndefined();
+  });
 });

--- a/frontend/src/lib/utils/settingsCoercion.ts
+++ b/frontend/src/lib/utils/settingsCoercion.ts
@@ -24,6 +24,7 @@ import type {
   PushFilterConfig,
   FalsePositiveFilterSettings,
 } from '$lib/stores/settings';
+import { AUDIO_GAIN_MIN_DB, AUDIO_GAIN_MAX_DB } from '$lib/stores/settings';
 
 // Type for partial/unknown settings data
 type UnknownSettings = Record<string, unknown>;
@@ -193,7 +194,7 @@ function coerceStreamConfig(stream: unknown): UnknownSettings {
   // validation). Only present when the caller sent one, so a stream without
   // gain configured stays undefined rather than materializing a fake 0.
   if ('gain' in rawStream) {
-    coercedStream.gain = coerceNumber(rawStream.gain, -40, 40, 0);
+    coercedStream.gain = coerceNumber(rawStream.gain, AUDIO_GAIN_MIN_DB, AUDIO_GAIN_MAX_DB, 0);
   }
 
   return coercedStream;
@@ -385,7 +386,7 @@ export function coerceAudioSettings(settings: PartialAudioSettings): PartialAudi
 
     // Clamp gain between -40 and +40 dB (backend validation)
     if ('gain' in exp) {
-      coercedExport.gain = coerceNumber(exp.gain, -40, 40, 0);
+      coercedExport.gain = coerceNumber(exp.gain, AUDIO_GAIN_MIN_DB, AUDIO_GAIN_MAX_DB, 0);
     }
 
     // Normalization settings

--- a/frontend/src/lib/utils/settingsCoercion.ts
+++ b/frontend/src/lib/utils/settingsCoercion.ts
@@ -177,7 +177,7 @@ export function coerceObject<T extends Record<string, unknown>>(
 function coerceStreamConfig(stream: unknown): UnknownSettings {
   const rawStream = coerceObject(stream, {} as UnknownSettings);
 
-  return {
+  const coercedStream: UnknownSettings = {
     ...rawStream,
     name: coerceString(rawStream.name, ''),
     url: coerceString(rawStream.url, ''),
@@ -188,6 +188,15 @@ function coerceStreamConfig(stream: unknown): UnknownSettings {
         ? rawStream.transport
         : undefined,
   };
+
+  // Clamp gain to the same -40..+40 dB range as sound card gain (backend
+  // validation). Only present when the caller sent one, so a stream without
+  // gain configured stays undefined rather than materializing a fake 0.
+  if ('gain' in rawStream) {
+    coercedStream.gain = coerceNumber(rawStream.gain, -40, 40, 0);
+  }
+
+  return coercedStream;
 }
 
 function coerceRTSPSettings(settings: unknown): UnknownSettings {

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -1379,26 +1379,59 @@ func (p *AudioPipelineService) buildSourceConfigsWithModels() []sourceConfigWith
 				Channels:         1,
 				SourceChannels:   probe.channels,
 				ChannelMode:      string(stream.ChannelMode),
+				Gain:             stream.Gain,
 			},
 			modelIDs: stream.Models,
 		})
 	}
 
-	// Local audio cards (multi-source).
+	// Collect the connection strings of ALL configured rtsp.streams (enabled AND
+	// disabled), so a stream URL misconfigured under audio.sources does not
+	// overwrite the rtsp.streams config: reconfigureChangedSources dedups the
+	// desired configs by connection string, and the audio.sources copy is
+	// appended later, so without this guard it would win. The rtsp.streams entry
+	// must win. Disabled streams are included so a duplicate under audio.sources
+	// is suppressed rather than silently re-enabling a stream the user turned off.
+	streamConns := make(map[string]struct{}, len(settings.Realtime.RTSP.Streams))
+	for i := range settings.Realtime.RTSP.Streams {
+		streamConns[strings.TrimSpace(settings.Realtime.RTSP.Streams[i].URL)] = struct{}{}
+	}
+
+	// Local audio cards and any stream URLs misconfigured under audio.sources.
 	for i := range settings.Realtime.Audio.Sources {
 		src := &settings.Realtime.Audio.Sources[i]
-		if src.Device == "" {
+		// Trim once so type detection, the dedup key, and the registered
+		// connection string all see the same value: audiocore.StreamSourceType
+		// matches scheme prefixes without trimming, so incidental whitespace
+		// would otherwise misclassify a stream URL as an ALSA device.
+		device := strings.TrimSpace(src.Device)
+		if device == "" {
 			continue
 		}
 		sampleRate := conf.SampleRate
 		if src.SampleRate > 0 {
 			sampleRate = src.SampleRate
 		}
+
+		// Default to an ALSA audio card; promote to a stream type only when the
+		// device is actually a network stream URL. This keeps a misplaced
+		// stream URL from being opened as an ALSA device (which fails and
+		// breaks live audio) even before the config migration relocates it.
+		sourceType := audiocore.SourceTypeAudioCard
+		if streamType, isStream := audiocore.StreamSourceType(device); isStream {
+			if _, dup := streamConns[device]; dup {
+				// Already produced from rtsp.streams; skip the duplicate so the
+				// proper rtsp.streams config wins the connection-keyed dedup.
+				continue
+			}
+			sourceType = streamType
+		}
+
 		result = append(result, sourceConfigWithModels{
 			config: &audiocore.SourceConfig{
 				DisplayName:      src.Name,
-				Type:             audiocore.SourceTypeAudioCard,
-				ConnectionString: src.Device,
+				Type:             sourceType,
+				ConnectionString: device,
 				SampleRate:       sampleRate,
 				BitDepth:         conf.BitDepth,
 				Channels:         1,

--- a/internal/analysis/audio_pipeline_source_typing_test.go
+++ b/internal/analysis/audio_pipeline_source_typing_test.go
@@ -1,0 +1,192 @@
+package analysis
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/conf/conftest"
+)
+
+// findConfigByConnection returns the built config whose ConnectionString
+// matches conn, or nil when none match.
+func findConfigByConnection(configs []sourceConfigWithModels, conn string) *audiocore.SourceConfig {
+	for i := range configs {
+		if configs[i].config.ConnectionString == conn {
+			return configs[i].config
+		}
+	}
+	return nil
+}
+
+// TestBuildSourceConfigsWithModels_RTSPStreamCarriesGain verifies per-stream
+// gain flows from the config into the built RTSP SourceConfig.
+func TestBuildSourceConfigsWithModels_RTSPStreamCarriesGain(t *testing.T) {
+	prev := conf.CloneSettings(conf.GetSettings())
+	t.Cleanup(func() { conftest.SetTestSettings(prev) })
+
+	settings := &conf.Settings{}
+	settings.Realtime.RTSP.Streams = []conf.StreamConfig{
+		{
+			Name:    "gain-stream",
+			URL:     "rtsp://cam-gain",
+			Enabled: true,
+			Type:    conf.StreamTypeRTSP,
+			Gain:    7.5,
+			Models:  []string{"birdnet"},
+		},
+	}
+	conftest.SetTestSettings(settings)
+
+	p := &AudioPipelineService{}
+	configs := p.buildSourceConfigsWithModels()
+
+	require.Len(t, configs, 1)
+	cfg := findConfigByConnection(configs, "rtsp://cam-gain")
+	require.NotNil(t, cfg, "rtsp stream config should be present")
+	assert.Equal(t, audiocore.SourceTypeRTSP, cfg.Type)
+	assert.InDelta(t, 7.5, cfg.Gain, 1e-9, "per-stream gain should flow to the pipeline")
+}
+
+// TestBuildSourceConfigsWithModels_StreamURLInAudioSources verifies that a
+// stream URL misplaced under audio.sources is emitted as a stream-typed
+// SourceConfig (not an ALSA audio card) with its gain carried.
+func TestBuildSourceConfigsWithModels_StreamURLInAudioSources(t *testing.T) {
+	prev := conf.CloneSettings(conf.GetSettings())
+	t.Cleanup(func() { conftest.SetTestSettings(prev) })
+
+	settings := &conf.Settings{}
+	settings.Realtime.Audio.Sources = []conf.AudioSourceConfig{
+		{
+			Name:   "misplaced-stream",
+			Device: "rtsp://cam-in-sources",
+			Gain:   4.25,
+			Models: []string{"birdnet"},
+		},
+		{
+			Name:   "real-mic",
+			Device: "hw:0,0",
+			Gain:   2.0,
+			Models: []string{"birdnet"},
+		},
+	}
+	conftest.SetTestSettings(settings)
+
+	p := &AudioPipelineService{}
+	configs := p.buildSourceConfigsWithModels()
+
+	require.Len(t, configs, 2)
+
+	streamCfg := findConfigByConnection(configs, "rtsp://cam-in-sources")
+	require.NotNil(t, streamCfg, "misplaced stream should still be emitted")
+	assert.Equal(t, audiocore.SourceTypeRTSP, streamCfg.Type, "stream URL must be typed as a stream, not an audio card")
+	assert.InDelta(t, 4.25, streamCfg.Gain, 1e-9)
+
+	micCfg := findConfigByConnection(configs, "hw:0,0")
+	require.NotNil(t, micCfg, "local mic should be emitted")
+	assert.Equal(t, audiocore.SourceTypeAudioCard, micCfg.Type, "genuine device must remain an audio card")
+	assert.InDelta(t, 2.0, micCfg.Gain, 1e-9)
+}
+
+// TestBuildSourceConfigsWithModels_DuplicateURLPrefersRTSPStream guards the
+// priority-inversion bug: when the same URL appears in both rtsp.streams and
+// audio.sources, exactly one config is produced and it comes from the
+// rtsp.streams entry (whose gain wins), so the audio.sources duplicate cannot
+// overwrite the proper stream config via the connection-keyed dedup.
+func TestBuildSourceConfigsWithModels_DuplicateURLPrefersRTSPStream(t *testing.T) {
+	prev := conf.CloneSettings(conf.GetSettings())
+	t.Cleanup(func() { conftest.SetTestSettings(prev) })
+
+	const dupURL = "rtsp://shared-cam"
+
+	settings := &conf.Settings{}
+	settings.Realtime.RTSP.Streams = []conf.StreamConfig{
+		{
+			Name:    "proper-stream",
+			URL:     dupURL,
+			Enabled: true,
+			Type:    conf.StreamTypeRTSP,
+			Gain:    10.0,
+			Models:  []string{"birdnet"},
+		},
+	}
+	settings.Realtime.Audio.Sources = []conf.AudioSourceConfig{
+		{
+			Name:   "duplicate-in-sources",
+			Device: dupURL,
+			Gain:   1.0,
+			Models: []string{"birdnet"},
+		},
+	}
+	conftest.SetTestSettings(settings)
+
+	p := &AudioPipelineService{}
+	configs := p.buildSourceConfigsWithModels()
+
+	require.Len(t, configs, 1, "duplicate URL must yield exactly one desired config")
+	cfg := configs[0].config
+	assert.Equal(t, dupURL, cfg.ConnectionString)
+	assert.Equal(t, audiocore.SourceTypeRTSP, cfg.Type)
+	assert.InDelta(t, 10.0, cfg.Gain, 1e-9, "the rtsp.streams entry must win, not the audio.sources duplicate")
+}
+
+// TestBuildSourceConfigsWithModels_DisabledStreamSuppressesAudioSourceDuplicate
+// guards the "disabled stream re-enabled via misplaced audio.sources entry"
+// regression: when a DISABLED rtsp.streams entry shares its URL with an
+// audio.sources entry, the disabled stream is not built (it is off) and the
+// audio.sources duplicate is skipped by the dedup guard, which keys off ALL
+// configured streams (enabled AND disabled). The net result is zero configs for
+// that URL, so a stream the user turned off is not silently re-enabled through
+// audio.sources.
+//
+// This test is hermetic: a disabled stream never reaches probeAllStreams (which
+// only receives EnabledStreams), so no ffprobe process is spawned.
+func TestBuildSourceConfigsWithModels_DisabledStreamSuppressesAudioSourceDuplicate(t *testing.T) {
+	prev := conf.CloneSettings(conf.GetSettings())
+	t.Cleanup(func() { conftest.SetTestSettings(prev) })
+
+	const dupURL = "rtsp://dup.local/stream"
+
+	settings := &conf.Settings{}
+	settings.Realtime.RTSP.Streams = []conf.StreamConfig{
+		{
+			Name:    "disabled-stream",
+			URL:     dupURL,
+			Enabled: false, // disabled: not built, but still shadows the audio.sources duplicate
+			Type:    conf.StreamTypeRTSP,
+			Gain:    3.0,
+			Models:  []string{"birdnet"},
+		},
+	}
+	settings.Realtime.Audio.Sources = []conf.AudioSourceConfig{
+		{
+			Name:   "duplicate-in-sources",
+			Device: dupURL,
+			Gain:   1.0,
+			Models: []string{"birdnet"},
+		},
+	}
+	conftest.SetTestSettings(settings)
+
+	p := &AudioPipelineService{}
+	configs := p.buildSourceConfigsWithModels()
+
+	// No config may reference the shared URL: the disabled stream is not built,
+	// and the audio.sources duplicate is suppressed by the dedup guard.
+	assert.Nil(t, findConfigByConnection(configs, dupURL),
+		"disabled stream duplicated under audio.sources must not be promoted to an active stream")
+
+	// Make the guarantee explicit: exactly zero configs for that URL.
+	var count int
+	for i := range configs {
+		if configs[i].config.ConnectionString == dupURL {
+			count++
+		}
+	}
+	assert.Equal(t, 0, count, "expected zero configs for the disabled/duplicated URL")
+
+	// Nothing else is configured, so the whole result set is empty.
+	assert.Empty(t, configs, "no sources should be built from a lone disabled stream plus its duplicate")
+}

--- a/internal/api/v2/audio/audio_hls.go
+++ b/internal/api/v2/audio/audio_hls.go
@@ -27,9 +27,11 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
+	"github.com/tphakala/birdnet-go/internal/audiocore/engine"
 	"github.com/tphakala/birdnet-go/internal/audiocore/equalizer"
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/privacy"
 	"github.com/tphakala/birdnet-go/internal/securefs"
@@ -354,7 +356,7 @@ func (c *Handler) StartHLSStream(ctx echo.Context) error {
 		return c.HandleError(ctx, nil, "Audio engine not initialized", http.StatusServiceUnavailable)
 	}
 	if _, bufErr := eng.BufferManager().CaptureBuffer(sourceID); bufErr != nil {
-		return c.HandleError(ctx, nil, "Audio source not found", http.StatusNotFound)
+		return c.respondNoCaptureBuffer(ctx, eng, sourceID)
 	}
 
 	// Check for existing healthy stream first (reuse if possible)
@@ -389,6 +391,58 @@ func (c *Handler) StartHLSStream(ctx echo.Context) error {
 	playlistReady := c.waitForHLSPlaylist(ctx, sourceID, stream)
 
 	return c.buildHLSStreamResponse(ctx, sourceID, stream, playlistReady)
+}
+
+// respondNoCaptureBuffer builds a diagnostic 404 for a live-audio start request
+// whose source has no capture buffer. Before this, StartHLSStream returned a bare
+// 404 with a nil error and no diagnostics, so users saw an error popup with "no
+// logs" (issue #3766). Here we gather the currently registered source IDs and the
+// source IDs that actually have a capture buffer (the ones that can back a live
+// stream right now), so the WARN log and the returned error explain what went
+// wrong and what could be started instead.
+//
+// All logged identifiers are opaque source-ID hashes (e.g. "rtsp_d13dfe45"), which
+// are safe to log. Raw connection strings are never logged; the requested source
+// ID is additionally passed through privacy.SanitizeRTSPUrl as defense in depth.
+func (c *Handler) respondNoCaptureBuffer(ctx echo.Context, eng *engine.AudioEngine, sourceID string) error {
+	// Registered sources from the source registry (all configured sources).
+	var registeredIDs []string
+	if registry := eng.Registry(); registry != nil {
+		sources := registry.List()
+		registeredIDs = make([]string, 0, len(sources))
+		for _, src := range sources {
+			registeredIDs = append(registeredIDs, src.ID)
+		}
+	}
+
+	// Source IDs that currently have a capture buffer allocated: these are the
+	// ones that can actually back a live stream right now.
+	health := eng.BufferManager().CaptureBufferHealthAll()
+	captureBufferIDs := make([]string, 0, len(health))
+	for _, h := range health {
+		captureBufferIDs = append(captureBufferIDs, h.SourceID)
+	}
+
+	availableCount := len(registeredIDs)
+
+	diagErr := errors.Newf("live audio source not available: no capture buffer for requested source").
+		Component("api").
+		Category(errors.CategoryAudioSource).
+		Context("requested_source", privacy.SanitizeRTSPUrl(sourceID)).
+		Context("available_source_count", availableCount).
+		Context("capture_buffer_count", len(captureBufferIDs)).
+		Build()
+
+	c.LogAPIRequest(ctx, logger.LogLevelWarn, "Live audio start failed: source has no capture buffer",
+		logger.String("requested_source", privacy.SanitizeRTSPUrl(sourceID)),
+		logger.Int("available_sources", availableCount),
+		logger.Int("capture_buffers", len(captureBufferIDs)),
+		logger.String("available_source_ids", strings.Join(registeredIDs, ",")),
+		logger.String("capture_buffer_ids", strings.Join(captureBufferIDs, ",")))
+
+	return c.HandleError(ctx, diagErr,
+		"Audio source not available for live streaming. If you recently changed audio settings, the stream may need a moment or a restart to become available.",
+		http.StatusNotFound)
 }
 
 // buildHLSStreamResponse constructs the HLS stream status response

--- a/internal/api/v2/audio/audio_hls.go
+++ b/internal/api/v2/audio/audio_hls.go
@@ -423,21 +423,23 @@ func (c *Handler) respondNoCaptureBuffer(ctx echo.Context, eng *engine.AudioEngi
 		captureBufferIDs = append(captureBufferIDs, h.SourceID)
 	}
 
-	availableCount := len(registeredIDs)
+	// registeredCount is the number of configured/registered sources, not the
+	// number usable for streaming right now (that is capture_buffer_count).
+	registeredCount := len(registeredIDs)
 
 	diagErr := errors.Newf("live audio source not available: no capture buffer for requested source").
 		Component("api").
 		Category(errors.CategoryAudioSource).
 		Context("requested_source", privacy.SanitizeRTSPUrl(sourceID)).
-		Context("available_source_count", availableCount).
+		Context("registered_source_count", registeredCount).
 		Context("capture_buffer_count", len(captureBufferIDs)).
 		Build()
 
 	c.LogAPIRequest(ctx, logger.LogLevelWarn, "Live audio start failed: source has no capture buffer",
 		logger.String("requested_source", privacy.SanitizeRTSPUrl(sourceID)),
-		logger.Int("available_sources", availableCount),
+		logger.Int("registered_sources", registeredCount),
 		logger.Int("capture_buffers", len(captureBufferIDs)),
-		logger.String("available_source_ids", strings.Join(registeredIDs, ",")),
+		logger.String("registered_source_ids", strings.Join(registeredIDs, ",")),
 		logger.String("capture_buffer_ids", strings.Join(captureBufferIDs, ",")))
 
 	return c.HandleError(ctx, diagErr,

--- a/internal/api/v2/audio/audio_hls_test.go
+++ b/internal/api/v2/audio/audio_hls_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
+	"github.com/tphakala/birdnet-go/internal/audiocore/engine"
 )
 
 // TestHLSStreamInfoStruct tests the HLSStreamInfo struct
@@ -632,4 +633,65 @@ func TestHLSConsumer_WriteDoesNotRetainFrameData(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("no frame delivered to channel")
 	}
+}
+
+// TestStartHLSStream_NoCaptureBuffer verifies that starting a live-audio (HLS)
+// stream for a source that has no capture buffer returns a diagnostic 404 rather
+// than the old opaque "Audio source not found" with a nil error (issue #3766).
+// The handler must not panic while gathering diagnostics, whether or not other
+// sources are registered, and the response must carry the improved user-facing
+// message.
+func TestStartHLSStream_NoCaptureBuffer(t *testing.T) {
+	const (
+		wantMsg  = "Audio source not available for live streaming"
+		unknown  = "rtsp_unknown_source"
+		startURL = "/api/v2/streams/hls/" + unknown + "/start"
+	)
+
+	// newHandlerWithEngine returns a Handler backed by a real (but idle) audio
+	// engine. No capture buffers are ever allocated, so CaptureBuffer always misses.
+	newHandlerWithEngine := func(t *testing.T) *Handler {
+		t.Helper()
+		eng := engine.New(t.Context(), &engine.Config{}, nil)
+		t.Cleanup(eng.Stop)
+		h := &Handler{Core: apitest.NewCore(t)}
+		h.Engine.Store(eng)
+		return h
+	}
+
+	callStart := func(t *testing.T, h *Handler) (*httptest.ResponseRecorder, error) {
+		t.Helper()
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodPost, startURL, http.NoBody)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		ctx.SetParamNames("sourceID")
+		ctx.SetParamValues(unknown)
+		return rec, h.StartHLSStream(ctx)
+	}
+
+	t.Run("empty engine returns diagnostic 404", func(t *testing.T) {
+		h := newHandlerWithEngine(t)
+		rec, err := callStart(t, h)
+		apitest.AssertControllerError(t, err, rec, http.StatusNotFound, wantMsg)
+	})
+
+	t.Run("other registered sources still return diagnostic 404", func(t *testing.T) {
+		h := newHandlerWithEngine(t)
+
+		// Register a couple of sources so the diagnostics-gathering loop over the
+		// registry actually runs. None of them have a capture buffer, matching the
+		// #3766 scenario where a source is configured but not yet streamable.
+		registry := h.Engine.Load().Registry()
+		for _, cfg := range []*audiocore.SourceConfig{
+			{ID: "rtsp_a", DisplayName: "Camera A", Type: audiocore.SourceTypeRTSP, ConnectionString: "rtsp://user:pass@cam-a.local/stream"},
+			{ID: "card_b", DisplayName: "Backyard Mic", Type: audiocore.SourceTypeAudioCard, ConnectionString: "hw:0,0"},
+		} {
+			_, regErr := registry.Register(cfg)
+			require.NoError(t, regErr)
+		}
+
+		rec, err := callStart(t, h)
+		apitest.AssertControllerError(t, err, rec, http.StatusNotFound, wantMsg)
+	})
 }

--- a/internal/api/v2/hotreload_coverage_test.go
+++ b/internal/api/v2/hotreload_coverage_test.go
@@ -166,6 +166,7 @@ var hotReloadRegistry = map[string]hotReloadEntry{
 	"Realtime.RTSP.Streams.*.Type":        {categories: []hotReloadCategory{hotReloadFresh}, action: "reconfigure_rtsp_sources"},
 	"Realtime.RTSP.Streams.*.Transport":   {categories: []hotReloadCategory{hotReloadFresh}, action: "reconfigure_rtsp_sources"},
 	"Realtime.RTSP.Streams.*.ChannelMode": {categories: []hotReloadCategory{hotReloadFresh}, action: "reconfigure_rtsp_sources"},
+	"Realtime.RTSP.Streams.*.Gain":        {categories: []hotReloadCategory{hotReloadFresh}, action: "reconfigure_rtsp_sources"},
 	"Realtime.RTSP.Streams.*.Equalizer":   {categories: []hotReloadCategory{hotReloadFresh}},
 	"Realtime.RTSP.Streams.*.QuietHours":  {categories: []hotReloadCategory{hotReloadFresh}, action: "reconfigure_quiet_hours"},
 	"Realtime.RTSP.Streams.*.Models":      {categories: []hotReloadCategory{hotReloadFresh}, action: "reconfigure_rtsp_sources"},

--- a/internal/audiocore/source.go
+++ b/internal/audiocore/source.go
@@ -189,6 +189,19 @@ func StreamTypeToSourceType(streamType string) SourceType {
 	}
 }
 
+// StreamSourceType reports the SourceType for a connection string and whether
+// it is a network stream type (RTSP/RTSPS, RTMP/RTMPS, UDP/RTP, HLS, HTTP/HTTPS).
+// ok is false for local audio cards, files, and unknown connection strings.
+func StreamSourceType(conn string) (SourceType, bool) {
+	st := detectSourceType(conn)
+	switch st {
+	case SourceTypeRTSP, SourceTypeHTTP, SourceTypeHLS, SourceTypeRTMP, SourceTypeUDP:
+		return st, true
+	default:
+		return st, false
+	}
+}
+
 // SourceConfig carries the parameters required to register a new audio source.
 type SourceConfig struct {
 	// ID is the unique identifier for the source.

--- a/internal/audiocore/source_test.go
+++ b/internal/audiocore/source_test.go
@@ -70,3 +70,35 @@ func TestStreamTypeToSourceType(t *testing.T) {
 		})
 	}
 }
+
+func TestStreamSourceType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		conn       string
+		wantType   SourceType
+		wantStream bool
+	}{
+		{"rtsp", "rtsp://192.168.1.10/stream", SourceTypeRTSP, true},
+		{"rtsps", "rtsps://192.168.1.10/stream", SourceTypeRTSP, true},
+		{"rtmp", "rtmp://example.com/live", SourceTypeRTMP, true},
+		{"rtmps", "rtmps://example.com/live", SourceTypeRTMP, true},
+		{"udp", "udp://239.0.0.1:1234", SourceTypeUDP, true},
+		{"rtp", "rtp://239.0.0.1:1234", SourceTypeUDP, true},
+		{"hls m3u8", "https://example.com/stream.m3u8", SourceTypeHLS, true},
+		{"http", "http://example.com/audio", SourceTypeHTTP, true},
+		{"https", "https://example.com/audio", SourceTypeHTTP, true},
+		{"sound card hw", "hw:0,0", SourceTypeAudioCard, false},
+		{"sound card sysdefault", "sysdefault", SourceTypeAudioCard, false},
+		{"file path", "/tmp/x.wav", SourceTypeFile, false},
+		{"empty", "", SourceTypeUnknown, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotType, gotOk := StreamSourceType(tt.conn)
+			assert.Equal(t, tt.wantType, gotType)
+			assert.Equal(t, tt.wantStream, gotOk)
+		})
+	}
+}

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -590,6 +590,7 @@ type StreamConfig struct {
 	Type        string             `yaml:"type" json:"type" mapstructure:"type"`                                    // Stream type: rtsp, http, hls, rtmp, udp
 	Transport   string             `yaml:"transport" json:"transport" mapstructure:"transport"`                     // Transport: tcp or udp (for RTSP/RTMP)
 	ChannelMode ChannelMode        `yaml:"channelMode,omitempty" json:"channelMode" mapstructure:"channelMode"`     // Channel handling: downmix, left, or right
+	Gain        float64            `yaml:"gain" json:"gain" mapstructure:"gain"`                                    // Input gain in dB (0 = no adjustment)
 	Equalizer   *EqualizerSettings `yaml:"equalizer,omitempty" json:"equalizer,omitempty" mapstructure:"equalizer"` // Per-stream EQ (nil = use global)
 	QuietHours  QuietHoursConfig   `yaml:"quietHours" json:"quietHours" mapstructure:"quietHours"`                  // Quiet hours configuration
 	Models      []string           `yaml:"models,omitempty" json:"models,omitempty" mapstructure:"models"`          // Model IDs for this stream (e.g., ["birdnet", "perch_v2"])

--- a/internal/conf/migrations.go
+++ b/internal/conf/migrations.go
@@ -551,12 +551,11 @@ func (s *Settings) findStreamByURL(url string) *StreamConfig {
 
 // appendStreamFromSource creates a new StreamConfig from a misplaced audio
 // source and appends it to the RTSP streams. Credentials in url are preserved
-// verbatim; only the ValidationWarnings note uses a sanitized URL.
+// verbatim; only the ValidationWarnings note uses a sanitized URL. The stream
+// name is made unique and length-bounded so the migration never produces a
+// config the stream validator would reject at load time.
 func (s *Settings) appendStreamFromSource(src *AudioSourceConfig, url, streamType string) {
-	name := src.Name
-	if strings.TrimSpace(name) == "" {
-		name = fmt.Sprintf("Stream %d", len(s.Realtime.RTSP.Streams)+1)
-	}
+	name := s.uniqueStreamName(src.Name)
 
 	// Transport only applies to connection-oriented stream types.
 	transport := ""
@@ -579,6 +578,65 @@ func (s *Settings) appendStreamFromSource(src *AudioSourceConfig, url, streamTyp
 	s.ValidationWarnings = append(s.ValidationWarnings,
 		fmt.Sprintf("moved misplaced stream URL %q from realtime.audio.sources to realtime.rtsp.streams as %q",
 			privacy.SanitizeStreamUrl(url), name))
+}
+
+// uniqueStreamName derives a stream name from the requested source name that
+// the stream validator will accept at load time: unique (case-insensitively)
+// among the already-configured streams and within MaxStreamNameLength. An empty
+// requested name falls back to "Stream N" (N based on the current stream count).
+// An over-long name is truncated on a UTF-8 rune boundary; a name that collides
+// gets an incrementing " (2)", " (3)" suffix (with the base truncated further to
+// keep room for the suffix) until a free name is found. A misplaced source name
+// may be up to MaxAudioSourceNameLength, longer than a stream name is allowed to
+// be, so both the length clamp and the dedup are needed to keep
+// ReconcileMisplacedAudioSources from producing a name the validator would
+// reject with a fatal error at load time.
+func (s *Settings) uniqueStreamName(requested string) string {
+	base := strings.TrimSpace(requested)
+	if base == "" {
+		base = fmt.Sprintf("Stream %d", len(s.Realtime.RTSP.Streams)+1)
+	}
+	candidate := truncateStreamName(base, MaxStreamNameLength)
+	for n := 2; s.streamNameTaken(candidate); n++ {
+		suffix := fmt.Sprintf(" (%d)", n)
+		candidate = truncateStreamName(base, MaxStreamNameLength-len(suffix)) + suffix
+	}
+	return candidate
+}
+
+// truncateStreamName shortens name to at most maxBytes bytes on a UTF-8 rune
+// boundary (never splitting a multi-byte rune), trimming any trailing spaces
+// left by the cut. Stream names are byte-length-limited by the validator, so
+// this keeps a long source name from yielding a name the validator rejects.
+func truncateStreamName(name string, maxBytes int) string {
+	if maxBytes <= 0 {
+		return ""
+	}
+	if len(name) <= maxBytes {
+		return name
+	}
+	// range over a string yields the byte index at each rune start; keep the
+	// largest start that still fits so the cut never lands inside a rune.
+	end := 0
+	for i := range name {
+		if i > maxBytes {
+			break
+		}
+		end = i
+	}
+	return strings.TrimRight(name[:end], " ")
+}
+
+// streamNameTaken reports whether any configured stream already uses name,
+// compared case-insensitively with surrounding whitespace trimmed, matching the
+// duplicate-name rule the stream validator enforces.
+func (s *Settings) streamNameTaken(name string) bool {
+	for i := range s.Realtime.RTSP.Streams {
+		if strings.EqualFold(strings.TrimSpace(s.Realtime.RTSP.Streams[i].Name), name) {
+			return true
+		}
+	}
+	return false
 }
 
 // mergeSourceIntoStream lightly merges non-default per-source overrides from a

--- a/internal/conf/migrations.go
+++ b/internal/conf/migrations.go
@@ -3,11 +3,13 @@ package conf
 import (
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 
 	"github.com/spf13/viper"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/privacy"
 )
 
 // persistMigration saves the config file after a successful migration.
@@ -158,24 +160,13 @@ func (s *Settings) MigrateOAuthConfig() bool {
 // inferStreamType detects the stream type from URL scheme.
 // Returns StreamTypeRTSP as default for unknown schemes.
 func inferStreamType(url string) string {
-	urlLower := strings.ToLower(url)
-
-	switch {
-	case strings.HasPrefix(urlLower, "rtsp://"), strings.HasPrefix(urlLower, "rtsps://"):
-		return StreamTypeRTSP
-	case strings.HasPrefix(urlLower, "rtmp://"), strings.HasPrefix(urlLower, "rtmps://"):
-		return StreamTypeRTMP
-	case strings.HasPrefix(urlLower, "udp://"), strings.HasPrefix(urlLower, "rtp://"):
-		return StreamTypeUDP
-	case strings.HasPrefix(urlLower, "http://"), strings.HasPrefix(urlLower, "https://"):
-		// Check for HLS (.m3u8) vs generic HTTP
-		if strings.Contains(urlLower, ".m3u8") {
-			return StreamTypeHLS
-		}
-		return StreamTypeHTTP
-	default:
-		return StreamTypeRTSP // Default to RTSP for unknown schemes
+	// Delegate to the strict scheme classifier and add the legacy default:
+	// unknown schemes fall back to RTSP (streamTypeForURL returns isStream=false
+	// for them). Sharing one scheme switch keeps the two classifiers from drifting.
+	if streamType, ok := streamTypeForURL(url); ok {
+		return streamType
 	}
+	return StreamTypeRTSP // Default to RTSP for unknown schemes
 }
 
 // MigrateRTSPConfig migrates legacy URLs []string to Streams []StreamConfig.
@@ -450,4 +441,219 @@ func (s *Settings) MigrateLocationConfigured() bool {
 
 	s.BirdNET.LocationConfigured = true
 	return true
+}
+
+// streamTypeForURL strictly classifies device as a network stream URL. It
+// returns a StreamType* constant and true only for recognized stream schemes;
+// unlike inferStreamType it never defaults an unknown or scheme-less value to
+// RTSP, so sound-card device names (hw:, plughw:, sysdefault, default, dsnoop,
+// "Loopback", bare names) and file paths classify as ("", false). Scheme
+// matching is case-insensitive and leading/trailing whitespace is trimmed
+// first.
+func streamTypeForURL(device string) (streamType string, isStream bool) {
+	lower := strings.ToLower(strings.TrimSpace(device))
+
+	switch {
+	case strings.HasPrefix(lower, "rtsp://"), strings.HasPrefix(lower, "rtsps://"):
+		return StreamTypeRTSP, true
+	case strings.HasPrefix(lower, "rtmp://"), strings.HasPrefix(lower, "rtmps://"):
+		return StreamTypeRTMP, true
+	case strings.HasPrefix(lower, "udp://"), strings.HasPrefix(lower, "rtp://"):
+		return StreamTypeUDP, true
+	case strings.HasPrefix(lower, "http://"), strings.HasPrefix(lower, "https://"):
+		if strings.Contains(lower, ".m3u8") {
+			return StreamTypeHLS, true
+		}
+		return StreamTypeHTTP, true
+	default:
+		return "", false
+	}
+}
+
+// ReconcileMisplacedAudioSources moves network stream URLs that were
+// misconfigured under realtime.audio.sources (meant for local sound cards)
+// into realtime.rtsp.streams, where the runtime opens them with FFmpeg. A
+// stream URL left in audio.sources is otherwise opened as an ALSA device,
+// which fails and breaks live audio.
+//
+// For each audio source whose device is a recognized stream URL:
+//   - If no rtsp.streams entry already has that URL, a new StreamConfig is
+//     appended carrying the source's per-source overrides (gain, models,
+//     equalizer, quiet hours) and the source entry is removed.
+//   - If an rtsp.streams entry already has that URL, non-default per-source
+//     fields are lightly merged into the existing stream without overwriting
+//     values the stream already sets, and the duplicate source entry is
+//     removed.
+//
+// Credentials embedded in a URL are preserved verbatim in the config;
+// sanitized URLs are used only in the recorded ValidationWarnings. The
+// function is idempotent: once every stream URL has been relocated, a second
+// call finds nothing to do and returns false. Returns true when at least one
+// source entry was moved or merged and removed.
+func (s *Settings) ReconcileMisplacedAudioSources() bool {
+	sources := s.Realtime.Audio.Sources
+	if len(sources) == 0 {
+		return false
+	}
+
+	changed := false
+	survivors := make([]AudioSourceConfig, 0, len(sources))
+
+	for i := range sources {
+		src := &sources[i]
+		device := strings.TrimSpace(src.Device)
+		streamType, isStream := streamTypeForURL(device)
+		if !isStream {
+			survivors = append(survivors, *src)
+			continue
+		}
+
+		if existing := s.findStreamByURL(device); existing != nil {
+			s.mergeSourceIntoStream(src, existing, device)
+		} else {
+			s.appendStreamFromSource(src, device, streamType)
+		}
+
+		if src.SampleRate > 0 {
+			s.ValidationWarnings = append(s.ValidationWarnings,
+				fmt.Sprintf("audio source %q sample rate %d Hz was not carried to stream %q: stream sample rate is auto-detected",
+					src.Name, src.SampleRate, privacy.SanitizeStreamUrl(device)))
+		}
+
+		changed = true
+	}
+
+	if !changed {
+		return false
+	}
+
+	s.Realtime.Audio.Sources = survivors
+
+	GetLogger().Info("Reconciled misplaced stream URLs from audio.sources into rtsp.streams",
+		logger.Int("stream_count", len(s.Realtime.RTSP.Streams)),
+		logger.Int("remaining_sources", len(survivors)))
+
+	return true
+}
+
+// findStreamByURL returns a pointer to the first configured stream whose URL
+// matches the given already-trimmed URL, or nil when none match. The compare
+// trims whitespace on the stored URL so cosmetic differences do not defeat
+// deduplication.
+func (s *Settings) findStreamByURL(url string) *StreamConfig {
+	for i := range s.Realtime.RTSP.Streams {
+		if strings.TrimSpace(s.Realtime.RTSP.Streams[i].URL) == url {
+			return &s.Realtime.RTSP.Streams[i]
+		}
+	}
+	return nil
+}
+
+// appendStreamFromSource creates a new StreamConfig from a misplaced audio
+// source and appends it to the RTSP streams. Credentials in url are preserved
+// verbatim; only the ValidationWarnings note uses a sanitized URL.
+func (s *Settings) appendStreamFromSource(src *AudioSourceConfig, url, streamType string) {
+	name := src.Name
+	if strings.TrimSpace(name) == "" {
+		name = fmt.Sprintf("Stream %d", len(s.Realtime.RTSP.Streams)+1)
+	}
+
+	// Transport only applies to connection-oriented stream types.
+	transport := ""
+	if streamType == StreamTypeRTSP || streamType == StreamTypeRTMP {
+		transport = DefaultTransport
+	}
+
+	s.Realtime.RTSP.Streams = append(s.Realtime.RTSP.Streams, StreamConfig{
+		Name:       name,
+		URL:        url,
+		Enabled:    true,
+		Type:       streamType,
+		Transport:  transport,
+		Gain:       src.Gain,
+		Equalizer:  src.Equalizer,
+		QuietHours: src.QuietHours,
+		Models:     src.Models,
+	})
+
+	s.ValidationWarnings = append(s.ValidationWarnings,
+		fmt.Sprintf("moved misplaced stream URL %q from realtime.audio.sources to realtime.rtsp.streams as %q",
+			privacy.SanitizeStreamUrl(url), name))
+}
+
+// mergeSourceIntoStream lightly merges non-default per-source overrides from a
+// misplaced audio source into an existing stream that already has the same URL.
+// Stream values that are already set are never overwritten. A ValidationWarnings
+// note records which fields were applied and which were kept as-is because the
+// stream already carried a non-default value.
+func (s *Settings) mergeSourceIntoStream(src *AudioSourceConfig, stream *StreamConfig, url string) {
+	var applied, kept []string
+
+	if src.Gain != 0 {
+		if stream.Gain == 0 {
+			stream.Gain = src.Gain
+			applied = append(applied, "gain")
+		} else {
+			kept = append(kept, "gain")
+		}
+	}
+
+	if len(src.Models) > 0 {
+		if len(stream.Models) == 0 {
+			stream.Models = src.Models
+			applied = append(applied, "models")
+		} else {
+			kept = append(kept, "models")
+		}
+	}
+
+	if src.Equalizer != nil {
+		if stream.Equalizer == nil {
+			stream.Equalizer = src.Equalizer
+			applied = append(applied, "equalizer")
+		} else {
+			kept = append(kept, "equalizer")
+		}
+	}
+
+	// QuietHours merges only when the struct is safely comparable to its zero
+	// value. If QuietHoursConfig ever gains a non-comparable field, skip the
+	// merge and record it rather than risking a reflect panic or losing data.
+	switch {
+	case !quietHoursComparable():
+		kept = append(kept, "quietHours (QuietHoursConfig not comparable)")
+	case reflect.ValueOf(src.QuietHours).IsZero():
+		// Source has no quiet-hours override to contribute.
+	case reflect.ValueOf(stream.QuietHours).IsZero():
+		stream.QuietHours = src.QuietHours
+		applied = append(applied, "quietHours")
+	default:
+		kept = append(kept, "quietHours")
+	}
+
+	s.ValidationWarnings = append(s.ValidationWarnings,
+		formatReconcileMergeWarning(privacy.SanitizeStreamUrl(url), stream.Name, applied, kept))
+}
+
+// quietHoursComparable reports whether QuietHoursConfig can be compared to its
+// zero value. Merging quiet hours relies on a zero-value check; if the struct
+// ever gains a non-comparable field this returns false so the merge is skipped
+// rather than risking a runtime panic.
+func quietHoursComparable() bool {
+	return reflect.TypeOf(QuietHoursConfig{}).Comparable()
+}
+
+// formatReconcileMergeWarning builds the ValidationWarnings note for a duplicate
+// source merged into an existing stream. sanitizedURL must already be stripped
+// of credentials.
+func formatReconcileMergeWarning(sanitizedURL, streamName string, applied, kept []string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "merged misplaced audio source for stream URL %q into existing stream %q", sanitizedURL, streamName)
+	if len(applied) > 0 {
+		fmt.Fprintf(&b, "; applied: %s", strings.Join(applied, ", "))
+	}
+	if len(kept) > 0 {
+		fmt.Fprintf(&b, "; kept existing stream values for: %s", strings.Join(kept, ", "))
+	}
+	return b.String()
 }

--- a/internal/conf/reconcile_audio_sources_test.go
+++ b/internal/conf/reconcile_audio_sources_test.go
@@ -1,6 +1,7 @@
 package conf
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -188,6 +189,92 @@ func TestSettings_ReconcileMisplacedAudioSources_FallbackName(t *testing.T) {
 	require.Len(t, settings.Realtime.RTSP.Streams, 2)
 	// New stream is appended after the existing one; N = len(streams)+1 = 2.
 	assert.Equal(t, "Stream 2", settings.Realtime.RTSP.Streams[1].Name)
+}
+
+// TestSettings_ReconcileMisplacedAudioSources_UniqueNameOnCollision verifies
+// the migration never produces a duplicate stream name, which the validator
+// would otherwise reject with a fatal error at load time. It covers both a
+// non-empty source name colliding (case-insensitively) with an existing stream
+// and the "Stream N" fallback colliding with a manually named stream.
+func TestSettings_ReconcileMisplacedAudioSources_UniqueNameOnCollision(t *testing.T) {
+	t.Parallel()
+
+	t.Run("non-empty name collides case-insensitively", func(t *testing.T) {
+		t.Parallel()
+
+		settings := Settings{}
+		settings.Realtime.RTSP.Streams = []StreamConfig{
+			{Name: "Backyard", URL: "rtsp://cam0/stream", Type: StreamTypeRTSP, Enabled: true},
+		}
+		settings.Realtime.Audio.Sources = []AudioSourceConfig{
+			{Name: "backyard", Device: "rtsp://cam2/stream"}, // collides with "Backyard"
+		}
+
+		require.True(t, settings.ReconcileMisplacedAudioSources())
+		require.Len(t, settings.Realtime.RTSP.Streams, 2)
+		assert.Equal(t, "backyard (2)", settings.Realtime.RTSP.Streams[1].Name)
+		// The reconciled config must pass the same validator that runs at load
+		// time; asserting it directly (rather than re-implementing the rule)
+		// covers the duplicate-name and length checks and stays drift-proof.
+		require.NoError(t, settings.Realtime.RTSP.ValidateStreams())
+	})
+
+	t.Run("empty-name fallback collides with manual name", func(t *testing.T) {
+		t.Parallel()
+
+		settings := Settings{}
+		// One existing stream, so the empty-name fallback base is "Stream 2"
+		// (len+1), which is already taken by the manually named stream below.
+		settings.Realtime.RTSP.Streams = []StreamConfig{
+			{Name: "Stream 2", URL: "rtsp://cam0/stream", Type: StreamTypeRTSP, Enabled: true},
+		}
+		settings.Realtime.Audio.Sources = []AudioSourceConfig{
+			{Name: "", Device: "rtsp://cam3/stream"},
+		}
+
+		require.True(t, settings.ReconcileMisplacedAudioSources())
+		require.Len(t, settings.Realtime.RTSP.Streams, 2)
+		assert.Equal(t, "Stream 2 (2)", settings.Realtime.RTSP.Streams[1].Name)
+		require.NoError(t, settings.Realtime.RTSP.ValidateStreams())
+	})
+
+	t.Run("repeated collisions increment the suffix", func(t *testing.T) {
+		t.Parallel()
+
+		// "Cam" and "Cam (2)" are both taken, so the moved source must become
+		// "Cam (3)" - exercises the increment loop past the first suffix.
+		settings := Settings{}
+		settings.Realtime.RTSP.Streams = []StreamConfig{
+			{Name: "Cam", URL: "rtsp://cam0/stream", Type: StreamTypeRTSP, Enabled: true},
+			{Name: "Cam (2)", URL: "rtsp://cam1/stream", Type: StreamTypeRTSP, Enabled: true},
+		}
+		settings.Realtime.Audio.Sources = []AudioSourceConfig{
+			{Name: "Cam", Device: "rtsp://cam2/stream"},
+		}
+
+		require.True(t, settings.ReconcileMisplacedAudioSources())
+		require.Len(t, settings.Realtime.RTSP.Streams, 3)
+		assert.Equal(t, "Cam (3)", settings.Realtime.RTSP.Streams[2].Name)
+		require.NoError(t, settings.Realtime.RTSP.ValidateStreams())
+	})
+
+	t.Run("over-length source name is truncated to a valid name", func(t *testing.T) {
+		t.Parallel()
+
+		// A name at MaxAudioSourceNameLength is valid for a source but exceeds
+		// MaxStreamNameLength, so the migration must truncate it rather than emit
+		// a name the length validator would reject with a fatal error at load.
+		longName := strings.Repeat("a", MaxAudioSourceNameLength)
+		settings := Settings{}
+		settings.Realtime.Audio.Sources = []AudioSourceConfig{
+			{Name: longName, Device: "rtsp://cam0/stream"},
+		}
+
+		require.True(t, settings.ReconcileMisplacedAudioSources())
+		require.Len(t, settings.Realtime.RTSP.Streams, 1)
+		assert.LessOrEqual(t, len(settings.Realtime.RTSP.Streams[0].Name), MaxStreamNameLength)
+		require.NoError(t, settings.Realtime.RTSP.ValidateStreams())
+	})
 }
 
 // TestSettings_ReconcileMisplacedAudioSources_DedupMergeDefaultStream verifies

--- a/internal/conf/reconcile_audio_sources_test.go
+++ b/internal/conf/reconcile_audio_sources_test.go
@@ -1,0 +1,344 @@
+package conf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStreamTypeForURL exercises the strict stream classifier used by
+// ReconcileMisplacedAudioSources. Unlike inferStreamType it must never promote
+// an unknown scheme or a sound-card device name to a stream type.
+func TestStreamTypeForURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		device     string
+		wantType   string
+		wantStream bool
+	}{
+		// Stream schemes.
+		{"rtsp", "rtsp://192.168.1.10/stream", StreamTypeRTSP, true},
+		{"rtsps", "rtsps://secure.cam/stream", StreamTypeRTSP, true},
+		{"rtsp uppercase", "RTSP://192.168.1.10/stream", StreamTypeRTSP, true},
+		{"rtmp", "rtmp://192.168.1.60/live", StreamTypeRTMP, true},
+		{"rtmps", "rtmps://secure.rtmp/live", StreamTypeRTMP, true},
+		{"udp", "udp://239.0.0.1:1234", StreamTypeUDP, true},
+		{"rtp", "rtp://239.0.0.1:5004", StreamTypeUDP, true},
+		{"hls http", "http://server/live/playlist.m3u8", StreamTypeHLS, true},
+		{"hls https", "https://cdn.example.com/stream.m3u8?token=abc", StreamTypeHLS, true},
+		{"http", "http://192.168.1.50:8000/audio", StreamTypeHTTP, true},
+		{"https", "https://secure.server/stream", StreamTypeHTTP, true},
+		{"whitespace trimmed", "  rtsp://192.168.1.10/stream  ", StreamTypeRTSP, true},
+
+		// Local sound cards and files must NOT classify as streams.
+		{"hw device", "hw:0,0", "", false},
+		{"plughw device", "plughw:1,0", "", false},
+		{"sysdefault", "sysdefault", "", false},
+		{"default", "default", "", false},
+		{"dsnoop", "dsnoop", "", false},
+		{"loopback", "Loopback", "", false},
+		{"bare name", "USB Audio Device", "", false},
+		{"file path wav", "/tmp/recording.wav", "", false},
+		{"empty", "", "", false},
+
+		// Unknown schemes must NOT default to RTSP (regression guard).
+		{"ftp scheme", "ftp://server/file", "", false},
+		{"unknown scheme", "unknown://something", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotType, gotStream := streamTypeForURL(tt.device)
+			assert.Equal(t, tt.wantStream, gotStream, "isStream mismatch for %q", tt.device)
+			assert.Equal(t, tt.wantType, gotType, "streamType mismatch for %q", tt.device)
+		})
+	}
+}
+
+// TestSettings_ReconcileMisplacedAudioSources_MovesStreamURL verifies that a
+// full stream URL (with credentials) misconfigured under audio.sources is moved
+// into rtsp.streams with every field carried over and credentials preserved.
+func TestSettings_ReconcileMisplacedAudioSources_MovesStreamURL(t *testing.T) {
+	t.Parallel()
+
+	eq := &EqualizerSettings{Enabled: true}
+	qh := QuietHoursConfig{Enabled: true, Mode: "fixed", StartTime: "22:00", EndTime: "06:00"}
+
+	settings := Settings{}
+	settings.Realtime.Audio.Sources = []AudioSourceConfig{
+		{
+			Name:       "Backyard Cam",
+			Device:     "rtsp://admin:secret@192.168.1.100:554/h264/main",
+			Gain:       6.5,
+			Models:     []string{"birdnet", "perch_v2"},
+			Equalizer:  eq,
+			QuietHours: qh,
+		},
+	}
+
+	changed := settings.ReconcileMisplacedAudioSources()
+	require.True(t, changed, "reconcile should report a change")
+
+	assert.Empty(t, settings.Realtime.Audio.Sources, "stream source should be removed from audio.sources")
+	require.Len(t, settings.Realtime.RTSP.Streams, 1, "stream should be added to rtsp.streams")
+
+	stream := settings.Realtime.RTSP.Streams[0]
+	assert.Equal(t, "Backyard Cam", stream.Name)
+	assert.Equal(t, "rtsp://admin:secret@192.168.1.100:554/h264/main", stream.URL, "credentials must be preserved verbatim")
+	assert.Equal(t, StreamTypeRTSP, stream.Type)
+	assert.Equal(t, DefaultTransport, stream.Transport)
+	assert.True(t, stream.Enabled)
+	assert.InDelta(t, 6.5, stream.Gain, 1e-9)
+	assert.Equal(t, []string{"birdnet", "perch_v2"}, stream.Models)
+	assert.Same(t, eq, stream.Equalizer)
+	assert.Equal(t, qh, stream.QuietHours)
+
+	assert.NotEmpty(t, settings.ValidationWarnings, "a warning should be recorded for the move")
+	// Credentials must not leak into the warning text.
+	for _, w := range settings.ValidationWarnings {
+		assert.NotContains(t, w, "secret", "warning must use a sanitized URL")
+	}
+}
+
+// TestSettings_ReconcileMisplacedAudioSources_AllStreamSchemes ensures every
+// recognized stream scheme is classified and moved with the correct type and
+// transport assignment.
+func TestSettings_ReconcileMisplacedAudioSources_AllStreamSchemes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		device        string
+		wantType      string
+		wantTransport string
+	}{
+		{"rtsp", "rtsp://cam/stream", StreamTypeRTSP, DefaultTransport},
+		{"rtsps", "rtsps://cam/stream", StreamTypeRTSP, DefaultTransport},
+		{"rtmp", "rtmp://live/stream", StreamTypeRTMP, DefaultTransport},
+		{"rtmps", "rtmps://live/stream", StreamTypeRTMP, DefaultTransport},
+		{"udp", "udp://239.0.0.1:1234", StreamTypeUDP, ""},
+		{"rtp", "rtp://239.0.0.1:5004", StreamTypeUDP, ""},
+		{"hls", "https://cdn/live.m3u8", StreamTypeHLS, ""},
+		{"http", "http://icecast:8000/audio", StreamTypeHTTP, ""},
+		{"https", "https://server/audio", StreamTypeHTTP, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			settings := Settings{}
+			settings.Realtime.Audio.Sources = []AudioSourceConfig{
+				{Name: "Src", Device: tt.device},
+			}
+
+			changed := settings.ReconcileMisplacedAudioSources()
+			require.True(t, changed)
+			assert.Empty(t, settings.Realtime.Audio.Sources)
+			require.Len(t, settings.Realtime.RTSP.Streams, 1)
+
+			stream := settings.Realtime.RTSP.Streams[0]
+			assert.Equal(t, tt.wantType, stream.Type)
+			assert.Equal(t, tt.wantTransport, stream.Transport)
+			assert.Equal(t, tt.device, stream.URL)
+			assert.True(t, stream.Enabled)
+		})
+	}
+}
+
+// TestSettings_ReconcileMisplacedAudioSources_LocalDevicesStay ensures that
+// genuine local audio devices are never promoted to streams.
+func TestSettings_ReconcileMisplacedAudioSources_LocalDevicesStay(t *testing.T) {
+	t.Parallel()
+
+	devices := []string{"hw:0,0", "sysdefault", "Loopback", "USB Audio", "/tmp/x.wav", ""}
+
+	settings := Settings{}
+	for _, d := range devices {
+		settings.Realtime.Audio.Sources = append(settings.Realtime.Audio.Sources,
+			AudioSourceConfig{Name: "local", Device: d})
+	}
+
+	changed := settings.ReconcileMisplacedAudioSources()
+	assert.False(t, changed, "no local device should be moved")
+	assert.Len(t, settings.Realtime.Audio.Sources, len(devices), "all local sources must be retained")
+	assert.Empty(t, settings.Realtime.RTSP.Streams, "no streams should be created")
+	assert.Empty(t, settings.ValidationWarnings)
+}
+
+// TestSettings_ReconcileMisplacedAudioSources_FallbackName verifies the
+// generated stream name when the source has no name.
+func TestSettings_ReconcileMisplacedAudioSources_FallbackName(t *testing.T) {
+	t.Parallel()
+
+	settings := Settings{}
+	settings.Realtime.RTSP.Streams = []StreamConfig{
+		{Name: "Existing", URL: "rtsp://cam0/stream", Type: StreamTypeRTSP, Enabled: true},
+	}
+	settings.Realtime.Audio.Sources = []AudioSourceConfig{
+		{Name: "", Device: "rtsp://cam1/stream"},
+	}
+
+	changed := settings.ReconcileMisplacedAudioSources()
+	require.True(t, changed)
+	require.Len(t, settings.Realtime.RTSP.Streams, 2)
+	// New stream is appended after the existing one; N = len(streams)+1 = 2.
+	assert.Equal(t, "Stream 2", settings.Realtime.RTSP.Streams[1].Name)
+}
+
+// TestSettings_ReconcileMisplacedAudioSources_DedupMergeDefaultStream verifies
+// that when the same URL exists in both places and the stream side is default,
+// the source's non-default fields fill the stream and the source is removed.
+func TestSettings_ReconcileMisplacedAudioSources_DedupMergeDefaultStream(t *testing.T) {
+	t.Parallel()
+
+	eq := &EqualizerSettings{Enabled: true}
+	qh := QuietHoursConfig{Enabled: true, Mode: "fixed", StartTime: "22:00", EndTime: "06:00"}
+
+	settings := Settings{}
+	settings.Realtime.RTSP.Streams = []StreamConfig{
+		{Name: "Cam", URL: "rtsp://cam/stream", Type: StreamTypeRTSP, Transport: DefaultTransport, Enabled: true},
+	}
+	settings.Realtime.Audio.Sources = []AudioSourceConfig{
+		{
+			Name:       "DupSrc",
+			Device:     "rtsp://cam/stream",
+			Gain:       3.0,
+			Models:     []string{"perch_v2"},
+			Equalizer:  eq,
+			QuietHours: qh,
+		},
+	}
+
+	changed := settings.ReconcileMisplacedAudioSources()
+	require.True(t, changed)
+	assert.Empty(t, settings.Realtime.Audio.Sources, "duplicate source must be removed")
+	require.Len(t, settings.Realtime.RTSP.Streams, 1, "no new stream should be created for a duplicate URL")
+
+	stream := settings.Realtime.RTSP.Streams[0]
+	assert.InDelta(t, 3.0, stream.Gain, 1e-9, "gain should be filled from source")
+	assert.Equal(t, []string{"perch_v2"}, stream.Models, "models should be filled from source")
+	assert.Same(t, eq, stream.Equalizer, "equalizer should be filled from source")
+	assert.Equal(t, qh, stream.QuietHours, "quiet hours should be filled from source")
+	assert.NotEmpty(t, settings.ValidationWarnings)
+}
+
+// TestSettings_ReconcileMisplacedAudioSources_DedupMergeNonDefaultStream
+// verifies that a stream's existing non-default values are never overwritten by
+// the duplicate source, and the warning notes what was kept.
+func TestSettings_ReconcileMisplacedAudioSources_DedupMergeNonDefaultStream(t *testing.T) {
+	t.Parallel()
+
+	streamEq := &EqualizerSettings{Enabled: true}
+	srcEq := &EqualizerSettings{Enabled: false}
+	streamQH := QuietHoursConfig{Enabled: true, Mode: "fixed", StartTime: "01:00", EndTime: "02:00"}
+	srcQH := QuietHoursConfig{Enabled: true, Mode: "fixed", StartTime: "22:00", EndTime: "06:00"}
+
+	settings := Settings{}
+	settings.Realtime.RTSP.Streams = []StreamConfig{
+		{
+			Name:       "Cam",
+			URL:        "rtsp://cam/stream",
+			Type:       StreamTypeRTSP,
+			Transport:  DefaultTransport,
+			Enabled:    true,
+			Gain:       9.0,
+			Models:     []string{"birdnet"},
+			Equalizer:  streamEq,
+			QuietHours: streamQH,
+		},
+	}
+	settings.Realtime.Audio.Sources = []AudioSourceConfig{
+		{
+			Name:       "DupSrc",
+			Device:     "rtsp://cam/stream",
+			Gain:       3.0,
+			Models:     []string{"perch_v2"},
+			Equalizer:  srcEq,
+			QuietHours: srcQH,
+		},
+	}
+
+	changed := settings.ReconcileMisplacedAudioSources()
+	require.True(t, changed)
+	assert.Empty(t, settings.Realtime.Audio.Sources)
+	require.Len(t, settings.Realtime.RTSP.Streams, 1)
+
+	stream := settings.Realtime.RTSP.Streams[0]
+	assert.InDelta(t, 9.0, stream.Gain, 1e-9, "existing stream gain must be preserved")
+	assert.Equal(t, []string{"birdnet"}, stream.Models, "existing stream models must be preserved")
+	assert.Same(t, streamEq, stream.Equalizer, "existing stream equalizer must be preserved")
+	assert.Equal(t, streamQH, stream.QuietHours, "existing stream quiet hours must be preserved")
+
+	require.NotEmpty(t, settings.ValidationWarnings)
+	joined := ""
+	for _, w := range settings.ValidationWarnings {
+		joined += w + "\n"
+	}
+	assert.Contains(t, joined, "gain", "warning should mention gain was kept")
+	assert.Contains(t, joined, "models", "warning should mention models were kept")
+	assert.Contains(t, joined, "equalizer", "warning should mention equalizer was kept")
+	assert.Contains(t, joined, "quietHours", "warning should mention quietHours were kept")
+}
+
+// TestSettings_ReconcileMisplacedAudioSources_SampleRateWarning verifies that a
+// non-zero SampleRate on a moved source emits a warning since stream sample
+// rates are auto-detected.
+func TestSettings_ReconcileMisplacedAudioSources_SampleRateWarning(t *testing.T) {
+	t.Parallel()
+
+	settings := Settings{}
+	settings.Realtime.Audio.Sources = []AudioSourceConfig{
+		{Name: "Src", Device: "rtsp://cam/stream", SampleRate: 96000},
+	}
+
+	changed := settings.ReconcileMisplacedAudioSources()
+	require.True(t, changed)
+	require.Len(t, settings.Realtime.RTSP.Streams, 1)
+
+	joined := ""
+	for _, w := range settings.ValidationWarnings {
+		joined += w + "\n"
+	}
+	assert.Contains(t, joined, "sample rate", "a sample-rate warning should be recorded")
+}
+
+// TestSettings_ReconcileMisplacedAudioSources_Idempotent ensures a second call
+// is a no-op once every stream URL has been relocated.
+func TestSettings_ReconcileMisplacedAudioSources_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	settings := Settings{}
+	settings.Realtime.Audio.Sources = []AudioSourceConfig{
+		{Name: "Cam", Device: "rtsp://cam/stream"},
+		{Name: "Mic", Device: "hw:0,0"},
+	}
+
+	changed1 := settings.ReconcileMisplacedAudioSources()
+	require.True(t, changed1)
+	require.Len(t, settings.Realtime.RTSP.Streams, 1)
+	require.Len(t, settings.Realtime.Audio.Sources, 1, "only the local mic should remain")
+
+	streamsAfterFirst := settings.Realtime.RTSP.Streams[0]
+	sourcesLen := len(settings.Realtime.Audio.Sources)
+
+	changed2 := settings.ReconcileMisplacedAudioSources()
+	assert.False(t, changed2, "second call must be a no-op")
+	require.Len(t, settings.Realtime.RTSP.Streams, 1)
+	assert.Equal(t, streamsAfterFirst, settings.Realtime.RTSP.Streams[0], "streams must not change on second call")
+	assert.Len(t, settings.Realtime.Audio.Sources, sourcesLen, "sources must not change on second call")
+}
+
+// TestSettings_ReconcileMisplacedAudioSources_EmptySources verifies the no-op
+// path when there are no audio sources at all.
+func TestSettings_ReconcileMisplacedAudioSources_EmptySources(t *testing.T) {
+	t.Parallel()
+
+	settings := Settings{}
+	changed := settings.ReconcileMisplacedAudioSources()
+	assert.False(t, changed)
+}

--- a/internal/conf/storage.go
+++ b/internal/conf/storage.go
@@ -92,6 +92,13 @@ func Load() (*Settings, error) {
 		persistMigration(settings, "source models")
 	}
 
+	// Relocate stream URLs misconfigured under realtime.audio.sources (meant
+	// for local sound cards) into realtime.rtsp.streams so the runtime opens
+	// them with FFmpeg instead of failing to open them as ALSA devices.
+	if settings.ReconcileMisplacedAudioSources() {
+		persistMigration(settings, "misplaced audio sources")
+	}
+
 	if streamEnabledMigrated {
 		persistMigration(settings, "stream enabled defaults")
 	}

--- a/internal/conf/stream_validation_test.go
+++ b/internal/conf/stream_validation_test.go
@@ -1,6 +1,7 @@
 package conf
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -546,6 +547,54 @@ func TestStreamConfig_ChannelModeValidation(t *testing.T) {
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "invalid channel mode")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestStreamConfig_Validate_GainRange mirrors TestAudioSourceConfig_Validate_GainRange:
+// StreamConfig.Validate must reject NaN, +/-Inf, and out-of-range gain so a
+// hand-edited config.yaml or a non-UI API client cannot push an out-of-range
+// gain past the frontend clamp. Only Gain varies; every other field is valid.
+func TestStreamConfig_Validate_GainRange(t *testing.T) {
+	t.Parallel()
+
+	base := func() StreamConfig {
+		return StreamConfig{
+			Name: "Gain Cam",
+			URL:  "rtsp://cam.local/stream",
+			Type: StreamTypeRTSP,
+		}
+	}
+
+	tests := []struct {
+		name    string
+		gain    float64
+		wantErr bool
+	}{
+		{"zero gain", 0, false},
+		{"max gain", MaxAudioGain, false},
+		{"min gain", MinAudioGain, false},
+		{"normal positive gain", 6.5, false},
+		{"NaN gain", math.NaN(), true},
+		{"positive Inf gain", math.Inf(1), true},
+		{"negative Inf gain", math.Inf(-1), true},
+		{"above max", MaxAudioGain + 1, true},
+		{"below min", MinAudioGain - 1, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := base()
+			s.Gain = tt.gain
+			err := s.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "gain")
+				assert.Contains(t, err.Error(), "out of range")
 			} else {
 				assert.NoError(t, err)
 			}

--- a/internal/conf/validate_audio.go
+++ b/internal/conf/validate_audio.go
@@ -145,6 +145,13 @@ func (s *StreamConfig) Validate() error {
 		return fmt.Errorf("invalid channel mode '%s' for '%s': must be downmix, left, or right", s.ChannelMode, s.Name)
 	}
 
+	// Validate gain range (NaN/Inf bypass < and > comparisons). Mirrors the
+	// AudioSourceConfig.Validate check so a hand-edited config.yaml or a non-UI
+	// API client cannot push an out-of-range gain past the frontend clamp.
+	if math.IsNaN(s.Gain) || math.IsInf(s.Gain, 0) || s.Gain < MinAudioGain || s.Gain > MaxAudioGain {
+		return fmt.Errorf("stream '%s': gain %.1f dB out of range [%.0f, +%.0f]", s.Name, s.Gain, MinAudioGain, MaxAudioGain)
+	}
+
 	// Validate URL scheme matches type
 	if err := s.validateURLScheme(); err != nil {
 		return err


### PR DESCRIPTION
## Summary

Live audio (HLS) failed with an opaque error popup and no logs while bird detection kept working. It happened when a stream URL was configured under `realtime.audio.sources`, which is meant for local sound cards: the stream got opened as an ALSA device, failed, and never received a capture buffer, so the HLS start handler returned a bare 404/500. Two users hit this in #3766.

I fixed the root cause with defense in depth, and closed a real gap I found along the way: streams had no gain setting at all.

## Changes

**Config self-reconciliation (`internal/conf`)**
- New `ReconcileMisplacedAudioSources` migration: on load it moves stream-URL entries out of `realtime.audio.sources` into `realtime.rtsp.streams` (strict scheme classifier, non-destructive dedup-merge, credentials preserved), records a validation warning, and persists the corrected config. Follows the existing `Migrate*` pattern.
- `inferStreamType` now shares that strict classifier instead of duplicating the scheme switch.

**Defensive source typing (`internal/analysis`)**
- `buildSourceConfigsWithModels` detects the real source type from the device string instead of assuming an audio card, so even an un-reconciled config registers a stream correctly. A dedup guard makes a configured stream (enabled or disabled) always win over a misplaced `audio.sources` duplicate, so a disabled stream can never be silently re-enabled. The device is trimmed once so detection, dedup, and the registered connection string agree.

**HLS diagnostics (`internal/api/v2/audio`)**
- `StartHLSStream` no longer returns a bare `nil`-error 404. It returns a real error, an actionable message, and a sanitized WARN log listing the available sources, so a failure is diagnosable instead of silent.

**Per-stream gain (new feature)**
- Streams had no gain control even though the pipeline already supported per-source gain. Added `realtime.rtsp.streams[].gain` end to end: pipeline wiring, hot-reload via the existing gain-only reconfigure path, range/NaN validation mirroring the sound-card check, config schema + hot-reload coverage, and a gain slider in `StreamCard`/`StreamManager` mirroring the sound-card control (reusing its i18n label).

## Testing

- New table-driven tests for the reconciliation migration (moves, all schemes, local-devices-stay, dedup-merge, credentials, idempotency), the strict classifier, defensive typing plus the disabled-stream dedup guard, stream gain validation, and the HLS 404 diagnostics. Each regression test was confirmed to fail on the pre-fix code.
- `go build`, full `golangci-lint` (0 issues), `go test` on all touched packages, the hot-reload coverage and schema drift guards, and the full frontend suite (`npm run check:all` + vitest) all pass.

## Notes

The reporters also hit a separate 500 on the support-dump generator (0-byte `support.log`) on an NFS-mounted config dir. That looks like a distinct filesystem/permissions issue, out of scope here, and I will track it separately.

Fixes #3766


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-stream input gain (dB) support across configuration, editing screens, and stream setup flows, including shared gain bounds in the UI.
  * Stream URLs now carry gain into built stream sources when enabled.

* **Bug Fixes**
  * Automatically reconciles “misplaced” stream URLs configured under local audio sources into the correct stream list, including dedup/merge behavior.
  * Improved live-stream start error details when a capture buffer is unavailable.

* **Tests**
  * Expanded validation, coercion/clamping, stream-type detection, migration/reconciliation, and HLS “no capture buffer” coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->