### PR TITLE
perf(hls): bound the live audio queue by bytes, not chunk count

### DIFF
--- a/internal/api/v2/audio/audio_hls.go
+++ b/internal/api/v2/audio/audio_hls.go
@@ -112,6 +112,25 @@ const (
 	// gives the native path's muxer configuration something to be checked
 	// against rather than a second bare literal.
 	hlsConsumerChannels = 1
+
+	// hlsFeedQueueUnbounded disables an audio feed queue's byte budget, leaving
+	// the channel's slot count (defaultReadBufferSize) as the only bound.
+	//
+	// This is what the FFmpeg path uses, deliberately. Its consumer writes PCM
+	// into a FIFO that the FFmpeg process reads, and FFmpeg cannot see a gap in
+	// what it is handed: it encodes whatever arrives as one continuous stream.
+	// Since pdtOffset is computed once from the first playlist and then applied
+	// to every later one, every dropped chunk shifts EXT-X-PROGRAM-DATE-TIME
+	// permanently behind wall-clock time, by the duration dropped. A budget
+	// tight enough to bite before fifoWriteTimeout (30s) gives up on the stall
+	// while FFmpeg is still willing to wait it out, and pays for it with a
+	// timeline that never recovers.
+	//
+	// The native path has no such coupling: it hands the muxer each chunk's own
+	// capture timestamp, so a drop shows up as a timestamp jump the muxer
+	// accounts for, and the timeline stays true. That is why it can afford
+	// nativeHLSFeedQueueBytes and this path cannot.
+	hlsFeedQueueUnbounded = 0
 )
 
 // HLSStreamInfo contains information about an active HLS streaming session
@@ -1544,7 +1563,7 @@ func (c *Handler) setupWindowsAudioFeed(ctx context.Context, sourceID string, cm
 		}()
 		apicore.GetLogger().Debug("Starting audio feed via stdin", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)))
 
-		audioChan, cleanup, err := c.setupAudioCallback(sourceID, c.ffmpegConsumerSampleRate())
+		feed, cleanup, err := c.setupAudioCallback(sourceID, c.ffmpegConsumerSampleRate(), hlsFeedQueueUnbounded)
 		if err != nil {
 			apicore.GetLogger().Error("Error setting up audio callback", logger.Error(err))
 			return
@@ -1556,11 +1575,14 @@ func (c *Handler) setupWindowsAudioFeed(ctx context.Context, sourceID string, cm
 			case <-ctx.Done():
 				apicore.GetLogger().Debug("Audio feed terminated due to context cancellation", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)))
 				return
-			case chunk, ok := <-audioChan:
+			case chunk, ok := <-feed.ch:
 				if !ok {
 					apicore.GetLogger().Debug("Audio channel closed", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)))
 					return
 				}
+				// Report the dequeue before anything can return early, so the
+				// producer's byte accounting cannot leak on a mid-loop exit.
+				feed.release(len(chunk.data))
 
 				data := chunk.data
 				written := 0
@@ -1622,12 +1644,82 @@ type audioChunk struct {
 	timestamp time.Time
 }
 
+// audioFeed is the per-stream PCM queue between the router, which produces
+// chunks on its dispatch goroutine, and an HLS feed loop, which drains them.
+//
+// The queue is bounded by bytes of queued PCM rather than by chunk count,
+// because chunk size is a property of the producer, not of HLS: the FFmpeg
+// ingest path emits ffmpegBufferSize (32 KiB) per frame, a directly captured
+// sound card emits miniaudio's default 10 ms period (under 1 KiB at 48 kHz
+// mono), and a route whose source rate differs from the consumer rate has a
+// resampler in between that changes the size again. A chunk-count bound
+// therefore means a different memory ceiling and a different amount of buffered
+// audio for every source; one small enough to bound RTSP frames leaves a sound
+// card with a fraction of a second of slack. A byte budget gives every producer
+// the same ceiling and the same wall-clock depth.
+//
+// Chunks leave the queue two ways, and each one has to be accounted for. The
+// producer evicts the oldest to make room: in makeRoom when the byte budget is
+// exceeded, and in Write's overflow arm when the channel's slots fill before the
+// byte budget does (which is the only eviction path when there is no budget).
+// The consumer receives. The invariant is simply that every
+// path removing a chunk from ch calls release(len(chunk.data)) for it; skipping
+// it leaves the producer believing the queue holds bytes that are already gone,
+// and the queue eventually evicts on every write.
+type audioFeed struct {
+	ch chan audioChunk
+
+	// maxBytes is the byte budget. hlsFeedQueueUnbounded disables it and leaves
+	// the channel's slot count as the only bound.
+	maxBytes int64
+
+	// queued is the PCM currently sitting in ch. It is only ever advisory:
+	// nothing serializes a producer's enqueue against a consumer's release, so
+	// it can lag reality by a chunk in either direction. That is bounded and
+	// harmless, since one chunk of slack on a multi-second budget changes
+	// neither the memory ceiling nor the buffered depth in any way that matters.
+	queued atomic.Int64
+}
+
+// release reports that a chunk of n bytes has been taken off the queue.
+func (f *audioFeed) release(n int) {
+	f.queued.Add(-int64(n))
+}
+
+// makeRoom evicts the oldest chunks until n more bytes fit within the byte
+// budget, returning the number of chunks it dropped.
+//
+// Dropping the oldest is the right policy for a live stream: the queue only
+// grows when the encoder falls behind, and audio that far behind the live edge
+// is past the point where any player would still ask for it.
+//
+// It stops early when the queue runs empty, which happens when a single chunk
+// is larger than the whole budget. Refusing that chunk would silence the stream
+// permanently rather than briefly, so it is admitted and the budget is exceeded
+// by that one chunk.
+func (f *audioFeed) makeRoom(n int) int {
+	if f.maxBytes <= 0 {
+		return 0
+	}
+	dropped := 0
+	for f.queued.Load()+int64(n) > f.maxBytes {
+		select {
+		case old := <-f.ch:
+			f.release(len(old.data))
+			dropped++
+		default:
+			return dropped
+		}
+	}
+	return dropped
+}
+
 // hlsConsumer implements audiocore.AudioConsumer for HLS streaming.
