### PR TITLE
fix(api): species analytics thumbnails use fallback provider via media proxy

### DIFF
--- a/frontend/src/lib/desktop/features/analytics/components/modals/SpeciesDetailModal.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/modals/SpeciesDetailModal.svelte
@@ -29,6 +29,11 @@
   // while isOpen transitions to false.
   let cachedSpecies = $state<SpeciesData | null>(null);
 
+  // Tracks a thumbnail load failure so a 404 from the media proxy degrades to the
+  // placeholder background instead of a broken image. Reset when the displayed species
+  // changes, since the modal reuses cachedSpecies across species.
+  let imageLoadFailed = $state(false);
+
   // Clear stale cache when the modal opens so previous species data doesn't flash.
   // The cache is only useful during the close transition (species becomes null while
   // isOpen transitions to false), not during open.
@@ -43,6 +48,7 @@
   $effect(() => {
     if (species) {
       cachedSpecies = species;
+      imageLoadFailed = false;
     }
   });
 
@@ -54,6 +60,10 @@
 
   function formatPercentage(value: number): string {
     return (value * 100).toFixed(1) + '%';
+  }
+
+  function handleImageError() {
+    imageLoadFailed = true;
   }
 
   function handleClose() {
@@ -88,11 +98,14 @@
     {#if displaySpecies}
       {#if displaySpecies.thumbnail_url}
         <div class="w-full aspect-[4/3] rounded-xl overflow-hidden bg-[var(--color-base-300)]">
-          <img
-            src={displaySpecies.thumbnail_url}
-            alt={displayName}
-            class="w-full h-full object-cover"
-          />
+          {#if !imageLoadFailed}
+            <img
+              src={displaySpecies.thumbnail_url}
+              alt={displayName}
+              class="w-full h-full object-cover"
+              onerror={handleImageError}
+            />
+          {/if}
         </div>
       {/if}
 

--- a/frontend/src/lib/desktop/features/analytics/components/modals/SpeciesDetailModal.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/modals/SpeciesDetailModal.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { cleanup } from '@testing-library/svelte';
+import { cleanup, fireEvent } from '@testing-library/svelte';
 import { createComponentTestFactory, screen } from '../../../../../../test/render-helpers';
 import userEvent from '@testing-library/user-event';
 import SpeciesDetailModal from './SpeciesDetailModal.svelte';
@@ -99,6 +99,37 @@ describe('SpeciesDetailModal', () => {
     await user.keyboard('{Escape}');
 
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the thumbnail image when thumbnail_url is set', () => {
+    const { container } = modalTest.render({
+      props: {
+        isOpen: true,
+        species: { ...mockSpecies, thumbnail_url: '/api/v2/media/image/Passer%20domesticus' },
+      },
+    });
+
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img).toHaveAttribute('src', '/api/v2/media/image/Passer%20domesticus');
+  });
+
+  // Regression for Forgejo #1311: under defer-to-proxy every species gets a media-proxy
+  // URL that can 404, so the modal must swap to the placeholder background on error
+  // rather than showing a broken image.
+  it('degrades to the placeholder (removes the img) when the thumbnail fails to load', async () => {
+    const { container } = modalTest.render({
+      props: {
+        isOpen: true,
+        species: { ...mockSpecies, thumbnail_url: '/api/v2/media/image/Passer%20domesticus' },
+      },
+    });
+
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    if (img) await fireEvent.error(img);
+
+    expect(container.querySelector('img')).toBeNull();
   });
 
   it('closes when clicking outside the modal content', async () => {

--- a/frontend/src/lib/desktop/features/analytics/components/ui/SpeciesCard.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/ui/SpeciesCard.svelte
@@ -32,6 +32,13 @@
   function handleImageError() {
     imageLoadFailed = true;
   }
+
+  // Reset the failed-load flag when a new species is provided so a reused
+  // component instance retries its thumbnail instead of keeping a prior
+  // species' placeholder (matches SpeciesDetailModal).
+  $effect(() => {
+    if (species) imageLoadFailed = false;
+  });
 </script>
 
 <div class={cn('card bg-[var(--color-base-200)]', className)}>

--- a/frontend/src/lib/desktop/features/analytics/components/ui/SpeciesCardMobile.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/ui/SpeciesCardMobile.svelte
@@ -105,7 +105,7 @@
     <div class="flex-shrink-0">
       <div class="avatar w-16 h-16">
         <div class="mask mask-squircle bg-[var(--color-base-300)]">
-          {#if species.thumbnail_url}
+          {#if species.thumbnail_url && !imageLoadFailed}
             <img
               src={species.thumbnail_url}
               alt={displayName}
@@ -152,7 +152,7 @@
   >
     <div class="avatar flex-shrink-0">
       <div class="mask mask-squircle w-12 h-12 bg-[var(--color-base-300)]">
-        {#if species.thumbnail_url}
+        {#if species.thumbnail_url && !imageLoadFailed}
           <img
             src={species.thumbnail_url}
             alt={displayName}

--- a/frontend/src/lib/desktop/features/analytics/components/ui/SpeciesCardMobile.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/ui/SpeciesCardMobile.svelte
@@ -36,6 +36,13 @@
     imageLoadFailed = true;
   }
 
+  // Reset the failed-load flag when a new species is provided so a reused
+  // component instance retries its thumbnail instead of keeping a prior
+  // species' placeholder (matches SpeciesDetailModal).
+  $effect(() => {
+    if (species) imageLoadFailed = false;
+  });
+
   function handleClick() {
     if (onClick) {
       onClick(species);

--- a/frontend/src/lib/desktop/features/analytics/components/ui/SpeciesCardMobile.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/ui/SpeciesCardMobile.test.ts
@@ -61,5 +61,28 @@ describe('SpeciesCardMobile', () => {
 
       expect(container.querySelector('img')).toBeNull();
     });
+
+    it(`resets the failed-load flag when the species prop changes for the ${variant} variant`, async () => {
+      const { container, rerender } = render(SpeciesCardMobile, {
+        props: { species: mockSpecies, variant },
+      });
+
+      const img = container.querySelector('img');
+      expect(img).not.toBeNull();
+      if (img) await fireEvent.error(img);
+      expect(container.querySelector('img')).toBeNull();
+
+      // A reused instance showing a different species must retry its thumbnail.
+      await rerender({
+        species: {
+          ...mockSpecies,
+          scientific_name: 'Corvus brachyrhynchos',
+          common_name: 'American Crow',
+          thumbnail_url: '/api/v2/media/image/Corvus%20brachyrhynchos',
+        },
+      });
+
+      expect(container.querySelector('img')).not.toBeNull();
+    });
   }
 });

--- a/frontend/src/lib/desktop/features/analytics/components/ui/SpeciesCardMobile.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/ui/SpeciesCardMobile.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/svelte';
+import SpeciesCardMobile from './SpeciesCardMobile.svelte';
+
+// Mock the i18n module (mirrors SpeciesDetailModal.test.ts).
+vi.mock('$lib/i18n', () => ({
+  t: vi.fn((key: string) => {
+    const translations: Record<string, string> = {
+      'analytics.species.card.detections': 'Detections',
+      'analytics.species.card.confidence': 'Confidence',
+      'analytics.species.card.first': 'First',
+    };
+    // eslint-disable-next-line security/detect-object-injection -- Test mock with controlled translation data
+    return translations[key] ?? key;
+  }),
+}));
+
+const mockSpecies = {
+  common_name: 'House Sparrow',
+  scientific_name: 'Passer domesticus',
+  count: 42,
+  avg_confidence: 0.85,
+  max_confidence: 0.95,
+  first_heard: '2024-01-15T10:30:00',
+  last_heard: '2024-01-20T14:45:00',
+  thumbnail_url: '/api/v2/media/image/Passer%20domesticus',
+};
+
+describe('SpeciesCardMobile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // Regression for Forgejo #1311: under defer-to-proxy every species gets a media-proxy
+  // URL that can 404, so each variant must remove the img on error (the wrapper's
+  // bg-base-300 shows as the placeholder) rather than leaving a broken image. Before the
+  // fix the compact and list variants set imageLoadFailed but never read it in the guard.
+  for (const variant of ['card', 'compact', 'list'] as const) {
+    it(`renders the thumbnail image for the ${variant} variant`, () => {
+      const { container } = render(SpeciesCardMobile, {
+        props: { species: mockSpecies, variant },
+      });
+
+      const img = container.querySelector('img');
+      expect(img).not.toBeNull();
+      expect(img).toHaveAttribute('src', '/api/v2/media/image/Passer%20domesticus');
+    });
+
+    it(`removes the img on load error for the ${variant} variant`, async () => {
+      const { container } = render(SpeciesCardMobile, {
+        props: { species: mockSpecies, variant },
+      });
+
+      const img = container.querySelector('img');
+      expect(img).not.toBeNull();
+      if (img) await fireEvent.error(img);
+
+      expect(container.querySelector('img')).toBeNull();
+    });
+  }
+});

--- a/frontend/src/lib/desktop/features/dashboard/API_ENDPOINTS.md
+++ b/frontend/src/lib/desktop/features/dashboard/API_ENDPOINTS.md
@@ -23,7 +23,7 @@
     "high_confidence": true,
     "first_heard": "09:09:54",
     "latest_heard": "09:09:54",
-    "thumbnail_url": "https://upload.wikimedia.org/..."
+    "thumbnail_url": "/api/v2/media/image/Crex%20crex"
   }
 ]
 ```

--- a/internal/api/v2/analytics/analytics.go
+++ b/internal/api/v2/analytics/analytics.go
@@ -20,11 +20,9 @@ import (
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/errors"
-	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
-const placeholderImageURL = "/ui/assets/bird-placeholder.svg"
 const maxSpeciesBatch = 10
 
 // Analytics constants (file-local)
@@ -329,9 +327,13 @@ func (c *Handler) processBatchDates(ctx context.Context, dates []string, minConf
 			break
 		}
 		// Bound each date's queries individually so one slow date cannot hang the batch.
-		dateCtx, cancel := context.WithTimeout(ctx, analyticsQueryTimeout)
-		result, err := c.processSingleDateForBatch(dateCtx, selectedDate, minConfidence, limit, ip, path)
-		cancel()
+		// Run in a closure with defer cancel() so the context timer is released even if
+		// processSingleDateForBatch panics, instead of leaking until the timeout fires.
+		result, err := func() ([]SpeciesDailySummary, error) {
+			dateCtx, cancel := context.WithTimeout(ctx, analyticsQueryTimeout)
+			defer cancel()
+			return c.processSingleDateForBatch(dateCtx, selectedDate, minConfidence, limit, ip, path)
+		}()
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				break // client disconnected; stop the batch without recording a failure
@@ -567,14 +569,6 @@ func (c *Handler) batchFetchSpeciesStatus(scientificNames []string, statusTime t
 	return tracker.GetBatchSpeciesStatus(scientificNames, statusTime)
 }
 
-// getThumbnailWithFallback returns thumbnail URL or placeholder
-func getThumbnailWithFallback(thumbnailURLs map[string]string, scientificName string) string {
-	if url, ok := thumbnailURLs[scientificName]; ok && url != "" {
-		return url
-	}
-	return placeholderImageURL
-}
-
 // buildSpeciesSummaryFromData creates a SpeciesDailySummary from aggregated data
 func buildSpeciesSummaryFromData(data *aggregatedBirdInfo, thumbnailURL string) SpeciesDailySummary {
 	hourlyCountsSlice := make([]int, apicore.HoursPerDay)
@@ -660,10 +654,12 @@ func (c *Handler) GetSpeciesSummary(ctx echo.Context) error {
 		)
 	}
 
-	// Build response with thumbnails
-	scientificNames := extractScientificNames(summaryData)
-	thumbnailURLs := c.batchFetchThumbnailsWithLogging(scientificNames, ip, path)
-	response := c.convertSummaryDataToResponse(summaryData, thumbnailURLs)
+	// Build response. Emit the media-proxy URL for every species (defer-to-proxy,
+	// matching the dashboard fix in #3806): ServeSpeciesImageProxy resolves images via
+	// the single-item Get() fallback chain and the local file cache, so species the
+	// primary provider lacks but a fallback has are honored at request time and a 404
+	// is cached. The frontend swaps to a placeholder on error.
+	response := c.convertSummaryDataToResponse(summaryData)
 
 	// Apply limit
 	response, limit := c.applyOptionalLimit(ctx, response, ip, path)
@@ -689,43 +685,8 @@ func (c *Handler) fetchSpeciesSummaryData(ctx echo.Context, startDate, endDate s
 	return summaryData, time.Since(dbStart), err
 }
 
-// extractScientificNames extracts scientific names from summary data
-func extractScientificNames(summaryData []datastore.SpeciesSummaryData) []string {
-	names := make([]string, 0, len(summaryData))
-	for i := range summaryData {
-		names = append(names, summaryData[i].ScientificName)
-	}
-	return names
-}
-
-// batchFetchThumbnailsWithLogging fetches thumbnails with debug logging
-func (c *Handler) batchFetchThumbnailsWithLogging(scientificNames []string, ip, path string) map[string]imageprovider.BirdImage {
-	cache := c.BirdImageCache
-	if cache == nil || len(scientificNames) == 0 {
-		return nil
-	}
-
-	c.LogDebugIfEnabled("Fetching cached thumbnails only",
-		logger.Int("count", len(scientificNames)),
-		logger.String("ip", ip),
-		logger.String("path", path),
-	)
-	thumbStart := time.Now()
-	thumbnailURLs := cache.GetBatchCachedOnly(scientificNames)
-	thumbDuration := time.Since(thumbStart)
-	c.LogInfoIfEnabled("Cached thumbnail fetch completed",
-		logger.Int64("duration_ms", thumbDuration.Milliseconds()),
-		logger.Int("cached_count", len(thumbnailURLs)),
-		logger.Int("requested_count", len(scientificNames)),
-		logger.String("ip", ip),
-		logger.String("path", path),
-	)
-
-	return thumbnailURLs
-}
-
 // convertSummaryDataToResponse converts datastore models to API response
-func (c *Handler) convertSummaryDataToResponse(summaryData []datastore.SpeciesSummaryData, thumbnailURLs map[string]imageprovider.BirdImage) []SpeciesSummary {
+func (c *Handler) convertSummaryDataToResponse(summaryData []datastore.SpeciesSummaryData) []SpeciesSummary {
 	response := make([]SpeciesSummary, 0, len(summaryData))
 
 	for i := range summaryData {
@@ -739,7 +700,7 @@ func (c *Handler) convertSummaryDataToResponse(summaryData []datastore.SpeciesSu
 			LastHeard:      formatTimeIfNotZero(data.LastSeen),
 			AvgConfidence:  data.AvgConfidence,
 			MaxConfidence:  data.MaxConfidence,
-			ThumbnailURL:   getThumbnailURLFromBirdImage(thumbnailURLs, data.ScientificName),
+			ThumbnailURL:   buildThumbnailURL(data.ScientificName),
 		})
 	}
 
@@ -756,17 +717,6 @@ func formatTimeIfNotZero(t time.Time) string {
 		return ""
 	}
 	return t.Format(time.RFC3339)
-}
-
-// getThumbnailURLFromBirdImage extracts URL from BirdImage map
-func getThumbnailURLFromBirdImage(thumbnailURLs map[string]imageprovider.BirdImage, scientificName string) string {
-	if thumbnailURLs == nil {
-		return ""
-	}
-	if img, ok := thumbnailURLs[scientificName]; ok && img.URL != "" && !img.IsNegativeEntry() {
-		return imageprovider.ProxyImageURL(scientificName)
-	}
-	return ""
 }
 
 // applyOptionalLimit parses and applies limit parameter
@@ -2313,48 +2263,22 @@ func (c *Handler) validateNewSpeciesDateParams(ctx echo.Context, startDate, endD
 	return c.validateDateOrderWithResponse(ctx, startDate, endDate, operation)
 }
 
-// convertNewSpeciesToResponse converts new species data to API response format
+// convertNewSpeciesToResponse converts new species data to API response format.
+// Thumbnails defer to the media proxy (see buildThumbnailURL / #3806): the proxy
+// resolves via the single-item Get() fallback chain and local file cache, so a
+// species the primary provider lacks but a fallback has is honored at request time.
 func (c *Handler) convertNewSpeciesToResponse(newSpeciesData []datastore.NewSpeciesData) []NewSpeciesResponse {
-	scientificNames := extractNewSpeciesNames(newSpeciesData)
-	thumbnailURLs := c.batchFetchThumbnailURLs(scientificNames)
-
 	response := make([]NewSpeciesResponse, 0, len(newSpeciesData))
 	for _, data := range newSpeciesData {
 		response = append(response, NewSpeciesResponse{
 			ScientificName: data.ScientificName,
 			CommonName:     data.CommonName,
 			FirstHeardDate: data.FirstSeenDate,
-			ThumbnailURL:   getThumbnailWithFallback(thumbnailURLs, data.ScientificName),
+			ThumbnailURL:   buildThumbnailURL(data.ScientificName),
 			CountInPeriod:  data.CountInPeriod,
 		})
 	}
 	return response
-}
-
-// extractNewSpeciesNames extracts scientific names from new species data
-func extractNewSpeciesNames(data []datastore.NewSpeciesData) []string {
-	names := make([]string, 0, len(data))
-	for _, d := range data {
-		names = append(names, d.ScientificName)
-	}
-	return names
-}
-
-// batchFetchThumbnailURLs fetches thumbnail URLs from cache
-func (c *Handler) batchFetchThumbnailURLs(scientificNames []string) map[string]string {
-	thumbnailURLs := make(map[string]string)
-	cache := c.BirdImageCache
-	if cache == nil {
-		return thumbnailURLs
-	}
-
-	batchResults := cache.GetBatch(scientificNames)
-	for name := range batchResults {
-		if img := batchResults[name]; img.URL != "" && !img.IsNegativeEntry() {
-			thumbnailURLs[name] = imageprovider.ProxyImageURL(name)
-		}
-	}
-	return thumbnailURLs
 }
 
 // Helper function to sum array values
@@ -2452,36 +2376,16 @@ func (c *Handler) GetSpeciesThumbnails(ctx echo.Context) error {
 	return ctx.JSON(http.StatusOK, result)
 }
 
-// buildThumbnailMap creates a map of species names to thumbnail URLs.
+// buildThumbnailMap maps each requested species to its media-proxy thumbnail URL.
+// Defer-to-proxy (see buildThumbnailURL / #3806): ServeSpeciesImageProxy resolves via
+// the single-item Get() fallback chain and the local file cache and caches a 404, so a
+// species the primary provider lacks but a fallback has is honored at request time. The
+// frontend swaps to a placeholder on error.
 func (c *Handler) buildThumbnailMap(speciesParams []string) map[string]string {
-	result := make(map[string]string)
-
-	cache := c.BirdImageCache
-	if cache == nil {
-		for _, name := range speciesParams {
-			result[name] = placeholderImageURL
-		}
-		return result
-	}
-
-	images := cache.GetBatch(speciesParams)
-
-	// Convert to simple map of scientific name -> proxy URL
-	for name := range images {
-		if img := images[name]; img.URL != "" && !img.IsNegativeEntry() {
-			result[name] = imageprovider.ProxyImageURL(name)
-		} else {
-			result[name] = placeholderImageURL
-		}
-	}
-
-	// Add placeholder for any missing species
+	result := make(map[string]string, len(speciesParams))
 	for _, name := range speciesParams {
-		if _, exists := result[name]; !exists {
-			result[name] = placeholderImageURL
-		}
+		result[name] = buildThumbnailURL(name)
 	}
-
 	return result
 }
 

--- a/internal/api/v2/analytics/analytics_test.go
+++ b/internal/api/v2/analytics/analytics_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"slices"
 	"testing"
 	"time"
@@ -1034,6 +1035,127 @@ func TestGetDailySpeciesSummary_ThumbnailDefersToProxy(t *testing.T) {
 		"dashboard thumbnail must not fall back to the static placeholder on the summary path")
 
 	mockDS.AssertExpectations(t)
+}
+
+// TestGetSpeciesSummary_ThumbnailDefersToProxy is a regression test for Forgejo #1311.
+// The species summary endpoint must emit the media-proxy URL for every species,
+// independent of the image cache, so the proxy resolves images through the single-item
+// fallback chain instead of showing a placeholder when the primary provider has a
+// negative cache entry. A nil BirdImageCache proves the thumbnail URL no longer depends
+// on the (negative-blind) batch cache lookup.
+func TestGetSpeciesSummary_ThumbnailDefersToProxy(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "analytics")
+	t.Attr("type", "regression")
+	t.Attr("feature", "species-summary")
+
+	e := echo.New()
+	mockDS := mocks.NewMockInterface(t)
+
+	const sciName = sciAmericanCrow
+	mockDS.On("GetSpeciesSummaryData", mock.Anything, "", "").Return([]datastore.SpeciesSummaryData{
+		{ScientificName: sciName, CommonName: "American Crow", Count: 5},
+	}, nil)
+
+	// Deliberately no BirdImageCache: the thumbnail URL must not depend on it.
+	controller := newTestHandler(&apicore.Core{DS: mockDS})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/analytics/species/summary", http.NoBody)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, controller.GetSpeciesSummary(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var response []SpeciesSummary
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	require.Len(t, response, 1)
+
+	assert.Equal(t, imageprovider.ProxyImageURL(sciName), response[0].ThumbnailURL,
+		"species summary must emit the media-proxy URL so the proxy applies the fallback chain (#1311)")
+	assert.Contains(t, response[0].ThumbnailURL, "/api/v2/media/image/Corvus%20brachyrhynchos")
+	assert.NotContains(t, response[0].ThumbnailURL, "bird-placeholder",
+		"species summary thumbnail must not fall back to the static placeholder")
+
+	mockDS.AssertExpectations(t)
+}
+
+// TestGetNewSpeciesDetections_ThumbnailDefersToProxy is a regression test for Forgejo
+// #1311. Like the species summary, the new-species endpoint must emit the media-proxy
+// URL for every species independent of the image cache.
+func TestGetNewSpeciesDetections_ThumbnailDefersToProxy(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "analytics")
+	t.Attr("type", "regression")
+	t.Attr("feature", "new-species")
+
+	e := echo.New()
+	mockDS := mocks.NewMockInterface(t)
+
+	const sciName = sciAmericanCrow
+	mockDS.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return([]datastore.NewSpeciesData{
+			{ScientificName: sciName, CommonName: "American Crow", FirstSeenDate: "2025-03-07", CountInPeriod: 3},
+		}, nil)
+
+	// Deliberately no BirdImageCache: the thumbnail URL must not depend on it.
+	controller := newTestHandler(&apicore.Core{DS: mockDS})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/analytics/species/detections/new", http.NoBody)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, controller.GetNewSpeciesDetections(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var response []NewSpeciesResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	require.Len(t, response, 1)
+
+	assert.Equal(t, imageprovider.ProxyImageURL(sciName), response[0].ThumbnailURL,
+		"new species detections must emit the media-proxy URL so the proxy applies the fallback chain (#1311)")
+	assert.Contains(t, response[0].ThumbnailURL, "/api/v2/media/image/Corvus%20brachyrhynchos")
+	assert.NotContains(t, response[0].ThumbnailURL, "bird-placeholder",
+		"new species thumbnail must not fall back to the static placeholder")
+
+	mockDS.AssertExpectations(t)
+}
+
+// TestGetSpeciesThumbnails_DefersToProxy is a regression test for Forgejo #1311. The
+// batch thumbnails endpoint previously returned the static placeholder for a species
+// with no positive cache entry (masking a fallback image); it must now emit the
+// media-proxy URL for every requested species, independent of the image cache.
+func TestGetSpeciesThumbnails_DefersToProxy(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "analytics")
+	t.Attr("type", "regression")
+	t.Attr("feature", "species-thumbnails")
+
+	e := echo.New()
+	mockDS := mocks.NewMockInterface(t)
+
+	// Deliberately no BirdImageCache: buildThumbnailMap must not touch the cache.
+	controller := newTestHandler(&apicore.Core{DS: mockDS})
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v2/analytics/species/thumbnails?species="+url.QueryEscape(sciAmericanCrow)+
+			"&species="+url.QueryEscape(sciRedBelliedWoodpecker), http.NoBody)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, controller.GetSpeciesThumbnails(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var response map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	require.Len(t, response, 2)
+
+	for _, sciName := range []string{sciAmericanCrow, sciRedBelliedWoodpecker} {
+		assert.Equal(t, imageprovider.ProxyImageURL(sciName), response[sciName],
+			"species thumbnails must emit the media-proxy URL so the proxy applies the fallback chain (#1311)")
+		assert.NotContains(t, response[sciName], "bird-placeholder",
+			"species thumbnails must not fall back to the static placeholder")
+	}
 }
 
 // TestGetDailySpeciesSummary_SingleDetection tests that the GetDailySpeciesSummary function


### PR DESCRIPTION
## What

Extends the dashboard defer-to-proxy thumbnail fix (#3816) to the remaining
Species Analytics endpoints, which still resolved thumbnails through the
cache-only batch path and therefore ignored the configured fallback image
provider whenever the primary provider had a negative `__NOT_FOUND__` cache
entry.

- `GET /api/v2/analytics/species/summary`
- `GET /api/v2/analytics/species/detections/new`
- `GET /api/v2/analytics/species/thumbnails`

All three now emit the media-proxy URL (`/api/v2/media/image/<name>`) for every
species via the existing `buildThumbnailURL` helper. `ServeSpeciesImageProxy`
resolves images through the single-item `Get()` fallback chain and the local
file cache, honoring the fallback policy at request time and caching a 404. The
now-dead cache-only helpers are removed.

## Frontend

Because every species now gets a proxy URL that can 404, the Species Analytics
image consumers must degrade a 404 to the placeholder rather than a broken
image:

- `SpeciesDetailModal.svelte`: its `<img>` had no error handler. Added the
  `imageLoadFailed` pattern (reset when the displayed species changes, since the
  modal reuses its cached species) so a 404 keeps the placeholder box.
- `SpeciesCardMobile.svelte`: the compact and list variants called the error
  handler but their render guards never read `imageLoadFailed`, so a broken
  image stayed on screen. Added `&& !imageLoadFailed` to both (the card variant
  was already correct).

`SpeciesCard.svelte`, the `Species.svelte` inline table, and `AnalyticsOverview`
already degraded correctly.

## Also

- `processBatchDates` wraps each per-date body in a closure with `defer
  cancel()` so the context timer is released even if the query panics, instead
  of leaking until the timeout.
- Updates the stale `species/daily` `thumbnail_url` example in the dashboard
  endpoint doc to the media-proxy URL (that endpoint moved to defer-to-proxy in
  #3816).

## Tests

- Backend regression tests assert the three endpoints emit proxy URLs
  unconditionally with a nil image cache (proving no cache dependency) and never
  the static placeholder; each fails against the old code.
- Frontend tests assert an image load error degrades to the placeholder for the
  modal and for all three mobile-card variants.

## Notes

The now-production-unused batch cache machinery in `internal/imageprovider`
(`GetBatch`/`GetBatchCachedOnly` and helpers) is intentionally left in place;
its removal, together with a related cache-warmup fix, is a follow-up so this
change stays focused and low-risk.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed species thumbnail rendering across cards and the species detail modal so broken images aren’t shown after load failures.
  - Ensured thumbnail failure state resets when switching to a different species, allowing correct re-rendering.
  - Updated analytics endpoints to consistently return proxy-based thumbnail URLs.

- **Tests**
  - Added UI regression tests for thumbnail src rendering and failure handling across card variants and the modal.
  - Added backend regression tests verifying proxy-based thumbnail URLs without relying on cached images.

- **Documentation**
  - Updated the “Daily Species Summary” API example to use the current thumbnail URL format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->