### PR TITLE
fix(detections): stop review comment duplication and allow unlock via review

### DIFF
--- a/frontend/src/lib/desktop/components/modals/ReviewModal.svelte
+++ b/frontend/src/lib/desktop/components/modals/ReviewModal.svelte
@@ -35,6 +35,7 @@
   let lockDetection = $state(false);
   let ignoreSpecies = $state(false);
   let comment = $state('');
+  let originalComment = $state('');
   let isLoading = $state(false);
   let errorMessage = $state<string | null>(null);
   let showCommentSection = $state(false);
@@ -51,6 +52,7 @@
       const firstComment = safeArrayAccess(detection.comments || [], 0);
       const firstCommentValue = firstComment?.entry || '';
       comment = firstCommentValue;
+      originalComment = firstCommentValue;
       // Use firstCommentValue (local variable) instead of comment ($state) to avoid
       // creating a reactive dependency that would reset the section when typing
       showCommentSection = !!firstCommentValue;
@@ -79,7 +81,7 @@
             verified: reviewStatus,
             lock_detection: desiredLockState,
             ignore_species: ignoreSpecies ? detection.commonName : null,
-            comment: comment,
+            comment: comment !== originalComment ? comment : undefined,
           }),
         });
       }

--- a/frontend/src/lib/desktop/components/review/ReviewCard.svelte
+++ b/frontend/src/lib/desktop/components/review/ReviewCard.svelte
@@ -31,6 +31,7 @@
   let lockDetection = $state(false);
   let ignoreSpecies = $state(false);
   let comment = $state('');
+  let originalComment = $state('');
   let isLoadingReview = $state(false);
   let reviewErrorMessage = $state<string | null>(null);
   let showCommentSection = $state(false);
@@ -48,6 +49,7 @@
           ? detection.comments[0]?.entry || ''
           : '';
       comment = firstComment;
+      originalComment = firstComment;
       // Use firstComment (local variable) instead of comment ($state) to avoid
       // creating a reactive dependency that would reset the section when typing
       showCommentSection = !!firstComment;
@@ -74,7 +76,7 @@
           verified: reviewStatus,
           lock_detection: desiredLockState,
           ignore_species: ignoreSpecies ? detection.commonName : null,
-          comment: comment,
+          comment: comment !== originalComment ? comment : undefined,
         }),
       });
 

--- a/frontend/src/lib/desktop/components/review/ReviewCard.test.ts
+++ b/frontend/src/lib/desktop/components/review/ReviewCard.test.ts
@@ -86,5 +86,99 @@ describe('ReviewCard', () => {
       // Section should still be expanded (textarea visible)
       expect(screen.getByRole('textbox')).toBeInTheDocument();
     });
+
+    it('should omit comment from payload when unchanged', async () => {
+      const user = userEvent.setup();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      render(ReviewCardTestWrapper as any, {
+        props: {
+          detection: {
+            id: 1,
+            date: '2024-12-30',
+            time: '12:00:00',
+            source: 'test',
+            beginTime: '12:00:00',
+            endTime: '12:00:03',
+            speciesCode: 'test',
+            scientificName: 'Testus birdus',
+            commonName: 'Test Bird',
+            confidence: 0.95,
+            verified: 'unverified',
+            locked: false,
+            comments: [
+              {
+                id: 1,
+                entry: 'Existing comment',
+                createdAt: '2024-12-30T12:00:00Z',
+                updatedAt: '2024-12-30T12:00:00Z',
+              },
+            ],
+          },
+        },
+      });
+
+      const saveButton = screen.getByRole('button', { name: /common\.review\.form\.saveReview/i });
+      await user.click(saveButton);
+
+      const fetchMock = (await import('$lib/utils/api')).fetchWithCSRF;
+      expect(fetchMock).toHaveBeenCalled();
+      // Use the most recent call (the mock accumulates calls across tests in this
+      // file), so this stays correct if a Save-clicking test is added earlier.
+      const lastCall = vi.mocked(fetchMock).mock.lastCall;
+      const body = JSON.parse((lastCall?.[1]?.body ?? '{}') as string);
+      expect(body.comment).toBeUndefined();
+    });
+
+    it('should include comment in payload when changed', async () => {
+      const user = userEvent.setup();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      render(ReviewCardTestWrapper as any, {
+        props: {
+          detection: {
+            id: 1,
+            date: '2024-12-30',
+            time: '12:00:00',
+            source: 'test',
+            beginTime: '12:00:00',
+            endTime: '12:00:03',
+            speciesCode: 'test',
+            scientificName: 'Testus birdus',
+            commonName: 'Test Bird',
+            confidence: 0.95,
+            verified: 'unverified',
+            locked: false,
+            comments: [
+              {
+                id: 1,
+                entry: 'Existing comment',
+                createdAt: '2024-12-30T12:00:00Z',
+                updatedAt: '2024-12-30T12:00:00Z',
+              },
+            ],
+          },
+        },
+      });
+
+      // Wait for rendering to complete
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /common\.review\.form\.saveReview/i })
+        ).toBeInTheDocument();
+      });
+
+      const textarea = await waitFor(() => screen.getByRole('textbox'));
+      await user.clear(textarea);
+      await user.type(textarea, 'New comment');
+
+      const saveButton = screen.getByRole('button', { name: /common\.review\.form\.saveReview/i });
+      await user.click(saveButton);
+
+      const fetchMock = (await import('$lib/utils/api')).fetchWithCSRF;
+      const lastCall = vi.mocked(fetchMock).mock.lastCall;
+      const body = JSON.parse((lastCall?.[1]?.body ?? '{}') as string);
+      expect(body.comment).toBe('New comment');
+    });
   });
 });

