### PR TITLE
fix(autotls): map installer/quadlet ports to 8080/8443 and serve /health over HTTP

### DIFF
--- a/Podman/quadlet/birdnet-go-autotls.container
+++ b/Podman/quadlet/birdnet-go-autotls.container
@@ -9,8 +9,12 @@ ContainerName=birdnet-go-autotls
 Volume=./config:/config
 Volume=./data:/data
 Volume=./certs:/certs
-PublishPort=80:80
-PublishPort=443:443
+# AutoTLS binds the ACME HTTP-01 + HTTP->HTTPS redirect listener on 8080 and
+# HTTPS on 8443 inside the container, so map the privileged host ports to those
+# non-privileged container ports (no NET_BIND_SERVICE needed). Mirrors
+# Podman/podman-compose.autotls.yml.
+PublishPort=80:8080
+PublishPort=443:8443
 Environment=TZ=UTC
 Environment=BIRDNET_UID=1000
 Environment=BIRDNET_GID=1000
@@ -19,7 +23,6 @@ Environment=BIRDNET_SECURITY_HOST=%i
 Device=/dev/snd:/dev/snd
 Network=bridge
 Tmpfs=/config/hls:exec,size=50M,uid=1000,gid=1000,mode=0755
-AddCapability=NET_BIND_SERVICE
 
 [Service]
 Restart=always

