### PR TITLE
fix(analytics): exclude false positives from new species detections

### DIFF
--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -1751,7 +1751,7 @@ func (r *detectionRepository) GetNewSpecies(ctx context.Context, start, end int6
 		JOIN %s d ON d.label_id = l.id AND d.detected_at = species_first.lifetime_first
 		LEFT JOIN %s dr ON dr.detection_id = d.id
 		WHERE (dr.verified IS NULL OR dr.verified != ?)
-		GROUP BY species_first.scientific_name, species_first.lifetime_first
+		GROUP BY species_first.scientific_name, species_first.lifetime_first, species_first.lifetime_last
 		ORDER BY first_detected DESC
 		LIMIT ? OFFSET ?
 	`, r.tableName(), r.labelsTable(), r.reviewsTable(), r.labelsTable(), r.tableName(), r.reviewsTable())

--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -1708,7 +1708,8 @@ func (r *detectionRepository) GetDetectionTrends(ctx context.Context, period str
 	return r.GetDailyAnalytics(ctx, startTime, now, tzOffsetSeconds, nil, modelID)
 }
 
-// GetNewSpecies returns species detected for the first time ever within the range.
+// GetNewSpecies returns species detected for the first time ever within the range, false positives
+// excluded, so a species whose qualifying detections were all reviewed away is not reported as new.
 // Groups by scientific_name to aggregate across all models for the same species.
 // Uses MIN(id) as tie-breaker to avoid duplicates when multiple detections share the same timestamp.
 func (r *detectionRepository) GetNewSpecies(ctx context.Context, start, end int64, limit, offset int) ([]NewSpeciesData, error) {
@@ -1720,6 +1721,12 @@ func (r *detectionRepository) GetNewSpecies(ctx context.Context, start, end int6
 	// Approach: Use a derived table to compute lifetime first detection per species,
 	// then filter and join back to get detection details. This is O(n) instead of
 	// the O(n²) correlated subquery approach.
+	// Both levels exclude false positives (same filter as buildAnalyticsBaseQuery): the derived table
+	// so a reviewed-away detection cannot pin a species' lifetime first-seen (or make an
+	// all-false-positive species look new at all), and the outer join so the reported
+	// detection_id/confidence never come from a false-positive row sharing that timestamp.
+	// DetectionReview has a unique index on detection_id, so neither LEFT JOIN multiplies rows.
+	fpFilter := string(entities.VerificationFalsePositive)
 	rawSQL := fmt.Sprintf(`
 		SELECT
 			MIN(d.label_id) as label_id,
@@ -1735,17 +1742,21 @@ func (r *detectionRepository) GetNewSpecies(ctx context.Context, start, end int6
 				MAX(d2.detected_at) as lifetime_last
 			FROM %s d2
 			JOIN %s l2 ON l2.id = d2.label_id
+			LEFT JOIN %s dr2 ON dr2.detection_id = d2.id
+			WHERE (dr2.verified IS NULL OR dr2.verified != ?)
 			GROUP BY l2.scientific_name
 			HAVING MIN(d2.detected_at) >= ? AND MIN(d2.detected_at) < ?
 		) species_first
 		JOIN %s l ON l.scientific_name = species_first.scientific_name
 		JOIN %s d ON d.label_id = l.id AND d.detected_at = species_first.lifetime_first
+		LEFT JOIN %s dr ON dr.detection_id = d.id
+		WHERE (dr.verified IS NULL OR dr.verified != ?)
 		GROUP BY species_first.scientific_name, species_first.lifetime_first
 		ORDER BY first_detected DESC
 		LIMIT ? OFFSET ?
-	`, r.tableName(), r.labelsTable(), r.labelsTable(), r.tableName())
+	`, r.tableName(), r.labelsTable(), r.reviewsTable(), r.labelsTable(), r.tableName(), r.reviewsTable())
 
