### PR TITLE
fix(datastore): fall back to default path when SQLite path is blank

### DIFF
--- a/internal/datastore/sqlite.go
+++ b/internal/datastore/sqlite.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -45,10 +46,29 @@ type SQLiteStore struct {
 	walCheckpointOnce sync.Once
 }
 
+// defaultSQLitePath mirrors the viper default set in conf/defaults.go
+// ("output.sqlite.path"). It is used as a fallback when the configured path is
+// blank, since that default only applies at fresh config bootstrap and can be
+// overwritten with an empty string by a later settings save.
+const defaultSQLitePath = "birdnet.db"
+
 func validateSQLiteConfig() error {
 	// Add validation logic for SQLite configuration
 	// Return an error if the configuration is invalid
 	return nil
+}
+
+// resolveSQLitePath returns the configured SQLite database path, falling back to
+// defaultSQLitePath when the configured value is blank. A blank path would
+// otherwise flow into buildSQLiteDSN and produce a bare "?<pragmas>" DSN; the
+// SQLite driver treats everything before the "?" as the filename, so it would
+// create/open a file literally named after the pragma query string in the
+// working directory instead of the intended database.
+func resolveSQLitePath(configured string) string {
+	if strings.TrimSpace(configured) == "" {
+		return defaultSQLitePath
+	}
+	return configured
 }
 
 // getDiskSpace returns available disk space for the given path using diskmanager
@@ -188,8 +208,13 @@ func (s *SQLiteStore) createBackup(dbPath string) error {
 
 // Open initializes the SQLite database connection
 func (s *SQLiteStore) Open() (retErr error) {
-	// Get database path from settings
-	dbPath := s.Settings.Output.SQLite.Path
+	// Get database path from settings, guarding against a blank value that
+	// would otherwise produce a malformed DSN and open a bogus file.
+	dbPath := resolveSQLitePath(s.Settings.Output.SQLite.Path)
+	if dbPath != s.Settings.Output.SQLite.Path {
+		GetLogger().Warn("Configured SQLite path is empty; falling back to default",
+			logger.String("default_path", dbPath))
+	}
 
 	// Initialize telemetry integration
 	telemetryEnabled := s.Settings != nil && s.Settings.Sentry.Enabled

--- a/internal/datastore/sqlite.go
+++ b/internal/datastore/sqlite.go
@@ -640,12 +640,16 @@ func (s *SQLiteStore) UpdateNote(id string, updates map[string]any) error {
 	return s.DB.Model(&Note{}).Where("id = ?", id).Updates(updates).Error
 }
 
-// GetDBPath returns the database file path for telemetry integration
+// GetDBPath returns the database file path for telemetry integration. It
+// resolves a blank configured path to the same default Open() falls back to, so
+// callers never see an empty path while the connection actually runs against the
+// default database.
 func (s *SQLiteStore) GetDBPath() string {
-	if s.Settings != nil && s.Settings.Output.SQLite.Path != "" {
-		return s.Settings.Output.SQLite.Path
+	var configured string
+	if s.Settings != nil {
+		configured = s.Settings.Output.SQLite.Path
 	}
-	return ""
+	return resolveSQLitePath(configured)
 }
 
 // CheckpointWAL forces a checkpoint of the Write-Ahead Log to ensure all changes are written to the main database file.

--- a/internal/datastore/sqlite_path_test.go
+++ b/internal/datastore/sqlite_path_test.go
@@ -1,0 +1,51 @@
+package datastore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestResolveSQLitePath verifies that a blank configured path falls back to the
+// default while any non-blank path (including SQLite special forms) is returned
+// unchanged. A blank path previously flowed into buildSQLiteDSN and produced a
+// bare "?<pragmas>" DSN, causing the driver to create a file literally named
+// after the pragma query string.
+func TestResolveSQLitePath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		configured string
+		expected   string
+	}{
+		{name: "empty string falls back to default", configured: "", expected: defaultSQLitePath},
+		{name: "whitespace-only falls back to default", configured: "   ", expected: defaultSQLitePath},
+		{name: "tab and newline fall back to default", configured: "\t\n", expected: defaultSQLitePath},
+		{name: "plain relative path preserved", configured: "birdnet.db", expected: "birdnet.db"},
+		{name: "absolute path preserved", configured: "/data/birdnet.db", expected: "/data/birdnet.db"},
+		{name: "in-memory path preserved", configured: ":memory:", expected: ":memory:"},
+		{name: "shared in-memory path preserved", configured: "file::memory:?cache=shared", expected: "file::memory:?cache=shared"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, resolveSQLitePath(tc.configured))
+		})
+	}
+}
+
+// TestResolveSQLitePathNeverProducesBareDSN guards the specific failure mode:
+// feeding the resolved path into buildSQLiteDSN must never yield a DSN that
+// begins with "?", which the SQLite driver would open as a bogus filename.
+func TestResolveSQLitePathNeverProducesBareDSN(t *testing.T) {
+	t.Parallel()
+
+	const pragmas = "_journal_mode=WAL&_busy_timeout=30000"
+	for _, configured := range []string{"", "   ", "\t"} {
+		dsn := buildSQLiteDSN(resolveSQLitePath(configured), pragmas)
+		assert.NotEmpty(t, dsn)
+		assert.NotEqual(t, byte('?'), dsn[0], "DSN must not start with '?' for input %q", configured)
+	}
+}

