### PR TITLE
fix(system): normalize process CPU usage so it never exceeds 100%

### DIFF
--- a/frontend/src/lib/desktop/features/system/components/SystemProcessTable.svelte
+++ b/frontend/src/lib/desktop/features/system/components/SystemProcessTable.svelte
@@ -162,6 +162,9 @@
       </thead>
       <tbody>
         {#each sortedProcesses as proc (proc.pid)}
+          {@const cpuPct = Number.isFinite(proc.cpu) ? Math.min(proc.cpu, 100) : 0}
+          <!-- cpuPct clamps to 100% (matching the backend normalization) and guards
+               non-finite values so a missing/NaN cpu renders 0.0% instead of NaN%. -->
           <tr
             class="border-b last:border-b-0 border-[var(--border-100)]/50 hover:bg-black/[0.02] dark:hover:bg-white/[0.02] transition-colors"
           >
@@ -193,12 +196,10 @@
                 <div class="w-12 h-1.5 rounded-full overflow-hidden bg-[var(--surface-300)]">
                   <div
                     class="h-full rounded-full bg-primary transition-[width] duration-600 ease-out"
-                    style:width="{Math.min(proc.cpu, 100)}%"
+                    style:width="{cpuPct}%"
                   ></div>
                 </div>
-                <span class="font-mono tabular-nums text-xs"
-                  >{Math.min(proc.cpu, 100).toFixed(1)}%</span
-                >
+                <span class="font-mono tabular-nums text-xs">{cpuPct.toFixed(1)}%</span>
               </div>
             </td>
             <td class="py-2 px-3">

--- a/frontend/src/lib/desktop/features/system/components/SystemProcessTable.svelte
+++ b/frontend/src/lib/desktop/features/system/components/SystemProcessTable.svelte
@@ -162,9 +162,10 @@
       </thead>
       <tbody>
         {#each sortedProcesses as proc (proc.pid)}
-          {@const cpuPct = Number.isFinite(proc.cpu) ? Math.min(proc.cpu, 100) : 0}
-          <!-- cpuPct clamps to 100% (matching the backend normalization) and guards
-               non-finite values so a missing/NaN cpu renders 0.0% instead of NaN%. -->
+          {@const cpuPct = Number.isFinite(proc.cpu) ? Math.max(0, Math.min(proc.cpu, 100)) : 0}
+          <!-- cpuPct clamps finite values to 0-100% (matching the backend
+               normalization) and guards non-finite values so a missing/NaN cpu
+               renders 0.0% instead of NaN%. -->
           <tr
             class="border-b last:border-b-0 border-[var(--border-100)]/50 hover:bg-black/[0.02] dark:hover:bg-white/[0.02] transition-colors"
           >

--- a/frontend/src/lib/desktop/features/system/components/SystemProcessTable.svelte
+++ b/frontend/src/lib/desktop/features/system/components/SystemProcessTable.svelte
@@ -196,7 +196,9 @@
                     style:width="{Math.min(proc.cpu, 100)}%"
                   ></div>
                 </div>
-                <span class="font-mono tabular-nums text-xs">{proc.cpu.toFixed(1)}%</span>
+                <span class="font-mono tabular-nums text-xs"
+                  >{Math.min(proc.cpu, 100).toFixed(1)}%</span
+                >
               </div>
             </td>
             <td class="py-2 px-3">

--- a/internal/api/v2/system/handler.go
+++ b/internal/api/v2/system/handler.go
@@ -15,9 +15,11 @@
 package system
 
 import (
+	"sync"
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shirou/gopsutil/v3/process"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/health"
@@ -51,6 +53,15 @@ type Handler struct {
 	healthErrors       *health.ErrorRingBuffer
 	healthMetricsStore *observability.HealthMetricsStore
 	healthEvents       *observability.HealthEventBuffer
+
+	// selfProc caches the *process.Process for the current PID, created lazily on
+	// first use. Reusing one instance lets Percent(0) report CPU consumed since
+	// the previous sample (interval usage) instead of the lifetime average a
+	// freshly created instance's CPUPercent() returns. selfProcMu guards it
+	// because Percent(0) mutates the instance's stored sample and resource
+	// requests may run concurrently.
+	selfProc   *process.Process
+	selfProcMu sync.Mutex
 }
 
 // New constructs the system handler from the shared core, the facade controller

--- a/internal/api/v2/system/handler.go
+++ b/internal/api/v2/system/handler.go
@@ -62,6 +62,29 @@ type Handler struct {
 	// requests may run concurrently.
 	selfProc   *process.Process
 	selfProcMu sync.Mutex
+
+	// procSamples caches one *process.Process per PID for the process table, for the
+	// same reason selfProc exists: process.Processes() hands back a freshly built
+	// instance on every request, and a fresh instance's CPUPercent() is the lifetime
+	// average since the process started, not what it is using now. Holding an instance
+	// across requests is what lets Percent(0) report interval usage, so the table can
+	// agree with the system CPU gauge instead of reporting a long-run average beside a
+	// live reading.
+	//
+	// Entries are validated against the process create time because the OS reuses PIDs:
+	// a recycled PID would otherwise be diffed against the dead process's CPU history.
+	// pruneProcSamples drops dead PIDs so the map stays bounded by the live process
+	// count. procSamplesMu guards both because Percent(0) mutates the instance's stored
+	// sample and requests may run concurrently.
+	procSamples   map[int32]*procSample
+	procSamplesMu sync.Mutex
+}
+
+// procSample is a retained per-PID CPU sampler plus the create time that identifies
+// which process the sampler's history belongs to.
+type procSample struct {
+	proc       *process.Process
+	createTime int64
 }
 
 // New constructs the system handler from the shared core, the facade controller

--- a/internal/api/v2/system/system.go
+++ b/internal/api/v2/system/system.go
@@ -491,6 +491,9 @@ func (c *Handler) GetResourceInfo(ctx echo.Context) error {
 		// Will use 0 as default value
 		procCPU = 0
 	}
+	// Normalize to a share of total system capacity (0-100%) so it matches the
+	// system CPU gauge and cannot exceed 100% on multi-core hosts.
+	procCPU = normalizeProcessCPU(procCPU)
 
 	// Convert process memory to MB for readability
 	var procMemMB float64
@@ -531,6 +534,26 @@ func (c *Handler) GetResourceInfo(ctx echo.Context) error {
 	)
 
 	return ctx.JSON(http.StatusOK, resourceInfo)
+}
+
+// normalizeProcessCPU converts a gopsutil per-process CPU percentage (reported
+// relative to a single core, so potentially >100% for a multi-threaded process)
+// into the process's share of total system capacity in the range
+// [0, maxPercentage]. Dividing by the logical core count matches the semantics of
+// the system CPU gauge; the clamp is a defensive guard against transient sampling
+// overshoot so the value never exceeds 100%.
+func normalizeProcessCPU(cpuPercent float64) float64 {
+	if numCPU := runtime.NumCPU(); numCPU > 0 {
+		cpuPercent /= float64(numCPU)
+	}
+	switch {
+	case cpuPercent > maxPercentage:
+		return maxPercentage
+	case cpuPercent < 0:
+		return 0
+	default:
+		return cpuPercent
+	}
 }
 
 // GetDiskInfo handles GET /api/v2/system/disks
@@ -716,6 +739,12 @@ func (c *Handler) getSingleProcessInfo(p *process.Process) (ProcessInfo, error) 
 		c.LogWarnIfEnabled("Failed to get process CPU percent", logger.Any("pid", p.Pid), logger.String("name", name), logger.Error(err))
 		cpuPercent = 0.0
 	}
+	// gopsutil reports per-process CPU relative to a single core, so a process
+	// spread across multiple cores can exceed 100% (e.g. 200% for two full cores).
+	// Normalize by the logical core count so the value is the process's share of
+	// total system capacity (0-100%), consistent with the system CPU gauge and
+	// never exceeding 100%.
+	cpuPercent = normalizeProcessCPU(cpuPercent)
 
 	memInfo, err := p.MemoryInfo()
 	var memRSS uint64

--- a/internal/api/v2/system/system.go
+++ b/internal/api/v2/system/system.go
@@ -566,6 +566,53 @@ func normalizeProcessCPU(cpuPercent float64) float64 {
 	}
 }
 
