### PR TITLE
docs: drop sunset Gemini Code Assist review references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ persistently flaky, raise it rather than patching around it.
 - Build system: Task (taskfile.dev)
 - Linting: golangci-lint (Go), npm run check:all (Frontend)
 - Testing: go test -race (Go), npm test (Frontend)
-- All PRs receive automated CodeRabbit and Gemini reviews
+- All PRs receive automated CodeRabbit reviews
 - API v1 is frozen; all new endpoints go in `internal/api/v2/`
 
 For detailed guidelines, see `CLAUDE.md` and the `CLAUDE.md` files in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,17 +149,15 @@ Full documentation in the birdnet-go-qa Forgejo wiki: `http://localhost:3000/tph
 
 ## PR Review Workflow
 
-After pushing updates to a PR, request automated reviews:
+Automated code review (CodeRabbit, plus the repo's configured review checks) runs on new PRs automatically and checks for bugs, security issues, and best practices. After pushing fixes, you can request a fresh CodeRabbit pass:
 
 ```bash
-# Request Gemini review
-gh pr comment <PR_NUMBER> --body "/gemini review"
+# Re-request a CodeRabbit review
+gh pr comment <PR_NUMBER> --body "@coderabbitai review"
 
 # Or from current branch
-gh pr comment $(gh pr view --json number -q .number) --body "/gemini review"
+gh pr comment $(gh pr view --json number -q .number) --body "@coderabbitai review"
 ```
-
-This triggers automated code review that checks for bugs, security issues, and best practices.
 
 ### Handling PR Review Comments
 


### PR DESCRIPTION
## Summary

Gemini Code Assist ceased operating on 2026-07-17, so the docs that tell contributors and agents to request a `/gemini review` and that claim PRs receive automated Gemini reviews are now stale and misleading.

This updates `CLAUDE.md`'s PR Review Workflow to point at CodeRabbit (the active automated reviewer, re-triggered with `@coderabbitai review`) and drops the dead Gemini mention in the `AGENTS.md` quick-facts list.

No behavior change; documentation only. The unrelated tool-agnostic mentions of "Gemini CLI" as one of several supported coding agents are left as-is.

## Test plan

- [x] `grep` confirms no `/gemini review` or `gemini-code-assist` references remain in tracked docs/workflows.