### PR TITLE
chore(audio): attribute clip exports to their encoder in the logs

### DIFF
--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -40,9 +40,9 @@ import (
 // rather than Warn (this is expected backpressure, not a failure).
 var errAudioExportDeferred = fmt.Errorf("audio export deferred until capture tail is available: %w", jobqueue.ErrJobDeferred)
 
-// Encoder tags recorded in the audio-export success log so the active encoder is
-// visible per clip (native go-flac or native WAV writer, or FFmpeg for the lossy
-// formats).
+// Encoder tags recorded in the audio-export logs so the active encoder is
+// visible per clip (native go-flac or native WAV writer, native go-aac/go-opus
+// where the gate opted the format in, or FFmpeg).
 const (
 	encoderFFmpeg     = "ffmpeg"
 	encoderNativeWAV  = "native-wav"
@@ -50,6 +50,20 @@ const (
 	encoderNativeAAC  = "native-aac"
 	encoderNativeOpus = "native-opus"
 )
+
+// clipEncoding records how a clip was written: which encoder owned the file and
+// the parameters a support log needs to explain the result on disk.
+//
+// It is resolved BEFORE the encoder runs, which is the point of the type: a
+// failed export can then name the encoder that failed. Otherwise an operator who
+// opted a format into its native encoder has no way to tell from the logs
+// whether go-aac or FFmpeg produced the failure, which is the one question the
+// gated rollout exists to answer.
+type clipEncoding struct {
+	Encoder     string  // encoderNativeAAC, encoderFFmpeg, ...
+	GainDB      float64 // loudness gain the encoder applies to the clip
+	BitrateKbps int     // encoded bitrate for the lossy formats; 0 when lossless
+}
 
 // Execute logs the note to the log file.
 // Note: File logging errors are logged but not returned. This is intentional because:
@@ -444,16 +458,19 @@ func (a *SaveAudioAction) Execute(ctx context.Context, _ any) error {
 	// Get the full path by joining the export path with the relative clip name
 	outputPath := filepath.Join(a.Settings.Realtime.Audio.Export.Path, a.ClipName)
 
-	// Ensure the directory exists
-	// Note: Errors are logged by the caller (handleAudioExportError) with full context
+	// Ensure the directory exists. The error unwinds to the job queue, which
+	// logs it; there is no export context to add here that it does not carry.
 	if err := os.MkdirAll(filepath.Dir(outputPath), 0o750); err != nil {
 		return err
 	}
 
 	exportRate, exportFormat, outputPath := a.resolveExportParams(outputPath)
 
-	encoderUsed, err := a.encodeClip(ctx, exportRate, exportFormat, outputPath)
+	encodeStart := time.Now()
+	enc, err := a.encodeClip(ctx, exportRate, exportFormat, outputPath)
+	encodeDuration := time.Since(encodeStart)
 	if err != nil {
+		a.logExportFailure(ctx, &enc, exportFormat, exportRate, outputPath, err)
 		return err
 	}
 
@@ -472,17 +489,32 @@ func (a *SaveAudioAction) Execute(ctx context.Context, _ any) error {
 			logger.String("operation", "audio_export_stat"))
 	}
 
-	// Log successful audio export at INFO level (BG-18)
-	// This provides evidence that audio export completed successfully
-	GetLogger().Info("Audio clip saved successfully",
+	// Log successful audio export at INFO level (BG-18).
+	//
+	// This is the primary support artefact for the clip export path, so it names
+	// the encoder that produced the file and the parameters that explain it. Two
+	// of the recurring reports are answered straight from this line: "my clips are
+	// too quiet" (gain_db, against the configured normalization) and "my clips are
+	// truncated" (duration_ms next to file_size_bytes, which on its own cannot
+	// distinguish a short capture from a bad encode).
+	fields := make([]logger.Field, 0, 12)
+	fields = append(fields,
 		logger.String("component", "analysis.processor.actions"),
 		logger.String("detection_id", a.CorrelationID),
 		logger.String("clip_path", filepath.Base(outputPath)),
 		logger.Int64("file_size_bytes", fileSize),
 		logger.String("format", exportFormat),
-		logger.String("encoder", encoderUsed),
+		logger.String("encoder", enc.Encoder),
 		logger.Int("sample_rate", exportRate),
-		logger.String("operation", "audio_export_success"))
+		logger.Float64("gain_db", enc.GainDB),
+		logger.Int64("duration_ms", clipDurationMs(len(a.pcmData), exportRate)),
+		logger.Int64("encode_ms", encodeDuration.Milliseconds()),
+	)
+	if enc.BitrateKbps > 0 {
+		fields = append(fields, logger.Int("bitrate_kbps", enc.BitrateKbps))
+	}
+	fields = append(fields, logger.String("operation", "audio_export_success"))
+	GetLogger().Info("Audio clip saved successfully", fields...)
 
 	// Signal that the clip file exists on disk. This is used by any late
 	// consumers that check whether the audio was actually exported.
@@ -517,25 +549,128 @@ func (a *SaveAudioAction) Execute(ctx context.Context, _ any) error {
 	return nil
 }
 
-// encodeClip writes the captured PCM to outputPath in the resolved format and
-// returns the encoder tag for the success log.
+// clipDurationMs is the wall duration of the captured PCM at the export rate.
+// It is logged next to the encoded file size because size alone cannot tell a
+// short capture apart from a truncated encode, and both get reported the same
+// way ("my clips are cut off").
+func clipDurationMs(pcmBytes, sampleRate int) int64 {
+	bytesPerFrame := (conf.BitDepth / 8) * conf.NumChannels
+	if sampleRate <= 0 || bytesPerFrame <= 0 {
+		return 0
+	}
+	const msPerSecond = 1000
+	return int64(pcmBytes/bytesPerFrame) * msPerSecond / int64(sampleRate)
+}
+
+// logExportFailure records a failed clip export against the encoder that failed.
+//
+// Without it the only trace of a failed export is the job queue's generic "Job
+// failed" line, which carries the action description and the error and names
+// neither the encoder nor the format. An operator who opted a format into its
+// native encoder could not tell from the logs whether go-aac or FFmpeg produced
+// the failure, which is exactly what the gated rollout needs to know.
+//
+// A cancelled context is shutdown rather than a defect, so it is recorded at
+// Debug: exports in flight when the process stops must not look like errors.
+func (a *SaveAudioAction) logExportFailure(ctx context.Context, enc *clipEncoding, exportFormat string, exportRate int, outputPath string, err error) {
+	fields := []logger.Field{
+		logger.String("component", "analysis.processor.actions"),
+		logger.String("detection_id", a.CorrelationID),
+		logger.String("clip_path", filepath.Base(outputPath)),
+		logger.String("format", exportFormat),
+		logger.String("encoder", enc.Encoder),
+		logger.Int("sample_rate", exportRate),
+		logger.Float64("gain_db", enc.GainDB),
+		logger.Int64("duration_ms", clipDurationMs(len(a.pcmData), exportRate)),
+		logger.Error(err),
+		logger.String("operation", "audio_export_failed"),
+	}
+	if ctx.Err() != nil || errors.Is(err, context.Canceled) {
+		GetLogger().Debug("Audio clip export cancelled", fields...)
+		return
+	}
+	GetLogger().Error("Audio clip export failed", fields...)
+}
+
+// selectEncoder names the encoder that will write a clip of this format at this
+// sample rate.
+//
+// Deciding the encoder as its own step, rather than inside the encode switch, is
+// what lets a failed export name its encoder: the tag exists before the encoder
+// is ever invoked.
 //
 // WAV and FLAC are always native (the WAV writer and go-flac); FFmpeg is never
 // used for them. AAC and Opus have native encoders too, but they are opt-in
 // while they earn field confidence, so they reach go-aac/go-m4a and go-opus only
-// when the matching gate in internal/audiocore/nativeenc is set and the encoder
-// accepts the clip's shape. Everything else, and every non-gated AAC or Opus
-// clip, goes to FFmpeg.
-//
-// Loudness is resolved identically for every format: when normalization is
-// enabled the EBU R128 gain is measured in Go via audionorm, otherwise the
-// static Export.Gain is used. A native encoder applies that gain itself, WAV has
-// it applied to the samples before writing, and FFmpeg receives it as a plain
-// volume filter. FFmpeg's loudnorm filter is not used on this path at all, so no
-// export format depends on FFmpeg for normalization.
-func (a *SaveAudioAction) encodeClip(ctx context.Context, exportRate int, exportFormat, outputPath string) (string, error) {
+// when the matching gate in internal/conf is set and the encoder accepts the
+// clip's shape. Everything else, and every non-gated AAC or Opus clip, goes to
+// FFmpeg.
+func selectEncoder(exportFormat string, exportRate int) string {
 	switch exportFormat {
 	case ffmpeg.FormatWAV:
+		return encoderNativeWAV
+	case ffmpeg.FormatFLAC:
+		return encoderNativeFLAC
+	case ffmpeg.FormatAAC:
+		// Opt-in; see internal/conf/native_encoders.go for the gate and its removal.
+		if nativeAACSelected(exportRate) {
+			return encoderNativeAAC
+		}
+		return encoderFFmpeg
+	case ffmpeg.FormatOpus:
+		// Opt-in; see internal/conf/native_encoders.go for the gate and its removal.
+		if nativeOpusSelected(exportRate) {
+			return encoderNativeOpus
+		}
+		return encoderFFmpeg
+	default:
+		// MP3 and ALAC are the only remaining formats, and FFmpeg owns their
+		// codecs only; the loudness gain is resolved in Go first.
+		return encoderFFmpeg
+	}
+}
+
+// lossyBitrateKbps returns the bitrate a lossy encode will actually use, or 0
+// for the lossless formats. The configured setting is not simply echoed:
+// EffectiveBitrateKbps clamps it to what the codec accepts, and it is the
+// clamped value that explains the size of the file on disk.
+func lossyBitrateKbps(exportFormat, bitrate string) int {
+	switch exportFormat {
+	case ffmpeg.FormatMP3, ffmpeg.FormatAAC, ffmpeg.FormatOpus:
+		return ffmpeg.EffectiveBitrateKbps(exportFormat, bitrate)
+	default:
+		return 0
+	}
+}
+
+// encodeClip writes the captured PCM to outputPath in the resolved format and
+// returns how it was encoded, for the success and failure logs.
+//
+// Loudness is resolved identically for every format and once for all of them,
+// before any encoder runs: when normalization is enabled the EBU R128 gain is
+// measured in Go via audionorm, otherwise the static Export.Gain is used. A
+// native encoder applies that gain itself, WAV has it applied to the samples
+// before writing, and FFmpeg receives it as a plain volume filter. FFmpeg's
+// loudnorm filter is not used on this path at all, so no export format depends
+// on FFmpeg for normalization.
+//
+// The returned clipEncoding is populated as far as the export got, so a caller
+// handling an error can still report the encoder and, past gain resolution, the
+// gain that was going to be applied.
+func (a *SaveAudioAction) encodeClip(ctx context.Context, exportRate int, exportFormat, outputPath string) (clipEncoding, error) {
+	enc := clipEncoding{
+		Encoder:     selectEncoder(exportFormat, exportRate),
+		BitrateKbps: lossyBitrateKbps(exportFormat, a.Settings.Realtime.Audio.Export.Bitrate),
+	}
+
+	gainDB, err := a.resolveExportGainDB(ctx, exportRate, exportFormat)
+	if err != nil {
+		return enc, err
+	}
+	enc.GainDB = gainDB
+
+	switch enc.Encoder {
+	case encoderNativeWAV:
 		// WAV honours the resolved gain like every other format. It used to be the
 		// one exception, writing captured samples verbatim, which meant an
 		// operator with normalization or Export.Gain configured silently got
@@ -543,73 +678,41 @@ func (a *SaveAudioAction) encodeClip(ctx context.Context, exportRate int, export
 		// resolveExportParams downgrades to it for bat/ultrasonic clips
 		// (needsBatFormatFallback) and for installs with no usable encoder
 		// (strandedWithoutEncoder), so a user could land here without asking to.
-		gainDB, err := a.resolveExportGainDB(ctx, exportRate, exportFormat)
-		if err != nil {
-			return "", err
-		}
 		pcm := a.pcmData
 		if gainDB != 0 {
 			// Applied returns a gained copy, so a.pcmData stays pristine for the
 			// spectrogram pre-render job that reads it after the export.
 			pcm = pcmgain.Applied(pcm, gainDB)
 		}
-		if err := convert.SavePCMDataToWAV(outputPath, pcm, exportRate, conf.BitDepth); err != nil {
-			return "", err
-		}
-		return encoderNativeWAV, nil
+		return enc, convert.SavePCMDataToWAV(outputPath, pcm, exportRate, conf.BitDepth)
 
-	case ffmpeg.FormatFLAC:
+	case encoderNativeFLAC:
 		// FLAC always encodes natively via go-flac; FFmpeg is never used for FLAC.
-		gainDB, err := a.resolveExportGainDB(ctx, exportRate, exportFormat)
-		if err != nil {
-			return "", err
-		}
-		if err := flac.EncodePCM(ctx, &flac.Options{
+		return enc, flac.EncodePCM(ctx, &flac.Options{
 			PCMData:    a.pcmData,
 			OutputPath: outputPath,
 			SampleRate: exportRate,
 			Channels:   conf.NumChannels,
 			BitDepth:   conf.BitDepth,
 			GainDB:     gainDB,
-		}); err != nil {
-			return "", err
-		}
-		return encoderNativeFLAC, nil
+		})
 
-	case ffmpeg.FormatAAC:
-		// Opt-in; see internal/conf/native_encoders.go for the gate and its removal.
-		if nativeAACSelected(exportRate) {
-			return a.encodeClipNativeAAC(ctx, exportRate, outputPath)
-		}
-		return a.encodeClipFFmpeg(ctx, exportRate, exportFormat, outputPath)
+	case encoderNativeAAC:
+		return enc, a.encodeClipNativeAAC(ctx, exportRate, enc.BitrateKbps, outputPath, gainDB)
 
-	case ffmpeg.FormatOpus:
-		// Opt-in; see internal/conf/native_encoders.go for the gate and its removal.
-		if nativeOpusSelected(exportRate) {
-			return a.encodeClipNativeOpus(ctx, exportRate, outputPath)
-		}
-		return a.encodeClipFFmpeg(ctx, exportRate, exportFormat, outputPath)
+	case encoderNativeOpus:
+		return enc, a.encodeClipNativeOpus(ctx, exportRate, enc.BitrateKbps, outputPath, gainDB)
 
 	default:
-		// MP3 is the only remaining format, and FFmpeg owns its codec only; the
-		// loudness gain is resolved in Go first. WAV, FLAC, AAC and Opus never
-		// reach this branch.
-		return a.encodeClipFFmpeg(ctx, exportRate, exportFormat, outputPath)
+		return enc, a.encodeClipFFmpeg(ctx, exportRate, exportFormat, outputPath, gainDB)
 	}
 }
 
 // encodeClipFFmpeg encodes the clip with FFmpeg, which owns the codec only. The
 // loudness gain is planned in Go before FFmpeg is invoked, exactly as on the
 // native paths, and FFmpeg applies it as a plain volume filter.
-func (a *SaveAudioAction) encodeClipFFmpeg(ctx context.Context, exportRate int, exportFormat, outputPath string) (string, error) {
-	opts, err := a.buildFFmpegExportOptions(ctx, exportRate, exportFormat, outputPath)
-	if err != nil {
-		return "", err
-	}
-	if err := ffmpeg.ExportAudio(ctx, opts); err != nil {
-		return "", err
-	}
-	return encoderFFmpeg, nil
+func (a *SaveAudioAction) encodeClipFFmpeg(ctx context.Context, exportRate int, exportFormat, outputPath string, gainDB float64) error {
+	return ffmpeg.ExportAudio(ctx, a.buildFFmpegExportOptions(exportRate, exportFormat, outputPath, gainDB))
 }
 
 // buildFFmpegExportOptions assembles the FFmpeg export request. It is separate
@@ -621,69 +724,48 @@ func (a *SaveAudioAction) encodeClipFFmpeg(ctx context.Context, exportRate int, 
 // setting, so an FFmpeg-encoded clip is normalised by the same audionorm
 // measurement as a natively encoded one. FFmpeg's loudnorm filter is no longer
 // used anywhere on this path.
-func (a *SaveAudioAction) buildFFmpegExportOptions(ctx context.Context, exportRate int, exportFormat, outputPath string) (*ffmpeg.ExportOptions, error) {
-	exportSettings := &a.Settings.Realtime.Audio.Export
-	gainDB, err := a.resolveExportGainDB(ctx, exportRate, exportFormat)
-	if err != nil {
-		return nil, err
-	}
+func (a *SaveAudioAction) buildFFmpegExportOptions(exportRate int, exportFormat, outputPath string, gainDB float64) *ffmpeg.ExportOptions {
 	return &ffmpeg.ExportOptions{
 		PCMData:    a.pcmData,
 		OutputPath: outputPath,
 		Format:     exportFormat,
-		Bitrate:    exportSettings.Bitrate,
+		Bitrate:    a.Settings.Realtime.Audio.Export.Bitrate,
 		SampleRate: exportRate,
 		Channels:   conf.NumChannels,
 		BitDepth:   conf.BitDepth,
 		FFmpegPath: a.Settings.Realtime.Audio.FfmpegPath,
 		GainDB:     gainDB,
-	}, nil
+	}
 }
 
 // encodeClipNativeAAC encodes the clip to AAC-LC in an MP4 (.m4a) container with
 // go-aac and go-m4a. A failure is returned rather than retried through FFmpeg:
 // the operator opted this clip into the native encoder, and a silent fallback
 // would hide exactly the failures this rollout exists to surface.
-func (a *SaveAudioAction) encodeClipNativeAAC(ctx context.Context, exportRate int, outputPath string) (string, error) {
-	exportSettings := &a.Settings.Realtime.Audio.Export
-	gainDB, err := a.resolveExportGainDB(ctx, exportRate, ffmpeg.FormatAAC)
-	if err != nil {
-		return "", err
-	}
-	if err := aac.EncodePCM(ctx, &aac.Options{
+func (a *SaveAudioAction) encodeClipNativeAAC(ctx context.Context, exportRate, bitrateKbps int, outputPath string, gainDB float64) error {
+	return aac.EncodePCM(ctx, &aac.Options{
 		PCMData:     a.pcmData,
 		OutputPath:  outputPath,
 		SampleRate:  exportRate,
 		Channels:    conf.NumChannels,
 		BitDepth:    conf.BitDepth,
-		BitrateKbps: ffmpeg.EffectiveBitrateKbps(ffmpeg.FormatAAC, exportSettings.Bitrate),
+		BitrateKbps: bitrateKbps,
 		GainDB:      gainDB,
-	}); err != nil {
-		return "", err
-	}
-	return encoderNativeAAC, nil
+	})
 }
 
 // encodeClipNativeOpus encodes the clip to Ogg Opus (.opus) with go-opus. As
 // with AAC, a failure is surfaced rather than falling back to FFmpeg.
-func (a *SaveAudioAction) encodeClipNativeOpus(ctx context.Context, exportRate int, outputPath string) (string, error) {
-	exportSettings := &a.Settings.Realtime.Audio.Export
-	gainDB, err := a.resolveExportGainDB(ctx, exportRate, ffmpeg.FormatOpus)
-	if err != nil {
-		return "", err
-	}
-	if err := opus.EncodePCM(ctx, &opus.Options{
+func (a *SaveAudioAction) encodeClipNativeOpus(ctx context.Context, exportRate, bitrateKbps int, outputPath string, gainDB float64) error {
+	return opus.EncodePCM(ctx, &opus.Options{
 		PCMData:     a.pcmData,
 		OutputPath:  outputPath,
 		SampleRate:  exportRate,
 		Channels:    conf.NumChannels,
 		BitDepth:    conf.BitDepth,
-		BitrateKbps: ffmpeg.EffectiveBitrateKbps(ffmpeg.FormatOpus, exportSettings.Bitrate),
+		BitrateKbps: bitrateKbps,
 		GainDB:      gainDB,
-	}); err != nil {
-		return "", err
-	}
-	return encoderNativeOpus, nil
+	})
 }
 
 // nativeAACSelected reports whether this clip should take the native AAC path:
@@ -728,9 +810,29 @@ func nativeOpusSelected(exportRate int) bool {
 //
 //nolint:gochecknoglobals // process-lifetime log-flood guards, matching mqttNotReadyWarnOnce
 var (
-	nativeAACSkipOnce  sync.Once
-	nativeOpusSkipOnce sync.Once
+	nativeAACSkipOnce      sync.Once
+	nativeOpusSkipOnce     sync.Once
+	batFormatDowngradeOnce sync.Once
 )
+
+// logBatFormatDowngrade explains why an install configured for a lossy format is
+// producing .wav files: an ultrasonic capture runs at a rate the configured
+// container cannot carry, so the export switched to WAV. The sibling downgrade
+// in strandedWithoutEncoder already logged its reason; this one did not, leaving
+// the operator with no explanation for a format they did not choose.
+//
+// Logged once per process for the same reason as the native-encoder skip
+// warning: a bat install takes this path on every single detection, and neither
+// the model nor the capture rate can change without a restart.
+func logBatFormatDowngrade(requestedFormat string, rate int) {
+	batFormatDowngradeOnce.Do(func() {
+		GetLogger().Info("Ultrasonic clip format downgraded to WAV; the configured format cannot carry this sample rate",
+			logger.String("component", "analysis.processor.actions"),
+			logger.String("requested_format", requestedFormat),
+			logger.Int("sample_rate", rate),
+			logger.String("operation", "audio_export_bat_format_fallback"))
+	})
+}
 
 // logNativeEncoderSkipped records, once per format, that an opted-in native
 // encoder could not carry this clip, so an operator who set the env flag and
@@ -996,7 +1098,8 @@ func (a *SaveAudioAction) resolveExportParams(outputPath string) (rate int, form
 	isBat := detection.ResolveModelType(a.modelName, "") == entities.ModelTypeBat
 
 	if needsBatFormatFallback(a.modelName, "", rate, format) {
-		format = "wav"
+		logBatFormatDowngrade(format, rate)
+		format = ffmpeg.FormatWAV
 		path = replaceExtension(path, ".wav")
 	} else if rate > conf.SampleRate && !isBat {
 		resampled, err := resample.ResampleBytes(a.pcmData, rate, conf.SampleRate)
@@ -1022,7 +1125,7 @@ func (a *SaveAudioAction) resolveExportParams(outputPath string) (rate int, form
 			logger.String("requested_format", format),
 			logger.Int("sample_rate", rate),
 			logger.String("operation", "audio_export_no_encoder_fallback"))
-		format = "wav"
+		format = ffmpeg.FormatWAV
 		path = replaceExtension(path, ".wav")
 	}
 

--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -574,10 +574,12 @@ func clipDurationMs(pcmBytes, sampleRate int) int64 {
 // Debug: exports in flight when the process stops must not look like errors.
 //
 // Everything else is WARN, not ERROR, even though it is a genuine failure. The
-// error is returned unchanged, so the job queue logs the same failure as ERROR
-// immediately afterwards; raising this line to ERROR too would report one root
+// error is returned unchanged, and the job queue logs that same failure as ERROR
+// once the attempts are exhausted (handleJobFailure only calls LogJobFailed when
+// Attempts >= MaxAttempts). Raising this line to ERROR too would report one root
 // cause as two, inflating error counts and alerting twice. This line exists to
-// carry the context the queue's generic line cannot, not to raise the alarm.
+// carry the context the queue's generic line cannot, not to raise the alarm, and
+// on the deferred path it is the only record of the attempts before the last.
 func (a *SaveAudioAction) logExportFailure(ctx context.Context, enc *clipEncoding, exportFormat string, exportRate int, outputPath string, err error) {
 	fields := make([]logger.Field, 0, 11)
 	fields = append(fields,
@@ -836,8 +838,8 @@ var (
 // the operator with no explanation for a format they did not choose.
 //
 // Logged once per process for the same reason as the native-encoder skip
-// warning: a bat install takes this path on every single detection, and neither
-// the model nor the capture rate can change without a restart.
+// warning: a bat install left on a lossy export format takes this path on every
+// single detection, and the explanation only needs stating once.
 func logBatFormatDowngrade(requestedFormat string, rate int) {
 	batFormatDowngradeOnce.Do(func() {
 		GetLogger().Info("Ultrasonic clip format downgraded to WAV; the configured format cannot carry this sample rate",

--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -572,8 +572,15 @@ func clipDurationMs(pcmBytes, sampleRate int) int64 {
 //
 // A cancelled context is shutdown rather than a defect, so it is recorded at
 // Debug: exports in flight when the process stops must not look like errors.
+//
+// Everything else is WARN, not ERROR, even though it is a genuine failure. The
+// error is returned unchanged, so the job queue logs the same failure as ERROR
+// immediately afterwards; raising this line to ERROR too would report one root
+// cause as two, inflating error counts and alerting twice. This line exists to
+// carry the context the queue's generic line cannot, not to raise the alarm.
 func (a *SaveAudioAction) logExportFailure(ctx context.Context, enc *clipEncoding, exportFormat string, exportRate int, outputPath string, err error) {
-	fields := []logger.Field{
+	fields := make([]logger.Field, 0, 11)
+	fields = append(fields,
 		logger.String("component", "analysis.processor.actions"),
 		logger.String("detection_id", a.CorrelationID),
 		logger.String("clip_path", filepath.Base(outputPath)),
@@ -582,14 +589,21 @@ func (a *SaveAudioAction) logExportFailure(ctx context.Context, enc *clipEncodin
 		logger.Int("sample_rate", exportRate),
 		logger.Float64("gain_db", enc.GainDB),
 		logger.Int64("duration_ms", clipDurationMs(len(a.pcmData), exportRate)),
-		logger.Error(err),
-		logger.String("operation", "audio_export_failed"),
+	)
+	// A rejected bitrate is one of the ways a lossy encode fails, so report the
+	// value that was going to be used rather than making it a second question.
+	if enc.BitrateKbps > 0 {
+		fields = append(fields, logger.Int("bitrate_kbps", enc.BitrateKbps))
 	}
+	fields = append(fields,
+		logger.Error(err),
+		logger.String("operation", "audio_export_failed"))
+
 	if ctx.Err() != nil || errors.Is(err, context.Canceled) {
 		GetLogger().Debug("Audio clip export cancelled", fields...)
 		return
 	}
-	GetLogger().Error("Audio clip export failed", fields...)
+	GetLogger().Warn("Audio clip export failed", fields...)
 }
 
 // selectEncoder names the encoder that will write a clip of this format at this

--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -570,8 +570,14 @@ func clipDurationMs(pcmBytes, sampleRate int) int64 {
 // native encoder could not tell from the logs whether go-aac or FFmpeg produced
 // the failure, which is exactly what the gated rollout needs to know.
 //
-// A cancelled context is shutdown rather than a defect, so it is recorded at
-// Debug: exports in flight when the process stops must not look like errors.
+// A CANCELLED context is shutdown rather than a defect, so it is recorded at
+// Debug: exports in flight when the process stops must not look like errors. A
+// context that EXPIRED is the opposite and stays at WARN. The job queue wraps
+// every execution in context.WithTimeout (handleJob), so the export context
+// always carries a deadline, and an encode slow enough to blow it (a hung
+// FFmpeg, a long extended capture on a Pi) is precisely the failure this line
+// exists to surface. Testing ctx.Err() != nil would bury it at Debug, because
+// Err() reports DeadlineExceeded just as readily as Canceled.
 //
 // Everything else is WARN, not ERROR, even though it is a genuine failure. The
 // error is returned unchanged, and the job queue logs that same failure as ERROR
@@ -601,7 +607,7 @@ func (a *SaveAudioAction) logExportFailure(ctx context.Context, enc *clipEncodin
 		logger.Error(err),
 		logger.String("operation", "audio_export_failed"))
 
-	if ctx.Err() != nil || errors.Is(err, context.Canceled) {
+	if errors.Is(ctx.Err(), context.Canceled) || errors.Is(err, context.Canceled) {
 		GetLogger().Debug("Audio clip export cancelled", fields...)
 		return
 	}

--- a/internal/analysis/processor/export_logging_test.go
+++ b/internal/analysis/processor/export_logging_test.go
@@ -163,6 +163,30 @@ func TestExecute_FailureLogNamesNativeEncoder(t *testing.T) {
 	assert.Contains(t, out, "format="+ffmpeg.FormatAAC)
 	assert.Contains(t, out, "operation=audio_export_failed")
 	assert.Contains(t, out, "detection_id=export-log-test")
+	// A rejected bitrate is one of the ways a lossy encode fails, so the value
+	// that was going to be used must not be a second question.
+	assert.Contains(t, out, "bitrate_kbps=96")
+}
+
+// The failure line is WARN, not ERROR: the error is returned unchanged, so the
+// job queue logs the same root cause as ERROR right afterwards. Two ERROR lines
+// for one failure would double-count and double-alert.
+func TestExecute_FailureLogIsWarnNotError(t *testing.T) {
+	logs := captureExportLogs(t)
+	dir := t.TempDir()
+	a := newExportLogAction(t, dir, "clip.mp3", ffmpeg.FormatMP3)
+	a.Settings.Realtime.Audio.FfmpegPath = ""
+
+	require.Error(t, a.Execute(t.Context(), nil))
+
+	out := logs.String()
+	require.Contains(t, out, "Audio clip export failed")
+	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+		if strings.Contains(line, "Audio clip export failed") {
+			assert.Contains(t, line, "level=WARN",
+				"the job queue owns the ERROR for this failure; this line only adds context")
+		}
+	}
 }
 
 // The other half of the pair: the same failure on the FFmpeg path is attributed

--- a/internal/analysis/processor/export_logging_test.go
+++ b/internal/analysis/processor/export_logging_test.go
@@ -1,0 +1,264 @@
+package processor
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// A bat model at an ultrasonic capture rate: the combination needsBatFormatFallback
+// downgrades to WAV, because no lossy container carries 256 kHz.
+const (
+	batModelName        = "BattyBirdNET"
+	batSourceSampleRate = 256000
+)
+
+// captureExportLogs redirects the global logger to an in-memory buffer for the
+// duration of the test and returns the buffer. The processor package logs
+// through logger.Global().Module("analysis.processor"), so this captures
+// everything the export path emits. It swaps process-wide global state, so
+// tests using it must not run with t.Parallel().
+func captureExportLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+
+	var buf bytes.Buffer
+	capture := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	cl, err := logger.NewCentralLogger(
+		&logger.LoggingConfig{
+			Console:      &logger.ConsoleOutput{Enabled: false},
+			FileOutput:   &logger.FileOutput{Enabled: false},
+			DefaultLevel: "debug",
+		},
+		capture,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cl.Close() })
+
+	prev := logger.Global()
+	logger.SetGlobal(cl)
+	t.Cleanup(func() { logger.SetGlobal(prev) })
+
+	return &buf
+}
+
+// newExportLogAction builds a SaveAudioAction that Execute will carry all the
+// way to an encoder: export enabled, a real output directory, and a second of
+// PCM. Normalization is left off so the resolved gain is the static Export.Gain
+// and the assertions stay deterministic.
+func newExportLogAction(t *testing.T, exportDir, clipName, format string) *SaveAudioAction {
+	t.Helper()
+	return &SaveAudioAction{
+		CorrelationID: "export-log-test",
+		ClipName:      clipName,
+		pcmData:       sinePCMBytes(8000, 1.0, 1000),
+		Settings: &conf.Settings{
+			Realtime: conf.RealtimeSettings{
+				Audio: conf.AudioSettings{
+					Export: conf.ExportSettings{
+						Enabled: true,
+						Path:    exportDir,
+						Type:    format,
+						Bitrate: "96k",
+						Gain:    -2.5,
+					},
+				},
+			},
+		},
+	}
+}
+
+// blockOutputPath makes the clip's destination unwritable by putting a
+// directory where the file belongs. Every encoder on this path writes to a temp
+// file and renames it into place, and a rename onto a directory always fails, so
+// this forces a failure inside the encoder rather than before it.
+func blockOutputPath(t *testing.T, exportDir, clipName string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Join(exportDir, clipName), 0o750))
+}
+
+// The success log is the primary support artefact for the clip export path. It
+// must name the encoder that produced the file, so a support log answers "native
+// or FFmpeg" without the reader having to reconstruct it from the format and the
+// operator's environment.
+func TestExecute_SuccessLogNamesNativeEncoder(t *testing.T) {
+	logs := captureExportLogs(t)
+	dir := t.TempDir()
+	a := newExportLogAction(t, dir, "clip.flac", ffmpeg.FormatFLAC)
+
+	require.NoError(t, a.Execute(t.Context(), nil))
+
+	out := logs.String()
+	assert.Contains(t, out, "Audio clip saved successfully")
+	assert.Contains(t, out, "encoder="+encoderNativeFLAC,
+		"the success log must name the encoder that wrote the clip")
+	assert.Contains(t, out, "format="+ffmpeg.FormatFLAC)
+	assert.Contains(t, out, "operation=audio_export_success")
+}
+
+// The troubleshooting fields alongside the encoder: the applied loudness gain
+// ("my clips are too quiet") and the clip duration next to the file size ("my
+// clips are cut off"). Both used to be reachable only at Debug, or not at all.
+func TestExecute_SuccessLogCarriesGainAndDuration(t *testing.T) {
+	logs := captureExportLogs(t)
+	dir := t.TempDir()
+	a := newExportLogAction(t, dir, "clip.wav", ffmpeg.FormatWAV)
+
+	require.NoError(t, a.Execute(t.Context(), nil))
+
+	out := logs.String()
+	assert.Contains(t, out, "gain_db=-2.5", "the resolved gain must be visible per clip")
+	assert.Contains(t, out, "duration_ms=", "clip duration must accompany the file size")
+	assert.Contains(t, out, "encode_ms=")
+	assert.Contains(t, out, "file_size_bytes=")
+	// WAV is lossless, so there is no bitrate to report and the field is omitted
+	// rather than logged as a misleading zero.
+	assert.NotContains(t, out, "bitrate_kbps=")
+}
+
+// A lossy format reports the bitrate the encoder actually used, which is the
+// clamped effective value rather than the raw setting.
+func TestExecute_SuccessLogCarriesBitrateForLossyFormats(t *testing.T) {
+	t.Setenv(conf.EnvNativeAACEncoder, "native")
+	resetNativeSkipOnce()
+	logs := captureExportLogs(t)
+	dir := t.TempDir()
+	a := newExportLogAction(t, dir, "clip.m4a", ffmpeg.FormatAAC)
+
+	require.NoError(t, a.Execute(t.Context(), nil))
+
+	out := logs.String()
+	assert.Contains(t, out, "encoder="+encoderNativeAAC)
+	assert.Contains(t, out, "bitrate_kbps=96")
+}
+
+// The gap this change closes: a failed export used to leave nothing but the job
+// queue's generic "Job failed" line, which names neither the encoder nor the
+// format. An operator who opted AAC into the native encoder could not tell
+// whether go-aac or FFmpeg produced the failure.
+func TestExecute_FailureLogNamesNativeEncoder(t *testing.T) {
+	t.Setenv(conf.EnvNativeAACEncoder, "native")
+	resetNativeSkipOnce()
+	logs := captureExportLogs(t)
+	dir := t.TempDir()
+	blockOutputPath(t, dir, "clip.m4a")
+	a := newExportLogAction(t, dir, "clip.m4a", ffmpeg.FormatAAC)
+
+	require.Error(t, a.Execute(t.Context(), nil))
+
+	out := logs.String()
+	assert.Contains(t, out, "Audio clip export failed")
+	assert.Contains(t, out, "encoder="+encoderNativeAAC,
+		"a failed export must be attributable to the encoder that failed")
+	assert.Contains(t, out, "format="+ffmpeg.FormatAAC)
+	assert.Contains(t, out, "operation=audio_export_failed")
+	assert.Contains(t, out, "detection_id=export-log-test")
+}
+
+// The other half of the pair: the same failure on the FFmpeg path is attributed
+// to FFmpeg, so the two are distinguishable in a support log.
+func TestExecute_FailureLogNamesFFmpeg(t *testing.T) {
+	logs := captureExportLogs(t)
+	dir := t.TempDir()
+	a := newExportLogAction(t, dir, "clip.mp3", ffmpeg.FormatMP3)
+	// No FFmpeg binary configured, so the export fails inside ffmpeg.ExportAudio.
+	a.Settings.Realtime.Audio.FfmpegPath = ""
+
+	require.Error(t, a.Execute(t.Context(), nil))
+
+	out := logs.String()
+	assert.Contains(t, out, "Audio clip export failed")
+	assert.Contains(t, out, "encoder="+encoderFFmpeg)
+	assert.Contains(t, out, "format="+ffmpeg.FormatMP3)
+}
+
+// The failure log must not leak the export directory. Only the clip's basename
+// is logged, matching the success line, because support logs and uploaded
+// support dumps are read by someone other than the operator.
+func TestExecute_FailureLogOmitsFullPath(t *testing.T) {
+	logs := captureExportLogs(t)
+	dir := t.TempDir()
+	a := newExportLogAction(t, dir, "clip.mp3", ffmpeg.FormatMP3)
+	a.Settings.Realtime.Audio.FfmpegPath = ""
+
+	require.Error(t, a.Execute(t.Context(), nil))
+
+	assert.Contains(t, logs.String(), "clip_path=clip.mp3")
+	assert.NotContains(t, logs.String(), "clip_path="+dir)
+}
+
+// A cancelled context is shutdown, not a defect: an export in flight when the
+// process stops must not be recorded as an error.
+func TestExecute_CancelledExportLogsAtDebug(t *testing.T) {
+	logs := captureExportLogs(t)
+	dir := t.TempDir()
+	a := newExportLogAction(t, dir, "clip.mp3", ffmpeg.FormatMP3)
+	a.Settings.Realtime.Audio.FfmpegPath = ""
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	require.Error(t, a.Execute(ctx, nil))
+
+	out := logs.String()
+	assert.Contains(t, out, "Audio clip export cancelled")
+	assert.NotContains(t, out, "Audio clip export failed")
+}
+
+// An ultrasonic capture whose configured container cannot carry the sample rate
+// is exported as WAV. That downgrade used to be entirely silent, leaving an
+// operator configured for a lossy format with no explanation for the .wav files
+// on disk.
+func TestResolveExportParams_BatDowngradeIsLogged(t *testing.T) {
+	resetBatFormatDowngradeOnce()
+	logs := captureExportLogs(t)
+	a := newExportLogAction(t, t.TempDir(), "clip.mp3", ffmpeg.FormatMP3)
+	a.modelName = batModelName
+	a.sourceSampleRate = batSourceSampleRate
+
+	_, format, path := a.resolveExportParams("/clips/clip.mp3")
+
+	require.Equal(t, ffmpeg.FormatWAV, format, "the downgrade itself must still happen")
+	assert.Equal(t, "/clips/clip.wav", path)
+	assert.Contains(t, logs.String(), "operation=audio_export_bat_format_fallback")
+	assert.Contains(t, logs.String(), "requested_format="+ffmpeg.FormatMP3)
+}
+
+// The downgrade fires on every single detection of a bat install, so it is
+// logged once per process rather than once per clip.
+func TestResolveExportParams_BatDowngradeLoggedOncePerProcess(t *testing.T) {
+	resetBatFormatDowngradeOnce()
+	logs := captureExportLogs(t)
+	a := newExportLogAction(t, t.TempDir(), "clip.mp3", ffmpeg.FormatMP3)
+	a.modelName = batModelName
+	a.sourceSampleRate = batSourceSampleRate
+
+	for range 3 {
+		_, _, _ = a.resolveExportParams("/clips/clip.mp3")
+	}
+
+	assert.Equal(t, 1, strings.Count(logs.String(), "audio_export_bat_format_fallback"),
+		"a bat install takes this path on every detection; the log must not repeat")
+}
+
+func TestClipDurationMs(t *testing.T) {
+	t.Parallel()
+
+	bytesPerFrame := (conf.BitDepth / 8) * conf.NumChannels
+
+	assert.Equal(t, int64(1000), clipDurationMs(bytesPerFrame*conf.SampleRate, conf.SampleRate))
+	assert.Equal(t, int64(500), clipDurationMs(bytesPerFrame*conf.SampleRate/2, conf.SampleRate))
+	assert.Equal(t, int64(0), clipDurationMs(0, conf.SampleRate))
+	assert.Equal(t, int64(0), clipDurationMs(bytesPerFrame*100, 0),
+		"an unknown sample rate must not divide by zero")
+}

--- a/internal/analysis/processor/export_logging_test.go
+++ b/internal/analysis/processor/export_logging_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -237,6 +238,30 @@ func TestExecute_CancelledExportLogsAtDebug(t *testing.T) {
 	out := logs.String()
 	assert.Contains(t, out, "Audio clip export cancelled")
 	assert.NotContains(t, out, "Audio clip export failed")
+}
+
+// The other side of that classification: an EXPIRED context is not shutdown. The
+// job queue wraps every execution in a timeout, so a hung encoder blows the
+// deadline, and that is exactly the failure this line exists to surface. It must
+// not be filed under "cancelled" at Debug.
+func TestExecute_TimedOutExportStaysAtWarn(t *testing.T) {
+	logs := captureExportLogs(t)
+	dir := t.TempDir()
+	a := newExportLogAction(t, dir, "clip.mp3", ffmpeg.FormatMP3)
+	a.Settings.Realtime.Audio.FfmpegPath = ""
+
+	// An already-expired deadline, which is what the job queue's execution
+	// timeout leaves on the context when an encode runs long.
+	ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
+	defer cancel()
+	require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded, "the test context must be expired, not cancelled")
+
+	require.Error(t, a.Execute(ctx, nil))
+
+	out := logs.String()
+	assert.Contains(t, out, "Audio clip export failed",
+		"a timeout is a real failure and must not be filed as shutdown")
+	assert.NotContains(t, out, "Audio clip export cancelled")
 }
 
 // An ultrasonic capture whose configured container cannot carry the sample rate

--- a/internal/analysis/processor/export_logging_test.go
+++ b/internal/analysis/processor/export_logging_test.go
@@ -275,6 +275,70 @@ func TestResolveExportParams_BatDowngradeLoggedOncePerProcess(t *testing.T) {
 		"a bat install takes this path on every detection; the log must not repeat")
 }
 
+// selectEncoder is the whole routing table, extracted so a failed export can
+// name its encoder. The gated formats are covered from both sides: with the gate
+// off, AAC and Opus must still resolve to FFmpeg, which is what every install
+// that has not opted in does on every clip. Asserting nativeAACSelected directly
+// (as the gate tests do) checks the predicate but not the routing built on it.
+func TestSelectEncoder_RoutingTable(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		aacGate    string
+		opusGate   string
+		format     string
+		rate       int
+		wantEncode string
+	}{
+		{"wav is always native", "", "", ffmpeg.FormatWAV, conf.SampleRate, encoderNativeWAV},
+		{"flac is always native", "", "", ffmpeg.FormatFLAC, conf.SampleRate, encoderNativeFLAC},
+		{"wav ignores the gates", "native", "native", ffmpeg.FormatWAV, conf.SampleRate, encoderNativeWAV},
+		{"flac ignores the gates", "native", "native", ffmpeg.FormatFLAC, conf.SampleRate, encoderNativeFLAC},
+		{"aac without the gate stays on ffmpeg", "", "", ffmpeg.FormatAAC, conf.SampleRate, encoderFFmpeg},
+		{"opus without the gate stays on ffmpeg", "", "", ffmpeg.FormatOpus, conf.SampleRate, encoderFFmpeg},
+		{"aac with the gate goes native", "native", "", ffmpeg.FormatAAC, conf.SampleRate, encoderNativeAAC},
+		{"opus with the gate goes native", "", "native", ffmpeg.FormatOpus, conf.SampleRate, encoderNativeOpus},
+		// Gated on, but the encoder cannot carry the clip's rate: FFmpeg takes it
+		// rather than the export failing outright.
+		{"aac falls back when the rate is unsupported", "native", "", ffmpeg.FormatAAC, 22050, encoderFFmpeg},
+		{"opus falls back when the rate is unsupported", "", "native", ffmpeg.FormatOpus, 22050, encoderFFmpeg},
+		// Neither gate touches the formats FFmpeg owns outright.
+		{"mp3 is always ffmpeg", "native", "native", ffmpeg.FormatMP3, conf.SampleRate, encoderFFmpeg},
+		{"alac is always ffmpeg", "native", "native", ffmpeg.FormatALAC, conf.SampleRate, encoderFFmpeg},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Not parallel: t.Setenv, and the skip warning uses a package-level Once.
+			t.Setenv(conf.EnvNativeAACEncoder, tc.aacGate)
+			t.Setenv(conf.EnvNativeOpusEncoder, tc.opusGate)
+			resetNativeSkipOnce()
+
+			assert.Equal(t, tc.wantEncode, selectEncoder(tc.format, tc.rate))
+		})
+	}
+}
+
+// The bitrate reported alongside the encoder is the effective one, and the
+// lossless formats report none at all rather than a misleading zero.
+func TestLossyBitrateKbps(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, 96, lossyBitrateKbps(ffmpeg.FormatMP3, "96k"))
+	assert.Equal(t, 96, lossyBitrateKbps(ffmpeg.FormatAAC, "96k"))
+	assert.Equal(t, 96, lossyBitrateKbps(ffmpeg.FormatOpus, "96k"))
+
+	assert.Equal(t, 0, lossyBitrateKbps(ffmpeg.FormatWAV, "96k"), "WAV is lossless")
+	assert.Equal(t, 0, lossyBitrateKbps(ffmpeg.FormatFLAC, "96k"), "FLAC is lossless")
+	assert.Equal(t, 0, lossyBitrateKbps(ffmpeg.FormatALAC, "96k"), "ALAC is lossless")
+
+	// A malformed setting parses to 0, which the log then omits rather than
+	// reporting a bitrate the encoder never used.
+	assert.Equal(t, 0, lossyBitrateKbps(ffmpeg.FormatMP3, "not-a-bitrate"))
+
+	// MP3 and Opus are clamped to what the codec accepts, so the logged value
+	// tracks the encode rather than echoing an over-large setting back.
+	assert.Positive(t, lossyBitrateKbps(ffmpeg.FormatMP3, "9999k"))
+	assert.Less(t, lossyBitrateKbps(ffmpeg.FormatMP3, "9999k"), 9999)
+}
+
 func TestClipDurationMs(t *testing.T) {
 	t.Parallel()
 

--- a/internal/analysis/processor/export_normalization_e2e_test.go
+++ b/internal/analysis/processor/export_normalization_e2e_test.go
@@ -78,7 +78,7 @@ func TestEncodeClip_FFmpegPathNormalizesToTarget(t *testing.T) {
 
 	enc, err := a.encodeClip(t.Context(), conf.SampleRate, ffmpeg.FormatMP3, out)
 	require.NoError(t, err)
-	require.Equal(t, encoderFFmpeg, enc, "MP3 has no native encoder; it must go through FFmpeg")
+	require.Equal(t, encoderFFmpeg, enc.Encoder, "MP3 has no native encoder; it must go through FFmpeg")
 
 	got := measureLUFS(t, decodeToPCM16(t, ffmpegBin, out))
 
@@ -110,7 +110,7 @@ func TestEncodeClip_WAVAppliesResolvedGain(t *testing.T) {
 
 	enc, err := a.encodeClip(t.Context(), conf.SampleRate, ffmpeg.FormatWAV, out)
 	require.NoError(t, err)
-	require.Equal(t, encoderNativeWAV, enc)
+	require.Equal(t, encoderNativeWAV, enc.Encoder)
 
 	got := measureLUFS(t, readWAVSamples(t, out))
 	assert.InDelta(t, testTargetLUFS, got, 0.5, "WAV must honour the resolved loudness gain")

--- a/internal/analysis/processor/export_test.go
+++ b/internal/analysis/processor/export_test.go
@@ -23,3 +23,9 @@ func resetNativeSkipOnce() {
 	nativeAACSkipOnce = sync.Once{}
 	nativeOpusSkipOnce = sync.Once{}
 }
+
+// resetBatFormatDowngradeOnce re-arms the ultrasonic WAV-downgrade log guard for
+// the same reason as resetNativeSkipOnce. Test-only.
+func resetBatFormatDowngradeOnce() {
+	batFormatDowngradeOnce = sync.Once{}
+}

--- a/internal/analysis/processor/native_encoder_gate_test.go
+++ b/internal/analysis/processor/native_encoder_gate_test.go
@@ -58,7 +58,7 @@ func TestEncodeClip_GateSelectsNativeAAC(t *testing.T) {
 	out := filepath.Join(t.TempDir(), "clip.m4a")
 	encoder, err := a.encodeClip(t.Context(), conf.SampleRate, ffmpeg.FormatAAC, out)
 	require.NoError(t, err)
-	assert.Equal(t, encoderNativeAAC, encoder, "the clip must record which encoder ran")
+	assert.Equal(t, encoderNativeAAC, encoder.Encoder, "the clip must record which encoder ran")
 
 	assertNonEmptyFileWithMagic(t, out, 4, "ftyp")
 }
@@ -74,7 +74,7 @@ func TestEncodeClip_GateSelectsNativeOpus(t *testing.T) {
 	out := filepath.Join(t.TempDir(), "clip.opus")
 	encoder, err := a.encodeClip(t.Context(), conf.SampleRate, ffmpeg.FormatOpus, out)
 	require.NoError(t, err)
-	assert.Equal(t, encoderNativeOpus, encoder)
+	assert.Equal(t, encoderNativeOpus, encoder.Encoder)
 
 	assertNonEmptyFileWithMagic(t, out, 0, "OggS")
 }
@@ -105,11 +105,11 @@ func TestEncodeClip_GatesDoNotAffectFLACOrWAV(t *testing.T) {
 
 	flacEncoder, err := a.encodeClip(t.Context(), conf.SampleRate, ffmpeg.FormatFLAC, filepath.Join(dir, "clip.flac"))
 	require.NoError(t, err)
-	assert.Equal(t, encoderNativeFLAC, flacEncoder)
+	assert.Equal(t, encoderNativeFLAC, flacEncoder.Encoder)
 
 	wavEncoder, err := a.encodeClip(t.Context(), conf.SampleRate, ffmpeg.FormatWAV, filepath.Join(dir, "clip.wav"))
 	require.NoError(t, err)
-	assert.Equal(t, encoderNativeWAV, wavEncoder)
+	assert.Equal(t, encoderNativeWAV, wavEncoder.Encoder)
 }
 
 // Static Export.Gain must reach the native lossy encoders, not just FLAC.
@@ -189,8 +189,9 @@ func TestEncodeClipFFmpeg_BuildsCompleteExportOptions(t *testing.T) {
 	}
 	a.Settings.Realtime.Audio.FfmpegPath = "/usr/bin/ffmpeg"
 
-	opts, err := a.buildFFmpegExportOptions(t.Context(), conf.SampleRate, ffmpeg.FormatMP3, "/clips/x.mp3")
+	gainDB, err := a.resolveExportGainDB(t.Context(), conf.SampleRate, ffmpeg.FormatMP3)
 	require.NoError(t, err)
+	opts := a.buildFFmpegExportOptions(conf.SampleRate, ffmpeg.FormatMP3, "/clips/x.mp3", gainDB)
 
 	assert.Equal(t, a.pcmData, opts.PCMData)
 	assert.Equal(t, "/clips/x.mp3", opts.OutputPath)
@@ -220,8 +221,9 @@ func TestEncodeClipFFmpeg_StaticGainWithoutNormalization(t *testing.T) {
 	a.Settings.Realtime.Audio.Export.Gain = -2.5
 	a.Settings.Realtime.Audio.FfmpegPath = "/usr/bin/ffmpeg"
 
-	opts, err := a.buildFFmpegExportOptions(t.Context(), conf.SampleRate, ffmpeg.FormatMP3, "/clips/x.mp3")
+	gainDB, err := a.resolveExportGainDB(t.Context(), conf.SampleRate, ffmpeg.FormatMP3)
 	require.NoError(t, err)
+	opts := a.buildFFmpegExportOptions(conf.SampleRate, ffmpeg.FormatMP3, "/clips/x.mp3", gainDB)
 
 	assert.InDelta(t, -2.5, opts.GainDB, 0.001)
 }
@@ -310,7 +312,7 @@ func TestEncodeClip_UltrasonicRatesUnaffectedByLossyGates(t *testing.T) {
 
 				encoder, err := a.encodeClip(t.Context(), rate, tc.format, out)
 				require.NoError(t, err, "%s export must work at %d Hz", tc.format, rate)
-				assert.Equal(t, tc.wantEncoder, encoder, "must stay on the native encoder")
+				assert.Equal(t, tc.wantEncoder, encoder.Encoder, "must stay on the native encoder")
 
 				assert.Equal(t, rate, tc.readRate(t, out),
 					"the written file must record the capture rate, not a clamped one")
@@ -350,7 +352,7 @@ func TestEncodeClip_UltrasonicRatesWithNormalization(t *testing.T) {
 			out := filepath.Join(dir, "clip.flac")
 			encoder, err := a.encodeClip(t.Context(), rate, ffmpeg.FormatFLAC, out)
 			require.NoError(t, err, "normalized FLAC export must work at %d Hz", rate)
-			assert.Equal(t, encoderNativeFLAC, encoder)
+			assert.Equal(t, encoderNativeFLAC, encoder.Encoder)
 			assert.Equal(t, rate, flacSampleRate(t, out))
 
 			// Asserting the planned gain is not enough: a typo passing GainDB 0

--- a/internal/analysis/processor/native_normalization_test.go
+++ b/internal/analysis/processor/native_normalization_test.go
@@ -411,7 +411,7 @@ func TestEncodeClipSelectsNativeNormalization(t *testing.T) {
 	out := filepath.Join(t.TempDir(), "clip.flac")
 	enc, err := a.encodeClip(t.Context(), conf.SampleRate, ffmpeg.FormatFLAC, out)
 	require.NoError(t, err)
-	assert.Equal(t, encoderNativeFLAC, enc, "must select the native FLAC encoder, not FFmpeg")
+	assert.Equal(t, encoderNativeFLAC, enc.Encoder, "must select the native FLAC encoder, not FFmpeg")
 
 	data, err := os.ReadFile(out) //nolint:gosec // test-controlled temp path
 	require.NoError(t, err)
@@ -445,7 +445,7 @@ func TestEncodeClipFLACWithoutNormalization(t *testing.T) {
 	out := filepath.Join(t.TempDir(), "clip.flac")
 	enc, err := a.encodeClip(t.Context(), conf.SampleRate, ffmpeg.FormatFLAC, out)
 	require.NoError(t, err)
-	assert.Equal(t, encoderNativeFLAC, enc, "FLAC must encode natively with no env gate and no FFmpeg")
+	assert.Equal(t, encoderNativeFLAC, enc.Encoder, "FLAC must encode natively with no env gate and no FFmpeg")
 
 	data, err := os.ReadFile(out) //nolint:gosec // test-controlled temp path
 	require.NoError(t, err)
@@ -485,7 +485,7 @@ func TestEncodeClipFLACNormalizationSkipped(t *testing.T) {
 	out := filepath.Join(t.TempDir(), "clip.flac")
 	enc, err := a.encodeClip(t.Context(), conf.SampleRate, ffmpeg.FormatFLAC, out)
 	require.NoError(t, err)
-	assert.Equal(t, encoderNativeFLAC, enc, "out-of-range normalization must still encode natively, never FFmpeg")
+	assert.Equal(t, encoderNativeFLAC, enc.Encoder, "out-of-range normalization must still encode natively, never FFmpeg")
 
 	data, err := os.ReadFile(out) //nolint:gosec // test-controlled temp path
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

The clip export path now has five encoders behind it (native WAV, native go-flac, native go-aac and go-opus where the runtime gate opts the format in, and FFmpeg), but only the success log said which one ran. A failed export logged nothing of its own: the only trace was the job queue's generic "Job failed" line, which carries the action description and the error and names neither the encoder nor the format. An operator who opted a format into its native encoder could not tell from the logs whether go-aac or FFmpeg produced the failure, which is the one question the gated rollout needs answered.

This resolves the encoder as its own step before the encode runs, so both outcomes can name it, and logs a failed export with the encoder, format, sample rate, gain, clip duration, effective bitrate and error. A cancelled context is shutdown rather than a defect, so that case is recorded at Debug. The failure line is WARN rather than ERROR because the job queue logs the same returned error as ERROR once the attempts are exhausted, and raising both would report one root cause as two; on the deferred (Extended Capture) path this line is also the only record of the attempts before the last.

Resolving the encoder up front also lets the loudness gain be resolved once for every format instead of separately inside each of the five branches.

The success line gained the fields the recurring support reports actually need: `gain_db` answers "my clips are too quiet" against the configured normalization, and `duration_ms` next to `file_size_bytes` answers "my clips are cut off", which size alone cannot distinguish from a bad encode. `encode_ms` and, for the lossy formats, the effective (clamped) bitrate come along for the same reason.

Finally, the ultrasonic WAV downgrade now logs. A bat capture whose configured container cannot carry the sample rate is exported as WAV, and that switch was entirely silent, leaving an operator configured for a lossy format with no explanation for the `.wav` files on disk. Its sibling downgrade in `strandedWithoutEncoder` already logged. It fires once per process, since a bat install left on a lossy format takes the path on every detection.

No change to encoder selection, gain values, or the bytes written.

## Test Plan

- [x] `go test -race ./internal/analysis/... ./internal/audiocore/...` green
- [x] `golangci-lint run` clean, including under the CI build tags (`integration,pebble_e2e,noembed,skipfrontend,normcompare`)
- [x] New tests assert encoder attribution on both the native and the FFmpeg failure paths, the WARN level, the omission of the full filesystem path, the Debug-on-cancellation case, and the once-per-process bat downgrade
- [x] `selectEncoder` routing table covered from both sides, including the AAC/Opus-to-FFmpeg default that every install without the gate takes; verified by mutation (routing AAC unconditionally to the native encoder fails the table)
- [x] Coverage of the new functions: 100% on `selectEncoder`, `lossyBitrateKbps`, `clipDurationMs`, `logExportFailure`, `logBatFormatDowngrade`

## Release notes
- audience: internal
- summary: Audio clip export logs now record which encoder produced each clip and why an export failed, for support diagnosis.
- feature: native clip encoders
- breaking: none
- config: none
- schema: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Export support logs now identify the encoder, format, gain, bitrate, clip duration, encoding time, and file size.
  * Export failures provide clearer diagnostics while limiting logged path information.
  * Cancelled exports are distinguished from failed exports.
  * Unsupported BAT format/sample-rate combinations now fall back to WAV with a one-time informational notice.

* **Bug Fixes**
  * Improved encoder selection and bitrate handling across native and FFmpeg exports.
  * Corrected gain and duration reporting for exported clips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->