### PR TITLE
fix(media): return 503 while extended-capture clips are still being written

### DIFF
--- a/frontend/src/lib/desktop/components/media/SpectrogramPlayer.svelte
+++ b/frontend/src/lib/desktop/components/media/SpectrogramPlayer.svelte
@@ -71,9 +71,18 @@
     },
   });
 
-  // Spectrogram retry
-  const MAX_RETRIES = 3;
-  const RETRY_DELAYS = [500, 1000, 2000];
+  // Spectrogram retry. When a detection's audio clip is still being produced (Extended
+  // Capture defers the clip write until the capture tail is recorded, which the server
+  // reports as 503 + Retry-After), the <img> onerror keeps retrying so the spectrogram
+  // resolves without a manual reload. The short leading delays keep recovery snappy for
+  // the common fast case (a normal encode race resolving in ~1s), while the tail caps at
+  // 15s, strictly under useDelayedLoading's 30s timeoutMs, so a retry never lands after
+  // the loading timeout has flipped the view to the error state and back (which would
+  // flash the error icon mid-wait). The budget sums to ~2.5 min, which covers a typical
+  // pending window; a maximum-length extended-capture clip can still outlast it, after
+  // which the error state shows and a reload retries. The last delay repeats past the array.
+  const MAX_RETRIES = 14;
+  const RETRY_DELAYS = [500, 1000, 2000, 4000, 8000, 15000];
   let retryCount = $state(0);
   let retryTimer: ReturnType<typeof setTimeout> | undefined;
   let cacheKey = $state(0);

--- a/internal/analysis/jobqueue/logger.go
+++ b/internal/analysis/jobqueue/logger.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
@@ -159,7 +160,16 @@ func LogJobRetryScheduled(ctx context.Context, jobID, actionDesc string, attempt
 	if traceID := extractTraceID(ctx); traceID != "" {
 		fields = append(fields, logger.String("trace_id", traceID))
 	}
-	getLog().WithContext(ctx).Warn("Job scheduled for retry after failure", fields...)
+	// A deferred action (errors.Is(lastErr, ErrJobDeferred)) is rescheduling itself on
+	// purpose (e.g. Extended Capture waiting for the capture tail), not failing. Log it
+	// at Debug so expected backpressure does not flood the warning stream; genuine
+	// failures still log at Warn.
+	log := getLog().WithContext(ctx)
+	if errors.Is(lastErr, ErrJobDeferred) {
+		log.Debug("Job deferred, retry scheduled", fields...)
+		return
+	}
+	log.Warn("Job scheduled for retry after failure", fields...)
 }
 
 // LogJobSuccess logs when a job completes successfully

--- a/internal/analysis/jobqueue/logger_test.go
+++ b/internal/analysis/jobqueue/logger_test.go
@@ -1,13 +1,18 @@
 package jobqueue
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"log/slog"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
 // TestGetLog tests the getLog function returns a valid logger
@@ -110,6 +115,66 @@ func TestLogJobRetryScheduled(t *testing.T) {
 	assert.NotPanics(t, func() {
 		LogJobRetryScheduled(t.Context(), "job-retry-sched-1", "HTTP POST request", 2, 5, delay, nextRetryAt, testErr)
 	})
+
+	// A deferred action wraps ErrJobDeferred and must take the Debug branch instead of
+	// the Warn branch; exercise it so the classification code path is covered.
+	deferredErr := fmt.Errorf("audio export deferred: %w", ErrJobDeferred)
+	require.ErrorIs(t, deferredErr, ErrJobDeferred, "wrapped deferral must satisfy errors.Is")
+	assert.NotPanics(t, func() {
+		LogJobRetryScheduled(t.Context(), "job-retry-sched-2", "Save audio clip to file", 2, 10, delay, nextRetryAt, deferredErr)
+	})
+}
+
+// TestLogJobRetryScheduled_Level asserts the classification OUTCOME (not just that the
+// branch runs): an intentional deferral (wrapping ErrJobDeferred) logs at Debug, a
+// genuine failure at Warn. A condition inversion in LogJobRetryScheduled would pass the
+// NotPanics test above but is caught here by capturing the emitted level.
+func TestLogJobRetryScheduled_Level(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		wantLevel string
+		wantMsg   string
+	}{
+		{
+			name:      "deferral logs at debug",
+			err:       fmt.Errorf("audio export deferred: %w", ErrJobDeferred),
+			wantLevel: "level=DEBUG",
+			wantMsg:   "Job deferred, retry scheduled",
+		},
+		{
+			name:      "genuine failure logs at warn",
+			err:       errors.New("connection refused"),
+			wantLevel: "level=WARN",
+			wantMsg:   "Job scheduled for retry after failure",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Not parallel: swaps the process-global logger for the duration.
+			var buf bytes.Buffer
+			handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+			cfg := &logger.LoggingConfig{
+				DefaultLevel: "debug",
+				Console:      &logger.ConsoleOutput{Enabled: false},
+				FileOutput:   &logger.FileOutput{Enabled: false},
+			}
+			cl, err := logger.NewCentralLogger(cfg, handler)
+			require.NoError(t, err)
+
+			oldGlobal := logger.Global()
+			logger.SetGlobal(cl)
+			t.Cleanup(func() { logger.SetGlobal(oldGlobal) })
+
+			LogJobRetryScheduled(t.Context(), "job-lvl", "Save audio clip to file", 2, 10,
+				3*time.Second, time.Now().Add(3*time.Second), tt.err)
+
+			output := buf.String()
+			assert.Contains(t, output, tt.wantLevel, "wrong log level for %s", tt.name)
+			assert.Contains(t, output, tt.wantMsg, "wrong log message for %s", tt.name)
+		})
+	}
 }
 
 // TestLogJobSuccess tests job success logging doesn't panic

--- a/internal/analysis/jobqueue/types.go
+++ b/internal/analysis/jobqueue/types.go
@@ -42,6 +42,15 @@ var (
 			Component("analysis.jobqueue").
 			Category(errors.CategoryLimit).
 			Build()
+
+	// ErrJobDeferred signals that an action could not run yet and is intentionally
+	// deferring its own execution to a later retry (not a failure). Actions wrap this
+	// sentinel so LogJobRetryScheduled logs the reschedule at Debug instead of Warn,
+	// keeping expected backpressure (e.g. Extended Capture waiting for the capture tail
+	// to be recorded) out of the warning stream. Detected with errors.Is. Kept as a
+	// plain sentinel (not an EnhancedError) so it carries no telemetry category: a
+	// deferral is a normal control-flow signal, not a reportable error.
+	ErrJobDeferred = errors.NewStd("job execution deferred")
 )
 
 // RetryConfig holds the configuration for retry behavior of an action

--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -5,11 +5,13 @@ package processor
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/analysis/jobqueue"
 	"github.com/tphakala/birdnet-go/internal/analysis/species"
 	"github.com/tphakala/birdnet-go/internal/audiocore/audionorm"
 	"github.com/tphakala/birdnet-go/internal/audiocore/convert"
