### PR TITLE
feat(audio): add per-stream RTSP media mode with full-stream default (#3953)

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -2468,6 +2468,10 @@
           "type": "string",
           "description": "Channel handling: downmix, left, or right"
         },
+        "mediaMode": {
+          "type": "string",
+          "description": "RTSP media request: auto, audio-only, or full-stream (ignored for non-RTSP)"
+        },
         "gain": {
           "type": "number",
           "description": "Input gain in dB (0 = no adjustment)"

--- a/frontend/src/lib/desktop/components/forms/StreamCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamCard.svelte
@@ -50,6 +50,7 @@
     EqualizerFilterType,
     QuietHoursConfig,
     ChannelMode,
+    MediaMode,
     ChannelAnalysis,
   } from '$lib/stores/settings';
   import {
@@ -61,7 +62,12 @@
   import StreamTestButton from './StreamTestButton.svelte';
   import StreamTimeline from './StreamTimeline.svelte';
   import StreamChannelControls from './StreamChannelControls.svelte';
-  import { streamTypeOptions, transportOptions, analyzeStreamChannels } from './streamOptions';
+  import {
+    streamTypeOptions,
+    transportOptions,
+    getMediaModeOptions,
+    analyzeStreamChannels,
+  } from './streamOptions';
   import { normalizeChannelMode } from './streamChannel';
 
   interface LocalEqualizerSettings {
@@ -199,6 +205,8 @@
   let showDeleteConfirm = $state(false);
   let showEqualizer = $state(false);
   let editChannelMode = $state<ChannelMode>('downmix');
+  // Default matches the backend default (empty = full-stream).
+  let editMediaMode = $state<MediaMode>('full-stream');
   let isAnalyzing = $state(false);
   let analysisResult = $state<ChannelAnalysis | null>(null);
   let analysisError = $state<string | null>(null);
@@ -315,11 +323,16 @@
   let showTransport = $derived(stream.type === 'rtsp' || stream.type === 'rtmp');
   let showTransportInEdit = $derived(editStreamType === 'rtsp' || editStreamType === 'rtmp');
 
+  // Media mode only affects the RTSP handshake, so it is RTSP-only.
+  let showMediaModeInEdit = $derived(editStreamType === 'rtsp');
+
   function startEdit() {
     editName = stream.name;
     editUrl = stream.url;
     editTransport = stream.transport ?? 'tcp';
     editChannelMode = normalizeChannelMode(stream.channelMode);
+    // Empty/unset media mode is the full-stream default.
+    editMediaMode = stream.mediaMode ?? 'full-stream';
     editStreamType = stream.type;
     editEnabled = stream.enabled;
     editGain = stream.gain ?? 0;
@@ -372,6 +385,8 @@
         channelMode: editChannelMode,
         // Use selected transport for RTSP/RTMP, omit for others
         ...(showTransportInEdit ? { transport: editTransport } : {}),
+        // Media mode is RTSP-only; omit for other stream types so it is not persisted where it has no effect.
+        ...(showMediaModeInEdit ? { mediaMode: editMediaMode } : {}),
         gain: editGain,
         equalizer: transformedEqualizer,
         quietHours: editQuietHours,
@@ -568,6 +583,23 @@
             </div>
           {/if}
         </div>
+
+        <!-- RTSP media mode: audio-only handshake, full stream, or auto fallback -->
+        {#if showMediaModeInEdit}
+          <div>
+            <SelectDropdown
+              value={editMediaMode}
+              label={t('settings.audio.streams.mediaModeLabel')}
+              options={getMediaModeOptions()}
+              onChange={value => (editMediaMode = value as MediaMode)}
+              groupBy={false}
+              menuSize="sm"
+            />
+            <p class="text-xs text-[var(--color-base-content)]/70 mt-1">
+              {t('settings.audio.streams.mediaModeHelp')}
+            </p>
+          </div>
+        {/if}
 
         <!-- Channel handling: format display, selector, and stereo analysis -->
         <StreamChannelControls
@@ -781,6 +813,19 @@
                 class="px-2 py-0.5 rounded text-xs font-mono font-semibold bg-[var(--color-info)]/15 text-[var(--color-info)]"
                 >R</span
               >
+            {/if}
+            {#if showTransport && stream.mediaMode === 'auto'}
+              <span
+                class="px-2 py-0.5 rounded text-xs font-semibold bg-[var(--color-secondary)]/15 text-[var(--color-secondary)]"
+              >
+                {t('settings.audio.streams.mediaMode.auto')}
+              </span>
+            {:else if showTransport && stream.mediaMode === 'audio-only'}
+              <span
+                class="px-2 py-0.5 rounded text-xs font-semibold bg-[var(--color-secondary)]/15 text-[var(--color-secondary)]"
+              >
+                {t('settings.audio.streams.mediaMode.audioOnly')}
+              </span>
             {/if}
           </div>
 

--- a/frontend/src/lib/desktop/components/forms/StreamCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamCard.svelte
@@ -590,14 +590,12 @@
             <SelectDropdown
               value={editMediaMode}
               label={t('settings.audio.streams.mediaModeLabel')}
+              helpText={t('settings.audio.streams.mediaModeHelp')}
               options={getMediaModeOptions()}
               onChange={value => (editMediaMode = value as MediaMode)}
               groupBy={false}
               menuSize="sm"
             />
-            <p class="text-xs text-[var(--color-base-content)]/70 mt-1">
-              {t('settings.audio.streams.mediaModeHelp')}
-            </p>
           </div>
         {/if}
 
@@ -814,13 +812,13 @@
                 >R</span
               >
             {/if}
-            {#if showTransport && stream.mediaMode === 'auto'}
+            {#if stream.type === 'rtsp' && stream.mediaMode === 'auto'}
               <span
                 class="px-2 py-0.5 rounded text-xs font-semibold bg-[var(--color-secondary)]/15 text-[var(--color-secondary)]"
               >
                 {t('settings.audio.streams.mediaMode.auto')}
               </span>
-            {:else if showTransport && stream.mediaMode === 'audio-only'}
+            {:else if stream.type === 'rtsp' && stream.mediaMode === 'audio-only'}
               <span
                 class="px-2 py-0.5 rounded text-xs font-semibold bg-[var(--color-secondary)]/15 text-[var(--color-secondary)]"
               >

--- a/frontend/src/lib/desktop/components/forms/streamOptions.ts
+++ b/frontend/src/lib/desktop/components/forms/streamOptions.ts
@@ -23,6 +23,14 @@ export function getChannelModeOptions() {
   ];
 }
 
+export function getMediaModeOptions() {
+  return [
+    { value: 'full-stream', label: t('settings.audio.streams.mediaMode.fullStream') },
+    { value: 'auto', label: t('settings.audio.streams.mediaMode.auto') },
+    { value: 'audio-only', label: t('settings.audio.streams.mediaMode.audioOnly') },
+  ];
+}
+
 export async function analyzeStreamChannels(url: string): Promise<ChannelAnalysis> {
   return api.post<ChannelAnalysis>('/api/v2/streams/analyze-channels', {
     url: url.trim(),

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -2506,6 +2506,11 @@ export type TranslationKey =
   | 'settings.audio.streams.typeLabel'
   | 'settings.audio.streams.typeHelp'
   | 'settings.audio.streams.transportLabel'
+  | 'settings.audio.streams.mediaModeLabel'
+  | 'settings.audio.streams.mediaModeHelp'
+  | 'settings.audio.streams.mediaMode.auto'
+  | 'settings.audio.streams.mediaMode.audioOnly'
+  | 'settings.audio.streams.mediaMode.fullStream'
   | 'settings.audio.streams.summary' // params: count
   | 'settings.audio.streams.healthy'
   | 'settings.audio.streams.unhealthy'

--- a/frontend/src/lib/stores/settings.ts
+++ b/frontend/src/lib/stores/settings.ts
@@ -191,6 +191,8 @@ export type StreamType = (typeof StreamTypes)[keyof typeof StreamTypes];
 
 export type ChannelMode = 'downmix' | 'left' | 'right';
 
+export type MediaMode = 'auto' | 'audio-only' | 'full-stream';
+
 // QuietHoursConfig represents quiet hours configuration for a stream or sound card
 export interface QuietHoursConfig {
   enabled: boolean;
@@ -223,6 +225,7 @@ export interface StreamConfig {
   type: StreamType; // Stream type: rtsp, http, hls, rtmp, udp
   transport?: 'tcp' | 'udp'; // Transport protocol (for RTSP/RTMP only)
   channelMode?: ChannelMode; // Channel selection mode: downmix, left, or right
+  mediaMode?: MediaMode; // RTSP media request: auto, audio-only, or full-stream (empty = full-stream)
   models?: string[]; // Model IDs for this stream (e.g., ["birdnet", "perch_v2"])
   equalizer?: EqualizerSettings; // Per-stream EQ (undefined = use global)
   quietHours?: QuietHoursConfig; // Quiet hours configuration

--- a/frontend/src/lib/utils/settingsCoercion.test.ts
+++ b/frontend/src/lib/utils/settingsCoercion.test.ts
@@ -142,4 +142,26 @@ describe('settingsCoercion realtime rtsp streams', () => {
 
     expect(result.rtsp.streams[0]?.gain).toBeUndefined();
   });
+
+  it('preserves valid media modes', () => {
+    for (const mode of ['auto', 'audio-only', 'full-stream']) {
+      const result = coerceSettings('realtime', {
+        rtsp: {
+          streams: [{ name: 'Cam', url: 'rtsp://cam7', type: 'rtsp', mediaMode: mode }],
+        },
+      }) as { rtsp: { streams: Array<Record<string, unknown>> } };
+
+      expect(result.rtsp.streams[0]?.mediaMode).toBe(mode);
+    }
+  });
+
+  it('drops an invalid media mode', () => {
+    const result = coerceSettings('realtime', {
+      rtsp: {
+        streams: [{ name: 'Cam', url: 'rtsp://cam8', type: 'rtsp', mediaMode: 'video-only' }],
+      },
+    }) as { rtsp: { streams: Array<Record<string, unknown>> } };
+
+    expect(result.rtsp.streams[0]?.mediaMode).toBeUndefined();
+  });
 });

--- a/frontend/src/lib/utils/settingsCoercion.ts
+++ b/frontend/src/lib/utils/settingsCoercion.ts
@@ -188,6 +188,12 @@ function coerceStreamConfig(stream: unknown): UnknownSettings {
       rawStream.transport === 'udp' || rawStream.transport === 'tcp'
         ? rawStream.transport
         : undefined,
+    mediaMode:
+      rawStream.mediaMode === 'auto' ||
+      rawStream.mediaMode === 'audio-only' ||
+      rawStream.mediaMode === 'full-stream'
+        ? rawStream.mediaMode
+        : undefined,
   };
 
   // Clamp gain to the same -40..+40 dB range as sound card gain (backend

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -3464,12 +3464,12 @@
         "typeLabel": "Typ streamu",
         "typeHelp": "Protokol streamu – automaticky zjištěn z URL",
         "transportLabel": "Protokol",
-        "mediaModeLabel": "Media Mode",
-        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaModeLabel": "Režim média",
+        "mediaModeHelp": "Úplný stream požaduje zvuk i video (video se po dekódování zahodí) a funguje s většinou kamer. Auto nejprve zkusí pouze zvuk a přepne se na úplný stream, pokud kamera nedokáže poskytnout samotný zvuk. Pouze zvuk nikdy neobsadí video slot kamery, ale selže, pokud kamera nedokáže poskytnout zvukovou stopu samostatně.",
         "mediaMode": {
           "auto": "Auto",
-          "audioOnly": "Audio only",
-          "fullStream": "Full stream"
+          "audioOnly": "Pouze zvuk",
+          "fullStream": "Úplný stream"
         },
         "summary": "Nakonfigurováno {count} streamů",
         "healthy": "v pořádku",

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -3464,6 +3464,13 @@
         "typeLabel": "Typ streamu",
         "typeHelp": "Protokol streamu – automaticky zjištěn z URL",
         "transportLabel": "Protokol",
+        "mediaModeLabel": "Media Mode",
+        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaMode": {
+          "auto": "Auto",
+          "audioOnly": "Audio only",
+          "fullStream": "Full stream"
+        },
         "summary": "Nakonfigurováno {count} streamů",
         "healthy": "v pořádku",
         "unhealthy": "v nepořádku",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -3464,12 +3464,12 @@
         "typeLabel": "Strømtype",
         "typeHelp": "Strømprotokol - registreres automatisk fra URL",
         "transportLabel": "Protokol",
-        "mediaModeLabel": "Media Mode",
-        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaModeLabel": "Medietilstand",
+        "mediaModeHelp": "Fuld stream anmoder om både lyd og video (videoen kasseres efter afkodning) og fungerer med de fleste kameraer. Auto prøver kun lyd først og skifter til fuld stream, hvis kameraet ikke kan levere lyd alene. Kun lyd åbner aldrig en videoplads på kameraet, men mislykkes, hvis kameraet ikke kan levere lydsporet selv.",
         "mediaMode": {
           "auto": "Auto",
-          "audioOnly": "Audio only",
-          "fullStream": "Full stream"
+          "audioOnly": "Kun lyd",
+          "fullStream": "Fuld stream"
         },
         "summary": "{count} strøm(me) konfigureret",
         "healthy": "sund",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -3464,6 +3464,13 @@
         "typeLabel": "Strømtype",
         "typeHelp": "Strømprotokol - registreres automatisk fra URL",
         "transportLabel": "Protokol",
+        "mediaModeLabel": "Media Mode",
+        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaMode": {
+          "auto": "Auto",
+          "audioOnly": "Audio only",
+          "fullStream": "Full stream"
+        },
         "summary": "{count} strøm(me) konfigureret",
         "healthy": "sund",
         "unhealthy": "usund",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -3464,6 +3464,13 @@
         "typeLabel": "Stream-Typ",
         "typeHelp": "Stream-Protokoll - automatisch aus URL erkannt",
         "transportLabel": "Protokoll",
+        "mediaModeLabel": "Media Mode",
+        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaMode": {
+          "auto": "Auto",
+          "audioOnly": "Audio only",
+          "fullStream": "Full stream"
+        },
         "summary": "{count} Stream(s) konfiguriert",
         "healthy": "gesund",
         "unhealthy": "fehlerhaft",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -3464,12 +3464,12 @@
         "typeLabel": "Stream-Typ",
         "typeHelp": "Stream-Protokoll - automatisch aus URL erkannt",
         "transportLabel": "Protokoll",
-        "mediaModeLabel": "Media Mode",
-        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaModeLabel": "Medienmodus",
+        "mediaModeHelp": "Der vollständige Stream fordert Audio und Video an (Video wird nach dem Dekodieren verworfen) und funktioniert mit den meisten Kameras. Auto versucht zuerst nur Audio und wechselt zum vollständigen Stream, wenn die Kamera kein Audio allein liefern kann. Nur Audio belegt nie einen Video-Slot der Kamera, schlägt aber fehl, wenn die Kamera die Audiospur nicht eigenständig liefern kann.",
         "mediaMode": {
           "auto": "Auto",
-          "audioOnly": "Audio only",
-          "fullStream": "Full stream"
+          "audioOnly": "Nur Audio",
+          "fullStream": "Vollständiger Stream"
         },
         "summary": "{count} Stream(s) konfiguriert",
         "healthy": "gesund",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -3464,6 +3464,13 @@
         "typeLabel": "Stream Type",
         "typeHelp": "Stream protocol - auto-detected from URL",
         "transportLabel": "Protocol",
+        "mediaModeLabel": "Media Mode",
+        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaMode": {
+          "auto": "Auto",
+          "audioOnly": "Audio only",
+          "fullStream": "Full stream"
+        },
         "summary": "{count} stream(s) configured",
         "healthy": "healthy",
         "unhealthy": "unhealthy",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -3464,12 +3464,12 @@
         "typeLabel": "Tipo de Stream",
         "typeHelp": "Protocolo del stream - detectado automáticamente de la URL",
         "transportLabel": "Protocolo",
-        "mediaModeLabel": "Media Mode",
-        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaModeLabel": "Modo de medios",
+        "mediaModeHelp": "El flujo completo solicita audio y vídeo (el vídeo se descarta tras la decodificación) y funciona con la mayoría de las cámaras. Auto intenta primero solo audio y recurre al flujo completo si la cámara no puede entregar audio por sí sola. Solo audio nunca ocupa una ranura de vídeo de la cámara, pero falla si la cámara no puede entregar la pista de audio por sí misma.",
         "mediaMode": {
           "auto": "Auto",
-          "audioOnly": "Audio only",
-          "fullStream": "Full stream"
+          "audioOnly": "Solo audio",
+          "fullStream": "Flujo completo"
         },
         "summary": "{count} stream(s) configurado(s)",
         "healthy": "saludable",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -3464,6 +3464,13 @@
         "typeLabel": "Tipo de Stream",
         "typeHelp": "Protocolo del stream - detectado automáticamente de la URL",
         "transportLabel": "Protocolo",
+        "mediaModeLabel": "Media Mode",
+        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaMode": {
+          "auto": "Auto",
+          "audioOnly": "Audio only",
+          "fullStream": "Full stream"
+        },
         "summary": "{count} stream(s) configurado(s)",
         "healthy": "saludable",
         "unhealthy": "con errores",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -3464,6 +3464,13 @@
         "typeLabel": "Striimin tyyppi",
         "typeHelp": "Striimin protokolla - tunnistetaan automaattisesti URL:sta",
         "transportLabel": "Protokolla",
+        "mediaModeLabel": "Media Mode",
+        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaMode": {
+          "auto": "Auto",
+          "audioOnly": "Audio only",
+          "fullStream": "Full stream"
+        },
         "summary": "{count} striimi(ä) määritetty",
         "healthy": "kunnossa",
         "unhealthy": "viallinen",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -3464,12 +3464,12 @@
         "typeLabel": "Striimin tyyppi",
         "typeHelp": "Striimin protokolla - tunnistetaan automaattisesti URL:sta",
         "transportLabel": "Protokolla",
-        "mediaModeLabel": "Media Mode",
-        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaModeLabel": "Mediatila",
+        "mediaModeHelp": "Täysi striimi pyytää sekä ääntä että videota (video hylätään dekoodauksen jälkeen) ja toimii useimpien kameroiden kanssa. Automaattinen yrittää ensin pelkkää ääntä ja siirtyy täyteen striimiin, jos kamera ei pysty toimittamaan pelkkää ääntä. Vain ääni ei koskaan varaa kameran videopaikkaa, mutta epäonnistuu, jos kamera ei pysty toimittamaan ääniraitaa itsenäisesti.",
         "mediaMode": {
-          "auto": "Auto",
-          "audioOnly": "Audio only",
-          "fullStream": "Full stream"
+          "auto": "Automaattinen",
+          "audioOnly": "Vain ääni",
+          "fullStream": "Täysi striimi"
         },
         "summary": "{count} striimi(ä) määritetty",
         "healthy": "kunnossa",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -3464,6 +3464,13 @@
         "typeLabel": "Type de Flux",
         "typeHelp": "Protocole du flux - détecté automatiquement depuis l'URL",
         "transportLabel": "Protocole",
+        "mediaModeLabel": "Media Mode",
+        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaMode": {
+          "auto": "Auto",
+          "audioOnly": "Audio only",
+          "fullStream": "Full stream"
+        },
         "summary": "{count} flux configuré(s)",
         "healthy": "sain",
         "unhealthy": "défaillant",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -3464,12 +3464,12 @@
         "typeLabel": "Type de Flux",
         "typeHelp": "Protocole du flux - détecté automatiquement depuis l'URL",
         "transportLabel": "Protocole",
-        "mediaModeLabel": "Media Mode",
-        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaModeLabel": "Mode multimédia",
+        "mediaModeHelp": "Le flux complet demande l'audio et la vidéo (la vidéo est ignorée après décodage) et fonctionne avec la plupart des caméras. Auto essaie d'abord l'audio seul et bascule vers le flux complet si la caméra ne peut pas fournir l'audio seul. Audio uniquement n'ouvre jamais d'emplacement vidéo sur la caméra mais échoue si la caméra ne peut pas fournir la piste audio par elle-même.",
         "mediaMode": {
           "auto": "Auto",
-          "audioOnly": "Audio only",
-          "fullStream": "Full stream"
+          "audioOnly": "Audio uniquement",
+          "fullStream": "Flux complet"
         },
         "summary": "{count} flux configuré(s)",
         "healthy": "sain",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -3464,12 +3464,12 @@
         "typeLabel": "Stream típus",
         "typeHelp": "Stream protokoll - automatikusan észlelve az URL-ből",
         "transportLabel": "Protokoll",
-        "mediaModeLabel": "Media Mode",
-        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaModeLabel": "Médiamód",
+        "mediaModeHelp": "A teljes adatfolyam hangot és videót is kér (a videót dekódolás után eldobja), és a legtöbb kamerával működik. Az Auto először csak hanggal próbálkozik, és a teljes adatfolyamra vált, ha a kamera nem tud önmagában hangot szolgáltatni. A csak hang soha nem foglal le videohelyet a kamerán, de sikertelen, ha a kamera nem tudja önállóan szolgáltatni a hangsávot.",
         "mediaMode": {
           "auto": "Auto",
-          "audioOnly": "Audio only",
-          "fullStream": "Full stream"
+          "audioOnly": "Csak hang",
+          "fullStream": "Teljes adatfolyam"
         },
         "summary": "{count} stream konfigurálva",
         "healthy": "egészséges",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -3464,6 +3464,13 @@
         "typeLabel": "Stream típus",
         "typeHelp": "Stream protokoll - automatikusan észlelve az URL-ből",
         "transportLabel": "Protokoll",
+        "mediaModeLabel": "Media Mode",
+        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaMode": {
+          "auto": "Auto",
+          "audioOnly": "Audio only",
+          "fullStream": "Full stream"
+        },
         "summary": "{count} stream konfigurálva",
         "healthy": "egészséges",
         "unhealthy": "nem egészséges",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -3464,12 +3464,12 @@
         "typeLabel": "Tipo Flusso",
         "typeHelp": "Protocollo flusso - rilevato automaticamente da URL",
         "transportLabel": "Protocollo",
-        "mediaModeLabel": "Media Mode",
-        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaModeLabel": "Modalità multimediale",
+        "mediaModeHelp": "Il flusso completo richiede audio e video (il video viene scartato dopo la decodifica) e funziona con la maggior parte delle telecamere. Auto prova prima solo l'audio e passa al flusso completo se la telecamera non è in grado di fornire solo l'audio. Solo audio non occupa mai uno slot video della telecamera, ma fallisce se la telecamera non è in grado di fornire la traccia audio da sola.",
         "mediaMode": {
           "auto": "Auto",
-          "audioOnly": "Audio only",
-          "fullStream": "Full stream"
+          "audioOnly": "Solo audio",
+          "fullStream": "Flusso completo"
         },
         "summary": "{count} flusso/i configurato/i",
         "healthy": "sano",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -3464,6 +3464,13 @@
         "typeLabel": "Tipo Flusso",
         "typeHelp": "Protocollo flusso - rilevato automaticamente da URL",
         "transportLabel": "Protocollo",
+        "mediaModeLabel": "Media Mode",
+        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaMode": {
+          "auto": "Auto",
+          "audioOnly": "Audio only",
+          "fullStream": "Full stream"
+        },
         "summary": "{count} flusso/i configurato/i",
         "healthy": "sano",
         "unhealthy": "insalubre",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -3464,12 +3464,12 @@
         "typeLabel": "Straumes tips",
         "typeHelp": "Straumes protokols — automātiski noteikts no URL",
         "transportLabel": "Protokols",
