### PR TITLE
fix(container): re-link TFLite on arm64 images so custom .tflite models load

### DIFF
--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -60,10 +60,12 @@ jobs:
         run: Docker/test/arbitrary-uid-smoke.sh birdnet-go:test
 
   arbitrary-uid-start-arm64:
-    name: ONNX-only arm64 startup
+    name: arm64 container startup
     # Native arm64 runner (free for public repos): the only PR-time job that
-    # exercises the arm64 Dockerfile path (ONNX-only, no libtensorflowlite_c).
-    # Without this the arm64 image first builds on push-to-main.
+    # exercises the arm64 Dockerfile path. The arm64 image ships the INT8-ARM ONNX
+    # stock default and links libtensorflowlite_c for custom .tflite models.
+    # Without this the arm64 image first builds on push-to-main. Custom-.tflite
+    # loading is not covered here; that is validated on real arm64 hardware.
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout code
@@ -74,7 +76,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
-      - name: Build container image (arm64 ONNX-only, load locally)
+      - name: Build container image (arm64, load locally)
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
@@ -90,5 +92,5 @@ jobs:
           cache-to: type=gha,mode=max,scope=arm64
           provenance: false
 
-      - name: Arbitrary-UID startup smoke test (arm64 ONNX-only)
+      - name: Arbitrary-UID startup smoke test (arm64)
         run: Docker/test/arbitrary-uid-smoke.sh birdnet-go:test-arm64

--- a/.github/workflows/golangci-test.yml
+++ b/.github/workflows/golangci-test.yml
@@ -69,6 +69,15 @@ jobs:
       - name: Setup ONNX Runtime
         uses: ./.github/actions/setup-onnxruntime
 
+      # notflite is retained as a minimal, strictly-ONNX build option, but after
+      # arm64 containers went back to linking libtensorflowlite_c no shipped
+      # artifact builds the notflite tag by default. Compile the whole tree with it
+      # once (shard 0) so the stub path (internal/inference/tflite/stub_notflite.go,
+      # internal/classifier/tflite_unavailable.go) cannot bitrot unnoticed.
+      - name: Compile check (notflite stub path)
+        if: matrix.shard == 0
+        run: go build -tags "noembed,skipfrontend,notflite" ./...
+
       - name: Install FFmpeg, SoX, and test dependencies
         uses: ./.github/actions/setup-apt-packages
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -219,8 +219,12 @@ COPY --chown=root:root --from=build /home/dev-user/lib/libonnxruntime*.so* /usr/
 # libtensorflowlite_c so a user-supplied custom `.tflite` model path loads in any
 # container. No TFLite interpreter is created unless a .tflite model is actually
 # loaded, so the arm64 memory win for the ONNX default is preserved.
+# Stage then cp (not a direct COPY) so cp dereferences the build-stage soname
+# symlinks into regular files under /usr/lib; cp runs as root here, so the installed
+# libraries are root-owned. Fail the build loudly if the library is missing.
 COPY --from=build /home/dev-user/lib/libtensorflowlite_c.so* /tmp/tflite-lib/
 RUN cp /tmp/tflite-lib/libtensorflowlite_c.so* /usr/lib/ && \
+    test -e /usr/lib/libtensorflowlite_c.so && \
     rm -rf /tmp/tflite-lib && \
     ldconfig
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -166,9 +166,10 @@ RUN --mount=type=cache,target=/go/pkg/mod,uid=10001,gid=10001 \
 # Create final image using a multi-platform base image
 FROM --platform=$TARGETPLATFORM debian:trixie-slim
 
