### PR TITLE
fix(api): review dialog's ignore-species checkbox never actually ignored anything

### DIFF
--- a/internal/api/v2/detections/detections.go
+++ b/internal/api/v2/detections/detections.go
@@ -198,7 +198,7 @@ type WeatherInfo struct {
 type DetectionRequest struct {
 	Comment       string `json:"comment,omitempty"`
 	Verified      string `json:"verified,omitempty"`
-	IgnoreSpecies string `json:"ignoreSpecies,omitempty"`
+	IgnoreSpecies string `json:"ignore_species,omitempty"`
 	Locked        bool   `json:"locked,omitempty"`
 	LockDetection bool   `json:"lock_detection,omitempty"`
 }

--- a/internal/api/v2/detections/detections_test.go
+++ b/internal/api/v2/detections/detections_test.go
@@ -1411,7 +1411,7 @@ func TestReviewDetectionFalsePositiveLocalizedResolution(t *testing.T) {
 	setupValidReviewMock(&mockDS.Mock, "7", 7, false)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v2/detections/7/review",
-		strings.NewReader(`{"verified": "false_positive", "ignoreSpecies": "mopsilepakko"}`))
+		strings.NewReader(`{"verified": "false_positive", "ignore_species": "mopsilepakko"}`))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)


### PR DESCRIPTION
Fixes #3674

## What was wrong

The review modal sends `ignore_species` in the POST body, but `DetectionRequest` binds `ignoreSpecies`. The two never matched, so the field always came through empty and `addToIgnoredSpecies()` quietly did nothing. The "Ignore this species" checkbox has been purely decorative.

The support bot pointed #3674 at #3637, but that PR fixed the detection-card *menu* path — it never touched `ReviewModal.svelte`/`ReviewCard.svelte`, which is the flow the reporter is using. So this would still be broken in the next nightly without this fix.

## The fix

One line: flip the struct tag to `ignore_species`, which is what both ReviewModal and ReviewCard actually send — and matches the snake_case of its own neighbour `lock_detection`, plus `common_name` over on the `/detections/ignore` endpoint. The camelCase tag was the odd one out.

My favourite detail: the existing false-positive review test was green this whole time because it was written against the backend's tag instead of the real UI payload — a test faithfully verifying the bug. I flipped its JSON literal to what the UI sends, so it now doubles as the regression test: fails on main, passes here.

## How I tested

- `go test -race -short ./internal/api/v2/detections/` — red before the tag change (species never lands in the exclude list), green after
- Full `./internal/api/v2/...` suite with `-race`: everything green except `TestAudioExportPartialUpdate` and three media tests, which fail identically on *unmodified main* on my machine — they want ffmpeg/sox which I don't have installed. Not related to this change.
- `golangci-lint run --new-from-rev=main` on the package: 0 new issues

## One thing to be aware of

If anyone scripted the review endpoint with camelCase `ignoreSpecies`, this changes that contract. I checked before picking a side: it's not in the API README, nothing in the repo sends it, and the shipped UI never worked — so fixing the backend to match the UI seemed right. If you'd rather accept both keys for safety, happy to add that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the detection review request to use the expected `ignore_species` field name in API requests.
  * Improved compatibility for clients sending detection-related data in snake_case format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->