### PR TITLE
fix(audio): fall back to full RTSP stream when audio-only handshake fails

### DIFF
--- a/internal/audiocore/ffmpeg/analyze.go
+++ b/internal/audiocore/ffmpeg/analyze.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"os/exec"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/errors"
@@ -55,10 +54,43 @@ func AnalyzeChannelEnergy(ctx context.Context, url, ffmpegPath string) (*Channel
 	// time budget for the actual analysis run.
 	ffmpegMajor := resolveFfmpegMajor(ffmpegBinary)
 
+	pcmData, err := runChannelAnalysis(ctx, ffmpegBinary, url, ffmpegMajor, true)
+	// Some cameras cannot SETUP the RTSP audio track alone, so the audio-only
+	// restriction breaks capture (issue #3902). Retry once requesting the full
+	// stream, from which -vn still extracts audio only. Skip the retry when the
+	// parent context is done (shutdown/caller cancel); a per-attempt analysis
+	// timeout leaves ctx live, so a hung audio-only handshake still falls back.
+	if err != nil && ctx.Err() == nil && isRTSPURL(url) {
+		pcmData, err = runChannelAnalysis(ctx, ffmpegBinary, url, ffmpegMajor, false)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	left, right := deinterleave(pcmData)
+
+	leftDbfs := computeRmsDbfs(left)
+	rightDbfs := computeRmsDbfs(right)
+
+	return &ChannelAnalysis{
+		Channels: analysisChannels,
+		Energy: []ChannelEnergy{
+			{Channel: 0, Label: "Left", RmsDbfs: math.Round(leftDbfs*10) / 10},
+			{Channel: 1, Label: "Right", RmsDbfs: math.Round(rightDbfs*10) / 10},
+		},
+		Recommended: recommendChannel(leftDbfs, rightDbfs),
+	}, nil
+}
+
+// runChannelAnalysis executes a single FFmpeg capture attempt and returns the
+// raw interleaved PCM. audioOnly controls whether the RTSP handshake is
+// restricted to audio tracks via -allowed_media_types audio; the fallback path
+// passes false for cameras that cannot SETUP audio alone (issue #3902).
+func runChannelAnalysis(ctx context.Context, ffmpegBinary, url string, ffmpegMajor int, audioOnly bool) ([]byte, error) {
 	analysisCtx, cancel := context.WithTimeout(ctx, analysisTimeout)
 	defer cancel()
 
-	args := buildAnalysisArgs(url, ffmpegMajor)
+	args := buildAnalysisArgs(url, ffmpegMajor, audioOnly)
 
 	cmd := exec.CommandContext(analysisCtx, ffmpegBinary, args...) //nolint:gosec // G204: ffmpegBinary validated by exec.LookPath, URL from user config
 	var stdout, stderr bytes.Buffer
@@ -88,26 +120,13 @@ func AnalyzeChannelEnergy(ctx context.Context, url, ffmpegPath string) (*Channel
 			Build()
 	}
 
-	left, right := deinterleave(pcmData)
-
-	leftDbfs := computeRmsDbfs(left)
-	rightDbfs := computeRmsDbfs(right)
-
-	return &ChannelAnalysis{
-		Channels: analysisChannels,
-		Energy: []ChannelEnergy{
-			{Channel: 0, Label: "Left", RmsDbfs: math.Round(leftDbfs*10) / 10},
-			{Channel: 1, Label: "Right", RmsDbfs: math.Round(rightDbfs*10) / 10},
-		},
-		Recommended: recommendChannel(leftDbfs, rightDbfs),
-	}, nil
+	return pcmData, nil
 }
 
-func buildAnalysisArgs(url string, ffmpegMajor int) []string {
+func buildAnalysisArgs(url string, ffmpegMajor int, audioOnly bool) []string {
 	args := make([]string, 0, 16)
 
-	lower := strings.ToLower(url)
-	isRTSP := strings.HasPrefix(lower, "rtsp://") || strings.HasPrefix(lower, "rtsps://")
+	isRTSP := isRTSPURL(url)
 	// Default to -timeout; RTSP on FFmpeg 4.x needs -stimeout instead, since 4.x
 	// treats -timeout on the RTSP demuxer as a listen timeout and fails to
 	// connect. Mirror the live capture path's flag selection.
@@ -115,8 +134,8 @@ func buildAnalysisArgs(url string, ffmpegMajor int) []string {
 	if isRTSP {
 		// Restrict the RTSP handshake to audio tracks; -vn below only drops video
 		// after decode, so without this the camera's video track is still SETUP
-		// (issue #3798).
-		args = append(args, "-rtsp_transport", "tcp", ffmpegAllowedMediaTypesFlag, ffmpegAllowedMediaTypesAudio)
+		// (issue #3798). audioOnly is false on the full-stream fallback (#3902).
+		args = appendRTSPMediaArgs(args, "tcp", audioOnly)
 		timeoutFlag = rtspTimeoutParamForMajor(ffmpegMajor)
 	}
 

--- a/internal/audiocore/ffmpeg/analyze_test.go
+++ b/internal/audiocore/ffmpeg/analyze_test.go
@@ -134,7 +134,7 @@ func TestBuildAnalysisArgs_TimeoutFlag(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			args := buildAnalysisArgs(tt.url, tt.ffmpegMajor)
+			args := buildAnalysisArgs(tt.url, tt.ffmpegMajor, true)
 
 			assert.Equal(t, tt.wantTransport, slices.Contains(args, "-rtsp_transport"), "rtsp_transport presence mismatch")
 			assert.Contains(t, args, tt.wantFlag, "expected timeout flag missing")
@@ -151,4 +151,18 @@ func TestBuildAnalysisArgs_TimeoutFlag(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildAnalysisArgs_AudioOnlyFallback(t *testing.T) {
+	t.Parallel()
+
+	// audioOnly=false is the full-stream fallback for cameras that cannot SETUP
+	// the audio track alone (issue #3902): keep the RTSP transport but drop the
+	// -allowed_media_types restriction. -vn still extracts audio only after decode.
+	args := buildAnalysisArgs("rtsp://cam.example.com/live", 7, false)
+
+	assert.Contains(t, args, "-rtsp_transport")
+	assert.Contains(t, args, "tcp")
+	assert.NotContains(t, args, "-allowed_media_types")
+	assert.Contains(t, args, "-vn")
 }

--- a/internal/audiocore/ffmpeg/probe.go
+++ b/internal/audiocore/ffmpeg/probe.go
@@ -64,15 +64,32 @@ type ffprobeStream struct {
 // audio properties. It applies a 10-second timeout and sanitizes the URL
 // in error messages to avoid leaking credentials.
 func ProbeStreamInfo(ctx context.Context, url string) (*StreamInfo, error) {
-	probeCtx, cancel := context.WithTimeout(ctx, probeTimeout)
-	defer cancel()
-
 	ffprobeBinary, err := resolveFFprobeBinary()
 	if err != nil {
 		return nil, err
 	}
 
-	args := buildProbeArgs(url)
+	info, err := runProbe(ctx, ffprobeBinary, url, true)
+	// Some cameras cannot SETUP the RTSP audio track alone, so the audio-only
+	// restriction breaks the handshake (issue #3902). Retry once requesting the
+	// full stream. Skip the retry when the parent context is done (shutdown/
+	// caller cancel), so a cancel is not spent on a doomed second attempt; a
+	// per-attempt probe timeout leaves ctx live, so a hung audio-only handshake
+	// still falls back. ErrNoAudioStreamsFound means the handshake succeeded but
+	// the input has no audio, which the fallback cannot fix, so skip it there too.
+	if err != nil && ctx.Err() == nil && isRTSPURL(url) && !errors.Is(err, ErrNoAudioStreamsFound) {
+		info, err = runProbe(ctx, ffprobeBinary, url, false)
+	}
+	return info, err
+}
+
+// runProbe executes a single ffprobe attempt. audioOnly controls whether the
+// RTSP handshake is restricted to audio tracks via -allowed_media_types audio.
+func runProbe(ctx context.Context, ffprobeBinary, url string, audioOnly bool) (*StreamInfo, error) {
+	probeCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+
+	args := buildProbeArgs(url, audioOnly)
 
 	cmd := exec.CommandContext(probeCtx, ffprobeBinary, args...) //nolint:gosec // G204: ffprobeBinary validated by config or exec.LookPath, URL from user config
 	var stdout, stderr bytes.Buffer
@@ -137,15 +154,16 @@ func parseProbeOutput(data []byte) (*StreamInfo, error) {
 
 // buildProbeArgs constructs the ffprobe argument list for the given URL.
 // For RTSP/RTSPS URLs, it prepends -rtsp_transport tcp to force TCP transport.
-func buildProbeArgs(url string) []string {
+// When audioOnly is true it also restricts the handshake to audio tracks; the
+// fallback path passes false for cameras that cannot SETUP audio alone (#3902).
+func buildProbeArgs(url string, audioOnly bool) []string {
 	args := make([]string, 0, 10)
 
 	// For RTSP streams, force TCP transport before the input URL and restrict the
 	// handshake to audio tracks so ffprobe never SETUPs the camera's video track
 	// (issue #3798); -select_streams below only filters ffprobe's output.
-	lower := strings.ToLower(url)
-	if strings.HasPrefix(lower, "rtsp://") || strings.HasPrefix(lower, "rtsps://") {
-		args = append(args, "-rtsp_transport", "tcp", ffmpegAllowedMediaTypesFlag, ffmpegAllowedMediaTypesAudio)
+	if isRTSPURL(url) {
+		args = appendRTSPMediaArgs(args, "tcp", audioOnly)
 	}
 
 	args = append(args,

--- a/internal/audiocore/ffmpeg/probe_test.go
+++ b/internal/audiocore/ffmpeg/probe_test.go
@@ -143,7 +143,7 @@ func TestBuildProbeArgs(t *testing.T) {
 	t.Run("RTSP URL includes tcp transport", func(t *testing.T) {
 		t.Parallel()
 
-		args := buildProbeArgs("rtsp://192.168.1.10:554/stream1")
+		args := buildProbeArgs("rtsp://192.168.1.10:554/stream1", true)
 
 		assert.Contains(t, args, "-rtsp_transport")
 		assert.Contains(t, args, "tcp")
@@ -162,7 +162,7 @@ func TestBuildProbeArgs(t *testing.T) {
 	t.Run("RTSPS URL includes tcp transport", func(t *testing.T) {
 		t.Parallel()
 
-		args := buildProbeArgs("rtsps://camera.example.com/live")
+		args := buildProbeArgs("rtsps://camera.example.com/live", true)
 
 		assert.Contains(t, args, "-rtsp_transport")
 		assert.Contains(t, args, "tcp")
@@ -181,7 +181,7 @@ func TestBuildProbeArgs(t *testing.T) {
 	t.Run("HTTP URL does not include rtsp transport", func(t *testing.T) {
 		t.Parallel()
 
-		args := buildProbeArgs("http://example.com/stream.m3u8")
+		args := buildProbeArgs("http://example.com/stream.m3u8", true)
 
 		assert.NotContains(t, args, "-rtsp_transport")
 		assert.NotContains(t, args, "-allowed_media_types")
@@ -190,5 +190,19 @@ func TestBuildProbeArgs(t *testing.T) {
 		assert.Contains(t, args, "quiet")
 		assert.Contains(t, args, "-print_format")
 		assert.Contains(t, args, "json")
+	})
+
+	t.Run("RTSP fallback drops audio-only restriction", func(t *testing.T) {
+		t.Parallel()
+
+		// audioOnly=false is the full-stream fallback for cameras that cannot
+		// SETUP the audio track alone (issue #3902); transport stays, but the
+		// -allowed_media_types restriction is dropped so the handshake succeeds.
+		args := buildProbeArgs("rtsp://192.168.1.10:554/stream1", false)
+
+		assert.Contains(t, args, "-rtsp_transport")
+		assert.Contains(t, args, "tcp")
+		assert.NotContains(t, args, "-allowed_media_types")
+		assert.Equal(t, "rtsp://192.168.1.10:554/stream1", args[len(args)-1])
 	})
 }

--- a/internal/audiocore/ffmpeg/process.go
+++ b/internal/audiocore/ffmpeg/process.go
@@ -49,6 +49,27 @@ const ffmpegAllowedMediaTypesFlag = "-allowed_media_types"
 // to accept audio tracks only.
 const ffmpegAllowedMediaTypesAudio = "audio"
 
+// isRTSPURL reports whether a raw URL string is an RTSP or RTSPS stream. Used by
+// the probe and channel-analysis paths, which take a bare URL rather than a
+// StreamConfig, to decide whether RTSP-specific FFmpeg flags apply.
+func isRTSPURL(url string) bool {
+	lower := strings.ToLower(url)
+	return strings.HasPrefix(lower, "rtsp://") || strings.HasPrefix(lower, "rtsps://")
+}
+
+// appendRTSPMediaArgs appends the RTSP transport flag and, when audioOnly is
+// true, the -allowed_media_types audio restriction. audioOnly is false only when
+// a camera has proven it cannot SETUP the audio track alone and the caller has
+// fallen back to requesting the full stream (issue #3902); video is still
+// dropped after decode via -vn, so the fallback only affects the RTSP handshake.
+func appendRTSPMediaArgs(args []string, transport string, audioOnly bool) []string {
+	args = append(args, "-rtsp_transport", transport)
+	if audioOnly {
+		args = append(args, ffmpegAllowedMediaTypesFlag, ffmpegAllowedMediaTypesAudio)
+	}
+	return args
+}
+
 // ffmpegMajorCache stores detected FFmpeg major versions by binary path.
 var ffmpegMajorCache sync.Map
 
@@ -481,7 +502,9 @@ func ProcessAudioToFile(ctx context.Context, filePath, ffmpegPath string, filter
 // RTSP-specific flags like -rtsp_transport are only added for RTSP sources.
 // A default -timeout is added unless the caller supplies one via ffmpegParameters.
 func BuildFFmpegArgs(cfg *StreamConfig, ffmpegParameters []string) []string {
-	args := buildInputArgs(cfg, ffmpegParameters)
+	// Audio-only restriction is on by default; the runtime path drops it per
+	// Stream via buildFFmpegInputArgs once a camera proves it cannot honor it.
+	args := buildInputArgs(cfg, ffmpegParameters, true)
 	return buildOutputArgs(args, cfg)
 }
 
@@ -536,13 +559,15 @@ func appendChannelArgs(args []string, channelMode string, sourceChannels int, nu
 // buildInputArgs constructs the pre-input FFmpeg flags (transport, timeout, extra parameters).
 // This mirrors the logic in Stream.buildFFmpegInputArgs but accepts explicit parameters.
 // RTSP streams use the timeout flag supported by the configured FFmpeg major version.
-func buildInputArgs(cfg *StreamConfig, ffmpegParameters []string) []string {
+// When audioOnly is false, the RTSP handshake is not restricted to audio tracks
+// (the full-stream fallback for cameras that cannot SETUP audio alone, issue #3902).
+func buildInputArgs(cfg *StreamConfig, ffmpegParameters []string, audioOnly bool) []string {
 	args := make([]string, 0, 8+len(ffmpegParameters))
 	ffmpegMajor := resolveFfmpegMajor(cfg.FFmpegPath)
 	timeoutFlag := timeoutParamForSource(cfg.sourceType(), ffmpegMajor)
 
 	if cfg.sourceType() == audiocore.SourceTypeRTSP {
-		args = append(args, "-rtsp_transport", cfg.Transport, ffmpegAllowedMediaTypesFlag, ffmpegAllowedMediaTypesAudio)
+		args = appendRTSPMediaArgs(args, cfg.Transport, audioOnly)
 	}
 
 	hasUserTimeout, userTimeoutValue := detectUserTimeout(ffmpegParameters)

--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -758,12 +758,14 @@ func (s *Stream) Run(parentCtx context.Context) {
 
 			runtime := time.Since(processStartTime)
 
+			fallbackEngaged := false
 			if err != nil && !errors.Is(err, context.Canceled) {
 				s.recordFailure(runtime)
 				// Latch to the full-stream request if repeated RTSP failures with
 				// no audio point at an audio-only handshake the camera cannot
-				// honor (issue #3902).
-				s.maybeEngageAudioOnlyFallback()
+				// honor (issue #3902). When it engages, skip this iteration's
+				// backoff below so the full-stream attempt starts immediately.
+				fallbackEngaged = s.maybeEngageAudioOnlyFallback()
 				errorMsg := err.Error()
 				sanitizedError := privacy.SanitizeFFmpegError(errorMsg)
 				isSilenceTimeout := strings.Contains(errorMsg, "silence timeout")
@@ -822,8 +824,11 @@ func (s *Stream) Run(parentCtx context.Context) {
 				s.onReset(s.config.SourceID)
 			}
 
+			// Skip the backoff on the iteration that engaged the audio-only
+			// fallback so the first full-stream attempt starts immediately
+			// (issue #3902); a later full-stream failure backs off normally.
 			currentState := s.GetProcessState()
-			if currentState != StateCircuitOpen {
+			if currentState != StateCircuitOpen && !fallbackEngaged {
 				s.handleRestartBackoff()
 			}
 		}
@@ -1937,25 +1942,30 @@ func (s *Stream) resetFailures() {
 // because a silence-timeout failure (connect succeeds, no audio flows) resets
 // those counters in Run, which would otherwise let a broken audio-only handshake
 // retry forever without ever falling back.
-func (s *Stream) maybeEngageAudioOnlyFallback() {
+//
+// Returns true on the call that engages the fallback, so Run can skip that
+// iteration's restart backoff and attempt the full stream immediately.
+func (s *Stream) maybeEngageAudioOnlyFallback() bool {
 	// Only RTSP carries the audio-only restriction; only act while it is still
 	// requested and the camera has never delivered audio under it.
 	if s.config.sourceType() != audiocore.SourceTypeRTSP {
-		return
+		return false
 	}
 	if s.audioOnlyFallback.Load() || s.receivedAudio.Load() {
-		return
+		return false
 	}
 
 	if s.audioOnlyFailures.Add(1) < audioOnlyFallbackThreshold {
-		return
+		return false
 	}
 
 	s.audioOnlyFallback.Store(true)
 
 	// Clear failure and circuit state accumulated during the audio-only attempts
-	// so the first full-stream attempt runs promptly instead of waiting out a
-	// backoff or circuit cooldown that the (now-resolved) audio-only failures caused.
+	// so a later full-stream failure backs off from a clean slate instead of the
+	// (now-resolved) audio-only failures' inflated count. The caller additionally
+	// skips this iteration's restart backoff (see Run) so the first full-stream
+	// attempt starts immediately rather than after a base backoff.
 	s.restartCountMu.Lock()
 	s.restartCount = 0
 	s.restartCountMu.Unlock()
@@ -1971,6 +1981,8 @@ func (s *Stream) maybeEngageAudioOnlyFallback() {
 		logger.Int("failures", int(s.audioOnlyFailures.Load())),
 		logger.String("component", "ffmpeg-stream"),
 		logger.String("operation", "audio_only_fallback"))
+
+	return true
 }
 
 // conditionalFailureReset resets failures only after the process has proven

--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/alerting"
@@ -55,6 +56,13 @@ const (
 	circuitBreakerImmediateThreshold = 3
 	circuitBreakerRapidThreshold     = 5
 	circuitBreakerQuickThreshold     = 8
+
+	// audioOnlyFallbackThreshold is the number of RTSP process failures with no
+	// audio ever received that trigger the audio-only fallback:
+	// the stream stops requesting -allowed_media_types audio and asks for the
+	// full stream instead (issue #3902). Kept below circuitBreakerImmediateThreshold
+	// so the fallback engages before the circuit breaker locks the source out.
+	audioOnlyFallbackThreshold = 2
 
 	// Circuit breaker runtime thresholds.
 	circuitBreakerImmediateRuntime = 1 * time.Second
@@ -507,6 +515,18 @@ type Stream struct {
 	circuitOpenTime     time.Time
 	circuitMu           sync.Mutex
 
+	// RTSP audio-only fallback state. BirdNET-Go requests audio-only via
+	// -allowed_media_types audio to avoid opening a camera video slot (#3798),
+	// but some cameras cannot SETUP the audio track alone and never deliver audio
+	// (#3902). audioOnlyFallback latches true after audioOnlyFailures reaches
+	// audioOnlyFallbackThreshold failures with no audio ever received, at which
+	// point the stream requests the full stream (video dropped via -vn).
+	// receivedAudio guards against engaging the fallback on a source that has
+	// already proven audio-only works, so a later transient failure never trips it.
+	audioOnlyFallback atomic.Bool
+	receivedAudio     atomic.Bool
+	audioOnlyFailures atomic.Int32
+
 	// Dropped data tracking.
 	lastDropLogTime time.Time
 	dropLogMu       sync.Mutex
@@ -740,6 +760,10 @@ func (s *Stream) Run(parentCtx context.Context) {
 
 			if err != nil && !errors.Is(err, context.Canceled) {
 				s.recordFailure(runtime)
+				// Latch to the full-stream request if repeated RTSP failures with
+				// no audio point at an audio-only handshake the camera cannot
+				// honor (issue #3902).
+				s.maybeEngageAudioOnlyFallback()
 				errorMsg := err.Error()
 				sanitizedError := privacy.SanitizeFFmpegError(errorMsg)
 				isSilenceTimeout := strings.Contains(errorMsg, "silence timeout")
@@ -891,9 +915,12 @@ func (s *Stream) startProcess() error {
 }
 
 // buildFFmpegInputArgs constructs the FFmpeg input arguments for this stream.
-// It delegates the actual argument construction to the shared buildInputArgs so
-// the runtime path stays in lockstep with the unit-tested BuildFFmpegArgs. The
-// only Stream-specific behavior is surfacing an invalid user-supplied timeout as
+// It delegates argument construction to the shared buildInputArgs so the runtime
+// path builds the same argument structure as the unit-tested BuildFFmpegArgs.
+// The two differ only where this stream intends them to: BuildFFmpegArgs always
+// requests audio-only, whereas this path passes audioOnly=false once the stream
+// has latched into the full-stream fallback (issue #3902). Stream-specific
+// behavior is otherwise limited to surfacing an invalid user-supplied timeout as
 // a warning log (buildInputArgs silently falls back to the default).
 func (s *Stream) buildFFmpegInputArgs(ffmpegParameters []string) []string {
 	if hasUserTimeout, userTimeoutValue := detectUserTimeout(ffmpegParameters); hasUserTimeout {
@@ -906,7 +933,10 @@ func (s *Stream) buildFFmpegInputArgs(ffmpegParameters []string) []string {
 				logger.String("operation", "validate_timeout"))
 		}
 	}
-	return buildInputArgs(&s.config, ffmpegParameters)
+	// Request audio-only unless this stream has fallen back to the full stream
+	// because the camera cannot SETUP the audio track alone (issue #3902).
+	audioOnly := !s.audioOnlyFallback.Load()
+	return buildInputArgs(&s.config, ffmpegParameters, audioOnly)
 }
 
 // readResult carries the outcome of a single stdout.Read call from the
@@ -1152,6 +1182,15 @@ func (s *Stream) dispatchAudioData(data []byte, ref *audiocore.FrameRef) {
 	defer ref.Release()
 
 	s.updateLastDataTime()
+
+	// Record that audio has flowed at least once. This confirms the current
+	// RTSP media-type request works for this camera, so the audio-only fallback
+	// never engages on a later transient failure (issue #3902). This is a
+	// set-once latch: the Load guard keeps the steady state a barrier-free read
+	// rather than a locked store on every audio chunk.
+	if !s.receivedAudio.Load() {
+		s.receivedAudio.Store(true)
+	}
 
 	n := len(data)
 	s.bytesReceivedMu.Lock()
@@ -1883,6 +1922,55 @@ func (s *Stream) resetFailures() {
 			logger.String("operation", "reset_failures"))
 		s.consecutiveFailures = 0
 	}
+}
+
+// maybeEngageAudioOnlyFallback latches the stream into full-stream mode when an
+// RTSP source repeatedly fails without ever delivering audio while audio-only
+// was requested. Some cameras cannot SETUP the audio track in isolation, so the
+// -allowed_media_types audio restriction (issue #3798) causes the handshake to
+// fail and no audio to arrive (issue #3902). Dropping the restriction restores
+// the pre-#3798 full-stream request; video is still discarded after decode via
+// -vn. This is a one-way latch per Stream instance: reconfiguring the source
+// creates a fresh Stream that retries audio-only.
+//
+// It uses its own failure counter rather than restartCount/consecutiveFailures
+// because a silence-timeout failure (connect succeeds, no audio flows) resets
+// those counters in Run, which would otherwise let a broken audio-only handshake
+// retry forever without ever falling back.
+func (s *Stream) maybeEngageAudioOnlyFallback() {
+	// Only RTSP carries the audio-only restriction; only act while it is still
+	// requested and the camera has never delivered audio under it.
+	if s.config.sourceType() != audiocore.SourceTypeRTSP {
+		return
+	}
+	if s.audioOnlyFallback.Load() || s.receivedAudio.Load() {
+		return
+	}
+
+	if s.audioOnlyFailures.Add(1) < audioOnlyFallbackThreshold {
+		return
+	}
+
+	s.audioOnlyFallback.Store(true)
+
+	// Clear failure and circuit state accumulated during the audio-only attempts
+	// so the first full-stream attempt runs promptly instead of waiting out a
+	// backoff or circuit cooldown that the (now-resolved) audio-only failures caused.
+	s.restartCountMu.Lock()
+	s.restartCount = 0
+	s.restartCountMu.Unlock()
+
+	s.circuitMu.Lock()
+	s.consecutiveFailures = 0
+	s.circuitOpenTime = time.Time{}
+	s.circuitMu.Unlock()
+
+	getStreamLogger().Warn("RTSP audio-only request failed repeatedly; falling back to full stream (audio decoded, video ignored)",
+		logger.String("url", s.config.safeURL()),
+		logger.String("source_id", s.config.SourceID),
+		logger.Int("failures", int(s.audioOnlyFailures.Load())),
+		logger.String("component", "ffmpeg-stream"),
+		logger.String("operation", "audio_only_fallback"))
 }
 
 // conditionalFailureReset resets failures only after the process has proven

--- a/internal/audiocore/ffmpeg/stream_audioonly_fallback_test.go
+++ b/internal/audiocore/ffmpeg/stream_audioonly_fallback_test.go
@@ -1,0 +1,104 @@
+package ffmpeg
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// hasAudioOnlyFlag reports whether the built input args request audio-only via
+// -allowed_media_types audio.
+func hasAudioOnlyFlag(args []string) bool {
+	idx := slices.Index(args, "-allowed_media_types")
+	return idx != -1 && idx+1 < len(args) && args[idx+1] == "audio"
+}
+
+func TestStream_AudioOnlyFallback_LatchesAfterThreshold(t *testing.T) {
+	t.Parallel()
+
+	stream := newTestStream(t) // RTSP by default
+
+	// Before any failure the stream requests audio-only.
+	require.True(t, hasAudioOnlyFlag(stream.buildFFmpegInputArgs(nil)),
+		"expected audio-only flag before any failure")
+
+	// Failures below audioOnlyFallbackThreshold must not latch the fallback.
+	for i := 1; i < audioOnlyFallbackThreshold; i++ {
+		stream.maybeEngageAudioOnlyFallback()
+		assert.Falsef(t, stream.audioOnlyFallback.Load(), "should not latch after %d failure(s)", i)
+		assert.True(t, hasAudioOnlyFlag(stream.buildFFmpegInputArgs(nil)),
+			"expected audio-only flag to remain below threshold")
+	}
+
+	// The failure that reaches the threshold latches the fallback.
+	stream.maybeEngageAudioOnlyFallback()
+	assert.True(t, stream.audioOnlyFallback.Load(), "should latch after reaching threshold")
+
+	args := stream.buildFFmpegInputArgs(nil)
+	assert.False(t, hasAudioOnlyFlag(args), "expected audio-only flag dropped after fallback")
+	// Transport must still be present; only the media-type restriction is dropped.
+	assert.Contains(t, args, "-rtsp_transport")
+}
+
+func TestStream_AudioOnlyFallback_SkippedAfterAudioReceived(t *testing.T) {
+	t.Parallel()
+
+	stream := newTestStream(t)
+	// Simulate audio having flowed at least once: audio-only is proven to work.
+	stream.receivedAudio.Store(true)
+
+	for range 5 {
+		stream.maybeEngageAudioOnlyFallback()
+	}
+
+	assert.False(t, stream.audioOnlyFallback.Load(),
+		"fallback must not engage once audio has been received")
+	assert.True(t, hasAudioOnlyFlag(stream.buildFFmpegInputArgs(nil)),
+		"expected audio-only flag to remain when audio was received")
+}
+
+func TestStream_AudioOnlyFallback_NonRTSPNoop(t *testing.T) {
+	t.Parallel()
+
+	cfg := newTestConfig()
+	cfg.Type = "http"
+	cfg.URL = "http://host.example.com/stream"
+	stream := newTestStreamWithConfig(t, &cfg)
+
+	for range 5 {
+		stream.maybeEngageAudioOnlyFallback()
+	}
+
+	assert.False(t, stream.audioOnlyFallback.Load(),
+		"fallback state must never change for non-RTSP sources")
+	// HTTP never carries the audio-only flag regardless of fallback state.
+	assert.False(t, hasAudioOnlyFlag(stream.buildFFmpegInputArgs(nil)))
+}
+
+func TestStream_AudioOnlyFallback_ClearsFailureCounters(t *testing.T) {
+	t.Parallel()
+
+	stream := newTestStream(t)
+
+	// Accumulate failure/circuit state as the audio-only attempts would.
+	stream.setConsecutiveFailures(2)
+	stream.restartCountMu.Lock()
+	stream.restartCount = 3
+	stream.restartCountMu.Unlock()
+
+	// Reach the threshold to engage the fallback.
+	for range audioOnlyFallbackThreshold {
+		stream.maybeEngageAudioOnlyFallback()
+	}
+	require.True(t, stream.audioOnlyFallback.Load(), "expected fallback to latch")
+
+	// Counters are cleared so the first full-stream attempt runs promptly.
+	assert.Equal(t, 0, stream.getConsecutiveFailures(),
+		"consecutive failures should reset when fallback engages")
+	stream.restartCountMu.Lock()
+	restart := stream.restartCount
+	stream.restartCountMu.Unlock()
+	assert.Equal(t, 0, restart, "restart count should reset when fallback engages")
+}

--- a/internal/audiocore/ffmpeg/stream_audioonly_fallback_test.go
+++ b/internal/audiocore/ffmpeg/stream_audioonly_fallback_test.go
@@ -26,15 +26,22 @@ func TestStream_AudioOnlyFallback_LatchesAfterThreshold(t *testing.T) {
 
 	// Failures below audioOnlyFallbackThreshold must not latch the fallback.
 	for i := 1; i < audioOnlyFallbackThreshold; i++ {
-		stream.maybeEngageAudioOnlyFallback()
+		assert.Falsef(t, stream.maybeEngageAudioOnlyFallback(),
+			"should report not-engaged after %d failure(s)", i)
 		assert.Falsef(t, stream.audioOnlyFallback.Load(), "should not latch after %d failure(s)", i)
 		assert.True(t, hasAudioOnlyFlag(stream.buildFFmpegInputArgs(nil)),
 			"expected audio-only flag to remain below threshold")
 	}
 
-	// The failure that reaches the threshold latches the fallback.
-	stream.maybeEngageAudioOnlyFallback()
+	// The failure that reaches the threshold latches the fallback and reports it
+	// engaged (so Run skips that iteration's backoff).
+	assert.True(t, stream.maybeEngageAudioOnlyFallback(),
+		"should report engaged on the call that reaches the threshold")
 	assert.True(t, stream.audioOnlyFallback.Load(), "should latch after reaching threshold")
+
+	// A further call after latching reports not-engaged (already engaged).
+	assert.False(t, stream.maybeEngageAudioOnlyFallback(),
+		"should report not-engaged once already latched")
 
 	args := stream.buildFFmpegInputArgs(nil)
 	assert.False(t, hasAudioOnlyFlag(args), "expected audio-only flag dropped after fallback")


### PR DESCRIPTION
## Summary

RTSP capture requests audio-only from the camera via the FFmpeg flag `-allowed_media_types audio` so BirdNET-Go only SETUPs the audio track and does not open a video client slot on the camera (#3798). Some cameras cannot SETUP the audio track in isolation: the RTSP handshake never completes and no audio ever arrives, so capture silently stopped working for those users after that change landed (#3902).

This keeps audio-only as the default first attempt but adds an automatic fallback to requesting the full stream when audio-only fails to deliver audio. Video is still discarded after decode via `-vn`, so only the RTSP handshake changes, not what gets analyzed.

## What changed

- **Live capture** (`stream.go`): a one-way per-Stream latch. After 2 failures with no audio ever received, the stream drops the flag and requests the full stream. It uses an independent counter so silence-timeout failures (which reset the restart/circuit counters) still count toward the fallback, and it engages before the circuit breaker (3 immediate failures) can lock the source out. Once audio has ever flowed on the stream, the fallback never engages, so a later transient network failure cannot trip it.
- **Probe** (`probe.go`) and **channel analysis** (`analyze.go`): retry once without the flag on RTSP failure. The retry is skipped when the parent context is done (shutdown/cancel), and for probe when the input genuinely has no audio.
- Shared `appendRTSPMediaArgs` / `isRTSPURL` helpers so all three RTSP paths stay in lockstep and the flag is emitted from a single place.

## Compatibility

Cameras that work today are behaviorally unchanged: the first attempt is byte-for-byte identical to the current code and no fallback engages on the success path. All new behavior is confined to failure paths. The exported API surface (`BuildFFmpegArgs`, `ProbeStreamInfo`, `AnalyzeChannelEnergy`) is unchanged; the audio-only decision lives on unexported helpers. No config, schema, or DB changes.

One deliberate tradeoff: a genuinely unreachable RTSP camera now takes up to 2x the timeout to report failure on the probe and channel-analysis paths (each makes a second attempt with its own timeout). Per-attempt timeouts are intentional so that a first attempt which hangs on the audio-only handshake still leaves a full budget for the fallback; sharing one budget would defeat the fallback for exactly the "hangs, no error" symptom this fixes. These are on-demand paths, not the capture hot loop.

## Related Issues

Fixes #3902

## Test Plan

- [x] `go build ./...`
- [x] `go test -race ./internal/audiocore/ffmpeg/`
- [x] `golangci-lint run ./internal/audiocore/ffmpeg/...` (0 issues)
- [x] New unit tests cover the fallback latch, the audio-received guard, the non-RTSP no-op, the counter reset, and the audio-only-dropped arg building on all three paths
- [ ] Manual: point an RTSP camera that cannot stream audio-only at BirdNET-Go and confirm capture recovers via the fallback (logged as `audio_only_fallback`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RTSP audio capture by first trying an audio-only handshake, then conditionally retrying with a broader stream handshake when the first attempt fails.
  * Added an audio-only fallback for RTSP streams that repeatedly fail to deliver audio, switching to full-stream capture while keeping RTSP transport settings intact.
  * Prevented unnecessary fallback changes for non-RTSP sources once audio has been received.

* **Tests**
  * Updated argument-building tests and added new coverage for RTSP retry behavior, fallback latching thresholds, post-audio stability, non-RTSP no-op behavior, and state reset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->