### PR TITLE
build: ship go-aac's SIMD kernels via the goaac_simd tag

### DIFF
--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -35,6 +35,13 @@ concurrency:
   group: cross-platform-build-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # Must match BASE_BUILD_TAGS in Taskfile.yml, which is what the release and
+  # container builds actually use. Declared once here so the four build/vet
+  # steps below cannot drift apart from each other; keeping it in step with the
+  # Taskfile is still manual, so change both together.
+  BASE_BUILD_TAGS: goaac_simd
+
 jobs:
   cross-build:
     name: cross-build (${{ matrix.goos }}/${{ matrix.goarch }})
@@ -94,12 +101,16 @@ jobs:
         run: |
           # Compile + link every non-test package for the target GOOS. noembed and
           # skipfrontend skip model/frontend embedding, so no dist/models are
-          # required and the frontend build is not pulled in.
+          # required and the frontend build is not pulled in. goaac_simd mirrors
+          # BASE_BUILD_TAGS in the Taskfile: this smoke build is NOT the release
+          # configuration (releases embed models and add openvino on linux), but it
+          # does compile the same SIMD kernel selection the release artifacts ship,
+          # which is the part that would otherwise only be built at release time.
           GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} \
           CGO_ENABLED=1 CC=${{ matrix.cc }} \
           CGO_CFLAGS="-I${{ github.workspace }}/.cache/tensorflow" \
           CGO_LDFLAGS="-L${{ matrix.libdir }} -ltensorflowlite_c" \
-          go build -tags noembed,skipfrontend ./...
+          go build -tags noembed,skipfrontend,"$BASE_BUILD_TAGS" ./...
 
       - name: Vet (type-checks test files too, no link, no run)
         run: |
@@ -111,7 +122,7 @@ jobs:
           CGO_ENABLED=1 CC=${{ matrix.cc }} \
           CGO_CFLAGS="-I${{ github.workspace }}/.cache/tensorflow" \
           CGO_LDFLAGS="-L${{ matrix.libdir }} -ltensorflowlite_c" \
-          go vet -tags noembed,skipfrontend ./...
+          go vet -tags noembed,skipfrontend,"$BASE_BUILD_TAGS" ./...
 
   # Compile-coverage gate for the OpenVINO inference backend
   # (internal/inference/openvino, //go:build openvino). This is the fast, dedicated
@@ -191,7 +202,7 @@ jobs:
           CGO_ENABLED=1 CC=${{ matrix.cc }} \
           CGO_CFLAGS="-I${{ github.workspace }}/.cache/tensorflow -I${{ github.workspace }}/.cache/openvino/include" \
           CGO_LDFLAGS="-L${{ matrix.libdir }} -ltensorflowlite_c" \
-          go build -tags noembed,skipfrontend,openvino ./...
+          go build -tags noembed,skipfrontend,openvino,"$BASE_BUILD_TAGS" ./...
 
       - name: Vet (openvino tag, type-checks test files too)
         run: |
@@ -201,4 +212,4 @@ jobs:
           CGO_ENABLED=1 CC=${{ matrix.cc }} \
           CGO_CFLAGS="-I${{ github.workspace }}/.cache/tensorflow -I${{ github.workspace }}/.cache/openvino/include" \
           CGO_LDFLAGS="-L${{ matrix.libdir }} -ltensorflowlite_c" \
-          go vet -tags noembed,skipfrontend,openvino ./...
+          go vet -tags noembed,skipfrontend,openvino,"$BASE_BUILD_TAGS" ./...

--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -37,9 +37,10 @@ concurrency:
 
 env:
   # Must match BASE_BUILD_TAGS in Taskfile.yml, which is what the release and
-  # container builds actually use. Declared once here so the four build/vet
-  # steps below cannot drift apart from each other; keeping it in step with the
-  # Taskfile is still manual, so change both together.
+  # container builds actually use. Declared once here so the four build/vet steps
+  # below cannot drift apart from each other; keeping it in step with the Taskfile
+  # is still manual, and several other workflows carry the tag too, so see the
+  # BASE_BUILD_TAGS comment in Taskfile.yml for the full list to change together.
   BASE_BUILD_TAGS: goaac_simd
 
 jobs:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -52,7 +52,9 @@ jobs:
           # change. Linting only compiles, so the missing ffmpeg is irrelevant here.
           # No non-test file is gated on !integration, so this stays a strict superset of
           # the plain noembed,skipfrontend view and reports into the same summary below.
