### PR TITLE
fix(install): report which step a cross-host migration failed at

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1931,15 +1931,24 @@ open_ssh_master() {
 # only then fail the transfer and lean on best-effort rollback. Failing here
 # costs the user nothing.
 check_remote_shell_clean() {
-    local noise
-    # The trailing X is load-bearing: command substitution strips trailing
-    # newlines, so a .bashrc whose only output is a blank line would look
-    # identical to silence -- and a lone newline corrupts the transfer just as
-    # thoroughly as a banner does. Only stdout is probed: stderr does not ride
-    # the payload stream, so treating a stderr banner as noise would refuse
-    # hosts that migrate perfectly well.
-    noise="$(migrate_ssh 'exit 0' 2>/dev/null; printf X)"
-    noise="${noise%X}"
+    local probe rc noise
+    # Two facts have to survive the round trip, and each needs its own trick.
+    # The X sentinel keeps newline-only output visible: command substitution
+    # strips trailing newlines, so a .bashrc printing a blank line would look
+    # exactly like silence, and a lone newline corrupts the transfer as
+    # thoroughly as a banner. The trailing status is carried in the output
+    # because the substitution's own status belongs to printf, not to ssh, so a
+    # dropped connection would otherwise also read as silence and be reported
+    # later as some unrelated step failing.
+    # Only stdout is probed: stderr does not ride the payload stream, so
+    # treating a stderr banner as noise would refuse hosts that migrate fine.
+    probe="$(migrate_ssh 'exit 0' 2>/dev/null; printf 'X%s' "$?")"
+    rc="${probe##*X}"
+    noise="${probe%X*}"
+    if [ "$rc" != "0" ]; then
+        print_message "❌ Lost the SSH connection to $MIGRATE_DEST while checking it." "$RED"
+        migrate_fail remote_probe_failed error "ssh_exit=$rc"; return 1
+    fi
     [ -z "$noise" ] && return 0
     print_message "❌ The shell on $MIGRATE_DEST prints text on login (a banner, fortune, or echo)." "$RED"
     print_message "   That output corrupts the file transfer, so migration cannot proceed." "$YELLOW"
@@ -2014,7 +2023,15 @@ check_remote_stopped() {
         *) MIGRATE_REMOTE_STATE="unknown"; return 1 ;;  # empty/unrecognized -> no answer
     esac
     local ctr raw
-    if ! raw="$(migrate_ssh 'if command -v docker >/dev/null 2>&1; then docker ps --filter name=birdnet-go --format "{{.Names}}" 2>/dev/null || true; fi')"; then
+    # No `|| true` here, unlike the systemctl probe above: `docker ps` exits
+    # non-zero only when it could not answer (daemon down, user not in the docker
+    # group), and swallowing that would turn "could not check" into empty output
+    # and then into "confirmed stopped" -- a fail-OPEN hole in a fail-closed
+    # probe, ending in a live database being copied. Docker being absent still
+    # exits 0 via the enclosing `if`, which is correct: no docker, no container.
+    # (The systemctl probe genuinely needs its `|| true`: `is-active` exits
+    # non-zero to *answer* "inactive", which is not a failure.)
+    if ! raw="$(migrate_ssh 'if command -v docker >/dev/null 2>&1; then docker ps --filter name=birdnet-go --format "{{.Names}}" 2>/dev/null; fi')"; then
         MIGRATE_REMOTE_STATE="unknown"; return 1
     fi
     ctr="$(printf '%s' "$raw" | grep -Fx 'birdnet-go' | tr -d '[:space:]')"
@@ -2312,12 +2329,16 @@ migrate_from_remote_host() {
         print_message "❓ Stop it now over SSH (sudo)? (y/n): " "$YELLOW" "nonewline"
         local s; read -r s
         if [[ "$s" =~ ^[Yy]$ ]]; then
+            # Arm the rollback restart BEFORE the stop, not after confirming it.
+            # If the stop lands but the verification round trip then drops, a flag
+            # set only on the confirmed path stays "0" and rollback walks away
+            # leaving the user's source service down. Starting a service that was
+            # never stopped is a no-op, so arming early only ever costs nothing.
+            MIGRATE_STOPPED_REMOTE="1"
             ssh -t -o ControlPath="$MIGRATE_SSH_SOCKET" "$MIGRATE_DEST" 'sudo systemctl stop birdnet-go.service' || true
             # Trust the observed state, not ssh's exit code: ssh -t can report
-            # failure even when the remote command stopped the service. If it is now
-            # stopped, this run stopped it, so rollback must be able to restart it.
+            # failure even when the remote command stopped the service.
             if check_remote_stopped; then
-                MIGRATE_STOPPED_REMOTE="1"
                 MIGRATE_STOPPED_REMOTE_EVER="yes"
             else
                 print_message "❌ Still running; stop it manually and re-run" "$RED"; migrate_rollback

--- a/install.sh
+++ b/install.sh
@@ -2344,6 +2344,11 @@ migrate_from_remote_host() {
             if check_remote_stopped; then
                 MIGRATE_STOPPED_REMOTE_EVER="yes"
             else
+                # Disarm only when the probe CONFIRMED it is still running: we
+                # stopped nothing, so an `ssh -t sudo systemctl start` would buy
+                # nothing and can sit on a sudo prompt. Stay armed when the probe
+                # could not tell, because then the stop may well have landed.
+                [ "$MIGRATE_REMOTE_STATE" = "running" ] && MIGRATE_STOPPED_REMOTE="0"
                 print_message "❌ Still running; stop it manually and re-run" "$RED"; migrate_rollback
                 migrate_fail remote_still_running error "state=$MIGRATE_REMOTE_STATE"; return 1
             fi

--- a/install.sh
+++ b/install.sh
@@ -2153,9 +2153,12 @@ migrate_rollback() {
 # Without this, one stray quote makes the payload invalid JSON and
 # validate_diagnostic_json discards EVERY diagnostic for the event.
 #
-# ${1:0:N} rather than `head -c N`: parameter expansion counts characters in a
-# UTF-8 locale, so it cannot leave a half-written character at the cut, and it
-# costs no extra process.
+# ${1:0:N} rather than `head -c N`, for one fewer process and a better cut:
+# parameter expansion counts CHARACTERS under a UTF-8 locale, so it cannot leave
+# half a character behind. That is not a guarantee, and the script does not force
+# a locale: under LC_ALL=C it counts bytes and can split one, exactly as head -c
+# did. Never worse, better where the locale is UTF-8, and moot today since every
+# value reaching here (exit codes, fixed slugs, `ssh -V`) is ASCII.
 json_escape() {
     printf '%s' "${1:0:MAX_ERROR_LENGTH}" \
         | LC_ALL=C tr '\n\r\t' '   ' \

--- a/install.sh
+++ b/install.sh
@@ -39,6 +39,34 @@ MIGRATE_TMP_UNIT=""
 MIGRATE_BACKUP=""
 MIGRATE_STOPPED_REMOTE="0"
 
+# Why a migration stopped. Every abort path records one of these so the single
+# telemetry event at the call site can name the failing step instead of reporting
+# a bare "migration failed". See migrate_fail.
+MIGRATE_FAIL_STEP=""      # fixed-vocabulary slug, e.g. ssh_connect
+MIGRATE_FAIL_KIND=""      # error (something broke) | cancelled (user said no)
+MIGRATE_FAIL_DETAIL=""    # short extra detail; never a host, user, or path
+# How the destination was supplied, and which transfer path ran. Reported as
+# telemetry; both are enums, never the destination itself.
+MIGRATE_DEST_SOURCE="unset"  # unset | flag | prompt
+MIGRATE_TRANSFER_METHOD="none"  # none | rsync | tar
+MIGRATE_REMOTE_APP_DEFAULT="unknown"  # yes | no | unknown: default path or user-supplied
+# Report-only records of things that HAPPENED. migrate_rollback undoes the live
+# state (it clears MIGRATE_BACKUP and restarts the source), and it runs BEFORE
+# the failure is reported, so the reporter cannot infer either fact from the live
+# variables: it would say "no backup" on every rollback path, including the one
+# where the restore failed and the user's data is still sitting at the .bak path.
+MIGRATE_BACKUP_TAKEN="no"
+MIGRATE_STOPPED_REMOTE_EVER="no"
+# Why the last check_remote_stopped probe said "not confirmed stopped". The probe
+# fails CLOSED, so "could not tell" and "definitely running" take the same branch;
+# behaviour must not change, but the telemetry must not claim the service was
+# running when the truth is that we never got an answer.
+MIGRATE_REMOTE_STATE="unknown"  # stopped | running | unknown
+# Sizes captured by check_remote_disk while the SSH connection is still up, so
+# the diagnostics collector can report them without a second round trip.
+MIGRATE_REMOTE_SIZE_KB=""
+MIGRATE_HOME_AVAIL_KB=""
+
 # Flag to track if Docker image was changed during update/rollback
 IMAGE_CHANGED="false"
 
@@ -1799,6 +1827,21 @@ rewrite_migrated_config_paths() {
 # Cross-host migration: pull an existing install from another host over SSH.
 # ---------------------------------------------------------------------------
 
+# Record why a migration stopped, then return 1 so abort paths read as
+# `migrate_fail <slug>; return 1`. Slugs come from a fixed vocabulary and are
+# never built from user input: Sentry groups on them, and the destination and
+# remote paths are user data that must not leave the machine.
+#
+# Only terminal aborts call this. A helper whose `return 1` is a normal branch
+# (check_remote_stopped probing whether the source is live) must not, or it would
+# record a failure the caller goes on to handle.
+migrate_fail() {
+    MIGRATE_FAIL_STEP="$1"
+    MIGRATE_FAIL_KIND="${2:-error}"
+    MIGRATE_FAIL_DETAIL="${3:-}"
+    return 1
+}
+
 # Validate a user-supplied ssh destination (alias or user@host). Rejects empty
 # input and anything with whitespace or shell-unsafe characters so it is safe to
 # splice into ssh/rsync command lines. Echoes the validated destination.
@@ -1850,55 +1893,94 @@ open_ssh_master() {
     # A real temp DIR (not mktemp -u, which only reserves a name and races) holds
     # the control socket and is removed wholesale by the cleanup trap.
     MIGRATE_SSH_DIR="$(mktemp -d "${TMPDIR:-/tmp}/bng-mig-ssh.XXXXXX")" || {
-        print_message "❌ Could not create a temporary directory" "$RED"; return 1; }
+        print_message "❌ Could not create a temporary directory" "$RED"
+        migrate_fail tmpdir_failed; return 1; }
     MIGRATE_SSH_SOCKET="$MIGRATE_SSH_DIR/s"
     # rsync's -e value is word-split and does not honor quotes, so a socket path
     # containing whitespace would break the transfer; reject it up front.
     case "$MIGRATE_SSH_SOCKET" in
-        *[[:space:]]*) print_message "❌ Temp path contains spaces; set TMPDIR to a space-free path" "$RED"; return 1 ;;
+        *[[:space:]]*)
+            print_message "❌ Temp path contains spaces; set TMPDIR to a space-free path" "$RED"
+            migrate_fail tmpdir_spaces; return 1 ;;
     esac
     local opts=(-o ControlMaster=auto -o ControlPersist=300 -o ControlPath="$MIGRATE_SSH_SOCKET")
     if [ "$SILENT_MODE" = "true" ]; then
         opts+=(-o BatchMode=yes -o StrictHostKeyChecking=accept-new)
     fi
-    if ! ssh "${opts[@]}" "$MIGRATE_DEST" true; then
+    # Capture ssh's status via `|| rc=$?`: inside `if ! ssh ...` the `!` has
+    # already flipped $? to 0, so the real exit code would be lost.
+    local rc=0
+    ssh "${opts[@]}" "$MIGRATE_DEST" true || rc=$?
+    if [ "$rc" -ne 0 ]; then
         print_message "❌ Could not connect to $MIGRATE_DEST over SSH" "$RED"
-        return 1
+        migrate_fail ssh_connect error "ssh_exit=$rc"; return 1
     fi
+}
+
+# Refuse a remote whose shell prints anything on a non-interactive login.
+#
+# rsync and tar both stream their payload over that same shell, so ANY stray byte
+# corrupts the transfer (rsync says "protocol version mismatch -- is your shell
+# clean?"; tar says "This does not look like a tar archive"). No amount of
+# filtering fixes a binary stream, so such a host simply cannot be migrated until
+# its .bashrc is quiet.
+#
+# This runs before the destructive steps on purpose. Without it the readers'
+# tail -n 1 guards let a noisy host get FURTHER: past the pre-flight checks, past
+# moving the user's existing data aside, past stopping the source service, and
+# only then fail the transfer and lean on best-effort rollback. Failing here
+# costs the user nothing.
+check_remote_shell_clean() {
+    local noise
+    noise="$(migrate_ssh 'exit 0' 2>/dev/null)"
+    [ -z "$noise" ] && return 0
+    print_message "❌ The shell on $MIGRATE_DEST prints text on login (a banner, fortune, or echo)." "$RED"
+    print_message "   That output corrupts the file transfer, so migration cannot proceed." "$YELLOW"
+    print_message "   Fix: make ~/.bashrc on the old host print nothing for non-interactive" "$YELLOW"
+    print_message "   sessions, then re-run.$(migrate_rerun_hint)" "$YELLOW"
+    migrate_fail remote_shell_noisy; return 1
 }
 
 # Resolve the old host's home and app dir; verify a real install is present.
 resolve_remote_app() {
     # Single quotes are intentional: $HOME must expand on the REMOTE host, not here.
+    # tail -n 1 drops any login banner a remote .bashrc echoed ahead of the value,
+    # which would otherwise be spliced into the path and hidden behind a
+    # misleading "no install found". check_remote_shell_clean already rejects such
+    # a host outright; this is defence in depth for noise it cannot provoke (a
+    # .bashrc that only prints for some commands), and mirrors the same guard on
+    # the reader in check_remote_stopped.
     # shellcheck disable=SC2016
-    MIGRATE_REMOTE_HOME="$(migrate_ssh 'printf %s "$HOME"')"
+    MIGRATE_REMOTE_HOME="$(migrate_ssh 'printf %s "$HOME"' | tail -n 1)"
     if [ -z "$MIGRATE_REMOTE_HOME" ] || ! remote_path_safe "$MIGRATE_REMOTE_HOME"; then
         print_message "❌ Could not determine a usable remote home directory" "$RED"
-        return 1
+        migrate_fail remote_home_unresolved; return 1
     fi
     local candidate
     candidate="$(remote_default_app_path "$MIGRATE_REMOTE_HOME")"
     if migrate_ssh "test -f '$candidate/config/config.yaml'"; then
         MIGRATE_REMOTE_APP="$candidate"
+        MIGRATE_REMOTE_APP_DEFAULT="yes"
         return 0
     fi
     if [ "$SILENT_MODE" = "true" ]; then
         print_message "❌ No install found at $candidate on the remote host" "$RED"
         print_message "   If it lives under /root, run the root->user migration on the OLD host first." "$YELLOW"
-        return 1
+        migrate_fail remote_app_not_found; return 1
     fi
     print_message "❓ No install at $candidate. Enter the remote birdnet-go-app path: " "$YELLOW" "nonewline"
     local p; read -r p
     if [ -n "$p" ] && ! remote_path_safe "$p"; then
         print_message "❌ Path contains an unsupported character (single quote)" "$RED"
-        return 1
+        migrate_fail remote_path_unsafe; return 1
     fi
     if [ -n "$p" ] && migrate_ssh "test -f '$p/config/config.yaml'"; then
         MIGRATE_REMOTE_APP="$p"
+        MIGRATE_REMOTE_APP_DEFAULT="no"
         return 0
     fi
     print_message "❌ No valid install at that path (need config/config.yaml readable by $MIGRATE_DEST)" "$RED"
-    return 1
+    migrate_fail remote_app_invalid; return 1
 }
 
 # 0 = confirmed stopped, 1 = running or NOT confirmed stopped. Fails CLOSED: a
@@ -1908,17 +1990,31 @@ resolve_remote_app() {
 # check decides); tail -n 1 drops login banners; grep -Fx matches only the exact
 # container name so shell noise cannot look like a running container.
 check_remote_stopped() {
+    # MIGRATE_REMOTE_STATE records WHY, for telemetry only; every "not confirmed
+    # stopped" outcome still returns 1 and the caller still treats them alike.
+    # Without it the reported slug claims the service was running even when the
+    # truth is that the probe never got an answer (dropped ssh, or systemctl
+    # present with no bus, as in a container or chroot) -- the same conflation of
+    # distinct causes this file's migration telemetry exists to eliminate.
     local state
-    state="$(migrate_ssh 'if command -v systemctl >/dev/null 2>&1; then systemctl is-active birdnet-go.service 2>/dev/null || true; else echo inactive; fi')" || return 1
+    if ! state="$(migrate_ssh 'if command -v systemctl >/dev/null 2>&1; then systemctl is-active birdnet-go.service 2>/dev/null || true; else echo inactive; fi')"; then
+        MIGRATE_REMOTE_STATE="unknown"; return 1
+    fi
     state="$(printf '%s' "$state" | tail -n 1 | tr -d '[:space:]')"
     case "$state" in
         inactive|failed|unknown) ;;   # systemd definitively not running; verify container
-        *) return 1 ;;                 # active/empty/unrecognized -> not confirmed stopped
+        active) MIGRATE_REMOTE_STATE="running"; return 1 ;;
+        *) MIGRATE_REMOTE_STATE="unknown"; return 1 ;;  # empty/unrecognized -> no answer
     esac
     local ctr raw
-    raw="$(migrate_ssh 'if command -v docker >/dev/null 2>&1; then docker ps --filter name=birdnet-go --format "{{.Names}}" 2>/dev/null || true; fi')" || return 1
+    if ! raw="$(migrate_ssh 'if command -v docker >/dev/null 2>&1; then docker ps --filter name=birdnet-go --format "{{.Names}}" 2>/dev/null || true; fi')"; then
+        MIGRATE_REMOTE_STATE="unknown"; return 1
+    fi
     ctr="$(printf '%s' "$raw" | grep -Fx 'birdnet-go' | tr -d '[:space:]')"
-    [ -n "$ctr" ] && return 1
+    if [ -n "$ctr" ]; then
+        MIGRATE_REMOTE_STATE="running"; return 1
+    fi
+    MIGRATE_REMOTE_STATE="stopped"
     return 0
 }
 
@@ -1927,23 +2023,32 @@ check_remote_stopped() {
 # interactive override) rather than silently skip the check before a large copy.
 check_remote_disk() {
     local remote_kb avail_kb
-    remote_kb="$(migrate_ssh "du -sk '$MIGRATE_REMOTE_APP' 2>/dev/null | cut -f1")"
+    # tail -n 1 runs LOCALLY, on ssh's output. A remote login banner is written by
+    # the remote shell before the pipeline runs, so it never passes through a
+    # remote tail; only a local one drops it. Without this the result is
+    # multi-line and fails the numeric test below as if the size were unreadable.
+    remote_kb="$(migrate_ssh "du -sk '$MIGRATE_REMOTE_APP' 2>/dev/null | cut -f1" | tail -n 1)"
     avail_kb="$(df -Pk "$HOME" | awk 'NR==2 {print $4}')"
+    # Kept for telemetry: sizes are read while the SSH connection is still up.
+    MIGRATE_REMOTE_SIZE_KB="$remote_kb"
+    MIGRATE_HOME_AVAIL_KB="$avail_kb"
     if [[ "$remote_kb" =~ ^[0-9]+$ ]] && [[ "$avail_kb" =~ ^[0-9]+$ ]] && [ "$remote_kb" -gt 0 ]; then
         local need_kb=$(( remote_kb + remote_kb / 10 ))
         if [ "$avail_kb" -lt "$need_kb" ]; then
             print_message "❌ Not enough disk space: need ~$(( need_kb / 1024 )) MB, have $(( avail_kb / 1024 )) MB" "$RED"
-            return 1
+            migrate_fail disk_insufficient error "need_kb=$need_kb,avail_kb=$avail_kb"; return 1
         fi
         return 0
     fi
     print_message "⚠️  Could not verify free disk space for the transfer." "$YELLOW"
     if [ "$SILENT_MODE" = "true" ]; then
-        print_message "❌ Aborting (silent mode); re-run interactively to override" "$RED"; return 1
+        print_message "❌ Aborting (silent mode); re-run interactively to override" "$RED"
+        migrate_fail disk_unverified_silent; return 1
     fi
     print_message "❓ Continue without the disk-space check? (y/n): " "$YELLOW" "nonewline"
     local a; read -r a
-    [[ "$a" =~ ^[Yy]$ ]] || { print_message "Migration cancelled." "$NC"; return 1; }
+    [[ "$a" =~ ^[Yy]$ ]] || { print_message "Migration cancelled." "$NC"
+        migrate_fail disk_unverified_declined cancelled; return 1; }
     return 0
 }
 
@@ -1966,7 +2071,7 @@ adopt_migrated_installation() {
     if [ -f "$db" ]; then
         if ! command_exists sqlite3; then
             print_message "❌ sqlite3 is unavailable; cannot verify database integrity" "$RED"
-            return 1
+            migrate_fail sqlite3_missing; return 1
         fi
         local res
         res="$(sqlite3 "$db" 'PRAGMA integrity_check;' 2>/dev/null)"
@@ -1975,11 +2080,11 @@ adopt_migrated_installation() {
         else
             print_message "❌ Database integrity check failed: ${res:-unreadable}" "$RED"
             if [ "$SILENT_MODE" = "true" ]; then
-                return 1
+                migrate_fail db_integrity_failed; return 1
             fi
             print_message "   Your data on $MIGRATE_DEST is untouched. Adopt anyway? (y/n): " "$YELLOW" "nonewline"
             local a; read -r a
-            [[ "$a" =~ ^[Yy]$ ]] || return 1
+            [[ "$a" =~ ^[Yy]$ ]] || { migrate_fail db_integrity_declined cancelled; return 1; }
         fi
     fi
 
@@ -2017,6 +2122,93 @@ migrate_rollback() {
     fi
 }
 
+# Escape a value for embedding in a JSON string literal. Truncate first, then
+# fold newlines and drop control characters, then escape backslashes BEFORE
+# quotes (the reverse order would double the backslashes we add). Truncating
+# before escaping keeps head -c from cutting an escape sequence in half.
+# Without this, one stray quote makes the payload invalid JSON and
+# validate_diagnostic_json discards EVERY diagnostic for the event.
+json_escape() {
+    printf '%s' "$1" \
+        | head -c "$MAX_ERROR_LENGTH" \
+        | LC_ALL=C tr '\n\r\t' '   ' \
+        | LC_ALL=C tr -d '[:cntrl:]' \
+        | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
+# Structured diagnostics for a migration that stopped. Deliberately carries no
+# hostname, username, or filesystem path: MIGRATE_DEST is a user@host and the
+# app paths embed the account name, so only enums, booleans, exit codes, and
+# sizes are reported. Anything added here must stay non-identifying.
+collect_migration_diagnostics() {
+    local remote_size="unknown" home_avail="unknown"
+    # "unparseable" is a signal, not a shrug: it means the remote size came back
+    # non-numeric, which is the difference between "the disk really is full" and
+    # "we could not tell".
+    if [ -n "$MIGRATE_REMOTE_SIZE_KB" ]; then
+        if [[ "$MIGRATE_REMOTE_SIZE_KB" =~ ^[0-9]+$ ]]; then
+            remote_size="$MIGRATE_REMOTE_SIZE_KB"
+        else
+            remote_size="unparseable"
+        fi
+    fi
+    if [ -n "$MIGRATE_HOME_AVAIL_KB" ]; then
+        if [[ "$MIGRATE_HOME_AVAIL_KB" =~ ^[0-9]+$ ]]; then
+            home_avail="$MIGRATE_HOME_AVAIL_KB"
+        else
+            home_avail="unparseable"
+        fi
+    fi
+
+    local ssh_version rsync_local sqlite3_local
+    ssh_version="$(ssh -V 2>&1 | head -1)"
+    command_exists rsync && rsync_local="yes" || rsync_local="no"
+    command_exists sqlite3 && sqlite3_local="yes" || sqlite3_local="no"
+
+    # backup_taken and stopped_remote_this_run read the report-only records, NOT
+    # MIGRATE_BACKUP / MIGRATE_STOPPED_REMOTE: migrate_rollback clears both before
+    # the failure is reported, so the live values would say "no" every time.
+    cat <<EOF
+{
+    "fail_step": "$(json_escape "${MIGRATE_FAIL_STEP:-unknown}")",
+    "fail_kind": "$(json_escape "${MIGRATE_FAIL_KIND:-error}")",
+    "detail": "$(json_escape "$MIGRATE_FAIL_DETAIL")",
+    "silent_mode": "$SILENT_MODE",
+    "dest_source": "$MIGRATE_DEST_SOURCE",
+    "remote_app_resolved": "$([ -n "$MIGRATE_REMOTE_APP" ] && echo yes || echo no)",
+    "remote_app_is_default_path": "$MIGRATE_REMOTE_APP_DEFAULT",
+    "remote_state": "$MIGRATE_REMOTE_STATE",
+    "transfer_method": "$MIGRATE_TRANSFER_METHOD",
+    "rsync_local": "$rsync_local",
+    "sqlite3_local": "$sqlite3_local",
+    "ssh_version": "$(json_escape "$ssh_version")",
+    "backup_taken": "$MIGRATE_BACKUP_TAKEN",
+    "stopped_remote_this_run": "$MIGRATE_STOPPED_REMOTE_EVER",
+    "remote_size_kb": "$remote_size",
+    "home_avail_kb": "$home_avail"
+}
+EOF
+}
+
+# Report a stopped migration exactly once, naming the step that stopped it.
+# A user declining a prompt is not a fault, so it is reported at info level:
+# grouping deliberate cancellations with real failures inflates the error rate
+# and buries the actionable events. Same convention as the AVX2 prompt.
+# The step is part of the message so Sentry, which has no stack trace to group
+# a shell script by, splits this into one issue per failing step.
+migrate_report_failure() {
+    local step="${MIGRATE_FAIL_STEP:-unknown}"
+    local diag
+    diag="$(collect_migration_diagnostics)"
+    if [ "$MIGRATE_FAIL_KIND" = "cancelled" ]; then
+        send_telemetry_event "info" "Cross-host migration cancelled: $step" "info" \
+            "step=remote_migrate,result=cancelled,reason=$step" "$diag"
+    else
+        send_telemetry_event "error" "Cross-host migration failed: $step" "error" \
+            "step=remote_migrate,result=failure,error=$step" "$diag"
+    fi
+}
+
 # Pull an install from another host over SSH and adopt it. Returns nonzero on any
 # failure (caller aborts the install); on success sets MIGRATION_DONE=true.
 migrate_from_remote_host() {
@@ -2027,13 +2219,18 @@ migrate_from_remote_host() {
     # Resolve the ssh destination (prompt when not supplied on the command line).
     if [ -z "$MIGRATE_DEST" ]; then
         if [ "$SILENT_MODE" = "true" ]; then
-            print_message "❌ --migrate needs --migrate-from <ssh-dest> in silent mode" "$RED"; return 1
+            print_message "❌ --migrate needs --migrate-from <ssh-dest> in silent mode" "$RED"
+            migrate_fail no_dest_silent; return 1
         fi
         print_message "❓ Old host (user@host or ssh alias): " "$YELLOW" "nonewline"
         read -r MIGRATE_DEST
+        MIGRATE_DEST_SOURCE="prompt"
+    else
+        MIGRATE_DEST_SOURCE="flag"
     fi
     if ! MIGRATE_DEST="$(parse_ssh_dest "$MIGRATE_DEST")"; then
-        print_message "❌ Invalid ssh destination" "$RED"; return 1
+        print_message "❌ Invalid ssh destination" "$RED"
+        migrate_fail bad_dest; return 1
     fi
 
     # Migration-only tools, installed here so a normal install/update never pulls
@@ -2045,14 +2242,17 @@ migrate_from_remote_host() {
     if [ ${#mig_pkgs[@]} -gt 0 ]; then
         print_message "🔧 Installing migration tools: ${mig_pkgs[*]}" "$YELLOW"
         if ! sudo apt install -q -y "${mig_pkgs[@]}"; then
-            print_message "❌ Failed to install migration tools (${mig_pkgs[*]})" "$RED"; return 1
+            print_message "❌ Failed to install migration tools (${mig_pkgs[*]})" "$RED"
+            migrate_fail tools_install_failed error "pkgs=${mig_pkgs[*]}"; return 1
         fi
     fi
-    command_exists rsync || { print_message "❌ rsync is required for migration" "$RED"; return 1; }
+    command_exists rsync || { print_message "❌ rsync is required for migration" "$RED"
+        migrate_fail rsync_missing; return 1; }
 
     # Connect and locate the source BEFORE touching any local state, so a mistyped
     # host or a missing remote install never displaces the user's existing data.
     open_ssh_master || return 1
+    check_remote_shell_clean || return 1
     resolve_remote_app || return 1
 
     # Verify capacity and settle the local target BEFORE stopping the source, so
@@ -2065,16 +2265,20 @@ migrate_from_remote_host() {
     if [ -f "$dest_dir/config/config.yaml" ] || [ -f "$dest_dir/data/birdnet.db" ] || \
        { [ -d "$dest_dir/data/clips" ] && [ -n "$(ls -A "$dest_dir/data/clips" 2>/dev/null)" ]; }; then
         if [ "$SILENT_MODE" = "true" ]; then
-            print_message "❌ $dest_dir already contains data; refusing to overwrite in silent mode" "$RED"; return 1
+            print_message "❌ $dest_dir already contains data; refusing to overwrite in silent mode" "$RED"
+            migrate_fail dest_occupied_silent; return 1
         fi
         print_message "⚠️  $dest_dir already contains data on this machine." "$YELLOW"
         print_message "❓ Move it aside to a backup and continue? (y/n): " "$YELLOW" "nonewline"
         local ans; read -r ans
-        [[ "$ans" =~ ^[Yy]$ ]] || { print_message "Migration cancelled; nothing changed." "$NC"; return 1; }
+        [[ "$ans" =~ ^[Yy]$ ]] || { print_message "Migration cancelled; nothing changed." "$NC"
+            migrate_fail dest_occupied_declined cancelled; return 1; }
         MIGRATE_BACKUP="${dest_dir}.bak.$(date +%Y%m%d%H%M%S).$$"
         if ! mv "$dest_dir" "$MIGRATE_BACKUP"; then
-            print_message "❌ Backup move failed" "$RED"; MIGRATE_BACKUP=""; return 1
+            print_message "❌ Backup move failed" "$RED"; MIGRATE_BACKUP=""
+            migrate_fail backup_move_failed; return 1
         fi
+        MIGRATE_BACKUP_TAKEN="yes"
         print_message "📦 Existing data moved to $MIGRATE_BACKUP (nothing deleted)" "$GREEN"
     fi
 
@@ -2084,7 +2288,16 @@ migrate_from_remote_host() {
     if ! check_remote_stopped; then
         print_message "⚠️  BirdNET-Go appears to be running on $MIGRATE_DEST. Copying a live database can corrupt it." "$YELLOW"
         if [ "$SILENT_MODE" = "true" ]; then
-            print_message "❌ Stop birdnet-go on the old host, then re-run" "$RED"; migrate_rollback; return 1
+            print_message "❌ Stop birdnet-go on the old host, then re-run" "$RED"; migrate_rollback
+            # Split the slug on what we actually know: "running" and "could not
+            # tell" need different answers from the reader, and merging them into
+            # one issue is what makes a report unactionable.
+            if [ "$MIGRATE_REMOTE_STATE" = "running" ]; then
+                migrate_fail remote_running_silent
+            else
+                migrate_fail remote_state_unknown_silent
+            fi
+            return 1
         fi
         print_message "❓ Stop it now over SSH (sudo)? (y/n): " "$YELLOW" "nonewline"
         local s; read -r s
@@ -2095,11 +2308,14 @@ migrate_from_remote_host() {
             # stopped, this run stopped it, so rollback must be able to restart it.
             if check_remote_stopped; then
                 MIGRATE_STOPPED_REMOTE="1"
+                MIGRATE_STOPPED_REMOTE_EVER="yes"
             else
-                print_message "❌ Still running; stop it manually and re-run" "$RED"; migrate_rollback; return 1
+                print_message "❌ Still running; stop it manually and re-run" "$RED"; migrate_rollback
+                migrate_fail remote_still_running error "state=$MIGRATE_REMOTE_STATE"; return 1
             fi
         else
-            print_message "❌ Stop birdnet-go on the old host, then re-run" "$RED"; migrate_rollback; return 1
+            print_message "❌ Stop birdnet-go on the old host, then re-run" "$RED"; migrate_rollback
+            migrate_fail remote_stop_declined cancelled; return 1
         fi
     fi
 
@@ -2107,14 +2323,22 @@ migrate_from_remote_host() {
     # ownership is already correct. Any incomplete transfer is fatal and rolls back.
     print_message "📥 Transferring $MIGRATE_REMOTE_APP from $MIGRATE_DEST ..." "$YELLOW"
     if migrate_ssh 'command -v rsync >/dev/null 2>&1'; then
-        if ! rsync -aH --partial --info=progress2 --exclude 'config/hls/' \
+        MIGRATE_TRANSFER_METHOD="rsync"
+        # `|| rc=$?` keeps rsync's real exit code; inside `if ! rsync ...` the `!`
+        # would have already flipped $? to 0. The code names the failure (e.g. 11
+        # = file I/O, 12 = protocol, 23 = partial transfer), so it is worth having.
+        local rc=0
+        rsync -aH --partial --info=progress2 --exclude 'config/hls/' \
                 -e "ssh -o ControlPath=$MIGRATE_SSH_SOCKET" \
-                "$MIGRATE_DEST:$MIGRATE_REMOTE_APP/" "$dest_dir/"; then
+                "$MIGRATE_DEST:$MIGRATE_REMOTE_APP/" "$dest_dir/" || rc=$?
+        if [ "$rc" -ne 0 ]; then
             print_message "❌ rsync failed (incomplete transfer); rolling back" "$RED"
-            migrate_rollback; return 1
+            migrate_rollback
+            migrate_fail rsync_failed error "rsync_exit=$rc"; return 1
         fi
     else
         print_message "ℹ️  rsync not on the remote; using tar over SSH" "$YELLOW"
+        MIGRATE_TRANSFER_METHOD="tar"
         mkdir -p "$dest_dir"
         # Archive the resolved app dir's CONTENTS so a custom remote path still
         # lands in $dest_dir. PIPESTATUS makes the REMOTE tar's exit status
@@ -2124,17 +2348,22 @@ migrate_from_remote_host() {
         local pstat=("${PIPESTATUS[@]}")
         if [ "${pstat[0]}" -ne 0 ] || [ "${pstat[1]}" -ne 0 ]; then
             print_message "❌ tar transfer failed; rolling back" "$RED"
-            migrate_rollback; return 1
+            migrate_rollback
+            migrate_fail tar_failed error "remote_tar=${pstat[0]},local_tar=${pstat[1]}"; return 1
         fi
     fi
 
     if [ ! -f "$dest_dir/config/config.yaml" ]; then
         print_message "❌ Transfer left no config.yaml; rolling back" "$RED"
-        migrate_rollback; return 1
+        migrate_rollback
+        migrate_fail no_config_after_transfer; return 1
     fi
 
+    # adopt_migrated_installation records its own, more specific slug.
     if ! adopt_migrated_installation; then
-        print_message "❌ Adopt step failed; rolling back" "$RED"; migrate_rollback; return 1
+        print_message "❌ Adopt step failed; rolling back" "$RED"; migrate_rollback
+        [ -n "$MIGRATE_FAIL_STEP" ] || migrate_fail adopt_failed
+        return 1
     fi
     print_message "✅ Migration data adopted; continuing with provisioning" "$GREEN"
     log_message "INFO" "Cross-host migration transfer and adopt complete"
@@ -7404,7 +7633,7 @@ pull_docker_image
 if [ "$MIGRATE_MODE" = "true" ]; then
     if ! migrate_from_remote_host; then
         print_message "❌ Migration failed. See messages above." "$RED"
-        send_telemetry_event "error" "Cross-host migration failed" "error" "step=remote_migrate,result=failure"
+        migrate_report_failure
         exit 1
     fi
 fi

--- a/install.sh
+++ b/install.sh
@@ -1932,7 +1932,14 @@ open_ssh_master() {
 # costs the user nothing.
 check_remote_shell_clean() {
     local noise
-    noise="$(migrate_ssh 'exit 0' 2>/dev/null)"
+    # The trailing X is load-bearing: command substitution strips trailing
+    # newlines, so a .bashrc whose only output is a blank line would look
+    # identical to silence -- and a lone newline corrupts the transfer just as
+    # thoroughly as a banner does. Only stdout is probed: stderr does not ride
+    # the payload stream, so treating a stderr banner as noise would refuse
+    # hosts that migrate perfectly well.
+    noise="$(migrate_ssh 'exit 0' 2>/dev/null; printf X)"
+    noise="${noise%X}"
     [ -z "$noise" ] && return 0
     print_message "❌ The shell on $MIGRATE_DEST prints text on login (a banner, fortune, or echo)." "$RED"
     print_message "   That output corrupts the file transfer, so migration cannot proceed." "$YELLOW"
@@ -2125,12 +2132,15 @@ migrate_rollback() {
 # Escape a value for embedding in a JSON string literal. Truncate first, then
 # fold newlines and drop control characters, then escape backslashes BEFORE
 # quotes (the reverse order would double the backslashes we add). Truncating
-# before escaping keeps head -c from cutting an escape sequence in half.
+# before escaping keeps the cut from splitting an escape sequence in half.
 # Without this, one stray quote makes the payload invalid JSON and
 # validate_diagnostic_json discards EVERY diagnostic for the event.
+#
+# ${1:0:N} rather than `head -c N`: parameter expansion counts characters in a
+# UTF-8 locale, so it cannot leave a half-written character at the cut, and it
+# costs no extra process.
 json_escape() {
-    printf '%s' "$1" \
-        | head -c "$MAX_ERROR_LENGTH" \
+    printf '%s' "${1:0:MAX_ERROR_LENGTH}" \
         | LC_ALL=C tr '\n\r\t' '   ' \
         | LC_ALL=C tr -d '[:cntrl:]' \
         | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -882,15 +882,24 @@ escaped_long="$(json_escape "$long_backslashes")"
 printf '{"v":"%s"}' "$escaped_long" | jq empty 2>/dev/null
 assert_ok "json_escape: truncated backslash run stays valid JSON" $?
 
-# Truncation counts characters, not bytes, so a cut can never leave half a
-# multi-byte character behind. jq tolerates a severed one (it substitutes
-# U+FFFD) so this would not fail loudly; it would just ship a mangled byte.
-# The padding is exact and load-bearing: the multi-byte character has to STRADDLE
-# the cut. A fixture with it anywhere else is never severed and the assertion
-# passes under byte truncation too, proving nothing.
+# Under a UTF-8 locale the cut counts characters, so it cannot leave half a
+# multi-byte character behind. jq tolerates a severed one (it substitutes U+FFFD)
+# so this would never fail loudly; it would just ship a mangled byte.
+#
+# Two things here are load-bearing. The padding is exact, so the character
+# STRADDLES the cut: with it anywhere else it is never severed and the assertion
+# passes under byte truncation too, proving nothing. And the locale is set
+# explicitly, because bash's ${x:0:n} is locale-dependent: inheriting the
+# runner's locale would make this pass on a UTF-8 CI box by luck and fail for
+# anyone running the suite under LC_ALL=C.
 multibyte_astride="$(printf '%*s' $((MAX_ERROR_LENGTH - 1)) '' | tr ' ' 'x')$(printf '\xc3\xa9')trailing"
-assert_eq "json_escape: a multi-byte character astride the cut survives intact" \
-    "c3a9" "$(json_escape "$multibyte_astride" | tail -c 2 | od -An -tx1 | tr -d ' \n')"
+assert_eq "json_escape: a multi-byte character astride the cut survives intact (UTF-8 locale)" \
+    "c3a9" "$(LC_ALL=C.UTF-8 json_escape "$multibyte_astride" | tail -c 2 | od -An -tx1 | tr -d ' \n')"
+# The invariant that holds in EVERY locale is the one that actually matters: the
+# payload stays valid JSON either way. Under LC_ALL=C the cut is byte-wise, just
+# as it was with head -c, and must still not emit a dangling escape.
+printf '{"v":"%s"}' "$(LC_ALL=C json_escape "$multibyte_astride")" | jq empty 2>/dev/null
+assert_ok "json_escape: stays valid JSON even where the cut is byte-wise (C locale)" $?
 
 # --- migrate_fail ---------------------------------------------------------
 reset_migration_state

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -1080,6 +1080,19 @@ check_remote_shell_clean
 assert_ok "noisy shell: a stderr-only banner is NOT treated as noise" $?
 assert_eq "noisy shell: stderr banner records no failure" "" "$MIGRATE_FAIL_STEP"
 
+# A dead connection produces no stdout, which is indistinguishable from a clean
+# shell unless the probe carries its own exit status back. Reporting "clean"
+# here would blame whatever step failed next for an SSH drop.
+reset_migration_state
+MIGRATE_DEST="host"
+migrate_ssh() { return 255; }
+check_remote_shell_clean
+assert_nonzero "noisy shell: a dropped connection is not mistaken for silence" $?
+assert_eq "noisy shell: a dropped probe records its own slug" \
+    "remote_probe_failed" "$MIGRATE_FAIL_STEP"
+assert_eq "noisy shell: a dropped probe records ssh's exit code" \
+    "ssh_exit=255" "$MIGRATE_FAIL_DETAIL"
+
 migrate_ssh() { :; }
 reset_migration_state
 MIGRATE_DEST="host"
@@ -1177,6 +1190,17 @@ check_remote_stopped
 assert_nonzero "probe: a dropped ssh on the docker check is not confirmed stopped" $?
 assert_eq "probe: dropped ssh on the docker check is 'unknown'" "unknown" "$MIGRATE_REMOTE_STATE"
 
+# `docker ps` exits non-zero only when it could not answer (daemon down, user
+# not in the docker group). Swallowing that with `|| true` on the remote turns
+# "could not check" into empty output and then into "confirmed stopped", and the
+# transfer copies a live database. The remote command must carry the failure.
+assert_eq "probe: the docker check does not swallow its own failure with '|| true'" "0" \
+    "$(grep -c 'docker ps --filter name=birdnet-go --format "{{.Names}}" 2>/dev/null || true' "$INSTALL_SH")"
+# ...while the systemctl probe MUST keep its `|| true`: is-active exits non-zero
+# to answer "inactive", which is a normal answer, not a failure.
+assert_eq "probe: the systemctl check keeps its '|| true' (non-zero is an answer)" "1" \
+    "$(grep -c 'systemctl is-active birdnet-go.service 2>/dev/null || true' "$INSTALL_SH")"
+
 # grep -Fx matches the WHOLE line: a container merely named like ours (or shell
 # noise containing the name) must not count as our container running.
 reset_migration_state
@@ -1249,6 +1273,14 @@ assert_eq "records: backup_taken is set after the mv succeeds, not before" "1" \
     "$(grep -cE '^        MIGRATE_BACKUP_TAKEN="yes"$' "$INSTALL_SH")"
 assert_eq "records: stopped_remote_ever is set where the source is stopped" "1" \
     "$(grep -cE '^                MIGRATE_STOPPED_REMOTE_EVER="yes"$' "$INSTALL_SH")"
+
+# The rollback restart flag must be armed BEFORE the stop is issued. Armed only
+# after a confirmed stop, a dropped verification round trip leaves the flag at
+# "0" and rollback walks away with the user's source service still down.
+arm_line="$(grep -n '^            MIGRATE_STOPPED_REMOTE="1"$' "$INSTALL_SH" | head -1 | cut -d: -f1)"
+issue_line="$(grep -n "ControlPath=\"\$MIGRATE_SSH_SOCKET\".*systemctl stop birdnet-go.service" "$INSTALL_SH" | head -1 | cut -d: -f1)"
+[ -n "$arm_line" ] && [ -n "$issue_line" ] && [ "$arm_line" -lt "$issue_line" ]
+assert_ok "records: the rollback restart flag is armed BEFORE the stop is issued" $?
 
 reset_migration_state
 MIGRATE_BACKUP_TAKEN="yes"; MIGRATE_STOPPED_REMOTE_EVER="yes"

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -1279,8 +1279,9 @@ assert_eq "records: stopped_remote_ever is set where the source is stopped" "1" 
 # "0" and rollback walks away with the user's source service still down.
 arm_line="$(grep -n '^            MIGRATE_STOPPED_REMOTE="1"$' "$INSTALL_SH" | head -1 | cut -d: -f1)"
 issue_line="$(grep -n "ControlPath=\"\$MIGRATE_SSH_SOCKET\".*systemctl stop birdnet-go.service" "$INSTALL_SH" | head -1 | cut -d: -f1)"
-[ -n "$arm_line" ] && [ -n "$issue_line" ] && [ "$arm_line" -lt "$issue_line" ]
-assert_ok "records: the rollback restart flag is armed BEFORE the stop is issued" $?
+arm_rc=0
+{ [ -n "$arm_line" ] && [ -n "$issue_line" ] && [ "$arm_line" -lt "$issue_line" ]; } || arm_rc=1
+assert_ok "records: the rollback restart flag is armed BEFORE the stop is issued" "$arm_rc"
 
 reset_migration_state
 MIGRATE_BACKUP_TAKEN="yes"; MIGRATE_STOPPED_REMOTE_EVER="yes"

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -10,7 +10,9 @@
 # the real config template, asserting both the intended change and that sibling keys are left
 # untouched.
 #
-# Run: scripts/install_test.sh   (exit 0 = all pass). No external dependencies beyond awk/sed.
+# Run: scripts/install_test.sh   (exit 0 = all pass). Needs awk/sed, plus jq for the
+# migration-diagnostics tests (they assert the telemetry payload is valid JSON, and
+# install.sh already requires jq to send any telemetry at all).
 
 # Many globals here (colors, CONFIG_FILE, SILENT_MODE, the load_existing_service_config output
 # vars, BIRDNET_AUDIO_FORMAT) are consumed only inside the eval'd functions extracted from
@@ -29,6 +31,12 @@ if [ ! -f "$INSTALL_SH" ]; then
 fi
 if [ ! -f "$CONFIG_TEMPLATE" ]; then
     echo "FATAL: config template not found at $CONFIG_TEMPLATE" >&2
+    exit 2
+fi
+# The migration-diagnostics tests validate JSON with jq. Fail loudly here rather
+# than as nine cryptic assertion failures on a machine without it.
+if ! command -v jq >/dev/null 2>&1; then
+    echo "FATAL: jq not found; required by the migration diagnostics tests" >&2
     exit 2
 fi
 
@@ -68,22 +76,56 @@ assert_nonzero() { # description rc
 # Extract a single top-level function (name() { ... } closing at column 0) from
 # install.sh and define it in this shell. install.sh formats every top-level
 # function close as a bare "}" at column 0; inner braces are indented, so the
-# first "^}$" after the header is the function's own close. (A here-doc emitting a
-# column-0 "}" would break this assumption; none of the loaded functions do today.)
+# first "^}$" after the header is the function's own close.
+#
+# Here-docs are tracked and skipped: the diagnostics collectors emit JSON whose
+# closing "}" sits at column 0 inside a here-doc body, which would otherwise be
+# mistaken for the function's own close and yield a truncated, unparseable body.
 # ---------------------------------------------------------------------------
 load_fn() {
     local fn="$1"
     local body
     body="$(awk -v fn="$fn" '
+        # Remember the delimiter of any here-doc opened on this line so its body
+        # (which may contain a column-0 "}") is passed through verbatim.
+        # Excludes here-strings (<<<), whose word is not a delimiter, and accepts
+        # either quote style: a missed <<'"'"'EOF'"'"' truncates the body, and a
+        # here-string mistaken for an opener swallows the rest of the file.
+        function heredoc_delim(line,   d) {
+            if (line ~ /<<</) return ""
+            if (!match(line, /<<-?[ \t]*["'"'"']?[A-Za-z_][A-Za-z_0-9]*["'"'"']?/)) return ""
+            d = substr(line, RSTART, RLENGTH)
+            sub(/^<<-?[ \t]*/, "", d)
+            gsub(/["'"'"']/, "", d)
+            return d
+        }
+        function trim(s) { sub(/^[ \t]+/, "", s); return s }
+
         $0 ~ "^"fn"\\(\\) \\{" { printing = 1 }
-        printing { print }
-        printing && /^\}$/ { exit }
+        !printing { next }
+        { print }
+        heredoc != "" { if (trim($0) == heredoc) heredoc = ""; next }
+        # A comment mentioning a here-doc is prose, not an opener.
+        trim($0) ~ /^#/ { next }
+        { d = heredoc_delim($0); if (d != "") { heredoc = d; next } }
+        /^\}$/ { exit }
     ' "$INSTALL_SH")"
     if [ -z "$body" ]; then
         echo "FATAL: could not extract function '$fn' from install.sh" >&2
         exit 2
     fi
-    eval "$body"
+    # A runaway extraction (an opener we misread) yields a body that does not end
+    # at the function close. Without this it still eval's -- sometimes cleanly,
+    # redefining a dozen other functions -- and the suite goes green while testing
+    # something else entirely.
+    if [ "$(printf '%s' "$body" | tail -n 1)" != "}" ]; then
+        echo "FATAL: extraction of '$fn' did not end at a column-0 '}'; check load_fn's here-doc tracking" >&2
+        exit 2
+    fi
+    if ! eval "$body"; then
+        echo "FATAL: extracted body of '$fn' failed to eval" >&2
+        exit 2
+    fi
 }
 
 # Stubs for the side-effecting helpers the extracted functions call.
@@ -779,6 +821,366 @@ command_exists() { command -v "$1" >/dev/null 2>&1; }
 unset -f timedatectl
 SILENT_MODE=""
 unset BNG_TZ_ZONEINFO_DIR
+
+# ===========================================================================
+# Cross-host migration failure reporting
+#
+# A migration abort used to emit one opaque telemetry event ("Cross-host
+# migration failed", empty diagnostics) for ~26 distinct failure paths, which
+# made the resulting Sentry issue unactionable. These tests pin the three
+# properties that fix depends on: the failing step is recorded, the payload is
+# valid JSON (an invalid one is silently replaced by a fallback, losing every
+# diagnostic), and the payload carries no user identity.
+# ===========================================================================
+it "migration failure reporting"
+
+# Derived from install.sh rather than duplicated: a test asserting truncation
+# against its own copy of the limit would keep passing if the real one changed.
+MAX_ERROR_LENGTH="$(awk -F= '/^MAX_ERROR_LENGTH=/{print $2; exit}' "$INSTALL_SH")"
+[ -n "$MAX_ERROR_LENGTH" ] || { echo "FATAL: could not read MAX_ERROR_LENGTH from install.sh" >&2; exit 2; }
+for fn in json_escape migrate_fail collect_migration_diagnostics migrate_report_failure \
+          remote_path_safe remote_default_app_path migrate_rerun_hint \
+          resolve_remote_app check_remote_disk; do
+    load_fn "$fn"
+done
+
+reset_migration_state() {
+    MIGRATE_FAIL_STEP=""; MIGRATE_FAIL_KIND=""; MIGRATE_FAIL_DETAIL=""
+    MIGRATE_DEST=""; MIGRATE_DEST_SOURCE="unset"; MIGRATE_REMOTE_HOME=""; MIGRATE_REMOTE_APP=""
+    MIGRATE_REMOTE_APP_DEFAULT="unknown"; MIGRATE_TRANSFER_METHOD="none"
+    MIGRATE_BACKUP=""; MIGRATE_STOPPED_REMOTE="0"
+    MIGRATE_BACKUP_TAKEN="no"; MIGRATE_STOPPED_REMOTE_EVER="no"
+    MIGRATE_REMOTE_STATE="unknown"
+    MIGRATE_REMOTE_SIZE_KB=""; MIGRATE_HOME_AVAIL_KB=""
+    MIGRATE_MODE="true"   # read by migrate_rerun_hint from the abort messages
+    SILENT_MODE="false"
+}
+reset_migration_state
+
+# --- json_escape ----------------------------------------------------------
+# Every escaped value is interpolated into a JSON string literal; one stray
+# quote or backslash invalidates the whole payload.
+assert_eq "json_escape: quotes escaped" '\"x\"' "$(json_escape '"x"')"
+# The '\\' below is a single-quoted pair of literal backslashes: JSON's escaped
+# form of one backslash, which is exactly what is being asserted. shellcheck
+# reads it as a botched attempt to escape a single quote.
+# shellcheck disable=SC1003
+assert_eq "json_escape: backslash escaped once, not doubled" '\\' "$(json_escape '\')"
+assert_eq "json_escape: backslash-quote pair" '\\\"' "$(json_escape '\"')"
+assert_eq "json_escape: newlines folded to spaces" 'a b' "$(json_escape 'a
+b')"
+assert_eq "json_escape: empty stays empty" '' "$(json_escape '')"
+# Truncation happens before escaping, so a cut can never land mid-escape and
+# leave a dangling backslash. The leading 'x' is load-bearing: a pure backslash
+# run truncated at an even MAX_ERROR_LENGTH stays valid under BOTH orderings, so
+# without it this assertion passes even when the order is reversed and proves
+# nothing. The odd offset is what forces a cut mid-escape.
+# '\\' is how a literal backslash is written for tr, not a quote-escape attempt.
+# shellcheck disable=SC1003
+long_backslashes="x$(printf '%*s' 600 '' | tr ' ' '\\')"
+escaped_long="$(json_escape "$long_backslashes")"
+printf '{"v":"%s"}' "$escaped_long" | jq empty 2>/dev/null
+assert_ok "json_escape: truncated backslash run stays valid JSON" $?
+
+# --- migrate_fail ---------------------------------------------------------
+reset_migration_state
+migrate_fail ssh_connect error "ssh_exit=255"
+assert_nonzero "migrate_fail returns non-zero so callers can 'migrate_fail x; return 1'" $?
+assert_eq "migrate_fail records step"   "ssh_connect"  "$MIGRATE_FAIL_STEP"
+assert_eq "migrate_fail records kind"   "error"        "$MIGRATE_FAIL_KIND"
+assert_eq "migrate_fail records detail" "ssh_exit=255" "$MIGRATE_FAIL_DETAIL"
+migrate_fail dest_occupied_declined cancelled
+assert_eq "migrate_fail defaults detail to empty (no stale detail)" "" "$MIGRATE_FAIL_DETAIL"
+migrate_fail some_step
+assert_eq "migrate_fail defaults kind to error" "error" "$MIGRATE_FAIL_KIND"
+
+# --- collect_migration_diagnostics ---------------------------------------
+reset_migration_state
+ssh() { echo "OpenSSH_9.9p1 Debian-3, OpenSSL 3.5.4" >&2; }
+migrate_fail rsync_failed error "rsync_exit=23"
+diag="$(collect_migration_diagnostics)"
+printf '%s' "$diag" | jq empty 2>/dev/null
+assert_ok "diagnostics: emits valid JSON" $?
+assert_eq "diagnostics: reports the failing step" "rsync_failed" "$(printf '%s' "$diag" | jq -r .fail_step)"
+assert_eq "diagnostics: reports the detail"       "rsync_exit=23" "$(printf '%s' "$diag" | jq -r .detail)"
+
+# A hostile detail must not be able to break the payload: invalid JSON is
+# swapped for a fallback by validate_diagnostic_json, silently dropping every
+# diagnostic on the event this whole change exists to capture.
+reset_migration_state
+migrate_fail rsync_failed error 'he said "boom" \ then
+newline'
+printf '%s' "$(collect_migration_diagnostics)" | jq empty 2>/dev/null
+assert_ok "diagnostics: quotes/backslashes/newlines in detail keep JSON valid" $?
+
+# Privacy: the destination is a user@host and the app paths embed the account
+# name. Neither may ever reach telemetry.
+#
+# The key set is an ALLOW-LIST, deliberately. A deny-list that greps for the
+# planted values only catches a leak of those exact values: adding a field
+# holding $HOME or $USER would leak just as much identity and sail through
+# (a sibling collector already ships "user": "$USER"). Asserting the exact key
+# set means ANY new field fails here until it is reviewed and declared.
+MIGRATION_DIAG_KEYS="backup_taken
+dest_source
+detail
+fail_kind
+fail_step
+home_avail_kb
+remote_app_is_default_path
+remote_app_resolved
+remote_size_kb
+remote_state
+rsync_local
+silent_mode
+sqlite3_local
+ssh_version
+stopped_remote_this_run
+transfer_method"
+
+reset_migration_state
+MIGRATE_DEST="pi@secret-host.example.com"
+MIGRATE_REMOTE_HOME="/home/secretuser"
+MIGRATE_REMOTE_APP="/home/secretuser/birdnet-go-app"
+migrate_fail ssh_connect error "ssh_exit=255"
+diag="$(collect_migration_diagnostics)"
+case "$diag" in
+    *secret-host*|*secretuser*|*"pi@"*) leaked="yes" ;;
+    *) leaked="no" ;;
+esac
+assert_eq "diagnostics: no hostname/username/path leaks into telemetry" "no" "$leaked"
+assert_eq "diagnostics: field set is exactly the reviewed allow-list" \
+    "$MIGRATION_DIAG_KEYS" "$(printf '%s' "$diag" | jq -r 'keys[]' | sort)"
+assert_eq "diagnostics: reports resolution as a boolean instead" "yes" "$(printf '%s' "$diag" | jq -r .remote_app_resolved)"
+
+# "unparseable" distinguishes "the disk really is full" from "we could not read
+# the size" (a login banner on the SSH output, or du failing).
+reset_migration_state
+MIGRATE_REMOTE_SIZE_KB="Welcome to Debian"
+MIGRATE_HOME_AVAIL_KB="123456"
+diag="$(collect_migration_diagnostics)"
+assert_eq "diagnostics: non-numeric remote size reported as unparseable" \
+    "unparseable" "$(printf '%s' "$diag" | jq -r .remote_size_kb)"
+assert_eq "diagnostics: numeric local size passed through" \
+    "123456" "$(printf '%s' "$diag" | jq -r .home_avail_kb)"
+reset_migration_state
+assert_eq "diagnostics: size unknown before the disk check runs" \
+    "unknown" "$(collect_migration_diagnostics | jq -r .remote_size_kb)"
+
+# --- migrate_report_failure ----------------------------------------------
+# A user declining a prompt is a choice, not a fault. Reporting it at error
+# level inflates the error rate and buries the events worth acting on.
+# Mirrors the real signature: event_type message level context diagnostics.
+# $5 is captured because the whole point of the reporter is that it carries a
+# diagnostics payload; without asserting it, deleting the argument entirely goes
+# unnoticed and the events go back to being empty.
+TELEMETRY_LEVEL=""; TELEMETRY_MSG=""; TELEMETRY_CTX=""; TELEMETRY_DIAG=""
+send_telemetry_event() { TELEMETRY_LEVEL="$3"; TELEMETRY_MSG="$2"; TELEMETRY_CTX="$4"; TELEMETRY_DIAG="${5:-}"; }
+
+reset_migration_state
+migrate_fail rsync_failed error "rsync_exit=23"
+migrate_report_failure
+assert_eq "report: real failure is error level" "error" "$TELEMETRY_LEVEL"
+assert_eq "report: message names the step so Sentry groups per step" \
+    "Cross-host migration failed: rsync_failed" "$TELEMETRY_MSG"
+assert_eq "report: context carries the step" \
+    "step=remote_migrate,result=failure,error=rsync_failed" "$TELEMETRY_CTX"
+printf '%s' "$TELEMETRY_DIAG" | jq empty 2>/dev/null
+assert_ok "report: passes a valid JSON diagnostics payload as the 5th arg" $?
+assert_eq "report: the payload carries the failing step" \
+    "rsync_failed" "$(printf '%s' "$TELEMETRY_DIAG" | jq -r .fail_step)"
+
+reset_migration_state
+migrate_fail dest_occupied_declined cancelled
+migrate_report_failure
+assert_eq "report: user cancellation is info level, not error" "info" "$TELEMETRY_LEVEL"
+assert_eq "report: cancellation message says cancelled" \
+    "Cross-host migration cancelled: dest_occupied_declined" "$TELEMETRY_MSG"
+
+reset_migration_state
+migrate_report_failure
+assert_eq "report: unrecorded failure degrades to 'unknown', never empty" \
+    "Cross-host migration failed: unknown" "$TELEMETRY_MSG"
+unset -f send_telemetry_event
+
+# --- login-banner tolerance ----------------------------------------------
+# A remote .bashrc that echoes before Debian's non-interactive guard prepends a
+# banner to every ssh command's output. The banner is written by the remote
+# shell outside the command pipeline, so only a LOCAL tail -n 1 drops it.
+reset_migration_state
+MIGRATE_DEST="host"
+migrate_ssh() {
+    case "$1" in
+        *printf*) printf 'Welcome to Debian GNU/Linux 13\nLast login: today\n%s' "/home/pi" ;;
+        *"test -f"*) case "$1" in *"/home/pi/birdnet-go-app/config/config.yaml"*) return 0 ;; *) return 1 ;; esac ;;
+        *) return 1 ;;
+    esac
+}
+resolve_remote_app
+assert_ok "banner: remote install still resolves through a login banner" $?
+assert_eq "banner: remote home is the path, not the banner text" "/home/pi" "$MIGRATE_REMOTE_HOME"
+assert_eq "banner: app path derived cleanly" "/home/pi/birdnet-go-app" "$MIGRATE_REMOTE_APP"
+assert_eq "banner: default path recorded for telemetry" "yes" "$MIGRATE_REMOTE_APP_DEFAULT"
+
+# du's size must survive the same banner, or the disk check aborts in silent
+# mode claiming it "could not verify free disk space".
+reset_migration_state
+MIGRATE_REMOTE_APP="/home/pi/birdnet-go-app"
+SILENT_MODE="true"
+migrate_ssh() { printf 'Welcome to Debian GNU/Linux 13\n%s\n' "1000"; }
+df() { printf 'Filesystem 1024-blocks Used Available Capacity Mounted\n/dev/x 100 1 999999 1%% /\n'; }
+check_remote_disk
+assert_ok "banner: disk check reads the size through a banner" $?
+assert_eq "banner: remote size captured numerically for telemetry" "1000" "$MIGRATE_REMOTE_SIZE_KB"
+unset -f migrate_ssh df ssh
+reset_migration_state
+
+# --- a noisy remote shell is refused BEFORE anything is moved or stopped ------
+# rsync and tar stream over the same shell, so a host that greets us cannot be
+# migrated at all. Failing here costs nothing; failing at the transfer costs the
+# user their data being moved aside and their source service stopped.
+load_fn check_remote_shell_clean
+reset_migration_state
+MIGRATE_DEST="host"
+migrate_ssh() { printf 'Welcome to Debian GNU/Linux 13\n'; }
+check_remote_shell_clean
+assert_nonzero "noisy shell: a greeting remote is refused" $?
+assert_eq "noisy shell: records its own slug" "remote_shell_noisy" "$MIGRATE_FAIL_STEP"
+assert_eq "noisy shell: is an error, not a cancellation" "error" "$MIGRATE_FAIL_KIND"
+migrate_ssh() { :; }
+reset_migration_state
+MIGRATE_DEST="host"
+check_remote_shell_clean
+assert_ok "noisy shell: a quiet remote passes" $?
+assert_eq "noisy shell: quiet remote records no failure" "" "$MIGRATE_FAIL_STEP"
+unset -f migrate_ssh
+
+# --- production abort paths record the slug the reporter will publish ---------
+# Exercising migrate_fail directly only proves the helper stores what it is
+# handed. The contract that matters is the slug each real abort path chooses:
+# rename them all and a mechanism-only suite stays green while every Sentry
+# issue is misfiled. These drive the real functions.
+load_fn check_remote_stopped
+
+reset_migration_state
+SILENT_MODE="true"
+MIGRATE_REMOTE_APP="/home/pi/birdnet-go-app"
+migrate_ssh() { printf '%s\n' "5000"; }                     # remote wants 5000 KB
+df() { printf 'h\n/dev/x 100 1 10 1%% /\n'; }               # only 10 KB free
+check_remote_disk
+assert_nonzero "abort: insufficient disk returns non-zero" $?
+assert_eq "abort: insufficient disk records disk_insufficient" "disk_insufficient" "$MIGRATE_FAIL_STEP"
+assert_eq "abort: insufficient disk is an error" "error" "$MIGRATE_FAIL_KIND"
+
+reset_migration_state
+SILENT_MODE="true"
+MIGRATE_REMOTE_APP="/home/pi/birdnet-go-app"
+migrate_ssh() { printf 'not-a-number\n'; }                  # du unreadable
+df() { printf 'h\n/dev/x 100 1 999999 1%% /\n'; }
+check_remote_disk
+assert_nonzero "abort: unverifiable disk aborts in silent mode" $?
+assert_eq "abort: unverifiable disk records disk_unverified_silent" \
+    "disk_unverified_silent" "$MIGRATE_FAIL_STEP"
+
+reset_migration_state
+MIGRATE_DEST="host"
+SILENT_MODE="true"
+migrate_ssh() { case "$1" in *printf*) printf '\n' ;; *) return 1 ;; esac; }
+resolve_remote_app
+assert_nonzero "abort: unusable remote home returns non-zero" $?
+assert_eq "abort: unusable remote home records remote_home_unresolved" \
+    "remote_home_unresolved" "$MIGRATE_FAIL_STEP"
+
+reset_migration_state
+MIGRATE_DEST="host"
+SILENT_MODE="true"
+migrate_ssh() { case "$1" in *printf*) printf '%s' "/home/pi" ;; *) return 1 ;; esac; }
+resolve_remote_app
+assert_nonzero "abort: no remote install returns non-zero" $?
+assert_eq "abort: no remote install records remote_app_not_found" \
+    "remote_app_not_found" "$MIGRATE_FAIL_STEP"
+
+# check_remote_stopped is a PROBE: returning 1 is a normal branch ("maybe
+# running"), not a failure, so it must never record a slug. But it must say WHY,
+# or the caller reports "service was running" when the truth is we never got an
+# answer.
+reset_migration_state
+migrate_ssh() { printf 'active\n'; }
+check_remote_stopped
+assert_nonzero "probe: an active service is not confirmed stopped" $?
+assert_eq "probe: records state=running" "running" "$MIGRATE_REMOTE_STATE"
+assert_eq "probe: records NO slug (its return 1 is a branch, not an abort)" "" "$MIGRATE_FAIL_STEP"
+
+reset_migration_state
+migrate_ssh() { printf '\n'; }                              # systemctl gave no answer
+check_remote_stopped
+assert_nonzero "probe: no answer is not confirmed stopped" $?
+assert_eq "probe: an unanswered probe is 'unknown', not 'running'" "unknown" "$MIGRATE_REMOTE_STATE"
+
+reset_migration_state
+migrate_ssh() { return 255; }                               # ssh dropped
+check_remote_stopped
+assert_nonzero "probe: dropped ssh is not confirmed stopped" $?
+assert_eq "probe: dropped ssh is 'unknown', not 'running'" "unknown" "$MIGRATE_REMOTE_STATE"
+
+reset_migration_state
+migrate_ssh() { case "$1" in *systemctl*) printf 'inactive\n' ;; *) printf '\n' ;; esac; }
+check_remote_stopped
+assert_ok "probe: inactive service with no container is confirmed stopped" $?
+assert_eq "probe: records state=stopped" "stopped" "$MIGRATE_REMOTE_STATE"
+
+unset -f migrate_ssh df
+
+# --- ssh's real exit code reaches the report ---------------------------------
+# `if ! ssh ...; then rc=$?` records the NEGATED status, i.e. 0, for every
+# failure. That reads as a successful connection in the payload: a plausible
+# lie is worse than no field at all, so pin the real code.
+load_fn open_ssh_master
+reset_migration_state
+MIGRATE_DEST="host"
+MIGRATE_SSH_DIR=""; MIGRATE_SSH_SOCKET=""
+mktemp() { mkdir -p "${WORK}/sshmaster"; printf '%s' "${WORK}/sshmaster"; }
+ssh() { return 255; }
+open_ssh_master
+assert_nonzero "ssh master: an unreachable host returns non-zero" $?
+assert_eq "ssh master: records ssh_connect" "ssh_connect" "$MIGRATE_FAIL_STEP"
+assert_eq "ssh master: records ssh's REAL exit code, not the negated status" \
+    "ssh_exit=255" "$MIGRATE_FAIL_DETAIL"
+
+reset_migration_state
+MIGRATE_DEST="host"
+MIGRATE_SSH_DIR=""; MIGRATE_SSH_SOCKET=""
+ssh() { return 0; }
+open_ssh_master
+assert_ok "ssh master: a reachable host succeeds" $?
+assert_eq "ssh master: success records no failure" "" "$MIGRATE_FAIL_STEP"
+
+reset_migration_state
+MIGRATE_DEST="host"
+MIGRATE_SSH_DIR=""; MIGRATE_SSH_SOCKET=""
+mktemp() { return 1; }
+open_ssh_master
+assert_nonzero "ssh master: unusable temp dir returns non-zero" $?
+assert_eq "ssh master: records tmpdir_failed" "tmpdir_failed" "$MIGRATE_FAIL_STEP"
+unset -f mktemp ssh
+
+# --- rollback must not erase the record of what it undid ---------------------
+# migrate_rollback clears MIGRATE_BACKUP and restarts the source BEFORE the
+# failure is reported, so inferring these from live state reports "no backup" on
+# every rollback path -- including the one where the restore failed and the
+# user's data is still sitting at the .bak path.
+reset_migration_state
+MIGRATE_BACKUP_TAKEN="yes"; MIGRATE_STOPPED_REMOTE_EVER="yes"
+MIGRATE_BACKUP=""; MIGRATE_STOPPED_REMOTE="0"              # what rollback leaves behind
+ssh() { echo "OpenSSH_9.9p1" >&2; }
+migrate_fail rsync_failed error "rsync_exit=23"
+diag="$(collect_migration_diagnostics)"
+assert_eq "rollback: backup_taken survives the rollback that cleared it" \
+    "yes" "$(printf '%s' "$diag" | jq -r .backup_taken)"
+assert_eq "rollback: stopped_remote survives the rollback that restarted it" \
+    "yes" "$(printf '%s' "$diag" | jq -r .stopped_remote_this_run)"
+unset -f ssh
+reset_migration_state
 
 # ===========================================================================
 # Result

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -11,8 +11,10 @@
 # untouched.
 #
 # Run: scripts/install_test.sh   (exit 0 = all pass). Needs awk/sed, plus jq for the
-# migration-diagnostics tests (they assert the telemetry payload is valid JSON, and
-# install.sh already requires jq to send any telemetry at all).
+# migration-diagnostics tests, which assert the telemetry payload is valid JSON.
+# jq is a test-harness dependency, not an install.sh one: install.sh lists jq in
+# REQUIRED_PACKAGES and installs it, and validate_diagnostic_json deliberately
+# degrades when jq is absent rather than requiring it.
 
 # Many globals here (colors, CONFIG_FILE, SILENT_MODE, the load_existing_service_config output
 # vars, BIRDNET_AUDIO_FORMAT) are consumed only inside the eval'd functions extracted from
@@ -1252,45 +1254,102 @@ assert_nonzero "ssh master: unusable temp dir returns non-zero" $?
 assert_eq "ssh master: records tmpdir_failed" "tmpdir_failed" "$MIGRATE_FAIL_STEP"
 unset -f mktemp ssh
 
-# --- "running" and "could not tell" must not become the same Sentry issue ----
-# The silent-mode abort picks its slug from the probe's recorded state. Merging
-# these back together re-creates exactly the conflation this change exists to
-# remove: one issue that says "stop the service" to people whose service was
-# never running.
-reset_migration_state
-MIGRATE_REMOTE_STATE="running"
-if [ "$MIGRATE_REMOTE_STATE" = "running" ]; then migrate_fail remote_running_silent; else migrate_fail remote_state_unknown_silent; fi
-assert_eq "silent abort: a confirmed-running source reports remote_running_silent" \
+# --- drive the REAL orchestrator, not a re-implementation of its branches -----
+# Asserting against a copy of a condition only proves the copy works: reversing
+# the shipped condition leaves such a test green, and grepping for a slug proves
+# the string exists, not that the right branch reaches it. So load the real
+# migrate_from_remote_host and stub its collaborators, and let the shipped
+# branches decide the outcome.
+load_fn migrate_from_remote_host
+
+STUB_REMOTE_STATE="running"
+SAVED_HOME="$HOME"
+migrate_flow_setup() {
+    reset_migration_state
+    MIGRATE_DEST="oldhost"
+    SILENT_MODE="true"
+    HOME="${WORK}/flow"; rm -rf "$HOME"; mkdir -p "$HOME"
+    open_ssh_master() { return 0; }
+    check_remote_shell_clean() { return 0; }
+    resolve_remote_app() { MIGRATE_REMOTE_APP="/home/pi/birdnet-go-app"; MIGRATE_REMOTE_APP_DEFAULT="yes"; return 0; }
+    check_remote_disk() { return 0; }
+    check_remote_stopped() { MIGRATE_REMOTE_STATE="$STUB_REMOTE_STATE"; [ "$STUB_REMOTE_STATE" = "stopped" ]; }
+    migrate_rollback() { :; }
+    adopt_migrated_installation() { MIGRATION_DONE="true"; return 0; }
+    command_exists() { return 0; }   # rsync/sqlite3 already present
+}
+
+# "running" and "could not tell" must not collapse into one Sentry issue: one
+# says "go stop your service", the other says "we never got an answer".
+migrate_flow_setup; STUB_REMOTE_STATE="running"
+migrate_from_remote_host
+assert_eq "flow: a confirmed-running source reports remote_running_silent" \
     "remote_running_silent" "$MIGRATE_FAIL_STEP"
-reset_migration_state
-MIGRATE_REMOTE_STATE="unknown"
-if [ "$MIGRATE_REMOTE_STATE" = "running" ]; then migrate_fail remote_running_silent; else migrate_fail remote_state_unknown_silent; fi
-assert_eq "silent abort: an unanswered probe reports remote_state_unknown_silent" \
+
+migrate_flow_setup; STUB_REMOTE_STATE="unknown"
+migrate_from_remote_host
+assert_eq "flow: an unanswered probe reports remote_state_unknown_silent" \
     "remote_state_unknown_silent" "$MIGRATE_FAIL_STEP"
 
-# Both slugs must actually exist at the real call site, or the branch above is
-# testing a copy of the logic rather than the shipped logic.
-assert_eq "silent abort: both slugs are wired into install.sh" "2" \
-    "$(grep -cE 'migrate_fail (remote_running_silent|remote_state_unknown_silent)$' "$INSTALL_SH")"
+# The backup evidence must be written only AFTER the mv actually succeeds.
+# Hoisting it above the mv would claim a backup that was never taken, on the one
+# path where the user most needs to know the truth.
+migrate_flow_setup; STUB_REMOTE_STATE="stopped"
+SILENT_MODE="false"
+mkdir -p "$HOME/birdnet-go-app/config"; printf 'x\n' > "$HOME/birdnet-go-app/config/config.yaml"
+mv() { return 1; }
+migrate_from_remote_host <<< "y"
+assert_eq "flow: a failed backup move records backup_move_failed" \
+    "backup_move_failed" "$MIGRATE_FAIL_STEP"
+assert_eq "flow: a failed backup move claims NO backup evidence" \
+    "no" "$MIGRATE_BACKUP_TAKEN"
+unset -f mv
 
-# --- the record globals are actually written, at the right moment -------------
-# migrate_rollback clears MIGRATE_BACKUP and restarts the source BEFORE the
-# failure is reported, so the reporter reads report-only records instead. Pin
-# both halves: that the records are WRITTEN where the fact becomes true, and
-# that the reporter reads them rather than the live state.
-assert_eq "records: backup_taken is set after the mv succeeds, not before" "1" \
-    "$(grep -cE '^        MIGRATE_BACKUP_TAKEN="yes"$' "$INSTALL_SH")"
-assert_eq "records: stopped_remote_ever is set where the source is stopped" "1" \
-    "$(grep -cE '^                MIGRATE_STOPPED_REMOTE_EVER="yes"$' "$INSTALL_SH")"
+# ...and once the mv succeeds the evidence must survive whatever fails later,
+# because migrate_rollback wipes the live state before the report is built.
+migrate_flow_setup; STUB_REMOTE_STATE="stopped"
+SILENT_MODE="false"
+mkdir -p "$HOME/birdnet-go-app/config"; printf 'x\n' > "$HOME/birdnet-go-app/config/config.yaml"
+migrate_ssh() { return 0; }          # remote has rsync
+rsync() { return 23; }               # ...and the transfer dies
+migrate_from_remote_host <<< "y"
+assert_eq "flow: a dead transfer reports rsync_failed" "rsync_failed" "$MIGRATE_FAIL_STEP"
+assert_eq "flow: with rsync's real exit code" "rsync_exit=23" "$MIGRATE_FAIL_DETAIL"
+assert_eq "flow: the transfer method is recorded" "rsync" "$MIGRATE_TRANSFER_METHOD"
+assert_eq "flow: backup evidence survives a later failure" "yes" "$MIGRATE_BACKUP_TAKEN"
+unset -f migrate_ssh rsync
 
-# The rollback restart flag must be armed BEFORE the stop is issued. Armed only
-# after a confirmed stop, a dropped verification round trip leaves the flag at
-# "0" and rollback walks away with the user's source service still down.
-arm_line="$(grep -n '^            MIGRATE_STOPPED_REMOTE="1"$' "$INSTALL_SH" | head -1 | cut -d: -f1)"
-issue_line="$(grep -n "ControlPath=\"\$MIGRATE_SSH_SOCKET\".*systemctl stop birdnet-go.service" "$INSTALL_SH" | head -1 | cut -d: -f1)"
-arm_rc=0
-{ [ -n "$arm_line" ] && [ -n "$issue_line" ] && [ "$arm_line" -lt "$issue_line" ]; } || arm_rc=1
-assert_ok "records: the rollback restart flag is armed BEFORE the stop is issued" "$arm_rc"
+# The rollback restart flag is a safety switch, so its two failure modes are not
+# symmetric. Armed too late, a stop that lands but whose verification then drops
+# leaves the user's source service down on the host they still depend on. Armed
+# too eagerly, we ssh -t a sudo restart at a service that never stopped, which
+# buys nothing and can sit on a password prompt. Capture what rollback actually
+# sees rather than trusting the assignment order by inspection.
+ROLLBACK_SAW_FLAG=""
+migrate_flow_setup; STUB_REMOTE_STATE="running"
+SILENT_MODE="false"
+migrate_rollback() { ROLLBACK_SAW_FLAG="$MIGRATE_STOPPED_REMOTE"; }
+ssh() { return 0; }
+migrate_from_remote_host <<< "y"
+assert_eq "flow: a confirmed-running source disarms the rollback restart" "0" "$ROLLBACK_SAW_FLAG"
+assert_eq "flow: ...and still reports remote_still_running" "remote_still_running" "$MIGRATE_FAIL_STEP"
+
+migrate_flow_setup; STUB_REMOTE_STATE="unknown"
+SILENT_MODE="false"
+migrate_rollback() { ROLLBACK_SAW_FLAG="$MIGRATE_STOPPED_REMOTE"; }
+ssh() { return 0; }
+migrate_from_remote_host <<< "y"
+assert_eq "flow: an unverifiable stop stays armed so rollback restarts it" "1" "$ROLLBACK_SAW_FLAG"
+unset -f ssh
+
+HOME="$SAVED_HOME"
+unset -f open_ssh_master check_remote_shell_clean resolve_remote_app check_remote_disk \
+         check_remote_stopped migrate_rollback adopt_migrated_installation migrate_flow_setup
+command_exists() { command -v "$1" >/dev/null 2>&1; }
+# Reload the real implementations the later assertions depend on.
+for fn in check_remote_shell_clean resolve_remote_app check_remote_disk check_remote_stopped; do
+    load_fn "$fn"
+done
 
 reset_migration_state
 MIGRATE_BACKUP_TAKEN="yes"; MIGRATE_STOPPED_REMOTE_EVER="yes"

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -882,6 +882,16 @@ escaped_long="$(json_escape "$long_backslashes")"
 printf '{"v":"%s"}' "$escaped_long" | jq empty 2>/dev/null
 assert_ok "json_escape: truncated backslash run stays valid JSON" $?
 
+# Truncation counts characters, not bytes, so a cut can never leave half a
+# multi-byte character behind. jq tolerates a severed one (it substitutes
+# U+FFFD) so this would not fail loudly; it would just ship a mangled byte.
+# The padding is exact and load-bearing: the multi-byte character has to STRADDLE
+# the cut. A fixture with it anywhere else is never severed and the assertion
+# passes under byte truncation too, proving nothing.
+multibyte_astride="$(printf '%*s' $((MAX_ERROR_LENGTH - 1)) '' | tr ' ' 'x')$(printf '\xc3\xa9')trailing"
+assert_eq "json_escape: a multi-byte character astride the cut survives intact" \
+    "c3a9" "$(json_escape "$multibyte_astride" | tail -c 2 | od -An -tx1 | tr -d ' \n')"
+
 # --- migrate_fail ---------------------------------------------------------
 reset_migration_state
 migrate_fail ssh_connect error "ssh_exit=255"
@@ -1047,6 +1057,29 @@ check_remote_shell_clean
 assert_nonzero "noisy shell: a greeting remote is refused" $?
 assert_eq "noisy shell: records its own slug" "remote_shell_noisy" "$MIGRATE_FAIL_STEP"
 assert_eq "noisy shell: is an error, not a cancellation" "error" "$MIGRATE_FAIL_KIND"
+
+# A .bashrc printing only a blank line is the hard case: command substitution
+# strips trailing newlines, so it reads as silence unless the probe defends
+# against it -- yet a lone newline corrupts rsync exactly like a banner does.
+for blank in 'printf "\n"' 'printf "\n\n"'; do
+    reset_migration_state
+    MIGRATE_DEST="host"
+    eval "migrate_ssh() { $blank; }"
+    check_remote_shell_clean
+    assert_nonzero "noisy shell: newline-only noise ($blank) is refused" $?
+    assert_eq "noisy shell: newline-only noise records the slug ($blank)" \
+        "remote_shell_noisy" "$MIGRATE_FAIL_STEP"
+done
+
+# stderr does not ride the payload stream, so a stderr banner must NOT be
+# treated as noise: refusing those hosts would block migrations that work.
+reset_migration_state
+MIGRATE_DEST="host"
+migrate_ssh() { echo "banner on stderr" >&2; }
+check_remote_shell_clean
+assert_ok "noisy shell: a stderr-only banner is NOT treated as noise" $?
+assert_eq "noisy shell: stderr banner records no failure" "" "$MIGRATE_FAIL_STEP"
+
 migrate_ssh() { :; }
 reset_migration_state
 MIGRATE_DEST="host"
@@ -1129,6 +1162,28 @@ check_remote_stopped
 assert_ok "probe: inactive service with no container is confirmed stopped" $?
 assert_eq "probe: records state=stopped" "stopped" "$MIGRATE_REMOTE_STATE"
 
+# The docker half of the same fail-closed contract. systemd says "not running",
+# but a live container means the database is live: confirming "stopped" here
+# would let the transfer copy a database mid-write.
+reset_migration_state
+migrate_ssh() { case "$1" in *systemctl*) printf 'inactive\n' ;; *) printf 'birdnet-go\n' ;; esac; }
+check_remote_stopped
+assert_nonzero "probe: a running container is NOT confirmed stopped" $?
+assert_eq "probe: a running container is state=running" "running" "$MIGRATE_REMOTE_STATE"
+
+reset_migration_state
+migrate_ssh() { case "$1" in *systemctl*) printf 'inactive\n' ;; *) return 255 ;; esac; }
+check_remote_stopped
+assert_nonzero "probe: a dropped ssh on the docker check is not confirmed stopped" $?
+assert_eq "probe: dropped ssh on the docker check is 'unknown'" "unknown" "$MIGRATE_REMOTE_STATE"
+
+# grep -Fx matches the WHOLE line: a container merely named like ours (or shell
+# noise containing the name) must not count as our container running.
+reset_migration_state
+migrate_ssh() { case "$1" in *systemctl*) printf 'inactive\n' ;; *) printf 'birdnet-go-sidecar\n' ;; esac; }
+check_remote_stopped
+assert_ok "probe: a similarly-named container does not count as ours" $?
+
 unset -f migrate_ssh df
 
 # --- ssh's real exit code reaches the report ---------------------------------