--- a/install.sh
+++ b/install.sh
@@ -4510,10 +4510,15 @@ generate_systemd_service_content() {
     # because load_existing_service_config() restores these flags from the current unit.
     # Any restored host bind address is reapplied so a localhost-only mapping survives a
     # regenerate (default is no address: published on all interfaces).
+    #
+    # AutoTLS maps host 80/443 to the container's non-privileged listeners: the app
+    # binds the ACME HTTP-01 + HTTP->HTTPS redirect listener on 8080 and HTTPS on 8443
+    # (see internal/api/server.go), so the container never binds privileged ports and
+    # needs no NET_BIND_SERVICE. This mirrors the docker/podman AutoTLS compose files.
     local tls_ports_line=""
     if [ "$BIND_TLS_PORTS" = "true" ]; then
-        tls_ports_line="-p ${TLS_BIND_ADDR:+${TLS_BIND_ADDR}:}80:80 \\
-    -p ${TLS_BIND_ADDR:+${TLS_BIND_ADDR}:}443:443"
+        tls_ports_line="-p ${TLS_BIND_ADDR:+${TLS_BIND_ADDR}:}80:8080 \\
+    -p ${TLS_BIND_ADDR:+${TLS_BIND_ADDR}:}443:8443"
     fi
     local metrics_port_line=""
     if [ "$BIND_METRICS_PORT" = "true" ]; then
@@ -4594,7 +4599,10 @@ _extract_bind_addr() {
 # systemd unit so updates and reconfiguration preserve the user's prior choices instead of
 # resetting to fresh-install defaults. This is the backward-compatibility guarantee: an
 # unchanged update regenerates a byte-identical unit (check_systemd_service then reports no
-# change). It must be called before check_systemd_service / add_systemd_config on the
+# change). The one deliberate exception is a legacy AutoTLS unit that still maps the dead
+# 443:443 / 80:80 ports: it is detected as AutoTLS-enabled and regenerated with the corrected
+# 443:8443 / 80:8080 mapping, so that single update is intentionally not byte-identical.
+# It must be called before check_systemd_service / add_systemd_config on the
 # update and reconfigure paths. Sets globals WEB_PORT, BIND_TLS_PORTS, BIND_METRICS_PORT,
 # and CONFIGURED_TZ.
 # shellcheck disable=SC2120  # optional $1 (unit path) is intentional, used by tests
@@ -4644,10 +4652,20 @@ load_existing_service_config() {
     # NOTE: this is binding preservation, not feature detection, so an unchanged update keeps
     # exactly what the user already ran.
     local tls_map
-    tls_map=$(grep -oE '\-p (\[[0-9a-fA-F:]+\]:|[0-9.]+:)?443:443' "$service_file" 2>/dev/null | head -1)
+    # Match the current 443:8443 mapping or the legacy 443:443 form. Pre-fix units
+    # published dead 443:443 / 80:80 mappings (the container binds 8080/8443); treat
+    # them as AutoTLS-enabled so a regenerate produces the corrected 443:8443 mapping
+    # instead of silently dropping AutoTLS. The trailing \b avoids a false match
+    # inside e.g. 443:4433.
+    tls_map=$(grep -oE '\-p (\[[0-9a-fA-F:]+\]:|[0-9.]+:)?443:(8443|443)\b' "$service_file" 2>/dev/null | head -1)
     if [ -n "$tls_map" ]; then
         BIND_TLS_PORTS="true"
-        TLS_BIND_ADDR=$(_extract_bind_addr "$tls_map" "443:443")
+        # Strip whichever container-port suffix matched to recover any bind address.
+        local tls_portpair="443:8443"
+        case "$tls_map" in
+            *443:443) tls_portpair="443:443" ;;
+        esac
+        TLS_BIND_ADDR=$(_extract_bind_addr "$tls_map" "$tls_portpair")
     fi
     local metrics_map
     metrics_map=$(grep -oE '\-p (\[[0-9a-fA-F:]+\]:|[0-9.]+:)?8090:8090' "$service_file" 2>/dev/null | head -1)

--- a/internal/api/autotls_test.go
+++ b/internal/api/autotls_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -198,11 +199,17 @@ func TestAutoTLS_DualListeners(t *testing.T) {
 	e.HidePort = true
 
 	s := &Server{
-		config:   cfg,
-		settings: settings,
-		echo:     e,
-		slogger:  GetLogger(),
+		config:    cfg,
+		settings:  settings,
+		echo:      e,
+		slogger:   GetLogger(),
+		startTime: time.Now(),
 	}
+
+	// Register the health route the AutoTLS HTTP fallback serves over plain HTTP.
+	// This test constructs the echo instance directly and never calls setupRoutes,
+	// so without this the /health probe below would hit echo's default 404.
+	e.GET(healthCheckPath, s.healthCheck)
 
 	// Echo.Shutdown returns early (skipping Server.Shutdown) if TLSServer.Shutdown
 	// returns context.Canceled — which happens when ctx is already done. Use an
@@ -255,6 +262,17 @@ func TestAutoTLS_DualListeners(t *testing.T) {
 		"redirect should target the advertised host with no internal port")
 	assert.NotContains(t, location, ":"+tlsPort,
 		"redirect must not leak the internal TLS port")
+
+	// The unauthenticated /health endpoint must be served as JSON over the plain-HTTP
+	// AutoTLS listener even though RedirectToHTTPS is on, so a container healthcheck
+	// probing this listener is not answered with a 308 (which carries no JSON body).
+	resp, err = client.Get(httpBase + healthCheckPath)
+	require.NoError(t, err)
+	healthBody, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "/health must be served, not redirected")
+	assert.Contains(t, string(healthBody), `"status":"healthy"`, "/health must return health JSON")
 
 	// TLS listener should accept TCP connections (full TLS handshake won't
 	// complete without a real cert, but a successful TCP connect proves the
@@ -623,8 +641,12 @@ func TestAutoTLS_RedirectDisabled_ServesApp(t *testing.T) {
 	e := echo.New()
 	e.HideBanner = true
 	e.HidePort = true
-	e.GET("/health", func(c echo.Context) error {
-		return c.String(http.StatusOK, "ok")
+	// Register a generic (non-health) app route. /health is special-cased by the
+	// health-over-HTTP bypass and would return 200 regardless of the redirect
+	// setting, so probing it here would not prove the app itself is served over
+	// plain HTTP when RedirectToHTTPS is disabled.
+	e.GET("/dashboard", func(c echo.Context) error {
+		return c.String(http.StatusOK, "app-content")
 	})
 
 	s := &Server{
@@ -658,12 +680,16 @@ func TestAutoTLS_RedirectDisabled_ServesApp(t *testing.T) {
 
 	// With RedirectToHTTPS=false, the app should be served over plain HTTP
 	httpBase := fmt.Sprintf("http://127.0.0.1:%s", httpPort)
-	resp, err := client.Get(httpBase + "/health")
+	resp, err := client.Get(httpBase + "/dashboard")
 	require.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
 	_ = resp.Body.Close()
+	require.NoError(t, err)
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode,
 		"with RedirectToHTTPS=false, HTTP should serve app content, not redirect")
+	assert.Contains(t, string(body), "app-content",
+		"the plain-HTTP listener should return the app response, not a redirect")
 }
 
 func mustGetFreePort(t *testing.T) string {
@@ -687,4 +713,45 @@ func requirePortOpen(t *testing.T, port string) {
 		time.Sleep(50 * time.Millisecond)
 	}
 	t.Fatalf("port %s did not open within 2s", port)
+}
+
+// TestServer_healthOrRedirect verifies the AutoTLS / manual-TLS HTTP fallback
+// serves the unauthenticated /health endpoint as JSON while redirecting everything
+// else, so a plain-HTTP container healthcheck is never answered with a 308.
+func TestServer_healthOrRedirect(t *testing.T) {
+	t.Parallel()
+
+	e := echo.New()
+	e.HideBanner = true
+	s := &Server{
+		echo:      e,
+		settings:  conftest.NewTestSettings().Build(),
+		startTime: time.Now(),
+	}
+	e.GET(healthCheckPath, s.healthCheck)
+
+	const sentinel = "redirected-elsewhere"
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusPermanentRedirect)
+		_, _ = w.Write([]byte(sentinel))
+	})
+	handler := s.healthOrRedirect(next)
+
+	t.Run("health served as JSON", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, healthCheckPath, http.NoBody)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Contains(t, rec.Body.String(), `"status":"healthy"`)
+		assert.NotContains(t, rec.Body.String(), sentinel,
+			"health must be served by echo, not delegated to the redirect handler")
+	})
+
+	t.Run("non-health delegated to next", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/dashboard", http.NoBody)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusPermanentRedirect, rec.Code)
+		assert.Contains(t, rec.Body.String(), sentinel)
+	})
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -475,10 +475,15 @@ func (s *Server) setupMiddleware() {
 	s.echo.Use(mw.NewSecureHeaders(securityConfig))
 }
 
