### PR TITLE
feat(system): notify when a newer build is available

### DIFF
--- a/frontend/src/lib/desktop/components/README.md
+++ b/frontend/src/lib/desktop/components/README.md
@@ -89,6 +89,7 @@ This folder contains **shared components** used across the application. Feature-
 - `ConfirmModal.svelte` - Confirmation dialog
 - `LoginModal.svelte` - User login modal
 - `ReviewModal.svelte` - Detection review modal
+- `UpdateAvailableModal.svelte` - "What's changed" window for a newer build (latest version, changelog, release link); driven by `/api/v2/system/update-check`
 - `SpeciesBadges.svelte` - Reusable species status and lock badges for modals
 - `SpeciesThumbnail.svelte` - Reusable species thumbnail image component
 

--- a/frontend/src/lib/desktop/components/modals/UpdateAvailableModal.svelte
+++ b/frontend/src/lib/desktop/components/modals/UpdateAvailableModal.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+  /**
+   * UpdateAvailableModal
+   *
+   * "What's changed" window for a newer build: shows the latest version details
+   * (title, released date, channel, changelog from the manifest) with a link to
+   * the GitHub release page. Driven by /api/v2/system/update-check.
+   */
+  import Modal from '$lib/desktop/components/ui/Modal.svelte';
+  import { t } from '$lib/i18n';
+  import { AlertTriangle, ExternalLink } from '@lucide/svelte';
+  import type { UpdateInfo } from '$lib/types/update';
+
+  interface Props {
+    isOpen: boolean;
+    info: UpdateInfo;
+    currentVersion?: string;
+    onClose: () => void;
+  }
+
+  let { isOpen, info, currentVersion, onClose }: Props = $props();
+
+  // Guard a malformed timestamp so the modal never shows "Invalid Date".
+  let releasedDate = $derived.by(() => {
+    if (!info.releasedAt) return '';
+    const parsed = new Date(info.releasedAt);
+    return Number.isNaN(parsed.getTime()) ? '' : parsed.toLocaleDateString();
+  });
+  let latestLabel = $derived(info.latestName || info.latestVersion || '');
+</script>
+
+<Modal {isOpen} {onClose} size="lg" title={t('navigation.update.title')} showCloseButton>
+  <div class="space-y-4">
+    {#if info.critical}
+      <div
+        class="flex items-start gap-2 rounded-lg p-3 bg-[color-mix(in_srgb,var(--color-error)_15%,transparent)] text-[var(--color-error)]"
+        role="alert"
+      >
+        <AlertTriangle class="size-5 shrink-0" />
+        <span class="text-sm">{t('navigation.update.critical')}</span>
+      </div>
+    {/if}
+
+    <dl class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-sm">
+      <dt class="text-[var(--color-base-content)]/60">{t('navigation.update.currentVersion')}</dt>
+      <dd class="font-medium">{currentVersion ?? info.currentVersion ?? ''}</dd>
+      <dt class="text-[var(--color-base-content)]/60">{t('navigation.update.latestVersion')}</dt>
+      <dd class="font-medium">{latestLabel}</dd>
+      {#if releasedDate}
+        <dt class="text-[var(--color-base-content)]/60">{t('navigation.update.released')}</dt>
+        <dd>{releasedDate}</dd>
+      {/if}
+      {#if info.channel}
+        <dt class="text-[var(--color-base-content)]/60">{t('navigation.update.channel')}</dt>
+        <dd class="capitalize">{info.channel}</dd>
+      {/if}
+    </dl>
+
+    {#if info.notes}
+      <div>
+        <h4 class="text-sm font-semibold mb-1">{t('navigation.update.whatsChanged')}</h4>
+        <div
+          class="max-h-64 overflow-y-auto rounded-lg bg-[var(--color-base-200)] p-3 text-xs whitespace-pre-wrap"
+        >
+          {info.notes}
+        </div>
+      </div>
+    {/if}
+  </div>
+
+  {#snippet footer()}
+    <div class="flex flex-wrap items-center justify-end gap-3">
+      <button
+        type="button"
+        class="text-sm px-3 py-1.5 rounded-lg text-[var(--color-base-content)]/70 hover:bg-[var(--color-base-200)]"
+        onclick={onClose}
+      >
+        {t('common.buttons.close')}
+      </button>
+      {#if info.releaseURL}
+        <a
+          href={info.releaseURL}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex items-center gap-1 text-sm px-3 py-1.5 rounded-lg bg-[var(--color-primary)] text-[var(--color-primary-content)] hover:bg-[var(--color-primary)]/90"
+        >
+          {t('navigation.update.viewRelease')}<ExternalLink class="size-3.5" />
+        </a>
+      {/if}
+    </div>
+  {/snippet}
+</Modal>

--- a/frontend/src/lib/desktop/components/modals/UpdateAvailableModal.test.ts
+++ b/frontend/src/lib/desktop/components/modals/UpdateAvailableModal.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Tests for UpdateAvailableModal.
+ *
+ * The i18n mock in src/test/setup.ts returns the key unchanged, so labels here
+ * equal their translation keys.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/svelte';
+import UpdateAvailableModal from './UpdateAvailableModal.svelte';
+import type { UpdateInfo } from '$lib/types/update';
+
+const baseInfo: UpdateInfo = {
+  updateAvailable: true,
+  latestVersion: 'v0.7.1',
+  latestName: 'v0.7.1 release',
+  releasedAt: '2026-07-08T12:00:00Z',
+  channel: 'stable',
+  notes: 'Fixed a notable bug',
+  releaseURL: 'https://example.test/release',
+  critical: false,
+};
+
+afterEach(cleanup);
+
+describe('UpdateAvailableModal', () => {
+  it('renders the release title, changelog, and a link to the release when open', () => {
+    render(UpdateAvailableModal, {
+      props: { isOpen: true, info: baseInfo, currentVersion: 'v0.7.0', onClose: () => {} },
+    });
+
+    expect(screen.getByText('v0.7.1 release')).toBeInTheDocument();
+    expect(screen.getByText('Fixed a notable bug')).toBeInTheDocument();
+
+    const link = screen.getByRole('link', { name: /viewRelease/i });
+    expect(link).toHaveAttribute('href', 'https://example.test/release');
+    // The manifest link was intentionally removed.
+    expect(screen.queryByText(/viewManifest/i)).not.toBeInTheDocument();
+  });
+
+  it('shows the critical banner only for critical updates', () => {
+    render(UpdateAvailableModal, {
+      props: {
+        isOpen: true,
+        info: { ...baseInfo, critical: true },
+        currentVersion: 'v0.7.0',
+        onClose: () => {},
+      },
+    });
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
+++ b/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
@@ -80,6 +80,10 @@ Performance Optimizations:
     Moon,
   } from '@lucide/svelte';
   import { t } from '$lib/i18n';
+  import { onMount } from 'svelte';
+  import { api } from '$lib/utils/api';
+  import UpdateAvailableModal from '$lib/desktop/components/modals/UpdateAvailableModal.svelte';
+  import type { UpdateInfo } from '$lib/types/update';
   import type { Component } from 'svelte';
   import CollapsibleNavSection from './CollapsibleNavSection.svelte';
   import type { NavItem } from './CollapsibleNavSection.svelte';
@@ -117,6 +121,35 @@ Performance Optimizations:
       enabledProviders: [],
     },
   }: Props = $props();
+
+  // Update availability for the running build's channel (see
+  // /api/v2/system/update-check). Best-effort: any failure (offline, dev build,
+  // unauthorized) leaves this null and no indicator is shown.
+  let updateInfo = $state<UpdateInfo | null>(null);
+  let showUpdateModal = $state(false);
+
+  // Accent for the version link by state: up to date (muted), update (warning),
+  // critical update (error).
+  let versionClass = $derived.by(() => {
+    if (!updateInfo) {
+      return 'text-[var(--color-base-content)]/60 hover:text-[var(--color-base-content)]/80';
+    }
+    if (updateInfo.critical) {
+      return 'italic text-[var(--color-error)] hover:text-[var(--color-error)]/80';
+    }
+    return 'italic text-[var(--color-warning)] hover:text-[var(--color-warning)]/80';
+  });
+
+  onMount(async () => {
+    try {
+      const info = await api.get<UpdateInfo>('/api/v2/system/update-check');
+      if (info.updateAvailable) {
+        updateInfo = info;
+      }
+    } catch {
+      // No update indicator when the check can't be reached.
+    }
+  });
 
   // Logo variant: solid uses flat color, gradient uses per-scheme handcrafted gradient
   let logoVariant: LogoVariant = $derived(
@@ -765,22 +798,45 @@ Performance Optimizations:
         {/if}
       {/if}
 
-      <!-- Version -->
+      <!-- Version: italic + asterisk when a newer build exists; opens the modal -->
       {#if !isCollapsed}
         <div class="mt-3 text-center">
-          <a
-            href={appState.projectLinks.repoUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            class="text-xs text-[var(--color-base-content)]/60 hover:text-[var(--color-base-content)]/80 transition-colors duration-150"
-            aria-label={t('navigation.viewOnGithubAriaLabel')}
-          >
-            {version}
-          </a>
+          {#if updateInfo}
+            <button
+              type="button"
+              class={cn('text-xs transition-colors duration-150', versionClass)}
+              title={t('navigation.updateAvailable', { version: updateInfo.latestVersion ?? '' })}
+              aria-label={t('navigation.updateAvailable', {
+                version: updateInfo.latestVersion ?? '',
+              })}
+              onclick={() => (showUpdateModal = true)}
+            >
+              {version}<span aria-hidden="true">*</span>
+            </button>
+          {:else}
+            <a
+              href={appState.projectLinks.repoUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              class={cn('text-xs transition-colors duration-150', versionClass)}
+              aria-label={t('navigation.viewOnGithubAriaLabel')}
+            >
+              {version}
+            </a>
+          {/if}
         </div>
       {/if}
     </div>
   </nav>
+
+  {#if updateInfo}
+    <UpdateAvailableModal
+      isOpen={showUpdateModal}
+      info={updateInfo}
+      currentVersion={version}
+      onClose={() => (showUpdateModal = false)}
+    />
+  {/if}
 
   <!-- Fixed-position tooltip for collapsed sidebar (escapes overflow containers).
        z-[210] keeps it above the drawer (z-[200] = Z_INDEX.SIDEBAR_DRAWER): the

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -224,6 +224,15 @@ export type TranslationKey =
   | 'navigation.reportBugAriaLabel'
   | 'navigation.askQuestionAriaLabel'
   | 'navigation.viewOnGithubAriaLabel'
+  | 'navigation.updateAvailable' // params: version
+  | 'navigation.update.title'
+  | 'navigation.update.critical'
+  | 'navigation.update.currentVersion'
+  | 'navigation.update.latestVersion'
+  | 'navigation.update.released'
+  | 'navigation.update.channel'
+  | 'navigation.update.whatsChanged'
+  | 'navigation.update.viewRelease'
   | 'navigation.health'
   | 'navigation.sections.explore'
   | 'navigation.sections.patterns'
@@ -3993,6 +4002,7 @@ export type TranslationParams = {
   'common.aria.imageCredit': { name: string | number };
   'common.review.modalTitle': { species: string | number };
   'common.review.form.commentCount': { chars: string | number };
+  'navigation.updateAvailable': { version: string | number };
   'notifications.timeAgo.minutesAgo': { minutes: string | number };
   'notifications.timeAgo.hoursAgo': { hours: string | number };
   'notifications.timeAgo.daysAgo': { days: string | number };

--- a/frontend/src/lib/types/update.ts
+++ b/frontend/src/lib/types/update.ts
@@ -1,0 +1,18 @@
+/**
+ * Response shape of GET /api/v2/system/update-check.
+ *
+ * Shared by the sidebar version indicator and the "what's changed" modal so the
+ * two stay in sync. All fields except updateAvailable are optional because the
+ * backend omits them for dev builds and when the check is unavailable (offline).
+ */
+export interface UpdateInfo {
+  updateAvailable: boolean;
+  currentVersion?: string;
+  latestVersion?: string;
+  latestName?: string;
+  releasedAt?: string;
+  notes?: string;
+  channel?: string;
+  releaseURL?: string;
+  critical?: boolean;
+}

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -246,6 +246,17 @@
     "reportBugAriaLabel": "Nahlásit chybu na GitHubu (otevře se v novém okně)",
     "askQuestionAriaLabel": "Položit dotaz na GitHub Discussions (otevře se v novém okně)",
     "viewOnGithubAriaLabel": "Zobrazit BirdNET-Go na GitHubu (otevře se v novém okně)",
+    "updateAvailable": "Dostupná aktualizace: {version}",
+    "update": {
+      "title": "Dostupná aktualizace",
+      "critical": "Toto je kriticky důležitá bezpečnostní aktualizace. Aktualizujte co nejdříve.",
+      "currentVersion": "Aktuální verze",
+      "latestVersion": "Nejnovější verze",
+      "released": "Vydáno",
+      "channel": "Kanál",
+      "whatsChanged": "Co je nového",
+      "viewRelease": "Zobrazit vydání"
+    },
     "health": "Health",
     "sections": {
       "explore": "Prozkoumat",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -246,6 +246,17 @@
     "reportBugAriaLabel": "Rapportér en fejl på GitHub (åbner i nyt vindue)",
     "askQuestionAriaLabel": "Stil et spørgsmål på GitHub Discussions (åbner i nyt vindue)",
     "viewOnGithubAriaLabel": "Se BirdNET-Go på GitHub (åbner i nyt vindue)",
+    "updateAvailable": "Opdatering tilgængelig: {version}",
+    "update": {
+      "title": "Opdatering tilgængelig",
+      "critical": "Dette er en sikkerhedskritisk opdatering. Opdater så hurtigt som muligt.",
+      "currentVersion": "Nuværende version",
+      "latestVersion": "Seneste version",
+      "released": "Udgivet",
+      "channel": "Kanal",
+      "whatsChanged": "Hvad er nyt",
+      "viewRelease": "Se udgivelse"
+    },
     "health": "Health",
     "sections": {
       "explore": "Udforsk",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -246,6 +246,17 @@
     "reportBugAriaLabel": "Einen Fehler auf GitHub melden (öffnet in neuem Fenster)",
     "askQuestionAriaLabel": "Eine Frage in GitHub Discussions stellen (öffnet in neuem Fenster)",
     "viewOnGithubAriaLabel": "BirdNET-Go auf GitHub ansehen (öffnet in neuem Fenster)",
+    "updateAvailable": "Update verfügbar: {version}",
+    "update": {
+      "title": "Update verfügbar",
+      "critical": "Dies ist ein sicherheitskritisches Update. Bitte aktualisieren Sie so bald wie möglich.",
+      "currentVersion": "Aktuelle Version",
+      "latestVersion": "Neueste Version",
+      "released": "Veröffentlicht",
+      "channel": "Kanal",
+      "whatsChanged": "Was ist neu",
+      "viewRelease": "Release anzeigen"
+    },
     "health": "Health",
     "sections": {
       "explore": "Erkunden",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -246,6 +246,17 @@
     "reportBugAriaLabel": "Report a bug on GitHub (opens in new window)",
     "askQuestionAriaLabel": "Ask a question on GitHub Discussions (opens in new window)",
     "viewOnGithubAriaLabel": "View BirdNET-Go on GitHub (opens in new window)",
+    "updateAvailable": "Update available: {version}",
+    "update": {
+      "title": "Update available",
+      "critical": "This is a security-critical update. Please upgrade as soon as possible.",
+      "currentVersion": "Current version",
+      "latestVersion": "Latest version",
+      "released": "Released",
+      "channel": "Channel",
+      "whatsChanged": "What's changed",
+      "viewRelease": "View release"
+    },
     "health": "Health",
     "sections": {
       "explore": "Explore",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -246,6 +246,17 @@
     "reportBugAriaLabel": "Reportar un error en GitHub (abre en una nueva ventana)",
     "askQuestionAriaLabel": "Hacer una pregunta en GitHub Discussions (abre en una nueva ventana)",
     "viewOnGithubAriaLabel": "Ver BirdNET-Go en GitHub (abre en una nueva ventana)",
+    "updateAvailable": "Actualización disponible: {version}",
+    "update": {
+      "title": "Actualización disponible",
+      "critical": "Esta es una actualización de seguridad crítica. Actualice lo antes posible.",
+      "currentVersion": "Versión actual",
+      "latestVersion": "Última versión",
+      "released": "Publicado",
+      "channel": "Canal",
+      "whatsChanged": "Novedades",
+      "viewRelease": "Ver versión"
+    },
     "health": "Health",
     "sections": {
       "explore": "Explorar",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -246,6 +246,17 @@
     "reportBugAriaLabel": "Ilmoita virheestä GitHubissa (avautuu uuteen ikkunaan)",
     "askQuestionAriaLabel": "Esitä kysymys GitHub Discussions -foorumilla (avautuu uuteen ikkunaan)",
     "viewOnGithubAriaLabel": "Näytä BirdNET-Go GitHubissa (avautuu uuteen ikkunaan)",
+    "updateAvailable": "Päivitys saatavilla: {version}",
+    "update": {
+      "title": "Päivitys saatavilla",
+      "critical": "Tämä on kriittinen tietoturvapäivitys. Päivitä mahdollisimman pian.",
+      "currentVersion": "Nykyinen versio",
+      "latestVersion": "Uusin versio",
+      "released": "Julkaistu",
+      "channel": "Kanava",
+      "whatsChanged": "Mitä uutta",
+      "viewRelease": "Näytä julkaisu"
+    },
     "health": "Health",
     "sections": {
       "explore": "Selaa",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -246,6 +246,17 @@
     "reportBugAriaLabel": "Signaler un bug sur GitHub (ouvre dans une nouvelle fenêtre)",
     "askQuestionAriaLabel": "Poser une question sur GitHub Discussions (ouvre dans une nouvelle fenêtre)",
     "viewOnGithubAriaLabel": "Voir BirdNET-Go sur GitHub (ouvre dans une nouvelle fenêtre)",
+    "updateAvailable": "Mise à jour disponible : {version}",
+    "update": {
+      "title": "Mise à jour disponible",
+      "critical": "Il s'agit d'une mise à jour de sécurité critique. Veuillez mettre à jour dès que possible.",
+      "currentVersion": "Version actuelle",
+      "latestVersion": "Dernière version",
+      "released": "Publié",
+      "channel": "Canal",
+      "whatsChanged": "Nouveautés",
+      "viewRelease": "Voir la version"
+    },
     "health": "Health",
     "sections": {
       "explore": "Explorer",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -246,6 +246,17 @@
     "reportBugAriaLabel": "Hiba bejelentése a GitHubon (új ablakban nyílik meg)",
     "askQuestionAriaLabel": "Kérdés feltevése a GitHub Discussions oldalon (új ablakban nyílik meg)",
     "viewOnGithubAriaLabel": "BirdNET-Go megtekintése a GitHubon (új ablakban nyílik meg)",
+    "updateAvailable": "Elérhető frissítés: {version}",
+    "update": {
+      "title": "Elérhető frissítés",
+      "critical": "Ez egy kritikus biztonsági frissítés. Kérjük, frissítsen a lehető leghamarabb.",
+      "currentVersion": "Jelenlegi verzió",
+      "latestVersion": "Legújabb verzió",
+      "released": "Kiadva",
+      "channel": "Csatorna",
+      "whatsChanged": "Változások",
+      "viewRelease": "Kiadás megtekintése"
+    },
     "health": "Rendszerállapot",
     "sections": {
       "explore": "Felfedezés",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -246,6 +246,17 @@
     "reportBugAriaLabel": "Segnala un bug su GitHub (si apre in una nuova finestra)",
     "askQuestionAriaLabel": "Fai una domanda su GitHub Discussions (si apre in una nuova finestra)",
     "viewOnGithubAriaLabel": "Visualizza BirdNET-Go su GitHub (si apre in una nuova finestra)",
+    "updateAvailable": "Aggiornamento disponibile: {version}",
+    "update": {
+      "title": "Aggiornamento disponibile",
+      "critical": "Questo è un aggiornamento di sicurezza critico. Aggiorna il prima possibile.",
+      "currentVersion": "Versione attuale",
+      "latestVersion": "Ultima versione",
+      "released": "Pubblicato",
+      "channel": "Canale",
+      "whatsChanged": "Novità",
+      "viewRelease": "Visualizza la versione"
+    },
     "health": "Health",
     "sections": {
       "explore": "Esplora",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -246,6 +246,17 @@
     "reportBugAriaLabel": "Ziņot par kļūdu GitHub (atveras jaunā logā)",
     "askQuestionAriaLabel": "Uzdot jautājumu GitHub Discussions (atveras jaunā logā)",
     "viewOnGithubAriaLabel": "Skatīt BirdNET-Go GitHub (atveras jaunā logā)",
+    "updateAvailable": "Pieejams atjauninājums: {version}",
+    "update": {
+      "title": "Pieejams atjauninājums",
+      "critical": "Šis ir kritisks drošības atjauninājums. Lūdzu, atjauniniet pēc iespējas ātrāk.",
+      "currentVersion": "Pašreizējā versija",
+      "latestVersion": "Jaunākā versija",
+      "released": "Izlaists",
+      "channel": "Kanāls",
+      "whatsChanged": "Kas jauns",
+      "viewRelease": "Skatīt laidienu"
+    },
     "health": "Health",
     "sections": {
       "explore": "Izpētīt",

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -246,6 +246,17 @@
     "reportBugAriaLabel": "Rapporter en feil på GitHub (åpnes i nytt vindu)",
     "askQuestionAriaLabel": "Still et spørsmål på GitHub Discussions (åpnes i nytt vindu)",
     "viewOnGithubAriaLabel": "Vis BirdNET-Go på GitHub (åpnes i nytt vindu)",
+    "updateAvailable": "Oppdatering tilgjengelig: {version}",
+    "update": {
+      "title": "Oppdatering tilgjengelig",
+      "critical": "Dette er en sikkerhetskritisk oppdatering. Oppdater så snart som mulig.",
+      "currentVersion": "Nåværende versjon",
+      "latestVersion": "Nyeste versjon",
+      "released": "Utgitt",
+      "channel": "Kanal",
+      "whatsChanged": "Hva er nytt",
+      "viewRelease": "Vis utgivelse"
+    },
     "health": "Helse",
     "sections": {
       "explore": "Utforsk",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -246,6 +246,17 @@
     "reportBugAriaLabel": "Meld een bug op GitHub (opent in nieuw venster)",
     "askQuestionAriaLabel": "Stel een vraag op GitHub Discussions (opent in nieuw venster)",
     "viewOnGithubAriaLabel": "Bekijk BirdNET-Go op GitHub (opent in nieuw venster)",
+    "updateAvailable": "Update beschikbaar: {version}",
+    "update": {
+      "title": "Update beschikbaar",
+      "critical": "Dit is een kritieke beveiligingsupdate. Werk zo snel mogelijk bij.",
+      "currentVersion": "Huidige versie",
+      "latestVersion": "Nieuwste versie",
+      "released": "Uitgebracht",
+      "channel": "Kanaal",
+      "whatsChanged": "Wat is er nieuw",
+      "viewRelease": "Release bekijken"
+    },
     "health": "Health",
     "sections": {
       "explore": "Verkennen",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -246,6 +246,17 @@
     "reportBugAriaLabel": "Zgłoś błąd na GitHubie (otwiera się w nowym oknie)",
     "askQuestionAriaLabel": "Zadaj pytanie na GitHub Discussions (otwiera się w nowym oknie)",
     "viewOnGithubAriaLabel": "Zobacz BirdNET-Go na GitHubie (otwiera się w nowym oknie)",
+    "updateAvailable": "Dostępna aktualizacja: {version}",
+    "update": {
+      "title": "Dostępna aktualizacja",
+      "critical": "To jest krytyczna aktualizacja zabezpieczeń. Zaktualizuj jak najszybciej.",
+      "currentVersion": "Bieżąca wersja",
+      "latestVersion": "Najnowsza wersja",
+      "released": "Wydano",
+      "channel": "Kanał",
+      "whatsChanged": "Co nowego",
+      "viewRelease": "Zobacz wydanie"
+    },
     "health": "Health",
     "sections": {
       "explore": "Odkryj",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -246,6 +246,17 @@
     "reportBugAriaLabel": "Reportar um erro no GitHub (abre em nova janela)",
     "askQuestionAriaLabel": "Fazer uma pergunta no GitHub Discussions (abre em nova janela)",
     "viewOnGithubAriaLabel": "Ver BirdNET-Go no GitHub (abre em nova janela)",
+    "updateAvailable": "Atualização disponível: {version}",
+    "update": {
+      "title": "Atualização disponível",
+      "critical": "Esta é uma atualização de segurança crítica. Atualize o mais rápido possível.",
+      "currentVersion": "Versão atual",
+      "latestVersion": "Versão mais recente",
+      "released": "Lançado",
+      "channel": "Canal",
+      "whatsChanged": "Novidades",
+      "viewRelease": "Ver versão"
+    },
     "health": "Health",
     "sections": {
       "explore": "Explorar",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -246,6 +246,17 @@
     "reportBugAriaLabel": "Nahlásiť chybu na GitHube (otvorí sa v novom okne)",
     "askQuestionAriaLabel": "Položiť otázku na GitHub Discussions (otvorí sa v novom okne)",
     "viewOnGithubAriaLabel": "Zobraziť BirdNET-Go na GitHube (otvorí sa v novom okne)",
+    "updateAvailable": "Dostupná aktualizácia: {version}",
+    "update": {
+      "title": "Dostupná aktualizácia",
+      "critical": "Toto je kritická bezpečnostná aktualizácia. Aktualizujte čo najskôr.",
+      "currentVersion": "Aktuálna verzia",
+      "latestVersion": "Najnovšia verzia",
+      "released": "Vydané",
+      "channel": "Kanál",
+      "whatsChanged": "Čo je nové",
+      "viewRelease": "Zobraziť vydanie"
+    },
     "health": "Health",
     "sections": {
       "explore": "Preskúmať",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -246,6 +246,17 @@
     "reportBugAriaLabel": "Rapportera en bugg på GitHub (öppnas i nytt fönster)",
     "askQuestionAriaLabel": "Ställ en fråga på GitHub Discussions (öppnas i nytt fönster)",
     "viewOnGithubAriaLabel": "Visa BirdNET-Go på GitHub (öppnas i nytt fönster)",
+    "updateAvailable": "Uppdatering tillgänglig: {version}",
+    "update": {
+      "title": "Uppdatering tillgänglig",
+      "critical": "Detta är en säkerhetskritisk uppdatering. Uppdatera så snart som möjligt.",
+      "currentVersion": "Nuvarande version",
+      "latestVersion": "Senaste version",
+      "released": "Släppt",
+      "channel": "Kanal",
+      "whatsChanged": "Vad är nytt",
+      "viewRelease": "Visa release"
+    },
     "health": "Health",
     "sections": {
       "explore": "Utforska",

--- a/internal/api/v2/routes_enumeration_test.go
+++ b/internal/api/v2/routes_enumeration_test.go
@@ -165,6 +165,7 @@ var goldenRoutes = []string{
 	"GET /api/v2/system/resources",
 	"GET /api/v2/system/restart-status",
 	"GET /api/v2/system/temperature/cpu",
+	"GET /api/v2/system/update-check",
 	"GET /api/v2/taxonomy/family/:family",
 	"GET /api/v2/taxonomy/genus/:genus",
 	"GET /api/v2/taxonomy/tree/:scientific_name",

--- a/internal/api/v2/system/handler.go
+++ b/internal/api/v2/system/handler.go
@@ -99,6 +99,7 @@ func (c *Handler) RegisterSystemRoutes(g *echo.Group) {
 	protectedGroup.GET("/restart-status", c.GetRestartStatus)
 	protectedGroup.GET("/models", c.GetActiveModels)
 	protectedGroup.GET("/inference", c.GetInferenceStatus)
+	protectedGroup.GET("/update-check", c.GetUpdateCheck)
 
 	// Events routes (detection lifecycle + operational logs).
 	c.registerEventsRoutes(protectedGroup)

--- a/internal/api/v2/system/update_check.go
+++ b/internal/api/v2/system/update_check.go
@@ -1,0 +1,198 @@
+package system
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/update/manifest"
+)
+
+// manifestURL is the stable, never-deleted manifest asset that always resolves
+// to the latest per-channel release info (see internal/update/manifest).
+const manifestURL = "https://github.com/tphakala/birdnet-go/releases/download/manifest/manifest.json"
+
+const (
+	updateCheckCacheTTL  = 1 * time.Hour
+	manifestFetchTimeout = 10 * time.Second
+	maxManifestBytes     = 1 << 20 // 1 MiB
+)
+
+// UpdateCheckResponse reports whether a newer build is available on the running
+// build's release channel. It is intentionally forgiving: when the latest
+// version cannot be determined (dev build, offline, unknown channel) it reports
+// UpdateAvailable=false so the UI simply shows no indicator.
+type UpdateCheckResponse struct {
+	CurrentVersion  string `json:"currentVersion"`
+	LatestVersion   string `json:"latestVersion,omitempty"`
+	LatestName      string `json:"latestName,omitempty"` // human-readable release title
+	ReleasedAt      string `json:"releasedAt,omitempty"` // RFC3339 publication time
+	Notes           string `json:"notes,omitempty"`      // release changelog (trimmed)
+	Channel         string `json:"channel,omitempty"`
+	UpdateAvailable bool   `json:"updateAvailable"`
+	Critical        bool   `json:"critical,omitempty"`
+	ReleaseURL      string `json:"releaseURL,omitempty"` // GitHub release page
+	IsDevBuild      bool   `json:"isDevBuild"`
+	// Unavailable is true when the check could not reach a verdict (offline /
+	// no channel data). The UI should treat this the same as "up to date".
+	Unavailable bool   `json:"unavailable,omitempty"`
+	CheckedAt   string `json:"checkedAt,omitempty"`
+}
+
+// computeUpdateStatus is the pure decision core: given the running version and a
+// parsed manifest, it fills in the channel comparison. It performs no I/O so it
+// is directly unit-testable. A nil manifest marks the result Unavailable.
+func computeUpdateStatus(current, buildDate string, m *manifest.Manifest) UpdateCheckResponse {
+	resp := UpdateCheckResponse{CurrentVersion: current}
+
+	channel, ok := manifest.ClassifyTag(current)
+	if !ok {
+		// Empty, "Development Build", or a locally-built binary: no channel to
+		// compare against.
+		resp.IsDevBuild = true
+		return resp
+	}
+	resp.Channel = channel
+
+	if m == nil {
+		resp.Unavailable = true
+		return resp
+	}
+	ch := m.Channels[channel]
+	if ch == nil || ch.Version == "" {
+		resp.Unavailable = true
+		return resp
+	}
+
+	resp.LatestVersion = ch.Version
+	resp.LatestName = ch.Name
+	resp.Notes = ch.Notes
+	resp.ReleaseURL = ch.ReleaseURL
+	if !ch.ReleasedAt.IsZero() {
+		resp.ReleasedAt = ch.ReleasedAt.Format(time.RFC3339)
+	}
+	resp.UpdateAvailable = isNewerRelease(current, buildDate, ch)
+	resp.Critical = ch.Critical && resp.UpdateAvailable
+	return resp
+}
+
+// isNewerRelease reports whether the channel's latest release is newer than the
+// running build. Version strings span multiple formats (semver stable tags,
+// date-based nightlies), so rather than parse versions it compares the build
+// date against the release date: a build produced at or after the latest release
+// cannot be behind it, which avoids a false "update available" when the running
+// build is ahead of a stale manifest. When either timestamp is missing it falls
+// back to a plain version mismatch so a genuine update is never hidden.
+func isNewerRelease(current, buildDate string, ch *manifest.Channel) bool {
+	if ch.Version == current {
+		return false
+	}
+	built, err := time.Parse(time.RFC3339, buildDate)
+	if err != nil || ch.ReleasedAt.IsZero() {
+		return true
+	}
+	return built.Before(ch.ReleasedAt)
+}
+
+// manifestCache memoizes the parsed manifest so the endpoint does not hit GitHub
+// on every request, and can serve a stale copy while offline.
+type manifestCache struct {
+	mu        sync.Mutex
+	manifest  *manifest.Manifest
+	fetchedAt time.Time
+}
+
+var sharedManifestCache manifestCache
+
+// get returns a cached manifest when fresh, otherwise fetches a new one. On
+// fetch failure it falls back to any previously cached manifest, and only
+// returns an error when there is nothing to serve.
+func (c *manifestCache) get(ctx context.Context) (*manifest.Manifest, error) {
+	// Snapshot the cache under the lock, then release it before any network I/O
+	// so a slow fetch never blocks other requests. A rare concurrent double-fetch
+	// is harmless for a small, idempotent manifest.
+	c.mu.Lock()
+	cached := c.manifest
+	fresh := cached != nil && time.Since(c.fetchedAt) < updateCheckCacheTTL
+	c.mu.Unlock()
+
+	if fresh {
+		return cached, nil
+	}
+
+	m, err := fetchManifest(ctx)
+	if err != nil {
+		if cached != nil {
+			return cached, nil // serve stale rather than fail
+		}
+		return nil, err
+	}
+
+	c.mu.Lock()
+	c.manifest = m
+	c.fetchedAt = time.Now()
+	c.mu.Unlock()
+	return m, nil
+}
+
+func fetchManifest(ctx context.Context) (*manifest.Manifest, error) {
+	ctx, cancel := context.WithTimeout(ctx, manifestFetchTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, manifestURL, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("build manifest request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch manifest: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch manifest: unexpected status %d", resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxManifestBytes))
+	if err != nil {
+		return nil, fmt.Errorf("read manifest body: %w", err)
+	}
+
+	return manifest.Parse(data)
+}
+
+// GetUpdateCheck reports whether a newer build is available for the running
+// build's channel. It never fails the request on network errors; those surface
+// as Unavailable=true so the UI degrades to "up to date".
+func (c *Handler) GetUpdateCheck(ctx echo.Context) error {
+	current, buildDate := "", ""
+	if s := c.CurrentSettings(); s != nil {
+		current = s.Version
+		buildDate = s.BuildDate
+	}
+
+	// Only reach out to the network when the running build maps to a channel;
+	// dev or unclassifiable builds skip the fetch entirely.
+	var m *manifest.Manifest
+	if _, ok := manifest.ClassifyTag(current); ok {
+		// Populate the shared cache with a detached context so an abandoned
+		// request (client disconnect or navigation) cannot cancel the fetch and
+		// leave the cache empty for the next caller. fetchManifest applies its
+		// own timeout.
+		fetched, err := sharedManifestCache.get(context.Background())
+		if err != nil {
+			c.Debug("update-check: manifest unavailable: %v", err)
+		} else {
+			m = fetched
+		}
+	}
+
+	resp := computeUpdateStatus(current, buildDate, m)
+	resp.CheckedAt = time.Now().Format(time.RFC3339)
+	return ctx.JSON(http.StatusOK, resp)
+}

--- a/internal/api/v2/system/update_check_test.go
+++ b/internal/api/v2/system/update_check_test.go
@@ -1,0 +1,81 @@
+package system
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/update/manifest"
+)
+
+func TestComputeUpdateStatus(t *testing.T) {
+	t.Parallel()
+
+	const (
+		buildBeforeRelease = "2026-06-15T00:00:00Z"
+		buildAfterRelease  = "2026-07-05T00:00:00Z"
+	)
+	m := &manifest.Manifest{
+		Channels: map[string]*manifest.Channel{
+			manifest.ChannelStable: {
+				Version:    "v0.7.0",
+				ReleaseURL: "https://example.test/v0.7.0",
+				ReleasedAt: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+				Critical:   true,
+			},
+		},
+	}
+
+	t.Run("unclassifiable version is treated as a dev build", func(t *testing.T) {
+		t.Parallel()
+		got := computeUpdateStatus("Development Build", "", m)
+		assert.True(t, got.IsDevBuild)
+		assert.False(t, got.UpdateAvailable)
+	})
+
+	t.Run("nil manifest is unavailable but still resolves the channel", func(t *testing.T) {
+		t.Parallel()
+		got := computeUpdateStatus("v0.6.4", buildBeforeRelease, nil)
+		assert.Equal(t, manifest.ChannelStable, got.Channel)
+		assert.True(t, got.Unavailable)
+		assert.False(t, got.UpdateAvailable)
+	})
+
+	t.Run("a build older than the release is flagged available", func(t *testing.T) {
+		t.Parallel()
+		got := computeUpdateStatus("v0.6.4", buildBeforeRelease, m)
+		assert.True(t, got.UpdateAvailable)
+		assert.Equal(t, "v0.7.0", got.LatestVersion)
+		assert.Equal(t, "https://example.test/v0.7.0", got.ReleaseURL)
+		assert.True(t, got.Critical)
+	})
+
+	t.Run("a build newer than the release reports no update", func(t *testing.T) {
+		t.Parallel()
+		got := computeUpdateStatus("v0.6.4", buildAfterRelease, m)
+		assert.False(t, got.UpdateAvailable)
+		assert.False(t, got.Critical)
+	})
+
+	t.Run("a missing build date falls back to a version mismatch", func(t *testing.T) {
+		t.Parallel()
+		got := computeUpdateStatus("v0.6.4", "", m)
+		assert.True(t, got.UpdateAvailable)
+	})
+
+	t.Run("running the latest reports no update", func(t *testing.T) {
+		t.Parallel()
+		got := computeUpdateStatus("v0.7.0", buildAfterRelease, m)
+		assert.False(t, got.UpdateAvailable)
+		assert.False(t, got.Critical)
+		assert.Equal(t, "v0.7.0", got.LatestVersion)
+	})
+
+	t.Run("channel absent from manifest is unavailable", func(t *testing.T) {
+		t.Parallel()
+		got := computeUpdateStatus("nightly-20260101", "", m)
+		assert.Equal(t, manifest.ChannelNightly, got.Channel)
+		assert.True(t, got.Unavailable)
+		assert.False(t, got.UpdateAvailable)
+	})
+}


### PR DESCRIPTION
## Summary

The version string in the sidebar now tells you when a newer build is available. It compares the running build's channel against the release manifest, and when there is a newer build it shows the version in italics with an asterisk. Clicking it opens a "what's changed" window with the latest version, release date, changelog, and a link to the release page. Releases flagged security-critical in the manifest get a highlighted warning.

This builds on the existing `internal/update/manifest` infrastructure (the `manifest.json` on the "manifest" release), which the schema comments describe as intended for exactly this kind of in-app update checker.

Closes #3627

## Changes

- `GET /api/v2/system/update-check`: resolves the running build's channel, fetches and caches the manifest, and reports whether a newer build exists (plus the release notes, date, and URL). It degrades quietly, so dev builds and offline instances just show no indicator instead of an error.
- Sidebar version indicator: italic plus an asterisk when an update is out; muted otherwise. It opens the modal on click.
- `UpdateAvailableModal`: the "what's changed" window, with a red banner for security-critical releases.

## Testing

- [x] `go test -race ./internal/api/v2/system/...`
- [x] `golangci-lint run --build-tags=noembed,skipfrontend ./internal/api/v2/system/...` (0 issues)
- [x] `npm run check:all` and the `UpdateAvailableModal` unit test
- [x] Manual: up-to-date, update-available, and critical states, plus the offline and dev-build fallbacks

## Open question

The endpoint sits on the authenticated route group. The version string it annotates is visible to everyone, so a guest or public-mode viewer would see the version but not the update indicator. I can move it to the public group if you would rather the indicator show without auth.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-app update check that notifies users when a newer build is available.
  * Sidebar version indicator now opens a “What’s changed” modal and provides a “view release” link when available.
  * Added localized update notification/modal text across multiple languages.
* **Bug Fixes**
  * Prevents incorrect display when the release date is missing or invalid.
  * Clearly highlights security-critical updates with a prominent alert.
* **Tests**
  * Added UI tests for the update modal (including critical updates) and backend update-check logic coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->