-        "mediaModeLabel": "Media Mode",
-        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaModeLabel": "Multivides režīms",
+        "mediaModeHelp": "Pilnā straume pieprasa gan audio, gan video (video pēc dekodēšanas tiek atmests) un darbojas ar lielāko daļu kameru. Auto vispirms mēģina tikai audio un pārslēdzas uz pilno straumi, ja kamera nevar nodrošināt tikai audio. Tikai audio nekad neaizņem kameras video slotu, bet neizdodas, ja kamera nevar patstāvīgi nodrošināt audio celiņu.",
         "mediaMode": {
           "auto": "Auto",
-          "audioOnly": "Audio only",
-          "fullStream": "Full stream"
+          "audioOnly": "Tikai audio",
+          "fullStream": "Pilna straume"
         },
         "summary": "{count} straume(-es) konfigurēta(-as)",
         "healthy": "veselīga",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -3464,6 +3464,13 @@
         "typeLabel": "Straumes tips",
         "typeHelp": "Straumes protokols — automātiski noteikts no URL",
         "transportLabel": "Protokols",
+        "mediaModeLabel": "Media Mode",
+        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaMode": {
+          "auto": "Auto",
+          "audioOnly": "Audio only",
+          "fullStream": "Full stream"
+        },
         "summary": "{count} straume(-es) konfigurēta(-as)",
         "healthy": "veselīga",
         "unhealthy": "neveselīga",

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -3464,12 +3464,12 @@
         "typeLabel": "Strømtype",
         "typeHelp": "Strømprotokoll – automatisk detektert fra URL",
         "transportLabel": "Protokoll",
