### PR TITLE
ci(release): run VirusTotal after assets are attached, not on release publish

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -115,6 +115,14 @@ jobs:
     permissions:
       contents: write
 
+  # Scan the attached tarballs and append VirusTotal results to the release body,
+  # after the release job has created the release with its assets. Replaces the
+  # old release:published trigger on virustotal.yml.
+  virustotal:
+    needs: release
+    uses: ./.github/workflows/virustotal.yml
+    secrets: inherit
+
   get-version:
     runs-on: ubuntu-24.04
     outputs:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -181,3 +181,13 @@ jobs:
     uses: ./.github/workflows/release-manifest.yml
     permissions:
       contents: write
+
+  # Scan the attached tarballs and append VirusTotal results to the release body.
+  # Runs after build + checksums so the assets already exist; replaces the old
+  # release:published trigger on virustotal.yml, which fired before the build
+  # attached any assets and always failed with "No Assets Found".
+  virustotal:
+    if: ${{ !contains(github.ref, 'nightly') && (github.event_name == 'release' || github.event_name == 'workflow_dispatch') }}
+    needs: [build, checksums]
+    uses: ./.github/workflows/virustotal.yml
+    secrets: inherit

--- a/.github/workflows/virustotal.yml
+++ b/.github/workflows/virustotal.yml
@@ -30,10 +30,14 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           # Prefer the release that triggered the calling pipeline; fall back to
-          # the latest published release for a standalone manual dispatch.
+          # the most recently created release for a caller without a release
+          # event (the workflow_dispatch nightly flow) or a standalone manual
+          # dispatch. Use the list endpoint, NOT releases/latest: the latter
+          # excludes prereleases, so it would resolve the wrong release for the
+          # prerelease nightly flow (flagged by CodeRabbit and Sentry).
           RID="${EVENT_RELEASE_ID}"
           if [ -z "$RID" ]; then
-            RID=$(gh api "repos/${REPO}/releases/latest" --jq '.id')
+            RID=$(gh api "repos/${REPO}/releases?per_page=1" --jq '.[0].id')
           fi
           echo "id=$RID" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/virustotal.yml
+++ b/.github/workflows/virustotal.yml
@@ -1,8 +1,14 @@
 name: VirusTotal Scan
 
+# Scans the release tarballs and appends the results to the release body.
+# Invoked as a downstream job of release-build.yml / nightly-build.yml AFTER the
+# assets are attached (workflow_call), so it never races the build and finds an
+# asset-less release. workflow_dispatch remains for a manual re-scan of the
+# latest release. The release:published trigger was removed because it fired the
+# moment the release was created, before the build attached any tarballs, which
+# made every date-based release scan fail with "No Assets Found".
 on:
-  release:
-    types: [published]
+  workflow_call:
   workflow_dispatch:
 
 permissions:
@@ -13,16 +19,25 @@ jobs:
     name: Scan Release Assets
     runs-on: ubuntu-24.04
     steps:
-      - name: Get latest release ID
-        if: github.event_name == 'workflow_dispatch'
+      - name: Resolve release id
         id: release
         env:
           GH_TOKEN: ${{ github.token }}
+          # The release that triggered the calling pipeline, if any (inherited
+          # from the caller's event on workflow_call). Passed via env, not inline
+          # ${{ }}, to keep the shell injection-safe.
+          EVENT_RELEASE_ID: ${{ github.event.release.id }}
+          REPO: ${{ github.repository }}
         run: |
-          RELEASE_ID=$(gh api repos/${{ github.repository }}/releases/latest --jq '.id')
-          echo "id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
+          # Prefer the release that triggered the calling pipeline; fall back to
+          # the latest published release for a standalone manual dispatch.
+          RID="${EVENT_RELEASE_ID}"
+          if [ -z "$RID" ]; then
+            RID=$(gh api "repos/${REPO}/releases/latest" --jq '.id')
+          fi
+          echo "id=$RID" >> "$GITHUB_OUTPUT"
 
       - uses: cssnr/virustotal-action@5edfa4c982eb0caec6d568ea27cf715269f5c23b # v2
         with:
           vt_api_key: ${{ secrets.VT_API_KEY }}
-          release_id: ${{ steps.release.outputs.id || '' }}
+          release_id: ${{ steps.release.outputs.id }}


### PR DESCRIPTION
The `virustotal.yml` workflow triggered on `release: published`, which fires the instant a release is created. In the `release-build.yml` flow (create an empty release, then attach tarballs in the build job) VirusTotal ran before any assets existed and failed with `No Assets Found` on every date-based release. The nightly flow avoided this only because nightly-build.yml creates the release together with its assets in a single step.

Fix: convert `virustotal.yml` to a reusable `workflow_call` (keeping `workflow_dispatch` for manual re-scans) and invoke it as a downstream job of `release-build.yml` (`needs: [build, checksums]`) and `nightly-build.yml` (`needs: release`), so it always runs after the tarballs are attached. The release id is resolved from the caller release event, falling back to the latest release on manual dispatch.

## Release notes
- audience: internal
- summary: none (CI-only; fixes VirusTotal scanning failing on every release because it ran before build assets were attached)
- feature: none
- breaking: none
- config: none
- schema: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VirusTotal scans now run automatically after release assets are ready, and scan results are appended to release notes.
  * Manual VirusTotal rescans can still be started when needed.
* **Bug Fixes**
  * Improved release targeting so scans consistently use the correct published release, avoiding failures or mismatches caused by earlier triggers or missing assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->