### PR TITLE
docs(profiling): rewrite PROFILING.md against verified behaviour

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2525,10 +2525,10 @@ go run -race . serve
 # are on the web server port, behind its authentication; where no auth provider
 # is configured, pass the token generated into diagnostics.profiling.token.
 # Profile CPU
-go tool pprof "http://localhost:8080/debug/pprof/profile?token=$BIRDNET_TOKEN"
+go tool pprof "http://localhost:8080/debug/pprof/profile?token=$BIRDNET_PROFILING_TOKEN"
 
 # Profile memory
-go tool pprof "http://localhost:8080/debug/pprof/heap?token=$BIRDNET_TOKEN"
+go tool pprof "http://localhost:8080/debug/pprof/heap?token=$BIRDNET_PROFILING_TOKEN"
 ```
 
 See [doc/PROFILING.md](doc/PROFILING.md) for the full profiling workflow.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2516,17 +2516,22 @@ See [.husky/pre-commit](.husky/pre-commit) for complete implementation.
 
 ```bash
 # Run with debug logging
-LOG_LEVEL=debug birdnet-go realtime
+birdnet-go serve --debug
 
-# Run with profiling
-go run -race ./cmd/birdnet/
+# Run from source with the race detector
+go run -race . serve
 
+# Profiling requires diagnostics.profiling.enabled in config.yaml. The endpoints
+# are on the web server port, behind its authentication; where no auth provider
+# is configured, pass the token generated into diagnostics.profiling.token.
 # Profile CPU
-go tool pprof http://localhost:8080/debug/pprof/profile
+go tool pprof "http://localhost:8080/debug/pprof/profile?token=$BIRDNET_TOKEN"
 
 # Profile memory
-go tool pprof http://localhost:8080/debug/pprof/heap
+go tool pprof "http://localhost:8080/debug/pprof/heap?token=$BIRDNET_TOKEN"
 ```
+
+See [doc/PROFILING.md](doc/PROFILING.md) for the full profiling workflow.
 
 ### Documentation
 

--- a/doc/DEBUG-COLLECTION.md
+++ b/doc/DEBUG-COLLECTION.md
@@ -4,10 +4,20 @@ This guide explains how to collect and analyze debug data from BirdNET-Go for pe
 
 ## Prerequisites
 
-1. BirdNET-Go running with `debug: true` in config.yaml
-2. `go` tool installed for profile analysis (optional - scripts will offer automatic installation)
-3. `curl` command available
-4. Python 3.x (for advanced analysis, optional)
+1. BirdNET-Go running with `diagnostics.profiling.enabled: true` in config.yaml.
+   Note this is not `debug: true`, which only controls logging verbosity.
+2. On an instance with no authentication provider configured, the profiling token
+   from `diagnostics.profiling.token`, exported as `BIRDNET_PROFILING_TOKEN`. The
+   collection scripts pass it on every request. See
+   [PROFILING.md](PROFILING.md#getting-the-token-on-an-instance-with-no-authentication)
+   for how to read it, since the API deliberately will not return it.
+3. `go` tool installed for profile analysis (optional - scripts will offer automatic installation)
+4. `curl` command available
+5. Python 3.x (for advanced analysis, optional)
+
+The collection scripts support unauthenticated and token-gated instances. They
+cannot log in to an instance behind basic auth or OAuth; collect those profiles
+manually as described in [PROFILING.md](PROFILING.md).
 
 ## Installing Go (Optional)
 
@@ -74,7 +84,7 @@ BIRDNET_CONTAINER=my-birdnet-container ./scripts/collect-debug-data-docker.sh
 This will:
 
 - Check for Go installation (and offer automatic installation if missing)
-- Verify debug mode is enabled
+- Verify the profiling endpoints are reachable
 - Collect all profiling data
 - Create a timestamped archive
 - Generate an analysis script
@@ -145,13 +155,23 @@ PROFILE_DURATION=60 ./scripts/collect-debug-data.sh
 
 While BirdNET-Go is running:
 
+These assume `BIRDNET_PROFILING_TOKEN` is exported; drop the `?token=...` on an
+instance that has an authentication provider configured.
+
+Pass the URL to `go tool pprof` directly. It does not read a profile from stdin,
+so piping `curl` into it does not work:
+
 ```bash
 # Watch memory usage in real-time
-watch -n 5 'curl -s http://localhost:8080/debug/pprof/heap | go tool pprof -top -unit=mb'
+watch -n 30 "go tool pprof -top -unit=mb -nodecount=15 'http://localhost:8080/debug/pprof/heap?token=$BIRDNET_PROFILING_TOKEN'"
 
 # Monitor goroutine count
-watch -n 10 'curl -s http://localhost:8080/debug/pprof/goroutine?debug=1 | grep "goroutine profile:" | head -1'
+watch -n 10 "curl -s 'http://localhost:8080/debug/pprof/goroutine?token=$BIRDNET_PROFILING_TOKEN&debug=1' | head -1"
 ```
+
+Note that `go tool pprof` saves a copy of every profile it fetches under
+`~/pprof/`, so a tight `watch` interval fills that directory quickly. Use a
+generous interval and clean up afterwards.
 
 ### Interactive Analysis
 
@@ -258,7 +278,11 @@ Set up a cron job for periodic collection:
 - Debug data may contain sensitive information
 - Only share data with trusted parties
 - Consider sanitizing system information before sharing
-- Disable debug mode in production after troubleshooting
+- Set `diagnostics.profiling.enabled` back to `false` after troubleshooting, and
+  reset `blockrate` and `mutexfraction` to `0` if you changed them, since those
+  two cost CPU continuously
+- Treat the profiling token as a credential. Rotate it, by deleting the `token:`
+  line under `diagnostics.profiling` and restarting, if you shared a config file
 
 ## Troubleshooting Collection
 
@@ -266,25 +290,36 @@ Set up a cron job for periodic collection:
 
 If collection fails:
 
-1. Verify debug mode: Check `debug: true` in config.yaml
+1. Verify profiling is enabled: check `diagnostics.profiling.enabled: true` in
+   config.yaml, and that BirdNET-Go was restarted after the edit. `debug: true`
+   does not enable profiling. A `404` from `/debug/pprof/` means it is off.
 2. Check connectivity: `curl http://localhost:8080/`
-3. Verify authentication: If using auth, the script may need credentials
-4. Check permissions: Ensure write access to current directory
+3. Verify the token: a `403` on an instance with no authentication provider means
+   `BIRDNET_PROFILING_TOKEN` is unset or stale. Re-read it from config.yaml.
+4. Verify authentication: the scripts cannot log in to an instance behind basic
+   auth or OAuth. Collect those profiles manually.
+5. Check the port: a `410` means you are on the telemetry listener (default 8090).
+   Profiling moved to the web server port (default 8080).
+6. Check permissions: ensure write access to current directory
 
 ### For Docker Installation
 
 If collection fails:
 
 1. Verify container is running: `docker ps | grep birdnet`
-2. Check debug mode in container:
+2. Check profiling is enabled in the container:
    ```bash
-   docker exec <container-name> grep "debug:" /path/to/config.yaml
+   docker exec <container-name> grep -A2 "^diagnostics:" /config/config.yaml
    ```
-3. Verify port mapping: `docker port <container-name>`
-4. Check container logs: `docker logs <container-name>`
-5. Ensure debug mode is enabled and container was restarted:
+3. Read the profiling token, if the instance has no authentication provider:
    ```bash
-   # Edit config.yaml to set debug: true
+   docker exec <container-name> awk '/^diagnostics:/{f=1} f && /^[[:space:]]*token:/{print $2; exit}' /config/config.yaml
+   ```
+4. Verify port mapping: `docker port <container-name>`
+5. Check container logs: `docker logs <container-name>`
+6. Ensure profiling is enabled and the container was restarted:
+   ```bash
+   # Edit config.yaml to set diagnostics.profiling.enabled: true
    docker restart <container-name>
    ```
 

--- a/doc/DEBUG-COLLECTION.md
+++ b/doc/DEBUG-COLLECTION.md
@@ -158,12 +158,12 @@ While BirdNET-Go is running:
 These assume `BIRDNET_PROFILING_TOKEN` is exported; drop the `?token=...` on an
 instance that has an authentication provider configured.
 
-Pass the URL to `go tool pprof` directly. It does not read a profile from stdin,
-so piping `curl` into it does not work:
-
-Note the single quotes. They keep the token out of the long-lived `watch`
-process's command line, where `ps` would show it to every user on the box; the
-shell `watch` spawns expands it from the exported environment on each iteration.
+Two things about the form below. Pass the URL to `go tool pprof` directly, because
+it does not read a profile from stdin, so piping `curl` into it does not work. And
+note the single quotes: they keep the token out of the long-lived `watch`
+process's own command line, since the shell `watch` spawns expands it from the
+exported environment on each iteration. The short-lived child still carries it in
+its argv, so this narrows the `ps` exposure rather than removing it.
 
 ```bash
 # Watch memory usage in real-time
@@ -316,11 +316,11 @@ If collection fails:
 1. Verify container is running: `docker ps | grep birdnet`
 2. Check profiling is enabled in the container:
    ```bash
-   docker exec <container-name> grep -A5 "^diagnostics:" /config/config.yaml
+   docker exec <container-name> awk '/^diagnostics:/{f=1;next} /^[^[:space:]#]/{f=0} f&&/^[[:space:]]*enabled:/{print;exit}' /config/config.yaml
    ```
 3. Read the profiling token, if the instance has no authentication provider:
    ```bash
-   docker exec <container-name> awk '/^diagnostics:/{f=1;next} /^[^[:space:]#]/{f=0} f&&/^[[:space:]]*token:/{sub(/^[[:space:]]*token:[[:space:]]*/,"");gsub(/^"|"$/,"");print;exit}' /config/config.yaml
+   docker exec <container-name> awk '/^diagnostics:/{f=1;next} /^[^[:space:]#]/{f=0} f&&/^[[:space:]]*token:/{sub(/\r$/,"");sub(/^[[:space:]]*token:[[:space:]]*/,"");sub(/[[:space:]]+#.*/,"");gsub(/"/,"");print;exit}' /config/config.yaml
    ```
 4. Verify port mapping: `docker port <container-name>`
 5. Check container logs: `docker logs <container-name>`

--- a/doc/DEBUG-COLLECTION.md
+++ b/doc/DEBUG-COLLECTION.md
@@ -161,12 +161,16 @@ instance that has an authentication provider configured.
 Pass the URL to `go tool pprof` directly. It does not read a profile from stdin,
 so piping `curl` into it does not work:
 
+Note the single quotes. They keep the token out of the long-lived `watch`
+process's command line, where `ps` would show it to every user on the box; the
+shell `watch` spawns expands it from the exported environment on each iteration.
+
 ```bash
 # Watch memory usage in real-time
-watch -n 30 "go tool pprof -top -unit=mb -nodecount=15 'http://localhost:8080/debug/pprof/heap?token=$BIRDNET_PROFILING_TOKEN'"
+watch -n 30 'go tool pprof -top -unit=mb -nodecount=15 "http://localhost:8080/debug/pprof/heap?token=$BIRDNET_PROFILING_TOKEN"'
 
 # Monitor goroutine count
