### PR TITLE
perf(datastore): label-first lookup in GetSpeciesLastDetectionDateBefore

### DIFF
--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -2956,18 +2956,30 @@ func (ds *Datastore) GetSpeciesLastDetectionDateBefore(ctx context.Context, scie
 	// Escape LIKE metacharacters with '!' (see scientificNameLikeEscaper).
 	escapedScientificName := scientificNameLikeEscaper.Replace(scientificName)
 	prefix := ds.manager.TablePrefix()
+
+	// Resolve the species to its label id(s) in a subquery so the planner drives
+	// off the (label_id, detected_at) index. Joining labels and filtering
+	// scientific_name inline instead makes SQLite drive off the near-unbounded
+	// "detected_at < before" range, scanning almost the entire detections table
+	// for a single, highly selective species — this function is called once per
+	// species during novelty-episode restore, so that plan is O(species * rows).
+	//
+	// Match the bare scientific name exactly, or a legacy concatenated label
+	// stored as "ScientificName_CommonName". The "!_%" suffix is "literal
+	// underscore separator, then anything" ('!_' is an escaped underscore,
+	// '%' is the wildcard), mirroring how such labels are split on the first
+	// underscore (see detection.ExtractScientificName).
+	labelIDs := ds.manager.DB().WithContext(ctx).
+		Table(prefix+"labels").
+		Select("id").
+		Where("scientific_name = ? OR scientific_name LIKE ? ESCAPE '!'", scientificName, escapedScientificName+`!_%`)
+
 	query := ds.manager.DB().WithContext(ctx).
 		Table(prefix+"detections d").
 		Select(fmt.Sprintf("COALESCE(MAX(%s), '') as last_seen_date", dateExpr)).
-		Joins(fmt.Sprintf("JOIN %slabels l ON d.label_id = l.id", prefix)).
 		Joins(fmt.Sprintf("LEFT JOIN %sdetection_reviews dr ON d.id = dr.detection_id", prefix)).
 		Where("d.detected_at < ?", before.Unix()).
-		// Match the bare scientific name exactly, or a legacy concatenated label
-		// stored as "ScientificName_CommonName". The "!_%" suffix is "literal
-		// underscore separator, then anything" ('!_' is an escaped underscore,
-		// '%' is the wildcard), mirroring how such labels are split on the first
-		// underscore (see detection.ExtractScientificName).
-		Where("(l.scientific_name = ? OR l.scientific_name LIKE ? ESCAPE '!')", scientificName, escapedScientificName+`!_%`).
+		Where("d.label_id IN (?)", labelIDs).
 		Where("(dr.verified IS NULL OR dr.verified != ?)", string(entities.VerificationFalsePositive))
 
 	if err := query.Scan(&result).Error; err != nil {


### PR DESCRIPTION
## Summary
`GetSpeciesLastDetectionDateBefore` does a full-table scan per species when Species/Yearly/Seasonal tracking is enabled. On large SQLite databases this produces a `slow query` storm.

## Root cause
The query joins `labels` and filters a single `scientific_name`, but also filters `detected_at < <now>`. SQLite drives off the `detected_at` range index (~95% of the table) instead of resolving the highly selective species to a `label_id` and using the `(label_id, detected_at)` index. The novelty-episode restore path calls this once per species, so the cost is O(species x full-table scan).

## Fix
Resolve `scientific_name` (including the legacy `Name_Common` LIKE form) to `label_id`(s) in a subquery, then filter `detections` by `label_id IN (...)`. The planner then uses the `(label_id, detected_at)` covering index. Behaviour and LIKE/ESCAPE semantics are unchanged.

## Measurements (1.7M-row DB)
- Rows matching `detected_at < now`: ~95% of the table
- Rows for a typical single species: a few hundred
- Before: ~1.4s per call (trips the 1s slow-query threshold)
- After: ~0.002s, identical result; `EXPLAIN QUERY PLAN` switches to a covering-index lookup

## Testing
- `go test ./internal/datastore/v2only/ ./internal/analysis/species/` passes (incl. LIKE/ESCAPE edge cases and novelty tests)
- Verified on a real 1.7M-row database: identical result, ~200x faster

## Related Issues
Fixes #3840

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy when determining the last detection date for a species.
  * Preserved filtering for detections recorded before a specified date and excluded false-positive reviews.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->