### PR TITLE
fix(api): stop SetSSEHeaders hardcoding CORS; let the middleware own it

### DIFF
--- a/internal/api/middleware/security.go
+++ b/internal/api/middleware/security.go
@@ -101,6 +101,7 @@ func NewCORS(config *SecurityConfig) echo.MiddlewareFunc {
 			echo.HeaderContentType,
 			echo.HeaderAccept,
 			echo.HeaderAuthorization,
+			echo.HeaderCacheControl,
 			"X-Requested-With",
 			"X-CSRF-Token",
 		},

--- a/internal/api/middleware/security_test.go
+++ b/internal/api/middleware/security_test.go
@@ -369,3 +369,26 @@ func TestNewCORS_WildcardWithCredentials(t *testing.T) {
 		assert.Equal(t, "true", rec.Header().Get(echo.HeaderAccessControlAllowCredentials))
 	})
 }
+
+// TestNewCORS_AllowsCacheControlHeader guards the CORS side of moving SSE CORS
+// from SetSSEHeaders to the middleware: SSE clients send a Cache-Control request
+// header, so the preflight must allow it now that SetSSEHeaders no longer
+// hardcodes Access-Control-Allow-Headers: Cache-Control.
+func TestNewCORS_AllowsCacheControlHeader(t *testing.T) {
+	t.Parallel()
+
+	corsMiddleware := NewCORS(&SecurityConfig{
+		AllowedOrigins: []string{"*"},
+	})
+
+	c, rec := newCORSTestContext(t, http.MethodOptions, "/api/v2/detections/stream", "https://example.com")
+	c.Request().Header.Set(echo.HeaderAccessControlRequestHeaders, echo.HeaderCacheControl)
+
+	handler := corsMiddleware(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+	require.NoError(t, handler(c))
+
+	assert.Contains(t, rec.Header().Get(echo.HeaderAccessControlAllowHeaders), echo.HeaderCacheControl,
+		"CORS preflight must allow the Cache-Control request header for cross-origin SSE")
+}

--- a/internal/api/v2/apicore/sse_stream.go
+++ b/internal/api/v2/apicore/sse_stream.go
@@ -46,12 +46,16 @@ const (
 )
 
 // SetSSEHeaders sets the required HTTP headers for a Server-Sent Events response.
+// CORS is intentionally left to the global CORS middleware (see middleware.NewCORS)
+// so SSE endpoints honor the configured AllowedOrigins. Previously this helper
+// hardcoded Access-Control-Allow-Origin: * , which clobbered the middleware and
+// let SSE bypass a restrictive CORS policy; the middleware's AllowHeaders now
+// includes Cache-Control so browsers that send that request header still pass
+// preflight.
 func SetSSEHeaders(ctx echo.Context) {
 	ctx.Response().Header().Set("Content-Type", "text/event-stream")
 	ctx.Response().Header().Set("Cache-Control", "no-cache")
 	ctx.Response().Header().Set("Connection", "keep-alive")
-	ctx.Response().Header().Set("Access-Control-Allow-Origin", "*")
-	ctx.Response().Header().Set("Access-Control-Allow-Headers", "Cache-Control")
 	DisableProxyBuffering(ctx)
 }
 

--- a/internal/api/v2/apicore/sse_stream_test.go
+++ b/internal/api/v2/apicore/sse_stream_test.go
@@ -21,18 +21,23 @@ func Test_SetSSEHeaders(t *testing.T) {
 	SetSSEHeaders(ctx)
 
 	expectedHeaders := map[string]string{
-		"Content-Type":                 "text/event-stream",
-		"Cache-Control":                "no-cache",
-		"Connection":                   "keep-alive",
-		"Access-Control-Allow-Origin":  "*",
-		"Access-Control-Allow-Headers": "Cache-Control",
-		"X-Accel-Buffering":            "no",
+		"Content-Type":      "text/event-stream",
+		"Cache-Control":     "no-cache",
+		"Connection":        "keep-alive",
+		"X-Accel-Buffering": "no",
 	}
 
 	for key, expectedValue := range expectedHeaders {
 		actualValue := rec.Header().Get(key)
 		assert.Equal(t, expectedValue, actualValue, "SetSSEHeaders() header %q mismatch", key)
 	}
+
+	// CORS must NOT be set here; it is owned by the global CORS middleware so SSE
+	// endpoints honor the configured AllowedOrigins instead of a hardcoded wildcard.
+	assert.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"),
+		"SetSSEHeaders must not hardcode Access-Control-Allow-Origin; CORS is the middleware's job")
+	assert.Empty(t, rec.Header().Get("Access-Control-Allow-Headers"),
+		"SetSSEHeaders must not hardcode Access-Control-Allow-Headers")
 }
 
 func Test_DisableProxyBuffering(t *testing.T) {


### PR DESCRIPTION
## Summary

`SetSSEHeaders` set `Access-Control-Allow-Origin: *` and `Access-Control-Allow-Headers: Cache-Control` on every Server-Sent Events response. Because it used `.Set()`, it overwrote whatever the global CORS middleware (`middleware.NewCORS`, applied in `server.go`) had evaluated. Three consequences:

1. SSE endpoints ignored a restrictive `AllowedOrigins` policy and always advertised `*`, so any origin could open a cross-origin SSE stream and read broadcast data (a silent CORS bypass).
2. When credentials are enabled with a wildcard origin, the middleware reflects the request origin (to stay spec-compliant); the hardcoded `*` clobbered that reflected origin, so an authenticated cross-origin `EventSource` (`withCredentials: true`) was rejected by the browser.
3. The hardcoded `Access-Control-Allow-Headers: Cache-Control` never did anything: a preflight `OPTIONS` is answered by the CORS middleware before the handler (and `SetSSEHeaders`) runs.

This is item 3 of the streaming/proxy header cleanup that also produced #3876.

## Changes

- **`internal/api/v2/apicore/sse_stream.go`**: remove both hardcoded `Access-Control-*` lines from `SetSSEHeaders` so the CORS middleware is the sole authority for SSE CORS.
- **`internal/api/middleware/security.go`**: add `echo.HeaderCacheControl` to the CORS `AllowHeaders`, so fetch-based SSE clients that send a `Cache-Control` request header still pass preflight (this replaces the hardcoded allow-header that never took effect).

## Behavior notes

Default deployments (`AllowedOrigins: ["*"]`) are unaffected: the middleware still emits `*` for cross-origin requests, and same-origin SSE (the dashboard) never needed a CORS header. Deployments with a restrictive `AllowedOrigins` now correctly have that policy enforced on SSE too, and authenticated cross-origin SSE now works.

## Testing

- `Test_SetSSEHeaders` updated to assert the CORS headers are NOT set by the helper.
- New `TestNewCORS_AllowsCacheControlHeader` asserts a preflight allows the `Cache-Control` request header.
- `go test -race` green on apicore/middleware/sse; `golangci-lint` clean. Independently reviewed for CORS/security regressions.