--- a/frontend/src/lib/desktop/components/review/ReviewCard.test.ts
+++ b/frontend/src/lib/desktop/components/review/ReviewCard.test.ts
@@ -118,14 +118,16 @@ describe('ReviewCard', () => {
         },
       });
 
+      const fetchMock = vi.mocked((await import('$lib/utils/api')).fetchWithCSRF);
+      const callsBefore = fetchMock.mock.calls.length;
+
       const saveButton = screen.getByRole('button', { name: /common\.review\.form\.saveReview/i });
       await user.click(saveButton);
 
-      const fetchMock = (await import('$lib/utils/api')).fetchWithCSRF;
-      expect(fetchMock).toHaveBeenCalled();
-      // Use the most recent call (the mock accumulates calls across tests in this
-      // file), so this stays correct if a Save-clicking test is added earlier.
-      const lastCall = vi.mocked(fetchMock).mock.lastCall;
+      // This click must issue exactly one new request; assert that before reading
+      // lastCall, since the mock accumulates calls across tests in this file.
+      expect(fetchMock.mock.calls.length).toBe(callsBefore + 1);
+      const lastCall = fetchMock.mock.lastCall;
       const body = JSON.parse((lastCall?.[1]?.body ?? '{}') as string);
       expect(body.comment).toBeUndefined();
     });
@@ -172,11 +174,14 @@ describe('ReviewCard', () => {
       await user.clear(textarea);
       await user.type(textarea, 'New comment');
 
+      const fetchMock = vi.mocked((await import('$lib/utils/api')).fetchWithCSRF);
+      const callsBefore = fetchMock.mock.calls.length;
+
       const saveButton = screen.getByRole('button', { name: /common\.review\.form\.saveReview/i });
       await user.click(saveButton);
 
-      const fetchMock = (await import('$lib/utils/api')).fetchWithCSRF;
-      const lastCall = vi.mocked(fetchMock).mock.lastCall;
+      expect(fetchMock.mock.calls.length).toBe(callsBefore + 1);
+      const lastCall = fetchMock.mock.lastCall;
       const body = JSON.parse((lastCall?.[1]?.body ?? '{}') as string);
       expect(body.comment).toBe('New comment');
     });

--- a/internal/api/v2/detections/detections.go
+++ b/internal/api/v2/detections/detections.go
@@ -194,13 +194,16 @@ type WeatherInfo struct {
 	MoonIllumination float64 `json:"moonIllumination,omitempty"`
 }
 
-// DetectionRequest represents the query parameters for listing detections
+// DetectionRequest is the JSON request body for the review and lock endpoints.
+// LockDetection is a pointer so the review handler can tell "field omitted" (nil,
+// leave the lock untouched) apart from an explicit false (unlock): a plain bool
+// would make an omitted field read as false and silently unlock a locked detection.
 type DetectionRequest struct {
 	Comment       string `json:"comment,omitempty"`
 	Verified      string `json:"verified,omitempty"`
 	IgnoreSpecies string `json:"ignore_species,omitempty"`
 	Locked        bool   `json:"locked,omitempty"`
-	LockDetection bool   `json:"lock_detection,omitempty"`
+	LockDetection *bool  `json:"lock_detection,omitempty"`
 }
 
 // PaginatedResponse represents a paginated API response
@@ -1433,8 +1436,14 @@ func (c *Handler) ReviewDetection(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Invalid request format", http.StatusBadRequest)
 	}
 
