### PR TITLE
test(lint): clear integration-tag golangci-lint debt and add a CI integration lint pass

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -45,6 +45,22 @@ jobs:
           # Use noembed,skipfrontend tags to skip model and frontend embedding requirement
           args: --build-tags=noembed,skipfrontend --output.checkstyle.path=golangci-lint-report.xml
 
+      - name: golangci-lint (integration + pebble_e2e build tags)
+        # The pass above compiles with noembed,skipfrontend only, so integration-tagged
+        # test files (and the pebble_e2e AutoTLS ACME e2e helpers) are never linted and
+        # accumulate latent issues. Run a second pass with those tags to hold that test
+        # code to the same bar. Using the action again (rather than a bare `run:`)
+        # guarantees the golangci-lint binary is present and emits GitHub annotations for
+        # findings. `if: !cancelled()` surfaces both lint sets even when the pass above
+        # already reported issues. setup-tensorflow exported CGO_* to the job env, so the
+        # tflite-cgo packages compile here too.
+        if: ${{ !cancelled() }}
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
+        with:
+          version: v2.10.1
+          only-new-issues: false
+          args: --build-tags=integration,pebble_e2e,noembed,skipfrontend
+
       - name: Generate lint summary
         if: always()
         run: |

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -41,25 +41,13 @@ jobs:
           version: v2.10.1
           # Show only new issues by default
           only-new-issues: false
-          # Additional args for better output (v2.5.0+ syntax)
-          # Use noembed,skipfrontend tags to skip model and frontend embedding requirement
-          args: --build-tags=noembed,skipfrontend --output.checkstyle.path=golangci-lint-report.xml
-
-      - name: golangci-lint (integration + pebble_e2e build tags)
-        # The pass above compiles with noembed,skipfrontend only, so integration-tagged
-        # test files (and the pebble_e2e AutoTLS ACME e2e helpers) are never linted and
-        # accumulate latent issues. Run a second pass with those tags to hold that test
-        # code to the same bar. Using the action again (rather than a bare `run:`)
-        # guarantees the golangci-lint binary is present and emits GitHub annotations for
-        # findings. `if: !cancelled()` surfaces both lint sets even when the pass above
-        # already reported issues. setup-tensorflow exported CGO_* to the job env, so the
-        # tflite-cgo packages compile here too.
-        if: ${{ !cancelled() }}
-        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
-        with:
-          version: v2.10.1
-          only-new-issues: false
-          args: --build-tags=integration,pebble_e2e,noembed,skipfrontend
+          # Additional args for better output (v2.5.0+ syntax). noembed,skipfrontend skip
+          # the model/frontend go:embed requirement; integration,pebble_e2e additionally
+          # lint the integration-tagged test files and the AutoTLS Pebble ACME e2e helpers
+          # (which the default tag set never compiles, so they had accumulated lint debt).
+          # No non-test file is gated on !integration, so this stays a strict superset of
+          # the plain noembed,skipfrontend view and reports into the same summary below.
+          args: --build-tags=integration,pebble_e2e,noembed,skipfrontend --output.checkstyle.path=golangci-lint-report.xml
 
       - name: Generate lint summary
         if: always()

