### PR TITLE
perf(hlsmux): serve the HLS playlist from a lock-free snapshot

### DIFF
--- a/internal/api/v2/audio/audio_hls_native.go
+++ b/internal/api/v2/audio/audio_hls_native.go
@@ -412,15 +412,20 @@ func (c *Handler) serveNativePlaylist(ctx echo.Context, sourceID string, stream 
 	ctx.Response().Header().Set("Content-Type", "application/vnd.apple.mpegurl")
 	ctx.Response().Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 
-	playlist := stream.mux.Playlist()
+	// Stats first, then the playlist. Both read the muxer's snapshot without a
+	// lock, so a segment cut can land between them; taking Stats first makes
+	// Retained a lower bound on what the playlist below advertises rather than
+	// an upper one. That is the safe direction: an extra Retry-After on a
+	// playlist that has just gained its first segment is ignored by a client
+	// that can already start, while a missing one on a genuinely empty playlist
+	// is the case the hint exists for.
 	stats := stream.mux.Stats()
+	playlist := stream.mux.Playlist()
 
 	c.checkNativeStreamFreshness(sourceID, &stats)
 
 	// Tell a client polling before the first segment how long to wait, matching
-	// what the FFmpeg path does with its placeholder playlist. Retained comes
-	// from the same Stats already sampled, so the answer is consistent with the
-	// playlist just rendered rather than read at a third instant.
+	// what the FFmpeg path does with its placeholder playlist.
 	if stats.Retained == 0 {
 		ctx.Response().Header().Set("Retry-After", strconv.Itoa(c.getEffectiveSegmentLength()))
 	}

--- a/internal/api/v2/audio/audio_hls_native.go
+++ b/internal/api/v2/audio/audio_hls_native.go
@@ -412,15 +412,12 @@ func (c *Handler) serveNativePlaylist(ctx echo.Context, sourceID string, stream 
 	ctx.Response().Header().Set("Content-Type", "application/vnd.apple.mpegurl")
 	ctx.Response().Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 
-	// Stats first, then the playlist. Both read the muxer's snapshot without a
-	// lock, so a segment cut can land between them; taking Stats first makes
-	// Retained a lower bound on what the playlist below advertises rather than
-	// an upper one. That is the safe direction: an extra Retry-After on a
-	// playlist that has just gained its first segment is ignored by a client
-	// that can already start, while a missing one on a genuinely empty playlist
-	// is the case the hint exists for.
-	stats := stream.mux.Stats()
-	playlist := stream.mux.Playlist()
+	// One snapshot for both, rather than a Playlist call and a Stats call that
+	// could land either side of a segment cut. Retained is then exactly the
+	// segment count of the playlist being served, not a count from a
+	// neighbouring instant that the Retry-After decision below would have to
+	// treat as a bound.
+	playlist, stats := stream.mux.PlaylistAndStats()
 
 	c.checkNativeStreamFreshness(sourceID, &stats)
 
@@ -462,6 +459,14 @@ func (c *Handler) checkNativeStreamFreshness(sourceID string, stats *hlsmux.Stat
 			logger.String("newest_segment_age", age.Round(time.Second).String()),
 			logger.String("stale_threshold", staleAfter.String()),
 			logger.Uint64("segments_cut", stats.Segments),
+			// Both of these separate a source that has genuinely stopped from
+			// one that is merely running slow. Drift grows without bound while
+			// a source delivers less audio than real time, and a rising
+			// discontinuity count means the muxer has already been re-anchoring
+			// the timeline. Without them a stall warning says only that
+			// segments stopped, not why.
+			logger.String("drift_correction", stats.DriftCorrection.Round(time.Millisecond).String()),
+			logger.Uint64("discontinuities", stats.Discontinuities),
 			logger.Bool("encode_failed", stats.Failed))
 	}
 }
