### PR TITLE
fix(audio): attribute exported clips to their species in the logs

### DIFF
--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -496,7 +496,7 @@ func (a *SaveAudioAction) Execute(ctx context.Context, _ any) error {
 			logger.String("component", "analysis.processor.actions"),
 			logger.String("detection_id", a.CorrelationID),
 			logger.Error(err),
-			logger.String("path", outputPath),
+			logger.String("clip_path", a.relativeClipPath(outputPath)),
 			logger.String("operation", "audio_export_stat"))
 	}
 
@@ -561,7 +561,7 @@ func (a *SaveAudioAction) Execute(ctx context.Context, _ any) error {
 				logger.String("component", "analysis.processor.actions"),
 				logger.String("detection_id", a.CorrelationID),
 				logger.Any("note_id", a.NoteID),
-				logger.String("clip_path", outputPath),
+				logger.String("clip_path", a.relativeClipPath(outputPath)),
 				logger.Error(err),
 				logger.String("operation", "prerender_submit"))
 		}
@@ -571,8 +571,13 @@ func (a *SaveAudioAction) Execute(ctx context.Context, _ any) error {
 }
 
 // relativeClipPath is the clip's name relative to the export directory, which is
-// how the rest of the system identifies a clip: it is the value stored on the
-// detection and the one the media endpoint resolves (/api/v2/media/audio/{name}).
+// how the rest of the system identifies a clip: it is normally the value stored
+// on the detection, and the shape the media endpoint resolves
+// (/api/v2/media/audio/{name}). "Normally" because resolveExportParams can
+// rewrite the extension to .wav; the bat downgrade mirrors that into the stored
+// ClipName, but the stranded-without-encoder fallback does not, so on that path
+// the logged name ends .wav while the database row still names the configured
+// format.
 //
 // The export directory is deliberately stripped. Support logs and uploaded
 // support dumps are read by someone other than the operator, and the absolute
