### PR TITLE
fix(security): derive session cookie Secure flag from effective TLS state

### DIFF
--- a/internal/analysis/api_service.go
+++ b/internal/analysis/api_service.go
@@ -170,8 +170,12 @@ func (s *APIServerService) Start(ctx context.Context) error {
 	serviceCtx, cancel := context.WithCancel(ctx)
 	s.cancel = cancel
 
-	// Create OAuth2 server.
-	s.oauth2Server = security.NewOAuth2Server(serviceCtx)
+	// Create OAuth2 server. Session/auth cookies must be Secure only when clients
+	// reach the app over HTTPS; derive that from the effective web-server TLS
+	// config, which knows the AutoTLS redirect default and cert presence that the
+	// persisted settings alone cannot express.
+	webCfg := api.ConfigFromSettings(s.settings)
+	s.oauth2Server = security.NewOAuth2Server(serviceCtx, webCfg.SessionCookiesSecure(s.settings))
 
 	// Create and start the HTTP API server.
 	GetLogger().Info("starting HTTP server")

--- a/internal/api/autotls_test.go
+++ b/internal/api/autotls_test.go
@@ -45,6 +45,84 @@ func TestConfigFromSettings_AutoTLS(t *testing.T) {
 		"redirect authority should be the advertised host, not the internal TLS port")
 }
 
+// TestConfig_SessionCookiesSecure verifies the effective-TLS predicate that
+// decides the Secure attribute on session/auth cookies. The critical case is
+// AutoTLS with RedirectToHTTPS disabled: startBlocking then serves the app over
+// plain HTTP on the ACME listener, so Secure must be false there or login (which
+// the session cookie also gates for basic auth) breaks over that HTTP path.
+func TestConfig_SessionCookiesSecure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  Config
+		baseURL string
+		want    bool
+	}{
+		{
+			name:   "AutoTLS with redirect (default) - secure",
+			config: Config{TLSEnabled: true, AutoTLS: true, RedirectToHTTPS: true},
+			want:   true,
+		},
+		{
+			name:   "AutoTLS without redirect serves app on HTTP - not secure",
+			config: Config{TLSEnabled: true, AutoTLS: true, RedirectToHTTPS: false},
+			want:   false,
+		},
+		{
+			name:   "manual TLS without redirect (HTTPS-only listener) - secure",
+			config: Config{TLSEnabled: true, AutoTLS: false, RedirectToHTTPS: false},
+			want:   true,
+		},
+		{
+			name:   "manual TLS with redirect - secure",
+			config: Config{TLSEnabled: true, AutoTLS: false, RedirectToHTTPS: true},
+			want:   true,
+		},
+		{
+			name:   "TLS mode selected but certs missing (plain HTTP fallback) - not secure",
+			config: Config{TLSEnabled: false, AutoTLS: false, RedirectToHTTPS: false},
+			want:   false,
+		},
+		{
+			// The RedirectToHTTPS clause secures independently of the TLS-mode
+			// clause. In practice ConfigFromSettings only sets RedirectToHTTPS
+			// together with TLSEnabled, but the predicate must handle the flag on
+			// its own.
+			name:   "redirect-to-HTTPS flag forces secure",
+			config: Config{RedirectToHTTPS: true},
+			want:   true,
+		},
+		{
+			name:    "reverse proxy https BaseURL, no app TLS - secure",
+			config:  Config{TLSEnabled: false, RedirectToHTTPS: false},
+			baseURL: "https://" + testHost,
+			want:    true,
+		},
+		{
+			name:    "reverse proxy http BaseURL, no app TLS - not secure",
+			config:  Config{TLSEnabled: false, RedirectToHTTPS: false},
+			baseURL: "http://" + testHost,
+			want:    false,
+		},
+		{
+			name:   "plain HTTP, nothing set - not secure",
+			config: Config{},
+			want:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			settings := &conf.Settings{Security: conf.Security{BaseURL: tc.baseURL}}
+			got := tc.config.SessionCookiesSecure(settings)
+			assert.Equal(t, tc.want, got, "Config.SessionCookiesSecure()")
+		})
+	}
+}
+
 // TestConfigFromSettings_AutoTLS_CustomTLSPort verifies that a user-configured
 // TLS port is respected in AutoTLS mode.
 func TestConfigFromSettings_AutoTLS_CustomTLSPort(t *testing.T) {

--- a/internal/api/autotls_test.go
+++ b/internal/api/autotls_test.go
@@ -70,6 +70,14 @@ func TestConfig_SessionCookiesSecure(t *testing.T) {
 			want:   false,
 		},
 		{
+			// AutoTLS+redirect-off serves the app over plain HTTP directly, so an
+			// advertised https BaseURL must NOT force Secure (would break HTTP login).
+			name:    "AutoTLS without redirect and https BaseURL still serves HTTP - not secure",
+			config:  Config{TLSEnabled: true, AutoTLS: true, RedirectToHTTPS: false},
+			baseURL: "https://" + testHost,
+			want:    false,
+		},
+		{
 			name:   "manual TLS without redirect (HTTPS-only listener) - secure",
 			config: Config{TLSEnabled: true, AutoTLS: false, RedirectToHTTPS: false},
 			want:   true,
@@ -121,6 +129,18 @@ func TestConfig_SessionCookiesSecure(t *testing.T) {
 			assert.Equal(t, tc.want, got, "Config.SessionCookiesSecure()")
 		})
 	}
