### PR TITLE
fix(api): dashboard thumbnails use fallback image provider via media proxy

### DIFF
--- a/internal/api/v2/analytics/analytics.go
+++ b/internal/api/v2/analytics/analytics.go
@@ -502,9 +502,6 @@ func (c *Handler) buildDailySpeciesSummaryResponse(aggregatedData map[string]agg
 	// Collect species names with detections
 	scientificNames := collectSpeciesWithDetections(aggregatedData)
 
-	// Batch fetch thumbnail URLs (cached only for fast response)
-	thumbnailURLs := c.batchFetchCachedThumbnails(scientificNames)
-
 	// Parse selected date for status computation
 	statusTime := parseStatusTimeFromDate(selectedDate)
 
@@ -515,7 +512,13 @@ func (c *Handler) buildDailySpeciesSummaryResponse(aggregatedData map[string]agg
 	result := make([]SpeciesDailySummary, 0, len(scientificNames))
 	for _, scientificName := range scientificNames {
 		data := aggregatedData[scientificName]
-		thumbnailURL := getThumbnailWithFallback(thumbnailURLs, scientificName)
+		// Emit the media-proxy URL directly rather than pre-resolving from the
+		// cache-only batch path. The proxy (ServeSpeciesImageProxy) resolves via
+		// the single-item Get() fallback chain and the local file cache, so
+		// dashboard thumbnails honor the configured fallback provider even when
+		// the primary provider has a negative cache entry (issue #3806). The
+		// frontend swaps to the placeholder on a 404 via handleBirdImageError.
+		thumbnailURL := buildThumbnailURL(scientificName)
 		summary := buildSpeciesSummaryFromData(&data, thumbnailURL)
 		if status, exists := batchSpeciesStatus[scientificName]; exists {
 			applySpeciesStatusToSummary(&summary, &status)
@@ -535,23 +538,6 @@ func collectSpeciesWithDetections(aggregatedData map[string]aggregatedBirdInfo) 
 		}
 	}
 	return names
-}
-
-// batchFetchCachedThumbnails fetches thumbnail URLs from cache only
-func (c *Handler) batchFetchCachedThumbnails(scientificNames []string) map[string]string {
-	thumbnailURLs := make(map[string]string)
-	cache := c.BirdImageCache
-	if cache == nil || len(scientificNames) == 0 {
-		return thumbnailURLs
-	}
-
-	batchResults := cache.GetBatchCachedOnly(scientificNames)
-	for name := range batchResults {
-		if img := batchResults[name]; img.URL != "" && !img.IsNegativeEntry() {
-			thumbnailURLs[name] = imageprovider.ProxyImageURL(name)
-		}
-	}
-	return thumbnailURLs
 }
 
 // parseStatusTimeFromDate parses selected date for species status computation

--- a/internal/api/v2/analytics/analytics_test.go
+++ b/internal/api/v2/analytics/analytics_test.go
@@ -805,53 +805,11 @@ func TestGetDailySpeciesSummary_MultipleDetections(t *testing.T) {
 		sciRedBelliedWoodpecker: expectedRbwoHourlyCounts,
 	}, nil)
 
-	// Mock for image cache initialization
-	mockDS.On("GetAllImageCaches", mock.AnythingOfType("string")).Return([]datastore.ImageCache{}, nil)
-
-	// GetImageCache not needed when using GetImageCacheBatch
-	// mockDS.On("GetImageCache", mock.AnythingOfType("datastore.ImageCacheQuery")).Return(nil, nil)
-
-	// Mock GetImageCacheBatch to return cached images with URLs containing scientific names
-	// Use dynamic return based on input parameters
-	mockDS.On("GetImageCacheBatch", mock.AnythingOfType("string"), mock.AnythingOfType("[]string")).Return(
-		func(provider string, names []string) map[string]*datastore.ImageCache {
-			result := make(map[string]*datastore.ImageCache)
-			for _, name := range names {
-				result[name] = &datastore.ImageCache{
-					ScientificName: name,
-					URL:            "http://example.com/" + name + ".jpg",
-					CachedAt:       time.Now(),
-					ProviderName:   provider,
-				}
-			}
-			return result
-		}, nil)
-
-	// Expect calls to SaveImageCache - not needed since we're returning cached images
-	// mockDS.On("SaveImageCache", mock.AnythingOfType("*datastore.ImageCache")).Return(nil)
-
-	// Create a mock image provider (can be nil if cache doesn't need real fetching)
-	mockImageProvider := &apitest.TestImageProvider{
-		FetchFunc: func(scientificName string) (imageprovider.BirdImage, error) {
-			// Return placeholder or specific mock image data if needed
-			return imageprovider.BirdImage{
-				ScientificName: scientificName,
-				URL:            fmt.Sprintf("http://example.com/%s.jpg", scientificName),
-				// Add other fields if necessary
-			}, nil
-		},
-	}
-
-	// Create a bird image cache with our mock provider
-	// ---> FIX: Provide a non-nil observability.Metrics instance <---
-	testMetrics, _ := observability.NewMetrics() // Create a dummy metrics instance
-	imageCache := imageprovider.InitCache("test", mockImageProvider, testMetrics, mockDS)
-	t.Cleanup(func() {
-		assert.NoError(t, imageCache.Close(), "Failed to close image cache")
-	})
-
-	// Create a controller with our mocks
-	controller := newTestHandler(&apicore.Core{DS: mockDS, BirdImageCache: imageCache})
+	// The daily summary emits the media-proxy URL directly and no longer queries
+	// the image cache for thumbnails (#3806), so no BirdImageCache is needed here.
+	// The ThumbnailURLContain assertions below prove the proxy URL is emitted
+	// regardless of cache state.
+	controller := newTestHandler(&apicore.Core{DS: mockDS})
 
 	// Create a request with the date we want to test
 	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/analytics/species/daily?date=%s", testDate), http.NoBody)
