### PR TITLE
fix(config): stop treating inert half-configured settings as fatal

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -94,22 +94,27 @@ The "realtime" command is an alias for backward compatibility.`,
 // setupFlags configures flags specific to the serve command.
 // These are the same flags previously on the realtime command.
 func setupFlags(cmd *cobra.Command, settings *conf.Settings) error {
-	// Flags whose target the config load rewrites take their default from the loaded
-	// settings rather than from viper, for the same reason as --locale in
-	// cmd/root.go: cobra assigns the default into the bound variable at registration
-	// time, so passing the raw viper value writes it straight back over whatever
-	// load produced. For --source, --rtsp and --rtsptransport that would resurrect
-	// the legacy keys MigrateAudioSourceConfig and MigrateRTSPConfig deliberately
-	// cleared, and the next save would write them back into config.yaml. For
-	// --listen it would undo the normalized telemetry address, leaving the endpoint
-	// with nothing to bind.
-	cmd.Flags().StringVar(&settings.Realtime.Audio.Export.Path, "clippath", viper.GetString("realtime.audio.export.path"), "Path to save audio clips")
+	// Every flag default comes from the loaded settings rather than from viper, for
+	// the same reason as --locale in cmd/root.go: cobra assigns the default into the
+	// bound variable at registration time, so passing the raw viper value writes it
+	// straight back over whatever load produced. For --source, --rtsp and
+	// --rtsptransport that would resurrect the legacy keys MigrateAudioSourceConfig
+	// and MigrateRTSPConfig deliberately cleared, and the next save would write them
+	// back into config.yaml. For --listen it would undo the normalized telemetry
+	// address, leaving the endpoint with nothing to bind.
+	//
+	// The remaining flags are read from settings too, even though nothing rewrites
+	// their keys today. Since the bound field already holds the loaded value, each
+	// default is a self-assignment, so the uniform spelling costs nothing and removes
+	// the trap: the next default or migration added to export.path, log.path or
+	// telemetry.enabled would otherwise silently reintroduce exactly this bug.
+	cmd.Flags().StringVar(&settings.Realtime.Audio.Export.Path, "clippath", settings.Realtime.Audio.Export.Path, "Path to save audio clips")
 	cmd.Flags().StringVar(&settings.Realtime.Audio.Source, "source", settings.Realtime.Audio.Source, "Audio capture source (\"sysdefault\", \"USB Audio\", \":0,0\", etc.)")
-	cmd.Flags().StringVar(&settings.Realtime.Log.Path, "logpath", viper.GetString("realtime.log.path"), "Path to save log files")
-	cmd.Flags().BoolVar(&settings.Realtime.ProcessingTime, "processingtime", viper.GetBool("realtime.processingtime"), "Report processing time for each detection")
+	cmd.Flags().StringVar(&settings.Realtime.Log.Path, "logpath", settings.Realtime.Log.Path, "Path to save log files")
+	cmd.Flags().BoolVar(&settings.Realtime.ProcessingTime, "processingtime", settings.Realtime.ProcessingTime, "Report processing time for each detection")
 	cmd.Flags().StringSliceVar(&settings.Realtime.RTSP.URLs, "rtsp", settings.Realtime.RTSP.URLs, "URL of RTSP audio stream to capture")
 	cmd.Flags().StringVar(&settings.Realtime.RTSP.Transport, "rtsptransport", settings.Realtime.RTSP.Transport, "RTSP transport (tcp/udp)")
-	cmd.Flags().BoolVar(&settings.Realtime.Telemetry.Enabled, "telemetry", viper.GetBool("realtime.telemetry.enabled"), "Enable Prometheus telemetry endpoint")
+	cmd.Flags().BoolVar(&settings.Realtime.Telemetry.Enabled, "telemetry", settings.Realtime.Telemetry.Enabled, "Enable Prometheus telemetry endpoint")
 	cmd.Flags().StringVar(&settings.Realtime.Telemetry.Listen, "listen", settings.Realtime.Telemetry.Listen, "Listen address and port of telemetry endpoint")
 
 	if err := viper.BindPFlags(cmd.Flags()); err != nil {

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -94,14 +94,23 @@ The "realtime" command is an alias for backward compatibility.`,
 // setupFlags configures flags specific to the serve command.
 // These are the same flags previously on the realtime command.
 func setupFlags(cmd *cobra.Command, settings *conf.Settings) error {
+	// Flags whose target the config load rewrites take their default from the loaded
+	// settings rather than from viper, for the same reason as --locale in
+	// cmd/root.go: cobra assigns the default into the bound variable at registration
+	// time, so passing the raw viper value writes it straight back over whatever
+	// load produced. For --source, --rtsp and --rtsptransport that would resurrect
+	// the legacy keys MigrateAudioSourceConfig and MigrateRTSPConfig deliberately
+	// cleared, and the next save would write them back into config.yaml. For
+	// --listen it would undo the normalized telemetry address, leaving the endpoint
+	// with nothing to bind.
 	cmd.Flags().StringVar(&settings.Realtime.Audio.Export.Path, "clippath", viper.GetString("realtime.audio.export.path"), "Path to save audio clips")
-	cmd.Flags().StringVar(&settings.Realtime.Audio.Source, "source", viper.GetString("realtime.audio.source"), "Audio capture source (\"sysdefault\", \"USB Audio\", \":0,0\", etc.)")
+	cmd.Flags().StringVar(&settings.Realtime.Audio.Source, "source", settings.Realtime.Audio.Source, "Audio capture source (\"sysdefault\", \"USB Audio\", \":0,0\", etc.)")
 	cmd.Flags().StringVar(&settings.Realtime.Log.Path, "logpath", viper.GetString("realtime.log.path"), "Path to save log files")
 	cmd.Flags().BoolVar(&settings.Realtime.ProcessingTime, "processingtime", viper.GetBool("realtime.processingtime"), "Report processing time for each detection")
-	cmd.Flags().StringSliceVar(&settings.Realtime.RTSP.URLs, "rtsp", viper.GetStringSlice("realtime.rtsp.urls"), "URL of RTSP audio stream to capture")
-	cmd.Flags().StringVar(&settings.Realtime.RTSP.Transport, "rtsptransport", viper.GetString("realtime.rtsp.transport"), "RTSP transport (tcp/udp)")
+	cmd.Flags().StringSliceVar(&settings.Realtime.RTSP.URLs, "rtsp", settings.Realtime.RTSP.URLs, "URL of RTSP audio stream to capture")
+	cmd.Flags().StringVar(&settings.Realtime.RTSP.Transport, "rtsptransport", settings.Realtime.RTSP.Transport, "RTSP transport (tcp/udp)")
 	cmd.Flags().BoolVar(&settings.Realtime.Telemetry.Enabled, "telemetry", viper.GetBool("realtime.telemetry.enabled"), "Enable Prometheus telemetry endpoint")
-	cmd.Flags().StringVar(&settings.Realtime.Telemetry.Listen, "listen", viper.GetString("realtime.telemetry.listen"), "Listen address and port of telemetry endpoint")
+	cmd.Flags().StringVar(&settings.Realtime.Telemetry.Listen, "listen", settings.Realtime.Telemetry.Listen, "Listen address and port of telemetry endpoint")
 
 	if err := viper.BindPFlags(cmd.Flags()); err != nil {
 		return fmt.Errorf("error binding flags: %w", err)

--- a/config.schema.json
+++ b/config.schema.json
@@ -1997,7 +1997,7 @@
         },
         "windowdays": {
           "type": "integer",
-          "description": "Days to show \"new this season\" indicator (default: 21)"
+          "description": "Days to show \"new this season\" indicator (default: 7, DefaultSeasonalTrackingWindowDays)"
         },
         "seasons": {
           "oneOf": [
@@ -2415,7 +2415,7 @@
         },
         "newspecieswindowdays": {
           "type": "integer",
-          "description": "Days to consider a species \"new\" (default: 14)"
+          "description": "Days to consider a species \"new\" (default: 7, DefaultNewSpeciesWindowDays)"
         },
         "syncintervalminutes": {
           "type": "integer",
@@ -2820,7 +2820,7 @@
         },
         "windowdays": {
           "type": "integer",
-          "description": "Days to show \"new this year\" indicator (default: 30)"
+          "description": "Days to show \"new this year\" indicator (default: 7, DefaultYearlyTrackingWindowDays)"
         }
       },
       "additionalProperties": false,

--- a/config.schema.json
+++ b/config.schema.json
@@ -1997,7 +1997,7 @@
         },
         "windowdays": {
           "type": "integer",
-          "description": "Days to show \"new this season\" indicator (default: 7, DefaultSeasonalTrackingWindowDays)"
+          "description": "Days to show \"new this season\" indicator (default: 7)"
         },
         "seasons": {
           "oneOf": [
@@ -2415,7 +2415,7 @@
         },
         "newspecieswindowdays": {
           "type": "integer",
-          "description": "Days to consider a species \"new\" (default: 7, DefaultNewSpeciesWindowDays)"
+          "description": "Days to consider a species \"new\" (default: 7)"
         },
         "syncintervalminutes": {
           "type": "integer",
@@ -2820,7 +2820,7 @@
         },
         "windowdays": {
           "type": "integer",
-          "description": "Days to show \"new this year\" indicator (default: 7, DefaultYearlyTrackingWindowDays)"
+          "description": "Days to show \"new this year\" indicator (default: 7)"
         }
       },
       "additionalProperties": false,

--- a/doc/wiki/configuration-reference.md
+++ b/doc/wiki/configuration-reference.md
@@ -307,15 +307,15 @@ RealtimeSettings contains all settings related to realtime processing.
 | `realtime.weather.wunderground.endpoint` | string | WeatherUnderground API endpoint |
 | `realtime.weather.wunderground.units` | string | units of measurement: "e" (imperial), "m" (metric), "h" (UK hybrid) |
 | `realtime.speciestracking.enabled` | boolean | true to enable new species tracking |
-| `realtime.speciestracking.newspecieswindowdays` | integer | Days to consider a species "new" (default: 7, DefaultNewSpeciesWindowDays) |
+| `realtime.speciestracking.newspecieswindowdays` | integer | Days to consider a species "new" (default: 7) |
 | `realtime.speciestracking.syncintervalminutes` | integer | Interval to sync with database (default: 60) |
 | `realtime.speciestracking.notificationsuppressionhours` | integer | Hours to suppress duplicate notifications (default: 168) |
 | `realtime.speciestracking.yearlytracking.enabled` | boolean | true to enable yearly tracking |
 | `realtime.speciestracking.yearlytracking.resetmonth` | integer | Month to reset yearly tracking (1=January, default: 1) |
 | `realtime.speciestracking.yearlytracking.resetday` | integer | Day to reset yearly tracking (default: 1) |
-| `realtime.speciestracking.yearlytracking.windowdays` | integer | Days to show "new this year" indicator (default: 7, DefaultYearlyTrackingWindowDays) |
+| `realtime.speciestracking.yearlytracking.windowdays` | integer | Days to show "new this year" indicator (default: 7) |
 | `realtime.speciestracking.seasonaltracking.enabled` | boolean | true to enable seasonal tracking |
-| `realtime.speciestracking.seasonaltracking.windowdays` | integer | Days to show "new this season" indicator (default: 7, DefaultSeasonalTrackingWindowDays) |
+| `realtime.speciestracking.seasonaltracking.windowdays` | integer | Days to show "new this season" indicator (default: 7) |
 | `realtime.speciestracking.seasonaltracking.seasons` | any |  |
 | `realtime.extendedcapture.enabled` | boolean |  |
 | `realtime.extendedcapture.maxduration` | integer |  |

--- a/doc/wiki/configuration-reference.md
+++ b/doc/wiki/configuration-reference.md
@@ -307,15 +307,15 @@ RealtimeSettings contains all settings related to realtime processing.
 | `realtime.weather.wunderground.endpoint` | string | WeatherUnderground API endpoint |
 | `realtime.weather.wunderground.units` | string | units of measurement: "e" (imperial), "m" (metric), "h" (UK hybrid) |
 | `realtime.speciestracking.enabled` | boolean | true to enable new species tracking |
-| `realtime.speciestracking.newspecieswindowdays` | integer | Days to consider a species "new" (default: 14) |
+| `realtime.speciestracking.newspecieswindowdays` | integer | Days to consider a species "new" (default: 7) |
 | `realtime.speciestracking.syncintervalminutes` | integer | Interval to sync with database (default: 60) |
 | `realtime.speciestracking.notificationsuppressionhours` | integer | Hours to suppress duplicate notifications (default: 168) |
 | `realtime.speciestracking.yearlytracking.enabled` | boolean | true to enable yearly tracking |
 | `realtime.speciestracking.yearlytracking.resetmonth` | integer | Month to reset yearly tracking (1=January, default: 1) |
 | `realtime.speciestracking.yearlytracking.resetday` | integer | Day to reset yearly tracking (default: 1) |
-| `realtime.speciestracking.yearlytracking.windowdays` | integer | Days to show "new this year" indicator (default: 30) |
+| `realtime.speciestracking.yearlytracking.windowdays` | integer | Days to show "new this year" indicator (default: 7) |
 | `realtime.speciestracking.seasonaltracking.enabled` | boolean | true to enable seasonal tracking |
-| `realtime.speciestracking.seasonaltracking.windowdays` | integer | Days to show "new this season" indicator (default: 21) |
+| `realtime.speciestracking.seasonaltracking.windowdays` | integer | Days to show "new this season" indicator (default: 7) |
 | `realtime.speciestracking.seasonaltracking.seasons` | any |  |
 | `realtime.extendedcapture.enabled` | boolean |  |
 | `realtime.extendedcapture.maxduration` | integer |  |

--- a/doc/wiki/configuration-reference.md
+++ b/doc/wiki/configuration-reference.md
@@ -307,15 +307,15 @@ RealtimeSettings contains all settings related to realtime processing.
 | `realtime.weather.wunderground.endpoint` | string | WeatherUnderground API endpoint |
 | `realtime.weather.wunderground.units` | string | units of measurement: "e" (imperial), "m" (metric), "h" (UK hybrid) |
 | `realtime.speciestracking.enabled` | boolean | true to enable new species tracking |
-| `realtime.speciestracking.newspecieswindowdays` | integer | Days to consider a species "new" (default: 7) |
+| `realtime.speciestracking.newspecieswindowdays` | integer | Days to consider a species "new" (default: 7, DefaultNewSpeciesWindowDays) |
 | `realtime.speciestracking.syncintervalminutes` | integer | Interval to sync with database (default: 60) |
 | `realtime.speciestracking.notificationsuppressionhours` | integer | Hours to suppress duplicate notifications (default: 168) |
 | `realtime.speciestracking.yearlytracking.enabled` | boolean | true to enable yearly tracking |
 | `realtime.speciestracking.yearlytracking.resetmonth` | integer | Month to reset yearly tracking (1=January, default: 1) |
 | `realtime.speciestracking.yearlytracking.resetday` | integer | Day to reset yearly tracking (default: 1) |
-| `realtime.speciestracking.yearlytracking.windowdays` | integer | Days to show "new this year" indicator (default: 7) |
+| `realtime.speciestracking.yearlytracking.windowdays` | integer | Days to show "new this year" indicator (default: 7, DefaultYearlyTrackingWindowDays) |
 | `realtime.speciestracking.seasonaltracking.enabled` | boolean | true to enable seasonal tracking |
-| `realtime.speciestracking.seasonaltracking.windowdays` | integer | Days to show "new this season" indicator (default: 7) |
+| `realtime.speciestracking.seasonaltracking.windowdays` | integer | Days to show "new this season" indicator (default: 7, DefaultSeasonalTrackingWindowDays) |
 | `realtime.speciestracking.seasonaltracking.seasons` | any |  |
 | `realtime.extendedcapture.enabled` | boolean |  |
 | `realtime.extendedcapture.maxduration` | integer |  |

--- a/internal/analysis/species/README.md
+++ b/internal/analysis/species/README.md
@@ -99,7 +99,7 @@ The tracker manages three independent time periods:
 
 Each period has a configurable "new species" window:
 
