### PR TITLE
test(api): AutoTLS end-to-end test against a Pebble ACME testcontainer

### DIFF
--- a/.github/workflows/golangci-test.yml
+++ b/.github/workflows/golangci-test.yml
@@ -216,6 +216,26 @@ jobs:
             -- -tags=integration -race -timeout 300s
         timeout-minutes: 10
 
+      - name: Run AutoTLS Pebble ACME e2e test
+        if: ${{ !cancelled() }}
+        run: |
+          # End-to-end AutoTLS issuance against a Pebble ACME testcontainer,
+          # driving the real dual-listener startBlocking() path (regression guard
+          # for #3527). Gated behind the extra pebble_e2e build tag so it never
+          # runs in the normal api suite; -run isolates it from the rest of the
+          # (compiled) api package.
+          gotestsum \
+            --format pkgname \
+            --jsonfile events-tc-pebble.json \
+            --junitfile junit-tc-pebble.xml \
+            --rerun-fails=1 \
+            --rerun-fails-abort-on-data-race \
+            --rerun-fails-max-failures=10 \
+            --rerun-fails-report=rerun-tc-pebble.txt \
+            --packages "./internal/api/" \
+            -- -tags=integration,pebble_e2e -run 'TestAutoTLS_Pebble' -race -timeout 300s
+        timeout-minutes: 10
+
       - name: Container diagnostics on failure
         if: failure()
         run: |

--- a/.github/workflows/golangci-test.yml
+++ b/.github/workflows/golangci-test.yml
@@ -223,7 +223,9 @@ jobs:
           # driving the real dual-listener startBlocking() path (regression guard
           # for #3527). Gated behind the extra pebble_e2e build tag so it never
           # runs in the normal api suite; -run isolates it from the rest of the
-          # (compiled) api package.
+          # (compiled) api package. noembed,skipfrontend skip the frontend/model
+          # go:embed requirements (this job does not build the frontend, and the
+          # AutoTLS listener path under test does not use the embedded assets).
           gotestsum \
             --format pkgname \
             --jsonfile events-tc-pebble.json \
@@ -233,7 +235,7 @@ jobs:
             --rerun-fails-max-failures=10 \
             --rerun-fails-report=rerun-tc-pebble.txt \
             --packages "./internal/api/" \
-            -- -tags=integration,pebble_e2e -run 'TestAutoTLS_Pebble' -race -timeout 300s
+            -- -tags=integration,pebble_e2e,noembed,skipfrontend -run 'TestAutoTLS_Pebble' -race -timeout 300s
         timeout-minutes: 10
 
       - name: Container diagnostics on failure

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/jlaffaye/ftp v0.2.1
 	github.com/klauspost/cpuid/v2 v2.3.0
 	github.com/labstack/echo/v4 v4.15.4
