### PR TITLE
fix(datastore): recognize migrated v2 DB with empty legacy tables as v2

### DIFF
--- a/internal/datastore/v2/startup.go
+++ b/internal/datastore/v2/startup.go
@@ -889,15 +889,18 @@ func legacyDataPresent(db *gorm.DB) (bool, error) {
 		if _, ok := existing[name]; !ok {
 			continue
 		}
-		// Existence probe, not a full COUNT(*): a contaminated legacy table can hold hundreds of
-		// thousands of unmigrated rows (GitHub #3924), and counting all of them on every startup
-		// just to learn "is it non-empty" would scan the whole table and could approach the DB
-		// startup timeout. SELECT 1 ... LIMIT 1 stops at the first row; RowsAffected reports it.
-		res := db.Table(name).Select("1").Limit(1).Scan(new(int))
-		if res.Error != nil {
-			return false, res.Error
+		// Existence probe via SELECT EXISTS, not a full COUNT(*): a contaminated legacy table can
+		// hold hundreds of thousands of unmigrated rows (GitHub #3924), and counting all of them on
+		// every startup would scan the whole table and could approach the DB startup timeout. EXISTS
+		// short-circuits at the first row and yields an explicit 0/1, so it does not depend on GORM
+		// populating RowsAffected after Scan (which can vary by version/driver). The table name comes
+		// from the fixed legacyDataTables allowlist, so the interpolation is safe. Backtick quoting
+		// works on both SQLite and MySQL (mirrors cleanupLegacySchemaContamination in this package).
+		var hasRow int
+		if err := db.Raw("SELECT EXISTS(SELECT 1 FROM `" + name + "`)").Scan(&hasRow).Error; err != nil {
+			return false, err
 		}
-		if res.RowsAffected > 0 {
+		if hasRow != 0 {
 			return true, nil
 		}
 	}

--- a/internal/datastore/v2/startup.go
+++ b/internal/datastore/v2/startup.go
@@ -872,19 +872,32 @@ var legacyDataTables = []string{"results", "notes"}
 // tables behind. The bool is meaningful only when the returned error is nil; because this decision
 // gates destructive startup actions, callers should fail closed (treat as not-clean-v2) on error.
 func legacyDataPresent(db *gorm.DB) (bool, error) {
+	// Resolve which tables exist with an error-returning probe. db.Migrator().HasTable swallows
+	// the underlying metadata-query error and just reports false, which would let a probe failure
+	// be misread as "no legacy data" (fail open) on a database this function is meant to fail
+	// closed for. GetTables surfaces the error so the caller can reject the database instead.
+	tables, err := db.Migrator().GetTables()
+	if err != nil {
+		return false, err
+	}
+	existing := make(map[string]struct{}, len(tables))
+	for _, t := range tables {
+		existing[t] = struct{}{}
+	}
+
 	for _, name := range legacyDataTables {
-		if !db.Migrator().HasTable(name) {
+		if _, ok := existing[name]; !ok {
 			continue
 		}
-		// Existence probe, not a full COUNT(*): a contaminated legacy table can hold
-		// hundreds of thousands of unmigrated rows (GitHub #3924), and counting all of
-		// them on every startup just to learn "is it non-empty" would scan the whole table
-		// and could approach the DB startup timeout. SELECT 1 ... LIMIT 1 stops at the first row.
-		var found []int
-		if err := db.Table(name).Select("1").Limit(1).Find(&found).Error; err != nil {
-			return false, err
+		// Existence probe, not a full COUNT(*): a contaminated legacy table can hold hundreds of
+		// thousands of unmigrated rows (GitHub #3924), and counting all of them on every startup
+		// just to learn "is it non-empty" would scan the whole table and could approach the DB
+		// startup timeout. SELECT 1 ... LIMIT 1 stops at the first row; RowsAffected reports it.
+		res := db.Table(name).Select("1").Limit(1).Scan(new(int))
+		if res.Error != nil {
+			return false, res.Error
 		}
-		if len(found) > 0 {
+		if res.RowsAffected > 0 {
 			return true, nil
 		}
 	}

--- a/internal/datastore/v2/startup.go
+++ b/internal/datastore/v2/startup.go
@@ -753,20 +753,24 @@ func CheckSQLiteHasV2Schema(dbPath string) bool {
 		return false
 	}
 
-	// A COMPLETED marker alone is NOT sufficient evidence of a usable fresh v2 schema:
-	// if a legacy data table ('results' or 'notes') exists, this is a PR #2165-contaminated
-	// legacy database, not a real v2 database.
+	// A COMPLETED marker together with a *populated* legacy data table ('results' or 'notes')
+	// means real user data is still stranded in the legacy schema: a PR #2165-contaminated
+	// legacy database masquerading as v2 (GitHub #3924). Treating it as v2 lets
+	// CheckAndConsolidateAtStartup delete the real migrated sidecar, so reject it.
 	//
-	// Fail closed: this function gates destructive startup actions (deleting/renaming the
-	// migrated sidecar in CheckAndConsolidateAtStartup). If the probe itself errors we cannot
-	// prove the database is a clean v2 schema, so return false rather than risk misclassifying
-	// a contaminated or corrupt database as v2 (matches the migration_states probe above).
-	var legacyTableCount int64
-	err = db.Raw("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name IN ('results', 'notes')").Scan(&legacyTableCount).Error
-	if err != nil {
-		return false
-	}
-	if legacyTableCount > 0 {
+	// An EMPTY legacy table, by contrast, is harmless residue: a fully migrated v2 database can
+	// still carry the old 'notes'/'results' tables (GORM never drops tables) with no rows left in
+	// them. Such databases MUST still be recognised as v2. Keying on table existence alone (as
+	// PR #3926 first did) forced these healthy databases into legacy mode, where legacy AutoMigrate
+	// then crashes with "Cannot add a NOT NULL column with default value NULL" while adding a
+	// legacy column to an already-populated table. Discriminate on row count, not mere table
+	// existence.
+	//
+	// Fail closed on probe error: this function gates destructive startup actions, so if we
+	// cannot prove the legacy tables are empty, return false rather than risk misclassifying a
+	// contaminated or corrupt database as v2 (matches the migration_states probe above).
+	hasLegacyData, err := legacyDataPresent(db)
+	if err != nil || hasLegacyData {
 		return false
 	}
 
@@ -844,14 +848,47 @@ func hasCompleteFreshV2Schema(db *gorm.DB) bool {
 	// initializeV2OnlyMode fall back to the v2_ prefixed schema, whose tables are
 	// (re)created by the subsequent Initialize()/AutoMigrate.
 	//
-	// A COMPLETED marker alongside a legacy data table ('results' or 'notes') means
-	// this is a PR #2165-contaminated legacy database, not a fresh no-prefix v2 schema.
-	// Mirror the same legacy-table guard used by CheckSQLiteHasV2Schema so both the
-	// SQLite and MySQL/dialect-agnostic paths reject contamination identically.
-	if db.Migrator().HasTable("results") || db.Migrator().HasTable("notes") {
+	// A COMPLETED marker alongside a *populated* legacy data table ('results' or 'notes')
+	// means real user data is still stranded in the legacy schema: a PR #2165-contaminated
+	// legacy database, not a fresh no-prefix v2 schema (GitHub #3924). Reject it. An EMPTY
+	// legacy table is harmless residue that a fully migrated v2 database can still carry and
+	// must NOT disqualify the schema; keying on table existence alone (as PR #3926 first did)
+	// wrongly forced healthy v2 databases into legacy mode. Mirror the same row-based guard
+	// used by CheckSQLiteHasV2Schema, failing closed on a row-count probe error.
+	if hasLegacyData, err := legacyDataPresent(db); err != nil || hasLegacyData {
 		return false
 	}
 	return db.Migrator().HasTable("detections")
+}
+
+// legacyDataTables lists the v1 data tables. After a completed in-place migration these tables
+// are commonly left behind EMPTY (GORM never drops tables); that residue is harmless. Only rows
+// still sitting in them indicate real unmigrated legacy data, i.e. a PR #2165-contaminated
+// database masquerading as a completed v2 schema (GitHub #3924).
+var legacyDataTables = []string{"results", "notes"}
+
+// legacyDataPresent reports whether any legacy data table exists AND still holds at least one row.
+// Table existence alone is not contamination: a genuine completed migration leaves empty legacy
+// tables behind. The bool is meaningful only when the returned error is nil; because this decision
+// gates destructive startup actions, callers should fail closed (treat as not-clean-v2) on error.
+func legacyDataPresent(db *gorm.DB) (bool, error) {
+	for _, name := range legacyDataTables {
+		if !db.Migrator().HasTable(name) {
+			continue
+		}
+		// Existence probe, not a full COUNT(*): a contaminated legacy table can hold
+		// hundreds of thousands of unmigrated rows (GitHub #3924), and counting all of
+		// them on every startup just to learn "is it non-empty" would scan the whole table
+		// and could approach the DB startup timeout. SELECT 1 ... LIMIT 1 stops at the first row.
+		var found []int
+		if err := db.Table(name).Select("1").Limit(1).Find(&found).Error; err != nil {
+			return false, err
+		}
+		if len(found) > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // cleanupOrphanedBareV2Tables removes bare v2 tables that were created by a broken nightly

--- a/internal/datastore/v2/startup_test.go
+++ b/internal/datastore/v2/startup_test.go
@@ -599,6 +599,20 @@ func TestLegacyDataPresent(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, present, "contamination in the second legacy table must still be detected")
 	})
+
+	t.Run("metadata probe error fails closed", func(t *testing.T) {
+		// A failure to enumerate tables must propagate as an error (fail closed), never be
+		// reported as (false, nil) which callers would read as "clean v2". Close the underlying
+		// connection to force the GetTables metadata query to fail.
+		db := newSchemaCheckDB(t)
+		sqlDB, err := db.DB()
+		require.NoError(t, err)
+		require.NoError(t, sqlDB.Close())
+
+		present, err := legacyDataPresent(db)
+		require.Error(t, err, "a metadata-probe failure must propagate")
+		assert.False(t, present, "the bool must be the safe zero value on error")
+	})
 }
 
 // createLegacySQLite creates a minimal legacy SQLite database with a notes table

--- a/internal/datastore/v2/startup_test.go
+++ b/internal/datastore/v2/startup_test.go
@@ -169,6 +169,50 @@ func TestCheckMigrationState_StaleEmptySidecar_V2Consolidated(t *testing.T) {
 	assert.True(t, os.IsNotExist(err), "stale sidecar should have been removed")
 }
 
+// TestCheckMigrationState_V2WithEmptyLegacyResidue_SQLite is a regression test for the
+// PR #3926 startup crash: a fully consolidated v2 database (COMPLETED marker, real v2 tables)
+// that still carries EMPTY leftover legacy tables ('notes'/'results') from an in-place
+// migration must route into v2-only mode. PR #3926 keyed on mere table existence and
+// misclassified such healthy databases as contaminated legacy, forcing legacy AutoMigrate,
+// which crashed with "Cannot add a NOT NULL column with default value NULL" (GitHub #3924).
+func TestCheckMigrationState_V2WithEmptyLegacyResidue_SQLite(t *testing.T) {
+	tmpDir := t.TempDir()
+	configuredPath := filepath.Join(tmpDir, "birdnet-2025.db")
+
+	createConsolidatedV2DBAt(t, configuredPath)
+
+	// Reproduce the production residue: empty legacy tables left behind by a completed
+	// in-place migration (GORM never drops them).
+	db, err := gorm.Open(sqlite.Open(configuredPath), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	// Ensure the writer handle is closed even if a require below fails, so t.TempDir()
+	// cleanup does not fail on Windows with an open file handle.
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	require.NoError(t, db.Exec("CREATE TABLE notes (id INTEGER PRIMARY KEY)").Error)
+	require.NoError(t, db.Exec("CREATE TABLE results (id INTEGER PRIMARY KEY)").Error)
+
+	// Close the writer handle before CheckMigrationStateBeforeStartup opens the file read-only.
+	require.NoError(t, sqlDB.Close())
+
+	settings := &conf.Settings{}
+	settings.Output.SQLite.Enabled = true
+	settings.Output.SQLite.Path = configuredPath
+
+	startupState := CheckMigrationStateBeforeStartup(settings)
+
+	assert.False(t, startupState.FreshInstall, "should NOT be fresh install")
+	assert.True(t, startupState.V2Available, "v2 should be available")
+	assert.False(t, startupState.LegacyRequired,
+		"legacy must not be required for a completed v2 DB with empty legacy residue")
+	assert.Equal(t, entities.MigrationStatusCompleted, startupState.MigrationStatus)
+	require.NoError(t, startupState.Error)
+}
+
 // TestCheckMigrationState_EmptySidecar_NoConfigured covers the edge case
 // where a stray empty sidecar exists but the configured path is missing.
 // The fallback must not trigger (there is no v2 schema to fall back to)
@@ -298,11 +342,13 @@ func TestCheckSQLiteHasV2Schema(t *testing.T) {
 		assert.False(t, CheckSQLiteHasV2Schema(dbPath), "should return false for empty file")
 	})
 
-	// Both 'results' and 'notes' are legacy data tables; a COMPLETED marker alongside
-	// either one is PR #2165 contamination, so each must independently force a false result.
-	for _, lt := range []struct{ name, ddl string }{
-		{"results", "CREATE TABLE results (id INTEGER PRIMARY KEY)"},
-		{"notes", "CREATE TABLE notes (id INTEGER PRIMARY KEY)"},
+	// A COMPLETED marker alongside a legacy data table that STILL HOLDS ROWS is PR #2165
+	// contamination: real user data was never migrated (GitHub #3924). Each populated legacy
+	// table must independently force a false result so CheckAndConsolidateAtStartup preserves
+	// the real migrated sidecar instead of deleting it.
+	for _, lt := range []struct{ name, ddl, insert string }{
+		{"results", "CREATE TABLE results (id INTEGER PRIMARY KEY)", "INSERT INTO results (id) VALUES (1)"},
+		{"notes", "CREATE TABLE notes (id INTEGER PRIMARY KEY)", "INSERT INTO notes (id) VALUES (1)"},
 	} {
 		t.Run("contaminated legacy database (PR #2165 bug) - "+lt.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
@@ -323,13 +369,50 @@ func TestCheckSQLiteHasV2Schema(t *testing.T) {
 			}
 			require.NoError(t, manager.DB().Save(&state).Error)
 
-			// Simulate PR #2165 contamination: a legacy data table alongside the COMPLETED marker.
+			// Simulate PR #2165 contamination: a legacy data table with UNMIGRATED ROWS
+			// alongside the COMPLETED marker.
 			require.NoError(t, manager.DB().Exec(lt.ddl).Error)
+			require.NoError(t, manager.DB().Exec(lt.insert).Error)
 
 			require.NoError(t, manager.Close())
 
 			assert.False(t, CheckSQLiteHasV2Schema(dbPath),
-				"should return false when legacy %s table exists", lt.name)
+				"should return false when legacy %s table holds unmigrated rows", lt.name)
+		})
+	}
+
+	// Regression test for PR #3926: an EMPTY leftover legacy table ('results' or 'notes') is
+	// harmless residue of a completed in-place migration (GORM never drops tables). The database
+	// is a genuine completed v2 schema and must still resolve as v2; the original "table exists"
+	// guard wrongly forced these into legacy mode, crashing AutoMigrate on startup (GitHub #3924).
+	for _, lt := range []struct{ name, ddl string }{
+		{"results", "CREATE TABLE results (id INTEGER PRIMARY KEY)"},
+		{"notes", "CREATE TABLE notes (id INTEGER PRIMARY KEY)"},
+	} {
+		t.Run("completed v2 with empty leftover legacy table - "+lt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			dbPath := filepath.Join(tmpDir, "residue.db")
+
+			manager, err := NewSQLiteManager(Config{DirectPath: dbPath})
+			require.NoError(t, err)
+			require.NoError(t, manager.Initialize())
+
+			now := time.Now()
+			state := entities.MigrationState{
+				ID:          1,
+				State:       entities.MigrationStatusCompleted,
+				StartedAt:   &now,
+				CompletedAt: &now,
+			}
+			require.NoError(t, manager.DB().Save(&state).Error)
+
+			// Empty legacy table: residue of a completed migration, not contamination.
+			require.NoError(t, manager.DB().Exec(lt.ddl).Error)
+
+			require.NoError(t, manager.Close())
+
+			assert.True(t, CheckSQLiteHasV2Schema(dbPath),
+				"an empty leftover legacy %s table must still resolve as v2", lt.name)
 		})
 	}
 }
@@ -435,23 +518,87 @@ func TestHasCompleteFreshV2Schema(t *testing.T) {
 	})
 
 	// The MySQL/dialect-agnostic path must reject either legacy data table ('results' or
-	// 'notes') coexisting with a COMPLETED marker and a bare detections table.
-	for _, lt := range []struct{ name, ddl string }{
-		{"results", "CREATE TABLE results (id INTEGER PRIMARY KEY)"},
-		{"notes", "CREATE TABLE notes (id INTEGER PRIMARY KEY)"},
+	// 'notes') when it STILL HOLDS ROWS (unmigrated data) alongside a COMPLETED marker and a
+	// bare detections table.
+	for _, lt := range []struct{ name, ddl, insert string }{
+		{"results", "CREATE TABLE results (id INTEGER PRIMARY KEY)", "INSERT INTO results (id) VALUES (1)"},
+		{"notes", "CREATE TABLE notes (id INTEGER PRIMARY KEY)", "INSERT INTO notes (id) VALUES (1)"},
 	} {
 		t.Run("contaminated legacy database (PR #2165 bug) - "+lt.name, func(t *testing.T) {
 			db := newSchemaCheckDB(t)
 			seedMigrationStatesTable(t, db, entities.MigrationStatusCompleted)
 			createBareDetectionsTable(t, db)
 
-			// Simulate PR #2165 contamination: a legacy data table alongside the COMPLETED marker.
+			// Simulate PR #2165 contamination: a legacy data table with UNMIGRATED ROWS
+			// alongside the COMPLETED marker.
 			require.NoError(t, db.Exec(lt.ddl).Error)
+			require.NoError(t, db.Exec(lt.insert).Error)
 
 			assert.False(t, hasCompleteFreshV2Schema(db),
-				"should return false when legacy %s table exists", lt.name)
+				"should return false when legacy %s table holds unmigrated rows", lt.name)
 		})
 	}
+
+	// Regression test for PR #3926: an EMPTY leftover legacy table is harmless residue of a
+	// completed in-place migration and must NOT disqualify an otherwise complete fresh v2 schema.
+	for _, lt := range []struct{ name, ddl string }{
+		{"results", "CREATE TABLE results (id INTEGER PRIMARY KEY)"},
+		{"notes", "CREATE TABLE notes (id INTEGER PRIMARY KEY)"},
+	} {
+		t.Run("completed v2 with empty leftover legacy table - "+lt.name, func(t *testing.T) {
+			db := newSchemaCheckDB(t)
+			seedMigrationStatesTable(t, db, entities.MigrationStatusCompleted)
+			createBareDetectionsTable(t, db)
+
+			// Empty legacy table: residue of a completed migration, not contamination.
+			require.NoError(t, db.Exec(lt.ddl).Error)
+
+			assert.True(t, hasCompleteFreshV2Schema(db),
+				"an empty leftover legacy %s table must not disqualify a fresh v2 schema", lt.name)
+		})
+	}
+}
+
+// TestLegacyDataPresent locks in the row-count discriminator directly: a legacy table signals
+// contamination only when it actually holds rows, and the probe walks past an empty table to
+// check the next one (order is results, then notes).
+func TestLegacyDataPresent(t *testing.T) {
+	t.Run("no legacy tables", func(t *testing.T) {
+		db := newSchemaCheckDB(t)
+		present, err := legacyDataPresent(db)
+		require.NoError(t, err)
+		assert.False(t, present, "a database with no legacy tables has no legacy data")
+	})
+
+	t.Run("empty legacy tables", func(t *testing.T) {
+		db := newSchemaCheckDB(t)
+		require.NoError(t, db.Exec("CREATE TABLE results (id INTEGER PRIMARY KEY)").Error)
+		require.NoError(t, db.Exec("CREATE TABLE notes (id INTEGER PRIMARY KEY)").Error)
+		present, err := legacyDataPresent(db)
+		require.NoError(t, err)
+		assert.False(t, present, "empty legacy tables are harmless residue, not contamination")
+	})
+
+	t.Run("populated notes", func(t *testing.T) {
+		db := newSchemaCheckDB(t)
+		require.NoError(t, db.Exec("CREATE TABLE notes (id INTEGER PRIMARY KEY)").Error)
+		require.NoError(t, db.Exec("INSERT INTO notes (id) VALUES (1)").Error)
+		present, err := legacyDataPresent(db)
+		require.NoError(t, err)
+		assert.True(t, present, "a populated legacy notes table is unmigrated data")
+	})
+
+	t.Run("empty results but populated notes", func(t *testing.T) {
+		// results is probed first and is empty; the loop must continue and still detect
+		// the unmigrated rows in notes.
+		db := newSchemaCheckDB(t)
+		require.NoError(t, db.Exec("CREATE TABLE results (id INTEGER PRIMARY KEY)").Error)
+		require.NoError(t, db.Exec("CREATE TABLE notes (id INTEGER PRIMARY KEY)").Error)
+		require.NoError(t, db.Exec("INSERT INTO notes (id) VALUES (1)").Error)
+		present, err := legacyDataPresent(db)
+		require.NoError(t, err)
+		assert.True(t, present, "contamination in the second legacy table must still be detected")
+	})
 }
 
 // createLegacySQLite creates a minimal legacy SQLite database with a notes table


### PR DESCRIPTION
## Summary

PR #3926 (fixing #3924) made `CheckSQLiteHasV2Schema` and `hasCompleteFreshV2Schema` treat the mere existence of a legacy `notes` or `results` table as proof of a "PR #2165-contaminated" legacy database. But a fully migrated v2 SQLite database can still carry those tables as empty residue (GORM never drops tables), so a healthy completed-v2 install gets misclassified as legacy on startup. It is routed into legacy AutoMigrate, which fails with `Cannot add a NOT NULL column with default value NULL` while adding a legacy column to an already-populated table, and the app crash-loops and never starts.

## Fix

Discriminate on row count, not table existence. A new `legacyDataPresent` helper reports contamination only when a legacy table still holds rows (real unmigrated data). An empty leftover table is treated as harmless residue and the database is correctly recognized as v2. This keeps the original #3924/#3926 protection intact (a legacy DB with unmigrated rows in `notes`/`results` is still rejected, so its migrated sidecar is not deleted) while fixing the crash for users who already completed migration. The probe uses `SELECT 1 ... LIMIT 1` rather than `COUNT(*)`, so a large contaminated table is not fully scanned on every startup.

## Test Plan

- [x] Reproduced end to end: a binary built from current `main` crashes with the NOT NULL error on a copy of an affected 432k-detection database; the fixed binary starts cleanly in enhanced v2 mode (`decision: v2_restart` then `enhanced database mode initialized successfully`).
- [x] Updated the PR #2165 contamination unit tests to insert a row (real unmigrated data) so they assert rejection for the right reason.
- [x] Added unit tests asserting an empty leftover `notes`/`results` table still resolves as v2, on both the SQLite raw-SQL path and the dialect-agnostic (MySQL) path.
- [x] Added a direct `legacyDataPresent` unit test (absent / empty / populated / mixed) and a routing-level regression test (`TestCheckMigrationState_V2WithEmptyLegacyResidue_SQLite`) covering the full startup decision.
- [x] `go test -race ./internal/datastore/v2/...` and `golangci-lint run` pass.

Fixes the startup regression introduced by #3926.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup/schema detection for completed v2 databases.
  * Legacy `notes`/`results` tables only block v2 detection when they contain legacy rows; empty leftovers no longer prevent v2-only startup.
  * Schema detection now fails safely when it encounters errors.
* **Tests**
  * Added SQLite regression coverage for empty legacy residue scenarios.
  * Extended tests to validate row-based contamination behavior and fail-closed handling of probe errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->