+// processCPUPercent returns p's CPU usage since the previous request, in gopsutil's
+// per-single-core units (so still normalizeProcessCPU's input).
+//
+// It samples through a retained per-PID instance (see the procSamples field) rather
+// than the caller's freshly listed p, because Percent(0) measures against the sample
+// the instance itself stored last time. createTimeMillis identifies the process
+// behind the PID; a mismatch means the PID was recycled and the retained history
+// belongs to a dead process, so the entry is replaced.
+//
+// The first sample for a PID has nothing to diff against and returns 0. That costs
+// one poll per process per server run — the cache lives as long as the handler — not
+// one per page load.
+func (c *Handler) processCPUPercent(p *process.Process, createTimeMillis int64) (float64, error) {
+	c.procSamplesMu.Lock()
+	defer c.procSamplesMu.Unlock()
+
+	if c.procSamples == nil {
+		c.procSamples = make(map[int32]*procSample)
+	}
+
+	if sample, ok := c.procSamples[p.Pid]; ok && sample.createTime == createTimeMillis {
+		return sample.proc.Percent(0)
+	}
+
+	c.procSamples[p.Pid] = &procSample{proc: p, createTime: createTimeMillis}
+	return p.Percent(0)
+}
+
+// pruneProcSamples drops retained samplers whose PID is no longer running, keeping
+// procSamples bounded by the live process count on a long-lived host. live is the
+// full process list, not the filtered table, so a process the table hides is not
+// evicted and re-primed on every request.
+func (c *Handler) pruneProcSamples(live []*process.Process) {
+	liveSet := make(map[int32]struct{}, len(live))
+	for _, p := range live {
+		liveSet[p.Pid] = struct{}{}
+	}
+
+	c.procSamplesMu.Lock()
+	defer c.procSamplesMu.Unlock()
+	for pid := range c.procSamples {
+		if _, ok := liveSet[pid]; !ok {
+			delete(c.procSamples, pid)
+		}
+	}
+}
+
 // selfProcessLocked returns the cached *process.Process for the current PID,
 // creating it on first use. Reusing a single instance is what lets Percent(0)
 // report interval CPU usage (see the selfProc field). Callers must hold
