### PR TITLE
feat(dashboard): highlight rare species with a configurable threshold

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -635,6 +635,10 @@
         "livespectrogram": {
           "type": "boolean",
           "description": "auto-start live spectrogram on dashboard"
+        },
+        "rarity": {
+          "$ref": "#/$defs/RarityHighlight",
+          "description": "rare-species highlight settings"
         }
       },
       "additionalProperties": false,
@@ -1763,6 +1767,23 @@
       "additionalProperties": false,
       "type": "object",
       "description": "RangeFilterSettings contains settings for the range filter"
+    },
+    "RarityHighlight": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "show the rare-species highlight icon on detections"
+        },
+        "threshold": {
+          "type": "number",
+          "maximum": 1,
+          "minimum": 0,
+          "description": "occurrence probability (0-1) at or below which a detection is flagged rare"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "RarityHighlight controls highlighting of detections whose geomodel occurrence probability is at or below Threshold (a \"rare\" sighting for the configured location and time of year)."
     },
     "RateLimitingConfig": {
       "properties": {

--- a/doc/wiki/configuration-reference.md
+++ b/doc/wiki/configuration-reference.md
@@ -210,6 +210,8 @@ RealtimeSettings contains all settings related to realtime processing.
 | `realtime.dashboard.layout.elements` | dashboard-element[] |  |
 | `realtime.dashboard.defaultaudiogain` | number | Default playback gain in dB (0-24) |
 | `realtime.dashboard.livespectrogram` | boolean | auto-start live spectrogram on dashboard |
+| `realtime.dashboard.rarity.enabled` | boolean | show the rare-species highlight icon on detections |
+| `realtime.dashboard.rarity.threshold` | number | occurrence probability (0-1) at or below which a detection is flagged rare |
 | `realtime.dynamicthreshold.enabled` | boolean | true to enable dynamic threshold |
 | `realtime.dynamicthreshold.debug` | boolean | true to enable debug mode |
 | `realtime.dynamicthreshold.trigger` | number | trigger threshold for dynamic threshold |

--- a/frontend/src/lib/desktop/components/README.md
+++ b/frontend/src/lib/desktop/components/README.md
@@ -24,6 +24,7 @@ This folder contains **shared components** used across the application. Feature-
 
 - `ConfidenceCircle.svelte` - Circular confidence indicator with progress ring
 - `DataTable.svelte` - Generic data table with controlled (parent-driven) sorting
+- `RareSpeciesIndicator.svelte` - Red star + tooltip shown when a species' geomodel occurrence probability is at or below the configurable Dashboard.Rarity threshold; reads the rarity score cache (`rarity.svelte.ts`)
 - `SortableDataTable.svelte` - Card-wrapped table with built-in client-side sorting and search, header bar (icon/title/count/search/actions), and loading/empty/no-results states; composes SortableHeader, ResizableContainer, and EmptyState
 - `StatsCard.svelte` - Statistical information card
 - `StatusBadges.svelte` - Status indicators (verified, locked, etc.)

--- a/frontend/src/lib/desktop/components/data/RareSpeciesIndicator.svelte
+++ b/frontend/src/lib/desktop/components/data/RareSpeciesIndicator.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  /**
+   * RareSpeciesIndicator
+   *
+   * Shows a red star with a tooltip when a species is "rare" for the configured
+   * location and time of year, i.e. its geomodel occurrence probability is at or
+   * below the configurable Dashboard.Rarity.Threshold. Renders nothing when the
+   * feature is disabled, scores are unavailable, or the species is not rare.
+   *
+   * The occurrence probability is the same value shown as Species Rarity on the
+   * detection detail page. Species without geomodel coverage (e.g. bats) are never
+   * flagged (see rarity.svelte.ts).
+   */
+  import { Star } from '@lucide/svelte';
+  import { t } from '$lib/i18n';
+  import { dashboardSettings, DEFAULT_RARITY } from '$lib/stores/settings';
+  import { isRareSpecies, getOccurrence, loadRarityScores } from '$lib/stores/rarity.svelte';
+
+  interface Props {
+    /** Scientific name of the detected species. */
+    scientificName: string | undefined;
+    /** Tailwind size class for the icon (defaults to the daily-summary star size). */
+    sizeClass?: string;
+  }
+
+  let { scientificName, sizeClass = 'size-3' }: Props = $props();
+
+  const PERCENT_MULTIPLIER = 100;
+
+  let enabled = $derived($dashboardSettings?.rarity?.enabled ?? DEFAULT_RARITY.enabled);
+  let threshold = $derived($dashboardSettings?.rarity?.threshold ?? DEFAULT_RARITY.threshold);
+
+  // Load the occurrence-score cache once the feature is on (dedupes internally).
+  $effect(() => {
+    if (enabled) {
+      void loadRarityScores();
+    }
+  });
+
+  let rare = $derived(enabled && isRareSpecies(scientificName, threshold));
+  let occurrence = $derived(getOccurrence(scientificName));
+  let percent = $derived(
+    occurrence !== undefined ? Math.round(occurrence * PERCENT_MULTIPLIER) : undefined
+  );
+
+  // Parenthetical tooltip to match sibling indicators, e.g. "Rare (12% occurrence)".
+  let tooltip = $derived(
+    percent !== undefined
+      ? t('species.rarity.highlightTooltip', { percent })
+      : t('species.rarity.statuses.rare')
+  );
+</script>
+
+{#if rare}
+  <span
+    class="inline-block shrink-0 text-[var(--color-error)]"
+    role="img"
+    title={tooltip}
+    aria-label={tooltip}
+  >
+    <Star class="{sizeClass} fill-current" />
+  </span>
+{/if}

--- a/frontend/src/lib/desktop/features/dashboard/components/DailySummaryCard.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/DailySummaryCard.svelte
@@ -79,6 +79,7 @@ Responsive Breakpoints:
     noveltyCategoryColorVar,
   } from '$lib/desktop/features/dashboard/utils/noveltyCategory';
   import { ChevronLeft, ChevronRight, Star, XCircle } from '@lucide/svelte';
+  import RareSpeciesIndicator from '$lib/desktop/components/data/RareSpeciesIndicator.svelte';
   import { untrack } from 'svelte';
   import AnimatedCounter from './AnimatedCounter.svelte';
   import BirdThumbnailPopup from './BirdThumbnailPopup.svelte';
@@ -1084,6 +1085,7 @@ Responsive Breakpoints:
                     title={displayName}
                   >
                     <span class="truncate flex-1">{displayName}</span>
+                    <RareSpeciesIndicator scientificName={item.scientific_name} />
                     {#if resolveNoveltyCategory(item) === 'lifetime'}
                       <span
                         class="inline-block shrink-0"

--- a/frontend/src/lib/desktop/features/dashboard/components/SpeciesInfoBar.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/SpeciesInfoBar.svelte
@@ -17,6 +17,7 @@
   import { t } from '$lib/i18n';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
   import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
+  import RareSpeciesIndicator from '$lib/desktop/components/data/RareSpeciesIndicator.svelte';
 
   interface Props {
     detection: Detection;
@@ -70,6 +71,7 @@
     <!-- Name row with verification badge -->
     <div class="species-name-row">
       <span class="species-name">{displayName}</span>
+      <RareSpeciesIndicator scientificName={detection.scientificName} />
       {#if isVerified}
         <span
           class="verified-badge"

--- a/frontend/src/lib/desktop/features/detections/components/DetectionRow.svelte
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionRow.svelte
@@ -33,6 +33,7 @@
   import SourceBadge from '$lib/desktop/features/dashboard/components/SourceBadge.svelte';
   import SpectrogramPlayer from '$lib/desktop/components/media/SpectrogramPlayer.svelte';
   import ActionMenu from '$lib/desktop/components/ui/ActionMenu.svelte';
+  import RareSpeciesIndicator from '$lib/desktop/components/data/RareSpeciesIndicator.svelte';
   import { handleBirdImageError } from '$lib/desktop/components/ui/image-utils.js';
   import { t } from '$lib/i18n';
   import type { Detection } from '$lib/types/detection.types';
@@ -263,12 +264,15 @@
     <!-- Species Names -->
     <div class="sp-species-info-wrapper">
       <div class="sp-species-names">
-        <button
-          onclick={handleDetailsClick}
-          class="sp-species-common-name hover:text-primary transition-colors cursor-pointer text-left"
-        >
-          {displayName}
-        </button>
+        <div class="flex items-center gap-1">
+          <button
+            onclick={handleDetailsClick}
+            class="sp-species-common-name hover:text-primary transition-colors cursor-pointer text-left"
+          >
+            {displayName}
+          </button>
+          <RareSpeciesIndicator scientificName={detection.scientificName} />
+        </div>
         <div class="sp-species-scientific-name">{detection.scientificName}</div>
       </div>
     </div>

--- a/frontend/src/lib/desktop/features/settings/pages/UserInterfaceSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/UserInterfaceSettingsPage.svelte
@@ -18,6 +18,7 @@
     settingsActions,
     dashboardSettings,
     DEFAULT_SPECTROGRAM_SETTINGS,
+    DEFAULT_RARITY,
     type SpectrogramPreRender,
     type SpectrogramStyle,
     type SpectrogramDynamicRange,
@@ -200,10 +201,12 @@
       {
         thumbnails: store.originalData.realtime?.dashboard?.thumbnails,
         spectrogram: store.originalData.realtime?.dashboard?.spectrogram,
+        rarity: store.originalData.realtime?.dashboard?.rarity,
       },
       {
         thumbnails: store.formData.realtime?.dashboard?.thumbnails,
         spectrogram: store.formData.realtime?.dashboard?.spectrogram,
+        rarity: store.formData.realtime?.dashboard?.rarity,
       }
     )
   );
@@ -231,6 +234,16 @@
       dashboard: {
         ...settings.dashboard,
         thumbnails: { ...settings.dashboard.thumbnails, [key]: value },
+      },
+    });
+  }
+
+  function updateRaritySetting(key: 'enabled' | 'threshold', value: boolean | number) {
+    const current = settings.dashboard.rarity ?? DEFAULT_RARITY;
+    settingsActions.updateSection('realtime', {
+      dashboard: {
+        ...settings.dashboard,
+        rarity: { ...current, [key]: value },
       },
     });
   }
