### PR TITLE
chore(go): require Go 1.26.5 toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tphakala/birdnet-go
 
-go 1.26.1
+go 1.26.5
 
 require (
 	github.com/UserExistsError/conpty v0.1.4


### PR DESCRIPTION
## Summary

Move the project to Go 1.26.5. Bumps the `go` directive in `go.mod` from 1.26.1 to 1.26.5.

`go.mod` is the single source of truth for the Go version:
- The Taskfile derives `GO_VERSION` from the `go` directive (`awk '/^go /'`), so the local dev-install helper now targets 1.26.5.
- Every CI workflow uses `actions/setup-go@v6` with `go-version-file: go.mod`, so all CI jobs build with 1.26.5.
- The Dockerfile builder uses the floating `golang:1.26-trixie` tag, which already resolves to the latest 1.26.x, so it needs no change.

One line changes; everything else follows from it.

## Why

Go 1.26.5 carries fixes for 5 standard-library security issues (crypto/tls, crypto/x509, net/textproto, mime, os) over 1.26.1. The `go` directive was lagging behind the available patch release.

## Test Plan

All run locally under go1.26.5 (fetched via `GOTOOLCHAIN=auto`):

- [x] `go mod tidy` - no module-graph changes (only the `go` line)
- [x] `go build ./...` - clean
- [x] `go vet ./...` - clean
- [x] `golangci-lint run` - 0 issues
- [x] `go test ./...` - all packages pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the required Go toolchain version to 1.26.5 for improved build and development consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->