@@ -758,7 +805,29 @@ func (c *Handler) getSingleProcessInfo(p *process.Process) (ProcessInfo, error) 
 		status = valueUnknown
 	}
 
-	cpuPercent, err := p.CPUPercent()
+	// Read the create time before CPU: it doubles as the identity check that keeps a
+	// retained CPU sampler from being diffed against a recycled PID's history.
+	createTimeMillis, createErr := p.CreateTime()
+	var uptimeSeconds int64
+	if createErr != nil {
+		// Log error but default to 0
+		c.LogWarnIfEnabled("Failed to get process create time", logger.Any("pid", p.Pid), logger.String("name", name), logger.Error(createErr))
+		uptimeSeconds = 0
+	} else {
+		// Calculate uptime relative to now
+		uptimeSeconds = max(time.Now().Unix()-(createTimeMillis/millisecondsPerSecond),
+			// Sanity check for clock skew
+			0)
+	}
+
+	var cpuPercent float64
+	if createErr != nil {
+		// Without a create time a recycled PID is indistinguishable from the original, so
+		// the retained sampler cannot be trusted; fall back to the lifetime average.
+		cpuPercent, err = p.CPUPercent()
+	} else {
+		cpuPercent, err = c.processCPUPercent(p, createTimeMillis)
+	}
 	if err != nil {
 		// Log error but default to 0
 		c.LogWarnIfEnabled("Failed to get process CPU percent", logger.Any("pid", p.Pid), logger.String("name", name), logger.Error(err))
@@ -779,19 +848,6 @@ func (c *Handler) getSingleProcessInfo(p *process.Process) (ProcessInfo, error) 
 		memRSS = 0
 	} else {
 		memRSS = memInfo.RSS // Resident Set Size
-	}
-
-	createTimeMillis, err := p.CreateTime()
-	var uptimeSeconds int64
-	if err != nil {
-		// Log error but default to 0
-		c.LogWarnIfEnabled("Failed to get process create time", logger.Any("pid", p.Pid), logger.String("name", name), logger.Error(err))
-		uptimeSeconds = 0
-	} else {
-		// Calculate uptime relative to now
-		uptimeSeconds = max(time.Now().Unix()-(createTimeMillis/millisecondsPerSecond),
-			// Sanity check for clock skew
-			0)
 	}
 
 	return ProcessInfo{
@@ -841,6 +897,8 @@ func (c *Handler) GetProcessInfo(ctx echo.Context) error {
 		c.LogErrorIfEnabled("Failed to list processes", logger.Error(err), logger.String("path", path), logger.String("ip", ip))
 		return c.HandleError(ctx, err, "Failed to list processes", http.StatusInternalServerError)
 	}
+
+	c.pruneProcSamples(procs)
 
 	processInfos := c.collectProcessInfos(procs, showAll)
 

--- a/internal/api/v2/system/system.go
+++ b/internal/api/v2/system/system.go
@@ -458,9 +458,16 @@ func (c *Handler) GetResourceInfo(ctx echo.Context) error {
 	// Get CPU usage from cache instead of blocking
 	cpuPercent := apicore.GetCachedCPUUsage()
 
-	// Get process information (current process)
-	proc, err := process.NewProcess(int32(os.Getpid())) // #nosec G115 -- PID conversion safe, PIDs are within int32 range
+	// Get process information for the current process. Reuse the cached
+	// *process.Process (see the selfProc field) and sample CPU via Percent(0) so
+	// the value reflects usage since the previous request — interval usage —
+	// rather than the lifetime average a freshly created instance's CPUPercent()
+	// returns and which grows steadily more dampened as the process ages. The
+	// instance access is serialized because Percent(0) mutates its stored sample.
+	c.selfProcMu.Lock()
+	proc, err := c.selfProcessLocked()
 	if err != nil {
+		c.selfProcMu.Unlock()
 		c.LogErrorIfEnabled("Failed to get process information",
 			logger.Error(err),
 			logger.String("path", ctx.Request().URL.Path),
@@ -468,23 +475,26 @@ func (c *Handler) GetResourceInfo(ctx echo.Context) error {
 		)
 		return c.HandleError(ctx, err, "Failed to get process information", http.StatusInternalServerError)
 	}
+	procMem, memErr := proc.MemoryInfo()
+	// Percent(0) returns the CPU used since the previous call; the first call
+	// after startup primes the sample and returns 0.
+	procCPU, cpuErr := proc.Percent(0)
+	c.selfProcMu.Unlock()
 
-	procMem, err := proc.MemoryInfo()
-	if err != nil {
-		c.Debug("Failed to get process memory info: %v", err)
+	if memErr != nil {
+		c.Debug("Failed to get process memory info: %v", memErr)
 		c.LogWarnIfEnabled("Failed to get process memory info",
-			logger.Error(err),
+			logger.Error(memErr),
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
 		)
 		// Continue with nil procMem, handled below
 	}
 
-	procCPU, err := proc.CPUPercent()
-	if err != nil {
-		c.Debug("Failed to get process CPU info: %v", err)
+	if cpuErr != nil {
+		c.Debug("Failed to get process CPU info: %v", cpuErr)
 		c.LogWarnIfEnabled("Failed to get process CPU info",
-			logger.Error(err),
+			logger.Error(cpuErr),
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
 		)
@@ -554,6 +564,21 @@ func normalizeProcessCPU(cpuPercent float64) float64 {
 	default:
 		return cpuPercent
 	}
+}
+
+// selfProcessLocked returns the cached *process.Process for the current PID,
+// creating it on first use. Reusing a single instance is what lets Percent(0)
+// report interval CPU usage (see the selfProc field). Callers must hold
+// c.selfProcMu.
+func (c *Handler) selfProcessLocked() (*process.Process, error) {
+	if c.selfProc == nil {
+		p, err := process.NewProcess(int32(os.Getpid())) // #nosec G115 -- PID conversion safe, PIDs are within int32 range
+		if err != nil {
+			return nil, err
+		}
+		c.selfProc = p
+	}
+	return c.selfProc, nil
 }
 
 // GetDiskInfo handles GET /api/v2/system/disks

--- a/internal/api/v2/system/system_test.go
+++ b/internal/api/v2/system/system_test.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"runtime"
 	"testing"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shirou/gopsutil/v3/process"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/analysis/jobqueue"
@@ -919,4 +921,116 @@ func TestGetRestartStatusWithPendingRestart(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &result))
 	assert.True(t, result.RestartRequired)
 	assert.Equal(t, []string{"Port changed"}, result.RestartReasons)
+}
+
+// selfProcessForTest returns a real *process.Process for the running test binary.
+// The CPU sampler needs a live PID whose create time the OS will actually report.
+func selfProcessForTest(t *testing.T) (proc *process.Process, createTime int64) {
+	t.Helper()
+	proc, err := process.NewProcess(int32(os.Getpid()))
+	require.NoError(t, err)
+	createTime, err = proc.CreateTime()
+	require.NoError(t, err)
+	return proc, createTime
+}
+
+// The process table lists processes afresh on every request, and a freshly listed
+// instance's CPUPercent() is the lifetime average since the process started. Interval
+// usage requires diffing against a sample the *same* instance stored earlier, so the
+// handler must retain its own instance and ignore the caller's.
+func TestProcessCPUPercent_RetainsSamplerAcrossRequests(t *testing.T) {
+	t.Attr("component", "system")
+	t.Attr("type", "unit")
+	t.Attr("feature", "process-info")
+
+	c := &Handler{}
+	first, createTime := selfProcessForTest(t)
+
+	// First sight of the PID has nothing to diff against, so it primes and reports 0.
+	got, err := c.processCPUPercent(first, createTime)
+	require.NoError(t, err)
+	assert.InDelta(t, 0.0, got, 0.001, "first sample should prime rather than report a value")
+	require.Contains(t, c.procSamples, first.Pid)
+	assert.Same(t, first, c.procSamples[first.Pid].proc)
+
+	// A later request hands over a different instance for the same process; the retained
+	// sampler must survive, or every request would re-prime and report 0 forever.
+	second, _ := selfProcessForTest(t)
+	require.NotSame(t, first, second, "each listing builds a new instance")
+
+	_, err = c.processCPUPercent(second, createTime)
+	require.NoError(t, err)
+	assert.Same(t, first, c.procSamples[first.Pid].proc, "retained sampler must not be replaced")
+}
+
+// PIDs are recycled. A retained sampler's history belongs to the dead process, so
+// diffing a new process against it would report nonsense; the create time is what
+// distinguishes them.
+func TestProcessCPUPercent_ReplacesRecycledPID(t *testing.T) {
+	t.Attr("component", "system")
+	t.Attr("type", "unit")
+	t.Attr("feature", "process-info")
+
+	c := &Handler{}
+	p, createTime := selfProcessForTest(t)
+
+	stale := &process.Process{Pid: p.Pid}
+	c.procSamples = map[int32]*procSample{
+		p.Pid: {proc: stale, createTime: createTime - 1000},
+	}
+
+	got, err := c.processCPUPercent(p, createTime)
+	require.NoError(t, err)
+
+	assert.NotSame(t, stale, c.procSamples[p.Pid].proc, "stale sampler must be discarded")
+	assert.Same(t, p, c.procSamples[p.Pid].proc)
+	assert.Equal(t, createTime, c.procSamples[p.Pid].createTime)
+	assert.InDelta(t, 0.0, got, 0.001, "a replaced entry re-primes")
+}
+
+// Without pruning the map would retain an entry for every process that ever ran.
+func TestPruneProcSamples_DropsDeadPIDs(t *testing.T) {
+	t.Attr("component", "system")
+	t.Attr("type", "unit")
+	t.Attr("feature", "process-info")
+
+	live, createTime := selfProcessForTest(t)
+	const deadPID int32 = 999999
+
+	c := &Handler{
+		procSamples: map[int32]*procSample{
+			live.Pid: {proc: live, createTime: createTime},
+			deadPID:  {proc: &process.Process{Pid: deadPID}, createTime: 1},
+		},
+	}
+
+	c.pruneProcSamples([]*process.Process{live})
+
+	assert.Contains(t, c.procSamples, live.Pid, "a running process keeps its sampler")
+	assert.NotContains(t, c.procSamples, deadPID, "a dead PID must not be retained")
+}
+
+// A process hidden by the table's relevance filter is still running, so pruning against
+// the full listing must not evict it — otherwise it would re-prime and report 0 on
+// every request that later shows it.
+func TestPruneProcSamples_KeepsFilteredButLiveProcesses(t *testing.T) {
+	t.Attr("component", "system")
+	t.Attr("type", "unit")
+	t.Attr("feature", "process-info")
+
+	live, createTime := selfProcessForTest(t)
+	other := &process.Process{Pid: live.Pid + 1}
+
+	c := &Handler{
+		procSamples: map[int32]*procSample{
+			live.Pid:  {proc: live, createTime: createTime},
+			other.Pid: {proc: other, createTime: 1},
+		},
+	}
+
+	// Both are in the full listing, even though the table may only render one.
+	c.pruneProcSamples([]*process.Process{live, other})
+
+	assert.Contains(t, c.procSamples, live.Pid)
+	assert.Contains(t, c.procSamples, other.Pid)
 }

--- a/internal/api/v2/system/system_test.go
+++ b/internal/api/v2/system/system_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"testing"
 
 	"github.com/labstack/echo/v4"
@@ -399,6 +400,39 @@ func TestGetResourceInfo(t *testing.T) {
 
 	// Process memory should be positive
 	assert.GreaterOrEqual(t, response.ProcessMem, float64(0), "ProcessMem should be >= 0")
+}
+
+// TestNormalizeProcessCPU verifies per-process CPU is normalized to a share of
+// total system capacity and clamped to [0, 100].
+func TestNormalizeProcessCPU(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "system")
+	t.Attr("type", "unit")
+	t.Attr("feature", "process-info")
+
+	numCPU := float64(runtime.NumCPU())
+
+	tests := []struct {
+		name string
+		in   float64
+		want float64
+	}{
+		{name: "zero stays zero", in: 0, want: 0},
+		{name: "negative clamps to zero", in: -10, want: 0},
+		{name: "single core share", in: numCPU * 25, want: 25},
+		{name: "full machine", in: numCPU * 100, want: 100},
+		{name: "over-full clamps to 100", in: numCPU * 250, want: 100},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := normalizeProcessCPU(tt.in)
+			assert.InDelta(t, tt.want, got, 0.001)
+			assert.GreaterOrEqual(t, got, float64(0), "result must be >= 0")
+			assert.LessOrEqual(t, got, float64(maxPercentage), "result must be <= 100")
+		})
+	}
 }
 
 // TestGetDiskInfo tests the GetDiskInfo endpoint