-// It forwards audio frames to a channel for encoding.
+// It forwards audio frames to a bounded feed queue (see audioFeed) for encoding.
 type hlsConsumer struct {
 	id       string
 	sourceID string
-	ch       chan audioChunk
+	feed     *audioFeed
 	rate     int
 	depth    int
 	channels int
@@ -1651,51 +1743,69 @@ func (h *hlsConsumer) BitDepth() int { return h.depth }
 // Channels returns the expected channel count.
 func (h *hlsConsumer) Channels() int { return h.channels }
 
-// Write delivers audio frame data to the HLS channel.
+// Write delivers audio frame data to the HLS feed queue.
 //
 // The frame data is copied before being sent so the caller (the audio router)
-// may safely reuse or recycle the underlying slice after Write returns. FFmpeg
-// reads asynchronously from the channel, so any retained slice header would
-// race with the caller's buffer reuse.
+// may safely reuse or recycle the underlying slice after Write returns. The
+// feed loop reads asynchronously from the queue, so any retained slice header
+// would race with the caller's buffer reuse.
+//
+// The send never blocks. A feed loop that has fallen behind costs the stream
+// its oldest queued audio, not the router its dispatch goroutine.
 func (h *hlsConsumer) Write(frame audiocore.AudioFrame) error { //nolint:gocritic // hugeParam: signature required by AudioConsumer interface
 	if h.closed.Load() {
 		return audiocore.ErrConsumerClosed
 	}
 
-	// Copy once up front. Both select arms below need an owned slice.
+	// Copy once up front. Every send arm below needs an owned slice.
 	chunk := audioChunk{data: slices.Clone(frame.Data), timestamp: frame.Timestamp}
+	chunkBytes := int64(len(chunk.data))
+
+	// Evict down to the byte budget first, so the queue is bounded by the PCM
+	// it holds rather than by the slot count of the channel behind it.
+	dropped := h.feed.makeRoom(len(chunk.data))
 
 	select {
-	case h.ch <- chunk:
+	case h.feed.ch <- chunk:
+		h.feed.queued.Add(chunkBytes)
 	default:
-		// Channel full, drop oldest to make room
-		dropped := false
+		// Slots exhausted while still inside the byte budget, which is what a
+		// stream of chunks far smaller than the budget looks like. Drop the
+		// oldest to make room, on the same reasoning as makeRoom.
 		select {
-		case <-h.ch:
-			dropped = true
+		case old := <-h.feed.ch:
+			h.feed.release(len(old.data))
+			dropped++
 		default:
 		}
-		// Non-blocking send - drop if still full
 		select {
-		case h.ch <- chunk:
+		case h.feed.ch <- chunk:
+			h.feed.queued.Add(chunkBytes)
 		default:
+			// Unreachable under the single-producer model (the eviction above,
+			// or the consumer draining, leaves a free slot before this retry),
+			// but count the loss rather than trust that invariant: if a second
+			// writer is ever added, the drop stays honest instead of silently
+			// under-reporting.
+			dropped++
 		}
+	}
 
-		if dropped {
-			h.dropMu.Lock()
-			h.dropCount++
-			now := time.Now()
-			if now.Sub(h.lastDropLog) >= hlsDropLogInterval {
-				sanitizedID := privacy.SanitizeRTSPUrl(h.sourceID)
-				apicore.GetLogger().Warn("HLS audio data dropped: channel full",
-					logger.String("source_id", sanitizedID),
-					logger.Int64("drops_since_last_log", h.dropCount),
-					logger.Int("channel_cap", defaultReadBufferSize))
-				h.dropCount = 0
-				h.lastDropLog = now
-			}
-			h.dropMu.Unlock()
+	if dropped > 0 {
+		h.dropMu.Lock()
+		h.dropCount += int64(dropped)
+		now := time.Now()
+		if now.Sub(h.lastDropLog) >= hlsDropLogInterval {
+			sanitizedID := privacy.SanitizeRTSPUrl(h.sourceID)
+			apicore.GetLogger().Warn("HLS audio data dropped: feed queue full",
+				logger.String("source_id", sanitizedID),
+				logger.Int64("drops_since_last_log", h.dropCount),
+				logger.Int64("queued_bytes", h.feed.queued.Load()),
+				logger.Int64("max_queued_bytes", h.feed.maxBytes))
+			h.dropCount = 0
+			h.lastDropLog = now
 		}
+		h.dropMu.Unlock()
 	}
 	return nil
 }
@@ -1716,11 +1826,16 @@ func (c *Handler) ffmpegConsumerSampleRate() int {
 	return hlsDefaultSampleRate
 }
 
-// setupAudioCallback sets up the audio callback channel using the AudioRouter.
+// setupAudioCallback sets up the audio feed queue using the AudioRouter.
 // sampleRate is the rate the consumer declares; the router inserts a resampler
-// whenever the source differs from it.
-func (c *Handler) setupAudioCallback(sourceID string, sampleRate int) (audioChan chan audioChunk, cleanup func(), err error) {
-	audioChan = make(chan audioChunk, defaultReadBufferSize)
+// whenever the source differs from it. maxQueuedBytes is the queue's byte
+// budget, or hlsFeedQueueUnbounded to leave the channel's slot count as the only
+// bound; see audioFeed for why the bound is in bytes rather than chunks.
+func (c *Handler) setupAudioCallback(sourceID string, sampleRate int, maxQueuedBytes int64) (feed *audioFeed, cleanup func(), err error) {
+	feed = &audioFeed{
+		ch:       make(chan audioChunk, defaultReadBufferSize),
+		maxBytes: maxQueuedBytes,
+	}
 
 	// hlsConsumerChannels is what this consumer declares to the router, and the
 	// native path derives its muxer sample-frame size from nativeHLSChannels.
@@ -1739,7 +1854,7 @@ func (c *Handler) setupAudioCallback(sourceID string, sampleRate int) (audioChan
 	consumer := &hlsConsumer{
 		id:       consumerID,
 		sourceID: sourceID,
-		ch:       audioChan,
+		feed:     feed,
 		rate:     sampleRate,
 		depth:    conf.BitDepth,
 		channels: hlsConsumerChannels,
@@ -1785,7 +1900,7 @@ func (c *Handler) setupAudioCallback(sourceID string, sampleRate int) (audioChan
 		apicore.GetLogger().Debug("Removed HLS audio route", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)), logger.String("consumer_id", consumerID))
 	}
 
-	return audioChan, cleanup, nil
+	return feed, cleanup, nil
 }
 
 // writeToFIFO performs a context-aware write to the FIFO pipe.
@@ -1817,10 +1932,10 @@ func writeToFIFO(ctx context.Context, fifo *os.File, data []byte) error {
 // callback is already registered and the FIFO is open when FFmpeg captures its
 // PROGRAM_DATE_TIME epoch.
 type audioFeedResources struct {
-	audioChan chan audioChunk    // Buffered channel receiving audio chunks from the broadcast callback
-	fifo      *os.File           // FIFO pipe opened for writing to FFmpeg (nil on the native path)
-	secFS     *securefs.SecureFS // Secure filesystem (nil on the native path; must be closed when done)
-	cleanup   func()             // Releases all resources (unregisters callback, closes FIFO and secFS)
+	feed    *audioFeed         // Feed queue from the router (byte-budgeted on the native path, slot-bounded otherwise)
+	fifo    *os.File           // FIFO pipe opened for writing to FFmpeg (nil on the native path)
+	secFS   *securefs.SecureFS // Secure filesystem (nil on the native path; must be closed when done)
+	cleanup func()             // Releases all resources (unregisters callback, closes FIFO and secFS)
 }
 
 // prepareAudioFeed initialises the audio callback and opens the FIFO pipe.
@@ -1843,7 +1958,7 @@ func (c *Handler) prepareAudioFeed(sourceID, pipePath string) (*audioFeedResourc
 
 	// Register the audio callback first so audio chunks start buffering
 	// in the channel while we open the FIFO and before FFmpeg starts.
-	audioChan, callbackCleanup, err := c.setupAudioCallback(sourceID, c.ffmpegConsumerSampleRate())
+	feed, callbackCleanup, err := c.setupAudioCallback(sourceID, c.ffmpegConsumerSampleRate(), hlsFeedQueueUnbounded)
 	if err != nil {
 		if closeErr := secFS.Close(); closeErr != nil {
 			apicore.GetLogger().Error("Failed to close secure filesystem", logger.Error(closeErr))
@@ -1866,9 +1981,9 @@ func (c *Handler) prepareAudioFeed(sourceID, pipePath string) (*audioFeedResourc
 	}
 
 	res := &audioFeedResources{
-		audioChan: audioChan,
-		fifo:      fifo,
-		secFS:     secFS,
+		feed:  feed,
+		fifo:  fifo,
+		secFS: secFS,
 		cleanup: func() {
 			callbackCleanup()
 			if closeErr := fifo.Close(); closeErr != nil {
@@ -1915,11 +2030,14 @@ func (c *Handler) runAudioFeedLoop(ctx context.Context, sourceID string, stream 
 			apicore.GetLogger().Debug("Audio feed stopped due to context cancellation",
 				logger.String("source_id", sanitizedID))
 			return
-		case chunk, ok := <-res.audioChan:
+		case chunk, ok := <-res.feed.ch:
 			if !ok {
 				apicore.GetLogger().Debug("Audio channel closed", logger.String("source_id", sanitizedID))
 				return
 			}
+			// Report the dequeue before anything can return early, so the
+			// producer's byte accounting cannot leak on a mid-loop exit.
+			res.feed.release(len(chunk.data))
 
 			data := chunk.data
 			writeStart := time.Now()

--- a/internal/api/v2/audio/audio_hls.go
+++ b/internal/api/v2/audio/audio_hls.go
@@ -1686,6 +1686,21 @@ func (f *audioFeed) release(n int) {
 	f.queued.Add(-int64(n))
 }
 
+// evictOldest drops the single oldest queued chunk if there is one, releasing
+// its bytes, and reports whether it evicted anything. It is the one place a
+// chunk leaves the queue on the producer side, so the receive and its matching
+// release stay welded together here rather than being repeated at each caller:
+// makeRoom's byte-budget loop and Write's slot-exhaustion arm both go through it.
+func (f *audioFeed) evictOldest() bool {
+	select {
+	case old := <-f.ch:
+		f.release(len(old.data))
+		return true
+	default:
+		return false
+	}
+}
+
 // makeRoom evicts the oldest chunks until n more bytes fit within the byte
 // budget, returning the number of chunks it dropped.
 //
@@ -1703,13 +1718,10 @@ func (f *audioFeed) makeRoom(n int) int {
 	}
 	dropped := 0
 	for f.queued.Load()+int64(n) > f.maxBytes {
-		select {
-		case old := <-f.ch:
-			f.release(len(old.data))
-			dropped++
-		default:
+		if !f.evictOldest() {
 			return dropped
 		}
+		dropped++
 	}
 	return dropped
 }
@@ -1772,11 +1784,8 @@ func (h *hlsConsumer) Write(frame audiocore.AudioFrame) error { //nolint:gocriti
 		// Slots exhausted while still inside the byte budget, which is what a
 		// stream of chunks far smaller than the budget looks like. Drop the
 		// oldest to make room, on the same reasoning as makeRoom.
-		select {
-		case old := <-h.feed.ch:
-			h.feed.release(len(old.data))
+		if h.feed.evictOldest() {
 			dropped++
-		default:
 		}
 		select {
 		case h.feed.ch <- chunk:

--- a/internal/api/v2/audio/audio_hls_feed_test.go
+++ b/internal/api/v2/audio/audio_hls_feed_test.go
@@ -1,0 +1,297 @@
+package audio
+
+import (
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+)
+
+// Frame sizes the HLS consumer sees in the field. They differ by two orders of
+// magnitude, which is the whole reason the feed queue is bounded by bytes
+// rather than by chunk count.
+const (
+	// rtspFrameBytes mirrors ffmpegBufferSize in internal/audiocore/ffmpeg,
+	// the read size of the FFmpeg ingest that feeds every RTSP source.
+	rtspFrameBytes = 32768
+
+	// soundCardFrameBytes is one miniaudio default low-latency period (10 ms)
+	// at 48 kHz mono 16-bit, which is what a directly captured USB microphone
+	// delivers: internal/audiocore/capture.go builds its device from
+	// malgo.DefaultDeviceConfig and never sets an explicit period size.
+	soundCardFrameBytes = 960
+)
+
+// newTestFeedConsumer builds an hlsConsumer over a feed with the given byte
+// budget, wired the way setupAudioCallback wires the real one.
+func newTestFeedConsumer(maxBytes int64) (*hlsConsumer, *audioFeed) {
+	feed := &audioFeed{
+		ch:       make(chan audioChunk, defaultReadBufferSize),
+		maxBytes: maxBytes,
+	}
+	return &hlsConsumer{
+		id:       "hls_test",
+		sourceID: "rtsp://user:pass@example.invalid/stream",
+		feed:     feed,
+		rate:     nativeHLSSampleRate,
+		depth:    16,
+		channels: hlsConsumerChannels,
+	}, feed
+}
+
+// writeFrame writes one frame of the given size, tagging its first 8 bytes with
+// seq so a drained chunk can be traced back to the write that produced it.
+func writeFrame(tb testing.TB, h *hlsConsumer, size int, seq uint64) {
+	tb.Helper()
+	require.GreaterOrEqual(tb, size, 8, "frames must be wide enough to carry the sequence tag")
+
+	data := make([]byte, size)
+	binary.BigEndian.PutUint64(data, seq)
+	require.NoError(tb, h.Write(audiocore.AudioFrame{
+		SourceID:   "src",
+		Data:       data,
+		SampleRate: nativeHLSSampleRate,
+		BitDepth:   16,
+		Channels:   hlsConsumerChannels,
+		Timestamp:  time.Unix(0, int64(seq)),
+	}))
+}
+
+// drainFeed empties the queue, reporting the sequence tags in order and the
+// total PCM the queue was holding.
+func drainFeed(feed *audioFeed) (seqs []uint64, totalBytes int64) {
+	for {
+		select {
+		case chunk := <-feed.ch:
+			feed.release(len(chunk.data))
+			seqs = append(seqs, binary.BigEndian.Uint64(chunk.data))
+			totalBytes += int64(len(chunk.data))
+		default:
+			return seqs, totalBytes
+		}
+	}
+}
+
+// TestAudioFeedBoundsQueuedPCM is the regression test for the reason the byte
+// budget exists: a 1024-slot channel of 32 KiB RTSP frames can hold 33.5 MB of
+// PCM per stream, which is 349 seconds of audio nobody will ever play back.
+func TestAudioFeedBoundsQueuedPCM(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		frameSize int
+		frames    int
+	}{
+		{
+			// The case from the report: 1024 of these used to queue 33.5 MB.
+			name:      "rtsp frames",
+			frameSize: rtspFrameBytes,
+			frames:    2 * defaultReadBufferSize,
+		},
+		{
+			// Small frames used to be bounded by the slot count long before
+			// they reached the byte budget. They must be bounded by bytes now.
+			name:      "sound card frames",
+			frameSize: soundCardFrameBytes,
+			frames:    2 * defaultReadBufferSize,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h, feed := newTestFeedConsumer(nativeHLSFeedQueueBytes)
+			for seq := range tc.frames {
+				writeFrame(t, h, tc.frameSize, uint64(seq))
+			}
+
+			assert.LessOrEqual(t, feed.queued.Load(), int64(nativeHLSFeedQueueBytes),
+				"the producer's byte accounting must stay inside the budget")
+
+			_, totalBytes := drainFeed(feed)
+			assert.LessOrEqual(t, totalBytes, int64(nativeHLSFeedQueueBytes),
+				"the PCM actually queued must stay inside the budget")
+			assert.Equal(t, int64(0), feed.queued.Load(),
+				"a fully drained queue must account for zero bytes")
+		})
+	}
+}
+
+// TestAudioFeedKeepsDepthForSmallFrames guards the reason the bound is in bytes
+// and not in chunks. A chunk count tight enough to bound 32 KiB RTSP frames
+// (8 to 16) would leave a sound card with a sixth of a second of slack; the
+// byte budget gives both producers the same multi-second depth.
+func TestAudioFeedKeepsDepthForSmallFrames(t *testing.T) {
+	t.Parallel()
+
+	h, feed := newTestFeedConsumer(nativeHLSFeedQueueBytes)
+	for seq := range defaultReadBufferSize {
+		writeFrame(t, h, soundCardFrameBytes, uint64(seq))
+	}
+
+	seqs, totalBytes := drainFeed(feed)
+
+	// Depth in time is what actually matters, so assert on that rather than on
+	// a chunk count that means something different for every producer.
+	const bytesPerSecond = nativeHLSSampleRate * nativeHLSChannels * nativeHLSBytesPerSample
+	bufferedSeconds := float64(totalBytes) / bytesPerSecond
+	assert.Greater(t, bufferedSeconds, 4.0,
+		"the queue must hold more than the ~4s a live listener sits behind the edge")
+	assert.Greater(t, len(seqs), 16,
+		"a 16-chunk bound would have kept 16 small frames; the byte budget keeps far more")
+}
+
+// TestAudioFeedDropsOldest verifies the eviction policy. On a live stream the
+// oldest queued audio is the least useful: it is furthest behind the edge and
+// closest to the point no player will request it.
+func TestAudioFeedDropsOldest(t *testing.T) {
+	t.Parallel()
+
+	// A budget of exactly four frames, so the arithmetic is exact.
+	const frameSize = 1024
+	const capacity = 4
+	h, feed := newTestFeedConsumer(frameSize * capacity)
+
+	const written = capacity + 3
+	for seq := range uint64(written) {
+		writeFrame(t, h, frameSize, seq)
+	}
+
+	seqs, totalBytes := drainFeed(feed)
+
+	require.Len(t, seqs, capacity, "the queue must hold exactly the budget")
+	assert.Equal(t, int64(frameSize*capacity), totalBytes)
+	assert.Equal(t, []uint64{3, 4, 5, 6}, seqs,
+		"the newest frames must survive and the oldest must be evicted")
+}
+
+// TestAudioFeedReleaseRestoresCapacity checks the accounting contract from the
+// consumer side: a feed loop that reports its dequeues gets the whole budget
+// back, so a queue that filled during a stall does not stay full afterwards.
+func TestAudioFeedReleaseRestoresCapacity(t *testing.T) {
+	t.Parallel()
+
+	const frameSize = 1024
+	const capacity = 4
+	h, feed := newTestFeedConsumer(frameSize * capacity)
+
+	for seq := range uint64(capacity) {
+		writeFrame(t, h, frameSize, seq)
+	}
+	require.Equal(t, int64(frameSize*capacity), feed.queued.Load())
+
+	seqs, _ := drainFeed(feed)
+	require.Len(t, seqs, capacity)
+	require.Equal(t, int64(0), feed.queued.Load())
+
+	// The next full budget must be admitted without a single eviction.
+	for seq := range uint64(capacity) {
+		writeFrame(t, h, frameSize, capacity+seq)
+	}
+	seqs, _ = drainFeed(feed)
+	assert.Equal(t, []uint64{4, 5, 6, 7}, seqs,
+		"a drained queue must accept a full budget again with nothing dropped")
+}
+
+// TestAudioFeedAdmitsOversizedChunk covers the makeRoom early exit. A chunk
+// larger than the entire budget can never be made to fit, and refusing it would
+// silence the stream permanently rather than briefly, so it is admitted and the
+// budget is exceeded by exactly that one chunk.
+func TestAudioFeedAdmitsOversizedChunk(t *testing.T) {
+	t.Parallel()
+
+	const budget = 4096
+	h, feed := newTestFeedConsumer(budget)
+
+	writeFrame(t, h, 1024, 0)
+	writeFrame(t, h, budget*2, 1)
+
+	seqs, totalBytes := drainFeed(feed)
+
+	assert.Equal(t, []uint64{1}, seqs,
+		"the oversized chunk must be admitted and the queue emptied to take it")
+	assert.Equal(t, int64(budget*2), totalBytes)
+}
+
+// TestAudioFeedUnboundedKeepsSlotBound pins the FFmpeg path's behaviour: with
+// hlsFeedQueueUnbounded the byte budget is inert and the channel's slot count
+// is the only bound, exactly as before the budget existed. Dropping PCM there
+// would shift EXT-X-PROGRAM-DATE-TIME permanently, because FFmpeg cannot see a
+// gap in what it is handed.
+func TestAudioFeedUnboundedKeepsSlotBound(t *testing.T) {
+	t.Parallel()
+
+	h, feed := newTestFeedConsumer(hlsFeedQueueUnbounded)
+
+	// Well past any byte budget: this is 32 MB of PCM at the RTSP frame size.
+	for seq := range uint64(defaultReadBufferSize) {
+		writeFrame(t, h, rtspFrameBytes, seq)
+	}
+
+	seqs, totalBytes := drainFeed(feed)
+
+	require.Len(t, seqs, defaultReadBufferSize,
+		"every slot must be used before anything is dropped")
+	assert.Equal(t, int64(defaultReadBufferSize)*rtspFrameBytes, totalBytes)
+	assert.Equal(t, uint64(0), seqs[0], "nothing should have been evicted")
+}
+
+// TestAudioFeedSlotExhaustionDropsOldest covers Write's slot-exhaustion arm: the
+// path taken when the channel's slots fill before the byte budget bites (an
+// unbounded feed, or any budget large enough that more than defaultReadBufferSize
+// chunks fit under it). makeRoom does nothing there, so the drop-oldest and the
+// release accounting are Write's own, and this is the only test that reaches
+// them. It exercises the audioFeed queue primitive directly; it does not drive
+// any encoder.
+func TestAudioFeedSlotExhaustionDropsOldest(t *testing.T) {
+	t.Parallel()
+
+	// Unbounded budget so the slot count, not the byte budget, is what bounds
+	// the queue. Small frames keep the intent legible.
+	h, feed := newTestFeedConsumer(hlsFeedQueueUnbounded)
+
+	const overflow = 3
+	const written = defaultReadBufferSize + overflow
+	for seq := range uint64(written) {
+		writeFrame(t, h, soundCardFrameBytes, seq)
+	}
+
+	seqs, totalBytes := drainFeed(feed)
+
+	require.Len(t, seqs, defaultReadBufferSize,
+		"the channel holds exactly its slot count once it overflows")
+	assert.Equal(t, int64(defaultReadBufferSize)*soundCardFrameBytes, totalBytes)
+	assert.Equal(t, uint64(overflow), seqs[0],
+		"the oldest `overflow` frames must be evicted, leaving the newest slot-count worth")
+	assert.Equal(t, uint64(written-1), seqs[len(seqs)-1],
+		"the most recent frame must survive")
+	assert.Equal(t, int64(0), feed.queued.Load(),
+		"release accounting through the slot-exhaustion arm must net to zero after a drain")
+}
+
+// TestAudioFeedWriteRejectsAfterClose keeps the closed-consumer contract intact
+// across the queue change: a closed consumer must not keep queueing PCM.
+func TestAudioFeedWriteRejectsAfterClose(t *testing.T) {
+	t.Parallel()
+
+	h, feed := newTestFeedConsumer(nativeHLSFeedQueueBytes)
+	require.NoError(t, h.Close())
+
+	err := h.Write(audiocore.AudioFrame{
+		SourceID:   "src",
+		Data:       make([]byte, rtspFrameBytes),
+		SampleRate: nativeHLSSampleRate,
+		BitDepth:   16,
+		Channels:   hlsConsumerChannels,
+	})
+
+	require.ErrorIs(t, err, audiocore.ErrConsumerClosed)
+	assert.Empty(t, feed.ch, "a closed consumer must not queue anything")
+	assert.Equal(t, int64(0), feed.queued.Load())
+}

--- a/internal/api/v2/audio/audio_hls_native.go
+++ b/internal/api/v2/audio/audio_hls_native.go
@@ -51,6 +51,25 @@ const (
 	// capture pipeline is 16-bit end to end, which hlsmux also assumes.
 	nativeHLSBytesPerSample = 2
 
+	// nativeHLSFeedQueueBytes is the byte budget for the PCM queued between the
+	// router and the feed loop. At nativeHLSSampleRate, nativeHLSChannels and
+	// nativeHLSBytesPerSample it is 5.4 seconds of audio.
+	//
+	// The depth only has to cover the encoder falling behind, and it does not
+	// fall behind: encoding costs about 2.5 ms of CPU per second of audio, so
+	// this is roughly a 2000x margin over the steady state and still absorbs a
+	// multi-second scheduling stall on a loaded ARM board. Depth past that is
+	// unusable rather than merely unnecessary. A live listener sits about 4
+	// seconds behind the edge (hls.js keeps liveSyncDurationCount segments of
+	// buffer), so audio queued deeper than this would be encoded into segments
+	// nobody will request.
+	//
+	// The bound is in bytes because chunk size belongs to the producer: RTSP
+	// ingest delivers 32 KiB frames, a directly captured sound card delivers
+	// miniaudio's 10 ms period, and a resampled route delivers something else
+	// again. See audioFeed.
+	nativeHLSFeedQueueBytes = 512 * 1024
+
 	// nativeHLSDefaultBitrate is the target in kbps when the setting is unset.
 	// The FFmpeg path resolves its own default through the same helper, so the
 	// two encoders cannot drift apart.
@@ -250,15 +269,15 @@ func (c *Handler) createNativeHLSStream(sourceID string) (*HLSStreamInfo, error)
 
 // prepareNativeAudioFeed registers the audio route. Unlike the FFmpeg path there
 // is no FIFO to open and no secure filesystem to hold, so the resources are just
-// the channel and the route cleanup.
+// the feed queue and the route cleanup.
 func (c *Handler) prepareNativeAudioFeed(sourceID string) (*audioFeedResources, error) {
-	audioChan, callbackCleanup, err := c.setupAudioCallback(sourceID, nativeHLSSampleRate)
+	feed, callbackCleanup, err := c.setupAudioCallback(sourceID, nativeHLSSampleRate, nativeHLSFeedQueueBytes)
 	if err != nil {
 		return nil, err
 	}
 	return &audioFeedResources{
-		audioChan: audioChan,
-		cleanup:   callbackCleanup,
+		feed:    feed,
+		cleanup: callbackCleanup,
 	}, nil
 }
 
@@ -311,11 +330,14 @@ func (c *Handler) runNativeAudioFeedLoop(ctx context.Context, sourceID string, s
 			apicore.GetLogger().Debug("Native audio feed stopped due to context cancellation",
 				logger.String("source_id", sanitizedID))
 			return
-		case chunk, ok := <-res.audioChan:
+		case chunk, ok := <-res.feed.ch:
 			if !ok {
 				apicore.GetLogger().Debug("Audio channel closed", logger.String("source_id", sanitizedID))
 				return
 			}
+			// Report the dequeue before anything can return early, so the
+			// producer's byte accounting cannot leak on a mid-loop exit.
+			res.feed.release(len(chunk.data))
 
 			// A frame with no capture time would anchor program-date-time to the
 			// zero instant, putting every segment in year 1. Falling back to now

--- a/internal/api/v2/audio/audio_hls_native_test.go
+++ b/internal/api/v2/audio/audio_hls_native_test.go
@@ -291,8 +291,8 @@ func TestNativeFeedLoopAnchorsPDTToCaptureTime(t *testing.T) {
 	defer cancel()
 	// The loop returns when the channel closes.
 	h.runNativeAudioFeedLoop(ctx, "native_src", stream, &audioFeedResources{
-		audioChan: ch,
-		cleanup:   func() {},
+		feed:    &audioFeed{ch: ch},
+		cleanup: func() {},
 	})
 
 	require.True(t, mux.Ready(1), "the feed loop must have produced segments")
@@ -326,8 +326,8 @@ func TestNativeFeedLoopFallsBackWhenCaptureTimeMissing(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 	h.runNativeAudioFeedLoop(ctx, "native_src", stream, &audioFeedResources{
-		audioChan: ch,
-		cleanup:   func() {},
+		feed:    &audioFeed{ch: ch},
+		cleanup: func() {},
 	})
 
 	require.True(t, mux.Ready(1))
@@ -352,8 +352,8 @@ func TestNativeFeedLoopStopsOnContextCancel(t *testing.T) {
 	cancel()
 
 	h.runNativeAudioFeedLoop(ctx, "native_src", stream, &audioFeedResources{
-		audioChan: make(chan audioChunk),
-		cleanup:   func() { cleanupCalled = true },
+		feed:    &audioFeed{ch: make(chan audioChunk)},
+		cleanup: func() { cleanupCalled = true },
 	})
 
 	assert.True(t, cleanupCalled, "the route must be unregistered when the loop exits")
@@ -473,7 +473,7 @@ func TestNativeFeedLoopAccumulatesSubSampleChunks(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 120*time.Second)
 	defer cancel()
 	h.runNativeAudioFeedLoop(ctx, "native_src", stream, &audioFeedResources{
-		audioChan: ch, cleanup: func() {},
+		feed: &audioFeed{ch: ch}, cleanup: func() {},
 	})
 
 	assert.False(t, stream.mux.Stats().Failed, "sub-sample chunks are not an encoder failure")
@@ -504,7 +504,7 @@ func TestNativeFeedLoopSurvivesAlternatingOddChunks(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
 	defer cancel()
 	h.runNativeAudioFeedLoop(ctx, "native_src", stream, &audioFeedResources{
-		audioChan: ch, cleanup: func() {},
+		feed: &audioFeed{ch: ch}, cleanup: func() {},
 	})
 
 	assert.False(t, stream.mux.Stats().Failed,

--- a/internal/api/v2/audio/audio_hls_test.go
+++ b/internal/api/v2/audio/audio_hls_test.go
@@ -603,7 +603,7 @@ func TestHLSConsumer_WriteDoesNotRetainFrameData(t *testing.T) {
 	h := &hlsConsumer{
 		id:       "test",
 		sourceID: "src",
-		ch:       ch,
+		feed:     &audioFeed{ch: ch},
 		rate:     48000,
 		depth:    16,
 		channels: 1,

--- a/internal/api/v2/audio/handler.go
+++ b/internal/api/v2/audio/handler.go
@@ -64,8 +64,14 @@ const (
 	filePermReadWrite  = 0o644
 	filePermExecutable = 0o755
 
-	// defaultReadBufferSize is the default channel/buffer capacity for the HLS
-	// audio feed.
+	// defaultReadBufferSize is the slot capacity of an HLS audio feed's channel.
+	//
+	// It bounds how many chunks can be queued, not how much memory they hold:
+	// chunk size belongs to the producer, so the same slot count is 33 MB of
+	// PCM for a 32 KiB RTSP frame and under 1 MB for a sound card's 10 ms
+	// period. The memory bound is audioFeed's byte budget; this is sized so
+	// that even the smallest chunks reach that budget before they run out of
+	// slots. The ring itself costs one audioChunk header per slot (48 bytes).
 	defaultReadBufferSize = 1024
 )
 


### PR DESCRIPTION
## Summary

The per-stream PCM queue between the audio router and the HLS feed loop was a 1024-slot channel with no byte bound (`make(chan audioChunk, defaultReadBufferSize)`). With RTSP ingest delivering 32 KiB frames, a stalled consumer could hold 1024 x 32 KiB = 33.5 MB of PCM per stream, about 349 seconds of 48 kHz mono audio. None of that depth is servable: a live listener sits roughly 4 seconds behind the edge (hls.js keeps `liveSyncDurationCount` segments buffered), so anything past the first couple of segments is encoded into segments no player will ever request. Because Go sizes the heap from its high-water mark and returns pages lazily, a single hiccup that fills the queue raises RSS for the life of the process. On a platform where 512 MB is still an unmet target this is worth bounding whether or not it turns out to dominate a given heap profile.

The fix bounds the queue by queued PCM bytes instead of by chunk count. Chunk size is a property of the producer, not of HLS: RTSP ingest delivers 32 KiB frames, a directly captured sound card delivers miniaudio's default 10 ms period (about 960 bytes at 48 kHz mono), and a route whose source rate differs from the consumer rate has a resampler in between that changes the size again. A chunk-count bound therefore means a different memory ceiling and a different amount of buffered audio for every source; one small enough to bound RTSP frames would leave a sound card with a fraction of a second of slack. A byte budget gives every producer the same ceiling and the same wall-clock depth.

The native encoder path caps queued PCM at 512 KiB (about 5.4 seconds), dropping the oldest chunks past that. That is generous against the roughly 4 second live edge and the roughly 2.5 ms of CPU per second of audio the encoder actually costs, so the queue only ever fills during a multi-second stall, and audio that far behind the edge is past the point any player would still ask for it. Worst case per stream falls from 33.5 MB to 512 KiB plus the 48 KB slot ring.

The legacy encoder path is deliberately left byte-unbounded and keeps the prior 1024-slot behaviour exactly. It feeds PCM to a separate process that cannot see a gap in what it is handed, and its playlist timeline epoch is computed once, so a dropped chunk there would shift the timeline permanently rather than briefly. The native path has no such coupling: it hands the muxer each chunk's own capture timestamp, so a drop shows up as a timestamp jump the muxer accounts for and the timeline stays true.

## Implementation notes

- New `audioFeed` type wraps the channel with an `atomic.Int64` byte counter and a byte budget. `Write` evicts the oldest chunks down to the budget before a non-blocking send; the send never blocks the router's dispatch goroutine. The three feed loops each report a dequeue via `release()` immediately after receiving, before any early return, so the counter cannot leak on a mid-loop exit.
- The counter is advisory under the single-producer / single-consumer model (bounded one-chunk skew), which is sufficient for a queue bound and never used for correctness.
- Minor operator-facing change: the drop warning log message and fields changed (`channel_cap` int replaced by `queued_bytes` / `max_queued_bytes` int64, message wording updated). This is a throttled degraded-condition WARN, not routine parsed output.

## Test plan

- [x] New `audio_hls_feed_test.go` covers the byte bound for large (32 KiB) and small (960 B) frames, small-frame time depth, drop-oldest ordering, `release` accounting round-trips, oversized-chunk admission, the slot-exhaustion drop path, and the unbounded path.
- [x] `go test -race ./internal/api/v2/audio/...` green.
- [x] `go vet` clean, `golangci-lint run` reports 0 issues.
- [x] Regression review confirms the legacy path is byte-for-byte behaviourally identical and no config, API, DB, or CLI surface is touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HLS audio streaming stability by managing buffered audio more effectively.
  * Prevented excessive audio backlog and memory growth during slow or overloaded playback conditions.
  * Preserved smooth audio delivery across native, FFmpeg, and Windows playback paths.
  * Added safer handling when audio consumers close or cannot accept additional data.

* **Documentation**
  * Clarified how audio buffering capacity affects playback behavior and resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->