### PR TITLE
test(containers): fix integration-tag lint debt in test helpers

### DIFF
--- a/internal/testutil/containers/cleanup.go
+++ b/internal/testutil/containers/cleanup.go
@@ -4,6 +4,7 @@ package containers
 
 import (
 	"fmt"
+	"slices"
 	"sync"
 	"testing"
 )
@@ -54,8 +55,7 @@ func (cm *CleanupManager) Cleanup() []error {
 	var errors []error
 
 	// Execute cleanups in reverse order without holding the lock
-	for i := len(cleanupsCopy) - 1; i >= 0; i-- {
-		cleanup := cleanupsCopy[i]
+	for _, cleanup := range slices.Backward(cleanupsCopy) {
 		if err := cleanup.fn(); err != nil {
 			errors = append(errors, fmt.Errorf("%s cleanup failed: %w", cleanup.name, err))
 		}

--- a/internal/testutil/containers/mosquitto_test.go
+++ b/internal/testutil/containers/mosquitto_test.go
@@ -17,7 +17,7 @@ import (
 // TestMosquittoContainer_ClearRetainedMessages tests the ClearRetainedMessages function
 // to ensure it properly clears retained messages without flakiness.
 func TestMosquittoContainer_ClearRetainedMessages(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create Mosquitto container
 	container, err := NewMosquittoContainer(ctx, nil)
@@ -124,7 +124,7 @@ func TestMosquittoContainer_ClearRetainedMessages(t *testing.T) {
 // TestMosquittoContainer_ClearRetainedMessages_ContextCancellation tests that
 // ClearRetainedMessages respects context cancellation.
 func TestMosquittoContainer_ClearRetainedMessages_ContextCancellation(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create Mosquitto container
 	container, err := NewMosquittoContainer(ctx, nil)

--- a/internal/testutil/containers/mysql.go
+++ b/internal/testutil/containers/mysql.go
@@ -43,6 +43,9 @@ type MySQLConfig struct {
 	InitScripts []string
 }
 
+// defaultMySQLImageTag is the MySQL image tag used when a config does not set one.
+const defaultMySQLImageTag = "8.0"
+
 // DefaultMySQLConfig returns a MySQLConfig with sensible defaults.
 func DefaultMySQLConfig() MySQLConfig {
 	return MySQLConfig{
@@ -50,7 +53,7 @@ func DefaultMySQLConfig() MySQLConfig {
 		RootPassword: "test",
 		Username:     "testuser",
 		Password:     "testpass",
-		ImageTag:     "8.0",
+		ImageTag:     defaultMySQLImageTag,
 	}
 }
 
@@ -79,8 +82,14 @@ func NewMySQLContainer(ctx context.Context, config *MySQLConfig) (*MySQLContaine
 	// Containers are created fresh for each test run to ensure isolation.
 
 	// Create and start container
-	// Note: mysql.Run already handles waiting for the container to be ready
-	image := fmt.Sprintf("mysql:%s", config.ImageTag)
+	// Note: mysql.Run already handles waiting for the container to be ready.
+	// Fall back to the default tag when a caller supplies a config without one,
+	// so the image is never the invalid "mysql:".
+	imageTag := config.ImageTag
+	if imageTag == "" {
+		imageTag = defaultMySQLImageTag
+	}
+	image := fmt.Sprintf("mysql:%s", imageTag)
 	mysqlContainer, err := mysql.Run(ctx, image, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start MySQL container: %w", err)

--- a/internal/testutil/containers/mysql.go
+++ b/internal/testutil/containers/mysql.go
@@ -63,11 +63,12 @@ func NewMySQLContainer(ctx context.Context, config *MySQLConfig) (*MySQLContaine
 	}
 
 	// Build container request
-	opts := []testcontainers.ContainerCustomizer{
+	opts := make([]testcontainers.ContainerCustomizer, 0, 3+len(config.InitScripts))
+	opts = append(opts,
 		mysql.WithDatabase(config.Database),
 		mysql.WithUsername(config.Username),
 		mysql.WithPassword(config.Password),
-	}
+	)
 
 	// Add init scripts if provided
 	for _, script := range config.InitScripts {
@@ -78,8 +79,9 @@ func NewMySQLContainer(ctx context.Context, config *MySQLConfig) (*MySQLContaine
 	// Containers are created fresh for each test run to ensure isolation.
 
 	// Create and start container
-	// Note: mysql.RunContainer already handles waiting for the container to be ready
-	mysqlContainer, err := mysql.RunContainer(ctx, opts...)
+	// Note: mysql.Run already handles waiting for the container to be ready
+	image := fmt.Sprintf("mysql:%s", config.ImageTag)
+	mysqlContainer, err := mysql.Run(ctx, image, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start MySQL container: %w", err)
 	}


### PR DESCRIPTION
## What

The shared testcontainer helpers in `internal/testutil/containers` had golangci-lint issues that only surface under the `integration` build tag. CI lints with `--build-tags=noembed,skipfrontend` (not `integration`), so these accumulated silently. They were found while adding the AutoTLS Pebble e2e test (#3784), which required linting those files locally with `--build-tags=integration`.

## Changes

- **mysql.go**: migrate the deprecated `mysql.RunContainer` to `mysql.Run` (staticcheck `SA1019`), which would break on a future testcontainers-go upgrade. The new call takes an explicit image, so it now honors the previously-unused documented `ImageTag` field (all callers already set it to `"8.0"`; the nil-config path defaults to `"8.0"`). Also preallocate the customizer slice (`prealloc`).
- **cleanup.go**: use `slices.Backward` for the reverse iteration (`gocritic`, Go 1.23+).
- **mosquitto_test.go**: use `t.Context()` instead of `context.Background()` in tests (`gocritic`, Go 1.24+).

## Verification

Clean under both tag sets for this package:

- `golangci-lint run --build-tags=integration ./internal/testutil/containers/...` -> 0 issues
- `golangci-lint run --build-tags=noembed,skipfrontend ./internal/testutil/containers/...` -> 0 issues

## Follow-up

A repo-wide `--build-tags=integration` lint currently reports 40 pre-existing issues in other integration-tagged files (datastore migration/repository, notification ntfy, spectrogram). Fixing those and adding an integration-tagged CI lint pass to prevent future drift is tracked separately, to keep this change focused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container cleanup handling while preserving the same execution order and error reporting.
  * Updated Mosquitto integration checks to use the current test context, improving cancellation behavior.
  * Made MySQL container startup more explicit and consistent, improving integration setup stability.

* **Tests**
  * Adjusted container-related tests to better align with context handling and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->