### PR DESCRIPTION
## Problem

On the System page, the **Process Information** table could display CPU usage **greater than 100%** (e.g. `187.3%`).

The value came straight from gopsutil's `Process.CPUPercent()`, which reports per-process CPU **relative to a single core**. A multi-threaded process — BirdNET-Go spreads inference across cores — legitimately reads above 100% under that convention. The progress bar next to the number was already capped at `Math.min(cpu, 100)`, so the bar sat "full" while the label read e.g. 187%, an inconsistent and confusing display for home users.

(The top **CPU** metric card is unaffected — it uses gopsutil's *aggregate* `cpu.Percent(…, false)`, which is hard-clamped to `[0, 100]`.)

## Fix

**Normalize per-process CPU by the logical core count**, so the value becomes the process's share of total system capacity (0–100%) — the same "% of the machine" semantics as the system CPU gauge. This matches `htop`'s normalized/Solaris mode. A defensive clamp guarantees the value never exceeds 100% even under transient sampling overshoot.

Applied in both `GetProcessInfo` (`/api/v2/system/processes`) and `GetResourceInfo` (`/api/v2/system/resources`), plus a matching clamp on the process-table CPU label in the frontend.

Note: on multi-core hosts the number now reads lower than a raw `top`-style per-core figure (a process using one full core on an 8-core box shows ~12%, not ~100%), which is the intended trade-off for a bounded, machine-relative metric.

## Changes

- `internal/api/v2/system/system.go` — add `normalizeProcessCPU`; apply it to the process-table and resource-endpoint CPU values.
- `internal/api/v2/system/system_test.go` — `TestNormalizeProcessCPU` (core-count normalization + `[0,100]` clamping).
- `frontend/src/lib/desktop/features/system/components/SystemProcessTable.svelte` — clamp the displayed CPU label to 100%, matching the existing progress bar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved per-process CPU reporting on multi-core systems by normalizing values to total system capacity and capping at 100%.
  * Updated the process CPU progress bar and numeric label to use the same normalized value (one decimal place), with safer clamping/validation to avoid invalid readings.
  * Reduced CPU reporting inconsistencies when process IDs are reused.
* **Tests**
  * Added unit tests covering CPU normalization/clamping and sampler lifecycle behavior (reuse, replacement on PID recycling, and pruning).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Release notes
- audience: user
- summary: Per-process CPU in the system dashboard is now a share of total system capacity, so it no longer reads above 100% on multi-core machines and matches the overall CPU gauge.
- feature: none
- breaking: none
- config: none
- schema: none
