### PR TITLE
fix(spectrogram): swap FFmpeg fallback color modes so default style renders colorful

### DIFF
--- a/internal/spectrogram/generator.go
+++ b/internal/spectrogram/generator.go
@@ -125,13 +125,17 @@ func fftFriendlyHeight(width int) int {
 // FFmpeg showspectrumpic color mode constants for style mapping.
 // These are the closest FFmpeg equivalents to the Sox style presets.
 const (
-	// ffmpegColorDefault is FFmpeg's default colorful spectrogram (channel mode).
-	// Matches Sox default style (colorful with dark background).
-	ffmpegColorDefault = "channel"
+	// ffmpegColorDefault is FFmpeg's colorful heat map ("intensity", the
+	// showspectrumpic default). Matches Sox default style (colorful with
+	// dark background). Not "channel": that mode assigns one color per
+	// audio channel, which renders mono clips in a single hue, i.e.
+	// black and white (issue #3835).
+	ffmpegColorDefault = "intensity"
 
-	// ffmpegColorIntensity produces a grayscale spectrogram in FFmpeg.
-	// Matches Sox monochrome mode (-m) used by scientific styles.
-	ffmpegColorIntensity = "intensity"
+	// ffmpegColorGrayscale produces a grayscale spectrogram for mono audio
+	// ("channel" assigns one color per audio channel). Closest FFmpeg
+	// equivalent to Sox monochrome mode (-m) used by scientific styles.
+	ffmpegColorGrayscale = "channel"
 
 	// ffmpegColorFire produces a high-saturation warm-toned spectrogram in FFmpeg.
 	// Matches Sox high-contrast mode (-h) used by high_contrast_dark style.
@@ -165,13 +169,13 @@ func getFFmpegColorMode(style string) string {
 	switch style {
 	case conf.SpectrogramStyleScientificDark:
 		// Grayscale - closest FFmpeg equivalent to Sox -m (monochrome)
-		return ffmpegColorIntensity
+		return ffmpegColorGrayscale
 	case conf.SpectrogramStyleHighContrastDark:
 		// High saturation - closest FFmpeg equivalent to Sox -h (high color)
 		return ffmpegColorFire
 	case conf.SpectrogramStyleScientific:
 		// Grayscale - closest FFmpeg equivalent to Sox -m -l (monochrome, light)
-		return ffmpegColorIntensity
+		return ffmpegColorGrayscale
 	default:
 		// Default colorful style
 		return ffmpegColorDefault

--- a/internal/spectrogram/generator_test.go
+++ b/internal/spectrogram/generator_test.go
@@ -2,7 +2,6 @@ package spectrogram
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -1209,6 +1208,11 @@ func TestGetStyleArgs(t *testing.T) {
 // TestGetFFmpegColorMode tests that FFmpeg color modes match the expected
 // values for each style preset, ensuring the FFmpeg fallback produces
 // visually consistent spectrograms with the Sox primary path.
+// Expectations are literal strings on purpose: asserting against the
+// ffmpegColor* constants would still pass with swapped values (issue #3835).
+// In FFmpeg's showspectrumpic filter "intensity" is the colorful heat map
+// (the filter's own default), while "channel" colors per audio channel and
+// renders mono clips in a single hue, i.e. black and white.
 func TestGetFFmpegColorMode(t *testing.T) {
 	t.Parallel()
 
@@ -1218,34 +1222,34 @@ func TestGetFFmpegColorMode(t *testing.T) {
 		wantColor string
 	}{
 		{
-			name:      "default style uses channel color mode",
+			name:      "default style uses intensity (colorful heat map)",
 			style:     conf.SpectrogramStyleDefault,
-			wantColor: ffmpegColorDefault,
+			wantColor: "intensity",
 		},
 		{
-			name:      "scientific dark uses intensity (grayscale)",
+			name:      "scientific dark uses channel (grayscale for mono)",
 			style:     conf.SpectrogramStyleScientificDark,
-			wantColor: ffmpegColorIntensity,
+			wantColor: "channel",
 		},
 		{
 			name:      "high contrast dark uses fire (high saturation)",
 			style:     conf.SpectrogramStyleHighContrastDark,
-			wantColor: ffmpegColorFire,
+			wantColor: "fire",
 		},
 		{
-			name:      "scientific uses intensity (grayscale)",
+			name:      "scientific uses channel (grayscale for mono)",
 			style:     conf.SpectrogramStyleScientific,
-			wantColor: ffmpegColorIntensity,
+			wantColor: "channel",
 		},
 		{
-			name:      "unknown style falls back to channel default",
+			name:      "unknown style falls back to colorful default",
 			style:     "nonexistent_style",
-			wantColor: ffmpegColorDefault,
+			wantColor: "intensity",
 		},
 		{
-			name:      "empty style falls back to channel default",
+			name:      "empty style falls back to colorful default",
 			style:     "",
-			wantColor: ffmpegColorDefault,
+			wantColor: "intensity",
 		},
 	}
 
@@ -1272,24 +1276,24 @@ func TestFFmpegFallback_AppliesStyleSetting(t *testing.T) {
 		expectInColor string // substring expected in the FFmpeg filter
 	}{
 		{
-			name:          "default style includes channel color",
+			name:          "default style includes intensity color",
 			style:         conf.SpectrogramStyleDefault,
-			expectInColor: "color=" + ffmpegColorDefault,
+			expectInColor: "color=intensity",
 		},
 		{
-			name:          "scientific dark includes intensity color",
+			name:          "scientific dark includes channel color",
 			style:         conf.SpectrogramStyleScientificDark,
-			expectInColor: "color=" + ffmpegColorIntensity,
+			expectInColor: "color=channel",
 		},
 		{
 			name:          "high contrast dark includes fire color",
 			style:         conf.SpectrogramStyleHighContrastDark,
-			expectInColor: "color=" + ffmpegColorFire,
+			expectInColor: "color=fire",
 		},
 		{
-			name:          "scientific includes intensity color",
+			name:          "scientific includes channel color",
 			style:         conf.SpectrogramStyleScientific,
-			expectInColor: "color=" + ffmpegColorIntensity,
+			expectInColor: "color=channel",
 		},
 	}
 
@@ -1297,11 +1301,7 @@ func TestFFmpegFallback_AppliesStyleSetting(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Build the same filter string that generateWithFFmpeg constructs,
-			// verifying the style-aware color parameter is integrated correctly.
-			colorMode := getFFmpegColorMode(tt.style)
-			filterStr := fmt.Sprintf("showspectrumpic=s=%dx%d:legend=%d:gain=%s:drange=%s:color=%s",
-				400, fftFriendlyHeight(400), 1, ffmpegGain, ffmpegDrange, colorMode)
+			filterStr := buildFFmpegSpectrogramFilter(400, false, tt.style, FrequencyProfile{})
 			assert.Contains(t, filterStr, tt.expectInColor,
 				"FFmpeg filter string should include style-aware color mode")
 		})


### PR DESCRIPTION
Fixes #3835

When clip generation falls back to FFmpeg (the reporter's case: MP3 clips on the native Windows build, where the bundled SoX can't decode MP3), the default spectrogram style renders black and white instead of the colorful style — and, less visibly, the scientific styles render *colorful* through the same fallback.

## Root cause

The FFmpeg color mode constants in `internal/spectrogram/generator.go` had `showspectrumpic` semantics backwards. `ffmpegColorDefault` was `"channel"` with a comment calling it "FFmpeg's default colorful spectrogram", and scientific styles mapped to `"intensity"` commented as grayscale. It's the other way around: `intensity` is the colorful heat map (and the filter's own default), while `channel` assigns one color per *audio channel* — and since the capture pipeline is mono (`conf.NumChannels = 1`), that renders every clip in a single hue, i.e. black and white.

Easy to reproduce with just ffmpeg:

```
ffmpeg -f lavfi -i "sine=frequency=440:duration=3" -lavfi "showspectrumpic=s=400x200:color=channel" ch.png
ffmpeg -f lavfi -i "sine=frequency=440:duration=3" -lavfi "showspectrumpic=s=400x200:color=intensity" int.png
```

Measuring saturation of the outputs (`ffprobe -f lavfi "movie=X.png,signalstats" -show_entries frame_tags=lavfi.signalstats.SATAVG`): `color=channel` → SATAVG 0.04 (black and white), `color=intensity` → SATAVG 4.84 (colorful). `ffmpeg -h filter=showspectrumpic` confirms the same: default is `intensity`, `channel` is "separate color for each channel".

## The fix

- Swap the mapping: default style → `intensity`, scientific styles → `channel`.
- Rename `ffmpegColorIntensity` → `ffmpegColorGrayscale` so the name matches what it actually produces, and fix the backwards comments.
- Pin **literal** color values in `TestGetFFmpegColorMode` — the old test compared against the constants themselves, so it would happily pass with swapped values. The literal expectations fail on the old code.
- While in that test file: `TestFFmpegFallback_AppliesStyleSetting` was rebuilding the filter string with its own `fmt.Sprintf` copy, so it couldn't catch regressions in the real construction. It now calls `buildFFmpegSpectrogramFilter` directly.

Sox path is untouched, so anyone whose spectrograms already render correctly sees no change.

## One caveat worth knowing

Spectrogram PNGs are cached by filename, and the filename doesn't encode the color mode — so clips that were already rendered black-and-white through the fallback will keep their old image until the cached PNG is deleted. Only newly generated spectrograms pick up the fix. Didn't want to grow this PR with cache-busting; happy to look at that separately if you think it's worth it.

## Testing

- `go test -race ./internal/spectrogram/` — pass
- `golangci-lint run -v` — 0 issues
- Empirical FFmpeg verification as above (ffmpeg 8.x)

## Preflight Status

- [x] Single concern: one fix (FFmpeg fallback color mapping)
- [x] Preflight passed: all findings resolved (test tautology fixed, filter-string duplication removed) or documented (stale-cache caveat above)
- [x] Linters clean: `golangci-lint run -v` zero issues (one pre-existing local-only `frontend/embed.go` typecheck from missing `dist/`, not related)
- [x] Tests pass: `go test -race ./internal/spectrogram/`
- [x] No unrelated changes
- [x] Scope complete
- [x] No regression/backward-compat break: Sox path unchanged; FFmpeg fallback output changes only to match what the styles already promise (cache caveat documented above)
- [x] Breaking changes documented: n/a
- [x] i18n complete: no user-facing strings changed
- [x] No secrets or PII


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected spectrogram color modes to better match Sox style presets.
  * Updated Scientific and Scientific Dark styles to use grayscale rendering.
  * Preserved the expected fire-style rendering for High Contrast Dark.
  * Improved validation of color settings applied to generated spectrograms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->