@@ -1027,6 +985,57 @@ func TestGetDailySpeciesSummary_LocalizedNonPrimarySpecies(t *testing.T) {
 	mockDS.AssertExpectations(t)
 }
 
+// TestGetDailySpeciesSummary_ThumbnailDefersToProxy is a regression test for #3806.
+// The dashboard daily summary must emit the media-proxy URL for every species with
+// detections, independent of the image cache, so the proxy resolves images through
+// the single-item fallback chain instead of the dashboard showing a placeholder when
+// the primary provider has a negative cache entry. A nil BirdImageCache proves the
+// thumbnail URL no longer depends on a cache-only lookup.
+func TestGetDailySpeciesSummary_ThumbnailDefersToProxy(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "analytics")
+	t.Attr("type", "regression")
+	t.Attr("feature", "species-summary")
+
+	e := echo.New()
+	mockDS := mocks.NewMockInterface(t)
+
+	const testDate = "2025-03-07"
+	const minConfidence = 0.0
+	const sciName = sciAmericanCrow
+
+	mockDS.On("GetTopBirdsData", mock.Anything, testDate, minConfidence, 0).Return([]datastore.Note{
+		{ID: 1, ScientificName: sciName, CommonName: "American Crow", Confidence: 0.9, Date: testDate, Time: "08:15:00"},
+	}, nil)
+
+	var hourly [24]int
+	hourly[8] = 1
+	mockDS.On("GetBatchHourlyOccurrences", mock.Anything, testDate, mock.Anything, minConfidence).
+		Return(map[string][24]int{sciName: hourly}, nil)
+
+	// Deliberately no BirdImageCache: the thumbnail URL must not depend on it.
+	controller := newTestHandler(&apicore.Core{DS: mockDS})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/analytics/species/daily?date="+testDate, http.NoBody)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, controller.GetDailySpeciesSummary(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var response []SpeciesDailySummary
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	require.Len(t, response, 1)
+
+	assert.Equal(t, imageprovider.ProxyImageURL(sciName), response[0].ThumbnailURL,
+		"daily summary must emit the media-proxy URL so the proxy applies the fallback chain (#3806)")
+	assert.Contains(t, response[0].ThumbnailURL, "/api/v2/media/image/Corvus%20brachyrhynchos")
+	assert.NotContains(t, response[0].ThumbnailURL, "bird-placeholder",
+		"dashboard thumbnail must not fall back to the static placeholder on the summary path")
+
+	mockDS.AssertExpectations(t)
+}
+
 // TestGetDailySpeciesSummary_SingleDetection tests that the GetDailySpeciesSummary function
 // correctly handles the case where each species has only one detection
 func TestGetDailySpeciesSummary_SingleDetection(t *testing.T) {
@@ -1074,41 +1083,9 @@ func TestGetDailySpeciesSummary_SingleDetection(t *testing.T) {
 		sciRedBelliedWoodpecker: expectedRbwoSingleHourly,
 	}, nil)
 