-          args: --build-tags=integration,pebble_e2e,noembed,skipfrontend,normcompare --output.checkstyle.path=golangci-lint-report.xml
+          # goaac_simd matches BASE_BUILD_TAGS in Taskfile.yml (and `task lint`), so
+          # this lane and a local pre-push lint compile the same configuration.
+          args: --build-tags=integration,pebble_e2e,noembed,skipfrontend,normcompare,goaac_simd --output.checkstyle.path=golangci-lint-report.xml
 
       - name: Generate lint summary
         if: always()

--- a/.github/workflows/golangci-test.yml
+++ b/.github/workflows/golangci-test.yml
@@ -37,6 +37,9 @@ env:
   # Number of parallel shards the portable unit suite is split across. Keep in
   # sync with the matrix below and the `NR % <N>` modulo in the shard step.
   UNIT_SHARDS: 4
+  # Must match BASE_BUILD_TAGS in Taskfile.yml (see the comment there for the
+  # full list of files that carry this tag and must change together).
+  BASE_BUILD_TAGS: goaac_simd
 
 jobs:
   golangci:
@@ -118,7 +121,7 @@ jobs:
           # Tags are kept identical to the `go test` step below so the enumerated
           # package set cannot drift from the tested one if a package ever becomes
           # build-tag conditional.
-          go list -tags noembed,skipfrontend,goaac_simd ./... \
+          go list -tags noembed,skipfrontend,"$BASE_BUILD_TAGS" ./... \
             | awk -v n="${UNIT_SHARDS}" -v s="${{ matrix.shard }}" 'NR % n == s' \
             > shard_pkgs.txt
           echo "Shard ${{ matrix.shard }} owns $(wc -l < shard_pkgs.txt) packages:"
@@ -145,7 +148,7 @@ jobs:
             --rerun-fails-max-failures=15 \
             --rerun-fails-report="rerun-unit-${{ matrix.shard }}.txt" \
             --packages "${PKGS[*]}" \
-            -- -tags noembed,skipfrontend,goaac_simd -race -short -timeout 300s
+            -- -tags noembed,skipfrontend,$BASE_BUILD_TAGS -race -short -timeout 300s
         timeout-minutes: 12
 
       - name: Cleanup any remaining processes

--- a/.github/workflows/golangci-test.yml
+++ b/.github/workflows/golangci-test.yml
@@ -115,7 +115,10 @@ jobs:
           # `go list` order is deterministic for a given checkout, so the split is
           # stable, and new packages are picked up automatically (no hand-curated
           # lists to maintain). noembed,skipfrontend skip model/frontend embedding.
-          go list -tags noembed,skipfrontend ./... \
+          # Tags are kept identical to the `go test` step below so the enumerated
+          # package set cannot drift from the tested one if a package ever becomes
+          # build-tag conditional.
+          go list -tags noembed,skipfrontend,goaac_simd ./... \
             | awk -v n="${UNIT_SHARDS}" -v s="${{ matrix.shard }}" 'NR % n == s' \
             > shard_pkgs.txt
           echo "Shard ${{ matrix.shard }} owns $(wc -l < shard_pkgs.txt) packages:"
@@ -142,7 +145,7 @@ jobs:
             --rerun-fails-max-failures=15 \
             --rerun-fails-report="rerun-unit-${{ matrix.shard }}.txt" \
             --packages "${PKGS[*]}" \
-            -- -tags noembed,skipfrontend -race -short -timeout 300s
+            -- -tags noembed,skipfrontend,goaac_simd -race -short -timeout 300s
         timeout-minutes: 12
 
       - name: Cleanup any remaining processes

--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -148,7 +148,12 @@ jobs:
           # -ltensorflowlite_c, so the rpath/library are harmlessly duplicated)
           # into JSON output events whose content crashes gotestfmt's tokenizer.
           # Failed tests are printed below and in the job summary instead.
-          go test -tags noembed,skipfrontend -race -json -v -short -timeout 900s ./... > gotest.log 2>&1
+          # goaac_simd matches BASE_BUILD_TAGS in Taskfile.yml. darwin/arm64 is a
+          # shipped release target that cannot be cross-compiled from Linux, so this
+          # is the ONLY job that compiles and runs its SIMD kernels (which include
+          # hand-written NEON assembly and a darwin-specific CPU-detection path)
+          # before a release build would.
+          go test -tags noembed,skipfrontend,goaac_simd -race -json -v -short -timeout 900s ./... > gotest.log 2>&1
           TEST_EXIT_CODE=$?
           grep '"Action":"fail"' gotest.log | jq -r 'select(.Test) | "FAIL  \(.Package)  \(.Test)"' | sort -u || true
 

