### PR TITLE
fix(diagnostics): tolerate non-finite floats in health report JSON

### DIFF
--- a/internal/health/json.go
+++ b/internal/health/json.go
@@ -2,23 +2,27 @@
 package health
 
 import (
+	"encoding"
 	"encoding/json"
+	"fmt"
 	"math"
 	"reflect"
+	"strconv"
+	"strings"
 )
 
-// MarshalJSON implements json.Marshaler for DiagnosticsReport. It replaces any
-// non-finite float (NaN, +Inf, -Inf) produced by a health check with JSON null
-// (or 0 for the always-present duration fields) before encoding.
+// MarshalJSON implements json.Marshaler for DiagnosticsReport. It zeroes the
+// always-present duration field when it is non-finite (NaN, +Inf, -Inf) and
+// relies on Result.MarshalJSON to sanitize each check's nested values.
 //
 // encoding/json returns an "unsupported value" error for non-finite floats, so
-// without this a single check emitting a non-finite metric — e.g. a rate or
-// percentage computed against a zero denominator — makes the whole response
+// without this a single check emitting a non-finite metric (e.g. a rate or
+// percentage computed against a zero denominator) makes the whole response
 // fail to encode. The System Health page then shows "Failed to load
 // diagnostics" instead of the report. Sanitizing at the serialization boundary
 // keeps one bad metric from taking down the entire diagnostics payload,
 // regardless of which check produced it.