@@ -470,7 +475,7 @@ func (c *Handler) checkNativeStreamFreshness(sourceID string, stats *hlsmux.Stat
 func (c *Handler) serveNativeContent(ctx echo.Context, stream *HLSStreamInfo, requestPath string) error {
 	// Traversal is unreachable here because nothing below this line touches a
 	// filesystem: the name is either matched against a literal or parsed to a
-	// sequence number and looked up in an in-memory ring. That, not the check
+	// sequence number and looked up in an in-memory segment window. That, not the check
 	// immediately below, is what makes securefs unnecessary. The separator
 	// rejection is defence in depth, and a reminder that any future branch which
 	// did resolve a name against disk would need securefs rather than this.
@@ -524,8 +529,8 @@ func (c *Handler) serveNativeBytes(ctx echo.Context, name string, data []byte, m
 }
 
 // waitForNativePlaylist polls until the muxer advertises enough segments for
-// immediate playback, mirroring the FFmpeg path's wait but reading the ring
-// directly instead of a file that this path never writes.
+// immediate playback, mirroring the FFmpeg path's wait but reading the muxer's
+// published snapshot instead of a file that this path never writes.
 //
 // The segment count matters: hls.js needs two fragments before it calls play(),
 // so returning after one costs the client a full playlist reload cycle, which

--- a/internal/api/v2/audio/audio_hls_native.go
+++ b/internal/api/v2/audio/audio_hls_native.go
@@ -475,8 +475,8 @@ func (c *Handler) checkNativeStreamFreshness(sourceID string, stats *hlsmux.Stat
 func (c *Handler) serveNativeContent(ctx echo.Context, stream *HLSStreamInfo, requestPath string) error {
 	// Traversal is unreachable here because nothing below this line touches a
 	// filesystem: the name is either matched against a literal or parsed to a
-	// sequence number and looked up in an in-memory segment window. That, not the check
-	// immediately below, is what makes securefs unnecessary. The separator
+	// sequence number and looked up in an in-memory segment window. That, not
+	// the check immediately below, is what makes securefs unnecessary. The separator
 	// rejection is defence in depth, and a reminder that any future branch which
 	// did resolve a name against disk would need securefs rather than this.
 	if requestPath == "" || strings.ContainsAny(requestPath, `/\`) {

--- a/internal/api/v2/audio/audio_hls_native_test.go
+++ b/internal/api/v2/audio/audio_hls_native_test.go
@@ -42,7 +42,7 @@ func newNativeMux(t *testing.T) *hlsmux.Stream {
 	return mux
 }
 
-// newEmptyNativeStream is for tests that never touch the media ring, so they do
+// newEmptyNativeStream is for tests that never touch the media window, so they do
 // not pay for encoding audio they will not read.
 func newEmptyNativeStream(t *testing.T) *HLSStreamInfo {
 	t.Helper()

--- a/internal/audiocore/hlsmux/bench_test.go
+++ b/internal/audiocore/hlsmux/bench_test.go
@@ -1,9 +1,82 @@
 package hlsmux
 
 import (
+	"strconv"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
+
+const (
+	// benchFramesPerSecond is how many capture buffers a second of audio is
+	// delivered in when a benchmark needs a source running at real time. A
+	// hundred models the ~10 ms period a sound card hands over.
+	benchFramesPerSecond = 100
+
+	// benchToneHz is the test signal. Real signal rather than silence, because
+	// an encoder handed pure zeros produces degenerate frames and a
+	// correspondingly unrepresentative segment size.
+	benchToneHz = 3000
+
+	// benchPollInterval paces each viewer in BenchmarkStreamWriteUnderPoll. It
+	// is chosen so that the largest audience in benchViewerCounts generates
+	// enough polls to keep a serialising lock busy most of the time, while
+	// leaving the machine far from CPU saturation: 64 viewers at 200 us is
+	// 320k polls a second, which is most of a core's worth of work when a poll
+	// costs microseconds under a shared mutex and negligible when it does not.
+	benchPollInterval = 200 * time.Microsecond
+)
+
+// benchViewerCounts is the audience axis. It is the axis that matters on the
+// read side and the one no other benchmark here varies: the encoder is per
+// source, so one muxer serves every viewer of a stream and encode cost does not
+// grow with audience at all. Playlist polling is the only path that does.
+var benchViewerCounts = []int{1, 2, 4, 8, 16, 64}
+
+// newBenchStream builds a stream over the shipping AAC codec, so write-side
+// timings stay comparable with the deployed measurements rather than with a
+// fake whose cost is arbitrary.
+func newBenchStream(b *testing.B) *Stream {
+	b.Helper()
+
+	s, err := New(&Config{
+		Codec:       AACLC(),
+		SampleRate:  testRate,
+		Channels:    testChannels,
+		BitrateKbps: testBitrate,
+	})
+	if err != nil {
+		b.Fatalf("new stream: %v", err)
+	}
+	b.Cleanup(func() {
+		if err := s.Close(); err != nil {
+			b.Errorf("close: %v", err)
+		}
+	})
+	return s
+}
+
+// fillWindow feeds enough audio to fill the playlist window and returns the
+// timestamp the next write should carry. A read benchmark against an empty
+// window would measure a header and nothing else.
+func fillWindow(b *testing.B, s *Stream) time.Time {
+	b.Helper()
+
+	pcm := tone(testRate, testChannels, testRate, benchToneHz)
+	at := testEpoch
+	// One second per write and DefaultSegmentDuration per segment, plus a
+	// couple of extra seconds so the window is certainly full rather than one
+	// cut short of it.
+	seconds := DefaultWindowSize*int(DefaultSegmentDuration/time.Second) + 2
+	for range seconds {
+		if err := s.Write(pcm, at); err != nil {
+			b.Fatalf("write: %v", err)
+		}
+		at = at.Add(time.Second)
+	}
+	return at
+}
 
 // Benchmarks for the per-frame encode path.
 //
@@ -64,38 +137,234 @@ func BenchmarkStreamWrite10ms(b *testing.B) {
 // whole pipe reads.
 func BenchmarkStreamWrite32k(b *testing.B) { benchFrame(b, 32768) }
 
-// BenchmarkPlaylistRender covers the read side, which every viewer polls once
-// per target duration and which contends with the encode path for the stream
-// mutex.
-func BenchmarkPlaylistRender(b *testing.B) {
-	s, err := New(&Config{
-		Codec:       AACLC(),
-		SampleRate:  testRate,
-		Channels:    testChannels,
-		BitrateKbps: testBitrate,
-	})
-	if err != nil {
-		b.Fatalf("new stream: %v", err)
-	}
-	b.Cleanup(func() {
-		if err := s.Close(); err != nil {
-			b.Errorf("close: %v", err)
-		}
-	})
+// BenchmarkStreamWriteSegmentCut isolates the segment-cadence allocation spike
+// that BenchmarkStreamWrite* cannot see, by carrying one segment's worth of
+// audio per write so that every iteration cuts almost exactly one segment.
+//
+// The per-segment allocation is by design and must not be driven to zero:
+// cutSegment hands its destination to HTTP handlers that may still be reading
+// it, so the arena can never be reused. What this pins is its SIZE, which the
+// segBufHint pre-sizing is what keeps at one allocation instead of the eight a
+// nil destination would grow through.
+func BenchmarkStreamWriteSegmentCut(b *testing.B) {
+	s := newBenchStream(b)
 
-	// Fill the window so the render walks a realistic segment list.
-	pcm := tone(testRate, testChannels, testRate, 3000)
+	samples := int(DefaultSegmentDuration * testRate / time.Second)
+	pcm := tone(samples, testChannels, testRate, benchToneHz)
 	at := testEpoch
-	for range 14 {
+
+	b.SetBytes(int64(len(pcm)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
 		if err := s.Write(pcm, at); err != nil {
 			b.Fatalf("write: %v", err)
 		}
-		at = at.Add(time.Second)
+		at = at.Add(DefaultSegmentDuration)
 	}
+}
+
+// BenchmarkPlaylistRender covers the read side, which every viewer polls once
+// per target duration.
+func BenchmarkPlaylistRender(b *testing.B) {
+	s := newBenchStream(b)
+	fillWindow(b, s)
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
 		_ = s.Playlist()
+	}
+}
+
+// benchPoll measures one playlist poll with viewers polling concurrently, which
+// is the only shape that shows what an audience costs. A single-goroutine
+// render benchmark cannot: the question is not what a render costs but what N
+// readers cost each other, and what they cost against a source that is encoding
+// at the same time.
+func benchPoll(b *testing.B, viewers int, writing bool) {
+	b.Helper()
+
+	s := newBenchStream(b)
+	at := fillWindow(b, s)
+
+	if writing {
+		startBenchWriter(b, s, at)
+	}
+
+	// A shared counter rather than an even split of b.N, so every viewer stays
+	// alive for the whole run and the contention level really is `viewers`
+	// throughout instead of decaying as the faster goroutines retire.
+	var remaining atomic.Int64
+	remaining.Store(int64(b.N))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	var pollers sync.WaitGroup
+	for range viewers {
+		pollers.Go(func() {
+			for remaining.Add(-1) >= 0 {
+				_ = s.Playlist()
+			}
+		})
+	}
+	pollers.Wait()
+	b.StopTimer()
+}
+
+// startBenchWriter runs a source encoding into s at real time until the
+// benchmark ends.
+//
+// Real time, not flat out: a writer with no pacing would hold the mutex
+// continuously and compete for CPU, measuring a situation that never occurs. A
+// live source occupies a low single-digit duty cycle, and it is the
+// interference at that duty cycle which the deferral of this optimisation was
+// argued on.
+func startBenchWriter(b *testing.B, s *Stream, at time.Time) {
+	b.Helper()
+
+	pcm := tone(testRate/benchFramesPerSecond, testChannels, testRate, benchToneHz)
+	step := time.Second / benchFramesPerSecond
+	stop := make(chan struct{})
+
+	var writer sync.WaitGroup
+	writer.Go(func() {
+		tick := time.NewTicker(step)
+		defer tick.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-tick.C:
+				if err := s.Write(pcm, at); err != nil {
+					b.Errorf("write: %v", err)
+					return
+				}
+				at = at.Add(step)
+			}
+		}
+	})
+
+	// Registered after newBenchStream's cleanup, so LIFO order stops the writer
+	// before the stream it writes to is closed.
+	b.Cleanup(func() {
+		close(stop)
+		writer.Wait()
+	})
+}
+
+// BenchmarkPlaylistPoll measures the read path on its own, which is what every
+// viewer pays once per segment.
+func BenchmarkPlaylistPoll(b *testing.B) {
+	for _, viewers := range benchViewerCounts {
+		b.Run("viewers="+strconv.Itoa(viewers), func(b *testing.B) {
+			benchPoll(b, viewers, false)
+		})
+	}
+}
+
+// BenchmarkPlaylistPollUnderWrite adds a source encoding at real time beside
+// the viewers, so the read side and the write side contend for the stream mutex
+// exactly as they do in production.
+func BenchmarkPlaylistPollUnderWrite(b *testing.B) {
+	for _, viewers := range benchViewerCounts {
+		b.Run("viewers="+strconv.Itoa(viewers), func(b *testing.B) {
+			benchPoll(b, viewers, true)
+		})
+	}
+}
+
+// startBenchPollers runs viewers polling the playlist on benchPollInterval
+// until the benchmark ends.
+func startBenchPollers(b *testing.B, s *Stream, viewers int) {
+	b.Helper()
+
+	stop := make(chan struct{})
+	var pollers sync.WaitGroup
+	for range viewers {
+		pollers.Go(func() {
+			tick := time.NewTicker(benchPollInterval)
+			defer tick.Stop()
+			for {
+				select {
+				case <-stop:
+					return
+				case <-tick.C:
+					_ = s.Playlist()
+				}
+			}
+		})
+	}
+	b.Cleanup(func() {
+		close(stop)
+		pollers.Wait()
+	})
+}
+
+// BenchmarkStreamWriteUnderPoll measures the capture goroutine's cost while
+// viewers poll, which is the coupling that matters most on this path. Write
+// runs on the audio thread, where added latency is not lost throughput but a
+// dropped buffer, and every poll used to take the same mutex Write needs.
+//
+// The pollers are rate limited rather than run flat out, and the rate is the
+// measurement. Flat-out pollers do not measure this: with a mutex in the way
+// they park and consume almost no CPU, and without one they spin at tens of
+// millions of polls a second and saturate every core, so removing the mutex
+// scores as a large regression on a machine with fewer cores than viewers. That
+// is an artefact of an infinite poll rate, not of the muxer. Pacing separates
+// the two, leaving lock interference as the only thing that varies.
+//
+// benchPollInterval is still thousands of times faster than the roughly 0.5 Hz
+// per viewer hls.js actually uses, so this remains a stress bound and not a
+// production shape. The mean poll rate was never the risk; polls arriving
+// together are.
+func BenchmarkStreamWriteUnderPoll(b *testing.B) {
+	for _, viewers := range benchViewerCounts {
+		b.Run("viewers="+strconv.Itoa(viewers), func(b *testing.B) {
+			s := newBenchStream(b)
+			at := fillWindow(b, s)
+			startBenchPollers(b, s, viewers)
+
+			pcm := tone(testRate/benchFramesPerSecond, testChannels, testRate, benchToneHz)
+			step := time.Second / benchFramesPerSecond
+
+			b.SetBytes(int64(len(pcm)))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				if err := s.Write(pcm, at); err != nil {
+					b.Fatalf("write: %v", err)
+				}
+				at = at.Add(step)
+			}
+		})
+	}
+}
+
+// BenchmarkSegmentLookup measures the window's linear scan at the shipping
+// window size and at two larger ones, to establish empirically where the scan
+// stops being free rather than arguing about it.
+//
+// It looks up the NEWEST segment, which is both the worst case for a scan that
+// starts at the oldest and what a client keeping up with the live edge actually
+// requests.
+func BenchmarkSegmentLookup(b *testing.B) {
+	for _, size := range []int{DefaultWindowSize, 60, 600} {
+		b.Run("window="+strconv.Itoa(size), func(b *testing.B) {
+			r := newSegmentWindow(size)
+			for i := range size {
+				r.push(&Segment{Seq: uint64(i)}) //nolint:gosec // loop bound is a small positive literal
+			}
+			newest := uint64(size - 1) //nolint:gosec // as above
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				if _, ok := findSegment(r.retained(), newest); !ok {
+					b.Fatal("newest segment must be retained")
+				}
+			}
+		})
 	}
 }

--- a/internal/audiocore/hlsmux/bench_test.go
+++ b/internal/audiocore/hlsmux/bench_test.go
@@ -25,7 +25,18 @@ const (
 	// leaving the machine far from CPU saturation: 64 viewers at 200 us is
 	// 320k polls a second, which is most of a core's worth of work when a poll
 	// costs microseconds under a shared mutex and negligible when it does not.
+	//
+	// The rate a ticker at this period actually achieves is well under the
+	// nominal one, because 200 us is at the scheduler's practical floor and
+	// dropped ticks are silent. BenchmarkStreamWriteUnderPoll therefore reports
+	// the achieved polls/s as a metric, so a starved run is visible rather than
+	// indistinguishable from a healthy one.
 	benchPollInterval = 200 * time.Microsecond
+
+	// benchClaimBatch is how many iterations a viewer claims from the shared
+	// counter at once in benchPoll. See the comment there: at one claim per
+	// iteration the counter costs more than the operation being measured.
+	benchClaimBatch = 512
 )
 
 // benchViewerCounts is the audience axis. It is the axis that matters on the
@@ -87,33 +98,27 @@ func fillWindow(b *testing.B, s *Stream) time.Time {
 // gets bumped routinely. A 10x encode regression from such a bump would
 // otherwise ship silently.
 //
-// B/op is the signal worth watching, not allocs/op. The design deliberately
-// allocates a fresh destination per segment (cutSegment: published bytes are
-// handed to HTTP handlers that may still be reading them), so allocs/op reads 0
-// only because one allocation per ~94 writes rounds down. A regression in the
-// per-write path shows up in B/op first.
+// Read the per-write numbers knowing that a segment cut is amortised into them,
+// and that the cut is not cheap in allocation terms even though it is cheap in
+// time. Each cut allocates the published segment (one, deliberately: those
+// bytes go to HTTP handlers that may still be reading them, so the arena can
+// never be reused), the copy-on-write window slice, the snapshot, and the
+// playlist render, for roughly 16 allocations and 1 KB beyond the segment
+// itself, once per segment per stream.
+//
+// So allocs/op is NOT uniformly zero here and a non-zero value is not by itself
+// a regression: BenchmarkStreamWrite32k reports 2 because a 32 KiB write is
+// 8192 samples against a ~95000-sample segment, so a cut lands every dozen
+// writes. What to watch is a change in the amortised value at a fixed shape,
+// and B/op on the shapes that cut rarely.
 
 // benchFrame sizes one router delivery. Both shapes occur in production: the
 // sound-card path delivers ~10 ms periods, the RTSP path a 32 KiB pipe read.
 func benchFrame(b *testing.B, frameBytes int) {
 	b.Helper()
 
-	s, err := New(&Config{
-		Codec:       AACLC(),
-		SampleRate:  testRate,
-		Channels:    testChannels,
-		BitrateKbps: testBitrate,
-	})
-	if err != nil {
-		b.Fatalf("new stream: %v", err)
-	}
-	b.Cleanup(func() {
-		if err := s.Close(); err != nil {
-			b.Errorf("close: %v", err)
-		}
-	})
-
-	pcm := tone(frameBytes/(testChannels*bytesPerSample), testChannels, testRate, 3000)
+	s := newBenchStream(b)
+	pcm := tone(frameBytes/(testChannels*bytesPerSample), testChannels, testRate, benchToneHz)
 	at := testEpoch
 	step := time.Duration(len(pcm)/(testChannels*bytesPerSample)) * time.Second / testRate
 
@@ -164,8 +169,15 @@ func BenchmarkStreamWriteSegmentCut(b *testing.B) {
 	}
 }
 
-// BenchmarkPlaylistRender covers the read side, which every viewer polls once
-// per target duration.
+// BenchmarkPlaylistRender is the uncontended cost of one playlist poll.
+//
+// The name is now a misnomer and is kept deliberately: nothing renders here any
+// more, because the playlist is rendered once per segment cut and a poll is an
+// atomic load. Keeping the name is what lets benchstat pair this against the
+// pre-change measurement, where it really did render. Quote THIS benchmark for
+// what a poll costs; BenchmarkPlaylistPoll answers a different question (how
+// that cost behaves as the audience grows) and carries its harness in the
+// number.
 func BenchmarkPlaylistRender(b *testing.B) {
 	s := newBenchStream(b)
 	fillWindow(b, s)
@@ -195,6 +207,15 @@ func benchPoll(b *testing.B, viewers int, writing bool) {
 	// A shared counter rather than an even split of b.N, so every viewer stays
 	// alive for the whole run and the contention level really is `viewers`
 	// throughout instead of decaying as the faster goroutines retire.
+	//
+	// Claimed in batches, which is not a micro-optimisation but the difference
+	// between measuring the muxer and measuring this loop. A poll is now a
+	// single atomic load of a few nanoseconds, while claiming one iteration at
+	// a time is a LOCK XADD on a line contended by every viewer, which costs
+	// several times more. Per-iteration claiming made this benchmark report
+	// 6-27 ns/op for an operation that measures 0.6 ns uncontended, i.e. over
+	// 90 percent harness, and left it unable to tell a tenfold regression from
+	// a tenfold win.
 	var remaining atomic.Int64
 	remaining.Store(int64(b.N))
 
@@ -204,13 +225,22 @@ func benchPoll(b *testing.B, viewers int, writing bool) {
 	var pollers sync.WaitGroup
 	for range viewers {
 		pollers.Go(func() {
-			for remaining.Add(-1) >= 0 {
-				_ = s.Playlist()
+			for {
+				claimed := remaining.Add(-benchClaimBatch)
+				if claimed <= -benchClaimBatch {
+					return
+				}
+				n := benchClaimBatch
+				if claimed < 0 {
+					n = benchClaimBatch + int(claimed)
+				}
+				for range n {
+					_ = s.Playlist()
+				}
 			}
 		})
 	}
 	pollers.Wait()
-	b.StopTimer()
 }
 
 // startBenchWriter runs a source encoding into s at real time until the
@@ -276,22 +306,32 @@ func BenchmarkPlaylistPollUnderWrite(b *testing.B) {
 }
 
 // startBenchPollers runs viewers polling the playlist on benchPollInterval
-// until the benchmark ends.
-func startBenchPollers(b *testing.B, s *Stream, viewers int) {
+// until the benchmark ends, and returns the total poll count so the caller can
+// report the rate actually achieved.
+//
+// The count is not bookkeeping. A ticker at benchPollInterval drops ticks
+// silently under load, so the nominal rate is an upper bound the run may fall
+// far short of, and a starved run would otherwise look exactly like a healthy
+// one in the output.
+func startBenchPollers(b *testing.B, s *Stream, viewers int) *atomic.Int64 {
 	b.Helper()
 
+	var polls atomic.Int64
 	stop := make(chan struct{})
 	var pollers sync.WaitGroup
 	for range viewers {
 		pollers.Go(func() {
 			tick := time.NewTicker(benchPollInterval)
 			defer tick.Stop()
+			local := int64(0)
+			defer func() { polls.Add(local) }()
 			for {
 				select {
 				case <-stop:
 					return
 				case <-tick.C:
 					_ = s.Playlist()
+					local++
 				}
 			}
 		})
@@ -300,6 +340,7 @@ func startBenchPollers(b *testing.B, s *Stream, viewers int) {
 		close(stop)
 		pollers.Wait()
 	})
+	return &polls
 }
 
 // BenchmarkStreamWriteUnderPoll measures the capture goroutine's cost while
@@ -324,7 +365,7 @@ func BenchmarkStreamWriteUnderPoll(b *testing.B) {
 		b.Run("viewers="+strconv.Itoa(viewers), func(b *testing.B) {
 			s := newBenchStream(b)
 			at := fillWindow(b, s)
-			startBenchPollers(b, s, viewers)
+			polls := startBenchPollers(b, s, viewers)
 
 			pcm := tone(testRate/benchFramesPerSecond, testChannels, testRate, benchToneHz)
 			step := time.Second / benchFramesPerSecond
@@ -338,6 +379,10 @@ func BenchmarkStreamWriteUnderPoll(b *testing.B) {
 				}
 				at = at.Add(step)
 			}
+			b.StopTimer()
+
+			// The load this run actually applied, not the load it asked for.
+			b.ReportMetric(float64(polls.Load())/b.Elapsed().Seconds(), "polls/s")
 		})
 	}
 }

--- a/internal/audiocore/hlsmux/bench_test.go
+++ b/internal/audiocore/hlsmux/bench_test.go
@@ -20,17 +20,17 @@ const (
 	benchToneHz = 3000
 
 	// benchPollInterval paces each viewer in BenchmarkStreamWriteUnderPoll. It
-	// is chosen so that the largest audience in benchViewerCounts generates
-	// enough polls to keep a serialising lock busy most of the time, while
-	// leaving the machine far from CPU saturation: 64 viewers at 200 us is
-	// 320k polls a second, which is most of a core's worth of work when a poll
-	// costs microseconds under a shared mutex and negligible when it does not.
+	// is chosen to generate enough polls to keep a serialising lock busy while
+	// leaving the machine far from CPU saturation, which is the separation the
+	// benchmark needs: a poll costing microseconds under a shared mutex is
+	// most of a core's worth of work at this rate, and negligible without one.
 	//
-	// The rate a ticker at this period actually achieves is well under the
-	// nominal one, because 200 us is at the scheduler's practical floor and
-	// dropped ticks are silent. BenchmarkStreamWriteUnderPoll therefore reports
-	// the achieved polls/s as a metric, so a starved run is visible rather than
-	// indistinguishable from a healthy one.
+	// Do not read the nominal rate as the applied one. 200 us is at the
+	// scheduler's practical floor, dropped ticks are silent, and the achieved
+	// rate measures around a fifth of nominal (roughly 1k polls/s per viewer,
+	// not 5k). That is why BenchmarkStreamWriteUnderPoll reports the achieved
+	// polls/s: the load is a property of the machine, so a starved run has to
+	// be visible rather than indistinguishable from a healthy one.
 	benchPollInterval = 200 * time.Microsecond
 
 	// benchClaimBatch is how many iterations a viewer claims from the shared
@@ -100,17 +100,23 @@ func fillWindow(b *testing.B, s *Stream) time.Time {
 //
 // Read the per-write numbers knowing that a segment cut is amortised into them,
 // and that the cut is not cheap in allocation terms even though it is cheap in
-// time. Each cut allocates the published segment (one, deliberately: those
-// bytes go to HTTP handlers that may still be reading them, so the arena can
-// never be reused), the copy-on-write window slice, the snapshot, and the
-// playlist render, for roughly 16 allocations and 1 KB beyond the segment
-// itself, once per segment per stream.
+// time. Beyond the published segment itself (one allocation, deliberately:
+// those bytes go to HTTP handlers that may still be reading them, so the arena
+// can never be reused), each cut allocates the copy-on-write window slice, the
+// snapshot, and the playlist render: measured at 15 allocations and about
+// 1.6 KB, once per segment per stream.
 //
 // So allocs/op is NOT uniformly zero here and a non-zero value is not by itself
 // a regression: BenchmarkStreamWrite32k reports 2 because a 32 KiB write is
 // 8192 samples against a ~95000-sample segment, so a cut lands every dozen
 // writes. What to watch is a change in the amortised value at a fixed shape,
 // and B/op on the shapes that cut rarely.
+//
+// One drift to know about when pairing runs: strconv's no-allocation fast path
+// for small integers stops at 100, so SegmentName starts allocating once a
+// stream passes roughly 200 segments. The per-cut figure therefore rises with
+// stream age, and two runs at different -benchtime are not directly
+// comparable.
 
 // benchFrame sizes one router delivery. Both shapes occur in production: the
 // sound-card path delivers ~10 ms periods, the RTSP path a 32 KiB pipe read.
@@ -305,20 +311,27 @@ func BenchmarkPlaylistPollUnderWrite(b *testing.B) {
 	}
 }
 
-// startBenchPollers runs viewers polling the playlist on benchPollInterval
-// until the benchmark ends, and returns the total poll count so the caller can
-// report the rate actually achieved.
+// startBenchPollers runs viewers polling the playlist on benchPollInterval and
+// returns a function that stops them and reports the rate they actually
+// achieved, in polls per second.
 //
-// The count is not bookkeeping. A ticker at benchPollInterval drops ticks
+// The rate is not bookkeeping. A ticker at benchPollInterval drops ticks
 // silently under load, so the nominal rate is an upper bound the run may fall
 // far short of, and a starved run would otherwise look exactly like a healthy
 // one in the output.
-func startBenchPollers(b *testing.B, s *Stream, viewers int) *atomic.Int64 {
+//
+// The caller must invoke the returned function before reporting the metric.
+// Reading a counter the poller goroutines publish on exit does not work: they
+// exit when the stop channel closes, which a b.Cleanup does, and cleanups run
+// after the benchmark body has already returned. A metric read in the body
+// would be zero every time, which is the same blindness this exists to remove.
+func startBenchPollers(b *testing.B, s *Stream, viewers int) func() float64 {
 	b.Helper()
 
 	var polls atomic.Int64
 	stop := make(chan struct{})
 	var pollers sync.WaitGroup
+	started := time.Now()
 	for range viewers {
 		pollers.Go(func() {
 			tick := time.NewTicker(benchPollInterval)
@@ -336,11 +349,22 @@ func startBenchPollers(b *testing.B, s *Stream, viewers int) *atomic.Int64 {
 			}
 		})
 	}
-	b.Cleanup(func() {
-		close(stop)
+
+	var once sync.Once
+	halt := func() float64 {
+		once.Do(func() { close(stop) })
 		pollers.Wait()
-	})
-	return &polls
+		// The pollers' own lifetime, not b.Elapsed: they start before the timer
+		// is reset, so dividing by the measured interval would overstate the
+		// rate they sustained.
+		if elapsed := time.Since(started).Seconds(); elapsed > 0 {
+			return float64(polls.Load()) / elapsed
+		}
+		return 0
+	}
+	// Idempotent, so the cleanup is a no-op once the caller has stopped them.
+	b.Cleanup(func() { _ = halt() })
+	return halt
 }
 
 // BenchmarkStreamWriteUnderPoll measures the capture goroutine's cost while
@@ -365,7 +389,7 @@ func BenchmarkStreamWriteUnderPoll(b *testing.B) {
 		b.Run("viewers="+strconv.Itoa(viewers), func(b *testing.B) {
 			s := newBenchStream(b)
 			at := fillWindow(b, s)
-			polls := startBenchPollers(b, s, viewers)
+			stopPollers := startBenchPollers(b, s, viewers)
 
 			pcm := tone(testRate/benchFramesPerSecond, testChannels, testRate, benchToneHz)
 			step := time.Second / benchFramesPerSecond
@@ -382,7 +406,7 @@ func BenchmarkStreamWriteUnderPoll(b *testing.B) {
 			b.StopTimer()
 
 			// The load this run actually applied, not the load it asked for.
-			b.ReportMetric(float64(polls.Load())/b.Elapsed().Seconds(), "polls/s")
+			b.ReportMetric(stopPollers(), "polls/s")
 		})
 	}
 }

--- a/internal/audiocore/hlsmux/codec_aac_test.go
+++ b/internal/audiocore/hlsmux/codec_aac_test.go
@@ -181,7 +181,7 @@ func TestAACLCStreamProducesPlayableSegments(t *testing.T) {
 	assert.Contains(t, playlist, "#EXT-X-PROGRAM-DATE-TIME")
 	assert.NotContains(t, playlist, "CODECS",
 		"CODECS belongs to a master playlist; this is a media playlist")
-	assert.Equal(t, strings.Count(playlist, "#EXTINF"), s.segments.len())
+	assert.Len(t, s.segments.retained(), strings.Count(playlist, "#EXTINF"))
 }
 
 // stubEncoder reports a fixed decoder config and priming without encoding

--- a/internal/audiocore/hlsmux/fake_test.go
+++ b/internal/audiocore/hlsmux/fake_test.go
@@ -56,6 +56,15 @@ type fakeEncoder struct {
 	// lookahead frame back until the stream ends.
 	tailSamples int
 
+	// flushHook runs inside Flush, immediately after the tail access unit has
+	// been handed to the muxer. That is the one instant at which a test can
+	// observe what a reader would see PART WAY through Close: the tail may have
+	// forced a segment cut, and that cut publishes a snapshot, while Close has
+	// not yet published its own final one. Since the read side takes no lock,
+	// the hook can call straight into Playlist or Stats from here even though
+	// the stream mutex is held.
+	flushHook func()
+
 	// failAfter, when positive, makes the encoder fail once it has emitted
 	// that many access units.
 	failAfter int
@@ -123,7 +132,13 @@ func (f *fakeEncoder) Flush(emit EmitFunc) error {
 	}
 	samples := f.tailSamples
 	f.tailSamples = 0
-	return f.emitOne(samples, emit)
+	if err := f.emitOne(samples, emit); err != nil {
+		return err
+	}
+	if f.flushHook != nil {
+		f.flushHook()
+	}
+	return nil
 }
 
 func (f *fakeEncoder) DecoderConfig() []byte { return make([]byte, flacStreamInfoLen) }
@@ -141,6 +156,7 @@ type fakeCodecOptions struct {
 	delay       int
 	tailSamples int
 	failAfter   int
+	flushHook   func()
 
 	// flushErr and closeErr make the encoder's teardown fail.
 	flushErr error
@@ -190,6 +206,7 @@ func newFakeCodec(opts *fakeCodecOptions) Codec {
 				delay:       opts.delay,
 				tailSamples: opts.tailSamples,
 				failAfter:   opts.failAfter,
+				flushHook:   opts.flushHook,
 				flushErr:    opts.flushErr,
 				closeErr:    opts.closeErr,
 			}

--- a/internal/audiocore/hlsmux/fake_test.go
+++ b/internal/audiocore/hlsmux/fake_test.go
@@ -62,7 +62,14 @@ type fakeEncoder struct {
 	// forced a segment cut, and that cut publishes a snapshot, while Close has
 	// not yet published its own final one. Since the read side takes no lock,
 	// the hook can call straight into Playlist or Stats from here even though
-	// the stream mutex is held.
+	// the stream mutex is held. That is a hard dependency, not a convenience:
+	// sync.Mutex is not reentrant, so if any read path ever takes it again this
+	// self-deadlocks, and the symptom is a test-binary timeout rather than a
+	// failed assertion.
+	//
+	// It runs only after a tail unit was emitted, so a stream configured with
+	// no tail, or one whose flush fails, never calls it. A test relying on the
+	// hook must assert that it ran.
 	flushHook func()
 
 	// failAfter, when positive, makes the encoder fail once it has emitted

--- a/internal/audiocore/hlsmux/hlsmux.go
+++ b/internal/audiocore/hlsmux/hlsmux.go
@@ -162,16 +162,17 @@ type view struct {
 // Stream encodes and muxes one live audio source into HLS media segments and
 // the playlist indexing them, holding everything in memory.
 //
-// Write is called from the audio feed goroutine; Playlist, Segment, Stats and
-// InitSegment are called from HTTP handlers. All of them are safe to call
-// concurrently, and the read side takes no lock at all: it reads a snapshot
+// Write is called from the audio feed goroutine; the read side (Playlist,
+// PlaylistAndStats, Segment, Ready, Stats and InitSegment) is called from HTTP
+// handlers. All of them are safe to call concurrently, and the read side takes
+// no lock at all: it reads a snapshot
 // republished on each segment cut, so an audience of any size can never delay
 // the goroutine encoding for it. See the view type.
 type Stream struct {
-	// view is the read side's snapshot; see the type. It is the only thing
-	// Playlist, Segment and Ready touch, and it supplies every Stats field
-	// except the two below, which is what keeps every reader off mu. Stored
-	// only from publishView, under mu.
+	// view is the read side's snapshot; see the type. Every reader goes through
+	// it and nothing else, which is what keeps them all off mu: it is the whole
+	// of Playlist, Segment and Ready, and every Stats field except the two
+	// below. Stored only from publishView, under mu.
 	view atomic.Pointer[view]
 
 	// driftCorrection and failed are the two Stats fields the segment window
@@ -611,8 +612,12 @@ func (s *Stream) cutSegment() error {
 		s.discontinuities++
 	}
 	s.segments.push(&Segment{
-		Seq:              s.nextSeq,
-		Data:             data,
+		Seq: s.nextSeq,
+		// Capacity clipped to length for the same reason segmentWindow.retained
+		// clips: segBufHint deliberately over-sizes the arena, so an unclipped
+		// slice would let a handler's append write into bytes another handler
+		// is still streaming.
+		Data:             data[:len(data):len(data)],
 		Samples:          s.pendingSamples,
 		Duration:         duration,
 		PDT:              s.segPDT,
@@ -641,8 +646,9 @@ func (s *Stream) cutSegment() error {
 //
 // It must be called with s.mu held, or before the Stream has been handed to any
 // other goroutine, and after any change to the segment window or to the
-// counters Stats reports. Missing one leaves every reader on a stale snapshot
-// indefinitely, with no error anywhere.
+// counters the view carries. Missing one leaves every reader on a stale
+// snapshot indefinitely, with no error anywhere. DriftCorrection and Failed are
+// deliberately outside the view and so are not among them; see their fields.
 //
 // ended is passed rather than read from s.closed because the two are not the
 // same event. Close sets s.closed before flushing the encoder, so that a Write

--- a/internal/audiocore/hlsmux/hlsmux.go
+++ b/internal/audiocore/hlsmux/hlsmux.go
@@ -3,6 +3,7 @@ package hlsmux
 import (
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	m4a "github.com/tphakala/go-m4a"
@@ -134,23 +135,70 @@ type Stats struct {
 	Failed bool
 }
 
+// view is the read side's snapshot of everything the segment window determines:
+// the rendered playlist, the window itself, and the counters Stats reports from
+// it. It is rebuilt once per segment cut and published behind an atomic
+// pointer, so reading any of it costs one atomic load.
+//
+// The alternative, rendering per poll under the stream mutex, is what this
+// replaces. Both halves of that were wasteful. The playlist only changes when a
+// segment is cut, so every poll in between rebuilt a byte-identical string; and
+// it did so holding the mutex Write needs, which puts an HTTP handler in the
+// way of the capture goroutine. The asymmetry that makes it worth removing is
+// that the encoder is per SOURCE: one muxer serves every viewer of a stream, so
+// encode cost is fixed however large the audience grows, while polling is the
+// one path that grows with it.
+//
+// Every field is immutable once stored. segments aliases the slice
+// segmentWindow.push has finished with and will never write into again.
+type view struct {
+	playlist        string
+	segments        []Segment
+	nextSeq         uint64
+	discontinuities uint64
+	lastSegmentPDT  time.Time
+}
+
 // Stream encodes and muxes one live audio source into HLS media segments and
 // the playlist indexing them, holding everything in memory.
 //
 // Write is called from the audio feed goroutine; Playlist, Segment, Stats and
 // InitSegment are called from HTTP handlers. All of them are safe to call
-// concurrently.
+// concurrently, and the read side takes no lock at all: it reads a snapshot
+// republished on each segment cut, so an audience of any size can never delay
+// the goroutine encoding for it. See the view type.
 type Stream struct {
+	// view is the read side's snapshot; see the type. It is the only thing
+	// Playlist, Segment, Ready and Stats touch, which is what keeps every
+	// reader off mu. Stored only from publishView, under mu.
+	view atomic.Pointer[view]
+
+	// driftCorrection and failed are the two Stats fields the segment window
+	// does not determine, so they cannot live in the view: one moves on every
+	// write and the other latches at an arbitrary one. They are atomics so that
+	// Stats stays lock free; both are still written only under mu, so the write
+	// side needs no compare-and-swap.
+	//
+	// driftCorrection, in nanoseconds, is the total the projected sample clock
+	// has been nudged toward the arriving timestamps. It only grows in one
+	// direction while a source runs persistently fast or slow, so a caller
+	// watching it can tell steady clock error (bounded, harmless) from
+	// sustained audio loss (unbounded), which the stall threshold alone cannot
+	// distinguish because the absorber is what stops the latter from ever
+	// reaching it.
+	driftCorrection atomic.Int64
+	failed          atomic.Bool
+
 	// mu guards everything below it. The critical sections are short: an
-	// encode plus a buffer append on the write side, a render or a lookup on
-	// the read side.
+	// encode plus a buffer append on the write side, and a render plus a
+	// pointer swap on a segment cut. Readers never take it.
 	mu sync.Mutex
 
 	codecName string
 	enc       FrameEncoder
 	frag      *m4a.FragmentWriter
 	initSeg   []byte
-	segments  *ring
+	segments  *segmentWindow
 
 	// appendSegment flushes the fragment writer into a finished segment. It is
 	// a field rather than a direct s.frag call so a test can drive the failure
@@ -199,14 +247,6 @@ type Stream struct {
 	// arrives is how a source stall is detected.
 	nextSampleTime time.Time
 
-	// driftCorrection is the total the projected sample clock has been nudged
-	// toward the arriving timestamps. It only grows in one direction while a
-	// source runs persistently fast or slow, so a caller watching it can tell
-	// steady clock error (bounded, harmless) from sustained audio loss
-	// (unbounded), which the stall threshold alone cannot distinguish because
-	// the absorber is what stops the latter from ever reaching it.
-	driftCorrection time.Duration
-
 	// discontinuities counts the timeline breaks so far, and pendingBreak
 	// records that the next segment cut begins a new timeline.
 	discontinuities uint64
@@ -217,7 +257,6 @@ type Stream struct {
 	segBufHint int
 
 	started bool
-	failed  bool
 	closed  bool
 }
 
@@ -330,7 +369,7 @@ func New(cfg *Config) (*Stream, error) {
 		enc:                enc,
 		frag:               frag,
 		initSeg:            initSeg,
-		segments:           newRing(windowSize),
+		segments:           newSegmentWindow(windowSize),
 		targetSamples:      targetSamples,
 		maxSegmentDuration: segmentDuration,
 		targetDuration:     ceilSeconds(segmentDuration),
@@ -341,6 +380,10 @@ func New(cfg *Config) (*Stream, error) {
 	}
 	s.emit = s.appendAccessUnit
 	s.appendSegment = frag.AppendSegment
+	// Publish the first snapshot before the Stream is handed to anyone, so a
+	// reader never loads a nil view and a poll arriving before the first
+	// segment is cut still learns the init segment from EXT-X-MAP.
+	s.publishView()
 	return s, nil
 }
 
@@ -437,7 +480,7 @@ func (s *Stream) Write(pcm []byte, ts time.Time) error {
 	switch {
 	case s.closed:
 		return validationErr("hlsmux: write to a closed stream")
-	case s.failed:
+	case s.failed.Load():
 		return validationErr("hlsmux: write to a stream that failed encoding")
 	case ts.IsZero():
 		return validationErr("hlsmux: write with a zero capture timestamp")
@@ -456,7 +499,7 @@ func (s *Stream) Write(pcm []byte, ts time.Time) error {
 	s.nextSampleTime = s.nextSampleTime.Add(s.inClock.advance(len(pcm) / s.frameBytes))
 
 	if err := s.enc.EncodeInterleaved(pcm, s.emit); err != nil {
-		s.failed = true
+		s.failed.Store(true)
 		return s.audioErr(err)
 	}
 	return nil
@@ -483,7 +526,7 @@ func (s *Stream) syncTimeline(ts time.Time) error {
 		// the observed time so a steady clock difference cannot accumulate
 		// into a false stall.
 		s.nextSampleTime = s.nextSampleTime.Add(gap >> driftCorrectionShift)
-		s.driftCorrection += gap >> driftCorrectionShift
+		s.driftCorrection.Add(int64(gap >> driftCorrectionShift))
 		return nil
 	}
 
@@ -499,7 +542,7 @@ func (s *Stream) syncTimeline(ts time.Time) error {
 			// the write as successful: a caller that kept feeding would build
 			// every later segment on a timeline whose break was never
 			// published.
-			s.failed = true
+			s.failed.Store(true)
 			return err
 		}
 	}
@@ -581,7 +624,34 @@ func (s *Stream) cutSegment() error {
 	s.segPDT = s.segPDT.Add(duration)
 	s.nextSeq++
 	s.pendingSamples = 0
+
+	// Last, once every field the snapshot reads is settled. A cut is the only
+	// thing that changes what a reader can see, apart from the stream ending,
+	// so this is also the only place the render happens.
+	s.publishView()
 	return nil
+}
+
+// publishView rebuilds the read-side snapshot and swaps it in.
+//
+// It must be called with s.mu held, or before the Stream has been handed to any
+// other goroutine, and it must be called after every change a reader can
+// observe: a segment cut, and the transition to closed that adds
+// EXT-X-ENDLIST.
+//
+// The render it costs runs on the capture goroutine rather than on an HTTP
+// handler, which is the one thing this trades away. It is worth it at any
+// audience above one: the render happens once per segment instead of once per
+// poll, and a segment is two seconds of a goroutine that spends single-digit
+// milliseconds per second encoding.
+func (s *Stream) publishView() {
+	s.view.Store(&view{
+		playlist:        renderPlaylist(s.segments, s.targetDuration, s.closed),
+		segments:        s.segments.retained(),
+		nextSeq:         s.nextSeq,
+		discontinuities: s.discontinuities,
+		lastSegmentPDT:  s.lastSegmentPDT,
+	})
 }
 
 // Close drains the encoder, publishes whatever audio remains as a final
@@ -599,12 +669,17 @@ func (s *Stream) Close() error {
 	s.closed = true
 
 	var flushErr error
-	if !s.failed {
+	if !s.failed.Load() {
 		flushErr = s.enc.Flush(s.emit)
 		if flushErr == nil && s.pendingSamples > 0 {
 			flushErr = s.cutSegment()
 		}
 	}
+
+	// Unconditionally, including when the flush failed: EXT-X-ENDLIST is what
+	// stops a client polling forever, and a stream that could not publish its
+	// last segment still has to stop advertising itself as live.
+	s.publishView()
 
 	closeErr := s.enc.Close()
 	switch {
@@ -632,16 +707,16 @@ func (s *Stream) InitSegment() []byte {
 // It reports false once the segment has scrolled out of the window, which is
 // what a client that fell too far behind should see as a 404.
 func (s *Stream) Segment(seq uint64) (Segment, bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.segments.get(seq)
+	return findSegment(s.view.Load().segments, seq)
 }
 
-// Playlist renders the current HLS media playlist.
+// Playlist returns the current HLS media playlist.
+//
+// It is the snapshot taken when the last segment was cut rather than a fresh
+// render, because nothing between two cuts can change a byte of it. See the
+// view type for why that matters more than the render cost alone suggests.
 func (s *Stream) Playlist() string {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return renderPlaylist(s.segments, s.targetDuration, s.closed)
+	return s.view.Load().playlist
 }
 
 // Ready reports whether the playlist advertises at least n media segments.
@@ -651,21 +726,25 @@ func (s *Stream) Playlist() string {
 // handed a one-segment playlist spends a full reload cycle waiting, which is
 // audible as a delayed start.
 func (s *Stream) Ready(n int) bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.segments.len() >= n
+	return len(s.view.Load().segments) >= n
 }
 
 // Stats returns a point-in-time view of the stream's health.
+//
+// Each call is internally consistent, but Stats and Playlist read the snapshot
+// separately, so a caller making both calls can catch a segment cut between
+// them and see a Retained one ahead of the playlist it just read. No field here
+// is an invariant of the playlist, so there is nothing that can be observed
+// broken; a caller that needs the two to agree exactly should treat Retained as
+// a lower bound on what the playlist it holds advertises.
 func (s *Stream) Stats() Stats {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	v := s.view.Load()
 	return Stats{
-		Segments:        s.nextSeq,
-		Retained:        s.segments.len(),
-		Discontinuities: s.discontinuities,
-		LastSegmentPDT:  s.lastSegmentPDT,
-		DriftCorrection: s.driftCorrection,
-		Failed:          s.failed,
+		Segments:        v.nextSeq,
+		Retained:        len(v.segments),
+		Discontinuities: v.discontinuities,
+		LastSegmentPDT:  v.lastSegmentPDT,
+		DriftCorrection: time.Duration(s.driftCorrection.Load()),
+		Failed:          s.failed.Load(),
 	}
 }

--- a/internal/audiocore/hlsmux/hlsmux.go
+++ b/internal/audiocore/hlsmux/hlsmux.go
@@ -169,8 +169,9 @@ type view struct {
 // the goroutine encoding for it. See the view type.
 type Stream struct {
 	// view is the read side's snapshot; see the type. It is the only thing
-	// Playlist, Segment, Ready and Stats touch, which is what keeps every
-	// reader off mu. Stored only from publishView, under mu.
+	// Playlist, Segment and Ready touch, and it supplies every Stats field
+	// except the two below, which is what keeps every reader off mu. Stored
+	// only from publishView, under mu.
 	view atomic.Pointer[view]
 
 	// driftCorrection and failed are the two Stats fields the segment window
@@ -382,8 +383,11 @@ func New(cfg *Config) (*Stream, error) {
 	s.appendSegment = frag.AppendSegment
 	// Publish the first snapshot before the Stream is handed to anyone, so a
 	// reader never loads a nil view and a poll arriving before the first
-	// segment is cut still learns the init segment from EXT-X-MAP.
-	s.publishView()
+	// segment is cut still learns the init segment from EXT-X-MAP. Nothing may
+	// return between the literal above and this call; the readers dereference
+	// the view unguarded, so a Stream that escaped without one would panic on
+	// the first poll.
+	s.publishView(false)
 	return s, nil
 }
 
@@ -626,27 +630,38 @@ func (s *Stream) cutSegment() error {
 	s.pendingSamples = 0
 
 	// Last, once every field the snapshot reads is settled. A cut is the only
-	// thing that changes what a reader can see, apart from the stream ending,
-	// so this is also the only place the render happens.
-	s.publishView()
+	// thing that changes the window while the stream runs, so it is the only
+	// render the running stream needs; New seeds the first snapshot and Close
+	// republishes the last one.
+	s.publishView(false)
 	return nil
 }
 
 // publishView rebuilds the read-side snapshot and swaps it in.
 //
 // It must be called with s.mu held, or before the Stream has been handed to any
-// other goroutine, and it must be called after every change a reader can
-// observe: a segment cut, and the transition to closed that adds
-// EXT-X-ENDLIST.
+// other goroutine, and after any change to the segment window or to the
+// counters Stats reports. Missing one leaves every reader on a stale snapshot
+// indefinitely, with no error anywhere.
 //
-// The render it costs runs on the capture goroutine rather than on an HTTP
-// handler, which is the one thing this trades away. It is worth it at any
-// audience above one: the render happens once per segment instead of once per
-// poll, and a segment is two seconds of a goroutine that spends single-digit
-// milliseconds per second encoding.
-func (s *Stream) publishView() {
+// ended is passed rather than read from s.closed because the two are not the
+// same event. Close sets s.closed before flushing the encoder, so that a Write
+// racing the teardown is refused and a second Close cannot re-enter a codec
+// that has just panicked. But the flush can still cut a segment, and rendering
+// EXT-X-ENDLIST from s.closed at that moment would publish a terminated
+// playlist that is missing the very segment the flush is producing. A client
+// honouring the tag stops polling and never sees it. Only Close's own final
+// publish ends the playlist.
+//
+// The render costs the capture goroutine roughly 2.4 microseconds and 1 KB once
+// per segment, which is the one thing this design trades away: it moves work
+// off HTTP handlers onto the real-time thread. Measured against a two-second
+// segment on a goroutine that spends single-digit milliseconds per second
+// encoding, that is under a thousandth of the budget, and it replaces a render
+// per poll per viewer with one render per segment.
+func (s *Stream) publishView(ended bool) {
 	s.view.Store(&view{
-		playlist:        renderPlaylist(s.segments, s.targetDuration, s.closed),
+		playlist:        renderPlaylist(s.segments, s.targetDuration, ended),
 		segments:        s.segments.retained(),
 		nextSeq:         s.nextSeq,
 		discontinuities: s.discontinuities,
@@ -668,6 +683,20 @@ func (s *Stream) Close() error {
 	}
 	s.closed = true
 
+	// Deferred, and registered after the unlock so that it runs before it,
+	// still holding the mutex.
+	//
+	// Deferred rather than called inline because the flush below runs codec
+	// code that this project already assumes can panic: the HLS handler wraps
+	// this very call in a recover (see closeNativeMuxGuarded) for exactly that
+	// reason. An inline publish would be skipped by the unwind, and since
+	// s.closed is already set, the second Close returns early and nothing ever
+	// publishes again, leaving a dead stream advertising itself as live for as
+	// long as the process runs. It also covers the ordinary failure paths, so a
+	// stream that could not publish its last segment still stops clients
+	// polling.
+	defer s.publishView(true)
+
 	var flushErr error
 	if !s.failed.Load() {
 		flushErr = s.enc.Flush(s.emit)
@@ -675,11 +704,6 @@ func (s *Stream) Close() error {
 			flushErr = s.cutSegment()
 		}
 	}
-
-	// Unconditionally, including when the flush failed: EXT-X-ENDLIST is what
-	// stops a client polling forever, and a stream that could not publish its
-	// last segment still has to stop advertising itself as live.
-	s.publishView()
 
 	closeErr := s.enc.Close()
 	switch {
@@ -731,14 +755,36 @@ func (s *Stream) Ready(n int) bool {
 
 // Stats returns a point-in-time view of the stream's health.
 //
-// Each call is internally consistent, but Stats and Playlist read the snapshot
-// separately, so a caller making both calls can catch a segment cut between
-// them and see a Retained one ahead of the playlist it just read. No field here
-// is an invariant of the playlist, so there is nothing that can be observed
-// broken; a caller that needs the two to agree exactly should treat Retained as
-// a lower bound on what the playlist it holds advertises.
+// Segments, Retained, Discontinuities and LastSegmentPDT all come from one
+// snapshot and so agree with each other. DriftCorrection and Failed are sampled
+// separately, because neither is determined by a segment cut: one moves on
+// every write and the other latches at an arbitrary one. They can therefore be
+// a generation ahead of the other four, which is what a caller wants from them
+// anyway, since both report the liveness of the write side rather than the
+// contents of the playlist.
+//
+// Retained is the number of segments the playlist advertises, but only for the
+// playlist rendered from the SAME snapshot. A separate Playlist call may land
+// either side of a cut; use PlaylistAndStats when the two have to agree.
 func (s *Stream) Stats() Stats {
+	return s.statsFrom(s.view.Load())
+}
+
+// PlaylistAndStats returns the media playlist together with the stats
+// describing that exact playlist, from a single snapshot load.
+//
+// This is what a caller reporting on the playlist it is about to serve wants:
+// Retained is then exactly the number of segments in the returned playlist,
+// rather than a count from a neighbouring instant that has to be reasoned about
+// as a bound.
+func (s *Stream) PlaylistAndStats() (playlist string, stats Stats) {
 	v := s.view.Load()
+	return v.playlist, s.statsFrom(v)
+}
+
+// statsFrom builds the Stats a given snapshot describes, plus the two fields
+// the snapshot does not determine.
+func (s *Stream) statsFrom(v *view) Stats {
 	return Stats{
 		Segments:        v.nextSeq,
 		Retained:        len(v.segments),

--- a/internal/audiocore/hlsmux/hlsmux_test.go
+++ b/internal/audiocore/hlsmux/hlsmux_test.go
@@ -117,7 +117,7 @@ func TestSegmentsCutOnAccessUnitBoundaries(t *testing.T) {
 	const total = testRate * 6
 	writeSamples(t, s, total, testEpoch)
 
-	segs := s.segments.window()
+	segs := s.segments.retained()
 	require.NotEmpty(t, segs)
 
 	target := s.targetSamples
@@ -144,14 +144,14 @@ func TestDurationsAccumulateWithoutDrift(t *testing.T) {
 	s := newTestStream(t, &fakeCodecOptions{
 		frameSizes: []int{aacFrame},
 	})
-	s.segments = newRing(1000)
+	s.segments = newSegmentWindow(1000)
 
 	const total = testRate * 600 // ten minutes
 	writeSamples(t, s, total, testEpoch)
 
 	var sumSamples int
 	var sumDuration time.Duration
-	for _, seg := range s.segments.window() {
+	for _, seg := range s.segments.retained() {
 		sumSamples += seg.Samples
 		sumDuration += seg.Duration
 	}
@@ -167,11 +167,11 @@ func TestProgramDateTimeTracksTheSampleTimeline(t *testing.T) {
 	t.Parallel()
 
 	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
-	s.segments = newRing(1000)
+	s.segments = newSegmentWindow(1000)
 
 	writeSamples(t, s, testRate*10, testEpoch)
 
-	segs := s.segments.window()
+	segs := s.segments.retained()
 	require.Greater(t, len(segs), 1)
 
 	assert.Equal(t, testEpoch, segs[0].PDT, "the first segment starts at the epoch")
@@ -188,7 +188,7 @@ func TestSourceStallDeclaresDiscontinuityAndReanchorsPDT(t *testing.T) {
 	t.Parallel()
 
 	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
-	s.segments = newRing(1000)
+	s.segments = newSegmentWindow(1000)
 
 	// Four seconds of well-behaved audio.
 	const before = testRate * 4
@@ -200,7 +200,7 @@ func TestSourceStallDeclaresDiscontinuityAndReanchorsPDT(t *testing.T) {
 	resume := sampleTime(before).Add(5 * time.Second)
 	writeSamples(t, s, testRate*4, resume)
 
-	segs := s.segments.window()
+	segs := s.segments.retained()
 	var breakIdx = -1
 	for i := range segs {
 		if segs[i].Discontinuity {
@@ -233,7 +233,7 @@ func TestJitterBelowThresholdIsAbsorbed(t *testing.T) {
 	t.Parallel()
 
 	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
-	s.segments = newRing(1000)
+	s.segments = newSegmentWindow(1000)
 
 	// Feed in chunks whose timestamps wobble by a few milliseconds, well
 	// inside the default one-second threshold. None of it should break the
@@ -245,7 +245,7 @@ func TestJitterBelowThresholdIsAbsorbed(t *testing.T) {
 		writeSamples(t, s, chunk, at)
 	}
 
-	for _, seg := range s.segments.window() {
+	for _, seg := range s.segments.retained() {
 		assert.False(t, seg.Discontinuity,
 			"ordinary jitter must not break the timeline (segment %d)", seg.Seq)
 	}
@@ -261,7 +261,7 @@ func TestRingEvictsOldestAndAdvancesMediaSequence(t *testing.T) {
 	// default six-segment window.
 	writeSamples(t, s, testRate*20, testEpoch)
 
-	segs := s.segments.window()
+	segs := s.segments.retained()
 	require.Len(t, segs, DefaultWindowSize)
 
 	oldest := segs[0].Seq
@@ -285,7 +285,7 @@ func TestPartialAccessUnitIsBufferedNotEmitted(t *testing.T) {
 	// Less than one access unit of audio.
 	writeSamples(t, s, aacFrame-1, testEpoch)
 
-	assert.Zero(t, s.segments.len(), "a partial access unit must not produce a segment")
+	assert.Empty(t, s.segments.retained(), "a partial access unit must not produce a segment")
 	assert.False(t, s.Ready(1))
 	assert.Zero(t, s.pendingSamples)
 }
@@ -323,11 +323,11 @@ func TestCloseFlushesTailAndEndsPlaylist(t *testing.T) {
 
 	// Half a segment's worth, so nothing has been cut yet.
 	writeSamples(t, s, testRate, testEpoch)
-	require.Zero(t, s.segments.len())
+	require.Empty(t, s.segments.retained())
 
 	require.NoError(t, s.Close())
 
-	assert.NotZero(t, s.segments.len(), "Close must publish the buffered audio as a final segment")
+	assert.NotEmpty(t, s.segments.retained(), "Close must publish the buffered audio as a final segment")
 	require.NotNil(t, enc)
 	assert.True(t, enc.closed, "Close must release the encoder")
 
@@ -367,11 +367,11 @@ func TestCodecNeutrality(t *testing.T) {
 		// Declared as variable: the muxer must record each unit's own
 		// duration rather than a fragment-wide default.
 	})
-	s.segments = newRing(1000)
+	s.segments = newSegmentWindow(1000)
 
 	writeSamples(t, s, testRate*10, testEpoch)
 
-	segs := s.segments.window()
+	segs := s.segments.retained()
 	require.NotEmpty(t, segs)
 
 	const largestFrame = 4096
@@ -425,7 +425,7 @@ func TestAccessUnitsAreCopiedNotAliased(t *testing.T) {
 
 	writeSamples(t, s, testRate*2+aacFrame, testEpoch)
 
-	segs := s.segments.window()
+	segs := s.segments.retained()
 	require.NotEmpty(t, segs)
 	require.NotNil(t, enc)
 
@@ -479,6 +479,46 @@ func TestConcurrentWriteAndServe(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+// TestPlaylistSnapshotNeverGoesStale pins the discipline the lock-free read side
+// costs. The playlist is now rendered when a segment is cut rather than when it
+// is asked for, so a future path that changes the window without calling
+// publishView would serve a playlist that is missing that segment, for as long
+// as the stream runs, while every other playlist assertion in this file kept
+// passing: they all read the same stale snapshot and would agree with each
+// other about it.
+func TestPlaylistSnapshotNeverGoesStale(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStream(t, &fakeCodecOptions{
+		frameSizes:  []int{aacFrame},
+		tailSamples: aacFrame,
+	})
+
+	// Quarter-second chunks, so cuts land inside the run rather than only at
+	// its edges, and enough of them to scroll the window past its capacity.
+	const chunk = testRate / 4
+	const chunks = 40
+	for i := range chunks {
+		writeSamples(t, s, chunk, sampleTime(i*chunk))
+
+		require.Equal(t, renderPlaylist(s.segments, s.targetDuration, s.closed), s.Playlist(),
+			"the snapshot must equal a fresh render of the window after write %d", i)
+		require.Equal(t, len(s.segments.retained()), s.Stats().Retained,
+			"Stats must be read from the same snapshot after write %d", i)
+	}
+
+	// A stall re-anchors the timeline and cuts through a second path into
+	// cutSegment, which has its own publish to get wrong.
+	stall := sampleTime(chunks * chunk).Add(10 * time.Second)
+	require.NoError(t, s.Write(silence(chunk, testChannels), stall))
+	require.Equal(t, renderPlaylist(s.segments, s.targetDuration, s.closed), s.Playlist(),
+		"a discontinuity cut must republish")
+
+	require.NoError(t, s.Close())
+	assert.Equal(t, renderPlaylist(s.segments, s.targetDuration, s.closed), s.Playlist(),
+		"Close must republish, or a client polls a playlist that never gains EXT-X-ENDLIST")
 }
 
 func TestPlaylistBeforeAnySegment(t *testing.T) {
@@ -537,10 +577,10 @@ func TestStereoFrameSizing(t *testing.T) {
 	// mono-sized buffers here would halve the sample count silently, which is
 	// exactly the bug this test exists to catch.
 	require.NoError(t, s.Write(silence(testRate*6, stereo), testEpoch))
-	require.GreaterOrEqual(t, s.segments.len(), 2)
+	require.GreaterOrEqual(t, len(s.segments.retained()), 2)
 
 	var sum int
-	for _, seg := range s.segments.window() {
+	for _, seg := range s.segments.retained() {
 		sum += seg.Samples
 	}
 	assert.Greater(t, sum, testRate*3,
@@ -577,7 +617,7 @@ func TestInputClockCarryIsExact(t *testing.T) {
 	assert.Equal(t, want, s.nextSampleTime,
 		"the input clock must project the exact sample time, with no accumulated truncation")
 
-	for _, seg := range s.segments.window() {
+	for _, seg := range s.segments.retained() {
 		assert.False(t, seg.Discontinuity,
 			"an exact sample clock must never look like a stall")
 	}
@@ -603,14 +643,14 @@ func TestStallThresholdBoundary(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
-			s.segments = newRing(1000)
+			s.segments = newSegmentWindow(1000)
 
 			const first = testRate
 			writeSamples(t, s, first, testEpoch)
 			writeSamples(t, s, testRate*3, sampleTime(first).Add(tt.offset))
 
 			var sawBreak bool
-			for _, seg := range s.segments.window() {
+			for _, seg := range s.segments.retained() {
 				sawBreak = sawBreak || seg.Discontinuity
 			}
 			assert.Equal(t, tt.breaks, sawBreak)
@@ -626,14 +666,14 @@ func TestBackwardClockJumpIsDetected(t *testing.T) {
 	t.Parallel()
 
 	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
-	s.segments = newRing(1000)
+	s.segments = newSegmentWindow(1000)
 
 	writeSamples(t, s, testRate, testEpoch)
 	// Far enough back that time.Time.Sub saturates.
 	writeSamples(t, s, testRate*3, time.Time{}.Add(time.Hour))
 
 	var sawBreak bool
-	for _, seg := range s.segments.window() {
+	for _, seg := range s.segments.retained() {
 		sawBreak = sawBreak || seg.Discontinuity
 	}
 	assert.True(t, sawBreak, "a saturating backwards jump must break the timeline")
@@ -785,7 +825,7 @@ func TestDiscontinuitySequenceIsStableAcrossReloads(t *testing.T) {
 			at = at.Add(10 * time.Second) // stall
 		}
 
-		if w := s.segments.window(); len(w) > 0 && w[0].Discontinuity {
+		if w := s.segments.retained(); len(w) > 0 && w[0].Discontinuity {
 			headBreaks++
 		}
 		for name, ds := range computeDiscontinuitySeqs(t, s.Playlist()) {
@@ -917,7 +957,7 @@ func TestCutFailureDuringNormalWriteIsReported(t *testing.T) {
 	err := s.Write(silence(testRate*3, testChannels), testEpoch)
 	require.Error(t, err)
 	require.ErrorIs(t, err, errFakeSegment)
-	assert.True(t, s.segments.len() == 0 || s.Stats().Failed)
+	assert.True(t, len(s.segments.retained()) == 0 || s.Stats().Failed)
 }
 
 // TestNewRejectsSegmentTargetBelowOneAccessUnit covers the configurations that

--- a/internal/audiocore/hlsmux/hlsmux_test.go
+++ b/internal/audiocore/hlsmux/hlsmux_test.go
@@ -19,19 +19,38 @@ const (
 	testChannels = 1
 	testBitrate  = 128
 	aacFrame     = 1024
+
+	// testWideWindow is a playlist window nothing scrolls out of, for tests that
+	// assert over every segment a run produced.
+	testWideWindow = 1000
 )
 
 // testEpoch is a fixed wall-clock origin so PDT assertions are exact.
 var testEpoch = time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
 
-// newTestStream builds a stream over a fixed-frame fake codec.
+// newTestStream builds a stream over a fixed-frame fake codec, with the default
+// playlist window.
 func newTestStream(t *testing.T, opts *fakeCodecOptions) *Stream {
+	t.Helper()
+	return newTestStreamWithWindow(t, opts, 0)
+}
+
+// newTestStreamWithWindow builds a stream whose playlist window holds
+// windowSize segments; zero selects DefaultWindowSize.
+//
+// It exists so that a test needing a window nothing scrolls out of configures
+// one, rather than replacing s.segments after New. Replacing it works today but
+// swaps the window a snapshot was already published from without republishing,
+// which is exactly the unpublished-mutation shape
+// TestPlaylistSnapshotNeverGoesStale exists to forbid.
+func newTestStreamWithWindow(t *testing.T, opts *fakeCodecOptions, windowSize int) *Stream {
 	t.Helper()
 	s, err := New(&Config{
 		Codec:       newFakeCodec(opts),
 		SampleRate:  testRate,
 		Channels:    testChannels,
 		BitrateKbps: testBitrate,
+		WindowSize:  windowSize,
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = s.Close() })
@@ -141,10 +160,9 @@ func TestDurationsAccumulateWithoutDrift(t *testing.T) {
 
 	// A window large enough to retain every segment produced below, so the
 	// sum can be checked against the total sample count.
-	s := newTestStream(t, &fakeCodecOptions{
+	s := newTestStreamWithWindow(t, &fakeCodecOptions{
 		frameSizes: []int{aacFrame},
-	})
-	s.segments = newSegmentWindow(1000)
+	}, testWideWindow)
 
 	const total = testRate * 600 // ten minutes
 	writeSamples(t, s, total, testEpoch)
@@ -166,8 +184,7 @@ func TestDurationsAccumulateWithoutDrift(t *testing.T) {
 func TestProgramDateTimeTracksTheSampleTimeline(t *testing.T) {
 	t.Parallel()
 
-	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
-	s.segments = newSegmentWindow(1000)
+	s := newTestStreamWithWindow(t, &fakeCodecOptions{frameSizes: []int{aacFrame}}, testWideWindow)
 
 	writeSamples(t, s, testRate*10, testEpoch)
 
@@ -187,8 +204,7 @@ func TestProgramDateTimeTracksTheSampleTimeline(t *testing.T) {
 func TestSourceStallDeclaresDiscontinuityAndReanchorsPDT(t *testing.T) {
 	t.Parallel()
 
-	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
-	s.segments = newSegmentWindow(1000)
+	s := newTestStreamWithWindow(t, &fakeCodecOptions{frameSizes: []int{aacFrame}}, testWideWindow)
 
 	// Four seconds of well-behaved audio.
 	const before = testRate * 4
@@ -232,8 +248,7 @@ func TestSourceStallDeclaresDiscontinuityAndReanchorsPDT(t *testing.T) {
 func TestJitterBelowThresholdIsAbsorbed(t *testing.T) {
 	t.Parallel()
 
-	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
-	s.segments = newSegmentWindow(1000)
+	s := newTestStreamWithWindow(t, &fakeCodecOptions{frameSizes: []int{aacFrame}}, testWideWindow)
 
 	// Feed in chunks whose timestamps wobble by a few milliseconds, well
 	// inside the default one-second threshold. None of it should break the
@@ -252,7 +267,7 @@ func TestJitterBelowThresholdIsAbsorbed(t *testing.T) {
 	assert.NotContains(t, s.Playlist(), "#EXT-X-DISCONTINUITY")
 }
 
-func TestRingEvictsOldestAndAdvancesMediaSequence(t *testing.T) {
+func TestSegmentWindowEvictsOldestAndAdvancesMediaSequence(t *testing.T) {
 	t.Parallel()
 
 	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
@@ -360,14 +375,13 @@ func TestEncoderFailurePropagates(t *testing.T) {
 func TestCodecNeutrality(t *testing.T) {
 	t.Parallel()
 
-	s := newTestStream(t, &fakeCodecOptions{
+	s := newTestStreamWithWindow(t, &fakeCodecOptions{
 		name:       "variable",
 		frameSizes: []int{4096, 2048, 512, 4096},
 		delay:      0,
 		// Declared as variable: the muxer must record each unit's own
 		// duration rather than a fragment-wide default.
-	})
-	s.segments = newSegmentWindow(1000)
+	}, testWideWindow)
 
 	writeSamples(t, s, testRate*10, testEpoch)
 
@@ -449,16 +463,30 @@ func TestAccessUnitsAreCopiedNotAliased(t *testing.T) {
 	}
 }
 
+// TestConcurrentWriteAndServe runs the readers against a writer under -race,
+// which is the only mechanism that can catch a FUTURE write into a published
+// window; the unit tests can only pin the implementation as it stands.
+//
+// Two details make it able to detect that, and both were established by
+// reverting push to its old in-place shift and confirming this test then fails.
+// The readers run until the writer is done rather than a fixed count, so they
+// cannot retire early and leave the interesting cuts unobserved; and the window
+// is small enough that every cut evicts, since the in-place shift only wrote
+// into the published array on eviction. With a fixed reader count and the
+// default window, the same revert survived twenty runs.
 func TestConcurrentWriteAndServe(t *testing.T) {
 	t.Parallel()
 
-	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
+	// A window that evicts on every cut after the second.
+	s := newTestStreamWithWindow(t, &fakeCodecOptions{frameSizes: []int{aacFrame}}, 2)
 
 	var wg sync.WaitGroup
 	const chunks = 200
 	const chunk = testRate / 10
+	done := make(chan struct{})
 
 	wg.Go(func() {
+		defer close(done)
 		for i := range chunks {
 			if err := s.Write(silence(chunk, testChannels), sampleTime(i*chunk)); err != nil {
 				t.Errorf("write: %v", err)
@@ -469,10 +497,23 @@ func TestConcurrentWriteAndServe(t *testing.T) {
 
 	for range 4 {
 		wg.Go(func() {
-			for range chunks {
+			for {
+				select {
+				case <-done:
+					return
+				default:
+				}
+				// Read the segment payloads, not just the counts: Playlist and
+				// Ready never touch a window element, so Segment is the only
+				// call here that a mutated header could be observed through.
+				stats := s.Stats()
+				for seq := range stats.Segments {
+					if seg, ok := s.Segment(seq); ok {
+						_ = len(seg.Data)
+					}
+				}
 				_ = s.Playlist()
 				_ = s.InitSegment()
-				_, _ = s.Segment(0)
 				_ = s.Ready(1)
 			}
 		})
@@ -497,28 +538,114 @@ func TestPlaylistSnapshotNeverGoesStale(t *testing.T) {
 	})
 
 	// Quarter-second chunks, so cuts land inside the run rather than only at
-	// its edges, and enough of them to scroll the window past its capacity.
+	// its edges, and enough of them to scroll the window well past its
+	// capacity. Scrolling matters: until the window fills, push never takes its
+	// eviction branch and Retained is just nextSeq, so the assertions below
+	// would agree for the wrong reason.
 	const chunk = testRate / 4
-	const chunks = 40
+	const chunks = 80
 	for i := range chunks {
 		writeSamples(t, s, chunk, sampleTime(i*chunk))
-
-		require.Equal(t, renderPlaylist(s.segments, s.targetDuration, s.closed), s.Playlist(),
-			"the snapshot must equal a fresh render of the window after write %d", i)
-		require.Equal(t, len(s.segments.retained()), s.Stats().Retained,
-			"Stats must be read from the same snapshot after write %d", i)
+		requireSnapshotMatchesWindow(t, s, i)
 	}
+	require.Greater(t, s.nextSeq, uint64(s.segments.capacity),
+		"the window must have scrolled, or eviction went untested")
 
 	// A stall re-anchors the timeline and cuts through a second path into
 	// cutSegment, which has its own publish to get wrong.
 	stall := sampleTime(chunks * chunk).Add(10 * time.Second)
 	require.NoError(t, s.Write(silence(chunk, testChannels), stall))
-	require.Equal(t, renderPlaylist(s.segments, s.targetDuration, s.closed), s.Playlist(),
-		"a discontinuity cut must republish")
+	requireSnapshotMatchesWindow(t, s, chunks)
 
 	require.NoError(t, s.Close())
-	assert.Equal(t, renderPlaylist(s.segments, s.targetDuration, s.closed), s.Playlist(),
-		"Close must republish, or a client polls a playlist that never gains EXT-X-ENDLIST")
+	requireSnapshotMatchesWindow(t, s, chunks+1)
+	assert.Contains(t, s.Playlist(), "#EXT-X-ENDLIST", "a closed stream must stop clients polling")
+}
+
+// requireSnapshotMatchesWindow asserts that every field a reader can see equals
+// what the stream's own state says it should be.
+//
+// It checks all five, not just the playlist, because the three counters are
+// exactly the fields cutSegment settles AFTER pushing the segment. Asserting
+// only the playlist and Retained would pass against a publish hoisted above
+// those updates, which is a way to get the snapshot wrong that no amount of
+// playlist comparison detects.
+func requireSnapshotMatchesWindow(t *testing.T, s *Stream, step int) {
+	t.Helper()
+
+	stats := s.Stats()
+	require.Equal(t, renderPlaylist(s.segments, s.targetDuration, s.closed), s.Playlist(),
+		"the snapshot must equal a fresh render of the window at step %d", step)
+	require.Equal(t, len(s.segments.retained()), stats.Retained, "Retained at step %d", step)
+	require.Equal(t, s.nextSeq, stats.Segments, "Segments at step %d", step)
+	require.Equal(t, s.discontinuities, stats.Discontinuities, "Discontinuities at step %d", step)
+	require.Equal(t, s.lastSegmentPDT, stats.LastSegmentPDT, "LastSegmentPDT at step %d", step)
+}
+
+// TestCloseWithNoPendingAudioEndsPlaylist covers the one path on which Close's
+// own publish is the only one: a stream with nothing buffered to cut.
+//
+// Without it the ENDLIST assertions elsewhere are satisfied by cutSegment's
+// publish instead, since Close sets s.closed before flushing. Deleting Close's
+// publish then leaves the whole suite green while a stream closed on a segment
+// boundary, or with no audio at all, serves a playlist that never ends and a
+// client that polls it forever.
+func TestCloseWithNoPendingAudioEndsPlaylist(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
+	require.NoError(t, s.Close())
+
+	assert.Contains(t, s.Playlist(), "#EXT-X-ENDLIST",
+		"a stream closed with nothing buffered must still stop advertising itself as live")
+}
+
+// TestCloseDoesNotEndThePlaylistBeforeTheFinalSegment pins the reason
+// publishView takes an explicit ended flag rather than reading s.closed.
+//
+// Close sets s.closed first, so that a racing Write is refused and a second
+// Close cannot re-enter a codec that just panicked. A cut triggered by the
+// flush therefore runs with s.closed already true, and rendering the tag from
+// that would publish a terminated playlist that omits the segment the flush is
+// producing. A client honouring EXT-X-ENDLIST stops there and never fetches it.
+//
+// The bad state is transient, so asserting on the final playlist proves
+// nothing: by the time Close returns, both the mid-flush cut and Close's own
+// publish have happened and the result is correct either way. The flush hook is
+// what makes the intermediate instant observable, and it can call Playlist from
+// inside the muxer's own critical section precisely because the read side no
+// longer takes the lock.
+func TestCloseDoesNotEndThePlaylistBeforeTheFinalSegment(t *testing.T) {
+	t.Parallel()
+
+	var s *Stream
+	var duringFlush string
+	opts := &fakeCodecOptions{
+		frameSizes:  []int{aacFrame},
+		tailSamples: aacFrame,
+	}
+	// Runs after the tail unit has forced its cut, and therefore after that
+	// cut has published a snapshot.
+	opts.flushHook = func() { duringFlush = s.Playlist() }
+	s = newTestStream(t, opts)
+
+	// Fill the segment in progress to within one access unit of the target, so
+	// that the flushed tail overflows it and forces a cut from inside Close.
+	writeSamples(t, s, s.targetSamples, testEpoch)
+	require.Positive(t, s.pendingSamples, "the flush must have a partial segment to overflow")
+
+	require.NoError(t, s.Close())
+
+	require.NotEmpty(t, duringFlush, "the flush hook must have run")
+	require.Contains(t, duringFlush, "#EXTINF", "the tail must have forced a cut during the flush")
+	assert.NotContains(t, duringFlush, "#EXT-X-ENDLIST",
+		"the playlist must not declare the stream over while the flush is still producing segments")
+
+	// And the finished playlist is complete and terminated.
+	playlist := s.Playlist()
+	require.Contains(t, playlist, "#EXT-X-ENDLIST")
+	assert.Equal(t, len(s.segments.retained()), strings.Count(playlist, "#EXTINF"),
+		"the ended playlist must advertise every retained segment")
 }
 
 func TestPlaylistBeforeAnySegment(t *testing.T) {
@@ -642,8 +769,7 @@ func TestStallThresholdBoundary(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
-			s.segments = newSegmentWindow(1000)
+			s := newTestStreamWithWindow(t, &fakeCodecOptions{frameSizes: []int{aacFrame}}, testWideWindow)
 
 			const first = testRate
 			writeSamples(t, s, first, testEpoch)
@@ -665,8 +791,7 @@ func TestStallThresholdBoundary(t *testing.T) {
 func TestBackwardClockJumpIsDetected(t *testing.T) {
 	t.Parallel()
 
-	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
-	s.segments = newSegmentWindow(1000)
+	s := newTestStreamWithWindow(t, &fakeCodecOptions{frameSizes: []int{aacFrame}}, testWideWindow)
 
 	writeSamples(t, s, testRate, testEpoch)
 	// Far enough back that time.Time.Sub saturates.

--- a/internal/audiocore/hlsmux/hlsmux_test.go
+++ b/internal/audiocore/hlsmux/hlsmux_test.go
@@ -3,6 +3,7 @@ package hlsmux
 import (
 	"bytes"
 	"errors"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -467,13 +468,14 @@ func TestAccessUnitsAreCopiedNotAliased(t *testing.T) {
 // which is the only mechanism that can catch a FUTURE write into a published
 // window; the unit tests can only pin the implementation as it stands.
 //
-// Two details make it able to detect that, and both were established by
-// reverting push to its old in-place shift and confirming this test then fails.
-// The readers run until the writer is done rather than a fixed count, so they
-// cannot retire early and leave the interesting cuts unobserved; and the window
-// is small enough that every cut evicts, since the in-place shift only wrote
-// into the published array on eviction. With a fixed reader count and the
-// default window, the same revert survived twenty runs.
+// What makes it able to detect that is the readers running until the writer is
+// done rather than for a fixed count. Established by reverting push to its old
+// in-place shift: with a fixed count the readers retired long before the writer,
+// left the interesting cuts unobserved, and the revert survived twenty runs;
+// with the unbounded loop it is caught. The small window is not required for
+// detection, and is kept only because it makes every cut after the second evict,
+// which is the sole branch in which the in-place shift wrote into a published
+// array at all.
 func TestConcurrentWriteAndServe(t *testing.T) {
 	t.Parallel()
 
@@ -503,6 +505,9 @@ func TestConcurrentWriteAndServe(t *testing.T) {
 					return
 				default:
 				}
+				// These readers spin for the writer's whole run, so yield
+				// rather than monopolise a core on a small CI runner.
+				runtime.Gosched()
 				// Read the segment payloads, not just the counts: Playlist and
 				// Ready never touch a window element, so Segment is the only
 				// call here that a mutated header could be observed through.
@@ -570,6 +575,10 @@ func TestPlaylistSnapshotNeverGoesStale(t *testing.T) {
 // only the playlist and Retained would pass against a publish hoisted above
 // those updates, which is a way to get the snapshot wrong that no amount of
 // playlist comparison detects.
+//
+// It reads the stream's fields without the mutex, so callers must have no
+// concurrent writer. That holds for its only caller and would be a hard data
+// race in a test shaped like TestConcurrentWriteAndServe.
 func requireSnapshotMatchesWindow(t *testing.T, s *Stream, step int) {
 	t.Helper()
 
@@ -585,11 +594,12 @@ func requireSnapshotMatchesWindow(t *testing.T, s *Stream, step int) {
 // TestCloseWithNoPendingAudioEndsPlaylist covers the one path on which Close's
 // own publish is the only one: a stream with nothing buffered to cut.
 //
-// Without it the ENDLIST assertions elsewhere are satisfied by cutSegment's
-// publish instead, since Close sets s.closed before flushing. Deleting Close's
-// publish then leaves the whole suite green while a stream closed on a segment
-// boundary, or with no audio at all, serves a playlist that never ends and a
-// client that polls it forever.
+// Every other ENDLIST assertion in this file closes a stream that still has
+// audio to cut, so each of them would also pass if the tag came from somewhere
+// in the cut path. This one cannot: there is nothing to cut, so Close's own
+// publish is the only thing that can end the playlist. Without a test here, a
+// stream closed on a segment boundary, or one that never received audio, would
+// serve a playlist that never ends and a client that polls it forever.
 func TestCloseWithNoPendingAudioEndsPlaylist(t *testing.T) {
 	t.Parallel()
 
@@ -1157,4 +1167,24 @@ func TestNewAcceptsASegmentThatFitsExactlyOneAccessUnit(t *testing.T) {
 	// And it must actually stream rather than merely construct.
 	writeSamples(t, s, testRate, testEpoch)
 	assert.True(t, s.Ready(1))
+}
+
+// TestPlaylistAndStatsComeFromOneSnapshot pins the reason the accessor exists:
+// Retained must be the segment count of the playlist returned beside it, not of
+// a neighbouring instant.
+func TestPlaylistAndStatsComeFromOneSnapshot(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStream(t, &fakeCodecOptions{frameSizes: []int{aacFrame}})
+
+	// Before any cut, and then across several, including once the window has
+	// scrolled so Retained stops tracking the total.
+	for i := range 40 {
+		playlist, stats := s.PlaylistAndStats()
+		assert.Equal(t, strings.Count(playlist, "#EXTINF"), stats.Retained,
+			"Retained must count the segments in the playlist returned with it, at write %d", i)
+		assert.Equal(t, s.Playlist(), playlist, "the playlist must match a plain Playlist call")
+		writeSamples(t, s, testRate/2, sampleTime(i*testRate/2))
+	}
+	require.Greater(t, s.nextSeq, uint64(s.segments.capacity), "the window must have scrolled")
 }

--- a/internal/audiocore/hlsmux/playlist.go
+++ b/internal/audiocore/hlsmux/playlist.go
@@ -38,15 +38,15 @@ const (
 	playlistBytesPerSegment = 96
 )
 
-// renderPlaylist builds the HLS media playlist describing the ring's current
-// window.
+// renderPlaylist builds the HLS media playlist describing a window's current
+// segments.
 //
 // It is a media playlist, not a master playlist, which is why no CODECS
 // attribute appears: RFC 8216 places CODECS on EXT-X-STREAM-INF, a master
 // playlist tag. Players determine the codec by probing the init segment named
 // by EXT-X-MAP.
-func renderPlaylist(r *ring, targetDuration int, ended bool) string {
-	segs := r.window()
+func renderPlaylist(w *segmentWindow, targetDuration int, ended bool) string {
+	segs := w.retained()
 
 	var b strings.Builder
 	b.Grow(playlistFixedLines*playlistBytesPerHeaderLine + len(segs)*playlistBytesPerSegment)
@@ -62,9 +62,9 @@ func renderPlaylist(r *ring, targetDuration int, ended bool) string {
 	b.WriteString("\n#EXT-X-TARGETDURATION:")
 	b.WriteString(strconv.Itoa(targetDuration))
 	b.WriteString("\n#EXT-X-MEDIA-SEQUENCE:")
-	b.WriteString(strconv.FormatUint(r.mediaSequence(), 10))
+	b.WriteString(strconv.FormatUint(w.mediaSequence(), 10))
 	b.WriteString("\n")
-	if ds := r.discontinuitySequence(); ds != 0 {
+	if ds := w.discontinuitySequence(); ds != 0 {
 		b.WriteString("#EXT-X-DISCONTINUITY-SEQUENCE:")
 		b.WriteString(strconv.FormatUint(ds, 10))
 		b.WriteString("\n")

--- a/internal/audiocore/hlsmux/playlist_test.go
+++ b/internal/audiocore/hlsmux/playlist_test.go
@@ -14,7 +14,7 @@ func TestRenderPlaylistGolden(t *testing.T) {
 	t.Parallel()
 
 	base := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
-	r := newRing(3)
+	r := newSegmentWindow(3)
 	r.push(&Segment{Seq: 7, Samples: 96256, Duration: 2005333333 * time.Nanosecond, PDT: base})
 	r.push(&Segment{Seq: 8, Samples: 96256, Duration: 2005333334 * time.Nanosecond, PDT: base.Add(2005333333 * time.Nanosecond)})
 
@@ -40,7 +40,7 @@ func TestRenderPlaylistWithDiscontinuityGolden(t *testing.T) {
 	t.Parallel()
 
 	base := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
-	r := newRing(2)
+	r := newSegmentWindow(2)
 	r.push(&Segment{Seq: 40, Duration: 2 * time.Second, PDT: base, DiscontinuitySeq: 2})
 	// A segment preceded by EXT-X-DISCONTINUITY carries its predecessor's
 	// discontinuity sequence number plus one, so that the number a client
@@ -78,7 +78,7 @@ func TestRenderPlaylistEndedGolden(t *testing.T) {
 	t.Parallel()
 
 	base := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
-	r := newRing(2)
+	r := newSegmentWindow(2)
 	r.push(&Segment{Seq: 0, Duration: 1500 * time.Millisecond, PDT: base})
 
 	want := `#EXTM3U
@@ -107,7 +107,7 @@ func TestRenderPlaylistEmptyGolden(t *testing.T) {
 #EXT-X-MEDIA-SEQUENCE:0
 #EXT-X-MAP:URI="init.mp4"
 `
-	assert.Equal(t, want, renderPlaylist(newRing(6), 2, false))
+	assert.Equal(t, want, renderPlaylist(newSegmentWindow(6), 2, false))
 }
 
 func TestFormatEXTINF(t *testing.T) {

--- a/internal/audiocore/hlsmux/segment.go
+++ b/internal/audiocore/hlsmux/segment.go
@@ -29,7 +29,7 @@ type Segment struct {
 	Seq uint64
 
 	// Data is the complete segment: styp, moof and mdat. It is owned by the
-	// stream and must be treated as read only; the ring never writes into a
+	// stream and must be treated as read only; nothing ever writes into a
 	// published segment's backing array.
 	Data []byte
 
@@ -55,8 +55,8 @@ type Segment struct {
 	// DiscontinuitySeq is this segment's own discontinuity sequence number,
 	// counting every break up to and including its own. It is not what
 	// EXT-X-DISCONTINUITY-SEQUENCE reports directly; see
-	// ring.discontinuitySequence, which subtracts this segment's own break
-	// because the renderer emits the tag for it separately.
+	// segmentWindow.discontinuitySequence, which subtracts this segment's own
+	// break because the renderer emits the tag for it separately.
 	DiscontinuitySeq uint64
 }
 
@@ -133,10 +133,13 @@ func newSegmentWindow(capacity int) *segmentWindow {
 // The retained headers are copied into a fresh slice rather than shifted down
 // in place. Shifting is one allocation cheaper, but it writes into an array a
 // reader may be walking at that moment, since the window is published to
-// playlist and segment lookups without a lock. Dropping the evicted header from
-// the new slice releases its Data as soon as the last reader holding the
-// previous slice lets go, which is the same collectability the in-place
-// overwrite gave.
+// playlist and segment lookups without a lock.
+//
+// The cost is that an evicted segment's Data is released strictly later than
+// the in-place overwrite released it: the overwrite dropped the reference at
+// push time, whereas the evicted header now survives in the previous slice
+// until the last reader holding it lets go. That is bounded by one window's
+// worth of payload, roughly 35 KB per stream at the default settings.
 func (w *segmentWindow) push(s *Segment) {
 	retained := w.segments
 	if len(retained) == w.capacity {
@@ -151,8 +154,14 @@ func (w *segmentWindow) push(s *Segment) {
 // retained returns the window's segments, oldest first. The returned slice is
 // final: push replaces it rather than writing into it, so a caller may keep it
 // for as long as it likes.
+//
+// Capacity is clipped to the length so that "final" is true of the spare slots
+// too. Until the window first fills, w.segments has room to spare, and an
+// unclipped slice would let a caller's append write into the array a concurrent
+// reader is walking, which is the one thing the copy-on-write push exists to
+// prevent.
 func (w *segmentWindow) retained() []Segment {
-	return w.segments
+	return w.segments[:len(w.segments):len(w.segments)]
 }
 
 // findSegment returns the segment with the given sequence number from a window

--- a/internal/audiocore/hlsmux/segment.go
+++ b/internal/audiocore/hlsmux/segment.go
@@ -97,25 +97,32 @@ func ParseSegmentName(name string) (seq uint64, ok bool) {
 	return seq, true
 }
 
-// ring is the bounded window of media segments a live playlist advertises.
-// Pushing past capacity evicts the oldest, which is what makes memory use
-// constant no matter how long a stream runs.
+// segmentWindow is the bounded list of media segments a live playlist
+// advertises. Pushing past capacity evicts the oldest, which is what makes
+// memory use constant no matter how long a stream runs.
 //
-// ring is not safe for concurrent use; Stream serialises access to it.
-type ring struct {
+// It is copy on write: push builds a fresh slice rather than shifting one in
+// place, so a slice already returned by retained is never written again. That
+// is what lets Stream hand the window straight to readers without a lock; see
+// the view type.
+//
+// segmentWindow is not safe for concurrent use. Stream serialises the push
+// side, and a reader only ever sees a slice that is already final.
+type segmentWindow struct {
 	segments []Segment
 	capacity int
 }
 
-// newRing returns a ring holding at most capacity segments. A capacity below
-// one is raised to one: push indexes the window unconditionally once full, so
-// a zero capacity would panic on the first segment, on the audio goroutine,
-// with nothing to recover it.
-func newRing(capacity int) *ring {
+// newSegmentWindow returns a window holding at most capacity segments. A
+// capacity below one is raised to one: push re-slices the retained segments as
+// soon as the window is full, so a zero capacity would treat an empty window as
+// full and panic on the first segment, on the audio goroutine, with nothing to
+// recover it.
+func newSegmentWindow(capacity int) *segmentWindow {
 	if capacity < 1 {
 		capacity = 1
 	}
-	return &ring{
+	return &segmentWindow{
 		segments: make([]Segment, 0, capacity),
 		capacity: capacity,
 	}
@@ -123,51 +130,55 @@ func newRing(capacity int) *ring {
 
 // push appends s, evicting the oldest segment when the window is full.
 //
-// When full it shifts the retained segments down and overwrites the last slot,
-// reusing the backing array. Overwriting drops the evicted segment's reference
-// to its Data, so the bytes become collectable; the array itself is only ever
-// reused for the Segment headers, never for segment payloads, so a segment
-// already handed out by get stays valid for as long as its caller holds it.
-func (r *ring) push(s *Segment) {
-	if len(r.segments) < r.capacity {
-		r.segments = append(r.segments, *s)
-		return
+// The retained headers are copied into a fresh slice rather than shifted down
+// in place. Shifting is one allocation cheaper, but it writes into an array a
+// reader may be walking at that moment, since the window is published to
+// playlist and segment lookups without a lock. Dropping the evicted header from
+// the new slice releases its Data as soon as the last reader holding the
+// previous slice lets go, which is the same collectability the in-place
+// overwrite gave.
+func (w *segmentWindow) push(s *Segment) {
+	retained := w.segments
+	if len(retained) == w.capacity {
+		retained = retained[1:]
 	}
-	copy(r.segments, r.segments[1:])
-	r.segments[len(r.segments)-1] = *s
+	next := make([]Segment, 0, w.capacity)
+	next = append(next, retained...)
+	next = append(next, *s)
+	w.segments = next
 }
 
-// get returns the retained segment with the given sequence number. It reports
-// false once the segment has been evicted, which a client that fell too far
-// behind will see as a 404.
-func (r *ring) get(seq uint64) (Segment, bool) {
-	for i := range r.segments {
-		if r.segments[i].Seq == seq {
-			return r.segments[i], true
+// retained returns the window's segments, oldest first. The returned slice is
+// final: push replaces it rather than writing into it, so a caller may keep it
+// for as long as it likes.
+func (w *segmentWindow) retained() []Segment {
+	return w.segments
+}
+
+// findSegment returns the segment with the given sequence number from a window
+// slice. It reports false once the segment has been evicted, which a client
+// that fell too far behind will see as a 404.
+//
+// A linear scan, which is free at the default window of six and stays cheap
+// well past it: the scan compares one uint64 per retained segment, and a
+// window large enough for that to matter would already be holding megabytes of
+// audio. See BenchmarkSegmentLookup for where it stops being free.
+func findSegment(segments []Segment, seq uint64) (Segment, bool) {
+	for i := range segments {
+		if segments[i].Seq == seq {
+			return segments[i], true
 		}
 	}
 	return Segment{}, false
 }
 
-// window returns the retained segments, oldest first. The returned slice
-// aliases the ring's storage and is only valid while the caller holds the
-// stream lock.
-func (r *ring) window() []Segment {
-	return r.segments
-}
-
-// len is how many segments the window currently holds.
-func (r *ring) len() int {
-	return len(r.segments)
-}
-
 // mediaSequence is the sequence number of the oldest retained segment, which
 // is what EXT-X-MEDIA-SEQUENCE reports.
-func (r *ring) mediaSequence() uint64 {
-	if len(r.segments) == 0 {
+func (w *segmentWindow) mediaSequence() uint64 {
+	if len(w.segments) == 0 {
 		return 0
 	}
-	return r.segments[0].Seq
+	return w.segments[0].Seq
 }
 
 // discontinuitySequence is the EXT-X-DISCONTINUITY-SEQUENCE value for the
@@ -181,12 +192,12 @@ func (r *ring) mediaSequence() uint64 {
 // second time. Subtracting it here is what keeps the number a client computes
 // for a given segment identical across reloads as the window scrolls, which is
 // the entire purpose of the tag.
-func (r *ring) discontinuitySequence() uint64 {
-	if len(r.segments) == 0 {
+func (w *segmentWindow) discontinuitySequence() uint64 {
+	if len(w.segments) == 0 {
 		return 0
 	}
-	seq := r.segments[0].DiscontinuitySeq
-	if r.segments[0].Discontinuity {
+	seq := w.segments[0].DiscontinuitySeq
+	if w.segments[0].Discontinuity {
 		// cutSegment increments the counter before assigning it, so a segment
 		// carrying a break always has DiscontinuitySeq >= 1 and this cannot
 		// underflow. Guarding for zero here would paper over a broken

--- a/internal/audiocore/hlsmux/segment.go
+++ b/internal/audiocore/hlsmux/segment.go
@@ -138,8 +138,10 @@ func newSegmentWindow(capacity int) *segmentWindow {
 // The cost is that an evicted segment's Data is released strictly later than
 // the in-place overwrite released it: the overwrite dropped the reference at
 // push time, whereas the evicted header now survives in the previous slice
-// until the last reader holding it lets go. That is bounded by one window's
-// worth of payload, roughly 35 KB per stream at the default settings.
+// until the last reader holding it lets go. In practice that is one extra
+// segment, about 34 KB at the default 128 kbps and two-second segments, since
+// a reader holds the slice for microseconds; the hard bound is one window,
+// roughly 200 KB.
 func (w *segmentWindow) push(s *Segment) {
 	retained := w.segments
 	if len(retained) == w.capacity {

--- a/internal/audiocore/hlsmux/segment_test.go
+++ b/internal/audiocore/hlsmux/segment_test.go
@@ -166,3 +166,29 @@ func TestSampleClockIsExactAcrossManyConversions(t *testing.T) {
 	want := time.Duration(frames) * aacFrame * time.Second / testRate
 	assert.Equal(t, want, total)
 }
+
+// TestRetainedExposesNoSpareCapacity pins the clip in retained.
+//
+// The guarantee is about capacity, so that is what this asserts. Until the
+// window fills, its backing array has spare slots; an unclipped slice would let
+// a caller's append write into slots the array still owns, which is the array a
+// concurrent reader is walking. Nothing in the tree appends to a retained slice
+// today, and that is the point: the first caller that does must get its own
+// storage rather than silently reach into a published window.
+func TestRetainedExposesNoSpareCapacity(t *testing.T) {
+	t.Parallel()
+
+	w := newSegmentWindow(4)
+	w.push(&Segment{Seq: 0})
+	w.push(&Segment{Seq: 1})
+
+	published := w.retained()
+	require.Len(t, published, 2, "the window is deliberately left short of capacity")
+	assert.Equal(t, len(published), cap(published),
+		"a published window must not hand out capacity into its own array")
+
+	// An append therefore reallocates, and the window is unaffected by it.
+	grown := append(published, Segment{Seq: 99}) //nolint:gocritic // the reallocation is the assertion
+	assert.Len(t, w.retained(), 2, "the window must not have grown")
+	assert.Equal(t, uint64(99), grown[2].Seq)
+}

--- a/internal/audiocore/hlsmux/segment_test.go
+++ b/internal/audiocore/hlsmux/segment_test.go
@@ -117,7 +117,7 @@ func TestCeilSeconds(t *testing.T) {
 	}
 }
 
-func TestSegmentWindowLen(t *testing.T) {
+func TestSegmentWindowNeverGrowsPastCapacity(t *testing.T) {
 	t.Parallel()
 
 	w := newSegmentWindow(3)
@@ -136,11 +136,16 @@ func TestNewSegmentWindowRaisesDegenerateCapacity(t *testing.T) {
 	t.Parallel()
 
 	for _, capacity := range []int{-1, 0} {
-		w := newSegmentWindow(capacity)
+		// The constructor is inside the closure too: without the raise, a
+		// capacity of -1 panics in make() rather than in push, and a panic out
+		// here takes the whole test binary down instead of failing this case.
+		var w *segmentWindow
 		assert.NotPanics(t, func() {
+			w = newSegmentWindow(capacity)
 			w.push(&Segment{Seq: 1})
 			w.push(&Segment{Seq: 2})
 		})
+		require.NotNil(t, w)
 		assert.Len(t, w.retained(), 1)
 	}
 }

--- a/internal/audiocore/hlsmux/segment_test.go
+++ b/internal/audiocore/hlsmux/segment_test.go
@@ -2,6 +2,7 @@ package hlsmux
 
 import (
 	"math"
+	"slices"
 	"testing"
 	"time"
 
@@ -39,26 +40,53 @@ func TestParseSegmentNameRejectsJunk(t *testing.T) {
 	}
 }
 
-func TestRingEvictionDropsDataReference(t *testing.T) {
+func TestSegmentWindowEvictionDropsDataReference(t *testing.T) {
 	t.Parallel()
 
-	r := newRing(2)
+	w := newSegmentWindow(2)
 	for i := range uint64(3) {
-		r.push(&Segment{Seq: i, Data: []byte{byte(i)}})
+		w.push(&Segment{Seq: i, Data: []byte{byte(i)}})
 	}
 
-	require.Len(t, r.window(), 2)
-	assert.Equal(t, uint64(1), r.mediaSequence())
+	require.Len(t, w.retained(), 2)
+	assert.Equal(t, uint64(1), w.mediaSequence())
 
-	_, ok := r.get(0)
+	_, ok := findSegment(w.retained(), 0)
 	assert.False(t, ok, "the evicted segment must be gone")
 
 	// The window holds the two newest segments in order. This is the
 	// observable half of eviction; that the evicted payload also becomes
-	// collectable follows from push overwriting the slot rather than
-	// re-slicing, which cannot be asserted directly without a finalizer.
-	assert.Equal(t, []byte{1}, r.window()[0].Data)
-	assert.Equal(t, []byte{2}, r.window()[1].Data)
+	// collectable follows from push building a slice that simply omits the
+	// evicted header, which cannot be asserted directly without a finalizer.
+	assert.Equal(t, []byte{1}, w.retained()[0].Data)
+	assert.Equal(t, []byte{2}, w.retained()[1].Data)
+}
+
+// TestSegmentWindowPushLeavesPublishedSliceAlone pins the invariant the
+// lock-free read side rests on. Stream hands the slice retained returns straight
+// to playlist renders and segment lookups with no lock held, so if push ever
+// went back to shifting headers down in place, a reader walking the previous
+// slice would see segments change underneath it: a client could be served one
+// segment's bytes under another's sequence number, and no test that only reads
+// after writing would notice.
+func TestSegmentWindowPushLeavesPublishedSliceAlone(t *testing.T) {
+	t.Parallel()
+
+	const capacity = 3
+	w := newSegmentWindow(capacity)
+	for i := range uint64(capacity) {
+		w.push(&Segment{Seq: i, Data: []byte{byte(i)}})
+	}
+
+	// What a reader would be holding across the next few cuts.
+	published := w.retained()
+	before := slices.Clone(published)
+
+	for i := range uint64(capacity * 2) {
+		w.push(&Segment{Seq: uint64(capacity) + i, Data: []byte{byte(capacity) + byte(i)}})
+	}
+
+	assert.Equal(t, before, published, "a published window must be immutable once handed out")
 }
 
 // TestCeilSeconds pins EXT-X-TARGETDURATION to a true ceiling. Rounding to
@@ -89,30 +117,31 @@ func TestCeilSeconds(t *testing.T) {
 	}
 }
 
-func TestRingLen(t *testing.T) {
+func TestSegmentWindowLen(t *testing.T) {
 	t.Parallel()
 
-	r := newRing(3)
-	assert.Zero(t, r.len())
+	w := newSegmentWindow(3)
+	assert.Empty(t, w.retained())
 	for i := range uint64(5) {
-		r.push(&Segment{Seq: i})
+		w.push(&Segment{Seq: i})
 	}
-	assert.Equal(t, 3, r.len(), "the window never grows past its capacity")
+	assert.Len(t, w.retained(), 3, "the window never grows past its capacity")
 }
 
-// TestNewRingRaisesDegenerateCapacity guards the audio goroutine: push indexes
-// the window unconditionally once full, so a zero capacity would panic on the
-// first segment with nothing to recover it.
-func TestNewRingRaisesDegenerateCapacity(t *testing.T) {
+// TestNewSegmentWindowRaisesDegenerateCapacity guards the audio goroutine: push
+// re-slices the retained segments once the window is full, so a zero capacity
+// would treat an empty window as full and panic on the first segment, with
+// nothing to recover it.
+func TestNewSegmentWindowRaisesDegenerateCapacity(t *testing.T) {
 	t.Parallel()
 
 	for _, capacity := range []int{-1, 0} {
-		r := newRing(capacity)
+		w := newSegmentWindow(capacity)
 		assert.NotPanics(t, func() {
-			r.push(&Segment{Seq: 1})
-			r.push(&Segment{Seq: 2})
+			w.push(&Segment{Seq: 1})
+			w.push(&Segment{Seq: 2})
 		})
-		assert.Equal(t, 1, r.len())
+		assert.Len(t, w.retained(), 1)
 	}
 }
 


### PR DESCRIPTION
## What this changes

`renderPlaylist` rebuilt a byte-identical playlist string on every poll, and did it holding the same mutex `Stream.Write` needs to encode audio. The playlist only changes when a segment is cut, so `Stream` now publishes a snapshot behind an `atomic.Pointer` at the end of every cut, holding the rendered playlist, the segment window and the counters `Stats` reports. `Playlist`, `Segment`, `Ready` and `Stats` read it with one atomic load and take no lock at all.

The reason this is worth doing is that the encoder is **per source**. One muxer serves every viewer of a stream, so encode cost is fixed however large the audience grows, and playlist polling was the only path that grew with it.

Two supporting changes were forced by that. `DriftCorrection` and `Failed` become atomics, since neither is determined by a segment cut. And the segment window had to stop reusing its backing array: `push` shifted retained headers down in place, which would write into a slice a lock-free reader was walking. It is copy on write now, one allocation per cut, and the type is renamed from `ring` to `segmentWindow` since it never was one and now is visibly not.

## Numbers

Measured on an i7-1260P, `-tags goaac_simd`, `-count=6`, benchstat against `main`.

Poll cost, from `BenchmarkPlaylistRender` (unchanged benchmark body, so the pairing is valid):

| | main | this branch |
| --- | --- | --- |
| ns/op | 2304 | 0.87 |
| B/op | 960 | 0 |
| allocs/op | 13 | 0 |

The write path under concurrent polling, which is the result that actually matters, since `Write` runs on the capture goroutine where added latency is a dropped buffer rather than lost throughput:

| viewers | main | this branch |
| --- | --- | --- |
| 1 | 162 us | 136 us |
| 2 | 166 us | 123 us |
| 8 | 155 us | 113 us |
| 16 | 168 us | 128 us |
| 64 | 218 us | 141 us |

Flat against audience size, where before it degraded. Allocation attributed to that path went from growing with viewers (326 B/op at 1 viewer to 14 KB at 64) to a flat 212 B/op regardless.

**The honest cost.** A segment cut goes from 1 to about 16 allocations: the playlist render moved onto the capture goroutine, plus the copy-on-write window slice and the snapshot. Bytes barely move (42.9 to 44.3 KiB, the segment dominates), and it is once per two seconds per stream. Break-even against the old per-poll render is roughly 1.2 viewers, so a single-viewer stream is about neutral and everything above that is a widening win. Profiling puts the added work below the CPU profiler's resolution: zero samples out of 2.26 s of collection, against 99% in the encoder.

`BenchmarkStreamWrite32k` moves from 0 to 2 allocs/op for the same reason, and that is expected rather than a regression: a 32 KiB write is 8192 samples against a roughly 95000-sample segment, so a cut amortises into every dozen writes.

## Bugs this surfaced, and fixed

Making the read lock-free exposed a defect that the mutex had been hiding, plus a worse variant of it. Both are in the follow-up commits.

**`Close` could publish `EXT-X-ENDLIST` before the final segment existed.** `Close` sets `s.closed` before flushing the encoder, deliberately: that is what refuses a racing `Write` and what stops a second `Close` re-entering a codec that has just panicked. But `publishView` rendered the ENDLIST tag from `s.closed`, so a segment cut triggered by the flush published a terminated playlist that omitted the very segment the flush was producing. A client honouring the tag stops polling and never fetches it. Previously `Playlist` held the mutex for the whole of `Close` and could only ever observe the final state.

**A panic in `enc.Flush` left the playlist live forever.** The final publish was described as unconditional, which held for a returned error but not for a panic: the unwind skipped it, and since `s.closed` was already set, the second `Close` returned early and nothing published again. Not hypothetical here, since `closeNativeMuxGuarded` exists in the handler specifically because that flush can panic.

Both fall to one change: `publishView` takes the ended flag explicitly, and `Close` registers it as a `defer` after the unlock defer so it runs first, still under the mutex, and runs during panic unwinding too.

Also fixed while in here: `retained()` and `Segment.Data` are both published capacity-clipped, so a caller's `append` cannot reach the array a concurrent reader is walking; `PlaylistAndStats` returns both from one snapshot load, so the handler no longer reasons about `Retained` as a bound across two loads; and the stale-segment warning now logs the drift and discontinuity counts, which are what separate a stopped source from a merely slow one.

## Tests and benchmarks

The package previously had no benchmark varying viewer count, so the lock-granularity question could not be settled with a number. It now has one, plus the segment-cut, concurrent-poll and window-lookup shapes.

Every new assertion was verified against the mutation it exists to catch, which caught two of my own tests being vacuous:

- The ENDLIST assertion passed with the code it guards deleted, because `Close` sets `s.closed` before flushing and the cut path supplied the tag. It now covers a stream with nothing buffered, where `Close`'s own publish is the only thing that can end the playlist.
- The transient-ENDLIST case cannot be seen from the final playlist, which is correct either way. A flush hook makes the intermediate publish observable, which works only because readers no longer take the lock.
- The concurrency test could not detect a reverted `push` at all: its readers retired before the writer and left the interesting cuts unobserved. With readers running until the writer finishes, the revert is caught every time.
- The read benchmark was measuring its own harness. Claiming one iteration per op from a shared atomic cost several times the atomic load under test, so over 90% of the reported figure was the counter, and it could not have told a tenfold regression from a tenfold win. It claims in batches now.
- The poll-rate metric added to make a starved benchmark run visible reported 0 in every configuration, because the counts were published from a defer that runs during `b.Cleanup`, after the body. Fixed, and it immediately confirmed that a 200 us ticker achieves about a fifth of its nominal rate.

## Risk

The native encoder is opt-in behind `BIRDNET_HLS_ENCODER=native` and is not the default, so a user on the FFmpeg path sees no change at all. `renderPlaylist` was verified to be a pure function of the window, target duration and ended flag, with no wall-clock dependence, so the served playlist is byte-identical to an on-demand render at every instant outside a write critical section. `Ready(n)` stays monotonic, so a viewer cannot regress from ready to not-ready. Memory grows by one extra segment payload per stream, about 34 KB, bounded by one window.

`golangci-lint` clean under the build tags CI uses, `go test -race` green on both packages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HLS playlist consistency during live playback and stream shutdown.
  - Reduced the chance of stale or mismatched playlist and stream status information.
  - Improved concurrent access reliability when playlists and media segments are requested simultaneously.
  - Refined polling behavior while waiting for the first available segment.
  - Added better diagnostics for delayed or discontinuous streams to support troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->