@@ -636,19 +641,20 @@ func clipDurationMs(pcmBytes, sampleRate int) int64 {
 //
 // Every path that CONTEXT cancellation can interrupt reports it in the error, so
 // nothing about a normal shutdown is lost: FFmpeg wraps ctx.Err() at each of its
-// exits, FLAC checks the context per chunk inside its write loop, AAC and Opus
-// check it before the file is created (audiotemp.WriteFile), and
-// resolveExportGainDB joins it onto a measurement that cancellation turned
-// terminal. The stretches that take no context at all (the WAV writer, and the
-// one-shot encode calls inside go-aac/go-opus once audiotemp has let them start)
+// exits, every native encoder checks the context before it writes anything (FLAC
+// additionally re-checks per chunk while applying gain, AAC and Opus via
+// audiotemp.WriteFile), and resolveExportGainDB joins it onto a measurement that
+// cancellation turned terminal. The stretches that take no context at all (the
+// WAV writer, and the one-shot encode calls once audiotemp has let them start)
 // cannot be interrupted by cancellation either, so any error they return is a
 // genuine defect and belongs at WARN.
 //
 // Not covered, deliberately: a signal delivered to the whole process group can
 // kill the FFmpeg child directly, and cmd.Wait() then reports "signal:
 // terminated" while ctx.Err() is still nil. That lands at WARN. It is a narrow
-// native-install case (in Docker, birdnet-go is PID 1 and the signal is not
-// forwarded), and the alternative is the misclassification above.
+// native-install case (the container image runs tini as PID 1 without -g, so it
+// forwards to its direct child rather than the group), and the alternative is
+// the misclassification above.
 //
 // A context that EXPIRED is not shutdown either. The job queue wraps every
 // execution in context.WithTimeout, so an encode slow enough to blow
@@ -663,12 +669,14 @@ func clipDurationMs(pcmBytes, sampleRate int) int64 {
 // Attempts >= MaxAttempts). Raising this line to ERROR too would report one root
 // cause as two, inflating error counts and alerting twice. This line exists to
 // carry the context the queue's generic line cannot, not to raise the alarm.
-// On the deferred path (an Extended Capture tail, the only SaveAudioAction that
-// getJobQueueRetryConfig enables retries for) LogJobRetryScheduled already
-// records every intermediate attempt at WARN with its error, so what this line
-// uniquely preserves for those attempts is the ENCODER context, not the attempt
-// itself. The ordinary eager-read action gets RetryConfig{Enabled: false}, so it
-// has no intermediate attempts and the queue logs it once, permanently failed.
+// Retries exist only on the deferred path (an Extended Capture tail is the only
+// SaveAudioAction getJobQueueRetryConfig enables them for); the ordinary
+// eager-read action gets RetryConfig{Enabled: false}, so the queue logs it once,
+// permanently failed. On the deferred path most intermediate attempts are the
+// action rescheduling itself while it waits for the tail, and those carry
+// errAudioExportDeferred, which LogJobRetryScheduled deliberately drops to Debug.
+// A genuine encode failure there is logged by the queue at WARN, but without the
+// encoder context, which is what this line adds.
 func (a *SaveAudioAction) logExportFailure(enc *clipEncoding, exportFormat string, exportRate int, outputPath string, err error) {
 	// 14 = the 9 unconditional fields below, plus gain_db and encode_ms when the
 	// export got far enough to have them, plus bitrate_kbps on the lossy formats,
@@ -683,8 +691,10 @@ func (a *SaveAudioAction) logExportFailure(enc *clipEncoding, exportFormat strin
 		logger.String("encoder", enc.Encoder),
 		logger.Int("sample_rate", exportRate),
 		logger.Int64("duration_ms", clipDurationMs(len(a.pcmData), exportRate)),
-		// Measurement always ran, so its duration is always meaningful, even when
-		// it is what failed.
+		// Gain resolution is always attempted, so this is reportable even on a
+		// pre-gain failure. It is 0 both when normalization is off (nothing to
+		// measure) and when a measurement was instant; the gain_db field
+		// disambiguates, since it is absent only when resolution did not finish.
 		logger.Int64("measure_ms", enc.MeasureMs),
 	)
 	// Both gated on the same fact: the encoder runs only once the gain resolves,

--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -63,6 +63,19 @@ type clipEncoding struct {
 	Encoder     string  // encoderNativeAAC, encoderFFmpeg, ...
 	GainDB      float64 // loudness gain the encoder applies to the clip
 	BitrateKbps int     // encoded bitrate for the lossy formats; 0 when lossless
+	// GainResolved distinguishes "the gain is 0 dB" from "the export failed
+	// before the gain was known". Without it a failure during gain resolution
+	// logs gain_db=0, which is also the default Export.Gain, so the field reads
+	// as a measurement when it is really an absence.
+	GainResolved bool
+	// MeasureMs and EncodeMs are timed separately because they answer different
+	// questions and have wildly different costs. Resolving the gain with
+	// normalization enabled is a full-clip EBU R128 pass, which on a Pi with a
+	// 20-minute extended capture dominates the export; folding it into a single
+	// encode_ms blames the codec for normalization cost and makes both "exports
+	// are slow" and native-vs-FFmpeg comparisons read wrong.
+	MeasureMs int64 // wall time resolving the loudness gain (0 when normalization is off)
+	EncodeMs  int64 // wall time inside the encoder itself
 }
 
 // Execute logs the note to the log file.
@@ -466,11 +479,9 @@ func (a *SaveAudioAction) Execute(ctx context.Context, _ any) error {
 
 	exportRate, exportFormat, outputPath := a.resolveExportParams(outputPath)
 
-	encodeStart := time.Now()
 	enc, err := a.encodeClip(ctx, exportRate, exportFormat, outputPath)
-	encodeDuration := time.Since(encodeStart)
 	if err != nil {
-		a.logExportFailure(ctx, &enc, exportFormat, exportRate, outputPath, err)
+		a.logExportFailure(&enc, exportFormat, exportRate, outputPath, err)
 		return err
 	}
 
@@ -497,18 +508,28 @@ func (a *SaveAudioAction) Execute(ctx context.Context, _ any) error {
 	// too quiet" (gain_db, against the configured normalization) and "my clips are
 	// truncated" (duration_ms next to file_size_bytes, which on its own cannot
 	// distinguish a short capture from a bad encode).
-	fields := make([]logger.Field, 0, 12)
+	//
+	// The species field is not decoration: GET /api/v2/system/events/detections
+	// attributes recorded clip paths to a species by reading species and clip_path
+	// back off this line (the audio_export_success case in
+	// internal/api/v2/system/events_aggregation.go). It consumes only this line, so
+	// dropping the field empties every ClipPaths the endpoint returns.
+	// 14 = the 12 unconditional fields below, plus bitrate_kbps on the lossy
+	// formats, plus operation.
+	fields := make([]logger.Field, 0, 14)
 	fields = append(fields,
 		logger.String("component", "analysis.processor.actions"),
 		logger.String("detection_id", a.CorrelationID),
-		logger.String("clip_path", filepath.Base(outputPath)),
+		logger.String("species", a.species),
+		logger.String("clip_path", a.relativeClipPath(outputPath)),
 		logger.Int64("file_size_bytes", fileSize),
 		logger.String("format", exportFormat),
 		logger.String("encoder", enc.Encoder),
 		logger.Int("sample_rate", exportRate),
 		logger.Float64("gain_db", enc.GainDB),
 		logger.Int64("duration_ms", clipDurationMs(len(a.pcmData), exportRate)),
-		logger.Int64("encode_ms", encodeDuration.Milliseconds()),
+		logger.Int64("measure_ms", enc.MeasureMs),
+		logger.Int64("encode_ms", enc.EncodeMs),
 	)
 	if enc.BitrateKbps > 0 {
 		fields = append(fields, logger.Int("bitrate_kbps", enc.BitrateKbps))
@@ -549,10 +570,39 @@ func (a *SaveAudioAction) Execute(ctx context.Context, _ any) error {
 	return nil
 }
 
+// relativeClipPath is the clip's name relative to the export directory, which is
+// how the rest of the system identifies a clip: it is the value stored on the
+// detection and the one the media endpoint resolves (/api/v2/media/audio/{name}).
+//
+// The export directory is deliberately stripped. Support logs and uploaded
+// support dumps are read by someone other than the operator, and the absolute
+// path leaks the account name and layout of their machine. The year/month
+// segments leak nothing and are load-bearing: GET /api/v2/system/events/detections
+// reports these values as SpeciesEntry.ClipPaths, and a bare basename cannot be
+// resolved back to a file. Recomputed from outputPath rather than reusing
+// a.ClipName because resolveExportParams may have corrected the extension.
+func (a *SaveAudioAction) relativeClipPath(outputPath string) string {
+	rel, err := filepath.Rel(a.Settings.Realtime.Audio.Export.Path, outputPath)
+	// Rel reports an error only when it cannot express the relationship at all
+	// (one path absolute and the other relative, different Windows volumes). It
+	// happily walks UP with ".." when both are absolute but outputPath sits
+	// outside the export directory, and that result would defeat the whole point
+	// of the function: "../../../etc/passwd" leaks the layout above the export
+	// directory into a support dump and is not a clip name any consumer can
+	// resolve. IsLocal rejects exactly that, plus absolute results and Windows
+	// reserved names. Either way the basename is the safe answer: it still names
+	// the clip and still contains no directory.
+	if err != nil || !filepath.IsLocal(rel) {
+		return filepath.Base(outputPath)
+	}
+	return filepath.ToSlash(rel)
+}
+
 // clipDurationMs is the wall duration of the captured PCM at the export rate.
-// It is logged next to the encoded file size because size alone cannot tell a
-// short capture apart from a truncated encode, and both get reported the same
-// way ("my clips are cut off").
+// On the success line it is logged next to the encoded file size, because size
+// alone cannot tell a short capture apart from a truncated encode and both get
+// reported the same way ("my clips are cut off"). The failure line has no file
+// size to pair it with; there it says how much audio the export was carrying.
 func clipDurationMs(pcmBytes, sampleRate int) int64 {
 	bytesPerFrame := (conf.BitDepth / 8) * conf.NumChannels
 	if sampleRate <= 0 || bytesPerFrame <= 0 {
@@ -564,40 +614,94 @@ func clipDurationMs(pcmBytes, sampleRate int) int64 {
 
 // logExportFailure records a failed clip export against the encoder that failed.
 //
-// Without it the only trace of a failed export is the job queue's generic "Job
-// failed" line, which carries the action description and the error and names
-// neither the encoder nor the format. An operator who opted a format into its
-// native encoder could not tell from the logs whether go-aac or FFmpeg produced
-// the failure, which is exactly what the gated rollout needs to know.
+// Without it the only trace of a failed export is the job queue's own line
+// ("Job failed permanently" once the attempts are exhausted, "Job scheduled for
+// retry after failure" before that), which carries the action description and
+// the error and names neither the encoder nor the format. An operator who opted
+// a format into its native encoder could not tell from the logs whether go-aac
+// or FFmpeg produced the failure, which is exactly what the gated rollout needs
+// to know.
 //
-// A CANCELLED context is shutdown rather than a defect, so it is recorded at
-// Debug: exports in flight when the process stops must not look like errors. A
-// context that EXPIRED is the opposite and stays at WARN. The job queue wraps
-// every execution in context.WithTimeout (handleJob), so the export context
-// always carries a deadline, and an encode slow enough to blow it (a hung
-// FFmpeg, a long extended capture on a Pi) is precisely the failure this line
-// exists to surface. Testing ctx.Err() != nil would bury it at Debug, because
-// Err() reports DeadlineExceeded just as readily as Canceled.
+// A CANCELLED export is shutdown rather than a defect, so it is recorded at
+// Debug: exports in flight when the process stops must not look like errors.
+//
+// The classification reads the ERROR, not the context state at the moment of
+// logging. Asking the context whether it was cancelled answers a different
+// question: it says the process is shutting down, not that shutdown is why this
+// export failed. ENOSPC, corrupt PCM or a missing FFmpeg binary hit while a
+// shutdown happens to be in progress all satisfy a ctx-based test and would be
+// filed at Debug under a message asserting they were cancelled, which on a
+// container that OOM-restarts misattributes every in-flight failure in the
+// restart window.
+//
+// Every path that CONTEXT cancellation can interrupt reports it in the error, so
+// nothing about a normal shutdown is lost: FFmpeg wraps ctx.Err() at each of its
+// exits, FLAC checks the context per chunk inside its write loop, AAC and Opus
+// check it before the file is created (audiotemp.WriteFile), and
+// resolveExportGainDB joins it onto a measurement that cancellation turned
+// terminal. The stretches that take no context at all (the WAV writer, and the
+// one-shot encode calls inside go-aac/go-opus once audiotemp has let them start)
+// cannot be interrupted by cancellation either, so any error they return is a
+// genuine defect and belongs at WARN.
+//
+// Not covered, deliberately: a signal delivered to the whole process group can
+// kill the FFmpeg child directly, and cmd.Wait() then reports "signal:
+// terminated" while ctx.Err() is still nil. That lands at WARN. It is a narrow
+// native-install case (in Docker, birdnet-go is PID 1 and the signal is not
+// forwarded), and the alternative is the misclassification above.
+//
+// A context that EXPIRED is not shutdown either. The job queue wraps every
+// execution in context.WithTimeout, so an encode slow enough to blow
+// it (a hung FFmpeg, a long extended capture on a Pi) is precisely the failure
+// this line exists to surface, and it stays at WARN because DeadlineExceeded is
+// not Canceled. The wrap happens in the queue's executeJobWithTimeout, which
+// gives every execution DefaultJobExecutionTimeout.
 //
 // Everything else is WARN, not ERROR, even though it is a genuine failure. The
 // error is returned unchanged, and the job queue logs that same failure as ERROR
 // once the attempts are exhausted (handleJobFailure only calls LogJobFailed when
 // Attempts >= MaxAttempts). Raising this line to ERROR too would report one root
 // cause as two, inflating error counts and alerting twice. This line exists to
-// carry the context the queue's generic line cannot, not to raise the alarm, and
-// on the deferred path it is the only record of the attempts before the last.
-func (a *SaveAudioAction) logExportFailure(ctx context.Context, enc *clipEncoding, exportFormat string, exportRate int, outputPath string, err error) {
-	fields := make([]logger.Field, 0, 11)
+// carry the context the queue's generic line cannot, not to raise the alarm.
+// On the deferred path (an Extended Capture tail, the only SaveAudioAction that
+// getJobQueueRetryConfig enables retries for) LogJobRetryScheduled already
+// records every intermediate attempt at WARN with its error, so what this line
+// uniquely preserves for those attempts is the ENCODER context, not the attempt
+// itself. The ordinary eager-read action gets RetryConfig{Enabled: false}, so it
+// has no intermediate attempts and the queue logs it once, permanently failed.
+func (a *SaveAudioAction) logExportFailure(enc *clipEncoding, exportFormat string, exportRate int, outputPath string, err error) {
+	// 14 = the 9 unconditional fields below, plus gain_db and encode_ms when the
+	// export got far enough to have them, plus bitrate_kbps on the lossy formats,
+	// plus error and operation.
+	fields := make([]logger.Field, 0, 14)
 	fields = append(fields,
 		logger.String("component", "analysis.processor.actions"),
 		logger.String("detection_id", a.CorrelationID),
-		logger.String("clip_path", filepath.Base(outputPath)),
+		logger.String("species", a.species),
+		logger.String("clip_path", a.relativeClipPath(outputPath)),
 		logger.String("format", exportFormat),
 		logger.String("encoder", enc.Encoder),
 		logger.Int("sample_rate", exportRate),
-		logger.Float64("gain_db", enc.GainDB),
 		logger.Int64("duration_ms", clipDurationMs(len(a.pcmData), exportRate)),
+		// Measurement always ran, so its duration is always meaningful, even when
+		// it is what failed.
+		logger.Int64("measure_ms", enc.MeasureMs),
 	)
+	// Both gated on the same fact: the encoder runs only once the gain resolves,
+	// so on a pre-gain failure neither the gain nor the encode duration exists.
+	// Reporting encode_ms=0 there would read as "the encoder returned instantly"
+	// rather than "the encoder never ran", which is the absence-versus-zero trap
+	// GainResolved was added to close; leaving its sibling in it would be odd.
+	//
+	// How long each phase ran before failing is what separates a hung encoder
+	// that burned the whole job deadline from one that rejected its arguments
+	// instantly. Both were already measured; only the success line consumed them.
+	if enc.GainResolved {
+		fields = append(fields,
+			logger.Float64("gain_db", enc.GainDB),
+			logger.Int64("encode_ms", enc.EncodeMs),
+		)
+	}
 	// A rejected bitrate is one of the ways a lossy encode fails, so report the
 	// value that was going to be used rather than making it a second question.
 	if enc.BitrateKbps > 0 {
@@ -607,7 +711,7 @@ func (a *SaveAudioAction) logExportFailure(ctx context.Context, enc *clipEncodin
 		logger.Error(err),
 		logger.String("operation", "audio_export_failed"))
 
-	if errors.Is(ctx.Err(), context.Canceled) || errors.Is(err, context.Canceled) {
+	if errors.Is(err, context.Canceled) {
 		GetLogger().Debug("Audio clip export cancelled", fields...)
 		return
 	}
@@ -685,13 +789,28 @@ func (a *SaveAudioAction) encodeClip(ctx context.Context, exportRate int, export
 		BitrateKbps: lossyBitrateKbps(exportFormat, a.Settings.Realtime.Audio.Export.Bitrate),
 	}
 
+	measureStart := time.Now()
 	gainDB, err := a.resolveExportGainDB(ctx, exportRate, exportFormat)
+	enc.MeasureMs = time.Since(measureStart).Milliseconds()
 	if err != nil {
 		return enc, err
 	}
 	enc.GainDB = gainDB
+	enc.GainResolved = true
 
-	switch enc.Encoder {
+	encodeStart := time.Now()
+	err = a.runEncoder(ctx, enc.Encoder, exportRate, enc.BitrateKbps, exportFormat, outputPath, gainDB)
+	enc.EncodeMs = time.Since(encodeStart).Milliseconds()
+	return enc, err
+}
+
+// runEncoder writes the clip with the encoder selectEncoder picked, applying the
+// already-resolved loudness gain. It is split out of encodeClip so the encoder's
+// own wall time can be measured without the loudness measurement that precedes
+// it; it deliberately takes no clipEncoding, because it only reads the routing
+// decision and must not be able to alter what the logs report.
+func (a *SaveAudioAction) runEncoder(ctx context.Context, encoder string, exportRate, bitrateKbps int, exportFormat, outputPath string, gainDB float64) error {
+	switch encoder {
 	case encoderNativeWAV:
 		// WAV honours the resolved gain like every other format. It used to be the
 		// one exception, writing captured samples verbatim, which meant an
@@ -706,11 +825,11 @@ func (a *SaveAudioAction) encodeClip(ctx context.Context, exportRate int, export
 			// spectrogram pre-render job that reads it after the export.
 			pcm = pcmgain.Applied(pcm, gainDB)
 		}
-		return enc, convert.SavePCMDataToWAV(outputPath, pcm, exportRate, conf.BitDepth)
+		return convert.SavePCMDataToWAV(outputPath, pcm, exportRate, conf.BitDepth)
 
 	case encoderNativeFLAC:
 		// FLAC always encodes natively via go-flac; FFmpeg is never used for FLAC.
-		return enc, flac.EncodePCM(ctx, &flac.Options{
+		return flac.EncodePCM(ctx, &flac.Options{
 			PCMData:    a.pcmData,
 			OutputPath: outputPath,
 			SampleRate: exportRate,
@@ -720,13 +839,13 @@ func (a *SaveAudioAction) encodeClip(ctx context.Context, exportRate int, export
 		})
 
 	case encoderNativeAAC:
-		return enc, a.encodeClipNativeAAC(ctx, exportRate, enc.BitrateKbps, outputPath, gainDB)
+		return a.encodeClipNativeAAC(ctx, exportRate, bitrateKbps, outputPath, gainDB)
 
 	case encoderNativeOpus:
-		return enc, a.encodeClipNativeOpus(ctx, exportRate, enc.BitrateKbps, outputPath, gainDB)
+		return a.encodeClipNativeOpus(ctx, exportRate, bitrateKbps, outputPath, gainDB)
 
 	default:
-		return enc, a.encodeClipFFmpeg(ctx, exportRate, exportFormat, outputPath, gainDB)
+		return a.encodeClipFFmpeg(ctx, exportRate, exportFormat, outputPath, gainDB)
 	}
 }
 
@@ -805,7 +924,7 @@ func nativeAACSelected(exportRate int) bool {
 		return false
 	}
 	if err := aac.Supports(exportRate, conf.BitDepth, conf.NumChannels); err != nil {
-		logNativeEncoderSkipped(&nativeAACSkipOnce, ffmpeg.FormatAAC, err)
+		logNativeEncoderSkipped(ffmpeg.FormatAAC, exportRate, err)
 		return false
 	}
 	return true
@@ -817,24 +936,60 @@ func nativeOpusSelected(exportRate int) bool {
 		return false
 	}
 	if err := opus.Supports(exportRate, conf.BitDepth, conf.NumChannels); err != nil {
-		logNativeEncoderSkipped(&nativeOpusSkipOnce, ffmpeg.FormatOpus, err)
+		logNativeEncoderSkipped(ffmpeg.FormatOpus, exportRate, err)
 		return false
 	}
 	return true
 }
 
-// Guards for the native-encoder fallback warning. Whether a clip shape is
-// supported cannot change without a restart (the bit depth and channel count are
-// build constants and the source rate is fixed per source), so an operator who
-// opted into a format their capture rate cannot use would otherwise get an
-// identical WARN on every single detection, forever. Log it once per format and
-// let the per-clip encoder field carry the ongoing signal.
+// onceByKey emits a message at most once per distinct condition, where the
+// condition is described by a key rather than by "the first time we got here".
+//
+// A bare sync.Once is the wrong instrument for these logs. Each guards a
+// decision made from a format and a sample rate, and neither is fixed for the
+// process: Export.Type is hot-reloadable (settings changed in the UI take effect
+// without a restart), and the capture rate is per-source, so a multi-source
+// install runs several at once. A sync.Once lets whichever condition happens to
+// fire first silence every later, different one, leaving the operator with an
+// explanation that names a format they have since changed away from, or a rate
+// belonging to another source.
+//
+// The key space is the product of a handful of formats and the configured source
+// rates, so it is small and bounded by the configuration rather than by traffic;
+// no eviction is needed.
+type onceByKey struct {
+	seen sync.Map // string key -> struct{}
+}
+
+// do runs emit unless this key has already been emitted.
+//
+// This is NOT sync.Once semantics and must not be reused as a lazy-init guard:
+// the key is marked before emit runs, so a concurrent second caller returns
+// immediately rather than blocking until the first has finished. That is what a
+// log-flood guard wants (no caller depends on the line having been written yet)
+// and exactly what an initializer does not.
+func (o *onceByKey) do(key string, emit func()) {
+	if _, loaded := o.seen.LoadOrStore(key, struct{}{}); !loaded {
+		emit()
+	}
+}
+
+// formatRateKey identifies a downgrade or fallback decision by the two inputs
+// that vary at runtime, so each distinct combination explains itself exactly
+// once instead of the first one silencing the rest.
+func formatRateKey(format string, rate int) string {
+	return format + "@" + strconv.Itoa(rate)
+}
+
+// Guards for the export-format warnings. Each fires on every single detection of
+// an affected install, so without a guard they are a permanent log flood; the
+// per-clip encoder and format fields carry the ongoing signal instead.
 //
 //nolint:gochecknoglobals // process-lifetime log-flood guards, matching mqttNotReadyWarnOnce
 var (
-	nativeAACSkipOnce      sync.Once
-	nativeOpusSkipOnce     sync.Once
-	batFormatDowngradeOnce sync.Once
+	nativeEncoderSkipLogged  onceByKey
+	batFormatDowngradeLogged onceByKey
+	strandedFormatLogged     onceByKey
 )
 
 // logBatFormatDowngrade explains why an install configured for a lossy format is
@@ -843,12 +998,16 @@ var (
 // in strandedWithoutEncoder already logged its reason; this one did not, leaving
 // the operator with no explanation for a format they did not choose.
 //
-// Logged once per process for the same reason as the native-encoder skip
-// warning: a bat install left on a lossy export format takes this path on every
-// single detection, and the explanation only needs stating once.
+// Logged at WARN, matching the sibling downgrade in resolveExportParams: both
+// mean "you are not getting the export format you configured", which is a
+// configuration mismatch the operator should act on rather than a note.
+//
+// Guarded per (format, rate) rather than once per process: a bat install left on
+// a lossy export format takes this path on every single detection, but the two
+// inputs still vary, by hot-reloaded Export.Type and by capture source.
 func logBatFormatDowngrade(requestedFormat string, rate int) {
-	batFormatDowngradeOnce.Do(func() {
-		GetLogger().Info("Ultrasonic clip format downgraded to WAV; the configured format cannot carry this sample rate",
+	batFormatDowngradeLogged.do(formatRateKey(requestedFormat, rate), func() {
+		GetLogger().Warn("Ultrasonic clip format downgraded to WAV; the configured format cannot carry this sample rate",
 			logger.String("component", "analysis.processor.actions"),
 			logger.String("requested_format", requestedFormat),
 			logger.Int("sample_rate", rate),
@@ -856,16 +1015,53 @@ func logBatFormatDowngrade(requestedFormat string, rate int) {
 	})
 }
 
-// logNativeEncoderSkipped records, once per format, that an opted-in native
-// encoder could not carry this clip, so an operator who set the env flag and
-// sees FFmpeg in the encoder field has a reason rather than a mystery. The
-// reason comes from the encoder's own Supports error, so the log names the
-// offending value instead of dumping all three.
-func logNativeEncoderSkipped(once *sync.Once, format string, reason error) {
-	once.Do(func() {
+// logStrandedFormatFallback explains why an install with no FFmpeg is producing
+// .wav files: the operator opted a lossy format into its native encoder, which
+// kept config validation from downgrading the format, and the native encoder
+// then turned out not to accept this clip's shape.
+//
+// Same level and same guard as logBatFormatDowngrade, because it means the same
+// thing to the operator: you are not getting the format you configured. It used
+// to be the sibling's opposite on both counts, warning on every single clip
+// forever where the bat downgrade logged once.
+//
+// No detection_id, matching the sibling. Once the line is guarded the id names
+// whichever clip happened to arrive first, which can be hours stale by the time
+// anyone reads it, and correlating by it finds a single line. The condition is a
+// property of the configuration, not of a clip.
+//
+// The key covers the format and the rate, not FfmpegPath, which is also part of
+// the condition and is hot-reloadable too. An operator who sets a path and later
+// clears it again will not be warned a second time for a combination already
+// reported. That is the intended trade: the message is about a configuration
+// that was already explained once, and keying on it would re-flood on every
+// path edit.
+func logStrandedFormatFallback(requestedFormat string, rate int) {
+	strandedFormatLogged.do(formatRateKey(requestedFormat, rate), func() {
+		GetLogger().Warn("No encoder can carry this clip; exporting as WAV",
+			logger.String("component", "analysis.processor.actions"),
+			logger.String("requested_format", requestedFormat),
+			logger.Int("sample_rate", rate),
+			logger.String("operation", "audio_export_no_encoder_fallback"))
+	})
+}
+
+// logNativeEncoderSkipped records that an opted-in native encoder could not
+// carry this clip, so an operator who set the env flag and sees FFmpeg in the
+// encoder field has a reason rather than a mystery. The reason comes from the
+// encoder's own Supports error, so the log names the offending value instead of
+// dumping all three.
+//
+// Guarded per (format, rate): the rate is what the encoder usually rejects, and
+// it varies per capture source, so a once-per-format guard would report only
+// whichever source happened to export first. One guard covers both formats,
+// because the format is part of the key.
+func logNativeEncoderSkipped(format string, rate int, reason error) {
+	nativeEncoderSkipLogged.do(formatRateKey(format, rate), func() {
 		GetLogger().Warn("Native encoder requested but the clip format is unsupported; using FFmpeg for this format",
 			logger.String("component", "analysis.processor.actions"),
 			logger.String("format", format),
+			logger.Int("sample_rate", rate),
 			logger.String("reason", reason.Error()),
 			logger.String("operation", "audio_export_native_unsupported"))
 	})
@@ -910,7 +1106,16 @@ func (a *SaveAudioAction) resolveExportGainDB(ctx context.Context, exportRate in
 			return gainDB, nil
 		case ctx.Err() != nil:
 			// The caller is going away; do not paper over that with a fallback.
-			return 0, err
+			//
+			// Joining the context error in is not the ctx-based misclassification
+			// logExportFailure warns about, it is the opposite: on THIS branch the
+			// measurement error alone is not fatal, because the code below would
+			// have degraded to the static gain and finished the export. The clip
+			// fails only because the context is done, so cancellation genuinely is
+			// the cause and the joined error says so. audionorm's own error need
+			// not wrap ctx.Err(), so without the join a normal shutdown here would
+			// be reported as a WARN failure.
+			return 0, errors.Join(err, ctx.Err())
 		}
 		// The clip could not be measured (audionorm rejects the dimensions, e.g. a
 		// source reporting a sample rate below the K-weighting minimum). Losing
@@ -1141,12 +1346,7 @@ func (a *SaveAudioAction) resolveExportParams(outputPath string) (rate int, form
 	}
 
 	if a.strandedWithoutEncoder(rate, format) {
-		GetLogger().Warn("No encoder can carry this clip; exporting as WAV",
-			logger.String("component", "analysis.processor.actions"),
-			logger.String("detection_id", a.CorrelationID),
-			logger.String("requested_format", format),
-			logger.Int("sample_rate", rate),
-			logger.String("operation", "audio_export_no_encoder_fallback"))
+		logStrandedFormatFallback(format, rate)
 		format = ffmpeg.FormatWAV
 		path = replaceExtension(path, ".wav")
 	}

--- a/internal/analysis/processor/actions_types.go
+++ b/internal/analysis/processor/actions_types.go
@@ -108,12 +108,14 @@ type SaveAudioAction struct {
 	readyAt          time.Time
 	sourceSampleRate int    // Actual source capture rate for correct export headers
 	modelName        string // Detection model name (e.g. "BattyBirdNET") for export strategy
-	// species is the detection's common name, carried solely so the
-	// audio_export_success log line can name it. GET /api/v2/system/events/detections
-	// attributes recorded clip paths to a species by reading that field back out of
-	// the log (see the audio_export_success case in
-	// internal/api/v2/system/events_aggregation.go); without it every bucket the
-	// endpoint returns has an empty ClipPaths.
+	// species is the detection's common name, LOWERCASED to match the casing the
+	// sibling detection operations log, carried so the export log lines can name
+	// it. GET /api/v2/system/events/detections attributes recorded clip paths to a
+	// species by reading this field back out of the audio_export_success line (see
+	// that case in internal/api/v2/system/events_aggregation.go), keyed by an
+	// exact string match. Without it every bucket the endpoint returns has an
+	// empty ClipPaths; with the wrong casing the paths land on a phantom
+	// zero-count species row instead of the counted one.
 	species       string
 	NoteID        uint              // Note ID for correlation logging with pre-renderer
 	PreRenderer   PreRendererSubmit // Injected from processor

--- a/internal/analysis/processor/actions_types.go
+++ b/internal/analysis/processor/actions_types.go
@@ -106,14 +106,21 @@ type SaveAudioAction struct {
 	beginTime        time.Time
 	duration         int
 	readyAt          time.Time
-	sourceSampleRate int               // Actual source capture rate for correct export headers
-	modelName        string            // Detection model name (e.g. "BattyBirdNET") for export strategy
-	NoteID           uint              // Note ID for correlation logging with pre-renderer
-	PreRenderer      PreRendererSubmit // Injected from processor
-	DetectionCtx     *DetectionContext // Shared context to signal ClipSaved to late consumers
-	EventTracker     *EventTracker
-	Description      string
-	CorrelationID    string // Detection correlation ID for log tracking
+	sourceSampleRate int    // Actual source capture rate for correct export headers
+	modelName        string // Detection model name (e.g. "BattyBirdNET") for export strategy
+	// species is the detection's common name, carried solely so the
+	// audio_export_success log line can name it. GET /api/v2/system/events/detections
+	// attributes recorded clip paths to a species by reading that field back out of
+	// the log (see the audio_export_success case in
+	// internal/api/v2/system/events_aggregation.go); without it every bucket the
+	// endpoint returns has an empty ClipPaths.
+	species       string
+	NoteID        uint              // Note ID for correlation logging with pre-renderer
+	PreRenderer   PreRendererSubmit // Injected from processor
+	DetectionCtx  *DetectionContext // Shared context to signal ClipSaved to late consumers
+	EventTracker  *EventTracker
+	Description   string
+	CorrelationID string // Detection correlation ID for log tracking
 }
 
 // PreRenderJob represents a spectrogram pre-rendering task.

--- a/internal/analysis/processor/export_logging_test.go
+++ b/internal/analysis/processor/export_logging_test.go
@@ -158,6 +158,26 @@ func TestExecute_SuccessLogNamesSpeciesForClipPathAggregation(t *testing.T) {
 	assert.Contains(t, line, "clip_path=clip.flac")
 }
 
+// The wiring test for the relative clip path. Every other Execute-level test
+// uses a bare-basename ClipName, so for them Rel and Base return the same string
+// and the assertions pass either way. Production ClipName is
+// filepath.Join(year, month, filename), so only a nested name distinguishes the
+// two, and only this test would fail if the field regressed to a basename and
+// left SpeciesEntry.ClipPaths unresolvable.
+func TestExecute_SuccessLogClipPathKeepsDateSegments(t *testing.T) {
+	logs := captureExportLogs(t)
+	dir := t.TempDir()
+	a := newExportLogAction(t, dir, "2026/07/wren.flac", ffmpeg.FormatFLAC)
+
+	require.NoError(t, a.Execute(t.Context(), nil))
+
+	line := logLineContaining(t, logs.String(), "operation=audio_export_success")
+	assert.Contains(t, line, "clip_path=2026/07/wren.flac",
+		"the date segments are what let a consumer resolve the clip back to a file")
+	assert.NotContains(t, line, dir,
+		"the export directory must never reach a support log")
+}
+
 // The half of the species contract the log assertion above cannot reach:
 // buildSaveAudioAction must actually POPULATE the field, on every branch, in the
 // casing the aggregator keys on.
@@ -194,8 +214,9 @@ func TestBuildSaveAudioAction_PopulatesLowercasedSpeciesOnEveryBranch(t *testing
 	}
 
 	tests := []struct {
-		name  string
-		build func(t *testing.T) (*Processor, *Detections)
+		name      string
+		build     func(t *testing.T) (*Processor, *Detections)
+		wantEager bool
 	}{
 		{
 			// Extended Capture: the tail is still being written, so the action
@@ -228,22 +249,39 @@ func TestBuildSaveAudioAction_PopulatesLowercasedSpeciesOnEveryBranch(t *testing
 			},
 		},
 		{
-			// The ordinary path: PCM is read eagerly at build time.
+			// The ordinary path, and the one most exports take: PCM is read
+			// eagerly at build time.
+			//
+			// Reaching it needs the requested window to be entirely in the PAST
+			// (otherwise buildSaveAudioAction defers) while still being readable
+			// from the ring. A freshly written buffer cannot satisfy both: its
+			// startTime is the moment of the first Write, so any window inside it
+			// ends in the future. Overfilling the ring forces a wrap, and on wrap
+			// the buffer re-anchors startTime to now-bufferDuration
+			// (buffer/capture.go), which puts the whole readable window behind the
+			// clock.
 			name: "eager read",
 			build: func(t *testing.T) (*Processor, *Detections) {
 				t.Helper()
+				const bufferSeconds = 3
 				mgr := audioBuffer.NewManager(GetLogger())
-				require.NoError(t, mgr.AllocateCapture(sourceID, 10, conf.SampleRate, conf.BitDepth/8))
+				require.NoError(t, mgr.AllocateCapture(sourceID, bufferSeconds, conf.SampleRate, conf.BitDepth/8))
 				cb, err := mgr.CaptureBuffer(sourceID)
 				require.NoError(t, err)
-				require.NoError(t, cb.Write(make([]byte, 3*conf.SampleRate*(conf.BitDepth/8))))
+				// Twice the ring, so it wraps and re-anchors startTime.
+				require.NoError(t, cb.Write(make([]byte, 2*bufferSeconds*conf.SampleRate*(conf.BitDepth/8))))
 				start := cb.StartTime()
+				require.False(t, start.Add(2*time.Second).After(time.Now()),
+					"the requested window must be in the past or this row silently retests the deferred branch")
 				return &Processor{
 						Settings:  buildSpeciesTestSettings(t),
 						BufferMgr: mgr,
 					},
 					newDetection(start, start.Add(2*time.Second))
 			},
+			// Distinguishes this branch from the other two: only the eager path
+			// pre-reads PCM and leaves bufferMgr unset.
+			wantEager: true,
 		},
 	}
 
@@ -254,6 +292,15 @@ func TestBuildSaveAudioAction_PopulatesLowercasedSpeciesOnEveryBranch(t *testing
 			action := p.buildSaveAudioAction(det, &DetectionContext{})
 
 			require.NotNil(t, action)
+			// Pin WHICH branch ran. Without this the eager row silently fell back
+			// to the deferred branch and the eager return site, the one most
+			// production exports take, was never executed at all.
+			if tt.wantEager {
+				require.NotEmpty(t, action.pcmData, "the eager branch pre-reads the PCM")
+				require.Nil(t, action.bufferMgr, "the eager branch does not defer")
+			} else {
+				require.Empty(t, action.pcmData, "only the eager branch pre-reads the PCM")
+			}
 			assert.Equal(t, wantSpecies, action.species,
 				"every construction branch must carry the species, lowercased to match approve_detection")
 		})
@@ -620,9 +667,10 @@ func TestResolveExportParams_BatDowngradeIsLogged(t *testing.T) {
 	assert.Contains(t, logs.String(), "requested_format="+ffmpeg.FormatMP3)
 }
 
-// The downgrade fires on every single detection of a bat install, so it is
-// logged once per process rather than once per clip.
-func TestResolveExportParams_BatDowngradeLoggedOncePerProcess(t *testing.T) {
+// The downgrade fires on every single detection of a bat install, so repeating
+// the SAME condition must not repeat the log. (The companion test below covers
+// the other half: a DIFFERENT condition still gets its own line.)
+func TestResolveExportParams_BatDowngradeLoggedOncePerCondition(t *testing.T) {
 	resetBatFormatDowngradeOnce()
 	logs := captureExportLogs(t)
 	a := newExportLogAction(t, t.TempDir(), "clip.mp3", ffmpeg.FormatMP3)
@@ -728,9 +776,10 @@ func TestResolveExportParams_StrandedFallbackLogsEachDistinctCondition(t *testin
 	assert.Equal(t, 2, strings.Count(out, "audio_export_no_encoder_fallback"),
 		"each distinct format/rate combination must explain itself exactly once")
 	// The two native-encoder skip warnings share one guard now that the format is
-	// part of the key; both formats must still get their own line.
-	assert.Contains(t, out, "format="+ffmpeg.FormatOpus)
-	assert.Contains(t, out, "format="+ffmpeg.FormatAAC)
+	// part of the key; both formats must still get their own line. Asserted by
+	// counting the operation, not by Contains("format=aac"), which is also a
+	// substring of the stranded line's own requested_format=aac and would pass
+	// even if these warnings were never emitted.
 	assert.Equal(t, 2, strings.Count(out, "audio_export_native_unsupported"),
 		"one shared guard must not let the first format silence the second")
 }

--- a/internal/analysis/processor/export_logging_test.go
+++ b/internal/analysis/processor/export_logging_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -13,10 +14,30 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	audioBuffer "github.com/tphakala/birdnet-go/internal/audiocore/buffer"
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/conf/conftest"
+	"github.com/tphakala/birdnet-go/internal/detection"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
+
+// logLineContaining returns the single captured log line carrying marker, so an
+// assertion about a line's level or fields cannot be satisfied by a DIFFERENT
+// line that happens to share the buffer. The export path emits several lines per
+// clip, so a buffer-wide Contains is a much weaker claim than it appears.
+func logLineContaining(t *testing.T, logs, marker string) string {
+	t.Helper()
+	var found string
+	for line := range strings.SplitSeq(logs, "\n") {
+		if strings.Contains(line, marker) {
+			require.Empty(t, found, "marker %q matched more than one line", marker)
+			found = line
+		}
+	}
+	require.NotEmpty(t, found, "no log line contains %q; captured:\n%s", marker, logs)
+	return found
+}
 
 // A bat model at an ultrasonic capture rate: the combination needsBatFormatFallback
 // downgrades to WAV, because no lossy container carries 256 kHz.
@@ -44,7 +65,7 @@ func captureExportLogs(t *testing.T) *bytes.Buffer {
 		capture,
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = cl.Close() })
+	t.Cleanup(func() { assert.NoError(t, cl.Close()) })
 
 	prev := logger.Global()
 	logger.SetGlobal(cl)
@@ -107,6 +128,147 @@ func TestExecute_SuccessLogNamesNativeEncoder(t *testing.T) {
 	assert.Contains(t, out, "operation=audio_export_success")
 }
 
+// The success line is a data source, not just a support artefact:
+// GET /api/v2/system/events/detections builds SpeciesEntry.ClipPaths by reading
+// species and clip_path back off it (the audio_export_success case in
+// internal/api/v2/system/events_aggregation.go). The species field went missing
+// for the entire life of that endpoint, so every bucket it returned had an empty
+// ClipPaths.
+//
+// The consumer-side test could not catch it: its fixture builds entries by hand
+// and sets species on every one, so it only ever exercised input the production
+// logger could not emit. This assertion is deliberately on the PRODUCER, against
+// the field set really written to the log.
+func TestExecute_SuccessLogNamesSpeciesForClipPathAggregation(t *testing.T) {
+	logs := captureExportLogs(t)
+	dir := t.TempDir()
+	a := newExportLogAction(t, dir, "clip.flac", ffmpeg.FormatFLAC)
+	// Lowercase, matching what buildSaveAudioAction stores and what the sibling
+	// detection operations log; see the casing rationale on
+	// TestBuildSaveAudioAction_PopulatesLowercasedSpeciesOnEveryBranch.
+	a.species = "eurasian wren"
+
+	require.NoError(t, a.Execute(t.Context(), nil))
+
+	line := logLineContaining(t, logs.String(), "operation=audio_export_success")
+	// Both halves of the pair the aggregator requires, on the SAME line; it drops
+	// the entry unless species AND clip_path are non-empty.
+	assert.Contains(t, line, `species="eurasian wren"`,
+		"without species the events endpoint cannot attribute the clip to a bird")
+	assert.Contains(t, line, "clip_path=clip.flac")
+}
+
+// The half of the species contract the log assertion above cannot reach:
+// buildSaveAudioAction must actually POPULATE the field, on every branch, in the
+// casing the aggregator keys on.
+//
+// This test exists because the original defect was a missing ASSIGNMENT, not a
+// missing log field. A test that sets a.species by hand and then checks the
+// logger emits it stays green with all three assignments deleted, which is the
+// same fabricated-fixture trap that let the bug through on the consumer side.
+//
+// The casing is load-bearing, not cosmetic. getOrCreateSpecies
+// (internal/api/v2/system/events_aggregation.go) keys species with an exact map
+// lookup, and the three sibling operations that create those entries
+// (approve_detection, discard_detection, flush_detection) all log
+// strings.ToLower(CommonName) via processor.go's speciesName. Emitting the
+// original case here would file the clip paths under a second, phantom species
+// row with zero counts, leaving the real row's ClipPaths empty: the exact defect
+// this work set out to fix, one layer down.
+func TestBuildSaveAudioAction_PopulatesLowercasedSpeciesOnEveryBranch(t *testing.T) {
+	const commonName = "Eurasian Wren"
+	const wantSpecies = "eurasian wren"
+	const sourceID = "test-source"
+
+	newDetection := func(begin, end time.Time) *Detections {
+		return &Detections{
+			CorrelationID: "build-species-test",
+			Result: detection.Result{
+				Species:     detection.Species{CommonName: commonName},
+				ClipName:    "2026/07/clip.wav",
+				BeginTime:   begin,
+				EndTime:     end,
+				AudioSource: detection.AudioSource{ID: sourceID, SampleRate: conf.SampleRate},
+			},
+		}
+	}
+
+	tests := []struct {
+		name  string
+		build func(t *testing.T) (*Processor, *Detections)
+	}{
+		{
+			// Extended Capture: the tail is still being written, so the action
+			// carries buffer coordinates and reads later.
+			name: "deferred read",
+			build: func(t *testing.T) (*Processor, *Detections) {
+				t.Helper()
+				mgr := audioBuffer.NewManager(GetLogger())
+				require.NoError(t, mgr.AllocateCapture(sourceID, 10, conf.SampleRate, conf.BitDepth/8))
+				now := time.Now()
+				return &Processor{
+						Settings:  buildSpeciesTestSettings(t),
+						BufferMgr: mgr,
+					},
+					newDetection(now, now.Add(30*time.Second))
+			},
+		},
+		{
+			// The capture buffer cannot be read, so the action is built as a
+			// no-op. It still reaches the export logger via Execute.
+			name: "capture read error",
+			build: func(t *testing.T) (*Processor, *Detections) {
+				t.Helper()
+				now := time.Now()
+				return &Processor{
+						Settings:  buildSpeciesTestSettings(t),
+						BufferMgr: audioBuffer.NewManager(GetLogger()), // no buffer allocated
+					},
+					newDetection(now.Add(-10*time.Second), now.Add(-8*time.Second))
+			},
+		},
+		{
+			// The ordinary path: PCM is read eagerly at build time.
+			name: "eager read",
+			build: func(t *testing.T) (*Processor, *Detections) {
+				t.Helper()
+				mgr := audioBuffer.NewManager(GetLogger())
+				require.NoError(t, mgr.AllocateCapture(sourceID, 10, conf.SampleRate, conf.BitDepth/8))
+				cb, err := mgr.CaptureBuffer(sourceID)
+				require.NoError(t, err)
+				require.NoError(t, cb.Write(make([]byte, 3*conf.SampleRate*(conf.BitDepth/8))))
+				start := cb.StartTime()
+				return &Processor{
+						Settings:  buildSpeciesTestSettings(t),
+						BufferMgr: mgr,
+					},
+					newDetection(start, start.Add(2*time.Second))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, det := tt.build(t)
+
+			action := p.buildSaveAudioAction(det, &DetectionContext{})
+
+			require.NotNil(t, action)
+			assert.Equal(t, wantSpecies, action.species,
+				"every construction branch must carry the species, lowercased to match approve_detection")
+		})
+	}
+}
+
+// buildSpeciesTestSettings is the minimal settings object buildSaveAudioAction
+// needs: an enabled export with a real directory.
+func buildSpeciesTestSettings(t *testing.T) *conf.Settings {
+	t.Helper()
+	return conftest.NewTestSettings().
+		WithAudioExport(t.TempDir(), "wav", "192k").
+		Build()
+}
+
 // The troubleshooting fields alongside the encoder: the applied loudness gain
 // ("my clips are too quiet") and the clip duration next to the file size ("my
 // clips are cut off"). Both used to be reachable only at Debug, or not at all.
@@ -119,16 +281,30 @@ func TestExecute_SuccessLogCarriesGainAndDuration(t *testing.T) {
 
 	out := logs.String()
 	assert.Contains(t, out, "gain_db=-2.5", "the resolved gain must be visible per clip")
-	assert.Contains(t, out, "duration_ms=", "clip duration must accompany the file size")
-	assert.Contains(t, out, "encode_ms=")
+	// By value, not key-only: the fixture is exactly one second of PCM at
+	// conf.SampleRate, so a rewiring that dropped the real duration (and logged
+	// a zero, or the PCM length at the wrong rate) would otherwise pass.
+	assert.Contains(t, out, "duration_ms=1000", "clip duration must accompany the file size")
 	assert.Contains(t, out, "file_size_bytes=")
+	// Encoding and loudness measurement are reported separately: with
+	// normalization on, measurement is a full-clip EBU R128 pass that can dwarf
+	// the encode, and one combined figure blames the codec for it.
+	//
+	// measure_ms is pinned BY VALUE. This fixture leaves normalization off, so
+	// resolving the gain is a struct read and must cost 0 ms. Asserting only that
+	// the key exists would still pass if both fields were fed by one timer, which
+	// is the exact regression the split exists to prevent.
+	assert.Contains(t, out, "measure_ms=0",
+		"with normalization off there is nothing to measure; a non-zero value means the encode was folded in")
+	assert.Contains(t, out, "encode_ms=")
 	// WAV is lossless, so there is no bitrate to report and the field is omitted
 	// rather than logged as a misleading zero.
 	assert.NotContains(t, out, "bitrate_kbps=")
 }
 
-// A lossy format reports the bitrate the encoder actually used, which is the
-// clamped effective value rather than the raw setting.
+// A lossy format reports the bitrate the encode used. 96k is within every
+// codec's range, so this covers the ordinary case only; the clamping the field
+// also has to survive is the test below.
 func TestExecute_SuccessLogCarriesBitrateForLossyFormats(t *testing.T) {
 	t.Setenv(conf.EnvNativeAACEncoder, "native")
 	resetNativeSkipOnce()
@@ -143,8 +319,30 @@ func TestExecute_SuccessLogCarriesBitrateForLossyFormats(t *testing.T) {
 	assert.Contains(t, out, "bitrate_kbps=96")
 }
 
+// The logged bitrate is the EFFECTIVE one, not the configured one: it exists to
+// explain the size of the file on disk, so a setting the codec refused would be
+// actively misleading. Opus caps at 256 kbps, so a 320k configuration is the
+// case that tells the two apart.
+func TestExecute_SuccessLogCarriesClampedBitrate(t *testing.T) {
+	t.Setenv(conf.EnvNativeOpusEncoder, "native")
+	resetNativeSkipOnce()
+	logs := captureExportLogs(t)
+	dir := t.TempDir()
+	a := newExportLogAction(t, dir, "clip.opus", ffmpeg.FormatOpus)
+	a.Settings.Realtime.Audio.Export.Bitrate = "320k"
+
+	require.NoError(t, a.Execute(t.Context(), nil))
+
+	out := logs.String()
+	assert.Contains(t, out, "encoder="+encoderNativeOpus)
+	assert.Contains(t, out, "bitrate_kbps=256",
+		"the clamped bitrate explains the file on disk; the configured 320k does not")
+	assert.NotContains(t, out, "bitrate_kbps=320")
+}
+
 // The gap this change closes: a failed export used to leave nothing but the job
-// queue's generic "Job failed" line, which names neither the encoder nor the
+// queue's own line ("Job failed permanently", or "Job scheduled for retry after
+// failure" on the attempts before it), which names neither the encoder nor the
 // format. An operator who opted AAC into the native encoder could not tell
 // whether go-aac or FFmpeg produced the failure.
 func TestExecute_FailureLogNamesNativeEncoder(t *testing.T) {
@@ -207,6 +405,112 @@ func TestExecute_FailureLogNamesFFmpeg(t *testing.T) {
 	assert.Contains(t, out, "format="+ffmpeg.FormatMP3)
 }
 
+// encodeClip documents that it populates clipEncoding "as far as the export
+// got", and the pre-gain failure is the branch where that matters: the encoder
+// is known but the gain is not. gain_db used to be emitted unconditionally, so
+// this case logged gain_db=0, which is also the default Export.Gain and reads as
+// a measured value rather than an absence.
+//
+// Reaching it needs normalization on (so gain resolution does real work) and a
+// context already cancelled (so planNativeNormalizationGain refuses before
+// measuring), which is the shape a shutdown mid-measurement produces.
+func TestExecute_FailureBeforeGainResolutionOmitsGain(t *testing.T) {
+	logs := captureExportLogs(t)
+	dir := t.TempDir()
+	a := newExportLogAction(t, dir, "clip.flac", ffmpeg.FormatFLAC)
+	a.Settings.Realtime.Audio.Export.Normalization = conf.NormalizationSettings{
+		Enabled:    true,
+		TargetLUFS: -23,
+		TruePeak:   -2,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	require.Error(t, a.Execute(ctx, nil))
+
+	// Scoped to the failure line: planNativeNormalizationGain legitimately logs
+	// its own gain_db on a Debug line, so a buffer-wide NotContains would break
+	// for the wrong reason the moment the failure point moved past measurement.
+	line := logLineContaining(t, logs.String(), "operation=audio_export_failed")
+	assert.Contains(t, line, "encoder="+encoderNativeFLAC,
+		"the encoder is known before the gain is, so it must still be reported")
+	assert.NotContains(t, line, "gain_db=",
+		"an export that failed before resolving the gain has none to report")
+	assert.NotContains(t, line, "encode_ms=",
+		"the encoder never ran, so encode_ms=0 would read as an instant rejection")
+	assert.Contains(t, line, "measure_ms=",
+		"measurement is what failed, so its duration is still meaningful")
+}
+
+// The other half of the timing contract: a failure that got as far as the
+// encoder reports how long each phase ran. That is what separates a hung encoder
+// which burned the whole job deadline from one that rejected its arguments
+// instantly, and both numbers were already measured before this change; only the
+// success line consumed them.
+func TestExecute_FailureLogCarriesPhaseTimings(t *testing.T) {
+	logs := captureExportLogs(t)
+	dir := t.TempDir()
+	a := newExportLogAction(t, dir, "clip.flac", ffmpeg.FormatFLAC)
+	blockOutputPath(t, dir, "clip.flac")
+
+	require.Error(t, a.Execute(t.Context(), nil))
+
+	line := logLineContaining(t, logs.String(), "operation=audio_export_failed")
+	assert.Contains(t, line, "measure_ms=0", "normalization is off in this fixture")
+	assert.Contains(t, line, "encode_ms=",
+		"the encoder ran and failed, so its duration is known and worth reporting")
+	assert.Contains(t, line, "gain_db=-2.5",
+		"the gain resolved before the encoder failed, so it is still reportable")
+}
+
+// clip_path is the clip's name relative to the export directory: the identifier
+// the media endpoint resolves, and what GET /api/v2/system/events/detections
+// hands back as SpeciesEntry.ClipPaths. The year/month segments are load-bearing
+// (a bare basename cannot be resolved back to a file) and the export directory
+// must never appear (support dumps are read by someone other than the operator).
+//
+// The escape cases matter because the value goes into a support artefact. If the
+// output ever lands outside the export directory, filepath.Rel does NOT fail; it
+// walks up with "..", which would both leak the layout above the export
+// directory and produce an unresolvable name. The basename is the safe answer.
+func TestRelativeClipPath(t *testing.T) {
+	t.Parallel()
+
+	const exportDir = "/srv/birdnet/clips"
+	tests := []struct {
+		name       string
+		exportPath string
+		outputPath string
+		want       string
+	}{
+		{"nested clip keeps its date segments", exportDir, exportDir + "/2026/07/wren.wav", "2026/07/wren.wav"},
+		{"trailing separator on the export path", exportDir + "/", exportDir + "/2026/07/wren.wav", "2026/07/wren.wav"},
+		{"clip directly in the export root", exportDir, exportDir + "/wren.wav", "wren.wav"},
+		{"escaping path falls back to the basename", exportDir, "/etc/passwd", "passwd"},
+		{"sibling directory falls back to the basename", exportDir, "/srv/birdnet/other/wren.wav", "wren.wav"},
+		{"unrelatable paths fall back to the basename", "relative/dir", "/absolute/wren.wav", "wren.wav"},
+		{"empty export path falls back to the basename", "", exportDir + "/wren.wav", "wren.wav"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			a := &SaveAudioAction{Settings: &conf.Settings{
+				Realtime: conf.RealtimeSettings{
+					Audio: conf.AudioSettings{Export: conf.ExportSettings{Path: tt.exportPath}},
+				},
+			}}
+
+			got := a.relativeClipPath(tt.outputPath)
+
+			assert.Equal(t, tt.want, got)
+			assert.NotContains(t, got, "..", "a support log must not carry the layout above the export directory")
+			assert.False(t, filepath.IsAbs(got), "a support log must not carry an absolute path")
+		})
+	}
+}
+
 // The failure log must not leak the export directory. Only the clip's basename
 // is logged, matching the success line, because support logs and uploaded
 // support dumps are read by someone other than the operator.
@@ -222,22 +526,55 @@ func TestExecute_FailureLogOmitsFullPath(t *testing.T) {
 	assert.NotContains(t, logs.String(), "clip_path="+dir)
 }
 
-// A cancelled context is shutdown, not a defect: an export in flight when the
+// A cancelled export is shutdown, not a defect: an export in flight when the
 // process stops must not be recorded as an error.
+//
+// FLAC, because it is a path that genuinely reports cancellation: flac.EncodePCM
+// checks ctx before it writes and returns ctx.Err(). The classification reads
+// that error, so the test has to produce one rather than merely arranging for
+// the context to be cancelled (see the sibling test below, which is the case
+// this one used to be testing by accident).
 func TestExecute_CancelledExportLogsAtDebug(t *testing.T) {
 	logs := captureExportLogs(t)
 	dir := t.TempDir()
+	a := newExportLogAction(t, dir, "clip.flac", ffmpeg.FormatFLAC)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := a.Execute(ctx, nil)
+	require.ErrorIs(t, err, context.Canceled, "the export must fail with a real cancellation")
+
+	out := logs.String()
+	assert.Contains(t, out, "Audio clip export cancelled")
+	assert.NotContains(t, out, "Audio clip export failed")
+}
+
+// The regression this pair exists to prevent: a genuine defect that merely
+// COINCIDES with shutdown is still a defect. The guard used to test the context
+// as well as the error, so ENOSPC, corrupt PCM or a missing FFmpeg binary hit
+// while the process was stopping were all logged at Debug under a message
+// asserting they had been cancelled. On a container that OOM-restarts that
+// misattributes every in-flight export failure in the restart window.
+func TestExecute_RealErrorDuringShutdownStaysAtWarn(t *testing.T) {
+	logs := captureExportLogs(t)
+	dir := t.TempDir()
 	a := newExportLogAction(t, dir, "clip.mp3", ffmpeg.FormatMP3)
+	// Not a cancellation: FFmpeg is simply not there.
 	a.Settings.Realtime.Audio.FfmpegPath = ""
 
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
-	require.Error(t, a.Execute(ctx, nil))
+	err := a.Execute(ctx, nil)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, context.Canceled,
+		"the failure under test must be a real error, not a cancellation")
 
 	out := logs.String()
-	assert.Contains(t, out, "Audio clip export cancelled")
-	assert.NotContains(t, out, "Audio clip export failed")
+	assert.Contains(t, out, "Audio clip export failed",
+		"a real failure must not be filed as shutdown just because the context was cancelled")
+	assert.NotContains(t, out, "Audio clip export cancelled")
 }
 
 // The other side of that classification: an EXPIRED context is not shutdown. The
@@ -298,6 +635,104 @@ func TestResolveExportParams_BatDowngradeLoggedOncePerProcess(t *testing.T) {
 
 	assert.Equal(t, 1, strings.Count(logs.String(), "audio_export_bat_format_fallback"),
 		"a bat install takes this path on every detection; the log must not repeat")
+}
+
+// The guard is keyed on the inputs the decision is made from, not on "have we
+// ever logged this". Both inputs vary at runtime: Export.Type is hot-reloadable,
+// and the capture rate belongs to the source, so a multi-source install runs
+// several at once. A bare sync.Once let the first condition silence every later,
+// DIFFERENT one, leaving the operator an explanation naming a format they had
+// since changed away from or a rate belonging to another source.
+func TestResolveExportParams_BatDowngradeLogsEachDistinctCondition(t *testing.T) {
+	resetBatFormatDowngradeOnce()
+	logs := captureExportLogs(t)
+	a := newExportLogAction(t, t.TempDir(), "clip.mp3", ffmpeg.FormatMP3)
+	a.modelName = batModelName
+	a.sourceSampleRate = batSourceSampleRate
+
+	_, _, _ = a.resolveExportParams("/clips/clip.mp3")
+
+	// A second source at a different ultrasonic rate: same format, new condition.
+	const otherBatRate = 192000
+	a.sourceSampleRate = otherBatRate
+	_, _, _ = a.resolveExportParams("/clips/clip.mp3")
+
+	// The operator switches the export format in the UI without restarting.
+	a.Settings.Realtime.Audio.Export.Type = ffmpeg.FormatOpus
+	a.sourceSampleRate = batSourceSampleRate
+	_, _, _ = a.resolveExportParams("/clips/clip.opus")
+
+	out := logs.String()
+	assert.Equal(t, 3, strings.Count(out, "audio_export_bat_format_fallback"),
+		"each distinct format/rate combination must explain itself exactly once")
+	assert.Contains(t, out, "sample_rate="+strconv.Itoa(otherBatRate),
+		"the second source's rate must not be hidden by the first")
+	assert.Contains(t, out, "requested_format="+ffmpeg.FormatOpus,
+		"a hot-reloaded format must re-explain itself")
+}
+
+// The sibling downgrade: an install with no FFmpeg whose opted-in native encoder
+// cannot carry the clip either. It means the same thing as the bat downgrade
+// ("you are not getting the format you configured"), so it is logged the same
+// way. It used to be the opposite of its sibling on both counts: WARN on every
+// single clip forever, against Info exactly once.
+func TestResolveExportParams_StrandedFallbackIsWarnedOncePerCondition(t *testing.T) {
+	t.Setenv(conf.EnvNativeOpusEncoder, "native")
+	resetNativeSkipOnce()
+	resetStrandedFormatOnce()
+	logs := captureExportLogs(t)
+
+	// 44.1 kHz is a rate Opus does not accept, and with no FFmpeg to fall back
+	// on there is no encoder left for the configured format.
+	const unsupportedOpusRate = 44100
+	a := newExportLogAction(t, t.TempDir(), "clip.opus", ffmpeg.FormatOpus)
+	a.Settings.Realtime.Audio.FfmpegPath = ""
+	a.sourceSampleRate = unsupportedOpusRate
+
+	for range 3 {
+		_, format, _ := a.resolveExportParams("/clips/clip.opus")
+		require.Equal(t, ffmpeg.FormatWAV, format, "the recording must still survive as WAV")
+	}
+
+	out := logs.String()
+	assert.Equal(t, 1, strings.Count(out, "audio_export_no_encoder_fallback"),
+		"the condition is static per clip shape; it must not warn on every detection")
+	// Scoped to the fallback line itself. A buffer-wide "level=WARN" is already
+	// satisfied by the native-encoder skip warning this same path emits, so it
+	// would pass even if the fallback were still logged at Info.
+	assert.Contains(t, logLineContaining(t, out, "audio_export_no_encoder_fallback"), "level=WARN",
+		"it means the same thing to the operator as the bat downgrade, so it takes the same level")
+}
+
+// The stranded guard is keyed like its sibling, so a second distinct condition
+// still explains itself. Without this, a bare sync.Once would pass the
+// once-per-condition test above identically.
+func TestResolveExportParams_StrandedFallbackLogsEachDistinctCondition(t *testing.T) {
+	t.Setenv(conf.EnvNativeOpusEncoder, "native")
+	t.Setenv(conf.EnvNativeAACEncoder, "native")
+	resetNativeSkipOnce()
+	resetStrandedFormatOnce()
+	logs := captureExportLogs(t)
+
+	a := newExportLogAction(t, t.TempDir(), "clip.opus", ffmpeg.FormatOpus)
+	a.Settings.Realtime.Audio.FfmpegPath = ""
+	a.sourceSampleRate = 44100
+	_, _, _ = a.resolveExportParams("/clips/clip.opus")
+
+	// A different format the native encoder also rejects at this rate.
+	a.Settings.Realtime.Audio.Export.Type = ffmpeg.FormatAAC
+	a.sourceSampleRate = 22050
+	_, _, _ = a.resolveExportParams("/clips/clip.m4a")
+
+	out := logs.String()
+	assert.Equal(t, 2, strings.Count(out, "audio_export_no_encoder_fallback"),
+		"each distinct format/rate combination must explain itself exactly once")
+	// The two native-encoder skip warnings share one guard now that the format is
+	// part of the key; both formats must still get their own line.
+	assert.Contains(t, out, "format="+ffmpeg.FormatOpus)
+	assert.Contains(t, out, "format="+ffmpeg.FormatAAC)
+	assert.Equal(t, 2, strings.Count(out, "audio_export_native_unsupported"),
+		"one shared guard must not let the first format silence the second")
 }
 
 // selectEncoder is the whole routing table, extracted so a failed export can

--- a/internal/analysis/processor/export_test.go
+++ b/internal/analysis/processor/export_test.go
@@ -17,15 +17,26 @@ func buildClipPathFallbackWarned() bool {
 
 // resetNativeSkipOnce re-arms the native-encoder fallback log guards so a test
 // can observe the warning more than once per process. Without it the first test
-// to hit an unsupported clip shape consumes the Once for the whole run, and a
+// to hit an unsupported clip shape consumes the guard for the whole run, and a
 // later assertion on that warning would fail for the wrong reason.
+// The guards are cleared rather than reassigned. onceByKey holds a sync.Map,
+// which is marked noCopy and must not be copied once used; Clear resets it in
+// place, which is what these helpers actually want. Note that go vet does NOT
+// catch the alternative: assigning a zero composite literal (guard = onceByKey{})
+// copies no lock state, so copylocks stays silent and the mistake would be
+// invisible. Clearing is a deliberate choice, not something a linter enforces.
 func resetNativeSkipOnce() {
-	nativeAACSkipOnce = sync.Once{}
-	nativeOpusSkipOnce = sync.Once{}
+	nativeEncoderSkipLogged.seen.Clear()
 }
 
 // resetBatFormatDowngradeOnce re-arms the ultrasonic WAV-downgrade log guard for
 // the same reason as resetNativeSkipOnce. Test-only.
 func resetBatFormatDowngradeOnce() {
-	batFormatDowngradeOnce = sync.Once{}
+	batFormatDowngradeLogged.seen.Clear()
+}
+
+// resetStrandedFormatOnce re-arms the no-encoder-left WAV-fallback log guard.
+// Test-only, same rationale as the two above.
+func resetStrandedFormatOnce() {
+	strandedFormatLogged.seen.Clear()
 }

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -2242,6 +2242,7 @@ func (p *Processor) buildSaveAudioAction(det *Detections, detectionCtx *Detectio
 			readyAt:          captureEndTime,
 			sourceSampleRate: det.Result.AudioSource.SampleRate,
 			modelName:        det.Result.Model.Name,
+			species:          strings.ToLower(det.Result.Species.CommonName),
 			NoteID:           det.Result.ID, // May be 0 here; updated after DB save via DetectionCtx
 			PreRenderer:      p.preRenderer,
 			DetectionCtx:     detectionCtx,
@@ -2268,6 +2269,7 @@ func (p *Processor) buildSaveAudioAction(det *Detections, detectionCtx *Detectio
 			ClipName:         det.Result.ClipName,
 			sourceSampleRate: det.Result.AudioSource.SampleRate,
 			modelName:        det.Result.Model.Name,
+			species:          strings.ToLower(det.Result.Species.CommonName),
 			NoteID:           det.Result.ID, // May be 0 here; updated after DB save via DetectionCtx
 			PreRenderer:      p.preRenderer,
 			DetectionCtx:     detectionCtx,
@@ -2281,6 +2283,7 @@ func (p *Processor) buildSaveAudioAction(det *Detections, detectionCtx *Detectio
 		pcmData:          pcmData,
 		sourceSampleRate: det.Result.AudioSource.SampleRate,
 		modelName:        det.Result.Model.Name,
+		species:          strings.ToLower(det.Result.Species.CommonName),
 		NoteID:           det.Result.ID, // May be 0 here; updated after DB save via DetectionCtx
 		PreRenderer:      p.preRenderer,
 		DetectionCtx:     detectionCtx,


### PR DESCRIPTION
`GET /api/v2/system/events/detections` builds `SpeciesEntry.ClipPaths` by reading `species` and `clip_path` back off the `audio_export_success` log line, but the producer never emitted `species`. The endpoint has therefore returned an empty `ClipPaths` for every bucket it has ever served. `SaveAudioAction` had no species field at all, so this adds one, populates it at all three `buildSaveAudioAction` construction sites, and logs it.

The value is lowercased deliberately. The aggregator keys species with an exact map lookup, and the sibling operations it consumes (`approve_detection`, `discard_detection`, `flush_detection`) all log `strings.ToLower(CommonName)`. Emitting the original case would have filed the clip paths under a second, phantom species row with zero counts while the real row kept its empty `ClipPaths`, which is the same defect one layer further down.

`clip_path` also changes from a bare basename to the clip's name relative to the export directory. The `year/month` segments are what let a consumer resolve the value back to a file, and the export directory itself stays stripped because support dumps get read by someone other than the operator. A path that would escape the export directory falls back to the basename rather than emitting `..`.

### Other fixes on the two export log sites

The failure guard classified shutdown by inspecting the context rather than the error. ENOSPC, corrupt PCM, or a missing FFmpeg binary hit while a shutdown happened to be in progress were all logged at Debug under a message asserting they had been cancelled; on a container that OOM-restarts, that misattributed every in-flight export failure in the restart window. It now tests only the error. `resolveExportGainDB` joins the cancellation onto a measurement that cancellation turned terminal, so a genuine shutdown still lands at Debug. I checked every path that cancellation can actually interrupt: FFmpeg wraps `ctx.Err()` at each exit, FLAC checks per chunk, AAC and Opus check before the temp file is created, and the stretches that take no context cannot be interrupted by cancellation in the first place.

`encode_ms` covered the loudness measurement as well as the encoder, so on a Pi with a long extended capture it blamed the codec for a full-clip EBU R128 pass. It is now split into `measure_ms` and `encode_ms`. On a failure that never reached the encoder, `gain_db` and `encode_ms` are omitted rather than reported as a zero indistinguishable from a real value, and the failure line now carries the timings it had already measured.

Several doc comments misstated the job queue's reachable log strings, the encoders' context handling, and which attempts `LogJobRetryScheduled` records. Corrected.

### Format-downgrade logs

The two downgrade sites disagreed with each other. The bat downgrade was Info once per process; the stranded-without-encoder fallback was Warn on every single clip, forever. Both mean "you are not getting the export format you configured", so both are Warn now and both are guarded.

The guards are keyed on the format and sample rate rather than a bare `sync.Once`. `Export.Type` is hot-reloadable and the capture rate is per source, so a single `sync.Once` let whichever condition fired first silence every later, different one, leaving the operator an explanation naming a format they had since changed away from.

### Notes for reviewers

`encode_ms` and the failure line both shipped yesterday in #3984 and are in no tagged release (`git tag --contains` is empty, newest tag is `20260716`), so narrowing `encode_ms`'s meaning and making `gain_db` conditional break no existing parser.

Once clip paths actually attach, an export whose success line falls in a later hour bucket than its approval can add a zero-count species row to that later bucket. That is pre-existing aggregator behaviour that was simply unreachable while `species` was never emitted; I left it alone rather than change the endpoint's semantics in a logging PR.

## Release notes
- audience: user
- summary: The detection events API now reports the audio clip files recorded for each species instead of always returning an empty list, and clip export log lines separate loudness-measurement time from encoding time.
- feature: native encoder rollout
- breaking: none
- config: none
- schema: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Audio export logs now include clearer species information and safer relative clip paths.
  - Export timing is reported separately for loudness measurement and encoding.
  - Failure logs more accurately distinguish cancellation from other errors and omit unavailable details.
  - Logged bitrate values now reflect effective encoder settings.
  - Format fallback warnings are tracked independently for each format and sample-rate combination.

- **Reliability**
  - Improved handling of export cancellation and measurement failures.
  - Expanded validation ensures consistent species attribution and safer logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->