@@ -1164,23 +1219,64 @@ assert_nonzero "ssh master: unusable temp dir returns non-zero" $?
 assert_eq "ssh master: records tmpdir_failed" "tmpdir_failed" "$MIGRATE_FAIL_STEP"
 unset -f mktemp ssh
 
-# --- rollback must not erase the record of what it undid ---------------------
+# --- "running" and "could not tell" must not become the same Sentry issue ----
+# The silent-mode abort picks its slug from the probe's recorded state. Merging
+# these back together re-creates exactly the conflation this change exists to
+# remove: one issue that says "stop the service" to people whose service was
+# never running.
+reset_migration_state
+MIGRATE_REMOTE_STATE="running"
+if [ "$MIGRATE_REMOTE_STATE" = "running" ]; then migrate_fail remote_running_silent; else migrate_fail remote_state_unknown_silent; fi
+assert_eq "silent abort: a confirmed-running source reports remote_running_silent" \
+    "remote_running_silent" "$MIGRATE_FAIL_STEP"
+reset_migration_state
+MIGRATE_REMOTE_STATE="unknown"
+if [ "$MIGRATE_REMOTE_STATE" = "running" ]; then migrate_fail remote_running_silent; else migrate_fail remote_state_unknown_silent; fi
+assert_eq "silent abort: an unanswered probe reports remote_state_unknown_silent" \
+    "remote_state_unknown_silent" "$MIGRATE_FAIL_STEP"
+
+# Both slugs must actually exist at the real call site, or the branch above is
+# testing a copy of the logic rather than the shipped logic.
+assert_eq "silent abort: both slugs are wired into install.sh" "2" \
+    "$(grep -cE 'migrate_fail (remote_running_silent|remote_state_unknown_silent)$' "$INSTALL_SH")"
+
+# --- the record globals are actually written, at the right moment -------------
 # migrate_rollback clears MIGRATE_BACKUP and restarts the source BEFORE the
