### PR TITLE
feat(audio): coalesce flapping RTSP source liveness notifications

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -275,7 +275,29 @@ func (p *AudioPipelineService) Start(_ context.Context) error {
 	p.quietHoursScheduler.Start()
 
 	// Start audio liveness watchdog for detecting silent capture deaths.
-	notifSvc := notification.GetService()
+	// Coalesce transient silence/recovery notifications so a source that
+	// repeatedly drops and self-recovers (e.g. a flaky RTSP camera) does not spam
+	// one high-priority notification per cycle. Critical escalated/failed states
+	// bypass coalescing. This affects only notifications; source restart and
+	// recovery are unchanged.
+	livenessNotif := newLivenessNotifier(func(priority notification.Priority, title, body string) {
+		// Resolve the notification service at send time rather than capturing it
+		// once at Start, matching the error-hook pattern, so notifications are not
+		// permanently dropped if the service initializes after the pipeline starts.
+		notifSvc := notification.GetService()
+		if notifSvc == nil {
+			return
+		}
+		if _, err := notifSvc.CreateWithComponent(
+			notification.TypeSystem, priority,
+			title, body, livenessComponent,
+		); err != nil {
+			audiocore.GetLogger().Warn("failed to send liveness notification",
+				logger.Error(err),
+				logger.String("operation", "liveness_notify"),
+				logger.String("title", title))
+		}
+	})
 	watchdogCallbacks := audiocore.LivenessCallbacks{
 		RestartSource: p.RestartSource,
 		Escalate: func(_ string) {
@@ -285,23 +307,7 @@ func (p *AudioPipelineService) Start(_ context.Context) error {
 			}
 		},
 		Notify: func(sourceID string, state audiocore.LivenessState, msg string) {
-			if notifSvc == nil {
-				return
-			}
-			priority := notification.PriorityHigh
-			title := "Audio source " + msg
-			body := "Source " + sourceID + ": " + msg
-			if state == audiocore.StateFailed || state == audiocore.StateEscalated {
-				priority = notification.PriorityCritical
-			}
-			if _, err := notifSvc.CreateWithComponent(
-				notification.TypeSystem, priority,
-				title, body, "audiocore.liveness",
-			); err != nil {
-				audiocore.GetLogger().Warn("failed to send liveness notification",
-					logger.Error(err),
-					logger.String("operation", "liveness_notify"))
-			}
+			livenessNotif.notify(sourceID, state, msg)
 		},
 		IsQuietHours: func(sourceID string) bool {
 			if p.quietHoursScheduler == nil {

--- a/internal/analysis/liveness_notifier.go
+++ b/internal/analysis/liveness_notifier.go
@@ -1,0 +1,91 @@
+package analysis
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+	"github.com/tphakala/birdnet-go/internal/notification"
+)
+
+// Liveness notification coalescing parameters. This reuses the same burst-tracker
+// mechanism as the error hook (internal/notification/error_integration.go), with a
+// wider window tuned for flapping audio sources: their silence/recovery events are
+// sparser and far more repetitive than distinct errors, so a longer window is
+// needed to actually collapse a source that drops every few minutes. The first
+// livenessBurstThreshold events in a window pass individually, the next becomes a
+// single flapping summary, and the rest are suppressed until the window rolls
+// over. Only the user-facing notification is affected; source restart/recovery
+// is driven independently by the watchdog and is not touched here.
+const (
+	livenessBurstThreshold = 2
+	livenessBurstWindow    = 15 * time.Minute
+	// livenessBurstCategory is the burst-tracker category for liveness events.
+	// The tracker keys on sourceID+category, so silence and recovery events for
+	// the same source share one bucket (one flapping incident).
+	livenessBurstCategory = "liveness"
+	// livenessComponent labels liveness notifications for telemetry/UI filtering.
+	livenessComponent = "audiocore.liveness"
+)
+
+// livenessNotifySender delivers a single audio-source notification. It is
+// injected so the coalescing policy can be unit-tested without the notification
+// service. The real sender calls notification.Service.CreateWithComponent.
+type livenessNotifySender func(priority notification.Priority, title, body string)
+
+// livenessNotifier coalesces repeated transient silence/recovery notifications
+// for a flapping audio source into a single summary, while letting critical
+// (escalated/failed) states through immediately and unbatched. It exists to stop
+// a source that repeatedly drops and self-recovers (e.g. an RTSP camera that
+// keeps tearing down its session) from producing a high-priority notification on
+// every cycle, without changing any stream or recovery behavior.
+type livenessNotifier struct {
+	burst *notification.ErrorBurstTracker
+	send  livenessNotifySender
+}
+
+// newLivenessNotifier builds a notifier that dispatches through send. A nil send
+// is replaced with a no-op so notify never panics on a misconfigured caller.
+func newLivenessNotifier(send livenessNotifySender) *livenessNotifier {
+	if send == nil {
+		send = func(notification.Priority, string, string) {}
+	}
+	return &livenessNotifier{
+		burst: notification.NewErrorBurstTracker(livenessBurstThreshold, livenessBurstWindow),
+		send:  send,
+	}
+}
+
+// notify dispatches a watchdog state change to the user, coalescing transient
+// flapping but never suppressing a genuinely-down source.
+func (n *livenessNotifier) notify(sourceID string, state audiocore.LivenessState, msg string) {
+	// Escalated/failed mean the source did not recover on its own; always alert
+	// immediately and bypass coalescing so a real outage is never hidden. Reset the
+	// burst window as well, so the "recovered" all-clear that follows a critical
+	// outage is delivered fresh instead of being suppressed by the flapping burst
+	// that preceded the escalation.
+	if state == audiocore.StateEscalated || state == audiocore.StateFailed {
+		n.burst.Reset(sourceID, livenessBurstCategory)
+		n.send(notification.PriorityCritical, "Audio source "+msg, "Source "+sourceID+": "+msg)
+		return
+	}
+
+	// Transient silence/recovery: collapse repeats per source.
+	action, summary := n.burst.Record(sourceID, livenessBurstCategory, msg)
+	switch action {
+	case notification.BurstActionAllow:
+		n.send(notification.PriorityHigh, "Audio source "+msg, "Source "+sourceID+": "+msg)
+	case notification.BurstActionSummary:
+		// One summary stands in for the rest of the window. Say the source is
+		// unstable (not down) and point at the dashboard, since further transient
+		// alerts are grouped away until the window rolls over. (An escalation to a
+		// critical outage resets the window, so a post-critical "recovered" is still
+		// delivered rather than grouped.)
+		body := fmt.Sprintf("Source %s is unstable: %d silence/recovery events in %d min. "+
+			"Further alerts are grouped to reduce noise; see the dashboard for live status.",
+			sourceID, summary.Count, summary.WindowMin)
+		n.send(notification.PriorityHigh, "Audio source flapping", body)
+	case notification.BurstActionSuppress:
+		// Already summarized this window; drop to avoid notification spam.
+	}
+}

--- a/internal/analysis/liveness_notifier_test.go
+++ b/internal/analysis/liveness_notifier_test.go
@@ -1,0 +1,167 @@
+package analysis
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+	"github.com/tphakala/birdnet-go/internal/notification"
+)
+
+// countTitle returns how many recorded sends have the exact given title.
+func countTitle(sent []recordedNotif, title string) int {
+	n := 0
+	for i := range sent {
+		if sent[i].title == title {
+			n++
+		}
+	}
+	return n
+}
+
+// countPriority returns how many recorded sends have the given priority.
+func countPriority(sent []recordedNotif, priority notification.Priority) int {
+	n := 0
+	for i := range sent {
+		if sent[i].priority == priority {
+			n++
+		}
+	}
+	return n
+}
+
+// recordedNotif captures a single send from the livenessNotifier under test.
+type recordedNotif struct {
+	priority notification.Priority
+	title    string
+	body     string
+}
+
+// newRecordingNotifier returns a livenessNotifier whose sends are appended to
+// the returned slice pointer. notify is driven sequentially by the watchdog, so
+// the recorder needs no synchronization.
+func newRecordingNotifier() (*livenessNotifier, *[]recordedNotif) {
+	var sent []recordedNotif
+	n := newLivenessNotifier(func(priority notification.Priority, title, body string) {
+		sent = append(sent, recordedNotif{priority: priority, title: title, body: body})
+	})
+	return n, &sent
+}
+
+// TestLivenessNotifier_CriticalBypassesCoalescing verifies that escalated and
+// failed states always produce an immediate critical notification, never
+// coalesced, no matter how many arrive in the window.
+func TestLivenessNotifier_CriticalBypassesCoalescing(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		state audiocore.LivenessState
+	}{
+		{"escalated", audiocore.StateEscalated},
+		{"failed", audiocore.StateFailed},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			n, sent := newRecordingNotifier()
+
+			const calls = 6
+			for range calls {
+				n.notify("rtsp_camera", tc.state, "retries exhausted")
+			}
+
+			require.Len(t, *sent, calls, "every critical event must be sent, none coalesced")
+			for _, s := range *sent {
+				assert.Equal(t, notification.PriorityCritical, s.priority)
+			}
+		})
+	}
+}
+
+// TestLivenessNotifier_TransientCoalesced verifies that a source repeatedly
+// dropping and self-recovering produces individual notifications up to the
+// threshold, then exactly one flapping summary, then silence.
+func TestLivenessNotifier_TransientCoalesced(t *testing.T) {
+	t.Parallel()
+	n, sent := newRecordingNotifier()
+
+	// Alternate silence/recovery events for one flapping source. Derive the event
+	// count from the threshold so the suppress phase stays exercised if the
+	// threshold constant changes.
+	states := []audiocore.LivenessState{audiocore.StateAlarmed, audiocore.StateHealthy}
+	msgs := []string{"silence detected", "recovered"}
+	events := livenessBurstThreshold + 8
+	for i := range events {
+		n.notify("rtsp_camera", states[i%2], msgs[i%2])
+	}
+
+	// First `threshold` events pass individually, the (threshold+1)th becomes a
+	// single summary, the rest are suppressed.
+	require.Len(t, *sent, livenessBurstThreshold+1)
+
+	for i := range livenessBurstThreshold {
+		assert.Equal(t, notification.PriorityHigh, (*sent)[i].priority)
+		assert.Equal(t, "Audio source "+msgs[i%2], (*sent)[i].title)
+	}
+
+	summary := (*sent)[livenessBurstThreshold]
+	assert.Equal(t, notification.PriorityHigh, summary.priority)
+	assert.Contains(t, summary.title, "flapping")
+	assert.Contains(t, summary.body, "rtsp_camera")
+	// The summary must report the coalesced count and window, not just a label.
+	assert.Contains(t, summary.body, fmt.Sprintf("%d", livenessBurstThreshold+1))
+	assert.Contains(t, summary.body, fmt.Sprintf("%d min", int(livenessBurstWindow.Minutes())))
+}
+
+// TestLivenessNotifier_IndependentPerSource verifies that each source has its
+// own coalescing budget: one noisy source must not silence another.
+func TestLivenessNotifier_IndependentPerSource(t *testing.T) {
+	t.Parallel()
+	n, sent := newRecordingNotifier()
+
+	// Exhaust source A's budget entirely.
+	for range livenessBurstThreshold + 8 {
+		n.notify("source_a", audiocore.StateAlarmed, "silence detected")
+	}
+	countAfterA := len(*sent)
+
+	// Source B's first alarm must still come through individually.
+	n.notify("source_b", audiocore.StateAlarmed, "silence detected")
+
+	require.Len(t, *sent, countAfterA+1)
+	last := (*sent)[len(*sent)-1]
+	assert.Equal(t, notification.PriorityHigh, last.priority)
+	assert.Contains(t, last.body, "source_b")
+	assert.Equal(t, "Audio source silence detected", last.title)
+}
+
+// TestLivenessNotifier_EscalationResetsCoalescing verifies that after a source
+// escalates to a critical outage, the following "recovered" all-clear is
+// delivered rather than being suppressed by the flapping burst that preceded the
+// escalation. Regression test for the swallowed post-critical recovery.
+func TestLivenessNotifier_EscalationResetsCoalescing(t *testing.T) {
+	t.Parallel()
+	n, sent := newRecordingNotifier()
+
+	// Flap enough to exhaust the silence budget so transient events are suppressed.
+	for range livenessBurstThreshold + 5 {
+		n.notify("rtsp_camera", audiocore.StateAlarmed, "silence detected")
+	}
+	// A recovery now would be swallowed: the burst window is still open.
+	n.notify("rtsp_camera", audiocore.StateHealthy, "recovered")
+	require.Zero(t, countTitle(*sent, "Audio source recovered"),
+		"precondition: recovery is suppressed while the burst window is open")
+
+	// The source escalates to a critical outage, then recovers.
+	n.notify("rtsp_camera", audiocore.StateFailed, "escalation timeout elapsed")
+	n.notify("rtsp_camera", audiocore.StateHealthy, "recovered")
+
+	// The post-critical all-clear must be delivered (Reset cleared the window).
+	assert.Equal(t, 1, countTitle(*sent, "Audio source recovered"),
+		"recovery after a critical escalation must notify the all-clear")
+	assert.GreaterOrEqual(t, countPriority(*sent, notification.PriorityCritical), 1,
+		"the critical escalation itself must be delivered")
+}

