### PR TITLE
feat(audio): in-memory HLS segment muxer and playlist builder

### DIFF
--- a/internal/audiocore/hlsmux/codec.go
+++ b/internal/audiocore/hlsmux/codec.go
@@ -24,12 +24,6 @@ type Codec struct {
 	// "aac-lc". It never appears in the playlist or in a segment.
 	Name string
 
-	// FrameSamples is the per-channel sample count of one access unit, 1024
-	// for AAC-LC. Zero means the codec emits variable-length frames, in which
-	// case the muxer records each unit's own duration instead of declaring a
-	// default for the fragment.
-	FrameSamples int
-
 	// newEncoder builds the per-stream encoder.
 	newEncoder func(EncoderConfig) (FrameEncoder, error)
 

--- a/internal/audiocore/hlsmux/codec.go
+++ b/internal/audiocore/hlsmux/codec.go
@@ -24,6 +24,13 @@ type Codec struct {
 	// "aac-lc". It never appears in the playlist or in a segment.
 	Name string
 
+	// MaxFrameSamples is the largest per-channel sample count one access unit
+	// can carry, 1024 for AAC-LC. It exists so New can reject a segment target
+	// smaller than a single access unit, a configuration that would otherwise
+	// build successfully and then refuse every frame the encoder produced.
+	// Zero means the codec does not declare a bound, and the check is skipped.
+	MaxFrameSamples int
+
 	// newEncoder builds the per-stream encoder.
 	newEncoder func(EncoderConfig) (FrameEncoder, error)
 

--- a/internal/audiocore/hlsmux/codec.go
+++ b/internal/audiocore/hlsmux/codec.go
@@ -1,0 +1,46 @@
+package hlsmux
+
+import (
+	m4a "github.com/tphakala/go-m4a"
+)
+
+// Codec bundles everything the muxer needs to know about an audio codec: how
+// to build an encoder for it, and how to describe it to the container.
+//
+// The two function fields are unexported, so a Codec can only be constructed
+// inside this package. That is the point: it makes "the codec is a parameter"
+// structural rather than a convention. A caller selects a codec, it cannot
+// invent one, and no file outside the one that defines a given codec has to
+// name it.
+//
+// Note what is deliberately absent: an RFC 6381 codec string. That belongs to
+// the CODECS attribute of EXT-X-STREAM-INF, which exists only in a master
+// playlist. This package emits a media playlist, where RFC 8216 gives CODECS
+// no home, so a player learns the codec by probing the init segment instead.
+// Add the field when and if a master playlist is added; carrying it unused
+// would only rot.
+type Codec struct {
+	// Name identifies the codec in configuration and in logs, for example
+	// "aac-lc". It never appears in the playlist or in a segment.
+	Name string
+
+	// FrameSamples is the per-channel sample count of one access unit, 1024
+	// for AAC-LC. Zero means the codec emits variable-length frames, in which
+	// case the muxer records each unit's own duration instead of declaring a
+	// default for the fragment.
+	FrameSamples int
+
+	// newEncoder builds the per-stream encoder.
+	newEncoder func(EncoderConfig) (FrameEncoder, error)
+
+	// writerConfig builds the go-m4a configuration describing this codec's
+	// sample entry. It runs after the encoder exists, because the container
+	// needs the encoder's decoder configuration and priming delay.
+	writerConfig func(EncoderConfig, FrameEncoder) (m4a.WriterConfig, error)
+}
+
+// valid reports whether c was built by this package rather than zero valued.
+// A zero Codec would otherwise fail later with a nil dereference inside New.
+func (c *Codec) valid() bool {
+	return c.newEncoder != nil && c.writerConfig != nil
+}

--- a/internal/audiocore/hlsmux/encoder.go
+++ b/internal/audiocore/hlsmux/encoder.go
@@ -14,8 +14,10 @@
 // cheaper to encode, which is the escape hatch if AAC proves too expensive on
 // the smallest ARM boards.
 //
-// This path is gated at the call site (see internal/conf/native_encoders.go);
-// HLS live streaming still defaults to FFmpeg.
+// Nothing constructs a Stream yet: the concrete codec and the wiring into the
+// v2 HLS handler land together, behind the BIRDNET_HLS_ENCODER gate in
+// internal/conf/native_encoders.go. Until then HLS live streaming runs entirely
+// through FFmpeg and this package is unreachable from production code.
 package hlsmux
 
 // EmitFunc receives one coded access unit and the per-channel sample count it
@@ -26,6 +28,10 @@ package hlsmux
 // encoder reuse a single scratch buffer for the whole stream. go-m4a's
 // FragmentWriter copies on WriteFrameDuration, so the muxer in this package
 // can pass the borrowed slice straight through.
+//
+// EmitFunc runs with the stream's lock already held, so it must not call back
+// into any Stream method. Go mutexes are not reentrant and doing so would
+// deadlock the audio goroutine.
 type EmitFunc func(au []byte, samples int) error
 
 // FrameEncoder turns interleaved PCM into coded access units, reporting each

--- a/internal/audiocore/hlsmux/encoder.go
+++ b/internal/audiocore/hlsmux/encoder.go
@@ -1,0 +1,78 @@
+// Package hlsmux turns a live PCM stream into HLS media segments and the
+// playlist that indexes them, with no FFmpeg process involved.
+//
+// It is deliberately pure: PCM goes in through Write, fragmented-MP4 (CMAF)
+// segments and an m3u8 playlist come out of the accessors, and nothing in here
+// touches the filesystem, the network or a subprocess. That is what makes the
+// segment cutting, the timeline arithmetic and the playlist shape table
+// testable without a live audio source.
+//
+// The codec is a parameter rather than a hardcode. A Codec value supplies the
+// encoder constructor and the muxer configuration, and no other file in the
+// package names a codec. Threading it through costs nothing and keeps the door
+// open: go-m4a already muxes Opus and FLAC, and Opus is roughly three times
+// cheaper to encode, which is the escape hatch if AAC proves too expensive on
+// the smallest ARM boards.
+//
+// This path is gated at the call site (see internal/conf/native_encoders.go);
+// HLS live streaming still defaults to FFmpeg.
+package hlsmux
+
+// EmitFunc receives one coded access unit and the per-channel sample count it
+// decodes to.
+//
+// The au slice is borrowed: it is valid only until EmitFunc returns, so an
+// implementation that needs to retain the bytes must copy them. This lets an
+// encoder reuse a single scratch buffer for the whole stream. go-m4a's
+// FragmentWriter copies on WriteFrameDuration, so the muxer in this package
+// can pass the borrowed slice straight through.
+type EmitFunc func(au []byte, samples int) error
+
+// FrameEncoder turns interleaved PCM into coded access units, reporting each
+// unit through a callback rather than writing a self-framing stream. A muxer
+// needs the units and their boundaries separately; a framed stream such as
+// ADTS would have to be re-split to recover them.
+//
+// One live stream owns one FrameEncoder. Implementations are not required to
+// be safe for concurrent use.
+type FrameEncoder interface {
+	// EncodeInterleaved consumes pcm, buffering any partial trailing frame,
+	// and calls emit once per complete access unit. A short write is
+	// therefore normal and emits nothing.
+	EncodeInterleaved(pcm []byte, emit EmitFunc) error
+
+	// Flush drains the encoder lookahead so the final samples of a stream are
+	// emitted rather than lost. Encoders that delay output by a frame (AAC-LC
+	// does) would otherwise drop the tail on every stream teardown.
+	Flush(emit EmitFunc) error
+
+	// DecoderConfig returns the codec-specific decoder configuration the
+	// container must carry: the MPEG-4 AudioSpecificConfig for AAC-LC, the
+	// STREAMINFO block for FLAC, or nil for a codec that needs none. The
+	// caller owns the returned bytes.
+	DecoderConfig() []byte
+
+	// Delay is the number of leading priming samples the muxer trims with an
+	// edit list. Zero means the codec has no priming.
+	Delay() int
+
+	// Close releases whatever the encoder holds. Pure-Go encoders have
+	// nothing to release and can return nil, but the method keeps a pooled or
+	// cgo-backed implementation from having to retrofit the interface.
+	Close() error
+}
+
+// EncoderConfig is the codec-independent description of the audio an encoder
+// is being asked to produce. Anything codec-specific belongs in the Codec that
+// builds the encoder, not here.
+type EncoderConfig struct {
+	// SampleRate is the output sample rate in Hz.
+	SampleRate int
+
+	// Channels is the output channel count.
+	Channels int
+
+	// BitrateKbps is the target bitrate in kilobits per second. Encoders for
+	// lossless codecs ignore it.
+	BitrateKbps int
+}

--- a/internal/audiocore/hlsmux/fake_test.go
+++ b/internal/audiocore/hlsmux/fake_test.go
@@ -27,7 +27,10 @@ const (
 )
 
 // errFakeEncoder is returned by a fake encoder configured to fail.
-var errFakeEncoder = errors.New("fake encoder failure")
+var (
+	errFakeEncoder = errors.New("fake encoder failure")
+	errFakeClose   = errors.New("fake encoder close failure")
+)
 
 // fakeEncoder emits deterministic access units without coding any audio.
 //
@@ -57,6 +60,16 @@ type fakeEncoder struct {
 	// that many access units.
 	failAfter int
 
+	// flushErr and closeErr make Flush and Close fail, so the stream's
+	// teardown error paths are reachable.
+	flushErr error
+	closeErr error
+
+	// stamp is the byte written into every sample of the next access unit,
+	// recorded per unit so a test can check the muxer preserved each one
+	// rather than aliasing the reused scratch buffer.
+	stamps []byte
+
 	emitted int
 	closed  bool
 	scratch []byte
@@ -74,9 +87,14 @@ func (f *fakeEncoder) emitOne(samples int, emit EmitFunc) error {
 		f.scratch = make([]byte, size)
 	}
 	f.scratch = f.scratch[:size]
+	// A stamp that is never a plausible container byte, so a test can look for
+	// it in the payload without matching box headers by accident. Cycling
+	// through the high half keeps consecutive units distinguishable.
+	stamp := byte(0x80 + f.emitted%0x7f)
 	for i := range f.scratch {
-		f.scratch[i] = byte(f.emitted)
+		f.scratch[i] = stamp
 	}
+	f.stamps = append(f.stamps, stamp)
 	f.emitted++
 	return emit(f.scratch, samples)
 }
@@ -97,6 +115,9 @@ func (f *fakeEncoder) EncodeInterleaved(pcm []byte, emit EmitFunc) error {
 }
 
 func (f *fakeEncoder) Flush(emit EmitFunc) error {
+	if f.flushErr != nil {
+		return f.flushErr
+	}
 	if f.tailSamples <= 0 {
 		return nil
 	}
@@ -110,7 +131,7 @@ func (f *fakeEncoder) Delay() int            { return f.delay }
 
 func (f *fakeEncoder) Close() error {
 	f.closed = true
-	return nil
+	return f.closeErr
 }
 
 // fakeCodecOptions configures the codec returned by newFakeCodec.
@@ -121,12 +142,18 @@ type fakeCodecOptions struct {
 	tailSamples int
 	failAfter   int
 
-	// declaredFrameSamples is what the Codec advertises. Leaving it zero
-	// models a variable-frame codec.
-	declaredFrameSamples int
+	// flushErr and closeErr make the encoder's teardown fail.
+	flushErr error
+	closeErr error
 
-	// encoderErr makes construction of the encoder fail.
+	// encoderErr makes construction of the encoder fail; writerErr makes the
+	// container configuration fail after the encoder already exists.
 	encoderErr error
+	writerErr  error
+
+	// nilEncoder makes the constructor return (nil, nil), the shape that would
+	// otherwise panic inside New.
+	nilEncoder bool
 
 	// captured receives the encoder once built, so a test can inspect it.
 	captured **fakeEncoder
@@ -142,11 +169,13 @@ func newFakeCodec(opts *fakeCodecOptions) Codec {
 		name = "fake"
 	}
 	return Codec{
-		Name:         name,
-		FrameSamples: opts.declaredFrameSamples,
+		Name: name,
 		newEncoder: func(cfg EncoderConfig) (FrameEncoder, error) {
 			if opts.encoderErr != nil {
 				return nil, opts.encoderErr
+			}
+			if opts.nilEncoder {
+				return nil, nil //nolint:nilnil // deliberately the malformed shape New must reject
 			}
 			enc := &fakeEncoder{
 				channels:    cfg.Channels,
@@ -154,6 +183,8 @@ func newFakeCodec(opts *fakeCodecOptions) Codec {
 				delay:       opts.delay,
 				tailSamples: opts.tailSamples,
 				failAfter:   opts.failAfter,
+				flushErr:    opts.flushErr,
+				closeErr:    opts.closeErr,
 			}
 			if opts.captured != nil {
 				*opts.captured = enc
@@ -161,6 +192,9 @@ func newFakeCodec(opts *fakeCodecOptions) Codec {
 			return enc, nil
 		},
 		writerConfig: func(cfg EncoderConfig, enc FrameEncoder) (m4a.WriterConfig, error) {
+			if opts.writerErr != nil {
+				return m4a.WriterConfig{}, opts.writerErr
+			}
 			return m4a.WriterConfig{
 				Codec:        m4a.CodecFLAC,
 				SampleRate:   cfg.SampleRate,

--- a/internal/audiocore/hlsmux/fake_test.go
+++ b/internal/audiocore/hlsmux/fake_test.go
@@ -168,8 +168,15 @@ func newFakeCodec(opts *fakeCodecOptions) Codec {
 	if name == "" {
 		name = "fake"
 	}
+	maxFrame := 0
+	for _, n := range opts.frameSizes {
+		if n > maxFrame {
+			maxFrame = n
+		}
+	}
 	return Codec{
-		Name: name,
+		Name:            name,
+		MaxFrameSamples: maxFrame,
 		newEncoder: func(cfg EncoderConfig) (FrameEncoder, error) {
 			if opts.encoderErr != nil {
 				return nil, opts.encoderErr

--- a/internal/audiocore/hlsmux/fake_test.go
+++ b/internal/audiocore/hlsmux/fake_test.go
@@ -1,0 +1,178 @@
+package hlsmux
+
+import (
+	"errors"
+
+	m4a "github.com/tphakala/go-m4a"
+)
+
+// The fakes below deliberately avoid the real codec. Two reasons: the AAC
+// encoder this package will ship with does not exist yet, and testing against
+// a codec that is not the production one is the only way to prove the muxer is
+// actually codec neutral rather than merely claiming to be.
+//
+// go-m4a's FLAC path is used for the container side because it is the least
+// constrained: it accepts any positive sample rate, only length-checks its
+// STREAMINFO, and has no priming of its own, so the test can vary frame size
+// and encoder delay independently of what any real codec would do.
+
+const (
+	// flacStreamInfoLen is the fixed size of a FLAC STREAMINFO metadata block,
+	// which is all go-m4a validates about it.
+	flacStreamInfoLen = 34
+
+	// fakeAUBytesPerSample sizes a fake access unit so segments have a
+	// plausible byte size without encoding anything.
+	fakeAUBytesPerSample = 2
+)
+
+// errFakeEncoder is returned by a fake encoder configured to fail.
+var errFakeEncoder = errors.New("fake encoder failure")
+
+// fakeEncoder emits deterministic access units without coding any audio.
+//
+// It reuses one scratch buffer across every emit, which is what makes it a
+// real test of the EmitFunc borrowing contract: if the muxer retained the
+// slice instead of letting go-m4a copy it, every access unit in a segment
+// would end up with the last unit's contents.
+type fakeEncoder struct {
+	channels int
+
+	// frameSizes is cycled to determine each access unit's sample count. A
+	// single-entry slice models a fixed-frame codec such as AAC-LC.
+	frameSizes []int
+	frameIdx   int
+
+	// delay is the priming sample count reported to the container.
+	delay int
+
+	// pending is the sample count buffered but not yet large enough to emit.
+	pending int
+
+	// tailSamples is emitted by Flush, modelling an encoder that holds a
+	// lookahead frame back until the stream ends.
+	tailSamples int
+
+	// failAfter, when positive, makes the encoder fail once it has emitted
+	// that many access units.
+	failAfter int
+
+	emitted int
+	closed  bool
+	scratch []byte
+}
+
+// emitOne hands one access unit of the given sample count to emit, reusing the
+// scratch buffer and filling it with a value derived from the emit index so a
+// test can tell units apart.
+func (f *fakeEncoder) emitOne(samples int, emit EmitFunc) error {
+	if f.failAfter > 0 && f.emitted >= f.failAfter {
+		return errFakeEncoder
+	}
+	size := samples * fakeAUBytesPerSample
+	if cap(f.scratch) < size {
+		f.scratch = make([]byte, size)
+	}
+	f.scratch = f.scratch[:size]
+	for i := range f.scratch {
+		f.scratch[i] = byte(f.emitted)
+	}
+	f.emitted++
+	return emit(f.scratch, samples)
+}
+
+func (f *fakeEncoder) EncodeInterleaved(pcm []byte, emit EmitFunc) error {
+	f.pending += len(pcm) / (f.channels * bytesPerSample)
+	for {
+		size := f.frameSizes[f.frameIdx%len(f.frameSizes)]
+		if f.pending < size {
+			return nil
+		}
+		f.pending -= size
+		f.frameIdx++
+		if err := f.emitOne(size, emit); err != nil {
+			return err
+		}
+	}
+}
+
+func (f *fakeEncoder) Flush(emit EmitFunc) error {
+	if f.tailSamples <= 0 {
+		return nil
+	}
+	samples := f.tailSamples
+	f.tailSamples = 0
+	return f.emitOne(samples, emit)
+}
+
+func (f *fakeEncoder) DecoderConfig() []byte { return make([]byte, flacStreamInfoLen) }
+func (f *fakeEncoder) Delay() int            { return f.delay }
+
+func (f *fakeEncoder) Close() error {
+	f.closed = true
+	return nil
+}
+
+// fakeCodecOptions configures the codec returned by newFakeCodec.
+type fakeCodecOptions struct {
+	name        string
+	frameSizes  []int
+	delay       int
+	tailSamples int
+	failAfter   int
+
+	// declaredFrameSamples is what the Codec advertises. Leaving it zero
+	// models a variable-frame codec.
+	declaredFrameSamples int
+
+	// encoderErr makes construction of the encoder fail.
+	encoderErr error
+
+	// captured receives the encoder once built, so a test can inspect it.
+	captured **fakeEncoder
+}
+
+// newFakeCodec builds a Codec backed by fakeEncoder.
+func newFakeCodec(opts *fakeCodecOptions) Codec {
+	if len(opts.frameSizes) == 0 {
+		opts.frameSizes = []int{1024}
+	}
+	name := opts.name
+	if name == "" {
+		name = "fake"
+	}
+	return Codec{
+		Name:         name,
+		FrameSamples: opts.declaredFrameSamples,
+		newEncoder: func(cfg EncoderConfig) (FrameEncoder, error) {
+			if opts.encoderErr != nil {
+				return nil, opts.encoderErr
+			}
+			enc := &fakeEncoder{
+				channels:    cfg.Channels,
+				frameSizes:  opts.frameSizes,
+				delay:       opts.delay,
+				tailSamples: opts.tailSamples,
+				failAfter:   opts.failAfter,
+			}
+			if opts.captured != nil {
+				*opts.captured = enc
+			}
+			return enc, nil
+		},
+		writerConfig: func(cfg EncoderConfig, enc FrameEncoder) (m4a.WriterConfig, error) {
+			return m4a.WriterConfig{
+				Codec:        m4a.CodecFLAC,
+				SampleRate:   cfg.SampleRate,
+				Channels:     cfg.Channels,
+				STREAMINFO:   enc.DecoderConfig(),
+				EncoderDelay: enc.Delay(),
+			}, nil
+		},
+	}
+}
+
+// silence returns samples worth of interleaved 16-bit PCM for channels.
+func silence(samples, channels int) []byte {
+	return make([]byte, samples*channels*bytesPerSample)
+}

--- a/internal/audiocore/hlsmux/hlsmux.go
+++ b/internal/audiocore/hlsmux/hlsmux.go
@@ -307,13 +307,31 @@ func New(cfg *Config) (*Stream, error) {
 	}
 
 	rate := int64(cfg.SampleRate)
+	targetSamples := int(int64(segmentDuration) * rate / int64(time.Second))
+	// A segment must be able to hold at least one access unit. Without this,
+	// a low sample rate or a short segment builds a Stream that looks fine and
+	// then rejects every frame the encoder emits, surfacing as a latched
+	// failure on the audio goroutine rather than as a configuration error the
+	// caller can act on.
+	switch {
+	case targetSamples < 1:
+		return nil, closeEncoderAndWrap(enc, fmt.Errorf(
+			"hlsmux: %s at %d Hz is less than one sample per segment",
+			segmentDuration, cfg.SampleRate), cfg.Codec.Name)
+	case cfg.Codec.MaxFrameSamples > 0 && targetSamples < cfg.Codec.MaxFrameSamples:
+		return nil, closeEncoderAndWrap(enc, fmt.Errorf(
+			"hlsmux: %s at %d Hz gives a %d-sample segment, smaller than codec %q's %d-sample access unit",
+			segmentDuration, cfg.SampleRate, targetSamples, cfg.Codec.Name, cfg.Codec.MaxFrameSamples),
+			cfg.Codec.Name)
+	}
+
 	s := &Stream{
 		codecName:          cfg.Codec.Name,
 		enc:                enc,
 		frag:               frag,
 		initSeg:            initSeg,
 		segments:           newRing(windowSize),
-		targetSamples:      int(int64(segmentDuration) * rate / int64(time.Second)),
+		targetSamples:      targetSamples,
 		maxSegmentDuration: segmentDuration,
 		targetDuration:     ceilSeconds(segmentDuration),
 		maxStallGap:        maxStallGap,

--- a/internal/audiocore/hlsmux/hlsmux.go
+++ b/internal/audiocore/hlsmux/hlsmux.go
@@ -14,9 +14,13 @@ const (
 	// component is the error-telemetry component name for this package.
 	component = "audiocore/hlsmux"
 
-	// bitDepth16 is the only PCM bit depth this muxer accepts. The capture
-	// pipeline is 16-bit end to end, and accepting a width the encoders would
-	// silently reinterpret buys nothing.
+	// bitDepth16 is the PCM sample width this muxer assumes. The capture
+	// pipeline is 16-bit end to end.
+	//
+	// Note this is an assumption, not a check: Config carries no bit depth and
+	// Write takes raw bytes, so a wider input is only caught when it happens to
+	// break the sample-frame alignment test, which 24- and 32-bit stereo do
+	// not. Callers are responsible for delivering 16-bit PCM.
 	bitDepth16 = 16
 
 	// bytesPerSample is the width of one sample of one channel at bitDepth16.
@@ -27,21 +31,42 @@ const (
 	// latency low, long enough that per-segment overhead stays negligible.
 	DefaultSegmentDuration = 2 * time.Second
 
+	// MinSegmentDuration and MaxSegmentDuration bound what a caller may ask
+	// for. The floor keeps SegmentDuration above one sample period, below
+	// which every access unit would become its own segment; the ceiling keeps
+	// the segment inside go-m4a's own per-segment limits and keeps the
+	// duration-to-samples conversion far from overflow.
+	MinSegmentDuration = 100 * time.Millisecond
+	MaxSegmentDuration = 60 * time.Second
+
 	// DefaultWindowSize is how many media segments the playlist advertises.
 	// It must stay above hls.js's liveSyncDurationCount, which is why the
 	// FFmpeg path settled on six as well.
 	DefaultWindowSize = 6
 
-	// DefaultMaxStallGap is how far the incoming frame timestamps may diverge
-	// from the sample clock before the timeline is treated as broken rather
-	// than jittery. Below this the difference is absorbed silently; above it
-	// the stream cuts a segment and declares a discontinuity.
+	// defaultStallGapFraction divides the effective segment duration to give
+	// the default stall threshold, so the default tracks the configured
+	// segment length instead of pinning to the package default.
 	//
-	// Half a segment is the useful boundary: smaller gaps are indistinguishable
-	// from ordinary scheduling jitter and buffer bunching, while anything
-	// larger means real audio is missing and a player that kept decoding
-	// straight through would report a wall-clock time that never happened.
-	DefaultMaxStallGap = DefaultSegmentDuration / 2
+	// Half a segment is the useful boundary: smaller divergences are absorbed
+	// as drift (see driftCorrectionShift), while a jump larger than this means
+	// real audio is missing and a player that decoded straight through would
+	// report a wall-clock time that never happened.
+	defaultStallGapFraction = 2
+
+	// driftCorrectionShift sets how fast the projected sample clock is pulled
+	// back toward the timestamps actually arriving, as a right shift of the
+	// observed difference (4 => one sixteenth per write).
+	//
+	// Without this the projection only ever advances by sample count, so any
+	// difference between the source's sample clock and wall clock accumulates
+	// forever. A commodity 100 ppm crystal reaches a one-second divergence in
+	// under three hours, which would then be reported as a stall on a
+	// perfectly healthy stream. Correcting a fraction per write absorbs that
+	// steady error while leaving a genuine step change well above the
+	// threshold on the write that carries it, because the threshold is tested
+	// before the correction is applied.
+	driftCorrectionShift = 4
 )
 
 // Config describes the live stream to be produced. Everything codec-specific
@@ -61,13 +86,15 @@ type Config struct {
 	// Channels is the output channel count, 1 or 2. Required.
 	Channels int
 
-	// BitrateKbps is the target bitrate passed to the encoder. Required for
-	// lossy codecs.
+	// BitrateKbps is the target bitrate passed to the encoder. Zero leaves the
+	// choice to the codec.
 	BitrateKbps int
 
-	// SegmentDuration is the nominal media segment length. Segments are cut on
-	// access-unit boundaries, so the real duration lands within one access
-	// unit of this. Zero selects DefaultSegmentDuration.
+	// SegmentDuration is the maximum media segment length. Segments are cut on
+	// access-unit boundaries at or below this, never above it, so the playlist
+	// can advertise it as a true target duration. Zero selects
+	// DefaultSegmentDuration; a non-zero value must lie between
+	// MinSegmentDuration and MaxSegmentDuration.
 	SegmentDuration time.Duration
 
 	// WindowSize is how many segments the playlist advertises and the stream
@@ -75,14 +102,36 @@ type Config struct {
 	WindowSize int
 
 	// MaxStallGap is the timestamp divergence that triggers a discontinuity.
-	// Zero selects DefaultMaxStallGap.
+	// Zero selects half the effective SegmentDuration.
 	MaxStallGap time.Duration
+}
+
+// Stats is a point-in-time view of a stream's health, for the caller to log or
+// surface. The muxer itself neither logs nor measures anything.
+type Stats struct {
+	// Segments is how many media segments have been cut for the life of the
+	// stream, which is also the sequence number the next one will take.
+	Segments uint64
+
+	// Retained is how many segments the playlist currently advertises.
+	Retained int
+
+	// Discontinuities is how many timeline breaks have been declared.
+	Discontinuities uint64
+
+	// LastSegmentPDT is the wall-clock start of the most recently cut segment,
+	// zero before the first cut. A value that stops advancing is the native
+	// equivalent of the FFmpeg path's stale-segment check.
+	LastSegmentPDT time.Time
+
+	// Failed reports that an encode error has latched the stream unusable.
+	Failed bool
 }
 
 // Stream encodes and muxes one live audio source into HLS media segments and
 // the playlist indexing them, holding everything in memory.
 //
-// Write is called from the audio feed goroutine; Playlist, Segment and
+// Write is called from the audio feed goroutine; Playlist, Segment, Stats and
 // InitSegment are called from HTTP handlers. All of them are safe to call
 // concurrently.
 type Stream struct {
@@ -91,17 +140,27 @@ type Stream struct {
 	// the read side.
 	mu sync.Mutex
 
-	codec    Codec
-	enc      FrameEncoder
-	frag     *m4a.FragmentWriter
-	initSeg  []byte
-	segments *ring
+	codecName string
+	enc       FrameEncoder
+	frag      *m4a.FragmentWriter
+	initSeg   []byte
+	segments  *ring
 
-	// targetSamples is SegmentDuration expressed in samples, the threshold a
-	// segment's accumulated access units must reach before it is cut.
-	targetSamples int
-	maxStallGap   time.Duration
-	frameBytes    int
+	// emit is appendAccessUnit bound to this Stream, built once. Passing the
+	// method value directly would build a fresh closure on every Write, which
+	// escapes because it crosses an interface call, so it would be one heap
+	// allocation per audio frame for a value that never changes.
+	emit EmitFunc
+
+	// targetSamples is the segment length in samples; a segment is cut before
+	// it would exceed this, never after. maxSegmentDuration is the same bound
+	// as a duration, and targetDuration is its ceiling in whole seconds.
+	targetSamples      int
+	maxSegmentDuration time.Duration
+	targetDuration     int
+
+	maxStallGap time.Duration
+	frameBytes  int
 
 	// segClock converts a cut segment's sample count to its exact duration;
 	// inClock does the same for incoming PCM to project the next expected
@@ -118,8 +177,9 @@ type Stream struct {
 	pendingSamples int
 
 	// segPDT is the wall-clock time of the first sample of the segment
-	// currently accumulating.
-	segPDT time.Time
+	// currently accumulating; lastSegmentPDT is that of the last one cut.
+	segPDT         time.Time
+	lastSegmentPDT time.Time
 
 	// nextSampleTime is the wall-clock time the next incoming sample is
 	// expected to carry. Comparing it against the timestamp that actually
@@ -131,8 +191,12 @@ type Stream struct {
 	discontinuities uint64
 	pendingBreak    bool
 
+	// segBufHint sizes the buffer each cut segment is built into, tracking the
+	// previous segment's length so a steady-state stream stops re-growing.
+	segBufHint int
+
 	started bool
-	ended   bool
+	failed  bool
 	closed  bool
 }
 
@@ -182,8 +246,14 @@ func New(cfg *Config) (*Stream, error) {
 	if err != nil {
 		return nil, errors.New(err).
 			Component(component).
-			Category(errors.CategoryAudio).
+			Category(errors.CategoryValidation).
 			Context("codec", cfg.Codec.Name).
+			Build()
+	}
+	if enc == nil {
+		return nil, errors.Newf("hlsmux: codec %q built a nil encoder", cfg.Codec.Name).
+			Component(component).
+			Category(errors.CategoryValidation).
 			Build()
 	}
 
@@ -212,22 +282,41 @@ func New(cfg *Config) (*Stream, error) {
 	}
 	maxStallGap := cfg.MaxStallGap
 	if maxStallGap == 0 {
-		maxStallGap = DefaultMaxStallGap
+		maxStallGap = segmentDuration / defaultStallGapFraction
 	}
 
 	rate := int64(cfg.SampleRate)
-	return &Stream{
-		codec:         cfg.Codec,
-		enc:           enc,
-		frag:          frag,
-		initSeg:       initSeg,
-		segments:      newRing(windowSize),
-		targetSamples: int(segmentDuration * time.Duration(cfg.SampleRate) / time.Second),
-		maxStallGap:   maxStallGap,
-		frameBytes:    cfg.Channels * bytesPerSample,
-		segClock:      sampleClock{rate: rate},
-		inClock:       sampleClock{rate: rate},
-	}, nil
+	s := &Stream{
+		codecName:          cfg.Codec.Name,
+		enc:                enc,
+		frag:               frag,
+		initSeg:            initSeg,
+		segments:           newRing(windowSize),
+		targetSamples:      int(int64(segmentDuration) * rate / int64(time.Second)),
+		maxSegmentDuration: segmentDuration,
+		targetDuration:     ceilSeconds(segmentDuration),
+		maxStallGap:        maxStallGap,
+		frameBytes:         cfg.Channels * bytesPerSample,
+		segClock:           sampleClock{rate: rate},
+		inClock:            sampleClock{rate: rate},
+	}
+	s.emit = s.appendAccessUnit
+	return s, nil
+}
+
+// ceilSeconds rounds a duration up to whole seconds, with a floor of one.
+//
+// EXT-X-TARGETDURATION is a whole number of seconds that every segment must
+// fit within, so the ceiling of the segment bound is the smallest value that
+// is always truthful. Rounding to nearest instead would understate a 2.4 s
+// bound as 2, which RFC 8216 tolerates on a rounding reading but Apple's
+// mediastreamvalidator treats as a segment overrunning its target.
+func ceilSeconds(d time.Duration) int {
+	secs := int((d + time.Second - 1) / time.Second)
+	if secs < 1 {
+		return 1
+	}
+	return secs
 }
 
 // closeEncoderAndWrap releases a half-built stream's encoder and wraps the
@@ -239,7 +328,7 @@ func closeEncoderAndWrap(enc FrameEncoder, err error, codecName string) error {
 	}
 	return errors.New(err).
 		Component(component).
-		Category(errors.CategoryAudio).
+		Category(errors.CategoryValidation).
 		Context("codec", codecName).
 		Build()
 }
@@ -248,153 +337,156 @@ func closeEncoderAndWrap(enc FrameEncoder, err error, codecName string) error {
 func (c *Config) validate() error {
 	switch {
 	case !c.Codec.valid():
-		return errors.Newf("hlsmux: codec is not set").
-			Component(component).
-			Category(errors.CategoryValidation).
-			Build()
+		return validationErr("hlsmux: codec is not set")
 	case c.SampleRate <= 0:
-		return errors.Newf("hlsmux: sample rate must be positive, got %d", c.SampleRate).
-			Component(component).
-			Category(errors.CategoryValidation).
-			Build()
+		return validationErr("hlsmux: sample rate must be positive, got %d", c.SampleRate)
 	case c.Channels != 1 && c.Channels != 2:
-		return errors.Newf("hlsmux: channel count must be 1 or 2, got %d", c.Channels).
-			Component(component).
-			Category(errors.CategoryValidation).
-			Build()
+		return validationErr("hlsmux: channel count must be 1 or 2, got %d", c.Channels)
 	case c.BitrateKbps < 0:
-		return errors.Newf("hlsmux: bitrate must not be negative, got %d kbps", c.BitrateKbps).
-			Component(component).
-			Category(errors.CategoryValidation).
-			Build()
-	case c.SegmentDuration < 0:
-		return errors.Newf("hlsmux: segment duration must not be negative, got %s", c.SegmentDuration).
-			Component(component).
-			Category(errors.CategoryValidation).
-			Build()
+		return validationErr("hlsmux: bitrate must not be negative, got %d kbps", c.BitrateKbps)
+	case c.SegmentDuration != 0 && c.SegmentDuration < MinSegmentDuration:
+		return validationErr("hlsmux: segment duration %s is below the minimum of %s", c.SegmentDuration, MinSegmentDuration)
+	case c.SegmentDuration > MaxSegmentDuration:
+		return validationErr("hlsmux: segment duration %s exceeds the maximum of %s", c.SegmentDuration, MaxSegmentDuration)
 	case c.WindowSize < 0:
-		return errors.Newf("hlsmux: window size must not be negative, got %d", c.WindowSize).
-			Component(component).
-			Category(errors.CategoryValidation).
-			Build()
+		return validationErr("hlsmux: window size must not be negative, got %d", c.WindowSize)
 	case c.MaxStallGap < 0:
-		return errors.Newf("hlsmux: max stall gap must not be negative, got %s", c.MaxStallGap).
-			Component(component).
-			Category(errors.CategoryValidation).
-			Build()
+		return validationErr("hlsmux: max stall gap must not be negative, got %s", c.MaxStallGap)
 	}
 	return nil
 }
 
+// validationErr builds a configuration error with this package's component and
+// category, so the many validate arms stay readable.
+func validationErr(format string, args ...any) error {
+	return errors.Newf(format, args...).
+		Component(component).
+		Category(errors.CategoryValidation).
+		Build()
+}
+
+// audioErr builds a runtime error with this package's component and category.
+func (s *Stream) audioErr(err error) error {
+	return errors.New(err).
+		Component(component).
+		Category(errors.CategoryAudio).
+		Context("codec", s.codecName).
+		Build()
+}
+
 // Write encodes interleaved PCM and appends the resulting access units to the
-// segment being accumulated, cutting a segment whenever it reaches the target
-// duration.
+// segment being accumulated, cutting a segment whenever the next unit would
+// take it past the target duration.
 //
 // ts is the wall-clock capture time of the first sample in pcm. It is what
 // anchors EXT-X-PROGRAM-DATE-TIME to real time. Deriving the time from the
 // sample count alone would be wrong for a monitoring system: a source that
 // stalls and resumes produces no samples for the gap, so every later timestamp
 // would be early by the length of the stall, permanently and silently. When
-// the gap exceeds MaxStallGap the stream instead declares a discontinuity and
-// re-anchors to ts.
+// the divergence exceeds MaxStallGap the stream declares a discontinuity and
+// re-anchors to ts; smaller divergences are absorbed as clock drift.
+//
+// An encode failure latches the stream: the timeline cannot be reconciled with
+// audio that was consumed but never encoded, so every later Write is refused
+// and the caller must tear the stream down rather than continue with a
+// silently shifted timeline.
 func (s *Stream) Write(pcm []byte, ts time.Time) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if s.closed {
-		return errors.Newf("hlsmux: write to a closed stream").
-			Component(component).
-			Category(errors.CategoryAudio).
-			Build()
-	}
-	if len(pcm) == 0 {
+	switch {
+	case s.closed:
+		return validationErr("hlsmux: write to a closed stream")
+	case s.failed:
+		return validationErr("hlsmux: write to a stream that failed encoding")
+	case ts.IsZero():
+		return validationErr("hlsmux: write with a zero capture timestamp")
+	case len(pcm) == 0:
 		return nil
-	}
-	if len(pcm)%s.frameBytes != 0 {
-		return errors.Newf("hlsmux: PCM length %d is not a multiple of the %d-byte sample frame", len(pcm), s.frameBytes).
-			Component(component).
-			Category(errors.CategoryValidation).
-			Build()
+	case len(pcm)%s.frameBytes != 0:
+		return validationErr("hlsmux: PCM length %d is not a multiple of the %d-byte sample frame", len(pcm), s.frameBytes)
 	}
 
-	if err := s.syncTimeline(ts); err != nil {
-		return err
-	}
+	s.syncTimeline(ts)
 
 	// Project where the following frame should start before encoding, so the
 	// projection is unaffected by how the encoder buffers this input.
 	s.nextSampleTime = s.nextSampleTime.Add(s.inClock.advance(len(pcm) / s.frameBytes))
 
-	if err := s.enc.EncodeInterleaved(pcm, s.appendAccessUnit); err != nil {
-		return errors.New(err).
-			Component(component).
-			Category(errors.CategoryAudio).
-			Context("codec", s.codec.Name).
-			Build()
+	if err := s.enc.EncodeInterleaved(pcm, s.emit); err != nil {
+		s.failed = true
+		return s.audioErr(err)
 	}
 	return nil
 }
 
 // syncTimeline anchors the stream on its first write and, on later writes,
-// decides whether the incoming timestamp represents ordinary jitter or a real
+// decides whether the incoming timestamp represents ordinary drift or a real
 // break in the source.
-func (s *Stream) syncTimeline(ts time.Time) error {
+func (s *Stream) syncTimeline(ts time.Time) {
 	if !s.started {
 		s.started = true
 		s.segPDT = ts
 		s.nextSampleTime = ts
-		return nil
+		return
 	}
 
+	// Compare against both bounds rather than taking an absolute value: a
+	// clock that jumps far enough backwards makes Sub saturate at the minimum
+	// Duration, and negating that yields the minimum again, which would read
+	// as no gap at all and let the largest possible jump through unnoticed.
 	gap := ts.Sub(s.nextSampleTime)
-	if gap < 0 {
-		gap = -gap
-	}
-	if gap <= s.maxStallGap {
-		return nil
+	if gap >= -s.maxStallGap && gap <= s.maxStallGap {
+		// Within tolerance: pull the projection a fraction of the way toward
+		// the observed time so a steady clock difference cannot accumulate
+		// into a false stall.
+		s.nextSampleTime = s.nextSampleTime.Add(gap >> driftCorrectionShift)
+		return
 	}
 
 	// The timeline broke. Close out whatever belongs to the old one before
-	// re-anchoring, so the partial segment keeps its correct duration and PDT
-	// instead of being merged across the gap.
+	// re-anchoring, so the published segment keeps its correct duration and
+	// PDT. Note the encoder may still hold a partial access unit of pre-gap
+	// audio, which will be emitted into the first post-gap segment; the
+	// container has no way to represent a break inside an access unit.
 	if s.pendingSamples > 0 {
 		if err := s.cutSegment(); err != nil {
-			return err
+			// A failed cut leaves the buffered audio in place; mark the break
+			// anyway so the next successful cut still reports it.
+			s.failed = true
 		}
 	}
 	s.pendingBreak = true
 	s.segPDT = ts
 	s.nextSampleTime = ts
-	return nil
 }
 
-// appendAccessUnit buffers one coded access unit into the current segment and
-// cuts the segment once it has reached the target duration. It is the EmitFunc
-// handed to the encoder, so it runs with s.mu already held.
+// appendAccessUnit buffers one coded access unit into the current segment,
+// cutting the current segment first when the unit would take it past the
+// target. It is the EmitFunc handed to the encoder, so it runs with s.mu
+// already held; an implementation that called back into a Stream method from
+// here would deadlock.
 func (s *Stream) appendAccessUnit(au []byte, samples int) error {
-	if samples <= 0 {
-		return errors.Newf("hlsmux: encoder emitted an access unit with %d samples", samples).
-			Component(component).
-			Category(errors.CategoryAudio).
-			Build()
+	if samples <= 0 || samples > s.targetSamples {
+		return validationErr("hlsmux: encoder emitted an access unit of %d samples, want 1 to %d", samples, s.targetSamples)
+	}
+
+	// Cut before overflowing rather than after reaching the target, so a
+	// segment never exceeds the duration the playlist advertises.
+	if s.pendingSamples > 0 && s.pendingSamples+samples > s.targetSamples {
+		if err := s.cutSegment(); err != nil {
+			return err
+		}
 	}
 
 	// WriteFrameDuration rather than WriteFrame: it carries the unit's own
 	// duration, so a codec with variable-length frames works unchanged, and
 	// go-m4a copies the access unit, which is what makes the borrowed-slice
 	// contract on EmitFunc safe to honour without copying here.
-	if err := s.frag.WriteFrameDuration(au, uint32(samples)); err != nil {
-		return errors.New(err).
-			Component(component).
-			Category(errors.CategoryAudio).
-			Context("codec", s.codec.Name).
-			Build()
+	if err := s.frag.WriteFrameDuration(au, uint32(samples)); err != nil { //nolint:gosec // samples is bounded by targetSamples above
+		return s.audioErr(err)
 	}
 	s.pendingSamples += samples
-
-	if s.pendingSamples >= s.targetSamples {
-		return s.cutSegment()
-	}
 	return nil
 }
 
@@ -404,17 +496,25 @@ func (s *Stream) appendAccessUnit(au []byte, samples int) error {
 func (s *Stream) cutSegment() error {
 	// A fresh destination every time: a published segment's bytes are handed
 	// out to HTTP handlers that may still be writing them to a client, so the
-	// arena must never be reused underneath them.
-	data, err := s.frag.AppendSegment(nil)
+	// arena must never be reused underneath them. Sized from the previous
+	// segment, which in a constant-bitrate stream is within a few percent, so
+	// the build stops re-growing after the first cut.
+	data, err := s.frag.AppendSegment(make([]byte, 0, s.segBufHint))
 	if err != nil {
-		return errors.New(err).
-			Component(component).
-			Category(errors.CategoryAudio).
-			Context("codec", s.codec.Name).
-			Build()
+		return s.audioErr(err)
 	}
+	s.segBufHint = len(data) + len(data)/16
 
 	duration := s.segClock.advance(s.pendingSamples)
+	// Count the break before publishing: a segment preceded by
+	// EXT-X-DISCONTINUITY has the predecessor's discontinuity sequence number
+	// plus one (RFC 8216 section 6.2.2). Assigning the predecessor's value and
+	// deferring the increment would make the number a client computes for a
+	// given segment change as the window scrolls, which is precisely what
+	// EXT-X-DISCONTINUITY-SEQUENCE exists to keep stable.
+	if s.pendingBreak {
+		s.discontinuities++
+	}
 	s.segments.push(&Segment{
 		Seq:              s.nextSeq,
 		Data:             data,
@@ -424,14 +524,12 @@ func (s *Stream) cutSegment() error {
 		Discontinuity:    s.pendingBreak,
 		DiscontinuitySeq: s.discontinuities,
 	})
+	s.pendingBreak = false
 
-	if s.pendingBreak {
-		s.discontinuities++
-		s.pendingBreak = false
-	}
 	// The next segment starts exactly where this one ended. Durations are
 	// exact, so accumulating PDT this way stays locked to the sample timeline
 	// until a discontinuity re-anchors it to wall clock.
+	s.lastSegmentPDT = s.segPDT
 	s.segPDT = s.segPDT.Add(duration)
 	s.nextSeq++
 	s.pendingSamples = 0
@@ -451,27 +549,23 @@ func (s *Stream) Close() error {
 		return nil
 	}
 	s.closed = true
-	s.ended = true
 
-	flushErr := s.enc.Flush(s.appendAccessUnit)
-	if flushErr == nil && s.pendingSamples > 0 {
-		flushErr = s.cutSegment()
+	var flushErr error
+	if !s.failed {
+		flushErr = s.enc.Flush(s.emit)
+		if flushErr == nil && s.pendingSamples > 0 {
+			flushErr = s.cutSegment()
+		}
 	}
 
 	closeErr := s.enc.Close()
-	if flushErr != nil {
-		return errors.New(flushErr).
-			Component(component).
-			Category(errors.CategoryAudio).
-			Context("codec", s.codec.Name).
-			Build()
-	}
-	if closeErr != nil {
-		return errors.New(closeErr).
-			Component(component).
-			Category(errors.CategoryAudio).
-			Context("codec", s.codec.Name).
-			Build()
+	switch {
+	case flushErr != nil && closeErr != nil:
+		return s.audioErr(fmt.Errorf("%w (also failed to close encoder: %w)", flushErr, closeErr))
+	case flushErr != nil:
+		return s.audioErr(flushErr)
+	case closeErr != nil:
+		return s.audioErr(closeErr)
 	}
 	return nil
 }
@@ -479,6 +573,9 @@ func (s *Stream) Close() error {
 // InitSegment returns the fragmented-MP4 initialization segment the playlist
 // names in EXT-X-MAP. It is fixed for the life of the stream and safe to serve
 // repeatedly; callers must not modify it.
+//
+// No lock: initSeg is written once in New before the Stream is published and
+// never again.
 func (s *Stream) InitSegment() []byte {
 	return s.initSeg
 }
@@ -496,14 +593,30 @@ func (s *Stream) Segment(seq uint64) (Segment, bool) {
 func (s *Stream) Playlist() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return renderPlaylist(s.segments, s.ended)
+	return renderPlaylist(s.segments, s.targetDuration, s.closed)
 }
 
-// Ready reports whether at least one media segment has been published. A
-// player given a playlist with no segments has nothing to fetch, so callers
-// should wait for this before advertising the stream.
-func (s *Stream) Ready() bool {
+// Ready reports whether the playlist advertises at least n media segments.
+//
+// Callers should wait for more than one before advertising the stream: hls.js
+// holds off starting playback until it has several fragments, so a player
+// handed a one-segment playlist spends a full reload cycle waiting, which is
+// audible as a delayed start.
+func (s *Stream) Ready(n int) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return !s.segments.empty()
+	return s.segments.len() >= n
+}
+
+// Stats returns a point-in-time view of the stream's health.
+func (s *Stream) Stats() Stats {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return Stats{
+		Segments:        s.nextSeq,
+		Retained:        s.segments.len(),
+		Discontinuities: s.discontinuities,
+		LastSegmentPDT:  s.lastSegmentPDT,
+		Failed:          s.failed,
+	}
 }

--- a/internal/audiocore/hlsmux/hlsmux.go
+++ b/internal/audiocore/hlsmux/hlsmux.go
@@ -1,0 +1,509 @@
+package hlsmux
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	m4a "github.com/tphakala/go-m4a"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+)
+
+const (
+	// component is the error-telemetry component name for this package.
+	component = "audiocore/hlsmux"
+
+	// bitDepth16 is the only PCM bit depth this muxer accepts. The capture
+	// pipeline is 16-bit end to end, and accepting a width the encoders would
+	// silently reinterpret buys nothing.
+	bitDepth16 = 16
+
+	// bytesPerSample is the width of one sample of one channel at bitDepth16.
+	bytesPerSample = bitDepth16 / 8
+
+	// DefaultSegmentDuration is the nominal length of a media segment. Two
+	// seconds is the usual live-HLS compromise: short enough to keep join
+	// latency low, long enough that per-segment overhead stays negligible.
+	DefaultSegmentDuration = 2 * time.Second
+
+	// DefaultWindowSize is how many media segments the playlist advertises.
+	// It must stay above hls.js's liveSyncDurationCount, which is why the
+	// FFmpeg path settled on six as well.
+	DefaultWindowSize = 6
+
+	// DefaultMaxStallGap is how far the incoming frame timestamps may diverge
+	// from the sample clock before the timeline is treated as broken rather
+	// than jittery. Below this the difference is absorbed silently; above it
+	// the stream cuts a segment and declares a discontinuity.
+	//
+	// Half a segment is the useful boundary: smaller gaps are indistinguishable
+	// from ordinary scheduling jitter and buffer bunching, while anything
+	// larger means real audio is missing and a player that kept decoding
+	// straight through would report a wall-clock time that never happened.
+	DefaultMaxStallGap = DefaultSegmentDuration / 2
+)
+
+// Config describes the live stream to be produced. Everything codec-specific
+// is carried by Codec, so this stays the same shape whichever codec is used.
+type Config struct {
+	// Codec supplies the encoder and the container description. Required.
+	Codec Codec
+
+	// SampleRate is the output sample rate in Hz. Required.
+	//
+	// Callers should pin this to 48000 rather than following the source: the
+	// audio router already inserts a resampler whenever a source's rate
+	// differs from the consumer's declared rate, so a fixed output rate costs
+	// nothing and removes a whole class of rate-mismatch playback bugs.
+	SampleRate int
+
+	// Channels is the output channel count, 1 or 2. Required.
+	Channels int
+
+	// BitrateKbps is the target bitrate passed to the encoder. Required for
+	// lossy codecs.
+	BitrateKbps int
+
+	// SegmentDuration is the nominal media segment length. Segments are cut on
+	// access-unit boundaries, so the real duration lands within one access
+	// unit of this. Zero selects DefaultSegmentDuration.
+	SegmentDuration time.Duration
+
+	// WindowSize is how many segments the playlist advertises and the stream
+	// keeps in memory. Zero selects DefaultWindowSize.
+	WindowSize int
+
+	// MaxStallGap is the timestamp divergence that triggers a discontinuity.
+	// Zero selects DefaultMaxStallGap.
+	MaxStallGap time.Duration
+}
+
+// Stream encodes and muxes one live audio source into HLS media segments and
+// the playlist indexing them, holding everything in memory.
+//
+// Write is called from the audio feed goroutine; Playlist, Segment and
+// InitSegment are called from HTTP handlers. All of them are safe to call
+// concurrently.
+type Stream struct {
+	// mu guards everything below it. The critical sections are short: an
+	// encode plus a buffer append on the write side, a render or a lookup on
+	// the read side.
+	mu sync.Mutex
+
+	codec    Codec
+	enc      FrameEncoder
+	frag     *m4a.FragmentWriter
+	initSeg  []byte
+	segments *ring
+
+	// targetSamples is SegmentDuration expressed in samples, the threshold a
+	// segment's accumulated access units must reach before it is cut.
+	targetSamples int
+	maxStallGap   time.Duration
+	frameBytes    int
+
+	// segClock converts a cut segment's sample count to its exact duration;
+	// inClock does the same for incoming PCM to project the next expected
+	// frame timestamp. They are separate because they advance over different
+	// quantities, and each carries its own remainder.
+	segClock sampleClock
+	inClock  sampleClock
+
+	// nextSeq is the sequence number the next cut segment will take.
+	nextSeq uint64
+
+	// pendingSamples is how many samples are buffered in frag for the segment
+	// currently accumulating.
+	pendingSamples int
+
+	// segPDT is the wall-clock time of the first sample of the segment
+	// currently accumulating.
+	segPDT time.Time
+
+	// nextSampleTime is the wall-clock time the next incoming sample is
+	// expected to carry. Comparing it against the timestamp that actually
+	// arrives is how a source stall is detected.
+	nextSampleTime time.Time
+
+	// discontinuities counts the timeline breaks so far, and pendingBreak
+	// records that the next segment cut begins a new timeline.
+	discontinuities uint64
+	pendingBreak    bool
+
+	started bool
+	ended   bool
+	closed  bool
+}
+
+// sampleClock converts sample counts to durations without accumulating
+// truncation error.
+//
+// The naive samples*time.Second/rate loses the remainder on every call, and a
+// live stream makes that call forever. Carrying the remainder into the next
+// conversion makes consecutive durations sum to exactly the duration of the
+// total sample count. Computing from a running total instead would be equally
+// exact but overflows int64 after about 53 hours at 48 kHz, which a live
+// stream reaches.
+type sampleClock struct {
+	rate  int64
+	carry int64
+}
+
+// advance converts samples to a duration, folding in the remainder left by
+// previous conversions.
+func (c *sampleClock) advance(samples int) time.Duration {
+	total := int64(samples)*int64(time.Second) + c.carry
+	c.carry = total % c.rate
+	return time.Duration(total / c.rate)
+}
+
+// New creates a live stream. It builds the encoder and the init segment up
+// front, so a caller that gets a Stream back has already had the codec
+// configuration validated.
+func New(cfg *Config) (*Stream, error) {
+	if cfg == nil {
+		return nil, errors.Newf("hlsmux: config is nil").
+			Component(component).
+			Category(errors.CategoryValidation).
+			Build()
+	}
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+
+	encCfg := EncoderConfig{
+		SampleRate:  cfg.SampleRate,
+		Channels:    cfg.Channels,
+		BitrateKbps: cfg.BitrateKbps,
+	}
+
+	enc, err := cfg.Codec.newEncoder(encCfg)
+	if err != nil {
+		return nil, errors.New(err).
+			Component(component).
+			Category(errors.CategoryAudio).
+			Context("codec", cfg.Codec.Name).
+			Build()
+	}
+
+	writerCfg, err := cfg.Codec.writerConfig(encCfg, enc)
+	if err != nil {
+		return nil, closeEncoderAndWrap(enc, err, cfg.Codec.Name)
+	}
+
+	initSeg, err := m4a.InitSegment(writerCfg)
+	if err != nil {
+		return nil, closeEncoderAndWrap(enc, err, cfg.Codec.Name)
+	}
+
+	frag, err := m4a.NewFragmentWriter(writerCfg)
+	if err != nil {
+		return nil, closeEncoderAndWrap(enc, err, cfg.Codec.Name)
+	}
+
+	segmentDuration := cfg.SegmentDuration
+	if segmentDuration == 0 {
+		segmentDuration = DefaultSegmentDuration
+	}
+	windowSize := cfg.WindowSize
+	if windowSize == 0 {
+		windowSize = DefaultWindowSize
+	}
+	maxStallGap := cfg.MaxStallGap
+	if maxStallGap == 0 {
+		maxStallGap = DefaultMaxStallGap
+	}
+
+	rate := int64(cfg.SampleRate)
+	return &Stream{
+		codec:         cfg.Codec,
+		enc:           enc,
+		frag:          frag,
+		initSeg:       initSeg,
+		segments:      newRing(windowSize),
+		targetSamples: int(segmentDuration * time.Duration(cfg.SampleRate) / time.Second),
+		maxStallGap:   maxStallGap,
+		frameBytes:    cfg.Channels * bytesPerSample,
+		segClock:      sampleClock{rate: rate},
+		inClock:       sampleClock{rate: rate},
+	}, nil
+}
+
+// closeEncoderAndWrap releases a half-built stream's encoder and wraps the
+// error that made it unusable. Without it a failure between constructing the
+// encoder and returning the Stream would leak whatever the encoder holds.
+func closeEncoderAndWrap(enc FrameEncoder, err error, codecName string) error {
+	if closeErr := enc.Close(); closeErr != nil {
+		err = fmt.Errorf("%w (also failed to close encoder: %w)", err, closeErr)
+	}
+	return errors.New(err).
+		Component(component).
+		Category(errors.CategoryAudio).
+		Context("codec", codecName).
+		Build()
+}
+
+// validate checks the configuration and reports the first problem found.
+func (c *Config) validate() error {
+	switch {
+	case !c.Codec.valid():
+		return errors.Newf("hlsmux: codec is not set").
+			Component(component).
+			Category(errors.CategoryValidation).
+			Build()
+	case c.SampleRate <= 0:
+		return errors.Newf("hlsmux: sample rate must be positive, got %d", c.SampleRate).
+			Component(component).
+			Category(errors.CategoryValidation).
+			Build()
+	case c.Channels != 1 && c.Channels != 2:
+		return errors.Newf("hlsmux: channel count must be 1 or 2, got %d", c.Channels).
+			Component(component).
+			Category(errors.CategoryValidation).
+			Build()
+	case c.BitrateKbps < 0:
+		return errors.Newf("hlsmux: bitrate must not be negative, got %d kbps", c.BitrateKbps).
+			Component(component).
+			Category(errors.CategoryValidation).
+			Build()
+	case c.SegmentDuration < 0:
+		return errors.Newf("hlsmux: segment duration must not be negative, got %s", c.SegmentDuration).
+			Component(component).
+			Category(errors.CategoryValidation).
+			Build()
+	case c.WindowSize < 0:
+		return errors.Newf("hlsmux: window size must not be negative, got %d", c.WindowSize).
+			Component(component).
+			Category(errors.CategoryValidation).
+			Build()
+	case c.MaxStallGap < 0:
+		return errors.Newf("hlsmux: max stall gap must not be negative, got %s", c.MaxStallGap).
+			Component(component).
+			Category(errors.CategoryValidation).
+			Build()
+	}
+	return nil
+}
+
+// Write encodes interleaved PCM and appends the resulting access units to the
+// segment being accumulated, cutting a segment whenever it reaches the target
+// duration.
+//
+// ts is the wall-clock capture time of the first sample in pcm. It is what
+// anchors EXT-X-PROGRAM-DATE-TIME to real time. Deriving the time from the
+// sample count alone would be wrong for a monitoring system: a source that
+// stalls and resumes produces no samples for the gap, so every later timestamp
+// would be early by the length of the stall, permanently and silently. When
+// the gap exceeds MaxStallGap the stream instead declares a discontinuity and
+// re-anchors to ts.
+func (s *Stream) Write(pcm []byte, ts time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return errors.Newf("hlsmux: write to a closed stream").
+			Component(component).
+			Category(errors.CategoryAudio).
+			Build()
+	}
+	if len(pcm) == 0 {
+		return nil
+	}
+	if len(pcm)%s.frameBytes != 0 {
+		return errors.Newf("hlsmux: PCM length %d is not a multiple of the %d-byte sample frame", len(pcm), s.frameBytes).
+			Component(component).
+			Category(errors.CategoryValidation).
+			Build()
+	}
+
+	if err := s.syncTimeline(ts); err != nil {
+		return err
+	}
+
+	// Project where the following frame should start before encoding, so the
+	// projection is unaffected by how the encoder buffers this input.
+	s.nextSampleTime = s.nextSampleTime.Add(s.inClock.advance(len(pcm) / s.frameBytes))
+
+	if err := s.enc.EncodeInterleaved(pcm, s.appendAccessUnit); err != nil {
+		return errors.New(err).
+			Component(component).
+			Category(errors.CategoryAudio).
+			Context("codec", s.codec.Name).
+			Build()
+	}
+	return nil
+}
+
+// syncTimeline anchors the stream on its first write and, on later writes,
+// decides whether the incoming timestamp represents ordinary jitter or a real
+// break in the source.
+func (s *Stream) syncTimeline(ts time.Time) error {
+	if !s.started {
+		s.started = true
+		s.segPDT = ts
+		s.nextSampleTime = ts
+		return nil
+	}
+
+	gap := ts.Sub(s.nextSampleTime)
+	if gap < 0 {
+		gap = -gap
+	}
+	if gap <= s.maxStallGap {
+		return nil
+	}
+
+	// The timeline broke. Close out whatever belongs to the old one before
+	// re-anchoring, so the partial segment keeps its correct duration and PDT
+	// instead of being merged across the gap.
+	if s.pendingSamples > 0 {
+		if err := s.cutSegment(); err != nil {
+			return err
+		}
+	}
+	s.pendingBreak = true
+	s.segPDT = ts
+	s.nextSampleTime = ts
+	return nil
+}
+
+// appendAccessUnit buffers one coded access unit into the current segment and
+// cuts the segment once it has reached the target duration. It is the EmitFunc
+// handed to the encoder, so it runs with s.mu already held.
+func (s *Stream) appendAccessUnit(au []byte, samples int) error {
+	if samples <= 0 {
+		return errors.Newf("hlsmux: encoder emitted an access unit with %d samples", samples).
+			Component(component).
+			Category(errors.CategoryAudio).
+			Build()
+	}
+
+	// WriteFrameDuration rather than WriteFrame: it carries the unit's own
+	// duration, so a codec with variable-length frames works unchanged, and
+	// go-m4a copies the access unit, which is what makes the borrowed-slice
+	// contract on EmitFunc safe to honour without copying here.
+	if err := s.frag.WriteFrameDuration(au, uint32(samples)); err != nil {
+		return errors.New(err).
+			Component(component).
+			Category(errors.CategoryAudio).
+			Context("codec", s.codec.Name).
+			Build()
+	}
+	s.pendingSamples += samples
+
+	if s.pendingSamples >= s.targetSamples {
+		return s.cutSegment()
+	}
+	return nil
+}
+
+// cutSegment flushes the buffered access units into a finished media segment
+// and publishes it. It must be called with s.mu held and with at least one
+// access unit buffered.
+func (s *Stream) cutSegment() error {
+	// A fresh destination every time: a published segment's bytes are handed
+	// out to HTTP handlers that may still be writing them to a client, so the
+	// arena must never be reused underneath them.
+	data, err := s.frag.AppendSegment(nil)
+	if err != nil {
+		return errors.New(err).
+			Component(component).
+			Category(errors.CategoryAudio).
+			Context("codec", s.codec.Name).
+			Build()
+	}
+
+	duration := s.segClock.advance(s.pendingSamples)
+	s.segments.push(&Segment{
+		Seq:              s.nextSeq,
+		Data:             data,
+		Samples:          s.pendingSamples,
+		Duration:         duration,
+		PDT:              s.segPDT,
+		Discontinuity:    s.pendingBreak,
+		DiscontinuitySeq: s.discontinuities,
+	})
+
+	if s.pendingBreak {
+		s.discontinuities++
+		s.pendingBreak = false
+	}
+	// The next segment starts exactly where this one ended. Durations are
+	// exact, so accumulating PDT this way stays locked to the sample timeline
+	// until a discontinuity re-anchors it to wall clock.
+	s.segPDT = s.segPDT.Add(duration)
+	s.nextSeq++
+	s.pendingSamples = 0
+	return nil
+}
+
+// Close drains the encoder, publishes whatever audio remains as a final
+// segment, and marks the playlist ended so clients stop polling.
+//
+// Closing twice is not an error, so a caller can Close on a deferred cleanup
+// path without tracking whether an earlier error path already did.
+func (s *Stream) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	s.ended = true
+
+	flushErr := s.enc.Flush(s.appendAccessUnit)
+	if flushErr == nil && s.pendingSamples > 0 {
+		flushErr = s.cutSegment()
+	}
+
+	closeErr := s.enc.Close()
+	if flushErr != nil {
+		return errors.New(flushErr).
+			Component(component).
+			Category(errors.CategoryAudio).
+			Context("codec", s.codec.Name).
+			Build()
+	}
+	if closeErr != nil {
+		return errors.New(closeErr).
+			Component(component).
+			Category(errors.CategoryAudio).
+			Context("codec", s.codec.Name).
+			Build()
+	}
+	return nil
+}
+
+// InitSegment returns the fragmented-MP4 initialization segment the playlist
+// names in EXT-X-MAP. It is fixed for the life of the stream and safe to serve
+// repeatedly; callers must not modify it.
+func (s *Stream) InitSegment() []byte {
+	return s.initSeg
+}
+
+// Segment returns the retained media segment with the given sequence number.
+// It reports false once the segment has scrolled out of the window, which is
+// what a client that fell too far behind should see as a 404.
+func (s *Stream) Segment(seq uint64) (Segment, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.segments.get(seq)
+}
+
+// Playlist renders the current HLS media playlist.
+func (s *Stream) Playlist() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return renderPlaylist(s.segments, s.ended)
+}
+
+// Ready reports whether at least one media segment has been published. A
+// player given a playlist with no segments has nothing to fetch, so callers
+// should wait for this before advertising the stream.
+func (s *Stream) Ready() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return !s.segments.empty()
+}

--- a/internal/audiocore/hlsmux/hlsmux.go
+++ b/internal/audiocore/hlsmux/hlsmux.go
@@ -124,6 +124,12 @@ type Stats struct {
 	// equivalent of the FFmpeg path's stale-segment check.
 	LastSegmentPDT time.Time
 
+	// DriftCorrection is the cumulative adjustment applied to the projected
+	// sample clock. A value that keeps growing in one direction means the
+	// source is delivering audio persistently slower or faster than real time,
+	// which is absorbed silently and would otherwise be invisible.
+	DriftCorrection time.Duration
+
 	// Failed reports that an encode error has latched the stream unusable.
 	Failed bool
 }
@@ -185,6 +191,14 @@ type Stream struct {
 	// expected to carry. Comparing it against the timestamp that actually
 	// arrives is how a source stall is detected.
 	nextSampleTime time.Time
+
+	// driftCorrection is the total the projected sample clock has been nudged
+	// toward the arriving timestamps. It only grows in one direction while a
+	// source runs persistently fast or slow, so a caller watching it can tell
+	// steady clock error (bounded, harmless) from sustained audio loss
+	// (unbounded), which the stall threshold alone cannot distinguish because
+	// the absorber is what stops the latter from ever reaching it.
+	driftCorrection time.Duration
 
 	// discontinuities counts the timeline breaks so far, and pendingBreak
 	// records that the next segment cut begins a new timeline.
@@ -407,7 +421,9 @@ func (s *Stream) Write(pcm []byte, ts time.Time) error {
 		return validationErr("hlsmux: PCM length %d is not a multiple of the %d-byte sample frame", len(pcm), s.frameBytes)
 	}
 
-	s.syncTimeline(ts)
+	if err := s.syncTimeline(ts); err != nil {
+		return err
+	}
 
 	// Project where the following frame should start before encoding, so the
 	// projection is unaffected by how the encoder buffers this input.
@@ -423,12 +439,12 @@ func (s *Stream) Write(pcm []byte, ts time.Time) error {
 // syncTimeline anchors the stream on its first write and, on later writes,
 // decides whether the incoming timestamp represents ordinary drift or a real
 // break in the source.
-func (s *Stream) syncTimeline(ts time.Time) {
+func (s *Stream) syncTimeline(ts time.Time) error {
 	if !s.started {
 		s.started = true
 		s.segPDT = ts
 		s.nextSampleTime = ts
-		return
+		return nil
 	}
 
 	// Compare against both bounds rather than taking an absolute value: a
@@ -441,7 +457,8 @@ func (s *Stream) syncTimeline(ts time.Time) {
 		// the observed time so a steady clock difference cannot accumulate
 		// into a false stall.
 		s.nextSampleTime = s.nextSampleTime.Add(gap >> driftCorrectionShift)
-		return
+		s.driftCorrection += gap >> driftCorrectionShift
+		return nil
 	}
 
 	// The timeline broke. Close out whatever belongs to the old one before
@@ -451,14 +468,19 @@ func (s *Stream) syncTimeline(ts time.Time) {
 	// container has no way to represent a break inside an access unit.
 	if s.pendingSamples > 0 {
 		if err := s.cutSegment(); err != nil {
-			// A failed cut leaves the buffered audio in place; mark the break
-			// anyway so the next successful cut still reports it.
+			// The container refused the segment, so the timeline cannot be
+			// closed out cleanly. Latch and surface it rather than reporting
+			// the write as successful: a caller that kept feeding would build
+			// every later segment on a timeline whose break was never
+			// published.
 			s.failed = true
+			return err
 		}
 	}
 	s.pendingBreak = true
 	s.segPDT = ts
 	s.nextSampleTime = ts
+	return nil
 }
 
 // appendAccessUnit buffers one coded access unit into the current segment,
@@ -508,7 +530,7 @@ func (s *Stream) cutSegment() error {
 	duration := s.segClock.advance(s.pendingSamples)
 	// Count the break before publishing: a segment preceded by
 	// EXT-X-DISCONTINUITY has the predecessor's discontinuity sequence number
-	// plus one (RFC 8216 section 6.2.2). Assigning the predecessor's value and
+	// plus one (RFC 8216 section 6.2.1). Assigning the predecessor's value and
 	// deferring the increment would make the number a client computes for a
 	// given segment change as the window scrolls, which is precisely what
 	// EXT-X-DISCONTINUITY-SEQUENCE exists to keep stable.
@@ -617,6 +639,7 @@ func (s *Stream) Stats() Stats {
 		Retained:        s.segments.len(),
 		Discontinuities: s.discontinuities,
 		LastSegmentPDT:  s.lastSegmentPDT,
+		DriftCorrection: s.driftCorrection,
 		Failed:          s.failed,
 	}
 }

--- a/internal/audiocore/hlsmux/hlsmux.go
+++ b/internal/audiocore/hlsmux/hlsmux.go
@@ -152,6 +152,13 @@ type Stream struct {
 	initSeg   []byte
 	segments  *ring
 
+	// appendSegment flushes the fragment writer into a finished segment. It is
+	// a field rather than a direct s.frag call so a test can drive the failure
+	// path: go-m4a rejects a segment only on limits a fake encoder cannot
+	// reach, which would otherwise leave the error handling in cutSegment and
+	// syncTimeline permanently unexercised.
+	appendSegment func(dst []byte) ([]byte, error)
+
 	// emit is appendAccessUnit bound to this Stream, built once. Passing the
 	// method value directly would build a fresh closure on every Write, which
 	// escapes because it crosses an interface call, so it would be one heap
@@ -315,6 +322,7 @@ func New(cfg *Config) (*Stream, error) {
 		inClock:            sampleClock{rate: rate},
 	}
 	s.emit = s.appendAccessUnit
+	s.appendSegment = frag.AppendSegment
 	return s, nil
 }
 
@@ -521,7 +529,7 @@ func (s *Stream) cutSegment() error {
 	// arena must never be reused underneath them. Sized from the previous
 	// segment, which in a constant-bitrate stream is within a few percent, so
 	// the build stops re-growing after the first cut.
-	data, err := s.frag.AppendSegment(make([]byte, 0, s.segBufHint))
+	data, err := s.appendSegment(make([]byte, 0, s.segBufHint))
 	if err != nil {
 		return s.audioErr(err)
 	}

--- a/internal/audiocore/hlsmux/hlsmux_test.go
+++ b/internal/audiocore/hlsmux/hlsmux_test.go
@@ -919,3 +919,77 @@ func TestCutFailureDuringNormalWriteIsReported(t *testing.T) {
 	require.ErrorIs(t, err, errFakeSegment)
 	assert.True(t, s.segments.len() == 0 || s.Stats().Failed)
 }
+
+// TestNewRejectsSegmentTargetBelowOneAccessUnit covers the configurations that
+// previously built a Stream successfully and then rejected every frame the
+// encoder produced, surfacing as a latched failure on the audio goroutine
+// instead of an error the caller could act on at construction.
+func TestNewRejectsSegmentTargetBelowOneAccessUnit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		rate       int
+		segment    time.Duration
+		frameSizes []int
+		errMsg     string
+	}{
+		{
+			name: "8 kHz with a 100ms segment cannot hold an AAC access unit",
+			rate: 8000, segment: 100 * time.Millisecond,
+			frameSizes: []int{aacFrame}, errMsg: "smaller than codec",
+		},
+		{
+			name: "a large-frame codec needs a longer segment",
+			rate: testRate, segment: 100 * time.Millisecond,
+			frameSizes: []int{8192}, errMsg: "smaller than codec",
+		},
+		{
+			name: "a 1 Hz rate yields less than one sample per segment",
+			rate: 1, segment: MinSegmentDuration,
+			frameSizes: []int{aacFrame}, errMsg: "less than one sample",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var enc *fakeEncoder
+			s, err := New(&Config{
+				Codec:           newFakeCodec(&fakeCodecOptions{frameSizes: tt.frameSizes, captured: &enc}),
+				SampleRate:      tt.rate,
+				Channels:        testChannels,
+				BitrateKbps:     testBitrate,
+				SegmentDuration: tt.segment,
+			})
+			require.Error(t, err)
+			assert.Nil(t, s)
+			assert.Contains(t, err.Error(), tt.errMsg)
+			require.NotNil(t, enc)
+			assert.True(t, enc.closed, "a rejected configuration must still release the encoder")
+		})
+	}
+}
+
+// TestNewAcceptsASegmentThatFitsExactlyOneAccessUnit pins the boundary: the
+// check must reject a target below one access unit without also rejecting a
+// target that holds exactly one.
+func TestNewAcceptsASegmentThatFitsExactlyOneAccessUnit(t *testing.T) {
+	t.Parallel()
+
+	// 1024 samples at 48 kHz is 21.333ms, so a 200ms segment holds 9600.
+	s, err := New(&Config{
+		Codec:           newFakeCodec(&fakeCodecOptions{frameSizes: []int{aacFrame}}),
+		SampleRate:      testRate,
+		Channels:        testChannels,
+		BitrateKbps:     testBitrate,
+		SegmentDuration: 200 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, s.Close()) })
+	assert.GreaterOrEqual(t, s.targetSamples, aacFrame)
+
+	// And it must actually stream rather than merely construct.
+	writeSamples(t, s, testRate, testEpoch)
+	assert.True(t, s.Ready(1))
+}

--- a/internal/audiocore/hlsmux/hlsmux_test.go
+++ b/internal/audiocore/hlsmux/hlsmux_test.go
@@ -1,6 +1,7 @@
 package hlsmux
 
 import (
+	"bytes"
 	"strconv"
 	"sync"
 	"testing"
@@ -68,7 +69,9 @@ func TestNewValidatesConfig(t *testing.T) {
 		{"three channels", func(c *Config) { c.Channels = 3 }, "channel count must be 1 or 2"},
 		{"zero channels", func(c *Config) { c.Channels = 0 }, "channel count must be 1 or 2"},
 		{"negative bitrate", func(c *Config) { c.BitrateKbps = -1 }, "bitrate must not be negative"},
-		{"negative segment duration", func(c *Config) { c.SegmentDuration = -time.Second }, "segment duration must not be negative"},
+		{"negative segment duration", func(c *Config) { c.SegmentDuration = -time.Second }, "below the minimum"},
+		{"segment duration below the floor", func(c *Config) { c.SegmentDuration = time.Millisecond }, "below the minimum"},
+		{"segment duration above the ceiling", func(c *Config) { c.SegmentDuration = time.Hour }, "exceeds the maximum"},
 		{"negative window", func(c *Config) { c.WindowSize = -1 }, "window size must not be negative"},
 		{"negative stall gap", func(c *Config) { c.MaxStallGap = -time.Second }, "max stall gap must not be negative"},
 	}
@@ -106,7 +109,7 @@ func TestNewClosesEncoderWhenContainerSetupFails(t *testing.T) {
 func TestSegmentsCutOnAccessUnitBoundaries(t *testing.T) {
 	t.Parallel()
 
-	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}, declaredFrameSamples: aacFrame})
+	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
 
 	// Six seconds of audio at the default two-second target.
 	const total = testRate * 6
@@ -115,15 +118,17 @@ func TestSegmentsCutOnAccessUnitBoundaries(t *testing.T) {
 	segs := s.segments.window()
 	require.NotEmpty(t, segs)
 
-	target := testRate * 2
+	target := s.targetSamples
 	for i := range segs {
-		// A segment is cut on the first access unit that reaches the target,
-		// so it is never shorter than the target and never longer than the
-		// target plus one access unit.
-		assert.GreaterOrEqual(t, segs[i].Samples, target,
-			"segment %d is short of the target", segs[i].Seq)
-		assert.Less(t, segs[i].Samples, target+aacFrame,
-			"segment %d overshot by more than one access unit", segs[i].Seq)
+		// A segment is cut before the next access unit would take it past the
+		// target, so it never exceeds the target and is never more than one
+		// access unit short of it. Never exceeding matters: the playlist
+		// advertises the target as EXT-X-TARGETDURATION, and Apple's
+		// validator treats that as an absolute ceiling.
+		assert.LessOrEqual(t, segs[i].Samples, target,
+			"segment %d exceeds the advertised target duration", segs[i].Seq)
+		assert.Greater(t, segs[i].Samples, target-aacFrame,
+			"segment %d is more than one access unit short", segs[i].Seq)
 		assert.Zero(t, segs[i].Samples%aacFrame,
 			"segment %d does not land on an access-unit boundary", segs[i].Seq)
 	}
@@ -135,8 +140,7 @@ func TestDurationsAccumulateWithoutDrift(t *testing.T) {
 	// A window large enough to retain every segment produced below, so the
 	// sum can be checked against the total sample count.
 	s := newTestStream(t, &fakeCodecOptions{
-		frameSizes:           []int{aacFrame},
-		declaredFrameSamples: aacFrame,
+		frameSizes: []int{aacFrame},
 	})
 	s.segments = newRing(1000)
 
@@ -160,7 +164,7 @@ func TestDurationsAccumulateWithoutDrift(t *testing.T) {
 func TestProgramDateTimeTracksTheSampleTimeline(t *testing.T) {
 	t.Parallel()
 
-	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}, declaredFrameSamples: aacFrame})
+	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
 	s.segments = newRing(1000)
 
 	writeSamples(t, s, testRate*10, testEpoch)
@@ -181,7 +185,7 @@ func TestProgramDateTimeTracksTheSampleTimeline(t *testing.T) {
 func TestSourceStallDeclaresDiscontinuityAndReanchorsPDT(t *testing.T) {
 	t.Parallel()
 
-	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}, declaredFrameSamples: aacFrame})
+	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
 	s.segments = newRing(1000)
 
 	// Four seconds of well-behaved audio.
@@ -206,12 +210,19 @@ func TestSourceStallDeclaresDiscontinuityAndReanchorsPDT(t *testing.T) {
 
 	assert.Equal(t, resume, segs[breakIdx].PDT,
 		"the segment after a stall must be re-anchored to the resume time, not to the sample clock")
-	assert.Equal(t, uint64(0), segs[breakIdx].DiscontinuitySeq,
-		"the first discontinuity is preceded by none")
-	if breakIdx+1 < len(segs) {
-		assert.Equal(t, uint64(1), segs[breakIdx+1].DiscontinuitySeq,
-			"segments after the break count it")
-	}
+
+	// RFC 8216 section 6.2.2: a segment preceded by EXT-X-DISCONTINUITY has
+	// the predecessor's discontinuity sequence number plus one. Numbering it
+	// with the predecessor's value would make the number a client computes for
+	// this segment change once the earlier ones scroll out of the window.
+	require.Positive(t, breakIdx, "the break must not be the first retained segment for this check")
+	assert.Equal(t, uint64(0), segs[breakIdx-1].DiscontinuitySeq,
+		"segments before the break carry zero")
+	assert.Equal(t, uint64(1), segs[breakIdx].DiscontinuitySeq,
+		"the segment carrying the break counts it")
+	require.Less(t, breakIdx+1, len(segs), "expected a segment after the break")
+	assert.Equal(t, uint64(1), segs[breakIdx+1].DiscontinuitySeq,
+		"later segments keep the same number until the next break")
 
 	assert.Contains(t, s.Playlist(), "#EXT-X-DISCONTINUITY\n")
 }
@@ -219,7 +230,7 @@ func TestSourceStallDeclaresDiscontinuityAndReanchorsPDT(t *testing.T) {
 func TestJitterBelowThresholdIsAbsorbed(t *testing.T) {
 	t.Parallel()
 
-	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}, declaredFrameSamples: aacFrame})
+	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
 	s.segments = newRing(1000)
 
 	// Feed in chunks whose timestamps wobble by a few milliseconds, well
@@ -242,7 +253,7 @@ func TestJitterBelowThresholdIsAbsorbed(t *testing.T) {
 func TestRingEvictsOldestAndAdvancesMediaSequence(t *testing.T) {
 	t.Parallel()
 
-	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}, declaredFrameSamples: aacFrame})
+	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
 
 	// Twenty seconds at two seconds per segment produces far more than the
 	// default six-segment window.
@@ -267,13 +278,13 @@ func TestRingEvictsOldestAndAdvancesMediaSequence(t *testing.T) {
 func TestPartialAccessUnitIsBufferedNotEmitted(t *testing.T) {
 	t.Parallel()
 
-	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}, declaredFrameSamples: aacFrame})
+	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
 
 	// Less than one access unit of audio.
 	writeSamples(t, s, aacFrame-1, testEpoch)
 
-	assert.True(t, s.segments.empty(), "a partial access unit must not produce a segment")
-	assert.False(t, s.Ready())
+	assert.Zero(t, s.segments.len(), "a partial access unit must not produce a segment")
+	assert.False(t, s.Ready(1))
 	assert.Zero(t, s.pendingSamples)
 }
 
@@ -303,19 +314,18 @@ func TestCloseFlushesTailAndEndsPlaylist(t *testing.T) {
 
 	var enc *fakeEncoder
 	s := newTestStream(t, &fakeCodecOptions{
-		frameSizes:           []int{aacFrame},
-		declaredFrameSamples: aacFrame,
-		tailSamples:          aacFrame,
-		captured:             &enc,
+		frameSizes:  []int{aacFrame},
+		tailSamples: aacFrame,
+		captured:    &enc,
 	})
 
 	// Half a segment's worth, so nothing has been cut yet.
 	writeSamples(t, s, testRate, testEpoch)
-	require.True(t, s.segments.empty())
+	require.Zero(t, s.segments.len())
 
 	require.NoError(t, s.Close())
 
-	assert.False(t, s.segments.empty(), "Close must publish the buffered audio as a final segment")
+	assert.NotZero(t, s.segments.len(), "Close must publish the buffered audio as a final segment")
 	require.NotNil(t, enc)
 	assert.True(t, enc.closed, "Close must release the encoder")
 
@@ -354,7 +364,6 @@ func TestCodecNeutrality(t *testing.T) {
 		delay:      0,
 		// Declared as variable: the muxer must record each unit's own
 		// duration rather than a fragment-wide default.
-		declaredFrameSamples: 0,
 	})
 	s.segments = newRing(1000)
 
@@ -363,12 +372,15 @@ func TestCodecNeutrality(t *testing.T) {
 	segs := s.segments.window()
 	require.NotEmpty(t, segs)
 
-	target := testRate * 2
+	const largestFrame = 4096
+	target := s.targetSamples
 	var sumSamples int
 	for _, seg := range segs {
-		assert.GreaterOrEqual(t, seg.Samples, target)
-		// The largest frame in the cycle bounds the overshoot.
-		assert.Less(t, seg.Samples, target+4096)
+		// Same invariant as the fixed-frame case, and it must hold with
+		// irregular frame sizes too: never over the advertised target, and
+		// never more than the largest frame short of it.
+		assert.LessOrEqual(t, seg.Samples, target)
+		assert.Greater(t, seg.Samples, target-largestFrame)
 		sumSamples += seg.Samples
 	}
 
@@ -397,30 +409,48 @@ func TestInitSegmentIsStableAndNonEmpty(t *testing.T) {
 func TestAccessUnitsAreCopiedNotAliased(t *testing.T) {
 	t.Parallel()
 
-	// The fake encoder reuses one scratch buffer and stamps each access unit
-	// with a distinct byte. If the muxer retained the borrowed slice instead
-	// of relying on go-m4a to copy, every unit in the segment would carry the
-	// last unit's stamp and the distinct values would be missing.
-	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}, declaredFrameSamples: aacFrame})
+	// The fake encoder reuses one scratch buffer and stamps every sample of
+	// each access unit with a distinct byte, recording the stamps it used. If
+	// the muxer retained the borrowed slice instead of relying on go-m4a to
+	// copy it, every unit in the segment would carry the LAST unit's stamp.
+	//
+	// Counting distinct bytes would not detect that: the styp/moof/trun
+	// headers alone contribute dozens of distinct values, so any threshold low
+	// enough to state is far below the container's own noise. The check has to
+	// be against what the encoder actually emitted, per unit.
+	var enc *fakeEncoder
+	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}, captured: &enc})
 
 	writeSamples(t, s, testRate*2+aacFrame, testEpoch)
 
 	segs := s.segments.window()
 	require.NotEmpty(t, segs)
+	require.NotNil(t, enc)
 
-	data := segs[0].Data
-	distinct := map[byte]struct{}{}
-	for _, b := range data {
-		distinct[b] = struct{}{}
+	seg := segs[0]
+	unitsInSegment := seg.Samples / aacFrame
+	require.GreaterOrEqual(t, len(enc.stamps), unitsInSegment)
+
+	// Each access unit occupies aacFrame*fakeAUBytesPerSample bytes of mdat,
+	// laid end to end. Find the payload by locating the first unit's run, then
+	// verify every subsequent unit carries its OWN stamp at its own offset.
+	unitBytes := aacFrame * fakeAUBytesPerSample
+	first := bytes.Repeat([]byte{enc.stamps[0]}, unitBytes)
+	start := bytes.Index(seg.Data, first)
+	require.GreaterOrEqual(t, start, 0, "first access unit not found intact in the segment payload")
+
+	for i := range unitsInSegment {
+		want := bytes.Repeat([]byte{enc.stamps[i]}, unitBytes)
+		got := seg.Data[start+i*unitBytes : start+(i+1)*unitBytes]
+		assert.Equal(t, want, got,
+			"access unit %d carries the wrong bytes; the muxer aliased the encoder's scratch buffer", i)
 	}
-	assert.Greater(t, len(distinct), 2,
-		"segment payload must contain the distinct per-unit stamps, not one repeated value")
 }
 
 func TestConcurrentWriteAndServe(t *testing.T) {
 	t.Parallel()
 
-	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}, declaredFrameSamples: aacFrame})
+	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
 
 	var wg sync.WaitGroup
 	const chunks = 200
@@ -441,7 +471,7 @@ func TestConcurrentWriteAndServe(t *testing.T) {
 				_ = s.Playlist()
 				_ = s.InitSegment()
 				_, _ = s.Segment(0)
-				_ = s.Ready()
+				_ = s.Ready(1)
 			}
 		})
 	}
@@ -480,4 +510,235 @@ func TestPlaylistHasNoCodecsAttribute(t *testing.T) {
 	playlist := s.Playlist()
 	assert.NotContains(t, playlist, "CODECS")
 	assert.NotContains(t, playlist, "EXT-X-STREAM-INF")
+}
+
+// TestStereoFrameSizing exercises the channel multiplier in frameBytes.
+// Dropping it survives a mono-only suite, and the consequence is that every
+// segment's sample count, duration and PDT are wrong by a factor of two.
+func TestStereoFrameSizing(t *testing.T) {
+	t.Parallel()
+
+	const stereo = 2
+	s, err := New(&Config{
+		Codec:       newFakeCodec(&fakeCodecOptions{frameSizes: []int{aacFrame}}),
+		SampleRate:  testRate,
+		Channels:    stereo,
+		BitrateKbps: testBitrate,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, s.Close()) })
+
+	assert.Equal(t, stereo*bytesPerSample, s.frameBytes)
+
+	// Six seconds of stereo audio: twice the bytes of the mono case but the
+	// same sample count, so it must cut the same number of segments. Writing
+	// mono-sized buffers here would halve the sample count silently, which is
+	// exactly the bug this test exists to catch.
+	require.NoError(t, s.Write(silence(testRate*6, stereo), testEpoch))
+	require.GreaterOrEqual(t, s.segments.len(), 2)
+
+	var sum int
+	for _, seg := range s.segments.window() {
+		sum += seg.Samples
+	}
+	assert.Greater(t, sum, testRate*3,
+		"a stereo stream must account for the same sample count as mono, not half or double it")
+	assert.LessOrEqual(t, sum, testRate*6)
+
+	// A single stereo sample frame is 4 bytes, so 2 bytes is misaligned even
+	// though it is a whole mono frame.
+	require.Error(t, s.Write(make([]byte, 2), testEpoch))
+}
+
+// TestInputClockCarryIsExact covers the second sample clock. Every chunk here
+// has a sample count whose nanosecond conversion leaves a remainder at 48 kHz,
+// so naive truncation accumulates. Without the carry the projected timeline
+// falls behind the real one and eventually declares a stall on a healthy
+// source; a suite whose chunk sizes all divide evenly never notices.
+func TestInputClockCarryIsExact(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
+
+	// 1000 samples at 48 kHz is 20833.333... microseconds: never a whole
+	// number of nanoseconds.
+	const chunk = 1000
+	const chunks = 20000
+	for i := range chunks {
+		writeSamples(t, s, chunk, sampleTime(i*chunk))
+	}
+
+	// The projection must land exactly on the sample after the last one
+	// written. Truncation would leave it short by hundreds of microseconds
+	// over this many chunks.
+	want := testEpoch.Add(time.Duration(chunk) * chunks * time.Second / testRate)
+	assert.Equal(t, want, s.nextSampleTime,
+		"the input clock must project the exact sample time, with no accumulated truncation")
+
+	for _, seg := range s.segments.window() {
+		assert.False(t, seg.Discontinuity,
+			"an exact sample clock must never look like a stall")
+	}
+}
+
+// TestStallThresholdBoundary probes both sides of the comparison the stall
+// detector actually makes, which the jitter test does not come near.
+func TestStallThresholdBoundary(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		offset time.Duration
+		breaks bool
+	}{
+		{"exactly at the threshold is absorbed", DefaultSegmentDuration / 2, false},
+		{"just past the threshold breaks", DefaultSegmentDuration/2 + time.Nanosecond, true},
+		{"exactly at the negative threshold is absorbed", -DefaultSegmentDuration / 2, false},
+		{"just past the negative threshold breaks", -DefaultSegmentDuration/2 - time.Nanosecond, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
+			s.segments = newRing(1000)
+
+			const first = testRate
+			writeSamples(t, s, first, testEpoch)
+			writeSamples(t, s, testRate*3, sampleTime(first).Add(tt.offset))
+
+			var sawBreak bool
+			for _, seg := range s.segments.window() {
+				sawBreak = sawBreak || seg.Discontinuity
+			}
+			assert.Equal(t, tt.breaks, sawBreak)
+		})
+	}
+}
+
+// TestBackwardClockJumpIsDetected covers the saturating-subtraction case. A
+// large enough backwards jump makes Sub clamp to the minimum Duration, and an
+// implementation that took the absolute value would negate that back to the
+// minimum and read the largest possible jump as no gap at all.
+func TestBackwardClockJumpIsDetected(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
+	s.segments = newRing(1000)
+
+	writeSamples(t, s, testRate, testEpoch)
+	// Far enough back that time.Time.Sub saturates.
+	writeSamples(t, s, testRate*3, time.Time{}.Add(time.Hour))
+
+	var sawBreak bool
+	for _, seg := range s.segments.window() {
+		sawBreak = sawBreak || seg.Discontinuity
+	}
+	assert.True(t, sawBreak, "a saturating backwards jump must break the timeline")
+}
+
+func TestWriteRejectsZeroTimestamp(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStream(t, &fakeCodecOptions{})
+	err := s.Write(silence(aacFrame, testChannels), time.Time{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "zero capture timestamp")
+}
+
+// TestEncodeFailureLatchesTheStream: the timeline has already consumed the
+// frame's duration when the encoder fails, so continuing would silently shift
+// every later PDT. The stream must refuse instead.
+func TestEncodeFailureLatchesTheStream(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}, failAfter: 2})
+
+	require.Error(t, s.Write(silence(testRate, testChannels), testEpoch))
+	assert.True(t, s.Stats().Failed)
+
+	err := s.Write(silence(aacFrame, testChannels), sampleTime(testRate))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed encoding")
+}
+
+func TestNewRejectsNilConfigAndBadEncoder(t *testing.T) {
+	t.Parallel()
+
+	_, err := New(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "config is nil")
+
+	base := func(opts *fakeCodecOptions) *Config {
+		return &Config{Codec: newFakeCodec(opts), SampleRate: testRate, Channels: testChannels, BitrateKbps: testBitrate}
+	}
+
+	_, err = New(base(&fakeCodecOptions{encoderErr: errFakeEncoder}))
+	require.ErrorIs(t, err, errFakeEncoder)
+
+	_, err = New(base(&fakeCodecOptions{nilEncoder: true}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil encoder")
+
+	var enc *fakeEncoder
+	_, err = New(base(&fakeCodecOptions{writerErr: errFakeEncoder, captured: &enc}))
+	require.ErrorIs(t, err, errFakeEncoder)
+	require.NotNil(t, enc)
+	assert.True(t, enc.closed, "a container failure must still release the encoder")
+}
+
+func TestCloseReportsFlushAndEncoderErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("flush error", func(t *testing.T) {
+		t.Parallel()
+		s := newTestStream(t, &fakeCodecOptions{flushErr: errFakeEncoder})
+		require.ErrorIs(t, s.Close(), errFakeEncoder)
+	})
+
+	t.Run("close error", func(t *testing.T) {
+		t.Parallel()
+		s := newTestStream(t, &fakeCodecOptions{closeErr: errFakeEncoder})
+		require.ErrorIs(t, s.Close(), errFakeEncoder)
+	})
+
+	t.Run("both errors are reported", func(t *testing.T) {
+		t.Parallel()
+		// A close error must not be swallowed just because flush also failed:
+		// a pooled or cgo-backed encoder failing to release is exactly the
+		// leak this reports.
+		s := newTestStream(t, &fakeCodecOptions{flushErr: errFakeEncoder, closeErr: errFakeClose})
+		err := s.Close()
+		require.Error(t, err)
+		require.ErrorIs(t, err, errFakeEncoder)
+		assert.ErrorIs(t, err, errFakeClose)
+	})
+}
+
+func TestReadyCountsSegmentsAndStatsTrackHealth(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
+
+	assert.False(t, s.Ready(1))
+	assert.Equal(t, Stats{}, s.Stats())
+
+	// Slightly over one segment's worth: the cut happens on the access unit
+	// that would overflow the target, so exactly one segment's worth of input
+	// publishes nothing yet.
+	writeSamples(t, s, testRate*3, testEpoch)
+	require.True(t, s.Ready(1))
+	// hls.js holds off until it has several fragments, so one segment is not
+	// enough to advertise the stream as playable.
+	assert.False(t, s.Ready(2), "one segment must not satisfy a two-segment readiness check")
+
+	writeSamples(t, s, testRate*2, sampleTime(testRate*3))
+	assert.True(t, s.Ready(2))
+
+	st := s.Stats()
+	assert.Equal(t, uint64(2), st.Segments)
+	assert.Equal(t, 2, st.Retained)
+	assert.Zero(t, st.Discontinuities)
+	assert.False(t, st.Failed)
+	assert.False(t, st.LastSegmentPDT.IsZero(), "a cut segment must advance the health timestamp")
 }

--- a/internal/audiocore/hlsmux/hlsmux_test.go
+++ b/internal/audiocore/hlsmux/hlsmux_test.go
@@ -2,6 +2,7 @@ package hlsmux
 
 import (
 	"bytes"
+	"errors"
 	"strconv"
 	"strings"
 	"sync"
@@ -768,6 +769,12 @@ func TestDiscontinuitySequenceIsStableAcrossReloads(t *testing.T) {
 	t.Cleanup(func() { assert.NoError(t, s.Close()) })
 
 	seen := map[string]uint64{}
+	// The defect only manifests when a segment CARRYING a break is the oldest
+	// one retained, because that is the only position where the renderer emits
+	// its EXT-X-DISCONTINUITY and the tag value must exclude it. A run that
+	// never reaches that position would pass with the bug fully restored, so
+	// count the visits and require them.
+	headBreaks := 0
 	at := testEpoch
 	// Drive several segments with two stalls, checking the whole playlist
 	// after every write so each segment is observed in many window positions.
@@ -778,6 +785,9 @@ func TestDiscontinuitySequenceIsStableAcrossReloads(t *testing.T) {
 			at = at.Add(10 * time.Second) // stall
 		}
 
+		if w := s.segments.window(); len(w) > 0 && w[0].Discontinuity {
+			headBreaks++
+		}
 		for name, ds := range computeDiscontinuitySeqs(t, s.Playlist()) {
 			if prev, ok := seen[name]; ok {
 				assert.Equal(t, prev, ds,
@@ -789,6 +799,9 @@ func TestDiscontinuitySequenceIsStableAcrossReloads(t *testing.T) {
 
 	require.NotEmpty(t, seen)
 	assert.Positive(t, s.Stats().Discontinuities, "the stalls must have produced breaks")
+	require.Positive(t, headBreaks,
+		"this run never placed a break-carrying segment at the window head, so it "+
+			"cannot have exercised the regression it exists to catch")
 }
 
 // computeDiscontinuitySeqs derives each segment's discontinuity sequence
@@ -864,4 +877,45 @@ func TestPersistentSourceSlownessIsObservable(t *testing.T) {
 		"steady slowness is absorbed rather than reported as a stall, by design")
 	assert.Greater(t, st.DriftCorrection, time.Second,
 		"the absorbed correction must be observable, or sustained audio loss is invisible")
+}
+
+// errFakeSegment is returned by a stream whose segment flush is made to fail.
+var errFakeSegment = errors.New("fake segment flush failure")
+
+// TestCutFailureDuringStallIsReported covers the path where the container
+// refuses the segment that closes out a stalled timeline. Reporting success
+// there would be the worst outcome: the break is never published, the stream
+// is latched, and the caller has been told the write landed.
+func TestCutFailureDuringStallIsReported(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
+
+	// Accumulate a partial segment on the old timeline.
+	const before = testRate
+	writeSamples(t, s, before, testEpoch)
+	require.Positive(t, s.pendingSamples)
+
+	s.appendSegment = func([]byte) ([]byte, error) { return nil, errFakeSegment }
+
+	// A stall now forces a cut, which fails.
+	err := s.Write(silence(aacFrame, testChannels), sampleTime(before).Add(5*time.Second))
+	require.Error(t, err, "a failed cut must not be reported as a successful write")
+	require.ErrorIs(t, err, errFakeSegment)
+	assert.True(t, s.Stats().Failed)
+}
+
+// TestCutFailureDuringNormalWriteIsReported covers the same flush failure on
+// the ordinary path, where the segment is cut because it reached the target
+// rather than because the timeline broke.
+func TestCutFailureDuringNormalWriteIsReported(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
+	s.appendSegment = func([]byte) ([]byte, error) { return nil, errFakeSegment }
+
+	err := s.Write(silence(testRate*3, testChannels), testEpoch)
+	require.Error(t, err)
+	require.ErrorIs(t, err, errFakeSegment)
+	assert.True(t, s.segments.len() == 0 || s.Stats().Failed)
 }

--- a/internal/audiocore/hlsmux/hlsmux_test.go
+++ b/internal/audiocore/hlsmux/hlsmux_test.go
@@ -3,6 +3,7 @@ package hlsmux
 import (
 	"bytes"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -211,7 +212,7 @@ func TestSourceStallDeclaresDiscontinuityAndReanchorsPDT(t *testing.T) {
 	assert.Equal(t, resume, segs[breakIdx].PDT,
 		"the segment after a stall must be re-anchored to the resume time, not to the sample clock")
 
-	// RFC 8216 section 6.2.2: a segment preceded by EXT-X-DISCONTINUITY has
+	// RFC 8216 section 6.2.1: a segment preceded by EXT-X-DISCONTINUITY has
 	// the predecessor's discontinuity sequence number plus one. Numbering it
 	// with the predecessor's value would make the number a client computes for
 	// this segment change once the earlier ones scroll out of the window.
@@ -741,4 +742,126 @@ func TestReadyCountsSegmentsAndStatsTrackHealth(t *testing.T) {
 	assert.Zero(t, st.Discontinuities)
 	assert.False(t, st.Failed)
 	assert.False(t, st.LastSegmentPDT.IsZero(), "a cut segment must advance the health timestamp")
+}
+
+// TestDiscontinuitySequenceIsStableAcrossReloads is the end-to-end property
+// EXT-X-DISCONTINUITY-SEQUENCE exists to provide: the number a client computes
+// for a given segment must not change as the window scrolls. RFC 8216 section
+// 6.2.1 defines it as the tag value plus the EXT-X-DISCONTINUITY tags
+// preceding the segment, so this recomputes it exactly that way from the
+// rendered playlist after every cut.
+//
+// The regression this guards is subtle: getting Segment.DiscontinuitySeq right
+// internally is not enough, because the head segment's own break is emitted as
+// a tag AND folded into the tag value, and a client adds both.
+func TestDiscontinuitySequenceIsStableAcrossReloads(t *testing.T) {
+	t.Parallel()
+
+	s, err := New(&Config{
+		Codec:       newFakeCodec(&fakeCodecOptions{frameSizes: []int{aacFrame}}),
+		SampleRate:  testRate,
+		Channels:    testChannels,
+		BitrateKbps: testBitrate,
+		WindowSize:  3,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, s.Close()) })
+
+	seen := map[string]uint64{}
+	at := testEpoch
+	// Drive several segments with two stalls, checking the whole playlist
+	// after every write so each segment is observed in many window positions.
+	for i := range 24 {
+		writeSamples(t, s, testRate, at)
+		at = at.Add(time.Second)
+		if i == 6 || i == 14 {
+			at = at.Add(10 * time.Second) // stall
+		}
+
+		for name, ds := range computeDiscontinuitySeqs(t, s.Playlist()) {
+			if prev, ok := seen[name]; ok {
+				assert.Equal(t, prev, ds,
+					"%s changed discontinuity sequence from %d to %d between reloads", name, prev, ds)
+			}
+			seen[name] = ds
+		}
+	}
+
+	require.NotEmpty(t, seen)
+	assert.Positive(t, s.Stats().Discontinuities, "the stalls must have produced breaks")
+}
+
+// computeDiscontinuitySeqs derives each segment's discontinuity sequence
+// number from a rendered playlist the way a client does.
+func computeDiscontinuitySeqs(t *testing.T, playlist string) map[string]uint64 {
+	t.Helper()
+
+	out := map[string]uint64{}
+	var current uint64
+	for line := range strings.SplitSeq(playlist, "\n") {
+		switch {
+		case strings.HasPrefix(line, "#EXT-X-DISCONTINUITY-SEQUENCE:"):
+			v, err := strconv.ParseUint(strings.TrimPrefix(line, "#EXT-X-DISCONTINUITY-SEQUENCE:"), 10, 64)
+			require.NoError(t, err)
+			current = v
+		case line == "#EXT-X-DISCONTINUITY":
+			current++
+		case strings.HasSuffix(line, segmentNameSuffix):
+			out[line] = current
+		}
+	}
+	return out
+}
+
+func TestParseSegmentNameRejectsNonCanonicalSpelling(t *testing.T) {
+	t.Parallel()
+
+	// ParseUint accepts any number of leading zeros, so without the canonical
+	// check an unbounded family of names resolves to one segment. Since this
+	// is the only validation applied to the path element, that lets a client
+	// mint unlimited distinct cache keys for the same body.
+	for _, name := range []string{"segment00.m4s", "segment007.m4s", "segment0000000001.m4s"} {
+		_, ok := ParseSegmentName(name)
+		assert.False(t, ok, "%q is not the canonical spelling and must be rejected", name)
+	}
+	// The one legitimate zero still parses.
+	seq, ok := ParseSegmentName("segment0.m4s")
+	require.True(t, ok)
+	assert.Equal(t, uint64(0), seq)
+}
+
+// TestOversizedAccessUnitIsRejected covers the bound on what an out-of-tree
+// FrameEncoder may emit. Without it the sample count reaches uint32 narrowing
+// and a value above the segment target produces a wildly wrong EXTINF.
+func TestOversizedAccessUnitIsRejected(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
+	err := s.appendAccessUnit(make([]byte, 4), s.targetSamples+1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "access unit")
+}
+
+// TestPersistentSourceSlownessIsObservable: the drift absorber deliberately
+// hides a steady clock difference, which also hides a source that keeps
+// delivering less audio than real time. Stats must expose the accumulated
+// correction so that case is diagnosable rather than silent.
+func TestPersistentSourceSlownessIsObservable(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
+
+	// 90 ms of audio per 100 ms of wall clock.
+	const chunk = testRate / 10
+	at := testEpoch
+	for range 200 {
+		writeSamples(t, s, chunk*9/10, at)
+		at = at.Add(100 * time.Millisecond)
+	}
+
+	st := s.Stats()
+	assert.Zero(t, st.Discontinuities,
+		"steady slowness is absorbed rather than reported as a stall, by design")
+	assert.Greater(t, st.DriftCorrection, time.Second,
+		"the absorbed correction must be observable, or sustained audio loss is invisible")
 }

--- a/internal/audiocore/hlsmux/hlsmux_test.go
+++ b/internal/audiocore/hlsmux/hlsmux_test.go
@@ -1,0 +1,483 @@
+package hlsmux
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	m4a "github.com/tphakala/go-m4a"
+)
+
+const (
+	testRate     = 48000
+	testChannels = 1
+	testBitrate  = 128
+	aacFrame     = 1024
+)
+
+// testEpoch is a fixed wall-clock origin so PDT assertions are exact.
+var testEpoch = time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+
+// newTestStream builds a stream over a fixed-frame fake codec.
+func newTestStream(t *testing.T, opts *fakeCodecOptions) *Stream {
+	t.Helper()
+	s, err := New(&Config{
+		Codec:       newFakeCodec(opts),
+		SampleRate:  testRate,
+		Channels:    testChannels,
+		BitrateKbps: testBitrate,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+// writeSamples feeds n samples timed from the stream's own sample clock, which
+// is what a well-behaved source does.
+func writeSamples(t *testing.T, s *Stream, n int, at time.Time) {
+	t.Helper()
+	require.NoError(t, s.Write(silence(n, testChannels), at))
+}
+
+// sampleTime returns the wall-clock time of sample n after testEpoch.
+func sampleTime(n int) time.Time {
+	return testEpoch.Add(time.Duration(n) * time.Second / testRate)
+}
+
+func TestNewValidatesConfig(t *testing.T) {
+	t.Parallel()
+
+	valid := Config{
+		Codec:       newFakeCodec(&fakeCodecOptions{}),
+		SampleRate:  testRate,
+		Channels:    testChannels,
+		BitrateKbps: testBitrate,
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*Config)
+		errMsg string
+	}{
+		{"zero codec", func(c *Config) { c.Codec = Codec{} }, "codec is not set"},
+		{"zero sample rate", func(c *Config) { c.SampleRate = 0 }, "sample rate must be positive"},
+		{"negative sample rate", func(c *Config) { c.SampleRate = -1 }, "sample rate must be positive"},
+		{"three channels", func(c *Config) { c.Channels = 3 }, "channel count must be 1 or 2"},
+		{"zero channels", func(c *Config) { c.Channels = 0 }, "channel count must be 1 or 2"},
+		{"negative bitrate", func(c *Config) { c.BitrateKbps = -1 }, "bitrate must not be negative"},
+		{"negative segment duration", func(c *Config) { c.SegmentDuration = -time.Second }, "segment duration must not be negative"},
+		{"negative window", func(c *Config) { c.WindowSize = -1 }, "window size must not be negative"},
+		{"negative stall gap", func(c *Config) { c.MaxStallGap = -time.Second }, "max stall gap must not be negative"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := valid
+			tt.mutate(&cfg)
+			s, err := New(&cfg)
+			require.Error(t, err)
+			assert.Nil(t, s)
+			assert.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
+}
+
+func TestNewClosesEncoderWhenContainerSetupFails(t *testing.T) {
+	t.Parallel()
+
+	var enc *fakeEncoder
+	codec := newFakeCodec(&fakeCodecOptions{captured: &enc})
+	// Fail the container configuration, which happens after the encoder has
+	// already been constructed and so is the path that would leak it.
+	codec.writerConfig = func(_ EncoderConfig, _ FrameEncoder) (m4a.WriterConfig, error) {
+		return m4a.WriterConfig{}, errFakeEncoder
+	}
+
+	_, err := New(&Config{Codec: codec, SampleRate: testRate, Channels: testChannels, BitrateKbps: testBitrate})
+	require.Error(t, err)
+	require.NotNil(t, enc)
+	assert.True(t, enc.closed, "encoder must be closed when the stream cannot be built")
+}
+
+func TestSegmentsCutOnAccessUnitBoundaries(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}, declaredFrameSamples: aacFrame})
+
+	// Six seconds of audio at the default two-second target.
+	const total = testRate * 6
+	writeSamples(t, s, total, testEpoch)
+
+	segs := s.segments.window()
+	require.NotEmpty(t, segs)
+
+	target := testRate * 2
+	for i := range segs {
+		// A segment is cut on the first access unit that reaches the target,
+		// so it is never shorter than the target and never longer than the
+		// target plus one access unit.
+		assert.GreaterOrEqual(t, segs[i].Samples, target,
+			"segment %d is short of the target", segs[i].Seq)
+		assert.Less(t, segs[i].Samples, target+aacFrame,
+			"segment %d overshot by more than one access unit", segs[i].Seq)
+		assert.Zero(t, segs[i].Samples%aacFrame,
+			"segment %d does not land on an access-unit boundary", segs[i].Seq)
+	}
+}
+
+func TestDurationsAccumulateWithoutDrift(t *testing.T) {
+	t.Parallel()
+
+	// A window large enough to retain every segment produced below, so the
+	// sum can be checked against the total sample count.
+	s := newTestStream(t, &fakeCodecOptions{
+		frameSizes:           []int{aacFrame},
+		declaredFrameSamples: aacFrame,
+	})
+	s.segments = newRing(1000)
+
+	const total = testRate * 600 // ten minutes
+	writeSamples(t, s, total, testEpoch)
+
+	var sumSamples int
+	var sumDuration time.Duration
+	for _, seg := range s.segments.window() {
+		sumSamples += seg.Samples
+		sumDuration += seg.Duration
+	}
+
+	// The exact duration of the samples actually segmented. Any per-segment
+	// truncation would make the sum fall short of this.
+	want := time.Duration(sumSamples) * time.Second / testRate
+	assert.Equal(t, want, sumDuration,
+		"segment durations must sum to the exact duration of their samples")
+}
+
+func TestProgramDateTimeTracksTheSampleTimeline(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}, declaredFrameSamples: aacFrame})
+	s.segments = newRing(1000)
+
+	writeSamples(t, s, testRate*10, testEpoch)
+
+	segs := s.segments.window()
+	require.Greater(t, len(segs), 1)
+
+	assert.Equal(t, testEpoch, segs[0].PDT, "the first segment starts at the epoch")
+
+	var elapsed time.Duration
+	for _, seg := range segs {
+		assert.Equal(t, testEpoch.Add(elapsed), seg.PDT,
+			"segment %d PDT must equal the epoch plus every preceding duration", seg.Seq)
+		elapsed += seg.Duration
+	}
+}
+
+func TestSourceStallDeclaresDiscontinuityAndReanchorsPDT(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}, declaredFrameSamples: aacFrame})
+	s.segments = newRing(1000)
+
+	// Four seconds of well-behaved audio.
+	const before = testRate * 4
+	writeSamples(t, s, before, testEpoch)
+
+	// The source drops out for five seconds, then resumes. Its frames carry
+	// real capture times, so the resume timestamp is five seconds beyond
+	// where the sample clock expected it.
+	resume := sampleTime(before).Add(5 * time.Second)
+	writeSamples(t, s, testRate*4, resume)
+
+	segs := s.segments.window()
+	var breakIdx = -1
+	for i := range segs {
+		if segs[i].Discontinuity {
+			breakIdx = i
+			break
+		}
+	}
+	require.NotEqual(t, -1, breakIdx, "a stall longer than MaxStallGap must mark a discontinuity")
+
+	assert.Equal(t, resume, segs[breakIdx].PDT,
+		"the segment after a stall must be re-anchored to the resume time, not to the sample clock")
+	assert.Equal(t, uint64(0), segs[breakIdx].DiscontinuitySeq,
+		"the first discontinuity is preceded by none")
+	if breakIdx+1 < len(segs) {
+		assert.Equal(t, uint64(1), segs[breakIdx+1].DiscontinuitySeq,
+			"segments after the break count it")
+	}
+
+	assert.Contains(t, s.Playlist(), "#EXT-X-DISCONTINUITY\n")
+}
+
+func TestJitterBelowThresholdIsAbsorbed(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}, declaredFrameSamples: aacFrame})
+	s.segments = newRing(1000)
+
+	// Feed in chunks whose timestamps wobble by a few milliseconds, well
+	// inside the default one-second threshold. None of it should break the
+	// timeline.
+	const chunk = testRate / 10
+	wobble := []time.Duration{0, 3 * time.Millisecond, -2 * time.Millisecond, 5 * time.Millisecond}
+	for i := range 100 {
+		at := sampleTime(i * chunk).Add(wobble[i%len(wobble)])
+		writeSamples(t, s, chunk, at)
+	}
+
+	for _, seg := range s.segments.window() {
+		assert.False(t, seg.Discontinuity,
+			"ordinary jitter must not break the timeline (segment %d)", seg.Seq)
+	}
+	assert.NotContains(t, s.Playlist(), "#EXT-X-DISCONTINUITY")
+}
+
+func TestRingEvictsOldestAndAdvancesMediaSequence(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}, declaredFrameSamples: aacFrame})
+
+	// Twenty seconds at two seconds per segment produces far more than the
+	// default six-segment window.
+	writeSamples(t, s, testRate*20, testEpoch)
+
+	segs := s.segments.window()
+	require.Len(t, segs, DefaultWindowSize)
+
+	oldest := segs[0].Seq
+	assert.Positive(t, oldest, "early segments must have been evicted")
+	assert.Equal(t, oldest, s.segments.mediaSequence())
+
+	_, ok := s.Segment(oldest - 1)
+	assert.False(t, ok, "an evicted segment must not be servable")
+
+	_, ok = s.Segment(oldest)
+	assert.True(t, ok, "the oldest retained segment must be servable")
+
+	assert.Contains(t, s.Playlist(), "#EXT-X-MEDIA-SEQUENCE:"+strconv.FormatUint(oldest, 10))
+}
+
+func TestPartialAccessUnitIsBufferedNotEmitted(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}, declaredFrameSamples: aacFrame})
+
+	// Less than one access unit of audio.
+	writeSamples(t, s, aacFrame-1, testEpoch)
+
+	assert.True(t, s.segments.empty(), "a partial access unit must not produce a segment")
+	assert.False(t, s.Ready())
+	assert.Zero(t, s.pendingSamples)
+}
+
+func TestWriteRejectsMisalignedPCM(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStream(t, &fakeCodecOptions{})
+
+	err := s.Write(make([]byte, 3), testEpoch) // 3 bytes is 1.5 mono samples
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a multiple")
+}
+
+func TestWriteAfterCloseFails(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStream(t, &fakeCodecOptions{})
+	require.NoError(t, s.Close())
+
+	err := s.Write(silence(aacFrame, testChannels), testEpoch)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "closed stream")
+}
+
+func TestCloseFlushesTailAndEndsPlaylist(t *testing.T) {
+	t.Parallel()
+
+	var enc *fakeEncoder
+	s := newTestStream(t, &fakeCodecOptions{
+		frameSizes:           []int{aacFrame},
+		declaredFrameSamples: aacFrame,
+		tailSamples:          aacFrame,
+		captured:             &enc,
+	})
+
+	// Half a segment's worth, so nothing has been cut yet.
+	writeSamples(t, s, testRate, testEpoch)
+	require.True(t, s.segments.empty())
+
+	require.NoError(t, s.Close())
+
+	assert.False(t, s.segments.empty(), "Close must publish the buffered audio as a final segment")
+	require.NotNil(t, enc)
+	assert.True(t, enc.closed, "Close must release the encoder")
+
+	playlist := s.Playlist()
+	assert.Contains(t, playlist, "#EXT-X-ENDLIST", "a closed stream must stop clients polling")
+}
+
+func TestCloseIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStream(t, &fakeCodecOptions{})
+	require.NoError(t, s.Close())
+	require.NoError(t, s.Close(), "closing twice must not error")
+}
+
+func TestEncoderFailurePropagates(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}, failAfter: 2})
+
+	err := s.Write(silence(testRate, testChannels), testEpoch)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errFakeEncoder)
+}
+
+// TestCodecNeutrality is the structural check that nothing in the muxer
+// assumes AAC-LC's shape. The codec here has variable frame sizes that are not
+// 1024 and no priming delay at all, which is exactly what a hardcoded frame
+// size or an assumed non-zero encoder delay would trip over.
+func TestCodecNeutrality(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStream(t, &fakeCodecOptions{
+		name:       "variable",
+		frameSizes: []int{4096, 2048, 512, 4096},
+		delay:      0,
+		// Declared as variable: the muxer must record each unit's own
+		// duration rather than a fragment-wide default.
+		declaredFrameSamples: 0,
+	})
+	s.segments = newRing(1000)
+
+	writeSamples(t, s, testRate*10, testEpoch)
+
+	segs := s.segments.window()
+	require.NotEmpty(t, segs)
+
+	target := testRate * 2
+	var sumSamples int
+	for _, seg := range segs {
+		assert.GreaterOrEqual(t, seg.Samples, target)
+		// The largest frame in the cycle bounds the overshoot.
+		assert.Less(t, seg.Samples, target+4096)
+		sumSamples += seg.Samples
+	}
+
+	// The timeline must still be exact with irregular frame sizes.
+	var sumDuration time.Duration
+	for _, seg := range segs {
+		sumDuration += seg.Duration
+	}
+	assert.Equal(t, time.Duration(sumSamples)*time.Second/testRate, sumDuration)
+}
+
+func TestInitSegmentIsStableAndNonEmpty(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStream(t, &fakeCodecOptions{})
+
+	init := s.InitSegment()
+	require.NotEmpty(t, init, "the init segment must carry the moov the player needs")
+	assert.Same(t, &init[0], &s.InitSegment()[0], "the init segment is fixed for the life of the stream")
+
+	// It must be a real ISO-BMFF init segment: ftyp first, then moov.
+	assert.Contains(t, string(init[:16]), "ftyp")
+	assert.Contains(t, string(init), "moov")
+}
+
+func TestAccessUnitsAreCopiedNotAliased(t *testing.T) {
+	t.Parallel()
+
+	// The fake encoder reuses one scratch buffer and stamps each access unit
+	// with a distinct byte. If the muxer retained the borrowed slice instead
+	// of relying on go-m4a to copy, every unit in the segment would carry the
+	// last unit's stamp and the distinct values would be missing.
+	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}, declaredFrameSamples: aacFrame})
+
+	writeSamples(t, s, testRate*2+aacFrame, testEpoch)
+
+	segs := s.segments.window()
+	require.NotEmpty(t, segs)
+
+	data := segs[0].Data
+	distinct := map[byte]struct{}{}
+	for _, b := range data {
+		distinct[b] = struct{}{}
+	}
+	assert.Greater(t, len(distinct), 2,
+		"segment payload must contain the distinct per-unit stamps, not one repeated value")
+}
+
+func TestConcurrentWriteAndServe(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}, declaredFrameSamples: aacFrame})
+
+	var wg sync.WaitGroup
+	const chunks = 200
+	const chunk = testRate / 10
+
+	wg.Go(func() {
+		for i := range chunks {
+			if err := s.Write(silence(chunk, testChannels), sampleTime(i*chunk)); err != nil {
+				t.Errorf("write: %v", err)
+				return
+			}
+		}
+	})
+
+	for range 4 {
+		wg.Go(func() {
+			for range chunks {
+				_ = s.Playlist()
+				_ = s.InitSegment()
+				_, _ = s.Segment(0)
+				_ = s.Ready()
+			}
+		})
+	}
+
+	wg.Wait()
+}
+
+func TestPlaylistBeforeAnySegment(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStream(t, &fakeCodecOptions{})
+	playlist := s.Playlist()
+
+	// A player polling during the first segment must still learn the init
+	// segment, and must not be told the stream has ended.
+	assert.Contains(t, playlist, "#EXTM3U")
+	assert.Contains(t, playlist, "#EXT-X-VERSION:7")
+	assert.Contains(t, playlist, `#EXT-X-MAP:URI="init.mp4"`)
+	assert.Contains(t, playlist, "#EXT-X-TARGETDURATION:")
+	assert.NotContains(t, playlist, "#EXTINF")
+	assert.NotContains(t, playlist, "#EXT-X-ENDLIST")
+
+	// A zero target duration is rejected outright by players.
+	assert.NotContains(t, playlist, "#EXT-X-TARGETDURATION:0")
+}
+
+func TestPlaylistHasNoCodecsAttribute(t *testing.T) {
+	t.Parallel()
+
+	// CODECS belongs to EXT-X-STREAM-INF in a master playlist. RFC 8216 gives
+	// it no place in a media playlist, and emitting it anyway is the kind of
+	// thing strict players reject.
+	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
+	writeSamples(t, s, testRate*4, testEpoch)
+
+	playlist := s.Playlist()
+	assert.NotContains(t, playlist, "CODECS")
+	assert.NotContains(t, playlist, "EXT-X-STREAM-INF")
+}

