### PR TITLE
chore(docker): run tini as PID 1 init in the container image

### DIFF
--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -66,6 +66,10 @@ jobs:
       - name: Custom .tflite model load smoke test
         run: Docker/test/custom-tflite-smoke.sh birdnet-go:test
 
+      # tini must be PID 1 (baked into the image) and reap orphaned grandchildren.
+      - name: tini PID 1 + reaping smoke test
+        run: Docker/test/tini-pid1-smoke.sh birdnet-go:test
+
   arbitrary-uid-start-arm64:
     name: arm64 container startup
     # Native arm64 runner (free for public repos): the only PR-time job that
@@ -101,3 +105,7 @@ jobs:
 
       - name: Arbitrary-UID startup smoke test (arm64)
         run: Docker/test/arbitrary-uid-smoke.sh birdnet-go:test-arm64
+
+      # tini must be PID 1 (baked into the image) and reap orphaned grandchildren.
+      - name: tini PID 1 + reaping smoke test (arm64)
+        run: Docker/test/tini-pid1-smoke.sh birdnet-go:test-arm64

--- a/Docker/test/tini-pid1-smoke.sh
+++ b/Docker/test/tini-pid1-smoke.sh
@@ -34,9 +34,18 @@ trap cleanup EXIT
 pid1=""
 deadline=$((SECONDS + TIMEOUT_SECONDS))
 while [ "$SECONDS" -lt "$deadline" ]; do
-    if [ "$(docker inspect -f '{{.State.Running}}' "$cid" 2>/dev/null || echo false)" = "true" ]; then
+    state=$(docker inspect -f '{{.State.Status}}' "$cid" 2>/dev/null || echo unknown)
+    if [ "$state" = "running" ]; then
+        # cat may lose an exec race while the container is still coming up, so
+        # tolerate a transient failure here and retry on the next tick.
         pid1=$(docker exec "$cid" cat /proc/1/comm 2>/dev/null || true)
         [ -n "$pid1" ] && break
+    elif [ "$state" = "exited" ] || [ "$state" = "dead" ]; then
+        echo "----- container logs (tail) -----"
+        docker logs "$cid" 2>&1 | tail -30
+        echo "---------------------------------"
+        echo "FAIL: container exited prematurely (status=$state) before PID 1 could be checked"
+        exit 1
     fi
     sleep 1
 done
@@ -53,9 +62,12 @@ fi
 # Reaping: orphan a grandchild to PID 1 (the `( sleep 1 & )` subshell exits at
 # once, reparenting the sleep to PID 1) and confirm tini reaps it after it dies,
 # leaving no <defunct> zombie.
-docker exec "$cid" bash -c '( sleep 1 & )' 2>/dev/null || true
+# No 2>/dev/null || true here: the container is confirmed running, so a failure
+# to inject the orphan is a real error that must fail the test loudly rather than
+# silently pass the reaping check with no orphan ever created.
+docker exec "$cid" bash -c '( sleep 1 & )'
 sleep 3
-zombies=$(docker exec "$cid" ps -eo stat,pid,ppid,comm 2>/dev/null | awk 'NR>1 && $1 ~ /^Z/')
+zombies=$(docker exec "$cid" ps -eo stat,pid,ppid,comm | awk 'NR>1 && $1 ~ /^Z/')
 if [ -n "$zombies" ]; then
     echo "FAIL: zombie process present after the orphan exited (tini did not reap):"
     echo "$zombies"

