### PR TITLE
refactor(analytics): unify thumbnail placeholder, drop dead two-phase load

### DIFF
--- a/frontend/src/lib/desktop/components/ui/image-utils.test.ts
+++ b/frontend/src/lib/desktop/components/ui/image-utils.test.ts
@@ -24,4 +24,17 @@ describe('handleBirdImageError', () => {
 
     expect(img.src).toContain('/birdnet/ui/assets/bird-placeholder.svg');
   });
+
+  it('does not re-swap when the src is already the placeholder (avoids an onerror loop)', () => {
+    const img = document.createElement('img');
+    // First failure swaps to the placeholder.
+    handleBirdImageError({ currentTarget: img } as unknown as Event);
+    const afterFirst = img.src;
+    expect(afterFirst).toContain('/ui/assets/bird-placeholder.svg');
+
+    // A subsequent error (e.g. the placeholder asset itself failing) is a no-op: the
+    // guard returns early instead of re-assigning src, which would re-fire onerror.
+    handleBirdImageError({ currentTarget: img } as unknown as Event);
+    expect(img.src).toBe(afterFirst);
+  });
 });

--- a/frontend/src/lib/desktop/components/ui/image-utils.ts
+++ b/frontend/src/lib/desktop/components/ui/image-utils.ts
@@ -8,13 +8,16 @@ import { buildAppUrl } from '$lib/utils/urlHelpers';
  * Handles bird thumbnail image load errors by replacing failed images with a bird placeholder
  * @param e - The error event from the bird thumbnail image element
  */
+/** Static asset path of the bird-silhouette placeholder (before base-path resolution). */
+const BIRD_PLACEHOLDER_PATH = '/ui/assets/bird-placeholder.svg';
+
 export function handleBirdImageError(e: Event): void {
   const target = e.currentTarget as globalThis.HTMLImageElement;
-  const placeholderSrc = buildAppUrl('/ui/assets/bird-placeholder.svg');
   // Guard against an infinite onerror loop if the placeholder asset itself fails to
-  // load. Comparing against the current src (rather than nulling target.onerror)
-  // keeps error handling working for a reused <img> whose bound src later changes to
-  // a new (potentially also-failing) thumbnail.
-  if (target.src.endsWith(placeholderSrc)) return;
-  target.src = placeholderSrc;
+  // load. Match the stable path with includes() so a base path or any query/hash
+  // suffix (dev server, CDN, cache-busting) can't defeat the check. Using this rather
+  // than nulling target.onerror keeps error handling working for a reused <img> whose
+  // bound src later changes to a new (potentially also-failing) thumbnail.
+  if (target.src.includes(BIRD_PLACEHOLDER_PATH)) return;
+  target.src = buildAppUrl(BIRD_PLACEHOLDER_PATH);
 }

--- a/frontend/src/lib/desktop/components/ui/image-utils.ts
+++ b/frontend/src/lib/desktop/components/ui/image-utils.ts
@@ -10,5 +10,11 @@ import { buildAppUrl } from '$lib/utils/urlHelpers';
  */
 export function handleBirdImageError(e: Event): void {
   const target = e.currentTarget as globalThis.HTMLImageElement;
-  target.src = buildAppUrl('/ui/assets/bird-placeholder.svg');
+  const placeholderSrc = buildAppUrl('/ui/assets/bird-placeholder.svg');
+  // Guard against an infinite onerror loop if the placeholder asset itself fails to
+  // load. Comparing against the current src (rather than nulling target.onerror)
+  // keeps error handling working for a reused <img> whose bound src later changes to
+  // a new (potentially also-failing) thumbnail.
+  if (target.src.endsWith(placeholderSrc)) return;
+  target.src = placeholderSrc;
 }

--- a/frontend/src/lib/desktop/features/analytics/components/modals/SpeciesDetailModal.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/modals/SpeciesDetailModal.svelte
@@ -4,6 +4,7 @@
   import { t } from '$lib/i18n';
   import { formatDate } from '$lib/utils/formatters';
   import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