+	github.com/moby/moby/api v1.55.0
 	github.com/nicholas-fedor/shoutrrr v0.16.1
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/sftp v1.13.10
@@ -86,7 +87,6 @@ require (
 	github.com/markbates/going v1.0.3 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.2.0 // indirect
-	github.com/moby/moby/api v1.55.0 // indirect
 	github.com/moby/moby/client v0.5.0 // indirect
 	github.com/moby/patternmatcher v0.6.1 // indirect
 	github.com/moby/sys/sequential v0.7.0 // indirect

--- a/internal/api/autotls_pebble_test.go
+++ b/internal/api/autotls_pebble_test.go
@@ -88,6 +88,9 @@ func TestAutoTLS_Pebble_EndToEnd(t *testing.T) {
 	settings.Security.Host = acmeHost
 	settings.Security.TLSPort = tlsPort
 	conftest.SetTestSettings(settings)
+	// Reset the global settings snapshot afterward so a stale snapshot does not leak
+	// into a later test (nil clears it; see conftest.SetTestSettings).
+	t.Cleanup(func() { conftest.SetTestSettings(nil) })
 
 	// Point config discovery at a non-existent path so startBlocking's cache setup
 	// (conf.FindConfigFile) fails deterministically and leaves the injected

--- a/internal/api/autotls_pebble_test.go
+++ b/internal/api/autotls_pebble_test.go
@@ -1,0 +1,219 @@
+//go:build integration && pebble_e2e
+
+// End-to-end AutoTLS validation against a real ACME server (Pebble) running as a
+// testcontainer. It drives the REAL startBlocking() dual-listener path through a
+// full ACME challenge validation and issuance, and asserts that (1) the CA
+// validates a challenge against the server's own listeners and issues a
+// certificate, (2) the HTTP-01 challenge listener serves ACME challenge paths
+// itself instead of redirecting them, and (3) non-ACME HTTP traffic 308-redirects
+// to the advertised host. This is the merge-gate regression proof for the AutoTLS
+// dual-listener fix (GitHub #3527): the earlier bug called StartAutoTLS on the
+// HTTP port with no separate HTTP-01 listener, so AutoTLS could never validate.
+//
+// The stock binary cannot point AutoTLS at a non-Let's-Encrypt directory, so the
+// test injects the ACME client (pointed at Pebble) directly on the AutoTLSManager,
+// which startBlocking leaves intact. Build+run with:
+//
+//	go test -tags=integration,pebble_e2e -run TestAutoTLS_Pebble ./internal/api/ -count=1 -v
+//
+// Two implementation notes:
+//
+//   - Success signal: autocert cannot retrieve the issued certificate from Pebble
+//     (Pebble omits the Location header on its finalize response, which x/crypto's
+//     CreateOrderCert requires to poll the order; this works against real Let's
+//     Encrypt). The test therefore confirms issuance from Pebble's own server side
+//     (WaitForIssuedCertificate) rather than by serving the cert back. That
+//     server-side confirmation is exactly what #3527 broke: with no HTTP-01 listener
+//     the CA could never validate, so no cert would issue.
+//   - Issuance runs through the TLS-ALPN-01 challenge (validation ports aligned with
+//     the server). A forced HTTP-01 issuance is not exercised because autocert's
+//     HostWhitelist compares the full Host header and Pebble validates HTTP-01 on the
+//     non-standard configured port, so the request arrives as "host:port" and is
+//     rejected; real Let's Encrypt validates HTTP-01 on port 80 with a bare-domain
+//     Host, so this only affects Pebble. The HTTP-01 listener is still asserted
+//     directly (assertion 2) to guard the #3527 regression.
+package api
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/acme"
+	"golang.org/x/crypto/acme/autocert"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/conf/conftest"
+	"github.com/tphakala/birdnet-go/internal/testutil/containers"
+)
+
+// issuanceDeadline bounds how long the test waits for Pebble to validate a
+// challenge and issue a certificate.
+const issuanceDeadline = 45 * time.Second
+
+func TestAutoTLS_Pebble_EndToEnd(t *testing.T) {
+	acmeHost := containers.DefaultPebbleChallengeHost
+	httpPort := mustGetFreePort(t)
+	tlsPort := mustGetFreePort(t)
+
+	// Start the ACME server. Its challenge validation must target the exact host
+	// ports the server binds below, and resolve acmeHost to this host.
+	startCtx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	t.Cleanup(cancel)
+	pebble, err := containers.NewPebbleContainer(startCtx, &containers.PebbleConfig{
+		ChallengeHost:      acmeHost,
+		HTTPValidationPort: mustAtoi(t, httpPort),
+		TLSValidationPort:  mustAtoi(t, tlsPort),
+	})
+	require.NoError(t, err, "failed to start Pebble ACME test server")
+	t.Cleanup(func() {
+		termCtx, termCancel := context.WithTimeout(context.Background(), 30*time.Second) //nolint:gocritic // t.Context() is already cancelled in Cleanup
+		defer termCancel()
+		assert.NoError(t, pebble.Terminate(termCtx))
+	})
+
+	// Build an AutoTLS config through the real path under test.
+	settings := conftest.NewTestSettings().WithWebServer(httpPort, true).Build()
+	settings.Security.TLSMode = conf.TLSModeAutoTLS
+	settings.Security.Host = acmeHost
+	settings.Security.TLSPort = tlsPort
+	conftest.SetTestSettings(settings)
+
+	// Point config discovery at a non-existent path so startBlocking's cache setup
+	// (conf.FindConfigFile) fails deterministically and leaves the injected
+	// AutoTLSManager.Cache untouched, rather than writing certs into a real config
+	// directory.
+	origConfigPath := conf.ConfigPath
+	conf.ConfigPath = filepath.Join(t.TempDir(), "nonexistent-config.yaml")
+	t.Cleanup(func() { conf.ConfigPath = origConfigPath })
+
+	cfg := ConfigFromSettings(settings)
+	require.True(t, cfg.RedirectToHTTPS, "AutoTLS must default redirect on")
+	require.Equal(t, acmeHost, cfg.RedirectAuthority, "redirect authority is the advertised host")
+	require.Equal(t, tlsPort, cfg.TLSPort)
+
+	e := echo.New()
+	e.HideBanner = true
+	e.HidePort = true
+
+	// Point AutoTLS at Pebble. startBlocking sets Cache + HostPolicy but never
+	// Client, so this injection is exactly what the shipped binary lacks. Pre-discover
+	// the directory so autocert's account registration (which can run before its own
+	// discovery) has populated endpoint URLs.
+	acmeClient := &acme.Client{DirectoryURL: pebble.DirectoryURL(), HTTPClient: pebble.APIHTTPClient()}
+	_, err = acmeClient.Discover(startCtx)
+	require.NoError(t, err, "ACME directory discovery against Pebble must succeed")
+	e.AutoTLSManager.Client = acmeClient
+	e.AutoTLSManager.Cache = autocert.DirCache(t.TempDir())
+	e.AutoTLSManager.Prompt = autocert.AcceptTOS
+
+	s := &Server{config: cfg, settings: settings, echo: e, slogger: GetLogger()}
+	t.Cleanup(func() {
+		ctx, ccancel := context.WithTimeout(context.Background(), 3*time.Second) //nolint:gocritic // t.Context() is already cancelled in Cleanup
+		defer ccancel()
+		_ = s.echo.Shutdown(ctx)
+		if srv := s.httpRedirectServer.Load(); srv != nil {
+			_ = srv.Shutdown(ctx)
+		}
+	})
+	go func() { _ = s.startBlocking() }()
+
+	requirePortOpen(t, httpPort)
+	requirePortOpen(t, tlsPort)
+
+	// (1) Drive a full ACME issuance through the real dual-listener path and confirm
+	// it from the CA's server side. A client TLS handshake to the TLS listener makes
+	// the server's own autocert run one ACME order whose challenge Pebble validates
+	// against the TLS-ALPN-01 listener. The background loop keeps handshaking until
+	// Pebble confirms issuance (see the file header for why we confirm server-side
+	// rather than via a served handshake).
+	stopTrigger := startACMEIssuanceTrigger(t, tlsPort, acmeHost)
+	waitErr := pebble.WaitForIssuedCertificate(startCtx, issuanceDeadline)
+	stopTrigger()
+	require.NoError(t, waitErr,
+		"Pebble must validate a challenge against the server listeners and issue a cert, proving the dual-listener ACME flow works end-to-end")
+
+	nonRedirectClient := &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+		Timeout:       5 * time.Second,
+	}
+
+	// (2) The HTTP listener must serve ACME challenge paths itself (via
+	// autocert.HTTPHandler), not 308-redirect them: that is the whole point of the
+	// dual-listener fix. The request uses a bare-domain Host so it passes autocert's
+	// HostWhitelist; an unknown token then yields 404 (handled by the ACME path, not
+	// redirected).
+	acmeReq, err := http.NewRequest(http.MethodGet,
+		fmt.Sprintf("http://127.0.0.1:%s/.well-known/acme-challenge/probe-token", httpPort), http.NoBody)
+	require.NoError(t, err)
+	acmeReq.Host = acmeHost
+	acmeProbe, err := nonRedirectClient.Do(acmeReq)
+	require.NoError(t, err)
+	_ = acmeProbe.Body.Close()
+	assert.Equal(t, http.StatusNotFound, acmeProbe.StatusCode,
+		"ACME challenge path must be handled by the HTTP listener (404 for unknown token), not redirected to HTTPS")
+
+	// (3) Non-ACME HTTP traffic 308-redirects to the advertised HTTPS host, not the
+	// internal TLS port.
+	resp, err := nonRedirectClient.Get(fmt.Sprintf("http://127.0.0.1:%s/dashboard", httpPort))
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	assert.Equal(t, http.StatusPermanentRedirect, resp.StatusCode, "non-ACME HTTP must 308-redirect")
+	assert.Equal(t, "https://"+acmeHost+"/dashboard", resp.Header.Get("Location"),
+		"redirect targets the advertised host, not the internal TLS port")
+}
+
+// startACMEIssuanceTrigger repeatedly handshakes the server's TLS listener in the
+// background to drive ACME issuance against the challenge listeners. The handshake
+// runs the server's own autocert (on the server goroutine, avoiding any data race
+// on the AutoTLSManager fields that startBlocking sets). The handshake itself fails
+// because autocert cannot retrieve the issued cert from Pebble; that is expected
+// and ignored, since the CA has already validated and issued by that point, which
+// is what the test asserts. It returns a stop function, safe to call once.
+func startACMEIssuanceTrigger(t *testing.T, tlsPort, host string) func() {
+	t.Helper()
+	stop := make(chan struct{})
+	addr := net.JoinHostPort("127.0.0.1", tlsPort)
+	triggerCtx := t.Context()
+	go func() {
+		// We do not verify the served cert here (issuance is confirmed via Pebble),
+		// so skip verification; the handshake exists only to trigger issuance.
+		cfg := &tls.Config{ServerName: host, InsecureSkipVerify: true} //nolint:gosec // triggers issuance only; not verifying
+		for {
+			dctx, dcancel := context.WithTimeout(triggerCtx, 10*time.Second)
+			conn, err := (&tls.Dialer{Config: cfg}).DialContext(dctx, "tcp", addr)
+			dcancel()
+			if err == nil {
+				_ = conn.Close()
+			}
+			select {
+			case <-stop:
+				return
+			case <-time.After(2 * time.Second):
+			}
+		}
+	}()
+	var once sync.Once
+	stopFn := func() { once.Do(func() { close(stop) }) }
+	// Always stop the loop, even if the test fails before the explicit call.
+	t.Cleanup(stopFn)
+	return stopFn
+}
+
+// mustAtoi parses a numeric string port or fails the test.
+func mustAtoi(t *testing.T, s string) int {
+	t.Helper()
+	n, err := strconv.Atoi(s)
+	require.NoError(t, err, "port %q must be numeric", s)
+	return n
+}

