### PR TITLE
fix(frontend): preserve line breaks in banner description

### DIFF
--- a/frontend/src/lib/desktop/features/dashboard/components/BannerCard.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/BannerCard.svelte
@@ -351,7 +351,9 @@
             {/if}
 
             {#if config.description}
-              <p class="text-sm leading-relaxed text-[var(--color-base-content)]/70">
+              <p
+                class="whitespace-pre-wrap text-sm leading-relaxed text-[var(--color-base-content)]/70"
+              >
                 {config.description}
               </p>
             {/if}


### PR DESCRIPTION
## Summary

The dashboard banner description collapses multi-line text into a single run-on line: newlines entered in the edit-mode textarea are lost when the banner is displayed. This PR preserves them.

## Before / After

Captured in the actual dashboard (real backend + real UI), same banner and same 3-line description — the only difference between the two shots is the one-line change in this PR.

**Before** (newlines collapse into one paragraph):

![Before: banner description collapsed to a single run-on paragraph](https://raw.githubusercontent.com/iamrans0m00/birdnet-go/pr-3524-assets/.pr-assets/before.png)

**After** (line breaks preserved):

![After: banner description renders as three separate lines](https://raw.githubusercontent.com/iamrans0m00/birdnet-go/pr-3524-assets/.pr-assets/after.png)

## Is this actually intended? (please confirm)

I'm assuming the single-line rendering is unintended rather than a deliberate design choice, but I don't know that for sure — happy to be told otherwise. What led me to treat it as a bug:

- The edit control is a `<textarea rows="2">` with `resize-y` (multi-line), while the **title** field next to it is a single-line `<input>` — which reads like the description was meant to accept more than one line.
- The value round-trips with newlines intact through the settings API and `BannerConfig.Description`; only the display `<p>` drops them, via the browser's default whitespace collapsing. There's no explicit single-line handling or comment.

If the single-line look was actually intentional, feel free to close this — or the cleaner fix might be to make the input a single-line `<input>` so it stops accepting newlines it won't render. Either way, this change is low-risk: `whitespace-pre-wrap` only produces extra lines the user actually typed, so single-line descriptions look pixel-identical before and after.

## Root cause

The description is rendered as a plain Svelte text node, so the browser collapses the `\n` characters. The edit-mode textarea and the persisted config already preserve newlines — only the display path drops them.

## Changes

- Add the `whitespace-pre-wrap` Tailwind utility to the display `<p>` in `frontend/src/lib/desktop/features/dashboard/components/BannerCard.svelte`.
- Preserves author-entered line breaks; long lines still wrap (`pre-wrap`, not `pre`, so no horizontal overflow).
- Keeps the value as a text node — no `{@html}`, no XSS surface.

## Testing

- [x] ESLint, Stylelint clean on the change
- [x] TypeScript / `svelte-check`: 0 errors, 0 warnings
- [x] `ast:all` (security / svelte5 / migration / best-practices): clean
- [x] Prettier: changed file conformant
- [x] Frontend unit tests pass (`2505/2505`)
- [x] Manual testing: verified end-to-end in the running app (screenshots above)

## Related Issues

Fixes #3524

## Preflight Status

- [x] Single concern: one bug fix, one file
- [x] No regression / backward-compat break: additive CSS only; no config/API/DB/CLI schema touched
- [x] No new user-facing strings (no i18n changes needed)
- [x] No secrets or PII in the diff

---

🤖 Prepared with AI assistance (Claude Code), reviewed and verified before submission, per the project's AI-Assisted Development guidelines.
