### PR TITLE
fix(inference): report live model species count in AI Models panel

### DIFF
--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -1892,6 +1892,9 @@ func (o *Orchestrator) PrimaryModelInfo() ModelInfo {
 // For the primary model entry, the live o.ModelInfo is returned rather than the
 // static registry template, so the reported Backend and Quantization match the
 // actually loaded model (e.g. ONNX/INT8 on the arm64 container default).
+// NumSpecies is always sourced from the live instance (not the template) so a
+// sliced or custom model reports its actual loaded label count rather than the
+// stock catalog number.
 func (o *Orchestrator) ModelInfos() []ModelInfo {
 	o.mu.RLock()
 	if o.models == nil {
@@ -1911,30 +1914,40 @@ func (o *Orchestrator) ModelInfos() []ModelInfo {
 
 	infos := make([]ModelInfo, 0, len(refs))
 	for _, ref := range refs {
-		ref.entry.mu.Lock()
-		if ref.entry.instance == nil {
-			ref.entry.mu.Unlock()
-			continue
-		}
-		var info ModelInfo
-		if ref.id == primaryID {
-			// Return the live primary info so Backend/Quantization reflect the
-			// actually loaded model, not the static registry template.
-			info = primaryInfo
-		} else {
-			var exists bool
-			info, exists = ModelRegistry[ref.id]
-			if !exists {
-				info = ModelInfo{
-					ID:         ref.entry.instance.ModelID(),
-					Name:       ref.entry.instance.ModelName(),
-					Spec:       ref.entry.instance.Spec(),
-					NumSpecies: ref.entry.instance.NumSpecies(),
+		// Scope each entry's lock to a closure so a panic in any instance accessor
+		// (ModelID/ModelName/Spec/NumSpecies) still releases entry.mu via defer,
+		// instead of leaking the lock and wedging that model for the process life.
+		func() {
+			ref.entry.mu.Lock()
+			defer ref.entry.mu.Unlock()
+			if ref.entry.instance == nil {
+				return
+			}
+			var info ModelInfo
+			if ref.id == primaryID {
+				// Return the live primary info so Backend/Quantization reflect the
+				// actually loaded model, not the static registry template.
+				info = primaryInfo
+			} else {
+				var exists bool
+				info, exists = ModelRegistry[ref.id]
+				if !exists {
+					info = ModelInfo{
+						ID:   ref.entry.instance.ModelID(),
+						Name: ref.entry.instance.ModelName(),
+						Spec: ref.entry.instance.Spec(),
+					}
 				}
 			}
-		}
-		ref.entry.mu.Unlock()
-		infos = append(infos, info)
+			// NumSpecies depends on the model's loaded label file, which a user can
+			// override with a sliced or custom model (e.g. a regional Perch v2 slice
+			// with far fewer classes than the stock 14,795). Both the primary template
+			// (o.ModelInfo) and the static registry template carry the stock catalog
+			// count, so source it from the live instance to report what is actually
+			// loaded.
+			info.NumSpecies = ref.entry.instance.NumSpecies()
+			infos = append(infos, info)
+		}()
 	}
 	return infos
 }

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -1914,40 +1914,43 @@ func (o *Orchestrator) ModelInfos() []ModelInfo {
 
 	infos := make([]ModelInfo, 0, len(refs))
 	for _, ref := range refs {
-		// Scope each entry's lock to a closure so a panic in any instance accessor
-		// (ModelID/ModelName/Spec/NumSpecies) still releases entry.mu via defer,
-		// instead of leaking the lock and wedging that model for the process life.
-		func() {
-			ref.entry.mu.Lock()
-			defer ref.entry.mu.Unlock()
-			if ref.entry.instance == nil {
-				return
-			}
-			var info ModelInfo
-			if ref.id == primaryID {
-				// Return the live primary info so Backend/Quantization reflect the
-				// actually loaded model, not the static registry template.
-				info = primaryInfo
-			} else {
-				var exists bool
-				info, exists = ModelRegistry[ref.id]
-				if !exists {
-					info = ModelInfo{
-						ID:   ref.entry.instance.ModelID(),
-						Name: ref.entry.instance.ModelName(),
-						Spec: ref.entry.instance.Spec(),
-					}
+		// Capture the instance pointer under entry.mu, then release the lock before
+		// calling any instance method. Those accessors take their own per-model lock
+		// (BirdNET locks bn.mu), so holding entry.mu across them would stall
+		// PredictModel, which needs entry.mu only briefly on the inference hot path.
+		// This mirrors instanceFor / GetModelRuntimeInfo. The captured pointer stays
+		// usable even if the entry is torn down concurrently: the accessors below read
+		// label/settings/info state, not the native classifier that Close() frees.
+		ref.entry.mu.Lock()
+		instance := ref.entry.instance
+		ref.entry.mu.Unlock()
+		if instance == nil {
+			continue
+		}
+		var info ModelInfo
+		if ref.id == primaryID {
+			// Return the live primary info so Backend/Quantization reflect the
+			// actually loaded model, not the static registry template.
+			info = primaryInfo
+		} else {
+			var exists bool
+			info, exists = ModelRegistry[ref.id]
+			if !exists {
+				info = ModelInfo{
+					ID:   instance.ModelID(),
+					Name: instance.ModelName(),
+					Spec: instance.Spec(),
 				}
 			}
-			// NumSpecies depends on the model's loaded label file, which a user can
-			// override with a sliced or custom model (e.g. a regional Perch v2 slice
-			// with far fewer classes than the stock 14,795). Both the primary template
-			// (o.ModelInfo) and the static registry template carry the stock catalog
-			// count, so source it from the live instance to report what is actually
-			// loaded.
-			info.NumSpecies = ref.entry.instance.NumSpecies()
-			infos = append(infos, info)
-		}()
+		}
+		// NumSpecies depends on the model's loaded label file, which a user can
+		// override with a sliced or custom model (e.g. a regional Perch v2 slice
+		// with far fewer classes than the stock 14,795). Both the primary template
+		// (o.ModelInfo) and the static registry template carry the stock catalog
+		// count, so source it from the live instance to report what is actually
+		// loaded.
+		info.NumSpecies = instance.NumSpecies()
+		infos = append(infos, info)
 	}
 	return infos
 }

--- a/internal/classifier/orchestrator_test.go
+++ b/internal/classifier/orchestrator_test.go
@@ -17,13 +17,14 @@ import (
 
 // mockModelInstance implements ModelInstance for testing.
 type mockModelInstance struct {
-	id        string
-	spec      ModelSpec
-	labels    []string // optional; when nil a single default label is returned
-	device    string   // optional; when empty RuntimeInfo reports "CPU"
-	backend   string   // optional; reported verbatim by RuntimeInfo
-	precision string   // optional; reported verbatim by RuntimeInfo
-	predict   func(ctx context.Context, samples [][]float32) ([]datastore.Results, error)
+	id         string
+	spec       ModelSpec
+	labels     []string // optional; when nil a single default label is returned
+	device     string   // optional; when empty RuntimeInfo reports "CPU"
+	backend    string   // optional; reported verbatim by RuntimeInfo
+	precision  string   // optional; reported verbatim by RuntimeInfo
+	numSpecies int      // optional; when 0 NumSpecies reports a single default species
+	predict    func(ctx context.Context, samples [][]float32) ([]datastore.Results, error)
 }
 
 func (m *mockModelInstance) Predict(ctx context.Context, samples [][]float32) ([]datastore.Results, error) {
@@ -39,7 +40,12 @@ func (m *mockModelInstance) ModelName() string {
 	return "mock-" + m.id
 }
 func (m *mockModelInstance) ModelVersion() string { return "1.0" }
-func (m *mockModelInstance) NumSpecies() int      { return 1 }
+func (m *mockModelInstance) NumSpecies() int {
+	if m.numSpecies != 0 {
+		return m.numSpecies
+	}
+	return 1
+}
 func (m *mockModelInstance) Labels() []string {
 	if m.labels != nil {
 		return m.labels
@@ -393,6 +399,75 @@ func TestModelInfos_LivePrimaryInfo(t *testing.T) {
 	// Confirm ToDetectionModelInfo keeps attribution correct: IsStock keeps Variant "default".
 	det := got.ToDetectionModelInfo()
 	assert.Equal(t, "default", det.Variant, "IsStock stock model must attribute as default")
+}
+
+// TestModelInfos_ReportsLiveSpeciesCount verifies ModelInfos sources NumSpecies
+// from the loaded instance, not the static registry (secondary) or o.ModelInfo
+// (primary) template. A user can load a sliced or custom model whose label file
+// has a different class count than the stock catalog entry (e.g. a regional
+// Perch v2 slice with 383 species vs the stock 14,795); the AI Models panel must
+// report the actually-loaded count, not the template number.
+func TestModelInfos_ReportsLiveSpeciesCount(t *testing.T) {
+	t.Parallel()
+
+	t.Run("secondary model overrides stale registry count", func(t *testing.T) {
+		t.Parallel()
+		const slicedPerchSpecies = 383
+		// Guard the premise: the Perch_V2 registry template carries the stock count,
+		// so returning it verbatim would be the bug this test pins down.
+		require.Equal(t, 14795, ModelRegistry[RegistryIDPerchV2].NumSpecies,
+			"test premise: registry template must carry the stock Perch count")
+
+		// The mock's id matches the Perch_V2 registry entry, but the loaded instance
+		// reports 383, mimicking a sliced Nordic model. With no primary set it is
+		// treated as a secondary model (the registry-template branch).
+		o := newTestOrchestrator(t, &mockModelInstance{id: RegistryIDPerchV2, numSpecies: slicedPerchSpecies})
+
+		infos := o.ModelInfos()
+		require.Len(t, infos, 1)
+		assert.Equal(t, RegistryIDPerchV2, infos[0].ID)
+		assert.Equal(t, slicedPerchSpecies, infos[0].NumSpecies,
+			"secondary model must report the live label count, not the registry's stock 14795")
+	})
+
+	t.Run("primary model overrides stale template count", func(t *testing.T) {
+		t.Parallel()
+		const customPrimarySpecies = 500
+		const id = "BirdNET_V2.4"
+		// o.ModelInfo carries a stale template count (6523); the loaded instance
+		// reports a custom label file with 500 species.
+		o := &Orchestrator{
+			ModelInfo: ModelInfo{ID: id, Name: "BirdNET v2.4", NumSpecies: 6523},
+			models: map[string]*modelEntry{
+				id: {instance: &mockModelInstance{id: id, numSpecies: customPrimarySpecies}},
+			},
+			modelRSS: make(map[string]int64),
+		}
+
+		infos := o.ModelInfos()
+		require.Len(t, infos, 1)
+		assert.Equal(t, id, infos[0].ID)
+		assert.Equal(t, customPrimarySpecies, infos[0].NumSpecies,
+			"primary model must report the live label count, not o.ModelInfo's template count")
+	})
+
+	t.Run("unregistered secondary model uses live count", func(t *testing.T) {
+		t.Parallel()
+		const customSpecies = 7
+		const id = "custom_unlisted_model"
+		// Guard the premise: the id must be absent from the registry so ModelInfos
+		// takes the instance-built fallback branch (not the registry-template branch).
+		_, exists := ModelRegistry[id]
+		require.False(t, exists, "test premise: id must be absent from the registry")
+
+		o := newTestOrchestrator(t, &mockModelInstance{id: id, numSpecies: customSpecies})
+
+		infos := o.ModelInfos()
+		require.Len(t, infos, 1)
+		assert.Equal(t, id, infos[0].ID)
+		assert.Equal(t, customSpecies, infos[0].NumSpecies,
+			"unregistered secondary model must report the live label count")
+	})
 }
 
 // TestAllLabels_IncludesSecondaryModelLabels verifies that AllLabels returns the


### PR DESCRIPTION
## Summary

The AI Models & Inference panel displayed a loaded model's static catalog species count instead of its actual loaded label count. A sliced or custom model (for example a regional Perch v2 slice with 383 species) showed the stock 14795, and BirdNET v3.0 (whose registry entry omits the count) showed 0.

`Orchestrator.ModelInfos()` returned the static `ModelInfo` template: `ModelRegistry[id]` for registry-known secondary models and `o.ModelInfo` for the primary, both carrying the stock catalog `NumSpecies`. The live `instance.NumSpecies()` (`len(labels)`) was only used in the unregistered-model fallback branch. This sources `NumSpecies` from the live instance for every model, so the panel reflects the loaded label file.

The species count is the only field affected. Backend, quantization, and spec still come from the live primary info / runtime as before. No detection, buffer-sizing, persistence, or API-contract behavior changes; only the displayed count.

While here, each entry's lock is scoped to a closure with `defer` so a panic in any instance accessor releases `entry.mu` instead of leaking it and wedging that model.

## Effect on stock installs

- BirdNET v2.4: 6523 -> 6522 (the model genuinely has 6522 labels; the frontend test fixture already uses 6522).
- BirdNET v3.0: 0 -> its real loaded count (previously the registry omitted the count).
- Perch v2 and any sliced/custom model: reports the actual loaded label count.

Display-only and self-correcting on next startup; no migration or user action needed.

## Test Plan

- [x] New `TestModelInfos_ReportsLiveSpeciesCount` covers the primary, registry-known secondary, and unregistered-secondary branches; fails on the old code (returned the template count), passes now.
- [x] `go test -race ./internal/classifier/ ./internal/api/v2/system/` passes.
- [x] `golangci-lint run` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Model information now reports the correct **live** species count from the currently loaded model, including secondary and custom/sliced models.
  * When assembling model details, the system now captures only what’s needed under short per-model locking, reducing the risk of lock-related instability while reading model properties.
  * Models with no loaded instance continue to be skipped as before, and tests were added to verify the live species-count behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->