@@ -636,6 +649,40 @@
               </span>
             </SettingsNote>
           </div>
+        </div>
+      </div>
+    </SettingsSection>
+
+    <SettingsSection
+      title={t('settings.userInterface.rarity.title')}
+      description={t('settings.userInterface.rarity.description')}
+      originalData={{ rarity: store.originalData.realtime?.dashboard?.rarity }}
+      currentData={{ rarity: store.formData.realtime?.dashboard?.rarity }}
+    >
+      <div class="space-y-4">
+        <Checkbox
+          checked={settings.dashboard.rarity?.enabled ?? DEFAULT_RARITY.enabled}
+          label={t('settings.userInterface.rarity.enabled.label')}
+          helpText={t('settings.userInterface.rarity.enabled.helpText')}
+          disabled={store.isLoading || store.isSaving}
+          onchange={value => updateRaritySetting('enabled', value)}
+        />
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-x-6">
+          <InlineSlider
+            label={t('settings.userInterface.rarity.threshold.label')}
+            helpText={t('settings.userInterface.rarity.threshold.helpText')}
+            value={Math.round(
+              (settings.dashboard.rarity?.threshold ?? DEFAULT_RARITY.threshold) * 100
+            )}
+            onUpdate={value => updateRaritySetting('threshold', value / 100)}
+            min={0}
+            max={100}
+            step={5}
+            unit={t('settings.userInterface.rarity.threshold.unit')}
+            disabled={store.isLoading ||
+              store.isSaving ||
+              !(settings.dashboard.rarity?.enabled ?? DEFAULT_RARITY.enabled)}
+          />
         </div>
       </div>
     </SettingsSection>

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -802,6 +802,7 @@ export type TranslationKey =
   | 'species.rarity.title'
   | 'species.rarity.score'
   | 'species.rarity.basedOnLocation' // params: latitude, longitude
+  | 'species.rarity.highlightTooltip' // params: percent
   | 'species.rarity.statuses.very_common'
   | 'species.rarity.statuses.common'
   | 'species.rarity.statuses.uncommon'
@@ -3336,6 +3337,13 @@ export type TranslationKey =
   | 'settings.userInterface.audioPlayback.defaultGain'
   | 'settings.userInterface.audioPlayback.defaultGainHelpText'
   | 'settings.userInterface.audioPlayback.defaultGainUnit'
+  | 'settings.userInterface.rarity.title'
+  | 'settings.userInterface.rarity.description'
+  | 'settings.userInterface.rarity.enabled.label'
+  | 'settings.userInterface.rarity.enabled.helpText'
+  | 'settings.userInterface.rarity.threshold.label'
+  | 'settings.userInterface.rarity.threshold.helpText'
+  | 'settings.userInterface.rarity.threshold.unit'
   | 'settings.restartRequired'
   | 'auth.login'
   | 'auth.logout'
