### PR TITLE
fix(frontend): stop the hour axis stretching past the last hour

### DIFF
--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/AcousticSuccessionChart.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/AcousticSuccessionChart.svelte
@@ -30,7 +30,13 @@
   import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
   import BaseChart from './BaseChart.svelte';
   import { createLinearScale } from './utils/scales';
-  import { createAxis, styleAxis, addAxisLabel, createHourAxisFormatter } from './utils/axes';
+  import {
+    createAxis,
+    styleAxis,
+    addAxisLabel,
+    createHourAxisFormatter,
+    hourAxisTickValues,
+  } from './utils/axes';
   import { ChartTooltip } from './utils/interactions';
   import type { ChartTheme } from './utils/theme';
   import { getSpeciesColor, registerChart } from './utils/speciesColor';
@@ -192,7 +198,13 @@
     }
     if (!Number.isFinite(yMin) || !Number.isFinite(yMax) || yMax - yMin < MIN_Y_SPAN) return;
 
-    const xScale = createLinearScale({ domain: [0, SUCCESSION_HOURS - 1], range: [0, innerWidth] });
+    // nice: false - the hour domain is exact; rounding it outward would leave the final hour short
+    // of the right edge and open a gap the bands never reach.
+    const xScale = createLinearScale({
+      domain: [0, SUCCESSION_HOURS - 1],
+      range: [0, innerWidth],
+      nice: false,
+    });
     const yScale = scaleLinear().domain([yMin, yMax]).range([innerHeight, 0]);
 
     // X axis: sampled hour ticks along the bottom. No y-axis (the wiggle baseline is meaningless).
@@ -201,9 +213,7 @@
       orientation: 'bottom',
       tickFormat: (d: AxisDomain) => hourFmt(Number(d)),
     });
-    xAxis.tickValues(
-      Array.from({ length: Math.ceil(SUCCESSION_HOURS / X_TICK_STEP) }, (_, i) => i * X_TICK_STEP)
-    );
+    xAxis.tickValues(hourAxisTickValues(SUCCESSION_HOURS - 1, X_TICK_STEP));
     const xAxisGroup = chartGroup
       .append('g')
       .attr('class', 'x-axis')

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesRidgeline.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesRidgeline.svelte
@@ -23,7 +23,13 @@
   import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
   import BaseChart from './BaseChart.svelte';
   import { createLinearScale } from './utils/scales';
-  import { createAxis, styleAxis, addAxisLabel, createHourAxisFormatter } from './utils/axes';
+  import {
+    createAxis,
+    styleAxis,
+    addAxisLabel,
+    createHourAxisFormatter,
+    hourAxisTickValues,
+  } from './utils/axes';
   import { ChartTooltip } from './utils/interactions';
   import type { ChartTheme } from './utils/theme';
   import { fitTextNode } from './utils/labels';
@@ -158,7 +164,13 @@
 
     // x: density index -> px. All series share the same length (24 hours / N bins); use the widest.
     const xLen = Math.max(1, ...rows.map(r => r.density.length));
-    const xScale = createLinearScale({ domain: [0, xLen - 1], range: [0, innerWidth] });
+    // nice: false - the bin domain is exact; rounding it outward would leave the last bin short of
+    // the right edge and open a gap the ridges never reach.
+    const xScale = createLinearScale({
+      domain: [0, xLen - 1],
+      range: [0, innerWidth],
+      nice: false,
+    });
 
     // Shared amplitude scale: global-max density -> layout.amplitude px above the baseline.
     const ampScale = scaleLinear()
@@ -172,7 +184,7 @@
       tickFormat: (d: AxisDomain) => tickFmt(Number(d)),
     });
     const step = Math.max(1, xTickStep);
-    xAxis.tickValues(Array.from({ length: Math.ceil(xLen / step) }, (_, i) => i * step));
+    xAxis.tickValues(hourAxisTickValues(xLen - 1, step));
     const xAxisGroup = chartGroup
       .append('g')
       .attr('class', 'x-axis')

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/TimeOfDaySpeciesChart.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/TimeOfDaySpeciesChart.svelte
@@ -10,7 +10,13 @@
   import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
   import BaseChart from './BaseChart.svelte';
   import { createLinearScale } from './utils/scales';
-  import { createAxis, styleAxis, addAxisLabel, createHourAxisFormatter } from './utils/axes';
+  import {
+    createAxis,
+    styleAxis,
+    addAxisLabel,
+    createHourAxisFormatter,
+    hourAxisTickValues,
+  } from './utils/axes';
   import { ChartTooltip, addCrosshair, createLegend } from './utils/interactions';
   import { getCurrentTheme, type ChartTheme } from './utils/theme';
   import { getSpeciesColor, registerChart } from './utils/speciesColor';
