### PR TITLE
fix(system): show Health page CPU temperature in the configured unit and unify thermal readers

### DIFF
--- a/internal/api/v2/system/constants.go
+++ b/internal/api/v2/system/constants.go
@@ -26,19 +26,6 @@ const (
 	millisecondsPerSecond = 1000 // Milliseconds in a second
 )
 
-// CPU temperature constants.
-const (
-	// milliCelsiusPerCelsius converts sysfs thermal readings, which are exposed
-	// in milli-degrees Celsius, to degrees Celsius.
-	milliCelsiusPerCelsius = 1000.0
-	// minValidCPUTempCelsius and maxValidCPUTempCelsius bound plausible CPU
-	// readings used to reject bogus sensor values. The upper bound is
-	// deliberately generous: high-performance x86 CPUs can legitimately report
-	// above 100°C under load before thermal throttling.
-	minValidCPUTempCelsius = 0.0
-	maxValidCPUTempCelsius = 120.0
-)
-
 // errResponseHandled signals that an HTTP error response has already been sent to
 // the client, so the caller should return it without sending another. It mirrors
 // the package-api sentinel of the same purpose; the value never escapes this

--- a/internal/api/v2/system/diagnostics.go
+++ b/internal/api/v2/system/diagnostics.go
@@ -90,15 +90,27 @@ func (c *Handler) registerHealthChecks() {
 		checks.NewDiskSpaceCheck(c.getDataPaths()),
 		checks.NewMemoryCheck(),
 		checks.NewCPULoadCheck(apicore.GetCachedCPUUsage),
-		checks.NewTemperatureCheck(func() (float64, error) {
-			celsius, _, err := readCPUTemperature(thermalBasePath)
-			if err != nil {
-				// Surface the real reason (no sensor, unreadable, or out of
-				// range) so the health check reports an accurate cause.
-				return 0, err
-			}
-			return celsius, nil
-		}),
+		checks.NewTemperatureCheck(
+			func() (float64, error) {
+				celsius, _, err := observability.ReadCPUTemperature(thermalBasePath)
+				if err != nil {
+					// Surface the real reason (no sensor, unreadable, or out of
+					// range) so the health check reports an accurate cause.
+					return 0, err
+				}
+				return celsius, nil
+			},
+			// Read the configured display unit per Run so a live settings
+			// change is reflected without a restart. Guard against a nil
+			// settings snapshot (possible only on a controller that never
+			// stored settings, e.g. standalone tests); "" displays Celsius.
+			func() string {
+				if s := c.CurrentSettings(); s != nil {
+					return s.Realtime.Dashboard.TemperatureUnit
+				}
+				return ""
+			},
+		),
 		checks.NewUptimeCheck(c.startTime),
 
 		// Audio checks

--- a/internal/api/v2/system/system.go
+++ b/internal/api/v2/system/system.go
@@ -14,7 +14,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -27,6 +26,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/observability"
 	"github.com/tphakala/birdnet-go/internal/restart"
 	"github.com/tphakala/birdnet-go/internal/sysinfo"
 	"golang.org/x/text/cases"
@@ -827,25 +827,18 @@ func (c *Handler) isRelevantProcess(p *process.Process, currentPID int32) bool {
 	return p.Pid == currentPID || parentPID == currentPID
 }
 
-// GetSystemCPUTemperature handles GET /api/v2/system/temperature/cpu
-// It attempts to read the CPU temperature by scanning /sys/class/thermal/thermal_zone*
-// for specific types like 'cpu-thermal' or 'x86_pkg_temp'.
-// It validates the temperature to be within a reasonable range (0-120°C).
-// thermalBasePath is the base directory for thermal zones on Linux
-const thermalBasePath = "/sys/class/thermal/"
+// thermalBasePath is the base directory for thermal zones on Linux. It aliases
+// observability.DefaultThermalBasePath so the path has a single source of truth
+// shared with the metrics collector and the temperature health check.
+const thermalBasePath = observability.DefaultThermalBasePath
 
 // defaultNoSensorMessage is the default message when no suitable CPU temperature sensor is found
 const defaultNoSensorMessage = "No suitable CPU temperature sensor found or temperature out of valid range."
 
-// cpuThermalTypes contains sensor types for CPU temperature
-var cpuThermalTypes = map[string]bool{
-	"cpu-thermal":     true, // Common on Raspberry Pi
-	"x86_pkg_temp":    true, // Common on Intel x86 systems (like NUC)
-	"soc_thermal":     true, // Common on some ARM SoCs
-	"cpu_thermal":     true, // Alternative name
-	"thermal-fan-est": true, // Seen on some systems
-}
-
+// GetSystemCPUTemperature handles GET /api/v2/system/temperature/cpu. It reads
+// the CPU temperature via observability.ReadCPUTemperature, which scans
+// /sys/class/thermal/thermal_zone* for CPU sensor types (e.g. 'cpu-thermal',
+// 'x86_pkg_temp') and validates the reading against the shared valid range.
 func (c *Handler) GetSystemCPUTemperature(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
 	c.LogInfoIfEnabled("Getting system CPU temperature", logger.String("path", path), logger.String("ip", ip))
@@ -864,7 +857,7 @@ func (c *Handler) GetSystemCPUTemperature(ctx echo.Context) error {
 		return ctx.JSON(http.StatusOK, response)
 	}
 
-	celsius, details, err := readCPUTemperature(thermalBasePath)
+	celsius, details, err := observability.ReadCPUTemperature(thermalBasePath)
 	if err == nil {
 		response.Celsius = celsius
 		response.IsAvailable = true
@@ -907,77 +900,6 @@ func (c *Handler) setTemperatureNotFoundResponse(response *SystemTemperature, la
 	}
 
 	c.LogInfoIfEnabled("Could not retrieve a valid CPU temperature after checking all zones.", logger.String("final_message", response.Message), logger.String("sensor_details_attempted", response.SensorDetails), logger.String("request_path", path), logger.String("ip", ip))
-}
-
-// readCPUTemperature attempts to read the CPU temperature by scanning thermal zones in the base path.
-// It returns the temperature in Celsius, details about the sensor, and any error.
-func readCPUTemperature(basePath string) (celsius float64, details string, err error) {
-	zones, err := filepath.Glob(filepath.Join(basePath, "thermal_zone*"))
-	if err != nil {
-		return 0, "", fmt.Errorf("failed to scan for thermal zones: %w", err)
-	}
-
-	var (
-		lastAttemptDetails string
-		hottestCelsius     float64
-		hottestDetails     string
-		found              bool
-	)
-	for _, zonePath := range zones {
-		zoneName := filepath.Base(zonePath)
-		typePath := filepath.Join(zonePath, "type")
-
-		//nolint:gosec // G304: typePath is from filepath.Glob
-		typeData, err := os.ReadFile(typePath)
-		if err != nil {
-			continue
-		}
-
-		sensorType := strings.ToLower(strings.TrimSpace(string(typeData)))
-		if !cpuThermalTypes[sensorType] {
-			continue
-		}
-
-		tempFilePath := filepath.Join(zonePath, "temp")
-		//nolint:gosec // G304: tempFilePath is from filepath.Glob
-		tempData, err := os.ReadFile(tempFilePath)
-		if err != nil {
-			lastAttemptDetails = fmt.Sprintf("Error reading temp from %s (type: %s)", zoneName, sensorType)
-			continue
-		}
-
-		tempStr := strings.TrimSpace(string(tempData))
-		tempMillCelsius, err := strconv.Atoi(tempStr)
-		if err != nil {
-			lastAttemptDetails = fmt.Sprintf("Error parsing temp from %s (type: %s, value: '%s')", zoneName, sensorType, tempStr)
-			continue
-		}
-
-		zoneCelsius := float64(tempMillCelsius) / milliCelsiusPerCelsius
-		if zoneCelsius < minValidCPUTempCelsius || zoneCelsius > maxValidCPUTempCelsius {
-			lastAttemptDetails = fmt.Sprintf("Invalid temp from %s (type: %s, value: %.1f°C, expected %.0f-%.0f°C)", zoneName, sensorType, zoneCelsius, minValidCPUTempCelsius, maxValidCPUTempCelsius)
-			continue
-		}
-
-		// Track the hottest valid CPU zone rather than returning the first, so
-		// multi-zone systems (dual-socket, multi-die) still surface an
-		// overheating package and selection does not depend on glob ordering.
-		if !found || zoneCelsius > hottestCelsius {
-			hottestCelsius = zoneCelsius
-			hottestDetails = fmt.Sprintf("Source: %s, Type: %s", zoneName, sensorType)
-			found = true
-		}
-	}
-
-	if found {
-		return hottestCelsius, hottestDetails, nil
-	}
-
-	if lastAttemptDetails != "" {
-		return 0, lastAttemptDetails, fmt.Errorf("a targeted CPU sensor was found but could not be read successfully or value was invalid")
-	}
-
-	return 0, "", fmt.Errorf("no valid CPU temperature sensor found")
 }
 
 // Helper functions

--- a/internal/health/checks/system.go
+++ b/internal/health/checks/system.go
@@ -243,14 +243,46 @@ func (c *CPULoadCheck) Run(_ context.Context) health.Result {
 	}
 }
 
+// Temperature display units. These mirror the dashboard "temperatureunit"
+// setting in internal/conf (kept as local constants so this package does not
+// depend on conf just to compare a string).
+const (
+	tempUnitCelsius    = "celsius"
+	tempUnitFahrenheit = "fahrenheit"
+)
+
+// Celsius-to-Fahrenheit conversion factors.
+const (
+	fahrenheitScale  = 9.0 / 5.0
+	fahrenheitOffset = 32.0
+)
+
 // TemperatureCheck verifies that the system temperature is within safe bounds.
 type TemperatureCheck struct {
 	getTemp func() (float64, error)
+	getUnit func() string
 }
 
-// NewTemperatureCheck creates a TemperatureCheck that uses getTemp to obtain the current temperature in Celsius.
-func NewTemperatureCheck(getTemp func() (float64, error)) *TemperatureCheck {
-	return &TemperatureCheck{getTemp: getTemp}
+// NewTemperatureCheck creates a TemperatureCheck that uses getTemp to obtain the
+// current temperature in Celsius. getUnit returns the configured display unit
+// ("celsius" or "fahrenheit") and is read per Run so a live settings change is
+// reflected without a restart; a nil getUnit displays Celsius.
+func NewTemperatureCheck(getTemp func() (float64, error), getUnit func() string) *TemperatureCheck {
+	return &TemperatureCheck{getTemp: getTemp, getUnit: getUnit}
+}
+
+// displayTemperature converts a Celsius reading to the configured display unit,
+// returning the converted value and its symbol. Warn/critical thresholds are
+// always compared in Celsius; only the displayed value is converted.
+func (c *TemperatureCheck) displayTemperature(celsius float64) (value float64, symbol string) {
+	unit := tempUnitCelsius
+	if c.getUnit != nil {
+		unit = c.getUnit()
+	}
+	if unit == tempUnitFahrenheit {
+		return celsius*fahrenheitScale + fahrenheitOffset, "F"
+	}
+	return celsius, "C"
 }
 
 // Name returns the check identifier.
@@ -282,16 +314,21 @@ func (c *TemperatureCheck) Run(_ context.Context) health.Result {
 	const warnTemp = 75.0
 	const critTemp = 85.0
 
+	// Thresholds are physical constants compared in Celsius; only the displayed
+	// value is converted to the configured unit (matching how other checks embed
+	// a display value in the message while keeping raw values in Details).
+	displayTemp, unitSymbol := c.displayTemperature(tempC)
+
 	status := health.StatusHealthy
-	msg := fmt.Sprintf("Temperature OK (%.1f C)", tempC)
+	msg := fmt.Sprintf("Temperature OK (%.1f %s)", displayTemp, unitSymbol)
 
 	switch {
 	case tempC >= critTemp:
 		status = health.StatusCritical
-		msg = fmt.Sprintf("Temperature critical: %.1f C", tempC)
+		msg = fmt.Sprintf("Temperature critical: %.1f %s", displayTemp, unitSymbol)
 	case tempC >= warnTemp:
 		status = health.StatusWarning
-		msg = fmt.Sprintf("Temperature high: %.1f C", tempC)
+		msg = fmt.Sprintf("Temperature high: %.1f %s", displayTemp, unitSymbol)
 	}
 
 	return health.Result{
@@ -300,7 +337,12 @@ func (c *TemperatureCheck) Run(_ context.Context) health.Result {
 		Status:   status,
 		Message:  msg,
 		Details: map[string]any{
-			"temperature_c": tempC,
+			// temperature_c is the raw Celsius reading (source of truth for
+			// machine consumers); the *_display/*_unit pair mirrors what the
+			// message shows.
+			"temperature_c":       tempC,
+			"temperature_display": displayTemp,
+			"temperature_unit":    unitSymbol,
 		},
 		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
 		Timestamp:  time.Now(),

--- a/internal/health/checks/system_test.go
+++ b/internal/health/checks/system_test.go
@@ -1,0 +1,197 @@
+package checks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/health"
+)
+
+func TestTemperatureCheck_Run(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		celsius     float64
+		unit        string // "" => nil getUnit provider
+		nilUnit     bool
+		wantStatus  health.Status
+		wantMessage string
+		wantDisplay float64
+		wantSymbol  string
+	}{
+		{
+			name:        "celsius healthy",
+			celsius:     45.0,
+			unit:        tempUnitCelsius,
+			wantStatus:  health.StatusHealthy,
+			wantMessage: "Temperature OK (45.0 C)",
+			wantDisplay: 45.0,
+			wantSymbol:  "C",
+		},
+		{
+			name:        "nil unit provider defaults to celsius",
+			celsius:     45.0,
+			nilUnit:     true,
+			wantStatus:  health.StatusHealthy,
+			wantMessage: "Temperature OK (45.0 C)",
+			wantDisplay: 45.0,
+			wantSymbol:  "C",
+		},
+		{
+			name:        "fahrenheit healthy converts display only",
+			celsius:     45.0,
+			unit:        tempUnitFahrenheit,
+			wantStatus:  health.StatusHealthy,
+			wantMessage: "Temperature OK (113.0 F)",
+			wantDisplay: 113.0,
+			wantSymbol:  "F",
+		},
+		{
+			// 80C is above the 75C warn threshold but below the 85C critical
+			// threshold. In Fahrenheit that is 176F; if the thresholds were
+			// wrongly compared in Fahrenheit this would read Critical. Asserting
+			// Warning proves the comparison stays in Celsius.
+			name:        "fahrenheit warning still compared in celsius",
+			celsius:     80.0,
+			unit:        tempUnitFahrenheit,
+			wantStatus:  health.StatusWarning,
+			wantMessage: "Temperature high: 176.0 F",
+			wantDisplay: 176.0,
+			wantSymbol:  "F",
+		},
+		{
+			name:        "celsius critical",
+			celsius:     90.0,
+			unit:        tempUnitCelsius,
+			wantStatus:  health.StatusCritical,
+			wantMessage: "Temperature critical: 90.0 C",
+			wantDisplay: 90.0,
+			wantSymbol:  "C",
+		},
+		// Threshold boundaries: the switch uses tempC >= 75 (warn) and
+		// tempC >= 85 (critical). Exact-boundary and just-below cases lock the
+		// >= comparisons against an off-by-one regression.
+		{
+			name:        "just below warn stays healthy",
+			celsius:     74.9,
+			unit:        tempUnitCelsius,
+			wantStatus:  health.StatusHealthy,
+			wantMessage: "Temperature OK (74.9 C)",
+			wantDisplay: 74.9,
+			wantSymbol:  "C",
+		},
+		{
+			name:        "exact warn boundary is warning",
+			celsius:     75.0,
+			unit:        tempUnitCelsius,
+			wantStatus:  health.StatusWarning,
+			wantMessage: "Temperature high: 75.0 C",
+			wantDisplay: 75.0,
+			wantSymbol:  "C",
+		},
+		{
+			name:        "just below critical stays warning",
+			celsius:     84.9,
+			unit:        tempUnitCelsius,
+			wantStatus:  health.StatusWarning,
+			wantMessage: "Temperature high: 84.9 C",
+			wantDisplay: 84.9,
+			wantSymbol:  "C",
+		},
+		{
+			name:        "exact critical boundary is critical",
+			celsius:     85.0,
+			unit:        tempUnitCelsius,
+			wantStatus:  health.StatusCritical,
+			wantMessage: "Temperature critical: 85.0 C",
+			wantDisplay: 85.0,
+			wantSymbol:  "C",
+		},
+		{
+			// An unrecognized/empty unit falls back to Celsius, matching the
+			// dashboard default.
+			name:        "unknown unit falls back to celsius",
+			celsius:     45.0,
+			unit:        "kelvin",
+			wantStatus:  health.StatusHealthy,
+			wantMessage: "Temperature OK (45.0 C)",
+			wantDisplay: 45.0,
+			wantSymbol:  "C",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var getUnit func() string
+			if !tt.nilUnit {
+				unit := tt.unit
+				getUnit = func() string { return unit }
+			}
+			check := NewTemperatureCheck(func() (float64, error) { return tt.celsius, nil }, getUnit)
+
+			result := check.Run(t.Context())
+
+			assert.Equal(t, "temperature", result.Name)
+			assert.Equal(t, health.CategorySystem, result.Category)
+			assert.Equal(t, tt.wantStatus, result.Status)
+			assert.Equal(t, tt.wantMessage, result.Message)
+
+			// temperature_c is always the raw Celsius reading, regardless of unit.
+			require.Contains(t, result.Details, "temperature_c")
+			assert.InDelta(t, tt.celsius, result.Details["temperature_c"], 0.0001)
+
+			require.Contains(t, result.Details, "temperature_display")
+			assert.InDelta(t, tt.wantDisplay, result.Details["temperature_display"], 0.001)
+
+			assert.Equal(t, tt.wantSymbol, result.Details["temperature_unit"])
+		})
+	}
+}
+
+func TestTemperatureCheck_Run_NilProvider(t *testing.T) {
+	t.Parallel()
+
+	check := NewTemperatureCheck(nil, nil)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusSkipped, result.Status)
+}
+
+func TestTemperatureCheck_Run_Error(t *testing.T) {
+	t.Parallel()
+
+	check := NewTemperatureCheck(
+		func() (float64, error) { return 0, errors.NewStd("no sensor") },
+		func() string { return tempUnitCelsius },
+	)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusUnknown, result.Status)
+	assert.Contains(t, result.Message, "Temperature unavailable")
+}
+
+// TestTemperatureCheck_Run_UnitHotReload proves the display unit is read per Run,
+// not captured at construction: flipping the unit between two Run calls must
+// change the rendered symbol without recreating the check.
+func TestTemperatureCheck_Run_UnitHotReload(t *testing.T) {
+	t.Parallel()
+
+	unit := tempUnitCelsius
+	check := NewTemperatureCheck(
+		func() (float64, error) { return 45.0, nil },
+		func() string { return unit },
+	)
+
+	first := check.Run(t.Context())
+	assert.Equal(t, "Temperature OK (45.0 C)", first.Message)
+	assert.Equal(t, "C", first.Details["temperature_unit"])
+
+	unit = tempUnitFahrenheit // simulate a live settings change
+	second := check.Run(t.Context())
+	assert.Equal(t, "Temperature OK (113.0 F)", second.Message)
+	assert.Equal(t, "F", second.Details["temperature_unit"])
+}