--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -148,11 +148,14 @@ jobs:
           # -ltensorflowlite_c, so the rpath/library are harmlessly duplicated)
           # into JSON output events whose content crashes gotestfmt's tokenizer.
           # Failed tests are printed below and in the job summary instead.
-          # goaac_simd matches BASE_BUILD_TAGS in Taskfile.yml. darwin/arm64 is a
-          # shipped release target that cannot be cross-compiled from Linux, so this
-          # is the ONLY job that compiles and runs its SIMD kernels (which include
-          # hand-written NEON assembly and a darwin-specific CPU-detection path)
-          # before a release build would.
+          # goaac_simd matches BASE_BUILD_TAGS in Taskfile.yml, so the AAC tests
+          # build the kernels the shipped darwin/arm64 binary uses. The NEON
+          # assembly itself is not darwin-specific (f32_arm64.s is //go:build
+          # arm64, so the linux/arm64 cross-build compiles it too); what only this
+          # job covers is the darwin CPU-detection path (simd/cpu/cpu_arm64_darwin.go)
+          # and actually EXECUTING the kernels on Apple silicon.
+          # Note this job is advisory: it is continue-on-error and runs on a PR only
+          # with the full-ci label, so it informs rather than gates.
           go test -tags noembed,skipfrontend,goaac_simd -race -json -v -short -timeout 900s ./... > gotest.log 2>&1
           TEST_EXIT_CODE=$?
           grep '"Action":"fail"' gotest.log | jq -r 'select(.Test) | "FAIL  \(.Package)  \(.Test)"' | sort -u || true

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -168,8 +168,11 @@ jobs:
           # ~2000 tests) intermittently exceeded the old 600s per-package ceiling
           # under runner load (cumulative race-instrumented work, not a deadlock).
           # 900s adds headroom and stays under the 25m step cap below.
-          # goaac_simd matches BASE_BUILD_TAGS in Taskfile.yml, so the AAC tests run
-          # the same kernels the shipped windows/amd64 binary uses.
+          # goaac_simd matches BASE_BUILD_TAGS in Taskfile.yml, so the AAC tests
+          # compile the same kernel set the shipped windows/amd64 binary does.
+          # Which kernel actually executes still depends on the runner's CPU
+          # features (AVX2 for the trellis, AVX/SSE2 for AbsPow34), not on the tag.
+          # This job is advisory: continue-on-error, and on a PR it needs full-ci.
           go test -tags noembed,skipfrontend,goaac_simd -race -json -v -short -timeout 900s ./... > gotest.log 2>&1
           TEST_EXIT_CODE=$?
           grep '"Action":"fail"' gotest.log | jq -r 'select(.Test) | "FAIL  \(.Package)  \(.Test)"' | sort -u || true

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -168,7 +168,9 @@ jobs:
           # ~2000 tests) intermittently exceeded the old 600s per-package ceiling
           # under runner load (cumulative race-instrumented work, not a deadlock).
           # 900s adds headroom and stays under the 25m step cap below.
-          go test -tags noembed,skipfrontend -race -json -v -short -timeout 900s ./... > gotest.log 2>&1
+          # goaac_simd matches BASE_BUILD_TAGS in Taskfile.yml, so the AAC tests run
+          # the same kernels the shipped windows/amd64 binary uses.
+          go test -tags noembed,skipfrontend,goaac_simd -race -json -v -short -timeout 900s ./... > gotest.log 2>&1
           TEST_EXIT_CODE=$?
           grep '"Action":"fail"' gotest.log | jq -r 'select(.Test) | "FAIL  \(.Package)  \(.Test)"' | sort -u || true
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -145,7 +145,7 @@ tasks:
       # binaries use, so a tag-specific failure cannot pass here and fail in CI.
       # CGO_FLAGS supplies CGO_ENABLED=1 and the TensorFlow header include path;
       # -race needs CGO so it must stay enabled here.