--- a/internal/datastore/sqlite_path_test.go
+++ b/internal/datastore/sqlite_path_test.go
@@ -43,9 +43,16 @@ func TestResolveSQLitePathNeverProducesBareDSN(t *testing.T) {
 	t.Parallel()
 
 	const pragmas = "_journal_mode=WAL&_busy_timeout=30000"
-	for _, configured := range []string{"", "   ", "\t"} {
-		dsn := buildSQLiteDSN(resolveSQLitePath(configured), pragmas)
-		assert.NotEmpty(t, dsn)
-		assert.NotEqual(t, byte('?'), dsn[0], "DSN must not start with '?' for input %q", configured)
+	for name, configured := range map[string]string{
+		"empty":  "",
+		"spaces": "   ",
+		"tab":    "\t",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			dsn := buildSQLiteDSN(resolveSQLitePath(configured), pragmas)
+			assert.NotEmpty(t, dsn)
+			assert.NotEqual(t, byte('?'), dsn[0], "DSN must not start with '?' for input %q", configured)
+		})
 	}
 }


### PR DESCRIPTION
I ran into this while developing a new feature: a settings change I made through
the API blanked `output.sqlite.path`, and the app then silently opened a garbage
database file instead of erroring or falling back to the default. *How* the path
gets blanked is a separate settings-API bug (#3993); this PR is a defensive guard
so a blank path can't cause a silent wrong-database situation regardless of how
it got blanked.

## Summary

An empty `Output.SQLite.Path` silently makes BirdNET-Go open the wrong
database — a file literally named after the SQLite pragma string — instead of
the intended DB, with no error.

## Root cause

`buildSQLiteDSN(dbPath, pragmas)` returns `dbPath + "?" + pragmas`. When
`dbPath` is empty it produces a bare query string:

```
?_journal_mode=WAL&_busy_timeout=30000&_foreign_keys=ON&_synchronous=NORMAL&_cache_size=-16000
```

The SQLite driver treats everything before the `?` as the filename, so with an
empty prefix it creates/opens a file **literally named** after that whole
pragma string in the working directory.

`SQLiteStore.Open()` read `s.Settings.Output.SQLite.Path` completely unguarded.
The viper default (`birdnet.db`, `internal/conf/defaults.go`) is only a
*first-boot* convenience: it's applied at unmarshal when the key is absent from
`config.yaml`, and it is never re-asserted afterward. The field is serialized
without `omitempty`, so once a settings save persists an empty string for it
(see #3993 for how that happens), `config.yaml` carries an explicit empty value,
the default no longer applies on reload, and the app runs against the wrong,
empty database.

## Fix

Resolve the configured path through a small `resolveSQLitePath` helper in
`Open()`:

- A blank value (empty or whitespace-only) falls back to the documented
  `birdnet.db` default and logs a warning.
- Every other value — including SQLite special forms like `:memory:` and
  `file::memory:?cache=shared` — is returned unchanged.

This is defense-in-depth at the point of use, not the root-cause fix: it makes a
blank path safe rather than preventing the path from being blanked. The
write-side cause is tracked separately in #3993.

There's also a frontend angle worth a follow-up: the Settings UI currently lets
the SQLite path field be cleared and saved blank with no validation (a plausible
way to reach this state with no API/curl involved). A small frontend change —
marking the field required, or falling back to the `birdnet.db` default on an
empty value — would prevent it at the source. That's out of scope here; this PR
keeps the guarantee at the layer that actually opens the database, which holds
regardless of how the path was blanked.

## Testing

- Added unit tests (`sqlite_path_test.go`) covering the fallback cases,
  preservation of normal/absolute/in-memory paths, and a guard asserting the
  resolved path can never produce a DSN that begins with `?`.
- Verified locally: `go build ./internal/datastore/`, `go test -race` on the
  full `internal/datastore` package (including the new tests), and
  `golangci-lint run` all pass.

## Possibly related

This may also explain a separately observed symptom where the alerts/rules API
starts returning `409 "requires enhanced (v2) database"` after a container
restart against an existing data volume — the bogus DSN-named file can defeat
v2-schema detection. I have not verified that linkage here; flagging it as
context, not as a claim.

## Scope

`internal/datastore/sqlite.go` (+ new test file). No change to behaviour for a
normally-configured path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQLite storage setup when no database path is configured.
  * Blank or whitespace-only paths now use the safe default database location instead of an invalid or empty filename.
  * Added a warning to clarify where data is being stored when the path is unspecified.
  * Preserved support for custom, in-memory, relative, and absolute SQLite paths.
  * Prevented invalid database connection strings when the path is blank.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->