-func (r DiagnosticsReport) MarshalJSON() ([]byte, error) {
+func (r DiagnosticsReport) MarshalJSON() ([]byte, error) { //nolint:gocritic // hugeParam: json.Marshaler requires a value receiver so json.Marshal invokes it when a value (not pointer) is passed
 	type alias DiagnosticsReport // sheds MarshalJSON to avoid infinite recursion
 	clone := alias(r)
 	clone.DurationMS = finiteOrZero(clone.DurationMS)
@@ -26,12 +30,24 @@ func (r DiagnosticsReport) MarshalJSON() ([]byte, error) {
 	return json.Marshal(clone)
 }
 
-// MarshalJSON implements json.Marshaler for Result, sanitizing its duration and
-// any non-finite floats nested in Details. See DiagnosticsReport.MarshalJSON.
-func (r Result) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements json.Marshaler for Result. It zeroes a non-finite
+// duration and, only when the check actually emitted a non-finite float
+// somewhere in Details, sanitizes Details so the payload still encodes. See
+// DiagnosticsReport.MarshalJSON.
+func (r Result) MarshalJSON() ([]byte, error) { //nolint:gocritic // hugeParam: json.Marshaler requires a value receiver so json.Marshal invokes it when a value (not pointer) is passed
 	type alias Result // sheds MarshalJSON to avoid infinite recursion
 	clone := alias(r)
 	clone.DurationMS = finiteOrZero(clone.DurationMS)
+
+	// Fast path: the overwhelmingly common case is an all-finite report, which
+	// marshals cleanly and byte-for-byte identically to the unsanitized struct.
+	if b, err := json.Marshal(clone); err == nil {
+		return b, nil
+	}
+
+	// Slow path: a non-finite float is nested somewhere in Details. Replace the
+	// offending values with null and retry. sanitizeValue only descends into
+	// subtrees that fail to marshal, so finite data is preserved verbatim.
 	if clone.Details != nil {
 		clone.Details = sanitizeMap(clone.Details)
 	}
@@ -48,35 +64,38 @@ func finiteOrZero(f float64) float64 {
 	return f
 }
 
-// sanitizeValue returns a JSON-safe copy of v with every non-finite float
-// (NaN, +Inf, -Inf) replaced by nil. Scalars take a fast path; slices, arrays,
-// and maps are walked generically via reflection. Reflection is required
-// because Go slices/maps are not covariant, so a type switch would miss the
-// nested shapes health checks can produce (e.g. []map[string]any or
-// map[string]float64), letting a non-finite float slip through and break
-// encoding/json. Any other value (structs, etc.) is returned unchanged.
+// sanitizeMap applies sanitizeValue to every value in m, returning a new map so
+// the caller's Details are not mutated.
+func sanitizeMap(m map[string]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = sanitizeValue(v)
+	}
+	return out
+}
+
+// sanitizeValue returns a JSON-safe copy of v in which every non-finite float
+// (NaN, +Inf, -Inf) has been replaced by nil. Any value that already marshals
+// cleanly is returned unchanged, so sanitizeValue only descends into the
+// subtrees that actually contain a non-finite float. Slices, arrays, maps, and
+// structs are walked generically (structs field-by-field, honoring json tags)
+// because Go's type system would let a non-finite float nested in a typed
+// container or a struct field slip past a plain type switch. Anything that
+// still cannot be represented is replaced by nil so the surrounding payload
+// encodes.
 func sanitizeValue(v any) any {
-	switch x := v.(type) {
-	case nil:
+	if v == nil {
 		return nil
-	case float64:
-		if math.IsNaN(x) || math.IsInf(x, 0) {
-			return nil
-		}
-		return x
-	case float32:
-		if f := float64(x); math.IsNaN(f) || math.IsInf(f, 0) {
-			return nil
-		}
-		return x
-	case string, bool,
-		int, int8, int16, int32, int64,
-		uint, uint8, uint16, uint32, uint64:
+	}
+	if _, err := json.Marshal(v); err == nil {
 		return v
 	}
 
 	rv := reflect.ValueOf(v)
 	switch rv.Kind() {
+	case reflect.Float32, reflect.Float64:
+		// A lone float only fails to marshal when it is non-finite.
+		return nil
 	case reflect.Slice, reflect.Array:
 		out := make([]any, rv.Len())
 		for i := range out {
@@ -87,28 +106,140 @@ func sanitizeValue(v any) any {
 		out := make(map[string]any, rv.Len())
 		iter := rv.MapRange()
 		for iter.Next() {
-			// JSON object keys are strings; skip any non-string-keyed map.
-			if k := iter.Key(); k.Kind() == reflect.String {
-				out[k.String()] = sanitizeValue(iter.Value().Interface())
-			}
+			out[mapKeyString(iter.Key())] = sanitizeValue(iter.Value().Interface())
 		}
 		return out
-	case reflect.Pointer:
+	case reflect.Pointer, reflect.Interface:
 		if rv.IsNil() {
 			return nil
 		}
 		return sanitizeValue(rv.Elem().Interface())
+	case reflect.Struct:
+		return sanitizeStruct(rv)
 	default:
-		return v
+		// Channels, funcs, complex numbers, etc. are not JSON-representable;
+		// drop them rather than fail the whole payload.
+		return nil
 	}
 }
 
-// sanitizeMap applies sanitizeValue to every value in m, returning a new map so
-// the caller's Details are not mutated.
-func sanitizeMap(m map[string]any) map[string]any {
-	out := make(map[string]any, len(m))
-	for k, v := range m {
-		out[k] = sanitizeValue(v)
+// mapKeyString renders a map key the way encoding/json would, so sanitized maps
+// keep their keys instead of silently dropping non-string-keyed entries.
+func mapKeyString(k reflect.Value) string {
+	if k.Kind() == reflect.String {
+		return k.String()
 	}
+	if tm, ok := reflect.TypeAssert[encoding.TextMarshaler](k); ok {
+		if b, err := tm.MarshalText(); err == nil {
+			return string(b)
+		}
+	}
+	switch k.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return strconv.FormatInt(k.Int(), 10)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return strconv.FormatUint(k.Uint(), 10)
+	default:
+		return fmt.Sprint(k.Interface())
+	}
+}
+
+// sanitizeStruct walks a struct value field-by-field, producing a map keyed by
+// each exported field's JSON name with sanitized values. It mirrors
+// encoding/json's tag handling (name override, "-" to skip, omitempty, and
+// promotion of anonymous struct fields) closely enough that the sanitized
+// object keeps the shape consumers expect. It is only reached when a struct
+// actually contains a non-finite float, since clean structs are returned
+// verbatim by sanitizeValue.
+func sanitizeStruct(rv reflect.Value) map[string]any {
+	out := make(map[string]any)
+	addStructFields(out, rv)
 	return out
+}
+
+// addStructFields adds rv's exported fields to out, recursing into anonymous
+// struct fields so their fields are promoted like encoding/json does.
+func addStructFields(out map[string]any, rv reflect.Value) {
+	for f, fv := range rv.Fields() {
+		if !f.IsExported() {
+			continue
+		}
+		tag := f.Tag.Get("json")
+		if tag == "-" {
+			continue
+		}
+
+		// Promote anonymous struct fields that have no explicit JSON name.
+		if f.Anonymous && !hasExplicitJSONName(tag) {
+			ev := fv
+			if ev.Kind() == reflect.Pointer {
+				if ev.IsNil() {
+					continue
+				}
+				ev = ev.Elem()
+			}
+			if ev.Kind() == reflect.Struct {
+				addStructFields(out, ev)
+				continue
+			}
+		}
+
+		name, omitempty := parseJSONFieldTag(tag, f.Name)
+		if omitempty && isEmptyValue(fv) {
+			continue
+		}
+		out[name] = sanitizeValue(fv.Interface())
+	}
+}
+
+// hasExplicitJSONName reports whether a json struct tag sets an explicit field
+// name (e.g. `json:"foo"` or `json:"foo,omitempty"`, but not `json:",omitempty"`).
+func hasExplicitJSONName(tag string) bool {
+	if tag == "" {
+		return false
+	}
+	name, _, _ := strings.Cut(tag, ",")
+	return name != ""
+}
+
+// parseJSONFieldTag returns the JSON name and omitempty flag for a struct field,
+// defaulting to fieldName when the tag does not override the name.
+func parseJSONFieldTag(tag, fieldName string) (name string, omitempty bool) {
+	name = fieldName
+	if tag == "" {
+		return name, false
+	}
+	first, rest, _ := strings.Cut(tag, ",")
+	if first != "" {
+		name = first
+	}
+	for rest != "" {
+		var opt string
+		opt, rest, _ = strings.Cut(rest, ",")
+		if opt == "omitempty" {
+			omitempty = true
+		}
+	}
+	return name, omitempty
+}
+
+// isEmptyValue reports whether v is empty using the same definition
+// encoding/json applies for the omitempty option.
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Pointer:
+		return v.IsNil()
+	default:
+		return false
+	}
 }

--- a/internal/health/json.go
+++ b/internal/health/json.go
@@ -1,0 +1,99 @@
+// internal/health/json.go
+package health
+
+import (
+	"encoding/json"
+	"math"
+)
+
+// MarshalJSON implements json.Marshaler for DiagnosticsReport. It replaces any
+// non-finite float (NaN, +Inf, -Inf) produced by a health check with JSON null
+// (or 0 for the always-present duration fields) before encoding.
+//
+// encoding/json returns an "unsupported value" error for non-finite floats, so
+// without this a single check emitting a non-finite metric — e.g. a rate or
+// percentage computed against a zero denominator — makes the whole response
+// fail to encode. The System Health page then shows "Failed to load
+// diagnostics" instead of the report. Sanitizing at the serialization boundary
+// keeps one bad metric from taking down the entire diagnostics payload,
+// regardless of which check produced it.
+func (r DiagnosticsReport) MarshalJSON() ([]byte, error) {
+	type alias DiagnosticsReport // sheds MarshalJSON to avoid infinite recursion
+	clone := alias(r)
+	clone.DurationMS = finiteOrZero(clone.DurationMS)
+	// Results are []Result and are sanitized by Result.MarshalJSON during encoding.
+	return json.Marshal(clone)
+}
+
+// MarshalJSON implements json.Marshaler for Result, sanitizing its duration and
+// any non-finite floats nested in Details. See DiagnosticsReport.MarshalJSON.
+func (r Result) MarshalJSON() ([]byte, error) {
+	type alias Result // sheds MarshalJSON to avoid infinite recursion
+	clone := alias(r)
+	clone.DurationMS = finiteOrZero(clone.DurationMS)
+	if clone.Details != nil {
+		clone.Details = sanitizeMap(clone.Details)
+	}
+	return json.Marshal(clone)
+}
+
+// finiteOrZero returns f, or 0 when f is NaN or infinite. Used for numeric
+// fields that are always present in the JSON schema (durations), where a null
+// would change the field's type for consumers.
+func finiteOrZero(f float64) float64 {
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return 0
+	}
+	return f
+}
+
+// sanitizeValue returns a JSON-safe copy of v with every non-finite float
+// (NaN, +Inf, -Inf) replaced by nil. Health-check Details hold primitives,
+// float slices, and nested maps/slices; those shapes are walked recursively and
+// any other value is returned unchanged.
+func sanitizeValue(v any) any {
+	switch x := v.(type) {
+	case float64:
+		if math.IsNaN(x) || math.IsInf(x, 0) {
+			return nil
+		}
+		return x
+	case float32:
+		if f := float64(x); math.IsNaN(f) || math.IsInf(f, 0) {
+			return nil
+		}
+		return x
+	case []any:
+		out := make([]any, len(x))
+		for i, e := range x {
+			out[i] = sanitizeValue(e)
+		}
+		return out
+	case []float64:
+		out := make([]any, len(x))
+		for i, e := range x {
+			out[i] = sanitizeValue(e)
+		}
+		return out
+	case []float32:
+		out := make([]any, len(x))
+		for i, e := range x {
+			out[i] = sanitizeValue(e)
+		}
+		return out
+	case map[string]any:
+		return sanitizeMap(x)
+	default:
+		return v
+	}
+}
+
+// sanitizeMap applies sanitizeValue to every value in m, returning a new map so
+// the caller's Details are not mutated.
+func sanitizeMap(m map[string]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = sanitizeValue(v)
+	}
+	return out
+}

--- a/internal/health/json.go
+++ b/internal/health/json.go
@@ -4,6 +4,7 @@ package health
 import (
 	"encoding/json"
 	"math"
+	"reflect"
 )
 
 // MarshalJSON implements json.Marshaler for DiagnosticsReport. It replaces any
@@ -48,11 +49,16 @@ func finiteOrZero(f float64) float64 {
 }
 
 // sanitizeValue returns a JSON-safe copy of v with every non-finite float
-// (NaN, +Inf, -Inf) replaced by nil. Health-check Details hold primitives,
-// float slices, and nested maps/slices; those shapes are walked recursively and
-// any other value is returned unchanged.
+// (NaN, +Inf, -Inf) replaced by nil. Scalars take a fast path; slices, arrays,
+// and maps are walked generically via reflection. Reflection is required
+// because Go slices/maps are not covariant, so a type switch would miss the
+// nested shapes health checks can produce (e.g. []map[string]any or
+// map[string]float64), letting a non-finite float slip through and break
+// encoding/json. Any other value (structs, etc.) is returned unchanged.
 func sanitizeValue(v any) any {
 	switch x := v.(type) {
+	case nil:
+		return nil
 	case float64:
 		if math.IsNaN(x) || math.IsInf(x, 0) {
 			return nil
@@ -63,26 +69,35 @@ func sanitizeValue(v any) any {
 			return nil
 		}
 		return x
-	case []any:
-		out := make([]any, len(x))
-		for i, e := range x {
-			out[i] = sanitizeValue(e)
+	case string, bool,
+		int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64:
+		return v
+	}
+
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Slice, reflect.Array:
+		out := make([]any, rv.Len())
+		for i := range out {
+			out[i] = sanitizeValue(rv.Index(i).Interface())
 		}
 		return out
-	case []float64:
-		out := make([]any, len(x))
-		for i, e := range x {
-			out[i] = sanitizeValue(e)
+	case reflect.Map:
+		out := make(map[string]any, rv.Len())
+		iter := rv.MapRange()
+		for iter.Next() {
+			// JSON object keys are strings; skip any non-string-keyed map.
+			if k := iter.Key(); k.Kind() == reflect.String {
+				out[k.String()] = sanitizeValue(iter.Value().Interface())
+			}
 		}
 		return out
-	case []float32:
-		out := make([]any, len(x))
-		for i, e := range x {
-			out[i] = sanitizeValue(e)
+	case reflect.Pointer:
+		if rv.IsNil() {
+			return nil
 		}
-		return out
-	case map[string]any:
-		return sanitizeMap(x)
+		return sanitizeValue(rv.Elem().Interface())
 	default:
 		return v
 	}

--- a/internal/health/json_test.go
+++ b/internal/health/json_test.go
@@ -53,33 +53,33 @@ func TestDiagnosticsReportMarshalJSON_NonFinite(t *testing.T) {
 	var back map[string]any
 	require.NoError(t, json.Unmarshal(b, &back))
 
-	assert.Equal(t, 0.0, back["duration_ms"])
+	assert.InDelta(t, 0.0, back["duration_ms"], 0)
 
 	results, ok := back["results"].([]any)
 	require.True(t, ok)
 	require.Len(t, results, 1)
 	res0, ok := results[0].(map[string]any)
 	require.True(t, ok)
-	assert.Equal(t, 0.0, res0["duration_ms"])
+	assert.InDelta(t, 0.0, res0["duration_ms"], 0)
 
 	details, ok := res0["details"].(map[string]any)
 	require.True(t, ok)
 
 	assert.Nil(t, details["percent"])
-	assert.Equal(t, 42.0, details["finite"])
+	assert.InDelta(t, 42.0, details["finite"], 0)
 	assert.Equal(t, "cpu0", details["label"])
 
 	perCore, ok := details["per_core_percent"].([]any)
 	require.True(t, ok)
 	require.Len(t, perCore, 3)
-	assert.Equal(t, 12.5, perCore[0])
+	assert.InDelta(t, 12.5, perCore[0], 0)
 	assert.Nil(t, perCore[1])
-	assert.Equal(t, 30.0, perCore[2])
+	assert.InDelta(t, 30.0, perCore[2], 0)
 
 	nested, ok := details["nested"].(map[string]any)
 	require.True(t, ok)
 	assert.Nil(t, nested["rate"])
-	assert.Equal(t, 3.0, nested["ok"])
+	assert.InDelta(t, 3.0, nested["ok"], 0)
 
 	sliceOfMaps, ok := details["slice_of_maps"].([]any)
 	require.True(t, ok)
@@ -91,6 +91,125 @@ func TestDiagnosticsReportMarshalJSON_NonFinite(t *testing.T) {
 	typedMap, ok := details["typed_map"].(map[string]any)
 	require.True(t, ok)
 	assert.Nil(t, typedMap["val"])
+}
+
+// sampleErrorGroup mirrors the shape checks store under details["top_errors"]:
+// a struct slice whose SampleFields carries arbitrary log-field values. A
+// non-finite float nested inside a struct field must not defeat serialization,
+// and a json.Marshaler field (time.Time) must survive unchanged.
+type sampleErrorGroup struct {
+	Component    string         `json:"component,omitempty"`
+	Message      string         `json:"message"`
+	Count        int            `json:"count"`
+	When         time.Time      `json:"when"`
+	SampleFields map[string]any `json:"sample_fields,omitempty"`
+	Internal     string         `json:"-"`
+	unexported   int
+}
+
+// TestResultMarshalJSON_NonFiniteInStruct verifies that a non-finite float
+// nested inside a struct value in Details (e.g. top_errors[].sample_fields)
+// does not break encoding, that the struct's other fields (including a
+// time.Time) are preserved, and that omitempty and json:"-" tags are honored.
+func TestResultMarshalJSON_NonFiniteInStruct(t *testing.T) {
+	t.Parallel()
+
+	when := time.Date(2026, 7, 12, 8, 30, 0, 0, time.UTC)
+	group := sampleErrorGroup{
+		Message: "boom",
+		Count:   2,
+		When:    when,
+		SampleFields: map[string]any{
+			"rate": math.Inf(1),
+			"ok":   7,
+		},
+		Internal:   "should-be-dropped",
+		unexported: 99,
+	}
+	// Reference the unexported field so it is not reported as unused; the
+	// sanitizer must still skip it (reflect would panic on Interface() otherwise).
+	require.Equal(t, 99, group.unexported)
+
+	r := Result{
+		Name:     "recent_errors",
+		Category: CategoryLogs,
+		Status:   StatusWarning,
+		Details: map[string]any{
+			"top_errors": []sampleErrorGroup{group},
+		},
+		Timestamp: time.Unix(0, 0).UTC(),
+	}
+
+	b, err := json.Marshal(r)
+	require.NoError(t, err)
+	for _, bad := range []string{"Inf", "inf", "NaN", "should-be-dropped"} {
+		assert.NotContains(t, string(b), bad)
+	}
+
+	var back map[string]any
+	require.NoError(t, json.Unmarshal(b, &back))
+	details, ok := back["details"].(map[string]any)
+	require.True(t, ok)
+	topErrors, ok := details["top_errors"].([]any)
+	require.True(t, ok)
+	require.Len(t, topErrors, 1)
+	got, ok := topErrors[0].(map[string]any)
+	require.True(t, ok)
+
+	assert.Equal(t, "boom", got["message"])
+	assert.InDelta(t, 2.0, got["count"], 0)
+	// time.Time survives as its RFC3339 string, not walked into a struct.
+	assert.Equal(t, when.Format(time.RFC3339Nano), got["when"])
+	// omitempty empty field and json:"-" field are absent.
+	assert.NotContains(t, got, "component")
+	assert.NotContains(t, got, "Internal")
+
+	fields, ok := got["sample_fields"].(map[string]any)
+	require.True(t, ok)
+	assert.Nil(t, fields["rate"])
+	assert.InDelta(t, 7.0, fields["ok"], 0)
+}
+
+// TestSanitizeValue_IntKeyedMapPreserved verifies that a non-string-keyed map is
+// re-keyed (not silently dropped) when it has to be sanitized.
+func TestSanitizeValue_IntKeyedMapPreserved(t *testing.T) {
+	t.Parallel()
+
+	in := map[int]any{1: math.Inf(1), 2: 5.0}
+	out, ok := sanitizeValue(in).(map[string]any)
+	require.True(t, ok)
+	require.Len(t, out, 2)
+	assert.Nil(t, out["1"])
+	assert.InDelta(t, 5.0, out["2"], 0)
+}
+
+// TestResultMarshalJSON_FiniteFastPath verifies that an all-finite result is
+// emitted byte-for-byte identically to the plain (unsanitized) struct, so the
+// sanitizer is transparent on the common path.
+func TestResultMarshalJSON_FiniteFastPath(t *testing.T) {
+	t.Parallel()
+
+	r := Result{
+		Name:     "cpu",
+		Category: CategorySystem,
+		Status:   StatusHealthy,
+		Details: map[string]any{
+			"percent":          12.5,
+			"per_core_percent": []float64{10.0, 20.0},
+			"count":            3,
+		},
+		DurationMS: 1.25,
+		Timestamp:  time.Unix(0, 0).UTC(),
+	}
+
+	got, err := json.Marshal(r)
+	require.NoError(t, err)
+
+	type alias Result
+	want, err := json.Marshal(alias(r))
+	require.NoError(t, err)
+
+	assert.JSONEq(t, string(want), string(got))
 }
 
 // TestSanitizeValue_FiniteUnchanged confirms sanitizeValue leaves finite and

--- a/internal/health/json_test.go
+++ b/internal/health/json_test.go
@@ -4,16 +4,22 @@ package health
 import (
 	"encoding/json"
 	"math"
-	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestDiagnosticsReportMarshalJSON_NonFinite verifies that a report containing
 // non-finite floats (which encoding/json rejects) still marshals to valid JSON,
 // with the offending values replaced by null (or 0 for duration fields) and
-// finite values left intact.
+// finite values left intact. Nested typed containers (e.g. []map[string]any and
+// map[string]float64) must be sanitized too, since Go's type system would let
+// them bypass a plain type switch.
 func TestDiagnosticsReportMarshalJSON_NonFinite(t *testing.T) {
+	t.Parallel()
+
 	r := DiagnosticsReport{
 		ID:         "test",
 		DurationMS: math.Inf(1),
@@ -26,6 +32,8 @@ func TestDiagnosticsReportMarshalJSON_NonFinite(t *testing.T) {
 				"percent":          math.Inf(1),
 				"per_core_percent": []float64{12.5, math.Inf(-1), 30.0},
 				"nested":           map[string]any{"rate": math.NaN(), "ok": 3},
+				"slice_of_maps":    []map[string]any{{"val": math.NaN()}},
+				"typed_map":        map[string]float64{"val": math.Inf(1)},
 				"finite":           42.0,
 				"label":            "cpu0",
 			},
@@ -34,60 +42,76 @@ func TestDiagnosticsReportMarshalJSON_NonFinite(t *testing.T) {
 	}
 
 	b, err := json.Marshal(r)
-	if err != nil {
-		t.Fatalf("marshal returned error: %v", err)
-	}
+	require.NoError(t, err)
 
 	// No non-finite tokens leak into the output.
 	for _, bad := range []string{"Inf", "inf", "NaN"} {
-		if strings.Contains(string(b), bad) {
-			t.Errorf("output contains %q: %s", bad, b)
-		}
+		assert.NotContains(t, string(b), bad)
 	}
 
 	// Output round-trips as valid JSON.
 	var back map[string]any
-	if err := json.Unmarshal(b, &back); err != nil {
-		t.Fatalf("output is not valid JSON: %v", err)
-	}
+	require.NoError(t, json.Unmarshal(b, &back))
 
-	if back["duration_ms"] != 0.0 {
-		t.Errorf("report duration_ms = %v, want 0", back["duration_ms"])
-	}
+	assert.Equal(t, 0.0, back["duration_ms"])
 
-	res0 := back["results"].([]any)[0].(map[string]any)
-	if res0["duration_ms"] != 0.0 {
-		t.Errorf("result duration_ms = %v, want 0", res0["duration_ms"])
-	}
+	results, ok := back["results"].([]any)
+	require.True(t, ok)
+	require.Len(t, results, 1)
+	res0, ok := results[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, 0.0, res0["duration_ms"])
 
-	details := res0["details"].(map[string]any)
-	if details["percent"] != nil {
-		t.Errorf("percent = %v, want null", details["percent"])
-	}
-	if details["finite"] != 42.0 {
-		t.Errorf("finite = %v, want 42", details["finite"])
-	}
-	if details["label"] != "cpu0" {
-		t.Errorf("label = %v, want cpu0", details["label"])
-	}
-	if got := details["per_core_percent"].([]any); got[0] != 12.5 || got[1] != nil || got[2] != 30.0 {
-		t.Errorf("per_core_percent = %v, want [12.5, null, 30]", got)
-	}
-	if nested := details["nested"].(map[string]any); nested["rate"] != nil || nested["ok"] != 3.0 {
-		t.Errorf("nested = %v, want {rate:null, ok:3}", nested)
-	}
+	details, ok := res0["details"].(map[string]any)
+	require.True(t, ok)
+
+	assert.Nil(t, details["percent"])
+	assert.Equal(t, 42.0, details["finite"])
+	assert.Equal(t, "cpu0", details["label"])
+
+	perCore, ok := details["per_core_percent"].([]any)
+	require.True(t, ok)
+	require.Len(t, perCore, 3)
+	assert.Equal(t, 12.5, perCore[0])
+	assert.Nil(t, perCore[1])
+	assert.Equal(t, 30.0, perCore[2])
+
+	nested, ok := details["nested"].(map[string]any)
+	require.True(t, ok)
+	assert.Nil(t, nested["rate"])
+	assert.Equal(t, 3.0, nested["ok"])
+
+	sliceOfMaps, ok := details["slice_of_maps"].([]any)
+	require.True(t, ok)
+	require.Len(t, sliceOfMaps, 1)
+	firstMap, ok := sliceOfMaps[0].(map[string]any)
+	require.True(t, ok)
+	assert.Nil(t, firstMap["val"])
+
+	typedMap, ok := details["typed_map"].(map[string]any)
+	require.True(t, ok)
+	assert.Nil(t, typedMap["val"])
 }
 
 // TestSanitizeValue_FiniteUnchanged confirms sanitizeValue leaves finite and
 // non-float values untouched.
 func TestSanitizeValue_FiniteUnchanged(t *testing.T) {
-	if got := sanitizeValue(3.14); got != 3.14 {
-		t.Errorf("finite float changed: %v", got)
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input any
+		want  any
+	}{
+		{"finite_float", 3.14, 3.14},
+		{"string", "x", "x"},
+		{"int", 7, 7},
 	}
-	if got := sanitizeValue("x"); got != "x" {
-		t.Errorf("string changed: %v", got)
-	}
-	if got := sanitizeValue(7); got != 7 {
-		t.Errorf("int changed: %v", got)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, sanitizeValue(tc.input), "value should be unchanged")
+		})
 	}
 }

--- a/internal/health/json_test.go
+++ b/internal/health/json_test.go
@@ -1,0 +1,93 @@
+// internal/health/json_test.go
+package health
+
+import (
+	"encoding/json"
+	"math"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestDiagnosticsReportMarshalJSON_NonFinite verifies that a report containing
+// non-finite floats (which encoding/json rejects) still marshals to valid JSON,
+// with the offending values replaced by null (or 0 for duration fields) and
+// finite values left intact.
+func TestDiagnosticsReportMarshalJSON_NonFinite(t *testing.T) {
+	r := DiagnosticsReport{
+		ID:         "test",
+		DurationMS: math.Inf(1),
+		Results: []Result{{
+			Name:       "cpu",
+			Category:   CategorySystem,
+			Status:     StatusWarning,
+			DurationMS: math.NaN(),
+			Details: map[string]any{
+				"percent":          math.Inf(1),
+				"per_core_percent": []float64{12.5, math.Inf(-1), 30.0},
+				"nested":           map[string]any{"rate": math.NaN(), "ok": 3},
+				"finite":           42.0,
+				"label":            "cpu0",
+			},
+			Timestamp: time.Unix(0, 0).UTC(),
+		}},
+	}
+
+	b, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal returned error: %v", err)
+	}
+
+	// No non-finite tokens leak into the output.
+	for _, bad := range []string{"Inf", "inf", "NaN"} {
+		if strings.Contains(string(b), bad) {
+			t.Errorf("output contains %q: %s", bad, b)
+		}
+	}
+
+	// Output round-trips as valid JSON.
+	var back map[string]any
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+
+	if back["duration_ms"] != 0.0 {
+		t.Errorf("report duration_ms = %v, want 0", back["duration_ms"])
+	}
+
+	res0 := back["results"].([]any)[0].(map[string]any)
+	if res0["duration_ms"] != 0.0 {
+		t.Errorf("result duration_ms = %v, want 0", res0["duration_ms"])
+	}
+
+	details := res0["details"].(map[string]any)
+	if details["percent"] != nil {
+		t.Errorf("percent = %v, want null", details["percent"])
+	}
+	if details["finite"] != 42.0 {
+		t.Errorf("finite = %v, want 42", details["finite"])
+	}
+	if details["label"] != "cpu0" {
+		t.Errorf("label = %v, want cpu0", details["label"])
+	}
+	if got := details["per_core_percent"].([]any); got[0] != 12.5 || got[1] != nil || got[2] != 30.0 {
+		t.Errorf("per_core_percent = %v, want [12.5, null, 30]", got)
+	}
+	if nested := details["nested"].(map[string]any); nested["rate"] != nil || nested["ok"] != 3.0 {
+		t.Errorf("nested = %v, want {rate:null, ok:3}", nested)
+	}
+}
+
+// TestSanitizeValue_FiniteUnchanged confirms sanitizeValue leaves finite and
+// non-float values untouched.
+func TestSanitizeValue_FiniteUnchanged(t *testing.T) {
+	if got := sanitizeValue(3.14); got != 3.14 {
+		t.Errorf("finite float changed: %v", got)
+	}
+	if got := sanitizeValue("x"); got != "x" {
+		t.Errorf("string changed: %v", got)
+	}
+	if got := sanitizeValue(7); got != 7 {
+		t.Errorf("int changed: %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

The **System Health** page intermittently shows **"Failed to load diagnostics"**
and then recovers on its own a few minutes later.

Root cause: `RunDiagnostics` serializes the health report with `ctx.JSON`
(`encoding/json`), which returns an `unsupported value` error for non-finite
floats (`NaN`, `+Inf`, `-Inf`). The report aggregates every check's
`Details map[string]any`, so a **single** check emitting a non-finite metric —
e.g. a rate or percentage computed against a momentarily-zero denominator —
makes the *entire* `POST /api/v2/system/diagnostics/run` response fail to
encode. Observed in production as repeated:

```
uri="/api/v2/system/diagnostics/run" status=200 error="json: unsupported value: +Inf"
```

Most checks already guard their divisions, but the failure mode is systemic:
any one unguarded (or future) metric takes down the whole payload. This fixes it
at the serialization boundary so it is robust regardless of which check is at
fault.

## Changes

- Add `MarshalJSON` to `DiagnosticsReport` and `Result` (`internal/health/json.go`)
  that replaces non-finite floats with JSON `null` (and `0` for the
  always-present `duration_ms` fields), walking values nested in each check's
  `Details` map, `[]any`, and float slices.
- Unit tests in `internal/health/json_test.go` covering scalars, nested maps,
  float slices, the duration fields, and that finite/non-float values are
  untouched.

No check logic changes; finite output is byte-for-byte unchanged.

## Testing

- [x] Go tests pass (`go test ./internal/health/` — new and existing)
- [x] `gofmt` clean
- [ ] Frontend tests pass (n/a — backend only)
- [x] Manual reasoning verified against the production log above
- [ ] Preflight quality gate passed (run `/preflight` before pushing)

## Prior art / why not reuse an existing helper

- #801 (merged) fixed the same class of bug — non-finite floats reaching JSON —
  for the sound-level subsystem (`myaudio/soundlevel.go`). This PR covers the
  diagnostics/health-report path, which #801 did not touch.
- There is no shared JSON float-sanitizer to reuse. `analysis.sanitizeFloat64`
  is package-private and substitutes a domain-specific dB default (−100.0),
  which is meaningless for heterogeneous diagnostics metrics (percent, latency,
  rate). Hence JSON `null` = "unknown" here.
- #3189 (merged) reworked health checks/frontend but did not add report
  serialization hardening.

## Related Issues

_No open issue/PR describes "Failed to load diagnostics"; standalone fix._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved health-check diagnostics JSON serialization when measurements contain `NaN` or infinite values.
  - Health-check payloads no longer fail to serialize; non-finite floats in nested details are now emitted as `null`.
  - Duration-related numeric fields now default to `0` for non-finite values.
  - Finite values, `time` fields, and existing JSON shape/field-tag behavior are preserved, including map entries.
  - Added unit tests to prevent regressions in JSON sanitization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->