### PR TITLE
fix(build): compile OpenVINO backend into linux release binaries (#3958)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1166,14 +1166,37 @@ tasks:
       TFLITE_LIB_DIR: '{{.DOCKER_LIB_DIR | default .SYSTEM_LIB_DIR}}'
       TFLITE_LIB_ARCH: linux_amd64.tar.gz
       TARGET: linux_amd64
+      # Linux release binaries ship with the OpenVINO backend compiled in so
+      # native tarball installs match the OpenVINO wiki (issue #3958). The
+      # backend is dlopen'd at runtime and self-gates to the ONNX Runtime when
+      # libopenvino_c is absent, so a tagged binary runs unchanged on hosts
+      # without the OpenVINO runtime installed. Pass OPENVINO=false to opt out.
+      OPENVINO: '{{.OPENVINO | default "true"}}'
     cmds:
       - task: download-tflite
         vars: {TFLITE_LIB_DIR: '{{.TFLITE_LIB_DIR}}', TFLITE_LIB_ARCH: '{{.TFLITE_LIB_ARCH}}', TARGET: '{{.TARGET}}'}
+      # Fetch the OpenVINO C API headers when this is an openvino build; the task
+      # no-ops for standard builds (OPENVINO unset or "false").
+      - task: check-openvino
+        vars: {OPENVINO: '{{.OPENVINO}}'}
       - |
         mkdir -p {{.TFLITE_LIB_DIR}}
+        # openvino adds the OpenVINO inference backend (dlopen'd at runtime, ORT
+        # fallback); headers are provided by the check-openvino task above.
+        BUILD_TAGS=""
+        if [ "{{.OPENVINO}}" = "true" ]; then
+          BUILD_TAGS="openvino"
+        fi
+        # go-task exposes EXTRA_BUILD_TAGS as a template var, not a shell env var,
+        # so read it via templating (works for both `task ... EXTRA_BUILD_TAGS=x`
+        # and a real env var); a bare shell `${EXTRA_BUILD_TAGS}` would be empty.
+        EXTRA_TAGS="{{.EXTRA_BUILD_TAGS}}"
+        if [ -n "${EXTRA_TAGS}" ]; then
+          BUILD_TAGS="${BUILD_TAGS:+${BUILD_TAGS},}${EXTRA_TAGS}"
+        fi
         GOOS=linux GOARCH=amd64 {{.CGO_FLAGS}} \
         CGO_LDFLAGS="-L{{.TFLITE_LIB_DIR}} -ltensorflowlite_c" \
-        go build -trimpath {{.BUILD_FLAGS}} -o {{.BINARY_DIR}}/{{.BINARY_NAME}}
+        go build -trimpath ${BUILD_TAGS:+-tags "${BUILD_TAGS}"} {{.LDFLAGS}} -o {{.BINARY_DIR}}/{{.BINARY_NAME}}
 
   linux_arm64:
     deps: [check-tools, check-tensorflow, download-avicommons-data, frontend-build]
@@ -1181,17 +1204,41 @@ tasks:
       TFLITE_LIB_DIR: '{{.DOCKER_LIB_DIR | default .CROSS_LIB_DIR_ARM64}}'
       TFLITE_LIB_ARCH: linux_arm64.tar.gz
       TARGET: linux_arm64
+      # Linux release binaries ship with the OpenVINO backend compiled in so
+      # native tarball installs match the OpenVINO wiki (issue #3958). The
+      # backend is dlopen'd at runtime and self-gates to the ONNX Runtime when
+      # libopenvino_c is absent, so a tagged binary runs unchanged on hosts
+      # without the OpenVINO runtime installed. Pass OPENVINO=false to opt out.
+      OPENVINO: '{{.OPENVINO | default "true"}}'
     cmds:
       - task: download-tflite
         vars: {TFLITE_LIB_DIR: '{{.TFLITE_LIB_DIR}}', TFLITE_LIB_ARCH: '{{.TFLITE_LIB_ARCH}}', TARGET: '{{.TARGET}}'}
+      # Fetch the OpenVINO C API headers when this is an openvino build; the task
+      # no-ops for standard builds (OPENVINO unset or "false"). The C API headers
+      # are architecture-independent, so the amd64-host cache serves arm64 too.
+      - task: check-openvino
+        vars: {OPENVINO: '{{.OPENVINO}}'}
       - |
         mkdir -p {{.TFLITE_LIB_DIR}}
         if [ "$(uname -m)" != "aarch64" ]; then
           export CC=aarch64-linux-gnu-gcc
         fi
+        # openvino adds the OpenVINO inference backend (dlopen'd at runtime, ORT
+        # fallback); headers are provided by the check-openvino task above.
+        BUILD_TAGS=""
+        if [ "{{.OPENVINO}}" = "true" ]; then
+          BUILD_TAGS="openvino"
+        fi
+        # go-task exposes EXTRA_BUILD_TAGS as a template var, not a shell env var,
+        # so read it via templating (works for both `task ... EXTRA_BUILD_TAGS=x`
+        # and a real env var); a bare shell `${EXTRA_BUILD_TAGS}` would be empty.
+        EXTRA_TAGS="{{.EXTRA_BUILD_TAGS}}"
+        if [ -n "${EXTRA_TAGS}" ]; then
+          BUILD_TAGS="${BUILD_TAGS:+${BUILD_TAGS},}${EXTRA_TAGS}"
+        fi
         GOOS=linux GOARCH=arm64 {{.CGO_FLAGS}} \
         CGO_LDFLAGS="-L{{.TFLITE_LIB_DIR}} -ltensorflowlite_c" \
-        go build -trimpath {{.BUILD_FLAGS}} -o {{.BINARY_DIR}}/{{.BINARY_NAME}}
+        go build -trimpath ${BUILD_TAGS:+-tags "${BUILD_TAGS}"} {{.LDFLAGS}} -o {{.BINARY_DIR}}/{{.BINARY_NAME}}
 
   windows_amd64:
     deps: [check-tools, check-tensorflow, download-avicommons-data, frontend-build]
@@ -1321,8 +1368,12 @@ tasks:
         if [ "{{.OPENVINO}}" = "true" ]; then
           BUILD_TAGS="${BUILD_TAGS},openvino"
         fi
-        if [ -n "${EXTRA_BUILD_TAGS:-}" ]; then
-          BUILD_TAGS="${BUILD_TAGS},${EXTRA_BUILD_TAGS}"
+        # go-task exposes EXTRA_BUILD_TAGS as a template var, not a shell env var,
+        # so read it via templating (works for both `task ... EXTRA_BUILD_TAGS=x`
+        # and a real env var); a bare shell `${EXTRA_BUILD_TAGS}` would be empty.
+        EXTRA_TAGS="{{.EXTRA_BUILD_TAGS}}"
+        if [ -n "${EXTRA_TAGS}" ]; then
+          BUILD_TAGS="${BUILD_TAGS},${EXTRA_TAGS}"
         fi
         TFLITE_LDFLAGS="-L{{.TFLITE_LIB_DIR}} -ltensorflowlite_c"
         if [ "{{.NOTFLITE}}" = "true" ]; then


### PR DESCRIPTION
## Summary

The `linux_amd64` and `linux_arm64` Taskfile targets that build the release tarballs were compiled without the `openvino` build tag, so they shipped the `stub_noopenvino.go` stub and reported `"openvino": {"supported": false}` no matter what runtime libraries, GPU driver, or config the user had. This contradicted the OpenVINO Acceleration wiki, which states the Linux binaries are built with the backend compiled in. Only the Docker images (built via `noembed_build`, where `OPENVINO` already defaults to `true`) got the real backend, so tarball users, including everyone who installs via the community ProxmoxVE script, silently got the stub.

Both linux targets now default `OPENVINO=true`, run `check-openvino` to fetch the C API headers, and append the `openvino` tag to the build, mirroring the existing `noembed_build` path. `OPENVINO=false` opts out.

The OpenVINO backend is dlopen-based and links only `-ldl`, so a tagged binary has no hard link-time dependency on `libopenvino_c` (confirmed with `readelf`/`ldd` on both arches). On a host without the runtime it self-gates to the ONNX Runtime, so users who never install OpenVINO see identical behavior. The tarball still ships only `libtensorflowlite_c` and `libonnxruntime`; `libopenvino_c` is provided by the user per the wiki and loaded at runtime.

While here, this also fixes `EXTRA_BUILD_TAGS` in the three linux build blocks to read the go-task template var (`{{.EXTRA_BUILD_TAGS}}`) instead of a shell env var (`${EXTRA_BUILD_TAGS}`), which go-task does not export to the command shell; the shell form silently dropped tags passed as `task <target> EXTRA_BUILD_TAGS=x`.

## Related issues

Fixes #3958.

## Test plan

- [x] Both arches compile with the tag by default (`libopenvino_c` dlopen refs present), and `OPENVINO=false` reproduces the old stub (0 refs).
- [x] `readelf -d` shows no `NEEDED` entry for `libopenvino_c` on either arch, so the loader starts the binary on any host.
- [x] Clean-room: a Debian 13 and an Ubuntu container with **no** `libopenvino_c` installed run the tagged binary, boot healthy, and report `openvino: {supported: true, active: false}`. The default TFLite model runs on CPU; with `backend: openvino` forced on an ONNX model the app gracefully falls back to the ONNX Runtime with no crash.
- [x] Feature check: on a host with the OpenVINO 2026.2 runtime installed, the same binary reports `openvino: {supported: true, active: true, devices: ["CPU", "GPU"]}` and runs BirdNET v2.4 on the iGPU, matching what the reporter observed by swapping in the Docker binary.

Note for ONNX-backend users without OpenVINO installed: the tagged binary now emits a benign startup log line noting OpenVINO is unavailable and it is using the ONNX Runtime (the same message Docker images already produce on non-accelerated hosts). Default TFLite users see no change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux release builds by consistently applying OpenVINO settings and build tags.
  * Ensured optional build tags are handled correctly across standard and no-embed builds.
  * Made release build options more predictable when enabling or disabling OpenVINO support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->