-# Copy model files to /models. arm64 ships ONNX-only (issue #1103); other arches
-# ship the TFLite models. Stage all candidates in one cacheable layer, then keep
-# only the set for the target architecture.
+# Copy stock model files to /models. arm64 ships ONNX-only stock models (the
+# reduced-memory INT8-ARM default); other arches ship the TFLite models. Stage all
+# candidates in one cacheable layer, then keep only the set for the target
+# architecture. Custom models are supplied by the user at runtime, not shipped here.
 RUN mkdir -p /models /tmp/allmodels
 COPY --from=build /home/dev-user/src/BirdNET-Go/internal/classifier/data/*.tflite /tmp/allmodels/
 COPY --from=build /home/dev-user/src/BirdNET-Go/internal/classifier/data/*.onnx /tmp/allmodels/
@@ -213,14 +214,13 @@ RUN apt-get update -q && apt-get install -q -y --no-install-recommends \
 # overwrite them if it happens to share that UID.
 COPY --chown=root:root --from=build /home/dev-user/lib/libonnxruntime*.so* /usr/lib/
 
-# TensorFlow Lite C library: installed for non-arm64 only. arm64 is ONNX-only
-# (issue #1103) and the binary does not link libtensorflowlite_c. Stage it, then
-# install per arch.
-ARG TARGETPLATFORM
+# TensorFlow Lite C library: installed for all arches. The stock default classifier
+# is ONNX on arm64 (reduced memory) and TFLite on amd64, but every arch links
+# libtensorflowlite_c so a user-supplied custom `.tflite` model path loads in any
+# container. No TFLite interpreter is created unless a .tflite model is actually
+# loaded, so the arm64 memory win for the ONNX default is preserved.
 COPY --from=build /home/dev-user/lib/libtensorflowlite_c.so* /tmp/tflite-lib/
-RUN if [ "$TARGETPLATFORM" != "linux/arm64" ]; then \
-        cp /tmp/tflite-lib/libtensorflowlite_c.so* /usr/lib/; \
-    fi && \
+RUN cp /tmp/tflite-lib/libtensorflowlite_c.so* /usr/lib/ && \
     rm -rf /tmp/tflite-lib && \
     ldconfig
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1352,7 +1352,7 @@ tasks:
           OPENVINO: '{{.OPENVINO | default "true"}}'
 
   noembed_linux_arm64:
-    desc: Build Linux ARM64 without embedded models (ONNX + OpenVINO, no TFLite)
+    desc: Build Linux ARM64 without embedded models (ONNX + TFLite + OpenVINO)
     cmds:
       - task: noembed_build
         vars:
@@ -1364,9 +1364,10 @@ tasks:
           CROSS_COMPILE_CHECK: 'aarch64'
           CC: 'aarch64-linux-gnu-gcc'
           BINARY_SUFFIX: ''
-          # arm64 ships ONNX-only: build without the TFLite backend so the binary
-          # does not link libtensorflowlite_c (issue #1103).
-          NOTFLITE: 'true'
+          # arm64 links the TFLite backend (like amd64) so custom `.tflite` model
+          # paths load; the stock default classifier is still INT8-ARM ONNX for the
+          # reduced-memory win. Pass NOTFLITE=true to build a strictly ONNX-only
+          # binary (no libtensorflowlite_c) for a minimal image.
           # arm64 includes the OpenVINO backend by default (activates on A76/ARMv8.2
           # at runtime, otherwise falls back to ONNX Runtime). The published Docker
           # images bundle the OpenVINO runtime libraries; pass OPENVINO=false to

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1348,7 +1348,8 @@ tasks:
           # amd64 includes the OpenVINO backend by default (activates on an Intel
           # iGPU at runtime when the host provides the GPU drivers, otherwise falls
           # back to ONNX Runtime). The published Docker images bundle the OpenVINO
-          # runtime libraries; pass OPENVINO=false to build an ONNX-only binary.
+          # runtime libraries; pass OPENVINO=false to build without the OpenVINO
+          # backend (ONNX Runtime + TFLite only).
           OPENVINO: '{{.OPENVINO | default "true"}}'
 
   noembed_linux_arm64:
@@ -1366,12 +1367,12 @@ tasks:
           BINARY_SUFFIX: ''
           # arm64 links the TFLite backend (like amd64) so custom `.tflite` model
           # paths load; the stock default classifier is still INT8-ARM ONNX for the
-          # reduced-memory win. Pass NOTFLITE=true to build a strictly ONNX-only
-          # binary (no libtensorflowlite_c) for a minimal image.
+          # reduced-memory win. Pass NOTFLITE=true to drop the TFLite backend and
+          # libtensorflowlite_c for a minimal ONNX-only image.
           # arm64 includes the OpenVINO backend by default (activates on A76/ARMv8.2
           # at runtime, otherwise falls back to ONNX Runtime). The published Docker
           # images bundle the OpenVINO runtime libraries; pass OPENVINO=false to
-          # build a strictly ONNX-only binary.
+          # build without the OpenVINO backend (ONNX Runtime + TFLite only).
           OPENVINO: '{{.OPENVINO | default "true"}}'
 
   noembed_windows_amd64:

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -181,10 +181,11 @@ func NewBirdNET(settings *conf.Settings, modelInfo *ModelInfo) (*BirdNET, error)
 		bn.ModelInfo = defaultClassifierModelInfo(runtime.GOARCH, findModelPathInStandardPaths)
 	}
 
-	// On ONNX-only builds (notflite, the arm64 image), transparently remap a
-	// resolved v2.4 TFLite model (from version:"2.4" or the default) to the INT8
-	// ONNX entry so existing arm64 configs keep starting without a TFLite backend.
-	bn.ModelInfo = remapV24ForONNXOnly(&bn.ModelInfo, tfliteBackendAvailable, findModelPathInStandardPaths)
+	// On arm64 (container images ship the INT8-ARM ONNX model), transparently remap
+	// a resolved v2.4 TFLite model (from version:"2.4" or the default) to the INT8
+	// ONNX entry so arm64 keeps the reduced-memory ONNX default; the TFLite backend
+	// stays available for custom `.tflite` model paths (CustomPath, left untouched).
+	bn.ModelInfo = remapV24ToONNXOnARM64(&bn.ModelInfo, runtime.GOARCH, findModelPathInStandardPaths)
 
 	// Seed the runtime triplet from the resolved static metadata so a model that
 	// somehow loads without an initialize*Model path still reports a sane value.
@@ -1285,12 +1286,12 @@ func (bn *BirdNET) reloadModelInternal() error {
 				Build()
 		}
 		newInfo.CustomPath = bn.Settings.BirdNET.ModelPath
-		// Mirror NewBirdNET (the remap at construction): on ONNX-only builds (notflite,
-		// arm64) a v2.4 TFLite model resolved from version:"2.4" is remapped to the INT8
-		// ONNX entry. Without this, a no-op reload re-resolves to the TFLite entry, and the
-		// identity check below misreads it as a model change requiring an orchestrator
-		// restart, so in-place hot-reloads fail and roll back.
-		newInfo = remapV24ForONNXOnly(&newInfo, tfliteBackendAvailable, findModelPathInStandardPaths)
+		// Mirror NewBirdNET (the remap at construction): on arm64 a v2.4 TFLite model
+		// resolved from version:"2.4" is remapped to the INT8 ONNX entry. Without this, a
+		// no-op reload re-resolves to the TFLite entry, and the identity check below
+		// misreads it as a model change requiring an orchestrator restart, so in-place
+		// hot-reloads fail and roll back.
+		newInfo = remapV24ToONNXOnARM64(&newInfo, runtime.GOARCH, findModelPathInStandardPaths)
 		if newInfo.ID != bn.ModelInfo.ID || newInfo.CustomPath != bn.ModelInfo.CustomPath {
 			rollback()
 			return errors.Newf("model identity changed from %s to %s: requires orchestrator restart", bn.ModelInfo.ID, newInfo.ID).

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -185,7 +185,7 @@ func NewBirdNET(settings *conf.Settings, modelInfo *ModelInfo) (*BirdNET, error)
 	// a resolved v2.4 TFLite model (from version:"2.4" or the default) to the INT8
 	// ONNX entry so arm64 keeps the reduced-memory ONNX default; the TFLite backend
 	// stays available for custom `.tflite` model paths (CustomPath, left untouched).
-	bn.ModelInfo = remapV24ToONNXOnARM64(&bn.ModelInfo, runtime.GOARCH, findModelPathInStandardPaths)
+	bn.ModelInfo = remapV24ToONNXOnARM64(&bn.ModelInfo, runtime.GOARCH, tfliteBackendAvailable, findModelPathInStandardPaths)
 
 	// Seed the runtime triplet from the resolved static metadata so a model that
 	// somehow loads without an initialize*Model path still reports a sane value.
@@ -1291,7 +1291,7 @@ func (bn *BirdNET) reloadModelInternal() error {
 		// no-op reload re-resolves to the TFLite entry, and the identity check below
 		// misreads it as a model change requiring an orchestrator restart, so in-place
 		// hot-reloads fail and roll back.
-		newInfo = remapV24ToONNXOnARM64(&newInfo, runtime.GOARCH, findModelPathInStandardPaths)
+		newInfo = remapV24ToONNXOnARM64(&newInfo, runtime.GOARCH, tfliteBackendAvailable, findModelPathInStandardPaths)
 		if newInfo.ID != bn.ModelInfo.ID || newInfo.CustomPath != bn.ModelInfo.CustomPath {
 			rollback()
 			return errors.Newf("model identity changed from %s to %s: requires orchestrator restart", bn.ModelInfo.ID, newInfo.ID).

--- a/internal/classifier/int8_default_test.go
+++ b/internal/classifier/int8_default_test.go
@@ -112,12 +112,13 @@ func TestDefaultClassifierModelInfo_AMD64AlwaysTFLite(t *testing.T) {
 	assert.Equal(t, BackendTFLite, info.Backend)
 }
 
-// TestRemapV24ToONNXOnARM64 verifies that on arm64 a registry-resolved BirdNET v2.4
-// TFLite model (from version:"2.4" or the default) is transparently remapped to the
-// INT8 ONNX entry when present, so arm64 keeps the reduced-memory ONNX default even
-// though the TFLite backend is linked for custom models. amd64 stays on TFLite via
-// the arch gate; native arm64 stays on TFLite because the INT8 ONNX model is absent;
-// a user-supplied .tflite (CustomPath) is never swapped.
+// TestRemapV24ToONNXOnARM64 verifies the stock v2.4 TFLite default is remapped to
+// the INT8-ARM ONNX entry when ONNX is the right stock backend and the file is
+// present: on arm64 (its reduced-memory default, TFLite still linked for custom
+// models) and on a non-arm64 notflite build (no TFLite backend to run). A normal
+// non-arm64 build keeps FP32 TFLite even with the ONNX file present, arm64 without
+// the ONNX file stays on TFLite, and a user-supplied .tflite (CustomPath) is never
+// swapped.
 func TestRemapV24ToONNXOnARM64(t *testing.T) {
 	t.Parallel()
 
@@ -130,24 +131,32 @@ func TestRemapV24ToONNXOnARM64(t *testing.T) {
 	}
 	findMiss := func(string) (string, bool) { return "", false }
 
-	t.Run("arm64 + int8 present: remapped to unified ONNX", func(t *testing.T) {
-		t.Parallel()
-		got := remapV24ToONNXOnARM64(&v24, "arm64", findHit)
+	assertRemappedToONNX := func(t *testing.T, got ModelInfo) {
+		t.Helper()
 		assert.Equal(t, DefaultModelVersion, got.ID)
 		assert.Equal(t, BackendONNX, got.Backend)
 		assert.Equal(t, QuantizationINT8, got.Quantization)
 		assert.True(t, got.IsStock)
 		assert.Equal(t, "/models/"+DefaultBirdNETINT8ONNXModelName, got.CustomPath)
-	})
-	t.Run("amd64 + int8 present: not remapped (arch gate)", func(t *testing.T) {
+	}
+
+	t.Run("arm64 (tflite linked) + int8 present: remapped to ONNX", func(t *testing.T) {
 		t.Parallel()
-		got := remapV24ToONNXOnARM64(&v24, "amd64", findHit)
+		assertRemappedToONNX(t, remapV24ToONNXOnARM64(&v24, "arm64", true, findHit))
+	})
+	t.Run("non-arm64 notflite + int8 present: remapped to ONNX (no-TFLite fallback)", func(t *testing.T) {
+		t.Parallel()
+		assertRemappedToONNX(t, remapV24ToONNXOnARM64(&v24, "amd64", false, findHit))
+	})
+	t.Run("normal amd64 (tflite available) + int8 present: not remapped", func(t *testing.T) {
+		t.Parallel()
+		got := remapV24ToONNXOnARM64(&v24, "amd64", true, findHit)
 		assert.Equal(t, DefaultModelVersion, got.ID)
 		assert.Equal(t, BackendTFLite, got.Backend)
 	})
 	t.Run("arm64 but int8 absent: unchanged (fails clearly downstream)", func(t *testing.T) {
 		t.Parallel()
-		got := remapV24ToONNXOnARM64(&v24, "arm64", findMiss)
+		got := remapV24ToONNXOnARM64(&v24, "arm64", true, findMiss)
 		assert.Equal(t, DefaultModelVersion, got.ID)
 		assert.Equal(t, BackendTFLite, got.Backend)
 	})
@@ -155,7 +164,7 @@ func TestRemapV24ToONNXOnARM64(t *testing.T) {
 		t.Parallel()
 		custom := v24
 		custom.CustomPath = "/data/model/my.tflite"
-		got := remapV24ToONNXOnARM64(&custom, "arm64", findHit)
+		got := remapV24ToONNXOnARM64(&custom, "arm64", true, findHit)
 		assert.Equal(t, DefaultModelVersion, got.ID)
 		assert.Equal(t, "/data/model/my.tflite", got.CustomPath)
 		assert.Equal(t, BackendTFLite, got.Backend)
@@ -163,7 +172,7 @@ func TestRemapV24ToONNXOnARM64(t *testing.T) {
 	t.Run("non-v2.4 entry: unchanged", func(t *testing.T) {
 		t.Parallel()
 		perch := ModelRegistry[RegistryIDPerchV2]
-		got := remapV24ToONNXOnARM64(&perch, "arm64", findHit)
+		got := remapV24ToONNXOnARM64(&perch, "arm64", true, findHit)
 		assert.Equal(t, RegistryIDPerchV2, got.ID)
 	})
 }
@@ -266,7 +275,7 @@ func TestRemapV24ToONNXOnARM64Unified(t *testing.T) {
 		return "", false
 	}
 	base := ModelRegistry[DefaultModelVersion]
-	got := remapV24ToONNXOnARM64(&base, "arm64", find)
+	got := remapV24ToONNXOnARM64(&base, "arm64", true, find)
 	assert.Equal(t, DefaultModelVersion, got.ID)
 	assert.Equal(t, BackendONNX, got.Backend)
 	assert.Equal(t, QuantizationINT8, got.Quantization)

--- a/internal/classifier/int8_default_test.go
+++ b/internal/classifier/int8_default_test.go
@@ -112,11 +112,13 @@ func TestDefaultClassifierModelInfo_AMD64AlwaysTFLite(t *testing.T) {
 	assert.Equal(t, BackendTFLite, info.Backend)
 }
 
-// TestRemapV24ForONNXOnly verifies that on ONNX-only (notflite) builds a
-// registry-resolved BirdNET v2.4 TFLite model (from version:"2.4" or the default)
-// is transparently remapped to the INT8 ONNX entry when present, so existing
-// arm64 configs keep starting instead of failing on the missing TFLite backend.
-func TestRemapV24ForONNXOnly(t *testing.T) {
+// TestRemapV24ToONNXOnARM64 verifies that on arm64 a registry-resolved BirdNET v2.4
+// TFLite model (from version:"2.4" or the default) is transparently remapped to the
+// INT8 ONNX entry when present, so arm64 keeps the reduced-memory ONNX default even
+// though the TFLite backend is linked for custom models. amd64 stays on TFLite via
+// the arch gate; native arm64 stays on TFLite because the INT8 ONNX model is absent;
+// a user-supplied .tflite (CustomPath) is never swapped.
+func TestRemapV24ToONNXOnARM64(t *testing.T) {
 	t.Parallel()
 
 	v24 := ModelRegistry[DefaultModelVersion]
@@ -128,38 +130,40 @@ func TestRemapV24ForONNXOnly(t *testing.T) {
 	}
 	findMiss := func(string) (string, bool) { return "", false }
 
-	t.Run("tflite available: unchanged", func(t *testing.T) {
+	t.Run("arm64 + int8 present: remapped to unified ONNX", func(t *testing.T) {
 		t.Parallel()
-		got := remapV24ForONNXOnly(&v24, true, findHit)
-		assert.Equal(t, DefaultModelVersion, got.ID)
-		assert.Equal(t, BackendTFLite, got.Backend)
-	})
-	t.Run("onnx-only + int8 present: remapped to unified ONNX", func(t *testing.T) {
-		t.Parallel()
-		got := remapV24ForONNXOnly(&v24, false, findHit)
+		got := remapV24ToONNXOnARM64(&v24, "arm64", findHit)
 		assert.Equal(t, DefaultModelVersion, got.ID)
 		assert.Equal(t, BackendONNX, got.Backend)
 		assert.Equal(t, QuantizationINT8, got.Quantization)
 		assert.True(t, got.IsStock)
 		assert.Equal(t, "/models/"+DefaultBirdNETINT8ONNXModelName, got.CustomPath)
 	})
-	t.Run("onnx-only but int8 absent: unchanged (fails clearly downstream)", func(t *testing.T) {
+	t.Run("amd64 + int8 present: not remapped (arch gate)", func(t *testing.T) {
 		t.Parallel()
-		got := remapV24ForONNXOnly(&v24, false, findMiss)
+		got := remapV24ToONNXOnARM64(&v24, "amd64", findHit)
 		assert.Equal(t, DefaultModelVersion, got.ID)
+		assert.Equal(t, BackendTFLite, got.Backend)
+	})
+	t.Run("arm64 but int8 absent: unchanged (fails clearly downstream)", func(t *testing.T) {
+		t.Parallel()
+		got := remapV24ToONNXOnARM64(&v24, "arm64", findMiss)
+		assert.Equal(t, DefaultModelVersion, got.ID)
+		assert.Equal(t, BackendTFLite, got.Backend)
 	})
 	t.Run("explicit custom .tflite path: not remapped", func(t *testing.T) {
 		t.Parallel()
 		custom := v24
 		custom.CustomPath = "/data/model/my.tflite"
-		got := remapV24ForONNXOnly(&custom, false, findHit)
+		got := remapV24ToONNXOnARM64(&custom, "arm64", findHit)
 		assert.Equal(t, DefaultModelVersion, got.ID)
 		assert.Equal(t, "/data/model/my.tflite", got.CustomPath)
+		assert.Equal(t, BackendTFLite, got.Backend)
 	})
 	t.Run("non-v2.4 entry: unchanged", func(t *testing.T) {
 		t.Parallel()
 		perch := ModelRegistry[RegistryIDPerchV2]
-		got := remapV24ForONNXOnly(&perch, false, findHit)
+		got := remapV24ToONNXOnARM64(&perch, "arm64", findHit)
 		assert.Equal(t, RegistryIDPerchV2, got.ID)
 	})
 }
@@ -251,9 +255,9 @@ func TestDetermineModelInfoINT8ONNX(t *testing.T) {
 	assert.False(t, info.IsStock, "explicit modelpath is not stock")
 }
 
-// TestRemapV24ForONNXOnlyUnified verifies that remapV24ForONNXOnly returns the
+// TestRemapV24ToONNXOnARM64Unified verifies that remapV24ToONNXOnARM64 returns the
 // unified BirdNET_V2.4 ID (not the forked INT8 ID) when remapping to ONNX.
-func TestRemapV24ForONNXOnlyUnified(t *testing.T) {
+func TestRemapV24ToONNXOnARM64Unified(t *testing.T) {
 	t.Parallel()
 	find := func(name string) (string, bool) {
 		if name == DefaultBirdNETINT8ONNXModelName {
@@ -262,7 +266,7 @@ func TestRemapV24ForONNXOnlyUnified(t *testing.T) {
 		return "", false
 	}
 	base := ModelRegistry[DefaultModelVersion]
-	got := remapV24ForONNXOnly(&base, false /*tfliteAvailable*/, find)
+	got := remapV24ToONNXOnARM64(&base, "arm64", find)
 	assert.Equal(t, DefaultModelVersion, got.ID)
 	assert.Equal(t, BackendONNX, got.Backend)
 	assert.Equal(t, QuantizationINT8, got.Quantization)

