### PR TITLE
chore(frontend): update low-risk major dev dependencies (@ast-grep/cli 0.44, @types/node 26)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,7 +23,7 @@
         "svelte-dnd-action": "^0.9.70"
       },
       "devDependencies": {
-        "@ast-grep/cli": "^0.43.0",
+        "@ast-grep/cli": "^0.44.1",
         "@axe-core/playwright": "^4.11.3",
         "@eslint/js": "^10.0.1",
         "@formatjs/icu-messageformat-parser": "^3.5.11",
@@ -34,7 +34,7 @@
         "@testing-library/svelte": "^5.4.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/d3": "^7.4.3",
-        "@types/node": "^25.9.4",
+        "@types/node": "^26.1.1",
         "@typescript-eslint/eslint-plugin": "^8.62.0",
         "@typescript-eslint/parser": "^8.62.0",
         "@vitest/browser": "^4.1.9",
@@ -127,9 +127,9 @@
       "license": "MIT"
     },
     "node_modules/@ast-grep/cli": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@ast-grep/cli/-/cli-0.43.0.tgz",
-      "integrity": "sha512-DGi6xXAOBJubGg9QWqTeW8PzKSGHWEOa3uxXspEfYf532yb3lHmNJAcKMl1d+O9Xs9bTcNeDLC8se+O+tirEFQ==",
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli/-/cli-0.44.1.tgz",
+      "integrity": "sha512-wSjtu0/9xSYzzo/EW31w5pf1qB33tejYKmKXb2nBAlZ5PpYtOqwFmk9H1nywhjzO913beugsKAZYxrwciqW9AQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -144,19 +144,19 @@
         "node": ">= 12.0.0"
       },
       "optionalDependencies": {
-        "@ast-grep/cli-darwin-arm64": "0.43.0",
-        "@ast-grep/cli-darwin-x64": "0.43.0",
-        "@ast-grep/cli-linux-arm64-gnu": "0.43.0",
-        "@ast-grep/cli-linux-x64-gnu": "0.43.0",
-        "@ast-grep/cli-win32-arm64-msvc": "0.43.0",
-        "@ast-grep/cli-win32-ia32-msvc": "0.43.0",
-        "@ast-grep/cli-win32-x64-msvc": "0.43.0"
+        "@ast-grep/cli-darwin-arm64": "0.44.1",
+        "@ast-grep/cli-darwin-x64": "0.44.1",
+        "@ast-grep/cli-linux-arm64-gnu": "0.44.1",
+        "@ast-grep/cli-linux-x64-gnu": "0.44.1",
+        "@ast-grep/cli-win32-arm64-msvc": "0.44.1",
+        "@ast-grep/cli-win32-ia32-msvc": "0.44.1",
+        "@ast-grep/cli-win32-x64-msvc": "0.44.1"
       }
     },
     "node_modules/@ast-grep/cli-darwin-arm64": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@ast-grep/cli-darwin-arm64/-/cli-darwin-arm64-0.43.0.tgz",
-      "integrity": "sha512-0i63gSBbgriPaRpFsbP3yETxolHPK2JAZbpcGbFOytB7QTnKAguwhlKmIOkUGKfsCzYiEq1awY0EBmvjMONXOg==",
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-darwin-arm64/-/cli-darwin-arm64-0.44.1.tgz",
+      "integrity": "sha512-wOzb+IqFy4Pdhvs+PeaHdQJ1VemsI1SgoOGJf+x0J0KBSJ+s/hUg2n1fVJwfsrw/XDIbz9m7PGKTGCLxsgYa1g==",
       "cpu": [
         "arm64"
       ],
@@ -171,9 +171,9 @@
       }
     },
     "node_modules/@ast-grep/cli-darwin-x64": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@ast-grep/cli-darwin-x64/-/cli-darwin-x64-0.43.0.tgz",
-      "integrity": "sha512-SPkj00HGKpYdqReUmso2ftG5Xgd+bWNFH4i9fubLxsWzn4ey2G6sotPruaOtcrzxb9xH+8kmhN7KJfm1k8Atzg==",
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-darwin-x64/-/cli-darwin-x64-0.44.1.tgz",
+      "integrity": "sha512-X3OzzsnO9Q3ISQ4qO3jasWk8EZhJA03xfmJHhuS9rGJZZCbNEuqjicrwrDMKK8EgEGJ7MG4oL0BE5qUcn3twLw==",
       "cpu": [
         "x64"
       ],
@@ -188,9 +188,9 @@
       }
     },
     "node_modules/@ast-grep/cli-linux-arm64-gnu": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@ast-grep/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-0.43.0.tgz",
-      "integrity": "sha512-U8+2fkcY8sBxNHHBYZ33vTa7C97GFAB+Kj6gFzVMSqK8Ve1Aw+DxhVWD4i/PBryDdmWb4/erjGSkTQtdhVa2vg==",
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-0.44.1.tgz",
+      "integrity": "sha512-2F1YBRd9tQnfrGX+4BlkfXWLb2jqNgTmjp0ETLNRLMmSDinR905QsZn2A55qcAZxhQDU982mEzzgT4NduPXIGg==",
       "cpu": [
         "arm64"
       ],
@@ -208,9 +208,9 @@
       }
     },
     "node_modules/@ast-grep/cli-linux-x64-gnu": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@ast-grep/cli-linux-x64-gnu/-/cli-linux-x64-gnu-0.43.0.tgz",