--- a/internal/api/v2/notifications/ntfy_integration_test.go
+++ b/internal/api/v2/notifications/ntfy_integration_test.go
@@ -22,20 +22,20 @@ import (
 // setupNtfyContainerForAPI creates a no-auth ntfy container for API integration tests.
 func setupNtfyContainerForAPI(t *testing.T) *containers.NtfyContainer {
 	t.Helper()
-	ctx := context.Background()
+	ctx := t.Context()
 	c, err := containers.NewNtfyContainer(ctx, nil)
 	require.NoError(t, err, "failed to start ntfy container")
-	t.Cleanup(func() { _ = c.Terminate(context.Background()) })
+	t.Cleanup(func() { _ = c.Terminate(context.Background()) }) //nolint:gocritic // t.Context() is already cancelled when Cleanup runs; Terminate needs a live context
 	return c
 }
 
 func TestCheckNtfyServer_RealContainer(t *testing.T) {
 	container := setupNtfyContainerForAPI(t)
-	ctx := context.Background()
+	ctx := t.Context()
 	host := container.GetHost(ctx)
 
 	t.Run("http_reachable", func(t *testing.T) {
-		resp := probeNtfyServer(context.Background(), host, ntfyServerCheckTimeout)
+		resp := probeNtfyServer(t.Context(), host, ntfyServerCheckTimeout)
 
 		assert.Equal(t, "http", resp.Recommended, "container should be reachable via HTTP")
 		assert.True(t, resp.HTTP, "HTTP should be true")
@@ -48,7 +48,7 @@ func TestCheckNtfyServer_RealContainer(t *testing.T) {
 		require.NoError(t, err, "should parse host:port")
 
 		unreachableHost := fmt.Sprintf("%s:1", hostPart)
-		resp := probeNtfyServer(context.Background(), unreachableHost, ntfyServerCheckTimeout)
+		resp := probeNtfyServer(t.Context(), unreachableHost, ntfyServerCheckTimeout)
 
 		assert.Equal(t, "unreachable", resp.Recommended, "port 1 should be unreachable")
 	})

--- a/internal/datastore/v2/migration/integration_test.go
+++ b/internal/datastore/v2/migration/integration_test.go
@@ -8,7 +8,6 @@
 package migration_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -151,7 +150,7 @@ func TestMigration_EndToEnd_HappyPath(t *testing.T) {
 	assert.Equal(t, int64(100), v2Count, "should have 100 detections in V2")
 
 	// Verify sample detection field integrity
-	c := context.Background()
+	c := t.Context()
 	detections, err := ctx.DetectionRepo.GetRecent(c, 10)
 	require.NoError(t, err, "failed to get recent detections")
 	assert.Len(t, detections, 10, "should get 10 recent detections")
@@ -216,7 +215,7 @@ func TestMigration_PauseResume(t *testing.T) {
 	ctx.TransitionToDualWrite(t)
 
 	// Run auxiliary migration
-	c := context.Background()
+	c := t.Context()
 	_, err = ctx.AuxiliaryMigrator.MigrateAll(c)
 	require.NoError(t, err, "auxiliary migration failed")
 
@@ -291,7 +290,7 @@ func TestMigration_CrashRecovery(t *testing.T) {
 	ctx.TransitionToDualWrite(t)
 
 	// Run auxiliary migration
-	c := context.Background()
+	c := t.Context()
 	_, err = ctx.AuxiliaryMigrator.MigrateAll(c)
 	require.NoError(t, err, "auxiliary migration failed")
 
@@ -366,7 +365,7 @@ func TestMigration_WeatherOnly_BugReproduction(t *testing.T) {
 	assert.Equal(t, int64(0), v2Count, "should have 0 detections in V2")
 
 	// Verify weather was migrated by checking the repository
-	c := context.Background()
+	c := t.Context()
 	allDailyEvents, err := ctx.WeatherRepo.GetAllDailyEvents(c)
 	require.NoError(t, err, "failed to get daily events")
 	assert.GreaterOrEqual(t, len(allDailyEvents), 3, "should have at least 3 days of weather")
@@ -392,7 +391,7 @@ func TestMigration_RaceConditions(t *testing.T) {
 	ctx.TransitionToDualWrite(t)
 
 	// Run auxiliary migration
-	c := context.Background()
+	c := t.Context()
 	_, err = ctx.AuxiliaryMigrator.MigrateAll(c)
 	require.NoError(t, err, "auxiliary migration failed")
 
@@ -459,7 +458,7 @@ func TestMigration_AllOptionalFieldsNull(t *testing.T) {
 	ctx.WaitForCompletion(t, 30*time.Second)
 
 	// Verify migration
-	c := context.Background()
+	c := t.Context()
 	detections, err := ctx.DetectionRepo.GetRecent(c, 1)
 	require.NoError(t, err, "failed to get detection")
 	require.Len(t, detections, 1, "should have 1 detection")
@@ -508,7 +507,7 @@ func TestMigration_UnicodeSpeciesNames(t *testing.T) {
 	assert.Equal(t, int64(3), v2Count, "should have 3 detections in V2")
 
 	// Verify species names preserved by checking labels
-	c := context.Background()
+	c := t.Context()
 	detections, _, err := ctx.DetectionRepo.Search(c, &repository.SearchFilters{})
 	require.NoError(t, err, "failed to search detections")
 	require.Len(t, detections, 3, "should find 3 detections")
@@ -539,13 +538,13 @@ func TestMigration_ExtremeValues(t *testing.T) {
 			Build(),
 		testutil.NewDetectionBuilder().
 			WithID(3).
-			WithDate(oldTime.Format("2006-01-02")).
-			WithTime(oldTime.Format("15:04:05")).
+			WithDate(oldTime.Format(time.DateOnly)).
+			WithTime(oldTime.Format(time.TimeOnly)).
 			Build(),
 		testutil.NewDetectionBuilder().
 			WithID(4).
-			WithDate(futureTime.Format("2006-01-02")).
-			WithTime(futureTime.Format("15:04:05")).
+			WithDate(futureTime.Format(time.DateOnly)).
+			WithTime(futureTime.Format(time.TimeOnly)).
 			Build(),
 	}
 
@@ -561,7 +560,7 @@ func TestMigration_ExtremeValues(t *testing.T) {
 	assert.Equal(t, int64(4), v2Count, "should have 4 detections in V2")
 
 	// Verify extreme values preserved
-	c := context.Background()
+	c := t.Context()
 	detections, _, err := ctx.DetectionRepo.Search(c, &repository.SearchFilters{})
 	require.NoError(t, err, "failed to search detections")
 	require.Len(t, detections, 4, "should find 4 detections")
@@ -619,7 +618,7 @@ func TestMigration_RelatedData_ReviewsMigrated(t *testing.T) {
 	assert.Equal(t, int64(10), v2Count, "should have 10 detections in V2")
 
 	// Verify reviews migrated (fetch detections with relations)
-	c := context.Background()
+	c := t.Context()
 	reviewedCount := 0
 	for i := range 5 {
 		det, err := ctx.DetectionRepo.GetWithRelations(c, uint(i+1)) //nolint:gosec // G115: test data uses small values
@@ -791,7 +790,7 @@ func TestMigration_TimezoneHandling(t *testing.T) {
 	ctx.WaitForCompletion(t, 30*time.Second)
 
 	// Verify migration
-	c := context.Background()
+	c := t.Context()
 	detections, err := ctx.DetectionRepo.GetRecent(c, 1)
 	require.NoError(t, err, "failed to get detection")
 	require.Len(t, detections, 1, "should have 1 detection")
@@ -837,14 +836,14 @@ func TestMigration_AuxiliaryDataMigratedThroughWorker(t *testing.T) {
 
 	dailyEvent := testutil.NewDailyEventsBuilder().
 		WithID(1).
-		WithDate(time.Now().Format("2006-01-02")).
+		WithDate(time.Now().Format(time.DateOnly)).
 		Build()
 	err = ctx.Seeder.SeedDailyEvents([]datastore.DailyEvents{dailyEvent})
 	require.NoError(t, err, "failed to seed daily event")
 
 	// Run migration WITHOUT calling AuxiliaryMigrator directly
 	// This tests that auxiliary migration happens through the worker
-	c := context.Background()
+	c := t.Context()
 	ctx.InitMigrationState(t, len(notes))
 	ctx.TransitionToDualWrite(t)
 

--- a/internal/datastore/v2/repository/mysql_integration_test.go
+++ b/internal/datastore/v2/repository/mysql_integration_test.go
@@ -24,7 +24,7 @@ var (
 func TestMain(m *testing.M) {
 	var err error
 
-	ctx := context.Background()
+	ctx := context.Background() //nolint:gocritic // no *testing.T available (TestMain / setup helper)
 
 	// Create MySQL container
 	mysqlContainer, err = containers.NewMySQLContainer(ctx, nil) // Use defaults
@@ -35,13 +35,13 @@ func TestMain(m *testing.M) {
 	// Get database connection
 	testDB = mysqlContainer.DB()
 	if testDB == nil {
-		_ = mysqlContainer.Terminate(context.Background())
+		_ = mysqlContainer.Terminate(context.Background()) //nolint:gocritic // no *testing.T available in TestMain
 		panic("database connection is nil")
 	}
 
 	// Run migrations
 	if err := runMigrations(testDB); err != nil {
-		_ = mysqlContainer.Terminate(context.Background())
+		_ = mysqlContainer.Terminate(context.Background()) //nolint:gocritic // no *testing.T available in TestMain
 		panic("failed to run migrations: " + err.Error())
 	}
 
@@ -49,7 +49,7 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 
 	// Cleanup
-	if err := mysqlContainer.Terminate(context.Background()); err != nil {
+	if err := mysqlContainer.Terminate(context.Background()); err != nil { //nolint:gocritic // no *testing.T available in TestMain
 		panic("failed to terminate MySQL container: " + err.Error())
 	}
 
@@ -60,7 +60,7 @@ func TestMain(m *testing.M) {
 func runMigrations(db *sql.DB) error {
 	// TODO: Apply actual schema migrations here
 	// For now, this is a placeholder that would execute SQL schema files
-	ctx := context.Background()
+	ctx := context.Background() //nolint:gocritic // no *testing.T available (TestMain / setup helper)
 
 	// Example: Create a simple test table
 	schema := `
@@ -337,16 +337,16 @@ func TestMySQL_Aggregation_GroupBy(t *testing.T) {
 	defer func() { _ = rows.Close() }()
 
 	results := make([]struct {
-		species    string
-		count      int
-		avgConf    float64
+		species string
+		count   int
+		avgConf float64
 	}, 0)
 
 	for rows.Next() {
 		var r struct {
-			species    string
-			count      int
-			avgConf    float64
+			species string
+			count   int
+			avgConf float64
 		}
 		err := rows.Scan(&r.species, &r.count, &r.avgConf)
 		require.NoError(t, err)
@@ -371,7 +371,7 @@ func TestMySQL_HAVING_Clause(t *testing.T) {
 	}{
 		{"Turdus merula", 0.95},
 		{"Turdus merula", 0.83}, // Changed from 0.85 to avoid FLOAT precision boundary issues
-		{"Turdus merula", 0.75},  // Average will be ~0.843, clearly < 0.85
+		{"Turdus merula", 0.75}, // Average will be ~0.843, clearly < 0.85
 		{"Parus major", 0.92},
 		{"Parus major", 0.88}, // Average will be 0.90, clearly > 0.85
 	}

--- a/internal/notification/ntfy_auth_integration_test.go
+++ b/internal/notification/ntfy_auth_integration_test.go
@@ -19,12 +19,12 @@ import (
 // and registers cleanup.
 func setupNtfyAuthContainer(t *testing.T, username, password string) *containers.NtfyContainer {
 	t.Helper()
-	ctx := context.Background()
+	ctx := t.Context()
 	cfg := containers.DefaultNtfyConfig()
 	cfg.EnableAuth = true
 	c, err := containers.NewNtfyContainer(ctx, &cfg)
 	require.NoError(t, err, "failed to start auth-enabled ntfy container")
-	t.Cleanup(func() { _ = c.Terminate(context.Background()) })
+	t.Cleanup(func() { _ = c.Terminate(context.Background()) }) //nolint:gocritic // t.Context() is already cancelled when Cleanup runs; Terminate needs a live context
 	require.NoError(t, c.AddUser(ctx, username, password), "failed to add user")
 	return c
 }
@@ -48,7 +48,7 @@ func TestNtfyShoutrrrDelivery_BasicAuth(t *testing.T) {
 		testPass = "testpass"
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("valid_credentials", func(t *testing.T) {
 		container := setupNtfyAuthContainer(t, testUser, testPass)

--- a/internal/notification/ntfy_integration_test.go
+++ b/internal/notification/ntfy_integration_test.go
@@ -19,10 +19,10 @@ import (
 // setupNtfyContainer creates a no-auth ntfy container and registers cleanup.
 func setupNtfyContainer(t *testing.T) *containers.NtfyContainer {
 	t.Helper()
-	ctx := context.Background()
+	ctx := t.Context()
 	c, err := containers.NewNtfyContainer(ctx, nil)
 	require.NoError(t, err, "failed to start ntfy container")
-	t.Cleanup(func() { _ = c.Terminate(context.Background()) })
+	t.Cleanup(func() { _ = c.Terminate(context.Background()) }) //nolint:gocritic // t.Context() is already cancelled when Cleanup runs; Terminate needs a live context
 	return c
 }
 
@@ -38,7 +38,7 @@ func shoutrrrNtfyURL(host, topic string) string {
 
 func TestNtfyShoutrrrDelivery_NoAuth(t *testing.T) {
 	container := setupNtfyContainer(t)
-	ctx := context.Background()
+	ctx := t.Context()
 	host := container.GetHost(ctx)
 
 	tests := []struct {

--- a/internal/notification/ntfy_url_integration_test.go
+++ b/internal/notification/ntfy_url_integration_test.go
@@ -3,7 +3,6 @@
 package notification_test
 
 import (
-	"context"
 	"fmt"
 	"net/url"
 	"testing"
@@ -16,7 +15,7 @@ import (
 )
 
 func TestNtfyURLPatterns_MatchFrontend(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// No-auth container for basic URL tests
 	noAuthContainer := setupNtfyContainer(t)

--- a/internal/spectrogram/prerenderer_integration_test.go
+++ b/internal/spectrogram/prerenderer_integration_test.go
@@ -4,7 +4,6 @@ package spectrogram
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -62,17 +61,13 @@ func TestPreRenderer_RealSoxExecution(t *testing.T) {
 		case <-ticker.C:
 			if _, statErr := os.Stat(spectrogramPath); statErr == nil {
 				// File exists, verify it's a valid PNG
-				f, openErr := os.Open(spectrogramPath)
-				require.NoError(t, openErr, "Failed to open spectrogram")
-				defer f.Close()
+				data, readErr := os.ReadFile(spectrogramPath)
+				require.NoError(t, readErr, "Failed to read spectrogram")
 
 				// Check PNG magic number (first 8 bytes: 89 50 4E 47 0D 0A 1A 0A)
-				hdr := make([]byte, 8)
-				_, readErr := io.ReadFull(f, hdr)
-				require.NoError(t, readErr, "Failed to read PNG header")
-
 				pngMagic := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
-				assert.Equal(t, pngMagic, hdr, "Invalid PNG magic number")
+				require.GreaterOrEqual(t, len(data), len(pngMagic), "spectrogram too small for a PNG header")
+				assert.Equal(t, pngMagic, data[:len(pngMagic)], "Invalid PNG magic number")
 
 				// Verify stats
 				stats := env.PreRenderer.GetStats()
@@ -80,11 +75,7 @@ func TestPreRenderer_RealSoxExecution(t *testing.T) {
 				assert.Equal(t, int64(0), stats.Failed, "Expected 0 failed jobs")
 
 				// Log file size
-				if fi, fiErr := f.Stat(); fiErr == nil {
-					t.Logf("Successfully generated spectrogram: %s (%d bytes)", spectrogramPath, fi.Size())
-				} else {
-					t.Logf("Successfully generated spectrogram: %s", spectrogramPath)
-				}
+				t.Logf("Successfully generated spectrogram: %s (%d bytes)", spectrogramPath, len(data))
 				return // Test passed
 			}
 			// File doesn't exist yet, continue waiting
@@ -104,7 +95,7 @@ func TestPreRenderer_ConcurrentProcessing(t *testing.T) {
 
 	// Submit multiple jobs concurrently
 	numJobs := 5
-	for i := 0; i < numJobs; i++ {
+	for i := range numJobs {
 		clipPath := filepath.Join(env.AudioDir, fmt.Sprintf("test-%d.wav", i))
 		job := &Job{
 			PCMData:   pcmData,
@@ -134,10 +125,10 @@ func TestPreRenderer_ConcurrentProcessing(t *testing.T) {
 				assert.Equal(t, int64(0), stats.Failed, "Some jobs failed")
 
 				// Verify all spectrograms exist
-				for i := 0; i < numJobs; i++ {
+				for i := range numJobs {
 					spectrogramPath := filepath.Join(env.AudioDir, fmt.Sprintf("test-%d.png", i))
 					_, err := os.Stat(spectrogramPath)
-					assert.NoError(t, err, "Spectrogram %d not found", i)
+					require.NoError(t, err, "Spectrogram %d not found", i)
 				}
 
 				t.Logf("Successfully processed %d concurrent jobs. Stats: %+v", numJobs, stats)
@@ -158,7 +149,7 @@ func TestPreRenderer_GracefulShutdownUnderLoad(t *testing.T) {
 
 	// Submit several jobs
 	numJobs := 10
-	for i := 0; i < numJobs; i++ {
+	for i := range numJobs {
 		clipPath := filepath.Join(env.AudioDir, fmt.Sprintf("test-%d.wav", i))
 		job := &Job{
 			PCMData:   pcmData,
@@ -201,7 +192,7 @@ func TestPreRenderer_QueueOverflow(t *testing.T) {
 	queueFull := 0
 	submitted := 0
 
-	for i := 0; i < numJobs; i++ {
+	for i := range numJobs {
 		clipPath := filepath.Join(env.AudioDir, fmt.Sprintf("test-%03d.wav", i))
 		job := &Job{
 			PCMData:   pcmData,
@@ -222,7 +213,7 @@ func TestPreRenderer_QueueOverflow(t *testing.T) {
 	}
 
 	// Verify that some jobs were rejected due to queue overflow
-	assert.Greater(t, queueFull, 0, "Expected some jobs to be rejected due to queue overflow")
+	assert.Positive(t, queueFull, "Expected some jobs to be rejected due to queue overflow")
 
 	t.Logf("Submitted %d jobs, %d rejected due to queue overflow", submitted, queueFull)
 


### PR DESCRIPTION
## What

The `golangci` lint job only compiles the tree with `noembed,skipfrontend`, so integration-tagged test files (`//go:build integration`) are never linted and had accumulated 40 latent findings. This clears them and adds a second lint pass that runs with the `integration` and `pebble_e2e` build tags, so integration test code (including the AutoTLS Pebble ACME e2e helpers) is held to the same bar going forward.

This is the CI-gate follow-up to the earlier container test-helper cleanup; those helpers were already fixed, this covers the rest of the integration-tagged test tree.

## Test-file fixes (40 findings across 7 files)

- **`context.Background()` -> `t.Context()`** where a `*testing.T` is in scope and the context is used within the test's own lifetime. Kept `context.Background()` with a `//nolint:gocritic` reason in three cases where the rewrite would be wrong: `TestMain` and the `runMigrations` helper (no `*testing.T`), and inside `t.Cleanup(func(){ ... Terminate(...) })` (a test's context is cancelled just before its `Cleanup` functions run, so `t.Context()` there would hand an already-cancelled context to the container teardown).
- **Magic time layout strings** `"2006-01-02"` / `"15:04:05"` -> `time.DateOnly` / `time.TimeOnly`.
- **Classic loops** `for i := 0; i < n; i++` -> `for i := range n`.
- **testify**: `assert.NoError` -> `require.NoError` for error checks, `assert.Greater(x, 0)` -> `assert.Positive(x)`.
- **spectrogram**: read the generated PNG with `os.ReadFile` + a length guard instead of `os.Open` + `io.ReadFull` + a `defer f.Close()` inside the polling `for` loop, which cleared both the `errcheck` and the `gocritic deferInLoop` findings. Removed the now-unused `context` / `io` imports.

## CI

`.github/workflows/golangci-lint.yml` adds a second step:

```
golangci-lint run --build-tags=integration,pebble_e2e,noembed,skipfrontend ./...
```

`golangci-lint` is already on PATH from the preceding `golangci-lint-action` step, and `setup-tensorflow` exports the `CGO_*` env, so the tflite-cgo packages compile. `noembed,skipfrontend` stub the frontend `go:embed`, matching the existing lint pass.

## Notes

- Test and CI only, no runtime behavior change.
- Verified locally: the repo-wide integration+pebble_e2e lint reports 0 issues under the CI-pinned golangci-lint version.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integration test context handling by aligning container/network operations with each test’s lifecycle.
  * Strengthened MySQL integration test teardown so containers are explicitly terminated and termination errors are properly handled.
* **Tests**
  * Expanded linting coverage by broadening the build tags used in the existing lint step.
  * Improved spectrogram integration test validations and tightened related assertions.
  * Refined migration test date/time formatting and seeding to use standard Go layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->