+// healthCheckPath is the unauthenticated health endpoint. It is served over every
+// listener, including the plain-HTTP AutoTLS/redirect listener, so a container
+// healthcheck or load balancer can verify the server without a valid certificate.
+const healthCheckPath = "/health"
+
 // setupRoutes configures all HTTP routes.
 func (s *Server) setupRoutes() error {
 	// Health check endpoint at root level
-	s.echo.GET("/health", s.healthCheck)
+	s.echo.GET(healthCheckPath, s.healthCheck)
 
 	// Social OAuth routes (Google, GitHub, Microsoft)
 	// These must be at /auth/:provider to match frontend expectations
@@ -651,7 +656,11 @@ func (s *Server) startBlocking() error {
 		//   mappings such as host 443 -> container 8443.
 		var httpFallback http.Handler
 		if s.config.RedirectToHTTPS {
-			httpFallback = httpsRedirectHandler(s.config.RedirectAuthority, "")
+			// Redirect non-ACME traffic to HTTPS, but keep serving the
+			// unauthenticated /health endpoint as JSON so a container healthcheck
+			// probing this plain-HTTP listener is answered with health status, not
+			// a 308 (which has no JSON body and fails the healthcheck's jq check).
+			httpFallback = s.healthOrRedirect(httpsRedirectHandler(s.config.RedirectAuthority, ""))
 		} else {
 			httpFallback = s.echo
 		}
@@ -816,6 +825,21 @@ func httpsRedirectHandler(externalAuthority, fallbackPort string) http.Handler {
 	})
 }
 
