### PR TITLE
feat(install): migrate an existing install from another host over SSH

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -36,6 +36,8 @@ MIGRATE_SSH_DIR=""
 MIGRATE_REMOTE_HOME=""
 MIGRATE_REMOTE_APP=""
 MIGRATE_TMP_UNIT=""
+MIGRATE_BACKUP=""
+MIGRATE_STOPPED_REMOTE="0"
 
 # Flag to track if Docker image was changed during update/rollback
 IMAGE_CHANGED="false"
@@ -1899,26 +1901,30 @@ resolve_remote_app() {
     return 1
 }
 
-# 0 = confirmed stopped, 1 = running or NOT confirmed stopped. Fail safe: an empty
-# or unrecognized answer (dropped SSH, MOTD noise, CRLF) is treated as "maybe
-# running" so we never copy a live database. Whitespace/CR is stripped so MOTD
-# banners and carriage returns do not defeat the match.
+# 0 = confirmed stopped, 1 = running or NOT confirmed stopped. Fails CLOSED: a
+# dropped SSH, missing systemctl, MOTD/shell noise, or any state other than a
+# definitive not-running one is treated as "maybe running" so a live database is
+# never copied. A remote without systemctl defaults to inactive (then the docker
+# check decides); tail -n 1 drops login banners; grep -Fx matches only the exact
+# container name so shell noise cannot look like a running container.
 check_remote_stopped() {
     local state
-    state="$(migrate_ssh 'systemctl is-active birdnet-go.service 2>/dev/null')"
-    state="$(printf '%s' "$state" | tr -d '[:space:]')"
+    state="$(migrate_ssh 'if command -v systemctl >/dev/null 2>&1; then systemctl is-active birdnet-go.service 2>/dev/null || true; else echo inactive; fi')" || return 1
+    state="$(printf '%s' "$state" | tail -n 1 | tr -d '[:space:]')"
     case "$state" in
-        active|activating|reloading|deactivating|"") return 1 ;;
+        inactive|failed|unknown) ;;   # systemd definitively not running; verify container
+        *) return 1 ;;                 # active/empty/unrecognized -> not confirmed stopped
     esac
-    local ctr
-    ctr="$(migrate_ssh 'docker ps --filter name=birdnet-go --format "{{.Names}}" 2>/dev/null')"
-    ctr="$(printf '%s' "$ctr" | tr -d '[:space:]')"
+    local ctr raw
+    raw="$(migrate_ssh 'if command -v docker >/dev/null 2>&1; then docker ps --filter name=birdnet-go --format "{{.Names}}" 2>/dev/null || true; fi')" || return 1
+    ctr="$(printf '%s' "$raw" | grep -Fx 'birdnet-go' | tr -d '[:space:]')"
     [ -n "$ctr" ] && return 1
     return 0
 }
 