@@ -127,6 +133,9 @@
     const xScale = createLinearScale({
       domain: [0, 23],
       range: [0, innerWidth],
+      // 0..23 is the exact hour domain; nice() would stretch it to 0..24 and leave 23:00 short of
+      // the right edge.
+      nice: false,
     });
 
     const yScale = createLinearScale({
@@ -145,8 +154,9 @@
       scale: xScale,
       orientation: 'bottom',
       tickFormat: (d: AxisDomain) => hourFormatter(d as number),
-      tickCount: 12,
     });
+    // Explicit hour ticks so the axis ends with a real 23:00 label at the edge.
+    xAxis.tickValues(hourAxisTickValues());
 
     const yAxis = createAxis({
       scale: yScale,

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/axes.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/axes.test.ts
@@ -1,7 +1,32 @@
 import { describe, it, expect } from 'vitest';
 import { scaleTime } from 'd3-scale';
 
-import { boundaryDateTicks } from './axes';
+import { boundaryDateTicks, hourAxisTickValues } from './axes';
+
+describe('hourAxisTickValues', () => {
+  it('always ends on the final hour so the edge is labelled', () => {
+    const ticks = hourAxisTickValues(23, 3);
+    expect(ticks[0]).toBe(0);
+    expect(ticks[ticks.length - 1]).toBe(23);
+    // d3's own ticks would stop at 21 and leave the last hour unlabelled at the plot edge.
+    expect(ticks).toEqual([0, 3, 6, 9, 12, 15, 18, 21, 23]);
+  });
+
+  it('drops a regular tick that would collide with the final hour', () => {
+    // With a step of 4, 20 sits 3 hours from 23 (>= half a step) and survives; a tick at 22 would
+    // not. Verified via a step whose last multiple lands adjacent to the final hour.
+    expect(hourAxisTickValues(23, 4)).toEqual([0, 4, 8, 12, 16, 20, 23]);
+    // Step 2 would put a tick at 22, only 1 hour from 23 (< half a step), so it is dropped.
+    expect(hourAxisTickValues(23, 2)).not.toContain(22);
+  });
+
+  it('never emits a tick beyond the final hour', () => {
+    for (const step of [1, 2, 3, 4, 6]) {
+      const ticks = hourAxisTickValues(23, step);
+      expect(Math.max(...ticks)).toBe(23);
+    }
+  });
+});
 
 describe('boundaryDateTicks', () => {
   it('always includes the exact domain start and end', () => {

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/axes.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/axes.ts
@@ -149,6 +149,29 @@ export function createHourAxisFormatter(use24Hour = true): (d: number) => string
   };
 }
 
+// Default spacing between hour-of-day ticks. Three hours keeps ~8 labels across a full-width chart
+// without crowding the forced final-hour tick.
+const HOUR_TICK_STEP = 3;
+
+/**
+ * Tick values for a 0..lastHour hour-of-day axis, always including the final hour.
+ *
+ * d3's own ticks stop at the last "nice" multiple (22:00 for a 0..23 axis), leaving the final hour
+ * unlabeled at the plot edge. Forcing `lastHour` puts a correctly positioned label there. A regular
+ * tick no more than half a step from the final hour is dropped so the two labels cannot collide
+ * (with a 2-hour step that removes 22:00, which would otherwise sit right on top of 23:00).
+ */
+export function hourAxisTickValues(lastHour = 23, step = HOUR_TICK_STEP): number[] {
+  const ticks: number[] = [];
+  for (let hour = 0; hour < lastHour; hour += step) {
+    if (lastHour - hour > step / 2) {
+      ticks.push(hour);
+    }
+  }
+  ticks.push(lastHour);
+  return ticks;
+}
+
 // Constants for date-range bucketing.
 const MS_PER_DAY = 86400000;
 const WEEK_THRESHOLD = 7;

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/scales.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/scales.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+
+import { createLinearScale } from './scales';
+
+describe('createLinearScale', () => {
+  it('rounds the domain outward by default', () => {
+    // The default suits value axes, where rounding a max up to a tidy number is desirable.
+    const scale = createLinearScale({ domain: [0, 23], range: [0, 1000] });
+    expect(scale.domain()).toEqual([0, 24]);
+  });
+
+  it('leaves an exact domain untouched when nice is false', () => {
+    // Regression: an hour-of-day axis is exactly 0..23. Rounding it to 0..24 pushed the final hour
+    // to ~96% of the width, so every series stopped short of the plot edge, and it added a tick at
+    // hour 24 that the hour formatter clamped to a misplaced "23:00" label.
+    const scale = createLinearScale({ domain: [0, 23], range: [0, 1000], nice: false });
+    expect(scale.domain()).toEqual([0, 23]);
+    expect(scale(23)).toBe(1000);
+    expect(scale(0)).toBe(0);
+  });
+
+  it('still validates the domain when nice is disabled', () => {
+    expect(() =>
+      // @ts-expect-error - exercising the runtime guard with a malformed domain
+      createLinearScale({ domain: ['a', 'b'], range: [0, 1000], nice: false })
+    ).toThrow(TypeError);
+  });
+});

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/scales.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/scales.ts
@@ -16,6 +16,15 @@ import { generateSpeciesColors, getCurrentTheme } from './theme';
 export interface LinearScaleConfig {
   domain: [number, number];
   range: [number, number];
+  /**
+   * Round the domain outward to "nice" values (default true).
+   *
+   * Pass false when the domain is already exact and must not grow. An hour-of-day axis is the
+   * motivating case: `nice()` stretches [0, 23] to [0, 24], which leaves the final hour ~4% short
+   * of the plot edge and adds a tick beyond the data (which an hour formatter then clamps back to
+   * "23:00", labelling hour 24 as 23:00).
+   */
+  nice?: boolean;
 }
 
 export interface BandScaleConfig {
@@ -42,7 +51,10 @@ export function createLinearScale(config: LinearScaleConfig): ScaleLinear<number
     throw new TypeError('createLinearScale: domain must be [number, number]');
   }
 
-  const scale = scaleLinear().domain(config.domain).range(config.range).nice();
+  const scale = scaleLinear().domain(config.domain).range(config.range);
+  if (config.nice ?? true) {
+    scale.nice();
+  }
 
   return scale;
 }


### PR DESCRIPTION
## Summary

Every hour-based chart on the Analytics **Patterns** tab stopped drawing before the right edge, leaving a dead ~1 hour gap — and the axis label at that edge was in the wrong place. Reported during QA: the tooltip showed real 23:00 values while the series appeared to end around 22:30.

## Root cause

`createLinearScale` applied d3's `nice()` **unconditionally**. `nice()` rounds a domain outward, which is right for a value axis but wrong for an hour-of-day axis whose domain is already exact:

```js
scaleLinear().domain([0, 23]).nice()   // -> domain [0, 24]
scale(23)                              // -> 958 of 1000  (~96%)
scale.ticks(12)                        // -> 0,2,…,22,24
```

Two consequences on each affected chart:

1. **Dead space.** Hour 23 renders at ~96% of the width, so every series stops short of the plot edge.
2. **The axis mislabels itself.** `nice()` adds a tick at hour **24**, and `createHourAxisFormatter` clamps values to 23 (`Math.min(23, …)`), so that tick renders as **"23:00"** — at a position where the 23:00 data is *not*. The real 23:00 point sits to its left, which is why hovering 23:00 showed values while the line looked finished.

Affected (all three build the same hour scale): `TimeOfDaySpeciesChart` (`[0, 23]`), `AcousticSuccessionChart` (`[0, SUCCESSION_HOURS - 1]`), `SpeciesRidgeline` (`[0, xLen - 1]`).

## Changes

- **`utils/scales.ts`** — `LinearScaleConfig` gains an optional `nice` flag, **defaulting to `true`** so every existing value axis is byte-for-byte unchanged. Only the hour axes opt out.
- **`utils/axes.ts`** — new `hourAxisTickValues(lastHour, step)`. d3's own ticks stop at the last nice multiple (22:00), leaving the final hour unlabeled; this always includes `lastHour` so the axis ends with a correctly positioned label at the edge. A regular tick no more than half a step from the final hour is dropped so the two can't collide (with a 2-hour step that removes 22:00).
- **The three charts** — pass `nice: false` and take their ticks from the shared helper, replacing two hand-rolled `Array.from(...)` tick expressions.

## Tests

- `scales.test.ts` (new): documents that the default still rounds `[0,23]` → `[0,24]`, and that `nice: false` keeps the domain exact with `scale(23)` landing on the plot edge. Also covers that domain validation still runs when `nice` is disabled.
- `axes.test.ts`: `hourAxisTickValues` always ends on the final hour, drops a colliding neighbour, and never emits a tick beyond it (checked across several steps).
- 202 chart tests pass; `npm run check:all` clean (svelte-check: 0 errors, 0 warnings).

## Notes

Pre-existing — it predates the current time-of-day work and is unrelated to it; it only became obvious once there was enough data in the final hour to notice. Kept separate from #3969 for that reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated analytics charts to preserve exact hour ranges and display the final hour tick, including 23:00.
  * Improved tick spacing to reduce label collisions and ensure consistent hour-axis formatting across charts.

* **Tests**
  * Added coverage for hour-axis tick generation and exact linear-scale domain behavior.
  * Verified validation remains intact for invalid scale domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->