-      - '{{.CGO_FLAGS}} go test -tags noembed,skipfrontend,{{.BASE_BUILD_TAGS}} -race ./... {{.TEST_FLAGS}}'
+      - '{{.CGO_FLAGS}} go test -tags noembed,skipfrontend{{if .BASE_BUILD_TAGS}},{{.BASE_BUILD_TAGS}}{{end}} -race ./... {{.TEST_FLAGS}}'
     vars:
       TEST_FLAGS: '{{default "" .CLI_ARGS}}'
 
@@ -163,7 +163,7 @@ tasks:
       - mkdir -p coverage
       # Use noembed,skipfrontend tags to skip model and frontend embedding for faster tests
       # Keep -race in sync with the test task so coverage runs catch data races too.
-      - '{{.CGO_FLAGS}} go test -tags noembed,skipfrontend,{{.BASE_BUILD_TAGS}} -race ./... -coverprofile=coverage/coverage.out {{.TEST_FLAGS}}'
+      - '{{.CGO_FLAGS}} go test -tags noembed,skipfrontend{{if .BASE_BUILD_TAGS}},{{.BASE_BUILD_TAGS}}{{end}} -race ./... -coverprofile=coverage/coverage.out {{.TEST_FLAGS}}'
       - go tool cover -html=coverage/coverage.out -o coverage/coverage.html
     vars:
       TEST_FLAGS: '{{default "" .CLI_ARGS}}'
@@ -182,7 +182,7 @@ tasks:
         esac
         # Use noembed,skipfrontend tags to skip model and frontend embedding for faster linting
         {{.CGO_FLAGS}} CGO_LDFLAGS="-L${LIB_DIR} -ltensorflowlite_c" \
-        golangci-lint run --build-tags=noembed,skipfrontend,{{.BASE_BUILD_TAGS}} {{.CLI_ARGS}}
+        golangci-lint run --build-tags=noembed,skipfrontend{{if .BASE_BUILD_TAGS}},{{.BASE_BUILD_TAGS}}{{end}} {{.CLI_ARGS}}
     vars:
       CLI_ARGS: '{{default "-v" .CLI_ARGS}}'
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -75,6 +75,16 @@ vars:
   # these in, or a target silently ships a different binary than the rest.
   # (tools/dbexport is deliberately exempt: it never reaches go-aac.)
   #
+  # CI carries the same tag so the checks compile what ships, and nothing
+  # enforces that automatically. Change these together:
+  #   .github/workflows/cross-platform-build.yml  (env: BASE_BUILD_TAGS)
+  #   .github/workflows/golangci-test.yml         (env: BASE_BUILD_TAGS)
+  #   .github/workflows/golangci-lint.yml         (literal; it is a
+  #                                                workflow_call target and does
+  #                                                not inherit the caller's env)
+  #   .github/workflows/macos-test.yml            (literal)
+  #   .github/workflows/windows-test.yml          (literal)
+  #
   # goaac_simd selects go-aac's SIMD kernels, which are opt-in upstream so that
   # the default build carries no assembly. It swaps exactly two hot kernels: the
   # NMR Viterbi trellis (f32.MinIdxOfSumRows) and the AbsPow34 magnitude
@@ -92,10 +102,12 @@ vars:
   # would not be caught here.
   #
   # Measured on a Raspberry Pi 5 (Cortex-A76), medians of -benchtime=2s -count=5
-  # over internal/audiocore/hlsmux BenchmarkStreamWrite: 11.2% faster for 10 ms
-  # frames, 12.8% for 32 KiB. That path is encode plus fMP4 fragmentation, so the
-  # encoder-only gain is higher; go-aac's README reports 14% for the trellis alone
-  # on the same hardware. Both consumers (native AAC clip export and native HLS)
+  # over internal/audiocore/hlsmux BenchmarkStreamWrite10ms and
+  # BenchmarkStreamWrite32k: 11.2% and 12.8% faster respectively. Those cover
+  # encode plus fMP4 fragmentation, so the encoder-only gain is larger by an
+  # unmeasured margin. (go-aac's README reports 14% on the same hardware, but for
+  # the trellis kernel alone; it lists the both-kernels figure as pending, so it
+  # is not directly comparable.) Both consumers (native AAC clip export, native HLS)
   # are still opt-in behind BIRDNET_AAC_ENCODER / BIRDNET_HLS_ENCODER=native, so
   # today this speeds up those gated paths rather than a default deployment.
   BASE_BUILD_TAGS: 'goaac_simd'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -70,10 +70,48 @@ vars:
   OPENVINO_HEADERS_DIR: '{{.ROOT_DIR}}/.cache/openvino'
   CGO_FLAGS: CGO_ENABLED=1 CGO_CFLAGS="-I{{.TENSORFLOW_HEADERS_DIR}} -I{{.OPENVINO_HEADERS_DIR}}/include"
   EXTRA_BUILD_TAGS: '{{.EXTRA_BUILD_TAGS | default ""}}'
