### PR TITLE
fix(classifier): clamp derived range-filter week via canonical helper

### DIFF
--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -15,6 +15,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/detection"
 	"github.com/tphakala/birdnet-go/internal/errors"
+	onnx "github.com/tphakala/birdnet-go/internal/inference/onnx"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/openfauna"
 )
@@ -673,23 +674,17 @@ func (bn *BirdNET) predictFilter(date time.Time, week float32, settings *conf.Se
 	return results, nil
 }
 
-// getWeekForFilter calculates the current week number for the filter model.
+// getWeekForFilter calculates the BirdNET week number for the filter model.
+// BirdNET assumes 4 weeks per month, so days 29-31 are clamped to week 4 of
+// their month; the result is always in [1, 48]. It delegates to the canonical
+// onnx.CalculateWeek instead of reimplementing the formula: a drifted, un-clamped
+// copy here was the original source of the out-of-range week (e.g. 49 for
+// Dec 29-31) fed into the range filter model.
 func getWeekForFilter(date time.Time) float32 {
-	var month int
-	var day int
-
 	if date.IsZero() {
 		date = time.Now()
 	}
-
-	month = int(date.Month())
-	day = date.Day()
-
-	// Calculate the week number
-	weeksFromMonths := (month - 1) * 4
-	weekInMonth := (day-1)/7 + 1
-
-	return float32(weeksFromMonths + weekInMonth)
+	return onnx.CalculateWeek(int(date.Month()), date.Day())
 }
 
 // debug functions

--- a/internal/classifier/range_filter_test.go
+++ b/internal/classifier/range_filter_test.go
@@ -346,3 +346,46 @@ func TestBuildRangeFilter_UnmappedSpeciesInIsSpeciesIncluded(t *testing.T) {
 	assert.True(t, updated.IsSpeciesIncluded("Ficedula hypoleuca_Pied Flycatcher"),
 		"unmapped species should be included when PassUnmappedSpecies is true")
 }
+
+// TestGetWeekForFilter_MonthEndClamp verifies the derived BirdNET week stays in
+// [1, 48] for every calendar day, clamping the 5th partial week at the end of a
+// 29-31 day month to week 4. Regression guard for the Dec 29-31 -> week 49 bug
+// (mirrors the fix in internal/api/v2/range.calculateWeek and the canonical
+// onnx.CalculateWeek).
+func TestGetWeekForFilter_MonthEndClamp(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		dateStr string
+		want    float32
+	}{
+		{"Jan 1", "2023-01-01", 1},
+		{"Jan 28", "2023-01-28", 4},
+		{"Jan 29 clamps to week 4", "2023-01-29", 4},
+		{"Jan 31 clamps to week 4", "2023-01-31", 4},
+		{"Feb 28", "2023-02-28", 8},
+		{"Feb 29 leap clamps to week 8", "2024-02-29", 8},
+		{"Dec 28", "2023-12-28", 48},
+		{"Dec 29 would be 49 without clamp", "2023-12-29", 48},
+		{"Dec 30 would be 49 without clamp", "2023-12-30", 48},
+		{"Dec 31 would be 49 without clamp", "2023-12-31", 48},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			date, err := time.Parse(time.DateOnly, tc.dateStr)
+			require.NoError(t, err)
+			assert.InDelta(t, tc.want, getWeekForFilter(date), 0.0001)
+		})
+	}
+
+	// Invariant: the derived week must stay within [1, 48] for every day of a
+	// full leap year, covering every month-end partial week (including Feb 29).
+	for date := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC); date.Year() == 2024; date = date.AddDate(0, 0, 1) {
+		week := getWeekForFilter(date)
+		assert.GreaterOrEqual(t, week, float32(1), "week below 1 for %s", date.Format(time.DateOnly))
+		assert.LessOrEqual(t, week, float32(48), "week above 48 for %s", date.Format(time.DateOnly))
+	}
+}


### PR DESCRIPTION
## Summary

`getWeekForFilter` in `internal/classifier/range_filter.go` reimplemented the BirdNET week formula without the month-end clamp:

```go
weekInMonth := (day-1)/7 + 1   // returns 5 for days 29-31
```

For days 29-31 this produced week N+1: in December that is week 49, which is outside the model's trained 48-week domain; in every other month it aliased those days to the *next* month's first week. The value is fed as a float32 model input into the range filter (ONNX/TFLite) on the live detection path (`predictFilter`, `BuildRangeFilter`), so those days got subtly wrong species-occurrence scores. There is no crash: the model silently accepts the out-of-range input.

This is the same class of bug that #3823 fixed for the API preview path (`internal/api/v2/range.calculateWeek`, merged in #3829). The canonical `onnx.CalculateWeek` already clamps; this classifier copy had drifted from it, which is exactly why it still carried the bug.

## Fix

Rather than hand-clamp a third copy of the formula, delegate to the single canonical implementation:

```go
func getWeekForFilter(date time.Time) float32 {
    if date.IsZero() {
        date = time.Now()
    }
    return onnx.CalculateWeek(int(date.Month()), date.Day())
}
```

`internal/classifier` already imports `internal/inference/onnx` unconditionally (via `model_onnx.go`, no build tag), so this adds no new dependency, build-tag risk, or import cycle. Removing the duplicate formula eliminates the drift that caused the bug in the first place.

## Behavioral change (worth a release note)

On the last 3 days of every month the live range filter now uses week 4 of the current month instead of the next month's first week (and a valid 48 instead of an out-of-range 49 in late December). This shifts which species pass the range-filter threshold on those ~36 days/year, bringing the live detection path in line with the API preview path and BirdNET's canonical 48-week convention. No config, DB, API, or CLI surface changes; nothing fails to load or parse on upgrade.

## Test plan

- [x] Added `TestGetWeekForFilter_MonthEndClamp`: month-end cases (Jan 29-31 -> 4, Feb 29 -> 8, Dec 29-31 -> 48) plus a full leap-year invariant asserting the derived week stays in [1, 48] for every day. Verified it fails on the pre-fix formula and passes on the fix.
- [x] `go test -race ./internal/classifier/` passes.
- [x] `golangci-lint run` clean (0 issues), `gofmt`/`go vet` clean.

Relates to #3823, follows up #3829.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected week calculations for date filters, especially around month-end and year-end dates.
  * Prevented invalid week values from being generated.

* **Tests**
  * Added coverage for month-end dates and leap-year date ranges to verify week values remain valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->