### PR TITLE
fix(media): remove misleading UTC marker from downloaded filenames

### DIFF
--- a/internal/api/v2/media/handler.go
+++ b/internal/api/v2/media/handler.go
@@ -62,6 +62,10 @@ type Handler struct {
 	// uses audioWaitTimeout. Tests set a short timeout to exercise the
 	// 503-after-timeout path without waiting the full default.
 	audioWaitTimeoutOverride time.Duration
+
+	// audioWaitStartedHook synchronizes tests with the point after an initial
+	// audio serve miss enters a wait path. Production leaves it nil.
+	audioWaitStartedHook func()
 }
 
 // New constructs the media domain handler around the shared core. It builds the

--- a/internal/api/v2/media/media.go
+++ b/internal/api/v2/media/media.go
@@ -62,6 +62,11 @@ const (
 	MimeTypeOGG  = "audio/ogg"
 )
 
+const (
+	headerAcceptRanges = "Accept-Ranges"
+	acceptRangesBytes  = "bytes"
+)
+
 // Cache duration in seconds for HTTP Cache-Control headers on media responses.
 const (
 	// ImageCacheSeconds is the cache duration for species images in seconds
@@ -158,13 +163,13 @@ func setAudioContentDisposition(ctx echo.Context, filename string) {
 	// QueryEscape provides the conservative percent-encoding needed for an
 	// RFC 5987 filename* value, except that its form-style spaces use '+'.
 	encodedFilename := strings.ReplaceAll(url.QueryEscape(dispositionFilename), "+", "%20")
-	ctx.Response().Header().Set("Content-Disposition", fmt.Sprintf("inline; filename*=UTF-8''%s", encodedFilename))
+	ctx.Response().Header().Set(echo.HeaderContentDisposition, fmt.Sprintf("inline; filename*=UTF-8''%s", encodedFilename))
 }
 
 func clearAudioResponseHeaders(ctx echo.Context) {
-	ctx.Response().Header().Del("Content-Type")
-	ctx.Response().Header().Del("Content-Disposition")
-	ctx.Response().Header().Del("Accept-Ranges")
+	ctx.Response().Header().Del(echo.HeaderContentType)
+	ctx.Response().Header().Del(echo.HeaderContentDisposition)
+	ctx.Response().Header().Del(headerAcceptRanges)
 }
 
 // AudioNotReadyError carries retry information for audio files that are not yet ready
@@ -444,6 +449,14 @@ func (c *Handler) translateSecureFSError(ctx echo.Context, err error, userMsg st
 	return c.HandleError(ctx, err, userMsg, http.StatusInternalServerError)
 }
 
+// translateAudioServeError clears headers intended for successful audio
+// responses before translating a terminal serve failure. Clearing first keeps
+// those headers off JSON bodies even when translation commits the response.
+func (c *Handler) translateAudioServeError(ctx echo.Context, err error, userMsg string) error {
+	clearAudioResponseHeaders(ctx)
+	return c.translateSecureFSError(ctx, err, userMsg)
+}
+
 // parseRawParameter parses the raw query parameter for spectrogram generation.
 // It defaults to true for backward compatibility with existing cached spectrograms.
 // Accepts: "true", "false", "1", "0", "t", "f", "yes", "no", "on", "off"
@@ -586,6 +599,9 @@ func (c *Handler) waitForAudioFile(ctx echo.Context, relClipPath, tempPath strin
 
 	ticker := time.NewTicker(audioWaitPollInterval)
 	defer ticker.Stop()
+	if c.audioWaitStartedHook != nil {
+		c.audioWaitStartedHook()
+	}
 
 	for {
 		// Check for the file before waiting. This avoids a race condition where
@@ -626,6 +642,9 @@ func (c *Handler) waitForAudioFileGrace(ctx echo.Context, relClipPath string) bo
 	// appears right after the initial 404.
 	if _, err := c.SFS.StatRel(relClipPath); err == nil {
 		return true
+	}
+	if c.audioWaitStartedHook != nil {
+		c.audioWaitStartedHook()
 	}
 
 	graceCtx, cancel := context.WithTimeout(ctx.Request().Context(), audioGracePeriod)
@@ -694,7 +713,7 @@ func (c *Handler) handleAudio404WithWait(ctx echo.Context, relClipPath string, o
 		if c.waitForAudioFile(ctx, relClipPath, tempPath) {
 			// File appeared - serve it now
 			if retryErr := c.SFS.ServeRelativeFile(ctx, relClipPath); retryErr != nil {
-				return c.translateSecureFSError(ctx, retryErr, "Failed to serve audio clip after encoding completed")
+				return c.translateAudioServeError(ctx, retryErr, "Failed to serve audio clip after encoding completed")
 			}
 			c.LogInfoIfEnabled("Successfully served audio clip after waiting for encoding", logFields...)
 			return nil
@@ -705,7 +724,7 @@ func (c *Handler) handleAudio404WithWait(ctx echo.Context, relClipPath string, o
 		}
 		// Temp file disappeared and final file is still missing -
 		// encoding failed, fall back to normal error translation.
-		return c.translateSecureFSError(ctx, originalErr, "Failed to serve audio clip due to an unexpected error")
+		return c.translateAudioServeError(ctx, originalErr, "Failed to serve audio clip due to an unexpected error")
 	}
 
 	// No temp file yet, but the export may be legitimately pending: for an
@@ -729,20 +748,20 @@ func (c *Handler) handleAudio404WithWait(ctx echo.Context, relClipPath string, o
 	// one worker each. Recent (or unknown-age) detections still get the brief
 	// grace wait for the FFmpeg race window.
 	if !isRecentClipCompletion(detectionEndTime) {
-		return c.translateSecureFSError(ctx, originalErr, "Failed to serve audio clip due to an unexpected error")
+		return c.translateAudioServeError(ctx, originalErr, "Failed to serve audio clip due to an unexpected error")
 	}
 
 	// Brief grace wait for the race window where FFmpeg hasn't created the temp
 	// file yet or already renamed it.
 	if c.waitForAudioFileGrace(ctx, relClipPath) {
 		if retryErr := c.SFS.ServeRelativeFile(ctx, relClipPath); retryErr != nil {
-			return c.translateSecureFSError(ctx, retryErr, "Failed to serve audio clip after grace wait")
+			return c.translateAudioServeError(ctx, retryErr, "Failed to serve audio clip after grace wait")
 		}
 		c.LogInfoIfEnabled("Successfully served audio clip after grace wait", logFields...)
 		return nil
 	}
 
-	return c.translateSecureFSError(ctx, originalErr, "Failed to serve audio clip due to an unexpected error")
+	return c.translateAudioServeError(ctx, originalErr, "Failed to serve audio clip due to an unexpected error")
 }
 
 // ServeAudioClip serves an audio clip file by filename using SecureFS
@@ -794,12 +813,8 @@ func (c *Handler) ServeAudioClip(ctx echo.Context) error {
 				logger.String("ip", ctx.RealIP()),
 			)
 		} else {
-			// Error logging is handled within translateSecureFSError
-			err = c.translateSecureFSError(ctx, err, "Failed to serve audio clip due to an unexpected error")
-		}
-
-		if err != nil && !ctx.Response().Committed {
-			clearAudioResponseHeaders(ctx)
+			// Error logging is handled within translateSecureFSError.
+			return c.translateAudioServeError(ctx, err, "Failed to serve audio clip due to an unexpected error")
 		}
 		return err
 	}
@@ -860,15 +875,15 @@ func (c *Handler) ServeAudioByID(ctx echo.Context) error {
 	// This ensures Safari recognizes the file as audio.
 	switch ext {
 	case ".flac":
-		ctx.Response().Header().Set("Content-Type", MimeTypeFLAC)
+		ctx.Response().Header().Set(echo.HeaderContentType, MimeTypeFLAC)
 	case ".wav":
-		ctx.Response().Header().Set("Content-Type", MimeTypeWAV)
+		ctx.Response().Header().Set(echo.HeaderContentType, MimeTypeWAV)
 	case ".mp3":
-		ctx.Response().Header().Set("Content-Type", MimeTypeMP3)
+		ctx.Response().Header().Set(echo.HeaderContentType, MimeTypeMP3)
 	case ".m4a":
-		ctx.Response().Header().Set("Content-Type", MimeTypeM4A)
+		ctx.Response().Header().Set(echo.HeaderContentType, MimeTypeM4A)
 	case ".ogg":
-		ctx.Response().Header().Set("Content-Type", MimeTypeOGG)
+		ctx.Response().Header().Set(echo.HeaderContentType, MimeTypeOGG)
 	default:
 		// Let ServeRelativeFile handle the content type
 	}
@@ -878,7 +893,7 @@ func (c *Handler) ServeAudioByID(ctx echo.Context) error {
 	setAudioContentDisposition(ctx, originalFilename)
 
 	// Ensure Accept-Ranges header is set for iOS Safari.
-	ctx.Response().Header().Set("Accept-Ranges", "bytes")
+	ctx.Response().Header().Set(headerAcceptRanges, acceptRangesBytes)
 
 	// Serve the file using SecureFS.
 	err = c.SFS.ServeRelativeFile(ctx, normalizedClipPath)
@@ -894,14 +909,7 @@ func (c *Handler) ServeAudioByID(ctx echo.Context) error {
 				logger.String("ip", ctx.RealIP()),
 			)
 		} else {
-			err = c.translateSecureFSError(ctx, err, "Failed to serve audio clip due to an unexpected error")
-		}
-
-		// Preserve the audio headers if a wait/retry served the file. Terminal
-		// JSON responses clear them in writeAudioNotReady; uncommitted errors are
-		// cleared here before Echo renders the error body.
-		if err != nil && !ctx.Response().Committed {
-			clearAudioResponseHeaders(ctx)
+			return c.translateAudioServeError(ctx, err, "Failed to serve audio clip due to an unexpected error")
 		}
 		return err
 	}

--- a/internal/api/v2/media/media.go
+++ b/internal/api/v2/media/media.go
@@ -106,6 +106,67 @@ func isValidFilename(filename string) bool {
 	return true
 }
 
+// contentDispositionFilename returns the user-facing clip filename advertised
+// by media responses. BirdNET-Go's legacy on-disk naming convention formats
+// clip timestamps in local time but appends a literal Z, which normally means
+// UTC. Keep the stored path unchanged for compatibility while removing that
+// misleading marker from recognized clip timestamps in download filenames.
+func contentDispositionFilename(filename string) string {
+	const timestampLayout = "20060102T150405Z"
+
+	ext := filepath.Ext(filename)
+	stem := strings.TrimSuffix(filename, ext)
+	timestampStem := diskmanager.StripDurationSuffix(stem)
+	timestampEnd := len(timestampStem)
+
+	if timestampEnd < len(timestampLayout) {
+		return filename
+	}
+	timestampStart := timestampEnd - len(timestampLayout)
+	if timestampStart == 0 || stem[timestampStart-1] != '_' {
+		return filename
+	}
+	prefix := timestampStem[:timestampStart-1]
+	confidenceSeparator := strings.LastIndexByte(prefix, '_')
+	if confidenceSeparator < 1 {
+		return filename
+	}
+	confidence := prefix[confidenceSeparator+1:]
+	if len(confidence) < 2 || confidence[len(confidence)-1] != 'p' {
+		return filename
+	}
+	if _, err := strconv.ParseUint(confidence[:len(confidence)-1], 10, 64); err != nil {
+		return filename
+	}
+
+	timestamp := stem[timestampStart:timestampEnd]
+	if _, err := time.ParseInLocation(timestampLayout, timestamp, time.Local); err != nil {
+		return filename
+	}
+
+	return stem[:timestampEnd-1] + stem[timestampEnd:] + ext
+}
+
+// setAudioContentDisposition advertises a safe, user-facing filename while
+// keeping the response inline for browser playback.
+func setAudioContentDisposition(ctx echo.Context, filename string) {
+	if !isValidFilename(filename) {
+		return
+	}
+
+	dispositionFilename := contentDispositionFilename(filename)
+	// QueryEscape provides the conservative percent-encoding needed for an
+	// RFC 5987 filename* value, except that its form-style spaces use '+'.
+	encodedFilename := strings.ReplaceAll(url.QueryEscape(dispositionFilename), "+", "%20")
+	ctx.Response().Header().Set("Content-Disposition", fmt.Sprintf("inline; filename*=UTF-8''%s", encodedFilename))
+}
+
+func clearAudioResponseHeaders(ctx echo.Context) {
+	ctx.Response().Header().Del("Content-Type")
+	ctx.Response().Header().Del("Content-Disposition")
+	ctx.Response().Header().Del("Accept-Ranges")
+}
+
 // AudioNotReadyError carries retry information for audio files that are not yet ready
 type AudioNotReadyError struct {
 	RetryAfter time.Duration
@@ -472,6 +533,9 @@ func (c *Handler) isAudioBeingEncoded(relClipPath string) bool {
 // error log, Sentry, and the bell. The JSON body is identical to HandleError's because
 // both build it via NewErrorResponse. Callers log the condition at Debug themselves.
 func (c *Handler) writeAudioNotReady(ctx echo.Context, err error, message string, retryAfterSeconds int) error {
+	// These handlers write a JSON response, so discard any audio headers set by
+	// the initial serve attempt before committing it.
+	clearAudioResponseHeaders(ctx)
 	ctx.Response().Header().Set("Retry-After", strconv.Itoa(retryAfterSeconds))
 	return ctx.JSON(http.StatusServiceUnavailable,
 		c.NewErrorResponse(err, message, http.StatusServiceUnavailable))
@@ -710,6 +774,8 @@ func (c *Handler) ServeAudioClip(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Invalid file path", http.StatusBadRequest)
 	}
 
+	setAudioContentDisposition(ctx, filepath.Base(normalizedFilename))
+
 	// Serve the file using SecureFS. It handles path validation and serves the file.
 	// ServeRelativeFile is expected to return appropriate echo.HTTPErrors (400, 404, 500).
 	err = c.SFS.ServeRelativeFile(ctx, normalizedFilename)
@@ -722,14 +788,20 @@ func (c *Handler) ServeAudioClip(ctx echo.Context) error {
 		if errors.As(err, &httpErr) && httpErr.Code == http.StatusNotFound {
 			// Filename-based serving has no note ID to resolve capture times, so pass
 			// zero times (unknown -> no pending window, keep the grace wait, fail-safe).
-			return c.handleAudio404WithWait(ctx, normalizedFilename, err, time.Time{}, time.Time{},
+			err = c.handleAudio404WithWait(ctx, normalizedFilename, err, time.Time{}, time.Time{},
 				logger.String("filename", filename),
 				logger.String("path", ctx.Request().URL.Path),
 				logger.String("ip", ctx.RealIP()),
 			)
+		} else {
+			// Error logging is handled within translateSecureFSError
+			err = c.translateSecureFSError(ctx, err, "Failed to serve audio clip due to an unexpected error")
 		}
-		// Error logging is handled within translateSecureFSError
-		return c.translateSecureFSError(ctx, err, "Failed to serve audio clip due to an unexpected error")
+
+		if err != nil && !ctx.Response().Committed {
+			clearAudioResponseHeaders(ctx)
+		}
+		return err
 	}
 
 	c.LogInfoIfEnabled("Successfully served audio clip by filename",
@@ -803,9 +875,7 @@ func (c *Handler) ServeAudioByID(ctx echo.Context) error {
 
 	// Set Content-Disposition as inline to enable playback in browser.
 	// Use filename* for proper UTF-8 filename encoding.
-	if isValidFilename(originalFilename) {
-		ctx.Response().Header().Set("Content-Disposition", fmt.Sprintf("inline; filename*=UTF-8''%s", url.QueryEscape(originalFilename)))
-	}
+	setAudioContentDisposition(ctx, originalFilename)
 
 	// Ensure Accept-Ranges header is set for iOS Safari.
 	ctx.Response().Header().Set("Accept-Ranges", "bytes")
@@ -813,26 +883,27 @@ func (c *Handler) ServeAudioByID(ctx echo.Context) error {
 	// Serve the file using SecureFS.
 	err = c.SFS.ServeRelativeFile(ctx, normalizedClipPath)
 	if err != nil {
-		// Clear audio-specific headers before error handling so 404 responses
-		// don't carry Content-Type: audio/wav on JSON error bodies.
-		if !ctx.Response().Committed {
-			ctx.Response().Header().Del("Content-Type")
-			ctx.Response().Header().Del("Content-Disposition")
-			ctx.Response().Header().Del("Accept-Ranges")
-		}
-
 		var httpErr *echo.HTTPError
 		if errors.As(err, &httpErr) && httpErr.Code == http.StatusNotFound {
 			// Capture times drive the pending-export and ghost decisions. They are
 			// looked up here on the 404 slow path only.
 			begin, end := c.noteCaptureTimes(noteID)
-			return c.handleAudio404WithWait(ctx, normalizedClipPath, err, begin, end,
+			err = c.handleAudio404WithWait(ctx, normalizedClipPath, err, begin, end,
 				logger.String("note_id", noteID),
 				logger.String("path", ctx.Request().URL.Path),
 				logger.String("ip", ctx.RealIP()),
 			)
+		} else {
+			err = c.translateSecureFSError(ctx, err, "Failed to serve audio clip due to an unexpected error")
 		}
-		return c.translateSecureFSError(ctx, err, "Failed to serve audio clip due to an unexpected error")
+
+		// Preserve the audio headers if a wait/retry served the file. Terminal
+		// JSON responses clear them in writeAudioNotReady; uncommitted errors are
+		// cleared here before Echo renders the error body.
+		if err != nil && !ctx.Response().Committed {
+			clearAudioResponseHeaders(ctx)
+		}
+		return err
 	}
 
 	return nil

--- a/internal/api/v2/media/media_test.go
+++ b/internal/api/v2/media/media_test.go
@@ -253,38 +253,70 @@ func TestServeAudioClip(t *testing.T) {
 	largeFilePath := filepath.Join(tempDir, largeFilename)
 	createLargeWAVFile(t, largeFilePath, 1100*1024)
 
+	standardClipFilename := "corvus_corax_74p_20260724T132919Z.wav"
+	require.NoError(t, createTestAudioFile(t, filepath.Join(tempDir, standardClipFilename)))
+	extendedClipFilename := "strix_uralensis_85p_20260724T231500Z_86s.wav"
+	require.NoError(t, createTestAudioFile(t, filepath.Join(tempDir, extendedClipFilename)))
+	spacedFilename := "my clip.wav"
+	require.NoError(t, createTestAudioFile(t, filepath.Join(tempDir, spacedFilename)))
+
 	// Test cases
 	testCases := []struct {
-		name           string
-		filename       string // Filename relative to SecureFS root
-		rangeHeader    string
-		expectedStatus int
-		expectedLength int64 // Use int64 for http.ServeContent
-		partialContent bool
+		name                string
+		filename            string // Filename relative to SecureFS root
+		rangeHeader         string
+		expectedStatus      int
+		expectedLength      int64 // Use int64 for http.ServeContent
+		partialContent      bool
+		expectedDisposition string
 	}{
 		{
-			name:           "Small file - full content",
-			filename:       smallFilename,
-			rangeHeader:    "",
-			expectedStatus: http.StatusOK,
-			expectedLength: 8864, // WAV header (44) + audio data (8820)
-			partialContent: false,
+			name:                "Small file - full content",
+			filename:            smallFilename,
+			rangeHeader:         "",
+			expectedStatus:      http.StatusOK,
+			expectedLength:      8864, // WAV header (44) + audio data (8820)
+			partialContent:      false,
+			expectedDisposition: "inline; filename*=UTF-8''small.wav",
 		},
 		{
-			name:           "Large file - full content",
-			filename:       largeFilename,
-			rangeHeader:    "",
-			expectedStatus: http.StatusOK,
-			expectedLength: 1100*1024 + 44, // Data size + WAV header
-			partialContent: false,
+			name:                "Large file - full content",
+			filename:            largeFilename,
+			rangeHeader:         "",
+			expectedStatus:      http.StatusOK,
+			expectedLength:      1100*1024 + 44, // Data size + WAV header
+			partialContent:      false,
+			expectedDisposition: "inline; filename*=UTF-8''large.wav",
 		},
 		{
-			name:           "Large file - partial content",
-			filename:       largeFilename,
-			rangeHeader:    "bytes=100-199",
-			expectedStatus: http.StatusPartialContent,
-			expectedLength: 100,
-			partialContent: true,
+			name:                "Large file - partial content",
+			filename:            largeFilename,
+			rangeHeader:         "bytes=100-199",
+			expectedStatus:      http.StatusPartialContent,
+			expectedLength:      100,
+			partialContent:      true,
+			expectedDisposition: "inline; filename*=UTF-8''large.wav",
+		},
+		{
+			name:                "Standard clip filename omits misleading UTC marker",
+			filename:            standardClipFilename,
+			expectedStatus:      http.StatusOK,
+			expectedLength:      8864,
+			expectedDisposition: "inline; filename*=UTF-8''corvus_corax_74p_20260724T132919.wav",
+		},
+		{
+			name:                "Extended clip filename omits misleading UTC marker",
+			filename:            extendedClipFilename,
+			expectedStatus:      http.StatusOK,
+			expectedLength:      8864,
+			expectedDisposition: "inline; filename*=UTF-8''strix_uralensis_85p_20260724T231500_86s.wav",
+		},
+		{
+			name:                "Filename spaces use RFC 5987 encoding",
+			filename:            spacedFilename,
+			expectedStatus:      http.StatusOK,
+			expectedLength:      8864,
+			expectedDisposition: "inline; filename*=UTF-8''my%20clip.wav",
 		},
 		{
 			name:           "Non-existent file",
@@ -306,7 +338,7 @@ func TestServeAudioClip(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			targetURL := "/api/v2/media/audio/" + tc.filename
+			targetURL := "/api/v2/media/audio/" + strings.ReplaceAll(tc.filename, " ", "%20")
 			req := httptest.NewRequest(http.MethodGet, targetURL, http.NoBody)
 			if tc.rangeHeader != "" {
 				req.Header.Set("Range", tc.rangeHeader)
@@ -316,6 +348,7 @@ func TestServeAudioClip(t *testing.T) {
 
 			isSmallFile := tc.filename == smallFilename
 			assertAudioClipResponse(t, rec, tc.expectedStatus, tc.expectedLength, tc.partialContent, isSmallFile)
+			assert.Equal(t, tc.expectedDisposition, rec.Header().Get("Content-Disposition"))
 		})
 	}
 }
@@ -893,7 +926,8 @@ func TestServeAudioByID(t *testing.T) {
 	e, controller, tempDir := setupMediaTestEnvironment(t)
 
 	// Create a test audio file
-	testFilename := "2024-01-15_14-30-45_Turdus_migratorius.wav"
+	testFilename := "turdus_migratorius_88p_20240115T143045Z.wav"
+	downloadFilename := "turdus_migratorius_88p_20240115T143045.wav"
 	filePath := filepath.Join(tempDir, testFilename)
 	testContent := "test audio content"
 	err := os.WriteFile(filePath, []byte(testContent), 0o600)
@@ -920,7 +954,7 @@ func TestServeAudioByID(t *testing.T) {
 			audioID:                "123",
 			expectedStatus:         http.StatusOK,
 			expectedContentType:    MimeTypeWAV,
-			expectedDisposition:    fmt.Sprintf("inline; filename*=UTF-8''%s", testFilename),
+			expectedDisposition:    fmt.Sprintf("inline; filename*=UTF-8''%s", downloadFilename),
 			shouldHaveAcceptRanges: true,
 		},
 		{
@@ -955,6 +989,54 @@ func TestServeAudioByID(t *testing.T) {
 
 	// Note: Error cases are omitted as they are tested elsewhere and the main
 	// goal of this test is to verify Content-Disposition header functionality
+}
+
+func TestContentDispositionFilename(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		filename string
+		expected string
+	}{
+		{
+			name:     "standard local timestamp",
+			filename: "corvus_corax_74p_20260724T132919Z.m4a",
+			expected: "corvus_corax_74p_20260724T132919.m4a",
+		},
+		{
+			name:     "extended capture duration",
+			filename: "strix_uralensis_85p_20260724T231500Z_86s.wav",
+			expected: "strix_uralensis_85p_20260724T231500_86s.wav",
+		},
+		{
+			name:     "timestamp already has no zone marker",
+			filename: "corvus_corax_74p_20260724T132919.m4a",
+			expected: "corvus_corax_74p_20260724T132919.m4a",
+		},
+		{
+			name:     "unrecognized filename preserves legitimate Z",
+			filename: "recordingZ.m4a",
+			expected: "recordingZ.m4a",
+		},
+		{
+			name:     "custom UTC timestamp is unchanged",
+			filename: "recording_20240115T143045Z.wav",
+			expected: "recording_20240115T143045Z.wav",
+		},
+		{
+			name:     "invalid timestamp is unchanged",
+			filename: "corvus_corax_74p_20261399T999999Z.m4a",
+			expected: "corvus_corax_74p_20261399T999999Z.m4a",
+		},
+	}
+
+	for i := range tests {
+		t.Run(tests[i].name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tests[i].expected, contentDispositionFilename(tests[i].filename))
+		})
+	}
 }
 
 // TestServeAudioByID_AudioFormats tests different audio format MIME type handling
@@ -1410,6 +1492,50 @@ func TestServeAudioClipWaitsForEncoding(t *testing.T) {
 	}
 }
 
+// TestServeAudioByIDWaitsForEncodingPreservesHeaders verifies that the ID route
+// keeps its audio metadata when the initial 404 is recovered by a successful
+// encoding wait and retry.
+func TestServeAudioByIDWaitsForEncodingPreservesHeaders(t *testing.T) {
+	e, controller, tempDir := setupMediaTestEnvironment(t)
+
+	audioFilename := "turdus_migratorius_88p_20260724T143045Z.wav"
+	audioFilePath := filepath.Join(tempDir, audioFilename)
+	tempFilePath := audioFilePath + ".99999.1" + ffmpeg.TempExt
+	require.NoError(t, os.WriteFile(tempFilePath, []byte("temp encoding data"), 0o600))
+
+	mockDS := mocks.NewMockInterface(t)
+	mockDS.On("GetNoteClipPath", "42").Return(audioFilename, nil)
+	mockDS.On("Get", "42").Return(datastore.Note{ID: 42, EndTime: time.Now()}, nil).Maybe()
+	controller.DS = mockDS
+
+	errChan := make(chan error, 1)
+	go func() {
+		time.Sleep(500 * time.Millisecond)
+		if err := createTestAudioFile(t, audioFilePath); err != nil {
+			errChan <- err
+			return
+		}
+		os.Remove(tempFilePath) //nolint:errcheck // best-effort cleanup in test
+		errChan <- nil
+	}()
+	t.Cleanup(func() {
+		if bgErr := <-errChan; bgErr != nil {
+			t.Errorf("Background goroutine failed: %v", bgErr)
+		}
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/audio/42", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("id")
+	ctx.SetParamValues("42")
+
+	require.NoError(t, controller.ServeAudioByID(ctx))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assertAudioHeaders(t, rec, MimeTypeWAV,
+		"inline; filename*=UTF-8''turdus_migratorius_88p_20260724T143045.wav", true)
+}
+
 // TestServeAudioClipReturns503AfterTimeout verifies that the server returns 503
 // with Retry-After header when encoding doesn't complete within the timeout.
 func TestServeAudioClipReturns503AfterTimeout(t *testing.T) {
@@ -1454,6 +1580,8 @@ func TestServeAudioClipReturns503AfterTimeout(t *testing.T) {
 	}
 	assert.Equal(t, audioRetryAfterSeconds, rec.Header().Get("Retry-After"),
 		"Should include Retry-After header")
+	assert.Empty(t, rec.Header().Get("Content-Disposition"),
+		"JSON error response should not advertise an audio filename")
 }
 
 // TestServeAudioClipNoTempFileReturns404 verifies that a missing file without
@@ -1612,6 +1740,7 @@ func TestServeAudioClipGraceWaitServesFile(t *testing.T) {
 	} else {
 		assert.Equal(t, http.StatusOK, rec.Code,
 			"Should serve the file successfully after grace wait")
+		assert.Equal(t, "inline; filename*=UTF-8''grace-wait-test.wav", rec.Header().Get("Content-Disposition"))
 	}
 }
 

--- a/internal/api/v2/media/media_test.go
+++ b/internal/api/v2/media/media_test.go
@@ -105,6 +105,32 @@ func assertAudioHeaders(t *testing.T, rec *httptest.ResponseRecorder, expectedCo
 	}
 }
 
+const testAudioAsyncTimeout = 5 * time.Second
+
+func requireAudioWaitStarted(t *testing.T, waitStarted <-chan struct{}, handlerErr <-chan error) {
+	t.Helper()
+
+	select {
+	case <-waitStarted:
+		return
+	case err := <-handlerErr:
+		require.Failf(t, "handler returned before entering audio wait", "handler error: %v", err)
+	case <-time.After(testAudioAsyncTimeout):
+		require.Fail(t, "handler did not enter audio wait before timeout")
+	}
+}
+
+func requireAudioHandlerSuccess(t *testing.T, handlerErr <-chan error) {
+	t.Helper()
+
+	select {
+	case err := <-handlerErr:
+		require.NoError(t, err)
+	case <-time.After(testAudioAsyncTimeout):
+		require.Fail(t, "audio handler did not complete before timeout")
+	}
+}
+
 // assertMediaResponseBody validates response body content based on type.
 func assertMediaResponseBody(t *testing.T, body []byte, expectedBody string, isAudioFile bool) {
 	t.Helper()
@@ -1039,6 +1065,23 @@ func TestContentDispositionFilename(t *testing.T) {
 	}
 }
 
+func TestTranslateAudioServeErrorClearsHeadersBeforeCommittedJSON(t *testing.T) {
+	e, controller, _ := setupMediaTestEnvironment(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/media/audio/test.wav", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	ctx.Response().Header().Set(echo.HeaderContentType, MimeTypeWAV)
+	ctx.Response().Header().Set(echo.HeaderContentDisposition, "inline; filename*=UTF-8''test.wav")
+	ctx.Response().Header().Set(headerAcceptRanges, acceptRangesBytes)
+
+	require.NoError(t, controller.translateAudioServeError(ctx, errors.New("forced serve failure"), "Failed to serve audio"))
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Contains(t, rec.Header().Get(echo.HeaderContentType), echo.MIMEApplicationJSON)
+	assert.Empty(t, rec.Header().Get(echo.HeaderContentDisposition))
+	assert.Empty(t, rec.Header().Get(headerAcceptRanges))
+}
+
 // TestServeAudioByID_AudioFormats tests different audio format MIME type handling
 func TestServeAudioByID_AudioFormats(t *testing.T) {
 	// Setup test environment
@@ -1400,9 +1443,6 @@ func TestGetSpectrogramLogger(t *testing.T) {
 	}, "Logger methods should not panic")
 }
 
-// TestServeAudioClipWaitsForEncoding verifies that when an audio file is being
-// encoded (temp file exists), the server waits for the final file to appear
-// instead of immediately returning 503.
 // TestIsExportTempFor verifies the in-progress-encoding temp matcher accepts the
 // export temp formats and rejects unrelated sidecar temps that merely share the
 // clip's prefix and the ".temp" suffix (GitHub #3323).
@@ -1434,8 +1474,12 @@ func TestIsExportTempFor(t *testing.T) {
 	}
 }
 
+// TestServeAudioClipWaitsForEncoding verifies that when an audio file is being
+// encoded (temp file exists), the server waits for the final file to appear
+// instead of immediately returning 503.
 func TestServeAudioClipWaitsForEncoding(t *testing.T) {
 	e, controller, tempDir := setupMediaTestEnvironment(t)
+	controller.audioWaitTimeoutOverride = testAudioAsyncTimeout
 
 	audioFilename := "encoding-test.wav"
 	audioFilePath := filepath.Join(tempDir, audioFilename)
@@ -1443,33 +1487,13 @@ func TestServeAudioClipWaitsForEncoding(t *testing.T) {
 	// exporters write, so this exercises the directory-scan detection in
 	// isAudioBeingEncoded rather than a fixed name that production never produces.
 	tempFilePath := audioFilePath + ".99999.1" + ffmpeg.TempExt
+	require.NoError(t, os.WriteFile(tempFilePath, []byte("temp encoding data"), 0o600))
 
-	// Create the temp file to simulate in-progress encoding
-	err := os.WriteFile(tempFilePath, []byte("temp encoding data"), 0o600)
-	require.NoError(t, err)
+	waitStarted := make(chan struct{})
+	controller.audioWaitStartedHook = func() {
+		close(waitStarted)
+	}
 
-	// Simulate the file appearing after a short delay (encoding completes).
-	// Use an error channel to propagate failures from the background goroutine.
-	errChan := make(chan error, 1)
-	go func() {
-		time.Sleep(500 * time.Millisecond)
-		// Create the final audio file
-		createErr := createTestAudioFile(t, audioFilePath)
-		if createErr != nil {
-			errChan <- createErr
-			return
-		}
-		// Remove the temp file to simulate FFmpeg completing
-		os.Remove(tempFilePath) //nolint:errcheck // best-effort cleanup in test
-		errChan <- nil
-	}()
-	t.Cleanup(func() {
-		if bgErr := <-errChan; bgErr != nil {
-			t.Errorf("Background goroutine failed: %v", bgErr)
-		}
-	})
-
-	// Make the request - should wait for the file and serve it
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/media/audio/"+audioFilename, http.NoBody)
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)
@@ -1477,19 +1501,17 @@ func TestServeAudioClipWaitsForEncoding(t *testing.T) {
 	ctx.SetParamNames("filename")
 	ctx.SetParamValues(audioFilename)
 
-	handlerErr := controller.ServeAudioClip(ctx)
+	handlerErr := make(chan error, 1)
+	go func() {
+		handlerErr <- controller.ServeAudioClip(ctx)
+	}()
 
-	// Should succeed (200) instead of 503
-	if handlerErr != nil {
-		// If there's an error, it should NOT be 503
-		if httpErr, ok := errors.AsType[*echo.HTTPError](handlerErr); ok {
-			assert.NotEqual(t, http.StatusServiceUnavailable, httpErr.Code,
-				"Should not return 503 when file appears within timeout")
-		}
-	} else {
-		assert.Equal(t, http.StatusOK, rec.Code,
-			"Should serve the file successfully after waiting for encoding")
-	}
+	requireAudioWaitStarted(t, waitStarted, handlerErr)
+	require.NoError(t, createTestAudioFile(t, audioFilePath))
+	require.NoError(t, os.Remove(tempFilePath))
+	requireAudioHandlerSuccess(t, handlerErr)
+	assert.Equal(t, http.StatusOK, rec.Code,
+		"Should serve the file successfully after waiting for encoding")
 }
 
 // TestServeAudioByIDWaitsForEncodingPreservesHeaders verifies that the ID route
@@ -1497,6 +1519,7 @@ func TestServeAudioClipWaitsForEncoding(t *testing.T) {
 // encoding wait and retry.
 func TestServeAudioByIDWaitsForEncodingPreservesHeaders(t *testing.T) {
 	e, controller, tempDir := setupMediaTestEnvironment(t)
+	controller.audioWaitTimeoutOverride = testAudioAsyncTimeout
 
 	audioFilename := "turdus_migratorius_88p_20260724T143045Z.wav"
 	audioFilePath := filepath.Join(tempDir, audioFilename)
@@ -1508,21 +1531,10 @@ func TestServeAudioByIDWaitsForEncodingPreservesHeaders(t *testing.T) {
 	mockDS.On("Get", "42").Return(datastore.Note{ID: 42, EndTime: time.Now()}, nil).Maybe()
 	controller.DS = mockDS
 
-	errChan := make(chan error, 1)
-	go func() {
-		time.Sleep(500 * time.Millisecond)
-		if err := createTestAudioFile(t, audioFilePath); err != nil {
-			errChan <- err
-			return
-		}
-		os.Remove(tempFilePath) //nolint:errcheck // best-effort cleanup in test
-		errChan <- nil
-	}()
-	t.Cleanup(func() {
-		if bgErr := <-errChan; bgErr != nil {
-			t.Errorf("Background goroutine failed: %v", bgErr)
-		}
-	})
+	waitStarted := make(chan struct{})
+	controller.audioWaitStartedHook = func() {
+		close(waitStarted)
+	}
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/audio/42", http.NoBody)
 	rec := httptest.NewRecorder()
@@ -1530,7 +1542,15 @@ func TestServeAudioByIDWaitsForEncodingPreservesHeaders(t *testing.T) {
 	ctx.SetParamNames("id")
 	ctx.SetParamValues("42")
 
-	require.NoError(t, controller.ServeAudioByID(ctx))
+	handlerErr := make(chan error, 1)
+	go func() {
+		handlerErr <- controller.ServeAudioByID(ctx)
+	}()
+
+	requireAudioWaitStarted(t, waitStarted, handlerErr)
+	require.NoError(t, createTestAudioFile(t, audioFilePath))
+	require.NoError(t, os.Remove(tempFilePath))
+	requireAudioHandlerSuccess(t, handlerErr)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assertAudioHeaders(t, rec, MimeTypeWAV,
 		"inline; filename*=UTF-8''turdus_migratorius_88p_20260724T143045.wav", true)
@@ -1710,17 +1730,10 @@ func TestServeAudioClipGraceWaitServesFile(t *testing.T) {
 	audioFilename := "grace-wait-test.wav"
 	audioFilePath := filepath.Join(tempDir, audioFilename)
 
-	// No temp file - only the final file appears after a short delay.
-	// This simulates the race window where FFmpeg hasn't started yet.
-	// Delay is derived from audioGracePeriod to stay aligned with production timing.
-	var wg sync.WaitGroup
-	wg.Go(func() {
-		time.Sleep(audioGracePeriod / 2)
-		if err := createTestAudioFile(t, audioFilePath); err != nil {
-			t.Errorf("Background goroutine failed: %v", err)
-		}
-	})
-	t.Cleanup(wg.Wait)
+	waitStarted := make(chan struct{})
+	controller.audioWaitStartedHook = func() {
+		close(waitStarted)
+	}
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/media/audio/"+audioFilename, http.NoBody)
 	rec := httptest.NewRecorder()
@@ -1729,19 +1742,17 @@ func TestServeAudioClipGraceWaitServesFile(t *testing.T) {
 	ctx.SetParamNames("filename")
 	ctx.SetParamValues(audioFilename)
 
-	handlerErr := controller.ServeAudioClip(ctx)
+	handlerErr := make(chan error, 1)
+	go func() {
+		handlerErr <- controller.ServeAudioClip(ctx)
+	}()
 
-	// Should succeed - grace wait should pick up the file
-	if handlerErr != nil {
-		if httpErr, ok := errors.AsType[*echo.HTTPError](handlerErr); ok {
-			assert.NotEqual(t, http.StatusNotFound, httpErr.Code,
-				"Should not return 404 when file appears within grace period")
-		}
-	} else {
-		assert.Equal(t, http.StatusOK, rec.Code,
-			"Should serve the file successfully after grace wait")
-		assert.Equal(t, "inline; filename*=UTF-8''grace-wait-test.wav", rec.Header().Get("Content-Disposition"))
-	}
+	requireAudioWaitStarted(t, waitStarted, handlerErr)
+	require.NoError(t, createTestAudioFile(t, audioFilePath))
+	requireAudioHandlerSuccess(t, handlerErr)
+	assert.Equal(t, http.StatusOK, rec.Code,
+		"Should serve the file successfully after grace wait")
+	assert.Equal(t, "inline; filename*=UTF-8''grace-wait-test.wav", rec.Header().Get(echo.HeaderContentDisposition))
 }
 
 // TestBuildStyleSuffix tests that spectrogram style and dynamic range are correctly

--- a/internal/diskmanager/file_utils.go
+++ b/internal/diskmanager/file_utils.go
@@ -348,7 +348,7 @@ func parseFileInfo(path string, info os.FileInfo, allowedExts []string) (FileInf
 	nameWithoutExt = strings.TrimSuffix(nameWithoutExt, "_400px")
 
 	// Strip optional duration suffix (e.g., _86s) added by extended capture mode
-	nameWithoutExt = stripDurationSuffix(nameWithoutExt)
+	nameWithoutExt = StripDurationSuffix(nameWithoutExt)
 
 	parts := strings.Split(nameWithoutExt, "_")
 	if len(parts) < 3 {
@@ -411,10 +411,10 @@ func parseFileInfo(path string, info os.FileInfo, allowedExts []string) (FileInf
 	}, nil
 }
 
-// stripDurationSuffix removes an optional duration suffix like "_86s" from the
+// StripDurationSuffix removes an optional duration suffix like "_86s" from the
 // end of a filename (without extension). Duration suffixes are added by extended
 // capture mode and follow the pattern _<digits>s.
-func stripDurationSuffix(name string) string {
+func StripDurationSuffix(name string) string {
 	lastUnderscore := strings.LastIndex(name, "_")
 	if lastUnderscore < 0 {
 		return name

--- a/internal/diskmanager/file_utils_test.go
+++ b/internal/diskmanager/file_utils_test.go
@@ -123,7 +123,7 @@ func TestProcessFileSkipsUnrecognizedFilenames(t *testing.T) {
 	}
 }
 
-// TestStripDurationSuffix tests the stripDurationSuffix helper
+// TestStripDurationSuffix tests the StripDurationSuffix helper.
 func TestStripDurationSuffix(t *testing.T) {
 	tests := []struct {
 		input    string
@@ -147,7 +147,7 @@ func TestStripDurationSuffix(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			assert.Equal(t, tt.expected, stripDurationSuffix(tt.input))
+			assert.Equal(t, tt.expected, StripDurationSuffix(tt.input))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

BirdNET-Go formats clip timestamps in local time but appends a literal `Z`, which normally identifies UTC. This removes that misleading marker from the user-facing filename advertised through `Content-Disposition`.

- Applies the correction consistently to both filename- and ID-based audio routes.
- Handles standard and extended-capture clip names.
- Preserves custom filenames that may contain a genuine UTC timestamp.
- Leaves stored filenames and database clip paths unchanged.
- Uses RFC 5987-safe encoding for filenames containing spaces.
- Prevents audio headers from leaking onto JSON not-ready responses while preserving them after a successful encoding retry.

## Behavior change

Canonical downloaded filenames change from forms such as `corvus_corax_74p_20260724T132919Z.m4a` to `corvus_corax_74p_20260724T132919.m4a`. This is intentional because the timestamp is local, not UTC. On-disk names and API resource paths remain unchanged.

## Testing

- `golangci-lint run -v`
- `go test -race ./...`
- `npm run check:all`
- `npm test` — 180 test files / 2,663 tests passed
- Focused media and disk-manager race tests

## Preflight Status

- Single concern: one downloaded-filename bug fix
- All six preflight review passes completed; all changed-code findings resolved
- Go and frontend linters passed with zero issues
- Full backend race suite and frontend test suite passed
- Diff contains only the five relevant media/disk-manager files
- No TODO/FIXME, secrets, credentials, or PII introduced
- No API, configuration, database, or stored-file compatibility break
- User-facing filename-format change documented above
- i18n not applicable; no frontend strings changed
- Secondary-model cross-validation unavailable because external model access was blocked


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio download/display filenames by normalizing legacy timestamp-based names (including edge cases like spaces).
  * Hardened audio response headers so inline playback/download uses correct `Content-Disposition` and audio-specific headers don’t leak into JSON error responses.
  * More consistent behavior when waiting for audio encoding (including grace-period serving) and for ID-based audio, including `Accept-Ranges: bytes`.

* **Refactor**
  * Standardized media duration-suffix stripping via a shared exported helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->