### PR TITLE
test(container): guard custom .tflite load on the amd64 image

### DIFF
--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -59,6 +59,13 @@ jobs:
       - name: Arbitrary-UID startup smoke test
         run: Docker/test/arbitrary-uid-smoke.sh birdnet-go:test
 
+      # Guards custom-.tflite users: the amd64 image must link libtensorflowlite_c
+      # and route a birdnet.modelpath .tflite to the TFLite backend (the regression
+      # class #3864 fixed for arm64). Selection is unit-tested; this covers the
+      # runtime dlopen + Dockerfile shipping dimension unit tests cannot.
+      - name: Custom .tflite model load smoke test
+        run: Docker/test/custom-tflite-smoke.sh birdnet-go:test
+
   arbitrary-uid-start-arm64:
     name: arm64 container startup
     # Native arm64 runner (free for public repos): the only PR-time job that

--- a/Docker/test/custom-tflite-smoke.sh
+++ b/Docker/test/custom-tflite-smoke.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Smoke test: a user-supplied custom TensorFlow Lite classifier model
+# (birdnet.modelpath / BIRDNET_MODELPATH pointing at a .tflite file) must load
+# via the TFLite backend inside the container image.
+#
+# This guards the regression class that PR #3536/#3544 (arm64 ONNX-only, notflite
+# stub) reintroduced and PR #3864 fixed for arm64: a container that no longer links
+# libtensorflowlite_c (or misroutes a .tflite to the ONNX backend) hard-fails a
+# custom .tflite with "use an ONNX model". The amd64 image has always shipped TFLite,
+# so this asserts that stays true end-to-end: the shipped libtensorflowlite_c actually
+# dlopens at runtime AND the classifier selection routes a .tflite modelpath to the
+# TFLite backend. Selection is unit-tested (TestCustomBirdNETV24ModelInfo,
+# TestUsesONNXBackend, TestRemapV24ToONNXOnARM64); this covers the runtime/packaging
+# dimension the unit tests cannot.
+#
+# The default model is a stock .tflite the amd64 image already ships in /models, so no
+# extra CI asset is needed. It is loaded via BIRDNET_MODELPATH exactly as a real user's
+# custom model would be: customBirdNETV24ModelInfo marks it IsStock=false, sets
+# Backend=TFLite from the extension, and initializeTFLiteModel loads it from the path.
+#
+# Usage: Docker/test/custom-tflite-smoke.sh <image-ref> [model-path]
+#   [model-path] should be a space-free absolute path inside the image (the log
+#   encoder quotes values containing whitespace, which the literal marker match
+#   would then miss); the default is space-free.
+#
+# The docker run/poll/cleanup harness mirrors arbitrary-uid-smoke.sh. Kept as a
+# separate copy (not a shared helper) while there are only two smoke tests with
+# divergent markers and check ordering; factor out a common lib if a third lands.
+#
+# Notes on the environment:
+#   -e BIRDNET_MODELPATH   the custom model path; overrides birdnet.modelpath (env.go
+#                          binds BIRDNET_MODELPATH -> birdnet.modelpath).
+#   --tmpfs mounts         writable by any UID (K8s emptyDir equivalent). /data needs
+#                          >=1GB for the entrypoint's disk preflight.
+set -euo pipefail
+
+IMAGE="${1:?usage: custom-tflite-smoke.sh <image-ref> [model-path]}"
+# A stock classifier .tflite the amd64 image ships in /models (see Dockerfile). Any
+# .tflite path exercises the same Tier-3 custom-model -> TFLite load path.
+MODEL_PATH="${2:-/models/BirdNET_GLOBAL_6K_V2.4_Model_FP32.tflite}"
+TIMEOUT_SECONDS="${SMOKE_TIMEOUT:-90}"
+
+# Markers, kept in one place so a production log refactor updates both sides.
+# SUCCESS: the TFLite init path logs this (internal/classifier/birdnet.go:368). The
+# birdnet module mirrors model-init to the console (logging.modules.birdnet.console_also
+# defaults to true), so it reaches `docker logs`. It carries the model path
+# (birdnet.go:360-362), so it also proves the CUSTOM path was taken, not the stock
+# default (which logs a version string). Matched literally (grep -F): the path holds
+# regex metacharacters, and a space-bearing path would be quoted by the log encoder.
+SUCCESS_MARKER="BirdNET model initialized model=${MODEL_PATH}"
+# FAIL (any of): the notflite stub hard-fail (internal/inference/tflite/stub_notflite.go),
+# a model-init failure, or a startup abort. Static strings, matched as an ERE alternation.
+FAIL_MARKERS="use an ONNX model|failed to initialize BirdNET|APPLICATION STARTUP FAILED|Cannot load settings"
+# The .tflite misrouted to the ONNX backend logs this (internal/classifier/model_onnx.go:86)
+# with OUR model path. Matched literally (grep -F, not folded into the ERE above) so a
+# path with regex metacharacters cannot corrupt the pattern, and so a legitimately-loaded
+# secondary ONNX model (e.g. perch) with a different path does not false-trip it.
+ONNX_MISROUTE_MARKER="ONNX model initialized model=${MODEL_PATH}"
+
+echo "==> Starting '$IMAGE' with BIRDNET_MODELPATH=$MODEL_PATH"
+cid=$(docker run -d \
+    -e BIRDNET_MODELPATH="$MODEL_PATH" \
+    -e TZ=Europe/Helsinki \
+    --tmpfs /config:size=64m \
+    --tmpfs /data:size=1200m \
+    "$IMAGE")
+cleanup() { docker rm -f "$cid" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+status="timeout"
+deadline=$((SECONDS + TIMEOUT_SECONDS))
+while [ "$SECONDS" -lt "$deadline" ]; do
+    logs=$(docker logs "$cid" 2>&1 || true)
+    # Check failure first: a fail marker plus the success line (unlikely) should still fail.
+    if grep -Eiq "$FAIL_MARKERS" <<<"$logs" || grep -qF "$ONNX_MISROUTE_MARKER" <<<"$logs"; then
+        status="failed"
+        break
+    fi
+    if grep -qF "$SUCCESS_MARKER" <<<"$logs"; then
+        status="ok"
+        break
+    fi
+    if [ "$(docker inspect -f '{{.State.Running}}' "$cid" 2>/dev/null || echo false)" != "true" ]; then
+        status="exited"
+        break
+    fi
+    sleep 2
+done
+
+echo "----- container logs (tail) -----"
+docker logs "$cid" 2>&1 | tail -40
+echo "---------------------------------"
+
+if [ "$status" != "ok" ]; then
+    echo "FAIL: custom .tflite ($MODEL_PATH) did not load via the TFLite backend (status=$status)"
+    echo "      expected log marker: '$SUCCESS_MARKER'"
+    exit 1
+fi
+
+echo "PASS: custom .tflite loaded via the TFLite backend ($MODEL_PATH)"

--- a/Docker/test/custom-tflite-smoke.sh
+++ b/Docker/test/custom-tflite-smoke.sh
@@ -20,9 +20,8 @@
 # Backend=TFLite from the extension, and initializeTFLiteModel loads it from the path.
 #
 # Usage: Docker/test/custom-tflite-smoke.sh <image-ref> [model-path]
-#   [model-path] should be a space-free absolute path inside the image (the log
-#   encoder quotes values containing whitespace, which the literal marker match
-#   would then miss); the default is space-free.
+#   [model-path] should be an absolute path inside the image; the default is
+#   /models/BirdNET_GLOBAL_6K_V2.4_Model_FP32.tflite.
 #
 # The docker run/poll/cleanup harness mirrors arbitrary-uid-smoke.sh. Kept as a
 # separate copy (not a shared helper) while there are only two smoke tests with
@@ -41,22 +40,22 @@ IMAGE="${1:?usage: custom-tflite-smoke.sh <image-ref> [model-path]}"
 MODEL_PATH="${2:-/models/BirdNET_GLOBAL_6K_V2.4_Model_FP32.tflite}"
 TIMEOUT_SECONDS="${SMOKE_TIMEOUT:-90}"
 
-# Markers, kept in one place so a production log refactor updates both sides.
-# SUCCESS: the TFLite init path logs this (internal/classifier/birdnet.go:368). The
-# birdnet module mirrors model-init to the console (logging.modules.birdnet.console_also
-# defaults to true), so it reaches `docker logs`. It carries the model path
-# (birdnet.go:360-362), so it also proves the CUSTOM path was taken, not the stock
-# default (which logs a version string). Matched literally (grep -F): the path holds
-# regex metacharacters, and a space-bearing path would be quoted by the log encoder.
-SUCCESS_MARKER="BirdNET model initialized model=${MODEL_PATH}"
+# Markers. The model-init line is "<message> ... model=<path>" (logfmt). We match the
+# MESSAGE and the PATH on the SAME line rather than the exact "model=<path>" substring,
+# so the check survives a log-encoder change (value quoting, JSON) and supports paths
+# with spaces, while staying precise. Same-line coupling is load-bearing: the entrypoint
+# echoes the path on its OWN line ("Custom model path configured: ...") and a secondary
+# ONNX model (perch) logs the ONNX message with a DIFFERENT path, so a cross-line "path
+# appears anywhere" check would false-pass (entrypoint echo) or false-fail (perch).
+# SUCCESS: the TFLite init path logs this (internal/classifier/birdnet.go:368), mirrored
+# to the console by logging.modules.birdnet.console_also (default true) so it reaches
+# `docker logs`. The ONNX path logs a different message, so it discriminates the backend.
+SUCCESS_MSG="BirdNET model initialized"
 # FAIL (any of): the notflite stub hard-fail (internal/inference/tflite/stub_notflite.go),
 # a model-init failure, or a startup abort. Static strings, matched as an ERE alternation.
 FAIL_MARKERS="use an ONNX model|failed to initialize BirdNET|APPLICATION STARTUP FAILED|Cannot load settings"
-# The .tflite misrouted to the ONNX backend logs this (internal/classifier/model_onnx.go:86)
-# with OUR model path. Matched literally (grep -F, not folded into the ERE above) so a
-# path with regex metacharacters cannot corrupt the pattern, and so a legitimately-loaded
-# secondary ONNX model (e.g. perch) with a different path does not false-trip it.
-ONNX_MISROUTE_MARKER="ONNX model initialized model=${MODEL_PATH}"
+# MISROUTE: OUR .tflite loaded via the ONNX backend logs this (internal/classifier/model_onnx.go:86).
+ONNX_MISROUTE_MSG="ONNX model initialized"
 
 echo "==> Starting '$IMAGE' with BIRDNET_MODELPATH=$MODEL_PATH"
 cid=$(docker run -d \
@@ -72,12 +71,17 @@ status="timeout"
 deadline=$((SECONDS + TIMEOUT_SECONDS))
 while [ "$SECONDS" -lt "$deadline" ]; do
     logs=$(docker logs "$cid" 2>&1 || true)
+    # Capture the message lines first (SIGPIPE-safe: never pipe grep into grep -q under
+    # pipefail), then require OUR path on one of them, so message and path stay coupled
+    # to the same line.
+    init_lines=$(grep -F "$SUCCESS_MSG" <<<"$logs" || true)
+    onnx_lines=$(grep -F "$ONNX_MISROUTE_MSG" <<<"$logs" || true)
     # Check failure first: a fail marker plus the success line (unlikely) should still fail.
-    if grep -Eiq "$FAIL_MARKERS" <<<"$logs" || grep -qF "$ONNX_MISROUTE_MARKER" <<<"$logs"; then
+    if grep -Eiq "$FAIL_MARKERS" <<<"$logs" || grep -qF "$MODEL_PATH" <<<"$onnx_lines"; then
         status="failed"
         break
     fi
-    if grep -qF "$SUCCESS_MARKER" <<<"$logs"; then
+    if grep -qF "$MODEL_PATH" <<<"$init_lines"; then
         status="ok"
         break
     fi
@@ -94,7 +98,7 @@ echo "---------------------------------"
 
 if [ "$status" != "ok" ]; then
     echo "FAIL: custom .tflite ($MODEL_PATH) did not load via the TFLite backend (status=$status)"
-    echo "      expected log marker: '$SUCCESS_MARKER'"
+    echo "      expected '$SUCCESS_MSG' on the same log line as '$MODEL_PATH'"
     exit 1
 fi
 


### PR DESCRIPTION
## What

Add a CI smoke test that a user-supplied custom `.tflite` classifier model loads via
the TFLite backend on the amd64 container image, and wire it into the amd64
`container-test` job.

## Why

PR #3864 re-linked TFLite on the arm64 container so custom `.tflite` models load there
again (the arm64 image had gone ONNX-only via the `notflite` stub, which hard-failed a
custom `.tflite` with "use an ONNX model"). amd64 has always shipped TFLite, but nothing
in CI actually verifies that a custom `.tflite` still loads on the container: the
existing `arbitrary-uid-smoke.sh` only checks startup as an arbitrary UID, it never
loads a model. So a future change to the classifier backend selection, or to the
Dockerfile shipping/linking of `libtensorflowlite_c`, could silently reintroduce the
exact regression #3864 fixed for arm64, with no CI signal.

The classifier-selection side is already unit-tested (`TestCustomBirdNETV24ModelInfo`
maps `.tflite` -> TFLite, `TestUsesONNXBackend`, `TestRemapV24ToONNXOnARM64`). This adds
the dimension unit tests cannot cover: that the shipped `libtensorflowlite_c` actually
dlopens at runtime and a `birdnet.modelpath` `.tflite` routes to the TFLite backend end
to end inside the real image.

## How

`Docker/test/custom-tflite-smoke.sh` runs the built image with
`-e BIRDNET_MODELPATH=/models/BirdNET_GLOBAL_6K_V2.4_Model_FP32.tflite` (a stock
`.tflite` the amd64 image already ships, so no extra CI asset), then polls `docker logs`
for `BirdNET model initialized model=<path>` (the TFLite init line; the ONNX path logs
`ONNX model initialized`, so the marker discriminates the backend). It fails on the
`notflite` hard-fail, an ONNX-misrouted `.tflite`, a model-init failure, or a startup
abort. The step reuses the `birdnet-go:test` image the job already builds, so it adds no
second build.

Loading via `BIRDNET_MODELPATH` exercises the same Tier-3 custom-model path a real
user's file takes: `customBirdNETV24ModelInfo` marks it `IsStock=false`, sets
`Backend=TFLite` from the extension, and `initializeTFLiteModel` loads it from the path.
The `birdnet` log module mirrors model-init to the console
(`logging.modules.birdnet.console_also` defaults to true), so the marker reaches
`docker logs`.

## Validation

- No regression exists today (verified by tracing the selection chain, the existing unit
  tests, and a live run of the amd64 binary with a custom `.tflite`: it loads via
  TFLite+XNNPACK and runs inference).
- Script control flow validated against a mock `docker`: PASS -> exit 0; `notflite`
  hard-fail -> exit 1; `.tflite` misrouted to ONNX -> exit 1.
- `shellcheck` and `actionlint` clean.

## Notes

- Scoped to amd64. The arm64 image ships no `.tflite` in `/models`, so an arm64
  custom-`.tflite` guard needs an externally-mounted model (and arm64 CI runs are
  slower); left as a possible follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a Docker smoke test that verifies user-supplied custom `.tflite` models load and initialize correctly using the TFLite backend.
  * The test monitors container logs for success, detects startup/load failures, and flags incorrect backend routing (e.g., `.tflite` handled as ONNX).
  * Includes timeout handling and surfaces relevant container log output on completion.

* **Bug Fixes**
  * Improved validation coverage for amd64 container model-loading behavior, ensuring failures are caught reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->