@@ -4119,6 +4127,7 @@ export type TranslationParams = {
   'detections.aria.thumbnailLoaded': { species: string | number };
   'detections.errors.loadFailed': { status: string | number };
   'species.rarity.basedOnLocation': { latitude: string | number; longitude: string | number };
+  'species.rarity.highlightTooltip': { percent: string | number };
   'spectrogram.gain.level': { value: string | number };
   'system.systemInfo.temperatureValue': { temp: string | number };
   'system.errors.systemInfo': { error: string | number };

--- a/frontend/src/lib/stores/rarity.svelte.test.ts
+++ b/frontend/src/lib/stores/rarity.svelte.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for the rarity store.
+ *
+ * Note: common mocks (logger, i18n, toast) are defined in src/test/setup.ts.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('$lib/utils/api', () => ({
+  api: {
+    get: vi.fn(),
+  },
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.name = 'ApiError';
+      this.status = status;
+    }
+  },
+}));
+
+import {
+  loadRarityScores,
+  getOccurrence,
+  isRareSpecies,
+  rarityScoresLoaded,
+  resetRarityScores,
+} from './rarity.svelte';
+import { api } from '$lib/utils/api';
+
+const mockGet = vi.mocked(api.get);
+
+// A representative slice of GET /api/v2/range/species/scores.
+const scoresResponse = {
+  species: [
+    { scientificName: 'Agelaius phoeniceus', score: 0.82 }, // common
+    { scientificName: 'Spinus tristis', score: 0.2 }, // rare at 0.25
+    { scientificName: 'Setophaga cerulea', score: 0.03 }, // very rare
+    // No score -> ignored
+    { scientificName: 'Corvus corax' },
+  ],
+};
+
+describe('rarity store', () => {
+  beforeEach(() => {
+    resetRarityScores();
+    mockGet.mockReset();
+  });
+
+  it('loads occurrence scores from GET /api/v2/range/species/scores', async () => {
+    mockGet.mockResolvedValue(scoresResponse);
+
+    expect(rarityScoresLoaded()).toBe(false);
+    await loadRarityScores();
+
+    expect(mockGet).toHaveBeenCalledWith('/api/v2/range/species/scores?names=false');
+    expect(rarityScoresLoaded()).toBe(true);
+    expect(getOccurrence('Agelaius phoeniceus')).toBe(0.82);
+    expect(getOccurrence('Setophaga cerulea')).toBe(0.03);
+  });
+
+  it('looks up scientific names case- and whitespace-insensitively', async () => {
+    mockGet.mockResolvedValue(scoresResponse);
+    await loadRarityScores();
+
+    expect(getOccurrence('  agelaius PHOENICEUS ')).toBe(0.82);
+  });
+
+  it('returns undefined for species without a score or geomodel coverage', async () => {
+    mockGet.mockResolvedValue(scoresResponse);
+    await loadRarityScores();
+
+    // Present in the list but without a numeric score.
+    expect(getOccurrence('Corvus corax')).toBeUndefined();
+    // Not in the geomodel at all (e.g. a bat).
+    expect(getOccurrence('Myotis lucifugus')).toBeUndefined();
+  });
+
+  it('flags a species rare only when occurrence is at or below the threshold', async () => {
+    mockGet.mockResolvedValue(scoresResponse);
+    await loadRarityScores();
+
+    expect(isRareSpecies('Spinus tristis', 0.25)).toBe(true); // 0.2 <= 0.25
+    expect(isRareSpecies('Spinus tristis', 0.1)).toBe(false); // 0.2 > 0.1
+    expect(isRareSpecies('Agelaius phoeniceus', 0.25)).toBe(false); // 0.82 > 0.25
+  });
+
+  it('never flags species without geomodel coverage as rare', async () => {
+    mockGet.mockResolvedValue(scoresResponse);
+    await loadRarityScores();
+
+    expect(isRareSpecies('Myotis lucifugus', 0.9)).toBe(false);
+    expect(isRareSpecies(undefined, 0.9)).toBe(false);
+  });
+
+  it('fetches only once for concurrent and repeat calls', async () => {
+    mockGet.mockResolvedValue(scoresResponse);
+
+    await Promise.all([loadRarityScores(), loadRarityScores()]);
+    await loadRarityScores();
+
+    expect(mockGet).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/lib/stores/rarity.svelte.ts
+++ b/frontend/src/lib/stores/rarity.svelte.ts
@@ -1,0 +1,115 @@
+/**
+ * rarity.svelte.ts
+ *
+ * Lazy, session-scoped cache of geomodel occurrence probabilities for the
+ * configured location and current week. Used to flag "rare" detections in the
+ * dashboard and detection lists without an extra per-row backend call.
+ *
+ * Contract:
+ * - One fetch per session against GET /api/v2/range/species/scores (which returns
+ *   ALL geomodel species with raw scores, threshold 0). Concurrent callers dedupe
+ *   on the in-flight promise.
+ * - The endpoint is primary-model only, so species with no geomodel coverage
+ *   (e.g. bats, Perch) are absent from the map. isRareSpecies() therefore returns
+ *   false for them: they have no occurrence probability and must never be flagged.
+ * - "Rare" is defined relative to a caller-supplied threshold (the configurable
+ *   Dashboard.Rarity.Threshold), consistent with the rarity shown on the detail page.
+ *
+ * Usage:
+ *   import { loadRarityScores, isRareSpecies, getOccurrence } from '$lib/stores/rarity.svelte';
+ */
+
+import { api } from '$lib/utils/api';
+import { getLogger } from '$lib/utils/logger';
+
+const logger = getLogger('rarity');
+
+/** One species entry from GET /api/v2/range/species/scores. */
+interface RangeSpeciesScore {
+  scientificName?: string;
+  score?: number;
+}
+
+/** Response shape of GET /api/v2/range/species/scores (only fields we use). */
+interface RangeScoresResponse {
+  species?: RangeSpeciesScore[];
+}
+
+// Module-level reactive state, populated once per session.
+let scores = $state<Map<string, number>>(new Map());
+let loaded = $state(false);
+let inFlight: Promise<void> | null = null;
+
+/** Normalize a scientific name for case/whitespace-insensitive lookup. */
+function normalize(scientificName: string): string {
+  return scientificName.trim().toLowerCase();
+}
+
+/**
+ * Fetch geomodel occurrence scores once and cache them. Safe to call repeatedly;
+ * concurrent calls share a single in-flight request and it no-ops once loaded.
+ */
+export async function loadRarityScores(): Promise<void> {
+  if (loaded) return;
+  if (inFlight) return inFlight;
+
+  inFlight = (async () => {
+    try {
+      // names=false skips per-species common-name resolution (the dominant cost
+      // when fetching all geomodel species); we only need scientificName -> score.
+      const data = await api.get<RangeScoresResponse>('/api/v2/range/species/scores?names=false');
+      const map = new Map<string, number>();
+      for (const entry of data.species ?? []) {
+        if (entry.scientificName && typeof entry.score === 'number') {
+          map.set(normalize(entry.scientificName), entry.score);
+        }
+      }
+      scores = map;
+      loaded = true;
+    } catch (error) {
+      // Best-effort: the indicator simply stays hidden. Failures are expected
+      // (offline, unauthenticated/public mode, geomodel not ready), so warn
+      // rather than error to avoid log noise.
+      logger.warn('failed to load rarity scores', error);
+    } finally {
+      inFlight = null;
+    }
+  })();
+
+  return inFlight;
+}
+
+/**
+ * Returns the geomodel occurrence probability (0-1) for a species, or undefined
+ * when the species is not in the geomodel (no coverage) or scores are not loaded.
+ */
+export function getOccurrence(scientificName: string | undefined): number | undefined {
+  if (!scientificName) return undefined;
+  return scores.get(normalize(scientificName));
+}
+
+/**
+ * Returns true when the species' occurrence probability is at or below the
+ * threshold. Species without geomodel coverage return false (never flagged rare).
+ */
+export function isRareSpecies(scientificName: string | undefined, threshold: number): boolean {
+  const occurrence = getOccurrence(scientificName);
+  return occurrence !== undefined && occurrence <= threshold;
+}
+
+/** Whether the occurrence-score cache has finished loading. */
+export function rarityScoresLoaded(): boolean {
+  return loaded;
+}
+
+/**
+ * Clear the cached occurrence scores so the next loadRarityScores() refetches.
+ * Called when the configured location changes on a settings save (the scores are
+ * location-specific and the endpoint carries no location marker to key on), and
+ * used by tests to start from a clean state.
+ */
+export function resetRarityScores(): void {
+  scores = new Map();
+  loaded = false;
+  inFlight = null;
+}

--- a/frontend/src/lib/stores/settings.ts
+++ b/frontend/src/lib/stores/settings.ts
@@ -574,6 +574,17 @@ export interface WebServerSettings {
   enableTerminal?: boolean; // Enable browser terminal (security risk - disabled by default)
 }
 
+// Rare-species highlight settings
+export interface RarityHighlight {
+  enabled: boolean; // Show the rare-species highlight icon on detections
+  threshold: number; // Occurrence probability (0-1) at or below which a detection is flagged rare
+}
+
+// Default rare-species highlight settings. Disabled by default so upgrading users
+// see no change until they opt in. Mirrors conf.Dashboard.Rarity defaults; the
+// threshold matches conf.DefaultRarityHighlightThreshold.
+export const DEFAULT_RARITY: RarityHighlight = { enabled: false, threshold: 0.25 };
+
 // Dashboard settings
 export interface Dashboard {
   thumbnails: Thumbnails;
@@ -586,6 +597,7 @@ export interface Dashboard {
   logoStyle?: string; // Logo display style: "gradient" or "solid"
   layout?: DashboardLayout; // Configurable dashboard element layout
   defaultAudioGain?: number; // Default playback gain in dB (0-24)
+  rarity?: RarityHighlight; // Rare-species highlight settings
 }
 
 // Dashboard layout configuration
@@ -1008,6 +1020,7 @@ function createEmptySettings(): SettingsFormData {
         summaryLimit: 30,
         spectrogram: DEFAULT_SPECTROGRAM_SETTINGS,
         temperatureUnit: 'celsius',
+        rarity: { ...DEFAULT_RARITY },
         layout: {
           elements: [
             {
@@ -1369,6 +1382,26 @@ export const settingsActions = {
         const { isValidLocale, setLocale } = await import('$lib/i18n/index.js');
         if (isValidLocale(newLocale)) {
           setLocale(newLocale);
+        }
+      }
+
+      // If the configured location changed, drop the cached rarity scores so the
+      // next dashboard mount refetches occurrence data for the new location. The
+      // scores are location-specific and the endpoint carries no location marker
+      // to key the cache on, so we invalidate on the location-changing save here.
+      const newLat = coercedFormData.birdnet.latitude;
+      const newLng = coercedFormData.birdnet.longitude;
+      const origLat = currentState.originalData.birdnet.latitude;
+      const origLng = currentState.originalData.birdnet.longitude;
+      if (newLat !== origLat || newLng !== origLng) {
+        // Isolated try-catch: failure here must not mask a successful settings save.
+        try {
+          const { resetRarityScores } = await import('$lib/stores/rarity.svelte');
+          resetRarityScores();
+        } catch (e) {
+          // Non-critical: rarity cache invalidation failed, but settings were saved.
+          // Cached scores may be stale for the old location until next page load.
+          logger.error('Failed to reset rarity scores after location change:', e);
         }
       }
 

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -1009,6 +1009,7 @@
       "title": "Vzácnost druhu",
       "score": "Skóre",
       "basedOnLocation": "Na základě polohy: {latitude}, {longitude}",
+      "highlightTooltip": "Vzácný ({percent}% výskyt)",
       "statuses": {
         "very_common": "Velmi běžný",
         "common": "Běžný",
@@ -4562,6 +4563,19 @@
         "defaultGain": "Výchozí zesílení hlasitosti",
         "defaultGainHelpText": "Počáteční zesílení při přehrávání nahrávek. Zvuky ptáků jsou často tiché, proto se doporučuje zesílení 6–12 dB.",
         "defaultGainUnit": "dB"
+      },
+      "rarity": {
+        "title": "Zvýraznění vzácných druhů",
+        "description": "Zvýraznit detekce druhů, které jsou pro vaši polohu a roční období vzácné.",
+        "enabled": {
+          "label": "Zvýraznit vzácné druhy",
+          "helpText": "Zobrazí červenou hvězdu u detekcí, jejichž pravděpodobnost výskytu je nižší nebo rovna prahové hodnotě."
+        },
+        "threshold": {
+          "label": "Práh vzácnosti",
+          "helpText": "Druhy s pravděpodobností výskytu nižší nebo rovnou této hodnotě jsou označeny jako vzácné.",
+          "unit": "%"
+        }
       }
     },
     "restartRequired": "Některé změny vyžadují restart serveru. Restartujte prosím BirdNET-Go."

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -1009,6 +1009,7 @@
       "title": "Artens sjældenhed",
       "score": "Score",
       "basedOnLocation": "Baseret på lokation: {latitude}, {longitude}",
+      "highlightTooltip": "Sjælden ({percent}% forekomst)",
       "statuses": {
         "very_common": "Meget almindelig",
         "common": "Almindelig",
@@ -4562,6 +4563,19 @@
         "defaultGain": "Standard lydstyrkeforstærkning",
         "defaultGainHelpText": "Indledende forstærkning ved afspilning af optagelser. Fuglelyde er ofte stille, så en forstærkning på 6-12 dB anbefales.",
         "defaultGainUnit": "dB"
+      },
+      "rarity": {
+        "title": "Fremhævning af sjældne arter",
+        "description": "Fremhæv registreringer af arter, der er sjældne for din placering og årstid.",
+        "enabled": {
+          "label": "Fremhæv sjældne arter",
+          "helpText": "Viser en rød stjerne på registreringer, hvis forekomstsandsynlighed er lig med eller under tærsklen."
+        },
+        "threshold": {
+          "label": "Tærskel for sjældenhed",
+          "helpText": "Arter med en forekomstsandsynlighed lig med eller under denne værdi markeres som sjældne.",
+          "unit": "%"
+        }
       }
     },
     "restartRequired": "Nogle ændringer kræver genstart af serveren for at træde i kraft. Genstart venligst BirdNET-Go."

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -1009,6 +1009,7 @@
       "title": "Seltenheit der Art",
       "score": "Bewertung",
       "basedOnLocation": "Basierend auf Standort: {latitude}, {longitude}",
+      "highlightTooltip": "Selten ({percent}% Vorkommen)",
       "statuses": {
         "very_common": "Sehr häufig",
         "common": "Häufig",
@@ -4562,6 +4563,19 @@
         "defaultGain": "Standard-Lautstärkeverstärkung",
         "defaultGainHelpText": "Anfangsverstärkung bei der Wiedergabe von Aufnahmen. Vogelstimmen sind oft leise, daher wird eine Verstärkung von 6-12 dB empfohlen.",
         "defaultGainUnit": "dB"
+      },
+      "rarity": {
+        "title": "Hervorhebung seltener Arten",
+        "description": "Erkennungen von Arten hervorheben, die für Ihren Standort und die Jahreszeit selten sind.",
+        "enabled": {
+          "label": "Seltene Arten hervorheben",
+          "helpText": "Zeigt einen roten Stern bei Erkennungen an, deren Vorkommenswahrscheinlichkeit auf oder unter dem Schwellenwert liegt."
+        },
+        "threshold": {
+          "label": "Seltenheitsschwelle",
+          "helpText": "Arten mit einer Vorkommenswahrscheinlichkeit auf oder unter diesem Wert werden als selten markiert.",
+          "unit": "%"
+        }
       }
     },
     "restartRequired": "Einige Änderungen erfordern einen Neustart des Servers. Bitte starten Sie BirdNET-Go neu."

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -1009,6 +1009,7 @@
       "title": "Species Rarity",
       "score": "Score",
       "basedOnLocation": "Based on location: {latitude}, {longitude}",
+      "highlightTooltip": "Rare ({percent}% occurrence)",
       "statuses": {
         "very_common": "Very Common",
         "common": "Common",
@@ -4562,6 +4563,19 @@
         "defaultGain": "Default Volume Boost",
         "defaultGainHelpText": "Initial gain applied when playing recordings. Bird sounds are often quiet, so a boost of 6-12 dB is recommended.",
         "defaultGainUnit": "dB"
+      },
+      "rarity": {
+        "title": "Rare Species Highlighting",
+        "description": "Highlight detections of species that are rare for your location and time of year.",
+        "enabled": {
+          "label": "Highlight rare species",
+          "helpText": "Show a red star on detections whose occurrence probability is at or below the threshold."
+        },
+        "threshold": {
+          "label": "Rarity threshold",
+          "helpText": "Species with an occurrence probability at or below this value are marked rare.",
+          "unit": "%"
+        }
       }
     },
     "restartRequired": "Some changes require a server restart to take effect. Please restart BirdNET-Go."

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -1009,6 +1009,7 @@
       "title": "Rareza de la especie",
       "score": "Puntuación",
       "basedOnLocation": "Basado en la ubicación: {latitude}, {longitude}",
+      "highlightTooltip": "Rara ({percent}% de aparición)",
       "statuses": {
         "very_common": "Muy común",
         "common": "Común",
@@ -4562,6 +4563,19 @@
         "defaultGain": "Amplificación de volumen predeterminada",
         "defaultGainHelpText": "Ganancia inicial aplicada al reproducir grabaciones. Los sonidos de aves suelen ser suaves, por lo que se recomienda una amplificación de 6-12 dB.",
         "defaultGainUnit": "dB"
+      },
+      "rarity": {
+        "title": "Resaltado de especies raras",
+        "description": "Resalta las detecciones de especies que son raras para tu ubicación y época del año.",
+        "enabled": {
+          "label": "Resaltar especies raras",
+          "helpText": "Muestra una estrella roja en las detecciones cuya probabilidad de aparición es igual o inferior al umbral."
+        },
+        "threshold": {
+          "label": "Umbral de rareza",
+          "helpText": "Las especies con una probabilidad de aparición igual o inferior a este valor se marcan como raras.",
+          "unit": "%"
+        }
       }
     },
     "restartRequired": "Algunos cambios requieren reiniciar el servidor para aplicarse. Reinicia BirdNET-Go."

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -1009,6 +1009,7 @@
       "title": "Lajin harvinaisuus",
       "score": "Pisteet",
       "basedOnLocation": "Sijainnin perusteella: {latitude}, {longitude}",
+      "highlightTooltip": "Harvinainen ({percent} % esiintyvyys)",
       "statuses": {
         "very_common": "Hyvin yleinen",
         "common": "Yleinen",
@@ -4562,6 +4563,19 @@
         "defaultGain": "Oletusäänenvahvistus",
         "defaultGainHelpText": "Alkuvahvistus äänitteiden toistossa. Lintujen äänet ovat usein hiljaisia, joten 6-12 dB:n vahvistus on suositeltavaa.",
         "defaultGainUnit": "dB"
+      },
+      "rarity": {
+        "title": "Harvinaisten lajien korostus",
+        "description": "Korosta havainnot lajeista, jotka ovat harvinaisia sijainnillesi ja vuodenajalle.",
+        "enabled": {
+          "label": "Korosta harvinaiset lajit",
+          "helpText": "Näyttää punaisen tähden havainnoissa, joiden esiintymistodennäköisyys on enintään kynnysarvo."
+        },
+        "threshold": {
+          "label": "Harvinaisuuden kynnysarvo",
+          "helpText": "Lajit, joiden esiintymistodennäköisyys on enintään tämä arvo, merkitään harvinaisiksi.",
+          "unit": "%"
+        }
       }
     },
     "restartRequired": "Jotkin muutokset vaativat palvelimen uudelleenkäynnistyksen astuakseen voimaan. Käynnistä BirdNET-Go uudelleen."

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -1009,6 +1009,7 @@
       "title": "Rareté de l'espèce",
       "score": "Score",
       "basedOnLocation": "Basé sur l'emplacement : {latitude}, {longitude}",
+      "highlightTooltip": "Rare ({percent} % de présence)",
       "statuses": {
         "very_common": "Très commun",
         "common": "Commun",
@@ -4562,6 +4563,19 @@
         "defaultGain": "Amplification du volume par défaut",
         "defaultGainHelpText": "Gain initial appliqué lors de la lecture des enregistrements. Les sons d'oiseaux sont souvent faibles, une amplification de 6 à 12 dB est recommandée.",
         "defaultGainUnit": "dB"
+      },
+      "rarity": {
+        "title": "Mise en évidence des espèces rares",
+        "description": "Mettre en évidence les détections d'espèces rares pour votre emplacement et la période de l'année.",
+        "enabled": {
+          "label": "Mettre en évidence les espèces rares",
+          "helpText": "Affiche une étoile rouge sur les détections dont la probabilité de présence est inférieure ou égale au seuil."
+        },
+        "threshold": {
+          "label": "Seuil de rareté",
+          "helpText": "Les espèces dont la probabilité de présence est inférieure ou égale à cette valeur sont marquées comme rares.",
+          "unit": "%"
+        }
       }
     },
     "restartRequired": "Certaines modifications nécessitent un redémarrage du serveur pour prendre effet. Veuillez redémarrer BirdNET-Go."

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -1009,6 +1009,7 @@
       "title": "Faj ritkasága",
       "score": "Pontszám",
       "basedOnLocation": "Helyszín alapján: {latitude}, {longitude}",
+      "highlightTooltip": "Ritka ({percent}% előfordulás)",
       "statuses": {
         "very_common": "Nagyon gyakori",
         "common": "Gyakori",
@@ -4562,6 +4563,19 @@
         "defaultGain": "Alapértelmezett hangerő növelés",
         "defaultGainHelpText": "Kezdeti erősítés a felvételek lejátszásakor. A madár hangok gyakran halkak, ezért 6-12 dB erősítés ajánlott.",
         "defaultGainUnit": "dB"
+      },
+      "rarity": {
+        "title": "Ritka fajok kiemelése",
+        "description": "Kiemeli azoknak a fajoknak az észleléseit, amelyek ritkák az Ön helyszínén és az évszakban.",
+        "enabled": {
+          "label": "Ritka fajok kiemelése",
+          "helpText": "Piros csillagot jelenít meg azoknál az észleléseknél, amelyek előfordulási valószínűsége a küszöbértéken vagy az alatt van."
+        },
+        "threshold": {
+          "label": "Ritkasági küszöb",
+          "helpText": "Az olyan fajok, amelyek előfordulási valószínűsége a küszöbértéken vagy az alatt van, ritkaként vannak megjelölve.",
+          "unit": "%"
+        }
       }
     },
     "restartRequired": "Néhány változtatáshoz szerver újraindítás szükséges. Kérjük, indítsa újra a BirdNET-Go-t."

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -1009,6 +1009,7 @@
       "title": "Rarità Specie",
       "score": "Punteggio",
       "basedOnLocation": "Basato sulla posizione: {latitude}, {longitude}",
+      "highlightTooltip": "Rara ({percent}% di presenza)",
       "statuses": {
         "very_common": "Molto comune",
         "common": "Comune",
@@ -4562,6 +4563,19 @@
         "defaultGain": "Amplificazione volume predefinita",
         "defaultGainHelpText": "Guadagno iniziale applicato durante la riproduzione delle registrazioni. I suoni degli uccelli sono spesso deboli, quindi è consigliato un incremento di 6-12 dB.",
         "defaultGainUnit": "dB"
+      },
+      "rarity": {
+        "title": "Evidenziazione delle specie rare",
+        "description": "Evidenzia i rilevamenti di specie rare per la tua posizione e il periodo dell'anno.",
+        "enabled": {
+          "label": "Evidenzia le specie rare",
+          "helpText": "Mostra una stella rossa sui rilevamenti la cui probabilità di presenza è pari o inferiore alla soglia."
+        },
+        "threshold": {
+          "label": "Soglia di rarità",
+          "helpText": "Le specie con una probabilità di presenza pari o inferiore a questo valore vengono contrassegnate come rare.",
+          "unit": "%"
+        }
       }
     },
     "restartRequired": "Alcune modifiche richiedono un riavvio del server per avere effetto. Riavvia BirdNET-Go."

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -1009,6 +1009,7 @@
       "title": "Sugas retums",
       "score": "Vērtējums",
       "basedOnLocation": "Pamatojoties uz atrašanās vietu: {latitude}, {longitude}",