--- a/Docker/test/tini-pid1-smoke.sh
+++ b/Docker/test/tini-pid1-smoke.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Smoke test: tini must be PID 1 in the container and must reap orphaned
+# grandchildren. The image bakes tini in as the outermost ENTRYPOINT so correct
+# PID 1 behaviour (orphan reaping + signal handling) is intrinsic to the image
+# on every runtime (docker/podman run, compose, quadlet, k8s) without needing
+# --init / init: true. This guards two regression classes:
+#   1. The ENTRYPOINT losing its `tini -s --` prefix (PID 1 becomes the shell).
+#   2. The image dropping the tini package.
+#
+# Usage: Docker/test/tini-pid1-smoke.sh <image-ref>
+#
+# Parsing (awk/grep) runs on the host, not in the container, so the image only
+# needs cat/ps/bash/sleep (all present); the runner supplies awk.
+set -euo pipefail
+
+IMAGE="${1:?usage: tini-pid1-smoke.sh <image-ref>}"
+TIMEOUT_SECONDS="${SMOKE_TIMEOUT:-60}"
+
+# Run normally (root entrypoint -> gosu drop -> wrapper -> app), the default
+# deployment path. tmpfs mounts are writable by any UID and give /data the
+# >=1GB the entrypoint preflight requires.
+echo "==> Starting '$IMAGE'"
+cid=$(docker run -d \
+    --tmpfs /config:size=64m \
+    --tmpfs /data:size=1200m \
+    -e TZ=UTC \
+    "$IMAGE")
+cleanup() { docker rm -f "$cid" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+# Wait until the container is running and PID 1 is readable. tini is PID 1 from
+# the start (it is the entrypoint), so this does not need a full app boot.
+pid1=""
+deadline=$((SECONDS + TIMEOUT_SECONDS))
+while [ "$SECONDS" -lt "$deadline" ]; do
+    if [ "$(docker inspect -f '{{.State.Running}}' "$cid" 2>/dev/null || echo false)" = "true" ]; then
+        pid1=$(docker exec "$cid" cat /proc/1/comm 2>/dev/null || true)
+        [ -n "$pid1" ] && break
+    fi
+    sleep 1
+done
+
+echo "==> PID 1 comm: '${pid1:-<none>}'"
+if [ "$pid1" != "tini" ]; then
+    echo "----- container logs (tail) -----"
+    docker logs "$cid" 2>&1 | tail -30
+    echo "---------------------------------"
+    echo "FAIL: PID 1 is '${pid1:-<none>}', expected 'tini'"
+    exit 1
+fi
+
+# Reaping: orphan a grandchild to PID 1 (the `( sleep 1 & )` subshell exits at
+# once, reparenting the sleep to PID 1) and confirm tini reaps it after it dies,
+# leaving no <defunct> zombie.
+docker exec "$cid" bash -c '( sleep 1 & )' 2>/dev/null || true
+sleep 3
+zombies=$(docker exec "$cid" ps -eo stat,pid,ppid,comm 2>/dev/null | awk 'NR>1 && $1 ~ /^Z/')
+if [ -n "$zombies" ]; then
+    echo "FAIL: zombie process present after the orphan exited (tini did not reap):"
+    echo "$zombies"
+    exit 1
+fi
+
+echo "PASS: tini is PID 1 and reaped an orphaned grandchild (no zombies)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -183,7 +183,8 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
     chmod a+x /models && \
     rm -rf /tmp/allmodels
 
-# Install ALSA library and SOX for audio processing, and other system utilities for debugging
+# Install ALSA library and SOX for audio processing, tini (a tiny init run as
+# PID 1, see the ENTRYPOINT note below), and other system utilities for debugging
 RUN apt-get update -q && apt-get install -q -y --no-install-recommends \
     adduser \
     ca-certificates \
@@ -206,6 +207,7 @@ RUN apt-get update -q && apt-get install -q -y --no-install-recommends \
     lsof \
     bash-completion \
     gosu \
+    tini \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy ONNX Runtime libraries (used by all arches; arm64 relies on them exclusively).
@@ -299,6 +301,18 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
     CMD curl -fs --connect-timeout 2 --max-time 3 http://localhost:8080/health | jq -e '.status == "healthy"' >/dev/null || curl -fsk --connect-timeout 2 --max-time 3 https://localhost:8443/health | jq -e '.status == "healthy"' >/dev/null || curl -fsk --connect-timeout 2 --max-time 3 https://localhost:443/health | jq -e '.status == "healthy"' >/dev/null || exit 1
 
 # Container startup execution chain:
+# 0. tini - A tiny init run as PID 1. This is defense-in-depth, not a bug fix:
+#    the bash wrapper below already forwards signals and (via its SIGCHLD
+#    handling) reaps processes reparented to PID 1, and birdnet-go Wait()s the
+#    ffmpeg/sox children it spawns. tini makes correct PID 1 behaviour (orphan
+#    reaping + signal handling) intrinsic to the image instead of relying on the
+#    shell's semantics, so it stays correct across future entrypoint changes and
+#    matches Docker's own --init default. Baked into the image so every deploy
+#    path (docker/podman run, compose, quadlet, k8s) is covered without needing
+#    --init / init: true, which on Podman would require catatonit on the host.
+#    `-s` enables subreaper mode so it still reaps its subtree if a user also
+#    passes --init (tini as PID 2).
+#
 # 1. entrypoint.sh - Sets up user permissions, timezone, device access, and performs
 #    pre-flight checks (disk space, config writability). Handles both rootful and
 #    rootless container modes. Exits early with clear error messages if checks fail.
@@ -320,5 +334,5 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
 #   - Clean signal handling for orchestration (Docker, Kubernetes)
 #   - Early failure detection before wasting resources
 #   - Actionable error messages for troubleshooting
-ENTRYPOINT ["/usr/bin/entrypoint.sh", "/usr/bin/startup-wrapper.sh"]
+ENTRYPOINT ["/usr/bin/tini", "-s", "--", "/usr/bin/entrypoint.sh", "/usr/bin/startup-wrapper.sh"]
 CMD ["birdnet-go", "realtime"]


### PR DESCRIPTION
## What

Bake `tini` into the container image and make it PID 1 via the ENTRYPOINT (`tini -s -- entrypoint.sh startup-wrapper.sh`). The existing `entrypoint.sh` -> `gosu` -> `startup-wrapper.sh` -> app chain is unchanged; tini just sits above it as the init.

## Why (this is hardening, not a bug fix)

This is defense-in-depth for correct PID 1 behaviour (orphan reaping and signal handling), not a fix for an observed bug. I verified the current image already handles reaping: the bash wrapper at PID 1 reaps orphaned ffmpeg/sox grandchildren (bash services SIGCHLD via `waitpid(-1)`), and birdnet-go `Wait()`s the ffmpeg/sox children it spawns (`internal/audiocore/ffmpeg/stream.go`). tini makes correct PID 1 behaviour intrinsic to the image instead of relying on the shell's semantics, so it stays correct across future entrypoint changes and matches Docker's own `--init` default.

## Why baked in, not `--init` / `init: true`

Baking tini into the image covers every deploy path (docker/podman run, compose, quadlet, k8s) without requiring `--init` / `init: true` / `RunInit=yes`. That matters for Podman: those flags require `catatonit` on the host, so setting them could break a minimal Podman host that lacks it, whereas a baked-in tini has zero host dependency. `-s` enables subreaper mode so tini still reaps its subtree if a user additionally passes `--init` (tini as PID 2).

## Testing

Validated runtime behaviour with a layered image (the current published image plus this exact change) on both runtimes and both arches, including real hardware:

- Podman amd64: PID 1 = tini, `/health` healthy, orphaned grandchild reaped (no zombie), SIGTERM stop in 1s with exit 0.
- Docker arm64 (real Raspberry Pi 5): PID 1 = tini, `/health` healthy, orphan reaped, SIGTERM stop in 2s with exit 0.
- Podman arm64 (emulated): PID 1 = tini, entrypoint arg passing intact, orphan reaped.
- `birdnet-go --help` through the full `tini -> entrypoint -> gosu -> wrapper` chain exits 0 with output intact.

Added `Docker/test/tini-pid1-smoke.sh` (shellcheck clean) and wired it into `container-test.yml` for amd64 and arm64. It asserts PID 1 is tini and that an orphaned grandchild is reaped. I validated the guard both ways: it passes on the tini image and fails on the stock image (`PID 1 is 'entrypoint.sh', expected 'tini'`), so it genuinely catches the regression.

## Release notes
- audience: internal
- summary: Container images now run tini as PID 1 (standard init) as defense-in-depth for process reaping and signal handling; no user-visible behaviour change.
- feature: none
- breaking: none
- config: none
- schema: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Container images now use `tini` as the initialization process, improving child-process and orphan cleanup.
  * Startup behavior is more resilient for applications running inside containers.

* **Tests**
  * Added smoke tests for both amd64 and arm64 images to verify `tini` runs as PID 1 and correctly reaps orphaned processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->