### PR TITLE
fix(profiling): decouple block and mutex sampling from debug: true

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1532,6 +1532,14 @@
         "token": {
           "type": "string",
           "description": "secret required when no auth provider is configured; generated automatically"
+        },
+        "blockrate": {
+          "type": "integer",
+          "description": "nanoseconds of blocked time per sample; 0 disables. Recommended starting point: 10000"
+        },
+        "mutexfraction": {
+          "type": "integer",
+          "description": "report 1 in N contention events; 0 disables. Recommended starting point: 100"
         }
       },
       "additionalProperties": false,

--- a/config.schema.json
+++ b/config.schema.json
@@ -1535,7 +1535,7 @@
         },
         "blockrate": {
           "type": "integer",
-          "description": "nanoseconds of blocked time per sample; 0 disables, and values above 10000000 (10ms) are clamped to it. Independent of enabled: sampling costs CPU continuously whether or not a profile is ever fetched, so 0 is the only free setting. Recommended starting point: 10000. Hot-reloadable via the settings API."
+          "description": "nanoseconds of blocked time per sample; 0 disables. Independent of enabled: sampling costs CPU continuously whether or not a profile is ever fetched, so 0 is the only free setting and a very coarse rate still pays most of the cost. Recommended starting point: 10000. Hot-reloadable via the settings API."
         },
         "mutexfraction": {
           "type": "integer",

--- a/config.schema.json
+++ b/config.schema.json
@@ -1535,11 +1535,11 @@
         },
         "blockrate": {
           "type": "integer",
-          "description": "nanoseconds of blocked time per sample; 0 disables. Recommended starting point: 10000"
+          "description": "nanoseconds of blocked time per sample; 0 disables, and values above 10000000 (10ms) are clamped to it. Independent of enabled: sampling costs CPU continuously whether or not a profile is ever fetched, so 0 is the only free setting. Recommended starting point: 10000. Hot-reloadable via the settings API."
         },
         "mutexfraction": {
           "type": "integer",
-          "description": "report 1 in N contention events; 0 disables. Recommended starting point: 100"
+          "description": "reports one sampled event per this many contention events; 0 disables. Independent of enabled: sampling costs CPU continuously whether or not a profile is ever fetched. Recommended starting point: 100. Hot-reloadable via the settings API."
         }
       },
       "additionalProperties": false,

--- a/doc/PROFILING.md
+++ b/doc/PROFILING.md
@@ -4,22 +4,56 @@ This guide explains how to use the built-in profiling capabilities in BirdNET-Go
 
 ## Prerequisites
 
-- BirdNET-Go running with debug mode enabled
+- BirdNET-Go running with `diagnostics.profiling.enabled` set
 - `go` tool installed on your system (for analyzing profiles)
 
-## Enabling Debug Mode
+## Enabling Profiling
 
-To enable profiling endpoints, you need to run BirdNET-Go with debug mode enabled. Set `debug: true` in your config.yaml:
+Profiling is off by default and is not related to `debug: true`, which controls
+logging verbosity only. Set it in your config.yaml:
 
 ```yaml
-debug: true
+diagnostics:
+  profiling:
+    enabled: true
 ```
 
-When debug mode is enabled:
+The endpoints are served by the main web server, behind whatever authentication
+you have configured. On an instance with no authentication provider, a token is
+generated into `diagnostics.profiling.token` when profiling is switched on, and
+must be passed as a `token=` query parameter. `go tool pprof` preserves query
+parameters, so the one-command workflow still works:
 
-- pprof HTTP endpoints are exposed at `/debug/pprof/`
-- Mutex profiling is enabled to detect lock contention
-- Block profiling is enabled to detect blocking operations
+```bash
+go tool pprof "http://localhost:8080/debug/pprof/heap?token=YOUR_TOKEN"
+```
+
+The setting takes effect immediately, with no restart.
+
+### Block and mutex sampling
+
+The heap, goroutine, CPU and trace profiles need nothing beyond the setting
+above. The block and mutex profiles are different: they require the Go runtime
+to be sampling, which costs CPU on the audio path whether or not anyone ever
+fetches a profile. They are therefore off by default and configured separately:
+
+```yaml
+diagnostics:
+  profiling:
+    blockrate: 10000      # ns of blocked time per sample; 0 disables
+    mutexfraction: 100    # report 1 in N contention events; 0 disables
+```
+
+Note the two have different units. `blockrate` is nanoseconds of blocked time
+per sample, so a larger number samples less. `mutexfraction` reports one in
+every N contention events. Go's own documentation suggests 1 for both, which
+records essentially every event; the values above are the recommended starting
+points and keep enough signal to find a contention problem without recording
+all of it. Both take effect immediately, with no restart.
+
+One caveat when changing a rate on a running instance: lowering or zeroing a
+rate does not discard samples already collected, so a profile taken shortly
+after a change can mix rates.
 
 ## Available Profiling Endpoints
 
@@ -83,7 +117,8 @@ go tool pprof http://localhost:8080/debug/pprof/goroutine
 
 ### 4. Finding Lock Contention
 
-To analyze mutex contention:
+To analyze mutex contention (requires `mutexfraction` to be set; see above, an
+empty profile means sampling was never switched on):
 
 ```bash
 go tool pprof http://localhost:8080/debug/pprof/mutex
@@ -91,7 +126,8 @@ go tool pprof http://localhost:8080/debug/pprof/mutex
 
 ### 5. Analyzing Blocking Operations
 
-To find where goroutines are blocking:
+To find where goroutines are blocking (requires `blockrate` to be set; see
+above, an empty profile means sampling was never switched on):
 
 ```bash
 go tool pprof http://localhost:8080/debug/pprof/block

--- a/doc/PROFILING.md
+++ b/doc/PROFILING.md
@@ -28,28 +28,33 @@ parameters, so the one-command workflow still works:
 go tool pprof "http://localhost:8080/debug/pprof/heap?token=YOUR_TOKEN"
 ```
 
-The setting takes effect immediately, with no restart.
+Changed in `config.yaml` this applies at the next restart, because the config
+file is not watched. Changed through the settings API it applies immediately.
 
 ### Block and mutex sampling
 
 The heap, goroutine, CPU and trace profiles need nothing beyond the setting
 above. The block and mutex profiles are different: they require the Go runtime
 to be sampling, which costs CPU on the audio path whether or not anyone ever
-fetches a profile. They are therefore off by default and configured separately:
+fetches a profile. They are therefore off by default and configured separately,
+as two more keys in the same `profiling` block:
 
 ```yaml
 diagnostics:
   profiling:
+    enabled: true
     blockrate: 10000      # ns of blocked time per sample; 0 disables
     mutexfraction: 100    # report 1 in N contention events; 0 disables
 ```
 
-Note the two have different units. `blockrate` is nanoseconds of blocked time
-per sample, so a larger number samples less. `mutexfraction` reports one in
-every N contention events. Go's own documentation suggests 1 for both, which
-records essentially every event; the values above are the recommended starting
-points and keep enough signal to find a contention problem without recording
-all of it. Both take effect immediately, with no restart.
+Note the two have different units, though both sample less as the number grows.
+`blockrate` is nanoseconds of blocked time per sample. `mutexfraction` reports
+one sampled event per that many contention events. Go documents rate 1 for the
+block profiler as the way to include every blocking event, and since the mutex
+fraction reports one in N, rate 1 there records every contention event too. That
+suits a benchmark; the values above are the recommended starting points for a
+machine doing real-time audio around the clock, and keep enough signal to find a
+contention problem without recording all of it.
 
 One caveat when changing a rate on a running instance: lowering or zeroing a
 rate does not discard samples already collected, so a profile taken shortly
@@ -57,7 +62,10 @@ after a change can mix rates.
 
 ## Available Profiling Endpoints
 
-All profiling endpoints require authentication (if you have authentication enabled) and are available at:
+All profiling endpoints sit behind the web server's authentication. Where no
+authentication provider is configured, the generated token described above is
+required instead, so the `?token=...` suffix applies to every command on this
+page even though the examples below omit it for brevity. The endpoints are:
 
 - `/debug/pprof/` - Index page listing all available profiles
 - `/debug/pprof/heap` - Heap memory profile
@@ -145,7 +153,7 @@ BIRDNET_GO_PROFILE=1 ./birdnet-go
 
 ## Best Practices
 
-1. **Production Use**: Only enable debug mode in production temporarily when diagnosing issues, as profiling has a performance overhead.
+1. **Production Use**: Turn `diagnostics.profiling.enabled` on temporarily when diagnosing an issue and off again afterwards. Be especially sparing with `blockrate` and `mutexfraction`, which cost CPU continuously rather than only while a profile is being fetched.
 
 2. **Memory Profiles**: Take multiple heap profiles over time to identify memory leaks:
 
@@ -174,9 +182,10 @@ The profiling endpoints are protected by the same authentication mechanism as ot
 
 If profiling endpoints are not available:
 
-1. Verify debug mode is enabled in config
-2. Check the logs for "pprof debugging endpoints enabled at /debug/pprof/"
+1. Verify `diagnostics.profiling.enabled` is `true` in config. `debug: true` does not enable profiling; it only controls logging verbosity.
+2. Where no authentication provider is configured, check you are passing `?token=` with the value from `diagnostics.profiling.token`. A missing or wrong token answers 403; a disabled feature answers 404.
 3. Ensure you're authenticated if security is enabled
-4. Check that the web server is running on the expected port
+4. Check that the web server is running on the expected port, not the telemetry port. The endpoints moved off the telemetry listener and the old location answers 410.
+5. An empty `block` or `mutex` profile with the endpoints otherwise working means `blockrate` / `mutexfraction` are still 0.
 
 For more information about pprof, see the [official Go documentation](https://pkg.go.dev/net/http/pprof).

--- a/doc/wiki/configuration-reference.md
+++ b/doc/wiki/configuration-reference.md
@@ -402,6 +402,8 @@ DiagnosticsConfig groups the developer-facing diagnostics features.
 |---------|------|-------------|
 | `diagnostics.profiling.enabled` | boolean | true to serve /debug/pprof/* on the web server |
 | `diagnostics.profiling.token` | string | secret required when no auth provider is configured; generated automatically |
+| `diagnostics.profiling.blockrate` | integer | nanoseconds of blocked time per sample; 0 disables. Recommended starting point: 10000 |
+| `diagnostics.profiling.mutexfraction` | integer | report 1 in N contention events; 0 disables. Recommended starting point: 100 |
 
 ## output
 

--- a/doc/wiki/configuration-reference.md
+++ b/doc/wiki/configuration-reference.md
@@ -402,8 +402,8 @@ DiagnosticsConfig groups the developer-facing diagnostics features.
 |---------|------|-------------|
 | `diagnostics.profiling.enabled` | boolean | true to serve /debug/pprof/* on the web server |
 | `diagnostics.profiling.token` | string | secret required when no auth provider is configured; generated automatically |
-| `diagnostics.profiling.blockrate` | integer | nanoseconds of blocked time per sample; 0 disables. Recommended starting point: 10000 |
-| `diagnostics.profiling.mutexfraction` | integer | report 1 in N contention events; 0 disables. Recommended starting point: 100 |
+| `diagnostics.profiling.blockrate` | integer | nanoseconds of blocked time per sample; 0 disables, and values above 10000000 (10ms) are clamped to it. Independent of enabled: sampling costs CPU continuously whether or not a profile is ever fetched, so 0 is the only free setting. Recommended starting point: 10000. Hot-reloadable via the settings API. |
+| `diagnostics.profiling.mutexfraction` | integer | reports one sampled event per this many contention events; 0 disables. Independent of enabled: sampling costs CPU continuously whether or not a profile is ever fetched. Recommended starting point: 100. Hot-reloadable via the settings API. |
 
 ## output
 

--- a/doc/wiki/configuration-reference.md
+++ b/doc/wiki/configuration-reference.md
@@ -402,7 +402,7 @@ DiagnosticsConfig groups the developer-facing diagnostics features.
 |---------|------|-------------|
 | `diagnostics.profiling.enabled` | boolean | true to serve /debug/pprof/* on the web server |
 | `diagnostics.profiling.token` | string | secret required when no auth provider is configured; generated automatically |
-| `diagnostics.profiling.blockrate` | integer | nanoseconds of blocked time per sample; 0 disables, and values above 10000000 (10ms) are clamped to it. Independent of enabled: sampling costs CPU continuously whether or not a profile is ever fetched, so 0 is the only free setting. Recommended starting point: 10000. Hot-reloadable via the settings API. |
+| `diagnostics.profiling.blockrate` | integer | nanoseconds of blocked time per sample; 0 disables. Independent of enabled: sampling costs CPU continuously whether or not a profile is ever fetched, so 0 is the only free setting and a very coarse rate still pays most of the cost. Recommended starting point: 10000. Hot-reloadable via the settings API. |
 | `diagnostics.profiling.mutexfraction` | integer | reports one sampled event per this many contention events; 0 disables. Independent of enabled: sampling costs CPU continuously whether or not a profile is ever fetched. Recommended starting point: 100. Hot-reloadable via the settings API. |
 
 ## output

--- a/frontend/src/lib/stores/settings.test.ts
+++ b/frontend/src/lib/stores/settings.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { get } from 'svelte/store';
 import { settingsStore, settingsActions } from './settings';
 import type { BirdNetSettings, RealtimeSettings, SettingsFormData } from './settings';
@@ -734,15 +734,29 @@ describe('Settings Store - Unmodelled Section Round-Trip', () => {
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    // clearAllMocks resets call history but LEAVES mockResolvedValue in place,
+    // so without this the stub below keeps answering settingsAPI.load for
+    // whatever describe block is appended after this one.
+    vi.mocked(settingsAPI.load).mockReset();
+  });
+
   it('preserves the diagnostics section through load and save', async () => {
     const diagnostics = {
       profiling: {
         enabled: true,
-        token: '_REDACTED_',
+        // The sentinel the backend actually substitutes, so the fixture looks
+        // like a real GET response rather than an invented one.
+        token: '**********',
         blockRate: 10000,
         mutexFraction: 100,
       },
     };
+    // Compare against a deep snapshot, not against the object the mock resolves.
+    // The store spreads the response, so formData.diagnostics is the SAME
+    // reference; asserting it equals itself would pass even against a coercer
+    // that stripped fields in place on the object it was handed.
+    const expected = JSON.parse(JSON.stringify(diagnostics));
 
     vi.mocked(settingsAPI.load).mockResolvedValue({
       main: { name: 'TestNode' },
@@ -752,11 +766,13 @@ describe('Settings Store - Unmodelled Section Round-Trip', () => {
     await settingsActions.loadSettings();
 
     expect((get(settingsStore).formData as unknown as Record<string, unknown>).diagnostics).toEqual(
-      diagnostics
+      expected
     );
 
     await settingsActions.saveSettings();
 
-    expect(settingsAPI.save).toHaveBeenCalledWith(expect.objectContaining({ diagnostics }));
+    expect(settingsAPI.save).toHaveBeenCalledWith(
+      expect.objectContaining({ diagnostics: expected })
+    );
   });
 });

--- a/frontend/src/lib/stores/settings.test.ts
+++ b/frontend/src/lib/stores/settings.test.ts
@@ -712,3 +712,51 @@ describe('Settings Store - syncTLSMode preserves unsaved Security edits', () => 
     expect(s.originalData.security?.basicAuth).toBeDefined();
   });
 });
+
+// The settings store has no TypeScript model for the diagnostics section: there
+// is deliberately no UI for the profiling switches, so nothing here declares
+// them. That makes the section's survival an accident of implementation rather
+// than something anyone states, and the accident is load-bearing.
+//
+// GET /api/v2/settings returns the whole Settings struct, and PUT replaces what
+// it is given: the backend merges the request body field by field over the
+// current config WITHOUT skipping zero values, so a body that omits diagnostics
+// writes 0 over diagnostics.profiling.blockrate and mutexfraction and false
+// over enabled. Sampling that an operator turned on in config.yaml would then be
+// silently switched off the next time anyone saved an unrelated setting from the
+// UI, and the block and mutex profiles would go quietly empty.
+//
+// Two things keep that from happening: object spread in loadSettings copies
+// properties the interfaces do not declare, and coerceSettings returns unknown
+// sections untouched. Both are easy to remove while "cleaning up types".
+describe('Settings Store - Unmodelled Section Round-Trip', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('preserves the diagnostics section through load and save', async () => {
+    const diagnostics = {
+      profiling: {
+        enabled: true,
+        token: '_REDACTED_',
+        blockRate: 10000,
+        mutexFraction: 100,
+      },
+    };
+
+    vi.mocked(settingsAPI.load).mockResolvedValue({
+      main: { name: 'TestNode' },
+      diagnostics,
+    } as unknown as SettingsFormData);
+
+    await settingsActions.loadSettings();
+
+    expect((get(settingsStore).formData as unknown as Record<string, unknown>).diagnostics).toEqual(
+      diagnostics
+    );
+
+    await settingsActions.saveSettings();
+
+    expect(settingsAPI.save).toHaveBeenCalledWith(expect.objectContaining({ diagnostics }));
+  });
+});

--- a/internal/api/v2/app/app.go
+++ b/internal/api/v2/app/app.go
@@ -166,7 +166,7 @@ func (c *Handler) GetAppConfig(ctx echo.Context) error {
 	}
 
 	// Determine if any security method is enabled
-	securityEnabled := settings.Security.BasicAuth.Enabled || len(enabledProviders) > 0
+	securityEnabled := settings.IsAuthProviderConfigured()
 
 	// Determine if access is currently allowed
 	accessAllowed := c.determineAccessAllowed(ctx, securityEnabled)
@@ -327,7 +327,7 @@ func (c *Handler) isExistingInstall(ctx context.Context, settings *conf.Settings
 	if len(settings.Realtime.Audio.Sources) > 0 {
 		return true
 	}
-	if settings.Security.BasicAuth.Enabled || len(settings.GetEnabledOAuthProviders()) > 0 {
+	if settings.IsAuthProviderConfigured() {
 		return true
 	}
 	if !c.hasZeroDetections(ctx) {

--- a/internal/api/v2/hotreload_coverage_test.go
+++ b/internal/api/v2/hotreload_coverage_test.go
@@ -240,12 +240,21 @@ var hotReloadRegistry = map[string]hotReloadEntry{
 	"Sentry": {categories: []hotReloadCategory{hotReloadFresh}, action: "reconfigure_telemetry"},
 
 	// --- Diagnostics ---
-	// The pprof routes are registered unconditionally and gated by middleware
-	// that reads the live snapshot per request, so a change to either field is
-	// observed on the next request with no restart and no action. Enabling
+	// Two different mechanisms, both actionless, which is why this stays one
+	// coarse entry.
+	//
+	// Enabled and Token: the pprof routes are registered unconditionally and
+	// gated by middleware that reads the live snapshot per request, so a change
+	// is observed on the next request with no restart and no action. Enabling
 	// profiling also mints the token during the same save
 	// (ensureProfilingTokenForSave), so the endpoint is usable immediately
 	// rather than refusing until the next start.
+	//
+	// BlockRate and MutexFraction: applied directly by handleSettingsChanges via
+	// profiling.ApplyRates. They declare no action because the runtime setters
+	// are process-global calls with no dependencies; routing them through
+	// controlChan would queue them behind audio reconfiguration and would apply
+	// them only in realtime analysis mode, where the control monitor runs.
 	"Diagnostics": {categories: []hotReloadCategory{hotReloadFresh}},
 
 	// --- Output ---

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/notification"
+	"github.com/tphakala/birdnet-go/internal/profiling"
 	"github.com/tphakala/birdnet-go/internal/restart"
 	"github.com/tphakala/birdnet-go/internal/support"
 	"github.com/tphakala/birdnet-go/internal/telemetry"
@@ -2291,6 +2292,38 @@ func (c *Controller) handleSettingsChanges(oldSettings, currentSettings *conf.Se
 		restart.MarkRestartRequired(reason)
 	}
 
+	// Apply the runtime block and mutex sampling rates.
+	//
+	// Deliberately NOT a settingsChangeChecks entry routed through controlChan
+	// like the reconfigure_* actions above. Those exist because the thing being
+	// reconfigured lives in the realtime analysis pipeline and must be touched
+	// from its own goroutine; sendReconfigActions therefore queues them with a
+	// delay between each. These two are process-global runtime calls with no
+	// dependencies and no ordering relationship to anything else, so queueing
+	// them behind a model reload would only add latency, and routing them
+	// through a monitor that exists solely in realtime analysis mode would make
+	// them silently do nothing anywhere else.
+	//
+	// Placed here, after the fallible audio reconfiguration, for the same reason
+	// the restart marks are: a change that is about to be rolled back should not
+	// have left the process sampling. It still runs before conf.SaveSettings, so
+	// a failed disk write leaves the rates applied; that matches how every other
+	// side effect in this function behaves (a failed write equally leaves MQTT
+	// reconnected and the model reloaded) and is not worth a bespoke unwind for
+	// a sampling rate.
+	//
+	// Not in publishAndSaveSettings, which does run after persistence: nothing
+	// that reaches it can carry a diagnostics change. Its only callers are the
+	// TLS, MQTT-TLS and detections writers. handleSettingsChanges is called by
+	// exactly the two handlers that can (UpdateSettings and
+	// UpdateSectionSettings), which makes it the one seam that covers this
+	// section without needing to be remembered at each write path separately.
+	// Getting that backwards is how the token mint first shipped dead; see
+	// ensureProfilingTokenForSave.
+	if profilingRatesChanged(oldSettings, currentSettings) {
+		profiling.ApplyRates(currentSettings)
+	}
+
 	// Trigger reconfigurations asynchronously.
 	// Capture debug flag from the settings snapshot so the goroutine never
 	// reloads settings (which may be republished by a concurrent update).
@@ -2562,6 +2595,20 @@ func birdWeatherSettingsChanged(oldSettings, currentSettings *conf.Settings) boo
 // pushNotificationSettingsChanged checks if push notification settings have changed.
 func pushNotificationSettingsChanged(oldSettings, currentSettings *conf.Settings) bool {
 	return !reflect.DeepEqual(oldSettings.Notification.Push, currentSettings.Notification.Push)
+}
+
+// profilingRatesChanged reports whether either runtime sampling rate differs
+// between the two snapshots.
+//
+// Only the rates. diagnostics.profiling.enabled and .token need no action at
+// all: the pprof routes are registered unconditionally and their middleware
+// reads the live snapshot per request, so those two are observed on the next
+// request without anything being applied here.
+func profilingRatesChanged(oldSettings, currentSettings *conf.Settings) bool {
+	oldProfiling := &oldSettings.Diagnostics.Profiling
+	newProfiling := &currentSettings.Diagnostics.Profiling
+	return oldProfiling.BlockRate != newProfiling.BlockRate ||
+		oldProfiling.MutexFraction != newProfiling.MutexFraction
 }
 
 // telemetrySettingsChanged checks if telemetry/observability settings have changed

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -318,6 +318,7 @@ func (c *Controller) UpdateSettings(ctx echo.Context) error {
 			// Rollback in-memory; disk write never happened successfully.
 			conf.StoreSettings(current)
 			c.Settings.Store(current)
+			c.restoreProfilingRates(current)
 			c.LogAPIRequest(ctx, logger.LogLevelError, "Failed to save settings to disk, rolling back", logger.Error(err))
 			return c.HandleError(ctx, err, "Failed to save settings, rolled back to previous settings", http.StatusInternalServerError)
 		}
@@ -761,6 +762,7 @@ func (c *Controller) UpdateSectionSettings(ctx echo.Context) error {
 		if err := conf.SaveSettings(); err != nil {
 			conf.StoreSettings(current)
 			c.Settings.Store(current)
+			c.restoreProfilingRates(current)
 			return c.HandleError(ctx, err, "Failed to save settings, rolled back to previous settings", http.StatusInternalServerError)
 		}
 		c.LogAPIRequest(ctx, logger.LogLevelInfo, "Section settings saved successfully",
@@ -2295,33 +2297,29 @@ func (c *Controller) handleSettingsChanges(oldSettings, currentSettings *conf.Se
 	// Apply the runtime block and mutex sampling rates.
 	//
 	// Deliberately NOT a settingsChangeChecks entry routed through controlChan
-	// like the reconfigure_* actions above. Those exist because the thing being
-	// reconfigured lives in the realtime analysis pipeline and must be touched
-	// from its own goroutine; sendReconfigActions therefore queues them with a
-	// delay between each. These two are process-global runtime calls with no
-	// dependencies and no ordering relationship to anything else, so queueing
-	// them behind a model reload would only add latency, and routing them
-	// through a monitor that exists solely in realtime analysis mode would make
-	// them silently do nothing anywhere else.
+	// like the reconfigure_* actions above. The property that separates these
+	// from those is not "process-global" (reconfigure_push_notifications and
+	// reconfigure_log_deduplication are process-global too): it is that both
+	// runtime setters are single atomic stores that cannot fail and cost
+	// microseconds. There is nothing to serialize, nothing that can report an
+	// error, and no success worth a toast, so the queue that sendReconfigActions
+	// maintains, with its delay between sends, buys nothing here.
 	//
-	// Placed here, after the fallible audio reconfiguration, for the same reason
-	// the restart marks are: a change that is about to be rolled back should not
-	// have left the process sampling. It still runs before conf.SaveSettings, so
-	// a failed disk write leaves the rates applied; that matches how every other
-	// side effect in this function behaves (a failed write equally leaves MQTT
-	// reconnected and the model reloaded) and is not worth a bespoke unwind for
-	// a sampling rate.
+	// Placed after the fallible audio reconfiguration for the same reason the
+	// restart marks are: a change that is about to be rolled back should not
+	// have left the process sampling.
 	//
-	// Not in publishAndSaveSettings, which does run after persistence: nothing
-	// that reaches it can carry a diagnostics change. Its only callers are the
-	// TLS, MQTT-TLS and detections writers. handleSettingsChanges is called by
-	// exactly the two handlers that can (UpdateSettings and
-	// UpdateSectionSettings), which makes it the one seam that covers this
-	// section without needing to be remembered at each write path separately.
-	// Getting that backwards is how the token mint first shipped dead; see
-	// ensureProfilingTokenForSave.
+	// Both handlers that can carry a diagnostics change route through
+	// handleSettingsChanges, and neither routes through publishAndSaveSettings,
+	// whose callers are the TLS, MQTT-TLS and detections writers. That is what
+	// makes this the one seam covering this section rather than something to be
+	// remembered at each write path; getting it backwards is how the token mint
+	// first shipped dead, see ensureProfilingTokenForSave. handleSettingsChanges
+	// does have those three writers as callers too, which is harmless: each
+	// clones the current snapshot and touches only its own section, so the gate
+	// below is false on those paths.
 	if profilingRatesChanged(oldSettings, currentSettings) {
-		profiling.ApplyRates(currentSettings)
+		profiling.ApplyRates(&currentSettings.Diagnostics.Profiling)
 	}
 
 	// Trigger reconfigurations asynchronously.
@@ -2597,6 +2595,28 @@ func pushNotificationSettingsChanged(oldSettings, currentSettings *conf.Settings
 	return !reflect.DeepEqual(oldSettings.Notification.Push, currentSettings.Notification.Push)
 }
 
+// restoreProfilingRates puts the runtime sampling rates back to what the
+// restored snapshot says, after a failed save has rolled the settings back.
+//
+// Without this the divergence is permanent, not merely temporary, which is what
+// separates it from the other side effects handleSettingsChanges triggers. The
+// reconfigure_* actions re-read the live snapshot when the control monitor
+// processes them (conf.Setting()), so a rollback makes them converge on the
+// persisted config by themselves. ApplyRates reads the snapshot at call time
+// and is never invoked again on its own, and the change gate then seals it: the
+// rolled-back config and the next save both say 0, the comparison finds no
+// change, and the process keeps sampling forever at a rate nothing records.
+// That is exactly the cost this feature exists to remove, made invisible.
+//
+// Cheap and idempotent, so it runs unconditionally rather than re-deriving
+// whether this particular save touched the rates.
+func (c *Controller) restoreProfilingRates(current *conf.Settings) {
+	if current == nil {
+		return
+	}
+	profiling.ApplyRates(&current.Diagnostics.Profiling)
+}
+
 // profilingRatesChanged reports whether either runtime sampling rate differs
 // between the two snapshots.
 //
@@ -2607,8 +2627,12 @@ func pushNotificationSettingsChanged(oldSettings, currentSettings *conf.Settings
 func profilingRatesChanged(oldSettings, currentSettings *conf.Settings) bool {
 	oldProfiling := &oldSettings.Diagnostics.Profiling
 	newProfiling := &currentSettings.Diagnostics.Profiling
-	return oldProfiling.BlockRate != newProfiling.BlockRate ||
-		oldProfiling.MutexFraction != newProfiling.MutexFraction
+	// Resolved rather than raw, so two values that mean the same thing to the
+	// runtime do not count as a change. Editing -1 to -5 leaves both profilers
+	// off either way, and firing on it would re-log the applied rates for a
+	// save that altered nothing.
+	return oldProfiling.ResolvedBlockRate() != newProfiling.ResolvedBlockRate() ||
+		oldProfiling.ResolvedMutexFraction() != newProfiling.ResolvedMutexFraction()
 }
 
 // telemetrySettingsChanged checks if telemetry/observability settings have changed

--- a/internal/api/v2/settings_profiling_test.go
+++ b/internal/api/v2/settings_profiling_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/labstack/echo/v4"
@@ -139,4 +140,114 @@ func TestEnsureProfilingTokenForSave_KeepsExistingToken(t *testing.T) {
 
 	assert.Equal(t, existing, updated.Diagnostics.Profiling.Token,
 		"an existing token must survive unrelated settings saves")
+}
+
+// The profiling rate tests below must not call t.Parallel(): the block and
+// mutex profile rates are process-global runtime state.
+
+// resetProfileRates restores both runtime sampling rates to off after a test.
+func resetProfileRates(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		runtime.SetBlockProfileRate(0)
+		runtime.SetMutexProfileFraction(0)
+	})
+}
+
+// TestProfilingRatesHotReload verifies the rates take effect through the real
+// settings-change path, in both directions, with no restart.
+//
+// The mutex fraction carries the assertion because it is the only one of the
+// two the runtime will read back (a negative argument to
+// SetMutexProfileFraction reports the current value and leaves it alone). There
+// is no equivalent for the block rate; internal/profiling covers that one by
+// showing samples appear.
+func TestProfilingRatesHotReload(t *testing.T) {
+	resetProfileRates(t)
+
+	c := newProfilingTestController(t)
+
+	off := &conf.Settings{}
+	on := &conf.Settings{}
+	on.Diagnostics.Profiling.BlockRate = conf.DefaultBlockProfileRate
+	on.Diagnostics.Profiling.MutexFraction = conf.DefaultMutexProfileFraction
+
+	require.NoError(t, c.handleSettingsChanges(off, on))
+	assert.Equal(t, conf.DefaultMutexProfileFraction, runtime.SetMutexProfileFraction(-1),
+		"turning the rates on must take effect without a restart")
+
+	require.NoError(t, c.handleSettingsChanges(on, off))
+	assert.Zero(t, runtime.SetMutexProfileFraction(-1),
+		"turning the rates back off must take effect without a restart")
+}
+
+// TestProfilingRatesUnchangedByUnrelatedSave pins the change gate. Applying
+// unconditionally would be harmless to the runtime but would log the applied
+// rates on every settings save, so an operator saving a node name would see
+// profiling chatter.
+func TestProfilingRatesUnchangedByUnrelatedSave(t *testing.T) {
+	resetProfileRates(t)
+
+	c := newProfilingTestController(t)
+
+	const sentinel = 777
+	runtime.SetMutexProfileFraction(sentinel)
+
+	before := &conf.Settings{}
+	after := &conf.Settings{}
+	after.Main.Name = "renamed node"
+
+	require.NoError(t, c.handleSettingsChanges(before, after))
+	assert.Equal(t, sentinel, runtime.SetMutexProfileFraction(-1),
+		"a settings change that does not touch the rates must not reapply them")
+}
+
+// TestProfilingRatesChangedScope pins which fields the detector watches.
+// enabled and token deliberately do not trigger it: the pprof routes are gated
+// by middleware reading the live snapshot per request, so they need nothing
+// applied, and treating them as a rate change would reapply sampling every time
+// somebody toggled the endpoint.
+func TestProfilingRatesChangedScope(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		mutate  func(*conf.Settings)
+		changed bool
+	}{
+		{
+			name:   "no change",
+			mutate: func(*conf.Settings) {},
+		},
+		{
+			name:    "block rate",
+			mutate:  func(s *conf.Settings) { s.Diagnostics.Profiling.BlockRate = conf.DefaultBlockProfileRate },
+			changed: true,
+		},
+		{
+			name:    "mutex fraction",
+			mutate:  func(s *conf.Settings) { s.Diagnostics.Profiling.MutexFraction = conf.DefaultMutexProfileFraction },
+			changed: true,
+		},
+		{
+			name:   "endpoint enabled",
+			mutate: func(s *conf.Settings) { s.Diagnostics.Profiling.Enabled = true },
+		},
+		{
+			name:   "token minted",
+			mutate: func(s *conf.Settings) { s.Diagnostics.Profiling.Token = "generated-secret" },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			old := &conf.Settings{}
+			updated := &conf.Settings{}
+			tt.mutate(updated)
+
+			assert.Equal(t, tt.changed, profilingRatesChanged(old, updated))
+		})
+	}
 }

--- a/internal/api/v2/settings_profiling_test.go
+++ b/internal/api/v2/settings_profiling_test.go
@@ -142,8 +142,11 @@ func TestEnsureProfilingTokenForSave_KeepsExistingToken(t *testing.T) {
 		"an existing token must survive unrelated settings saves")
 }
 
-// The profiling rate tests below must not call t.Parallel(): the block and
-// mutex profile rates are process-global runtime state.
+// The tests below that APPLY a rate must not call t.Parallel(): the block and
+// mutex profile rates are process-global runtime state, shared by every test in
+// this binary rather than just this file. TestProfilingRatesChangedScope is
+// parallel and may stay that way, since it only evaluates the change predicate
+// and never reaches the runtime.
 
 // resetProfileRates restores both runtime sampling rates to off after a test.
 func resetProfileRates(t *testing.T) {

--- a/internal/api/v2/settings_profiling_test.go
+++ b/internal/api/v2/settings_profiling_test.go
@@ -169,11 +169,11 @@ func TestProfilingRatesHotReload(t *testing.T) {
 
 	off := &conf.Settings{}
 	on := &conf.Settings{}
-	on.Diagnostics.Profiling.BlockRate = conf.DefaultBlockProfileRate
-	on.Diagnostics.Profiling.MutexFraction = conf.DefaultMutexProfileFraction
+	on.Diagnostics.Profiling.BlockRate = conf.RecommendedBlockProfileRate
+	on.Diagnostics.Profiling.MutexFraction = conf.RecommendedMutexProfileFraction
 
 	require.NoError(t, c.handleSettingsChanges(off, on))
-	assert.Equal(t, conf.DefaultMutexProfileFraction, runtime.SetMutexProfileFraction(-1),
+	assert.Equal(t, conf.RecommendedMutexProfileFraction, runtime.SetMutexProfileFraction(-1),
 		"turning the rates on must take effect without a restart")
 
 	require.NoError(t, c.handleSettingsChanges(on, off))
@@ -211,7 +211,12 @@ func TestProfilingRatesChangedScope(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name    string
+		name string
+		// base seeds BOTH snapshots, so a case can start from a non-zero rate.
+		// Without it every case starts from zero, and a detector written as
+		// "either new rate is non-zero" would pass the whole table while
+		// reapplying sampling on every save that merely kept it on.
+		base    func(*conf.Settings)
 		mutate  func(*conf.Settings)
 		changed bool
 	}{
@@ -220,13 +225,41 @@ func TestProfilingRatesChangedScope(t *testing.T) {
 			mutate: func(*conf.Settings) {},
 		},
 		{
+			name: "equal non-zero rates are not a change",
+			base: func(s *conf.Settings) {
+				s.Diagnostics.Profiling.BlockRate = conf.RecommendedBlockProfileRate
+				s.Diagnostics.Profiling.MutexFraction = conf.RecommendedMutexProfileFraction
+			},
+			mutate: func(s *conf.Settings) {
+				s.Diagnostics.Profiling.BlockRate = conf.RecommendedBlockProfileRate
+				s.Diagnostics.Profiling.MutexFraction = conf.RecommendedMutexProfileFraction
+			},
+		},
+		{
+			name: "turning a rate off is a change",
+			base: func(s *conf.Settings) {
+				s.Diagnostics.Profiling.BlockRate = conf.RecommendedBlockProfileRate
+			},
+			mutate:  func(s *conf.Settings) { s.Diagnostics.Profiling.BlockRate = 0 },
+			changed: true,
+		},
+		{
+			name: "two negatives both meaning off are not a change",
+			base: func(s *conf.Settings) {
+				s.Diagnostics.Profiling.BlockRate = -1
+			},
+			mutate: func(s *conf.Settings) {
+				s.Diagnostics.Profiling.BlockRate = -5
+			},
+		},
+		{
 			name:    "block rate",
-			mutate:  func(s *conf.Settings) { s.Diagnostics.Profiling.BlockRate = conf.DefaultBlockProfileRate },
+			mutate:  func(s *conf.Settings) { s.Diagnostics.Profiling.BlockRate = conf.RecommendedBlockProfileRate },
 			changed: true,
 		},
 		{
 			name:    "mutex fraction",
-			mutate:  func(s *conf.Settings) { s.Diagnostics.Profiling.MutexFraction = conf.DefaultMutexProfileFraction },
+			mutate:  func(s *conf.Settings) { s.Diagnostics.Profiling.MutexFraction = conf.RecommendedMutexProfileFraction },
 			changed: true,
 		},
 		{
@@ -245,9 +278,54 @@ func TestProfilingRatesChangedScope(t *testing.T) {
 
 			old := &conf.Settings{}
 			updated := &conf.Settings{}
+			if tt.base != nil {
+				tt.base(old)
+				tt.base(updated)
+			}
 			tt.mutate(updated)
 
 			assert.Equal(t, tt.changed, profilingRatesChanged(old, updated))
 		})
 	}
+}
+
+// TestRestoreProfilingRatesUndoesAFailedSave is the closure test for the
+// rollback gap.
+//
+// The failure it pins is not "the rates are briefly wrong". It is that they
+// stay wrong forever: a save that applies a rate and then fails its disk write
+// rolls the snapshot back to the old value, and the change gate then compares
+// the rolled-back config against the next save's config, finds them equal, and
+// never reapplies. The process keeps sampling on the audio path at a rate no
+// config records and no later save can clear, which is precisely the cost this
+// whole change exists to remove, made invisible.
+//
+// The other side effects handleSettingsChanges triggers do not have this shape:
+// the reconfigure_* actions re-read the live snapshot when the control monitor
+// processes them, so a rollback makes them converge on their own.
+func TestRestoreProfilingRatesUndoesAFailedSave(t *testing.T) {
+	resetProfileRates(t)
+
+	c := newProfilingTestController(t)
+
+	current := &conf.Settings{}
+	updated := &conf.Settings{}
+	updated.Diagnostics.Profiling.MutexFraction = conf.RecommendedMutexProfileFraction
+
+	// The save-succeeded path: the requested rate is live.
+	require.NoError(t, c.handleSettingsChanges(current, updated))
+	require.Equal(t, conf.RecommendedMutexProfileFraction, runtime.SetMutexProfileFraction(-1),
+		"setup: the rate must be applied before the rollback is exercised")
+
+	// Now the disk write fails and the handler republishes the old snapshot.
+	c.restoreProfilingRates(current)
+
+	assert.Zero(t, runtime.SetMutexProfileFraction(-1),
+		"a rolled-back save must leave the runtime matching the config that survived, not the one that failed to persist")
+
+	// And the process is not wedged: because the runtime now agrees with the
+	// persisted config, an ordinary later save can still turn sampling on.
+	require.NoError(t, c.handleSettingsChanges(current, updated))
+	assert.Equal(t, conf.RecommendedMutexProfileFraction, runtime.SetMutexProfileFraction(-1),
+		"a later save must still be able to apply the rate")
 }

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1732,28 +1732,31 @@ type BackupConfig struct {
 // The leaf key is deliberately named "token" and not "profilingtoken": support
 // dump scrubbing matches sensitive keys on word boundaries, so a squashed name
 // would not be redacted. See isSensitiveKey in internal/support/collector.go.
-// The two rate fields have different units and opposite senses, which is a
-// documented footgun in the Go API rather than an inconsistency here:
-// SetBlockProfileRate takes nanoseconds of blocked time per sample, so a LARGER
-// number samples LESS, while SetMutexProfileFraction takes a 1-in-N fraction of
-// contention events, so a larger number also samples less but on a different
-// scale entirely. Both are independent of Enabled: collecting samples and
+// The two rate fields have different units on entirely different scales, which
+// is a documented footgun in the Go API rather than an inconsistency here:
+// SetBlockProfileRate takes nanoseconds of blocked time per sample, while
+// SetMutexProfileFraction takes a 1-in-N fraction of contention events. Both
+// sample LESS as the number grows, so the senses agree; only the units and the
+// magnitudes differ. Both are independent of Enabled: collecting samples and
 // serving /debug/pprof are separate decisions, and turning on the endpoint to
 // grab a heap profile must not silently start taxing the audio path.
 //
-// Use ResolvedBlockRate and ResolvedMutexFraction rather than reading the fields
-// directly; they clamp values the runtime would otherwise misread.
+// Use ResolvedBlockRate and ResolvedMutexFraction when handing these to the
+// runtime rather than reading the fields directly; they clamp values the
+// runtime would otherwise misread.
 //
 // The two rate comments below are lifted verbatim into the generated config
 // schema and the wiki's configuration reference, so they spell the recommended
-// numbers out rather than naming the constants that hold them.
-// TestSamplingDefaultsMatchDocumentedValues keeps those copies in step.
+// numbers out rather than naming the constants that hold them. Those two copies
+// cannot drift: TestSchemaUpToDate regenerates and byte-compares them. The
+// copies in config.yaml and doc/PROFILING.md are hand-maintained, and
+// TestRecommendedRatesMatchShippedConfig covers the config.yaml one.
 type ProfilingConfig struct {
 	Enabled bool   `yaml:"enabled" json:"enabled"` // true to serve /debug/pprof/* on the web server
 	Token   string `yaml:"token" json:"token"`     // secret required when no auth provider is configured; generated automatically
 
-	BlockRate     int `yaml:"blockrate" json:"blockRate"`         // nanoseconds of blocked time per sample; 0 disables. Recommended starting point: 10000
-	MutexFraction int `yaml:"mutexfraction" json:"mutexFraction"` // report 1 in N contention events; 0 disables. Recommended starting point: 100
+	BlockRate     int `yaml:"blockrate" json:"blockRate"`         // nanoseconds of blocked time per sample; 0 disables, and values above 10000000 (10ms) are clamped to it. Independent of enabled: sampling costs CPU continuously whether or not a profile is ever fetched, so 0 is the only free setting. Recommended starting point: 10000. Hot-reloadable via the settings API.
+	MutexFraction int `yaml:"mutexfraction" json:"mutexFraction"` // reports one sampled event per this many contention events; 0 disables. Independent of enabled: sampling costs CPU continuously whether or not a profile is ever fetched. Recommended starting point: 100. Hot-reloadable via the settings API.
 }
 
 // DiagnosticsConfig groups the developer-facing diagnostics features. It is a

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1755,7 +1755,7 @@ type ProfilingConfig struct {
 	Enabled bool   `yaml:"enabled" json:"enabled"` // true to serve /debug/pprof/* on the web server
 	Token   string `yaml:"token" json:"token"`     // secret required when no auth provider is configured; generated automatically
 
-	BlockRate     int `yaml:"blockrate" json:"blockRate"`         // nanoseconds of blocked time per sample; 0 disables, and values above 10000000 (10ms) are clamped to it. Independent of enabled: sampling costs CPU continuously whether or not a profile is ever fetched, so 0 is the only free setting. Recommended starting point: 10000. Hot-reloadable via the settings API.
+	BlockRate     int `yaml:"blockrate" json:"blockRate"`         // nanoseconds of blocked time per sample; 0 disables. Independent of enabled: sampling costs CPU continuously whether or not a profile is ever fetched, so 0 is the only free setting and a very coarse rate still pays most of the cost. Recommended starting point: 10000. Hot-reloadable via the settings API.
 	MutexFraction int `yaml:"mutexfraction" json:"mutexFraction"` // reports one sampled event per this many contention events; 0 disables. Independent of enabled: sampling costs CPU continuously whether or not a profile is ever fetched. Recommended starting point: 100. Hot-reloadable via the settings API.
 }
 

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1732,9 +1732,28 @@ type BackupConfig struct {
 // The leaf key is deliberately named "token" and not "profilingtoken": support
 // dump scrubbing matches sensitive keys on word boundaries, so a squashed name
 // would not be redacted. See isSensitiveKey in internal/support/collector.go.
+// The two rate fields have different units and opposite senses, which is a
+// documented footgun in the Go API rather than an inconsistency here:
+// SetBlockProfileRate takes nanoseconds of blocked time per sample, so a LARGER
+// number samples LESS, while SetMutexProfileFraction takes a 1-in-N fraction of
+// contention events, so a larger number also samples less but on a different
+// scale entirely. Both are independent of Enabled: collecting samples and
+// serving /debug/pprof are separate decisions, and turning on the endpoint to
+// grab a heap profile must not silently start taxing the audio path.
+//
+// Use ResolvedBlockRate and ResolvedMutexFraction rather than reading the fields
+// directly; they clamp values the runtime would otherwise misread.
+//
+// The two rate comments below are lifted verbatim into the generated config
+// schema and the wiki's configuration reference, so they spell the recommended
+// numbers out rather than naming the constants that hold them.
+// TestSamplingDefaultsMatchDocumentedValues keeps those copies in step.
 type ProfilingConfig struct {
 	Enabled bool   `yaml:"enabled" json:"enabled"` // true to serve /debug/pprof/* on the web server
 	Token   string `yaml:"token" json:"token"`     // secret required when no auth provider is configured; generated automatically
+
+	BlockRate     int `yaml:"blockrate" json:"blockRate"`         // nanoseconds of blocked time per sample; 0 disables. Recommended starting point: 10000
+	MutexFraction int `yaml:"mutexfraction" json:"mutexFraction"` // report 1 in N contention events; 0 disables. Recommended starting point: 100
 }
 
 // DiagnosticsConfig groups the developer-facing diagnostics features. It is a

--- a/internal/conf/config.yaml
+++ b/internal/conf/config.yaml
@@ -467,6 +467,22 @@ diagnostics:
     # provider is configured, a token is generated here automatically once
     # profiling is enabled, and must then be passed as ?token=... Keep it secret.
     # token: ""
+    #
+    # Runtime sampling rates for the block and mutex profiles. Both are 0 (off)
+    # by default and are independent of the endpoint above: turning on
+    # /debug/pprof does not start sampling, and sampling costs CPU on the audio
+    # path whether or not anyone ever fetches a profile. Both take effect
+    # immediately, with no restart.
+    #
+    # Note the two have different units. blockrate is nanoseconds of blocked
+    # time per sample, so a larger number samples less; 10000 is one sample per
+    # 10 microseconds and is the recommended starting point. mutexfraction
+    # reports 1 in N contention events; 100 is the recommended starting point.
+    # Go's own documentation suggests 1 for both, which records essentially
+    # every event: fine for a benchmark, expensive for a machine doing
+    # real-time audio around the clock.
+    blockrate: 0          # ns of blocked time per sample; 0 disables. Try 10000
+    mutexfraction: 0      # report 1 in N contention events; 0 disables. Try 100
 
 # Notification settings
 notification:

--- a/internal/conf/config.yaml
+++ b/internal/conf/config.yaml
@@ -467,20 +467,13 @@ diagnostics:
     # provider is configured, a token is generated here automatically once
     # profiling is enabled, and must then be passed as ?token=... Keep it secret.
     # token: ""
-    #
-    # Runtime sampling rates for the block and mutex profiles. Both are 0 (off)
-    # by default and are independent of the endpoint above: turning on
-    # /debug/pprof does not start sampling, and sampling costs CPU on the audio
-    # path whether or not anyone ever fetches a profile. Both take effect
-    # immediately, with no restart.
-    #
-    # Note the two have different units. blockrate is nanoseconds of blocked
-    # time per sample, so a larger number samples less; 10000 is one sample per
-    # 10 microseconds and is the recommended starting point. mutexfraction
-    # reports 1 in N contention events; 100 is the recommended starting point.
-    # Go's own documentation suggests 1 for both, which records essentially
-    # every event: fine for a benchmark, expensive for a machine doing
-    # real-time audio around the clock.
+
+    # Runtime sampling rates for the block and mutex profiles, both off by
+    # default and independent of the endpoint above: sampling costs CPU on the
+    # audio path whether or not anyone ever fetches a profile. The two use
+    # different units, and both sample less as the number grows. Edited here
+    # they apply at the next restart; changed through the settings API they
+    # apply immediately. See doc/PROFILING.md.
     blockrate: 0          # ns of blocked time per sample; 0 disables. Try 10000
     mutexfraction: 0      # report 1 in N contention events; 0 disables. Try 100
 

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -111,7 +111,7 @@ func setDefaultConfig() {
 	viper.SetDefault("realtime.processingtime", false)
 
 	// Audio source configuration (multi-source array).
-	// Default is empty — fresh installs get no source, user configures via UI.
+	// Default is empty: fresh installs get no source, user configures via UI.
 	// Legacy configs with realtime.audio.source are migrated by MigrateAudioSourceConfig.
 	// An empty default ensures the migration guard sees len(Sources)==0 and runs correctly.
 	viper.SetDefault("realtime.audio.sources", []map[string]any{})
@@ -451,9 +451,7 @@ func setDefaultConfig() {
 	//
 	// The two sampling rates default to 0, meaning off, and are independent of
 	// the endpoint: serving /debug/pprof must not start charging the audio path
-	// for block and mutex samples. DefaultBlockProfileRate and
-	// DefaultMutexProfileFraction are the values to reach for when turning them
-	// on, not what an unset config resolves to.
+	// for block and mutex samples.
 	viper.SetDefault("diagnostics.profiling.enabled", false)
 	viper.SetDefault("diagnostics.profiling.token", "")
 	viper.SetDefault("diagnostics.profiling.blockrate", 0)

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -448,8 +448,16 @@ func setDefaultConfig() {
 
 	// Diagnostics: pprof profiling endpoints. Off by default; the token is
 	// generated on demand when profiling is enabled without an auth provider.
+	//
+	// The two sampling rates default to 0, meaning off, and are independent of
+	// the endpoint: serving /debug/pprof must not start charging the audio path
+	// for block and mutex samples. DefaultBlockProfileRate and
+	// DefaultMutexProfileFraction are the values to reach for when turning them
+	// on, not what an unset config resolves to.
 	viper.SetDefault("diagnostics.profiling.enabled", false)
 	viper.SetDefault("diagnostics.profiling.token", "")
+	viper.SetDefault("diagnostics.profiling.blockrate", 0)
+	viper.SetDefault("diagnostics.profiling.mutexfraction", 0)
 }
 
 // setModuleLogDefaults sets default values for a module log configuration

--- a/internal/conf/profiling.go
+++ b/internal/conf/profiling.go
@@ -25,28 +25,34 @@ const (
 	// of the profile survives the sampling.
 	RecommendedMutexProfileFraction = 100
 
-	// maxBlockProfileRate bounds ResolvedBlockRate from above, at 10ms.
+	// maxBlockProfileRate bounds ResolvedBlockRate from above, for correctness
+	// only, and is deliberately far coarser than any sane configuration.
 	//
-	// Two reasons, and the second is why the bound is this low rather than
-	// merely finite.
+	// The runtime converts nanoseconds to cycles as
+	// int64(float64(rate) * float64(ticksPerSecond()) / 1e9), and the Go spec
+	// leaves an out-of-range float-to-int conversion implementation-defined.
+	// amd64 (CVTTSD2SI) yields MinInt64, which blocksampled reads as off, so the
+	// profiler silently stops while the log reports the rate as applied. arm64
+	// (FCVTZS) saturates to MaxInt64 instead, so it stays armed and merely never
+	// samples. Different failure, same root cause, and neither is what the
+	// operator asked for; the bound removes the whole class rather than the one
+	// architecture's version of it. Overflow needs roughly 9e17 even on an
+	// implausible 10GHz clock; 1e15 ns is about 11 days per sample, which is
+	// already meaningless, so the clamp cannot reach a rate anyone chose on
+	// purpose.
 	//
-	// First, correctness: the runtime converts nanoseconds to cycles as
-	// int64(float64(rate) * float64(ticksPerSecond()) / 1e9), which on a ~3GHz
-	// TSC overflows int64 above roughly 3e18 and wraps negative, and
-	// blocksampled reads a negative rate as "off". A large enough rate would
-	// therefore disable the profiler while the log reported it as applied.
-	//
-	// Second, and the reason for 10ms specifically: the cost of block profiling
-	// is dominated by the on/off decision rather than by the rate. Any non-zero
-	// rate arms an unconditional cputicks() read at every channel send, channel
+	// It deliberately does NOT enforce a rate worth its cost. Block profiling is
+	// dominated by the on/off decision rather than the rate: any non-zero value
+	// arms an unconditional cputicks() read at every channel send, channel
 	// receive, select and semacquire. Benchmarked on a Raspberry Pi 5, a
 	// blocking channel round-trip costs +55% at rate 1 and still +28% at rate
-	// 100000, against rate 0. So a very coarse rate buys most of the cost and
-	// almost none of the signal. At 10ms the profiler still records every block
-	// long enough to matter on an audio path, which keeps the accepted range one
-	// where the profile is worth what it costs. Zero remains the only free
-	// setting, and the field documentation says so.
-	maxBlockProfileRate = 10_000_000
+	// 100000, against rate 0. So a very coarse rate does buy most of the cost
+	// and little of the signal, and coarseBlockProfileRate exists to say so in
+	// the log. Saying so is the right response, not overriding the number: this
+	// package already declines to clamp a too-aggressive rate on the grounds
+	// that silently overriding what the user typed is worse than the overhead,
+	// and the same reasoning applies at the other end.
+	maxBlockProfileRate = 1_000_000_000_000_000
 )
 
 // ResolvedBlockRate returns the value to hand runtime.SetBlockProfileRate.

--- a/internal/conf/profiling.go
+++ b/internal/conf/profiling.go
@@ -2,40 +2,68 @@ package conf
 
 // Recommended sampling rates for the two runtime profilers.
 //
-// These are the values to reach for when a rate has to be chosen without the
-// user naming one: the documentation quotes them, and a UI toggle would write
-// them. They deliberately are NOT what an unset config resolves to, because an
-// unset rate means "off" and opening a profile endpoint must not start charging
-// the audio path for samples nobody asked for.
+// Named Recommended rather than Default because they are deliberately NOT what
+// an unset config resolves to: an unset rate means off, and every other
+// Default* constant in this package IS the value its key defaults to. These are
+// the numbers to reach for when a rate has to be chosen without the user naming
+// one, which is what the documentation quotes and what a UI toggle would write.
 //
-// The Go documentation's own examples use rate 1 for both, which records every
-// blocking event and every contention event. That is the right choice for a
+// Go documents rate 1 for the block profiler as the way to "include every
+// blocking event", and since the mutex fraction reports one event in N, rate 1
+// there records every contention event too. That is the right choice for a
 // microbenchmark and the wrong one for a long-running appliance doing real-time
 // audio, which is why these constants exist rather than deferring to the
 // runtime's idea of a starting point.
 const (
-	// DefaultBlockProfileRate samples one blocking event per 10 microseconds of
-	// blocked time. Coarse enough to be cheap, fine enough that a contended
-	// lock or a starved channel still shows up.
-	DefaultBlockProfileRate = 10000
+	// RecommendedBlockProfileRate samples one blocking event per 10
+	// microseconds of blocked time. Coarse enough to be cheap, fine enough that
+	// a contended lock or a starved channel still shows up.
+	RecommendedBlockProfileRate = 10000
 
-	// DefaultMutexProfileFraction reports 1 in 100 contention events. A real
-	// contention problem produces far more than 100 events, so the shape of the
-	// profile survives the sampling.
-	DefaultMutexProfileFraction = 100
+	// RecommendedMutexProfileFraction reports one in 100 contention events. A
+	// real contention problem produces far more than 100 events, so the shape
+	// of the profile survives the sampling.
+	RecommendedMutexProfileFraction = 100
+
+	// maxBlockProfileRate bounds ResolvedBlockRate from above, at 10ms.
+	//
+	// Two reasons, and the second is why the bound is this low rather than
+	// merely finite.
+	//
+	// First, correctness: the runtime converts nanoseconds to cycles as
+	// int64(float64(rate) * float64(ticksPerSecond()) / 1e9), which on a ~3GHz
+	// TSC overflows int64 above roughly 3e18 and wraps negative, and
+	// blocksampled reads a negative rate as "off". A large enough rate would
+	// therefore disable the profiler while the log reported it as applied.
+	//
+	// Second, and the reason for 10ms specifically: the cost of block profiling
+	// is dominated by the on/off decision rather than by the rate. Any non-zero
+	// rate arms an unconditional cputicks() read at every channel send, channel
+	// receive, select and semacquire. Benchmarked on a Raspberry Pi 5, a
+	// blocking channel round-trip costs +55% at rate 1 and still +28% at rate
+	// 100000, against rate 0. So a very coarse rate buys most of the cost and
+	// almost none of the signal. At 10ms the profiler still records every block
+	// long enough to matter on an audio path, which keeps the accepted range one
+	// where the profile is worth what it costs. Zero remains the only free
+	// setting, and the field documentation says so.
+	maxBlockProfileRate = 10_000_000
 )
 
 // ResolvedBlockRate returns the value to hand runtime.SetBlockProfileRate.
 //
 // Non-positive resolves to 0, which disables block profiling. The runtime
-// already treats every value <= 0 as off, so the clamp changes no behaviour;
-// it exists so the value that gets logged as "applied" is the value that took
-// effect, rather than whatever the user typed.
+// already treats every value <= 0 as off, so that clamp changes no behaviour;
+// it exists so the value logged as applied is the value that took effect.
+// The upper clamp is load-bearing: see maxBlockProfileRate.
 func (p *ProfilingConfig) ResolvedBlockRate() int {
-	if p == nil || p.BlockRate <= 0 {
+	switch {
+	case p == nil, p.BlockRate <= 0:
 		return 0
+	case p.BlockRate > maxBlockProfileRate:
+		return maxBlockProfileRate
+	default:
+		return p.BlockRate
 	}
-	return p.BlockRate
 }
 
 // ResolvedMutexFraction returns the value to hand
@@ -46,6 +74,10 @@ func (p *ProfilingConfig) ResolvedBlockRate() int {
 // leave it unchanged, so passing a negative config value straight through would
 // silently keep mutex profiling at whatever it already was, which is the
 // opposite of what someone writing a negative number into a config file wants.
+//
+// No upper clamp: the runtime stores the fraction verbatim and samples when
+// cheaprand64()%N == 0, so a huge value degrades honestly toward never sampling
+// rather than wrapping into a different meaning.
 func (p *ProfilingConfig) ResolvedMutexFraction() int {
 	if p == nil || p.MutexFraction <= 0 {
 		return 0

--- a/internal/conf/profiling.go
+++ b/internal/conf/profiling.go
@@ -1,5 +1,7 @@
 package conf
 
+import "math"
+
 // Recommended sampling rates for the two runtime profilers.
 //
 // Named Recommended rather than Default because they are deliberately NOT what
@@ -52,7 +54,12 @@ const (
 	// package already declines to clamp a too-aggressive rate on the grounds
 	// that silently overriding what the user typed is worse than the overhead,
 	// and the same reasoning applies at the other end.
-	maxBlockProfileRate = 1_000_000_000_000_000
+	//
+	// Capped at MaxInt so the package still builds for a 32-bit GOARCH, where
+	// the literal does not fit an int. No behaviour is lost there: a 32-bit int
+	// cannot hold a rate large enough to overflow the conversion in the first
+	// place, so the clamp correctly becomes unreachable rather than absent.
+	maxBlockProfileRate = min(1_000_000_000_000_000, math.MaxInt)
 )
 
 // ResolvedBlockRate returns the value to hand runtime.SetBlockProfileRate.

--- a/internal/conf/profiling.go
+++ b/internal/conf/profiling.go
@@ -1,0 +1,54 @@
+package conf
+
+// Recommended sampling rates for the two runtime profilers.
+//
+// These are the values to reach for when a rate has to be chosen without the
+// user naming one: the documentation quotes them, and a UI toggle would write
+// them. They deliberately are NOT what an unset config resolves to, because an
+// unset rate means "off" and opening a profile endpoint must not start charging
+// the audio path for samples nobody asked for.
+//
+// The Go documentation's own examples use rate 1 for both, which records every
+// blocking event and every contention event. That is the right choice for a
+// microbenchmark and the wrong one for a long-running appliance doing real-time
+// audio, which is why these constants exist rather than deferring to the
+// runtime's idea of a starting point.
+const (
+	// DefaultBlockProfileRate samples one blocking event per 10 microseconds of
+	// blocked time. Coarse enough to be cheap, fine enough that a contended
+	// lock or a starved channel still shows up.
+	DefaultBlockProfileRate = 10000
+
+	// DefaultMutexProfileFraction reports 1 in 100 contention events. A real
+	// contention problem produces far more than 100 events, so the shape of the
+	// profile survives the sampling.
+	DefaultMutexProfileFraction = 100
+)
+
+// ResolvedBlockRate returns the value to hand runtime.SetBlockProfileRate.
+//
+// Non-positive resolves to 0, which disables block profiling. The runtime
+// already treats every value <= 0 as off, so the clamp changes no behaviour;
+// it exists so the value that gets logged as "applied" is the value that took
+// effect, rather than whatever the user typed.
+func (p *ProfilingConfig) ResolvedBlockRate() int {
+	if p == nil || p.BlockRate <= 0 {
+		return 0
+	}
+	return p.BlockRate
+}
+
+// ResolvedMutexFraction returns the value to hand
+// runtime.SetMutexProfileFraction.
+//
+// The clamp is load-bearing here, unlike the block-rate one. A negative
+// argument tells SetMutexProfileFraction to report the current fraction and
+// leave it unchanged, so passing a negative config value straight through would
+// silently keep mutex profiling at whatever it already was, which is the
+// opposite of what someone writing a negative number into a config file wants.
+func (p *ProfilingConfig) ResolvedMutexFraction() int {
+	if p == nil || p.MutexFraction <= 0 {
+		return 0
+	}
+	return p.MutexFraction
+}

--- a/internal/conf/profiling_test.go
+++ b/internal/conf/profiling_test.go
@@ -260,7 +260,7 @@ func TestResolvedRates(t *testing.T) {
 			wantMutexFraction: RecommendedMutexProfileFraction,
 		},
 		{
-			name:              "a block rate past the overflow ceiling is clamped rather than wrapping to off",
+			name:              "a block rate above the ceiling is clamped",
 			blockRate:         maxBlockProfileRate + 1,
 			mutexFraction:     1,
 			wantBlockRate:     maxBlockProfileRate,
@@ -353,15 +353,20 @@ func TestRecommendedRatesMatchShippedConfig(t *testing.T) {
 	template, err := configFiles.ReadFile("config.yaml")
 	require.NoError(t, err)
 
-	// Scoped to the line carrying each key, not a whole-file Contains. "Try
-	// 100" is a prefix of "Try 10000", so a file-wide search for the mutex
-	// value is satisfied by the blockrate line and the guard would pass with
-	// the mutexfraction comment deleted outright.
-	assert.Contains(t, shippedLineFor(t, template, "blockrate:"),
-		"Try "+strconv.Itoa(RecommendedBlockProfileRate),
+	// HasSuffix, scoped to the line carrying each key, rather than a whole-file
+	// Contains. Two distinct prefix hazards make the obvious spelling useless:
+	// across keys, "Try 100" is contained in the blockrate line's "Try 10000",
+	// so the mutex guard passes with its comment deleted outright; and within a
+	// key, "Try 100" is a prefix of "Try 1000", so a drift that lengthens the
+	// number is invisible. Both template lines end with the number, so
+	// anchoring at the end closes both.
+	assert.True(t,
+		strings.HasSuffix(shippedLineFor(t, template, "blockrate:"),
+			"Try "+strconv.Itoa(RecommendedBlockProfileRate)),
 		"config.yaml must recommend the same block rate as RecommendedBlockProfileRate; update doc/PROFILING.md too")
-	assert.Contains(t, shippedLineFor(t, template, "mutexfraction:"),
-		"Try "+strconv.Itoa(RecommendedMutexProfileFraction),
+	assert.True(t,
+		strings.HasSuffix(shippedLineFor(t, template, "mutexfraction:"),
+			"Try "+strconv.Itoa(RecommendedMutexProfileFraction)),
 		"config.yaml must recommend the same mutex fraction as RecommendedMutexProfileFraction; update doc/PROFILING.md too")
 }
 

--- a/internal/conf/profiling_test.go
+++ b/internal/conf/profiling_test.go
@@ -3,6 +3,7 @@ package conf
 import (
 	"math"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -259,7 +260,7 @@ func TestResolvedRates(t *testing.T) {
 			wantMutexFraction: RecommendedMutexProfileFraction,
 		},
 		{
-			name:              "a block rate above the ceiling is clamped, not passed to the runtime's overflowing conversion",
+			name:              "a block rate past the overflow ceiling is clamped rather than wrapping to off",
 			blockRate:         maxBlockProfileRate + 1,
 			mutexFraction:     1,
 			wantBlockRate:     maxBlockProfileRate,
@@ -351,10 +352,31 @@ func TestRecommendedRatesMatchShippedConfig(t *testing.T) {
 
 	template, err := configFiles.ReadFile("config.yaml")
 	require.NoError(t, err)
-	shipped := string(template)
 
-	assert.Contains(t, shipped, "Try "+strconv.Itoa(RecommendedBlockProfileRate),
+	// Scoped to the line carrying each key, not a whole-file Contains. "Try
+	// 100" is a prefix of "Try 10000", so a file-wide search for the mutex
+	// value is satisfied by the blockrate line and the guard would pass with
+	// the mutexfraction comment deleted outright.
+	assert.Contains(t, shippedLineFor(t, template, "blockrate:"),
+		"Try "+strconv.Itoa(RecommendedBlockProfileRate),
 		"config.yaml must recommend the same block rate as RecommendedBlockProfileRate; update doc/PROFILING.md too")
-	assert.Contains(t, shipped, "Try "+strconv.Itoa(RecommendedMutexProfileFraction),
+	assert.Contains(t, shippedLineFor(t, template, "mutexfraction:"),
+		"Try "+strconv.Itoa(RecommendedMutexProfileFraction),
 		"config.yaml must recommend the same mutex fraction as RecommendedMutexProfileFraction; update doc/PROFILING.md too")
+}
+
+// shippedLineFor returns the single line of the embedded template that declares
+// the given key, failing the test if it is absent or ambiguous.
+func shippedLineFor(t *testing.T, template []byte, key string) string {
+	t.Helper()
+
+	var found []string
+	for line := range strings.Lines(string(template)) {
+		if strings.Contains(line, key) {
+			found = append(found, strings.TrimRight(line, "\n"))
+		}
+	}
+
+	require.Len(t, found, 1, "expected exactly one line declaring %q in the shipped config template", key)
+	return found[0]
 }

--- a/internal/conf/profiling_test.go
+++ b/internal/conf/profiling_test.go
@@ -1,6 +1,8 @@
 package conf
 
 import (
+	"math"
+	"strconv"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -214,6 +216,13 @@ func TestConfigTemplateShipsProfilingDisabled(t *testing.T) {
 		"block profiling must ship off; sampling costs CPU whether or not a profile is ever fetched")
 	assert.Zero(t, settings.Diagnostics.Profiling.MutexFraction,
 		"mutex profiling must ship off for the same reason")
+
+	// Zero is also what an absent, misspelled or misnested key produces, so
+	// assert the keys are actually present and land where they are meant to.
+	// Without this the two assertions above pass just as happily against a
+	// template that stopped shipping them at all.
+	assert.Contains(t, string(template), "blockrate:", "the template must ship the blockrate key")
+	assert.Contains(t, string(template), "mutexfraction:", "the template must ship the mutexfraction key")
 }
 
 // TestResolvedRates covers the clamping the two runtime setters need.
@@ -236,18 +245,36 @@ func TestResolvedRates(t *testing.T) {
 			name: "unset resolves to off",
 		},
 		{
-			name:              "explicit values pass through",
-			blockRate:         10000,
-			mutexFraction:     100,
-			wantBlockRate:     10000,
-			wantMutexFraction: 100,
+			name:              "an arbitrary user value passes through",
+			blockRate:         50000,
+			mutexFraction:     250,
+			wantBlockRate:     50000,
+			wantMutexFraction: 250,
 		},
 		{
-			name:              "the recommended defaults pass through unchanged",
-			blockRate:         DefaultBlockProfileRate,
-			mutexFraction:     DefaultMutexProfileFraction,
-			wantBlockRate:     DefaultBlockProfileRate,
-			wantMutexFraction: DefaultMutexProfileFraction,
+			name:              "the recommended rates pass through unchanged",
+			blockRate:         RecommendedBlockProfileRate,
+			mutexFraction:     RecommendedMutexProfileFraction,
+			wantBlockRate:     RecommendedBlockProfileRate,
+			wantMutexFraction: RecommendedMutexProfileFraction,
+		},
+		{
+			name:              "a block rate above the ceiling is clamped, not passed to the runtime's overflowing conversion",
+			blockRate:         maxBlockProfileRate + 1,
+			mutexFraction:     1,
+			wantBlockRate:     maxBlockProfileRate,
+			wantMutexFraction: 1,
+		},
+		{
+			name:              "math.MaxInt block rate is clamped rather than wrapping negative",
+			blockRate:         math.MaxInt,
+			wantBlockRate:     maxBlockProfileRate,
+			wantMutexFraction: 0,
+		},
+		{
+			name:              "the mutex fraction has no ceiling; a huge value degrades to never sampling",
+			mutexFraction:     math.MaxInt,
+			wantMutexFraction: math.MaxInt,
 		},
 		{
 			name:              "rate 1 is honoured rather than overridden",
@@ -260,11 +287,6 @@ func TestResolvedRates(t *testing.T) {
 			name:          "negatives clamp to off",
 			blockRate:     -1,
 			mutexFraction: -1,
-		},
-		{
-			name:          "large negatives clamp to off",
-			blockRate:     -999999,
-			mutexFraction: -999999,
 		},
 	}
 
@@ -283,9 +305,13 @@ func TestResolvedRates(t *testing.T) {
 	}
 }
 
-// TestResolvedRatesNilReceiver pins the nil guard. Both resolvers are called
-// from an apply path that walks in from a settings pointer, so a nil section
-// must read as "off" rather than panicking on a diagnostics setting.
+// TestResolvedRatesNilReceiver pins the nil guard.
+//
+// Not reachable from production today: every caller takes the address of a
+// ProfilingConfig field on a non-nil Settings, so the pointer cannot be nil.
+// These are exported methods on an exported config type, though, so the guard
+// is the contract for any future caller that holds the section on its own, and
+// a panic in a diagnostics accessor would be a poor trade for two comparisons.
 func TestResolvedRatesNilReceiver(t *testing.T) {
 	t.Parallel()
 
@@ -303,25 +329,32 @@ func TestResolvedRatesNilReceiver(t *testing.T) {
 func TestSamplingDefaultsAreNotRateOne(t *testing.T) {
 	t.Parallel()
 
-	assert.Greater(t, DefaultBlockProfileRate, 1,
+	assert.Greater(t, RecommendedBlockProfileRate, 1,
 		"the recommended block rate must sample, not record every blocking event")
-	assert.Greater(t, DefaultMutexProfileFraction, 1,
+	assert.Greater(t, RecommendedMutexProfileFraction, 1,
 		"the recommended mutex fraction must sample, not record every contention event")
 }
 
-// TestSamplingDefaultsMatchDocumentedValues keeps the constants in step with the
-// numbers quoted to users.
+// TestRecommendedRatesMatchShippedConfig keeps the constants in step with the
+// numbers quoted to users in the shipped config template.
 //
-// The struct field comments become the generated config schema and the wiki's
-// configuration reference, and config.yaml repeats them, so those places spell
-// the numbers out rather than naming these constants. That is three copies that
-// can drift apart silently; changing a constant without this test would leave
-// the documentation quietly recommending the old value.
-func TestSamplingDefaultsMatchDocumentedValues(t *testing.T) {
+// It reads config.yaml rather than restating the constants, which is what makes
+// it a drift guard rather than a second copy of the same literal: editing
+// either the constant or the template alone fails it. The other published
+// copies divide as follows. The struct field comments feed config.schema.json
+// and doc/wiki/configuration-reference.md, and cmd/gen-schema's TestSchemaUpToDate
+// regenerates and byte-compares both, so those cannot drift from the comments.
+// doc/PROFILING.md is hand-maintained with no mechanical guard, which is why the
+// failure message names it.
+func TestRecommendedRatesMatchShippedConfig(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, 10000, DefaultBlockProfileRate,
-		"update the blockrate field comment, config.yaml and doc/PROFILING.md together with this constant")
-	assert.Equal(t, 100, DefaultMutexProfileFraction,
-		"update the mutexfraction field comment, config.yaml and doc/PROFILING.md together with this constant")
+	template, err := configFiles.ReadFile("config.yaml")
+	require.NoError(t, err)
+	shipped := string(template)
+
+	assert.Contains(t, shipped, "Try "+strconv.Itoa(RecommendedBlockProfileRate),
+		"config.yaml must recommend the same block rate as RecommendedBlockProfileRate; update doc/PROFILING.md too")
+	assert.Contains(t, shipped, "Try "+strconv.Itoa(RecommendedMutexProfileFraction),
+		"config.yaml must recommend the same mutex fraction as RecommendedMutexProfileFraction; update doc/PROFILING.md too")
 }

--- a/internal/conf/profiling_test.go
+++ b/internal/conf/profiling_test.go
@@ -210,4 +210,118 @@ func TestConfigTemplateShipsProfilingDisabled(t *testing.T) {
 		"profiling must ship disabled")
 	assert.Empty(t, settings.Diagnostics.Profiling.Token,
 		"the shipped template must not carry a profiling token")
+	assert.Zero(t, settings.Diagnostics.Profiling.BlockRate,
+		"block profiling must ship off; sampling costs CPU whether or not a profile is ever fetched")
+	assert.Zero(t, settings.Diagnostics.Profiling.MutexFraction,
+		"mutex profiling must ship off for the same reason")
+}
+
+// TestResolvedRates covers the clamping the two runtime setters need.
+//
+// The mutex case is the one that matters. runtime.SetMutexProfileFraction reads
+// the current fraction and leaves it alone when handed a negative, so passing a
+// negative config value through unclamped would quietly keep mutex profiling at
+// whatever it already was rather than turning it off.
+func TestResolvedRates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		blockRate         int
+		mutexFraction     int
+		wantBlockRate     int
+		wantMutexFraction int
+	}{
+		{
+			name: "unset resolves to off",
+		},
+		{
+			name:              "explicit values pass through",
+			blockRate:         10000,
+			mutexFraction:     100,
+			wantBlockRate:     10000,
+			wantMutexFraction: 100,
+		},
+		{
+			name:              "the recommended defaults pass through unchanged",
+			blockRate:         DefaultBlockProfileRate,
+			mutexFraction:     DefaultMutexProfileFraction,
+			wantBlockRate:     DefaultBlockProfileRate,
+			wantMutexFraction: DefaultMutexProfileFraction,
+		},
+		{
+			name:              "rate 1 is honoured rather than overridden",
+			blockRate:         1,
+			mutexFraction:     1,
+			wantBlockRate:     1,
+			wantMutexFraction: 1,
+		},
+		{
+			name:          "negatives clamp to off",
+			blockRate:     -1,
+			mutexFraction: -1,
+		},
+		{
+			name:          "large negatives clamp to off",
+			blockRate:     -999999,
+			mutexFraction: -999999,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			profiling := &ProfilingConfig{
+				BlockRate:     tt.blockRate,
+				MutexFraction: tt.mutexFraction,
+			}
+
+			assert.Equal(t, tt.wantBlockRate, profiling.ResolvedBlockRate())
+			assert.Equal(t, tt.wantMutexFraction, profiling.ResolvedMutexFraction())
+		})
+	}
+}
+
+// TestResolvedRatesNilReceiver pins the nil guard. Both resolvers are called
+// from an apply path that walks in from a settings pointer, so a nil section
+// must read as "off" rather than panicking on a diagnostics setting.
+func TestResolvedRatesNilReceiver(t *testing.T) {
+	t.Parallel()
+
+	var profiling *ProfilingConfig
+
+	assert.Zero(t, profiling.ResolvedBlockRate())
+	assert.Zero(t, profiling.ResolvedMutexFraction())
+}
+
+// TestSamplingDefaultsAreNotRateOne is the regression guard for the change that
+// introduced these constants. Both rates used to be set to 1 by debug: true,
+// which records essentially every blocking and contention event. Anyone tempted
+// to "simplify" these constants back toward the Go documentation's rate 1 has to
+// delete this test to do it.
+func TestSamplingDefaultsAreNotRateOne(t *testing.T) {
+	t.Parallel()
+
+	assert.Greater(t, DefaultBlockProfileRate, 1,
+		"the recommended block rate must sample, not record every blocking event")
+	assert.Greater(t, DefaultMutexProfileFraction, 1,
+		"the recommended mutex fraction must sample, not record every contention event")
+}
+
+// TestSamplingDefaultsMatchDocumentedValues keeps the constants in step with the
+// numbers quoted to users.
+//
+// The struct field comments become the generated config schema and the wiki's
+// configuration reference, and config.yaml repeats them, so those places spell
+// the numbers out rather than naming these constants. That is three copies that
+// can drift apart silently; changing a constant without this test would leave
+// the documentation quietly recommending the old value.
+func TestSamplingDefaultsMatchDocumentedValues(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, 10000, DefaultBlockProfileRate,
+		"update the blockrate field comment, config.yaml and doc/PROFILING.md together with this constant")
+	assert.Equal(t, 100, DefaultMutexProfileFraction,
+		"update the mutexfraction field comment, config.yaml and doc/PROFILING.md together with this constant")
 }

--- a/internal/profiling/rates.go
+++ b/internal/profiling/rates.go
@@ -1,15 +1,12 @@
 // Package profiling applies the Go runtime's block and mutex sampling rates
 // from configuration.
 //
-// It is deliberately not part of internal/observability. That package is the
-// Prometheus metrics side of the house and logs under the telemetry module,
-// and keeping profiling out of it is the entire point of the diagnostics
-// config section: enabling metrics must not enable profiling, and the two
-// should not share a home that implies they do.
-//
 // The HTTP half of profiling lives in internal/api/pprof.go. This half runs
 // with no HTTP involvement at all: sampling costs CPU whether or not anyone
-// ever fetches a profile, so it is configured, and logged, separately.
+// ever fetches a profile, which is why it is configured separately. The
+// reasoning for keeping the whole feature out of the Prometheus telemetry
+// settings is recorded once, on conf.DiagnosticsConfig, rather than restated
+// here.
 package profiling
 
 import (
@@ -24,8 +21,8 @@ import (
 //
 // Neither is enforced. Someone chasing a deadlock on a development machine has
 // a legitimate reason to record everything, and silently overriding a number
-// the user typed would be worse than the overhead. The warning exists because
-// Go's own documentation offers rate 1 as the way to "include every blocking
+// the user typed would be worse than the overhead. The note exists because Go
+// documents rate 1 for the block profiler as the way to "include every blocking
 // event", with no mention of what that costs a process doing real-time audio,
 // and rate 1 is therefore the value people copy.
 const (
@@ -37,13 +34,33 @@ const (
 	aggressiveMutexFraction = 10
 )
 
+// blockRateIsAggressive reports whether a configured block rate records so
+// large a share of blocking events that it is worth telling the operator.
+//
+// Split out from ApplyRates purely so it is testable: the branch it guards
+// produces only a log line, and inverting the comparison would otherwise be
+// invisible to the whole suite.
+func blockRateIsAggressive(rate int) bool {
+	return rate > 0 && rate < aggressiveBlockRateNanos
+}
+
+// mutexFractionIsAggressive is the mutex-side counterpart to
+// blockRateIsAggressive.
+func mutexFractionIsAggressive(fraction int) bool {
+	return fraction > 0 && fraction < aggressiveMutexFraction
+}
+
 // GetLogger returns the package logger.
+//
+// Fetched from the global logger on each call rather than cached, so it always
+// uses the current centralized logger, which may be installed after package
+// init. Do not hoist this into a package-level var: that captures whatever is
+// installed at init time, which at init is the fallback console logger.
 func GetLogger() logger.Logger {
 	return logger.Global().Module("profiling")
 }
 
-// ApplyRates sets the runtime block and mutex profile sampling rates from
-// settings and returns the values that took effect.
+// ApplyRates sets the runtime block and mutex profile sampling rates.
 //
 // Both rates used to be switched on at their most aggressive possible value by
 // debug: true, which is a flag people turn on for verbose logging while chasing
@@ -52,46 +69,65 @@ func GetLogger() logger.Logger {
 // configuration, off unless set.
 //
 // Safe to call repeatedly and at any point in the process lifetime, which is
-// what makes these settings hot-reloadable. One caveat worth knowing when
-// reading a profile taken shortly after a change: lowering or zeroing a rate
-// does not retroactively discard samples already collected, so such a profile
-// can mix rates.
+// what makes these settings hot-reloadable: both setters are atomic stores, so
+// there is no stop-the-world and no lock, and calling this from a request
+// goroutine on a loaded system is fine. One caveat worth knowing when reading a
+// profile taken shortly after a change: lowering or zeroing a rate does not
+// retroactively discard samples already collected, so such a profile can mix
+// rates.
 //
-// The applied values are returned rather than only logged because the runtime
-// offers no way to read the block profile rate back, so a test has no other
-// way to assert what was applied.
-func ApplyRates(settings *conf.Settings) (blockRate, mutexFraction int) {
-	if settings == nil {
-		return 0, 0
+// A nil config is a no-op rather than a reset: the callers all pass the address
+// of a struct field, so nil means "something is badly wrong upstream", and
+// silently disabling a profiler the operator asked for is not an improvement on
+// leaving it alone.
+func ApplyRates(cfg *conf.ProfilingConfig) {
+	if cfg == nil {
+		return
 	}
 
-	cfg := &settings.Diagnostics.Profiling
-	blockRate = cfg.ResolvedBlockRate()
-	mutexFraction = cfg.ResolvedMutexFraction()
+	blockRate := cfg.ResolvedBlockRate()
+	mutexFraction := cfg.ResolvedMutexFraction()
 
 	runtime.SetBlockProfileRate(blockRate)
 	runtime.SetMutexProfileFraction(mutexFraction)
 
 	log := GetLogger()
 	if blockRate == 0 && mutexFraction == 0 {
+		// Serving /debug/pprof with no sampling configured is a supported
+		// combination, not a mistake: heap, goroutine, CPU and trace all work.
+		// But /debug/pprof/block and /debug/pprof/mutex then answer 200 with an
+		// empty profile, which reads as "nothing is contending" rather than
+		// "nothing was recorded". That false negative is worth one line at a
+		// level the operator will actually see, since they just asked for
+		// profiling.
+		if cfg.Enabled {
+			log.Info("Profiling endpoints are enabled but block and mutex sampling are off; those two profiles will be empty until blockrate or mutexfraction is set",
+				logger.Int("suggested_block_rate_ns", conf.RecommendedBlockProfileRate),
+				logger.Int("suggested_mutex_fraction", conf.RecommendedMutexProfileFraction))
+			return
+		}
 		log.Debug("Runtime block and mutex profiling disabled")
-		return blockRate, mutexFraction
+		return
 	}
 
 	log.Info("Runtime profiling rates applied",
 		logger.Int("block_rate_ns", blockRate),
 		logger.Int("mutex_fraction", mutexFraction))
 
-	if blockRate > 0 && blockRate < aggressiveBlockRateNanos {
-		log.Warn("Block profile rate records a large share of blocking events and costs CPU on the audio path; consider a coarser rate",
+	// Info, not Warn. Every Warn in this process is captured by the health
+	// error-buffer handler installed in main and listed back to the user as a
+	// recent error by the diagnostics API, which counts entries with no level
+	// filter. A rate the operator typed on purpose is not an error, and
+	// reporting it as one would push a deliberate debugging session toward the
+	// degraded-health thresholds.
+	if blockRateIsAggressive(blockRate) {
+		log.Info("Block profile rate records a large share of blocking events and costs CPU on the audio path; consider a coarser rate",
 			logger.Int("block_rate_ns", blockRate),
-			logger.Int("suggested_block_rate_ns", conf.DefaultBlockProfileRate))
+			logger.Int("suggested_block_rate_ns", conf.RecommendedBlockProfileRate))
 	}
-	if mutexFraction > 0 && mutexFraction < aggressiveMutexFraction {
-		log.Warn("Mutex profile fraction records a large share of contention events and costs CPU on the audio path; consider a larger fraction",
+	if mutexFractionIsAggressive(mutexFraction) {
+		log.Info("Mutex profile fraction records a large share of contention events and costs CPU on the audio path; consider a larger fraction",
 			logger.Int("mutex_fraction", mutexFraction),
-			logger.Int("suggested_mutex_fraction", conf.DefaultMutexProfileFraction))
+			logger.Int("suggested_mutex_fraction", conf.RecommendedMutexProfileFraction))
 	}
-
-	return blockRate, mutexFraction
 }

--- a/internal/profiling/rates.go
+++ b/internal/profiling/rates.go
@@ -32,6 +32,16 @@ const (
 
 	// aggressiveMutexFraction reports more than one in ten contention events.
 	aggressiveMutexFraction = 10
+
+	// coarseBlockProfileRate is the other end of the same advice. Above 100ms
+	// per sample the profile records almost nothing, while the process still
+	// pays the unconditional cputicks() read that any non-zero rate arms at
+	// every channel and semaphore operation: measured on a Raspberry Pi 5, a
+	// blocking channel round-trip costs +28% at rate 100000 against rate 0, so
+	// most of the cost survives however coarse the rate goes. Zero is the only
+	// free setting, and someone who set a very large number probably believed
+	// otherwise.
+	coarseBlockProfileRate = 100_000_000
 )
 
 // blockRateIsAggressive reports whether a configured block rate records so
@@ -48,6 +58,12 @@ func blockRateIsAggressive(rate int) bool {
 // blockRateIsAggressive.
 func mutexFractionIsAggressive(fraction int) bool {
 	return fraction > 0 && fraction < aggressiveMutexFraction
+}
+
+// blockRateIsCoarse reports whether a configured block rate is so coarse that
+// the operator is paying for sampling that records almost nothing.
+func blockRateIsCoarse(rate int) bool {
+	return rate > coarseBlockProfileRate
 }
 
 // GetLogger returns the package logger.
@@ -76,10 +92,11 @@ func GetLogger() logger.Logger {
 // retroactively discard samples already collected, so such a profile can mix
 // rates.
 //
-// A nil config is a no-op rather than a reset: the callers all pass the address
-// of a struct field, so nil means "something is badly wrong upstream", and
-// silently disabling a profiler the operator asked for is not an improvement on
-// leaving it alone.
+// A nil config is a no-op rather than a reset, because disabling a profiler the
+// operator asked for is not an improvement on leaving it alone. Note what that
+// guard does NOT buy: every caller passes the address of a struct field, so a
+// nil settings pointer upstream panics on the address-of before this function is
+// entered. It covers a literal ApplyRates(nil) and nothing else.
 func ApplyRates(cfg *conf.ProfilingConfig) {
 	if cfg == nil {
 		return
@@ -100,6 +117,14 @@ func ApplyRates(cfg *conf.ProfilingConfig) {
 		// "nothing was recorded". That false negative is worth one line at a
 		// level the operator will actually see, since they just asked for
 		// profiling.
+		//
+		// In practice this is a startup line. The settings-API path reaches
+		// ApplyRates only when profilingRatesChanged fires, and that compares
+		// the two rates and not Enabled, so switching the endpoint on at runtime
+		// with both rates at 0 does not produce it. That is the right trade:
+		// widening the gate to Enabled would reapply sampling every time
+		// somebody toggled the endpoint, and with no UI for this section the
+		// realistic path is editing config.yaml and restarting anyway.
 		if cfg.Enabled {
 			log.Info("Profiling endpoints are enabled but block and mutex sampling are off; those two profiles will be empty until blockrate or mutexfraction is set",
 				logger.Int("suggested_block_rate_ns", conf.RecommendedBlockProfileRate),
@@ -122,6 +147,11 @@ func ApplyRates(cfg *conf.ProfilingConfig) {
 	// degraded-health thresholds.
 	if blockRateIsAggressive(blockRate) {
 		log.Info("Block profile rate records a large share of blocking events and costs CPU on the audio path; consider a coarser rate",
+			logger.Int("block_rate_ns", blockRate),
+			logger.Int("suggested_block_rate_ns", conf.RecommendedBlockProfileRate))
+	}
+	if blockRateIsCoarse(blockRate) {
+		log.Info("Block profile rate is coarse enough to record almost nothing, but sampling still costs CPU on the audio path; set blockrate to 0 to stop paying for it",
 			logger.Int("block_rate_ns", blockRate),
 			logger.Int("suggested_block_rate_ns", conf.RecommendedBlockProfileRate))
 	}

--- a/internal/profiling/rates.go
+++ b/internal/profiling/rates.go
@@ -1,0 +1,97 @@
+// Package profiling applies the Go runtime's block and mutex sampling rates
+// from configuration.
+//
+// It is deliberately not part of internal/observability. That package is the
+// Prometheus metrics side of the house and logs under the telemetry module,
+// and keeping profiling out of it is the entire point of the diagnostics
+// config section: enabling metrics must not enable profiling, and the two
+// should not share a home that implies they do.
+//
+// The HTTP half of profiling lives in internal/api/pprof.go. This half runs
+// with no HTTP involvement at all: sampling costs CPU whether or not anyone
+// ever fetches a profile, so it is configured, and logged, separately.
+package profiling
+
+import (
+	"runtime"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// Thresholds below which a configured rate records so large a share of events
+// that it is worth a line in the log.
+//
+// Neither is enforced. Someone chasing a deadlock on a development machine has
+// a legitimate reason to record everything, and silently overriding a number
+// the user typed would be worse than the overhead. The warning exists because
+// Go's own documentation offers rate 1 as the way to "include every blocking
+// event", with no mention of what that costs a process doing real-time audio,
+// and rate 1 is therefore the value people copy.
+const (
+	// aggressiveBlockRateNanos samples more often than once per microsecond of
+	// blocked time.
+	aggressiveBlockRateNanos = 1000
+
+	// aggressiveMutexFraction reports more than one in ten contention events.
+	aggressiveMutexFraction = 10
+)
+
+// GetLogger returns the package logger.
+func GetLogger() logger.Logger {
+	return logger.Global().Module("profiling")
+}
+
+// ApplyRates sets the runtime block and mutex profile sampling rates from
+// settings and returns the values that took effect.
+//
+// Both rates used to be switched on at their most aggressive possible value by
+// debug: true, which is a flag people turn on for verbose logging while chasing
+// something unrelated, so the cost was paid by users who had not asked for a
+// profile and had no way to know they were paying it. They are now explicit
+// configuration, off unless set.
+//
+// Safe to call repeatedly and at any point in the process lifetime, which is
+// what makes these settings hot-reloadable. One caveat worth knowing when
+// reading a profile taken shortly after a change: lowering or zeroing a rate
+// does not retroactively discard samples already collected, so such a profile
+// can mix rates.
+//
+// The applied values are returned rather than only logged because the runtime
+// offers no way to read the block profile rate back, so a test has no other
+// way to assert what was applied.
+func ApplyRates(settings *conf.Settings) (blockRate, mutexFraction int) {
+	if settings == nil {
+		return 0, 0
+	}
+
+	cfg := &settings.Diagnostics.Profiling
+	blockRate = cfg.ResolvedBlockRate()
+	mutexFraction = cfg.ResolvedMutexFraction()
+
+	runtime.SetBlockProfileRate(blockRate)
+	runtime.SetMutexProfileFraction(mutexFraction)
+
+	log := GetLogger()
+	if blockRate == 0 && mutexFraction == 0 {
+		log.Debug("Runtime block and mutex profiling disabled")
+		return blockRate, mutexFraction
+	}
+
+	log.Info("Runtime profiling rates applied",
+		logger.Int("block_rate_ns", blockRate),
+		logger.Int("mutex_fraction", mutexFraction))
+
+	if blockRate > 0 && blockRate < aggressiveBlockRateNanos {
+		log.Warn("Block profile rate records a large share of blocking events and costs CPU on the audio path; consider a coarser rate",
+			logger.Int("block_rate_ns", blockRate),
+			logger.Int("suggested_block_rate_ns", conf.DefaultBlockProfileRate))
+	}
+	if mutexFraction > 0 && mutexFraction < aggressiveMutexFraction {
+		log.Warn("Mutex profile fraction records a large share of contention events and costs CPU on the audio path; consider a larger fraction",
+			logger.Int("mutex_fraction", mutexFraction),
+			logger.Int("suggested_mutex_fraction", conf.DefaultMutexProfileFraction))
+	}
+
+	return blockRate, mutexFraction
+}

--- a/internal/profiling/rates_test.go
+++ b/internal/profiling/rates_test.go
@@ -163,9 +163,9 @@ func TestDefaultRatesProduceUsableProfiles(t *testing.T) {
 		// reaches the rate, and 2ms is 200x the 10us rate, so a single call
 		// must produce a sample. Retrying here is what would let a rate orders
 		// of magnitude too coarse pass by accumulating lucky rounds.
-		before := countProfileSamples(t, "block", "blockOnChannel")
+		before := countProfileEvents(t, "block", "blockOnChannel")
 		blockOnChannel()
-		after := countProfileSamples(t, "block", "blockOnChannel")
+		after := countProfileEvents(t, "block", "blockOnChannel")
 
 		assert.Greater(t, after, before,
 			"one 2ms channel block must be sampled at rate %d; a single round failing means the rate is far too coarse or sampling was never applied",
@@ -173,39 +173,49 @@ func TestDefaultRatesProduceUsableProfiles(t *testing.T) {
 	})
 
 	t.Run("mutex profile records real lock contention", func(t *testing.T) {
-		// Statistical, so this asserts a sample COUNT rather than mere
-		// presence. contendMutex produces a few thousand contention events, of
-		// which 1-in-100 is sampled, so tens of samples are expected. Asserting
-		// presence alone would pass at a fraction 10,000x coarser, which is
-		// exactly the mutation this floor exists to kill; a floor this far
-		// below the expectation cannot flake.
-		const wantAtLeast = 5
-
-		before := countProfileSamples(t, "mutex", "contendMutex")
+		// One round, no retries, for the same reason as the block case: a retry
+		// loop lets a rate too coarse to be usable pass by accumulating lucky
+		// rounds, which is exactly how the first version of this test accepted
+		// a fraction 10,000x coarser than the recommended one.
+		//
+		// Genuinely statistical, unlike the block case. contendMutex produces
+		// a few thousand contention events and 1-in-100 is sampled, so the
+		// chance of a round recording nothing is vanishingly small, while a
+		// fraction two orders of magnitude coarser routinely records nothing at
+		// all within one round. That is the discrimination here; see
+		// countProfileEvents for why the magnitude of the number cannot carry a
+		// finer claim than that.
+		before := countProfileEvents(t, "mutex", "contendMutex")
 		contendMutex()
-		after := countProfileSamples(t, "mutex", "contendMutex")
+		after := countProfileEvents(t, "mutex", "contendMutex")
 
-		assert.GreaterOrEqual(t, after-before, wantAtLeast,
-			"expected at least %d sampled contention events at fraction %d, got %d",
-			wantAtLeast, conf.RecommendedMutexProfileFraction, after-before)
+		assert.Greater(t, after, before,
+			"contention must be recorded at fraction %d", conf.RecommendedMutexProfileFraction)
 	})
 }
 
-// countProfileSamples returns how many sampled events in the named runtime
-// profile have wantFrame somewhere in their stack.
+// countProfileEvents returns the event count the named runtime profile
+// attributes to stacks mentioning wantFrame.
 //
-// It counts events rather than testing for the frame's presence for two
-// reasons. Presence cannot fail on a repeat run: block and mutex profiles
-// accumulate for the life of the process and cannot be reset, so under
-// go test -count=2 a frame left by the first run satisfies the second even if
-// sampling was never switched on. And presence is insensitive to the rate,
-// which is the one property these tests exist to check.
+// It returns a count rather than testing for the frame's presence because
+// presence cannot fail on a repeat run: block and mutex profiles accumulate for
+// the life of the process and cannot be reset, so under go test -count=2 a
+// frame left by the first run satisfies the second even if sampling was never
+// switched on. Comparing a count before and against after does fail there.
+//
+// What the number is NOT is the raw number of samples taken. saveBlockEventStack
+// scales both columns by the sampling rate (count += rate, cycles += rate *
+// cycles), so each column estimates the whole event population rather than the
+// sampled subset, and is therefore close to rate-invariant wherever sampling
+// happens at all. So this discriminates "sampling produced records" from
+// "sampling produced none", not one rate from a slightly coarser one.
 //
 // The legacy text format writes one record per unique stack as
-// "<count> <cycles> @ <addrs>" followed by "#\t<addr>\t<function>..." lines, so
-// a record's count is attributed to wantFrame when any of its frame lines
-// mentions it.
-func countProfileSamples(t *testing.T, profileName, wantFrame string) int {
+// "<cycles> <count> @ <addrs>" (runtime/pprof.writeProfileInternal:
+// Fprintf(w, "%v %v @", r.Cycles, r.Count), cycles FIRST) followed by
+// "#\t<addr>\t<function>..." lines, so a record's count is attributed to
+// wantFrame when any of its frame lines mentions it.
+func countProfileEvents(t *testing.T, profileName, wantFrame string) int {
 	t.Helper()
 
 	var (
@@ -229,9 +239,12 @@ func countProfileSamples(t *testing.T, profileName, wantFrame string) int {
 			}
 		case strings.Contains(line, " @ "):
 			flush()
-			// "<count> <cycles> @ ..." -- the record header.
-			if count, err := strconv.Atoi(strings.Fields(line)[0]); err == nil {
-				pendingCount = count
+			// "<cycles> <count> @ ..." -- the record header. Field 1, not 0:
+			// cycles come first.
+			if fields := strings.Fields(line); len(fields) >= 2 {
+				if count, err := strconv.Atoi(fields[1]); err == nil {
+					pendingCount = count
+				}
 			}
 		}
 	}
@@ -271,6 +284,21 @@ func TestAggressiveRateThresholds(t *testing.T) {
 		assert.False(t, blockRateIsAggressive(aggressiveBlockRateNanos))
 		assert.False(t, blockRateIsAggressive(conf.RecommendedBlockProfileRate),
 			"the rate we recommend must never trigger our own warning")
+	})
+
+	t.Run("coarse block rate", func(t *testing.T) {
+		t.Parallel()
+
+		assert.False(t, blockRateIsCoarse(0), "off is not coarse, it is free")
+		assert.False(t, blockRateIsCoarse(conf.RecommendedBlockProfileRate),
+			"the rate we recommend must never trigger the coarse advisory either")
+		assert.False(t, blockRateIsCoarse(coarseBlockProfileRate))
+		assert.True(t, blockRateIsCoarse(coarseBlockProfileRate+1))
+
+		// The two advisories must not both fire for one value, or the operator
+		// gets told to go in both directions at once.
+		assert.False(t, blockRateIsAggressive(coarseBlockProfileRate+1))
+		assert.False(t, blockRateIsCoarse(1))
 	})
 
 	t.Run("mutex fraction", func(t *testing.T) {

--- a/internal/profiling/rates_test.go
+++ b/internal/profiling/rates_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
-// None of the tests in this file may call t.Parallel(). The block and mutex
-// profile rates are process-global runtime state, so two tests setting them
-// concurrently would read each other's values.
+// Any test here that applies a rate must NOT call t.Parallel(). The block and
+// mutex profile rates are process-global runtime state, so two tests setting
+// them concurrently would read each other's values. TestAggressiveRateThresholds
+// is the exception and is parallel: it exercises the threshold predicates as
+// pure functions and never touches the runtime.
 
 // sentinelMutexFraction is a value no code under test can produce, so an
 // assertion that the fraction is something else proves the setter actually ran

--- a/internal/profiling/rates_test.go
+++ b/internal/profiling/rates_test.go
@@ -1,0 +1,267 @@
+package profiling
+
+import (
+	"bytes"
+	"runtime"
+	"runtime/pprof"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// None of the tests in this file may call t.Parallel(). The block and mutex
+// profile rates are process-global runtime state, so two tests setting them
+// concurrently would read each other's values.
+
+// resetRatesAfterTest restores both rates to off once the test finishes, so a
+// test that turns sampling on cannot leave the rest of the package's tests, or
+// the test binary itself, paying for samples nobody reads.
+func resetRatesAfterTest(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		runtime.SetBlockProfileRate(0)
+		runtime.SetMutexProfileFraction(0)
+	})
+}
+
+// settingsWithRates builds a settings snapshot carrying only the two rates.
+func settingsWithRates(blockRate, mutexFraction int) *conf.Settings {
+	settings := &conf.Settings{}
+	settings.Diagnostics.Profiling.BlockRate = blockRate
+	settings.Diagnostics.Profiling.MutexFraction = mutexFraction
+	return settings
+}
+
+// currentMutexFraction reads the live mutex fraction without changing it.
+//
+// A negative argument to SetMutexProfileFraction means "report the current
+// value and leave it alone", which is the only way to read either rate back
+// from the runtime. There is no equivalent for the block rate, which is why
+// ApplyRates returns what it applied.
+func currentMutexFraction() int {
+	return runtime.SetMutexProfileFraction(-1)
+}
+
+func TestApplyRates(t *testing.T) {
+	tests := []struct {
+		name              string
+		blockRate         int
+		mutexFraction     int
+		wantBlockRate     int
+		wantMutexFraction int
+	}{
+		{
+			name: "unset leaves both profilers off",
+		},
+		{
+			name:              "recommended sampling defaults",
+			blockRate:         conf.DefaultBlockProfileRate,
+			mutexFraction:     conf.DefaultMutexProfileFraction,
+			wantBlockRate:     conf.DefaultBlockProfileRate,
+			wantMutexFraction: conf.DefaultMutexProfileFraction,
+		},
+		{
+			name:              "block only",
+			blockRate:         50000,
+			wantBlockRate:     50000,
+			wantMutexFraction: 0,
+		},
+		{
+			name:              "mutex only",
+			mutexFraction:     250,
+			wantMutexFraction: 250,
+		},
+		{
+			name:          "negatives resolve to off rather than leaving the rate unchanged",
+			blockRate:     -1,
+			mutexFraction: -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetRatesAfterTest(t)
+
+			// Start from a known non-zero mutex fraction so a case expecting 0
+			// proves the value was actively cleared rather than never set. This
+			// is what catches an unclamped negative being passed through to the
+			// runtime, where it would read the fraction and leave it at 999.
+			runtime.SetMutexProfileFraction(999)
+
+			blockRate, mutexFraction := ApplyRates(settingsWithRates(tt.blockRate, tt.mutexFraction))
+
+			assert.Equal(t, tt.wantBlockRate, blockRate, "applied block rate")
+			assert.Equal(t, tt.wantMutexFraction, mutexFraction, "applied mutex fraction")
+			assert.Equal(t, tt.wantMutexFraction, currentMutexFraction(),
+				"the runtime's live mutex fraction must match what ApplyRates reported")
+		})
+	}
+}
+
+// TestApplyRatesIgnoresDebug is the regression guard for the change this package
+// exists for. Both rates used to be set to 1 whenever debug: true was set, which
+// is a flag people turn on for verbose logging while chasing something
+// unrelated, so it charged the real-time audio path for recording every blocking
+// and contention event on their behalf. Nothing may reintroduce that coupling.
+func TestApplyRatesIgnoresDebug(t *testing.T) {
+	resetRatesAfterTest(t)
+
+	settings := settingsWithRates(0, 0)
+	settings.Debug = true
+	settings.WebServer.Debug = true
+	settings.Realtime.Telemetry.Enabled = true
+	settings.Diagnostics.Profiling.Enabled = true
+
+	blockRate, mutexFraction := ApplyRates(settings)
+
+	assert.Zero(t, blockRate,
+		"debug: true must not switch on block profiling")
+	assert.Zero(t, mutexFraction,
+		"debug: true must not switch on mutex profiling")
+	assert.Zero(t, currentMutexFraction(),
+		"nothing but the explicit rate settings may move the runtime's mutex fraction")
+}
+
+// TestApplyRatesNilSettings pins the nil guard: a diagnostics setting must not
+// be able to panic the startup path.
+func TestApplyRatesNilSettings(t *testing.T) {
+	resetRatesAfterTest(t)
+
+	blockRate, mutexFraction := ApplyRates(nil)
+
+	assert.Zero(t, blockRate)
+	assert.Zero(t, mutexFraction)
+}
+
+// TestDefaultRatesProduceUsableProfiles is the acceptance test for the sampling
+// defaults: coarser rates are only worth having if a real contention problem
+// still shows up in the profile.
+//
+// It exercises genuine blocking and genuine lock contention rather than
+// asserting the rates were stored, because "the value was applied" and "the
+// profile is usable at that value" are different claims and only the second one
+// matters to someone debugging a stall.
+func TestDefaultRatesProduceUsableProfiles(t *testing.T) {
+	resetRatesAfterTest(t)
+
+	applied, fraction := ApplyRates(settingsWithRates(conf.DefaultBlockProfileRate, conf.DefaultMutexProfileFraction))
+	require.Equal(t, conf.DefaultBlockProfileRate, applied)
+	require.Equal(t, conf.DefaultMutexProfileFraction, fraction)
+
+	t.Run("block profile records a blocked channel receive", func(t *testing.T) {
+		// A 2ms block is 200x the 10µs sampling rate, and the runtime always
+		// records an event at least as long as the rate, so one call suffices.
+		// The loop is insurance against a scheduler that returns early, not a
+		// statistical requirement.
+		requireProfileContains(t, "block", "blockOnChannel", blockOnChannel)
+	})
+
+	t.Run("mutex profile records real lock contention", func(t *testing.T) {
+		// Unlike the block case this genuinely is statistical: at 1-in-100,
+		// each contention event has a 1% chance of being sampled, so the
+		// generator produces thousands of events per round.
+		requireProfileContains(t, "mutex", "contendMutex", contendMutex)
+	})
+}
+
+// profileSampleDeadline bounds the retry loop below. Both generators are
+// expected to succeed on the first round; this only stops a pathological
+// scheduler from hanging the suite.
+const profileSampleDeadline = 30 * time.Second
+
+// requireProfileContains runs generate until the named runtime profile contains
+// a frame mentioning wantFrame, or the deadline expires.
+//
+// Block and mutex profiles are cumulative for the life of the process and
+// cannot be reset, so the assertion is scoped to a frame only this test
+// produces rather than to a sample count.
+func requireProfileContains(t *testing.T, profileName, wantFrame string, generate func()) {
+	t.Helper()
+
+	deadline := time.Now().Add(profileSampleDeadline)
+	for rounds := 1; ; rounds++ {
+		generate()
+
+		if strings.Contains(dumpProfile(t, profileName), wantFrame) {
+			t.Logf("%s profile contained %q after %d round(s)", profileName, wantFrame, rounds)
+			return
+		}
+
+		if time.Now().After(deadline) {
+			t.Fatalf("%s profile contained no %q frame after %d round(s) at the default sampling rate; "+
+				"the default is too coarse to be usable, or sampling was never applied",
+				profileName, wantFrame, rounds)
+		}
+	}
+}
+
+// dumpProfile renders a runtime profile in the legacy text format, which is
+// symbolized and therefore greppable by function name.
+func dumpProfile(t *testing.T, name string) string {
+	t.Helper()
+
+	profile := pprof.Lookup(name)
+	require.NotNil(t, profile, "runtime profile %q must exist", name)
+
+	var buf bytes.Buffer
+	require.NoError(t, profile.WriteTo(&buf, 1))
+	return buf.String()
+}
+
+// blockOnChannel blocks the calling goroutine on a channel receive for long
+// enough to be sampled.
+//
+// It must be a channel receive and not time.Sleep: the block profiler records
+// goroutines parked on synchronization primitives (channel operations, select,
+// sync.Mutex, sync.WaitGroup, sync.Cond), and a sleeping goroutine is parked on
+// a timer, which it does not record at all. The sleep here runs in the OTHER
+// goroutine, purely to guarantee the receive has to wait.
+func blockOnChannel() {
+	const blockFor = 2 * time.Millisecond
+
+	ch := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		time.Sleep(blockFor)
+		close(ch)
+	})
+
+	<-ch
+	wg.Wait()
+}
+
+// contendMutex generates mutex contention events.
+//
+// An uncontended Lock/Unlock pair takes the fast path (a single atomic swap)
+// and records nothing at all: the mutex profile only sees an event when a
+// waiter had to park on the semaphore, and the sample is attributed to the
+// goroutine whose Unlock released it. Yielding inside the critical section is
+// what forces that, and it forces it even at GOMAXPROCS=1, where the waiters
+// would otherwise never get scheduled while the lock was held.
+func contendMutex() {
+	const (
+		contenders = 4
+		iterations = 1000
+	)
+
+	var (
+		mu sync.Mutex
+		wg sync.WaitGroup
+	)
+	for range contenders {
+		wg.Go(func() {
+			for range iterations {
+				mu.Lock()
+				runtime.Gosched()
+				mu.Unlock()
+			}
+		})
+	}
+	wg.Wait()
+}

--- a/internal/profiling/rates_test.go
+++ b/internal/profiling/rates_test.go
@@ -178,13 +178,18 @@ func TestDefaultRatesProduceUsableProfiles(t *testing.T) {
 		// rounds, which is exactly how the first version of this test accepted
 		// a fraction 10,000x coarser than the recommended one.
 		//
-		// Genuinely statistical, unlike the block case. contendMutex produces
-		// a few thousand contention events and 1-in-100 is sampled, so the
-		// chance of a round recording nothing is vanishingly small, while a
-		// fraction two orders of magnitude coarser routinely records nothing at
-		// all within one round. That is the discrimination here; see
+		// Genuinely statistical, unlike the block case. contendMutex produces a
+		// few thousand contention events and 1-in-100 is sampled, so the chance
+		// of a round recording nothing at the shipped fraction is vanishingly
+		// small.
+		//
+		// Its discriminating power is limited and worth stating rather than
+		// overselling: measured, a fraction 100x coarser fails this about half
+		// the time, because a single sample is enough and one is often still
+		// taken. What it does catch every time is sampling not being applied at
+		// all, which is the regression that actually matters. See
 		// countProfileEvents for why the magnitude of the number cannot carry a
-		// finer claim than that.
+		// finer claim.
 		before := countProfileEvents(t, "mutex", "contendMutex")
 		contendMutex()
 		after := countProfileEvents(t, "mutex", "contendMutex")
@@ -203,12 +208,13 @@ func TestDefaultRatesProduceUsableProfiles(t *testing.T) {
 // frame left by the first run satisfies the second even if sampling was never
 // switched on. Comparing a count before and against after does fail there.
 //
-// What the number is NOT is the raw number of samples taken. saveBlockEventStack
-// scales both columns by the sampling rate (count += rate, cycles += rate *
-// cycles), so each column estimates the whole event population rather than the
-// sampled subset, and is therefore close to rate-invariant wherever sampling
-// happens at all. So this discriminates "sampling produced records" from
-// "sampling produced none", not one rate from a slightly coarser one.
+// What the number is NOT is the raw count of samples taken. saveBlockEventStack
+// up-scales by the sampling rate so the recorded value estimates the whole
+// event population rather than the sampled subset: for the mutex profile it
+// adds rate per sample, and for the block profile it adds rate/cycles when the
+// event was shorter than the rate. Either way the result is close to
+// rate-invariant wherever sampling happens at all, so this discriminates
+// "sampling produced records" from "sampling produced none" and nothing finer.
 //
 // The legacy text format writes one record per unique stack as
 // "<cycles> <count> @ <addrs>" (runtime/pprof.writeProfileInternal:

--- a/internal/profiling/rates_test.go
+++ b/internal/profiling/rates_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"runtime"
 	"runtime/pprof"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -19,6 +20,11 @@ import (
 // profile rates are process-global runtime state, so two tests setting them
 // concurrently would read each other's values.
 
+// sentinelMutexFraction is a value no code under test can produce, so an
+// assertion that the fraction is something else proves the setter actually ran
+// rather than that it happened to already hold the expected value.
+const sentinelMutexFraction = 999
+
 // resetRatesAfterTest restores both rates to off once the test finishes, so a
 // test that turns sampling on cannot leave the rest of the package's tests, or
 // the test binary itself, paying for samples nobody reads.
@@ -30,20 +36,20 @@ func resetRatesAfterTest(t *testing.T) {
 	})
 }
 
-// settingsWithRates builds a settings snapshot carrying only the two rates.
-func settingsWithRates(blockRate, mutexFraction int) *conf.Settings {
-	settings := &conf.Settings{}
-	settings.Diagnostics.Profiling.BlockRate = blockRate
-	settings.Diagnostics.Profiling.MutexFraction = mutexFraction
-	return settings
+// profilingConfig builds a config section carrying only the two rates.
+func profilingConfig(blockRate, mutexFraction int) *conf.ProfilingConfig {
+	return &conf.ProfilingConfig{
+		BlockRate:     blockRate,
+		MutexFraction: mutexFraction,
+	}
 }
 
 // currentMutexFraction reads the live mutex fraction without changing it.
 //
 // A negative argument to SetMutexProfileFraction means "report the current
 // value and leave it alone", which is the only way to read either rate back
-// from the runtime. There is no equivalent for the block rate, which is why
-// ApplyRates returns what it applied.
+// from the runtime. There is no equivalent for the block rate, which is why the
+// block-rate assertions in this file go through an actual profile instead.
 func currentMutexFraction() int {
 	return runtime.SetMutexProfileFraction(-1)
 }
@@ -53,24 +59,20 @@ func TestApplyRates(t *testing.T) {
 		name              string
 		blockRate         int
 		mutexFraction     int
-		wantBlockRate     int
 		wantMutexFraction int
 	}{
 		{
 			name: "unset leaves both profilers off",
 		},
 		{
-			name:              "recommended sampling defaults",
-			blockRate:         conf.DefaultBlockProfileRate,
-			mutexFraction:     conf.DefaultMutexProfileFraction,
-			wantBlockRate:     conf.DefaultBlockProfileRate,
-			wantMutexFraction: conf.DefaultMutexProfileFraction,
+			name:              "recommended sampling rates",
+			blockRate:         conf.RecommendedBlockProfileRate,
+			mutexFraction:     conf.RecommendedMutexProfileFraction,
+			wantMutexFraction: conf.RecommendedMutexProfileFraction,
 		},
 		{
-			name:              "block only",
-			blockRate:         50000,
-			wantBlockRate:     50000,
-			wantMutexFraction: 0,
+			name:      "block only",
+			blockRate: 50000,
 		},
 		{
 			name:              "mutex only",
@@ -88,18 +90,17 @@ func TestApplyRates(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			resetRatesAfterTest(t)
 
-			// Start from a known non-zero mutex fraction so a case expecting 0
-			// proves the value was actively cleared rather than never set. This
-			// is what catches an unclamped negative being passed through to the
-			// runtime, where it would read the fraction and leave it at 999.
-			runtime.SetMutexProfileFraction(999)
+			// Start from a value nothing under test produces, so a case
+			// expecting 0 proves the fraction was actively cleared rather than
+			// never set. Without this the zero-expecting cases pass with the
+			// SetMutexProfileFraction call deleted, and an unclamped negative
+			// would read the fraction and leave it at the sentinel.
+			runtime.SetMutexProfileFraction(sentinelMutexFraction)
 
-			blockRate, mutexFraction := ApplyRates(settingsWithRates(tt.blockRate, tt.mutexFraction))
+			ApplyRates(profilingConfig(tt.blockRate, tt.mutexFraction))
 
-			assert.Equal(t, tt.wantBlockRate, blockRate, "applied block rate")
-			assert.Equal(t, tt.wantMutexFraction, mutexFraction, "applied mutex fraction")
 			assert.Equal(t, tt.wantMutexFraction, currentMutexFraction(),
-				"the runtime's live mutex fraction must match what ApplyRates reported")
+				"the runtime's live mutex fraction after ApplyRates")
 		})
 	}
 }
@@ -112,93 +113,131 @@ func TestApplyRates(t *testing.T) {
 func TestApplyRatesIgnoresDebug(t *testing.T) {
 	resetRatesAfterTest(t)
 
-	settings := settingsWithRates(0, 0)
+	settings := &conf.Settings{}
 	settings.Debug = true
 	settings.WebServer.Debug = true
 	settings.Realtime.Telemetry.Enabled = true
 	settings.Diagnostics.Profiling.Enabled = true
 
-	blockRate, mutexFraction := ApplyRates(settings)
+	// Same sentinel discipline as TestApplyRates: without it this asserts 0
+	// against a fraction that was already 0, and passes with the setter gone.
+	runtime.SetMutexProfileFraction(sentinelMutexFraction)
 
-	assert.Zero(t, blockRate,
-		"debug: true must not switch on block profiling")
-	assert.Zero(t, mutexFraction,
-		"debug: true must not switch on mutex profiling")
+	ApplyRates(&settings.Diagnostics.Profiling)
+
 	assert.Zero(t, currentMutexFraction(),
-		"nothing but the explicit rate settings may move the runtime's mutex fraction")
+		"debug: true must not switch on mutex profiling, and nothing but the rate settings may move the fraction")
 }
 
-// TestApplyRatesNilSettings pins the nil guard: a diagnostics setting must not
-// be able to panic the startup path.
-func TestApplyRatesNilSettings(t *testing.T) {
+// TestApplyRatesNilConfig pins that a nil section is a no-op rather than a
+// reset: it must not silently disable a profiler the operator asked for.
+func TestApplyRatesNilConfig(t *testing.T) {
 	resetRatesAfterTest(t)
 
-	blockRate, mutexFraction := ApplyRates(nil)
+	runtime.SetMutexProfileFraction(sentinelMutexFraction)
+	ApplyRates(nil)
 
-	assert.Zero(t, blockRate)
-	assert.Zero(t, mutexFraction)
+	assert.Equal(t, sentinelMutexFraction, currentMutexFraction(),
+		"a nil config must leave the runtime alone")
 }
 
 // TestDefaultRatesProduceUsableProfiles is the acceptance test for the sampling
-// defaults: coarser rates are only worth having if a real contention problem
-// still shows up in the profile.
+// rates: coarser rates are only worth having if a real contention problem still
+// shows up in the profile.
 //
 // It exercises genuine blocking and genuine lock contention rather than
 // asserting the rates were stored, because "the value was applied" and "the
 // profile is usable at that value" are different claims and only the second one
-// matters to someone debugging a stall.
+// matters to someone debugging a stall. It is also the only coverage that
+// SetBlockProfileRate is called at all, since the runtime exposes no getter for
+// it.
 func TestDefaultRatesProduceUsableProfiles(t *testing.T) {
 	resetRatesAfterTest(t)
 
-	applied, fraction := ApplyRates(settingsWithRates(conf.DefaultBlockProfileRate, conf.DefaultMutexProfileFraction))
-	require.Equal(t, conf.DefaultBlockProfileRate, applied)
-	require.Equal(t, conf.DefaultMutexProfileFraction, fraction)
+	ApplyRates(profilingConfig(conf.RecommendedBlockProfileRate, conf.RecommendedMutexProfileFraction))
+	require.Equal(t, conf.RecommendedMutexProfileFraction, currentMutexFraction())
 
 	t.Run("block profile records a blocked channel receive", func(t *testing.T) {
-		// A 2ms block is 200x the 10µs sampling rate, and the runtime always
-		// records an event at least as long as the rate, so one call suffices.
-		// The loop is insurance against a scheduler that returns early, not a
-		// statistical requirement.
-		requireProfileContains(t, "block", "blockOnChannel", blockOnChannel)
+		// Deterministic, so it gets exactly one round and no retries.
+		// blocksampled records an event unconditionally once its blocked time
+		// reaches the rate, and 2ms is 200x the 10us rate, so a single call
+		// must produce a sample. Retrying here is what would let a rate orders
+		// of magnitude too coarse pass by accumulating lucky rounds.
+		before := countProfileSamples(t, "block", "blockOnChannel")
+		blockOnChannel()
+		after := countProfileSamples(t, "block", "blockOnChannel")
+
+		assert.Greater(t, after, before,
+			"one 2ms channel block must be sampled at rate %d; a single round failing means the rate is far too coarse or sampling was never applied",
+			conf.RecommendedBlockProfileRate)
 	})
 
 	t.Run("mutex profile records real lock contention", func(t *testing.T) {
-		// Unlike the block case this genuinely is statistical: at 1-in-100,
-		// each contention event has a 1% chance of being sampled, so the
-		// generator produces thousands of events per round.
-		requireProfileContains(t, "mutex", "contendMutex", contendMutex)
+		// Statistical, so this asserts a sample COUNT rather than mere
+		// presence. contendMutex produces a few thousand contention events, of
+		// which 1-in-100 is sampled, so tens of samples are expected. Asserting
+		// presence alone would pass at a fraction 10,000x coarser, which is
+		// exactly the mutation this floor exists to kill; a floor this far
+		// below the expectation cannot flake.
+		const wantAtLeast = 5
+
+		before := countProfileSamples(t, "mutex", "contendMutex")
+		contendMutex()
+		after := countProfileSamples(t, "mutex", "contendMutex")
+
+		assert.GreaterOrEqual(t, after-before, wantAtLeast,
+			"expected at least %d sampled contention events at fraction %d, got %d",
+			wantAtLeast, conf.RecommendedMutexProfileFraction, after-before)
 	})
 }
 
-// profileSampleDeadline bounds the retry loop below. Both generators are
-// expected to succeed on the first round; this only stops a pathological
-// scheduler from hanging the suite.
-const profileSampleDeadline = 30 * time.Second
-
-// requireProfileContains runs generate until the named runtime profile contains
-// a frame mentioning wantFrame, or the deadline expires.
+// countProfileSamples returns how many sampled events in the named runtime
+// profile have wantFrame somewhere in their stack.
 //
-// Block and mutex profiles are cumulative for the life of the process and
-// cannot be reset, so the assertion is scoped to a frame only this test
-// produces rather than to a sample count.
-func requireProfileContains(t *testing.T, profileName, wantFrame string, generate func()) {
+// It counts events rather than testing for the frame's presence for two
+// reasons. Presence cannot fail on a repeat run: block and mutex profiles
+// accumulate for the life of the process and cannot be reset, so under
+// go test -count=2 a frame left by the first run satisfies the second even if
+// sampling was never switched on. And presence is insensitive to the rate,
+// which is the one property these tests exist to check.
+//
+// The legacy text format writes one record per unique stack as
+// "<count> <cycles> @ <addrs>" followed by "#\t<addr>\t<function>..." lines, so
+// a record's count is attributed to wantFrame when any of its frame lines
+// mentions it.
+func countProfileSamples(t *testing.T, profileName, wantFrame string) int {
 	t.Helper()
 
-	deadline := time.Now().Add(profileSampleDeadline)
-	for rounds := 1; ; rounds++ {
-		generate()
-
-		if strings.Contains(dumpProfile(t, profileName), wantFrame) {
-			t.Logf("%s profile contained %q after %d round(s)", profileName, wantFrame, rounds)
-			return
+	var (
+		total        int
+		pendingCount int
+		matched      bool
+	)
+	flush := func() {
+		if matched {
+			total += pendingCount
 		}
+		pendingCount, matched = 0, false
+	}
 
-		if time.Now().After(deadline) {
-			t.Fatalf("%s profile contained no %q frame after %d round(s) at the default sampling rate; "+
-				"the default is too coarse to be usable, or sampling was never applied",
-				profileName, wantFrame, rounds)
+	for line := range strings.Lines(dumpProfile(t, profileName)) {
+		line = strings.TrimRight(line, "\n")
+		switch {
+		case strings.HasPrefix(line, "#"):
+			if strings.Contains(line, wantFrame) {
+				matched = true
+			}
+		case strings.Contains(line, " @ "):
+			flush()
+			// "<count> <cycles> @ ..." -- the record header.
+			if count, err := strconv.Atoi(strings.Fields(line)[0]); err == nil {
+				pendingCount = count
+			}
 		}
 	}
+	flush()
+
+	return total
 }
 
 // dumpProfile renders a runtime profile in the legacy text format, which is
@@ -212,6 +251,38 @@ func dumpProfile(t *testing.T, name string) string {
 	var buf bytes.Buffer
 	require.NoError(t, profile.WriteTo(&buf, 1))
 	return buf.String()
+}
+
+// TestAggressiveRateThresholds covers the two branches that produce the
+// advisory log lines.
+//
+// Without this, inverting either comparison is invisible: the branches only
+// log, so the whole suite stays green with the guidance firing on exactly the
+// rates it was written to bless.
+func TestAggressiveRateThresholds(t *testing.T) {
+	t.Parallel()
+
+	t.Run("block rate", func(t *testing.T) {
+		t.Parallel()
+
+		assert.False(t, blockRateIsAggressive(0), "off is not aggressive")
+		assert.True(t, blockRateIsAggressive(1), "rate 1 records every blocking event")
+		assert.True(t, blockRateIsAggressive(aggressiveBlockRateNanos-1))
+		assert.False(t, blockRateIsAggressive(aggressiveBlockRateNanos))
+		assert.False(t, blockRateIsAggressive(conf.RecommendedBlockProfileRate),
+			"the rate we recommend must never trigger our own warning")
+	})
+
+	t.Run("mutex fraction", func(t *testing.T) {
+		t.Parallel()
+
+		assert.False(t, mutexFractionIsAggressive(0), "off is not aggressive")
+		assert.True(t, mutexFractionIsAggressive(1), "fraction 1 records every contention event")
+		assert.True(t, mutexFractionIsAggressive(aggressiveMutexFraction-1))
+		assert.False(t, mutexFractionIsAggressive(aggressiveMutexFraction))
+		assert.False(t, mutexFractionIsAggressive(conf.RecommendedMutexProfileFraction),
+			"the fraction we recommend must never trigger our own warning")
+	})
 }
 
 // blockOnChannel blocks the calling goroutine on a channel receive for long

--- a/internal/security/oauth.go
+++ b/internal/security/oauth.go
@@ -965,14 +965,16 @@ func (s *OAuth2Server) IsAuthenticationEnabled(ip string) bool {
 		return false // Authentication not required for allowed subnets
 	}
 
-	// Check if basic auth is enabled
+	// Both values are read for the log line only. The decision itself goes
+	// through conf.IsAuthProviderConfigured so that this middleware and the
+	// pprof gate cannot disagree about what "authentication is configured"
+	// means: the gate falls back to its generated token when the predicate is
+	// false, and no token is minted when it is true, so a third authentication
+	// mechanism learned by only one copy would lock a legitimate admin out.
 	basicEnabled := settings.Security.BasicAuth.Enabled
-
-	// Check if any OAuth provider is enabled using the new array
 	enabledOAuthProviders := settings.GetEnabledOAuthProviders()
-	oauthEnabled := len(enabledOAuthProviders) > 0
 
-	if basicEnabled || oauthEnabled {
+	if settings.IsAuthProviderConfigured() {
 		authLog.Info("Authentication required: at least one provider enabled and IP not in allowed subnet",
 			logger.Bool("basic_enabled", basicEnabled),
 			logger.Any("oauth_providers", enabledOAuthProviders),

--- a/internal/security/oauth.go
+++ b/internal/security/oauth.go
@@ -966,7 +966,7 @@ func (s *OAuth2Server) IsAuthenticationEnabled(ip string) bool {
 	}
 
 	// Both values are read for the log line only. The decision itself goes
-	// through conf.IsAuthProviderConfigured so that this middleware and the
+	// through conf.Settings.IsAuthProviderConfigured so that this middleware and the
 	// pprof gate cannot disagree about what "authentication is configured"
 	// means: the gate falls back to its generated token when the predicate is
 	// false, and no token is minted when it is true, so a third authentication

--- a/main.go
+++ b/main.go
@@ -171,6 +171,16 @@ func mainWithExitCode() int {
 	// Create main module logger
 	mainLog := centralLogger.Module("main")
 
+	// Apply the configured block and mutex sampling rates. The rationale lives
+	// on profiling.ApplyRates; changes made through the settings API are applied
+	// by profilingRatesChanged in internal/api/v2/settings.go.
+	//
+	// As early as the logger allows, and deliberately ahead of telemetry init:
+	// that path blocks for up to five seconds waiting for readiness, which is
+	// itself a plausible thing to reach for block profiling to explain. The old
+	// debug-gated version sat after it and could not see it.
+	profiling.ApplyRates(&settings.Diagnostics.Profiling)
+
 	// Load or create system ID for telemetry
 	systemID, err := telemetry.LoadOrCreateSystemID(filepath.Dir(viper.ConfigFileUsed()))
 	if err != nil {
@@ -201,17 +211,6 @@ func mainWithExitCode() int {
 			logger.Error(err))
 		// Continue - not critical for operation
 	}
-
-	// Apply the configured block and mutex sampling rates.
-	//
-	// These used to be switched on at rate 1, the most aggressive value the
-	// runtime accepts, whenever debug: true was set. That is a flag people turn
-	// on to get verbose logging while chasing something unrelated, so it charged
-	// the real-time audio path for recording every blocking and contention event
-	// on behalf of users who had not asked for a profile. They are now explicit
-	// settings under diagnostics.profiling, off unless set, and independent of
-	// the pprof endpoint. They hot-reload; see reconfigure_profiling.
-	profiling.ApplyRates(settings)
 
 	// Process configuration validation warnings that occurred before Sentry initialization.
 	//

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"runtime"
 	"runtime/pprof"
 	"strings"
 	"time"
@@ -22,6 +21,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/notification"
+	"github.com/tphakala/birdnet-go/internal/profiling"
 	"github.com/tphakala/birdnet-go/internal/restart"
 	"github.com/tphakala/birdnet-go/internal/telemetry"
 )
@@ -202,16 +202,16 @@ func mainWithExitCode() int {
 		// Continue - not critical for operation
 	}
 
-	// Enable runtime profiling if debug mode is enabled
-	if settings.Debug {
-		// Enable mutex profiling for detecting lock contention
-		runtime.SetMutexProfileFraction(1)
-
-		// Enable block profiling for detecting blocking operations
-		runtime.SetBlockProfileRate(1)
-
-		mainLog.Debug("Runtime profiling enabled (mutex and block profiling active)")
-	}
+	// Apply the configured block and mutex sampling rates.
+	//
+	// These used to be switched on at rate 1, the most aggressive value the
+	// runtime accepts, whenever debug: true was set. That is a flag people turn
+	// on to get verbose logging while chasing something unrelated, so it charged
+	// the real-time audio path for recording every blocking and contention event
+	// on behalf of users who had not asked for a profile. They are now explicit
+	// settings under diagnostics.profiling, off unless set, and independent of
+	// the pprof endpoint. They hot-reload; see reconfigure_profiling.
+	profiling.ApplyRates(settings)
 
 	// Process configuration validation warnings that occurred before Sentry initialization.
 	//


### PR DESCRIPTION
## What this changes

`main.go` used to do this:

```go
if settings.Debug {
    runtime.SetMutexProfileFraction(1)
    runtime.SetBlockProfileRate(1)
}
```

`debug: true` is a flag people turn on to get verbose logging while chasing something unrelated. Rate 1 is the most aggressive value the Go runtime accepts: `SetBlockProfileRate(1)` records essentially every blocking event and `SetMutexProfileFraction(1)` records every contention event. So enabling verbose logging quietly charged the real-time audio path for sampling nobody asked for, and nothing documented that it did. Benchmarked on a Raspberry Pi 5, a blocking channel round-trip costs **+55% at rate 1** against no sampling at all.

Both rates are now explicit settings, off unless set:

```yaml
diagnostics:
  profiling:
    blockrate: 0          # ns of blocked time per sample; 0 disables. Try 10000
    mutexfraction: 0      # report 1 in N contention events; 0 disables. Try 100