+      "highlightTooltip": "Rets ({percent}% sastopamība)",
       "statuses": {
         "very_common": "Ļoti izplatīta",
         "common": "Izplatīta",
@@ -4562,6 +4563,19 @@
         "defaultGain": "Noklusējuma skaļuma pastiprināšana",
         "defaultGainHelpText": "Sākotnējā pastiprināšana, kas tiek piemērota, atskaņojot ierakstus. Putnu skaņas bieži ir klusas, tāpēc ieteicama 6-12 dB pastiprināšana.",
         "defaultGainUnit": "dB"
+      },
+      "rarity": {
+        "title": "Reto sugu izcelšana",
+        "description": "Izcelt to sugu atklājumus, kas ir retas jūsu atrašanās vietai un gadalaikam.",
+        "enabled": {
+          "label": "Izcelt retās sugas",
+          "helpText": "Rāda sarkanu zvaigzni pie atklājumiem, kuru sastopamības varbūtība ir vienāda ar slieksni vai mazāka."
+        },
+        "threshold": {
+          "label": "Retuma slieksnis",
+          "helpText": "Sugas, kuru sastopamības varbūtība ir vienāda ar šo vērtību vai mazāka, tiek atzīmētas kā retas.",
+          "unit": "%"
+        }
       }
     },
     "restartRequired": "Dažām izmaiņām nepieciešama servera pārstartēšana, lai tās stātos spēkā. Lūdzu, pārstartējiet BirdNET-Go."

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -1009,6 +1009,7 @@
       "title": "Sjeldenhetsgrad",
       "score": "Score",
       "basedOnLocation": "Basert på posisjon: {latitude}, {longitude}",
