### PR TITLE
fix(logger): render non-finite floats safely in structured logs

### DIFF
--- a/internal/birdweather/birdweather_client.go
+++ b/internal/birdweather/birdweather_client.go
@@ -576,7 +576,7 @@ func (b *BwClient) encodeFlacUsingFFmpeg(ctx context.Context, pcmData []byte, ff
 	log.Debug("Calculated gain adjustment",
 		logger.Float64("gain_db", gainNeeded),
 		logger.Float64("target_lufs", targetIntegratedLoudnessLUFS),
-		logger.String("measured_lufs", logSafeLUFS(inputLUFS)),
+		logger.Float64("measured_lufs", inputLUFS),
 		logger.Bool("limited", gainLimited))
 
 	// --- Pass 2: Apply simple gain adjustment and encode ---
@@ -640,24 +640,6 @@ func soundscapeGainDB(inputLUFS float64) float64 {
 		return 0
 	}
 	return gain
-}
-
-// logSafeLUFS renders a measured loudness value for structured logging. ffmpeg
-// reports input_i as "-inf" for a silent clip, so the parsed measurement can be
-// non-finite, and slog's JSON handler cannot encode a non-finite float (it
-// substitutes an "!ERROR:json: unsupported value" string that corrupts the log
-// line). Render a non-finite measurement as its symbolic form instead.
-func logSafeLUFS(lufs float64) string {
-	switch {
-	case math.IsInf(lufs, -1):
-		return "-inf"
-	case math.IsInf(lufs, 1):
-		return "+inf"
-	case math.IsNaN(lufs):
-		return "nan"
-	default:
-		return strconv.FormatFloat(lufs, 'g', -1, 64)
-	}
 }
 
 // UploadSoundscape uploads a soundscape file to the Birdweather API and returns the soundscape ID if successful.

--- a/internal/birdweather/soundscape_gain_test.go
+++ b/internal/birdweather/soundscape_gain_test.go
@@ -41,30 +41,3 @@ func TestSoundscapeGainDB(t *testing.T) {
 		})
 	}
 }
-
-// TestLogSafeLUFS verifies that a non-finite loudness measurement is rendered as
-// a plain symbolic string, so it can never reach slog's JSON handler as a
-// non-finite float (which would corrupt the log line with an "!ERROR:json"
-// substitution), while finite measurements render to their numeric form.
-func TestLogSafeLUFS(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name  string
-		input float64
-		want  string
-	}{
-		{"silent clip (-inf)", math.Inf(-1), "-inf"},
-		{"positive inf", math.Inf(1), "+inf"},
-		{"nan", math.NaN(), "nan"},
-		{"finite negative", -23.4, "-23.4"},
-		{"finite zero", 0.0, "0"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got := logSafeLUFS(tt.input)
-			assert.Equal(t, tt.want, got, "logSafeLUFS(%v) mismatch", tt.input)
-		})
-	}
-}

--- a/internal/logger/bench_test.go
+++ b/internal/logger/bench_test.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"io"
+	"math"
 	"testing"
 	"time"
 )
@@ -52,11 +53,38 @@ func BenchmarkFieldCreation(b *testing.B) {
 		}
 	})
 
+	b.Run("Float64", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			_ = Float64("confidence", 0.9512)
+		}
+	})
+
 	b.Run("Any", func(b *testing.B) {
 		b.ReportAllocs()
 		data := map[string]int{"a": 1, "b": 2}
 		for b.Loop() {
 			_ = Any("data", data)
+		}
+	})
+}
+
+// BenchmarkFieldToAttrFloat benchmarks the float Field->slog.Attr conversion,
+// including the non-finite guard in floatAttr. This is the per-field hot path.
+func BenchmarkFieldToAttrFloat(b *testing.B) {
+	b.Run("Finite", func(b *testing.B) {
+		b.ReportAllocs()
+		f := Float64("confidence", 0.9512)
+		for b.Loop() {
+			_ = fieldToAttr(f)
+		}
+	})
+
+	b.Run("NegInf", func(b *testing.B) {
+		b.ReportAllocs()
+		f := Float64("measured_lufs", math.Inf(-1))
+		for b.Loop() {
+			_ = fieldToAttr(f)
 		}
 	})
 }

--- a/internal/logger/central_logger.go
+++ b/internal/logger/central_logger.go
@@ -674,6 +674,31 @@ func roundFloat(val float64) float64 {
 	return math.Round(val*floatPrecisionRatio) / floatPrecisionRatio
 }
 