--- a/internal/observability/collector.go
+++ b/internal/observability/collector.go
@@ -3,10 +3,7 @@ package observability
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
-	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -68,7 +65,7 @@ type Collector struct {
 	prevAudioSnaps  map[string]AudioRouterSnapshot
 	prevStreamSnaps map[string]StreamHealthSnapshot
 	// Audio Prometheus gauge setters (optional, set via SetAudioGaugeSetters).
-	audioQueueDepthGauge   func(source string, depth float64)
+	audioQueueDepthGauge    func(source string, depth float64)
 	audioDroppedChunksGauge func(source string, total float64)
 
 	// Track which metrics have had logged errors to avoid log spam
@@ -133,10 +130,6 @@ const (
 	metricDBReadLatencyMax  = "db.read_latency_max_ms"
 	metricDBWriteLatencyMax = "db.write_latency_max_ms"
 	metricDBQueriesPerSec   = "db.queries_per_sec"
-
-	// maxValidCelsius is the upper bound for valid CPU temperature readings.
-	// 120°C captures overheating events before thermal shutdown while filtering bogus values.
-	maxValidCelsius = 120.0
 )
 
 func inferenceMetricKey(modelID string) string {
@@ -188,12 +181,13 @@ func (c *Collector) collectMemory(points map[string]float64) {
 	points[metricMemoryUsedPercent] = memInfo.UsedPercent
 }
 
-// collectTemperature reads CPU temperature from Linux thermal zones.
-// Gracefully skipped on non-Linux or if no suitable sensor is found.
+// collectTemperature reads CPU temperature from Linux thermal zones via the
+// shared ReadCPUTemperature reader. Gracefully skipped on non-Linux or if no
+// suitable sensor is found.
 func (c *Collector) collectTemperature(points map[string]float64) {
-	temp, ok := readCPUTemperature()
-	if ok {
-		points[metricCPUTemperature] = temp
+	celsius, _, err := ReadCPUTemperature(DefaultThermalBasePath)
+	if err == nil {
+		points[metricCPUTemperature] = celsius
 	}
 }
 
@@ -697,68 +691,5 @@ func (c *Collector) recordHealthDelta(key string, current, previous int64, sourc
 	}
 }
 
-// --- CPU Temperature reading (Linux-specific) ---
-
-// thermalBasePath is the base directory for thermal zones on Linux.
-const collectorThermalBasePath = "/sys/class/thermal/"
-
-// cpuThermalSensorTypes contains sensor type names that indicate CPU temperature.
-var cpuThermalSensorTypes = map[string]bool{
-	"cpu-thermal":     true,
-	"x86_pkg_temp":    true,
-	"soc_thermal":     true,
-	"cpu_thermal":     true,
-	"thermal-fan-est": true,
-}
-
-// readCPUTemperature scans Linux thermal zones for a CPU temperature sensor.
-// Returns the temperature in Celsius and true if found, or 0 and false otherwise.
-func readCPUTemperature() (float64, bool) {
-	zones, err := filepath.Glob(filepath.Join(collectorThermalBasePath, "thermal_zone*"))
-	if err != nil || len(zones) == 0 {
-		return 0, false
-	}
-
-	// Sort for deterministic sensor selection on systems with multiple thermal zones.
-	slices.Sort(zones)
-
-	for _, zone := range zones {
-		temp, ok := readThermalZone(zone)
-		if ok {
-			return temp, true
-		}
-	}
-	return 0, false
-}
-
-// readThermalZone reads a single thermal zone and returns its temperature
-// if it matches a CPU thermal sensor type and has a valid reading.
-func readThermalZone(zonePath string) (float64, bool) {
-	// Read sensor type — paths are from filepath.Glob on /sys/class/thermal/, not user input.
-	typeData, err := os.ReadFile(filepath.Join(zonePath, "type")) //nolint:gosec // system path from Glob
-	if err != nil {
-		return 0, false
-	}
-	sensorType := strings.ToLower(strings.TrimSpace(string(typeData)))
-	if !cpuThermalSensorTypes[sensorType] {
-		return 0, false
-	}
-
-	// Read temperature (in millidegrees Celsius)
-	tempData, err := os.ReadFile(filepath.Join(zonePath, "temp")) //nolint:gosec // system path from Glob
-	if err != nil {
-		return 0, false
-	}
-	milliCelsius, err := strconv.Atoi(strings.TrimSpace(string(tempData)))
-	if err != nil {
-		return 0, false
-	}
-
-	const milliToUnit = 1000.0
-	celsius := float64(milliCelsius) / milliToUnit
-
-	if celsius < 0 || celsius > maxValidCelsius {
-		return 0, false
-	}
-	return celsius, true
-}
+// CPU temperature reading is provided by the shared ReadCPUTemperature reader
+// in thermal.go, used by collectTemperature above.

--- a/internal/observability/collector_test.go
+++ b/internal/observability/collector_test.go
@@ -2,8 +2,6 @@ package observability
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -144,38 +142,8 @@ func TestSkipCollectorFS(t *testing.T) {
 	assert.False(t, skipCollectorFS("ntfs"))
 }
 
-func TestReadThermalZone_InvalidPath(t *testing.T) {
-	t.Parallel()
-
-	_, ok := readThermalZone("/nonexistent/path")
-	assert.False(t, ok)
-}
-
-func TestReadThermalZone_ValidSyntheticZone(t *testing.T) {
-	t.Parallel()
-
-	tmpDir := t.TempDir()
-
-	// Create a synthetic thermal zone
-	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "type"), []byte("cpu-thermal\n"), 0o600))
-	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "temp"), []byte("45000\n"), 0o600))
-
-	temp, ok := readThermalZone(tmpDir)
-	require.True(t, ok)
-	assert.InDelta(t, 45.0, temp, 0.01)
-}
-
-func TestReadThermalZone_NonCPUSensor(t *testing.T) {
-	t.Parallel()
-
-	tmpDir := t.TempDir()
-
-	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "type"), []byte("gpu-thermal\n"), 0o600))
-	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "temp"), []byte("50000\n"), 0o600))
-
-	_, ok := readThermalZone(tmpDir)
-	assert.False(t, ok, "non-CPU sensor should be skipped")
-}
+// CPU thermal-zone reading tests moved to thermal_test.go alongside the shared
+// ReadCPUTemperature reader.
 
 func TestCollector_CollectsInferenceMetrics(t *testing.T) {
 	t.Parallel()
@@ -264,19 +232,6 @@ func TestCollector_EmitsRTFKeyAndGauge(t *testing.T) {
 
 	assert.Equal(t, "M", gotRTFModel, "rtf gauge model should be M")
 	assert.InDelta(t, 0.01, gotRTF, 0.001, "rtf should be approx 0.01")
-}
-
-func TestReadThermalZone_OutOfRangeTemperature(t *testing.T) {
-	t.Parallel()
-
-	tmpDir := t.TempDir()
-
-	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "type"), []byte("cpu-thermal\n"), 0o600))
-	// 150°C is out of valid range
-	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "temp"), []byte("150000\n"), 0o600))
-
-	_, ok := readThermalZone(tmpDir)
-	assert.False(t, ok, "out-of-range temperature should be rejected")
 }
 
 // TestCollector_AudioQueueDepth verifies that collectAudio records the aggregate