-watch -n 10 "curl -s 'http://localhost:8080/debug/pprof/goroutine?token=$BIRDNET_PROFILING_TOKEN&debug=1' | head -1"
+watch -n 10 'curl -s "http://localhost:8080/debug/pprof/goroutine?token=$BIRDNET_PROFILING_TOKEN&debug=1" | head -1'
 ```
 
 Note that `go tool pprof` saves a copy of every profile it fetches under
@@ -296,10 +300,13 @@ If collection fails:
 2. Check connectivity: `curl http://localhost:8080/`
 3. Verify the token: a `403` on an instance with no authentication provider means
    `BIRDNET_PROFILING_TOKEN` is unset or stale. Re-read it from config.yaml.
-4. Verify authentication: the scripts cannot log in to an instance behind basic
-   auth or OAuth. Collect those profiles manually.
+4. Verify authentication: a `401`, or a `302` to `/login`, means an authentication
+   provider is configured. The scripts cannot log in, and neither can
+   `go tool pprof`. Collect those profiles with the login-then-fetch recipe in
+   [PROFILING.md](PROFILING.md#on-an-instance-that-does-have-authentication-configured).
 5. Check the port: a `410` means you are on the telemetry listener (default 8090).
-   Profiling moved to the web server port (default 8080).
+   Profiling moved to the web server port (default 8080). A refused connection on
+   8090 means the same thing on an instance where telemetry is switched off.
 6. Check permissions: ensure write access to current directory
 
 ### For Docker Installation
@@ -309,11 +316,11 @@ If collection fails:
 1. Verify container is running: `docker ps | grep birdnet`
 2. Check profiling is enabled in the container:
    ```bash
-   docker exec <container-name> grep -A2 "^diagnostics:" /config/config.yaml
+   docker exec <container-name> grep -A5 "^diagnostics:" /config/config.yaml
    ```
 3. Read the profiling token, if the instance has no authentication provider:
    ```bash
-   docker exec <container-name> awk '/^diagnostics:/{f=1} f && /^[[:space:]]*token:/{print $2; exit}' /config/config.yaml
+   docker exec <container-name> awk '/^diagnostics:/{f=1;next} /^[^[:space:]#]/{f=0} f&&/^[[:space:]]*token:/{sub(/^[[:space:]]*token:[[:space:]]*/,"");gsub(/^"|"$/,"");print;exit}' /config/config.yaml
    ```
 4. Verify port mapping: `docker port <container-name>`
 5. Check container logs: `docker logs <container-name>`

--- a/doc/DEBUG-COLLECTION.md
+++ b/doc/DEBUG-COLLECTION.md
@@ -320,7 +320,7 @@ If collection fails:
    ```
 3. Read the profiling token, if the instance has no authentication provider:
    ```bash
-   docker exec <container-name> awk '/^diagnostics:/{f=1;next} /^[^[:space:]#]/{f=0} f&&/^[[:space:]]*token:/{sub(/\r$/,"");sub(/^[[:space:]]*token:[[:space:]]*/,"");sub(/[[:space:]]+#.*/,"");gsub(/"/,"");print;exit}' /config/config.yaml
+   docker exec <container-name> awk '/^diagnostics:/{f=1;next} /^[^[:space:]#]/{f=0} f&&/^[[:space:]]*token:/{sub(/^[[:space:]]*token:[[:space:]]*/,"");sub(/[[:space:]]+#.*/,"");gsub(/[[:space:]]|"|\r/,"");print;exit}' /config/config.yaml
    ```
 4. Verify port mapping: `docker port <container-name>`
 5. Check container logs: `docker logs <container-name>`

--- a/doc/PROFILING.md
+++ b/doc/PROFILING.md
@@ -95,14 +95,14 @@ search that just runs forward from `diagnostics:` will happily print a
 notification provider's secret instead:
 
 ```bash
-awk '/^diagnostics:/{f=1;next} /^[^[:space:]#]/{f=0} f&&/^[[:space:]]*token:/{sub(/^[[:space:]]*token:[[:space:]]*/,"");gsub(/^"|"$/,"");print;exit}' config.yaml
+awk '/^diagnostics:/{f=1;next} /^[^[:space:]#]/{f=0} f&&/^[[:space:]]*token:/{sub(/\r$/,"");sub(/^[[:space:]]*token:[[:space:]]*/,"");sub(/[[:space:]]+#.*/,"");gsub(/"/,"");print;exit}' config.yaml
 ```
 
 For a container installation the config lives inside the config volume, so read
 it through the container:
 
 ```bash
-docker exec birdnet-go awk '/^diagnostics:/{f=1;next} /^[^[:space:]#]/{f=0} f&&/^[[:space:]]*token:/{sub(/^[[:space:]]*token:[[:space:]]*/,"");gsub(/^"|"$/,"");print;exit}' /config/config.yaml
+docker exec birdnet-go awk '/^diagnostics:/{f=1;next} /^[^[:space:]#]/{f=0} f&&/^[[:space:]]*token:/{sub(/\r$/,"");sub(/^[[:space:]]*token:[[:space:]]*/,"");sub(/[[:space:]]+#.*/,"");gsub(/"/,"");print;exit}' /config/config.yaml
 ```
 
 The host-side copy of that file is under the directory bind-mounted at `/config`
@@ -120,7 +120,7 @@ Every example below assumes the token is in a shell variable. This is the same
 name the collection scripts in `scripts/` read, so exporting it once serves both:
 
 ```bash
-export BIRDNET_PROFILING_TOKEN="$(awk '/^diagnostics:/{f=1;next} /^[^[:space:]#]/{f=0} f&&/^[[:space:]]*token:/{sub(/^[[:space:]]*token:[[:space:]]*/,"");gsub(/^"|"$/,"");print;exit}' config.yaml)"
+export BIRDNET_PROFILING_TOKEN="$(awk '/^diagnostics:/{f=1;next} /^[^[:space:]#]/{f=0} f&&/^[[:space:]]*token:/{sub(/\r$/,"");sub(/^[[:space:]]*token:[[:space:]]*/,"");sub(/[[:space:]]+#.*/,"");gsub(/"/,"");print;exit}' config.yaml)"
 ```
 
 `go tool pprof` has no flag for custom headers, but it does preserve query
@@ -133,9 +133,11 @@ go tool pprof "http://localhost:8080/debug/pprof/heap?token=$BIRDNET_PROFILING_T
 
 ### On an instance that does have authentication configured
 
-No token is generated and none is accepted: the web server's own auth middleware
-is the gate, and it runs instead of the token check. Passing `?token=...` there
-gets you a `401`, not access.
+No token is generated and none is consulted: the web server's own auth middleware
+runs instead of the token check, so adding `?token=...` changes nothing. Without a
+valid session you get a `401` whether or not you send one. (The exception is
+`security.allowsubnetbypass`, which lets a client on the configured subnet
+through with no credential at all; see the security note below.)
 
 **`go tool pprof` cannot authenticate against such an instance.** It has no flag
 for headers and no cookie jar, and BirdNET-Go's `security.basicauth` is a form
@@ -148,22 +150,40 @@ Log in with `curl`, keep the session cookie, fetch the profile to a file, and
 analyse the file locally:
 
 ```bash
-curl -s -c jar.txt http://localhost:8080/ -o /dev/null
-CSRF=$(awk '$6=="csrf"{print $7}' jar.txt)
-REDIRECT=$(curl -s -b jar.txt -c jar.txt -X POST http://localhost:8080/api/v2/auth/login \
-  -H 'Content-Type: application/json' -H "X-CSRF-Token: $CSRF" \
-  -d '{"username":"admin","password":"YOUR_PASSWORD"}' |
-  python3 -c 'import json,sys; print(json.load(sys.stdin)["redirectUrl"])')
-curl -s -b jar.txt -c jar.txt -L -o /dev/null "http://localhost:8080$REDIRECT"
+JAR=$(mktemp)
+read -rs -p 'password: ' PASS; echo
 
-curl -s -b jar.txt -o heap.pprof "http://localhost:8080/debug/pprof/heap"
+curl -s -c "$JAR" http://localhost:8080/ -o /dev/null
+
+REDIRECT=$(printf '{"username":"admin","password":"%s"}' "$PASS" |
+  curl -s -b "$JAR" -c "$JAR" -X POST http://localhost:8080/api/v2/auth/login \
+    -H 'Content-Type: application/json' --data @- |
+  sed -e 's/.*"redirectUrl":"\([^"]*\)".*/\1/' -e 's/\\u0026/\&/g')
+curl -s -b "$JAR" -c "$JAR" -L -o /dev/null "http://localhost:8080$REDIRECT"
+
+curl -s -b "$JAR" -o heap.pprof "http://localhost:8080/debug/pprof/heap"
 go tool pprof heap.pprof