--- a/internal/notification/burst_tracker.go
+++ b/internal/notification/burst_tracker.go
@@ -102,3 +102,16 @@ func (t *ErrorBurstTracker) Record(component, category, errMsg string) (BurstAct
 
 	return BurstActionSuppress, nil
 }
+
+// Reset clears any burst state for a component+category so the next Record for
+// that key starts a fresh window. Use it after handling a significant state
+// change out-of-band (for example a critical escalation that bypasses
+// coalescing) so a following recovery event is not suppressed by the window
+// still open from the preceding burst. Resetting an unknown key is a no-op.
+func (t *ErrorBurstTracker) Reset(component, category string) {
+	key := component + ":" + category
+
+	t.mu.Lock()
+	delete(t.buckets, key)
+	t.mu.Unlock()
+}

--- a/internal/notification/burst_tracker_test.go
+++ b/internal/notification/burst_tracker_test.go
@@ -72,3 +72,26 @@ func TestBurstTracker_DifferentKeysIndependent(t *testing.T) {
 	action, _ := bt.Record("mqtt", "connection", "broker unreachable")
 	assert.Equal(t, BurstActionAllow, action)
 }
+
+func TestBurstTracker_ResetClearsBucket(t *testing.T) {
+	bt := NewErrorBurstTracker(3, 5*time.Minute)
+	for range 4 {
+		bt.Record("securefs", "file-io", "error")
+	}
+	// Now in the suppress phase; Reset must clear the window so the next event
+	// starts fresh and is allowed individually again.
+	bt.Reset("securefs", "file-io")
+
+	action, summary := bt.Record("securefs", "file-io", "error after reset")
+	assert.Equal(t, BurstActionAllow, action)
+	assert.Nil(t, summary)
+}
+
+func TestBurstTracker_ResetUnknownKeyIsNoop(t *testing.T) {
+	bt := NewErrorBurstTracker(3, 5*time.Minute)
+	// Resetting a key that was never recorded must not panic or disturb other keys.
+	bt.Reset("never", "seen")
+
+	action, _ := bt.Record("securefs", "file-io", "error")
+	assert.Equal(t, BurstActionAllow, action)
+}