+
+	t.Run("nil-safety", func(t *testing.T) {
+		t.Parallel()
+		// nil settings skips the BaseURL clause and falls through to the Config clauses.
+		assert.True(t, (&Config{RedirectToHTTPS: true}).SessionCookiesSecure(nil),
+			"nil settings must still honor the RedirectToHTTPS clause")
+		assert.False(t, (&Config{}).SessionCookiesSecure(nil),
+			"nil settings with no TLS config is not secure")
+		// nil receiver is safe.
+		var nilCfg *Config
+		assert.False(t, nilCfg.SessionCookiesSecure(nil), "nil *Config must not panic and returns false")
+	})
 }
 
 // TestConfigFromSettings_AutoTLS_CustomTLSPort verifies that a user-configured

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -194,6 +194,38 @@ func ConfigFromSettings(settings *conf.Settings) *Config {
 	return cfg
 }
 
+// SessionCookiesSecure reports whether session and auth cookies should carry the
+// Secure attribute, i.e. whether clients reach the app over HTTPS given the
+// EFFECTIVE server configuration (not merely the persisted redirect toggle). It
+// is true when any of the following hold:
+//   - a reverse proxy terminates TLS and the canonical BaseURL uses https;
+//   - the app redirects all HTTP traffic to HTTPS (RedirectToHTTPS), so every
+//     client ends up on HTTPS;
+//   - the app terminates TLS itself and serves no plain-HTTP app listener, i.e.
+//     manual or self-signed TLS with certificates present (TLSEnabled without
+//     AutoTLS). Manual/self-signed either redirects or listens HTTPS-only, so the
+//     browser always reaches it over HTTPS.
+//
+// AutoTLS is deliberately excluded from the last clause: with RedirectToHTTPS
+// disabled, AutoTLS serves the full app over plain HTTP on the ACME listener too
+// (see Server.startBlocking), so forcing Secure there would drop the session
+// cookie (which also authenticates basic auth) and break login over that HTTP
+// path. When AutoTLS does redirect (its default), the RedirectToHTTPS clause
+// already yields true. Missing manual/self-signed certs leave TLSEnabled false,
+// correctly yielding a non-Secure cookie for the plain-HTTP fallback.
+//
+// The settings argument supplies BaseURL, which Config intentionally does not
+// carry.
+func (c *Config) SessionCookiesSecure(settings *conf.Settings) bool {
+	if settings.Security.IsHTTPSBaseURL() {
+		return true
+	}
+	if c.RedirectToHTTPS {
+		return true
+	}
+	return c.TLSEnabled && !c.AutoTLS
+}
+
 // Validate checks the configuration for errors.
 func (c *Config) Validate() error {
 	if c.Port == "" {

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -196,8 +196,15 @@ func ConfigFromSettings(settings *conf.Settings) *Config {
 
 // SessionCookiesSecure reports whether session and auth cookies should carry the
 // Secure attribute, i.e. whether clients reach the app over HTTPS given the
-// EFFECTIVE server configuration (not merely the persisted redirect toggle). It
-// is true when any of the following hold:
+// EFFECTIVE server configuration (not merely the persisted redirect toggle).
+//
+// AutoTLS with the HTTP->HTTPS redirect disabled is handled first: that mode
+// deliberately serves the full app over plain HTTP on the ACME listener (see
+// Server.startBlocking), so Secure must never be forced there, even when an
+// https BaseURL is advertised. Forcing it would drop the session cookie (which
+// also authenticates basic auth) and break login over that direct HTTP path.
+//
+// Otherwise it is true when any of the following hold:
 //   - a reverse proxy terminates TLS and the canonical BaseURL uses https;
 //   - the app redirects all HTTP traffic to HTTPS (RedirectToHTTPS), so every
 //     client ends up on HTTPS;
@@ -206,18 +213,19 @@ func ConfigFromSettings(settings *conf.Settings) *Config {
 //     AutoTLS). Manual/self-signed either redirects or listens HTTPS-only, so the
 //     browser always reaches it over HTTPS.
 //
-// AutoTLS is deliberately excluded from the last clause: with RedirectToHTTPS
-// disabled, AutoTLS serves the full app over plain HTTP on the ACME listener too
-// (see Server.startBlocking), so forcing Secure there would drop the session
-// cookie (which also authenticates basic auth) and break login over that HTTP
-// path. When AutoTLS does redirect (its default), the RedirectToHTTPS clause
-// already yields true. Missing manual/self-signed certs leave TLSEnabled false,
-// correctly yielding a non-Secure cookie for the plain-HTTP fallback.
-//
-// The settings argument supplies BaseURL, which Config intentionally does not
-// carry.
+// Missing manual/self-signed certs leave TLSEnabled false, correctly yielding a
+// non-Secure cookie for the plain-HTTP fallback. The settings argument supplies
+// BaseURL, which Config intentionally does not carry.
 func (c *Config) SessionCookiesSecure(settings *conf.Settings) bool {
-	if settings.Security.IsHTTPSBaseURL() {
+	if c == nil {
+		return false
+	}
+	// AutoTLS without the redirect serves the app over plain HTTP directly, so
+	// keep Secure off regardless of any advertised https BaseURL.
+	if c.AutoTLS && !c.RedirectToHTTPS {
+		return false
+	}
+	if settings != nil && settings.Security.IsHTTPSBaseURL() {
 		return true
 	}
 	if c.RedirectToHTTPS {

--- a/internal/conf/security_helpers.go
+++ b/internal/conf/security_helpers.go
@@ -110,9 +110,12 @@ func (s *Security) GetExternalHost() string {
 // alone is ambiguous (it may front a plain-HTTP LAN deployment), so relying on it
 // could over-set Secure and drop the session cookie over HTTP.
 func (s *Security) IsHTTPSBaseURL() bool {
-	if s.BaseURL == "" {
+	if s == nil || s.BaseURL == "" {
 		return false
 	}
 	u, err := url.Parse(strings.TrimSpace(s.BaseURL))
-	return err == nil && u.Scheme == SchemeHTTPS
+	// Require a real authority: url.Parse treats "https:" and the opaque
+	// "https:host" as scheme https with an empty Host, which is not a usable
+	// external URL and must not be treated as HTTPS.
+	return err == nil && u.Scheme == SchemeHTTPS && u.Host != ""
 }

--- a/internal/conf/security_helpers.go
+++ b/internal/conf/security_helpers.go
@@ -100,3 +100,19 @@ func (s *Security) GetExternalHost() string {
 	// Priority 2: Fall back to Host
 	return s.Host
 }
+
+// IsHTTPSBaseURL reports whether the canonical external BaseURL uses the https
+// scheme, which indicates that a reverse proxy terminates TLS upstream while the
+// app itself may serve plain HTTP. It is used to decide whether clients reach the
+// app over HTTPS in reverse-proxy deployments (e.g. for the Secure cookie flag).
+//
+// A bare Host without an https BaseURL is deliberately NOT treated as HTTPS: Host
+// alone is ambiguous (it may front a plain-HTTP LAN deployment), so relying on it
+// could over-set Secure and drop the session cookie over HTTP.
+func (s *Security) IsHTTPSBaseURL() bool {
+	if s.BaseURL == "" {
+		return false
+	}
+	u, err := url.Parse(strings.TrimSpace(s.BaseURL))
+	return err == nil && u.Scheme == SchemeHTTPS
+}

--- a/internal/conf/security_helpers_test.go
+++ b/internal/conf/security_helpers_test.go
@@ -433,3 +433,67 @@ func TestSecurity_GetExternalHost_ConcurrentAccess(t *testing.T) {
 		assert.Equal(t, expectedHost, result, "Goroutine %d returned unexpected result", i)
 	}
 }
+
+// TestSecurity_IsHTTPSBaseURL tests the IsHTTPSBaseURL helper that reports whether
+// the canonical external BaseURL uses the https scheme (reverse-proxy TLS).
+func TestSecurity_IsHTTPSBaseURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		security Security
+		want     bool
+	}{
+		{
+			name:     "no BaseURL - false",
+			security: Security{},
+			want:     false,
+		},
+		{
+			name:     "https BaseURL - true",
+			security: Security{BaseURL: testURLHTTPSNoPort},
+			want:     true,
+		},
+		{
+			name:     "https BaseURL with surrounding whitespace - true",
+			security: Security{BaseURL: "  " + testURLHTTPSNoPort + "  "},
+			want:     true,
+		},
+		{
+			name:     "uppercase HTTPS scheme - true (scheme normalized by url.Parse)",
+			security: Security{BaseURL: "HTTPS://" + testHostExample},
+			want:     true,
+		},
+		{
+			name:     "http BaseURL - false",
+			security: Security{BaseURL: testURLHTTPNoPort},
+			want:     false,
+		},
+		{
+			name:     "bare host without scheme - false",
+			security: Security{BaseURL: testHostExample},
+			want:     false,
+		},
+		{
+			name:     "invalid BaseURL (parses with empty scheme) - false",
+			security: Security{BaseURL: testURLInvalid},
+			want:     false,
+		},
+		{
+			// url.Parse returns an error here (unterminated IPv6 host), exercising
+			// the err != nil branch, which must yield false.
+			name:     "malformed BaseURL (parse error) - false",
+			security: Security{BaseURL: "http://[::1"},
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.security.IsHTTPSBaseURL()
+			assert.Equal(t, tt.want, got, "Security.IsHTTPSBaseURL()")
+		})
+	}
+}

--- a/internal/conf/security_helpers_test.go
+++ b/internal/conf/security_helpers_test.go
@@ -470,6 +470,16 @@ func TestSecurity_IsHTTPSBaseURL(t *testing.T) {
 			want:     false,
 		},
 		{
+			name:     "https scheme with no authority - false",
+			security: Security{BaseURL: "https:"},
+			want:     false,
+		},
+		{
+			name:     "opaque https URL (no host) - false",
+			security: Security{BaseURL: "https:" + testHostExample},
+			want:     false,
+		},
+		{
 			name:     "bare host without scheme - false",
 			security: Security{BaseURL: testHostExample},
 			want:     false,
@@ -496,4 +506,10 @@ func TestSecurity_IsHTTPSBaseURL(t *testing.T) {
 			assert.Equal(t, tt.want, got, "Security.IsHTTPSBaseURL()")
 		})
 	}
+
+	t.Run("nil receiver is safe", func(t *testing.T) {
+		t.Parallel()
+		var nilSec *Security
+		assert.False(t, nilSec.IsHTTPSBaseURL(), "nil *Security must not panic and returns false")
+	})
 }

--- a/internal/security/oauth.go
+++ b/internal/security/oauth.go
@@ -419,6 +419,12 @@ func (s *OAuth2Server) setupTokenPersistence() {
 // the Secure attribute on the session store's cookies; the caller derives it from
 // the effective web-server TLS configuration (api.Config.SessionCookiesSecure).
 func InitializeGoth(settings *conf.Settings, secureCookies bool) {
+	if settings == nil {
+		// settings is a required dependency: setupSessionStore and
+		// initializeProviders both dereference it. Fail fast with a clear message
+		// instead of a confusing nil dereference deeper in initialization.
+		panic("security.InitializeGoth: settings must not be nil")
+	}
 	GetLogger().Info("Initializing Goth providers")
 
 	// Setup session store (filesystem or fallback to cookie-based)

--- a/internal/security/oauth.go
+++ b/internal/security/oauth.go
@@ -227,6 +227,12 @@ type OAuth2Server struct {
 
 	// Throttling
 	throttledMessages map[string]time.Time
+
+	// secureCookies records whether session/auth cookies must carry the Secure
+	// attribute. It is decided by the caller from the effective web-server TLS
+	// config (the security package cannot import internal/api to derive it) and
+	// reused when providers are re-initialized on a settings reload.
+	secureCookies bool
 }
 
 // currentSettings returns the latest settings snapshot so security
@@ -255,7 +261,12 @@ var (
 // governs background goroutines owned by the server (currently the periodic
 // expired-token cleanup); cancelling it stops them, giving the cleanup goroutine
 // a proper shutdown path instead of running for the process lifetime.
-func NewOAuth2Server(ctx context.Context) *OAuth2Server {
+//
+// secureCookies controls the Secure attribute on the session/auth cookies. The
+// caller decides it from the effective web-server TLS configuration (see
+// api.Config.SessionCookiesSecure), since the security package cannot import
+// internal/api.
+func NewOAuth2Server(ctx context.Context, secureCookies bool) *OAuth2Server {
 	// Re-enable OIDC discovery retries for this instance, clearing any disabled
 	// state a previous instance's shutdown left behind (sequential tests).
 	enableOIDCRetries()
@@ -264,16 +275,17 @@ func NewOAuth2Server(ctx context.Context) *OAuth2Server {
 	settings := conf.GetSettings()
 
 	server := &OAuth2Server{
-		settings:     settings,
-		authCodes:    make(map[string]AuthCode),
-		accessTokens: make(map[string]AccessToken),
+		settings:      settings,
+		authCodes:     make(map[string]AuthCode),
+		accessTokens:  make(map[string]AccessToken),
+		secureCookies: secureCookies,
 	}
 
 	// Validate and potentially fix session secret
 	validateSessionSecret(settings)
 
 	// Initialize Gothic with the provided configuration
-	InitializeGoth(settings)
+	InitializeGoth(settings, secureCookies)
 
 	// Set up token persistence
 	server.setupTokenPersistence()
@@ -403,12 +415,14 @@ func (s *OAuth2Server) setupTokenPersistence() {
 	}
 }
 
-// InitializeGoth initializes social authentication providers.
-func InitializeGoth(settings *conf.Settings) {
+// InitializeGoth initializes social authentication providers. secureCookies sets
+// the Secure attribute on the session store's cookies; the caller derives it from
+// the effective web-server TLS configuration (api.Config.SessionCookiesSecure).
+func InitializeGoth(settings *conf.Settings, secureCookies bool) {
 	GetLogger().Info("Initializing Goth providers")
 
 	// Setup session store (filesystem or fallback to cookie-based)
-	setupSessionStore(settings)
+	setupSessionStore(settings, secureCookies)
 
 	// Initialize OAuth providers
 	initializeProviders(settings)
@@ -416,13 +430,29 @@ func InitializeGoth(settings *conf.Settings) {
 
 // setupSessionStore configures the Gothic session store.
 // It attempts to use a filesystem store, falling back to an in-memory cookie store on failure.
-func setupSessionStore(settings *conf.Settings) {
+// secureCookies sets the Secure attribute on the session cookies; it is derived by
+// the caller from the effective web-server TLS configuration.
+func setupSessionStore(settings *conf.Settings, secureCookies bool) {
 	secLog := GetLogger()
+
+	maxAge := DefaultSessionMaxAgeSeconds
+	if settings.Security.SessionDuration > 0 {
+		maxAge = int(settings.Security.SessionDuration.Seconds())
+	}
+
+	// newCookieStoreFallback builds the in-memory fallback store with the same
+	// cookie hardening (Secure, HttpOnly, SameSite) as the filesystem store, so a
+	// fallback does not silently drop the Secure attribute the caller requested.
+	newCookieStoreFallback := func() *sessions.CookieStore {
+		store := sessions.NewCookieStore(createSessionKey(settings.Security.SessionSecret))
+		store.Options = buildSessionOptions(secureCookies, maxAge)
+		return store
+	}
 
 	sessionPath, ok := getSessionPath()
 	if !ok {
 		// Fallback to in-memory store if config paths can't be retrieved
-		gothic.Store = sessions.NewCookieStore(createSessionKey(settings.Security.SessionSecret))
+		gothic.Store = newCookieStoreFallback()
 		return
 	}
 
@@ -431,7 +461,7 @@ func setupSessionStore(settings *conf.Settings) {
 	// Ensure directory exists
 	if err := os.MkdirAll(sessionPath, DirPermissions); err != nil {
 		secLog.Error("Failed to create session directory, falling back to in-memory cookie store", logger.Error(err))
-		gothic.Store = sessions.NewCookieStore(createSessionKey(settings.Security.SessionSecret))
+		gothic.Store = newCookieStoreFallback()
 		return
 	}
 
@@ -447,13 +477,8 @@ func setupSessionStore(settings *conf.Settings) {
 
 	// Configure session store options
 	store := gothic.Store.(*sessions.FilesystemStore)
-	maxAge := DefaultSessionMaxAgeSeconds
-	if settings.Security.SessionDuration > 0 {
-		maxAge = int(settings.Security.SessionDuration.Seconds())
-	}
-	secureCookie := settings.Security.RedirectToHTTPS
-	store.Options = buildSessionOptions(secureCookie, maxAge)
-	secLog.Info("Filesystem session store configured", logger.Int("max_age_seconds", maxAge), logger.Bool("secure", secureCookie))
+	store.Options = buildSessionOptions(secureCookies, maxAge)
+	secLog.Info("Filesystem session store configured", logger.Int("max_age_seconds", maxAge), logger.Bool("secure", secureCookies))
 
 	// Set reasonable values for session cookie storage
 	store.MaxLength(MaxSessionSizeBytes)
@@ -668,7 +693,7 @@ func SetTestConfigPath(path string) {
 func (s *OAuth2Server) UpdateProviders() {
 	GetLogger().Info("Updating Goth providers based on potentially changed settings")
 	cancelAllOIDCRetries()
-	InitializeGoth(s.currentSettings())
+	InitializeGoth(s.currentSettings(), s.secureCookies)
 }
 
 // IsUserAuthenticated checks if the user is authenticated

--- a/internal/security/oauth_test.go
+++ b/internal/security/oauth_test.go
@@ -26,7 +26,7 @@ func TestIsUserAuthenticatedValidAccessToken(t *testing.T) {
 	settings := conftest.NewTestSettings().Apply()
 	t.Cleanup(func() { conftest.NewTestSettings().Apply() })
 
-	s := NewOAuth2Server(t.Context())
+	s := NewOAuth2Server(t.Context(), false)
 
 	// Initialize gothic exactly as in production
 	gothic.Store = sessions.NewCookieStore([]byte(settings.Security.SessionSecret))
@@ -76,7 +76,7 @@ func TestIsUserAuthenticatedTableDriven(t *testing.T) {
 				},
 			}
 
-			s := NewOAuth2Server(t.Context())
+			s := NewOAuth2Server(t.Context(), false)
 
 			// Initialize gothic exactly as in production
 			gothic.Store = sessions.NewCookieStore([]byte(settings.Security.SessionSecret))
@@ -161,7 +161,7 @@ func TestOAuth2Server(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewOAuth2Server(t.Context())
+			s := NewOAuth2Server(t.Context(), false)
 			tt.test(t, s)
 		})
 	}

--- a/internal/security/persistence_test.go
+++ b/internal/security/persistence_test.go
@@ -107,8 +107,8 @@ func TestFilesystemStore(t *testing.T) {
 		},
 	}
 
-	// Initialize gothic with these settings
-	InitializeGoth(settings)
+	// Initialize gothic with these settings; no effective TLS -> non-Secure cookie.
+	InitializeGoth(settings, false)
 
 	// Verify that gothic.Store is a FilesystemStore
 	_, ok := gothic.Store.(*sessions.FilesystemStore)
@@ -119,7 +119,7 @@ func TestFilesystemStore(t *testing.T) {
 	assert.NotNil(t, store.Options, "Store options should not be nil")
 	assert.Equal(t, "/", store.Options.Path, "Path should be /")
 	assert.Equal(t, 86400*7, store.Options.MaxAge, "MaxAge should be 7 days")
-	assert.False(t, store.Options.Secure, "Secure should match RedirectToHTTPS")
+	assert.False(t, store.Options.Secure, "Secure should be false when no effective TLS is configured")
 	assert.True(t, store.Options.HttpOnly, "HttpOnly should be true")
 
 	// Verify the sessions directory was created with correct permissions
@@ -132,6 +132,40 @@ func TestFilesystemStore(t *testing.T) {
 	// comparison there.
 	if runtime.GOOS != osWindows {
 		assert.Equal(t, os.FileMode(DirPermissions), info.Mode().Perm(), "Sessions directory should have secure permissions")
+	}
+}
+
+// TestFilesystemStore_SecureCookieFlag verifies that the secureCookies argument
+// threaded into InitializeGoth reaches the session cookie's Secure attribute. The
+// decision of WHAT that flag should be (from the effective TLS config) is tested
+// in internal/api (TestConfig_SessionCookiesSecure).
+func TestFilesystemStore_SecureCookieFlag(t *testing.T) {
+	// Not parallel: InitializeGoth mutates the global gothic.Store and the test
+	// config path.
+	tempDir := t.TempDir()
+	SetTestConfigPath(tempDir)
+	t.Cleanup(func() { SetTestConfigPath("") })
+
+	tests := []struct {
+		name   string
+		secure bool
+	}{
+		{"secureCookies false", false},
+		{"secureCookies true", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Subtests share the global gothic.Store; keep them sequential.
+			settings := &conf.Settings{Security: conf.Security{SessionSecret: "test-secret"}}
+			InitializeGoth(settings, tt.secure)
+
+			store, ok := gothic.Store.(*sessions.FilesystemStore)
+			require.True(t, ok, "gothic store should be a FilesystemStore")
+			require.NotNil(t, store.Options, "store options should not be nil")
+			assert.Equal(t, tt.secure, store.Options.Secure,
+				"Secure flag should match the secureCookies argument")
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

The OAuth / basic-auth session cookie's `Secure` attribute was set from the
persisted `settings.Security.RedirectToHTTPS` value:

```go
secureCookie := settings.Security.RedirectToHTTPS
```

That keys the flag off the HTTP->HTTPS redirect toggle rather than whether TLS is
actually in use. AutoTLS serves HTTPS while its persisted redirect flag stays at
its default `false` (the redirect defaults on at the server layer, not in the
stored setting), so a default AutoTLS deployment served HTTPS yet issued
**non-Secure** session cookies unless the admin also explicitly set
`redirecttohttps=true`. The same latent gap existed for manual/self-signed TLS.
The session cookie authenticates both OAuth and basic-auth sessions, so this
weakened session security for every HTTPS deployment that did not flip the
redirect toggle.

## Fix

Derive the `Secure` flag from the **effective** web-server TLS configuration
rather than the persisted setting. The persisted settings alone cannot express
the AutoTLS redirect default or whether TLS certificates actually exist; the
already-computed `api.Config` can. New predicate:

```go
func (c *Config) SessionCookiesSecure(settings *conf.Settings) bool {
	if settings.Security.IsHTTPSBaseURL() { // reverse proxy terminates TLS
		return true
	}
	if c.RedirectToHTTPS { // all HTTP traffic is redirected to HTTPS
		return true
	}
	return c.TLSEnabled && !c.AutoTLS // manual/self-signed: HTTPS-only or redirect
}
```

Why AutoTLS is excluded from the last clause: with `RedirectToHTTPS` disabled,
AutoTLS deliberately serves the full app over plain HTTP on the ACME listener
(see `Server.startBlocking`). Forcing `Secure` there would drop the session
cookie and break login over that HTTP path. When AutoTLS redirects (its default),
the `RedirectToHTTPS` clause already yields `true`, so HTTPS deployments still get
Secure cookies. Manual/self-signed TLS either redirects or listens HTTPS-only, so
it is always safe; missing certs leave `TLSEnabled` false and correctly yield a
non-Secure cookie for the plain-HTTP fallback.

The `security` package cannot import `internal/api`, so `internal/analysis`
computes the flag from the effective config and threads it into
`security.NewOAuth2Server`.

While threading the flag through `setupSessionStore`, the two in-memory
cookie-store fallback paths (used when the filesystem session store cannot be
created) now go through `buildSessionOptions` as well, so they honor the same
`Secure` / `HttpOnly` / `SameSite` hardening instead of silently dropping it.

## Behavior

| Deployment | Before | After |
| --- | --- | --- |
| AutoTLS, default redirect on (HTTPS) | non-Secure (bug) | **Secure** |
| AutoTLS, `redirecttohttps=false` (serves app on HTTP) | non-Secure | non-Secure (login over HTTP preserved) |
| Manual/self-signed TLS, certs present | non-Secure unless redirect on | **Secure** |
| Manual/self-signed selected, certs missing (HTTP fallback) | non-Secure | non-Secure |
| Reverse proxy, `https://` baseURL | non-Secure unless redirect on | **Secure** |
| Plain HTTP | non-Secure | non-Secure |

The flag is computed when the session store is configured (server start /
restart). Changing `TLSMode` or `redirecttohttps` already requires a restart, so
switching into AutoTLS applies the fix after that restart.

## Tests

- `internal/api`: `TestConfig_SessionCookiesSecure` covers every effective-config
  case, including the AutoTLS-without-redirect case that must stay non-Secure.
- `internal/conf`: `TestSecurity_IsHTTPSBaseURL` covers the reverse-proxy baseURL
  scheme check (https/http/bare host/whitespace/uppercase/malformed).
- `internal/security`: `TestFilesystemStore_SecureCookieFlag` verifies the flag
  threads through to the session cookie.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session and authentication cookies now reliably use the HTTPS-only (“Secure”) flag when the app is effectively reachable via HTTPS, including TLS-enabled and HTTPS-redirect deployments.
  * AutoTLS behavior is handled correctly (including the exception when AutoTLS is enabled but HTTP redirect-to-HTTPS is disabled), preventing cookies from being hardened incorrectly.
  * Reverse-proxy configurations with an `https` base URL are now recognized, and cookie hardening stays consistent across OAuth2 provider/session refreshes, including fallback session storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->