+// floatAttr renders a float value as a slog attribute. slog's JSON handler
+// cannot encode a non-finite float (+Inf, -Inf, NaN); it substitutes an
+// "!ERROR:json: unsupported value" string that corrupts the whole log line. A
+// non-finite value is therefore rendered as its symbolic string form (matching
+// Go's %v: "+Inf"/"-Inf"/"NaN"), while a finite value keeps the rounded numeric
+// form. The non-finite branch is cold, so the common path stays allocation-free.
+func floatAttr(key string, v float64) slog.Attr {
+	switch {
+	case math.IsNaN(v):
+		return slog.String(key, "NaN")
+	case math.IsInf(v, 1):
+		return slog.String(key, "+Inf")
+	case math.IsInf(v, -1):
+		return slog.String(key, "-Inf")
+	default:
+		// roundFloat multiplies by floatPrecisionRatio, which can overflow a very
+		// large finite magnitude to ±Inf; fall back to the raw (still finite)
+		// value in that rare case so it stays an encodable JSON number.
+		if r := roundFloat(v); !math.IsInf(r, 0) {
+			return slog.Float64(key, r)
+		}
+		return slog.Float64(key, v)
+	}
+}
+
 // fieldToAttr converts Field to slog.Attr
 func fieldToAttr(f Field) slog.Attr {
 	switch v := f.Value.(type) {
@@ -684,11 +709,11 @@ func fieldToAttr(f Field) slog.Attr {
 	case int64:
 		return slog.Int64(f.Key, v)
 	case float32:
-		// Round for cleaner output
-		return slog.Float64(f.Key, roundFloat(float64(v)))
+		// Round for cleaner output; guard non-finite values (see floatAttr).
+		return floatAttr(f.Key, float64(v))
 	case float64:
-		// Round for cleaner output
-		return slog.Float64(f.Key, roundFloat(v))
+		// Round for cleaner output; guard non-finite values (see floatAttr).
+		return floatAttr(f.Key, v)
 	case bool:
 		return slog.Bool(f.Key, v)
 	case time.Time:

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"log/slog"
+	"math"
 	"os"
 	"runtime"
 	"strings"
@@ -113,6 +115,79 @@ func TestNewSlogLogger(t *testing.T) {
 			assert.NotNil(t, logger)
 		}
 	})
+}
+
+// TestFieldToAttr_NonFiniteFloats verifies that non-finite float fields are
+// converted to symbolic string attrs (which slog's JSON handler can encode)
+// rather than raw float attrs (which it cannot), while finite floats keep the
+// rounded numeric form.
+func TestFieldToAttr_NonFiniteFloats(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		field     Field
+		wantKind  slog.Kind
+		wantStr   string  // expected when wantKind is KindString
+		wantFloat float64 // expected when wantKind is KindFloat64
+	}{
+		{"float64 -inf", Float64("k", math.Inf(-1)), slog.KindString, "-Inf", 0},
+		{"float64 +inf", Float64("k", math.Inf(1)), slog.KindString, "+Inf", 0},
+		{"float64 nan", Float64("k", math.NaN()), slog.KindString, "NaN", 0},
+		{"float64 finite rounds", Float64("k", 1.23456), slog.KindFloat64, "", 1.235},
+		// A finite magnitude whose rounding overflows to ±Inf must still log as a
+		// numeric attr (the raw value), never a symbolic string.
+		{"float64 max stays numeric", Float64("k", math.MaxFloat64), slog.KindFloat64, "", math.MaxFloat64},
+		{"float64 -max stays numeric", Float64("k", -math.MaxFloat64), slog.KindFloat64, "", -math.MaxFloat64},
+		{"float32 -inf", Float32("k", float32(math.Inf(-1))), slog.KindString, "-Inf", 0},
+		{"float32 +inf", Float32("k", float32(math.Inf(1))), slog.KindString, "+Inf", 0},
+		{"float32 nan", Float32("k", float32(math.NaN())), slog.KindString, "NaN", 0},
+		{"float32 finite", Float32("k", 2.5), slog.KindFloat64, "", 2.5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			attr := fieldToAttr(tt.field)
+			require.Equal(t, tt.wantKind, attr.Value.Kind(), "attr kind for %s", tt.name)
+			switch tt.wantKind {
+			case slog.KindString:
+				assert.Equal(t, tt.wantStr, attr.Value.String())
+			case slog.KindFloat64:
+				assert.InDelta(t, tt.wantFloat, attr.Value.Float64(), 1e-9)
+			default:
+				t.Fatalf("unexpected wantKind %v", tt.wantKind)
+			}
+		})
+	}
+}
+
+// TestSlogLogger_NonFiniteFloatJSON is the end-to-end guard: a non-finite float
+// field must produce a valid JSON log line with a readable value, never slog's
+// "!ERROR:json: unsupported value" substitution.
+func TestSlogLogger_NonFiniteFloatJSON(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	log := NewSlogLogger(buf, LogLevelInfo, time.UTC)
+	log.Info("loudness",
+		Float64("neg_inf", math.Inf(-1)),
+		Float64("pos_inf", math.Inf(1)),
+		Float64("nan", math.NaN()),
+		Float64("finite", 1.5),
+		Float64("huge", math.MaxFloat64),
+	)
+
+	out := buf.String()
+	assert.NotContains(t, out, "!ERROR", "non-finite float corrupted the log line: %s", out)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &m), "log line must be valid JSON: %s", out)
+	assert.Equal(t, "-Inf", m["neg_inf"])
+	assert.Equal(t, "+Inf", m["pos_inf"])
+	assert.Equal(t, "NaN", m["nan"])
+	assert.InDelta(t, 1.5, m["finite"], 1e-9)
+	// A large finite value whose rounding overflows stays an encodable JSON number.
+	assert.InDelta(t, math.MaxFloat64, m["huge"], 1e292)
 }
 
 // TestSlogLogger_Module tests module scoping


