### PR TITLE
perf(api): skip name resolution on species scores when names=false

### DIFF
--- a/internal/api/v2/range/range.go
+++ b/internal/api/v2/range/range.go
@@ -124,16 +124,36 @@ func resolveLocalizedName(resolver *classifier.Orchestrator, locale string, sp d
 // response format with probability score pointers. When resolver and locale
 // are provided, common names are resolved to the user's locale.
 func convertSpeciesScores(scores []classifier.SpeciesScore, resolver *classifier.Orchestrator, locale string) []dto.RangeFilterSpecies {
+	return buildRangeFilterSpecies(scores, func(label string) string {
+		return resolveLocalizedName(resolver, locale, detection.ParseSpeciesString(label))
+	})
+}
+
+// convertSpeciesScoresNoNames converts geomodel scores without resolving localized
+// common names. Name resolution is the dominant cost when converting all geomodel
+// species (threshold 0), so callers that only need scientificName->score skip it.
+func convertSpeciesScoresNoNames(scores []classifier.SpeciesScore) []dto.RangeFilterSpecies {
+	return buildRangeFilterSpecies(scores, nil)
+}
+
+// buildRangeFilterSpecies converts geomodel scores into API species entries. When
+// resolveName is non-nil it supplies the localized common name for each label;
+// passing nil skips common-name resolution entirely (the expensive step for large
+// species sets). The scientific name is extracted with detection.ExtractScientificName,
+// which avoids the per-label slice allocation of ParseSpeciesString.
+func buildRangeFilterSpecies(scores []classifier.SpeciesScore, resolveName func(label string) string) []dto.RangeFilterSpecies {
 	species := make([]dto.RangeFilterSpecies, 0, len(scores))
 	for _, s := range scores {
-		sp := detection.ParseSpeciesString(s.Label)
 		score := s.Score
-		species = append(species, dto.RangeFilterSpecies{
+		entry := dto.RangeFilterSpecies{
 			Label:          s.Label,
-			ScientificName: sp.ScientificName,
-			CommonName:     resolveLocalizedName(resolver, locale, sp),
+			ScientificName: detection.ExtractScientificName(s.Label),
 			Score:          &score,
-		})
+		}
+		if resolveName != nil {
+			entry.CommonName = resolveName(s.Label)
+		}
+		species = append(species, entry)
 	}
 	return species
 }
@@ -394,7 +414,16 @@ func (c *Handler) GetRangeFilterSpeciesScores(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to get species scores", http.StatusInternalServerError)
 	}
 
-	speciesList := convertSpeciesScores(speciesScores, birdnetInstance, locale)
+	// Resolving localized common names is O(species) and dominates latency when
+	// all geomodel species are requested (threshold 0). Callers that only need
+	// scientificName->score (e.g. rare-species highlighting) pass names=false to
+	// skip it. Names are included by default for backward compatibility.
+	var speciesList []dto.RangeFilterSpecies
+	if ctx.QueryParam("names") == "false" {
+		speciesList = convertSpeciesScoresNoNames(speciesScores)
+	} else {
+		speciesList = convertSpeciesScores(speciesScores, birdnetInstance, locale)
+	}
 
 	response := RangeFilterScoresResponse{
 		Species:   speciesList,

--- a/internal/api/v2/range/range_scores_names_test.go
+++ b/internal/api/v2/range/range_scores_names_test.go
@@ -1,0 +1,70 @@
+// range_scores_names_test.go: tests for the names=false fast path of the
+// species-scores endpoint, which skips localized common-name resolution.
+
+package rangeapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/classifier"
+)
+
+// convertSpeciesScoresNoNames backs GET /api/v2/range/species/scores?names=false.
+// It must preserve label/scientificName/score but skip common-name resolution,
+// which is the expensive step when converting all geomodel species.
+func TestConvertSpeciesScoresNoNames(t *testing.T) {
+	t.Parallel()
+
+	scores := []classifier.SpeciesScore{
+		{Label: "Turdus merula_Eurasian Blackbird", Score: 0.85},
+		{Label: "Parus major_Great Tit", Score: 0.02},
+	}
+
+	got := convertSpeciesScoresNoNames(scores)
+	require.Len(t, got, 2)
+
+	// Scientific name is parsed from the label; common name is intentionally empty.
+	assert.Equal(t, "Turdus merula_Eurasian Blackbird", got[0].Label)
+	assert.Equal(t, "Turdus merula", got[0].ScientificName)
+	assert.Empty(t, got[0].CommonName)
+	require.NotNil(t, got[0].Score)
+	assert.InDelta(t, 0.85, *got[0].Score, 1e-9)
+
+	assert.Equal(t, "Parus major", got[1].ScientificName)
+	assert.Empty(t, got[1].CommonName)
+	require.NotNil(t, got[1].Score)
+	assert.InDelta(t, 0.02, *got[1].Score, 1e-9)
+
+	// Each entry must own a distinct score pointer (no loop-variable aliasing).
+	assert.NotSame(t, got[0].Score, got[1].Score)
+}
+
+func TestConvertSpeciesScoresNoNames_Empty(t *testing.T) {
+	t.Parallel()
+	assert.Empty(t, convertSpeciesScoresNoNames(nil))
+}
+
+// buildRangeFilterSpecies invokes resolveName once per label (with the full label)
+// and stores the result as the common name; the names/default path relies on this.
+func TestBuildRangeFilterSpecies_WithResolver(t *testing.T) {
+	t.Parallel()
+
+	scores := []classifier.SpeciesScore{
+		{Label: "Turdus merula_Eurasian Blackbird", Score: 0.85},
+		{Label: "Parus major_Great Tit", Score: 0.02},
+	}
+
+	var seen []string
+	got := buildRangeFilterSpecies(scores, func(label string) string {
+		seen = append(seen, label)
+		return "COMMON"
+	})
+
+	require.Len(t, got, 2)
+	assert.Equal(t, "Turdus merula", got[0].ScientificName)
+	assert.Equal(t, "COMMON", got[0].CommonName)
+	assert.Equal(t, "COMMON", got[1].CommonName)
+	assert.Equal(t, []string{"Turdus merula_Eurasian Blackbird", "Parus major_Great Tit"}, seen)
+}


### PR DESCRIPTION
## Summary

`GET /api/v2/range/species/scores` resolves localized common names for **every** geomodel species (~12k) on each call via `resolveLocalizedName`. That per-species resolution dominates the endpoint's latency and, when all species are requested (threshold 0), can make the endpoint effectively hang.

This adds an opt-in `names=false` query parameter that returns `scientificName` → `score` only, skipping common-name resolution. Names are included by default, so existing callers are unaffected.

## Changes

- Add `names=false` query parameter to `GetRangeFilterSpeciesScores`.
- Add `convertSpeciesScoresNoNames`, which builds the score list without resolving localized common names.
- Unit tests for the new helper.

## Testing

- [x] `go test -race ./internal/api/v2/range/...`
- [x] `golangci-lint run --build-tags=noembed,skipfrontend ./internal/api/v2/range/...` (0 issues)
- [x] Manual: `GET /api/v2/range/species/scores?names=false` returns 200 quickly with all species; the default (names included) response is unchanged.

## Notes

Standalone performance improvement. A follow-up PR (rare-species highlighting) will consume the `names=false` path to flag rare detections client-side without an extra per-row call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to return species scores without localized/common names for lighter responses.
  * Kept the default response behavior unchanged when names are requested.

* **Bug Fixes**
  * Improved species score conversion so each result keeps its own score value correctly.
  * Ensured empty inputs return an empty species list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->