```

They are independent of `diagnostics.profiling.enabled` as well as of `debug`. Serving `/debug/pprof` to grab a heap profile no longer starts block and mutex sampling either, because sampling costs CPU whether or not a profile is ever fetched. Changed through the settings API they apply immediately; changed in `config.yaml` they apply at the next restart, because the config file is not watched.

## Notes for review

**Why two plain integers rather than a boolean plus a rate.** A flat int is both the switch and the magnitude, so there is no way to express the contradictory state a `{enabled, rate}` pair allows (`enabled: false` sitting next to a configured `10000`). The cost is that the config file has no valueless "on", so the recommended numbers reach the user through the shipped `config.yaml` comment, the generated schema and wiki, and `doc/PROFILING.md`. `TestRecommendedRatesMatchShippedConfig` keeps the template copy in step with the constants, scoped to the line declaring each key.

**Why 10000 and 100 rather than the rate 1 Go documents.** Measured: rate 1 costs +55% per blocking operation on a Pi 5, rate 10000 costs +32%, and rate 100000 still costs +28%. 10000 sits at the knee, and going coarser buys almost nothing because any non-zero rate arms an unconditional `cputicks()` read at every channel and semaphore operation. `TestDefaultRatesProduceUsableProfiles` drives real channel blocking and real lock contention and asserts both profiles still record at those rates, because a cheaper default is only worth having if a contention problem still shows up in it.

**Clamping.** Negatives resolve to 0. That matters for `SetMutexProfileFraction`, where a negative argument reports the current fraction and leaves it unchanged, so passing one through would silently keep mutex profiling at whatever it already was. There is also an upper bound, for correctness only: the runtime's nanoseconds-to-cycles conversion overflows int64 at the top of the range, and Go leaves the out-of-range conversion implementation-defined (amd64 yields MinInt64, which reads as off; arm64 saturates to MaxInt64 and never samples). The bound sits far above any real configuration. A rate that is merely unwise, in either direction, gets a log line rather than an override.

**Where the hot-reload hook lives.** `handleSettingsChanges`, not a `controlChan` action. Both runtime setters are single atomic stores that cannot fail and cost microseconds, so there is nothing to serialize and no error to report; the queue `sendReconfigActions` maintains buys nothing. `publishAndSaveSettings` looks like the tidier seam but is the wrong one: its callers are the TLS, MQTT-TLS and detections writers, none of which can carry a diagnostics change.

**A failed save restores the rates.** This is the one thing worth a close look. Applying before `conf.SaveSettings` and not unwinding would leave the process sampling at a rate no config records, and the change gate would then seal it: the rolled-back config and the next save both read 0, the comparison finds no change, and it is never reapplied or cleared. Both save-failure branches now call `restoreProfilingRates`. This does not apply to the other side effects in that function, which re-read the live snapshot when the control monitor processes them and therefore converge on their own.

**Also folded in**, rather than filed as another backlog item: `IsAuthProviderConfigured` had four separate spellings and only one of them was the shared predicate. That matters here specifically, because the pprof gate picks its security branch on it while the auth middleware enforces another copy, so a third authentication mechanism learned by only one copy would make the gate demand a token that was never minted.

**Documentation.** `doc/PROFILING.md`'s enabling, troubleshooting and best-practices sections are corrected here because this change falsifies them. The rest of that document is still stale from the endpoint move in #4031 and its full rewrite is tracked separately; this PR does not attempt it.

## Verification

- `go build ./...` clean; `go test -race ./internal/... ./cmd/...` exit 0, including `-count=3` on the profiling package.
- `golangci-lint run`: 256 issues on this branch, 256 on clean `main`, none in changed files.
- `task generate-schema` re-run and the regenerated `config.schema.json` / `doc/wiki/configuration-reference.md` committed; the `cmd/gen-schema` drift test passes.
- `TestSettingsHotReloadCoverage` passes; the new leaves are covered by the existing `Diagnostics` parent entry, whose comment now documents both reload mechanisms.
- Frontend `npm run check:all`: format, lint, lint:css, typecheck (0 errors) and `ast:all` all pass.
- The sampling tests were mutation-checked rather than assumed: rates 10000x coarser, and a mutex fraction 100x coarser, both fail the acceptance test.

## Release notes
- audience: user
- summary: Turning on debug logging no longer switches on the most aggressive block and mutex profiling the Go runtime allows, which measured at +55% per blocking operation on a Raspberry Pi 5; both are now separate opt-in settings that take effect without a restart
- feature: none
- breaking: `debug: true` no longer enables block and mutex profiling. Anyone relying on that will get empty `/debug/pprof/block` and `/debug/pprof/mutex` profiles until they set `diagnostics.profiling.blockrate` and `diagnostics.profiling.mutexfraction`
- config: new `diagnostics.profiling.blockrate` (default 0, off; recommended 10000) and `diagnostics.profiling.mutexfraction` (default 0, off; recommended 100)
- schema: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `blockrate` and `mutexfraction` controls for Go profiling sampling.
  * Profiling sampling settings can be applied instantly via the settings API (no restart).
  * Added runtime safeguards to manage sampling overhead.
* **Documentation**
  * Updated profiling guides and configuration reference with new sampling options, performance notes, and endpoint access/token behavior.
  * Clarified that debug mode no longer determines profiling sampling.
* **Bug Fixes**
  * Improved authentication detection consistency for profiling/security access.
  * Ensured profiling rate changes apply only when relevant and are rolled back on failed updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->