-# failure is reported, so inferring these from live state reports "no backup" on
-# every rollback path -- including the one where the restore failed and the
-# user's data is still sitting at the .bak path.
+# failure is reported, so the reporter reads report-only records instead. Pin
+# both halves: that the records are WRITTEN where the fact becomes true, and
+# that the reporter reads them rather than the live state.
+assert_eq "records: backup_taken is set after the mv succeeds, not before" "1" \
+    "$(grep -cE '^        MIGRATE_BACKUP_TAKEN="yes"$' "$INSTALL_SH")"
+assert_eq "records: stopped_remote_ever is set where the source is stopped" "1" \
+    "$(grep -cE '^                MIGRATE_STOPPED_REMOTE_EVER="yes"$' "$INSTALL_SH")"
+
 reset_migration_state
 MIGRATE_BACKUP_TAKEN="yes"; MIGRATE_STOPPED_REMOTE_EVER="yes"
 MIGRATE_BACKUP=""; MIGRATE_STOPPED_REMOTE="0"              # what rollback leaves behind
 ssh() { echo "OpenSSH_9.9p1" >&2; }
 migrate_fail rsync_failed error "rsync_exit=23"
 diag="$(collect_migration_diagnostics)"
-assert_eq "rollback: backup_taken survives the rollback that cleared it" \
+assert_eq "records: backup_taken survives the rollback that cleared it" \
     "yes" "$(printf '%s' "$diag" | jq -r .backup_taken)"
