### PR TITLE
fix(install): stop update from resetting container TZ to UTC (#3950)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3878,54 +3878,98 @@ get_ip_location() {
     return 1
 }
 
+# Validate a candidate IANA zone name against the zoneinfo database. Rejects an empty
+# value, path traversal ("..", which would let the existence check escape the zoneinfo
+# tree) and any name with no matching zoneinfo file (e.g. timedatectl's "n/a" on an
+# unconfigured host, or an absolute path left by a non-standard /etc/localtime symlink).
+# On success echoes the zone and returns 0; otherwise echoes nothing and returns 1.
+# $2 overrides the zoneinfo directory (test seam).
+_valid_iana_tz() {
+    local tz="$1"
+    local zoneinfo_dir="${2:-/usr/share/zoneinfo}"
+    [ -n "$tz" ] || return 1
+    case "$tz" in
+        *..*) return 1 ;;
+    esac
+    [ -f "$zoneinfo_dir/$tz" ] || return 1
+    printf '%s' "$tz"
+}
+
 # Resolve the host timezone using a single, validated detection chain.
 # Shared by configure_timezone() and generate_systemd_service_content() so the two
 # cannot drift apart (Forgejo #877). Tries, in order: an optional preferred candidate
-# (e.g. a previously configured zone), /etc/timezone, timedatectl, and the
-# /etc/localtime symlink. The result is validated against the zoneinfo database and
-# rejected if it contains path traversal. Echoes a valid IANA zone name, or an empty
-# string if none could be resolved (callers decide the UTC fallback so they can warn).
+# (e.g. a previously configured zone), timedatectl, the /etc/localtime symlink, and
+# finally /etc/timezone. Each source is validated against the zoneinfo database
+# independently and skipped on failure, so a stale or invalid earlier source no longer
+# defeats a valid later one. Echoes a valid IANA zone name, or an empty string if none
+# could be resolved (callers decide the UTC fallback so they can warn).
+#
+# timedatectl is preferred over /etc/timezone (GitHub #3950): /etc/timezone is a
+# Debian-ism updated only by tzdata tooling and can go stale (e.g. `timedatectl
+# set-timezone` on some setups only rewrites /etc/localtime), whereas timedatectl and
+# /etc/localtime reflect the zone the kernel and Go's time.Local actually use. On systemd
+# hosts without /etc/timezone (Debian 13, #3351) detection still succeeds at timedatectl
+# or /etc/localtime; /etc/timezone stays in the chain only as a last resort for
+# pre-systemd hosts with no working timedatectl.
 resolve_host_timezone() {
     local candidate="${1:-}"
-    local tz="$candidate"
+    # Test seams: default to the real system paths.
+    local tz_etc="${BNG_TZ_ETC_TIMEZONE:-/etc/timezone}"
+    local localtime_link="${BNG_TZ_LOCALTIME:-/etc/localtime}"
+    local zoneinfo_dir="${BNG_TZ_ZONEINFO_DIR:-/usr/share/zoneinfo}"
+    zoneinfo_dir="${zoneinfo_dir%/}"   # tolerate a trailing slash so the symlink prefix-strip matches
+    local tz
 
-    if [ -z "$tz" ] && [ -f /etc/timezone ]; then
-        tz=$(cat /etc/timezone 2>/dev/null | tr -d '\n' | tr -d ' ')
+    # 1. Explicit prior configuration (preservation above all else).
+    if [ -n "$candidate" ] && tz=$(_valid_iana_tz "$candidate" "$zoneinfo_dir"); then
+        printf '%s' "$tz"; return 0
     fi
 
-    if [ -z "$tz" ] && command_exists timedatectl; then
-        tz=$(timedatectl show --property=Timezone --value 2>/dev/null | tr -d '\n' | tr -d ' ')
+    # 2. timedatectl: systemd's authoritative view of the host zone.
+    if command_exists timedatectl; then
+        local td
+        td=$(timedatectl show --property=Timezone --value 2>/dev/null | tr -d '[:space:]')
+        if tz=$(_valid_iana_tz "$td" "$zoneinfo_dir"); then
+            printf '%s' "$tz"; return 0
+        fi
     fi
 
-    if [ -z "$tz" ] && [ -L /etc/localtime ]; then
+    # 3. /etc/localtime symlink into the zoneinfo tree (the file Go's time.Local reads).
+    if [ -L "$localtime_link" ]; then
         local tz_path
-        tz_path=$(readlink -f /etc/localtime)
-        tz=${tz_path#/usr/share/zoneinfo/}
+        tz_path=$(readlink -f "$localtime_link" 2>/dev/null)
+        if tz=$(_valid_iana_tz "${tz_path#"$zoneinfo_dir"/}" "$zoneinfo_dir"); then
+            printf '%s' "$tz"; return 0
+        fi
     fi
 
-    # Validate against the zoneinfo database before trusting it. timedatectl can report
-    # "n/a" on unconfigured images and a non-standard /etc/localtime symlink can leave an
-    # absolute path; neither is a valid zone identifier. A value containing ".." would let
-    # the existence check escape /usr/share/zoneinfo, so reject those outright.
-    if [ -n "$tz" ] && { [[ "$tz" == *..* ]] || [ ! -f "/usr/share/zoneinfo/$tz" ]; }; then
-        tz=""
+    # 4. /etc/timezone: Debian-ism, last resort (can be stale, see header).
+    if [ -f "$tz_etc" ]; then
+        local ft
+        ft=$(tr -d '[:space:]' < "$tz_etc" 2>/dev/null)
+        if tz=$(_valid_iana_tz "$ft" "$zoneinfo_dir"); then
+            printf '%s' "$tz"; return 0
+        fi
     fi
 
-    printf '%s' "$tz"
+    printf ''
 }
 
 # Function to configure timezone
 configure_timezone() {
-    # Silent mode: use system timezone
+    # Silent mode: preserve any zone already chosen this run (e.g. one restored from an
+    # existing unit during an update/migration), otherwise detect the host zone via the
+    # shared resolver so silent installs use the same validated, timedatectl-first chain as
+    # interactive ones. The old inline chain preferred a stale /etc/timezone, skipped
+    # zoneinfo validation, and unconditionally clobbered a restored zone (GitHub #3950).
     if [ "$SILENT_MODE" = "true" ]; then
-        if [ -f /etc/timezone ]; then
-            CONFIGURED_TZ=$(cat /etc/timezone 2>/dev/null | tr -d '\n')
-        elif command -v timedatectl &>/dev/null; then
-            CONFIGURED_TZ=$(timedatectl show --property=Timezone --value 2>/dev/null)
-        else
+        CONFIGURED_TZ=$(resolve_host_timezone "$CONFIGURED_TZ")
+        if [ -z "$CONFIGURED_TZ" ]; then
             CONFIGURED_TZ="UTC"
+            print_message "🔇 Silent mode: could not detect timezone, defaulting to UTC" "$YELLOW"
+        else
+            print_message "🔇 Silent mode: timezone set to $CONFIGURED_TZ" "$YELLOW"
         fi
-        print_message "🔇 Silent mode: timezone set to $CONFIGURED_TZ" "$YELLOW"
         return
     fi
 
@@ -4848,6 +4892,8 @@ generate_systemd_service_content() {
     TZ=$(resolve_host_timezone "$CONFIGURED_TZ")
     if [ -z "$TZ" ]; then
         TZ="UTC"
+        # stdout is the unit file here, so warn to the log only, never via print_message.
+        log_message "WARN" "Could not resolve host timezone; systemd unit will use TZ=UTC"
     fi
 
     # Determine host UID/GID even when executed with sudo
@@ -4985,6 +5031,30 @@ _extract_bind_addr() {
 # It must be called before check_systemd_service / add_systemd_config on the
 # update and reconfigure paths. Sets globals WEB_PORT, BIND_TLS_PORTS, BIND_METRICS_PORT,
 # and CONFIGURED_TZ.
+
+# Read a systemd unit file, falling back to sudo when the file exists but is not readable
+# by the invoking user (root-owned mode 600 units, GitHub #3950 - a silent read failure
+# there left CONFIGURED_TZ empty and reset the container TZ to UTC on update). Echoes the
+# file content, or nothing if it cannot be read. `sudo -n` (non-interactive) is tried first
+# so unattended/cron updates never hang on a password prompt; an interactive `sudo` is used
+# only when a TTY is attached.
+_read_unit_file() {
+    local f="$1"
+    [ -f "$f" ] || return 0
+    if [ -r "$f" ]; then
+        cat "$f" 2>/dev/null
+        return 0
+    fi
+    if command_exists sudo; then
+        if sudo -n cat "$f" 2>/dev/null; then
+            return 0
+        fi
+        if [ -t 0 ]; then
+            sudo cat "$f" 2>/dev/null
+        fi
+    fi
+}
+
 # shellcheck disable=SC2120  # optional $1 (unit path) is intentional, used by tests
 load_existing_service_config() {
     # Optional explicit unit path (used by tests); defaults to the installed locations.
@@ -4998,13 +5068,19 @@ load_existing_service_config() {
     fi
     [ -z "$service_file" ] && return 0
 
+    # Read the unit once (with a sudo fallback for a root-only-readable unit, GitHub #3950)
+    # and parse the captured content below, so a unit the invoking user cannot read no
+    # longer silently loses the web port / TLS / metrics bindings and timezone.
+    local unit_content
+    unit_content=$(_read_unit_file "$service_file")
+
     # Web interface mapping: the one whose container side is 8080 (-p <host>:8080). The host
     # side may carry an optional bind address (e.g. 127.0.0.1:9000:8080 when a user manually
     # bound to localhost behind a same-host reverse proxy). Preserve the bind address as well
     # as the port so an update does not silently re-expose a localhost-only binding to all
     # interfaces. Each -p is on its own continuation line, so a per-line match is sufficient.
     local web_map
-    web_map=$(grep -oE '\-p (\[[0-9a-fA-F:]+\]:|[0-9.]+:)?[0-9]+:8080' "$service_file" 2>/dev/null | head -1)
+    web_map=$(grep -oE '\-p (\[[0-9a-fA-F:]+\]:|[0-9.]+:)?[0-9]+:8080' <<<"$unit_content" | head -1)
     if [ -n "$web_map" ]; then
         # Strip the leading "-p " and trailing ":8080", leaving "<addr>:<port>" or "<port>".
         local host_spec
@@ -5037,7 +5113,7 @@ load_existing_service_config() {
     # them as AutoTLS-enabled so a regenerate produces the corrected 443:8443 mapping
     # instead of silently dropping AutoTLS. The trailing \b avoids a false match
     # inside e.g. 443:4433.
-    tls_map=$(grep -oE '\-p (\[[0-9a-fA-F:]+\]:|[0-9.]+:)?443:(8443|443)\b' "$service_file" 2>/dev/null | head -1)
+    tls_map=$(grep -oE '\-p (\[[0-9a-fA-F:]+\]:|[0-9.]+:)?443:(8443|443)\b' <<<"$unit_content" | head -1)
     if [ -n "$tls_map" ]; then
         BIND_TLS_PORTS="true"
         # Strip whichever container-port suffix matched to recover any bind address.
@@ -5048,7 +5124,7 @@ load_existing_service_config() {
         TLS_BIND_ADDR=$(_extract_bind_addr "$tls_map" "$tls_portpair")
     fi
     local metrics_map
-    metrics_map=$(grep -oE '\-p (\[[0-9a-fA-F:]+\]:|[0-9.]+:)?8090:8090' "$service_file" 2>/dev/null | head -1)
+    metrics_map=$(grep -oE '\-p (\[[0-9a-fA-F:]+\]:|[0-9.]+:)?8090:8090' <<<"$unit_content" | head -1)
     if [ -n "$metrics_map" ]; then
         BIND_METRICS_PORT="true"
         METRICS_BIND_ADDR=$(_extract_bind_addr "$metrics_map" "8090:8090")
@@ -5057,7 +5133,13 @@ load_existing_service_config() {
     # Timezone, only if not already chosen this run.
     if [ -z "$CONFIGURED_TZ" ]; then
         local existing_tz
-        existing_tz=$(sed -n 's/.*--env TZ="\([^"]*\)".*/\1/p' "$service_file" 2>/dev/null | head -1)
+        existing_tz=$(sed -n 's/.*--env TZ="\([^"]*\)".*/\1/p' <<<"$unit_content" | head -1)
+        # If the unit could not be read or carried no TZ, fall back to the still-running
+        # container's env: the update path calls this before stopping the service, so the
+        # --rm container is up and its TZ reflects the zone actually in use (GitHub #3950).
+        if [ -z "$existing_tz" ]; then
+            existing_tz=$(safe_docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' birdnet-go | sed -n 's/^TZ=//p' | head -1)
+        fi
         if [ -n "$existing_tz" ]; then
             CONFIGURED_TZ="$existing_tz"
             log_message "INFO" "Restored timezone from existing service: $CONFIGURED_TZ"
@@ -5553,6 +5635,11 @@ handle_container_update() {
     load_existing_service_config
     if [ -n "$CONFIGURED_TZ" ]; then
         print_message "📍 Using existing timezone configuration: $CONFIGURED_TZ" "$GREEN"
+    elif [ -f "/etc/systemd/system/birdnet-go.service" ] || [ -f "/lib/systemd/system/birdnet-go.service" ]; then
+        # An existing unit is present but no timezone could be recovered from it (e.g. a
+        # root-only-readable unit this run could not read). The regenerated unit will fall
+        # back to host detection; warn so a silent TZ reset to UTC is visible (GitHub #3950).
+        print_message "⚠️  Could not read the timezone from the existing unit; the regenerated unit will use host timezone detection. If detection is wrong (e.g. a stale /etc/timezone), re-run the update with sudo or set the zone from the reconfigure menu." "$YELLOW"
     fi
 
     local service_needs_update
@@ -6602,7 +6689,7 @@ reconfigure_menu() {
     # unit is usually world-readable); if it cannot be copied, rollback restores config only.
     local service_backup="${CONFIG_FILE}.service.reconfigure.bak"
     local has_service_backup="false"
-    if [ -f "/etc/systemd/system/birdnet-go.service" ] && cp "/etc/systemd/system/birdnet-go.service" "$service_backup" 2>/dev/null; then
+    if [ -f "/etc/systemd/system/birdnet-go.service" ] && _read_unit_file "/etc/systemd/system/birdnet-go.service" > "$service_backup" 2>/dev/null && [ -s "$service_backup" ]; then
         has_service_backup="true"
     fi
     stop_birdnet_service

--- a/install.sh
+++ b/install.sh
@@ -2371,7 +2371,10 @@ check_existing_installation_owner() {
 
         if [ -n "$service_file" ]; then
             local service_config_path
-            service_config_path=$(sed -n 's/.*-v \([^ ]*\):\/config.*/\1/p' "$service_file" 2>/dev/null | head -1)
+            # Read via _read_unit_file so a root-only-readable unit (mode 600) is still
+            # parsed (sudo fallback), consistent with load_existing_service_config; a silent
+            # read failure here would blank the cross-user detection path (GitHub #3950).
+            service_config_path=$(_read_unit_file "$service_file" | sed -n 's/.*-v \([^ ]*\):\/config.*/\1/p' | head -1)
 
             if [ -n "$service_config_path" ]; then
                 _check_install_home "${service_config_path%/birdnet-go-app/config}"

--- a/install.sh
+++ b/install.sh
@@ -5052,7 +5052,9 @@ _read_unit_file() {
         if sudo -n cat "$f" 2>/dev/null; then
             return 0
         fi
-        if [ -t 0 ]; then
+        # Interactive sudo only outside silent mode and with a TTY, so an unattended
+        # or --silent run never blocks on a password prompt (GitHub #3950 review).
+        if [ "${SILENT_MODE:-false}" != "true" ] && [ -t 0 ]; then
             sudo cat "$f" 2>/dev/null
         fi
     fi

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -100,6 +100,9 @@ resolve_host_timezone() { printf '%s' "${1:-UTC}"; }
 check_directory_exists() { return 1; }
 is_raspberry_pi() { return 1; }
 has_intel_gpu() { return 1; }
+# No docker on the CI runner path we exercise; the container-TZ fallback degrades to empty.
+# The load_existing_service_config container-fallback test overrides this stub.
+safe_docker() { return 1; }
 
 # Globals the extracted functions reference (install.sh defines these at the top; the harness
 # only pulls function bodies, so under set -u they must exist here).
@@ -116,6 +119,7 @@ for fn in \
     set_yaml_value \
     set_first_audio_source \
     _extract_bind_addr \
+    _read_unit_file \
     load_existing_service_config \
     generate_systemd_service_content \
     apply_tls_settings \
@@ -650,6 +654,131 @@ remote_path_safe "/data'; rm -rf ~"; assert_nonzero "rejects embedded single quo
 it "remote_default_app_path"
 assert_eq "default app path from home" "/home/pi/birdnet-go-app" "$(remote_default_app_path /home/pi)"
 assert_eq "root home" "/root/birdnet-go-app" "$(remote_default_app_path /root)"
+
+# ===========================================================================
+# resolve_host_timezone / _valid_iana_tz  (GitHub #3950)
+# timedatectl must win over a stale /etc/timezone; each source is validated
+# independently so an invalid early source no longer defeats a valid later one.
+# These load the REAL functions, replacing the deterministic stub used by the
+# generation tests above, so this section MUST stay after them.
+# ===========================================================================
+it "resolve_host_timezone"
+load_fn _valid_iana_tz
+load_fn resolve_host_timezone
+
+# Hermetic zoneinfo fixture: these tests never depend on the runner's tzdata and can
+# validate Etc/UTC deterministically. BNG_TZ_ZONEINFO_DIR points _valid_iana_tz at it and
+# stays exported for the container-fallback and silent-mode blocks below (unset at the end).
+ZI="${WORK}/zoneinfo"
+mkdir -p "$ZI/America" "$ZI/Europe" "$ZI/Asia" "$ZI/Etc"
+touch "$ZI/America/Chicago" "$ZI/Europe/Helsinki" "$ZI/Europe/Berlin" \
+      "$ZI/Asia/Tokyo" "$ZI/Etc/UTC"
+ZI="$(cd "$ZI" && pwd -P)"   # canonical, so the /etc/localtime symlink test prefix-strips cleanly
+export BNG_TZ_ZONEINFO_DIR="$ZI"
+
+tzdir="${WORK}/tz"; mkdir -p "$tzdir"
+printf 'Etc/UTC\n' > "${tzdir}/etc_stale"
+printf 'Europe/Helsinki\n' > "${tzdir}/etc_valid"
+ln -sf "$ZI/Asia/Tokyo" "${tzdir}/localtime_tokyo"
+
+# 1. Regression repro: stale /etc/timezone=Etc/UTC must NOT override a correct
+#    timedatectl=America/Chicago when no candidate is supplied. Pre-fix this returned
+#    Etc/UTC (the container-TZ reset). BNG_TZ_LOCALTIME points at a nonexistent path.
+timedatectl() { echo "America/Chicago"; }
+got=$(BNG_TZ_ETC_TIMEZONE="${tzdir}/etc_stale" BNG_TZ_LOCALTIME="${tzdir}/none" resolve_host_timezone "")
+assert_eq "timedatectl beats stale /etc/timezone" "America/Chicago" "$got"
+
+# 2. Debian 13 / Forgejo #877 guard: no /etc/timezone, timedatectl still resolves.
+timedatectl() { echo "Europe/Helsinki"; }
+got=$(BNG_TZ_ETC_TIMEZONE="${tzdir}/absent" BNG_TZ_LOCALTIME="${tzdir}/none" resolve_host_timezone "")
+assert_eq "no /etc/timezone: timedatectl resolves (Debian 13)" "Europe/Helsinki" "$got"
+
+# 3. Candidate preservation: an explicit prior zone wins over host detection.
+timedatectl() { echo "America/Chicago"; }
+got=$(BNG_TZ_ETC_TIMEZONE="${tzdir}/etc_stale" BNG_TZ_LOCALTIME="${tzdir}/none" resolve_host_timezone "Europe/Helsinki")
+assert_eq "candidate preserved over detection" "Europe/Helsinki" "$got"
+
+# 4. timedatectl 'n/a' rejected by validation; /etc/localtime symlink resolves.
+timedatectl() { echo "n/a"; }
+got=$(BNG_TZ_ETC_TIMEZONE="${tzdir}/absent" BNG_TZ_LOCALTIME="${tzdir}/localtime_tokyo" resolve_host_timezone "")
+assert_eq "timedatectl n/a: falls through to /etc/localtime symlink" "Asia/Tokyo" "$got"
+
+# 5. timedatectl absent: /etc/timezone used as last resort.
+command_exists() { case "$1" in timedatectl) return 1 ;; *) command -v "$1" >/dev/null 2>&1 ;; esac; }
+got=$(BNG_TZ_ETC_TIMEZONE="${tzdir}/etc_valid" BNG_TZ_LOCALTIME="${tzdir}/none" resolve_host_timezone "")
+assert_eq "no timedatectl: /etc/timezone last resort" "Europe/Helsinki" "$got"
+command_exists() { command -v "$1" >/dev/null 2>&1; }   # restore
+
+# 6. Path-traversal candidate rejected; empty when nothing else valid.
+timedatectl() { echo ""; }
+got=$(BNG_TZ_ETC_TIMEZONE="${tzdir}/absent" BNG_TZ_LOCALTIME="${tzdir}/none" resolve_host_timezone "../../etc/passwd")
+assert_eq "traversal candidate rejected, nothing else -> empty" "" "$got"
+
+# 7. Invalid candidate falls through to a valid timedatectl.
+timedatectl() { echo "Europe/Berlin"; }
+got=$(BNG_TZ_ETC_TIMEZONE="${tzdir}/absent" BNG_TZ_LOCALTIME="${tzdir}/none" resolve_host_timezone "Not/AZone")
+assert_eq "invalid candidate falls through to detection" "Europe/Berlin" "$got"
+
+unset -f timedatectl
+
+# ===========================================================================
+# load_existing_service_config: running-container TZ fallback (GitHub #3950)
+# ===========================================================================
+it "load_existing_service_config container-TZ fallback"
+unit_notz="${WORK}/notz.service"
+cat > "$unit_notz" <<'UNIT'
+[Service]
+ExecStart=/usr/bin/docker run --rm --name birdnet-go \
+    -p 8080:8080 \
+    --env BIRDNET_UID=1000 \
+    -v /x:/config
+UNIT
+# Unit carries no --env TZ=; the running container reports it via safe_docker inspect.
+safe_docker() { printf 'PATH=/usr/bin\nTZ=Europe/Oslo\nLANG=C\n'; }
+WEB_PORT=""; WEB_PORT_BIND_ADDR=""; BIND_TLS_PORTS="false"; TLS_BIND_ADDR=""
+BIND_METRICS_PORT="false"; METRICS_BIND_ADDR=""; CONFIGURED_TZ=""
+load_existing_service_config "$unit_notz"
+assert_eq "container TZ fallback used when unit has no TZ" "Europe/Oslo" "$CONFIGURED_TZ"
+
+# A unit that DOES carry TZ wins over the container fallback.
+unit_withtz="${WORK}/withtz.service"
+cat > "$unit_withtz" <<'UNIT'
+[Service]
+ExecStart=/usr/bin/docker run --rm --name birdnet-go \
+    -p 8080:8080 \
+    --env TZ="America/Chicago" \
+    -v /x:/config
+UNIT
+safe_docker() { printf 'TZ=Europe/Oslo\n'; }
+WEB_PORT=""; WEB_PORT_BIND_ADDR=""; BIND_TLS_PORTS="false"; TLS_BIND_ADDR=""
+BIND_METRICS_PORT="false"; METRICS_BIND_ADDR=""; CONFIGURED_TZ=""
+load_existing_service_config "$unit_withtz"
+assert_eq "unit TZ wins over container fallback" "America/Chicago" "$CONFIGURED_TZ"
+safe_docker() { return 1; }   # restore default stub
+
+# ===========================================================================
+# configure_timezone silent mode: preserve a restored zone; UTC only when nothing
+# resolves (GitHub #3950 - the old inline chain clobbered a restored zone).
+# ===========================================================================
+it "configure_timezone silent mode"
+load_fn configure_timezone
+SILENT_MODE="true"
+
+# (a) a zone already restored this run is preserved (candidate wins in the resolver).
+timedatectl() { echo "America/Chicago"; }
+CONFIGURED_TZ="Europe/Helsinki"
+BNG_TZ_ETC_TIMEZONE="${WORK}/no_such_tz" BNG_TZ_LOCALTIME="${WORK}/no_such_localtime" configure_timezone
+assert_eq "silent: restored zone preserved" "Europe/Helsinki" "$CONFIGURED_TZ"
+
+# (b) nothing detectable -> UTC.
+command_exists() { case "$1" in timedatectl) return 1 ;; *) command -v "$1" >/dev/null 2>&1 ;; esac; }
+CONFIGURED_TZ=""
+BNG_TZ_ETC_TIMEZONE="${WORK}/no_such_tz" BNG_TZ_LOCALTIME="${WORK}/no_such_localtime" configure_timezone
+assert_eq "silent: no detection -> UTC" "UTC" "$CONFIGURED_TZ"
+command_exists() { command -v "$1" >/dev/null 2>&1; }
+unset -f timedatectl
+SILENT_MODE=""
+unset BNG_TZ_ZONEINFO_DIR
 
 # ===========================================================================
 # Result


### PR DESCRIPTION
## Summary

Fixes #3950. Updating via `install.sh` could silently reset the Docker container's `TZ` to `Etc/UTC`, after which every detection date/time returned by the API and published over MQTT rendered in UTC instead of the server's local zone. The web dashboard still looked right because it re-localizes the absolute RFC3339 `timestamp` in the browser; only the flat `date`/`time` string fields and MQTT exposed the wrong zone. It surfaced widely in 20260716 because the v2 datastore read path (reached by more installs after #3947) re-renders stored epochs through the process-local zone, so a wrong container `TZ` rewrote all history, not just new detections.

## Root cause (two combined install.sh defects)

1. **Unit read without privilege.** `load_existing_service_config` parsed the existing systemd unit with plain `grep`/`sed` and `2>/dev/null`. On hosts where `/etc/systemd/system/birdnet-go.service` is root-owned mode `600`, every read failed silently, `CONFIGURED_TZ` stayed empty, and the previously configured zone (plus web port / TLS / metrics bindings) was lost on regeneration.
2. **Stale `/etc/timezone` preferred over `timedatectl`.** With `CONFIGURED_TZ` empty, `resolve_host_timezone` consulted `/etc/timezone` before `timedatectl`. A stale `/etc/timezone` (e.g. `Etc/UTC` left by debconf while `timedatectl` and `/etc/localtime` correctly report `America/Chicago`) won, so the regenerated unit got `--env TZ="Etc/UTC"`.

## Fix

- Reorder `resolve_host_timezone` to `candidate → timedatectl → /etc/localtime → /etc/timezone`, validating each source independently against the zoneinfo database with fall-through (`_valid_iana_tz`). `timedatectl`/`/etc/localtime` reflect the zone the kernel and the process actually use; `/etc/timezone` stays as a last resort so pre-systemd hosts and the Debian 13 no-`/etc/timezone` case (#3351) still resolve.
- Read the unit once via `_read_unit_file`, which falls back to `sudo` when the file exists but is unreadable (`sudo -n` first so unattended/cron updates never hang; interactive `sudo` only with a TTY). Add a running-container `docker inspect` `TZ` fallback so the zone is recovered even when the unit yields nothing.
- Unify the silent-mode `configure_timezone` branch onto the shared resolver and preserve an already-restored zone.
- Warn on the update path when an existing unit is present but no timezone was recovered; log a WARN when the generator falls back to `TZ=UTC`.

An existing user's explicitly configured zone is always preserved (candidate wins). No API, config-schema, or CLI surface changes.

## Tests

Adds 11 regression tests to `scripts/install_test.sh` (105 pass total): the precedence reorder (stale `/etc/timezone` vs correct `timedatectl`), per-source validation, Debian 13 (no `/etc/timezone`), candidate preservation, `timedatectl` `n/a`, the `/etc/localtime` symlink, path-traversal rejection, the container-`TZ` fallback, and silent-mode preservation. `shellcheck -S error install.sh` and `shellcheck -S warning scripts/install_test.sh` are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timezone detection by validating candidate timezones against the IANA database and rejecting empty/invalid/suspicious values.
  * Updated silent-mode timezone configuration to preserve previously restored settings when available; otherwise defaults to UTC.
  * Hardened service updates and reconfiguration to preserve port, TLS, metrics, and timezone when possible, with warnings if timezone can’t be reliably recovered.
  * Improved systemd unit backup/restore behavior for setups where unit files require elevated permissions to read.
* **Tests**
  * Added extensive timezone-resolution test coverage using hermetic fixtures and scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->