### PR TITLE
feat(bat): support head-pruned embedding-only v2.4 embedding model

### DIFF
--- a/internal/classifier/bat_onnx.go
+++ b/internal/classifier/bat_onnx.go
@@ -56,13 +56,6 @@ type BatModelConfig struct {
 	OpenVINODevice string // BirdNET.OpenVINODevice ("auto"/"cpu"/"gpu")
 }
 
-// batEmbeddingOutputIndex is the output port of the bat embedding model
-// (birdnet-v24-embeddings.onnx) that carries the embedding vector; port 0 is the
-// species logits, which the bat pipeline discards. The selected port's element count
-// is validated against the bat classifier's input dimension in tryBatOpenVINO, so a
-// wrong index degrades to ORT rather than feeding a malformed embedding downstream.
-const batEmbeddingOutputIndex = 1
-
 // NewBat creates a new bat detection model instance.
 func NewBat(cfg *BatModelConfig) (*Bat, error) {
 	log := GetLogger()
@@ -117,7 +110,7 @@ func NewBat(cfg *BatModelConfig) (*Bat, error) {
 		if !isExtractor {
 			embClassifier.Close()
 			batCC.Close()
-			return nil, errors.Newf("embedding model does not support embedding extraction; ensure it has 2 outputs").
+			return nil, errors.Newf("embedding model does not support embedding extraction").
 				Category(errors.CategoryModelInit).
 				Context("embedding_model", cfg.EmbeddingModelPath).
 				Build()
@@ -164,13 +157,34 @@ func NewBat(cfg *BatModelConfig) (*Bat, error) {
 // f16. expectedDim is the bat classifier's input dimension, used to reject a wrong
 // output port before any inference.
 func tryBatOpenVINO(cfg *BatModelConfig, expectedDim int) (inference.EmbeddingExtractor, string, bool) {
-	plan, ok, reason := openVINOPlanFor(cfg.Backend, cfg.OpenVINODevice, RegistryIDBat, cfg.OpenVINOPath, batEmbeddingOutputIndex)
+	log := GetLogger()
+
+	// openVINOPlanFor gates on the build tag, backend preference, and device
+	// availability without needing the output port, so run it first; only read the
+	// model metadata to resolve the embedding port once OpenVINO is actually in play.
+	// This avoids a wasted metadata read (and a misleading warning) on the common
+	// non-OpenVINO build. The output index passed here is a placeholder, overwritten
+	// below once detected.
+	plan, ok, reason := openVINOPlanFor(cfg.Backend, cfg.OpenVINODevice, RegistryIDBat, cfg.OpenVINOPath, 0)
 	if !ok {
 		logOpenVINODeclined(RegistryIDBat, cfg.Backend, reason)
 		return nil, "", false
 	}
 
-	log := GetLogger()
+	// Resolve which output port carries the [1024] embedding: index 1 for the 2-output
+	// backbone (logits@0 + embedding@1), index 0 for the head-pruned, embedding-only
+	// model. The OpenVINO extractor binds to a fixed port at compile time. On any
+	// detection failure, decline OpenVINO and fall back to ORT, which derives the
+	// embedding port internally. ORT is initialized by NewBat before this runs.
+	embIndex, _, err := inference.DetectEmbeddingOutput(cfg.EmbeddingModelPath)
+	if err != nil {
+		log.Warn("Bat OpenVINO embedding-output detection failed; using ONNX Runtime",
+			logger.String("embedding_model", cfg.EmbeddingModelPath),
+			logger.Error(err))
+		return nil, "", false
+	}
+	plan.outputIndex = embIndex
+
 	// InitOpenVINO is idempotent: the auto/GPU plan above may already have loaded the
 	// core to enumerate devices, but the explicit-CPU plan path does not, so init here
 	// to cover it. A load failure means no usable OpenVINO; fall back to ORT.

--- a/internal/classifier/openvino_dispatch_test.go
+++ b/internal/classifier/openvino_dispatch_test.go
@@ -121,7 +121,9 @@ func TestTryBatOpenVINO_FallsBackWithoutTag(t *testing.T) {
 // logs why OpenVINO was declined rather than falling back silently.
 func TestOpenVINOPlanForBat_NotBuilt(t *testing.T) {
 	t.Parallel()
-	_, ok, reason := openVINOPlanFor(conf.BackendPrefOpenVINO, conf.OVDeviceGPU, RegistryIDBat, "", batEmbeddingOutputIndex)
+	// Output index 1 is the 2-output backbone's embedding port; its exact value is
+	// immaterial here since the no-tag planner declines before using it.
+	_, ok, reason := openVINOPlanFor(conf.BackendPrefOpenVINO, conf.OVDeviceGPU, RegistryIDBat, "", 1)
 	assert.False(t, ok)
 	assert.Equal(t, ovReasonNotBuilt, reason)
 }

--- a/internal/classifier/openvino_gating_openvino_test.go
+++ b/internal/classifier/openvino_gating_openvino_test.go
@@ -86,6 +86,9 @@ func TestOpenVINOPlan_ExplicitCPU(t *testing.T) {
 // "f32 everywhere" deviation at the plan level, where compilation actually reads it.
 func TestOpenVINOPlan_Bat_ForcesF32(t *testing.T) {
 	t.Parallel()
+	// Output index 1 is the 2-output backbone's embedding port (the head-pruned model's
+	// port is resolved at runtime from model metadata, not from a constant).
+	const batEmbeddingOutputIndex = 1
 	plan, ok, reason := openVINOPlanFor(conf.BackendPrefOpenVINO, conf.OVDeviceCPU, RegistryIDBat, "", batEmbeddingOutputIndex)
 	expected := cpuspec.HasNativeF16() || runtime.GOARCH == archAMD64
 	assert.Equal(t, expected, ok, "explicit CPU is allowed on ARM A76 or amd64, not on ARM A72")

--- a/internal/inference/onnx.go
+++ b/internal/inference/onnx.go
@@ -113,6 +113,16 @@ func (c *onnxClassifier) Close() {
 	}
 }
 
+// DetectEmbeddingOutput returns the output-port index and size of a model's BirdNET
+// v2.4 embedding output ([.,1024]): index 1 for the 2-output backbone (logits@0 +
+// embedding@1), index 0 for the head-pruned, embedding-only model. The bat OpenVINO
+// path uses it to bind the embedding extractor to the correct port before inference.
+// Returns an error when the model has no 1024-dim output. The ONNX Runtime must be
+// initialized via InitONNXRuntime before calling.
+func DetectEmbeddingOutput(modelPath string) (index, size int, err error) {
+	return ort.DetectEmbeddingOutput(modelPath)
+}
+
 // ONNXCustomClassifierOptions configures the ONNX custom classifier.
 type ONNXCustomClassifierOptions struct {
 	Labels     []string // Provide labels directly (takes priority over LabelsPath)

--- a/internal/inference/onnx/classifier.go
+++ b/internal/inference/onnx/classifier.go
@@ -183,10 +183,13 @@ func resolveModelType(cfg *classifierConfig, inputShapes [][]int64, numOutputs i
 
 // validateLabelCount checks that the label count matches the model's logits output dimension.
 func validateLabelCount(modelCfg *ModelConfig, outputInfos []ort.InputOutputInfo, labelCount int) error {
-	// An embedding-only model (LogitsIndex < 0) produces no logits, so there is no
-	// logits dimension to validate the label count against.
+	// An embedding-only model (LogitsIndex < 0) produces no logits, so it cannot serve
+	// the provided species labels. Reject it here so a model misconfigured as a
+	// label-validated classifier fails at construction with a clear message rather than
+	// only later at prediction time. Embedding-only consumers (the bat pipeline) load
+	// the model with WithSkipLabelValidation, which bypasses this check entirely.
 	if modelCfg.LogitsIndex < 0 {
-		return nil
+		return fmt.Errorf("birdnet: model produces no logits (embedding-only); it cannot be used as a label-validated classifier; load it with WithSkipLabelValidation for embedding extraction")
 	}
 	if modelCfg.LogitsIndex >= len(outputInfos) {
 		return fmt.Errorf("birdnet: LogitsIndex %d is out of range for model with %d outputs", modelCfg.LogitsIndex, len(outputInfos))

--- a/internal/inference/onnx/classifier.go
+++ b/internal/inference/onnx/classifier.go
@@ -183,7 +183,12 @@ func resolveModelType(cfg *classifierConfig, inputShapes [][]int64, numOutputs i
 
 // validateLabelCount checks that the label count matches the model's logits output dimension.
 func validateLabelCount(modelCfg *ModelConfig, outputInfos []ort.InputOutputInfo, labelCount int) error {
-	if modelCfg.LogitsIndex < 0 || modelCfg.LogitsIndex >= len(outputInfos) {
+	// An embedding-only model (LogitsIndex < 0) produces no logits, so there is no
+	// logits dimension to validate the label count against.
+	if modelCfg.LogitsIndex < 0 {
+		return nil
+	}
+	if modelCfg.LogitsIndex >= len(outputInfos) {
 		return fmt.Errorf("birdnet: LogitsIndex %d is out of range for model with %d outputs", modelCfg.LogitsIndex, len(outputInfos))
 	}
 	logitsDims := outputInfos[modelCfg.LogitsIndex].Dimensions
@@ -283,20 +288,24 @@ func (c *Classifier) PredictRawWithEmbeddings(audio []float32) (logits, embeddin
 		return nil, nil, fmt.Errorf("birdnet: inference failed: %w", err)
 	}
 
-	logitsTensor, ok := outputs[c.config.LogitsIndex].(*ort.Tensor[float32])
-	if !ok {
-		return nil, nil, fmt.Errorf("birdnet: logits tensor has unexpected type")
+	// Embedding-only models (LogitsIndex < 0, e.g. the head-pruned bat backbone)
+	// produce no logits; skip logits extraction and return nil logits.
+	if c.config.LogitsIndex >= 0 {
+		logitsTensor, ok := outputs[c.config.LogitsIndex].(*ort.Tensor[float32])
+		if !ok {
+			return nil, nil, fmt.Errorf("birdnet: logits tensor has unexpected type")
+		}
+		allLogits := logitsTensor.GetData()
+		logitsSize := c.config.LogitsSize
+		if logitsSize <= 0 {
+			return nil, nil, fmt.Errorf("birdnet: invalid logits size %d", logitsSize)
+		}
+		if logitsSize > len(allLogits) {
+			return nil, nil, fmt.Errorf("birdnet: logits tensor too small: need %d, have %d", logitsSize, len(allLogits))
+		}
+		logits = make([]float32, logitsSize)
+		copy(logits, allLogits[:logitsSize])
 	}
-	allLogits := logitsTensor.GetData()
-	logitsSize := c.config.LogitsSize
-	if logitsSize <= 0 {
-		return nil, nil, fmt.Errorf("birdnet: invalid logits size %d", logitsSize)
-	}
-	if logitsSize > len(allLogits) {
-		return nil, nil, fmt.Errorf("birdnet: logits tensor too small: need %d, have %d", logitsSize, len(allLogits))
-	}
-	logits = make([]float32, logitsSize)
-	copy(logits, allLogits[:logitsSize])
 
 	if c.config.EmbeddingIndex >= 0 {
 		embTensor, ok := outputs[c.config.EmbeddingIndex].(*ort.Tensor[float32])
@@ -459,13 +468,17 @@ func (c *Classifier) outputShape(outputIdx, batchSize int) ([]int64, error) {
 	batch := int64(batchSize)
 	switch c.config.Type {
 	case BirdNETv24:
+		// Index-aware so it covers the 2-output model (logits@0 + embedding@1), the
+		// head-pruned embedding-only model (embedding@0, no logits), and the plain
+		// 1-output classifier (logits@0, no embedding). EmbeddingIndex/LogitsIndex are
+		// -1 when absent, which never equals a real outputIdx (>= 0).
 		switch outputIdx {
-		case 0:
-			return []int64{batch, int64(c.config.LogitsSize)}, nil
-		case 1:
+		case c.config.EmbeddingIndex:
 			if c.config.EmbeddingSize > 0 {
 				return []int64{batch, int64(c.config.EmbeddingSize)}, nil
 			}
+		case c.config.LogitsIndex:
+			return []int64{batch, int64(c.config.LogitsSize)}, nil
 		}
 	case BirdNETv30:
 		switch outputIdx {
@@ -491,6 +504,11 @@ func (c *Classifier) outputShape(outputIdx, batchSize int) ([]int64, error) {
 
 // processOutput extracts predictions and embeddings from output tensors for a given batch index.
 func (c *Classifier) processOutput(outputs []ort.Value, batchIdx int) (*Result, error) {
+	// An embedding-only model produces no logits and therefore no species
+	// predictions; callers that need embeddings must use PredictRawWithEmbeddings.
+	if c.config.LogitsIndex < 0 {
+		return nil, fmt.Errorf("birdnet: model has no logits output; use PredictRawWithEmbeddings for embedding extraction")
+	}
 	logitsTensor, ok := outputs[c.config.LogitsIndex].(*ort.Tensor[float32])
 	if !ok {
 		return nil, fmt.Errorf("birdnet: logits tensor has unexpected type")

--- a/internal/inference/onnx/detection.go
+++ b/internal/inference/onnx/detection.go
@@ -1,6 +1,10 @@
 package onnx
 
-import "fmt"
+import (
+	"fmt"
+
+	ort "github.com/yalue/onnxruntime_go"
+)
 
 // Known model sample counts and output counts for auto-detection.
 const (
@@ -11,6 +15,7 @@ const (
 	numOutputsV30    = 2      // BirdNET v3.0: embeddings + logits
 	numOutputsPerch  = 4      // Perch v2: embeddings + features + attention + logits
 
+	embeddingSizeV24   = 1024 // BirdNET v2.4 embedding dimension (head-pruned embedding-only model)
 	embeddingSizeV30   = 1280 // BirdNET v3.0 embedding dimension
 	embeddingSizePerch = 1536 // Perch v2 embedding dimension
 )
@@ -59,12 +64,28 @@ func buildModelConfig(mt ModelType, inputShape []int64, outputShapes [][]int64) 
 
 	switch mt {
 	case BirdNETv24:
-		cfg.LogitsIndex = 0
-		cfg.LogitsSize = lastDim(outputShapes[0])
-		if numOutputs >= 2 {
-			if embSize := lastDim(outputShapes[1]); embSize > 0 {
-				cfg.EmbeddingIndex = 1
-				cfg.EmbeddingSize = embSize
+		if numOutputs == 1 && lastDim(outputShapes[0]) == embeddingSizeV24 {
+			// Head-pruned embedding-only backbone: a single [.,1024] embedding output
+			// (the [6522] logits head is pruned). Distinguished from the plain
+			// 1-output classifier ([.,6522] logits) by output size. LogitsSize stays 0
+			// and LogitsIndex is -1 to mark that this model produces no logits.
+			//
+			// Disambiguation is by output size: a hypothetical custom BirdNET v2.4
+			// classifier with exactly 1024 output classes would be misread as
+			// embedding-only. The shipped models make this safe (the classifier head is
+			// 6522 classes, the backbone embedding is 1024), and a 1024-class v2.4
+			// classifier is not a configuration this project produces.
+			cfg.LogitsIndex = -1
+			cfg.EmbeddingIndex = 0
+			cfg.EmbeddingSize = embeddingSizeV24
+		} else {
+			cfg.LogitsIndex = 0
+			cfg.LogitsSize = lastDim(outputShapes[0])
+			if numOutputs >= 2 {
+				if embSize := lastDim(outputShapes[1]); embSize > 0 {
+					cfg.EmbeddingIndex = 1
+					cfg.EmbeddingSize = embSize
+				}
 			}
 		}
 	case BirdNETv30:
@@ -87,4 +108,33 @@ func lastDim(shape []int64) int {
 		return 0
 	}
 	return int(shape[len(shape)-1])
+}
+
+// DetectEmbeddingOutput inspects an ONNX model's output tensors and returns the
+// index and size of its BirdNET v2.4 embedding output (the [.,1024] tensor). The
+// bat OpenVINO path uses this to bind the extractor to the correct output port up
+// front, before inference. Returns a ModelDetectionError when the model has no
+// 1024-dim output.
+func DetectEmbeddingOutput(modelPath string) (index, size int, err error) {
+	_, outputInfos, err := ort.GetInputOutputInfo(modelPath)
+	if err != nil {
+		return -1, 0, fmt.Errorf("birdnet: failed to load model metadata: %w", err)
+	}
+	return selectEmbeddingOutput(outputInfos)
+}
+
+// selectEmbeddingOutput returns the index and size of the BirdNET v2.4 embedding
+// output ([.,1024]) among a model's output tensors: index 1 for the 2-output backbone
+// (logits@0 + embedding@1), index 0 for the head-pruned, embedding-only model. Returns
+// a ModelDetectionError when no 1024-dim output exists. Split out so the port-selection
+// logic is unit-testable without a real ONNX model.
+func selectEmbeddingOutput(outputInfos []ort.InputOutputInfo) (index, size int, err error) {
+	for i := range outputInfos {
+		if lastDim(outputInfos[i].Dimensions) == embeddingSizeV24 {
+			return i, embeddingSizeV24, nil
+		}
+	}
+	return -1, 0, &ModelDetectionError{
+		Reason: fmt.Sprintf("model has no %d-dim embedding output", embeddingSizeV24),
+	}
 }

--- a/internal/inference/onnx/detection_test.go
+++ b/internal/inference/onnx/detection_test.go
@@ -1,0 +1,218 @@
+package onnx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ort "github.com/yalue/onnxruntime_go"
+)
+
+// v24LogitsSize is the BirdNET v2.4 species-logits dimension, used here to build
+// representative output shapes for the model-config tests.
+const v24LogitsSize = 6522
+
+// TestBuildModelConfig_BirdNETv24 covers the three BirdNET v2.4 output layouts the
+// bat pipeline must distinguish: the current 2-output backbone (logits@0 +
+// embedding@1), the head-pruned embedding-only model (embedding@0, no logits), and
+// the plain single-output classifier (logits@0, no embedding). The embedding-only
+// case is disambiguated from the plain classifier purely by output size (1024 vs
+// 6522), since both have a single output.
+func TestBuildModelConfig_BirdNETv24(t *testing.T) {
+	t.Parallel()
+	inputShape := []int64{1, sampleCountV24}
+	tests := []struct {
+		name           string
+		outputShapes   [][]int64
+		wantLogitsIdx  int
+		wantLogitsSize int
+		wantEmbIdx     int
+		wantEmbSize    int
+	}{
+		{
+			name:           "two-output backbone (logits@0 + embedding@1)",
+			outputShapes:   [][]int64{{1, v24LogitsSize}, {1, embeddingSizeV24}},
+			wantLogitsIdx:  0,
+			wantLogitsSize: v24LogitsSize,
+			wantEmbIdx:     1,
+			wantEmbSize:    embeddingSizeV24,
+		},
+		{
+			name:           "head-pruned embedding-only (embedding@0, no logits)",
+			outputShapes:   [][]int64{{1, embeddingSizeV24}},
+			wantLogitsIdx:  -1,
+			wantLogitsSize: 0,
+			wantEmbIdx:     0,
+			wantEmbSize:    embeddingSizeV24,
+		},
+		{
+			name:           "plain single-output classifier (logits@0, no embedding)",
+			outputShapes:   [][]int64{{1, v24LogitsSize}},
+			wantLogitsIdx:  0,
+			wantLogitsSize: v24LogitsSize,
+			wantEmbIdx:     -1,
+			wantEmbSize:    0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := buildModelConfig(BirdNETv24, inputShape, tt.outputShapes)
+			assert.Equal(t, BirdNETv24, cfg.Type)
+			assert.Equal(t, len(tt.outputShapes), cfg.NumOutputs)
+			assert.Equal(t, tt.wantLogitsIdx, cfg.LogitsIndex, "LogitsIndex")
+			assert.Equal(t, tt.wantLogitsSize, cfg.LogitsSize, "LogitsSize")
+			assert.Equal(t, tt.wantEmbIdx, cfg.EmbeddingIndex, "EmbeddingIndex")
+			assert.Equal(t, tt.wantEmbSize, cfg.EmbeddingSize, "EmbeddingSize")
+		})
+	}
+}
+
+// TestValidateLabelCount checks that an embedding-only model (LogitsIndex < 0) skips
+// label validation entirely (it has no logits to validate against), while a normal
+// logits model still validates the label count and rejects an out-of-range index.
+func TestValidateLabelCount(t *testing.T) {
+	t.Parallel()
+
+	t.Run("embedding-only model skips validation", func(t *testing.T) {
+		t.Parallel()
+		cfg := &ModelConfig{LogitsIndex: -1}
+		// A nonsense label count and nil outputs must still pass: there are no logits.
+		require.NoError(t, validateLabelCount(cfg, nil, 999))
+	})
+
+	t.Run("matching label count passes", func(t *testing.T) {
+		t.Parallel()
+		cfg := &ModelConfig{LogitsIndex: 0}
+		outputs := []ort.InputOutputInfo{{Dimensions: ort.NewShape(1, v24LogitsSize)}}
+		require.NoError(t, validateLabelCount(cfg, outputs, v24LogitsSize))
+	})
+
+	t.Run("mismatched label count errors", func(t *testing.T) {
+		t.Parallel()
+		cfg := &ModelConfig{LogitsIndex: 0}
+		outputs := []ort.InputOutputInfo{{Dimensions: ort.NewShape(1, v24LogitsSize)}}
+		require.Error(t, validateLabelCount(cfg, outputs, v24LogitsSize-1))
+	})
+
+	t.Run("logits index out of range errors", func(t *testing.T) {
+		t.Parallel()
+		cfg := &ModelConfig{LogitsIndex: 2}
+		outputs := []ort.InputOutputInfo{{Dimensions: ort.NewShape(1, v24LogitsSize)}}
+		require.Error(t, validateLabelCount(cfg, outputs, v24LogitsSize))
+	})
+}
+
+// TestOutputShape_BirdNETv24 verifies createOutputTensors gets correctly-sized output
+// shapes for each v2.4 layout. The critical case is the head-pruned model, whose only
+// output (index 0) is the [.,1024] embedding rather than logits: a wrong size here
+// would allocate a zero- or mis-sized tensor and fail inference.
+func TestOutputShape_BirdNETv24(t *testing.T) {
+	t.Parallel()
+
+	t.Run("embedding-only model sizes output 0 as the embedding", func(t *testing.T) {
+		t.Parallel()
+		c := &Classifier{config: ModelConfig{
+			Type: BirdNETv24, NumOutputs: 1,
+			LogitsIndex: -1, LogitsSize: 0,
+			EmbeddingIndex: 0, EmbeddingSize: embeddingSizeV24,
+		}}
+		shape, err := c.outputShape(0, 1)
+		require.NoError(t, err)
+		assert.Equal(t, []int64{1, embeddingSizeV24}, shape)
+	})
+
+	t.Run("two-output model sizes logits@0 and embedding@1", func(t *testing.T) {
+		t.Parallel()
+		c := &Classifier{config: ModelConfig{
+			Type: BirdNETv24, NumOutputs: 2,
+			LogitsIndex: 0, LogitsSize: v24LogitsSize,
+			EmbeddingIndex: 1, EmbeddingSize: embeddingSizeV24,
+		}}
+		logits, err := c.outputShape(0, 1)
+		require.NoError(t, err)
+		assert.Equal(t, []int64{1, v24LogitsSize}, logits)
+		emb, err := c.outputShape(1, 1)
+		require.NoError(t, err)
+		assert.Equal(t, []int64{1, embeddingSizeV24}, emb)
+	})
+
+	t.Run("single-output classifier sizes logits@0", func(t *testing.T) {
+		t.Parallel()
+		c := &Classifier{config: ModelConfig{
+			Type: BirdNETv24, NumOutputs: 1,
+			LogitsIndex: 0, LogitsSize: v24LogitsSize,
+			EmbeddingIndex: -1,
+		}}
+		shape, err := c.outputShape(0, 1)
+		require.NoError(t, err)
+		assert.Equal(t, []int64{1, v24LogitsSize}, shape)
+	})
+}
+
+// TestSelectEmbeddingOutput covers the port-selection logic behind DetectEmbeddingOutput
+// without a real ONNX model: the [.,1024] embedding is at index 1 in the 2-output
+// backbone and at index 0 in the head-pruned model, and a model with no 1024-dim output
+// is an error.
+func TestSelectEmbeddingOutput(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		outputs   []ort.InputOutputInfo
+		wantIndex int
+		wantSize  int
+		wantErr   bool
+	}{
+		{
+			name:      "two-output backbone: embedding at index 1",
+			outputs:   []ort.InputOutputInfo{{Dimensions: ort.NewShape(1, v24LogitsSize)}, {Dimensions: ort.NewShape(1, embeddingSizeV24)}},
+			wantIndex: 1,
+			wantSize:  embeddingSizeV24,
+		},
+		{
+			name:      "head-pruned: embedding at index 0",
+			outputs:   []ort.InputOutputInfo{{Dimensions: ort.NewShape(1, embeddingSizeV24)}},
+			wantIndex: 0,
+			wantSize:  embeddingSizeV24,
+		},
+		{
+			name:    "no 1024-dim output errors",
+			outputs: []ort.InputOutputInfo{{Dimensions: ort.NewShape(1, v24LogitsSize)}},
+			wantErr: true,
+		},
+		{
+			name:    "nil outputs errors",
+			outputs: nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			idx, size, err := selectEmbeddingOutput(tt.outputs)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Equal(t, -1, idx)
+				assert.Equal(t, 0, size)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantIndex, idx)
+			assert.Equal(t, tt.wantSize, size)
+		})
+	}
+}
+
+// TestProcessOutput_EmbeddingOnlyModelErrors confirms that calling the logits-based
+// Predict path on an embedding-only model returns a clear error instead of panicking
+// on outputs[-1]. The guard returns before indexing, so nil outputs is sufficient.
+func TestProcessOutput_EmbeddingOnlyModelErrors(t *testing.T) {
+	t.Parallel()
+	c := &Classifier{config: ModelConfig{
+		Type: BirdNETv24, NumOutputs: 1,
+		LogitsIndex: -1, EmbeddingIndex: 0, EmbeddingSize: embeddingSizeV24,
+	}}
+	res, err := c.processOutput(nil, 0)
+	require.Error(t, err)
+	assert.Nil(t, res)
+}

--- a/internal/inference/onnx/detection_test.go
+++ b/internal/inference/onnx/detection_test.go
@@ -74,11 +74,14 @@ func TestBuildModelConfig_BirdNETv24(t *testing.T) {
 func TestValidateLabelCount(t *testing.T) {
 	t.Parallel()
 
-	t.Run("embedding-only model skips validation", func(t *testing.T) {
+	t.Run("embedding-only model without skip is rejected", func(t *testing.T) {
 		t.Parallel()
 		cfg := &ModelConfig{LogitsIndex: -1}
-		// A nonsense label count and nil outputs must still pass: there are no logits.
-		require.NoError(t, validateLabelCount(cfg, nil, 999))
+		// An embedding-only model has no logits to match labels against, so with
+		// validation enabled it must fail fast rather than error only at prediction
+		// time. The bat pipeline loads such models with SkipLabelValidation, which
+		// bypasses this function entirely.
+		require.Error(t, validateLabelCount(cfg, nil, 999))
 	})
 
 	t.Run("matching label count passes", func(t *testing.T) {

--- a/internal/inference/onnx/embedding_only_functional_test.go
+++ b/internal/inference/onnx/embedding_only_functional_test.go
@@ -1,0 +1,65 @@
+package onnx
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ort "github.com/yalue/onnxruntime_go"
+)
+
+// TestClassifierEmbeddingOnly_Functional loads a real head-pruned, 1-output BirdNET
+// v2.4 embedding model and exercises the inference paths the bat pipeline depends on.
+// It is the ORT-side companion to TestOpenVINOBatEmbeddingParity_Functional and is
+// skipped unless ONNX_TEST_EMB_ONLY_MODEL points at such a model, so normal CI stays
+// green (the pruned model is not vendored). Env:
+//
+//   - ONNX_TEST_EMB_ONLY_MODEL: path to the head-pruned embedding-only ONNX model
+//     ([batch,144000] -> single [.,1024] embedding output).
+//   - ONNX_TEST_ORT_LIB:        optional libonnxruntime path (empty = default discovery).
+func TestClassifierEmbeddingOnly_Functional(t *testing.T) {
+	modelPath := os.Getenv("ONNX_TEST_EMB_ONLY_MODEL")
+	if modelPath == "" {
+		t.Skip("set ONNX_TEST_EMB_ONLY_MODEL to a head-pruned 1-output embedding ONNX model to run")
+	}
+
+	// Idempotent guard: other gated tests in this package may already have initialized
+	// the runtime. Do not DestroyORT here for the same reason.
+	if !ort.IsInitialized() {
+		MustInitORT(os.Getenv("ONNX_TEST_ORT_LIB"))
+	}
+
+	// Mirror how the bat pipeline loads the embedding model: a placeholder label with
+	// validation skipped, since the model produces no species logits to match.
+	c, err := NewClassifier(modelPath,
+		WithLabels([]string{"placeholder"}),
+		WithSkipLabelValidation(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, c.Close()) })
+
+	cfg := c.Config()
+	assert.Equal(t, BirdNETv24, cfg.Type)
+	assert.Equal(t, 1, cfg.NumOutputs)
+	assert.Equal(t, -1, cfg.LogitsIndex, "embedding-only model must report no logits")
+	assert.Equal(t, 0, cfg.EmbeddingIndex)
+	assert.Equal(t, embeddingSizeV24, cfg.EmbeddingSize)
+
+	samples := make([]float32, cfg.SampleCount)
+
+	// e1: the exact path the bat pipeline uses. It must return nil logits and a full
+	// embedding vector without panicking on outputs[LogitsIndex] at index -1.
+	logits, emb, err := c.PredictRawWithEmbeddings(samples)
+	require.NoError(t, err)
+	assert.Nil(t, logits, "embedding-only model must return nil logits")
+	assert.Len(t, emb, embeddingSizeV24)
+
+	// e2: the logits-based prediction paths must fail cleanly (an error, never a panic)
+	// on a model that has no logits output.
+	_, err = c.Predict(samples)
+	require.Error(t, err, "Predict must error on an embedding-only model")
+
+	_, err = c.PredictBatch([][]float32{samples})
+	require.Error(t, err, "PredictBatch must error on an embedding-only model")
+}


### PR DESCRIPTION
## Summary

Adds support for a head-pruned, 1-output "embedding-only" BattyBirdNET v2.4 embedding backbone that carries only the `[1024]` embedding output, dropping the unused `[6522]` BirdNET logits head (about 26 MB smaller). The existing 2-output backbone (logits at output 0, embedding at output 1) keeps working unchanged, so existing installs are unaffected.

birdnet-go previously read the bat embedding by a fixed output index and detected the model by output count, both of which break for a 1-output embedding-only model (a 1-output v2.4 model was assumed to be the plain `[6522]` classifier). This makes those paths shape-aware.

## Changes

- `internal/inference/onnx/detection.go`: a single `[.,1024]` output is configured as embedding-only (`LogitsIndex = -1`, `EmbeddingIndex = 0`, `EmbeddingSize = 1024`), disambiguated from the plain 1-output `[.,6522]` classifier by output size. New `DetectEmbeddingOutput` / `selectEmbeddingOutput` report the embedding output port from model metadata.
- `internal/inference/onnx/classifier.go`: the ORT extraction (`PredictRawWithEmbeddings`), output-tensor sizing (`outputShape`), label validation, and the `Predict`/`PredictBatch` path all handle a model with no logits without indexing an out-of-range logits output.
- `internal/inference/onnx.go`: thin `DetectEmbeddingOutput` wrapper on the inference facade.
- `internal/classifier/bat_onnx.go`: the OpenVINO path derives the embedding output port at load time (index 1 for the 2-output model, 0 for the pruned one) instead of a hardcoded constant, gated behind the existing OpenVINO eligibility check, and falls back to ONNX Runtime on any detection failure. The ORT path derives the port internally via the model config, so it needs no index passed.

Both backends produce the same embedding for the current 2-output model. The model catalog is intentionally not switched in this PR; that follows once the pruned model is published.

## Test Plan

- [x] `go build ./internal/...`, `go vet ./internal/...`, and `go vet -tags openvino ./internal/classifier/` all pass.
- [x] `golangci-lint run` clean on the affected packages.
- [x] New unit tests (`detection_test.go`) cover `buildModelConfig`, `validateLabelCount`, `outputShape`, `processOutput`, and `selectEmbeddingOutput` across the 2-output, head-pruned, and plain-classifier layouts; pass with `-race`.
- [x] New model-gated functional test (`embedding_only_functional_test.go`) exercises the real ORT inference paths on a pruned model (skipped in CI without `ONNX_TEST_EMB_ONLY_MODEL`).
- [ ] Native arm64 validation on rpi5 for both ORT and OpenVINO once the pruned model is produced (embedding parity and end-to-end bat top-k identical to the current 2-output model; embedding stays fp32).