-	err := r.db.WithContext(ctx).Raw(rawSQL, start, end, limit, offset).Scan(&results).Error
+	err := r.db.WithContext(ctx).Raw(rawSQL, fpFilter, start, end, fpFilter, limit, offset).Scan(&results).Error
 	return results, err
 }
 

--- a/internal/datastore/v2/repository/new_species_test.go
+++ b/internal/datastore/v2/repository/new_species_test.go
@@ -34,10 +34,30 @@ func TestGetNewSpecies_ExcludesFalsePositives(t *testing.T) {
 	assert.Equal(t, int64(1800), got[0].FirstDetected)
 }
 
-// TestGetNewSpecies_FalsePositiveDoesNotHideEarlierLifetimeFirst checks the exclusion is applied
-// when computing the lifetime first-seen, not only inside the window: a species whose only real
-// detection predates the window must still not be reported as new.
-func TestGetNewSpecies_FalsePositiveDoesNotHideEarlierLifetimeFirst(t *testing.T) {
+// TestGetNewSpecies_FalsePositiveBeforeWindowDoesNotHideNewSpecies checks the exclusion is applied
+// when computing the lifetime first-seen, not only within the window. A false positive predating the
+// window must not count as prior history: the species is genuinely new and must still be reported.
+// This is the inverse failure of the reported bug — the old query hid real new species this way.
+func TestGetNewSpecies_FalsePositiveBeforeWindowDoesNotHideNewSpecies(t *testing.T) {
+	db := setupInsightsTestDB(t)
+	repo := NewDetectionRepository(db, nil, false, false)
+	ctx := t.Context()
+
+	label := seedLabel(t, db, "Parus major")
+	fpID := seedDetection(t, db, label, 100, 0.6) // false positive before the window
+	seedFalsePositiveReview(t, db, fpID)
+	seedDetection(t, db, label, 1000, 0.8) // first real detection, inside the window
+
+	got, err := repo.GetNewSpecies(ctx, 500, 5000, 100, 0)
+	require.NoError(t, err)
+	require.Len(t, got, 1, "a species whose only prior detection was a false positive is still new")
+	assert.Equal(t, "Parus major", got[0].ScientificName)
+	assert.Equal(t, int64(1000), got[0].FirstDetected)
+}
+
+// TestGetNewSpecies_RealDetectionBeforeWindowIsNotNew guards the window bound itself while the
+// false-positive filter moves around it: genuine prior history still disqualifies a species.
+func TestGetNewSpecies_RealDetectionBeforeWindowIsNotNew(t *testing.T) {
 	db := setupInsightsTestDB(t)
 	repo := NewDetectionRepository(db, nil, false, false)
 	ctx := t.Context()

--- a/internal/datastore/v2/repository/new_species_test.go
+++ b/internal/datastore/v2/repository/new_species_test.go
@@ -1,0 +1,52 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetNewSpecies_ExcludesFalsePositives guards the "New Species Detected" chart against counting
+// species whose detections were all reviewed as false positives, and against a species' lifetime
+// first-seen being pinned to a false-positive detection.
+func TestGetNewSpecies_ExcludesFalsePositives(t *testing.T) {
+	db := setupInsightsTestDB(t)
+	repo := NewDetectionRepository(db, nil, false, false)
+	ctx := t.Context()
+
+	withFP := seedLabel(t, db, "Parus major")
+	allFP := seedLabel(t, db, "Turdus merula")
+
+	// Parus major's earliest detection is a false positive: first-seen must skip it for the next real one.
+	fpID := seedDetection(t, db, withFP, 1000, 0.6)
+	seedFalsePositiveReview(t, db, fpID)
+	seedDetection(t, db, withFP, 1800, 0.9)
+
+	// Turdus merula has only a false-positive detection: it is not a newly detected species.
+	allFPID := seedDetection(t, db, allFP, 1200, 0.5)
+	seedFalsePositiveReview(t, db, allFPID)
+
+	got, err := repo.GetNewSpecies(ctx, 500, 5000, 100, 0)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "Parus major", got[0].ScientificName)
+	assert.Equal(t, int64(1800), got[0].FirstDetected)
+}
+
+// TestGetNewSpecies_FalsePositiveDoesNotHideEarlierLifetimeFirst checks the exclusion is applied
+// when computing the lifetime first-seen, not only inside the window: a species whose only real
+// detection predates the window must still not be reported as new.
+func TestGetNewSpecies_FalsePositiveDoesNotHideEarlierLifetimeFirst(t *testing.T) {
+	db := setupInsightsTestDB(t)
+	repo := NewDetectionRepository(db, nil, false, false)
+	ctx := t.Context()
+
+	label := seedLabel(t, db, "Parus major")
+	seedDetection(t, db, label, 100, 0.9) // real detection before the window
+	seedDetection(t, db, label, 1000, 0.8)
+
+	got, err := repo.GetNewSpecies(ctx, 500, 5000, 100, 0)
+	require.NoError(t, err)
+	assert.Empty(t, got, "species first detected before the window is not new")
+}


### PR DESCRIPTION
## Problem

The **New Species Detected** chart on the Analytics Summary page lists species whose detections were all reviewed and flagged as false positives. Reported twice during Raspberry Pi QA — on that station, the only two "new" species shown were both ones the owner had marked incorrect.

## Root cause

`detectionRepository.GetNewSpecies` computes each species' lifetime first detection with a derived table over `detections JOIN labels`, with no join to the reviews table and no false-positive filter — at either level of the query. Every neighbouring analytics query (`GetSpeciesFirstSeenInPeriod`, `GetSpeciesPhenologyInPeriod`, `GetHourlyDistribution`, …) applies the filter via `buildAnalyticsBaseQuery`; this one was missed.

Two visible consequences:

1. A species whose detections were **all** reviewed away is still reported as newly detected.
2. A false-positive detection can **pin** a species' first-seen date earlier than its first real detection.

The legacy `internal/datastore/analytics.go` implementation already excludes false positives in both of its CTEs, so only the v2 datastore path is affected.

Same class of bug as #3915 fixed for `GetTopSpecies`.

## Fix

Apply the established exclusion pattern at both levels of the query:

- the **derived lifetime-first table**, so a reviewed-away detection cannot establish or move a species' first-seen;
- the **outer detail join**, so the reported `detection_id`/`confidence` never come from a false-positive row sharing that timestamp.

`DetectionReview` has a unique index on `detection_id`, so neither `LEFT JOIN` multiplies rows — the aggregates are unaffected.

## Tests

New `internal/datastore/v2/repository/new_species_test.go`, following the existing `TestGetSpeciesFirstSeenInPeriod_ExcludesFalsePositives` precedent:

- `TestGetNewSpecies_ExcludesFalsePositives` — an all-false-positive species is absent; a species whose earliest detection is a false positive reports its first *real* detection as first-seen. Fails on `main` with exactly the reported symptom.
- `TestGetNewSpecies_FalsePositiveDoesNotHideEarlierLifetimeFirst` — a species first detected before the window is still not reported as new (guards the window bound while changing the query).

## Verification

- `go test ./internal/... -race -count=1` — datastore packages green. One unrelated pre-existing failure (`TestAudioExportPartialUpdate` in `internal/api/v2`), confirmed failing identically without this change.
- `golangci-lint run --timeout 10m` — 0 issues.
- No frontend files touched; no interface change, so no mock regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved “new species” results by excluding detections marked as false positives.
  - Updated first-seen and lifetime representative calculations to ensure false-positive detections don’t impact whether a species is considered newly detected.
  - Prevented species with only false-positive detections from appearing in new species results.
- **Tests**
  - Added/extended coverage to verify false-positive exclusion behavior both inside and outside the query window.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->