### PR TITLE
fix(api): bind AutoTLS to standard ports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -143,6 +143,7 @@ RUN apt-get update -q && apt-get install -q -y --no-install-recommends \
     lsof \
     bash-completion \
     gosu \
+    libcap2-bin \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy ONNX Runtime libraries (used by all arches; arm64 relies on them exclusively).
@@ -186,6 +187,7 @@ WORKDIR /data
 EXPOSE 80 443 8080 8090
 
 COPY --from=build /home/dev-user/src/BirdNET-Go/bin /usr/bin/
+RUN setcap cap_net_bind_service=+ep /usr/bin/birdnet-go
 
 # Add container labels for metadata and compatibility information
 LABEL org.opencontainers.image.title="BirdNET-Go"

--- a/Dockerfile
+++ b/Dockerfile
@@ -217,9 +217,12 @@ LABEL usage.compose.podman="Use Podman/podman-compose.yml"
 # Add healthcheck to monitor container status
 # Uses /health endpoint and validates JSON status via jq to avoid false positives
 # from HTTP->HTTPS 308 redirects (curl -f treats 3xx as success).
+# The port-80 probe covers AutoTLS mode: the app serves /health over plain HTTP
+# there, while a localhost HTTPS probe on :443 is rejected by autocert's
+# hostname whitelist and nothing listens on 8080/8443.
 # Extended start-period for low-power devices (e.g., Raspberry Pi)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
-    CMD curl -fs --connect-timeout 2 --max-time 3 http://localhost:8080/health | jq -e '.status == "healthy"' >/dev/null || curl -fsk --connect-timeout 2 --max-time 3 https://localhost:8443/health | jq -e '.status == "healthy"' >/dev/null || curl -fsk --connect-timeout 2 --max-time 3 https://localhost:443/health | jq -e '.status == "healthy"' >/dev/null || exit 1
+    CMD curl -fs --connect-timeout 2 --max-time 3 http://localhost:8080/health | jq -e '.status == "healthy"' >/dev/null || curl -fs --connect-timeout 2 --max-time 3 http://localhost:80/health | jq -e '.status == "healthy"' >/dev/null || curl -fsk --connect-timeout 2 --max-time 3 https://localhost:8443/health | jq -e '.status == "healthy"' >/dev/null || curl -fsk --connect-timeout 2 --max-time 3 https://localhost:443/health | jq -e '.status == "healthy"' >/dev/null || exit 1
 
 # Container startup execution chain:
 # 1. entrypoint.sh - Sets up user permissions, timezone, device access, and performs