+
+rm -f "$JAR"
 ```
 
-The login response carries an OAuth2 callback URL that has to be followed before
-the session cookie is valid, which is what the third command does. Everything
-after that is the ordinary two-step fetch-then-analyse workflow, and it applies to
-every endpoint in the table below.
+Three steps in there are not obvious and all three are load-bearing. The opening
+`curl` exists only to prime the cookie jar; without it the callback fails and the
+session is never established. The login response carries an OAuth2 callback URL
+that has to be followed before the session cookie is valid, which is the second
+`curl`. And the second `sed` expression is required because Go's JSON encoder
+escapes ampersands, so the raw `redirectUrl` string carries the six characters
+`\u0026` where the URL needs a literal `&`; without that substitution the callback
+receives a mangled query string and returns `401`.
+
+The login endpoint is exempt from CSRF, so no token is needed for it. The cookie
+jar holds a live session, which is why it goes in `mktemp` and is deleted at the
+end, and the password is read into a variable and piped rather than passed as an
+argument, so it stays out of `ps` and out of shell history. If `$REDIRECT` comes
+back empty the login failed.
+
+Everything after that is the ordinary two-step fetch-then-analyse workflow, and it
+applies to every endpoint in the table below.
 
 ## Available profiling endpoints
 
@@ -189,17 +209,19 @@ Requesting `/debug/pprof` without the trailing slash redirects to
 The response codes are worth knowing, because they distinguish the ways this goes
 wrong, and which one you get depends on whether authentication is configured:
 
-| Code  | Meaning                                                                         |
-| ----- | ------------------------------------------------------------------------------- |
-| `200` | Success                                                                         |
-| `302` | Auth configured, and you look like a browser. Redirected to the login page      |
-| `401` | Auth configured, and you sent no valid session or `Bearer` token                |
-| `403` | No auth provider configured, and the `token=` parameter is missing or wrong     |
-| `404` | Profiling is disabled. The feature does not announce that it exists but is shut |
-| `410` | You are on the old telemetry-listener location. Use the web server port         |
+| Code  | Meaning                                                                                                                                                         |
+| ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `200` | Success                                                                                                                                                         |
+| `302` | The trailing-slash redirect above, or auth is configured and your client looks like a browser, so it was sent to the login page. The `Location` tells you which |
+| `401` | Auth configured, and you sent no valid session or `Bearer` token                                                                                                |
+| `403` | The `token=` parameter is missing or wrong                                                                                                                      |
+| `404` | Profiling is disabled, or your build predates the feature                                                                                                       |
+| `410` | You are on the old telemetry-listener location. Use the web server port                                                                                         |
 
-`403` and `401` are mutually exclusive: the token is only consulted when no
-authentication provider is configured, so an instance never returns both. The
+An instance normally returns `401` or `403` but not both, because the token is
+consulted only when no authentication provider is configured. One case returns
+`403` with auth configured: if the auth middleware was never wired up it fails
+closed, rather than falling through to a token that was never minted. The
 `enabled` check runs before either, which is why a correct token still gets `404`
 when profiling is off.
 
@@ -221,11 +243,12 @@ Useful commands in pprof interactive mode:
 - `top` - show the largest consumers
 - `web` - open an interactive graph in a browser (requires graphviz)
 - `list <function>` - show the annotated source. This one needs the matching
-  source available at the path recorded in the profile. Against a release binary
-  that path is module-relative (`-trimpath`), so a plain checkout is not enough
-  and it reports `could not find file ... on path`; point pprof at your checkout
-  with `-trim_path=github.com/tphakala/birdnet-go` or `-source_path=<dir>`.
-  `top` and `web` need nothing but the profile.
+  source available. Against a release binary the recorded path is
+  module-relative (`-trimpath`), which pprof resolves against the current
+  directory, so running it from the root of a matching checkout works with no
+  extra flags. From anywhere else it reports `could not find file ... on path`;
+  pass `-source_path=<checkout>` in that case. `top` and `web` need nothing but
+  the profile.
 
 ### 2. CPU profiling
 
@@ -447,9 +470,9 @@ stripping.
 `-trimpath`, also used by the release build, is harmless for profiling. It
 rewrites source paths to module-relative form
 (`github.com/tphakala/birdnet-go/internal/...` rather than a path on the build
-machine). The only thing it costs is that `list <function>` cannot find the
-source unless you have a matching checkout; `top`, `web` and every aggregate view
-are unaffected.
+machine). The only thing it costs is that `list <function>` needs a matching
+checkout to resolve against, as described above; `top`, `web` and every aggregate
+view are unaffected.
 
 Building with `-gcflags=all=-N -l` to get better symbols would be actively
 counterproductive: disabling optimization and inlining changes the performance of
@@ -565,8 +588,9 @@ If the profiling endpoints are not behaving:
     process was hard-killed before the profile was flushed. See the environment
     variable section above.
 12. **`could not find file ... on path` from `list`** - expected against a release
-    binary, which records module-relative paths. Pass
-    `-trim_path=github.com/tphakala/birdnet-go` or `-source_path=<dir>`.
+    binary, which records module-relative paths that pprof resolves against the
+    current directory. Run it from the root of a matching checkout, or pass
+    `-source_path=<checkout>`.
 
 For more information about pprof, see the
 [official Go documentation](https://pkg.go.dev/net/http/pprof).

--- a/doc/PROFILING.md
+++ b/doc/PROFILING.md
@@ -9,6 +9,34 @@ to diagnose performance issues and memory usage.
 - `curl`, or any HTTP client, to collect profiles
 - The `go` tool, to analyse them (not needed to collect them)
 
+> **Availability.** The `diagnostics.profiling` section and the endpoints on the
+> web server are newer than the `20260716` release. On an older build there is no
+> such config section, `/debug/pprof/` on the web server port answers `404` no
+> matter what you set, and the endpoints are still on the telemetry listener. If
+> you set the key, restart, and still get `404`, your build predates the feature.
+
+## Migrating from the old telemetry-port workflow
+
+If you were profiling before this changed, four things moved:
+
+1. **The port.** Profiling is on the web server port (default 8080), not the
+   telemetry listener (default 8090). The old location answers `410 Gone` if the
+   telemetry listener is still enabled, and refuses the connection if it is not,
+   since telemetry is off by default. Both mean the same thing.
+2. **The gate.** `debug: true` never enabled the endpoints, despite what this
+   guide used to say. Set `diagnostics.profiling.enabled: true` and restart.
+3. **Block and mutex sampling.** `debug: true` used to switch both on at their
+   most aggressive setting as a side effect. It no longer does, so
+   `/debug/pprof/block` and `/debug/pprof/mutex` come back empty until you set
+   `blockrate` and `mutexfraction` explicitly. See below for why the old
+   behaviour was worth removing.
+4. **Credentials.** The endpoints are now behind the web server's authentication,
+   or behind a generated token where none is configured.
+
+One thing you can now turn off: if `realtime.telemetry.enabled` was on only to
+reach pprof, it no longer serves any profiling purpose. Turning it off closes an
+unauthenticated listener, which is the point of the change.
+
 ## Enabling profiling
 
 Profiling is off by default. It is not related to `debug: true`, which controls
@@ -31,9 +59,12 @@ curl -X PATCH http://localhost:8080/api/v2/settings/diagnostics \
 ```
 
 That request needs whatever authentication and CSRF token the settings API
-already requires on your instance; it is the same path the settings UI uses.
-Prefer `PATCH` over `PUT` here: `PUT` replaces the whole section and zeroes any
-field the request body omits.
+already requires on your instance. Use `PATCH /api/v2/settings/diagnostics`, as
+above: there is no section-level `PUT`, and the whole-document
+`PUT /api/v2/settings` zeroes every field the request body omits.
+
+There is no switch for any of this in the settings UI; the config file and the
+settings API are the only two ways in.
 
 The endpoints are served by **the main web server, on the same port as the web
 UI** (default 8080), behind whatever authentication you have configured. They are
@@ -55,32 +86,41 @@ first time profiling is switched on, and every request must carry it as a
 **The token cannot be read back through the API.** `GET /api/v2/settings` and
 `GET /api/v2/settings/diagnostics` both return it as `**********`, and it is
 never written to the log or included in a support dump. That is deliberate, but
-it means enabling profiling from the web UI mints a credential the UI will never
-show you. The only place to read it is `config.yaml`.
+it means switching profiling on through the settings API mints a credential that
+same API will never show you. The only place to read it is `config.yaml`.
 
-Read it from the config file, scoping the match to the `diagnostics` section.
-A bare search for `token:` also matches notification provider secrets elsewhere
-in the file:
+Read it from the config file. The command has to stop at the end of the
+`diagnostics` section, because other sections have `token:` keys of their own; a
+search that just runs forward from `diagnostics:` will happily print a
+notification provider's secret instead:
 
 ```bash
-awk '/^diagnostics:/{f=1} f && /^[[:space:]]*token:/{print $2; exit}' config.yaml
+awk '/^diagnostics:/{f=1;next} /^[^[:space:]#]/{f=0} f&&/^[[:space:]]*token:/{sub(/^[[:space:]]*token:[[:space:]]*/,"");gsub(/^"|"$/,"");print;exit}' config.yaml
 ```
 
 For a container installation the config lives inside the config volume, so read
 it through the container:
 
 ```bash
-docker exec birdnet-go awk '/^diagnostics:/{f=1} f && /^[[:space:]]*token:/{print $2; exit}' /config/config.yaml
+docker exec birdnet-go awk '/^diagnostics:/{f=1;next} /^[^[:space:]#]/{f=0} f&&/^[[:space:]]*token:/{sub(/^[[:space:]]*token:[[:space:]]*/,"");gsub(/^"|"$/,"");print;exit}' /config/config.yaml
 ```
 
 The host-side copy of that file is under the directory bind-mounted at `/config`
 (`~/birdnet-go-app/config/config.yaml` for a default `install.sh` deployment), so
 reading it there works too.
 
-Every example below assumes the token is in a shell variable:
+If that prints nothing, or prints an empty string, no token has been minted yet.
+Check that `diagnostics.profiling.enabled` is `true`, that the instance has been
+restarted since, and that it has no authentication provider configured (with one,
+no token is generated because none is needed). If all three hold and there is
+still no `token:` line, generation or persistence failed: the startup log carries
+the reason, and a config file the process cannot write is the usual cause.
+
+Every example below assumes the token is in a shell variable. This is the same
+name the collection scripts in `scripts/` read, so exporting it once serves both:
 
 ```bash
-export BIRDNET_TOKEN="$(awk '/^diagnostics:/{f=1} f && /^[[:space:]]*token:/{print $2; exit}' config.yaml)"
+export BIRDNET_PROFILING_TOKEN="$(awk '/^diagnostics:/{f=1;next} /^[^[:space:]#]/{f=0} f&&/^[[:space:]]*token:/{sub(/^[[:space:]]*token:[[:space:]]*/,"");gsub(/^"|"$/,"");print;exit}' config.yaml)"
 ```
 
 `go tool pprof` has no flag for custom headers, but it does preserve query
@@ -88,18 +128,42 @@ parameters it did not set and merges its own into them, so the token survives an
 the one-command workflow is intact:
 
 ```bash
-go tool pprof "http://localhost:8080/debug/pprof/heap?token=$BIRDNET_TOKEN"
+go tool pprof "http://localhost:8080/debug/pprof/heap?token=$BIRDNET_PROFILING_TOKEN"
 ```
 
-**On an instance that does have an authentication provider configured**, no token
-is generated and none is needed: the web server's own auth middleware is the
-gate. Drop the `?token=...` from every command below and authenticate the way you
-normally do. For basic auth, `go tool pprof` honours credentials embedded in the
-URL:
+### On an instance that does have authentication configured
+
+No token is generated and none is accepted: the web server's own auth middleware
+is the gate, and it runs instead of the token check. Passing `?token=...` there
+gets you a `401`, not access.
+
+**`go tool pprof` cannot authenticate against such an instance.** It has no flag
+for headers and no cookie jar, and BirdNET-Go's `security.basicauth` is a form
+login that mints a session cookie, not HTTP Basic. Credentials embedded in the
+URL (`http://user:pass@host/...`) are therefore rejected with a `401`, because
+the middleware accepts only a `Bearer` token or a session cookie. Presenting them
+makes the request fail harder than sending nothing.
+
+Log in with `curl`, keep the session cookie, fetch the profile to a file, and
+analyse the file locally:
 
 ```bash
-go tool pprof "http://user:password@localhost:8080/debug/pprof/heap"
+curl -s -c jar.txt http://localhost:8080/ -o /dev/null
+CSRF=$(awk '$6=="csrf"{print $7}' jar.txt)
+REDIRECT=$(curl -s -b jar.txt -c jar.txt -X POST http://localhost:8080/api/v2/auth/login \
+  -H 'Content-Type: application/json' -H "X-CSRF-Token: $CSRF" \
+  -d '{"username":"admin","password":"YOUR_PASSWORD"}' |
+  python3 -c 'import json,sys; print(json.load(sys.stdin)["redirectUrl"])')
+curl -s -b jar.txt -c jar.txt -L -o /dev/null "http://localhost:8080$REDIRECT"
+
+curl -s -b jar.txt -o heap.pprof "http://localhost:8080/debug/pprof/heap"
+go tool pprof heap.pprof
 ```
+
+The login response carries an OAuth2 callback URL that has to be followed before
+the session cookie is valid, which is what the third command does. Everything
+after that is the ordinary two-step fetch-then-analyse workflow, and it applies to
+every endpoint in the table below.
 
 ## Available profiling endpoints
 
@@ -122,15 +186,22 @@ All of these sit under `/debug/pprof/` on the web server port.
 Requesting `/debug/pprof` without the trailing slash redirects to
 `/debug/pprof/`, carrying the query string across so the token is not lost.
 
