### PR TITLE
feat(bat): use the DFT-truncated v2.4 embedding backbone (drop-in)

### DIFF
--- a/internal/classifier/model_catalog.go
+++ b/internal/classifier/model_catalog.go
@@ -185,9 +185,16 @@ var EmbeddedCatalog = []CatalogEntry{
 }
 
 // Shared BirdNET v2.4 embeddings model, used by all BattyBirdNET classifiers.
+// This is the DFT-truncated variant (remote birdnet-v2.4-embeddings-fp32-dfttrunc.onnx):
+// bit-exact with the original 2-output backbone (embedding max|delta| = 0.0, identical
+// output order, so no inference-code change) but about 2x faster on CPU and roughly 8 MB
+// smaller. The local filename is deliberately kept as birdnet-v24-embeddings.onnx so
+// existing installs keep their on-disk shared/birdnet-v24-embeddings.onnx (the startup
+// scan is presence-only and never re-verifies it) and upgrade transparently the next
+// time a bat model is reinstalled or another bat region is installed.
 const (
-	embeddingsSHA256          = "b6b8f24dc9c3d43f2deb14a6f2c7b5b233e7477b6baf1b52341291e714903fb0"
-	embeddingsSizeBytes int64 = 66932350
+	embeddingsSHA256          = "b91139d3c63d55d742779a56531078bc88366a09bcc9bd6a9b703d425914c380"
+	embeddingsSizeBytes int64 = 58763257
 )
 
 // Shared v3.0 geomodel, used as range filter companion by Perch v2 and BirdNET v3.0.
