### PR TITLE
fix(install): pass Intel iGPU /dev/dri into container for OpenVINO offload

### DIFF
--- a/Docker/docker-compose.autotls.yml
+++ b/Docker/docker-compose.autotls.yml
@@ -30,6 +30,10 @@ services:
     # For ALSA audio input (sound card)
     devices:
       - /dev/snd:/dev/snd
+      # For Intel iGPU OpenVINO acceleration (amd64 hosts with an Intel GPU),
+      # uncomment the next line to pass the render device into the container.
+      # Leave it commented on hosts without /dev/dri or `docker compose up` fails.
+      # - /dev/dri:/dev/dri
     # Add any host mappings needed
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -57,6 +57,10 @@ services:
     # For ALSA audio input (sound card)
     devices:
       - /dev/snd:/dev/snd
+      # For Intel iGPU OpenVINO acceleration (amd64 hosts with an Intel GPU),
+      # uncomment the next line to pass the render device into the container.
+      # Leave it commented on hosts without /dev/dri or `docker compose up` fails.
+      # - /dev/dri:/dev/dri
     # Add any host mappings needed
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -182,7 +182,7 @@ fi
 # If Intel GPU device present, add user to render group for OpenVINO iGPU inference
 if [ -d "/dev/dri" ]; then
     if [ "$RUNNING_AS_ROOT" = true ]; then
-        # Detect the actual GID of the first render node on the host — it varies
+        # Detect the actual GID of the first render node on the host; it varies
         # across distributions (105, 109, 44, 989 …) and Docker preserves the
         # host GID when passing --device /dev/dri. Using a hardcoded GID would
         # mismatch. Use a glob so the code works whether the device landed as
@@ -206,9 +206,12 @@ if [ -d "/dev/dri" ]; then
                 echo "Added $USER_NAME to group $DRM_GROUP (GID $RENDER_GID) for Intel iGPU access"
             fi
         fi
-    fi
     else
-        echo "Warning: /dev/dri detected but cannot configure Intel iGPU access without root privileges"
+        # Rootless: cannot create or join groups. Intel iGPU access still works if
+        # the container user was started already in the host render group (e.g. via
+        # --group-add on docker run). This is a heads-up, not an error.
+        echo "Note: /dev/dri present but running rootless; relying on pre-set render group membership for Intel iGPU access"
+    fi
 fi
 
 # Pre-flight checks before starting application

