### PR TITLE
fix(observability): make the clip export path answerable from logs and dumps

### DIFF
--- a/internal/analysis/jobqueue/logger.go
+++ b/internal/analysis/jobqueue/logger.go
@@ -54,7 +54,14 @@ func LogJobCompleted(ctx context.Context, jobID, actionType string, duration tim
 	getLog().WithContext(ctx).Info("Job completed", fields...)
 }
 
-// LogJobFailed logs when a job fails
+// LogJobFailed logs a job's final, permanent failure.
+//
+// It is only ever reached once a job's attempts are exhausted: the sole caller
+// is handleJobFailure (queue.go), inside its job.Attempts >= job.MaxAttempts
+// branch. A retryable failure goes to LogJobRetryScheduled instead, so this
+// function does not need, and must not have, a "will retry" level. The two
+// counters stay in the signature because they say how many attempts were spent
+// before giving up, which is the useful part of the record.
 func LogJobFailed(ctx context.Context, jobID, actionType string, attempt, maxAttempts int, err error) {
 	fields := []logger.Field{
 		logger.String("job_id", jobID),
@@ -67,13 +74,7 @@ func LogJobFailed(ctx context.Context, jobID, actionType string, attempt, maxAtt
 		fields = append(fields, logger.String("trace_id", traceID))
 	}
 
-	contextLogger := getLog().WithContext(ctx)
-	// Use Error level for final failure, Warn for retryable failures
-	if attempt >= maxAttempts {
-		contextLogger.Error("Job failed permanently", fields...)
-	} else {
-		contextLogger.Warn("Job failed, will retry", fields...)
-	}
+	getLog().WithContext(ctx).Error("Job failed permanently", fields...)
 }
 
 // LogQueueStats logs queue statistics

--- a/internal/analysis/jobqueue/logger_test.go
+++ b/internal/analysis/jobqueue/logger_test.go
@@ -70,6 +70,9 @@ func TestLogJobFailed(t *testing.T) {
 		FileOutput:   &logger.FileOutput{Enabled: false},
 	}, handler)
 	require.NoError(t, err)
+	// assert, not require: a require inside a cleanup func calls runtime.Goexit
+	// from the cleanup goroutine.
+	t.Cleanup(func() { assert.NoError(t, cl.Close()) })
 	oldGlobal := logger.Global()
 	logger.SetGlobal(cl)
 	t.Cleanup(func() { logger.SetGlobal(oldGlobal) })

--- a/internal/analysis/jobqueue/logger_test.go
+++ b/internal/analysis/jobqueue/logger_test.go
@@ -52,19 +52,39 @@ func TestLogJobCompleted(t *testing.T) {
 	})
 }
 
-// TestLogJobFailed tests job failure logging doesn't panic
+// TestLogJobFailed pins the level and message, not just the absence of a panic.
+// The whole point of the change here is that the line is unconditionally an
+// Error reading "Job failed permanently"; a NotPanics-only assertion would stay
+// green if it regressed to Warn or to the old retryable wording.
+//
+// Only the exhausted-attempts shape is exercised, because that is the only one
+// handleJobFailure ever produces; see the doc comment on LogJobFailed.
 func TestLogJobFailed(t *testing.T) {
+	// Not parallel: swaps the process-global logger, same shape as
+	// TestLogJobRetryScheduled_Level below.
+	var buf bytes.Buffer
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	cl, err := logger.NewCentralLogger(&logger.LoggingConfig{
+		DefaultLevel: "debug",
+		Console:      &logger.ConsoleOutput{Enabled: false},
+		FileOutput:   &logger.FileOutput{Enabled: false},
+	}, handler)
+	require.NoError(t, err)
+	oldGlobal := logger.Global()
+	logger.SetGlobal(cl)
+	t.Cleanup(func() { logger.SetGlobal(oldGlobal) })
+
 	testErr := errors.New("connection timeout")
-
-	// Test retryable failure (attempt < maxAttempts)
-	assert.NotPanics(t, func() {
-		LogJobFailed(t.Context(), "job-999", "download", 3, 5, testErr)
-	})
-
-	// Test permanent failure (attempt >= maxAttempts)
 	assert.NotPanics(t, func() {
 		LogJobFailed(t.Context(), "job-1000", "process", 5, 5, testErr)
 	})
+
+	out := buf.String()
+	assert.Contains(t, out, "Job failed permanently")
+	assert.Contains(t, out, "level=ERROR",
+		"a permanently failed job must be an Error, not a Warn")
+	assert.NotContains(t, out, "will retry",
+		"the retryable wording is unreachable and must not come back")
 }
 
 // TestLogQueueStats tests queue statistics logging doesn't panic

--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/analysis/species"
 	"github.com/tphakala/birdnet-go/internal/audiocore/aac"
 	"github.com/tphakala/birdnet-go/internal/audiocore/audionorm"
