### PR TITLE
fix(ui): stop modal backdrop from intercepting clicks during close transition

### DIFF
--- a/frontend/src/lib/desktop/components/ui/Modal.svelte
+++ b/frontend/src/lib/desktop/components/ui/Modal.svelte
@@ -209,7 +209,10 @@
 <div
   class={cn(
     'fixed inset-0 z-[2000] flex items-center justify-center p-4 bg-black/50 opacity-0 invisible transition-[opacity,visibility] duration-200 ease-out',
-    { 'opacity-100 visible': isOpen }
+    {
+      'opacity-100 visible pointer-events-auto': isOpen,
+      'pointer-events-none': !isOpen,
+    }
   )}
   role="dialog"
   aria-modal="true"


### PR DESCRIPTION
I hit this while developing a new feature — it was triggered by an automated
test I was building, where a click fired within the modal's close transition.
It's low severity and probably not something users normally run into, though a
user clicking immediately after dismissing a modal could experience it (the
invisible backdrop covers the whole viewport for ~200ms after close).

## Summary

The modal backdrop kept intercepting pointer events for ~200ms after the modal
had already closed, silently swallowing a fast click on whatever was behind it
(for example, a button directly behind a confirm dialog that was just dismissed).

## Root cause

The full-viewport overlay `<div>` only toggled `opacity`/`visibility` classes on
`isOpen`. Because the overlay uses a `transition-[opacity,visibility] duration-200`,
the browser delays the actual `visibility: hidden` switch until the fade-out
transition finishes. During that window the overlay is invisible but still
covers the viewport and still receives pointer events, so a click landing there
is absorbed by the backdrop instead of reaching the element underneath.

## Fix

Drive `pointer-events` directly off `isOpen` rather than letting it ride on the
transitioned `visibility` property:

- `pointer-events-auto` while open
- `pointer-events-none` while closed

`pointer-events` is not transitioned, so it flips the instant the modal closes,
regardless of how long the fade-out animation runs. The visual fade is unchanged.

## Testing

- `prettier --check` and `eslint` pass on the changed file.
- Manually verified a click on an element directly behind a just-closed modal
  now registers immediately instead of being swallowed during the fade-out.

## Scope

One file, CSS-class-only change (`frontend/src/lib/desktop/components/ui/Modal.svelte`).
No behavioural change while the modal is open or fully closed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented hidden modal backdrops from intercepting clicks and other pointer interactions.
  * Ensured pointer interaction is enabled only while the modal is open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->