### PR TITLE
fix(birdweather): guard soundscape gain against silent-clip +Inf

### DIFF
--- a/internal/birdweather/birdweather_client.go
+++ b/internal/birdweather/birdweather_client.go
@@ -557,7 +557,7 @@ func (b *BwClient) encodeFlacUsingFFmpeg(ctx context.Context, pcmData []byte, ff
 
 	// --- Calculate gain needed to reach target loudness ---
 	inputLUFS := parseDouble(loudnessStats.InputI, -70.0)
-	gainNeeded := targetIntegratedLoudnessLUFS - inputLUFS
+	gainNeeded := soundscapeGainDB(inputLUFS)
 
 	// Apply safety limits to prevent excessive amplification or attenuation
 	maxGain := 30.0 // Maximum gain in dB (absolute value)
@@ -623,6 +623,23 @@ func parseDouble(s string, defaultValue float64) float64 {
 		return defaultValue
 	}
 	return val
+}
+
+// soundscapeGainDB returns the gain (dB) needed to bring a clip whose measured
+// integrated loudness is inputLUFS to targetIntegratedLoudnessLUFS.
+//
+// ffmpeg's loudnorm analysis reports input_i as "-inf" for a silent clip, which
+// parseDouble turns into -Inf, making the raw gain +Inf. Amplifying silence
+// only lifts the noise floor, and the non-finite value is not JSON-encodable so
+// it corrupts the structured gain-limit log. A non-finite measurement therefore
+// yields 0 dB — leave the clip untouched — matching the native encoder path,
+// which returns GainDB 0 for silence (see encode_native.go).
+func soundscapeGainDB(inputLUFS float64) float64 {
+	gain := targetIntegratedLoudnessLUFS - inputLUFS
+	if math.IsInf(gain, 0) || math.IsNaN(gain) {
+		return 0
+	}
+	return gain
 }
 
 // UploadSoundscape uploads a soundscape file to the Birdweather API and returns the soundscape ID if successful.

--- a/internal/birdweather/birdweather_client.go
+++ b/internal/birdweather/birdweather_client.go
@@ -576,7 +576,7 @@ func (b *BwClient) encodeFlacUsingFFmpeg(ctx context.Context, pcmData []byte, ff
 	log.Debug("Calculated gain adjustment",
 		logger.Float64("gain_db", gainNeeded),
 		logger.Float64("target_lufs", targetIntegratedLoudnessLUFS),
-		logger.Float64("measured_lufs", inputLUFS),
+		logger.String("measured_lufs", logSafeLUFS(inputLUFS)),
 		logger.Bool("limited", gainLimited))
 
 	// --- Pass 2: Apply simple gain adjustment and encode ---
@@ -640,6 +640,24 @@ func soundscapeGainDB(inputLUFS float64) float64 {
 		return 0
 	}
 	return gain
+}
+
+// logSafeLUFS renders a measured loudness value for structured logging. ffmpeg
+// reports input_i as "-inf" for a silent clip, so the parsed measurement can be
+// non-finite, and slog's JSON handler cannot encode a non-finite float (it
+// substitutes an "!ERROR:json: unsupported value" string that corrupts the log
+// line). Render a non-finite measurement as its symbolic form instead.
+func logSafeLUFS(lufs float64) string {
+	switch {
+	case math.IsInf(lufs, -1):
+		return "-inf"
+	case math.IsInf(lufs, 1):
+		return "+inf"
+	case math.IsNaN(lufs):
+		return "nan"
+	default:
+		return strconv.FormatFloat(lufs, 'g', -1, 64)
+	}
 }
 
 // UploadSoundscape uploads a soundscape file to the Birdweather API and returns the soundscape ID if successful.

--- a/internal/birdweather/soundscape_gain_test.go
+++ b/internal/birdweather/soundscape_gain_test.go
@@ -4,12 +4,16 @@ package birdweather
 import (
 	"math"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // TestSoundscapeGainDB verifies that a non-finite loudness measurement (ffmpeg
 // reports input_i as "-inf" for a silent clip) yields a finite 0 dB gain
 // instead of +Inf, while finite measurements map to target - inputLUFS.
 func TestSoundscapeGainDB(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name  string
 		input float64
@@ -24,13 +28,12 @@ func TestSoundscapeGainDB(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := soundscapeGainDB(tt.input)
 			if math.IsNaN(got) || math.IsInf(got, 0) {
 				t.Fatalf("soundscapeGainDB(%v) returned non-finite %v", tt.input, got)
 			}
-			if got != tt.want {
-				t.Errorf("soundscapeGainDB(%v) = %v, want %v", tt.input, got, tt.want)
-			}
+			assert.Equal(t, tt.want, got, "soundscapeGainDB(%v) mismatch", tt.input)
 		})
 	}
 }

