### PR TITLE
fix(frontend): stop import progress SSE reconnecting forever after a server restart

### DIFF
--- a/frontend/src/lib/desktop/features/import-export/components/BirdNetPiImportWizard.svelte
+++ b/frontend/src/lib/desktop/features/import-export/components/BirdNetPiImportWizard.svelte
@@ -11,7 +11,7 @@
   import ErrorAlert from '$lib/desktop/components/ui/ErrorAlert.svelte';
   import ProgressBar from '$lib/desktop/components/ui/ProgressBar.svelte';
   import TextInput from '$lib/desktop/components/forms/TextInput.svelte';
-  import { CheckCircle2, XCircle, ArrowLeft, ArrowRight } from '@lucide/svelte';
+  import { CheckCircle2, XCircle, Unplug, ArrowLeft, ArrowRight } from '@lucide/svelte';
   import type {
     ImportSourcesResponse,
     SourceCandidate,
@@ -86,6 +86,10 @@
   let importComplete = $state(false);
   let importCancelled = $state(false);
   let importError = $state<string | null>(null);
+  // Set when the progress stream stalls and a status re-poll confirms the job is
+  // gone (server restarted mid-import). Honest terminal state: the import did not
+  // finish here and its real outcome is unknown, so it is neither success nor error.
+  let importInterrupted = $state(false);
   let isCancelling = $state(false);
   let eventSource: ReconnectingEventSource | null = null;
   let destroyed = false;
@@ -154,6 +158,7 @@
     importComplete = false;
     importCancelled = false;
     importError = null;
+    importInterrupted = false;
     errorMessage = null;
     isCancelling = false;
     sourcePath = '';
@@ -314,7 +319,46 @@
         currentStep = 'done';
         closeEventSource();
       },
+      onStalled: () => {
+        void reconcileAfterStall();
+      },
     });
+  }
+
+  /**
+   * The progress stream has been failing to reconnect. Re-poll the authoritative
+   * status: a finished job shows its real terminal state; a job that is simply
+   * gone (server restarted mid-import) shows an honest "interrupted" state; a
+   * still-running same job keeps the stream. A failed fetch (server unreachable)
+   * is ignored so the stream keeps retrying and the next stall tick reconciles.
+   */
+  async function reconcileAfterStall() {
+    // Only meaningful while still on the progress step; a terminal SSE event may
+    // have already moved us to 'done'.
+    if (destroyed || currentStep !== 'progress') return;
+    const myJobId = jobId;
+    try {
+      const s = await api.get<ImportStatusResponse>('/api/v2/import/status');
+      // Re-check after the await: an SSE terminal event could have landed a real
+      // outcome, or a fresh import could have started, during the fetch. Either
+      // way this reconcile is stale and must not clobber the newer state.
+      if (destroyed || currentStep !== 'progress' || jobId !== myJobId) return;
+      // Adopt a finished status only when it describes the job we were watching;
+      // the single-slot status endpoint could otherwise report a different job.
+      if (s.status === 'done' && s.job_id === myJobId) {
+        closeEventSource();
+        applyFinalStatus(s);
+        return;
+      }
+      if (s.running && s.job_id === myJobId) return; // transient blip; keep the stream
+      // Our job is gone (server restarted, or a different job now holds the slot).
+      closeEventSource();
+      importInterrupted = true;
+      currentStep = 'done';
+    } catch (err) {
+      // Server unreachable: keep retrying; reconcile again on the next stall tick.
+      logger.debug('import status reconcile failed after stall; will retry', err);
+    }
   }
 
   function closeEventSource() {
@@ -369,9 +413,20 @@
           try {
             const s = await api.get<ImportStatusResponse>('/api/v2/import/status');
             if (destroyed) return;
-            applyFinalStatus(s);
+            if (s.job_id === jobId) {
+              applyFinalStatus(s);
+            } else {
+              // The status endpoint no longer describes the job we cancelled;
+              // report the cancellation rather than adopting an unrelated outcome.
+              importCancelled = true;
+              currentStep = 'done';
+            }
           } catch (err) {
             logger.error('Failed to load final import status after cancel', err);
+            // Fall back to a terminal state so the wizard never wedges on
+            // "Cancelling..." when the final status fetch fails.
+            importCancelled = true;
+            currentStep = 'done';
           }
         }
       }
@@ -932,7 +987,7 @@
         <!-- Done step -->
         <div class="space-y-4 text-center">
           {#if importComplete && !importError && !importCancelled}
-            <CheckCircle2 class="size-12 mx-auto text-[var(--color-success)]" />
+            <CheckCircle2 class="size-12 mx-auto text-[var(--color-success)]" aria-hidden="true" />
             <div>
               <h4 class="text-lg font-semibold text-[var(--color-base-content)]">
                 {t('system.importExport.done.successTitle')}
@@ -973,7 +1028,7 @@
               </div>
             {/if}
           {:else if importCancelled}
-            <XCircle class="size-12 mx-auto text-[var(--color-warning)]" />
+            <XCircle class="size-12 mx-auto text-[var(--color-warning)]" aria-hidden="true" />
             <div>
               <h4 class="text-lg font-semibold text-[var(--color-base-content)]">
                 {t('system.importExport.done.cancelledTitle')}
@@ -990,12 +1045,31 @@
               </p>
             {/if}
           {:else if importError}
-            <XCircle class="size-12 mx-auto text-[var(--color-error)]" />
+            <XCircle class="size-12 mx-auto text-[var(--color-error)]" aria-hidden="true" />
             <div>
               <h4 class="text-lg font-semibold text-[var(--color-base-content)]">
                 {t('system.importExport.done.errorTitle')}
               </h4>
               <p class="text-sm text-[var(--color-base-content)]/70 mt-1">{importError}</p>
+            </div>
+          {:else if importInterrupted}
+            <Unplug class="size-12 mx-auto text-[var(--color-warning)]" aria-hidden="true" />
+            <div>
+              <h4 class="text-lg font-semibold text-[var(--color-base-content)]">
+                {t('system.importExport.done.interruptedTitle')}
+              </h4>
+              <p class="text-sm text-[var(--color-base-content)]/70 mt-1">
+                {t('system.importExport.done.interruptedDescription')}
+              </p>
+            </div>
+            <div class="mt-2">
+              <a
+                href={buildDetectionsFilterUrl()}
+                onclick={() => onClose()}
+                class="inline-flex items-center gap-1.5 text-sm text-[var(--color-primary)] hover:underline"
+              >
+                {t('system.importExport.done.viewDetectionsLink')}
+              </a>
             </div>
           {/if}
         </div>

--- a/frontend/src/lib/desktop/features/import-export/components/BirdNetPiImportWizard.test.ts
+++ b/frontend/src/lib/desktop/features/import-export/components/BirdNetPiImportWizard.test.ts
@@ -44,6 +44,7 @@ let mockEsListeners = new Map<string, EventHandler[]>();
 let mockEsInstance: {
   addEventListener: ReturnType<typeof vi.fn>;
   close: ReturnType<typeof vi.fn>;
+  onreconnectfailed: ((attempts: number) => void) | null;
 } | null = null;
 
 const { MockReconnectingEventSource } = vi.hoisted(() => {
@@ -67,11 +68,17 @@ vi.mock('$lib/utils/ReconnectingEventSource', () => {
         }
       }),
       close: vi.fn(),
+      onreconnectfailed: null,
     };
     return mockEsInstance;
   });
   return { ReconnectingEventSource: MockReconnectingEventSource };
 });
