### PR TITLE
feat(models): add BirdNET v3.0 acoustic classifier support

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -499,6 +499,29 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "BirdNETV3Config": {
+      "properties": {
+        "modelpath": {
+          "type": "string",
+          "description": "path to BirdNET v3.0 ONNX model file"
+        },
+        "labelpath": {
+          "type": "string",
+          "description": "path to BirdNET v3.0 label file"
+        },
+        "threshold": {
+          "type": "number",
+          "description": "confidence threshold for detections"
+        },
+        "locale": {
+          "type": "string",
+          "description": "locale for species label translation"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "BirdNETV3Config holds configuration for the BirdNET v3.0 acoustic classifier."
+    },
     "BirdweatherSettings": {
       "properties": {
         "enabled": {
@@ -2131,6 +2154,10 @@
         "perch": {
           "$ref": "#/$defs/PerchConfig",
           "description": "Perch v2 model configuration"
+        },
+        "birdnetv3": {
+          "$ref": "#/$defs/BirdNETV3Config",
+          "description": "BirdNET v3.0 acoustic classifier configuration"
         },
         "bat": {
           "$ref": "#/$defs/BatConfig",

--- a/doc/wiki/configuration-reference.md
+++ b/doc/wiki/configuration-reference.md
@@ -85,6 +85,17 @@ PerchConfig holds configuration for the Google Perch v2 model.
 | `perch.threshold` | number | confidence threshold for detections |
 | `perch.locale` | string | locale for species label translation |
 
+## birdnetv3
+
+BirdNETV3Config holds configuration for the BirdNET v3.0 acoustic classifier.
+
+| Setting | Type | Description |
+|---------|------|-------------|
+| `birdnetv3.modelpath` | string | path to BirdNET v3.0 ONNX model file |
+| `birdnetv3.labelpath` | string | path to BirdNET v3.0 label file |
+| `birdnetv3.threshold` | number | confidence threshold for detections |
+| `birdnetv3.locale` | string | locale for species label translation |
+
 ## bat
 
 BatConfig holds configuration for bat detection using BirdNET v2.4 embeddings.

--- a/internal/api/v2/hotreload_coverage_test.go
+++ b/internal/api/v2/hotreload_coverage_test.go
@@ -71,6 +71,9 @@ var hotReloadRegistry = map[string]hotReloadEntry{
 	// --- Perch ---
 	"Perch": {categories: []hotReloadCategory{hotReloadRestart}},
 
+	// --- BirdNET v3.0 ---
+	"BirdNETV3": {categories: []hotReloadCategory{hotReloadRestart}},
+
 	// --- Bat ---
 	"Bat": {categories: []hotReloadCategory{hotReloadFresh}},
 

--- a/internal/api/v2/settings_restart_test.go
+++ b/internal/api/v2/settings_restart_test.go
@@ -308,6 +308,7 @@ func TestHotReloadRestartFieldsCovered(t *testing.T) {
 		"BirdNET.OpenVINOPath":    "OpenVINO library path; loaded once at init and not safely unloadable, so it takes effect on restart (mirrors ONNXRuntimePath)",
 		"Models":                  "model registry path; restart-vs-reload undecided",
 		"Perch":                   "perch model path; not wired",
+		"BirdNETV3":               "BirdNET v3.0 model path; not wired",
 		"BSG":                     "BSG model path; not wired",
 		"Realtime.Audio.Watchdog": "no UI controls (project decision)",
 		"LowMemory":               "startup-only memory policy; not exposed via the live settings API",

--- a/internal/classifier/birdnet_v3.go
+++ b/internal/classifier/birdnet_v3.go
@@ -14,6 +14,13 @@ import (
 // start of a Go source file.
 const utf8BOM = "\uFEFF"
 
+// Label scanner buffer sizes. Labels are short ("SciName_CommonName"), but the
+// buffer is grown beyond bufio's default 64 KiB line cap defensively.
+const (
+	labelScannerInitialBufBytes = 64 * 1024   // initial scan buffer (64 KiB)
+	labelScannerMaxLineBytes    = 1024 * 1024 // max label line length (1 MiB)
+)
+
 // ParseBirdNETV3Labels parses a BirdNET v3.0 label file.
 //
 // Format: one label per line in "Scientific name_Common name" form (the same
@@ -24,9 +31,7 @@ const utf8BOM = "\uFEFF"
 // model load rather than silently shifting labels off by one.
 func ParseBirdNETV3Labels(data []byte) ([]string, error) {
 	scanner := bufio.NewScanner(bytes.NewReader(data))
-	// Labels can be long (scientific + common name); grow the buffer beyond the
-	// default 64 KiB line cap defensively even though v3.0 labels are short.
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	scanner.Buffer(make([]byte, 0, labelScannerInitialBufBytes), labelScannerMaxLineBytes)
 
 	var labels []string
 	first := true

--- a/internal/classifier/birdnet_v3.go
+++ b/internal/classifier/birdnet_v3.go
@@ -1,0 +1,47 @@
+// birdnet_v3.go provides BirdNET v3.0 acoustic classifier label parsing.
+// Label parsing is available in all builds; ONNX inference is in birdnet_v3_onnx.go.
+package classifier
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+)
+
+// utf8BOM is the UTF-8 byte order mark that some label files carry on the first
+// line. It is stripped so the first label is not corrupted. It is written as an
+// escape (not a literal BOM) because a literal BOM is only legal at the very
+// start of a Go source file.
+const utf8BOM = "\uFEFF"
+
+// ParseBirdNETV3Labels parses a BirdNET v3.0 label file.
+//
+// Format: one label per line in "Scientific name_Common name" form (the same
+// format as BirdNET v2.4), one line per class in model-output order. Empty lines
+// are skipped and a UTF-8 BOM on the first line is stripped. Every non-empty line
+// is kept as a label; no header line is skipped, so the returned count equals the
+// number of classes and a stray header would surface as a label-count mismatch at
+// model load rather than silently shifting labels off by one.
+func ParseBirdNETV3Labels(data []byte) ([]string, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	// Labels can be long (scientific + common name); grow the buffer beyond the
+	// default 64 KiB line cap defensively even though v3.0 labels are short.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var labels []string
+	first := true
+	for scanner.Scan() {
+		line := scanner.Text()
+		if first {
+			line = strings.TrimPrefix(line, utf8BOM)
+			first = false
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		labels = append(labels, line)
+	}
+
+	return labels, scanner.Err()
+}

--- a/internal/classifier/birdnet_v3_functional_test.go
+++ b/internal/classifier/birdnet_v3_functional_test.go
@@ -66,7 +66,7 @@ func TestBirdNETV3_Functional(t *testing.T) {
 
 	m, err := NewBirdNETV3(&cfg)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = m.Close() })
+	t.Cleanup(func() { assert.NoError(t, m.Close()) })
 
 	require.Equal(t, len(labels), m.NumSpecies(), "NumSpecies must equal the label count")
 	require.Equal(t, 32000, m.Spec().SampleRate)

--- a/internal/classifier/birdnet_v3_functional_test.go
+++ b/internal/classifier/birdnet_v3_functional_test.go
@@ -1,0 +1,115 @@
+//go:build onnx
+
+package classifier
+
+import (
+	"encoding/binary"
+	"math"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// birdnetV3InputSampleCount is the BirdNET v3.0 input length (32 kHz * 5 s).
+const birdnetV3InputSampleCount = 160000
+
+// TestBirdNETV3_Functional is a model-gated end-to-end test that loads a real
+// BirdNET v3.0 ONNX model and runs one inference through the full BirdNETV3.Predict
+// path (ONNX Runtime backend). It is skipped unless V3_TEST_MODEL and V3_TEST_LABELS
+// point at a real GPU-native v3.0 model and its "SciName_CommonName" label file, so
+// normal CI stays green.
+//
+// Optional env:
+//   - V3_TEST_LIB:   libonnxruntime.so path (default /usr/lib/libonnxruntime.so).
+//   - V3_TEST_AUDIO: raw little-endian float32, mono, 32 kHz PCM. When set, a 5 s
+//     window is fed to the model and the top detections are logged; otherwise a
+//     silent (zero) buffer is used to exercise the plumbing only.
+//
+// It proves the production path end to end: label parsing, ORT load, the
+// size-based predictions-port detection, and the no-activation output handling
+// (the model's in-graph sigmoid is not re-applied), returning one score per label
+// in [0,1].
+func TestBirdNETV3_Functional(t *testing.T) {
+	model := os.Getenv("V3_TEST_MODEL")
+	labelPath := os.Getenv("V3_TEST_LABELS")
+	if model == "" || labelPath == "" {
+		t.Skip("set V3_TEST_MODEL and V3_TEST_LABELS to run the BirdNET v3.0 functional test")
+	}
+
+	labelData, err := os.ReadFile(labelPath)
+	require.NoError(t, err)
+	labels, err := ParseBirdNETV3Labels(labelData)
+	require.NoError(t, err)
+	require.NotEmpty(t, labels)
+
+	lib := os.Getenv("V3_TEST_LIB")
+	if lib == "" {
+		lib = "/usr/lib/libonnxruntime.so"
+	}
+
+	// Predict records to the global metrics; publish a test registry so the span
+	// bookkeeping has somewhere to write.
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	SetMetrics(newTestMetrics(t))
+
+	cfg := BirdNETV3Config{
+		ModelPath:       model,
+		LabelPath:       labelPath,
+		ONNXRuntimePath: lib,
+		Threads:         4,
+		Backend:         conf.BackendPrefONNX, // force the ORT path for a deterministic CI-less run
+	}
+
+	m, err := NewBirdNETV3(&cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = m.Close() })
+
+	require.Equal(t, len(labels), m.NumSpecies(), "NumSpecies must equal the label count")
+	require.Equal(t, 32000, m.Spec().SampleRate)
+
+	samples := loadV3Audio(t, birdnetV3InputSampleCount)
+
+	results, err := m.Predict(t.Context(), [][]float32{samples})
+	require.NoError(t, err)
+	require.NotEmpty(t, results, "inference must return at least one detection")
+
+	// The model applies its per-class sigmoid in-graph, so every score is a
+	// probability in [0,1]; results are sorted by confidence descending.
+	for i := range results {
+		assert.GreaterOrEqual(t, results[i].Confidence, float32(0), "confidence must be >= 0")
+		assert.LessOrEqual(t, results[i].Confidence, float32(1), "confidence must be <= 1 (no double sigmoid)")
+		if i > 0 {
+			assert.LessOrEqual(t, results[i].Confidence, results[i-1].Confidence, "results must be sorted descending")
+		}
+	}
+
+	for i := range results {
+		t.Logf("v3.0 top %d: %-45s %.4f", i+1, results[i].Species, results[i].Confidence)
+	}
+}
+
+// loadV3Audio returns a mono 32 kHz float32 window of length n. If V3_TEST_AUDIO
+// points at a raw little-endian float32 file it is used (truncated or zero-padded
+// to n); otherwise a silent buffer is returned.
+func loadV3Audio(t *testing.T, n int) []float32 {
+	t.Helper()
+	samples := make([]float32, n)
+
+	path := os.Getenv("V3_TEST_AUDIO")
+	if path == "" {
+		return samples
+	}
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	avail := len(raw) / 4
+	count := min(avail, n)
+	for i := range count {
+		samples[i] = math.Float32frombits(binary.LittleEndian.Uint32(raw[i*4:]))
+	}
+	return samples
+}

--- a/internal/classifier/birdnet_v3_onnx.go
+++ b/internal/classifier/birdnet_v3_onnx.go
@@ -78,6 +78,20 @@ func NewBirdNETV3(cfg *BirdNETV3Config) (*BirdNETV3, error) {
 			Build()
 	}
 
+	// Initialize the ONNX Runtime up front, before attempting OpenVINO. The
+	// OpenVINO path's predictions-port detection (DetectPredictionsOutput) reads the
+	// model metadata through ONNX Runtime, and the ORT fallback classifier needs it
+	// too; InitONNXRuntime is idempotent. Doing this here (mirroring NewBat) ensures
+	// OpenVINO is not silently skipped when v3.0 is the first ONNX model loaded: an
+	// uninitialized runtime would make DetectPredictionsOutput fail and force the ORT
+	// fallback even when the user selected the OpenVINO backend.
+	if err := inference.InitONNXRuntime(cfg.ONNXRuntimePath); err != nil {
+		return nil, errors.New(err).
+			Category(errors.CategoryModelInit).
+			Context("onnx_runtime_path", cfg.ONNXRuntimePath).
+			Build()
+	}
+
 	// Prefer the OpenVINO backend when the gate allows it, falling back to ORT on
 	// any failure. OpenVINO must never make BirdNET v3.0 fail to load, so
 	// tryBirdNETV3OpenVINO logs and swallows OV errors and returns ok=false. device
@@ -90,15 +104,7 @@ func NewBirdNETV3(cfg *BirdNETV3Config) (*BirdNETV3, error) {
 	backend := BackendOpenVINO
 	precision := string(QuantizationFP16)
 	if !ok {
-		// Initialize ONNX Runtime
-		if err := inference.InitONNXRuntime(cfg.ONNXRuntimePath); err != nil {
-			return nil, errors.New(err).
-				Category(errors.CategoryModelInit).
-				Context("onnx_runtime_path", cfg.ONNXRuntimePath).
-				Build()
-		}
-
-		// Create ONNX classifier
+		// Create the ONNX Runtime classifier (the runtime was initialized above).
 		var cerr error
 		classifier, cerr = inference.NewONNXClassifier(cfg.ModelPath, inference.ONNXClassifierOptions{
 			Labels:  labels,

--- a/internal/classifier/birdnet_v3_onnx.go
+++ b/internal/classifier/birdnet_v3_onnx.go
@@ -1,0 +1,305 @@
+// birdnet_v3_onnx.go provides BirdNET v3.0 acoustic classifier support using the
+// ONNX backend. Label parsing is in birdnet_v3.go.
+package classifier
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/inference"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// BirdNETV3 represents a loaded BirdNET v3.0 acoustic classifier.
+// Implements ModelInstance. Goroutine-safe via internal mutex.
+type BirdNETV3 struct {
+	classifier inference.Classifier
+	labels     []string
+	info       ModelInfo
+	mu         sync.Mutex
+	// device is the compute device the classifier bound to: the OpenVINO device
+	// (CPU/GPU) when the OV path succeeds, otherwise deviceCPU for the ONNX Runtime
+	// CPU EP. Set once at construction; reported via RuntimeInfo().
+	device string
+	// backend is the live execution backend (BackendOpenVINO on the OV path, else
+	// BackendONNX), and precision is the effective runtime precision (FP16 on the OV
+	// path; the weight precision detected from the model filename on the ORT path).
+	// Both set once at construction; reported via RuntimeInfo().
+	backend   string
+	precision string
+}
+
+// BirdNETV3Config holds configuration for creating a BirdNET v3.0 model instance.
+type BirdNETV3Config struct {
+	ModelPath       string // Path to the BirdNET v3.0 ONNX model file
+	LabelPath       string // Path to the BirdNET v3.0 label file
+	ONNXRuntimePath string // Path to ONNX Runtime shared library
+	Threads         int    // CPU threads for inference (0 = default)
+
+	// OpenVINO opt-in, sourced from BirdNET settings. The v3.0 GPU-native model runs
+	// on OpenVINO directly (its mel front-end is a Conv1d, not the STFT op that
+	// blocks OpenVINO), so there is no model-variant gate; when the gate allows it
+	// BirdNET v3.0 runs on OpenVINO (ARM A76 f16 CPU or Intel iGPU) and any failure
+	// falls back to ORT.
+	Backend        string // BirdNET.Backend ("auto"/"onnx"/"openvino")
+	OpenVINOPath   string // BirdNET.OpenVINOPath (libopenvino_c location)
+	OpenVINODevice string // BirdNET.OpenVINODevice ("auto"/"cpu"/"gpu")
+}
+
+// NewBirdNETV3 creates a new BirdNET v3.0 model instance.
+func NewBirdNETV3(cfg *BirdNETV3Config) (*BirdNETV3, error) {
+	log := GetLogger()
+
+	// Load and parse labels
+	labelData, err := os.ReadFile(cfg.LabelPath)
+	if err != nil {
+		return nil, errors.New(err).
+			Category(errors.CategoryFileIO).
+			Context("label_path", cfg.LabelPath).
+			Build()
+	}
+
+	labels, err := ParseBirdNETV3Labels(labelData)
+	if err != nil {
+		return nil, errors.New(err).
+			Category(errors.CategoryLabelLoad).
+			Context("label_path", cfg.LabelPath).
+			Build()
+	}
+
+	if len(labels) == 0 {
+		return nil, errors.Newf("no labels parsed from %s", cfg.LabelPath).
+			Category(errors.CategoryLabelLoad).
+			Build()
+	}
+
+	// Prefer the OpenVINO backend when the gate allows it, falling back to ORT on
+	// any failure. OpenVINO must never make BirdNET v3.0 fail to load, so
+	// tryBirdNETV3OpenVINO logs and swallows OV errors and returns ok=false. device
+	// records the compute device actually bound to (the OpenVINO device on the OV
+	// path, else the ONNX Runtime CPU EP).
+	classifier, device, ok := tryBirdNETV3OpenVINO(cfg, labels)
+	// The v3.0 OpenVINO path uses the backend default precision (f16 on every
+	// device; openVINOPrecisionFor returns "" for v3.0). The ORT path overrides both
+	// below.
+	backend := BackendOpenVINO
+	precision := string(QuantizationFP16)
+	if !ok {
+		// Initialize ONNX Runtime
+		if err := inference.InitONNXRuntime(cfg.ONNXRuntimePath); err != nil {
+			return nil, errors.New(err).
+				Category(errors.CategoryModelInit).
+				Context("onnx_runtime_path", cfg.ONNXRuntimePath).
+				Build()
+		}
+
+		// Create ONNX classifier
+		var cerr error
+		classifier, cerr = inference.NewONNXClassifier(cfg.ModelPath, inference.ONNXClassifierOptions{
+			Labels:  labels,
+			Threads: cfg.Threads,
+		})
+		if cerr != nil {
+			return nil, errors.New(cerr).
+				Category(errors.CategoryModelInit).
+				Context("model_path", cfg.ModelPath).
+				Context("label_count", len(labels)).
+				Build()
+		}
+		// ONNX Runtime runs BirdNET v3.0 on the CPU execution provider, executing the
+		// model file as-is: surface the weight precision detected from the filename
+		// (e.g. FP16 for a *_fp16.onnx file; empty when no token).
+		device = deviceCPU
+		backend = BackendONNX
+		precision = string(detectQuantization(cfg.ModelPath))
+	}
+
+	info := ModelRegistry[RegistryIDBirdNETV3]
+	info.Description = fmt.Sprintf("BirdNET v3.0 acoustic classifier with %d species", len(labels))
+	info.NumSpecies = len(labels)
+
+	log.Info("BirdNET v3.0 model initialized",
+		logger.String("model_path", cfg.ModelPath),
+		logger.String("backend", backend),
+		logger.String("device", device),
+		logger.Int("species", len(labels)))
+
+	return &BirdNETV3{
+		classifier: classifier,
+		labels:     labels,
+		info:       info,
+		device:     device,
+		backend:    backend,
+		precision:  precision,
+	}, nil
+}
+
+// tryBirdNETV3OpenVINO attempts to build an OpenVINO classifier for BirdNET v3.0.
+// It returns (classifier, device, true) on success or (nil, "", false) to fall
+// back to ORT, where device is the concrete OpenVINO device the classifier bound
+// to (inference.OVDeviceCPU/OVDeviceGPU). Any failure (gate denied,
+// init/compile/validation error) is logged and swallowed: OpenVINO must never make
+// BirdNET v3.0 fail to load. Unlike Perch there is no model-variant filename gate:
+// the v3.0 GPU-native model has no STFT op, so it compiles on OpenVINO directly.
+func tryBirdNETV3OpenVINO(cfg *BirdNETV3Config, labels []string) (inference.Classifier, string, bool) {
+	// openVINOPlanFor gates on the build tag, backend preference, and device
+	// availability without needing the output port, so run it first; only read the
+	// model metadata to resolve the predictions port once OpenVINO is actually in
+	// play. This avoids a wasted metadata read on the common non-OpenVINO build. The
+	// output index passed here is a placeholder, overwritten below once detected.
+	plan, ok, reason := openVINOPlanFor(cfg.Backend, cfg.OpenVINODevice, RegistryIDBirdNETV3, cfg.OpenVINOPath, 0)
+	if !ok {
+		logOpenVINODeclined(RegistryIDBirdNETV3, cfg.Backend, reason)
+		return nil, "", false
+	}
+
+	log := GetLogger()
+
+	// Resolve the predictions output port by size (the output whose dimension equals
+	// the label count). The v3.0 graph also exposes a 1280-dim embeddings output, and
+	// export tooling has emitted the two outputs in both orders, so binding OpenVINO
+	// to a fixed port would risk the wrong tensor. On any detection failure, decline
+	// OpenVINO and fall back to ORT, which derives the port internally.
+	outIdx, err := inference.DetectPredictionsOutput(cfg.ModelPath, len(labels))
+	if err != nil {
+		log.Warn("BirdNET v3.0 OpenVINO predictions-output detection failed; using ONNX Runtime",
+			logger.String("model_path", cfg.ModelPath),
+			logger.Error(err))
+		return nil, "", false
+	}
+	plan.outputIndex = outIdx
+
+	// InitOpenVINO is idempotent: the auto/GPU plan above may already have loaded the
+	// core to enumerate devices, but the explicit-CPU plan path does not, so init
+	// here to cover it. A load failure means no usable OpenVINO; fall back to ORT.
+	if err := inference.InitOpenVINO(cfg.OpenVINOPath); err != nil {
+		log.Warn("BirdNET v3.0 OpenVINO init failed; using ONNX Runtime", logger.Error(err))
+		return nil, "", false
+	}
+
+	start := time.Now()
+	classifier, err := inference.NewOpenVINOClassifier(cfg.ModelPath, inference.OpenVINOClassifierOptions{
+		Labels:        labels,
+		Threads:       cfg.Threads,
+		Device:        plan.device,
+		OutputIndex:   plan.outputIndex,
+		PrecisionHint: plan.precision, // "" => f16 default; v3.0 f16 validated OK
+	})
+	if err != nil {
+		log.Warn("BirdNET v3.0 OpenVINO classifier init failed; using ONNX Runtime",
+			logger.String("device", plan.device),
+			logger.Error(err))
+		return nil, "", false
+	}
+
+	log.Info("BirdNET v3.0 model using OpenVINO backend",
+		logger.String("device", plan.device),
+		logger.String("precision", openVINOPrecisionLabel(plan.precision)),
+		logger.Int("species", classifier.NumSpecies()),
+		logger.String("init_time", time.Since(start).String()))
+	return classifier, plan.device, true
+}
+
+// Predict runs inference on the given audio samples.
+// Implements ModelInstance.
+func (b *BirdNETV3) Predict(ctx context.Context, samples [][]float32) ([]datastore.Results, error) {
+	span, _ := startPredictSpan(ctx, RegistryIDBirdNETV3, samples)
+	defer span.Finish()
+
+	start := time.Now()
+
+	// Guard against empty sample slice. Pre-inference rejections are tagged but not
+	// counted as predictions, mirroring BirdNET.Predict.
+	if len(samples) == 0 || len(samples[0]) == 0 {
+		span.markErrored(errTypeEmptySample)
+		return nil, errors.Newf("empty audio sample").
+			Category(errors.CategoryValidation).
+			Build()
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	// Guard against nil classifier (e.g., after Close() is called concurrently)
+	if b.classifier == nil {
+		span.markErrored(errTypeClassifierNil)
+		return nil, errors.Newf("BirdNET v3.0 classifier is not initialized").
+			Category(errors.CategoryModelInit).
+			Build()
+	}
+
+	// The classifier returns the v3.0 predictions output, which is already a
+	// per-class sigmoid (multi-label, applied in-graph, values in [0,1]). Unlike
+	// Perch (softmax) and BirdNET v2.4 (sigmoid), no activation is applied here:
+	// re-applying sigmoid would double-squash the scores.
+	scores, err := b.classifier.Predict(samples[0])
+	if err != nil {
+		err = errors.New(err).
+			Category(errors.CategoryAudio).
+			Context("model", RegistryIDBirdNETV3).
+			Build()
+		recordPredictionFailure(span, RegistryIDBirdNETV3, errTypeInvokeFailed, start, err)
+		return nil, err
+	}
+
+	// Pair labels with predictions
+	results, err := pairLabelsAndConfidence(b.labels, scores)
+	if err != nil {
+		recordPredictionFailure(span, RegistryIDBirdNETV3, errTypeLabelMismatch, start, err)
+		return nil, err
+	}
+
+	// Success: Finish records the single prediction because the span is not errored.
+	topResults := getTopKResults(results, defaultTopKResults)
+	recordPredictionSuccess(span, len(topResults), start)
+
+	return topResults, nil
+}
+
+// Spec returns the audio requirements for BirdNET v3.0.
+func (b *BirdNETV3) Spec() ModelSpec { return b.info.Spec }
+
+// ModelID returns the unique model identifier.
+func (b *BirdNETV3) ModelID() string { return b.info.ID }
+
+// ModelName returns the human-readable model name.
+func (b *BirdNETV3) ModelName() string { return b.info.Name }
+
+// ModelVersion returns the model version string.
+func (b *BirdNETV3) ModelVersion() string { return "V3.0" }
+
+// NumSpecies returns the number of species.
+func (b *BirdNETV3) NumSpecies() int { return len(b.labels) }
+
+// Labels returns a copy of the species labels to prevent mutation of internal state.
+func (b *BirdNETV3) Labels() []string {
+	out := make([]string, len(b.labels))
+	copy(out, b.labels)
+	return out
+}
+
+// RuntimeInfo returns the device, backend, and effective precision the BirdNET
+// v3.0 classifier bound to at construction: the OpenVINO device on the OV path
+// (else "CPU"); BackendOpenVINO on the OV path (else BackendONNX); FP16 on the OV
+// path or the weight precision detected from the model filename on the ORT path.
+// All three are set once and never mutated, so no lock is needed. Implements
+// ModelInstance.
+func (b *BirdNETV3) RuntimeInfo() (device, backend, precision string) {
+	return b.device, b.backend, b.precision
+}
+
+// Close releases resources held by the BirdNET v3.0 model.
+func (b *BirdNETV3) Close() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.classifier != nil {
+		b.classifier.Close()
+		b.classifier = nil
+	}
+	return nil
+}

--- a/internal/classifier/birdnet_v3_onnx_test.go
+++ b/internal/classifier/birdnet_v3_onnx_test.go
@@ -1,0 +1,140 @@
+package classifier
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestBirdNETV3 builds a BirdNETV3 instance around a fake classifier, with the
+// model metadata sourced from the registry (as NewBirdNETV3 does at runtime).
+func newTestBirdNETV3(classifier *predTelemetryClassifier, labels []string) *BirdNETV3 {
+	info := ModelRegistry[RegistryIDBirdNETV3]
+	info.NumSpecies = len(labels)
+	return &BirdNETV3{classifier: classifier, labels: labels, info: info}
+}
+
+// TestBirdNETV3Predict_NoActivation is the core correctness guard: the v3.0
+// predictions output is already a per-class sigmoid (in-graph), so BirdNETV3.Predict
+// must return those probabilities verbatim, applying neither sigmoid (BirdNET v2.4)
+// nor softmax (Perch). A re-applied sigmoid would map 0.9 -> ~0.711 and a softmax
+// would renormalize all scores, so an exact match proves no activation was applied.
+func TestBirdNETV3Predict_NoActivation(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	SetMetrics(newTestMetrics(t))
+
+	labels := []string{"Aaa aaa_Alpha", "Bbb bbb_Beta", "Ccc ccc_Gamma"}
+	probs := []float32{0.9, 0.1, 0.3}
+	b := newTestBirdNETV3(&predTelemetryClassifier{logits: probs}, labels)
+
+	results, err := b.Predict(t.Context(), [][]float32{{0.1, 0.2, 0.3}})
+	require.NoError(t, err)
+	require.Len(t, results, len(labels))
+
+	// Results are sorted by confidence descending; the top must be the 0.9 class
+	// with its probability unchanged.
+	assert.Equal(t, "Aaa aaa_Alpha", results[0].Species)
+	assert.InDelta(t, 0.9, results[0].Confidence, 1e-6,
+		"v3.0 must return the in-graph sigmoid probability verbatim, not re-activated")
+
+	// Guard explicitly against a double sigmoid: sigmoid(0.9) ~= 0.7109.
+	assert.Greater(t, math.Abs(float64(results[0].Confidence)-0.7109), 0.1,
+		"confidence must not be a re-applied sigmoid of the input probability")
+
+	// Every input probability must be preserved on its label.
+	byLabel := map[string]float32{}
+	for _, r := range results {
+		byLabel[r.Species] = r.Confidence
+	}
+	assert.InDelta(t, 0.1, byLabel["Bbb bbb_Beta"], 1e-6)
+	assert.InDelta(t, 0.3, byLabel["Ccc ccc_Gamma"], 1e-6)
+}
+
+// TestBirdNETV3_Metadata verifies the ModelInstance metadata surface.
+func TestBirdNETV3_Metadata(t *testing.T) {
+	t.Parallel()
+
+	labels := []string{"Aaa aaa_Alpha", "Bbb bbb_Beta"}
+	b := newTestBirdNETV3(&predTelemetryClassifier{logits: []float32{0.5, 0.5}}, labels)
+
+	assert.Equal(t, RegistryIDBirdNETV3, b.ModelID())
+	assert.Equal(t, ModelNameBirdNETv30, b.ModelName())
+	assert.Equal(t, "V3.0", b.ModelVersion())
+	assert.Equal(t, 2, b.NumSpecies())
+	assert.Equal(t, 32000, b.Spec().SampleRate)
+	assert.Equal(t, 5*time.Second, b.Spec().ClipLength)
+
+	// Labels returns a copy: mutating it must not affect internal state.
+	got := b.Labels()
+	require.Equal(t, labels, got)
+	got[0] = "mutated"
+	assert.Equal(t, "Aaa aaa_Alpha", b.Labels()[0])
+}
+
+// TestBirdNETV3Predict_EmptySample verifies the pre-inference empty-sample guard.
+func TestBirdNETV3Predict_EmptySample(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	b := newTestBirdNETV3(&predTelemetryClassifier{logits: []float32{0.5}}, []string{"Aaa aaa_Alpha"})
+
+	_, err := b.Predict(t.Context(), nil)
+	require.Error(t, err)
+
+	assert.InDelta(t, 0.0, predictionCount(t, m, RegistryIDBirdNETV3, "success"), 0,
+		"an empty-sample rejection must not record a success")
+}
+
+// TestBirdNETV3Predict_NilClassifier verifies the nil-classifier guard fires
+// (e.g. after Close()).
+func TestBirdNETV3Predict_NilClassifier(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	SetMetrics(newTestMetrics(t))
+
+	b := &BirdNETV3{labels: []string{"Aaa aaa_Alpha"}} // classifier is a nil interface
+
+	_, err := b.Predict(t.Context(), [][]float32{{0.1, 0.2}})
+	require.Error(t, err)
+}
+
+// TestBirdNETV3_LoaderRegistered guards the orchestrator wiring: without a
+// modelLoaders entry, models.enabled=[birdnet_v3.0] would be silently skipped.
+func TestBirdNETV3_LoaderRegistered(t *testing.T) {
+	t.Parallel()
+
+	_, ok := modelLoaders[RegistryIDBirdNETV3]
+	assert.True(t, ok, "BirdNET v3.0 must have a modelLoaders entry")
+
+	_, ok = openvinoCapableSecondaryBuilders[RegistryIDBirdNETV3]
+	assert.True(t, ok, "BirdNET v3.0 must have an OpenVINO-capable secondary builder")
+}
+
+// TestBirdNETV3_CatalogEntry guards the catalog entry shape: correct repo, hidden
+// during preview, and the expected model/labels/geomodel/taxonomy companion files.
+func TestBirdNETV3_CatalogEntry(t *testing.T) {
+	t.Parallel()
+
+	entry, ok := GetCatalogEntry("birdnet-v3.0")
+	require.True(t, ok, "birdnet-v3.0 catalog entry must exist")
+
+	assert.Equal(t, RegistryIDBirdNETV3, entry.RegistryID)
+	assert.Equal(t, "tphakala/BirdNET-v3.0-Models", entry.HuggingFaceRepo)
+	assert.True(t, entry.Hidden, "v3.0 stays hidden until GA (private HF repo, no final checksums)")
+	assert.True(t, entry.RequiresONNX)
+
+	roles := map[string]int{}
+	for _, f := range entry.Files {
+		roles[f.Role]++
+	}
+	assert.Equal(t, 1, roles[RoleModel], "one model file")
+	assert.Equal(t, 1, roles[RoleLabels], "one labels file")
+	assert.True(t, HasGeomodelFiles(&entry), "v3.0 pairs with the v3 geomodel range filter")
+	assert.True(t, HasTaxonomyFiles(&entry), "v3.0 ships the shared taxonomy companion")
+}

--- a/internal/classifier/birdnet_v3_onnx_test.go
+++ b/internal/classifier/birdnet_v3_onnx_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
 // newTestBirdNETV3 builds a BirdNETV3 instance around a fake classifier, with the
@@ -137,4 +138,54 @@ func TestBirdNETV3_CatalogEntry(t *testing.T) {
 	assert.Equal(t, 1, roles[RoleLabels], "one labels file")
 	assert.True(t, HasGeomodelFiles(&entry), "v3.0 pairs with the v3 geomodel range filter")
 	assert.True(t, HasTaxonomyFiles(&entry), "v3.0 ships the shared taxonomy companion")
+}
+
+// TestBirdNETV3Predict_InferenceError verifies an inference failure surfaces as an
+// error and is recorded exactly once (and not as a success).
+func TestBirdNETV3Predict_InferenceError(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	boom := errors.Newf("backend inference failed").Category(errors.CategoryAudio).Build()
+	b := newTestBirdNETV3(&predTelemetryClassifier{err: boom}, []string{"Aaa aaa_Alpha", "Bbb bbb_Beta"})
+
+	_, err := b.Predict(t.Context(), [][]float32{{0.1, 0.2}})
+	require.Error(t, err)
+	assert.InDelta(t, 1.0, predictionCount(t, m, RegistryIDBirdNETV3, "error"), 0,
+		"a failed inference must be recorded exactly once as an error")
+	assert.InDelta(t, 0.0, predictionCount(t, m, RegistryIDBirdNETV3, "success"), 0,
+		"a failed inference must not record a spurious success")
+}
+
+// TestBirdNETV3Predict_LabelMismatch verifies a label/score count mismatch (a
+// failure after inference begins) records exactly one error.
+func TestBirdNETV3Predict_LabelMismatch(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	// Two labels but only one score: pairLabelsAndConfidence returns an error.
+	b := newTestBirdNETV3(&predTelemetryClassifier{logits: []float32{0.5}}, []string{"Aaa aaa_Alpha", "Bbb bbb_Beta"})
+
+	_, err := b.Predict(t.Context(), [][]float32{{0.1, 0.2}})
+	require.Error(t, err)
+	assert.InDelta(t, 1.0, predictionCount(t, m, RegistryIDBirdNETV3, "error"), 0,
+		"a label/score mismatch must be recorded exactly once as an error")
+}
+
+// TestBirdNETV3_Close verifies Close releases the classifier without error and that
+// a subsequent Predict fails via the nil-classifier guard.
+func TestBirdNETV3_Close(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	SetMetrics(newTestMetrics(t))
+
+	b := newTestBirdNETV3(&predTelemetryClassifier{logits: []float32{0.5}}, []string{"Aaa aaa_Alpha"})
+	require.NoError(t, b.Close())
+
+	_, err := b.Predict(t.Context(), [][]float32{{0.1}})
+	require.Error(t, err, "Predict after Close must fail via the nil-classifier guard")
 }

--- a/internal/classifier/birdnet_v3_test.go
+++ b/internal/classifier/birdnet_v3_test.go
@@ -1,6 +1,7 @@
 package classifier
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -74,13 +75,14 @@ func TestParseBirdNETV3Labels_LargeFile(t *testing.T) {
 
 	const n = 11560
 	var sb strings.Builder
-	for range n {
-		sb.WriteString("Genus")
-		sb.WriteByte('_')
-		sb.WriteString("Common")
-		sb.WriteByte('\n')
+	for i := range n {
+		fmt.Fprintf(&sb, "Genus%d_Common %d\n", i, i)
 	}
 	got, err := ParseBirdNETV3Labels([]byte(sb.String()))
 	require.NoError(t, err)
-	assert.Len(t, got, n)
+	require.Len(t, got, n)
+	// Order is preserved: spot-check first, middle, and last labels.
+	assert.Equal(t, "Genus0_Common 0", got[0])
+	assert.Equal(t, "Genus5780_Common 5780", got[5780])
+	assert.Equal(t, "Genus11559_Common 11559", got[n-1])
 }

--- a/internal/classifier/birdnet_v3_test.go
+++ b/internal/classifier/birdnet_v3_test.go
@@ -1,0 +1,86 @@
+package classifier
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseBirdNETV3Labels(t *testing.T) {
+	t.Parallel()
+
+	const bom = "\uFEFF"
+
+	tests := []struct {
+		name string
+		data string
+		want []string
+	}{
+		{
+			name: "scientific and common name pairs",
+			data: "Turdus merula_Eurasian Blackbird\nParus major_Great Tit\n",
+			want: []string{"Turdus merula_Eurasian Blackbird", "Parus major_Great Tit"},
+		},
+		{
+			name: "strips utf-8 bom on first line only",
+			data: bom + "Turdus merula_Eurasian Blackbird\nParus major_Great Tit\n",
+			want: []string{"Turdus merula_Eurasian Blackbird", "Parus major_Great Tit"},
+		},
+		{
+			name: "skips blank and whitespace-only lines",
+			data: "Turdus merula_Eurasian Blackbird\n\n   \nParus major_Great Tit\n",
+			want: []string{"Turdus merula_Eurasian Blackbird", "Parus major_Great Tit"},
+		},
+		{
+			name: "trims surrounding whitespace and CR",
+			data: "  Turdus merula_Eurasian Blackbird  \r\nParus major_Great Tit\r\n",
+			want: []string{"Turdus merula_Eurasian Blackbird", "Parus major_Great Tit"},
+		},
+		{
+			name: "no trailing newline",
+			data: "Turdus merula_Eurasian Blackbird",
+			want: []string{"Turdus merula_Eurasian Blackbird"},
+		},
+		{
+			name: "empty input yields no labels",
+			data: "",
+			want: nil,
+		},
+		{
+			// A stray header is NOT skipped: it is returned as a label so the count
+			// mismatch surfaces at model load instead of silently shifting labels.
+			name: "does not skip a header line",
+			data: "idx;id;sci_name;com_name\nTurdus merula_Eurasian Blackbird\n",
+			want: []string{"idx;id;sci_name;com_name", "Turdus merula_Eurasian Blackbird"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseBirdNETV3Labels([]byte(tt.data))
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestParseBirdNETV3Labels_LargeFile checks the parser handles a full-size label
+// file (11,560 classes) without truncation and preserves order.
+func TestParseBirdNETV3Labels_LargeFile(t *testing.T) {
+	t.Parallel()
+
+	const n = 11560
+	var sb strings.Builder
+	for range n {
+		sb.WriteString("Genus")
+		sb.WriteByte('_')
+		sb.WriteString("Common")
+		sb.WriteByte('\n')
+	}
+	got, err := ParseBirdNETV3Labels([]byte(sb.String()))
+	require.NoError(t, err)
+	assert.Len(t, got, n)
+}

--- a/internal/classifier/model_catalog.go
+++ b/internal/classifier/model_catalog.go
@@ -71,26 +71,35 @@ type CatalogFile struct {
 // information to drive the download process.
 var EmbeddedCatalog = []CatalogEntry{
 	// Wildlife models (multi-taxa classifiers)
+	// BirdNET v3.0 acoustic classifier (developer preview). Global GPU-native model
+	// (EfficientNetV2-S backbone, 11,560 species, 32kHz/5s), paired with the v3.0
+	// geomodel range filter. Kept Hidden until GA: the HuggingFace repo is private
+	// during preview and the file checksums/sizes are finalized in a follow-up (as
+	// was done for Perch v2), so the gallery Install path is not wired yet. The
+	// backend loader is fully functional, so v3.0 can be enabled via config
+	// (models.enabled + birdnetv3 model/label paths) for evaluation. The empty
+	// SHA256 on this hidden entry is intentional: it avoids a false checksum
+	// mismatch and, being Hidden, the entry is never installed from the gallery.
 	{
 		ID:              "birdnet-v3.0",
 		Name:            "BirdNET v3.0",
-		Description:     "Global wildlife classifier using BirdNET v3.0 architecture",
+		Description:     "Global wildlife classifier using the BirdNET v3.0 architecture (11,560 species, birds and other fauna; scientific and common names)",
 		Author:          "Cornell Lab of Ornithology & Chemnitz University of Technology",
-		License:         "TBD",
+		License:         "CC-BY-SA-4.0",
 		CommercialUse:   false,
 		Category:        CategoryWildlife,
 		Region:          "",
-		SpeciesCount:    0, // determined at runtime from label file
+		SpeciesCount:    11560,
 		Version:         "3.0",
 		GeomodelVersion: "v3",
 		RegistryID:      RegistryIDBirdNETV3,
 		Hidden:          true,
 		RequiresONNX:    true,
 		UpstreamURL:     "https://github.com/birdnet-team/BirdNET-Analyzer",
-		HuggingFaceRepo: "tphakala/BirdNET-v3.0",
+		HuggingFaceRepo: "tphakala/BirdNET-v3.0-Models",
 		Files: slices.Concat([]CatalogFile{
-			{RemotePath: "birdnet_v3.0.onnx", LocalName: "birdnet_v3.0.onnx", Role: RoleModel, SHA256: "", SizeBytes: 0},
-			{RemotePath: "labels.txt", LocalName: "birdnet_v3.0_labels.txt", Role: RoleLabels, SHA256: "", SizeBytes: 0},
+			{RemotePath: "full/birdnet_v3.0_fp32.onnx", LocalName: "birdnet_v3.0_fp32.onnx", Role: RoleModel, SHA256: "", SizeBytes: 0},
+			{RemotePath: "full/birdnet_v3.0_labels.txt", LocalName: "birdnet_v3.0_labels.txt", Role: RoleLabels, SHA256: "", SizeBytes: 0},
 		}, geomodelFiles(), taxonomyFiles()),
 	},
 	{

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -1155,8 +1155,12 @@ func (mm *ModelManager) applyConfigForInstall(entry *CatalogEntry, modelPath, la
 
 	switch entry.RegistryID {
 	case RegistryIDBirdNETV3:
-		// BirdNET v3.0 acoustic model config will be added when the model is released.
-		// Geomodel range filter config is applied generically below.
+		if modelPath != "" {
+			updated.BirdNETV3.ModelPath = modelPath
+		}
+		if labelsPath != "" {
+			updated.BirdNETV3.LabelPath = labelsPath
+		}
 	case RegistryIDPerchV2:
 		if modelPath != "" {
 			updated.Perch.ModelPath = modelPath
@@ -1233,8 +1237,8 @@ func (mm *ModelManager) applyConfigForUninstall(entry *CatalogEntry) {
 
 	switch entry.RegistryID {
 	case RegistryIDBirdNETV3:
-		// BirdNET v3.0 acoustic model config will be cleared when the model is released.
-		// Geomodel range filter config is handled generically below.
+		updated.BirdNETV3.ModelPath = ""
+		updated.BirdNETV3.LabelPath = ""
 	case RegistryIDPerchV2:
 		updated.Perch.ModelPath = ""
 		updated.Perch.LabelPath = ""

--- a/internal/classifier/model_registry.go
+++ b/internal/classifier/model_registry.go
@@ -159,7 +159,7 @@ var ModelRegistry = map[string]ModelInfo{
 		DetectionVersion: "3.0",
 		Description:      "BirdNET v3.0 model (32kHz, 5s clips, embeddings)", // NumSpecies omitted: determined at runtime from label file
 		Spec:             ModelSpec{SampleRate: 32000, ClipLength: 5 * time.Second},
-		ConfigAliases:    []string{"birdnet_v3.0"},
+		ConfigAliases:    []string{conf.ModelIDBirdNETV3},
 		SupportedLocales: []string{"af", "ar", "bg", "ca", "cs", "da", "de", "el", "en-uk", "en-us", "es",
 			"et", "fi", "fr", "he", "hr", "hu", "id", "is", "it", "ja", "ko", "lt", "lv", "ml", "nl",
 			"no", "pl", "pt", "pt-br", "pt-pt", "ro", "ru", "sk", "sl", "sr", "sv", "th", "tr", "uk", "zh"},

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -1517,8 +1517,9 @@ func (o *Orchestrator) IsModelLoaded(registryID string) bool {
 // this map are recognized but not yet implemented; callers log a warning
 // and skip. Adding a new loader only requires one entry here.
 var modelLoaders = map[string]func(o *Orchestrator, threads int) error{
-	RegistryIDPerchV2: (*Orchestrator).loadPerch,
-	RegistryIDBat:     (*Orchestrator).loadBat,
+	RegistryIDBirdNETV3: (*Orchestrator).loadBirdNETV3,
+	RegistryIDPerchV2:   (*Orchestrator).loadPerch,
+	RegistryIDBat:       (*Orchestrator).loadBat,
 }
 
 // secondaryModelBuilder constructs (but does not register) a secondary model
@@ -1534,6 +1535,15 @@ type secondaryModelBuilder func(o *Orchestrator, settings *conf.Settings, thread
 // secondary OpenVINO support is a one-line entry here, paired with the OV fields on
 // its loader config.
 var openvinoCapableSecondaryBuilders = map[string]secondaryModelBuilder{
+	RegistryIDBirdNETV3: func(o *Orchestrator, settings *conf.Settings, threads int) (ModelInstance, error) {
+		// Explicit nil-on-error return avoids the typed-nil interface trap (a
+		// nil *BirdNETV3 wrapped in a non-nil ModelInstance).
+		m, err := o.buildBirdNETV3(settings, threads)
+		if err != nil {
+			return nil, err
+		}
+		return m, nil
+	},
 	RegistryIDPerchV2: func(o *Orchestrator, settings *conf.Settings, threads int) (ModelInstance, error) {
 		// Explicit nil-on-error return avoids the typed-nil interface trap (a
 		// nil *Perch wrapped in a non-nil ModelInstance).

--- a/internal/classifier/orchestrator_birdnet_v3_onnx.go
+++ b/internal/classifier/orchestrator_birdnet_v3_onnx.go
@@ -1,0 +1,100 @@
+//nolint:dupl // Parallel to orchestrator_perch_onnx.go by design: each single-file secondary ONNX classifier (Perch v2, BirdNET v3.0) has its own loader file that shares this build/load/warm-up skeleton but differs in its settings fields, registry ID, config type, and constructor.
+package classifier
+
+import (
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// buildBirdNETV3 constructs a BirdNET v3.0 model instance from the given settings
+// snapshot WITHOUT registering it in o.models. loadBirdNETV3 uses it for the
+// initial registration; the hot-reload path (ReloadSecondaryModels) uses it
+// directly so it can build the new instance on the new backend/device before
+// transactionally swapping it into the existing modelEntry.
+//
+// The settings snapshot is passed in (rather than read inside) so the caller
+// builds with the exact settings it gated the reload decision on.
+func (o *Orchestrator) buildBirdNETV3(settings *conf.Settings, threads int) (*BirdNETV3, error) {
+	modelPath := settings.BirdNETV3.ModelPath
+	labelPath := settings.BirdNETV3.LabelPath
+
+	if modelPath == "" || labelPath == "" {
+		m, l, _ := o.resolveInstalledPaths(RegistryIDBirdNETV3)
+		if modelPath == "" {
+			modelPath = m
+		}
+		if labelPath == "" {
+			labelPath = l
+		}
+	}
+
+	if modelPath == "" || labelPath == "" {
+		return nil, errors.Newf("BirdNET v3.0 model files not installed or configured").
+			Component("classifier.orchestrator").
+			Category(errors.CategoryModelInit).
+			Context("model", RegistryIDBirdNETV3).
+			Build()
+	}
+
+	if err := checkORTOrFail(settings.BirdNET.ONNXRuntimePath, "BirdNET v3.0", RegistryIDBirdNETV3, "classifier.orchestrator"); err != nil {
+		return nil, err
+	}
+
+	cfg := BirdNETV3Config{
+		ModelPath:       modelPath,
+		LabelPath:       labelPath,
+		ONNXRuntimePath: settings.BirdNET.ONNXRuntimePath,
+		Threads:         threads,
+		Backend:         settings.BirdNET.Backend,
+		OpenVINOPath:    settings.BirdNET.OpenVINOPath,
+		OpenVINODevice:  settings.BirdNET.OpenVINODevice,
+	}
+
+	model, err := NewBirdNETV3(&cfg)
+	if err != nil {
+		return nil, errors.New(err).
+			Component("classifier.orchestrator").
+			Category(errors.CategoryModelInit).
+			Context("model", RegistryIDBirdNETV3).
+			Build()
+	}
+
+	return model, nil
+}
+
+// loadBirdNETV3 creates and registers a BirdNET v3.0 model instance from settings.
+// o.mu.Lock() is held by the caller.
+func (o *Orchestrator) loadBirdNETV3(threads int) error {
+	// Capture the settings snapshot once so the recorded backend triplet matches
+	// the exact configuration the instance was built against (mirroring loadPerch).
+	// This is what makes an out-of-band runtime install (LoadModel) reconcile
+	// correctly: the entry records its own triplet, so a later
+	// ReloadSecondaryModels rebuilds it only when the backend/device changes.
+	settings := o.currentSettings()
+	before := o.captureRSSBefore()
+	model, err := o.buildBirdNETV3(settings, threads)
+	if err != nil {
+		return err
+	}
+
+	o.models[model.ModelID()] = &modelEntry{
+		instance: model,
+		backend:  secondaryTripletFor(settings),
+	}
+	// Defer the warm-up + RSS measurement until the caller releases o.mu, so the
+	// warm-up inference runs via the serialized inference path instead of stalling
+	// live inference on o.mu. The entry is registered above first so the drainer
+	// can find it by key.
+	o.deferWarmup(model.ModelID(), before)
+
+	// No separate name resolver needed. BirdNET v3.0 labels carry both the
+	// scientific and common name ("Scientific name_Common name"), like BirdNET
+	// v2.4, so downstream species-string parsing resolves the common name directly.
+
+	GetLogger().Info("BirdNET v3.0 model loaded into Orchestrator",
+		logger.String("model_id", model.ModelID()),
+		logger.Int("species", model.NumSpecies()))
+
+	return nil
+}

--- a/internal/classifier/orchestrator_perch_onnx.go
+++ b/internal/classifier/orchestrator_perch_onnx.go
@@ -1,3 +1,4 @@
+//nolint:dupl // Parallel to orchestrator_birdnet_v3_onnx.go by design: each single-file secondary ONNX classifier (Perch v2, BirdNET v3.0) has its own loader file that shares this build/load/warm-up skeleton but differs in its settings fields, registry ID, config type, and constructor.
 package classifier
 
 import (

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1740,7 +1740,7 @@ type Settings struct {
 
 	BirdNET   BirdNETConfig   `yaml:"birdnet" json:"birdnet"`     // BirdNET configuration
 	Perch     PerchConfig     `yaml:"perch" json:"perch"`         // Perch v2 model configuration
-	BirdNETV3 BirdNETV3Config `yaml:"birdnetv3" json:"birdNetV3"` // BirdNET v3.0 acoustic classifier configuration
+	BirdNETV3 BirdNETV3Config `yaml:"birdnetv3" json:"birdnetv3"` // BirdNET v3.0 acoustic classifier configuration
 	Bat       BatConfig       `yaml:"bat" json:"bat"`             // Bat detection configuration
 	BSG       BSGConfig       `yaml:"bsg" json:"bsg"`             // BSG regional bird model configuration
 	Models    ModelsConfig    `yaml:"models" json:"models"`       // Global model enablement and management

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1311,6 +1311,14 @@ type PerchConfig struct {
 	Locale    string  `yaml:"locale,omitempty" json:"locale,omitempty"`       // locale for species label translation
 }
 
+// BirdNETV3Config holds configuration for the BirdNET v3.0 acoustic classifier.
+type BirdNETV3Config struct {
+	ModelPath string  `yaml:"modelpath,omitempty" json:"modelPath,omitempty"` // path to BirdNET v3.0 ONNX model file
+	LabelPath string  `yaml:"labelpath,omitempty" json:"labelPath,omitempty"` // path to BirdNET v3.0 label file
+	Threshold float64 `yaml:"threshold" json:"threshold"`                     // confidence threshold for detections
+	Locale    string  `yaml:"locale,omitempty" json:"locale,omitempty"`       // locale for species label translation
+}
+
 // BatConfig holds configuration for bat detection using BirdNET v2.4 embeddings.
 type BatConfig struct {
 	EmbeddingModel      string                      `yaml:"embeddingmodel,omitempty" json:"embeddingModel,omitempty"`   // path to BirdNET v2.4 embeddings ONNX model
@@ -1730,11 +1738,12 @@ type Settings struct {
 		TimeAs24h bool   `yaml:"timeas24h" json:"timeAs24h"` // true 24-hour time format, false 12-hour time format
 	} `yaml:"main" json:"main"`
 
-	BirdNET BirdNETConfig `yaml:"birdnet" json:"birdnet"` // BirdNET configuration
-	Perch   PerchConfig   `yaml:"perch" json:"perch"`     // Perch v2 model configuration
-	Bat     BatConfig     `yaml:"bat" json:"bat"`         // Bat detection configuration
-	BSG     BSGConfig     `yaml:"bsg" json:"bsg"`         // BSG regional bird model configuration
-	Models  ModelsConfig  `yaml:"models" json:"models"`   // Global model enablement and management
+	BirdNET   BirdNETConfig   `yaml:"birdnet" json:"birdnet"`     // BirdNET configuration
+	Perch     PerchConfig     `yaml:"perch" json:"perch"`         // Perch v2 model configuration
+	BirdNETV3 BirdNETV3Config `yaml:"birdnetv3" json:"birdNetV3"` // BirdNET v3.0 acoustic classifier configuration
+	Bat       BatConfig       `yaml:"bat" json:"bat"`             // Bat detection configuration
+	BSG       BSGConfig       `yaml:"bsg" json:"bsg"`             // BSG regional bird model configuration
+	Models    ModelsConfig    `yaml:"models" json:"models"`       // Global model enablement and management
 
 	LowMemory LowMemoryConfig `yaml:"lowmemory" json:"lowMemory" mapstructure:"lowmemory"` // Low-memory mode override (auto/on/off) for constrained systems
 

--- a/internal/conf/consts.go
+++ b/internal/conf/consts.go
@@ -5,10 +5,11 @@ import "time"
 
 const (
 	// Model IDs identify the inference backends available for detection.
-	ModelIDBirdNET = "birdnet"
-	ModelIDPerchV2 = "perch_v2"
-	ModelIDBat     = "bat"
-	ModelIDBSG     = "bsg"
+	ModelIDBirdNET   = "birdnet"
+	ModelIDBirdNETV3 = "birdnet_v3.0"
+	ModelIDPerchV2   = "perch_v2"
+	ModelIDBat       = "bat"
+	ModelIDBSG       = "bsg"
 
 	SampleRate     = 48000 // Sample rate of the audio fed to BirdNET Analyzer
 	BitDepth       = 16    // Bit depth of the audio fed to BirdNET Analyzer

--- a/internal/conf/migrations.go
+++ b/internal/conf/migrations.go
@@ -405,7 +405,7 @@ func (s *Settings) applyModelValidation() error {
 	// Default known IDs - matches classifier.KnownConfigIDs() at compile time.
 	// This fallback is used during config loading before the classifier package
 	// is available. The orchestrator re-validates with the authoritative list.
-	knownIDs := map[string]bool{ModelIDBirdNET: true, ModelIDPerchV2: true, ModelIDBat: true, ModelIDBSG: true}
+	knownIDs := map[string]bool{ModelIDBirdNET: true, ModelIDBirdNETV3: true, ModelIDPerchV2: true, ModelIDBat: true, ModelIDBSG: true}
 	modelIssues := s.ValidateModelConfig(knownIDs, false)
 	var fatalErrors []string
 	for _, issue := range modelIssues {

--- a/internal/conf/multi_model_config_test.go
+++ b/internal/conf/multi_model_config_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // testKnownIDs mirrors classifier.KnownConfigIDs() for testing without circular imports.
-var testKnownIDs = map[string]bool{"birdnet": true, "perch_v2": true, "bat": true, "bsg": true}
+var testKnownIDs = map[string]bool{"birdnet": true, "birdnet_v3.0": true, "perch_v2": true, "bat": true, "bsg": true}
 
 func TestPerchConfig_Defaults(t *testing.T) {
 	t.Parallel()

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -67,11 +67,12 @@ var (
 // ValidAudioModels contains recognized AI model identifiers.
 // Empty string is also valid (defaults to birdnet).
 var ValidAudioModels = map[string]bool{
-	"":             true, // default (birdnet)
-	ModelIDBirdNET: true,
-	ModelIDPerchV2: true,
-	ModelIDBat:     true,
-	ModelIDBSG:     true,
+	"":               true, // default (birdnet)
+	ModelIDBirdNET:   true,
+	ModelIDBirdNETV3: true,
+	ModelIDPerchV2:   true,
+	ModelIDBat:       true,
+	ModelIDBSG:       true,
 }
 
 // ValidationError is the set of fatal validation findings produced by

--- a/internal/inference/onnx.go
+++ b/internal/inference/onnx.go
@@ -123,6 +123,15 @@ func DetectEmbeddingOutput(modelPath string) (index, size int, err error) {
 	return ort.DetectEmbeddingOutput(modelPath)
 }
 
+// DetectPredictionsOutput returns the output-port index of a model's
+// species-predictions output: the output whose last dimension equals numClasses.
+// BirdNET v3.0 also exposes a 1280-dim embeddings output whose position varies by
+// export, so the OpenVINO path uses this to bind the classifier to the correct
+// port before inference. Returns an error when no output matches numClasses.
+func DetectPredictionsOutput(modelPath string, numClasses int) (index int, err error) {
+	return ort.DetectPredictionsOutput(modelPath, numClasses)
+}
+
 // ONNXCustomClassifierOptions configures the ONNX custom classifier.
 type ONNXCustomClassifierOptions struct {
 	Labels     []string // Provide labels directly (takes priority over LabelsPath)

--- a/internal/inference/onnx/classifier.go
+++ b/internal/inference/onnx/classifier.go
@@ -484,10 +484,12 @@ func (c *Classifier) outputShape(outputIdx, batchSize int) ([]int64, error) {
 			return []int64{batch, int64(c.config.LogitsSize)}, nil
 		}
 	case BirdNETv30:
+		// Index-aware (like the BirdNETv24 case) so it covers both export orderings:
+		// EmbeddingIndex/LogitsIndex are resolved by size in buildModelConfig.
 		switch outputIdx {
-		case 0:
+		case c.config.EmbeddingIndex:
 			return []int64{batch, int64(c.config.EmbeddingSize)}, nil
-		case 1:
+		case c.config.LogitsIndex:
 			return []int64{batch, int64(c.config.LogitsSize)}, nil
 		}
 	case PerchV2:
@@ -528,13 +530,7 @@ func (c *Classifier) processOutput(outputs []ort.Value, batchIdx int) (*Result, 
 	}
 	logits := allLogits[start:end]
 
-	var scores []float32
-	switch c.config.Type {
-	case BirdNETv24, BirdNETv30:
-		scores = sigmoidSlice(logits)
-	case PerchV2:
-		scores = softmax(logits)
-	}
+	scores := activationFor(c.config.Type, logits)
 
 	var embeddings []float32
 	if c.config.EmbeddingIndex >= 0 {

--- a/internal/inference/onnx/detection.go
+++ b/internal/inference/onnx/detection.go
@@ -95,6 +95,8 @@ func buildModelConfig(mt ModelType, inputShape []int64, outputShapes [][]int64) 
 		// GPU-native export, the reverse for the stock export). Pick the embeddings
 		// port by its embeddingSizeV30 dimension and treat the other of the two
 		// outputs as predictions, so either ordering loads correctly.
+		// detectModelTypeFromShapes only classifies a model as BirdNETv30 when it has
+		// exactly two outputs, so indexing outputShapes[0] and [1] here is safe.
 		cfg.EmbeddingSize = embeddingSizeV30
 		if lastDim(outputShapes[0]) == embeddingSizeV30 {
 			cfg.EmbeddingIndex, cfg.LogitsIndex = 0, 1

--- a/internal/inference/onnx/detection.go
+++ b/internal/inference/onnx/detection.go
@@ -89,10 +89,19 @@ func buildModelConfig(mt ModelType, inputShape []int64, outputShapes [][]int64) 
 			}
 		}
 	case BirdNETv30:
-		cfg.LogitsIndex = 1
-		cfg.LogitsSize = lastDim(outputShapes[1])
-		cfg.EmbeddingIndex = 0
+		// Detect the ports by size rather than position. The v3.0 graph has a
+		// 1280-dim embeddings output and a species-predictions output, and export
+		// tooling has emitted them in both orders (embeddings@0/predictions@1 for the
+		// GPU-native export, the reverse for the stock export). Pick the embeddings
+		// port by its embeddingSizeV30 dimension and treat the other of the two
+		// outputs as predictions, so either ordering loads correctly.
 		cfg.EmbeddingSize = embeddingSizeV30
+		if lastDim(outputShapes[0]) == embeddingSizeV30 {
+			cfg.EmbeddingIndex, cfg.LogitsIndex = 0, 1
+		} else {
+			cfg.EmbeddingIndex, cfg.LogitsIndex = 1, 0
+		}
+		cfg.LogitsSize = lastDim(outputShapes[cfg.LogitsIndex])
 	case PerchV2:
 		cfg.LogitsIndex = 3
 		cfg.LogitsSize = lastDim(outputShapes[3])
@@ -121,6 +130,35 @@ func DetectEmbeddingOutput(modelPath string) (index, size int, err error) {
 		return -1, 0, fmt.Errorf("birdnet: failed to load model metadata: %w", err)
 	}
 	return selectEmbeddingOutput(outputInfos)
+}
+
+// DetectPredictionsOutput inspects an ONNX model's output tensors and returns the
+// index of its species-predictions output: the output whose last dimension equals
+// numClasses (the label count). BirdNET v3.0 also exposes a 1280-dim embeddings
+// output whose position varies by export, so the OpenVINO path uses this to bind
+// the classifier to the correct port before inference. Returns a
+// ModelDetectionError when no output matches numClasses.
+func DetectPredictionsOutput(modelPath string, numClasses int) (index int, err error) {
+	_, outputInfos, err := ort.GetInputOutputInfo(modelPath)
+	if err != nil {
+		return -1, fmt.Errorf("birdnet: failed to load model metadata: %w", err)
+	}
+	return selectPredictionsOutput(outputInfos, numClasses)
+}
+
+// selectPredictionsOutput returns the index of the species-predictions output
+// among a model's output tensors: the first output whose last dimension equals
+// numClasses. Split out so the port-selection logic is unit-testable without a
+// real ONNX model. Returns a ModelDetectionError when no output matches.
+func selectPredictionsOutput(outputInfos []ort.InputOutputInfo, numClasses int) (index int, err error) {
+	for i := range outputInfos {
+		if lastDim(outputInfos[i].Dimensions) == numClasses {
+			return i, nil
+		}
+	}
+	return -1, &ModelDetectionError{
+		Reason: fmt.Sprintf("model has no output matching %d classes", numClasses),
+	}
 }
 
 // selectEmbeddingOutput returns the index and size of the BirdNET v2.4 embedding

--- a/internal/inference/onnx/detection_test.go
+++ b/internal/inference/onnx/detection_test.go
@@ -206,6 +206,116 @@ func TestSelectEmbeddingOutput(t *testing.T) {
 	}
 }
 
+// v30LogitsSize is the BirdNET v3.0 species-predictions dimension.
+const v30LogitsSize = 11560
+
+// TestBuildModelConfig_BirdNETv30 verifies the v3.0 ports are resolved by output
+// size, not position: the GPU-native export orders outputs embeddings@0 +
+// predictions@1, while the stock export uses the reverse. Both must load with the
+// embeddings port bound to the 1280-dim output and predictions to the other.
+func TestBuildModelConfig_BirdNETv30(t *testing.T) {
+	t.Parallel()
+	inputShape := []int64{1, sampleCountV30}
+	tests := []struct {
+		name          string
+		outputShapes  [][]int64
+		wantLogitsIdx int
+		wantEmbIdx    int
+	}{
+		{
+			name:          "gpu-native order (embeddings@0, predictions@1)",
+			outputShapes:  [][]int64{{1, embeddingSizeV30}, {1, v30LogitsSize}},
+			wantLogitsIdx: 1,
+			wantEmbIdx:    0,
+		},
+		{
+			name:          "stock order (predictions@0, embeddings@1)",
+			outputShapes:  [][]int64{{1, v30LogitsSize}, {1, embeddingSizeV30}},
+			wantLogitsIdx: 0,
+			wantEmbIdx:    1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := buildModelConfig(BirdNETv30, inputShape, tt.outputShapes)
+			assert.Equal(t, BirdNETv30, cfg.Type)
+			assert.Equal(t, tt.wantLogitsIdx, cfg.LogitsIndex, "LogitsIndex")
+			assert.Equal(t, v30LogitsSize, cfg.LogitsSize, "LogitsSize")
+			assert.Equal(t, tt.wantEmbIdx, cfg.EmbeddingIndex, "EmbeddingIndex")
+			assert.Equal(t, embeddingSizeV30, cfg.EmbeddingSize, "EmbeddingSize")
+		})
+	}
+}
+
+// TestOutputShape_BirdNETv30 verifies createOutputTensors sizes each v3.0 output
+// correctly for both export orderings (index-aware, driven by the resolved ports).
+func TestOutputShape_BirdNETv30(t *testing.T) {
+	t.Parallel()
+	inputShape := []int64{1, sampleCountV30}
+	orders := [][][]int64{
+		{{1, embeddingSizeV30}, {1, v30LogitsSize}},
+		{{1, v30LogitsSize}, {1, embeddingSizeV30}},
+	}
+	for _, outputShapes := range orders {
+		cfg := buildModelConfig(BirdNETv30, inputShape, outputShapes)
+		c := &Classifier{config: cfg}
+		emb, err := c.outputShape(cfg.EmbeddingIndex, 1)
+		require.NoError(t, err)
+		assert.Equal(t, []int64{1, embeddingSizeV30}, emb)
+		logits, err := c.outputShape(cfg.LogitsIndex, 1)
+		require.NoError(t, err)
+		assert.Equal(t, []int64{1, v30LogitsSize}, logits)
+	}
+}
+
+// TestSelectPredictionsOutput covers the port-selection logic behind
+// DetectPredictionsOutput without a real ONNX model: the predictions output is the
+// one matching the label count, at either position, and a model with no matching
+// output is an error.
+func TestSelectPredictionsOutput(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		outputs    []ort.InputOutputInfo
+		numClasses int
+		wantIndex  int
+		wantErr    bool
+	}{
+		{
+			name:       "predictions at index 1 (embeddings-first)",
+			outputs:    []ort.InputOutputInfo{{Dimensions: ort.NewShape(1, embeddingSizeV30)}, {Dimensions: ort.NewShape(1, v30LogitsSize)}},
+			numClasses: v30LogitsSize,
+			wantIndex:  1,
+		},
+		{
+			name:       "predictions at index 0 (predictions-first)",
+			outputs:    []ort.InputOutputInfo{{Dimensions: ort.NewShape(1, v30LogitsSize)}, {Dimensions: ort.NewShape(1, embeddingSizeV30)}},
+			numClasses: v30LogitsSize,
+			wantIndex:  0,
+		},
+		{
+			name:       "no matching output errors",
+			outputs:    []ort.InputOutputInfo{{Dimensions: ort.NewShape(1, embeddingSizeV30)}},
+			numClasses: v30LogitsSize,
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			idx, err := selectPredictionsOutput(tt.outputs, tt.numClasses)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Equal(t, -1, idx)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantIndex, idx)
+		})
+	}
+}
+
 // TestProcessOutput_EmbeddingOnlyModelErrors confirms that calling the logits-based
 // Predict path on an embedding-only model returns a clear error instead of panicking
 // on outputs[-1]. The guard returns before indexing, so nil outputs is sufficient.

--- a/internal/inference/onnx/postprocess.go
+++ b/internal/inference/onnx/postprocess.go
@@ -19,7 +19,10 @@ func sigmoidSlice(logits []float32) []float32 {
 
 func softmax(logits []float32) []float32 {
 	if len(logits) == 0 {
-		return logits
+		// Return a fresh empty slice (never the input) so callers relying on the
+		// "newly allocated, never aliases logits" contract (activationFor) hold even
+		// for an unexpected empty output, whose backing tensor the caller destroys.
+		return []float32{}
 	}
 	result := make([]float32, len(logits))
 	maxVal := logits[0]

--- a/internal/inference/onnx/postprocess.go
+++ b/internal/inference/onnx/postprocess.go
@@ -39,6 +39,26 @@ func softmax(logits []float32) []float32 {
 	return result
 }
 
+// activationFor converts a model's raw output tensor into per-class scores.
+// BirdNET v2.4 applies sigmoid and Perch v2 applies softmax in post-processing,
+// while BirdNET v3.0 applies its per-class sigmoid in-graph: its "predictions"
+// output is already probabilities in [0,1], so it is passed through unchanged
+// (re-applying sigmoid would double-squash the scores). The returned slice is
+// always newly allocated and never aliases logits, because the caller destroys
+// the backing ONNX output tensor after post-processing.
+func activationFor(mt ModelType, logits []float32) []float32 {
+	switch mt {
+	case BirdNETv24:
+		return sigmoidSlice(logits)
+	case BirdNETv30:
+		return slices.Clone(logits)
+	case PerchV2:
+		return softmax(logits)
+	}
+	// Unknown types fall back to sigmoid, matching the historical default.
+	return sigmoidSlice(logits)
+}
+
 func topK(scores []float32, labels []string, k int, minConf float32) []Prediction {
 	var preds []Prediction
 	n := min(len(scores), len(labels))

--- a/internal/inference/onnx/postprocess.go
+++ b/internal/inference/onnx/postprocess.go
@@ -55,7 +55,8 @@ func activationFor(mt ModelType, logits []float32) []float32 {
 	case PerchV2:
 		return softmax(logits)
 	}
-	// Unknown types fall back to sigmoid, matching the historical default.
+	// Defensive fallback for an unhandled model type. ModelType is a closed
+	// three-value enum, all handled above, so this is unreachable in practice.
 	return sigmoidSlice(logits)
 }
 

--- a/internal/inference/onnx/postprocess_test.go
+++ b/internal/inference/onnx/postprocess_test.go
@@ -37,6 +37,17 @@ func TestActivationFor_BirdNETv24Sigmoid(t *testing.T) {
 	assert.InDelta(t, 0.5, got[0], 1e-6, "sigmoid(0) must be 0.5")
 }
 
+// TestActivationFor_UnknownTypeFallsBackToSigmoid pins the defensive default: an
+// out-of-range ModelType returns a sigmoid (never nil), so a future unhandled type
+// degrades to a bounded score rather than a nil-scores panic downstream.
+func TestActivationFor_UnknownTypeFallsBackToSigmoid(t *testing.T) {
+	t.Parallel()
+
+	got := activationFor(ModelType(99), []float32{0})
+	require.Len(t, got, 1)
+	assert.InDelta(t, 0.5, got[0], 1e-6, "unknown type must fall back to sigmoid(0)=0.5")
+}
+
 // TestActivationFor_PerchV2Softmax verifies Perch still gets a softmax (scores
 // sum to 1).
 func TestActivationFor_PerchV2Softmax(t *testing.T) {

--- a/internal/inference/onnx/postprocess_test.go
+++ b/internal/inference/onnx/postprocess_test.go
@@ -1,0 +1,52 @@
+package onnx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestActivationFor_BirdNETv30Passthrough is the regression guard for the v3.0
+// double-sigmoid bug: v3.0 applies its per-class sigmoid in-graph, so the
+// predictions output must be passed through unchanged, not re-activated.
+func TestActivationFor_BirdNETv30Passthrough(t *testing.T) {
+	t.Parallel()
+
+	probs := []float32{0.9, 0.01, 0.3, 0.0, 1.0}
+	got := activationFor(BirdNETv30, probs)
+
+	require.Len(t, got, len(probs))
+	for i := range probs {
+		assert.InDelta(t, probs[i], got[i], 1e-9,
+			"v3.0 predictions must pass through without re-activation")
+	}
+
+	// Must be a distinct slice: the caller destroys the backing tensor.
+	require.NotSame(t, &probs[0], &got[0], "activationFor must not alias the input")
+	got[0] = -1
+	assert.InDelta(t, float32(0.9), probs[0], 0, "mutating the result must not touch the input")
+}
+
+// TestActivationFor_BirdNETv24Sigmoid verifies v2.4 still gets a sigmoid.
+func TestActivationFor_BirdNETv24Sigmoid(t *testing.T) {
+	t.Parallel()
+
+	got := activationFor(BirdNETv24, []float32{0})
+	require.Len(t, got, 1)
+	assert.InDelta(t, 0.5, got[0], 1e-6, "sigmoid(0) must be 0.5")
+}
+
+// TestActivationFor_PerchV2Softmax verifies Perch still gets a softmax (scores
+// sum to 1).
+func TestActivationFor_PerchV2Softmax(t *testing.T) {
+	t.Parallel()
+
+	got := activationFor(PerchV2, []float32{1, 2, 3})
+	require.Len(t, got, 3)
+	var sum float32
+	for _, v := range got {
+		sum += v
+	}
+	assert.InDelta(t, 1.0, sum, 1e-6, "softmax scores must sum to 1")
+}


### PR DESCRIPTION
## Summary

Adds a working, tested backend inference path for the BirdNET v3.0 acoustic classifier (EfficientNetV2-S backbone, 11,560 species, 32 kHz / 5 s window), gated so BirdNET v2.4 stays the default. v3.0 is a preview-track effort: it reuses the existing 32 kHz / 5 s buffer path (shared with Perch v2), so the audio pipeline needs no new buffer, and the catalog entry is kept hidden until the model repository goes public at GA.

Key points:

- New `BirdNETV3` model instance mirroring the Perch v2 path: OpenVINO-first with ONNX Runtime fallback, but with no model-variant filename gate because the GPU-native v3.0 graph (Conv1d front-end, no `STFT` op) runs on OpenVINO directly.
- v3.0's `predictions` output is a per-class sigmoid applied in-graph, so it is used verbatim with no re-activation (unlike Perch's softmax and v2.4's sigmoid). This also fixes a latent double-sigmoid in the shared ONNX post-processing for the v3.0 model type (reachable only via the high-level Predict path, not the production instance path).
- The embeddings and predictions output ports are resolved by size, not fixed position, so both ONNX export orderings load correctly.
- `Scientific name_Common name` label parsing (identical format to BirdNET v2.4), so common names resolve directly with no extra name resolver.
- New `conf.BirdNETV3Config` plus settings / orchestrator loader / model-manager wiring; the v3 geomodel range filter already auto-selects for v3.0.

Not in this PR (preview-track follow-ups): the model repository is private during preview, so the gallery download entry stays hidden and its checksums land later; the regional model catalog and the settings model-selection UI are separate follow-ups.

## Validation

- New unit tests: label parsing, the no-activation output contract, size-based port detection (both export orderings), orchestrator/loader registration, catalog entry shape, and the Predict error branches.
- End-to-end real-inference check through the ONNX Runtime path on real 32 kHz audio: a tawny owl clip yields `Strix aluco` (Tawny Owl) at 0.92 confidence with every other species near zero; a multi-species soundscape yields a realistic probability spread (no double-sigmoid flattening).
- `golangci-lint` clean, `go test -race` green for the affected packages, `config.schema.json` and the configuration reference regenerated, and the hot-reload coverage and schema-drift guards pass.

## Test Plan

- [ ] CI green (build, unit tests, lint, cross-platform)
- [ ] Automated review addressed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added BirdNET v3.0 acoustic classification support with ONNX Runtime and optional OpenVINO acceleration.
  * Added configurable model and label paths, confidence threshold, and locale settings.
  * Added automatic model installation, loading, prediction, and runtime detection.
  * Updated the model catalog with BirdNET v3.0 metadata and 11,560 species labels.
* **Documentation**
  * Added BirdNET v3.0 settings to the configuration reference.
* **Bug Fixes**
  * Improved model output detection across different export formats.
  * Ensured model settings are correctly saved during installation and cleared during removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->