### PR TITLE
fix(api): bind review "ignore_species" field so False Positive exclusion works

### DIFF
--- a/frontend/src/lib/types/detection.types.ts
+++ b/frontend/src/lib/types/detection.types.ts
@@ -104,8 +104,12 @@ export interface DetectionQueryParams {
 export interface DetectionReviewRequest {
   comment?: string;
   verified?: 'correct' | 'false_positive';
-  ignoreSpecies?: string;
-  locked?: boolean;
+  // Wire keys must match the /detections/:id/review request body the frontend
+  // sends and the Go DetectionRequest binds (snake_case), otherwise the field
+  // silently fails to bind server-side. See issue #3674. The frontend sends
+  // `null` when the ignore checkbox is unchecked, so allow null here too.
+  ignore_species?: string | null;
+  lock_detection?: boolean;
 }
 
 export type ConfidenceLevel = 'high' | 'medium' | 'low';

--- a/internal/api/v2/detections/detections.go
+++ b/internal/api/v2/detections/detections.go
@@ -198,7 +198,7 @@ type WeatherInfo struct {
 type DetectionRequest struct {
 	Comment       string `json:"comment,omitempty"`
 	Verified      string `json:"verified,omitempty"`
-	IgnoreSpecies string `json:"ignoreSpecies,omitempty"`
+	IgnoreSpecies string `json:"ignore_species,omitempty"`
 	Locked        bool   `json:"locked,omitempty"`
 	LockDetection bool   `json:"lock_detection,omitempty"`
 }

--- a/internal/api/v2/detections/detections_test.go
+++ b/internal/api/v2/detections/detections_test.go
@@ -1410,8 +1410,11 @@ func TestReviewDetectionFalsePositiveLocalizedResolution(t *testing.T) {
 	mockDS.ExpectedCalls = nil
 	setupValidReviewMock(&mockDS.Mock, "7", 7, false)
 
+	// Payload uses the snake_case "ignore_species" key that the frontend actually
+	// sends (see ReviewCard.svelte / ReviewModal.svelte); a camelCase key would not
+	// bind to DetectionRequest.IgnoreSpecies and would silently skip the exclusion.
 	req := httptest.NewRequest(http.MethodPost, "/api/v2/detections/7/review",
-		strings.NewReader(`{"verified": "false_positive", "ignoreSpecies": "mopsilepakko"}`))
+		strings.NewReader(`{"verified": "false_positive", "ignore_species": "mopsilepakko"}`))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)


### PR DESCRIPTION
## Summary

Fixes the "Ignore this species" checkbox on a **False Positive** review, which silently did nothing. Ticking it never added the species to the exclude list, so the species kept being detected — exactly as reported in #3674.

**Root cause:** a JSON field-name mismatch. The frontend posts the field as snake_case `ignore_species` (`ReviewCard.svelte` / `ReviewModal.svelte`), but `DetectionRequest` bound it as `json:"ignoreSpecies"`. The two keys differ by an underscore, so Go's case-insensitive JSON fallback can't match them — `req.IgnoreSpecies` was always empty, and `addToIgnoredSpecies` skipped the exclusion. The three sibling fields (`comment`, `verified`, `lock_detection`) already matched, so this field was the lone outlier.

The one test covering this path masked the bug by posting the camelCase key that matched the wrong struct tag rather than the real frontend payload.

## Changes

- **`internal/api/v2/detections/detections.go`** — align the struct tag to `json:"ignore_species"` (consistent with the sibling `lock_detection`). `DetectionRequest` is bind-only (never marshaled), so this affects inbound parsing only — no response contract change.
- **`internal/api/v2/detections/detections_test.go`** — post the real `ignore_species` key so the test guards the actual wire contract. Verified this makes the test fail on the old tag and pass on the new one (true red→green).
- **`frontend/src/lib/types/detection.types.ts`** — fix the unused `DetectionReviewRequest` type, which had the same wrong field names; type `ignore_species` as `string | null` to match the payload the frontend sends when the checkbox is unchecked.

## Testing

- [x] Go test passes (`go test -race ./internal/api/v2/detections/` → ok); full Go suite otherwise green (the only failures are pre-existing, time/environment-dependent tests in `internal/support` and `internal/api/v2/weather`, untouched by this PR)
- [x] Frontend suite passes (`vitest run` → 2578 tests / 171 files); `svelte-check`, eslint, prettier, stylelint, ast-grep all clean
- [x] Linting passes (full-project `golangci-lint` v2.12.2 → 0 issues; `gofmt` clean)
- [x] Regression guard: the updated Go test fails on the old `ignoreSpecies` tag and passes on the fix (verified by reverting the tag in isolation)
- [x] End-to-end verified against a live server: reviewing a real detection as False Positive with "Ignore this species" ticked persisted the resolved scientific name to `config.yaml`'s exclude list and returned it from `GET /api/v2/detections/ignored`
- [x] Preflight quality gate passed

## Related Issues

Fixes #3674

## Breaking changes

The `/api/v2/detections/:id/review` request field is now `ignore_species` (snake_case), matching what the frontend has always sent. The previous `ignoreSpecies` camelCase tag never bound — that was the bug. This is a fix for every real client (the web UI); the only theoretical impact is on an undocumented external script that relied on the camelCase key the official UI never used. Response shape, config keys, DB schema, and CLI flags are unchanged.

## Preflight Status

- [x] Single concern: exactly one fix (#3674)
- [x] Preflight passed: all six review passes clean; no maintainer-confirm items
- [x] Linters clean: full-project `golangci-lint` → 0 issues; frontend lint stages → 0
- [x] Tests pass: changed package passes with `-race`; full frontend suite green
- [x] No unrelated changes: diff is only the fix, its test, and the request type
- [x] Scope complete: no TODO/FIXME; fix verified end-to-end
- [x] No regression/backward-compat break: bind-only struct; no response/config/DB/CLI change
- [x] Breaking changes documented: see section above
- [x] Maintainer-confirm items resolved: none
- [x] i18n complete: no new user-facing strings
- [x] No secrets or PII: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed detection review submissions to use the correct request field names expected by the backend.
  * Improved handling of species exclusions during review, including support for empty values where needed.
  * Updated review behavior so detection locking and ignore-species actions are sent reliably from the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->