### PR TITLE
fix(notifications): make template preview and Reset reflect real defaults

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
@@ -301,12 +301,6 @@
     }))
   );
 
-  const defaultTemplate = {
-    title: 'New Species: {{.CommonName}}',
-    message:
-      '{{.ImageURL}}\n\nFirst detection of {{.CommonName}} ({{.ScientificName}}) with {{.ConfidencePercent}}% confidence at {{.DetectionTime}}.\n\n{{.DetectionURL}}',
-  };
-
   let isServiceFormValid = $derived.by(() => {
     switch (selectedService) {
       case 'discord':
@@ -546,13 +540,13 @@
 
       if (data.templates?.newSpecies) {
         templateConfig = {
-          title: data.templates.newSpecies.title ?? defaultTemplate.title,
-          message: data.templates.newSpecies.message ?? defaultTemplate.message,
+          title: data.templates.newSpecies.title ?? '',
+          message: data.templates.newSpecies.message ?? '',
         };
         editedTitle = templateConfig.title;
         editedMessage = templateConfig.message;
       } else {
-        templateConfig = { ...defaultTemplate };
+        templateConfig = { title: '', message: '' };
         editedTitle = templateConfig.title;
         editedMessage = templateConfig.message;
       }
@@ -567,7 +561,7 @@
         originalPushSettings = JSON.parse(JSON.stringify(pushSettings));
       }
     } catch {
-      templateConfig = { ...defaultTemplate };
+      templateConfig = { title: '', message: '' };
       editedTitle = templateConfig.title;
       editedMessage = templateConfig.message;
     } finally {
@@ -620,8 +614,12 @@
   function resetTemplates() {
     const confirmReset = window.confirm(t('settings.notifications.templates.resetConfirm'));
     if (!confirmReset) return;
-    editedTitle = defaultTemplate.title;
-    editedMessage = defaultTemplate.message;
+    // Clear the template so the real backend default applies (the seeded rule
+    // name for the title and the dispatcher's DefaultDetectionMessage for the
+    // body), rather than pre-filling invented example text that no real
+    // notification produces. The inputs' placeholders show the example format.
+    editedTitle = '';
+    editedMessage = '';
   }
 
   async function sendTestNewSpeciesNotification() {

--- a/internal/alerting/constants.go
+++ b/internal/alerting/constants.go
@@ -94,6 +94,14 @@ const (
 	TargetPush = "push"
 )
 
+// Built-in rule English display names. Exported as the single source of truth
+// so seeding (DefaultRules) and anything previewing "what a real, uncustomized
+// notification looks like" (the notifications API's test-fire endpoints) can't
+// drift apart into two different names for the same rule.
+const (
+	RuleNameNewSpecies = "New species detected"
+)
+
 // Built-in rule i18n key constants.
 // These correspond to entries in the frontend i18n files under
 // "settings.alerts.builtInRules.*".

--- a/internal/alerting/defaults.go
+++ b/internal/alerting/defaults.go
@@ -9,7 +9,7 @@ import (
 func DefaultRules() []entities.AlertRule {
 	return []entities.AlertRule{
 		{
-			Name:           "New species detected",
+			Name:           RuleNameNewSpecies,
 			Description:    "Notifies when a species is detected for the first time",
 			NameKey:        RuleKeyNewSpeciesName,
 			DescriptionKey: RuleKeyNewSpeciesDesc,

--- a/internal/alerting/dispatcher.go
+++ b/internal/alerting/dispatcher.go
@@ -268,8 +268,20 @@ func detectionMessage(event *AlertEvent) (key string, params map[string]any, fal
 		"species_name": species,
 		"confidence":   confStr,
 	}
-	fallback = fmt.Sprintf("%s detected with %s%% confidence", species, confStr)
+	fallback = DefaultDetectionMessage(species, confFloat)
 	return MsgAlertDetectionOccurred, params, fallback
+}
+
+// DefaultDetectionMessage returns the default English fallback message for a
+// detection notification when no per-rule custom template applies: "<species>
+// detected with <confidence>% confidence". confidence is in the range 0.0-1.0.
+//
+// Exported so callers outside this package (the notifications API's test-fire
+// endpoints) can preview the same default text a real detection would produce,
+// instead of maintaining their own separate fallback string that silently
+// drifts out of sync with this one.
+func DefaultDetectionMessage(species string, confidence float64) string {
+	return fmt.Sprintf("%s detected with %.0f%% confidence", species, confidence*100)
 }
 
 func errorMessage(event *AlertEvent) (key string, params map[string]any, fallback string) {

--- a/internal/alerting/dispatcher_test.go
+++ b/internal/alerting/dispatcher_test.go
@@ -463,6 +463,13 @@ func TestRenderTemplate_WithVariables(t *testing.T) {
 	assert.Equal(t, "Rule My Rule fired on stream.disconnected", result)
 }
 
+func TestDefaultDetectionMessage(t *testing.T) {
+	assert.Equal(t, "American Woodcock detected with 32% confidence",
+		DefaultDetectionMessage("American Woodcock", 0.32))
+	assert.Equal(t, "Eurasian Blue Tit detected with 92% confidence",
+		DefaultDetectionMessage("Eurasian Blue Tit", 0.923))
+}
+
 func TestRenderTemplate_WithProperties(t *testing.T) {
 	rule := &entities.AlertRule{Name: "Stream Alert"}
 	event := &AlertEvent{

--- a/internal/api/v2/notifications/notifications.go
+++ b/internal/api/v2/notifications/notifications.go
@@ -34,6 +34,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
+	"github.com/tphakala/birdnet-go/internal/alerting"
 	"github.com/tphakala/birdnet-go/internal/api/auth"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/errors"
@@ -116,7 +117,7 @@ const (
 // or rendering fails. Logs errors if logError is provided.
 func renderTemplateWithDefault(name, template, defaultVal string, data *notification.TemplateData, logError func(string, ...any)) string {
 	if template == "" {
-		return "" // Empty template = user wants empty value
+		return defaultVal
 	}
 	result, err := notification.RenderTemplate(name, template, data)
 	if err != nil {
@@ -1018,15 +1019,20 @@ func (c *Handler) CreateTestNewSpeciesNotification(ctx echo.Context) error {
 		DaysSinceFirstSeen: 0,
 	}
 
-	// Render notification using templates with defaults
+	// Render notification using templates with defaults. The fallback values
+	// (used only when no custom template is configured) match what a real,
+	// uncustomized detection would actually produce — the seeded rule's own
+	// name for the title, and the same DefaultDetectionMessage the alerting
+	// dispatcher falls back to for the message — so this preview isn't showing
+	// text no real notification would ever contain.
 	title := renderTemplateWithDefault("title",
 		settings.Notification.Templates.NewSpecies.Title,
-		"New Species: Test Bird Species",
+		alerting.RuleNameNewSpecies,
 		testTemplateData, nil)
 
 	message := renderTemplateWithDefault("message",
 		settings.Notification.Templates.NewSpecies.Message,
-		"First detection of Test Bird Species (Testus birdicus) at Fake Test Location",
+		alerting.DefaultDetectionMessage(testTemplateData.CommonName, testNotificationConfidence),
 		testTemplateData, nil)
 
 	testNotification := notification.NewNotification(notification.TypeDetection, notification.PriorityHigh, title, message).

--- a/internal/api/v2/notifications/notifications_new_species_test.go
+++ b/internal/api/v2/notifications/notifications_new_species_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/alerting"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/conf"
@@ -123,4 +124,50 @@ func TestCreateTestNewSpeciesNotification_Success(t *testing.T) {
 	require.NotNil(t, response.ExpiresAt)
 	expectedExpiry := response.Timestamp.Add(24 * time.Hour)
 	assert.WithinDuration(t, expectedExpiry, *response.ExpiresAt, time.Second)
+}
+
+// TestCreateTestNewSpeciesNotification_EmptyTemplate_UsesRealDefault guards
+// against the test-fire preview silently drifting from what an actual,
+// uncustomized detection notification would say: with no
+// Templates.NewSpecies configured, the fallback title/message must match
+// the seeded rule's own name and alerting.DefaultDetectionMessage exactly —
+// not some made-up preview string that no real notification ever produces.
+func TestCreateTestNewSpeciesNotification_EmptyTemplate_UsesRealDefault(t *testing.T) {
+	config := &notification.ServiceConfig{
+		Debug:              true,
+		MaxNotifications:   100,
+		CleanupInterval:    30 * time.Minute,
+		RateLimitWindow:    1 * time.Minute,
+		RateLimitMaxEvents: 10,
+	}
+
+	service := notification.NewService(config)
+	t.Cleanup(service.Stop)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/notifications/test/new-species", http.NoBody)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	controller := New(&apicore.Core{}, service, nil)
+	settings := &conf.Settings{}
+	settings.Security.Host = "localhost"
+	settings.WebServer.Port = "8080"
+	settings.Main.TimeAs24h = true
+	// Templates.NewSpecies deliberately left empty (zero value).
+	controller.Settings.Store(settings)
+	apitest.PublishTestSettings(t, settings)
+
+	err := controller.CreateTestNewSpeciesNotification(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var response notification.Notification
+	err = parseJSONResponse(rec.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, alerting.RuleNameNewSpecies, response.Title,
+		"empty-template title fallback should match the seeded rule's own name")
+	assert.Equal(t, alerting.DefaultDetectionMessage("Test Bird Species", testNotificationConfidence), response.Message,
+		"empty-template message fallback should match the real alerting default")
 }


### PR DESCRIPTION
## Summary

The New Species notification template UI and the **Send Test** preview both
showed default text that no real notification ever produces. Two related bugs.

## Backend

**1. `renderTemplateWithDefault()` ignored its own default for empty templates.**
It only used the `defaultVal` argument when template rendering *failed* (bad
syntax). An empty/uncustomized template returned `""` unconditionally — so a
test-fire with no template configured produced a notification with a genuinely
**blank** title and message, not a preview of the real default. Empty template
now falls through to `defaultVal`, matching what the function name already
promises. (Its only callers are the test-fire handler.)

**2. Those default values were invented preview text.** `"New Species: Test Bird
Species"` and `"First detection of ... at Fake Test Location"` matched neither
the seeded rule nor what a real detection notification produces. Real
notifications fall back to the seeded rule's own **name** for the title and
`"<species> detected with <confidence>% confidence"` for the message (see
`dispatcher.go`'s `detectionMessage()`).

Exported `DefaultDetectionMessage()` and the `RuleNameNewSpecies` constant from
`internal/alerting` so the dispatcher and the test-fire handler share **one**
definition instead of keeping separate copies that drift apart. The message a
real detection produces is unchanged (identical `%.0f` formatting as before —
verified by inspection and covered by a new dispatcher test).

## Frontend (`NotificationsSettingsPage.svelte`)

The template editor pre-filled a hardcoded `defaultTemplate`
(`New Species: {{.CommonName}}` / `First detection of ...`) on load and on
**Reset**, presenting it as "the default" even though it matched neither the
backend default nor the shipped config. Load and Reset now clear the fields to
empty, so an uncustomized template means "use the built-in default" (rendered
correctly by the backend fix). The inputs already carry example placeholders
(`e.g., New Species: {{.CommonName}}`), so the empty state stays
self-explanatory.

## Testing

- Added `TestDefaultDetectionMessage` (alerting) and
  `TestCreateTestNewSpeciesNotification_EmptyTemplate_UsesRealDefault`
  (notifications API), which asserts the empty-template fallbacks equal the
  seeded rule name and `alerting.DefaultDetectionMessage` exactly.
- Frontend: `prettier`, `eslint`, and `svelte-check` (0 errors / 0 warnings)
  pass. No frontend test asserted the old hardcoded behaviour.
- **Note:** I could not run the Go build/tests in my local environment (no Go
  toolchain on this machine); please rely on CI for the Go tests. The existing
  `_Success` test is unaffected — it configures a non-empty template that still
  renders.

## Scope

Backend: `internal/alerting/{constants,defaults,dispatcher}.go` +
`internal/api/v2/notifications/notifications.go` and their tests. Frontend: one
Svelte file. No i18n keys changed.
