### PR TITLE
test(browser): migrate to vitest-browser-svelte v3 (async render)

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -37,5 +37,7 @@ vite.config.*.ts
 .env.test.local
 .env.production.local
 
-# Vitest browser mode screenshots
+# Vitest browser mode screenshots and attachments (generated on test failures)
 src/test/__screenshots__/
+src/test/browser/__screenshots__/
+.vitest-attachments/

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -65,7 +65,7 @@
         "vite": "8.0.16",
         "vite-bundle-analyzer": "^1.3.8",
         "vitest": "^4.1.9",
-        "vitest-browser-svelte": "^2.1.1"
+        "vitest-browser-svelte": "^3.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -9137,9 +9137,9 @@
       }
     },
     "node_modules/vitest-browser-svelte": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/vitest-browser-svelte/-/vitest-browser-svelte-2.2.1.tgz",
-      "integrity": "sha512-dVjmXuk58eLSloA41Lvz5ALMqWVzK7Gk5TvY5KWFbI8VoEO1nJF1/M498NwJRbxlnjaEZrASd02h+NDS/T9mBA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vitest-browser-svelte/-/vitest-browser-svelte-3.0.0.tgz",
+      "integrity": "sha512-BKM9iBGNsEQzigWuSZFAiw6AJDqQqMttApoD8gM8LTI6vxfd423rDMN8GqUHJyGbhH3XcOo9N9u/4hu47Nxhsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -126,7 +126,7 @@
     "vite": "8.0.16",
     "vite-bundle-analyzer": "^1.3.8",
     "vitest": "^4.1.9",