--- a/install.sh
+++ b/install.sh
@@ -4510,6 +4510,15 @@ generate_systemd_service_content() {
     # because load_existing_service_config() restores these flags from the current unit.
     # Any restored host bind address is reapplied so a localhost-only mapping survives a
     # regenerate (default is no address: published on all interfaces).
+    # The container only listens on 8080 outside AutoTLS. Under AutoTLS the app
+    # serves the UI on 443 and an HTTP entrypoint (redirect + ACME + health) on
+    # 80, so publishing the 8080 mapping would expose a dead host port. Publish
+    # the web mapping only when AutoTLS is off; the 80/443 mapping below covers
+    # the AutoTLS HTTP entrypoint.
+    local web_port_line=""
+    if [ "$BIND_TLS_PORTS" != "true" ]; then
+        web_port_line="-p ${WEB_PORT_BIND_ADDR:+${WEB_PORT_BIND_ADDR}:}${WEB_PORT}:8080"
+    fi
     local tls_ports_line=""
     if [ "$BIND_TLS_PORTS" = "true" ]; then
         tls_ports_line="-p ${TLS_BIND_ADDR:+${TLS_BIND_ADDR}:}80:80 \\
@@ -4562,8 +4571,8 @@ ExecStartPre=-/bin/chown -h ${HOST_UID}:${HOST_GID} /mnt/birdnet-go/external
 ${wifi_power_save_script:+${wifi_power_save_script}
 }ExecStart=/usr/bin/docker run --rm \\
     --name birdnet-go \\
-    -p ${WEB_PORT_BIND_ADDR:+${WEB_PORT_BIND_ADDR}:}${WEB_PORT}:8080 \\
-${tls_ports_line:+    ${tls_ports_line} \\
+${web_port_line:+    ${web_port_line} \\
+}${tls_ports_line:+    ${tls_ports_line} \\
 }${metrics_port_line:+    ${metrics_port_line} \\
 }${tls_capability_line:+    ${tls_capability_line} \\
 }    --env TZ="${TZ}" \\

--- a/install.sh
+++ b/install.sh
@@ -4519,6 +4519,10 @@ generate_systemd_service_content() {
     if [ "$BIND_METRICS_PORT" = "true" ]; then
         metrics_port_line="-p ${METRICS_BIND_ADDR:+${METRICS_BIND_ADDR}:}8090:8090"
     fi
+    local tls_capability_line=""
+    if [ "$BIND_TLS_PORTS" = "true" ]; then
+        tls_capability_line="--cap-add NET_BIND_SERVICE"
+    fi
 
     # Check if running on Raspberry Pi and add WiFi power save disable script
     local wifi_power_save_script=""
@@ -4561,6 +4565,7 @@ ${wifi_power_save_script:+${wifi_power_save_script}
     -p ${WEB_PORT_BIND_ADDR:+${WEB_PORT_BIND_ADDR}:}${WEB_PORT}:8080 \\
 ${tls_ports_line:+    ${tls_ports_line} \\
 }${metrics_port_line:+    ${metrics_port_line} \\
+}${tls_capability_line:+    ${tls_capability_line} \\
 }    --env TZ="${TZ}" \\
     --env BIRDNET_UID=${HOST_UID} \\
     --env BIRDNET_GID=${HOST_GID} \\

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -180,10 +180,22 @@ func (c *Config) Address() string {
 
 // TLSAddress returns the full address string for the HTTPS server to listen on.
 func (c *Config) TLSAddress() string {
+	if c.AutoTLS {
+		return c.addressForPort("443")
+	}
 	port := c.TLSPort
 	if port == "" {
 		port = "8443"
 	}
+	return c.addressForPort(port)
+}
+
+// AutoTLSHTTPAddress returns the address for AutoTLS HTTP redirects.
+func (c *Config) AutoTLSHTTPAddress() string {
+	return c.addressForPort("80")
+}
+
+func (c *Config) addressForPort(port string) string {
 	if c.Host == "" {
 		return ":" + port
 	}

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -23,6 +23,12 @@ const (
 	DefaultIdleTimeout     = 120 * time.Second
 	DefaultShutdownTimeout = 10 * time.Second
 
+	defaultHTTPPort       = "8080"
+	defaultManualTLSPort  = "8443"
+	autoTLSHTTPSPort      = "443"
+	autoTLSHTTPPort       = "80"
+	manualTLSConflictPort = "8444"
+
 	// DefaultLogPath is the default path for the server log file.
 	DefaultLogPath = "logs/server.log"
 )
@@ -68,10 +74,10 @@ type Config struct {
 func DefaultConfig() *Config {
 	return &Config{
 		Host:            "",
-		Port:            "8080",
+		Port:            defaultHTTPPort,
 		TLSEnabled:      false,
 		AutoTLS:         false,
-		TLSPort:         "8443",
+		TLSPort:         defaultManualTLSPort,
 		RedirectToHTTPS: false,
 		AllowedOrigins:  []string{"*"},
 		ReadTimeout:     DefaultReadTimeout,
@@ -115,12 +121,12 @@ func ConfigFromSettings(settings *conf.Settings) *Config {
 			cfg.RedirectToHTTPS = settings.Security.RedirectToHTTPS
 			cfg.TLSPort = settings.Security.TLSPort
 			if cfg.TLSPort == "" {
-				cfg.TLSPort = "8443"
+				cfg.TLSPort = defaultManualTLSPort
 			}
 			if cfg.TLSPort == cfg.Port {
-				fallback := "8443"
-				if cfg.Port == "8443" {
-					fallback = "8444"
+				fallback := defaultManualTLSPort
+				if cfg.Port == defaultManualTLSPort {
+					fallback = manualTLSConflictPort
 				}
 				GetLogger().Warn("TLS port must differ from HTTP port",
 					logger.String("http_port", cfg.Port),
@@ -181,18 +187,18 @@ func (c *Config) Address() string {
 // TLSAddress returns the full address string for the HTTPS server to listen on.
 func (c *Config) TLSAddress() string {
 	if c.AutoTLS {
-		return c.addressForPort("443")
+		return c.addressForPort(autoTLSHTTPSPort)
 	}
 	port := c.TLSPort
 	if port == "" {
-		port = "8443"
+		port = defaultManualTLSPort
 	}
 	return c.addressForPort(port)
 }
 
 // AutoTLSHTTPAddress returns the address for AutoTLS HTTP redirects.
 func (c *Config) AutoTLSHTTPAddress() string {
-	return c.addressForPort("80")
+	return c.addressForPort(autoTLSHTTPPort)
 }
 
 func (c *Config) addressForPort(port string) string {

--- a/internal/api/config_test.go
+++ b/internal/api/config_test.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+func TestConfigFromSettingsAutoTLSUsesStandardHTTPSPort(t *testing.T) {
+	t.Parallel()
+
+	settings := &conf.Settings{}
+	settings.WebServer.Port = "8080"
+	settings.Security.TLSMode = conf.TLSModeAutoTLS
+	settings.Security.TLSPort = "9443"
+
+	cfg := ConfigFromSettings(settings)
+
+	if !cfg.AutoTLS {
+		t.Fatal("expected AutoTLS to be enabled")
+	}
+	if got, want := cfg.Address(), ":8080"; got != want {
+		t.Fatalf("regular web address = %q, want %q", got, want)
+	}
+	if got, want := cfg.TLSAddress(), ":443"; got != want {
+		t.Fatalf("AutoTLS HTTPS address = %q, want %q", got, want)
+	}
+	if got, want := cfg.AutoTLSHTTPAddress(), ":80"; got != want {
+		t.Fatalf("AutoTLS HTTP redirect address = %q, want %q", got, want)
+	}
+}

--- a/internal/api/config_test.go
+++ b/internal/api/config_test.go
@@ -3,6 +3,9 @@ package api
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
@@ -16,16 +19,8 @@ func TestConfigFromSettingsAutoTLSUsesStandardHTTPSPort(t *testing.T) {
 
 	cfg := ConfigFromSettings(settings)
 
-	if !cfg.AutoTLS {
-		t.Fatal("expected AutoTLS to be enabled")
-	}
-	if got, want := cfg.Address(), ":8080"; got != want {
-		t.Fatalf("regular web address = %q, want %q", got, want)
-	}
-	if got, want := cfg.TLSAddress(), ":443"; got != want {
-		t.Fatalf("AutoTLS HTTPS address = %q, want %q", got, want)
-	}
-	if got, want := cfg.AutoTLSHTTPAddress(), ":80"; got != want {
-		t.Fatalf("AutoTLS HTTP redirect address = %q, want %q", got, want)
-	}
+	require.True(t, cfg.AutoTLS, "expected AutoTLS to be enabled")
+	assert.Equal(t, ":8080", cfg.Address(), "regular web address")
+	assert.Equal(t, ":443", cfg.TLSAddress(), "AutoTLS HTTPS address")
+	assert.Equal(t, ":80", cfg.AutoTLSHTTPAddress(), "AutoTLS HTTP redirect address")
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -472,10 +472,15 @@ func (s *Server) setupMiddleware() {
 	s.echo.Use(mw.NewSecureHeaders(securityConfig))
 }
 
+// healthCheckPath is the unauthenticated health endpoint used by container
+// healthchecks and load balancers. It is served over every listener, including
+// the plain-HTTP AutoTLS port, so a self-check never needs a valid certificate.
+const healthCheckPath = "/health"
+
 // setupRoutes configures all HTTP routes.
 func (s *Server) setupRoutes() error {
 	// Health check endpoint at root level
-	s.echo.GET("/health", s.healthCheck)
+	s.echo.GET(healthCheckPath, s.healthCheck)
 
 	// Social OAuth routes (Google, GitHub, Microsoft)
 	// These must be at /auth/:provider to match frontend expectations
@@ -765,10 +770,25 @@ func (s *Server) newHTTPRedirectServer(httpAddr, tlsPort string) *http.Server {
 // autocert.Manager.HTTPHandler intercepts ACME HTTP-01 challenges and delegates
 // non-challenge requests to the fallback redirect handler.
 func (s *Server) newAutoTLSHTTPServer(httpAddr string) *http.Server {
-	fallback := http.NotFoundHandler()
+	// Non-challenge requests either redirect to HTTPS or 404.
+	redirectOrNotFound := http.NotFoundHandler()
 	if s.config.RedirectToHTTPS {
-		fallback = newHTTPSRedirectHandler(autoTLSHTTPSPort)
+		redirectOrNotFound = newHTTPSRedirectHandler(autoTLSHTTPSPort)
 	}
+
+	// Serve the health endpoint over plain HTTP so container healthchecks can
+	// verify AutoTLS deployments. A localhost probe to the HTTPS listener on
+	// :443 fails autocert's HostPolicy (localhost is never whitelisted), and
+	// nothing listens on the plain web port in AutoTLS mode, so port 80 is the
+	// only address a self-check can reach without a valid certificate. This is
+	// checked ahead of the redirect so the probe receives JSON, not a 308.
+	fallback := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == healthCheckPath {
+			s.echo.ServeHTTP(w, r)
+			return
+		}
+		redirectOrNotFound.ServeHTTP(w, r)
+	})
 
 	return &http.Server{
 		Addr:         httpAddr,

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -810,7 +810,7 @@ func newHTTPSRedirectHandler(tlsPort string) http.Handler {
 			host = h
 		}
 		target := "https://" + host
-		if tlsPort != "443" {
+		if tlsPort != autoTLSHTTPSPort {
 			target += ":" + tlsPort
 		}
 		target += r.URL.RequestURI()

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -587,7 +587,7 @@ func (s *Server) Start() {
 	addr := s.config.Address()
 	switch {
 	case s.config.AutoTLS:
-		s.slogger.Info("HTTPS server starting with AutoTLS", logger.String("address", addr))
+		s.slogger.Info("HTTPS server starting with AutoTLS", logger.String("address", s.config.TLSAddress()))
 	case s.config.TLSEnabled:
 		s.slogger.Info("HTTPS server starting",
 			logger.String("https_address", s.config.TLSAddress()),
@@ -606,13 +606,12 @@ const autoTLSCacheDirName = "tls-acme"
 func (s *Server) startBlocking() error {
 	addr := s.config.Address()
 
-	s.slogger.Info("Starting HTTP server", logger.String("address", addr))
-
 	var err error
 	switch {
 	case s.config.AutoTLS:
 		// AutoTLS with Let's Encrypt
-		s.slogger.Info("Starting with AutoTLS (Let's Encrypt)")
+		tlsAddr := s.config.TLSAddress()
+		s.slogger.Info("Starting with AutoTLS (Let's Encrypt)", logger.String("https_address", tlsAddr))
 		// Configure persistent cert cache so certificates survive restarts.
 		// Without this, Echo's AutoTLSManager has no storage backend and certs
 		// are lost on every shutdown, triggering a fresh ACME request each time
@@ -639,7 +638,14 @@ func (s *Server) startBlocking() error {
 				Build()
 		}
 		s.echo.AutoTLSManager.HostPolicy = autocert.HostWhitelist(host)
-		err = s.echo.StartAutoTLS(addr)
+		if s.config.RedirectToHTTPS {
+			s.httpRedirectServer = s.newHTTPRedirectServer(s.config.AutoTLSHTTPAddress(), "443")
+			go s.serveHTTPRedirect()
+		}
+		err = s.echo.StartAutoTLS(tlsAddr)
+		if err != nil && s.httpRedirectServer != nil {
+			_ = s.httpRedirectServer.Close()
+		}
 	case s.config.TLSEnabled:
 		// Manual/Self-signed TLS: HTTPS on TLSPort, HTTP stays on configured port
 		tlsAddr := s.config.TLSAddress()
@@ -664,6 +670,7 @@ func (s *Server) startBlocking() error {
 		}
 	default:
 		// Plain HTTP
+		s.slogger.Info("Starting HTTP server", logger.String("address", addr))
 		err = s.echo.Start(addr)
 	}
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -587,7 +587,10 @@ func (s *Server) Start() {
 	addr := s.config.Address()
 	switch {
 	case s.config.AutoTLS:
-		s.slogger.Info("HTTPS server starting with AutoTLS", logger.String("address", s.config.TLSAddress()))
+		s.slogger.Info("HTTPS server starting with AutoTLS",
+			logger.String("https_address", s.config.TLSAddress()),
+			logger.String("http_address", s.config.AutoTLSHTTPAddress()),
+		)
 	case s.config.TLSEnabled:
 		s.slogger.Info("HTTPS server starting",
 			logger.String("https_address", s.config.TLSAddress()),
@@ -764,7 +767,7 @@ func (s *Server) newHTTPRedirectServer(httpAddr, tlsPort string) *http.Server {
 func (s *Server) newAutoTLSHTTPServer(httpAddr string) *http.Server {
 	fallback := http.NotFoundHandler()
 	if s.config.RedirectToHTTPS {
-		fallback = newHTTPSRedirectHandler("443")
+		fallback = newHTTPSRedirectHandler(autoTLSHTTPSPort)
 	}
 
 	return &http.Server{
@@ -777,7 +780,7 @@ func (s *Server) newAutoTLSHTTPServer(httpAddr string) *http.Server {
 
 func newHTTPSRedirectHandler(tlsPort string) http.Handler {
 	if tlsPort == "" {
-		tlsPort = "8443"
+		tlsPort = defaultManualTLSPort
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -638,10 +638,8 @@ func (s *Server) startBlocking() error {
 				Build()
 		}
 		s.echo.AutoTLSManager.HostPolicy = autocert.HostWhitelist(host)
-		if s.config.RedirectToHTTPS {
-			s.httpRedirectServer = s.newHTTPRedirectServer(s.config.AutoTLSHTTPAddress(), "443")
-			go s.serveHTTPRedirect()
-		}
+		s.httpRedirectServer = s.newAutoTLSHTTPServer(s.config.AutoTLSHTTPAddress())
+		go s.serveHTTPRedirect()
 		err = s.echo.StartAutoTLS(tlsAddr)
 		if err != nil && s.httpRedirectServer != nil {
 			_ = s.httpRedirectServer.Close()
@@ -752,11 +750,37 @@ func (s *Server) ShutdownWithContext(ctx context.Context) error {
 // newHTTPRedirectServer creates an HTTP server that redirects all requests to HTTPS.
 // The server is created synchronously to avoid a race between assignment and shutdown.
 func (s *Server) newHTTPRedirectServer(httpAddr, tlsPort string) *http.Server {
+	return &http.Server{
+		Addr:         httpAddr,
+		Handler:      newHTTPSRedirectHandler(tlsPort),
+		ReadTimeout:  s.config.ReadTimeout,
+		WriteTimeout: s.config.WriteTimeout,
+	}
+}
+
+// newAutoTLSHTTPServer creates the port-80 HTTP server required by autocert.
+// autocert.Manager.HTTPHandler intercepts ACME HTTP-01 challenges and delegates
+// non-challenge requests to the fallback redirect handler.
+func (s *Server) newAutoTLSHTTPServer(httpAddr string) *http.Server {
+	fallback := http.NotFoundHandler()
+	if s.config.RedirectToHTTPS {
+		fallback = newHTTPSRedirectHandler("443")
+	}
+
+	return &http.Server{
+		Addr:         httpAddr,
+		Handler:      s.echo.AutoTLSManager.HTTPHandler(fallback),
+		ReadTimeout:  s.config.ReadTimeout,
+		WriteTimeout: s.config.WriteTimeout,
+	}
+}
+
+func newHTTPSRedirectHandler(tlsPort string) http.Handler {
 	if tlsPort == "" {
 		tlsPort = "8443"
 	}
 
-	redirectHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Extract hostname, stripping any port from the Host header
 		host := r.Host
 		if h, _, err := net.SplitHostPort(r.Host); err == nil {
@@ -769,13 +793,6 @@ func (s *Server) newHTTPRedirectServer(httpAddr, tlsPort string) *http.Server {
 		target += r.URL.RequestURI()
 		http.Redirect(w, r, target, http.StatusPermanentRedirect)
 	})
-
-	return &http.Server{
-		Addr:         httpAddr,
-		Handler:      redirectHandler,
-		ReadTimeout:  s.config.ReadTimeout,
-		WriteTimeout: s.config.WriteTimeout,
-	}
 }
 
 // serveHTTPRedirect starts listening on the HTTP redirect server.

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+func TestNewAutoTLSHTTPServerHandlesACMEChallengeBeforeRedirect(t *testing.T) {
+	t.Parallel()
+
+	server := &Server{
+		echo: echo.New(),
+		config: &Config{
+			RedirectToHTTPS: true,
+			ReadTimeout:     DefaultConfig().ReadTimeout,
+			WriteTimeout:    DefaultConfig().WriteTimeout,
+		},
+	}
+
+	httpServer := server.newAutoTLSHTTPServer(":80")
+
+	redirectReq := httptest.NewRequest(http.MethodGet, "http://example.com/status", http.NoBody)
+	redirectRec := httptest.NewRecorder()
+	httpServer.Handler.ServeHTTP(redirectRec, redirectReq)
+
+	if got, want := redirectRec.Code, http.StatusPermanentRedirect; got != want {
+		t.Fatalf("non-challenge request status = %d, want %d", got, want)
+	}
+	if got, want := redirectRec.Header().Get("Location"), "https://example.com/status"; got != want {
+		t.Fatalf("non-challenge redirect location = %q, want %q", got, want)
+	}
+
+	challengeReq := httptest.NewRequest(http.MethodGet, "http://example.com/.well-known/acme-challenge/missing", http.NoBody)
+	challengeRec := httptest.NewRecorder()
+	httpServer.Handler.ServeHTTP(challengeRec, challengeReq)
+
+	if got, want := challengeRec.Code, http.StatusNotFound; got != want {
+		t.Fatalf("challenge request status = %d, want %d", got, want)
+	}
+	if got := challengeRec.Header().Get("Location"); got != "" {
+		t.Fatalf("challenge request unexpectedly redirected to %q", got)
+	}
+}
+
+func TestNewAutoTLSHTTPServerReturnsNotFoundWhenRedirectDisabled(t *testing.T) {
+	t.Parallel()
+
+	server := &Server{
+		echo: echo.New(),
+		config: &Config{
+			RedirectToHTTPS: false,
+			ReadTimeout:     DefaultConfig().ReadTimeout,
+			WriteTimeout:    DefaultConfig().WriteTimeout,
+		},
+	}
+
+	httpServer := server.newAutoTLSHTTPServer(":80")
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/status", http.NoBody)
+	rec := httptest.NewRecorder()
+	httpServer.Handler.ServeHTTP(rec, req)
+
+	if got, want := rec.Code, http.StatusNotFound; got != want {
+		t.Fatalf("non-challenge request status = %d, want %d", got, want)
+	}
+	if got := rec.Header().Get("Location"); got != "" {
+		t.Fatalf("non-challenge request unexpectedly redirected to %q", got)
+	}
+}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/labstack/echo/v4"
@@ -67,5 +68,41 @@ func TestNewAutoTLSHTTPServerReturnsNotFoundWhenRedirectDisabled(t *testing.T) {
 	}
 	if got := rec.Header().Get("Location"); got != "" {
 		t.Fatalf("non-challenge request unexpectedly redirected to %q", got)
+	}
+}
+
+func TestNewAutoTLSHTTPServerServesHealthOverPlainHTTP(t *testing.T) {
+	t.Parallel()
+
+	e := echo.New()
+	e.GET(healthCheckPath, func(c echo.Context) error {
+		return c.JSON(http.StatusOK, map[string]any{"status": "healthy"})
+	})
+
+	server := &Server{
+		echo: e,
+		// RedirectToHTTPS is on so a plain request would normally 308; the health
+		// endpoint must still be served directly so container healthchecks can
+		// probe AutoTLS deployments on port 80.
+		config: &Config{
+			RedirectToHTTPS: true,
+			ReadTimeout:     DefaultConfig().ReadTimeout,
+			WriteTimeout:    DefaultConfig().WriteTimeout,
+		},
+	}
+
+	httpServer := server.newAutoTLSHTTPServer(":80")
+	req := httptest.NewRequest(http.MethodGet, "http://example.com"+healthCheckPath, http.NoBody)
+	rec := httptest.NewRecorder()
+	httpServer.Handler.ServeHTTP(rec, req)
+
+	if got, want := rec.Code, http.StatusOK; got != want {
+		t.Fatalf("health status = %d, want %d", got, want)
+	}
+	if got := rec.Header().Get("Location"); got != "" {
+		t.Fatalf("health request unexpectedly redirected to %q", got)
+	}
+	if got := rec.Body.String(); !strings.Contains(got, `"status":"healthy"`) {
+		t.Fatalf("health body = %q, want it to contain healthy status", got)
 	}
 }

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -392,11 +392,17 @@ BIND_METRICS_PORT="false"; METRICS_BIND_ADDR=""; CONFIGURED_TZ="UTC"
 unit_content="$(generate_systemd_service_content)"
 autotls_cap_count="$(printf '%s\n' "$unit_content" | grep -c -- '--cap-add NET_BIND_SERVICE' || true)"
 assert_eq "AutoTLS unit grants low-port bind capability" "1" "$autotls_cap_count"
+# AutoTLS serves the UI on 443 and the HTTP entrypoint on 80; the container never
+# listens on 8080, so the dead web mapping must not be published.
+autotls_web_count="$(printf '%s\n' "$unit_content" | grep -c -- ':8080' || true)"
+assert_eq "AutoTLS unit does not publish the dead 8080 mapping" "0" "$autotls_web_count"
 
 BIND_TLS_PORTS="false"
 unit_content="$(generate_systemd_service_content)"
 plain_cap_count="$(printf '%s\n' "$unit_content" | grep -c -- '--cap-add NET_BIND_SERVICE' || true)"
 assert_eq "plain HTTP unit does not grant low-port bind capability" "0" "$plain_cap_count"
+plain_web_count="$(printf '%s\n' "$unit_content" | grep -c -- ':8080' || true)"
+assert_eq "plain HTTP unit publishes the web port mapping" "1" "$plain_web_count"
 
 # The container entrypoint drops from root to BIRDNET_UID with gosu before
 # launching birdnet-go. Docker's --cap-add keeps NET_BIND_SERVICE in the

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -398,6 +398,17 @@ unit_content="$(generate_systemd_service_content)"
 plain_cap_count="$(printf '%s\n' "$unit_content" | grep -c -- '--cap-add NET_BIND_SERVICE' || true)"
 assert_eq "plain HTTP unit does not grant low-port bind capability" "0" "$plain_cap_count"
 
+# The container entrypoint drops from root to BIRDNET_UID with gosu before
+# launching birdnet-go. Docker's --cap-add keeps NET_BIND_SERVICE in the
+# container bounding set, but the binary also needs a file capability so the
+# non-root process can bind ports 80/443 after the uid switch.
+it "Dockerfile grants birdnet-go low-port bind file capability"
+dockerfile_content="$(cat "${REPO_ROOT}/Dockerfile")"
+libcap_count="$(printf '%s\n' "$dockerfile_content" | grep -c -- 'libcap2-bin' || true)"
+setcap_count="$(printf '%s\n' "$dockerfile_content" | grep -c -- 'setcap cap_net_bind_service=+ep /usr/bin/birdnet-go' || true)"
+assert_eq "Docker image installs setcap tool" "1" "$libcap_count"
+assert_eq "Docker image grants birdnet-go CAP_NET_BIND_SERVICE" "1" "$setcap_count"
+
 # ===========================================================================
 # apply_tls_settings (full slate; mode switch must clear stale host)
 # ===========================================================================

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -91,6 +91,9 @@ print_message() { :; }
 log_message() { :; }
 log_command_result() { :; }
 command_exists() { command -v "$1" >/dev/null 2>&1; }
+check_directory_exists() { return 1; }
+is_raspberry_pi() { return 1; }
+resolve_host_timezone() { printf '%s' "$1"; }
 
 # Globals the extracted functions reference (install.sh defines these at the top; the harness
 # only pulls function bodies, so under set -u they must exist here).
@@ -98,6 +101,16 @@ RED=""; GREEN=""; YELLOW=""; NC=""; GRAY=""
 CONFIG_FILE=""
 SILENT_MODE=""
 BIRDNET_PASSWORD=""
+CONFIG_DIR="/tmp/birdnet-go-test-config"
+DATA_DIR="/tmp/birdnet-go-test-data"
+BIRDNET_GO_IMAGE="ghcr.io/tphakala/birdnet-go:nightly"
+WEB_PORT="8080"
+WEB_PORT_BIND_ADDR=""
+BIND_TLS_PORTS="false"
+TLS_BIND_ADDR=""
+BIND_METRICS_PORT="false"
+METRICS_BIND_ADDR=""
+CONFIGURED_TZ="UTC"
 
 # Load the helpers under test (order matters: callees before callers).
 for fn in \
@@ -108,6 +121,7 @@ for fn in \
     set_first_audio_source \
     _extract_bind_addr \
     load_existing_service_config \
+    generate_systemd_service_content \
     apply_tls_settings \
     ensure_internal_port_8080 \
     configure_rtsp_in_config \
@@ -367,6 +381,22 @@ load_existing_service_config "$unit"
 assert_eq "web-only: port restored" "8080" "$WEB_PORT"
 assert_eq "web-only: TLS stays off" "false" "$BIND_TLS_PORTS"
 assert_eq "web-only: metrics stays off" "false" "$BIND_METRICS_PORT"
+
+# ===========================================================================
+# generate_systemd_service_content
+# ===========================================================================
+it "generate_systemd_service_content"
+
+WEB_PORT="8080"; WEB_PORT_BIND_ADDR=""; BIND_TLS_PORTS="true"; TLS_BIND_ADDR=""
+BIND_METRICS_PORT="false"; METRICS_BIND_ADDR=""; CONFIGURED_TZ="UTC"
+unit_content="$(generate_systemd_service_content)"
+autotls_cap_count="$(printf '%s\n' "$unit_content" | grep -c -- '--cap-add NET_BIND_SERVICE' || true)"
+assert_eq "AutoTLS unit grants low-port bind capability" "1" "$autotls_cap_count"
+
+BIND_TLS_PORTS="false"
+unit_content="$(generate_systemd_service_content)"
+plain_cap_count="$(printf '%s\n' "$unit_content" | grep -c -- '--cap-add NET_BIND_SERVICE' || true)"
+assert_eq "plain HTTP unit does not grant low-port bind capability" "0" "$plain_cap_count"
 
 # ===========================================================================
 # apply_tls_settings (full slate; mode switch must clear stale host)


### PR DESCRIPTION
## Summary

Fixes AutoTLS startup so it uses the ACME-required standard ports in container installs.

## Changes

- Bind AutoTLS HTTPS on `:443` and start the HTTP-to-HTTPS redirect listener on `:80`.
- Add `--cap-add NET_BIND_SERVICE` to generated container systemd units when TLS binding is enabled.
- Add focused regression coverage for AutoTLS addresses and generated install service flags.

## Testing

- [x] Go lint passes: `golangci-lint run -v --build-tags=noembed,skipfrontend`
- [x] Go tests pass: `go test -race -tags noembed,skipfrontend ./...`
- [x] Frontend checks pass: `npm run check:all`
- [x] Frontend tests pass: `npm test -- --run`
- [x] Install script tests pass: `scripts/install_test.sh`
- [x] Manual testing completed: generated systemd service content inspected by regression test
- [x] Preflight quality gate passed (AI-assisted PR)

## Preflight Status

- Scope: one bug fix for AutoTLS standard-port binding and installer container capability support.
- Findings fixed during preflight: corrected stale AutoTLS startup logging so it reports the actual HTTPS bind address.
- Local review passes completed: reuse, correctness/safety, quality, i18n applicability, integration wiring, and regression/backward compatibility.
- Secondary model review unavailable locally: `gemini` command not installed.

## Related Issues

Fixes #3527 (AutoTLS binds HTTPS to 8080 with no cert instead of 443; expected 80→443 redirect with a working cert)
Refs #3000

## Breaking Changes

None. This only changes AutoTLS mode to bind the ports ACME HTTP-01 expects and grants the generated container unit permission to bind those privileged ports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AutoTLS now uses standard HTTPS (443) and HTTP→HTTPS redirect (80) ports.
  * System startup logs now show the AutoTLS HTTPS endpoint and the port-80 redirect address.

* **Bug Fixes**
  * AutoTLS no longer publishes an unused host port, and it reliably supports binding to privileged ports when AutoTLS is enabled.
  * Improved AutoTLS redirect/health handling, including clean shutdown if AutoTLS fails to start.

* **Tests**
  * Added coverage for standard-port selection, redirect behavior, health responses, and generated system startup rules.

* **Chores**
  * Updated container health checks to probe AutoTLS health over port 80.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
