### PR TITLE
fix(audio): stop dropping the partial PCM frame at a read boundary

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -250,14 +250,9 @@ func (p *AudioPipelineService) Start(_ context.Context) error {
 			logger.String("operation", "startup_audio_check"))
 	}
 
-	// Register watchdog reset callback so analysis monitors are recreated, and
-	// stale PCM alignment state is dropped, when the watchdog force-resets a
-	// stuck stream.
+	// Register watchdog reset callback so analysis monitors are recreated
+	// when the watchdog force-resets a stuck stream.
 	p.engine.FFmpegManager().SetOnStreamReset(func(newSourceID string) {
-		// A restarted stream begins a new byte stream on a sample boundary, so
-		// any partial sample the router still holds from the old one would
-		// shift every sample that follows it for the life of the route.
-		p.engine.Router().ResetAlignment(newSourceID)
 		if err := p.bufferMgr.AddMonitor(newSourceID); err != nil {
 			audiocore.GetLogger().Warn("failed to add monitor after watchdog stream reset",
 				logger.String("source_id", newSourceID),

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -250,9 +250,14 @@ func (p *AudioPipelineService) Start(_ context.Context) error {
 			logger.String("operation", "startup_audio_check"))
 	}
 
-	// Register watchdog reset callback so analysis monitors are recreated
-	// when the watchdog force-resets a stuck stream.
+	// Register watchdog reset callback so analysis monitors are recreated, and
+	// stale PCM alignment state is dropped, when the watchdog force-resets a
+	// stuck stream.
 	p.engine.FFmpegManager().SetOnStreamReset(func(newSourceID string) {
+		// A restarted stream begins a new byte stream on a sample boundary, so
+		// any partial sample the router still holds from the old one would
+		// shift every sample that follows it for the life of the route.
+		p.engine.Router().ResetAlignment(newSourceID)
 		if err := p.bufferMgr.AddMonitor(newSourceID); err != nil {
 			audiocore.GetLogger().Warn("failed to add monitor after watchdog stream reset",
 				logger.String("source_id", newSourceID),

--- a/internal/api/v2/audio/audio_hls_native.go
+++ b/internal/api/v2/audio/audio_hls_native.go
@@ -283,13 +283,15 @@ func (c *Handler) runNativeAudioFeedLoop(ctx context.Context, sourceID string, s
 		// carry holds the bytes of a partial sample frame left over from the
 		// previous chunk, and joined is the scratch buffer the join happens in.
 		//
-		// This is not defensive: the router only guarantees whole sample frames
-		// when it resamples or applies EQ/gain, and with the common default
-		// (source already at the pinned rate, no EQ, 0 dB gain) it does neither,
-		// so a partial read from an FFmpeg source arrives here as-is. Truncating
-		// the odd byte would be worse than useless, because the dropped half of a
-		// sample desynchronises every following byte and the audio becomes noise.
-		// Carrying it into the next chunk keeps the sample stream aligned.
+		// Since the PCM alignment fix in audiocore, the FFmpeg reader and the
+		// router both deliver whole samples on PCM16 routes, so for the in-tree
+		// producers this carry is a second line of defence rather than the
+		// primary fix. It stays because this loop must not depend on every
+		// current and future producer honouring that contract: truncating the
+		// odd byte would be worse than useless, because the dropped half of a
+		// sample desynchronises every following byte and the audio becomes
+		// noise. Carrying it into the next chunk keeps the sample stream
+		// aligned.
 		carry  []byte
 		joined []byte
 	)

--- a/internal/audiocore/ffmpeg/common.go
+++ b/internal/audiocore/ffmpeg/common.go
@@ -96,6 +96,24 @@ func ValidateSoxPath(soxPath string) error {
 	return nil
 }
 
+// pcmSampleBytes returns the size in bytes of one PCM sample in the output
+// format GetFFmpegFormat selects for the given bit depth: 16 maps to s16le,
+// 24 to s24le, 32 to s32le, and anything else falls back to s16le.
+//
+// This is the byte-size twin of GetFFmpegFormat's format switch. The two are
+// kept in agreement by TestPCMSampleBytesMatchesFFmpegFormat, which derives the
+// expected byte size from the format string itself, so adding a bit depth to
+// one without the other fails the build's tests rather than silently making
+// stream readers frame on the wrong unit.
+func pcmSampleBytes(bitDepth int) int {
+	switch bitDepth {
+	case 16, 24, 32:
+		return bitDepth / bitsPerByte
+	default:
+		return defaultPCMSampleBytes
+	}
+}
+
 // GetFFmpegFormat converts audio configuration values to FFmpeg-compatible format strings.
 // Returns sampleRateStr (e.g. "48000"), channelsStr (e.g. "1"), and formatStr (e.g. "s16le").
 // Supported bit depths: 16 → "s16le", 24 → "s24le", 32 → "s32le". Defaults to "s16le".

--- a/internal/audiocore/ffmpeg/process.go
+++ b/internal/audiocore/ffmpeg/process.go
@@ -552,6 +552,15 @@ func buildOutputArgs(args []string, cfg *StreamConfig) []string {
 	return args
 }
 
+// channelModeLeft and channelModeRight are the ChannelMode values that make
+// appendChannelArgs insert a pan filter and force mono output. They are shared
+// with effectiveOutputChannels so the frame-size derivation and the argument
+// builder cannot drift apart.
+const (
+	channelModeLeft  = "left"
+	channelModeRight = "right"
+)
+
 // appendChannelArgs appends the appropriate FFmpeg channel selection flags.
 // When channelMode is "left" or "right" and the source has >1 channel,
 // it uses a pan filter to extract the selected channel. Falls back to
@@ -559,13 +568,28 @@ func buildOutputArgs(args []string, cfg *StreamConfig) []string {
 func appendChannelArgs(args []string, channelMode string, sourceChannels int, numChannels string) []string {
 	if sourceChannels > 1 {
 		switch strings.ToLower(channelMode) {
-		case "left":
+		case channelModeLeft:
 			return append(args, "-af", "pan=mono|c0=c0", "-ac", "1")
-		case "right":
+		case channelModeRight:
 			return append(args, "-af", "pan=mono|c0=c1", "-ac", "1")
 		}
 	}
 	return append(args, "-ac", numChannels)
+}
+
+// effectiveOutputChannels returns the channel count of the PCM stream FFmpeg
+// actually emits for cfg. The left and right channel modes make
+// appendChannelArgs pan a multi-channel source down to mono regardless of
+// cfg.Channels, so readers of the output stream must use this, not the
+// configured count. Every other configuration emits cfg.Channels unchanged.
+func effectiveOutputChannels(cfg *StreamConfig) int {
+	if cfg.SourceChannels > 1 {
+		switch strings.ToLower(cfg.ChannelMode) {
+		case channelModeLeft, channelModeRight:
+			return 1
+		}
+	}
+	return cfg.Channels
 }
 
 // buildInputArgs constructs the pre-input FFmpeg flags (transport, timeout, extra parameters).

--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -25,6 +25,13 @@ const (
 	// Buffer size for reading FFmpeg stdout.
 	ffmpegBufferSize = 32768
 
+	// bitsPerByte converts a configured bit depth to a PCM sample size in bytes.
+	bitsPerByte = 8
+
+	// defaultPCMSampleBytes is the sample size for the s16le output format that
+	// buildOutputArgs falls back to for any bit depth other than 16, 24 or 32.
+	defaultPCMSampleBytes = 2
+
 	// Health check intervals and timeouts.
 	healthCheckInterval  = 5 * time.Second
 	silenceTimeout       = 90 * time.Second
@@ -1101,6 +1108,35 @@ func (s *Stream) processAudio() error {
 	}
 }
 
+// pcmFrameBytes returns the size in bytes of one interleaved PCM frame (one
+// sample for each channel) in the raw stream FFmpeg writes to stdout.
+//
+// It must track buildOutputArgs, which derives the output format from
+// cfg.BitDepth via GetFFmpegFormat: 16 -> s16le, 24 -> s24le, 32 -> s32le, and
+// s16le for anything else. Aligning on the whole interleaved frame rather than
+// on a single sample also keeps channel order stable, so a read that lands
+// between the left and right sample of a stereo pair does not swap the two
+// channels for the rest of the stream.
+//
+// The result is always at least 1, so callers can use it as a modulus.
+func pcmFrameBytes(cfg *StreamConfig) int {
+	sampleBytes := defaultPCMSampleBytes
+	switch cfg.BitDepth {
+	case 16, 24, 32:
+		sampleBytes = cfg.BitDepth / bitsPerByte
+	}
+
+	frameBytes := sampleBytes * max(cfg.Channels, 1)
+	if frameBytes > ffmpegBufferSize {
+		// A frame that cannot fit in a read buffer would stall the reader:
+		// every read would be a partial frame and nothing would ever be
+		// emitted. No real configuration reaches this, but falling back to
+		// byte alignment fails open rather than silently going mute.
+		return 1
+	}
+	return frameBytes
+}
+
 // readStdout is the body of the dedicated reader goroutine launched by
 // processAudio. When a buffer manager is wired it borrows a full-sized slice
 // from the size-specific BytePool and attaches a FrameRef whose release
@@ -1113,6 +1149,19 @@ func (s *Stream) processAudio() error {
 // sub-slice sent downstream, so the pool always sees a correctly sized buffer
 // on Put.
 func (s *Stream) readStdout(stdout io.ReadCloser, readCh chan<- readResult, readerDone <-chan struct{}) {
+	// A pipe read boundary is not a PCM frame boundary: stdout.Read returns
+	// whatever bytes happen to be available, so a read routinely ends part-way
+	// through a sample. Every downstream consumer reinterprets these bytes as
+	// samples, and a partial one cannot be handled locally by any of them:
+	// dropping the odd byte shifts every following byte by one, so each
+	// subsequent sample decodes with its halves swapped and the audio becomes
+	// broadband noise, while the resampler rejects the frame outright. So the
+	// remainder is held here and prepended to the next read, and only whole
+	// frames go downstream. carry and carryLen are local to this goroutine.
+	frameBytes := pcmFrameBytes(&s.config)
+	carry := make([]byte, frameBytes)
+	carryLen := 0
+
 	for {
 		var (
 			out []byte
@@ -1132,13 +1181,24 @@ func (s *Stream) readStdout(stdout io.ReadCloser, readCh chan<- readResult, read
 			out = make([]byte, ffmpegBufferSize)
 		}
 
-		n, err := stdout.Read(out)
-		if n > 0 {
-			// Shrink the slice to the actual read size; the underlying
-			// capacity is preserved and returned to the pool via the ref
-			// closure (which captures the full-length slice).
+		// Read behind the carry so the joined bytes are already contiguous:
+		// no second buffer and no copy of the payload itself.
+		copy(out, carry[:carryLen])
+		n, err := stdout.Read(out[carryLen:])
+		total := carryLen + n
+		carryLen = 0
+		if rem := total % frameBytes; rem != 0 {
+			// Copy before re-slicing: out is recycled on the next iteration.
+			carryLen = copy(carry, out[total-rem:total])
+			total -= rem
+		}
+
+		if total > 0 {
+			// Shrink the slice to the whole frames actually available; the
+			// underlying capacity is preserved and returned to the pool via
+			// the ref closure (which captures the full-length slice).
 			select {
-			case readCh <- readResult{data: out[:n], ref: ref}:
+			case readCh <- readResult{data: out[:total], ref: ref}:
 			case <-readerDone:
 				// Main loop exited before we could hand off: release the
 				// producer's own reference so the pool slice is not leaked.
@@ -1146,7 +1206,9 @@ func (s *Stream) readStdout(stdout io.ReadCloser, readCh chan<- readResult, read
 				return
 			}
 		} else {
-			// No bytes read: return the buffer to the pool immediately.
+			// Nothing whole to hand downstream, either because the read was
+			// empty or because it only advanced part of a frame. Return the
+			// buffer to the pool immediately; the bytes live on in carry.
 			ref.Release()
 		}
 		if err != nil {

--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -539,6 +539,12 @@ type Stream struct {
 	receivedAudio     atomic.Bool
 	audioOnlyFailures atomic.Int32
 
+	// partialFrameCarries counts reads that ended part-way through a PCM frame,
+	// forcing readStdout to hold the remainder for the next read. Diagnostic
+	// only: a partial read is normal pipe behaviour and self correcting, but the
+	// rate shows whether realignment is engaging and how often.
+	partialFrameCarries atomic.Int64
+
 	// Dropped data tracking.
 	lastDropLogTime time.Time
 	dropLogMu       sync.Mutex
@@ -1111,30 +1117,32 @@ func (s *Stream) processAudio() error {
 // pcmFrameBytes returns the size in bytes of one interleaved PCM frame (one
 // sample for each channel) in the raw stream FFmpeg writes to stdout.
 //
-// It must track buildOutputArgs, which derives the output format from
-// cfg.BitDepth via GetFFmpegFormat: 16 -> s16le, 24 -> s24le, 32 -> s32le, and
-// s16le for anything else. Aligning on the whole interleaved frame rather than
-// on a single sample also keeps channel order stable, so a read that lands
-// between the left and right sample of a stereo pair does not swap the two
-// channels for the rest of the stream.
+// The sample size follows pcmSampleBytes, the byte-size twin of the format
+// switch GetFFmpegFormat owns. The channel count follows
+// effectiveOutputChannels, which accounts for the left and right channel modes
+// where appendChannelArgs tells FFmpeg to fold a multi-channel source down to
+// mono. Aligning on the whole interleaved frame keeps each sample intact across
+// a read boundary, and for true multi-channel output keeps the channel order
+// stable as well, so a read landing between the left and right sample of a
+// stereo pair does not swap the two channels for the rest of the stream.
 //
-// The result is always at least 1, so callers can use it as a modulus.
+// The result is always at least 1 and never larger than ffmpegBufferSize, so
+// callers can use it as a modulus and size their carry from it.
 func pcmFrameBytes(cfg *StreamConfig) int {
-	sampleBytes := defaultPCMSampleBytes
-	switch cfg.BitDepth {
-	case 16, 24, 32:
-		sampleBytes = cfg.BitDepth / bitsPerByte
-	}
-
-	frameBytes := sampleBytes * max(cfg.Channels, 1)
-	if frameBytes > ffmpegBufferSize {
-		// A frame that cannot fit in a read buffer would stall the reader:
-		// every read would be a partial frame and nothing would ever be
-		// emitted. No real configuration reaches this, but falling back to
-		// byte alignment fails open rather than silently going mute.
+	sampleBytes := pcmSampleBytes(cfg.BitDepth)
+	channels := max(effectiveOutputChannels(cfg), 1)
+	// Bound the multiplicand, not the product, so the multiplication cannot
+	// overflow on a 32-bit build. A wrapped product would turn the modulus
+	// callers apply into a divide by zero, or a negative make size, and
+	// readStdout runs in a goroutine with no recover. The bound itself matters
+	// too: a frame larger than the read buffer could never be completed, the
+	// carry would fill the buffer, and every subsequent read would be handed a
+	// zero-length slice, spinning hot without ever emitting a byte. No real
+	// configuration reaches either case; byte alignment fails open.
+	if channels > ffmpegBufferSize/sampleBytes {
 		return 1
 	}
-	return frameBytes
+	return sampleBytes * channels
 }
 
 // readStdout is the body of the dedicated reader goroutine launched by
@@ -1145,9 +1153,9 @@ func pcmFrameBytes(cfg *StreamConfig) int {
 // cleanupProcess), on a read error, or when readerDone is closed (main loop
 // exited, preventing a goroutine leak).
 //
-// The release closure captures the FULL-capacity slice, not the n-byte
-// sub-slice sent downstream, so the pool always sees a correctly sized buffer
-// on Put.
+// The release closure captures the FULL-capacity slice, not the out[:total]
+// sub-slice of whole frames sent downstream, so the pool always sees a
+// correctly sized buffer on Put.
 func (s *Stream) readStdout(stdout io.ReadCloser, readCh chan<- readResult, readerDone <-chan struct{}) {
 	// A pipe read boundary is not a PCM frame boundary: stdout.Read returns
 	// whatever bytes happen to be available, so a read routinely ends part-way
@@ -1188,6 +1196,7 @@ func (s *Stream) readStdout(stdout io.ReadCloser, readCh chan<- readResult, read
 		total := carryLen + n
 		carryLen = 0
 		if rem := total % frameBytes; rem != 0 {
+			s.partialFrameCarries.Add(1)
 			// Copy before re-slicing: out is recycled on the next iteration.
 			carryLen = copy(carry, out[total-rem:total])
 			total -= rem
@@ -1879,6 +1888,7 @@ func (s *Stream) logStreamHealth() {
 			logger.Bool("is_healthy", health.IsHealthy),
 			logger.Bool("is_receiving_data", health.IsReceivingData),
 			logger.Int64("total_bytes_received", totalBytes),
+			logger.Int64("partial_frame_carries", s.partialFrameCarries.Load()),
 			logger.Float64("bytes_per_second", dataRate),
 			logger.Float64("last_data_ago_seconds", secondsSinceOrZero(health.LastDataReceived)),
 			logger.String("component", "ffmpeg-stream"),
@@ -1889,6 +1899,7 @@ func (s *Stream) logStreamHealth() {
 			logger.Bool("is_healthy", health.IsHealthy),
 			logger.Bool("is_receiving_data", health.IsReceivingData),
 			logger.Int64("total_bytes_received", totalBytes),
+			logger.Int64("partial_frame_carries", s.partialFrameCarries.Load()),
 			logger.Float64("last_data_ago_seconds", secondsSinceOrZero(health.LastDataReceived)),
 			logger.String("component", "ffmpeg-stream"),
 			logger.String("operation", "health_check"))

--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -1196,7 +1196,13 @@ func (s *Stream) readStdout(stdout io.ReadCloser, readCh chan<- readResult, read
 		total := carryLen + n
 		carryLen = 0
 		if rem := total % frameBytes; rem != 0 {
-			s.partialFrameCarries.Add(1)
+			if n > 0 {
+				// Count only reads that actually delivered bytes. A read
+				// returning nothing re-observes the remainder that the previous
+				// read already carried, so counting it again would double-count
+				// a single orphan at end of stream.
+				s.partialFrameCarries.Add(1)
+			}
 			// Copy before re-slicing: out is recycled on the next iteration.
 			carryLen = copy(carry, out[total-rem:total])
 			total -= rem
@@ -1307,7 +1313,11 @@ func (s *Stream) dispatchAudioData(data []byte, ref *audiocore.FrameRef) {
 
 	s.conditionalFailureReset(totalReceived)
 
-	// Invoke onFrame callback with a fully populated AudioFrame.
+	// Invoke onFrame callback with a fully populated AudioFrame. The channel
+	// count is the one FFmpeg was actually told to emit, not the configured one:
+	// the left and right channel modes fold a multi-channel source to mono, so
+	// reporting cfg.Channels would describe the payload wrongly. This is the
+	// same derivation readStdout frames on.
 	if s.onFrame != nil {
 		s.onFrame(audiocore.AudioFrame{
 			SourceID:   s.config.SourceID,
@@ -1315,7 +1325,7 @@ func (s *Stream) dispatchAudioData(data []byte, ref *audiocore.FrameRef) {
 			Data:       data,
 			SampleRate: s.config.SampleRate,
 			BitDepth:   s.config.BitDepth,
-			Channels:   s.config.Channels,
+			Channels:   effectiveOutputChannels(&s.config),
 			Timestamp:  time.Now(),
 			Ref:        ref,
 		})

--- a/internal/audiocore/ffmpeg/stream_pcm_align_test.go
+++ b/internal/audiocore/ffmpeg/stream_pcm_align_test.go
@@ -1,25 +1,53 @@
 package ffmpeg
 
 import (
+	"bytes"
+	"errors"
 	"io"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+	"github.com/tphakala/birdnet-go/internal/audiocore/buffer"
 )
+
+// errScriptedFailure is the non-EOF read failure used to check that a pending
+// carry is discarded rather than emitted when the stream breaks.
+var errScriptedFailure = errors.New("scripted read failure")
 
 // scriptedReader hands out a fixed byte stream in the read sizes given by
 // script, mimicking a pipe: stdout.Read returns whatever bytes happen to be
-// available, which is not necessarily a whole number of PCM samples.
+// available, which is not necessarily a whole number of PCM frames.
+//
+// failAtEnd makes the final call return errScriptedFailure instead of io.EOF, so
+// a test can drive the "read fails while a carry is pending" path.
 type scriptedReader struct {
-	data   []byte
-	script []int
-	off    int
-	step   int
+	data      []byte
+	script    []int
+	off       int
+	step      int
+	failAtEnd bool
+}
+
+// newScriptedReader validates the script before use. A zero or negative entry
+// would make Read return (0, nil) forever, hanging the test instead of failing
+// it, so it is rejected up front rather than left as a trap.
+func newScriptedReader(t *testing.T, data []byte, script []int) *scriptedReader {
+	t.Helper()
+	for i, n := range script {
+		require.Positive(t, n, "scripted read size %d must be positive", i)
+	}
+	return &scriptedReader{data: data, script: script}
 }
 
 func (s *scriptedReader) Read(p []byte) (int, error) {
 	if s.off >= len(s.data) {
+		if s.failAtEnd {
+			return 0, errScriptedFailure
+		}
 		return 0, io.EOF
 	}
 	n := len(s.data) - s.off
@@ -37,7 +65,7 @@ func (s *scriptedReader) Read(p []byte) (int, error) {
 
 func (s *scriptedReader) Close() error { return nil }
 
-// pcmRamp builds a PCM16 byte stream whose every byte is distinct from its
+// pcmRamp builds a PCM byte stream whose every byte is distinct from its
 // neighbours, so a one-byte shift in the framing cannot go unnoticed.
 func pcmRamp(sampleCount int) []byte {
 	data := make([]byte, sampleCount*2)
@@ -46,22 +74,65 @@ func pcmRamp(sampleCount int) []byte {
 		if i%2 == 1 {
 			v = -v
 		}
-		data[i*2] = byte(v)        //nolint:gosec // G115: intentional int16→byte truncation for PCM serialisation
-		data[i*2+1] = byte(v >> 8) //nolint:gosec // G115: intentional int16→byte truncation for PCM serialisation
+		data[i*2] = byte(v)        //nolint:gosec // G115: intentional int16 to byte truncation for PCM serialisation
+		data[i*2+1] = byte(v >> 8) //nolint:gosec // G115: intentional int16 to byte truncation for PCM serialisation
 	}
 	return data
+}
+
+// alignTestStream builds a Stream from the package's own test config, overriding
+// only the fields that determine the PCM frame size.
+func alignTestStream(t *testing.T, bitDepth, channels, sourceChannels int, channelMode string, bufMgr *buffer.Manager) *Stream {
+	t.Helper()
+	cfg := newTestConfig()
+	cfg.BitDepth = bitDepth
+	cfg.Channels = channels
+	cfg.SourceChannels = sourceChannels
+	cfg.ChannelMode = channelMode
+	return NewStream(&cfg, nil, nil, nil, bufMgr)
+}
+
+// collectFrames drains readCh until the reader reports an error, returning the
+// concatenated payload. Each receive is bounded: readStdout never closes readCh,
+// so an unbounded range would deadlock until the package timeout and take the
+// whole package down with a goroutine dump instead of a named failure.
+//
+// releaseRefs makes the collector return each pooled buffer immediately, which
+// lets the pool recycle it before the next read and so exercises the carry
+// against a reused slice.
+func collectFrames(t *testing.T, readCh <-chan readResult, frameBytes int, releaseRefs bool) ([]byte, error) {
+	t.Helper()
+	var got []byte
+	for {
+		select {
+		case res := <-readCh:
+			if res.err != nil {
+				return got, res.err
+			}
+			assert.Zero(t, len(res.data)%frameBytes,
+				"every frame handed downstream must hold whole PCM frames, got %d bytes for a %d-byte frame",
+				len(res.data), frameBytes)
+			got = append(got, res.data...)
+			if releaseRefs {
+				res.ref.Release()
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("readStdout produced no further result within 5s")
+			return got, nil
+		}
+	}
 }
 
 // TestReadStdout_EmitsWholeFrames verifies that the FFmpeg reader never hands a
 // partial PCM frame downstream, and never loses or reorders a byte doing so.
 //
 // A pipe read boundary is not a frame boundary, so a read that ends mid-frame is
-// normal. Every downstream consumer (the router's EQ/gain and resampling paths,
-// the sound level and audio level consumers, the analysis buffers) reinterprets
-// these bytes as samples, and none of them can recover locally: dropping the
-// remainder shifts every following byte, so each subsequent sample decodes with
-// its halves swapped and turns into noise, while the resampler rejects the frame
-// outright. Reassembly belongs at the producer.
+// normal. Every downstream consumer (the router's alignment, EQ, gain and
+// resampling paths, the sound level and audio level consumers, the analysis
+// buffers) reinterprets these bytes as samples, and none of them can recover
+// locally: dropping the remainder shifts every following byte, so each subsequent
+// sample decodes with its halves swapped and turns into noise, while the
+// resampler rejects the frame outright. Reassembly belongs at the producer.
 //
 // The cases cover every output format buildOutputArgs can select, because the
 // frame size is derived from the configured bit depth and channel count. Mono
@@ -71,16 +142,23 @@ func TestReadStdout_EmitsWholeFrames(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
-		name       string
-		bitDepth   int
-		channels   int
-		frameBytes int
+		name           string
+		bitDepth       int
+		channels       int
+		sourceChannels int
+		channelMode    string
+		frameBytes     int
 	}{
-		{"mono_s16le", 16, 1, 2},
-		{"stereo_s16le", 16, 2, 4},
-		{"mono_s24le", 24, 1, 3},
-		{"stereo_s32le", 32, 2, 8},
-		{"unsupported_depth_falls_back_to_s16le", 20, 1, 2},
+		{name: "mono_s16le", bitDepth: 16, channels: 1, frameBytes: 2},
+		// SourceChannels is left at zero so the pan path does not apply and
+		// FFmpeg really is told to emit two channels.
+		{name: "stereo_s16le", bitDepth: 16, channels: 2, frameBytes: 4},
+		{name: "mono_s24le", bitDepth: 24, channels: 1, frameBytes: 3},
+		{name: "stereo_s32le", bitDepth: 32, channels: 2, frameBytes: 8},
+		{name: "unsupported_depth_falls_back_to_s16le", bitDepth: 20, channels: 1, frameBytes: 2},
+		// The pan filter folds a multi-channel source to mono regardless of the
+		// configured channel count, so the real frame is one sample wide.
+		{name: "left_channel_mode_emits_mono", bitDepth: 16, channels: 2, sourceChannels: 2, channelMode: "left", frameBytes: 2},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -93,16 +171,7 @@ func TestReadStdout_EmitsWholeFrames(t *testing.T) {
 			// carry at EOF and the comparison can be exact.
 			signal := pcmRamp(4096 * tc.frameBytes / 2)
 
-			s := NewStream(&StreamConfig{
-				URL:        "rtsp://example.invalid/stream",
-				SourceID:   "align-src",
-				SourceName: "align",
-				Type:       "rtsp",
-				SampleRate: 48000,
-				BitDepth:   tc.bitDepth,
-				Channels:   tc.channels,
-			}, nil, nil, nil, nil)
-
+			s := alignTestStream(t, tc.bitDepth, tc.channels, tc.sourceChannels, tc.channelMode, nil)
 			require.Equal(t, tc.frameBytes, pcmFrameBytes(&s.config),
 				"frame size must follow the output format buildOutputArgs selects")
 
@@ -110,24 +179,43 @@ func TestReadStdout_EmitsWholeFrames(t *testing.T) {
 			readerDone := make(chan struct{})
 			t.Cleanup(func() { close(readerDone) })
 
-			go s.readStdout(&scriptedReader{data: signal, script: script}, readCh, readerDone)
+			reader := newScriptedReader(t, signal, script)
+			go s.readStdout(reader, readCh, readerDone)
 
-			var got []byte
-			for res := range readCh {
-				if res.err != nil {
-					require.ErrorIs(t, res.err, io.EOF, "the scripted reader only ends with EOF")
-					break
-				}
-				assert.Zero(t, len(res.data)%tc.frameBytes,
-					"every frame handed downstream must hold whole PCM frames, got %d bytes for a %d-byte frame",
-					len(res.data), tc.frameBytes)
-				got = append(got, res.data...)
-			}
-
+			got, err := collectFrames(t, readCh, tc.frameBytes, false)
+			require.ErrorIs(t, err, io.EOF, "the scripted reader only ends with EOF")
 			assert.Equal(t, signal, got,
 				"the reassembled stream must match the source byte for byte; a mismatch means a byte was dropped or reordered")
+			assert.Positive(t, s.partialFrameCarries.Load(), "this script must exercise the carry")
 		})
 	}
+}
+
+// TestReadStdout_PooledCarrySurvivesBufferRecycling drives the carry against a
+// live buffer pool, with every frame released as soon as it is collected so the
+// pool hands the same slice back on the next read. That is the interaction the
+// producer's carry copy exists for: the remainder must be copied out of the read
+// buffer before that buffer is recycled. Without a pool the read buffer is a
+// fresh allocation each time and a carry-copied-after-handoff regression would go
+// unnoticed.
+func TestReadStdout_PooledCarrySurvivesBufferRecycling(t *testing.T) {
+	t.Parallel()
+
+	signal := pcmRamp(4096)
+	s := alignTestStream(t, 16, 1, 0, "", buffer.NewManager(audiocore.GetLogger()))
+
+	readCh := make(chan readResult, 1)
+	readerDone := make(chan struct{})
+	t.Cleanup(func() { close(readerDone) })
+
+	reader := newScriptedReader(t, signal, []int{1001, 999, 3, 1, 2047, 4095})
+	go s.readStdout(reader, readCh, readerDone)
+
+	got, err := collectFrames(t, readCh, 2, true)
+	require.ErrorIs(t, err, io.EOF)
+	assert.Equal(t, signal, got,
+		"the reassembled stream must survive the read buffer being recycled between reads")
+	assert.Positive(t, s.partialFrameCarries.Load(), "this script must exercise the carry")
 }
 
 // TestReadStdout_DropsOnlyTheFinalPartialFrame verifies the one case where bytes
@@ -137,31 +225,201 @@ func TestReadStdout_DropsOnlyTheFinalPartialFrame(t *testing.T) {
 	t.Parallel()
 
 	signal := append(pcmRamp(512), 0x7f) // odd total: the last byte has no pair
-
-	s := NewStream(&StreamConfig{
-		URL:        "rtsp://example.invalid/stream",
-		SourceID:   "align-src",
-		SourceName: "align",
-		Type:       "rtsp",
-		SampleRate: 48000,
-		BitDepth:   16,
-		Channels:   1,
-	}, nil, nil, nil, nil)
+	s := alignTestStream(t, 16, 1, 0, "", nil)
 
 	readCh := make(chan readResult, 64)
 	readerDone := make(chan struct{})
 	t.Cleanup(func() { close(readerDone) })
 
-	go s.readStdout(&scriptedReader{data: signal, script: []int{255, 513}}, readCh, readerDone)
+	reader := newScriptedReader(t, signal, []int{255, 513})
+	go s.readStdout(reader, readCh, readerDone)
 
-	var got []byte
-	for res := range readCh {
-		if res.err != nil {
-			break
-		}
-		got = append(got, res.data...)
-	}
-
+	got, err := collectFrames(t, readCh, 2, false)
+	require.ErrorIs(t, err, io.EOF)
 	assert.Equal(t, signal[:len(signal)-1], got,
 		"everything but the unpaired trailing byte must be emitted")
+}
+
+// TestReadStdout_PendingCarryDroppedOnReadError checks that a read failure while
+// a partial frame is pending forwards the error and does not emit the orphaned
+// bytes as if they were a frame.
+func TestReadStdout_PendingCarryDroppedOnReadError(t *testing.T) {
+	t.Parallel()
+
+	signal := append(pcmRamp(256), 0x7f) // ends mid-frame
+	s := alignTestStream(t, 16, 1, 0, "", nil)
+
+	reader := newScriptedReader(t, signal, []int{513})
+	reader.failAtEnd = true
+
+	readCh := make(chan readResult, 64)
+	readerDone := make(chan struct{})
+	t.Cleanup(func() { close(readerDone) })
+
+	go s.readStdout(reader, readCh, readerDone)
+
+	got, err := collectFrames(t, readCh, 2, false)
+	require.ErrorIs(t, err, errScriptedFailure, "the read error must be forwarded")
+	assert.Equal(t, signal[:len(signal)-1], got,
+		"the pending partial frame must not be emitted when the stream fails")
+}
+
+// TestPCMFrameBytes_Bounds pins the frame-size derivation at its edges. The
+// oversize and huge-channel-count rows matter because the ceiling is applied to
+// the multiplicand: applying it to the product instead would let a 32-bit build
+// wrap to zero and divide by zero in readStdout.
+func TestPCMFrameBytes_Bounds(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		bitDepth int
+		channels int
+		want     int
+	}{
+		{name: "mono_16", bitDepth: 16, channels: 1, want: 2},
+		{name: "mono_24", bitDepth: 24, channels: 1, want: 3},
+		{name: "stereo_32", bitDepth: 32, channels: 2, want: 8},
+		{name: "zero_channels_treated_as_mono", bitDepth: 16, channels: 0, want: 2},
+		{name: "negative_channels_treated_as_mono", bitDepth: 16, channels: -3, want: 2},
+		{name: "frame_larger_than_read_buffer_falls_back", bitDepth: 32, channels: 20000, want: 1},
+		{name: "channel_count_that_would_overflow_falls_back", bitDepth: 16, channels: 1 << 30, want: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := newTestConfig()
+			cfg.BitDepth = tc.bitDepth
+			cfg.Channels = tc.channels
+			got := pcmFrameBytes(&cfg)
+			assert.Equal(t, tc.want, got)
+			assert.Positive(t, got, "the result must always be usable as a modulus")
+			assert.LessOrEqual(t, got, ffmpegBufferSize, "a frame must fit in the read buffer")
+		})
+	}
+}
+
+// TestPCMSampleBytesMatchesFFmpegFormat pins the byte-size helper to the format
+// string GetFFmpegFormat emits, so adding a bit depth to one without the other
+// fails here instead of silently making stream readers frame on the wrong unit.
+func TestPCMSampleBytesMatchesFFmpegFormat(t *testing.T) {
+	t.Parallel()
+
+	for _, bitDepth := range []int{0, 8, 16, 20, 24, 32, 64} {
+		t.Run(strconv.Itoa(bitDepth), func(t *testing.T) {
+			t.Parallel()
+			_, _, format := GetFFmpegFormat(48000, 1, bitDepth)
+			// Formats are named sNNle where NN is the bit count.
+			require.Regexp(t, `^s\d+le$`, format)
+			bits, err := strconv.Atoi(format[1 : len(format)-2])
+			require.NoError(t, err)
+			assert.Equal(t, bits/8, pcmSampleBytes(bitDepth),
+				"sample size must match the %q format GetFFmpegFormat selects", format)
+		})
+	}
+}
+
+// TestPCMFrameBytes_MatchesFFmpegArgs pins the frame size to the channel count
+// FFmpeg is actually told to emit. appendChannelArgs overrides the configured
+// count with mono whenever the pan filter is used, so deriving the frame size
+// from cfg.Channels alone would overstate it for those configurations.
+func TestPCMFrameBytes_MatchesFFmpegArgs(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name           string
+		bitDepth       int
+		channels       int
+		sourceChannels int
+		channelMode    string
+	}{
+		{name: "mono_downmix", bitDepth: 16, channels: 1, sourceChannels: 1, channelMode: "downmix"},
+		{name: "stereo_empty_mode", bitDepth: 16, channels: 2, sourceChannels: 2, channelMode: ""},
+		{name: "stereo_left", bitDepth: 16, channels: 2, sourceChannels: 2, channelMode: "left"},
+		{name: "stereo_right", bitDepth: 16, channels: 2, sourceChannels: 2, channelMode: "right"},
+		{name: "stereo_left_mono_source", bitDepth: 16, channels: 2, sourceChannels: 1, channelMode: "left"},
+		{name: "s24_stereo_right", bitDepth: 24, channels: 2, sourceChannels: 4, channelMode: "RIGHT"},
+		{name: "s32_quad_downmix", bitDepth: 32, channels: 4, sourceChannels: 4, channelMode: "downmix"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := newTestConfig()
+			cfg.BitDepth = tc.bitDepth
+			cfg.Channels = tc.channels
+			cfg.SourceChannels = tc.sourceChannels
+			cfg.ChannelMode = tc.channelMode
+
+			args := appendChannelArgs(nil, cfg.ChannelMode, cfg.SourceChannels, strconv.Itoa(cfg.Channels))
+			acValue := 0
+			for i, a := range args {
+				if a == "-ac" && i+1 < len(args) {
+					v, err := strconv.Atoi(args[i+1])
+					require.NoError(t, err)
+					acValue = v
+				}
+			}
+			require.Positive(t, acValue, "appendChannelArgs must always emit an -ac value")
+
+			assert.Equal(t, pcmSampleBytes(tc.bitDepth)*acValue, pcmFrameBytes(&cfg),
+				"the frame size must match the channel count FFmpeg is told to emit")
+		})
+	}
+}
+
+// FuzzReadStdoutFraming asserts the framer's total invariants over arbitrary read
+// sizes, which the hand-picked scripts above cannot cover: every frame handed
+// downstream holds whole PCM frames, and the concatenated output is exactly the
+// input truncated to a whole number of frames, with nothing reordered.
+func FuzzReadStdoutFraming(f *testing.F) {
+	f.Add(pcmRamp(200), []byte{99, 1, 200, 3}, uint8(0))
+	f.Add(pcmRamp(64), []byte{1}, uint8(3))
+	f.Add([]byte{1, 2, 3}, []byte{2}, uint8(1))
+
+	formats := []struct{ bitDepth, channels int }{
+		{16, 1}, {16, 2}, {24, 1}, {32, 2},
+	}
+
+	f.Fuzz(func(t *testing.T, payload, sizes []byte, format uint8) {
+		fm := formats[int(format)%len(formats)]
+		cfg := newTestConfig()
+		cfg.BitDepth = fm.bitDepth
+		cfg.Channels = fm.channels
+		s := NewStream(&cfg, nil, nil, nil, nil)
+		frameBytes := pcmFrameBytes(&cfg)
+
+		script := make([]int, 0, len(sizes))
+		for _, b := range sizes {
+			if b > 0 {
+				script = append(script, int(b))
+			}
+		}
+
+		readCh := make(chan readResult, 64)
+		readerDone := make(chan struct{})
+		defer close(readerDone)
+
+		go s.readStdout(&scriptedReader{data: payload, script: script}, readCh, readerDone)
+
+		var got []byte
+		for done := false; !done; {
+			select {
+			case res := <-readCh:
+				if res.err != nil {
+					done = true
+					break
+				}
+				require.Zero(t, len(res.data)%frameBytes, "every emitted chunk must hold whole frames")
+				got = append(got, res.data...)
+			case <-time.After(10 * time.Second):
+				t.Fatal("readStdout stalled")
+			}
+		}
+
+		want := payload[:len(payload)-len(payload)%frameBytes]
+		// bytes.Equal rather than require.Equal: an all-truncated payload leaves
+		// got nil and want an empty slice, which are equal here but not to
+		// reflect.DeepEqual.
+		require.Truef(t, bytes.Equal(want, got),
+			"the reassembled stream must equal the input truncated to whole frames (want %d bytes, got %d)",
+			len(want), len(got))
+	})
 }

--- a/internal/audiocore/ffmpeg/stream_pcm_align_test.go
+++ b/internal/audiocore/ffmpeg/stream_pcm_align_test.go
@@ -1,0 +1,167 @@
+package ffmpeg
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// scriptedReader hands out a fixed byte stream in the read sizes given by
+// script, mimicking a pipe: stdout.Read returns whatever bytes happen to be
+// available, which is not necessarily a whole number of PCM samples.
+type scriptedReader struct {
+	data   []byte
+	script []int
+	off    int
+	step   int
+}
+
+func (s *scriptedReader) Read(p []byte) (int, error) {
+	if s.off >= len(s.data) {
+		return 0, io.EOF
+	}
+	n := len(s.data) - s.off
+	if s.step < len(s.script) && s.script[s.step] < n {
+		n = s.script[s.step]
+	}
+	if n > len(p) {
+		n = len(p)
+	}
+	s.step++
+	copied := copy(p, s.data[s.off:s.off+n])
+	s.off += copied
+	return copied, nil
+}
+
+func (s *scriptedReader) Close() error { return nil }
+
+// pcmRamp builds a PCM16 byte stream whose every byte is distinct from its
+// neighbours, so a one-byte shift in the framing cannot go unnoticed.
+func pcmRamp(sampleCount int) []byte {
+	data := make([]byte, sampleCount*2)
+	for i := range sampleCount {
+		v := int16((i*2731)%40000 - 20000) //nolint:gosec // G115: intentional wrap for a synthetic test signal
+		if i%2 == 1 {
+			v = -v
+		}
+		data[i*2] = byte(v)        //nolint:gosec // G115: intentional int16→byte truncation for PCM serialisation
+		data[i*2+1] = byte(v >> 8) //nolint:gosec // G115: intentional int16→byte truncation for PCM serialisation
+	}
+	return data
+}
+
+// TestReadStdout_EmitsWholeFrames verifies that the FFmpeg reader never hands a
+// partial PCM frame downstream, and never loses or reorders a byte doing so.
+//
+// A pipe read boundary is not a frame boundary, so a read that ends mid-frame is
+// normal. Every downstream consumer (the router's EQ/gain and resampling paths,
+// the sound level and audio level consumers, the analysis buffers) reinterprets
+// these bytes as samples, and none of them can recover locally: dropping the
+// remainder shifts every following byte, so each subsequent sample decodes with
+// its halves swapped and turns into noise, while the resampler rejects the frame
+// outright. Reassembly belongs at the producer.
+//
+// The cases cover every output format buildOutputArgs can select, because the
+// frame size is derived from the configured bit depth and channel count. Mono
+// PCM16 alone would pass even if the derivation were wrong, since its frame size
+// happens to equal a single sample.
+func TestReadStdout_EmitsWholeFrames(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name       string
+		bitDepth   int
+		channels   int
+		frameBytes int
+	}{
+		{"mono_s16le", 16, 1, 2},
+		{"stereo_s16le", 16, 2, 4},
+		{"mono_s24le", 24, 1, 3},
+		{"stereo_s32le", 32, 2, 8},
+		{"unsupported_depth_falls_back_to_s16le", 20, 1, 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Read sizes are deliberately coprime with the frame sizes under
+			// test, so a read lands mid-frame repeatedly and the carry is
+			// exercised on consecutive reads.
+			script := []int{1001, 999, 3, 1, 2047, 4095}
+			// A whole number of frames in total, so nothing is left in the
+			// carry at EOF and the comparison can be exact.
+			signal := pcmRamp(4096 * tc.frameBytes / 2)
+
+			s := NewStream(&StreamConfig{
+				URL:        "rtsp://example.invalid/stream",
+				SourceID:   "align-src",
+				SourceName: "align",
+				Type:       "rtsp",
+				SampleRate: 48000,
+				BitDepth:   tc.bitDepth,
+				Channels:   tc.channels,
+			}, nil, nil, nil, nil)
+
+			require.Equal(t, tc.frameBytes, pcmFrameBytes(&s.config),
+				"frame size must follow the output format buildOutputArgs selects")
+
+			readCh := make(chan readResult, 64)
+			readerDone := make(chan struct{})
+			t.Cleanup(func() { close(readerDone) })
+
+			go s.readStdout(&scriptedReader{data: signal, script: script}, readCh, readerDone)
+
+			var got []byte
+			for res := range readCh {
+				if res.err != nil {
+					require.ErrorIs(t, res.err, io.EOF, "the scripted reader only ends with EOF")
+					break
+				}
+				assert.Zero(t, len(res.data)%tc.frameBytes,
+					"every frame handed downstream must hold whole PCM frames, got %d bytes for a %d-byte frame",
+					len(res.data), tc.frameBytes)
+				got = append(got, res.data...)
+			}
+
+			assert.Equal(t, signal, got,
+				"the reassembled stream must match the source byte for byte; a mismatch means a byte was dropped or reordered")
+		})
+	}
+}
+
+// TestReadStdout_DropsOnlyTheFinalPartialFrame verifies the one case where bytes
+// legitimately do not come out: a stream that ends mid-frame has nothing left to
+// complete it with, so the remainder is discarded at EOF rather than held forever.
+func TestReadStdout_DropsOnlyTheFinalPartialFrame(t *testing.T) {
+	t.Parallel()
+
+	signal := append(pcmRamp(512), 0x7f) // odd total: the last byte has no pair
+
+	s := NewStream(&StreamConfig{
+		URL:        "rtsp://example.invalid/stream",
+		SourceID:   "align-src",
+		SourceName: "align",
+		Type:       "rtsp",
+		SampleRate: 48000,
+		BitDepth:   16,
+		Channels:   1,
+	}, nil, nil, nil, nil)
+
+	readCh := make(chan readResult, 64)
+	readerDone := make(chan struct{})
+	t.Cleanup(func() { close(readerDone) })
+
+	go s.readStdout(&scriptedReader{data: signal, script: []int{255, 513}}, readCh, readerDone)
+
+	var got []byte
+	for res := range readCh {
+		if res.err != nil {
+			break
+		}
+		got = append(got, res.data...)
+	}
+
+	assert.Equal(t, signal[:len(signal)-1], got,
+		"everything but the unpaired trailing byte must be emitted")
+}

--- a/internal/audiocore/ffmpeg/stream_pcm_align_test.go
+++ b/internal/audiocore/ffmpeg/stream_pcm_align_test.go
@@ -192,19 +192,23 @@ func TestReadStdout_EmitsWholeFrames(t *testing.T) {
 }
 
 // TestReadStdout_PooledCarrySurvivesBufferRecycling drives the carry against a
-// live buffer pool, with every frame released as soon as it is collected so the
-// pool hands the same slice back on the next read. That is the interaction the
-// producer's carry copy exists for: the remainder must be copied out of the read
-// buffer before that buffer is recycled. Without a pool the read buffer is a
-// fresh allocation each time and a carry-copied-after-handoff regression would go
-// unnoticed.
+// live buffer pool, releasing each frame as soon as it is collected so the pool
+// can hand the same slice back on the next read. Without a pool the read buffer
+// is a fresh allocation every iteration, so the pooled path is otherwise only
+// covered by a test that reads four aligned bytes and never carries anything.
+//
+// The channel is unbuffered so the reader cannot borrow the next buffer until
+// this collector has taken the previous frame, and the pool's hit count is
+// asserted afterwards: recycling is the premise of the test, so a run where it
+// never happened must fail rather than pass vacuously.
 func TestReadStdout_PooledCarrySurvivesBufferRecycling(t *testing.T) {
 	t.Parallel()
 
 	signal := pcmRamp(4096)
-	s := alignTestStream(t, 16, 1, 0, "", buffer.NewManager(audiocore.GetLogger()))
+	mgr := buffer.NewManager(audiocore.GetLogger())
+	s := alignTestStream(t, 16, 1, 0, "", mgr)
 
-	readCh := make(chan readResult, 1)
+	readCh := make(chan readResult)
 	readerDone := make(chan struct{})
 	t.Cleanup(func() { close(readerDone) })
 
@@ -216,6 +220,8 @@ func TestReadStdout_PooledCarrySurvivesBufferRecycling(t *testing.T) {
 	assert.Equal(t, signal, got,
 		"the reassembled stream must survive the read buffer being recycled between reads")
 	assert.Positive(t, s.partialFrameCarries.Load(), "this script must exercise the carry")
+	assert.Positive(t, mgr.BytePoolFor(ffmpegBufferSize).GetStats().Hits,
+		"the pool must actually have recycled a buffer, otherwise this test proves nothing about recycling")
 }
 
 // TestReadStdout_DropsOnlyTheFinalPartialFrame verifies the one case where bytes
@@ -262,6 +268,11 @@ func TestReadStdout_PendingCarryDroppedOnReadError(t *testing.T) {
 	require.ErrorIs(t, err, errScriptedFailure, "the read error must be forwarded")
 	assert.Equal(t, signal[:len(signal)-1], got,
 		"the pending partial frame must not be emitted when the stream fails")
+	// Exactly one: the single read that delivered the orphan byte. The failing
+	// read that follows delivers nothing new, so counting it again would report
+	// two carries for one orphan and overstate the rate in the health log.
+	assert.Equal(t, int64(1), s.partialFrameCarries.Load(),
+		"one orphaned byte must be counted once, not once per read that observes it")
 }
 
 // TestPCMFrameBytes_Bounds pins the frame-size derivation at its edges. The

--- a/internal/audiocore/ffmpeg/stream_test.go
+++ b/internal/audiocore/ffmpeg/stream_test.go
@@ -1457,7 +1457,10 @@ func TestProcessAudio_ResponsiveToRestart(t *testing.T) {
 func TestProcessAudio_DataFlowsThroughReaderGoroutine(t *testing.T) {
 	t.Parallel()
 
-	testData := []byte("audio-payload-12345")
+	// An even byte count: readStdout emits whole PCM frames only and holds a
+	// trailing partial frame back for the next read, so an odd payload would
+	// arrive one byte short here. See TestReadStdout_EmitsWholeFrames.
+	testData := []byte("audio-payload-123456")
 	var received []byte
 
 	cfg := newTestConfig()
@@ -1808,7 +1811,10 @@ func TestStream_ReadStdout_AttachesRefWhenPooled(t *testing.T) {
 	cfg := newTestConfig()
 	stream := NewStream(&cfg, nil, nil, nil, bufMgr)
 
-	reader := io.NopCloser(bytes.NewReader([]byte{1, 2, 3}))
+	// A whole number of PCM frames: readStdout holds a trailing partial frame
+	// back for the next read, so an odd payload would arrive short here for
+	// reasons unrelated to what this test is about. See TestReadStdout_EmitsWholeFrames.
+	reader := io.NopCloser(bytes.NewReader([]byte{1, 2, 3, 4}))
 	readCh := make(chan readResult, 1)
 	readerDone := make(chan struct{})
 	t.Cleanup(func() { close(readerDone) })
@@ -1819,7 +1825,7 @@ func TestStream_ReadStdout_AttachesRefWhenPooled(t *testing.T) {
 	case result := <-readCh:
 		require.NoError(t, result.err)
 		require.NotNil(t, result.ref, "pooled readStdout must attach a FrameRef to every readResult")
-		assert.Equal(t, []byte{1, 2, 3}, result.data)
+		assert.Equal(t, []byte{1, 2, 3, 4}, result.data)
 		result.ref.Release()
 	case <-time.After(time.Second):
 		t.Fatal("readStdout did not produce a readResult within 1s")
@@ -1835,7 +1841,8 @@ func TestStream_ReadStdout_NilRefWhenNoBufMgr(t *testing.T) {
 	cfg := newTestConfig()
 	stream := NewStream(&cfg, nil, nil, nil, nil)
 
-	reader := io.NopCloser(bytes.NewReader([]byte{1, 2, 3}))
+	// Whole PCM frames, for the same reason as the pooled test above.
+	reader := io.NopCloser(bytes.NewReader([]byte{1, 2, 3, 4}))
 	readCh := make(chan readResult, 1)
 	readerDone := make(chan struct{})
 	t.Cleanup(func() { close(readerDone) })
@@ -1846,7 +1853,7 @@ func TestStream_ReadStdout_NilRefWhenNoBufMgr(t *testing.T) {
 	case result := <-readCh:
 		require.NoError(t, result.err)
 		assert.Nil(t, result.ref, "non-pooled readStdout must dispatch nil ref")
-		assert.Equal(t, []byte{1, 2, 3}, result.data)
+		assert.Equal(t, []byte{1, 2, 3, 4}, result.data)
 	case <-time.After(time.Second):
 		t.Fatal("readStdout did not produce a readResult within 1s")
 	}

--- a/internal/audiocore/router.go
+++ b/internal/audiocore/router.go
@@ -32,13 +32,23 @@ const (
 	// errorLogInterval controls how often consumer write errors are logged.
 	errorLogInterval = 100
 
+	// realignmentLogInterval controls how often the router reports that it
+	// started carrying a partial PCM16 sample between frames. It counts
+	// carrying runs, not frames: realignment is normal and self correcting, so
+	// errorLogInterval is reserved for genuine failures.
+	realignmentLogInterval = 100
+
 	// dropSentryThreshold is the total number of drops per route before
 	// a single Sentry report is fired. This fires once; the log.Warn at
 	// dropLogInterval provides ongoing visibility.
 	dropSentryThreshold int64 = 1000
 
-	// bitDepthPCM16 is the only bit depth the router's resampling and
-	// EQ/gain paths can interpret; other depths are passed through untouched.
+	// bitDepthPCM16 is the only bit depth the router's alignment, EQ and gain
+	// paths interpret; frames with other depths skip those stages untouched.
+	// The resampler is the exception: it assumes PCM16 by contract regardless
+	// of the frame's declared bit depth, so a resampling route fed non-PCM16
+	// data rejects odd-length frames loudly and garbles the rest. Do not
+	// configure a resampler on a non-PCM16 route.
 	bitDepthPCM16 = 16
 
 	// bytesPerPCM16Sample is the size of one 16-bit PCM sample. Frames handed
@@ -87,10 +97,13 @@ type Route struct {
 	// sustained-write-errors Sentry threshold separately from resampler errors.
 	writeErrors atomic.Int64
 
-	// realignments counts odd-length PCM16 frames observed on this route.
-	// Kept separate from errors so RouteInfo.Errors retains its "real error"
-	// semantics for operators; an upstream that splits samples across reads
-	// is not an error, it does not inflate that metric.
+	// realignments counts the times a partial trailing PCM16 sample was carried
+	// out of a frame on this route. It is not a per-odd-frame count: a frame
+	// that consumes a pending carry and ends on a sample boundary realigns the
+	// stream without incrementing it. Kept separate from errors so
+	// RouteInfo.Errors retains its "real error" semantics for operators; an
+	// upstream that splits samples across reads is not an error, it does not
+	// inflate that metric.
 	realignments atomic.Int64
 
 	// carry holds the bytes of a PCM16 sample that the previous frame ended
@@ -101,6 +114,20 @@ type Route struct {
 	carry    [bytesPerPCM16Sample - 1]byte
 	carryLen int
 	alignBuf []byte
+
+	// carryResetPending asks the drainer goroutine to drop any partial sample
+	// held in carry before it processes its next frame. Set from outside the
+	// drainer by ResetAlignment; carry and carryLen themselves stay
+	// single-goroutine, this flag is the only cross-goroutine signal.
+	carryResetPending atomic.Bool
+
+	// realignmentRuns counts how many times this route entered a carrying run,
+	// i.e. held a partial sample when it previously held none. Realignment
+	// latches: once a run starts, an even-length producer keeps re-arming the
+	// carry on every frame, so realignments grows per frame while this grows
+	// once per episode. Logging is gated on this so a latched route reports the
+	// transition instead of repeating itself forever.
+	realignmentRuns atomic.Int64
 
 	// done is closed to signal the drainer goroutine to exit.
 	done chan struct{}
@@ -138,6 +165,12 @@ type RouteInfo struct {
 
 	// Errors is the total number of Write errors for this route.
 	Errors int64
+
+	// Realignments is the total number of partial PCM16 samples carried between
+	// frames on this route. Not an error count: realignment is normal and self
+	// correcting, but a nonzero value shows a producer is splitting samples
+	// across frames.
+	Realignments int64
 
 	// QueueDepth is the current occupancy of the route inbox (len of the bounded channel).
 	QueueDepth int
@@ -436,11 +469,12 @@ func (r *AudioRouter) Routes(sourceID string) []RouteInfo {
 	infos := make([]RouteInfo, 0, len(routes))
 	for _, rt := range routes {
 		infos = append(infos, RouteInfo{
-			SourceID:   rt.SourceID,
-			ConsumerID: rt.Consumer.ID(),
-			Drops:      rt.drops.Load(),
-			Errors:     rt.errors.Load(),
-			QueueDepth: len(rt.inbox),
+			SourceID:     rt.SourceID,
+			ConsumerID:   rt.Consumer.ID(),
+			Drops:        rt.drops.Load(),
+			Errors:       rt.errors.Load(),
+			Realignments: rt.realignments.Load(),
+			QueueDepth:   len(rt.inbox),
 		})
 	}
 	return infos
@@ -463,6 +497,24 @@ func (r *AudioRouter) LastDispatchTime(sourceID string) time.Time {
 func (r *AudioRouter) ResetDispatchTime(sourceID string) {
 	ts := r.getOrCreateDispatchTimestamp(sourceID)
 	ts.Store(time.Now().UnixNano())
+}
+
+// ResetAlignment requests that every route on the given source drop any partial
+// PCM16 sample held in its alignment carry. Call it when the source's byte
+// stream restarts (an FFmpeg process restart or a watchdog force reset): the new
+// stream starts on a sample boundary, so a byte held over from the old stream
+// would shift every sample that follows it, for the life of the route.
+//
+// The reset is applied by each route's drainer goroutine before its next frame,
+// so any frames already queued when this is called consume the reset first. That
+// is acceptable because the carry is second-line defence: the in-tree PCM16
+// producers deliver whole samples, so the carry is normally empty anyway.
+func (r *AudioRouter) ResetAlignment(sourceID string) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, rt := range r.routes[sourceID] {
+		rt.carryResetPending.Store(true)
+	}
 }
 
 // ClearDispatchTime removes the dispatch timestamp for sourceID.
@@ -699,18 +751,19 @@ func drainInboxRefs(inbox <-chan AudioFrame) {
 // writes it to the route's consumer. It is called from drainRoute's select loop
 // and is extracted to keep drainRoute under the cognitive-complexity limit.
 //
-// Pool discipline (three release sites, seven scenarios):
-//   - Resample buffer: allocated before resampling, returned after Write (or on
-//     error). When processing follows, the resample buffer is returned before
-//     frame.Data is reassigned so the wrong (processed) slice is never put back
-//     to the resample pool; resamplePool is nilled so the trailing guard is a
-//     no-op.
-//   - Processing float64 scratch and output byte buffers: allocated inside
-//     applyProcessing, bundled in procResult. procResult.release() is called
-//     unconditionally in the trailing guards; it is a no-op on a zero-value
-//     result (processing never ran or errored with internal cleanup).
-//   - procResult.OutPool and resamplePool cannot both be non-nil at the trailing
-//     guards by construction, so their Put calls are mutually exclusive.
+// Pool discipline (two release sites, one common exit):
+//   - The function-level defer is the single common release point. It runs
+//     procResult.release(), a no-op on a zero-value result, and returns the
+//     resample buffer while resamplePool is still non-nil. Being deferred, it
+//     also runs when Consumer.Write panics; drainRoute's recover would otherwise
+//     strand both buffers in the panicking frame.
+//   - The processing branch is the one early release: it returns the resample
+//     buffer before frame.Data is reassigned to the processing output, so the
+//     wrong (processed) slice is never put back to the resample pool, and nils
+//     resamplePool so the deferred release cannot return it a second time.
+//   - applyProcessing releases its own float64 scratch and output buffers
+//     internally on error and returns a zero-value result, so the deferred
+//     procResult.release() stays a no-op on that path.
 func (r *AudioRouter) handleRouteFrame(frame AudioFrame, route *Route) { //nolint:gocritic // hugeParam: AudioFrame is large but copying is intentional
 	// Balance the Retain performed by Dispatch for this route. Runs even if
 	// consumer.Write panics (drainRoute's recover catches the panic).
@@ -719,15 +772,29 @@ func (r *AudioRouter) handleRouteFrame(frame AudioFrame, route *Route) { //nolin
 	frameStart := time.Now()
 	var resampleDur, processingDur time.Duration
 
-	// Resampling and EQ/gain both reinterpret Data as a stream of 16-bit
-	// samples, so both need whole samples. Align once here, ahead of the first
-	// of them, and carry any partial sample into the next frame. A pass-through
-	// route is left untouched: it hands the producer's bytes to the consumer
-	// without interpreting them. The resampler assumes PCM16 by contract
-	// regardless of the frame's declared bit depth, so its presence alone
-	// requires the alignment.
+	// A stream discontinuity makes a held partial sample meaningless: the next
+	// frame starts a new byte stream on a sample boundary, and prepending a
+	// stale byte to it would shift every subsequent sample for the life of the
+	// route. The flag is consumed here, on the drainer goroutine, so carryLen
+	// keeps its single-goroutine discipline.
+	if route.carryResetPending.Load() {
+		route.carryResetPending.Store(false)
+		route.carryLen = 0
+	}
+
+	// Resampling, EQ and gain all reinterpret Data as a stream of 16-bit
+	// samples, and so does every consumer of a PCM16 route, so every PCM16
+	// frame is aligned to whole samples here regardless of what this route
+	// does with it afterwards; any partial sample is carried into the next
+	// frame. Aligning only the routes that resample or process would leave the
+	// analysis consumers, which read a pass-through route, enforcing the
+	// invariant nowhere. Non-PCM16 frames are left untouched: a 2-byte carry
+	// would regroup their frame boundaries and permanently withhold a trailing
+	// byte at stream end. The resampler assumes PCM16 by contract, so a
+	// resampling route fed another depth now fails loudly in ResampleTo
+	// instead of being silently realigned on the wrong unit.
 	chain := route.filterChain.Load()
-	if route.resampler != nil || (frame.BitDepth == bitDepthPCM16 && (chain != nil || route.gainLinear != 1.0)) {
+	if frame.BitDepth == bitDepthPCM16 {
 		frame.Data = r.alignPCM16(frame.Data, route)
 		if len(frame.Data) == 0 {
 			// Every byte of this frame is now held in the carry (or the frame
@@ -744,6 +811,24 @@ func (r *AudioRouter) handleRouteFrame(frame AudioFrame, route *Route) { //nolin
 
 	var resampleBuf []byte // full-length pooled buffer for Put; nil when no resampling
 
+	// Release the router's own pooled buffers on every exit from this function,
+	// including a panicking Consumer.Write. drainRoute recovers that panic above
+	// this frame, so a release at the tail would be skipped and the buffers
+	// would never return to their pools. Releasing during the unwind is safe for
+	// the same reason it is safe on the normal path: AudioConsumer.Write forbids
+	// retaining frame.Data past return, so a consumer that aborted mid-Write
+	// holds no reference either.
+	//
+	// No path can Put twice: the processing branch returns resampleBuf early and
+	// nils resamplePool when it takes ownership, and procResult.release is a
+	// no-op on a zero value.
+	defer func() {
+		procResult.release()
+		if resamplePool != nil {
+			resamplePool.Put(resampleBuf)
+		}
+	}()
+
 	// Apply per-route resampling when rates differ.
 	if route.resampler != nil {
 		resampleStart := time.Now()
@@ -756,9 +841,7 @@ func (r *AudioRouter) handleRouteFrame(frame AudioFrame, route *Route) { //nolin
 		}
 		n, err := route.resampler.ResampleTo(frame.Data, resampleBuf)
 		if err != nil {
-			if resamplePool != nil {
-				resamplePool.Put(resampleBuf)
-			}
+			// The deferred release returns resampleBuf to its pool.
 			errCount := route.errors.Add(1)
 			if errCount%errorLogInterval == 1 {
 				r.log.Warn("resampler error",
@@ -786,15 +869,13 @@ func (r *AudioRouter) handleRouteFrame(frame AudioFrame, route *Route) { //nolin
 		procStart := time.Now()
 		result, err := r.applyProcessing(frame, route, chain)
 		if err != nil {
-			// applyProcessing already released its own pool buffers on error.
-			// Release the resample buffer.
-			if resamplePool != nil {
-				resamplePool.Put(resampleBuf)
-			}
+			// applyProcessing already released its own pool buffers on error;
+			// the deferred release returns the resample buffer.
 			return
 		}
 		// Release the resample buffer BEFORE frame.Data is reassigned to the
-		// processing output. Nil out the pointer so the trailing guard is a no-op.
+		// processing output. Nil out the pointer so the deferred release cannot
+		// return it a second time.
 		if resamplePool != nil {
 			resamplePool.Put(resampleBuf)
 			resamplePool = nil
@@ -831,17 +912,6 @@ func (r *AudioRouter) handleRouteFrame(frame AudioFrame, route *Route) { //nolin
 	}
 	writeDur := time.Since(writeStart)
 
-	// Release processing buffers (output byte slice and float64 scratch).
-	// Safe to call unconditionally: no-op when procResult is zero value.
-	// All in-tree consumers copy synchronously, so recycling is safe here.
-	procResult.release()
-	// Release resample buffer when processing did NOT run (processing branch
-	// nilled resamplePool before reassigning frame.Data). When processing ran,
-	// resamplePool is nil here and this is a no-op.
-	if resamplePool != nil {
-		resamplePool.Put(resampleBuf)
-	}
-
 	route.stats.record(resampleDur, processingDur, writeDur, time.Since(frameStart))
 	route.stats.checkAndLog(r.log, route.SourceID, route.Consumer.ID())
 }
@@ -856,8 +926,12 @@ func (r *AudioRouter) handleRouteFrame(frame AudioFrame, route *Route) { //nolin
 // broadband noise until the framing happens to realign. Carrying the byte forward
 // keeps the sample stream intact.
 //
-// Odd lengths are not an upstream bug. internal/audiocore/ffmpeg reads its source
-// from a pipe, and a pipe read returns whatever bytes happen to be available.
+// The in-tree producers no longer deliver odd lengths themselves: the FFmpeg
+// reader reassembles whole frames before dispatch, and the malgo capture path
+// emits whole 16-bit samples by construction. The carry here is the router's own
+// enforcement of the whole-sample invariant, one hop before the consumers, so it
+// holds for every producer, present or future, and keeps a producer-side
+// regression from turning into corrupted audio downstream.
 //
 // The returned slice aliases either data or route.alignBuf. Both stay valid for
 // the rest of the frame's journey through handleRouteFrame, which reads them into
@@ -871,6 +945,11 @@ func (r *AudioRouter) alignPCM16(data []byte, route *Route) []byte {
 	}
 
 	frameBytes := len(data)
+	// Whether this frame starts a new carrying run. Realignment latches: once a
+	// run starts, joining the carry makes an even-length frame odd again, so
+	// every following frame re-arms the carry. Logging per frame would then
+	// repeat forever, so only the transition into a run is reported.
+	startsRun := route.carryLen == 0
 
 	if route.carryLen > 0 {
 		route.alignBuf = append(route.alignBuf[:0], route.carry[:route.carryLen]...)
@@ -890,12 +969,17 @@ func (r *AudioRouter) alignPCM16(data []byte, route *Route) []byte {
 	data = data[:len(data)-rem]
 
 	count := route.realignments.Add(1)
-	if count%errorLogInterval == 1 {
-		r.log.Info("odd-length PCM16 frame realigned",
+	if !startsRun {
+		return data
+	}
+	runs := route.realignmentRuns.Add(1)
+	if runs%realignmentLogInterval == 1 {
+		r.log.Info("partial PCM16 sample carried to next frame",
 			logger.String("source_id", route.SourceID),
 			logger.String("consumer_id", route.Consumer.ID()),
 			logger.Int("frame_bytes", frameBytes),
-			logger.Int64("total_realignments", count))
+			logger.Int64("total_realignments", count),
+			logger.Int64("realignment_runs", runs))
 	}
 	return data
 }
@@ -936,11 +1020,14 @@ func (p *processingResult) release() {
 // make() with no corresponding Put, preserving legacy behaviour for unit tests
 // that construct routers with a nil Manager.
 func (r *AudioRouter) applyProcessing(frame AudioFrame, route *Route, chain *equalizer.FilterChain) (processingResult, error) { //nolint:gocritic // hugeParam: AudioFrame is large but copying is intentional
-	// frame.Data holds a whole number of samples: handleRouteFrame runs it
-	// through alignPCM16 first, which carries any partial sample into the next
-	// frame. The floor below is a bounds guard for callers that build a frame by
-	// hand (the benchmarks in this package), not a truncation policy. Dropping a
-	// byte mid-stream desynchronises every sample that follows it.
+	// frame.Data holds a whole number of samples: handleRouteFrame aligns every
+	// PCM16 frame before either processing stage runs, and only PCM16 frames
+	// reach this function, so the align gate covers a strict superset of the
+	// frames seen here. The floor below is a bounds guard for callers that build
+	// a frame by hand (the tests and benchmarks in this package), not a
+	// truncation policy. Dropping a byte mid-stream desynchronises every sample
+	// that follows it, so narrowing the align gate in handleRouteFrame below
+	// this function's own gate would silently reintroduce that truncation.
 	evenLen := len(frame.Data) &^ (bytesPerPCM16Sample - 1)
 	sampleCount := evenLen / bytesPerPCM16Sample
 

--- a/internal/audiocore/router.go
+++ b/internal/audiocore/router.go
@@ -47,8 +47,10 @@ const (
 	// paths interpret; frames with other depths skip those stages untouched.
 	// The resampler is the exception: it assumes PCM16 by contract regardless
 	// of the frame's declared bit depth, so a resampling route fed non-PCM16
-	// data rejects odd-length frames loudly and garbles the rest. Do not
-	// configure a resampler on a non-PCM16 route.
+	// data rejects odd-length frames loudly and garbles the rest. AddRoute
+	// builds the resampler purely from a rate mismatch, so nothing currently
+	// prevents that pairing; it is unreachable only because both source
+	// construction sites hardcode 16-bit.
 	bitDepthPCM16 = 16
 
 	// bytesPerPCM16Sample is the size of one 16-bit PCM sample. Frames handed
@@ -111,15 +113,20 @@ type Route struct {
 	// alignBuf is the scratch buffer the carry is joined with the next frame
 	// in. All three are touched only by this route's drainer goroutine, via
 	// alignPCM16, so they need no synchronisation.
+	//
+	// Known limitation: the carry is not cleared at a stream discontinuity. A
+	// Route outlives an FFmpeg process restart, so a producer that ends one
+	// stream generation mid-sample would have that byte prepended to the first
+	// frame of the next. Clearing it correctly needs a marker travelling in
+	// band with the frames, because an out-of-band signal is consumed by
+	// whichever frame the drainer happens to dequeue next, which is still an
+	// old-stream frame while the inbox is draining. No in-tree producer can
+	// reach this: readStdout reassembles whole frames and its own carry is
+	// goroutine-local, so it resets per process, and the malgo path emits whole
+	// samples by construction.
 	carry    [bytesPerPCM16Sample - 1]byte
 	carryLen int
 	alignBuf []byte
-
-	// carryResetPending asks the drainer goroutine to drop any partial sample
-	// held in carry before it processes its next frame. Set from outside the
-	// drainer by ResetAlignment; carry and carryLen themselves stay
-	// single-goroutine, this flag is the only cross-goroutine signal.
-	carryResetPending atomic.Bool
 
 	// realignmentRuns counts how many times this route entered a carrying run,
 	// i.e. held a partial sample when it previously held none. Realignment
@@ -163,14 +170,9 @@ type RouteInfo struct {
 	// Drops is the total number of frames dropped for this route.
 	Drops int64
 
-	// Errors is the total number of Write errors for this route.
+	// Errors is the total number of processing failures for this route,
+	// counting resampler, conversion and Consumer.Write failures alike.
 	Errors int64
-
-	// Realignments is the total number of partial PCM16 samples carried between
-	// frames on this route. Not an error count: realignment is normal and self
-	// correcting, but a nonzero value shows a producer is splitting samples
-	// across frames.
-	Realignments int64
 
 	// QueueDepth is the current occupancy of the route inbox (len of the bounded channel).
 	QueueDepth int
@@ -469,12 +471,11 @@ func (r *AudioRouter) Routes(sourceID string) []RouteInfo {
 	infos := make([]RouteInfo, 0, len(routes))
 	for _, rt := range routes {
 		infos = append(infos, RouteInfo{
-			SourceID:     rt.SourceID,
-			ConsumerID:   rt.Consumer.ID(),
-			Drops:        rt.drops.Load(),
-			Errors:       rt.errors.Load(),
-			Realignments: rt.realignments.Load(),
-			QueueDepth:   len(rt.inbox),
+			SourceID:   rt.SourceID,
+			ConsumerID: rt.Consumer.ID(),
+			Drops:      rt.drops.Load(),
+			Errors:     rt.errors.Load(),
+			QueueDepth: len(rt.inbox),
 		})
 	}
 	return infos
@@ -497,24 +498,6 @@ func (r *AudioRouter) LastDispatchTime(sourceID string) time.Time {
 func (r *AudioRouter) ResetDispatchTime(sourceID string) {
 	ts := r.getOrCreateDispatchTimestamp(sourceID)
 	ts.Store(time.Now().UnixNano())
-}
-
-// ResetAlignment requests that every route on the given source drop any partial
-// PCM16 sample held in its alignment carry. Call it when the source's byte
-// stream restarts (an FFmpeg process restart or a watchdog force reset): the new
-// stream starts on a sample boundary, so a byte held over from the old stream
-// would shift every sample that follows it, for the life of the route.
-//
-// The reset is applied by each route's drainer goroutine before its next frame,
-// so any frames already queued when this is called consume the reset first. That
-// is acceptable because the carry is second-line defence: the in-tree PCM16
-// producers deliver whole samples, so the carry is normally empty anyway.
-func (r *AudioRouter) ResetAlignment(sourceID string) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	for _, rt := range r.routes[sourceID] {
-		rt.carryResetPending.Store(true)
-	}
 }
 
 // ClearDispatchTime removes the dispatch timestamp for sourceID.
@@ -772,16 +755,6 @@ func (r *AudioRouter) handleRouteFrame(frame AudioFrame, route *Route) { //nolin
 	frameStart := time.Now()
 	var resampleDur, processingDur time.Duration
 
-	// A stream discontinuity makes a held partial sample meaningless: the next
-	// frame starts a new byte stream on a sample boundary, and prepending a
-	// stale byte to it would shift every subsequent sample for the life of the
-	// route. The flag is consumed here, on the drainer goroutine, so carryLen
-	// keeps its single-goroutine discipline.
-	if route.carryResetPending.Load() {
-		route.carryResetPending.Store(false)
-		route.carryLen = 0
-	}
-
 	// Resampling, EQ and gain all reinterpret Data as a stream of 16-bit
 	// samples, and so does every consumer of a PCM16 route, so every PCM16
 	// frame is aligned to whole samples here regardless of what this route
@@ -811,13 +784,14 @@ func (r *AudioRouter) handleRouteFrame(frame AudioFrame, route *Route) { //nolin
 
 	var resampleBuf []byte // full-length pooled buffer for Put; nil when no resampling
 
-	// Release the router's own pooled buffers on every exit from this function,
-	// including a panicking Consumer.Write. drainRoute recovers that panic above
-	// this frame, so a release at the tail would be skipped and the buffers
-	// would never return to their pools. Releasing during the unwind is safe for
-	// the same reason it is safe on the normal path: AudioConsumer.Write forbids
-	// retaining frame.Data past return, so a consumer that aborted mid-Write
-	// holds no reference either.
+	// Release the router's own pooled buffers on every exit from this function.
+	// A single deferred release keeps the accounting in one place, and it also
+	// covers a panicking Consumer.Write, where a release at the tail would be
+	// skipped. That leak was bounded rather than unbounded, since drainRoute's
+	// recover retires the route, but the buffers are cheap to return correctly.
+	// Releasing during the unwind is safe for the same reason it is safe on the
+	// normal path: AudioConsumer.Write forbids retaining frame.Data past return,
+	// and Go runs the consumer's own defers before this one.
 	//
 	// No path can Put twice: the processing branch returns resampleBuf early and
 	// nils resamplePool when it takes ownership, and procResult.release is a
@@ -933,9 +907,13 @@ func (r *AudioRouter) handleRouteFrame(frame AudioFrame, route *Route) { //nolin
 // holds for every producer, present or future, and keeps a producer-side
 // regression from turning into corrupted audio downstream.
 //
-// The returned slice aliases either data or route.alignBuf. Both stay valid for
-// the rest of the frame's journey through handleRouteFrame, which reads them into
-// a separate output buffer before handing anything to the consumer.
+// The returned slice aliases either data or route.alignBuf, and route.alignBuf is
+// overwritten by the next frame on this route. That is safe for the same reason
+// the producer's pooled slice is: AudioConsumer.Write forbids retaining
+// frame.Data past return, and the next overwrite happens on this same goroutine,
+// after Write has returned. A pass-through route hands alignBuf to the consumer
+// directly, so the no-retain contract, not an intervening copy, is what makes
+// this sound.
 //
 // Called only from the route's drainer goroutine, so route.carry, route.carryLen
 // and route.alignBuf are unsynchronised by design.

--- a/internal/audiocore/router.go
+++ b/internal/audiocore/router.go
@@ -36,6 +36,14 @@ const (
 	// a single Sentry report is fired. This fires once; the log.Warn at
 	// dropLogInterval provides ongoing visibility.
 	dropSentryThreshold int64 = 1000
+
+	// bitDepthPCM16 is the only bit depth the router's resampling and
+	// EQ/gain paths can interpret; other depths are passed through untouched.
+	bitDepthPCM16 = 16
+
+	// bytesPerPCM16Sample is the size of one 16-bit PCM sample. Frames handed
+	// to the resampler or to applyProcessing must hold a whole multiple of it.
+	bytesPerPCM16Sample = 2
 )
 
 // drainerStopTimeout is the maximum time to wait for a drainer goroutine
@@ -79,11 +87,20 @@ type Route struct {
 	// sustained-write-errors Sentry threshold separately from resampler errors.
 	writeErrors atomic.Int64
 
-	// truncations counts odd-length PCM16 frames observed on this route.
+	// realignments counts odd-length PCM16 frames observed on this route.
 	// Kept separate from errors so RouteInfo.Errors retains its "real error"
-	// semantics for operators; a misbehaving upstream does not inflate that
-	// metric.
-	truncations atomic.Int64
+	// semantics for operators; an upstream that splits samples across reads
+	// is not an error, it does not inflate that metric.
+	realignments atomic.Int64
+
+	// carry holds the bytes of a PCM16 sample that the previous frame ended
+	// part-way through, and carryLen is how many of them are valid (0 or 1).
+	// alignBuf is the scratch buffer the carry is joined with the next frame
+	// in. All three are touched only by this route's drainer goroutine, via
+	// alignPCM16, so they need no synchronisation.
+	carry    [bytesPerPCM16Sample - 1]byte
+	carryLen int
+	alignBuf []byte
 
 	// done is closed to signal the drainer goroutine to exit.
 	done chan struct{}
@@ -702,6 +719,23 @@ func (r *AudioRouter) handleRouteFrame(frame AudioFrame, route *Route) { //nolin
 	frameStart := time.Now()
 	var resampleDur, processingDur time.Duration
 
+	// Resampling and EQ/gain both reinterpret Data as a stream of 16-bit
+	// samples, so both need whole samples. Align once here, ahead of the first
+	// of them, and carry any partial sample into the next frame. A pass-through
+	// route is left untouched: it hands the producer's bytes to the consumer
+	// without interpreting them. The resampler assumes PCM16 by contract
+	// regardless of the frame's declared bit depth, so its presence alone
+	// requires the alignment.
+	chain := route.filterChain.Load()
+	if route.resampler != nil || (frame.BitDepth == bitDepthPCM16 && (chain != nil || route.gainLinear != 1.0)) {
+		frame.Data = r.alignPCM16(frame.Data, route)
+		if len(frame.Data) == 0 {
+			// Every byte of this frame is now held in the carry (or the frame
+			// was empty to begin with); there is nothing to hand downstream.
+			return
+		}
+	}
+
 	var resamplePool *buffer.BytePool // nil when not pooled
 
 	// procResult holds the processing output and pool handles. Zero value is
@@ -748,8 +782,7 @@ func (r *AudioRouter) handleRouteFrame(frame AudioFrame, route *Route) { //nolin
 	}
 	// Apply per-route EQ filtering and/or gain adjustment.
 	// Both require 16-bit PCM; skip for other formats.
-	chain := route.filterChain.Load()
-	if frame.BitDepth == 16 && (chain != nil || route.gainLinear != 1.0) {
+	if frame.BitDepth == bitDepthPCM16 && (chain != nil || route.gainLinear != 1.0) {
 		procStart := time.Now()
 		result, err := r.applyProcessing(frame, route, chain)
 		if err != nil {
@@ -813,6 +846,60 @@ func (r *AudioRouter) handleRouteFrame(frame AudioFrame, route *Route) { //nolin
 	route.stats.checkAndLog(r.log, route.SourceID, route.Consumer.ID())
 }
 
+// alignPCM16 returns data trimmed to a whole number of 16-bit samples, with any
+// partial sample left over from the previous frame prepended and any new partial
+// sample retained in route.carry for the next frame.
+//
+// The trailing byte of an odd-length frame is half a sample. Discarding it does
+// not merely shorten the audio: it shifts every following byte by one, so each
+// subsequent sample decodes with its halves swapped and the stream turns into
+// broadband noise until the framing happens to realign. Carrying the byte forward
+// keeps the sample stream intact.
+//
+// Odd lengths are not an upstream bug. internal/audiocore/ffmpeg reads its source
+// from a pipe, and a pipe read returns whatever bytes happen to be available.
+//
+// The returned slice aliases either data or route.alignBuf. Both stay valid for
+// the rest of the frame's journey through handleRouteFrame, which reads them into
+// a separate output buffer before handing anything to the consumer.
+//
+// Called only from the route's drainer goroutine, so route.carry, route.carryLen
+// and route.alignBuf are unsynchronised by design.
+func (r *AudioRouter) alignPCM16(data []byte, route *Route) []byte {
+	if route.carryLen == 0 && len(data)%bytesPerPCM16Sample == 0 {
+		return data
+	}
+
+	frameBytes := len(data)
+
+	if route.carryLen > 0 {
+		route.alignBuf = append(route.alignBuf[:0], route.carry[:route.carryLen]...)
+		route.alignBuf = append(route.alignBuf, data...)
+		data = route.alignBuf
+		route.carryLen = 0
+	}
+
+	rem := len(data) % bytesPerPCM16Sample
+	if rem == 0 {
+		return data
+	}
+
+	// Copy into the fixed-size array before re-slicing: the source may be
+	// route.alignBuf, which the next call overwrites.
+	route.carryLen = copy(route.carry[:], data[len(data)-rem:])
+	data = data[:len(data)-rem]
+
+	count := route.realignments.Add(1)
+	if count%errorLogInterval == 1 {
+		r.log.Info("odd-length PCM16 frame realigned",
+			logger.String("source_id", route.SourceID),
+			logger.String("consumer_id", route.Consumer.ID()),
+			logger.Int("frame_bytes", frameBytes),
+			logger.Int64("total_realignments", count))
+	}
+	return data
+}
+
 // processingResult carries an EQ / gain processed frame plus the pooled
 // buffers that must be returned to their pools after the consumer has
 // synchronously observed the frame. A zero-value result (all pools nil)
@@ -849,21 +936,13 @@ func (p *processingResult) release() {
 // make() with no corresponding Put, preserving legacy behaviour for unit tests
 // that construct routers with a nil Manager.
 func (r *AudioRouter) applyProcessing(frame AudioFrame, route *Route, chain *equalizer.FilterChain) (processingResult, error) { //nolint:gocritic // hugeParam: AudioFrame is large but copying is intentional
-	evenLen := len(frame.Data) &^ 1
-	if evenLen != len(frame.Data) {
-		// Separate counter: this is a diagnostic for upstream producer bugs,
-		// not a true local error. Keeping it out of route.errors preserves the
-		// meaning of RouteInfo.Errors for operators.
-		truncCount := route.truncations.Add(1)
-		if truncCount%errorLogInterval == 1 {
-			r.log.Info("odd-length PCM16 frame truncated",
-				logger.String("source_id", route.SourceID),
-				logger.String("consumer_id", route.Consumer.ID()),
-				logger.Int("frame_bytes", len(frame.Data)),
-				logger.Int64("total_truncations", truncCount))
-		}
-	}
-	sampleCount := evenLen / 2
+	// frame.Data holds a whole number of samples: handleRouteFrame runs it
+	// through alignPCM16 first, which carries any partial sample into the next
+	// frame. The floor below is a bounds guard for callers that build a frame by
+	// hand (the benchmarks in this package), not a truncation policy. Dropping a
+	// byte mid-stream desynchronises every sample that follows it.
+	evenLen := len(frame.Data) &^ (bytesPerPCM16Sample - 1)
+	sampleCount := evenLen / bytesPerPCM16Sample
 
 	floatPool := r.cachedFloat64Pool(&route.float64Pool, &route.float64PoolLen, sampleCount)
 	var floatBuf []float64

--- a/internal/audiocore/router.go
+++ b/internal/audiocore/router.go
@@ -46,11 +46,17 @@ const (
 	// bitDepthPCM16 is the only bit depth the router's alignment, EQ and gain
 	// paths interpret; frames with other depths skip those stages untouched.
 	// The resampler is the exception: it assumes PCM16 by contract regardless
-	// of the frame's declared bit depth, so a resampling route fed non-PCM16
-	// data rejects odd-length frames loudly and garbles the rest. AddRoute
-	// builds the resampler purely from a rate mismatch, so nothing currently
-	// prevents that pairing; it is unreachable only because both source
-	// construction sites hardcode 16-bit.
+	// of the frame's declared bit depth, so a resampling route fed another
+	// depth rejects odd-length frames loudly and garbles the rest. Nothing
+	// gates that pairing, because AddRoute derives the resampler from a rate
+	// mismatch alone.
+	//
+	// It does not bite today because bit depth is not a user setting: there is
+	// no conf field for it, and the paths that build a source pass
+	// conf.BitDepth, which is 16. The engine forwards whatever it is given,
+	// substituting the default only for a non-positive value, so it does not
+	// normalise a wrong value either. A non-16 source would therefore reach
+	// FFmpeg's output format selection, this gate, and the resampler at once.
 	bitDepthPCM16 = 16
 
 	// bytesPerPCM16Sample is the size of one 16-bit PCM sample. Frames handed

--- a/internal/audiocore/router_pcm_align_test.go
+++ b/internal/audiocore/router_pcm_align_test.go
@@ -2,11 +2,15 @@ package audiocore
 
 import (
 	"bytes"
+	"runtime/debug"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/audiocore/buffer"
 	"github.com/tphakala/birdnet-go/internal/audiocore/resample"
+	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
 // collectingConsumer accumulates every byte handed to Write so a test can
@@ -103,7 +107,7 @@ func runChunksThroughRoute(t *testing.T, chunks [][]byte, opts alignRunOpts) ali
 	t.Cleanup(r.Close)
 
 	consumer := newCollectingConsumer(opts.dstRate)
-	route := newAlignTestRoute(t, r, consumer, opts)
+	route := newAlignTestRoute(t, consumer, opts)
 
 	for _, chunk := range chunks {
 		r.handleRouteFrame(AudioFrame{
@@ -126,9 +130,8 @@ func runChunksThroughRoute(t *testing.T, chunks [][]byte, opts alignRunOpts) ali
 
 // newAlignTestRoute builds a Route wired to consumer, adding a resampler only
 // when the rates differ (mirroring what AddRoute does).
-func newAlignTestRoute(t *testing.T, r *AudioRouter, consumer AudioConsumer, opts alignRunOpts) *Route {
+func newAlignTestRoute(t *testing.T, consumer AudioConsumer, opts alignRunOpts) *Route {
 	t.Helper()
-	_ = r
 	route := &Route{
 		SourceID:         "align-src",
 		Consumer:         consumer,
@@ -237,34 +240,63 @@ func TestRouter_PassThroughPCM16RealignsOddFrames(t *testing.T) {
 		"a pass-through route must reassemble the same sample stream from odd-length frames")
 }
 
-// TestRouter_NonPCM16PassThroughIsUntouched pins the other half of the gate. A
-// 2-byte carry applied to a stream that is not 16-bit PCM would regroup its frame
+// TestRouter_NonPCM16IsNeverRealigned pins the narrow half of the gate. A 2-byte
+// carry applied to a stream that is not 16-bit PCM would regroup its frame
 // boundaries and permanently withhold a trailing byte at stream end, so frames
-// declaring another bit depth must pass through byte for byte.
-func TestRouter_NonPCM16PassThroughIsUntouched(t *testing.T) {
+// declaring another bit depth must never enter the carry.
+//
+// The resampling case is the one that discriminates: the previous gate aligned
+// any route that had a resampler, regardless of bit depth, so 8-bit data was
+// silently realigned on a unit that does not describe it and then resampled as
+// if it were 16-bit. Now the resampler rejects the odd frame instead, which is a
+// visible failure rather than mislabelled noise.
+func TestRouter_NonPCM16IsNeverRealigned(t *testing.T) {
 	t.Parallel()
 
 	const rate = 48000
-	sizes := []int{999, 1001, 997, 1003}
 	signal := alignTestSignal(2000)
-	chunks := splitAt(t, signal, sizes)
+	chunks := splitAt(t, signal, []int{999, 1001, 997, 1003})
 
-	r := NewAudioRouter(GetLogger(), nil)
-	t.Cleanup(r.Close)
-	consumer := newCollectingConsumer(rate)
-	route := newAlignTestRoute(t, r, consumer, alignRunOpts{gainLinear: 1.0, srcRate: rate, dstRate: rate})
+	t.Run("pass_through", func(t *testing.T) {
+		t.Parallel()
+		r := NewAudioRouter(GetLogger(), nil)
+		t.Cleanup(r.Close)
+		consumer := newCollectingConsumer(rate)
+		route := newAlignTestRoute(t, consumer, alignRunOpts{gainLinear: 1.0, srcRate: rate, dstRate: rate})
 
-	for _, chunk := range chunks {
-		r.handleRouteFrame(AudioFrame{
-			SourceID: "align-src", SourceName: "align",
-			Data: chunk, SampleRate: rate,
-			BitDepth: 8, Channels: 1,
-		}, route)
-	}
+		for _, chunk := range chunks {
+			r.handleRouteFrame(AudioFrame{
+				SourceID: "align-src", SourceName: "align",
+				Data: chunk, SampleRate: rate,
+				BitDepth: 8, Channels: 1,
+			}, route)
+		}
 
-	assert.Equal(t, len(chunks), consumer.writes, "every non-PCM16 frame must reach the consumer")
-	assert.Zero(t, route.realignments.Load(), "a non-PCM16 route must not realign")
-	assert.Equal(t, signal, consumer.out, "a non-PCM16 route must pass every byte through unchanged")
+		assert.Equal(t, len(chunks), consumer.writes, "every non-PCM16 frame must reach the consumer")
+		assert.Zero(t, route.realignments.Load(), "a non-PCM16 route must not realign")
+		assert.Equal(t, signal, consumer.out, "a non-PCM16 route must pass every byte through unchanged")
+	})
+
+	t.Run("resampling_route_rejects_rather_than_realigns", func(t *testing.T) {
+		t.Parallel()
+		r := NewAudioRouter(GetLogger(), nil)
+		t.Cleanup(r.Close)
+		consumer := newCollectingConsumer(32000)
+		route := newAlignTestRoute(t, consumer, alignRunOpts{gainLinear: 1.0, srcRate: rate, dstRate: 32000})
+
+		for _, chunk := range chunks {
+			r.handleRouteFrame(AudioFrame{
+				SourceID: "align-src", SourceName: "align",
+				Data: chunk, SampleRate: rate,
+				BitDepth: 8, Channels: 1,
+			}, route)
+		}
+
+		assert.Zero(t, route.realignments.Load(),
+			"8-bit data must never be realigned on a 16-bit sample unit, even when the route resamples")
+		assert.Positive(t, route.errors.Load(),
+			"the resampler must reject odd-length non-PCM16 frames rather than silently consume realigned ones")
+	})
 }
 
 // TestRouter_AllCarryFrameSkipsWrite covers the frame that disappears entirely
@@ -305,55 +337,6 @@ func TestRouter_StrandedFinalByteIsWithheld(t *testing.T) {
 
 	assert.Positive(t, got.realignments, "the odd chunking must exercise the carry")
 	assert.Equal(t, signal, got.out, "the unpaired trailing byte must stay in the carry")
-}
-
-// TestRouter_ResetAlignmentDropsStalePartialSample covers a stream discontinuity.
-// A Route outlives an FFmpeg process restart, so a half-sample held when the old
-// stream died would be prepended to the first frame of the new one, shifting
-// every sample that follows it for the life of the route.
-func TestRouter_ResetAlignmentDropsStalePartialSample(t *testing.T) {
-	t.Parallel()
-
-	const rate = 48000
-	first := alignTestSignal(500)   // 1000 bytes
-	second := alignTestSignal(1000) // 2000 bytes, a fresh whole stream
-
-	r := NewAudioRouter(GetLogger(), nil)
-	t.Cleanup(r.Close)
-	consumer := newCollectingConsumer(rate)
-	route := newAlignTestRoute(t, r, consumer, alignRunOpts{gainLinear: 1.0, srcRate: rate, dstRate: rate})
-
-	writeFrame := func(data []byte) {
-		r.handleRouteFrame(AudioFrame{
-			SourceID: "align-src", SourceName: "align",
-			Data: data, SampleRate: rate,
-			BitDepth: 16, Channels: 1,
-		}, route)
-	}
-
-	// End the first stream mid-sample: 999 of 1000 bytes go out, one is held.
-	writeFrame(first[:999])
-	require.Equal(t, 1, route.carryLen, "the truncated first stream must leave a byte in the carry")
-
-	// Register the route so ResetAlignment can find it by source ID, then
-	// deregister it so the router's own teardown does not wait on a drainer
-	// goroutine this test never started.
-	r.mu.Lock()
-	r.routes["align-src"] = []*Route{route}
-	r.mu.Unlock()
-	r.ResetAlignment("align-src")
-	r.mu.Lock()
-	delete(r.routes, "align-src")
-	r.mu.Unlock()
-
-	require.True(t, route.carryResetPending.Load(), "ResetAlignment must arm the pending flag")
-
-	// The new stream must arrive unshifted.
-	writeFrame(second)
-
-	assert.Zero(t, route.carryLen, "the reset must clear the carry before the next frame")
-	assert.Equal(t, append(bytes.Clone(first[:998]), second...), consumer.out,
-		"the stale half-sample must be dropped, not prepended to the new stream")
 }
 
 // FuzzRouterAlignPCM16 asserts the framer's total invariants over arbitrary
@@ -403,4 +386,103 @@ func FuzzRouterAlignPCM16(f *testing.F) {
 			"the reassembled stream must equal the input truncated to whole samples (want %d bytes, got %d)",
 			len(want), len(consumer.out))
 	})
+}
+
+// TestRouter_ResampleAndProcessReturnsEachPooledBufferOnce guards the pool
+// discipline in handleRouteFrame, which is the riskiest thing about routing a
+// frame: the resample buffer is returned early by the processing branch and the
+// deferred release must then skip it. Getting that wrong hands the same backing
+// array to two callers at once, and every existing test still passes, because
+// nothing else asserts buffer identity.
+//
+// The route resamples and applies gain, so both release sites run for every
+// frame. Afterwards the pool must hold that buffer exactly once: two successive
+// Gets then return distinct arrays, whereas a double Put returns the same array
+// twice.
+func TestRouter_ResampleAndProcessReturnsEachPooledBufferOnce(t *testing.T) {
+	// Not parallel: it pins the GC so sync.Pool cannot be drained mid-test.
+	defer debug.SetGCPercent(debug.SetGCPercent(-1))
+
+	const (
+		srcRate = 48000
+		dstRate = 32000
+	)
+	mgr := buffer.NewManager(GetLogger())
+	r := NewAudioRouter(GetLogger(), mgr)
+	t.Cleanup(r.Close)
+
+	consumer := newCollectingConsumer(dstRate)
+	route := newAlignTestRoute(t, consumer, alignRunOpts{
+		gainLinear: 0.5, srcRate: srcRate, dstRate: dstRate,
+	})
+
+	signal := alignTestSignal(1200)
+	r.handleRouteFrame(AudioFrame{
+		SourceID: "align-src", SourceName: "align",
+		Data: signal, SampleRate: srcRate,
+		BitDepth: 16, Channels: 1,
+	}, route)
+	require.NotEmpty(t, consumer.out, "the frame must reach the consumer")
+
+	// The resample buffer is sized from the resampler's own estimate, which is
+	// what handleRouteFrame asked the manager for.
+	outSize := route.resampler.EstimateOutputBytes(len(signal))
+	pool := mgr.BytePoolFor(outSize)
+	require.NotNil(t, pool)
+
+	first := pool.Get()
+	second := pool.Get()
+	require.NotEmpty(t, first)
+	require.NotEmpty(t, second)
+	assert.NotSame(t, &first[0], &second[0],
+		"the resample buffer was returned to its pool twice: two Gets handed back the same array, "+
+			"so two routes would write over each other")
+}
+
+// TestRouter_RealignmentLogsOncePerRunNotPerFrame guards the logging gate.
+// Realignment latches: joining the carry makes an even-length frame odd again,
+// so once a route starts carrying it realigns on every frame for as long as the
+// producer keeps splitting samples. Gating the log on a frame count would then
+// emit forever, one line per interval, for a condition that is normal and self
+// correcting. The log therefore reports the transition into a carrying run.
+func TestRouter_RealignmentLogsOncePerRunNotPerFrame(t *testing.T) {
+	t.Parallel()
+
+	const (
+		rate      = 48000
+		numFrames = 200
+	)
+	var logs bytes.Buffer
+	log := logger.NewSlogLogger(&logs, logger.LogLevelDebug, time.UTC)
+
+	r := NewAudioRouter(log, nil)
+	t.Cleanup(r.Close)
+	consumer := newCollectingConsumer(rate)
+	route := newAlignTestRoute(t, consumer, alignRunOpts{gainLinear: 1.0, srcRate: rate, dstRate: rate})
+
+	// One odd frame followed by even ones is what latches the carry: the odd
+	// frame leaves a byte, and every even frame after it joins that byte, goes
+	// odd, and leaves a new one. The run never ends, so realignments grows once
+	// per frame while the route stays in a single carrying run. (An all-odd
+	// stream does the opposite: the carry drains on every second frame, which is
+	// many short runs rather than one long one.)
+	send := func(data []byte) {
+		r.handleRouteFrame(AudioFrame{
+			SourceID: "align-src", SourceName: "align",
+			Data: data, SampleRate: rate,
+			BitDepth: 16, Channels: 1,
+		}, route)
+	}
+	signal := alignTestSignal(64)
+	send(signal[:127])
+	for range numFrames - 1 {
+		send(signal[:128])
+	}
+
+	require.Equal(t, int64(numFrames), route.realignments.Load(),
+		"a latched run realigns on every frame, which is what makes per-frame logging unbounded")
+	assert.Equal(t, int64(1), route.realignmentRuns.Load(),
+		"the whole sequence is one carrying run, entered once")
+	assert.Equal(t, 1, bytes.Count(logs.Bytes(), []byte("partial PCM16 sample carried to next frame")),
+		"a latched route must report the transition once, not once per interval forever")
 }

--- a/internal/audiocore/router_pcm_align_test.go
+++ b/internal/audiocore/router_pcm_align_test.go
@@ -1,6 +1,7 @@
 package audiocore
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,19 +12,24 @@ import (
 // collectingConsumer accumulates every byte handed to Write so a test can
 // compare the whole processed stream rather than individual frames. Write
 // copies the payload because the router recycles frame buffers as soon as
-// Write returns.
+// Write returns, and counts calls so a test can tell "the router skipped this
+// frame" apart from "the router wrote an empty frame".
 type collectingConsumer struct {
-	id         string
-	sampleRate int
-	out        []byte
-	writes     int
+	mockConsumer
+	out    []byte
+	writes int
 }
 
-func (c *collectingConsumer) ID() string      { return c.id }
-func (c *collectingConsumer) SampleRate() int { return c.sampleRate }
-func (c *collectingConsumer) BitDepth() int   { return 16 }
-func (c *collectingConsumer) Channels() int   { return 1 }
-func (c *collectingConsumer) Close() error    { return nil }
+func newCollectingConsumer(sampleRate int) *collectingConsumer {
+	return &collectingConsumer{
+		mockConsumer: mockConsumer{
+			id:         "align-consumer",
+			sampleRate: sampleRate,
+			bitDepth:   16,
+			channels:   1,
+		},
+	}
+}
 
 func (c *collectingConsumer) Write(frame AudioFrame) error { //nolint:gocritic // hugeParam: signature required by AudioConsumer interface
 	c.out = append(c.out, frame.Data...)
@@ -40,12 +46,12 @@ func (c *collectingConsumer) Write(frame AudioFrame) error { //nolint:gocritic /
 func alignTestSignal(sampleCount int) []byte {
 	data := make([]byte, sampleCount*2)
 	for i := range sampleCount {
-		v := int16((i*2731)%40000 - 20000)
+		v := int16((i*2731)%40000 - 20000) //nolint:gosec // G115: intentional wrap for a synthetic test signal
 		if i%2 == 1 {
 			v = -v
 		}
-		data[i*2] = byte(v)        //nolint:gosec // G115: intentional int16→byte truncation for PCM serialisation
-		data[i*2+1] = byte(v >> 8) //nolint:gosec // G115: intentional int16→byte truncation for PCM serialisation
+		data[i*2] = byte(v)        //nolint:gosec // G115: intentional int16 to byte truncation for PCM serialisation
+		data[i*2+1] = byte(v >> 8) //nolint:gosec // G115: intentional int16 to byte truncation for PCM serialisation
 	}
 	return data
 }
@@ -65,46 +71,80 @@ func splitAt(t *testing.T, src []byte, sizes []int) [][]byte {
 	return chunks
 }
 
+// alignRunOpts configures one run through a hand-built route.
+type alignRunOpts struct {
+	gainLinear float64
+	srcRate    int
+	dstRate    int
+	bitDepth   int
+}
+
+// alignRunResult is everything a test needs to assert on after a run.
+type alignRunResult struct {
+	out          []byte
+	writes       int
+	routeErrors  int64
+	realignments int64
+}
+
 // runChunksThroughRoute feeds chunks through handleRouteFrame on a freshly built
-// route and returns the consumer's concatenated output plus the route's error count.
-// Calling handleRouteFrame directly (as the benchmarks do) keeps the test
-// deterministic: it exercises the same resample/process/write path as the drainer
-// goroutine without depending on channel scheduling.
-func runChunksThroughRoute(t *testing.T, chunks [][]byte, gainLinear float64, srcRate, dstRate int) (out []byte, routeErrors int64) {
+// route. Calling handleRouteFrame directly (as the benchmarks do) keeps the test
+// deterministic: it exercises the same align/resample/process/write path as the
+// drainer goroutine without depending on channel scheduling.
+//
+// The realignments count is returned so every test can assert that alignment
+// actually engaged. Without that assertion a future edit to the chunk sizes that
+// accidentally made every chunk even would leave the comparisons green and
+// vacuous, comparing two identical control runs.
+func runChunksThroughRoute(t *testing.T, chunks [][]byte, opts alignRunOpts) alignRunResult {
 	t.Helper()
 
 	r := NewAudioRouter(GetLogger(), nil)
 	t.Cleanup(r.Close)
 
-	consumer := &collectingConsumer{id: "align-consumer", sampleRate: dstRate}
-	route := &Route{
-		SourceID:         "align-src",
-		Consumer:         consumer,
-		sourceSampleRate: srcRate,
-		gainLinear:       gainLinear,
-		inbox:            make(chan AudioFrame, 1),
-		done:             make(chan struct{}),
-		stopped:          make(chan struct{}),
-	}
-	if srcRate != dstRate {
-		rs, err := resample.NewResampler(srcRate, dstRate)
-		require.NoError(t, err)
-		t.Cleanup(func() { _ = rs.Close() })
-		route.resampler = rs
-	}
+	consumer := newCollectingConsumer(opts.dstRate)
+	route := newAlignTestRoute(t, r, consumer, opts)
 
 	for _, chunk := range chunks {
 		r.handleRouteFrame(AudioFrame{
 			SourceID:   "align-src",
 			SourceName: "align",
 			Data:       chunk,
-			SampleRate: srcRate,
-			BitDepth:   16,
+			SampleRate: opts.srcRate,
+			BitDepth:   opts.bitDepth,
 			Channels:   1,
 		}, route)
 	}
 
-	return consumer.out, route.errors.Load()
+	return alignRunResult{
+		out:          consumer.out,
+		writes:       consumer.writes,
+		routeErrors:  route.errors.Load(),
+		realignments: route.realignments.Load(),
+	}
+}
+
+// newAlignTestRoute builds a Route wired to consumer, adding a resampler only
+// when the rates differ (mirroring what AddRoute does).
+func newAlignTestRoute(t *testing.T, r *AudioRouter, consumer AudioConsumer, opts alignRunOpts) *Route {
+	t.Helper()
+	_ = r
+	route := &Route{
+		SourceID:         "align-src",
+		Consumer:         consumer,
+		sourceSampleRate: opts.srcRate,
+		gainLinear:       opts.gainLinear,
+		inbox:            make(chan AudioFrame, 1),
+		done:             make(chan struct{}),
+		stopped:          make(chan struct{}),
+	}
+	if opts.srcRate != opts.dstRate {
+		rs, err := resample.NewResampler(opts.srcRate, opts.dstRate)
+		require.NoError(t, err)
+		t.Cleanup(func() { assert.NoError(t, rs.Close()) })
+		route.resampler = rs
+	}
+	return route
 }
 
 // TestRouter_OddLengthFramesDoNotDesyncGainPath is the regression test for the
@@ -127,17 +167,17 @@ func TestRouter_OddLengthFramesDoNotDesyncGainPath(t *testing.T) {
 		rate       = 48000
 	)
 	signal := alignTestSignal(sampleCount)
+	opts := alignRunOpts{gainLinear: gainLinear, srcRate: rate, dstRate: rate, bitDepth: 16}
 
-	evenSizes := []int{1000, 1000, 1000, 1000}
-	oddSizes := []int{999, 1001, 997, 1003}
+	control := runChunksThroughRoute(t, splitAt(t, signal, []int{1000, 1000, 1000, 1000}), opts)
+	require.Zero(t, control.routeErrors, "even-length control run must not produce route errors")
+	require.Zero(t, control.realignments, "even-length control run must not realign anything")
+	require.Len(t, control.out, len(signal), "control run must emit every input sample")
 
-	control, controlErrs := runChunksThroughRoute(t, splitAt(t, signal, evenSizes), gainLinear, rate, rate)
-	require.Zero(t, controlErrs, "even-length control run must not produce route errors")
-	require.Len(t, control, len(signal), "control run must emit every input sample")
-
-	got, gotErrs := runChunksThroughRoute(t, splitAt(t, signal, oddSizes), gainLinear, rate, rate)
-	assert.Zero(t, gotErrs, "odd-length frames must not produce route errors")
-	assert.Equal(t, control, got,
+	got := runChunksThroughRoute(t, splitAt(t, signal, []int{999, 1001, 997, 1003}), opts)
+	assert.Zero(t, got.routeErrors, "odd-length frames must not produce route errors")
+	assert.Positive(t, got.realignments, "the odd chunking must actually exercise the carry")
+	assert.Equal(t, control.out, got.out,
 		"odd-length frames must yield the same processed sample stream as even-length frames; "+
 			"a mismatch means the trailing byte was dropped and the stream desynchronised")
 }
@@ -156,16 +196,211 @@ func TestRouter_OddLengthFramesSurviveResampling(t *testing.T) {
 		dstRate     = 32000
 	)
 	signal := alignTestSignal(sampleCount)
+	opts := alignRunOpts{gainLinear: 1.0, srcRate: srcRate, dstRate: dstRate, bitDepth: 16}
 
-	evenSizes := []int{1200, 1200, 1200, 1200}
-	oddSizes := []int{1199, 1201, 1197, 1203}
+	control := runChunksThroughRoute(t, splitAt(t, signal, []int{1200, 1200, 1200, 1200}), opts)
+	require.Zero(t, control.routeErrors, "even-length control run must not produce route errors")
+	require.NotEmpty(t, control.out, "control run must emit resampled audio")
 
-	control, controlErrs := runChunksThroughRoute(t, splitAt(t, signal, evenSizes), 1.0, srcRate, dstRate)
-	require.Zero(t, controlErrs, "even-length control run must not produce route errors")
-	require.NotEmpty(t, control, "control run must emit resampled audio")
-
-	got, gotErrs := runChunksThroughRoute(t, splitAt(t, signal, oddSizes), 1.0, srcRate, dstRate)
-	assert.Zero(t, gotErrs, "odd-length frames must not be rejected by the resampler")
-	assert.Equal(t, control, got,
+	got := runChunksThroughRoute(t, splitAt(t, signal, []int{1199, 1201, 1197, 1203}), opts)
+	assert.Zero(t, got.routeErrors, "odd-length frames must not be rejected by the resampler")
+	assert.Positive(t, got.realignments, "the odd chunking must actually exercise the carry")
+	// Exact equality relies on go-audio-resampler being chunk-boundary
+	// invariant: a fixed-length-kernel convolution produces identical output for
+	// identical input regardless of how the input was split. If a resampler
+	// upgrade ever breaks this test with both runs individually plausible,
+	// suspect that property before suspecting the alignment code.
+	assert.Equal(t, control.out, got.out,
 		"odd-length frames must yield the same resampled stream as even-length frames")
+}
+
+// TestRouter_PassThroughPCM16RealignsOddFrames pins the alignment gate covering
+// pass-through routes, which is the default configuration (no resampler, no EQ,
+// 0 dB gain). The analysis consumers all read a pass-through route, so aligning
+// only the routes that resample or process would leave them enforcing the
+// whole-sample invariant nowhere.
+func TestRouter_PassThroughPCM16RealignsOddFrames(t *testing.T) {
+	t.Parallel()
+
+	const rate = 48000
+	signal := alignTestSignal(2000)
+	opts := alignRunOpts{gainLinear: 1.0, srcRate: rate, dstRate: rate, bitDepth: 16}
+
+	control := runChunksThroughRoute(t, splitAt(t, signal, []int{1000, 1000, 1000, 1000}), opts)
+	require.Zero(t, control.realignments, "even-length control run must not realign anything")
+	require.Equal(t, signal, control.out, "a pass-through route must emit the stream unchanged")
+
+	got := runChunksThroughRoute(t, splitAt(t, signal, []int{999, 1001, 997, 1003}), opts)
+	assert.Zero(t, got.routeErrors, "odd-length frames must not produce route errors")
+	assert.Positive(t, got.realignments, "a pass-through PCM16 route must realign odd frames")
+	assert.Equal(t, signal, got.out,
+		"a pass-through route must reassemble the same sample stream from odd-length frames")
+}
+
+// TestRouter_NonPCM16PassThroughIsUntouched pins the other half of the gate. A
+// 2-byte carry applied to a stream that is not 16-bit PCM would regroup its frame
+// boundaries and permanently withhold a trailing byte at stream end, so frames
+// declaring another bit depth must pass through byte for byte.
+func TestRouter_NonPCM16PassThroughIsUntouched(t *testing.T) {
+	t.Parallel()
+
+	const rate = 48000
+	sizes := []int{999, 1001, 997, 1003}
+	signal := alignTestSignal(2000)
+	chunks := splitAt(t, signal, sizes)
+
+	r := NewAudioRouter(GetLogger(), nil)
+	t.Cleanup(r.Close)
+	consumer := newCollectingConsumer(rate)
+	route := newAlignTestRoute(t, r, consumer, alignRunOpts{gainLinear: 1.0, srcRate: rate, dstRate: rate})
+
+	for _, chunk := range chunks {
+		r.handleRouteFrame(AudioFrame{
+			SourceID: "align-src", SourceName: "align",
+			Data: chunk, SampleRate: rate,
+			BitDepth: 8, Channels: 1,
+		}, route)
+	}
+
+	assert.Equal(t, len(chunks), consumer.writes, "every non-PCM16 frame must reach the consumer")
+	assert.Zero(t, route.realignments.Load(), "a non-PCM16 route must not realign")
+	assert.Equal(t, signal, consumer.out, "a non-PCM16 route must pass every byte through unchanged")
+}
+
+// TestRouter_AllCarryFrameSkipsWrite covers the frame that disappears entirely
+// into the carry. A frame shorter than one sample leaves nothing to hand
+// downstream, and consumers are not documented to accept a zero-length frame, so
+// the router must skip the write rather than deliver an empty one.
+func TestRouter_AllCarryFrameSkipsWrite(t *testing.T) {
+	t.Parallel()
+
+	const rate = 48000
+	signal := alignTestSignal(2000)
+	// The leading 1-byte chunk is consumed entirely into the carry, so only
+	// three of the four chunks produce a write. The sizes still sum to an even
+	// total, so nothing is stranded at the end.
+	chunks := splitAt(t, signal, []int{1, 999, 1001, 1999})
+	opts := alignRunOpts{gainLinear: 1.0, srcRate: rate, dstRate: rate, bitDepth: 16}
+
+	got := runChunksThroughRoute(t, chunks, opts)
+
+	assert.Equal(t, len(chunks)-1, got.writes,
+		"the sub-sample frame must be withheld, not written as an empty frame")
+	assert.Positive(t, got.realignments, "the sub-sample frame must engage the carry")
+	assert.Equal(t, signal, got.out, "no byte may be lost when a whole frame is carried")
+}
+
+// TestRouter_StrandedFinalByteIsWithheld covers the one byte that legitimately
+// does not come out: a stream ending mid-sample has nothing left to pair its
+// last byte with, so it stays in the carry rather than being emitted alone.
+func TestRouter_StrandedFinalByteIsWithheld(t *testing.T) {
+	t.Parallel()
+
+	const rate = 48000
+	signal := alignTestSignal(2000)
+	withStray := append(bytes.Clone(signal), 0x7f)
+	opts := alignRunOpts{gainLinear: 1.0, srcRate: rate, dstRate: rate, bitDepth: 16}
+
+	got := runChunksThroughRoute(t, splitAt(t, withStray, []int{999, 1001, 997, 1004}), opts)
+
+	assert.Positive(t, got.realignments, "the odd chunking must exercise the carry")
+	assert.Equal(t, signal, got.out, "the unpaired trailing byte must stay in the carry")
+}
+
+// TestRouter_ResetAlignmentDropsStalePartialSample covers a stream discontinuity.
+// A Route outlives an FFmpeg process restart, so a half-sample held when the old
+// stream died would be prepended to the first frame of the new one, shifting
+// every sample that follows it for the life of the route.
+func TestRouter_ResetAlignmentDropsStalePartialSample(t *testing.T) {
+	t.Parallel()
+
+	const rate = 48000
+	first := alignTestSignal(500)   // 1000 bytes
+	second := alignTestSignal(1000) // 2000 bytes, a fresh whole stream
+
+	r := NewAudioRouter(GetLogger(), nil)
+	t.Cleanup(r.Close)
+	consumer := newCollectingConsumer(rate)
+	route := newAlignTestRoute(t, r, consumer, alignRunOpts{gainLinear: 1.0, srcRate: rate, dstRate: rate})
+
+	writeFrame := func(data []byte) {
+		r.handleRouteFrame(AudioFrame{
+			SourceID: "align-src", SourceName: "align",
+			Data: data, SampleRate: rate,
+			BitDepth: 16, Channels: 1,
+		}, route)
+	}
+
+	// End the first stream mid-sample: 999 of 1000 bytes go out, one is held.
+	writeFrame(first[:999])
+	require.Equal(t, 1, route.carryLen, "the truncated first stream must leave a byte in the carry")
+
+	// Register the route so ResetAlignment can find it by source ID, then
+	// deregister it so the router's own teardown does not wait on a drainer
+	// goroutine this test never started.
+	r.mu.Lock()
+	r.routes["align-src"] = []*Route{route}
+	r.mu.Unlock()
+	r.ResetAlignment("align-src")
+	r.mu.Lock()
+	delete(r.routes, "align-src")
+	r.mu.Unlock()
+
+	require.True(t, route.carryResetPending.Load(), "ResetAlignment must arm the pending flag")
+
+	// The new stream must arrive unshifted.
+	writeFrame(second)
+
+	assert.Zero(t, route.carryLen, "the reset must clear the carry before the next frame")
+	assert.Equal(t, append(bytes.Clone(first[:998]), second...), consumer.out,
+		"the stale half-sample must be dropped, not prepended to the new stream")
+}
+
+// FuzzRouterAlignPCM16 asserts the framer's total invariants over arbitrary
+// splits, which the hand-picked chunk lists above cannot cover: every frame
+// handed downstream holds whole samples, and the concatenated output is exactly
+// the input truncated to a whole number of samples, with nothing reordered.
+func FuzzRouterAlignPCM16(f *testing.F) {
+	f.Add(alignTestSignal(200), []byte{99, 1, 200, 3})
+	f.Add(alignTestSignal(64), []byte{1, 1, 1, 1})
+	f.Add([]byte{1, 2, 3}, []byte{1})
+
+	f.Fuzz(func(t *testing.T, payload, sizes []byte) {
+		const rate = 48000
+		r := NewAudioRouter(GetLogger(), nil)
+		defer r.Close()
+
+		consumer := newCollectingConsumer(rate)
+		route := &Route{
+			SourceID: "fuzz-src", Consumer: consumer,
+			sourceSampleRate: rate, gainLinear: 1.0,
+			inbox: make(chan AudioFrame, 1),
+			done:  make(chan struct{}), stopped: make(chan struct{}),
+		}
+
+		off := 0
+		for i := 0; off < len(payload); i++ {
+			n := len(payload) - off
+			if len(sizes) > 0 {
+				if step := int(sizes[i%len(sizes)]); step > 0 && step < n {
+					n = step
+				}
+			}
+			r.handleRouteFrame(AudioFrame{
+				SourceID: "fuzz-src", SourceName: "fuzz",
+				Data: payload[off : off+n], SampleRate: rate,
+				BitDepth: 16, Channels: 1,
+			}, route)
+			off += n
+		}
+
+		require.Zero(t, len(consumer.out)%2, "every emitted byte count must be a whole number of samples")
+		want := payload[:len(payload)&^1]
+		// bytes.Equal rather than require.Equal: an all-truncated payload leaves
+		// the output nil and want an empty slice, which are equal here but not
+		// to reflect.DeepEqual.
+		require.Truef(t, bytes.Equal(want, consumer.out),
+			"the reassembled stream must equal the input truncated to whole samples (want %d bytes, got %d)",
+			len(want), len(consumer.out))
+	})
 }

--- a/internal/audiocore/router_pcm_align_test.go
+++ b/internal/audiocore/router_pcm_align_test.go
@@ -1,0 +1,171 @@
+package audiocore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/audiocore/resample"
+)
+
+// collectingConsumer accumulates every byte handed to Write so a test can
+// compare the whole processed stream rather than individual frames. Write
+// copies the payload because the router recycles frame buffers as soon as
+// Write returns.
+type collectingConsumer struct {
+	id         string
+	sampleRate int
+	out        []byte
+	writes     int
+}
+
+func (c *collectingConsumer) ID() string      { return c.id }
+func (c *collectingConsumer) SampleRate() int { return c.sampleRate }
+func (c *collectingConsumer) BitDepth() int   { return 16 }
+func (c *collectingConsumer) Channels() int   { return 1 }
+func (c *collectingConsumer) Close() error    { return nil }
+
+func (c *collectingConsumer) Write(frame AudioFrame) error { //nolint:gocritic // hugeParam: signature required by AudioConsumer interface
+	c.out = append(c.out, frame.Data...)
+	c.writes++
+	return nil
+}
+
+// alignTestSignal builds sampleCount mono PCM16 samples with strong sample-to-sample
+// variation. A trivial signal (silence, a constant, or a slow ramp) would hide the
+// defect this file guards: byte-swapping silence yields silence, so the stream can
+// desynchronise without changing a single output byte. The alternating sign and the
+// odd stride keep both bytes of every sample distinct from its neighbours, so a
+// one-byte shift is guaranteed to change the output.
+func alignTestSignal(sampleCount int) []byte {
+	data := make([]byte, sampleCount*2)
+	for i := range sampleCount {
+		v := int16((i*2731)%40000 - 20000)
+		if i%2 == 1 {
+			v = -v
+		}
+		data[i*2] = byte(v)        //nolint:gosec // G115: intentional int16→byte truncation for PCM serialisation
+		data[i*2+1] = byte(v >> 8) //nolint:gosec // G115: intentional int16→byte truncation for PCM serialisation
+	}
+	return data
+}
+
+// splitAt cuts src into consecutive chunks of the given sizes. The sizes must
+// sum to len(src).
+func splitAt(t *testing.T, src []byte, sizes []int) [][]byte {
+	t.Helper()
+	chunks := make([][]byte, 0, len(sizes))
+	off := 0
+	for _, n := range sizes {
+		require.LessOrEqual(t, off+n, len(src), "chunk sizes overrun the source signal")
+		chunks = append(chunks, src[off:off+n])
+		off += n
+	}
+	require.Equal(t, len(src), off, "chunk sizes must consume the whole source signal")
+	return chunks
+}
+
+// runChunksThroughRoute feeds chunks through handleRouteFrame on a freshly built
+// route and returns the consumer's concatenated output plus the route's error count.
+// Calling handleRouteFrame directly (as the benchmarks do) keeps the test
+// deterministic: it exercises the same resample/process/write path as the drainer
+// goroutine without depending on channel scheduling.
+func runChunksThroughRoute(t *testing.T, chunks [][]byte, gainLinear float64, srcRate, dstRate int) (out []byte, routeErrors int64) {
+	t.Helper()
+
+	r := NewAudioRouter(GetLogger(), nil)
+	t.Cleanup(r.Close)
+
+	consumer := &collectingConsumer{id: "align-consumer", sampleRate: dstRate}
+	route := &Route{
+		SourceID:         "align-src",
+		Consumer:         consumer,
+		sourceSampleRate: srcRate,
+		gainLinear:       gainLinear,
+		inbox:            make(chan AudioFrame, 1),
+		done:             make(chan struct{}),
+		stopped:          make(chan struct{}),
+	}
+	if srcRate != dstRate {
+		rs, err := resample.NewResampler(srcRate, dstRate)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = rs.Close() })
+		route.resampler = rs
+	}
+
+	for _, chunk := range chunks {
+		r.handleRouteFrame(AudioFrame{
+			SourceID:   "align-src",
+			SourceName: "align",
+			Data:       chunk,
+			SampleRate: srcRate,
+			BitDepth:   16,
+			Channels:   1,
+		}, route)
+	}
+
+	return consumer.out, route.errors.Load()
+}
+
+// TestRouter_OddLengthFramesDoNotDesyncGainPath is the regression test for the
+// router discarding the odd trailing byte of a PCM16 frame on the EQ/gain path.
+// Dropping half a sample is not a truncation, it is a desynchronisation: every
+// following sample is then read from the wrong byte offset and decodes as noise.
+//
+// The assertion is exact byte equality against a control run that carries the
+// same total byte stream in even-length chunks. Because the odd chunk sizes sum
+// to an even total, nothing is left in the carry at the end and the two runs must
+// produce identical output.
+func TestRouter_OddLengthFramesDoNotDesyncGainPath(t *testing.T) {
+	t.Parallel()
+
+	const (
+		sampleCount = 2000
+		// -6 dB, chosen so no sample clamps and the transform stays lossless
+		// enough for an exact comparison between the two chunkings.
+		gainLinear = 0.5
+		rate       = 48000
+	)
+	signal := alignTestSignal(sampleCount)
+
+	evenSizes := []int{1000, 1000, 1000, 1000}
+	oddSizes := []int{999, 1001, 997, 1003}
+
+	control, controlErrs := runChunksThroughRoute(t, splitAt(t, signal, evenSizes), gainLinear, rate, rate)
+	require.Zero(t, controlErrs, "even-length control run must not produce route errors")
+	require.Len(t, control, len(signal), "control run must emit every input sample")
+
+	got, gotErrs := runChunksThroughRoute(t, splitAt(t, signal, oddSizes), gainLinear, rate, rate)
+	assert.Zero(t, gotErrs, "odd-length frames must not produce route errors")
+	assert.Equal(t, control, got,
+		"odd-length frames must yield the same processed sample stream as even-length frames; "+
+			"a mismatch means the trailing byte was dropped and the stream desynchronised")
+}
+
+// TestRouter_OddLengthFramesSurviveResampling covers the second consumer of
+// whole-sample framing on this path. resample.ResampleTo rejects an odd byte
+// count outright, so before the carry existed an odd frame on a resampling route
+// was dropped entirely and reported as a route error (and a telemetry event) for
+// every frame.
+func TestRouter_OddLengthFramesSurviveResampling(t *testing.T) {
+	t.Parallel()
+
+	const (
+		sampleCount = 2400
+		srcRate     = 48000
+		dstRate     = 32000
+	)
+	signal := alignTestSignal(sampleCount)
+
+	evenSizes := []int{1200, 1200, 1200, 1200}
+	oddSizes := []int{1199, 1201, 1197, 1203}
+
+	control, controlErrs := runChunksThroughRoute(t, splitAt(t, signal, evenSizes), 1.0, srcRate, dstRate)
+	require.Zero(t, controlErrs, "even-length control run must not produce route errors")
+	require.NotEmpty(t, control, "control run must emit resampled audio")
+
+	got, gotErrs := runChunksThroughRoute(t, splitAt(t, signal, oddSizes), 1.0, srcRate, dstRate)
+	assert.Zero(t, gotErrs, "odd-length frames must not be rejected by the resampler")
+	assert.Equal(t, control, got,
+		"odd-length frames must yield the same resampled stream as even-length frames")
+}


### PR DESCRIPTION
> **Note on FFmpeg deprecation.** FFmpeg support is deprecated and is being removed; new work should not target it. This PR was already open when that came up, so it is being carried through rather than restarted, but the split matters for how to read it.
>
> The durable half is `internal/audiocore/router.go` and its tests, which is the larger part of the diff. The router is producer-agnostic: it is the chokepoint every audio source feeds, including the sound card path and the native (FFmpeg-free) encoders, so its whole-sample invariant holds after FFmpeg is gone. That half is worth reviewing on its own merits.
>
> The `internal/audiocore/ffmpeg/` half fixes the producer that can actually emit a partial frame today. It stops the desync for users still on FFmpeg sources until the subsystem is removed, and it is deliberately self-contained, so deleting the package later takes the whole fix with it and leaves nothing to unpick.

## What

An FFmpeg audio source is read from a pipe, and a pipe read returns whatever bytes happen to be available, so a read routinely ends part-way through a PCM frame. Several places then discarded that trailing partial frame.

Discarding it is not a truncation, it is a desynchronisation. The dropped byte is half a sample, so every following byte shifts by one and each subsequent sample decodes with its halves swapped: broadband noise rather than slightly shorter audio. Silence stays silent through the same transform, which is a large part of why this went unnoticed.

## Where it was broken

The reader itself, plus every downstream consumer that reinterprets those bytes as samples, and none of them could recover locally:

- `applyProcessing` in the router dropped the odd byte on the EQ/gain path.
- `resample.ResampleTo` rejects an odd byte count outright, so an odd frame on a resampling route was dropped whole and built a telemetry-reporting error for every frame it saw.
- `SoundLevelConsumer.Write` drops the byte silently into a stateful octave-band processor.
- `BufferConsumer.Write`, the main analysis path, has no whole-sample guard at all. It writes frame data straight into the capture buffer and the model analysis buffers, so a one-byte shift desynchronises every later sample of an exported clip.

## The fix

Reassembly belongs at the producer, which is the only place that can emit a partial frame (the sound card path delivers whole device frames by construction). `readStdout` now holds the remainder and prepends it to the next read, reading behind the carry in the same pooled buffer, so there is no extra copy and no second allocation. The frame size follows the configured bit depth and channel count the same way the output arguments are built, and alignment is on the whole interleaved frame, so a read landing between a stereo pair cannot swap the channels for the rest of the stream.

The router keeps its own carry as the boundary that makes the invariant hold regardless of producer. That alignment now covers every PCM16 route rather than only the ones that resample or process: the analysis consumers all read a pass-through route, so the narrower gate left them enforcing the invariant nowhere. It also now excludes non-PCM16 frames, which the old gate fed into a 16-bit carry whenever a resampler was present.

Also fixed along the way, all found while reviewing the above:

- `pcmFrameBytes` applied its ceiling after multiplying, so on a 32-bit build a large channel count wrapped past the check and returned zero, and the modulus in `readStdout` then divided by zero inside a goroutine with no recover. It now bounds the multiplicand, which makes the overflow unreachable at any int width.
- The frame size ignored the pan filter, which folds a multi-channel source to mono regardless of the configured channel count. It never split a sample, because the overestimate was always a whole multiple of the real frame, but the derivation and its documentation were wrong. Both halves now go through one helper shared with the code that builds the arguments, and the emitted frame reports the same count.
- Realignment logging is gated on entering a carrying run rather than on a frame count. Realignment latches, so a per-frame interval logs forever; a benchmark run reached 158601 realignments and drowned its own output.
- Pre-existing: the router released its pooled buffers at the end of `handleRouteFrame` rather than in a defer, so a consumer that panicked during `Write` leaked them.

## Who is affected

Anyone on an FFmpeg source, which is every RTSP user. The EQ and gain paths need those settings configured, but the sound level, audio level and analysis buffer consumers are on the default path.

## Behaviour changes worth knowing

- Pass-through PCM16 routes now realign; previously they handed producer bytes through byte for byte.
- A non-PCM16 route that resamples now fails loudly in the resampler instead of being silently realigned on a unit that does not describe the data. That configuration was already producing garbage.
- Up to one frame short of a whole sample is dropped at the end of an FFmpeg process, roughly 10 microseconds of audio, rather than being emitted as a partial frame.
- Empty and sub-sample frames no longer reach `Consumer.Write`.

## Testing

Both regression tests were written first and failed for the right reasons: the gain path desynchronised, and the resample path produced four route errors and zero output.

The trap here is that a naive test passes against the bug, because byte-swapping silence yields silence and small sample deficits vanish into codec frame quantisation. So the signals use a stride with per-sample sign inversion, every byte differs from its neighbours, and the oracle is exact byte equality over the whole stream against a control run of the same bytes in whole-frame chunks. The router tests are differential: the even chunking provably bypasses the alignment code, so the expectation comes from an independent execution path rather than restated logic.

Coverage includes both halves of the gate separately, the frame that vanishes entirely into the carry, the stranded final byte, the carry against a live buffer pool that recycles the read buffer between reads, a read failure with a carry pending, the frame-size derivation checked against the arguments FFmpeg is actually given, and two fuzz targets asserting that every emitted frame holds whole samples and that the reassembled stream equals the input truncated to whole frames.

Verified by mutation: fourteen mutations, all killed. That set includes reverting the gate to its previous expression, deleting the line that prevents a pooled buffer being returned twice, and removing the logging transition gate.

A known limitation is documented in the code rather than half-fixed: the router carry is not cleared at a stream discontinuity. Doing that correctly needs a marker travelling in band with the frames, because an out-of-band signal is consumed by whichever frame the drainer dequeues next, which is still an old-stream frame while the inbox drains. No in-tree producer can reach it, since the reader reassembles whole frames and its own carry resets per process.

## Release notes
- audience: user
- summary: Fix audio being decoded as noise for RTSP sources, which could affect detection accuracy, sound level readings and exported clips
- feature: none
- breaking: none
- config: none
- schema: none