--- a/internal/birdweather/soundscape_gain_test.go
+++ b/internal/birdweather/soundscape_gain_test.go
@@ -14,6 +14,10 @@ import (
 func TestSoundscapeGainDB(t *testing.T) {
 	t.Parallel()
 
+	// gainTolerance is effectively exact: both sides compute the same
+	// deterministic subtraction, so any real regression exceeds this bound.
+	const gainTolerance = 1e-9
+
 	tests := []struct {
 		name  string
 		input float64
@@ -33,7 +37,34 @@ func TestSoundscapeGainDB(t *testing.T) {
 			if math.IsNaN(got) || math.IsInf(got, 0) {
 				t.Fatalf("soundscapeGainDB(%v) returned non-finite %v", tt.input, got)
 			}
-			assert.Equal(t, tt.want, got, "soundscapeGainDB(%v) mismatch", tt.input)
+			assert.InDelta(t, tt.want, got, gainTolerance, "soundscapeGainDB(%v) mismatch", tt.input)
+		})
+	}
+}
+
+// TestLogSafeLUFS verifies that a non-finite loudness measurement is rendered as
+// a plain symbolic string, so it can never reach slog's JSON handler as a
+// non-finite float (which would corrupt the log line with an "!ERROR:json"
+// substitution), while finite measurements render to their numeric form.
+func TestLogSafeLUFS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input float64
+		want  string
+	}{
+		{"silent clip (-inf)", math.Inf(-1), "-inf"},
+		{"positive inf", math.Inf(1), "+inf"},
+		{"nan", math.NaN(), "nan"},
+		{"finite negative", -23.4, "-23.4"},
+		{"finite zero", 0.0, "0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := logSafeLUFS(tt.input)
+			assert.Equal(t, tt.want, got, "logSafeLUFS(%v) mismatch", tt.input)
 		})
 	}
 }

--- a/internal/birdweather/soundscape_gain_test.go
+++ b/internal/birdweather/soundscape_gain_test.go
@@ -1,0 +1,36 @@
+// internal/birdweather/soundscape_gain_test.go
+package birdweather
+
+import (
+	"math"
+	"testing"
+)
+
+// TestSoundscapeGainDB verifies that a non-finite loudness measurement (ffmpeg
+// reports input_i as "-inf" for a silent clip) yields a finite 0 dB gain
+// instead of +Inf, while finite measurements map to target - inputLUFS.
+func TestSoundscapeGainDB(t *testing.T) {
+	tests := []struct {
+		name  string
+		input float64
+		want  float64
+	}{
+		{"silent clip (-inf) left untouched", math.Inf(-1), 0},
+		{"positive inf guarded", math.Inf(1), 0},
+		{"nan guarded", math.NaN(), 0},
+		{"quiet clip needs positive gain", -70.0, targetIntegratedLoudnessLUFS - (-70.0)},
+		{"already at target needs no gain", targetIntegratedLoudnessLUFS, 0},
+		{"loud clip needs negative gain", 0.0, targetIntegratedLoudnessLUFS},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := soundscapeGainDB(tt.input)
+			if math.IsNaN(got) || math.IsInf(got, 0) {
+				t.Fatalf("soundscapeGainDB(%v) returned non-finite %v", tt.input, got)
+			}
+			if got != tt.want {
+				t.Errorf("soundscapeGainDB(%v) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

When a soundscape clip is silent, ffmpeg's `loudnorm` analysis reports
`input_i` as `"-inf"`. `parseDouble` parses that to `-Inf`, so
`gainNeeded = targetIntegratedLoudnessLUFS - inputLUFS` becomes `+Inf`. That
value is then:

1. **logged** as `calculated_gain` — a non-finite float is not JSON-encodable,
   so the structured log records the literal
   `"calculated_gain":"!ERROR:json: unsupported value: +Inf"`; and
2. **clamped to +30 dB**, i.e. the silent clip is amplified, lifting its noise
   floor instead of being left alone.

The newer native-FLAC path already handles this correctly — its comment notes
*"Silence yields GainDB == 0 … so quiet clips stay quiet instead of being
boosted into noise"* (`encode_native.go`). This brings the legacy ffmpeg path in
line.

## Changes

- Extract the loudness→gain mapping into `soundscapeGainDB(inputLUFS float64)`
  (`internal/birdweather/birdweather_client.go`), returning `0` dB for a
  non-finite measurement (leave the clip untouched); the existing clamp/log
  block is unchanged and now always sees a finite value.
- Unit test `TestSoundscapeGainDB` (`internal/birdweather/soundscape_gain_test.go`)
  covering `-Inf`/`+Inf`/`NaN` inputs and the finite mappings.

## Testing

- [x] Go tests pass (`go test ./internal/birdweather/ -run TestSoundscapeGainDB`)
- [x] `gofmt` clean
- [ ] Frontend tests pass (n/a — backend only)
- [x] Full-package pre-existing failures (`TestUploadSoundscape`, `TestPublish`,
      `…MalformedUploadResponse…`) require an `ffmpeg` binary and fail
      identically on clean `main` — unrelated to this change
- [ ] Preflight quality gate passed (run `/preflight` before pushing)

## Prior art

- The native-encoder path already returns 0 dB for silence (#3502 / #3777,
  merged) — its comment: *"Silence yields GainDB == 0 … so quiet clips stay
  quiet."* This PR brings the legacy ffmpeg path in line with that.
- #3671 (merged) hardened this file's upload transport and FLAC encoding but did
  not touch the loudness→gain calculation, which is still unguarded on `main`.

## Related Issues

_No open issue/PR describes the silent-clip +Inf gain; standalone fix._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio loudness normalization by safely handling non-finite loudness readings, preventing invalid gain values.
  * Updated loudness reporting to log non-finite values safely (e.g., `nan`, `+inf`, `-inf`) instead of raw floating-point output.
* **Tests**
  * Added unit tests covering gain calculation for finite and non-finite loudness inputs and verifying safe loudness string formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->