-      "integrity": "sha512-r/o9Mag6OZmGevY9OJjatuUKDOX1rSvgo29qSfxpMbIciiH3hkzEW/2w1xTPZI8xnM7iC+k+CkGoknmoXVTYGg==",
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-linux-x64-gnu/-/cli-linux-x64-gnu-0.44.1.tgz",
+      "integrity": "sha512-d5UNoDLT2i6xV4GGqcPnrAR6CB3H078+v3BiqjKxZdZMHFnDe46+i+DxfH1IK6yvJqViqv2F611+wiAAn/s7qw==",
       "cpu": [
         "x64"
       ],
@@ -228,9 +228,9 @@
       }
     },
     "node_modules/@ast-grep/cli-win32-arm64-msvc": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-0.43.0.tgz",
-      "integrity": "sha512-oHa4ruD87xccnqFuR+Pmx6F/suHV0YtibuyZ6SxUqgpNJAFZiUNAiFblzhEgQ5gp03e8B012P/Yy/7GYOvxOLg==",
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-0.44.1.tgz",
+      "integrity": "sha512-r6K49Z14BLOeJdBSmaoK+TdgtPRqJfJ562F0n0KvRi0qH3o8is8N2dXtEMYKynYm/tdOd65i69Mc1WKSuIeWyA==",
       "cpu": [
         "arm64"
       ],
@@ -245,9 +245,9 @@
       }
     },
     "node_modules/@ast-grep/cli-win32-ia32-msvc": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-0.43.0.tgz",
-      "integrity": "sha512-RSzz9bKzSEutWgX7/g84guudEp75Q990CYpG/TBasdJP+U27zX8aA9d5p1+o/lF0hw3UoTYuFCGG8PU/QelfNQ==",
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-0.44.1.tgz",
+      "integrity": "sha512-AusXTP5SfUQEL/EkF0fhHoA4H30M7hsVgvsVEZ7PeZrxB69trzUcqKnHC8pBDYTmgIsJsr9dtXjTPDcBauaPiA==",
       "cpu": [
         "ia32"
       ],
@@ -262,9 +262,9 @@
       }
     },
     "node_modules/@ast-grep/cli-win32-x64-msvc": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-x64-msvc/-/cli-win32-x64-msvc-0.43.0.tgz",
-      "integrity": "sha512-/5dDD9B65vVuHCdVHN5+tIDquhE5s43S5CgEn88w1BgQaoayf+nRnUO4ZFez6SqyCGqAfa/yZdoaOQ9N2ySa1w==",
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-x64-msvc/-/cli-win32-x64-msvc-0.44.1.tgz",
+      "integrity": "sha512-gDMHT17Edmp/tXTDdMSQHd9vJki2Y2WSXq9ycrvjziHwpmnsnc6xlCQ7SEOGA1987vepSpkOkqBCPliP2TVW0w==",
       "cpu": [
         "x64"
       ],
@@ -2477,13 +2477,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
-      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/trusted-types": {
@@ -8887,9 +8887,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -84,7 +84,7 @@
     ]
   },
   "devDependencies": {
-    "@ast-grep/cli": "^0.43.0",
+    "@ast-grep/cli": "^0.44.1",
     "@axe-core/playwright": "^4.11.3",
     "@eslint/js": "^10.0.1",
     "@formatjs/icu-messageformat-parser": "^3.5.11",
@@ -95,7 +95,7 @@
     "@testing-library/svelte": "^5.4.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/d3": "^7.4.3",
-    "@types/node": "^25.9.4",
+    "@types/node": "^26.1.1",
     "@typescript-eslint/eslint-plugin": "^8.62.0",
     "@typescript-eslint/parser": "^8.62.0",
     "@vitest/browser": "^4.1.9",


### PR DESCRIPTION
## Summary

Follow-up to the frontend minor/patch pass (#3850). Bumps the two major dev-dependency updates that are **drop-in** (no source changes required), each validated individually against the full frontend gate.

## Changes

- `@ast-grep/cli` `^0.43.0` -> `^0.44.1` - dev lint tooling only. All four `ast:*` rule scans (`ast:security`, `ast:svelte5`, `ast:migration`, `ast:best-practices`) still pass unchanged.
- `@types/node` `^25.9.4` -> `^26.1.1` - types only. `svelte-check` reports 0 errors, and it aligns the type defs with the Node 26 runtime the project builds on.

`npm audit`: 0 vulnerabilities.

## Explicitly deferred

- `vitest-browser-svelte` 3.0.0 is **not** included. v3 makes `render()` async (returns `Promise<RenderResult>`), so `.rerender()` / `.unmount()` call sites must `await render(...)` first (it breaks `svelte-check` in `src/test/browser/duplicate-keys.browser.test.ts` today). That is a code migration, not a drop-in bump, so it needs its own PR.
- `typescript` 7 (native rewrite, gated on svelte-check / typescript-eslint support) and `vite` 8.1.x (exact-pinned at 8.0.16 for the rolldown/date-fns CI/Docker regression) remain held.

## Test Plan

- [x] `npm audit` - 0 vulnerabilities
- [x] `npm run check:all` - prettier, eslint, stylelint, svelte-check (0 errors), and all four ast-grep 0.44 scans clean
- [x] `npm run test:ci` - 2592 tests pass (173 files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling packages to newer versions.
  * Updated Node.js type definitions for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->