-# Ensure the new host has room for the remote dataset (+10% margin). Fails open if
-# either size cannot be determined.
+# Ensure the new host has room for the remote dataset (+10% margin). Fails CLOSED:
+# if the remote or local size cannot be parsed, abort (or take an explicit
+# interactive override) rather than silently skip the check before a large copy.
 check_remote_disk() {
     local remote_kb avail_kb
     remote_kb="$(migrate_ssh "du -sk '$MIGRATE_REMOTE_APP' 2>/dev/null | cut -f1")"
@@ -1929,7 +1935,15 @@ check_remote_disk() {
             print_message "❌ Not enough disk space: need ~$(( need_kb / 1024 )) MB, have $(( avail_kb / 1024 )) MB" "$RED"
             return 1
         fi
+        return 0
     fi
+    print_message "⚠️  Could not verify free disk space for the transfer." "$YELLOW"
+    if [ "$SILENT_MODE" = "true" ]; then
+        print_message "❌ Aborting (silent mode); re-run interactively to override" "$RED"; return 1
+    fi
+    print_message "❓ Continue without the disk-space check? (y/n): " "$YELLOW" "nonewline"
+    local a; read -r a
+    [[ "$a" =~ ^[Yy]$ ]] || { print_message "Migration cancelled." "$NC"; return 1; }
     return 0
 }
 
@@ -1949,13 +1963,23 @@ adopt_migrated_installation() {
     fi
 
     local db="$dest/data/birdnet.db"
-    if [ -f "$db" ] && command_exists sqlite3; then
+    if [ -f "$db" ]; then
+        if ! command_exists sqlite3; then
+            print_message "❌ sqlite3 is unavailable; cannot verify database integrity" "$RED"
+            return 1
+        fi
         local res
         res="$(sqlite3 "$db" 'PRAGMA integrity_check;' 2>/dev/null)"
         if [ "$res" = "ok" ]; then
             print_message "✅ Database integrity verified" "$GREEN"
         else
-            print_message "⚠️  Database integrity check: ${res:-unreadable}. If the old service was running during copy, stop it and re-run." "$YELLOW"
+            print_message "❌ Database integrity check failed: ${res:-unreadable}" "$RED"
+            if [ "$SILENT_MODE" = "true" ]; then
+                return 1
+            fi
+            print_message "   Your data on $MIGRATE_DEST is untouched. Adopt anyway? (y/n): " "$YELLOW" "nonewline"
+            local a; read -r a
+            [[ "$a" =~ ^[Yy]$ ]] || return 1
         fi
     fi
 
@@ -1966,6 +1990,31 @@ adopt_migrated_installation() {
     load_telemetry_config
     MIGRATION_DONE="true"
     return 0
+}
+
+# Restore pre-migration state after a failure: drop the partial target, move any
+# backed-up data back into place, and restart the source service if THIS run
+# stopped it. Best effort; each step is guarded and reports what it did so the
+# user is never left thinking data was lost.
+migrate_rollback() {
+    local dest_dir="$HOME/birdnet-go-app"
+    rm -rf "$dest_dir" 2>/dev/null
+    if [ -n "$MIGRATE_BACKUP" ] && [ -d "$MIGRATE_BACKUP" ]; then
+        if mv "$MIGRATE_BACKUP" "$dest_dir" 2>/dev/null; then
+            print_message "↩️  Restored your previous data to $dest_dir" "$YELLOW"
+        else
+            print_message "⚠️  Could not auto-restore; your previous data is safe at $MIGRATE_BACKUP" "$YELLOW"
+        fi
+        MIGRATE_BACKUP=""
+    fi
+    if [ "$MIGRATE_STOPPED_REMOTE" = "1" ] && [ -n "$MIGRATE_SSH_SOCKET" ]; then
+        if ssh -t -o ControlPath="$MIGRATE_SSH_SOCKET" "$MIGRATE_DEST" 'sudo systemctl start birdnet-go.service' 2>/dev/null; then
+            print_message "↩️  Restarted BirdNET-Go on $MIGRATE_DEST" "$YELLOW"
+        else
+            print_message "⚠️  Could not restart BirdNET-Go on $MIGRATE_DEST; start it there manually" "$YELLOW"
+        fi
+        MIGRATE_STOPPED_REMOTE="0"
+    fi
 }
 
 # Pull an install from another host over SSH and adopt it. Returns nonzero on any
@@ -2006,28 +2055,13 @@ migrate_from_remote_host() {
     open_ssh_master || return 1
     resolve_remote_app || return 1
 
-    # Require the source service to be stopped so we never copy a live database.
-    if ! check_remote_stopped; then
-        print_message "⚠️  BirdNET-Go appears to be running on $MIGRATE_DEST. Copying a live database can corrupt it." "$YELLOW"
-        if [ "$SILENT_MODE" = "true" ]; then
-            print_message "❌ Stop birdnet-go on the old host, then re-run" "$RED"; return 1
-        fi
-        print_message "❓ Stop it now over SSH (sudo)? (y/n): " "$YELLOW" "nonewline"
-        local s; read -r s
-        if [[ "$s" =~ ^[Yy]$ ]]; then
-            ssh -t -o ControlPath="$MIGRATE_SSH_SOCKET" "$MIGRATE_DEST" 'sudo systemctl stop birdnet-go.service' || true
-            check_remote_stopped || { print_message "❌ Still running; stop it manually and re-run" "$RED"; return 1; }
-        else
-            print_message "❌ Stop birdnet-go on the old host, then re-run" "$RED"; return 1
-        fi
-    fi
-
+    # Verify capacity and settle the local target BEFORE stopping the source, so
+    # aborting on a disk or overwrite decision never leaves the old host offline.
     check_remote_disk || return 1
 
     # Overwrite guard: never merge into pre-existing data. setup_logging already
     # created data/logs here, so that alone must NOT count; trigger only on a real
-    # payload (config, database, or clips). Move it aside (never delete). Runs only
-    # after the remote checks pass, so a bad remote never displaces local data.
+    # payload (config, database, or clips). Move it aside (never delete).
     if [ -f "$dest_dir/config/config.yaml" ] || [ -f "$dest_dir/data/birdnet.db" ] || \
        { [ -d "$dest_dir/data/clips" ] && [ -n "$(ls -A "$dest_dir/data/clips" 2>/dev/null)" ]; }; then
         if [ "$SILENT_MODE" = "true" ]; then
@@ -2037,9 +2071,31 @@ migrate_from_remote_host() {
         print_message "❓ Move it aside to a backup and continue? (y/n): " "$YELLOW" "nonewline"
         local ans; read -r ans
         [[ "$ans" =~ ^[Yy]$ ]] || { print_message "Migration cancelled; nothing changed." "$NC"; return 1; }
-        local backup; backup="${dest_dir}.bak.$(date +%Y%m%d%H%M%S).$$"
-        mv "$dest_dir" "$backup" || { print_message "❌ Backup move failed" "$RED"; return 1; }
-        print_message "📦 Existing data moved to $backup (nothing deleted)" "$GREEN"
+        MIGRATE_BACKUP="${dest_dir}.bak.$(date +%Y%m%d%H%M%S).$$"
+        if ! mv "$dest_dir" "$MIGRATE_BACKUP"; then
+            print_message "❌ Backup move failed" "$RED"; MIGRATE_BACKUP=""; return 1
+        fi
+        print_message "📦 Existing data moved to $MIGRATE_BACKUP (nothing deleted)" "$GREEN"
+    fi
+
+    # Require the source service to be stopped so we never copy a live database.
+    # From here on, failures route through migrate_rollback, which restores the
+    # backed-up local data and restarts the source if this run stopped it.
+    if ! check_remote_stopped; then
+        print_message "⚠️  BirdNET-Go appears to be running on $MIGRATE_DEST. Copying a live database can corrupt it." "$YELLOW"
+        if [ "$SILENT_MODE" = "true" ]; then
+            print_message "❌ Stop birdnet-go on the old host, then re-run" "$RED"; migrate_rollback; return 1
+        fi
+        print_message "❓ Stop it now over SSH (sudo)? (y/n): " "$YELLOW" "nonewline"
+        local s; read -r s
+        if [[ "$s" =~ ^[Yy]$ ]]; then
+            if ssh -t -o ControlPath="$MIGRATE_SSH_SOCKET" "$MIGRATE_DEST" 'sudo systemctl stop birdnet-go.service'; then
+                MIGRATE_STOPPED_REMOTE="1"
+            fi
+            check_remote_stopped || { print_message "❌ Still running; stop it manually and re-run" "$RED"; migrate_rollback; return 1; }
+        else
+            print_message "❌ Stop birdnet-go on the old host, then re-run" "$RED"; migrate_rollback; return 1
+        fi
     fi
 
     # Transfer straight into the destination; rsync runs as the local user so
@@ -2049,8 +2105,8 @@ migrate_from_remote_host() {
         if ! rsync -aH --partial --info=progress2 --exclude 'config/hls/' \
                 -e "ssh -o ControlPath=$MIGRATE_SSH_SOCKET" \
                 "$MIGRATE_DEST:$MIGRATE_REMOTE_APP/" "$dest_dir/"; then
-            print_message "❌ rsync failed (incomplete transfer); nothing adopted" "$RED"
-            rm -rf "$dest_dir"; return 1
+            print_message "❌ rsync failed (incomplete transfer); rolling back" "$RED"
+            migrate_rollback; return 1
         fi
     else
         print_message "ℹ️  rsync not on the remote; using tar over SSH" "$YELLOW"
@@ -2062,18 +2118,18 @@ migrate_from_remote_host() {
         migrate_ssh "tar -C '$MIGRATE_REMOTE_APP' --exclude=./config/hls -cf - ." | tar -C "$dest_dir" -xf -
         local pstat=("${PIPESTATUS[@]}")
         if [ "${pstat[0]}" -ne 0 ] || [ "${pstat[1]}" -ne 0 ]; then
-            print_message "❌ tar transfer failed; nothing adopted" "$RED"
-            rm -rf "$dest_dir"; return 1
+            print_message "❌ tar transfer failed; rolling back" "$RED"
+            migrate_rollback; return 1
         fi
     fi
 
     if [ ! -f "$dest_dir/config/config.yaml" ]; then
-        print_message "❌ Transfer left no config.yaml; aborting" "$RED"
-        rm -rf "$dest_dir"; return 1
+        print_message "❌ Transfer left no config.yaml; rolling back" "$RED"
+        migrate_rollback; return 1
     fi
 
     if ! adopt_migrated_installation; then
-        print_message "❌ Adopt step failed" "$RED"; rm -rf "$dest_dir"; return 1
+        print_message "❌ Adopt step failed; rolling back" "$RED"; migrate_rollback; return 1
     fi
     print_message "✅ Migration data adopted; continuing with provisioning" "$GREEN"
     log_message "INFO" "Cross-host migration transfer and adopt complete"

--- a/install.sh
+++ b/install.sh
@@ -32,6 +32,7 @@ FORCE_ROOT="false"
 MIGRATE_MODE="false"
 MIGRATE_DEST=""
 MIGRATE_SSH_SOCKET=""
+MIGRATE_SSH_DIR=""
 MIGRATE_REMOTE_HOME=""
 MIGRATE_REMOTE_APP=""
 MIGRATE_TMP_UNIT=""
@@ -69,6 +70,7 @@ cleanup_temp_files() {
     if [ -n "$MIGRATE_SSH_SOCKET" ] && [ -n "$MIGRATE_DEST" ]; then
         ssh -o ControlPath="$MIGRATE_SSH_SOCKET" -O exit "$MIGRATE_DEST" 2>/dev/null || true
     fi
+    [ -n "$MIGRATE_SSH_DIR" ] && rm -rf "$MIGRATE_SSH_DIR" 2>/dev/null
     [ -n "$MIGRATE_TMP_UNIT" ] && rm -f "$MIGRATE_TMP_UNIT" 2>/dev/null
     return 0
 }
@@ -1802,9 +1804,21 @@ parse_ssh_dest() {
     local dest="$1"
     [ -n "$dest" ] || return 1
     case "$dest" in
+        -*) return 1 ;;                       # never let a dest be read as an ssh/rsync flag
         *[!A-Za-z0-9._@-]*) return 1 ;;
     esac
     printf '%s' "$dest"
+}
+
+# Reject a remote path that could break out of the single quotes we splice it into
+# when building remote ssh commands (a literal single quote is the only character
+# that breaks a single-quoted string).
+remote_path_safe() {
+    case "$1" in
+        "" ) return 1 ;;
+        *\'* ) return 1 ;;
+    esac
+    return 0
 }
 
 # When a group-change re-login is required mid-migration, tell the user the exact
@@ -1831,7 +1845,16 @@ migrate_ssh() {
 # Open one ControlMaster connection so the user authenticates once. Silent mode
 # must never block on a prompt.
 open_ssh_master() {
-    MIGRATE_SSH_SOCKET="$(mktemp -u "${TMPDIR:-/tmp}/bng-mig-ssh.XXXXXX")"
+    # A real temp DIR (not mktemp -u, which only reserves a name and races) holds
+    # the control socket and is removed wholesale by the cleanup trap.
+    MIGRATE_SSH_DIR="$(mktemp -d "${TMPDIR:-/tmp}/bng-mig-ssh.XXXXXX")" || {
+        print_message "❌ Could not create a temporary directory" "$RED"; return 1; }
+    MIGRATE_SSH_SOCKET="$MIGRATE_SSH_DIR/s"
+    # rsync's -e value is word-split and does not honor quotes, so a socket path
+    # containing whitespace would break the transfer; reject it up front.
+    case "$MIGRATE_SSH_SOCKET" in
+        *[[:space:]]*) print_message "❌ Temp path contains spaces; set TMPDIR to a space-free path" "$RED"; return 1 ;;
+    esac
     local opts=(-o ControlMaster=auto -o ControlPersist=300 -o ControlPath="$MIGRATE_SSH_SOCKET")
     if [ "$SILENT_MODE" = "true" ]; then
         opts+=(-o BatchMode=yes -o StrictHostKeyChecking=accept-new)
@@ -1844,9 +1867,11 @@ open_ssh_master() {
 
 # Resolve the old host's home and app dir; verify a real install is present.
 resolve_remote_app() {
+    # Single quotes are intentional: $HOME must expand on the REMOTE host, not here.
+    # shellcheck disable=SC2016
     MIGRATE_REMOTE_HOME="$(migrate_ssh 'printf %s "$HOME"')"
-    if [ -z "$MIGRATE_REMOTE_HOME" ]; then
-        print_message "❌ Could not determine the remote home directory" "$RED"
+    if [ -z "$MIGRATE_REMOTE_HOME" ] || ! remote_path_safe "$MIGRATE_REMOTE_HOME"; then
+        print_message "❌ Could not determine a usable remote home directory" "$RED"
         return 1
     fi
     local candidate
@@ -1860,8 +1885,12 @@ resolve_remote_app() {
         print_message "   If it lives under /root, run the root->user migration on the OLD host first." "$YELLOW"
         return 1
     fi
-    print_message "No install at $candidate. Enter the remote birdnet-go-app path: " "$YELLOW" "nonewline"
+    print_message "❓ No install at $candidate. Enter the remote birdnet-go-app path: " "$YELLOW" "nonewline"
     local p; read -r p
+    if [ -n "$p" ] && ! remote_path_safe "$p"; then
+        print_message "❌ Path contains an unsupported character (single quote)" "$RED"
+        return 1
+    fi
     if [ -n "$p" ] && migrate_ssh "test -f '$p/config/config.yaml'"; then
         MIGRATE_REMOTE_APP="$p"
         return 0
@@ -1870,14 +1899,20 @@ resolve_remote_app() {
     return 1
 }
 
-# 0 = stopped/absent, 1 = still running. Compare the is-active OUTPUT string, not
-# the exit code (which cannot distinguish inactive from an ssh failure).
+# 0 = confirmed stopped, 1 = running or NOT confirmed stopped. Fail safe: an empty
+# or unrecognized answer (dropped SSH, MOTD noise, CRLF) is treated as "maybe
+# running" so we never copy a live database. Whitespace/CR is stripped so MOTD
+# banners and carriage returns do not defeat the match.
 check_remote_stopped() {
     local state
-    state="$(migrate_ssh 'systemctl is-active birdnet-go.service 2>/dev/null' || true)"
-    [ "$state" = "active" ] && return 1
+    state="$(migrate_ssh 'systemctl is-active birdnet-go.service 2>/dev/null')"
+    state="$(printf '%s' "$state" | tr -d '[:space:]')"
+    case "$state" in
+        active|activating|reloading|deactivating|"") return 1 ;;
+    esac
     local ctr
-    ctr="$(migrate_ssh 'docker ps --filter name=birdnet-go --format "{{.Names}}" 2>/dev/null' || true)"
+    ctr="$(migrate_ssh 'docker ps --filter name=birdnet-go --format "{{.Names}}" 2>/dev/null')"
+    ctr="$(printf '%s' "$ctr" | tr -d '[:space:]')"
     [ -n "$ctr" ] && return 1
     return 0
 }
@@ -1888,7 +1923,7 @@ check_remote_disk() {
     local remote_kb avail_kb
     remote_kb="$(migrate_ssh "du -sk '$MIGRATE_REMOTE_APP' 2>/dev/null | cut -f1")"
     avail_kb="$(df -Pk "$HOME" | awk 'NR==2 {print $4}')"
-    if [ -n "$remote_kb" ] && [ "$remote_kb" -gt 0 ] 2>/dev/null && [ -n "$avail_kb" ]; then
+    if [[ "$remote_kb" =~ ^[0-9]+$ ]] && [[ "$avail_kb" =~ ^[0-9]+$ ]] && [ "$remote_kb" -gt 0 ]; then
         local need_kb=$(( remote_kb + remote_kb / 10 ))
         if [ "$avail_kb" -lt "$need_kb" ]; then
             print_message "❌ Not enough disk space: need ~$(( need_kb / 1024 )) MB, have $(( avail_kb / 1024 )) MB" "$RED"
@@ -1902,6 +1937,7 @@ check_remote_disk() {
 # old service settings, verify the DB, and flag migration complete.
 adopt_migrated_installation() {
     local dest="$HOME/birdnet-go-app"
+    log_message "INFO" "Adopting migrated installation at $dest (source $MIGRATE_DEST)"
     rewrite_migrated_config_paths "$dest/config/config.yaml" "$MIGRATE_REMOTE_HOME" "$HOME"
 
     MIGRATE_TMP_UNIT="$(mktemp "${TMPDIR:-/tmp}/bng-mig-unit.XXXXXX")"
@@ -1937,43 +1973,46 @@ adopt_migrated_installation() {
 migrate_from_remote_host() {
     local dest_dir="$HOME/birdnet-go-app"
     print_message "\n🔄 Migrating BirdNET-Go from another host over SSH" "$GREEN"
+    log_message "INFO" "Starting cross-host migration (dest=$MIGRATE_DEST)"
 
+    # Resolve the ssh destination (prompt when not supplied on the command line).
     if [ -z "$MIGRATE_DEST" ]; then
         if [ "$SILENT_MODE" = "true" ]; then
             print_message "❌ --migrate needs --migrate-from <ssh-dest> in silent mode" "$RED"; return 1
         fi
-        print_message "Old host (user@host or ssh alias): " "$YELLOW" "nonewline"
+        print_message "❓ Old host (user@host or ssh alias): " "$YELLOW" "nonewline"
         read -r MIGRATE_DEST
     fi
     if ! MIGRATE_DEST="$(parse_ssh_dest "$MIGRATE_DEST")"; then
         print_message "❌ Invalid ssh destination" "$RED"; return 1
     fi
 
-    # Overwrite guard: never rsync-merge into pre-existing data. Trigger on a real
-    # install (config.yaml), an existing database, OR any non-empty app dir, then
-    # move the whole dir aside so the transfer writes into a clean target.
-    if [ -f "$dest_dir/config/config.yaml" ] || [ -f "$dest_dir/data/birdnet.db" ] || \
-       { [ -d "$dest_dir" ] && [ -n "$(ls -A "$dest_dir" 2>/dev/null)" ]; }; then
-        if [ "$SILENT_MODE" = "true" ]; then
-            print_message "❌ $dest_dir already contains data; refusing to overwrite in silent mode" "$RED"; return 1
+    # Migration-only tools, installed here so a normal install/update never pulls
+    # packages it does not use.
+    local mig_pkgs=() _p
+    for _p in rsync sqlite3; do
+        command_exists "$_p" || mig_pkgs+=("$_p")
+    done
+    if [ ${#mig_pkgs[@]} -gt 0 ]; then
+        print_message "🔧 Installing migration tools: ${mig_pkgs[*]}" "$YELLOW"
+        if ! sudo apt install -q -y "${mig_pkgs[@]}"; then
+            print_message "❌ Failed to install migration tools (${mig_pkgs[*]})" "$RED"; return 1
         fi
-        print_message "⚠️  $dest_dir already contains data on this machine." "$YELLOW"
-        print_message "Move it aside to a backup and continue? [y/N]: " "$YELLOW" "nonewline"
-        local ans; read -r ans
-        [[ "$ans" =~ ^[Yy]$ ]] || { print_message "Migration cancelled; nothing changed." "$NC"; return 1; }
-        local backup="${dest_dir}.bak.$(date +%Y%m%d%H%M%S)"
-        mv "$dest_dir" "$backup" || { print_message "❌ Backup move failed" "$RED"; return 1; }
-        print_message "📦 Existing data moved to $backup (nothing deleted)" "$GREEN"
     fi
+    command_exists rsync || { print_message "❌ rsync is required for migration" "$RED"; return 1; }
 
-    command_exists rsync || { print_message "❌ rsync missing locally (should have been installed)" "$RED"; return 1; }
-
+    # Connect and locate the source BEFORE touching any local state, so a mistyped
+    # host or a missing remote install never displaces the user's existing data.
     open_ssh_master || return 1
     resolve_remote_app || return 1
 
+    # Require the source service to be stopped so we never copy a live database.
     if ! check_remote_stopped; then
-        print_message "⚠️  BirdNET-Go is still running on $MIGRATE_DEST. Copying a live database can corrupt it." "$YELLOW"
-        print_message "Stop it now over SSH (sudo)? [y/N]: " "$YELLOW" "nonewline"
+        print_message "⚠️  BirdNET-Go appears to be running on $MIGRATE_DEST. Copying a live database can corrupt it." "$YELLOW"
+        if [ "$SILENT_MODE" = "true" ]; then
+            print_message "❌ Stop birdnet-go on the old host, then re-run" "$RED"; return 1
+        fi
+        print_message "❓ Stop it now over SSH (sudo)? (y/n): " "$YELLOW" "nonewline"
         local s; read -r s
         if [[ "$s" =~ ^[Yy]$ ]]; then
             ssh -t -o ControlPath="$MIGRATE_SSH_SOCKET" "$MIGRATE_DEST" 'sudo systemctl stop birdnet-go.service' || true
@@ -1985,6 +2024,26 @@ migrate_from_remote_host() {
 
     check_remote_disk || return 1
 
+    # Overwrite guard: never merge into pre-existing data. setup_logging already
+    # created data/logs here, so that alone must NOT count; trigger only on a real
+    # payload (config, database, or clips). Move it aside (never delete). Runs only
+    # after the remote checks pass, so a bad remote never displaces local data.
+    if [ -f "$dest_dir/config/config.yaml" ] || [ -f "$dest_dir/data/birdnet.db" ] || \
+       { [ -d "$dest_dir/data/clips" ] && [ -n "$(ls -A "$dest_dir/data/clips" 2>/dev/null)" ]; }; then
+        if [ "$SILENT_MODE" = "true" ]; then
+            print_message "❌ $dest_dir already contains data; refusing to overwrite in silent mode" "$RED"; return 1
+        fi
+        print_message "⚠️  $dest_dir already contains data on this machine." "$YELLOW"
+        print_message "❓ Move it aside to a backup and continue? (y/n): " "$YELLOW" "nonewline"
+        local ans; read -r ans
+        [[ "$ans" =~ ^[Yy]$ ]] || { print_message "Migration cancelled; nothing changed." "$NC"; return 1; }
+        local backup; backup="${dest_dir}.bak.$(date +%Y%m%d%H%M%S).$$"
+        mv "$dest_dir" "$backup" || { print_message "❌ Backup move failed" "$RED"; return 1; }
+        print_message "📦 Existing data moved to $backup (nothing deleted)" "$GREEN"
+    fi
+
+    # Transfer straight into the destination; rsync runs as the local user so
+    # ownership is already correct. Any incomplete transfer is fatal and rolls back.
     print_message "📥 Transferring $MIGRATE_REMOTE_APP from $MIGRATE_DEST ..." "$YELLOW"
     if migrate_ssh 'command -v rsync >/dev/null 2>&1'; then
         if ! rsync -aH --partial --info=progress2 --exclude 'config/hls/' \
@@ -1996,7 +2055,13 @@ migrate_from_remote_host() {
     else
         print_message "ℹ️  rsync not on the remote; using tar over SSH" "$YELLOW"
         mkdir -p "$dest_dir"
-        if ! migrate_ssh "tar -C '$MIGRATE_REMOTE_HOME' --exclude='birdnet-go-app/config/hls' -cf - birdnet-go-app" | tar -C "$HOME" -xf -; then
+        # Archive the resolved app dir's CONTENTS so a custom remote path still
+        # lands in $dest_dir. PIPESTATUS makes the REMOTE tar's exit status
+        # authoritative (no pipefail), so a truncated remote stream is not masked
+        # by the local tar exiting 0 on EOF.
+        migrate_ssh "tar -C '$MIGRATE_REMOTE_APP' --exclude=./config/hls -cf - ." | tar -C "$dest_dir" -xf -
+        local pstat=("${PIPESTATUS[@]}")
+        if [ "${pstat[0]}" -ne 0 ] || [ "${pstat[1]}" -ne 0 ]; then
             print_message "❌ tar transfer failed; nothing adopted" "$RED"
             rm -rf "$dest_dir"; return 1
         fi
@@ -2011,6 +2076,8 @@ migrate_from_remote_host() {
         print_message "❌ Adopt step failed" "$RED"; rm -rf "$dest_dir"; return 1
     fi
     print_message "✅ Migration data adopted; continuing with provisioning" "$GREEN"
+    log_message "INFO" "Cross-host migration transfer and adopt complete"
+    send_telemetry_event "info" "Cross-host migration completed" "info" "step=remote_migrate,result=success"
     return 0
 }
 
@@ -2184,6 +2251,9 @@ migrate_installation() {
 
 # Function to check for existing BirdNET-Go installation under a different user
 check_existing_installation_owner() {
+    # Cross-host migrate mode owns install placement via the remote pull; skip the
+    # local cross-user detection so it cannot preempt or collide with migration.
+    [ "$MIGRATE_MODE" = "true" ] && return 0
     local found_other_install=false
     local other_user=""
     local other_path=""
@@ -3265,7 +3335,7 @@ validate_audio_device() {
         print_message "⚠️ User $USER is not in the audio group" "$YELLOW"
         if sudo usermod -aG audio "$USER"; then
             print_message "✅ Added user $USER to audio group" "$GREEN"
-            print_message "⚠️ Please log out and log back in for group changes to take effect" "$YELLOW"
+            print_message "⚠️ Please log out and log back in for group changes to take effect.$(migrate_rerun_hint)" "$YELLOW"
             exit 0
         else
             print_message "❌ Failed to add user to audio group" "$RED"
@@ -6207,8 +6277,8 @@ show_usage() {
     echo "                          Default: nightly"
     echo "                          Examples: latest, v1.2.3, nightly, sha256:abc123..."
     echo "  --silent                Non-interactive install using environment variables"
-    echo "  --migrate                 Migrate an existing install from another host over SSH"
-    echo "  --migrate-from <ssh-dest> Non-interactive migrate source (user@host or ssh alias)"
+    echo "  --migrate               Migrate an existing install from another host over SSH"
+    echo "  --migrate-from <host>   Migrate source (user@host or ssh alias); add --silent to avoid prompts"
     echo "  --force-root            Allow running as root (not recommended)"
     echo "  -h, --help              Show this help message"
     echo ""
@@ -7051,7 +7121,7 @@ handle_menu_selection() {
 }
 
 # Silent mode skips the menu and forces fresh install
-if [ "$SILENT_MODE" = "true" ] && { [ "$INSTALLATION_TYPE" != "none" ] || [ "$PRESERVED_DATA" = true ]; }; then
+if [ "$SILENT_MODE" = "true" ] && [ "$MIGRATE_MODE" != "true" ] && { [ "$INSTALLATION_TYPE" != "none" ] || [ "$PRESERVED_DATA" = true ]; }; then
     print_message "🔇 Silent mode: performing update on existing installation" "$YELLOW"
     if [ "$INSTALLATION_TYPE" = "full" ] || [ "$INSTALLATION_TYPE" = "docker" ]; then
         check_network
@@ -7069,7 +7139,7 @@ if [ "$SILENT_MODE" = "true" ] && { [ "$INSTALLATION_TYPE" != "none" ] || [ "$PR
 fi
 
 # Menu loop for existing installations (skipped in silent mode and after migration)
-if [ "$SILENT_MODE" != "true" ] && [ "$MIGRATION_DONE" != "true" ] && { [ "$INSTALLATION_TYPE" != "none" ] || [ "$PRESERVED_DATA" = true ]; }; then
+if [ "$SILENT_MODE" != "true" ] && [ "$MIGRATE_MODE" != "true" ] && [ "$MIGRATION_DONE" != "true" ] && { [ "$INSTALLATION_TYPE" != "none" ] || [ "$PRESERVED_DATA" = true ]; }; then
     while true; do
         # Display menu based on installation type
         print_message ""  # Add spacing
@@ -7143,7 +7213,7 @@ sudo apt -qq update
 print_message "\n🔧 Checking and installing required packages..." "$YELLOW"
 
 # Check which packages need to be installed
-REQUIRED_PACKAGES=("alsa-utils" "curl" "bc" "jq" "apache2-utils" "netcat-openbsd" "iproute2" "lsof" "avahi-daemon" "libnss-mdns" "sqlite3")
+REQUIRED_PACKAGES=("alsa-utils" "curl" "bc" "jq" "apache2-utils" "netcat-openbsd" "iproute2" "lsof" "avahi-daemon" "libnss-mdns")
 TO_INSTALL=()
 
 for pkg in "${REQUIRED_PACKAGES[@]}"; do
@@ -7180,7 +7250,8 @@ pull_docker_image
 # fresh-install directory/config steps run.
 if [ "$MIGRATE_MODE" = "true" ]; then
     if ! migrate_from_remote_host; then
-        print_message "❌ Migration failed; no changes started. See messages above." "$RED"
+        print_message "❌ Migration failed. See messages above." "$RED"
+        send_telemetry_event "error" "Cross-host migration failed" "error" "step=remote_migrate,result=failure"
         exit 1
     fi
 fi

--- a/install.sh
+++ b/install.sh
@@ -28,6 +28,14 @@ SILENT_MODE="false"
 # Force root mode - allow running as root despite warnings (set via --force-root flag)
 FORCE_ROOT="false"
 
+# Cross-host migration (set via --migrate / --migrate-from flags)
+MIGRATE_MODE="false"
+MIGRATE_DEST=""
+MIGRATE_SSH_SOCKET=""
+MIGRATE_REMOTE_HOME=""
+MIGRATE_REMOTE_APP=""
+MIGRATE_TMP_UNIT=""
+
 # Flag to track if Docker image was changed during update/rollback
 IMAGE_CHANGED="false"
 
@@ -57,6 +65,12 @@ cleanup_temp_files() {
     rm -f /tmp/version_history_*.tmp 2>/dev/null
     rm -f "$LOG_DIR/.last_backup_time" 2>/dev/null
     rm -f "$VERSION_HISTORY_FILE.lock" 2>/dev/null
+    # Migration teardown: close the shared ssh master and drop the temp unit file.
+    if [ -n "$MIGRATE_SSH_SOCKET" ] && [ -n "$MIGRATE_DEST" ]; then
+        ssh -o ControlPath="$MIGRATE_SSH_SOCKET" -O exit "$MIGRATE_DEST" 2>/dev/null || true
+    fi
+    [ -n "$MIGRATE_TMP_UNIT" ] && rm -f "$MIGRATE_TMP_UNIT" 2>/dev/null
+    return 0
 }
 trap cleanup_temp_files EXIT INT TERM
 
@@ -1610,7 +1624,7 @@ EOF
         fi
 
         if [ "$groups_added" = true ]; then
-            print_message "Please log out and log back in for group changes to take effect, and rerun install.sh to continue with install" "$YELLOW"
+            print_message "Please log out and log back in for group changes to take effect, and rerun install.sh to continue with install.$(migrate_rerun_hint)" "$YELLOW"
             exit 0
         fi
     }
@@ -1646,7 +1660,7 @@ EOF
             exit 1
         fi
         log_message "INFO" "Docker installation completed, user needs to log out and back in for group changes"
-        print_message "⚠️ Docker installed successfully. To make group member changes take effect, please log out and log back in and rerun install.sh to continue with install" "$YELLOW"
+        print_message "⚠️ Docker installed successfully. To make group member changes take effect, please log out and log back in and rerun install.sh to continue with install.$(migrate_rerun_hint)" "$YELLOW"
         # exit install script
         exit 0
     else
@@ -1775,6 +1789,229 @@ rewrite_migrated_config_paths() {
         sed -i -e "s|${esc_old}|${esc_new}|g" -- "$config"
     done
     log_message "INFO" "Rewrote migrated config paths from ${old_home}/* to ${new_home}/* in $config"
+}
+
+# ---------------------------------------------------------------------------
+# Cross-host migration: pull an existing install from another host over SSH.
+# ---------------------------------------------------------------------------
+
+# Validate a user-supplied ssh destination (alias or user@host). Rejects empty
+# input and anything with whitespace or shell-unsafe characters so it is safe to
+# splice into ssh/rsync command lines. Echoes the validated destination.
+parse_ssh_dest() {
+    local dest="$1"
+    [ -n "$dest" ] || return 1
+    case "$dest" in
+        *[!A-Za-z0-9._@-]*) return 1 ;;
+    esac
+    printf '%s' "$dest"
+}
+
+# When a group-change re-login is required mid-migration, tell the user the exact
+# flag to re-run with so the resumed run stays in migration mode.
+migrate_rerun_hint() {
+    [ "$MIGRATE_MODE" = "true" ] || return 0
+    if [ -n "$MIGRATE_DEST" ]; then
+        printf ' Re-run with: ./install.sh --migrate-from %s' "$MIGRATE_DEST"
+    else
+        printf ' Re-run with: ./install.sh --migrate'
+    fi
+}
+
+# The default remote app path for a given remote home. Pure; unit-tested.
+remote_default_app_path() {
+    printf '%s/birdnet-go-app' "$1"
+}
+
+# Run a command on the migration source over the shared ssh connection.
+migrate_ssh() {
+    ssh -o ControlPath="$MIGRATE_SSH_SOCKET" "$MIGRATE_DEST" "$@"
+}
+
+# Open one ControlMaster connection so the user authenticates once. Silent mode
+# must never block on a prompt.
+open_ssh_master() {
+    MIGRATE_SSH_SOCKET="$(mktemp -u "${TMPDIR:-/tmp}/bng-mig-ssh.XXXXXX")"
+    local opts=(-o ControlMaster=auto -o ControlPersist=300 -o ControlPath="$MIGRATE_SSH_SOCKET")
+    if [ "$SILENT_MODE" = "true" ]; then
+        opts+=(-o BatchMode=yes -o StrictHostKeyChecking=accept-new)
+    fi
+    if ! ssh "${opts[@]}" "$MIGRATE_DEST" true; then
+        print_message "❌ Could not connect to $MIGRATE_DEST over SSH" "$RED"
+        return 1
+    fi
+}
+
+# Resolve the old host's home and app dir; verify a real install is present.
+resolve_remote_app() {
+    MIGRATE_REMOTE_HOME="$(migrate_ssh 'printf %s "$HOME"')"
+    if [ -z "$MIGRATE_REMOTE_HOME" ]; then
+        print_message "❌ Could not determine the remote home directory" "$RED"
+        return 1
+    fi
+    local candidate
+    candidate="$(remote_default_app_path "$MIGRATE_REMOTE_HOME")"
+    if migrate_ssh "test -f '$candidate/config/config.yaml'"; then
+        MIGRATE_REMOTE_APP="$candidate"
+        return 0
+    fi
+    if [ "$SILENT_MODE" = "true" ]; then
+        print_message "❌ No install found at $candidate on the remote host" "$RED"
+        print_message "   If it lives under /root, run the root->user migration on the OLD host first." "$YELLOW"
+        return 1
+    fi
+    print_message "No install at $candidate. Enter the remote birdnet-go-app path: " "$YELLOW" "nonewline"
+    local p; read -r p
+    if [ -n "$p" ] && migrate_ssh "test -f '$p/config/config.yaml'"; then
+        MIGRATE_REMOTE_APP="$p"
+        return 0
+    fi
+    print_message "❌ No valid install at that path (need config/config.yaml readable by $MIGRATE_DEST)" "$RED"
+    return 1
+}
+
+# 0 = stopped/absent, 1 = still running. Compare the is-active OUTPUT string, not
+# the exit code (which cannot distinguish inactive from an ssh failure).
+check_remote_stopped() {
+    local state
+    state="$(migrate_ssh 'systemctl is-active birdnet-go.service 2>/dev/null' || true)"
+    [ "$state" = "active" ] && return 1
+    local ctr
+    ctr="$(migrate_ssh 'docker ps --filter name=birdnet-go --format "{{.Names}}" 2>/dev/null' || true)"
+    [ -n "$ctr" ] && return 1
+    return 0
+}
+
+# Ensure the new host has room for the remote dataset (+10% margin). Fails open if
+# either size cannot be determined.
+check_remote_disk() {
+    local remote_kb avail_kb
+    remote_kb="$(migrate_ssh "du -sk '$MIGRATE_REMOTE_APP' 2>/dev/null | cut -f1")"
+    avail_kb="$(df -Pk "$HOME" | awk 'NR==2 {print $4}')"
+    if [ -n "$remote_kb" ] && [ "$remote_kb" -gt 0 ] 2>/dev/null && [ -n "$avail_kb" ]; then
+        local need_kb=$(( remote_kb + remote_kb / 10 ))
+        if [ "$avail_kb" -lt "$need_kb" ]; then
+            print_message "❌ Not enough disk space: need ~$(( need_kb / 1024 )) MB, have $(( avail_kb / 1024 )) MB" "$RED"
+            return 1
+        fi
+    fi
+    return 0
+}
+
+# Adopt an already-transferred birdnet-go-app: rewrite host paths, preserve the
+# old service settings, verify the DB, and flag migration complete.
+adopt_migrated_installation() {
+    local dest="$HOME/birdnet-go-app"
+    rewrite_migrated_config_paths "$dest/config/config.yaml" "$MIGRATE_REMOTE_HOME" "$HOME"
+
+    MIGRATE_TMP_UNIT="$(mktemp "${TMPDIR:-/tmp}/bng-mig-unit.XXXXXX")"
+    if migrate_ssh 'cat /etc/systemd/system/birdnet-go.service 2>/dev/null || cat /lib/systemd/system/birdnet-go.service 2>/dev/null' > "$MIGRATE_TMP_UNIT" && [ -s "$MIGRATE_TMP_UNIT" ]; then
+        load_existing_service_config "$MIGRATE_TMP_UNIT"
+        print_message "📍 Preserved old settings (web port: ${WEB_PORT:-default}, timezone: ${CONFIGURED_TZ:-unset})" "$GREEN"
+    else
+        print_message "⚠️  Could not read the old systemd unit; using default port/TLS/timezone" "$YELLOW"
+    fi
+
+    local db="$dest/data/birdnet.db"
+    if [ -f "$db" ] && command_exists sqlite3; then
+        local res
+        res="$(sqlite3 "$db" 'PRAGMA integrity_check;' 2>/dev/null)"
+        if [ "$res" = "ok" ]; then
+            print_message "✅ Database integrity verified" "$GREEN"
+        else
+            print_message "⚠️  Database integrity check: ${res:-unreadable}. If the old service was running during copy, stop it and re-run." "$YELLOW"
+        fi
+    fi
+
+    if grep -qiE '^[[:space:]]*type:[[:space:]]*mysql' "$dest/config/config.yaml" 2>/dev/null; then
+        print_message "⚠️  Config references a MySQL database; only config and clips migrated, not the external DB." "$YELLOW"
+    fi
+
+    load_telemetry_config
+    MIGRATION_DONE="true"
+    return 0
+}
+
+# Pull an install from another host over SSH and adopt it. Returns nonzero on any
+# failure (caller aborts the install); on success sets MIGRATION_DONE=true.
+migrate_from_remote_host() {
+    local dest_dir="$HOME/birdnet-go-app"
+    print_message "\n🔄 Migrating BirdNET-Go from another host over SSH" "$GREEN"
+
+    if [ -z "$MIGRATE_DEST" ]; then
+        if [ "$SILENT_MODE" = "true" ]; then
+            print_message "❌ --migrate needs --migrate-from <ssh-dest> in silent mode" "$RED"; return 1
+        fi
+        print_message "Old host (user@host or ssh alias): " "$YELLOW" "nonewline"
+        read -r MIGRATE_DEST
+    fi
+    if ! MIGRATE_DEST="$(parse_ssh_dest "$MIGRATE_DEST")"; then
+        print_message "❌ Invalid ssh destination" "$RED"; return 1
+    fi
+
+    # Overwrite guard: never rsync-merge into pre-existing data. Trigger on a real
+    # install (config.yaml), an existing database, OR any non-empty app dir, then
+    # move the whole dir aside so the transfer writes into a clean target.
+    if [ -f "$dest_dir/config/config.yaml" ] || [ -f "$dest_dir/data/birdnet.db" ] || \
+       { [ -d "$dest_dir" ] && [ -n "$(ls -A "$dest_dir" 2>/dev/null)" ]; }; then
+        if [ "$SILENT_MODE" = "true" ]; then
+            print_message "❌ $dest_dir already contains data; refusing to overwrite in silent mode" "$RED"; return 1
+        fi
+        print_message "⚠️  $dest_dir already contains data on this machine." "$YELLOW"
+        print_message "Move it aside to a backup and continue? [y/N]: " "$YELLOW" "nonewline"
+        local ans; read -r ans
+        [[ "$ans" =~ ^[Yy]$ ]] || { print_message "Migration cancelled; nothing changed." "$NC"; return 1; }
+        local backup="${dest_dir}.bak.$(date +%Y%m%d%H%M%S)"
+        mv "$dest_dir" "$backup" || { print_message "❌ Backup move failed" "$RED"; return 1; }
+        print_message "📦 Existing data moved to $backup (nothing deleted)" "$GREEN"
+    fi
+
+    command_exists rsync || { print_message "❌ rsync missing locally (should have been installed)" "$RED"; return 1; }
+
+    open_ssh_master || return 1
+    resolve_remote_app || return 1
+
+    if ! check_remote_stopped; then
+        print_message "⚠️  BirdNET-Go is still running on $MIGRATE_DEST. Copying a live database can corrupt it." "$YELLOW"
+        print_message "Stop it now over SSH (sudo)? [y/N]: " "$YELLOW" "nonewline"
+        local s; read -r s
+        if [[ "$s" =~ ^[Yy]$ ]]; then
+            ssh -t -o ControlPath="$MIGRATE_SSH_SOCKET" "$MIGRATE_DEST" 'sudo systemctl stop birdnet-go.service' || true
+            check_remote_stopped || { print_message "❌ Still running; stop it manually and re-run" "$RED"; return 1; }
+        else
+            print_message "❌ Stop birdnet-go on the old host, then re-run" "$RED"; return 1
+        fi
+    fi
+
+    check_remote_disk || return 1
+
+    print_message "📥 Transferring $MIGRATE_REMOTE_APP from $MIGRATE_DEST ..." "$YELLOW"
+    if migrate_ssh 'command -v rsync >/dev/null 2>&1'; then
+        if ! rsync -aH --partial --info=progress2 --exclude 'config/hls/' \
+                -e "ssh -o ControlPath=$MIGRATE_SSH_SOCKET" \
+                "$MIGRATE_DEST:$MIGRATE_REMOTE_APP/" "$dest_dir/"; then
+            print_message "❌ rsync failed (incomplete transfer); nothing adopted" "$RED"
+            rm -rf "$dest_dir"; return 1
+        fi
+    else
+        print_message "ℹ️  rsync not on the remote; using tar over SSH" "$YELLOW"
+        mkdir -p "$dest_dir"
+        if ! migrate_ssh "tar -C '$MIGRATE_REMOTE_HOME' --exclude='birdnet-go-app/config/hls' -cf - birdnet-go-app" | tar -C "$HOME" -xf -; then
+            print_message "❌ tar transfer failed; nothing adopted" "$RED"
+            rm -rf "$dest_dir"; return 1
+        fi
+    fi
+
+    if [ ! -f "$dest_dir/config/config.yaml" ]; then
+        print_message "❌ Transfer left no config.yaml; aborting" "$RED"
+        rm -rf "$dest_dir"; return 1
+    fi
+
+    if ! adopt_migrated_installation; then
+        print_message "❌ Adopt step failed" "$RED"; rm -rf "$dest_dir"; return 1
+    fi
+    print_message "✅ Migration data adopted; continuing with provisioning" "$GREEN"
+    return 0
 }
 
 # Function to migrate a root installation to the current user's home directory
@@ -5970,6 +6207,8 @@ show_usage() {
     echo "                          Default: nightly"
     echo "                          Examples: latest, v1.2.3, nightly, sha256:abc123..."
     echo "  --silent                Non-interactive install using environment variables"
+    echo "  --migrate                 Migrate an existing install from another host over SSH"
+    echo "  --migrate-from <ssh-dest> Non-interactive migrate source (user@host or ssh alias)"
     echo "  --force-root            Allow running as root (not recommended)"
     echo "  -h, --help              Show this help message"
     echo ""
@@ -6014,6 +6253,22 @@ parse_arguments() {
             --silent)
                 SILENT_MODE="true"
                 shift
+                ;;
+            --migrate)
+                MIGRATE_MODE="true"
+                shift
+                ;;
+            --migrate-from)
+                if [ -n "$2" ] && [[ $2 != -* ]]; then
+                    MIGRATE_MODE="true"
+                    MIGRATE_DEST="$2"
+                    shift 2
+                else
+                    echo "❌ Error: --migrate-from requires an ssh destination (user@host or ssh alias)" >&2
+                    echo ""
+                    show_usage
+                    exit 1
+                fi
                 ;;
             --force-root)
                 FORCE_ROOT="true"
@@ -6888,7 +7143,7 @@ sudo apt -qq update
 print_message "\n🔧 Checking and installing required packages..." "$YELLOW"
 
 # Check which packages need to be installed
-REQUIRED_PACKAGES=("alsa-utils" "curl" "bc" "jq" "apache2-utils" "netcat-openbsd" "iproute2" "lsof" "avahi-daemon" "libnss-mdns")
+REQUIRED_PACKAGES=("alsa-utils" "curl" "bc" "jq" "apache2-utils" "netcat-openbsd" "iproute2" "lsof" "avahi-daemon" "libnss-mdns" "sqlite3")
 TO_INSTALL=()
 
 for pkg in "${REQUIRED_PACKAGES[@]}"; do
@@ -6920,6 +7175,15 @@ fi
 
 # Pull Docker image
 pull_docker_image
+
+# Cross-host migration: pull and adopt an existing install before the normal
+# fresh-install directory/config steps run.
+if [ "$MIGRATE_MODE" = "true" ]; then
+    if ! migrate_from_remote_host; then
+        print_message "❌ Migration failed; no changes started. See messages above." "$RED"
+        exit 1
+    fi
+fi
 
 # Check if directories can be created
 check_directory "$CONFIG_DIR"

--- a/install.sh
+++ b/install.sh
@@ -1954,8 +1954,8 @@ adopt_migrated_installation() {
     log_message "INFO" "Adopting migrated installation at $dest (source $MIGRATE_DEST)"
     rewrite_migrated_config_paths "$dest/config/config.yaml" "$MIGRATE_REMOTE_HOME" "$HOME"
 
-    MIGRATE_TMP_UNIT="$(mktemp "${TMPDIR:-/tmp}/bng-mig-unit.XXXXXX")"
-    if migrate_ssh 'cat /etc/systemd/system/birdnet-go.service 2>/dev/null || cat /lib/systemd/system/birdnet-go.service 2>/dev/null' > "$MIGRATE_TMP_UNIT" && [ -s "$MIGRATE_TMP_UNIT" ]; then
+    MIGRATE_TMP_UNIT="$(mktemp "${TMPDIR:-/tmp}/bng-mig-unit.XXXXXX")" || MIGRATE_TMP_UNIT=""
+    if [ -n "$MIGRATE_TMP_UNIT" ] && migrate_ssh 'cat /etc/systemd/system/birdnet-go.service 2>/dev/null || cat /lib/systemd/system/birdnet-go.service 2>/dev/null' > "$MIGRATE_TMP_UNIT" && [ -s "$MIGRATE_TMP_UNIT" ]; then
         load_existing_service_config "$MIGRATE_TMP_UNIT"
         print_message "📍 Preserved old settings (web port: ${WEB_PORT:-default}, timezone: ${CONFIGURED_TZ:-unset})" "$GREEN"
     else
@@ -2089,10 +2089,15 @@ migrate_from_remote_host() {
         print_message "❓ Stop it now over SSH (sudo)? (y/n): " "$YELLOW" "nonewline"
         local s; read -r s
         if [[ "$s" =~ ^[Yy]$ ]]; then
-            if ssh -t -o ControlPath="$MIGRATE_SSH_SOCKET" "$MIGRATE_DEST" 'sudo systemctl stop birdnet-go.service'; then
+            ssh -t -o ControlPath="$MIGRATE_SSH_SOCKET" "$MIGRATE_DEST" 'sudo systemctl stop birdnet-go.service' || true
+            # Trust the observed state, not ssh's exit code: ssh -t can report
+            # failure even when the remote command stopped the service. If it is now
+            # stopped, this run stopped it, so rollback must be able to restart it.
+            if check_remote_stopped; then
                 MIGRATE_STOPPED_REMOTE="1"
+            else
+                print_message "❌ Still running; stop it manually and re-run" "$RED"; migrate_rollback; return 1
             fi
-            check_remote_stopped || { print_message "❌ Still running; stop it manually and re-run" "$RED"; migrate_rollback; return 1; }
         else
             print_message "❌ Stop birdnet-go on the old host, then re-run" "$RED"; migrate_rollback; return 1
         fi

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -126,6 +126,7 @@ for fn in \
     configure_auth \
     rewrite_migrated_config_paths \
     parse_ssh_dest \
+    remote_path_safe \
     remote_default_app_path
 do
     load_fn "$fn"
@@ -622,11 +623,26 @@ assert_eq "already-8080 stays 8080 (idempotent)" '"8080"' "$(yaml_after "$cfg" '
 # parse_ssh_dest (validate the migration ssh destination)
 # ===========================================================================
 it "parse_ssh_dest"
-assert_eq "accepts user@host" "pi@raspi4.local" "$(parse_ssh_dest 'pi@raspi4.local')"
+ssh_dest_out="$(parse_ssh_dest 'pi@raspi4.local')"; ssh_dest_rc=$?
+assert_eq "accepts user@host" "pi@raspi4.local" "$ssh_dest_out"
+assert_ok "user@host returns success rc" "$ssh_dest_rc"
 assert_eq "accepts bare alias" "oldpi" "$(parse_ssh_dest 'oldpi')"
+assert_eq "accepts underscore alias" "old_pi" "$(parse_ssh_dest 'old_pi')"
 parse_ssh_dest "" >/dev/null 2>&1; assert_nonzero "rejects empty" "$?"
 parse_ssh_dest "a b" >/dev/null 2>&1; assert_nonzero "rejects whitespace" "$?"
-parse_ssh_dest 'a;rm -rf /' >/dev/null 2>&1; assert_nonzero "rejects shell metacharacters" "$?"
+# metachar WITHOUT whitespace: isolates the charset guard from the whitespace guard
+parse_ssh_dest 'a;b' >/dev/null 2>&1; assert_nonzero "rejects semicolon (no whitespace)" "$?"
+parse_ssh_dest 'host|nc' >/dev/null 2>&1; assert_nonzero "rejects pipe" "$?"
+parse_ssh_dest 'host$(id)' >/dev/null 2>&1; assert_nonzero "rejects command substitution chars" "$?"
+# colon is rejected: the transfer appends :$path itself, so the dest must not carry one
+parse_ssh_dest 'host:22' >/dev/null 2>&1; assert_nonzero "rejects colon" "$?"
+# leading dash must not be accepted (would be read as an ssh/rsync flag)
+parse_ssh_dest '-oProxyCommand=x' >/dev/null 2>&1; assert_nonzero "rejects leading-dash flag-like dest" "$?"
+
+it "remote_path_safe"
+remote_path_safe "/home/pi/birdnet-go-app"; assert_ok "accepts a normal path" "$?"
+remote_path_safe ""; assert_nonzero "rejects empty" "$?"
+remote_path_safe "/data'; rm -rf ~"; assert_nonzero "rejects embedded single quote" "$?"
 
 # ===========================================================================
 # remote_default_app_path (default remote birdnet-go-app location)

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -124,7 +124,9 @@ for fn in \
     configure_audio_format \
     configure_locale \
     configure_auth \
-    rewrite_migrated_config_paths
+    rewrite_migrated_config_paths \
+    parse_ssh_dest \
+    remote_default_app_path
 do
     load_fn "$fn"
 done
@@ -615,6 +617,23 @@ ensure_internal_port_8080
 assert_eq "custom internal port normalized to 8080" '"8080"' "$(yaml_after "$cfg" '^webserver:' 2 port)"
 ensure_internal_port_8080
 assert_eq "already-8080 stays 8080 (idempotent)" '"8080"' "$(yaml_after "$cfg" '^webserver:' 2 port)"
+
+# ===========================================================================
+# parse_ssh_dest (validate the migration ssh destination)
+# ===========================================================================
+it "parse_ssh_dest"
+assert_eq "accepts user@host" "pi@raspi4.local" "$(parse_ssh_dest 'pi@raspi4.local')"
+assert_eq "accepts bare alias" "oldpi" "$(parse_ssh_dest 'oldpi')"
+parse_ssh_dest "" >/dev/null 2>&1; assert_nonzero "rejects empty" "$?"
+parse_ssh_dest "a b" >/dev/null 2>&1; assert_nonzero "rejects whitespace" "$?"
+parse_ssh_dest 'a;rm -rf /' >/dev/null 2>&1; assert_nonzero "rejects shell metacharacters" "$?"
+
+# ===========================================================================
+# remote_default_app_path (default remote birdnet-go-app location)
+# ===========================================================================
+it "remote_default_app_path"
+assert_eq "default app path from home" "/home/pi/birdnet-go-app" "$(remote_default_app_path /home/pi)"
+assert_eq "root home" "/root/birdnet-go-app" "$(remote_default_app_path /root)"
 
 # ===========================================================================
 # Result


### PR DESCRIPTION
## Summary

Adds a cross-host migration mode to `install.sh` so a user moving BirdNET-Go to a new machine (e.g. Raspberry Pi 4 to Pi 5) can pull their existing install over SSH and adopt it, instead of copying files by hand and re-doing the systemd/group setup.

`install.sh --migrate` (or `--migrate-from <host>` to name the source non-interactively) rsyncs the old `~/birdnet-go-app` (config, SQLite database, and audio clips) from the old host straight into the new host's app directory, then reconfigures the systemd service for the new machine while preserving the user's web port, TLS, metrics, and timezone from the old host's unit. apt + systemd Linux only; no macOS/Windows.

How it works: it opens one shared SSH connection, verifies the old service is stopped before copying (offering to stop it over SSH), checks free disk space before the transfer, rsyncs straight into the destination (tar-over-SSH fallback when the remote lacks rsync), then rewrites host paths in the config, preserves service settings from the old unit, runs a SQLite integrity check, and lets the normal install flow regenerate the unit and start the service.

Safety: it never overwrites existing data on the target (moves it aside to a timestamped backup, or refuses in silent mode), rolls back a partial transfer, validates the SSH destination and remote path before splicing them into remote commands, and installs `rsync`/`sqlite3` only on the migrate path so a normal install/update gains no unused packages. It reuses the existing config-path-rewrite and service-setting-preservation helpers and does not touch the existing local root-to-user migration.

## Test Plan

- [x] `shellcheck -S error install.sh` clean; `shellcheck -S warning scripts/install_test.sh` clean (the CI gate)
- [x] `scripts/install_test.sh` passes (94/94), including new `parse_ssh_dest`, `remote_path_safe`, and `remote_default_app_path` cases
- [x] `--help` lists the new flags; `--migrate-from` with no value and unknown flags still error
- [ ] End-to-end migration between two hosts (manual; needs two machines): old host stopped -> data pulled, adopted, service starts on the preserved port; running-old-host prompt path; group-change re-login resumes in migrate mode; interrupted rsync resumes via --partial

## Release notes
- audience: user
- summary: Move an existing BirdNET-Go install to a new machine over SSH: run install.sh --migrate on the new host and it pulls your config, database, and recordings from the old host and reconfigures the service, keeping your port, TLS, metrics, and timezone settings.
- feature: none
- breaking: none
- config: none
- schema: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cross-host installation migration using `--migrate` and `--migrate-from`, including remote data transfer and local adoption.
  * Migration preserves prior service settings and performs integrity checks when possible.
  * Migration is designed to avoid interactive prompts and updates CLI help and guidance.
* **Bug Fixes**
  * Added validation for remote SSH destination/paths, remote service stopped state, and remote disk capacity, with rollback on failure.
* **Tests**
  * Added unit tests for SSH destination/path parsing and default remote path selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->