+      "highlightTooltip": "Sjelden ({percent}% forekomst)",
       "statuses": {
         "very_common": "Svært vanlig",
         "common": "Vanlig",
@@ -4562,6 +4563,19 @@
         "defaultGain": "Standard volumforsterkning",
         "defaultGainHelpText": "Startforsterkning ved avspilling av opptak. Fuglelyder er ofte stille, så en forsterkning på 6–12 dB anbefales.",
         "defaultGainUnit": "dB"
+      },
+      "rarity": {
+        "title": "Utheving av sjeldne arter",
+        "description": "Uthev deteksjoner av arter som er sjeldne for stedet ditt og tiden på året.",
+        "enabled": {
+          "label": "Uthev sjeldne arter",
+          "helpText": "Viser en rød stjerne på deteksjoner der forekomstsannsynligheten er lik eller under terskelen."
+        },
+        "threshold": {
+          "label": "Terskel for sjeldenhet",
+          "helpText": "Arter med en forekomstsannsynlighet lik eller under denne verdien merkes som sjeldne.",
+          "unit": "%"
+        }
       }
     },
     "restartRequired": "Noen endringer krever en serveromstart for å ta effekt. Start BirdNET-Go på nytt."

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -1009,6 +1009,7 @@
       "title": "Soort zeldzaamheid",
       "score": "Score",
       "basedOnLocation": "Gebaseerd op locatie: {latitude}, {longitude}",