### PR DESCRIPTION
## Summary

slog's JSON handler cannot encode a non-finite float (`+Inf`/`-Inf`/`NaN`): it substitutes an `!ERROR:json: unsupported value` string that corrupts the entire log line. The logger's `fieldToAttr` handed `float32`/`float64` fields straight to `slog.Float64`, so any non-finite value silently corrupted its JSON log entry. The concrete trigger was BirdWeather soundscape encoding: ffmpeg reports a silent clip's integrated loudness as `-inf`, which reaches the debug log as a `-Inf` float.

This fixes it at the root. Both float cases in `fieldToAttr` now route through a small `floatAttr` helper that renders a non-finite value as its symbolic string form (`"+Inf"`/`"-Inf"`/`"NaN"`, matching Go's `%v`) and a finite value as the rounded number exactly as before. `fieldToAttr` is the single `Field` to `slog.Attr` conversion point for both logger implementations (`SlogLogger` and `moduleLogger`), so one change covers every caller, including the three sites that log `measured_lufs`/`true_peak_dbtp` on silent clips (`birdweather_client.go`, `encode_native.go`, `actions_database.go`).

Because the logger now guarantees this centrally, the follow-up also removes the `logSafeLUFS` call-site workaround added in #3870 and restores the plain `logger.Float64("measured_lufs", inputLUFS)` call, so finite values are JSON numbers again (consistent with the sibling `gain_db`/`target_lufs` fields). The functional silence fix (`soundscapeGainDB`, returns 0 dB gain for silent clips) is untouched.

`floatAttr` also guards the rounded result: `roundFloat` multiplies by the precision ratio and can overflow a very large finite magnitude to `±Inf`, so it falls back to the raw finite value in that rare case rather than re-introducing the corruption. This path is unreachable for real loudness/gain values but keeps the helper's safety contract total.

## Changes

- `internal/logger/central_logger.go`: new `floatAttr` helper; `fieldToAttr` float cases route through it.
- `internal/birdweather/birdweather_client.go`: remove the now-redundant `logSafeLUFS` workaround; restore `logger.Float64("measured_lufs", inputLUFS)`.
- Tests: unit coverage of `fieldToAttr` for finite/non-finite `float32` and `float64` (including the rounding-overflow fallback) and an end-to-end JSON test asserting no `!ERROR` substitution; the removed helper's test is dropped.
- Benchmarks: a `Float64` field-creation case and a `fieldToAttr` float-conversion benchmark (finite + non-finite), previously an uncovered hot path. Confirmed allocation-free.

## Test plan

- [x] `go test -race ./internal/logger/ ./internal/birdweather/`
- [x] New tests fail against the pre-fix code (verified the `!ERROR` corruption reproduces)
- [x] `golangci-lint run` clean on both packages
- [x] Benchmarks confirm 0 allocs/op on the float conversion path

A narrow pre-existing edge remains out of scope and is tracked separately: a non-finite value of a *named* float type, or one nested inside a struct/map/slice passed via `logger.Any`, still falls through to `slog.Any`. No current caller triggers it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved logging for non-finite audio loudness values.
  - Prevented `NaN` and infinite floating-point values from corrupting JSON log output.
  - Ensured these values are displayed clearly as `NaN`, `+Inf`, or `-Inf`.
  - Preserved numeric formatting and rounding for valid floating-point values.

- **Tests**
  - Added coverage for non-finite loudness handling and valid JSON logging.
  - Added benchmarks for floating-point field processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->