### PR TITLE
fix(api): disable proxy buffering on integration streaming test endpoints

### DIFF
--- a/internal/api/middleware/compression.go
+++ b/internal/api/middleware/compression.go
@@ -59,6 +59,19 @@ var precompressedRoutes = map[string]struct{}{
 	"/api/v2/species/dictionary/:locale": {},
 }
 
+// streamingJSONRoutes serve long-lived NDJSON/JSON progress streams (the
+// integration connection-test endpoints) that flush incremental results to the
+// client as a test proceeds. Gzipping them adds a buffering boundary that
+// withholds each flushed result until the compressor's window fills, defeating
+// the live progress UX, so they are skipped exactly like SSE. Matched on the
+// route template like binaryMediaRoutes.
+var streamingJSONRoutes = map[string]struct{}{
+	"/api/v2/integrations/mqtt/test":        {},
+	"/api/v2/integrations/birdweather/test": {},
+	"/api/v2/integrations/weather/test":     {},
+	"/api/v2/integrations/ebird/test":       {},
+}
+
 // hlsContentRoutePrefix matches token-based HLS playlist and segment routes.
 // The registered route template is /api/v2/streams/hls/t/:streamToken/* where
 // the trailing * is an Echo wildcard. We cannot lookup wildcard templates in
@@ -96,6 +109,9 @@ func NewGzipWithSkipper(level int, skipper middleware.Skipper) echo.MiddlewareFu
 //   - Server-Sent Events endpoints (see SSESkipper).
 //   - Binary media routes serving audio, images, or HLS content (see MediaPathSkipper).
 //   - Routes that serve already-compressed responses (see precompressedRoutes).
+//   - NDJSON/JSON progress-streaming routes (see streamingJSONRoutes), where a
+//     gzip buffering boundary would withhold flushed results and defeat the
+//     live progress UX.
 //   - Any request carrying a Range header, since gzip is incompatible with
 //     byte-range responses served via http.ServeContent.
 func DefaultGzipSkipper(c echo.Context) bool {
@@ -106,6 +122,9 @@ func DefaultGzipSkipper(c echo.Context) bool {
 		return true
 	}
 	if _, ok := precompressedRoutes[c.Path()]; ok {
+		return true
+	}
+	if _, ok := streamingJSONRoutes[c.Path()]; ok {
 		return true
 	}
 	return c.Request().Header.Get(headerRange) != ""

--- a/internal/api/middleware/compression_test.go
+++ b/internal/api/middleware/compression_test.go
@@ -156,6 +156,85 @@ func TestDefaultGzipSkipper(t *testing.T) {
 	})
 }
 
