### PR TITLE
fix(search): match partial common names

### DIFF
--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -439,15 +439,16 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 		c.getSettingsOrFallback, c.publishAndSaveSettings, c.handleSettingsChanges)
 	// The detections handler needs the same facade settings-save machinery as the
 	// integrations/TLS handlers (the review/ignore exclude-list mutation persists
-	// settings) plus three more facade-owned function dependencies whose subsystems
+	// settings) plus four more facade-owned function dependencies whose subsystems
 	// are not extracted yet: the auth check (isClientAuthenticated) and the cached
-	// name-map accessors (loadCommonNameMap/loadCommonToScientificMap). c is fully
+	// name-map accessors (display, folded-search, and exact-resolution maps). c is fully
 	// constructed here and these deps are stable for its lifetime; the method values
 	// read their backing fields at call time (so the post-option authService is
 	// observed), so this is wired before the functional options loop.
 	c.detections = detections.New(c.Core, &c.settingsMutex,
 		c.getSettingsOrFallback, c.publishAndSaveSettings, c.handleSettingsChanges,
-		c.isClientAuthenticated, c.loadCommonNameMap, c.loadCommonToScientificMap)
+		c.isClientAuthenticated, c.loadCommonNameMap, c.loadFoldedCommonNameMap,
+		c.loadCommonToScientificMap)
 	// The analytics handler is injected the same facade-owned dependencies as
 	// detections: the auth check (isClientAuthenticated, read per request so the
 	// public /analytics/sources response anonymizes source names) and the cached

