### PR TITLE
fix(classifier): auto-select ONNX range filter for default "latest" model

### DIFF
--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -531,8 +531,10 @@ func (bn *BirdNET) initializeMetaModel(settings *conf.Settings) error {
 
 	// Auto-select v3 geomodel for compatible classifiers when files exist on disk.
 	// Only applies locally for routing; does NOT publish settings to avoid
-	// inconsistency if the backend fails to initialize.
-	if rf.Model == "" && bn.modelsDir != "" && shouldAutoSelectV3Geomodel(bn.ModelInfo.ID, bn.modelsDir) {
+	// inconsistency if the backend fails to initialize. Skipped when an explicit
+	// rangefilter.modelpath is set, so a user-provided range-filter path is never
+	// overridden by the stock geomodel (mirrors the arm64 default gate below).
+	if shouldAutoSelectV3GeomodelForConfig(rf.Model, rf.ModelPath, bn.ModelInfo.ID, bn.modelsDir) {
 		localSettings := conf.CloneSettings(settings)
 		applyAutoSelectedGeomodelPaths(localSettings, bn.modelsDir)
 		settings = localSettings
@@ -543,21 +545,22 @@ func (bn *BirdNET) initializeMetaModel(settings *conf.Settings) error {
 	}
 
 	// On arm64 (container images ship the ONNX range filter instead of the TFLite
-	// MData models), prefer the ONNX MData range filter when no range filter is
-	// configured and the v3 geomodel was not auto-selected above. Gated to the
-	// BirdNET v2.4 family: the MData V2 model outputs the v2.4 species set, and the
-	// strict ONNX path (no labels file) requires the model output dimension to
-	// equal the classifier label count, so it only fits a v2.4-family classifier.
-	// Routed locally only; settings are not published.
-	if rf.Model == "" && rf.ModelPath == "" && isBirdNETV24Family(bn.ModelInfo.ID) {
-		if path, ok := defaultRangeFilterONNXPath(runtime.GOARCH, findModelPathInStandardPaths); ok {
-			localSettings := conf.CloneSettings(settings)
-			localSettings.BirdNET.RangeFilter.ModelPath = path
-			settings = localSettings
-			rf = settings.BirdNET.RangeFilter
-			log.Info("Selected ONNX range filter (arm64 default)",
-				logger.String("model_path", path))
-		}
+	// MData models), prefer the ONNX MData range filter when the range filter is left
+	// on auto-select ("" or the "latest" default), no explicit model path is set, and
+	// the v3 geomodel was not auto-selected above. Gated to the BirdNET v2.4 family:
+	// the MData V2 model outputs the v2.4 species set, and the strict ONNX path (no
+	// labels file) requires the model output dimension to equal the classifier label
+	// count, so it only fits a v2.4-family classifier. Without this, the "latest"
+	// default dead-ends at the TFLite backend, which has no model file on ONNX-only
+	// arm64 images, leaving the instance unfiltered (#3932). Routed locally only;
+	// settings are not published.
+	if path, ok := shouldSelectDefaultONNXRangeFilter(rf.Model, rf.ModelPath, bn.ModelInfo.ID, runtime.GOARCH, findModelPathInStandardPaths); ok {
+		localSettings := conf.CloneSettings(settings)
+		localSettings.BirdNET.RangeFilter.ModelPath = path
+		settings = localSettings
+		rf = settings.BirdNET.RangeFilter
+		log.Info("Selected ONNX range filter (arm64 default)",
+			logger.String("model_path", path))
 	}
 
 	switch resolveRangeFilterBackend(&rf) {
@@ -1774,6 +1777,18 @@ func shouldAutoSelectV3Geomodel(modelID, modelsDir string) bool {
 		return false
 	}
 	return true
+}
+
+// shouldAutoSelectV3GeomodelForConfig reports whether initializeMetaModel should
+// auto-select the stock v3 geomodel for this range-filter config. It requires the
+// model to be auto-select ("" or the "latest" default), no explicit range-filter
+// modelpath (an explicit user path is never overridden), a known models dir, and a
+// compatible classifier with the stock geomodel files present on disk. The
+// modelpath guard mirrors shouldSelectDefaultONNXRangeFilter so both auto-select
+// gates honor an explicit path consistently.
+func shouldAutoSelectV3GeomodelForConfig(model, modelPath, classifierID, modelsDir string) bool {
+	return isAutoSelectRangeFilterModel(model) && modelPath == "" && modelsDir != "" &&
+		shouldAutoSelectV3Geomodel(classifierID, modelsDir)
 }
 
 // applyAutoSelectedGeomodelPaths configures the range filter settings to

--- a/internal/classifier/birdnet_test.go
+++ b/internal/classifier/birdnet_test.go
@@ -108,6 +108,49 @@ func TestShouldAutoSelectV3Geomodel(t *testing.T) {
 	}
 }
 
+// TestShouldAutoSelectV3GeomodelForConfig covers the config-level gate that drives
+// the v3 geomodel auto-selection in initializeMetaModel: the model must be
+// auto-select ("" or the "latest" default), no explicit rangefilter.modelpath may be
+// set (an explicit user path is never overridden), and the classifier + stock files
+// must qualify. The explicit-modelpath rows are the #3932-followup regression guard:
+// extending auto-select to the default "latest" must not clobber a user-provided
+// range-filter path (mirrors shouldSelectDefaultONNXRangeFilter's ModelPath guard).
+func TestShouldAutoSelectV3GeomodelForConfig(t *testing.T) {
+	t.Parallel()
+
+	modelsDir := t.TempDir()
+	sharedDir := filepath.Join(modelsDir, "shared")
+	require.NoError(t, os.MkdirAll(sharedDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sharedDir, conf.GeomodelONNXLocalName), []byte("fake-onnx"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(sharedDir, conf.GeomodelLabelsLocalName), []byte("fake-labels"), 0o644))
+
+	tests := []struct {
+		name      string
+		model     string
+		modelPath string
+		modelID   string
+		modelsDir string
+		want      bool
+	}{
+		{"latest + no path + PerchV2 + files -> auto-select", "latest", "", RegistryIDPerchV2, modelsDir, true},
+		{"empty model + no path + BirdNET V3.0 + files -> auto-select", "", "", RegistryIDBirdNETV3, modelsDir, true},
+		{"latest + explicit modelpath suppresses (custom path honored)", "latest", "/data/custom_geomodel.onnx", RegistryIDPerchV2, modelsDir, false},
+		{"empty model + explicit modelpath suppresses", "", "/data/custom_geomodel.onnx", RegistryIDPerchV2, modelsDir, false},
+		{"explicit v3 is not auto-select", "v3", "", RegistryIDPerchV2, modelsDir, false},
+		{"legacy is not auto-select", "legacy", "", RegistryIDPerchV2, modelsDir, false},
+		{"v2.4 family classifier not eligible", "latest", "", "BirdNET_V2.4", modelsDir, false},
+		{"empty modelsDir -> false", "latest", "", RegistryIDPerchV2, "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := shouldAutoSelectV3GeomodelForConfig(tt.model, tt.modelPath, tt.modelID, tt.modelsDir)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestApplyAutoSelectedGeomodelPaths(t *testing.T) {
 	t.Parallel()
 

--- a/internal/classifier/birdnet_test.go
+++ b/internal/classifier/birdnet_test.go
@@ -132,14 +132,14 @@ func TestShouldAutoSelectV3GeomodelForConfig(t *testing.T) {
 		modelsDir string
 		want      bool
 	}{
-		{"latest + no path + PerchV2 + files -> auto-select", "latest", "", RegistryIDPerchV2, modelsDir, true},
+		{"latest + no path + PerchV2 + files -> auto-select", conf.RangeFilterModelLatest, "", RegistryIDPerchV2, modelsDir, true},
 		{"empty model + no path + BirdNET V3.0 + files -> auto-select", "", "", RegistryIDBirdNETV3, modelsDir, true},
-		{"latest + explicit modelpath suppresses (custom path honored)", "latest", "/data/custom_geomodel.onnx", RegistryIDPerchV2, modelsDir, false},
+		{"latest + explicit modelpath suppresses (custom path honored)", conf.RangeFilterModelLatest, "/data/custom_geomodel.onnx", RegistryIDPerchV2, modelsDir, false},
 		{"empty model + explicit modelpath suppresses", "", "/data/custom_geomodel.onnx", RegistryIDPerchV2, modelsDir, false},
 		{"explicit v3 is not auto-select", "v3", "", RegistryIDPerchV2, modelsDir, false},
 		{"legacy is not auto-select", "legacy", "", RegistryIDPerchV2, modelsDir, false},
-		{"v2.4 family classifier not eligible", "latest", "", "BirdNET_V2.4", modelsDir, false},
-		{"empty modelsDir -> false", "latest", "", RegistryIDPerchV2, "", false},
+		{"v2.4 family classifier not eligible", conf.RangeFilterModelLatest, "", "BirdNET_V2.4", modelsDir, false},
+		{"empty modelsDir -> false", conf.RangeFilterModelLatest, "", RegistryIDPerchV2, "", false},
 	}
 
 	for _, tt := range tests {

--- a/internal/classifier/int8_default_test.go
+++ b/internal/classifier/int8_default_test.go
@@ -281,3 +281,77 @@ func TestRemapV24ToONNXOnARM64Unified(t *testing.T) {
 	assert.Equal(t, QuantizationINT8, got.Quantization)
 	assert.True(t, got.IsStock)
 }
+
+// TestIsAutoSelectRangeFilterModel verifies that the empty string and the "latest"
+// default sentinel both request automatic range-filter backend selection, while
+// explicit model choices do not. Regression guard for #3932, where the default
+// "latest" dead-ended at the TFLite backend on ONNX-only arm64 images.
+func TestIsAutoSelectRangeFilterModel(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		model string
+		want  bool
+	}{
+		{"empty string is auto-select", "", true},
+		{"latest sentinel is auto-select", "latest", true},
+		{"explicit v3 is not auto-select", "v3", false},
+		{"legacy is not auto-select", "legacy", false},
+		{"custom value is not auto-select", "custom", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isAutoSelectRangeFilterModel(tt.model))
+		})
+	}
+}
+
+// TestShouldSelectDefaultONNXRangeFilter verifies the arm64 default ONNX MData
+// range-filter selection. It fires for the auto-select models ("" and "latest") on
+// arm64 with a v2.4-family classifier when the ONNX file is present, and is correctly
+// suppressed by an explicit ModelPath, a non-auto-select model, a non-v2.4 classifier,
+// amd64, or a missing file. The "latest" cases are the #3932 regression guard: the
+// default config must select the shipped ONNX MData model on ONNX-only arm64 images
+// instead of dead-ending at the unavailable TFLite model.
+func TestShouldSelectDefaultONNXRangeFilter(t *testing.T) {
+	t.Parallel()
+
+	onnxName := DefaultRangeFilterV2ONNXModelName
+	findHit := func(name string) (string, bool) {
+		if name == onnxName {
+			return "/models/" + name, true
+		}
+		return "", false
+	}
+	findMiss := func(string) (string, bool) { return "", false }
+	wantPath := "/models/" + onnxName
+
+	tests := []struct {
+		name       string
+		model      string
+		modelPath  string
+		classifier string
+		goarch     string
+		find       func(string) (string, bool)
+		wantPath   string
+		wantOK     bool
+	}{
+		{"latest on arm64 v2.4 with file selects ONNX MData", "latest", "", DefaultModelVersion, "arm64", findHit, wantPath, true},
+		{"empty on arm64 v2.4 with file selects ONNX MData", "", "", DefaultModelVersion, "arm64", findHit, wantPath, true},
+		{"explicit v3 does not auto-select", "v3", "", DefaultModelVersion, "arm64", findHit, "", false},
+		{"legacy does not auto-select", "legacy", "", DefaultModelVersion, "arm64", findHit, "", false},
+		{"explicit ModelPath suppresses selection", "latest", "/data/custom.onnx", DefaultModelVersion, "arm64", findHit, "", false},
+		{"non-v2.4 classifier is skipped", "latest", "", RegistryIDPerchV2, "arm64", findHit, "", false},
+		{"amd64 is skipped", "latest", "", DefaultModelVersion, "amd64", findHit, "", false},
+		{"arm64 without file falls through", "latest", "", DefaultModelVersion, "arm64", findMiss, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			path, ok := shouldSelectDefaultONNXRangeFilter(tt.model, tt.modelPath, tt.classifier, tt.goarch, tt.find)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantPath, path)
+		})
+	}
+}

--- a/internal/classifier/int8_default_test.go
+++ b/internal/classifier/int8_default_test.go
@@ -294,7 +294,7 @@ func TestIsAutoSelectRangeFilterModel(t *testing.T) {
 		want  bool
 	}{
 		{"empty string is auto-select", "", true},
-		{"latest sentinel is auto-select", "latest", true},
+		{"latest sentinel is auto-select", conf.RangeFilterModelLatest, true},
 		{"explicit v3 is not auto-select", "v3", false},
 		{"legacy is not auto-select", "legacy", false},
 		{"custom value is not auto-select", "custom", false},
@@ -337,14 +337,14 @@ func TestShouldSelectDefaultONNXRangeFilter(t *testing.T) {
 		wantPath   string
 		wantOK     bool
 	}{
-		{"latest on arm64 v2.4 with file selects ONNX MData", "latest", "", DefaultModelVersion, "arm64", findHit, wantPath, true},
+		{"latest on arm64 v2.4 with file selects ONNX MData", conf.RangeFilterModelLatest, "", DefaultModelVersion, "arm64", findHit, wantPath, true},
 		{"empty on arm64 v2.4 with file selects ONNX MData", "", "", DefaultModelVersion, "arm64", findHit, wantPath, true},
 		{"explicit v3 does not auto-select", "v3", "", DefaultModelVersion, "arm64", findHit, "", false},
 		{"legacy does not auto-select", "legacy", "", DefaultModelVersion, "arm64", findHit, "", false},
-		{"explicit ModelPath suppresses selection", "latest", "/data/custom.onnx", DefaultModelVersion, "arm64", findHit, "", false},
-		{"non-v2.4 classifier is skipped", "latest", "", RegistryIDPerchV2, "arm64", findHit, "", false},
-		{"amd64 is skipped", "latest", "", DefaultModelVersion, "amd64", findHit, "", false},
-		{"arm64 without file falls through", "latest", "", DefaultModelVersion, "arm64", findMiss, "", false},
+		{"explicit ModelPath suppresses selection", conf.RangeFilterModelLatest, "/data/custom.onnx", DefaultModelVersion, "arm64", findHit, "", false},
+		{"non-v2.4 classifier is skipped", conf.RangeFilterModelLatest, "", RegistryIDPerchV2, "arm64", findHit, "", false},
+		{"amd64 is skipped", conf.RangeFilterModelLatest, "", DefaultModelVersion, "amd64", findHit, "", false},
+		{"arm64 without file falls through", conf.RangeFilterModelLatest, "", DefaultModelVersion, "arm64", findMiss, "", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/classifier/model_registry.go
+++ b/internal/classifier/model_registry.go
@@ -321,7 +321,7 @@ func defaultRangeFilterONNXPath(goarch string, find func(name string) (path stri
 // TFLite backend, which has no model file on ONNX-only (arm64) container images,
 // leaving the instance with no range filter and every species unfiltered (#3932).
 func isAutoSelectRangeFilterModel(model string) bool {
-	return model == "" || model == "latest"
+	return model == "" || model == conf.RangeFilterModelLatest
 }
 
 // shouldSelectDefaultONNXRangeFilter reports the ONNX MData range-filter model path

--- a/internal/classifier/model_registry.go
+++ b/internal/classifier/model_registry.go
@@ -311,6 +311,32 @@ func defaultRangeFilterONNXPath(goarch string, find func(name string) (path stri
 	return find(DefaultRangeFilterV2ONNXModelName)
 }
 
+// isAutoSelectRangeFilterModel reports whether the configured range-filter model
+// requests automatic backend selection. Both "" and the "latest" sentinel (the
+// config default in defaults.go) mean "pick the best available range filter": the
+// v3 geomodel when its files are present, then the shipped ONNX MData model, then
+// the classifier's embedded/shipped TFLite MData model.
+//
+// Without treating "latest" as auto-select, the default config dead-ends at the
+// TFLite backend, which has no model file on ONNX-only (arm64) container images,
+// leaving the instance with no range filter and every species unfiltered (#3932).
+func isAutoSelectRangeFilterModel(model string) bool {
+	return model == "" || model == "latest"
+}
+
+// shouldSelectDefaultONNXRangeFilter reports the ONNX MData range-filter model path
+// to use as the arm64 default. It returns ("", false) unless the config requests
+// auto-selection (isAutoSelectRangeFilterModel), no explicit range-filter ModelPath
+// is set, the classifier is the BirdNET v2.4 family (whose labels match the MData V2
+// output dimension), and defaultRangeFilterONNXPath locates the ONNX MData model
+// (arm64 only). find resolves a model filename within the standard search paths.
+func shouldSelectDefaultONNXRangeFilter(model, modelPath, classifierID, goarch string, find func(name string) (path string, ok bool)) (string, bool) {
+	if !isAutoSelectRangeFilterModel(model) || modelPath != "" || !isBirdNETV24Family(classifierID) {
+		return "", false
+	}
+	return defaultRangeFilterONNXPath(goarch, find)
+}
+
 // birdnetVersionToRegistryID maps user-facing BirdNET version strings to registry IDs.
 var birdnetVersionToRegistryID = map[string]string{
 	"2.4": "BirdNET_V2.4",

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -87,7 +87,7 @@ func setDefaultConfig() {
 
 	// Range filter configuration
 	viper.SetDefault("birdnet.rangefilter.debug", false)
-	viper.SetDefault("birdnet.rangefilter.model", "latest")
+	viper.SetDefault("birdnet.rangefilter.model", RangeFilterModelLatest)
 	viper.SetDefault("birdnet.rangefilter.threshold", 0.01)
 
 	// Perch model configuration

--- a/internal/conf/env.go
+++ b/internal/conf/env.go
@@ -320,7 +320,7 @@ func validateEnvTLSMode(value string) error {
 
 func validateEnvRangeFilterModel(value string) error {
 	value = strings.TrimSpace(value)
-	validModels := []string{"latest", "legacy", "v3"}
+	validModels := []string{RangeFilterModelLatest, RangeFilterModelLegacy, RangeFilterModelV3}
 	if !slices.Contains(validModels, value) {
 		return fmt.Errorf("must be one of: %s", strings.Join(validModels, ", "))
 	}

--- a/internal/conf/range_filter_migration.go
+++ b/internal/conf/range_filter_migration.go
@@ -13,10 +13,22 @@ const (
 	GeomodelLabelsLocalName = "geomodel_v3.0.2_labels.txt"
 )
 
+// Range filter model sentinels for birdnet.rangefilter.model. The empty string
+// and RangeFilterModelLatest both request automatic backend selection (see
+// classifier.isAutoSelectRangeFilterModel); RangeFilterModelLegacy pins the V1
+// MData model; RangeFilterModelV3 selects the geomodel. Defined here in conf
+// (which classifier imports) so the sentinels are shared, not duplicated per
+// package.
+const (
+	RangeFilterModelLatest = "latest"
+	RangeFilterModelLegacy = "legacy"
+	RangeFilterModelV3     = "v3"
+)
+
 // rangeFilterGeomodelV3 is the literal that the runtime, status code, and UI
 // key off to recognize the geomodel v3 range filter (see
 // internal/classifier/birdnet.go and internal/conf/validate_services.go).
-const rangeFilterGeomodelV3 = "v3"
+const rangeFilterGeomodelV3 = RangeFilterModelV3
 
 // ResolveModelsDir computes the model gallery directory. If Models.Directory is set,
 // it is used verbatim; otherwise the OS user config directory is used (falling back to

--- a/internal/conf/validate_services.go
+++ b/internal/conf/validate_services.go
@@ -39,7 +39,7 @@ func ValidateBirdNETSettings(cfg *BirdNETConfig) ValidationResult {
 	}
 
 	// Empty string, "latest", "legacy", or "v3" are valid
-	if cfg.RangeFilter.Model != "" && cfg.RangeFilter.Model != "latest" && cfg.RangeFilter.Model != "legacy" && cfg.RangeFilter.Model != "v3" {
+	if cfg.RangeFilter.Model != "" && cfg.RangeFilter.Model != RangeFilterModelLatest && cfg.RangeFilter.Model != RangeFilterModelLegacy && cfg.RangeFilter.Model != RangeFilterModelV3 {
 		result.Valid = false
 		result.Errors = append(result.Errors, "RangeFilter model must be either empty (v2 default), 'latest', 'legacy', or 'v3'")
 	}


### PR DESCRIPTION
Fixes #3932.

## Problem

After updating, arm64 users (e.g. Raspberry Pi via Docker) started getting detections for out-of-range species: the active species list jumped from ~100 for their location to 6000+, i.e. the range filter stopped working entirely.

## Root cause

The config default is `birdnet.rangefilter.model: "latest"`, persisted in essentially every existing `config.yaml`. The two range-filter auto-selection gates in `initializeMetaModel` only fired when the model string was empty (`rf.Model == ""`), so the `"latest"` default triggered neither and fell through to the TFLite range-filter backend.

On ONNX-only arm64 container images this is fatal: those images ship `BirdNET_MData_V2.onnx` (the ONNX range-filter model) but no `.tflite` range-filter file, so the TFLite path cannot find its model, fails to load, and the instance runs with no range filter. amd64 images ship the `.tflite` files, so they were unaffected. This matches the reports (Raspberry Pi 4 / aarch64).

## Fix

Treat the `"latest"` sentinel the same as `""` for auto-selection, so it means "pick the best available range filter": the v3 geomodel when its files are present, then the shipped ONNX MData model on arm64, then the embedded/shipped TFLite MData. For affected arm64 installs this restores the exact v2.4 range filter with no download and no change to detection characteristics.

Both auto-select gates now honor an explicit `rangefilter.modelpath`: the v3 geomodel gate gains the same ModelPath guard the arm64 gate already had, so a user-provided range-filter path is never overridden by the stock geomodel.

## Behavior change (release note)

arm64 users who have been running unfiltered since `"latest"` became the default will get range filtering back, so out-of-range species that were showing up get suppressed again. This is the intended restoration of pre-regression behavior, but it visibly changes detection output for anyone who got used to the unfiltered results, so it is worth a line in the release notes.

## Tests

- `TestIsAutoSelectRangeFilterModel`, `TestShouldSelectDefaultONNXRangeFilter` cover the arm64 ONNX MData selection matrix.
- `TestShouldAutoSelectV3GeomodelForConfig` covers the v3 geomodel gate, including the explicit-modelpath guard.
- Full `internal/classifier` suite passes with `-race`; `golangci-lint` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic range-filter and geomodel selection consistency.
  * Respects explicitly provided range-filter model paths without overriding them.
  * Enhanced default ONNX range-filter selection for compatible ARM64 setups, with better safeguards when files are missing or configurations are incompatible.
  * Standardized accepted range-filter model names during configuration/environment validation.
* **Tests**
  * Added unit tests covering v3 geomodel auto-selection gating and default ONNX range-filter selection behavior (including explicit vs auto modes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->