@@ -28,8 +30,10 @@ import (
 // errAudioExportDeferred signals that SaveAudioAction cannot yet read the
 // requested capture segment because the tail of the clip is still being
 // written (Extended Capture). The job queue's retry mechanism re-runs the
-// action after a backoff delay until the buffer has caught up.
-var errAudioExportDeferred = errors.NewStd("audio export deferred until capture tail is available")
+// action after a backoff delay until the buffer has caught up. It wraps
+// jobqueue.ErrJobDeferred so LogJobRetryScheduled records the reschedule at Debug
+// rather than Warn (this is expected backpressure, not a failure).
+var errAudioExportDeferred = fmt.Errorf("audio export deferred until capture tail is available: %w", jobqueue.ErrJobDeferred)
 
 // Encoder tags recorded in the audio-export success log so the active encoder is
 // visible per clip (native go-flac or native WAV writer, or FFmpeg for the lossy

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -2199,34 +2199,28 @@ func retryConfigFromSettings(rs conf.RetrySettings) jobqueue.RetryConfig {
 func (p *Processor) buildSaveAudioAction(det *Detections, detectionCtx *DetectionContext) *SaveAudioAction {
 	settings := p.currentSettings()
 
-	captureLength := settings.Realtime.Audio.Export.Length
-	if !det.Result.EndTime.IsZero() && !det.Result.BeginTime.IsZero() {
-		preCapture := settings.Realtime.Audio.Export.PreCapture
-		derivedLength := int(det.Result.EndTime.Sub(det.Result.BeginTime).Seconds()) + preCapture
-		if derivedLength > captureLength {
-			captureLength = derivedLength
-			GetLogger().Info("Using derived capture duration from detection time span",
-				logger.String("detection_id", det.CorrelationID),
-				logger.String("species", det.Result.Species.CommonName),
-				logger.Int("duration_seconds", captureLength),
-				logger.Int("configured_length", settings.Realtime.Audio.Export.Length),
-				logger.String("operation", "extended_capture_audio_export"))
-		}
+	// Derive the capture length and readiness time from the shared conf helper so this
+	// scheduler and the media API (which decides whether a not-yet-written clip is still
+	// legitimately pending) never compute the window differently. The two log lines are
+	// preserved verbatim, driven off the returned Derived/Capped flags.
+	win, _ := settings.DetectionCaptureWindow(det.Result.BeginTime, det.Result.EndTime)
+	if win.Derived {
+		GetLogger().Info("Using derived capture duration from detection time span",
+			logger.String("detection_id", det.CorrelationID),
+			logger.String("species", det.Result.Species.CommonName),
+			logger.Int("duration_seconds", win.RequestedLength),
+			logger.Int("configured_length", settings.Realtime.Audio.Export.Length),
+			logger.String("operation", "extended_capture_audio_export"))
 	}
-
-	// Cap at capture buffer size to prevent reading beyond buffer bounds.
-	bufferCap := conf.DefaultCaptureBufferSeconds
-	if settings.Realtime.ExtendedCapture.Enabled && settings.Realtime.ExtendedCapture.CaptureBufferSeconds > 0 {
-		bufferCap = settings.Realtime.ExtendedCapture.CaptureBufferSeconds
-	}
-	if captureLength > bufferCap {
+	if win.Capped {
+		// Cap at capture buffer size to prevent reading beyond buffer bounds.
 		GetLogger().Warn("Capping capture length at buffer size",
 			logger.String("detection_id", det.CorrelationID),
-			logger.Int("requested_seconds", captureLength),
-			logger.Int("buffer_seconds", bufferCap),
+			logger.Int("requested_seconds", win.RequestedLength),
+			logger.Int("buffer_seconds", win.BufferCap),
 			logger.String("operation", "capture_buffer_cap"))
-		captureLength = bufferCap
 	}
+	captureLength := win.Length
 
 	// Extended Capture may request a segment whose tail has not yet been
 	// written to the ring buffer (e.g. BeginTime was a few seconds ago but
@@ -2236,7 +2230,7 @@ func (p *Processor) buildSaveAudioAction(det *Detections, detectionCtx *Detectio
 	// mechanism picks it up once the buffer has caught up to captureEndTime.
 	// Only take this path when BufferMgr is available; if it is nil the
 	// eager read below will produce a proper error log and no-op action.
-	captureEndTime := det.Result.BeginTime.Add(time.Duration(captureLength) * time.Second)
+	captureEndTime := win.ReadyAt
 	if p.BufferMgr != nil && captureEndTime.After(time.Now()) {
 		return &SaveAudioAction{
 			Settings:         settings,

--- a/internal/analysis/processor/save_audio_action_test.go
+++ b/internal/analysis/processor/save_audio_action_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/tphakala/birdnet-go/internal/analysis/jobqueue"
 	audioBuffer "github.com/tphakala/birdnet-go/internal/audiocore/buffer"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/conf/conftest"
@@ -228,5 +229,10 @@ func TestErrAudioExportDeferred_IsSentinel(t *testing.T) {
 	t.Parallel()
 
 	wrapped := fmt.Errorf("deferred execute: %w", errAudioExportDeferred)
-	assert.ErrorIs(t, wrapped, errAudioExportDeferred)
+	require.ErrorIs(t, wrapped, errAudioExportDeferred)
+
+	// errAudioExportDeferred itself wraps jobqueue.ErrJobDeferred so the retry logger
+	// classifies the reschedule as expected backpressure (Debug), not a failure (Warn).
+	// If a refactor drops the wrap, deferrals would flood the warning stream again.
+	require.ErrorIs(t, errAudioExportDeferred, jobqueue.ErrJobDeferred)
 }

--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -177,6 +177,17 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 | GET    | `/spectrogram/:id/status`            | `GetSpectrogramStatus`   | ❌   | Get spectrogram generation status  |
 | POST   | `/audio/:id/clip`                    | `ExtractAudioClipByID`   | ✅   | Extract audio clip from time range |
 
+**Pending clip handling (`503 + Retry-After`).** A detection's DB record and SSE
+broadcast are emitted before its audio clip is written, and with Extended Capture the
+clip write is deferred until the capture tail is recorded (up to the capture-buffer
+size). While a clip is still legitimately pending, the by-ID audio and spectrogram
+endpoints (`GET /audio/:id`, `GET /spectrogram/:id`) return `503 Service Unavailable`
+with a `Retry-After` header sized to the remaining time, instead of `404`. Clients
+should honor `Retry-After` and retry; the clip appears once the capture completes. A
+`404` from these endpoints means the clip is genuinely absent (never produced, or purged
+by retention). These pending 503s are intentionally not logged as errors and are not
+reported to telemetry, since they are expected, self-resolving backpressure.
+
 ### Notifications (`notifications/notifications.go`)
 
 | Method | Route                              | Handler                            | Auth | Description                                                                                                         |

--- a/internal/api/v2/media/media.go
+++ b/internal/api/v2/media/media.go
@@ -171,6 +171,25 @@ const audioWaitPollInterval = 250 * time.Millisecond
 // hasn't created the temp file yet or has already atomically renamed it.
 const audioGracePeriod = 1 * time.Second
 
+// pendingExportGraceMargin extends a detection's computed capture-ready time to
+// account for the job-queue retry lag and the pickup-to-temp-file gap before the
+// export actually starts encoding. While now is before ReadyAt+margin, a missing clip
+// is treated as legitimately pending (503 + Retry-After) rather than a ghost (404).
+// Once encoding starts, the temp-file branch of handleAudio404WithWait takes over.
+const pendingExportGraceMargin = 60 * time.Second
+
+// pendingRetryAfterCushionSeconds pads the Retry-After hint past the computed ReadyAt
+// so a client that honors it does not come back a hair too early and 404 on a boundary.
+const pendingRetryAfterCushionSeconds = 2
+
+// minRetryAfterSeconds is the floor for any not-ready Retry-After hint.
+const minRetryAfterSeconds = 2
+
+// pendingClipPollInterval is how often the async spectrogram worker polls for a pending
+// (not-yet-written) audio clip to appear while waiting out the Extended Capture deferral
+// window.
+const pendingClipPollInterval = 1 * time.Second
+
 // ClipExtractionRequest represents a request to extract an audio clip.
 type ClipExtractionRequest struct {
 	Start     float64 `json:"start"`
@@ -256,13 +275,26 @@ func (c *Handler) translateSecureFSError(ctx echo.Context, err error, userMsg st
 		// If it's already an HTTPError from SecureFS, just pass it through
 		ctx.Logger().Debugf("SecureFS httpErr=%d internal=%v msg=%v",
 			httpErr.Code, httpErr.Internal, httpErr.Message)
-		// Log this as an error since it represents a failed request from SFS
-		c.LogErrorIfEnabled("SecureFS returned HTTP error",
+		// Level the log by status code, not by caller intent: this helper is generic
+		// across media routes. A 404 for a not-yet-written or reconcile-ghost clip is
+		// not a server fault, so log it at Info (matching the not-found branch below);
+		// other 4xx are client problems (Warn); only 5xx are genuine failures (Error).
+		// This keeps the high-volume transient extended-capture / encode-race 404s out
+		// of the error stream without hiding real failures.
+		fields := []logger.Field{
 			logger.Error(err),
 			logger.Int("status_code", httpErr.Code),
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
-		)
+		}
+		switch {
+		case httpErr.Code >= http.StatusInternalServerError:
+			c.LogErrorIfEnabled("SecureFS returned HTTP error", fields...)
+		case httpErr.Code == http.StatusNotFound:
+			c.LogInfoIfEnabled("SecureFS file not found", fields...)
+		default:
+			c.LogWarnIfEnabled("SecureFS returned HTTP client error", fields...)
+		}
 		return httpErr
 	}
 
@@ -428,13 +460,45 @@ func (c *Handler) isAudioBeingEncoded(relClipPath string) bool {
 	return ok
 }
 
+// writeAudioNotReady writes a 503 Service Unavailable response with a Retry-After
+// header for a clip that is not yet on disk. It deliberately bypasses HandleError:
+// HandleError logs "API Error" at ERROR and, for any status >= 500 (which includes
+// 503), reports to Sentry and raises a PriorityHigh notification-bell entry. A clip
+// that is still encoding or still scheduled for export will appear on its own, so this
+// is expected backpressure, not a bug; routing it through HandleError would spam the
+// error log, Sentry, and the bell. The JSON body is identical to HandleError's because
+// both build it via NewErrorResponse. Callers log the condition at Debug themselves.
+func (c *Handler) writeAudioNotReady(ctx echo.Context, err error, message string, retryAfterSeconds int) error {
+	ctx.Response().Header().Set("Retry-After", strconv.Itoa(retryAfterSeconds))
+	return ctx.JSON(http.StatusServiceUnavailable,
+		c.NewErrorResponse(err, message, http.StatusServiceUnavailable))
+}
+
 // handleAudioNotReady returns a 503 Service Unavailable response with a
 // Retry-After header, indicating that the audio file is still being encoded.
 func (c *Handler) handleAudioNotReady(ctx echo.Context) error {
-	ctx.Response().Header().Set("Retry-After", audioRetryAfterSeconds)
-	return c.HandleError(ctx, ffmpeg.ErrAudioFileNotReady,
-		"Audio file is still being processed, please retry",
-		http.StatusServiceUnavailable)
+	return c.writeAudioNotReady(ctx, ffmpeg.ErrAudioFileNotReady, "Audio file is still being processed, please retry", minRetryAfterSeconds)
+}
+
+// handleAudioPending returns a 503 + Retry-After for a clip whose export is scheduled
+// but not yet started (Extended Capture deferring the write until the capture tail is
+// recorded). The Retry-After hint is sized to the remaining time until ReadyAt plus a
+// small cushion, floored at minRetryAfterSeconds. Logged at Debug only: the clip is
+// still being produced, so this must not reach the error log, Sentry, or the bell.
+func (c *Handler) handleAudioPending(ctx echo.Context, readyAt time.Time, logFields ...logger.Field) error {
+	retryAfter := minRetryAfterSeconds
+	if remaining := time.Until(readyAt); remaining > 0 {
+		retryAfter = int(remaining.Seconds()) + pendingRetryAfterCushionSeconds
+	}
+	retryAfter = max(retryAfter, minRetryAfterSeconds)
+
+	c.LogDebugIfEnabled("Audio clip export pending",
+		append([]logger.Field{
+			logger.Time("ready_at", readyAt),
+			logger.Int("retry_after", retryAfter),
+		}, logFields...)...)
+
+	return c.writeAudioNotReady(ctx, ffmpeg.ErrAudioFileNotReady, "Audio clip is scheduled for export and not yet available", retryAfter)
 }
 
 // waitForAudioFile polls for an audio file to appear on disk while encoding
@@ -527,19 +591,27 @@ func isRecentClipCompletion(endTime time.Time) bool {
 	return endTime.IsZero() || time.Since(endTime) < diskmanager.ClipRecencyWindow
 }
 
-// noteCompletionTime returns the detection's capture completion time (Note.EndTime)
-// for the grace-poll recency decision, or the zero time if it cannot be determined
-// (nil datastore, lookup error, or unset). It is only called on the 404 slow path,
-// so the extra lookup does not affect normal audio serves.
-func (c *Handler) noteCompletionTime(noteID string) time.Time {
+// noteCaptureTimes returns the detection's capture begin and completion times
+// (Note.BeginTime, Note.EndTime), or zero times if they cannot be determined (nil
+// datastore, lookup error, or unset). It is only called on the 404 slow path, so the
+// extra lookup does not affect normal audio serves. EndTime feeds the grace-poll
+// recency decision; both feed the pending-export window via
+// conf.Settings.DetectionCaptureWindow.
+func (c *Handler) noteCaptureTimes(noteID string) (begin, end time.Time) {
 	if c.DS == nil {
-		return time.Time{}
+		return time.Time{}, time.Time{}
 	}
 	note, err := c.DS.Get(noteID)
 	if err != nil {
-		return time.Time{}
+		// Fail-safe: on a lookup error, return zero times so the caller treats the clip
+		// as having no pending window (falls back to the grace/404 path). Log at Debug so
+		// the swallowed error is still diagnosable without noising the error stream.
+		c.LogDebugIfEnabled("Could not resolve note capture times for pending-clip check",
+			logger.String("note_id", noteID),
+			logger.Error(err))
+		return time.Time{}, time.Time{}
 	}
-	return note.EndTime
+	return note.BeginTime, note.EndTime
 }
 
 // handleAudio404WithWait handles a 404 error for an audio file that may still be
@@ -547,7 +619,7 @@ func (c *Handler) noteCompletionTime(noteID string) time.Time {
 // then falls back to a brief grace period for the race window where FFmpeg hasn't
 // created the temp file yet or already renamed it. Returns nil if the file was
 // successfully served, or the original/translated error otherwise.
-func (c *Handler) handleAudio404WithWait(ctx echo.Context, relClipPath string, originalErr error, detectionEndTime time.Time, logFields ...logger.Field) error {
+func (c *Handler) handleAudio404WithWait(ctx echo.Context, relClipPath string, originalErr error, detectionBeginTime, detectionEndTime time.Time, logFields ...logger.Field) error {
 	if tempPath, encoding := c.findEncodingTempPath(relClipPath); encoding {
 		// Wait server-side for the file to appear instead of immediately
 		// returning 503, reducing unnecessary client round-trips. Pass the
@@ -567,6 +639,19 @@ func (c *Handler) handleAudio404WithWait(ctx echo.Context, relClipPath string, o
 		// Temp file disappeared and final file is still missing -
 		// encoding failed, fall back to normal error translation.
 		return c.translateSecureFSError(ctx, originalErr, "Failed to serve audio clip due to an unexpected error")
+	}
+
+	// No temp file yet, but the export may be legitimately pending: for an
+	// Extended Capture detection the DB note and SSE broadcast go out immediately while
+	// the clip write is deferred until the capture tail is recorded (the job queue
+	// retries until then). If we are still inside that window (ReadyAt + margin), return
+	// 503 + Retry-After so the client comes back once the clip lands, instead of a 404
+	// that reads as data loss. This returns immediately (no wait loop), so it does not
+	// pin the worker. Once encoding actually starts, the temp-file branch above handles
+	// it. Filename-based serves pass zero times, so ok is false and this is skipped.
+	if win, ok := c.CurrentSettings().DetectionCaptureWindow(detectionBeginTime, detectionEndTime); ok &&
+		time.Now().Before(win.ReadyAt.Add(pendingExportGraceMargin)) {
+		return c.handleAudioPending(ctx, win.ReadyAt, logFields...)
 	}
 
 	// No temp file visible. For a detection whose capture completed long ago,
@@ -632,9 +717,9 @@ func (c *Handler) ServeAudioClip(ctx echo.Context) error {
 		// frontend may request the file before it exists on disk.
 		var httpErr *echo.HTTPError
 		if errors.As(err, &httpErr) && httpErr.Code == http.StatusNotFound {
-			// Filename-based serving has no note ID to resolve a completion time,
-			// so pass the zero time (unknown -> keep the grace wait, fail-safe).
-			return c.handleAudio404WithWait(ctx, normalizedFilename, err, time.Time{},
+			// Filename-based serving has no note ID to resolve capture times, so pass
+			// zero times (unknown -> no pending window, keep the grace wait, fail-safe).
+			return c.handleAudio404WithWait(ctx, normalizedFilename, err, time.Time{}, time.Time{},
 				logger.String("filename", filename),
 				logger.String("path", ctx.Request().URL.Path),
 				logger.String("ip", ctx.RealIP()),
@@ -735,9 +820,10 @@ func (c *Handler) ServeAudioByID(ctx echo.Context) error {
 
 		var httpErr *echo.HTTPError
 		if errors.As(err, &httpErr) && httpErr.Code == http.StatusNotFound {
-			// Skip the grace wait for old detections whose clip is a pre-reconcile
-			// ghost. Completion time is looked up here on the 404 slow path only.
-			return c.handleAudio404WithWait(ctx, normalizedClipPath, err, c.noteCompletionTime(noteID),
+			// Capture times drive the pending-export and ghost decisions. They are
+			// looked up here on the 404 slow path only.
+			begin, end := c.noteCaptureTimes(noteID)
+			return c.handleAudio404WithWait(ctx, normalizedClipPath, err, begin, end,
 				logger.String("note_id", noteID),
 				logger.String("path", ctx.Request().URL.Path),
 				logger.String("ip", ctx.RealIP()),
@@ -1157,19 +1243,16 @@ func (c *Handler) ProcessedSpectrogramByID(ctx echo.Context) error {
 func (c *Handler) spectrogramHTTPError(ctx echo.Context, err error) error {
 	switch {
 	case errors.Is(err, ffmpeg.ErrAudioFileNotReady) || errors.Is(err, ffmpeg.ErrAudioFileIncomplete):
-		// Audio file is not ready yet - client should retry
-		// Check if we have a dynamic retry duration from validation
+		// Audio file is not ready yet - client should retry. Prefer a dynamic retry
+		// duration from validation when available, else the default. Emitted via the
+		// non-reporting 503 path (not HandleError) so this expected "still encoding"
+		// backpressure does not spam the error log, Sentry, and the notification bell.
+		secs := spectrogramRetryAfterSecondsInt
 		var anr *AudioNotReadyError
 		if errors.As(err, &anr) && anr.RetryAfter > 0 {
-			// Use the dynamic retry duration from audio validation
-			secs := int(math.Ceil(anr.RetryAfter.Seconds()))
-			ctx.Response().Header().Set("Retry-After", strconv.Itoa(secs))
-		} else {
-			// Fall back to default retry duration
-			ctx.Response().Header().Set("Retry-After", spectrogramRetryAfterSeconds)
+			secs = int(math.Ceil(anr.RetryAfter.Seconds()))
 		}
-		// Use 503 Service Unavailable to indicate temporary unavailability
-		return c.HandleError(ctx, err, "Audio file is still being processed, please retry", http.StatusServiceUnavailable)
+		return c.writeAudioNotReady(ctx, err, "Audio file is still being processed, please retry", secs)
 	case errors.Is(err, ErrAudioFileNotFound) || errors.Is(err, os.ErrNotExist):
 		// Handle cases where the source audio file doesn't exist
 		return c.HandleError(ctx, err, "Source audio file not found", http.StatusNotFound)
@@ -1392,12 +1475,25 @@ func (c *Handler) handleAutoPreRenderMode(ctx echo.Context, noteID, clipPath str
 			logger.String("ip", ctx.RealIP()),
 		}
 
-		// Check if this is an operational error (context canceled, timeout, etc.)
-		if spectrogram.IsOperationalError(err) {
-			// Log at Debug level for expected operational events
+		switch {
+		case spectrogram.IsOperationalError(err):
+			// Expected operational events (context canceled, timeout, etc.)
 			c.LogDebugIfEnabled("Spectrogram generation canceled or interrupted", logFields...)
-		} else {
-			// Log at Error level for unexpected failures
+		case errors.Is(err, ErrAudioFileNotFound):
+			// The source clip is not on disk. If an Extended Capture export for this note
+			// is still pending, tell the client to retry (503 + Retry-After) rather than
+			// 404; the clip will land shortly. Emitted via the non-reporting path so it
+			// does not spam the error log, Sentry, or the bell. Otherwise the clip is
+			// genuinely missing (a reconcile ghost): Warn (not Error), and fall through to
+			// the 404 from spectrogramHTTPError.
+			begin, end := c.noteCaptureTimes(noteID)
+			if win, ok := c.CurrentSettings().DetectionCaptureWindow(begin, end); ok &&
+				time.Now().Before(win.ReadyAt.Add(pendingExportGraceMargin)) {
+				return c.handleAudioPending(ctx, win.ReadyAt, logFields...)
+			}
+			c.LogWarnIfEnabled("Spectrogram generation skipped: source audio clip not available", logFields...)
+		default:
+			// Unexpected failures (sox/ffmpeg broken, unreadable clip, etc.)
 			c.LogErrorIfEnabled("Spectrogram generation failed", logFields...)
 		}
 		return c.spectrogramHTTPError(ctx, err)
@@ -1768,6 +1864,88 @@ func (c *Handler) GetSpectrogramStatus(ctx echo.Context) error {
 //   - 404 Not Found: Audio file not found
 //   - 408 Request Timeout: Generation timed out
 //   - 500 Internal Server Error: Generation failed
+// runAsyncSpectrogramGeneration is the background worker spawned by
+// GenerateSpectrogramByID. It waits out any pending Extended Capture clip export before
+// generating, then records the outcome in the queue status and logs. Extracted from the
+// handler so the handler stays under the cognitive-complexity budget.
+func (c *Handler) runAsyncSpectrogramGeneration(noteID, clipPath, relAudioPath, queueKey string, params spectrogramParameters, freqSuffix string, profile spectrogram.FrequencyProfile) {
+	defer func() {
+		if r := recover(); r != nil {
+			if queueKey != "" {
+				failedStatus := &SpectrogramQueueStatus{}
+				failedStatus.Update(spectrogramStatusFailed, 0, "Generation failed")
+				spectrogramQueue.Store(queueKey, failedStatus)
+				time.AfterFunc(failedStatusRetentionTime, func() {
+					deleteFailedStatusIfUnchanged(queueKey, failedStatus)
+				})
+			}
+			c.LogErrorIfEnabled("Panic in async spectrogram generation",
+				logger.String("note_id", noteID),
+				logger.Any("panic", r))
+		}
+	}()
+
+	// Generation runs on its own c.Context()-derived budget inside
+	// generateSpectrogramFromRel; bgCtx here bounds the caller-side wait and the
+	// pending-clip wait. If the source clip is not on disk yet, an Extended Capture
+	// export may still be writing its tail: resolve the export-ready window (one DS
+	// lookup, only on this cold path), extend the budget past it, and wait for the clip
+	// (bounded, cancellable on shutdown) before generating, instead of failing on a
+	// missing file. The lookup and wait are skipped when the clip already exists.
+	genTimeout := spectrogramGenerationTimeout
+	var pendingDeadline time.Time
+	if _, statErr := c.SFS.StatRel(relAudioPath); statErr != nil {
+		begin, end := c.noteCaptureTimes(noteID)
+		if win, ok := c.CurrentSettings().DetectionCaptureWindow(begin, end); ok {
+			pendingDeadline = win.ReadyAt.Add(pendingExportGraceMargin)
+			if extra := time.Until(pendingDeadline); extra > 0 {
+				genTimeout += extra
+			}
+		}
+	}
+
+	bgCtx, cancel := context.WithTimeout(c.Context(), genTimeout)
+	defer cancel()
+
+	if !pendingDeadline.IsZero() && time.Now().Before(pendingDeadline) {
+		if queueKey != "" {
+			c.updateQueueStatus(queueKey, spectrogramStatusQueued, 0, "Waiting for audio capture to complete")
+		}
+		c.waitForPendingClip(bgCtx, relAudioPath, pendingDeadline, pendingClipPollInterval)
+	}
+
+	profileOpt := spectrogram.WithFrequencyProfile(profile)
+
+	spectrogramPath, err := c.generateSpectrogramFromRel(bgCtx, relAudioPath, clipPath, queueKey, params.width, params.raw, params.style, params.dynamicRange, freqSuffix, profileOpt)
+	if err != nil {
+		if queueKey != "" {
+			c.updateQueueStatus(queueKey, spectrogramStatusFailed, 0, "Generation failed")
+		}
+
+		logFields := []logger.Field{
+			logger.String("note_id", noteID),
+			logger.String("clip_path", clipPath),
+			logger.Error(err),
+		}
+		switch {
+		case spectrogram.IsOperationalError(err):
+			c.LogDebugIfEnabled("Async spectrogram generation canceled or interrupted", logFields...)
+		case errors.Is(err, ErrAudioFileNotFound):
+			// The source clip never landed within the pending window (extended-capture
+			// export abandoned on restart, or a reconcile ghost). Expected and
+			// self-describing, so Warn, not Error.
+			c.LogWarnIfEnabled("Async spectrogram generation skipped: audio clip not available", logFields...)
+		default:
+			c.LogErrorIfEnabled("Async spectrogram generation failed", logFields...)
+		}
+		return
+	}
+
+	c.LogInfoIfEnabled("Async spectrogram generated successfully",
+		logger.String("note_id", noteID),
+		logger.String("spectrogram_path", spectrogramPath))
+}
+
 func (c *Handler) GenerateSpectrogramByID(ctx echo.Context) error {
 	// Validate note ID and get clip path using shared helper
 	noteID, clipPath, err := c.validateNoteIDAndGetClipPath(ctx)
@@ -1866,48 +2044,11 @@ func (c *Handler) GenerateSpectrogramByID(ctx echo.Context) error {
 	// Initialize queue status BEFORE spawning goroutine (prevents "not_started" flicker)
 	c.initializeQueueStatus(queueKey)
 
-	// Start async generation in background with proper cleanup and panic recovery
-	// Track goroutine lifecycle for graceful shutdown
+	// Start async generation in background with proper cleanup and panic recovery.
+	// Track goroutine lifecycle for graceful shutdown. The body lives in a named method
+	// to keep this request handler's cognitive complexity in check.
 	c.Go(func() {
-
-		defer func() {
-			if r := recover(); r != nil {
-				if queueKey != "" {
-					failedStatus := &SpectrogramQueueStatus{}
-					failedStatus.Update(spectrogramStatusFailed, 0, "Generation failed")
-					spectrogramQueue.Store(queueKey, failedStatus)
-					time.AfterFunc(failedStatusRetentionTime, func() {
-						deleteFailedStatusIfUnchanged(queueKey, failedStatus)
-					})
-				}
-				c.LogErrorIfEnabled("Panic in async spectrogram generation",
-					logger.String("note_id", noteID),
-					logger.Any("panic", r))
-			}
-		}()
-
-		bgCtx, cancel := context.WithTimeout(c.Context(), spectrogramGenerationTimeout)
-		defer cancel()
-
-		profileOpt := spectrogram.WithFrequencyProfile(profile)
-
-		spectrogramPath, err := c.generateSpectrogramFromRel(bgCtx, relAudioPath, clipPath, queueKey, params.width, params.raw, params.style, params.dynamicRange, freqSuffix, profileOpt)
-
-		if err != nil {
-
-			if queueKey != "" {
-				c.updateQueueStatus(queueKey, spectrogramStatusFailed, 0, "Generation failed")
-			}
-
-			c.LogErrorIfEnabled("Async spectrogram generation failed",
-				logger.String("note_id", noteID),
-				logger.String("clip_path", clipPath),
-				logger.Error(err))
-		} else {
-			c.LogInfoIfEnabled("Async spectrogram generated successfully",
-				logger.String("note_id", noteID),
-				logger.String("spectrogram_path", spectrogramPath))
-		}
+		c.runAsyncSpectrogramGeneration(noteID, clipPath, relAudioPath, queueKey, params, freqSuffix, profile)
 	})
 
 	// Return 202 Accepted immediately - client should poll status endpoint
@@ -1941,9 +2082,10 @@ var maxConcurrentSpectrograms = runtime.NumCPU()
 // semaphoreAcquireTimeout is the maximum time to wait for a semaphore slot before timing out
 const semaphoreAcquireTimeout = 30 * time.Second
 
-// spectrogramRetryAfterSeconds is the suggested retry delay in seconds for 503 responses
-// when audio files are not yet ready for processing
-const spectrogramRetryAfterSeconds = "2"
+// spectrogramRetryAfterSecondsInt is the default suggested retry delay in seconds for
+// spectrogram 503 responses when audio files are not yet ready, used by the
+// non-reporting not-ready emitter.
+const spectrogramRetryAfterSecondsInt = 2
 
 // Spectrogram generation timing and cache constants
 const (
@@ -2496,6 +2638,38 @@ func (c *Handler) updateQueueStatus(queueKey, status string, queuePos int, messa
 	}
 }
 
+// waitForPendingClip polls for a not-yet-written audio clip to appear on disk, up to
+// deadline, returning true if it appeared. Unlike waitForAudioFileCtx (a short fixed
+// wait for the FFmpeg encode race), this covers the longer Extended Capture deferral
+// window, so it is only called from the async generation goroutine, which holds no HTTP
+// worker. It returns promptly on ctx cancellation (shutdown) so it never hangs a tracked
+// goroutine. pollInterval is a parameter so tests can drive it with a short real interval.
+func (c *Handler) waitForPendingClip(ctx context.Context, relAudioPath string, deadline time.Time, pollInterval time.Duration) bool {
+	// Fast path: already present.
+	if _, err := c.SFS.StatRel(relAudioPath); err == nil {
+		return true
+	}
+
+	waitCtx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-waitCtx.Done():
+			// Final check in case the clip landed between the last tick and the deadline.
+			_, err := c.SFS.StatRel(relAudioPath)
+			return err == nil
+		case <-ticker.C:
+			if _, err := c.SFS.StatRel(relAudioPath); err == nil {
+				return true
+			}
+		}
+	}
+}
+
 // checkAudioFileExists verifies the audio file exists
 func (c *Handler) checkAudioFileExists(relAudioPath string) error {
 	getSpectrogramLogger().Debug("Checking if audio file exists",
@@ -2546,6 +2720,15 @@ func (c *Handler) waitForAudioFileCtx(ctx context.Context, relAudioPath string) 
 			// between the last tick and the deadline.
 			if _, err := c.SFS.StatRel(relAudioPath); err == nil {
 				return nil
+			}
+			// Distinguish a genuine "file never appeared" from a canceled/timed-out
+			// PARENT context (shutdown, client disconnect, or the generation deadline):
+			// waitCtx.Done() fires for both, but only the local audioWaitTimeout means
+			// the clip is actually missing. Returning the context error keeps callers
+			// from misclassifying an operational cancellation as ErrAudioFileNotFound
+			// (which would log the shutdown at Warn instead of Debug).
+			if ctx.Err() != nil {
+				return ctx.Err()
 			}
 			getSpectrogramLogger().Debug("Audio file did not appear within wait timeout",
 				logger.String("relative_audio_path", relAudioPath),

--- a/internal/api/v2/media/media_pending_export_test.go
+++ b/internal/api/v2/media/media_pending_export_test.go
@@ -1,0 +1,154 @@
+// media_pending_export_test.go: coverage for the Extended Capture pending-clip
+// handling. When a detection's audio clip write is deferred until the capture tail is
+// recorded, the media API must return 503 + Retry-After (not 404) while the clip is
+// still legitimately pending, and must fall back to 404 once the window has passed.
+
+package media
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
+)
+
+// TestServeAudioByID_PendingExport verifies that a missing clip whose Extended Capture
+// export is still within its computed ready window returns 503 + Retry-After
+// immediately (not a 404, and without blocking on the grace wait), while a clip whose
+// window has long passed reverts to a 404.
+func TestServeAudioByID_PendingExport(t *testing.T) {
+	const missingClip = "2024/01/pending_95p_20240101T000000Z.wav"
+	now := time.Now()
+
+	tests := []struct {
+		name      string
+		begin     time.Time
+		end       time.Time
+		wantCode  int
+		wantRetry bool
+	}{
+		{
+			name:      "recent detection with pending export returns 503",
+			begin:     now,
+			end:       now.Add(30 * time.Second), // long capture still finishing
+			wantCode:  http.StatusServiceUnavailable,
+			wantRetry: true,
+		},
+		{
+			name:     "old detection past the export window 404s",
+			begin:    now.Add(-2 * time.Hour),
+			end:      now.Add(-2 * time.Hour),
+			wantCode: http.StatusNotFound,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e, controller, _ := setupMediaTestEnvironment(t)
+
+			mockDS := mocks.NewMockInterface(t)
+			mockDS.On("GetNoteClipPath", "42").Return(missingClip, nil)
+			mockDS.On("Get", "42").Return(datastore.Note{ID: 42, BeginTime: tc.begin, EndTime: tc.end}, nil).Maybe()
+			controller.DS = mockDS
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v2/audio/42", http.NoBody)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetParamNames("id")
+			c.SetParamValues("42")
+
+			handlerErr := controller.ServeAudioByID(c)
+
+			// Pending returns 503 via ctx.JSON (nil error, code on the recorder); a
+			// missing/ghost clip returns an echo.HTTPError 404. Resolve either way. The
+			// status code alone distinguishes the paths: a 503 can only come from the
+			// immediate pending branch (the grace/ghost path yields 404), so no wall-clock
+			// timing assertion is needed (and none is used, to avoid CI flakiness).
+			code := rec.Code
+			if httpErr, ok := errors.AsType[*echo.HTTPError](handlerErr); ok {
+				code = httpErr.Code
+			}
+			assert.Equal(t, tc.wantCode, code)
+
+			if tc.wantRetry {
+				retryAfter := rec.Header().Get("Retry-After")
+				require.NotEmpty(t, retryAfter, "503 must carry a Retry-After header")
+				secs, convErr := strconv.Atoi(retryAfter)
+				require.NoError(t, convErr)
+				assert.GreaterOrEqual(t, secs, minRetryAfterSeconds)
+			}
+		})
+	}
+}
+
+// TestWaitForPendingClip covers the async spectrogram worker's bounded wait for a
+// not-yet-written clip. It uses an injected short poll interval and real short
+// deadlines rather than synctest, because the file appearing is a real filesystem
+// event decoupled from any fake clock.
+func TestWaitForPendingClip(t *testing.T) {
+	const rel = "pending.wav"
+	const pollInterval = 5 * time.Millisecond
+
+	t.Run("returns true immediately when the file already exists", func(t *testing.T) {
+		_, controller, tempDir := setupMediaTestEnvironment(t)
+		require.NoError(t, os.WriteFile(filepath.Join(tempDir, rel), []byte("x"), 0o600))
+
+		// Deadline in the past: if the fast-path existence check did not short-circuit,
+		// the wait would return false at once. A true result proves the pre-poll check
+		// fired, without asserting a flaky wall-clock upper bound.
+		ok := controller.waitForPendingClip(t.Context(), rel, time.Now().Add(-time.Second), pollInterval)
+
+		assert.True(t, ok)
+	})
+
+	t.Run("returns false when the file never appears by the deadline", func(t *testing.T) {
+		_, controller, _ := setupMediaTestEnvironment(t)
+
+		const waitDeadline = 50 * time.Millisecond
+		// Lower bound only (context.WithDeadline never fires early, so slow/-race CI can
+		// only push elapsed higher): proves the poller waited toward the deadline rather
+		// than returning false immediately. Derived from waitDeadline so the two stay in
+		// sync if the deadline is retuned.
+		const minWait = waitDeadline - 10*time.Millisecond
+
+		start := time.Now()
+		ok := controller.waitForPendingClip(t.Context(), rel, time.Now().Add(waitDeadline), pollInterval)
+
+		assert.False(t, ok)
+		assert.GreaterOrEqual(t, time.Since(start), minWait, "should wait until near the deadline")
+	})
+
+	t.Run("returns true when the file appears before the deadline", func(t *testing.T) {
+		_, controller, tempDir := setupMediaTestEnvironment(t)
+		go func() {
+			time.Sleep(20 * time.Millisecond)
+			_ = os.WriteFile(filepath.Join(tempDir, rel), []byte("x"), 0o600)
+		}()
+
+		ok := controller.waitForPendingClip(t.Context(), rel, time.Now().Add(time.Second), pollInterval)
+
+		assert.True(t, ok)
+	})
+
+	t.Run("returns false promptly when the context is canceled", func(t *testing.T) {
+		_, controller, _ := setupMediaTestEnvironment(t)
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		ok := controller.waitForPendingClip(ctx, rel, time.Now().Add(time.Second), pollInterval)
+
+		assert.False(t, ok)
+	})
+}

--- a/internal/api/v2/media/media_spectrogram_queuekey_test.go
+++ b/internal/api/v2/media/media_spectrogram_queuekey_test.go
@@ -194,9 +194,10 @@ func TestGenerateSpectrogramByID_PanicUpdatesQueueStatus(t *testing.T) {
 	mockDS.On("GetNoteClipPath", "42").Return("test_panic.wav", nil)
 	mockDS.On("GetNoteModelType", "42").Return("bird", nil)
 	// The worker looks up capture times when the clip is missing (it is, in this empty
-	// tmp dir). Return a zero-time note so the pending-export window is not-ok and the
-	// goroutine proceeds to the nil-context panic this test exercises.
-	mockDS.On("Get", "42").Return(datastore.Note{}, nil).Maybe()
+	// tmp dir), so require the Get call: a zero-time note makes the pending-export window
+	// not-ok and the goroutine proceeds to the nil-context panic this test exercises.
+	// Mandatory (no .Maybe()) so the test fails if noteCaptureTimes stops looking up.
+	mockDS.On("Get", "42").Return(datastore.Note{}, nil)
 
 	controllerCore := &apicore.Core{SFS: sfs, DS: mockDS}
 	// By setting a nil context, the goroutine will panic when calling context.WithTimeout(nil, ...)

--- a/internal/api/v2/media/media_spectrogram_queuekey_test.go
+++ b/internal/api/v2/media/media_spectrogram_queuekey_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/conf/conftest"
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
 	"github.com/tphakala/birdnet-go/internal/securefs"
 )
@@ -192,6 +193,10 @@ func TestGenerateSpectrogramByID_PanicUpdatesQueueStatus(t *testing.T) {
 	// Mock DS to return a valid clip path so we get past validateNoteIDAndGetClipPath
 	mockDS.On("GetNoteClipPath", "42").Return("test_panic.wav", nil)
 	mockDS.On("GetNoteModelType", "42").Return("bird", nil)
+	// The worker looks up capture times when the clip is missing (it is, in this empty
+	// tmp dir). Return a zero-time note so the pending-export window is not-ok and the
+	// goroutine proceeds to the nil-context panic this test exercises.
+	mockDS.On("Get", "42").Return(datastore.Note{}, nil).Maybe()
 
 	controllerCore := &apicore.Core{SFS: sfs, DS: mockDS}
 	// By setting a nil context, the goroutine will panic when calling context.WithTimeout(nil, ...)

--- a/internal/conf/capture_window.go
+++ b/internal/conf/capture_window.go
@@ -1,0 +1,83 @@
+package conf
+
+import "time"
+
+// CaptureWindow describes the audio-clip capture length and readiness time derived for
+// a detection. It is the single source of truth shared by the audio-export scheduler
+// (which decides when to defer the clip write until the capture tail is recorded) and
+// the media API (which decides whether a not-yet-written clip is still legitimately
+// pending, and how long a client should wait before retrying).
+type CaptureWindow struct {
+	// Length is the capture length in seconds after applying both the derived-duration
+	// and the buffer-cap rules. This is the length actually captured to disk.
+	Length int
+	// RequestedLength is the length after the derived-duration rule but before the
+	// buffer cap. It equals Length when the clip is not capped, and is retained so the
+	// scheduler can log how long a clip was requested before capping (diagnostically
+	// useful for continuous vocalizers that request far more than the buffer holds).
+	RequestedLength int
+	// BufferCap is the ring-buffer size the length was capped at.
+	BufferCap int
+	// ReadyAt is the wall-clock time at which the capture tail has been recorded,
+	// equal to beginTime advanced by Length seconds. Before this time the clip may not
+	// yet exist on disk.
+	ReadyAt time.Time
+	// Derived is true when the detection time span produced a capture length longer
+	// than the configured Export.Length.
+	Derived bool
+	// Capped is true when the capture length was reduced to the ring-buffer size.
+	Capped bool
+}
+
+// DetectionCaptureWindow computes the capture length and readiness time for a detection
+// spanning beginTime..endTime, using the same rules as the audio-export scheduler (see
+// analysis/processor.buildSaveAudioAction, which is refactored onto this method so the
+// two never diverge). The boolean return is false when beginTime is zero: no meaningful
+// readiness time can be derived from an unknown start, so the media API must not treat
+// such a clip as pending. The CaptureWindow is still fully populated in that case so the
+// scheduler can consume it unconditionally.
+//
+// The rules, in order:
+//   - start from the configured export length (Realtime.Audio.Export.Length);
+//   - when both timestamps are set, derive a length from the detection span plus the
+//     pre-capture padding and use it when it exceeds the configured length;
+//   - cap the length at the ring-buffer size (ExtendedCapture.CaptureBufferSeconds when
+//     extended capture is enabled and that value is positive, otherwise
+//     DefaultCaptureBufferSeconds).
+//
+// ReadyAt is beginTime advanced by the resulting Length.
+func (s *Settings) DetectionCaptureWindow(beginTime, endTime time.Time) (CaptureWindow, bool) {
+	length := s.Realtime.Audio.Export.Length
+	derived := false
+	// The span-derived length is only meaningful when both endpoints are known. This
+	// matches buildSaveAudioAction's guard exactly, including its integer truncation of
+	// sub-second spans and its treatment of a negative span (endTime before beginTime),
+	// where derivedLength stays below the configured length and is therefore ignored.
+	if !beginTime.IsZero() && !endTime.IsZero() {
+		derivedLength := int(endTime.Sub(beginTime).Seconds()) + s.Realtime.Audio.Export.PreCapture
+		if derivedLength > length {
+			length = derivedLength
+			derived = true
+		}
+	}
+	requested := length
+
+	bufferCap := DefaultCaptureBufferSeconds
+	if s.Realtime.ExtendedCapture.Enabled && s.Realtime.ExtendedCapture.CaptureBufferSeconds > 0 {
+		bufferCap = s.Realtime.ExtendedCapture.CaptureBufferSeconds
+	}
+	capped := false
+	if length > bufferCap {
+		length = bufferCap
+		capped = true
+	}
+
+	return CaptureWindow{
+		Length:          length,
+		RequestedLength: requested,
+		BufferCap:       bufferCap,
+		ReadyAt:         beginTime.Add(time.Duration(length) * time.Second),
+		Derived:         derived,
+		Capped:          capped,
+	}, !beginTime.IsZero()
+}

--- a/internal/conf/capture_window_test.go
+++ b/internal/conf/capture_window_test.go
@@ -1,0 +1,145 @@
+package conf
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newCaptureWindowSettings builds a minimal Settings with only the fields
+// DetectionCaptureWindow reads populated.
+func newCaptureWindowSettings(length, preCapture int, ecEnabled bool, ecBuffer int) *Settings {
+	s := &Settings{}
+	s.Realtime.Audio.Export.Length = length
+	s.Realtime.Audio.Export.PreCapture = preCapture
+	s.Realtime.ExtendedCapture.Enabled = ecEnabled
+	s.Realtime.ExtendedCapture.CaptureBufferSeconds = ecBuffer
+	return s
+}
+
+func TestDetectionCaptureWindow(t *testing.T) {
+	t.Parallel()
+
+	begin := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name        string
+		length      int
+		preCapture  int
+		ecEnabled   bool
+		ecBuffer    int
+		begin       time.Time
+		end         time.Time
+		wantOK      bool
+		wantLength  int
+		wantReqLen  int
+		wantCap     int
+		wantDerived bool
+		wantCapped  bool
+	}{
+		{
+			name: "configured length wins over short span", length: 20, preCapture: 3,
+			ecEnabled: false, ecBuffer: 0,
+			begin: begin, end: begin.Add(5 * time.Second),
+			wantOK: true, wantLength: 20, wantReqLen: 20, wantCap: DefaultCaptureBufferSeconds,
+			wantDerived: false, wantCapped: false,
+		},
+		{
+			name: "derived length wins over configured", length: 20, preCapture: 3,
+			ecEnabled: false, ecBuffer: 0,
+			begin: begin, end: begin.Add(40 * time.Second),
+			// 40s span + 3s precapture = 43 > 20, under the 120 default cap.
+			wantOK: true, wantLength: 43, wantReqLen: 43, wantCap: DefaultCaptureBufferSeconds,
+			wantDerived: true, wantCapped: false,
+		},
+		{
+			name: "derived length capped at extended-capture buffer", length: 20, preCapture: 3,
+			ecEnabled: true, ecBuffer: 185,
+			begin: begin, end: begin.Add(1000 * time.Second),
+			// 1000 + 3 = 1003 requested, capped at the configured 185s EC buffer.
+			wantOK: true, wantLength: 185, wantReqLen: 1003, wantCap: 185,
+			wantDerived: true, wantCapped: true,
+		},
+		{
+			name: "cap falls back to default when EC disabled", length: 20, preCapture: 3,
+			ecEnabled: false, ecBuffer: 999, // ignored because EC disabled
+			begin: begin, end: begin.Add(1000 * time.Second),
+			wantOK: true, wantLength: DefaultCaptureBufferSeconds, wantReqLen: 1003,
+			wantCap: DefaultCaptureBufferSeconds, wantDerived: true, wantCapped: true,
+		},
+		{
+			name: "cap falls back to default when EC buffer is zero", length: 20, preCapture: 3,
+			ecEnabled: true, ecBuffer: 0, // enabled but unset -> default cap under approach (a)
+			begin: begin, end: begin.Add(1000 * time.Second),
+			wantOK: true, wantLength: DefaultCaptureBufferSeconds, wantReqLen: 1003,
+			wantCap: DefaultCaptureBufferSeconds, wantDerived: true, wantCapped: true,
+		},
+		{
+			name: "sub-second span truncates like the scheduler", length: 5, preCapture: 0,
+			ecEnabled: false, ecBuffer: 0,
+			begin: begin, end: begin.Add(9500 * time.Millisecond),
+			// int(9.5) = 9 > 5 configured.
+			wantOK: true, wantLength: 9, wantReqLen: 9, wantCap: DefaultCaptureBufferSeconds,
+			wantDerived: true, wantCapped: false,
+		},
+		{
+			name: "end before begin ignores negative derived length", length: 20, preCapture: 3,
+			ecEnabled: false, ecBuffer: 0,
+			begin: begin, end: begin.Add(-30 * time.Second),
+			// derived = -30 + 3 = -27 < 20 configured -> configured used, not derived.
+			wantOK: true, wantLength: 20, wantReqLen: 20, wantCap: DefaultCaptureBufferSeconds,
+			wantDerived: false, wantCapped: false,
+		},
+		{
+			name: "zero end uses configured length", length: 20, preCapture: 3,
+			ecEnabled: false, ecBuffer: 0,
+			begin: begin, end: time.Time{},
+			wantOK: true, wantLength: 20, wantReqLen: 20, wantCap: DefaultCaptureBufferSeconds,
+			wantDerived: false, wantCapped: false,
+		},
+		{
+			name: "zero begin returns not-ok", length: 20, preCapture: 3,
+			ecEnabled: false, ecBuffer: 0,
+			begin: time.Time{}, end: begin,
+			wantOK: false, wantLength: 20, wantReqLen: 20, wantCap: DefaultCaptureBufferSeconds,
+			wantDerived: false, wantCapped: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := newCaptureWindowSettings(tt.length, tt.preCapture, tt.ecEnabled, tt.ecBuffer)
+
+			win, ok := s.DetectionCaptureWindow(tt.begin, tt.end)
+
+			assert.Equal(t, tt.wantOK, ok, "ok")
+			assert.Equal(t, tt.wantLength, win.Length, "Length")
+			assert.Equal(t, tt.wantReqLen, win.RequestedLength, "RequestedLength")
+			assert.Equal(t, tt.wantCap, win.BufferCap, "BufferCap")
+			assert.Equal(t, tt.wantDerived, win.Derived, "Derived")
+			assert.Equal(t, tt.wantCapped, win.Capped, "Capped")
+
+			if !tt.begin.IsZero() {
+				assert.Equal(t, tt.begin.Add(time.Duration(tt.wantLength)*time.Second), win.ReadyAt, "ReadyAt")
+			}
+		})
+	}
+}
+
+// TestDetectionCaptureWindow_ReadyAtArithmetic pins the exact readiness time so a future
+// refactor of the length math cannot silently shift when clips are considered pending.
+func TestDetectionCaptureWindow_ReadyAtArithmetic(t *testing.T) {
+	t.Parallel()
+
+	begin := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	s := newCaptureWindowSettings(20, 3, true, 185)
+
+	win, ok := s.DetectionCaptureWindow(begin, begin.Add(90*time.Second))
+	require.True(t, ok)
+	// 90 + 3 = 93 > 20, under the 185 cap.
+	assert.Equal(t, 93, win.Length)
+	assert.Equal(t, begin.Add(93*time.Second), win.ReadyAt)
+}


### PR DESCRIPTION
## Summary

Detections whose audio clip write is deferred by Extended Capture (the clip is not written until the capture tail is recorded) have their DB note and SSE broadcast emitted immediately, so the media API races the clip file. Audio and spectrogram requests returned 404 and logged at ERROR, and the deferred save-clip job logged a WARN on every backoff retry. The errors were transient and self-healing but spammed the logs and left the detections-list UI showing a broken audio/spectrogram player until a manual reload.

This adds a single source of truth for a clip's capture window and teaches the media API to tell a clip that is still legitimately pending apart from one that is genuinely gone.

Key changes:

- `conf.Settings.DetectionCaptureWindow` computes a clip's capture length and readiness time; `buildSaveAudioAction` is refactored onto it so the export scheduler and the media API can never compute the window differently.
- `GET /audio/:id` and `GET /spectrogram/:id` now return `503 + Retry-After` (not `404`) while a clip is still within its capture-ready window, emitted through a non-reporting helper so these expected, self-resolving responses no longer hit Sentry or the notification bell. Genuinely-absent clips still return `404`.
- The async spectrogram worker waits out the pending window instead of hard-failing after the short encode-race wait.
- Transient logs are re-leveled: SecureFS `404` to Info, the deferred save-clip retry to Debug (via a new `jobqueue.ErrJobDeferred` sentinel, which retires a high-volume WARN class), spectrogram source-missing to Warn; genuine failures stay at ERROR. A canceled or shutting-down context is now classified as operational rather than "file not found".
- Frontend: the `SpectrogramPlayer` retry budget is extended (with delays kept under the loader timeout) so a pending clip resolves on its own without a manual reload.

## Related

Relates to discussion https://github.com/tphakala/birdnet-go/discussions/3735.

## Test plan

- [x] `go build ./...` clean; `golangci-lint run` reports 0 issues on the changed packages
- [x] `go test -race` passes for `internal/conf`, `internal/analysis/jobqueue`, `internal/analysis/processor`, `internal/api/v2/media`
- [x] New tests: `DetectionCaptureWindow` (all branches), `ServeAudioByID` pending 503-vs-404, `waitForPendingClip`, and the jobqueue deferral log level
- [x] Frontend: `prettier` and `svelte-check` clean; `SpectrogramPlayer` vitest 14/14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Media endpoints now return `503 Service Unavailable` with an accurate `Retry-After` while audio/spectrogram clips are still pending (extended capture); `404 Not Found` is used only when clips truly don’t exist.
  * Improved spectrogram availability retries when generation is delayed.
  * Refined extended-capture timing to prevent premature missing-clip responses.
* **Tests**
  * Added coverage for pending-export behavior and pending-clip waiting logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->