-The response codes are worth knowing, because they distinguish the three ways
-this goes wrong:
+The response codes are worth knowing, because they distinguish the ways this goes
+wrong, and which one you get depends on whether authentication is configured:
 
 | Code  | Meaning                                                                         |
 | ----- | ------------------------------------------------------------------------------- |
 | `200` | Success                                                                         |
-| `403` | Token missing or wrong, or the server's own authentication rejected you         |
+| `302` | Auth configured, and you look like a browser. Redirected to the login page      |
+| `401` | Auth configured, and you sent no valid session or `Bearer` token                |
+| `403` | No auth provider configured, and the `token=` parameter is missing or wrong     |
 | `404` | Profiling is disabled. The feature does not announce that it exists but is shut |
 | `410` | You are on the old telemetry-listener location. Use the web server port         |
+
+`403` and `401` are mutually exclusive: the token is only consulted when no
+authentication provider is configured, so an instance never returns both. The
+`enabled` check runs before either, which is why a correct token still gets `404`
+when profiling is off.
 
 ## Common profiling tasks
 
@@ -138,10 +209,10 @@ this goes wrong:
 
 ```bash
 # Analyse directly
-go tool pprof "http://localhost:8080/debug/pprof/heap?token=$BIRDNET_TOKEN"
+go tool pprof "http://localhost:8080/debug/pprof/heap?token=$BIRDNET_PROFILING_TOKEN"
 
 # Or save it first
-curl -o heap.pprof "http://localhost:8080/debug/pprof/heap?token=$BIRDNET_TOKEN"
+curl -o heap.pprof "http://localhost:8080/debug/pprof/heap?token=$BIRDNET_PROFILING_TOKEN"
 go tool pprof heap.pprof
 ```
 
@@ -150,33 +221,36 @@ Useful commands in pprof interactive mode:
 - `top` - show the largest consumers
 - `web` - open an interactive graph in a browser (requires graphviz)
 - `list <function>` - show the annotated source. This one needs the matching
-  source checked out locally; against a release binary it reports
-  `could not find file ... on path` because the build is trimmed to
-  module-relative paths. `top` and `web` need nothing but the profile.
+  source available at the path recorded in the profile. Against a release binary
+  that path is module-relative (`-trimpath`), so a plain checkout is not enough
+  and it reports `could not find file ... on path`; point pprof at your checkout
+  with `-trim_path=github.com/tphakala/birdnet-go` or `-source_path=<dir>`.
+  `top` and `web` need nothing but the profile.
 
 ### 2. CPU profiling
 
 ```bash
 # 30 seconds by default
-go tool pprof "http://localhost:8080/debug/pprof/profile?token=$BIRDNET_TOKEN"
+go tool pprof "http://localhost:8080/debug/pprof/profile?token=$BIRDNET_PROFILING_TOKEN"
 
 # Or a specific duration, saved to a file
-curl -o cpu.pprof "http://localhost:8080/debug/pprof/profile?token=$BIRDNET_TOKEN&seconds=30"
+curl -o cpu.pprof "http://localhost:8080/debug/pprof/profile?token=$BIRDNET_PROFILING_TOKEN&seconds=30"
 go tool pprof cpu.pprof
 ```
 
-Put the token first in the query string and append `&seconds=N` after it, as
-above. Long profiles need no special handling: the server extends its own write
-deadline for the requested sampling duration.
+Query-parameter order does not matter. Long profiles need no special handling
+either: `net/http/pprof` extends the response write deadline itself for the
+requested sampling duration, so the default 30-second profile completes against
+the server's 30-second write timeout.
 
 ### 3. Analysing goroutine leaks
 
 ```bash
 # Human-readable count and stacks
-curl "http://localhost:8080/debug/pprof/goroutine?token=$BIRDNET_TOKEN&debug=1" | head -1
+curl "http://localhost:8080/debug/pprof/goroutine?token=$BIRDNET_PROFILING_TOKEN&debug=1" | head -1
 
 # Or analyse with pprof
-go tool pprof "http://localhost:8080/debug/pprof/goroutine?token=$BIRDNET_TOKEN"
+go tool pprof "http://localhost:8080/debug/pprof/goroutine?token=$BIRDNET_PROFILING_TOKEN"
 ```
 
 ### 4. Finding lock contention
@@ -185,7 +259,7 @@ Requires `mutexfraction` to be non-zero; see below. An empty profile means
 sampling was never switched on, not that nothing contended.
 
 ```bash
-go tool pprof "http://localhost:8080/debug/pprof/mutex?token=$BIRDNET_TOKEN"
+go tool pprof "http://localhost:8080/debug/pprof/mutex?token=$BIRDNET_PROFILING_TOKEN"
 ```
 
 ### 5. Analysing blocking operations
@@ -193,13 +267,13 @@ go tool pprof "http://localhost:8080/debug/pprof/mutex?token=$BIRDNET_TOKEN"
 Requires `blockrate` to be non-zero; see below. Same caveat about empty profiles.
 
 ```bash
-go tool pprof "http://localhost:8080/debug/pprof/block?token=$BIRDNET_TOKEN"
+go tool pprof "http://localhost:8080/debug/pprof/block?token=$BIRDNET_PROFILING_TOKEN"
 ```
 
 ### 6. Execution traces
 
 ```bash
-curl -o trace.out "http://localhost:8080/debug/pprof/trace?token=$BIRDNET_TOKEN&seconds=5"
+curl -o trace.out "http://localhost:8080/debug/pprof/trace?token=$BIRDNET_PROFILING_TOKEN&seconds=5"
 go tool trace trace.out
 ```
 
@@ -268,8 +342,11 @@ consequences, both of which have caused real confusion:
   isolate the interval between them.
 
 To compare two states cleanly, restart the process between them. This does not
-apply to heap or CPU profiles: `heap` reports live objects at the moment you ask,
-and `profile` samples only the window you requested.
+apply to CPU profiles, which sample only the window you requested, nor to the
+default `inuse_space` view of `heap`, which reports live objects at the moment you
+ask. Note that a heap profile also carries `alloc_space` and `alloc_objects`
+views, and those two are cumulative since process start in exactly the way block
+and mutex profiles are, as is `/debug/pprof/allocs`.
 
 ## Environment variable CPU profiling
 
@@ -391,18 +468,19 @@ anyone runs.
    moment of the request, so a diff between two of them is meaningful:
 
    ```bash
-   curl -o heap1.pprof "http://localhost:8080/debug/pprof/heap?token=$BIRDNET_TOKEN"
+   curl -o heap1.pprof "http://localhost:8080/debug/pprof/heap?token=$BIRDNET_PROFILING_TOKEN"
    # wait
-   curl -o heap2.pprof "http://localhost:8080/debug/pprof/heap?token=$BIRDNET_TOKEN"
+   curl -o heap2.pprof "http://localhost:8080/debug/pprof/heap?token=$BIRDNET_PROFILING_TOKEN"
    go tool pprof -base heap1.pprof heap2.pprof
    ```
 
 3. **CPU profiles.** Profile during a representative workload. A profile taken
    while the instance is idle mostly reports that it is idle.
 
-4. **Rotate the token** if you have shared a config file or a support archive
-   with someone. Delete the `token:` line under `diagnostics.profiling`, restart,
-   and a new one is generated.
+4. **Rotate the token** if you have shared a config file with someone. Delete the
+   `token:` line under `diagnostics.profiling`, restart, and a new one is
+   generated. A support archive does not need this: the token is redacted from
+   it.
 
 ## Security note
 
@@ -439,8 +517,9 @@ directions:
   load the box for anyone who can reach them.
 
 The accurate summary is code-structure and configuration disclosure, plus a way
-to spend CPU. Real, and worth keeping behind authentication, but not a dump of
-your secrets.
+to spend CPU. Real, but not a dump of your secrets. Never expose these endpoints
+to an untrusted network without authentication, and turn profiling off again when
+you are done with it.
 
 ## Troubleshooting
 
@@ -449,25 +528,45 @@ If the profiling endpoints are not behaving:
 1. **`404`** - Profiling is disabled. Verify `diagnostics.profiling.enabled` is
    `true`. `debug: true` does not enable profiling; it only controls logging
    verbosity. If you set it in `config.yaml`, remember it applies at the next
-   restart.
-2. **`403`** - On an instance with no authentication provider, check you are
-   passing `?token=` with the value from `diagnostics.profiling.token`. Remember
-   the API returns that field as `**********`, so read it from `config.yaml`. On
-   an instance with authentication configured, authenticate normally and send no
-   token.
-3. **`410`** - You are talking to the telemetry listener (default port 8090). The
+   restart. If the key is set, the instance has been restarted, and you still get
+   `404`, your build predates the feature; see Availability above.
+2. **`403`** - You are on an instance with no authentication provider, and the
+   `token=` parameter is missing or wrong. Read the value from `config.yaml`; the
+   API returns that field as `**********` by design.
+3. **`401`** - The opposite case: an authentication provider is configured, so the
+   token is never consulted and a session or `Bearer` token is required instead.
+   `go tool pprof` cannot supply either. Use the login-then-fetch recipe above.
+4. **`302` to `/login`** - Same cause as `401`, but your client sent
+   `Accept: text/html`, so it was redirected rather than refused.
+5. **The token command prints nothing, or an empty string** - No token has been
+   minted. Either an authentication provider is configured (in which case none is
+   needed), or profiling was never enabled and restarted, or generation or
+   persistence failed. The last case is usually a config file the process cannot
+   write, and the startup log says so.
+6. **`410`** - You are talking to the telemetry listener (default port 8090). The
    endpoints moved to the web server port (default 8080). The telemetry listener
    now serves Prometheus metrics only.
-4. **Connection refused** - Check the web server is running and you have the right
-   port. It is the same port as the web UI.
-5. **Empty `block` or `mutex` profile, everything else working** - `blockrate`
+7. **Connection refused on 8090** - The same situation as `410`, on an instance
+   where the telemetry listener is not enabled at all. Use the web server port.
+8. **Connection refused on the web server port** - Check the web server is running
+   and you have the right port. It is the same port as the web UI.
+9. **Empty `block` or `mutex` profile, everything else working** - `blockrate`
    and `mutexfraction` are still 0. The endpoints answer `200` with a profile
    containing no samples, which reads as "nothing is contending" but means
    "nothing was recorded". `go tool pprof` shows this as
    `Showing nodes accounting for 0, 0% of 0 total`. The startup log says so too,