@@ -366,7 +373,9 @@ func batCatalogEntry(id, name, region string, speciesCount int, fileRegion strin
 				SizeBytes:  checksums.labelsSize,
 			},
 			{
-				RemotePath: "birdnet-v24-embeddings.onnx",
+				// RemotePath is the DFT-truncated backbone; LocalName stays the
+				// original filename for drop-in compatibility (see embeddingsSHA256).
+				RemotePath: "birdnet-v2.4-embeddings-fp32-dfttrunc.onnx",
 				LocalName:  "birdnet-v24-embeddings.onnx",
 				Role:       RoleEmbeddings,
 				SHA256:     embeddingsSHA256,

--- a/internal/classifier/model_catalog.go
+++ b/internal/classifier/model_catalog.go
@@ -189,9 +189,10 @@ var EmbeddedCatalog = []CatalogEntry{
 // bit-exact with the original 2-output backbone (embedding max|delta| = 0.0, identical
 // output order, so no inference-code change) but about 2x faster on CPU and roughly 8 MB
 // smaller. The local filename is deliberately kept as birdnet-v24-embeddings.onnx so
-// existing installs keep their on-disk shared/birdnet-v24-embeddings.onnx (the startup
-// scan is presence-only and never re-verifies it) and upgrade transparently the next
-// time a bat model is reinstalled or another bat region is installed.
+// existing installs keep their on-disk shared/birdnet-v24-embeddings.onnx: the startup
+// scan only stats each bat model's own regional file and never inspects or re-verifies
+// the shared embeddings file, so nothing is flagged, and installs upgrade transparently
+// the next time a bat model is reinstalled or another bat region is installed.
 const (
 	embeddingsSHA256          = "b91139d3c63d55d742779a56531078bc88366a09bcc9bd6a9b703d425914c380"
 	embeddingsSizeBytes int64 = 58763257

--- a/internal/classifier/model_catalog_test.go
+++ b/internal/classifier/model_catalog_test.go
@@ -119,12 +119,27 @@ func TestEmbeddedCatalog_BatEntriesHaveEmbeddingsFile(t *testing.T) {
 
 		hasEmbeddings := false
 		for _, f := range entry.Files {
-			if f.Role == RoleEmbeddings {
-				hasEmbeddings = true
-				assert.Equal(t, "birdnet-v24-embeddings.onnx", f.LocalName,
-					"bat entry %q should use shared embeddings file", entry.ID)
-				break
+			if f.Role != RoleEmbeddings {
+				continue
 			}
+			hasEmbeddings = true
+			// LocalName is kept stable for drop-in compatibility with existing
+			// installs; RemotePath points at the DFT-truncated backbone (bit-exact,
+			// ~2x faster). The two intentionally differ, so assert both. Size and
+			// SHA256 are pinned to literals (not the embeddingsSizeBytes/embeddingsSHA256
+			// constants) so this locks the exact expected file content: comparing the
+			// field to the constant it is assigned from would be a tautology, whereas a
+			// literal catches an accidental constant change and forces a deliberate model
+			// swap to update the test too.
+			assert.Equal(t, "birdnet-v24-embeddings.onnx", f.LocalName,
+				"bat entry %q should use shared embeddings file", entry.ID)
+			assert.Equal(t, "birdnet-v2.4-embeddings-fp32-dfttrunc.onnx", f.RemotePath,
+				"bat entry %q should fetch the DFT-truncated backbone", entry.ID)
+			assert.Equal(t, int64(58763257), f.SizeBytes,
+				"bat entry %q embeddings size should match the DFT-truncated backbone", entry.ID)
+			assert.Equal(t, "b91139d3c63d55d742779a56531078bc88366a09bcc9bd6a9b703d425914c380", f.SHA256,
+				"bat entry %q embeddings checksum should match the DFT-truncated backbone", entry.ID)
+			break
 		}
 		assert.True(t, hasEmbeddings, "bat entry %q must have an embeddings file", entry.ID)
 	}

--- a/internal/classifier/model_catalog_test.go
+++ b/internal/classifier/model_catalog_test.go
@@ -117,12 +117,12 @@ func TestEmbeddedCatalog_BatEntriesHaveEmbeddingsFile(t *testing.T) {
 			continue
 		}
 
-		hasEmbeddings := false
+		embeddingsCount := 0
 		for _, f := range entry.Files {
 			if f.Role != RoleEmbeddings {
 				continue
 			}
-			hasEmbeddings = true
+			embeddingsCount++
 			// LocalName is kept stable for drop-in compatibility with existing
 			// installs; RemotePath points at the DFT-truncated backbone (bit-exact,
 			// ~2x faster). The two intentionally differ, so assert both. Size and
@@ -130,7 +130,8 @@ func TestEmbeddedCatalog_BatEntriesHaveEmbeddingsFile(t *testing.T) {
 			// constants) so this locks the exact expected file content: comparing the
 			// field to the constant it is assigned from would be a tautology, whereas a
 			// literal catches an accidental constant change and forces a deliberate model
-			// swap to update the test too.
+			// swap to update the test too. No break: validate every embeddings file so a
+			// future entry carrying a second, mismatched one would still fail.
 			assert.Equal(t, "birdnet-v24-embeddings.onnx", f.LocalName,
 				"bat entry %q should use shared embeddings file", entry.ID)
 			assert.Equal(t, "birdnet-v2.4-embeddings-fp32-dfttrunc.onnx", f.RemotePath,
@@ -139,9 +140,8 @@ func TestEmbeddedCatalog_BatEntriesHaveEmbeddingsFile(t *testing.T) {
 				"bat entry %q embeddings size should match the DFT-truncated backbone", entry.ID)
 			assert.Equal(t, "b91139d3c63d55d742779a56531078bc88366a09bcc9bd6a9b703d425914c380", f.SHA256,
 				"bat entry %q embeddings checksum should match the DFT-truncated backbone", entry.ID)
-			break
 		}
-		assert.True(t, hasEmbeddings, "bat entry %q must have an embeddings file", entry.ID)
+		assert.Equal(t, 1, embeddingsCount, "bat entry %q must have exactly one embeddings file", entry.ID)
 	}
 }
 


### PR DESCRIPTION
## What

Repoints the shared BattyBirdNET bat embedding backbone in the model catalog to the DFT-truncated variant `birdnet-v2.4-embeddings-fp32-dfttrunc.onnx` (58,763,257 bytes). It keeps both outputs (`output` `[6522]` at index 0, the `[1024]` embedding at index 1) in the same order, so it is a drop-in that needs no inference-code change: only the catalog checksum, size, and remote path change. It is bit-exact with the current backbone and about 2x faster on CPU (roughly 8 MB smaller).

`RemotePath` points at the new file while `LocalName` stays `birdnet-v24-embeddings.onnx`.

## Why keep the local filename

The shared embeddings file is used by every BattyBirdNET regional model. Keeping `LocalName` stable means:

- Existing installs keep their on-disk `shared/birdnet-v24-embeddings.onnx`. The startup scan is presence-only and never re-verifies the embeddings checksum, so nothing is flagged as corrupt and the bat pipeline keeps working (the two backbones are bit-exact).
- They upgrade to the faster file transparently the next time a bat model is reinstalled or another bat region is installed (the checksum mismatch triggers a normal re-download of the same local filename).
- No orphaned file is left on disk. Renaming the local file would have stranded the old ~67 MB backbone.

New installs fetch the faster file immediately.

## Validation

Parity checked on aarch64 (Raspberry Pi 5) against the current backbone, on both backends the bat embedding extractor uses:

- ONNX Runtime CPU: old vs new `max|delta| = 0.0` on embedding and logits, top-1 identical.
- OpenVINO CPU (fp32): the truncated graph compiles and runs, and old vs new `max|delta| = 0.0`, top-1 identical.

The published file was verified against the catalog constants: HuggingFace reports size 58,763,257 and a content hash matching `embeddingsSHA256`.

Full `golangci-lint` is clean and `go test -race ./internal/classifier/...` passes. The catalog test now pins the new remote path, size, and checksum as literals so an accidental revert fails the test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the bundled BatNET v2.4 embeddings download to the correct DFT-truncated variant.
  * Preserved the existing local filename for compatibility with current installations.
  * Corrected the associated file size and checksum metadata to ensure reliable downloads and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->