### PR TITLE
docs(observability): correct a false claim about the system-events feed

### DIFF
--- a/internal/api/v2/system/events.go
+++ b/internal/api/v2/system/events.go
@@ -41,6 +41,20 @@ var noiseOperations = []string{
 	// audio_export_success directly above: both report that a normal encode
 	// succeeded, which is not an operational event. The matching failure tags
 	// are deliberately absent, so a failed upload still surfaces.
+	//
+	// Inert today. This list is consumed only by isNoiseEntry, i.e. only by
+	// GetOperationalEvents, which reads GetDefaultOutputPath() and
+	// GetOutputPath("audio") and nothing else. Both this operation and
+	// audio_export_success are emitted by modules that own a dedicated log file
+	// (logs/birdweather.log, logs/actions.log), and a module with its
+	// own output does not also write to application.log, so neither entry can
+	// ever match here. Kept rather than pruned because the intent is right and
+	// widening the endpoint to read per-module logs would otherwise immediately
+	// flood the feed with per-detection success lines.
+	//
+	// Note this says nothing about audio_export_success in detectionOperations
+	// above: that list IS live, because GetDetectionEvents explicitly reads
+	// GetOutputPath("analysis.processor").
 	"birdweather_soundscape_encode",
 	"process_detections_summary",
 }

--- a/internal/api/v2/system/events.go
+++ b/internal/api/v2/system/events.go
@@ -42,18 +42,20 @@ var noiseOperations = []string{
 	// succeeded, which is not an operational event. The matching failure tags
 	// are deliberately absent, so a failed upload still surfaces.
 	//
-	// Inert today. This list is consumed only by isNoiseEntry, i.e. only by
-	// GetOperationalEvents, which reads GetDefaultOutputPath() and
-	// GetOutputPath("audio") and nothing else. Both this operation and
-	// audio_export_success are emitted by modules that own a dedicated log file
-	// (logs/birdweather.log, logs/actions.log), and a module with its
-	// own output does not also write to application.log, so neither entry can
-	// ever match here. Kept rather than pruned because the intent is right and
-	// widening the endpoint to read per-module logs would otherwise immediately
-	// flood the feed with per-detection success lines.
+	// Whether this entry and audio_export_success can match here depends on the
+	// logging configuration. This list is consumed only by isNoiseEntry, i.e.
+	// only by GetOperationalEvents, which reads the configured
+	// GetDefaultOutputPath() and GetOutputPath("audio") base paths. Both
+	// operations are emitted by modules that get their own output on a default
+	// install (birdweather, analysis.processor), so their lines land outside
+	// those two sources and the entries sit unused. Disable or redirect either
+	// module's output and CentralLogger.Module falls back to the shared base
+	// handler, the lines reach the default output, and these entries start doing
+	// the filtering they exist for. That conditional liveness is why they are
+	// kept rather than pruned.
 	//
-	// Note this says nothing about audio_export_success in detectionOperations
-	// above: that list IS live, because GetDetectionEvents explicitly reads
+	// None of this applies to audio_export_success in detectionOperations above:
+	// that list is always live, because GetDetectionEvents explicitly reads
 	// GetOutputPath("analysis.processor").
 	"birdweather_soundscape_encode",
 	"process_detections_summary",

--- a/internal/birdweather/encode_attribution_test.go
+++ b/internal/birdweather/encode_attribution_test.go
@@ -69,7 +69,8 @@ func TestEncodeWithNativeFLAC_LogsEncoderAttribution(t *testing.T) {
 	// from birdweather_client.go, so a Contains on the bare name cannot tell the
 	// two apart.
 	assert.Contains(t, out, "operation=birdweather_soundscape_encode\n",
-		"the success line must carry the tag that noiseOperations filters on")
+		"the success line must carry its operation tag, so success and failure are "+
+			"distinguishable without parsing the message")
 	assert.NotContains(t, out, "birdweather_soundscape_encode_failed",
 		"a successful encode must not emit the failure tag")
 }

