### PR TITLE
feat(models): add DFT-truncated BirdNET v2.4 variants to the model catalog

### DIFF
--- a/internal/api/v2/models/models.go
+++ b/internal/api/v2/models/models.go
@@ -208,6 +208,14 @@ func (c *Handler) InstallModel(ctx echo.Context) error {
 		return c.HandleError(ctx, nil, "unknown catalog ID: "+catalogID, http.StatusNotFound)
 	}
 
+	// Hidden entries are foundation-only: excluded from the gallery and not meant
+	// to be installed by ID. Some (the DFT-truncated BirdNET v2.4 variants) carry
+	// the permanent registry ID, which Uninstall then refuses, so an inadvertent
+	// install would leave an unremovable, unused model on disk. Reject them here.
+	if entry.Hidden {
+		return c.HandleError(ctx, nil, "catalog entry "+catalogID+" is not available for installation", http.StatusNotFound)
+	}
+
 	if c.ModelManager == nil {
 		return c.HandleError(ctx, nil, "model manager is not available", http.StatusServiceUnavailable)
 	}
@@ -263,6 +271,11 @@ func (c *Handler) ReinstallModel(ctx echo.Context) error {
 	entry, ok := classifier.GetCatalogEntry(catalogID)
 	if !ok {
 		return c.HandleError(ctx, nil, "unknown catalog ID: "+catalogID, http.StatusNotFound)
+	}
+
+	// Hidden entries are foundation-only and not installable by ID (see InstallModel).
+	if entry.Hidden {
+		return c.HandleError(ctx, nil, "catalog entry "+catalogID+" is not available for installation", http.StatusNotFound)
 	}
 
 	if c.ModelManager == nil {

--- a/internal/api/v2/models/models_test.go
+++ b/internal/api/v2/models/models_test.go
@@ -1,9 +1,13 @@
 package models
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 )
 
@@ -27,4 +31,39 @@ func TestModelsRouteRegistration(t *testing.T) {
 		"GET /api/v2/models/install/:id/progress",
 	}
 	apitest.AssertRoutesRegistered(t, e, expectedRoutes)
+}
+
+// TestInstallModel_RejectsHiddenEntries verifies that hidden, foundation-only
+// catalog entries (the DFT-truncated BirdNET v2.4 variants) cannot be installed
+// or reinstalled by ID. They carry the permanent registry ID, which Uninstall
+// refuses, so allowing an install-by-ID would leave an unremovable, unused model.
+func TestInstallModel_RejectsHiddenEntries(t *testing.T) {
+	core := apitest.NewCore(t)
+	h := New(core)
+	e := echo.New()
+
+	hiddenIDs := []string{"birdnet-v2.4-fp32-dfttrunc", "birdnet-v2.4-int8-arm-dfttrunc"}
+	for _, id := range hiddenIDs {
+		t.Run(id, func(t *testing.T) {
+			// Install must be rejected with 404 before touching the model manager.
+			req := httptest.NewRequest(http.MethodPost, "/api/v2/models/install/"+id, http.NoBody)
+			rec := httptest.NewRecorder()
+			ctx := e.NewContext(req, rec)
+			ctx.SetParamNames("id")
+			ctx.SetParamValues(id)
+			require.NoError(t, h.InstallModel(ctx))
+			assert.Equal(t, http.StatusNotFound, rec.Code, "install of hidden entry %q must be rejected", id)
+			assert.Contains(t, rec.Body.String(), "not available for installation")
+
+			// Reinstall must be rejected the same way.
+			req = httptest.NewRequest(http.MethodPost, "/api/v2/models/reinstall/"+id, http.NoBody)
+			rec = httptest.NewRecorder()
+			ctx = e.NewContext(req, rec)
+			ctx.SetParamNames("id")
+			ctx.SetParamValues(id)
+			require.NoError(t, h.ReinstallModel(ctx))
+			assert.Equal(t, http.StatusNotFound, rec.Code, "reinstall of hidden entry %q must be rejected", id)
+			assert.Contains(t, rec.Body.String(), "not available for installation")
+		})
+	}
 }

