### PR TITLE
build(docker): bundle OpenVINO runtime libraries in container images

### DIFF
--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -114,12 +114,12 @@ jobs:
           go vet -tags noembed,skipfrontend ./...
 
   # Compile-coverage gate for the OpenVINO inference backend
-  # (internal/inference/openvino, //go:build openvino). No other workflow
-  # compiles the openvino-tagged code: cross-build above and release/nightly omit
-  # the tag, and the Docker images build with OPENVINO=false. Without this job a
-  # compile error (including an arch-specific one) in the openvino-tagged backend
-  # or its tests would not be caught pre-merge. The backend is linux-only, so this
-  # covers linux/amd64 (native) and linux/arm64 (cross).
+  # (internal/inference/openvino, //go:build openvino). This is the fast, dedicated
+  # per-arch compile+vet gate for the openvino-tagged code: it runs on every PR and
+  # catches a compile error (including an arch-specific one) in the openvino-tagged
+  # backend or its tests before the heavier Docker image build (which now compiles
+  # the tag and bundles the OpenVINO runtime) runs. The backend is linux-only, so
+  # this covers linux/amd64 (native) and linux/arm64 (cross).
   openvino-build:
     name: openvino-build (linux/${{ matrix.goarch }})
     runs-on: ubuntu-24.04

--- a/Dockerfile
+++ b/Dockerfile
@@ -140,7 +140,8 @@ RUN set -eu; \
     cp -a "${OV_SRC}"/libopenvino_ir_frontend.so* /home/dev-user/lib/openvino/; \
     cp -a "${OV_SRC}/${OV_CPU_PLUGIN}"* /home/dev-user/lib/openvino/; \
     if [ -n "${OV_GPU_PLUGIN}" ]; then cp -a "${OV_SRC}/${OV_GPU_PLUGIN}"* /home/dev-user/lib/openvino/; fi; \