+  # Tags applied to every artifact we ship, independent of the caller-supplied
+  # EXTRA_BUILD_TAGS. Every build path that produces a shipped binary must fold
+  # these in, or a target silently ships a different binary than the rest.
+  # (tools/dbexport is deliberately exempt: it never reaches go-aac.)
+  #
+  # goaac_simd selects go-aac's SIMD kernels, which are opt-in upstream so that
+  # the default build carries no assembly. It swaps exactly two hot kernels: the
+  # NMR Viterbi trellis (f32.MinIdxOfSumRows) and the AbsPow34 magnitude
+  # transform. Dispatch is by CPU feature at RUNTIME, via github.com/tphakala/simd
+  # (which wraps golang.org/x/sys/cpu and adds its own darwin/arm64 detection):
+  # the trellis takes AVX2 on amd64 and NEON on arm64, AbsPow34 takes AVX, else
+  # SSE2, on amd64 and NEON on arm64. Every kernel falls back to pure Go when the
+  # feature bit is absent, and f32_other.go covers architectures that are neither
+  # amd64 nor arm64, so a tagged binary runs unchanged on any CPU rather than
+  # trapping on an unsupported instruction.
+  #
+  # Output is bit-identical to the scalar path; go-aac gates both kernels with
+  # bitwise differential tests plus fuzz targets. Note those tests live upstream
+  # and do not run in our CI, so a go-aac bump that regressed only the SIMD path
+  # would not be caught here.
+  #
+  # Measured on a Raspberry Pi 5 (Cortex-A76), medians of -benchtime=2s -count=5
+  # over internal/audiocore/hlsmux BenchmarkStreamWrite: 11.2% faster for 10 ms
+  # frames, 12.8% for 32 KiB. That path is encode plus fMP4 fragmentation, so the
+  # encoder-only gain is higher; go-aac's README reports 14% for the trellis alone
+  # on the same hardware. Both consumers (native AAC clip export and native HLS)
+  # are still opt-in behind BIRDNET_AAC_ENCODER / BIRDNET_HLS_ENCODER=native, so
+  # today this speeds up those gated paths rather than a default deployment.
+  BASE_BUILD_TAGS: 'goaac_simd'
+  # Emits nothing when the joined list is empty, mirroring the ${BUILD_TAGS:+...}
+  # guard on the linux_amd64 / linux_arm64 build lines. (noembed_build needs no
+  # such guard: its list always contains noembed.) Without this, overriding
+  # BASE_BUILD_TAGS to empty would emit a bare `-tags`, which then swallows the
+  # following -ldflags and fails with a confusing "flag provided but not defined".
   BUILD_TAGS_FLAG:
     sh: |
-      if [ -n "{{.EXTRA_BUILD_TAGS}}" ]; then
-        echo "-tags {{.EXTRA_BUILD_TAGS}}"
+      TAGS="{{.BASE_BUILD_TAGS}}"
+      EXTRA="{{.EXTRA_BUILD_TAGS}}"
+      TAGS="${TAGS:+${TAGS},}${EXTRA}"
+      TAGS="${TAGS%,}"
+      if [ -n "${TAGS}" ]; then
+        echo "-tags ${TAGS}"
       fi
   LDFLAGS: -ldflags "-s -w -X 'main.buildDate={{.BUILD_DATE}}' -X 'main.version={{.VERSION}}' -X 'github.com/tphakala/birdnet-go/internal/telemetry.sentryDSN={{.SENTRY_DSN}}' -X 'github.com/tphakala/birdnet-go/internal/branding.projectName={{.PROJECT_NAME}}' -X 'github.com/tphakala/birdnet-go/internal/branding.projectRepoURL={{.PROJECT_REPO_URL}}' -X 'github.com/tphakala/birdnet-go/internal/branding.projectCommunityURL={{.PROJECT_COMMUNITY_URL}}'"
   BUILD_FLAGS: '{{.BUILD_TAGS_FLAG}} {{.LDFLAGS}}'