+func TestDefaultGzipSkipper_SkipsStreamingJSONRoutes(t *testing.T) {
+	t.Parallel()
+
+	// Hardcoded route templates (NOT derived from streamingJSONRoutes) so that
+	// dropping or renaming an entry in the production map fails this test instead
+	// of silently reducing coverage. These must equal the templates the
+	// integrations handler registers (RegisterRoutes under the /api/v2 group).
+	streamingRoutes := []string{
+		"/api/v2/integrations/mqtt/test",
+		"/api/v2/integrations/birdweather/test",
+		"/api/v2/integrations/weather/test",
+		"/api/v2/integrations/ebird/test",
+	}
+	for _, route := range streamingRoutes {
+		t.Run("skips "+route, func(t *testing.T) {
+			t.Parallel()
+			// Fetch-based POSTs whose Accept is not text/event-stream, so SSESkipper
+			// does not cover them; the route-template skip must, otherwise gzip
+			// buffering would withhold the flushed progress results.
+			c, _ := newTestContext(t, http.MethodPost, "/irrelevant")
+			setPathForContext(t, c, route)
+			assert.True(t, DefaultGzipSkipper(c),
+				"streaming route %q must skip gzip so flushed results reach the client immediately", route)
+		})
+	}
+
+	// Negative: a non-streaming sibling endpoint must still be compressed.
+	t.Run("does not skip non-streaming integration route", func(t *testing.T) {
+		t.Parallel()
+		c, _ := newTestContext(t, http.MethodGet, "/irrelevant")
+		setPathForContext(t, c, "/api/v2/integrations/mqtt/status")
+		assert.False(t, DefaultGzipSkipper(c),
+			"the MQTT status route returns a normal JSON body and must still be gzip-compressed")
+	})
+
+	// Guard against the production map drifting from the hardcoded set: every known
+	// route must be present, and the map must contain nothing unexpected.
+	known := make(map[string]struct{}, len(streamingRoutes))
+	for _, r := range streamingRoutes {
+		known[r] = struct{}{}
+		if _, ok := streamingJSONRoutes[r]; !ok {
+			t.Errorf("streamingJSONRoutes is missing expected streaming route %q", r)
+		}
+	}
+	for r := range streamingJSONRoutes {
+		if _, ok := known[r]; !ok {
+			t.Errorf("streamingJSONRoutes has unexpected route %q not asserted by this test", r)
+		}
+	}
+}
+
+// TestNewGzip_EndToEnd_StreamingJSONRouteNotCompressed drives the real gzip
+// middleware stack against a registered streaming route template and verifies the
+// response is not gzip-wrapped even when the client advertises Accept-Encoding:
+// gzip. This complements the skipper unit test by exercising c.Path() through the
+// actual Echo router, so a mismatch between the skip-set template and the
+// registered route would surface here.
+func TestNewGzip_EndToEnd_StreamingJSONRouteNotCompressed(t *testing.T) {
+	t.Parallel()
+
+	e := echo.New()
+	e.Use(NewGzip())
+	// Register the real streaming route template so c.Path() matches the skip set.
+	e.POST("/api/v2/integrations/mqtt/test", func(c echo.Context) error {
+		return c.String(http.StatusOK, strings.Repeat("PROGRESS_JSON_LINE", 2048))
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/integrations/mqtt/test", http.NoBody)
+	req.Header.Set(echo.HeaderAcceptEncoding, "gzip")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Empty(t, rec.Header().Get(echo.HeaderContentEncoding),
+		"streaming test route must not be gzip-compressed even when the client asks for it")
+	assert.False(t, bytes.HasPrefix(rec.Body.Bytes(), []byte{0x1f, 0x8b}),
+		"streaming test route body must not be a gzip stream")
+}
+
 // TestNewGzip_EndToEnd_AudioRouteNotCompressed is a regression test for
 // tphakala/birdnet-go#2709. It drives a real Echo router with the gzip
 // middleware stack used in production and verifies that a matched audio

--- a/internal/api/v2/apicore/sse_stream.go
+++ b/internal/api/v2/apicore/sse_stream.go
@@ -71,18 +71,17 @@ func DisableProxyBuffering(ctx echo.Context) {
 	ctx.Response().Header().Set("X-Accel-Buffering", "no")
 }
 
-// SetStreamWriteDeadline applies the shared SSE write deadline to the response
-// writer when it supports one, so a stalled or disconnected client cannot block
-// the writer indefinitely. It is best-effort: writers that do not implement
-// WriteDeadlineSetter are left unchanged, and a SetWriteDeadline failure is logged
-// at debug and otherwise ignored (the deadline is advisory). Streaming handlers
-// call it before each streamed write, like SendSSEMessage does inline.
+// SetStreamWriteDeadline extends the response write deadline by the shared SSE
+// window so a stalled or disconnected client cannot block the writer past it.
+// It uses http.NewResponseController (the Go 1.20+ idiom) so the deadline reaches
+// the underlying connection; asserting SetWriteDeadline directly on the response
+// writer is a no-op for the standard net/http writer, which does not expose it.
+// A writer that does not support deadlines yields http.ErrNotSupported, which is
+// logged at debug and otherwise ignored (the deadline is advisory). Streaming
+// handlers call it before each streamed write.
 func SetStreamWriteDeadline(ctx echo.Context) {
-	conn, ok := ctx.Response().Writer.(WriteDeadlineSetter)
-	if !ok {
-		return
-	}
-	if err := conn.SetWriteDeadline(time.Now().Add(SSEWriteDeadline)); err != nil {
+	rc := http.NewResponseController(ctx.Response().Writer)
+	if err := rc.SetWriteDeadline(time.Now().Add(SSEWriteDeadline)); err != nil {
 		GetLogger().Debug("Failed to set stream write deadline", logger.Error(err))
 	}
 }
@@ -122,14 +121,8 @@ func (c *Core) SendSSEMessage(ctx echo.Context, event string, data any) error {
 	// Format SSE message
 	message := fmt.Sprintf("event: %s\ndata: %s\n\n", event, string(jsonData))
 
-	// Set write deadline to prevent hanging on slow/disconnected clients
-	if conn, ok := ctx.Response().Writer.(WriteDeadlineSetter); ok {
-		deadline := time.Now().Add(SSEWriteDeadline) // Write deadline timeout
-		if err := conn.SetWriteDeadline(deadline); err != nil {
-			// If we can't set deadline, log but continue - not all response writers support this
-			c.LogDebugIfEnabled("Failed to set write deadline for SSE message", logger.Error(err))
-		}
-	}
+	// Set write deadline to prevent hanging on slow/disconnected clients.
+	SetStreamWriteDeadline(ctx)
 
 	// Write to response
 	if _, err := ctx.Response().Write([]byte(message)); err != nil {

--- a/internal/api/v2/apicore/sse_stream.go
+++ b/internal/api/v2/apicore/sse_stream.go
@@ -59,7 +59,32 @@ func SetSSEHeaders(ctx echo.Context) {
 	ctx.Response().Header().Set("Connection", "keep-alive")
 	ctx.Response().Header().Set("Access-Control-Allow-Origin", "*")
 	ctx.Response().Header().Set("Access-Control-Allow-Headers", "Cache-Control")
+	DisableProxyBuffering(ctx)
+}
+
+// DisableProxyBuffering sets X-Accel-Buffering: no so nginx and compatible
+// reverse proxies stream the response immediately instead of buffering it.
+// Streaming endpoints that build their own headers (SSE as well as the
+// NDJSON/JSON progress streams) call this so the buffering behavior has a single
+// source of truth and cannot drift between endpoints.
+func DisableProxyBuffering(ctx echo.Context) {
 	ctx.Response().Header().Set("X-Accel-Buffering", "no")
+}
+
+// SetStreamWriteDeadline applies the shared SSE write deadline to the response
+// writer when it supports one, so a stalled or disconnected client cannot block
+// the writer indefinitely. It is best-effort: writers that do not implement
+// WriteDeadlineSetter are left unchanged, and a SetWriteDeadline failure is logged
+// at debug and otherwise ignored (the deadline is advisory). Streaming handlers
+// call it before each streamed write, like SendSSEMessage does inline.
+func SetStreamWriteDeadline(ctx echo.Context) {
+	conn, ok := ctx.Response().Writer.(WriteDeadlineSetter)
+	if !ok {
+		return
+	}
+	if err := conn.SetWriteDeadline(time.Now().Add(SSEWriteDeadline)); err != nil {
+		GetLogger().Debug("Failed to set stream write deadline", logger.Error(err))
+	}
 }
 
 // SafeMarshalJSON marshals data to JSON with panic recovery.

--- a/internal/api/v2/apicore/sse_stream.go
+++ b/internal/api/v2/apicore/sse_stream.go
@@ -45,13 +45,6 @@ const (
 	SSEStatusDisconnected = "disconnected"
 )
 
-// WriteDeadlineSetter is implemented by response writers that support a write
-// deadline (e.g. the underlying TCP connection). SSE writers use it to avoid
-// hanging on stalled clients.
-type WriteDeadlineSetter interface {
-	SetWriteDeadline(time.Time) error
-}
-
 // SetSSEHeaders sets the required HTTP headers for a Server-Sent Events response.
 func SetSSEHeaders(ctx echo.Context) {
 	ctx.Response().Header().Set("Content-Type", "text/event-stream")

--- a/internal/api/v2/apicore/sse_stream_test.go
+++ b/internal/api/v2/apicore/sse_stream_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
@@ -32,4 +33,63 @@ func Test_SetSSEHeaders(t *testing.T) {
 		actualValue := rec.Header().Get(key)
 		assert.Equal(t, expectedValue, actualValue, "SetSSEHeaders() header %q mismatch", key)
 	}
+}
+
+func Test_DisableProxyBuffering(t *testing.T) {
+	t.Parallel()
+
+	e := echo.New()
+	req := httptest.NewRequest("GET", "/test", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	DisableProxyBuffering(ctx)
+
+	assert.Equal(t, "no", rec.Header().Get("X-Accel-Buffering"),
+		"DisableProxyBuffering must set X-Accel-Buffering: no")
+}
+
+// deadlineRecorder is a ResponseWriter that records SetWriteDeadline calls so
+// tests can assert SetStreamWriteDeadline wired the deadline through.
+type deadlineRecorder struct {
+	*httptest.ResponseRecorder
+	deadlineSet bool
+	deadline    time.Time
+}
+
+func (d *deadlineRecorder) SetWriteDeadline(t time.Time) error {
+	d.deadlineSet = true
+	d.deadline = t
+	return nil
+}
+
+func Test_SetStreamWriteDeadline(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sets deadline when writer supports it", func(t *testing.T) {
+		t.Parallel()
+		e := echo.New()
+		req := httptest.NewRequest("GET", "/test", http.NoBody)
+		writer := &deadlineRecorder{ResponseRecorder: httptest.NewRecorder()}
+		ctx := e.NewContext(req, httptest.NewRecorder())
+		ctx.Response().Writer = writer
+
+		before := time.Now()
+		SetStreamWriteDeadline(ctx)
+
+		assert.True(t, writer.deadlineSet, "SetStreamWriteDeadline must set a write deadline when the writer supports it")
+		assert.WithinDuration(t, before.Add(SSEWriteDeadline), writer.deadline, time.Second,
+			"deadline should be roughly SSEWriteDeadline in the future")
+	})
+
+	t.Run("no-op when writer does not support deadlines", func(t *testing.T) {
+		t.Parallel()
+		e := echo.New()
+		req := httptest.NewRequest("GET", "/test", http.NoBody)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		// A plain recorder does not implement WriteDeadlineSetter; this must not panic.
+		assert.NotPanics(t, func() { SetStreamWriteDeadline(ctx) })
+	})
 }

--- a/internal/api/v2/apicore/sse_stream_test.go
+++ b/internal/api/v2/apicore/sse_stream_test.go
@@ -89,7 +89,8 @@ func Test_SetStreamWriteDeadline(t *testing.T) {
 		rec := httptest.NewRecorder()
 		ctx := e.NewContext(req, rec)
 
-		// A plain recorder does not implement WriteDeadlineSetter; this must not panic.
+		// A plain recorder does not support write deadlines, so NewResponseController
+		// returns http.ErrNotSupported; this must be handled without panicking.
 		assert.NotPanics(t, func() { SetStreamWriteDeadline(ctx) })
 	})
 }

--- a/internal/api/v2/audio/audio_level.go
+++ b/internal/api/v2/audio/audio_level.go
@@ -656,10 +656,9 @@ func (c *Handler) extractRemoteAddr(ctx echo.Context) string {
 // resetAudioLevelWriteDeadline resets the write deadline for the SSE connection.
 // This prevents the server's WriteTimeout from terminating long-lived SSE connections.
 func (c *Handler) resetAudioLevelWriteDeadline(ctx echo.Context, operation string) {
-	if conn, ok := ctx.Response().Writer.(apicore.WriteDeadlineSetter); ok {
-		if err := conn.SetWriteDeadline(time.Now().Add(audioLevelWriteDeadline)); err != nil {
-			c.LogDebugIfEnabled("Failed to set write deadline for "+operation, logger.Error(err))
-		}
+	rc := http.NewResponseController(ctx.Response().Writer)
+	if err := rc.SetWriteDeadline(time.Now().Add(audioLevelWriteDeadline)); err != nil {
+		c.LogDebugIfEnabled("Failed to set write deadline for "+operation, logger.Error(err))
 	}
 }
 

--- a/internal/api/v2/audio/audio_level_write_deadline_test.go
+++ b/internal/api/v2/audio/audio_level_write_deadline_test.go
@@ -27,7 +27,7 @@ type mockWriteDeadlineResponseWriter struct {
 	lastDeadline           time.Time
 }
 
-// SetWriteDeadline implements apicore.WriteDeadlineSetter interface
+// SetWriteDeadline lets http.NewResponseController find and set a write deadline
 func (m *mockWriteDeadlineResponseWriter) SetWriteDeadline(t time.Time) error {
 	m.setWriteDeadlineCalled.Store(true)
 	m.lastDeadline = t

--- a/internal/api/v2/imports/import.go
+++ b/internal/api/v2/imports/import.go
@@ -612,13 +612,7 @@ func (c *Handler) sendImportEvent(ctx echo.Context, id uint64, event string, dat
 		return fmt.Errorf("marshal import event: %w", err)
 	}
 	msg := fmt.Sprintf("id: %d\nevent: %s\ndata: %s\n\n", id, event, payload)
-	if conn, ok := ctx.Response().Writer.(apicore.WriteDeadlineSetter); ok {
-		if err := conn.SetWriteDeadline(time.Now().Add(apicore.SSEWriteDeadline)); err != nil {
-			// Best-effort: not all response writers support deadlines; log and proceed,
-			// matching SendSSEMessage in apicore.
-			c.LogDebugIfEnabled("Failed to set write deadline for import SSE event", logger.Error(err))
-		}
-	}
+	apicore.SetStreamWriteDeadline(ctx)
 	if _, err := ctx.Response().Write([]byte(msg)); err != nil {
 		return fmt.Errorf("write import event: %w", err)
 	}

--- a/internal/api/v2/integrations/integrations.go
+++ b/internal/api/v2/integrations/integrations.go
@@ -251,6 +251,7 @@ func runStreamingIntegrationTest[T any](
 	// Stream results to client until done
 	for result := range resultChan {
 		writeMu.Lock()
+		apicore.SetStreamWriteDeadline(ctx)
 		if err := encoder.Encode(result); err != nil {
 			apicore.GetLogger().Error("Error encoding test result",
 				logger.String("integration", integrationName),
@@ -469,8 +470,7 @@ func (c *Handler) TestMQTTConnection(ctx echo.Context) error {
 	}
 
 	// Prepare for testing
-	ctx.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
-	ctx.Response().WriteHeader(http.StatusOK)
+	setStreamingHeaders(ctx, echo.MIMEApplicationJSON)
 
 	// Channel for test results
 	resultChan := make(chan mqtt.TestResult)
@@ -526,8 +526,7 @@ func (c *Handler) TestBirdWeatherConnection(ctx echo.Context) error {
 	}
 
 	// Prepare for testing
-	ctx.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
-	ctx.Response().WriteHeader(http.StatusOK)
+	setStreamingHeaders(ctx, echo.MIMEApplicationJSON)
 
 	// Channel for test results
 	resultChan := make(chan birdweather.TestResult)
@@ -599,10 +598,7 @@ func (c *Handler) TestWeatherConnection(ctx echo.Context) error {
 	}
 
 	// Set up streaming response
-	ctx.Response().Header().Set("Content-Type", "application/x-ndjson")
-	ctx.Response().Header().Set("Cache-Control", "no-cache")
-	ctx.Response().Header().Set("Connection", "keep-alive")
-	ctx.Response().WriteHeader(http.StatusOK)
+	setStreamingHeaders(ctx, mimeNDJSON)
 
 	// Clone current settings and override only Weather fields from the request
 	testSettings := conf.CloneSettings(current)
@@ -623,6 +619,7 @@ func (c *Handler) TestWeatherConnection(ctx echo.Context) error {
 
 	// Helper function to send stage results
 	sendStage := func(stage WeatherTestStage) error {
+		apicore.SetStreamWriteDeadline(ctx)
 		if err := encoder.Encode(stage); err != nil {
 			return err
 		}
@@ -869,10 +866,28 @@ func formatClientError(prefix string, err error, settings *conf.Settings) string
 	return prefix + ". Check configuration and try again."
 }
 
+// mimeNDJSON is the content type for newline-delimited JSON streaming responses.
+const mimeNDJSON = "application/x-ndjson"
+
+// setStreamingHeaders configures the response for a streamed JSON/NDJSON body and
+// commits the 200 status. It disables proxy buffering (X-Accel-Buffering: no) via
+// the shared apicore helper so nginx and compatible reverse proxies deliver each
+// streamed result immediately instead of withholding them until the handler
+// returns.
+func setStreamingHeaders(ctx echo.Context, contentType string) {
+	h := ctx.Response().Header()
+	h.Set(echo.HeaderContentType, contentType)
+	h.Set(echo.HeaderCacheControl, "no-cache")
+	h.Set(echo.HeaderConnection, "keep-alive")
+	apicore.DisableProxyBuffering(ctx)
+	ctx.Response().WriteHeader(http.StatusOK)
+}
+
 // writeJSONResponse writes a JSON response to the client
 // NOTE: For most cases, consider using Echo's built-in ctx.JSON(httpStatus, data) instead
 // This function is primarily useful for streaming or special encoding scenarios
 func (c *Handler) writeJSONResponse(ctx echo.Context, data any) error {
+	apicore.SetStreamWriteDeadline(ctx)
 	encoder := json.NewEncoder(ctx.Response())
 	return encoder.Encode(data)
 }
@@ -907,10 +922,7 @@ func (c *Handler) TestEBirdConnection(ctx echo.Context) error {
 		})
 	}
 
-	ctx.Response().Header().Set("Content-Type", "application/x-ndjson")
-	ctx.Response().Header().Set("Cache-Control", "no-cache")
-	ctx.Response().Header().Set("Connection", "keep-alive")
-	ctx.Response().WriteHeader(http.StatusOK)
+	setStreamingHeaders(ctx, mimeNDJSON)
 
 	testCtx, cancel := context.WithTimeout(ctx.Request().Context(), integrationMediumTimeout*time.Second)
 	defer cancel()
@@ -918,6 +930,7 @@ func (c *Handler) TestEBirdConnection(ctx echo.Context) error {
 	encoder := json.NewEncoder(ctx.Response())
 
 	sendStage := func(stage WeatherTestStage) error {
+		apicore.SetStreamWriteDeadline(ctx)
 		if err := encoder.Encode(stage); err != nil {
 			return err
 		}

--- a/internal/api/v2/integrations/integrations_test.go
+++ b/internal/api/v2/integrations/integrations_test.go
@@ -851,3 +851,36 @@ func TestTestEBirdConnection_RestoresRedactedAPIKey(t *testing.T) {
 			"eBird test must use the real saved key, not the redacted placeholder")
 	})
 }
+
+// TestSetStreamingHeaders verifies the shared streaming-response header helper
+// sets the content type, no-cache/keep-alive, and X-Accel-Buffering: no so the
+// integration connection-test streams are not buffered behind a reverse proxy.
+func TestSetStreamingHeaders(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		contentType string
+	}{
+		{"ndjson stream", mimeNDJSON},
+		{"json stream", echo.MIMEApplicationJSON},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, "/api/v2/integrations/mqtt/test", http.NoBody)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			setStreamingHeaders(c, tt.contentType)
+
+			assert.Equal(t, tt.contentType, rec.Header().Get(echo.HeaderContentType))
+			assert.Equal(t, "no-cache", rec.Header().Get(echo.HeaderCacheControl))
+			assert.Equal(t, "keep-alive", rec.Header().Get(echo.HeaderConnection))
+			assert.Equal(t, "no", rec.Header().Get("X-Accel-Buffering"),
+				"streaming responses must set X-Accel-Buffering: no so reverse proxies do not buffer them")
+			assert.Equal(t, http.StatusOK, rec.Code)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The integration connection-test endpoints (MQTT, BirdWeather, Weather, eBird) stream incremental progress as NDJSON/JSON and flush per result, but they set their response headers inline and never disabled reverse-proxy buffering. Behind nginx the flushed progress was withheld until the handler returned, so the settings UI showed no live progress during a test. Echo's own gzip middleware added a second buffering layer, because its SSE skipper only matches `Accept: text/event-stream` and these are `fetch`-based POSTs.

This is the non-SSE follow-up to #3862 / #3863 (which fixed the SSE streams): the same reverse-proxy buffering problem, a different response class.

## Changes

- **`internal/api/v2/apicore/sse_stream.go`**: new `DisableProxyBuffering(ctx)` (sets `X-Accel-Buffering: no`) and `SetStreamWriteDeadline(ctx)` helpers. `SetSSEHeaders` now delegates the buffering header to `DisableProxyBuffering`, so the header has a single source of truth shared by SSE and non-SSE streams.
- **`internal/api/v2/integrations/integrations.go`**: the four test endpoints now build their headers through a shared `setStreamingHeaders(ctx, contentType)` helper (which disables proxy buffering), and set a per-write deadline before each streamed `Encode` so a stalled client cannot block the writer. This also closes a pre-existing gap where the long-running BirdWeather/Weather tests (up to 30s) could be cut off at the 30s server `WriteTimeout` mid-stream.
- **`internal/api/middleware/compression.go`**: skip gzip for the four streaming route templates (`/api/v2/integrations/{mqtt,birdweather,weather,ebird}/test`), matching the existing `binaryMediaRoutes`/`precompressedRoutes` skip pattern.

### Write-deadline mechanism fix

While adding the deadline I found the existing SSE write-deadline code asserted `SetWriteDeadline` directly on the echo response writer, which the standard net/http writer does not expose, so the assertion failed and the deadline was never actually set. All streaming write paths now go through `http.NewResponseController` (the Go 1.20+ idiom, as `internal/api/v2/support` already does): `SetStreamWriteDeadline` uses it, `SendSSEMessage` and `sendImportEvent` route through the shared helper, and `resetAudioLevelWriteDeadline` uses `NewResponseController` directly. The now-dead `WriteDeadlineSetter` interface is removed.

## Behavior notes

Additive and backward-compatible. The response bodies and content types are unchanged (MQTT/BirdWeather keep `application/json`, Weather/eBird keep `application/x-ndjson`); MQTT/BirdWeather additionally gain `Cache-Control: no-cache` and `Connection: keep-alive`, which the frontend streaming reader ignores. The write deadline is reset before every write, so it bounds a single write and cannot fail a slow-but-alive stream.

## Testing

- Unit tests for `DisableProxyBuffering`, `SetStreamWriteDeadline`, and `setStreamingHeaders` (asserts `X-Accel-Buffering: no` and status).
- Gzip-skip test uses hardcoded route templates plus a negative case and a drift guard against the production map, and a new end-to-end test drives the real gzip middleware to confirm a streaming route is not compressed.
- `go test -race` green on apicore/middleware/integrations/audio/imports/sse; `golangci-lint` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved live progress streaming for JSON/NDJSON integration responses with the correct headers and streaming setup.
  - Added more reliable SSE streaming behavior by enforcing per-write deadlines and disabling proxy buffering.
- **Bug Fixes**
  - Prevented gzip compression from buffering long-lived JSON/NDJSON streaming endpoints so progress updates flush immediately.
- **Tests**
  - Added unit and end-to-end coverage to verify streaming routes are excluded from gzip (while neighboring endpoints are not) and that SSE deadline/buffering helpers behave correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->