--- a/internal/classifier/model_registry.go
+++ b/internal/classifier/model_registry.go
@@ -206,18 +206,25 @@ func isBirdNETV24Family(id string) bool {
 	return id == DefaultModelVersion
 }
 
-// remapV24ForONNXOnly remaps a registry-resolved BirdNET v2.4 TFLite model to the
-// INT8-ARM ONNX entry when this build has no TFLite backend (notflite, i.e. the
-// ONNX-only arm64 image) and the ONNX model is present in the standard paths.
-// This keeps arm64 configs that select v2.4 via `version: "2.4"` or the default
-// working on ONNX-only images instead of failing to start on the missing TFLite
-// backend. An explicit model path (CustomPath set) is left untouched so a
+// remapV24ToONNXOnARM64 remaps a registry-resolved BirdNET v2.4 TFLite model to the
+// INT8-ARM ONNX entry on arm64 when the ONNX model is present in the standard
+// paths. arm64 container images ship the INT8-ARM ONNX model as the stock default
+// (for the reduced-memory win) yet also link libtensorflowlite_c so custom
+// `.tflite` models still load; this remap keeps the stock default and a config that
+// selects v2.4 via `version: "2.4"` on ONNX regardless of whether the TFLite
+// backend is compiled in. It mirrors defaultClassifierModelInfo: the arch gate
+// keeps the "amd64/native unchanged" invariant structural, since only the arm64
+// image ships BirdNET_INT8_ARM.onnx (a stray copy on another arch must not silently
+// switch backends). An explicit model path (CustomPath set) is left untouched so a
 // user-supplied model is never silently swapped.