### PR DESCRIPTION
## Summary

A source that repeatedly drops and self-recovers (for example a Unifi camera that periodically tears down its RTSPS session) previously produced one high-priority notification per silence/recovery cycle, flooding the user even though detections and clips kept working. This reuses the existing notification burst tracker to collapse repeated transient silence/recovery events per source into a single "flapping" summary, while escalated/failed states still alert immediately as critical.

## Details

- Coalescing is per source with a 15 minute window and a threshold of 2: the first couple of transient events pass through individually, the next becomes one "flapping" summary, and the rest are grouped until the window rolls over. The window is intentionally wider than the error hook's 5 minutes because liveness events are sparser and far more repetitive.
- An escalation to a critical outage resets the burst window, so the post-critical "recovered" all-clear is delivered rather than being grouped away.
- The notification service is now resolved at send time (matching the error hook) instead of being captured once at pipeline start, so alerts are not permanently dropped if the service initializes after the pipeline.
- Notification-only change. Stream opening, media mode, ffmpeg arguments, reconnect/backoff, and the watchdog's restart/recovery behavior are all unchanged, so a working stream cannot regress.

## Related

Relates to #3953. That camera's RTSPS session is torn down periodically by the camera or network (verified from the support dump; it is not the audio-only handshake), so the drops themselves are external. This PR targets the resulting notification noise rather than the drops.

## Test plan

- [x] `go test -race` on `internal/analysis` and `internal/notification` (coalescing, critical-bypass, per-source independence, and an escalation-reset regression test)
- [x] `golangci-lint run` clean on both packages
- [x] `go build ./...`