+	"github.com/tphakala/birdnet-go/internal/audiocore/clipenc"
 	"github.com/tphakala/birdnet-go/internal/audiocore/convert"
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/audiocore/flac"
@@ -40,17 +41,6 @@ import (
 // rather than Warn (this is expected backpressure, not a failure).
 var errAudioExportDeferred = fmt.Errorf("audio export deferred until capture tail is available: %w", jobqueue.ErrJobDeferred)
 
-// Encoder tags recorded in the audio-export logs so the active encoder is
-// visible per clip (native go-flac or native WAV writer, native go-aac/go-opus
-// where the gate opted the format in, or FFmpeg).
-const (
-	encoderFFmpeg     = "ffmpeg"
-	encoderNativeWAV  = "native-wav"
-	encoderNativeFLAC = "native-flac"
-	encoderNativeAAC  = "native-aac"
-	encoderNativeOpus = "native-opus"
-)
-
 // clipEncoding records how a clip was written: which encoder owned the file and
 // the parameters a support log needs to explain the result on disk.
 //
@@ -60,7 +50,7 @@ const (
 // whether go-aac or FFmpeg produced the failure, which is the one question the
 // gated rollout exists to answer.
 type clipEncoding struct {
-	Encoder     string  // encoderNativeAAC, encoderFFmpeg, ...
+	Encoder     string  // clipenc.NativeAAC, clipenc.FFmpeg, ...
 	GainDB      float64 // loudness gain the encoder applies to the clip
 	BitrateKbps int     // encoded bitrate for the lossy formats; 0 when lossless
 	// GainResolved distinguishes "the gain is 0 dB" from "the export failed
@@ -68,6 +58,15 @@ type clipEncoding struct {
 	// logs gain_db=0, which is also the default Export.Gain, so the field reads
 	// as a measurement when it is really an absence.
 	GainResolved bool
+	// Normalized reports whether the gain came from an actual loudness
+	// measurement, as opposed to falling back to the static Export.Gain. It is
+	// on the success line because the WARN explaining a fallback is emitted at
+	// most once per (reason, format, rate) for the process lifetime: on a
+	// long-running install the explanation can fall outside the window a support
+	// dump captures, leaving every clip in that dump unexplained. gain_db cannot
+	// substitute, because the default Export.Gain is 0 and so is a measured gain
+	// of 0. This makes each clip say for itself which path produced it.
+	Normalized bool
 	// MeasureMs and EncodeMs are timed separately because they answer different
 	// questions and have wildly different costs. Resolving the gain with
 	// normalization enabled is a full-clip EBU R128 pass, which on a Pi with a
@@ -440,9 +439,15 @@ func (a *SaveAudioAction) Execute(ctx context.Context, _ any) error {
 
 	// If PCM data was not captured (e.g., buffer read failed), skip export.
 	if len(a.pcmData) == 0 {
+		// species is carried here for the same reason it is carried on the
+		// success line, and with more force: this is the branch where the clip is
+		// lost outright, so it is the export log where naming the bird matters
+		// most. Unguarded on purpose, unlike the configuration warnings above:
+		// this reports a per-detection loss, not a standing misconfiguration.
 		GetLogger().Warn("Skipping audio export: no PCM data available",
 			logger.String("component", "analysis.processor.actions"),
 			logger.String("detection_id", a.CorrelationID),
+			logger.String("species", a.species),
 			logger.String("clip_name", a.ClipName),
 			logger.String("operation", "audio_export_skip"))
 		return nil
@@ -514,9 +519,9 @@ func (a *SaveAudioAction) Execute(ctx context.Context, _ any) error {
 	// back off this line (the audio_export_success case in
 	// internal/api/v2/system/events_aggregation.go). It consumes only this line, so
 	// dropping the field empties every ClipPaths the endpoint returns.
-	// 14 = the 12 unconditional fields below, plus bitrate_kbps on the lossy
+	// 15 = the 13 unconditional fields below, plus bitrate_kbps on the lossy
 	// formats, plus operation.
-	fields := make([]logger.Field, 0, 14)
+	fields := make([]logger.Field, 0, 15)
 	fields = append(fields,
 		logger.String("component", "analysis.processor.actions"),
 		logger.String("detection_id", a.CorrelationID),
@@ -527,6 +532,7 @@ func (a *SaveAudioAction) Execute(ctx context.Context, _ any) error {
 		logger.String("encoder", enc.Encoder),
 		logger.Int("sample_rate", exportRate),
 		logger.Float64("gain_db", enc.GainDB),
+		logger.Bool("normalized", enc.Normalized),
 		logger.Int64("duration_ms", clipDurationMs(len(a.pcmData), exportRate)),
 		logger.Int64("measure_ms", enc.MeasureMs),
 		logger.Int64("encode_ms", enc.EncodeMs),
@@ -744,25 +750,25 @@ func (a *SaveAudioAction) logExportFailure(enc *clipEncoding, exportFormat strin
 func selectEncoder(exportFormat string, exportRate int) string {
 	switch exportFormat {
 	case ffmpeg.FormatWAV:
-		return encoderNativeWAV
+		return clipenc.NativeWAV
 	case ffmpeg.FormatFLAC:
-		return encoderNativeFLAC
+		return clipenc.NativeFLAC
 	case ffmpeg.FormatAAC:
 		// Opt-in; see internal/conf/native_encoders.go for the gate and its removal.
 		if nativeAACSelected(exportRate) {
-			return encoderNativeAAC
+			return clipenc.NativeAAC
 		}
-		return encoderFFmpeg
+		return clipenc.FFmpeg
 	case ffmpeg.FormatOpus:
 		// Opt-in; see internal/conf/native_encoders.go for the gate and its removal.
 		if nativeOpusSelected(exportRate) {
-			return encoderNativeOpus
+			return clipenc.NativeOpus
 		}
-		return encoderFFmpeg
+		return clipenc.FFmpeg
 	default:
 		// MP3 and ALAC are the only remaining formats, and FFmpeg owns their
 		// codecs only; the loudness gain is resolved in Go first.
-		return encoderFFmpeg
+		return clipenc.FFmpeg
 	}
 }
 
@@ -800,13 +806,14 @@ func (a *SaveAudioAction) encodeClip(ctx context.Context, exportRate int, export
 	}
 
 	measureStart := time.Now()
-	gainDB, err := a.resolveExportGainDB(ctx, exportRate, exportFormat)
+	gainDB, normalized, err := a.resolveExportGainDB(ctx, exportRate, exportFormat)
 	enc.MeasureMs = time.Since(measureStart).Milliseconds()
 	if err != nil {
 		return enc, err
 	}
 	enc.GainDB = gainDB
 	enc.GainResolved = true
+	enc.Normalized = normalized
 
 	encodeStart := time.Now()
 	err = a.runEncoder(ctx, enc.Encoder, exportRate, enc.BitrateKbps, exportFormat, outputPath, gainDB)
@@ -821,7 +828,7 @@ func (a *SaveAudioAction) encodeClip(ctx context.Context, exportRate int, export
 // decision and must not be able to alter what the logs report.
 func (a *SaveAudioAction) runEncoder(ctx context.Context, encoder string, exportRate, bitrateKbps int, exportFormat, outputPath string, gainDB float64) error {
 	switch encoder {
-	case encoderNativeWAV:
+	case clipenc.NativeWAV:
 		// WAV honours the resolved gain like every other format. It used to be the
 		// one exception, writing captured samples verbatim, which meant an
 		// operator with normalization or Export.Gain configured silently got
@@ -837,7 +844,7 @@ func (a *SaveAudioAction) runEncoder(ctx context.Context, encoder string, export
 		}
 		return convert.SavePCMDataToWAV(outputPath, pcm, exportRate, conf.BitDepth)
 
-	case encoderNativeFLAC:
+	case clipenc.NativeFLAC:
 		// FLAC always encodes natively via go-flac; FFmpeg is never used for FLAC.
 		return flac.EncodePCM(ctx, &flac.Options{
 			PCMData:    a.pcmData,
@@ -848,10 +855,10 @@ func (a *SaveAudioAction) runEncoder(ctx context.Context, encoder string, export
 			GainDB:     gainDB,
 		})
 
-	case encoderNativeAAC:
+	case clipenc.NativeAAC:
 		return a.encodeClipNativeAAC(ctx, exportRate, bitrateKbps, outputPath, gainDB)
 
-	case encoderNativeOpus:
+	case clipenc.NativeOpus:
 		return a.encodeClipNativeOpus(ctx, exportRate, bitrateKbps, outputPath, gainDB)
 
 	default:
@@ -991,15 +998,46 @@ func formatRateKey(format string, rate int) string {
 	return format + "@" + strconv.Itoa(rate)
 }
 
-// Guards for the export-format warnings. Each fires on every single detection of
+// reasonFormatRateKey adds the decision's reason to formatRateKey, for guards
+// whose site can fire for more than one cause. Without the reason in the key, an
+// install that trips one cause would never report the other for the same format
+// and rate, which is the exact silencing onceByKey exists to prevent.
+func reasonFormatRateKey(reason, format string, rate int) string {
+	return reason + "|" + formatRateKey(format, rate)
+}
+
+// resampleKey identifies a resampling attempt by the rate pair it converts
+// between, which is what determines whether the attempt can succeed.
+func resampleKey(srcRate, dstRate int) string {
+	return strconv.Itoa(srcRate) + "->" + strconv.Itoa(dstRate)
+}
+
+// Reasons a clip was encoded without normalization. Named rather than inlined
+// because each is now part of a log-flood guard key as well as a log field, so a
+// typo in one of the two spellings would silently split or merge the guard.
+const (
+	normalizeSkipMeasureFailed     = "measurement_failed"
+	normalizeSkipTargetsOutOfRange = "normalization_targets_out_of_native_range"
+	normalizeSkipUnsupportedDepth  = "unsupported_bit_depth"
+)
+
+// Guards for the export-path warnings. Each fires on every single detection of
 // an affected install, so without a guard they are a permanent log flood; the
 // per-clip encoder and format fields carry the ongoing signal instead.
 //
-//nolint:gochecknoglobals // process-lifetime log-flood guards, matching mqttNotReadyWarnOnce
+// None of the guarded lines carries detection_id. Under a guard the field would
+// name only the first detection to trip the condition, reading as if the
+// condition were specific to that clip when every one of these is a property of
+// the configuration or the source, not of a detection.
+//
+//nolint:gochecknoglobals // process-lifetime log-flood guards
 var (
-	nativeEncoderSkipLogged  onceByKey
-	batFormatDowngradeLogged onceByKey
-	strandedFormatLogged     onceByKey
+	nativeEncoderSkipLogged   onceByKey
+	batFormatDowngradeLogged  onceByKey
+	strandedFormatLogged      onceByKey
+	normalizeSkipLogged       onceByKey
+	resampleFailureLogged     onceByKey
+	clipPathExtFallbackLogged onceByKey
 )
 
 // logBatFormatDowngrade explains why an install configured for a lossy format is
@@ -1101,10 +1139,10 @@ func logNativeEncoderSkipped(format string, rate int, reason error) {
 // export length. Extended capture can export far longer clips
 // (conf.MaxExtendedCaptureDuration is 1200 s), where dynamic-range treatment
 // would matter more, and the corpus does not cover that.
-func (a *SaveAudioAction) resolveExportGainDB(ctx context.Context, exportRate int, format string) (float64, error) {
+func (a *SaveAudioAction) resolveExportGainDB(ctx context.Context, exportRate int, format string) (gain float64, normalized bool, err error) {
 	exportSettings := &a.Settings.Realtime.Audio.Export
 	if !exportSettings.Normalization.Enabled {
-		return exportSettings.Gain, nil
+		return exportSettings.Gain, false, nil
 	}
 
 	depthSupported := conf.BitDepth == nativeNormalizationBitDepth
@@ -1113,7 +1151,7 @@ func (a *SaveAudioAction) resolveExportGainDB(ctx context.Context, exportRate in
 			exportSettings.Normalization.TargetLUFS, exportSettings.Normalization.TruePeak)
 		switch {
 		case err == nil:
-			return gainDB, nil
+			return gainDB, true, nil
 		case ctx.Err() != nil:
 			// The caller is going away; do not paper over that with a fallback.
 			//
@@ -1125,7 +1163,7 @@ func (a *SaveAudioAction) resolveExportGainDB(ctx context.Context, exportRate in
 			// the cause and the joined error says so. audionorm's own error need
 			// not wrap ctx.Err(), so without the join a normal shutdown here would
 			// be reported as a WARN failure.
-			return 0, errors.Join(err, ctx.Err())
+			return 0, false, errors.Join(err, ctx.Err())
 		}
 		// The clip could not be measured (audionorm rejects the dimensions, e.g. a
 		// source reporting a sample rate below the K-weighting minimum). Losing
@@ -1134,15 +1172,20 @@ func (a *SaveAudioAction) resolveExportGainDB(ctx context.Context, exportRate in
 		// path stopped using loudnorm, FFmpeg would still have produced a clip
 		// here, so failing hard would be a new way to lose audio on the default
 		// MP3 install.
-		GetLogger().Warn("Loudness measurement failed; encoding without normalization",
-			logger.String("component", "analysis.processor.actions"),
-			logger.String("detection_id", a.CorrelationID),
-			logger.String("format", format),
-			logger.Int("sample_rate", exportRate),
-			logger.Error(err),
-			logger.String("reason", "measurement_failed"),
-			logger.String("operation", "audio_export_normalize_skip"))
-		return exportSettings.Gain, nil
+		// Guarded per (format, rate): audionorm rejects the clip's dimensions, and
+		// those come from the source, not from this detection, so the failure
+		// repeats for every clip that source produces. The error text can vary
+		// within a rate pair but the cause does not, so it is not part of the key.
+		normalizeSkipLogged.do(reasonFormatRateKey(normalizeSkipMeasureFailed, format, exportRate), func() {
+			GetLogger().Warn("Loudness measurement failed; encoding without normalization",
+				logger.String("component", "analysis.processor.actions"),
+				logger.String("format", format),
+				logger.Int("sample_rate", exportRate),
+				logger.Error(err),
+				logger.String("reason", normalizeSkipMeasureFailed),
+				logger.String("operation", "audio_export_normalize_skip"))
+		})
+		return exportSettings.Gain, false, nil
 	}
 
 	// Unreachable for a validated config: capture is 16-bit (conf.BitDepth) and
@@ -1151,17 +1194,27 @@ func (a *SaveAudioAction) resolveExportGainDB(ctx context.Context, exportRate in
 	// Defense-in-depth for unvalidated/legacy settings only. There is no longer a
 	// loudnorm fallback on any path, FFmpeg included, so encode with the static
 	// gain and surface the skipped normalization at WARN.
-	reason := "normalization_targets_out_of_native_range"
+	reason := normalizeSkipTargetsOutOfRange
 	if !depthSupported {
-		reason = "unsupported_bit_depth"
+		reason = normalizeSkipUnsupportedDepth
 	}
-	GetLogger().Warn("Native normalization skipped; encoding without normalization",
-		logger.String("component", "analysis.processor.actions"),
-		logger.String("detection_id", a.CorrelationID),
-		logger.String("format", format),
-		logger.String("reason", reason),
-		logger.String("operation", "audio_export_normalize_skip"))
-	return exportSettings.Gain, nil
+	// The reason is part of the key, unlike the measurement-failure guard above.
+	// The bit-depth arm is decided by a build constant, but the targets arm is
+	// decided by hot-reloadable normalization settings, so a format+rate key
+	// would let whichever arm fired first silence the other for good.
+	//
+	// sample_rate is logged here as well: both sites carry the same operation
+	// tag, and emitting divergent field sets under one tag makes the tag lie
+	// about being one thing.
+	normalizeSkipLogged.do(reasonFormatRateKey(reason, format, exportRate), func() {
+		GetLogger().Warn("Native normalization skipped; encoding without normalization",
+			logger.String("component", "analysis.processor.actions"),
+			logger.String("format", format),
+			logger.Int("sample_rate", exportRate),
+			logger.String("reason", reason),
+			logger.String("operation", "audio_export_normalize_skip"))
+	})
+	return exportSettings.Gain, false, nil
 }
 
 // nativeNormalizationBitDepth is the only PCM bit depth the native gain and
@@ -1341,13 +1394,18 @@ func (a *SaveAudioAction) resolveExportParams(outputPath string) (rate int, form
 	} else if rate > conf.SampleRate && !isBat {
 		resampled, err := resample.ResampleBytes(a.pcmData, rate, conf.SampleRate)
 		if err != nil {
-			GetLogger().Warn("Resampling failed, exporting at source rate",
-				logger.String("component", "analysis.processor.actions"),
-				logger.String("detection_id", a.CorrelationID),
-				logger.Int("source_rate", rate),
-				logger.Int("target_rate", conf.SampleRate),
-				logger.Error(err),
-				logger.String("operation", "audio_export_resample"))
+			// Guarded per rate pair: resampling a fixed pair either works or it
+			// does not, so an affected source fails on every detection forever.
+			// The target is conf.SampleRate today, but it is keyed rather than
+			// assumed so a future variable target cannot silence the new pair.
+			resampleFailureLogged.do(resampleKey(rate, conf.SampleRate), func() {
+				GetLogger().Warn("Resampling failed, exporting at source rate",
+					logger.String("component", "analysis.processor.actions"),
+					logger.Int("source_rate", rate),
+					logger.Int("target_rate", conf.SampleRate),
+					logger.Error(err),
+					logger.String("operation", "audio_export_resample"))
+			})
 		} else {
 			a.pcmData = resampled
 			a.sourceSampleRate = conf.SampleRate

--- a/internal/analysis/processor/export_log_guards_test.go
+++ b/internal/analysis/processor/export_log_guards_test.go
@@ -1,0 +1,342 @@
+package processor
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// fallbackTestTime is a fixed timestamp so the generated clip names are
+// deterministic; the tests here assert on log counts, not on names.
+var fallbackTestTime = time.Date(2026, 7, 20, 9, 37, 1, 0, time.UTC)
+
+// unmeasurableSampleRate is below audionorm's K-weighting minimum, so a
+// loudness measurement of a clip at this rate fails. It is a property of the
+// capture source rather than of any one clip, which is exactly why the WARN it
+// produces is guarded per (reason, format, rate).
+const unmeasurableSampleRate = 4000
+
+// countLines is how many captured log lines mention the substring. The guards
+// under test are about repetition, so the assertions need a count rather than a
+// contains check: "the line appears" passes just as well when it appears on
+// every detection, which is the bug.
+func countLines(t *testing.T, logs, substr string) int {
+	t.Helper()
+	n := 0
+	for line := range strings.SplitSeq(logs, "\n") {
+		if strings.Contains(line, substr) {
+			n++
+		}
+	}
+	return n
+}
+
+// resetExportLogGuards re-arms every keyed guard this file exercises, so the
+// test observes its own emissions rather than whichever earlier test in the
+// package happened to consume the guard first.
+func resetExportLogGuards(t *testing.T) {
+	t.Helper()
+	rearm := func() {
+		normalizeSkipLogged.seen.Clear()
+		resampleFailureLogged.seen.Clear()
+	}
+	rearm()
+	t.Cleanup(rearm)
+}
+
+// TestOnceByKeyEmitsPerDistinctKey is the property every guard in the export
+// path depends on, asserted directly rather than through a log site: once per
+// distinct key, and never a second time for a key already seen. A bare
+// sync.Once would fail the second half of this.
+func TestOnceByKeyEmitsPerDistinctKey(t *testing.T) {
+	t.Parallel()
+
+	var guard onceByKey
+	emitted := make([]string, 0, 4)
+
+	for range 3 {
+		guard.do("mp3@48000", func() { emitted = append(emitted, "mp3@48000") })
+		guard.do("opus@48000", func() { emitted = append(emitted, "opus@48000") })
+	}
+
+	assert.Equal(t, []string{"mp3@48000", "opus@48000"}, emitted,
+		"each distinct key explains itself exactly once; neither silences the other")
+}
+
+// TestNormalizeSkipKeyDistinguishesReasons pins why the targets/bit-depth guard
+// keys on the reason as well as the format and rate. The bit-depth arm is
+// decided by a build constant, but the targets arm is decided by hot-reloadable
+// settings, so a format+rate-only key would let whichever arm fired first
+// silence the other for the rest of the process.
+func TestNormalizeSkipKeyDistinguishesReasons(t *testing.T) {
+	t.Parallel()
+
+	depth := reasonFormatRateKey("unsupported_bit_depth", "mp3", 48000)
+	targets := reasonFormatRateKey("normalization_targets_out_of_native_range", "mp3", 48000)
+
+	assert.NotEqual(t, depth, targets,
+		"two causes at the same format and rate must not share a key")
+	assert.Equal(t, depth, reasonFormatRateKey("unsupported_bit_depth", "mp3", 48000),
+		"the same cause at the same format and rate must share a key")
+}
+
+// TestResampleKeyDistinguishesRatePairs guards the resample flood: resampling a
+// fixed rate pair fails deterministically, so an affected source would emit on
+// every detection forever without a key, and a differently-configured second
+// source must not be silenced by the first.
+func TestResampleKeyDistinguishesRatePairs(t *testing.T) {
+	t.Parallel()
+
+	assert.NotEqual(t, resampleKey(96000, 48000), resampleKey(192000, 48000),
+		"two source rates converting to the same target must not share a key")
+	assert.Equal(t, "96000->48000", resampleKey(96000, 48000),
+		"the key names both ends of the conversion, so it stays readable in a guard dump")
+}
+
+// TestNormalizeSkipLogsOncePerFormat drives the real log site. Normalization is
+// enabled with a target audionorm cannot accept, which is the branch that used
+// to emit on every single detection of an affected install.
+func TestNormalizeSkipLogsOncePerFormat(t *testing.T) {
+	logs := captureExportLogs(t)
+	resetExportLogGuards(t)
+
+	a := newExportLogAction(t, t.TempDir(), "clip.mp3", "mp3")
+	// Out of audionorm's accepted range, so resolveExportGainDB takes the
+	// targets arm rather than measuring. Unreachable for a validated config;
+	// set directly here because that branch is the one under test.
+	a.Settings.Realtime.Audio.Export.Normalization.Enabled = true
+	a.Settings.Realtime.Audio.Export.Normalization.TargetLUFS = audionormMinTargetLUFS - 10
+	a.Settings.Realtime.Audio.Export.Normalization.TruePeak = -2
+
+	for range 5 {
+		_, _, err := a.resolveExportGainDB(t.Context(), conf.SampleRate, "mp3")
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, 1, countLines(t, logs.String(), "audio_export_normalize_skip"),
+		"five detections on one misconfiguration must produce one line, not five")
+
+	// A second format is a different key and must still be explained.
+	for range 3 {
+		_, _, err := a.resolveExportGainDB(t.Context(), conf.SampleRate, "opus")
+		require.NoError(t, err)
+	}
+	assert.Equal(t, 2, countLines(t, logs.String(), "audio_export_normalize_skip"),
+		"a different format must not be silenced by the first one")
+}
+
+// TestNormalizeSkipReasonsAreNotConflated pins the reason-in-key decision at the
+// log site, which the key-builder unit test above cannot: a pure-function test
+// cannot observe which key the production code actually passes. Both arms run at
+// one format AND one rate, so dropping the reason from the key collapses them
+// onto a single key and the count drops to 1.
+//
+// This also covers the measurement-failure arm, which had no execution at all.
+func TestNormalizeSkipReasonsAreNotConflated(t *testing.T) {
+	logs := captureExportLogs(t)
+	resetExportLogGuards(t)
+
+	const format = "mp3"
+
+	// BOTH arms are driven at unmeasurableSampleRate, which is what makes this
+	// test discriminating. The rate must be the shared one rather than
+	// conf.SampleRate: arm 2 reaches the measurement-failure branch only because
+	// the rate is below audionorm's K-weighting minimum, and with mono int16 PCM
+	// no other input can force that failure. Arm 1 does not care about the rate
+	// at all, so it is the one that moves.
+	//
+	// Drive them at DIFFERENT rates and the test proves nothing: the two keys
+	// stay distinct on the format+rate alone, so it stays green through exactly
+	// the revert it exists to catch.
+	const rate = unmeasurableSampleRate
+
+	// Arm 1: targets outside audionorm's accepted range, so the targets branch
+	// is taken before any measurement is attempted.
+	a := newExportLogAction(t, t.TempDir(), "clip.mp3", format)
+	a.Settings.Realtime.Audio.Export.Normalization.Enabled = true
+	a.Settings.Realtime.Audio.Export.Normalization.TargetLUFS = audionormMinTargetLUFS - 10
+	a.Settings.Realtime.Audio.Export.Normalization.TruePeak = -2
+	_, normalized, err := a.resolveExportGainDB(t.Context(), rate, format)
+	require.NoError(t, err)
+	assert.False(t, normalized, "a skipped normalization must not report itself as normalized")
+
+	// Arm 2: valid targets, so the measurement is attempted and fails on the
+	// rate. Same format, same rate, same guard, different reason.
+	b := newExportLogAction(t, t.TempDir(), "clip.mp3", format)
+	b.Settings.Realtime.Audio.Export.Normalization.Enabled = true
+	b.Settings.Realtime.Audio.Export.Normalization.TargetLUFS = -23
+	b.Settings.Realtime.Audio.Export.Normalization.TruePeak = -2
+	_, normalized, err = b.resolveExportGainDB(t.Context(), rate, format)
+	require.NoError(t, err, "an unmeasurable clip must degrade to the static gain, not fail the export")
+	assert.False(t, normalized, "a failed measurement must not report itself as normalized")
+
+	assert.Equal(t, 2, countLines(t, logs.String(), "audio_export_normalize_skip"),
+		"two distinct causes at one format and rate must each be explained; "+
+			"a key without the reason would let the first silence the second")
+	assert.Equal(t, 1, countLines(t, logs.String(), normalizeSkipMeasureFailed))
+	assert.Equal(t, 1, countLines(t, logs.String(), normalizeSkipTargetsOutOfRange))
+}
+
+// TestNormalizeSkipLineOmitsDetectionID pins the field-set decision. Under a
+// guard, detection_id would name only the first detection to trip a standing
+// misconfiguration, reading as if the problem belonged to that one clip.
+func TestNormalizeSkipLineOmitsDetectionID(t *testing.T) {
+	logs := captureExportLogs(t)
+	resetExportLogGuards(t)
+
+	a := newExportLogAction(t, t.TempDir(), "clip.mp3", "mp3")
+	a.Settings.Realtime.Audio.Export.Normalization.Enabled = true
+	a.Settings.Realtime.Audio.Export.Normalization.TargetLUFS = audionormMinTargetLUFS - 10
+	a.Settings.Realtime.Audio.Export.Normalization.TruePeak = -2
+
+	_, _, err := a.resolveExportGainDB(t.Context(), conf.SampleRate, "mp3")
+	require.NoError(t, err)
+
+	line := ""
+	for l := range strings.SplitSeq(logs.String(), "\n") {
+		if strings.Contains(l, "audio_export_normalize_skip") {
+			line = l
+			break
+		}
+	}
+	require.NotEmpty(t, line, "the normalize-skip line must have been emitted")
+	assert.NotContains(t, line, "detection_id")
+	// Both normalize-skip sites carry the same operation tag, so they must carry
+	// the same field set; sample_rate used to be on only one of them.
+	assert.Contains(t, line, "sample_rate")
+	assert.Contains(t, line, "reason")
+}
+
+// TestResampleFailureLogsOncePerRatePair drives the real resample log site,
+// which the key-builder test above does not reach. Without this, a regression
+// dropping the .do() wrapper (back to the per-detection flood this change
+// exists to stop) would not be caught by anything.
+func TestResampleFailureLogsOncePerRatePair(t *testing.T) {
+	logs := captureExportLogs(t)
+	resetExportLogGuards(t)
+
+	a := newExportLogAction(t, t.TempDir(), "clip.mp3", "mp3")
+	// An odd byte count cannot be whole int16 samples, so ResampleBytes rejects
+	// it. The rate is above conf.SampleRate so resolveExportParams takes the
+	// resampling branch rather than passing the clip through.
+	a.pcmData = []byte{0x01, 0x02, 0x03}
+	a.sourceSampleRate = conf.SampleRate * 2
+
+	for range 4 {
+		// resolveExportParams returns no error; a failed resample is reported
+		// through the log line under test and the export continues at the source
+		// rate, which is the behaviour being pinned.
+		_, _, _ = a.resolveExportParams(filepath.Join(t.TempDir(), "clip.mp3"))
+		// resolveExportParams rewrites sourceSampleRate only on success; on the
+		// failure path under test it stays put, so the loop keeps re-entering.
+		a.sourceSampleRate = conf.SampleRate * 2
+	}
+
+	assert.Equal(t, 1, countLines(t, logs.String(), "audio_export_resample"),
+		"a rate pair that cannot resample fails identically every time, so it explains itself once")
+
+	line := logLineContaining(t, logs.String(), "operation=audio_export_resample")
+	assert.NotContains(t, line, "detection_id",
+		"a guarded line must not name the first detection to trip a standing condition")
+}
+
+// TestNormalizedReportsWhetherMeasurementRan pins the field that makes each clip
+// self-describing. gain_db cannot answer this on its own: the default static
+// Export.Gain is 0 and so is a measured gain of 0, so without this flag a dump
+// taken after the one-time skip warning aged out of the log window cannot tell
+// a normalized clip from an unnormalized one.
+func TestNormalizedReportsWhetherMeasurementRan(t *testing.T) {
+	// Captured only to keep the guarded WARNs out of the test output; this test
+	// asserts the returned flag, not the log.
+	captureExportLogs(t)
+	resetExportLogGuards(t)
+
+	// Normalization off: the static gain is used, so nothing was measured.
+	off := newExportLogAction(t, t.TempDir(), "clip.mp3", "mp3")
+	off.Settings.Realtime.Audio.Export.Normalization.Enabled = false
+	_, normalized, err := off.resolveExportGainDB(t.Context(), conf.SampleRate, "mp3")
+	require.NoError(t, err)
+	assert.False(t, normalized, "normalization disabled must not report as normalized")
+
+	// Normalization on with targets audionorm accepts, at a measurable rate:
+	// the measurement runs and the gain comes from it.
+	on := newExportLogAction(t, t.TempDir(), "clip.mp3", "mp3")
+	on.Settings.Realtime.Audio.Export.Normalization.Enabled = true
+	on.Settings.Realtime.Audio.Export.Normalization.TargetLUFS = -23
+	on.Settings.Realtime.Audio.Export.Normalization.TruePeak = -2
+	_, normalized, err = on.resolveExportGainDB(t.Context(), conf.SampleRate, "mp3")
+	require.NoError(t, err)
+	assert.True(t, normalized, "a real loudness measurement must report as normalized")
+}
+
+// TestClipPathFallbackWarnsPerExportType is the hot-reload half of #1373's
+// argument: Export.Type is the value this WARN reports and is changeable from
+// the UI, so a process-wide sync.Once let the first bad value silence every
+// later, different one.
+func TestClipPathFallbackWarnsPerExportType(t *testing.T) {
+	logs := captureExportLogs(t)
+	resetBuildClipPathFallbackOnce()
+	t.Cleanup(resetBuildClipPathFallbackOnce)
+
+	p := &Processor{}
+	settings := &conf.Settings{}
+
+	emit := func(exportType string) {
+		settings.Realtime.Audio.Export.Type = exportType
+		p.buildClipPath(settings, "Turdus merula", 0.82, 0, fallbackTestTime)
+	}
+
+	// Whitespace-only types produce an empty extension, which is the fallback
+	// branch. Two distinct bad values, each repeated.
+	emit("  ")
+	emit("  ")
+	emit("\t")
+
+	assert.Equal(t, 2, countLines(t, logs.String(), "buildClipPath_fallback"),
+		"each distinct bad Export.Type must be reported once; the first must not silence the second")
+	assert.True(t, buildClipPathFallbackWarned())
+}
+
+// TestNoPCMSkipLineNamesSpecies covers the branch where the clip is lost
+// outright, which is the export log where naming the bird matters most. It
+// carried detection_id and clip_name only.
+func TestNoPCMSkipLineNamesSpecies(t *testing.T) {
+	logs := captureExportLogs(t)
+
+	a := newExportLogAction(t, t.TempDir(), "clip.mp3", "mp3")
+	a.pcmData = nil
+	a.species = "eurasian blackbird"
+
+	require.NoError(t, a.Execute(t.Context(), nil))
+
+	// Scoped to the line and asserted key-and-value: a buffer-wide substring
+	// check would pass just as well if the species were emitted under some other
+	// field name, which is not the contract.
+	line := logLineContaining(t, logs.String(), "operation=audio_export_skip")
+	assert.Contains(t, line, `species="eurasian blackbird"`,
+		"the line reporting a lost clip must say which bird was lost")
+}
+
+// TestMQTTNotReadyWarnsPerTopic covers the guard that used to log a per-call
+// topic inside a process-wide sync.Once, so the single line it emitted named a
+// topic that did not generalise. The topic derives from the hot-reloadable
+// Realtime.MQTT.Topic setting.
+func TestMQTTNotReadyWarnsPerTopic(t *testing.T) {
+	logs := captureExportLogs(t)
+
+	p := &Processor{}
+	for range 3 {
+		require.ErrorIs(t, p.PublishMQTT(t.Context(), "birdnet/soundlevel", "{}"), ErrMQTTClientNotReady)
+	}
+	require.ErrorIs(t, p.PublishMQTT(t.Context(), "birdnet-renamed/soundlevel", "{}"), ErrMQTTClientNotReady)
+
+	assert.Equal(t, 2, countLines(t, logs.String(), "publish_mqtt_not_ready"),
+		"one line per topic: repeats stay silent, a renamed topic is explained again")
+	assert.Contains(t, logs.String(), "birdnet-renamed/soundlevel")
+}

--- a/internal/analysis/processor/export_logging_test.go
+++ b/internal/analysis/processor/export_logging_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	audioBuffer "github.com/tphakala/birdnet-go/internal/audiocore/buffer"
+	"github.com/tphakala/birdnet-go/internal/audiocore/clipenc"
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/conf/conftest"
@@ -122,7 +123,7 @@ func TestExecute_SuccessLogNamesNativeEncoder(t *testing.T) {
 
 	out := logs.String()
 	assert.Contains(t, out, "Audio clip saved successfully")
-	assert.Contains(t, out, "encoder="+encoderNativeFLAC,
+	assert.Contains(t, out, "encoder="+clipenc.NativeFLAC,
 		"the success log must name the encoder that wrote the clip")
 	assert.Contains(t, out, "format="+ffmpeg.FormatFLAC)
 	assert.Contains(t, out, "operation=audio_export_success")
@@ -362,7 +363,7 @@ func TestExecute_SuccessLogCarriesBitrateForLossyFormats(t *testing.T) {
 	require.NoError(t, a.Execute(t.Context(), nil))
 
 	out := logs.String()
-	assert.Contains(t, out, "encoder="+encoderNativeAAC)
+	assert.Contains(t, out, "encoder="+clipenc.NativeAAC)
 	assert.Contains(t, out, "bitrate_kbps=96")
 }
 
@@ -381,7 +382,7 @@ func TestExecute_SuccessLogCarriesClampedBitrate(t *testing.T) {
 	require.NoError(t, a.Execute(t.Context(), nil))
 
 	out := logs.String()
-	assert.Contains(t, out, "encoder="+encoderNativeOpus)
+	assert.Contains(t, out, "encoder="+clipenc.NativeOpus)
 	assert.Contains(t, out, "bitrate_kbps=256",
 		"the clamped bitrate explains the file on disk; the configured 320k does not")
 	assert.NotContains(t, out, "bitrate_kbps=320")
@@ -404,7 +405,7 @@ func TestExecute_FailureLogNamesNativeEncoder(t *testing.T) {
 
 	out := logs.String()
 	assert.Contains(t, out, "Audio clip export failed")
-	assert.Contains(t, out, "encoder="+encoderNativeAAC,
+	assert.Contains(t, out, "encoder="+clipenc.NativeAAC,
 		"a failed export must be attributable to the encoder that failed")
 	assert.Contains(t, out, "format="+ffmpeg.FormatAAC)
 	assert.Contains(t, out, "operation=audio_export_failed")
@@ -448,7 +449,7 @@ func TestExecute_FailureLogNamesFFmpeg(t *testing.T) {
 
 	out := logs.String()
 	assert.Contains(t, out, "Audio clip export failed")
-	assert.Contains(t, out, "encoder="+encoderFFmpeg)
+	assert.Contains(t, out, "encoder="+clipenc.FFmpeg)
 	assert.Contains(t, out, "format="+ffmpeg.FormatMP3)
 }
 
@@ -480,7 +481,7 @@ func TestExecute_FailureBeforeGainResolutionOmitsGain(t *testing.T) {
 	// its own gain_db on a Debug line, so a buffer-wide NotContains would break
 	// for the wrong reason the moment the failure point moved past measurement.
 	line := logLineContaining(t, logs.String(), "operation=audio_export_failed")
-	assert.Contains(t, line, "encoder="+encoderNativeFLAC,
+	assert.Contains(t, line, "encoder="+clipenc.NativeFLAC,
 		"the encoder is known before the gain is, so it must still be reported")
 	assert.NotContains(t, line, "gain_db=",
 		"an export that failed before resolving the gain has none to report")
@@ -798,21 +799,21 @@ func TestSelectEncoder_RoutingTable(t *testing.T) {
 		rate       int
 		wantEncode string
 	}{
-		{"wav is always native", "", "", ffmpeg.FormatWAV, conf.SampleRate, encoderNativeWAV},
-		{"flac is always native", "", "", ffmpeg.FormatFLAC, conf.SampleRate, encoderNativeFLAC},
-		{"wav ignores the gates", "native", "native", ffmpeg.FormatWAV, conf.SampleRate, encoderNativeWAV},
-		{"flac ignores the gates", "native", "native", ffmpeg.FormatFLAC, conf.SampleRate, encoderNativeFLAC},
-		{"aac without the gate stays on ffmpeg", "", "", ffmpeg.FormatAAC, conf.SampleRate, encoderFFmpeg},
-		{"opus without the gate stays on ffmpeg", "", "", ffmpeg.FormatOpus, conf.SampleRate, encoderFFmpeg},
-		{"aac with the gate goes native", "native", "", ffmpeg.FormatAAC, conf.SampleRate, encoderNativeAAC},
-		{"opus with the gate goes native", "", "native", ffmpeg.FormatOpus, conf.SampleRate, encoderNativeOpus},
+		{"wav is always native", "", "", ffmpeg.FormatWAV, conf.SampleRate, clipenc.NativeWAV},
+		{"flac is always native", "", "", ffmpeg.FormatFLAC, conf.SampleRate, clipenc.NativeFLAC},
+		{"wav ignores the gates", "native", "native", ffmpeg.FormatWAV, conf.SampleRate, clipenc.NativeWAV},
+		{"flac ignores the gates", "native", "native", ffmpeg.FormatFLAC, conf.SampleRate, clipenc.NativeFLAC},
+		{"aac without the gate stays on ffmpeg", "", "", ffmpeg.FormatAAC, conf.SampleRate, clipenc.FFmpeg},
+		{"opus without the gate stays on ffmpeg", "", "", ffmpeg.FormatOpus, conf.SampleRate, clipenc.FFmpeg},
+		{"aac with the gate goes native", "native", "", ffmpeg.FormatAAC, conf.SampleRate, clipenc.NativeAAC},
+		{"opus with the gate goes native", "", "native", ffmpeg.FormatOpus, conf.SampleRate, clipenc.NativeOpus},
 		// Gated on, but the encoder cannot carry the clip's rate: FFmpeg takes it
 		// rather than the export failing outright.
-		{"aac falls back when the rate is unsupported", "native", "", ffmpeg.FormatAAC, 22050, encoderFFmpeg},
-		{"opus falls back when the rate is unsupported", "", "native", ffmpeg.FormatOpus, 22050, encoderFFmpeg},
+		{"aac falls back when the rate is unsupported", "native", "", ffmpeg.FormatAAC, 22050, clipenc.FFmpeg},
+		{"opus falls back when the rate is unsupported", "", "native", ffmpeg.FormatOpus, 22050, clipenc.FFmpeg},
 		// Neither gate touches the formats FFmpeg owns outright.
-		{"mp3 is always ffmpeg", "native", "native", ffmpeg.FormatMP3, conf.SampleRate, encoderFFmpeg},
-		{"alac is always ffmpeg", "native", "native", ffmpeg.FormatALAC, conf.SampleRate, encoderFFmpeg},
+		{"mp3 is always ffmpeg", "native", "native", ffmpeg.FormatMP3, conf.SampleRate, clipenc.FFmpeg},
+		{"alac is always ffmpeg", "native", "native", ffmpeg.FormatALAC, conf.SampleRate, clipenc.FFmpeg},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			// Not parallel: t.Setenv, and the skip warning uses a package-level Once.

--- a/internal/analysis/processor/export_normalization_e2e_test.go
+++ b/internal/analysis/processor/export_normalization_e2e_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/tphakala/birdnet-go/internal/audiocore/clipenc"
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
@@ -78,7 +79,7 @@ func TestEncodeClip_FFmpegPathNormalizesToTarget(t *testing.T) {
 
 	enc, err := a.encodeClip(t.Context(), conf.SampleRate, ffmpeg.FormatMP3, out)
 	require.NoError(t, err)
-	require.Equal(t, encoderFFmpeg, enc.Encoder, "MP3 has no native encoder; it must go through FFmpeg")
+	require.Equal(t, clipenc.FFmpeg, enc.Encoder, "MP3 has no native encoder; it must go through FFmpeg")
 
 	got := measureLUFS(t, decodeToPCM16(t, ffmpegBin, out))
 
@@ -110,7 +111,7 @@ func TestEncodeClip_WAVAppliesResolvedGain(t *testing.T) {
 
 	enc, err := a.encodeClip(t.Context(), conf.SampleRate, ffmpeg.FormatWAV, out)
 	require.NoError(t, err)
-	require.Equal(t, encoderNativeWAV, enc.Encoder)
+	require.Equal(t, clipenc.NativeWAV, enc.Encoder)
 
 	got := measureLUFS(t, readWAVSamples(t, out))
 	assert.InDelta(t, testTargetLUFS, got, 0.5, "WAV must honour the resolved loudness gain")

--- a/internal/analysis/processor/export_test.go
+++ b/internal/analysis/processor/export_test.go
@@ -1,11 +1,11 @@
 package processor
 
-import "sync"
-
-// resetBuildClipPathFallbackOnce resets the one-shot WARN guard so tests
+// resetBuildClipPathFallbackOnce resets the keyed WARN guard so tests
 // can exercise the fallback path multiple times. Test-only.
+// Cleared rather than reassigned, for the reason spelled out on
+// resetNativeSkipOnce below.
 func resetBuildClipPathFallbackOnce() {
-	buildClipPathFallbackOnce = sync.Once{}
+	clipPathExtFallbackLogged.seen.Clear()
 	buildClipPathFallbackFired.Store(false)
 }
 

--- a/internal/analysis/processor/mqtt.go
+++ b/internal/analysis/processor/mqtt.go
@@ -93,12 +93,18 @@ func (p *Processor) PublishMQTT(ctx context.Context, topic, payload string) erro
 	if client != nil {
 		return client.Publish(ctx, topic, payload)
 	}
-	// Emit a single warn log per process lifetime so operators learn MQTT is
-	// configured but not reachable. Subsequent attempts are silent — the
-	// sentinel is all the caller needs to decide to skip.
-	p.mqttNotReadyWarnOnce.Do(func() {
+	// Emit one warn log per topic so operators learn MQTT is configured but not
+	// reachable. Subsequent attempts on that topic are silent — the sentinel is
+	// all the caller needs to decide to skip.
+	//
+	// Keyed on the topic rather than guarded once per process, because the line
+	// names the topic and a process-wide guard would report a topic the operator
+	// may have since changed away from: the topic derives from the
+	// hot-reloadable Realtime.MQTT.Topic setting. The key space is bounded by
+	// how many distinct topics the configuration has held, not by traffic.
+	p.mqttNotReadyWarnLogged.do(topic, func() {
 		GetLogger().Warn(
-			"MQTT publish suppressed: client not ready (further suppressed publishes are silent)",
+			"MQTT publish suppressed: client not ready (further suppressed publishes on this topic are silent)",
 			logger.String("topic", topic),
 			logger.String("operation", "publish_mqtt_not_ready"))
 	})

--- a/internal/analysis/processor/native_encoder_gate_test.go
+++ b/internal/analysis/processor/native_encoder_gate_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/tphakala/birdnet-go/internal/audiocore/clipenc"
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
@@ -58,7 +59,7 @@ func TestEncodeClip_GateSelectsNativeAAC(t *testing.T) {
 	out := filepath.Join(t.TempDir(), "clip.m4a")
 	encoder, err := a.encodeClip(t.Context(), conf.SampleRate, ffmpeg.FormatAAC, out)
 	require.NoError(t, err)
-	assert.Equal(t, encoderNativeAAC, encoder.Encoder, "the clip must record which encoder ran")
+	assert.Equal(t, clipenc.NativeAAC, encoder.Encoder, "the clip must record which encoder ran")
 
 	assertNonEmptyFileWithMagic(t, out, 4, "ftyp")
 }
@@ -74,7 +75,7 @@ func TestEncodeClip_GateSelectsNativeOpus(t *testing.T) {
 	out := filepath.Join(t.TempDir(), "clip.opus")
 	encoder, err := a.encodeClip(t.Context(), conf.SampleRate, ffmpeg.FormatOpus, out)
 	require.NoError(t, err)
-	assert.Equal(t, encoderNativeOpus, encoder.Encoder)
+	assert.Equal(t, clipenc.NativeOpus, encoder.Encoder)
 
 	assertNonEmptyFileWithMagic(t, out, 0, "OggS")
 }
@@ -105,11 +106,11 @@ func TestEncodeClip_GatesDoNotAffectFLACOrWAV(t *testing.T) {
 
 	flacEncoder, err := a.encodeClip(t.Context(), conf.SampleRate, ffmpeg.FormatFLAC, filepath.Join(dir, "clip.flac"))
 	require.NoError(t, err)
-	assert.Equal(t, encoderNativeFLAC, flacEncoder.Encoder)
+	assert.Equal(t, clipenc.NativeFLAC, flacEncoder.Encoder)
 
 	wavEncoder, err := a.encodeClip(t.Context(), conf.SampleRate, ffmpeg.FormatWAV, filepath.Join(dir, "clip.wav"))
 	require.NoError(t, err)
-	assert.Equal(t, encoderNativeWAV, wavEncoder.Encoder)
+	assert.Equal(t, clipenc.NativeWAV, wavEncoder.Encoder)
 }
 
 // Static Export.Gain must reach the native lossy encoders, not just FLAC.
@@ -120,7 +121,7 @@ func TestEncodeClip_NativeLossyAppliesStaticGain(t *testing.T) {
 	a := newGateTestAction(t, "96k")
 	a.Settings.Realtime.Audio.Export.Gain = -6
 
-	gainDB, err := a.resolveExportGainDB(t.Context(), conf.SampleRate, ffmpeg.FormatAAC)
+	gainDB, _, err := a.resolveExportGainDB(t.Context(), conf.SampleRate, ffmpeg.FormatAAC)
 	require.NoError(t, err)
 	assert.InDelta(t, -6.0, gainDB, 0.001, "static gain must pass through when normalization is off")
 }
@@ -141,7 +142,7 @@ func TestResolveExportGainDB_NormalizationReplacesStaticGain(t *testing.T) {
 	// ceiling nor the +/-30 dB clamp binds and the gain is exactly the distance
 	// from measured to target loudness. That value is not the static -6 dB.
 	measured := measureLUFS(t, a.pcmData)
-	gainDB, err := a.resolveExportGainDB(t.Context(), conf.SampleRate, ffmpeg.FormatAAC)
+	gainDB, _, err := a.resolveExportGainDB(t.Context(), conf.SampleRate, ffmpeg.FormatAAC)
 	require.NoError(t, err)
 	assert.InDelta(t, testTargetLUFS-measured, gainDB, 0.5,
 		"the measured loudness gain must supersede the static gain")
@@ -163,7 +164,7 @@ func TestResolveExportGainDB_OutOfRangeTargetsFallBackToStaticGain(t *testing.T)
 		TruePeak:   testTruePeakDBTP,
 	}
 
-	gainDB, err := a.resolveExportGainDB(t.Context(), conf.SampleRate, ffmpeg.FormatAAC)
+	gainDB, _, err := a.resolveExportGainDB(t.Context(), conf.SampleRate, ffmpeg.FormatAAC)
 	require.NoError(t, err)
 	assert.InDelta(t, -4.0, gainDB, 0.001, "static gain must survive an unusable normalization config")
 }
@@ -189,7 +190,7 @@ func TestEncodeClipFFmpeg_BuildsCompleteExportOptions(t *testing.T) {
 	}
 	a.Settings.Realtime.Audio.FfmpegPath = "/usr/bin/ffmpeg"
 
-	gainDB, err := a.resolveExportGainDB(t.Context(), conf.SampleRate, ffmpeg.FormatMP3)
+	gainDB, _, err := a.resolveExportGainDB(t.Context(), conf.SampleRate, ffmpeg.FormatMP3)
 	require.NoError(t, err)
 	opts := a.buildFFmpegExportOptions(conf.SampleRate, ffmpeg.FormatMP3, "/clips/x.mp3", gainDB)
 
@@ -221,7 +222,7 @@ func TestEncodeClipFFmpeg_StaticGainWithoutNormalization(t *testing.T) {
 	a.Settings.Realtime.Audio.Export.Gain = -2.5
 	a.Settings.Realtime.Audio.FfmpegPath = "/usr/bin/ffmpeg"
 
-	gainDB, err := a.resolveExportGainDB(t.Context(), conf.SampleRate, ffmpeg.FormatMP3)
+	gainDB, _, err := a.resolveExportGainDB(t.Context(), conf.SampleRate, ffmpeg.FormatMP3)
 	require.NoError(t, err)
 	opts := a.buildFFmpegExportOptions(conf.SampleRate, ffmpeg.FormatMP3, "/clips/x.mp3", gainDB)
 
@@ -302,8 +303,8 @@ func TestEncodeClip_UltrasonicRatesUnaffectedByLossyGates(t *testing.T) {
 			wantEncoder string
 			readRate    func(*testing.T, string) int
 		}{
-			{ffmpeg.FormatWAV, "wav", encoderNativeWAV, wavSampleRate},
-			{ffmpeg.FormatFLAC, "flac", encoderNativeFLAC, flacSampleRate},
+			{ffmpeg.FormatWAV, "wav", clipenc.NativeWAV, wavSampleRate},
+			{ffmpeg.FormatFLAC, "flac", clipenc.NativeFLAC, flacSampleRate},
 		} {
 			t.Run(fmt.Sprintf("%s_%dHz", tc.format, rate), func(t *testing.T) {
 				a := newGateTestAction(t, "96k")
@@ -342,7 +343,7 @@ func TestEncodeClip_UltrasonicRatesWithNormalization(t *testing.T) {
 
 			// Confirm normalization actually engages rather than silently
 			// returning a zero gain, which is what a sub-gate-length clip would do.
-			gainDB, err := a.resolveExportGainDB(t.Context(), rate, ffmpeg.FormatFLAC)
+			gainDB, _, err := a.resolveExportGainDB(t.Context(), rate, ffmpeg.FormatFLAC)
 			require.NoError(t, err)
 			assert.Greater(t, math.Abs(gainDB), 0.01,
 				"normalization must produce a real gain at %d Hz, not the no-op zero "+
@@ -352,7 +353,7 @@ func TestEncodeClip_UltrasonicRatesWithNormalization(t *testing.T) {
 			out := filepath.Join(dir, "clip.flac")
 			encoder, err := a.encodeClip(t.Context(), rate, ffmpeg.FormatFLAC, out)
 			require.NoError(t, err, "normalized FLAC export must work at %d Hz", rate)
-			assert.Equal(t, encoderNativeFLAC, encoder.Encoder)
+			assert.Equal(t, clipenc.NativeFLAC, encoder.Encoder)
 			assert.Equal(t, rate, flacSampleRate(t, out))
 
 			// Asserting the planned gain is not enough: a typo passing GainDB 0

--- a/internal/analysis/processor/native_normalization_test.go
+++ b/internal/analysis/processor/native_normalization_test.go
@@ -16,6 +16,7 @@ import (
 	goflac "github.com/tphakala/go-flac/pcm"
 
 	"github.com/tphakala/birdnet-go/internal/audiocore/audionorm"
+	"github.com/tphakala/birdnet-go/internal/audiocore/clipenc"
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/audiocore/flac"
 	"github.com/tphakala/birdnet-go/internal/audiocore/pcmgain"
@@ -393,7 +394,7 @@ func TestAudionormSupportsTargets(t *testing.T) {
 
 // TestEncodeClipSelectsNativeNormalization drives the real encodeClip switch with
 // normalization enabled, proving FLAC routes to the native audionorm path (returns
-// encoderNativeFLAC, not FFmpeg) AND that the static Export.Gain is NOT applied on
+// clipenc.NativeFLAC, not FFmpeg) AND that the static Export.Gain is NOT applied on
 // top of the loudness gain (FFmpeg gives normalization precedence over gain, and
 // the native path must match).
 func TestEncodeClipSelectsNativeNormalization(t *testing.T) {
@@ -411,7 +412,7 @@ func TestEncodeClipSelectsNativeNormalization(t *testing.T) {
 	out := filepath.Join(t.TempDir(), "clip.flac")
 	enc, err := a.encodeClip(t.Context(), conf.SampleRate, ffmpeg.FormatFLAC, out)
 	require.NoError(t, err)
-	assert.Equal(t, encoderNativeFLAC, enc.Encoder, "must select the native FLAC encoder, not FFmpeg")
+	assert.Equal(t, clipenc.NativeFLAC, enc.Encoder, "must select the native FLAC encoder, not FFmpeg")
 
 	data, err := os.ReadFile(out) //nolint:gosec // test-controlled temp path
 	require.NoError(t, err)
@@ -445,7 +446,7 @@ func TestEncodeClipFLACWithoutNormalization(t *testing.T) {
 	out := filepath.Join(t.TempDir(), "clip.flac")
 	enc, err := a.encodeClip(t.Context(), conf.SampleRate, ffmpeg.FormatFLAC, out)
 	require.NoError(t, err)
-	assert.Equal(t, encoderNativeFLAC, enc.Encoder, "FLAC must encode natively with no env gate and no FFmpeg")
+	assert.Equal(t, clipenc.NativeFLAC, enc.Encoder, "FLAC must encode natively with no env gate and no FFmpeg")
 
 	data, err := os.ReadFile(out) //nolint:gosec // test-controlled temp path
 	require.NoError(t, err)
@@ -485,7 +486,7 @@ func TestEncodeClipFLACNormalizationSkipped(t *testing.T) {
 	out := filepath.Join(t.TempDir(), "clip.flac")
 	enc, err := a.encodeClip(t.Context(), conf.SampleRate, ffmpeg.FormatFLAC, out)
 	require.NoError(t, err)
-	assert.Equal(t, encoderNativeFLAC, enc.Encoder, "out-of-range normalization must still encode natively, never FFmpeg")
+	assert.Equal(t, clipenc.NativeFLAC, enc.Encoder, "out-of-range normalization must still encode natively, never FFmpeg")
 
 	data, err := os.ReadFile(out) //nolint:gosec // test-controlled temp path
 	require.NoError(t, err)

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -53,45 +53,45 @@ const MinJobQueueGracePeriod = 500 * time.Millisecond
 
 // Processor represents the main processing unit for audio analysis.
 type Processor struct {
-	Settings             *conf.Settings
-	Ds                   datastore.Interface           // Legacy - to be removed after migration
-	Repo                 datastore.DetectionRepository // New - preferred for detection operations
-	Bn                   *classifier.Orchestrator
-	log                  logger.Logger // Logger inherited from analysis package with "processor" child module
-	BwClient             *birdweather.BwClient
-	bwClientMutex        sync.RWMutex // Mutex to protect BwClient access
-	MqttClient           mqtt.Client
-	mqttMutex            sync.RWMutex // Mutex to protect MQTT client access
-	mqttNotReadyWarnOnce sync.Once    // Ensures the "client not ready" warning logs at most once per process to avoid flood
-	BirdImageCache       *imageprovider.BirdImageCache
-	EventTracker         *EventTracker
-	eventTrackerMu       sync.RWMutex            // Mutex to protect EventTracker access
-	NewSpeciesTracker    *species.SpeciesTracker // Tracks new species detections
-	speciesTrackerMu     sync.RWMutex            // Mutex to protect NewSpeciesTracker access
-	lastSyncAttempt      time.Time               // Last time sync was attempted
-	syncMutex            sync.Mutex              // Mutex to protect sync operations
-	syncInProgress       atomic.Bool             // Flag to prevent overlapping syncs
-	LastDogDetection     map[string]time.Time    // keep track of dog barks per audio source
-	LastHumanDetection   map[string]time.Time    // keep track of human vocal per audio source
-	Metrics              *observability.Metrics
-	DynamicThresholds    map[string]*DynamicThreshold
-	thresholdsMutex      sync.RWMutex        // Mutex to protect access to DynamicThresholds
-	pendingResets        map[string]struct{} // Species names pending reset, protected by thresholdsMutex
-	pendingResetAll      bool                // True if a full reset is pending, protected by thresholdsMutex
-	pendingDetections    map[string]PendingDetection
-	pendingMutex         sync.RWMutex // RWMutex to protect access to pendingDetections (RLock for snapshots)
-	dogDetectionMutex    sync.Mutex
-	detectionMutex       sync.RWMutex // Mutex to protect LastDogDetection and LastHumanDetection maps
-	controlChan          chan string
-	JobQueue             *jobqueue.JobQueue // Queue for managing job retries
-	workerCancel         context.CancelFunc // Function to cancel worker goroutines
-	thresholdsCtx        context.Context    // Context for threshold persistence/cleanup goroutines
-	thresholdsCancel     context.CancelFunc // Function to cancel threshold persistence/cleanup goroutines
-	flusherCtx           context.Context    // Context for pending detections flusher goroutine
-	flusherCancel        context.CancelFunc // Function to cancel flusher goroutine
-	preRenderer          PreRendererSubmit  // Spectrogram pre-renderer for background generation
-	preRendererOnce      sync.Once          // Ensures pre-renderer is initialized only once
-	startOnce            sync.Once          // Ensures Start() is called only once
+	Settings               *conf.Settings
+	Ds                     datastore.Interface           // Legacy - to be removed after migration
+	Repo                   datastore.DetectionRepository // New - preferred for detection operations
+	Bn                     *classifier.Orchestrator
+	log                    logger.Logger // Logger inherited from analysis package with "processor" child module
+	BwClient               *birdweather.BwClient
+	bwClientMutex          sync.RWMutex // Mutex to protect BwClient access
+	MqttClient             mqtt.Client
+	mqttMutex              sync.RWMutex // Mutex to protect MQTT client access
+	mqttNotReadyWarnLogged onceByKey    // Emits the "client not ready" warning at most once per topic to avoid flood
+	BirdImageCache         *imageprovider.BirdImageCache
+	EventTracker           *EventTracker
+	eventTrackerMu         sync.RWMutex            // Mutex to protect EventTracker access
+	NewSpeciesTracker      *species.SpeciesTracker // Tracks new species detections
+	speciesTrackerMu       sync.RWMutex            // Mutex to protect NewSpeciesTracker access
+	lastSyncAttempt        time.Time               // Last time sync was attempted
+	syncMutex              sync.Mutex              // Mutex to protect sync operations
+	syncInProgress         atomic.Bool             // Flag to prevent overlapping syncs
+	LastDogDetection       map[string]time.Time    // keep track of dog barks per audio source
+	LastHumanDetection     map[string]time.Time    // keep track of human vocal per audio source
+	Metrics                *observability.Metrics
+	DynamicThresholds      map[string]*DynamicThreshold
+	thresholdsMutex        sync.RWMutex        // Mutex to protect access to DynamicThresholds
+	pendingResets          map[string]struct{} // Species names pending reset, protected by thresholdsMutex
+	pendingResetAll        bool                // True if a full reset is pending, protected by thresholdsMutex
+	pendingDetections      map[string]PendingDetection
+	pendingMutex           sync.RWMutex // RWMutex to protect access to pendingDetections (RLock for snapshots)
+	dogDetectionMutex      sync.Mutex
+	detectionMutex         sync.RWMutex // Mutex to protect LastDogDetection and LastHumanDetection maps
+	controlChan            chan string
+	JobQueue               *jobqueue.JobQueue // Queue for managing job retries
+	workerCancel           context.CancelFunc // Function to cancel worker goroutines
+	thresholdsCtx          context.Context    // Context for threshold persistence/cleanup goroutines
+	thresholdsCancel       context.CancelFunc // Function to cancel threshold persistence/cleanup goroutines
+	flusherCtx             context.Context    // Context for pending detections flusher goroutine
+	flusherCancel          context.CancelFunc // Function to cancel flusher goroutine
+	preRenderer            PreRendererSubmit  // Spectrogram pre-renderer for background generation
+	preRendererOnce        sync.Once          // Ensures pre-renderer is initialized only once
+	startOnce              sync.Once          // Ensures Start() is called only once
 	// SSE related fields
 	SSEBroadcaster      func(note *datastore.Note, birdImage *imageprovider.BirdImage) error // Function to broadcast detection via SSE
 	sseBroadcasterMutex sync.RWMutex                                                         // Mutex to protect SSE broadcaster access
@@ -1404,18 +1404,25 @@ func (p *Processor) generateClipNameWithDuration(settings *conf.Settings, scient
 	return p.buildClipPath(settings, scientificName, confidence, durationSeconds, detectionTime)
 }
 
-// buildClipPathFallbackOnce guards the one-shot WARN log emitted when
-// buildClipPath falls back to a wav extension because Export.Type produced
-// an empty GetFileExtension result. Post fix this branch should be
-// unreachable - the WARN exists purely as a defense-in-depth signal that a
-// previously unknown code path is writing extension-less clip paths to the
-// DB (see GitHub #2810, #2814).
+// buildClipPathFallbackFired records that the fallback branch below has been
+// taken at least once, for the test helper. It is set outside the log guard on
+// purpose; see the comment at the assignment. The guard itself is
+// clipPathExtFallbackLogged (actions_database.go), keyed on the offending
+// Export.Type.
 //
-//nolint:gochecknoglobals // one-shot WARN guard for defense-in-depth fallback
-var (
-	buildClipPathFallbackOnce  sync.Once
-	buildClipPathFallbackFired atomic.Bool
-)
+// buildClipPath falls back to a wav extension when Export.Type produces an
+// empty GetFileExtension result. Post fix this branch should be unreachable -
+// the WARN exists purely as a defense-in-depth signal that a previously unknown
+// code path is writing extension-less clip paths to the DB (see GitHub #2810,
+// #2814).
+//
+// Keyed rather than once-per-process because Export.Type is hot-reloadable and
+// is the very value the WARN reports. A bare sync.Once let the first bad value
+// silence every later, different one, so an operator who fixed one typo and
+// introduced another would get silence instead of the second warning.
+//
+//nolint:gochecknoglobals // paired with the log-flood guard, see above
+var buildClipPathFallbackFired atomic.Bool
 
 // buildClipPath constructs a clip file path with optional duration suffix.
 // When durationSeconds is 0, the duration suffix is omitted.
@@ -1431,8 +1438,13 @@ func (p *Processor) buildClipPath(settings *conf.Settings, scientificName string
 	// only Type would otherwise leak into the filename as a ". " suffix.
 	fileType := convert.GetFileExtension(strings.TrimSpace(rawExportType))
 	if fileType == "" {
-		buildClipPathFallbackOnce.Do(func() {
-			buildClipPathFallbackFired.Store(true)
+		// Stored outside the guard: onceByKey marks the key BEFORE running emit,
+		// so a concurrent second caller returns while the first is still inside
+		// the closure, and a flag set in there would read as false for a branch
+		// that had already been taken. Set here it means exactly what its reader
+		// wants to know, "the fallback ran", and cannot race the guard.
+		buildClipPathFallbackFired.Store(true)
+		clipPathExtFallbackLogged.do(rawExportType, func() {
 			GetLogger().Warn("audio export type produced empty file extension, falling back to wav",
 				logger.String("export_type", rawExportType),
 				logger.String("component", "processor"),
@@ -2230,16 +2242,14 @@ func (p *Processor) buildSaveAudioAction(det *Detections, detectionCtx *Detectio
 	// mechanism picks it up once the buffer has caught up to captureEndTime.
 	// Only take this path when BufferMgr is available; if it is nil the
 	// eager read below will produce a proper error log and no-op action.
-	captureEndTime := win.ReadyAt
-	if p.BufferMgr != nil && captureEndTime.After(time.Now()) {
+	// Every branch below returns the same action differing only in how the PCM
+	// is obtained, so the shared fields are built once. Restating them per branch
+	// means every newly added field has to be repeated in all three, and a field
+	// missed on one branch is invisible until that branch is exercised.
+	base := func() *SaveAudioAction {
 		return &SaveAudioAction{
 			Settings:         settings,
 			ClipName:         det.Result.ClipName,
-			bufferMgr:        p.BufferMgr,
-			sourceID:         det.Result.AudioSource.ID,
-			beginTime:        det.Result.BeginTime,
-			duration:         captureLength,
-			readyAt:          captureEndTime,
 			sourceSampleRate: det.Result.AudioSource.SampleRate,
 			modelName:        det.Result.Model.Name,
 			species:          strings.ToLower(det.Result.Species.CommonName),
@@ -2248,6 +2258,17 @@ func (p *Processor) buildSaveAudioAction(det *Detections, detectionCtx *Detectio
 			DetectionCtx:     detectionCtx,
 			CorrelationID:    det.CorrelationID,
 		}
+	}
+
+	captureEndTime := win.ReadyAt
+	if p.BufferMgr != nil && captureEndTime.After(time.Now()) {
+		a := base()
+		a.bufferMgr = p.BufferMgr
+		a.sourceID = det.Result.AudioSource.ID
+		a.beginTime = det.Result.BeginTime
+		a.duration = captureLength
+		a.readyAt = captureEndTime
+		return a
 	}
 
 	// Read PCM data from the capture buffer NOW, while the data is still in the
@@ -2264,31 +2285,12 @@ func (p *Processor) buildSaveAudioAction(det *Detections, detectionCtx *Detectio
 			logger.Int("duration_seconds", captureLength),
 			logger.String("operation", "capture_buffer_read_for_export"))
 		// Return an action with nil pcmData; Execute() will be a no-op
-		return &SaveAudioAction{
-			Settings:         settings,
-			ClipName:         det.Result.ClipName,
-			sourceSampleRate: det.Result.AudioSource.SampleRate,
-			modelName:        det.Result.Model.Name,
-			species:          strings.ToLower(det.Result.Species.CommonName),
-			NoteID:           det.Result.ID, // May be 0 here; updated after DB save via DetectionCtx
-			PreRenderer:      p.preRenderer,
-			DetectionCtx:     detectionCtx,
-			CorrelationID:    det.CorrelationID,
-		}
+		return base()
 	}
 
-	return &SaveAudioAction{
-		Settings:         settings,
-		ClipName:         det.Result.ClipName,
-		pcmData:          pcmData,
-		sourceSampleRate: det.Result.AudioSource.SampleRate,
-		modelName:        det.Result.Model.Name,
-		species:          strings.ToLower(det.Result.Species.CommonName),
-		NoteID:           det.Result.ID, // May be 0 here; updated after DB save via DetectionCtx
-		PreRenderer:      p.preRenderer,
-		DetectionCtx:     detectionCtx,
-		CorrelationID:    det.CorrelationID,
-	}
+	a := base()
+	a.pcmData = pcmData
+	return a
 }
 
 // readCaptureSegment reads PCM data from the audiocore capture buffer.

--- a/internal/api/v2/media/media.go
+++ b/internal/api/v2/media/media.go
@@ -19,6 +19,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/audiocore/audiotemp"
+	"github.com/tphakala/birdnet-go/internal/audiocore/clipenc"
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/repository"
@@ -26,6 +27,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/privacy"
 	"github.com/tphakala/birdnet-go/internal/securefs"
 	"github.com/tphakala/birdnet-go/internal/spectrogram"
 	"golang.org/x/sync/singleflight"
@@ -836,6 +838,59 @@ func (c *Handler) ServeAudioByID(ctx echo.Context) error {
 	return nil
 }
 
+// processedAudioFormat is what the two ProcessAudioToFile calls hand to FFmpeg.
+// Unlike the clip-extraction endpoint, neither takes a format from the request:
+// both write a temp .wav so FFmpeg can seek back and fix the RIFF chunk sizes.
+// It is the transcode's output, which is what a transcode failure needs to
+// report, not necessarily the endpoint's own response type (the spectrogram
+// endpoint goes on to render a PNG from it; its operation tag says which is
+// which). Named rather than inlined so the log field cannot silently disagree
+// with the temp-file suffix it describes.
+const processedAudioFormat = "wav"
+
+// logTranscodeFailure records which encoder ran and the validated request
+// parameters that shaped it. HandleError cannot: handleErrorInternal logs a
+// fixed field set and does not surface an EnhancedError's Context, so without
+// this line a transcode that fails only for one format, or only with a filter
+// chain attached, is invisible in the log file.
+//
+// encoder is recorded for the same reason the clip export records it. The
+// compound case is the point: with a native encoder gate on, a clip written by
+// go-aac can later be re-encoded by FFmpeg through these endpoints, so two
+// encoders touch one file and until now only the first was ever named.
+//
+// The error is scrubbed rather than logged raw, matching what apicore does to
+// the same value a statement later. An FFmpeg failure wraps the command's
+// stderr, which names the absolute input path, so the raw string carries the
+// operator's account name and directory layout; emitting it here unscrubbed
+// would defeat the redaction HandleError performs on the identical error.
+//
+// One helper rather than three copies: all three FFmpeg entry points in this
+// file (ExtractClip plus the two ProcessAudioToFile sites) fail the same way and
+// need the same fields, and a fourth transcode path added later has an obvious
+// thing to call.
+func (c *Handler) logTranscodeFailure(noteID, operation, format string, filters *ffmpeg.AudioFilters, err error) {
+	// 5 unconditional fields plus the 3 filter fields.
+	fields := make([]logger.Field, 0, 8)
+	fields = append(fields,
+		logger.String("note_id", noteID),
+		logger.String("encoder", clipenc.FFmpeg),
+		logger.String("format", format),
+		logger.String("error", privacy.ScrubMessage(err.Error())),
+	)
+	// nil means the request asked for no processing at all, which is itself the
+	// answer to "did a filter cause this"; logging three zero values instead
+	// would read as "filters were configured and were all off".
+	if filters != nil {
+		fields = append(fields,
+			logger.Float64("gain_db", filters.GainDB),
+			logger.Bool("normalize", filters.Normalize),
+			logger.String("denoise", filters.Denoise))
+	}
+	fields = append(fields, logger.String("operation", operation))
+	c.LogErrorIfEnabled("Audio transcode failed", fields...)
+}
+
 // ExtractAudioClipByID extracts a time range from an audio clip and returns the
 // re-encoded segment. Requires authentication.
 //
@@ -946,6 +1001,7 @@ func (c *Handler) ExtractAudioClipByID(ctx echo.Context) error {
 		if ctx.Request().Context().Err() != nil {
 			return nil // Client disconnected
 		}
+		c.logTranscodeFailure(noteID, "media_clip_transcode_failed", req.Format, filters, err)
 		return c.HandleError(ctx, err, "Failed to extract audio clip", http.StatusInternalServerError)
 	}
 
@@ -1087,6 +1143,7 @@ func (c *Handler) ProcessAudioByID(ctx echo.Context) error {
 		if ctx.Request().Context().Err() != nil {
 			return nil // Client disconnected
 		}
+		c.logTranscodeFailure(noteID, "media_processed_audio_failed", processedAudioFormat, &filters, err)
 		return c.HandleError(ctx, err, "Failed to process audio", http.StatusInternalServerError)
 	}
 
@@ -1204,6 +1261,7 @@ func (c *Handler) ProcessedSpectrogramByID(ctx echo.Context) error {
 		if ctx.Request().Context().Err() != nil {
 			return nil // Client disconnected
 		}
+		c.logTranscodeFailure(noteID, "media_processed_spectrogram_failed", processedAudioFormat, &filters, err)
 		return c.HandleError(ctx, err, "Failed to process audio", http.StatusInternalServerError)
 	}
 

--- a/internal/api/v2/media/media.go
+++ b/internal/api/v2/media/media.go
@@ -878,8 +878,9 @@ func (c *Handler) logTranscodeFailure(noteID, operation, format string, filters 
 		logger.String("format", format),
 		logger.String("error", privacy.ScrubMessage(err.Error())),
 	)
-	// nil means the request asked for no processing at all, which is itself the
-	// answer to "did a filter cause this"; logging three zero values instead
+	// nil means the request asked for no FILTER processing; the transcode itself
+	// still ran. That distinction is the answer to "did a filter cause this",
+	// so the fields are omitted rather than logged as three zero values, which
 	// would read as "filters were configured and were all off".
 	if filters != nil {
 		fields = append(fields,

--- a/internal/api/v2/system/events.go
+++ b/internal/api/v2/system/events.go
@@ -36,6 +36,12 @@ var noiseOperations = []string{
 	"dog_bark_filter",
 	"privacy_filter",
 	"audio_export_success",
+	// Routine per-upload success chatter on a BirdWeather-enabled install, i.e.
+	// one INFO event per detection. Listed for the same reason as its sibling
+	// audio_export_success directly above: both report that a normal encode
+	// succeeded, which is not an operational event. The matching failure tags
+	// are deliberately absent, so a failed upload still surfaces.
+	"birdweather_soundscape_encode",
 	"process_detections_summary",
 }
 

--- a/internal/audiocore/clipenc/clipenc.go
+++ b/internal/audiocore/clipenc/clipenc.go
@@ -1,0 +1,37 @@
+// Package clipenc holds the encoder identity tags recorded in the audio export
+// logs, so that "encoder=" means the same thing on every path that writes or
+// re-encodes audio and one grep answers the question across all of them.
+//
+// The tags used to be private constants in internal/analysis/processor, which
+// covered the detection clip export only. The sibling paths (the BirdWeather
+// soundscape upload and the on-demand clip transcode in the media API) fail
+// independently of it, so a report of "BirdWeather uploads stopped working"
+// produced no log line naming the encoder involved, and the triage that
+// attribution makes possible for saved clips was unavailable for uploads.
+//
+// This is a leaf package with no imports on purpose. The obvious alternative
+// homes both cost more than they are worth for five strings: internal/conf
+// documents its native-encoder gate file as scaffolding with a planned
+// deletion, and the tags outlive the gate; internal/audiocore/ffmpeg already
+// exports the sibling format constants but transitively pulls in datastore,
+// telemetry, notification and alerting, none of which internal/birdweather
+// depends on today.
+//
+// Deliberately limited to the tags. The routing that picks between them
+// (selectEncoder in the processor) stays where it is until the native AAC/Opus
+// gate is removed and the branching simplifies, so it is moved once rather than
+// twice. These names survive that removal unchanged.
+package clipenc
+
+const (
+	// FFmpeg is the external ffmpeg binary.
+	FFmpeg = "ffmpeg"
+	// NativeWAV is the in-tree WAV writer.
+	NativeWAV = "native-wav"
+	// NativeFLAC is the in-tree go-flac encoder.
+	NativeFLAC = "native-flac"
+	// NativeAAC is the in-tree go-aac encoder (with go-m4a for .m4a).
+	NativeAAC = "native-aac"
+	// NativeOpus is the in-tree go-opus encoder.
+	NativeOpus = "native-opus"
+)

--- a/internal/birdweather/birdweather_client.go
+++ b/internal/birdweather/birdweather_client.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/alerting"
+	"github.com/tphakala/birdnet-go/internal/audiocore/clipenc"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/errors"
@@ -1038,10 +1039,18 @@ func (b *BwClient) encodeAudioForUpload(pcmData []byte, timestamp string) (*audi
 func logFLACEncodingError(err error) {
 	log := GetLogger()
 
+	// Both branches name the encoder and carry an operation tag, matching the
+	// success line, so a failed upload is attributable to an encoder the same way
+	// a failed clip export is.
+	fields := []logger.Field{
+		logger.Error(err),
+		logger.String("encoder", clipenc.NativeFLAC),
+		logger.String("operation", "birdweather_soundscape_encode_failed"),
+	}
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		log.Warn("FLAC encoding timed out or was cancelled", logger.Error(err))
+		log.Warn("FLAC encoding timed out or was cancelled", fields...)
 	} else {
-		log.Error("Failed to encode/normalize PCM to FLAC", logger.Error(err))
+		log.Error("Failed to encode/normalize PCM to FLAC", fields...)
 	}
 }
 

--- a/internal/birdweather/encode_attribution_test.go
+++ b/internal/birdweather/encode_attribution_test.go
@@ -1,0 +1,91 @@
+package birdweather
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore/clipenc"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// captureUploadLogs redirects the global logger to a buffer at Info level, which
+// is the level a default support dump actually contains. Anything the tests here
+// require must therefore be emitted at Info or above; a field only present at
+// Debug is not available to triage. It swaps process-wide state, so tests using
+// it must not run with t.Parallel().
+func captureUploadLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+
+	var buf bytes.Buffer
+	capture := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
+	cl, err := logger.NewCentralLogger(
+		&logger.LoggingConfig{
+			Console:      &logger.ConsoleOutput{Enabled: false},
+			FileOutput:   &logger.FileOutput{Enabled: false},
+			DefaultLevel: "info",
+		},
+		capture,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, cl.Close()) })
+
+	prev := logger.Global()
+	logger.SetGlobal(cl)
+	t.Cleanup(func() { logger.SetGlobal(prev) })
+
+	return &buf
+}
+
+// TestEncodeWithNativeFLAC_LogsEncoderAttribution covers the gap that made
+// "my BirdWeather uploads are too quiet" unanswerable from a default-level
+// dump, even though the same question was answerable for saved clips: the
+// upload path recorded neither the encoder that ran nor the gain it applied
+// anywhere above Debug.
+func TestEncodeWithNativeFLAC_LogsEncoderAttribution(t *testing.T) {
+	logs := captureUploadLogs(t)
+
+	client := &BwClient{Settings: &conf.Settings{}}
+	res, err := client.encodeWithNativeFLAC(sinePCM(conf.SampleRate, -30), testTimestamp)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	out := logs.String()
+	assert.Contains(t, out, "encoder="+clipenc.NativeFLAC,
+		"the upload log must name the encoder, using the same vocabulary as the clip export path")
+	// Asserted by value, not just by key: a key-only check passes on a garbage
+	// value, and the point of the field is that it reports the gain actually
+	// applied. -30 dBFS input normalised toward -23 LUFS yields a positive gain.
+	gainLine := logLineWith(t, out, "encoder=native-flac")
+	assert.Regexp(t, `gain_db=[0-9]+\.[0-9]+`, gainLine,
+		"gain must be visible at Info with a real value; at Debug it is absent from a default dump")
+	// Exact match, not a prefix: birdweather_soundscape_encode is a strict
+	// prefix of birdweather_soundscape_encode_failed, the failure tag emitted
+	// from birdweather_client.go, so a Contains on the bare name cannot tell the
+	// two apart.
+	assert.Contains(t, out, "operation=birdweather_soundscape_encode\n",
+		"the success line must carry the tag that noiseOperations filters on")
+	assert.NotContains(t, out, "birdweather_soundscape_encode_failed",
+		"a successful encode must not emit the failure tag")
+}
+
+// logLineWith returns the single captured log line containing marker, failing
+// if none or more than one matches. Assertions scoped to a line cannot be
+// satisfied by a value that happens to appear on some other line.
+func logLineWith(t *testing.T, logs, marker string) string {
+	t.Helper()
+	var found string
+	for line := range strings.SplitSeq(logs, "\n") {
+		if strings.Contains(line, marker) {
+			require.Empty(t, found, "marker %q matched more than one line", marker)
+			found = line
+		}
+	}
+	require.NotEmpty(t, found, "no log line contains %q; captured:\n%s", marker, logs)
+	return found
+}

--- a/internal/birdweather/encode_native.go
+++ b/internal/birdweather/encode_native.go
@@ -9,6 +9,7 @@ import (
 	"context"
 
 	"github.com/tphakala/birdnet-go/internal/audiocore/audionorm"
+	"github.com/tphakala/birdnet-go/internal/audiocore/clipenc"
 	"github.com/tphakala/birdnet-go/internal/audiocore/flac"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
@@ -51,6 +52,7 @@ func (b *BwClient) encodeWithNativeFLAC(pcmData []byte, timestamp string) (*audi
 			Component("birdweather").
 			Category(errors.CategoryAudio).
 			Context("operation", "native_flac_measure").
+			Context("encoder", clipenc.NativeFLAC).
 			Context("timestamp", timestamp).
 			Build()
 	}
@@ -95,8 +97,28 @@ func (b *BwClient) encodeWithNativeFLAC(pcmData []byte, timestamp string) (*audi
 			Build()
 	}
 
+	// encoder and gain_db are on the Info line, not just the Debug one above, so
+	// that a default-level support dump answers for uploads the two questions it
+	// already answers for saved clips: which encoder produced the audio, and how
+	// much gain it applied ("my BirdWeather uploads are too quiet"). The Debug
+	// line keeps the full measurement detail.
+	//
+	// operation is what lets the system-events feed treat this line the way it
+	// already treats its sibling. An untagged entry is not unclassifiable, it
+	// simply falls through isNoiseEntry (internal/api/v2/system/events.go) as
+	// "not noise" and is emitted; so before this tag existed, every soundscape
+	// upload showed up in /api/v2/system/events/operational as an INFO event,
+	// once per detection. With the tag, the operation is listed in
+	// noiseOperations alongside audio_export_success, so routine success chatter
+	// is filtered out while birdweather_soundscape_encode_failed (emitted by
+	// logFLACEncodingError in birdweather_client.go) still surfaces. The match is
+	// exact, so listing this tag does not also suppress that one despite the
+	// prefix relationship.
 	log.Info("Encoded audio to FLAC format (native go-flac)",
 		logger.String("timestamp", timestamp),
-		logger.Int("bytes", buf.Len()))
+		logger.String("encoder", clipenc.NativeFLAC),
+		logger.Float64("gain_db", gainDB),
+		logger.Int("bytes", buf.Len()),
+		logger.String("operation", "birdweather_soundscape_encode"))
 	return &audioEncodingResult{buffer: buf, ext: "flac"}, nil
 }

--- a/internal/conf/support_env.go
+++ b/internal/conf/support_env.go
@@ -1,0 +1,52 @@
+package conf
+
+import "slices"
+
+// supportEnvAllowlist names the environment variables a support dump may
+// capture verbatim, together with their values.
+//
+// Why this list exists at all: the native-encoder gates are env-only and are
+// read live per export, so nothing in config.yaml records them. A dump that
+// arrives without a clip export inside the captured log window therefore cannot
+// answer whether the reporter was running a native encoder or FFmpeg, which is
+// the first thing to establish while the gate is still opt-in.
+//
+// Coverage before this was partial and asymmetric: the deployment collector
+// reads unit-file Environment= lines, so a systemd user who set a gate in their
+// unit file might have it captured, while Docker and compose users, who set it
+// with -e or in the compose file, had no coverage whatsoever.
+//
+// Why an allowlist and not a BIRDNET_ prefix scan: the process environment can
+// hold credentials, and a future BIRDNET_-prefixed variable could carry one. A
+// prefix scan would capture it the day it is added, silently, in a file the
+// user uploads to a third party. This list only grows by someone deciding a
+// specific variable is safe to disclose.
+//
+// The entries here are all "native" or unset, so they are not secrets. Add a
+// future BIRDNET_* runtime gate here so it shows up in dumps without needing
+// the collector changed again; do not add anything that identifies the
+// operator or their location (the coordinate and locale variables in env.go are
+// deliberately absent), and do not add anything already recorded in
+// config.yaml, which the dump captures separately.
+//
+// Unexported and returned by copy rather than exported directly: this list is a
+// privacy control, deciding what gets written into a file the user uploads to a
+// third party. An exported slice can be appended to or overwritten in place by
+// any package in the tree, so the "only grows by someone deciding a specific
+// variable is safe to disclose" rule above would be enforced by nothing.
+//
+//nolint:gochecknoglobals // package-level allowlist, never mutated after init
+var supportEnvAllowlist = []string{
+	EnvNativeAACEncoder,
+	EnvNativeOpusEncoder,
+	// Historical: no longer read by any code path, because native FLAC is now
+	// unconditional. Captured anyway, so a dump distinguishes "the operator set
+	// nothing" from "the operator set a variable that stopped doing anything",
+	// which otherwise look identical from the outside.
+	"BIRDNET_FLAC_ENCODER",
+}
+
+// SupportEnvAllowlist returns a copy of the environment variables a support dump
+// may capture verbatim. A copy, so no caller can widen what a dump discloses;
+// see supportEnvAllowlist for the full rationale.
+func SupportEnvAllowlist() []string { return slices.Clone(supportEnvAllowlist) }

--- a/internal/spectrogram/generator.go
+++ b/internal/spectrogram/generator.go
@@ -289,8 +289,8 @@ func (g *Generator) GenerateFromFile(ctx context.Context, audioPath, outputPath 
 	}
 
 	g.log().Debug("Starting spectrogram generation from file",
-		logger.String("audio_path", audioPath),
-		logger.String("output_path", outputPath),
+		logger.String("audio_path", g.relPath(audioPath)),
+		logger.String("output_path", g.relPath(outputPath)),
 		logger.Int("width", width),
 		logger.Bool("raw", raw),
 		logger.Float64("pre_validated_duration", options.preValidatedDuration),
@@ -309,7 +309,7 @@ func (g *Generator) GenerateFromFile(ctx context.Context, audioPath, outputPath 
 			Component("spectrogram").
 			Category(errors.CategoryValidation).
 			Context("operation", "generate_from_file").
-			Context("output_path", outputPath).
+			Context("output_path", g.relPath(outputPath)).
 			Build()
 	}
 	if width <= 0 {
@@ -371,7 +371,7 @@ func (g *Generator) GenerateFromFile(ctx context.Context, audioPath, outputPath 
 		}
 
 		g.log().Warn("Sox spectrogram generation failed, falling back to FFmpeg",
-			logger.String("audio_path", audioPath),
+			logger.String("audio_path", g.relPath(audioPath)),
 			logger.Error(err),
 			logger.Int64("elapsed_ms", time.Since(start).Milliseconds()))
 
@@ -385,7 +385,7 @@ func (g *Generator) GenerateFromFile(ctx context.Context, audioPath, outputPath 
 		// Fallback to FFmpeg pipeline with fresh context
 		if ffmpegErr := g.generateWithFFmpeg(ffmpegCtx, settings, audioPath, tempPath, width, raw, profile); ffmpegErr != nil {
 			g.log().Error("Both Sox and FFmpeg generation failed",
-				logger.String("audio_path", audioPath),
+				logger.String("audio_path", g.relPath(audioPath)),
 				logger.String("sox_error", err.Error()),
 				logger.String("ffmpeg_error", ffmpegErr.Error()))
 			return ffmpegErr
@@ -400,12 +400,12 @@ func (g *Generator) GenerateFromFile(ctx context.Context, audioPath, outputPath 
 			Component("spectrogram").
 			Category(errors.CategoryFileIO).
 			Context("operation", "finalize_spectrogram").
-			Context("output_path", outputPath).
+			Context("output_path", g.relPath(outputPath)).
 			Build()
 	}
 
 	g.log().Info("Spectrogram generation from file completed",
-		logger.String("audio_path", audioPath),
+		logger.String("audio_path", g.relPath(audioPath)),
 		logger.Int("width", width),
 		logger.Int64("total_ms", time.Since(start).Milliseconds()))
 
@@ -438,7 +438,7 @@ func (g *Generator) GenerateFromPCM(ctx context.Context, pcmData []byte, outputP
 	}
 
 	g.log().Debug("Starting spectrogram generation from PCM",
-		logger.String("output_path", outputPath),
+		logger.String("output_path", g.relPath(outputPath)),
 		logger.Int("pcm_bytes", len(pcmData)),
 		logger.Int("width", width),
 		logger.Bool("raw", raw),
@@ -457,7 +457,7 @@ func (g *Generator) GenerateFromPCM(ctx context.Context, pcmData []byte, outputP
 			Component("spectrogram").
 			Category(errors.CategoryValidation).
 			Context("operation", "generate_from_pcm").
-			Context("output_path", outputPath).
+			Context("output_path", g.relPath(outputPath)).
 			Build()
 	}
 	if width <= 0 {
@@ -511,12 +511,12 @@ func (g *Generator) GenerateFromPCM(ctx context.Context, pcmData []byte, outputP
 			Component("spectrogram").
 			Category(errors.CategoryFileIO).
 			Context("operation", "finalize_spectrogram").
-			Context("output_path", outputPath).
+			Context("output_path", g.relPath(outputPath)).
 			Build()
 	}
 
 	g.log().Info("Spectrogram generation from PCM completed",
-		logger.String("output_path", outputPath),
+		logger.String("output_path", g.relPath(outputPath)),
 		logger.Int("width", width),
 		logger.Int("pcm_bytes", len(pcmData)),
 		logger.Int64("total_ms", time.Since(start).Milliseconds()))
@@ -578,8 +578,8 @@ func (g *Generator) generateWithSoxDirect(ctx context.Context, settings *conf.Se
 
 	g.log().Debug("Executing SoX command directly",
 		logger.String("sox_binary", soxBinary),
-		logger.String("audio_path", audioPath),
-		logger.String("output_path", outputPath))
+		logger.String("audio_path", g.relPath(audioPath)),
+		logger.String("output_path", g.relPath(outputPath)))
 
 	cmd := createCommandWithNice(ctx, soxBinary, soxArgs)
 
@@ -592,16 +592,16 @@ func (g *Generator) generateWithSoxDirect(ctx context.Context, settings *conf.Se
 	soxStart := time.Now()
 	if err := cmd.Run(); err != nil {
 		g.log().Warn("SoX direct execution failed",
-			logger.String("audio_path", audioPath),
+			logger.String("audio_path", g.relPath(audioPath)),
 			logger.Int("width", width),
 			logger.Int64("sox_ms", time.Since(soxStart).Milliseconds()))
 		eb := errors.New(err).
 			Component("spectrogram").
 			Category(errors.CategorySystem).
 			Context("operation", "generate_with_sox_direct").
-			Context("audio_path", audioPath).
+			Context("audio_path", g.relPath(audioPath)).
 			Context("input_file_bytes", getFileSizeBytes(audioPath)).
-			Context("output_path", outputPath).
+			Context("output_path", g.relPath(outputPath)).
 			Context("width", width).
 			Context("raw", raw).
 			Context("sox_output", output.String())
@@ -613,7 +613,7 @@ func (g *Generator) generateWithSoxDirect(ctx context.Context, settings *conf.Se
 	runtime.Gosched()
 
 	g.log().Info("SoX direct execution completed",
-		logger.String("audio_path", audioPath),
+		logger.String("audio_path", g.relPath(audioPath)),
 		logger.Int("width", width),
 		logger.Int64("sox_ms", time.Since(soxStart).Milliseconds()))
 
@@ -680,7 +680,7 @@ func (g *Generator) generateWithFFmpegSoxPipeline(ctx context.Context, settings 
 			Component("spectrogram").
 			Category(errors.CategorySystem).
 			Context("operation", "create_pipe").
-			Context("audio_path", audioPath).
+			Context("audio_path", g.relPath(audioPath)).
 			Context("width", width).
 			Context("raw", raw).
 			Build()
@@ -701,7 +701,7 @@ func (g *Generator) generateWithFFmpegSoxPipeline(ctx context.Context, settings 
 			Component("spectrogram").
 			Category(errors.CategorySystem).
 			Context("operation", "start_sox").
-			Context("audio_path", audioPath).
+			Context("audio_path", g.relPath(audioPath)).
 			Context("width", width).
 			Context("raw", raw).
 			Build()
@@ -735,14 +735,14 @@ func (g *Generator) generateWithFFmpegSoxPipeline(ctx context.Context, settings 
 		g.waitWithTimeout(soxCmd, soxKillTimeout)
 		soxWaitDone = true
 		g.log().Warn("FFmpeg|SoX pipeline failed (FFmpeg stage)",
-			logger.String("audio_path", audioPath),
+			logger.String("audio_path", g.relPath(audioPath)),
 			logger.Int("width", width),
 			logger.Int64("pipeline_ms", time.Since(pipelineStart).Milliseconds()))
 		eb := errors.New(err).
 			Component("spectrogram").
 			Category(errors.CategorySystem).
 			Context("operation", "run_ffmpeg").
-			Context("audio_path", audioPath).
+			Context("audio_path", g.relPath(audioPath)).
 			Context("input_file_bytes", getFileSizeBytes(audioPath)).
 			Context("width", width).
 			Context("raw", raw).
@@ -766,7 +766,7 @@ func (g *Generator) generateWithFFmpegSoxPipeline(ctx context.Context, settings 
 
 	if soxWaitErr != nil {
 		g.log().Warn("FFmpeg|SoX pipeline failed (SoX stage)",
-			logger.String("audio_path", audioPath),
+			logger.String("audio_path", g.relPath(audioPath)),
 			logger.Int("width", width),
 			logger.Int64("ffmpeg_ms", ffmpegElapsedMs),
 			logger.Int64("pipeline_ms", time.Since(pipelineStart).Milliseconds()))
@@ -774,7 +774,7 @@ func (g *Generator) generateWithFFmpegSoxPipeline(ctx context.Context, settings 
 			Component("spectrogram").
 			Category(errors.CategorySystem).
 			Context("operation", "wait_sox").
-			Context("audio_path", audioPath).
+			Context("audio_path", g.relPath(audioPath)).
 			Context("input_file_bytes", getFileSizeBytes(audioPath)).
 			Context("width", width).
 			Context("raw", raw).
@@ -789,7 +789,7 @@ func (g *Generator) generateWithFFmpegSoxPipeline(ctx context.Context, settings 
 	runtime.Gosched()
 
 	g.log().Info("FFmpeg|SoX pipeline completed",
-		logger.String("audio_path", audioPath),
+		logger.String("audio_path", g.relPath(audioPath)),
 		logger.Int("width", width),
 		logger.Int64("ffmpeg_ms", ffmpegElapsedMs),
 		logger.Int64("pipeline_ms", time.Since(pipelineStart).Milliseconds()))
@@ -869,7 +869,7 @@ func (g *Generator) generateWithSoxPCM(ctx context.Context, settings *conf.Setti
 	soxStart := time.Now()
 	if err := cmd.Run(); err != nil {
 		g.log().Warn("SoX PCM execution failed",
-			logger.String("output_path", outputPath),
+			logger.String("output_path", g.relPath(outputPath)),
 			logger.Int("width", width),
 			logger.Int("pcm_bytes", len(pcmData)),
 			logger.Int64("sox_ms", time.Since(soxStart).Milliseconds()))
@@ -877,7 +877,7 @@ func (g *Generator) generateWithSoxPCM(ctx context.Context, settings *conf.Setti
 			Component("spectrogram").
 			Category(errors.CategorySystem).
 			Context("operation", "generate_with_sox_pcm").
-			Context("output_path", outputPath).
+			Context("output_path", g.relPath(outputPath)).
 			Context("width", width).
 			Context("raw", raw).
 			Context("sox_stderr", stderr.String()).
@@ -889,7 +889,7 @@ func (g *Generator) generateWithSoxPCM(ctx context.Context, settings *conf.Setti
 	}
 
 	g.log().Info("SoX PCM execution completed",
-		logger.String("output_path", outputPath),
+		logger.String("output_path", g.relPath(outputPath)),
 		logger.Int("width", width),
 		logger.Int("pcm_bytes", len(pcmData)),
 		logger.Int64("sox_ms", time.Since(soxStart).Milliseconds()))
@@ -963,16 +963,16 @@ func (g *Generator) generateWithFFmpeg(ctx context.Context, settings *conf.Setti
 	ffmpegStart := time.Now()
 	if err := cmd.Run(); err != nil {
 		g.log().Warn("FFmpeg-only execution failed",
-			logger.String("audio_path", audioPath),
+			logger.String("audio_path", g.relPath(audioPath)),
 			logger.Int("width", width),
 			logger.Int64("ffmpeg_ms", time.Since(ffmpegStart).Milliseconds()))
 		eb := errors.New(err).
 			Component("spectrogram").
 			Category(errors.CategorySystem).
 			Context("operation", "generate_with_ffmpeg").
-			Context("audio_path", audioPath).
+			Context("audio_path", g.relPath(audioPath)).
 			Context("input_file_bytes", getFileSizeBytes(audioPath)).
-			Context("output_path", outputPath).
+			Context("output_path", g.relPath(outputPath)).
 			Context("width", width).
 			Context("raw", raw).
 			Context("ffmpeg_output", output.String())
@@ -983,7 +983,7 @@ func (g *Generator) generateWithFFmpeg(ctx context.Context, settings *conf.Setti
 	}
 
 	g.log().Info("FFmpeg-only execution completed",
-		logger.String("audio_path", audioPath),
+		logger.String("audio_path", g.relPath(audioPath)),
 		logger.Int("width", width),
 		logger.Int64("ffmpeg_ms", time.Since(ffmpegStart).Milliseconds()))
 
@@ -1028,7 +1028,7 @@ func (g *Generator) getSoxSpectrogramArgs(ctx context.Context, settings *conf.Se
 	// Priority: pre-validated (from FFprobe) > cached sox/ffprobe > configured fallback.
 	duration := preValidatedDuration
 	if duration <= 0 {
-		duration = getCachedAudioDuration(ctx, settings.Realtime.Audio.SoxPath, audioPath)
+		duration = g.getCachedAudioDuration(ctx, settings.Realtime.Audio.SoxPath, audioPath)
 	}
 	if duration <= 0 {
 		// Fallback: Use configured capture length if both sox and ffprobe fail
@@ -1036,7 +1036,7 @@ func (g *Generator) getSoxSpectrogramArgs(ctx context.Context, settings *conf.Se
 		duration = float64(captureLength)
 		g.log().Warn("Duration query failed, using configured fallback duration",
 			logger.Float64("fallback_duration_seconds", duration),
-			logger.String("audio_path", audioPath))
+			logger.String("audio_path", g.relPath(audioPath)))
 	}
 
 	// Convert duration to string, rounding to nearest integer
@@ -1068,8 +1068,8 @@ func (g *Generator) ensureOutputDirectory(outputPath string) error {
 			Component("spectrogram").
 			Category(errors.CategoryFileIO).
 			Context("operation", "ensure_output_directory").
-			Context("output_dir", outputDir).
-			Context("output_path", outputPath).
+			Context("output_dir", g.relPath(outputDir)).
+			Context("output_path", g.relPath(outputPath)).
 			Build()
 	}
 	return nil
@@ -1191,7 +1191,7 @@ func (g *Generator) waitWithTimeoutErr(cmd *exec.Cmd, timeout time.Duration) err
 // falling back to ffprobe if sox fails (e.g., for MP3/AAC files without libsox-fmt-mp3).
 // The cache is invalidated if the file has been modified (size or modTime changed).
 // Returns 0 if duration cannot be determined (caller should use configured fallback).
-func getCachedAudioDuration(ctx context.Context, soxPath, audioPath string) float64 {
+func (g *Generator) getCachedAudioDuration(ctx context.Context, soxPath, audioPath string) float64 {
 	// Get file info for cache validation
 	fileInfo, err := os.Stat(audioPath)
 	if err != nil {
@@ -1221,9 +1221,16 @@ func getCachedAudioDuration(ctx context.Context, soxPath, audioPath string) floa
 	duration, soxErr := getAudioDurationViaSox(ctx, soxPath, audioPath)
 	if soxErr != nil {
 		// Sox failed (common for MP3/AAC without libsox-fmt-mp3) — fall back to ffprobe
+		// A method rather than a free function purely so this log line can reach
+		// both export roots. Resolving them via conf.Setting() instead would be
+		// a trap: that call is not a pure accessor, it lazily loads and can WRITE
+		// a default config.yaml, and it publishes the result as the process-wide
+		// settings, which would then override the injected settings every other
+		// path in this package resolves against. It would also run before the
+		// level filter, so a disabled Debug line would still pay for it.
 		GetLogger().Debug("Sox duration query failed, falling back to ffprobe",
 			logger.Error(soxErr),
-			logger.String("audio_path", audioPath))
+			logger.String("audio_path", g.relPath(audioPath)))
 		duration, err = ffmpeg.GetDurationViaFFprobe(ctx, audioPath)
 		if err != nil {
 			return 0 // Caller will use configured fallback

--- a/internal/spectrogram/prerenderer.go
+++ b/internal/spectrogram/prerenderer.go
@@ -64,9 +64,13 @@ type PreRenderer struct {
 
 // Job represents a single spectrogram generation task.
 type Job struct {
-	PCMData          []byte           // Raw PCM data from memory (s16le, mono)
-	SampleRate       int              // PCM sample rate in Hz (0 = use conf.SampleRate default)
-	ClipPath         string           // Full absolute path to audio clip; PNG path is derived by swapping extension
+	PCMData    []byte // Raw PCM data from memory (s16le, mono)
+	SampleRate int    // PCM sample rate in Hz (0 = use conf.SampleRate default)
+	// ClipPath is the audio clip joined against the configured export directory,
+	// so it is absolute whenever that directory is. The PNG path is derived by
+	// swapping the extension. It is the full path because the renderer has to
+	// open the file; never log it directly, run it through exportRelPath.
+	ClipPath         string
 	NoteID           uint             // For logging correlation
 	Timestamp        time.Time        // Job submission time
 	FrequencyProfile FrequencyProfile // Frequency profile for spectrogram generation (bird vs bat)
@@ -113,6 +117,62 @@ func (pr *PreRenderer) normalizeSpectrogramPath(settings *conf.Settings, spectro
 		return filepath.Join(pr.sfs.BaseDir(), relToExport)
 	}
 	return filepath.Join(pr.sfs.BaseDir(), spectrogramPath)
+}
+
+// exportRelPath is the name of a clip or spectrogram relative to the export
+// directory, and is the only shape a path may take in a log field or an error
+// context here.
+//
+// The pre-renderer is handed the full path (it has to open the file), but a
+// support log and an uploaded support dump are read by someone other than the
+// operator, and an absolute path leaks the account name and the directory
+// layout of their machine. The year/month segments leak nothing and are what
+// makes the value resolvable back to a file, so they are kept. This mirrors
+// SaveAudioAction.relativeClipPath, which strips the same prefix on the export
+// side; without the same treatment here, a dump that no longer leaks the path
+// from the export logs still leaks it from the pre-render logs.
+//
+// Two roots are tried because the two available answers can disagree. The
+// clip path arrives joined against settings.Realtime.Audio.Export.Path, which
+// is hot-reloadable and may be relative; sfs.BaseDir() is that same directory
+// resolved to absolute, but frozen at construction (securefs.New is called once
+// with the startup value). Either can be the one that matches, so both get a
+// turn before falling back.
+//
+// IsLocal rejects a result that walks UP out of the export directory: Rel
+// happily answers "../../../etc/passwd" when both paths are absolute but the
+// input sits outside, and that both leaks the layout above the export directory
+// and names nothing any consumer can resolve. The basename is the safe answer
+// in that case; it still identifies the file and still contains no directory.
+func exportRelPath(settings *conf.Settings, sfs *securefs.SecureFS, p string) string {
+	if p == "" {
+		return ""
+	}
+	roots := [2]string{}
+	if settings != nil {
+		roots[0] = settings.Realtime.Audio.Export.Path
+	}
+	if sfs != nil {
+		roots[1] = sfs.BaseDir()
+	}
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+		if rel, err := filepath.Rel(root, p); err == nil && filepath.IsLocal(rel) {
+			return filepath.ToSlash(rel)
+		}
+	}
+	return filepath.Base(p)
+}
+
+// relPath is the Generator's access to the same helper. The generator receives
+// the derived ABSOLUTE spectrogram and audio paths from the pre-renderer (it has
+// to, it opens and writes them), so without this every path the pre-renderer
+// strips is re-leaked microseconds later by the code it calls, including at Info
+// level where a default-level support dump picks it up.
+func (g *Generator) relPath(p string) string {
+	return exportRelPath(g.currentSettings(), g.sfs, p)
 }
 
 // NewPreRenderer creates a new pre-renderer instance.
@@ -217,6 +277,11 @@ func (pr *PreRenderer) Submit(jobDTO interface {
 		modelType:        modelType,
 	}
 
+	// One settings snapshot for this submission, for the same reason processJob
+	// captures one: a UI edit to the export path landing mid-call must not make
+	// two path fields on the same log line resolve against different roots.
+	settings := pr.currentSettings()
+
 	// Early check: skip if spectrogram already exists (avoid queueing duplicate jobs)
 	// Note: TOCTOU (time-of-check-time-of-use) race condition is intentional here.
 	// The file might be created between this check and processJob(), which is fine:
@@ -227,7 +292,7 @@ func (pr *PreRenderer) Submit(jobDTO interface {
 	if err != nil {
 		pr.logger.Error("Invalid clip path, rejecting job",
 			logger.Any("note_id", job.NoteID),
-			logger.String("clip_path", job.ClipPath),
+			logger.String("clip_path", exportRelPath(settings, pr.sfs, job.ClipPath)),
 			logger.Error(err))
 		// Increment Failed stat for validation errors
 		pr.mu.Lock()
@@ -238,7 +303,7 @@ func (pr *PreRenderer) Submit(jobDTO interface {
 			Category(errors.CategoryValidation).
 			Context("operation", "build_spectrogram_path").
 			Context("note_id", job.NoteID).
-			Context("clip_path", job.ClipPath).
+			Context("clip_path", exportRelPath(settings, pr.sfs, job.ClipPath)).
 			Build()
 	}
 
@@ -250,16 +315,36 @@ func (pr *PreRenderer) Submit(jobDTO interface {
 
 	// Make spectrogram path absolute using SecureFS base dir, stripping export
 	// prefix to avoid path doubling (e.g., "clips/clips/..."). See #2342.
-	absOut := pr.normalizeSpectrogramPath(pr.currentSettings(), spectrogramPath)
+	absOut := pr.normalizeSpectrogramPath(settings, spectrogramPath)
 
 	relPath, err := filepath.Rel(absRoot, absOut)
 	if err != nil || relPath == ".." || strings.HasPrefix(relPath, ".."+string(os.PathSeparator)) {
+		// export_path is deliberately not logged: it IS the absolute export
+		// directory, so reporting it here would leak exactly what exportRelPath
+		// strips everywhere else on this line.
+		//
+		// reason carries what export_path used to. The two arms of this guard
+		// fail for different causes and only one of them explains itself:
+		// on the escape arm relative_path holds the "../..." result and says it
+		// all, but on the Rel-error arm (different Windows volumes) Rel returns
+		// "" and exportRelPath likewise falls through to a bare basename, so
+		// without reason the line would report a traversal and give the operator
+		// nothing to act on.
+		//
+		// relative_path is ToSlash'd to match the other two path fields; mixing
+		// separators within one line makes it unparseable by any consumer that
+		// normalizes on one convention.
+		reason := "escapes_export_root"
+		if err != nil {
+			reason = "path_not_relatable_to_export_root"
+		}
 		pr.logger.Error("Path traversal attempt detected, rejecting job",
 			logger.Any("note_id", job.NoteID),
-			logger.String("clip_path", job.ClipPath),
-			logger.String("spectrogram_path", absOut),
-			logger.String("export_path", absRoot),
-			logger.String("relative_path", relPath))
+			logger.String("clip_path", exportRelPath(settings, pr.sfs, job.ClipPath)),
+			logger.String("spectrogram_path", exportRelPath(settings, pr.sfs, absOut)),
+			logger.String("relative_path", filepath.ToSlash(relPath)),
+			logger.String("reason", reason),
+			logger.String("operation", "spectrogram_path_validation"))
 		pr.mu.Lock()
 		pr.stats.Failed++
 		pr.mu.Unlock()
@@ -268,10 +353,10 @@ func (pr *PreRenderer) Submit(jobDTO interface {
 			Category(errors.CategoryValidation).
 			Context("operation", "path_validation").
 			Context("note_id", job.NoteID).
-			Context("clip_path", job.ClipPath).
-			Context("spectrogram_path", absOut).
-			Context("export_path", absRoot).
-			Context("relative_path", relPath).
+			Context("clip_path", exportRelPath(settings, pr.sfs, job.ClipPath)).
+			Context("spectrogram_path", exportRelPath(settings, pr.sfs, absOut)).
+			Context("relative_path", filepath.ToSlash(relPath)).
+			Context("reason", reason).
 			Build()
 	}
 
@@ -282,7 +367,7 @@ func (pr *PreRenderer) Submit(jobDTO interface {
 		pr.mu.Unlock()
 		pr.logger.Debug("Spectrogram already exists, skipping queue",
 			logger.Any("note_id", job.NoteID),
-			logger.String("spectrogram_path", absOut))
+			logger.String("spectrogram_path", exportRelPath(settings, pr.sfs, absOut)))
 		return nil
 	}
 
@@ -327,7 +412,7 @@ func (pr *PreRenderer) Submit(jobDTO interface {
 	default:
 		pr.logger.Warn("Pre-render queue full, dropping job",
 			logger.Any("note_id", job.NoteID),
-			logger.String("clip_path", job.ClipPath),
+			logger.String("clip_path", exportRelPath(settings, pr.sfs, job.ClipPath)),
 			logger.Int("queue_size", defaultQueueSize))
 		pr.mu.Lock()
 		pr.stats.Failed++
@@ -375,7 +460,7 @@ func (pr *PreRenderer) processJob(job *Job, workerID int) {
 	pr.logger.Debug("Processing pre-render job",
 		logger.Int("worker_id", workerID),
 		logger.Any("note_id", job.NoteID),
-		logger.String("clip_path", job.ClipPath),
+		logger.String("clip_path", exportRelPath(settings, pr.sfs, job.ClipPath)),
 		logger.Int("pcm_bytes", len(job.PCMData)))
 
 	// Build spectrogram path from clip path
@@ -384,7 +469,7 @@ func (pr *PreRenderer) processJob(job *Job, workerID int) {
 		pr.logger.Error("Failed to build spectrogram path",
 			logger.Int("worker_id", workerID),
 			logger.Any("note_id", job.NoteID),
-			logger.String("clip_path", job.ClipPath),
+			logger.String("clip_path", exportRelPath(settings, pr.sfs, job.ClipPath)),
 			logger.Error(err))
 		pr.mu.Lock()
 		pr.stats.Failed++
@@ -406,7 +491,7 @@ func (pr *PreRenderer) processJob(job *Job, workerID int) {
 		pr.logger.Debug("Spectrogram already exists, skipping",
 			logger.Int("worker_id", workerID),
 			logger.Any("note_id", job.NoteID),
-			logger.String("spectrogram_path", spectrogramPath))
+			logger.String("spectrogram_path", exportRelPath(settings, pr.sfs, spectrogramPath)))
 		pr.mu.Lock()
 		pr.stats.Skipped++
 		pr.mu.Unlock()
@@ -435,7 +520,7 @@ func (pr *PreRenderer) processJob(job *Job, workerID int) {
 	// This provides visibility into the generation pipeline
 	pr.logger.Info("Spectrogram generation started",
 		logger.Any("note_id", job.NoteID),
-		logger.String("audio_path", job.ClipPath),
+		logger.String("audio_path", exportRelPath(settings, pr.sfs, job.ClipPath)),
 		logger.String("size", specSettings.Size),
 		logger.String("operation", "spectrogram_generation_start"))
 
@@ -448,8 +533,8 @@ func (pr *PreRenderer) processJob(job *Job, workerID int) {
 			pr.logger.Debug("Spectrogram generation canceled or interrupted",
 				logger.Int("worker_id", workerID),
 				logger.Any("note_id", job.NoteID),
-				logger.String("clip_path", job.ClipPath),
-				logger.String("spectrogram_path", spectrogramPath),
+				logger.String("clip_path", exportRelPath(settings, pr.sfs, job.ClipPath)),
+				logger.String("spectrogram_path", exportRelPath(settings, pr.sfs, spectrogramPath)),
 				logger.Error(err),
 				logger.Int64("duration_ms", time.Since(start).Milliseconds()),
 				logger.String("operation", "spectrogram_generation_canceled"))
@@ -458,8 +543,8 @@ func (pr *PreRenderer) processJob(job *Job, workerID int) {
 			pr.logger.Error("Failed to generate spectrogram",
 				logger.Int("worker_id", workerID),
 				logger.Any("note_id", job.NoteID),
-				logger.String("clip_path", job.ClipPath),
-				logger.String("spectrogram_path", spectrogramPath),
+				logger.String("clip_path", exportRelPath(settings, pr.sfs, job.ClipPath)),
+				logger.String("spectrogram_path", exportRelPath(settings, pr.sfs, spectrogramPath)),
 				logger.Error(err),
 				logger.Int64("duration_ms", time.Since(start).Milliseconds()),
 				logger.String("operation", "spectrogram_generation_failed"))
@@ -481,14 +566,14 @@ func (pr *PreRenderer) processJob(job *Job, workerID int) {
 		pr.logger.Debug("Failed to stat spectrogram file for size logging",
 			logger.Any("note_id", job.NoteID),
 			logger.Error(err),
-			logger.String("path", spectrogramPath))
+			logger.String("path", exportRelPath(settings, pr.sfs, spectrogramPath)))
 	}
 
 	// Log at INFO level when generation succeeds (BG-18)
 	// This provides confirmation that spectrograms are being created successfully
 	pr.logger.Info("Spectrogram generated successfully",
 		logger.Any("note_id", job.NoteID),
-		logger.String("output_path", spectrogramPath),
+		logger.String("output_path", exportRelPath(settings, pr.sfs, spectrogramPath)),
 		logger.Int64("file_size_bytes", fileSize),
 		logger.Int64("duration_ms", time.Since(start).Milliseconds()),
 		logger.String("operation", "spectrogram_generation_success"))

--- a/internal/spectrogram/prerenderer_path_privacy_test.go
+++ b/internal/spectrogram/prerenderer_path_privacy_test.go
@@ -1,0 +1,201 @@
+package spectrogram
+
+import (
+	"bytes"
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// capturePreRenderLogs points one PreRenderer at an in-memory buffer. Scoped to
+// the instance rather than swapping the global logger, so these tests stay
+// isolated from the package's other tests.
+func capturePreRenderLogs(t *testing.T, pr *PreRenderer) *bytes.Buffer {
+	t.Helper()
+
+	var buf bytes.Buffer
+	capture := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	cl, err := logger.NewCentralLogger(
+		&logger.LoggingConfig{
+			Console:      &logger.ConsoleOutput{Enabled: false},
+			FileOutput:   &logger.FileOutput{Enabled: false},
+			DefaultLevel: "debug",
+		},
+		capture,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, cl.Close()) })
+
+	pr.logger = cl.Module("spectrogram.test")
+	return &buf
+}
+
+// TestExportRelPathStripsExportDirectory pins the privacy contract of
+// exportRelPath: nothing it returns may carry the export directory, because
+// every path-valued log field and error context in this package goes through
+// it, and support logs plus uploaded support dumps are read by someone other
+// than the operator. An absolute path there leaks the account name and the
+// directory layout of the reporting machine.
+func TestExportRelPathStripsExportDirectory(t *testing.T) {
+	t.Parallel()
+
+	pr, env := createTestPreRenderer(t, nil)
+	exportDir := env.TempDir
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "clip under the export directory keeps year/month",
+			input: filepath.Join(exportDir, "2026", "07", "turdus_merula_82p.wav"),
+			want:  "2026/07/turdus_merula_82p.wav",
+		},
+		{
+			name:  "spectrogram under the export directory keeps year/month",
+			input: filepath.Join(exportDir, "2026", "07", "turdus_merula_82p.png"),
+			want:  "2026/07/turdus_merula_82p.png",
+		},
+		{
+			name:  "file directly in the export directory is its own name",
+			input: filepath.Join(exportDir, "clip.wav"),
+			want:  "clip.wav",
+		},
+		{
+			name: "path outside the export directory degrades to the basename " +
+				"rather than a .. walk that would leak the layout above it",
+			input: "/var/lib/somebodyelse/clips/2026/07/clip.wav",
+			want:  "clip.wav",
+		},
+		{
+			name:  "empty stays empty rather than becoming the current directory",
+			input: "",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := exportRelPath(env.Settings, pr.sfs, tt.input)
+			assert.Equal(t, tt.want, got)
+			assert.False(t, filepath.IsAbs(got), "result must never be absolute")
+			assert.NotContains(t, got, "..", "result must never walk up out of the export directory")
+			if tt.input != "" {
+				assert.NotContains(t, got, exportDir, "result must not carry the export directory")
+			}
+		})
+	}
+}
+
+// TestExportRelPathHandlesRelativeExportPath covers the configuration where
+// Export.Path is relative (e.g. "clips") while SecureFS resolved it to an
+// absolute base at construction. The clip path is joined against the former, so
+// the fallback to the latter is what makes the value strippable at all.
+func TestExportRelPathHandlesRelativeExportPath(t *testing.T) {
+	t.Parallel()
+
+	pr, env := createTestPreRenderer(t, nil)
+
+	// SecureFS keeps the absolute base captured at construction; point the
+	// hot-reloadable setting at a relative directory the way a config file
+	// written as `path: clips` would.
+	env.Settings.Realtime.Audio.Export.Path = "clips"
+
+	// A path joined against the relative setting resolves on the first root.
+	assert.Equal(t, "2026/07/clip.wav", exportRelPath(env.Settings, pr.sfs, filepath.Join("clips", "2026", "07", "clip.wav")))
+
+	// A path joined against the absolute SecureFS base resolves on the second,
+	// and must still come back stripped rather than absolute.
+	got := exportRelPath(env.Settings, pr.sfs, filepath.Join(env.TempDir, "2026", "07", "clip.wav"))
+	assert.Equal(t, "2026/07/clip.wav", got)
+	assert.False(t, filepath.IsAbs(got))
+}
+
+// TestBuildSpectrogramPathErrorOmitsDirectory guards the Sentry side of the
+// same contract: this error is reported upstream, so its context must name the
+// offending file without the directory it sits in.
+//
+// The assertions read the error's Context map, not err.Error(). The message is
+// a fixed string that never carried a path, so asserting on it would pass just
+// as well before the change as after, and would not discriminate a revert.
+func TestBuildSpectrogramPathErrorOmitsDirectory(t *testing.T) {
+	t.Parallel()
+
+	_, err := BuildSpectrogramPath("/home/someuser/birdnet/clips/2026/07/extensionless")
+	require.Error(t, err)
+
+	var enhanced *errors.EnhancedError
+	require.ErrorAs(t, err, &enhanced, "the error must carry a reportable context")
+
+	assert.Equal(t, "extensionless", enhanced.Context["clip_basename"],
+		"the context must still identify the offending file by name")
+	for key, value := range enhanced.Context {
+		text, ok := value.(string)
+		if !ok {
+			continue
+		}
+		assert.NotContains(t, text, "someuser",
+			"context key %q must not carry the account name of the reporting machine", key)
+		assert.NotContains(t, text, "/home/",
+			"context key %q must not carry the directory layout", key)
+	}
+}
+
+// TestBuildSpectrogramPathWithParamsErrorOmitsDirectory covers the sibling that
+// builds the same class of error from the same kind of input. It was left
+// leaking the full path when its twin was fixed, which is the asymmetry that
+// makes a one-site privacy fix worth checking for.
+func TestBuildSpectrogramPathWithParamsErrorOmitsDirectory(t *testing.T) {
+	t.Parallel()
+
+	_, err := BuildSpectrogramPathWithParams("/home/someuser/birdnet/clips/2026/07/extensionless", sizeLargePx, false)
+	require.Error(t, err)
+
+	var enhanced *errors.EnhancedError
+	require.ErrorAs(t, err, &enhanced)
+
+	assert.Equal(t, "extensionless", enhanced.Context["clip_basename"])
+	for key, value := range enhanced.Context {
+		if text, ok := value.(string); ok {
+			assert.NotContains(t, text, "someuser",
+				"context key %q must not carry the account name", key)
+		}
+	}
+}
+
+// TestSubmitRejectionLogsNoAbsolutePath drives a real call site rather than the
+// helper in isolation. The privacy contract lives at the call sites, not in the
+// helper: with only a unit test on the helper, reverting any single site back to
+// the raw path leaves the whole suite green.
+//
+// Scope, stated honestly: this covers the Submit rejection branch. The Generator
+// sites cannot be reached from here, because Generator logs through the
+// process-global GetLogger() rather than an injected logger, so capturing them
+// would need a global swap. They are covered by construction instead: every one
+// is an inline argument to a log field, verified by grep at review time.
+func TestSubmitRejectionLogsNoAbsolutePath(t *testing.T) {
+	pr, env := createTestPreRenderer(t, nil)
+	logs := capturePreRenderLogs(t, pr)
+
+	// No extension, so BuildSpectrogramPath rejects the job and takes the
+	// logging branch under test.
+	outside := filepath.Join(env.TempDir, "2026", "07", "extensionless")
+	err := pr.Submit(&Job{ClipPath: outside, NoteID: 42})
+	require.Error(t, err)
+
+	out := logs.String()
+	require.NotEmpty(t, out, "the rejection must have been logged")
+	assert.NotContains(t, out, env.TempDir,
+		"the export directory must not reach the log from a call site")
+	assert.Contains(t, out, "2026/07/extensionless",
+		"the clip must still be identifiable by its export-relative name")
+}

--- a/internal/spectrogram/utils.go
+++ b/internal/spectrogram/utils.go
@@ -97,11 +97,21 @@ func GetValidSizes() []string {
 func BuildSpectrogramPath(clipPath string) (string, error) {
 	ext := filepath.Ext(clipPath)
 	if ext == "" {
+		// Only the basename goes into the context. Callers pass a path joined
+		// against the export directory, and this error is reported to Sentry,
+		// where the directory prefix would leak the account name and directory
+		// layout of the reporting machine. The diagnostic here is which file
+		// lacks an extension, which the basename answers on its own.
+		//
+		// Keyed clip_basename rather than clip_name because clip_name is already
+		// taken: elsewhere it carries the DB column value, which keeps its
+		// year/month directories. Reusing it for a bare filename would make one
+		// key mean two shapes.
 		return "", errors.Newf("clip path has no extension").
 			Component("spectrogram").
 			Category(errors.CategoryValidation).
 			Context("operation", "build_spectrogram_path").
-			Context("clip_path", clipPath).
+			Context("clip_basename", filepath.Base(clipPath)).
 			Build()
 	}
 
@@ -114,11 +124,11 @@ func BuildSpectrogramPath(clipPath string) (string, error) {
 // and process kills (e.g. context-triggered SIGKILL/SIGTERM).
 //
 // The function checks for operational errors in this order:
-// 1. Context errors (Canceled, DeadlineExceeded)
-// 2. An operational classification already attached upstream: a CategorySystem
-//    EnhancedError tagged PriorityLow (set by the generator via isOperationalExecError)
-// 3. Process exit codes (SIGKILL=137, SIGTERM=143) - more reliable than string matching
-// 4. String matching for "signal: killed" - fallback for compatibility
+//  1. Context errors (Canceled, DeadlineExceeded)
+//  2. An operational classification already attached upstream: a CategorySystem
+//     EnhancedError tagged PriorityLow (set by the generator via isOperationalExecError)
+//  3. Process exit codes (SIGKILL=137, SIGTERM=143) - more reliable than string matching
+//  4. String matching for "signal: killed" - fallback for compatibility
 func IsOperationalError(err error) bool {
 	if err == nil {
 		return false
@@ -203,8 +213,11 @@ func BuildSpectrogramPathWithParams(audioPath string, width int, raw bool) (stri
 		return "", errors.Newf("audio path has no extension").
 			Component("spectrogram").
 			Category(errors.CategoryValidation).
+			// Basename only, for the reason spelled out on the sibling above:
+			// this error is reported to Sentry and the directory prefix leaks
+			// the account name and layout of the reporting machine.
 			Context("operation", "build_spectrogram_path_with_params").
-			Context("audio_path", audioPath).
+			Context("clip_basename", filepath.Base(audioPath)).
 			Build()
 	}
 	baseName := strings.TrimSuffix(audioPath, ext)

--- a/internal/support/collector.go
+++ b/internal/support/collector.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/shirou/gopsutil/v3/disk"
 	"github.com/shirou/gopsutil/v3/mem"
+	"github.com/tphakala/birdnet-go/internal/conf"
 	diagpkg "github.com/tphakala/birdnet-go/internal/diagnostics"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -775,6 +776,50 @@ func (c *Collector) CreateArchive(ctx context.Context, dump *SupportDump, opts C
 	return buf.Bytes(), nil
 }
 
+// collectRuntimeEnv reads the environment variables on the supplied allowlist
+// that are set, so a dump can report runtime behaviour that config.yaml does not
+// record (see the allowlist's own comment for why the gates are invisible
+// otherwise, and why this is an allowlist rather than a prefix scan).
+//
+// Unset variables are skipped rather than recorded as empty, so the map is
+// nil-and-omitted on the overwhelmingly common install where no gate is set,
+// instead of adding a block of empty strings to every dump.
+//
+// Values are redacted by key even though the allowlist is supposed to make that
+// unnecessary. SystemInfo is the one dump section no scrubber touches: it has
+// only ever held machine-derived facts (GOOS, CPU count, disk usage), so
+// scrubConfig and AnonymizePII both pass it by, and these values are the first
+// operator-supplied strings to land in it. The allowlist is currently the only
+// thing keeping a secret out, and it is a list a future maintainer will extend
+// while thinking "a path is not a password" (BIRDNET_MODELPATH under a home
+// directory, or an MQTT URL with embedded credentials, would both be plausible
+// additions). Every other env-capture route in this package already redacts by
+// key: scrubEnvironmentLine does it for systemd unit-file Environment= lines.
+// This costs nothing today and makes a bad future allowlist entry fail safe
+// rather than silently upload a credential to a third party.
+//
+// A method rather than a free function purely so it can reach c.sensitiveKeys.
+// The allowlist is a parameter rather than read inline so a test can inject the
+// entry a future maintainer might wrongly add, and prove the net catches it.
+func (c *Collector) collectRuntimeEnv(allowlist []string) map[string]string {
+	var env map[string]string
+	for _, name := range allowlist {
+		value := os.Getenv(name)
+		if value == "" {
+			continue
+		}
+		if env == nil {
+			env = make(map[string]string, len(allowlist))
+		}
+		if MatchesSensitiveKey(name, c.sensitiveKeys) {
+			env[name] = redactedPlaceholder
+			continue
+		}
+		env[name] = value
+	}
+	return env
+}
+
 // collectSystemInfo gathers system information
 func (c *Collector) collectSystemInfo() SystemInfo {
 	info := SystemInfo{
@@ -783,6 +828,7 @@ func (c *Collector) collectSystemInfo() SystemInfo {
 		GoVersion:    runtime.Version(),
 		CPUCount:     runtime.NumCPU(),
 		DiskInfo:     []DiskInfo{},
+		RuntimeEnv:   c.collectRuntimeEnv(conf.SupportEnvAllowlist()),
 	}
 
 	// Get system memory info using gopsutil

--- a/internal/support/collector.go
+++ b/internal/support/collector.go
@@ -781,9 +781,12 @@ func (c *Collector) CreateArchive(ctx context.Context, dump *SupportDump, opts C
 // record (see the allowlist's own comment for why the gates are invisible
 // otherwise, and why this is an allowlist rather than a prefix scan).
 //
-// Unset variables are skipped rather than recorded as empty, so the map is
-// nil-and-omitted on the overwhelmingly common install where no gate is set,
-// instead of adding a block of empty strings to every dump.
+// Variables that are unset OR set to the empty string are both skipped, so the
+// map is nil-and-omitted on the overwhelmingly common install where no gate is
+// set, instead of adding a block of empty strings to every dump. os.Getenv
+// cannot tell those two states apart, and for these gates nothing does: an
+// empty value fails nativeEncoderSelected exactly as an unset one does, so a
+// dump loses no triage signal by collapsing them.
 //
 // Values are redacted by key even though the allowlist is supposed to make that
 // unnecessary. SystemInfo is the one dump section no scrubber touches: it has

--- a/internal/support/runtime_env_test.go
+++ b/internal/support/runtime_env_test.go
@@ -1,0 +1,92 @@
+package support
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// newTestCollector builds a Collector carrying the default sensitive-key list,
+// which is what collectRuntimeEnv consults to redact by key.
+func newTestCollector() *Collector {
+	return &Collector{sensitiveKeys: DefaultSensitiveKeys()}
+}
+
+// TestCollectRuntimeEnvRedactsASensitiveKey pins the defense-in-depth layer:
+// the allowlist is supposed to make this unreachable, but SystemInfo is the one
+// dump section no scrubber touches, so a future allowlist entry naming a
+// credential must still fail safe rather than upload the value.
+func TestCollectRuntimeEnvRedactsASensitiveKey(t *testing.T) {
+	const sensitive = "BIRDNET_TEST_API_TOKEN"
+	t.Setenv(sensitive, "super-secret-value")
+
+	// Inject the entry a future maintainer might wrongly add, to prove the
+	// redaction net catches what the allowlist review missed. SystemInfo is the
+	// one dump section no scrubber touches, so this net is the last line.
+	env := newTestCollector().collectRuntimeEnv(append(conf.SupportEnvAllowlist(), sensitive))
+
+	assert.NotContains(t, env[sensitive], "super-secret-value",
+		"a sensitive-looking key must never reach the dump verbatim")
+	assert.Equal(t, redactedPlaceholder, env[sensitive])
+}
+
+// TestCollectRuntimeEnvCapturesAllowlistedGates covers the case the feature
+// exists for: a dump that arrives without a clip export in the captured log
+// window must still reveal whether a native encoder gate was on.
+func TestCollectRuntimeEnvCapturesAllowlistedGates(t *testing.T) {
+	t.Setenv(conf.EnvNativeAACEncoder, "native")
+
+	env := newTestCollector().collectRuntimeEnv(conf.SupportEnvAllowlist())
+
+	require.NotNil(t, env)
+	assert.Equal(t, "native", env[conf.EnvNativeAACEncoder])
+	assert.NotContains(t, env, conf.EnvNativeOpusEncoder,
+		"an unset gate must be absent, not present with an empty value")
+}
+
+// TestCollectRuntimeEnvIgnoresNonAllowlisted is the privacy half of the
+// contract. The allowlist exists because the process environment can hold
+// credentials, so a BIRDNET_-prefixed variable that nobody vetted must not be
+// swept into a file the user uploads to a third party.
+func TestCollectRuntimeEnvIgnoresNonAllowlisted(t *testing.T) {
+	t.Setenv("BIRDNET_SOMETHING_SECRET", "hunter2")
+
+	env := newTestCollector().collectRuntimeEnv(conf.SupportEnvAllowlist())
+
+	assert.NotContains(t, env, "BIRDNET_SOMETHING_SECRET")
+	for _, v := range env {
+		assert.NotEqual(t, "hunter2", v)
+	}
+}
+
+// TestCollectRuntimeEnvEmptyWhenNoGatesSet keeps the common install clean: with
+// nothing set the map is nil, so runtime_env is omitted from the JSON entirely
+// rather than adding an empty block to every dump.
+func TestCollectRuntimeEnvEmptyWhenNoGatesSet(t *testing.T) {
+	for _, name := range conf.SupportEnvAllowlist() {
+		t.Setenv(name, "")
+	}
+
+	env := newTestCollector().collectRuntimeEnv(conf.SupportEnvAllowlist())
+	assert.Empty(t, env)
+
+	encoded, err := json.Marshal(SystemInfo{RuntimeEnv: env})
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), "runtime_env")
+}
+
+// TestCollectSystemInfoIncludesRuntimeEnv checks the collector actually wires
+// the helper in, since the helper being correct in isolation is not what the
+// support dump depends on.
+func TestCollectSystemInfoIncludesRuntimeEnv(t *testing.T) {
+	t.Setenv(conf.EnvNativeOpusEncoder, "native")
+
+	c := &Collector{}
+	info := c.collectSystemInfo()
+
+	assert.Equal(t, "native", info.RuntimeEnv[conf.EnvNativeOpusEncoder])
+}

--- a/internal/support/types.go
+++ b/internal/support/types.go
@@ -46,6 +46,12 @@ type SystemInfo struct {
 	MemoryMB     uint64      `json:"memory_mb"`
 	DiskInfo     []DiskInfo  `json:"disk_info"`
 	DockerInfo   *DockerInfo `json:"docker_info,omitempty"`
+	// RuntimeEnv holds the environment variables on the collector's allowlist
+	// (conf.SupportEnvAllowlist in production) that are actually set, so a dump
+	// can report runtime gates that config.yaml cannot record. Only non-empty values are present, so an absent key means
+	// the variable was unset rather than set to "". Empty and omitted entirely
+	// when no allowlisted variable is set, which is the common case.
+	RuntimeEnv map[string]string `json:"runtime_env,omitempty"`
 }
 
 // DiskInfo represents information about a disk or filesystem mount point.
@@ -252,7 +258,7 @@ type DeploymentInfo struct {
 	// diagnostics boot journal).
 	ConfigDirectoryFiles []DataDirectoryFile `json:"config_directory_files,omitempty"`
 	DockerMounts         []DockerMount       `json:"docker_mounts,omitempty"`
-	CollectionErrors   []string            `json:"collection_errors,omitempty"`
+	CollectionErrors     []string            `json:"collection_errors,omitempty"`
 }
 
 // DataDirectoryFile describes a file in the data directory.

--- a/internal/support/types.go
+++ b/internal/support/types.go
@@ -48,9 +48,11 @@ type SystemInfo struct {
 	DockerInfo   *DockerInfo `json:"docker_info,omitempty"`
 	// RuntimeEnv holds the environment variables on the collector's allowlist
 	// (conf.SupportEnvAllowlist in production) that are actually set, so a dump
-	// can report runtime gates that config.yaml cannot record. Only non-empty values are present, so an absent key means
-	// the variable was unset rather than set to "". Empty and omitted entirely
-	// when no allowlisted variable is set, which is the common case.
+	// can report runtime gates that config.yaml cannot record. Only non-empty
+	// values are present, so an absent key means the variable was unset OR set
+	// to the empty string; the two are indistinguishable here and behave
+	// identically at every gate. Empty and omitted entirely when no allowlisted
+	// variable is set, which is the common case.
 	RuntimeEnv map[string]string `json:"runtime_env,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

Four follow-ups to the native Go encoder rollout, all observability-only: log fields, log-flood guards, and one new support-dump field. No audio behaviour changes anywhere in the diff, so the whole change is reviewable as one theme despite touching several packages.

**Stop leaking absolute clip paths.** An earlier change routed every clip-path log field in the processor through a helper that strips the export directory, because support logs and uploaded support dumps are read by someone other than the operator, and an absolute path leaks their account name and directory layout. That sweep stopped at the package boundary, so a dump that no longer leaked the path from the export logs still leaked it from the spectrogram logs. Every path-valued log field and error context in `internal/spectrogram` now routes through one shared helper: the pre-renderer, the generator (which receives the derived absolute paths and re-logged them at Info, where a default-level dump picks them up), and both path-builder errors, which reach Sentry. The helper takes the caller's settings snapshot, so two path fields on one log line cannot resolve against different roots after a mid-job settings edit. The traversal error drops the export directory it was reporting and gains a `reason` field, so the cross-volume arm stays diagnosable without it.

**Guard three per-detection WARN floods.** Both `audio_export_normalize_skip` sites and `audio_export_resample` fire on every single detection of an affected install, forever, because each reports a standing property of the configuration or the capture source rather than anything about the clip. They now use the existing keyed guard, keyed on the reason as well as the format and rate so two causes cannot silence each other. `detection_id` comes off the guarded lines: under a guard it would permanently name the first detection to trip the condition. To keep the condition answerable from a dump taken long after the one-time warning, the success line now reports whether normalization actually applied; `gain_db` could not answer it, because the default static gain is 0 and so is a measured gain of 0. Two sibling guards keyed on nothing get the same treatment: the clip-path extension fallback, which reports the hot-reloadable `Export.Type`, and the MQTT not-ready warning, which logged a per-call topic inside a process-wide `sync.Once`. The lost-clip line now names the species, and `LogJobFailed` loses an unreachable "will retry" branch that only its own test ever exercised.

**Attribute encoders outside the detection clip path.** The encoder tags move to a new leaf package so `encoder=` means the same thing everywhere and one grep answers it across paths. The BirdWeather upload now names its encoder and logs `gain_db` at Info rather than Debug, so "my uploads are too quiet" is answerable from a default-level dump the way it already is for saved clips; its success line is tagged and listed as routine chatter alongside the clip-export success line, so it stops filling the operational events feed, while the failure tag still surfaces. All three FFmpeg transcode paths in the media API now report the encoder and the request parameters that shaped the failure, through one helper rather than only at the site where the gap was first noticed; the error is scrubbed there, matching what the shared error handler does to the same value a statement later.

**Let a support dump reveal the native-encoder gate.** The gates are env-only and read live per export, so `config.yaml` does not record them, and a dump without a clip export in its log window could not establish which encoder was running. This adds an allowlisted set of environment variables to the dump: an allowlist rather than a `BIRDNET_` prefix scan, because the process environment can hold credentials. The list is returned by copy so no caller can widen it, and values are still redacted by key, because `SystemInfo` is the one dump section no scrubber touches.

## Test Plan

- [x] `go test -race ./internal/...` green
- [x] `golangci-lint run` clean with the CI build tags (`integration,pebble_e2e,noembed,skipfrontend,normcompare`)
- [x] `go test -shuffle=on -count=2` on the touched packages, no order dependence
- [x] New tests verified to fail on the pre-change code; the reason-in-key guard test verified by mutation (reverting the key to `formatRateKey` makes it fail)
- [x] No consumer reads the removed `detection_id` / `export_path` log fields (`events_aggregation.go` reads only `species` and `clip_path` off `audio_export_success`, which is unchanged)
- [x] `TestSchemaUpToDate` and the hot-reload coverage test unaffected (no `conf.Settings` field added)