+
+/** Simulate the stream stalling (attempts consecutive failed reconnects). */
+function triggerStall(attempts: number) {
+  mockEsInstance?.onreconnectfailed?.(attempts);
+}
 
 /** Helper to dispatch a mock SSE event with JSON data. */
 function dispatchMockEvent(type: string, data: unknown) {
@@ -86,6 +93,7 @@ function dispatchMockEvent(type: string, data: unknown) {
 import BirdNetPiImportWizard from './BirdNetPiImportWizard.svelte';
 import { api } from '$lib/utils/api';
 import { loggers } from '$lib/utils/logger';
+import { STREAM_STALL_THRESHOLD } from '../utils';
 import { flushSync } from 'svelte';
 
 // Default sources response: one readable candidate in a container environment.
@@ -133,6 +141,7 @@ function makeMockEsImplementation() {
         }
       }),
       close: vi.fn(),
+      onreconnectfailed: null,
     };
     return mockEsInstance;
   };
@@ -639,6 +648,129 @@ describe('BirdNetPiImportWizard', () => {
     expect(mockEsInstance?.close).toHaveBeenCalledOnce();
   });
 
+  // ---- SSE stall reconcile (server restart mid-import, Forgejo #1323) ----
+
+  it('stall with an empty job manager shows the interrupted state and closes the stream', async () => {
+    render(BirdNetPiImportWizard, { props: { onClose } });
+
+    await navigatePastSource();
+    await waitFor(() => screen.getByText('system.importExport.mode.label'));
+    await fireEvent.click(screen.getByRole('button', { name: /common.buttons.next/ }));
+    await waitFor(() => screen.getByText('system.importExport.confirm.description'));
+    await fireEvent.click(
+      screen.getByRole('button', { name: /system.importExport.confirm.startButton/ })
+    );
+    await waitFor(() => {
+      expect(screen.getByText('system.importExport.progress.runningLabel')).toBeInTheDocument();
+    });
+
+    // The stream keeps failing to reconnect; the status re-poll (default mock) now
+    // reports idle because the server restarted and lost the in-memory job.
+    triggerStall(STREAM_STALL_THRESHOLD);
+
+    await waitFor(() => {
+      expect(screen.getByText('system.importExport.done.interruptedTitle')).toBeInTheDocument();
+    });
+    expect(mockEsInstance?.close).toHaveBeenCalledOnce();
+    // Not an error: the outcome is unknown, not failed.
+    expect(screen.queryByText('system.importExport.done.errorTitle')).not.toBeInTheDocument();
+  });
+
+  it('stall where status reports a finished job shows the real terminal summary', async () => {
+    let statusCalls = 0;
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === '/api/v2/import/status') {
+        statusCalls++;
+        if (statusCalls === 1) {
+          return Promise.resolve({ running: false, status: 'idle' });
+        }
+        return Promise.resolve({
+          running: false,
+          job_id: 'test-job-123',
+          status: 'done',
+          progress: { ...defaultProgress, processed: 1000, inserted: 990, phase: 'done' as const },
+          error: undefined,
+        });
+      }
+      if (url === '/api/v2/import/sources') {
+        return Promise.resolve(defaultSourcesResponse);
+      }
+      return Promise.reject(new Error(`Unmocked GET: ${url}`));
+    });
+
+    render(BirdNetPiImportWizard, { props: { onClose } });
+
+    await navigatePastSource();
+    await waitFor(() => screen.getByText('system.importExport.mode.label'));
+    await fireEvent.click(screen.getByRole('button', { name: /common.buttons.next/ }));
+    await waitFor(() => screen.getByText('system.importExport.confirm.description'));
+    await fireEvent.click(
+      screen.getByRole('button', { name: /system.importExport.confirm.startButton/ })
+    );
+    await waitFor(() => {
+      expect(screen.getByText('system.importExport.progress.runningLabel')).toBeInTheDocument();
+    });
+
+    triggerStall(STREAM_STALL_THRESHOLD);
+
+    await waitFor(() => {
+      expect(screen.getByText('system.importExport.done.successTitle')).toBeInTheDocument();
+    });
+    // A finished job must NOT be reported as interrupted.
+    expect(screen.queryByText('system.importExport.done.interruptedTitle')).not.toBeInTheDocument();
+    expect(mockEsInstance?.close).toHaveBeenCalledOnce();
+  });
+
+  it('a stall reconcile does not clobber a terminal SSE event that lands during its fetch', async () => {
+    // Hold the reconcile's /status fetch open so an SSE terminal can land first.
+    let releaseStatus!: (v: unknown) => void;
+    let statusCalls = 0;
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === '/api/v2/import/status') {
+        statusCalls++;
+        if (statusCalls === 1) return Promise.resolve({ running: false, status: 'idle' });
+        return new Promise(resolve => {
+          releaseStatus = resolve;
+        });
+      }
+      if (url === '/api/v2/import/sources') return Promise.resolve(defaultSourcesResponse);
+      return Promise.reject(new Error(`Unmocked GET: ${url}`));
+    });
+
+    render(BirdNetPiImportWizard, { props: { onClose } });
+    await navigatePastSource();
+    await waitFor(() => screen.getByText('system.importExport.mode.label'));
+    await fireEvent.click(screen.getByRole('button', { name: /common.buttons.next/ }));
+    await waitFor(() => screen.getByText('system.importExport.confirm.description'));
+    await fireEvent.click(
+      screen.getByRole('button', { name: /system.importExport.confirm.startButton/ })
+    );
+    await waitFor(() => screen.getByText('system.importExport.progress.runningLabel'));
+
+    // Stall kicks off reconcileAfterStall; its /status fetch is now pending.
+    triggerStall(STREAM_STALL_THRESHOLD);
+    await waitFor(() => expect(statusCalls).toBe(2));
+
+    // The SSE 'complete' terminal event lands while the reconcile fetch is in flight.
+    flushSync(() => {
+      dispatchMockEvent('complete', {
+        ...defaultProgress,
+        processed: 1000,
+        inserted: 990,
+        phase: 'done',
+      });
+    });
+    await waitFor(() => screen.getByText('system.importExport.done.successTitle'));
+
+    // The stale reconcile now resolves (job gone). The post-await guard must drop
+    // it so the real success outcome is preserved, not overwritten by interrupted.
+    releaseStatus({ running: false, status: 'idle' });
+    await waitFor(() => {
+      expect(screen.getByText('system.importExport.done.successTitle')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('system.importExport.done.interruptedTitle')).not.toBeInTheDocument();
+  });
+
   // ---- Cancel ----
 
   it('cancel button posts to the cancel endpoint', async () => {
@@ -864,6 +996,7 @@ describe('BirdNetPiImportWizard', () => {
         }
         return Promise.resolve({
           running: false,
+          job_id: 'test-job-123',
           status: 'done',
           progress: completedProgress,
           error: undefined,

--- a/frontend/src/lib/desktop/features/import-export/components/ImportActivityCard.svelte
+++ b/frontend/src/lib/desktop/features/import-export/components/ImportActivityCard.svelte
@@ -93,7 +93,10 @@
         if (finalKind === null || resp.job_id !== connectedJobId) {
           finalKind = resp.cancelled ? 'cancelled' : resp.error ? 'error' : 'success';
         }
-      } else {
+      } else if (finalKind !== 'interrupted') {
+        // Preserve a prior interruption across idle refreshes (e.g. the
+        // refreshSignal bump when the wizard closes) until a new running or
+        // finished job supersedes it; otherwise clear to the idle/empty view.
         finalKind = null;
       }
     } catch (err) {
@@ -149,8 +152,19 @@
     const generation = ++loadGeneration;
     try {
       const resp = await api.get<ImportStatusResponse>('/api/v2/import/status');
-      if (destroyed || generation !== loadGeneration) return;
-      if (resp.running && resp.job_id === watchedJobId) return; // transient blip; keep the stream
+      // Bail if superseded, unmounted, or a terminal SSE event already landed a
+      // real outcome during the fetch (it must not be clobbered by this reconcile).
+      if (destroyed || generation !== loadGeneration || finalKind !== null) return;
+      if (resp.running && resp.job_id) {
+        // Same job: a transient blip, keep the existing stream. Different job: a
+        // new import now holds the single slot, so monitor it instead of stalling.
+        if (resp.job_id !== watchedJobId) {
+          status = resp;
+          progress = resp.progress ?? null;
+          connectEventSource(resp.job_id);
+        }
+        return;
+      }
       closeEventSource();
       if (resp.status === 'done' && resp.job_id === watchedJobId) {
         status = resp;
@@ -158,8 +172,8 @@
         finalKind = resp.cancelled ? 'cancelled' : resp.error ? 'error' : 'success';
         return;
       }
-      // The watched job is gone (server restarted, or a different job now holds
-      // the single import slot). Report it honestly instead of going empty.
+      // The watched job is gone (server restarted). Report it honestly instead of
+      // going empty; loadStatus preserves this until a new job supersedes it.
       status = resp;
       progress = null;
       finalKind = watchedJobId ? 'interrupted' : null;
@@ -293,7 +307,7 @@
           {t('system.importExport.done.interruptedDescription')}
         </p>
       {/if}
-      {#if finalKind === 'success' ? (progress?.inserted ?? 0) > 0 : finalKind === 'interrupted'}
+      {#if (finalKind === 'success' && (progress?.inserted ?? 0) > 0) || finalKind === 'interrupted'}
         <a
           href={buildDetectionsFilterUrl()}
           class="inline-flex items-center gap-1 text-sm font-medium underline text-[var(--color-primary)] hover:opacity-80"

--- a/frontend/src/lib/desktop/features/import-export/components/ImportActivityCard.svelte
+++ b/frontend/src/lib/desktop/features/import-export/components/ImportActivityCard.svelte
@@ -9,7 +9,7 @@
   import LoadingSpinner from '$lib/desktop/components/ui/LoadingSpinner.svelte';
   import ErrorAlert from '$lib/desktop/components/ui/ErrorAlert.svelte';
   import ProgressBar from '$lib/desktop/components/ui/ProgressBar.svelte';
-  import { Activity, CheckCircle2, XCircle, CircleSlash } from '@lucide/svelte';
+  import { Activity, CheckCircle2, XCircle, CircleSlash, Unplug } from '@lucide/svelte';
   import ImportCountTile from './ImportCountTile.svelte';
   import {
     buildDetectionsFilterUrl,
@@ -31,7 +31,10 @@
 
   let { refreshSignal = 0, onOpenWizard }: Props = $props();
 
-  type FinalKind = 'success' | 'cancelled' | 'error';
+  // 'interrupted' is reached when the progress stream stalls (server restart) and
+  // a status re-poll confirms the watched job is gone: the outcome is unknown, so
+  // it is neither success nor error.
+  type FinalKind = 'success' | 'cancelled' | 'error' | 'interrupted';
 
   let status = $state<ImportStatusResponse | null>(null);
   let progress = $state<ImportProgress | null>(null);
@@ -126,7 +129,45 @@
         finalKind = 'error';
         closeEventSource();
       },
+      onStalled: () => {
+        void reconcileStalledStream();
+      },
     });
+  }
+
+  /**
+   * The progress stream has been failing to reconnect (e.g. a 404 after a server
+   * restart left the in-memory job manager empty). Re-poll the authoritative
+   * status and reconcile: keep the stream if the same job is still running; show
+   * its real terminal state if it finished; otherwise surface an honest
+   * "interrupted" state (rather than the generic empty view, which would read as
+   * "nothing ever happened"). A failed fetch means the server is unreachable, so
+   * keep the stream retrying and reconcile again on the next stall tick.
+   */
+  async function reconcileStalledStream() {
+    const watchedJobId = connectedJobId;
+    const generation = ++loadGeneration;
+    try {
+      const resp = await api.get<ImportStatusResponse>('/api/v2/import/status');
+      if (destroyed || generation !== loadGeneration) return;
+      if (resp.running && resp.job_id === watchedJobId) return; // transient blip; keep the stream
+      closeEventSource();
+      if (resp.status === 'done' && resp.job_id === watchedJobId) {
+        status = resp;
+        progress = resp.progress ?? null;
+        finalKind = resp.cancelled ? 'cancelled' : resp.error ? 'error' : 'success';
+        return;
+      }
+      // The watched job is gone (server restarted, or a different job now holds
+      // the single import slot). Report it honestly instead of going empty.
+      status = resp;
+      progress = null;
+      finalKind = watchedJobId ? 'interrupted' : null;
+    } catch (err) {
+      if (destroyed || generation !== loadGeneration) return;
+      // Server unreachable: keep the stream retrying; reconcile again next tick.
+      logger.debug('import status reconcile failed after stall; will retry', err);
+    }
   }
 
   function closeEventSource() {
@@ -149,6 +190,8 @@
         return 'system.importExport.done.cancelledTitle';
       case 'error':
         return 'system.importExport.done.errorTitle';
+      case 'interrupted':
+        return 'system.importExport.done.interruptedTitle';
     }
   }
 </script>
@@ -222,6 +265,8 @@
           <CheckCircle2 class="size-5 text-[var(--color-success)]" aria-hidden="true" />
         {:else if finalKind === 'cancelled'}
           <CircleSlash class="size-5 text-[var(--color-base-content)]/50" aria-hidden="true" />
+        {:else if finalKind === 'interrupted'}
+          <Unplug class="size-5 text-[var(--color-warning)]" aria-hidden="true" />
         {:else}
           <XCircle class="size-5 text-[var(--color-error)]" aria-hidden="true" />
         {/if}
@@ -243,7 +288,12 @@
           />
         </div>
       {/if}
-      {#if finalKind === 'success' && (progress?.inserted ?? 0) > 0}
+      {#if finalKind === 'interrupted'}
+        <p class="text-sm text-[var(--color-base-content)]/70">
+          {t('system.importExport.done.interruptedDescription')}
+        </p>
+      {/if}
+      {#if finalKind === 'success' ? (progress?.inserted ?? 0) > 0 : finalKind === 'interrupted'}
         <a
           href={buildDetectionsFilterUrl()}
           class="inline-flex items-center gap-1 text-sm font-medium underline text-[var(--color-primary)] hover:opacity-80"

--- a/frontend/src/lib/desktop/features/import-export/components/ImportActivityCard.test.ts
+++ b/frontend/src/lib/desktop/features/import-export/components/ImportActivityCard.test.ts
@@ -29,6 +29,7 @@ let mockEsListeners = new Map<string, EventHandler[]>();
 let mockEsInstance: {
   addEventListener: ReturnType<typeof vi.fn>;
   close: ReturnType<typeof vi.fn>;
+  onreconnectfailed: ((attempts: number) => void) | null;
 } | null = null;
 
 const { MockReconnectingEventSource } = vi.hoisted(() => {
@@ -51,11 +52,19 @@ vi.mock('$lib/utils/ReconnectingEventSource', () => {
         }
       }),
       close: vi.fn(),
+      // The helper assigns its stall callback here; tests invoke it to simulate a
+      // persistently failing reconnect.
+      onreconnectfailed: null,
     };
     return mockEsInstance;
   });
   return { ReconnectingEventSource: MockReconnectingEventSource };
 });
+
+/** Simulate the stream stalling (attempts consecutive failed reconnects). */
+function triggerStall(attempts: number) {
+  mockEsInstance?.onreconnectfailed?.(attempts);
+}
 
 /** Helper to dispatch a mock SSE event with JSON data. */
 function dispatchMockEvent(type: string, data: unknown) {
@@ -77,6 +86,7 @@ function dispatchPlainEvent(type: string) {
 
 import ImportActivityCard from './ImportActivityCard.svelte';
 import { api } from '$lib/utils/api';
+import { STREAM_STALL_THRESHOLD } from '../utils';
 import type { ImportProgress, ImportStatusResponse } from '../types';
 
 const idleStatus: ImportStatusResponse = { running: false, status: 'idle' };
@@ -333,6 +343,43 @@ describe('ImportActivityCard', () => {
     });
     expect(MockReconnectingEventSource).toHaveBeenCalledTimes(1);
     expect(mockEsInstance?.close).not.toHaveBeenCalled();
+  });
+
+  it('reconciles to an interrupted state when the stream stalls and the job is gone', async () => {
+    // Mount sees the running job; the stall reconcile sees an empty manager
+    // (server restarted), so the card must stop the stream and show an honest
+    // interrupted state instead of the misleading "no activity" empty view.
+    vi.mocked(api.get).mockResolvedValueOnce(runningStatus).mockResolvedValue(idleStatus);
+    renderCard();
+    await waitFor(() => {
+      expect(MockReconnectingEventSource).toHaveBeenCalledTimes(1);
+    });
+
+    triggerStall(STREAM_STALL_THRESHOLD);
+
+    await waitFor(() => {
+      expect(screen.getByText('system.importExport.done.interruptedTitle')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('system.importExport.activity.empty.title')).not.toBeInTheDocument();
+    expect(api.get).toHaveBeenCalledTimes(2);
+    expect(mockEsInstance?.close).toHaveBeenCalled();
+  });
+
+  it('keeps the running view and stream when the stall reconcile still reports the same job', async () => {
+    vi.mocked(api.get).mockResolvedValue(runningStatus);
+    renderCard();
+    await waitFor(() => {
+      expect(MockReconnectingEventSource).toHaveBeenCalledTimes(1);
+    });
+
+    triggerStall(STREAM_STALL_THRESHOLD);
+
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledTimes(2);
+    });
+    expect(screen.getByText(/system.importExport.progress.runningLabel/)).toBeInTheDocument();
+    expect(mockEsInstance?.close).not.toHaveBeenCalled();
+    expect(MockReconnectingEventSource).toHaveBeenCalledTimes(1);
   });
 
   it('keeps the terminal state when a stale running response arrives after the SSE terminal event', async () => {

--- a/frontend/src/lib/desktop/features/import-export/components/ImportActivityCard.test.ts
+++ b/frontend/src/lib/desktop/features/import-export/components/ImportActivityCard.test.ts
@@ -382,6 +382,97 @@ describe('ImportActivityCard', () => {
     expect(MockReconnectingEventSource).toHaveBeenCalledTimes(1);
   });
 
+  it('preserves the interrupted state across an idle refresh (e.g. the wizard closing)', async () => {
+    // Running job -> stall -> interrupted; a later refreshSignal bump returns idle
+    // (the wizard closed). The interruption must remain, not revert to the empty view.
+    vi.mocked(api.get).mockResolvedValueOnce(runningStatus).mockResolvedValue(idleStatus);
+    const onOpenWizard = vi.fn();
+    const { rerender } = render(ImportActivityCard, {
+      props: { onOpenWizard, refreshSignal: 0 },
+    });
+    await waitFor(() => {
+      expect(MockReconnectingEventSource).toHaveBeenCalledTimes(1);
+    });
+
+    triggerStall(STREAM_STALL_THRESHOLD);
+    await waitFor(() => {
+      expect(screen.getByText('system.importExport.done.interruptedTitle')).toBeInTheDocument();
+    });
+
+    await rerender({ onOpenWizard, refreshSignal: 1 });
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledTimes(3);
+    });
+    expect(screen.getByText('system.importExport.done.interruptedTitle')).toBeInTheDocument();
+    expect(screen.queryByText('system.importExport.activity.empty.title')).not.toBeInTheDocument();
+  });
+
+  it('monitors a new running job when a different job appears during a stall', async () => {
+    const newJobStatus: ImportStatusResponse = {
+      running: true,
+      job_id: 'job-2',
+      status: 'running',
+      progress: runningProgress,
+    };
+    vi.mocked(api.get).mockResolvedValueOnce(runningStatus).mockResolvedValue(newJobStatus);
+    renderCard();
+    await waitFor(() => {
+      expect(MockReconnectingEventSource).toHaveBeenCalledWith(
+        '/api/v2/import/jobs/job-1/progress'
+      );
+    });
+
+    triggerStall(STREAM_STALL_THRESHOLD);
+    await waitFor(() => {
+      expect(MockReconnectingEventSource).toHaveBeenCalledWith(
+        '/api/v2/import/jobs/job-2/progress'
+      );
+    });
+    // It connected to the new job rather than freezing on an "interrupted" state.
+    expect(screen.queryByText('system.importExport.done.interruptedTitle')).not.toBeInTheDocument();
+    expect(screen.getByText(/system.importExport.progress.runningLabel/)).toBeInTheDocument();
+  });
+
+  it('a stall reconcile does not clobber a terminal SSE event that lands during its fetch', async () => {
+    let releaseStatus!: (v: unknown) => void;
+    let statusCalls = 0;
+    vi.mocked(api.get).mockImplementation(() => {
+      statusCalls++;
+      if (statusCalls === 1) return Promise.resolve(runningStatus);
+      return new Promise(resolve => {
+        releaseStatus = resolve;
+      });
+    });
+    renderCard();
+    await waitFor(() => {
+      expect(MockReconnectingEventSource).toHaveBeenCalledTimes(1);
+    });
+
+    // Stall kicks off the reconcile; its /status fetch is now pending.
+    triggerStall(STREAM_STALL_THRESHOLD);
+    await waitFor(() => {
+      expect(statusCalls).toBe(2);
+    });
+
+    // The SSE 'complete' terminal event lands while the reconcile fetch is in flight.
+    dispatchMockEvent('complete', {
+      ...runningProgress,
+      processed: 100,
+      inserted: 90,
+      phase: 'done',
+    });
+    await waitFor(() => {
+      expect(screen.getByText('system.importExport.done.successTitle')).toBeInTheDocument();
+    });
+
+    // The stale reconcile now resolves (job gone). The finalKind guard must drop it.
+    releaseStatus(idleStatus);
+    await waitFor(() => {
+      expect(screen.getByText('system.importExport.done.successTitle')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('system.importExport.done.interruptedTitle')).not.toBeInTheDocument();
+  });
+
   it('keeps the terminal state when a stale running response arrives after the SSE terminal event', async () => {
     // Refetch resolves only when released, snapshotting "running" before the
     // SSE terminal event lands.

--- a/frontend/src/lib/desktop/features/import-export/utils.test.ts
+++ b/frontend/src/lib/desktop/features/import-export/utils.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { deriveSourceStepState, importProgressPercent, isUnreadable } from './utils';
+import {
+  deriveSourceStepState,
+  importProgressPercent,
+  isUnreadable,
+  shouldReconcileStalledStream,
+  STREAM_STALL_THRESHOLD,
+} from './utils';
 import type { ImportProgress, ImportSourcesResponse, SourceCandidate } from './types';
 
 const baseResp: ImportSourcesResponse = {
@@ -81,5 +87,20 @@ describe('importProgressPercent', () => {
 
   it('clamps below 0 when processed is negative', () => {
     expect(importProgressPercent(progress(10, -5))).toBe(0);
+  });
+});
+
+describe('shouldReconcileStalledStream', () => {
+  it('returns false below the threshold', () => {
+    for (let attempts = 0; attempts < STREAM_STALL_THRESHOLD; attempts++) {
+      expect(shouldReconcileStalledStream(attempts)).toBe(false);
+    }
+  });
+
+  it('returns true at the threshold and its multiples only', () => {
+    expect(shouldReconcileStalledStream(STREAM_STALL_THRESHOLD)).toBe(true);
+    expect(shouldReconcileStalledStream(STREAM_STALL_THRESHOLD + 1)).toBe(false);
+    expect(shouldReconcileStalledStream(STREAM_STALL_THRESHOLD * 2)).toBe(true);
+    expect(shouldReconcileStalledStream(STREAM_STALL_THRESHOLD * 3)).toBe(true);
   });
 });

--- a/frontend/src/lib/desktop/features/import-export/utils.ts
+++ b/frontend/src/lib/desktop/features/import-export/utils.ts
@@ -46,6 +46,23 @@ export function importProgressPercent(progress: ImportProgress | null): number {
   return Math.max(0, Math.min(100, Math.round((progress.processed / progress.total) * 100)));
 }
 
+/**
+ * Consecutive failed (re)connect attempts before a stalled progress stream
+ * triggers a status reconcile. With the default 3s backoff cap this is up to
+ * ~3.5s of failed reconnects, long enough to rule out a transient blip.
+ */
+export const STREAM_STALL_THRESHOLD = 4;
+
+/**
+ * True when a stalled stream (attempts consecutive failed reconnects without an
+ * open) should trigger a status reconcile: at the threshold and every
+ * STREAM_STALL_THRESHOLD failures after, so re-polls stay rate-limited while a
+ * server stays unreachable.
+ */
+export function shouldReconcileStalledStream(attempts: number): boolean {
+  return attempts >= STREAM_STALL_THRESHOLD && attempts % STREAM_STALL_THRESHOLD === 0;
+}
+
 /** Callbacks for the import job SSE progress stream. */
 export interface ImportProgressStreamHandlers {
   onProgress: (progress: ImportProgress) => void;
@@ -55,6 +72,12 @@ export interface ImportProgressStreamHandlers {
   onCancelled: (progress: ImportProgress | null) => void;
   /** Terminal: job failed server-side (data-carrying 'error' event only). */
   onError: (progress: ImportProgress | null) => void;
+  /**
+   * Non-terminal: the stream has been failing to (re)connect long enough that
+   * the caller should reconcile against GET /api/v2/import/status (the job may
+   * be gone after a server restart). The stream keeps retrying regardless.
+   */
+  onStalled?: () => void;
 }
 
 function parseProgressEvent(event: Event, eventName: string): ImportProgress | null {
@@ -70,15 +93,22 @@ function parseProgressEvent(event: Event, eventName: string): ImportProgress | n
  * Subscribe to an import job's SSE progress stream with the shared protocol
  * rules: payloads are parsed with logging on failure, and transport 'error'
  * events without data are NOT terminal (ReconnectingEventSource reconnects
- * those); only data-carrying 'error' events reach onError. The server also
- * emits 'heartbeat' keep-alives, which need no listener. The caller owns the
- * returned source and must close() it on terminal events and teardown.
+ * those); only data-carrying 'error' events reach onError. A stream that keeps
+ * failing to (re)connect (e.g. a 404 after a server restart) invokes the
+ * optional onStalled handler so the caller can reconcile against
+ * /api/v2/import/status. The server also emits 'heartbeat' keep-alives, which
+ * need no listener. The caller owns the returned source and must close() it on
+ * terminal events and teardown.
  */
 export function connectImportProgressStream(
   jobId: string,
   handlers: ImportProgressStreamHandlers
 ): ReconnectingEventSource {
   const es = new ReconnectingEventSource(`/api/v2/import/jobs/${jobId}/progress`);
+
+  es.onreconnectfailed = attempts => {
+    if (handlers.onStalled && shouldReconcileStalledStream(attempts)) handlers.onStalled();
+  };
 
   es.addEventListener('progress', (event: Event) => {
     const progress = parseProgressEvent(event, 'progress');

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -1018,6 +1018,8 @@ export type TranslationKey =
   | 'system.importExport.done.cancelledTitle'
   | 'system.importExport.done.cancelledDescription'
   | 'system.importExport.done.errorTitle'
+  | 'system.importExport.done.interruptedTitle'
+  | 'system.importExport.done.interruptedDescription'
   | 'system.importExport.done.viewDetectionsLink'
   | 'system.importExport.done.partialInserted' // params: count
   | 'system.importExport.done.importAnother'

--- a/frontend/src/lib/utils/ReconnectingEventSource.test.ts
+++ b/frontend/src/lib/utils/ReconnectingEventSource.test.ts
@@ -341,4 +341,77 @@ describe('ReconnectingEventSource', () => {
       expect(MockEventSource.instances).toHaveLength(1);
     });
   });
+
+  describe('onreconnectfailed escalation hook', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.spyOn(Math, 'random').mockReturnValue(1);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      vi.useRealTimers();
+    });
+
+    it('fires with an incrementing count on each never-opened (re)connect failure', () => {
+      const es = new ReconnectingEventSource('/x', { eventSourceClass: ESClass });
+      const onreconnectfailed = vi.fn();
+      es.onreconnectfailed = onreconnectfailed;
+
+      // 404-style failure: fails straight from CONNECTING, never opens.
+      lastInstance().simulateFailure();
+      expect(onreconnectfailed).toHaveBeenNthCalledWith(1, 1);
+
+      vi.advanceTimersByTime(500); // reconnect #2 created
+      lastInstance().simulateFailure();
+      expect(onreconnectfailed).toHaveBeenNthCalledWith(2, 2);
+
+      vi.advanceTimersByTime(1000); // reconnect #3 created
+      lastInstance().simulateFailure();
+      expect(onreconnectfailed).toHaveBeenNthCalledWith(3, 3);
+
+      es.close();
+    });
+
+    it('resets the failure count after a successful open', () => {
+      const es = new ReconnectingEventSource('/x', { eventSourceClass: ESClass });
+      const onreconnectfailed = vi.fn();
+      es.onreconnectfailed = onreconnectfailed;
+
+      lastInstance().simulateFailure();
+      expect(onreconnectfailed).toHaveBeenLastCalledWith(1);
+      vi.advanceTimersByTime(500);
+      lastInstance().simulateFailure();
+      expect(onreconnectfailed).toHaveBeenLastCalledWith(2);
+
+      // Reconnect succeeds, resetting the counter.
+      vi.advanceTimersByTime(1000);
+      lastInstance().simulateOpen();
+
+      // A subsequent failure counts from 1 again.
+      lastInstance().simulateFailure();
+      expect(onreconnectfailed).toHaveBeenLastCalledWith(1);
+
+      es.close();
+    });
+
+    it('does nothing when no callback is set (no throw, reconnect unaffected)', () => {
+      const es = new ReconnectingEventSource('/x', { eventSourceClass: ESClass });
+      lastInstance().simulateFailure();
+      vi.advanceTimersByTime(500);
+      expect(MockEventSource.instances).toHaveLength(2);
+      es.close();
+    });
+
+    it('stops reconnecting when the callback closes the source', () => {
+      const es = new ReconnectingEventSource('/x', { eventSourceClass: ESClass });
+      es.onreconnectfailed = () => es.close();
+
+      lastInstance().simulateFailure();
+      vi.advanceTimersByTime(10000);
+
+      // The scheduled reconnect timer was cleared by close() inside the callback.
+      expect(MockEventSource.instances).toHaveLength(1);
+    });
+  });
 });

--- a/frontend/src/lib/utils/ReconnectingEventSource.ts
+++ b/frontend/src/lib/utils/ReconnectingEventSource.ts
@@ -56,6 +56,15 @@ export class ReconnectingEventSource {
   onopen: ((event: Event) => void) | null = null;
   onmessage: ((event: MessageEvent) => void) | null = null;
   onerror: ((event: Event) => void) | null = null;
+  /**
+   * Fires after each (re)connect attempt that fails without the connection ever
+   * opening, with the running count of such failures since the last successful
+   * open (reset to 0 on open). Opt-in escalation hook so a caller can react to a
+   * persistently failing stream (e.g. a 404 after a server restart, which never
+   * reaches OPEN); default null preserves the reconnect-forever behaviour every
+   * other consumer relies on.
+   */
+  onreconnectfailed: ((attempts: number) => void) | null = null;
 
   private readonly maxRetryTime: number;
   private readonly eventSourceClass: typeof EventSource;
@@ -64,6 +73,9 @@ export class ReconnectingEventSource {
   private readonly listeners = new Map<string, Set<EventListenerFn>>();
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private retryDelay = INITIAL_RETRY_TIME_MS;
+  // Consecutive (re)connect failures since the last successful open; drives the
+  // opt-in onreconnectfailed escalation hook. Reset in handleOpen.
+  private failuresSinceOpen = 0;
   private closed = false;
 
   // A single bound forwarder so add/removeEventListener on the native source use
@@ -100,8 +112,9 @@ export class ReconnectingEventSource {
   }
 
   private handleOpen(event: Event): void {
-    // A successful (re)connect resets the backoff window.
+    // A successful (re)connect resets the backoff window and failure counter.
     this.retryDelay = INITIAL_RETRY_TIME_MS;
+    this.failuresSinceOpen = 0;
     if (this.readyState === ReconnectingEventSource.CONNECTING) {
       this.readyState = ReconnectingEventSource.OPEN;
       this.onopen?.(event);
@@ -119,7 +132,13 @@ export class ReconnectingEventSource {
     if (source?.readyState === NATIVE_CLOSED) {
       source.close();
       this.eventSource = null;
+      // A source in CONNECTING is retrying internally (transient drop) and never
+      // reaches here, so every increment is a genuine full-cycle failure.
+      this.failuresSinceOpen += 1;
       this.scheduleReconnect();
+      // Fire last: if the callback closes the source synchronously, close()
+      // clears the timer scheduleReconnect just set.
+      this.onreconnectfailed?.(this.failuresSinceOpen);
     }
   }
 

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -1316,6 +1316,8 @@
         "cancelledTitle": "Import zrušen",
         "cancelledDescription": "Import byl zrušen před dokončením.",
         "errorTitle": "Import se nezdařil",
+        "interruptedTitle": "Import přerušen",
+        "interruptedDescription": "Spojení se serverem bylo během importu ztraceno, takže jeho konečný výsledek není známý. Zkontrolujte své detekce a v případě potřeby import spusťte znovu.",
         "viewDetectionsLink": "Zobrazit importované detekce",
         "partialInserted": "Před zrušením bylo importováno {count} detekcí.",
         "importAnother": "Importovat další"

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -1316,6 +1316,8 @@
         "cancelledTitle": "Import annulleret",
         "cancelledDescription": "Importen blev annulleret, før den var fuldført.",
         "errorTitle": "Import mislykkedes",
+        "interruptedTitle": "Import afbrudt",
+        "interruptedDescription": "Forbindelsen til serveren gik tabt, mens importen kørte, så det endelige resultat er ukendt. Tjek dine registreringer, og start importen igen om nødvendigt.",
         "viewDetectionsLink": "Se importerede registreringer",
         "partialInserted": "{count} registreringer blev importeret før annulleringen.",
         "importAnother": "Importér igen"

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -1316,6 +1316,8 @@
         "cancelledTitle": "Import abgebrochen",
         "cancelledDescription": "Der Import wurde vor dem Abschluss abgebrochen.",
         "errorTitle": "Import fehlgeschlagen",
+        "interruptedTitle": "Import unterbrochen",
+        "interruptedDescription": "Die Verbindung zum Server ging während des Imports verloren, daher ist das endgültige Ergebnis unbekannt. Überprüfe deine Erkennungen und starte den Import bei Bedarf erneut.",
         "viewDetectionsLink": "Importierte Erkennungen ansehen",
         "partialInserted": "{count} Erkennungen wurden vor dem Abbruch importiert.",
         "importAnother": "Weiteren Import starten"

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -1316,6 +1316,8 @@
         "cancelledTitle": "Import cancelled",
         "cancelledDescription": "The import was cancelled before completing.",
         "errorTitle": "Import failed",
+        "interruptedTitle": "Import interrupted",
+        "interruptedDescription": "The connection to the server was lost while the import was running, so its final result is unknown. Check your detections and start the import again if needed.",
         "viewDetectionsLink": "View imported detections",
         "partialInserted": "{count} detections were imported before cancellation.",
         "importAnother": "Import another"

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -1316,6 +1316,8 @@
         "cancelledTitle": "Importación cancelada",
         "cancelledDescription": "La importación se canceló antes de completarse.",
         "errorTitle": "Error en la importación",
+        "interruptedTitle": "Importación interrumpida",
+        "interruptedDescription": "Se perdió la conexión con el servidor mientras la importación estaba en curso, por lo que se desconoce su resultado final. Revisa tus detecciones y vuelve a iniciar la importación si es necesario.",
         "viewDetectionsLink": "Ver detecciones importadas",
         "partialInserted": "Se importaron {count} detecciones antes de la cancelación.",
         "importAnother": "Importar otra"

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -1316,6 +1316,8 @@
         "cancelledTitle": "Tuonti peruutettu",
         "cancelledDescription": "Tuonti peruutettiin ennen valmistumista.",
         "errorTitle": "Tuonti epäonnistui",
+        "interruptedTitle": "Tuonti keskeytyi",
+        "interruptedDescription": "Yhteys palvelimeen katkesi tuonnin aikana, joten sen lopullinen tulos ei ole tiedossa. Tarkista havaintosi ja aloita tuonti tarvittaessa uudelleen.",
         "viewDetectionsLink": "Näytä tuodut havainnot",
         "partialInserted": "{count} havaintoa tuotiin ennen peruutusta.",
         "importAnother": "Tuo uudelleen"

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -1316,6 +1316,8 @@
         "cancelledTitle": "Import annulé",
         "cancelledDescription": "L'import a été annulé avant la fin.",
         "errorTitle": "Échec de l'import",
+        "interruptedTitle": "Import interrompu",
+        "interruptedDescription": "La connexion au serveur a été perdue pendant l'import, son résultat final est donc inconnu. Vérifiez vos détections et relancez l'import si nécessaire.",
         "viewDetectionsLink": "Voir les détections importées",
         "partialInserted": "{count} détections ont été importées avant l'annulation.",
         "importAnother": "Importer à nouveau"

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -1316,6 +1316,8 @@
         "cancelledTitle": "Importálás megszakítva",
         "cancelledDescription": "Az importálás a befejezés előtt megszakadt.",
         "errorTitle": "Az importálás sikertelen",
+        "interruptedTitle": "Importálás félbeszakadt",
+        "interruptedDescription": "A szerverrel való kapcsolat megszakadt az importálás közben, ezért a végeredménye ismeretlen. Ellenőrizze az észleléseit, és szükség esetén indítsa újra az importálást.",
         "viewDetectionsLink": "Importált észlelések megtekintése",
         "partialInserted": "{count} észlelést importáltunk a megszakítás előtt.",
         "importAnother": "Újabb importálása"

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -1316,6 +1316,8 @@
         "cancelledTitle": "Importazione annullata",
         "cancelledDescription": "L'importazione è stata annullata prima del completamento.",
         "errorTitle": "Importazione non riuscita",
+        "interruptedTitle": "Importazione interrotta",
+        "interruptedDescription": "La connessione al server è stata persa durante l'importazione, quindi il suo risultato finale è sconosciuto. Controlla i tuoi rilevamenti e riavvia l'importazione se necessario.",
         "viewDetectionsLink": "Visualizza i rilevamenti importati",
         "partialInserted": "{count} rilevamenti sono stati importati prima dell'annullamento.",
         "importAnother": "Importa di nuovo"

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -1316,6 +1316,8 @@
         "cancelledTitle": "Importēšana atcelta",
         "cancelledDescription": "Importēšana tika atcelta pirms pabeigšanas.",
         "errorTitle": "Importēšana neizdevās",
+        "interruptedTitle": "Importēšana pārtraukta",
+        "interruptedDescription": "Savienojums ar serveri tika zaudēts importēšanas laikā, tāpēc tās galīgais rezultāts nav zināms. Pārbaudiet savus konstatējumus un vajadzības gadījumā sāciet importēšanu vēlreiz.",
         "viewDetectionsLink": "Skatīt importētos konstatējumus",
         "partialInserted": "Pirms atcelšanas tika importēti {count} konstatējumi.",
         "importAnother": "Importēt citu"

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -1316,6 +1316,8 @@
         "cancelledTitle": "Import avbrutt",
         "cancelledDescription": "Importen ble avbrutt før den var fullført.",
         "errorTitle": "Import mislyktes",
+        "interruptedTitle": "Import stanset",
+        "interruptedDescription": "Tilkoblingen til serveren ble brutt mens importen pågikk, så det endelige resultatet er ukjent. Sjekk deteksjonene dine og start importen på nytt om nødvendig.",
         "viewDetectionsLink": "Vis importerte deteksjoner",
         "partialInserted": "{count} deteksjoner ble importert før avbruddet.",
         "importAnother": "Importer på nytt"

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -1316,6 +1316,8 @@
         "cancelledTitle": "Import geannuleerd",
         "cancelledDescription": "De import is geannuleerd voordat deze voltooid was.",
         "errorTitle": "Import mislukt",
+        "interruptedTitle": "Import onderbroken",
+        "interruptedDescription": "De verbinding met de server is verbroken terwijl de import bezig was, dus het uiteindelijke resultaat is onbekend. Controleer je detecties en start de import opnieuw als dat nodig is.",
         "viewDetectionsLink": "Geïmporteerde detecties bekijken",
         "partialInserted": "{count} detecties zijn geïmporteerd vóór de annulering.",
         "importAnother": "Nog een import uitvoeren"

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -1316,6 +1316,8 @@
         "cancelledTitle": "Import anulowany",
         "cancelledDescription": "Import został anulowany przed ukończeniem.",
         "errorTitle": "Import nie powiódł się",
+        "interruptedTitle": "Import przerwany",
+        "interruptedDescription": "Połączenie z serwerem zostało utracone podczas trwania importu, więc jego ostateczny wynik jest nieznany. Sprawdź swoje wykrycia i w razie potrzeby rozpocznij import ponownie.",
         "viewDetectionsLink": "Zobacz zaimportowane wykrycia",
         "partialInserted": "Przed anulowaniem zaimportowano {count} wykryć.",
         "importAnother": "Importuj kolejny"

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -1316,6 +1316,8 @@
         "cancelledTitle": "Importação cancelada",
         "cancelledDescription": "A importação foi cancelada antes de concluir.",
         "errorTitle": "A importação falhou",
+        "interruptedTitle": "Importação interrompida",
+        "interruptedDescription": "A ligação ao servidor foi perdida durante a importação, pelo que o seu resultado final é desconhecido. Verifique as suas deteções e reinicie a importação se necessário.",
         "viewDetectionsLink": "Ver deteções importadas",
         "partialInserted": "{count} deteções foram importadas antes do cancelamento.",
         "importAnother": "Importar outra"

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -1316,6 +1316,8 @@
         "cancelledTitle": "Import zrušený",
         "cancelledDescription": "Import bol zrušený pred dokončením.",
         "errorTitle": "Import zlyhal",
+        "interruptedTitle": "Import prerušený",
+        "interruptedDescription": "Spojenie so serverom sa počas importu prerušilo, takže jeho konečný výsledok nie je známy. Skontrolujte svoje detekcie a v prípade potreby spustite import znova.",
         "viewDetectionsLink": "Zobraziť importované detekcie",
         "partialInserted": "Pred zrušením bolo importovaných {count} detekcií.",
         "importAnother": "Importovať ďalší"

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -1316,6 +1316,8 @@
         "cancelledTitle": "Import avbruten",
         "cancelledDescription": "Importen avbröts innan den slutfördes.",
         "errorTitle": "Importen misslyckades",
+        "interruptedTitle": "Import stoppad",
+        "interruptedDescription": "Anslutningen till servern bröts medan importen pågick, så det slutliga resultatet är okänt. Kontrollera dina detekteringar och starta importen igen om det behövs.",
         "viewDetectionsLink": "Visa importerade detekteringar",
         "partialInserted": "{count} detekteringar importerades före avbrottet.",
         "importAnother": "Importera igen"


### PR DESCRIPTION
## Summary

When the server restarts while a BirdNET-Pi import is running, the in-memory import job manager comes back empty, so `GET /api/v2/import/jobs/{id}/progress` returns 404 on reconnect. The native EventSource treats that as fatal and closes, and `ReconnectingEventSource` then retried every ~3s indefinitely, leaving the import UI stuck showing a stale "running" state with frozen progress until the user reloaded the page. This affected both the persistent activity card and the import wizard.

The root cause is architectural: the UI trusted the SSE stream as the sole liveness signal, with no reconciliation against the authoritative `GET /api/v2/import/status` endpoint.

This adds an opt-in `onreconnectfailed` hook to `ReconnectingEventSource` that counts consecutive failed reconnects since the last successful open. It defaults to `null`, so the other SSE consumers (metrics, notifications, live audio, etc.) keep reconnecting forever unchanged. The import progress helper uses it, once the stream has been failing long enough (up to ~3.5s) to rule out a transient blip, to reconcile against `/api/v2/import/status`.

On a stall both consumers re-poll status: if the same job is still running it was a transient blip and the stream is kept; if the job is gone (server restarted) they stop the stream and show an honest "interrupted" state instead of a stale running view or a misleading empty state; if the job actually finished they show its real terminal outcome. The reconciliation only adopts a finished status whose job id matches the job it was watching, and the wizard cancel path now falls back to a terminal state so a failed post-cancel status fetch can no longer wedge the UI on "Cancelling...".

## Changes

- `ReconnectingEventSource`: opt-in `onreconnectfailed(attempts)` escalation hook (default off; the ~10 other consumers are byte-for-byte unaffected).
- Import progress helper: `STREAM_STALL_THRESHOLD` + pure `shouldReconcileStalledStream`, wired to a new optional `onStalled` handler.
- `ImportActivityCard`: reconciles on stall and shows an honest interrupted state (an `Unplug` icon, description, and a detections link) instead of reverting to the empty view.
- `BirdNetPiImportWizard`: interrupted terminal state, job-id-guarded status reconciliation, and a cancel-path terminal fallback.
- New i18n keys `system.importExport.done.interruptedTitle` / `interruptedDescription`, translated across all 15 locales.

## Test Plan

- [x] `npm run check:all` (typecheck, eslint, stylelint, ast-grep, prettier) clean
- [x] `npm test` full suite green
- [x] New unit tests: `onreconnectfailed` count semantics and reset-on-open, `shouldReconcileStalledStream` threshold gating, card + wizard stall reconcile (interrupted / kept / real-terminal), and a stale-reconcile-vs-terminal-SSE race guard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Interrupted” import result when the server connection is lost and the final outcome cannot be confirmed.
  * Added guidance to review detections and retry the import when necessary.
  * Improved cancellation handling to prevent incorrect status updates.
  * Added accessibility improvements for completion-state icons.
  * Added translations for the interrupted state across supported languages.

* **Bug Fixes**
  * Import progress now reconciles stalled connections with the latest job status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->