-	// Mock for image cache initialization
-	mockDS.On("GetAllImageCaches", mock.AnythingOfType("string")).Return([]datastore.ImageCache{}, nil)
-	// Mock GetImageCacheBatch to return cached images with URLs containing scientific names
-	// Use dynamic return based on input parameters
-	mockDS.On("GetImageCacheBatch", mock.AnythingOfType("string"), mock.AnythingOfType("[]string")).Return(
-		func(provider string, names []string) map[string]*datastore.ImageCache {
-			result := make(map[string]*datastore.ImageCache)
-			for _, name := range names {
-				result[name] = &datastore.ImageCache{
-					ScientificName: name,
-					URL:            "http://example.com/" + name + ".jpg",
-					CachedAt:       time.Now(),
-					ProviderName:   provider,
-				}
-			}
-			return result
-		}, nil)
-	// SaveImageCache not needed since we're returning already cached images
-	// mockDS.On("SaveImageCache", mock.AnythingOfType("*datastore.ImageCache")).Return(nil)
-
-	// Create a mock image provider
-	mockImageProvider := &apitest.TestImageProvider{
-		FetchFunc: func(scientificName string) (imageprovider.BirdImage, error) {
-			return imageprovider.BirdImage{
-				ScientificName: scientificName,
-				URL:            "http://example.com/" + scientificName + ".jpg",
-			}, nil
-		},
-	}
-
-	// Create a bird image cache with our mock provider
-	imageCache := imageprovider.InitCache("test", mockImageProvider, apitest.NewTestMetrics(t), mockDS)
-
-	// Create a controller with our mocks
-	controller := newTestHandler(&apicore.Core{DS: mockDS, BirdImageCache: imageCache})
+	// The daily summary emits proxy URLs directly and no longer queries the image
+	// cache for thumbnails (#3806), so no BirdImageCache is needed here.
+	controller := newTestHandler(&apicore.Core{DS: mockDS})
 
 	// Create a request with the date we want to test
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/analytics/species/daily?date=2025-03-07", http.NoBody)
@@ -1136,9 +1113,6 @@ func TestGetDailySpeciesSummary_SingleDetection(t *testing.T) {
 	for _, species := range response {
 		assert.Equal(t, 1, species.Count, "%s should have 1 detection", species.CommonName)
 	}
-
-	// Close the image cache to clean up resources
-	require.NoError(t, imageCache.Close(), "Failed to close image cache")
 
 	// Assert that all expectations were met
 	mockDS.AssertExpectations(t)


### PR DESCRIPTION
## Problem

With Image Provider = Avicommons and Fallback Policy = "Try all providers in sequence", species the primary provider lacks (e.g. Eastern Chipmunk, American Bullfrog, Green Frog) showed the generic `bird-placeholder.svg` on the dashboard Daily Summary table and the "New & Returning Species" banner, even though the fallback provider (Wikimedia) has the image and the species' own detail page rendered it correctly.

Both dashboard surfaces are fed by `buildDailySpeciesSummaryResponse`, which resolved thumbnails through the cache-only `GetBatchCachedOnly` path. That path treats a primary-provider negative `__NOT_FOUND__` cache entry as "resolved" and never consults the fallback provider, so the fallback chain configured by the user was silently skipped on the dashboard.

This completes the earlier partial fix in #3807, which only handled the "no cache row" case and missed negative cache entries.

## Fix

`buildDailySpeciesSummaryResponse` now emits the media-proxy URL for every species (via `buildThumbnailURL`, matching the existing `insights.go` pattern) instead of pre-resolving from the cache-only batch path. The media proxy `ServeSpeciesImageProxy` resolves images through the single-item `Get()` fallback chain and the local disk file cache, honoring the fallback policy at request time, and returns a cacheable 404 for genuinely image-less species. The frontend already renders these thumbnails through `<img onerror={handleBirdImageError}>`, which swaps to the placeholder on a 404, so nothing regresses for species with no image anywhere.

The now-dead `batchFetchCachedThumbnails` helper is removed.

## Behavior change

`thumbnail_url` on `/api/v2/analytics/species/daily` and `/daily/batch` is now always the media-proxy URL and no longer ever returns the static placeholder path. The frontend is unaffected (it already routes through the proxy for cached species and falls back on 404). An external, non-browser API client that inferred "no image" from the placeholder path should instead follow the proxy URL and handle a 404.

## Tests

Adds `TestGetDailySpeciesSummary_ThumbnailDefersToProxy`, a regression test that builds the response with a nil image cache and asserts the thumbnail is the proxy URL (never the placeholder). It fails against the old cache-only behavior. The existing daily-summary tests were updated to drop the now-unused image-cache mock scaffolding.

Fixes #3806

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Daily species summary thumbnails now reliably load through the image proxy for each species, even when cached images are unavailable.
  * Removed the fallback to a static placeholder so thumbnail behavior is more consistent across summaries.
  * Updated related tests to reflect the new thumbnail behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->