### PR TITLE
fix(profiling): move pprof off the unauthenticated telemetry listener

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -748,6 +748,17 @@
       "type": "object",
       "description": "DetectionsGridConfig holds configuration for the detections grid element."
     },
+    "DiagnosticsConfig": {
+      "properties": {
+        "profiling": {
+          "$ref": "#/$defs/ProfilingConfig",
+          "description": "pprof HTTP endpoint configuration"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "DiagnosticsConfig groups the developer-facing diagnostics features."
+    },
     "DiskMonitorConfig": {
       "properties": {
         "enabled": {
@@ -1512,6 +1523,21 @@
       "type": "object",
       "description": "PrivacyFilterSettings contains settings for the privacy filter."
     },
+    "ProfilingConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "true to serve /debug/pprof/* on the web server"
+        },
+        "token": {
+          "type": "string",
+          "description": "secret required when no auth provider is configured; generated automatically"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ProfilingConfig gates the Go pprof HTTP endpoints."
+    },
     "PublicAccess": {
       "properties": {
         "liveaudio": {
@@ -2204,6 +2230,10 @@
         "sentry": {
           "$ref": "#/$defs/SentrySettings",
           "description": "Sentry error tracking configuration"
+        },
+        "diagnostics": {
+          "$ref": "#/$defs/DiagnosticsConfig",
+          "description": "developer diagnostics (pprof profiling)"
         },
         "output": {
           "properties": {

--- a/config.schema.json
+++ b/config.schema.json
@@ -1531,7 +1531,7 @@
         },
         "token": {
           "type": "string",
-          "description": "secret required when no auth provider is configured; generated at startup"
+          "description": "secret required when no auth provider is configured; generated automatically"
         }
       },
       "additionalProperties": false,

--- a/config.schema.json
+++ b/config.schema.json
@@ -1531,7 +1531,7 @@
         },
         "token": {
           "type": "string",
-          "description": "secret required when no auth provider is configured; generated automatically"
+          "description": "secret required when no auth provider is configured; generated at startup"
         }
       },
       "additionalProperties": false,

--- a/doc/wiki/configuration-reference.md
+++ b/doc/wiki/configuration-reference.md
@@ -401,7 +401,7 @@ DiagnosticsConfig groups the developer-facing diagnostics features.
 | Setting | Type | Description |
 |---------|------|-------------|
 | `diagnostics.profiling.enabled` | boolean | true to serve /debug/pprof/* on the web server |
-| `diagnostics.profiling.token` | string | secret required when no auth provider is configured; generated automatically |
+| `diagnostics.profiling.token` | string | secret required when no auth provider is configured; generated at startup |
 
 ## output
 

--- a/doc/wiki/configuration-reference.md
+++ b/doc/wiki/configuration-reference.md
@@ -401,7 +401,7 @@ DiagnosticsConfig groups the developer-facing diagnostics features.
 | Setting | Type | Description |
 |---------|------|-------------|
 | `diagnostics.profiling.enabled` | boolean | true to serve /debug/pprof/* on the web server |
-| `diagnostics.profiling.token` | string | secret required when no auth provider is configured; generated at startup |
+| `diagnostics.profiling.token` | string | secret required when no auth provider is configured; generated automatically |
 
 ## output
 

--- a/doc/wiki/configuration-reference.md
+++ b/doc/wiki/configuration-reference.md
@@ -394,6 +394,15 @@ SentrySettings contains settings for Sentry error tracking
 | `sentry.enabled` | boolean | true to enable Sentry error tracking (opt-in) |
 | `sentry.debug` | boolean | true to enable transparent telemetry logging |
 
+## diagnostics
+
+DiagnosticsConfig groups the developer-facing diagnostics features.
+
+| Setting | Type | Description |
+|---------|------|-------------|
+| `diagnostics.profiling.enabled` | boolean | true to serve /debug/pprof/* on the web server |
+| `diagnostics.profiling.token` | string | secret required when no auth provider is configured; generated automatically |
+
 ## output
 
 | Setting | Type | Description |

--- a/internal/api/middleware/compression.go
+++ b/internal/api/middleware/compression.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	pathpkg "path"
 	"strings"
 
 	"github.com/labstack/echo/v4"
@@ -127,7 +128,21 @@ func DefaultGzipSkipper(c echo.Context) bool {
 	if _, ok := streamingJSONRoutes[c.Path()]; ok {
 		return true
 	}
+	if PprofSkipper(c) {
+		return true
+	}
 	return c.Request().Header.Get(headerRange) != ""
+}
+
+// PprofSkipper returns true for the Go pprof endpoints.
+//
+// A pprof profile is already a gzip-compressed protobuf (it starts with the
+// gzip magic bytes), so compressing it again spends CPU to make the payload
+// slightly larger. The execution trace is a long-lived stream that a compressor
+// would buffer, like the SSE and progress-stream routes above.
+func PprofSkipper(c echo.Context) bool {
+	path := pathpkg.Clean(c.Request().URL.Path)
+	return path == pprofBasePath || strings.HasPrefix(path, pprofBasePath+"/")
 }
 
 // SSESkipper is a skipper function that skips compression for Server-Sent Events endpoints.

--- a/internal/api/middleware/compression.go
+++ b/internal/api/middleware/compression.go
@@ -110,6 +110,8 @@ func NewGzipWithSkipper(level int, skipper middleware.Skipper) echo.MiddlewareFu
 //   - Server-Sent Events endpoints (see SSESkipper).
 //   - Binary media routes serving audio, images, or HLS content (see MediaPathSkipper).
 //   - Routes that serve already-compressed responses (see precompressedRoutes).
+//   - The Go pprof endpoints, whose profiles are already gzip streams (see
+//     PprofSkipper).
 //   - NDJSON/JSON progress-streaming routes (see streamingJSONRoutes), where a
 //     gzip buffering boundary would withhold flushed results and defeat the
 //     live progress UX.
@@ -136,13 +138,22 @@ func DefaultGzipSkipper(c echo.Context) bool {
 
 // PprofSkipper returns true for the Go pprof endpoints.
 //
-// A pprof profile is already a gzip-compressed protobuf (it starts with the
-// gzip magic bytes), so compressing it again spends CPU to make the payload
-// slightly larger. The execution trace is a long-lived stream that a compressor
-// would buffer, like the SSE and progress-stream routes above.
+// The profile endpoints dominate the traffic here and are already
+// gzip-compressed protobuf (a profile response starts with the gzip magic
+// bytes), so compressing them again spends CPU to make the payload slightly
+// larger, and the execution trace is a long-lived stream a compressor would
+// buffer, like the SSE and progress-stream routes above. The index, /cmdline
+// and /symbol are plain text and would compress fine; they are covered by the
+// same prefix because splitting the subtree would buy a few hundred bytes on
+// endpoints nobody polls, at the cost of a second rule to keep in sync.
+//
+// Unlike its siblings above this matches the cleaned REQUEST path rather than
+// the route template, because it shares isPprofPath with the CSRF skipper,
+// which must match on the request path to stay traversal-safe. Matching both on
+// the same value is what guarantees the two exemptions cannot disagree about
+// which requests are pprof requests.
 func PprofSkipper(c echo.Context) bool {
-	path := pathpkg.Clean(c.Request().URL.Path)
-	return path == pprofBasePath || strings.HasPrefix(path, pprofBasePath+"/")
+	return isPprofPath(pathpkg.Clean(c.Request().URL.Path))
 }
 
 // SSESkipper is a skipper function that skips compression for Server-Sent Events endpoints.

--- a/internal/api/middleware/compression_test.go
+++ b/internal/api/middleware/compression_test.go
@@ -154,6 +154,25 @@ func TestDefaultGzipSkipper(t *testing.T) {
 		assert.True(t, DefaultGzipSkipper(c),
 			"the species dictionary route serves precompressed bytes and must not be re-gzipped")
 	})
+
+	t.Run("skips pprof routes", func(t *testing.T) {
+		t.Parallel()
+		// Matched on the request path, not the route template, because the
+		// named profiles are served by one wildcard route.
+		for _, path := range []string{"/debug/pprof", "/debug/pprof/heap", "/debug/pprof/profile"} {
+			c, _ := newTestContext(t, http.MethodGet, path)
+			setPathForContext(t, c, "/debug/pprof/*")
+			assert.True(t, DefaultGzipSkipper(c),
+				"a pprof profile is already a gzip stream: %s", path)
+		}
+	})
+
+	t.Run("does not skip a pprof lookalike path", func(t *testing.T) {
+		t.Parallel()
+		c, _ := newTestContext(t, http.MethodGet, "/debug/pprofiler")
+		setPathForContext(t, c, "/debug/pprofiler")
+		assert.False(t, DefaultGzipSkipper(c))
+	})
 }
 
 func TestDefaultGzipSkipper_SkipsStreamingJSONRoutes(t *testing.T) {

--- a/internal/api/middleware/csrf.go
+++ b/internal/api/middleware/csrf.go
@@ -187,7 +187,9 @@ func DefaultCSRFSkipper(c echo.Context) bool {
 	// the media/streams block above uses, so a future state-changing route
 	// under this prefix does not inherit the exemption by accident.
 	if isPprofPath(path) {
-		return isSafeHTTPMethod(c.Request().Method) || path == pprofBasePath+"/symbol"
+		method := c.Request().Method
+		return isSafeHTTPMethod(method) ||
+			(method == http.MethodPost && path == pprofBasePath+"/symbol")
 	}
 
 	return false

--- a/internal/api/middleware/csrf.go
+++ b/internal/api/middleware/csrf.go
@@ -28,6 +28,12 @@ const (
 	csrfTokenLength = 32
 )
 
+// pprofBasePath is the URL prefix under which the api package mounts the Go
+// pprof endpoints. It is duplicated here rather than imported because the api
+// package imports this one; net/http/pprof pins the prefix anyway, so it cannot
+// drift. Used by the CSRF and gzip skippers.
+const pprofBasePath = "/debug/pprof"
+
 // IsSecureRequest determines if the request is over HTTPS.
 // Checks direct TLS connection first, then X-Forwarded-Proto but only when
 // the request originates from a trusted source (loopback or private network).
@@ -150,6 +156,17 @@ func DefaultCSRFSkipper(c echo.Context) bool {
 
 	// Skip for social OAuth endpoints (GET requests for OAuth flow)
 	if strings.HasPrefix(path, "/auth/") {
+		return true
+	}
+
+	// Skip for the pprof endpoints. `go tool pprof` resolves addresses with a
+	// POST to /debug/pprof/symbol and sends no CSRF token, so requiring one
+	// would break symbolization for the tool the endpoints exist to serve.
+	// Exempting them is safe on both counts CSRF protects: the handlers are
+	// read-only (symbol lookup returns names, it changes nothing), and the
+	// routes carry their own gate, which is either the auth middleware or a
+	// secret query token that a cross-site request cannot supply.
+	if path == pprofBasePath || strings.HasPrefix(path, pprofBasePath+"/") {
 		return true
 	}
 

--- a/internal/api/middleware/csrf.go
+++ b/internal/api/middleware/csrf.go
@@ -29,10 +29,26 @@ const (
 )
 
 // pprofBasePath is the URL prefix under which the api package mounts the Go
-// pprof endpoints. It is duplicated here rather than imported because the api
-// package imports this one; net/http/pprof pins the prefix anyway, so it cannot
-// drift. Used by the CSRF and gzip skippers.
+// pprof endpoints. It is duplicated from api.PprofBasePath rather than imported
+// because the api package imports this one, so the dependency cannot be
+// reversed.
+//
+// Nothing mechanically couples the two constants, so TestPprofSkippersMatchMountPath
+// in package api feeds api.PprofBasePath through both skippers. Without it a
+// relocated mount would silently re-enable CSRF on the symbol POST and
+// double-gzip every profile, with no test failing.
 const pprofBasePath = "/debug/pprof"
+
+// isPprofPath reports whether an already-cleaned request path addresses the
+// pprof mount. Shared by the CSRF and gzip skippers so the two cannot drift
+// into different spellings of the same predicate.
+//
+// The caller passes a path that has been through path.Clean, which is what
+// keeps a traversal such as /debug/pprof/../api/v2/settings from inheriting the
+// exemption: it cleans to the settings path and stops matching here.
+func isPprofPath(cleanPath string) bool {
+	return cleanPath == pprofBasePath || strings.HasPrefix(cleanPath, pprofBasePath+"/")
+}
 
 // IsSecureRequest determines if the request is over HTTPS.
 // Checks direct TLS connection first, then X-Forwarded-Proto but only when
@@ -162,12 +178,16 @@ func DefaultCSRFSkipper(c echo.Context) bool {
 	// Skip for the pprof endpoints. `go tool pprof` resolves addresses with a
 	// POST to /debug/pprof/symbol and sends no CSRF token, so requiring one
 	// would break symbolization for the tool the endpoints exist to serve.
-	// Exempting them is safe on both counts CSRF protects: the handlers are
-	// read-only (symbol lookup returns names, it changes nothing), and the
-	// routes carry their own gate, which is either the auth middleware or a
-	// secret query token that a cross-site request cannot supply.
-	if path == pprofBasePath || strings.HasPrefix(path, pprofBasePath+"/") {
-		return true
+	// Exempting it is safe on both counts CSRF protects: pprof.Symbol is
+	// read-only (it returns function names for addresses, changing nothing),
+	// and the routes carry their own gate, either the auth middleware or a
+	// secret query token a cross-site request cannot supply.
+	//
+	// Scoped to safe methods plus that one POST, matching the narrower idiom
+	// the media/streams block above uses, so a future state-changing route
+	// under this prefix does not inherit the exemption by accident.
+	if isPprofPath(path) {
+		return isSafeHTTPMethod(c.Request().Method) || path == pprofBasePath+"/symbol"
 	}
 
 	return false

--- a/internal/api/middleware/csrf_test.go
+++ b/internal/api/middleware/csrf_test.go
@@ -170,6 +170,16 @@ func TestDefaultCSRFSkipper(t *testing.T) {
 		// Logout — skipped (must work even with expired CSRF tokens)
 		{"POST auth logout", http.MethodPost, "/api/v2/auth/logout", true},
 
+		// pprof — always skipped. go tool pprof POSTs to /symbol with no CSRF
+		// token, and the handlers are read-only and separately gated (auth
+		// middleware, or a secret query token a cross-site request cannot supply).
+		{"GET pprof index", http.MethodGet, "/debug/pprof", true},
+		{"GET pprof heap", http.MethodGet, "/debug/pprof/heap", true},
+		{"POST pprof symbol", http.MethodPost, "/debug/pprof/symbol", true},
+
+		// A path that merely starts with the same characters is not pprof.
+		{"POST debug lookalike", http.MethodPost, "/debug/pprofiler", false},
+
 		// Regular API paths — never skipped
 		{"GET detections", http.MethodGet, "/api/v2/detections/1", false},
 		{"POST settings", http.MethodPost, "/api/v2/settings", false},

--- a/internal/api/pprof.go
+++ b/internal/api/pprof.go
@@ -1,0 +1,138 @@
+// internal/api/pprof.go
+package api
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"net/http/pprof"
+
+	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+const (
+	// PprofBasePath is the URL prefix serving the Go pprof endpoints. The pprof
+	// package derives the requested profile name from this exact prefix, so it
+	// cannot be relocated without wrapping every handler.
+	PprofBasePath = "/debug/pprof"
+
+	// pprofTokenParam carries the profiling token when no authentication
+	// provider is configured. A query parameter rather than a header because
+	// `go tool pprof` has no flag for custom headers, but does preserve query
+	// parameters it did not set and merges its own into them, which keeps the
+	// one-command workflow intact:
+	//
+	//	go tool pprof "http://host:8080/debug/pprof/profile?token=SECRET&seconds=3"
+	//
+	// The access logger scrubs token= from the query string it records
+	// (privacy.ScrubQueryString), so the credential does not land in the logs.
+	pprofTokenParam = "token" //nolint:gosec // parameter name, not a credential
+
+	// profilingRefusedMessage is returned for every refused profiling request.
+	// It is deliberately identical whether the token was absent, malformed, or
+	// simply wrong.
+	profilingRefusedMessage = "Profiling access denied"
+)
+
+// registerPprofRoutes mounts the Go pprof endpoints on the main web server.
+//
+// They used to live on the Prometheus telemetry listener, which is served by a
+// bare ServeMux with no middleware, so enabling metrics also published
+// profiling on every interface with no authentication at all. Here they sit
+// behind the server's own auth, or behind a generated token where no
+// authentication provider is configured.
+//
+// The routes are registered unconditionally and gated per request, so
+// diagnostics.profiling.enabled hot-reloads like every other setting.
+//
+// Long-running requests need no special handling here: net/http/pprof extends
+// the response write deadline itself (configureWriteDeadline) to the server's
+// WriteTimeout plus the requested sampling duration, so the default 30-second
+// CPU profile completes against the server's 30-second WriteTimeout. It reaches
+// the connection through http.ResponseController, which walks the writer chain
+// via Unwrap; both echo.Response and Echo's gzip writer implement Unwrap, so
+// the chain holds. TestProfilingCPUProfileOutlivesWriteTimeout is the guard on
+// that, since SetWriteDeadline's error is discarded inside pprof and a broken
+// chain would truncate profiles silently.
+func (s *Server) registerPprofRoutes() {
+	gate := s.profilingGate()
+
+	// pprof.Index serves the landing page and also dispatches every named
+	// runtime profile (heap, allocs, goroutine, block, mutex, threadcreate)
+	// from the path suffix, so one wildcard route covers all of them. The
+	// handlers below are not runtime profiles and need their own routes; Index
+	// would answer them with "Unknown profile".
+	index := echo.WrapHandler(http.HandlerFunc(pprof.Index))
+
+	s.echo.GET(PprofBasePath, index, gate)
+	s.echo.GET(PprofBasePath+"/cmdline", echo.WrapHandler(http.HandlerFunc(pprof.Cmdline)), gate)
+	s.echo.GET(PprofBasePath+"/profile", echo.WrapHandler(http.HandlerFunc(pprof.Profile)), gate)
+	s.echo.GET(PprofBasePath+"/trace", echo.WrapHandler(http.HandlerFunc(pprof.Trace)), gate)
+	// go tool pprof resolves addresses with a POST body of newline-separated
+	// addresses, so /symbol answers both methods.
+	s.echo.GET(PprofBasePath+"/symbol", echo.WrapHandler(http.HandlerFunc(pprof.Symbol)), gate)
+	s.echo.POST(PprofBasePath+"/symbol", echo.WrapHandler(http.HandlerFunc(pprof.Symbol)), gate)
+	s.echo.GET(PprofBasePath+"/*", index, gate)
+
+	s.slogger.Debug("pprof routes registered (gated by diagnostics.profiling.enabled)",
+		logger.String("path", PprofBasePath))
+}
+
+// profilingGate guards every pprof route.
+//
+// Settings are read per request through currentSettings() rather than captured
+// at construction, so toggling diagnostics.profiling.enabled takes effect
+// without a restart, matching how the basepath middleware resolves its own
+// setting.
+func (s *Server) profilingGate() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			settings := s.currentSettings()
+			if settings == nil || !settings.Diagnostics.Profiling.Enabled {
+				// 404 rather than 403: a disabled feature should not announce
+				// that it exists and is merely closed.
+				return echo.NewHTTPError(http.StatusNotFound)
+			}
+
+			// With an authentication provider configured, the server's own auth
+			// middleware is the gate. It also applies the allowed-subnet bypass
+			// exactly as it does for every other protected route, so profiling
+			// is not held to a stricter standard than the settings pages that
+			// already expose real credentials.
+			if settings.IsAuthProviderConfigured() {
+				if s.authMiddleware == nil {
+					// Configured but never wired (no OAuth2Server injected).
+					// Fail closed rather than fall through to the token branch,
+					// where no token was minted precisely because auth exists.
+					s.slogger.Error("Profiling request refused: authentication is configured but the auth middleware is not initialized",
+						logger.String("ip", c.RealIP()))
+					return echo.NewHTTPError(http.StatusForbidden, profilingRefusedMessage)
+				}
+				return s.authMiddleware(next)(c)
+			}
+
+			// No authentication provider, so the generated token is the only
+			// credential. Never log its value, presented or configured.
+			if !profilingTokenMatches(settings.Diagnostics.Profiling.Token, c.QueryParam(pprofTokenParam)) {
+				s.slogger.Warn("Profiling request refused: missing or invalid token",
+					logger.String("ip", c.RealIP()),
+					logger.String("path", c.Request().URL.Path))
+				return echo.NewHTTPError(http.StatusForbidden, profilingRefusedMessage)
+			}
+
+			return next(c)
+		}
+	}
+}
+
+// profilingTokenMatches compares the presented token against the configured one
+// in constant time.
+//
+// An empty configured token never matches, so an instance where token
+// generation failed refuses every request instead of accepting any.
+func profilingTokenMatches(configured, presented string) bool {
+	if configured == "" || presented == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(configured), []byte(presented)) == 1
+}

--- a/internal/api/pprof.go
+++ b/internal/api/pprof.go
@@ -50,10 +50,18 @@ const (
 // WriteTimeout plus the requested sampling duration, so the default 30-second
 // CPU profile completes against the server's 30-second WriteTimeout. It reaches
 // the connection through http.ResponseController, which walks the writer chain
-// via Unwrap; both echo.Response and Echo's gzip writer implement Unwrap, so
-// the chain holds. TestProfilingCPUProfileOutlivesWriteTimeout is the guard on
-// that, since SetWriteDeadline's error is discarded inside pprof and a broken
-// chain would truncate profiles silently.
+// via Unwrap, and it discards SetWriteDeadline's error, so a middleware that
+// wraps the ResponseWriter without implementing Unwrap would truncate long
+// profiles with no log line. echo.Response implements Unwrap; gzip is not in
+// this chain at all, because PprofSkipper takes these routes out of it.
+// TestProfilingCPUProfileOutlivesWriteTimeout drives the real middleware stack
+// over a real listener to keep that true.
+//
+// Note the gate is route middleware, so it runs only for the methods registered
+// below. A request with another method is answered by Echo's own 405/204
+// handler before the gate, which reveals that the routes are mounted but
+// nothing about whether profiling is enabled or what it would serve. Every
+// build mounts them, so that discloses nothing instance-specific.
 func (s *Server) registerPprofRoutes() {
 	gate := s.profilingGate()
 
@@ -64,7 +72,7 @@ func (s *Server) registerPprofRoutes() {
 	// would answer them with "Unknown profile".
 	index := echo.WrapHandler(http.HandlerFunc(pprof.Index))
 
-	s.echo.GET(PprofBasePath, index, gate)
+	s.echo.GET(PprofBasePath, s.redirectToPprofIndex, gate)
 	s.echo.GET(PprofBasePath+"/cmdline", echo.WrapHandler(http.HandlerFunc(pprof.Cmdline)), gate)
 	s.echo.GET(PprofBasePath+"/profile", echo.WrapHandler(http.HandlerFunc(pprof.Profile)), gate)
 	s.echo.GET(PprofBasePath+"/trace", echo.WrapHandler(http.HandlerFunc(pprof.Trace)), gate)
@@ -76,6 +84,29 @@ func (s *Server) registerPprofRoutes() {
 
 	s.slogger.Debug("pprof routes registered (gated by diagnostics.profiling.enabled)",
 		logger.String("path", PprofBasePath))
+}
+
+// redirectToPprofIndex sends /debug/pprof to /debug/pprof/.
+//
+// pprof.Index emits RELATIVE links (`<a href="goroutine?debug=2">`). A browser
+// resolves those against /debug/ from the unslashed path and against
+// /debug/pprof/ from the slashed one, so serving the index directly here would
+// render a page on which every link 404s. net/http.ServeMux issued this
+// redirect implicitly for a subtree pattern, which is why the endpoints did not
+// need it in their previous home; Echo matches the two paths as distinct routes
+// and does not.
+//
+// The query string is carried across, or the hop would drop the token and land
+// on a 403. The basepath is resolved per request so the Location stays valid
+// behind a reverse-proxy prefix. 302 rather than 301: the URL can carry a
+// credential and a permanent redirect is worth neither the cache entry nor the
+// risk of pinning a stale path in browsers.
+func (s *Server) redirectToPprofIndex(c echo.Context) error {
+	target := ingressPath(c, s.currentSettings()) + PprofBasePath + "/"
+	if q := c.Request().URL.RawQuery; q != "" {
+		target += "?" + q
+	}
+	return c.Redirect(http.StatusFound, target)
 }
 
 // profilingGate guards every pprof route.
@@ -95,16 +126,27 @@ func (s *Server) profilingGate() echo.MiddlewareFunc {
 			}
 
 			// With an authentication provider configured, the server's own auth
-			// middleware is the gate. It also applies the allowed-subnet bypass
-			// exactly as it does for every other protected route, so profiling
-			// is not held to a stricter standard than the settings pages that
-			// already expose real credentials.
+			// middleware is the gate, and it applies the allowed-subnet bypass
+			// exactly as it does for every other protected route.
+			//
+			// That bypass is worth stating plainly rather than filing under
+			// consistency: with security.allowsubnetbypass on, enabling
+			// profiling gives the whole configured subnet /debug/pprof with no
+			// credential, and no token is minted to stand in the way (none is,
+			// when an auth provider exists). The settings pages reachable the
+			// same way redact their secrets on read; /debug/pprof/cmdline
+			// returns argv verbatim and goroutine dumps carry live stacks, so
+			// this is a wider grant than the bypass already implies. It is
+			// opt-in and off by default, which is why it is documented here
+			// rather than special-cased.
 			if settings.IsAuthProviderConfigured() {
 				if s.authMiddleware == nil {
 					// Configured but never wired (no OAuth2Server injected).
 					// Fail closed rather than fall through to the token branch,
 					// where no token was minted precisely because auth exists.
-					s.slogger.Error("Profiling request refused: authentication is configured but the auth middleware is not initialized",
+					// Credential events go to the security log, where #3381
+					// established admins look for them, not the api log.
+					s.securityLog().Error("Profiling request refused: authentication is configured but the auth middleware is not initialized",
 						logger.String("ip", c.RealIP()))
 					return echo.NewHTTPError(http.StatusForbidden, profilingRefusedMessage)
 				}

--- a/internal/api/pprof_live_test.go
+++ b/internal/api/pprof_live_test.go
@@ -2,6 +2,8 @@
 package api
 
 import (
+	"bytes"
+	"compress/gzip"
 	"io"
 	"net"
 	"net/http"
@@ -9,11 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tphakala/birdnet-go/internal/conf"
-	"github.com/tphakala/birdnet-go/internal/conf/conftest"
 )
 
 // TestProfilingCPUProfileOutlivesWriteTimeout serves the routes over a real
@@ -41,20 +40,11 @@ func TestProfilingCPUProfileOutlivesWriteTimeout(t *testing.T) {
 	require.Greater(t, profileSeconds*time.Second, serverWriteTimeout,
 		"the test is meaningless unless the profile outlasts the write timeout")
 
-	settings := profilingSettings(true, testProfilingToken)
-
-	previous := conf.GetSettings()
-	t.Cleanup(func() { conf.StoreSettings(previous) })
-	conftest.SetTestSettings(settings)
-
-	s := &Server{
-		echo:     echo.New(),
-		config:   DefaultConfig(),
-		settings: settings,
-		slogger:  GetLogger(),
-	}
-	s.echo.HideBanner = true
-	s.registerPprofRoutes()
+	s := newPprofTestServer(t, profilingSettings(true, testProfilingToken))
+	// The real middleware stack, which is the entire point: the Unwrap chain
+	// this test guards runs through whatever setupMiddleware installs, and a
+	// bare echo.New() would prove only that echo.Response implements Unwrap.
+	s.setupMiddleware()
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
@@ -83,31 +73,28 @@ func TestProfilingCPUProfileOutlivesWriteTimeout(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode,
 		"pprof refused the request; body: %s", string(body))
 	assert.NotEmpty(t, body)
-	// A CPU profile is a gzip stream; the magic bytes confirm a complete,
-	// well-formed response rather than a truncated or error body.
-	require.GreaterOrEqual(t, len(body), 2)
-	assert.Equal(t, []byte{0x1f, 0x8b}, body[:2],
-		"expected a gzip-framed pprof profile")
+
+	// Decompress rather than checking the gzip magic bytes. Magic bytes are the
+	// FIRST two, so a response truncated at 99% still has them: the assertion
+	// would hold for exactly the failure it claims to detect. gzip.Reader
+	// verifies the trailing CRC32 and length, so a short read fails here.
+	zr, err := gzip.NewReader(bytes.NewReader(body))
+	require.NoError(t, err, "response is not a gzip-framed pprof profile")
+	defer func() { _ = zr.Close() }()
+
+	raw, err := io.ReadAll(zr)
+	require.NoError(t, err,
+		"the profile was truncated: the write deadline cut the response short")
+	assert.NotEmpty(t, raw, "a complete profile must decompress to a non-empty payload")
 }
 
-// TestProfilingLiveTokenRefusal confirms the refusal path over a real listener
-// too, so the gate is not accidentally bypassed by anything in the real serving
-// stack that the in-process tests skip.
+// TestProfilingLiveTokenRefusal confirms the refusal survives the full
+// middleware stack over a real transport. The in-process tests drive Echo
+// directly with no middleware, so this is the one that would notice a
+// middleware ordering change letting a request past the gate.
 func TestProfilingLiveTokenRefusal(t *testing.T) {
-	settings := profilingSettings(true, testProfilingToken)
-
-	previous := conf.GetSettings()
-	t.Cleanup(func() { conf.StoreSettings(previous) })
-	conftest.SetTestSettings(settings)
-
-	s := &Server{
-		echo:     echo.New(),
-		config:   DefaultConfig(),
-		settings: settings,
-		slogger:  GetLogger(),
-	}
-	s.echo.HideBanner = true
-	s.registerPprofRoutes()
+	s := newPprofTestServer(t, profilingSettings(true, testProfilingToken))
+	s.setupMiddleware()
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)

--- a/internal/api/pprof_live_test.go
+++ b/internal/api/pprof_live_test.go
@@ -1,0 +1,125 @@
+// internal/api/pprof_live_test.go
+package api
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/conf/conftest"
+)
+
+// TestProfilingCPUProfileOutlivesWriteTimeout serves the routes over a real
+// listener whose http.Server carries a WriteTimeout shorter than the requested
+// sampling duration. That is the shape production runs in: the web server's
+// WriteTimeout is 30s and `go tool pprof` asks for 30 seconds by default, so
+// without the deadline being extended every default CPU profile would be cut
+// off mid-response.
+//
+// net/http/pprof extends that deadline itself (configureWriteDeadline), but it
+// reaches the connection through http.ResponseController, which walks the
+// writer chain via Unwrap, and it discards SetWriteDeadline's error. So any
+// middleware that wraps the ResponseWriter without implementing Unwrap breaks
+// long profiles silently, with no log line and no failing unit test. This is
+// the guard on that, and it has to use a real listener: an httptest recorder
+// has no deadline to miss.
+//
+// The durations are scaled down so the test costs a few seconds rather than
+// thirty; the relationship that matters (requested > WriteTimeout) is the same.
+func TestProfilingCPUProfileOutlivesWriteTimeout(t *testing.T) {
+	const (
+		serverWriteTimeout = 2 * time.Second
+		profileSeconds     = 3
+	)
+	require.Greater(t, profileSeconds*time.Second, serverWriteTimeout,
+		"the test is meaningless unless the profile outlasts the write timeout")
+
+	settings := profilingSettings(true, testProfilingToken)
+
+	previous := conf.GetSettings()
+	t.Cleanup(func() { conf.StoreSettings(previous) })
+	conftest.SetTestSettings(settings)
+
+	s := &Server{
+		echo:     echo.New(),
+		config:   DefaultConfig(),
+		settings: settings,
+		slogger:  GetLogger(),
+	}
+	s.echo.HideBanner = true
+	s.registerPprofRoutes()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv := &http.Server{
+		Handler:           s.echo,
+		ReadHeaderTimeout: serverWriteTimeout,
+		WriteTimeout:      serverWriteTimeout,
+	}
+	go func() { _ = srv.Serve(listener) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	url := "http://" + listener.Addr().String() + PprofBasePath + "/profile" +
+		"?token=" + testProfilingToken +
+		"&seconds=" + strconv.Itoa(profileSeconds)
+
+	// A generous client timeout: the server side is what is under test.
+	client := &http.Client{Timeout: time.Duration(profileSeconds)*time.Second + 30*time.Second}
+	resp, err := client.Get(url) //nolint:noctx // bounded by the client timeout above
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err, "the profile must not be cut short by the write deadline")
+
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"pprof refused the request; body: %s", string(body))
+	assert.NotEmpty(t, body)
+	// A CPU profile is a gzip stream; the magic bytes confirm a complete,
+	// well-formed response rather than a truncated or error body.
+	require.GreaterOrEqual(t, len(body), 2)
+	assert.Equal(t, []byte{0x1f, 0x8b}, body[:2],
+		"expected a gzip-framed pprof profile")
+}
+
+// TestProfilingLiveTokenRefusal confirms the refusal path over a real listener
+// too, so the gate is not accidentally bypassed by anything in the real serving
+// stack that the in-process tests skip.
+func TestProfilingLiveTokenRefusal(t *testing.T) {
+	settings := profilingSettings(true, testProfilingToken)
+
+	previous := conf.GetSettings()
+	t.Cleanup(func() { conf.StoreSettings(previous) })
+	conftest.SetTestSettings(settings)
+
+	s := &Server{
+		echo:     echo.New(),
+		config:   DefaultConfig(),
+		settings: settings,
+		slogger:  GetLogger(),
+	}
+	s.echo.HideBanner = true
+	s.registerPprofRoutes()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv := &http.Server{Handler: s.echo, ReadHeaderTimeout: 5 * time.Second}
+	go func() { _ = srv.Serve(listener) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get("http://" + listener.Addr().String() + heapPath) //nolint:noctx // bounded by the client timeout above
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}

--- a/internal/api/pprof_test.go
+++ b/internal/api/pprof_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	mw "github.com/tphakala/birdnet-go/internal/api/middleware"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/conf/conftest"
 )
@@ -62,21 +63,75 @@ func doPprofRequest(t *testing.T, s *Server, target string) *httptest.ResponseRe
 	return rec
 }
 
+// gatedRoute is one registered pprof route, as (method, path).
+type gatedRoute struct {
+	method string
+	path   string
+}
+
+// gatedRoutes enumerates EVERY route registerPprofRoutes mounts.
+//
+// It is a single shared list precisely so the refusal tests cannot drift into
+// covering a subset. The earlier version of this file drove only /heap through
+// the gate, which meant deleting the gate from /trace or /symbol left the whole
+// suite green while republishing an execution trace and the symbol table
+// unauthenticated. Any route added to registerPprofRoutes must be added here,
+// and TestProfilingRoutesAreAllGated fails if the two ever disagree in the
+// direction that matters.
+var gatedRoutes = []gatedRoute{
+	{http.MethodGet, PprofBasePath},
+	{http.MethodGet, PprofBasePath + "/"},
+	{http.MethodGet, PprofBasePath + "/cmdline"},
+	{http.MethodGet, PprofBasePath + "/profile"},
+	{http.MethodGet, PprofBasePath + "/trace"},
+	{http.MethodGet, PprofBasePath + "/symbol"},
+	{http.MethodPost, PprofBasePath + "/symbol"},
+	{http.MethodGet, PprofBasePath + "/heap"},
+	{http.MethodGet, PprofBasePath + "/allocs"},
+	{http.MethodGet, PprofBasePath + "/goroutine"},
+	{http.MethodGet, PprofBasePath + "/block"},
+	{http.MethodGet, PprofBasePath + "/mutex"},
+	{http.MethodGet, PprofBasePath + "/threadcreate"},
+}
+
+// doGatedRequest issues one route's request with an optional query.
+func doGatedRequest(t *testing.T, s *Server, r gatedRoute, query string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(r.method, r.path+query, http.NoBody)
+	rec := httptest.NewRecorder()
+	s.echo.ServeHTTP(rec, req)
+	return rec
+}
+
 // TestProfilingGate_DisabledReturns404 covers the acceptance criterion that a
-// disabled feature must not advertise itself: 404, never 403.
+// disabled feature must not advertise itself: 404, never 403. Every registered
+// route, not a sample.
 func TestProfilingGate_DisabledReturns404(t *testing.T) {
 	s := newPprofTestServer(t, profilingSettings(false, testProfilingToken))
 
-	for _, path := range []string{
-		PprofBasePath,
-		heapPath,
-		PprofBasePath + "/cmdline",
-		PprofBasePath + "/profile",
-	} {
-		t.Run(path, func(t *testing.T) {
-			rec := doPprofRequest(t, s, path)
+	for _, r := range gatedRoutes {
+		t.Run(r.method+r.path, func(t *testing.T) {
+			rec := doGatedRequest(t, s, r, "")
 			assert.Equal(t, http.StatusNotFound, rec.Code,
 				"disabled profiling must be indistinguishable from an unrouted path")
+		})
+	}
+}
+
+// TestProfilingRoutesAreAllGated drives every registered route with no
+// credential on an ENABLED instance. This is the fail-open guard: a route that
+// lost its gate would answer 200 here.
+func TestProfilingRoutesAreAllGated(t *testing.T) {
+	s := newPprofTestServer(t, profilingSettings(true, testProfilingToken))
+
+	for _, r := range gatedRoutes {
+		t.Run(r.method+r.path, func(t *testing.T) {
+			rec := doGatedRequest(t, s, r, "")
+			assert.Equal(t, http.StatusForbidden, rec.Code,
+				"every pprof route must refuse a request carrying no token")
+			assert.NotContains(t, rec.Body.String(), "runtime.",
+				"a refused request must not carry profile content")
 		})
 	}
 }
@@ -279,7 +334,7 @@ func TestProfilingRoutes_NamedProfilesAndHandlers(t *testing.T) {
 
 	// trace and profile are excluded: both sample for seconds before responding.
 	for _, path := range []string{
-		PprofBasePath,
+		PprofBasePath + "/",
 		PprofBasePath + "/heap",
 		PprofBasePath + "/allocs",
 		PprofBasePath + "/goroutine",
@@ -292,6 +347,81 @@ func TestProfilingRoutes_NamedProfilesAndHandlers(t *testing.T) {
 		t.Run(path, func(t *testing.T) {
 			rec := doPprofRequest(t, s, path+"?token="+testProfilingToken)
 			assert.Equal(t, http.StatusOK, rec.Code)
+		})
+	}
+}
+
+// TestProfilingIndexRedirectsToSlashedPath guards a bug that static review
+// missed and only rendering the page exposes.
+//
+// pprof.Index emits RELATIVE links. Served at /debug/pprof they resolve against
+// /debug/ and every link on the index 404s; served at /debug/pprof/ they
+// resolve correctly. net/http.ServeMux issued this redirect implicitly, so the
+// endpoints never needed it in their previous home and the regression is
+// invisible unless something actually follows a link.
+func TestProfilingIndexRedirectsToSlashedPath(t *testing.T) {
+	s := newPprofTestServer(t, profilingSettings(true, testProfilingToken))
+
+	rec := doPprofRequest(t, s, PprofBasePath+"?token="+testProfilingToken)
+
+	require.Equal(t, http.StatusFound, rec.Code,
+		"the unslashed index path must redirect, not render links that 404")
+
+	location := rec.Header().Get("Location")
+	assert.Equal(t, PprofBasePath+"/?token="+testProfilingToken, location,
+		"the redirect must keep the query, or the hop drops the token into a 403")
+}
+
+// TestProfilingRefusalIsUniform pins the anti-oracle property the gate's own
+// comment commits to: absent, malformed, and simply-wrong tokens must be
+// indistinguishable to a caller probing the endpoint. Asserting the status code
+// alone would not notice a helpful "token missing" vs "token invalid" split.
+func TestProfilingRefusalIsUniform(t *testing.T) {
+	s := newPprofTestServer(t, profilingSettings(true, testProfilingToken))
+
+	queries := []string{
+		"",
+		"?token=",
+		"?token=wrong",
+		"?token=" + testProfilingToken[:10],
+		"?token=" + testProfilingToken + "x",
+	}
+
+	var first string
+	for i, q := range queries {
+		rec := doPprofRequest(t, s, heapPath+q)
+		require.Equal(t, http.StatusForbidden, rec.Code, "query %q", q)
+		if i == 0 {
+			first = rec.Body.String()
+			continue
+		}
+		assert.Equal(t, first, rec.Body.String(),
+			"refusal bodies must be byte-identical; query %q differs and is an oracle", q)
+	}
+}
+
+// TestPprofSkippersMatchMountPath couples the two duplicated path constants.
+//
+// middleware.pprofBasePath is a hand-copy of api.PprofBasePath (the api package
+// imports middleware, so the dependency cannot be reversed). Nothing else makes
+// them agree, and a silent divergence would re-enable CSRF on the symbol POST
+// that go tool pprof needs and start double-gzipping every profile, with no
+// other test failing. This is the coupling.
+func TestPprofSkippersMatchMountPath(t *testing.T) {
+	t.Parallel()
+
+	e := echo.New()
+	for _, path := range []string{PprofBasePath, PprofBasePath + "/heap", PprofBasePath + "/symbol"} {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodGet, path, http.NoBody)
+			c := e.NewContext(req, httptest.NewRecorder())
+
+			assert.True(t, mw.PprofSkipper(c),
+				"the gzip skipper must recognise the path the api package actually mounts")
+			assert.True(t, mw.DefaultCSRFSkipper(c),
+				"the CSRF skipper must recognise the path the api package actually mounts")
 		})
 	}
 }

--- a/internal/api/pprof_test.go
+++ b/internal/api/pprof_test.go
@@ -1,0 +1,325 @@
+// internal/api/pprof_test.go
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/conf/conftest"
+)
+
+const (
+	testProfilingToken = "test-profiling-token-value-0123456789"
+	heapPath           = PprofBasePath + "/heap"
+)
+
+// newPprofTestServer builds a Server with only the pieces the pprof routes
+// touch, registers the routes, and publishes the settings globally so the
+// gate's currentSettings() lookup sees them. The previous global snapshot is
+// restored on cleanup.
+//
+// Tests using this must not run in parallel: the settings singleton is global.
+func newPprofTestServer(t *testing.T, settings *conf.Settings) *Server {
+	t.Helper()
+
+	previous := conf.GetSettings()
+	t.Cleanup(func() { conf.StoreSettings(previous) })
+	conftest.SetTestSettings(settings)
+
+	s := &Server{
+		echo:     echo.New(),
+		config:   DefaultConfig(),
+		settings: settings,
+		slogger:  GetLogger(),
+	}
+	s.echo.HideBanner = true
+	s.registerPprofRoutes()
+
+	return s
+}
+
+// profilingSettings returns settings with profiling configured as requested and
+// no authentication provider, which is the default home-LAN shape.
+func profilingSettings(enabled bool, token string) *conf.Settings {
+	settings := conftest.NewTestSettings().Build()
+	settings.Diagnostics.Profiling.Enabled = enabled
+	settings.Diagnostics.Profiling.Token = token
+	return settings
+}
+
+// doPprofRequest issues a GET against the server's Echo instance.
+func doPprofRequest(t *testing.T, s *Server, target string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, target, http.NoBody)
+	rec := httptest.NewRecorder()
+	s.echo.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestProfilingGate_DisabledReturns404 covers the acceptance criterion that a
+// disabled feature must not advertise itself: 404, never 403.
+func TestProfilingGate_DisabledReturns404(t *testing.T) {
+	s := newPprofTestServer(t, profilingSettings(false, testProfilingToken))
+
+	for _, path := range []string{
+		PprofBasePath,
+		heapPath,
+		PprofBasePath + "/cmdline",
+		PprofBasePath + "/profile",
+	} {
+		t.Run(path, func(t *testing.T) {
+			rec := doPprofRequest(t, s, path)
+			assert.Equal(t, http.StatusNotFound, rec.Code,
+				"disabled profiling must be indistinguishable from an unrouted path")
+		})
+	}
+}
+
+// TestProfilingGate_DisabledIgnoresValidToken guards against a gate that checks
+// the credential before the enable flag.
+func TestProfilingGate_DisabledIgnoresValidToken(t *testing.T) {
+	s := newPprofTestServer(t, profilingSettings(false, testProfilingToken))
+
+	rec := doPprofRequest(t, s, heapPath+"?token="+testProfilingToken)
+	assert.Equal(t, http.StatusNotFound, rec.Code,
+		"a valid token must not open a disabled endpoint")
+}
+
+// TestProfilingGate_TokenAuth covers the no-auth-provider path, which is the
+// common home-LAN default.
+func TestProfilingGate_TokenAuth(t *testing.T) {
+	tests := []struct {
+		name            string
+		configuredToken string
+		query           string
+		wantStatus      int
+	}{
+		{
+			name:            "correct token is accepted",
+			configuredToken: testProfilingToken,
+			query:           "?token=" + testProfilingToken,
+			wantStatus:      http.StatusOK,
+		},
+		{
+			name:            "missing token is refused",
+			configuredToken: testProfilingToken,
+			query:           "",
+			wantStatus:      http.StatusForbidden,
+		},
+		{
+			name:            "wrong token is refused",
+			configuredToken: testProfilingToken,
+			query:           "?token=not-the-token",
+			wantStatus:      http.StatusForbidden,
+		},
+		{
+			name:            "token that is a prefix of the real one is refused",
+			configuredToken: testProfilingToken,
+			query:           "?token=" + testProfilingToken[:10],
+			wantStatus:      http.StatusForbidden,
+		},
+		{
+			name:            "empty configured token refuses an empty presented token",
+			configuredToken: "",
+			query:           "?token=",
+			wantStatus:      http.StatusForbidden,
+		},
+		{
+			name:            "empty configured token refuses any presented token",
+			configuredToken: "",
+			query:           "?token=anything",
+			wantStatus:      http.StatusForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newPprofTestServer(t, profilingSettings(true, tt.configuredToken))
+
+			rec := doPprofRequest(t, s, heapPath+tt.query)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+			if tt.wantStatus == http.StatusOK {
+				assert.NotEmpty(t, rec.Body.Bytes(), "a served heap profile must have a body")
+			}
+		})
+	}
+}
+
+// TestProfilingGate_DelegatesToAuthMiddleware verifies that a configured
+// authentication provider makes the server's own auth middleware the gate, and
+// that the token is not consulted as a second way in.
+func TestProfilingGate_DelegatesToAuthMiddleware(t *testing.T) {
+	const authHeader = "X-Test-Authenticated"
+
+	tests := []struct {
+		name        string
+		header      string
+		query       string
+		wantStatus  int
+		wantReached bool
+	}{
+		{
+			name:        "authenticated request is served",
+			header:      "yes",
+			wantStatus:  http.StatusOK,
+			wantReached: true,
+		},
+		{
+			name:       "unauthenticated request is refused",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "profiling token is not a bypass when auth is configured",
+			query:      "?token=" + testProfilingToken,
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			settings := profilingSettings(true, testProfilingToken)
+			settings.Security.BasicAuth.Enabled = true
+			require.True(t, settings.IsAuthProviderConfigured(),
+				"test setup must produce a configured auth provider")
+
+			previous := conf.GetSettings()
+			t.Cleanup(func() { conf.StoreSettings(previous) })
+			conftest.SetTestSettings(settings)
+
+			var middlewareCalled bool
+			s := &Server{
+				echo:     echo.New(),
+				config:   DefaultConfig(),
+				settings: settings,
+				slogger:  GetLogger(),
+				authMiddleware: func(next echo.HandlerFunc) echo.HandlerFunc {
+					return func(c echo.Context) error {
+						middlewareCalled = true
+						if c.Request().Header.Get(authHeader) == "" {
+							return echo.NewHTTPError(http.StatusUnauthorized)
+						}
+						return next(c)
+					}
+				},
+			}
+			s.echo.HideBanner = true
+			s.registerPprofRoutes()
+
+			req := httptest.NewRequest(http.MethodGet, heapPath+tt.query, http.NoBody)
+			if tt.header != "" {
+				req.Header.Set(authHeader, tt.header)
+			}
+			rec := httptest.NewRecorder()
+			s.echo.ServeHTTP(rec, req)
+
+			assert.Equal(t, tt.wantStatus, rec.Code)
+			assert.True(t, middlewareCalled,
+				"the auth middleware must gate the route whenever a provider is configured")
+			if tt.wantReached {
+				assert.NotEmpty(t, rec.Body.Bytes())
+			}
+		})
+	}
+}
+
+// TestProfilingGate_AuthConfiguredButMiddlewareMissing verifies the fail-closed
+// branch. No token is minted when auth is configured, so falling through to the
+// token check would leave the endpoint permanently open.
+func TestProfilingGate_AuthConfiguredButMiddlewareMissing(t *testing.T) {
+	settings := profilingSettings(true, testProfilingToken)
+	settings.Security.BasicAuth.Enabled = true
+
+	s := newPprofTestServer(t, settings)
+	require.Nil(t, s.authMiddleware, "test setup must leave the middleware unwired")
+
+	rec := doPprofRequest(t, s, heapPath+"?token="+testProfilingToken)
+	assert.Equal(t, http.StatusForbidden, rec.Code,
+		"an unwired auth middleware must fail closed, not fall back to the token")
+}
+
+// TestProfilingGate_HotReload verifies the setting takes effect in both
+// directions without re-registering routes or restarting the server.
+func TestProfilingGate_HotReload(t *testing.T) {
+	settings := profilingSettings(false, testProfilingToken)
+	s := newPprofTestServer(t, settings)
+
+	target := heapPath + "?token=" + testProfilingToken
+
+	rec := doPprofRequest(t, s, target)
+	require.Equal(t, http.StatusNotFound, rec.Code, "profiling starts disabled")
+
+	// Publish an enabled snapshot the way a settings save does (copy-on-write),
+	// rather than mutating the one already published.
+	enabled := conf.CloneSettings(settings)
+	enabled.Diagnostics.Profiling.Enabled = true
+	conf.StoreSettings(enabled)
+
+	rec = doPprofRequest(t, s, target)
+	assert.Equal(t, http.StatusOK, rec.Code, "enabling must take effect without a restart")
+
+	disabled := conf.CloneSettings(enabled)
+	disabled.Diagnostics.Profiling.Enabled = false
+	conf.StoreSettings(disabled)
+
+	rec = doPprofRequest(t, s, target)
+	assert.Equal(t, http.StatusNotFound, rec.Code, "disabling must take effect without a restart")
+}
+
+// TestProfilingRoutes_NamedProfilesAndHandlers checks that the wildcard route
+// really does dispatch the named runtime profiles, and that the four handlers
+// which are not runtime profiles have their own routes.
+func TestProfilingRoutes_NamedProfilesAndHandlers(t *testing.T) {
+	s := newPprofTestServer(t, profilingSettings(true, testProfilingToken))
+
+	// trace and profile are excluded: both sample for seconds before responding.
+	for _, path := range []string{
+		PprofBasePath,
+		PprofBasePath + "/heap",
+		PprofBasePath + "/allocs",
+		PprofBasePath + "/goroutine",
+		PprofBasePath + "/block",
+		PprofBasePath + "/mutex",
+		PprofBasePath + "/threadcreate",
+		PprofBasePath + "/cmdline",
+		PprofBasePath + "/symbol",
+	} {
+		t.Run(path, func(t *testing.T) {
+			rec := doPprofRequest(t, s, path+"?token="+testProfilingToken)
+			assert.Equal(t, http.StatusOK, rec.Code)
+		})
+	}
+}
+
+// TestProfilingTokenMatches covers the comparison helper directly, including the
+// fail-closed empty cases that the gate depends on.
+func TestProfilingTokenMatches(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		configured string
+		presented  string
+		want       bool
+	}{
+		{name: "equal tokens match", configured: "secret", presented: "secret", want: true},
+		{name: "different tokens do not match", configured: "secret", presented: "other"},
+		{name: "empty configured never matches", configured: "", presented: "secret"},
+		{name: "empty presented never matches", configured: "secret", presented: ""},
+		{name: "both empty never matches", configured: "", presented: ""},
+		{name: "prefix does not match", configured: "secretvalue", presented: "secret"},
+		{name: "case differences do not match", configured: "Secret", presented: "secret"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, profilingTokenMatches(tt.configured, tt.presented))
+		})
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -489,6 +489,10 @@ func (s *Server) setupRoutes() error {
 	// These must be at /auth/:provider to match frontend expectations
 	s.registerOAuthRoutes()
 
+	// pprof endpoints, registered unconditionally and gated per request so the
+	// setting hot-reloads. They are refused with 404 until profiling is enabled.
+	s.registerPprofRoutes()
+
 	// Initialize static file server for frontend assets (uses centralized logger)
 	s.staticServer = NewStaticFileServer()
 	s.staticServer.RegisterRoutes(s.echo)

--- a/internal/api/v2/hotreload_coverage_test.go
+++ b/internal/api/v2/hotreload_coverage_test.go
@@ -239,6 +239,12 @@ var hotReloadRegistry = map[string]hotReloadEntry{
 	// --- Sentry ---
 	"Sentry": {categories: []hotReloadCategory{hotReloadFresh}, action: "reconfigure_telemetry"},
 
+	// --- Diagnostics ---
+	// The pprof routes are registered unconditionally and gated by middleware
+	// that reads the live snapshot per request, so both the enable flag and the
+	// token take effect on the next request with no restart and no action.
+	"Diagnostics": {categories: []hotReloadCategory{hotReloadFresh}},
+
 	// --- Output ---
 	"Output": {categories: []hotReloadCategory{hotReloadRestart}},
 

--- a/internal/api/v2/hotreload_coverage_test.go
+++ b/internal/api/v2/hotreload_coverage_test.go
@@ -242,11 +242,10 @@ var hotReloadRegistry = map[string]hotReloadEntry{
 	// --- Diagnostics ---
 	// The pprof routes are registered unconditionally and gated by middleware
 	// that reads the live snapshot per request, so a change to either field is
-	// observed on the next request with no restart and no action. Note this is
-	// about when a CHANGED value takes effect, which is what this registry
-	// tracks; minting a token that does not exist yet happens on the config
-	// load path, so enabling profiling via the API on an instance with no auth
-	// provider still needs a restart before the endpoints answer.
+	// observed on the next request with no restart and no action. Enabling
+	// profiling also mints the token during the same save
+	// (ensureProfilingTokenForSave), so the endpoint is usable immediately
+	// rather than refusing until the next start.
 	"Diagnostics": {categories: []hotReloadCategory{hotReloadFresh}},
 
 	// --- Output ---

--- a/internal/api/v2/hotreload_coverage_test.go
+++ b/internal/api/v2/hotreload_coverage_test.go
@@ -241,8 +241,12 @@ var hotReloadRegistry = map[string]hotReloadEntry{
 
 	// --- Diagnostics ---
 	// The pprof routes are registered unconditionally and gated by middleware
-	// that reads the live snapshot per request, so both the enable flag and the
-	// token take effect on the next request with no restart and no action.
+	// that reads the live snapshot per request, so a change to either field is
+	// observed on the next request with no restart and no action. Note this is
+	// about when a CHANGED value takes effect, which is what this registry
+	// tracks; minting a token that does not exist yet happens on the config
+	// load path, so enabling profiling via the API on an instance with no auth
+	// provider still needs a restart before the endpoints answer.
 	"Diagnostics": {categories: []hotReloadCategory{hotReloadFresh}},
 
 	// --- Output ---

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -572,16 +572,6 @@ func handlePrimitiveField(
 // Must be called while c.settingsMutex is held. On save failure, the atomic
 // Settings snapshot is rolled back to current.
 func (c *Controller) publishAndSaveSettings(current, updated *conf.Settings) error {
-	// Mint the profiling token before publishing, so enabling pprof at runtime
-	// on an instance without an authentication provider produces a usable
-	// credential instead of an enabled-but-unreachable endpoint. Non-fatal: the
-	// routes fail closed without it, which must not cost the user their other
-	// settings changes.
-	if _, err := conf.EnsureProfilingToken(updated); err != nil {
-		apicore.GetLogger().Warn("Failed to generate profiling token; the profiling endpoints will refuse requests",
-			logger.Error(err))
-	}
-
 	if c.isGlobalOwner {
 		conf.StoreSettings(updated)
 	}
@@ -1758,6 +1748,9 @@ func sanitizeSettingsForAPI(s *conf.Settings) *conf.Settings {
 	sanitized.Security.BasicAuth.ClientID = ""
 	sanitized.Security.BasicAuth.ClientSecret = ""
 
+	// --- Diagnostics section ---
+	sanitized.Diagnostics.Profiling.Token = redact(s.Diagnostics.Profiling.Token)
+
 	// Legacy OAuth providers
 	sanitized.Security.GoogleAuth.ClientSecret = redact(s.Security.GoogleAuth.ClientSecret)
 	sanitized.Security.GithubAuth.ClientSecret = redact(s.Security.GithubAuth.ClientSecret)
@@ -1872,6 +1865,9 @@ func restoreRedactedSecrets(current, incoming *conf.Settings) error {
 	restore(&current.Security.GithubAuth.ClientSecret, &incoming.Security.GithubAuth.ClientSecret)
 	restore(&current.Security.MicrosoftAuth.ClientSecret, &incoming.Security.MicrosoftAuth.ClientSecret)
 
+	// Diagnostics
+	restore(&current.Diagnostics.Profiling.Token, &incoming.Diagnostics.Profiling.Token)
+
 	// Array-based OAuth providers — match by Provider name to handle reordering
 	for i := range incoming.Security.OAuthProviders {
 		if incoming.Security.OAuthProviders[i].ClientSecret != redactedValue {
@@ -1983,6 +1979,7 @@ func validateNoRedactedSentinels(s *conf.Settings) error {
 	check(s.Security.GoogleAuth.ClientSecret, "security.googleAuth.clientSecret")
 	check(s.Security.GithubAuth.ClientSecret, "security.githubAuth.clientSecret")
 	check(s.Security.MicrosoftAuth.ClientSecret, "security.microsoftAuth.clientSecret")
+	check(s.Diagnostics.Profiling.Token, "diagnostics.profiling.token")
 	check(s.Realtime.MQTT.Password, "realtime.mqtt.password")
 	check(s.Output.MySQL.Password, "output.mysql.password")
 	check(s.Realtime.Weather.OpenWeather.APIKey, "realtime.weather.openWeather.apiKey")
@@ -2050,6 +2047,7 @@ func clearRedactedSentinels(s *conf.Settings) {
 	clearField(&s.Security.GoogleAuth.ClientSecret)
 	clearField(&s.Security.GithubAuth.ClientSecret)
 	clearField(&s.Security.MicrosoftAuth.ClientSecret)
+	clearField(&s.Diagnostics.Profiling.Token)
 	clearField(&s.Realtime.MQTT.Password)
 	clearField(&s.Output.MySQL.Password)
 	clearField(&s.Realtime.Weather.OpenWeather.APIKey)
@@ -2131,6 +2129,19 @@ func getBlockedFieldMap() map[string]any {
 				"ClientSecret":   true, // OAuth2 server internal field (different from user's password)
 				"AuthCodeExp":    true, // OAuth2 server internal field
 				"AccessTokenExp": true, // OAuth2 server internal field
+			},
+		},
+
+		// Diagnostics section - block the generated credential, same class as
+		// Security.SessionSecret above. Enabled stays writable; the token is
+		// minted server-side when the config is loaded, so letting a client
+		// pin it to a chosen value would only weaken it. This matters most in
+		// the configuration the token exists for: with no auth provider the
+		// settings API has no auth either, so an unblocked field would let any
+		// LAN client set a token it knows and then read profiles.
+		"Diagnostics": map[string]any{
+			"Profiling": map[string]any{
+				"Token": true, // Generated internally, never updated via API
 			},
 		},
 

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -1045,8 +1045,15 @@ func getSettingsSectionValue(settings *conf.Settings, section string) (any, erro
 		return &settings.Realtime.Telemetry, nil
 	case "sentry":
 		return &settings.Sentry, nil
-	case "diagnostics":
-		return &settings.Diagnostics, nil
+	// NOTE: "diagnostics" is deliberately absent, so PATCH on it returns 400.
+	// The section holds a generated credential that getBlockedFieldMap marks
+	// never-updatable-via-API, and the PATCH merge path does not enforce that
+	// map: handleGenericSection merges the incoming JSON into the section and
+	// then only RECORDS that restrictions exist. Adding the case here would let
+	// an unauthenticated client on a no-auth instance set a token it chose and
+	// read profiles with it. PUT /api/v2/settings does enforce the map, so
+	// enabling profiling at runtime still works there.
+	// Re-add this once the PATCH path enforces blocked fields.
 	case "notification":
 		return &settings.Notification, nil
 	case "logging":

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -1045,6 +1045,8 @@ func getSettingsSectionValue(settings *conf.Settings, section string) (any, erro
 		return &settings.Realtime.Telemetry, nil
 	case "sentry":
 		return &settings.Sentry, nil
+	case "diagnostics":
+		return &settings.Diagnostics, nil
 	case "notification":
 		return &settings.Notification, nil
 	case "logging":

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -572,6 +572,16 @@ func handlePrimitiveField(
 // Must be called while c.settingsMutex is held. On save failure, the atomic
 // Settings snapshot is rolled back to current.
 func (c *Controller) publishAndSaveSettings(current, updated *conf.Settings) error {
+	// Mint the profiling token before publishing, so enabling pprof at runtime
+	// on an instance without an authentication provider produces a usable
+	// credential instead of an enabled-but-unreachable endpoint. Non-fatal: the
+	// routes fail closed without it, which must not cost the user their other
+	// settings changes.
+	if _, err := conf.EnsureProfilingToken(updated); err != nil {
+		apicore.GetLogger().Warn("Failed to generate profiling token; the profiling endpoints will refuse requests",
+			logger.Error(err))
+	}
+
 	if c.isGlobalOwner {
 		conf.StoreSettings(updated)
 	}

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -289,6 +289,7 @@ func (c *Controller) UpdateSettings(ctx echo.Context) error {
 	// (controllerSettings) return the freshly published value. Both stores are
 	// lock-free; settingsMutex here only serialises this read-modify-write
 	// against other update handlers, not against readers.
+	c.ensureProfilingTokenForSave(updated)
 	if publishGlobal {
 		conf.StoreSettings(updated)
 	}
@@ -571,7 +572,34 @@ func handlePrimitiveField(
 // publishAndSaveSettings publishes updated settings and persists to disk.
 // Must be called while c.settingsMutex is held. On save failure, the atomic
 // Settings snapshot is rolled back to current.
+// ensureProfilingTokenForSave mints the profiling token into a settings
+// snapshot that is about to be published and persisted, so enabling pprof at
+// runtime on an instance with no authentication provider yields a usable
+// credential rather than an endpoint that refuses every request until restart.
+//
+// It is called at each of the three publish points rather than from one shared
+// save helper because the settings-write paths each inline their own
+// publish-then-persist sequence. Hooking only one of them is exactly how the
+// first attempt at this shipped a dead feature: publishAndSaveSettings is used
+// by the TLS, integrations and detections writers, none of which can carry a
+// diagnostics change, so the two handlers that CAN (PUT /settings and
+// PATCH /settings/:section) never minted anything.
+//
+// Non-fatal by design. The pprof routes fail closed without a token, and a
+// diagnostics credential must not cost the user the rest of their settings
+// change. EnsureProfilingToken is a no-op unless profiling is enabled, the
+// token is empty, and no auth provider is configured, so the normal save path
+// pays a boolean check and nothing else.
+func (c *Controller) ensureProfilingTokenForSave(updated *conf.Settings) {
+	if _, err := conf.EnsureProfilingToken(updated); err != nil {
+		apicore.GetLogger().Warn(
+			"Failed to generate profiling token; the profiling endpoints will refuse requests",
+			logger.Error(err))
+	}
+}
+
 func (c *Controller) publishAndSaveSettings(current, updated *conf.Settings) error {
+	c.ensureProfilingTokenForSave(updated)
 	if c.isGlobalOwner {
 		conf.StoreSettings(updated)
 	}
@@ -710,6 +738,7 @@ func (c *Controller) UpdateSectionSettings(ctx echo.Context) error {
 	// republish the controller's own atomic snapshot. See the matching comment
 	// in UpdateSettings for why Debug reads via conf.GetSettings() (the global)
 	// rather than the per-controller snapshot.
+	c.ensureProfilingTokenForSave(updated)
 	if publishGlobal {
 		conf.StoreSettings(updated)
 	}

--- a/internal/api/v2/settings_profiling_test.go
+++ b/internal/api/v2/settings_profiling_test.go
@@ -83,6 +83,26 @@ func TestEnsureProfilingTokenForSave_NoOpCases(t *testing.T) {
 	}
 }
 
+// TestDiagnosticsSectionIsWritable closes the read/write asymmetry review
+// found: GET /api/v2/settings/diagnostics resolved by reflection over the
+// Settings fields and worked, while PATCH went through a hardcoded switch that
+// had no diagnostics case and answered 400. The section was readable but not
+// writable, so a client could see the feature's config and never change it.
+func TestDiagnosticsSectionIsWritable(t *testing.T) {
+	t.Parallel()
+
+	settings := &conf.Settings{}
+	settings.Diagnostics.Profiling.Enabled = true
+
+	value, err := getSettingsSectionValue(settings, "diagnostics")
+	require.NoError(t, err, "the diagnostics section must be writable via PATCH")
+
+	section, ok := value.(*conf.DiagnosticsConfig)
+	require.True(t, ok, "expected the diagnostics section, got %T", value)
+	assert.True(t, section.Profiling.Enabled,
+		"the returned section must alias the live settings, not a copy")
+}
+
 // TestEnsureProfilingTokenForSave_KeepsExistingToken guards token stability: a
 // settings save must not rotate a token the operator has already copied into a
 // profiling command.

--- a/internal/api/v2/settings_profiling_test.go
+++ b/internal/api/v2/settings_profiling_test.go
@@ -83,24 +83,44 @@ func TestEnsureProfilingTokenForSave_NoOpCases(t *testing.T) {
 	}
 }
 
-// TestDiagnosticsSectionIsWritable closes the read/write asymmetry review
-// found: GET /api/v2/settings/diagnostics resolved by reflection over the
-// Settings fields and worked, while PATCH went through a hardcoded switch that
-// had no diagnostics case and answered 400. The section was readable but not
-// writable, so a client could see the feature's config and never change it.
-func TestDiagnosticsSectionIsWritable(t *testing.T) {
+// TestDiagnosticsSectionIsNotPatchable pins that PATCH on the diagnostics
+// section is refused, and records why, because the obvious "fix" reopens a hole.
+//
+// The section carries a generated credential that getBlockedFieldMap marks
+// never-updatable-via-API. The PATCH merge path does NOT enforce that map:
+// handleGenericSection merges the incoming JSON into the section and then only
+// records that restrictions exist, so a client could set a token it chose. On a
+// no-auth instance the settings API is itself unauthenticated, which is exactly
+// the configuration where the token is the only thing gating pprof.
+//
+// PUT /api/v2/settings does enforce the blocked map, so enabling profiling at
+// runtime still works. Re-add the PATCH case once the merge path enforces
+// blocked fields.
+func TestDiagnosticsSectionIsNotPatchable(t *testing.T) {
 	t.Parallel()
 
-	settings := &conf.Settings{}
-	settings.Diagnostics.Profiling.Enabled = true
+	_, err := getSettingsSectionValue(&conf.Settings{}, "diagnostics")
+	require.Error(t, err,
+		"PATCH must refuse the diagnostics section while the merge path ignores blocked fields")
+}
 
-	value, err := getSettingsSectionValue(settings, "diagnostics")
-	require.NoError(t, err, "the diagnostics section must be writable via PATCH")
+// TestProfilingTokenIsBlockedFromAPIWrites pins the blocked-field entry that
+// keeps a client from choosing the token on the PUT path.
+func TestProfilingTokenIsBlockedFromAPIWrites(t *testing.T) {
+	t.Parallel()
 
-	section, ok := value.(*conf.DiagnosticsConfig)
-	require.True(t, ok, "expected the diagnostics section, got %T", value)
-	assert.True(t, section.Profiling.Enabled,
-		"the returned section must alias the live settings, not a copy")
+	blocked := getBlockedFieldMap()
+
+	diagnostics, ok := blocked["Diagnostics"].(map[string]any)
+	require.True(t, ok, "Diagnostics must carry field-level restrictions: %#v", blocked)
+
+	profiling, ok := diagnostics["Profiling"].(map[string]any)
+	require.True(t, ok, "Profiling must carry field-level restrictions: %#v", diagnostics)
+
+	assert.Equal(t, true, profiling["Token"],
+		"the generated profiling token must never be settable through the API")
+	assert.NotContains(t, profiling, "Enabled",
+		"the enable flag must stay writable, or profiling could not be turned on at all")
 }
 
 // TestEnsureProfilingTokenForSave_KeepsExistingToken guards token stability: a

--- a/internal/api/v2/settings_profiling_test.go
+++ b/internal/api/v2/settings_profiling_test.go
@@ -1,0 +1,102 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// newProfilingTestController builds a controller that publishes only to its own
+// snapshot, so these tests never touch the global settings singleton or disk.
+func newProfilingTestController(t *testing.T) *Controller {
+	t.Helper()
+
+	c := &Controller{
+		Core:                &apicore.Core{Echo: echo.New()},
+		controlChan:         make(chan string, 1),
+		DisableSaveSettings: true,
+	}
+	c.Settings.Store(&conf.Settings{})
+	return c
+}
+
+// TestEnsureProfilingTokenForSave_MintsOnRuntimeEnable is the regression test
+// for the gap review found: the token used to be minted only on the config load
+// path, so switching profiling on through the settings API left
+// diagnostics.profiling.enabled true with an empty token, and the gate then
+// refused every request until the process restarted.
+//
+// The mint now runs at each settings publish point, so a runtime enable
+// produces a usable credential in the same save.
+func TestEnsureProfilingTokenForSave_MintsOnRuntimeEnable(t *testing.T) {
+	c := newProfilingTestController(t)
+
+	updated := &conf.Settings{}
+	updated.Diagnostics.Profiling.Enabled = true
+	require.Empty(t, updated.Diagnostics.Profiling.Token,
+		"setup must start from the enabled-but-tokenless state")
+
+	c.ensureProfilingTokenForSave(updated)
+
+	assert.NotEmpty(t, updated.Diagnostics.Profiling.Token,
+		"enabling profiling at runtime must mint a token, not defer it to a restart")
+}
+
+// TestEnsureProfilingTokenForSave_NoOpCases pins the cases where nothing should
+// be minted, so the mint cannot start handing out credentials an instance does
+// not need.
+func TestEnsureProfilingTokenForSave_NoOpCases(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*conf.Settings)
+	}{
+		{
+			name:   "profiling disabled",
+			mutate: func(*conf.Settings) {},
+		},
+		{
+			name: "auth provider configured, so the middleware is the gate",
+			mutate: func(s *conf.Settings) {
+				s.Diagnostics.Profiling.Enabled = true
+				s.Security.BasicAuth.Enabled = true
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newProfilingTestController(t)
+
+			updated := &conf.Settings{}
+			tt.mutate(updated)
+
+			c.ensureProfilingTokenForSave(updated)
+
+			assert.Empty(t, updated.Diagnostics.Profiling.Token,
+				"no token should be minted for this configuration")
+		})
+	}
+}
+
+// TestEnsureProfilingTokenForSave_KeepsExistingToken guards token stability: a
+// settings save must not rotate a token the operator has already copied into a
+// profiling command.
+func TestEnsureProfilingTokenForSave_KeepsExistingToken(t *testing.T) {
+	const existing = "an-already-issued-profiling-token"
+
+	c := newProfilingTestController(t)
+
+	updated := &conf.Settings{}
+	updated.Diagnostics.Profiling.Enabled = true
+	updated.Diagnostics.Profiling.Token = existing
+
+	c.ensureProfilingTokenForSave(updated)
+
+	assert.Equal(t, existing, updated.Diagnostics.Profiling.Token,
+		"an existing token must survive unrelated settings saves")
+}

--- a/internal/api/v2/settings_sanitize_test.go
+++ b/internal/api/v2/settings_sanitize_test.go
@@ -101,6 +101,8 @@ func settingsWithSecrets(t *testing.T) *conf.Settings {
 		},
 	}
 
+	s.Diagnostics.Profiling.Token = "diagnostics-token-secret"
+
 	return s
 }
 
@@ -144,6 +146,9 @@ func TestSanitizeSettingsForAPI_RedactsAllSecrets(t *testing.T) {
 
 	// --- eBird ---
 	assert.Equal(t, redactedValue, sanitized.Realtime.EBird.APIKey, "ebird.apiKey must be redacted")
+
+	// --- Diagnostics ---
+	assert.Equal(t, redactedValue, sanitized.Diagnostics.Profiling.Token, "diagnostics.profiling.token must be redacted")
 
 	// --- Backup ---
 	assert.Equal(t, redactedValue, sanitized.Backup.EncryptionKey, "backup.encryptionKey must be redacted")

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -157,6 +157,7 @@ func sanitizeConfig(config *conf.Settings) *conf.Settings {
 	sanitized.Security.GoogleAuth.ClientSecret = ""
 	sanitized.Security.GithubAuth.ClientSecret = ""
 	sanitized.Security.SessionSecret = ""
+	sanitized.Diagnostics.Profiling.Token = ""
 	sanitized.Output.MySQL.Password = ""
 	sanitized.Realtime.MQTT.Password = ""
 	sanitized.Realtime.Weather.OpenWeather.APIKey = ""

--- a/internal/backup/sanitize_test.go
+++ b/internal/backup/sanitize_test.go
@@ -1,0 +1,98 @@
+package backup
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// TestSanitizeConfigStripsEverySecret asserts that sanitizeConfig removes every
+// credential before the config is written into a backup archive.
+//
+// Backup archives leave the machine, so a credential that survives this
+// function is a credential shipped to whatever target the user configured.
+// The check is written against the SERIALIZED output rather than field by
+// field, so a newly added credential that nobody remembered to register here
+// fails this test instead of silently riding along: that is exactly how
+// diagnostics.profiling.token was missed when it was introduced.
+func TestSanitizeConfigStripsEverySecret(t *testing.T) {
+	t.Parallel()
+
+	// Each value is distinctive so finding it in the output is unambiguous.
+	secrets := map[string]string{
+		"basic auth password":  "SECRET-basic-auth-password",
+		"basic auth client":    "SECRET-basic-auth-client",
+		"google client secret": "SECRET-google-client",
+		"github client secret": "SECRET-github-client",
+		"session secret":       "SECRET-session",
+		"profiling token":      "SECRET-profiling-token",
+		"mysql password":       "SECRET-mysql",
+		"mqtt password":        "SECRET-mqtt",
+		"openweather api key":  "SECRET-openweather",
+	}
+
+	settings := &conf.Settings{}
+	settings.Security.BasicAuth.Password = secrets["basic auth password"]
+	settings.Security.BasicAuth.ClientSecret = secrets["basic auth client"]
+	settings.Security.GoogleAuth.ClientSecret = secrets["google client secret"]
+	settings.Security.GithubAuth.ClientSecret = secrets["github client secret"]
+	settings.Security.SessionSecret = secrets["session secret"]
+	settings.Diagnostics.Profiling.Token = secrets["profiling token"]
+	settings.Output.MySQL.Password = secrets["mysql password"]
+	settings.Realtime.MQTT.Password = secrets["mqtt password"]
+	settings.Realtime.Weather.OpenWeather.APIKey = secrets["openweather api key"]
+
+	// Prove the setup actually plants every secret, so a renamed field cannot
+	// turn this into a test that passes because it asserts on nothing.
+	original, err := yaml.Marshal(settings)
+	require.NoError(t, err)
+	for name, value := range secrets {
+		require.Contains(t, string(original), value,
+			"test setup failed to plant the %s", name)
+	}
+
+	sanitized := sanitizeConfig(settings)
+	require.NotNil(t, sanitized)
+
+	rendered, err := yaml.Marshal(sanitized)
+	require.NoError(t, err)
+
+	for name, value := range secrets {
+		assert.NotContains(t, string(rendered), value,
+			"the %s must not reach a backup archive", name)
+	}
+
+	// The original must be untouched: callers keep using it after sanitizing.
+	untouched, err := yaml.Marshal(settings)
+	require.NoError(t, err)
+	assert.Equal(t, string(original), string(untouched),
+		"sanitizeConfig must not mutate the config it was given")
+}
+
+// TestSanitizeConfigKeepsNonSecrets guards against over-redaction: a backup's
+// config copy is only useful if the non-sensitive settings survive.
+func TestSanitizeConfigKeepsNonSecrets(t *testing.T) {
+	t.Parallel()
+
+	settings := &conf.Settings{}
+	settings.Main.Name = "test-node"
+	settings.Diagnostics.Profiling.Enabled = true
+	settings.Diagnostics.Profiling.Token = "SECRET-profiling-token"
+
+	sanitized := sanitizeConfig(settings)
+	require.NotNil(t, sanitized)
+
+	assert.Equal(t, "test-node", sanitized.Main.Name)
+	assert.True(t, sanitized.Diagnostics.Profiling.Enabled,
+		"whether profiling is on is diagnostic signal, not a secret")
+	assert.Empty(t, sanitized.Diagnostics.Profiling.Token)
+
+	rendered, err := yaml.Marshal(sanitized)
+	require.NoError(t, err)
+	assert.NotContains(t, string(rendered), "SECRET-",
+		"no planted secret should survive")
+}

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1725,16 +1725,16 @@ type BackupConfig struct {
 // The endpoints are served by the main web server behind its authentication
 // middleware, never by the Prometheus telemetry listener. When no
 // authentication provider is configured (the common home-LAN default), Token is
-// required instead. It is generated on the first startup with profiling
-// enabled, not at the moment the setting is flipped, so enabling profiling
-// through the settings API needs a restart before the endpoints will answer.
+// required instead, and is generated automatically: on the config load path
+// when profiling is already enabled, and on the settings-save path when it is
+// switched on at runtime.
 //
 // The leaf key is deliberately named "token" and not "profilingtoken": support
 // dump scrubbing matches sensitive keys on word boundaries, so a squashed name
 // would not be redacted. See isSensitiveKey in internal/support/collector.go.
 type ProfilingConfig struct {
 	Enabled bool   `yaml:"enabled" json:"enabled"` // true to serve /debug/pprof/* on the web server
-	Token   string `yaml:"token" json:"token"`     // secret required when no auth provider is configured; generated at startup
+	Token   string `yaml:"token" json:"token"`     // secret required when no auth provider is configured; generated automatically
 }
 
 // DiagnosticsConfig groups the developer-facing diagnostics features. It is a

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1720,6 +1720,30 @@ type BackupConfig struct {
 	} `yaml:"operationtimeouts" json:"operationTimeouts"`
 }
 
+// ProfilingConfig gates the Go pprof HTTP endpoints.
+//
+// The endpoints are served by the main web server behind its authentication
+// middleware, never by the Prometheus telemetry listener. When no
+// authentication provider is configured (the common home-LAN default), Token
+// is required instead and is generated automatically the first time profiling
+// is enabled.
+//
+// The leaf key is deliberately named "token" and not "profilingtoken": support
+// dump scrubbing matches sensitive keys on word boundaries, so a squashed name
+// would not be redacted. See isSensitiveKey in internal/support/collector.go.
+type ProfilingConfig struct {
+	Enabled bool   `yaml:"enabled" json:"enabled"` // true to serve /debug/pprof/* on the web server
+	Token   string `yaml:"token" json:"token"`     // secret required when no auth provider is configured; generated automatically
+}
+
+// DiagnosticsConfig groups the developer-facing diagnostics features. It is a
+// sibling of Logging and WebServer rather than a member of the telemetry
+// settings, because decoupling profiling from Prometheus metrics is the point:
+// enabling metrics must not expose profiling.
+type DiagnosticsConfig struct {
+	Profiling ProfilingConfig `yaml:"profiling" json:"profiling"` // pprof HTTP endpoint configuration
+}
+
 // Settings contains all configuration options for the BirdNET-Go application.
 type Settings struct {
 	Debug bool `yaml:"debug" json:"debug"` // true to enable debug mode
@@ -1755,6 +1779,8 @@ type Settings struct {
 	WebServer WebServerSettings `yaml:"webserver" json:"webServer"` // web server configuration
 	Security  Security          `yaml:"security" json:"security"`   // security configuration
 	Sentry    SentrySettings    `yaml:"sentry" json:"sentry"`       // Sentry error tracking configuration
+
+	Diagnostics DiagnosticsConfig `yaml:"diagnostics" json:"diagnostics"` // developer diagnostics (pprof profiling)
 
 	Output struct {
 		File struct {
@@ -1836,6 +1862,19 @@ func (s *Settings) GetEnabledOAuthProviders() []string {
 		}
 	}
 	return enabled
+}
+
+// IsAuthProviderConfigured reports whether this instance has any way to
+// authenticate a user: basic auth is enabled, or at least one OAuth provider is
+// enabled and fully configured.
+//
+// It deliberately ignores the allowed-subnet bypass, which is a per-request
+// concern handled by OAuth2Server.IsAuthenticationEnabled. This answers the
+// global question "can this instance authenticate anyone at all", which is what
+// decides whether an endpoint can rely on the auth middleware or has to carry
+// its own credential.
+func (s *Settings) IsAuthProviderConfigured() bool {
+	return s.Security.BasicAuth.Enabled || len(s.GetEnabledOAuthProviders()) > 0
 }
 
 // GenerateRandomSecret generates a URL-safe base64 encoded random string

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1724,16 +1724,17 @@ type BackupConfig struct {
 //
 // The endpoints are served by the main web server behind its authentication
 // middleware, never by the Prometheus telemetry listener. When no
-// authentication provider is configured (the common home-LAN default), Token
-// is required instead and is generated automatically the first time profiling
-// is enabled.
+// authentication provider is configured (the common home-LAN default), Token is
+// required instead. It is generated on the first startup with profiling
+// enabled, not at the moment the setting is flipped, so enabling profiling
+// through the settings API needs a restart before the endpoints will answer.
 //
 // The leaf key is deliberately named "token" and not "profilingtoken": support
 // dump scrubbing matches sensitive keys on word boundaries, so a squashed name
 // would not be redacted. See isSensitiveKey in internal/support/collector.go.
 type ProfilingConfig struct {
 	Enabled bool   `yaml:"enabled" json:"enabled"` // true to serve /debug/pprof/* on the web server
-	Token   string `yaml:"token" json:"token"`     // secret required when no auth provider is configured; generated automatically
+	Token   string `yaml:"token" json:"token"`     // secret required when no auth provider is configured; generated at startup
 }
 
 // DiagnosticsConfig groups the developer-facing diagnostics features. It is a

--- a/internal/conf/config.yaml
+++ b/internal/conf/config.yaml
@@ -464,10 +464,8 @@ diagnostics:
   profiling:
     enabled: false        # true to serve Go pprof endpoints at /debug/pprof/ on the web server
     # The pprof routes sit behind the web server's authentication. When no auth
-    # provider is configured, a token is generated here on the first startup
-    # with profiling enabled, and must then be passed as ?token=... Keep it
-    # secret. Enabling profiling without restarting leaves the endpoints
-    # refusing requests until the token exists.
+    # provider is configured, a token is generated here automatically once
+    # profiling is enabled, and must then be passed as ?token=... Keep it secret.
     # token: ""
 
 # Notification settings

--- a/internal/conf/config.yaml
+++ b/internal/conf/config.yaml
@@ -459,6 +459,15 @@ output:
 sentry:
   enabled: false          # false by default, must be explicitly enabled by user (opt-in)
 
+# Developer diagnostics, off by default
+diagnostics:
+  profiling:
+    enabled: false        # true to serve Go pprof endpoints at /debug/pprof/ on the web server
+    # The pprof routes sit behind the web server's authentication. When no auth
+    # provider is configured, a token is generated here the first time profiling
+    # is enabled and must be passed as ?token=... Keep it secret.
+    # token: ""
+
 # Notification settings
 notification:
   templates:

--- a/internal/conf/config.yaml
+++ b/internal/conf/config.yaml
@@ -464,8 +464,10 @@ diagnostics:
   profiling:
     enabled: false        # true to serve Go pprof endpoints at /debug/pprof/ on the web server
     # The pprof routes sit behind the web server's authentication. When no auth
-    # provider is configured, a token is generated here the first time profiling
-    # is enabled and must be passed as ?token=... Keep it secret.
+    # provider is configured, a token is generated here on the first startup
+    # with profiling enabled, and must then be passed as ?token=... Keep it
+    # secret. Enabling profiling without restarting leaves the endpoints
+    # refusing requests until the token exists.
     # token: ""
 
 # Notification settings

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -445,6 +445,11 @@ func setDefaultConfig() {
 
 	// Alerting rules engine
 	viper.SetDefault("alerting.history_retention_days", 30)
+
+	// Diagnostics: pprof profiling endpoints. Off by default; the token is
+	// generated on demand when profiling is enabled without an auth provider.
+	viper.SetDefault("diagnostics.profiling.enabled", false)
+	viper.SetDefault("diagnostics.profiling.token", "")
 }
 
 // setModuleLogDefaults sets default values for a module log configuration

--- a/internal/conf/migrations.go
+++ b/internal/conf/migrations.go
@@ -85,6 +85,44 @@ func ensureSessionSecret(settings *Settings) error {
 	return nil
 }
 
+// EnsureProfilingToken mints diagnostics.profiling.token when the pprof
+// endpoints are enabled on an instance that has no way to authenticate a user.
+// It follows the SessionSecret pattern deliberately: a stable secret generated
+// from crypto/rand and persisted to the config file, so a profiling session
+// survives the restart it often spans.
+//
+// Nothing is generated when an authentication provider is configured. There the
+// web server's auth middleware already gates the routes, and a second
+// credential sitting in the config would only widen the way in.
+//
+// The caller owns persistence. It reports whether the token was generated so a
+// caller that is not about to save anyway can persist the change.
+func EnsureProfilingToken(settings *Settings) (bool, error) {
+	profiling := &settings.Diagnostics.Profiling
+	if !profiling.Enabled || profiling.Token != "" || settings.IsAuthProviderConfigured() {
+		return false, nil
+	}
+
+	token, err := GenerateRandomSecret()
+	if err != nil {
+		return false, errors.New(err).
+			Component("conf").
+			Category(errors.CategoryConfiguration).
+			Context("operation", "generate_profiling_token").
+			Build()
+	}
+
+	profiling.Token = token
+
+	// Mirror into viper so a viper-driven save path writes the same value.
+	viper.Set("diagnostics.profiling.token", token)
+
+	// The value itself is never logged.
+	GetLogger().Info("Generated profiling token; no authentication provider is configured, so /debug/pprof/ requires the token from diagnostics.profiling.token")
+
+	return true, nil
+}
+
 // migrateLegacyProvider converts a legacy SocialProvider to the new OAuthProviderConfig format.
 // Returns nil if the legacy provider is not configured (no ClientID).
 func migrateLegacyProvider(providerName string, legacy SocialProvider) *OAuthProviderConfig {

--- a/internal/conf/migrations.go
+++ b/internal/conf/migrations.go
@@ -95,9 +95,24 @@ func ensureSessionSecret(settings *Settings) error {
 // web server's auth middleware already gates the routes, and a second
 // credential sitting in the config would only widen the way in.
 //
-// The caller owns persistence. It reports whether the token was generated so a
-// caller that is not about to save anyway can persist the change.
+// This runs on the config load path only, which makes profiling a config-file
+// feature: enabling it takes effect for the enable flag immediately (the gate
+// reads settings per request) but the token appears on the next start. That is
+// the deliberate first-pass scope; there is no UI toggle, and wiring the mint
+// into the settings-write handlers is follow-up work.
+//
+// Unlike ensureSessionSecret this does NOT mirror the value into viper. That
+// mirror is vestigial there: nothing in this repository persists through viper
+// (SaveYAMLConfig marshals the struct), and viper.Set is not goroutine-safe, so
+// staging a value it would never write is cost without a payer.
+//
+// The caller owns persistence, and is told whether anything changed so it can
+// decide whether a write is needed.
 func EnsureProfilingToken(settings *Settings) (bool, error) {
+	if settings == nil {
+		return false, nil
+	}
+
 	profiling := &settings.Diagnostics.Profiling
 	if !profiling.Enabled || profiling.Token != "" || settings.IsAuthProviderConfigured() {
 		return false, nil
@@ -113,9 +128,6 @@ func EnsureProfilingToken(settings *Settings) (bool, error) {
 	}
 
 	profiling.Token = token
-
-	// Mirror into viper so a viper-driven save path writes the same value.
-	viper.Set("diagnostics.profiling.token", token)
 
 	// The value itself is never logged.
 	GetLogger().Info("Generated profiling token; no authentication provider is configured, so /debug/pprof/ requires the token from diagnostics.profiling.token")

--- a/internal/conf/migrations.go
+++ b/internal/conf/migrations.go
@@ -95,11 +95,9 @@ func ensureSessionSecret(settings *Settings) error {
 // web server's auth middleware already gates the routes, and a second
 // credential sitting in the config would only widen the way in.
 //
-// This runs on the config load path only, which makes profiling a config-file
-// feature: enabling it takes effect for the enable flag immediately (the gate
-// reads settings per request) but the token appears on the next start. That is
-// the deliberate first-pass scope; there is no UI toggle, and wiring the mint
-// into the settings-write handlers is follow-up work.
+// It runs on the config load path AND on every settings-save path, so switching
+// profiling on at runtime yields a usable credential rather than an endpoint
+// that refuses everything until the next restart.
 //
 // Unlike ensureSessionSecret this does NOT mirror the value into viper. That
 // mirror is vestigial there: nothing in this repository persists through viper

--- a/internal/conf/profiling_test.go
+++ b/internal/conf/profiling_test.go
@@ -1,0 +1,204 @@
+package conf
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// settingsWithProfiling builds settings with the profiling section configured
+// and, optionally, an authentication provider enabled.
+func settingsWithProfiling(enabled bool, token string, withAuth bool) *Settings {
+	settings := &Settings{}
+	settings.Diagnostics.Profiling.Enabled = enabled
+	settings.Diagnostics.Profiling.Token = token
+	settings.Security.BasicAuth.Enabled = withAuth
+	return settings
+}
+
+// TestEnsureProfilingToken covers when a token is minted and, more importantly,
+// when it is not. Minting one on an instance that already has authentication
+// would add a second, weaker way into the profiling endpoints for no benefit.
+func TestEnsureProfilingToken(t *testing.T) {
+	tests := []struct {
+		name          string
+		settings      *Settings
+		wantGenerated bool
+	}{
+		{
+			name:          "enabled without an auth provider mints a token",
+			settings:      settingsWithProfiling(true, "", false),
+			wantGenerated: true,
+		},
+		{
+			name:     "disabled mints nothing",
+			settings: settingsWithProfiling(false, "", false),
+		},
+		{
+			name:     "an existing token is left alone",
+			settings: settingsWithProfiling(true, "already-set", false),
+		},
+		{
+			name:     "a configured auth provider means no token is needed",
+			settings: settingsWithProfiling(true, "", true),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// viper.Set is global state, so these cannot run in parallel.
+			viper.Reset()
+			t.Cleanup(viper.Reset)
+
+			before := tt.settings.Diagnostics.Profiling.Token
+
+			generated, err := EnsureProfilingToken(tt.settings)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantGenerated, generated)
+
+			got := tt.settings.Diagnostics.Profiling.Token
+			if !tt.wantGenerated {
+				assert.Equal(t, before, got, "the token must not change")
+				assert.Nil(t, viper.Get("diagnostics.profiling.token"),
+					"nothing should be staged for persistence")
+				return
+			}
+
+			assert.NotEmpty(t, got)
+			assert.Len(t, got, 43,
+				"a token should carry the same 256 bits of entropy as the session secret")
+			assert.Equal(t, got, viper.GetString("diagnostics.profiling.token"),
+				"the generated token must be staged for persistence")
+		})
+	}
+}
+
+// TestEnsureProfilingTokenIsUnique guards against a fixed or seeded value: two
+// instances must never end up sharing a credential.
+func TestEnsureProfilingTokenIsUnique(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	first := settingsWithProfiling(true, "", false)
+	second := settingsWithProfiling(true, "", false)
+
+	generated, err := EnsureProfilingToken(first)
+	require.NoError(t, err)
+	require.True(t, generated)
+
+	generated, err = EnsureProfilingToken(second)
+	require.NoError(t, err)
+	require.True(t, generated)
+
+	assert.NotEqual(t, first.Diagnostics.Profiling.Token, second.Diagnostics.Profiling.Token)
+}
+
+// TestEnsureProfilingTokenIsIdempotent verifies a second pass over already
+// backfilled settings is a no-op, so restarts do not churn the config file.
+func TestEnsureProfilingTokenIsIdempotent(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	settings := settingsWithProfiling(true, "", false)
+
+	generated, err := EnsureProfilingToken(settings)
+	require.NoError(t, err)
+	require.True(t, generated)
+	minted := settings.Diagnostics.Profiling.Token
+
+	generated, err = EnsureProfilingToken(settings)
+	require.NoError(t, err)
+	assert.False(t, generated, "a second pass must report no change")
+	assert.Equal(t, minted, settings.Diagnostics.Profiling.Token,
+		"the token must be stable across restarts; a profiling session outlives one")
+}
+
+// TestIsAuthProviderConfigured pins the predicate that decides whether the
+// profiling routes rely on the auth middleware or on their own token.
+func TestIsAuthProviderConfigured(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		mutate   func(*Settings)
+		expected bool
+	}{
+		{
+			name:   "nothing configured",
+			mutate: func(*Settings) {},
+		},
+		{
+			name:     "basic auth enabled",
+			mutate:   func(s *Settings) { s.Security.BasicAuth.Enabled = true },
+			expected: true,
+		},
+		{
+			name: "fully configured OAuth provider",
+			mutate: func(s *Settings) {
+				s.Security.OAuthProviders = []OAuthProviderConfig{{
+					Provider:     "google",
+					Enabled:      true,
+					ClientID:     "id",
+					ClientSecret: "secret",
+				}}
+			},
+			expected: true,
+		},
+		{
+			name: "OAuth provider enabled but missing credentials does not count",
+			mutate: func(s *Settings) {
+				s.Security.OAuthProviders = []OAuthProviderConfig{{
+					Provider: "google",
+					Enabled:  true,
+				}}
+			},
+		},
+		{
+			name: "fully credentialed but disabled OAuth provider does not count",
+			mutate: func(s *Settings) {
+				s.Security.OAuthProviders = []OAuthProviderConfig{{
+					Provider:     "google",
+					ClientID:     "id",
+					ClientSecret: "secret",
+				}}
+			},
+		},
+		{
+			name: "subnet bypass is a per-request concern and does not count",
+			mutate: func(s *Settings) {
+				s.Security.AllowSubnetBypass.Enabled = true
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			settings := &Settings{}
+			tt.mutate(settings)
+			assert.Equal(t, tt.expected, settings.IsAuthProviderConfigured())
+		})
+	}
+}
+
+// TestConfigTemplateShipsProfilingDisabled guards the embedded config template.
+// A token committed to the repository would be identical on every install, which
+// is worse than having none.
+func TestConfigTemplateShipsProfilingDisabled(t *testing.T) {
+	t.Parallel()
+
+	template, err := configFiles.ReadFile("config.yaml")
+	require.NoError(t, err)
+
+	var settings Settings
+	require.NoError(t, yaml.Unmarshal(template, &settings))
+
+	assert.False(t, settings.Diagnostics.Profiling.Enabled,
+		"profiling must ship disabled")
+	assert.Empty(t, settings.Diagnostics.Profiling.Token,
+		"the shipped template must not carry a profiling token")
+}

--- a/internal/conf/profiling_test.go
+++ b/internal/conf/profiling_test.go
@@ -62,16 +62,25 @@ func TestEnsureProfilingToken(t *testing.T) {
 			got := tt.settings.Diagnostics.Profiling.Token
 			if !tt.wantGenerated {
 				assert.Equal(t, before, got, "the token must not change")
-				assert.Nil(t, viper.Get("diagnostics.profiling.token"),
-					"nothing should be staged for persistence")
 				return
 			}
 
 			assert.NotEmpty(t, got)
-			assert.Len(t, got, 43,
-				"a token should carry the same 256 bits of entropy as the session secret")
-			assert.Equal(t, got, viper.GetString("diagnostics.profiling.token"),
-				"the generated token must be staged for persistence")
+			// Length is derived, not hardcoded, so raising the entropy in
+			// GenerateRandomSecret does not silently leave this assertion
+			// pinning the old size.
+			expected, err := GenerateRandomSecret()
+			require.NoError(t, err)
+			assert.Len(t, got, len(expected),
+				"a token should carry the same entropy as any other generated secret")
+
+			// The token is deliberately NOT mirrored into viper: nothing in
+			// this repository persists through viper (SaveYAMLConfig marshals
+			// the struct), and viper.Set is not goroutine-safe. Asserting the
+			// absence keeps a well-meaning "mirror it like ensureSessionSecret
+			// does" from creeping back in.
+			assert.Empty(t, viper.GetString("diagnostics.profiling.token"),
+				"the token must not be staged into viper")
 		})
 	}
 }

--- a/internal/conf/storage.go
+++ b/internal/conf/storage.go
@@ -160,7 +160,17 @@ func Load() (*Settings, error) {
 	if generated, err := EnsureProfilingToken(settings); err != nil {
 		GetLogger().Warn("Failed to generate profiling token; the profiling endpoints will refuse requests", logger.Error(err))
 	} else if generated {
-		persistMigration(settings, "profiling token")
+		// A token that is minted but never written to disk is worse than none:
+		// it gates the endpoints for this process while being unreadable (it is
+		// never logged), and the next start mints a different one. Say so
+		// plainly, because persistMigration is silent when there is no config
+		// file to write and only warns on a write failure.
+		if viper.ConfigFileUsed() == "" {
+			GetLogger().Warn("Generated a profiling token but there is no config file to save it to; " +
+				"the profiling endpoints will be unusable and the token will differ on the next start")
+		} else {
+			persistMigration(settings, "profiling token")
+		}
 	}
 
 	// Resolve features that are switched on but were never configured, before the

--- a/internal/conf/storage.go
+++ b/internal/conf/storage.go
@@ -153,6 +153,16 @@ func Load() (*Settings, error) {
 		return nil, err
 	}
 
+	// Mint the profiling token when pprof is enabled without an authentication
+	// provider. Deliberately non-fatal: without a token the pprof routes refuse
+	// every request, which is the safe outcome, and a diagnostics feature must
+	// not be able to stop the application from starting.
+	if generated, err := EnsureProfilingToken(settings); err != nil {
+		GetLogger().Warn("Failed to generate profiling token; the profiling endpoints will refuse requests", logger.Error(err))
+	} else if generated {
+		persistMigration(settings, "profiling token")
+	}
+
 	// Resolve features that are switched on but were never configured, before the
 	// validators get to see them. A config file can age into that state across
 	// upgrades, and rejecting the file leaves no UI in which to correct it, so

--- a/internal/observability/debug.go
+++ b/internal/observability/debug.go
@@ -6,9 +6,16 @@ import (
 	"net/http"
 )
 
-// debugPath is the base URL path that used to serve the pprof debugging
-// endpoints on this listener.
-const debugPath = "/debug/pprof/"
+// debugRootPath is the exact old pprof path; debugPath is its subtree form.
+//
+// Both are registered. The subtree pattern alone would leave a request for the
+// unslashed path answered by ServeMux's own redirect, so a client that does not
+// follow redirects (plain curl, a scripted probe) would get a bare 3xx instead
+// of the explanation this handler exists to give.
+const (
+	debugRootPath = "/debug/pprof"
+	debugPath     = debugRootPath + "/"
+)
 
 // movedNotice is the body returned at the old pprof location.
 //
@@ -47,7 +54,7 @@ The telemetry listener serves Prometheus metrics only.
 // breadcrumb answers "where did the old endpoint go", a question whose answer
 // does not depend on the current setting.
 func RegisterMovedDebugHandler(mux *http.ServeMux) {
-	mux.HandleFunc(debugPath, func(w http.ResponseWriter, _ *http.Request) {
+	handler := func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.WriteHeader(http.StatusGone)
@@ -55,5 +62,7 @@ func RegisterMovedDebugHandler(mux *http.ServeMux) {
 		// reachable unauthenticated and unthrottled, so the per-request copy of
 		// the constant would be attacker-paced for no reason.
 		_, _ = io.WriteString(w, movedNotice)
-	})
+	}
+	mux.HandleFunc(debugRootPath, handler)
+	mux.HandleFunc(debugPath, handler)
 }

--- a/internal/observability/debug.go
+++ b/internal/observability/debug.go
@@ -2,6 +2,7 @@
 package observability
 
 import (
+	"io"
 	"net/http"
 )
 
@@ -9,17 +10,18 @@ import (
 // endpoints on this listener.
 const debugPath = "/debug/pprof/"
 
-// movedNotice is the body returned at the old pprof location. It names the new
-// path and the setting that opens it, so an existing profiling workflow gets an
-// answer instead of a bare status code.
+// movedNotice is the body returned at the old pprof location.
+//
+// It is deliberately terse. This listener has no authentication and no rate
+// limiting, so the notice points at the configuration section and stops there:
+// naming the credential mechanism would hand a scanner both the parameter to
+// brute-force and the port shape to aim at, for no benefit to the operator,
+// who has the documentation. Pointing at the setting is enough to reconnect
+// someone whose profiling workflow just broke, which is the entire job here.
 const movedNotice = `The pprof endpoints have moved off the telemetry listener.
 
-They are now served by the main web server at /debug/pprof/, gated by the
-diagnostics.profiling.enabled setting and placed behind the web server's
-authentication. When no authentication provider is configured, pass the
-generated diagnostics.profiling.token as a query parameter:
-
-    go tool pprof "http://<host>:<webserver-port>/debug/pprof/heap?token=<token>"
+They are now served by the main web server and are configured under the
+"diagnostics.profiling" section. See the profiling documentation for details.
 
 The telemetry listener serves Prometheus metrics only.
 `
@@ -31,13 +33,27 @@ The telemetry listener serves Prometheus metrics only.
 // middleware of any kind, so enabling Prometheus metrics also published
 // profiling on every interface with no authentication. They now live on the
 // authenticated web server instead. Removing them outright would turn every
-// existing profiling workflow into a connection error with nothing to go on;
-// this handler costs nothing, discloses nothing, and explains itself.
+// existing profiling workflow into a connection error with nothing to go on.
+//
+// What it discloses, stated plainly rather than claimed away: any unauthenticated
+// caller on this port learns that this is a BirdNET-Go instance and that its
+// profiling endpoints moved. It discloses no profile data, no credential, and
+// no instance-specific state; the response is a compile-time constant and no
+// request data reaches it. That is judged worth the support cost of an
+// unexplained break, on a port the operator opted into exposing.
+//
+// Note this is registered whether or not profiling is enabled, which is a
+// weaker stance than the web-server gate's 404. That is deliberate: the
+// breadcrumb answers "where did the old endpoint go", a question whose answer
+// does not depend on the current setting.
 func RegisterMovedDebugHandler(mux *http.ServeMux) {
 	mux.HandleFunc(debugPath, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.WriteHeader(http.StatusGone)
-		_, _ = w.Write([]byte(movedNotice))
+		// io.WriteString rather than Write([]byte(const)): this handler is
+		// reachable unauthenticated and unthrottled, so the per-request copy of
+		// the constant would be attacker-paced for no reason.
+		_, _ = io.WriteString(w, movedNotice)
 	})
 }

--- a/internal/observability/debug.go
+++ b/internal/observability/debug.go
@@ -3,43 +3,41 @@ package observability
 
 import (
 	"net/http"
-	"net/http/pprof"
 )
 
-// debugPath is the base URL path for pprof debugging endpoints.
+// debugPath is the base URL path that used to serve the pprof debugging
+// endpoints on this listener.
 const debugPath = "/debug/pprof/"
 
-// RegisterDebugHandlers adds pprof debugging routes to the provided http.ServeMux.
+// movedNotice is the body returned at the old pprof location. It names the new
+// path and the setting that opens it, so an existing profiling workflow gets an
+// answer instead of a bare status code.
+const movedNotice = `The pprof endpoints have moved off the telemetry listener.
+
+They are now served by the main web server at /debug/pprof/, gated by the
+diagnostics.profiling.enabled setting and placed behind the web server's
+authentication. When no authentication provider is configured, pass the
+generated diagnostics.profiling.token as a query parameter:
+
+    go tool pprof "http://<host>:<webserver-port>/debug/pprof/heap?token=<token>"
+
+The telemetry listener serves Prometheus metrics only.
+`
+
+// RegisterMovedDebugHandler registers a 410 Gone breadcrumb at the old pprof
+// location on the telemetry mux.
 //
-// This function registers various pprof handlers for profiling and debugging purposes.
-// It should only be used in development or controlled environments, as it can expose
-// sensitive information about the application's internals.
-//
-// The following endpoints are registered:
-//   - /debug/pprof/
-//   - /debug/pprof/cmdline
-//   - /debug/pprof/profile
-//   - /debug/pprof/symbol
-//   - /debug/pprof/trace
-//   - /debug/pprof/allocs
-//   - /debug/pprof/goroutine
-//   - /debug/pprof/heap
-//   - /debug/pprof/threadcreate
-//   - /debug/pprof/block
-//   - /debug/pprof/mutex
-//
-// Parameters:
-//   - mux: The http.ServeMux to which the debug handlers will be added.
-func RegisterDebugHandlers(mux *http.ServeMux) {
-	mux.HandleFunc(debugPath, pprof.Index)
-	mux.HandleFunc(debugPath+"cmdline", pprof.Cmdline)
-	mux.HandleFunc(debugPath+"profile", pprof.Profile)
-	mux.HandleFunc(debugPath+"symbol", pprof.Symbol)
-	mux.HandleFunc(debugPath+"trace", pprof.Trace)
-	mux.Handle(debugPath+"allocs", pprof.Handler("allocs"))
-	mux.Handle(debugPath+"goroutine", pprof.Handler("goroutine"))
-	mux.Handle(debugPath+"heap", pprof.Handler("heap"))
-	mux.Handle(debugPath+"threadcreate", pprof.Handler("threadcreate"))
-	mux.Handle(debugPath+"block", pprof.Handler("block"))
-	mux.Handle(debugPath+"mutex", pprof.Handler("mutex"))
+// The pprof handlers used to be registered here on a bare ServeMux with no
+// middleware of any kind, so enabling Prometheus metrics also published
+// profiling on every interface with no authentication. They now live on the
+// authenticated web server instead. Removing them outright would turn every
+// existing profiling workflow into a connection error with nothing to go on;
+// this handler costs nothing, discloses nothing, and explains itself.
+func RegisterMovedDebugHandler(mux *http.ServeMux) {
+	mux.HandleFunc(debugPath, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.WriteHeader(http.StatusGone)
+		_, _ = w.Write([]byte(movedNotice))
+	})
 }

--- a/internal/observability/debug_test.go
+++ b/internal/observability/debug_test.go
@@ -1,0 +1,94 @@
+package observability
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTelemetryMuxServesNoProfiles is the regression test for the exposure this
+// change closes: the telemetry listener runs a bare ServeMux with no middleware
+// of any kind, so every pprof handler registered on it was reachable, without
+// authentication, on all interfaces the moment Prometheus metrics were enabled.
+//
+// The named profiles below are the ones that used to be registered here.
+func TestTelemetryMuxServesNoProfiles(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	RegisterMovedDebugHandler(mux)
+
+	profiles := []string{
+		debugPath + "cmdline",
+		debugPath + "profile",
+		debugPath + "symbol",
+		debugPath + "trace",
+		debugPath + "allocs",
+		debugPath + "goroutine",
+		debugPath + "heap",
+		debugPath + "threadcreate",
+		debugPath + "block",
+		debugPath + "mutex",
+	}
+
+	for _, path := range profiles {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, http.NoBody))
+
+			assert.Equal(t, http.StatusGone, rec.Code,
+				"the telemetry listener must not serve profiling data")
+			assert.NotContains(t, rec.Body.String(), "runtime.",
+				"a 410 body must not carry profile content")
+		})
+	}
+}
+
+// TestMovedDebugHandlerExplainsItself checks the breadcrumb actually earns its
+// place. A bare 410 would be no better than a connection error for someone whose
+// profiling workflow just stopped working, so the body has to name both the new
+// location and the setting that opens it.
+func TestMovedDebugHandlerExplainsItself(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	RegisterMovedDebugHandler(mux)
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, debugPath, http.NoBody))
+
+	require.Equal(t, http.StatusGone, rec.Code)
+
+	body := rec.Body.String()
+	assert.Contains(t, body, "diagnostics.profiling.enabled", "the body must name the setting")
+	assert.Contains(t, body, debugPath, "the body must name the new path")
+	assert.Contains(t, body, "diagnostics.profiling.token", "the body must explain the no-auth case")
+	assert.True(t, strings.HasPrefix(rec.Header().Get("Content-Type"), "text/plain"),
+		"the notice is plain text, not something a browser should render as markup")
+	assert.Equal(t, "nosniff", rec.Header().Get("X-Content-Type-Options"))
+}
+
+// TestTelemetryMuxStillServesMetrics confirms removing the profiling handlers
+// left the listener's actual job intact.
+func TestTelemetryMuxStillServesMetrics(t *testing.T) {
+	t.Parallel()
+
+	metrics, err := NewMetrics()
+	require.NoError(t, err)
+
+	mux := http.NewServeMux()
+	metrics.RegisterHandlers(mux)
+	RegisterMovedDebugHandler(mux)
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", http.NoBody))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.NotEmpty(t, rec.Body.Bytes())
+}

--- a/internal/observability/debug_test.go
+++ b/internal/observability/debug_test.go
@@ -16,11 +16,29 @@ import (
 // authentication, on all interfaces the moment Prometheus metrics were enabled.
 //
 // The named profiles below are the ones that used to be registered here.
+// newTelemetryMux builds the mux the telemetry listener actually serves.
+//
+// The tests deliberately go through Endpoint.buildMux rather than assembling an
+// equivalent mux themselves. Assembling one locally is what made the earlier
+// version of this file unable to fail: re-adding a single
+// mux.Handle("/debug/pprof/heap", pprof.Handler("heap")) line to the listener
+// republishes a real heap profile unauthenticated on every interface, and Go
+// 1.22+ pattern precedence gives that exact registration priority over the
+// breadcrumb's subtree pattern, so a test holding its own mux stayed green
+// through the exact regression it existed to catch.
+func newTelemetryMux(t *testing.T) *http.ServeMux {
+	t.Helper()
+
+	metrics, err := NewMetrics()
+	require.NoError(t, err)
+
+	return (&Endpoint{metrics: metrics}).buildMux()
+}
+
 func TestTelemetryMuxServesNoProfiles(t *testing.T) {
 	t.Parallel()
 
-	mux := http.NewServeMux()
-	RegisterMovedDebugHandler(mux)
+	mux := newTelemetryMux(t)
 
 	profiles := []string{
 		debugPath + "cmdline",
@@ -36,7 +54,7 @@ func TestTelemetryMuxServesNoProfiles(t *testing.T) {
 	}
 
 	for _, path := range profiles {
-		t.Run(path, func(t *testing.T) {
+		t.Run(strings.TrimPrefix(path, debugPath), func(t *testing.T) {
 			t.Parallel()
 
 			rec := httptest.NewRecorder()
@@ -44,8 +62,11 @@ func TestTelemetryMuxServesNoProfiles(t *testing.T) {
 
 			assert.Equal(t, http.StatusGone, rec.Code,
 				"the telemetry listener must not serve profiling data")
-			assert.NotContains(t, rec.Body.String(), "runtime.",
-				"a 410 body must not carry profile content")
+			// Byte-equality with the constant, not a substring probe: it pins
+			// both that no profile was served AND that the handler reflects
+			// nothing from the request into the body.
+			assert.Equal(t, movedNotice, rec.Body.String(),
+				"the only thing this path may return is the fixed notice")
 		})
 	}
 }
@@ -57,8 +78,7 @@ func TestTelemetryMuxServesNoProfiles(t *testing.T) {
 func TestMovedDebugHandlerExplainsItself(t *testing.T) {
 	t.Parallel()
 
-	mux := http.NewServeMux()
-	RegisterMovedDebugHandler(mux)
+	mux := newTelemetryMux(t)
 
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, debugPath, http.NoBody))
@@ -66,29 +86,57 @@ func TestMovedDebugHandlerExplainsItself(t *testing.T) {
 	require.Equal(t, http.StatusGone, rec.Code)
 
 	body := rec.Body.String()
-	assert.Contains(t, body, "diagnostics.profiling.enabled", "the body must name the setting")
-	assert.Contains(t, body, debugPath, "the body must name the new path")
-	assert.Contains(t, body, "diagnostics.profiling.token", "the body must explain the no-auth case")
+	assert.Contains(t, body, "diagnostics.profiling",
+		"the body must name the configuration section so a broken workflow can reconnect")
 	assert.True(t, strings.HasPrefix(rec.Header().Get("Content-Type"), "text/plain"),
 		"the notice is plain text, not something a browser should render as markup")
 	assert.Equal(t, "nosniff", rec.Header().Get("X-Content-Type-Options"))
+
+	// This listener is unauthenticated, so the notice must stay a signpost and
+	// not become a briefing. Naming the credential mechanism would hand a
+	// scanner the parameter to brute-force for no operator benefit.
+	assert.NotContains(t, body, "token",
+		"the breadcrumb must not name the credential mechanism")
 }
 
 // TestTelemetryMuxStillServesMetrics confirms removing the profiling handlers
-// left the listener's actual job intact.
+// left the listener's actual job intact. It goes through buildMux, so dropping
+// either registration from the listener fails here.
 func TestTelemetryMuxStillServesMetrics(t *testing.T) {
 	t.Parallel()
 
-	metrics, err := NewMetrics()
-	require.NoError(t, err)
-
-	mux := http.NewServeMux()
-	metrics.RegisterHandlers(mux)
-	RegisterMovedDebugHandler(mux)
+	mux := newTelemetryMux(t)
 
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", http.NoBody))
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.NotEmpty(t, rec.Body.Bytes())
+}
+
+// TestTelemetryMuxRejectsReAddedProfileHandler is the direct guard on the
+// regression this whole change exists to prevent.
+//
+// It does not test production code; it tests that the OTHER tests in this file
+// would notice. A profile handler re-added to buildMux wins over the
+// breadcrumb's subtree pattern under Go 1.22+ precedence, so this asserts that
+// precedence explicitly: if a future Go release or a mux change made the
+// subtree pattern win instead, the shape of the risk would have changed and
+// this test says so.
+func TestTelemetryMuxRejectsReAddedProfileHandler(t *testing.T) {
+	t.Parallel()
+
+	mux := newTelemetryMux(t)
+	// Simulate the regression: a specific pattern alongside the subtree one.
+	mux.HandleFunc(debugPath+"heap", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("runtime.mallocgc"))
+	})
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, debugPath+"heap", http.NoBody))
+
+	require.Equal(t, http.StatusOK, rec.Code,
+		"a specific pattern must still beat the subtree breadcrumb; if this "+
+			"ever fails, the assumption behind the other tests in this file changed")
 }

--- a/internal/observability/endpoint.go
+++ b/internal/observability/endpoint.go
@@ -57,7 +57,9 @@ func NewEndpoint(settings *conf.Settings, metrics *Metrics) (*Endpoint, error) {
 func (e *Endpoint) Start(wg *sync.WaitGroup, quitChan <-chan struct{}) {
 	mux := http.NewServeMux()
 	e.metrics.RegisterHandlers(mux)
-	RegisterDebugHandlers(mux)
+	// This listener serves Prometheus metrics only. pprof moved to the
+	// authenticated web server; all that is left here is the breadcrumb.
+	RegisterMovedDebugHandler(mux)
 
 	e.server = &http.Server{
 		Addr:    e.listenAddress,

--- a/internal/observability/endpoint.go
+++ b/internal/observability/endpoint.go
@@ -46,6 +46,23 @@ func NewEndpoint(settings *conf.Settings, metrics *Metrics) (*Endpoint, error) {
 	}, nil
 }
 
+// buildMux assembles the telemetry listener's routing table.
+//
+// It exists so tests can assert against the mux this listener actually serves
+// rather than reassembling an equivalent one. That distinction is the whole
+// point here: this mux is served with no middleware of any kind, so anything
+// registered on it is reachable unauthenticated on every interface, and a
+// re-added pprof handler would win over the breadcrumb's subtree pattern under
+// Go 1.22+ precedence rules while a test that builds its own mux stayed green.
+func (e *Endpoint) buildMux() *http.ServeMux {
+	mux := http.NewServeMux()
+	e.metrics.RegisterHandlers(mux)
+	// This listener serves Prometheus metrics only. pprof moved to the
+	// authenticated web server; all that is left here is the breadcrumb.
+	RegisterMovedDebugHandler(mux)
+	return mux
+}
+
 // Start initializes and runs the HTTP server for the telemetry endpoint.
 //
 // It sets up the necessary routes, starts the server in a separate goroutine,
@@ -55,11 +72,7 @@ func NewEndpoint(settings *conf.Settings, metrics *Metrics) (*Endpoint, error) {
 //   - wg: A pointer to a WaitGroup for coordinating goroutine completion.
 //   - quitChan: A channel for receiving the quit signal.
 func (e *Endpoint) Start(wg *sync.WaitGroup, quitChan <-chan struct{}) {
-	mux := http.NewServeMux()
-	e.metrics.RegisterHandlers(mux)
-	// This listener serves Prometheus metrics only. pprof moved to the
-	// authenticated web server; all that is left here is the breadcrumb.
-	RegisterMovedDebugHandler(mux)
+	mux := e.buildMux()
 
 	e.server = &http.Server{
 		Addr:    e.listenAddress,

--- a/internal/support/profiling_token_test.go
+++ b/internal/support/profiling_token_test.go
@@ -1,0 +1,77 @@
+package support
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"gopkg.in/yaml.v3"
+)
+
+// profilingTokenSecret is a value distinctive enough that finding it anywhere in
+// a generated dump is unambiguous.
+const profilingTokenSecret = "PROFILING-TOKEN-MUST-NOT-LEAK-8b41c7"
+
+// TestSupportDumpRedactsProfilingToken asserts the profiling token is redacted
+// from a collected support dump.
+//
+// This is the trap that made the config key name a design decision rather than
+// a detail. Support dumps upload to Sentry, and scrubbing matches sensitive keys
+// on word boundaries (isSensitiveKey), so "token" and "profiling_token" are
+// redacted but a squashed "profilingtoken" is not. The project's YAML house
+// style is squashed lowercase, which is exactly the form that fails, so the leaf
+// key is "token" and this test is what keeps it that way.
+//
+// It marshals a real conf.Settings rather than a hand-written map, so the yaml
+// tag on the struct field is part of what is being asserted.
+func TestSupportDumpRedactsProfilingToken(t *testing.T) {
+	t.Parallel()
+
+	settings := &conf.Settings{}
+	settings.Diagnostics.Profiling.Enabled = true
+	settings.Diagnostics.Profiling.Token = profilingTokenSecret
+
+	data, err := yaml.Marshal(settings)
+	require.NoError(t, err)
+	require.Contains(t, string(data), profilingTokenSecret,
+		"test setup must actually write the token into the config file")
+
+	configDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.yaml"), data, 0o600))
+
+	collector := NewCollector(configDir, t.TempDir(), "test-system", "test-version")
+
+	scrubbed, err := collector.collectConfig(true)
+	require.NoError(t, err)
+
+	rendered, err := yaml.Marshal(scrubbed)
+	require.NoError(t, err)
+	assert.NotContains(t, string(rendered), profilingTokenSecret,
+		"the profiling token must never reach a support dump")
+
+	diagnostics, ok := scrubbed["diagnostics"].(map[string]any)
+	require.True(t, ok, "diagnostics section should survive scrubbing: %#v", scrubbed)
+	profiling, ok := diagnostics["profiling"].(map[string]any)
+	require.True(t, ok, "profiling section should survive scrubbing: %#v", diagnostics)
+
+	assert.Equal(t, "[redacted]", profiling["token"])
+	assert.Equal(t, true, profiling["enabled"],
+		"only the token is sensitive; the enable flag is diagnostic signal worth keeping")
+}
+
+// TestProfilingTokenKeyIsRedactable pins the naming rule itself, independent of
+// the collector. The negative case is the point: it records why the leaf key
+// cannot be renamed to the squashed form the rest of the config file uses.
+func TestProfilingTokenKeyIsRedactable(t *testing.T) {
+	t.Parallel()
+
+	keys := DefaultSensitiveKeys()
+
+	assert.True(t, MatchesSensitiveKey("diagnostics.profiling.token", keys),
+		"the configured key path must be redacted")
+	assert.False(t, MatchesSensitiveKey("diagnostics.profiling.profilingtoken", keys),
+		"squashed naming is NOT redacted; renaming the leaf key would leak the credential")
+}

--- a/scripts/collect-debug-data-docker.sh
+++ b/scripts/collect-debug-data-docker.sh
@@ -175,18 +175,36 @@ check_connectivity() {
 # configured. Set BIRDNET_PROFILING_TOKEN to the diagnostics.profiling.token
 # value from config.yaml. When authentication IS configured, the endpoints sit
 # behind it instead and this stays empty.
+# Note: these collectors support unauthenticated and token-gated instances only;
+# they cannot log in to an instance protected by basic auth or OAuth.
 PROFILING_TOKEN="${BIRDNET_PROFILING_TOKEN:-}"
+
+# urlencode percent-encodes a string for safe use in a URL query value.
+# The generated token is base64url and needs no encoding, but a hand-configured
+# one may contain &, =, + or spaces, which would silently corrupt the request.
+urlencode() {
+    local raw=$1
+    local i char out=""
+    for (( i = 0; i < ${#raw}; i++ )); do
+        char=${raw:i:1}
+        case "$char" in
+            [a-zA-Z0-9.~_-]) out+="$char" ;;
+            *) out+=$(printf '%%%02X' "'$char") ;;
+        esac
+    done
+    printf '%s' "$out"
+}
 
 # auth_query returns the query-string fragment carrying the profiling token,
 # with the correct separator for a URL that may already have parameters.
 auth_query() {
     local separator=${1:-?}
     if [ -n "${PROFILING_TOKEN}" ]; then
-        printf '%stoken=%s' "${separator}" "${PROFILING_TOKEN}"
+        printf '%stoken=%s' "${separator}" "$(urlencode "${PROFILING_TOKEN}")"
     fi
 }
 
-# Function to check if debug mode is enabled
+# Function to check that the profiling endpoints are reachable
 check_debug_mode() {
     print_status "Checking if profiling is enabled..."
     if ! curl -s -f "${BASE_URL}/debug/pprof/$(auth_query)" > /dev/null 2>&1; then

--- a/scripts/collect-debug-data-docker.sh
+++ b/scripts/collect-debug-data-docker.sh
@@ -171,18 +171,34 @@ check_connectivity() {
     print_status "✓ Connected to BirdNET-Go"
 }
 
+# Profiling token, required when BirdNET-Go has no authentication provider
+# configured. Set BIRDNET_PROFILING_TOKEN to the diagnostics.profiling.token
+# value from config.yaml. When authentication IS configured, the endpoints sit
+# behind it instead and this stays empty.
+PROFILING_TOKEN="${BIRDNET_PROFILING_TOKEN:-}"
+
+# auth_query returns the query-string fragment carrying the profiling token,
+# with the correct separator for a URL that may already have parameters.
+auth_query() {
+    local separator=${1:-?}
+    if [ -n "${PROFILING_TOKEN}" ]; then
+        printf '%stoken=%s' "${separator}" "${PROFILING_TOKEN}"
+    fi
+}
+
 # Function to check if debug mode is enabled
 check_debug_mode() {
-    print_status "Checking if debug mode is enabled..."
-    if ! curl -s -f "${BASE_URL}/debug/pprof/" > /dev/null 2>&1; then
-        print_error "Debug mode is not enabled or pprof endpoints are not accessible"
-        print_error "Please set 'debug: true' in your config.yaml and restart the container"
-        print_warning "You may need to restart the container with debug mode enabled:"
-        print_warning "  1. Update config.yaml with 'debug: true'"
+    print_status "Checking if profiling is enabled..."
+    if ! curl -s -f "${BASE_URL}/debug/pprof/$(auth_query)" > /dev/null 2>&1; then
+        print_error "Profiling endpoints are not accessible"
+        print_error "Set 'diagnostics.profiling.enabled: true' in your config.yaml and restart the container:"
+        print_warning "  1. Update config.yaml with 'diagnostics.profiling.enabled: true'"
         print_warning "  2. docker restart ${CONTAINER_NAME}"
+        print_warning "  3. If no authentication provider is configured, export the generated token:"
+        print_warning "     export BIRDNET_PROFILING_TOKEN=\"<diagnostics.profiling.token from config.yaml>\""
         exit 1
     fi
-    print_status "✓ Debug mode is enabled"
+    print_status "✓ Profiling is enabled"
 }
 
 # Function to collect a profile
@@ -190,9 +206,13 @@ collect_profile() {
     local profile_type=$1
     local output_file=$2
     local url_params=${3:-""}
-    
+    local separator="?"
+    if [ -n "${url_params}" ]; then
+        separator="&"
+    fi
+
     print_status "Collecting ${profile_type} profile..."
-    if curl -s -f -o "${output_file}" "${BASE_URL}/debug/pprof/${profile_type}${url_params}"; then
+    if curl -s -f -o "${output_file}" "${BASE_URL}/debug/pprof/${profile_type}${url_params}$(auth_query "${separator}")"; then
         print_status "✓ Collected ${profile_type} profile → ${output_file}"
     else
         print_warning "Failed to collect ${profile_type} profile"
@@ -449,12 +469,12 @@ main() {
     
     # Check if debug mode is actually enabled in config
     if [ -f "${OUTPUT_DIR}/config.yaml" ]; then
-        if ! grep -q "^debug: true" "${OUTPUT_DIR}/config.yaml" 2>/dev/null; then
+        if ! grep -A3 '^diagnostics:' "${OUTPUT_DIR}/config.yaml" 2>/dev/null | grep -q "enabled: true"; then
             print_warning ""
-            print_warning "⚠️  IMPORTANT: Debug mode may not be properly enabled!"
-            print_warning "Found 'debug: false' in config.yaml"
-            print_warning "To enable debug mode:"
-            print_warning "1. Edit your config.yaml and set 'debug: true'"
+            print_warning "⚠️  IMPORTANT: Profiling may not be properly enabled!"
+            print_warning "Did not find 'diagnostics.profiling.enabled: true' in config.yaml"
+            print_warning "To enable profiling:"
+            print_warning "1. Edit your config.yaml and set 'diagnostics.profiling.enabled: true'"
             print_warning "2. Restart the container: sudo systemctl restart birdnet-go"
             print_warning "3. Run this script again"
         fi

--- a/scripts/collect-debug-data-docker.sh
+++ b/scripts/collect-debug-data-docker.sh
@@ -183,6 +183,11 @@ PROFILING_TOKEN="${BIRDNET_PROFILING_TOKEN:-}"
 # The generated token is base64url and needs no encoding, but a hand-configured
 # one may contain &, =, + or spaces, which would silently corrupt the request.
 urlencode() {
+    # LC_ALL=C forces byte-oriented iteration. Under a UTF-8 locale bash walks
+    # CHARACTERS, so a token containing e.g. 'e-acute' would be emitted as its
+    # single code point (%E9) rather than its UTF-8 bytes (%C3%A9), and the
+    # server would receive a different token than the one configured.
+    local LC_ALL=C
     local raw=$1
     local i char out=""
     for (( i = 0; i < ${#raw}; i++ )); do

--- a/scripts/collect-debug-data.sh
+++ b/scripts/collect-debug-data.sh
@@ -120,15 +120,32 @@ check_connectivity() {
     print_status "✓ Connected to BirdNET-Go"
 }
 
-# Function to check if debug mode is enabled
+# Profiling token, required when BirdNET-Go has no authentication provider
+# configured. Set BIRDNET_PROFILING_TOKEN to the diagnostics.profiling.token
+# value from config.yaml. When authentication IS configured, the endpoints sit
+# behind it instead and this stays empty.
+PROFILING_TOKEN="${BIRDNET_PROFILING_TOKEN:-}"
+
+# auth_query returns the query-string fragment carrying the profiling token,
+# with the correct separator for a URL that may already have parameters.
+auth_query() {
+    local separator=${1:-?}
+    if [ -n "${PROFILING_TOKEN}" ]; then
+        printf '%stoken=%s' "${separator}" "${PROFILING_TOKEN}"
+    fi
+}
+
+# Function to check that the profiling endpoints are reachable
 check_debug_mode() {
-    print_status "Checking if debug mode is enabled..."
-    if ! curl -s -f "${BASE_URL}/debug/pprof/" > /dev/null 2>&1; then
-        print_error "Debug mode is not enabled or pprof endpoints are not accessible"
-        print_error "Please set 'debug: true' in your config.yaml and restart BirdNET-Go"
+    print_status "Checking if profiling is enabled..."
+    if ! curl -s -f "${BASE_URL}/debug/pprof/$(auth_query)" > /dev/null 2>&1; then
+        print_error "Profiling endpoints are not accessible"
+        print_error "Set 'diagnostics.profiling.enabled: true' in config.yaml and restart BirdNET-Go."
+        print_error "If no authentication provider is configured, also export the generated token:"
+        print_error "  export BIRDNET_PROFILING_TOKEN=\"\$(grep -A3 '^diagnostics:' config.yaml | awk '/token:/{print \$2}')\""
         exit 1
     fi
-    print_status "✓ Debug mode is enabled"
+    print_status "✓ Profiling is enabled"
 }
 
 # Function to collect a profile
@@ -136,9 +153,13 @@ collect_profile() {
     local profile_type=$1
     local output_file=$2
     local url_params=${3:-""}
-    
+    local separator="?"
+    if [ -n "${url_params}" ]; then
+        separator="&"
+    fi
+
     print_status "Collecting ${profile_type} profile..."
-    if curl -s -f -o "${output_file}" "${BASE_URL}/debug/pprof/${profile_type}${url_params}"; then
+    if curl -s -f -o "${output_file}" "${BASE_URL}/debug/pprof/${profile_type}${url_params}$(auth_query "${separator}")"; then
         print_status "✓ Collected ${profile_type} profile → ${output_file}"
     else
         print_warning "Failed to collect ${profile_type} profile"

--- a/scripts/collect-debug-data.sh
+++ b/scripts/collect-debug-data.sh
@@ -124,14 +124,32 @@ check_connectivity() {
 # configured. Set BIRDNET_PROFILING_TOKEN to the diagnostics.profiling.token
 # value from config.yaml. When authentication IS configured, the endpoints sit
 # behind it instead and this stays empty.
+# Note: these collectors support unauthenticated and token-gated instances only;
+# they cannot log in to an instance protected by basic auth or OAuth.
 PROFILING_TOKEN="${BIRDNET_PROFILING_TOKEN:-}"
+
+# urlencode percent-encodes a string for safe use in a URL query value.
+# The generated token is base64url and needs no encoding, but a hand-configured
+# one may contain &, =, + or spaces, which would silently corrupt the request.
+urlencode() {
+    local raw=$1
+    local i char out=""
+    for (( i = 0; i < ${#raw}; i++ )); do
+        char=${raw:i:1}
+        case "$char" in
+            [a-zA-Z0-9.~_-]) out+="$char" ;;
+            *) out+=$(printf '%%%02X' "'$char") ;;
+        esac
+    done
+    printf '%s' "$out"
+}
 
 # auth_query returns the query-string fragment carrying the profiling token,
 # with the correct separator for a URL that may already have parameters.
 auth_query() {
     local separator=${1:-?}
     if [ -n "${PROFILING_TOKEN}" ]; then
-        printf '%stoken=%s' "${separator}" "${PROFILING_TOKEN}"
+        printf '%stoken=%s' "${separator}" "$(urlencode "${PROFILING_TOKEN}")"
     fi
 }
 

--- a/scripts/collect-debug-data.sh
+++ b/scripts/collect-debug-data.sh
@@ -132,6 +132,11 @@ PROFILING_TOKEN="${BIRDNET_PROFILING_TOKEN:-}"
 # The generated token is base64url and needs no encoding, but a hand-configured
 # one may contain &, =, + or spaces, which would silently corrupt the request.
 urlencode() {
+    # LC_ALL=C forces byte-oriented iteration. Under a UTF-8 locale bash walks
+    # CHARACTERS, so a token containing e.g. 'e-acute' would be emitted as its
+    # single code point (%E9) rather than its UTF-8 bytes (%C3%A9), and the
+    # server would receive a different token than the one configured.
+    local LC_ALL=C
     local raw=$1
     local i char out=""
     for (( i = 0; i < ${#raw}; i++ )); do

--- a/scripts/docker-quick-check.sh
+++ b/scripts/docker-quick-check.sh
@@ -56,14 +56,15 @@ if [ -n "$CONTAINER" ]; then
         echo -e "${YELLOW}⚠️  Web interface not accessible at http://localhost:${PORT}${NC}"
     fi
     
-    # Check debug mode
+    # Check profiling
     echo ""
-    if docker exec birdnet-go grep -q "^debug: true" /config/config.yaml 2>/dev/null; then
-        echo -e "${GREEN}✅ Debug mode is enabled${NC}"
-        echo "   Debug endpoints available at: http://localhost:${PORT}/debug/pprof/"
+    if docker exec birdnet-go grep -A3 '^diagnostics:' /config/config.yaml 2>/dev/null | grep -q "enabled: true"; then
+        echo -e "${GREEN}✅ Profiling is enabled${NC}"
+        echo "   Profiling endpoints available at: http://localhost:${PORT}/debug/pprof/"
+        echo "   If no authentication is configured, append ?token=<diagnostics.profiling.token>"
     else
-        echo -e "${YELLOW}ℹ️  Debug mode is disabled${NC}"
-        echo "   To enable: Set 'debug: true' in config.yaml and restart"
+        echo -e "${YELLOW}ℹ️  Profiling is disabled${NC}"
+        echo "   To enable: Set 'diagnostics.profiling.enabled: true' in config.yaml and restart"
     fi
     
     # Check audio device


### PR DESCRIPTION
## Problem

The Go pprof handlers were registered on the Prometheus telemetry mux, which is a bare `http.ServeMux` served with no middleware of any kind. Enabling `realtime.telemetry.enabled` therefore also published `/debug/pprof/` on all interfaces (default `0.0.0.0:8090`) with no authentication and no gate of its own.

`doc/PROFILING.md` claimed these endpoints were "protected by the same authentication mechanism as other admin endpoints" and that `debug: true` controlled them. Neither was true.

## What actually leaked

Measured rather than assumed, so the fix is scoped correctly. A Go heap profile does not contain the contents of allocations: 2000 live buffers holding a known secret produced a profile containing no trace of it. It does contain allocation call stacks, function names, and absolute source paths. Combined with `/debug/pprof/cmdline` (argv), `/debug/pprof/goroutine?debug=2` (goroutine stacks), and `/debug/pprof/profile?seconds=N` (unauthenticated work amplification), the exposure is code-structure and build-path disclosure plus a cheap resource lever. Worth fixing promptly; not a credential leak.

## Fix

pprof now mounts on the main web server behind its existing authentication middleware, gated by a new top-level config section:

```yaml
diagnostics:
  profiling:
    enabled: false
    token: ""
```

Routes are registered unconditionally and guarded by dynamic per-request middleware, so the toggle hot-reloads. With profiling disabled the routes return 404 rather than 403, so the feature does not advertise itself. Where no authentication provider is configured (the common home-LAN default), a token generated the same way as `security.sessionsecret` is required instead, compared with `crypto/subtle.ConstantTimeCompare` and never logged.

The old telemetry path returns `410 Gone` with a short body pointing at the new configuration section, so an existing profiling workflow gets an explanation instead of a connection error.

`go tool pprof` still works in one command. It has no flag for custom headers, but it preserves query parameters it did not set and merges its own into them, so `?token=...` survives:

```
go tool pprof "http://host:8080/debug/pprof/profile?token=SECRET&seconds=3"
```

Verified end to end against a running instance through the full middleware stack, including a default 30-second CPU profile against the server's 30-second `WriteTimeout`.

### The config key name is load-bearing

The leaf key is `token`, not `profilingtoken`. Support-dump scrubbing matches sensitive keys on word boundaries, so the squashed form this project's YAML style would otherwise suggest is **not** redacted and would ship the credential to Sentry in plaintext. There is a test asserting redaction on a generated dump rather than a comment claiming it.

## Notable review findings, fixed in the second commit

- The token was returned in plaintext by `GET /api/v2/settings`. Every other credential is redacted there, but the new field was not, and when no auth provider is configured those endpoints have no authentication either. The credential's only distribution channel was an endpoint requiring no credential. Now redacted, with the matching restore/validate/clear entries and a blocked-field entry matching `SessionSecret`.
- Backup archives run a separate config sanitizer that had the same gap. Fixed, with a test that asserts on serialized output so the next unregistered credential fails rather than rides along.
- `GET /debug/pprof` rendered an index whose every link 404s, because `pprof.Index` emits relative links and `net/http.ServeMux` used to issue the trailing-slash redirect implicitly. Now redirects, carrying the query so the token survives.
- The test suite could not fail for the regression it exists to catch: the telemetry tests built their own mux instead of the listener's, and only `/heap` was ever driven through the gate. Both closed; every registered route is now driven through the disabled and no-credential cases from one shared list.

## Not addressed here, by design

Both were evaluated and rejected with reasons rather than silently dropped, since the original report asked for them:

- **No separate unstripped build target.** Go binaries always retain the pclntab, which is what pprof uses to symbolize Go frames, so `-s -w` costs nothing at the Go level. `-gcflags=all=-N -l` would be actively wrong for a profiling build, since disabling inlining distorts the profile being measured.
- **No cgosymbolizer.** It runs libbacktrace from a SIGPROF handler, which allocates and takes locks, so it is not async-signal-safe. Its traceback carries a linux-only build constraint, and the native frames it reveals are overwhelmingly inside the legacy TFLite backend. `perf record -g` covers the rare case with nothing shipped in the product.

## Breaking change

Anyone currently profiling via the telemetry listener on port 8090 will find the endpoints gone, answered by a 410 naming the new location. Profiling must now be enabled explicitly.

## Testing

`golangci-lint run` clean on all changed files (256 issues repo-wide, against 257 pre-existing on main). `go test -race ./...` green. `task generate-schema` re-run with the regenerated files committed. Verified against a running instance: token minted and persisted at startup and absent from every log, telemetry listener serving 410 and `/metrics`, every pprof route refusing without a token and serving with one, and the token redacted from every settings endpoint.

## Release notes
- audience: user
- summary: Profiling endpoints are no longer exposed without authentication when Prometheus metrics are enabled, and are now opt-in behind a new diagnostics.profiling setting
- feature: none
- breaking: The pprof endpoints are no longer served on the telemetry listener (port 8090). Enable `diagnostics.profiling.enabled` and use the main web server port instead; the old path returns 410 with instructions.
- config: new `diagnostics.profiling.enabled` (default false) and `diagnostics.profiling.token` (generated automatically at startup when profiling is enabled and no authentication provider is configured)
- schema: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added web-server–served profiling diagnostics with `diagnostics.profiling.enabled` and `diagnostics.profiling.token`.
  * Access uses existing authentication or a token (auto-generated when enabled and no auth provider is configured).
  * Profiling settings take effect immediately via live configuration reload.
* **Security**
  * Profiling tokens are protected in API responses, backups, and support bundles.
* **Documentation**
  * Updated configuration reference and quick-check/debug-data scripts for the new profiling settings and token parameter.
* **Bug Fixes**
  * Updated pprof routing/redirect behavior and improved compatibility by bypassing gzip/CSRF checks for profiling endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->