### PR TITLE
fix(frontend): stop analytics charts clipping labels and series at plot edges

### DIFF
--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/BarChart.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/BarChart.svelte
@@ -52,11 +52,12 @@
   const TRANSITION_MS = 120;
   const CATEGORY_LABEL_ROTATION = -30;
   const ROTATED_CATEGORY_LABEL_OFFSET = 70;
-  // Clearance for the vertical chart's rotated value-axis title so it does not overlap the
-  // y-axis tick numbers. Worked from the widest realistic tick label ("300,000"-scale detection
-  // counts, ~60px at the 12px axis font) plus D3's default axisLeft tick gap
-  // (tickSizeInner 6 + tickPadding 3 = 9px) plus the rotated title's own ~13px glyph thickness
-  // (ascent + descent), each with a few px of buffer: 9 + 60 + 4 + 13 + 4 = 90.
+  // How far left of the value axis the rotated title's baseline sits (addAxisLabel places it at
+  // x = -offset, centered vertically). It must clear the widest realistic tick label
+  // ("300,000"-scale detection counts, ~60px at the 12px axis font) plus D3's default axisLeft
+  // tick gap (tickSizeInner 6 + tickPadding 3 = 9px), plus a few px of buffer and half the
+  // rotated title's ~13px glyph thickness: 9 + 60 + 4 + ~3 = 76. VERTICAL_MARGIN.left (90) adds
+  // the title's remaining outer half-thickness and edge buffer on top of this offset.
   const VERTICAL_VALUE_AXIS_LABEL_OFFSET = 76;
 
   // Margins per orientation. Horizontal bars put long category names on the

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/BarChart.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/BarChart.svelte
@@ -10,6 +10,7 @@
   import { createAxis, styleAxis, addAxisLabel, createGridLines } from './utils/axes';
   import { ChartTooltip } from './utils/interactions';
   import { generateSpeciesColors, type ChartRenderContext } from './utils/theme';