-    cp -a /tmp/ov/runtime/3rdparty/tbb/lib/*.so* /home/dev-user/lib/openvino/; \
+    find /tmp/ov/runtime/3rdparty/tbb/lib -name '*.so*' -exec cp -a {} /home/dev-user/lib/openvino/ \; ; \
+    test -e /home/dev-user/lib/openvino/libtbb.so.12; \
     rm -rf /tmp/openvino.tgz /tmp/ov; \
     echo "Staged OpenVINO runtime libraries: $(ls /home/dev-user/lib/openvino | wc -l) entries"
 
@@ -207,7 +208,10 @@ RUN apt-get update -q && apt-get install -q -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy ONNX Runtime libraries (used by all arches; arm64 relies on them exclusively).
-COPY --from=build /home/dev-user/lib/libonnxruntime*.so* /usr/lib/
+# --chown=root:root because COPY --from preserves the build-stage owner (dev-user,
+# UID 10001); system libraries must be root-owned so a runtime process cannot
+# overwrite them if it happens to share that UID.
+COPY --chown=root:root --from=build /home/dev-user/lib/libonnxruntime*.so* /usr/lib/
 
 # TensorFlow Lite C library: installed for non-arm64 only. arm64 is ONNX-only
 # (issue #1103) and the binary does not link libtensorflowlite_c. Stage it, then
@@ -225,7 +229,9 @@ RUN if [ "$TARGETPLATFORM" != "linux/arm64" ]; then \
 # without Intel GPU drivers, falls back to ONNX Runtime cleanly. The staging dir
 # holds the arch-appropriate set (see the build stage), with symlinks preserved so
 # the bare-soname dlopen resolves; ldconfig then refreshes the loader cache.
-COPY --from=build /home/dev-user/lib/openvino/ /usr/lib/
+# --chown=root:root because COPY --from preserves the build-stage owner (dev-user,
+# UID 10001); system libraries must be root-owned (see the ONNX Runtime copy above).
+COPY --chown=root:root --from=build /home/dev-user/lib/openvino/ /usr/lib/
 RUN ldconfig
 
 # Include reset_auth tool from build stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 ARG TENSORFLOW_VERSION=2.17.1
 ARG ONNXRUNTIME_VERSION=1.25.1
+# OpenVINO toolkit pin for the runtime libraries bundled into the images. Keep the
+# release/build in sync with the Taskfile OPENVINO_RELEASE / OPENVINO_BUILD values;
+# the SHA256s are per-arch (arm64 matches the Taskfile OPENVINO_SHA256 header pin).
+ARG OPENVINO_RELEASE=2026.2
+ARG OPENVINO_BUILD=2026.2.0.21903.52ddc073857
+ARG OPENVINO_SHA256_AMD64=86896e9347cd160370d16f80fa2c49c2b7a51ec33b55cea6493c7dc7c4c61c55
+ARG OPENVINO_SHA256_ARM64=8ce45467967e22fddb83a6b72a8bd1f9bfa6f43351e1ca2eaf5251064fe17767
 
 FROM --platform=$BUILDPLATFORM golang:1.26-trixie AS buildenv
 
@@ -90,16 +97,70 @@ RUN ONNX_ARCH=$(case "${TARGETPLATFORM}" in \
     cp /tmp/onnxruntime/lib/libonnxruntime*.so* /home/dev-user/lib/ && \
     rm -rf /tmp/onnxruntime /tmp/onnxruntime.tgz
 
-# Build assets and compile BirdNET-Go (non-embedded, TFLite + ONNX)
-# OPENVINO=false keeps the published images ONNX-only: the noembed_linux_* targets
-# default OpenVINO on, so the standard image must opt out explicitly.
+# OpenVINO runtime provisioning for the target platform. One toolkit download
+# serves two purposes: (1) the arch-independent C API headers are staged into the
+# Taskfile OpenVINO header cache (.cache/openvino) with a matching .build-id stamp,
+# so the check-openvino task treats them as up-to-date and does not re-download
+# during the build; (2) the arch-specific runtime .so set is staged into
+# /home/dev-user/lib/openvino for the final image. Only the libraries the backend
+# needs are kept (core, C API, ONNX + IR frontends, the arch CPU plugin, the amd64
+# iGPU plugin, and TBB); the unused frontends and plugins are dropped to save size.
+# The SHA256 is verified per arch before extraction (a moved or tampered upstream
+# archive can still return HTTP 200).
+ARG OPENVINO_RELEASE
+ARG OPENVINO_BUILD
+ARG OPENVINO_SHA256_AMD64
+ARG OPENVINO_SHA256_ARM64
+RUN set -eu; \
+    case "${TARGETPLATFORM}" in \
+        "linux/amd64") OV_SUFFIX=x86_64; OV_LIBDIR=intel64; OV_SHA256="${OPENVINO_SHA256_AMD64}"; OV_CPU_PLUGIN=libopenvino_intel_cpu_plugin.so; OV_GPU_PLUGIN=libopenvino_intel_gpu_plugin.so ;; \
+        "linux/arm64") OV_SUFFIX=arm64;  OV_LIBDIR=aarch64; OV_SHA256="${OPENVINO_SHA256_ARM64}"; OV_CPU_PLUGIN=libopenvino_arm_cpu_plugin.so;   OV_GPU_PLUGIN="" ;; \
+        *) echo "Error: unsupported platform ${TARGETPLATFORM}" >&2; exit 1 ;; \
+    esac; \
+    OV_BASE="openvino_toolkit_ubuntu22_${OPENVINO_BUILD}_${OV_SUFFIX}"; \
+    OV_URL="https://storage.openvinotoolkit.org/repositories/openvino/packages/${OPENVINO_RELEASE}/linux/${OV_BASE}.tgz"; \
+    echo "Downloading OpenVINO ${OPENVINO_BUILD} (${OV_SUFFIX})"; \
+    curl -fsSL "${OV_URL}" -o /tmp/openvino.tgz; \
+    echo "${OV_SHA256}  /tmp/openvino.tgz" | sha256sum -c -; \
+    mkdir -p /tmp/ov; \
+    tar -xzf /tmp/openvino.tgz -C /tmp/ov --strip-components=1 \
+        "${OV_BASE}/runtime/include" \
+        "${OV_BASE}/runtime/lib/${OV_LIBDIR}" \
+        "${OV_BASE}/runtime/3rdparty/tbb/lib"; \
+    mkdir -p .cache/openvino; \
+    rm -rf .cache/openvino/include; \
+    cp -a /tmp/ov/runtime/include .cache/openvino/include; \
+    test -f .cache/openvino/include/openvino/c/openvino.h; \
+    printf '%s\n' "${OPENVINO_BUILD}" > .cache/openvino/.build-id; \
+    mkdir -p /home/dev-user/lib/openvino; \
+    OV_SRC="/tmp/ov/runtime/lib/${OV_LIBDIR}"; \
+    cp -a "${OV_SRC}"/libopenvino.so* /home/dev-user/lib/openvino/; \
+    cp -a "${OV_SRC}"/libopenvino_c.so* /home/dev-user/lib/openvino/; \
+    cp -a "${OV_SRC}"/libopenvino_onnx_frontend.so* /home/dev-user/lib/openvino/; \
+    cp -a "${OV_SRC}"/libopenvino_ir_frontend.so* /home/dev-user/lib/openvino/; \
+    cp -a "${OV_SRC}/${OV_CPU_PLUGIN}"* /home/dev-user/lib/openvino/; \
+    if [ -n "${OV_GPU_PLUGIN}" ]; then cp -a "${OV_SRC}/${OV_GPU_PLUGIN}"* /home/dev-user/lib/openvino/; fi; \
+    cp -a /tmp/ov/runtime/3rdparty/tbb/lib/*.so* /home/dev-user/lib/openvino/; \
+    rm -rf /tmp/openvino.tgz /tmp/ov; \
+    echo "Staged OpenVINO runtime libraries: $(ls /home/dev-user/lib/openvino | wc -l) entries"
+
+# Build assets and compile BirdNET-Go (non-embedded, TFLite/ONNX + native OpenVINO).
+# The noembed_linux_* targets default OPENVINO=true, and the runtime libraries
+# staged above ship in the final image so the backend can dlopen libopenvino_c.
+# The backend self-gates (non-A76 arm64, or amd64 without Intel GPU drivers) and
+# falls back to ONNX Runtime, so enabling it here is safe for every deployment.
+# OPENVINO_BUILD is passed through to the task so the check-openvino header-cache
+# guard compares against the SAME build id this stage staged into .cache/openvino
+# above. That makes the guard a guaranteed no-op (no re-download) and keeps the
+# compiled-against headers and the shipped runtime .so set on one version even if
+# the Taskfile default and this Dockerfile ARG ever drift.
 # Note: frontend-build (including Tailwind) is handled as a dependency of noembed_* tasks
 RUN --mount=type=cache,target=/go/pkg/mod,uid=10001,gid=10001 \
     --mount=type=cache,target=/home/dev-user/.cache/go-build,uid=10001,gid=10001 \
     task check-tensorflow && \
     TARGET=$(echo ${TARGETPLATFORM} | tr '/' '_') && \
     echo "Building non-embedded version with BUILD_VERSION=${BUILD_VERSION}" && \
-    BUILD_VERSION="${BUILD_VERSION}" SENTRY_DSN="${SENTRY_DSN}" PROJECT_NAME="${PROJECT_NAME}" PROJECT_REPO_URL="${PROJECT_REPO_URL}" PROJECT_COMMUNITY_URL="${PROJECT_COMMUNITY_URL}" DOCKER_LIB_DIR=/home/dev-user/lib task noembed_${TARGET} OPENVINO=false
+    BUILD_VERSION="${BUILD_VERSION}" SENTRY_DSN="${SENTRY_DSN}" PROJECT_NAME="${PROJECT_NAME}" PROJECT_REPO_URL="${PROJECT_REPO_URL}" PROJECT_COMMUNITY_URL="${PROJECT_COMMUNITY_URL}" DOCKER_LIB_DIR=/home/dev-user/lib task noembed_${TARGET} OPENVINO_BUILD="${OPENVINO_BUILD}"
 
 # Create final image using a multi-platform base image
 FROM --platform=$TARGETPLATFORM debian:trixie-slim
@@ -159,6 +220,14 @@ RUN if [ "$TARGETPLATFORM" != "linux/arm64" ]; then \
     rm -rf /tmp/tflite-lib && \
     ldconfig
 
+# OpenVINO runtime libraries (both arches). The openvino-tagged binary dlopens
+# libopenvino_c at runtime and self-gates: a non-A76 arm64 CPU, or an amd64 host
+# without Intel GPU drivers, falls back to ONNX Runtime cleanly. The staging dir
+# holds the arch-appropriate set (see the build stage), with symlinks preserved so
+# the bare-soname dlopen resolves; ldconfig then refreshes the loader cache.
+COPY --from=build /home/dev-user/lib/openvino/ /usr/lib/
+RUN ldconfig
+
 # Include reset_auth tool from build stage
 COPY --from=build /home/dev-user/src/BirdNET-Go/reset_auth.sh /usr/bin/
 RUN chmod +x /usr/bin/reset_auth.sh
@@ -189,7 +258,7 @@ COPY --from=build /home/dev-user/src/BirdNET-Go/bin /usr/bin/
 
 # Add container labels for metadata and compatibility information
 LABEL org.opencontainers.image.title="BirdNET-Go"
-LABEL org.opencontainers.image.description="Real-time bird sound identification using BirdNET with ONNX Runtime support"
+LABEL org.opencontainers.image.description="Real-time bird sound identification using BirdNET with ONNX Runtime and OpenVINO support"
 LABEL org.opencontainers.image.source="https://github.com/tphakala/birdnet-go"
 LABEL org.opencontainers.image.documentation="https://github.com/tphakala/birdnet-go/blob/main/README.md"
 LABEL org.opencontainers.image.url="https://github.com/tphakala/birdnet-go"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1346,8 +1346,9 @@ tasks:
           GOARCH: amd64
           BINARY_SUFFIX: ''
           # amd64 includes the OpenVINO backend by default (activates on an Intel
-          # iGPU at runtime, otherwise falls back to ONNX Runtime). The standard
-          # Docker and CI images pass OPENVINO=false to stay ONNX-only.
+          # iGPU at runtime when the host provides the GPU drivers, otherwise falls
+          # back to ONNX Runtime). The published Docker images bundle the OpenVINO
+          # runtime libraries; pass OPENVINO=false to build an ONNX-only binary.
           OPENVINO: '{{.OPENVINO | default "true"}}'
 
   noembed_linux_arm64:
@@ -1367,8 +1368,9 @@ tasks:
           # does not link libtensorflowlite_c (issue #1103).
           NOTFLITE: 'true'
           # arm64 includes the OpenVINO backend by default (activates on A76/ARMv8.2
-          # at runtime, otherwise falls back to ONNX Runtime). The standard Docker
-          # and CI images pass OPENVINO=false to stay strictly ONNX-only.
+          # at runtime, otherwise falls back to ONNX Runtime). The published Docker
+          # images bundle the OpenVINO runtime libraries; pass OPENVINO=false to
+          # build a strictly ONNX-only binary.
           OPENVINO: '{{.OPENVINO | default "true"}}'
 
   noembed_windows_amd64:


### PR DESCRIPTION
## What

The native OpenVINO inference backend was already compiled into the `noembed_linux_*` targets by default, but the published container images built with `OPENVINO=false` and shipped no OpenVINO runtime libraries. The backend was stubbed out and could never activate in a container deployment.

This enables the `openvino` build tag for the published amd64 and arm64 images and bundles the pinned OpenVINO 2026.2 runtime `.so` set into `/usr/lib` so the backend can `dlopen` `libopenvino_c` at runtime.

## How

- A single build-stage step downloads the OpenVINO toolkit tarball per `TARGETPLATFORM`, SHA256-verifies it, and serves two purposes from one download:
  - stages the arch-independent C API headers into the Taskfile OpenVINO header cache (so `check-openvino` treats them as up to date and does not re-download), and
  - stages a curated runtime library set (core, C API, ONNX + IR frontends, the arch CPU plugin, the amd64 iGPU plugin, and TBB) into the final image, preserving symlinks so the bare-soname `dlopen` resolves.
- `OPENVINO_BUILD` is passed through to the build task so the header-cache guard always matches the staged headers, keeping the compiled-against headers and the shipped runtime libraries on one version.
- The final stage copies the staged libraries into `/usr/lib` and runs `ldconfig`.

The backend self-gates and falls back to ONNX Runtime where OpenVINO cannot run, so enabling it is safe for every existing deployment. **No model files change.**

## Behavior notes (for release notes)

- **Raspberry Pi 5 / A76 (arm64):** on upgrade the inference engine silently switches from ONNX Runtime to OpenVINO f16 (same model file, graceful fallback, parity-tested). This is the intended ~1.8x latency improvement.
- **amd64 iGPU:** the Intel GPU plugin is bundled, but iGPU acceleration additionally requires the host to pass `/dev/dri` and provide the Intel Compute Runtime (`intel-opencl-icd`). Without it, amd64 stays on TFLite/ONNX Runtime as before.
- **Image size:** amd64 grows about 118MB, arm64 about 63MB.

## Testing

- Verified the curated x86_64 runtime set loads and runs end to end against these exact libraries (device enumeration returns `[CPU GPU]`, and a full BirdNET v2.4 compile + inference round-trip passes) with no `plugins.xml` present (2026.2 uses compiled-in plugin registration).
- Simulated the per-arch staging to confirm the correct library set and preserved symlinks.
- Built and ran the arm64 image on Raspberry Pi 5 hardware to confirm OpenVINO activates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated container builds and runtime images to support OpenVINO using a pinned, version-matched toolkit runtime.
  * Improved cross-platform build coverage and ensured OpenVINO-enabled binaries align with the bundled OpenVINO runtime libraries.
* **Documentation**
  * Clarified that disabling OpenVINO produces an ONNX-only build behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->