--- a/internal/api/v2/detections/detections.go
+++ b/internal/api/v2/detections/detections.go
@@ -223,16 +223,17 @@ type TimeOfDayResponse struct {
 
 // detectionQueryParams holds all query parameters for detection requests
 type detectionQueryParams struct {
-	Date       string
-	Hour       string
-	Duration   int
-	Species    string
-	Search     string
-	StartDate  string
-	EndDate    string
-	NumResults int
-	Offset     int
-	QueryType  string
+	Date             string
+	Hour             string
+	Duration         int
+	Species          string
+	Search           string
+	SearchScientific []string
+	StartDate        string
+	EndDate          string
+	NumResults       int
+	Offset           int
+	QueryType        string
 	// Advanced filter parameters
 	Confidence string
 	TimeOfDay  string
@@ -249,8 +250,8 @@ type detectionQueryParams struct {
 // advancedSearchCacheKey generates a deterministic cache key for advanced search queries.
 // Includes all filter parameters to avoid cache collisions.
 func (p *detectionQueryParams) advancedSearchCacheKey() string {
-	return fmt.Sprintf("adv_search:%s:%d:%d:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%d",
-		p.Search, p.NumResults, p.Offset,
+	return fmt.Sprintf("adv_search:%s:%s:%d:%d:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%d",
+		p.Search, strings.Join(p.SearchScientific, "\x00"), p.NumResults, p.Offset,
 		p.Confidence, p.TimeOfDay, p.HourRange,
 		p.Verified, p.Location, p.Locked,
 		p.Species, p.Date, p.StartDate+":"+p.EndDate,
@@ -619,14 +620,19 @@ func (p *detectionQueryParams) needsAdvancedRouting() bool {
 
 // getDetectionsByQueryType retrieves detections based on the query type
 func (c *Handler) getDetectionsByQueryType(params *detectionQueryParams) ([]datastore.Note, int64, error) {
-	// Resolve locale common names to scientific names before routing so every
-	// query type benefits without per-case duplication.
+	// Species filtering is exact, so an unambiguous common name can be replaced
+	// with its scientific name directly.
 	if resolved, hit := c.resolveSpeciesToScientific(params.Species); hit {
 		params.Species = resolved
 	}
-	if resolved, hit := c.resolveSpeciesToScientific(params.Search); hit {
-		params.Search = resolved
-	}
+
+	// Free-text search is different: an exact common name can also be a substring
+	// of another species (Barn Owl / American Barn Owl). Keep the raw text and add
+	// every active-locale common-name substring match as an OR-ed scientific-name
+	// alternative. Replacing the raw term with one exact resolution would silently
+	// narrow the result set.
+	params.Search = strings.TrimSpace(params.Search)
+	params.SearchScientific = c.resolveCommonNameSubstrings(params.Search)
 
 	switch params.QueryType {
 	case queryTypeHourly:
@@ -643,7 +649,7 @@ func (c *Handler) getDetectionsByQueryType(params *detectionQueryParams) ([]data
 		if params.needsAdvancedRouting() {
 			return c.getSearchDetectionsAdvanced(params)
 		}
-		return c.getSearchDetections(params.Search, params.NumResults, params.Offset)
+		return c.getSearchDetections(params.Search, params.SearchScientific, params.NumResults, params.Offset)
 	default:
 		if params.needsAdvancedRouting() {
 			return c.getSearchDetectionsAdvanced(params)
@@ -1052,10 +1058,11 @@ func (c *Handler) getSearchDetectionsAdvanced(params *detectionQueryParams) ([]d
 // buildAdvancedSearchFilters constructs search filters from query parameters
 func (c *Handler) buildAdvancedSearchFilters(params *detectionQueryParams) datastore.AdvancedSearchFilters {
 	filters := datastore.AdvancedSearchFilters{
-		TextQuery:     params.Search,
-		Limit:         params.NumResults,
-		Offset:        params.Offset,
-		SortAscending: false,
+		TextQuery:         params.Search,
+		SpeciesScientific: params.SearchScientific,
+		Limit:             params.NumResults,
+		Offset:            params.Offset,
+		SortAscending:     false,
 	}
 
 	// Apply confidence filter using shared helper
@@ -1120,9 +1127,9 @@ func (c *Handler) buildAdvancedSearchFilters(params *detectionQueryParams) datas
 }
 
 // getSearchDetections handles search query type logic
-func (c *Handler) getSearchDetections(search string, numResults, offset int) ([]datastore.Note, int64, error) {
+func (c *Handler) getSearchDetections(search string, scientific []string, numResults, offset int) ([]datastore.Note, int64, error) {
 	// Generate a cache key based on parameters
-	cacheKey := fmt.Sprintf("search:%s:%d:%d", search, numResults, offset)
+	cacheKey := fmt.Sprintf("search:%s:%s:%d:%d", search, strings.Join(scientific, "\x00"), numResults, offset)
 
 	// Check if data is in cache
 	if cachedData, found := c.DetectionCache.Get(cacheKey); found {
@@ -1133,8 +1140,23 @@ func (c *Handler) getSearchDetections(search string, numResults, offset int) ([]
 		return cachedResult.Notes, cachedResult.Total, nil
 	}
 
-	// If not in cache, query the database
-	notes, totalCount, err := c.DS.SearchNotes(search, false, numResults, offset)
+	// If the active common-name map found scientific alternatives, use the
+	// advanced datastore path that can OR them with the raw text. Otherwise retain
+	// the lightweight legacy call for ordinary scientific/unknown text queries.
+	var notes []datastore.Note
+	var totalCount int64
+	var err error
+	if len(scientific) > 0 {
+		notes, totalCount, err = c.DS.SearchNotesAdvanced(&datastore.AdvancedSearchFilters{
+			TextQuery:         search,
+			SpeciesScientific: scientific,
+			Limit:             numResults,
+			Offset:            offset,
+			SortBy:            datastore.SortBySearchDefault,
+		})
+	} else {
+		notes, totalCount, err = c.DS.SearchNotes(search, false, numResults, offset)
+	}
 	if err != nil {
 		c.LogErrorIfEnabled("Failed to search notes",
 			logger.String("query", search),

--- a/internal/api/v2/detections/detections.go
+++ b/internal/api/v2/detections/detections.go
@@ -1126,7 +1126,8 @@ func (c *Handler) buildAdvancedSearchFilters(params *detectionQueryParams) datas
 	return filters
 }
 
-// getSearchDetections handles search query type logic
+// getSearchDetections returns cached or datastore results for raw text, unioning
+// any resolved scientific-name alternatives through advanced search.
 func (c *Handler) getSearchDetections(search string, scientific []string, numResults, offset int) ([]datastore.Note, int64, error) {
 	// Generate a cache key based on parameters
 	cacheKey := fmt.Sprintf("search:%s:%s:%d:%d", search, strings.Join(scientific, "\x00"), numResults, offset)

--- a/internal/api/v2/detections/detections_search_common_name_test.go
+++ b/internal/api/v2/detections/detections_search_common_name_test.go
@@ -1,0 +1,113 @@
+package detections
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
+)
+
+// TestGetDetections_CommonNameSubstringUnion exercises the GET endpoint used by
+// DetectionsPage. "Barn Owl" is both an exact common name and a substring of
+// "American Barn Owl", so resolving it by replacement would hide Tyto furcata.
+func TestGetDetections_CommonNameSubstringUnion(t *testing.T) {
+	t.Attr("component", "detections")
+	t.Attr("feature", "common-name-substring-union")
+
+	e := echo.New()
+	mockDS := mocks.NewMockInterface(t)
+	core := apitest.NewCore(t, apitest.WithEcho(e), apitest.WithDatastore(mockDS))
+	commonToSci := map[string]string{
+		apicore.NormalizeForLookup("Barn Owl"):          "Tyto alba",
+		apicore.NormalizeForLookup("American Barn Owl"): "Tyto furcata",
+	}
+	sciToCommon := map[string]string{
+		"Tyto alba":    "Barn Owl",
+		"Tyto furcata": "American Barn Owl",
+	}
+	handler := buildTestHandler(t, core, commonToSci, sciToCommon)
+
+	var captured *datastore.AdvancedSearchFilters
+	mockDS.EXPECT().
+		SearchNotesAdvanced(mock.AnythingOfType("*datastore.AdvancedSearchFilters")).
+		RunAndReturn(func(filters *datastore.AdvancedSearchFilters) ([]datastore.Note, int64, error) {
+			captured = filters
+			return []datastore.Note{
+				{ID: 1, ScientificName: "Tyto alba", CommonName: "Barn Owl"},
+				{ID: 2, ScientificName: "Tyto furcata", CommonName: "American Barn Owl"},
+			}, 2, nil
+		}).Once()
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v2/detections?queryType=search&search=barn%20owl&numResults=25&offset=0",
+		http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	require.NoError(t, handler.GetDetections(ctx))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, captured)
+	assert.Equal(t, "barn owl", captured.TextQuery,
+		"raw text must remain available for substring matching")
+	assert.Equal(t, []string{"Tyto alba", "Tyto furcata"}, captured.SpeciesScientific,
+		"all active-locale substring matches must be OR-ed with the raw query")
+	assert.Equal(t, datastore.SortBySearchDefault, captured.SortBy,
+		"expanded simple search must preserve the datastore's historical ordering")
+
+	mockDS.AssertExpectations(t)
+}
+
+// TestGetDetections_CommonNameSubstringUnionAdvanced verifies that additional
+// filters cannot drop the expanded scientific-name alternatives when the HTTP
+// request routes directly through advanced search.
+func TestGetDetections_CommonNameSubstringUnionAdvanced(t *testing.T) {
+	t.Attr("component", "detections")
+	t.Attr("feature", "common-name-substring-union")
+
+	e := echo.New()
+	mockDS := mocks.NewMockInterface(t)
+	core := apitest.NewCore(t, apitest.WithEcho(e), apitest.WithDatastore(mockDS))
+	handler := buildTestHandler(t, core,
+		map[string]string{
+			apicore.NormalizeForLookup("Barn Owl"):          "Tyto alba",
+			apicore.NormalizeForLookup("American Barn Owl"): "Tyto furcata",
+		},
+		map[string]string{
+			"Tyto alba":    "Barn Owl",
+			"Tyto furcata": "American Barn Owl",
+		})
+
+	var captured *datastore.AdvancedSearchFilters
+	mockDS.EXPECT().
+		SearchNotesAdvanced(mock.AnythingOfType("*datastore.AdvancedSearchFilters")).
+		RunAndReturn(func(filters *datastore.AdvancedSearchFilters) ([]datastore.Note, int64, error) {
+			captured = filters
+			return nil, 0, nil
+		}).Once()
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v2/detections?queryType=search&search=barn%20owl&confidence=%3E%3D50&numResults=25&offset=0",
+		http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	require.NoError(t, handler.GetDetections(ctx))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, captured)
+	assert.Equal(t, "barn owl", captured.TextQuery)
+	assert.Equal(t, []string{"Tyto alba", "Tyto furcata"}, captured.SpeciesScientific)
+	require.NotNil(t, captured.Confidence)
+	assert.Equal(t, ">=", captured.Confidence.Operator)
+	assert.InDelta(t, 0.5, captured.Confidence.Value, 1e-9)
+
+	mockDS.AssertExpectations(t)
+}

--- a/internal/api/v2/detections/detections_test_helpers_test.go
+++ b/internal/api/v2/detections/detections_test_helpers_test.go
@@ -40,6 +40,13 @@ func buildTestHandler(t *testing.T, core *apicore.Core, commonToSci, sciToCommon
 		func(_, _ *conf.Settings) error { return nil },
 		func(echo.Context) bool { return false },
 		func() map[string]string { return sciToCommon },
+		func() map[string]string {
+			folded := make(map[string]string, len(sciToCommon))
+			for scientific, common := range sciToCommon {
+				folded[scientific] = apicore.NormalizeForLookup(common)
+			}
+			return folded
+		},
 		func() map[string]string { return commonToSci },
 	)
 }

--- a/internal/api/v2/detections/handler.go
+++ b/internal/api/v2/detections/handler.go
@@ -8,7 +8,7 @@
 // AuthMiddleware, the HandleError/logging helpers, and the settings accessors)
 // promote onto it.
 //
-// Seven members are injected from the facade because they live on facade-owned
+// Eight members are injected from the facade because they live on facade-owned
 // subsystems that have not been extracted into their own domains yet:
 //   - settingsMutex / getSettingsOrFallback / publishAndSaveSettings /
 //     handleSettingsChanges: the facade settings-save machinery, used by the
@@ -19,9 +19,9 @@
 //   - isClientAuthenticated: the auth-service check (audio_level.go), read per
 //     request so public detection/search responses can strip source metadata for
 //     unauthenticated callers.
-//   - loadCommonNameMap / loadCommonToScientificMap: the cached BirdNET name maps
-//     (insights.go) used to resolve and localize species names in responses and
-//     in the search resolver (the species precedent injects loadCommonNameMap).
+//   - loadCommonNameMap / loadFoldedCommonNameMap /
+//     loadCommonToScientificMap: the cached BirdNET name maps (name_maps.go) used
+//     to resolve and localize species names in responses and search.
 package detections
 
 import (
@@ -69,6 +69,7 @@ type Handler struct {
 	handleSettingsChanges     func(oldSettings, currentSettings *conf.Settings) error
 	isClientAuthenticated     func(ctx echo.Context) bool
 	loadCommonNameMap         func() map[string]string
+	loadFoldedCommonNameMap   func() map[string]string
 	loadCommonToScientificMap func() map[string]string
 }
 
@@ -87,6 +88,7 @@ func New(
 	handleSettingsChanges func(oldSettings, currentSettings *conf.Settings) error,
 	isClientAuthenticated func(ctx echo.Context) bool,
 	loadCommonNameMap func() map[string]string,
+	loadFoldedCommonNameMap func() map[string]string,
 	loadCommonToScientificMap func() map[string]string,
 ) *Handler {
 	return &Handler{
@@ -97,6 +99,7 @@ func New(
 		handleSettingsChanges:     handleSettingsChanges,
 		isClientAuthenticated:     isClientAuthenticated,
 		loadCommonNameMap:         loadCommonNameMap,
+		loadFoldedCommonNameMap:   loadFoldedCommonNameMap,
 		loadCommonToScientificMap: loadCommonToScientificMap,
 	}
 }

--- a/internal/api/v2/detections/search.go
+++ b/internal/api/v2/detections/search.go
@@ -18,19 +18,19 @@ import (
 const defaultSearchTimeout = 60 * time.Second
 const defaultPerPage = 20
 
-// maxSearchSpeciesScientific caps how many client-resolved scientific names a
-// single search may carry. The endpoint is public and each name triggers a label
-// lookup, so this bounds the work an anonymous caller can request. A reverse
-// dictionary match for an ambiguous or substring name stays well under this.
+// maxSearchSpeciesScientific caps how many resolved scientific names a single
+// search may carry. The endpoint is public, so this bounds the batched label
+// lookup and resulting query parameter list an anonymous caller can request.
 const maxSearchSpeciesScientific = 100
 
 // SearchRequest defines the structure of the search API request
 type SearchRequest struct {
 	Species string `json:"species"`
-	// SpeciesScientific carries exact scientific names the client resolved in the
-	// browser from the per-visitor name dictionary (e.g. an ambiguous localized
-	// common name resolving to several species). When set, these are matched in
-	// addition to the free-text Species term. The list is capped server-side.
+	// SpeciesScientific carries exact scientific names to match in addition to the
+	// free-text Species term. The client may supply names resolved from its
+	// per-visitor dictionary; HandleSearch also adds all server-side common-name
+	// substring matches from the active species locale. The combined list is capped
+	// server-side.
 	SpeciesScientific []string `json:"speciesScientific,omitempty"`
 	DateStart         string   `json:"dateStart"`
 	DateEnd           string   `json:"dateEnd"`
@@ -70,26 +70,31 @@ func (c *Handler) HandleSearch(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Invalid search parameters", http.StatusBadRequest)
 	}
 
-	// Bound and clean the client-resolved scientific name list before it reaches
-	// the datastore (public endpoint; each name is a label lookup).
-	req.SpeciesScientific = sanitizeSpeciesScientific(req.SpeciesScientific)
-
-	originalSpecies := req.Species
-	resolved, hit := c.resolveSpeciesToScientific(req.Species)
-	req.Species = resolved
-	if hit {
-		c.LogDebugIfEnabled("Resolved common-name query to scientific name",
-			logger.String("input", originalSpecies),
-			logger.String("resolved", req.Species),
+	// Keep the raw text for the datastore's scientific/common-name substring path,
+	// and independently expand the active-locale common-name map into exact
+	// scientific alternatives. The expansion cannot be delegated solely to the
+	// datastore: legacy rows may contain historical common names, while normalized
+	// datastore modes may not have the facade's current name-map snapshot. For
+	// example, "Barn Owl" must include both Tyto alba and American Barn Owl's
+	// Tyto furcata after the taxonomic split.
+	req.Species = strings.TrimSpace(req.Species)
+	resolvedScientific := c.resolveCommonNameSubstrings(req.Species)
+	req.SpeciesScientific = mergeSpeciesScientific(
+		resolvedScientific,
+		sanitizeSpeciesScientific(req.SpeciesScientific),
+	)
+	if len(resolvedScientific) > 0 {
+		c.LogDebugIfEnabled("Resolved common-name substring query to scientific names",
+			logger.String("input", req.Species),
+			logger.Int("resolved_count", len(resolvedScientific)),
 			logger.String("path", path),
 			logger.String("ip", ip),
 		)
-	} else if originalSpecies != "" {
-		// The species term did not map to a known scientific name; the query falls
-		// back to substring/LIKE. Log it so "unresolvable name" is distinguishable
-		// from "resolved but no detections" when triaging an empty result.
-		c.LogDebugIfEnabled("Species query did not resolve to a scientific name, using substring search",
-			logger.String("input", originalSpecies),
+	} else if req.Species != "" {
+		// No active-locale common names matched; the raw query still falls back to
+		// the datastore's scientific/common-name substring path.
+		c.LogDebugIfEnabled("Species query did not match the active common-name map, using raw substring search",
+			logger.String("input", req.Species),
 			logger.String("path", path),
 			logger.String("ip", ip),
 		)
@@ -183,9 +188,9 @@ func (c *Handler) buildSearchFilters(req *SearchRequest, ctxTimeout context.Cont
 }
 
 // sanitizeSpeciesScientific trims, drops empties, de-duplicates, and caps the
-// client-supplied scientific name list. The search endpoint is public and each
-// name triggers a label lookup, so the cap bounds the work an anonymous caller
-// can request. Insertion order of the kept entries is preserved.
+// client-supplied scientific name list. The search endpoint is public, so the cap
+// bounds the batched lookup and query parameter list an anonymous caller can
+// request. Insertion order of the kept entries is preserved.
 func sanitizeSpeciesScientific(in []string) []string {
 	if len(in) == 0 {
 		return nil
@@ -206,6 +211,64 @@ func sanitizeSpeciesScientific(in []string) []string {
 		out = append(out, name)
 		if len(out) >= maxSearchSpeciesScientific {
 			break
+		}
+	}
+	return out
+}
+
+// resolveCommonNameSubstrings returns the scientific names whose common name in
+// the active server locale contains input. The facade pre-folds common names when
+// the locale/model map changes, avoiding repeated Unicode normalization on this
+// public search path. Sorting before capping makes broad searches deterministic
+// despite randomized map iteration.
+func (c *Handler) resolveCommonNameSubstrings(input string) []string {
+	needle := apicore.NormalizeForLookup(strings.TrimSpace(input))
+	if needle == "" || c.loadFoldedCommonNameMap == nil {
+		return nil
+	}
+
+	matches := make([]string, 0, 8)
+	for scientific, foldedCommon := range c.loadFoldedCommonNameMap() {
+		if strings.Contains(foldedCommon, needle) {
+			matches = append(matches, scientific)
+		}
+	}
+	if len(matches) == 0 {
+		return nil
+	}
+
+	slices.Sort(matches)
+	if len(matches) > maxSearchSpeciesScientific {
+		matches = matches[:maxSearchSpeciesScientific]
+	}
+	return matches
+}
+
+// mergeSpeciesScientific combines trusted server matches with the sanitized
+// client list, de-duplicating while preserving priority and the public endpoint's
+// lookup cap. Server matches come first because they are derived from the raw
+// query and active server locale; remaining capacity keeps client-dictionary
+// matches for per-visitor localization.
+func mergeSpeciesScientific(serverMatches, clientMatches []string) []string {
+	if len(serverMatches) == 0 && len(clientMatches) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{}, min(len(serverMatches)+len(clientMatches), maxSearchSpeciesScientific))
+	out := make([]string, 0, min(len(serverMatches)+len(clientMatches), maxSearchSpeciesScientific))
+	for _, names := range [][]string{serverMatches, clientMatches} {
+		for _, name := range names {
+			if name == "" {
+				continue
+			}
+			if _, duplicate := seen[name]; duplicate {
+				continue
+			}
+			seen[name] = struct{}{}
+			out = append(out, name)
+			if len(out) == maxSearchSpeciesScientific {
+				return out
+			}
 		}
 	}
 	return out

--- a/internal/api/v2/detections/search_species_scientific_test.go
+++ b/internal/api/v2/detections/search_species_scientific_test.go
@@ -39,6 +39,73 @@ func TestSanitizeSpeciesScientific(t *testing.T) {
 	})
 }
 
+func TestResolveCommonNameSubstrings(t *testing.T) {
+	t.Parallel()
+
+	c := &Handler{
+		Core: &apicore.Core{},
+		loadFoldedCommonNameMap: func() map[string]string {
+			return map[string]string{
+				"Tyto furcata": apicore.NormalizeForLookup("American Barn Owl"),
+				"Tyto alba":    apicore.NormalizeForLookup("Barn Owl"),
+				"Strix aluco":  apicore.NormalizeForLookup("Lehtopöllö"),
+			}
+		},
+	}
+
+	t.Run("finds exact and containing common names", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, []string{"Tyto alba", "Tyto furcata"}, c.resolveCommonNameSubstrings("BARN OWL"))
+	})
+
+	t.Run("normalizes Unicode composition", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, []string{"Strix aluco"}, c.resolveCommonNameSubstrings("pöllö"))
+	})
+
+	t.Run("empty and unknown queries return nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, c.resolveCommonNameSubstrings("   "))
+		assert.Nil(t, c.resolveCommonNameSubstrings("unknown"))
+	})
+}
+
+func TestMergeSpeciesScientific(t *testing.T) {
+	t.Parallel()
+
+	t.Run("server matches precede client matches", func(t *testing.T) {
+		t.Parallel()
+		got := mergeSpeciesScientific(
+			[]string{"Tyto alba", "Tyto furcata"},
+			[]string{"Strix aluco"},
+		)
+		assert.Equal(t, []string{"Tyto alba", "Tyto furcata", "Strix aluco"}, got)
+	})
+
+	t.Run("de-duplicates across sources", func(t *testing.T) {
+		t.Parallel()
+		got := mergeSpeciesScientific(
+			[]string{"Tyto alba", "Tyto furcata"},
+			[]string{"Tyto furcata", "Strix aluco"},
+		)
+		assert.Equal(t, []string{"Tyto alba", "Tyto furcata", "Strix aluco"}, got)
+	})
+
+	t.Run("caps the combined list with server matches retained", func(t *testing.T) {
+		t.Parallel()
+		clientMatches := make([]string, maxSearchSpeciesScientific)
+		for i := range clientMatches {
+			clientMatches[i] = "Species " + strconv.Itoa(i)
+		}
+
+		got := mergeSpeciesScientific([]string{"Tyto alba", "Tyto furcata"}, clientMatches)
+		assert.Len(t, got, maxSearchSpeciesScientific)
+		assert.Equal(t, []string{"Tyto alba", "Tyto furcata"}, got[:2])
+		assert.Contains(t, got, "Species 0")
+		assert.NotContains(t, got, "Species "+strconv.Itoa(maxSearchSpeciesScientific-1))
+	})
+}
+
 func TestBuildSearchFilters_ThreadsSpeciesScientific(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/v2/detections/search_species_scientific_test.go
+++ b/internal/api/v2/detections/search_species_scientific_test.go
@@ -2,6 +2,7 @@ package detections
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"testing"
 
@@ -70,6 +71,29 @@ func TestResolveCommonNameSubstrings(t *testing.T) {
 		assert.Nil(t, c.resolveCommonNameSubstrings("   "))
 		assert.Nil(t, c.resolveCommonNameSubstrings("unknown"))
 	})
+
+	t.Run("sorts before capping broad matches deterministically", func(t *testing.T) {
+		t.Parallel()
+		const total = maxSearchSpeciesScientific + 50
+		folded := make(map[string]string, total)
+		for i := range total {
+			folded[fmt.Sprintf("Genus %03d", i)] = apicore.NormalizeForLookup("Barn Owl")
+		}
+		broad := &Handler{
+			Core:                    &apicore.Core{},
+			loadFoldedCommonNameMap: func() map[string]string { return folded },
+		}
+
+		got := broad.resolveCommonNameSubstrings("barn owl")
+		// Every entry matches, so the cap must trim to the maximum.
+		require.Len(t, got, maxSearchSpeciesScientific)
+		// Sorting happens before the cap: the kept window is the first N names in
+		// sorted order, so a cap applied before the sort (returning a random N of
+		// the 150) would fail these deterministic bounds.
+		assert.Equal(t, "Genus 000", got[0])
+		assert.Equal(t, fmt.Sprintf("Genus %03d", maxSearchSpeciesScientific-1), got[len(got)-1])
+		assert.NotContains(t, got, fmt.Sprintf("Genus %03d", maxSearchSpeciesScientific))
+	})
 }
 
 // TestMergeSpeciesScientific verifies deterministic, bounded union of server-
@@ -103,7 +127,7 @@ func TestMergeSpeciesScientific(t *testing.T) {
 		}
 
 		got := mergeSpeciesScientific([]string{"Tyto alba", "Tyto furcata"}, clientMatches)
-		assert.Len(t, got, maxSearchSpeciesScientific)
+		require.Len(t, got, maxSearchSpeciesScientific)
 		assert.Equal(t, []string{"Tyto alba", "Tyto furcata"}, got[:2])
 		assert.Contains(t, got, "Species 0")
 		assert.NotContains(t, got, "Species "+strconv.Itoa(maxSearchSpeciesScientific-1))

--- a/internal/api/v2/detections/search_species_scientific_test.go
+++ b/internal/api/v2/detections/search_species_scientific_test.go
@@ -39,6 +39,8 @@ func TestSanitizeSpeciesScientific(t *testing.T) {
 	})
 }
 
+// TestResolveCommonNameSubstrings verifies normalized substring matching against
+// the active locale's folded common-name map.
 func TestResolveCommonNameSubstrings(t *testing.T) {
 	t.Parallel()
 
@@ -70,6 +72,8 @@ func TestResolveCommonNameSubstrings(t *testing.T) {
 	})
 }
 
+// TestMergeSpeciesScientific verifies deterministic, bounded union of server-
+// and client-resolved scientific names.
 func TestMergeSpeciesScientific(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/v2/name_maps.go
+++ b/internal/api/v2/name_maps.go
@@ -18,12 +18,15 @@ import (
 	"github.com/tphakala/birdnet-go/internal/datastore"
 )
 
-// nameMaps holds the bidirectional BirdNET label lookup maps. Grouping them
-// into one struct lets a single atomic.Value Store swap both maps together,
-// avoiding any window where readers could see a partially updated pair.
+// nameMaps holds the BirdNET display, folded-search, and exact-resolution maps.
+// Grouping them lets a single atomic.Value Store swap one consistent snapshot,
+// avoiding any window where readers could see a partially updated set.
 type nameMaps struct {
 	// sciToCommon maps scientific name -> common name.
 	sciToCommon map[string]string
+	// sciToCommonFolded maps scientific name -> NFC-normalised, lowercased common
+	// name for allocation-free substring matching on the search hot path.
+	sciToCommonFolded map[string]string
 	// commonToSci maps NFC-normalised, lowercased common name -> scientific name.
 	commonToSci map[string]string
 }
@@ -42,14 +45,16 @@ type nameMaps struct {
 // not cover keep their embedded common name.
 func buildNameMaps(labels []string, resolver datastore.SpeciesNameResolver) *nameMaps {
 	nm := &nameMaps{
-		sciToCommon: make(map[string]string, len(labels)),
-		commonToSci: make(map[string]string, len(labels)),
+		sciToCommon:       make(map[string]string, len(labels)),
+		sciToCommonFolded: make(map[string]string, len(labels)),
+		commonToSci:       make(map[string]string, len(labels)),
 	}
 	ambiguous := make(map[string]struct{})
 	for _, sn := range datastore.ResolveLabelNames(labels, resolver) {
 		nm.sciToCommon[sn.Scientific] = sn.Common
 
 		key := apicore.NormalizeForLookup(sn.Common)
+		nm.sciToCommonFolded[sn.Scientific] = key
 		if _, seen := ambiguous[key]; seen {
 			continue
 		}
@@ -65,10 +70,11 @@ func buildNameMaps(labels []string, resolver datastore.SpeciesNameResolver) *nam
 
 // emptyNameMaps is returned by loadNameMaps when the atomic.Value has not been
 // populated yet (a narrow startup window before initInsightsRoutes runs). It
-// avoids allocating a fresh struct and two empty maps on every cold-path call.
+// avoids allocating a fresh struct and empty maps on every cold-path call.
 var emptyNameMaps = &nameMaps{
-	sciToCommon: map[string]string{},
-	commonToSci: map[string]string{},
+	sciToCommon:       map[string]string{},
+	sciToCommonFolded: map[string]string{},
+	commonToSci:       map[string]string{},
 }
 
 // loadNameMaps returns the current name-maps struct. Always returns a non-nil
@@ -90,6 +96,12 @@ func (c *Controller) loadCommonToScientificMap() map[string]string {
 // Always returns a non-nil map.
 func (c *Controller) loadCommonNameMap() map[string]string {
 	return c.loadNameMaps().sciToCommon
+}
+
+// loadFoldedCommonNameMap returns the current scientific-to-normalized-common
+// lookup map used by substring search. Always returns a non-nil map.
+func (c *Controller) loadFoldedCommonNameMap() map[string]string {
+	return c.loadNameMaps().sciToCommonFolded
 }
 
 // canonicalizeExcludeList canonicalizes the species exclude list (resolve each

--- a/internal/api/v2/search_common_name_test.go
+++ b/internal/api/v2/search_common_name_test.go
@@ -34,10 +34,10 @@ func (a *analyticsBatchFakeResolver) ResolveLocalizedBatch(names []string) map[s
 	return out
 }
 
-// TestUpdateCommonNameMap_PopulatesBothMaps verifies that UpdateCommonNameMap
-// populates both the scientific-to-common map and the common-to-scientific map
-// from the same label input, keeping them consistent.
-func TestUpdateCommonNameMap_PopulatesBothMaps(t *testing.T) {
+// TestUpdateCommonNameMap_PopulatesAllMaps verifies that UpdateCommonNameMap
+// populates the display, folded-search, and exact-resolution maps from the same
+// label input, keeping them consistent.
+func TestUpdateCommonNameMap_PopulatesAllMaps(t *testing.T) {
 	t.Parallel()
 
 	e := echo.New()
@@ -54,6 +54,12 @@ func TestUpdateCommonNameMap_PopulatesBothMaps(t *testing.T) {
 	require.NotNil(t, sciToCommon)
 	assert.Equal(t, "Tawny Owl", sciToCommon["Strix aluco"])
 	assert.Equal(t, "Great Tit", sciToCommon["Parus major"])
+
+	// Verify the pre-folded scientific-to-common map (used by substring search).
+	folded := c.loadFoldedCommonNameMap()
+	require.NotNil(t, folded)
+	assert.Equal(t, "tawny owl", folded["Strix aluco"])
+	assert.Equal(t, "great tit", folded["Parus major"])
 
 	// Verify the common-to-scientific map (used by the search resolver).
 	commonToSci := c.loadCommonToScientificMap()
@@ -131,8 +137,10 @@ func TestLoadNameMaps_CalledBeforeInit(t *testing.T) {
 
 	c := &Controller{Core: &apicore.Core{}}
 	assert.NotNil(t, c.loadCommonNameMap())
+	assert.NotNil(t, c.loadFoldedCommonNameMap())
 	assert.NotNil(t, c.loadCommonToScientificMap())
 	assert.Empty(t, c.loadCommonNameMap())
+	assert.Empty(t, c.loadFoldedCommonNameMap())
 	assert.Empty(t, c.loadCommonToScientificMap())
 }
 
@@ -140,10 +148,10 @@ func TestLoadNameMaps_CalledBeforeInit(t *testing.T) {
 // HTTP regression test for the localized common-name search fix. It verifies that when a search
 // request arrives with a localized common name for a secondary-model species
 // (a bat label that has no embedded common name in the label string and is
-// resolved only via the batch localizer), the name is resolved to the scientific
-// name before the datastore query runs. Pre-fix, the batch seam was absent so
-// the bat label never entered commonToSci and the search fell back to a
-// substring match on the unresolved localized string.
+// resolved only via the batch localizer), the raw term and resolved scientific
+// name both reach the datastore. Pre-fix, the batch seam was absent so the bat
+// label never entered commonToSci and the search fell back to a substring match
+// on the unresolved localized string.
 func TestHandleSearch_LocalizedCommonName_SecondaryModelSpecies(t *testing.T) {
 	t.Attr("component", "search")
 	t.Attr("feature", "localized-name-resolution")
@@ -187,11 +195,52 @@ func TestHandleSearch_LocalizedCommonName_SecondaryModelSpecies(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec.Code)
 
-	// The localized name must have been resolved to the scientific name before
-	// the datastore call. Pre-fix this would be "mopsilepakko" (unresolved).
+	// Keep the localized text for raw substring matching and add every matching
+	// scientific name from the active-locale common-name map.
 	require.NotNil(t, captured, "SearchDetections must have been called")
-	assert.Equal(t, "Barbastella barbastellus", captured.Species,
-		"localized bat name must resolve to scientific name before the datastore query")
+	assert.Equal(t, "mopsilepakko", captured.Species)
+	assert.Equal(t, []string{"Barbastella barbastellus"}, captured.SpeciesScientific)
+
+	mockDS.AssertExpectations(t)
+}
+
+// TestHandleSearch_ExactCommonNamePreservesSubstringUnion covers a taxonomic
+// split where "Barn Owl" is an exact common name for Tyto alba but is also a
+// substring of "American Barn Owl" (Tyto furcata). The exact resolution must be
+// additive; replacing the raw term with Tyto alba hides Tyto furcata detections.
+func TestHandleSearch_ExactCommonNamePreservesSubstringUnion(t *testing.T) {
+	t.Attr("component", "search")
+	t.Attr("feature", "common-name-substring-union")
+
+	e, mockDS, controller := setupTestEnvironment(t)
+	controller.UpdateCommonNameMap([]string{
+		"Tyto alba_Barn Owl",
+		"Tyto furcata_American Barn Owl",
+	})
+
+	var captured *datastore.SearchFilters
+	mockDS.EXPECT().
+		SearchDetections(mock.Anything).
+		RunAndReturn(func(f *datastore.SearchFilters) ([]datastore.DetectionRecord, int, error) {
+			captured = f
+			return nil, 0, nil
+		}).Once()
+
+	body := strings.NewReader(`{"species":"barn owl"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/search", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetPath("/api/v2/search")
+
+	err := controller.detections.HandleSearch(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, captured, "SearchDetections must have been called")
+	assert.Equal(t, "barn owl", captured.Species,
+		"raw common name must remain available for substring matching")
+	assert.Equal(t, []string{"Tyto alba", "Tyto furcata"}, captured.SpeciesScientific,
+		"all active-locale common-name substring matches must be added")
 
 	mockDS.AssertExpectations(t)
 }

--- a/internal/datastore/gorm_integration_test.go
+++ b/internal/datastore/gorm_integration_test.go
@@ -549,10 +549,7 @@ func TestSearchNotesAdvanced_MinID_CursorVisitsAllRecords(t *testing.T) {
 func TestSearchNotesAdvanced_TextAndScientificUnion(t *testing.T) {
 	t.Parallel()
 
-	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
-		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
-	})
-	require.NoError(t, err)
+	db := openSQLiteTestDB(t)
 	require.NoError(t, db.AutoMigrate(&Note{}, &NoteReview{}, &NoteLock{}, &NoteComment{}))
 
 	ds := &DataStore{DB: db}

--- a/internal/datastore/gorm_integration_test.go
+++ b/internal/datastore/gorm_integration_test.go
@@ -542,6 +542,44 @@ func TestSearchNotesAdvanced_MinID_CursorVisitsAllRecords(t *testing.T) {
 	assert.Less(t, iterations, maxIterations, "should complete without hitting iteration safety limit")
 }
 
+// TestSearchNotesAdvanced_TextAndScientificUnion verifies that API-resolved
+// scientific alternatives expand free-text results instead of narrowing them.
+// The Tyto furcata row deliberately carries a historical/non-English common name
+// to prove the exact scientific branch is needed alongside the raw text branch.
+func TestSearchNotesAdvanced_TextAndScientificUnion(t *testing.T) {
+	t.Parallel()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&Note{}, &NoteReview{}, &NoteLock{}, &NoteComment{}))
+
+	ds := &DataStore{DB: db}
+	notes := []Note{
+		{Date: "2026-07-25", Time: "10:00:00", ScientificName: "Tyto alba", CommonName: "Barn Owl", Confidence: 0.9},
+		{Date: "2026-07-25", Time: "10:01:00", ScientificName: "Tyto furcata", CommonName: "Schleiereule", Confidence: 0.9},
+		{Date: "2026-07-25", Time: "10:02:00", ScientificName: "Corvus corax", CommonName: "Common Raven", Confidence: 0.9},
+	}
+	for i := range notes {
+		require.NoError(t, db.Create(&notes[i]).Error)
+	}
+
+	results, total, err := ds.SearchNotesAdvanced(&AdvancedSearchFilters{
+		TextQuery:         "barn owl",
+		SpeciesScientific: []string{"Tyto furcata"},
+		Limit:             10,
+		SortBy:            SortBySearchDefault,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), total)
+	require.Len(t, results, 2)
+	assert.Equal(t, []string{"Tyto furcata", "Tyto alba"}, []string{
+		results[0].ScientificName,
+		results[1].ScientificName,
+	}, "simple-search compatibility order should remain ID descending")
+}
+
 // TestDataStore_Save_SetsNoteID verifies that DataStore.Save() correctly sets
 // the Note's ID field after GORM Create with a real SQLite database.
 // This is the foundation of the MQTT detection ID chain — if this fails,

--- a/internal/datastore/index_reconcile_test.go
+++ b/internal/datastore/index_reconcile_test.go
@@ -35,7 +35,9 @@ func openSQLiteTestDB(t *testing.T) *gorm.DB {
 	require.NoError(t, err, "retrieve *sql.DB from gorm")
 	sqlDB.SetMaxOpenConns(1)
 	t.Cleanup(func() {
-		require.NoError(t, sqlDB.Close(), "close in-memory sqlite")
+		// assert, not require: a failing require calls runtime.Goexit from the
+		// cleanup goroutine and would abort any remaining t.Cleanup functions.
+		assert.NoError(t, sqlDB.Close(), "close in-memory sqlite")
 	})
 	return db
 }

--- a/internal/datastore/index_reconcile_test.go
+++ b/internal/datastore/index_reconcile_test.go
@@ -35,7 +35,7 @@ func openSQLiteTestDB(t *testing.T) *gorm.DB {
 	require.NoError(t, err, "retrieve *sql.DB from gorm")
 	sqlDB.SetMaxOpenConns(1)
 	t.Cleanup(func() {
-		_ = sqlDB.Close()
+		require.NoError(t, sqlDB.Close(), "close in-memory sqlite")
 	})
 	return db
 }

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -2140,10 +2140,9 @@ func (ds *DataStore) CountHourlyDetections(date, hour string, duration int) (int
 // SearchFilters defines parameters for filtering detection records
 type SearchFilters struct {
 	Species string
-	// SpeciesScientific holds exact scientific names the client already resolved
-	// (e.g. in the browser from a per-visitor name dictionary). They are resolved
-	// to label IDs and OR-ed into the species match, so an ambiguous localized
-	// common name can match multiple species without server-locale resolution.
+	// SpeciesScientific holds exact scientific names resolved before the datastore
+	// query, either by the client dictionary or the API's active-locale common-name
+	// substring resolver. They are OR-ed into the free-text species match.
 	SpeciesScientific []string
 	DateStart         string
 	DateEnd           string
@@ -2223,8 +2222,7 @@ func (f *SearchFilters) sanitise() error {
 //
 // filters.Species is a free-text substring match on the scientific or common name.
 // filters.SpeciesScientific is an exact match on any of the listed scientific names,
-// used when the client already resolved the term (e.g. in the browser from the
-// per-visitor name dictionary, which sends scientific names with an empty Species).
+// used when either the API or client dictionary resolved common-name alternatives.
 // When both are present they are OR-ed so the result is their union, mirroring the
 // v2 search path. Without the SpeciesScientific branch a dictionary-resolved search
 // (empty Species) would match every species on the legacy datastore.

--- a/internal/datastore/search_advanced.go
+++ b/internal/datastore/search_advanced.go
@@ -10,21 +10,30 @@ import (
 	"gorm.io/gorm"
 )
 
+// SortBySearchDefault preserves each datastore implementation's historical
+// ordering for the simple detection-search endpoint when it needs advanced
+// predicates. Legacy notes sort by ID; the normalized datastore sorts by time.
+const SortBySearchDefault = "search_default"
+
 // AdvancedSearchFilters represents all possible search filters from the frontend
 type AdvancedSearchFilters struct {
-	TextQuery     string
-	Confidence    *ConfidenceFilter
-	TimeOfDay     []string // ["dawn", "day", "dusk", "night"]
-	Hour          *HourFilter
-	DateRange     *DateRange
-	Verified      *bool
-	Species       []string
-	Location      []string // Maps to source_node column
-	Locked        *bool
-	SortAscending bool
-	SortBy        string // "date_desc", "date_asc", "species_asc", "species_desc", "confidence_asc", "confidence_desc", "status"
-	Limit         int
-	Offset        int
+	TextQuery string
+	// SpeciesScientific contains exact scientific names that are OR-ed with
+	// TextQuery. It lets the API expand active-locale common-name substrings while
+	// preserving raw scientific/common-name substring matching.
+	SpeciesScientific []string
+	Confidence        *ConfidenceFilter
+	TimeOfDay         []string // ["dawn", "day", "dusk", "night"]
+	Hour              *HourFilter
+	DateRange         *DateRange
+	Verified          *bool
+	Species           []string
+	Location          []string // Maps to source_node column
+	Locked            *bool
+	SortAscending     bool
+	SortBy            string // "date_desc", "date_asc", "species_asc", "species_desc", "confidence_asc", "confidence_desc", "status", or SortBySearchDefault
+	Limit             int
+	Offset            int
 	// MinID filters to records with ID > MinID (cursor-based pagination for migration)
 	MinID uint
 	// CursorPagination indicates this query uses cursor-based pagination and must
@@ -71,11 +80,12 @@ func (ds *DataStore) SearchNotesAdvanced(filters *AdvancedSearchFilters) ([]Note
 			return db.Order("created_at DESC")
 		})
 
-	// Apply text search if provided
-	if filters.TextQuery != "" {
-		query = query.Where("common_name LIKE ? OR scientific_name LIKE ?",
-			"%"+filters.TextQuery+"%", "%"+filters.TextQuery+"%")
-	}
+	// Reuse the standard free-text + exact-scientific OR grouping so the simple
+	// and advanced legacy search paths cannot drift.
+	query = applySpeciesFilter(query, &SearchFilters{
+		Species:           filters.TextQuery,
+		SpeciesScientific: filters.SpeciesScientific,
+	})
 
 	// Apply confidence filter
 	query = applyConfidenceFilter(query, filters.Confidence)
@@ -130,6 +140,8 @@ func (ds *DataStore) SearchNotesAdvanced(filters *AdvancedSearchFilters) ([]Note
 	} else {
 		// Apply sorting based on SortBy field, falling back to SortAscending for backward compatibility
 		switch strings.ToLower(filters.SortBy) {
+		case SortBySearchDefault:
+			query = query.Order("id DESC")
 		case "date_asc":
 			query = query.Order("date ASC, time ASC")
 		case "species_asc":

--- a/internal/datastore/v2/repository/filter_conversion.go
+++ b/internal/datastore/v2/repository/filter_conversion.go
@@ -267,6 +267,32 @@ func ConfidenceFilterToMinMax(cf *datastore.ConfidenceFilter) (minConf, maxConf 
 // "no filter applied" (nil).
 var sentinelNoMatchIDs = []uint{0}
 
+// mergeUniqueIDs combines label-ID sets while preserving first-seen order.
+// Common-name and explicit-scientific resolution often identify the same label;
+// keeping the IN-list unique avoids redundant query parameters.
+func mergeUniqueIDs(groups ...[]uint) []uint {
+	total := 0
+	for _, group := range groups {
+		total += len(group)
+	}
+	if total == 0 {
+		return nil
+	}
+
+	merged := make([]uint, 0, total)
+	seen := make(map[uint]struct{}, total)
+	for _, group := range groups {
+		for _, id := range group {
+			if _, exists := seen[id]; exists {
+				continue
+			}
+			seen[id] = struct{}{}
+			merged = append(merged, id)
+		}
+	}
+	return merged
+}
+
 // FilterLookupDeps contains dependencies for filter entity lookups.
 type FilterLookupDeps struct {
 	LabelRepo  LabelRepository
@@ -281,7 +307,7 @@ type FilterLookupDeps struct {
 }
 
 // ResolveSpeciesToLabelIDs converts species names to label IDs.
-// Accepts scientific names (looked up via GetLabelIDsByScientificName for cross-model support).
+// Accepts scientific names and resolves the full list in one cross-model batch.
 // If species is non-empty but no labels are found, returns sentinel []uint{0}
 // to ensure the query returns zero results (rather than ignoring the filter).
 // Returns nil if species is empty.
@@ -293,14 +319,21 @@ func ResolveSpeciesToLabelIDs(ctx context.Context, deps *FilterLookupDeps, speci
 		return nil, nil
 	}
 
+	labelsByName, err := deps.LabelRepo.GetByScientificNames(ctx, species)
+	if err != nil {
+		return nil, err
+	}
+
 	labelIDs := make([]uint, 0, len(species))
+	seen := make(map[uint]struct{}, len(species))
 	for _, name := range species {
-		// Use cross-model lookup to get all label IDs for this species
-		ids, err := deps.LabelRepo.GetLabelIDsByScientificName(ctx, name)
-		if err != nil {
-			return nil, err
+		for _, label := range labelsByName[name] {
+			if _, duplicate := seen[label.ID]; duplicate {
+				continue
+			}
+			seen[label.ID] = struct{}{}
+			labelIDs = append(labelIDs, label.ID)
 		}
-		labelIDs = append(labelIDs, ids...)
 	}
 
 	// If input was non-empty but we found nothing, use sentinel
@@ -682,7 +715,7 @@ func ConvertSearchFilters(
 			if sciErr != nil {
 				return nil, sciErr
 			}
-			sf.CommonLabelIDs = append(sf.CommonLabelIDs, sciLabelIDs...)
+			sf.CommonLabelIDs = mergeUniqueIDs(sf.CommonLabelIDs, sciLabelIDs)
 		}
 
 		// Convert device string to audio source IDs
@@ -737,6 +770,11 @@ func ConvertAdvancedFilters(
 
 	// Map SortBy string to v2 sort field constants
 	switch strings.ToLower(filters.SortBy) {
+	case datastore.SortBySearchDefault:
+		// SearchNotes historically sorts the normalized datastore by detection
+		// time, so preserve that contract when simple search needs exact-name ORs.
+		sf.SortBy = SortFieldDetectedAt
+		sf.SortDesc = true
 	case "date_asc":
 		sf.SortBy = SortFieldDetectedAt
 		sf.SortDesc = false
@@ -792,6 +830,17 @@ func ConvertAdvancedFilters(
 		sf.CommonLabelIDs, err = ResolveCommonNameToLabelIDs(ctx, deps, filters.TextQuery)
 		if err != nil {
 			return nil, err
+		}
+
+		// Exact scientific names resolved by the API are OR-ed into the same
+		// label-ID branch as common-name matches. This preserves the raw substring
+		// query while covering names whose stored/indexed common name is stale.
+		if len(filters.SpeciesScientific) > 0 {
+			sciLabelIDs, sciErr := ResolveSpeciesToLabelIDs(ctx, deps, filters.SpeciesScientific)
+			if sciErr != nil {
+				return nil, sciErr
+			}
+			sf.CommonLabelIDs = mergeUniqueIDs(sf.CommonLabelIDs, sciLabelIDs)
 		}
 
 		// Convert location names to audio source IDs

--- a/internal/datastore/v2/repository/filter_conversion_test.go
+++ b/internal/datastore/v2/repository/filter_conversion_test.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -412,6 +413,7 @@ func TestConvertAdvancedFilters(t *testing.T) {
 			{"confidence_asc", SortFieldConfidence, false},
 			{"confidence_desc", SortFieldConfidence, true},
 			{"status", SortFieldStatus, false},
+			{datastore.SortBySearchDefault, SortFieldDetectedAt, true},
 			{"", SortFieldDetectedAt, true},
 		}
 
@@ -425,6 +427,30 @@ func TestConvertAdvancedFilters(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("text and explicit scientific alternatives share the OR branch", func(t *testing.T) {
+		deps := &FilterLookupDeps{
+			LabelRepo: &mockLabelRepository{
+				labels: map[string]*entities.Label{
+					"Tyto alba":    {ID: 11},
+					"Tyto furcata": {ID: 22},
+				},
+			},
+			SciToCommon: map[string]string{
+				"Tyto alba":    "Barn Owl",
+				"Tyto furcata": "American Barn Owl",
+			},
+		}
+		filters := &datastore.AdvancedSearchFilters{
+			TextQuery:         "barn owl",
+			SpeciesScientific: []string{"Tyto alba", "Tyto furcata"},
+		}
+
+		result, err := ConvertAdvancedFilters(ctx, filters, deps, tz)
+		require.NoError(t, err)
+		assert.Equal(t, "barn owl", result.Query)
+		assert.ElementsMatch(t, []uint{11, 22}, result.CommonLabelIDs)
+	})
 }
 
 // =============================================================================
@@ -433,7 +459,9 @@ func TestConvertAdvancedFilters(t *testing.T) {
 
 // mockLabelRepository is a simple mock for testing ResolveSpeciesToLabelIDs
 type mockLabelRepository struct {
-	labels map[string]*entities.Label
+	labels      map[string]*entities.Label
+	batchCalls  atomic.Int64
+	singleCalls atomic.Int64
 }
 
 // GetOrCreate implements LabelRepository.
@@ -503,6 +531,7 @@ func (m *mockLabelRepository) GetByScientificName(_ context.Context, name string
 
 // GetLabelIDsByScientificName implements LabelRepository (cross-model ID lookup).
 func (m *mockLabelRepository) GetLabelIDsByScientificName(_ context.Context, name string) ([]uint, error) {
+	m.singleCalls.Add(1)
 	if label, ok := m.labels[name]; ok {
 		return []uint{label.ID}, nil
 	}
@@ -511,6 +540,7 @@ func (m *mockLabelRepository) GetLabelIDsByScientificName(_ context.Context, nam
 
 // GetByScientificNames implements LabelRepository (batch cross-model lookup).
 func (m *mockLabelRepository) GetByScientificNames(_ context.Context, names []string) (map[string][]*entities.Label, error) {
+	m.batchCalls.Add(1)
 	result := make(map[string][]*entities.Label, len(names))
 	for _, name := range names {
 		if label, ok := m.labels[name]; ok {
@@ -602,6 +632,8 @@ func TestResolveSpeciesToLabelIDs(t *testing.T) {
 		result, err := ResolveSpeciesToLabelIDs(ctx, deps, []string{"Turdus merula", "Parus major"})
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []uint{1, 2}, result)
+		assert.Equal(t, int64(1), labelRepo.batchCalls.Load(), "all scientific names should resolve in one batch")
+		assert.Zero(t, labelRepo.singleCalls.Load())
 	})
 
 	t.Run("unknown species returns sentinel", func(t *testing.T) {

--- a/internal/datastore/v2/repository/filter_conversion_test.go
+++ b/internal/datastore/v2/repository/filter_conversion_test.go
@@ -438,7 +438,7 @@ func TestConvertAdvancedFilters(t *testing.T) {
 			},
 			SciToCommon: map[string]string{
 				"Tyto alba":    "Barn Owl",
-				"Tyto furcata": "American Barn Owl",
+				"Tyto furcata": "Schleiereule",
 			},
 		}
 		filters := &datastore.AdvancedSearchFilters{


### PR DESCRIPTION
## Summary

- make detection searches match substrings of localized common names
- preserve the original free-text query while adding matching scientific names as alternatives
- apply the same behavior through both legacy and v2 datastore search paths without changing their existing result ordering

For example, searching for "barn owl" now returns American Barn Owl detections.

## Testing

- manually verified on an arm64 Raspberry Pi using the `search-name-fix-v3` image
- `go test -race ./...` (run with `TZ=UTC` to avoid two pre-existing local/UTC date-boundary test failures)
- `golangci-lint run -v` with the repository build tags: 0 issues
- `npm run check:all`: passed with 0 warnings
- `CI=true npm test`: 2,678 tests passed
- `git diff --check`: passed

## Preflight Status

- [x] Single concern: one detection-search bug fix
- [x] All six preflight review passes completed; all changed-code findings resolved
- [x] Batched label resolution replaces per-match database lookups
- [x] Localized common-name normalization is cached rather than repeated per request
- [x] Existing search ordering is preserved for both datastore implementations
- [x] GET, POST, advanced-filter, legacy datastore, and v2 repository paths have regression coverage
- [x] Go and frontend linters pass
- [x] Go race suite and frontend test suite pass
- [x] Diff contains no unrelated changes, incomplete TODOs, secrets, or PII
- [x] No API, configuration, migration, i18n, or breaking behavior changes

Secondary-model cross-validation was unavailable; the primary regression and backward-compatibility review found no remaining issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced species search to expand common-name *substring* matches into all related scientific-name alternatives.
  * Combined free-text and scientific-name filters to improve result accuracy (including exact scientific-name constraints).
  * Preserved the raw search term for substring matching, with improved Unicode-normalized common-name handling.
* **Bug Fixes**
  * Prevented search-cache collisions across different resolved species sets.
  * Removed duplicate species constraints and kept consistent ordering across query modes.
  * Updated advanced search default sorting to match expected “search” behavior.
* **Tests**
  * Added coverage for substring-union behavior, deterministic merging, and advanced text+scientific union queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Release notes
- audience: user
- summary: Detection search now matches partial common names, so searching "barn owl" also returns American Barn Owl (and other species whose current localized name contains the term), including after a taxonomic split
- feature: none
- breaking: none
- config: none
- schema: none
