### PR TITLE
fix(audio): repair corrupt BirdWeather soundscape FLAC (go-flac v0.4.1)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.43.0
 	github.com/testcontainers/testcontainers-go/modules/mysql v0.43.0
 	github.com/tphakala/go-audio-resampler v1.4.0
-	github.com/tphakala/go-flac v0.4.0
+	github.com/tphakala/go-flac v0.4.1
 	github.com/tphakala/go-tflite v0.2.2-0.20260514101223-29408e53fff7
 	github.com/tphakala/simd v1.4.0-rc.2
 	github.com/yalue/onnxruntime_go v1.30.1

--- a/go.sum
+++ b/go.sum
@@ -289,8 +289,8 @@ github.com/tklauser/numcpus v0.12.0 h1:NR85qdvHA9pFse3x3weVZ0r0ST8R6l5RHbZrlRaqo
 github.com/tklauser/numcpus v0.12.0/go.mod h1:ABHeXzJnr/qqwguhClkZKT1/8VABcYrsyUiUGobwWJg=
 github.com/tphakala/go-audio-resampler v1.4.0 h1:Iv71vuUVzH2apR9tw4TrWDRvjNOc1e8Qr58TKl6IaLo=
 github.com/tphakala/go-audio-resampler v1.4.0/go.mod h1:mDVvtgIkzupYeqTcxRIJeEED53yrCTu2BP3mAYpiYj0=
-github.com/tphakala/go-flac v0.4.0 h1:aze0YFqJOPRRWEaDH5ek2yquDfPW/qxmMkLZFrx12S8=
-github.com/tphakala/go-flac v0.4.0/go.mod h1:d6cu4zAcEOyHq1mHJHvKH92v8i7/MmreUtcPsx7FhNs=
+github.com/tphakala/go-flac v0.4.1 h1:c8nGxcTEQwwqzUAWeHONWBbpM+D7O++bcul19XBoIrU=
+github.com/tphakala/go-flac v0.4.1/go.mod h1:d6cu4zAcEOyHq1mHJHvKH92v8i7/MmreUtcPsx7FhNs=
 github.com/tphakala/go-tflite v0.2.2-0.20260514101223-29408e53fff7 h1:fJtEs8rODoFDk8HDRwvNxIYEgsUUrEAvqPdllxF0cmg=
 github.com/tphakala/go-tflite v0.2.2-0.20260514101223-29408e53fff7/go.mod h1:xCgggryHiQ3nD0Sy0oCZESPWmzThLKKB28Vky5m6HCo=
 github.com/tphakala/goth v0.0.0-20260315123917-08c3db6a364a h1:BBvsu7Mes8McH6ikyagnU9y2N8hjoDxvDNCl162hwdA=