+      "highlightTooltip": "Zeldzaam ({percent}% voorkomen)",
       "statuses": {
         "very_common": "Zeer algemeen",
         "common": "Algemeen",
@@ -4562,6 +4563,19 @@
         "defaultGain": "Standaard volumeversterking",
         "defaultGainHelpText": "Initiële versterking bij het afspelen van opnames. Vogelgeluiden zijn vaak zacht, dus een versterking van 6-12 dB wordt aanbevolen.",
         "defaultGainUnit": "dB"
+      },
+      "rarity": {
+        "title": "Zeldzame soorten markeren",
+        "description": "Markeer detecties van soorten die zeldzaam zijn voor jouw locatie en tijd van het jaar.",
+        "enabled": {
+          "label": "Zeldzame soorten markeren",
+          "helpText": "Toont een rode ster bij detecties waarvan de voorkomenswaarschijnlijkheid gelijk is aan of lager dan de drempel."
+        },
+        "threshold": {
+          "label": "Zeldzaamheidsdrempel",
+          "helpText": "Soorten met een voorkomenswaarschijnlijkheid gelijk aan of lager dan deze waarde worden als zeldzaam gemarkeerd.",
+          "unit": "%"
+        }
       }
     },
     "restartRequired": "Sommige wijzigingen vereisen een herstart van de server. Herstart BirdNET-Go."

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -1009,6 +1009,7 @@
       "title": "Rzadkość Gatunku",
       "score": "Wynik",
       "basedOnLocation": "Na podstawie lokalizacji: {latitude}, {longitude}",