-func remapV24ForONNXOnly(info *ModelInfo, tfliteAvailable bool, find func(name string) (path string, ok bool)) ModelInfo {
-	if tfliteAvailable || info.CustomPath != "" {
+func remapV24ToONNXOnARM64(info *ModelInfo, goarch string, find func(name string) (path string, ok bool)) ModelInfo {
+	if info.CustomPath != "" {
 		return *info
 	}
 	if info.Backend != BackendTFLite || info.ID != DefaultModelVersion {
+		return *info
+	}
+	if goarch != defaultBirdNETClassifierARM64Arch {
 		return *info
 	}
 	if path, ok := find(DefaultBirdNETINT8ONNXModelName); ok {

--- a/internal/classifier/model_registry.go
+++ b/internal/classifier/model_registry.go
@@ -207,24 +207,26 @@ func isBirdNETV24Family(id string) bool {
 }
 
 // remapV24ToONNXOnARM64 remaps a registry-resolved BirdNET v2.4 TFLite model to the
-// INT8-ARM ONNX entry on arm64 when the ONNX model is present in the standard
-// paths. arm64 container images ship the INT8-ARM ONNX model as the stock default
-// (for the reduced-memory win) yet also link libtensorflowlite_c so custom
-// `.tflite` models still load; this remap keeps the stock default and a config that
-// selects v2.4 via `version: "2.4"` on ONNX regardless of whether the TFLite
-// backend is compiled in. It mirrors defaultClassifierModelInfo: the arch gate
-// keeps the "amd64/native unchanged" invariant structural, since only the arm64
-// image ships BirdNET_INT8_ARM.onnx (a stray copy on another arch must not silently
-// switch backends). An explicit model path (CustomPath set) is left untouched so a
-// user-supplied model is never silently swapped.
-func remapV24ToONNXOnARM64(info *ModelInfo, goarch string, find func(name string) (path string, ok bool)) ModelInfo {
+// INT8-ARM ONNX entry when ONNX is the appropriate stock backend and the ONNX model
+// is present in the standard paths. That holds in two cases: on arm64 (where INT8-ARM
+// ONNX is the reduced-memory stock default; arm64 container images also link
+// libtensorflowlite_c so custom `.tflite` models still load), and on any build with
+// no TFLite backend (the notflite tag), whose stub classifier cannot run TFLite and
+// would otherwise fail to start. A normal non-arm64 build keeps its FP32 TFLite v2.4
+// default even when the ONNX file happens to be present, so a stray copy never
+// silently switches backends. An explicit model path (CustomPath set) is left
+// untouched so a user-supplied model is never swapped.
+func remapV24ToONNXOnARM64(info *ModelInfo, goarch string, tfliteAvailable bool, find func(name string) (path string, ok bool)) ModelInfo {
 	if info.CustomPath != "" {
 		return *info
 	}
 	if info.Backend != BackendTFLite || info.ID != DefaultModelVersion {
 		return *info
 	}
-	if goarch != defaultBirdNETClassifierARM64Arch {
+	// Remap to ONNX on arm64 (its stock default) or on a build with no TFLite
+	// backend (notflite), where TFLite cannot run. A normal non-arm64 build keeps
+	// FP32 TFLite even when the ONNX file is present, so nothing silently switches.
+	if goarch != defaultBirdNETClassifierARM64Arch && tfliteAvailable {
 		return *info
 	}
 	if path, ok := find(DefaultBirdNETINT8ONNXModelName); ok {

--- a/internal/classifier/orchestrator_test.go
+++ b/internal/classifier/orchestrator_test.go
@@ -372,7 +372,7 @@ func TestUnionLabels_SkipsEmptyEntries(t *testing.T) {
 
 // TestModelInfos_LivePrimaryInfo verifies that ModelInfos returns the live
 // o.ModelInfo for the primary model entry rather than the static registry
-// template. This matters for the arm64 ONNX-only default, where o.ModelInfo
+// template. This matters for the arm64 ONNX default, where o.ModelInfo
 // carries Backend=ONNX and Quantization=INT8 while the registry template has
 // Backend=TFLite and Quantization=FP32.
 func TestModelInfos_LivePrimaryInfo(t *testing.T) {

--- a/internal/classifier/tflite_unavailable.go
+++ b/internal/classifier/tflite_unavailable.go
@@ -3,7 +3,7 @@
 package classifier
 
 // tfliteBackendAvailable reports whether this build links the TFLite backend.
-// False here: ONNX-only builds (notflite tag, e.g. arm64 container images) have
-// no TFLite classifier or range filter, so paths that would fall back to the
-// embedded TFLite range filter must be disabled.
+// False here: strictly-ONNX builds (the notflite tag) have no TFLite classifier or
+// range filter, so paths that would fall back to the embedded TFLite range filter
+// must be disabled.
 const tfliteBackendAvailable = false

--- a/internal/inference/tflite/stub_notflite.go
+++ b/internal/inference/tflite/stub_notflite.go
@@ -3,7 +3,7 @@
 package tflite
 
 // This file provides stub implementations of the TFLite backend for builds with
-// the notflite tag (ONNX-only builds, e.g. arm64 container images). The stubs
+// the notflite tag (a strictly-ONNX build with no libtensorflowlite_c). The stubs
 // keep the same exported API as the real backend but return an error and, most
 // importantly, do not import go-tflite, so the binary does not link
 // libtensorflowlite_c.


### PR DESCRIPTION
## Summary

arm64 container images were built ONNX-only (via the `notflite` build tag), which stubbed out the TFLite backend and dropped `libtensorflowlite_c`. A user pointing `birdnet.modelpath` at a custom `.tflite` model on an arm64 container hit a hard-fail ("use an ONNX model"), breaking custom classifiers on arm64.

This re-links the TFLite backend on the arm64 container build and ships `libtensorflowlite_c.so` in the arm64 image, matching amd64. The INT8-ARM ONNX model stays the stock default, so the reduced-memory win is preserved: no TFLite interpreter is created unless a `.tflite` model is actually loaded, so only users who supply a custom `.tflite` pay the interpreter cost.

### What changed

- `Taskfile.yml`: `noembed_linux_arm64` no longer sets `NOTFLITE`, so the arm64 binary compiles the TFLite backend and links `libtensorflowlite_c`.
- `Dockerfile`: `libtensorflowlite_c.so*` is installed on all arches (arm64 still ships ONNX-only stock models).
- `internal/classifier/model_registry.go`: `remapV24ToONNXOnARM64` (renamed from `remapV24ForONNXOnly`) now gates on `runtime.GOARCH == arm64` plus INT8-ARM ONNX file presence instead of on TFLite-backend availability. This mirrors `defaultClassifierModelInfo` and keeps an explicit `birdnet.version: "2.4"` on arm64 resolving to INT8 ONNX rather than the FP32 TFLite model the arm64 image does not ship. amd64 and native/tarball installs are unchanged (the INT8-ARM ONNX file ships only in arm64 container images).
- The `notflite` tag is retained as a strictly-ONNX minimal-image option and guarded by a CI compile check (`go build -tags noembed,skipfrontend,notflite`) so its stub path does not bitrot.

### Behavior

Only one intended behavior change: a custom `.tflite` on an arm64 container goes from hard-fail to loading via the TFLite backend. Stock default (INT8 ONNX), `birdnet.version: "2.4"` resolution, amd64 containers, and native/tarball installs are all unchanged.

Note: on arm64 the range-filter fallback path can now attempt a TFLite MData load that is not shipped (only when the ONNX range filter itself fails to load); this is non-fatal, the end state is identical to before (range filter surfaces unhealthy), and only the log line differs.

## Test plan

Validated on native arm64 hardware (Raspberry Pi 5):

- [x] `golangci-lint` clean, classifier race suite green, `notflite` compile guard green
- [x] arm64 image binary links `libtensorflowlite_c`; `/usr/lib` has `libtensorflowlite_c.so*` + `libonnxruntime`; `/models` stays ONNX-only; `libstdc++` resolves (no GLIBCXX conflict)
- [x] stock default: loads INT8-ARM ONNX, 6522 species, no TFLite interpreter created
- [x] custom `.tflite` via `birdnet.modelpath`: loads via the TFLite backend + XNNPACK (previously hard-failed)
- [x] `birdnet.version: "2.4"`: resolves to INT8 ONNX, no fatal missing-FP32-TFLite
- [x] arm64 container startup smoke test runs in CI (`container-test.yml`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - ARM64 no-embed builds now include TFLite support, enabling custom `.tflite` models.
  - BirdNET v2.4 on arm64 defaults to the INT8 ONNX variant when available; explicit ONNX-only builds remain supported via configuration.
  - Runtime images now include the TensorFlow Lite C library across architectures to improve `.tflite` compatibility.
- **Bug Fixes**
  - Improved arm64 model hot-reload behavior to maintain consistent model identities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->