-        "mediaModeLabel": "Media Mode",
-        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaModeLabel": "Mediemodus",
+        "mediaModeHelp": "Full strøm ber om både lyd og video (videoen forkastes etter dekoding) og fungerer med de fleste kameraer. Auto prøver kun lyd først og bytter til full strøm hvis kameraet ikke kan levere lyd alene. Kun lyd åpner aldri en videoplass på kameraet, men mislykkes hvis kameraet ikke kan levere lydsporet på egen hånd.",
         "mediaMode": {
           "auto": "Auto",
-          "audioOnly": "Audio only",
-          "fullStream": "Full stream"
+          "audioOnly": "Kun lyd",
+          "fullStream": "Full strøm"
         },
         "summary": "{count} strøm(mer) konfigurert",
         "healthy": "sunn",

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -3464,6 +3464,13 @@
         "typeLabel": "Strømtype",
         "typeHelp": "Strømprotokoll – automatisk detektert fra URL",
         "transportLabel": "Protokoll",
+        "mediaModeLabel": "Media Mode",
+        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaMode": {
+          "auto": "Auto",
+          "audioOnly": "Audio only",
+          "fullStream": "Full stream"
+        },
         "summary": "{count} strøm(mer) konfigurert",
         "healthy": "sunn",
         "unhealthy": "usunn",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -3464,6 +3464,13 @@
         "typeLabel": "Streamtype",
         "typeHelp": "Streamprotocol - automatisch gedetecteerd uit URL",
         "transportLabel": "Protocol",
+        "mediaModeLabel": "Media Mode",
+        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaMode": {
+          "auto": "Auto",
+          "audioOnly": "Audio only",
+          "fullStream": "Full stream"
+        },
         "summary": "{count} stream(s) geconfigureerd",
         "healthy": "gezond",
         "unhealthy": "ongezond",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -3464,12 +3464,12 @@
         "typeLabel": "Streamtype",
         "typeHelp": "Streamprotocol - automatisch gedetecteerd uit URL",
         "transportLabel": "Protocol",
-        "mediaModeLabel": "Media Mode",
-        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaModeLabel": "Mediamodus",
+        "mediaModeHelp": "Volledige stream vraagt om audio en video (video wordt na het decoderen weggegooid) en werkt met de meeste camera's. Auto probeert eerst alleen audio en schakelt over naar de volledige stream als de camera geen audio alleen kan leveren. Alleen audio opent nooit een videoslot van de camera, maar mislukt als de camera het audiospoor niet zelfstandig kan leveren.",
         "mediaMode": {
           "auto": "Auto",
-          "audioOnly": "Audio only",
-          "fullStream": "Full stream"
+          "audioOnly": "Alleen audio",
+          "fullStream": "Volledige stream"
         },
         "summary": "{count} stream(s) geconfigureerd",
         "healthy": "gezond",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -3464,6 +3464,13 @@
         "typeLabel": "Typ Strumienia",
         "typeHelp": "Protokół strumienia - wykrywany automatycznie z URL",
         "transportLabel": "Protokół",
+        "mediaModeLabel": "Media Mode",
+        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaMode": {
+          "auto": "Auto",
+          "audioOnly": "Audio only",
+          "fullStream": "Full stream"
+        },
         "summary": "{count} strumień(i) skonfigurowany(ch)",
         "healthy": "sprawny",
         "unhealthy": "niesprawny",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -3464,12 +3464,12 @@
         "typeLabel": "Typ Strumienia",
         "typeHelp": "Protokół strumienia - wykrywany automatycznie z URL",
         "transportLabel": "Protokół",
-        "mediaModeLabel": "Media Mode",
-        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaModeLabel": "Tryb multimediów",
+        "mediaModeHelp": "Pełny strumień żąda audio i wideo (wideo jest odrzucane po dekodowaniu) i działa z większością kamer. Auto najpierw próbuje tylko audio, a jeśli kamera nie może dostarczyć samego audio, przełącza się na pełny strumień. Tylko audio nigdy nie zajmuje gniazda wideo kamery, ale kończy się niepowodzeniem, jeśli kamera nie może samodzielnie dostarczyć ścieżki audio.",
         "mediaMode": {
           "auto": "Auto",
-          "audioOnly": "Audio only",
-          "fullStream": "Full stream"
+          "audioOnly": "Tylko audio",
+          "fullStream": "Pełny strumień"
         },
         "summary": "{count} strumień(i) skonfigurowany(ch)",
         "healthy": "sprawny",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -3464,6 +3464,13 @@
         "typeLabel": "Tipo de Stream",
         "typeHelp": "Protocolo do stream - detectado automaticamente da URL",
         "transportLabel": "Protocolo",
+        "mediaModeLabel": "Media Mode",
+        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaMode": {
+          "auto": "Auto",
+          "audioOnly": "Audio only",
+          "fullStream": "Full stream"
+        },
         "summary": "{count} stream(s) configurado(s)",
         "healthy": "saudável",
         "unhealthy": "com falha",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -3464,12 +3464,12 @@
         "typeLabel": "Tipo de Stream",
         "typeHelp": "Protocolo do stream - detectado automaticamente da URL",
         "transportLabel": "Protocolo",
-        "mediaModeLabel": "Media Mode",
-        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaModeLabel": "Modo de mídia",
+        "mediaModeHelp": "O fluxo completo solicita áudio e vídeo (o vídeo é descartado após a decodificação) e funciona com a maioria das câmeras. Auto tenta primeiro apenas áudio e recorre ao fluxo completo se a câmera não conseguir fornecer áudio sozinha. Apenas áudio nunca ocupa um slot de vídeo da câmera, mas falha se a câmera não conseguir fornecer a faixa de áudio por conta própria.",
         "mediaMode": {
           "auto": "Auto",
-          "audioOnly": "Audio only",
-          "fullStream": "Full stream"
+          "audioOnly": "Apenas áudio",
+          "fullStream": "Fluxo completo"
         },
         "summary": "{count} stream(s) configurado(s)",
         "healthy": "saudável",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -3464,6 +3464,13 @@
         "typeLabel": "Typ streamu",
         "typeHelp": "Protokol streamu - automaticky zistený z URL",
         "transportLabel": "Protokol",