+  import { fitTextNode } from './utils/labels';
 
   export interface BarChartDatum {
     label: string;
@@ -59,6 +60,9 @@
   // rotated title's ~13px glyph thickness: 9 + 60 + 4 + ~3 = 76. VERTICAL_MARGIN.left (90) adds
   // the title's remaining outer half-thickness and edge buffer on top of this offset.
   const VERTICAL_VALUE_AXIS_LABEL_OFFSET = 76;
+  // D3's default axisLeft tick gap (tickSizeInner 6 + tickPadding 3): where an end-anchored tick
+  // label's right edge sits, so margin.left minus this is the room a category name actually has.
+  const AXIS_TICK_GAP = 9;
 
   // Margins per orientation. Horizontal bars put long category names on the
   // left axis, so widen the left margin to avoid clipping. Vertical bars rotate
@@ -125,6 +129,19 @@
 
       styleAxis(xAxisGroup, theme.axis);
       styleAxis(yAxisGroup, theme.axis);
+
+      // Category names are end-anchored at the tick gap and grow left into the margin, so a name
+      // wider than the margin is clipped by the viewport. Fit each to the margin by measured width.
+      // Must run after styleAxis, which applies the font the measurement depends on.
+      yAxisGroup.selectAll<globalThis.SVGTextElement, AxisDomain>('.tick text').each(function (d) {
+        fitTextNode(this, String(d), HORIZONTAL_MARGIN.left - AXIS_TICK_GAP);
+      });
+      // Full name on the tick group (not the <text>, whose textContent must stay the visible label)
+      // so an ellipsized name is still recoverable via hover, touch long-press, and assistive tech.
+      yAxisGroup
+        .selectAll<globalThis.SVGGElement, AxisDomain>('.tick')
+        .append('title')
+        .text(d => String(d));
 
       if (valueAxisLabel) {
         addAxisLabel(

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/BarChart.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/BarChart.svelte
@@ -52,12 +52,20 @@
   const TRANSITION_MS = 120;
   const CATEGORY_LABEL_ROTATION = -30;
   const ROTATED_CATEGORY_LABEL_OFFSET = 70;
+  // Clearance for the vertical chart's rotated value-axis title so it does not overlap the
+  // y-axis tick numbers. Worked from the widest realistic tick label ("300,000"-scale detection
+  // counts, ~60px at the 12px axis font) plus D3's default axisLeft tick gap
+  // (tickSizeInner 6 + tickPadding 3 = 9px) plus the rotated title's own ~13px glyph thickness
+  // (ascent + descent), each with a few px of buffer: 9 + 60 + 4 + 13 + 4 = 90.
+  const VERTICAL_VALUE_AXIS_LABEL_OFFSET = 76;
 
   // Margins per orientation. Horizontal bars put long category names on the
   // left axis, so widen the left margin to avoid clipping. Vertical bars rotate
-  // their category labels along the bottom, so add bottom room for them.
+  // their category labels along the bottom, so add bottom room for them, and
+  // widen the left margin so the rotated value-axis title clears wide tick numbers
+  // (see VERTICAL_VALUE_AXIS_LABEL_OFFSET for the math).
   const HORIZONTAL_MARGIN = { top: 20, right: 20, bottom: 65, left: 130 };
-  const VERTICAL_MARGIN = { top: 20, right: 20, bottom: 90, left: 60 };
+  const VERTICAL_MARGIN = { top: 20, right: 20, bottom: 90, left: 90 };
   const margin = $derived(orientation === 'horizontal' ? HORIZONTAL_MARGIN : VERTICAL_MARGIN);
 
   let tooltip: ChartTooltip | null = null;
@@ -209,7 +217,7 @@
           {
             text: valueAxisLabel,
             orientation: 'left',
-            offset: AXIS_LABEL_OFFSET + 5,
+            offset: VERTICAL_VALUE_AXIS_LABEL_OFFSET,
             width: innerWidth,
             height: innerHeight,
           },

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/LineChart.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/LineChart.svelte
@@ -154,9 +154,13 @@
     const xTickNodes = xAxisGroup.selectAll<globalThis.SVGGElement, Date>('.tick').nodes();
     if (xTickNodes.length > 0) {
       select(xTickNodes[0]).select('text').style('text-anchor', 'start');
-      select(xTickNodes[xTickNodes.length - 1])
-        .select('text')
-        .style('text-anchor', 'end');
+      // Only anchor the last tick to 'end' when it's a distinct node — a lone tick
+      // (zero-width domain) must stay 'start' or it shifts left off the origin.
+      if (xTickNodes.length > 1) {
+        select(xTickNodes[xTickNodes.length - 1])
+          .select('text')
+          .style('text-anchor', 'end');
+      }
     }
 
     if (dateAxisLabel) {

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/LineChart.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/LineChart.svelte
@@ -15,6 +15,7 @@
     addAxisLabel,
     createDateAxisFormatter,
     pickDateRangeBucket,
+    boundaryDateTicks,
   } from './utils/axes';
   import { ChartTooltip, addCrosshair, createLegend } from './utils/interactions';
   import { generateSpeciesColors, type ChartRenderContext } from './utils/theme';
@@ -71,6 +72,9 @@
   const TRANSITION_MS = 150;
   const LEGEND_WIDTH = 150;
 
+  // Per-instance clip-path id. Math.random (not crypto) so it works on plain HTTP.
+  const clipId = `line-plot-clip-${Math.random().toString(36).slice(2, 10)}`;
+
   let tooltip: ChartTooltip | null = null;
   let chartContainer: HTMLDivElement | null = null;
 
@@ -118,12 +122,15 @@
     const span = xScale.domain();
     const dateTick = createDateAxisFormatter(pickDateRangeBucket([span[0], span[1]]));
 
+    const xTickCount = Math.min(MAX_X_TICKS, Math.max(2, Math.floor(innerWidth / TICK_SPACING_PX)));
     const xAxis = createAxis({
       scale: xScale,
       orientation: 'bottom',
       tickFormat: (d: AxisDomain) => dateTick(d as Date),
-      tickCount: Math.min(MAX_X_TICKS, Math.max(2, Math.floor(innerWidth / TICK_SPACING_PX))),
     });
+    // Always label the domain endpoints (esp. the most recent day at the right
+    // edge, which d3's nice ticks otherwise drop). See boundaryDateTicks.
+    xAxis.tickValues(boundaryDateTicks(xScale, xTickCount));
     const yAxis = createAxis({
       scale: yScale,
       orientation: 'left',
@@ -140,6 +147,17 @@
 
     styleAxis(xAxisGroup, theme.axis);
     styleAxis(yAxisGroup, theme.axis);
+
+    // Keep the forced boundary labels inside the plot: anchor the first label to
+    // its start and the last to its end so neither overflows the side margins
+    // (the container clips overflow, so a centered edge label loses characters).
+    const xTickNodes = xAxisGroup.selectAll<globalThis.SVGGElement, Date>('.tick').nodes();
+    if (xTickNodes.length > 0) {
+      select(xTickNodes[0]).select('text').style('text-anchor', 'start');
+      select(xTickNodes[xTickNodes.length - 1])
+        .select('text')
+        .style('text-anchor', 'end');
+    }
 
     if (dateAxisLabel) {
       addAxisLabel(
@@ -183,7 +201,22 @@
       .y(p => yScale(p.value))
       .curve(curveMonotoneX);
 
-    const seriesGroup = chartGroup.append('g').attr('class', 'series');
+    // Clip the series to the plot area so points/line for dates outside the fixed
+    // domain can't draw over the Y-axis and its label (or spill past the right
+    // edge). Padded vertically so edge points/hover aren't trimmed top or bottom.
+    chartGroup
+      .append('clipPath')
+      .attr('id', clipId)
+      .append('rect')
+      .attr('x', 0)
+      .attr('y', -POINT_HOVER_RADIUS)
+      .attr('width', innerWidth)
+      .attr('height', innerHeight + 2 * POINT_HOVER_RADIUS);
+
+    const seriesGroup = chartGroup
+      .append('g')
+      .attr('class', 'series')
+      .attr('clip-path', `url(#${clipId})`);
 
     resolved.forEach(s => {
       const group = seriesGroup.append('g').attr('class', 'series-group').attr('data-series', s.id);

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/LineChart.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/LineChart.test.ts
@@ -66,6 +66,39 @@ describe('LineChart', () => {
     expect(legend).toBeFalsy();
   });
 
+  it('labels the domain endpoints and anchors edge labels inward', async () => {
+    // Jan 1..15 spans two weeks, so d3's nice ticks would otherwise stop short of
+    // the last day. The endpoint (Jan 15 → "Jan 15") must be labeled.
+    const series = [
+      makeSeries(
+        'a',
+        Array.from({ length: 15 }, (_, i) => i + 1)
+      ),
+    ];
+    const { container } = render(LineChart, { props: { series } });
+    await Promise.resolve();
+
+    const xTicks = Array.from(container.querySelectorAll('.x-axis .tick text'));
+    expect(xTicks.length).toBeGreaterThan(0);
+    expect(xTicks[xTicks.length - 1].textContent).toBe('Jan 15');
+    // Edge labels are anchored inward so they cannot clip the container margins.
+    expect((xTicks[0] as SVGTextElement).style.textAnchor).toBe('start');
+    expect((xTicks[xTicks.length - 1] as SVGTextElement).style.textAnchor).toBe('end');
+  });
+
+  it('clips the series to the plot area so it cannot draw over the axes', async () => {
+    const series = [makeSeries('a', [1, 2, 3])];
+    const { container } = render(LineChart, { props: { series } });
+    await Promise.resolve();
+
+    const seriesGroup = container.querySelector('g.series');
+    const clip = seriesGroup?.getAttribute('clip-path');
+    expect(clip).toMatch(/^url\(#.+\)$/);
+    // The referenced clipPath exists and defines a rect (the plot area).
+    const id = clip?.slice('url(#'.length, -1) ?? '';
+    expect(container.querySelector(`clipPath#${id} rect`)).toBeTruthy();
+  });
+
   it('sets an accessible label on the chart container', () => {
     const series = [makeSeries('a', [1])];
     const { container } = render(LineChart, {

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/NewSpeciesTimelineChart.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/NewSpeciesTimelineChart.svelte
@@ -18,6 +18,7 @@
   } from './utils/axes';
   import { ChartTooltip } from './utils/interactions';
   import { generateSpeciesColors, type ChartRenderContext } from './utils/theme';
+  import { fitTextNode } from './utils/labels';
 
   export interface NewSpeciesDatum {
     commonName: string;
@@ -67,6 +68,9 @@
   const MAX_X_TICKS = 8;
   const TICK_SPACING_PX = 80;
   const X_AXIS_LABEL_OFFSET = 35;
+  // D3's default axisLeft tick gap (tickSizeInner 6 + tickPadding 3): where an end-anchored tick
+  // label's right edge sits, so MARGIN.left minus this is the room a species name actually has.
+  const AXIS_TICK_GAP = 9;
   const BAND_PADDING = 0.3;
   const MARKER_OPACITY = 0.85;
   const MARKER_HOVER_OPACITY = 1;
@@ -153,6 +157,19 @@
 
     styleAxis(xAxisGroup, theme.axis);
     styleAxis(yAxisGroup, theme.axis);
+
+    // Species names are end-anchored at the tick gap and grow left into the margin, so a name wider
+    // than the margin is clipped by the viewport. Fit each to the margin by measured width. Must run
+    // after styleAxis, which applies the font the measurement depends on.
+    yAxisGroup.selectAll<globalThis.SVGTextElement, AxisDomain>('.tick text').each(function (d) {
+      fitTextNode(this, keyToDisplay.get(String(d)) ?? String(d), MARGIN.left - AXIS_TICK_GAP);
+    });
+    // Full name on the tick group (not the <text>, whose textContent must stay the visible label) so
+    // an ellipsized name is still recoverable via hover, touch long-press, and assistive tech.
+    yAxisGroup
+      .selectAll<globalThis.SVGGElement, AxisDomain>('.tick')
+      .append('title')
+      .text(d => keyToDisplay.get(String(d)) ?? String(d));
 
     if (dateAxisLabel) {
       addAxisLabel(

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/SeasonalHeatmap.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/SeasonalHeatmap.svelte
@@ -274,17 +274,12 @@
 
     // Re-anchor the whole group so the "More" label's measured right edge lands within
     // innerWidth instead of the hard-coded `innerWidth - legendWidth`. getComputedTextLength()
-    // returns a real width in browsers but jsdom (unit tests) does not implement the method at
-    // all, so guard with a typeof check rather than just a null check -- calling straight through
-    // would throw `moreNode.getComputedTextLength is not a function` under jsdom. Falling back to
-    // 0 there reproduces the original flush-right placement, so tests are unaffected. The "Less"
-    // label (end-anchored at x = -6) stays inside the chart because the group only ever moves
-    // further left, never right.
+    // returns a real width in browsers; jsdom (unit tests) does not implement the method, so the
+    // optional call short-circuits and we fall back to 0, reproducing the original flush-right
+    // placement (tests unaffected). The "Less" label (end-anchored at x = -6) stays inside because
+    // the group only ever moves further left, never right.
     const moreNode = moreLabel.node();
-    const moreWidth =
-      moreNode && typeof moreNode.getComputedTextLength === 'function'
-        ? moreNode.getComputedTextLength()
-        : 0;
+    const moreWidth = moreNode?.getComputedTextLength?.() ?? 0;
     const groupX = Math.max(0, innerWidth - legendWidth - 6 - moreWidth);
     legend.attr('transform', `translate(${groupX},${-LEGEND_SWATCH - 6})`);
   }

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/SeasonalHeatmap.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/SeasonalHeatmap.svelte
@@ -275,9 +275,10 @@
     // Re-anchor the whole group so the "More" label's measured right edge lands within
     // innerWidth instead of the hard-coded `innerWidth - legendWidth`. getComputedTextLength()
     // returns a real width in browsers; jsdom (unit tests) does not implement the method, so the
-    // optional call short-circuits and we fall back to 0, reproducing the original flush-right
-    // placement (tests unaffected). The "Less" label (end-anchored at x = -6) stays inside because
-    // the group only ever moves further left, never right.
+    // optional call short-circuits to 0. With moreWidth = 0 the formula parks the label's
+    // (zero-width) right edge exactly at innerWidth -- 6px left of the original swatch-flush
+    // placement, which is harmless and keeps tests stable. The "Less" label (end-anchored at
+    // x = -6) stays inside because the group only ever moves further left, never right.
     const moreNode = moreLabel.node();
     const moreWidth = moreNode?.getComputedTextLength?.() ?? 0;
     const groupX = Math.max(0, innerWidth - legendWidth - 6 - moreWidth);

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/SeasonalHeatmap.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/SeasonalHeatmap.svelte
@@ -225,6 +225,11 @@
   }
 
   // Compact gradient legend in the top margin: faint -> solid swatches with min/max labels.
+  //
+  // The group is provisionally placed at `innerWidth - legendWidth` (flush with the inner-right
+  // edge), then shifted further left once the "More {max}" label's real width is known -- that
+  // label sits past the swatches at `legendWidth + 6`, so left-aligning the group alone left its
+  // right edge running past `innerWidth` and into the 16px right margin, clipping. See PR brief.
   function drawLegend(context: NonNullable<typeof chartContext>, colorMax: number): void {
     const { chartGroup, innerWidth, theme } = context;
     const legendWidth = LEGEND_STEPS * LEGEND_SWATCH;
@@ -258,7 +263,7 @@
       .style('fill', theme.axis.color)
       .style('font-size', theme.axis.fontSize)
       .text(t('analytics.advanced.charts.heatmap.legendLess'));
-    legend
+    const moreLabel = legend
       .append('text')
       .attr('x', legendWidth + 6)
       .attr('y', LEGEND_SWATCH - 3)
@@ -266,6 +271,22 @@
       .style('fill', theme.axis.color)
       .style('font-size', theme.axis.fontSize)
       .text(t('analytics.advanced.charts.heatmap.legendMore', { max: colorMax }));
+
+    // Re-anchor the whole group so the "More" label's measured right edge lands within
+    // innerWidth instead of the hard-coded `innerWidth - legendWidth`. getComputedTextLength()
+    // returns a real width in browsers but jsdom (unit tests) does not implement the method at
+    // all, so guard with a typeof check rather than just a null check -- calling straight through
+    // would throw `moreNode.getComputedTextLength is not a function` under jsdom. Falling back to
+    // 0 there reproduces the original flush-right placement, so tests are unaffected. The "Less"
+    // label (end-anchored at x = -6) stays inside the chart because the group only ever moves
+    // further left, never right.
+    const moreNode = moreLabel.node();
+    const moreWidth =
+      moreNode && typeof moreNode.getComputedTextLength === 'function'
+        ? moreNode.getComputedTextLength()
+        : 0;
+    const groupX = Math.max(0, innerWidth - legendWidth - 6 - moreWidth);
+    legend.attr('transform', `translate(${groupX},${-LEGEND_SWATCH - 6})`);
   }
 
   $effect(() => {

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesRidgeline.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesRidgeline.svelte
@@ -25,6 +25,7 @@
   import { createAxis, styleAxis, addAxisLabel, createHourAxisFormatter } from './utils/axes';
   import { ChartTooltip } from './utils/interactions';
   import { generateSpeciesColors, type ChartTheme } from './utils/theme';
+  import { fitTextNode } from './utils/labels';
   import {
     ridgelineLayout,
     peakIndex,
@@ -75,8 +76,10 @@
   const RIDGE_FILL_OPACITY = 0.55; // translucent so overlapping ridges blend
   const RIDGE_STROKE_WIDTH = 1.5;
   const RIDGE_STROKE_WIDTH_HOVER = 2.5;
-  const LABEL_MAX_CHARS = 18;
   const LABEL_GAP = 10; // px between the left edge and a row label
+  // Labels are end-anchored at x = -LABEL_GAP, so they grow left into the margin; this is all the
+  // room they have before the SVG viewport clips them.
+  const LABEL_BUDGET_PX = MARGIN.left - LABEL_GAP;
   const X_AXIS_LABEL_OFFSET = 34;
   const MIN_DENSITY_DOMAIN = 1e-6; // floor so an all-zero set never yields a degenerate amp domain
 
@@ -120,10 +123,6 @@
     innerHeight: number;
     theme: ChartTheme;
   } | null>(null);
-
-  function truncateLabel(label: string): string {
-    return label.length > LABEL_MAX_CHARS ? `${label.slice(0, LABEL_MAX_CHARS - 1)}…` : label;
-  }
 
   // Force a palette color to full opacity for the crisp ridge top line; the fill keeps the
   // translucent original so overlaps blend. d3-color robustly parses the rgba palette strings and
@@ -229,7 +228,8 @@
           tooltip?.hide();
         });
 
-      // Row label in the left margin, anchored at the baseline; full name in a native <title>.
+      // Row label in the left margin, anchored at the baseline; fitted to the margin by measured
+      // width, with the full name in a native <title> (appended after fitting, which sets the text).
       const labelText = group
         .append('text')
         .attr('class', 'ridge-label')
@@ -239,8 +239,8 @@
         .attr('dominant-baseline', 'middle')
         .style('fill', theme.text)
         .style('font-size', theme.axis.fontSize)
-        .style('font-family', theme.axis.fontFamily)
-        .text(truncateLabel(row.label));
+        .style('font-family', theme.axis.fontFamily);
+      fitTextNode(labelText.node(), row.label, LABEL_BUDGET_PX);
       labelText.append('title').text(row.label);
     }
   }

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/TimeOfDaySpeciesChart.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/TimeOfDaySpeciesChart.svelte
@@ -41,6 +41,9 @@
   // all-zero range keeps zero at the bottom) plus a fixed headroom above the max.
   const MIN_Y_DOMAIN_MAX = 1;
   const Y_AXIS_HEADROOM = 1.1;
+  // Width reserved for the legend, inset from the plot's right edge. Doubles as the label budget:
+  // anything wider would overflow the plot rather than wrap.
+  const LEGEND_WIDTH = 150;
 
   // Component state
   let tooltip: ChartTooltip | null = null;
@@ -331,8 +334,11 @@
     if (legendItems.length > 0) {
       createLegend(chartGroup, {
         items: legendItems,
-        position: { x: innerWidth - 150, y: 20 },
+        position: { x: innerWidth - LEGEND_WIDTH, y: 20 },
         itemHeight: 20,
+        // The legend is inset from the right edge by exactly its own width, so this is also the room
+        // a label has before it would overflow the plot; long species names are ellipsized to fit.
+        maxLabelWidth: LEGEND_WIDTH,
         onToggle: (id, visible) => {
           // Toggle visibility of the corresponding line and points
           chartGroup

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/YearOverYearChart.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/YearOverYearChart.svelte
@@ -47,10 +47,18 @@
   let { data, width = 800, height = 400, ariaLabel }: Props = $props();
 
   // Layout / behavior constants.
-  const MARGIN = { top: 24, right: 18, bottom: 48, left: 60 };
+  // MARGIN.left and Y_AXIS_LABEL_OFFSET are sized together so the rotated "axisCount" title
+  // clears wide y-axis tick numbers (cumulative counts render as plain integers, no thousands
+  // separator, up to 6 digits for a very active station's yearly total: ~45px at the 12px axis
+  // font). D3's default axisLeft tick gap (tickSizeInner 6 + tickPadding 3) adds 9px, and the
+  // rotated title itself is ~13px "thick" (ascent + descent); a few px of buffer on each side
+  // gives 9 + 45 + 4 + 13 + 4 = 75, rounded up to 78 for margin.left, with an offset (64) that
+  // keeps the title's pivot centered in that clearance. See BarChart.svelte's analogous
+  // VERTICAL_VALUE_AXIS_LABEL_OFFSET for the same derivation against comma-formatted counts.
+  const MARGIN = { top: 24, right: 18, bottom: 48, left: 78 };
   const MAX_X_TICKS = 8;
   const X_AXIS_LABEL_OFFSET = 38;
-  const Y_AXIS_LABEL_OFFSET = 46;
+  const Y_AXIS_LABEL_OFFSET = 64;
   const BAND_OPACITY = 0.15;
   const DOT_RADIUS = 3;
   const FOCUS_RADIUS = 4;

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/axes.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/axes.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { scaleTime } from 'd3-scale';
+
+import { boundaryDateTicks } from './axes';
+
+describe('boundaryDateTicks', () => {
+  it('always includes the exact domain start and end', () => {
+    const start = new Date(2024, 5, 18); // spans a month → weekly nice ticks
+    const end = new Date(2024, 6, 18);
+    const scale = scaleTime().domain([start, end]).range([0, 1000]);
+
+    const ticks = boundaryDateTicks(scale, 8);
+
+    expect(ticks[0]).toEqual(start);
+    expect(ticks[ticks.length - 1]).toEqual(end);
+  });
+
+  it('drops nice ticks that hug an endpoint so labels do not overlap', () => {
+    const start = new Date(2024, 5, 18);
+    const end = new Date(2024, 6, 18);
+    const scale = scaleTime().domain([start, end]).range([0, 1000]);
+
+    // A large gap threshold removes every interior nice tick, leaving only the
+    // two forced endpoints.
+    const ticks = boundaryDateTicks(scale, 8, 10_000);
+
+    expect(ticks).toHaveLength(2);
+    expect(ticks[0]).toEqual(start);
+    expect(ticks[1]).toEqual(end);
+  });
+
+  it('collapses a zero-width domain to a single tick', () => {
+    const day = new Date(2024, 5, 18);
+    const scale = scaleTime().domain([day, day]).range([0, 1000]);
+
+    expect(boundaryDateTicks(scale, 8)).toEqual([day]);
+  });
+});

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/axes.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/axes.ts
@@ -226,6 +226,34 @@ export function createDateAxisFormatter(
 }
 
 /**
+ * Tick values for a time axis that always include the domain endpoints.
+ *
+ * d3's "nice" time ticks land on calendar boundaries, and any boundary outside
+ * the domain is dropped — so the most recent day (the domain max) is often left
+ * unlabeled at the right edge, and a boundary that falls just inside the edge
+ * renders a label that clips against the plot's narrow side margin. This returns
+ * d3's nice ticks with the exact domain start/end appended, dropping any nice
+ * tick within `minEdgeGapPx` of an endpoint so the forced boundary labels don't
+ * overlap their neighbour.
+ */
+export function boundaryDateTicks(
+  scale: ScaleTime<number, number>,
+  tickCount: number,
+  minEdgeGapPx = 48
+): Date[] {
+  const [start, end] = scale.domain();
+  if (start.getTime() === end.getTime()) return [start];
+
+  const xStart = scale(start);
+  const xEnd = scale(end);
+  const inner = scale.ticks(tickCount).filter(t => {
+    const x = scale(t);
+    return x - xStart >= minEdgeGapPx && xEnd - x >= minEdgeGapPx;
+  });
+  return [start, ...inner, end];
+}
+
+/**
  * Create grid lines for a chart
  */
 export function createGridLines(

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/interactions.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/interactions.ts
@@ -1,6 +1,11 @@
 // D3 interaction utilities for analytics charts
 import * as d3 from 'd3';
 
+import { fitTextNode } from './labels';
+
+/** Where a legend label starts, clearing the 12px color swatch at x = 0 plus a 6px gap. */
+const LEGEND_LABEL_X = 18;
+
 /**
  * Escape a string for safe interpolation into tooltip HTML.
  * The ampersand must be replaced first so the entities produced by the other
@@ -329,6 +334,11 @@ export function createLegend(
     position: { x: number; y: number };
     itemHeight: number;
     onToggle?: (id: string, visible: boolean) => void;
+    /**
+     * Total width reserved for the legend, measured from `position.x`. Labels wider than the room
+     * left after the swatch are ellipsized to fit. Omit to let labels run at full width.
+     */
+    maxLabelWidth?: number;
   }
 ): void {
   const legend = container
@@ -371,9 +381,9 @@ export function createLegend(
     .style('opacity', d => (d.visible ? 1 : 0.3));
 
   // Labels
-  legendItems
+  const labels = legendItems
     .append('text')
-    .attr('x', 18)
+    .attr('x', LEGEND_LABEL_X)
     .attr('y', 0)
     .attr('dy', '0.32em')
     .style('font-size', '12px')
@@ -381,4 +391,15 @@ export function createLegend(
     .style('fill', 'currentColor')
     .style('opacity', d => (d.visible ? 1 : 0.5))
     .text(d => d.label);
+
+  // Labels are start-anchored and grow right, so a long one runs past the chart's right edge and is
+  // clipped by the viewport. Fit each to the caller's reserved width, keeping the full label in a
+  // <title> on the item group so an ellipsized name stays recoverable.
+  if (config.maxLabelWidth !== undefined) {
+    const budget = config.maxLabelWidth - LEGEND_LABEL_X;
+    labels.each(function (d) {
+      fitTextNode(this, d.label, budget);
+    });
+    legendItems.append('title').text(d => d.label);
+  }
 }

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/labels.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/labels.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { truncateToWidth } from './labels';
+
+/**
+ * Fake proportional font: 10px for a wide glyph ('W'/'M'), 4px for a narrow one ('i'/'l'), 6px
+ * otherwise. Mirrors the property that makes character-count truncation wrong — two strings of
+ * equal length can differ in rendered width.
+ */
+function measureProportional(text: string): number {
+  let total = 0;
+  for (const ch of text) {
+    if ('WM'.includes(ch)) total += 10;
+    else if ('il'.includes(ch)) total += 4;
+    else total += 6;
+  }
+  return total;
+}
+
+describe('truncateToWidth', () => {
+  it('returns the text unchanged when it already fits', () => {
+    expect(truncateToWidth('Robin', 100, measureProportional)).toBe('Robin');
+  });
+
+  it('returns the text unchanged when it exactly fills the budget', () => {
+    // 'Robin' = 5 narrow-ish glyphs: R,o,b,n = 6 each, i = 4 -> 28px.
+    expect(measureProportional('Robin')).toBe(28);
+    expect(truncateToWidth('Robin', 28, measureProportional)).toBe('Robin');
+  });
+
+  it('truncates with an ellipsis and stays within the budget', () => {
+    const result = truncateToWidth('Black-crowned Night-Heron', 60, measureProportional);
+
+    expect(result).not.toBe('Black-crowned Night-Heron');
+    expect(result.endsWith('…')).toBe(true);
+    expect(measureProportional(result)).toBeLessThanOrEqual(60);
+  });
+
+  it('keeps the widest prefix that fits — one more character would overflow', () => {
+    const result = truncateToWidth('Black-crowned Night-Heron', 60, measureProportional);
+    const oneMore = 'Black-crowned Night-Heron'.slice(0, result.length) + '…';
+
+    expect(measureProportional(oneMore)).toBeGreaterThan(60);
+  });
+
+  /**
+   * The regression this whole module exists for: equal-length names truncated by character count
+   * would produce equal-length output, but a wide-glyph name must lose more characters to fit the
+   * same pixel budget.
+   */
+  it('drops more characters from a wide-glyph name than a narrow one of equal length', () => {
+    const wide = 'WWWWWWWWWWWW';
+    const narrow = 'iiiiiiiiiiii';
+    expect(wide).toHaveLength(narrow.length);
+
+    const wideFitted = truncateToWidth(wide, 50, measureProportional);
+    const narrowFitted = truncateToWidth(narrow, 50, measureProportional);
+
+    expect(measureProportional(wideFitted)).toBeLessThanOrEqual(50);
+    expect(measureProportional(narrowFitted)).toBeLessThanOrEqual(50);
+    expect(wideFitted.length).toBeLessThan(narrowFitted.length);
+  });
+
+  it('returns an empty string when not even an ellipsis fits', () => {
+    expect(truncateToWidth('Robin', 3, measureProportional)).toBe('');
+  });
+
+  it('returns an empty string for a non-positive budget', () => {
+    expect(truncateToWidth('Robin', 0, measureProportional)).toBe('');
+    expect(truncateToWidth('Robin', -10, measureProportional)).toBe('');
+  });
+
+  it('handles an empty string without measuring', () => {
+    const measure = vi.fn(measureProportional);
+    expect(truncateToWidth('', 100, measure)).toBe('');
+    expect(measure).not.toHaveBeenCalled();
+  });
+
+  it('bisects rather than walking every prefix', () => {
+    const measure = vi.fn(measureProportional);
+    const long = 'A'.repeat(500);
+
+    truncateToWidth(long, 100, measure);
+
+    // Linear scanning would measure ~500 times; log2(500) ≈ 9, plus the two upfront checks.
+    expect(measure.mock.calls.length).toBeLessThan(20);
+  });
+});

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/labels.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/labels.ts
@@ -1,0 +1,68 @@
+/**
+ * Pixel-accurate label fitting for chart text drawn into a fixed-size margin or legend slot.
+ *
+ * Charts place species names into a fixed pixel budget (a left margin, a legend column). Truncating
+ * by character count cannot honor that budget: a proportional font renders "Willow Warbler" and
+ * "WWWWWWWWWWWWWW" at very different widths, so a char-capped label still overflows and is clipped
+ * by the SVG viewport. These helpers cap by measured width instead.
+ */
+
+const ELLIPSIS = '…';
+
+/**
+ * Longest prefix of `text` that fits `maxPx`, with an ellipsis appended when anything was dropped.
+ *
+ * `measure` returns the rendered width of a candidate string. Assumes width grows monotonically
+ * with prefix length (true for the LTR, non-combining species names these charts draw), which lets
+ * the search bisect instead of walking every prefix.
+ *
+ * Returns the full text when it already fits, and an empty string when the budget cannot even hold
+ * a lone ellipsis — callers get "no label" rather than a stray glyph over the plot.
+ */
+export function truncateToWidth(
+  text: string,
+  maxPx: number,
+  measure: (_candidate: string) => number
+): string {
+  if (text === '' || maxPx <= 0) return '';
+  if (measure(text) <= maxPx) return text;
+  if (measure(ELLIPSIS) > maxPx) return '';
+
+  // Bisect on prefix length: the widest k where prefix(k) + ellipsis still fits. lo always fits
+  // (the ellipsis alone was checked above), hi never does, so the loop converges on lo = answer.
+  let lo = 0;
+  let hi = text.length;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    if (measure(text.slice(0, mid) + ELLIPSIS) <= maxPx) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return text.slice(0, lo) + ELLIPSIS;
+}
+
+/**
+ * Fits an already-rendered SVG <text> to `maxPx` in place, ellipsizing it if needed.
+ *
+ * Sets the node's text content, so call it before attaching any <title> child. Attaching the full
+ * name is the caller's job: axis ticks hang it on the enclosing `<g class="tick">` rather than the
+ * <text>, which keeps the tick's own textContent equal to the visible label.
+ *
+ * Measurement needs a real layout engine. jsdom (unit tests) does not implement
+ * getComputedTextLength, so there the node keeps its full text and this is a no-op by design — the
+ * truncation logic is covered by truncateToWidth's tests, and the pixel fit is verified in a
+ * browser.
+ */
+export function fitTextNode(node: SVGTextElement | null, full: string, maxPx: number): void {
+  if (!node) return;
+
+  node.textContent = full;
+  if (typeof node.getComputedTextLength !== 'function') return;
+
+  node.textContent = truncateToWidth(full, maxPx, candidate => {
+    node.textContent = candidate;
+    return node.getComputedTextLength();
+  });
+}


### PR DESCRIPTION
## Summary

Several analytics D3 charts clipped content at their plot edges: long species names were cut off, the Detection Trends x-axis never labelled the most recent day, and that same line chart drew its series over the Y-axis (and its rotated label) for points near/outside the domain. All changes are layout/rendering-only (text fitting, tick placement, clip-path) — no data, color, or scale changes.

## Changes

**Species-name label fitting** (`utils/labels.ts`, new)

- `truncateToWidth` / `fitTextNode` measure the real rendered text width and truncate with an ellipsis to a pixel budget. Both are no-ops under jsdom (which doesn't implement `getComputedTextLength`), so unit tests assert the pure helper.
- `BarChart` (Top 10 Species) and `NewSpeciesTimelineChart` (New Species Detected): left y-axis tick names now fit the left margin; the full name is preserved in a `<title>` tooltip.
- `SpeciesRidgeline` (Who Sings When): row labels fit the left-margin budget instead of clipping.
- `TimeOfDaySpeciesChart` legend + `createLegend` (`utils/interactions.ts`): legend labels fit a configurable max width.

**Detection Trends line chart** (`LineChart.svelte`, `utils/axes.ts`)

- `boundaryDateTicks()` forces x-axis ticks at both domain endpoints, so the most recent day is always labelled — d3's "nice" ticks land on calendar boundaries and drop any that fall outside the domain, leaving the right edge blank. Nice ticks that hug an endpoint are dropped so the forced boundary labels don't overlap.
- The first/last tick labels are anchored inward (`start`/`end`) so they don't clip the narrow side margins.
- The series group is clipped to the plot area, so the line/points for dates outside the fixed `[start, end]` domain can no longer draw over the Y-axis and its label (or spill past the right edge).

## Testing

- [x] Frontend tests pass — chart suite green; adds `utils/axes.test.ts` and `utils/labels.test.ts`, extends `LineChart.test.ts`.
- [x] `npm run check:all` green (format, lint, css, typecheck, ast).
- [ ] Go tests — N/A, frontend-only change.
- [x] Manual/visual QA recommended: Summary → Detection Trends (recent-day date label + line vs. Y-axis), Top 10 Species / New Species Detected / Who Sings When (long names), Time-of-Day legend.

## Related

Addresses reported edge clipping of species names (Top 10, New Species Detected, Who Sings When), the Detection Patterns by Time of Day legend, and the Detection Trends date axis + series line overlapping the Y-axis.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated analytics charts to reduce clipping/overflow for axis labels, legends, and plotted series by fitting text to available space and standardizing legend width.
  - Time-axis ticks now keep exact domain endpoints visible with safer boundary label placement.
  - Added plot-area clipping for line charts to prevent series from spilling into margins.
  - Adjusted vertical chart spacing and legend “More” positioning to improve alignment.

- **Tests**
  - Added/expanded coverage for boundary tick generation, pixel-accurate label fitting, endpoint alignment, and plot-area clipping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Release notes
- audience: user
- summary: Analytics charts no longer clip axis labels, edge data points, or the last series at the plot boundary, so the first and last values on a chart stay readable.
- feature: none
- breaking: none
- config: none
- schema: none