+// healthOrRedirect returns an http.Handler that serves the unauthenticated health
+// endpoint via echo (so a plain-HTTP container healthcheck receives JSON rather
+// than a 308) and delegates every other request to next. It backs the AutoTLS
+// ACME/redirect listener and the manual-TLS HTTP redirect server, both of which
+// otherwise 308 all traffic (including /health) to HTTPS.
+func (s *Server) healthOrRedirect(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == healthCheckPath {
+			s.echo.ServeHTTP(w, r)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 // newHTTPRedirectServer creates an HTTP server that redirects all requests to HTTPS.
 // The server is created synchronously to avoid a race between assignment and shutdown.
 func (s *Server) newHTTPRedirectServer(httpAddr, tlsPort string) *http.Server {
@@ -825,7 +849,7 @@ func (s *Server) newHTTPRedirectServer(httpAddr, tlsPort string) *http.Server {
 
 	return &http.Server{
 		Addr:         httpAddr,
-		Handler:      httpsRedirectHandler(s.config.RedirectAuthority, tlsPort),
+		Handler:      s.healthOrRedirect(httpsRedirectHandler(s.config.RedirectAuthority, tlsPort)),
 		ReadTimeout:  s.config.ReadTimeout,
 		WriteTimeout: s.config.WriteTimeout,
 	}

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -92,6 +92,13 @@ log_message() { :; }
 log_command_result() { :; }
 command_exists() { command -v "$1" >/dev/null 2>&1; }
 
+# Deterministic stubs for the helpers generate_systemd_service_content calls: force
+# audio/thermal/Pi detection off and resolve the timezone to the passed value so the
+# generated unit is stable across hosts.
+resolve_host_timezone() { printf '%s' "${1:-UTC}"; }
+check_directory_exists() { return 1; }
+is_raspberry_pi() { return 1; }
+
 # Globals the extracted functions reference (install.sh defines these at the top; the harness
 # only pulls function bodies, so under set -u they must exist here).
 RED=""; GREEN=""; YELLOW=""; NC=""; GRAY=""
@@ -108,6 +115,7 @@ for fn in \
     set_first_audio_source \
     _extract_bind_addr \
     load_existing_service_config \
+    generate_systemd_service_content \
     apply_tls_settings \
     ensure_internal_port_8080 \
     configure_rtsp_in_config \
@@ -339,7 +347,8 @@ cat > "$unit" <<'EOF'
 ExecStart=/usr/bin/docker run --rm \
     --name birdnet-go \
     -p 127.0.0.1:9000:8080 \
-    -p 443:443 \
+    -p 80:8080 \
+    -p 443:8443 \
     -p 8090:8090 \
     --env TZ="Europe/Helsinki" \
     -v /home/pi/birdnet-go-app/config:/config \
@@ -351,8 +360,43 @@ load_existing_service_config "$unit"
 assert_eq "restored web port" "9000" "$WEB_PORT"
 assert_eq "restored web bind addr" "127.0.0.1" "$WEB_PORT_BIND_ADDR"
 assert_eq "restored TLS binding" "true" "$BIND_TLS_PORTS"
+assert_eq "restored TLS bind addr (none)" "" "$TLS_BIND_ADDR"
 assert_eq "restored metrics binding" "true" "$BIND_METRICS_PORT"
 assert_eq "restored timezone" "Europe/Helsinki" "$CONFIGURED_TZ"
+
+# A legacy (pre-fix) AutoTLS unit still maps the dead 80:80 / 443:443 ports. It must still
+# be detected as AutoTLS-enabled so a regenerate produces the corrected 443:8443 mapping
+# instead of silently dropping AutoTLS.
+cat > "$unit" <<'EOF'
+[Service]
+ExecStart=/usr/bin/docker run --rm \
+    -p 8080:8080 \
+    -p 80:80 \
+    -p 443:443 \
+    ghcr.io/tphakala/birdnet-go:nightly
+EOF
+WEB_PORT=""; WEB_PORT_BIND_ADDR=""; BIND_TLS_PORTS="false"; TLS_BIND_ADDR=""
+BIND_METRICS_PORT="false"; METRICS_BIND_ADDR=""; CONFIGURED_TZ=""
+load_existing_service_config "$unit"
+assert_eq "legacy 443:443: web port restored" "8080" "$WEB_PORT"
+assert_eq "legacy 443:443: TLS binding restored" "true" "$BIND_TLS_PORTS"
+assert_eq "legacy 443:443: TLS bind addr (none)" "" "$TLS_BIND_ADDR"
+
+# A localhost-bound AutoTLS mapping must preserve the host bind address so an update does
+# not silently re-expose it on all interfaces.
+cat > "$unit" <<'EOF'
+[Service]
+ExecStart=/usr/bin/docker run --rm \
+    -p 127.0.0.1:8080:8080 \
+    -p 127.0.0.1:80:8080 \
+    -p 127.0.0.1:443:8443 \
+    ghcr.io/tphakala/birdnet-go:nightly
+EOF
+WEB_PORT=""; WEB_PORT_BIND_ADDR=""; BIND_TLS_PORTS="false"; TLS_BIND_ADDR=""
+BIND_METRICS_PORT="false"; METRICS_BIND_ADDR=""; CONFIGURED_TZ=""
+load_existing_service_config "$unit"
+assert_eq "bind-addr: TLS binding restored" "true" "$BIND_TLS_PORTS"
+assert_eq "bind-addr: TLS bind addr preserved" "127.0.0.1" "$TLS_BIND_ADDR"
 
 # A unit with only the web port (no 80/443, no 8090) leaves TLS/metrics off.
 cat > "$unit" <<'EOF'
@@ -367,6 +411,36 @@ load_existing_service_config "$unit"
 assert_eq "web-only: port restored" "8080" "$WEB_PORT"
 assert_eq "web-only: TLS stays off" "false" "$BIND_TLS_PORTS"
 assert_eq "web-only: metrics stays off" "false" "$BIND_METRICS_PORT"
+
+# ===========================================================================
+# generate_systemd_service_content: AutoTLS maps host 80/443 to container 8080/8443
+# (never dead 443:443), adds no NET_BIND_SERVICE, and round-trips cleanly through the
+# parser (the new 80:8080 line must not be mistaken for the web-port mapping).
+# ===========================================================================
+it "generate_systemd_service_content AutoTLS ports"
+
+CONFIG_DIR="/home/pi/birdnet-go-app/config"
+DATA_DIR="/home/pi/birdnet-go-app/data"
+BIRDNET_GO_IMAGE="ghcr.io/tphakala/birdnet-go:nightly"
+WEB_PORT="9000"; WEB_PORT_BIND_ADDR=""
+BIND_TLS_PORTS="true"; TLS_BIND_ADDR=""
+BIND_METRICS_PORT="false"; METRICS_BIND_ADDR=""
+CONFIGURED_TZ="UTC"
+
+autotls_unit="${WORK}/autotls.service"
+generate_systemd_service_content > "$autotls_unit"
+assert_eq "AutoTLS unit maps host 80 -> container 8080" "1" "$(grep -c -- '-p 80:8080' "$autotls_unit")"
+assert_eq "AutoTLS unit maps host 443 -> container 8443" "1" "$(grep -c -- '-p 443:8443' "$autotls_unit")"
+assert_eq "AutoTLS unit has no dead 443:443 mapping" "0" "$(grep -c -- '443:443' "$autotls_unit")"
+assert_eq "AutoTLS unit still publishes the web port" "1" "$(grep -c -- '-p 9000:8080' "$autotls_unit")"
+assert_eq "AutoTLS unit adds no NET_BIND_SERVICE" "0" "$(grep -c 'NET_BIND_SERVICE' "$autotls_unit")"
+
+WEB_PORT=""; WEB_PORT_BIND_ADDR=""; BIND_TLS_PORTS="false"; TLS_BIND_ADDR=""
+BIND_METRICS_PORT="false"; METRICS_BIND_ADDR=""; CONFIGURED_TZ=""
+load_existing_service_config "$autotls_unit"
+assert_eq "round-trip: web port restored (not 80)" "9000" "$WEB_PORT"
+assert_eq "round-trip: TLS binding restored" "true" "$BIND_TLS_PORTS"
+assert_eq "round-trip: TLS bind addr empty" "" "$TLS_BIND_ADDR"
 
 # ===========================================================================
 # apply_tls_settings (full slate; mode switch must clear stale host)


### PR DESCRIPTION
## Summary

Closes the two remaining AutoTLS deployment gaps that #3612 left open. #3612 moved AutoTLS to bind the ACME HTTP-01 / redirect listener on container port 8080 and HTTPS on 8443, then remap host `80->8080` / `443->8443` at the host layer (so the container needs no `NET_BIND_SERVICE`). It updated the docker/podman compose files but missed two coupled artifacts, so AutoTLS was still broken for installer- and quadlet-based deployments, and the container healthcheck failed in AutoTLS mode.

Both gaps were surfaced by @brycesub in #3780; thanks for the digging.

## What was broken

1. **Installer and Podman quadlet mapped dead ports.** `install.sh` generated systemd units and `Podman/quadlet/birdnet-go-autotls.container` still published `80:80` / `443:443`. The container binds 8080/8443, so those host ports mapped to container ports where nothing listens: ACME HTTP-01 validation and HTTPS were both unreachable, and the quadlet still requested a now-pointless `NET_BIND_SERVICE`. `podman-install.sh` ships that quadlet verbatim, so every Podman-quadlet AutoTLS install was affected.
2. **AutoTLS + redirect broke the container healthcheck.** With `RedirectToHTTPS` on (the AutoTLS default), the ACME HTTP listener's fallback 308-redirected every path, including `/health`. The Docker `HEALTHCHECK` probes `http://localhost:8080/health | jq '.status == "healthy"'`; a 308 has no JSON body, so the probe failed, and the HTTPS fallback probe then failed autocert's host whitelist (`localhost` is never whitelisted). Containers were marked unhealthy in AutoTLS mode.

## Changes

- **install.sh**: the generated AutoTLS systemd unit now maps host `80->8080` and `443->8443`, matching the compose files. `load_existing_service_config` recognizes both the new `443:8443` and the legacy `443:443` forms, so an existing (broken) unit is detected as AutoTLS-enabled and regenerated with the corrected mapping instead of silently dropping AutoTLS on the next update.
- **Podman/quadlet/birdnet-go-autotls.container**: same `80:8080` / `443:8443` remap, and dropped the unnecessary `NET_BIND_SERVICE` capability.
- **internal/api/server.go**: a small `healthOrRedirect` handler serves the unauthenticated `/health` endpoint as JSON over the AutoTLS ACME listener and the manual-TLS HTTP redirect server, while everything else still redirects. ACME challenge paths are still intercepted first; no Dockerfile change is needed (the existing `:8080/health` probe now returns JSON).

## Testing

- `go test -race ./internal/api/...` (extended `TestAutoTLS_DualListeners` to assert `/health` returns 200 JSON over the plain-HTTP listener, plus a focused `TestServer_healthOrRedirect`).
- `scripts/install_test.sh` (added legacy-unit, localhost-bind-preservation, and a full `generate_systemd_service_content` round-trip that asserts the `80:8080` / `443:8443` mapping, no `NET_BIND_SERVICE`, and that the parser does not mistake the new `80:8080` line for the web port).
- `golangci-lint run`, `go vet`, shellcheck (no new findings), and the local quality gate.

## Related

Refs #3527, #3612.

## Breaking changes

None. Existing AutoTLS installs get a one-time systemd-unit rewrite on their next `install.sh` update that replaces the dead port mapping with the working one; this is the intended repair.