+        "mediaModeLabel": "Media Mode",
+        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaMode": {
+          "auto": "Auto",
+          "audioOnly": "Audio only",
+          "fullStream": "Full stream"
+        },
         "summary": "{count} nakonfigurovaných streamov",
         "healthy": "zdravý",
         "unhealthy": "nezdravý",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -3464,12 +3464,12 @@
         "typeLabel": "Typ streamu",
         "typeHelp": "Protokol streamu - automaticky zistený z URL",
         "transportLabel": "Protokol",
-        "mediaModeLabel": "Media Mode",
-        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaModeLabel": "Režim média",
+        "mediaModeHelp": "Úplný stream požaduje zvuk aj video (video sa po dekódovaní zahodí) a funguje s väčšinou kamier. Auto najprv skúsi iba zvuk a prepne sa na úplný stream, ak kamera nedokáže poskytnúť samotný zvuk. Iba zvuk nikdy neobsadí video slot kamery, ale zlyhá, ak kamera nedokáže poskytnúť zvukovú stopu samostatne.",
         "mediaMode": {
           "auto": "Auto",
-          "audioOnly": "Audio only",
-          "fullStream": "Full stream"
+          "audioOnly": "Iba zvuk",
+          "fullStream": "Úplný stream"
         },
         "summary": "{count} nakonfigurovaných streamov",
         "healthy": "zdravý",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -3464,6 +3464,13 @@
         "typeLabel": "Strömtyp",
         "typeHelp": "Strömprotokoll - identifieras automatiskt från URL",
         "transportLabel": "Protokoll",
+        "mediaModeLabel": "Media Mode",
+        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaMode": {
+          "auto": "Auto",
+          "audioOnly": "Audio only",
+          "fullStream": "Full stream"
+        },
         "summary": "{count} ström(mar) konfigurerade",
         "healthy": "frisk",
         "unhealthy": "ohälsosam",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -3464,12 +3464,12 @@
         "typeLabel": "Strömtyp",
         "typeHelp": "Strömprotokoll - identifieras automatiskt från URL",
         "transportLabel": "Protokoll",
-        "mediaModeLabel": "Media Mode",
-        "mediaModeHelp": "Full stream requests audio and video (video is discarded after decode) and works with the widest range of cameras. Auto tries audio-only first and falls back to the full stream if the camera cannot deliver audio alone. Audio-only never opens a camera video slot but fails if the camera cannot deliver the audio track by itself.",
+        "mediaModeLabel": "Medieläge",
+        "mediaModeHelp": "Full ström begär både ljud och video (videon kasseras efter avkodning) och fungerar med de flesta kameror. Auto försöker med endast ljud först och växlar till full ström om kameran inte kan leverera ljud ensamt. Endast ljud öppnar aldrig en videoplats på kameran men misslyckas om kameran inte kan leverera ljudspåret på egen hand.",
         "mediaMode": {
           "auto": "Auto",
-          "audioOnly": "Audio only",
-          "fullStream": "Full stream"
+          "audioOnly": "Endast ljud",
+          "fullStream": "Full ström"
         },
         "summary": "{count} ström(mar) konfigurerade",
         "healthy": "frisk",

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -1045,11 +1045,18 @@ func sourceNeedsReconfigure(running *audiocore.AudioSource, desired *audiocore.S
 	// needlessly restart the stream.
 	channelModeChanged := conf.ChannelMode(running.ChannelMode).Canonical() !=
 		conf.ChannelMode(desired.ChannelMode).Canonical()
+	// Compare canonical media modes so an unset value and an explicit default
+	// (which build identical FFmpeg args) are not treated as a change. Without
+	// this, a mediaMode-only edit would persist to disk but never restart the
+	// running FFmpeg, silently breaking hot-reload.
+	mediaModeChanged := conf.MediaMode(running.MediaMode).Canonical() !=
+		conf.MediaMode(desired.MediaMode).Canonical()
 	return running.SampleRate != desired.SampleRate ||
 		sourceSampleRateChanged ||
 		running.BitDepth != desired.BitDepth ||
 		running.Channels != desired.Channels ||
 		channelModeChanged ||
+		mediaModeChanged ||
 		sourceChannelsChanged
 }
 
@@ -1379,6 +1386,7 @@ func (p *AudioPipelineService) buildSourceConfigsWithModels() []sourceConfigWith
 				Channels:         1,
 				SourceChannels:   probe.channels,
 				ChannelMode:      string(stream.ChannelMode),
+				MediaMode:        string(stream.MediaMode),
 				Gain:             stream.Gain,
 			},
 			modelIDs: stream.Models,