--- a/internal/observability/thermal.go
+++ b/internal/observability/thermal.go
@@ -1,0 +1,118 @@
+package observability
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// DefaultThermalBasePath is the base directory for Linux thermal zones. Every
+// CPU-temperature consumer (the metrics collector, the /system/temperature/cpu
+// endpoint, and the temperature health check) scans below this path.
+const DefaultThermalBasePath = "/sys/class/thermal/"
+
+// CPU temperature bounds and conversion for sysfs thermal-zone readings.
+const (
+	// milliCelsiusPerCelsius converts sysfs thermal readings, which are exposed
+	// in milli-degrees Celsius, to degrees Celsius.
+	milliCelsiusPerCelsius = 1000.0
+	// minValidCPUTempCelsius and maxValidCPUTempCelsius bound plausible CPU
+	// readings used to reject bogus sensor values. The upper bound is
+	// deliberately generous: high-performance x86 CPUs can legitimately report
+	// above 100°C under load before thermal throttling.
+	minValidCPUTempCelsius = 0.0
+	maxValidCPUTempCelsius = 120.0
+)
+
+// cpuThermalSensorTypes holds the sysfs thermal-zone "type" values that identify
+// a CPU temperature sensor, filtering out unrelated zones (GPU, battery, ACPI).
+var cpuThermalSensorTypes = map[string]bool{
+	"cpu-thermal":     true, // Common on Raspberry Pi
+	"x86_pkg_temp":    true, // Common on Intel x86 systems (like NUC)
+	"soc_thermal":     true, // Common on some ARM SoCs
+	"cpu_thermal":     true, // Alternative name
+	"thermal-fan-est": true, // Seen on some systems
+}
+
+// ReadCPUTemperature scans Linux thermal zones under basePath for a CPU
+// temperature sensor. It returns the hottest valid reading in Celsius, details
+// about the selected sensor, and any error.
+//
+// It is the single source of truth for CPU thermal-zone reading, shared by the
+// metrics collector, the /system/temperature/cpu API endpoint, and the
+// temperature health check, so all three stay consistent on the sensor-type
+// allowlist, conversion, and valid range.
+//
+// The hottest valid zone is selected rather than the first, so multi-zone
+// systems (dual-socket, multi-die) still surface an overheating package and
+// selection does not depend on glob ordering.
+func ReadCPUTemperature(basePath string) (celsius float64, details string, err error) {
+	zones, err := filepath.Glob(filepath.Join(basePath, "thermal_zone*"))
+	if err != nil {
+		return 0, "", fmt.Errorf("failed to scan for thermal zones: %w", err)
+	}
+
+	var (
+		lastAttemptDetails string
+		hottestCelsius     float64
+		hottestDetails     string
+		found              bool
+	)
+	for _, zonePath := range zones {
+		zoneName := filepath.Base(zonePath)
+		typePath := filepath.Join(zonePath, "type")
+
+		//nolint:gosec // G304: typePath is from filepath.Glob
+		typeData, err := os.ReadFile(typePath)
+		if err != nil {
+			continue
+		}
+
+		sensorType := strings.ToLower(strings.TrimSpace(string(typeData)))
+		if !cpuThermalSensorTypes[sensorType] {
+			continue
+		}
+
+		tempFilePath := filepath.Join(zonePath, "temp")
+		//nolint:gosec // G304: tempFilePath is from filepath.Glob
+		tempData, err := os.ReadFile(tempFilePath)
+		if err != nil {
+			lastAttemptDetails = fmt.Sprintf("Error reading temp from %s (type: %s)", zoneName, sensorType)
+			continue
+		}
+
+		tempStr := strings.TrimSpace(string(tempData))
+		tempMillCelsius, err := strconv.Atoi(tempStr)
+		if err != nil {
+			lastAttemptDetails = fmt.Sprintf("Error parsing temp from %s (type: %s, value: '%s')", zoneName, sensorType, tempStr)
+			continue
+		}
+
+		zoneCelsius := float64(tempMillCelsius) / milliCelsiusPerCelsius
+		if zoneCelsius < minValidCPUTempCelsius || zoneCelsius > maxValidCPUTempCelsius {
+			lastAttemptDetails = fmt.Sprintf("Invalid temp from %s (type: %s, value: %.1f°C, expected %.0f-%.0f°C)", zoneName, sensorType, zoneCelsius, minValidCPUTempCelsius, maxValidCPUTempCelsius)
+			continue
+		}
+
+		// Track the hottest valid CPU zone rather than returning the first, so
+		// multi-zone systems (dual-socket, multi-die) still surface an
+		// overheating package and selection does not depend on glob ordering.
+		if !found || zoneCelsius > hottestCelsius {
+			hottestCelsius = zoneCelsius
+			hottestDetails = fmt.Sprintf("Source: %s, Type: %s", zoneName, sensorType)
+			found = true
+		}
+	}
+
+	if found {
+		return hottestCelsius, hottestDetails, nil
+	}
+
+	if lastAttemptDetails != "" {
+		return 0, lastAttemptDetails, fmt.Errorf("a targeted CPU sensor was found but could not be read successfully or value was invalid")
+	}
+
+	return 0, "", fmt.Errorf("no valid CPU temperature sensor found")
+}

