### PR TITLE
fix(audio): normalize quiet clips to target on the native export path

### DIFF
--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -6,6 +6,7 @@ package processor
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -20,6 +21,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/audiocore/flac"
 	"github.com/tphakala/birdnet-go/internal/audiocore/opus"
+	"github.com/tphakala/birdnet-go/internal/audiocore/pcmgain"
 	"github.com/tphakala/birdnet-go/internal/audiocore/resample"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
@@ -776,27 +778,92 @@ func audionormSupportsTargets(targetLUFS, truePeakDBTP float64) bool {
 	return targetLUFS < 0 && targetLUFS > audionormMinTargetLUFS && truePeakDBTP <= 0
 }
 
+// nativeExportMaxGainDB is the absolute backstop on the loudness gain a native
+// export applies. It is not an arbitrary round number: the widest lift any
+// in-range configuration can legitimately ask for is the most aggressive
+// permitted target (conf.MaxTargetLUFS, -10) minus the EBU R128 absolute gate
+// (audionormMinTargetLUFS, -70), which is exactly 60 dB. It also coincides with
+// the ceiling the FFmpeg loudnorm path allows (ffmpeg.MaxGainDB), so a quiet
+// clip is corrected no less on a native encoder than it was on FFmpeg.
+//
+// Deliberately not audionorm.DefaultMaxGainDB (30 dB). That is the BirdWeather
+// soundscape-upload ceiling and stays where it is: those uploads go to a public
+// platform and are not this path's to change. At the default -23 LUFS target
+// the per-clip bounds below always bind first, so this constant only backstops
+// the most aggressive targets.
+const nativeExportMaxGainDB = 60.0
+
+// gateFallbackGainDB handles the clip EBU R128 gating cannot measure. A clip
+// whose gated integrated loudness falls below the -70 LUFS absolute gate yields
+// -Inf, and PlanGain plans no gain at all for it, so the clip would be exported
+// untouched and inaudible. When such a clip still has a finite true peak there
+// is enough signal to work with, so the gain is anchored to the true-peak
+// ceiling, as the FFmpeg path does in loudnormGateFallbackOffset.
+//
+// That anchor alone is not enough. Lifting purely by true-peak headroom leaves
+// the resulting loudness at (ceiling - crest factor), so a FLAT signal (steady
+// hiss from a dead or muted microphone, whose crest factor is only a few dB)
+// lands far LOUDER than the loudness target: measured, a sub-gate noise floor
+// came out at -13.8 LUFS against a -23 target. The second bound closes that.
+// Gating failing is itself information: the clip's true loudness must be below
+// audionormMinTargetLUFS, so lifting by no more than (target - gate) cannot
+// overshoot the target however peaky or flat the clip turns out to be.
+//
+// That premise is worth stating precisely, since the bound rests on it.
+// audionorm's meter reports -Inf on exactly three paths: every 400 ms block sat
+// under the absolute gate (the premise holds by construction); the relative gate
+// eliminated every block (unreachable, because the loudest gated block always
+// exceeds a gate set 10 LU below their mean); or the clip is shorter than one
+// 400 ms block, where loudness is undefined at ANY level. Only that third path
+// breaks the premise, and it cannot arise here because exported clips are whole
+// detection segments, orders of magnitude longer. Even if it did, the true-peak
+// anchor is the tighter bound for a short LOUD clip, so it would still attenuate
+// rather than amplify.
+//
+// Genuine silence (a true peak of -Inf too) reports false and is left alone;
+// there is nothing to lift.
+func gateFallbackGainDB(meas audionorm.Measurement, targetLUFS, truePeakDBTP float64) (gainDB float64, ok bool) {
+	if !math.IsInf(meas.IntegratedLUFS, -1) || math.IsInf(meas.TruePeakDBTP, -1) {
+		return 0, false
+	}
+	peakBound := truePeakDBTP - meas.TruePeakDBTP
+	loudnessBound := targetLUFS - audionormMinTargetLUFS
+	return math.Min(peakBound, loudnessBound), true
+}
+
+// refineLiftedGainDB returns the extra gain to add on top of a gate-fallback
+// lift. Loudness gating is not linear in gain, so the loudness of the lifted
+// signal cannot be derived arithmetically: blocks that sat under the absolute
+// gate before the lift pass it afterwards. The only way to know is to measure
+// the lifted signal, which is what this does, on a copy so pcm is untouched.
+//
+// Once the clip is measurable a normal PlanGain finishes the job, landing it on
+// the target and respecting the true-peak ceiling. A clip still under the gate
+// after the lift (or a measurement error) yields 0, leaving the conservative
+// fallback as the final answer rather than guessing.
+//
+// This runs only for sub-gate clips, so the extra measurement pass is off the
+// common path entirely.
+func refineLiftedGainDB(pcm []byte, liftDB float64, opts audionorm.Options) float64 {
+	lifted, err := audionorm.MeasureInt16Bytes(pcmgain.Applied(pcm, liftDB), opts.SampleRate, opts.Channels)
+	if err != nil || math.IsInf(lifted.IntegratedLUFS, -1) {
+		return 0
+	}
+	return audionorm.PlanGain(lifted, opts).GainDB
+}
+
 // planNativeNormalizationGain measures the clip's EBU R128 integrated loudness and
 // true peak with audionorm and returns the single linear gain (dB) that brings it
 // to targetLUFS without its true peak exceeding truePeakDBTP, clamped to