-assert_eq "rollback: stopped_remote survives the rollback that restarted it" \
+assert_eq "records: stopped_remote survives the rollback that restarted it" \
     "yes" "$(printf '%s' "$diag" | jq -r .stopped_remote_this_run)"
 unset -f ssh
 reset_migration_state
+
+# --- the noisy-shell probe is actually wired in ------------------------------
+# The function is unit-tested above; this pins that migrate_from_remote_host
+# calls it, and calls it BEFORE the steps that move data and stop the service.
+probe_line="$(grep -n 'check_remote_shell_clean || return 1' "$INSTALL_SH" | cut -d: -f1)"
+backup_line="$(grep -n 'MIGRATE_BACKUP="\${dest_dir}' "$INSTALL_SH" | cut -d: -f1)"
+# Anchor on the migration's OWN stop (the one issued over the ssh master), not
+# the unrelated local `systemctl stop` sites elsewhere in the installer.
+stop_line="$(grep -n "ControlPath=\"\$MIGRATE_SSH_SOCKET\".*systemctl stop birdnet-go.service" "$INSTALL_SH" | head -1 | cut -d: -f1)"
+assert_eq "wiring: the noisy-shell probe is called from the migration flow" \
+    "1" "$(grep -c 'check_remote_shell_clean || return 1' "$INSTALL_SH")"
+[ -n "$probe_line" ] && [ -n "$backup_line" ] && [ "$probe_line" -lt "$backup_line" ]
+assert_ok "wiring: the probe runs BEFORE the user's data is moved aside" $?
+[ -n "$probe_line" ] && [ -n "$stop_line" ] && [ "$probe_line" -lt "$stop_line" ]
+assert_ok "wiring: the probe runs BEFORE the source service is stopped" $?
 
 # ===========================================================================
 # Result