--- a/internal/birdweather/encode_native.go
+++ b/internal/birdweather/encode_native.go
@@ -108,16 +108,18 @@ func (b *BwClient) encodeWithNativeFLAC(pcmData []byte, timestamp string) (*audi
 	// logFLACEncodingError in birdweather_client.go) so success and failure are
 	// distinguishable without parsing the message.
 	//
-	// It does NOT currently affect GET /api/v2/system/events/operational, and an
-	// earlier version of this comment wrongly said it did. That endpoint reads
-	// exactly two files, GetDefaultOutputPath() and GetOutputPath("audio"), so
-	// it only ever sees application.log and audio.log. This package logs through
-	// a module logger, and CentralLogger.Module falls back to the shared base
-	// handler only for a module with NO dedicated output; birdweather has one
-	// (logs/birdweather.log via ensureModuleOutput), so these lines never reach
-	// that endpoint at all. The matching noiseOperations entry is therefore inert
-	// today, kept so the feed does not start carrying per-upload success chatter
-	// if it is ever widened to read the per-module logs.
+	// Whether it reaches GET /api/v2/system/events/operational depends on the
+	// logging configuration, and an earlier version of this comment wrongly said
+	// it always does. That endpoint reads two configured base paths (plus their
+	// rotated variants): GetDefaultOutputPath() and GetOutputPath("audio").
+	// CentralLogger.Module routes to a module's own writer only when that module
+	// has an output entry AND it is enabled, otherwise it falls back to the
+	// shared base handler. On a default install birdweather gets its own file
+	// (ensureModuleOutput, DefaultBirdweatherLogPath), so these lines land
+	// outside what the endpoint reads and never appear there. Disable or
+	// redirect the birdweather module output and they land in the default output
+	// instead, at which point they DO appear, which is what the matching
+	// noiseOperations entry is for.
 	log.Info("Encoded audio to FLAC format (native go-flac)",
 		logger.String("timestamp", timestamp),
 		logger.String("encoder", clipenc.NativeFLAC),

--- a/internal/birdweather/encode_native.go
+++ b/internal/birdweather/encode_native.go
@@ -103,17 +103,21 @@ func (b *BwClient) encodeWithNativeFLAC(pcmData []byte, timestamp string) (*audi
 	// much gain it applied ("my BirdWeather uploads are too quiet"). The Debug
 	// line keeps the full measurement detail.
 	//
-	// operation is what lets the system-events feed treat this line the way it
-	// already treats its sibling. An untagged entry is not unclassifiable, it
-	// simply falls through isNoiseEntry (internal/api/v2/system/events.go) as
-	// "not noise" and is emitted; so before this tag existed, every soundscape
-	// upload showed up in /api/v2/system/events/operational as an INFO event,
-	// once per detection. With the tag, the operation is listed in
-	// noiseOperations alongside audio_export_success, so routine success chatter
-	// is filtered out while birdweather_soundscape_encode_failed (emitted by
-	// logFLACEncodingError in birdweather_client.go) still surfaces. The match is
-	// exact, so listing this tag does not also suppress that one despite the
-	// prefix relationship.
+	// operation names the line for grep and for the system-events classifier,
+	// and pairs with birdweather_soundscape_encode_failed (emitted by
+	// logFLACEncodingError in birdweather_client.go) so success and failure are
+	// distinguishable without parsing the message.
+	//
+	// It does NOT currently affect GET /api/v2/system/events/operational, and an
+	// earlier version of this comment wrongly said it did. That endpoint reads
+	// exactly two files, GetDefaultOutputPath() and GetOutputPath("audio"), so
+	// it only ever sees application.log and audio.log. This package logs through
+	// a module logger, and CentralLogger.Module falls back to the shared base
+	// handler only for a module with NO dedicated output; birdweather has one
+	// (logs/birdweather.log via ensureModuleOutput), so these lines never reach
+	// that endpoint at all. The matching noiseOperations entry is therefore inert
+	// today, kept so the feed does not start carrying per-upload success chatter
+	// if it is ever widened to read the per-module logs.
 	log.Info("Encoded audio to FLAC format (native go-flac)",
 		logger.String("timestamp", timestamp),
 		logger.String("encoder", clipenc.NativeFLAC),


### PR DESCRIPTION
## Summary

Self-reported follow-up to #3989. That PR tagged the BirdWeather soundscape success line with an `operation` and listed that operation in `noiseOperations`, justifying both with a comment claiming the line "showed up in /api/v2/system/events/operational as an INFO event, once per detection" and that the tag now filters it out. Both halves are false, and I wrote them.

`GetOperationalEvents` reads exactly two files, `GetDefaultOutputPath()` and `GetOutputPath("audio")`, so it only ever sees `application.log` and `audio.log`. `CentralLogger.Module` appends the shared base handler only in its `else` branch, i.e. only for a module with no dedicated output; `ensureModuleOutput` gives birdweather `logs/birdweather.log`. Those lines therefore never reach that endpoint, and the `noiseOperations` entry is inert, exactly as the neighbouring `audio_export_success` entry already is.

The entry stays rather than being pruned. The intent is right, and widening the endpoint to read the per-module logs would otherwise immediately flood the feed with per-detection success lines. What changes is that the comments now say what is true, and explicitly note that none of this applies to `audio_export_success` in `detectionOperations`, which IS live because `GetDetectionEvents` reads `GetOutputPath("analysis.processor")` (`logs/actions.log`).

Root cause worth recording: a review agent asserted the line reaches the feed, and I verified `isNoiseEntry`'s matching logic (exact vs prefix, which was correct) without ever checking which log files the endpoint opens. Necessary but not sufficient. The pre-push gate has since gained a check for exactly this class, a comment asserting behaviour the code cannot produce, and this is its first real instance.

No behaviour change. The diff is comments plus one test assertion message that repeated the same claim.

## Test Plan

- [x] `golangci-lint run` clean with the CI build tags
- [x] `go test -race ./internal/birdweather/ ./internal/api/v2/system/` green
- [x] Every log filename asserted in the new comments cross-checked against `internal/logger/config.go` (`logs/birdweather.log`, `logs/actions.log`); an earlier draft of this fix invented `logs/analysis.processor.log` and was corrected before pushing
- [x] Confirmed `noiseOperations` is referenced only by `isNoiseEntry`, which is called only from `GetOperationalEvents`