### PR TITLE
fix(frontend): hide species toggle where species filtering does not apply

### DIFF
--- a/frontend/src/lib/desktop/features/analytics/components/AnalyticsControlBar.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/AnalyticsControlBar.svelte
@@ -11,7 +11,9 @@
   toggle (the date range stays visible) to keep the toolbar compact. Each
   control honors the active tab's chart `supports` flags: when no chart in the
   active tab filters by species (e.g. Biodiversity), the species toggle is
-  disabled with an explanation. The source/mic filter is governed by
+  hidden entirely (a permanently-disabled toggle showing a stale selection
+  count would be confusing) and a short note explains why. The source/mic
+  filter is governed by
   `sourceApplicable`: no chart consumes the source dimension yet, so the control
   is hidden until a source-aware chart lands. It still renders (enabled, so it is
   clearable) when a stale `source` value arrives from a URL/bookmark, so that
@@ -220,24 +222,27 @@
 
     <div class="grow"></div>
 
-    <!-- Species toggle: expands the chip selector; shows the current count -->
-    <button
-      id="analyticsSpeciesToggle"
-      type="button"
-      class="inline-flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm font-medium border border-[var(--color-base-300)] hover:bg-[var(--color-base-100)] disabled:opacity-50 disabled:cursor-not-allowed"
-      aria-expanded={speciesPanelOpen}
-      aria-controls={speciesPanelOpen ? 'analyticsSpeciesPanel' : undefined}
-      disabled={!speciesApplicable}
-      title={speciesApplicable ? undefined : t('analytics.hub.controls.speciesNotApplicable')}
-      onclick={() => (speciesExpanded = !speciesExpanded)}
-    >
-      {#if speciesPanelOpen}
-        <ChevronDown class="h-4 w-4" aria-hidden="true" />
-      {:else}
-        <ChevronRight class="h-4 w-4" aria-hidden="true" />
-      {/if}
-      <span>{speciesLabel}</span>
-    </button>
+    <!-- Species toggle: expands the chip selector; shows the current count. Only rendered when a
+         chart in the active tab filters by species — a permanently-disabled toggle showing a
+         selection count that is silently ignored is confusing, so the control is dropped entirely
+         rather than shown disabled (see the "not applicable" note below instead). -->
+    {#if speciesApplicable}
+      <button
+        id="analyticsSpeciesToggle"
+        type="button"
+        class="inline-flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm font-medium border border-[var(--color-base-300)] hover:bg-[var(--color-base-100)]"
+        aria-expanded={speciesPanelOpen}
+        aria-controls={speciesPanelOpen ? 'analyticsSpeciesPanel' : undefined}
+        onclick={() => (speciesExpanded = !speciesExpanded)}
+      >
+        {#if speciesPanelOpen}
+          <ChevronDown class="h-4 w-4" aria-hidden="true" />
+        {:else}
+          <ChevronRight class="h-4 w-4" aria-hidden="true" />
+        {/if}
+        <span>{speciesLabel}</span>
+      </button>
+    {/if}
   </div>
 
   {#if !speciesApplicable}

--- a/frontend/src/lib/desktop/features/analytics/components/AnalyticsControlBar.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/AnalyticsControlBar.test.ts
@@ -230,7 +230,7 @@ describe('AnalyticsControlBar', () => {
     expect(document.querySelector('#analyticsSpeciesPanel')).not.toBeInTheDocument();
   });
 
-  it('disables the species toggle (collapsed, aria-expanded false) when species filtering does not apply', () => {
+  it('hides the species toggle entirely when species filtering does not apply', () => {
     const onParamsChange = vi.fn();
     render(AnalyticsControlBar, {
       props: {
@@ -241,10 +241,25 @@ describe('AnalyticsControlBar', () => {
       },
     });
 
-    const toggle = document.getElementById('analyticsSpeciesToggle') as HTMLButtonElement;
-    expect(toggle).toBeDisabled();
-    expect(toggle).toHaveAttribute('aria-expanded', 'false');
-    expect(toggle).not.toHaveAttribute('aria-controls');
+    // A permanently-disabled toggle with a stale selection count is confusing, so the control is
+    // dropped entirely; the "not applicable" note (asserted above) is the only explanation shown.
+    expect(document.querySelector('#analyticsSpeciesToggle')).not.toBeInTheDocument();
     expect(document.querySelector('#analyticsSpeciesPanel')).not.toBeInTheDocument();
+  });
+
+  it('shows the species toggle when species filtering applies', () => {
+    const onParamsChange = vi.fn();
+    render(AnalyticsControlBar, {
+      props: {
+        params: makeParams(),
+        availableSpecies: species,
+        speciesApplicable: true,
+        onParamsChange,
+      },
+    });
+
+    const toggle = document.getElementById('analyticsSpeciesToggle');
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).not.toBeDisabled();
   });
 });


### PR DESCRIPTION
## Summary

On analytics tabs where no chart filters by species (Summary, Trends, Biodiversity), the control bar still rendered a disabled "Species Selection (N/10)" toggle. Showing a selected count on a tab that ignores the selection is confusing. The toggle is now hidden when species filtering doesn't apply; the existing short "not applicable" note remains as the explanation.

## Changes

- Gate the species toggle button on `speciesApplicable` in `AnalyticsControlBar`; remove the now-dead `disabled`/`title` attributes and correct the stale doc comment.
- Update the component test to assert the toggle is absent when species filtering does not apply and present when it does.

## Testing

- [ ] Go tests pass (`task test`) — N/A, frontend-only change
- [x] Frontend tests pass (`task frontend-test`) — full suite green
- [x] Linting passes (`npm run check:all`); `task frontend-build` OK
- [x] Manual/visual testing in the running app — confirm toggle hidden on Summary/Trends, present on Patterns
- [ ] Preflight quality gate — automated review requested from CodeRabbit + Gemini on this PR

## Preflight Status

Single concern (one fix). Frontend lint/typecheck/tests/build green. No i18n keys added, no secrets/PII. Go build/tests are N/A (frontend-only). Deep multi-reviewer analysis delegated to CodeRabbit + Gemini on this PR plus maintainer visual QA.

## Related

Addresses "(1/10) shown on the species toggle where the selection isn't used" on the analytics hub.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analytics filter controls for clearer behavior when chart data is unavailable or outdated.
  * Source/microphone filters now explain when they are unavailable while still allowing stale selections to be cleared.
  * Species filtering controls are shown only when applicable, reducing unavailable or confusing options.
* **Tests**
  * Added coverage for applicable and unavailable species-filter states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Release notes
- audience: user
- summary: The analytics species filter is now hidden on tabs where no chart filters by species, instead of showing a permanently greyed-out control with a stale selection count.
- feature: none
- breaking: none
- config: none
- schema: none