### PR DESCRIPTION
## Problem

A cross-host migration failure reports one opaque Sentry event for every way it can fail:

```
message:     [install.sh] Cross-host migration failed
context:     step=remote_migrate,result=failure
diagnostics: {}
```

`migrate_from_remote_host` has ~26 distinct abort paths (wrong SSH host, no install on the remote, disk full, rsync died, corrupt database, or the user simply answering "n" at a prompt). All of them collapse into that single message, so the resulting issue says only "something went wrong" and cannot be acted on. The user sees the real reason on their terminal; telemetry receives none of it.

A recent report from a Raspberry Pi 5 showed the problem exactly: two failures 36 seconds apart, identical payloads, empty diagnostics, no way to tell which step failed.

Two smaller problems fall out of the same call site:

- **Cancellations are reported as errors.** Four of those paths are the user deliberately declining a prompt. They raise `error`-level events at priority 75 alongside genuine failures, which inflates the error rate and buries the actionable events.
- **SSH's exit code was never captured.** The `if ! ssh ...` form leaves `$?` as the negated status, so the real code was unavailable.

## Change

Each abort path records a slug from a fixed 27-value vocabulary (`ssh_connect`, `disk_insufficient`, `rsync_failed`, `dest_occupied_declined`, ...) via a new `migrate_fail` helper. One reporter then emits it:

```
[install.sh] Cross-host migration failed: rsync_failed        (error)
[install.sh] Cross-host migration cancelled: dest_occupied_declined   (info)
```

The step is part of the message because Sentry has no stack trace to group a shell script by, so this splits one opaque issue into one issue per failing step. Same convention as the existing `Service startup failed: $error_type`. Cancellations drop to `info`, matching the existing AVX2-prompt precedent.

`send_telemetry_event` already accepted a 5th `diagnostic_json` argument that 11 other call sites use; the migration path now uses it too.

### Diagnostics are privacy-safe by construction

The SSH destination is a `user@host` and the app paths embed the account name, so the payload carries only enums, booleans, exit codes, and sizes. A test asserts nothing identifying leaks.

```json
{
  "fail_step": "disk_insufficient",
  "detail": "need_kb=5305300,avail_kb=1200000",
  "silent_mode": "false",
  "dest_source": "flag",
  "remote_app_resolved": "yes",
  "transfer_method": "rsync",
  "remote_size_kb": "4823000",
  "home_avail_kb": "1200000"
}
```

`remote_size_kb: "unparseable"` is deliberate: it distinguishes "the disk really is full" from "we could not read the size".

### A noisy remote shell now fails early instead of halfway through

rsync and tar both stream their payload over the remote login shell, so a `.bashrc` that prints a banner corrupts the transfer outright (`protocol version mismatch -- is your shell clean?`). No filtering fixes a binary stream.

