### PR TITLE
fix(frontend): stop species selector overlapping charts when max species selected

### DIFF
--- a/frontend/src/lib/components/ui/SpeciesSelector.svelte
+++ b/frontend/src/lib/components/ui/SpeciesSelector.svelte
@@ -58,10 +58,9 @@
   // Generate unique ID for dropdown (client-only to avoid SSR hydration mismatch)
   let dropdownId = $state('');
 
-  // Size configurations.
-  // ponytail: container height is a floor, not a fixed height — the chip variant wraps to
-  // multiple rows (chips + "max selected" warning) and a fixed h-* made it overflow onto the
-  // content below instead of pushing it down.
+  // Size configurations. Container height is a floor (min-h-*), not a fixed height: the chip
+  // and list variants wrap to multiple rows, and a fixed h-* made the extra rows overflow onto
+  // the content below instead of pushing it down.
   const sizeConfig = {
     xs: {
       container: 'min-h-6 text-xs',

--- a/frontend/src/lib/components/ui/SpeciesSelector.svelte
+++ b/frontend/src/lib/components/ui/SpeciesSelector.svelte
@@ -58,38 +58,41 @@
   // Generate unique ID for dropdown (client-only to avoid SSR hydration mismatch)
   let dropdownId = $state('');
 
-  // Size configurations
+  // Size configurations.
+  // ponytail: container height is a floor, not a fixed height — the chip variant wraps to
+  // multiple rows (chips + "max selected" warning) and a fixed h-* made it overflow onto the
+  // content below instead of pushing it down.
   const sizeConfig = {
     xs: {
-      container: 'h-6 text-xs',
+      container: 'min-h-6 text-xs',
       chip: 'h-5 px-2 text-xs',
       button: 'h-6 w-6 text-xs',
       input: 'input-xs',
       list: 'text-xs py-1',
     },
     sm: {
-      container: 'h-8 text-sm',
+      container: 'min-h-8 text-sm',
       chip: 'h-6 px-3 text-sm',
       button: 'h-8 w-8 text-sm',
       input: 'input-sm',
       list: 'text-sm py-2',
     },
     md: {
-      container: 'h-10 text-base',
+      container: 'min-h-10 text-base',
       chip: 'h-7 px-3 text-sm',
       button: 'h-10 w-10',
       input: 'input-md',
       list: 'text-sm py-2',
     },
     lg: {
-      container: 'h-12 text-base',
+      container: 'min-h-12 text-base',
       chip: 'h-8 px-4',
       button: 'h-12 w-12',
       input: 'input-lg',
       list: 'py-3',
     },
     xl: {
-      container: 'h-14 text-lg',
+      container: 'min-h-14 text-lg',
       chip: 'h-9 px-4 text-base',
       button: 'h-14 w-14 text-lg',
       input: 'input-lg',

--- a/frontend/src/lib/desktop/features/analytics/components/AnalyticsControlBar.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/AnalyticsControlBar.svelte
@@ -261,7 +261,7 @@
       <p id="analyticsSpeciesHint" class="mb-2 text-xs text-[var(--color-base-content)]/60">
         {t('analytics.advanced.speciesSelectionHint')}
       </p>
-      <div class="w-full min-h-[100px] relative">
+      <div class="w-full relative">
         <SpeciesSelector
           species={availableSpecies}
           selected={params.species}


### PR DESCRIPTION
## Summary

Selecting the maximum 10 species on the Analytics → Activity Patterns page makes the species panel overlap the Seasonal Activity Heatmap card header.

`SpeciesSelector`'s root element applied a **fixed** height from its `sizeConfig` (`h-10` at `md`), but the `chip` variant wraps to as many rows as it needs. At 10 selections the extra "Max 10 species selected" warning chip pushes the content to a fourth row, past the fixed 40px, so it overflowed onto the content below instead of pushing it down. The `list` variant has the same latent problem.

## Changes

- `sizeConfig[*].container`: `h-*` → `min-h-*`, so the size preset is a floor rather than a cap. (`min-h-12` was already used on the inner chip wrapper in the same component, so this is consistent with the existing intent.)
- Removed the `min-h-[100px]` band-aid on the analytics species panel wrapper, which existed to paper over the same overflow.

CSS-class-only change; no logic, props, or markup structure touched.

## Testing

- [x] Frontend tests pass (`npm test`) — 2644 passed, 1 failed: `src/lib/stores/settings.test.ts > should convert empty modelPath to null when saving` times out at 5000ms. **Pre-existing on `main`** — reproduced identically in a clean `main` worktree.
- [x] Targeted tests — `SpeciesSelector.test.ts` + `AnalyticsControlBar.test.ts`, 13/13 passed.
- [x] Linting passes — `npm run check:all` clean: prettier, eslint, stylelint, `svelte-check` 0 errors / 0 warnings, all four ast-grep rule sets.
- [x] Go tests (`task test`) — all packages pass except `internal/support`: `TestCollectDockerMounts_NotInContainer` and `TestCollectDeploymentInfo_Orchestration` fail because the suite was run **inside** the dev container. Environmental, and no Go files are touched by this PR.
- [x] Manual testing completed — verified on a Raspberry Pi running this branch: with 10 species selected the panel now pushes the heatmap card down instead of overlapping its header.

All checks were run in the project dev container.

## Preflight Status

All six review passes were run inline by the coordinating agent (sequentially, not as parallel subagents) over the full diff.

- Reviewer 1 (reuse/efficiency): no findings — no new code paths.
- Reviewer 2 (correctness/safety): no findings — no logic changed.
- Reviewer 3 (quality/patterns): one comment reworded to explain *why* the height is a floor. `min-h-<number>` verified as valid Tailwind v4 and already used elsewhere in the file.
- Reviewer 4 (i18n): no new user-facing strings. **[PRE-EXISTING]** `SpeciesSelector` hardcodes several English strings (`Max {n} species selected`, `Clear`, `Loading species...`) instead of using the i18n library — left alone to keep this PR to a single concern.
- Reviewer 5 (integration/wiring): no new fields, functions, events, or options.
- Reviewer 6 (regression/back-compat): `min-h-*` only relaxes a constraint — nothing can render shorter than before. `SpeciesSelector` has one production consumer (`AnalyticsControlBar`). No config keys, API fields, DB columns, CLI flags, or defaults touched. **Secondary-model cross-validation was unavailable** (no independent model CLI in this environment).

### Preflight Certification

- [x] Single concern: one fix
- [x] Preflight passed: all findings resolved; the one pre-existing i18n gap is reported above, not fixed
- [x] Linters clean: `npm run check:all` passes with zero warnings (`golangci-lint` not applicable — no Go changes)
- [ ] Tests pass: frontend and Go suites pass **except** the two pre-existing/environmental failures detailed above, neither reachable from this diff
- [x] No unrelated changes
- [x] Scope complete: no TODO/FIXME left behind
- [x] No regression/backward-compat break
- [x] Breaking changes documented: none to document
- [x] Maintainer-confirm items resolved: none raised
- [x] i18n complete: no new strings
- [x] No secrets or PII

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved species selector sizing so wrapped content displays without overflow across all size variants.
  * Updated selected-option indicators for clearer visual feedback.
  * Improved disabled-option styling and appearance.
  * Adjusted the analytics species selector panel to expand naturally based on its content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->