--- a/internal/audiocore/hlsmux/playlist.go
+++ b/internal/audiocore/hlsmux/playlist.go
@@ -7,8 +7,14 @@ import (
 )
 
 const (
-	// playlistVersion is the EXT-X-VERSION this package emits. Fragmented MP4
-	// segments carried by EXT-X-MAP require version 7 (RFC 8216 section 8).
+	// playlistVersion is the EXT-X-VERSION this package emits.
+	//
+	// The format's floor is 6: RFC 8216 section 4.3.2.5 requires 6 or greater
+	// for EXT-X-MAP in a playlist without EXT-X-I-FRAMES-ONLY, which is this
+	// one. Emitting 7 is this package's choice, not the format's, because 7 is
+	// what Apple's HLS Authoring Specification pairs with fragmented MP4 and
+	// what fMP4 packagers emit in practice, so it is the value players are
+	// exercised against. Dropping to 6 would be legal.
 	playlistVersion = 7
 
 	// extinfPrecision is the number of fractional digits in an EXTINF
@@ -22,8 +28,10 @@ const (
 	pdtLayout = "2006-01-02T15:04:05.000Z07:00"
 
 	// playlistFixedLines is the number of header lines rendered before the
-	// segment list, used only to pre-size the builder.
-	playlistFixedLines = 5
+	// segment list, and playlistBytesPerHeaderLine a generous estimate of one
+	// such line. Both are used only to pre-size the builder.
+	playlistFixedLines         = 6
+	playlistBytesPerHeaderLine = 32
 
 	// playlistBytesPerSegment is a generous per-segment estimate for
 	// pre-sizing the builder: an EXTINF line, a PDT line and a filename.
@@ -37,15 +45,22 @@ const (
 // attribute appears: RFC 8216 places CODECS on EXT-X-STREAM-INF, a master
 // playlist tag. Players determine the codec by probing the init segment named
 // by EXT-X-MAP.
-func renderPlaylist(r *ring, ended bool) string {
+func renderPlaylist(r *ring, targetDuration int, ended bool) string {
+	segs := r.window()
+
 	var b strings.Builder
-	b.Grow(playlistFixedLines*32 + len(r.window())*playlistBytesPerSegment)
+	b.Grow(playlistFixedLines*playlistBytesPerHeaderLine + len(segs)*playlistBytesPerSegment)
 
 	b.WriteString("#EXTM3U\n")
 	b.WriteString("#EXT-X-VERSION:")
 	b.WriteString(strconv.Itoa(playlistVersion))
+	// Every access unit of every audio codec this package muxes is
+	// independently decodable, so each segment can be decoded without the one
+	// before it. Declaring that lets a player seek and switch without first
+	// fetching a predecessor.
+	b.WriteString("\n#EXT-X-INDEPENDENT-SEGMENTS")
 	b.WriteString("\n#EXT-X-TARGETDURATION:")
-	b.WriteString(strconv.Itoa(r.targetDuration()))
+	b.WriteString(strconv.Itoa(targetDuration))
 	b.WriteString("\n#EXT-X-MEDIA-SEQUENCE:")
 	b.WriteString(strconv.FormatUint(r.mediaSequence(), 10))
 	b.WriteString("\n")
@@ -61,8 +76,8 @@ func renderPlaylist(r *ring, ended bool) string {
 	b.WriteString(InitSegmentName)
 	b.WriteString("\"\n")
 
-	for i := range r.window() {
-		seg := &r.segments[i]
+	for i := range segs {
+		seg := &segs[i]
 		if seg.Discontinuity {
 			b.WriteString("#EXT-X-DISCONTINUITY\n")
 		}

--- a/internal/audiocore/hlsmux/playlist.go
+++ b/internal/audiocore/hlsmux/playlist.go
@@ -1,0 +1,91 @@
+package hlsmux
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// playlistVersion is the EXT-X-VERSION this package emits. Fragmented MP4
+	// segments carried by EXT-X-MAP require version 7 (RFC 8216 section 8).
+	playlistVersion = 7
+
+	// extinfPrecision is the number of fractional digits in an EXTINF
+	// duration. Six digits resolve a single sample at 48 kHz (about 20.8
+	// microseconds) with room to spare, so the playlist never rounds away a
+	// difference the timeline actually has.
+	extinfPrecision = 6
+
+	// pdtLayout formats EXT-X-PROGRAM-DATE-TIME. RFC 8216 requires an ISO 8601
+	// date-time, and milliseconds are what every packager emits in practice.
+	pdtLayout = "2006-01-02T15:04:05.000Z07:00"
+
+	// playlistFixedLines is the number of header lines rendered before the
+	// segment list, used only to pre-size the builder.
+	playlistFixedLines = 5
+
+	// playlistBytesPerSegment is a generous per-segment estimate for
+	// pre-sizing the builder: an EXTINF line, a PDT line and a filename.
+	playlistBytesPerSegment = 96
+)
+
+// renderPlaylist builds the HLS media playlist describing the ring's current
+// window.
+//
+// It is a media playlist, not a master playlist, which is why no CODECS
+// attribute appears: RFC 8216 places CODECS on EXT-X-STREAM-INF, a master
+// playlist tag. Players determine the codec by probing the init segment named
+// by EXT-X-MAP.
+func renderPlaylist(r *ring, ended bool) string {
+	var b strings.Builder
+	b.Grow(playlistFixedLines*32 + len(r.window())*playlistBytesPerSegment)
+
+	b.WriteString("#EXTM3U\n")
+	b.WriteString("#EXT-X-VERSION:")
+	b.WriteString(strconv.Itoa(playlistVersion))
+	b.WriteString("\n#EXT-X-TARGETDURATION:")
+	b.WriteString(strconv.Itoa(r.targetDuration()))
+	b.WriteString("\n#EXT-X-MEDIA-SEQUENCE:")
+	b.WriteString(strconv.FormatUint(r.mediaSequence(), 10))
+	b.WriteString("\n")
+	if ds := r.discontinuitySequence(); ds != 0 {
+		b.WriteString("#EXT-X-DISCONTINUITY-SEQUENCE:")
+		b.WriteString(strconv.FormatUint(ds, 10))
+		b.WriteString("\n")
+	}
+	// EXT-X-MAP is emitted even for an empty window so that a player polling
+	// during the first segment's worth of audio already knows the init segment
+	// and can fetch it before any media arrives.
+	b.WriteString(`#EXT-X-MAP:URI="`)
+	b.WriteString(InitSegmentName)
+	b.WriteString("\"\n")
+
+	for i := range r.window() {
+		seg := &r.segments[i]
+		if seg.Discontinuity {
+			b.WriteString("#EXT-X-DISCONTINUITY\n")
+		}
+		b.WriteString("#EXT-X-PROGRAM-DATE-TIME:")
+		b.WriteString(seg.PDT.Format(pdtLayout))
+		b.WriteString("\n#EXTINF:")
+		b.WriteString(formatEXTINF(seg.Duration))
+		b.WriteString(",\n")
+		b.WriteString(SegmentName(seg.Seq))
+		b.WriteString("\n")
+	}
+
+	// EXT-X-ENDLIST tells a client to stop polling. Without it a player keeps
+	// refreshing a playlist that will never change again.
+	if ended {
+		b.WriteString("#EXT-X-ENDLIST\n")
+	}
+
+	return b.String()
+}
+
+// formatEXTINF renders a segment duration as the fixed-point seconds value an
+// EXTINF tag carries.
+func formatEXTINF(d time.Duration) string {
+	return strconv.FormatFloat(d.Seconds(), 'f', extinfPrecision, 64)
+}

--- a/internal/audiocore/hlsmux/playlist_test.go
+++ b/internal/audiocore/hlsmux/playlist_test.go
@@ -20,6 +20,7 @@ func TestRenderPlaylistGolden(t *testing.T) {
 
 	want := `#EXTM3U
 #EXT-X-VERSION:7
+#EXT-X-INDEPENDENT-SEGMENTS
 #EXT-X-TARGETDURATION:2
 #EXT-X-MEDIA-SEQUENCE:7
 #EXT-X-MAP:URI="init.mp4"
@@ -30,7 +31,7 @@ segment7.m4s
 #EXTINF:2.005333,
 segment8.m4s
 `
-	assert.Equal(t, want, renderPlaylist(r, false))
+	assert.Equal(t, want, renderPlaylist(r, 2, false))
 }
 
 // TestRenderPlaylistWithDiscontinuityGolden covers the tags that only appear
@@ -41,16 +42,21 @@ func TestRenderPlaylistWithDiscontinuityGolden(t *testing.T) {
 	base := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
 	r := newRing(2)
 	r.push(&Segment{Seq: 40, Duration: 2 * time.Second, PDT: base, DiscontinuitySeq: 2})
+	// A segment preceded by EXT-X-DISCONTINUITY carries its predecessor's
+	// discontinuity sequence number plus one, so that the number a client
+	// computes for it does not change when segment 40 scrolls out of the
+	// window and 41 becomes the first entry.
 	r.push(&Segment{
 		Seq:              41,
 		Duration:         2 * time.Second,
 		PDT:              base.Add(9 * time.Second),
 		Discontinuity:    true,
-		DiscontinuitySeq: 2,
+		DiscontinuitySeq: 3,
 	})
 
 	want := `#EXTM3U
 #EXT-X-VERSION:7
+#EXT-X-INDEPENDENT-SEGMENTS
 #EXT-X-TARGETDURATION:2
 #EXT-X-MEDIA-SEQUENCE:40
 #EXT-X-DISCONTINUITY-SEQUENCE:2
@@ -63,7 +69,7 @@ segment40.m4s
 #EXTINF:2.000000,
 segment41.m4s
 `
-	assert.Equal(t, want, renderPlaylist(r, false))
+	assert.Equal(t, want, renderPlaylist(r, 2, false))
 }
 
 // TestRenderPlaylistEndedGolden covers the closed stream, where the trailing
@@ -77,6 +83,7 @@ func TestRenderPlaylistEndedGolden(t *testing.T) {
 
 	want := `#EXTM3U
 #EXT-X-VERSION:7
+#EXT-X-INDEPENDENT-SEGMENTS
 #EXT-X-TARGETDURATION:2
 #EXT-X-MEDIA-SEQUENCE:0
 #EXT-X-MAP:URI="init.mp4"
@@ -85,7 +92,7 @@ func TestRenderPlaylistEndedGolden(t *testing.T) {
 segment0.m4s
 #EXT-X-ENDLIST
 `
-	assert.Equal(t, want, renderPlaylist(r, true))
+	assert.Equal(t, want, renderPlaylist(r, 2, true))
 }
 
 // TestRenderPlaylistEmptyGolden covers the window a player sees while the very
@@ -95,11 +102,12 @@ func TestRenderPlaylistEmptyGolden(t *testing.T) {
 
 	want := `#EXTM3U
 #EXT-X-VERSION:7
-#EXT-X-TARGETDURATION:1
+#EXT-X-INDEPENDENT-SEGMENTS
+#EXT-X-TARGETDURATION:2
 #EXT-X-MEDIA-SEQUENCE:0
 #EXT-X-MAP:URI="init.mp4"
 `
-	assert.Equal(t, want, renderPlaylist(newRing(6), false))
+	assert.Equal(t, want, renderPlaylist(newRing(6), 2, false))
 }
 
 func TestFormatEXTINF(t *testing.T) {

--- a/internal/audiocore/hlsmux/playlist_test.go
+++ b/internal/audiocore/hlsmux/playlist_test.go
@@ -1,0 +1,125 @@
+package hlsmux
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRenderPlaylistGolden pins the exact bytes of a rendered playlist. The
+// tag set, their order and their formatting are what a player parses, so a
+// change here should have to be deliberate.
+func TestRenderPlaylistGolden(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	r := newRing(3)
+	r.push(&Segment{Seq: 7, Samples: 96256, Duration: 2005333333 * time.Nanosecond, PDT: base})
+	r.push(&Segment{Seq: 8, Samples: 96256, Duration: 2005333334 * time.Nanosecond, PDT: base.Add(2005333333 * time.Nanosecond)})
+
+	want := `#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-TARGETDURATION:2
+#EXT-X-MEDIA-SEQUENCE:7
+#EXT-X-MAP:URI="init.mp4"
+#EXT-X-PROGRAM-DATE-TIME:2026-07-21T12:00:00.000Z
+#EXTINF:2.005333,
+segment7.m4s
+#EXT-X-PROGRAM-DATE-TIME:2026-07-21T12:00:02.005Z
+#EXTINF:2.005333,
+segment8.m4s
+`
+	assert.Equal(t, want, renderPlaylist(r, false))
+}
+
+// TestRenderPlaylistWithDiscontinuityGolden covers the tags that only appear
+// once a source has stalled and the earlier segments have scrolled away.
+func TestRenderPlaylistWithDiscontinuityGolden(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	r := newRing(2)
+	r.push(&Segment{Seq: 40, Duration: 2 * time.Second, PDT: base, DiscontinuitySeq: 2})
+	r.push(&Segment{
+		Seq:              41,
+		Duration:         2 * time.Second,
+		PDT:              base.Add(9 * time.Second),
+		Discontinuity:    true,
+		DiscontinuitySeq: 2,
+	})
+
+	want := `#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-TARGETDURATION:2
+#EXT-X-MEDIA-SEQUENCE:40
+#EXT-X-DISCONTINUITY-SEQUENCE:2
+#EXT-X-MAP:URI="init.mp4"
+#EXT-X-PROGRAM-DATE-TIME:2026-07-21T12:00:00.000Z
+#EXTINF:2.000000,
+segment40.m4s
+#EXT-X-DISCONTINUITY
+#EXT-X-PROGRAM-DATE-TIME:2026-07-21T12:00:09.000Z
+#EXTINF:2.000000,
+segment41.m4s
+`
+	assert.Equal(t, want, renderPlaylist(r, false))
+}
+
+// TestRenderPlaylistEndedGolden covers the closed stream, where the trailing
+// EXT-X-ENDLIST is what stops clients polling forever.
+func TestRenderPlaylistEndedGolden(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	r := newRing(2)
+	r.push(&Segment{Seq: 0, Duration: 1500 * time.Millisecond, PDT: base})
+
+	want := `#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-TARGETDURATION:2
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-MAP:URI="init.mp4"
+#EXT-X-PROGRAM-DATE-TIME:2026-07-21T12:00:00.000Z
+#EXTINF:1.500000,
+segment0.m4s
+#EXT-X-ENDLIST
+`
+	assert.Equal(t, want, renderPlaylist(r, true))
+}
+
+// TestRenderPlaylistEmptyGolden covers the window a player sees while the very
+// first segment is still accumulating.
+func TestRenderPlaylistEmptyGolden(t *testing.T) {
+	t.Parallel()
+
+	want := `#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-TARGETDURATION:1
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-MAP:URI="init.mp4"
+`
+	assert.Equal(t, want, renderPlaylist(newRing(6), false))
+}
+
+func TestFormatEXTINF(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		d    time.Duration
+		want string
+	}{
+		{"whole seconds", 2 * time.Second, "2.000000"},
+		{"aac segment at 48 kHz", 2005333333 * time.Nanosecond, "2.005333"},
+		{"sub-second", 500 * time.Millisecond, "0.500000"},
+		{"zero", 0, "0.000000"},
+		{"single 1024-sample frame", 21333333 * time.Nanosecond, "0.021333"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, formatEXTINF(tt.d))
+		})
+	}
+}

--- a/internal/audiocore/hlsmux/segment.go
+++ b/internal/audiocore/hlsmux/segment.go
@@ -1,0 +1,184 @@
+package hlsmux
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// InitSegmentName is the filename the playlist's EXT-X-MAP points at. It
+	// is a name rather than a path because nothing here writes to disk; the
+	// HTTP layer maps it back to Stream.InitSegment.
+	InitSegmentName = "init.mp4"
+
+	// segmentNamePrefix and segmentNameSuffix bracket a media segment's
+	// sequence number. The sequence number is written in full rather than
+	// zero padded to a fixed width, because a live stream outlives any fixed
+	// width: the FFmpeg path's segment%03d.m4s wraps after 1000 segments,
+	// which is a little over half an hour at two seconds each.
+	segmentNamePrefix = "segment"
+	segmentNameSuffix = ".m4s"
+)
+
+// Segment is one fragmented-MP4 media segment together with the timeline facts
+// the playlist needs to describe it.
+type Segment struct {
+	// Seq is the media sequence number, counting from zero for the life of
+	// the stream. It names the segment and orders the playlist.
+	Seq uint64
+
+	// Data is the complete segment: styp, moof and mdat. It is owned by the
+	// stream and must be treated as read only; the ring never writes into a
+	// published segment's backing array.
+	Data []byte
+
+	// Samples is the per-channel sample count actually contained, summed over
+	// the segment's access units. It is the ground truth from which Duration
+	// derives, never the nominal target.
+	Samples int
+
+	// Duration is the exact playback duration of Samples at the stream's
+	// sample rate. Consecutive durations sum without drift; see the carry
+	// arithmetic in Stream.
+	Duration time.Duration
+
+	// PDT is the wall-clock time of this segment's first sample, for
+	// EXT-X-PROGRAM-DATE-TIME.
+	PDT time.Time
+
+	// Discontinuity marks a break in the timeline immediately before this
+	// segment, which happens when the source stalls and resumes. The playlist
+	// emits EXT-X-DISCONTINUITY ahead of it.
+	Discontinuity bool
+
+	// DiscontinuitySeq is the number of discontinuities that occurred before
+	// this segment, which is what EXT-X-DISCONTINUITY-SEQUENCE must report
+	// once earlier segments have scrolled out of the window.
+	DiscontinuitySeq uint64
+}
+
+// SegmentName returns the playlist filename for a media sequence number.
+func SegmentName(seq uint64) string {
+	return segmentNamePrefix + strconv.FormatUint(seq, 10) + segmentNameSuffix
+}
+
+// ParseSegmentName recovers the media sequence number from a segment filename
+// produced by SegmentName. It reports false for anything else, so an HTTP
+// handler can reject a bad request without a second validation rule.
+func ParseSegmentName(name string) (seq uint64, ok bool) {
+	digits, found := strings.CutPrefix(name, segmentNamePrefix)
+	if !found {
+		return 0, false
+	}
+	digits, found = strings.CutSuffix(digits, segmentNameSuffix)
+	if !found || digits == "" {
+		return 0, false
+	}
+	// Reject a leading '+' or '-', which ParseUint would otherwise accept for
+	// '+', so that exactly one name maps to each sequence number.
+	if digits[0] < '0' || digits[0] > '9' {
+		return 0, false
+	}
+	seq, err := strconv.ParseUint(digits, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return seq, true
+}
+
+// ring is the bounded window of media segments a live playlist advertises.
+// Pushing past capacity evicts the oldest, which is what makes memory use
+// constant no matter how long a stream runs.
+//
+// ring is not safe for concurrent use; Stream serialises access to it.
+type ring struct {
+	segments []Segment
+	capacity int
+}
+
+// newRing returns a ring holding at most capacity segments.
+func newRing(capacity int) *ring {
+	return &ring{
+		segments: make([]Segment, 0, capacity),
+		capacity: capacity,
+	}
+}
+
+// push appends s, evicting the oldest segment when the window is full.
+//
+// When full it shifts the retained segments down and overwrites the last slot,
+// reusing the backing array. Overwriting drops the evicted segment's reference
+// to its Data, so the bytes become collectable; the array itself is only ever
+// reused for the Segment headers, never for segment payloads, so a segment
+// already handed out by get stays valid for as long as its caller holds it.
+func (r *ring) push(s *Segment) {
+	if len(r.segments) < r.capacity {
+		r.segments = append(r.segments, *s)
+		return
+	}
+	copy(r.segments, r.segments[1:])
+	r.segments[len(r.segments)-1] = *s
+}
+
+// get returns the retained segment with the given sequence number. It reports
+// false once the segment has been evicted, which a client that fell too far
+// behind will see as a 404.
+func (r *ring) get(seq uint64) (Segment, bool) {
+	for i := range r.segments {
+		if r.segments[i].Seq == seq {
+			return r.segments[i], true
+		}
+	}
+	return Segment{}, false
+}
+
+// window returns the retained segments, oldest first. The returned slice
+// aliases the ring's storage and is only valid while the caller holds the
+// stream lock.
+func (r *ring) window() []Segment {
+	return r.segments
+}
+
+// empty reports whether the ring holds no segments, which is the state a
+// stream is in before the first segment is cut.
+func (r *ring) empty() bool {
+	return len(r.segments) == 0
+}
+
+// mediaSequence is the sequence number of the oldest retained segment, which
+// is what EXT-X-MEDIA-SEQUENCE reports.
+func (r *ring) mediaSequence() uint64 {
+	if len(r.segments) == 0 {
+		return 0
+	}
+	return r.segments[0].Seq
+}
+
+// discontinuitySequence is the discontinuity count applying to the oldest
+// retained segment, which is what EXT-X-DISCONTINUITY-SEQUENCE reports once
+// earlier segments have scrolled out of the window.
+func (r *ring) discontinuitySequence() uint64 {
+	if len(r.segments) == 0 {
+		return 0
+	}
+	return r.segments[0].DiscontinuitySeq
+}
+
+// targetDuration is the EXT-X-TARGETDURATION value for the current window.
+//
+// RFC 8216 section 4.3.3.1 requires every segment's EXTINF, rounded to the
+// nearest integer, to be less than or equal to this value, so the maximum of
+// the rounded durations is both the smallest legal value and a correct one.
+// It never returns zero, because a playlist with a zero target duration is
+// rejected outright by players.
+func (r *ring) targetDuration() int {
+	maxRounded := 1
+	for i := range r.segments {
+		rounded := int(r.segments[i].Duration.Round(time.Second) / time.Second)
+		if rounded > maxRounded {
+			maxRounded = rounded
+		}
+	}
+	return maxRounded
+}

--- a/internal/audiocore/hlsmux/segment.go
+++ b/internal/audiocore/hlsmux/segment.go
@@ -52,9 +52,11 @@ type Segment struct {
 	// emits EXT-X-DISCONTINUITY ahead of it.
 	Discontinuity bool
 
-	// DiscontinuitySeq is the number of discontinuities that occurred before
-	// this segment, which is what EXT-X-DISCONTINUITY-SEQUENCE must report
-	// once earlier segments have scrolled out of the window.
+	// DiscontinuitySeq is this segment's own discontinuity sequence number,
+	// counting every break up to and including its own. It is not what
+	// EXT-X-DISCONTINUITY-SEQUENCE reports directly; see
+	// ring.discontinuitySequence, which subtracts this segment's own break
+	// because the renderer emits the tag for it separately.
 	DiscontinuitySeq uint64
 }
 
@@ -168,12 +170,24 @@ func (r *ring) mediaSequence() uint64 {
 	return r.segments[0].Seq
 }
 
-// discontinuitySequence is the discontinuity count applying to the oldest
-// retained segment, which is what EXT-X-DISCONTINUITY-SEQUENCE reports once
-// earlier segments have scrolled out of the window.
+// discontinuitySequence is the EXT-X-DISCONTINUITY-SEQUENCE value for the
+// current window.
+//
+// RFC 8216 section 6.2.1 defines a segment's discontinuity sequence number as
+// this tag's value plus the number of EXT-X-DISCONTINUITY tags preceding that
+// segment in the playlist. Segment.DiscontinuitySeq already counts the
+// segment's own break, so when the oldest retained segment carries one, the
+// renderer also emits its EXT-X-DISCONTINUITY and the client would add it a
+// second time. Subtracting it here is what keeps the number a client computes
+// for a given segment identical across reloads as the window scrolls, which is
+// the entire purpose of the tag.
 func (r *ring) discontinuitySequence() uint64 {
 	if len(r.segments) == 0 {
 		return 0
 	}
-	return r.segments[0].DiscontinuitySeq
+	seq := r.segments[0].DiscontinuitySeq
+	if r.segments[0].Discontinuity && seq > 0 {
+		seq--
+	}
+	return seq
 }

--- a/internal/audiocore/hlsmux/segment.go
+++ b/internal/audiocore/hlsmux/segment.go
@@ -76,12 +76,20 @@ func ParseSegmentName(name string) (seq uint64, ok bool) {
 		return 0, false
 	}
 	// Reject a leading '+' or '-', which ParseUint would otherwise accept for
-	// '+', so that exactly one name maps to each sequence number.
+	// '+'.
 	if digits[0] < '0' || digits[0] > '9' {
 		return 0, false
 	}
 	seq, err := strconv.ParseUint(digits, 10, 64)
 	if err != nil {
+		return 0, false
+	}
+	// Require the canonical spelling, so exactly one name maps to each
+	// sequence number. ParseUint alone would accept any number of leading
+	// zeros, giving an unbounded family of names for one segment; since this
+	// is the only validation applied to the path element, that would let a
+	// client mint unlimited distinct cache keys for the same body.
+	if SegmentName(seq) != name {
 		return 0, false
 	}
 	return seq, true
@@ -97,8 +105,14 @@ type ring struct {
 	capacity int
 }
 
-// newRing returns a ring holding at most capacity segments.
+// newRing returns a ring holding at most capacity segments. A capacity below
+// one is raised to one: push indexes the window unconditionally once full, so
+// a zero capacity would panic on the first segment, on the audio goroutine,
+// with nothing to recover it.
 func newRing(capacity int) *ring {
+	if capacity < 1 {
+		capacity = 1
+	}
 	return &ring{
 		segments: make([]Segment, 0, capacity),
 		capacity: capacity,
@@ -140,10 +154,9 @@ func (r *ring) window() []Segment {
 	return r.segments
 }
 
-// empty reports whether the ring holds no segments, which is the state a
-// stream is in before the first segment is cut.
-func (r *ring) empty() bool {
-	return len(r.segments) == 0
+// len is how many segments the window currently holds.
+func (r *ring) len() int {
+	return len(r.segments)
 }
 
 // mediaSequence is the sequence number of the oldest retained segment, which
@@ -163,22 +176,4 @@ func (r *ring) discontinuitySequence() uint64 {
 		return 0
 	}
 	return r.segments[0].DiscontinuitySeq
-}
-
-// targetDuration is the EXT-X-TARGETDURATION value for the current window.
-//
-// RFC 8216 section 4.3.3.1 requires every segment's EXTINF, rounded to the
-// nearest integer, to be less than or equal to this value, so the maximum of
-// the rounded durations is both the smallest legal value and a correct one.
-// It never returns zero, because a playlist with a zero target duration is
-// rejected outright by players.
-func (r *ring) targetDuration() int {
-	maxRounded := 1
-	for i := range r.segments {
-		rounded := int(r.segments[i].Duration.Round(time.Second) / time.Second)
-		if rounded > maxRounded {
-			maxRounded = rounded
-		}
-	}
-	return maxRounded
 }

--- a/internal/audiocore/hlsmux/segment.go
+++ b/internal/audiocore/hlsmux/segment.go
@@ -186,7 +186,11 @@ func (r *ring) discontinuitySequence() uint64 {
 		return 0
 	}
 	seq := r.segments[0].DiscontinuitySeq
-	if r.segments[0].Discontinuity && seq > 0 {
+	if r.segments[0].Discontinuity {
+		// cutSegment increments the counter before assigning it, so a segment
+		// carrying a break always has DiscontinuitySeq >= 1 and this cannot
+		// underflow. Guarding for zero here would paper over a broken
+		// invariant rather than report it.
 		seq--
 	}
 	return seq

--- a/internal/audiocore/hlsmux/segment_test.go
+++ b/internal/audiocore/hlsmux/segment_test.go
@@ -1,0 +1,107 @@
+package hlsmux
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSegmentNameRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	for _, seq := range []uint64{0, 1, 9, 10, 999, 1000, 1 << 32, math.MaxUint64} {
+		name := SegmentName(seq)
+		got, ok := ParseSegmentName(name)
+		require.True(t, ok, "%q must parse", name)
+		assert.Equal(t, seq, got)
+	}
+}
+
+func TestParseSegmentNameRejectsJunk(t *testing.T) {
+	t.Parallel()
+
+	// The HTTP layer uses this as its only validation of a path element, so
+	// anything that is not exactly a name this package emits must be refused.
+	bad := []string{
+		"", "segment.m4s", "segment", "0.m4s", "init.mp4",
+		"segment-1.m4s", "segment+1.m4s", "segment 1.m4s",
+		"segment1.ts", "segment1.m4s.m4s", "Segment1.m4s",
+		"segment0x10.m4s", "../segment1.m4s", "segment1.m4s/../../etc",
+		// One past uint64.
+		"segment18446744073709551616.m4s",
+	}
+	for _, name := range bad {
+		_, ok := ParseSegmentName(name)
+		assert.False(t, ok, "%q must be rejected", name)
+	}
+}
+
+func TestRingEvictionDropsDataReference(t *testing.T) {
+	t.Parallel()
+
+	r := newRing(2)
+	for i := range uint64(3) {
+		r.push(&Segment{Seq: i, Data: []byte{byte(i)}})
+	}
+
+	require.Len(t, r.window(), 2)
+	assert.Equal(t, uint64(1), r.mediaSequence())
+
+	_, ok := r.get(0)
+	assert.False(t, ok, "the evicted segment must be gone")
+
+	// The window holds the two newest segments in order. This is the
+	// observable half of eviction; that the evicted payload also becomes
+	// collectable follows from push overwriting the slot rather than
+	// re-slicing, which cannot be asserted directly without a finalizer.
+	assert.Equal(t, []byte{1}, r.window()[0].Data)
+	assert.Equal(t, []byte{2}, r.window()[1].Data)
+}
+
+func TestRingTargetDuration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		durations []time.Duration
+		want      int
+	}{
+		{"empty ring floors at one", nil, 1},
+		{"sub-second segments floor at one", []time.Duration{300 * time.Millisecond}, 1},
+		{"two second segments", []time.Duration{2005 * time.Millisecond, 1994 * time.Millisecond}, 2},
+		{"rounds to nearest, not up", []time.Duration{2400 * time.Millisecond}, 2},
+		{"rounds up past the halfway point", []time.Duration{2600 * time.Millisecond}, 3},
+		{"takes the maximum", []time.Duration{time.Second, 4 * time.Second, 2 * time.Second}, 4},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			r := newRing(len(tt.durations) + 1)
+			for i, d := range tt.durations {
+				r.push(&Segment{Seq: uint64(i), Duration: d})
+			}
+			assert.Equal(t, tt.want, r.targetDuration())
+		})
+	}
+}
+
+func TestSampleClockIsExactAcrossManyConversions(t *testing.T) {
+	t.Parallel()
+
+	// 1024 samples at 48 kHz is 21.333... ms, which no integer number of
+	// nanoseconds represents. Summing many of them is where a lost remainder
+	// would show up.
+	c := sampleClock{rate: testRate}
+	const frames = 100_000
+	var total time.Duration
+	for range frames {
+		total += c.advance(aacFrame)
+	}
+
+	want := time.Duration(frames) * aacFrame * time.Second / testRate
+	assert.Equal(t, want, total)
+}

--- a/internal/audiocore/hlsmux/segment_test.go
+++ b/internal/audiocore/hlsmux/segment_test.go
@@ -61,31 +61,58 @@ func TestRingEvictionDropsDataReference(t *testing.T) {
 	assert.Equal(t, []byte{2}, r.window()[1].Data)
 }
 
-func TestRingTargetDuration(t *testing.T) {
+// TestCeilSeconds pins EXT-X-TARGETDURATION to a true ceiling. Rounding to
+// nearest would report a 2.4s bound as 2, which RFC 8216 tolerates on a
+// rounding reading of section 4.3.3.1 but Apple's mediastreamvalidator treats
+// as a segment overrunning its declared target.
+func TestCeilSeconds(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		durations []time.Duration
-		want      int
+		name string
+		d    time.Duration
+		want int
 	}{
-		{"empty ring floors at one", nil, 1},
-		{"sub-second segments floor at one", []time.Duration{300 * time.Millisecond}, 1},
-		{"two second segments", []time.Duration{2005 * time.Millisecond, 1994 * time.Millisecond}, 2},
-		{"rounds to nearest, not up", []time.Duration{2400 * time.Millisecond}, 2},
-		{"rounds up past the halfway point", []time.Duration{2600 * time.Millisecond}, 3},
-		{"takes the maximum", []time.Duration{time.Second, 4 * time.Second, 2 * time.Second}, 4},
+		{"zero floors at one", 0, 1},
+		{"sub-second floors at one", 300 * time.Millisecond, 1},
+		{"exactly two seconds", 2 * time.Second, 2},
+		{"just over two rounds up", 2001 * time.Millisecond, 3},
+		{"well under three still rounds up", 2400 * time.Millisecond, 3},
+		{"exactly ten", 10 * time.Second, 10},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			r := newRing(len(tt.durations) + 1)
-			for i, d := range tt.durations {
-				r.push(&Segment{Seq: uint64(i), Duration: d})
-			}
-			assert.Equal(t, tt.want, r.targetDuration())
+			assert.Equal(t, tt.want, ceilSeconds(tt.d))
 		})
+	}
+}
+
+func TestRingLen(t *testing.T) {
+	t.Parallel()
+
+	r := newRing(3)
+	assert.Zero(t, r.len())
+	for i := range uint64(5) {
+		r.push(&Segment{Seq: i})
+	}
+	assert.Equal(t, 3, r.len(), "the window never grows past its capacity")
+}
+
+// TestNewRingRaisesDegenerateCapacity guards the audio goroutine: push indexes
+// the window unconditionally once full, so a zero capacity would panic on the
+// first segment with nothing to recover it.
+func TestNewRingRaisesDegenerateCapacity(t *testing.T) {
+	t.Parallel()
+
+	for _, capacity := range []int{-1, 0} {
+		r := newRing(capacity)
+		assert.NotPanics(t, func() {
+			r.push(&Segment{Seq: 1})
+			r.push(&Segment{Seq: 2})
+		})
+		assert.Equal(t, 1, r.len())
 	}
 }
 

--- a/internal/conf/native_encoders.go
+++ b/internal/conf/native_encoders.go
@@ -29,7 +29,8 @@ import (
 //
 //	AAC:  exportFormatNeedsFFmpeg and SaveAudioAction.encodeClip
 //	Opus: exportFormatNeedsFFmpeg and SaveAudioAction.encodeClip
-//	HLS:  the backend selection in internal/api/v2/audio
+//	HLS:  no reader yet; the backend selection in internal/api/v2/audio lands
+//	      with the handler wiring, and this list must name it then
 //
 // Nothing else depends on this file, and it deliberately holds no other logic
 // so that each removal stays a mechanical edit.

--- a/internal/conf/native_encoders.go
+++ b/internal/conf/native_encoders.go
@@ -5,33 +5,43 @@ import (
 	"strings"
 )
 
-// Temporary runtime opt-in for the native Go clip encoders.
+// Temporary runtime opt-in for the native Go encoders.
 //
-// AAC and Opus clip export still runs through FFmpeg by default. Setting
-// BIRDNET_AAC_ENCODER=native or BIRDNET_OPUS_ENCODER=native switches the
-// matching format to the pure-Go encoder (go-aac plus go-m4a for .m4a, go-opus
-// for .opus) so it can be exercised in the field before it becomes the default.
-// The two gates are independent, so one codec can be promoted while the other is
-// still proving itself.
+// AAC and Opus clip export, and HLS live streaming, still run through FFmpeg by
+// default. Setting BIRDNET_AAC_ENCODER=native, BIRDNET_OPUS_ENCODER=native or
+// BIRDNET_HLS_ENCODER=native switches the matching path to the pure-Go encoder
+// (go-aac plus go-m4a for .m4a and for HLS, go-opus for .opus) so it can be
+// exercised in the field before it becomes the default. The gates are
+// independent, so one path can be promoted while another is still proving
+// itself.
 //
-// This lives in conf rather than in a package of its own so that both consumers
-// reach it without a new dependency edge: the export-format validation here, and
-// the encoder dispatch in the analysis processor, already depend on conf. A
-// dedicated package under audiocore would make conf import audiocore, which
-// inverts the layering and widens the deliberately exact internal closure that
-// internal/diagnostics guards.
+// This lives in conf rather than in a package of its own so that every consumer
+// reaches it without a new dependency edge: the export-format validation here,
+// the encoder dispatch in the analysis processor, and the HLS handler in the v2
+// API already depend on conf. A dedicated package under audiocore would make
+// conf import audiocore, which inverts the layering and widens the deliberately
+// exact internal closure that internal/diagnostics guards.
 //
-// REMOVAL: this file is scaffolding with a planned end of life. Once both native
-// encoders have earned field confidence, delete it along with the gate checks in
-// exportFormatNeedsFFmpeg and in SaveAudioAction.encodeClip; the native branches
-// become unconditional and the FFmpeg branches for AAC and Opus go away with
-// them. Nothing else depends on it, and it deliberately holds no other logic so
-// that removal stays a mechanical edit.
+// REMOVAL: this file is scaffolding with a planned end of life. Once a native
+// encoder has earned field confidence, delete its gate along with the branch
+// that reads it; the native path becomes unconditional and the FFmpeg branch
+// goes away with it. The call sites are, per gate:
+//
+//	AAC:  exportFormatNeedsFFmpeg and SaveAudioAction.encodeClip
+//	Opus: exportFormatNeedsFFmpeg and SaveAudioAction.encodeClip
+//	HLS:  the backend selection in internal/api/v2/audio
+//
+// Nothing else depends on this file, and it deliberately holds no other logic
+// so that each removal stays a mechanical edit.
 const (
 	// EnvNativeAACEncoder selects the native AAC encoder for .m4a clip export.
 	EnvNativeAACEncoder = "BIRDNET_AAC_ENCODER"
 	// EnvNativeOpusEncoder selects the native Opus encoder for .opus clip export.
 	EnvNativeOpusEncoder = "BIRDNET_OPUS_ENCODER"
+	// EnvNativeHLSEncoder selects the native encoder and muxer for HLS live
+	// streaming, replacing the FFmpeg process that would otherwise encode,
+	// segment and write the playlist for a live stream.
+	EnvNativeHLSEncoder = "BIRDNET_HLS_ENCODER"
 
 	// nativeEncoderValue is the only value that enables a native encoder.
 	// Anything else, including an unset variable, keeps the FFmpeg path.
@@ -45,6 +55,10 @@ func NativeAACEncoderEnabled() bool { return nativeEncoderSelected(EnvNativeAACE
 // NativeOpusEncoderEnabled reports whether Opus clip export should use the
 // native encoder.
 func NativeOpusEncoderEnabled() bool { return nativeEncoderSelected(EnvNativeOpusEncoder) }
+
+// NativeHLSEncoderEnabled reports whether HLS live streaming should use the
+// native encoder and muxer instead of spawning an FFmpeg process.
+func NativeHLSEncoderEnabled() bool { return nativeEncoderSelected(EnvNativeHLSEncoder) }
 
 // nativeEncoderSelected reads env and reports whether it opts into the native
 // encoder. Matching is case-insensitive and tolerates surrounding whitespace,

--- a/internal/conf/support_env.go
+++ b/internal/conf/support_env.go
@@ -39,6 +39,7 @@ import "slices"
 var supportEnvAllowlist = []string{
 	EnvNativeAACEncoder,
 	EnvNativeOpusEncoder,
+	EnvNativeHLSEncoder,
 	// Historical: no longer read by any code path, because native FLAC is now
 	// unconditional. Captured anyway, so a dump distinguishes "the operator set
 	// nothing" from "the operator set a variable that stopped doing anything",

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -440,6 +440,7 @@ func init() {
 	RegisterComponent("audiocore/engine", "audiocore.engine")
 	RegisterComponent("audiocore/schedule", "audiocore.schedule")
 	RegisterComponent("audiocore/equalizer", "audiocore.equalizer")
+	RegisterComponent("audiocore/hlsmux", "audiocore.hlsmux")
 }
 
 // Helper functions for auto-detection and categorization


### PR DESCRIPTION
## Summary

Adds `internal/audiocore/hlsmux`, the foundation for serving live HLS audio with no FFmpeg process in the path. It takes PCM and produces fragmented MP4 (CMAF) media segments plus the m3u8 that indexes them, entirely in memory: no filesystem, no subprocess, no HTTP. That purity is what makes the segment cutting, the timeline arithmetic and the playlist shape table-testable without a live audio source.

**Nothing constructs a `Stream` yet, so this changes no behaviour.** The concrete AAC codec and the wiring into the v2 HLS handler land together in a follow-up, behind the `BIRDNET_HLS_ENCODER` gate added here. Until then HLS live streaming runs entirely through FFmpeg and this package is unreachable from production code.

## Why this shape

**The codec is a parameter, not a hardcode.** A `Codec` value carries the encoder constructor and the container configuration, and its function fields are unexported, so a codec can only be defined inside the package. That makes codec-neutrality structural rather than a review promise, and the tests drive the muxer with variable frame sizes and zero priming delay, so a hardcoded 1024 or an assumption that priming is non-zero fails the suite rather than surviving until someone tries a second codec.

**Program-date-time is anchored to frame capture timestamps, not to the sample count.** A source that stalls and resumes produces no samples for the gap, so a sample-count timeline would report wall-clock times that never happened, permanently and silently. For a monitoring system that is a correctness problem rather than a playback nit. Divergence beyond a threshold cuts the segment, emits `EXT-X-DISCONTINUITY` and re-anchors; smaller divergence is absorbed as clock drift, because a commodity 100 ppm crystal would otherwise trip the threshold every few hours on a perfectly healthy stream. `Stats.DriftCorrection` exposes the accumulated absorption so that a source persistently delivering less audio than real time is diagnosable rather than invisible.

**Segment durations carry their remainder between conversions,** so consecutive `EXTINF` values sum to exactly the duration of their samples. The obvious `samples*time.Second/rate` loses the remainder on every segment and a live stream makes that call forever; computing from a running total instead would be exact but overflows int64 after about 53 hours at 48 kHz, which a live stream reaches.

**Segments are cut before they would exceed the target, never after reaching it.** RFC 8216 section 6.2.1 forbids `EXT-X-TARGETDURATION` from changing, and Apple's validator treats it as an absolute ceiling, so the advertised value is computed once from the configured segment length and the media always respects it.

**No `CODECS` attribute.** RFC 8216 places it on `EXT-X-STREAM-INF`, a master playlist tag; this is a media playlist and the system has no master playlist. Players learn the codec by probing the init segment named in `EXT-X-MAP`.

## Test plan

- [x] `go test -race` green, 40 tests, 95% statement coverage
- [x] `golangci-lint run` repo-wide 0 issues, with default tags and with CI's `--build-tags=integration,pebble_e2e,noembed,skipfrontend,normcompare`
- [x] Mutation-tested: reverting the discontinuity-sequence fix, the drift-free duration arithmetic, the stall detection, the cut-before-exceed rule, the canonical segment-name check, the access-unit bound, or either half of the cut-failure error propagation each turns the suite red
- [x] Discontinuity numbering verified exhaustively against RFC 8216 section 6.2.1 across all 256 break patterns over 8 segments, every window size 1 to 8, at every offset
- [x] Hot path confirmed allocation-free per audio frame by escape analysis

## Release notes
- audience: internal
- summary: Adds the in-memory HLS muxer that will replace the FFmpeg process for live streaming; no user-visible change yet, nothing constructs it.
- feature: FFmpeg-free HLS live streaming
- breaking: none
- config: none
- schema: none