--- a/internal/observability/thermal.go
+++ b/internal/observability/thermal.go
@@ -84,13 +84,13 @@ func ReadCPUTemperature(basePath string) (celsius float64, details string, err e
 		}
 
 		tempStr := strings.TrimSpace(string(tempData))
-		tempMillCelsius, err := strconv.Atoi(tempStr)
+		tempMilliCelsius, err := strconv.Atoi(tempStr)
 		if err != nil {
 			lastAttemptDetails = fmt.Sprintf("Error parsing temp from %s (type: %s, value: '%s')", zoneName, sensorType, tempStr)
 			continue
 		}
 
-		zoneCelsius := float64(tempMillCelsius) / milliCelsiusPerCelsius
+		zoneCelsius := float64(tempMilliCelsius) / milliCelsiusPerCelsius
 		if zoneCelsius < minValidCPUTempCelsius || zoneCelsius > maxValidCPUTempCelsius {
 			lastAttemptDetails = fmt.Sprintf("Invalid temp from %s (type: %s, value: %.1f°C, expected %.0f-%.0f°C)", zoneName, sensorType, zoneCelsius, minValidCPUTempCelsius, maxValidCPUTempCelsius)
 			continue

--- a/internal/observability/thermal_test.go
+++ b/internal/observability/thermal_test.go
@@ -1,4 +1,4 @@
-package system
+package observability
 
 import (
 	"os"
@@ -154,7 +154,7 @@ func TestReadCPUTemperature(t *testing.T) {
 			t.Parallel()
 
 			base := writeThermalZones(t, tt.zones)
-			celsius, details, err := readCPUTemperature(base)
+			celsius, details, err := ReadCPUTemperature(base)
 
 			if tt.wantErr {
 				require.Error(t, err)


### PR DESCRIPTION
## Summary

Two follow-ups from the review of #3941 (the CPU-temperature fix for #3940), folded into one PR since they touch the same subsystem.

**1. Health page ignored the configured Fahrenheit unit.** The System > Health page always printed the CPU temperature in Celsius even when the dashboard was set to Fahrenheit, while the Overview page converted correctly. The temperature health check now renders its message in the configured unit. The warn/critical thresholds (75/85 C) are still compared in Celsius, and the raw Celsius reading is kept in `details.temperature_c`, mirroring how the memory check shows MB in its message while storing raw bytes. The unit is read per health-check run, so changing it in the UI takes effect without a restart.

**2. Three duplicate CPU thermal-zone readers consolidated into one.** The sensor-type allowlist, base path, milli-Celsius conversion, and 0-120 C valid range were duplicated across `internal/api/v2/system` and `internal/observability` (plus a third partial copy). They are now a single shared `observability.ReadCPUTemperature`, called by the `/system/temperature/cpu` endpoint, the metrics collector, and the temperature health check.

## Behavior change worth noting

As a side effect of the consolidation, the metrics collector now reports the **hottest** valid thermal zone instead of the first one in glob order. On single-zone systems (typical Raspberry Pi / NUC) the value is identical. On multi-zone / multi-socket systems the `cpu.temperature` metric may read higher after upgrade, which aligns it with the `/system/temperature/cpu` endpoint and the Health page and is better for overheating detection. Thresholds and the JSON response shape are unchanged.

## Test Plan

- [x] `go build ./...`, `go vet`, and `golangci-lint run` clean
- [x] `go test -race` for `internal/observability`, `internal/health/checks`, `internal/api/v2/system`
- [x] New `TestReadCPUTemperature` (moved) covers hottest-zone selection, non-CPU skip, out-of-range, unparseable, and the inclusive 120 C boundary
- [x] New `TestTemperatureCheck_Run` covers Celsius/Fahrenheit display, the exact 75/85 C threshold boundaries, and a two-run hot-reload assertion proving the unit is read per run and thresholds stay in Celsius

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CPU temperature health reporting now supports dashboard-configured display units (Celsius or Fahrenheit).
  * Health check results include both raw Celsius temperature and the converted display temperature, along with the selected unit.
  * System diagnostics continue to show temperature sensor details when available.
* **Bug Fixes**
  * Improved CPU temperature detection by consolidating sensor discovery, validation, and selection for more reliable readings.
* **Tests**
  * Added/expanded tests for unit conversion, thresholds, sensor errors, nil unit handling, and hot-reload of unit settings.
  * Relocated thermal sensor parsing tests under the observability package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->