+      "highlightTooltip": "Rzadki ({percent}% występowania)",
       "statuses": {
         "very_common": "Bardzo pospolity",
         "common": "Pospolity",
@@ -4562,6 +4563,19 @@
         "defaultGain": "Domyślne wzmocnienie głośności",
         "defaultGainHelpText": "Początkowe wzmocnienie stosowane podczas odtwarzania nagrań. Dźwięki ptaków są często ciche, dlatego zalecane jest wzmocnienie 6-12 dB.",
         "defaultGainUnit": "dB"
+      },
+      "rarity": {
+        "title": "Wyróżnianie rzadkich gatunków",
+        "description": "Wyróżnia wykrycia gatunków, które są rzadkie dla Twojej lokalizacji i pory roku.",
+        "enabled": {
+          "label": "Wyróżniaj rzadkie gatunki",
+          "helpText": "Pokazuje czerwoną gwiazdkę przy wykryciach, których prawdopodobieństwo występowania jest równe progowi lub niższe."
+        },
+        "threshold": {
+          "label": "Próg rzadkości",
+          "helpText": "Gatunki o prawdopodobieństwie występowania równym tej wartości lub niższym są oznaczane jako rzadkie.",
+          "unit": "%"
+        }
       }
     },
     "restartRequired": "Niektóre zmiany wymagają ponownego uruchomienia serwera. Uruchom ponownie BirdNET-Go."

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -1009,6 +1009,7 @@
       "title": "Raridade da espécie",
       "score": "Pontuação",
       "basedOnLocation": "Baseado na localização: {latitude}, {longitude}",
+      "highlightTooltip": "Rara ({percent}% de ocorrência)",
       "statuses": {
         "very_common": "Muito comum",
         "common": "Comum",
@@ -4562,6 +4563,19 @@
         "defaultGain": "Amplificação de Volume Padrão",
         "defaultGainHelpText": "Ganho inicial aplicado ao reproduzir gravações. Os sons de aves são frequentemente baixos, pelo que um reforço de 6-12 dB é recomendado.",
         "defaultGainUnit": "dB"
+      },
+      "rarity": {
+        "title": "Destaque de espécies raras",
+        "description": "Destaca deteções de espécies raras para a sua localização e época do ano.",
+        "enabled": {
+          "label": "Destacar espécies raras",
+          "helpText": "Mostra uma estrela vermelha nas deteções cuja probabilidade de ocorrência é igual ou inferior ao limite."
+        },
+        "threshold": {
+          "label": "Limite de raridade",
+          "helpText": "As espécies com uma probabilidade de ocorrência igual ou inferior a este valor são marcadas como raras.",
+          "unit": "%"
+        }
       }
     },
     "restartRequired": "Algumas alterações requerem um reinício do servidor para terem efeito. Por favor, reinicie o BirdNET-Go."

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -1009,6 +1009,7 @@
       "title": "Vzácnosť druhu",
       "score": "Skóre",
       "basedOnLocation": "Na základe polohy: {latitude}, {longitude}",
+      "highlightTooltip": "Vzácny ({percent}% výskyt)",
       "statuses": {
         "very_common": "Veľmi bežný",
         "common": "Bežný",
@@ -4562,6 +4563,19 @@
         "defaultGain": "Predvolené zosilnenie hlasitosti",
         "defaultGainHelpText": "Počiatočné zosilnenie pri prehrávaní nahrávok. Zvuky vtákov sú často tiché, preto sa odporúča zosilnenie 6-12 dB.",
         "defaultGainUnit": "dB"
+      },
+      "rarity": {
+        "title": "Zvýraznenie vzácnych druhov",
+        "description": "Zvýrazniť detekcie druhov, ktoré sú pre vašu polohu a ročné obdobie vzácne.",
+        "enabled": {
+          "label": "Zvýrazniť vzácne druhy",
+          "helpText": "Zobrazí červenú hviezdu pri detekciách, ktorých pravdepodobnosť výskytu je nižšia alebo rovná prahovej hodnote."
+        },
+        "threshold": {
+          "label": "Prah vzácnosti",
+          "helpText": "Druhy s pravdepodobnosťou výskytu nižšou alebo rovnou tejto hodnote sú označené ako vzácne.",
+          "unit": "%"
+        }
       }
     },
     "restartRequired": "Niektoré zmeny vyžadujú reštart servera. Reštartujte BirdNET-Go."

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -1009,6 +1009,7 @@
       "title": "Arternas sällsynthet",
       "score": "Poäng",
       "basedOnLocation": "Baserat på plats: {latitude}, {longitude}",
+      "highlightTooltip": "Sällsynt ({percent}% förekomst)",
       "statuses": {
         "very_common": "Mycket vanlig",
         "common": "Vanlig",
@@ -4562,6 +4563,19 @@
         "defaultGain": "Standard volymförstärkning",
         "defaultGainHelpText": "Initial förstärkning vid uppspelning av inspelningar. Fågelljud är ofta svaga, så en förstärkning på 6–12 dB rekommenderas.",
         "defaultGainUnit": "dB"
+      },
+      "rarity": {
+        "title": "Markering av sällsynta arter",
+        "description": "Markera detektioner av arter som är sällsynta för din plats och tid på året.",
+        "enabled": {
+          "label": "Markera sällsynta arter",
+          "helpText": "Visar en röd stjärna på detektioner vars förekomstsannolikhet är lika med eller under tröskelvärdet."
+        },
+        "threshold": {
+          "label": "Tröskel för sällsynthet",
+          "helpText": "Arter med en förekomstsannolikhet som är lika med eller under detta värde markeras som sällsynta.",
+          "unit": "%"
+        }
       }
     },
     "restartRequired": "Vissa ändringar kräver en omstart av servern för att träda i kraft. Starta om BirdNET-Go."

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -182,7 +182,21 @@ type Dashboard struct {
 	Layout           DashboardLayout      `yaml:"layout" json:"layout"`                                 // configurable dashboard element layout
 	DefaultAudioGain float64              `yaml:"defaultaudiogain" json:"defaultAudioGain"`             // Default playback gain in dB (0-24)
 	LiveSpectrogram  bool                 `yaml:"livespectrogram" json:"liveSpectrogram"`               // auto-start live spectrogram on dashboard
+	Rarity           RarityHighlight      `yaml:"rarity" json:"rarity"`                                 // rare-species highlight settings
 }