+  import { handleBirdImageError } from '$lib/desktop/components/ui/image-utils';
 
   interface SpeciesData {
     common_name: string;
@@ -29,11 +30,6 @@
   // while isOpen transitions to false.
   let cachedSpecies = $state<SpeciesData | null>(null);
 
-  // Tracks a thumbnail load failure so a 404 from the media proxy degrades to the
-  // placeholder background instead of a broken image. Reset when the displayed species
-  // changes, since the modal reuses cachedSpecies across species.
-  let imageLoadFailed = $state(false);
-
   // Clear stale cache when the modal opens so previous species data doesn't flash.
   // The cache is only useful during the close transition (species becomes null while
   // isOpen transitions to false), not during open.
@@ -48,7 +44,6 @@
   $effect(() => {
     if (species) {
       cachedSpecies = species;
-      imageLoadFailed = false;
     }
   });
 
@@ -60,10 +55,6 @@
 
   function formatPercentage(value: number): string {
     return (value * 100).toFixed(1) + '%';
-  }
-
-  function handleImageError() {
-    imageLoadFailed = true;
   }
 
   function handleClose() {
@@ -98,14 +89,12 @@
     {#if displaySpecies}
       {#if displaySpecies.thumbnail_url}
         <div class="w-full aspect-[4/3] rounded-xl overflow-hidden bg-[var(--color-base-300)]">
-          {#if !imageLoadFailed}
-            <img
-              src={displaySpecies.thumbnail_url}
-              alt={displayName}
-              class="w-full h-full object-cover"
-              onerror={handleImageError}
-            />
-          {/if}
+          <img
+            src={displaySpecies.thumbnail_url}
+            alt={displayName}
+            class="w-full h-full object-cover"
+            onerror={handleBirdImageError}
+          />
         </div>
       {/if}
 

--- a/frontend/src/lib/desktop/features/analytics/components/modals/SpeciesDetailModal.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/modals/SpeciesDetailModal.test.ts
@@ -114,10 +114,11 @@ describe('SpeciesDetailModal', () => {
     expect(img).toHaveAttribute('src', '/api/v2/media/image/Passer%20domesticus');
   });
 
-  // Regression for Forgejo #1311: under defer-to-proxy every species gets a media-proxy
-  // URL that can 404, so the modal must swap to the placeholder background on error
-  // rather than showing a broken image.
-  it('degrades to the placeholder (removes the img) when the thumbnail fails to load', async () => {
+  // Under defer-to-proxy every species gets a media-proxy URL that can 404, so the
+  // modal degrades to the shared bird-silhouette placeholder (handleBirdImageError) on
+  // error, matching the dashboard and analytics overview. The img is kept (alt text
+  // preserved) with its src swapped to the placeholder asset.
+  it('swaps to the bird placeholder when the thumbnail fails to load', async () => {
     const { container } = modalTest.render({
       props: {
         isOpen: true,
@@ -129,7 +130,9 @@ describe('SpeciesDetailModal', () => {
     expect(img).not.toBeNull();
     if (img) await fireEvent.error(img);
 
-    expect(container.querySelector('img')).toBeNull();
+    const afterError = container.querySelector('img');
+    expect(afterError).not.toBeNull();
+    expect(afterError?.getAttribute('src')).toContain('bird-placeholder.svg');
   });
 
   it('closes when clicking outside the modal content', async () => {

--- a/frontend/src/lib/desktop/features/analytics/components/ui/SpeciesCard.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/ui/SpeciesCard.svelte
@@ -3,6 +3,7 @@
   import { t } from '$lib/i18n';
   import { formatDate } from '$lib/utils/formatters';
   import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
+  import { handleBirdImageError } from '$lib/desktop/components/ui/image-utils';
 
   interface SpeciesData {
     common_name: string;
@@ -26,30 +27,18 @@
     return (value * 100).toFixed(1) + '%';
   }
 
-  let imageLoadFailed = $state(false);
   let displayName = $derived(localizeSpeciesName(species.scientific_name, species.common_name));
-
-  function handleImageError() {
-    imageLoadFailed = true;
-  }
-
-  // Reset the failed-load flag when a new species is provided so a reused
-  // component instance retries its thumbnail instead of keeping a prior
-  // species' placeholder (matches SpeciesDetailModal).
-  $effect(() => {
-    if (species) imageLoadFailed = false;
-  });
 </script>
 
 <div class={cn('card bg-[var(--color-base-200)]', className)}>
   <figure class="px-4 pt-4">
     <div class="rounded-xl w-full aspect-[4/3] overflow-hidden bg-[var(--color-base-300)]">
-      {#if species.thumbnail_url && !imageLoadFailed}
+      {#if species.thumbnail_url}
         <img
           src={species.thumbnail_url}
           alt={displayName}
           class="h-full w-full object-cover"
-          onerror={handleImageError}
+          onerror={handleBirdImageError}
         />
       {/if}
     </div>

--- a/frontend/src/lib/desktop/features/analytics/components/ui/SpeciesCard.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/ui/SpeciesCard.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/svelte';
+import SpeciesCard from './SpeciesCard.svelte';
+
+// Mock the i18n module (mirrors SpeciesCardMobile.test.ts).
+vi.mock('$lib/i18n', () => ({
+  t: vi.fn((key: string) => {
+    const translations: Record<string, string> = {
+      'analytics.species.card.detections': 'Detections',
+      'analytics.species.card.confidence': 'Confidence',
+      'analytics.species.card.first': 'First',
+    };
+    // eslint-disable-next-line security/detect-object-injection -- Test mock with controlled translation data
+    return translations[key] ?? key;
+  }),
+}));
+
+const mockSpecies = {
+  common_name: 'House Sparrow',
+  scientific_name: 'Passer domesticus',
+  count: 42,
+  avg_confidence: 0.85,
+  max_confidence: 0.95,
+  first_heard: '2024-01-15T10:30:00',
+  last_heard: '2024-01-20T14:45:00',
+  thumbnail_url: '/api/v2/media/image/Passer%20domesticus',
+};
+
+describe('SpeciesCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // Under defer-to-proxy every species gets a media-proxy URL that can 404, so the
+  // card degrades to the shared bird-silhouette placeholder (handleBirdImageError) on
+  // error, matching the dashboard and analytics overview. The img is kept (alt text
+  // preserved) with its src swapped to the placeholder asset.
+  it('renders the thumbnail image when thumbnail_url is set', () => {
+    const { container } = render(SpeciesCard, { props: { species: mockSpecies } });
+
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img).toHaveAttribute('src', '/api/v2/media/image/Passer%20domesticus');
+  });
+
+  it('swaps to the bird placeholder on load error', async () => {
+    const { container } = render(SpeciesCard, { props: { species: mockSpecies } });
+
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    if (img) await fireEvent.error(img);
+
+    const afterError = container.querySelector('img');
+    expect(afterError).not.toBeNull();
+    expect(afterError?.getAttribute('src')).toContain('bird-placeholder.svg');
+  });
+
+  it('rebinds to the new thumbnail when the species prop changes', async () => {
+    const { container, rerender } = render(SpeciesCard, { props: { species: mockSpecies } });
+
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    if (img) await fireEvent.error(img);
+    expect(container.querySelector('img')?.getAttribute('src')).toContain('bird-placeholder.svg');
+
+    // A reused instance showing a different species must display the new thumbnail
+    // again, not stay on the previous placeholder.
+    await rerender({
+      species: {
+        ...mockSpecies,
+        scientific_name: 'Corvus brachyrhynchos',
+        common_name: 'American Crow',
+        thumbnail_url: '/api/v2/media/image/Corvus%20brachyrhynchos',
+      },
+    });
+
+    const rebound = container.querySelector('img');
+    expect(rebound).not.toBeNull();
+    expect(rebound).toHaveAttribute('src', '/api/v2/media/image/Corvus%20brachyrhynchos');
+  });
+});

--- a/frontend/src/lib/desktop/features/analytics/components/ui/SpeciesCardMobile.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/ui/SpeciesCardMobile.svelte
@@ -4,6 +4,7 @@
   import { formatDate } from '$lib/utils/formatters';
   import { ChevronRight } from '@lucide/svelte';
   import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
+  import { handleBirdImageError } from '$lib/desktop/components/ui/image-utils';
 
   interface SpeciesData {
     common_name: string;
@@ -29,19 +30,7 @@
     return (value * 100).toFixed(1) + '%';
   }
 
-  let imageLoadFailed = $state(false);
   let displayName = $derived(localizeSpeciesName(species.scientific_name, species.common_name));
-
-  function handleImageError() {
-    imageLoadFailed = true;
-  }
-
-  // Reset the failed-load flag when a new species is provided so a reused
-  // component instance retries its thumbnail instead of keeping a prior
-  // species' placeholder (matches SpeciesDetailModal).
-  $effect(() => {
-    if (species) imageLoadFailed = false;
-  });
 
   function handleClick() {
     if (onClick) {
@@ -61,12 +50,12 @@
   >
     <figure class="px-4 pt-4">
       <div class="rounded-xl w-full aspect-[4/3] overflow-hidden bg-[var(--color-base-300)]">
-        {#if species.thumbnail_url && !imageLoadFailed}
+        {#if species.thumbnail_url}
           <img
             src={species.thumbnail_url}
             alt={displayName}
             class="h-full w-full object-cover"
-            onerror={handleImageError}
+            onerror={handleBirdImageError}
           />
         {/if}
       </div>
@@ -112,12 +101,12 @@
     <div class="flex-shrink-0">
       <div class="avatar w-16 h-16">
         <div class="mask mask-squircle bg-[var(--color-base-300)]">
-          {#if species.thumbnail_url && !imageLoadFailed}
+          {#if species.thumbnail_url}
             <img
               src={species.thumbnail_url}
               alt={displayName}
               class="object-cover"
-              onerror={handleImageError}
+              onerror={handleBirdImageError}
             />
           {/if}
         </div>
@@ -159,12 +148,12 @@
   >
     <div class="avatar flex-shrink-0">
       <div class="mask mask-squircle w-12 h-12 bg-[var(--color-base-300)]">
-        {#if species.thumbnail_url && !imageLoadFailed}
+        {#if species.thumbnail_url}
           <img
             src={species.thumbnail_url}
             alt={displayName}
             class="object-cover"
-            onerror={handleImageError}
+            onerror={handleBirdImageError}
           />
         {/if}
       </div>

--- a/frontend/src/lib/desktop/features/analytics/components/ui/SpeciesCardMobile.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/ui/SpeciesCardMobile.test.ts
@@ -35,10 +35,10 @@ describe('SpeciesCardMobile', () => {
     cleanup();
   });
 
-  // Regression for Forgejo #1311: under defer-to-proxy every species gets a media-proxy
-  // URL that can 404, so each variant must remove the img on error (the wrapper's
-  // bg-base-300 shows as the placeholder) rather than leaving a broken image. Before the
-  // fix the compact and list variants set imageLoadFailed but never read it in the guard.
+  // Under defer-to-proxy every species gets a media-proxy URL that can 404, so each
+  // variant degrades to the shared bird-silhouette placeholder (handleBirdImageError)
+  // on error, matching the dashboard and analytics overview. The <img> is kept (its
+  // alt text is preserved) and its src is swapped to the placeholder asset.
   for (const variant of ['card', 'compact', 'list'] as const) {
     it(`renders the thumbnail image for the ${variant} variant`, () => {
       const { container } = render(SpeciesCardMobile, {
@@ -50,7 +50,7 @@ describe('SpeciesCardMobile', () => {
       expect(img).toHaveAttribute('src', '/api/v2/media/image/Passer%20domesticus');
     });
 
-    it(`removes the img on load error for the ${variant} variant`, async () => {
+    it(`swaps to the bird placeholder on load error for the ${variant} variant`, async () => {
       const { container } = render(SpeciesCardMobile, {
         props: { species: mockSpecies, variant },
       });
@@ -59,10 +59,14 @@ describe('SpeciesCardMobile', () => {
       expect(img).not.toBeNull();
       if (img) await fireEvent.error(img);
 
-      expect(container.querySelector('img')).toBeNull();
+      // The img is kept (alt preserved) with its src swapped to the placeholder,
+      // rather than being removed.
+      const afterError = container.querySelector('img');
+      expect(afterError).not.toBeNull();
+      expect(afterError?.getAttribute('src')).toContain('bird-placeholder.svg');
     });
 
-    it(`resets the failed-load flag when the species prop changes for the ${variant} variant`, async () => {
+    it(`rebinds to the new thumbnail when the species prop changes for the ${variant} variant`, async () => {
       const { container, rerender } = render(SpeciesCardMobile, {
         props: { species: mockSpecies, variant },
       });
@@ -70,9 +74,10 @@ describe('SpeciesCardMobile', () => {
       const img = container.querySelector('img');
       expect(img).not.toBeNull();
       if (img) await fireEvent.error(img);
-      expect(container.querySelector('img')).toBeNull();
+      expect(container.querySelector('img')?.getAttribute('src')).toContain('bird-placeholder.svg');
 
-      // A reused instance showing a different species must retry its thumbnail.
+      // A reused instance showing a different species must display the new
+      // thumbnail again, not stay on the previous placeholder.
       await rerender({
         species: {
           ...mockSpecies,
@@ -82,7 +87,9 @@ describe('SpeciesCardMobile', () => {
         },
       });
 
-      expect(container.querySelector('img')).not.toBeNull();
+      const rebound = container.querySelector('img');
+      expect(rebound).not.toBeNull();
+      expect(rebound).toHaveAttribute('src', '/api/v2/media/image/Corvus%20brachyrhynchos');
     });
   }
 });

--- a/frontend/src/lib/desktop/features/analytics/pages/Species.svelte
+++ b/frontend/src/lib/desktop/features/analytics/pages/Species.svelte
@@ -203,7 +203,13 @@
     return (value * 100).toFixed(1) + '%';
   }
 
+  // Guards fetchData against out-of-order responses: when filters change in quick
+  // succession, a slow earlier request must not overwrite the results (or clear the
+  // loading flag) of a newer one.
+  let fetchSeq = 0;
+
   async function fetchData() {
+    const currentSeq = ++fetchSeq;
     isLoading = true;
     // Apply Filters (and mount/reset) commit the pending dropdown selection.
     appliedSortOrder = filters.sortOrder;
@@ -265,6 +271,8 @@
       }
 
       const rawSpecies: SpeciesData[] = await response.json();
+      // A newer fetchData superseded this request; drop its now-stale response.
+      if (currentSeq !== fetchSeq) return;
       // Backend returns relative URLs (e.g. /api/v2/media/image/...). Run them
       // through buildAppUrl so they include the configured base path (e.g.
       // /birdnet, HA Ingress token) before they end up in <img src=...>.
@@ -274,10 +282,13 @@
           : species
       );
     } catch (error) {
+      // Ignore a stale request's failure so it cannot blank out fresher results.
+      if (currentSeq !== fetchSeq) return;
       logger.error('Error fetching species data:', error);
       speciesData = [];
     } finally {
-      isLoading = false;
+      // Only the latest request owns the loading flag.
+      if (currentSeq === fetchSeq) isLoading = false;
     }
   }
 

--- a/frontend/src/lib/desktop/features/analytics/pages/Species.svelte
+++ b/frontend/src/lib/desktop/features/analytics/pages/Species.svelte
@@ -7,6 +7,7 @@
   import { getStoredValue, setStoredValue } from '$lib/utils/storage';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
   import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
+  import { handleBirdImageError } from '$lib/desktop/components/ui/image-utils';
   import { onMount, onDestroy } from 'svelte';
   import SortableHeader from '$lib/desktop/components/ui/SortableHeader.svelte';
   import SpeciesFilterForm from '../components/forms/SpeciesFilterForm.svelte';
@@ -202,13 +203,8 @@
     return (value * 100).toFixed(1) + '%';
   }
 
-  // Increments on every fetchData so an in-flight thumbnail loop from a previous
-  // fetch can detect it has been superseded and stop mutating speciesData.
-  let thumbnailFetchSeq = 0;
-
   async function fetchData() {
     isLoading = true;
-    const fetchSeq = ++thumbnailFetchSeq;
     // Apply Filters (and mount/reset) commit the pending dropdown selection.
     appliedSortOrder = filters.sortOrder;
     setStoredValue<SortOrder>(SORT_STORAGE_KEY, filters.sortOrder);
@@ -277,9 +273,6 @@
           ? { ...species, thumbnail_url: buildAppUrl(species.thumbnail_url) }
           : species
       );
-
-      // Load thumbnails asynchronously after main data is displayed
-      loadThumbnailsAsync(fetchSeq);
     } catch (error) {
       logger.error('Error fetching species data:', error);
       speciesData = [];
@@ -421,67 +414,6 @@
     filters.startDate = formatDateForInput(lastMonth);
 
     fetchData();
-  }
-
-  async function loadThumbnailsAsync(fetchSeq: number) {
-    // Skip if we don't have species data
-    if (!speciesData || speciesData.length === 0) {
-      return;
-    }
-
-    // Get scientific names that need thumbnails
-    const scientificNames = speciesData
-      .filter(species => !species.thumbnail_url)
-      .map(species => species.scientific_name);
-
-    if (scientificNames.length === 0) {
-      return;
-    }
-
-    try {
-      // Fetch thumbnails in batches to avoid overwhelming the server
-      const batchSize = 20;
-      for (let i = 0; i < scientificNames.length; i += batchSize) {
-        // A newer fetchData superseded this run; stop fetching and mutating stale state.
-        if (fetchSeq !== thumbnailFetchSeq) return;
-        const batch = scientificNames.slice(i, i + batchSize);
-
-        // Create query parameters for this batch
-        const params = new URLSearchParams();
-        batch.forEach(name => params.append('species', name));
-
-        // Fetch thumbnails for this batch
-        const response = await fetch(
-          buildAppUrl(`/api/v2/analytics/species/thumbnails?${params.toString()}`)
-        );
-        if (response.ok) {
-          const thumbnails = await response.json();
-          // Re-check after the await: a newer fetch may have replaced speciesData
-          // while this batch was in flight, so don't apply stale thumbnails to it.
-          if (fetchSeq !== thumbnailFetchSeq) return;
-
-          // Update species data with fetched thumbnails. Backend URLs are
-          // relative; buildAppUrl prepends the configured base path so the
-          // image request resolves correctly behind a reverse proxy.
-          speciesData = speciesData.map(species => {
-            const url = thumbnails[species.scientific_name];
-            if (url) {
-              return { ...species, thumbnail_url: buildAppUrl(url) };
-            }
-            return species;
-          });
-          // filteredSpecies is $derived; reassigning speciesData re-renders it.
-        }
-
-        // Small delay between batches
-        if (i + batchSize < scientificNames.length) {
-          await new Promise(resolve => setTimeout(resolve, 100));
-        }
-      }
-    } catch (error) {
-      logger.error('Error loading thumbnails:', error);
-      // Continue without thumbnails - don't break the UI
-    }
   }
 
   function exportData() {
@@ -717,21 +649,13 @@
                   <td>
                     <div class="flex items-center gap-3">
                       <div class="avatar">
-                        <div
-                          class="mask mask-squircle w-12 h-12"
-                          class:bg-[var(--color-base-300)]={!species.thumbnail_url}
-                        >
+                        <div class="mask mask-squircle w-12 h-12 bg-[var(--color-base-300)]">
                           {#if species.thumbnail_url}
                             <img
                               src={species.thumbnail_url}
                               alt={displayName}
-                              onerror={e => {
-                                const img = e.target as HTMLImageElement;
-                                if (img) {
-                                  img.style.display = 'none';
-                                  img.parentElement?.classList.add('bg-[var(--color-base-300)]');
-                                }
-                              }}
+                              class="h-full w-full object-cover"
+                              onerror={handleBirdImageError}
                             />
                           {/if}
                         </div>

--- a/frontend/src/lib/desktop/features/analytics/pages/Species.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/pages/Species.test.ts
@@ -72,7 +72,6 @@ describe('Species (analytics page)', () => {
 
     globalThis.fetch = mockFetchSequence({
       '/api/v2/analytics/species/summary': () => summary,
-      '/api/v2/analytics/species/thumbnails': () => ({}),
     });
 
     const { container } = speciesTest.render({});
@@ -89,46 +88,6 @@ describe('Species (analytics page)', () => {
     );
 
     expect(img.getAttribute('src')).toBe('/birdnet/api/v2/media/image/Cardellina%20pusilla');
-  });
-
-  it('also prefixes URLs returned by the batched thumbnails endpoint', async () => {
-    setBasePath('/birdnet');
-
-    const summary: SpeciesSummary[] = [
-      {
-        common_name: 'Northern Cardinal',
-        scientific_name: 'Cardinalis cardinalis',
-        count: 7,
-        avg_confidence: 0.91,
-        max_confidence: 0.99,
-        first_heard: '2026-04-10',
-        last_heard: '2026-04-26',
-        // No thumbnail_url here — the page's loadThumbnailsAsync() should
-        // populate it from the batch endpoint.
-      },
-    ];
-
-    globalThis.fetch = mockFetchSequence({
-      '/api/v2/analytics/species/summary': () => summary,
-      '/api/v2/analytics/species/thumbnails': () => ({
-        'Cardinalis cardinalis': '/api/v2/media/image/Cardinalis%20cardinalis',
-      }),
-    });
-
-    const { container } = speciesTest.render({});
-
-    const img = await waitFor(
-      () => {
-        const found = container.querySelector('img');
-        if (!found?.getAttribute('src')?.includes('Cardinalis')) {
-          throw new Error('thumbnail not yet rendered');
-        }
-        return found;
-      },
-      { timeout: 2000 }
-    );
-
-    expect(img.getAttribute('src')).toBe('/birdnet/api/v2/media/image/Cardinalis%20cardinalis');
   });
 });
 
@@ -178,7 +137,6 @@ describe('Species (analytics page) — sortable column headers', () => {
     vi.clearAllMocks();
     globalThis.fetch = mockFetchSequence({
       '/api/v2/analytics/species/summary': () => summary,
-      '/api/v2/analytics/species/thumbnails': () => ({}),
     });
     window.localStorage.clear();
   });


### PR DESCRIPTION
## What

Follow-up frontend cleanup after #3816/#3817 rerouted the analytics Species endpoints to the media proxy (defer-to-proxy). `/api/v2/analytics/species/summary` now returns a proxy `thumbnail_url` for every species.

1. **Remove the dead two-phase thumbnail loader** in `Species.svelte`. Because every species already carries a `thumbnail_url`, `loadThumbnailsAsync` filtered to nothing and never fetched `/species/thumbnails`. Deletes `loadThumbnailsAsync` and its `thumbnailFetchSeq` guard/call site (also removes a per-page-load burst of `ceil(N/20)` throttled fetches plus the re-render churn they caused). The `/api/v2/analytics/species/thumbnails` endpoint is **kept** as a standalone API; only its dead frontend caller is removed.

2. **Unify the missing-thumbnail placeholder** across the Species page family (`SpeciesCard`, `SpeciesCardMobile` (all 3 variants), `SpeciesDetailModal`, and the `Species.svelte` table) to the app-wide `handleBirdImageError` bird-silhouette, matching the dashboard and `AnalyticsOverview` (which already use it). Previously the Species surfaces used a divergent gray-box treatment that removed the `<img>` on error via an `imageLoadFailed` state + a reset `$effect`. The silhouette keeps the `<img>` (and its `alt`) and swaps `src` to `bird-placeholder.svg` on a proxy 404. Removing the `imageLoadFailed` state and reset effect simplifies the components; Svelte's reactive `src={species.thumbnail_url}` binding handles the reused-instance case (a changed species overrides the placeholder). The table `<img>` gains the same `h-full w-full object-cover` sizing the sibling cards already use.

## Tests

- Updated the SpeciesCardMobile and SpeciesDetailModal error tests to assert the silhouette swap (img kept, `src` contains `bird-placeholder.svg`) instead of img removal.
- Removed the Species page test that exercised the deleted two-phase loader, plus the now-dead `/species/thumbnails` mocks.
- Added `SpeciesCard.test.ts` (the grid card previously had no test) covering the placeholder swap and the reactive rebind on species change.
- `npm run check:all` clean; full analytics suite green.

## Notes / follow-ups (pre-existing, filed separately)

- The visible change is the app-wide bird-silhouette placeholder on the Species page (previously a gray box), which matches the dashboard/overview. The placeholder SVG is not theme-aware (a light-gray patch in dark mode) app-wide; a dark-mode render check is worthwhile when that is addressed.
- Tracked separately: hardening `handleBirdImageError` against the placeholder asset itself failing, making the placeholder SVG theme-aware, and the analytics `{#each}` keys embedding the row index (defeats sort diffing). None are introduced by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Thumbnail images across analytics species UI now remain visible and swap to the bird placeholder when they fail to load.
  * Switching species after an error now updates the thumbnail correctly.
  * Added a guard to avoid repeated placeholder reload loops if the placeholder fails.
  * Improved the Species page request handling to prevent stale results; resetting filters no longer triggers an immediate refresh.

* **Refactor**
  * Centralized thumbnail error handling for consistent behavior across components.

* **Tests**
  * Updated and added tests to cover placeholder swap behavior, species switching, and the placeholder edge case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->