### PR TITLE
fix(classifier): refresh primary ModelInfo.NumSpecies from the loaded label count

### DIFF
--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -641,13 +641,25 @@ func (bn *BirdNET) initializeTFLiteMetaModel(settings *conf.Settings) error {
 func (bn *BirdNET) loadLabels() error {
 	bn.Settings.BirdNET.Labels = []string{} // Reset labels.
 
-	// Use embedded labels if no external label path is set
+	// Use embedded labels if no external label path is set, otherwise use external labels.
+	var err error
 	if bn.Settings.BirdNET.LabelPath == "" {
-		return bn.loadEmbeddedLabels()
+		err = bn.loadEmbeddedLabels()
+	} else {
+		err = bn.loadExternalLabels()
+	}
+	if err != nil {
+		return err
 	}
 
-	// Otherwise use external labels
-	return bn.loadExternalLabels()
+	// Refresh the cached ModelInfo.NumSpecies to the actually-loaded label count.
+	// ModelInfo is seeded from the registry template, whose NumSpecies is the stock
+	// catalog figure (e.g. 6523 for BirdNET v2.4) and can differ from the real label
+	// file (6522) or a custom/sliced label file. loadLabels is the single place the
+	// label set changes, so refreshing here keeps o.ModelInfo / PrimaryModelInfo()
+	// reporting the live count. bn.NumSpecies() already reads len(labels) directly.
+	bn.ModelInfo.NumSpecies = len(bn.Settings.BirdNET.Labels)
+	return nil
 }
 
 // loadEmbeddedLabels loads labels from the embedded label files

--- a/internal/classifier/label_loading_external_test.go
+++ b/internal/classifier/label_loading_external_test.go
@@ -78,3 +78,41 @@ func TestLoadExternalLabels_MissingPathReportsExpandedPath(t *testing.T) {
 	assert.Contains(t, err.Error(), missing,
 		"error context should reference the expanded path, not the unexpanded $VAR template")
 }
+
+// TestLoadLabels_RefreshesModelInfoNumSpecies verifies loadLabels refreshes the
+// cached ModelInfo.NumSpecies to the actual loaded label count, so a stale stock
+// count seeded from the registry template (e.g. 6523 for BirdNET v2.4 vs the real
+// 6522) is corrected, and leaves it untouched when loading fails. This keeps
+// o.ModelInfo / PrimaryModelInfo() reporting the live count.
+func TestLoadLabels_RefreshesModelInfoNumSpecies(t *testing.T) {
+	t.Parallel()
+
+	const staleStockCount = 6523
+
+	t.Run("refreshes to the loaded label count", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		labelPath := filepath.Join(dir, "labels.txt")
+		require.NoError(t, os.WriteFile(labelPath, []byte(twoLabelFile), 0o644))
+
+		bn := newExternalLabelBirdNET(labelPath)
+		bn.ModelInfo.NumSpecies = staleStockCount // as the registry template would seed it
+
+		require.NoError(t, bn.loadLabels())
+		require.Len(t, bn.Settings.BirdNET.Labels, 2)
+		assert.Equal(t, 2, bn.ModelInfo.NumSpecies,
+			"loadLabels must refresh ModelInfo.NumSpecies to the loaded label count, not keep the stale template value")
+		assert.Equal(t, bn.NumSpecies(), bn.ModelInfo.NumSpecies,
+			"ModelInfo.NumSpecies must match the live NumSpecies() count")
+	})
+
+	t.Run("leaves NumSpecies untouched when loading fails", func(t *testing.T) {
+		t.Parallel()
+		bn := newExternalLabelBirdNET(filepath.Join(t.TempDir(), "does-not-exist.txt"))
+		bn.ModelInfo.NumSpecies = staleStockCount
+
+		require.Error(t, bn.loadLabels())
+		assert.Equal(t, staleStockCount, bn.ModelInfo.NumSpecies,
+			"a failed label load must not clobber the previous NumSpecies")
+	})
+}


### PR DESCRIPTION
## Summary

Follow-up hardening after the AI Models panel species-count fix (#3790).

The primary BirdNET's cached `ModelInfo.NumSpecies` was seeded from the registry template (the stock catalog figure, e.g. 6523 for v2.4) and never refreshed to the actually-loaded label count (6522), so `o.ModelInfo` and `PrimaryModelInfo()` reported the stale template value. `loadLabels()` is the single place the label set changes, so this refreshes `NumSpecies` there, covering both the construction (`NewBirdNET`) and reload (`reloadModelInternal`) paths. It brings the primary in line with the bat and perch models, which already set `NumSpecies = len(labels)` at load.

The value is left untouched on a failed load (early return before the assignment), and the reload rollback restores the prior count via its existing `ModelInfo` snapshot.

## Scope / impact

Latent-only correction. The AI Models & Inference panel already reports the live count via `ModelInfos()`, which overrides `NumSpecies` from the live instance, so no consumer read the stale `o.ModelInfo` field. No API, config, DB, or detection behavior changes; the raw cached field is simply brought in line with reality.

## Test Plan

- [x] New `TestLoadLabels_RefreshesModelInfoNumSpecies` (refresh-to-live-count + no-clobber-on-failure); fails on the old code (kept the stale 6523), passes now.
- [x] `go test -race ./internal/classifier/` passes.
- [x] `golangci-lint run` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Label loading now updates the app’s species count to match the actual labels loaded, preventing stale counts from appearing.
  * If label loading fails, the previous species count is preserved instead of being overwritten.
  * Error handling during label loading is now more consistent across supported label sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->