@@ -90,10 +128,12 @@ tasks:
   test:
     desc: Run tests for the application
     cmds:
-      # Use noembed,skipfrontend tags to skip model and frontend embedding for faster tests
+      # Use noembed,skipfrontend tags to skip model and frontend embedding for faster tests.
+      # BASE_BUILD_TAGS keeps the local run on the same kernels CI and the shipped
+      # binaries use, so a tag-specific failure cannot pass here and fail in CI.
       # CGO_FLAGS supplies CGO_ENABLED=1 and the TensorFlow header include path;
       # -race needs CGO so it must stay enabled here.
-      - '{{.CGO_FLAGS}} go test -tags noembed,skipfrontend -race ./... {{.TEST_FLAGS}}'
+      - '{{.CGO_FLAGS}} go test -tags noembed,skipfrontend,{{.BASE_BUILD_TAGS}} -race ./... {{.TEST_FLAGS}}'
     vars:
       TEST_FLAGS: '{{default "" .CLI_ARGS}}'
 
@@ -111,7 +151,7 @@ tasks:
       - mkdir -p coverage
       # Use noembed,skipfrontend tags to skip model and frontend embedding for faster tests
       # Keep -race in sync with the test task so coverage runs catch data races too.
-      - '{{.CGO_FLAGS}} go test -tags noembed,skipfrontend -race ./... -coverprofile=coverage/coverage.out {{.TEST_FLAGS}}'
+      - '{{.CGO_FLAGS}} go test -tags noembed,skipfrontend,{{.BASE_BUILD_TAGS}} -race ./... -coverprofile=coverage/coverage.out {{.TEST_FLAGS}}'
       - go tool cover -html=coverage/coverage.out -o coverage/coverage.html
     vars:
       TEST_FLAGS: '{{default "" .CLI_ARGS}}'
@@ -130,7 +170,7 @@ tasks:
         esac
         # Use noembed,skipfrontend tags to skip model and frontend embedding for faster linting
         {{.CGO_FLAGS}} CGO_LDFLAGS="-L${LIB_DIR} -ltensorflowlite_c" \
-        golangci-lint run --build-tags=noembed,skipfrontend {{.CLI_ARGS}}
+        golangci-lint run --build-tags=noembed,skipfrontend,{{.BASE_BUILD_TAGS}} {{.CLI_ARGS}}
     vars:
       CLI_ARGS: '{{default "-v" .CLI_ARGS}}'
 
@@ -1183,9 +1223,9 @@ tasks:
         mkdir -p {{.TFLITE_LIB_DIR}}
         # openvino adds the OpenVINO inference backend (dlopen'd at runtime, ORT
         # fallback); headers are provided by the check-openvino task above.
-        BUILD_TAGS=""
+        BUILD_TAGS="{{.BASE_BUILD_TAGS}}"
         if [ "{{.OPENVINO}}" = "true" ]; then
-          BUILD_TAGS="openvino"
+          BUILD_TAGS="${BUILD_TAGS:+${BUILD_TAGS},}openvino"
         fi
         # go-task exposes EXTRA_BUILD_TAGS as a template var, not a shell env var,
         # so read it via templating (works for both `task ... EXTRA_BUILD_TAGS=x`
@@ -1225,9 +1265,9 @@ tasks:
         fi
         # openvino adds the OpenVINO inference backend (dlopen'd at runtime, ORT
         # fallback); headers are provided by the check-openvino task above.
-        BUILD_TAGS=""
+        BUILD_TAGS="{{.BASE_BUILD_TAGS}}"
         if [ "{{.OPENVINO}}" = "true" ]; then
-          BUILD_TAGS="openvino"
+          BUILD_TAGS="${BUILD_TAGS:+${BUILD_TAGS},}openvino"
         fi
         # go-task exposes EXTRA_BUILD_TAGS as a template var, not a shell env var,
         # so read it via templating (works for both `task ... EXTRA_BUILD_TAGS=x`
@@ -1356,7 +1396,8 @@ tasks:
         {{else if .CC}}
         export CC={{.CC}}
         {{end}}
-        BUILD_TAGS="noembed"
+        BUILD_TAGS="{{.BASE_BUILD_TAGS}}"
+        BUILD_TAGS="${BUILD_TAGS:+${BUILD_TAGS},}noembed"
         # notflite produces an ONNX-only binary that does not link libtensorflowlite_c.
         if [ "{{.NOTFLITE}}" = "true" ]; then
           BUILD_TAGS="${BUILD_TAGS},notflite"