--- a/internal/classifier/model_catalog.go
+++ b/internal/classifier/model_catalog.go
@@ -80,7 +80,7 @@ var EmbeddedCatalog = []CatalogEntry{
 		CommercialUse:   false,
 		Category:        CategoryWildlife,
 		Region:          "",
-		SpeciesCount:    0, // determined at runtime from label file
+		SpeciesCount:    0, // determined at runtime from the embedded v2.4 labels (no labels file is downloaded)
 		Version:         "3.0",
 		GeomodelVersion: "v3",
 		RegistryID:      RegistryIDBirdNETV3,
@@ -136,6 +136,67 @@ var EmbeddedCatalog = []CatalogEntry{
 			{RemotePath: "BSG_birds_Finland_v4_4_calibration.csv", LocalName: "BSG_birds_Finland_v4_4_calibration.csv", Role: RoleData, SHA256: "b248ca8dac8205b427604ccc2832afdc2ab4672653c7e35ca78f44cc36ee5b28", SizeBytes: 6800},
 			{RemotePath: "BSG_birds_Finland_v4_4_distribution.bin", LocalName: "BSG_birds_Finland_v4_4_distribution.bin", Role: RoleData, SHA256: "0617f19f3eca7f7bc409e3d853d742a171a835464862dc3ced2f5b72ef3093f5", SizeBytes: 25828768},
 			{RemotePath: "BSG_birds_Finland_v4_4_migration.csv", LocalName: "BSG_birds_Finland_v4_4_migration.csv", Role: RoleData, SHA256: "a3fdbfc744645f6945def7fbfa3ee19e347c31d1b46ae78fba75e7059b54a86b", SizeBytes: 17054},
+		},
+	},
+
+	// BirdNET v2.4 DFT-truncated variants: opt-in, faster drop-in files for the
+	// primary classifier. DFT-bin truncation drops the mel-DFT bins the filterbank
+	// discards, so the output is bit-exact (single classification head, unchanged
+	// labels) while CPU/OpenVINO inference is about 1.4-2x faster. The files are
+	// published under NEW HuggingFace filenames, so existing installs are untouched.
+	//
+	// These entries are Hidden on purpose. The primary BirdNET v2.4 classifier is
+	// resolved at startup from config and the standard model paths (see NewBirdNET),
+	// NOT from the gallery, and nothing in the install path wires an installed file
+	// into BirdNET.ModelPath or hot-swaps the primary model. A visible "Install"
+	// button would therefore download a file that nothing activates. So these entries
+	// only record the authoritative checksums, sizes, and repo paths as a catalog
+	// foundation; a future primary-variant selector (tracked separately) will make
+	// them selectable. RegistryID is the permanent BirdNET v2.4 ID because these ARE
+	// that model in an alternate file: being Hidden they are never hot-loaded (there
+	// is no secondary loader for the primary), and Uninstall refuses them via the
+	// permanent-model guard. Labels are the embedded v2.4 set (data/labels/V2.4), so
+	// no labels file is downloaded. If a power user points birdnet.modelpath at a
+	// manually fetched file, the primary loader uses it as-is (remapV24ToONNXOnARM64
+	// honors an explicit CustomPath).
+	{
+		ID:              "birdnet-v2.4-fp32-dfttrunc",
+		Name:            "BirdNET v2.4 (DFT-truncated, FP32)",
+		Description:     "Drop-in BirdNET v2.4 classifier with DFT-bin truncation: bit-exact output, about 1.4-2x faster CPU and OpenVINO inference. FP32 ONNX for OpenVINO (A76/Pi5, amd64 CPU and Intel iGPU).",
+		Author:          "Cornell Lab of Ornithology & Chemnitz University of Technology",
+		License:         "CC-BY-NC-SA-4.0",
+		CommercialUse:   false,
+		Category:        CategoryBird,
+		Region:          "",
+		SpeciesCount:    0, // determined at runtime from the embedded v2.4 labels (no labels file is downloaded)
+		Version:         "2.4",
+		RegistryID:      permanentRegistryID,
+		Hidden:          true,
+		RequiresONNX:    true,
+		UpstreamURL:     "https://github.com/birdnet-team/BirdNET-Analyzer",
+		HuggingFaceRepo: "tphakala/BirdNET-v2.4",
+		Files: []CatalogFile{
+			{RemotePath: "BirdNET_v2.4_fp32_dfttrunc.onnx", LocalName: "BirdNET_v2.4_fp32_dfttrunc.onnx", Role: RoleModel, SHA256: "3b72e88b3ad0c310a41adabccf8cf75b1a05daeeb40884ebd38038c91d0e423d", SizeBytes: 54068648},
+		},
+	},
+	{
+		ID:              "birdnet-v2.4-int8-arm-dfttrunc",
+		Name:            "BirdNET v2.4 (DFT-truncated, INT8 ARM)",
+		Description:     "Drop-in BirdNET v2.4 classifier with DFT-bin truncation: bit-exact output, about 1.4-2x faster inference. INT8 ONNX for low-RAM ARM via ONNX Runtime (Pi4/Pi3, no native f16).",
+		Author:          "Cornell Lab of Ornithology & Chemnitz University of Technology",
+		License:         "CC-BY-NC-SA-4.0",
+		CommercialUse:   false,
+		Category:        CategoryBird,
+		Region:          "",
+		SpeciesCount:    0, // determined at runtime from the embedded v2.4 labels (no labels file is downloaded)
+		Version:         "2.4",
+		RegistryID:      permanentRegistryID,
+		Hidden:          true,
+		RequiresONNX:    true,
+		UpstreamURL:     "https://github.com/birdnet-team/BirdNET-Analyzer",
+		HuggingFaceRepo: "tphakala/BirdNET-v2.4",
+		Files: []CatalogFile{
+			{RemotePath: "BirdNET_v2.4_int8_arm_dfttrunc.onnx", LocalName: "BirdNET_v2.4_int8_arm_dfttrunc.onnx", Role: RoleModel, SHA256: "7550498ba996064feca12005ff4133eb1d35741c4061376e7a987d8227518893", SizeBytes: 38727042},
 		},
 	},
 