-// +/-audionorm.DefaultMaxGainDB. Silent or sub-400 ms input yields 0 (the clip is
-// left unchanged rather than boosted into noise), matching the BirdWeather native
-// path. The gain is applied by flac.EncodePCM during encoding; a.pcmData is not
-// modified here.
+// +/-nativeExportMaxGainDB. A clip under the R128 absolute gate is lifted by its
+// true-peak headroom instead (see gateFallbackGainDB); genuine silence yields 0.
+// The gain is applied by the encoder; a.pcmData is not modified here.
 func (a *SaveAudioAction) planNativeNormalizationGain(ctx context.Context, sampleRate int, format string, targetLUFS, truePeakDBTP float64) (float64, error) {
 	if err := ctx.Err(); err != nil {
 		return 0, err
 	}
-	// audionorm decodes the PCM bytes inline; a.pcmData is not mutated. Silence
-	// yields GainDB == 0 (audionorm returns -Inf LUFS); the clamp is the secondary
-	// guard for low-peak clips and for attenuation, applied silently on this path
-	// (the BirdWeather path logs its own limiting, hence the discarded flag).
-	gainDB, meas, res, _, err := audionorm.PlanClampedGainInt16Bytes(a.pcmData, audionorm.Options{
-		SampleRate:   sampleRate,
-		Channels:     conf.NumChannels,
-		TargetLUFS:   targetLUFS,
-		TruePeakDBTP: truePeakDBTP,
-	}, audionorm.DefaultMaxGainDB)
+	// audionorm decodes the PCM bytes inline; a.pcmData is not mutated.
+	meas, err := audionorm.MeasureInt16Bytes(a.pcmData, sampleRate, conf.NumChannels)
 	if err != nil {
 		return 0, errors.New(err).
 			Component("analysis.processor").
@@ -807,6 +874,28 @@ func (a *SaveAudioAction) planNativeNormalizationGain(ctx context.Context, sampl
 			Build()
 	}
 
+	opts := audionorm.Options{
+		SampleRate:   sampleRate,
+		Channels:     conf.NumChannels,
+		TargetLUFS:   targetLUFS,
+		TruePeakDBTP: truePeakDBTP,
+	}
+	res := audionorm.PlanGain(meas, opts)
+
+	planned := res.GainDB
+	gateLifted := false
+	if fallback, ok := gateFallbackGainDB(meas, targetLUFS, truePeakDBTP); ok {
+		// The fallback is deliberately conservative, because a sub-gate clip's
+		// real loudness is unknown and the bound has to assume the worst case.
+		// Lifting it, however, usually raises it above the gate, at which point
+		// it CAN be measured: refine from that real measurement so a very quiet
+		// clip still lands on target instead of merely somewhere audible.
+		planned = fallback + refineLiftedGainDB(a.pcmData, fallback, opts)
+		gateLifted = true
+	}
+
+	gainDB, clamped := audionorm.ClampGainDB(planned, nativeExportMaxGainDB)
+
 	GetLogger().Debug("Native loudness analysis (detection save)",
 		logger.String("format", format),
 		logger.Float64("measured_lufs", meas.IntegratedLUFS),
@@ -814,6 +903,8 @@ func (a *SaveAudioAction) planNativeNormalizationGain(ctx context.Context, sampl
 		logger.Float64("target_lufs", targetLUFS),
 		logger.Float64("gain_db", gainDB),
 		logger.Bool("peak_limited", res.PeakLimited),
+		logger.Bool("gate_lifted", gateLifted),
+		logger.Bool("gain_clamped", clamped),
 		logger.String("detection_id", a.CorrelationID))
 	return gainDB, nil
 }

--- a/internal/analysis/processor/native_normalization_test.go
+++ b/internal/analysis/processor/native_normalization_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"io"
 	"math"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"testing"
@@ -17,6 +18,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/audiocore/audionorm"
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/audiocore/flac"
+	"github.com/tphakala/birdnet-go/internal/audiocore/pcmgain"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
@@ -32,6 +34,45 @@ func sinePCMBytes(amp int16, seconds, freqHz float64) []byte {
 		binary.LittleEndian.PutUint16(buf[i*2:], uint16(int16(math.Round(v))))
 	}
 	return buf
+}
+
+// burstPCMBytes builds a mono 16-bit LE PCM buffer of totalSeconds that is
+// silent except for a burst of sine at the start. A short enough burst leaves
+// every 400 ms R128 block below the -70 LUFS absolute gate while the true peak
+// stays well above it, which is the sub-gate shape the gate fallback exists for
+// and which a steady sine cannot produce.
+func burstPCMBytes(amp int16, totalSeconds, burstSeconds, freqHz float64) []byte {
+	buf := make([]byte, int(float64(conf.SampleRate)*totalSeconds)*2)
+	burst := int(float64(conf.SampleRate) * burstSeconds)
+	for i := range burst {
+		v := float64(amp) * math.Sin(2*math.Pi*freqHz*float64(i)/float64(conf.SampleRate))
+		//nolint:gosec // G115: rounded sine within int16 range, then LE bit-write
+		binary.LittleEndian.PutUint16(buf[i*2:], uint16(int16(math.Round(v))))
+	}
+	return buf
+}
+
+// noisePCMBytes builds mono 16-bit LE uniform noise of the given peak amplitude.
+// Unlike a sine or a short burst it has a LOW crest factor, which is the shape
+// that exposes a true-peak-anchored lift overshooting the loudness target. The
+// generator is seeded so the measurement is reproducible.
+func noisePCMBytes(amp, seconds float64) []byte {
+	n := int(float64(conf.SampleRate) * seconds)
+	buf := make([]byte, n*2)
+	r := rand.New(rand.NewSource(42)) //nolint:gosec // G404: deterministic test fixture, not security
+	for i := range n {
+		v := (r.Float64()*2 - 1) * amp
+		//nolint:gosec // G115: bounded by amp, well inside int16 range
+		binary.LittleEndian.PutUint16(buf[i*2:], uint16(int16(math.Round(v))))
+	}
+	return buf
+}
+
+func measureTruePeak(t *testing.T, pcm []byte) float64 {
+	t.Helper()
+	meas, err := audionorm.MeasureInt16Bytes(pcm, conf.SampleRate, conf.NumChannels)
+	require.NoError(t, err)
+	return meas.TruePeakDBTP
 }
 
 func measureLUFS(t *testing.T, pcm []byte) float64 {
@@ -64,7 +105,163 @@ func TestPlanNativeNormalizationGain_QuietClipReachesTarget(t *testing.T) {
 	assert.Positive(t, gainDB, "quiet clip must be boosted")
 	assert.InDelta(t, testTargetLUFS, measured+gainDB, 0.1,
 		"gain must bring the measured loudness onto the target (not peak-limited, not clamped)")
-	assert.Less(t, gainDB, audionorm.DefaultMaxGainDB, "this clip must not hit the clamp")
+	assert.Less(t, gainDB, nativeExportMaxGainDB, "this clip must not hit the clamp")
+}
+
+// TestPlanNativeNormalizationGain_VeryQuietClipPassesOldClamp guards the ceiling
+// raise from 30 dB to nativeExportMaxGainDB. A clip around -61 LUFS wants ~+38 dB,
+// which the old 30 dB clamp truncated, leaving the export ~8 LU below target while
+// the FFmpeg path (ceiling 60 dB) reached it. It must now reach target too.
+func TestPlanNativeNormalizationGain_VeryQuietClipPassesOldClamp(t *testing.T) {
+	t.Parallel()
+	pcm := sinePCMBytes(40, 1.0, 1000) // ~-61 LUFS
+	measured := measureLUFS(t, pcm)
+	require.Less(t, measured, testTargetLUFS-30, "sanity: uncapped gain exceeds the old 30 dB clamp")
+	require.Greater(t, measured, audionormMinTargetLUFS, "sanity: still above the absolute gate")
+
+	a := &SaveAudioAction{pcmData: pcm, CorrelationID: "test"}
+	gainDB, err := a.planNativeNormalizationGain(t.Context(), conf.SampleRate, ffmpeg.FormatFLAC, testTargetLUFS, testTruePeakDBTP)
+	require.NoError(t, err)
+
+	assert.Greater(t, gainDB, 30.0, "must no longer be truncated at the old 30 dB clamp")
+	assert.InDelta(t, testTargetLUFS, measured+gainDB, 0.1, "must now land on the loudness target")
+}
+
+// TestPlanNativeNormalizationGain_SubGateClipIsLifted covers the defect this
+// change exists to fix. A clip whose every R128 block sits below the -70 LUFS
+// absolute gate measures -Inf, so the loudness plan asks for no gain and the clip
+// used to be exported untouched and inaudible. With a finite true peak it must
+// instead be lifted to the true-peak ceiling.
+func TestPlanNativeNormalizationGain_SubGateClipIsLifted(t *testing.T) {
+	t.Parallel()
+	pcm := burstPCMBytes(45, 1.0, 0.01, 1000)
+	require.True(t, math.IsInf(measureLUFS(t, pcm), -1), "sanity: clip must be under the R128 absolute gate")
+
+	truePeak := measureTruePeak(t, pcm)
+	require.False(t, math.IsInf(truePeak, -1), "sanity: clip must still have a finite true peak")
+
+	a := &SaveAudioAction{pcmData: pcm, CorrelationID: "test"}
+	gainDB, err := a.planNativeNormalizationGain(t.Context(), conf.SampleRate, ffmpeg.FormatFLAC, testTargetLUFS, testTruePeakDBTP)
+	require.NoError(t, err)
+
+	assert.Positive(t, gainDB, "a sub-gate clip with signal in it must not be exported untouched")
+	assert.LessOrEqual(t, truePeak+gainDB, testTruePeakDBTP+0.1,
+		"the lift must never push the true peak above the ceiling")
+
+	// The conservative fallback alone would stop at the loudness bound, leaving
+	// the clip merely audible. The refinement pass re-measures the lifted signal
+	// and finishes the job, so the clip actually lands on target.
+	assert.Greater(t, gainDB, testTargetLUFS-audionormMinTargetLUFS,
+		"the refinement pass must carry the lift past the conservative bound")
+
+	after, err := audionorm.MeasureInt16Bytes(pcmgain.Applied(pcm, gainDB), conf.SampleRate, conf.NumChannels)
+	require.NoError(t, err)
+	assert.InDelta(t, testTargetLUFS, after.IntegratedLUFS, 0.5,
+		"a lifted sub-gate clip must end up on the loudness target")
+}
+
+// TestGateFallbackGainDB pins the fallback's contract directly, rather than only
+// through planNativeNormalizationGain. That matters because the refinement pass
+// downstream re-measures and corrects the result, so an integration-level test
+// stays green even if a bound here is removed (mutation-verified). These bounds
+// are the safety net for the case refinement cannot rescue: a clip still under
+// the gate after the lift, or a failed re-measurement.
+func TestGateFallbackGainDB(t *testing.T) {
+	t.Parallel()
+
+	const (
+		target  = -23.0
+		ceiling = -2.0
+	)
+	// The lift that brings a clip sitting exactly at the absolute gate to target.
+	loudnessBound := target - audionormMinTargetLUFS
+
+	tests := []struct {
+		name     string
+		meas     audionorm.Measurement
+		wantOK   bool
+		wantGain float64
+		why      string
+	}{
+		{
+			name:   "measurable loudness is not the fallback's business",
+			meas:   audionorm.Measurement{IntegratedLUFS: -40, TruePeakDBTP: -30},
+			wantOK: false,
+			why:    "PlanGain already handles any clip R128 can measure",
+		},
+		{
+			name:   "digital silence is left alone",
+			meas:   audionorm.Measurement{IntegratedLUFS: math.Inf(-1), TruePeakDBTP: math.Inf(-1)},
+			wantOK: false,
+			why:    "there is no signal to lift, so amplifying would only invent noise",
+		},
+		{
+			name:     "peaky sub-gate clip is bounded by the true-peak ceiling",
+			meas:     audionorm.Measurement{IntegratedLUFS: math.Inf(-1), TruePeakDBTP: -10},
+			wantOK:   true,
+			wantGain: 8, // ceiling - truePeak; tighter than the 47 dB loudness bound
+			why:      "lifting further would push the peak past the ceiling",
+		},
+		{
+			name:     "flat sub-gate clip is bounded by the loudness target",
+			meas:     audionorm.Measurement{IntegratedLUFS: math.Inf(-1), TruePeakDBTP: -80},
+			wantOK:   true,
+			wantGain: loudnessBound, // 78 dB of peak headroom, but only 47 is safe
+			why:      "the true-peak anchor alone would drive a flat signal past the target",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gain, ok := gateFallbackGainDB(tt.meas, target, ceiling)
+			require.Equal(t, tt.wantOK, ok, tt.why)
+			if tt.wantOK {
+				assert.InDelta(t, tt.wantGain, gain, 1e-9, tt.why)
+			} else {
+				assert.Zero(t, gain, "a fallback that does not apply must plan no gain")
+			}
+		})
+	}
+}
+
+// TestPlanNativeNormalizationGain_SubGateFlatSignalDoesNotOvershoot is the
+// regression guard for a defect found by measurement, not by reading: anchoring
+// a sub-gate lift purely to true-peak headroom leaves the output loudness at
+// (ceiling - crest factor), so a FLAT signal is driven far past the target. A
+// steady low-level noise floor (a dead or muted microphone) has a crest factor
+// of only a few dB and came out at -13.8 LUFS against a -23 target, i.e. a user
+// upgrading would get loud hiss where they previously got a silent clip.
+//
+// The loudness bound in gateFallbackGainDB exists solely to prevent this, so
+// this test asserts the property that bound guarantees.
+func TestPlanNativeNormalizationGain_SubGateFlatSignalDoesNotOvershoot(t *testing.T) {
+	t.Parallel()
+
+	// Steady uniform noise: sub-gate integrated loudness, low crest factor.
+	pcm := noisePCMBytes(8, 1.0)
+	meas, err := audionorm.MeasureInt16Bytes(pcm, conf.SampleRate, conf.NumChannels)
+	require.NoError(t, err)
+	require.True(t, math.IsInf(meas.IntegratedLUFS, -1), "sanity: clip must be under the R128 absolute gate")
+	require.False(t, math.IsInf(meas.TruePeakDBTP, -1), "sanity: clip must still have a finite true peak")
+
+	a := &SaveAudioAction{pcmData: pcm, CorrelationID: "test"}
+	gainDB, err := a.planNativeNormalizationGain(t.Context(), conf.SampleRate, ffmpeg.FormatFLAC, testTargetLUFS, testTruePeakDBTP)
+	require.NoError(t, err)
+	assert.Positive(t, gainDB, "the clip must still be lifted out of inaudibility")
+
+	// Measure what the encoder would actually write, rather than trusting the
+	// planned gain: the whole defect was a mismatch between the two.
+	after, err := audionorm.MeasureInt16Bytes(pcmgain.Applied(pcm, gainDB), conf.SampleRate, conf.NumChannels)
+	require.NoError(t, err)
+
+	// The property that matters: never LOUDER than the target. The small
+	// tolerance absorbs the measurement round trip, and is far tighter than the
+	// ~10 LU overshoot this test exists to catch.
+	assert.LessOrEqual(t, after.IntegratedLUFS, testTargetLUFS+0.5,
+		"a flat sub-gate clip must never be lifted past the loudness target")
+	assert.InDelta(t, testTargetLUFS, after.IntegratedLUFS, 0.5,
+		"and it should still reach the target, not stop short of it")
 }
 
 // TestPlanNativeNormalizationGain_Silence keeps silent input unchanged (gain 0)
@@ -78,23 +275,32 @@ func TestPlanNativeNormalizationGain_Silence(t *testing.T) {
 	assert.Zero(t, gainDB, "silence must not be amplified")
 }
 
-// TestPlanNativeNormalizationGain_ClampsExtremeBoost bounds a near-silent (but
-// above the gate) clip to +audionorm.DefaultMaxGainDB instead of the full
-// target-driven gain.
+// TestPlanNativeNormalizationGain_ClampsExtremeBoost bounds the gain at
+// nativeExportMaxGainDB.
+//
+// Reaching that backstop takes the most aggressive target the config allows.
+// nativeExportMaxGainDB is conf.MaxTargetLUFS (-10) minus the R128 absolute gate
+// (-70), so at any lower target both the loudness bound and the measurable-clip
+// path stay strictly under it and the ceiling never binds. This uses -10 so the
+// backstop is genuinely exercised rather than asserted against dead code.
 func TestPlanNativeNormalizationGain_ClampsExtremeBoost(t *testing.T) {
 	t.Parallel()
-	// ~-61 LUFS with a low peak: wants ~+38 dB, above the +30 clamp and below the
-	// true-peak ceiling, so the clamp (not the ceiling) binds.
-	pcm := sinePCMBytes(40, 1.0, 1000)
-	measured := measureLUFS(t, pcm)
-	require.Less(t, measured, testTargetLUFS-audionorm.DefaultMaxGainDB,
-		"sanity: uncapped gain would exceed the clamp")
-	require.Greater(t, measured, audionormMinTargetLUFS+3, "sanity: still above the absolute gate")
+	// A very short, very low burst in silence: sub-gate loudness and a true peak
+	// around -72 dBFS, so both fallback bounds exceed the ceiling.
+	const aggressiveTargetLUFS = -10.0 // conf.MaxTargetLUFS
+	pcm := burstPCMBytes(8, 1.0, 0.01, 1000)
+	require.True(t, math.IsInf(measureLUFS(t, pcm), -1), "sanity: clip must be under the R128 absolute gate")
+	truePeak := measureTruePeak(t, pcm)
+	require.False(t, math.IsInf(truePeak, -1), "sanity: true peak is finite")
+	require.Greater(t, testTruePeakDBTP-truePeak, nativeExportMaxGainDB,
+		"sanity: the true-peak-anchored gain must exceed the ceiling")
+	require.Greater(t, aggressiveTargetLUFS-audionormMinTargetLUFS, nativeExportMaxGainDB-1e-9,
+		"sanity: the loudness bound must also reach the ceiling at this target")
 
 	a := &SaveAudioAction{pcmData: pcm, CorrelationID: "test"}
-	gainDB, err := a.planNativeNormalizationGain(t.Context(), conf.SampleRate, ffmpeg.FormatFLAC, testTargetLUFS, testTruePeakDBTP)
+	gainDB, err := a.planNativeNormalizationGain(t.Context(), conf.SampleRate, ffmpeg.FormatFLAC, aggressiveTargetLUFS, testTruePeakDBTP)
 	require.NoError(t, err)
-	assert.InDelta(t, audionorm.DefaultMaxGainDB, gainDB, 1e-9, "extreme boost must clamp to +DefaultMaxGainDB")
+	assert.InDelta(t, nativeExportMaxGainDB, gainDB, 1e-9, "extreme boost must clamp to +nativeExportMaxGainDB")
 }
 
 // TestPlanNativeNormalizationGain_Attenuates reduces a loud clip toward the target

--- a/internal/audiocore/audionorm/audionorm.go
+++ b/internal/audiocore/audionorm/audionorm.go
@@ -201,12 +201,16 @@ func PlanGain(meas Measurement, opts Options) Result {
 	return res
 }
 
-// DefaultMaxGainDB bounds the loudness gain the FLAC export paths apply: 30 dB,
-// the same clamp the BirdWeather FFmpeg FLAC path uses, so a clip's loudness is
-// corrected no more aggressively under one encoder than the other. It stops a
-// near-silent clip from being over-amplified into loud static, and a hot clip
-// from being driven toward digital silence. (Distinct from ffmpeg.MaxGainDB,
-// which is a wider loudnorm-offset validation range, not this export clamp.)
+// DefaultMaxGainDB bounds the loudness gain the BirdWeather soundscape upload
+// applies: 30 dB, the same clamp the BirdWeather FFmpeg FLAC path used, so a
+// soundscape's loudness is corrected no more aggressively under one encoder
+// than the other. It stops a near-silent clip from being over-amplified into
+// loud static, and a hot clip from being driven toward digital silence.
+//
+// The detection-clip export path deliberately does NOT use this: it bounds gain
+// with its own nativeExportMaxGainDB (internal/analysis/processor), derived from
+// the widest lift a valid loudness target can ask for. (Distinct again from
+// ffmpeg.MaxGainDB, which is a loudnorm-offset validation range, not a clamp.)
 const DefaultMaxGainDB = 30.0
 
 // ClampGainDB constrains a planned gain (dB) to [-maxAbsDB, +maxAbsDB] and reports
@@ -228,8 +232,8 @@ func ClampGainDB(gainDB, maxAbsDB float64) (clamped float64, limited bool) {
 	}
 }
 