-	// Check lock status (both in-memory and database for race condition)
-	if c.checkDetectionNotLocked(ctx, idStr, note.Locked) {
+	// A locked detection is frozen against changes, EXCEPT an explicit unlock: when
+	// the request unlocks it (currently locked, lock_detection explicitly false),
+	// allow it through so the unlock (and any changes made alongside it) are applied.
+	// This mirrors LockDetection, which only enforces the lock guard when locking.
+	// lock_detection is a *bool: a nil (omitted) value is NOT an unlock, so a
+	// verify-only request that omits the field cannot silently unlock the detection.
+	unlocking := note.Locked && req.LockDetection != nil && !*req.LockDetection
+	if !unlocking && c.checkDetectionNotLocked(ctx, idStr, note.Locked) {
 		return nil // Response already handled by checkDetectionNotLocked
 	}
 
@@ -1465,21 +1474,23 @@ func (c *Handler) ReviewDetection(ctx echo.Context) error {
 		}
 	}
 
-	// Handle lock/unlock request separately
-	if req.LockDetection != note.Locked {
+	// Handle lock/unlock request separately. A nil LockDetection means the field was
+	// omitted from the request, so the lock state is left untouched.
+	if req.LockDetection != nil && *req.LockDetection != note.Locked {
+		newLocked := *req.LockDetection
 		c.LogInfoIfEnabled("Updating lock status",
 			logger.String("detection_id", idStr),
 			logger.Bool("current_locked", note.Locked),
-			logger.Bool("new_locked", req.LockDetection),
+			logger.Bool("new_locked", newLocked),
 			logger.String("ip", ctx.RealIP()),
 		)
 
-		err = c.AddLock(note.ID, req.LockDetection)
+		err = c.AddLock(note.ID, newLocked)
 		if err != nil {
 			// Log the lock operation failure
 			c.LogErrorIfEnabled("Failed to update lock status",
 				logger.String("detection_id", idStr),
-				logger.Bool("attempted_lock_state", req.LockDetection),
+				logger.Bool("attempted_lock_state", newLocked),
 				logger.Error(err),
 				logger.String("ip", ctx.RealIP()),
 			)

--- a/internal/api/v2/detections/detections_test.go
+++ b/internal/api/v2/detections/detections_test.go
@@ -1328,6 +1328,8 @@ func TestReviewDetection(t *testing.T) {
 		{
 			name:        "Locked detection",
 			detectionID: "4",
+			// No lock_detection field: with LockDetection as a *bool this stays nil,
+			// so a verify-only request cannot unlock a locked detection (409 stands).
 			requestBody: `{"verified": "correct"}`,
 			mockSetup: func(m *mock.Mock) {
 				m.On("Get", "4").Return(datastore.Note{ID: 4, Locked: true}, nil)
@@ -1430,6 +1432,83 @@ func TestReviewDetectionFalsePositiveLocalizedResolution(t *testing.T) {
 	assert.NotContains(t, controller.Settings.Load().Realtime.Species.Exclude, "mopsilepakko")
 
 	mockDS.AssertExpectations(t)
+}
+
+// TestReviewDetectionLockState verifies that a locked detection is frozen against changes
+// unless the request is explicitly unlocking it.
+func TestReviewDetectionLockState(t *testing.T) {
+	e, mockDS, controller := setupTestEnvironment(t)
+
+	t.Run("Unlock a locked detection should succeed", func(t *testing.T) {
+		mockDS.ExpectedCalls = nil
+
+		note := datastore.Note{ID: 10, Locked: true}
+		mockDS.On("Get", "10").Return(note, nil)
+
+		// checkDetectionNotLocked is bypassed when unlocking, so we process the review.
+		mockDS.On("SaveNoteReview", mock.AnythingOfType("*datastore.NoteReview")).Return(nil)
+		mockDS.On("UnlockNote", "10").Return(nil)
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v2/detections/10/review",
+			strings.NewReader(`{"verified":"false_positive","lock_detection":false}`))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetParamNames("id")
+		c.SetParamValues("10")
+
+		err := controller.ReviewDetection(c)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		mockDS.AssertExpectations(t)
+	})
+
+	t.Run("Locking an already locked detection should return 409", func(t *testing.T) {
+		mockDS.ExpectedCalls = nil
+
+		note := datastore.Note{ID: 11, Locked: true}
+		mockDS.On("Get", "11").Return(note, nil)
+		// No IsNoteLocked check is needed since in-memory check fails first.
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v2/detections/11/review",
+			strings.NewReader(`{"verified":"false_positive","lock_detection":true}`))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetParamNames("id")
+		c.SetParamValues("11")
+
+		err := controller.ReviewDetection(c)
+		require.NoError(t, err) // Handled error logic within controller
+		assert.Equal(t, http.StatusConflict, rec.Code)
+
+		mockDS.AssertExpectations(t)
+	})
+
+	t.Run("Verify-only without lock_detection on a locked detection stays 409", func(t *testing.T) {
+		mockDS.ExpectedCalls = nil
+
+		note := datastore.Note{ID: 12, Locked: true}
+		mockDS.On("Get", "12").Return(note, nil)
+
+		// lock_detection is omitted, so LockDetection binds to nil. That is NOT an
+		// unlock, so the freeze guard applies and the detection is left untouched.
+		// A plain bool would read the omitted field as false and silently unlock it.
+		req := httptest.NewRequest(http.MethodPost, "/api/v2/detections/12/review",
+			strings.NewReader(`{"verified":"false_positive"}`))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetParamNames("id")
+		c.SetParamValues("12")
+
+		err := controller.ReviewDetection(c)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusConflict, rec.Code)
+
+		mockDS.AssertExpectations(t)
+	})
 }
 
 // TestLockDetection tests the LockDetection endpoint


### PR DESCRIPTION
## Summary

Fixes two pre-existing bugs in the detection review endpoint (`POST /api/v2/detections/:id/review`) that I found while reviewing the `ignore_species` fix (#3674). Both are independent of that fix.

### Bug 1: comment duplication on every review save

The review forms pre-fill the comment box from the detection's existing first comment (`detection.comments[0]`) and always resend it, while the backend `AddComment` is an unconditional `INSERT`. So every re-review of a detection that already has a comment (even one that only changes verification or lock state) inserted a **duplicate** comment row.

**Fix (frontend):** send `comment` in the request body only when it differs from the value loaded into the form (`comment !== originalComment ? comment : undefined`; `JSON.stringify` drops `undefined`). A genuinely new or edited comment is still sent; an unchanged one is omitted, so the backend's existing `if req.Comment != ""` guard no-ops.

### Bug 2: unlocking a detection via the review form always returned 409

`ReviewDetection` ran `checkDetectionNotLocked` unconditionally, so unchecking the "lock" checkbox on a locked detection in the review form always failed with 409. (Unlock via the dashboard lock toggle already worked; only the review-form path was broken.)

**Fix (backend):** allow an explicit unlock through the guard, mirroring the standalone `LockDetection` endpoint. `DetectionRequest.LockDetection` is now a `*bool` so the handler can distinguish:
- **omitted** (`nil`) -> leave the lock untouched (freeze still applies; a verify-only request cannot unlock a locked detection),
- **explicit `false`** -> unlock,
- **explicit `true`** -> keep/lock.

A plain `bool` would read an omitted field as `false` and **silently unlock** a locked detection on any verify-only request (the quick-verify path, `setDetectionVerification`, sends only `{verified}`). The pointer prevents that; verify-only on a locked detection still returns 409.

## Behavioral change (please confirm)

Unlocking a locked detection via the review form now **succeeds** (was 409) and applies any verification/comment changes made in the same request, instead of rejecting them. This loosens a restriction rather than breaking an existing contract (a client sending `lock_detection: false` is explicitly asking to unlock), but it is a deliberate semantics change worth a maintainer's confirmation.

## Testing

- **Backend** `TestReviewDetectionLockState`: unlock (`lock_detection:false`) -> 200 + unlock applied; re-lock (`true`) on locked -> 409; **verify-only (omitted) on locked -> 409** (the key guard proving an omitted field cannot unlock). Plus the existing "Locked detection" case restored to omit `lock_detection` and expect 409. Verified these fail on a plain-`bool` implementation.
- **Frontend** `ReviewCard.test.ts`: asserts the request body omits `comment` when unchanged and includes it when edited. Verified to fail on the pre-fix code.
- `go test -race ./internal/api/v2/detections/`, full-project `golangci-lint` (0 issues), `svelte-check`, eslint, prettier, and the frontend unit suite all pass.

## Notes

- `DetectionRequest.LockDetection` `bool` -> `*bool` is fully contained to `ReviewDetection`; the standalone `/lock` endpoint reads the separate `Locked bool` field and is unchanged. No other code constructs the field.
- The `ignore_species` fix (#3674) is unrelated and already merged; this PR only touches the review/lock request handling and the review forms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Review submissions now omit the `comment` field when the comment hasn’t changed, while still saving edited comments.
  * Detection lock state now remains unchanged when no lock action is specified.
  * Locked detections can be explicitly unlocked when allowed; invalid lock changes are still blocked.
* **Tests**
  * Added/expanded tests to verify request payload behavior for unchanged vs edited comments.
  * Added tests covering detection lock-state scenarios, including verify-only requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->