--- a/internal/classifier/model_catalog.go
+++ b/internal/classifier/model_catalog.go
@@ -80,7 +80,7 @@ var EmbeddedCatalog = []CatalogEntry{
 		CommercialUse:   false,
 		Category:        CategoryWildlife,
 		Region:          "",
-		SpeciesCount:    0, // determined at runtime from the embedded v2.4 labels (no labels file is downloaded)
+		SpeciesCount:    0, // determined at runtime from label file
 		Version:         "3.0",
 		GeomodelVersion: "v3",
 		RegistryID:      RegistryIDBirdNETV3,

--- a/internal/classifier/model_catalog_test.go
+++ b/internal/classifier/model_catalog_test.go
@@ -148,8 +148,9 @@ func TestEmbeddedCatalog_BatEntriesHaveEmbeddingsFile(t *testing.T) {
 func TestEmbeddedCatalog_EntryCount(t *testing.T) {
 	t.Parallel()
 
-	// 2 wildlife + 1 bird + 1 geomodel + 11 bat = 15 total
-	assert.Len(t, EmbeddedCatalog, 15, "expected 15 total catalog entries")
+	// 2 wildlife + 3 bird + 1 geomodel + 11 bat = 17 total
+	// (bird: bsg-finland + the two hidden BirdNET v2.4 DFT-truncated variants)
+	assert.Len(t, EmbeddedCatalog, 17, "expected 17 total catalog entries")
 }
 
 func TestVisibleCatalog_ExcludesHiddenEntries(t *testing.T) {
@@ -170,8 +171,26 @@ func TestVisibleCatalog_ExcludesHiddenEntries(t *testing.T) {
 	require.True(t, ok)
 	assert.True(t, bsg.Hidden)
 
-	// Visible count should be total minus hidden
-	assert.Len(t, visible, len(EmbeddedCatalog)-2)
+	// The DFT-truncated BirdNET v2.4 variants are hidden foundation entries.
+	dftVariants := []string{"birdnet-v2.4-fp32-dfttrunc", "birdnet-v2.4-int8-arm-dfttrunc"}
+	for _, id := range dftVariants {
+		entry, ok := GetCatalogEntry(id)
+		require.True(t, ok, "expected to find hidden catalog entry %q", id)
+		assert.True(t, entry.Hidden, "entry %q must be hidden", id)
+	}
+
+	// The hidden variants must be directly absent from the visible set, not just
+	// inferred from the count assertion below.
+	for i := range visible {
+		assert.NotContains(t, dftVariants, visible[i].ID,
+			"hidden entry %q must be excluded from the visible catalog", visible[i].ID)
+	}
+
+	// Visible count should be total minus the 4 hidden entries
+	// (birdnet-v3.0, bsg-finland, and the two BirdNET v2.4 DFT-truncated variants).
+	// The hardcoded count is an intentional tripwire: a new hidden entry must
+	// update it, forcing a conscious check that the exclusion is intended.
+	assert.Len(t, visible, len(EmbeddedCatalog)-4)
 }
 
 func TestGetCatalogEntry_BSGFinland(t *testing.T) {
@@ -207,4 +226,56 @@ func TestGetCatalogEntry_BirdNETv30(t *testing.T) {
 	assert.Equal(t, "BirdNET v3.0", entry.Name)
 	assert.Equal(t, RegistryIDBirdNETV3, entry.RegistryID)
 	assert.Equal(t, CategoryWildlife, entry.Category)
+}
+
+// TestEmbeddedCatalog_DFTTruncatedVariants pins the identity of the two hidden
+// BirdNET v2.4 DFT-truncated variant entries: their RemotePath, LocalName, size,
+// and checksum are the authoritative values published on HuggingFace, and the
+// entries are intentionally hidden ONNX drop-ins for the primary classifier. The
+// literals mean an accidental edit, revert, or checksum drift is caught here.
+func TestEmbeddedCatalog_DFTTruncatedVariants(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		id         string
+		remotePath string
+		sha256     string
+		sizeBytes  int64
+	}{
+		{
+			id:         "birdnet-v2.4-fp32-dfttrunc",
+			remotePath: "BirdNET_v2.4_fp32_dfttrunc.onnx",
+			sha256:     "3b72e88b3ad0c310a41adabccf8cf75b1a05daeeb40884ebd38038c91d0e423d",
+			sizeBytes:  54068648,
+		},
+		{
+			id:         "birdnet-v2.4-int8-arm-dfttrunc",
+			remotePath: "BirdNET_v2.4_int8_arm_dfttrunc.onnx",
+			sha256:     "7550498ba996064feca12005ff4133eb1d35741c4061376e7a987d8227518893",
+			sizeBytes:  38727042,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			t.Parallel()
+
+			entry, ok := GetCatalogEntry(tc.id)
+			require.True(t, ok, "expected to find catalog entry %q", tc.id)
+			assert.Equal(t, CategoryBird, entry.Category, "%q must be a bird model", tc.id)
+			assert.True(t, entry.Hidden, "%q must be hidden (no primary-variant selector yet)", tc.id)
+			assert.True(t, entry.RequiresONNX, "%q must require ONNX", tc.id)
+			assert.Equal(t, permanentRegistryID, entry.RegistryID,
+				"%q must map to the permanent BirdNET v2.4 registry ID", tc.id)
+			assert.Equal(t, "tphakala/BirdNET-v2.4", entry.HuggingFaceRepo, "%q repo", tc.id)
+
+			require.Len(t, entry.Files, 1, "%q must have exactly one (model) file", tc.id)
+			f := entry.Files[0]
+			assert.Equal(t, RoleModel, f.Role, "%q file must have the model role", tc.id)
+			assert.Equal(t, tc.remotePath, f.RemotePath, "%q RemotePath", tc.id)
+			assert.Equal(t, tc.remotePath, f.LocalName, "%q LocalName", tc.id)
+			assert.Equal(t, tc.sha256, f.SHA256, "%q checksum", tc.id)
+			assert.Equal(t, tc.sizeBytes, f.SizeBytes, "%q size", tc.id)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Adds two catalog entries for the DFT-truncated BirdNET v2.4 ONNX models published to HuggingFace (`tphakala/BirdNET-v2.4`): `BirdNET_v2.4_fp32_dfttrunc.onnx` (OpenVINO on A76/Pi5 and amd64 CPU/iGPU) and `BirdNET_v2.4_int8_arm_dfttrunc.onnx` (low-RAM ARM via ONNX Runtime). DFT-bin truncation drops the mel-DFT bins the filterbank discards, so the output is bit-exact with the current v2.4 (single classification head, unchanged labels) while CPU/OpenVINO inference is about 1.4-2x faster.

Both entries are intentionally `Hidden`. The primary BirdNET v2.4 classifier is resolved at startup from config and the standard model paths (`NewBirdNET`), not from the gallery, and nothing in the install path wires an installed file into the primary model, so a visible Install button would download a file nothing activates. These entries only record the authoritative HuggingFace checksums, sizes, and repo paths as a catalog foundation for a future primary-variant selector, matching the existing hidden placeholders `birdnet-v3.0` and `bsg-finland`. `RegistryID` is the permanent BirdNET v2.4 ID because these are that model in an alternate file: being hidden they are never hot-loaded (there is no secondary loader for the primary), and Uninstall refuses them via the permanent-model guard. Labels are the embedded v2.4 set, so no labels file is downloaded.

## Test Plan

- [x] `go test -race ./internal/classifier/` and `./internal/api/v2/models/` pass
- [x] `golangci-lint run ./...` clean (default and CI build tags)
- [x] New `TestEmbeddedCatalog_DFTTruncatedVariants` pins each file's remote path, local name, size, and SHA256; the visibility test asserts the entries are excluded from the gallery
- [x] Previously-skipped `TestModelManager_UninstallRejectsPermanent` now runs and passes (an entry maps to the permanent registry ID)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for two BirdNET v2.4 DFT-truncated classifier variants.
  * These variants are available as hidden, model-only options and are configured for automatic label handling.
* **Bug Fixes**
  * Updated catalog metadata to accurately reflect runtime label handling for BirdNET v3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->