+
+// RarityHighlight controls highlighting of detections whose geomodel occurrence
+// probability is at or below Threshold (a "rare" sighting for the configured
+// location and time of year). The occurrence probability is the same value shown
+// as species rarity on the detection detail page (0-1, higher = more common).
+type RarityHighlight struct {
+	Enabled   bool    `yaml:"enabled" json:"enabled"`                                      // show the rare-species highlight icon on detections
+	Threshold float64 `yaml:"threshold" json:"threshold" jsonschema:"minimum=0,maximum=1"` // occurrence probability (0-1) at or below which a detection is flagged rare
+}
+
+// DefaultRarityHighlightThreshold is the default occurrence probability at or
+// below which a detection is highlighted as rare (see RarityHighlight).
+const DefaultRarityHighlightThreshold = 0.25
 
 // DashboardLayout defines the ordered list of elements displayed on the dashboard.
 // Element order is determined by array index position.

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -176,6 +176,12 @@ func setDefaultConfig() {
 	viper.SetDefault("realtime.dashboard.defaultaudiogain", 0.0)      // Default playback gain in dB (no boost)
 	viper.SetDefault("realtime.dashboard.livespectrogram", false)     // Auto-start live spectrogram on dashboard
 
+	// Rare-species highlighting: flag detections whose geomodel occurrence
+	// probability is at or below the threshold (0-1, lower = rarer). Off by
+	// default so existing installs are unchanged on upgrade; opt in via the UI.
+	viper.SetDefault("realtime.dashboard.rarity.enabled", false)
+	viper.SetDefault("realtime.dashboard.rarity.threshold", DefaultRarityHighlightThreshold)
+
 	// Spectrogram pre-rendering configuration
 	viper.SetDefault("realtime.dashboard.spectrogram.enabled", false)                                // Opt-in for safety
 	viper.SetDefault("realtime.dashboard.spectrogram.mode", "auto")                                  // Default to auto mode (generate on demand)

--- a/internal/conf/validate_rarity_test.go
+++ b/internal/conf/validate_rarity_test.go
@@ -1,0 +1,45 @@
+package conf
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The rare-species highlight threshold is an occurrence probability and must stay
+// within [0, 1]; validateDashboardSettings clamps out-of-range or non-finite values.
+func TestValidateDashboardSettings_RarityThresholdClamped(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   float64
+		want float64
+	}{
+		{"in-range unchanged", 0.25, 0.25},
+		{"lower boundary kept", 0, 0},
+		{"upper boundary kept", 1, 1},
+		{"above range clamped to 1", 1.5, 1},
+		{"below range clamped to 0", -0.2, 0},
+		{"NaN reset to default", math.NaN(), DefaultRarityHighlightThreshold},
+		{"positive infinity reset to default", math.Inf(1), DefaultRarityHighlightThreshold},
+		{"negative infinity reset to default", math.Inf(-1), DefaultRarityHighlightThreshold},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			settings := &Dashboard{Rarity: RarityHighlight{Enabled: true, Threshold: tt.in}}
+
+			require.NoError(t, validateDashboardSettings(settings))
+			assert.InDelta(t, tt.want, settings.Rarity.Threshold, 1e-9)
+		})
+	}
+}
+
+// The default highlight threshold is 25% occurrence, matching the UI default.
+func TestDefaultRarityHighlightThreshold(t *testing.T) {
+	t.Parallel()
+	assert.InDelta(t, 0.25, DefaultRarityHighlightThreshold, 1e-9)
+}

--- a/internal/conf/validate_realtime.go
+++ b/internal/conf/validate_realtime.go
@@ -164,6 +164,25 @@ func validateRetentionSettings(settings *RetentionSettings) error {
 	return nil
 }
 
+// clampRarityHighlightThreshold clamps the rare-species highlight threshold to the
+// valid occurrence-probability range [0, 1]. Non-finite values reset to the default.
+func clampRarityHighlightThreshold(r *RarityHighlight) {
+	t := r.Threshold
+	if !math.IsNaN(t) && !math.IsInf(t, 0) && t >= 0 && t <= 1 {
+		return
+	}
+	GetLogger().Warn("Dashboard rarity highlight threshold out of range (0-1), clamping",
+		logger.Float64("invalid_value", t))
+	switch {
+	case math.IsNaN(t) || math.IsInf(t, 0):
+		r.Threshold = DefaultRarityHighlightThreshold
+	case t < 0:
+		r.Threshold = 0
+	default:
+		r.Threshold = 1
+	}
+}
+
 func validateDashboardSettings(settings *Dashboard) error {
 	// Validate deprecated root SummaryLimit (only when non-zero, i.e. not yet migrated)
 	if settings.SummaryLimit != 0 && (settings.SummaryLimit < 10 || settings.SummaryLimit > 1000) {
@@ -230,6 +249,9 @@ func validateDashboardSettings(settings *Dashboard) error {
 			settings.DefaultAudioGain = MaxPlaybackGain
 		}
 	}
+
+	// Validate rare-species highlight threshold (an occurrence probability, 0-1).
+	clampRarityHighlightThreshold(&settings.Rarity)
 
 	// Validate spectrogram settings
 	if settings.Spectrogram.Mode != "" {


### PR DESCRIPTION
## Summary

Highlights detections of species that are rare for the configured location and time of year. A species is "rare" when its BirdNET geomodel occurrence probability is at or below a configurable threshold (default 25%), which is the same probability shown as Species Rarity on the detection detail page. Rare detections get a red star and a "Rare (N% occurrence)" tooltip on:

- the detections list (`/ui/detections`),
- dashboard recent-detection cards,
- the dashboard daily-summary species table (next to the existing new-species star).

The feature is off by default, so existing installs are unchanged on upgrade; users enable it and adjust the threshold on the User Interface settings page.

Rarity is read once per session from `GET /api/v2/range/species/scores?names=false` (added in #3834) and mapped client-side by scientific name, so there is no extra per-row backend call. Species with no geomodel coverage (e.g. bats) are never flagged.

Closes #70

## Changes

- Backend config: `Realtime.Dashboard.Rarity { Enabled, Threshold }` with defaults (off, 0.25) and 0-1 clamp validation; regenerated config schema and reference.
- Frontend: a session-scoped rarity score cache (`rarity.svelte.ts`), a shared `RareSpeciesIndicator` component, wiring into the detections list, dashboard cards, and daily-summary table, and the settings control on the User Interface page.
- i18n: new keys translated into all 15 locales.
- Tests: Go (threshold clamp and default) and frontend (rarity store).

## Testing

- [x] `go test -race ./internal/conf/...`
- [x] `golangci-lint run --build-tags=noembed,skipfrontend ./internal/conf/...` (0 issues)
- [x] `npm run check:all` and the rarity store unit tests
- [x] i18n locales and generated types in sync
- [x] Manual: red star and tooltip across the three surfaces; enable toggle and threshold hot-reload; off by default


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rare-species highlighting with a red star indicator across the dashboard, daily summaries, and detection rows, including a localized tooltip with occurrence percent.
  * Added “Rarity” UI settings to enable highlighting and set the 0–100% threshold.
* **Bug Fixes**
  * Improved rarity-threshold validation by clamping to 0–1 and safely resetting non-finite values.
  * Rarity score cache is invalidated when latitude/longitude changes.
* **Documentation**
  * Updated configuration schema/reference, component docs, and added i18n strings for the new feature and settings.
* **Tests**
  * Added tests for rarity-score caching/loading, rare detection logic, and threshold/validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->