--- a/internal/audiocore/flac/encode_test.go
+++ b/internal/audiocore/flac/encode_test.go
@@ -3,6 +3,7 @@ package flac
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"math"
@@ -462,6 +463,37 @@ func TestEncodePCMToBuffer_FinalizesTotalSamples(t *testing.T) {
 	assert.NotZero(t, info.TotalSamples, "total_samples must be finalized, not the unknown sentinel")
 	assert.Equal(t, uint64(sampleCount), info.TotalSamples,
 		"total_samples must equal the input frame count")
+}
+
+// TestEncodePCMToBuffer_FinalizesBlockSize is the birdnet-go-side regression guard
+// for GitHub #3965: the in-memory BirdWeather upload path (a non-seekable
+// bytes.Buffer sink) must emit a STREAMINFO with a finalized, non-zero min/max block
+// size. A zero max_blocksize makes strict decoders (browser Web Audio decodeAudioData,
+// Apple CoreAudio) reject the soundscape, because they derive each fixed-blocksize
+// frame's running sample number as frame_number * max_blocksize and a zero collapses
+// every frame to sample 0. Requires go-flac >= v0.4.1.
+func TestEncodePCMToBuffer_FinalizesBlockSize(t *testing.T) {
+	t.Parallel()
+	const flacBlockSize = 4096 // go-flac's fixed encoder block size
+	// Several full 4096-sample frames plus a short final frame, matching a real clip.
+	pcm := makeTestPCM(5*flacBlockSize + 777)
+	buf, err := EncodePCMToBuffer(t.Context(), bufferBaseOpts(pcm))
+	require.NoError(t, err)
+
+	minBlk, maxBlk := streamInfoBlockSizes(t, buf.Bytes())
+	assert.Equal(t, flacBlockSize, minBlk, "min_blocksize must be finalized, not the 0 unknown sentinel")
+	assert.Equal(t, flacBlockSize, maxBlk, "max_blocksize must be finalized, not the 0 unknown sentinel")
+}
+
+// streamInfoBlockSizes parses the STREAMINFO min/max block size (in samples) from an
+// in-memory FLAC stream. STREAMINFO is always the first metadata block, so its body
+// starts at byte 8 ("fLaC" marker + 4-byte block header), with min_blocksize and
+// max_blocksize as the first two big-endian uint16 fields (bytes 8..9 and 10..11).
+func streamInfoBlockSizes(t *testing.T, flacBytes []byte) (minBlock, maxBlock int) {
+	t.Helper()
+	require.GreaterOrEqual(t, len(flacBytes), 12, "FLAC stream too short to hold STREAMINFO block sizes")
+	require.Equal(t, "fLaC", string(flacBytes[:4]), "missing fLaC stream marker")
+	return int(binary.BigEndian.Uint16(flacBytes[8:10])), int(binary.BigEndian.Uint16(flacBytes[10:12]))
 }
 
 func TestEncodePCMToBuffer_Validation(t *testing.T) {

--- a/internal/audiocore/flac/encode_test.go
+++ b/internal/audiocore/flac/encode_test.go
@@ -486,14 +486,25 @@ func TestEncodePCMToBuffer_FinalizesBlockSize(t *testing.T) {
 }
 
 // streamInfoBlockSizes parses the STREAMINFO min/max block size (in samples) from an
-// in-memory FLAC stream. STREAMINFO is always the first metadata block, so its body
-// starts at byte 8 ("fLaC" marker + 4-byte block header), with min_blocksize and
-// max_blocksize as the first two big-endian uint16 fields (bytes 8..9 and 10..11).
+// in-memory FLAC stream. It validates the "fLaC" marker and that the first metadata
+// block is STREAMINFO (which the spec mandates), so the fixed offsets are reliable:
+// the STREAMINFO body starts after the marker + metadata block header, with
+// min_blocksize and max_blocksize as its first two 16-bit big-endian fields.
 func streamInfoBlockSizes(t *testing.T, flacBytes []byte) (minBlock, maxBlock int) {
 	t.Helper()
-	require.GreaterOrEqual(t, len(flacBytes), 12, "FLAC stream too short to hold STREAMINFO block sizes")
-	require.Equal(t, "fLaC", string(flacBytes[:4]), "missing fLaC stream marker")
-	return int(binary.BigEndian.Uint16(flacBytes[8:10])), int(binary.BigEndian.Uint16(flacBytes[10:12]))
+	const (
+		markerLen           = 4 // "fLaC"
+		metaBlockHeaderLen  = 4 // 1 type/last-flag byte + 3 length bytes
+		metaBlockTypeMask   = 0x7f
+		streamInfoBlockType = 0                              // STREAMINFO must be the first metadata block
+		minBlockOffset      = markerLen + metaBlockHeaderLen // STREAMINFO body byte 0
+		maxBlockOffset      = minBlockOffset + 2             // STREAMINFO body byte 2
+		minLen              = maxBlockOffset + 2             // must reach through the max-block field
+	)
+	require.GreaterOrEqual(t, len(flacBytes), minLen, "FLAC stream too short to hold STREAMINFO block sizes")
+	require.Equal(t, "fLaC", string(flacBytes[:markerLen]), "missing fLaC stream marker")
+	require.Equal(t, byte(streamInfoBlockType), flacBytes[markerLen]&metaBlockTypeMask, "first FLAC metadata block must be STREAMINFO")
+	return int(binary.BigEndian.Uint16(flacBytes[minBlockOffset:])), int(binary.BigEndian.Uint16(flacBytes[maxBlockOffset:]))
 }
 
 func TestEncodePCMToBuffer_Validation(t *testing.T) {

--- a/internal/birdweather/encode_native_test.go
+++ b/internal/birdweather/encode_native_test.go
@@ -64,6 +64,14 @@ func TestEncodeWithNativeFLAC(t *testing.T) {
 	assert.Equal(t, uint64(conf.SampleRate), sampleRate, "FLAC STREAMINFO sample rate mismatch")
 	assert.Equal(t, uint64(sampleCount), totalSamples, "FLAC STREAMINFO total samples should be finalized")
 
+	// STREAMINFO must carry a finalized, non-zero block size on this non-seekable
+	// upload path (#3965). A zero max_blocksize makes browsers and CoreAudio reject
+	// the soundscape; go-flac >= v0.4.1 writes the fixed 4096 block size up front.
+	const flacBlockSize = 4096 // go-flac's fixed encoder block size
+	minBlock, maxBlock := flacBlockSizes(t, flacBytes)
+	assert.Equal(t, uint16(flacBlockSize), minBlock, "FLAC STREAMINFO min block size must be finalized, not the 0 sentinel")
+	assert.Equal(t, uint16(flacBlockSize), maxBlock, "FLAC STREAMINFO max block size must be finalized, not the 0 sentinel")
+
 	// Re-measure the decoded output: it should sit near the target loudness.
 	out := decodeToInt16(t, flacBytes)
 	meas, err := audionorm.MeasureInt16(out, conf.SampleRate, conf.NumChannels)

--- a/internal/birdweather/helpers_test.go
+++ b/internal/birdweather/helpers_test.go
@@ -63,6 +63,7 @@ func flacBlockSizes(t *testing.T, data []byte) (minBlock, maxBlock uint16) {
 	t.Helper()
 	require.GreaterOrEqual(t, len(data), flacStreamInfoMinLen, "FLAC data too short for STREAMINFO")
 	require.Equal(t, flacMagic, string(data[:flacMagicLen]), "FLAC signature not found")
+	require.Equal(t, byte(flacStreamInfoBlockType), data[flacMagicLen]&flacMetadataBlockTypeMask, "first FLAC metadata block must be STREAMINFO")
 	minBlock = binary.BigEndian.Uint16(data[flacMinBlockSizeOffset:])
 	maxBlock = binary.BigEndian.Uint16(data[flacMaxBlockSizeOffset:])
 	return minBlock, maxBlock

--- a/internal/birdweather/helpers_test.go
+++ b/internal/birdweather/helpers_test.go
@@ -31,6 +31,11 @@ const (
 	flacSampleRateShift        = 44
 	flacSampleRateMask         = 0xfffff
 	flacTotalSamplesBitCount   = 36
+	// The STREAMINFO body starts right after the "fLaC" marker and the 4-byte
+	// metadata block header; its first two 16-bit big-endian fields are the minimum
+	// and maximum block size (in samples).
+	flacMinBlockSizeOffset = flacMagicLen + flacMetadataBlockHeaderLen // body byte 0 (file byte 8)
+	flacMaxBlockSizeOffset = flacMinBlockSizeOffset + 2                // body byte 2 (file byte 10)
 )
 
 func flacStreamInfo(t *testing.T, data []byte) (sampleRate, totalSamples uint64) {
@@ -48,6 +53,19 @@ func flacStreamInfo(t *testing.T, data []byte) (sampleRate, totalSamples uint64)
 	sampleRate = (fields >> flacSampleRateShift) & flacSampleRateMask
 	totalSamples = fields & ((1 << flacTotalSamplesBitCount) - 1)
 	return sampleRate, totalSamples
+}
+
+// flacBlockSizes returns the STREAMINFO minimum and maximum block sizes (in
+// samples). Both must be non-zero and spec-legal (RFC 9639 requires 16..65535); a
+// zero max_blocksize makes strict decoders (browser Web Audio, Apple CoreAudio)
+// reject the stream, which is the BirdWeather soundscape failure in GitHub #3965.
+func flacBlockSizes(t *testing.T, data []byte) (minBlock, maxBlock uint16) {
+	t.Helper()
+	require.GreaterOrEqual(t, len(data), flacStreamInfoMinLen, "FLAC data too short for STREAMINFO")
+	require.Equal(t, flacMagic, string(data[:flacMagicLen]), "FLAC signature not found")
+	minBlock = binary.BigEndian.Uint16(data[flacMinBlockSizeOffset:])
+	maxBlock = binary.BigEndian.Uint16(data[flacMaxBlockSizeOffset:])
+	return minBlock, maxBlock
 }
 
 // TestParseSoundscapeResponse tests the JSON response parsing helper


### PR DESCRIPTION
## Problem

BirdWeather soundscapes fail to load in the browser. The in-memory FLAC upload path (`flac.EncodePCMToBuffer`, a non-seekable `bytes.Buffer` sink) left `STREAMINFO.min_blocksize`/`max_blocksize` at the `0` "unknown" sentinel. RFC 9639 requires those fields to be in `16..65535`, and a decoder derives each fixed-blocksize frame's running sample number as `frame_number * max_blocksize`, so a zero collapses every frame to sample 0: Chrome's Web Audio `decodeAudioData` throws "invalid content which cannot be decoded", Apple CoreAudio rejects the file, and `flac -t` warns "sample or frame number does not increase correctly" at every 4096-sample block boundary.

## Fix

Bumps `github.com/tphakala/go-flac` v0.4.0 to v0.4.1, which finalizes a spec-legal STREAMINFO block size up front on the non-seekable encode path (the fixed 4096 block size, floored to the 16-sample minimum). Audio and `total_samples` are unchanged; only the STREAMINFO block-size bytes differ. go-flac release notes: https://github.com/tphakala/go-flac/releases/tag/v0.4.1

## Tests

- `TestEncodePCMToBuffer_FinalizesBlockSize` (internal/audiocore/flac): asserts the in-memory encode output carries a finalized, non-zero block size.
- `TestEncodeWithNativeFLAC` (internal/birdweather): asserts the same at the actual soundscape upload layer, guarding the exact path that regressed.

Both fail against go-flac v0.4.0 (block size 0) and pass on v0.4.1.

Fixes #3965.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * FLAC encoding now finalizes STREAMINFO block-size metadata correctly for in-memory and native upload paths.
  * Encoded files report the expected block size instead of leaving these values unset.

* **Tests**
  * Added regression coverage to verify finalized FLAC block-size metadata across supported encoding paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->