--- a/internal/api/autotls_pebble_test.go
+++ b/internal/api/autotls_pebble_test.go
@@ -202,6 +202,8 @@ func startACMEIssuanceTrigger(t *testing.T, tlsPort, host string) func() {
 			select {
 			case <-stop:
 				return
+			case <-triggerCtx.Done():
+				return
 			case <-time.After(2 * time.Second):
 			}
 		}

--- a/internal/testutil/containers/pebble.go
+++ b/internal/testutil/containers/pebble.go
@@ -364,8 +364,10 @@ func (c *PebbleContainer) Logs(ctx context.Context) (string, error) {
 	return string(b), nil
 }
 
-// Terminate stops and removes the Pebble container.
+// Terminate stops and removes the Pebble container and releases the API client's
+// idle keep-alive connections.
 func (c *PebbleContainer) Terminate(ctx context.Context) error {
+	c.httpClient.CloseIdleConnections()
 	if err := c.container.Terminate(ctx); err != nil {
 		return fmt.Errorf("pebble: terminate container: %w", err)
 	}

--- a/internal/testutil/containers/pebble.go
+++ b/internal/testutil/containers/pebble.go
@@ -1,0 +1,374 @@
+//go:build integration
+
+package containers
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/moby/moby/api/types/container"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// Pebble (https://github.com/letsencrypt/pebble) is Let's Encrypt's small ACME
+// test server. This helper runs it as a testcontainer so an in-process server
+// can obtain a real, CA-issued certificate end-to-end without touching the
+// public Let's Encrypt service or its rate limits.
+//
+// Networking model: ACME validation is bidirectional.
+//   - The test process (ACME client) reaches Pebble's ACME + management APIs via
+//     the container's dynamically mapped host ports.
+//   - Pebble (the ACME server) reaches back to the applicant's HTTP-01 and
+//     TLS-ALPN-01 challenge listeners. Those listeners run in the test process on
+//     the host, so Pebble must resolve the challenge host to the container host
+//     (via a host-gateway ExtraHost) and connect to the exact host ports the
+//     server listens on (PebbleConfig.HTTPValidationPort / TLSValidationPort).
+const (
+	pebbleImage = "ghcr.io/letsencrypt/pebble"
+	// pebbleDefaultTag pins a known-good Pebble version rather than "latest": the
+	// success signal (WaitForIssuedCertificate) matches Pebble's own log strings,
+	// so a pinned image keeps that marker contract stable and the test reproducible.
+	pebbleDefaultTag = "2.9.0"
+	// pebbleACMEPort and pebbleMgmtPort are the container-internal ports (in the
+	// testcontainers "N/tcp" form) that Pebble binds. The config listen addresses
+	// below derive from these via trimming "/tcp", so the two cannot drift.
+	pebbleACMEPort       = "14000/tcp"
+	pebbleMgmtPort       = "15000/tcp"
+	pebbleConfigPath     = "/test/config/pebble-config.json"
+	pebbleStartupTimeout = 60 * time.Second
+
+	// DefaultPebbleChallengeHost is a dotted host name usable as an ACME
+	// identifier. It must not be single-label: golang.org/x/crypto/acme/autocert
+	// rejects single-label names ("server name component count invalid").
+	DefaultPebbleChallengeHost = "bng.test"
+
+	// pebbleHostGateway is the ExtraHost target that resolves, from inside the
+	// container, to the Docker/podman host running the test. Docker Engine 20.10+
+	// and rootless podman both understand the special "host-gateway" value.
+	pebbleHostGateway = "host-gateway"
+)
+
+// PebbleConfig configures a Pebble ACME test-server container.
+type PebbleConfig struct {
+	// ImageTag for ghcr.io/letsencrypt/pebble (default: pebbleDefaultTag).
+	ImageTag string
+	// ChallengeHost is the ACME identifier a certificate will be requested for.
+	// Pebble resolves it to the container host (host-gateway) so it can reach the
+	// applicant's challenge listeners. Must be dotted. Defaults to
+	// DefaultPebbleChallengeHost.
+	ChallengeHost string
+	// HTTPValidationPort and TLSValidationPort are the HOST ports the applicant
+	// server listens on for HTTP-01 and TLS-ALPN-01 challenges. Pebble connects to
+	// ChallengeHost at these ports during validation, so they MUST equal the ports
+	// the server binds on the host. Both are required.
+	HTTPValidationPort int
+	TLSValidationPort  int
+}
+
+// PebbleContainer wraps a running Pebble ACME test-server container.
+type PebbleContainer struct {
+	container    testcontainers.Container
+	directoryURL string
+	httpClient   *http.Client
+	rootPool     *x509.CertPool
+}
+
+// pebbleConfigDoc is the on-disk Pebble configuration document.
+type pebbleConfigDoc struct {
+	Pebble pebbleConfigBody `json:"pebble"`
+}
+
+type pebbleConfigBody struct {
+	ListenAddress           string `json:"listenAddress"`
+	ManagementListenAddress string `json:"managementListenAddress"`
+	Certificate             string `json:"certificate"`
+	PrivateKey              string `json:"privateKey"`
+	HTTPPort                int    `json:"httpPort"`
+	TLSPort                 int    `json:"tlsPort"`
+	OCSPResponderURL        string `json:"ocspResponderURL"`
+}
+
+// NewPebbleContainer creates and starts a Pebble ACME test-server container. The
+// caller must Terminate it. HTTPValidationPort and TLSValidationPort are
+// required and must match the applicant server's host listener ports.
+func NewPebbleContainer(ctx context.Context, config *PebbleConfig) (*PebbleContainer, error) {
+	if config == nil {
+		return nil, fmt.Errorf("pebble: config is required")
+	}
+	if config.HTTPValidationPort == 0 || config.TLSValidationPort == 0 {
+		return nil, fmt.Errorf("pebble: HTTPValidationPort and TLSValidationPort are required")
+	}
+
+	tag := config.ImageTag
+	if tag == "" {
+		tag = pebbleDefaultTag
+	}
+	challengeHost := config.ChallengeHost
+	if challengeHost == "" {
+		challengeHost = DefaultPebbleChallengeHost
+	}
+
+	// Point Pebble's challenge validation at the host ports the server listens on.
+	// The certificate/privateKey paths are the test CA baked into the image
+	// (relative to the container WORKDIR "/").
+	configJSON, err := json.Marshal(pebbleConfigDoc{Pebble: pebbleConfigBody{
+		ListenAddress:           "0.0.0.0:" + strings.TrimSuffix(pebbleACMEPort, "/tcp"),
+		ManagementListenAddress: "0.0.0.0:" + strings.TrimSuffix(pebbleMgmtPort, "/tcp"),
+		Certificate:             "test/certs/localhost/cert.pem",
+		PrivateKey:              "test/certs/localhost/key.pem",
+		HTTPPort:                config.HTTPValidationPort,
+		TLSPort:                 config.TLSValidationPort,
+		OCSPResponderURL:        "",
+	}})
+	if err != nil {
+		return nil, fmt.Errorf("pebble: marshal config: %w", err)
+	}
+
+	req := testcontainers.ContainerRequest{
+		Image:        fmt.Sprintf("%s:%s", pebbleImage, tag),
+		ExposedPorts: []string{pebbleACMEPort, pebbleMgmtPort},
+		Env: map[string]string{
+			// Validate challenges immediately instead of the default ~5s sleep,
+			// and do not randomly reject nonces: both keep the e2e fast and
+			// deterministic. These are test-only accelerators.
+			"PEBBLE_VA_NOSLEEP":      "1",
+			"PEBBLE_WFE_NONCEREJECT": "0",
+		},
+		Cmd: []string{"-config", pebbleConfigPath},
+		Files: []testcontainers.ContainerFile{{
+			Reader:            bytes.NewReader(configJSON),
+			ContainerFilePath: pebbleConfigPath,
+			FileMode:          0o644,
+		}},
+		HostConfigModifier: func(hc *container.HostConfig) {
+			// Make the ACME identifier resolve to the host so Pebble can reach the
+			// applicant's challenge listeners running in the test process.
+			hc.ExtraHosts = append(hc.ExtraHosts, fmt.Sprintf("%s:%s", challengeHost, pebbleHostGateway))
+		},
+		WaitingFor: wait.ForListeningPort(pebbleACMEPort).
+			WithStartupTimeout(pebbleStartupTimeout),
+	}
+
+	ctr, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		// GenericContainer returns a non-nil container on both create and start
+		// failure (e.g. a WaitingFor timeout leaves a started container behind), so
+		// terminate it to avoid a leak when the Ryuk reaper is disabled.
+		if ctr != nil {
+			_ = ctr.Terminate(context.Background())
+		}
+		return nil, fmt.Errorf("pebble: start container: %w", err)
+	}
+
+	pc, err := newPebbleFromContainer(ctx, ctr)
+	if err != nil {
+		_ = ctr.Terminate(context.Background())
+		return nil, err
+	}
+	return pc, nil
+}
+
+// newPebbleFromContainer resolves the mapped endpoints, builds an HTTP client
+// that trusts Pebble's self-signed API certificate, and waits for the ACME
+// directory to become reachable while capturing the issuing root(s).
+func newPebbleFromContainer(ctx context.Context, ctr testcontainers.Container) (*PebbleContainer, error) {
+	host, err := ctr.Host(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("pebble: container host: %w", err)
+	}
+	acmePort, err := ctr.MappedPort(ctx, pebbleACMEPort)
+	if err != nil {
+		return nil, fmt.Errorf("pebble: mapped ACME port: %w", err)
+	}
+	mgmtPort, err := ctr.MappedPort(ctx, pebbleMgmtPort)
+	if err != nil {
+		return nil, fmt.Errorf("pebble: mapped management port: %w", err)
+	}
+
+	// Pebble serves its ACME + management APIs over HTTPS with a self-signed cert
+	// for "localhost", which will not match the mapped host: skip verification for
+	// API calls only. The issued leaf is verified separately against rootPool.
+	httpClient := &http.Client{
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}, //nolint:gosec // Pebble test CA, API endpoints only
+		Timeout:   15 * time.Second,
+	}
+
+	directoryURL := fmt.Sprintf("https://%s/dir", net.JoinHostPort(host, acmePort.Port()))
+	mgmtRootsURL := fmt.Sprintf("https://%s/roots/0", net.JoinHostPort(host, mgmtPort.Port()))
+
+	pc := &PebbleContainer{
+		container:    ctr,
+		directoryURL: directoryURL,
+		httpClient:   httpClient,
+	}
+
+	if err := pc.waitDirectoryReady(ctx); err != nil {
+		return nil, err
+	}
+	// Fetch the issuing root eagerly: it doubles as a readiness check that the
+	// management API works, and exposing it (IssuerRoots) lets callers verify a
+	// Pebble-issued leaf, the obvious next use of this helper.
+	rootPool, err := pc.fetchIssuerRoot(ctx, mgmtRootsURL)
+	if err != nil {
+		return nil, err
+	}
+	pc.rootPool = rootPool
+	return pc, nil
+}
+
+// waitDirectoryReady polls the ACME directory endpoint until it responds 200 or
+// the context/deadline expires.
+func (c *PebbleContainer) waitDirectoryReady(ctx context.Context) error {
+	deadline := time.Now().Add(pebbleStartupTimeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.directoryURL, http.NoBody)
+		if err != nil {
+			return fmt.Errorf("pebble: build directory request: %w", err)
+		}
+		resp, err := c.httpClient.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+			lastErr = fmt.Errorf("directory returned status %d", resp.StatusCode)
+		} else {
+			lastErr = err
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("pebble: waiting for directory: %w", ctx.Err())
+		case <-time.After(250 * time.Millisecond):
+		}
+	}
+	return fmt.Errorf("pebble: ACME directory not ready within %s: %w", pebbleStartupTimeout, lastErr)
+}
+
+// fetchIssuerRoot retrieves Pebble's randomly-generated issuing root certificate
+// and returns a pool containing it, so the test can verify served leaf certs.
+func (c *PebbleContainer) fetchIssuerRoot(ctx context.Context, rootsURL string) (*x509.CertPool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rootsURL, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("pebble: build roots request: %w", err)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("pebble: fetch issuing root: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("pebble: fetch issuing root: status %d", resp.StatusCode)
+	}
+	rootPEM, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("pebble: read issuing root: %w", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(rootPEM) {
+		return nil, fmt.Errorf("pebble: issuing root PEM was not accepted")
+	}
+	return pool, nil
+}
+
+// DirectoryURL returns the ACME directory URL to point an ACME client at.
+func (c *PebbleContainer) DirectoryURL() string { return c.directoryURL }
+
+// APIHTTPClient returns an HTTP client that trusts Pebble's self-signed ACME and
+// management API certificate. Use it as the ACME client's HTTPClient.
+func (c *PebbleContainer) APIHTTPClient() *http.Client { return c.httpClient }
+
+// IssuerRoots returns a cert pool containing Pebble's issuing root, for verifying
+// certificates that Pebble issues.
+func (c *PebbleContainer) IssuerRoots() *x509.CertPool { return c.rootPool }
+
+// Pebble log markers used to confirm a challenge validated and a cert was issued.
+// These are the CA's own server-side confirmation of the ACME flow. autocert
+// cannot retrieve an issued cert from Pebble (Pebble omits the Location header on
+// its finalize response, which x/crypto's CreateOrderCert requires; this works
+// against real Let's Encrypt), so the CA-side log is the reliable success signal.
+const (
+	pebbleLogChallengeValidated = "set VALID by completed challenge"
+	pebbleLogCertIssued         = "Issued certificate serial"
+)
+
+// WaitForIssuedCertificate blocks until Pebble's logs show that it validated a
+// challenge against the applicant's listeners and issued a certificate, or the
+// timeout elapses. Because a fresh Pebble instance only ever handles the single
+// host the caller requests, an issued certificate necessarily belongs to that
+// host. It proves the applicant's HTTP-01 / TLS-ALPN-01 challenge listeners
+// answered the CA end-to-end. On timeout it returns an error that includes the
+// captured logs for diagnosis.
+func (c *PebbleContainer) WaitForIssuedCertificate(ctx context.Context, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	var lastLogs string
+	var lastErr error
+	for time.Now().Before(deadline) {
+		logs, err := c.Logs(ctx)
+		if err != nil {
+			lastErr = err
+		} else {
+			lastLogs = logs
+			if strings.Contains(logs, pebbleLogChallengeValidated) &&
+				strings.Contains(logs, pebbleLogCertIssued) {
+				return nil
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("pebble: waiting for issuance: %w", ctx.Err())
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+	// Surface the last log-read error too: without it a persistent Logs() failure
+	// would print empty logs and hide why detection never succeeded. Stringify it
+	// (rather than %w) so a nil error reads cleanly and it does not join the chain.
+	lastErrText := "none"
+	if lastErr != nil {
+		lastErrText = lastErr.Error()
+	}
+	return fmt.Errorf("pebble: no certificate issued within %s (last log-read error: %s); logs:\n%s",
+		timeout, lastErrText, lastLogs)
+}
+
+// Logs returns the Pebble container's stdout/stderr, which record ACME order and
+// challenge-validation attempts. Useful for diagnosing issuance failures in CI.
+func (c *PebbleContainer) Logs(ctx context.Context) (string, error) {
+	if c.container == nil {
+		return "", fmt.Errorf("pebble: no container")
+	}
+	rc, err := c.container.Logs(ctx)
+	if err != nil {
+		return "", fmt.Errorf("pebble: read logs: %w", err)
+	}
+	defer func() { _ = rc.Close() }()
+	b, err := io.ReadAll(rc)
+	if err != nil {
+		return "", fmt.Errorf("pebble: read logs: %w", err)
+	}
+	return string(b), nil
+}
+
+// Terminate stops and removes the Pebble container.
+func (c *PebbleContainer) Terminate(ctx context.Context) error {
+	if c.container == nil {
+		return nil
+	}
+	if err := c.container.Terminate(ctx); err != nil {
+		return fmt.Errorf("pebble: terminate container: %w", err)
+	}
+	return nil
+}

--- a/internal/testutil/containers/pebble.go
+++ b/internal/testutil/containers/pebble.go
@@ -155,8 +155,13 @@ func NewPebbleContainer(ctx context.Context, config *PebbleConfig) (*PebbleConta
 			// applicant's challenge listeners running in the test process.
 			hc.ExtraHosts = append(hc.ExtraHosts, fmt.Sprintf("%s:%s", challengeHost, pebbleHostGateway))
 		},
-		WaitingFor: wait.ForListeningPort(pebbleACMEPort).
-			WithStartupTimeout(pebbleStartupTimeout),
+		// Wait for BOTH the ACME and management listeners: fetchIssuerRoot hits the
+		// management port (once, no retry) right after construction, so waiting only
+		// for the ACME port would let a slow management listener flake construction.
+		WaitingFor: wait.ForAll(
+			wait.ForListeningPort(pebbleACMEPort),
+			wait.ForListeningPort(pebbleMgmtPort),
+		).WithDeadline(pebbleStartupTimeout),
 	}
 
 	ctr, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
@@ -347,9 +352,6 @@ func (c *PebbleContainer) WaitForIssuedCertificate(ctx context.Context, timeout 
 // Logs returns the Pebble container's stdout/stderr, which record ACME order and
 // challenge-validation attempts. Useful for diagnosing issuance failures in CI.
 func (c *PebbleContainer) Logs(ctx context.Context) (string, error) {
-	if c.container == nil {
-		return "", fmt.Errorf("pebble: no container")
-	}
 	rc, err := c.container.Logs(ctx)
 	if err != nil {
 		return "", fmt.Errorf("pebble: read logs: %w", err)
@@ -364,9 +366,6 @@ func (c *PebbleContainer) Logs(ctx context.Context) (string, error) {
 
 // Terminate stops and removes the Pebble container.
 func (c *PebbleContainer) Terminate(ctx context.Context) error {
-	if c.container == nil {
-		return nil
-	}
 	if err := c.container.Terminate(ctx); err != nil {
 		return fmt.Errorf("pebble: terminate container: %w", err)
 	}

--- a/internal/testutil/containers/pebble_test.go
+++ b/internal/testutil/containers/pebble_test.go
@@ -1,0 +1,45 @@
+//go:build integration
+
+package containers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPebbleContainer_DirectoryAndRoots is a smoke test: it starts a Pebble
+// container and asserts the ACME directory is reachable and the issuing root is
+// captured. Constructing the container is the real check (it pulls and boots the
+// image and, internally, waits for the ACME directory and fetches the issuing
+// root in this environment); the assertions below pin the resulting contract so a
+// future change that drops either surfaces here. The full AutoTLS issuance e2e
+// lives in internal/api behind the pebble_e2e build tag because it needs the api
+// package's unexported server path.
+func TestPebbleContainer_DirectoryAndRoots(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	t.Cleanup(cancel)
+
+	httpPort, err := GetFreePort()
+	require.NoError(t, err)
+	tlsPort, err := GetFreePort()
+	require.NoError(t, err)
+
+	pebble, err := NewPebbleContainer(ctx, &PebbleConfig{
+		HTTPValidationPort: httpPort,
+		TLSValidationPort:  tlsPort,
+	})
+	require.NoError(t, err, "Pebble container must start with its ACME directory and issuing root reachable")
+	t.Cleanup(func() {
+		termCtx, termCancel := context.WithTimeout(context.Background(), 30*time.Second) //nolint:gocritic // t.Context() is already cancelled in Cleanup
+		defer termCancel()
+		assert.NoError(t, pebble.Terminate(termCtx))
+	})
+
+	assert.Contains(t, pebble.DirectoryURL(), "/dir", "directory URL should point at the ACME directory")
+	assert.NotNil(t, pebble.APIHTTPClient(), "API HTTP client should be available")
+	assert.NotNil(t, pebble.IssuerRoots(), "issuing root pool should be captured")
+}


### PR DESCRIPTION
test(api): AutoTLS end-to-end test against a Pebble ACME testcontainer

## What

Adds an automated end-to-end AutoTLS test that drives the real
`api.Server.startBlocking()` dual-listener path against a real ACME server
(Pebble) running as a testcontainer, and asserts the certificate-issuance and
HTTP-01/redirect behavior. This is the automated regression proof for the AutoTLS
dual-listener fix in #3612 (which fixed #3527); during that PR the flow was
validated by hand against Pebble but the harness was never committed.

## How

- New `internal/testutil/containers/pebble.go` (`//go:build integration`): a
  testcontainer helper for `ghcr.io/letsencrypt/pebble`, following the existing
  ntfy/mosquitto/mediamtx helper idiom. It solves the ACME two-way networking:
  the test process reaches Pebble's ACME/management APIs via dynamically mapped
  host ports, while Pebble reaches back to the server's challenge listeners via a
  `host-gateway` ExtraHost and validation ports aligned with the server's host
  ports. `WaitForIssuedCertificate` confirms issuance from Pebble's server-side
  logs.
- New `internal/testutil/containers/pebble_test.go` (`//go:build integration`): a
  smoke test that starts Pebble and checks the directory + issuing root are
  reachable. Runs in the existing container-integration CI step.
- New `internal/api/autotls_pebble_test.go` (`//go:build integration &&
  pebble_e2e`): the full e2e. It injects an ACME client pointed at Pebble on the
  `AutoTLSManager` (the shipped binary cannot set the ACME directory), runs the
  real `startBlocking()` dual-listener path, drives issuance with a background TLS
  handshake, and asserts (1) the CA validates a challenge against the server's own
  listeners and issues a cert, (2) the HTTP-01 listener serves ACME challenge
  paths itself (not a redirect), and (3) non-ACME HTTP 308-redirects to the
  advertised host.
- CI: a new step in the `testcontainer-tests` job runs the e2e under both tags.
- `go.mod`: promotes `github.com/moby/moby/api` from indirect to direct (the
  helper imports its `types/container` for `HostConfigModifier`); already in the
  module graph via testcontainers-go, so this is a no-op for normal builds.

## Notes on the design

Two Pebble-specific constraints shaped the assertions:

- autocert cannot **retrieve** the issued cert from Pebble: Pebble omits the
  `Location` header on its finalize response, which x/crypto's `CreateOrderCert`
  needs to poll the order (this works against real Let's Encrypt). So the test
  confirms issuance from Pebble's server side rather than by serving the cert back
  over a handshake. That server-side confirmation is exactly what #3527 broke:
  with no HTTP-01 listener the CA could never validate, so no cert would issue.
- Issuance runs through TLS-ALPN-01 (validation ports aligned). A forced HTTP-01
  issuance is infeasible with Pebble because autocert's `HostWhitelist` compares
  the full Host header and Pebble validates HTTP-01 on the non-standard configured
  port, so the request arrives as `host:port` and is rejected. Real Let's Encrypt
  validates HTTP-01 on port 80 with a bare-domain Host, so this only affects
  Pebble. The HTTP-01 listener is still asserted directly (assertion 2).

## Testing

- e2e + smoke run green and race-clean, deterministically (3x locally, ~6s each),
  against rootless Podman and (in CI) Docker Engine.
- `go build ./...` and default `go test ./...` are unaffected (the new files are
  fully build-tagged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests / CI**
  * Expanded end-to-end AutoTLS testing by adding a gated Pebble ACME scenario in CI and ensuring its test artifacts are captured with the existing report uploads.
  * Added integration smoke coverage and helper utilities for running a Pebble ACME server in the test suite (including readiness checks and issued-certificate waiting).
* **Chores**
  * Updated a Go module dependency (`github.com/moby/moby/api`) in the project configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->