-// PlanClampedGainInt16Bytes runs the measure -> plan -> clamp sequence the native
-// FLAC export paths share: it measures the integrated loudness and true peak of
+// PlanClampedGainInt16Bytes runs the measure -> plan -> clamp sequence the
+// BirdWeather native FLAC upload uses: it measures the integrated loudness and true peak of
 // interleaved little-endian int16 PCM bytes (via MeasureInt16Bytes, which decodes
 // inline without mutating pcm), plans the single gain that brings the clip to
 // opts.TargetLUFS without its true peak exceeding opts.TruePeakDBTP (via PlanGain),
@@ -246,8 +250,9 @@ func ClampGainDB(gainDB, maxAbsDB float64) (clamped float64, limited bool) {
 // Like PlanGain, opts.TargetLUFS and opts.TruePeakDBTP are NOT range-checked
 // here, so callers must pass a target in (-70, 0) and a ceiling <= 0; a
 // non-finite or out-of-range target otherwise flows through as a NaN or garbage
-// gain. Both current callers gate their targets before calling (the detection
-// path via audionormSupportsTargets, the BirdWeather path with fixed constants).
+// gain. The sole current caller, the BirdWeather upload path, passes fixed
+// constants. (The detection export path plans its gain step by step instead, so
+// it can apply a gate fallback for clips R128 cannot measure.)
 func PlanClampedGainInt16Bytes(pcm []byte, opts Options, maxAbsGainDB float64) (gainDB float64, meas Measurement, res Result, limited bool, err error) {
 	meas, err = MeasureInt16Bytes(pcm, opts.SampleRate, opts.Channels)
 	if err != nil {

--- a/internal/audiocore/normbench/compare_test.go
+++ b/internal/audiocore/normbench/compare_test.go
@@ -1,0 +1,402 @@
+//go:build normcompare
+
+package normbench
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore/audionorm"
+	"github.com/tphakala/birdnet-go/internal/audiocore/convert"
+	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
+	"github.com/tphakala/birdnet-go/internal/audiocore/pcmgain"
+)
+
+// The BirdNET-Go export defaults (conf.AudioSettings.Export.Normalization).
+const (
+	targetLUFS     = -23.0
+	targetTruePeak = -2.0
+	targetLRA      = 7.0
+
+	// absoluteGateLUFS is the EBU R128 absolute gate, mirroring
+	// audionormMinTargetLUFS in internal/analysis/processor.
+	absoluteGateLUFS = -70.0
+
+	// productionMaxGainDB mirrors nativeExportMaxGainDB in
+	// internal/analysis/processor. preFixMaxGainDB is what it was before this
+	// work (audionorm.DefaultMaxGainDB), kept so the change stays measurable.
+	productionMaxGainDB = 60.0
+	preFixMaxGainDB     = 30.0
+)
+
+// loudness is a parsed measurement of one audio file.
+type loudness struct {
+	integrated float64 // LUFS
+	truePeak   float64 // dBTP
+	rangeLU    float64 // LU
+}
+
+// subGateLoudness reports whether R128 gating left the clip with no integrated
+// loudness at all, which audionorm signals as -Inf. It is the case the native
+// path currently has no answer for.
+func subGateLoudness(meas audionorm.Measurement) bool {
+	return math.IsInf(meas.IntegratedLUFS, -1)
+}
+
+// bound names what stopped a planned gain from reaching the loudness target.
+// Reading this per row is the whole point of the harness: a divergence caused by
+// the 30 dB clamp is a policy choice, one caused by R128 gating is a defect.
+type bound string
+
+const (
+	boundNone    bound = "-"        // reached the target
+	boundPeak    bound = "peak"     // true-peak ceiling reduced the gain
+	boundClamp   bound = "clamp"    // the 30 dB ceiling reduced the gain
+	boundSubGate bound = "sub-gate" // integrated loudness is -Inf, so no gain was planned
+	boundSilent  bound = "silent"   // no signal at all
+)
+
+// plan is one implementation's gain decision for a clip.
+type plan struct {
+	wantDB     float64 // gain needed to hit the target, before any limiting
+	headroomDB float64 // gain the true-peak ceiling allows
+	gainDB     float64 // gain actually applied
+	bound      bound
+}
+
+// outcome is one case run through every implementation under comparison.
+type outcome struct {
+	tc    testCase
+	input loudness
+
+	preFixPlan plan
+	preFix     loudness // the native path before the sub-gate fix and ceiling raise
+
+	nativePlan plan
+	native     loudness // the native path as it now ships
+
+	ffm loudness // the FFmpeg loudnorm export path
+}
+
+// TestCompareNormalization runs every corpus case through the native Go
+// normalization as it stood before the sub-gate fix and ceiling raise, through
+// the native path as it now ships, and through the FFmpeg loudnorm export path.
+// All three outputs are measured with the same analyser so the numbers are
+// directly comparable.
+//
+// It is a report, not a gate: it asserts only that each path produces a
+// measurable file. Read the table it prints.
+func TestCompareNormalization(t *testing.T) {
+	ffmpegBin := ffmpegPath(t)
+	cases := loadCorpus(t, ffmpegBin)
+	dir := t.TempDir()
+	ctx := t.Context()
+
+	outcomes := make([]outcome, 0, len(cases))
+	for i, tc := range cases {
+		stem := filepath.Join(dir, "case"+itoa(i))
+		o := outcome{tc: tc}
+
+		o.input = measure(t, ctx, ffmpegBin, writeWAV(t, stem+"-in.wav", tc.pcm))
+
+		meas := measureNative(t, tc.pcm)
+		o.preFixPlan = planPreFix(meas)
+		o.nativePlan = planNative(meas, tc.pcm)
+
+		o.preFix = measure(t, ctx, ffmpegBin,
+			writeWAV(t, stem+"-prefix.wav", pcmgain.Applied(tc.pcm, o.preFixPlan.gainDB)))
+		o.native = measure(t, ctx, ffmpegBin,
+			writeWAV(t, stem+"-native.wav", pcmgain.Applied(tc.pcm, o.nativePlan.gainDB)))
+		o.ffm = runFFmpeg(t, ctx, ffmpegBin, stem, tc.pcm)
+
+		outcomes = append(outcomes, o)
+	}
+
+	report(t, outcomes)
+}
+
+// measureNative runs audionorm's pass one, the same measurement the production
+// native path performs inside PlanClampedGainInt16Bytes.
+func measureNative(t *testing.T, pcm []byte) audionorm.Measurement {
+	t.Helper()
+	meas, err := audionorm.MeasureInt16Bytes(pcm, sampleRate, channels)
+	require.NoError(t, err)
+	return meas
+}
+
+// planPreFix reproduces the native decision as it stood before this work: plan
+// target-minus-measured, reduce it to the true-peak headroom, clamp to +/-30 dB,
+// and give a clip whose gated integrated loudness is -Inf no gain at all, so it
+// is exported untouched. Kept as the baseline the fix is measured against.
+func planPreFix(meas audionorm.Measurement) plan {
+	res := audionorm.PlanGain(meas, audionorm.Options{
+		SampleRate:   sampleRate,
+		Channels:     channels,
+		TargetLUFS:   targetLUFS,
+		TruePeakDBTP: targetTruePeak,
+	})
+	gain, clamped := audionorm.ClampGainDB(res.GainDB, preFixMaxGainDB)
+
+	p := plan{
+		wantDB:     res.TargetGainDB,
+		headroomDB: targetTruePeak - meas.TruePeakDBTP,
+		gainDB:     gain,
+	}
+	switch {
+	case subGateLoudness(meas):
+		p.bound = boundSubGate
+		if math.IsInf(meas.TruePeakDBTP, -1) {
+			p.bound = boundSilent
+		}
+	case clamped:
+		p.bound = boundClamp
+	case res.PeakLimited:
+		p.bound = boundPeak
+	default:
+		p.bound = boundNone
+	}
+	return p
+}
+
+// nativeMaxGainDB is the gain ceiling the native path applies. It defaults to
+// the production value and is overridable because the ceiling turned out to be
+// the dominant cause of divergence from FFmpeg, so the harness has to be able to
+// price a different policy without editing production constants.
+func nativeMaxGainDB() float64 {
+	if v := os.Getenv("BIRDNET_NORMCOMPARE_MAXGAIN"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			return f
+		}
+	}
+	return productionMaxGainDB
+}
+
+// planNative mirrors planNativeNormalizationGain and gateFallbackGainDB in
+// internal/analysis/processor: when R128 gating leaves the integrated loudness at
+// -Inf but the clip still has a finite true peak, the gain is derived from the
+// true-peak ceiling instead of being abandoned.
+//
+// This is a reimplementation, not a call into production code, because the
+// production planner is an unexported method on SaveAudioAction. Keep the two in
+// step; if they drift, this harness stops measuring what actually ships.
+func planNative(meas audionorm.Measurement, pcmForRefine []byte) plan {
+	maxGain := nativeMaxGainDB()
+
+	if !subGateLoudness(meas) || math.IsInf(meas.TruePeakDBTP, -1) {
+		res := audionorm.PlanGain(meas, audionorm.Options{
+			SampleRate:   sampleRate,
+			Channels:     channels,
+			TargetLUFS:   targetLUFS,
+			TruePeakDBTP: targetTruePeak,
+		})
+		gain, clamped := audionorm.ClampGainDB(res.GainDB, maxGain)
+		p := plan{
+			wantDB:     res.TargetGainDB,
+			headroomDB: targetTruePeak - meas.TruePeakDBTP,
+			gainDB:     gain,
+		}
+		switch {
+		case subGateLoudness(meas):
+			p.bound = boundSilent
+		case clamped:
+			p.bound = boundClamp
+		case res.PeakLimited:
+			p.bound = boundPeak
+		default:
+			p.bound = boundNone
+		}
+		return p
+	}
+
+	// Both bounds from gateFallbackGainDB: the true-peak anchor, and the bound
+	// that keeps a flat sub-gate signal from being lifted past the loudness
+	// target (its loudness is unmeasurable only because it is under the gate,
+	// so it cannot exceed the target after a lift of target-minus-gate).
+	peakBound := targetTruePeak - meas.TruePeakDBTP
+	loudnessBound := targetLUFS - absoluteGateLUFS
+	want := math.Min(peakBound, loudnessBound)
+
+	// Mirrors refineLiftedGainDB: the lift usually raises the clip above the
+	// gate, so re-measuring the lifted signal lets a normal plan finish the job
+	// instead of stopping at the deliberately conservative bound.
+	if lifted, err := audionorm.MeasureInt16Bytes(pcmgain.Applied(pcmForRefine, want), sampleRate, channels); err == nil &&
+		!math.IsInf(lifted.IntegratedLUFS, -1) {
+		want += audionorm.PlanGain(lifted, audionorm.Options{
+			SampleRate:   sampleRate,
+			Channels:     channels,
+			TargetLUFS:   targetLUFS,
+			TruePeakDBTP: targetTruePeak,
+		}).GainDB
+	}
+
+	gain, clamped := audionorm.ClampGainDB(want, maxGain)
+
+	p := plan{wantDB: want, headroomDB: peakBound, gainDB: gain, bound: boundNone}
+	if clamped {
+		p.bound = boundClamp
+	}
+	return p
+}
+
+// runFFmpeg drives the production FFmpeg export path with normalization on, so
+// the comparison exercises the real filter construction (two-pass linear
+// loudnorm, the gate fallback, and the single-pass fallback) rather than a
+// hand-built filter string.
+//
+// The output format is FLAC rather than WAV for two reasons: it is lossless, so
+// what is measured is the filter's output and not codec loss; and WAV is not
+// actually reachable through this path in production (it maps to "-c:a wav",
+// which is not an FFmpeg encoder) because WAV export is always native.
+func runFFmpeg(t *testing.T, ctx context.Context, ffmpegBin, stem string, pcm []byte) loudness {
+	t.Helper()
+
+	out := stem + "-ffmpeg.flac"
+	err := ffmpeg.ExportAudio(ctx, &ffmpeg.ExportOptions{
+		PCMData:    pcm,
+		OutputPath: out,
+		Format:     ffmpeg.FormatFLAC,
+		SampleRate: sampleRate,
+		Channels:   channels,
+		BitDepth:   bitDepth,
+		Normalization: ffmpeg.ExportNormalization{
+			Enabled:       true,
+			TargetLUFS:    targetLUFS,
+			TruePeak:      targetTruePeak,
+			LoudnessRange: targetLRA,
+		},
+		FFmpegPath: ffmpegBin,
+	})
+	require.NoError(t, err, "ffmpeg export")
+
+	return measure(t, ctx, ffmpegBin, out)
+}
+
+func writeWAV(t *testing.T, path string, pcm []byte) string {
+	t.Helper()
+	require.NoError(t, convert.SavePCMDataToWAV(path, pcm, sampleRate, bitDepth))
+	return path
+}
+
+// measure reads a file's loudness through the same production analyser all
+// paths are judged by. Its own targets do not affect the input_* fields it
+// reports, which is all this harness reads.
+func measure(t *testing.T, ctx context.Context, ffmpegBin, path string) loudness {
+	t.Helper()
+	stats, err := ffmpeg.AnalyzeFileLoudness(ctx, path, ffmpegBin, ffmpeg.AudioFilters{}, nil)
+	require.NoError(t, err, "measuring %s", path)
+
+	return loudness{
+		integrated: parseLoudnessField(stats.InputI),
+		truePeak:   parseLoudnessField(stats.InputTP),
+		rangeLU:    parseLoudnessField(stats.InputLRA),
+	}
+}
+
+// parseLoudnessField accepts the "-inf" FFmpeg emits for silence and for clips
+// that fall entirely under the R128 gate, which is a real outcome here rather
+// than a parse failure.
+func parseLoudnessField(v string) float64 {
+	f, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		return math.Inf(-1)
+	}
+	return f
+}
+
+func report(t *testing.T, outcomes []outcome) {
+	t.Helper()
+
+	t.Logf("\nTargets: I=%.1f LUFS  TP=%.1f dBTP  LRA=%.1f LU   pre-fix clamp %.0f dB, native clamp %.0f dB, ffmpeg clamp %.0f dB\n",
+		targetLUFS, targetTruePeak, targetLRA, preFixMaxGainDB, nativeMaxGainDB(), ffmpeg.MaxGainDB)
+
+	header := fmt.Sprintf("%-38s | %14s | %6s | %6s | %15s | %7s | %7s | %7s | %14s",
+		"case", "input I/TP", "want", "hdroom", "applied (bound)",
+		"pre-fix I", "native I", "ffmpeg I", "LRA p/n/f")
+	t.Log(header)
+	t.Log(dashes(len(header)))
+
+	var worstPreFix, worstNative float64
+	var worstPreFixName, worstNativeName string
+	subGate, clampBound := 0, 0
+
+	for i := range outcomes {
+		o := &outcomes[i]
+
+		dPreFix := delta(o.ffm.integrated, o.preFix.integrated)
+		dNative := delta(o.ffm.integrated, o.native.integrated)
+		if math.Abs(dPreFix) > math.Abs(worstPreFix) && !math.IsInf(dPreFix, 0) {
+			worstPreFix, worstPreFixName = dPreFix, o.tc.name
+		}
+		if math.Abs(dNative) > math.Abs(worstNative) && !math.IsInf(dNative, 0) {
+			worstNative, worstNativeName = dNative, o.tc.name
+		}
+		switch o.preFixPlan.bound {
+		case boundSubGate:
+			subGate++
+		case boundClamp:
+			clampBound++
+		case boundNone, boundPeak, boundSilent:
+			// Not a divergence worth counting: the gain either reached target or
+			// was stopped by the true-peak ceiling, which both paths respect.
+		}
+
+		t.Logf("%-38s | %14s | %6s | %6s | %15s | %7s | %7s | %7s | %14s",
+			o.tc.name,
+			fmt.Sprintf("%6.2f/%6.2f", o.input.integrated, o.input.truePeak),
+			db(o.preFixPlan.wantDB),
+			db(o.preFixPlan.headroomDB),
+			fmt.Sprintf("%6s (%s)", db(o.preFixPlan.gainDB), o.preFixPlan.bound),
+			lufs(o.preFix.integrated),
+			lufs(o.native.integrated),
+			lufs(o.ffm.integrated),
+			fmt.Sprintf("%4.1f/%4.1f/%4.1f", o.preFix.rangeLU, o.native.rangeLU, o.ffm.rangeLU),
+		)
+	}
+
+	t.Log("")
+	t.Log("want    = gain needed to reach the loudness target, before any limiting")
+	t.Log("hdroom  = gain the true-peak ceiling allows")
+	t.Log("bound   = what actually stopped the gain: clamp, peak, sub-gate, or - for none")
+	t.Log("LRA p/n/f = loudness range of the pre-fix / native / ffmpeg output")
+	t.Log("")
+	t.Logf("cases where the pre-fix 30 dB clamp was the binding constraint: %d of %d", clampBound, len(outcomes))
+	t.Logf("cases where R128 gating left the native path with no gain at all: %d of %d", subGate, len(outcomes))
+	t.Logf("largest finite loudness gap, ffmpeg vs pre-fix native: %+.2f LU on %s", worstPreFix, worstPreFixName)
+	t.Logf("largest finite loudness gap, ffmpeg vs native now:      %+.2f LU on %s", worstNative, worstNativeName)
+}
+
+func delta(a, b float64) float64 {
+	if math.IsInf(a, 0) || math.IsInf(b, 0) {
+		return math.Inf(1)
+	}
+	return a - b
+}
+
+func db(v float64) string {
+	if math.IsInf(v, 0) {
+		return "  -Inf"
+	}
+	return fmt.Sprintf("%+6.1f", v)
+}
+
+func lufs(v float64) string {
+	if math.IsInf(v, 0) {
+		return "   -Inf"
+	}
+	return fmt.Sprintf("%7.2f", v)
+}
+
+func dashes(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = '-'
+	}
+	return string(b)
+}