-- **Lifetime Window**: Days after first-ever detection (default: 14 days)
+- **Lifetime Window**: Days after first-ever detection (default: 7 days)
 - **Yearly Window**: Days after first detection this year
 - **Seasonal Window**: Days after first detection this season
 

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -928,7 +928,7 @@ type LogDeduplicationSettings struct {
 // SpeciesTrackingSettings contains settings for tracking new species
 type SpeciesTrackingSettings struct {
 	Enabled                      bool                     `yaml:"enabled" json:"enabled"`                                           // true to enable new species tracking
-	NewSpeciesWindowDays         int                      `yaml:"newspecieswindowdays" json:"newSpeciesWindowDays"`                 // Days to consider a species "new" (default: 7, DefaultNewSpeciesWindowDays)
+	NewSpeciesWindowDays         int                      `yaml:"newspecieswindowdays" json:"newSpeciesWindowDays"`                 // Days to consider a species "new" (default: 7)
 	SyncIntervalMinutes          int                      `yaml:"syncintervalminutes" json:"syncIntervalMinutes"`                   // Interval to sync with database (default: 60)
 	NotificationSuppressionHours int                      `yaml:"notificationsuppressionhours" json:"notificationSuppressionHours"` // Hours to suppress duplicate notifications (default: 168)
 	YearlyTracking               YearlyTrackingSettings   `yaml:"yearlytracking" json:"yearlyTracking"`                             // Settings for yearly species tracking
@@ -940,13 +940,13 @@ type YearlyTrackingSettings struct {
 	Enabled    bool `yaml:"enabled" json:"enabled"`       // true to enable yearly tracking
 	ResetMonth int  `yaml:"resetmonth" json:"resetMonth"` // Month to reset yearly tracking (1=January, default: 1)
 	ResetDay   int  `yaml:"resetday" json:"resetDay"`     // Day to reset yearly tracking (default: 1)
-	WindowDays int  `yaml:"windowdays" json:"windowDays"` // Days to show "new this year" indicator (default: 7, DefaultYearlyTrackingWindowDays)
+	WindowDays int  `yaml:"windowdays" json:"windowDays"` // Days to show "new this year" indicator (default: 7)
 }
 
 // SeasonalTrackingSettings contains settings for tracking first arrivals each season
 type SeasonalTrackingSettings struct {
 	Enabled    bool              `yaml:"enabled" json:"enabled"`                       // true to enable seasonal tracking
-	WindowDays int               `yaml:"windowdays" json:"windowDays"`                 // Days to show "new this season" indicator (default: 7, DefaultSeasonalTrackingWindowDays)
+	WindowDays int               `yaml:"windowdays" json:"windowDays"`                 // Days to show "new this season" indicator (default: 7)
 	Seasons    map[string]Season `yaml:"seasons" json:"seasons" jsonschema:"nullable"` // Season definitions
 }
 

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -928,7 +928,7 @@ type LogDeduplicationSettings struct {
 // SpeciesTrackingSettings contains settings for tracking new species
 type SpeciesTrackingSettings struct {
 	Enabled                      bool                     `yaml:"enabled" json:"enabled"`                                           // true to enable new species tracking
-	NewSpeciesWindowDays         int                      `yaml:"newspecieswindowdays" json:"newSpeciesWindowDays"`                 // Days to consider a species "new" (default: 14)
+	NewSpeciesWindowDays         int                      `yaml:"newspecieswindowdays" json:"newSpeciesWindowDays"`                 // Days to consider a species "new" (default: DefaultNewSpeciesWindowDays)
 	SyncIntervalMinutes          int                      `yaml:"syncintervalminutes" json:"syncIntervalMinutes"`                   // Interval to sync with database (default: 60)
 	NotificationSuppressionHours int                      `yaml:"notificationsuppressionhours" json:"notificationSuppressionHours"` // Hours to suppress duplicate notifications (default: 168)
 	YearlyTracking               YearlyTrackingSettings   `yaml:"yearlytracking" json:"yearlyTracking"`                             // Settings for yearly species tracking
@@ -940,13 +940,13 @@ type YearlyTrackingSettings struct {
 	Enabled    bool `yaml:"enabled" json:"enabled"`       // true to enable yearly tracking
 	ResetMonth int  `yaml:"resetmonth" json:"resetMonth"` // Month to reset yearly tracking (1=January, default: 1)
 	ResetDay   int  `yaml:"resetday" json:"resetDay"`     // Day to reset yearly tracking (default: 1)
-	WindowDays int  `yaml:"windowdays" json:"windowDays"` // Days to show "new this year" indicator (default: 30)
+	WindowDays int  `yaml:"windowdays" json:"windowDays"` // Days to show "new this year" indicator (default: DefaultYearlyTrackingWindowDays)
 }
 
 // SeasonalTrackingSettings contains settings for tracking first arrivals each season
 type SeasonalTrackingSettings struct {
 	Enabled    bool              `yaml:"enabled" json:"enabled"`                       // true to enable seasonal tracking
-	WindowDays int               `yaml:"windowdays" json:"windowDays"`                 // Days to show "new this season" indicator (default: 21)
+	WindowDays int               `yaml:"windowdays" json:"windowDays"`                 // Days to show "new this season" indicator (default: DefaultSeasonalTrackingWindowDays)
 	Seasons    map[string]Season `yaml:"seasons" json:"seasons" jsonschema:"nullable"` // Season definitions
 }
 

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -928,7 +928,7 @@ type LogDeduplicationSettings struct {
 // SpeciesTrackingSettings contains settings for tracking new species
 type SpeciesTrackingSettings struct {
 	Enabled                      bool                     `yaml:"enabled" json:"enabled"`                                           // true to enable new species tracking
-	NewSpeciesWindowDays         int                      `yaml:"newspecieswindowdays" json:"newSpeciesWindowDays"`                 // Days to consider a species "new" (default: DefaultNewSpeciesWindowDays)
+	NewSpeciesWindowDays         int                      `yaml:"newspecieswindowdays" json:"newSpeciesWindowDays"`                 // Days to consider a species "new" (default: 7, DefaultNewSpeciesWindowDays)
 	SyncIntervalMinutes          int                      `yaml:"syncintervalminutes" json:"syncIntervalMinutes"`                   // Interval to sync with database (default: 60)
 	NotificationSuppressionHours int                      `yaml:"notificationsuppressionhours" json:"notificationSuppressionHours"` // Hours to suppress duplicate notifications (default: 168)
 	YearlyTracking               YearlyTrackingSettings   `yaml:"yearlytracking" json:"yearlyTracking"`                             // Settings for yearly species tracking
@@ -940,13 +940,13 @@ type YearlyTrackingSettings struct {
 	Enabled    bool `yaml:"enabled" json:"enabled"`       // true to enable yearly tracking
 	ResetMonth int  `yaml:"resetmonth" json:"resetMonth"` // Month to reset yearly tracking (1=January, default: 1)
 	ResetDay   int  `yaml:"resetday" json:"resetDay"`     // Day to reset yearly tracking (default: 1)
-	WindowDays int  `yaml:"windowdays" json:"windowDays"` // Days to show "new this year" indicator (default: DefaultYearlyTrackingWindowDays)
+	WindowDays int  `yaml:"windowdays" json:"windowDays"` // Days to show "new this year" indicator (default: 7, DefaultYearlyTrackingWindowDays)
 }
 
 // SeasonalTrackingSettings contains settings for tracking first arrivals each season
 type SeasonalTrackingSettings struct {
 	Enabled    bool              `yaml:"enabled" json:"enabled"`                       // true to enable seasonal tracking
-	WindowDays int               `yaml:"windowdays" json:"windowDays"`                 // Days to show "new this season" indicator (default: DefaultSeasonalTrackingWindowDays)
+	WindowDays int               `yaml:"windowdays" json:"windowDays"`                 // Days to show "new this season" indicator (default: 7, DefaultSeasonalTrackingWindowDays)
 	Seasons    map[string]Season `yaml:"seasons" json:"seasons" jsonschema:"nullable"` // Season definitions
 }
 

--- a/internal/conf/consts.go
+++ b/internal/conf/consts.go
@@ -49,6 +49,35 @@ const (
 
 	// DefaultWeatherPollInterval is the default weather poll interval in minutes.
 	DefaultWeatherPollInterval = 60
+
+	// The viper defaults, named so defaults.go and the incomplete-feature
+	// normalization cannot drift apart. Most are applied by normalizeIncompleteFeatures
+	// when a feature is switched on and the field was left at its zero value;
+	// DefaultNotificationSuppressionHours is the exception, because zero is a legal
+	// value there rather than an unwritten one, so only viper uses it.
+	DefaultWebServerPort                = "8080"
+	DefaultTelemetryListen              = "0.0.0.0:8090"
+	DefaultSoundLevelInterval           = 10
+	DefaultDynamicThresholdValidHours   = 24
+	DefaultNewSpeciesWindowDays         = 7
+	DefaultSpeciesSyncIntervalMinutes   = 60
+	DefaultYearlyTrackingResetMonth     = 1
+	DefaultYearlyTrackingResetDay       = 1
+	DefaultYearlyTrackingWindowDays     = 7
+	DefaultSeasonalTrackingWindowDays   = 7
+	DefaultNotificationSuppressionHours = 168
+	DefaultAudioExportLength            = 15
+	DefaultAudioExportBitrate           = "96k"
+	DefaultNormalizationTargetLUFS      = -23.0
+	DefaultRetentionMaxAge              = "30d"
+	DefaultRetentionMaxUsage            = "80%"
+	DefaultRetryBackoffMultiplier       = 2.0
+
+	// DefaultEQQFactor is the Q factor applied to an equalizer filter whose q was
+	// never set. eqfilter_config.go offers it as the settings UI's default too, so a
+	// filter created in the UI and one repaired here get the same value. 0.707 is the
+	// conventional rounding of the Butterworth 1/sqrt(2).
+	DefaultEQQFactor = 0.707
 )
 
 // DefaultSessionDuration is the default session duration (7 days).

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -119,23 +119,23 @@ func setDefaultConfig() {
 
 	// Sound level monitoring configuration
 	viper.SetDefault("realtime.audio.soundlevel.enabled", false)
-	viper.SetDefault("realtime.audio.soundlevel.interval", 10)
+	viper.SetDefault("realtime.audio.soundlevel.interval", DefaultSoundLevelInterval)
 
 	// Audio capture configuration
 	viper.SetDefault("realtime.audio.export.debug", false)
 	viper.SetDefault("realtime.audio.export.enabled", true)
 	viper.SetDefault("realtime.audio.export.path", "clips/")
 	viper.SetDefault("realtime.audio.export.type", "wav")
-	viper.SetDefault("realtime.audio.export.bitrate", "96k")
-	viper.SetDefault("realtime.audio.export.length", 15)
+	viper.SetDefault("realtime.audio.export.bitrate", DefaultAudioExportBitrate)
+	viper.SetDefault("realtime.audio.export.length", DefaultAudioExportLength)
 	viper.SetDefault("realtime.audio.export.preCapture", 3)
 	viper.SetDefault("realtime.audio.export.gain", 0.0)
 
 	// Audio normalization configuration (EBU R128 standard)
-	viper.SetDefault("realtime.audio.export.normalization.enabled", false)     // disabled by default
-	viper.SetDefault("realtime.audio.export.normalization.targetLUFS", -23.0)  // EBU R128 broadcast standard
-	viper.SetDefault("realtime.audio.export.normalization.loudnessRange", 7.0) // typical range for broadcast
-	viper.SetDefault("realtime.audio.export.normalization.truePeak", -2.0)     // headroom to prevent clipping
+	viper.SetDefault("realtime.audio.export.normalization.enabled", false)                             // disabled by default
+	viper.SetDefault("realtime.audio.export.normalization.targetLUFS", DefaultNormalizationTargetLUFS) // EBU R128 broadcast standard
+	viper.SetDefault("realtime.audio.export.normalization.loudnessRange", 7.0)                         // typical range for broadcast
+	viper.SetDefault("realtime.audio.export.normalization.truePeak", -2.0)                             // headroom to prevent clipping
 
 	// Quiet hours configuration (sound card)
 	viper.SetDefault("realtime.audio.quiethours.enabled", false)
@@ -188,8 +188,8 @@ func setDefaultConfig() {
 	viper.SetDefault("realtime.audio.export.retention.enabled", true)
 	viper.SetDefault("realtime.audio.export.retention.debug", false)
 	viper.SetDefault("realtime.audio.export.retention.policy", "usage")
-	viper.SetDefault("realtime.audio.export.retention.maxusage", "80%")
-	viper.SetDefault("realtime.audio.export.retention.maxage", "30d")
+	viper.SetDefault("realtime.audio.export.retention.maxusage", DefaultRetentionMaxUsage)
+	viper.SetDefault("realtime.audio.export.retention.maxage", DefaultRetentionMaxAge)
 	viper.SetDefault("realtime.audio.export.retention.minclips", 10)
 	viper.SetDefault("realtime.audio.export.retention.keepspectrograms", true)
 	viper.SetDefault("realtime.audio.export.retention.checkinterval", DefaultCleanupCheckInterval)
@@ -199,7 +199,7 @@ func setDefaultConfig() {
 	viper.SetDefault("realtime.dynamicthreshold.debug", false)
 	viper.SetDefault("realtime.dynamicthreshold.trigger", 0.90)
 	viper.SetDefault("realtime.dynamicthreshold.min", 0.20)
-	viper.SetDefault("realtime.dynamicthreshold.validhours", 24)
+	viper.SetDefault("realtime.dynamicthreshold.validhours", DefaultDynamicThresholdValidHours)
 
 	// Log deduplication configuration
 	viper.SetDefault("realtime.logdeduplication.enabled", true)
@@ -280,7 +280,7 @@ func setDefaultConfig() {
 	viper.SetDefault("realtime.mqtt.retrysettings.maxretries", 5)
 	viper.SetDefault("realtime.mqtt.retrysettings.initialdelay", 30)
 	viper.SetDefault("realtime.mqtt.retrysettings.maxdelay", 3600)
-	viper.SetDefault("realtime.mqtt.retrysettings.backoffmultiplier", 2.0)
+	viper.SetDefault("realtime.mqtt.retrysettings.backoffmultiplier", DefaultRetryBackoffMultiplier)
 
 	// Home Assistant MQTT auto-discovery configuration
 	viper.SetDefault("realtime.mqtt.homeassistant.enabled", false)
@@ -301,7 +301,7 @@ func setDefaultConfig() {
 
 	// Telemetry configuration
 	viper.SetDefault("realtime.telemetry.enabled", false)
-	viper.SetDefault("realtime.telemetry.listen", "0.0.0.0:8090")
+	viper.SetDefault("realtime.telemetry.listen", DefaultTelemetryListen)
 
 	// System monitoring configuration
 	viper.SetDefault("realtime.monitoring.enabled", true)
@@ -316,19 +316,19 @@ func setDefaultConfig() {
 
 	// Species tracking configuration
 	viper.SetDefault("realtime.speciestracking.enabled", true)
-	viper.SetDefault("realtime.speciestracking.newspecieswindowdays", 7)
-	viper.SetDefault("realtime.speciestracking.syncintervalminutes", 60)
-	viper.SetDefault("realtime.speciestracking.notificationsuppressionhours", 168) // 7 days
+	viper.SetDefault("realtime.speciestracking.newspecieswindowdays", DefaultNewSpeciesWindowDays)
+	viper.SetDefault("realtime.speciestracking.syncintervalminutes", DefaultSpeciesSyncIntervalMinutes)
+	viper.SetDefault("realtime.speciestracking.notificationsuppressionhours", DefaultNotificationSuppressionHours) // 7 days
 
 	// Yearly tracking defaults
 	viper.SetDefault("realtime.speciestracking.yearlytracking.enabled", true)
-	viper.SetDefault("realtime.speciestracking.yearlytracking.resetmonth", 1)
-	viper.SetDefault("realtime.speciestracking.yearlytracking.resetday", 1)
-	viper.SetDefault("realtime.speciestracking.yearlytracking.windowdays", 7)
+	viper.SetDefault("realtime.speciestracking.yearlytracking.resetmonth", DefaultYearlyTrackingResetMonth)
+	viper.SetDefault("realtime.speciestracking.yearlytracking.resetday", DefaultYearlyTrackingResetDay)
+	viper.SetDefault("realtime.speciestracking.yearlytracking.windowdays", DefaultYearlyTrackingWindowDays)
 
 	// Seasonal tracking defaults
 	viper.SetDefault("realtime.speciestracking.seasonaltracking.enabled", true)
-	viper.SetDefault("realtime.speciestracking.seasonaltracking.windowdays", 7)
+	viper.SetDefault("realtime.speciestracking.seasonaltracking.windowdays", DefaultSeasonalTrackingWindowDays)
 
 	// Default seasons (Northern Hemisphere)
 	viper.SetDefault("realtime.speciestracking.seasonaltracking.seasons.spring.startmonth", 3)
@@ -343,7 +343,7 @@ func setDefaultConfig() {
 	// Webserver configuration
 	viper.SetDefault("webserver.debug", false)
 	viper.SetDefault("webserver.enabled", true)
-	viper.SetDefault("webserver.port", "8080")
+	viper.SetDefault("webserver.port", DefaultWebServerPort)
 
 	// Live stream configuration
 	viper.SetDefault("webserver.livestream.debug", false)

--- a/internal/conf/eqfilter_config.go
+++ b/internal/conf/eqfilter_config.go
@@ -5,7 +5,7 @@ var EqFilterConfig = map[string]EqFilterTypeConfig{
 	"LowPass": {
 		Parameters: []EqFilterParameter{
 			{Name: "Frequency", Label: "Cutoff Frequency", Type: "number", Unit: "Hz", Min: 20, Max: 20000, Default: 15000, Tooltip: "Cutoff frequency above which the signal is attenuated"},
-			{Name: "Q", Label: "Q Factor", Type: "number", Min: 0.1, Max: 10, Default: 0.707, Tooltip: "Quality factor that determines the sharpness of the filter's response"},
+			{Name: "Q", Label: "Q Factor", Type: "number", Min: 0.1, Max: 10, Default: DefaultEQQFactor, Tooltip: "Quality factor that determines the sharpness of the filter's response"},
 			{Name: "Passes", Label: "Attenuation", Type: "number", Min: 1, Max: 4, Default: 1, Tooltip: "Number of passes to apply the filter — 1=12dB, 2=24dB, 3=36dB, 4=48dB"},
 		},
 		Tooltip: "Low-pass filter attenuates frequencies above the cutoff frequency.",
@@ -13,7 +13,7 @@ var EqFilterConfig = map[string]EqFilterTypeConfig{
 	"HighPass": {
 		Parameters: []EqFilterParameter{
 			{Name: "Frequency", Label: "Cutoff Frequency", Type: "number", Unit: "Hz", Min: 20, Max: 20000, Default: 100, Tooltip: "Cutoff frequency below which the signal is attenuated"},
-			{Name: "Q", Label: "Q Factor", Type: "number", Min: 0.1, Max: 10, Default: 0.707, Tooltip: "Quality factor that determines the sharpness of the filter's response"},
+			{Name: "Q", Label: "Q Factor", Type: "number", Min: 0.1, Max: 10, Default: DefaultEQQFactor, Tooltip: "Quality factor that determines the sharpness of the filter's response"},
 			{Name: "Passes", Label: "Attenuation", Type: "number", Min: 1, Max: 4, Default: 1, Tooltip: "Number of passes to apply the filter — 1=12dB, 2=24dB, 3=36dB, 4=48dB"},
 		},
 		Tooltip: "High-pass filter attenuates frequencies below the cutoff frequency.",
@@ -37,7 +37,7 @@ var EqFilterConfig = map[string]EqFilterTypeConfig{
 		"LowShelf": {
 			Parameters: []EqFilterParameter{
 				{Name: "Frequency", Label: "Transition Frequency", Type: "number", Unit: "Hz", Min: 20, Max: 20000, Default: 0, Tooltip: "Transition frequency of the shelf filter"},
-				{Name: "Q", Label: "Q Factor", Type: "number", Min: 0.1, Max: 10, Default: 0.707, Tooltip: "Quality factor that determines the transition slope"},
+				{Name: "Q", Label: "Q Factor", Type: "number", Min: 0.1, Max: 10, Default: DefaultEQQFactor, Tooltip: "Quality factor that determines the transition slope"},
 				{Name: "Gain", Label: "Gain", Type: "number", Unit: "dB", Min: -30, Max: 30, Default: 0, Tooltip: "Amount of boost or cut applied to frequencies below the transition frequency"},
 			},
 			Tooltip: "Low-shelf filter boosts or cuts frequencies below the transition frequency.",
@@ -45,7 +45,7 @@ var EqFilterConfig = map[string]EqFilterTypeConfig{
 		"HighShelf": {
 			Parameters: []EqFilterParameter{
 				{Name: "Frequency", Label: "Transition Frequency", Type: "number", Unit: "Hz", Min: 20, Max: 20000, Default: 0, Tooltip: "Transition frequency of the shelf filter"},
-				{Name: "Q", Label: "Q Factor", Type: "number", Min: 0.1, Max: 10, Default: 0.707, Tooltip: "Quality factor that determines the transition slope"},
+				{Name: "Q", Label: "Q Factor", Type: "number", Min: 0.1, Max: 10, Default: DefaultEQQFactor, Tooltip: "Quality factor that determines the transition slope"},
 				{Name: "Gain", Label: "Gain", Type: "number", Unit: "dB", Min: -30, Max: 30, Default: 0, Tooltip: "Amount of boost or cut applied to frequencies above the transition frequency"},
 			},
 			Tooltip: "High-shelf filter boosts or cuts frequencies above the transition frequency.",

--- a/internal/conf/migrations.go
+++ b/internal/conf/migrations.go
@@ -412,8 +412,7 @@ func (s *Settings) applyModelValidation() error {
 		if strings.HasPrefix(issue, "error:") {
 			fatalErrors = append(fatalErrors, strings.TrimPrefix(issue, "error: "))
 		} else {
-			GetLogger().Warn("model configuration issue", logger.String("issue", issue))
-			s.ValidationWarnings = append(s.ValidationWarnings, issue)
+			s.recordValidationWarning(warnComponentModels, "%s", strings.TrimPrefix(issue, "warning: "))
 		}
 	}
 	if len(fatalErrors) > 0 {
@@ -515,9 +514,9 @@ func (s *Settings) ReconcileMisplacedAudioSources() bool {
 		}
 
 		if src.SampleRate > 0 {
-			s.ValidationWarnings = append(s.ValidationWarnings,
-				fmt.Sprintf("audio source %q sample rate %d Hz was not carried to stream %q: stream sample rate is auto-detected",
-					src.Name, src.SampleRate, privacy.SanitizeStreamUrl(device)))
+			s.recordValidationWarning(warnComponentStreams,
+				"audio source %q sample rate %d Hz was not carried to stream %q; a stream's sample rate is auto-detected",
+				src.Name, src.SampleRate, privacy.SanitizeStreamUrl(device))
 		}
 
 		changed = true
@@ -575,9 +574,9 @@ func (s *Settings) appendStreamFromSource(src *AudioSourceConfig, url, streamTyp
 		Models:     src.Models,
 	})
 
-	s.ValidationWarnings = append(s.ValidationWarnings,
-		fmt.Sprintf("moved misplaced stream URL %q from realtime.audio.sources to realtime.rtsp.streams as %q",
-			privacy.SanitizeStreamUrl(url), name))
+	s.recordValidationWarning(warnComponentStreams,
+		"moved misplaced stream URL %q from realtime.audio.sources to realtime.rtsp.streams as %q",
+		privacy.SanitizeStreamUrl(url), name)
 }
 
 // uniqueStreamName derives a stream name from the requested source name that
@@ -689,7 +688,7 @@ func (s *Settings) mergeSourceIntoStream(src *AudioSourceConfig, stream *StreamC
 		kept = append(kept, "quietHours")
 	}
 
-	s.ValidationWarnings = append(s.ValidationWarnings,
+	s.recordValidationWarning(warnComponentStreams, "%s",
 		formatReconcileMergeWarning(privacy.SanitizeStreamUrl(url), stream.Name, applied, kept))
 }
 

--- a/internal/conf/pure_validation_test.go
+++ b/internal/conf/pure_validation_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestValidateBirdNETSettings_Valid verifies valid BirdNET configurations pass.
@@ -263,38 +264,6 @@ func TestValidateBirdweatherSettings_Invalid(t *testing.T) {
 		expectError string
 	}{
 		{
-			name: "enabled without ID",
-			settings: BirdweatherSettings{
-				Enabled: true,
-				ID:      "",
-			},
-			expectError: "Birdweather ID is required",
-		},
-		{
-			name: "invalid ID too short",
-			settings: BirdweatherSettings{
-				Enabled: true,
-				ID:      "short",
-			},
-			expectError: "Invalid Birdweather ID format",
-		},
-		{
-			name: "invalid ID too long",
-			settings: BirdweatherSettings{
-				Enabled: true,
-				ID:      "abcdef123456789012345678extra",
-			},
-			expectError: "Invalid Birdweather ID format",
-		},
-		{
-			name: "invalid ID with special characters",
-			settings: BirdweatherSettings{
-				Enabled: true,
-				ID:      "abcdef12345678901234567!",
-			},
-			expectError: "Invalid Birdweather ID format",
-		},
-		{
 			name: "threshold too low",
 			settings: BirdweatherSettings{
 				Enabled:   true,
@@ -338,6 +307,46 @@ func TestValidateBirdweatherSettings_Invalid(t *testing.T) {
 				}
 			}
 			assert.True(t, found, "expected error containing %q, got errors: %v", tt.expectError, result.Errors)
+		})
+	}
+}
+
+// TestValidateBirdweatherSettings_UnusableIDIsFatal verifies that an unusable
+// station ID is reported as an error and only as an error. It used to be reported
+// as an error AND as a "will be disabled" warning that cleared Enabled on the
+// normalized copy, so one condition carried two contradictory severities. The
+// graceful half now lives in normalizeIncompleteFeatures, which runs before this
+// validator on the load path; keeping the error here is what stops the settings API
+// from accepting a bad ID and silently saving BirdWeather switched off.
+func TestValidateBirdweatherSettings_UnusableIDIsFatal(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		id          string
+		expectError string
+	}{
+		{name: "enabled without ID", id: "", expectError: "Birdweather ID is required"},
+		{name: "ID too short", id: "short", expectError: "Invalid Birdweather ID format"},
+		{name: "ID too long", id: "abcdef123456789012345678extra", expectError: "Invalid Birdweather ID format"},
+		{name: "ID with special characters", id: "abcdef12345678901234567!", expectError: "Invalid Birdweather ID format"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			settings := BirdweatherSettings{Enabled: true, ID: tt.id}
+
+			result := ValidateBirdweatherSettings(&settings)
+
+			assert.False(t, result.Valid)
+			assert.Contains(t, strings.Join(result.Errors, " "), tt.expectError)
+			assert.Empty(t, result.Warnings,
+				"the condition must carry one severity, not an error and a warning at once")
+
+			normalized, ok := result.Normalized.(*BirdweatherSettings)
+			require.True(t, ok, "expected normalized BirdweatherSettings")
+			assert.True(t, normalized.Enabled,
+				"a rejected save must not report the integration as switched off")
 		})
 	}
 }

--- a/internal/conf/storage.go
+++ b/internal/conf/storage.go
@@ -153,10 +153,21 @@ func Load() (*Settings, error) {
 		return nil, err
 	}
 
+	// Resolve features that are switched on but were never configured, before the
+	// validators get to see them. A config file can age into that state across
+	// upgrades, and rejecting the file leaves no UI in which to correct it, so
+	// those features are disabled or defaulted with a warning instead. This is
+	// deliberately scoped to loading a file: the settings API validates without
+	// normalizing, so a half-finished section submitted from the UI is still
+	// answered with an error the user can act on rather than silently discarded.
+	// See validate_incomplete.go for the policy and the per-rule reasoning.
+	normalizeIncompleteFeatures(settings)
+
 	// Validate settings. Any error ValidateSettings returns is a fatal
 	// misconfiguration that must block startup; non-fatal findings live on the
 	// separate settings.ValidationWarnings channel (recorded during config
-	// migration), never demoted from a fatal error by matching its message text.
+	// migration and normalization), never demoted from a fatal error by matching
+	// its message text.
 	if err := finalizeValidation(ValidateSettings(settings)); err != nil {
 		return nil, err
 	}
@@ -184,9 +195,10 @@ func Load() (*Settings, error) {
 //
 // Severity is structural: every error a validator returns (collected into
 // ValidationError.Errors) is fatal and blocks startup. Non-fatal configuration
-// findings use a separate channel, Settings.ValidationWarnings, recorded during
-// config migration (see applyModelValidation), not by the ValidateSettings
-// validators. Severity is never inferred from the error message text;
+// findings use a separate channel, Settings.ValidationWarnings, written during
+// config migration, during normalizeIncompleteFeatures, and by the few validators
+// that normalize a value rather than rejecting it. Severity is never inferred from
+// the error message text;
 // an earlier heuristic that demoted errors whose message contained substrings
 // like "fallback" or "not supported" to warnings could silently start the app
 // with invalid config, so it was removed.

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -79,8 +79,11 @@ var ValidAudioModels = map[string]bool{
 // ValidateSettings. Every entry in Errors blocks startup: severity is decided
 // structurally by whether a validator returned an error, never by inspecting
 // the message text. Non-fatal configuration findings use a separate channel,
-// Settings.ValidationWarnings, recorded during config migration (see
-// applyModelValidation), not derived from the text of a fatal error.
+// Settings.ValidationWarnings, written through recordValidationWarning during
+// config migration, during the incomplete-feature normalization Load runs before
+// validating (see validate_incomplete.go), and by the few validators that
+// normalize a value instead of rejecting it. None of them is derived from the text
+// of a fatal error.
 type ValidationError struct {
 	Errors []string
 }
@@ -196,8 +199,8 @@ func ValidateSettings(settings *Settings) error {
 	case "", LowMemoryModeAuto, LowMemoryModeOn, LowMemoryModeOff:
 		settings.LowMemory.Mode = normalized
 	default:
-		settings.ValidationWarnings = append(settings.ValidationWarnings,
-			fmt.Sprintf("invalid lowmemory.mode %q; using %q", settings.LowMemory.Mode, LowMemoryModeAuto))
+		settings.recordValidationWarning(warnComponentLowMemory,
+			"invalid lowmemory.mode %q; using %q", settings.LowMemory.Mode, LowMemoryModeAuto)
 		settings.LowMemory.Mode = LowMemoryModeAuto
 	}
 

--- a/internal/conf/validate_audio.go
+++ b/internal/conf/validate_audio.go
@@ -11,7 +11,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -65,6 +64,12 @@ const (
 const (
 	MaxQuietHoursOffset = 180  // Maximum offset in minutes from sun event
 	MinQuietHoursOffset = -180 // Minimum offset in minutes from sun event
+
+	// quietHoursTimeLayout is the clock format accepted for fixed-mode start and
+	// end times. The scheduler that consumes these values must parse them with the
+	// same layout; internal/audiocore/schedule.parseHHMM does, and widening one
+	// side without the other would accept times the runtime then rejects.
+	quietHoursTimeLayout = "15:04"
 )
 
 // Quiet hours mode constants
@@ -163,8 +168,10 @@ func (s *StreamConfig) Validate() error {
 		return err
 	}
 
-	// Validate per-stream EQ if set
-	if s.Equalizer != nil {
+	// Validate per-stream EQ when it is switched on. Filters belonging to a
+	// disabled equalizer never reach the audio path (BuildFilterChain returns nil
+	// for it), so an unfinished one is not a reason to reject the whole config.
+	if s.Equalizer != nil && s.Equalizer.Enabled {
 		if err := validateEQFilters(s.Equalizer.Filters, fmt.Sprintf("stream '%s'", s.Name)); err != nil {
 			return err
 		}
@@ -191,12 +198,12 @@ func ValidateQuietHours(qh *QuietHoursConfig, context string) error {
 
 	switch qh.Mode {
 	case QuietHoursModeFixed:
-		// Validate start time format
-		if _, err := time.Parse("15:04", qh.StartTime); err != nil {
+		// Both sides use isValidClockTime so this rule and the normalization pass
+		// that disables an unusable block cannot disagree about what parses.
+		if !isValidClockTime(qh.StartTime) {
 			return fmt.Errorf("%s: quiet hours start time must be in HH:MM format, got '%s'", context, qh.StartTime)
 		}
-		// Validate end time format
-		if _, err := time.Parse("15:04", qh.EndTime); err != nil {
+		if !isValidClockTime(qh.EndTime) {
 			return fmt.Errorf("%s: quiet hours end time must be in HH:MM format, got '%s'", context, qh.EndTime)
 		}
 
@@ -347,8 +354,9 @@ func (a *AudioSourceConfig) Validate() error {
 		return fmt.Errorf("audio source '%s': unknown model '%s'", a.Name, a.Model)
 	}
 
-	// Validate per-source EQ if set
-	if a.Equalizer != nil {
+	// Validate per-source EQ when it is switched on, matching the global
+	// equalizer: a disabled filter set is never built into the audio path.
+	if a.Equalizer != nil && a.Equalizer.Enabled {
 		if err := validateEQFilters(a.Equalizer.Filters, fmt.Sprintf("audio source '%s'", a.Name)); err != nil {
 			return err
 		}

--- a/internal/conf/validate_incomplete.go
+++ b/internal/conf/validate_incomplete.go
@@ -47,7 +47,6 @@ package conf
 
 import (
 	"fmt"
-	"net/url"
 	"slices"
 	"strings"
 	"time"
@@ -109,8 +108,11 @@ func normalizeIncompleteFeatures(s *Settings) {
 	s.normalizeWebServer()
 }
 
-// normalizeOAuthProviders disables OAuth providers that cannot authenticate anyone
-// and warns about the ones that can but have no redirect URL to come back to.
+// normalizeOAuthProviders disables OAuth providers that cannot authenticate anyone.
+//
+// A provider that keeps its credentials but has no redirect URL to come back to is
+// not handled here: validateOAuthRedirects rejects it outright, because it forces
+// authentication on while making sign-in impossible.
 //
 // Disabling is limited to providers the runtime already refuses to use:
 // GetEnabledOAuthProviders and initializeProviders both require a non-empty
@@ -121,7 +123,6 @@ func normalizeIncompleteFeatures(s *Settings) {
 // it off would drop authentication from a server the operator meant to protect.
 func (s *Settings) normalizeOAuthProviders() {
 	sec := &s.Security
-	hasRedirectSource := sec.Host != "" || sec.BaseURL != ""
 
 	for i := range sec.OAuthProviders {
 		p := &sec.OAuthProviders[i]
@@ -137,12 +138,11 @@ func (s *Settings) normalizeOAuthProviders() {
 			continue
 		}
 
-		// Credentials are present, so the provider stays enabled and
-		// authentication stays required. Warn about what will not work.
-		if reason := oauthRedirectProblem(p, hasRedirectSource); reason != "" {
-			s.recordValidationWarning(warnComponentSecurity,
-				"OAuth provider %q is enabled but %s, so sign-in will fail", p.Provider, reason)
-		}
+		// Credentials are present, so the provider stays enabled and authentication
+		// stays required. A provider in that state with no usable redirect URL is
+		// left to validateOAuthRedirects, which is fatal: warning here instead would
+		// boot an instance that requires a sign-in nobody can complete, and put the
+		// warning behind the login that cannot complete.
 	}
 
 	// The deprecated googleAuth/githubAuth/microsoftAuth blocks are migrated into
@@ -174,31 +174,6 @@ func (s *Settings) normalizeOAuthProviders() {
 				l.key)
 		}
 	}
-}
-
-// oauthRedirectProblem describes why a provider has no usable redirect URL, or
-// returns "" when it has one. It mirrors what initializeProviders actually
-// computes: an explicit redirectUri is used verbatim, and only an absent one is
-// built from security.host or security.baseUrl.
-//
-// Testing merely for an empty redirectUri would miss the common case. The
-// deprecated googleAuth and githubAuth blocks default redirecturi to "/settings"
-// (see defaults.go), and MigrateOAuthConfig copies that into the array as-is, so a
-// migrated provider usually carries a non-empty but relative value that no OAuth
-// provider can redirect back to. That shape used to be caught by the fatal
-// host-required rule; without this check it would degrade to silence.
-func oauthRedirectProblem(p *OAuthProviderConfig, hasOrigin bool) string {
-	if p.RedirectURI == "" {
-		if hasOrigin {
-			return ""
-		}
-		return "no redirect URL can be built; set security.host or security.baseUrl, or security.oauthProviders[].redirectUri"
-	}
-	parsed, err := url.Parse(p.RedirectURI)
-	if err != nil || parsed.Host == "" || (parsed.Scheme != SchemeHTTPS && parsed.Scheme != SchemeHTTP) {
-		return "its redirectUri is not an absolute http(s) URL, so the provider has nowhere to send the user back to"
-	}
-	return ""
 }
 
 // normalizeQuietHours disables quiet hours blocks that cannot produce a window.
@@ -487,12 +462,14 @@ func (s *Settings) normalizeNotificationProviders() {
 func (s *Settings) normalizeWebhookProvider(p *PushProviderConfig, disable func(string, ...any)) {
 	for i := range p.Endpoints {
 		endpoint := &p.Endpoints[i]
+		// 1-based to match the stream and filter warnings, and to match how an
+		// operator counts the entries in their YAML list.
 		if strings.TrimSpace(endpoint.URL) == "" {
-			disable("endpoint %d has no URL; disabling the provider", i)
+			disable("endpoint %d has no URL; disabling the provider", i+1)
 			return
 		}
 		if reason := missingWebhookAuthSecret(&endpoint.Auth); reason != "" {
-			disable("endpoint %d cannot authenticate: %s; disabling the provider", i, reason)
+			disable("endpoint %d cannot authenticate: %s; disabling the provider", i+1, reason)
 			return
 		}
 	}

--- a/internal/conf/validate_incomplete.go
+++ b/internal/conf/validate_incomplete.go
@@ -1,0 +1,669 @@
+// conf/validate_incomplete.go
+//
+// Reclassification of "switched on but never finished" settings.
+//
+// Every error a validator returns is fatal and blocks startup (see
+// finalizeValidation in storage.go). That is correct for a value that would make
+// the application behave wrongly, and wrong for a feature the user toggled on and
+// never configured: such a feature cannot do anything, and refusing to boot over
+// it removes the web UI that is the only practical way to undo the toggle. On a
+// headless install the service then crash-loops until someone edits YAML by hand.
+//
+// normalizeIncompleteFeatures runs once per Load, before the validators, and
+// resolves those configurations the way the running system already treats them:
+//
+//   - a required string left empty means the feature was never configured, so the
+//     documented default is bound when the setting has one and the feature is
+//     disabled when it does not;
+//   - a required number left at zero means the field was never written, so the
+//     documented default is applied;
+//   - a value the running system already ignores, meaning an unrecognised entry in
+//     a fixed set (a quiet hours mode, a solar event, a push provider type), is
+//     resolved the way the runtime resolves it, which is to switch the feature off;
+//   - anything else explicitly wrong (negative, out of range, an unparsable number,
+//     NaN or Inf) is left alone and the existing validator still rejects it.
+//
+// The third rule is the one that needs justifying, since an unrecognised enum was
+// typed on purpose. It is included because the runtime does not fail on those
+// values either: it falls through to a default branch and the feature does nothing.
+// Refusing to boot would therefore not protect anything, it would only hide the
+// dead feature behind a boot loop. The fourth rule is where that reasoning stops:
+// an out-of-range number does change what the code computes.
+//
+// Because most fatal rules are already written as "if feature.Enabled", disabling
+// the feature here makes them unreachable without weakening them.
+//
+// It is called from Load and not from ValidateSettings on purpose. Leniency is
+// wanted when reading a config file that aged into this state, where the only
+// alternative is a boot loop, and is not wanted when the settings API validates an
+// update: there the strict rules still apply, so a half-finished section from the
+// UI is answered with an error the user can act on instead of being silently
+// turned off and saved.
+//
+// Security rule that overrides the above: nothing here may reduce the set of
+// authentications the server requires. An OAuth provider is disabled only when the
+// runtime already ignores it (see normalizeOAuthProviders).
+package conf
+
+import (
+	"fmt"
+	"net/url"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// Component names used for the warnings recorded below. They become the prefix of
+// each ValidationWarnings entry and are parsed back out in main.go.
+const (
+	warnComponentSecurity     = "security"
+	warnComponentAudio        = "audio"
+	warnComponentBirdweather  = "birdweather"
+	warnComponentMQTT         = "mqtt"
+	warnComponentTelemetry    = "telemetry"
+	warnComponentWebServer    = "webserver"
+	warnComponentNotification = "notification"
+	warnComponentRealtime     = "realtime"
+	warnComponentLowMemory    = "lowmemory"
+	warnComponentModels       = "models"
+	warnComponentStreams      = "streams"
+)
+
+// recordValidationWarning logs a non-fatal configuration finding and records it on
+// the settings so it can be surfaced outside the log. The "component: message"
+// shape is the one main.go splits when forwarding warnings to telemetry and to the
+// notification centre.
+//
+// Duplicates are dropped for two reasons. Within one pass, two entities producing
+// the same sentence (two audio sources sharing a name, a repeated filter message)
+// should report once. Across calls it is load-bearing: ValidateSettings also records
+// here for an invalid lowmemory.mode, and the settings API runs it on every save
+// against a clone that carries the previously recorded warnings forward.
+func (s *Settings) recordValidationWarning(component, format string, args ...any) {
+	message := fmt.Sprintf(format, args...)
+	entry := component + ": " + message
+	if slices.Contains(s.ValidationWarnings, entry) {
+		return
+	}
+	GetLogger().Warn("Configuration validation warning",
+		logger.String("component", component),
+		logger.String("message", message))
+	s.ValidationWarnings = append(s.ValidationWarnings, entry)
+}
+
+// normalizeIncompleteFeatures disables or defaults settings that are enabled but
+// not configured enough to have any effect, recording a warning for each. See the
+// file comment for the policy and its one security exception.
+func normalizeIncompleteFeatures(s *Settings) {
+	s.normalizeOAuthProviders()
+	s.normalizeQuietHours()
+	s.normalizeEqualizers()
+	s.normalizeAudioExport()
+	s.normalizeRetention()
+	s.normalizeIntegrations()
+	s.normalizeNotificationProviders()
+	s.normalizeRealtimeFeatures()
+	s.normalizeSpeciesTracking()
+	s.normalizeWebServer()
+}
+
+// normalizeOAuthProviders disables OAuth providers that cannot authenticate anyone
+// and warns about the ones that can but have no redirect URL to come back to.
+//
+// Disabling is limited to providers the runtime already refuses to use:
+// GetEnabledOAuthProviders and initializeProviders both require a non-empty
+// clientId and clientSecret, so clearing Enabled on such an entry changes nothing
+// about which requests are authenticated - it only makes the stored state honest.
+// A provider that does have credentials is never disabled here, however broken the
+// rest of its configuration: it counts towards IsAuthenticationEnabled, so turning
+// it off would drop authentication from a server the operator meant to protect.
+func (s *Settings) normalizeOAuthProviders() {
+	sec := &s.Security
+	hasRedirectSource := sec.Host != "" || sec.BaseURL != ""
+
+	for i := range sec.OAuthProviders {
+		p := &sec.OAuthProviders[i]
+		if !p.Enabled {
+			continue
+		}
+
+		if p.ClientID == "" || p.ClientSecret == "" {
+			p.Enabled = false
+			s.recordValidationWarning(warnComponentSecurity,
+				"OAuth provider %q is enabled but has no clientId/clientSecret, so it cannot sign anyone in; disabling it (set security.oauthProviders[].clientId and clientSecret to use it)",
+				p.Provider)
+			continue
+		}
+
+		// Credentials are present, so the provider stays enabled and
+		// authentication stays required. Warn about what will not work.
+		if reason := oauthRedirectProblem(p, hasRedirectSource); reason != "" {
+			s.recordValidationWarning(warnComponentSecurity,
+				"OAuth provider %q is enabled but %s, so sign-in will fail", p.Provider, reason)
+		}
+	}
+
+	// The deprecated googleAuth/githubAuth/microsoftAuth blocks are migrated into
+	// OAuthProviders on load, and MigrateOAuthConfig skips the whole migration when
+	// that array already has entries, while migrateLegacyProvider skips an
+	// individual block with no clientId. A block that did not become an array entry
+	// is therefore inert: no code outside migration uses these fields to
+	// authenticate anyone, and the remaining readers only redact their secrets. Say
+	// so rather than rejecting the file.
+	legacy := []struct {
+		key      string
+		name     string
+		provider SocialProvider
+	}{
+		{"security.googleauth", providerGoogle, sec.GoogleAuth},
+		{"security.githubauth", providerGitHub, sec.GithubAuth},
+		{"security.microsoftauth", providerMicrosoft, sec.MicrosoftAuth},
+	}
+	for _, l := range legacy {
+		if !l.provider.Enabled {
+			continue
+		}
+		migrated := slices.ContainsFunc(sec.OAuthProviders, func(p OAuthProviderConfig) bool {
+			return p.Provider == l.name
+		})
+		if !migrated {
+			s.recordValidationWarning(warnComponentSecurity,
+				"%s is enabled but was not migrated into security.oauthProviders, so it signs nobody in; configure the provider under security.oauthProviders instead",
+				l.key)
+		}
+	}
+}
+
+// oauthRedirectProblem describes why a provider has no usable redirect URL, or
+// returns "" when it has one. It mirrors what initializeProviders actually
+// computes: an explicit redirectUri is used verbatim, and only an absent one is
+// built from security.host or security.baseUrl.
+//
+// Testing merely for an empty redirectUri would miss the common case. The
+// deprecated googleAuth and githubAuth blocks default redirecturi to "/settings"
+// (see defaults.go), and MigrateOAuthConfig copies that into the array as-is, so a
+// migrated provider usually carries a non-empty but relative value that no OAuth
+// provider can redirect back to. That shape used to be caught by the fatal
+// host-required rule; without this check it would degrade to silence.
+func oauthRedirectProblem(p *OAuthProviderConfig, hasOrigin bool) string {
+	if p.RedirectURI == "" {
+		if hasOrigin {
+			return ""
+		}
+		return "no redirect URL can be built; set security.host or security.baseUrl, or security.oauthProviders[].redirectUri"
+	}
+	parsed, err := url.Parse(p.RedirectURI)
+	if err != nil || parsed.Host == "" || (parsed.Scheme != SchemeHTTPS && parsed.Scheme != SchemeHTTP) {
+		return "its redirectUri is not an absolute http(s) URL, so the provider has nowhere to send the user back to"
+	}
+	return ""
+}
+
+// normalizeQuietHours disables quiet hours blocks that cannot produce a window.
+//
+// The scheduler already treats them as "not quiet": isInQuietHours returns false
+// for an unknown mode and for an unparsable HH:MM. Solar mode with an unrecognised
+// event is the exception that makes disabling better than tolerating - there
+// getSolarEventTime returns the zero time, which would silence audio around
+// midnight rather than around the intended sun event.
+//
+// Offsets outside the supported range are deliberately left to the fatal
+// validator: zero is a valid offset, so an out-of-range value was typed on purpose
+// and it does shift a real window.
+func (s *Settings) normalizeQuietHours() {
+	audio := &s.Realtime.Audio
+
+	s.normalizeQuietHoursBlock(&audio.QuietHours, "realtime.audio.quietHours")
+	for i := range audio.Sources {
+		s.normalizeQuietHoursBlock(&audio.Sources[i].QuietHours,
+			fmt.Sprintf("audio source %q quiet hours", audio.Sources[i].Name))
+	}
+	for i, stream := range s.Realtime.RTSP.AllStreams() {
+		s.normalizeQuietHoursBlock(&stream.QuietHours,
+			fmt.Sprintf("stream %d (%q) quiet hours", i+1, stream.Name))
+	}
+}
+
+// normalizeQuietHoursBlock disables one quiet hours configuration when it is
+// enabled but incomplete, describing it with the given config path.
+func (s *Settings) normalizeQuietHoursBlock(qh *QuietHoursConfig, context string) {
+	if !qh.Enabled {
+		return
+	}
+
+	disable := func(format string, args ...any) {
+		qh.Enabled = false
+		s.recordValidationWarning(warnComponentAudio, "%s %s", context, fmt.Sprintf(format, args...))
+	}
+
+	switch {
+	case qh.Mode == "":
+		disable("is enabled but no mode is set; disabling it (set mode to %q or %q to use it)",
+			QuietHoursModeFixed, QuietHoursModeSolar)
+	case !ValidQuietHoursModes[qh.Mode]:
+		disable("is enabled with unrecognised mode %q; disabling it (valid modes are %q and %q)",
+			qh.Mode, QuietHoursModeFixed, QuietHoursModeSolar)
+	case qh.Mode == QuietHoursModeFixed && !isValidClockTime(qh.StartTime):
+		disable("is enabled but its start time %q is not HH:MM; disabling it", qh.StartTime)
+	case qh.Mode == QuietHoursModeFixed && !isValidClockTime(qh.EndTime):
+		disable("is enabled but its end time %q is not HH:MM; disabling it", qh.EndTime)
+	case qh.Mode == QuietHoursModeSolar && !ValidSolarEvents[qh.StartEvent]:
+		disable("is enabled but its start event %q is not %q or %q; disabling it",
+			qh.StartEvent, SolarEventSunrise, SolarEventSunset)
+	case qh.Mode == QuietHoursModeSolar && !ValidSolarEvents[qh.EndEvent]:
+		disable("is enabled but its end event %q is not %q or %q; disabling it",
+			qh.EndEvent, SolarEventSunrise, SolarEventSunset)
+	}
+}
+
+// isValidClockTime reports whether a string parses as an HH:MM clock time.
+func isValidClockTime(value string) bool {
+	_, err := time.Parse(quietHoursTimeLayout, value)
+	return err == nil
+}
+
+// eqFilterUsesQ reports whether a filter type derives its coefficients from Q.
+// The width-based types (BandPass, BandReject, Peaking) take a bandwidth in Hz
+// instead and never read Q, so a zero there is the normal state rather than an
+// unfinished one. See buildFilter in internal/audiocore/equalizer.
+func eqFilterUsesQ(filterType string) bool {
+	switch filterType {
+	case "LowPass", "HighPass", "AllPass", "LowShelf", "HighShelf":
+		return true
+	default:
+		return false
+	}
+}
+
+// normalizeEqualizers replaces a filter Q of exactly zero with the standard
+// default. Zero is the never-written value rather than a choice, and for the
+// Q-based filters it is also dangerous: their constructors compute sin(w0)/(2*q)
+// with no guard, so a zero would make every coefficient non-finite and poison the
+// audio.
+//
+// Two deliberate asymmetries with the validators:
+//
+// Filter sets are normalized whether or not the equalizer is enabled, even though
+// StreamConfig.Validate and AudioSourceConfig.Validate now skip a disabled one.
+// validateEQFilters demands a positive Q from every filter type, so leaving a
+// stored zero in place would mean the user's later "enable" is rejected over a
+// field the settings UI never offered them. Nothing is warned about for a disabled
+// set, though: a notification about a switched-off feature is noise.
+//
+// Every other invalid Q, and every invalid frequency, stays fatal. A frequency of
+// zero is the sharpest case: it makes w0 zero, which zeroes the whole numerator, so
+// a LowPass at frequency 0 outputs silence rather than doing nothing.
+func (s *Settings) normalizeEqualizers() {
+	audio := &s.Realtime.Audio
+
+	s.normalizeEQFilters(&audio.Equalizer, "realtime.audio.equalizer")
+	for i := range audio.Sources {
+		src := &audio.Sources[i]
+		if src.Equalizer != nil {
+			s.normalizeEQFilters(src.Equalizer, fmt.Sprintf("audio source %q equalizer", src.Name))
+		}
+	}
+	for i, stream := range s.Realtime.RTSP.AllStreams() {
+		if stream.Equalizer != nil {
+			s.normalizeEQFilters(stream.Equalizer, fmt.Sprintf("stream %d (%q) equalizer", i+1, stream.Name))
+		}
+	}
+}
+
+// normalizeEQFilters applies the default Q factor to filters whose q is zero,
+// reporting only the ones where Q is a setting the user could have filled in.
+func (s *Settings) normalizeEQFilters(eq *EqualizerSettings, configPath string) {
+	for i := range eq.Filters {
+		f := &eq.Filters[i]
+		if f.Q != 0 {
+			continue
+		}
+		f.Q = DefaultEQQFactor
+		if eq.Enabled && eqFilterUsesQ(f.Type) {
+			s.recordValidationWarning(warnComponentAudio,
+				"%s filter %d (%s) has no Q factor set; using the default %.3f",
+				configPath, i+1, f.Type, DefaultEQQFactor)
+		}
+	}
+}
+
+// normalizeIntegrations disables integrations whose mandatory endpoint or
+// credential was never filled in, and defaults the telemetry listen address.
+func (s *Settings) normalizeIntegrations() {
+	// BirdWeather uploads nothing without a usable station ID.
+	// ValidateBirdweatherSettings rejects the same two shapes, which is what the
+	// settings API should keep doing; clearing Enabled here means the load path
+	// reaches that validator with the integration already switched off.
+	bw := &s.Realtime.Birdweather
+	if bw.Enabled {
+		switch {
+		case bw.ID == "":
+			bw.Enabled = false
+			s.recordValidationWarning(warnComponentBirdweather,
+				"BirdWeather is enabled but no station ID is set; disabling uploads (set realtime.birdweather.id to use it)")
+		case !birdweatherIDPattern.MatchString(bw.ID):
+			bw.Enabled = false
+			s.recordValidationWarning(warnComponentBirdweather,
+				"BirdWeather is enabled but the station ID is not 24 alphanumeric characters; disabling uploads")
+		}
+	}
+
+	// An MQTT client with no broker or no topic publishes nothing.
+	mqtt := &s.Realtime.MQTT
+	if mqtt.Enabled {
+		switch {
+		case strings.TrimSpace(mqtt.Broker) == "":
+			mqtt.Enabled = false
+			s.recordValidationWarning(warnComponentMQTT,
+				"MQTT is enabled but no broker URL is set; disabling it (set realtime.mqtt.broker to use it)")
+		case strings.TrimSpace(mqtt.Topic) == "":
+			mqtt.Enabled = false
+			s.recordValidationWarning(warnComponentMQTT,
+				"MQTT is enabled but no topic is set; disabling it (set realtime.mqtt.topic to use it)")
+		case mqtt.RetrySettings.Enabled && mqtt.RetrySettings.BackoffMultiplier == 0:
+			mqtt.RetrySettings.BackoffMultiplier = DefaultRetryBackoffMultiplier
+			s.recordValidationWarning(warnComponentMQTT,
+				"MQTT retries are enabled but no backoff multiplier is set; using the default %.1f",
+				DefaultRetryBackoffMultiplier)
+		}
+	}
+
+	// An empty listen address is the never-written value and the endpoint has a
+	// documented default, so bind it rather than refusing to start. Bound whether
+	// or not telemetry is on, for the same reason the equalizer Q is: viper drops
+	// this nested default when the parent key is present, and leaving the blank in
+	// place would make a later enable from the settings UI fail on a field the
+	// operator never saw. Only an enabled endpoint is worth reporting, though.
+	telemetry := &s.Realtime.Telemetry
+	if telemetry.Listen == "" {
+		telemetry.Listen = DefaultTelemetryListen
+		if telemetry.Enabled {
+			s.recordValidationWarning(warnComponentTelemetry,
+				"telemetry is enabled but no listen address is set; using the default %s", DefaultTelemetryListen)
+		}
+	}
+}
+
+// normalizeAudioExport fills in the export fields that a half-written export:
+// block leaves at zero. realtime.audio.export is the section users hand-edit most,
+// and viper drops a nested default whenever the parent key is present but the child
+// is not, so an unfinished edit here is the likeliest way to meet this whole class
+// of failure.
+func (s *Settings) normalizeAudioExport() {
+	export := &s.Realtime.Audio.Export
+	if !export.Enabled {
+		return
+	}
+
+	if export.Length == 0 {
+		export.Length = DefaultAudioExportLength
+		s.recordValidationWarning(warnComponentAudio,
+			"audio export is enabled but no clip length is set; using the default %d seconds",
+			DefaultAudioExportLength)
+	}
+
+	switch export.Type {
+	case AudioExportTypeAAC, AudioExportTypeOPUS, AudioExportTypeMP3:
+		if export.Bitrate == "" {
+			export.Bitrate = DefaultAudioExportBitrate
+			s.recordValidationWarning(warnComponentAudio,
+				"audio export is enabled with the lossy format %s but no bitrate is set; using the default %s",
+				export.Type, DefaultAudioExportBitrate)
+		}
+	}
+
+	// Only targetLufs needs this: zero is outside its supported range, while zero
+	// is a legal true peak and a legal loudness range.
+	if export.Normalization.Enabled && export.Normalization.TargetLUFS == 0 {
+		export.Normalization.TargetLUFS = DefaultNormalizationTargetLUFS
+		s.recordValidationWarning(warnComponentAudio,
+			"audio normalization is enabled but no target loudness is set; using the default %.1f LUFS",
+			DefaultNormalizationTargetLUFS)
+	}
+}
+
+// normalizeRetention fills in the retention limit belonging to the selected
+// policy. An empty policy already means "no cleanup", so only the two active
+// policies can be left half-configured.
+func (s *Settings) normalizeRetention() {
+	retention := &s.Realtime.Audio.Export.Retention
+	switch retention.Policy {
+	case RetentionPolicyAge:
+		if retention.MaxAge == "" {
+			retention.MaxAge = DefaultRetentionMaxAge
+			s.recordValidationWarning(warnComponentAudio,
+				"age-based retention is selected but no maximum age is set; using the default %s",
+				DefaultRetentionMaxAge)
+		}
+	case RetentionPolicyUsage:
+		if retention.MaxUsage == "" {
+			retention.MaxUsage = DefaultRetentionMaxUsage
+			s.recordValidationWarning(warnComponentAudio,
+				"usage-based retention is selected but no maximum usage is set; using the default %s",
+				DefaultRetentionMaxUsage)
+		}
+	}
+}
+
+// normalizeNotificationProviders disables push providers that are missing the one
+// field their type cannot work without. A provider that cannot deliver anything is
+// exactly the case where refusing to start costs a user their detections for no
+// safety gain.
+func (s *Settings) normalizeNotificationProviders() {
+	push := &s.Notification.Push
+	if !push.Enabled {
+		return
+	}
+
+	for i := range push.Providers {
+		p := &push.Providers[i]
+		if !p.Enabled {
+			continue
+		}
+
+		disable := func(format string, args ...any) {
+			p.Enabled = false
+			s.recordValidationWarning(warnComponentNotification,
+				"push provider %q %s", p.Name, fmt.Sprintf(format, args...))
+		}
+
+		if reason := pushProviderProblem(p); reason != "" {
+			disable("%s; disabling it", reason)
+			continue
+		}
+		if strings.EqualFold(p.Type, pushProviderWebhook) {
+			s.normalizeWebhookProvider(p, disable)
+		}
+	}
+}
+
+// normalizeWebhookProvider disables a webhook provider whose endpoint has no URL to
+// post to, or declares an auth scheme without the credential it needs. Sending the
+// request unauthenticated, or to nowhere, is not an option, so the provider is
+// switched off and reported. The zero-endpoints case is handled by
+// pushProviderProblem alongside the other per-type requirements.
+func (s *Settings) normalizeWebhookProvider(p *PushProviderConfig, disable func(string, ...any)) {
+	for i := range p.Endpoints {
+		endpoint := &p.Endpoints[i]
+		if strings.TrimSpace(endpoint.URL) == "" {
+			disable("endpoint %d has no URL; disabling the provider", i)
+			return
+		}
+		if reason := missingWebhookAuthSecret(&endpoint.Auth); reason != "" {
+			disable("endpoint %d cannot authenticate: %s; disabling the provider", i, reason)
+			return
+		}
+	}
+}
+
+// pushProviderProblem returns a description of the field a push provider's type
+// cannot work without and does not have, or "" when the provider is configured. It
+// is the single definition of "configured enough to deliver", shared by the fatal
+// validator and by the normalization pass that switches an unusable provider off.
+func pushProviderProblem(p *PushProviderConfig) string {
+	switch strings.ToLower(p.Type) {
+	case "":
+		return "has no type set; set type to script, shoutrrr, or webhook"
+	case pushProviderScript:
+		if strings.TrimSpace(p.Command) == "" {
+			return "is a script provider with no command"
+		}
+	case pushProviderShoutrrr:
+		if len(p.URLs) == 0 {
+			return "is a shoutrrr provider with no URLs"
+		}
+	case pushProviderWebhook:
+		if len(p.Endpoints) == 0 {
+			return "is a webhook provider with no endpoints"
+		}
+	default:
+		return fmt.Sprintf("has unknown type %q", p.Type)
+	}
+	return ""
+}
+
+// missingWebhookAuthSecret returns a description of why an endpoint's auth
+// configuration cannot be used, or "" when it can. An unrecognised auth type counts:
+// the sender rejects it outright (see push_webhook.go), so the endpoint is dead in
+// the same way a provider with an unrecognised type is, and the file's policy on
+// values the runtime already ignores applies to both.
+func missingWebhookAuthSecret(auth *WebhookAuthConfig) string {
+	blank := func(values ...string) bool {
+		for _, v := range values {
+			if strings.TrimSpace(v) != "" {
+				return false
+			}
+		}
+		return true
+	}
+
+	switch strings.ToLower(auth.Type) {
+	case webhookAuthBearer:
+		if blank(auth.Token, auth.TokenFile) {
+			return "no token or token_file is set"
+		}
+	case webhookAuthBasic:
+		if blank(auth.User, auth.UserFile) {
+			return "no user or user_file is set"
+		}
+		if blank(auth.Pass, auth.PassFile) {
+			return "no pass or pass_file is set"
+		}
+	case webhookAuthCustom:
+		if blank(auth.Header) {
+			return "no header is set"
+		}
+		if blank(auth.Value, auth.ValueFile) {
+			return "no value or value_file is set"
+		}
+	case "", webhookAuthNone:
+		// No credential to check.
+	default:
+		return "its auth type is not one of bearer, basic, custom or none"
+	}
+	return ""
+}
+
+// normalizeRealtimeFeatures applies the documented default to enabled features
+// whose interval or window was left at zero. Zero never means "immediately" or
+// "no window" for any of these, it means the key was never written, so the
+// alternative to defaulting is refusing to start over a field the user never saw.
+// Non-zero values outside the supported range are left to the fatal validators.
+func (s *Settings) normalizeRealtimeFeatures() {
+	if sl := &s.Realtime.Audio.SoundLevel; sl.Enabled && sl.Interval == 0 {
+		sl.Interval = DefaultSoundLevelInterval
+		s.recordValidationWarning(warnComponentAudio,
+			"sound level monitoring is enabled but no interval is set; using the default %d seconds",
+			DefaultSoundLevelInterval)
+	}
+
+	if dt := &s.Realtime.DynamicThreshold; dt.Enabled && dt.ValidHours == 0 {
+		dt.ValidHours = DefaultDynamicThresholdValidHours
+		s.recordValidationWarning(warnComponentRealtime,
+			"dynamic threshold is enabled but validHours is not set; using the default %d hours",
+			DefaultDynamicThresholdValidHours)
+	}
+
+}
+
+// normalizeSpeciesTracking applies the documented defaults to the species tracking
+// windows and reset dates. Split out from normalizeRealtimeFeatures so its early
+// returns cannot silently skip an unrelated feature added after it.
+func (s *Settings) normalizeSpeciesTracking() {
+	st := &s.Realtime.SpeciesTracking
+	if !st.Enabled {
+		return
+	}
+	if st.NewSpeciesWindowDays == 0 {
+		st.NewSpeciesWindowDays = DefaultNewSpeciesWindowDays
+		s.recordValidationWarning(warnComponentRealtime,
+			"species tracking is enabled but no new-species window is set; using the default %d days",
+			DefaultNewSpeciesWindowDays)
+	}
+	if st.SyncIntervalMinutes == 0 {
+		st.SyncIntervalMinutes = DefaultSpeciesSyncIntervalMinutes
+		s.recordValidationWarning(warnComponentRealtime,
+			"species tracking is enabled but no sync interval is set; using the default %d minutes",
+			DefaultSpeciesSyncIntervalMinutes)
+	}
+
+	// The month and the day are defaulted independently. Filling in both whenever
+	// the month is missing would discard a reset day the user did write, which is
+	// the one thing this whole pass exists not to do.
+	if yt := &st.YearlyTracking; yt.Enabled {
+		if yt.ResetMonth == 0 {
+			yt.ResetMonth = DefaultYearlyTrackingResetMonth
+			s.recordValidationWarning(warnComponentRealtime,
+				"yearly tracking is enabled but no reset month is set; using month %d",
+				DefaultYearlyTrackingResetMonth)
+		}
+		if yt.ResetDay == 0 {
+			yt.ResetDay = DefaultYearlyTrackingResetDay
+			s.recordValidationWarning(warnComponentRealtime,
+				"yearly tracking is enabled but no reset day is set; using day %d",
+				DefaultYearlyTrackingResetDay)
+		}
+		if yt.WindowDays == 0 {
+			yt.WindowDays = DefaultYearlyTrackingWindowDays
+			s.recordValidationWarning(warnComponentRealtime,
+				"yearly tracking is enabled but no window is set; using the default %d days",
+				DefaultYearlyTrackingWindowDays)
+		}
+	}
+
+	seasonal := &st.SeasonalTracking
+	if !seasonal.Enabled {
+		return // nothing follows; keep any new feature out of this function
+	}
+	// An empty season map is filled in rather than treated as a reason to switch
+	// the feature off. GetDefaultSeasons is the documented default, and it is the
+	// same source Load uses for the hemisphere repair it applies after validation -
+	// which this state never reached before, since validateSeasonalTrackingSettings
+	// rejected an empty map outright. Disabling instead would also put the feature
+	// out of reach of that repair, which is gated on Enabled and LocationConfigured.
+	if len(seasonal.Seasons) == 0 {
+		seasonal.Seasons = GetDefaultSeasons(s.BirdNET.Latitude)
+		s.recordValidationWarning(warnComponentRealtime,
+			"seasonal tracking is enabled but no seasons are defined; using the defaults for the configured hemisphere")
+	}
+	if seasonal.WindowDays == 0 {
+		seasonal.WindowDays = DefaultSeasonalTrackingWindowDays
+		s.recordValidationWarning(warnComponentRealtime,
+			"seasonal tracking is enabled but no window is set; using the default %d days",
+			DefaultSeasonalTrackingWindowDays)
+	}
+}
+
+// normalizeWebServer binds the default port when the web server is enabled with
+// none set. The web UI is the recovery path for every other misconfiguration, so
+// refusing to start because its own port is blank is the least useful failure the
+// application can produce.
+func (s *Settings) normalizeWebServer() {
+	if s.WebServer.Enabled && s.WebServer.Port == "" {
+		s.WebServer.Port = DefaultWebServerPort
+		s.recordValidationWarning(warnComponentWebServer,
+			"the web server is enabled but no port is set; using the default %s", DefaultWebServerPort)
+	}
+}

--- a/internal/conf/validate_incomplete_test.go
+++ b/internal/conf/validate_incomplete_test.go
@@ -166,6 +166,28 @@ func TestValidateOAuthRedirects_ScopedToLockOutShape(t *testing.T) {
 			}},
 			wantErr: true,
 		},
+		{
+			name: "bare host gains the https scheme computeBaseURL assumes",
+			security: Security{Host: "example.com", OAuthProviders: []OAuthProviderConfig{
+				{Provider: providerGoogle, Enabled: true, ClientID: "id", ClientSecret: "secret"},
+			}},
+		},
+		{
+			// computeBaseURL returns baseUrl verbatim and prefers it over host, so a
+			// malformed one yields a callback the identity provider rejects and a
+			// valid host cannot rescue it.
+			name: "malformed baseUrl is not a usable origin",
+			security: Security{BaseURL: "example.com", Host: "https://real.example.com", OAuthProviders: []OAuthProviderConfig{
+				{Provider: providerGoogle, Enabled: true, ClientID: "id", ClientSecret: "secret"},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "malformed baseUrl is tolerated when the provider carries its own redirectUri",
+			security: Security{BaseURL: "example.com", OAuthProviders: []OAuthProviderConfig{
+				{Provider: providerGoogle, Enabled: true, ClientID: "id", ClientSecret: "secret", RedirectURI: "https://example.com/callback"},
+			}},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/conf/validate_incomplete_test.go
+++ b/internal/conf/validate_incomplete_test.go
@@ -70,27 +70,32 @@ func TestNormalizeOAuthProviders_DisablesProviderWithoutCredentials(t *testing.T
 
 // TestNormalizeOAuthProviders_KeepsCredentialedProviderEnabled verifies the other
 // half of the security rule: a provider that does have credentials is never
-// disabled, however broken the rest of its configuration. It counts towards
-// IsAuthenticationEnabled, so switching it off here would drop authentication from
-// a server the operator meant to protect. Sign-in fails, the operator is warned,
-// and the server stays closed.
+// disabled by normalization, however broken the rest of its configuration. It
+// counts towards IsAuthenticationEnabled, so switching it off here would drop
+// authentication from a server the operator meant to protect.
+//
+// Such a provider with no usable redirect URL is the one shape this change does
+// NOT downgrade to a warning: it forces authentication on while making sign-in
+// impossible, so validateOAuthRedirects rejects it and startup stops with the field
+// named. Booting instead would leave an instance nobody can sign in to, with the
+// warning that explains why sitting behind the login that cannot complete.
 func TestNormalizeOAuthProviders_KeepsCredentialedProviderEnabled(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		provider      OAuthProviderConfig
-		expectWarning string
+		name        string
+		provider    OAuthProviderConfig
+		expectFatal string
 	}{
 		{
-			name:          "no redirect source",
-			provider:      OAuthProviderConfig{Provider: "google", Enabled: true, ClientID: "id", ClientSecret: "secret"},
-			expectWarning: "no redirect URL can be built",
+			name:        "no redirect source",
+			provider:    OAuthProviderConfig{Provider: "google", Enabled: true, ClientID: "id", ClientSecret: "secret"},
+			expectFatal: "no redirect URL can be built",
 		},
 		{
-			name:          "relative redirect URI, the shape a migrated legacy block carries",
-			provider:      OAuthProviderConfig{Provider: providerGoogle, Enabled: true, ClientID: "id", ClientSecret: "secret", RedirectURI: "/settings"},
-			expectWarning: "not an absolute http(s) URL",
+			name:        "relative redirect URI, the shape a migrated legacy block carries",
+			provider:    OAuthProviderConfig{Provider: providerGoogle, Enabled: true, ClientID: "id", ClientSecret: "secret", RedirectURI: "/settings"},
+			expectFatal: "not an absolute http(s) URL",
 		},
 	}
 
@@ -106,8 +111,72 @@ func TestNormalizeOAuthProviders_KeepsCredentialedProviderEnabled(t *testing.T) 
 				"a credentialed provider must stay enabled so authentication is still required")
 			assert.Equal(t, []string{tt.provider.Provider}, s.GetEnabledOAuthProviders(),
 				"authentication must not be silently removed")
-			assert.Contains(t, warningsText(s), tt.expectWarning)
-			require.NoError(t, ValidateSettings(s))
+
+			err := ValidateSettings(s)
+			require.Error(t, err,
+				"a provider that forces auth on but cannot complete a sign-in must stay fatal")
+			assert.Contains(t, err.Error(), tt.expectFatal)
+		})
+	}
+}
+
+// TestValidateOAuthRedirects_ScopedToLockOutShape pins the boundaries of the fatal
+// rule, so it cannot drift back into the blunt host requirement it replaced.
+//
+// The deleted security-oauth-host rule rejected any enabled social provider without
+// security.host or security.baseUrl, even one carrying a perfectly good absolute
+// redirectUri. Only the absence of a usable redirect is fatal now, and only when the
+// provider has the credentials that make authentication mandatory.
+func TestValidateOAuthRedirects_ScopedToLockOutShape(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		security Security
+		wantErr  bool
+	}{
+		{
+			name: "absolute redirectUri without host or baseUrl is accepted",
+			security: Security{OAuthProviders: []OAuthProviderConfig{
+				{Provider: providerGoogle, Enabled: true, ClientID: "id", ClientSecret: "secret", RedirectURI: "https://example.com/callback"},
+			}},
+		},
+		{
+			name: "host supplies the redirect source",
+			security: Security{Host: "example.com", OAuthProviders: []OAuthProviderConfig{
+				{Provider: providerGitHub, Enabled: true, ClientID: "id", ClientSecret: "secret"},
+			}},
+		},
+		{
+			name: "no credentials is inert, not fatal",
+			security: Security{OAuthProviders: []OAuthProviderConfig{
+				{Provider: providerGoogle, Enabled: true, RedirectURI: "/settings"},
+			}},
+		},
+		{
+			name: "disabled provider is never consulted",
+			security: Security{OAuthProviders: []OAuthProviderConfig{
+				{Provider: providerGoogle, ClientID: "id", ClientSecret: "secret", RedirectURI: "/settings"},
+			}},
+		},
+		{
+			name: "credentialed provider with no usable redirect is fatal",
+			security: Security{OAuthProviders: []OAuthProviderConfig{
+				{Provider: providerMicrosoft, Enabled: true, ClientID: "id", ClientSecret: "secret", RedirectURI: "/settings"},
+			}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateOAuthRedirects(&tt.security)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
 		})
 	}
 }
@@ -246,11 +315,12 @@ func TestNormalizeOAuthProviders_WarnsForEveryLegacyBlock(t *testing.T) {
 	}
 }
 
-// TestNormalizeOAuthProviders_LegacyCredentialedBlockWarnsAfterMigration covers the
-// one shape the deleted host rule was doing real work for: a legacy block with
-// credentials and no redirect source. After migration it becomes an array entry, so
-// the redirect warning is what has to fire.
-func TestNormalizeOAuthProviders_LegacyCredentialedBlockWarnsAfterMigration(t *testing.T) {
+// TestNormalizeOAuthProviders_LegacyCredentialedBlockStaysFatalAfterMigration covers
+// the one shape the deleted host rule was doing real work for: a legacy block with
+// credentials and no redirect source. After migration it becomes an array entry that
+// forces authentication on while being unable to complete a sign-in, so it must stay
+// fatal rather than degrade to a warning nobody can reach.
+func TestNormalizeOAuthProviders_LegacyCredentialedBlockStaysFatalAfterMigration(t *testing.T) {
 	t.Parallel()
 
 	s := &Settings{}
@@ -261,8 +331,10 @@ func TestNormalizeOAuthProviders_LegacyCredentialedBlockWarnsAfterMigration(t *t
 
 	assert.Equal(t, []string{providerGoogle}, s.GetEnabledOAuthProviders(),
 		"a credentialed provider keeps requiring authentication")
-	assert.Contains(t, warningsText(s), "no redirect URL can be built")
-	require.NoError(t, ValidateSettings(s))
+
+	err := ValidateSettings(s)
+	require.Error(t, err, "a migrated legacy block with no redirect source must not boot")
+	assert.Contains(t, err.Error(), "no redirect URL can be built")
 }
 
 // TestNormalizeQuietHours_DisablesUnusableBlocks verifies that a quiet hours block
@@ -1083,7 +1155,10 @@ realtime:
 	require.NoError(t, os.WriteFile(configPath, []byte(configYAML), 0o600))
 
 	oldPath := ConfigPath
-	oldSettings := GetSettings()
+	// Clone rather than keep the live pointer: GetSettings returns the published
+	// settings, so a snapshot taken by reference would follow any mutation the test
+	// makes and restore the mutated state instead of the original.
+	oldSettings := CloneSettings(GetSettings())
 	t.Cleanup(func() {
 		ConfigPath = oldPath
 		viper.Reset()

--- a/internal/conf/validate_incomplete_test.go
+++ b/internal/conf/validate_incomplete_test.go
@@ -1,0 +1,1118 @@
+package conf
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// warningsText joins the recorded validation warnings so a test can assert on the
+// text without caring which entry carried it.
+func warningsText(s *Settings) string {
+	return strings.Join(s.ValidationWarnings, "\n")
+}
+
+// TestNormalizeOAuthProviders_DisablesProviderWithoutCredentials verifies that a
+// provider switched on without a client ID or secret is turned off rather than
+// rejected. Disabling it is safe precisely because the runtime already ignores that
+// shape, which is also why the GetEnabledOAuthProviders assertion below holds by
+// construction for these inputs: it records the invariant rather than testing it.
+// The assertion with teeth is in
+// TestNormalizeOAuthProviders_KeepsCredentialedProviderEnabled, which fails if this
+// pass ever disables a provider that does count as an authentication method.
+func TestNormalizeOAuthProviders_DisablesProviderWithoutCredentials(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		provider OAuthProviderConfig
+	}{
+		{
+			name:     "no credentials at all",
+			provider: OAuthProviderConfig{Provider: "google", Enabled: true},
+		},
+		{
+			name:     "client ID without secret",
+			provider: OAuthProviderConfig{Provider: "github", Enabled: true, ClientID: "id"},
+		},
+		{
+			name:     "secret without client ID",
+			provider: OAuthProviderConfig{Provider: "microsoft", Enabled: true, ClientSecret: "secret"},
+		},
+		{
+			name:     "OIDC with neither credentials nor issuer",
+			provider: OAuthProviderConfig{Provider: providerOIDC, Enabled: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := &Settings{}
+			s.Security.OAuthProviders = []OAuthProviderConfig{tt.provider}
+
+			normalizeIncompleteFeatures(s)
+
+			assert.False(t, s.Security.OAuthProviders[0].Enabled,
+				"a provider that cannot authenticate anyone must be left disabled")
+			assert.Empty(t, s.GetEnabledOAuthProviders(),
+				"a half-configured provider must never be consulted during auth")
+			assert.Contains(t, warningsText(s), "clientId/clientSecret")
+			require.NoError(t, ValidateSettings(s))
+		})
+	}
+}
+
+// TestNormalizeOAuthProviders_KeepsCredentialedProviderEnabled verifies the other
+// half of the security rule: a provider that does have credentials is never
+// disabled, however broken the rest of its configuration. It counts towards
+// IsAuthenticationEnabled, so switching it off here would drop authentication from
+// a server the operator meant to protect. Sign-in fails, the operator is warned,
+// and the server stays closed.
+func TestNormalizeOAuthProviders_KeepsCredentialedProviderEnabled(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		provider      OAuthProviderConfig
+		expectWarning string
+	}{
+		{
+			name:          "no redirect source",
+			provider:      OAuthProviderConfig{Provider: "google", Enabled: true, ClientID: "id", ClientSecret: "secret"},
+			expectWarning: "no redirect URL can be built",
+		},
+		{
+			name:          "relative redirect URI, the shape a migrated legacy block carries",
+			provider:      OAuthProviderConfig{Provider: providerGoogle, Enabled: true, ClientID: "id", ClientSecret: "secret", RedirectURI: "/settings"},
+			expectWarning: "not an absolute http(s) URL",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := &Settings{}
+			s.Security.OAuthProviders = []OAuthProviderConfig{tt.provider}
+
+			normalizeIncompleteFeatures(s)
+
+			assert.True(t, s.Security.OAuthProviders[0].Enabled,
+				"a credentialed provider must stay enabled so authentication is still required")
+			assert.Equal(t, []string{tt.provider.Provider}, s.GetEnabledOAuthProviders(),
+				"authentication must not be silently removed")
+			assert.Contains(t, warningsText(s), tt.expectWarning)
+			require.NoError(t, ValidateSettings(s))
+		})
+	}
+}
+
+// TestNormalizeOAuthProviders_LegacyFieldsAreReportedNotRejected verifies the
+// exact configuration from the field report: a deprecated googleAuth block left
+// enabled with no client ID. migrateLegacyProvider skips it, so nothing at runtime
+// reads it, and the old rule made that inert leftover fatal.
+func TestNormalizeOAuthProviders_LegacyFieldsAreReportedNotRejected(t *testing.T) {
+	t.Parallel()
+
+	s := &Settings{}
+	s.Security.GoogleAuth = SocialProvider{Enabled: true}
+	s.Security.GithubAuth = SocialProvider{Enabled: true}
+
+	normalizeIncompleteFeatures(s)
+
+	require.NoError(t, ValidateSettings(s))
+	assert.Empty(t, s.GetEnabledOAuthProviders(),
+		"a legacy block with no clientId is never migrated, so it authenticates nobody")
+	assert.Contains(t, warningsText(s), "security.googleauth")
+	assert.Contains(t, warningsText(s), "security.githubauth")
+}
+
+// TestNormalizeOAuthProviders_LeavesCompleteConfigurationAlone guards against a
+// blanket downgrade touching configurations that are fine.
+func TestNormalizeOAuthProviders_LeavesCompleteConfigurationAlone(t *testing.T) {
+	t.Parallel()
+
+	s := &Settings{}
+	s.Security.Host = "birdnet.example.com"
+	s.Security.OAuthProviders = []OAuthProviderConfig{
+		{Provider: "google", Enabled: true, ClientID: "id", ClientSecret: "secret"},
+	}
+
+	normalizeIncompleteFeatures(s)
+
+	assert.True(t, s.Security.OAuthProviders[0].Enabled)
+	assert.Equal(t, []string{"google"}, s.GetEnabledOAuthProviders())
+	assert.Empty(t, s.ValidationWarnings)
+}
+
+// TestNormalizeOAuthProviders_LeavesDisabledProviderAlone verifies that a provider
+// the operator deliberately switched off is neither re-examined nor warned about.
+func TestNormalizeOAuthProviders_LeavesDisabledProviderAlone(t *testing.T) {
+	t.Parallel()
+
+	s := &Settings{}
+	s.Security.OAuthProviders = []OAuthProviderConfig{
+		{Provider: providerGoogle, Enabled: false},
+		{Provider: providerOIDC, Enabled: false, ClientID: "id", ClientSecret: "secret"},
+	}
+
+	normalizeIncompleteFeatures(s)
+
+	assert.Empty(t, s.ValidationWarnings, "a disabled provider is not an unfinished one")
+	assert.Empty(t, s.GetEnabledOAuthProviders())
+}
+
+// TestNormalizeOAuthProviders_AcceptsCompleteOIDC verifies that a fully configured
+// OIDC provider draws no warning. Without this, a regression that always reported an
+// issuer problem would tell every healthy install that sign-in is broken.
+func TestNormalizeOAuthProviders_AcceptsCompleteOIDC(t *testing.T) {
+	t.Parallel()
+
+	s := &Settings{}
+	s.Security.Host = "birdnet.example.com"
+	s.Security.OAuthProviders = []OAuthProviderConfig{
+		{Provider: providerOIDC, Enabled: true, ClientID: "id", ClientSecret: "secret", IssuerURL: "https://idp.example.com"},
+	}
+
+	normalizeIncompleteFeatures(s)
+
+	assert.Empty(t, s.ValidationWarnings)
+	assert.Equal(t, []string{providerOIDC}, s.GetEnabledOAuthProviders())
+	require.NoError(t, ValidateSettings(s))
+}
+
+// TestNormalizeOAuthProviders_WarnsForEveryLegacyBlock verifies all three deprecated
+// blocks are covered, including microsoftAuth, and that a block whose provider did
+// reach security.oauthProviders is not reported as ignored.
+func TestNormalizeOAuthProviders_WarnsForEveryLegacyBlock(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		apply      func(s *Settings)
+		expectKey  string
+		expectWarn bool
+	}{
+		{
+			name:       "google",
+			apply:      func(s *Settings) { s.Security.GoogleAuth = SocialProvider{Enabled: true} },
+			expectKey:  "security.googleauth",
+			expectWarn: true,
+		},
+		{
+			name:       "github",
+			apply:      func(s *Settings) { s.Security.GithubAuth = SocialProvider{Enabled: true} },
+			expectKey:  "security.githubauth",
+			expectWarn: true,
+		},
+		{
+			name:       "microsoft",
+			apply:      func(s *Settings) { s.Security.MicrosoftAuth = SocialProvider{Enabled: true} },
+			expectKey:  "security.microsoftauth",
+			expectWarn: true,
+		},
+		{
+			name: "legacy block that was migrated is not reported",
+			apply: func(s *Settings) {
+				s.Security.GoogleAuth = SocialProvider{Enabled: true, ClientID: "id", ClientSecret: "secret"}
+				s.Security.OAuthProviders = []OAuthProviderConfig{
+					{Provider: providerGoogle, Enabled: true, ClientID: "id", ClientSecret: "secret", RedirectURI: "https://app.example.com/cb"},
+				}
+			},
+			expectKey:  "security.googleauth",
+			expectWarn: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := &Settings{}
+			tt.apply(s)
+
+			normalizeIncompleteFeatures(s)
+
+			if tt.expectWarn {
+				assert.Contains(t, warningsText(s), tt.expectKey)
+			} else {
+				assert.NotContains(t, warningsText(s), tt.expectKey)
+			}
+		})
+	}
+}
+
+// TestNormalizeOAuthProviders_LegacyCredentialedBlockWarnsAfterMigration covers the
+// one shape the deleted host rule was doing real work for: a legacy block with
+// credentials and no redirect source. After migration it becomes an array entry, so
+// the redirect warning is what has to fire.
+func TestNormalizeOAuthProviders_LegacyCredentialedBlockWarnsAfterMigration(t *testing.T) {
+	t.Parallel()
+
+	s := &Settings{}
+	s.Security.GoogleAuth = SocialProvider{Enabled: true, ClientID: "id", ClientSecret: "secret"}
+	require.True(t, s.MigrateOAuthConfig())
+
+	normalizeIncompleteFeatures(s)
+
+	assert.Equal(t, []string{providerGoogle}, s.GetEnabledOAuthProviders(),
+		"a credentialed provider keeps requiring authentication")
+	assert.Contains(t, warningsText(s), "no redirect URL can be built")
+	require.NoError(t, ValidateSettings(s))
+}
+
+// TestNormalizeQuietHours_DisablesUnusableBlocks verifies that a quiet hours block
+// which cannot produce a window is switched off. The scheduler already treats each
+// of these as "not quiet", so nothing about the running system changes.
+func TestNormalizeQuietHours_DisablesUnusableBlocks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		quietHours    QuietHoursConfig
+		expectWarning string
+	}{
+		{
+			name:          "enabled with no mode",
+			quietHours:    QuietHoursConfig{Enabled: true},
+			expectWarning: "no mode is set",
+		},
+		{
+			name:          "unrecognised mode",
+			quietHours:    QuietHoursConfig{Enabled: true, Mode: "nocturnal"},
+			expectWarning: "unrecognised mode",
+		},
+		{
+			name:          "fixed mode with empty times",
+			quietHours:    QuietHoursConfig{Enabled: true, Mode: QuietHoursModeFixed},
+			expectWarning: "start time",
+		},
+		{
+			name:          "fixed mode with unparsable end time",
+			quietHours:    QuietHoursConfig{Enabled: true, Mode: QuietHoursModeFixed, StartTime: "22:00", EndTime: "6am"},
+			expectWarning: "end time",
+		},
+		{
+			name:          "solar mode with no events",
+			quietHours:    QuietHoursConfig{Enabled: true, Mode: QuietHoursModeSolar},
+			expectWarning: "start event",
+		},
+		{
+			name:          "solar mode with unrecognised end event",
+			quietHours:    QuietHoursConfig{Enabled: true, Mode: QuietHoursModeSolar, StartEvent: SolarEventSunset, EndEvent: "moonrise"},
+			expectWarning: "end event",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := createMinimalValidSettings()
+			s.Realtime.Audio.QuietHours = tt.quietHours
+
+			normalizeIncompleteFeatures(s)
+
+			assert.False(t, s.Realtime.Audio.QuietHours.Enabled, "quiet hours must be switched off")
+			assert.Contains(t, warningsText(s), tt.expectWarning)
+			require.NoError(t, ValidateSettings(s))
+		})
+	}
+}
+
+// TestNormalizeQuietHours_CoversSourcesAndStreams verifies the sweep reaches every
+// place a quiet hours block can live, not only the global one. The stream case is
+// the one from the field report.
+func TestNormalizeQuietHours_CoversSourcesAndStreams(t *testing.T) {
+	t.Parallel()
+
+	s := createMinimalValidSettings()
+	s.Realtime.Audio.Sources = []AudioSourceConfig{
+		{Name: "Sound Card 1", Device: testAudioDeviceSysdefault, QuietHours: QuietHoursConfig{Enabled: true}},
+	}
+	s.Realtime.RTSP.Streams = []StreamConfig{
+		{Name: "Garden", URL: "rtsp://cam.local/stream", Type: StreamTypeRTSP, QuietHours: QuietHoursConfig{Enabled: true}},
+	}
+
+	normalizeIncompleteFeatures(s)
+
+	assert.False(t, s.Realtime.Audio.Sources[0].QuietHours.Enabled)
+	assert.False(t, s.Realtime.RTSP.Streams[0].QuietHours.Enabled)
+	assert.Contains(t, warningsText(s), `audio source "Sound Card 1"`)
+	assert.Contains(t, warningsText(s), `stream 1 ("Garden")`)
+	require.NoError(t, ValidateSettings(s))
+}
+
+// TestNormalizeQuietHours_KeepsOutOfRangeOffsetsFatal guards the boundary of the
+// downgrade. An offset outside the supported range is an explicitly typed value
+// that shifts a real suppression window, not a field that was never filled in, so
+// it must still be rejected.
+func TestNormalizeQuietHours_KeepsOutOfRangeOffsetsFatal(t *testing.T) {
+	t.Parallel()
+
+	s := createMinimalValidSettings()
+	s.Realtime.Audio.QuietHours = QuietHoursConfig{
+		Enabled:     true,
+		Mode:        QuietHoursModeSolar,
+		StartEvent:  SolarEventSunset,
+		EndEvent:    SolarEventSunrise,
+		StartOffset: MaxQuietHoursOffset + 1,
+	}
+
+	normalizeIncompleteFeatures(s)
+
+	assert.True(t, s.Realtime.Audio.QuietHours.Enabled, "a complete configuration must not be disabled")
+	err := ValidateSettings(s)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "quiet hours start offset must be between")
+}
+
+// TestNormalizeEqualizers_AppliesDefaultQ verifies that a filter with no Q factor
+// gets the standard one. This is not only a startup fix: NewLowPass computes
+// sin(w0)/(2*q) without guarding q, so a zero reaching the audio path would make
+// every coefficient infinite.
+func TestNormalizeEqualizers_AppliesDefaultQ(t *testing.T) {
+	t.Parallel()
+
+	s := createMinimalValidSettings()
+	s.Realtime.Audio.Equalizer = EqualizerSettings{
+		Enabled: true,
+		Filters: []EqualizerFilter{
+			{Type: "LowPass", Frequency: 15000},
+			{Type: "HighPass", Frequency: 100},
+		},
+	}
+	s.Realtime.Audio.Sources = []AudioSourceConfig{
+		{
+			Name:      "Sound Card 1",
+			Device:    testAudioDeviceSysdefault,
+			Equalizer: &EqualizerSettings{Enabled: true, Filters: []EqualizerFilter{{Type: "LowPass", Frequency: 12000}}},
+		},
+	}
+	s.Realtime.RTSP.Streams = []StreamConfig{
+		{
+			Name:      "Garden",
+			URL:       "rtsp://cam.local/stream",
+			Type:      StreamTypeRTSP,
+			Equalizer: &EqualizerSettings{Enabled: true, Filters: []EqualizerFilter{{Type: "HighPass", Frequency: 200}}},
+		},
+	}
+
+	normalizeIncompleteFeatures(s)
+
+	assert.InDelta(t, DefaultEQQFactor, s.Realtime.Audio.Equalizer.Filters[0].Q, 0.0001)
+	assert.InDelta(t, DefaultEQQFactor, s.Realtime.Audio.Equalizer.Filters[1].Q, 0.0001)
+	assert.InDelta(t, DefaultEQQFactor, s.Realtime.Audio.Sources[0].Equalizer.Filters[0].Q, 0.0001)
+	assert.InDelta(t, DefaultEQQFactor, s.Realtime.RTSP.Streams[0].Equalizer.Filters[0].Q, 0.0001)
+	assert.Contains(t, warningsText(s), "no Q factor set")
+	require.NoError(t, ValidateSettings(s))
+}
+
+// TestNormalizeEqualizers_NormalizesDisabledSetsSilently covers the file's most
+// contested carve-out, in both halves: a switched-off equalizer still has its zero Q
+// rewritten, so a later enable is not rejected over a field the settings UI never
+// offered, and it produces no warning, so a feature the user turned off does not
+// generate a notification.
+func TestNormalizeEqualizers_NormalizesDisabledSetsSilently(t *testing.T) {
+	t.Parallel()
+
+	s := createMinimalValidSettings()
+	s.Realtime.Audio.Equalizer = EqualizerSettings{
+		Enabled: false,
+		Filters: []EqualizerFilter{{Type: "LowPass", Frequency: 15000}},
+	}
+
+	normalizeIncompleteFeatures(s)
+
+	assert.InDelta(t, DefaultEQQFactor, s.Realtime.Audio.Equalizer.Filters[0].Q, 0.0001,
+		"a stored zero would make the user's later enable fail validation")
+	assert.Empty(t, s.ValidationWarnings, "a switched-off equalizer is not worth a notification")
+	require.NoError(t, ValidateSettings(s))
+}
+
+// TestNormalizeEqualizers_SilentForWidthBasedFilters verifies that the width-based
+// filter types, which ignore Q entirely, are normalized without being reported. The
+// validator still demands a positive Q from every type, so the value must be filled
+// in, but telling the user a Q default was applied to a filter that has no Q setting
+// would be misleading.
+func TestNormalizeEqualizers_SilentForWidthBasedFilters(t *testing.T) {
+	t.Parallel()
+
+	for _, filterType := range []string{"BandPass", "BandReject", "Peaking"} {
+		t.Run(filterType, func(t *testing.T) {
+			t.Parallel()
+			assert.False(t, eqFilterUsesQ(filterType))
+
+			s := createMinimalValidSettings()
+			s.Realtime.Audio.Equalizer = EqualizerSettings{
+				Enabled: true,
+				Filters: []EqualizerFilter{{Type: filterType, Frequency: 1000, Width: 100}},
+			}
+
+			normalizeIncompleteFeatures(s)
+
+			assert.InDelta(t, DefaultEQQFactor, s.Realtime.Audio.Equalizer.Filters[0].Q, 0.0001)
+			assert.Empty(t, s.ValidationWarnings)
+			require.NoError(t, ValidateSettings(s))
+		})
+	}
+}
+
+// TestNormalizeIntegrations_BindsListenWhenTelemetryDisabled covers the other
+// deliberate carve-out: the listen address is bound even when telemetry is off, so
+// enabling it from the settings UI later is not rejected over a blank the operator
+// never saw, but a disabled endpoint is not reported.
+func TestNormalizeIntegrations_BindsListenWhenTelemetryDisabled(t *testing.T) {
+	t.Parallel()
+
+	s := createMinimalValidSettings()
+	s.Realtime.Telemetry = TelemetrySettings{Enabled: false, Listen: ""}
+
+	normalizeIncompleteFeatures(s)
+
+	assert.Equal(t, DefaultTelemetryListen, s.Realtime.Telemetry.Listen)
+	assert.Empty(t, s.ValidationWarnings)
+}
+
+// TestNormalizeIntegrations_DefaultsMQTTBackoffMultiplier verifies the retry
+// multiplier is filled in rather than rejected. Zero is never a usable multiplier,
+// so it can only mean the key was never written.
+func TestNormalizeIntegrations_DefaultsMQTTBackoffMultiplier(t *testing.T) {
+	t.Parallel()
+
+	s := createMinimalValidSettings()
+	s.Realtime.MQTT = MQTTSettings{
+		Enabled:       true,
+		Broker:        "tcp://localhost:1883",
+		Topic:         "birdnet",
+		RetrySettings: RetrySettings{Enabled: true},
+	}
+
+	normalizeIncompleteFeatures(s)
+
+	assert.True(t, s.Realtime.MQTT.Enabled)
+	assert.InDelta(t, DefaultRetryBackoffMultiplier, s.Realtime.MQTT.RetrySettings.BackoffMultiplier, 0.0001)
+	assert.Contains(t, warningsText(s), "no backoff multiplier is set")
+	require.NoError(t, ValidateSettings(s))
+}
+
+// TestNormalizeEqualizers_KeepsInvalidValuesFatal guards the boundary: only an
+// exact zero means "never written". Anything else could reach the biquad and
+// change what gets analysed, and the audio engine does not defend against it.
+func TestNormalizeEqualizers_KeepsInvalidValuesFatal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		filter      EqualizerFilter
+		expectError string
+	}{
+		{name: "negative Q", filter: EqualizerFilter{Type: "LowPass", Frequency: 15000, Q: -1},
+			expectError: "invalid Q factor"},
+		{name: "Q above maximum", filter: EqualizerFilter{Type: "LowPass", Frequency: 15000, Q: MaxEQQ + 1},
+			expectError: "Q factor 101.0 exceeds maximum"},
+		{name: "zero frequency", filter: EqualizerFilter{Type: "LowPass", Q: 0.7},
+			expectError: "invalid frequency"},
+		{name: "frequency above maximum", filter: EqualizerFilter{Type: "LowPass", Frequency: MaxEQFrequency + 1, Q: 0.7},
+			expectError: "exceeds maximum"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := createMinimalValidSettings()
+			s.Realtime.Audio.Equalizer = EqualizerSettings{Enabled: true, Filters: []EqualizerFilter{tt.filter}}
+
+			normalizeIncompleteFeatures(s)
+
+			err := ValidateSettings(s)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectError)
+		})
+	}
+}
+
+// TestValidateEqualizer_SkipsDisabledFilterSets verifies that filters belonging to
+// an equalizer that is switched off are not validated. BuildFilterChain returns nil
+// for a disabled equalizer, so those values never reach the audio path.
+func TestValidateEqualizer_SkipsDisabledFilterSets(t *testing.T) {
+	t.Parallel()
+
+	broken := &EqualizerSettings{Enabled: false, Filters: []EqualizerFilter{{Type: "LowPass", Frequency: 15000, Q: -1}}}
+
+	source := AudioSourceConfig{Name: "Sound Card 1", Device: testAudioDeviceSysdefault, Equalizer: broken}
+	assert.NoError(t, source.Validate())
+
+	stream := StreamConfig{Name: "Garden", URL: "rtsp://cam.local/stream", Type: StreamTypeRTSP, Equalizer: broken}
+	assert.NoError(t, stream.Validate())
+}
+
+// TestNormalizeIntegrations_DisablesUnusableIntegrations verifies that an
+// integration with no endpoint or credential is switched off with a warning.
+func TestNormalizeIntegrations_DisablesUnusableIntegrations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		apply         func(s *Settings)
+		stillEnabled  func(s *Settings) bool
+		expectWarning string
+	}{
+		{
+			name:          "BirdWeather without station ID",
+			apply:         func(s *Settings) { s.Realtime.Birdweather = BirdweatherSettings{Enabled: true} },
+			stillEnabled:  func(s *Settings) bool { return s.Realtime.Birdweather.Enabled },
+			expectWarning: "no station ID is set",
+		},
+		{
+			name:          "BirdWeather with malformed station ID",
+			apply:         func(s *Settings) { s.Realtime.Birdweather = BirdweatherSettings{Enabled: true, ID: "short"} },
+			stillEnabled:  func(s *Settings) bool { return s.Realtime.Birdweather.Enabled },
+			expectWarning: "24 alphanumeric characters",
+		},
+		{
+			name:          "MQTT without broker",
+			apply:         func(s *Settings) { s.Realtime.MQTT = MQTTSettings{Enabled: true, Topic: "birdnet"} },
+			stillEnabled:  func(s *Settings) bool { return s.Realtime.MQTT.Enabled },
+			expectWarning: "no broker URL is set",
+		},
+		{
+			name:          "MQTT without topic",
+			apply:         func(s *Settings) { s.Realtime.MQTT = MQTTSettings{Enabled: true, Broker: "tcp://localhost:1883"} },
+			stillEnabled:  func(s *Settings) bool { return s.Realtime.MQTT.Enabled },
+			expectWarning: "no topic is set",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := createMinimalValidSettings()
+			tt.apply(s)
+
+			normalizeIncompleteFeatures(s)
+
+			assert.False(t, tt.stillEnabled(s), "an integration that cannot connect must be switched off")
+			assert.Contains(t, warningsText(s), tt.expectWarning)
+			require.NoError(t, ValidateSettings(s))
+		})
+	}
+}
+
+// TestNormalizeIntegrations_DefaultsListenAndPort verifies that an address left
+// blank falls back to the documented default instead of blocking startup. The web
+// server matters most here: it is the recovery path for every other setting.
+func TestNormalizeIntegrations_DefaultsListenAndPort(t *testing.T) {
+	t.Parallel()
+
+	s := createMinimalValidSettings()
+	s.Realtime.Telemetry = TelemetrySettings{Enabled: true}
+	s.WebServer.Enabled = true
+	s.WebServer.Port = ""
+
+	normalizeIncompleteFeatures(s)
+
+	assert.Equal(t, DefaultTelemetryListen, s.Realtime.Telemetry.Listen)
+	assert.Equal(t, DefaultWebServerPort, s.WebServer.Port)
+	assert.Contains(t, warningsText(s), "no listen address is set")
+	assert.Contains(t, warningsText(s), "no port is set")
+	require.NoError(t, ValidateSettings(s))
+}
+
+// TestNormalizeNotificationProviders_DisablesUndeliverableProviders verifies that a
+// push provider missing the one field its type needs is switched off. Losing
+// notifications is the same outcome as before; losing every detection because the
+// process will not start is not.
+func TestNormalizeNotificationProviders_DisablesUndeliverableProviders(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		provider      PushProviderConfig
+		expectWarning string
+	}{
+		{
+			name:          "no type",
+			provider:      PushProviderConfig{Name: "unnamed", Enabled: true},
+			expectWarning: "has no type set",
+		},
+		{
+			name:          "unknown type",
+			provider:      PushProviderConfig{Name: "legacy", Enabled: true, Type: "pushover"},
+			expectWarning: "unknown type",
+		},
+		{
+			name:          "script without command",
+			provider:      PushProviderConfig{Name: "runner", Enabled: true, Type: pushProviderScript},
+			expectWarning: "no command",
+		},
+		{
+			name:          "shoutrrr without URLs",
+			provider:      PushProviderConfig{Name: "shout", Enabled: true, Type: pushProviderShoutrrr},
+			expectWarning: "no URLs",
+		},
+		{
+			name:          "webhook without endpoints",
+			provider:      PushProviderConfig{Name: "hook", Enabled: true, Type: pushProviderWebhook},
+			expectWarning: "no endpoints",
+		},
+		{
+			name: "webhook endpoint with bearer auth and no token",
+			provider: PushProviderConfig{
+				Name: "hook", Enabled: true, Type: pushProviderWebhook,
+				Endpoints: []WebhookEndpointConfig{{
+					URL:  "https://example.com/hook",
+					Auth: WebhookAuthConfig{Type: webhookAuthBearer},
+				}},
+			},
+			expectWarning: "no token or token_file is set",
+		},
+		{
+			name: "webhook endpoint with basic auth and no password",
+			provider: PushProviderConfig{
+				Name: "hook", Enabled: true, Type: pushProviderWebhook,
+				Endpoints: []WebhookEndpointConfig{{
+					URL:  "https://example.com/hook",
+					Auth: WebhookAuthConfig{Type: webhookAuthBasic, User: "birdnet"},
+				}},
+			},
+			expectWarning: "no pass or pass_file is set",
+		},
+		{
+			name: "webhook endpoint with an auth type the sender cannot use",
+			provider: PushProviderConfig{
+				Name: "hook", Enabled: true, Type: pushProviderWebhook,
+				Endpoints: []WebhookEndpointConfig{{
+					URL:  "https://example.com/hook",
+					Auth: WebhookAuthConfig{Type: "mtls"},
+				}},
+			},
+			expectWarning: "auth type is not one of",
+		},
+		{
+			name: "webhook endpoint with no URL",
+			provider: PushProviderConfig{
+				Name: "hook", Enabled: true, Type: pushProviderWebhook,
+				Endpoints: []WebhookEndpointConfig{{Auth: WebhookAuthConfig{}}},
+			},
+			expectWarning: "has no URL",
+		},
+		{
+			name: "webhook endpoint with custom auth and no value",
+			provider: PushProviderConfig{
+				Name: "hook", Enabled: true, Type: pushProviderWebhook,
+				Endpoints: []WebhookEndpointConfig{{
+					URL:  "https://example.com/hook",
+					Auth: WebhookAuthConfig{Type: webhookAuthCustom, Header: "X-Token"},
+				}},
+			},
+			expectWarning: "no value or value_file is set",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := createMinimalValidSettings()
+			s.Notification.Push.Enabled = true
+			s.Notification.Push.Providers = []PushProviderConfig{tt.provider}
+
+			normalizeIncompleteFeatures(s)
+
+			assert.False(t, s.Notification.Push.Providers[0].Enabled, "an undeliverable provider must be switched off")
+			assert.Contains(t, warningsText(s), tt.expectWarning)
+			require.NoError(t, ValidateSettings(s))
+		})
+	}
+}
+
+// TestNormalizeNotificationProviders_KeepsWorkingProvidersEnabled verifies the
+// direction that matters most: a provider that CAN deliver is never switched off.
+// Without it, a regression that disabled every webhook would cost users their alerts
+// silently.
+func TestNormalizeNotificationProviders_KeepsWorkingProvidersEnabled(t *testing.T) {
+	t.Parallel()
+
+	endpoint := func(auth WebhookAuthConfig) WebhookEndpointConfig {
+		return WebhookEndpointConfig{URL: "https://example.com/hook", Auth: auth}
+	}
+
+	tests := []struct {
+		name     string
+		provider PushProviderConfig
+	}{
+		{
+			name:     "script with a command",
+			provider: PushProviderConfig{Name: "runner", Enabled: true, Type: pushProviderScript, Command: "/usr/local/bin/notify"},
+		},
+		{
+			name:     "shoutrrr with a URL",
+			provider: PushProviderConfig{Name: "shout", Enabled: true, Type: pushProviderShoutrrr, URLs: []string{"ntfy://ntfy.sh/birds"}},
+		},
+		{
+			name: "webhook with no auth",
+			provider: PushProviderConfig{Name: "hook", Enabled: true, Type: pushProviderWebhook,
+				Endpoints: []WebhookEndpointConfig{endpoint(WebhookAuthConfig{})}},
+		},
+		{
+			name: "webhook with auth type none",
+			provider: PushProviderConfig{Name: "hook", Enabled: true, Type: pushProviderWebhook,
+				Endpoints: []WebhookEndpointConfig{endpoint(WebhookAuthConfig{Type: webhookAuthNone})}},
+		},
+		{
+			name: "webhook with complete bearer auth",
+			provider: PushProviderConfig{Name: "hook", Enabled: true, Type: pushProviderWebhook,
+				Endpoints: []WebhookEndpointConfig{endpoint(WebhookAuthConfig{Type: webhookAuthBearer, Token: "t"})}},
+		},
+		{
+			name: "webhook with complete basic auth",
+			provider: PushProviderConfig{Name: "hook", Enabled: true, Type: pushProviderWebhook,
+				Endpoints: []WebhookEndpointConfig{endpoint(WebhookAuthConfig{Type: webhookAuthBasic, User: "u", Pass: "p"})}},
+		},
+		{
+			name: "webhook with complete custom auth",
+			provider: PushProviderConfig{Name: "hook", Enabled: true, Type: pushProviderWebhook,
+				Endpoints: []WebhookEndpointConfig{endpoint(WebhookAuthConfig{Type: webhookAuthCustom, Header: "X-Token", Value: "v"})}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := createMinimalValidSettings()
+			s.Notification.Push.Enabled = true
+			s.Notification.Push.Providers = []PushProviderConfig{tt.provider}
+
+			normalizeIncompleteFeatures(s)
+
+			assert.True(t, s.Notification.Push.Providers[0].Enabled,
+				"a provider that can deliver must not be switched off")
+			assert.Empty(t, s.ValidationWarnings)
+		})
+	}
+}
+
+// TestNormalizeIncompleteFeatures_LeavesConfiguredValuesAlone verifies the pass only
+// fills in what was never written. A regression that defaulted unconditionally would
+// rebind a telemetry endpoint the operator pinned to loopback onto every interface,
+// which no "the empty value gets a default" test can detect.
+func TestNormalizeIncompleteFeatures_LeavesConfiguredValuesAlone(t *testing.T) {
+	t.Parallel()
+
+	s := createMinimalValidSettings()
+	s.Realtime.Telemetry = TelemetrySettings{Enabled: true, Listen: "127.0.0.1:9100"}
+	s.WebServer.Enabled = true
+	s.WebServer.Port = "9000"
+	s.Realtime.Audio.SoundLevel = SoundLevelSettings{Enabled: true, Interval: 30}
+	s.Realtime.DynamicThreshold = DynamicThresholdSettings{Enabled: true, Trigger: 0.9, Min: 0.2, ValidHours: 12}
+	s.Realtime.SpeciesTracking = SpeciesTrackingSettings{
+		Enabled:              true,
+		NewSpeciesWindowDays: 21,
+		SyncIntervalMinutes:  15,
+		YearlyTracking:       YearlyTrackingSettings{Enabled: true, ResetMonth: 4, ResetDay: 15, WindowDays: 30},
+		SeasonalTracking: SeasonalTrackingSettings{
+			Enabled: true, WindowDays: 14,
+			Seasons: map[string]Season{"spring": {StartMonth: 3, StartDay: 20}},
+		},
+	}
+	s.Realtime.Audio.Export = ExportSettings{Enabled: true, Type: AudioExportTypeOPUS, Bitrate: "128k", Length: 30}
+
+	normalizeIncompleteFeatures(s)
+
+	assert.Equal(t, "127.0.0.1:9100", s.Realtime.Telemetry.Listen)
+	assert.Equal(t, "9000", s.WebServer.Port)
+	assert.Equal(t, 30, s.Realtime.Audio.SoundLevel.Interval)
+	assert.Equal(t, 12, s.Realtime.DynamicThreshold.ValidHours)
+	assert.Equal(t, 21, s.Realtime.SpeciesTracking.NewSpeciesWindowDays)
+	assert.Equal(t, 15, s.Realtime.SpeciesTracking.SyncIntervalMinutes)
+	assert.Equal(t, 4, s.Realtime.SpeciesTracking.YearlyTracking.ResetMonth)
+	assert.Equal(t, 15, s.Realtime.SpeciesTracking.YearlyTracking.ResetDay)
+	assert.Equal(t, 30, s.Realtime.SpeciesTracking.YearlyTracking.WindowDays)
+	assert.Equal(t, 14, s.Realtime.SpeciesTracking.SeasonalTracking.WindowDays)
+	assert.Equal(t, "128k", s.Realtime.Audio.Export.Bitrate)
+	assert.Equal(t, 30, s.Realtime.Audio.Export.Length)
+	assert.Empty(t, s.ValidationWarnings, "nothing here was left unconfigured")
+}
+
+// TestNormalizeSpeciesTracking_DefaultsResetDayIndependently verifies that a reset
+// day the user did write survives a missing reset month. Filling in both from the
+// month's absence would discard a value the user set, which is the one thing this
+// pass exists not to do.
+func TestNormalizeSpeciesTracking_DefaultsResetDayIndependently(t *testing.T) {
+	t.Parallel()
+
+	t.Run("month missing, day kept", func(t *testing.T) {
+		t.Parallel()
+		s := createMinimalValidSettings()
+		s.Realtime.SpeciesTracking = SpeciesTrackingSettings{
+			Enabled:        true,
+			YearlyTracking: YearlyTrackingSettings{Enabled: true, ResetDay: 15},
+		}
+
+		normalizeIncompleteFeatures(s)
+
+		yt := s.Realtime.SpeciesTracking.YearlyTracking
+		assert.Equal(t, DefaultYearlyTrackingResetMonth, yt.ResetMonth)
+		assert.Equal(t, 15, yt.ResetDay, "a reset day the user set must survive")
+		require.NoError(t, ValidateSettings(s))
+	})
+
+	t.Run("day missing, month kept", func(t *testing.T) {
+		t.Parallel()
+		s := createMinimalValidSettings()
+		s.Realtime.SpeciesTracking = SpeciesTrackingSettings{
+			Enabled:        true,
+			YearlyTracking: YearlyTrackingSettings{Enabled: true, ResetMonth: 9},
+		}
+
+		normalizeIncompleteFeatures(s)
+
+		yt := s.Realtime.SpeciesTracking.YearlyTracking
+		assert.Equal(t, 9, yt.ResetMonth, "a reset month the user set must survive")
+		assert.Equal(t, DefaultYearlyTrackingResetDay, yt.ResetDay)
+		require.NoError(t, ValidateSettings(s))
+	})
+}
+
+// TestNormalizeAudioExport_AppliesDefaults covers the section users hand-edit most,
+// where viper drops a nested default whenever the parent key is present.
+func TestNormalizeAudioExport_AppliesDefaults(t *testing.T) {
+	t.Parallel()
+
+	s := createMinimalValidSettings()
+	s.Realtime.Audio.Export = ExportSettings{
+		Enabled:       true,
+		Type:          AudioExportTypeOPUS,
+		Normalization: NormalizationSettings{Enabled: true},
+	}
+	s.Realtime.Audio.Export.Retention = RetentionSettings{Policy: RetentionPolicyAge}
+
+	normalizeIncompleteFeatures(s)
+
+	export := s.Realtime.Audio.Export
+	assert.Equal(t, DefaultAudioExportLength, export.Length)
+	assert.Equal(t, DefaultAudioExportBitrate, export.Bitrate)
+	assert.InDelta(t, DefaultNormalizationTargetLUFS, export.Normalization.TargetLUFS, 0.0001)
+	assert.Equal(t, DefaultRetentionMaxAge, export.Retention.MaxAge)
+	require.NoError(t, ValidateSettings(s))
+}
+
+// TestValidateNotificationSettings_IgnoresDisabledUnknownProvider verifies that a
+// leftover provider entry with a type this build no longer knows does not block
+// startup while it is switched off.
+func TestValidateNotificationSettings_IgnoresDisabledUnknownProvider(t *testing.T) {
+	t.Parallel()
+
+	n := &NotificationConfig{}
+	n.Push.Enabled = true
+	n.Push.Providers = []PushProviderConfig{{Name: "legacy", Enabled: false, Type: "pushover"}}
+
+	assert.NoError(t, validateNotificationSettings(n))
+}
+
+// TestNormalizeRealtimeFeatures_AppliesDefaults verifies that an interval or window
+// left at zero gets the documented default. Zero never means "no window" for any of
+// these, so the alternative is refusing to start over a field the user never saw.
+func TestNormalizeRealtimeFeatures_AppliesDefaults(t *testing.T) {
+	t.Parallel()
+
+	s := createMinimalValidSettings()
+	s.Realtime.Audio.SoundLevel = SoundLevelSettings{Enabled: true}
+	s.Realtime.DynamicThreshold = DynamicThresholdSettings{Enabled: true, Trigger: 0.9, Min: 0.2}
+	s.Realtime.SpeciesTracking = SpeciesTrackingSettings{
+		Enabled:          true,
+		YearlyTracking:   YearlyTrackingSettings{Enabled: true},
+		SeasonalTracking: SeasonalTrackingSettings{Enabled: true, Seasons: map[string]Season{"spring": {StartMonth: 3, StartDay: 20}}},
+	}
+
+	normalizeIncompleteFeatures(s)
+
+	assert.Equal(t, DefaultSoundLevelInterval, s.Realtime.Audio.SoundLevel.Interval)
+	assert.Equal(t, DefaultDynamicThresholdValidHours, s.Realtime.DynamicThreshold.ValidHours)
+	assert.Equal(t, DefaultNewSpeciesWindowDays, s.Realtime.SpeciesTracking.NewSpeciesWindowDays)
+	assert.Equal(t, DefaultSpeciesSyncIntervalMinutes, s.Realtime.SpeciesTracking.SyncIntervalMinutes)
+	assert.Equal(t, DefaultYearlyTrackingResetMonth, s.Realtime.SpeciesTracking.YearlyTracking.ResetMonth)
+	assert.Equal(t, DefaultYearlyTrackingResetDay, s.Realtime.SpeciesTracking.YearlyTracking.ResetDay)
+	assert.Equal(t, DefaultYearlyTrackingWindowDays, s.Realtime.SpeciesTracking.YearlyTracking.WindowDays)
+	assert.Equal(t, DefaultSeasonalTrackingWindowDays, s.Realtime.SpeciesTracking.SeasonalTracking.WindowDays)
+	require.NoError(t, ValidateSettings(s))
+}
+
+// TestNormalizeRealtimeFeatures_KeepsExplicitOutOfRangeFatal guards the boundary
+// between "never written" and "written wrongly".
+func TestNormalizeRealtimeFeatures_KeepsExplicitOutOfRangeFatal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		apply       func(s *Settings)
+		expectError string
+	}{
+		{
+			expectError: "sound level interval must be at least",
+			name:        "sound level interval below the CPU floor",
+			apply: func(s *Settings) {
+				s.Realtime.Audio.SoundLevel = SoundLevelSettings{Enabled: true, Interval: MinSoundLevelInterval - 1}
+			},
+		},
+		{
+			expectError: "dynamic threshold validHours must be positive",
+			name:        "negative dynamic threshold validHours",
+			apply: func(s *Settings) {
+				s.Realtime.DynamicThreshold = DynamicThresholdSettings{Enabled: true, Trigger: 0.9, Min: 0.2, ValidHours: -1}
+			},
+		},
+		{
+			expectError: "species tracking window days must be between",
+			name:        "species tracking window out of range",
+			apply: func(s *Settings) {
+				s.Realtime.SpeciesTracking = SpeciesTrackingSettings{
+					Enabled: true, NewSpeciesWindowDays: 400, SyncIntervalMinutes: 60,
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := createMinimalValidSettings()
+			tt.apply(s)
+
+			normalizeIncompleteFeatures(s)
+
+			err := ValidateSettings(s)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectError)
+		})
+	}
+}
+
+// TestNormalizeRealtimeFeatures_FillsMissingSeasons verifies that an empty season
+// map is populated from the configured latitude rather than used as a reason to
+// switch seasonal tracking off. Disabling would also remove the repair Load already
+// performs after validation, since that is gated on the feature being enabled.
+func TestNormalizeRealtimeFeatures_FillsMissingSeasons(t *testing.T) {
+	t.Parallel()
+
+	s := createMinimalValidSettings()
+	s.BirdNET.Latitude = -33.9 // southern hemisphere, so the defaults are not the northern ones
+	s.Realtime.SpeciesTracking = SpeciesTrackingSettings{
+		Enabled:          true,
+		SeasonalTracking: SeasonalTrackingSettings{Enabled: true},
+	}
+
+	normalizeIncompleteFeatures(s)
+
+	seasonal := s.Realtime.SpeciesTracking.SeasonalTracking
+	assert.True(t, seasonal.Enabled, "seasonal tracking must stay on")
+	assert.Equal(t, GetDefaultSeasons(-33.9), seasonal.Seasons)
+	assert.Contains(t, warningsText(s), "no seasons are defined")
+	require.NoError(t, ValidateSettings(s))
+}
+
+// TestRecordValidationWarning_Deduplicates verifies that repeated normalization of
+// an unfixed configuration cannot grow the warning slice without bound.
+func TestRecordValidationWarning_Deduplicates(t *testing.T) {
+	t.Parallel()
+
+	s := createMinimalValidSettings()
+	s.Realtime.MQTT = MQTTSettings{Enabled: true, Topic: "birdnet"}
+
+	normalizeIncompleteFeatures(s)
+	s.Realtime.MQTT.Enabled = true
+	normalizeIncompleteFeatures(s)
+
+	assert.Len(t, s.ValidationWarnings, 1)
+}
+
+// TestLoad_AcceptsPreviouslyRejectedConfig is the regression for the reported
+// failure, exercised through the path the server actually takes. This config.yaml
+// produced four fatal errors at once, so conf.Load returned an error, main exited
+// 1, and the service restarted forever with no UI in which to correct any of them.
+// Every one of the four settings is switched on and unfinished, none can affect
+// analysis, and together they must no longer stop the server from starting.
+//
+// Not parallel: Load mutates ConfigPath, viper, and the published settings.
+func TestLoad_AcceptsPreviouslyRejectedConfig(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	// 1. OAuth providers toggled on with no credentials and no host or baseUrl.
+	// 2. Stream quiet hours enabled with an unset mode and empty times.
+	// 3. BirdWeather enabled with no station ID.
+	// 4. Two global equalizer filters with no Q factor.
+	configYAML := `
+security:
+  host: ""
+  baseurl: ""
+  googleauth:
+    enabled: true
+    clientid: ""
+    clientsecret: ""
+  githubauth:
+    enabled: true
+    clientid: ""
+    clientsecret: ""
+realtime:
+  birdweather:
+    enabled: true
+    id: ""
+  rtsp:
+    streams:
+      - name: "Sound Card 1"
+        url: "rtsp://192.168.1.10/stream"
+        type: "rtsp"
+        quietHours:
+          enabled: true
+          mode: ""
+          startTime: ""
+          endTime: ""
+  audio:
+    equalizer:
+      enabled: true
+      filters:
+        - type: "LowPass"
+          frequency: 15000
+          q: 0
+        - type: "HighPass"
+          frequency: 100
+          q: 0
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(configYAML), 0o600))
+
+	oldPath := ConfigPath
+	oldSettings := GetSettings()
+	t.Cleanup(func() {
+		ConfigPath = oldPath
+		viper.Reset()
+		StoreSettings(oldSettings)
+	})
+	// Reset viper before loading: initViper does not clear it, so a viper.Set
+	// override left by an earlier sequential test would outrank the config file and
+	// this test would pass or fail for a reason that has nothing to do with it.
+	viper.Reset()
+	ConfigPath = configPath
+
+	settings, err := Load()
+	require.NoError(t, err, "a config with only inert half-configured features must load")
+
+	// Each feature is off or defaulted rather than left silently half-on.
+	assert.Empty(t, settings.GetEnabledOAuthProviders(),
+		"OAuth providers without credentials must not be consulted")
+	require.Len(t, settings.Realtime.RTSP.Streams, 1)
+	assert.False(t, settings.Realtime.RTSP.Streams[0].QuietHours.Enabled)
+	assert.False(t, settings.Realtime.Birdweather.Enabled)
+	require.Len(t, settings.Realtime.Audio.Equalizer.Filters, 2)
+	assert.InDelta(t, DefaultEQQFactor, settings.Realtime.Audio.Equalizer.Filters[0].Q, 0.0001)
+	assert.InDelta(t, DefaultEQQFactor, settings.Realtime.Audio.Equalizer.Filters[1].Q, 0.0001)
+
+	// And the user is told about all four, on the channel main.go forwards to
+	// telemetry and the notification centre.
+	warnings := warningsText(settings)
+	assert.Contains(t, warnings, "security.googleauth")
+	assert.Contains(t, warnings, "quiet hours")
+	assert.Contains(t, warnings, "BirdWeather")
+	assert.Contains(t, warnings, "Q factor")
+}

--- a/internal/conf/validate_security.go
+++ b/internal/conf/validate_security.go
@@ -11,20 +11,27 @@ import (
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
-// validateSecuritySettings validates the security-specific settings
-func validateSecuritySettings(settings *Security) error {
-	// Check if any OAuth provider is enabled (OAuth providers require host or baseUrl for redirect URLs)
-	// Note: BasicAuth doesn't require host as it doesn't use OAuth redirects
-	if (settings.GoogleAuth.Enabled || settings.GithubAuth.Enabled || settings.MicrosoftAuth.Enabled) && settings.Host == "" && settings.BaseURL == "" {
-		return errors.Newf("security.host or security.baseUrl must be set when using OAuth authentication providers (Google, GitHub, or Microsoft)").
-			Category(errors.CategoryValidation).
-			Context("validation_type", "security-oauth-host").
-			Context("google_enabled", settings.GoogleAuth.Enabled).
-			Context("github_enabled", settings.GithubAuth.Enabled).
-			Context("microsoft_enabled", settings.MicrosoftAuth.Enabled).
-			Build()
-	}
+// Provider IDs used in security.oauthProviders, and by the deprecated
+// googleAuth/githubAuth/microsoftAuth blocks that MigrateOAuthConfig converts into
+// it. These must stay equal to the values internal/security dispatches on
+// (ConfigGoogle, ConfigGitHub, ConfigMicrosoft, ConfigOIDC in
+// internal/security/constants.go). They are duplicated rather than shared because
+// security imports conf, so the dependency cannot run the other way.
+const (
+	providerGoogle    = "google"
+	providerGitHub    = "github"
+	providerMicrosoft = "microsoft"
+	providerOIDC      = "oidc"
+)
 
+// validateSecuritySettings validates the security-specific settings.
+//
+// A social provider that is enabled but cannot complete a sign-in no longer blocks
+// startup: normalizeIncompleteFeatures disables the ones the runtime already
+// ignores and warns about the rest, because the alternative is a server that will
+// not boot and therefore serves no UI in which to fix the provider. OIDC is the
+// exception, and validateOIDCProviders explains why.
+func validateSecuritySettings(settings *Security) error {
 	// TLS mode validation
 	if err := validateTLSMode(settings); err != nil {
 		return err
@@ -133,42 +140,64 @@ func validateTLSMode(settings *Security) error {
 	return nil
 }
 
-// validateOIDCProviders validates OIDC-specific provider configuration:
-// at most one OIDC entry, valid issuer URL when enabled, callback URL source required, HTTPS warning.
+// validateOIDCProviders validates OIDC-specific provider configuration.
+//
+// Only a duplicate among ENABLED entries is fatal on that count: two of those make
+// it ambiguous which one a sign-in would use, because goth registers providers by
+// name and the second silently replaces the first. A disabled second entry never
+// reaches goth (GetEnabledOAuthProviders and initializeProviders both skip it), so
+// refusing to start over a leftover is the failure this whole change exists to
+// remove.
+//
+// An unusable issuer URL, and a provider with no way back from the identity
+// provider, both stay fatal. That is worth spelling out because the rest of this
+// change moves in the other direction. Enabling OIDC is the setting that can lock
+// an operator out of their own instance: the provider counts towards
+// IsAuthenticationEnabled as soon as it has credentials, so accepting either shape
+// means authentication becomes required while no sign-in can complete. The settings
+// API validates without normalizing, so keeping these rules here is what answers
+// that save with an error instead of a 200 and a locked door.
+//
+// The load path pays for that: an OIDC provider with credentials and a broken
+// issuer still refuses to boot. The trade is deliberate. A provider merely toggled
+// on has no credentials, so normalizeIncompleteFeatures disables it before this
+// runs and the common case never reaches here; what remains is a provider someone
+// deliberately configured, where booting into a locked door is worse than saying
+// which field is wrong.
 func validateOIDCProviders(settings *Security) error {
 	oidcCount := 0
 	for i := range settings.OAuthProviders {
 		provider := &settings.OAuthProviders[i]
-		if provider.Provider != "oidc" {
+		if provider.Provider != providerOIDC || !provider.Enabled {
 			continue
 		}
 		oidcCount++
 		if oidcCount > 1 {
-			return errors.Newf("only one OIDC provider (provider: \"oidc\") is allowed in security.oauthProviders, found duplicate entry").
+			return errors.Newf("only one enabled OIDC provider (provider: %q) is allowed in security.oauthProviders, found duplicate entry", providerOIDC).
 				Category(errors.CategoryValidation).
 				Context("validation_type", "security-oidc-duplicate").
 				Build()
 		}
-		if !provider.Enabled {
-			continue
-		}
-		// Require a callback URL source — without host/baseUrl/redirectUri, the OAuth flow will fail
-		if provider.RedirectURI == "" && settings.Host == "" && settings.BaseURL == "" {
-			return errors.Newf("security.host or security.baseUrl must be set, or redirectUri must be configured, when OIDC provider is enabled").
+		// A provider with no way back from the identity provider is the same
+		// lock-out as a broken issuer, so it is fatal for the same reason. Scoped to
+		// OIDC because that is where the rule already existed; the array-based
+		// social providers never had one, and adding it here would newly reject
+		// configurations that load today.
+		if reason := oauthRedirectProblem(provider, settings.Host != "" || settings.BaseURL != ""); reason != "" {
+			return errors.Newf("security.oauthProviders: OIDC provider is enabled but %s", reason).
 				Category(errors.CategoryValidation).
 				Context("validation_type", "security-oidc-redirect-missing").
-				Context("issuer_url", provider.IssuerURL).
 				Build()
 		}
 		if provider.IssuerURL == "" {
-			return errors.Newf("security.oauthProviders: issuerUrl is required when provider is \"oidc\" and enabled").
+			return errors.Newf("security.oauthProviders: issuerUrl is required when provider is %q and enabled", providerOIDC).
 				Category(errors.CategoryValidation).
 				Context("validation_type", "security-oidc-issuer-missing").
 				Build()
 		}
 		parsed, err := url.Parse(provider.IssuerURL)
 		if err != nil || parsed.Host == "" || (parsed.Scheme != SchemeHTTPS && parsed.Scheme != SchemeHTTP) {
-			return errors.Newf("security.oauthProviders: issuerUrl %q is not a valid URL", provider.IssuerURL).
+			return errors.Newf("security.oauthProviders: issuerUrl %q is not a valid http(s) URL", provider.IssuerURL).
 				Category(errors.CategoryValidation).
 				Context("validation_type", "security-oidc-issuer-invalid").
 				Context("issuer_url", provider.IssuerURL).

--- a/internal/conf/validate_security.go
+++ b/internal/conf/validate_security.go
@@ -3,6 +3,7 @@
 package conf
 
 import (
+	"fmt"
 	"net"
 	"net/url"
 	"strings"
@@ -112,16 +113,59 @@ func validateSecuritySettings(settings *Security) error {
 // (see defaults.go), and MigrateOAuthConfig copies that into the array as-is, so a
 // migrated provider usually carries a non-empty but relative value that no OAuth
 // provider can redirect back to.
-func oauthRedirectProblem(p *OAuthProviderConfig, hasOrigin bool) string {
+//
+// originProblem describes the shared fallback, and is what a provider without its
+// own redirectUri inherits; see oauthOriginProblem.
+func oauthRedirectProblem(p *OAuthProviderConfig, originProblem string) string {
 	if p.RedirectURI == "" {
-		if hasOrigin {
-			return ""
-		}
-		return "no redirect URL can be built; set security.host or security.baseUrl, or security.oauthProviders[].redirectUri"
+		return originProblem
 	}
 	parsed, err := url.Parse(p.RedirectURI)
 	if err != nil || parsed.Host == "" || (parsed.Scheme != SchemeHTTPS && parsed.Scheme != SchemeHTTP) {
 		return "its redirectUri is not an absolute http(s) URL, so the provider has nowhere to send the user back to"
+	}
+	return ""
+}
+
+// oauthOriginProblem describes why security.host and security.baseUrl cannot
+// produce a redirect origin, or returns "" when they can.
+//
+// Presence is not enough: computeBaseURL returns baseUrl verbatim, so a value that
+// is not an absolute http(s) URL yields a callback the identity provider will
+// reject, which is the same lock-out as having no origin at all. baseUrl also wins
+// outright when set, so a valid host cannot rescue a malformed one.
+//
+// This mirrors computeBaseURL in internal/security/oauth.go, including its rule
+// that a host without a scheme is assumed to be https. The logic is duplicated
+// rather than shared for the same reason as the provider name constants above:
+// security imports conf, so the dependency cannot run the other way.
+//
+// A malformed baseUrl is only reported through this path, when a credentialed
+// provider actually depends on it. Rejecting one that nothing consumes would be the
+// kind of inert-config failure this pass exists to remove.
+func oauthOriginProblem(settings *Security) string {
+	var origin string
+	switch {
+	case settings.BaseURL != "":
+		origin = strings.TrimSuffix(settings.BaseURL, "/")
+	case settings.Host != "":
+		host := strings.TrimSuffix(settings.Host, "/")
+		if strings.HasPrefix(host, "http://") || strings.HasPrefix(host, "https://") {
+			origin = host
+		} else {
+			origin = "https://" + host
+		}
+	default:
+		return "no redirect URL can be built; set security.host or security.baseUrl, or security.oauthProviders[].redirectUri"
+	}
+
+	parsed, err := url.Parse(origin)
+	if err != nil || parsed.Host == "" || (parsed.Scheme != SchemeHTTPS && parsed.Scheme != SchemeHTTP) {
+		field := "security.host"
+		if settings.BaseURL != "" {
+			field = "security.baseUrl"
+		}
+		return fmt.Sprintf("%s does not form an absolute http(s) URL (%q), so no redirect URL can be built from it; fix it or set security.oauthProviders[].redirectUri", field, origin)
 	}
 	return ""
 }
@@ -147,13 +191,13 @@ func oauthRedirectProblem(p *OAuthProviderConfig, hasOrigin bool) string {
 // perfectly good absolute redirectUri. Only the absence of any usable redirect is
 // fatal here.
 func validateOAuthRedirects(settings *Security) error {
-	hasOrigin := settings.Host != "" || settings.BaseURL != ""
+	originProblem := oauthOriginProblem(settings)
 	for i := range settings.OAuthProviders {
 		provider := &settings.OAuthProviders[i]
 		if !provider.Enabled || provider.ClientID == "" || provider.ClientSecret == "" {
 			continue
 		}
-		if reason := oauthRedirectProblem(provider, hasOrigin); reason != "" {
+		if reason := oauthRedirectProblem(provider, originProblem); reason != "" {
 			return errors.Newf("security.oauthProviders: provider %q is enabled but %s", provider.Provider, reason).
 				Category(errors.CategoryValidation).
 				Context("validation_type", "security-oauth-redirect-missing").

--- a/internal/conf/validate_security.go
+++ b/internal/conf/validate_security.go
@@ -26,11 +26,12 @@ const (
 
 // validateSecuritySettings validates the security-specific settings.
 //
-// A social provider that is enabled but cannot complete a sign-in no longer blocks
-// startup: normalizeIncompleteFeatures disables the ones the runtime already
-// ignores and warns about the rest, because the alternative is a server that will
-// not boot and therefore serves no UI in which to fix the provider. OIDC is the
-// exception, and validateOIDCProviders explains why.
+// A provider that is enabled but merely unfinished no longer blocks startup:
+// normalizeIncompleteFeatures disables the ones the runtime already ignores,
+// because the alternative is a server that will not boot and therefore serves no
+// UI in which to fix the provider. The exception is a provider that can still
+// force authentication on while being unable to complete a sign-in; see
+// validateOAuthRedirects and validateOIDCProviders.
 func validateSecuritySettings(settings *Security) error {
 	// TLS mode validation
 	if err := validateTLSMode(settings); err != nil {
@@ -86,11 +87,80 @@ func validateSecuritySettings(settings *Security) error {
 		settings.SessionDuration = DefaultSessionDuration // 7 days, matches viper default
 	}
 
+	// Reject providers that would force authentication on without being able to
+	// complete a sign-in. Runs before validateOIDCProviders so that the reason an
+	// operator cannot get in is reported ahead of the OIDC-only issuer rules.
+	if err := validateOAuthRedirects(settings); err != nil {
+		return err
+	}
+
 	// Validate OIDC provider configuration
 	if err := validateOIDCProviders(settings); err != nil {
 		return err
 	}
 
+	return nil
+}
+
+// oauthRedirectProblem describes why a provider has no usable redirect URL, or
+// returns "" when it has one. It mirrors what initializeProviders actually
+// computes: an explicit redirectUri is used verbatim, and only an absent one is
+// built from security.host or security.baseUrl.
+//
+// Testing merely for an empty redirectUri would miss the common case. The
+// deprecated googleAuth and githubAuth blocks default redirecturi to "/settings"
+// (see defaults.go), and MigrateOAuthConfig copies that into the array as-is, so a
+// migrated provider usually carries a non-empty but relative value that no OAuth
+// provider can redirect back to.
+func oauthRedirectProblem(p *OAuthProviderConfig, hasOrigin bool) string {
+	if p.RedirectURI == "" {
+		if hasOrigin {
+			return ""
+		}
+		return "no redirect URL can be built; set security.host or security.baseUrl, or security.oauthProviders[].redirectUri"
+	}
+	parsed, err := url.Parse(p.RedirectURI)
+	if err != nil || parsed.Host == "" || (parsed.Scheme != SchemeHTTPS && parsed.Scheme != SchemeHTTP) {
+		return "its redirectUri is not an absolute http(s) URL, so the provider has nowhere to send the user back to"
+	}
+	return ""
+}
+
+// validateOAuthRedirects rejects an enabled OAuth provider that has credentials but
+// no usable redirect URL, for every provider kind.
+//
+// This is the one shape that the rest of this change cannot afford to downgrade to
+// a warning. Credentials are what make a provider count towards
+// IsAuthenticationEnabled (see GetEnabledOAuthProviders), so such an entry makes
+// authentication mandatory, while initializeProviders still registers it with a
+// redirect the identity provider will reject. The result is an instance nobody can
+// sign in to, and the notification that reports the problem lives behind the very
+// login that cannot complete. Refusing to boot at least names the field.
+//
+// The credentials guard is what keeps this consistent with the rest of the pass: a
+// provider merely toggled on cannot sign anyone in either, but it also does not
+// make authentication required, so it is inert and normalizeOAuthProviders just
+// disables it.
+//
+// This deliberately does not restore the deleted security-oauth-host rule, which
+// demanded security.host or security.baseUrl even from a provider carrying a
+// perfectly good absolute redirectUri. Only the absence of any usable redirect is
+// fatal here.
+func validateOAuthRedirects(settings *Security) error {
+	hasOrigin := settings.Host != "" || settings.BaseURL != ""
+	for i := range settings.OAuthProviders {
+		provider := &settings.OAuthProviders[i]
+		if !provider.Enabled || provider.ClientID == "" || provider.ClientSecret == "" {
+			continue
+		}
+		if reason := oauthRedirectProblem(provider, hasOrigin); reason != "" {
+			return errors.Newf("security.oauthProviders: provider %q is enabled but %s", provider.Provider, reason).
+				Category(errors.CategoryValidation).
+				Context("validation_type", "security-oauth-redirect-missing").
+				Context("provider", provider.Provider).
+				Build()
+		}
+	}
 	return nil
 }
 
@@ -149,14 +219,17 @@ func validateTLSMode(settings *Security) error {
 // refusing to start over a leftover is the failure this whole change exists to
 // remove.
 //
-// An unusable issuer URL, and a provider with no way back from the identity
-// provider, both stay fatal. That is worth spelling out because the rest of this
-// change moves in the other direction. Enabling OIDC is the setting that can lock
-// an operator out of their own instance: the provider counts towards
-// IsAuthenticationEnabled as soon as it has credentials, so accepting either shape
-// means authentication becomes required while no sign-in can complete. The settings
-// API validates without normalizing, so keeping these rules here is what answers
-// that save with an error instead of a 200 and a locked door.
+// An unusable issuer URL stays fatal. That is worth spelling out because the rest
+// of this change moves in the other direction. Enabling OIDC is the setting that
+// can lock an operator out of their own instance: the provider counts towards
+// IsAuthenticationEnabled as soon as it has credentials, so accepting a broken
+// issuer means authentication becomes required while no sign-in can complete. The
+// settings API validates without normalizing, so keeping this rule here is what
+// answers that save with an error instead of a 200 and a locked door.
+//
+// The matching "no way back from the identity provider" rule used to live here too.
+// It now applies to every provider kind in validateOAuthRedirects, because the
+// lock-out it prevents was never specific to OIDC.
 //
 // The load path pays for that: an OIDC provider with credentials and a broken
 // issuer still refuses to boot. The trade is deliberate. A provider merely toggled
@@ -176,17 +249,6 @@ func validateOIDCProviders(settings *Security) error {
 			return errors.Newf("only one enabled OIDC provider (provider: %q) is allowed in security.oauthProviders, found duplicate entry", providerOIDC).
 				Category(errors.CategoryValidation).
 				Context("validation_type", "security-oidc-duplicate").
-				Build()
-		}
-		// A provider with no way back from the identity provider is the same
-		// lock-out as a broken issuer, so it is fatal for the same reason. Scoped to
-		// OIDC because that is where the rule already existed; the array-based
-		// social providers never had one, and adding it here would newly reject
-		// configurations that load today.
-		if reason := oauthRedirectProblem(provider, settings.Host != "" || settings.BaseURL != ""); reason != "" {
-			return errors.Newf("security.oauthProviders: OIDC provider is enabled but %s", reason).
-				Category(errors.CategoryValidation).
-				Context("validation_type", "security-oidc-redirect-missing").
 				Build()
 		}
 		if provider.IssuerURL == "" {

--- a/internal/conf/validate_security_oidc_test.go
+++ b/internal/conf/validate_security_oidc_test.go
@@ -8,6 +8,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestValidateSecuritySettings_OIDC covers the OIDC rules that block startup. An
+// unusable issuer URL and a missing redirect source both stay fatal, because
+// enabling OIDC is the setting that can lock an operator out: the provider counts
+// towards IsAuthenticationEnabled as soon as it has credentials, so accepting either
+// shape would make authentication required while no sign-in can complete. The
+// settings API validates without normalizing, so this is what answers such a save
+// with an error rather than a 200 and a locked door.
 func TestValidateSecuritySettings_OIDC(t *testing.T) {
 	t.Parallel()
 
@@ -84,6 +91,16 @@ func TestValidateSecuritySettings_OIDC(t *testing.T) {
 			errMsg:  "duplicate",
 		},
 		{
+			name: "one enabled and one disabled OIDC provider - should pass",
+			modify: func(s *Security) {
+				s.OAuthProviders = []OAuthProviderConfig{
+					{Provider: "oidc", Enabled: true, ClientID: "id1", ClientSecret: "secret1", IssuerURL: "https://idp1.example.com"},
+					{Provider: "oidc", Enabled: false, ClientID: "id2", ClientSecret: "secret2", IssuerURL: "https://idp2.example.com"},
+				}
+			},
+			wantErr: false,
+		},
+		{
 			name: "OIDC with HTTP issuerUrl - should pass with warning",
 			modify: func(s *Security) {
 				s.OAuthProviders = []OAuthProviderConfig{
@@ -112,7 +129,7 @@ func TestValidateSecuritySettings_OIDC(t *testing.T) {
 				}
 			},
 			wantErr: true,
-			errMsg:  "redirectUri",
+			errMsg:  "redirect URL",
 		},
 		{
 			name: "OIDC enabled with explicit redirectUri but no host - should pass",

--- a/internal/conf/validate_security_test.go
+++ b/internal/conf/validate_security_test.go
@@ -12,12 +12,13 @@ import (
 func TestValidateSecuritySettings_OAuth(t *testing.T) {
 	t.Parallel()
 
-	// validateSecuritySettings no longer carries an OAuth-specific rule. A provider
-	// that cannot complete a sign-in is reported by normalizeIncompleteFeatures on
-	// the load path, which this entry point does not run; see
-	// TestNormalizeOAuthProviders_LegacyCredentialedBlockWarnsAfterMigration for the
-	// behaviour that replaced the deleted host rule, and validateOIDCProviders for
-	// the one provider kind where an unusable configuration is still rejected here.
+	// The blunt security-oauth-host rule is gone: it rejected a provider carrying a
+	// perfectly good absolute redirectUri just because security.host was unset, and
+	// it only ever looked at the deprecated blocks. What replaced it is
+	// validateOAuthRedirects, which is narrower (only a missing usable redirect is
+	// fatal) and wider (every provider kind, via the migrated array). The cases below
+	// all supply an absolute redirectUri, so none of them is rejected here; see
+	// TestValidateOAuthRedirects_ScopedToLockOutShape for the boundary.
 	tests := []struct {
 		name     string
 		security Security

--- a/internal/conf/validate_security_test.go
+++ b/internal/conf/validate_security_test.go
@@ -12,6 +12,12 @@ import (
 func TestValidateSecuritySettings_OAuth(t *testing.T) {
 	t.Parallel()
 
+	// validateSecuritySettings no longer carries an OAuth-specific rule. A provider
+	// that cannot complete a sign-in is reported by normalizeIncompleteFeatures on
+	// the load path, which this entry point does not run; see
+	// TestNormalizeOAuthProviders_LegacyCredentialedBlockWarnsAfterMigration for the
+	// behaviour that replaced the deleted host rule, and validateOIDCProviders for
+	// the one provider kind where an unusable configuration is still rejected here.
 	tests := []struct {
 		name     string
 		security Security
@@ -19,7 +25,7 @@ func TestValidateSecuritySettings_OAuth(t *testing.T) {
 		errType  string
 	}{
 		{
-			name: "Google OAuth enabled without host - should fail",
+			name: "Google OAuth enabled without host - not rejected here",
 			security: Security{
 				Host: "",
 				GoogleAuth: SocialProvider{
@@ -29,11 +35,10 @@ func TestValidateSecuritySettings_OAuth(t *testing.T) {
 					RedirectURI:  "https://example.com/callback",
 				},
 			},
-			wantErr: true,
-			errType: "security-oauth-host",
+			wantErr: false,
 		},
 		{
-			name: "GitHub OAuth enabled without host - should fail",
+			name: "GitHub OAuth enabled without host - not rejected here",
 			security: Security{
 				Host: "",
 				GithubAuth: SocialProvider{
@@ -43,11 +48,10 @@ func TestValidateSecuritySettings_OAuth(t *testing.T) {
 					RedirectURI:  "https://example.com/callback",
 				},
 			},
-			wantErr: true,
-			errType: "security-oauth-host",
+			wantErr: false,
 		},
 		{
-			name: "Both OAuth providers enabled without host - should fail",
+			name: "Both OAuth providers enabled without host - not rejected here",
 			security: Security{
 				Host: "",
 				GoogleAuth: SocialProvider{
@@ -63,8 +67,7 @@ func TestValidateSecuritySettings_OAuth(t *testing.T) {
 					RedirectURI:  "https://example.com/github/callback",
 				},
 			},
-			wantErr: true,
-			errType: "security-oauth-host",
+			wantErr: false,
 		},
 		{
 			name: "Google OAuth enabled with valid host - should pass",

--- a/internal/conf/validate_services.go
+++ b/internal/conf/validate_services.go
@@ -15,6 +15,22 @@ import (
 	"github.com/tphakala/birdnet-go/internal/templatefuncs"
 )
 
+// Push notification provider types.
+const (
+	pushProviderScript   = "script"
+	pushProviderShoutrrr = "shoutrrr"
+	pushProviderWebhook  = "webhook"
+)
+
+// Webhook endpoint authentication types. An empty type is equivalent to
+// webhookAuthNone.
+const (
+	webhookAuthNone   = "none"
+	webhookAuthBearer = "bearer"
+	webhookAuthBasic  = "basic"
+	webhookAuthCustom = "custom"
+)
+
 // ValidateBirdNETSettings performs BirdNET validation without side effects.
 // Returns normalized settings and any errors/warnings.
 // This pure function enables testing without log output or settings mutation.
@@ -82,23 +98,29 @@ func ValidateBirdweatherSettings(settings *BirdweatherSettings) ValidationResult
 	if settings == nil {
 		return ValidationResult{Valid: false, Errors: []string{"Birdweather settings is nil"}}
 	}
-	result := ValidationResult{Valid: true, Warnings: []string{}}
+	result := ValidationResult{Valid: true}
 	normalized := *settings
 
 	if settings.Enabled {
-		// Check if ID is provided when enabled
-		if settings.ID == "" {
+		// An unusable station ID is an error here and only an error. It used to be
+		// reported as an error AND as a "will be disabled" warning that cleared
+		// Enabled on the normalized copy, which meant one condition carried two
+		// contradictory severities: the config was rejected, and the rejection
+		// claimed the integration had been switched off instead.
+		//
+		// The graceful half now lives in normalizeIncompleteFeatures, which runs
+		// before this validator on the load path and clears Enabled, so an aged
+		// config file no longer blocks startup. Keeping the error is what stops the
+		// settings API from accepting a bad ID, silently switching BirdWeather off
+		// and saving that back over the user's own toggle.
+		switch {
+		case settings.ID == "":
 			result.Valid = false
 			result.Errors = append(result.Errors, "Birdweather ID is required when enabled")
-			// Suggest disabling
-			normalized.Enabled = false
-			result.Warnings = append(result.Warnings, "Birdweather will be disabled due to missing ID")
-		} else if !birdweatherIDPattern.MatchString(settings.ID) {
+		case !birdweatherIDPattern.MatchString(settings.ID):
 			// Validate Birdweather ID format using precompiled regex
 			result.Valid = false
 			result.Errors = append(result.Errors, "Invalid Birdweather ID format: must be 24 alphanumeric characters")
-			normalized.Enabled = false
-			result.Warnings = append(result.Warnings, "Birdweather will be disabled due to invalid ID format")
 		}
 
 		checkRange(&result, settings.Threshold, 0, 1, "birdweather threshold must be between 0 and 1")
@@ -462,11 +484,6 @@ func validateBirdweatherSettings(settings *BirdweatherSettings) error {
 	}
 	*settings = *normalized
 
-	// Handle warnings (side effect: logging)
-	for _, warning := range result.Warnings {
-		GetLogger().Warn("Birdweather validation warning", logger.String("message", warning))
-	}
-
 	// Return errors if validation failed
 	if !result.Valid {
 		// Join errors for backward compatibility
@@ -501,15 +518,15 @@ func validateNotificationSettings(n *NotificationConfig) error {
 		p := &n.Push.Providers[i]
 		ptype := strings.ToLower(p.Type)
 		switch ptype {
-		case "script":
-			if p.Enabled && strings.TrimSpace(p.Command) == "" {
+		case pushProviderScript:
+			if p.Enabled && pushProviderProblem(p) != "" {
 				return errors.Newf("script provider requires command when enabled").
 					Category(errors.CategoryValidation).
 					Context("validation_type", "notification-push-script-command").
 					Build()
 			}
-		case "shoutrrr":
-			if p.Enabled && len(p.URLs) == 0 {
+		case pushProviderShoutrrr:
+			if p.Enabled && pushProviderProblem(p) != "" {
 				return errors.Newf("shoutrrr provider requires at least one URL when enabled").
 					Category(errors.CategoryValidation).
 					Context("validation_type", "notification-push-shoutrrr-urls").
@@ -517,11 +534,17 @@ func validateNotificationSettings(n *NotificationConfig) error {
 			}
 			// Normalize ntfy URLs: ntfy://topic -> ntfy://ntfy.sh/topic
 			normalizeNtfyURLs(p)
-		case "webhook":
+		case pushProviderWebhook:
 			if err := validateWebhookProvider(p); err != nil {
 				return err
 			}
 		default:
+			// Only reject an unrecognised type on a provider that is switched on.
+			// A disabled leftover entry (an older type name, or a half-created
+			// provider) sends nothing, so it is not a reason to refuse to start.
+			if !p.Enabled {
+				continue
+			}
 			return errors.Newf("unknown push provider type: %s", p.Type).
 				Category(errors.CategoryValidation).
 				Context("validation_type", "notification-push-provider-type").
@@ -572,55 +595,19 @@ func validateWebhookAuth(auth *WebhookAuthConfig, providerName string, endpointI
 	authType := strings.ToLower(auth.Type)
 
 	// Empty auth type defaults to "none" - this is valid
-	if authType == "" || authType == "none" { //nolint:goconst // auth-type value, not the RetentionPolicyNone constant
+	if authType == "" || authType == webhookAuthNone {
 		return nil
 	}
 
 	switch authType {
-	case "bearer":
-		// At least one of token or token_file must be provided
-		if strings.TrimSpace(auth.Token) == "" && strings.TrimSpace(auth.TokenFile) == "" {
-			return errors.Newf("webhook provider '%s' endpoint %d: bearer auth requires token or token_file", providerName, endpointIndex).
+	case webhookAuthBearer, webhookAuthBasic, webhookAuthCustom:
+		// Which credential each auth type needs is defined once, in
+		// missingWebhookAuthSecret, so this rule and the normalization pass that
+		// disables an unusable provider cannot drift apart.
+		if reason := missingWebhookAuthSecret(auth); reason != "" {
+			return errors.Newf("webhook provider '%s' endpoint %d: %s auth requires a credential, %s", providerName, endpointIndex, authType, reason).
 				Category(errors.CategoryValidation).
-				Context("validation_type", "notification-push-webhook-auth-bearer").
-				Context("provider_name", providerName).
-				Context("endpoint_index", endpointIndex).
-				Build()
-		}
-	case "basic":
-		// Check user/user_file
-		if strings.TrimSpace(auth.User) == "" && strings.TrimSpace(auth.UserFile) == "" {
-			return errors.Newf("webhook provider '%s' endpoint %d: basic auth requires user or user_file", providerName, endpointIndex).
-				Category(errors.CategoryValidation).
-				Context("validation_type", "notification-push-webhook-auth-basic").
-				Context("provider_name", providerName).
-				Context("endpoint_index", endpointIndex).
-				Build()
-		}
-		// Check pass/pass_file
-		if strings.TrimSpace(auth.Pass) == "" && strings.TrimSpace(auth.PassFile) == "" {
-			return errors.Newf("webhook provider '%s' endpoint %d: basic auth requires pass or pass_file", providerName, endpointIndex).
-				Category(errors.CategoryValidation).
-				Context("validation_type", "notification-push-webhook-auth-basic").
-				Context("provider_name", providerName).
-				Context("endpoint_index", endpointIndex).
-				Build()
-		}
-	case "custom":
-		// Header name is always required (no file variant)
-		if strings.TrimSpace(auth.Header) == "" {
-			return errors.Newf("webhook provider '%s' endpoint %d: custom auth requires header", providerName, endpointIndex).
-				Category(errors.CategoryValidation).
-				Context("validation_type", "notification-push-webhook-auth-custom").
-				Context("provider_name", providerName).
-				Context("endpoint_index", endpointIndex).
-				Build()
-		}
-		// Check value/value_file
-		if strings.TrimSpace(auth.Value) == "" && strings.TrimSpace(auth.ValueFile) == "" {
-			return errors.Newf("webhook provider '%s' endpoint %d: custom auth requires value or value_file", providerName, endpointIndex).
-				Category(errors.CategoryValidation).
-				Context("validation_type", "notification-push-webhook-auth-custom").
+				Context("validation_type", "notification-push-webhook-auth-"+authType).
 				Context("provider_name", providerName).
 				Context("endpoint_index", endpointIndex).
 				Build()

--- a/main.go
+++ b/main.go
@@ -21,9 +21,27 @@ import (
 	"github.com/tphakala/birdnet-go/internal/health"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/notification"
 	"github.com/tphakala/birdnet-go/internal/restart"
 	"github.com/tphakala/birdnet-go/internal/telemetry"
 )
+
+// fallbackWarningComponent labels a validation warning that was recorded without
+// the "component: message" prefix conf.recordValidationWarning produces.
+const fallbackWarningComponent = "config"
+
+// splitValidationWarning separates a validation warning into its component and its
+// message. Every producer goes through conf.recordValidationWarning, which always
+// prefixes, so the fallback is defence rather than a live path: an unprefixed entry
+// used to be discarded here, which meant it reached neither telemetry nor the user,
+// and a future producer that forgets the prefix should be reported whole rather than
+// silently dropped again.
+func splitValidationWarning(warning string) (component, message string) {
+	if component, message, found := strings.Cut(warning, ": "); found {
+		return component, message
+	}
+	return fallbackWarningComponent, warning
+}
 
 // buildTime is the time when the binary was built.
 var buildDate string
@@ -195,15 +213,19 @@ func mainWithExitCode() int {
 		mainLog.Debug("Runtime profiling enabled (mutex and block profiling active)")
 	}
 
-	// Process configuration validation warnings that occurred before Sentry initialization
+	// Process configuration validation warnings that occurred before Sentry initialization.
+	//
+	// These are settings that were switched on but never finished, which the config
+	// loader disabled or defaulted instead of refusing to start. Sentry only sees
+	// them when telemetry is enabled, and the field is cleared below, so without a
+	// notification the user's only clue that a feature stopped working would be a
+	// line in the log they will never read. Both core systems are initialized by
+	// this point; NotifyWarning is a no-op if they are not.
 	if len(settings.ValidationWarnings) > 0 {
 		for _, warning := range settings.ValidationWarnings {
-			parts := strings.SplitN(warning, ": ", 2)
-			if len(parts) == 2 {
-				component := parts[0]
-				message := parts[1]
-				telemetry.CaptureMessage(message, sentry.LevelWarning, component)
-			}
+			component, message := splitValidationWarning(warning)
+			telemetry.CaptureMessage(message, sentry.LevelWarning, component)
+			notification.NotifyWarning(component, "Configuration Problem", message)
 		}
 		// Clear the warnings as they've been processed
 		settings.ValidationWarnings = nil


### PR DESCRIPTION
## What

Config validation treated a feature that is switched on but never finished configuring as a fatal error. `conf.Load` rejected the file, `main` exited 1, and the service restarted forever, so the web UI that would let the user undo the toggle was gone too. On a headless Pi that is a brick until someone SSHes in and edits YAML.

I hit this on a test box whose `config.yaml` had aged across upgrades. Four independent rejections in one startup, none of which could affect analysis or safety:

```
Validation errors: [security.host or security.baseUrl must be set when using OAuth authentication
providers stream 1: stream 'Sound Card 1': quiet hours mode must be 'fixed' or 'solar', got ''
Birdweather ID is required when enabled global equalizer: filter 1 has invalid Q factor 0.0000]
```

## How

A new pass, `normalizeIncompleteFeatures` (`internal/conf/validate_incomplete.go`), runs inside `conf.Load` just before validation and resolves those configurations the way the running system already treats them:

- a required string left empty means the feature was never configured, so the feature is disabled (or the documented default is bound when there is one)
- a required number left at zero means the field was never written, so the documented default is applied
- a value the running system already ignores (an unrecognised quiet hours mode, solar event, or push provider type) is resolved the way the runtime resolves it, which is to switch the feature off
- anything else explicitly wrong (negative, out of range, an unparsable number, NaN/Inf) is untouched and still fatal

Because most fatal rules are already written as `if feature.Enabled`, disabling the feature makes them unreachable without weakening them.

It is called from `Load` and not from `ValidateSettings` on purpose. Leniency is wanted when reading a config file that aged into this state, where the only alternative is a boot loop, and not wanted when the settings API validates an update: there the strict rules still apply, so a half-finished section from the UI is answered with an error the user can act on instead of being silently turned off and saved.

## Per-rule reasoning

| Rule | Before | Now | Why |
|---|---|---|---|
| OAuth provider enabled without clientId/clientSecret | fatal | disabled, warn | `GetEnabledOAuthProviders` and `initializeProviders` already require both, so the provider was never consulted; clearing `Enabled` only makes the stored state honest |
| Social provider enabled, credentialed, no usable redirect URL | fatal | warn, stays enabled | disabling would drop authentication from a server the operator meant to protect; sign-in fails but the server stays closed |
| Deprecated `googleAuth`/`githubAuth`/`microsoftAuth` enabled but not migrated | fatal | warn | `MigrateOAuthConfig` skips the migration entirely when the array is non-empty, and `migrateLegacyProvider` skips a block with no clientId, so nothing at runtime reads them |
| OIDC issuerUrl missing or malformed, or no usable redirect URL | fatal | **still fatal** | with credentials present the provider makes authentication *required* while no sign-in can complete, so accepting it locks the operator out. The settings API validates without normalizing, so this is what answers such a save with an error rather than a 200 and a locked door |
| Duplicate OIDC providers | fatal for any pair | fatal for enabled pairs | a disabled second entry never reaches goth, so a leftover is not a reason to refuse to start |
| Quiet hours enabled with unset/unknown mode, unparsable times, or unknown solar events | fatal | disabled, warn | `isInQuietHours` already returns false for all of these; the solar case is worse than inert, since an unknown event yields a zero-time window |
| Quiet hours offset outside ±180 | fatal | fatal | zero is a legal offset, so an out-of-range value was typed on purpose and it shifts a real window |
| BirdWeather enabled with missing/malformed ID | fatal **and** warn, from one condition | disabled + warn on load; still fatal on the settings API | the condition carried two contradictory severities at once. The graceful half moved to the normalization pass, which runs first on the load path, so the file no longer blocks startup. Keeping the error is what stops the API accepting a bad ID, silently switching BirdWeather off, and saving that over the user's own toggle |
| Equalizer filter with `q: 0` | fatal | default 0.707 | zero is the never-written value, and `NewLowPass` computes `sin(w0)/(2*q)` unguarded, so zero must never reach the biquad. Applied whether or not the equalizer is enabled, so a later enable is not rejected over a field the UI never offered; reported only for the filter types that actually read Q, since `BandPass`/`BandReject`/`Peaking` take a bandwidth and ignore it |
| Any other invalid Q, or any invalid frequency | fatal | fatal | frequency is the sharpest case: zero makes `w0` zero, which zeroes the whole numerator, so a `LowPass` at frequency 0 outputs **silence** rather than doing nothing |
| Filters under a disabled equalizer | fatal | not validated | `BuildFilterChain` returns nil for a disabled equalizer, matching the gate the global equalizer already had |
| MQTT enabled with no broker or topic | fatal | disabled, warn | publishes nothing either way |
| Push provider enabled with no type/command/URLs/endpoints/auth secret | fatal | that provider disabled, warn | delivers nothing either way; losing notifications beats losing every detection |
| Telemetry listen / web server port empty | fatal | documented default, warn | the web UI is the recovery path for every other setting |
| Sound level interval, dynamic threshold validHours, species tracking windows at zero | fatal | documented default, warn | zero never means "no window" for any of them |
| Yearly reset month and day at zero | fatal | defaulted **independently**, warn | defaulting both from the month's absence would discard a reset day the user did write |
| Seasonal tracking enabled with no seasons | fatal | default seasons for the hemisphere, warn | `GetDefaultSeasons` is the documented default, and disabling instead would also put the feature out of reach of the hemisphere repair `Load` applies after validation |
| Audio export enabled with no length or bitrate, normalization with no target LUFS, retention policy with no limit, MQTT retries with no backoff multiplier | fatal | documented default, warn | `realtime.audio.export` is the section users hand-edit most, and viper drops a nested default whenever the parent key is present |
| The same fields set to a non-zero out-of-range value | fatal | fatal | typed on purpose |

## Making the warnings visible

`Settings.ValidationWarnings` was logged, converted to Sentry messages in `main.go`, and then cleared, so although the field is serialised the settings API always returned it empty: a user whose OAuth provider was disabled had no way to find out short of reading `journalctl`. Each warning is now also raised through `notification.NotifyWarning`, so it appears in the notification centre.

## Tests

Table-driven coverage per reclassified rule, plus a case per rule that stays fatal so the downgrade is not blanket. The security invariant is asserted directly: a provider with no credentials ends up `Enabled == false` and absent from `GetEnabledOAuthProviders`, while a credentialed provider stays enabled and still counts, so authentication is never silently removed. `TestLoad_AcceptsPreviouslyRejectedConfig` drives the real `conf.Load` with the exact `config.yaml` from the report, and fails on the old code.

## Worth calling out for the release notes

**The disablement becomes permanent.** Nothing is written at load time, but `SaveSettings` serialises the post-normalization snapshot, and the model manager calls it automatically, so the first save after upgrade rewrites `enabled: true` to `enabled: false` in the user's `config.yaml`. `ValidationWarnings` is `yaml:"-"`, so the file carries no record of why. After filling in the missing field the user has to re-enable the feature.

**Warnings that were previously swallowed now surface.** `main.go` used to drop any `ValidationWarnings` entry with no `": "` in it, which silenced two of the six producers outright and turned a sentence fragment into the Sentry component for two more. All six now go through one helper, so a config that aged across upgrades can produce a burst of "Configuration Problem" notifications on the first boot after this lands. They are accurate; they were just invisible before.

**Removed Sentry tags.** `security-oauth-host` is gone. `security-oidc-redirect-missing`, `security-oidc-issuer-missing` and `security-oidc-issuer-invalid` are unchanged in meaning but now fire only for an enabled provider. Any saved search keyed on the first one stops matching.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Incomplete configurations are now normalized at load time, applying defaults or disabling unfinished/unused features to keep startup from failing.
* **Bug Fixes**
  * Validation is tightened to avoid failures from disabled equalizers and undeliverable/unfinished notification providers.
  * OAuth redirect validation is improved, and security validation now allows more previously blocking “enabled but incomplete” cases.
* **Documentation**
  * Updated species-tracking and “new” indicator defaults: yearly/seasonal windows are now 7 days.
* **Refactor**
  * Serve flag defaults now consistently use loaded configuration values.
* **Telemetry & Notifications**
  * Configuration validation warnings are now reliably surfaced to both telemetry and user notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->