### PR TITLE
fix(api): emit RFC3339 timestamps for species summary first_heard/last_heard

### DIFF
--- a/internal/api/v2/analytics/analytics.go
+++ b/internal/api/v2/analytics/analytics.go
@@ -760,12 +760,16 @@ func (c *Handler) convertSummaryDataToResponse(summaryData []datastore.SpeciesSu
 	return response
 }
 
-// formatTimeIfNotZero formats time as string if not zero
+// formatTimeIfNotZero formats a timestamp as an ISO 8601 (RFC3339) string with a
+// timezone offset, or "" if the time is zero. RFC3339 is the timestamp format used
+// across the rest of the v2 API (detections, SSE, weather, notifications), so the
+// species summary's first_heard/last_heard match it and carry an unambiguous offset
+// for timezone-aware clients. See issue #3793.
 func formatTimeIfNotZero(t time.Time) string {
 	if t.IsZero() {
 		return ""
 	}
-	return t.Format(time.DateTime)
+	return t.Format(time.RFC3339)
 }
 
 // getThumbnailURLFromBirdImage extracts URL from BirdImage map

--- a/internal/api/v2/analytics/analytics_test.go
+++ b/internal/api/v2/analytics/analytics_test.go
@@ -129,9 +129,73 @@ func TestGetSpeciesSummary(t *testing.T) {
 		assert.Equal(t, "Blue Jay", response[1]["common_name"])
 		assert.Equal(t, "blujay", response[1]["species_code"])
 		assert.InDelta(t, 27, response[1]["count"], 0.01)
+
+		// first_heard / last_heard must be ISO 8601 (RFC3339) with a timezone
+		// offset, not the offset-less "2006-01-02 15:04:05" form. Regression
+		// guard for issue #3793. A successful RFC3339 parse also proves the
+		// offset is present, since RFC3339 requires one.
+		firstHeard, ok := response[0]["first_heard"].(string)
+		require.True(t, ok, "first_heard should be a string")
+		parsedFirst, err := time.Parse(time.RFC3339, firstHeard)
+		require.NoErrorf(t, err, "first_heard %q must be valid RFC3339", firstHeard)
+		assert.WithinDuration(t, firstSeen, parsedFirst, time.Second,
+			"first_heard should round-trip the FirstSeen instant")
+
+		lastHeard, ok := response[0]["last_heard"].(string)
+		require.True(t, ok, "last_heard should be a string")
+		parsedLast, err := time.Parse(time.RFC3339, lastHeard)
+		require.NoErrorf(t, err, "last_heard %q must be valid RFC3339", lastHeard)
+		assert.WithinDuration(t, lastSeen, parsedLast, time.Second,
+			"last_heard should round-trip the LastSeen instant")
 	}
 
 	// Verify mock expectations
+	mockDS.AssertExpectations(t)
+}
+
+// TestGetSpeciesSummary_ZeroTimeOmitsHeardFields verifies that a species with no
+// recorded first/last detection time (a zero time.Time) omits first_heard/last_heard
+// from the JSON response entirely, rather than emitting an empty string or a
+// 1970 epoch value. This guards the omitempty contract on the RFC3339-formatted
+// fields. Companion to the RFC3339 format assertion in TestGetSpeciesSummary. See
+// issue #3793.
+func TestGetSpeciesSummary_ZeroTimeOmitsHeardFields(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "analytics")
+	t.Attr("feature", "species-summary")
+
+	e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+	mockSummaryData := []datastore.SpeciesSummaryData{
+		{
+			ScientificName: "Turdus migratorius",
+			CommonName:     "American Robin",
+			SpeciesCode:    "amerob",
+			Count:          42,
+			// FirstSeen and LastSeen left as the zero time.Time on purpose.
+			AvgConfidence: 0.75,
+			MaxConfidence: 0.85,
+		},
+	}
+	mockDS.On("GetSpeciesSummaryData", mock.Anything, "", "").Return(mockSummaryData, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/analytics/species/summary", http.NoBody)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/api/v2/analytics/species/summary")
+
+	require.NoError(t, controller.GetSpeciesSummary(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var response []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	require.Len(t, response, 1)
+
+	_, hasFirst := response[0]["first_heard"]
+	assert.False(t, hasFirst, "first_heard should be omitted when the detection time is zero")
+	_, hasLast := response[0]["last_heard"]
+	assert.False(t, hasLast, "last_heard should be omitted when the detection time is zero")
+
 	mockDS.AssertExpectations(t)
 }
 


### PR DESCRIPTION
## What

`GET /api/v2/analytics/species/summary` returned `first_heard` / `last_heard` as `"2026-07-06 04:51:31"`: Go's `time.DateTime`, which has no timezone offset and is not ISO 8601. It was the only full-timestamp field in the entire v2 API that was not already RFC3339 (detections `timestamp`/`beginTime`/`endTime`, SSE, weather, and notifications all use RFC3339).

This switches the single formatting helper (`formatTimeIfNotZero`, one caller) to `time.RFC3339`, so the fields now emit e.g. `"2026-07-06T04:51:31+03:00"` with the server's timezone offset.

## Why

Without an offset the timestamps are ambiguous and clients have to guess the timezone. The underlying `time.Time` values already carry a real location (local time in the legacy datastore, the configured zone in the v2 datastore), so this is purely a formatting change.

## Regression / compatibility

- The web UI parses these fields through `parseLocalDateString` -> `new Date()`, which handles RFC3339 cleanly (and more reliably than the old space-separated form, which is implementation-defined in JS). Sorting compares `getTime()` and is unaffected. No frontend change is needed.
- The format is not pinned in any OpenAPI spec or the API README, and no test hardcoded the old string.
- This is technically a wire-format change: an external client that hardcoded a parser for `"YYYY-MM-DD HH:MM:SS"` on this endpoint should switch to an RFC3339 / ISO 8601 parser.
- The sibling daily-summary endpoint (`/analytics/species/daily`) is untouched; its `first_heard`/`latest_heard` are time-of-day strings from a different code path.

## Tests

- `TestGetSpeciesSummary` now asserts `first_heard`/`last_heard` parse as RFC3339 and round-trip the instant.
- `TestGetSpeciesSummary_ZeroTimeOmitsHeardFields` asserts a zero detection time still omits the fields (`omitempty`).

## Release note

`GET /api/v2/analytics/species/summary` now returns `first_heard` / `last_heard` in ISO 8601 (RFC3339) with a timezone offset (e.g. `2026-07-06T04:51:31+03:00`) instead of the previous offset-less `2026-07-06 04:51:31`. Clients parsing these fields should use an RFC3339 / ISO 8601 parser.

Fixes #3793


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Species summary responses now return `first_heard` and `last_heard` in standard RFC3339/ISO-8601 format.
  * When those values are not set, the fields are omitted from the response instead of showing blank or invalid timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->