`check_remote_shell_clean` probes for this up front and refuses with an actionable message, **before** the destructive steps. That ordering is the point: without it, a noisy host gets further — past the pre-flight checks, past moving the user's existing data aside, past stopping the source service — and only then dies at the transfer, leaning on best-effort rollback. Failing at the probe costs the user nothing.

The `tail -n 1` guard that `check_remote_stopped` already documents is also applied to its two sibling readers, where banner noise otherwise surfaces as a misleading "No install found at ..." or a bogus "could not verify free disk space". It runs locally, the only place it works: the banner is written by the remote shell outside the command's own pipeline, so a remote `tail` never sees it. With the probe in front, this is defence in depth.

### "Running" and "couldn't tell" are no longer the same event

`check_remote_stopped` fails closed, so a live service, a dropped SSH, and `systemctl` with no bus (a container or chroot) all took one branch and reported "service was running". Behaviour is unchanged — it still fails closed — but the probe now records *why*, so the silent-mode abort splits into `remote_running_silent` and `remote_state_unknown_silent`. Conflating distinct causes into one unactionable event is the exact thing this PR exists to stop.

## Verification

- 40 new assertions; `scripts/install_test.sh` reports 173 passed, 0 failed
- No new `shellcheck` findings in either file (93 before, 93 after); clean at CI's stricter `-S warning`
- End-to-end payload confirmed accepted by `validate_diagnostic_json` unchanged (an invalid payload is silently swapped for a fallback, losing every diagnostic)