--- a/install.sh
+++ b/install.sh
@@ -5803,10 +5803,12 @@ verify_post_start() {
 # container image; other render nodes (AMD, NVIDIA, Pi VideoCore) gain nothing, so
 # they are not mapped into the container. Used to decide whether to pass /dev/dri.
 has_intel_gpu() {
-    local vendor
+    local vendor id
     for vendor in /sys/class/drm/renderD*/device/vendor; do
         [ -r "$vendor" ] || continue
-        if grep -qi '0x8086' "$vendor" 2>/dev/null; then
+        # Read the single-line sysfs vendor file with the bash builtin rather than
+        # spawning grep per node. The kernel writes lowercase; match both cases.
+        if read -r id < "$vendor" 2>/dev/null && [[ "$id" == *0x8086* || "$id" == *0X8086* ]]; then
             return 0  # True - Intel render node present
         fi
     done

--- a/install.sh
+++ b/install.sh
@@ -4492,6 +4492,17 @@ generate_systemd_service_content() {
         audio_env_line="--device /dev/snd"
     fi
 
+    # Intel iGPU passthrough for OpenVINO GPU offload. Mapped only when an Intel
+    # render node is present: the amd64 image bundles the Intel OpenCL/Level-Zero
+    # userspace and the entrypoint grants the render group at runtime. Hardcoding
+    # /dev/dri on a host without it would make docker run fail, so gate on
+    # detection (mirrors the /dev/snd handling above). Re-detected on every
+    # regenerate, so adding or removing an Intel GPU later just needs a re-run.
+    local gpu_env_line=""
+    if has_intel_gpu; then
+        gpu_env_line="--device /dev/dri"
+    fi
+
     # Check for /sys/class/thermal, used for Raspberry Pi temperature reporting in system dashboard
     local thermal_volume_line=""
     if check_directory_exists "/sys/class/thermal"; then
@@ -4570,6 +4581,7 @@ ${tls_ports_line:+    ${tls_ports_line} \\
     --env BIRDNET_UID=${HOST_UID} \\
     --env BIRDNET_GID=${HOST_GID} \\
 ${audio_env_line:+    ${audio_env_line} \\
+}${gpu_env_line:+    ${gpu_env_line} \\
 }    -v ${CONFIG_DIR}:/config \\
     -v ${DATA_DIR}:/data \\
 ${thermal_volume_line:+    ${thermal_volume_line} \\
@@ -5784,6 +5796,21 @@ verify_post_start() {
             print_message "   AutoTLS needs your domain to resolve to this host with ports 80/443 reachable from the internet." "$YELLOW"
         fi
     fi
+}
+
+# Detect an Intel GPU render node (PCI vendor 0x8086) for OpenVINO iGPU offload.
+# Only Intel iGPUs are accelerated by the OpenVINO GPU plugin bundled in the amd64
+# container image; other render nodes (AMD, NVIDIA, Pi VideoCore) gain nothing, so
+# they are not mapped into the container. Used to decide whether to pass /dev/dri.
+has_intel_gpu() {
+    local vendor
+    for vendor in /sys/class/drm/renderD*/device/vendor; do
+        [ -r "$vendor" ] || continue
+        if grep -qi '0x8086' "$vendor" 2>/dev/null; then
+            return 0  # True - Intel render node present
+        fi
+    done
+    return 1  # False - no Intel render node
 }
 
 # Function to check if system is a Raspberry Pi

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -93,11 +93,13 @@ log_command_result() { :; }
 command_exists() { command -v "$1" >/dev/null 2>&1; }
 
 # Deterministic stubs for the helpers generate_systemd_service_content calls: force
-# audio/thermal/Pi detection off and resolve the timezone to the passed value so the
-# generated unit is stable across hosts.
+# audio/thermal/Pi/GPU detection off and resolve the timezone to the passed value so the
+# generated unit is stable across hosts (a CI runner with an Intel iGPU must not add
+# --device /dev/dri to the baseline units; the GPU-passthrough test overrides this stub).
 resolve_host_timezone() { printf '%s' "${1:-UTC}"; }
 check_directory_exists() { return 1; }
 is_raspberry_pi() { return 1; }
+has_intel_gpu() { return 1; }
 
 # Globals the extracted functions reference (install.sh defines these at the top; the harness
 # only pulls function bodies, so under set -u they must exist here).
@@ -441,6 +443,36 @@ load_existing_service_config "$autotls_unit"
 assert_eq "round-trip: web port restored (not 80)" "9000" "$WEB_PORT"
 assert_eq "round-trip: TLS binding restored" "true" "$BIND_TLS_PORTS"
 assert_eq "round-trip: TLS bind addr empty" "" "$TLS_BIND_ADDR"
+
+# ===========================================================================
+# generate_systemd_service_content: Intel iGPU passthrough is gated on has_intel_gpu.
+# With detection stubbed off the unit must omit --device /dev/dri; when an Intel render
+# node is present it must map /dev/dri into the container so the OpenVINO GPU plugin
+# (bundled in the amd64 image) can reach it. Mirrors the /dev/snd audio gating.
+# ===========================================================================
+it "generate_systemd_service_content GPU passthrough"
+
+CONFIG_DIR="/home/pi/birdnet-go-app/config"
+DATA_DIR="/home/pi/birdnet-go-app/data"
+BIRDNET_GO_IMAGE="ghcr.io/tphakala/birdnet-go:nightly"
+WEB_PORT="9000"; WEB_PORT_BIND_ADDR=""
+BIND_TLS_PORTS="false"; TLS_BIND_ADDR=""
+BIND_METRICS_PORT="false"; METRICS_BIND_ADDR=""
+CONFIGURED_TZ="UTC"
+
+# Default stub (has_intel_gpu -> 1): no Intel render node, so no device mapping.
+nogpu_unit="${WORK}/nogpu.service"
+generate_systemd_service_content > "$nogpu_unit"
+assert_eq "no Intel GPU: unit omits --device /dev/dri" "0" "$(grep -c -- '--device /dev/dri' "$nogpu_unit")"
+
+# Intel render node present (has_intel_gpu -> 0): exactly one /dev/dri mapping is added,
+# and generation is otherwise intact (web port still published).
+has_intel_gpu() { return 0; }
+gpu_unit="${WORK}/gpu.service"
+generate_systemd_service_content > "$gpu_unit"
+assert_eq "Intel GPU: unit maps /dev/dri exactly once" "1" "$(grep -c -- '--device /dev/dri' "$gpu_unit")"
+assert_eq "Intel GPU: web port still published" "1" "$(grep -c -- '-p 9000:8080' "$gpu_unit")"
+has_intel_gpu() { return 1; }   # restore the deterministic default for subsequent tests
 
 # ===========================================================================
 # apply_tls_settings (full slate; mode switch must clear stale host)


### PR DESCRIPTION
## Summary

PR #3888 added Intel iGPU OpenVINO acceleration inside the container image: the amd64 image bundles the Intel NEO/Level-Zero OpenCL userspace and the OpenVINO GPU plugin, and `Docker/entrypoint.sh` grants the container user the host render group at runtime. That work only takes effect when the host maps the render device into the container, but nothing on the host side did, so on `install.sh`-based deployments the acceleration stayed inert and silently fell back to CPU/ONNX.

This wires up the missing host-side half:

- `install.sh` now detects an Intel render node (PCI vendor `0x8086` under `/sys/class/drm/renderD*/device/vendor`) and appends `--device /dev/dri` to the generated `docker run` systemd unit. It is gated exactly like the existing `--device /dev/snd` handling, so hosts without an Intel GPU (AMD/NVIDIA/Raspberry Pi/headless) generate a byte-identical unit and are unaffected. Detection runs on every regenerate, so adding or removing an Intel GPU later just needs a re-run. Gating on the Intel vendor ID (rather than mere `/dev/dri` presence) avoids pointlessly mapping a render node on non-Intel hosts, which the bundled Intel driver cannot use.
- `Docker/docker-compose.yml` and `Docker/docker-compose.autotls.yml` gain a commented `# - /dev/dri:/dev/dri` device line with instructions. Compose files are static and shared, so the mapping is left commented (an always-on device that is absent on the host would break `docker compose up`); Intel users uncomment one line.
- Fixes a pre-existing brace bug in `Docker/entrypoint.sh`: the `else` was bound to the outer `if [ -d "/dev/dri" ]` instead of the inner root check, so the `"cannot configure Intel iGPU access"` warning printed precisely when `/dev/dri` was absent (backwards, and on nearly every existing container). The `else` is now correctly scoped to the rootless case and reworded to an informational note.

No config-key, REST API, DB, or CLI-flag surface is touched; the change is purely additive and detection-gated. No host-side driver install or `--group-add` is needed: the userspace ships in the image and the entrypoint self-manages the render group.

## Test Plan

- [x] `bash -n install.sh` and `bash -n Docker/entrypoint.sh` pass; `shellcheck` clean on the new code
- [x] On an Intel host (Iris Xe, `renderD128` = `0x8086`): the generated unit gets `--device /dev/dri` right after `--device /dev/snd`
- [x] Negative case (no Intel GPU): device line is gated out with no dangling backslash or blank line in the `docker run` command
- [x] `entrypoint.sh` verified across the three branches: absent `/dev/dri` is silent (bug fixed), present+root runs the group-add path, present+rootless prints the note
- [x] Both compose files parse as valid YAML; uncommenting the `/dev/dri` line yields correct 6-space indentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic Intel iGPU detection during installation to enable OpenVINO iGPU acceleration when appropriate.
  * When Intel iGPU hardware is present, the container is started with the required `/dev/dri` device mapping for acceleration.
* **Documentation**
  * Added optional Docker Compose guidance (commented) for enabling Intel iGPU access via `/dev/dri`.
  * Updated rootless-mode messaging with clearer instructions for render-group access.
* **Tests**
  * Added unit coverage to verify GPU passthrough behavior and ensure port publishing remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->