### PR TITLE
ci(release): support date-based release tags with :nightly retention

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -172,6 +172,14 @@ jobs:
                 emit "${repo}:${no_v}"
                 emit "${repo}:podman-${no_v}"
               fi
+              # Date-based release (YYYYMMDD): also move the :nightly alias so
+              # the install.sh userbase that pins :nightly keeps receiving each
+              # dated release. Gated to date tags so a stable vX.Y.Z release does
+              # not move :nightly.
+              if printf '%s' "$VERSION" | grep -qE '^[0-9]{8}$'; then
+                emit "${repo}:nightly"
+                emit "${repo}:podman-nightly"
+              fi
             elif [ "$STRATEGY" = "dev" ]; then
               # Dev images built on every push to main: a floating :dev alias and
               # the immutable commit SHA (passed in as version), plus podman

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -135,10 +135,21 @@ jobs:
 
       - name: Get version
         id: get_version
+        env:
+          # Passed via env, not inline ${{ }}, so a crafted ref name cannot
+          # inject shell (matches the build job's hardening).
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          # Restrict to stable release tags so a workflow_dispatch from a
-          # non-tagged ref does not resolve to the "manifest" prerelease tag.
-          VERSION=$(git describe --tags --always --match 'v*')
+          # On a release event the tag IS the version (a date-based 20260712 or
+          # a stable v1.2.3), so use it directly. Only fall back to git describe
+          # on a manual dispatch from a non-tagged ref, restricting to stable
+          # tags so it does not resolve the "manifest" prerelease tag.
+          if [ "${EVENT_NAME}" = "release" ]; then
+            VERSION="${REF_NAME}"
+          else
+            VERSION=$(git describe --tags --always --match 'v*')
+          fi
           echo "VERSION=${VERSION}" >> ${GITHUB_ENV}
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -148,7 +148,10 @@ jobs:
           if [ "${EVENT_NAME}" = "release" ]; then
             VERSION="${REF_NAME}"
           else
-            VERSION=$(git describe --tags --always --match 'v*')
+            # Match the build and checksums jobs exactly (--abbrev=0), so a
+            # workflow_dispatch run versions the binaries and the container
+            # images with the identical clean tag rather than a describe suffix.
+            VERSION=$(git describe --tags --abbrev=0 --match 'v*')
           fi
           echo "VERSION=${VERSION}" >> ${GITHUB_ENV}
           echo "version=${VERSION}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
So a bare date tag (e.g. `20260712`) produces a correct release, two targeted changes:

- **`release-build.yml` `get-version`**: on a `release` event use the release tag (`ref_name`) directly instead of `git describe --match 'v*'`, which resolves a stale `v*` tag and would version the container images wrong for a date tag. Mirrors the binary build job's existing `ref_name` logic.
- **`docker-build-push.yml` `release` strategy**: also emit `:nightly` + `:podman-nightly` for date tags (`YYYYMMDD`), so the install.sh userbase that pins `:nightly` keeps receiving each dated release. Gated to date tags so a stable `vX.Y.Z` release does not move `:nightly`.

`:latest` is already emitted via `create-latest-tag: true`. No auto-update manifest changes: the in-app update checker is not active, so channel classification is out of scope here.

## Release notes
- audience: internal
- summary: none (CI-only; enables date-based release tags to publish images tagged :date + :latest + :nightly)
- feature: none
- breaking: none
- config: none
- schema: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected release version detection for automated releases and manual runs.
  * Updated nightly Docker image alias behavior so `:nightly` aligns with date-based release series while keeping stable `vX.Y.Z` aliases unchanged.
* **Chores**
  * Improved Docker build/publish tag generation for more consistent and predictable release artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->