Mutation-tested against 13 mutations, including every one that a review pass found surviving an earlier version of these tests. Each of the following now fails at least one assertion: renaming any production slug; dropping the diagnostics payload from the telemetry call; adding a field that leaks `$HOME`; reverting `|| rc=$?` so ssh's exit code reports a fake 0; reversing the escape/truncate order; reading `backup_taken` from rollback-wiped state; reporting an unknown remote state as "running"; removing either banner guard; and dropping backslash escaping.

Two test weaknesses that reviews caught and this fixes are worth naming, because both looked fine:

- the privacy check was a deny-list grepping for the three values it planted, so a field leaking `$HOME` passed. It is now an allow-list over the exact key set, so any new field fails until reviewed.
- the truncation fixture was a pure backslash run, which stays valid under *both* orderings at an even limit. It now carries a one-character prefix, which is what forces a cut mid-escape.

`load_fn` in the test harness gained here-doc awareness so the JSON collector (whose here-doc body contains a column-0 `}`) can be extracted at all; the harness documented that exact limitation. It also now rejects a runaway extraction, whose old failure mode was silent: one comment mentioning a here-doc could swallow a dozen functions and leave the suite green while testing something else.

## Note

This does not retro-diagnose the Pi 5 report, and no fix is claimed for it. The data needed to explain it was never sent. This makes the next occurrence land as a specific, named issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-host migration failure handling with more precise, step-based telemetry and JSON diagnostics.
  * Added stronger SSH setup and preflight validation, including rejecting noisy remote shells before data transfer.
  * Hardened remote app/home path validation and improved remote stop/disk probing behavior for clearer aborts.

* **Tests**
  * Expanded automated coverage for failure reporting, JSON diagnostics correctness, telemetry semantics, SSH/login-banner and remote-shell checks, rollback evidence, and transfer abort slugs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->