--- a/internal/analysis/source_config_diff_test.go
+++ b/internal/analysis/source_config_diff_test.go
@@ -110,6 +110,38 @@ func TestSourceNeedsReconfigure(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			// Unset and explicit "full-stream" produce identical FFmpeg args (the
+			// default is full-stream), so the transition must not restart the stream.
+			name: "media mode unset to full-stream is a no-op",
+			running: &audiocore.AudioSource{
+				SampleRate: 48000, BitDepth: 16, Channels: 1, MediaMode: "",
+			},
+			desired: &audiocore.SourceConfig{
+				SampleRate: 48000, BitDepth: 16, Channels: 1, MediaMode: string(conf.MediaModeFullStream),
+			},
+			expected: false,
+		},
+		{
+			name: "media mode full-stream to auto changes",
+			running: &audiocore.AudioSource{
+				SampleRate: 48000, BitDepth: 16, Channels: 1, MediaMode: string(conf.MediaModeFullStream),
+			},
+			desired: &audiocore.SourceConfig{
+				SampleRate: 48000, BitDepth: 16, Channels: 1, MediaMode: string(conf.MediaModeAuto),
+			},
+			expected: true,
+		},
+		{
+			name: "media mode unset to audio-only changes",
+			running: &audiocore.AudioSource{
+				SampleRate: 48000, BitDepth: 16, Channels: 1, MediaMode: "",
+			},
+			desired: &audiocore.SourceConfig{
+				SampleRate: 48000, BitDepth: 16, Channels: 1, MediaMode: string(conf.MediaModeAudioOnly),
+			},
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/api/v2/hotreload_coverage_test.go
+++ b/internal/api/v2/hotreload_coverage_test.go
@@ -166,6 +166,7 @@ var hotReloadRegistry = map[string]hotReloadEntry{
 	"Realtime.RTSP.Streams.*.Type":        {categories: []hotReloadCategory{hotReloadFresh}, action: "reconfigure_rtsp_sources"},
 	"Realtime.RTSP.Streams.*.Transport":   {categories: []hotReloadCategory{hotReloadFresh}, action: "reconfigure_rtsp_sources"},
 	"Realtime.RTSP.Streams.*.ChannelMode": {categories: []hotReloadCategory{hotReloadFresh}, action: "reconfigure_rtsp_sources"},
+	"Realtime.RTSP.Streams.*.MediaMode":   {categories: []hotReloadCategory{hotReloadFresh}, action: "reconfigure_rtsp_sources"},
 	"Realtime.RTSP.Streams.*.Gain":        {categories: []hotReloadCategory{hotReloadFresh}, action: "reconfigure_rtsp_sources"},
 	"Realtime.RTSP.Streams.*.Equalizer":   {categories: []hotReloadCategory{hotReloadFresh}},
 	"Realtime.RTSP.Streams.*.QuietHours":  {categories: []hotReloadCategory{hotReloadFresh}, action: "reconfigure_quiet_hours"},

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -2415,7 +2415,8 @@ func streamsSettingsChanged(oldSettings, currentSettings *conf.Settings) bool {
 		return true
 	}
 
-	// Check for changes in individual streams (name, URL, type, transport, channel mode, or models)
+	// Check for changes in individual streams (name, URL, type, transport, channel
+	// mode, media mode, or models)
 	for i := range oldRTSP.Streams {
 		if i >= len(newRTSP.Streams) {
 			return true
@@ -2428,6 +2429,7 @@ func streamsSettingsChanged(oldSettings, currentSettings *conf.Settings) bool {
 			oldStream.Type != newStream.Type ||
 			oldStream.Transport != newStream.Transport ||
 			oldStream.ChannelMode.Canonical() != newStream.ChannelMode.Canonical() ||
+			oldStream.MediaMode.Canonical() != newStream.MediaMode.Canonical() ||
 			!slices.Equal(oldStream.Models, newStream.Models) {
 			return true
 		}

--- a/internal/api/v2/settings_update_test.go
+++ b/internal/api/v2/settings_update_test.go
@@ -787,3 +787,49 @@ func TestStreamsSettingsChanged_ChannelMode(t *testing.T) {
 		})
 	}
 }
+
+// TestStreamsSettingsChanged_MediaMode verifies that a real media-mode edit
+// triggers reconfiguration while the no-op transition between the empty default
+// and its canonical form ("" <-> "full-stream") does NOT. Without canonical
+// comparison the first save after the frontend starts sending an explicit
+// "full-stream" would needlessly restart the stream.
+func TestStreamsSettingsChanged_MediaMode(t *testing.T) {
+	t.Parallel()
+
+	makeSettings := func(mode conf.MediaMode) *conf.Settings {
+		s := &conf.Settings{}
+		s.Realtime.RTSP.Streams = []conf.StreamConfig{{
+			Name:      "Front Yard",
+			URL:       "rtsp://192.168.1.10/stream",
+			Type:      conf.StreamTypeRTSP,
+			Transport: "tcp",
+			Enabled:   true,
+			MediaMode: mode,
+			Models:    []string{"birdnet"},
+		}}
+		return s
+	}
+
+	tests := []struct {
+		name string
+		old  conf.MediaMode
+		new  conf.MediaMode
+		want bool
+	}{
+		{"unset to explicit full-stream is a no-op", "", conf.MediaModeFullStream, false},
+		{"explicit full-stream to unset is a no-op", conf.MediaModeFullStream, "", false},
+		{"identical auto", conf.MediaModeAuto, conf.MediaModeAuto, false},
+		{"unset to auto changes", "", conf.MediaModeAuto, true},
+		{"full-stream to auto changes", conf.MediaModeFullStream, conf.MediaModeAuto, true},
+		{"auto to audio-only changes", conf.MediaModeAuto, conf.MediaModeAudioOnly, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			old := makeSettings(tc.old)
+			cur := makeSettings(tc.new)
+			assert.Equal(t, tc.want, streamsSettingsChanged(old, cur))
+		})
+	}
+}

--- a/internal/audiocore/engine/engine.go
+++ b/internal/audiocore/engine/engine.go
@@ -301,6 +301,7 @@ func (e *AudioEngine) StartStream(sourceID, url, transport string) error {
 		Channels:         channels,
 		SourceChannels:   src.SourceChannels,
 		ChannelMode:      src.ChannelMode,
+		MediaMode:        src.MediaMode,
 		FFmpegPath:       e.ffmpegPath,
 		Transport:        transport,
 		FFmpegParameters: e.ffmpegParameters,
@@ -438,6 +439,7 @@ func (e *AudioEngine) AddSource(cfg *audiocore.SourceConfig) error {
 			Channels:         channels,
 			SourceChannels:   cfg.SourceChannels,
 			ChannelMode:      cfg.ChannelMode,
+			MediaMode:        cfg.MediaMode,
 			FFmpegPath:       e.ffmpegPath,
 			Transport:        e.transport,
 			FFmpegParameters: e.ffmpegParameters,
@@ -643,6 +645,7 @@ func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.Sourc
 			Channels:         channels,
 			SourceChannels:   newCfg.SourceChannels,
 			ChannelMode:      newCfg.ChannelMode,
+			MediaMode:        newCfg.MediaMode,
 			FFmpegPath:       e.ffmpegPath,
 			Transport:        e.transport,
 			FFmpegParameters: e.ffmpegParameters,
@@ -677,7 +680,13 @@ func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.Sourc
 		}
 	}
 
-	// 6. Update registry so downstream consumers see the new audio params.
+	// 6. Update registry so downstream consumers see the new audio params. Sync the
+	// mode and source-shape fields first (ReconfigureSource does not re-register, so
+	// the registry otherwise keeps the values from add time), then UpdateAudioParams
+	// snapshots and emits the SourceReconfigured event with the fully updated entry.
+	// Without the sync, a channel/media-mode-only change re-triggers on every later
+	// reconfigure and restarts the stream indefinitely.
+	e.registry.SyncReconfiguredParams(sourceID, newCfg.ChannelMode, newCfg.MediaMode, newCfg.SourceSampleRate, newCfg.SourceChannels)
 	e.registry.UpdateAudioParams(sourceID, sampleRate, bitDepth, channels)
 
 	e.logger.Info("source reconfigured",

--- a/internal/audiocore/engine/engine.go
+++ b/internal/audiocore/engine/engine.go
@@ -686,8 +686,20 @@ func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.Sourc
 	// snapshots and emits the SourceReconfigured event with the fully updated entry.
 	// Without the sync, a channel/media-mode-only change re-triggers on every later
 	// reconfigure and restarts the stream indefinitely.
-	e.registry.SyncReconfiguredParams(sourceID, newCfg.ChannelMode, newCfg.MediaMode, newCfg.SourceSampleRate, newCfg.SourceChannels)
-	e.registry.UpdateAudioParams(sourceID, sampleRate, bitDepth, channels)
+	syncedModes := e.registry.SyncReconfiguredParams(sourceID, newCfg.ChannelMode, newCfg.MediaMode, newCfg.SourceSampleRate, newCfg.SourceChannels)
+	syncedParams := e.registry.UpdateAudioParams(sourceID, sampleRate, bitDepth, channels)
+	if !syncedModes || !syncedParams {
+		// The source was fetched at the top of this function and the reconfigure
+		// path is serialized, so a false here means the entry was unregistered
+		// concurrently: the registry keeps no updated config and no
+		// SourceReconfigured event fires, leaving downstream consumers with stale
+		// data. The stream itself already restarted above, so warn rather than fail.
+		e.logger.Warn("source missing from registry during reconfigure write-back; downstream config may be stale",
+			logger.String("source_id", sourceID),
+			logger.Bool("synced_modes", syncedModes),
+			logger.Bool("synced_params", syncedParams),
+			logger.String("operation", "reconfigure_source"))
+	}
 
 	e.logger.Info("source reconfigured",
 		logger.String("source_id", sourceID),

--- a/internal/audiocore/ffmpeg/process.go
+++ b/internal/audiocore/ffmpeg/process.go
@@ -502,10 +502,46 @@ func ProcessAudioToFile(ctx context.Context, filePath, ffmpegPath string, filter
 // RTSP-specific flags like -rtsp_transport are only added for RTSP sources.
 // A default -timeout is added unless the caller supplies one via ffmpegParameters.
 func BuildFFmpegArgs(cfg *StreamConfig, ffmpegParameters []string) []string {
-	// Audio-only restriction is on by default; the runtime path drops it per
-	// Stream via buildFFmpegInputArgs once a camera proves it cannot honor it.
-	args := buildInputArgs(cfg, ffmpegParameters, true)
+	// Represent the initial request (no reactive fallback engaged yet). The audio
+	// mode is decided by resolveAudioOnly so this mirror matches the runtime path
+	// (buildFFmpegInputArgs) under every media mode.
+	args := buildInputArgs(cfg, ffmpegParameters, resolveAudioOnly(cfg, false))
 	return buildOutputArgs(args, cfg)
+}
+
+// resolveAudioOnly reports whether the stream should request audio-only RTSP
+// media (-allowed_media_types audio). It is the single source of truth for that
+// decision, shared by the runtime path (Stream.buildFFmpegInputArgs) and the
+// unit-tested mirror (BuildFFmpegArgs), so the two cannot diverge.
+//
+// fallbackEngaged is consulted only in auto mode; audio-only and full-stream are
+// deterministic and ignore it. Empty/unknown modes canonicalize to the default
+// (full-stream).
+func resolveAudioOnly(cfg *StreamConfig, fallbackEngaged bool) bool {
+	switch conf.MediaMode(cfg.MediaMode).Canonical() {
+	case conf.MediaModeAudioOnly:
+		return true
+	case conf.MediaModeFullStream:
+		return false
+	case conf.MediaModeAuto:
+		// Audio-only first, dropping the restriction once the reactive fallback
+		// latches because the camera cannot deliver audio alone (issue #3902).
+		return !fallbackEngaged
+	default:
+		return false
+	}
+}
+
+// mediaModeAllowsFallback reports whether the reactive audio-only fallback may
+// engage for this stream. Only auto mode allows it; audio-only fails visibly
+// rather than falling back, and full-stream never requested audio-only at all.
+func mediaModeAllowsFallback(cfg *StreamConfig) bool {
+	return conf.MediaMode(cfg.MediaMode).Canonical() == conf.MediaModeAuto
+}
+
+// effectiveMediaMode returns the canonical media mode as a string, for logging.
+func effectiveMediaMode(cfg *StreamConfig) string {
+	return string(conf.MediaMode(cfg.MediaMode).Canonical())
 }
 
 // buildOutputArgs appends the post-input FFmpeg flags: the input URL, decode

--- a/internal/audiocore/ffmpeg/process.go
+++ b/internal/audiocore/ffmpeg/process.go
@@ -515,8 +515,9 @@ func BuildFFmpegArgs(cfg *StreamConfig, ffmpegParameters []string) []string {
 // unit-tested mirror (BuildFFmpegArgs), so the two cannot diverge.
 //
 // fallbackEngaged is consulted only in auto mode; audio-only and full-stream are
-// deterministic and ignore it. Empty/unknown modes canonicalize to the default
-// (full-stream).
+// deterministic and ignore it. An empty mode canonicalizes to the default
+// (full-stream); any other unrecognized value (rejected at config validation)
+// falls through to the default branch and is also treated as full-stream.
 func resolveAudioOnly(cfg *StreamConfig, fallbackEngaged bool) bool {
 	switch conf.MediaMode(cfg.MediaMode).Canonical() {
 	case conf.MediaModeAudioOnly:

--- a/internal/audiocore/ffmpeg/process_test.go
+++ b/internal/audiocore/ffmpeg/process_test.go
@@ -107,6 +107,34 @@ func TestBuildFFmpegArgs_MediaModes(t *testing.T) {
 	}
 }
 
+// TestResolveAudioOnly covers the media-mode decision helpers directly, including
+// the default branch for an invalid/unknown mode (which validation rejects but
+// which must still resolve to the safe full-stream default).
+func TestResolveAudioOnly(t *testing.T) {
+	t.Parallel()
+
+	cfg := func(mode string) *StreamConfig { return &StreamConfig{MediaMode: mode} }
+
+	// resolveAudioOnly: (mode, fallbackEngaged) -> audioOnly
+	assert.False(t, resolveAudioOnly(cfg(""), false), "empty defaults to full-stream")
+	assert.False(t, resolveAudioOnly(cfg("full-stream"), false))
+	assert.True(t, resolveAudioOnly(cfg("audio-only"), false))
+	assert.True(t, resolveAudioOnly(cfg("audio-only"), true), "audio-only ignores the latch")
+	assert.True(t, resolveAudioOnly(cfg("auto"), false), "auto requests audio-only before fallback")
+	assert.False(t, resolveAudioOnly(cfg("auto"), true), "auto drops audio-only after fallback")
+	assert.False(t, resolveAudioOnly(cfg("video-only"), false), "invalid mode falls through to full-stream default")
+
+	// mediaModeAllowsFallback: only auto allows the reactive fallback.
+	assert.True(t, mediaModeAllowsFallback(cfg("auto")))
+	assert.False(t, mediaModeAllowsFallback(cfg("audio-only")))
+	assert.False(t, mediaModeAllowsFallback(cfg("full-stream")))
+	assert.False(t, mediaModeAllowsFallback(cfg("")), "empty (full-stream default) does not allow fallback")
+
+	// effectiveMediaMode: canonical string for logging.
+	assert.Equal(t, "full-stream", effectiveMediaMode(cfg("")))
+	assert.Equal(t, "auto", effectiveMediaMode(cfg("auto")))
+}
+
 // TestBuildFFmpegArgs_HTTP verifies that BuildFFmpegArgs produces the correct
 // argument sequence for an HTTP stream source and does NOT include RTSP flags.
 func TestBuildFFmpegArgs_HTTP(t *testing.T) {

--- a/internal/audiocore/ffmpeg/process_test.go
+++ b/internal/audiocore/ffmpeg/process_test.go
@@ -24,6 +24,9 @@ func TestBuildFFmpegArgs_RTSP(t *testing.T) {
 		Channels:   1,
 		Transport:  "tcp",
 		LogLevel:   "error",
+		// Auto mode requests audio-only on the initial handshake (the default is
+		// now full-stream); see TestBuildFFmpegArgs_MediaModes for the full matrix.
+		MediaMode: "auto",
 	}
 
 	args := BuildFFmpegArgs(cfg, nil)
@@ -34,7 +37,7 @@ func TestBuildFFmpegArgs_RTSP(t *testing.T) {
 	require.Less(t, rtspIdx+1, len(args), "-rtsp_transport must have a value")
 	assert.Equal(t, "tcp", args[rtspIdx+1])
 
-	// Only audio streams should be requested during RTSP handshake.
+	// Only audio streams should be requested during RTSP handshake in auto mode.
 	allowedMediaIdx := slices.Index(args, "-allowed_media_types")
 	require.NotEqual(t, -1, allowedMediaIdx, "expected -allowed_media_types flag for RTSP")
 	require.Less(t, allowedMediaIdx+1, len(args), "-allowed_media_types must have a value")
@@ -59,6 +62,49 @@ func TestBuildFFmpegArgs_RTSP(t *testing.T) {
 	assert.Contains(t, args, "-ac")
 	assert.Contains(t, args, "-f")
 	assert.Contains(t, args, "-vn")
+}
+
+// TestBuildFFmpegArgs_MediaModes verifies the audio-only request tracks the
+// configured media mode: audio-only and auto request -allowed_media_types audio
+// on the initial handshake, full-stream never does, and an unset mode defaults to
+// full-stream (#3953). -vn is present in every mode so video is dropped after
+// decode regardless.
+func TestBuildFFmpegArgs_MediaModes(t *testing.T) {
+	t.Parallel()
+
+	baseCfg := func(mode string) *StreamConfig {
+		return &StreamConfig{
+			URL:        "rtsp://camera.example.com/live",
+			Type:       "rtsp",
+			SampleRate: 48000,
+			BitDepth:   16,
+			Channels:   1,
+			Transport:  "tcp",
+			LogLevel:   "error",
+			MediaMode:  mode,
+		}
+	}
+
+	tests := []struct {
+		name          string
+		mode          string
+		wantAudioOnly bool
+	}{
+		{"empty defaults to full-stream", "", false},
+		{"auto requests audio-only first", "auto", true},
+		{"audio-only requests audio-only", "audio-only", true},
+		{"full-stream never requests audio-only", "full-stream", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			args := BuildFFmpegArgs(baseCfg(tt.mode), nil)
+			assert.Equalf(t, tt.wantAudioOnly, hasAudioOnlyFlag(args),
+				"audio-only flag mismatch for media mode %q", tt.mode)
+			assert.Contains(t, args, "-vn", "video must be dropped after decode in every mode")
+		})
+	}
 }
 
 // TestBuildFFmpegArgs_HTTP verifies that BuildFFmpegArgs produces the correct

--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -232,6 +232,11 @@ type StreamConfig struct {
 	// Values: "downmix" (default), "left", "right".
 	ChannelMode string
 
+	// MediaMode controls which RTSP media is requested from the camera.
+	// Values: "auto", "audio-only", "full-stream" (empty = full-stream). Only
+	// applied for RTSP sources.
+	MediaMode string
+
 	// FFmpegPath is the absolute path to the FFmpeg binary.
 	FFmpegPath string
 
@@ -911,6 +916,7 @@ func (s *Stream) startProcess() error {
 		logger.String("url", s.config.safeURL()),
 		logger.Int("pid", s.cmd.Process.Pid),
 		logger.String("transport", s.config.Transport),
+		logger.String("media_mode", effectiveMediaMode(&s.config)),
 		logger.Int("target_sample_rate", s.config.SampleRate),
 		logger.Int("source_sample_rate", s.config.SourceSampleRate),
 		logger.Bool("ffmpeg_resampling", s.config.needsOutputResampling()),
@@ -924,11 +930,11 @@ func (s *Stream) startProcess() error {
 // buildFFmpegInputArgs constructs the FFmpeg input arguments for this stream.
 // It delegates argument construction to the shared buildInputArgs so the runtime
 // path builds the same argument structure as the unit-tested BuildFFmpegArgs.
-// The two differ only where this stream intends them to: BuildFFmpegArgs always
-// requests audio-only, whereas this path passes audioOnly=false once the stream
-// has latched into the full-stream fallback (issue #3902). Stream-specific
-// behavior is otherwise limited to surfacing an invalid user-supplied timeout as
-// a warning log (buildInputArgs silently falls back to the default).
+// Both derive the audio-only decision from the same resolveAudioOnly helper, so
+// they agree under every media mode; they differ only in that this path also
+// consults the live reactive fallback latch (auto mode) and surfaces an invalid
+// user-supplied timeout as a warning log (buildInputArgs silently falls back to
+// the default).
 func (s *Stream) buildFFmpegInputArgs(ffmpegParameters []string) []string {
 	if hasUserTimeout, userTimeoutValue := detectUserTimeout(ffmpegParameters); hasUserTimeout {
 		if err := validateTimeout(userTimeoutValue); err != nil {
@@ -940,9 +946,11 @@ func (s *Stream) buildFFmpegInputArgs(ffmpegParameters []string) []string {
 				logger.String("operation", "validate_timeout"))
 		}
 	}
-	// Request audio-only unless this stream has fallen back to the full stream
-	// because the camera cannot SETUP the audio track alone (issue #3902).
-	audioOnly := !s.audioOnlyFallback.Load()
+	// The media mode decides whether to request audio-only. In auto mode the
+	// reactive fallback (audioOnlyFallback) drops the restriction once the camera
+	// proves it cannot SETUP the audio track alone (issue #3902); audio-only and
+	// full-stream are deterministic and ignore the latch.
+	audioOnly := resolveAudioOnly(&s.config, s.audioOnlyFallback.Load())
 	return buildInputArgs(&s.config, ffmpegParameters, audioOnly)
 }
 
@@ -1970,6 +1978,12 @@ func (s *Stream) maybeEngageAudioOnlyFallback() bool {
 	// Only RTSP carries the audio-only restriction; only act while it is still
 	// requested and the camera has never delivered audio under it.
 	if s.config.sourceType() != audiocore.SourceTypeRTSP {
+		return false
+	}
+	// The reactive fallback only applies in auto mode. A stream forced to
+	// audio-only must fail visibly instead of silently opening a video slot, and
+	// full-stream never requested audio-only in the first place.
+	if !mediaModeAllowsFallback(&s.config) {
 		return false
 	}
 	if s.audioOnlyFallback.Load() || s.receivedAudio.Load() {

--- a/internal/audiocore/ffmpeg/stream_audioonly_fallback_test.go
+++ b/internal/audiocore/ffmpeg/stream_audioonly_fallback_test.go
@@ -109,3 +109,70 @@ func TestStream_AudioOnlyFallback_ClearsFailureCounters(t *testing.T) {
 	stream.restartCountMu.Unlock()
 	assert.Equal(t, 0, restart, "restart count should reset when fallback engages")
 }
+
+// TestStream_BuildFFmpegInputArgs_MediaModeWinsOverLatch verifies the runtime arg
+// path honors the configured media mode over the reactive fallback latch:
+// full-stream never requests audio-only, audio-only always does (even if the latch
+// is set), and auto follows the latch. An unset mode defaults to full-stream.
+func TestStream_BuildFFmpegInputArgs_MediaModeWinsOverLatch(t *testing.T) {
+	t.Parallel()
+
+	newStream := func(mode string) *Stream {
+		cfg := newTestConfig()
+		cfg.MediaMode = mode
+		return newTestStreamWithConfig(t, &cfg)
+	}
+
+	t.Run("full-stream ignores latch", func(t *testing.T) {
+		t.Parallel()
+		s := newStream("full-stream")
+		assert.False(t, hasAudioOnlyFlag(s.buildFFmpegInputArgs(nil)), "full-stream must not request audio-only")
+		s.audioOnlyFallback.Store(true)
+		assert.False(t, hasAudioOnlyFlag(s.buildFFmpegInputArgs(nil)), "full-stream must stay full-stream even if latched")
+	})
+
+	t.Run("audio-only ignores latch", func(t *testing.T) {
+		t.Parallel()
+		s := newStream("audio-only")
+		assert.True(t, hasAudioOnlyFlag(s.buildFFmpegInputArgs(nil)), "audio-only must request audio-only")
+		s.audioOnlyFallback.Store(true)
+		assert.True(t, hasAudioOnlyFlag(s.buildFFmpegInputArgs(nil)), "audio-only must not drop the restriction when latched")
+	})
+
+	t.Run("auto follows latch", func(t *testing.T) {
+		t.Parallel()
+		s := newStream("auto")
+		assert.True(t, hasAudioOnlyFlag(s.buildFFmpegInputArgs(nil)), "auto requests audio-only before fallback")
+		s.audioOnlyFallback.Store(true)
+		assert.False(t, hasAudioOnlyFlag(s.buildFFmpegInputArgs(nil)), "auto drops audio-only after fallback engages")
+	})
+
+	t.Run("empty defaults to full-stream", func(t *testing.T) {
+		t.Parallel()
+		s := newStream("")
+		assert.False(t, hasAudioOnlyFlag(s.buildFFmpegInputArgs(nil)), "empty media mode defaults to full-stream")
+	})
+}
+
+// TestStream_MaybeEngageAudioOnlyFallback_ForcedModes verifies the reactive
+// fallback only engages in auto mode. A stream forced to audio-only or full-stream
+// must never latch the fallback, even after the failure threshold is exceeded.
+func TestStream_MaybeEngageAudioOnlyFallback_ForcedModes(t *testing.T) {
+	t.Parallel()
+
+	for _, mode := range []string{"audio-only", "full-stream"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Parallel()
+			cfg := newTestConfig()
+			cfg.MediaMode = mode
+			s := newTestStreamWithConfig(t, &cfg)
+
+			for range audioOnlyFallbackThreshold + 2 {
+				assert.Falsef(t, s.maybeEngageAudioOnlyFallback(),
+					"forced %s mode must never engage the reactive fallback", mode)
+			}
+			assert.Falsef(t, s.audioOnlyFallback.Load(),
+				"forced %s mode must not latch the fallback", mode)
+		})
+	}
+}

--- a/internal/audiocore/ffmpeg/stream_test.go
+++ b/internal/audiocore/ffmpeg/stream_test.go
@@ -45,6 +45,10 @@ func newTestConfig() StreamConfig {
 		FFmpegPath: "/usr/bin/ffmpeg",
 		Transport:  "tcp",
 		LogLevel:   "error",
+		// Auto mode exercises the historical audio-only-first request plus the
+		// reactive fallback. The default (empty) is now full-stream, so tests that
+		// assert audio-only behavior set auto explicitly here.
+		MediaMode: "auto",
 	}
 }
 

--- a/internal/audiocore/source.go
+++ b/internal/audiocore/source.go
@@ -121,6 +121,10 @@ type AudioSource struct {
 	// Values: "downmix" (default), "left", "right".
 	ChannelMode string `json:"channelMode,omitempty"`
 
+	// MediaMode controls which RTSP media is requested from the camera.
+	// Values: "auto", "audio-only", "full-stream" (empty = full-stream).
+	MediaMode string `json:"mediaMode,omitempty"`
+
 	// Gain is the configured input gain in dB. 0 means no adjustment.
 	Gain float64 `json:"gain"`
 
@@ -236,6 +240,10 @@ type SourceConfig struct {
 	// ChannelMode controls how multi-channel audio is handled.
 	// Values: "downmix" (default), "left", "right".
 	ChannelMode string
+
+	// MediaMode controls which RTSP media is requested from the camera.
+	// Values: "auto", "audio-only", "full-stream" (empty = full-stream).
+	MediaMode string
 
 	// Gain is the input gain adjustment in dB. 0 means no adjustment.
 	// Positive values amplify, negative values attenuate.

--- a/internal/audiocore/source_registry.go
+++ b/internal/audiocore/source_registry.go
@@ -139,6 +139,7 @@ func (r *SourceRegistry) Register(cfg *SourceConfig) (*AudioSource, error) {
 		Channels:         cfg.Channels,
 		SourceChannels:   cfg.SourceChannels,
 		ChannelMode:      cfg.ChannelMode,
+		MediaMode:        cfg.MediaMode,
 		Gain:             cfg.Gain,
 		State:            SourceInactive,
 		RegisteredAt:     time.Now(),
@@ -311,6 +312,36 @@ func (r *SourceRegistry) UpdateAudioParams(sourceID string, sampleRate, bitDepth
 	r.mu.Unlock()
 
 	r.notify(SourceEvent{Type: SourceReconfigured, SourceID: sourceID, Source: snapshot})
+	return true
+}
+
+// SyncReconfiguredParams updates the registry entry's mode and probed source-shape
+// fields after an in-place reconfigure. Register writes these once at add time and
+// ReconfigureSource does not re-register, so without this the registry keeps the
+// values captured when the source was first added. Because sourceNeedsReconfigure
+// diffs the desired config against the registry entry, a stale entry makes a
+// change to only these fields re-trigger on every subsequent reconfigure and
+// restart the stream indefinitely; quiet-hours resume (which rebuilds the stream
+// config from the registry) would also use the old values. Source-shape fields are
+// only overwritten when the new value is known (non-zero), matching the "desired
+// != 0" guard in sourceNeedsReconfigure. It does not notify; the caller's
+// following UpdateAudioParams emits the SourceReconfigured event with the fully
+// updated snapshot.
+func (r *SourceRegistry) SyncReconfiguredParams(sourceID, channelMode, mediaMode string, sourceSampleRate, sourceChannels int) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	src, ok := r.sources[sourceID]
+	if !ok {
+		return false
+	}
+	src.ChannelMode = channelMode
+	src.MediaMode = mediaMode
+	if sourceSampleRate != 0 {
+		src.SourceSampleRate = sourceSampleRate
+	}
+	if sourceChannels != 0 {
+		src.SourceChannels = sourceChannels
+	}
 	return true
 }
 

--- a/internal/audiocore/source_registry_test.go
+++ b/internal/audiocore/source_registry_test.go
@@ -452,3 +452,54 @@ func TestSourceRegistry_TypeDetection(t *testing.T) {
 		})
 	}
 }
+
+// TestSourceRegistry_SyncReconfiguredParams verifies the reconfigure write-back:
+// the mode fields are always overwritten and the probed source-shape fields are
+// only overwritten when the new value is non-zero. Without this write-back a
+// mode-only edit would re-trigger reconfigure on every later cycle and
+// quiet-hours resume would rebuild the stream from a stale entry.
+func TestSourceRegistry_SyncReconfiguredParams(t *testing.T) {
+	t.Parallel()
+	r := newTestRegistry(t)
+
+	src, err := r.Register(&SourceConfig{
+		ConnectionString: "rtsp://sync.example.com/stream",
+		ChannelMode:      "downmix",
+		MediaMode:        "auto",
+		SourceSampleRate: 48000,
+		SourceChannels:   2,
+	})
+	require.NoError(t, err)
+
+	// New mode plus non-zero shape overwrites all four fields.
+	ok := r.SyncReconfiguredParams(src.ID, "left", "full-stream", 44100, 1)
+	require.True(t, ok)
+
+	got, ok := r.Get(src.ID)
+	require.True(t, ok)
+	assert.Equal(t, "left", got.ChannelMode, "channel mode must be written back")
+	assert.Equal(t, "full-stream", got.MediaMode, "media mode must be written back")
+	assert.Equal(t, 44100, got.SourceSampleRate, "non-zero source sample rate must be written back")
+	assert.Equal(t, 1, got.SourceChannels, "non-zero source channels must be written back")
+
+	// Zero-valued shape must NOT clobber the known values (mirrors the
+	// "desired != 0" guard in sourceNeedsReconfigure); modes are always written.
+	ok = r.SyncReconfiguredParams(src.ID, "right", "audio-only", 0, 0)
+	require.True(t, ok)
+
+	got, ok = r.Get(src.ID)
+	require.True(t, ok)
+	assert.Equal(t, "right", got.ChannelMode)
+	assert.Equal(t, "audio-only", got.MediaMode)
+	assert.Equal(t, 44100, got.SourceSampleRate, "zero source sample rate must not clobber the known value")
+	assert.Equal(t, 1, got.SourceChannels, "zero source channels must not clobber the known value")
+}
+
+// TestSourceRegistry_SyncReconfiguredParams_NotFound verifies the write-back
+// reports false for an unknown source ID.
+func TestSourceRegistry_SyncReconfiguredParams_NotFound(t *testing.T) {
+	t.Parallel()
+	r := newTestRegistry(t)
+
+	assert.False(t, r.SyncReconfiguredParams("nonexistent-id", "left", "full-stream", 48000, 1))
+}

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -582,6 +582,51 @@ var ValidChannelModes = map[ChannelMode]bool{
 	ChannelModeRight:   true,
 }
 
+// MediaMode controls which RTSP media a stream requests from the camera. It
+// only affects RTSP sources; other stream types ignore it.
+type MediaMode string
+
+const (
+	// MediaModeAuto requests audio-only first and falls back to the full stream
+	// (video decoded then discarded via -vn) only after repeated failures with no
+	// audio ever received. This is the bandwidth-conserving mode that avoids
+	// opening a camera video slot when the camera can deliver audio alone (#3798).
+	MediaModeAuto MediaMode = "auto"
+	// MediaModeAudioOnly forces the audio-only request and never falls back, so a
+	// camera that cannot deliver the audio track alone fails visibly instead of
+	// silently opening a video slot.
+	MediaModeAudioOnly MediaMode = "audio-only"
+	// MediaModeFullStream requests the full stream from the start (video decoded
+	// then discarded via -vn). It never sends -allowed_media_types audio, so it
+	// works with cameras that cannot SETUP the audio track in isolation.
+	MediaModeFullStream MediaMode = "full-stream"
+)
+
+// DefaultMediaMode is used when a stream does not specify a media mode. Full
+// stream is the most compatible request (every RTSP camera can deliver it) and
+// avoids the fragile audio-only handshake that some cameras (e.g. Unifi) complete
+// just long enough to mislead the audio-only fallback (#3953). Users who want to
+// conserve a camera video slot can select "auto" or "audio-only".
+const DefaultMediaMode = MediaModeFullStream
+
+// Canonical returns the effective media mode, treating an empty value as the
+// default. Callers comparing modes (e.g. hot-reload change detection) should
+// compare canonical values so an unset field and an explicit default are not
+// treated as a real change that would needlessly restart the stream.
+func (m MediaMode) Canonical() MediaMode {
+	if m == "" {
+		return DefaultMediaMode
+	}
+	return m
+}
+
+// ValidMediaModes is the set of accepted media mode values.
+var ValidMediaModes = map[MediaMode]bool{
+	MediaModeAuto:       true,
+	MediaModeAudioOnly:  true,
+	MediaModeFullStream: true,
+}
+
 // StreamConfig represents a single audio stream source
 type StreamConfig struct {
 	Name        string             `yaml:"name" json:"name" mapstructure:"name"`                                    // Required: descriptive name like "Front Yard"
@@ -590,6 +635,7 @@ type StreamConfig struct {
 	Type        string             `yaml:"type" json:"type" mapstructure:"type"`                                    // Stream type: rtsp, http, hls, rtmp, udp
 	Transport   string             `yaml:"transport" json:"transport" mapstructure:"transport"`                     // Transport: tcp or udp (for RTSP/RTMP)
 	ChannelMode ChannelMode        `yaml:"channelMode,omitempty" json:"channelMode" mapstructure:"channelMode"`     // Channel handling: downmix, left, or right
+	MediaMode   MediaMode          `yaml:"mediaMode,omitempty" json:"mediaMode" mapstructure:"mediaMode"`            // RTSP media request: auto, audio-only, or full-stream (ignored for non-RTSP)
 	Gain        float64            `yaml:"gain" json:"gain" mapstructure:"gain"`                                    // Input gain in dB (0 = no adjustment)
 	Equalizer   *EqualizerSettings `yaml:"equalizer,omitempty" json:"equalizer,omitempty" mapstructure:"equalizer"` // Per-stream EQ (nil = use global)
 	QuietHours  QuietHoursConfig   `yaml:"quietHours" json:"quietHours" mapstructure:"quietHours"`                  // Quiet hours configuration

--- a/internal/conf/stream_validation_test.go
+++ b/internal/conf/stream_validation_test.go
@@ -554,6 +554,59 @@ func TestStreamConfig_ChannelModeValidation(t *testing.T) {
 	}
 }
 
+func TestStreamConfig_MediaModeValidation(t *testing.T) {
+	t.Parallel()
+
+	base := func() StreamConfig {
+		return StreamConfig{
+			Name:    "Test Stream",
+			URL:     "rtsp://192.168.1.10/stream",
+			Enabled: true,
+			Type:    StreamTypeRTSP,
+		}
+	}
+
+	tests := []struct {
+		name      string
+		mediaMode MediaMode
+		wantErr   bool
+	}{
+		{"empty defaults to full-stream", "", false},
+		{"explicit auto", MediaModeAuto, false},
+		{"explicit audio-only", MediaModeAudioOnly, false},
+		{"explicit full-stream", MediaModeFullStream, false},
+		{"invalid mode rejected", MediaMode("video-only"), true},
+		{"invalid mode garbage", MediaMode("both"), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := base()
+			s.MediaMode = tt.mediaMode
+			err := s.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid media mode")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestMediaMode_Canonical verifies an unset media mode resolves to the default
+// (full-stream) while explicit values are returned unchanged.
+func TestMediaMode_Canonical(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, MediaModeFullStream, MediaMode("").Canonical(), "empty must canonicalize to full-stream")
+	assert.Equal(t, DefaultMediaMode, MediaMode("").Canonical(), "empty must equal DefaultMediaMode")
+	assert.Equal(t, MediaModeAuto, MediaModeAuto.Canonical())
+	assert.Equal(t, MediaModeAudioOnly, MediaModeAudioOnly.Canonical())
+	assert.Equal(t, MediaModeFullStream, MediaModeFullStream.Canonical())
+}
+
 // TestStreamConfig_Validate_GainRange mirrors TestAudioSourceConfig_Validate_GainRange:
 // StreamConfig.Validate must reject NaN, +/-Inf, and out-of-range gain so a
 // hand-edited config.yaml or a non-UI API client cannot push an out-of-range

--- a/internal/conf/stream_validation_test.go
+++ b/internal/conf/stream_validation_test.go
@@ -513,8 +513,20 @@ func TestApplyStreamDefaults(t *testing.T) {
 	}
 }
 
-func TestStreamConfig_ChannelModeValidation(t *testing.T) {
-	t.Parallel()
+// streamModeCase is one enum-mode validation case: the raw value to set and
+// whether StreamConfig.Validate must reject it.
+type streamModeCase struct {
+	name    string
+	value   string
+	wantErr bool
+}
+
+// runStreamModeValidation applies each case's value to a base RTSP StreamConfig
+// via apply, runs Validate, and asserts errSubstr appears in any rejection. The
+// channel-mode and media-mode validation tests share this scaffolding since they
+// are otherwise identical over different enum fields.
+func runStreamModeValidation(t *testing.T, apply func(*StreamConfig, string), errSubstr string, cases []streamModeCase) {
+	t.Helper()
 
 	base := func() StreamConfig {
 		return StreamConfig{
@@ -525,28 +537,15 @@ func TestStreamConfig_ChannelModeValidation(t *testing.T) {
 		}
 	}
 
-	tests := []struct {
-		name        string
-		channelMode ChannelMode
-		wantErr     bool
-	}{
-		{"empty defaults to downmix", "", false},
-		{"explicit downmix", ChannelModeDownmix, false},
-		{"left channel", ChannelModeLeft, false},
-		{"right channel", ChannelModeRight, false},
-		{"invalid mode rejected", ChannelMode("stereo"), true},
-		{"invalid mode center", ChannelMode("center"), true},
-	}
-
-	for _, tt := range tests {
+	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			s := base()
-			s.ChannelMode = tt.channelMode
+			apply(&s, tt.value)
 			err := s.Validate()
 			if tt.wantErr {
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), "invalid channel mode")
+				assert.Contains(t, err.Error(), errSubstr)
 			} else {
 				assert.NoError(t, err)
 			}
@@ -554,45 +553,34 @@ func TestStreamConfig_ChannelModeValidation(t *testing.T) {
 	}
 }
 
+func TestStreamConfig_ChannelModeValidation(t *testing.T) {
+	t.Parallel()
+	runStreamModeValidation(t,
+		func(s *StreamConfig, v string) { s.ChannelMode = ChannelMode(v) },
+		"invalid channel mode",
+		[]streamModeCase{
+			{"empty defaults to downmix", "", false},
+			{"explicit downmix", string(ChannelModeDownmix), false},
+			{"left channel", string(ChannelModeLeft), false},
+			{"right channel", string(ChannelModeRight), false},
+			{"invalid mode rejected", "stereo", true},
+			{"invalid mode center", "center", true},
+		})
+}
+
 func TestStreamConfig_MediaModeValidation(t *testing.T) {
 	t.Parallel()
-
-	base := func() StreamConfig {
-		return StreamConfig{
-			Name:    "Test Stream",
-			URL:     "rtsp://192.168.1.10/stream",
-			Enabled: true,
-			Type:    StreamTypeRTSP,
-		}
-	}
-
-	tests := []struct {
-		name      string
-		mediaMode MediaMode
-		wantErr   bool
-	}{
-		{"empty defaults to full-stream", "", false},
-		{"explicit auto", MediaModeAuto, false},
-		{"explicit audio-only", MediaModeAudioOnly, false},
-		{"explicit full-stream", MediaModeFullStream, false},
-		{"invalid mode rejected", MediaMode("video-only"), true},
-		{"invalid mode garbage", MediaMode("both"), true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			s := base()
-			s.MediaMode = tt.mediaMode
-			err := s.Validate()
-			if tt.wantErr {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "invalid media mode")
-			} else {
-				assert.NoError(t, err)
-			}
+	runStreamModeValidation(t,
+		func(s *StreamConfig, v string) { s.MediaMode = MediaMode(v) },
+		"invalid media mode",
+		[]streamModeCase{
+			{"empty defaults to full-stream", "", false},
+			{"explicit auto", string(MediaModeAuto), false},
+			{"explicit audio-only", string(MediaModeAudioOnly), false},
+			{"explicit full-stream", string(MediaModeFullStream), false},
+			{"invalid mode rejected", "video-only", true},
+			{"invalid mode garbage", "both", true},
 		})
-	}
 }
 
 // TestMediaMode_Canonical verifies an unset media mode resolves to the default

--- a/internal/conf/validate_audio.go
+++ b/internal/conf/validate_audio.go
@@ -145,6 +145,12 @@ func (s *StreamConfig) Validate() error {
 		return fmt.Errorf("invalid channel mode '%s' for '%s': must be downmix, left, or right", s.ChannelMode, s.Name)
 	}
 
+	// Validate media mode (empty defaults to full-stream, explicit values must be
+	// valid). Accepted on any stream type but only applied at runtime for RTSP.
+	if s.MediaMode != "" && !ValidMediaModes[s.MediaMode] {
+		return fmt.Errorf("invalid media mode '%s' for '%s': must be auto, audio-only, or full-stream", s.MediaMode, s.Name)
+	}
+
 	// Validate gain range (NaN/Inf bypass < and > comparisons). Mirrors the
 	// AudioSourceConfig.Validate check so a hand-edited config.yaml or a non-UI
 	// API client cannot push an out-of-range gain past the frontend clamp.


### PR DESCRIPTION
Fixes #3953.

## Background

BirdNET-Go requests audio-only RTSP (`-allowed_media_types audio`) to avoid opening a camera video slot (#3798). Cameras that cannot SETUP the audio track alone deliver no audio, so a reactive per-stream fallback drops the restriction after repeated audio-less failures. That fallback has been a recurring source of bugs (#3902, #3905, #3937, and the recently closed #3954): some cameras (Unifi in #3953) complete the audio-only handshake and deliver a brief burst of audio before dropping the connection, which fools the `receivedAudio` latch into treating the source as working so the fallback never engages.

Rather than keep tuning that reactive guess, this adds an explicit per-source control.

## What this does

New per-stream `mediaMode` setting with three values:

- **`full-stream`** (new default): request audio and video, discard video after decode via `-vn`. Most compatible request; never sends `-allowed_media_types audio`.
- **`auto`**: audio-only first with the existing reactive fallback (the previous default behavior). The fallback latch and counters run only in this mode.
- **`audio-only`**: force audio-only and never fall back, so a camera that cannot deliver audio alone fails visibly instead of silently opening a video slot.

An unset value canonicalizes to `full-stream`, modeled on the existing `ChannelMode` pattern (empty means default). The audio-only decision is centralized in one helper (`resolveAudioOnly`) so the runtime path and the unit-tested `BuildFFmpegArgs` mirror agree under every mode, and `maybeEngageAudioOnlyFallback` is gated to `auto` only.

## Behavior change on upgrade (release-note worthy)

This changes the effective default for existing installs: a stream with no `mediaMode` set canonicalizes to `full-stream`, so on upgrade every existing RTSP camera switches from requesting audio-only first to requesting the full stream (video is still discarded after decode via `-vn`).

Full stream is the most broadly compatible request, but it is **not** a strict superset of audio-only at the RTSP SETUP handshake. A subset of setups that only worked in audio-only mode can regress: a camera whose concurrent video slots are already held (by an NVR or Home Assistant), or one that advertises a broken/absent video track, may now fail at SETUP where audio-only previously connected. Those users restore the old behavior by setting the stream's media mode to `auto` (audio-only first with the reactive fallback, the exact prior default) or `audio-only`. Existing `config.yaml` files load unchanged (the field is additive, no strict decode), and the default lives in a single constant (`conf.DefaultMediaMode`) if we revisit it.

Release notes should call out both the new default and the `auto` / `audio-only` escape hatch.

## Hot-reload correctness

`sourceNeedsReconfigure` and `streamsSettingsChanged` compare canonical media modes, and `ReconfigureSource` now syncs the mode and probed source-shape fields back to the source registry (`SyncReconfiguredParams`). Without that write-back a channel- or media-mode-only edit was re-detected as a diff on every subsequent reconfigure and restarted the stream indefinitely, and quiet-hours resume rebuilt the stream from the stale registry entry. That was a latent bug for `ChannelMode` already; it is fixed here too.

## Frontend

RTSP-only media-mode dropdown in the stream editor with help text, plus a badge for non-default modes.

## Tests

- Arg construction under every mode (runtime `buildFFmpegInputArgs` and the `BuildFFmpegArgs` mirror), including mode-wins-over-latch and `-vn` present in all modes.
- Reactive fallback never engages for forced modes.
- `conf` validation and `MediaMode.Canonical()`.
- `sourceNeedsReconfigure` and `streamsSettingsChanged` canonical comparisons (unset vs explicit default is a no-op).
- Hot-reload coverage registry entry for the new field.
- Frontend coercion (valid modes preserved, invalid dropped).

`golangci-lint`, `go test -race` on the touched packages, and `npm run check:all` + i18n validation all pass locally.

## Deferred to a follow-up

- Thread the media mode into the startup and channel-analysis probes so a forced `audio-only` stream never opens a video slot while probing.
- Surface a recommended mode from the "test stream" button.
- Expose the reactive fallback state in stream health so the dropdown choice is better informed.