-    "vitest-browser-svelte": "^2.1.1"
+    "vitest-browser-svelte": "^3.0.0"
   },
   "dependencies": {
     "@bybas/weather-icons": "^2.0.0",

--- a/frontend/src/test/browser/duplicate-keys.browser.test.ts
+++ b/frontend/src/test/browser/duplicate-keys.browser.test.ts
@@ -16,6 +16,11 @@
  * - Tests PASS when rendering succeeds without Svelte errors
  * - Tests FAIL when Svelte throws each_key_duplicate errors
  *
+ * vitest-browser-svelte v3 made render() async: it returns a Promise that
+ * resolves once the component mounts, or rejects if mounting throws. So every
+ * render() is awaited, and duplicate-key cases assert on the rejected promise
+ * with `.rejects.toThrow(...)` instead of a synchronous `expect(() => ...).toThrow`.
+ *
  * Related components and their issues:
  * - SubnetInput.svelte:179       → {#each subnets as subnet, index (subnet)}
  * - SelectDropdown.svelte:477    → {#each options as option (option.value)}
@@ -44,7 +49,7 @@ import IndexKeyFixed from './wrappers/IndexKeyFixed.svelte';
 
 describe('Duplicate Key: String value as key — (item)', () => {
   it('renders unique string items without error', async () => {
-    render(StringListKey, {
+    await render(StringListKey, {
       items: ['Parus major', 'Turdus merula', 'Erithacus rubecula'],
     });
 
@@ -58,32 +63,34 @@ describe('Duplicate Key: String value as key — (item)', () => {
 
   it('throws on duplicate string items', async () => {
     // Reproduces the {#each items as item (item)} pattern: when a list contains the
-    // same string twice, Svelte throws each_key_duplicate at runtime.
-    expect(() => {
+    // same string twice, Svelte throws each_key_duplicate at runtime. In
+    // vitest-browser-svelte v3 render() is async, so the mount error surfaces as a
+    // rejected promise rather than a synchronous throw.
+    await expect(
       render(StringListKey, {
         items: ['Parus major', 'Turdus merula', 'Parus major'],
-      });
-    }).toThrow(/each_key_duplicate|duplicate key/i);
+      })
+    ).rejects.toThrow(/each_key_duplicate|duplicate key/i);
   });
 
   it('throws on duplicate subnet strings (SubnetInput bug)', async () => {
     // Reproduces SubnetInput.svelte:179 — {#each subnets as subnet, index (subnet)}
     // When the subnets array has identical CIDR blocks
-    expect(() => {
+    await expect(
       render(StringListKey, {
         items: ['192.168.1.0/24', '10.0.0.0/8', '192.168.1.0/24'],
-      });
-    }).toThrow(/each_key_duplicate|duplicate key/i);
+      })
+    ).rejects.toThrow(/each_key_duplicate|duplicate key/i);
   });
 
   it('renders empty list without error', async () => {
-    render(StringListKey, { items: [] });
+    await render(StringListKey, { items: [] });
     // Empty <ul> renders but may not be "visible" (no height) — just check it's in the DOM
     await expect.element(page.getByTestId('string-list')).toBeInTheDocument();
   });
 
   it('renders single item without error', async () => {
-    render(StringListKey, { items: ['Parus major'] });
+    await render(StringListKey, { items: ['Parus major'] });
     await expect.element(page.getByTestId('string-list')).toBeVisible();
   });
 });
@@ -95,7 +102,7 @@ describe('Duplicate Key: String value as key — (item)', () => {
 
 describe('Duplicate Key: Object property as key — (option.value)', () => {
   it('renders unique option values without error', async () => {
-    render(OptionValueKey, {
+    await render(OptionValueKey, {
       options: [
         { value: 'wav', label: 'WAV' },
         { value: 'mp3', label: 'MP3' },
@@ -110,27 +117,27 @@ describe('Duplicate Key: Object property as key — (option.value)', () => {
     // Reproduces SelectDropdown.svelte:477 and SelectField.svelte:103
     // When two options share the same value (e.g., multiple audio devices
     // reporting the same ID, or a device list with duplicate "default" entries)
-    expect(() => {
+    await expect(
       render(OptionValueKey, {
         options: [
           { value: 'default', label: 'System Default' },
           { value: 'hdmi', label: 'HDMI Output' },
           { value: 'default', label: 'Default (Speakers)' },
         ],
-      });
-    }).toThrow(/each_key_duplicate|duplicate key/i);
+      })
+    ).rejects.toThrow(/each_key_duplicate|duplicate key/i);
   });
 
   it('throws when all options have the same value', async () => {
-    expect(() => {
+    await expect(
       render(OptionValueKey, {
         options: [
           { value: 'true', label: 'Yes' },
           { value: 'true', label: 'Enabled' },
           { value: 'true', label: 'On' },
         ],
-      });
-    }).toThrow(/each_key_duplicate|duplicate key/i);
+      })
+    ).rejects.toThrow(/each_key_duplicate|duplicate key/i);
   });
 });
 
@@ -141,7 +148,7 @@ describe('Duplicate Key: Object property as key — (option.value)', () => {
 
 describe('Duplicate Key: Group category as key — (group.category)', () => {
   it('renders unique category names without error', async () => {
-    render(GroupCategoryKey, {
+    await render(GroupCategoryKey, {
       groups: [
         {
           category: 'songbirds',
@@ -165,7 +172,7 @@ describe('Duplicate Key: Group category as key — (group.category)', () => {
     // Reproduces SpeciesSelector.svelte:413 — {#each filteredSpecies as group (group.category)}
     // When filteredSpecies contains multiple groups with the same category
     // (e.g., when filtering produces duplicate category groupings)
-    expect(() => {
+    await expect(
       render(GroupCategoryKey, {
         groups: [
           {
@@ -181,13 +188,13 @@ describe('Duplicate Key: Group category as key — (group.category)', () => {
             items: [{ id: '3', name: 'Wren' }],
           },
         ],
-      });
-    }).toThrow(/each_key_duplicate|duplicate key/i);
+      })
+    ).rejects.toThrow(/each_key_duplicate|duplicate key/i);
   });
 
   it('throws on empty string categories (uncategorized fallback)', async () => {
     // When uncategorized species all get category: '' they produce duplicate keys
-    expect(() => {
+    await expect(
       render(GroupCategoryKey, {
         groups: [
           {
@@ -199,8 +206,8 @@ describe('Duplicate Key: Group category as key — (group.category)', () => {
             items: [{ id: '2', name: 'Unknown Bird B' }],
           },
         ],
-      });
-    }).toThrow(/each_key_duplicate|duplicate key/i);
+      })
+    ).rejects.toThrow(/each_key_duplicate|duplicate key/i);
   });
 });
 
@@ -213,7 +220,7 @@ describe('Index as Key: DOM recycling issue — (index)', () => {
   it('renders all items correctly with index keys', async () => {
     // Index keys don't cause duplicate key errors (indices are unique)
     // but they cause incorrect DOM recycling on remove/reorder
-    render(IndexKey, {
+    await render(IndexKey, {
       items: ['rtsp://cam1/stream', 'rtsp://cam2/stream', 'rtsp://cam3/stream'],
     });
 
@@ -231,7 +238,7 @@ describe('Index as Key: DOM recycling issue — (index)', () => {
     // - It keeps DOM for keys 0 and 1, removes key 2
     // - DOM for key 1 still has old value (cam2) but data says cam3
     // This tests that rerender with the correct data works
-    const { rerender } = render(IndexKey, {
+    const { rerender } = await render(IndexKey, {
       items: ['rtsp://cam1/stream', 'rtsp://cam2/stream', 'rtsp://cam3/stream'],
     });
 
@@ -248,7 +255,7 @@ describe('Index as Key: DOM recycling issue — (index)', () => {
   it('value key: rerender after middle removal shows correct items', async () => {
     // The fixed version uses (item) instead of (index) as key
     // This correctly associates DOM elements with their data values
-    const { rerender } = render(IndexKeyFixed, {
+    const { rerender } = await render(IndexKeyFixed, {
       items: ['rtsp://cam1/stream', 'rtsp://cam2/stream', 'rtsp://cam3/stream'],
     });
 
@@ -275,7 +282,7 @@ describe('Index as Key: DOM recycling issue — (index)', () => {
 describe('Duplicate Key Edge Cases', () => {
   it('case-different strings are unique keys (no error)', async () => {
     // Keys are case-sensitive, so "parus major" and "Parus major" are different
-    render(StringListKey, {
+    await render(StringListKey, {
       items: ['Parus major', 'parus major', 'PARUS MAJOR'],
     });
 
@@ -284,31 +291,31 @@ describe('Duplicate Key Edge Cases', () => {
 
   it('throws on empty string duplicate keys', async () => {
     // Empty strings as keys will collide
-    expect(() => {
+    await expect(
       render(StringListKey, {
         items: ['', 'valid', ''],
-      });
-    }).toThrow(/each_key_duplicate|duplicate key/i);
+      })
+    ).rejects.toThrow(/each_key_duplicate|duplicate key/i);
   });
 
   it('throws on empty string duplicate option values', async () => {
     // Options where value is empty string can duplicate
-    expect(() => {
+    await expect(
       render(OptionValueKey, {
         options: [
           { value: '', label: 'None' },
           { value: 'valid', label: 'Valid' },
           { value: '', label: 'Unset' },
         ],
-      });
-    }).toThrow(/each_key_duplicate|duplicate key/i);
+      })
+    ).rejects.toThrow(/each_key_duplicate|duplicate key/i);
   });
 
   it('handles large list with unique items without error', async () => {
     // Ensure no false positives with many items
     const items = Array.from({ length: 100 }, (_, i) => `Species ${i}`);
 
-    render(StringListKey, { items });
+    await render(StringListKey, { items });
 
     await expect.element(page.getByTestId('string-list')).toBeVisible();
   });
@@ -318,8 +325,8 @@ describe('Duplicate Key Edge Cases', () => {
     const items = Array.from({ length: 100 }, (_, i) => `Species ${i}`);
     items[99] = 'Species 0'; // Duplicate of first item
 
-    expect(() => {
-      render(StringListKey, { items });
-    }).toThrow(/each_key_duplicate|duplicate key/i);
+    await expect(render(StringListKey, { items })).rejects.toThrow(
+      /each_key_duplicate|duplicate key/i
+    );
   });
 });


### PR DESCRIPTION
## Summary

Completes the frontend major-dependency updates by upgrading `vitest-browser-svelte` from v2 to v3, the one major that needed a code migration (it was deliberately excluded from the drop-in low-risk batch in #3854).

v3's breaking change is that **`render()` became async**: it returns a `Promise` that resolves once the component mounts and rejects if mounting throws. Only one file imports it (`src/test/browser/duplicate-keys.browser.test.ts`); everything else uses `@testing-library/svelte`'s synchronous render and is unaffected.

## Changes

- `vitest-browser-svelte` `^2.1.1` -> `^3.0.0`
- `src/test/browser/duplicate-keys.browser.test.ts`:
  - `await` every `render()` call
  - `await` the destructured render result before using `rerender()`
  - assert duplicate-key mount errors with `await expect(render(...)).rejects.toThrow(...)` instead of the old synchronous `expect(() => render(...)).toThrow(...)`. Under async render, Svelte's `each_key_duplicate` error surfaces as a promise rejection, not a synchronous throw (confirmed: the old form left the errors as unhandled rejections and failed 11/19 tests).
- `.gitignore`: cover the browser-mode failure artifacts whose locations weren't ignored (`src/test/browser/__screenshots__/`, `.vitest-attachments/`).

## Test Plan

- [x] `npm run test:browser` - 19 passed (was 11 failed / 8 passed before the migration)
- [x] `npm run check:all` - svelte-check 0 errors, prettier/eslint/stylelint/ast-grep clean
- [x] `npm run test:ci` - 2592 tests pass (173 files)
- [x] `npm audit` - 0 vulnerabilities

## Notes

Remaining held frontend majors after this: `typescript` 7 (gated on svelte-check / typescript-eslint TS7 support) and `vite` 8.1.x (exact-pinned at 8.0.16 for the rolldown/date-fns CI/Docker regression).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling and validation of duplicate-key errors during browser-based rendering.
  * Updated duplicate-key checks to work reliably with asynchronous rendering behavior.

* **Chores**
  * Updated browser testing support.
  * Expanded ignored test artifacts to prevent generated screenshots and attachments from being tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->