### PR TITLE
refactor(audio): unify native FLAC loudness-gain planning via shared helper

### DIFF
--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -623,8 +623,16 @@ func (a *SaveAudioAction) planNativeNormalizationGain(ctx context.Context, sampl
 	if err := ctx.Err(); err != nil {
 		return 0, err
 	}
-	// audionorm decodes the PCM bytes inline; a.pcmData is not mutated.
-	meas, err := audionorm.MeasureInt16Bytes(a.pcmData, sampleRate, conf.NumChannels)
+	// audionorm decodes the PCM bytes inline; a.pcmData is not mutated. Silence
+	// yields GainDB == 0 (audionorm returns -Inf LUFS); the clamp is the secondary
+	// guard for low-peak clips and for attenuation, applied silently on this path
+	// (the BirdWeather path logs its own limiting, hence the discarded flag).
+	gainDB, meas, res, _, err := audionorm.PlanClampedGainInt16Bytes(a.pcmData, audionorm.Options{
+		SampleRate:   sampleRate,
+		Channels:     conf.NumChannels,
+		TargetLUFS:   targetLUFS,
+		TruePeakDBTP: truePeakDBTP,
+	}, audionorm.DefaultMaxGainDB)
 	if err != nil {
 		return 0, errors.New(err).
 			Component("analysis.processor").
@@ -633,18 +641,6 @@ func (a *SaveAudioAction) planNativeNormalizationGain(ctx context.Context, sampl
 			Context("detection_id", a.CorrelationID).
 			Build()
 	}
-
-	res := audionorm.PlanGain(meas, audionorm.Options{
-		SampleRate:   sampleRate,
-		Channels:     conf.NumChannels,
-		TargetLUFS:   targetLUFS,
-		TruePeakDBTP: truePeakDBTP,
-	})
-
-	// Silence yields GainDB == 0 (audionorm returns -Inf LUFS); the clamp is the
-	// secondary guard for low-peak clips and for attenuation. Applied silently on
-	// this path (the BirdWeather path logs its own limiting).
-	gainDB, _ := audionorm.ClampGainDB(res.GainDB, audionorm.DefaultMaxGainDB)
 
 	GetLogger().Debug("Native FLAC loudness analysis (detection save)",
 		logger.Float64("measured_lufs", meas.IntegratedLUFS),

--- a/internal/audiocore/audionorm/audionorm.go
+++ b/internal/audiocore/audionorm/audionorm.go
@@ -228,6 +228,36 @@ func ClampGainDB(gainDB, maxAbsDB float64) (clamped float64, limited bool) {
 	}
 }
 
+// PlanClampedGainInt16Bytes runs the measure -> plan -> clamp sequence the native
+// FLAC export paths share: it measures the integrated loudness and true peak of
+// interleaved little-endian int16 PCM bytes (via MeasureInt16Bytes, which decodes
+// inline without mutating pcm), plans the single gain that brings the clip to
+// opts.TargetLUFS without its true peak exceeding opts.TruePeakDBTP (via PlanGain),
+// then clamps that gain to [-maxAbsGainDB, +maxAbsGainDB] (via ClampGainDB).
+//
+// It returns the clamped gain to apply, the pass-one measurement, the pre-clamp
+// planning Result (whose GainDB and PeakLimited callers use for logging), and
+// whether the clamp took effect. Silent or sub-400 ms input yields gainDB == 0,
+// leaving quiet clips unchanged rather than boosting the noise floor. On a
+// measurement error every value is its zero and err is the raw MeasureInt16Bytes
+// error, so callers can wrap it with their own component and context.
+//
+// Only the sample rate and channel count are validated (by MeasureInt16Bytes).
+// Like PlanGain, opts.TargetLUFS and opts.TruePeakDBTP are NOT range-checked
+// here, so callers must pass a target in (-70, 0) and a ceiling <= 0; a
+// non-finite or out-of-range target otherwise flows through as a NaN or garbage
+// gain. Both current callers gate their targets before calling (the detection
+// path via audionormSupportsTargets, the BirdWeather path with fixed constants).
+func PlanClampedGainInt16Bytes(pcm []byte, opts Options, maxAbsGainDB float64) (gainDB float64, meas Measurement, res Result, limited bool, err error) {
+	meas, err = MeasureInt16Bytes(pcm, opts.SampleRate, opts.Channels)
+	if err != nil {
+		return 0, Measurement{}, Result{}, false, err
+	}
+	res = PlanGain(meas, opts)
+	gainDB, limited = ClampGainDB(res.GainDB, maxAbsGainDB)
+	return gainDB, meas, res, limited, nil
+}
+
 func validateDims(sampleRate, channels, n int) error {
 	switch {
 	case sampleRate < minSampleRate:

--- a/internal/audiocore/audionorm/int16bytes_test.go
+++ b/internal/audiocore/audionorm/int16bytes_test.go
@@ -161,3 +161,99 @@ func TestClampGainDB(t *testing.T) {
 		})
 	}
 }
+
+// TestPlanClampedGainInt16Bytes proves the shared helper is a faithful
+// measure -> plan -> clamp composition of MeasureInt16Bytes, PlanGain and
+// ClampGainDB, so collapsing the two native-FLAC export call sites onto it does
+// not change the gain they apply, the measurement they log, or the clamp flag one
+// of them logs and the other discards.
+func TestPlanClampedGainInt16Bytes(t *testing.T) {
+	t.Parallel()
+
+	const (
+		sampleRate = 48000
+		channels   = 1
+		maxAbsGain = DefaultMaxGainDB
+	)
+	// A quiet clip (~-35 LUFS) that wants a real boost toward -23, well under the
+	// true-peak ceiling and the 30 dB clamp on both export paths.
+	quietOpts := Options{SampleRate: sampleRate, Channels: channels, TargetLUFS: -23, TruePeakDBTP: -1}
+	quietPCM := int16sToLEBytes(sineInt16(-35, 1000, 1, sampleRate))
+
+	t.Run("matches the primitive sequence", func(t *testing.T) {
+		t.Parallel()
+		wantMeas, err := MeasureInt16Bytes(quietPCM, sampleRate, channels)
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantRes := PlanGain(wantMeas, quietOpts)
+		wantGain, wantLimited := ClampGainDB(wantRes.GainDB, maxAbsGain)
+
+		gotGain, gotMeas, gotRes, gotLimited, err := PlanClampedGainInt16Bytes(quietPCM, quietOpts, maxAbsGain)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if gotMeas != wantMeas {
+			t.Errorf("meas = %+v, want %+v", gotMeas, wantMeas)
+		}
+		if gotRes != wantRes {
+			t.Errorf("res = %+v, want %+v", gotRes, wantRes)
+		}
+		if gotGain != wantGain || gotLimited != wantLimited {
+			t.Errorf("gain/limited = (%v, %v), want (%v, %v)", gotGain, gotLimited, wantGain, wantLimited)
+		}
+		if gotLimited {
+			t.Error("a mid-range boost must not hit the clamp")
+		}
+	})
+
+	t.Run("clamp binds and exposes the pre-clamp gain", func(t *testing.T) {
+		t.Parallel()
+		// The same clip wants far more than 1 dB toward the target, so a 1 dB
+		// ceiling makes the clamp (not the true-peak limiter) the binding limit.
+		gotGain, _, res, limited, err := PlanClampedGainInt16Bytes(quietPCM, quietOpts, 1.0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !limited {
+			t.Fatal("clamp must bind for a boost above the 1 dB ceiling")
+		}
+		if math.Abs(gotGain-1.0) > 1e-9 {
+			t.Errorf("clamped gain = %v, want 1.0", gotGain)
+		}
+		if res.GainDB <= 1.0 {
+			t.Errorf("pre-clamp GainDB = %v, want > 1.0 so callers can log the real limiting", res.GainDB)
+		}
+		if res.PeakLimited {
+			t.Error("the true-peak ceiling must not bind here; the 1 dB clamp must be the sole limit")
+		}
+	})
+
+	t.Run("silence yields zero gain", func(t *testing.T) {
+		t.Parallel()
+		pcm := make([]byte, sampleRate*2) // 1 s of digital silence
+		gotGain, meas, _, limited, err := PlanClampedGainInt16Bytes(pcm, quietOpts, maxAbsGain)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if gotGain != 0 || limited {
+			t.Errorf("silence: gain/limited = (%v, %v), want (0, false)", gotGain, limited)
+		}
+		if !math.IsInf(meas.IntegratedLUFS, -1) {
+			t.Errorf("silence: IntegratedLUFS = %v, want -Inf", meas.IntegratedLUFS)
+		}
+	})
+
+	t.Run("measurement error returns zero values", func(t *testing.T) {
+		t.Parallel()
+		// A sub-minimum sample rate makes MeasureInt16Bytes reject the dimensions.
+		badOpts := Options{SampleRate: 4000, Channels: channels, TargetLUFS: -23, TruePeakDBTP: -1}
+		gotGain, meas, res, limited, err := PlanClampedGainInt16Bytes(quietPCM, badOpts, maxAbsGain)
+		if err == nil {
+			t.Fatal("want an error for a sub-minimum sample rate")
+		}
+		if gotGain != 0 || limited || meas != (Measurement{}) || res != (Result{}) {
+			t.Errorf("on error want zero values, got gain=%v limited=%v meas=%+v res=%+v", gotGain, limited, meas, res)
+		}
+	})
+}

--- a/internal/birdweather/encode_native.go
+++ b/internal/birdweather/encode_native.go
@@ -33,9 +33,19 @@ func (b *BwClient) encodeWithNativeFLAC(pcmData []byte, timestamp string) (*audi
 	ctx, cancel := context.WithTimeout(context.Background(), encodingTimeout)
 	defer cancel()
 
-	// Pass 1: measure loudness + true peak directly from the PCM bytes; the
-	// original bytes are never mutated.
-	meas, err := audionorm.MeasureInt16Bytes(pcmData, conf.SampleRate, conf.NumChannels)
+	opts := audionorm.DefaultOptions()
+	opts.SampleRate = conf.SampleRate
+	opts.Channels = conf.NumChannels
+	// Target the same loudness as the FFmpeg path. The default -1.0 dBTP ceiling
+	// is kept, adding inter-sample-peak protection the volume filter lacked.
+	opts.TargetLUFS = targetIntegratedLoudnessLUFS
+
+	// Pass 1: measure loudness + true peak directly from the PCM bytes (never
+	// mutated), plan the gain toward opts.TargetLUFS, and clamp to the same
+	// +/-audionorm.DefaultMaxGainDB bound the FFmpeg path used. Silence yields
+	// GainDB == 0 (audionorm returns -Inf LUFS), so quiet clips stay quiet instead
+	// of being boosted into noise.
+	gainDB, meas, res, limited, err := audionorm.PlanClampedGainInt16Bytes(pcmData, opts, audionorm.DefaultMaxGainDB)
 	if err != nil {
 		return nil, errors.New(err).
 			Component("birdweather").
@@ -45,19 +55,6 @@ func (b *BwClient) encodeWithNativeFLAC(pcmData []byte, timestamp string) (*audi
 			Build()
 	}
 
-	opts := audionorm.DefaultOptions()
-	opts.SampleRate = conf.SampleRate
-	opts.Channels = conf.NumChannels
-	// Target the same loudness as the FFmpeg path. The default -1.0 dBTP ceiling
-	// is kept, adding inter-sample-peak protection the volume filter lacked.
-	opts.TargetLUFS = targetIntegratedLoudnessLUFS
-
-	res := audionorm.PlanGain(meas, opts)
-
-	// Clamp to the same +/-audionorm.DefaultMaxGainDB bound the FFmpeg path used.
-	// Silence yields GainDB == 0 (audionorm returns -Inf LUFS), so quiet clips stay quiet
-	// instead of being boosted into noise.
-	gainDB, limited := audionorm.ClampGainDB(res.GainDB, audionorm.DefaultMaxGainDB)
 	if limited {
 		if res.GainDB > 0 {
 			b.logGainLimit(log, "Limiting gain to prevent excessive amplification",


### PR DESCRIPTION
## Summary
The detection-save (`SaveAudioAction.planNativeNormalizationGain`) and BirdWeather (`BwClient.encodeWithNativeFLAC`) native FLAC encode paths both ran the same loudness sequence inline: `MeasureInt16Bytes` -> `PlanGain` -> `ClampGainDB`, plus a near-identical "Native FLAC loudness analysis" debug log. They diverged only cosmetically: how they build `Options`, how they wrap the measurement error, and that BirdWeather logs limiting while the detection path clamps silently.

This adds `audionorm.PlanClampedGainInt16Bytes`, a shared helper that collapses that measure -> plan -> clamp core into one call, and reroutes both sites through it. Each call site keeps its own error wrapping and debug logging, so the per-site behavior is unchanged: the detection path still discards the clamp flag, BirdWeather still logs limiting via `logGainLimit`. The helper returns the clamped gain, the pass-one measurement, the pre-clamp planning result, and the clamp flag, so both call sites read exactly the values they logged before.

This is a pure refactor with no behavior change: no config keys, API contracts, DB schema, or CLI flags are touched.

## Test Plan
- [x] New `TestPlanClampedGainInt16Bytes` asserts the helper is a faithful composition of the three primitives, plus clamp-binds, silence, and measurement-error coverage
- [x] `go test -race` green for `audionorm`, `analysis/processor`, and `birdweather`
- [x] `golangci-lint run` clean (0 issues)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Audio Export**
  - Improved native FLAC loudness normalization with more consistent gain planning.
  - Maintains target loudness while respecting true-peak and maximum gain limits.
  - Provides more reliable handling of silence, constrained gain, and invalid audio measurements.
  - Preserves normalization diagnostics, including loudness measurements and peak-limiting details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->