### PR TITLE
fix(frontend): keep species colors consistent across patterns charts

### DIFF
--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/AcousticSuccessionChart.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/AcousticSuccessionChart.svelte
@@ -8,7 +8,8 @@
   There is no y-axis (the wiggle baseline is meaningless). Bands are identified by an inline label at
   their thickest hour (when it fits) plus a hover tooltip; the scientific name is the stable D3 stack
   key and the localized common name is the label (re-localized here so it tracks the visitor locale,
-  matching the sibling charts). Species color comes from theme.ts generateSpeciesColors.
+  matching the sibling charts). Species color comes from utils/speciesColor.ts getSpeciesColor, a
+  shared page-scoped map so a species keeps the same color across the sibling charts.
 -->
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
@@ -31,7 +32,8 @@
   import { createLinearScale } from './utils/scales';
   import { createAxis, styleAxis, addAxisLabel, createHourAxisFormatter } from './utils/axes';
   import { ChartTooltip } from './utils/interactions';
-  import { generateSpeciesColors, type ChartTheme } from './utils/theme';
+  import type { ChartTheme } from './utils/theme';
+  import { getSpeciesColor, registerChart } from './utils/speciesColor';
   import { SUCCESSION_HOURS, readableTextColor, type SuccessionSeries } from './utils/succession';
   // peakIndex is the shared argmax for per-species distribution charts (same helper the ridgeline
   // uses); reused here rather than duplicated.
@@ -119,16 +121,16 @@
   // Persistent legend: a real-DOM swatch + localized name per band. A streamgraph has no species
   // y-axis, and the hover tooltip plus the thick-band inline labels do not identify a band on touch
   // or by keyboard (this UI is tablet/desktop), so a thin band would otherwise be an unlabeled color.
-  // Colors come from the same generateSpeciesColors call and rows order the bands use, so a swatch
-  // matches its band exactly. Depends on the BaseChart theme, so it is empty until the chart mounts.
+  // Colors come from the same shared getSpeciesColor map the bands use (keyed on scientific name), so
+  // a swatch matches its band exactly. Depends on the BaseChart theme, so it is empty until the chart
+  // mounts.
   const legendItems = $derived.by(() => {
     const theme = chartContext?.theme;
     if (!theme || rows.length === 0) return [];
-    const colors = generateSpeciesColors(rows.length, theme);
-    return rows.map((r, i) => ({
+    return rows.map(r => ({
       scientificName: r.scientificName,
       label: r.label,
-      color: colors.at(i) ?? theme.primary,
+      color: getSpeciesColor(r.scientificName, theme),
     }));
   });
 
@@ -162,8 +164,7 @@
     if (innerWidth <= 0 || innerHeight <= 0 || rows.length === 0) return;
 
     const names = rows.map(r => r.scientificName);
-    const colors = generateSpeciesColors(rows.length, theme);
-    const colorByName = new Map(names.map((n, i) => [n, colors.at(i) ?? theme.primary]));
+    const colorByName = new Map(names.map(n => [n, getSpeciesColor(n, theme)]));
     const rowByName = new Map(rows.map(r => [r.scientificName, r]));
 
     // d3.stack over the 24 hour indices; value(hourIdx, name) reads the species' count at that hour
@@ -309,6 +310,10 @@
       tooltip = new ChartTooltip(chartContainer);
     }
   });