--- a/internal/audiocore/normbench/corpus_test.go
+++ b/internal/audiocore/normbench/corpus_test.go
@@ -1,0 +1,239 @@
+//go:build normcompare
+
+package normbench
+
+import (
+	"encoding/binary"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// The export PCM shape. Every clip BirdNET-Go normalizes is 48 kHz, mono,
+	// 16-bit (conf.SampleRate / conf.NumChannels / conf.BitDepth), so the corpus
+	// is decoded to exactly that rather than to whatever the source file holds.
+	sampleRate = 48000
+	channels   = 1
+	bitDepth   = 16
+
+	bytesPerSample = bitDepth / 8
+	bytesPerSecond = sampleRate * channels * bytesPerSample
+
+	// clipSeconds matches the default detection clip length, so the measured
+	// divergence is the divergence a real export sees. It also sits far above
+	// the 400 ms EBU R128 gating block, which a shorter clip would fall under.
+	clipSeconds = 15
+
+	// clipsPerSource caps how much of a long recording is used, so a 2-minute
+	// soundscape does not dominate the report.
+	clipsPerSource = 3
+)
+
+// clipBytes is the size of one detection-length clip at the export PCM shape.
+// Sizing by the export rate rather than a fixed sample count is deliberate:
+// a fixed count silently falls under the 400 ms gate at high rates.
+const clipBytes = clipSeconds * bytesPerSecond
+
+// testCase is one clip to run through both normalization paths.
+type testCase struct {
+	// name identifies the source recording and the loudness case applied to it.
+	name string
+	// why states what the case is meant to exercise, so a surprising row in the
+	// report can be read without cross-referencing the generator.
+	why string
+	pcm []byte
+}
+
+// ffmpegPath resolves the ffmpeg binary the harness shells out to for decoding
+// the corpus and for measuring outputs.
+func ffmpegPath(t *testing.T) string {
+	t.Helper()
+	if p := os.Getenv("BIRDNET_NORMCOMPARE_FFMPEG"); p != "" {
+		return p
+	}
+	p, err := exec.LookPath("ffmpeg")
+	require.NoError(t, err, "normcompare needs ffmpeg on PATH or BIRDNET_NORMCOMPARE_FFMPEG set")
+	return p
+}
+
+// corpusDir returns the directory holding the source recordings. It defaults to
+// the repository root, which carries the checked-in field recordings.
+func corpusDir(t *testing.T) string {
+	t.Helper()
+	if d := os.Getenv("BIRDNET_NORMCOMPARE_CORPUS"); d != "" {
+		return d
+	}
+	// This package sits at internal/audiocore/normbench.
+	root, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	require.NoError(t, err)
+	return root
+}
+
+// loadCorpus decodes every WAV in the corpus directory to the export PCM shape
+// and slices each into detection-length clips.
+func loadCorpus(t *testing.T, ffmpeg string) []testCase {
+	t.Helper()
+
+	dir := corpusDir(t)
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err, "reading corpus directory %s", dir)
+
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !strings.EqualFold(filepath.Ext(e.Name()), ".wav") {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	slices.Sort(names) // stable report ordering
+	require.NotEmpty(t, names, "no .wav recordings found in %s; set BIRDNET_NORMCOMPARE_CORPUS", dir)
+
+	var cases []testCase
+	for _, name := range names {
+		pcm := decodeToExportPCM(t, ffmpeg, filepath.Join(dir, name))
+		base := strings.TrimSuffix(name, filepath.Ext(name))
+
+		for i := range clipsPerSource {
+			start := i * clipBytes
+			if start+clipBytes > len(pcm) {
+				break
+			}
+			clip := pcm[start : start+clipBytes]
+			cases = append(cases, expandCases(base, i, clip)...)
+		}
+	}
+	require.NotEmpty(t, cases, "corpus produced no clips of %d s", clipSeconds)
+	return cases
+}
+
+// decodeToExportPCM decodes any WAV to headerless 48 kHz mono 16-bit PCM, the
+// same bytes the export path receives from the capture buffer.
+func decodeToExportPCM(t *testing.T, ffmpeg, path string) []byte {
+	t.Helper()
+	cmd := exec.Command(ffmpeg, //nolint:gosec // G204: harness-only, paths come from the test environment
+		"-hide_banner", "-v", "error",
+		"-i", path,
+		"-f", "s16le",
+		"-acodec", "pcm_s16le",
+		"-ar", itoa(sampleRate),
+		"-ac", itoa(channels),
+		"-",
+	)
+	out, err := cmd.Output()
+	require.NoError(t, err, "decoding %s", path)
+	require.NotEmpty(t, out, "decoding %s produced no PCM", path)
+	return out
+}
+
+// expandCases turns one clip into the loudness cases that separate the two
+// implementations. A clip as captured usually sits inside FFmpeg's linear gate
+// and above the R128 absolute gate, where the two agree; the derived cases push
+// it outside those bounds on purpose.
+func expandCases(base string, idx int, clip []byte) []testCase {
+	id := func(kind string) string { return base + "#" + itoa(idx) + "/" + kind }
+
+	return []testCase{
+		{
+			name: id("as-captured"),
+			why:  "baseline: the clip as the capture buffer delivers it",
+			pcm:  cloneScaled(clip, 1),
+		},
+		{
+			name: id("quiet-20dB"),
+			why:  "a distant or gain-starved recording that still measures above the R128 gate",
+			pcm:  cloneScaled(clip, dbToFactor(-20)),
+		},
+		{
+			name: id("quiet-40dB"),
+			why:  "so quiet that R128 gating cannot measure it, which only the gate fallback rescues",
+			pcm:  cloneScaled(clip, dbToFactor(-40)),
+		},
+		{
+			name: id("hot"),
+			why:  "recorded near full scale, so normalization must attenuate",
+			pcm:  cloneScaled(clip, dbToFactor(+12)),
+		},
+		{
+			name: id("transient-over-quiet-bed"),
+			why:  "loud call over a quiet bed: high LRA, one of the conditions that voids linear=true",
+			pcm:  transientOverQuietBed(clip),
+		},
+	}
+}
+
+// transientOverQuietBed attenuates the clip into a quiet bed and restores full
+// level over one short window, producing the wide loudness range that pushes
+// FFmpeg's loudnorm out of linear mode even when linear=true is requested.
+func transientOverQuietBed(clip []byte) []byte {
+	out := cloneScaled(clip, dbToFactor(-30))
+
+	// One second of the original level, a third of the way in: long enough to
+	// dominate the gated integrated loudness, short enough to leave the bed as
+	// the clip's character.
+	burstStart := (len(out) / 3) &^ 1 // keep the offset sample-aligned
+	burstEnd := burstStart + bytesPerSecond
+	if burstEnd > len(out) {
+		burstEnd = len(out)
+	}
+	copy(out[burstStart:burstEnd], clip[burstStart:burstEnd])
+	return out
+}
+
+// cloneScaled copies int16 PCM with a linear amplitude factor, saturating rather
+// than wrapping so an amplified clip clips the way real hot audio does.
+func cloneScaled(src []byte, factor float64) []byte {
+	dst := make([]byte, len(src))
+	if factor == 1 {
+		copy(dst, src)
+		return dst
+	}
+	for i := 0; i+1 < len(src); i += 2 {
+		v := float64(int16(binary.LittleEndian.Uint16(src[i:]))) * factor
+		binary.LittleEndian.PutUint16(dst[i:], uint16(saturateInt16(v)))
+	}
+	return dst
+}
+
+func saturateInt16(v float64) int16 {
+	r := math.Round(v)
+	switch {
+	case r > math.MaxInt16:
+		return math.MaxInt16
+	case r < math.MinInt16:
+		return math.MinInt16
+	default:
+		return int16(r)
+	}
+}
+
+func dbToFactor(db float64) float64 { return math.Pow(10, db/20) }
+
+// itoa avoids pulling strconv into every call site for the small integers here.
+func itoa(v int) string {
+	if v == 0 {
+		return "0"
+	}
+	neg := v < 0
+	if neg {
+		v = -v
+	}
+	var buf [20]byte
+	i := len(buf)
+	for v > 0 {
+		i--
+		buf[i] = byte('0' + v%10)
+		v /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/internal/audiocore/normbench/doc.go
+++ b/internal/audiocore/normbench/doc.go
@@ -1,0 +1,28 @@
+// Package normbench holds an on-demand comparison harness that measures the
+// native Go loudness normalization (audiocore/audionorm plus audiocore/pcmgain)
+// against FFmpeg's loudnorm filter on the same PCM.
+//
+// It has no production code. The harness lives behind the "normcompare" build
+// tag so it never runs in CI, where FFmpeg availability would make the numbers
+// meaningless. Run it deliberately:
+//
+//	go test -tags normcompare -v ./internal/audiocore/normbench/
+//
+// It needs an ffmpeg binary on PATH (or in BIRDNET_NORMCOMPARE_FFMPEG) and a
+// corpus of real recordings. Synthetic tones are deliberately not used: the two
+// implementations agree trivially on a steady tone and diverge only where EBU
+// R128 gating and FFmpeg's linear/dynamic mode selection bite, which needs real
+// material with a real noise floor.
+//
+// The corpus defaults to the WAV files in the repository root and can be
+// pointed elsewhere with BIRDNET_NORMCOMPARE_CORPUS. Each source recording is
+// decoded to the export PCM shape (48 kHz mono 16-bit), sliced into
+// detection-length clips, and expanded into the loudness cases that matter for
+// field recordings: as captured, attenuated, hot, and a loud transient over a
+// quiet bed.
+//
+// For every case it reports the input loudness, the gain each implementation
+// chose, and the measured integrated loudness, true peak and loudness range of
+// both outputs, so the divergence can be read off directly rather than
+// asserted.
+package normbench


### PR DESCRIPTION
Native loudness normalization was leaving two classes of quiet clip short of the configured target. Both are user-visible on FLAC export, which is unconditionally native, and both are fixed here so the FFmpeg `loudnorm` path can be removed in a follow-up without changing what users hear.

## Sub-gate clips were exported inaudible

A clip whose gated integrated loudness falls below EBU R128's -70 LUFS absolute gate measures as `-Inf`, so no gain was planned at all and the clip was written out untouched. The FFmpeg path has never had this hole: `loudnormGateFallbackOffset` derives an offset from the true peak instead of giving up. `gateFallbackGainDB` ports that idea.

The true-peak anchor alone is not enough. It leaves the output loudness at `ceiling - crestFactor`, which drives a flat signal far past the target: measured, a steady noise floor (a dead or muted microphone, crest factor of a few dB) landed at **-13.8 LUFS against a -23 target**. That would be loud hiss where users previously got a silent clip. Gating failing is itself information, so a second bound caps the lift at `target - gate`, which cannot overshoot however flat the clip turns out to be.

That bound has to assume the worst case, so alone it left clips well short of where FFmpeg put them. The lift usually raises a clip above the gate though, at which point it *can* be measured, so `refineLiftedGainDB` re-measures the lifted signal and lets a normal plan finish the job. A clip still under the gate afterwards keeps the conservative bound rather than guessing.

## The 30 dB gain ceiling was the dominant constraint

It bound 7 of 20 measured cases, leaving exports up to 8.6 LU below target where FFmpeg reached it. The new `nativeExportMaxGainDB` is derived rather than picked: the widest lift any in-range config can ask for is `conf.MaxTargetLUFS` (-10) minus the absolute gate (-70), so 60 dB. It also happens to match `ffmpeg.MaxGainDB`.

BirdWeather soundscape uploads deliberately keep the 30 dB ceiling. Those go to a public platform and are not this path's to change.

## Verification

A new comparison harness (`internal/audiocore/normbench`, build tag `normcompare`, never runs in CI) normalizes real recordings both ways and measures both outputs with the same analyser:

```
go test -tags normcompare -v ./internal/audiocore/normbench/
```

After this change the native path tracks FFmpeg **within 0.05 LU on 16 of 20 cases**, and the 6 previously untouched sub-gate clips are normalized. The residual gap is true-peak-limited clips, where FFmpeg silently abandons `linear=true` and applies dynamic range compression while the native path stays linear. That is the intended behaviour for nature recordings, which is also why `Normalization.LoudnessRange` stays unconsumed: on 15 s clips `loudnorm`'s dynamic mode barely moves LRA (7.4 to 7.1 on a purpose-built high-LRA clip) and misses the loudness target by 1.1 LU where the linear gain lands within 0.02.

Also verified: full-project `golangci-lint` under the CI build tags, `go test -race` across the audio packages, and the existing `TestEncodeClip_Ultrasonic*` regressions at 96/192/256/384 kHz.

## Release note

Quiet clips now reach the configured loudness target on FLAC export. Clips that were previously exported silent because they fell below the R128 measurement gate are now audible. MP3, AAC and Opus are unchanged.