-   if profiling was enabled at startup with both rates at 0.
-6. **A profile looks like it has stale or doubled data** - Block and mutex
-   profiles are cumulative and cannot be reset; see the sampling section above.
+   if profiling was enabled at startup with both rates at 0. If you previously
+   relied on `debug: true` switching sampling on, that coupling is gone; see
+   Migrating above.
+10. **A profile looks like it has stale or doubled data** - Block and mutex
+    profiles are cumulative and cannot be reset; see the sampling section above.
+11. **A `BIRDNET_GO_PROFILE` file that `go tool pprof` rejects** with
+    `failed to fetch any source profiles` - the file is 0 bytes because the
+    process was hard-killed before the profile was flushed. See the environment
+    variable section above.
+12. **`could not find file ... on path` from `list`** - expected against a release
+    binary, which records module-relative paths. Pass
+    `-trim_path=github.com/tphakala/birdnet-go` or `-source_path=<dir>`.
 
 For more information about pprof, see the
 [official Go documentation](https://pkg.go.dev/net/http/pprof).

--- a/doc/PROFILING.md
+++ b/doc/PROFILING.md
@@ -1,191 +1,473 @@
 # BirdNET-Go Profiling Guide
 
-This guide explains how to use the built-in profiling capabilities in BirdNET-Go to diagnose performance issues and memory usage.
+This guide explains how to use the built-in profiling capabilities in BirdNET-Go
+to diagnose performance issues and memory usage.
 
 ## Prerequisites
 
-- BirdNET-Go running with `diagnostics.profiling.enabled` set
-- `go` tool installed on your system (for analyzing profiles)
+- BirdNET-Go running with `diagnostics.profiling.enabled` set to `true`
+- `curl`, or any HTTP client, to collect profiles
+- The `go` tool, to analyse them (not needed to collect them)
 
-## Enabling Profiling
+## Enabling profiling
 
-Profiling is off by default and is not related to `debug: true`, which controls
-logging verbosity only. Set it in your config.yaml:
-
-```yaml
-diagnostics:
-  profiling:
-    enabled: true
-```
-
-The endpoints are served by the main web server, behind whatever authentication
-you have configured. On an instance with no authentication provider, a token is
-generated into `diagnostics.profiling.token` when profiling is switched on, and
-must be passed as a `token=` query parameter. `go tool pprof` preserves query
-parameters, so the one-command workflow still works:
-
-```bash
-go tool pprof "http://localhost:8080/debug/pprof/heap?token=YOUR_TOKEN"
-```
-
-Changed in `config.yaml` this applies at the next restart, because the config
-file is not watched. Changed through the settings API it applies immediately.
-
-### Block and mutex sampling
-
-The heap, goroutine, CPU and trace profiles need nothing beyond the setting
-above. The block and mutex profiles are different: they require the Go runtime
-to be sampling, which costs CPU on the audio path whether or not anyone ever
-fetches a profile. They are therefore off by default and configured separately,
-as two more keys in the same `profiling` block:
+Profiling is off by default. It is not related to `debug: true`, which controls
+logging verbosity only.
 
 ```yaml
 diagnostics:
   profiling:
     enabled: true
-    blockrate: 10000      # ns of blocked time per sample; 0 disables
-    mutexfraction: 100    # report 1 in N contention events; 0 disables
 ```
 
-Note the two have different units, though both sample less as the number grows.
-`blockrate` is nanoseconds of blocked time per sample. `mutexfraction` reports
-one sampled event per that many contention events. Go documents rate 1 for the
-block profiler as the way to include every blocking event, and since the mutex
-fraction reports one in N, rate 1 there records every contention event too. That
-suits a benchmark; the values above are the recommended starting points for a
-machine doing real-time audio around the clock, and keep enough signal to find a
-contention problem without recording all of it.
-
-One caveat when changing a rate on a running instance: lowering or zeroing a
-rate does not discard samples already collected, so a profile taken shortly
-after a change can mix rates.
-
-## Available Profiling Endpoints
-
-All profiling endpoints sit behind the web server's authentication. Where no
-authentication provider is configured, the generated token described above is
-required instead, so the `?token=...` suffix applies to every command on this
-page even though the examples below omit it for brevity. The endpoints are:
-
-- `/debug/pprof/` - Index page listing all available profiles
-- `/debug/pprof/heap` - Heap memory profile
-- `/debug/pprof/goroutine` - Current goroutines
-- `/debug/pprof/allocs` - Memory allocations
-- `/debug/pprof/threadcreate` - Thread creation profile
-- `/debug/pprof/block` - Blocking profile (goroutines waiting on synchronization)
-- `/debug/pprof/mutex` - Mutex contention profile
-- `/debug/pprof/profile` - CPU profile (captures 30 seconds of CPU usage)
-- `/debug/pprof/trace` - Execution trace
-
-## Common Profiling Tasks
-
-### 1. Analyzing Memory Usage
-
-To capture and analyze a heap profile:
+Edited in `config.yaml` this applies at the next restart, because the config file
+is not watched. Changed through the settings API it applies immediately, with no
+restart:
 
 ```bash
-# Capture the heap profile
-go tool pprof http://localhost:8080/debug/pprof/heap
+curl -X PATCH http://localhost:8080/api/v2/settings/diagnostics \
+  -H 'Content-Type: application/json' \
+  -d '{"profiling":{"enabled":true}}'
+```
 
-# Or save it to a file
-curl -o heap.pprof http://localhost:8080/debug/pprof/heap
+That request needs whatever authentication and CSRF token the settings API
+already requires on your instance; it is the same path the settings UI uses.
+Prefer `PATCH` over `PUT` here: `PUT` replaces the whole section and zeroes any
+field the request body omits.
+
+The endpoints are served by **the main web server, on the same port as the web
+UI** (default 8080), behind whatever authentication you have configured. They are
+not on the Prometheus telemetry listener, which is where they used to live. The
+old location on the telemetry port answers `410 Gone` with a pointer to the
+config section above.
+
+### Getting the token, on an instance with no authentication
+
+This is the step most people miss, and it is the one that makes every command
+below fail with `403` if you skip it.
+
+If no authentication provider is configured, which is the common home-LAN
+default and exactly the case the token exists for, there is no session to
+authenticate with. A token is generated into `diagnostics.profiling.token` the
+first time profiling is switched on, and every request must carry it as a
+`token=` query parameter.
+
+**The token cannot be read back through the API.** `GET /api/v2/settings` and
+`GET /api/v2/settings/diagnostics` both return it as `**********`, and it is
+never written to the log or included in a support dump. That is deliberate, but
+it means enabling profiling from the web UI mints a credential the UI will never
+show you. The only place to read it is `config.yaml`.
+
+Read it from the config file, scoping the match to the `diagnostics` section.
+A bare search for `token:` also matches notification provider secrets elsewhere
+in the file:
+
+```bash
+awk '/^diagnostics:/{f=1} f && /^[[:space:]]*token:/{print $2; exit}' config.yaml
+```
+
+For a container installation the config lives inside the config volume, so read
+it through the container:
+
+```bash
+docker exec birdnet-go awk '/^diagnostics:/{f=1} f && /^[[:space:]]*token:/{print $2; exit}' /config/config.yaml
+```
+
+The host-side copy of that file is under the directory bind-mounted at `/config`
+(`~/birdnet-go-app/config/config.yaml` for a default `install.sh` deployment), so
+reading it there works too.
+
+Every example below assumes the token is in a shell variable:
+
+```bash
+export BIRDNET_TOKEN="$(awk '/^diagnostics:/{f=1} f && /^[[:space:]]*token:/{print $2; exit}' config.yaml)"
+```
+
+`go tool pprof` has no flag for custom headers, but it does preserve query
+parameters it did not set and merges its own into them, so the token survives and
+the one-command workflow is intact:
+
+```bash
+go tool pprof "http://localhost:8080/debug/pprof/heap?token=$BIRDNET_TOKEN"
+```
+
+**On an instance that does have an authentication provider configured**, no token
+is generated and none is needed: the web server's own auth middleware is the
+gate. Drop the `?token=...` from every command below and authenticate the way you
+normally do. For basic auth, `go tool pprof` honours credentials embedded in the
+URL:
+
+```bash
+go tool pprof "http://user:password@localhost:8080/debug/pprof/heap"
+```
+
+## Available profiling endpoints
+
+All of these sit under `/debug/pprof/` on the web server port.
+
+| Path                        | What it returns                                     |
+| --------------------------- | --------------------------------------------------- |
+| `/debug/pprof/`             | Index page listing the available profiles           |
+| `/debug/pprof/heap`         | Heap memory profile (live objects)                  |
+| `/debug/pprof/allocs`       | All allocations since process start                 |
+| `/debug/pprof/goroutine`    | Current goroutines                                  |
+| `/debug/pprof/threadcreate` | OS thread creation profile                          |
+| `/debug/pprof/block`        | Blocking profile; needs `blockrate` set             |
+| `/debug/pprof/mutex`        | Mutex contention profile; needs `mutexfraction` set |
+| `/debug/pprof/profile`      | CPU profile, 30 seconds unless `seconds=N` is given |
+| `/debug/pprof/trace`        | Execution trace                                     |
+| `/debug/pprof/cmdline`      | The process command line                            |
+| `/debug/pprof/symbol`       | Address-to-symbol lookup, used by `go tool pprof`   |
+
+Requesting `/debug/pprof` without the trailing slash redirects to
+`/debug/pprof/`, carrying the query string across so the token is not lost.
+
+The response codes are worth knowing, because they distinguish the three ways
+this goes wrong:
+
+| Code  | Meaning                                                                         |
+| ----- | ------------------------------------------------------------------------------- |
+| `200` | Success                                                                         |
+| `403` | Token missing or wrong, or the server's own authentication rejected you         |
+| `404` | Profiling is disabled. The feature does not announce that it exists but is shut |
+| `410` | You are on the old telemetry-listener location. Use the web server port         |
+
+## Common profiling tasks
+
+### 1. Analysing memory usage
+
+```bash
+# Analyse directly
+go tool pprof "http://localhost:8080/debug/pprof/heap?token=$BIRDNET_TOKEN"
+
+# Or save it first
+curl -o heap.pprof "http://localhost:8080/debug/pprof/heap?token=$BIRDNET_TOKEN"
 go tool pprof heap.pprof
 ```
 
 Useful commands in pprof interactive mode:
 
-- `top` - Show top memory consumers
-- `list <function>` - Show source code with memory allocations
-- `web` - Open interactive graph in browser (requires graphviz)
+- `top` - show the largest consumers
+- `web` - open an interactive graph in a browser (requires graphviz)
+- `list <function>` - show the annotated source. This one needs the matching
+  source checked out locally; against a release binary it reports
+  `could not find file ... on path` because the build is trimmed to
+  module-relative paths. `top` and `web` need nothing but the profile.
 
-### 2. CPU Profiling
-
-To capture CPU profile (30 seconds):
+### 2. CPU profiling
 
 ```bash
-# Capture CPU profile
-go tool pprof http://localhost:8080/debug/pprof/profile
+# 30 seconds by default
+go tool pprof "http://localhost:8080/debug/pprof/profile?token=$BIRDNET_TOKEN"
 
-# Or save it
-curl -o cpu.pprof http://localhost:8080/debug/pprof/profile?seconds=30
+# Or a specific duration, saved to a file
+curl -o cpu.pprof "http://localhost:8080/debug/pprof/profile?token=$BIRDNET_TOKEN&seconds=30"
 go tool pprof cpu.pprof
 ```
 
-### 3. Analyzing Goroutine Leaks
+Put the token first in the query string and append `&seconds=N` after it, as
+above. Long profiles need no special handling: the server extends its own write
+deadline for the requested sampling duration.
 
-To check for goroutine leaks:
-
-```bash
-# View current goroutines
-curl http://localhost:8080/debug/pprof/goroutine?debug=1
-
-# Or analyze with pprof
-go tool pprof http://localhost:8080/debug/pprof/goroutine
-```
-
-### 4. Finding Lock Contention
-
-To analyze mutex contention (requires `mutexfraction` to be set; see above, an
-empty profile means sampling was never switched on):
+### 3. Analysing goroutine leaks
 
 ```bash
-go tool pprof http://localhost:8080/debug/pprof/mutex
+# Human-readable count and stacks
+curl "http://localhost:8080/debug/pprof/goroutine?token=$BIRDNET_TOKEN&debug=1" | head -1
+
+# Or analyse with pprof
+go tool pprof "http://localhost:8080/debug/pprof/goroutine?token=$BIRDNET_TOKEN"
 ```
 
-### 5. Analyzing Blocking Operations
+### 4. Finding lock contention
 
-To find where goroutines are blocking (requires `blockrate` to be set; see
-above, an empty profile means sampling was never switched on):
+Requires `mutexfraction` to be non-zero; see below. An empty profile means
+sampling was never switched on, not that nothing contended.
 
 ```bash
-go tool pprof http://localhost:8080/debug/pprof/block
+go tool pprof "http://localhost:8080/debug/pprof/mutex?token=$BIRDNET_TOKEN"
 ```
 
-## Environment Variable CPU Profiling
+### 5. Analysing blocking operations
 
-For startup performance issues, you can enable CPU profiling via environment variable:
+Requires `blockrate` to be non-zero; see below. Same caveat about empty profiles.
 
 ```bash
-BIRDNET_GO_PROFILE=1 ./birdnet-go
-
-# This creates a profile file: profile_YYYYMMDD_HHMMSS.pprof
+go tool pprof "http://localhost:8080/debug/pprof/block?token=$BIRDNET_TOKEN"
 ```
 
-## Best Practices
+### 6. Execution traces
 
-1. **Production Use**: Turn `diagnostics.profiling.enabled` on temporarily when diagnosing an issue and off again afterwards. Be especially sparing with `blockrate` and `mutexfraction`, which cost CPU continuously rather than only while a profile is being fetched.
+```bash
+curl -o trace.out "http://localhost:8080/debug/pprof/trace?token=$BIRDNET_TOKEN&seconds=5"
+go tool trace trace.out
+```
 
-2. **Memory Profiles**: Take multiple heap profiles over time to identify memory leaks:
+## Block and mutex sampling
+
+The heap, goroutine, CPU and trace profiles need nothing beyond
+`diagnostics.profiling.enabled`. The block and mutex profiles are different: they
+require the Go runtime to be sampling continuously, which costs CPU on the audio
+path whether or not anyone ever fetches a profile. They are therefore off by
+default and configured separately:
+
+```yaml
+diagnostics:
+  profiling:
+    enabled: true
+    blockrate: 10000 # ns of blocked time per sample; 0 disables
+    mutexfraction: 100 # report 1 in N contention events; 0 disables
+```
+
+Both keys hot-reload through the settings API, so you can switch sampling on for
+the duration of an investigation and off again without a restart:
+
+```bash
+curl -X PATCH http://localhost:8080/api/v2/settings/diagnostics \
+  -H 'Content-Type: application/json' \
+  -d '{"profiling":{"blockRate":10000,"mutexFraction":100}}'
+```
+
+The two have different units, on entirely different scales, though both sample
+less as the number grows. `blockrate` is nanoseconds of blocked time per sample.
+`mutexfraction` reports one sampled event per that many contention events. Go
+documents rate 1 for the block profiler as the way to include every blocking
+event, and since the mutex fraction reports one in N, rate 1 there records every
+contention event too. That suits a microbenchmark. The values above are the
+recommended starting points for a machine doing real-time audio around the clock.
+
+Use whole positive numbers. There is no validation on this section, so a negative
+value is accepted by the API and written to `config.yaml`; it is then treated as
+0, meaning off, at the point where the rate is handed to the runtime. The
+behaviour is safe but the config file will not read the way you intended.
+
+### Two things about these two profiles that will mislead you
+
+**Zero is the only free setting for the block profiler.** The cost is dominated
+by the on/off decision, not by the rate. Any non-zero rate arms an unconditional
+timestamp read at every channel send, channel receive, select and semaphore
+acquire. Measured on a Raspberry Pi 5, a blocking channel round-trip costs about
+55% more at rate 1 and still about 28% more at rate 100000, both against rate 0.
+So picking a very coarse rate to be safe buys you most of the cost and almost
+none of the signal. Either sample at a rate that will tell you something, or set
+it to 0.
+
+The mutex fraction is far cheaper. Fraction 1 against fraction 100 was not
+resolvable above measurement noise on either arm64 or x86, so the two knobs are
+not comparable and should not be reasoned about as a pair.
+
+**Block and mutex profiles are cumulative for the life of the process and cannot
+be reset.** There is no endpoint and no setting that clears them. Two
+consequences, both of which have caused real confusion:
+
+- A profile fetched after you lower or zero a rate still contains everything
+  collected at the old rate. Setting `blockrate` back to 0 does not empty
+  `/debug/pprof/block`; it only stops adding to it.
+- Two profiles fetched from one process are not independent. The second includes
+  everything in the first, so diffing them with `go tool pprof -base` does not
+  isolate the interval between them.
+
+To compare two states cleanly, restart the process between them. This does not
+apply to heap or CPU profiles: `heap` reports live objects at the moment you ask,
+and `profile` samples only the window you requested.
+
+## Environment variable CPU profiling
+
+For startup performance issues, where the web server is not up yet, enable CPU
+profiling for the whole run with an environment variable:
+
+```bash
+BIRDNET_GO_PROFILE=1 ./birdnet-go serve
+```
+
+This writes `profile_YYYYMMDD_HHMMSS.pprof` in the working directory.
+
+Three caveats:
+
+- It covers the entire run and cannot be narrowed to a window.
+- The file is written to the process working directory, which is not
+  configurable.
+- The profile is only flushed when the process shuts down cleanly. After a hard
+  kill (`SIGKILL`, or the OOM killer) the file still exists but is **0 bytes**,
+  and `go tool pprof` rejects it with `failed to fetch any source profiles`. That
+  is worse than losing it outright, because an empty file looks like a profile
+  until you try to open it. It matters, because running out of memory is one of
+  the cases you would most want a profile of.
+
+For anything after startup, prefer the HTTP endpoints.
+
+## Seeing inside the inference library
+
+A CPU profile of a running instance shows most of its time inside a single opaque
+native frame belonging to the inference backend. On a TFLite build the top of the
+profile looks like this, and this is normal rather than a symptom:
+
+```
+      flat  flat%   sum%        cum   cum%
+    13.59s 85.96% 85.96%     13.59s 85.96%  [libtensorflowlite_c.so.2.17.1]
+     0.93s  5.88% 91.84%      0.93s  5.88%  runtime.cgocall
+```
+
+That is expected: Go's profiler symbolizes Go frames, and the backend is C or C++.
+The number is also the answer to "where is the CPU going", it just is not a very
+actionable one.
+
+`perf` is the tool for native stacks, and it needs no code shipped in the
+product:
+
+```bash
+perf record -g -p "$(pgrep -n birdnet-go)" -- sleep 30
+perf report
+```
+
+**Be realistic about how far that gets you.** `perf` can only name a frame if the
+library it lives in carries symbols, and the inference libraries shipped with
+BirdNET-Go are stripped. The TFLite library, for example, exports its ~216
+`TfLite*` C API functions and nothing below them, so a report resolves the API
+boundary the call entered through and shows raw hex addresses for the operator
+kernels underneath. Frames in the BirdNET-Go binary itself come out as addresses
+too, because the release build strips the ELF symbol table; that costs nothing in
+practice, since `go tool pprof` names Go frames properly and is the right tool
+for them. Going deeper into the backend with `perf` means running a build of that
+backend with symbols, which is not what ships.
+
+So `perf` answers "which backend entry point is hot", not "which operator is
+slow". The better answer to the second question is per-operator timings from the
+backends themselves (ONNX Runtime session profiling, OpenVINO `PERF_COUNT`),
+which also answer whether more threads helped and whether an int8 model actually
+selected an int8 kernel. Both backends expose the capability. BirdNET-Go does not
+wire it up yet, so there is no flag for it at the moment.
+
+**cgosymbolizer was evaluated and rejected.** It is the obvious-looking way to get
+native frames into Go's own profiles, so the reasoning is recorded here to save
+the next person the investigation. It runs libbacktrace from a `SIGPROF` signal
+handler, and libbacktrace allocates and takes locks, so it is not
+async-signal-safe: that is a deadlock risk in a long-running appliance, accepted
+in exchange for diagnostics. Its traceback implementation carries a Linux-only
+build constraint, so macOS and Windows fail to link and it would need a build tag
+regardless. The native frames it would reveal are overwhelmingly inside TFLite,
+the legacy backend being phased out in favour of ONNX and OpenVINO. And `perf`
+already covers the rare case where native stacks are genuinely needed.
+
+## Why there is no special profiling build
+
+Stripped binaries look like they should break profiling. They do not, and there
+is deliberately no separate unstripped build target.
+
+Go binaries always retain the `pclntab`, the runtime line table `go tool pprof`
+uses to symbolize Go frames. The release build's `-ldflags "-s -w"` strips DWARF
+debug info and the ELF symbol table, which matter for delve and for tools that
+read native symbols, but not for Go-level profiling. A release binary reports
+fully qualified Go function names in every profile, generic instantiations
+included.
+
+An unstripped build would buy one thing: `perf` could name Go frames instead of
+printing addresses for them. That is not worth a build target, because `go tool
+pprof` already names those frames and does it better. It would not help with the
+inference backend at all, which is a separate shared library with its own
+stripping.
+
+`-trimpath`, also used by the release build, is harmless for profiling. It
+rewrites source paths to module-relative form
+(`github.com/tphakala/birdnet-go/internal/...` rather than a path on the build
+machine). The only thing it costs is that `list <function>` cannot find the
+source unless you have a matching checkout; `top`, `web` and every aggregate view
+are unaffected.
+
+Building with `-gcflags=all=-N -l` to get better symbols would be actively
+counterproductive: disabling optimization and inlining changes the performance of
+the code you are trying to measure, so the profile no longer describes the binary
+anyone runs.
+
+## Best practices
+
+1. **Production use.** Turn `diagnostics.profiling.enabled` on while diagnosing
+   an issue and off again afterwards. Be especially sparing with `blockrate` and
+   `mutexfraction`, which cost CPU continuously rather than only while a profile
+   is being fetched.
+
+2. **Memory profiles.** Take several heap profiles over time to find a leak.
+   Unlike block and mutex profiles, heap profiles report live objects at the
+   moment of the request, so a diff between two of them is meaningful:
 
    ```bash
-   # Take baseline
-   curl -o heap1.pprof http://localhost:8080/debug/pprof/heap
-   # Wait some time...
-   curl -o heap2.pprof http://localhost:8080/debug/pprof/heap
-   # Compare
+   curl -o heap1.pprof "http://localhost:8080/debug/pprof/heap?token=$BIRDNET_TOKEN"
+   # wait
+   curl -o heap2.pprof "http://localhost:8080/debug/pprof/heap?token=$BIRDNET_TOKEN"
    go tool pprof -base heap1.pprof heap2.pprof
    ```
 
-3. **CPU Profiles**: Run CPU profiling during typical workload for accurate results.
+3. **CPU profiles.** Profile during a representative workload. A profile taken
+   while the instance is idle mostly reports that it is idle.
 
-4. **Trace Analysis**: For detailed execution analysis:
-   ```bash
-   curl -o trace.out http://localhost:8080/debug/pprof/trace?seconds=5
-   go tool trace trace.out
-   ```
+4. **Rotate the token** if you have shared a config file or a support archive
+   with someone. Delete the `token:` line under `diagnostics.profiling`, restart,
+   and a new one is generated.
 
-## Security Note
+## Security note
 
-The profiling endpoints are protected by the same authentication mechanism as other admin endpoints. Never expose these endpoints publicly without authentication as they can reveal sensitive information about your application's internals.
+Since the endpoints moved to the web server, they sit behind whatever
+authentication the instance has configured, or behind the generated token where
+no authentication provider exists. They are no longer reachable unauthenticated
+on the telemetry listener.
+
+Two things are worth stating plainly rather than left implicit:
+
+- **`security.allowsubnetbypass` applies to these routes too.** With it enabled,
+  every host on the configured subnet reaches `/debug/pprof/` with no credential
+  at all, and no token is minted to stand in the way, because an auth provider is
+  configured. That is a wider grant than it first appears; see below for what it
+  hands over.
+- **Enabling profiling is not free even before anyone fetches a profile**, if you
+  also set `blockrate` or `mutexfraction`. See the sampling section above.
+
+What a Go profile actually exposes, since this is widely misunderstood in both
+directions:
+
+- A heap profile does **not** contain the contents of allocations. Audio buffers,
+  passwords and API keys living in memory do not appear in it. What it contains
+  is allocation call stacks, sizes and counts.
+- It does expose **code structure**: fully qualified function names, the call
+  graph, and source file paths. On a release build those paths are
+  module-relative rather than paths on the build machine, because of `-trimpath`.
+- `/debug/pprof/cmdline` returns the process command line verbatim, including any
+  paths and flags it was started with.
+- `/debug/pprof/goroutine?debug=2` returns full goroutine stacks, which include
+  some function arguments as raw words.
+- `/debug/pprof/profile?seconds=N` and `/debug/pprof/trace?seconds=N` make the
+  process do measurable work for the duration requested, so they are a way to
+  load the box for anyone who can reach them.
+
+The accurate summary is code-structure and configuration disclosure, plus a way
+to spend CPU. Real, and worth keeping behind authentication, but not a dump of
+your secrets.
 
 ## Troubleshooting
 
-If profiling endpoints are not available:
+If the profiling endpoints are not behaving:
 
-1. Verify `diagnostics.profiling.enabled` is `true` in config. `debug: true` does not enable profiling; it only controls logging verbosity.
-2. Where no authentication provider is configured, check you are passing `?token=` with the value from `diagnostics.profiling.token`. A missing or wrong token answers 403; a disabled feature answers 404.
-3. Ensure you're authenticated if security is enabled
-4. Check that the web server is running on the expected port, not the telemetry port. The endpoints moved off the telemetry listener and the old location answers 410.
-5. An empty `block` or `mutex` profile with the endpoints otherwise working means `blockrate` / `mutexfraction` are still 0.
+1. **`404`** - Profiling is disabled. Verify `diagnostics.profiling.enabled` is
+   `true`. `debug: true` does not enable profiling; it only controls logging
+   verbosity. If you set it in `config.yaml`, remember it applies at the next
+   restart.
+2. **`403`** - On an instance with no authentication provider, check you are
+   passing `?token=` with the value from `diagnostics.profiling.token`. Remember
+   the API returns that field as `**********`, so read it from `config.yaml`. On
+   an instance with authentication configured, authenticate normally and send no
+   token.
+3. **`410`** - You are talking to the telemetry listener (default port 8090). The
+   endpoints moved to the web server port (default 8080). The telemetry listener
+   now serves Prometheus metrics only.
+4. **Connection refused** - Check the web server is running and you have the right
+   port. It is the same port as the web UI.
+5. **Empty `block` or `mutex` profile, everything else working** - `blockrate`
+   and `mutexfraction` are still 0. The endpoints answer `200` with a profile
+   containing no samples, which reads as "nothing is contending" but means
+   "nothing was recorded". `go tool pprof` shows this as
+   `Showing nodes accounting for 0, 0% of 0 total`. The startup log says so too,
+   if profiling was enabled at startup with both rates at 0.
+6. **A profile looks like it has stale or doubled data** - Block and mutex
+   profiles are cumulative and cannot be reset; see the sampling section above.
 
-For more information about pprof, see the [official Go documentation](https://pkg.go.dev/net/http/pprof).
+For more information about pprof, see the
+[official Go documentation](https://pkg.go.dev/net/http/pprof).

--- a/doc/PROFILING.md
+++ b/doc/PROFILING.md
@@ -95,14 +95,14 @@ search that just runs forward from `diagnostics:` will happily print a
 notification provider's secret instead:
 
 ```bash
-awk '/^diagnostics:/{f=1;next} /^[^[:space:]#]/{f=0} f&&/^[[:space:]]*token:/{sub(/\r$/,"");sub(/^[[:space:]]*token:[[:space:]]*/,"");sub(/[[:space:]]+#.*/,"");gsub(/"/,"");print;exit}' config.yaml
+awk '/^diagnostics:/{f=1;next} /^[^[:space:]#]/{f=0} f&&/^[[:space:]]*token:/{sub(/^[[:space:]]*token:[[:space:]]*/,"");sub(/[[:space:]]+#.*/,"");gsub(/[[:space:]]|"|\r/,"");print;exit}' config.yaml
 ```
 
 For a container installation the config lives inside the config volume, so read
 it through the container:
 
 ```bash
-docker exec birdnet-go awk '/^diagnostics:/{f=1;next} /^[^[:space:]#]/{f=0} f&&/^[[:space:]]*token:/{sub(/\r$/,"");sub(/^[[:space:]]*token:[[:space:]]*/,"");sub(/[[:space:]]+#.*/,"");gsub(/"/,"");print;exit}' /config/config.yaml
+docker exec birdnet-go awk '/^diagnostics:/{f=1;next} /^[^[:space:]#]/{f=0} f&&/^[[:space:]]*token:/{sub(/^[[:space:]]*token:[[:space:]]*/,"");sub(/[[:space:]]+#.*/,"");gsub(/[[:space:]]|"|\r/,"");print;exit}' /config/config.yaml
 ```
 
 The host-side copy of that file is under the directory bind-mounted at `/config`
@@ -120,7 +120,7 @@ Every example below assumes the token is in a shell variable. This is the same
 name the collection scripts in `scripts/` read, so exporting it once serves both:
 
 ```bash
-export BIRDNET_PROFILING_TOKEN="$(awk '/^diagnostics:/{f=1;next} /^[^[:space:]#]/{f=0} f&&/^[[:space:]]*token:/{sub(/\r$/,"");sub(/^[[:space:]]*token:[[:space:]]*/,"");sub(/[[:space:]]+#.*/,"");gsub(/"/,"");print;exit}' config.yaml)"
+export BIRDNET_PROFILING_TOKEN="$(awk '/^diagnostics:/{f=1;next} /^[^[:space:]#]/{f=0} f&&/^[[:space:]]*token:/{sub(/^[[:space:]]*token:[[:space:]]*/,"");sub(/[[:space:]]+#.*/,"");gsub(/[[:space:]]|"|\r/,"");print;exit}' config.yaml)"
 ```
 
 `go tool pprof` has no flag for custom headers, but it does preserve query
@@ -149,38 +149,56 @@ makes the request fail harder than sending nothing.
 Log in with `curl`, keep the session cookie, fetch the profile to a file, and
 analyse the file locally:
 
-```bash
-JAR=$(mktemp)
-read -rs -p 'password: ' PASS; echo
+Run this line on its own first, so the password is not left in your shell history:
 
-curl -s -c "$JAR" http://localhost:8080/ -o /dev/null
+```bash
+read -rs -p 'password: ' PASS; echo
+```
+
+Then the rest:
+
+```bash
+JAR=$(mktemp) || return
+BASE=http://localhost:8080
+
+curl -s -c "$JAR" "$BASE/" -o /dev/null
 
 REDIRECT=$(printf '{"username":"admin","password":"%s"}' "$PASS" |
-  curl -s -b "$JAR" -c "$JAR" -X POST http://localhost:8080/api/v2/auth/login \
+  curl -s -b "$JAR" -c "$JAR" -X POST "$BASE/api/v2/auth/login" \
     -H 'Content-Type: application/json' --data @- |
-  sed -e 's/.*"redirectUrl":"\([^"]*\)".*/\1/' -e 's/\\u0026/\&/g')
-curl -s -b "$JAR" -c "$JAR" -L -o /dev/null "http://localhost:8080$REDIRECT"
+  sed -n 's/.*"redirectUrl":"\([^"]*\)".*/\1/p' | sed 's/\\u0026/\&/g')
 
-curl -s -b "$JAR" -o heap.pprof "http://localhost:8080/debug/pprof/heap"
-go tool pprof heap.pprof
-
+if [ -z "$REDIRECT" ]; then
+  echo 'login failed, or this instance does not require authentication'
+else
+  curl -s -b "$JAR" -c "$JAR" -L -o /dev/null "$BASE$REDIRECT"
+  curl -s -b "$JAR" -o heap.pprof -w 'fetch: %{http_code}\n' "$BASE/debug/pprof/heap"
+fi
 rm -f "$JAR"
 ```
 
+```bash
+go tool pprof heap.pprof
+```
+
 Three steps in there are not obvious and all three are load-bearing. The opening
-`curl` exists only to prime the cookie jar; without it the callback fails and the
-session is never established. The login response carries an OAuth2 callback URL
-that has to be followed before the session cookie is valid, which is the second
-`curl`. And the second `sed` expression is required because Go's JSON encoder
+`curl` primes the cookie jar. The login response carries an OAuth2 callback URL
+that has to be followed before the session cookie is valid, which is the `curl`
+inside the `if`. And the second `sed` is required because Go's JSON encoder
 escapes ampersands, so the raw `redirectUrl` string carries the six characters
 `\u0026` where the URL needs a literal `&`; without that substitution the callback
 receives a mangled query string and returns `401`.
 
+Note the `sed -n` with a trailing `p` rather than a bare substitution. Without it
+a failed login prints the whole error body instead of nothing, `$REDIRECT` is
+never empty, and the flow limps on to write an error page into `heap.pprof`.
+
 The login endpoint is exempt from CSRF, so no token is needed for it. The cookie
-jar holds a live session, which is why it goes in `mktemp` and is deleted at the
-end, and the password is read into a variable and piped rather than passed as an
-argument, so it stays out of `ps` and out of shell history. If `$REDIRECT` comes
-back empty the login failed.
+jar holds a live session, which is why it goes in `mktemp` and is removed as soon
+as the fetch is done, and the password is piped rather than passed as an argument
+so it stays out of `ps`. Reading it with `read -rs` on its own line, before the
+block, keeps it out of shell history and stops the `read` from swallowing the
+next pasted line.
 
 Everything after that is the ordinary two-step fetch-then-analyse workflow, and it
 applies to every endpoint in the table below.
@@ -243,12 +261,19 @@ Useful commands in pprof interactive mode:
 - `top` - show the largest consumers
 - `web` - open an interactive graph in a browser (requires graphviz)
 - `list <function>` - show the annotated source. This one needs the matching
-  source available. Against a release binary the recorded path is
-  module-relative (`-trimpath`), which pprof resolves against the current
-  directory, so running it from the root of a matching checkout works with no
-  extra flags. From anywhere else it reports `could not find file ... on path`;
-  pass `-source_path=<checkout>` in that case. `top` and `web` need nothing but
-  the profile.
+  source available. Every build target passes `-trimpath`, so the recorded path
+  is module-relative (`github.com/tphakala/birdnet-go/internal/...`). pprof
+  resolves that by matching the last element of the module path against the
+  basename of your source directory, so it works with no flags at all from a
+  checkout in a directory named `birdnet-go`. If your directory is named
+  anything else, which is the case for a release tarball
+  (`birdnet-go-<tag>/`) or most `git worktree` layouts, you need both:
+
+  ```bash
+  go tool pprof -trim_path=github.com/tphakala/birdnet-go -source_path=<dir> heap.pprof
+  ```
+
+  `top` and `web` need nothing but the profile.
 
 ### 2. CPU profiling
 
@@ -553,9 +578,9 @@ If the profiling endpoints are not behaving:
    verbosity. If you set it in `config.yaml`, remember it applies at the next
    restart. If the key is set, the instance has been restarted, and you still get
    `404`, your build predates the feature; see Availability above.
-2. **`403`** - You are on an instance with no authentication provider, and the
-   `token=` parameter is missing or wrong. Read the value from `config.yaml`; the
-   API returns that field as `**********` by design.
+2. **`403`** - On an instance with no authentication provider, the `token=`
+   parameter is missing or wrong. Read the value from `config.yaml`; the API
+   returns that field as `**********` by design.
 3. **`401`** - The opposite case: an authentication provider is configured, so the
    token is never consulted and a session or `Bearer` token is required instead.
    `go tool pprof` cannot supply either. Use the login-then-fetch recipe above.
@@ -587,10 +612,10 @@ If the profiling endpoints are not behaving:
     `failed to fetch any source profiles` - the file is 0 bytes because the
     process was hard-killed before the profile was flushed. See the environment
     variable section above.
-12. **`could not find file ... on path` from `list`** - expected against a release
-    binary, which records module-relative paths that pprof resolves against the
-    current directory. Run it from the root of a matching checkout, or pass
-    `-source_path=<checkout>`.
+12. **`could not find file ... on path` from `list`** - expected against any build,
+    since all of them are `-trimpath`ed. Run it from a checkout in a directory
+    named `birdnet-go`, or pass both
+    `-trim_path=github.com/tphakala/birdnet-go` and `-source_path=<dir>`.
 
 For more information about pprof, see the
 [official Go documentation](https://pkg.go.dev/net/http/pprof).

--- a/doc/PROFILING.md
+++ b/doc/PROFILING.md
@@ -158,23 +158,27 @@ read -rs -p 'password: ' PASS; echo
 Then the rest:
 
 ```bash
-JAR=$(mktemp) || return
-BASE=http://localhost:8080
+(
+  set -e
+  JAR=$(mktemp)
+  trap 'rm -f "$JAR"' EXIT
+  BASE=http://localhost:8080
 
-curl -s -c "$JAR" "$BASE/" -o /dev/null
+  curl -s -c "$JAR" "$BASE/" -o /dev/null
 
-REDIRECT=$(printf '{"username":"admin","password":"%s"}' "$PASS" |
-  curl -s -b "$JAR" -c "$JAR" -X POST "$BASE/api/v2/auth/login" \
-    -H 'Content-Type: application/json' --data @- |
-  sed -n 's/.*"redirectUrl":"\([^"]*\)".*/\1/p' | sed 's/\\u0026/\&/g')
+  REDIRECT=$(printf '{"username":"admin","password":"%s"}' "$PASS" |
+    curl -s -b "$JAR" -c "$JAR" -X POST "$BASE/api/v2/auth/login" \
+      -H 'Content-Type: application/json' --data @- |
+    sed -n 's/.*"redirectUrl":"\([^"]*\)".*/\1/p' | sed 's/\\u0026/\&/g')
 
-if [ -z "$REDIRECT" ]; then
-  echo 'login failed, or this instance does not require authentication'
-else
+  if [ -z "$REDIRECT" ]; then
+    echo 'login failed, or this instance does not require authentication'
+    exit 1
+  fi
+
   curl -s -b "$JAR" -c "$JAR" -L -o /dev/null "$BASE$REDIRECT"
   curl -s -b "$JAR" -o heap.pprof -w 'fetch: %{http_code}\n' "$BASE/debug/pprof/heap"
-fi
-rm -f "$JAR"
+)
 ```
 
 ```bash
@@ -194,11 +198,15 @@ a failed login prints the whole error body instead of nothing, `$REDIRECT` is
 never empty, and the flow limps on to write an error page into `heap.pprof`.
 
 The login endpoint is exempt from CSRF, so no token is needed for it. The cookie
-jar holds a live session, which is why it goes in `mktemp` and is removed as soon
-as the fetch is done, and the password is piped rather than passed as an argument
-so it stays out of `ps`. Reading it with `read -rs` on its own line, before the
-block, keeps it out of shell history and stops the `read` from swallowing the
-next pasted line.
+jar holds a live session, which is why it goes in `mktemp` and is removed by the
+`trap` on the way out, whichever branch exits; and the password is piped rather
+than passed as an argument so it stays out of `ps`. Reading it with `read -rs` on
+its own line, before the block, keeps it out of shell history and stops the
+`read` from swallowing the next pasted line.
+
+The whole block runs in a subshell so `set -e` and `exit 1` abort just that
+block. Pasted into an interactive terminal, a bare `exit` would close the
+terminal and a bare `return` would error, since neither is inside a function.
 
 Everything after that is the ordinary two-step fetch-then-analyse workflow, and it
 applies to every endpoint in the table below.


### PR DESCRIPTION
Rewrites `doc/PROFILING.md` against behaviour verified on a running instance, and fixes the same stale claims where they had spread to `doc/DEBUG-COLLECTION.md` and `ARCHITECTURE.md`.

The guide had drifted badly. It said `debug: true` enabled the pprof endpoints, which was never true; it said they were authenticated, which was not true until recently; and it told readers to grep for a log line that does not exist anywhere in the tree. Two earlier PRs corrected the sections their own changes falsified, but the per-task examples were left behind. Since the document's entire defect was claims nobody checked, I ran every command in it against a live instance rather than reading them off the source, which is also how most of what follows was found.

## The step every reader hits

Where no authentication provider is configured, which is the common home-LAN default and exactly the case the token exists for, enabling profiling mints a credential the API will never show you: it is redacted on both `GET /settings` and `GET /settings/:section` and never logged. The only way to get it is to read `config.yaml`. That was undocumented, and without it every example on the page fails with `403`. It is now the section immediately after enabling.

## Two counter-intuitive facts about block and mutex sampling

Both are now stated plainly, because both have already misled someone.

**Zero is the only free block-profile setting.** Cost is dominated by the on/off decision, not the rate: any non-zero value arms an unconditional timestamp read at every channel send, receive, select and semaphore acquire. Measured on a Pi 5, a blocking channel round-trip costs about +55% at rate 1 and still about +28% at rate 100000. Picking a coarse rate "to be safe" buys most of the cost and almost none of the signal. The mutex fraction is far cheaper and is not comparable; fraction 1 against 100 was not resolvable above noise on either architecture.

**Block and mutex profiles are cumulative for the process lifetime and cannot be reset.** Lowering or zeroing a rate does not empty them, and two profiles from one run are not independent, so `-base` between them does not isolate the interval. This is what let an acceptance test in an earlier PR pass against a rate 10000x too coarse.

## Corrections to things the guide asserted

Several of these were assertions inherited from earlier planning that turned out to be wrong when I actually ran them:

- **The basic-auth example could not work.** `security.basicauth` is a form login that mints a session cookie, not HTTP Basic, and the middleware accepts only a `Bearer` token or that cookie. `go tool pprof "http://user:password@host/..."` returns `401`, and it fails *because* credentials were supplied, so a reader would conclude their password was wrong. Replaced with a login-then-fetch recipe that I ran verbatim against an auth-configured instance.
- **The status-code table was wrong for that same case.** It claimed `403` covered "the server's own authentication rejected you". The auth middleware returns `401` to an API client and `302` to `/login` for a browser; `403` comes only from the token branch, which is never reached when an auth provider exists. Both codes are now documented, with the note that `401` and `403` are mutually exclusive.
- **The token-reading command leaked another section's secret.** My first version set a flag at `diagnostics:` and matched the first `token:` after it, with no section boundary, despite the sentence next to it claiming otherwise. On the shipped config template it printed the Slack webhook secret. The replacement stops at the next top-level key; verified against four config shapes.
- **`perf record -g` does not get you inside the inference library.** The shipped TFLite library is itself stripped: it exports its C API and nothing below, so perf names the entry point and shows raw addresses for the operator kernels. It answers "which entry point is hot", not "which operator is slow".
- **Release builds do not leak absolute build paths.** `-trimpath` rewrites them module-relative. The cost is that `list <function>` cannot find source without `-trim_path`.
- **`BIRDNET_GO_PROFILE` on a hard kill leaves a 0-byte file**, not nothing, which is worse because it looks like a profile until you open it.
- The environment variable carrying the token was `BIRDNET_TOKEN` in two files and `BIRDNET_PROFILING_TOKEN` in a third; only the latter is read by the collection scripts, so following the guide and then running the scripts produced a `403` blamed on the config. Unified on the name with a consumer.
- "Enabling profiling from the web UI" described a UI that deliberately does not exist. There is no section-level `PUT`, only a whole-document one. Query-parameter order does not matter. The write deadline is extended by `net/http/pprof`, not the server. Heap `alloc_space`/`alloc_objects` are cumulative in the same way block and mutex are.

## Additions

**Why there is no special profiling build**, verified rather than asserted: a `-trimpath -ldflags "-s -w"` binary keeps `.gopclntab` with no `.symtab` and no `.debug_info`, and pprof symbolizes Go frames from it correctly, generic instantiations included. **Why cgosymbolizer was rejected**, so it does not get reopened. **An availability note and a migration section**, because the feature postdates the current release: a user who set the key, restarted, and still saw `404` was previously sent by troubleshooting back to the step they had just done. The migration section also states two things that were only implied, that block and mutex profiles come back empty because `debug: true` no longer switches sampling on, and that a telemetry listener enabled solely to reach pprof can now be turned off, which is the security payoff of the move.

The security section now describes what a Go profile actually exposes: allocation call stacks, function names and source paths, plus argv via `/debug/pprof/cmdline` and live stacks via `goroutine?debug=2`. A heap profile does **not** contain the contents of allocations, which is a common misconception worth correcting rather than repeating.

## Verification

Every command was run against a live instance, in both the no-auth and auth-configured shapes, including the `403`/`404`/`401`/`302`/`410` responses, token redaction, PATCH hot-reload of the sampling rates, cumulative block profiles surviving a rate reset, token rotation, and the default 30-second CPU profile completing against the server's write timeout.

`npx prettier --check` passes on all three files.

## Release notes

```
audience: user
summary: Rewritten profiling guide covering the moved pprof endpoints, the profiling token, and the cost of block and mutex sampling.
feature: false
breaking: false
config: false
schema: false
```