### PR DESCRIPTION
go-aac gates its SIMD kernels behind an opt-in `goaac_simd` build tag, so its default build carries no assembly. We never set that tag, so every binary we have shipped runs the scalar fallback.

## Measurement

Raspberry Pi 5 (Cortex-A76, arm64), go-aac v0.4.0, `internal/audiocore/hlsmux` benchmarks, `-benchtime=2s -count=5`, medians:

| Benchmark | scalar (today) | `goaac_simd` | Gain |
| --- | ---: | ---: | ---: |
| `BenchmarkStreamWrite10ms` | 233,867 ns/op (4.10 MB/s) | 207,653 ns/op (4.62 MB/s) | 11.2% |
| `BenchmarkStreamWrite32k` | 8,105,357 ns/op (4.04 MB/s) | 7,071,652 ns/op (4.63 MB/s) | 12.8% |

Allocations are 0/op on both, so this is pure compute. That benchmark covers encode plus fMP4 fragmentation, so the encoder-only gain is higher; go-aac's README reports 14% for the trellis kernel alone on the same hardware. Both go-aac consumers benefit: native AAC clip export and native HLS live streaming.

## Why it is safe on every platform we ship

The tag selects a dispatch layer, not a fixed instruction set. `tphakala/simd` picks the kernel at **runtime** from CPU feature bits, so an amd64 host without AVX2 takes the scalar path rather than trapping:

- trellis (`f32.MinIdxOfSumRows`): AVX2 on amd64, NEON on arm64, else pure Go
- `AbsPow34`: AVX, else SSE2, on amd64; NEON on arm64; else pure Go
- `f32_other.go` (`//go:build !amd64 && !arm64`) covers everything else

Output is bit-identical to the scalar path, which go-aac gates with bitwise differential tests plus fuzz targets. Verified during review by encoding a deterministic multi-tone signal and hashing the bitstream: identical with the tag, without it, and with SIMD force-disabled, on an AVX2+FMA host.

No new dependency: `tphakala/simd` is already a direct require and already linked via `internal/audiocore/audionorm`. `go list -deps` output is unchanged by the tag.

Verified compiling with the tag for linux/amd64, linux/arm64, windows/amd64, darwin/arm64, darwin/amd64, plus linux/arm, linux/386 and linux/riscv64 for anyone building from source.

## What changed

`BASE_BUILD_TAGS` in the Taskfile, applied to every build path that produces a shipped binary, folded into all four tag-composition shapes: `BUILD_TAGS_FLAG` (windows, darwin), the `linux_amd64` and `linux_arm64` shell blocks, and `noembed_build` (Docker plus the noembed targets). `tools/dbexport` stays exempt since it never reaches go-aac.

The checks are updated so they compile what we ship:

- `cross-platform-build` builds and vets with the tag, so a break surfaces on a PR instead of during a release build. Declared once as a workflow-level `env` var so the four steps cannot drift apart from each other.
- `macos-test` gains the tag. darwin/arm64 is a shipped target that cannot be cross-compiled from Linux, so this is the **only** job that compiles its NEON kernels and darwin-specific CPU detection before a release would.
- `windows-test` and the Linux unit lane gain it, so at least one race run per OS exercises the kernels users actually get.
- `task test`, `task test-coverage` and `task lint` gain it, so a local pre-push run cannot pass on tags that differ from CI.

`BUILD_TAGS_FLAG` now emits nothing when the joined tag list is empty, mirroring the guard the linux build lines already use, so overriding `BASE_BUILD_TAGS` to empty no longer emits a bare `-tags` that swallows the following `-ldflags`.

## Verification

Real `task noembed_linux_amd64` and `task linux_amd64` builds emit `-tags=noembed,goaac_simd,openvino` and `-tags=goaac_simd,openvino` respectively. Tag composition was checked across the full cross-product of OPENVINO on/off, NOTFLITE on/off, `EXTRA_BUILD_TAGS` set/unset and an empty `BASE_BUILD_TAGS` override: no dropped tags, no malformed lists. `golangci-lint` clean and `internal/audiocore/...` plus `internal/api/v2/audio` tests pass under the new tag set.

## Follow-up

Nothing in this repo pins the encoder's output bytes, so a future go-aac or simd bump that regressed only the SIMD path would not be caught here; go-aac's differential tests live upstream and do not run in our CI. Tracked separately.