+
+  // Reference-count this chart so the shared species→color map clears when the
+  // last patterns chart unmounts (fresh colors per page view; no session growth).
+  onMount(() => registerChart());
 
   onDestroy(() => {
     tooltip?.destroy();

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesRidgeline.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesRidgeline.svelte
@@ -6,8 +6,9 @@
 
   Each ridge is a d3-shape area with curveBasis; a shared amplitude scale maps the global-max
   density to a fixed pixel height, so a species with concentrated activity rises taller than an
-  all-day one. Species color comes from theme.ts generateSpeciesColors (rgba, so it is never fed to
-  a d3 color interpolator). The scientific name is the stable D3 key; the localized common name is
+  all-day one. Species color comes from utils/speciesColor.ts getSpeciesColor (rgba, so it is never
+  fed to a d3 color interpolator), a shared page-scoped map so a species keeps the same color across
+  the sibling charts. The scientific name is the stable D3 key; the localized common name is
   the row label (re-localized here so it tracks the visitor's locale, matching the sibling charts).
 -->
 <script lang="ts">
@@ -24,8 +25,9 @@
   import { createLinearScale } from './utils/scales';
   import { createAxis, styleAxis, addAxisLabel, createHourAxisFormatter } from './utils/axes';
   import { ChartTooltip } from './utils/interactions';
-  import { generateSpeciesColors, type ChartTheme } from './utils/theme';
+  import type { ChartTheme } from './utils/theme';
   import { fitTextNode } from './utils/labels';
+  import { getSpeciesColor, registerChart } from './utils/speciesColor';
   import {
     ridgelineLayout,
     peakIndex,
@@ -151,9 +153,8 @@
     if (innerWidth <= 0 || innerHeight <= 0 || rows.length === 0) return;
 
     // layout.rows[i] aligns with rows[i]: both derive from `series` in order (rows is a 1:1
-    // localized map of series), so layoutRow.index indexes `rows`, `colors`, and `series` alike.
+    // localized map of series), so layoutRow.index indexes `rows` and `series` alike.
     const layout = ridgelineLayout(series, innerHeight, RIDGE_OVERLAP);
-    const colors = generateSpeciesColors(rows.length, theme);
 
     // x: density index -> px. All series share the same length (24 hours / N bins); use the widest.
     const xLen = Math.max(1, ...rows.map(r => r.density.length));
@@ -194,7 +195,7 @@
     // Ridges, drawn top row first so lower (front) ridges overlap onto the ones above them.
     for (const layoutRow of layout.rows) {
       const row = rows[layoutRow.index];
-      const color = colors[layoutRow.index] ?? theme.primary;
+      const color = getSpeciesColor(row.scientificName, theme);
       const baseline = layoutRow.baseline;
 
       const gen = d3Area<number>()
@@ -256,6 +257,10 @@
       tooltip = new ChartTooltip(chartContainer);
     }
   });
+
+  // Reference-count this chart so the shared species→color map clears when the
+  // last patterns chart unmounts (fresh colors per page view; no session growth).
+  onMount(() => registerChart());
 
   onDestroy(() => {
     tooltip?.destroy();

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/TimeOfDaySpeciesChart.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/TimeOfDaySpeciesChart.svelte
@@ -1,6 +1,6 @@
 <!-- Multi-Species Time of Day Chart -->
 <script lang="ts">
-  import { onDestroy } from 'svelte';
+  import { onMount, onDestroy } from 'svelte';
   import { select } from 'd3-selection';
   import { line as d3Line, curveMonotoneX } from 'd3-shape';
   import { max, scaleLinear } from 'd3';
@@ -12,7 +12,8 @@
   import { createLinearScale } from './utils/scales';
   import { createAxis, styleAxis, addAxisLabel, createHourAxisFormatter } from './utils/axes';
   import { ChartTooltip, addCrosshair, createLegend } from './utils/interactions';
-  import { generateSpeciesColors, getCurrentTheme, type ChartTheme } from './utils/theme';
+  import { getCurrentTheme, type ChartTheme } from './utils/theme';
+  import { getSpeciesColor, registerChart } from './utils/speciesColor';
 
   interface HourlyData {
     hour: number;
@@ -53,12 +54,10 @@
     if (!data.length) return [];
 
     const currentTheme = getCurrentTheme();
-    const colors = generateSpeciesColors(data.length, currentTheme);
 
-    return data.map((species, index) => ({
+    return data.map(species => ({
       ...species,
-      // eslint-disable-next-line security/detect-object-injection -- Safe: internal array access with controlled index
-      color: species.color || colors[index],
+      color: species.color ?? getSpeciesColor(species.species, currentTheme),
       visible: selectedSpecies.length === 0 || selectedSpecies.includes(species.species),
       // Visitor-locale display label. Computed here (inside the $derived) so the
       // repaint $effect that reads visibleData re-runs when the dictionary loads
@@ -379,6 +378,10 @@
       }
     }
   });
+
+  // Reference-count this chart so the shared species→color map clears when the
+  // last patterns chart unmounts (fresh colors per page view; no session growth).
+  onMount(() => registerChart());
 
   onDestroy(() => {
     tooltip?.destroy();

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/speciesColor.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/speciesColor.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getSpeciesColor, registerChart, resetSpeciesColors } from './speciesColor';
+import type { ChartTheme } from './theme';
+
+const theme = { background: '#ffffff' } as unknown as ChartTheme; // only background drives the palette
+
+describe('getSpeciesColor', () => {
+  beforeEach(() => resetSpeciesColors());
+
+  it('returns a stable color per species regardless of call order', () => {
+    const robinFirst = getSpeciesColor('Turdus migratorius', theme);
+    getSpeciesColor('Cardinalis cardinalis', theme);
+    const robinAgain = getSpeciesColor('Turdus migratorius', theme);
+    expect(robinAgain).toBe(robinFirst);
+  });
+
+  it('gives distinct colors to distinct species within palette size', () => {
+    expect(getSpeciesColor('A', theme)).not.toBe(getSpeciesColor('B', theme));
+  });
+
+  it('keeps the map while at least one chart remains registered', () => {
+    const unregA = registerChart();
+    const unregB = registerChart();
+    const aColor = getSpeciesColor('A', theme);
+    unregA(); // one chart still registered → map must NOT clear
+    expect(getSpeciesColor('A', theme)).toBe(aColor);
+    unregB();
+  });
+
+  it('clears the map when the last chart unregisters, restarting assignment', () => {
+    const unregister = registerChart();
+    const first = getSpeciesColor('A', theme); // palette[0]
+    getSpeciesColor('B', theme); // palette[1]
+    unregister(); // count → 0, map cleared
+    // A fresh species now takes palette[0] again, proving the map was cleared.
+    expect(getSpeciesColor('C', theme)).toBe(first);
+  });
+});

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/speciesColor.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/speciesColor.ts
@@ -1,0 +1,49 @@
+// Shared, page-scoped species→color mapping so the same bird keeps one color
+// across every chart on the page (who-sings-when, succession, time-of-day).
+// Colors assign first-seen and are distinct only up to the 12-color palette.
+// The map is reference-counted by the active charts (registerChart) and cleared
+// when the last one unmounts, so it does not grow across the SPA session and
+// each page view assigns colors fresh.
+// Limitation: first-seen ordering. Upgrade path if >12 species must stay distinct
+// on one page: seed the map from a canonical page-level species ordering.
+import { speciesPalette } from './theme';
+import type { ChartTheme } from './theme';
+
+const indexBySpecies = new Map<string, number>();
+// Number of mounted charts sharing the map; the map is cleared when it hits 0.
+let activeChartCount = 0;
+
+/** Stable palette color for a species (keyed by scientific name) in the current theme. */
+export function getSpeciesColor(scientificName: string, theme: ChartTheme): string {
+  const palette = speciesPalette(theme);
+  let idx = indexBySpecies.get(scientificName);
+  if (idx === undefined) {
+    idx = indexBySpecies.size % palette.length;
+    indexBySpecies.set(scientificName, idx);
+  }
+  // eslint-disable-next-line security/detect-object-injection -- idx is bounded by % palette.length
+  return palette[idx];
+}
+
+/**
+ * Register a chart as an active consumer of the shared color map. The map is
+ * cleared when the last registered chart unmounts, so it does not grow across
+ * the SPA session and each fresh page view restarts color assignment. Returns
+ * the unregister function; call it on unmount, e.g. `onMount(() => registerChart())`.
+ */
+export function registerChart(): () => void {
+  activeChartCount++;
+  return () => {
+    activeChartCount--;
+    if (activeChartCount <= 0) {
+      activeChartCount = 0;
+      indexBySpecies.clear();
+    }
+  };
+}
+
+/** Test-only: clear the assignment map and active-chart count between cases. */
+export function resetSpeciesColors(): void {
+  indexBySpecies.clear();
+  activeChartCount = 0;
+}

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/theme.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/theme.ts
@@ -270,20 +270,21 @@ function getColorLuminance(color: string): number {
 }
 
 /**
- * Generate species color palette based on theme
- * Using a curated palette for better visual distinction
+ * The ordered base species palette for the current theme (12 distinct hues).
+ * Extracted from generateSpeciesColors so callers that need a stable, indexable
+ * palette (e.g. a species->color identity map) can build on the same base
+ * colors rather than duplicating them.
  */
-export function generateSpeciesColors(count: number, theme: ChartTheme): string[] {
+export function speciesPalette(theme: ChartTheme): string[] {
   // Check if we're in dark mode using luminance calculation
-  const backgroundLuminance = getColorLuminance(theme.background);
-  const isDark = backgroundLuminance < 0.5;
+  const isDark = getColorLuminance(theme.background) < 0.5;
 
   // Adjust base opacity based on theme
   const baseOpacity = isDark ? 0.8 : 0.7;
 
   // Use a more diverse color palette for better distinction between species
   // These colors are carefully chosen to be distinguishable in both light and dark themes
-  const baseColors = [
+  return [
     `rgba(59, 130, 246, ${baseOpacity})`, // Blue
     `rgba(16, 185, 129, ${baseOpacity})`, // Green
     `rgba(245, 158, 11, ${baseOpacity})`, // Orange
@@ -297,6 +298,17 @@ export function generateSpeciesColors(count: number, theme: ChartTheme): string[
     `rgba(168, 85, 247, ${baseOpacity})`, // Purple-pink
     `rgba(34, 197, 94, ${baseOpacity})`, // Emerald
   ];
+}
+
+/**
+ * Generate species color palette based on theme
+ * Using a curated palette for better visual distinction
+ */
+export function generateSpeciesColors(count: number, theme: ChartTheme): string[] {
+  // Check if we're in dark mode using luminance calculation (needed below for
+  // the overflow opacity variations, kept in sync with speciesPalette's own).
+  const isDark = getColorLuminance(theme.background) < 0.5;
+  const baseColors = speciesPalette(theme);
 
   if (count <= baseColors.length) {
     return baseColors.slice(0, count);


### PR DESCRIPTION
## Summary

On the Activity Patterns page a species could appear in a different color on each chart, because every multi-species chart colored species by their index in that chart's own list (`generateSpeciesColors(count)[i]`), and each chart orders its subset differently. This introduces a shared, page-scoped color mapping keyed by species identity so the same bird keeps one color across Who-Sings-When, Acoustic Succession, and Time-of-Day.

Scope is deliberately same-page only (not project/DB-wide): only the species actually shown are colored (top-5/top-6 + up to 10 selected), which fits the existing 12-color palette.

## Changes

- Extract the base palette into `speciesPalette(theme)` in `theme.ts`; `generateSpeciesColors` now builds on it with no change to its output (including the >12 overflow path), so existing callers are unaffected.
- Add `getSpeciesColor(scientificName, theme)` in a new `speciesColor.ts`: a module-level first-seen `name → palette-index` map. It caches the palette index (not a resolved color string) so light/dark opacity stays correct.
- Point `SpeciesRidgeline`, `AcousticSuccessionChart`, and `TimeOfDaySpeciesChart` at the shared helper, keyed on each row's scientific name (marks and legends stay in sync).

## Testing

- [ ] Go tests pass (`task test`) — N/A, frontend-only change
- [x] Frontend tests pass (`task frontend-test`) — 180/180 d3 chart tests green; new helper unit test added
- [x] Linting passes (`npm run check:all`); `task frontend-build` OK
- [x] Manual/visual testing in the running app — pending maintainer confirmation (colors match across the three charts)
- [ ] Preflight quality gate — automated review requested from CodeRabbit + Gemini on this PR

## Preflight Status

Single concern (one fix). Frontend lint/typecheck/tests/build green. No i18n keys added, no secrets/PII. Go build/tests are N/A (frontend-only). Deep multi-reviewer analysis delegated to CodeRabbit + Gemini on this PR plus maintainer visual QA.

## Related

Addresses "the same species has different colors on different graphs" on the Activity Patterns page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Improvements**
  - Species colors are now consistent across analytics charts using a stable scientific-name mapping.
  - Legends and chart elements (bands/ridgelines/lines) render with matching per-species colors.
  - Theme-aware palette handling improves light vs. dark contrast.
  - Species color assignments are automatically cleared when the last related chart unmounts to avoid stale carryover.

- **Tests**
  - Added automated tests covering species color stability and registration/unregistration lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Release notes
- audience: user
- summary: A species now keeps the same color across all the Activity Patterns charts, so you can follow one bird between the ridgeline, succession and time-of-day views.
- feature: none
- breaking: none
- config: none
- schema: none
