### PR TITLE
fix: safely sanitize non-finite floats in slog arguments

### DIFF
--- a/internal/logger/central_logger.go
+++ b/internal/logger/central_logger.go
@@ -800,6 +800,24 @@ func sanitizeReflect(rv reflect.Value, visited map[uintptr]bool) (any, bool) {
 		return nil, false
 	}
 
+	// Also check if the pointer to the value implements these interfaces (if addressable)
+	if rv.CanAddr() {
+		addr := rv.Addr()
+		ifaceAddr := addr.Interface()
+		if _, ok := ifaceAddr.(slog.LogValuer); ok {
+			return nil, false
+		}
+		if _, ok := ifaceAddr.(fmt.Stringer); ok {
+			return nil, false
+		}
+		if _, ok := ifaceAddr.(error); ok {
+			return nil, false
+		}
+		if addr.Type().Implements(reflect.TypeFor[interface{ MarshalJSON() ([]byte, error) }]()) {
+			return nil, false
+		}
+	}
+
 	switch rv.Kind() {
 	case reflect.Float32, reflect.Float64:
 		f := rv.Float()

--- a/internal/logger/central_logger.go
+++ b/internal/logger/central_logger.go
@@ -752,7 +752,10 @@ func sanitizeAny(v any) any {
 	}
 
 	rv := reflect.ValueOf(v)
-	return sanitizeReflect(rv)
+	if san, mod := sanitizeReflect(rv, make(map[uintptr]bool)); mod {
+		return san
+	}
+	return v
 }
 
 func logSafeFloat(f float64) string {
@@ -770,68 +773,128 @@ func logSafeFloat(f float64) string {
 }
 
 // sanitizeReflect recursively traverses the reflect.Value and returns a sanitized any.
-// To avoid mutating user data, it creates copies of structs/maps/slices that contain
-// non-finite floats. If no non-finite floats are found, it returns the original value.
-//nolint:gocognit // Recursive reflection is inherently complex
-func sanitizeReflect(rv reflect.Value) any {
-	if !rv.IsValid() {
-		return nil
+// It tracks visited pointers to avoid stack overflows on cyclic data.
+// If no non-finite floats are found, it returns (nil, false) to avoid heap allocations.
+//nolint:gocognit,cyclop,gocyclo // Recursive reflection is inherently complex
+func sanitizeReflect(rv reflect.Value, visited map[uintptr]bool) (any, bool) {
+	if !rv.IsValid() || !rv.CanInterface() {
+		return nil, false
+	}
+
+	// Trust custom serialization for types that implement it natively.
+	// encoding/json relies on json.Marshaler, slog relies on slog.LogValuer
+	iface := rv.Interface()
+	if _, ok := iface.(slog.LogValuer); ok {
+		return nil, false
+	}
+	if _, ok := iface.(fmt.Stringer); ok {
+		return nil, false
+	}
+	if _, ok := iface.(error); ok {
+		return nil, false
+	}
+
+	// Avoid descending into json.Marshaler (we do this via reflection to avoid
+	// unnecessarily importing encoding/json here if not needed, though the package might).
+	if rv.Type().Implements(reflect.TypeFor[interface{ MarshalJSON() ([]byte, error) }]()) {
+		return nil, false
 	}
 
 	switch rv.Kind() {
 	case reflect.Float32, reflect.Float64:
 		f := rv.Float()
 		if math.IsNaN(f) || math.IsInf(f, 0) {
-			return logSafeFloat(f)
+			return logSafeFloat(f), true
 		}
-		return rv.Interface()
+		return nil, false
 
 	case reflect.Slice, reflect.Array:
-		if rv.IsZero() {
-			return rv.Interface()
+		if rv.Len() == 0 || (rv.Kind() == reflect.Slice && rv.IsNil()) {
+			return nil, false
 		}
-		// Try to find if any element needs sanitizing first, to avoid allocation
+		if rv.Kind() == reflect.Slice {
+			ptr := rv.Pointer()
+			if visited[ptr] {
+				return nil, false
+			}
+			visited[ptr] = true
+			defer delete(visited, ptr)
+		}
+
 		needsCopy := false
 		for i := range rv.Len() {
-			elem := rv.Index(i)
-			sanitized := sanitizeReflect(elem)
-			if sanitized != elem.Interface() {
+			if _, mod := sanitizeReflect(rv.Index(i), visited); mod {
 				needsCopy = true
 				break
 			}
 		}
 		if !needsCopy {
-			return rv.Interface()
+			return nil, false
 		}
 
 		cp := make([]any, rv.Len())
 		for i := range rv.Len() {
-			cp[i] = sanitizeReflect(rv.Index(i))
+			elem := rv.Index(i)
+			san, mod := sanitizeReflect(elem, visited)
+			if mod {
+				cp[i] = san
+			} else if elem.CanInterface() {
+				cp[i] = elem.Interface()
+			}
 		}
-		return cp
+		return cp, true
 
 	case reflect.Map:
-		if rv.IsZero() {
-			return rv.Interface()
+		if rv.Len() == 0 || rv.IsNil() {
+			return nil, false
 		}
+		ptr := rv.Pointer()
+		if visited[ptr] {
+			return nil, false
+		}
+		visited[ptr] = true
+		defer delete(visited, ptr)
+
 		needsCopy := false
 		iter := rv.MapRange()
 		for iter.Next() {
-			if sanitizeReflect(iter.Key()) != iter.Key().Interface() || sanitizeReflect(iter.Value()) != iter.Value().Interface() {
+			_, kMod := sanitizeReflect(iter.Key(), visited)
+			_, vMod := sanitizeReflect(iter.Value(), visited)
+			if kMod || vMod {
 				needsCopy = true
 				break
 			}
 		}
 		if !needsCopy {
-			return rv.Interface()
+			return nil, false
 		}
 
-		cp := make(map[any]any, rv.Len())
+		cp := make(map[string]any, rv.Len())
 		iter = rv.MapRange()
 		for iter.Next() {
-			cp[sanitizeReflect(iter.Key())] = sanitizeReflect(iter.Value())
+			k := iter.Key()
+			v := iter.Value()
+			kSan, kMod := sanitizeReflect(k, visited)
+			vSan, vMod := sanitizeReflect(v, visited)
+
+			kStr := ""
+			switch {
+			case k.Kind() == reflect.String:
+				kStr = k.String()
+			case kMod:
+				kStr = fmt.Sprint(kSan)
+			case k.CanInterface():
+				kStr = fmt.Sprint(k.Interface())
+			}
+
+			switch {
+			case vMod:
+				cp[kStr] = vSan
+			case v.CanInterface():
+				cp[kStr] = v.Interface()
+			}
 		}
-		return cp
+		return cp, true
 
 	case reflect.Struct:
 		needsCopy := false
@@ -841,13 +904,13 @@ func sanitizeReflect(rv reflect.Value) any {
 			if !field.IsExported() {
 				continue
 			}
-			if sanitizeReflect(rv.Field(i)) != rv.Field(i).Interface() {
+			if _, mod := sanitizeReflect(rv.Field(i), visited); mod {
 				needsCopy = true
 				break
 			}
 		}
 		if !needsCopy {
-			return rv.Interface()
+			return nil, false
 		}
 
 		cp := make(map[string]any, rv.NumField())
@@ -857,25 +920,52 @@ func sanitizeReflect(rv reflect.Value) any {
 			if !field.IsExported() {
 				continue
 			}
-			cp[field.Name] = sanitizeReflect(rv.Field(i))
+
+			key := field.Name
+			tag := field.Tag.Get("json")
+			if tag == "-" {
+				continue
+			}
+			if tag != "" {
+				if idx := strings.Index(tag, ","); idx != -1 {
+					if idx > 0 {
+						key = tag[:idx]
+					}
+				} else {
+					key = tag
+				}
+			}
+
+			san, mod := sanitizeReflect(rv.Field(i), visited)
+			if mod {
+				cp[key] = san
+			} else if rv.Field(i).CanInterface() {
+				cp[key] = rv.Field(i).Interface()
+			}
 		}
-		return cp
+		return cp, true
 
 	case reflect.Pointer, reflect.Interface:
 		if rv.IsNil() {
-			return rv.Interface()
+			return nil, false
 		}
-		sanitized := sanitizeReflect(rv.Elem())
-		if sanitized != rv.Elem().Interface() {
-			return sanitized
+		if rv.Kind() == reflect.Pointer {
+			ptr := rv.Pointer()
+			if visited[ptr] {
+				return nil, false
+			}
+			visited[ptr] = true
+			defer delete(visited, ptr)
 		}
-		return rv.Interface()
+
+		san, mod := sanitizeReflect(rv.Elem(), visited)
+		if mod {
+			return san, true
+		}
+		return nil, false
 
 	default:
-		if rv.CanInterface() {
-			return rv.Interface()
-		}
-		return nil
+		return nil, false
 	}
 }
 

--- a/internal/logger/central_logger.go
+++ b/internal/logger/central_logger.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strings"
 	"sync"
@@ -723,7 +724,158 @@ func fieldToAttr(f Field) slog.Attr {
 		// slog.Duration outputs nanoseconds in JSON which is not human-friendly
 		return slog.String(f.Key, v.Round(time.Millisecond).String())
 	default:
-		return slog.Any(f.Key, v)
+		return slog.Any(f.Key, sanitizeAny(v))
+	}
+}
+
+// sanitizeAny recursively sanitizes a value passed to logger.Any to ensure it contains
+// no non-finite floats (NaN, +Inf, -Inf) which would corrupt the JSON log output.
+func sanitizeAny(v any) any {
+	if v == nil {
+		return nil
+	}
+
+	// Fast path for common basic types to avoid reflection overhead
+	switch val := v.(type) {
+	case float64:
+		if math.IsNaN(val) || math.IsInf(val, 0) {
+			return logSafeFloat(val)
+		}
+		return val
+	case float32:
+		if math.IsNaN(float64(val)) || math.IsInf(float64(val), 0) {
+			return logSafeFloat(float64(val))
+		}
+		return val
+	case int, int64, string, bool:
+		return val
+	}
+
+	rv := reflect.ValueOf(v)
+	return sanitizeReflect(rv)
+}
+
+func logSafeFloat(f float64) string {
+	switch {
+	case math.IsNaN(f):
+		return "nan"
+	case math.IsInf(f, 1):
+		return "+inf"
+	case math.IsInf(f, -1):
+		return "-inf"
+	default:
+		// Should not be reached, but fallback safely
+		return "unknown"
+	}
+}
+
+// sanitizeReflect recursively traverses the reflect.Value and returns a sanitized any.
+// To avoid mutating user data, it creates copies of structs/maps/slices that contain
+// non-finite floats. If no non-finite floats are found, it returns the original value.
+//nolint:gocognit // Recursive reflection is inherently complex
+func sanitizeReflect(rv reflect.Value) any {
+	if !rv.IsValid() {
+		return nil
+	}
+
+	switch rv.Kind() {
+	case reflect.Float32, reflect.Float64:
+		f := rv.Float()
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			return logSafeFloat(f)
+		}
+		return rv.Interface()
+
+	case reflect.Slice, reflect.Array:
+		if rv.IsZero() {
+			return rv.Interface()
+		}
+		// Try to find if any element needs sanitizing first, to avoid allocation
+		needsCopy := false
+		for i := range rv.Len() {
+			elem := rv.Index(i)
+			sanitized := sanitizeReflect(elem)
+			if sanitized != elem.Interface() {
+				needsCopy = true
+				break
+			}
+		}
+		if !needsCopy {
+			return rv.Interface()
+		}
+
+		cp := make([]any, rv.Len())
+		for i := range rv.Len() {
+			cp[i] = sanitizeReflect(rv.Index(i))
+		}
+		return cp
+
+	case reflect.Map:
+		if rv.IsZero() {
+			return rv.Interface()
+		}
+		needsCopy := false
+		iter := rv.MapRange()
+		for iter.Next() {
+			if sanitizeReflect(iter.Key()) != iter.Key().Interface() || sanitizeReflect(iter.Value()) != iter.Value().Interface() {
+				needsCopy = true
+				break
+			}
+		}
+		if !needsCopy {
+			return rv.Interface()
+		}
+
+		cp := make(map[any]any, rv.Len())
+		iter = rv.MapRange()
+		for iter.Next() {
+			cp[sanitizeReflect(iter.Key())] = sanitizeReflect(iter.Value())
+		}
+		return cp
+
+	case reflect.Struct:
+		needsCopy := false
+		//nolint:gocritic
+		for i := 0; i < rv.NumField(); i++ {
+			field := rv.Type().Field(i)
+			if !field.IsExported() {
+				continue
+			}
+			if sanitizeReflect(rv.Field(i)) != rv.Field(i).Interface() {
+				needsCopy = true
+				break
+			}
+		}
+		if !needsCopy {
+			return rv.Interface()
+		}
+
+		cp := make(map[string]any, rv.NumField())
+		//nolint:gocritic
+		for i := 0; i < rv.NumField(); i++ {
+			field := rv.Type().Field(i)
+			if !field.IsExported() {
+				continue
+			}
+			cp[field.Name] = sanitizeReflect(rv.Field(i))
+		}
+		return cp
+
+	case reflect.Pointer, reflect.Interface:
+		if rv.IsNil() {
+			return rv.Interface()
+		}
+		sanitized := sanitizeReflect(rv.Elem())
+		if sanitized != rv.Elem().Interface() {
+			return sanitized
+		}
+		return rv.Interface()
+
+	default:
+		if rv.CanInterface() {
+			return rv.Interface()
+		}
+		return nil
 	}
 }
 

--- a/internal/logger/central_logger.go
+++ b/internal/logger/central_logger.go
@@ -775,10 +775,13 @@ func sanitizeAny(v any) any {
 	// unexported embedded struct. If such a value still fails to encode because
 	// of a non-finite float, fall back to a string so the logger emits readable
 	// data instead of a corrupt "!ERROR: json: unsupported value" placeholder.
-	// Unsupported *types* (chan/func) are left untouched and render as before.
+	// Stringify the partially-sanitized san (not v): it preserves the float
+	// replacements already made and has any reference cycles broken, so it is
+	// both more informative and safe to format. Unsupported *types* (chan/func)
+	// are left untouched and render as before.
 	if _, err := json.Marshal(san); err != nil {
 		if _, ok := stderrors.AsType[*json.UnsupportedValueError](err); ok {
-			return fmt.Sprintf("%+v", v)
+			return fmt.Sprintf("%+v", san)
 		}
 	}
 	return san
@@ -870,26 +873,24 @@ func sanitizeReflect(rv reflect.Value, visited map[uintptr]bool) (any, bool) {
 			defer delete(visited, ptr)
 		}
 
+		// Single lazy pass: sanitize each element once, tracking whether any
+		// changed. Recursing twice (detect then copy) is O(2^depth) on nested
+		// dirty values.
+		cp := make([]any, rv.Len())
 		needsCopy := false
 		for i := range rv.Len() {
-			if _, mod := sanitizeReflect(rv.Index(i), visited); mod {
+			elem := rv.Index(i)
+			san, mod := sanitizeReflect(elem, visited)
+			switch {
+			case mod:
 				needsCopy = true
-				break
+				cp[i] = san
+			case elem.CanInterface():
+				cp[i] = elem.Interface()
 			}
 		}
 		if !needsCopy {
 			return nil, false
-		}
-
-		cp := make([]any, rv.Len())
-		for i := range rv.Len() {
-			elem := rv.Index(i)
-			san, mod := sanitizeReflect(elem, visited)
-			if mod {
-				cp[i] = san
-			} else if elem.CanInterface() {
-				cp[i] = elem.Interface()
-			}
 		}
 		return cp, true
 
@@ -904,27 +905,19 @@ func sanitizeReflect(rv reflect.Value, visited map[uintptr]bool) (any, bool) {
 		visited[ptr] = true
 		defer delete(visited, ptr)
 
+		// Single lazy pass: sanitize each key/value once, tracking whether any
+		// changed, then discard the copy if nothing did.
+		cp := make(map[string]any, rv.Len())
 		needsCopy := false
 		iter := rv.MapRange()
-		for iter.Next() {
-			_, kMod := sanitizeReflect(iter.Key(), visited)
-			_, vMod := sanitizeReflect(iter.Value(), visited)
-			if kMod || vMod {
-				needsCopy = true
-				break
-			}
-		}
-		if !needsCopy {
-			return nil, false
-		}
-
-		cp := make(map[string]any, rv.Len())
-		iter = rv.MapRange()
 		for iter.Next() {
 			k := iter.Key()
 			v := iter.Value()
 			kSan, kMod := sanitizeReflect(k, visited)
 			vSan, vMod := sanitizeReflect(v, visited)
+			if kMod || vMod {
+				needsCopy = true
+			}
 
 			kStr := ""
 			switch {
@@ -954,14 +947,16 @@ func sanitizeReflect(rv reflect.Value, visited map[uintptr]bool) (any, bool) {
 				cp[kStr] = v.Interface()
 			}
 		}
+		if !needsCopy {
+			return nil, false
+		}
 		return cp, true
 
 	case reflect.Struct:
-		if !structNeedsCopy(rv, visited) {
+		cp := make(map[string]any)
+		if !flattenStruct(rv, cp, visited) {
 			return nil, false
 		}
-		cp := make(map[string]any)
-		flattenStruct(rv, cp, visited)
 		return cp, true
 
 	case reflect.Pointer, reflect.Interface:
@@ -1000,8 +995,15 @@ func getTraceIDFromContext(ctx context.Context) string {
 	return ""
 }
 
+// flattenStruct writes rv's exported fields into cp, mirroring encoding/json's
+// promotion of anonymous fields and its json tag / omitempty / omitzero
+// handling, with non-finite floats sanitized. It reports whether any value was
+// modified so the caller can discard cp (and fall back to the original struct)
+// when nothing needed changing. Doing detection and copying in one pass avoids
+// the O(2^depth) re-walk of a separate needs-copy probe.
+//
 //nolint:gocognit // Recursive struct flattening naturally has higher complexity
-func structNeedsCopy(rv reflect.Value, visited map[uintptr]bool) bool {
+func flattenStruct(rv reflect.Value, cp map[string]any, visited map[uintptr]bool) bool {
 	if rv.Kind() == reflect.Pointer || rv.Kind() == reflect.Interface {
 		if rv.IsNil() {
 			return false
@@ -1011,65 +1013,7 @@ func structNeedsCopy(rv reflect.Value, visited map[uintptr]bool) bool {
 	if rv.Kind() != reflect.Struct {
 		return false
 	}
-	//nolint:gocritic // rv.NumField() is appropriate for iterating over fields
-	for i := 0; i < rv.NumField(); i++ {
-		field := rv.Type().Field(i)
-		if !field.IsExported() {
-			continue
-		}
-		fv := rv.Field(i)
-
-		if field.Anonymous {
-			fvElem := fv
-			var ptr uintptr
-			var isPtr bool
-			if fvElem.Kind() == reflect.Pointer || fvElem.Kind() == reflect.Interface {
-				if !fvElem.IsNil() {
-					if fvElem.Kind() == reflect.Pointer {
-						ptr = fvElem.Pointer()
-						isPtr = true
-					}
-					fvElem = fvElem.Elem()
-				}
-			}
-			if fvElem.Kind() == reflect.Struct {
-				if isPtr {
-					if visited[ptr] {
-						continue
-					}
-					visited[ptr] = true
-				}
-				if structNeedsCopy(fvElem, visited) {
-					if isPtr {
-						delete(visited, ptr)
-					}
-					return true
-				}
-				if isPtr {
-					delete(visited, ptr)
-				}
-				continue
-			}
-		}
-
-		if _, mod := sanitizeReflect(fv, visited); mod {
-			return true
-		}
-	}
-	return false
-}
-
-//nolint:gocognit // Recursive struct flattening naturally has higher complexity
-func flattenStruct(rv reflect.Value, cp map[string]any, visited map[uintptr]bool) {
-	if rv.Kind() == reflect.Pointer || rv.Kind() == reflect.Interface {
-		if rv.IsNil() {
-			return
-		}
-		rv = rv.Elem()
-	}
-	if rv.Kind() != reflect.Struct {
-		return
-	}
+	modified := false
 	//nolint:gocritic // rv.NumField() is appropriate for iterating over fields in a struct.
 	for i := 0; i < rv.NumField(); i++ {
 		field := rv.Type().Field(i)
@@ -1097,7 +1041,9 @@ func flattenStruct(rv reflect.Value, cp map[string]any, visited map[uintptr]bool
 					}
 					visited[ptr] = true
 				}
-				flattenStruct(fvElem, cp, visited)
+				if flattenStruct(fvElem, cp, visited) {
+					modified = true
+				}
 				if isPtr {
 					delete(visited, ptr)
 				}
@@ -1129,6 +1075,9 @@ func flattenStruct(rv reflect.Value, cp map[string]any, visited map[uintptr]bool
 		}
 
 		san, mod := sanitizeReflect(fv, visited)
+		if mod {
+			modified = true
+		}
 		var val any
 		if mod {
 			val = san
@@ -1144,6 +1093,7 @@ func flattenStruct(rv reflect.Value, cp map[string]any, visited map[uintptr]bool
 		}
 		cp[key] = val
 	}
+	return modified
 }
 
 func isEmptyValue(v reflect.Value, val any) bool {

--- a/internal/logger/central_logger.go
+++ b/internal/logger/central_logger.go
@@ -2,6 +2,8 @@ package logger
 
 import (
 	"context"
+	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"log/slog"
 	"math"
@@ -246,7 +248,7 @@ func (cl *CentralLogger) createBaseHandler() error {
 
 		fileLevel := parseLogLevel(cl.config.FileOutput.Level)
 		opts := &slog.HandlerOptions{
-			Level: fileLevel,
+			Level:       fileLevel,
 			ReplaceAttr: timeZoneReplaceAttr(cl.timezone),
 		}
 		handlers = append(handlers, slog.NewJSONHandler(writer, opts))
@@ -752,21 +754,48 @@ func sanitizeAny(v any) any {
 		return val
 	}
 
-	rv := reflect.ValueOf(v)
-	if san, mod := sanitizeReflect(rv, make(map[uintptr]bool)); mod {
-		return san
+	// If the value already marshals cleanly it holds no non-finite floats (and
+	// no reference cycles), so return it unchanged: slog then serializes it with
+	// real encoding/json semantics and the reflective walk is skipped entirely.
+	// Only values encoding/json cannot encode fall through to the sanitizer.
+	if _, err := json.Marshal(v); err == nil {
+		return v
 	}
-	return v
+
+	// Best effort: recursively replace non-finite floats and break reference
+	// cycles so the value becomes encodable while preserving structure where
+	// possible.
+	san := v
+	if s, mod := sanitizeReflect(reflect.ValueOf(v), make(map[uintptr]bool)); mod {
+		san = s
+	}
+
+	// Safety net: the reflective walk cannot reach a non-finite float hidden
+	// behind a fmt.Stringer/error/json.Marshaler, or one promoted from an
+	// unexported embedded struct. If such a value still fails to encode because
+	// of a non-finite float, fall back to a string so the logger emits readable
+	// data instead of a corrupt "!ERROR: json: unsupported value" placeholder.
+	// Unsupported *types* (chan/func) are left untouched and render as before.
+	if _, err := json.Marshal(san); err != nil {
+		if _, ok := stderrors.AsType[*json.UnsupportedValueError](err); ok {
+			return fmt.Sprintf("%+v", v)
+		}
+	}
+	return san
 }
 
+// logSafeFloat renders a non-finite float as a JSON-safe string. It mirrors the
+// spelling used by floatAttr ("NaN"/"+Inf"/"-Inf", matching Go's %v) so the same
+// value renders identically whether it arrives as a typed float field or nested
+// inside an Any value.
 func logSafeFloat(f float64) string {
 	switch {
 	case math.IsNaN(f):
-		return "nan"
+		return "NaN"
 	case math.IsInf(f, 1):
-		return "+inf"
+		return "+Inf"
 	case math.IsInf(f, -1):
-		return "-inf"
+		return "-Inf"
 	default:
 		// Should not be reached, but fallback safely
 		return "unknown"
@@ -776,6 +805,7 @@ func logSafeFloat(f float64) string {
 // sanitizeReflect recursively traverses the reflect.Value and returns a sanitized any.
 // It tracks visited pointers to avoid stack overflows on cyclic data.
 // If no non-finite floats are found, it returns (nil, false) to avoid heap allocations.
+//
 //nolint:gocognit,cyclop,gocyclo // Recursive reflection is inherently complex
 func sanitizeReflect(rv reflect.Value, visited map[uintptr]bool) (any, bool) {
 	if !rv.IsValid() || !rv.CanInterface() {
@@ -988,7 +1018,7 @@ func structNeedsCopy(rv reflect.Value, visited map[uintptr]bool) bool {
 			continue
 		}
 		fv := rv.Field(i)
-		
+
 		if field.Anonymous {
 			fvElem := fv
 			var ptr uintptr

--- a/internal/logger/central_logger.go
+++ b/internal/logger/central_logger.go
@@ -247,6 +247,7 @@ func (cl *CentralLogger) createBaseHandler() error {
 		fileLevel := parseLogLevel(cl.config.FileOutput.Level)
 		opts := &slog.HandlerOptions{
 			Level: fileLevel,
+			ReplaceAttr: timeZoneReplaceAttr(cl.timezone),
 		}
 		handlers = append(handlers, slog.NewJSONHandler(writer, opts))
 	}
@@ -833,7 +834,7 @@ func sanitizeReflect(rv reflect.Value, visited map[uintptr]bool) (any, bool) {
 		if rv.Kind() == reflect.Slice {
 			ptr := rv.Pointer()
 			if visited[ptr] {
-				return nil, false
+				return "[Circular]", true
 			}
 			visited[ptr] = true
 			defer delete(visited, ptr)
@@ -868,7 +869,7 @@ func sanitizeReflect(rv reflect.Value, visited map[uintptr]bool) (any, bool) {
 		}
 		ptr := rv.Pointer()
 		if visited[ptr] {
-			return nil, false
+			return "[Circular]", true
 		}
 		visited[ptr] = true
 		defer delete(visited, ptr)
@@ -915,52 +916,11 @@ func sanitizeReflect(rv reflect.Value, visited map[uintptr]bool) (any, bool) {
 		return cp, true
 
 	case reflect.Struct:
-		needsCopy := false
-		//nolint:gocritic
-		for i := 0; i < rv.NumField(); i++ {
-			field := rv.Type().Field(i)
-			if !field.IsExported() {
-				continue
-			}
-			if _, mod := sanitizeReflect(rv.Field(i), visited); mod {
-				needsCopy = true
-				break
-			}
-		}
-		if !needsCopy {
+		if !structNeedsCopy(rv, visited) {
 			return nil, false
 		}
-
-		cp := make(map[string]any, rv.NumField())
-		//nolint:gocritic
-		for i := 0; i < rv.NumField(); i++ {
-			field := rv.Type().Field(i)
-			if !field.IsExported() {
-				continue
-			}
-
-			key := field.Name
-			tag := field.Tag.Get("json")
-			if tag == "-" {
-				continue
-			}
-			if tag != "" {
-				if idx := strings.Index(tag, ","); idx != -1 {
-					if idx > 0 {
-						key = tag[:idx]
-					}
-				} else {
-					key = tag
-				}
-			}
-
-			san, mod := sanitizeReflect(rv.Field(i), visited)
-			if mod {
-				cp[key] = san
-			} else if rv.Field(i).CanInterface() {
-				cp[key] = rv.Field(i).Interface()
-			}
-		}
+		cp := make(map[string]any)
+		flattenStruct(rv, cp, visited)
 		return cp, true
 
 	case reflect.Pointer, reflect.Interface:
@@ -970,7 +930,7 @@ func sanitizeReflect(rv reflect.Value, visited map[uintptr]bool) (any, bool) {
 		if rv.Kind() == reflect.Pointer {
 			ptr := rv.Pointer()
 			if visited[ptr] {
-				return nil, false
+				return "[Circular]", true
 			}
 			visited[ptr] = true
 			defer delete(visited, ptr)
@@ -997,4 +957,158 @@ func getTraceIDFromContext(ctx context.Context) string {
 		return traceID
 	}
 	return ""
+}
+
+func structNeedsCopy(rv reflect.Value, visited map[uintptr]bool) bool {
+	if rv.Kind() == reflect.Pointer || rv.Kind() == reflect.Interface {
+		if rv.IsNil() {
+			return false
+		}
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Struct {
+		return false
+	}
+	//nolint:gocritic // rv.NumField() is appropriate for iterating over fields
+	for i := 0; i < rv.NumField(); i++ {
+		field := rv.Type().Field(i)
+		if !field.IsExported() {
+			continue
+		}
+		fv := rv.Field(i)
+		
+		if field.Anonymous {
+			fvElem := fv
+			if fvElem.Kind() == reflect.Pointer || fvElem.Kind() == reflect.Interface {
+				if !fvElem.IsNil() {
+					fvElem = fvElem.Elem()
+				}
+			}
+			if fvElem.Kind() == reflect.Struct {
+				if structNeedsCopy(fvElem, visited) {
+					return true
+				}
+				continue
+			}
+		}
+
+		if _, mod := sanitizeReflect(fv, visited); mod {
+			return true
+		}
+	}
+	return false
+}
+
+func flattenStruct(rv reflect.Value, cp map[string]any, visited map[uintptr]bool) {
+	if rv.Kind() == reflect.Pointer || rv.Kind() == reflect.Interface {
+		if rv.IsNil() {
+			return
+		}
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Struct {
+		return
+	}
+	//nolint:gocritic // rv.NumField() is appropriate for iterating over fields in a struct.
+	for i := 0; i < rv.NumField(); i++ {
+		field := rv.Type().Field(i)
+		if !field.IsExported() {
+			continue
+		}
+		fv := rv.Field(i)
+		if field.Anonymous {
+			fvElem := fv
+			if fvElem.Kind() == reflect.Pointer || fvElem.Kind() == reflect.Interface {
+				if !fvElem.IsNil() {
+					fvElem = fvElem.Elem()
+				}
+			}
+			if fvElem.Kind() == reflect.Struct {
+				flattenStruct(fvElem, cp, visited)
+				continue
+			}
+		}
+
+		key := field.Name
+		tag := field.Tag.Get("json")
+		if tag == "-" {
+			continue
+		}
+
+		omitempty := false
+		omitzero := false
+		if tag != "" {
+			parts := strings.Split(tag, ",")
+			if parts[0] != "" {
+				key = parts[0]
+			}
+			for _, part := range parts[1:] {
+				switch part {
+				case "omitempty":
+					omitempty = true
+				case "omitzero":
+					omitzero = true
+				}
+			}
+		}
+
+		san, mod := sanitizeReflect(fv, visited)
+		var val any
+		if mod {
+			val = san
+		} else if fv.CanInterface() {
+			val = fv.Interface()
+		}
+
+		if omitempty && isEmptyValue(fv, val) {
+			continue
+		}
+		if omitzero && isZeroValue(fv) {
+			continue
+		}
+		cp[key] = val
+	}
+}
+
+func isEmptyValue(v reflect.Value, val any) bool {
+	if val == nil {
+		return true
+	}
+	//nolint:exhaustive // Intentionally handling only types that can be empty values
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Pointer:
+		return v.IsNil()
+	}
+	return false
+}
+
+func isZeroValue(v reflect.Value) bool {
+	if !v.IsValid() {
+		return true
+	}
+	return v.IsZero()
+}
+
+func timeZoneReplaceAttr(tz *time.Location) func(groups []string, a slog.Attr) slog.Attr {
+	if tz == nil || tz == time.UTC {
+		return nil
+	}
+	return func(groups []string, a slog.Attr) slog.Attr {
+		if a.Key == slog.TimeKey && len(groups) == 0 {
+			if t, ok := a.Value.Any().(time.Time); ok {
+				return slog.Time(a.Key, t.In(tz))
+			}
+		}
+		return a
+	}
 }

--- a/internal/logger/central_logger.go
+++ b/internal/logger/central_logger.go
@@ -906,6 +906,17 @@ func sanitizeReflect(rv reflect.Value, visited map[uintptr]bool) (any, bool) {
 				kStr = fmt.Sprint(k.Interface())
 			}
 
+			// Prevent key collisions for distinct keys that stringify to the same value
+			origKStr := kStr
+			counter := 1
+			for {
+				if _, exists := cp[kStr]; !exists {
+					break
+				}
+				kStr = fmt.Sprintf("%s_%d", origKStr, counter)
+				counter++
+			}
+
 			switch {
 			case vMod:
 				cp[kStr] = vSan
@@ -959,6 +970,7 @@ func getTraceIDFromContext(ctx context.Context) string {
 	return ""
 }
 
+//nolint:gocognit // Recursive struct flattening naturally has higher complexity
 func structNeedsCopy(rv reflect.Value, visited map[uintptr]bool) bool {
 	if rv.Kind() == reflect.Pointer || rv.Kind() == reflect.Interface {
 		if rv.IsNil() {
@@ -979,14 +991,32 @@ func structNeedsCopy(rv reflect.Value, visited map[uintptr]bool) bool {
 		
 		if field.Anonymous {
 			fvElem := fv
+			var ptr uintptr
+			var isPtr bool
 			if fvElem.Kind() == reflect.Pointer || fvElem.Kind() == reflect.Interface {
 				if !fvElem.IsNil() {
+					if fvElem.Kind() == reflect.Pointer {
+						ptr = fvElem.Pointer()
+						isPtr = true
+					}
 					fvElem = fvElem.Elem()
 				}
 			}
 			if fvElem.Kind() == reflect.Struct {
+				if isPtr {
+					if visited[ptr] {
+						continue
+					}
+					visited[ptr] = true
+				}
 				if structNeedsCopy(fvElem, visited) {
+					if isPtr {
+						delete(visited, ptr)
+					}
 					return true
+				}
+				if isPtr {
+					delete(visited, ptr)
 				}
 				continue
 			}
@@ -999,6 +1029,7 @@ func structNeedsCopy(rv reflect.Value, visited map[uintptr]bool) bool {
 	return false
 }
 
+//nolint:gocognit // Recursive struct flattening naturally has higher complexity
 func flattenStruct(rv reflect.Value, cp map[string]any, visited map[uintptr]bool) {
 	if rv.Kind() == reflect.Pointer || rv.Kind() == reflect.Interface {
 		if rv.IsNil() {
@@ -1018,13 +1049,28 @@ func flattenStruct(rv reflect.Value, cp map[string]any, visited map[uintptr]bool
 		fv := rv.Field(i)
 		if field.Anonymous {
 			fvElem := fv
+			var ptr uintptr
+			var isPtr bool
 			if fvElem.Kind() == reflect.Pointer || fvElem.Kind() == reflect.Interface {
 				if !fvElem.IsNil() {
+					if fvElem.Kind() == reflect.Pointer {
+						ptr = fvElem.Pointer()
+						isPtr = true
+					}
 					fvElem = fvElem.Elem()
 				}
 			}
 			if fvElem.Kind() == reflect.Struct {
+				if isPtr {
+					if visited[ptr] {
+						continue
+					}
+					visited[ptr] = true
+				}
 				flattenStruct(fvElem, cp, visited)
+				if isPtr {
+					delete(visited, ptr)
+				}
 				continue
 			}
 		}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -762,24 +762,24 @@ func TestSanitizeAny(t *testing.T) {
 
 	t.Run("non-finite floats", func(t *testing.T) {
 		t.Parallel()
-		assert.Equal(t, "+inf", sanitizeAny(math.Inf(1)))
-		assert.Equal(t, "-inf", sanitizeAny(math.Inf(-1)))
-		assert.Equal(t, "nan", sanitizeAny(math.NaN()))
-		assert.Equal(t, "nan", sanitizeAny(float32(math.NaN())))
-		assert.Equal(t, "+inf", sanitizeAny(float32(math.Inf(1))))
+		assert.Equal(t, "+Inf", sanitizeAny(math.Inf(1)))
+		assert.Equal(t, "-Inf", sanitizeAny(math.Inf(-1)))
+		assert.Equal(t, "NaN", sanitizeAny(math.NaN()))
+		assert.Equal(t, "NaN", sanitizeAny(float32(math.NaN())))
+		assert.Equal(t, "+Inf", sanitizeAny(float32(math.Inf(1))))
 	})
 
 	t.Run("named non-finite floats", func(t *testing.T) {
 		t.Parallel()
-		assert.Equal(t, "+inf", sanitizeAny(Decibels(math.Inf(1))))
-		assert.Equal(t, "-inf", sanitizeAny(Decibels(math.Inf(-1))))
+		assert.Equal(t, "+Inf", sanitizeAny(Decibels(math.Inf(1))))
+		assert.Equal(t, "-Inf", sanitizeAny(Decibels(math.Inf(-1))))
 	})
 
 	t.Run("nested slice", func(t *testing.T) {
 		t.Parallel()
 		input := []any{1.23, math.Inf(1), "test"}
 		got := sanitizeAny(input)
-		expected := []any{1.23, "+inf", "test"}
+		expected := []any{1.23, "+Inf", "test"}
 		assert.Equal(t, expected, got)
 	})
 
@@ -787,7 +787,7 @@ func TestSanitizeAny(t *testing.T) {
 		t.Parallel()
 		input := map[string]any{"a": math.Inf(-1), "b": 1.23}
 		got := sanitizeAny(input)
-		expected := map[string]any{"a": "-inf", "b": 1.23}
+		expected := map[string]any{"a": "-Inf", "b": 1.23}
 		assert.Equal(t, expected, got)
 	})
 
@@ -801,7 +801,7 @@ func TestSanitizeAny(t *testing.T) {
 		}
 		input := Nested{Val: math.NaN(), Ok: true, Ignored: 10, Slice: []int{1, 2}}
 		got := sanitizeAny(input)
-		expected := map[string]any{"val": "nan", "ok": true, "slice": []int{1, 2}}
+		expected := map[string]any{"val": "NaN", "ok": true, "slice": []int{1, 2}}
 		assert.Equal(t, expected, got)
 	})
 
@@ -813,19 +813,215 @@ func TestSanitizeAny(t *testing.T) {
 		m["val"] = math.NaN()
 
 		got := sanitizeAny(m)
-		// cycle detected at self, returned as is (without infinite recursion)
-		// the val should still be sanitized
+		// The cycle is broken with a "[Circular]" placeholder (not the original
+		// self-referential map), and the sibling non-finite float is sanitized.
 		resMap, ok := got.(map[string]any)
 		require.True(t, ok)
-		assert.Equal(t, "nan", resMap["val"])
-		assert.NotNil(t, resMap["self"])
+		assert.Equal(t, "NaN", resMap["val"])
+		assert.Equal(t, "[Circular]", resMap["self"])
+		// The whole result must be JSON-encodable (no residual cycle or NaN).
+		_, err := json.Marshal(resMap)
+		require.NoError(t, err)
 	})
 
 	t.Run("delegates to json.Marshaler", func(t *testing.T) {
 		t.Parallel()
 		input := []any{math.NaN(), mockJSONMarshaler{}}
 		got := sanitizeAny(input)
-		expected := []any{"nan", mockJSONMarshaler{}}
+		expected := []any{"NaN", mockJSONMarshaler{}}
 		assert.Equal(t, expected, got)
+	})
+
+	t.Run("clean struct is returned unchanged (not flattened)", func(t *testing.T) {
+		t.Parallel()
+		type Clean struct {
+			A int    `json:"a"`
+			B string `json:"b"`
+		}
+		in := Clean{A: 1, B: "x"}
+		// No non-finite float: the value must pass through untouched so slog
+		// serializes it with real encoding/json semantics.
+		assert.Equal(t, in, sanitizeAny(in))
+	})
+
+	t.Run("clean composites pass through by identity", func(t *testing.T) {
+		t.Parallel()
+		s := []int{1, 2, 3}
+		assert.Equal(t, s, sanitizeAny(s))
+		m := map[string]int{"a": 1}
+		assert.Equal(t, m, sanitizeAny(m))
+	})
+
+	t.Run("array with non-finite float", func(t *testing.T) {
+		t.Parallel()
+		got := sanitizeAny([3]any{1.23, math.Inf(1), "x"})
+		assert.Equal(t, []any{1.23, "+Inf", "x"}, got)
+	})
+
+	t.Run("map with non-string keys", func(t *testing.T) {
+		t.Parallel()
+		got := sanitizeAny(map[int]float64{1: math.NaN(), 2: 3.0})
+		resMap, ok := got.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "NaN", resMap["1"])
+		assert.InEpsilon(t, 3.0, resMap["2"], 1e-9)
+	})
+
+	t.Run("pointer to struct with non-finite float", func(t *testing.T) {
+		t.Parallel()
+		type P struct {
+			V float64 `json:"v"`
+		}
+		got := sanitizeAny(&P{V: math.NaN()})
+		requireJSONSafe(t, got)
+	})
+}
+
+// --- Helpers and types for sanitizeAny corruption/fuzz tests ---
+
+// requireJSONSafe asserts a value can be JSON-encoded without a non-finite-float
+// error (the corruption sanitizeAny exists to prevent). Unsupported *types*
+// (chan/func) are out of scope and tolerated.
+func requireJSONSafe(t *testing.T, v any) {
+	t.Helper()
+	_, err := json.Marshal(v)
+	_, isValueErr := errors.AsType[*json.UnsupportedValueError](err)
+	require.Falsef(t, isValueErr, "sanitized value must not carry a non-finite float: %v", err)
+}
+
+// logDataField renders v through the real slog JSON handler exactly like
+// fieldToAttr's default case does, and returns the emitted line.
+func logDataField(t *testing.T, v any) string {
+	t.Helper()
+	var buf bytes.Buffer
+	slog.New(slog.NewJSONHandler(&buf, nil)).Info("m", slog.Any("data", sanitizeAny(v)))
+	return buf.String()
+}
+
+func assertNoCorruption(t *testing.T, line string) {
+	t.Helper()
+	assert.NotContains(t, line, "!ERROR", "log line must not contain a marshal-error placeholder")
+	var m map[string]any
+	require.NoError(t, json.Unmarshal([]byte(line), &m), "log line must be valid JSON")
+}
+
+// stringerWithFloat implements fmt.Stringer and carries a float field. Under the
+// JSON handler slog ignores String() and marshals the fields, so a non-finite
+// float here must still be sanitized.
+type stringerWithFloat struct {
+	Gain float64
+}
+
+func (stringerWithFloat) String() string { return "src" }
+
+// floatFieldError implements error and carries a float field.
+type floatFieldError struct {
+	Gain float64
+}
+
+func (floatFieldError) Error() string { return "boom" }
+
+// innerFloat is an unexported type whose exported field is promoted into
+// outerEmbed, mirroring encoding/json's promotion of unexported embedded structs.
+type innerFloat struct {
+	Y float64
+}
+
+type outerEmbed struct {
+	innerFloat
+	Name string
+}
+
+// fuzzStruct is a small mixed struct used by FuzzSanitizeAny.
+type fuzzStruct struct {
+	V float64
+	S string
+}
+
+// TestSanitizeAny_NonFiniteBehindInterfaces covers the classes the reflective
+// walk cannot reach on its own (values behind fmt.Stringer/error, or promoted
+// from an unexported embedded struct): the safety net must still keep the log
+// line uncorrupted.
+func TestSanitizeAny_NonFiniteBehindInterfaces(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		val  any
+	}{
+		{"top-level Stringer with NaN", stringerWithFloat{Gain: math.NaN()}},
+		{"nested Stringer with NaN", map[string]any{"src": stringerWithFloat{Gain: math.NaN()}, "trigger": math.Inf(1)}},
+		{"top-level error with Inf", floatFieldError{Gain: math.Inf(1)}},
+		{"nested error with NaN", map[string]any{"err": floatFieldError{Gain: math.NaN()}, "trigger": math.Inf(1)}},
+		{"unexported embedded struct with NaN", outerEmbed{innerFloat: innerFloat{Y: math.NaN()}, Name: "x"}},
+		{"pointer to Stringer with NaN", &stringerWithFloat{Gain: math.NaN()}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			requireJSONSafe(t, sanitizeAny(tt.val))
+			assertNoCorruption(t, logDataField(t, tt.val))
+		})
+	}
+}
+
+// TestSanitizeAny_MatchesEncodingJSONForCleanValues pins the "no schema drift"
+// property: a value with no non-finite float must marshal identically to what
+// encoding/json produces for the original.
+func TestSanitizeAny_MatchesEncodingJSONForCleanValues(t *testing.T) {
+	t.Parallel()
+	type Inner struct {
+		A int    `json:"a"`
+		B string `json:"b,omitempty"`
+	}
+	type Outer struct {
+		Inner
+		Name  string  `json:"name"`
+		Ptr   *int    `json:"ptr,omitempty"`
+		Score float64 `json:"score"`
+	}
+	cases := []any{
+		Outer{Inner: Inner{A: 1}, Name: "x", Score: 2.5},
+		[]any{1, "two", 3.5, true},
+		map[string]any{"a": 1, "b": []int{1, 2}},
+		Inner{A: 7, B: "z"},
+	}
+	for i, c := range cases {
+		want, err := json.Marshal(c)
+		require.NoError(t, err)
+		got, err := json.Marshal(sanitizeAny(c))
+		require.NoErrorf(t, err, "case %d", i)
+		assert.JSONEqf(t, string(want), string(got), "case %d", i)
+	}
+}
+
+// FuzzSanitizeAny asserts the two load-bearing invariants over generated input:
+// sanitizeAny never panics, and its output never fails to JSON-encode because of
+// a non-finite float.
+func FuzzSanitizeAny(f *testing.F) {
+	f.Add([]byte("hello"), 3, 1.5)
+	f.Add([]byte{}, 0, math.NaN())
+	f.Add([]byte("x"), -1, math.Inf(1))
+	f.Fuzz(func(t *testing.T, b []byte, n int, x float64) {
+		inputs := []any{
+			x,
+			float32(x),
+			Decibels(x),
+			[]any{x, string(b), n},
+			map[string]any{"x": x, "s": string(b)},
+			map[int]float64{n: x},
+			fuzzStruct{V: x, S: string(b)},
+			stringerWithFloat{Gain: x},
+			floatFieldError{Gain: x},
+			outerEmbed{innerFloat: innerFloat{Y: x}, Name: string(b)},
+			&fuzzStruct{V: x, S: string(b)},
+			[]float64{x, float64(n)},
+		}
+		for i, in := range inputs {
+			out := sanitizeAny(in) // must not panic
+			_, err := json.Marshal(out)
+			if _, ok := errors.AsType[*json.UnsupportedValueError](err); ok {
+				t.Fatalf("input %d (%T) still fails to encode on a non-finite float: %v", i, in, err)
+			}
+		}
 	})
 }

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"math"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -565,8 +566,14 @@ func TestSlogLogger_Timezone(t *testing.T) {
 		err = json.Unmarshal(buf.Bytes(), &logEntry)
 		require.NoError(t, err)
 
-		// Verify timestamp exists (actual timezone verification would require parsing the timestamp)
-		assert.Contains(t, logEntry, "time")
+		timeStr, ok := logEntry["time"].(string)
+		require.True(t, ok)
+		parsedTime, err := time.Parse(time.RFC3339Nano, timeStr)
+		require.NoError(t, err)
+
+		_, offset := parsedTime.Zone()
+		_, expectedOffset := time.Now().In(tz).Zone()
+		assert.Equal(t, expectedOffset, offset)
 	})
 }
 
@@ -575,7 +582,7 @@ func TestSlogLogger_FileLogging(t *testing.T) {
 	t.Run("create logger with file output", func(t *testing.T) {
 		t.Helper()
 
-		tmpFile := t.TempDir() + "/test.log"
+		tmpFile := filepath.Join(t.TempDir(), "test.log")
 		tz, err := time.LoadLocation("Europe/Helsinki")
 		require.NoError(t, err)
 
@@ -604,7 +611,7 @@ func TestSlogLogger_FileLogging(t *testing.T) {
 	t.Run("file logger with nil timezone defaults to UTC", func(t *testing.T) {
 		t.Helper()
 
-		tmpFile := t.TempDir() + "/test.log"
+		tmpFile := filepath.Join(t.TempDir(), "test.log")
 
 		logger, err := NewSlogLoggerWithFile(tmpFile, LogLevelInfo, nil)
 		require.NoError(t, err)
@@ -623,7 +630,7 @@ func TestSlogLogger_FileLogging(t *testing.T) {
 			t.Skip("SIGHUP-based log rotation is a Unix-only pattern; Windows does not allow renaming open files")
 		}
 
-		tmpFile := t.TempDir() + "/test.log"
+		tmpFile := filepath.Join(t.TempDir(), "test.log")
 
 		logger, err := NewSlogLoggerWithFile(tmpFile, LogLevelInfo, time.UTC)
 		require.NoError(t, err)
@@ -694,7 +701,7 @@ func TestSlogLogger_FileLogging(t *testing.T) {
 	t.Run("file logger Module preserves file handle", func(t *testing.T) {
 		t.Helper()
 
-		tmpFile := t.TempDir() + "/test.log"
+		tmpFile := filepath.Join(t.TempDir(), "test.log")
 
 		logger, err := NewSlogLoggerWithFile(tmpFile, LogLevelInfo, time.UTC)
 		require.NoError(t, err)
@@ -721,19 +728,28 @@ func TestSlogLogger_FileLogging(t *testing.T) {
 // type Decibels float64 for testing named float type
 type Decibels float64
 
+type mockJSONMarshaler struct{}
+
+func (mockJSONMarshaler) MarshalJSON() ([]byte, error) { return []byte(`"mock"`), nil }
+
 func TestSanitizeAny(t *testing.T) {
+	t.Parallel()
+
 	//nolint:testifylint // Intentionally strict typing for our float return tests
 	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
 		assert.Nil(t, sanitizeAny(nil))
 	})
 
 	t.Run("basic types", func(t *testing.T) {
+		t.Parallel()
 		assert.Equal(t, 42, sanitizeAny(42))
 		assert.Equal(t, "test", sanitizeAny("test"))
 		assert.Equal(t, true, sanitizeAny(true))
 	})
 
 	t.Run("finite floats", func(t *testing.T) {
+		t.Parallel()
 		if v := sanitizeAny(1.23); v != 1.23 {
 			t.Errorf("expected 1.23, got %v", v)
 		}
@@ -746,17 +762,22 @@ func TestSanitizeAny(t *testing.T) {
 	})
 
 	t.Run("non-finite floats", func(t *testing.T) {
+		t.Parallel()
 		assert.Equal(t, "+inf", sanitizeAny(math.Inf(1)))
 		assert.Equal(t, "-inf", sanitizeAny(math.Inf(-1)))
 		assert.Equal(t, "nan", sanitizeAny(math.NaN()))
+		assert.Equal(t, "nan", sanitizeAny(float32(math.NaN())))
+		assert.Equal(t, "+inf", sanitizeAny(float32(math.Inf(1))))
 	})
 
 	t.Run("named non-finite floats", func(t *testing.T) {
+		t.Parallel()
 		assert.Equal(t, "+inf", sanitizeAny(Decibels(math.Inf(1))))
 		assert.Equal(t, "-inf", sanitizeAny(Decibels(math.Inf(-1))))
 	})
 
 	t.Run("nested slice", func(t *testing.T) {
+		t.Parallel()
 		input := []any{1.23, math.Inf(1), "test"}
 		got := sanitizeAny(input)
 		expected := []any{1.23, "+inf", "test"}
@@ -764,20 +785,48 @@ func TestSanitizeAny(t *testing.T) {
 	})
 
 	t.Run("nested map", func(t *testing.T) {
+		t.Parallel()
 		input := map[string]any{"a": math.Inf(-1), "b": 1.23}
 		got := sanitizeAny(input)
-		expected := map[any]any{"a": "-inf", "b": 1.23}
+		expected := map[string]any{"a": "-inf", "b": 1.23}
 		assert.Equal(t, expected, got)
 	})
 
-	t.Run("nested struct", func(t *testing.T) {
+	t.Run("nested struct with tags and uncomparable types", func(t *testing.T) {
+		t.Parallel()
 		type Nested struct {
-			Val float64
-			Ok  bool
+			Val     float64 `json:"val"`
+			Ok      bool    `json:"ok"`
+			Ignored int     `json:"-"`
+			Slice   []int   `json:"slice"` // Uncomparable
 		}
-		input := Nested{Val: math.NaN(), Ok: true}
+		input := Nested{Val: math.NaN(), Ok: true, Ignored: 10, Slice: []int{1, 2}}
 		got := sanitizeAny(input)
-		expected := map[string]any{"Val": "nan", "Ok": true}
+		expected := map[string]any{"val": "nan", "ok": true, "slice": []int{1, 2}}
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("cyclic data structure", func(t *testing.T) {
+		t.Parallel()
+		// map pointing to itself
+		m := make(map[string]any)
+		m["self"] = m
+		m["val"] = math.NaN()
+
+		got := sanitizeAny(m)
+		// cycle detected at self, returned as is (without infinite recursion)
+		// the val should still be sanitized
+		resMap, ok := got.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "nan", resMap["val"])
+		assert.NotNil(t, resMap["self"])
+	})
+
+	t.Run("delegates to json.Marshaler", func(t *testing.T) {
+		t.Parallel()
+		input := []any{math.NaN(), mockJSONMarshaler{}}
+		got := sanitizeAny(input)
+		expected := []any{"nan", mockJSONMarshaler{}}
 		assert.Equal(t, expected, got)
 	})
 }

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -565,14 +565,13 @@ func TestSlogLogger_Timezone(t *testing.T) {
 		var logEntry map[string]any
 		err = json.Unmarshal(buf.Bytes(), &logEntry)
 		require.NoError(t, err)
-
 		timeStr, ok := logEntry["time"].(string)
 		require.True(t, ok)
 		parsedTime, err := time.Parse(time.RFC3339Nano, timeStr)
 		require.NoError(t, err)
 
 		_, offset := parsedTime.Zone()
-		_, expectedOffset := time.Now().In(tz).Zone()
+		_, expectedOffset := parsedTime.In(tz).Zone()
 		assert.Equal(t, expectedOffset, offset)
 	})
 }

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -717,3 +717,67 @@ func TestSlogLogger_FileLogging(t *testing.T) {
 		assert.Contains(t, string(content), "test-module")
 	})
 }
+
+// type Decibels float64 for testing named float type
+type Decibels float64
+
+func TestSanitizeAny(t *testing.T) {
+	//nolint:testifylint // Intentionally strict typing for our float return tests
+	t.Run("nil", func(t *testing.T) {
+		assert.Nil(t, sanitizeAny(nil))
+	})
+
+	t.Run("basic types", func(t *testing.T) {
+		assert.Equal(t, 42, sanitizeAny(42))
+		assert.Equal(t, "test", sanitizeAny("test"))
+		assert.Equal(t, true, sanitizeAny(true))
+	})
+
+	t.Run("finite floats", func(t *testing.T) {
+		if v := sanitizeAny(1.23); v != 1.23 {
+			t.Errorf("expected 1.23, got %v", v)
+		}
+		if v := sanitizeAny(float32(1.23)); v != float32(1.23) {
+			t.Errorf("expected float32 1.23, got %v", v)
+		}
+		if v := sanitizeAny(Decibels(1.23)); v != Decibels(1.23) {
+			t.Errorf("expected Decibels 1.23, got %v", v)
+		}
+	})
+
+	t.Run("non-finite floats", func(t *testing.T) {
+		assert.Equal(t, "+inf", sanitizeAny(math.Inf(1)))
+		assert.Equal(t, "-inf", sanitizeAny(math.Inf(-1)))
+		assert.Equal(t, "nan", sanitizeAny(math.NaN()))
+	})
+
+	t.Run("named non-finite floats", func(t *testing.T) {
+		assert.Equal(t, "+inf", sanitizeAny(Decibels(math.Inf(1))))
+		assert.Equal(t, "-inf", sanitizeAny(Decibels(math.Inf(-1))))
+	})
+
+	t.Run("nested slice", func(t *testing.T) {
+		input := []any{1.23, math.Inf(1), "test"}
+		got := sanitizeAny(input)
+		expected := []any{1.23, "+inf", "test"}
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("nested map", func(t *testing.T) {
+		input := map[string]any{"a": math.Inf(-1), "b": 1.23}
+		got := sanitizeAny(input)
+		expected := map[any]any{"a": "-inf", "b": 1.23}
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("nested struct", func(t *testing.T) {
+		type Nested struct {
+			Val float64
+			Ok  bool
+		}
+		input := Nested{Val: math.NaN(), Ok: true}
+		got := sanitizeAny(input)
+		expected := map[string]any{"Val": "nan", "Ok": true}
+		assert.Equal(t, expected, got)
+	})
+}

--- a/internal/logger/slog_logger.go
+++ b/internal/logger/slog_logger.go
@@ -46,6 +46,7 @@ func NewSlogLogger(writer io.Writer, level LogLevel, timezone *time.Location) *S
 
 	opts := &slog.HandlerOptions{
 		Level: parseSlogLevel(level),
+		ReplaceAttr: timeZoneReplaceAttr(timezone),
 	}
 
 	handler := slog.NewJSONHandler(writer, opts)
@@ -92,6 +93,7 @@ func NewSlogLoggerWithFile(filePath string, level LogLevel, timezone *time.Locat
 	// Create handler with buffered writer
 	opts := &slog.HandlerOptions{
 		Level: parseSlogLevel(level),
+		ReplaceAttr: timeZoneReplaceAttr(timezone),
 	}
 	handler := slog.NewJSONHandler(writer, opts)
 
@@ -135,6 +137,7 @@ func (l *SlogLogger) ReopenLogFile() error {
 	// Recreate handler with new writer
 	opts := &slog.HandlerOptions{
 		Level: l.level,
+		ReplaceAttr: timeZoneReplaceAttr(l.timezone),
 	}
 	l.handler = slog.NewJSONHandler(writer, opts)
 	l.slogLogger = slog.New(l.handler) // update cached logger

--- a/internal/logger/slog_logger.go
+++ b/internal/logger/slog_logger.go
@@ -45,7 +45,7 @@ func NewSlogLogger(writer io.Writer, level LogLevel, timezone *time.Location) *S
 	}
 
 	opts := &slog.HandlerOptions{
-		Level: parseSlogLevel(level),
+		Level:       parseSlogLevel(level),
 		ReplaceAttr: timeZoneReplaceAttr(timezone),
 	}
 
@@ -92,7 +92,7 @@ func NewSlogLoggerWithFile(filePath string, level LogLevel, timezone *time.Locat
 
 	// Create handler with buffered writer
 	opts := &slog.HandlerOptions{
-		Level: parseSlogLevel(level),
+		Level:       parseSlogLevel(level),
 		ReplaceAttr: timeZoneReplaceAttr(timezone),
 	}
 	handler := slog.NewJSONHandler(writer, opts)
@@ -136,7 +136,7 @@ func (l *SlogLogger) ReopenLogFile() error {
 
 	// Recreate handler with new writer
 	opts := &slog.HandlerOptions{
-		Level: l.level,
+		Level:       l.level,
 		ReplaceAttr: timeZoneReplaceAttr(l.timezone),
 	}
 	l.handler = slog.NewJSONHandler(writer, opts)


### PR DESCRIPTION
## Summary
Fixes `encoding/json` panics when `slog` attempts to log non-finite floats (NaN, +Inf, -Inf) wrapped inside structs, slices, or maps.
This adds a reflection-based `sanitizeReflect` utility that recursively scrubs non-finite floats to strings (`"nan"`, `"+inf"`, `"-inf"`) while safely avoiding cyclic data stack overflows, preserving original struct `json` tags, and delegating to custom serialization interfaces like `json.Marshaler` or `slog.LogValuer` when present.

## Related Issues
*(Internal task)*

## Test Plan
- [x] Run `go test -race ./...`
- [x] Tested with `float32`, cyclic maps, structs containing uncomparable types (slices), and nested maps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON logging safety for special numeric values (NaN/±Inf) and complex/cyclic data structures (now emits a safe placeholder instead of breaking output).
  * Ensured log timestamps consistently use the configured timezone, including after reopening log files.
  * Hardened structured value handling to avoid JSON corruption while keeping standard/valid values compatible.
* **Tests**
  * Expanded unit coverage for sanitization, including nested structures, tagged fields, interface-backed non-finite values, and “no output schema drift”.
  * Added fuzz testing to confirm sanitization never panics and always produces JSON-encodable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->