### PR TITLE
ci(docker): allow manual dispatch of the dev container build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -26,11 +26,14 @@ jobs:
   # Publish the :dev / :<sha> multi-arch images through the shared reusable
   # workflow (dev strategy), so dev, nightly, and release all build and tag the
   # same way. Dev builds go to GHCR only (no Docker Hub) and skip the Podman
-  # validation and cleanup jobs. Gated to push-on-main to preserve the prior
-  # behaviour; the schedule/dispatch triggers above are currently no-ops under
-  # this gate (kept for parity with the previous workflow).
+  # validation and cleanup jobs. Runs on push-to-main (the normal path) and on a
+  # manual workflow_dispatch (used to cut a draft image for pre-release upgrade
+  # QA without moving :nightly/:latest). The scheduled cron stays a no-op by
+  # omission from this gate.
   dev:
-    if: github.event_name == 'push' && github.ref_name == 'main'
+    if: >-
+      (github.event_name == 'push' && github.ref_name == 'main') ||
+      github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/docker-build-push.yml
     with:
       tag-strategy: "dev"


### PR DESCRIPTION
Widen the `dev` job's `if`-gate in `docker-build.yml` so it runs on `workflow_dispatch` as well as push-to-main. The `workflow_dispatch` entry was already declared in the `on:` block but was a dead no-op under the previous gate.

The `dev` strategy is the only build path that publishes multi-arch images (`:dev` + `:<sha>`, GHCR-only) without moving `:nightly` or `:latest`, so it is the right vehicle for cutting a draft image on demand to run pre-release upgrade QA without exposing the `:nightly`-pinned install.sh userbase to it. The scheduled cron stays a no-op by omission from the gate.

## Release notes
- audience: internal
- summary: none (CI-only; lets a maintainer manually cut a draft dev image for pre-release testing)
- feature: none
- breaking: none
- config: none
- schema: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Prevented overlapping Docker build workflow runs for the same branch or reference.
  * Added support for manually triggering development Docker builds.
  * Kept scheduled workflow runs from executing the development build unintentionally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->