### PR TITLE
fix(imageprovider): send a Wikimedia-compliant User-Agent on image downloads, and stop retrying past a refusal

### DIFF
--- a/internal/imageprovider/cache_validation_test.go
+++ b/internal/imageprovider/cache_validation_test.go
@@ -15,10 +15,6 @@ import (
 	"github.com/tphakala/birdnet-go/internal/observability"
 )
 
-// backgroundRefreshWait bounds how long a test waits for the background refresh
-// goroutine to record a fetch.
-const backgroundRefreshWait = 10 * time.Second
-
 // setupTestCache creates a new cache instance with mock provider for testing
 func setupTestCache(t *testing.T) (*mockProviderWithAPICounter, *imageprovider.BirdImageCache) {
 	t.Helper()
@@ -236,7 +232,7 @@ func TestBackgroundRefreshIsolation(t *testing.T) {
 	// Background refresh must actually run. Poll rather than sleep a fixed interval.
 	assert.Eventually(t, func() bool {
 		return mockProvider.getBackgroundFetchCount() > 0
-	}, backgroundRefreshWait, 20*time.Millisecond, "Expected background refresh to occur")
+	}, backgroundFetchWaitTimeout, 20*time.Millisecond, "Expected background refresh to occur")
 
 	t.Logf("User fetches: %d, Background fetches: %d",
 		mockProvider.getUserFetchCount(), mockProvider.getBackgroundFetchCount())

--- a/internal/imageprovider/cache_validation_test.go
+++ b/internal/imageprovider/cache_validation_test.go
@@ -7,12 +7,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/observability"
 )
+
+// backgroundRefreshWait bounds how long a test waits for the background refresh
+// goroutine to record a fetch.
+const backgroundRefreshWait = 10 * time.Second
 
 // setupTestCache creates a new cache instance with mock provider for testing
 func setupTestCache(t *testing.T) (*mockProviderWithAPICounter, *imageprovider.BirdImageCache) {
@@ -31,6 +36,9 @@ func setupTestCache(t *testing.T) (*mockProviderWithAPICounter, *imageprovider.B
 	cache, err := imageprovider.CreateDefaultCache(metrics, mockStore)
 	require.NoError(t, err, "Failed to create cache")
 	cache.SetImageProvider(mockProvider)
+	t.Cleanup(func() {
+		assert.NoError(t, cache.Close(), "Failed to close cache")
+	})
 
 	return mockProvider, cache
 }
@@ -52,6 +60,9 @@ func setupTestCacheWithSharedStore(t *testing.T) (*mockProviderWithAPICounter, *
 	cache, err := imageprovider.CreateDefaultCache(metrics, mockStore)
 	require.NoError(t, err, "Failed to create cache")
 	cache.SetImageProvider(mockProvider)
+	t.Cleanup(func() {
+		assert.NoError(t, cache.Close(), "Failed to close cache")
+	})
 
 	return mockProvider, cache, mockStore, metrics
 }
@@ -115,6 +126,9 @@ func TestCacheEffectiveness(t *testing.T) {
 		cache2, err := imageprovider.CreateDefaultCache(metrics, mockStore)
 		require.NoError(t, err, "Failed to create second cache")
 		cache2.SetImageProvider(mockProvider)
+		t.Cleanup(func() {
+			assert.NoError(t, cache2.Close(), "Failed to close second cache")
+		})
 
 		_, err = cache2.Get(species)
 		require.NoError(t, err, "Failed to get image from new cache")
@@ -138,6 +152,9 @@ func TestNegativeCaching(t *testing.T) {
 	cache, err := imageprovider.CreateDefaultCache(metrics, mockStore)
 	require.NoError(t, err, "Failed to create cache")
 	cache.SetImageProvider(mockProvider)
+	t.Cleanup(func() {
+		assert.NoError(t, cache.Close(), "Failed to close cache")
+	})
 
 	// Test repeated requests for non-existent species
 	t.Run("RepeatedNotFoundRequests", func(t *testing.T) {
@@ -160,18 +177,26 @@ func TestNegativeCaching(t *testing.T) {
 	})
 }
 
-// TestBackgroundRefreshIsolation ensures background refresh doesn't affect user requests
+// TestBackgroundRefreshIsolation ensures background refresh doesn't affect user requests.
+//
+// This test was permanently skipped for two independent reasons: an unconditional
+// t.Skip, and a mock that read the background-operation context key as an untyped
+// string, so getBackgroundFetchCount() was always zero. Both are fixed.
 func TestBackgroundRefreshIsolation(t *testing.T) {
-	t.Skip("TODO: Fix test - background refresh tracking mechanism needs refactoring")
-	if testing.Short() {
-		t.Skip("Skipping background refresh test in short mode")
-	}
 	t.Parallel()
+
+	// providerFetchDelay must be comfortably larger than the latency budget below so
+	// "returned without waiting for the provider" is a real discrimination and not a
+	// timing coincidence on a loaded CI runner.
+	const (
+		providerFetchDelay = 400 * time.Millisecond
+		userLatencyBudget  = 150 * time.Millisecond
+	)
 
 	mockProvider := &mockProviderWithContextTracking{
 		mockProviderWithAPICounter: mockProviderWithAPICounter{
 			mockImageProvider: mockImageProvider{
-				fetchDelay: 50 * time.Millisecond, // Simulate slower API
+				fetchDelay: providerFetchDelay, // Simulate slow API
 			},
 		},
 	}
@@ -194,34 +219,34 @@ func TestBackgroundRefreshIsolation(t *testing.T) {
 	cache, err := imageprovider.CreateDefaultCache(metrics, mockStore)
 	require.NoError(t, err, "Failed to create cache")
 	cache.SetImageProvider(mockProvider)
+	t.Cleanup(func() {
+		assert.NoError(t, cache.Close(), "Failed to close cache")
+	})
 
-	// Wait for background refresh to potentially start
-	time.Sleep(100 * time.Millisecond)
-
-	// User request should return immediately with stale data
+	// User request must return stale data without blocking on the in-flight refresh.
 	start := time.Now()
 	img, err := cache.Get(species)
 	duration := time.Since(start)
 
 	require.NoError(t, err, "Failed to get image")
-
-	// Should return quickly (not wait for background refresh)
-	assert.LessOrEqual(t, duration, 10*time.Millisecond, "User request took too long, expected < 10ms")
-
-	// Should have returned stale data
+	assert.Less(t, duration, userLatencyBudget,
+		"user request blocked on the background provider fetch (%s delay)", providerFetchDelay)
 	assert.Equal(t, "http://example.com/old.jpg", img.URL, "Expected stale URL")
 
-	// Wait for background refresh to complete
-	time.Sleep(200 * time.Millisecond)
-
-	// Check that background refresh happened
-	assert.Positive(t, mockProvider.getBackgroundFetchCount(), "Expected background refresh to occur")
+	// Background refresh must actually run. Poll rather than sleep a fixed interval.
+	assert.Eventually(t, func() bool {
+		return mockProvider.getBackgroundFetchCount() > 0
+	}, backgroundRefreshWait, 20*time.Millisecond, "Expected background refresh to occur")
 
 	t.Logf("User fetches: %d, Background fetches: %d",
 		mockProvider.getUserFetchCount(), mockProvider.getBackgroundFetchCount())
 }
 
-// TestCacheMetrics validates that metrics accurately reflect cache behavior
+// TestCacheMetrics validates that metrics accurately reflect cache behavior.
+//
+// The previous version was explicitly labelled pseudocode and asserted nothing about
+// metrics at all; it only logged counts. Prometheus counters are read directly here
+// via testutil.ToFloat64.
 func TestCacheMetrics(t *testing.T) {
 	t.Parallel()
 	mockProvider := &mockProviderWithAPICounter{
@@ -235,26 +260,39 @@ func TestCacheMetrics(t *testing.T) {
 	cache, err := imageprovider.CreateDefaultCache(metrics, mockStore)
 	require.NoError(t, err, "Failed to create cache")
 	cache.SetImageProvider(mockProvider)
+	t.Cleanup(func() {
+		assert.NoError(t, cache.Close(), "Failed to close cache")
+	})
 
-	// Track metrics before and after operations
-	// Note: This is pseudocode - actual metric tracking would need proper instrumentation
 	species := []string{"Species_A", "Species_B", "Species_C"}
 
-	// First fetch each species
+	hitsBefore := testutil.ToFloat64(metrics.ImageProvider.CacheHits)
+	missesBefore := testutil.ToFloat64(metrics.ImageProvider.CacheMisses)
+
+	// First fetch of each species: all misses, each reaching the provider.
 	for _, s := range species {
 		_, err := cache.Get(s)
 		require.NoError(t, err, "Failed to get %s", s)
 	}
 
-	// Fetch again (should be cache hits)
+	missesAfterFirstPass := testutil.ToFloat64(metrics.ImageProvider.CacheMisses)
+	assert.InDelta(t, float64(len(species)), missesAfterFirstPass-missesBefore, 0.001,
+		"expected one cache miss per species on first fetch")
+	assert.Equal(t, int64(len(species)), mockProvider.getAPICallCount(),
+		"expected one provider call per species on first fetch")
+
+	// Second fetch of each species: all served from the in-memory cache.
 	for _, s := range species {
 		_, err := cache.Get(s)
 		require.NoError(t, err, "Failed to get %s", s)
 	}
 
-	// Log the results
-	t.Logf("Total API calls: %d (expected 3)", mockProvider.getAPICallCount())
-	t.Logf("Total requests: 6 (3 misses + 3 hits)")
+	assert.InDelta(t, float64(len(species)), testutil.ToFloat64(metrics.ImageProvider.CacheHits)-hitsBefore, 0.001,
+		"expected one cache hit per species on second fetch")
+	assert.InDelta(t, missesAfterFirstPass, testutil.ToFloat64(metrics.ImageProvider.CacheMisses), 0.001,
+		"second fetch must not record additional cache misses")
+	assert.Equal(t, int64(len(species)), mockProvider.getAPICallCount(),
+		"second fetch must not reach the provider")
 }
 
 // mockProviderWithAPICounter tracks API calls
@@ -304,12 +342,8 @@ type mockProviderWithContextTracking struct {
 
 func (m *mockProviderWithContextTracking) FetchWithContext(ctx context.Context, scientificName string) (imageprovider.BirdImage, error) {
 	// Track whether this is a background fetch
-	if ctx != nil {
-		if bg, ok := ctx.Value("background").(bool); ok && bg {
-			atomic.AddInt64(&m.backgroundFetches, 1)
-		} else {
-			atomic.AddInt64(&m.userFetches, 1)
-		}
+	if imageprovider.IsBackgroundContext(ctx) {
+		atomic.AddInt64(&m.backgroundFetches, 1)
 	} else {
 		atomic.AddInt64(&m.userFetches, 1)
 	}

--- a/internal/imageprovider/export_test.go
+++ b/internal/imageprovider/export_test.go
@@ -1,0 +1,47 @@
+package imageprovider
+
+import (
+	"context"
+	"net/http"
+)
+
+// This file exposes package internals to the external imageprovider_test package.
+// It is a _test.go file, so nothing here is compiled into production builds.
+
+// IsBackgroundContext reports whether ctx carries the background-operation marker
+// set by refreshStaleEntries.
+//
+// Test mocks must not spell the key as an untyped string: backgroundOperationKey has
+// the unexported named type contextKey, and context.Value compares the dynamic type
+// of the key, so ctx.Value("background") never matches ctx.Value(backgroundOperationKey).
+// Mocks that made that mistake silently classified every background fetch as a user
+// fetch, which permanently skipped the tests asserting on background behaviour.
+func IsBackgroundContext(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	bg, ok := ctx.Value(backgroundOperationKey).(bool)
+	return ok && bg
+}
+
+// SetFileCacheHTTPClient overrides the HTTP client used for image byte downloads.
+// The production client (imageHTTPClient) rejects loopback addresses as SSRF
+// protection, so an httptest server is unreachable without this override.
+func SetFileCacheHTTPClient(fc *ImageFileCache, client *http.Client) {
+	fc.httpClient = client
+}
+
+// BuildUserAgent exposes buildUserAgent so external tests can assert that the
+// image download sends the same policy-compliant User-Agent as the API path.
+func BuildUserAgent(appVersion string) string {
+	return buildUserAgent(appVersion)
+}
+
+// NegativeEntryMarker is the sentinel URL stored for "no image exists" entries.
+// Exported so external tests assert against the production constant instead of
+// re-spelling the literal.
+const NegativeEntryMarker = negativeEntryMarker
+
+// NegativeCacheTTL is how long a negative cache entry is honoured before the
+// request path re-queries the provider.
+const NegativeCacheTTL = negativeCacheTTL

--- a/internal/imageprovider/export_test.go
+++ b/internal/imageprovider/export_test.go
@@ -1,40 +1,18 @@
 package imageprovider
 
-import (
-	"context"
-	"net/http"
-)
+import "context"
 
 // This file exposes package internals to the external imageprovider_test package.
 // It is a _test.go file, so nothing here is compiled into production builds.
 
-// IsBackgroundContext reports whether ctx carries the background-operation marker
-// set by refreshStaleEntries.
+// IsBackgroundContext reports whether ctx carries the background-operation marker.
 //
-// Test mocks must not spell the key as an untyped string: backgroundOperationKey has
-// the unexported named type contextKey, and context.Value compares the dynamic type
-// of the key, so ctx.Value("background") never matches ctx.Value(backgroundOperationKey).
-// Mocks that made that mistake silently classified every background fetch as a user
-// fetch, which permanently skipped the tests asserting on background behaviour.
+// backgroundOperationKey has the unexported named type contextKey, and context.Value
+// compares the dynamic type of the key, so a mock spelling it as the untyped string
+// "background" never matches. Test mocks must go through this helper, which forwards to
+// the production predicate rather than restating it.
 func IsBackgroundContext(ctx context.Context) bool {
-	if ctx == nil {
-		return false
-	}
-	bg, ok := ctx.Value(backgroundOperationKey).(bool)
-	return ok && bg
-}
-
-// SetFileCacheHTTPClient overrides the HTTP client used for image byte downloads.
-// The production client (imageHTTPClient) rejects loopback addresses as SSRF
-// protection, so an httptest server is unreachable without this override.
-func SetFileCacheHTTPClient(fc *ImageFileCache, client *http.Client) {
-	fc.httpClient = client
-}
-
-// BuildUserAgent exposes buildUserAgent so external tests can assert that the
-// image download sends the same policy-compliant User-Agent as the API path.
-func BuildUserAgent(appVersion string) string {
-	return buildUserAgent(appVersion)
+	return isBackgroundContext(ctx)
 }
 
 // NegativeEntryMarker is the sentinel URL stored for "no image exists" entries.
@@ -45,3 +23,6 @@ const NegativeEntryMarker = negativeEntryMarker
 // NegativeCacheTTL is how long a negative cache entry is honoured before the
 // request path re-queries the provider.
 const NegativeCacheTTL = negativeCacheTTL
+
+// RefreshDelay is the pacing gap the background sweep leaves between entries.
+const RefreshDelay = refreshDelay

--- a/internal/imageprovider/filecache.go
+++ b/internal/imageprovider/filecache.go
@@ -99,15 +99,16 @@ var imageHTTPClient = func() *http.Client {
 	}
 }()
 
-// cachedImageUserAgent memoizes the image-download User-Agent once the app version is
-// known. It is a pointer rather than a sync.OnceValue because conf.Setting() can return
-// nil early: latching a version-less string for the whole process lifetime would send
-// weaker identification to Wikimedia than the policy asks for.
+// cachedImageUserAgent memoizes the image-download User-Agent. It is an atomic.Pointer
+// rather than a sync.OnceValue because conf.Setting() can return nil, and Version is
+// published after startup: latching at first call could pin a version-less string for
+// the process lifetime. Only a non-empty version is memoized, so an early call does not
+// poison the value.
 var cachedImageUserAgent atomic.Pointer[string]
 
-// currentAppVersion returns the running application version, or "" if settings cannot
-// be loaded. conf.Setting() returns nil when the config fails to load, so the nil check
-// is required rather than defensive.
+// currentAppVersion returns the running application version. It is empty both when
+// conf.Setting() returns nil (the config failed to load) and when Version has not been
+// published yet; callers only need "not yet usable", so the two are equivalent here.
 func currentAppVersion() string {
 	if settings := conf.Setting(); settings != nil {
 		return settings.Version
@@ -115,58 +116,24 @@ func currentAppVersion() string {
 	return ""
 }
 
-// imageDownloadUserAgent returns a User-Agent for the image byte download that complies
-// with the Wikimedia Foundation User-Agent policy.
+// imageDownloadUserAgent returns a User-Agent for the image byte download that satisfies
+// the Wikimedia Foundation User-Agent policy.
 //
-// upload.wikimedia.org answers 403 to Go's default "Go-http-client/1.1" and to an empty
-// User-Agent. Without this header the download failed for every species on every
-// request, the disk cache stayed permanently empty, and the media proxy fell back to
-// redirecting clients to the external URL, where non-browser clients hit the same 403.
-//
-// It reuses buildUserAgent so this path and the MediaWiki API path cannot drift apart.
-// Note that httpclient's own default User-Agent ("BirdNET-Go", no version, no contact
-// URL) does not satisfy the policy and would not lift the 403.
+// Wikimedia answers 403 both to Go's default "Go-http-client/1.1" and to any User-Agent
+// beginning with "BirdNET-Go", so the byte fetch needs the same policy-compliant header
+// the MediaWiki API path already sends. It reuses buildUserAgent to keep the two in the
+// same format.
 func imageDownloadUserAgent() string {
 	if ua := cachedImageUserAgent.Load(); ua != nil {
 		return *ua
 	}
 	version := currentAppVersion()
 	ua := buildUserAgent(version)
-	// Only memoize once a real version is available.
 	if version != "" {
-		cachedImageUserAgent.Store(&ua)
+		// CompareAndSwap rather than Store so concurrent first callers publish once.
+		cachedImageUserAgent.CompareAndSwap(nil, &ua)
 	}
 	return ua
-}
-
-// imageRejectionLogged latches the first permanent image-host rejection so the
-// escalated log below is emitted once per process rather than once per download.
-var imageRejectionLogged atomic.Bool
-
-// logPermanentImageRejection escalates a 401/403 from the image host to Error, once.
-//
-// A 401 or 403 is a policy or credential rejection: permanent, and identical on every
-// subsequent request. The caller logs download failures at Info deliberately, so that
-// transient upstream errors (404s, throttling) do not trip the diagnostics health
-// check's elevated-error-count rule. That choice also meant a 100%-failure condition
-// such as a User-Agent block was logged at the level chosen for transient faults and so
-// never escalated: the cache stayed empty for every species indefinitely and nothing
-// said why. Escalating once keeps the transient-noise property while making a blanket
-// block visible the first time it happens.
-func logPermanentImageRejection(statusCode int, provider, scientificName, imageURL string) {
-	if statusCode != http.StatusForbidden && statusCode != http.StatusUnauthorized {
-		return
-	}
-	if !imageRejectionLogged.CompareAndSwap(false, true) {
-		return
-	}
-	GetLogger().Error("Image host rejected the download; this is a permanent condition, not a transient failure",
-		logger.String("provider", provider),
-		logger.String("species", scientificName),
-		logger.Int("status", statusCode),
-		logger.String("user_agent", imageDownloadUserAgent()),
-		logger.String("url", imageURL),
-	)
 }
 
 // ImageFileCache manages disk-based image caching organized by provider.
@@ -174,11 +141,15 @@ type ImageFileCache struct {
 	basePath    string
 	downloadSem chan struct{}      // limits concurrent external downloads
 	sfGroup     singleflight.Group // deduplicates concurrent fetches for same species
-	// httpClient performs the image byte downloads. It defaults to imageHTTPClient,
-	// whose DialContext rejects loopback and private IPs as SSRF protection. Tests
-	// override it to reach an httptest server, which binds 127.0.0.1 and is therefore
-	// unreachable through the production client.
+	// httpClient performs the image byte downloads. imageHTTPClient's DialContext
+	// rejects loopback and private IPs as SSRF protection, so tests override this to
+	// reach an httptest server, which binds 127.0.0.1.
 	httpClient *http.Client
+	// rejectionLogged suppresses repeat escalations of a permanent host rejection.
+	// Scoped per cache and cleared by a successful download, mirroring how
+	// wikiMediaProvider.networkErrorLogged is cleared by resetCircuit: a
+	// never-reset process-global latch would hide a second block entirely.
+	rejectionLogged atomic.Bool
 }
 
 // NewImageFileCache creates a new ImageFileCache rooted at basePath.
@@ -190,13 +161,33 @@ func NewImageFileCache(basePath string) *ImageFileCache {
 	}
 }
 
-// client returns the HTTP client used for image downloads, falling back to the
-// shared SSRF-protected client so a zero-value ImageFileCache never nil-panics.
-func (c *ImageFileCache) client() *http.Client {
-	if c.httpClient != nil {
-		return c.httpClient
+// logPermanentImageRejection escalates a 401/403 from the image host to Error, at most
+// once until the next successful download.
+//
+// A 401 or 403 is treated as a policy or credential rejection rather than a transient
+// fault. Callers log download failures at Info on purpose, so that ordinary upstream
+// errors (404s, throttling) do not inflate the diagnostics error count. The side effect
+// was that a blanket condition such as a User-Agent block, which fails every species on
+// every request, was reported at the level chosen for transient faults and so never
+// stood out. Escalating once preserves the low-noise property while making a blanket
+// rejection visible.
+//
+// Note this is a heuristic: Wikimedia's edge also answers 403 for transient bot
+// challenges, so a single escalation is a signal to investigate, not proof of a block.
+func (c *ImageFileCache) logPermanentImageRejection(statusCode int, provider, scientificName, imageURL string) {
+	if statusCode != http.StatusForbidden && statusCode != http.StatusUnauthorized {
+		return
 	}
-	return imageHTTPClient
+	if !c.rejectionLogged.CompareAndSwap(false, true) {
+		return
+	}
+	GetLogger().Error("Image host rejected the download; treating as a permanent condition, not a transient failure",
+		logger.String("provider", provider),
+		logger.String("species", scientificName),
+		logger.Int("status", statusCode),
+		logger.String("user_agent", imageDownloadUserAgent()),
+		logger.String("url", imageURL),
+	)
 }
 
 // normalizeSpeciesName converts a species name to a filesystem-safe form:
@@ -394,6 +385,19 @@ func (fc *ImageFileCache) DownloadAndStore(ctx context.Context, provider, scient
 	key := provider + "/" + normalizeSpeciesName(scientificName)
 
 	result, err, _ := fc.sfGroup.Do(key, func() (any, error) {
+		// Build the User-Agent before taking a semaphore slot. It can reach
+		// conf.Setting(), whose slow path takes a package-global lock and can read from
+		// disk, and doing that while holding one of only five download slots would
+		// serialize unrelated downloads behind it.
+		userAgent := imageDownloadUserAgent()
+
+		// An already-cancelled context must not acquire a slot and issue a request.
+		// With a free semaphore both select cases are ready and the choice is random,
+		// so check first rather than relying on the select.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+
 		// Acquire semaphore to limit concurrent downloads, respecting context cancellation.
 		select {
 		case fc.downloadSem <- struct{}{}:
@@ -406,16 +410,16 @@ func (fc *ImageFileCache) DownloadAndStore(ctx context.Context, provider, scient
 		if err != nil {
 			return nil, fmt.Errorf("failed to create image request: %w", err)
 		}
-		// Required: upload.wikimedia.org rejects Go's default User-Agent with 403.
-		req.Header.Set("User-Agent", imageDownloadUserAgent())
-		resp, err := fc.client().Do(req)
+		// Required: Wikimedia rejects Go's default User-Agent with 403.
+		req.Header.Set("User-Agent", userAgent)
+		resp, err := fc.httpClient.Do(req)
 		if err != nil {
 			return nil, fmt.Errorf("failed to download image: %w", err)
 		}
 		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode != http.StatusOK {
-			logPermanentImageRejection(resp.StatusCode, provider, scientificName, imageURL)
+			fc.logPermanentImageRejection(resp.StatusCode, provider, scientificName, imageURL)
 			return nil, fmt.Errorf("non-200 status downloading image: %d", resp.StatusCode)
 		}
 
@@ -434,12 +438,19 @@ func (fc *ImageFileCache) DownloadAndStore(ctx context.Context, provider, scient
 		if storeErr != nil {
 			return nil, storeErr
 		}
+
+		// A success means any earlier rejection is over, so re-arm the escalated log.
+		fc.rejectionLogged.Store(false)
+
 		return &downloadResult{path: path, contentType: ct}, nil
 	})
 
 	if err != nil {
 		return "", "", err
 	}
-	dr := result.(*downloadResult)
+	dr, ok := result.(*downloadResult)
+	if !ok {
+		return "", "", fmt.Errorf("unexpected download result type %T", result)
+	}
 	return dr.path, dr.contentType, nil
 }

--- a/internal/imageprovider/filecache.go
+++ b/internal/imageprovider/filecache.go
@@ -119,10 +119,13 @@ func currentAppVersion() string {
 // imageDownloadUserAgent returns a User-Agent for the image byte download that satisfies
 // the Wikimedia Foundation User-Agent policy.
 //
-// Wikimedia answers 403 both to Go's default "Go-http-client/1.1" and to any User-Agent
-// beginning with "BirdNET-Go", so the byte fetch needs the same policy-compliant header
-// the MediaWiki API path already sends. It reuses buildUserAgent to keep the two in the
-// same format.
+// Wikimedia answers 403 to Go's default "Go-http-client/1.1", so the byte fetch needs the
+// same policy-compliant header the MediaWiki API path already sends. Reusing
+// buildUserAgent keeps the two in one format.
+//
+// Do not "correct" userAgentName to the hyphenated project name: Wikimedia refuses any
+// User-Agent starting with "BirdNET-Go", so the current hyphen-less spelling is the one
+// that works. See internal/imageprovider/wikipedia.go for where that name is defined.
 func imageDownloadUserAgent() string {
 	if ua := cachedImageUserAgent.Load(); ua != nil {
 		return *ua
@@ -174,7 +177,11 @@ func NewImageFileCache(basePath string) *ImageFileCache {
 //
 // Note this is a heuristic: Wikimedia's edge also answers 403 for transient bot
 // challenges, so a single escalation is a signal to investigate, not proof of a block.
-func (c *ImageFileCache) logPermanentImageRejection(statusCode int, provider, scientificName, imageURL string) {
+// userAgent must be the value actually sent on the rejected request, not a fresh
+// lookup: re-deriving it could report a different string if the memoized value latched
+// between the request and the log, which is exactly the wrong thing to do in a
+// diagnostic about which User-Agent was refused.
+func (c *ImageFileCache) logPermanentImageRejection(statusCode int, provider, scientificName, imageURL, userAgent string) {
 	if statusCode != http.StatusForbidden && statusCode != http.StatusUnauthorized {
 		return
 	}
@@ -185,7 +192,7 @@ func (c *ImageFileCache) logPermanentImageRejection(statusCode int, provider, sc
 		logger.String("provider", provider),
 		logger.String("species", scientificName),
 		logger.Int("status", statusCode),
-		logger.String("user_agent", imageDownloadUserAgent()),
+		logger.String("user_agent", userAgent),
 		logger.String("url", imageURL),
 	)
 }
@@ -419,7 +426,7 @@ func (fc *ImageFileCache) DownloadAndStore(ctx context.Context, provider, scient
 		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode != http.StatusOK {
-			fc.logPermanentImageRejection(resp.StatusCode, provider, scientificName, imageURL)
+			fc.logPermanentImageRejection(resp.StatusCode, provider, scientificName, imageURL, userAgent)
 			return nil, fmt.Errorf("non-200 status downloading image: %d", resp.StatusCode)
 		}
 

--- a/internal/imageprovider/filecache.go
+++ b/internal/imageprovider/filecache.go
@@ -102,6 +102,11 @@ type ImageFileCache struct {
 	basePath    string
 	downloadSem chan struct{}      // limits concurrent external downloads
 	sfGroup     singleflight.Group // deduplicates concurrent fetches for same species
+	// httpClient performs the image byte downloads. It defaults to imageHTTPClient,
+	// whose DialContext rejects loopback and private IPs as SSRF protection. Tests
+	// override it to reach an httptest server, which binds 127.0.0.1 and is therefore
+	// unreachable through the production client.
+	httpClient *http.Client
 }
 
 // NewImageFileCache creates a new ImageFileCache rooted at basePath.
@@ -109,7 +114,17 @@ func NewImageFileCache(basePath string) *ImageFileCache {
 	return &ImageFileCache{
 		basePath:    basePath,
 		downloadSem: make(chan struct{}, maxConcurrentDownloads),
+		httpClient:  imageHTTPClient,
 	}
+}
+
+// client returns the HTTP client used for image downloads, falling back to the
+// shared SSRF-protected client so a zero-value ImageFileCache never nil-panics.
+func (c *ImageFileCache) client() *http.Client {
+	if c.httpClient != nil {
+		return c.httpClient
+	}
+	return imageHTTPClient
 }
 
 // normalizeSpeciesName converts a species name to a filesystem-safe form:
@@ -319,7 +334,7 @@ func (fc *ImageFileCache) DownloadAndStore(ctx context.Context, provider, scient
 		if err != nil {
 			return nil, fmt.Errorf("failed to create image request: %w", err)
 		}
-		resp, err := imageHTTPClient.Do(req)
+		resp, err := fc.client().Do(req)
 		if err != nil {
 			return nil, fmt.Errorf("failed to download image: %w", err)
 		}

--- a/internal/imageprovider/filecache.go
+++ b/internal/imageprovider/filecache.go
@@ -139,6 +139,36 @@ func imageDownloadUserAgent() string {
 	return ua
 }
 
+// imageRejectionLogged latches the first permanent image-host rejection so the
+// escalated log below is emitted once per process rather than once per download.
+var imageRejectionLogged atomic.Bool
+
+// logPermanentImageRejection escalates a 401/403 from the image host to Error, once.
+//
+// A 401 or 403 is a policy or credential rejection: permanent, and identical on every
+// subsequent request. The caller logs download failures at Info deliberately, so that
+// transient upstream errors (404s, throttling) do not trip the diagnostics health
+// check's elevated-error-count rule. That choice also meant a 100%-failure condition
+// such as a User-Agent block was logged at the level chosen for transient faults and so
+// never escalated: the cache stayed empty for every species indefinitely and nothing
+// said why. Escalating once keeps the transient-noise property while making a blanket
+// block visible the first time it happens.
+func logPermanentImageRejection(statusCode int, provider, scientificName, imageURL string) {
+	if statusCode != http.StatusForbidden && statusCode != http.StatusUnauthorized {
+		return
+	}
+	if !imageRejectionLogged.CompareAndSwap(false, true) {
+		return
+	}
+	GetLogger().Error("Image host rejected the download; this is a permanent condition, not a transient failure",
+		logger.String("provider", provider),
+		logger.String("species", scientificName),
+		logger.Int("status", statusCode),
+		logger.String("user_agent", imageDownloadUserAgent()),
+		logger.String("url", imageURL),
+	)
+}
+
 // ImageFileCache manages disk-based image caching organized by provider.
 type ImageFileCache struct {
 	basePath    string
@@ -385,6 +415,7 @@ func (fc *ImageFileCache) DownloadAndStore(ctx context.Context, provider, scient
 		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode != http.StatusOK {
+			logPermanentImageRejection(resp.StatusCode, provider, scientificName, imageURL)
 			return nil, fmt.Errorf("non-200 status downloading image: %d", resp.StatusCode)
 		}
 

--- a/internal/imageprovider/filecache.go
+++ b/internal/imageprovider/filecache.go
@@ -10,8 +10,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/httpclient"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"golang.org/x/sync/singleflight"
@@ -96,6 +98,46 @@ var imageHTTPClient = func() *http.Client {
 		},
 	}
 }()
+
+// cachedImageUserAgent memoizes the image-download User-Agent once the app version is
+// known. It is a pointer rather than a sync.OnceValue because conf.Setting() can return
+// nil early: latching a version-less string for the whole process lifetime would send
+// weaker identification to Wikimedia than the policy asks for.
+var cachedImageUserAgent atomic.Pointer[string]
+
+// currentAppVersion returns the running application version, or "" if settings cannot
+// be loaded. conf.Setting() returns nil when the config fails to load, so the nil check
+// is required rather than defensive.
+func currentAppVersion() string {
+	if settings := conf.Setting(); settings != nil {
+		return settings.Version
+	}
+	return ""
+}
+
+// imageDownloadUserAgent returns a User-Agent for the image byte download that complies
+// with the Wikimedia Foundation User-Agent policy.
+//
+// upload.wikimedia.org answers 403 to Go's default "Go-http-client/1.1" and to an empty
+// User-Agent. Without this header the download failed for every species on every
+// request, the disk cache stayed permanently empty, and the media proxy fell back to
+// redirecting clients to the external URL, where non-browser clients hit the same 403.
+//
+// It reuses buildUserAgent so this path and the MediaWiki API path cannot drift apart.
+// Note that httpclient's own default User-Agent ("BirdNET-Go", no version, no contact
+// URL) does not satisfy the policy and would not lift the 403.
+func imageDownloadUserAgent() string {
+	if ua := cachedImageUserAgent.Load(); ua != nil {
+		return *ua
+	}
+	version := currentAppVersion()
+	ua := buildUserAgent(version)
+	// Only memoize once a real version is available.
+	if version != "" {
+		cachedImageUserAgent.Store(&ua)
+	}
+	return ua
+}
 
 // ImageFileCache manages disk-based image caching organized by provider.
 type ImageFileCache struct {
@@ -334,6 +376,8 @@ func (fc *ImageFileCache) DownloadAndStore(ctx context.Context, provider, scient
 		if err != nil {
 			return nil, fmt.Errorf("failed to create image request: %w", err)
 		}
+		// Required: upload.wikimedia.org rejects Go's default User-Agent with 403.
+		req.Header.Set("User-Agent", imageDownloadUserAgent())
 		resp, err := fc.client().Do(req)
 		if err != nil {
 			return nil, fmt.Errorf("failed to download image: %w", err)

--- a/internal/imageprovider/filecache_test.go
+++ b/internal/imageprovider/filecache_test.go
@@ -1,6 +1,9 @@
 package imageprovider
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -8,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/branding"
 )
 
 func TestImageFileCache_StoreAndGet(t *testing.T) {
@@ -119,11 +123,241 @@ func TestImageFileCache_RejectsPathTraversal(t *testing.T) {
 	}
 }
 
-func TestImageFileCache_DownloadAndStore_InvalidURL(t *testing.T) {
+// TestImageFileCache_DownloadAndStore_SSRFGuardRejectsLoopback asserts that the
+// production HTTP client refuses a loopback target.
+//
+// This was named _InvalidURL, but "http://[::1]:0/img.jpg" parses fine; what rejects
+// it is imageHTTPClient's DialContext SSRF guard, before a wire request is ever built.
+// The old name and its bare assert.Error meant the test passed for any cause at all and
+// left the status check, size cap, content-type read and Store handoff untested. Those
+// are covered by the newServedCache tests below, which inject a client that can reach
+// an httptest server.
+func TestImageFileCache_DownloadAndStore_SSRFGuardRejectsLoopback(t *testing.T) {
 	t.Parallel()
 	cache := NewImageFileCache(t.TempDir())
 	_, _, err := cache.DownloadAndStore(t.Context(), "avicommons", "Test species", "http://[::1]:0/img.jpg")
-	assert.Error(t, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no safe IP addresses",
+		"the SSRF dialer, not URL parsing, should be what rejects a loopback target")
+}
+
+// pngBytes is a minimal PNG signature, enough for http.DetectContentType to sniff.
+var pngBytes = []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52}
+
+// newServedCache starts an httptest server running handler and returns a file cache
+// wired to reach it. The production client's SSRF dialer rejects the server's loopback
+// address, so the injected client is what makes DownloadAndStore testable at all.
+func newServedCache(t *testing.T, handler http.HandlerFunc) (*ImageFileCache, *httptest.Server) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	cache := NewImageFileCache(filepath.Join(t.TempDir(), "cache"))
+	cache.httpClient = server.Client()
+	return cache, server
+}
+
+// TestDownloadAndStore_SendsUserAgent is the regression test for the Wikimedia
+// User-Agent policy violation: DownloadAndStore built its request with no headers at
+// all, so Go sent "Go-http-client/1.1" and upload.wikimedia.org answered 403 for every
+// species, forever. This test fails without the fix.
+func TestDownloadAndStore_SendsUserAgent(t *testing.T) {
+	t.Parallel()
+
+	var gotUA string
+	cache, server := newServedCache(t, func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write([]byte{0xFF, 0xD8, 0xFF, 0xE0})
+	})
+
+	_, _, err := cache.DownloadAndStore(t.Context(), "wikimedia", "Delichon urbicum", server.URL+"/img.jpg")
+	require.NoError(t, err)
+
+	require.NotEmpty(t, gotUA, "image download must send a User-Agent")
+	assert.NotContains(t, gotUA, "Go-http-client",
+		"Go's default User-Agent is rejected with 403 by upload.wikimedia.org")
+	assert.Contains(t, gotUA, userAgentName+"/", "User-Agent must identify the client by name and version")
+	assert.Contains(t, gotUA, branding.RepoURL(), "Wikimedia policy requires contact information")
+
+	// Assert against the shared builder rather than re-spelling the string, so the API
+	// path and the image path cannot drift apart.
+	assert.Equal(t, buildUserAgent(currentAppVersion()), gotUA,
+		"image download must send the same User-Agent as the Wikipedia API path")
+}
+
+// TestDownloadAndStore_403DoesNotPopulateCache asserts the cascade described in the bug
+// report: a rejected download must leave the file cache empty, which is what makes
+// ServeSpeciesImageProxy fall through to a 302 to the external URL on every request.
+func TestDownloadAndStore_403DoesNotPopulateCache(t *testing.T) {
+	t.Parallel()
+
+	cache, server := newServedCache(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	})
+
+	_, _, err := cache.DownloadAndStore(t.Context(), "wikimedia", "Delichon urbicum", server.URL+"/img.jpg")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403")
+
+	path, contentType, fresh, getErr := cache.Get("wikimedia", "Delichon urbicum")
+	require.NoError(t, getErr, "a cache miss is not an error")
+	assert.Empty(t, path, "a failed download must not leave a cached file behind")
+	assert.Empty(t, contentType)
+	assert.False(t, fresh)
+}
+
+func TestDownloadAndStore_ErrorResponses(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		status     int
+		wantErrSub string
+	}{
+		{name: "forbidden", status: http.StatusForbidden, wantErrSub: "403"},
+		{name: "rate limited", status: http.StatusTooManyRequests, wantErrSub: "429"},
+		{name: "server error", status: http.StatusInternalServerError, wantErrSub: "500"},
+		{name: "not found", status: http.StatusNotFound, wantErrSub: "404"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cache, server := newServedCache(t, func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+			})
+
+			_, _, err := cache.DownloadAndStore(t.Context(), "wikimedia", "Parus major", server.URL+"/img.jpg")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErrSub)
+
+			path, _, _, getErr := cache.Get("wikimedia", "Parus major")
+			require.NoError(t, getErr)
+			assert.Empty(t, path, "non-200 response must not populate the cache")
+		})
+	}
+}
+
+func TestDownloadAndStore_CancelledContext(t *testing.T) {
+	t.Parallel()
+
+	released := make(chan struct{})
+	cache, server := newServedCache(t, func(w http.ResponseWriter, _ *http.Request) {
+		<-released
+		w.WriteHeader(http.StatusOK)
+	})
+	t.Cleanup(func() { close(released) })
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, _, err := cache.DownloadAndStore(ctx, "wikimedia", "Parus major", server.URL+"/img.jpg")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// TestDownloadAndStore_ContentTypes covers the extension mapping through the real
+// download path, including the empty-Content-Type case that forces the
+// http.DetectContentType sniff.
+func TestDownloadAndStore_ContentTypes(t *testing.T) {
+	t.Parallel()
+
+	const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>`
+
+	tests := []struct {
+		name            string
+		upstreamCT      string
+		body            []byte
+		wantExt         string
+		wantContentType string
+	}{
+		{
+			name:            "png",
+			upstreamCT:      "image/png",
+			body:            pngBytes,
+			wantExt:         ".png",
+			wantContentType: "image/png",
+		},
+		{
+			name:            "webp",
+			upstreamCT:      "image/webp",
+			body:            []byte("RIFF\x00\x00\x00\x00WEBPVP8 "),
+			wantExt:         ".webp",
+			wantContentType: "image/webp",
+		},
+		{
+			name:            "svg",
+			upstreamCT:      "image/svg+xml",
+			body:            []byte(svg),
+			wantExt:         ".svg",
+			wantContentType: "image/svg+xml",
+		},
+		{
+			name:            "gif",
+			upstreamCT:      "image/gif",
+			body:            []byte("GIF89a"),
+			wantExt:         ".gif",
+			wantContentType: "image/gif",
+		},
+		{
+			name: "empty content type falls back to sniffing",
+			// No Content-Type header: Store must sniff the bytes instead.
+			upstreamCT:      "",
+			body:            pngBytes,
+			wantExt:         ".png",
+			wantContentType: "image/png",
+		},
+		{
+			name:            "unknown content type defaults to jpeg",
+			upstreamCT:      "application/octet-stream",
+			body:            []byte{0xFF, 0xD8, 0xFF, 0xE0},
+			wantExt:         ".jpg",
+			wantContentType: "image/jpeg",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cache, server := newServedCache(t, func(w http.ResponseWriter, _ *http.Request) {
+				if tt.upstreamCT != "" {
+					w.Header().Set("Content-Type", tt.upstreamCT)
+				} else {
+					// Go sniffs and sets Content-Type on write unless it is suppressed.
+					w.Header()["Content-Type"] = nil
+				}
+				_, _ = w.Write(tt.body)
+			})
+
+			path, contentType, err := cache.DownloadAndStore(t.Context(), "wikimedia", "Parus major", server.URL+"/img")
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantExt, filepath.Ext(path), "cached file extension")
+			assert.Equal(t, tt.wantContentType, contentType)
+
+			stored, readErr := os.ReadFile(path)
+			require.NoError(t, readErr)
+			assert.Equal(t, tt.body, stored, "cached bytes must match what was served")
+		})
+	}
+}
+
+func TestDownloadAndStore_RejectsOversizeBody(t *testing.T) {
+	t.Parallel()
+
+	cache, server := newServedCache(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		// One byte over the cap, so the limit itself is what rejects it.
+		_, _ = w.Write(make([]byte, maxImageSize+1))
+	})
+
+	_, _, err := cache.DownloadAndStore(t.Context(), "wikimedia", "Parus major", server.URL+"/img.jpg")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum size")
+
+	path, _, _, getErr := cache.Get("wikimedia", "Parus major")
+	require.NoError(t, getErr)
+	assert.Empty(t, path, "an oversize download must not write anything to disk")
 }
 
 func TestImageFileCache_DetectsContentType(t *testing.T) {

--- a/internal/imageprovider/filecache_test.go
+++ b/internal/imageprovider/filecache_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -164,9 +165,15 @@ func newServedCache(t *testing.T, handler http.HandlerFunc) (*ImageFileCache, *h
 func TestDownloadAndStore_SendsUserAgent(t *testing.T) {
 	t.Parallel()
 
-	var gotUA string
+	// Buffered channel rather than a shared variable: the handler runs on the server's
+	// goroutine, and a channel gives the read a happens-before edge without relying on
+	// net/http incidentally providing one.
+	uaCh := make(chan string, 1)
 	cache, server := newServedCache(t, func(w http.ResponseWriter, r *http.Request) {
-		gotUA = r.Header.Get("User-Agent")
+		select {
+		case uaCh <- r.Header.Get("User-Agent"):
+		default:
+		}
 		w.Header().Set("Content-Type", "image/jpeg")
 		_, _ = w.Write([]byte{0xFF, 0xD8, 0xFF, 0xE0})
 	})
@@ -174,10 +181,16 @@ func TestDownloadAndStore_SendsUserAgent(t *testing.T) {
 	_, _, err := cache.DownloadAndStore(t.Context(), "wikimedia", "Delichon urbicum", server.URL+"/img.jpg")
 	require.NoError(t, err)
 
+	var gotUA string
+	select {
+	case gotUA = <-uaCh:
+	default:
+		t.Fatal("handler never observed a request")
+	}
 	require.NotEmpty(t, gotUA, "image download must send a User-Agent")
 	assert.NotContains(t, gotUA, "Go-http-client",
 		"Go's default User-Agent is rejected with 403 by upload.wikimedia.org")
-	assert.Contains(t, gotUA, userAgentName+"/", "User-Agent must identify the client by name and version")
+	assert.Contains(t, gotUA, userAgentName+"/", "User-Agent must carry the client name and a version token")
 	assert.Contains(t, gotUA, branding.RepoURL(), "Wikimedia policy requires contact information")
 
 	// Assert against the shared builder rather than re-spelling the string, so the API
@@ -365,10 +378,7 @@ func TestImageFileCache_DetectsContentType(t *testing.T) {
 
 	cache := NewImageFileCache(filepath.Join(t.TempDir(), "cache"))
 
-	// PNG file signature.
-	pngData := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52}
-
-	storedPath, storedCT, err := cache.Store("wikimedia", "Cyanistes caeruleus", pngData, "https://example.com/img.png", "")
+	storedPath, storedCT, err := cache.Store("wikimedia", "Cyanistes caeruleus", pngBytes, "https://example.com/img.png", "")
 	require.NoError(t, err)
 	assert.Equal(t, ".png", filepath.Ext(storedPath), "expected .png extension")
 	assert.Equal(t, "image/png", storedCT)
@@ -377,4 +387,69 @@ func TestImageFileCache_DetectsContentType(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, path)
 	assert.Equal(t, "image/png", contentType)
+}
+
+// TestDownloadAndStore_PermanentRejectionLatch asserts the escalation bookkeeping for a
+// permanent host rejection.
+//
+// Without this, deleting the logPermanentImageRejection call site entirely left the whole
+// package green: the 403 tests execute that function incidentally, so it reported 100%
+// coverage while no assertion depended on it. Coverage proves a line ran, never that a
+// regression would fail a test.
+func TestDownloadAndStore_PermanentRejectionLatch(t *testing.T) {
+	t.Parallel()
+
+	// status is switched per request so one cache can be walked through
+	// reject -> reject-again -> succeed.
+	var status atomic.Int64
+	status.Store(http.StatusForbidden)
+
+	cache, server := newServedCache(t, func(w http.ResponseWriter, _ *http.Request) {
+		code := int(status.Load())
+		if code != http.StatusOK {
+			w.WriteHeader(code)
+			return
+		}
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write([]byte{0xFF, 0xD8, 0xFF, 0xE0})
+	})
+
+	require.False(t, cache.rejectionLogged.Load(), "latch should start clear")
+
+	// A 403 latches the escalation.
+	_, _, err := cache.DownloadAndStore(t.Context(), "wikimedia", "Rejected one", server.URL+"/a.jpg")
+	require.Error(t, err)
+	assert.True(t, cache.rejectionLogged.Load(), "a 403 must latch the escalated log")
+
+	// A second rejection must not re-escalate, which is what keeps the log quiet.
+	_, _, err = cache.DownloadAndStore(t.Context(), "wikimedia", "Rejected two", server.URL+"/b.jpg")
+	require.Error(t, err)
+	assert.True(t, cache.rejectionLogged.Load(), "latch stays set while rejections continue")
+
+	// A success clears it, so a later block is visible again rather than silent forever.
+	status.Store(http.StatusOK)
+	_, _, err = cache.DownloadAndStore(t.Context(), "wikimedia", "Recovered", server.URL+"/c.jpg")
+	require.NoError(t, err)
+	assert.False(t, cache.rejectionLogged.Load(),
+		"a successful download must re-arm the escalation, mirroring resetCircuit")
+}
+
+// TestDownloadAndStore_TransientStatusDoesNotLatch asserts the escalation is reserved for
+// policy rejections, so ordinary upstream failures stay at the quiet log level.
+func TestDownloadAndStore_TransientStatusDoesNotLatch(t *testing.T) {
+	t.Parallel()
+
+	for _, status := range []int{http.StatusNotFound, http.StatusTooManyRequests, http.StatusInternalServerError} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			t.Parallel()
+			cache, server := newServedCache(t, func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(status)
+			})
+
+			_, _, err := cache.DownloadAndStore(t.Context(), "wikimedia", "Parus major", server.URL+"/img.jpg")
+			require.Error(t, err)
+			assert.False(t, cache.rejectionLogged.Load(),
+				"HTTP %d is transient and must not escalate as a permanent rejection", status)
+		})
+	}
 }

--- a/internal/imageprovider/imageprovider.go
+++ b/internal/imageprovider/imageprovider.go
@@ -72,6 +72,17 @@ type contextKey string
 // backgroundOperationKey is the context key for background operations
 const backgroundOperationKey contextKey = "background"
 
+// isBackgroundContext reports whether ctx was created by the background refresh path.
+// The key has an unexported named type, so this is the only correct way to read it:
+// context.Value compares key dynamic types, and an untyped string never matches.
+func isBackgroundContext(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	bg, ok := ctx.Value(backgroundOperationKey).(bool)
+	return ok && bg
+}
+
 // isRealError checks if an error is a genuine error (not a cache miss)
 func isRealError(err error) bool {
 	return err != nil && !errors.Is(err, ErrCacheMiss)

--- a/internal/imageprovider/imageprovider_bench_test.go
+++ b/internal/imageprovider/imageprovider_bench_test.go
@@ -3,6 +3,7 @@ package imageprovider_test
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -243,7 +244,9 @@ func BenchmarkConcurrentCacheAccess(b *testing.B) {
 // and produce numbers that depend on someone else's rate limiting. Run it with
 // BIRDNET_BENCH_LIVE=1 when measuring the limiter deliberately.
 func BenchmarkRateLimitedFetch(b *testing.B) {
-	if os.Getenv(benchLiveNetworkEnv) == "" {
+	// ParseBool, not a non-empty check: BIRDNET_BENCH_LIVE=0 is how anyone would
+	// disable a flag, and an emptiness test would have enabled it instead.
+	if live, err := strconv.ParseBool(os.Getenv(benchLiveNetworkEnv)); err != nil || !live {
 		b.Skipf("skipping live-network benchmark; set %s=1 to run it", benchLiveNetworkEnv)
 	}
 

--- a/internal/imageprovider/imageprovider_bench_test.go
+++ b/internal/imageprovider/imageprovider_bench_test.go
@@ -2,6 +2,7 @@ package imageprovider_test
 
 import (
 	"fmt"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -11,6 +12,9 @@ import (
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/observability"
 )
+
+// benchLiveNetworkEnv gates benchmarks that issue real requests to third-party APIs.
+const benchLiveNetworkEnv = "BIRDNET_BENCH_LIVE"
 
 // Benchmark scenarios:
 // 1. Cache hit performance - measuring in-memory lookup speed
@@ -232,8 +236,17 @@ func BenchmarkConcurrentCacheAccess(b *testing.B) {
 	})
 }
 
-// BenchmarkRateLimitedFetch measures the impact of rate limiting on fetch operations
+// BenchmarkRateLimitedFetch measures the impact of rate limiting on fetch operations.
+//
+// This benchmark issues real requests to the live Wikipedia API, so it is opt-in: an
+// unguarded `go test -bench=.` would otherwise hammer a third-party service from CI
+// and produce numbers that depend on someone else's rate limiting. Run it with
+// BIRDNET_BENCH_LIVE=1 when measuring the limiter deliberately.
 func BenchmarkRateLimitedFetch(b *testing.B) {
+	if os.Getenv(benchLiveNetworkEnv) == "" {
+		b.Skipf("skipping live-network benchmark; set %s=1 to run it", benchLiveNetworkEnv)
+	}
+
 	// This benchmark will use the actual Wikipedia provider to test rate limiting
 	provider, err := imageprovider.NewWikiMediaProvider()
 	if err != nil {

--- a/internal/imageprovider/imageprovider_test.go
+++ b/internal/imageprovider/imageprovider_test.go
@@ -28,10 +28,6 @@ const (
 	// backgroundFetchWaitTimeout bounds how long a test waits for the background
 	// refresh goroutine to issue its first fetch. Generous for slow CI runners.
 	backgroundFetchWaitTimeout = 10 * time.Second
-
-	// backgroundFetchSettleWindow is how long to keep collecting background fetches
-	// after the first one arrives, so the rate-limit ceiling can be asserted.
-	backgroundFetchSettleWindow = 500 * time.Millisecond
 )
 
 // mockImageProvider is a mock implementation of the ImageProvider interface
@@ -1004,44 +1000,48 @@ func populateStaleEntries(t *testing.T, store *mockStore, count int) {
 	}
 }
 
-// monitorBackgroundFetches waits for background refresh to issue fetches and asserts
-// that at least one happened and that the count stays within maxExpected.
+// awaitPacedBackgroundFetches waits for the background sweep's first two fetches and
+// asserts they are spaced by at least the configured refresh delay.
 //
 // Zero fetches is a failure, not a skip: background refresh not running at all is
-// exactly the regression this test exists to catch, and skipping on that condition
-// made the test green for the bug.
-func monitorBackgroundFetches(t *testing.T, fetchAttempts <-chan struct{}, maxExpected int) {
+// exactly the regression this helper exists to catch, and the earlier version skipped
+// on that condition, which made the test green for the bug.
+//
+// The gap is the assertion that actually pins pacing. A count ceiling does not: the
+// sweep waits refreshDelay (2s) before each entry, so within any short window the count
+// is deterministically 1 and "count <= number of stale entries" can never fail, even
+// with the pacing removed entirely.
+func awaitPacedBackgroundFetches(t *testing.T, fetchAttempts <-chan time.Time) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(t.Context(), backgroundFetchWaitTimeout)
 	defer cancel()
 
-	// The first fetch must arrive: its absence means background refresh never ran.
-	select {
-	case <-fetchAttempts:
-	case <-ctx.Done():
+	first, ok := awaitFetch(ctx, fetchAttempts)
+	if !ok {
 		t.Fatalf("no background fetch observed within %s: background refresh did not run", backgroundFetchWaitTimeout)
 	}
-	fetchCount := 1
+	second, ok := awaitFetch(ctx, fetchAttempts)
+	if !ok {
+		t.Fatalf("only one background fetch observed within %s: cannot verify pacing", backgroundFetchWaitTimeout)
+	}
 
-	// Drain any further fetches over a settle window so the rate-limit ceiling can be
-	// asserted. The refresh is rate limited, so fetches trickle in rather than burst.
-	settle := time.NewTimer(backgroundFetchSettleWindow)
-	defer settle.Stop()
-	for {
-		select {
-		case <-fetchAttempts:
-			fetchCount++
-		case <-settle.C:
-			t.Logf("Observed %d background fetch(es), ceiling %d", fetchCount, maxExpected)
-			assert.LessOrEqual(t, fetchCount, maxExpected,
-				"background refresh issued more fetches than there are stale entries")
-			return
-		case <-ctx.Done():
-			t.Logf("Observed %d background fetch(es) before timeout, ceiling %d", fetchCount, maxExpected)
-			assert.LessOrEqual(t, fetchCount, maxExpected,
-				"background refresh issued more fetches than there are stale entries")
-			return
-		}
+	gap := second.Sub(first)
+	t.Logf("Gap between the first two background fetches: %s (minimum %s)", gap, imageprovider.RefreshDelay)
+
+	// Allow a small tolerance: the sweep sleeps refreshDelay, and the timestamp is taken
+	// inside the provider, so scheduling can shave a little off the observed gap.
+	minGap := imageprovider.RefreshDelay - imageprovider.RefreshDelay/10
+	assert.GreaterOrEqual(t, gap, minGap,
+		"background refresh must pace its fetches by at least %s", imageprovider.RefreshDelay)
+}
+
+// awaitFetch returns the next fetch timestamp, or ok=false if the context expires first.
+func awaitFetch(ctx context.Context, fetchAttempts <-chan time.Time) (ts time.Time, ok bool) {
+	select {
+	case ts = <-fetchAttempts:
+		return ts, true
+	case <-ctx.Done():
+		return time.Time{}, false
 	}
 }
 
@@ -1059,7 +1059,7 @@ func TestBackgroundRequestsRateLimited(t *testing.T) {
 
 	const numStaleEntries = 5
 
-	fetchAttempts := make(chan struct{}, 2*numStaleEntries)
+	fetchAttempts := make(chan time.Time, 2*numStaleEntries)
 	mockProvider := &mockProviderWithContext{
 		mockImageProvider: mockImageProvider{fetchDelay: 5 * time.Millisecond},
 		fetchChannel:      fetchAttempts,
@@ -1076,7 +1076,7 @@ func TestBackgroundRequestsRateLimited(t *testing.T) {
 		require.NoError(t, cache.Close(), "Failed to close cache")
 	})
 
-	monitorBackgroundFetches(t, fetchAttempts, numStaleEntries)
+	awaitPacedBackgroundFetches(t, fetchAttempts)
 }
 
 // mockProviderWithContext extends mockImageProvider to support context-aware fetching
@@ -1084,7 +1084,7 @@ type mockProviderWithContext struct {
 	mockImageProvider
 	backgroundFetches int
 	mu2               sync.Mutex
-	fetchChannel      chan<- struct{}
+	fetchChannel      chan<- time.Time
 }
 
 func (m *mockProviderWithContext) FetchWithContext(ctx context.Context, scientificName string) (imageprovider.BirdImage, error) {
@@ -1098,7 +1098,7 @@ func (m *mockProviderWithContext) FetchWithContext(ctx context.Context, scientif
 			// Signal through channel if available
 			if m.fetchChannel != nil {
 				select {
-				case m.fetchChannel <- struct{}{}:
+				case m.fetchChannel <- time.Now():
 				default:
 				}
 			}

--- a/internal/imageprovider/imageprovider_test.go
+++ b/internal/imageprovider/imageprovider_test.go
@@ -24,6 +24,16 @@ import (
 	"gorm.io/gorm"
 )
 
+const (
+	// backgroundFetchWaitTimeout bounds how long a test waits for the background
+	// refresh goroutine to issue its first fetch. Generous for slow CI runners.
+	backgroundFetchWaitTimeout = 10 * time.Second
+
+	// backgroundFetchSettleWindow is how long to keep collecting background fetches
+	// after the first one arrives, so the rate-limit ceiling can be asserted.
+	backgroundFetchSettleWindow = 500 * time.Millisecond
+)
+
 // mockImageProvider is a mock implementation of the ImageProvider interface
 type mockImageProvider struct {
 	fetchCounter int
@@ -31,6 +41,14 @@ type mockImageProvider struct {
 	fetchDelay   time.Duration
 	mu           sync.Mutex
 	lastURL      string // Track last generated URL for consistency
+}
+
+// getFetchCount returns the number of Fetch calls under the mock's lock, so tests
+// can read it from a background refresh goroutine without racing.
+func (m *mockImageProvider) getFetchCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.fetchCounter
 }
 
 func (m *mockImageProvider) Fetch(scientificName string) (imageprovider.BirdImage, error) {
@@ -483,16 +501,25 @@ func (m *mockFailingStore) GetSpeciesFirstDetectionInPeriod(ctx context.Context,
 
 // verifyCacheEntry validates that an image was cached correctly in the store.
 // Note: CreateDefaultCache uses "wikimedia" as the provider name.
+//
+// The entry must exist. Treating "not cached yet" as acceptable made this helper
+// vacuous: a total saveToDB breakage would return ErrImageCacheNotFound for every
+// species and every caller would still pass. saveToDB is asynchronous, so the
+// lookup is retried briefly rather than checked once.
 func verifyCacheEntry(t *testing.T, store *mockStore, scientificName, expectedURL string) {
 	t.Helper()
-	cached, err := store.GetImageCache(datastore.ImageCacheQuery{ScientificName: scientificName, ProviderName: "wikimedia"})
-	if errors.Is(err, datastore.ErrImageCacheNotFound) {
-		return // Not cached yet is acceptable
-	}
-	require.NoError(t, err, "Failed to get cached image")
-	if cached != nil {
-		assert.Equal(t, expectedURL, cached.URL, "Cached URL mismatch")
-	}
+
+	var cached *datastore.ImageCache
+	require.Eventuallyf(t, func() bool {
+		entry, err := store.GetImageCache(datastore.ImageCacheQuery{ScientificName: scientificName, ProviderName: "wikimedia"})
+		if err != nil || entry == nil {
+			return false
+		}
+		cached = entry
+		return true
+	}, 2*time.Second, 10*time.Millisecond, "image for %q was never written to the DB cache", scientificName)
+
+	assert.Equal(t, expectedURL, cached.URL, "Cached URL mismatch")
 }
 
 // TestBirdImageCache tests the BirdImageCache implementation
@@ -977,41 +1004,62 @@ func populateStaleEntries(t *testing.T, store *mockStore, count int) {
 	}
 }
 
-// monitorBackgroundFetches collects fetch attempts and returns when enough are detected or timeout.
+// monitorBackgroundFetches waits for background refresh to issue fetches and asserts
+// that at least one happened and that the count stays within maxExpected.
+//
+// Zero fetches is a failure, not a skip: background refresh not running at all is
+// exactly the regression this test exists to catch, and skipping on that condition
+// made the test green for the bug.
 func monitorBackgroundFetches(t *testing.T, fetchAttempts <-chan struct{}, maxExpected int) {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), backgroundFetchWaitTimeout)
 	defer cancel()
 
-	fetchCount := 0
-	ticker := time.NewTicker(100 * time.Millisecond)
-	defer ticker.Stop()
+	// The first fetch must arrive: its absence means background refresh never ran.
+	select {
+	case <-fetchAttempts:
+	case <-ctx.Done():
+		t.Fatalf("no background fetch observed within %s: background refresh did not run", backgroundFetchWaitTimeout)
+	}
+	fetchCount := 1
 
+	// Drain any further fetches over a settle window so the rate-limit ceiling can be
+	// asserted. The refresh is rate limited, so fetches trickle in rather than burst.
+	settle := time.NewTimer(backgroundFetchSettleWindow)
+	defer settle.Stop()
 	for {
 		select {
 		case <-fetchAttempts:
 			fetchCount++
-			t.Logf("Background fetch attempt %d detected", fetchCount)
-		case <-ticker.C:
-			if fetchCount > 0 && fetchCount <= maxExpected {
-				t.Logf("Background fetches completed: %d (expected <= %d)", fetchCount, maxExpected)
-				return
-			}
+		case <-settle.C:
+			t.Logf("Observed %d background fetch(es), ceiling %d", fetchCount, maxExpected)
+			assert.LessOrEqual(t, fetchCount, maxExpected,
+				"background refresh issued more fetches than there are stale entries")
+			return
 		case <-ctx.Done():
-			if fetchCount == 0 {
-				t.Skip("No background fetches detected - background refresh might not have started")
-			}
-			t.Logf("Test completed with %d background fetches", fetchCount)
+			t.Logf("Observed %d background fetch(es) before timeout, ceiling %d", fetchCount, maxExpected)
+			assert.LessOrEqual(t, fetchCount, maxExpected,
+				"background refresh issued more fetches than there are stale entries")
 			return
 		}
 	}
 }
 
-// TestBackgroundRequestsRateLimited tests that background requests are subject to rate limiting
+// TestBackgroundRequestsRateLimited tests that background requests are subject to rate limiting.
+//
+// Ordering here is load-bearing. refreshInterval is one hour, so the only prompt sweep
+// is the immediate one startCacheRefresh runs at construction. The previous version
+// created the cache first and populated the stale entries afterwards, so that sweep
+// almost always read an empty store and no background fetch ever happened; the test
+// only passed by winning a race. The store is now seeded first, and the provider is
+// passed to InitCache rather than attached afterwards with SetImageProvider, so the
+// sweep cannot start before the provider exists.
 func TestBackgroundRequestsRateLimited(t *testing.T) {
 	t.Parallel()
 
-	fetchAttempts := make(chan struct{}, 10)
+	const numStaleEntries = 5
+
+	fetchAttempts := make(chan struct{}, 2*numStaleEntries)
 	mockProvider := &mockProviderWithContext{
 		mockImageProvider: mockImageProvider{fetchDelay: 5 * time.Millisecond},
 		fetchChannel:      fetchAttempts,
@@ -1021,15 +1069,13 @@ func TestBackgroundRequestsRateLimited(t *testing.T) {
 	metrics, err := observability.NewMetrics()
 	require.NoError(t, err, "Failed to create metrics")
 
-	cache, err := imageprovider.CreateDefaultCache(metrics, store)
-	require.NoError(t, err, "Failed to create default cache")
-	cache.SetImageProvider(mockProvider)
+	populateStaleEntries(t, store, numStaleEntries)
+
+	cache := imageprovider.InitCache("wikimedia", mockProvider, metrics, store)
 	t.Cleanup(func() {
 		require.NoError(t, cache.Close(), "Failed to close cache")
 	})
 
-	numStaleEntries := 5
-	populateStaleEntries(t, store, numStaleEntries)
 	monitorBackgroundFetches(t, fetchAttempts, numStaleEntries)
 }
 
@@ -1044,7 +1090,7 @@ type mockProviderWithContext struct {
 func (m *mockProviderWithContext) FetchWithContext(ctx context.Context, scientificName string) (imageprovider.BirdImage, error) {
 	// Check if it's a background operation
 	if ctx != nil {
-		if bg, ok := ctx.Value("background").(bool); ok && bg {
+		if imageprovider.IsBackgroundContext(ctx) {
 			m.mu2.Lock()
 			m.backgroundFetches++
 			m.mu2.Unlock()
@@ -1069,8 +1115,8 @@ func TestMain(m *testing.M) {
 		goleak.IgnoreTopFunction("testing.(*T).Run"),
 		goleak.IgnoreTopFunction("runtime.gopark"),
 		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
-		// Ignore the cache refresh goroutine pattern - it should be properly cleaned up by Close()
-		goleak.IgnoreTopFunction("github.com/tphakala/birdnet-go/internal/imageprovider.(*BirdImageCache).startCacheRefresh.func1"),
+		// NOTE: startCacheRefresh.func1 is deliberately NOT ignored. Close() stops it, so
+		// ignoring it hid every test that constructed a cache and never closed it.
 		// Ignore HTTP/2 client connection goroutines from the shared imageHTTPClient
 		goleak.IgnoreAnyFunction("net/http.(*http2clientConnReadLoop).run"),
 	)

--- a/internal/imageprovider/negative_cache_test.go
+++ b/internal/imageprovider/negative_cache_test.go
@@ -65,11 +65,18 @@ func TestNegativeCachingBehavior(t *testing.T) {
 
 	t.Run("NegativeCacheExpiry", func(t *testing.T) {
 		t.Parallel()
-		// A negative entry older than the 15-minute negative TTL must be re-queried
-		// rather than served from cache. The previous version of this subtest was named
-		// for expiry, exercised none of it, and ended in a t.Logf with no assertion:
-		// it would have passed with negativeCacheTTL set to ten years.
-		const species = "Expiredbird species"
+		// A negative entry older than the negative TTL must be re-queried rather than
+		// served from cache.
+		//
+		// The seed age below is a reviewed literal, deliberately NOT derived from
+		// NegativeCacheTTL. Deriving it (e.g. -2 * NegativeCacheTTL) makes the test
+		// self-referential: raising the constant moves the seed with it and the test
+		// keeps passing, so it cannot detect a wrong TTL. The companion assertion in
+		// TestNegativeCacheTTLValue pins the constant itself.
+		const (
+			species         = "Expiredbird species"
+			expiredEntryAge = 30 * time.Minute
+		)
 
 		mockProvider := &mockProviderWithNotFound{notFoundSpecies: map[string]bool{species: true}}
 		mockStore := newMockStore()
@@ -81,7 +88,7 @@ func TestNegativeCachingBehavior(t *testing.T) {
 			ScientificName: species,
 			ProviderName:   "wikimedia",
 			URL:            imageprovider.NegativeEntryMarker,
-			CachedAt:       time.Now().Add(-2 * imageprovider.NegativeCacheTTL),
+			CachedAt:       time.Now().Add(-expiredEntryAge),
 		}), "Failed to seed expired negative cache entry")
 
 		cache, err := imageprovider.CreateDefaultCache(metrics, mockStore)
@@ -155,7 +162,7 @@ func TestNegativeCachePersistence(t *testing.T) {
 	dbEntries := mockStore.GetAllTestEntries()
 	foundNegative := false
 	for _, entry := range dbEntries {
-		if entry.ScientificName == species && entry.URL == "__NOT_FOUND__" {
+		if entry.ScientificName == species && entry.URL == imageprovider.NegativeEntryMarker {
 			foundNegative = true
 			t.Logf("Found negative cache entry in DB: %+v", entry)
 			break
@@ -236,4 +243,16 @@ func (m *mockProviderWithTransientError) Fetch(scientificName string) (imageprov
 
 func (m *mockProviderWithTransientError) getAPICallCount() int64 {
 	return atomic.LoadInt64(&m.apiCallCount)
+}
+
+// TestNegativeCacheTTLValue pins the negative-cache TTL.
+//
+// TestNegativeCachingBehavior/NegativeCacheExpiry exercises the expiry BEHAVIOUR with a
+// literal seed age, which deliberately cannot detect a change to the constant. This
+// asserts the value, so the two together catch both a broken staleness check and a
+// wrong TTL. Mirrors TestCircuitBreakerNetworkDuration in network_failure_test.go.
+func TestNegativeCacheTTLValue(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, 15*time.Minute, imageprovider.NegativeCacheTTL,
+		"negative cache TTL changed; confirm the expiry seed age in NegativeCacheExpiry still exceeds it")
 }

--- a/internal/imageprovider/negative_cache_test.go
+++ b/internal/imageprovider/negative_cache_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/observability"
@@ -25,6 +26,9 @@ func setupNegativeCacheTest(t *testing.T, notFoundSpecies map[string]bool) (*moc
 	cache, err := imageprovider.CreateDefaultCache(metrics, mockStore)
 	require.NoError(t, err, "Failed to create cache")
 	cache.SetImageProvider(mockProvider)
+	t.Cleanup(func() {
+		assert.NoError(t, cache.Close(), "Failed to close cache")
+	})
 
 	return mockProvider, cache
 }
@@ -61,18 +65,41 @@ func TestNegativeCachingBehavior(t *testing.T) {
 
 	t.Run("NegativeCacheExpiry", func(t *testing.T) {
 		t.Parallel()
-		mockProvider, cache := setupNegativeCacheTest(t, map[string]bool{"Missingbird species": true})
-		species := "Missingbird species"
+		// A negative entry older than the 15-minute negative TTL must be re-queried
+		// rather than served from cache. The previous version of this subtest was named
+		// for expiry, exercised none of it, and ended in a t.Logf with no assertion:
+		// it would have passed with negativeCacheTTL set to ten years.
+		const species = "Expiredbird species"
 
-		// First request
-		_, err := cache.Get(species)
-		assertImageNotFoundError(t, err, "first request")
+		mockProvider := &mockProviderWithNotFound{notFoundSpecies: map[string]bool{species: true}}
+		mockStore := newMockStore()
+		metrics, err := observability.NewMetrics()
+		require.NoError(t, err, "Failed to create metrics")
 
-		// Immediate second request should use cache
+		// Seed an already-expired negative entry, as a restart would load from the DB.
+		require.NoError(t, mockStore.SaveImageCache(&datastore.ImageCache{
+			ScientificName: species,
+			ProviderName:   "wikimedia",
+			URL:            imageprovider.NegativeEntryMarker,
+			CachedAt:       time.Now().Add(-2 * imageprovider.NegativeCacheTTL),
+		}), "Failed to seed expired negative cache entry")
+
+		cache, err := imageprovider.CreateDefaultCache(metrics, mockStore)
+		require.NoError(t, err, "Failed to create cache")
+		cache.SetImageProvider(mockProvider)
+		t.Cleanup(func() { assert.NoError(t, cache.Close(), "Failed to close cache") })
+
+		// The expired negative entry must not be served: the provider is consulted again.
 		_, err = cache.Get(species)
-		assertImageNotFoundError(t, err, "cached request")
+		assertImageNotFoundError(t, err, "request against expired negative entry")
+		assert.Equal(t, int64(1), mockProvider.getAPICallCount(),
+			"expired negative entry must be re-queried, not served from cache")
 
-		t.Logf("Negative cache confirmed: %d API call(s) for multiple requests", mockProvider.getAPICallCount())
+		// The fresh negative entry written by that lookup is now honoured.
+		_, err = cache.Get(species)
+		assertImageNotFoundError(t, err, "request against refreshed negative entry")
+		assert.Equal(t, int64(1), mockProvider.getAPICallCount(),
+			"fresh negative entry must be served from cache without a second provider call")
 	})
 
 	t.Run("TransientErrorsNotCached", func(t *testing.T) {
@@ -85,6 +112,7 @@ func TestNegativeCachingBehavior(t *testing.T) {
 		cache, err := imageprovider.CreateDefaultCache(metrics, mockStore)
 		require.NoError(t, err, "Failed to create cache")
 		cache.SetImageProvider(errorProvider)
+		t.Cleanup(func() { assert.NoError(t, cache.Close(), "Failed to close cache") })
 
 		species := "Any species"
 
@@ -116,6 +144,7 @@ func TestNegativeCachePersistence(t *testing.T) {
 	cache1, err := imageprovider.CreateDefaultCache(metrics, mockStore)
 	require.NoError(t, err, "Failed to create cache")
 	cache1.SetImageProvider(mockProvider)
+	t.Cleanup(func() { assert.NoError(t, cache1.Close(), "Failed to close first cache") })
 
 	// Get a not-found species
 	species := "Persisticus negative"
@@ -139,6 +168,7 @@ func TestNegativeCachePersistence(t *testing.T) {
 	cache2, err := imageprovider.CreateDefaultCache(metrics, mockStore)
 	require.NoError(t, err, "Failed to create second cache")
 	cache2.SetImageProvider(mockProvider)
+	t.Cleanup(func() { assert.NoError(t, cache2.Close(), "Failed to close second cache") })
 
 	mockProvider.resetCounters()
 
@@ -146,10 +176,10 @@ func TestNegativeCachePersistence(t *testing.T) {
 	_, err = cache2.Get(species)
 	require.ErrorIs(t, err, imageprovider.ErrImageNotFound, "Expected ErrImageNotFound from cached negative entry")
 
-	// Check API calls - if negative cache was loaded from DB, should be 0
-	// (Unless the 15-minute TTL expired, which is unlikely in test)
-	apiCalls := mockProvider.getAPICallCount()
-	t.Logf("API calls after restart: %d (0 means negative cache was loaded from DB)", apiCalls)
+	// The negative entry was written moments ago, so it is well inside the negative
+	// TTL and the fresh cache must serve it from the DB without touching the provider.
+	assert.Equal(t, int64(0), mockProvider.getAPICallCount(),
+		"negative cache entry was not loaded from the DB after restart")
 }
 
 // mockProviderWithNotFound returns not found for specific species

--- a/internal/imageprovider/network_failure_test.go
+++ b/internal/imageprovider/network_failure_test.go
@@ -262,3 +262,45 @@ func TestCircuitBreakerNetworkDuration(t *testing.T) {
 	assert.Equal(t, 2*time.Minute, circuitBreakerNetworkDuration,
 		"network circuit breaker duration should be 2 minutes")
 }
+
+// TestQueryWithNonPositiveMaxRetriesReturnsError covers the guard added for a
+// non-positive maxRetries.
+//
+// Without it the loop body never runs, lastErr stays nil, and the post-loop error
+// construction dereferences it: buildRetryExhaustedError calls lastErr.Error() and
+// logAPIError does the same, so the call panics rather than returning. Production always
+// sets defaultMaxRetries, but the provider is a plain struct that tests construct
+// directly, so a zero value is one forgotten field away.
+func TestQueryWithNonPositiveMaxRetriesReturnsError(t *testing.T) {
+	t.Parallel()
+
+	for _, maxRetries := range []int{0, -1} {
+		t.Run(fmt.Sprintf("maxRetries=%d", maxRetries), func(t *testing.T) {
+			t.Parallel()
+
+			rt := &statusRoundTripper{status: http.StatusOK}
+			provider := &wikiMediaProvider{
+				httpClient:    &http.Client{Transport: rt},
+				userAgent:     buildUserAgent("test"),
+				maxRetries:    maxRetries,
+				globalLimiter: rate.NewLimiter(rate.Inf, 1),
+			}
+
+			// require.NotPanics is the assertion that matters: the pre-guard code
+			// panicked here rather than returning.
+			var (
+				resp *wikiAPIResponse
+				err  error
+			)
+			require.NotPanics(t, func() {
+				resp, err = provider.queryWithRetryAndLimiter(t.Context(), "test-maxretries",
+					map[string]string{"action": "query", "titles": "Parus major"}, nil)
+			})
+
+			require.Error(t, err, "a non-positive maxRetries must be reported, not silently ignored")
+			assert.Nil(t, resp)
+			assert.Contains(t, err.Error(), "maxRetries")
+			assert.Zero(t, rt.calls.Load(), "no request should be attempted with a non-positive retry count")
+		})
+	}
+}

--- a/internal/imageprovider/network_failure_test.go
+++ b/internal/imageprovider/network_failure_test.go
@@ -114,8 +114,7 @@ func (rt *dnsFailureRoundTripper) RoundTrip(req *http.Request) (*http.Response, 
 func TestNetworkErrorOpensCircuitBreaker(t *testing.T) {
 	t.Parallel()
 
-	// synctest makes the retry backoff (retryMinDelay, 2s) virtual, so the test is
-	// instant rather than waiting out a real sleep.
+	// synctest bubbles the clock so any backoff is virtual and the test stays instant.
 	synctest.Test(t, func(t *testing.T) {
 		rt := &dnsFailureRoundTripper{}
 		provider := &wikiMediaProvider{
@@ -143,31 +142,21 @@ func TestNetworkErrorOpensCircuitBreaker(t *testing.T) {
 // statusRoundTripper answers every request with a fixed status and counts the calls.
 type statusRoundTripper struct {
 	status int
-	body   string
 	calls  atomic.Int64
 }
 
 func (rt *statusRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	rt.calls.Add(1)
-	body := rt.body
-	if body == "" {
-		body = "{}"
-	}
 	return &http.Response{
 		StatusCode: rt.status,
-		Body:       io.NopCloser(strings.NewReader(body)),
+		Body:       io.NopCloser(strings.NewReader("{}")),
 		Header:     http.Header{"Content-Type": []string{"application/json"}},
 		Request:    req,
 	}, nil
 }
 
 // TestRateLimitStopsFurtherAttempts asserts that a 429 which opens the circuit breaker
-// also stops the retry loop.
-//
-// The breaker was checked once BEFORE the loop and never again, so a 429 on attempt 1
-// opened the circuit and attempts 2 and 3 were still sent. That tripled outbound volume
-// at precisely the moment Wikimedia was asking for less, which is the traffic profile
-// that gets a User-Agent blocked. Fails without the in-loop re-check.
+// stops the retry loop immediately, spending neither another request nor a backoff.
 func TestRateLimitStopsFurtherAttempts(t *testing.T) {
 	t.Parallel()
 
@@ -180,8 +169,10 @@ func TestRateLimitStopsFurtherAttempts(t *testing.T) {
 			globalLimiter: rate.NewLimiter(rate.Inf, 1),
 		}
 
+		start := time.Now()
 		_, err := provider.queryWithRetryAndLimiter(t.Context(), "test-429",
 			map[string]string{"action": "query", "titles": "Parus major"}, nil)
+		elapsed := time.Since(start)
 		require.Error(t, err)
 
 		open, _ := provider.isCircuitOpen()
@@ -189,6 +180,18 @@ func TestRateLimitStopsFurtherAttempts(t *testing.T) {
 
 		assert.Equal(t, int64(1), rt.calls.Load(),
 			"once the 429 opened the circuit, no further request should have been sent")
+
+		// Bailing out must also skip the backoff that precedes the abandoned attempt.
+		// Checking the breaker only at the top of the next iteration still burned
+		// calculateRetryDelay(0) first, which this pins.
+		assert.Zero(t, elapsed,
+			"no backoff should be paid once the circuit is open")
+
+		// The invariant the whole design rests on: a transient breaker error must never
+		// be mistaken for a permanent "no image exists" and persisted as a negative
+		// cache entry. Without this, a rate-limit episode could blank species for ~10y.
+		require.NotErrorIs(t, err, ErrImageNotFound,
+			"a circuit-breaker error must never be classified as image-not-found")
 	})
 }
 
@@ -196,8 +199,8 @@ func TestRateLimitStopsFurtherAttempts(t *testing.T) {
 // last attempt fails, instead of sleeping a backoff it will never use.
 //
 // The loop slept calculateRetryDelay(attempt) unconditionally, so an exhausted fetch
-// held its caller for an extra retryMinDelay after the final attempt for nothing. With
-// synctest the virtual clock makes that wasted sleep directly observable.
+// held its caller a further calculateRetryDelay(maxRetries-1) with nothing left to wait
+// for. synctest makes that wasted sleep directly observable as virtual time.
 func TestRetryLoopDoesNotBackOffAfterFinalAttempt(t *testing.T) {
 	t.Parallel()
 
@@ -222,9 +225,12 @@ func TestRetryLoopDoesNotBackOffAfterFinalAttempt(t *testing.T) {
 
 		// Backoff runs only BETWEEN attempts: delays for attempts 0 and 1, none after
 		// attempt 2. Sleeping after the final attempt would add calculateRetryDelay(2).
-		wantMax := calculateRetryDelay(0) + calculateRetryDelay(1)
-		assert.LessOrEqual(t, elapsed, wantMax,
-			"the loop must not back off after the final attempt (extra wait would be %s)",
+		// Exact, not LessOrEqual: the virtual clock makes this deterministic, and a
+		// one-sided bound also passes at elapsed == 0, so it would stay green if the
+		// between-attempt backoff were removed entirely.
+		wantTotal := calculateRetryDelay(0) + calculateRetryDelay(1)
+		assert.Equal(t, wantTotal, elapsed,
+			"backoff must run between attempts only (a trailing sleep would add %s)",
 			calculateRetryDelay(2))
 	})
 }

--- a/internal/imageprovider/network_failure_test.go
+++ b/internal/imageprovider/network_failure_test.go
@@ -3,10 +3,15 @@ package imageprovider
 import (
 	"fmt"
 	"net"
+	"net/http"
+	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
 )
 
 // TestIsNetworkError tests detection of DNS and network-level errors.
@@ -81,51 +86,76 @@ func TestIsNetworkError(t *testing.T) {
 	}
 }
 
-// TestNetworkErrorOpensCircuitBreaker tests that network/DNS failures open the circuit breaker.
+// dnsFailureRoundTripper fails every request with a DNS resolution error without
+// touching the network, so the production retry-and-circuit-breaker path can be
+// driven end to end in a unit test.
+type dnsFailureRoundTripper struct {
+	calls atomic.Int64
+}
+
+func (rt *dnsFailureRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.calls.Add(1)
+	return nil, &net.OpError{
+		Op:  "dial",
+		Net: "tcp",
+		Err: &net.DNSError{Err: "server misbehaving", Name: req.URL.Hostname()},
+	}
+}
+
+// TestNetworkErrorOpensCircuitBreaker tests that network/DNS failures open the circuit
+// breaker through the real request path.
+//
+// The previous version called provider.openCircuit itself and then asserted the circuit
+// was open, which only proved that a setter sets. It would have stayed green if
+// queryWithRetryAndLimiter stopped calling openCircuit altogether. This drives the
+// production retry loop with a failing transport instead.
 func TestNetworkErrorOpensCircuitBreaker(t *testing.T) {
 	t.Parallel()
 
-	provider := &wikiMediaProvider{
-		maxRetries: 1,
-	}
+	// synctest makes the retry backoff (retryMinDelay, 2s) virtual, so the test is
+	// instant rather than waiting out a real sleep.
+	synctest.Test(t, func(t *testing.T) {
+		rt := &dnsFailureRoundTripper{}
+		provider := &wikiMediaProvider{
+			httpClient:    &http.Client{Transport: rt},
+			userAgent:     buildUserAgent("test"),
+			maxRetries:    1,
+			globalLimiter: rate.NewLimiter(rate.Inf, 1),
+		}
 
-	// Verify circuit is initially closed
-	open, _ := provider.isCircuitOpen()
-	assert.False(t, open, "circuit should start closed")
+		open, _ := provider.isCircuitOpen()
+		require.False(t, open, "circuit should start closed")
 
-	// Simulate a DNS error triggering circuit open
-	dnsErr := &net.DNSError{
-		Err:  "server misbehaving",
-		Name: "en.wikipedia.org",
-	}
-	provider.openCircuit(circuitBreakerNetworkDuration,
-		fmt.Sprintf("Network/DNS failure: %s", dnsErr.Error()))
+		_, err := provider.queryWithRetryAndLimiter(t.Context(), "test-req-1",
+			map[string]string{"action": "query", "titles": "Parus major"}, nil)
+		require.Error(t, err, "a failing transport must surface an error")
+		assert.Positive(t, rt.calls.Load(), "the production path should have attempted the request")
 
-	// Verify circuit is now open
-	open, reason := provider.isCircuitOpen()
-	assert.True(t, open, "circuit should be open after network error")
-	assert.Contains(t, reason, "Network/DNS failure", "reason should mention network failure")
-	assert.Contains(t, reason, "server misbehaving", "reason should contain original error")
+		open, reason := provider.isCircuitOpen()
+		assert.True(t, open, "circuit should be open after the retry loop exhausts on a network error")
+		assert.Contains(t, reason, "Network/DNS failure", "reason should mention network failure")
+		assert.Contains(t, reason, "server misbehaving", "reason should contain original error")
+	})
 }
 
-// TestNetworkErrorLogDowngrade tests that repeated network errors are downgraded to debug level.
-func TestNetworkErrorLogDowngrade(t *testing.T) {
+// TestResetCircuitReenablesErrorLevelLogging tests that circuit recovery clears the
+// latch that downgrades repeated network-error logs to Debug.
+//
+// The previous TestNetworkErrorLogDowngrade asserted the first two CompareAndSwap
+// results directly, which only restated sync/atomic.Bool semantics. Only the
+// resetCircuit behaviour below belongs to this package.
+func TestResetCircuitReenablesErrorLevelLogging(t *testing.T) {
 	t.Parallel()
 
 	provider := &wikiMediaProvider{}
 
-	// First call: CompareAndSwap(false, true) should succeed
-	swapped := provider.networkErrorLogged.CompareAndSwap(false, true)
-	assert.True(t, swapped, "first network error should log at Error level")
+	// Latch the flag as the first logged network error would.
+	require.True(t, provider.networkErrorLogged.CompareAndSwap(false, true))
 
-	// Second call: CompareAndSwap(false, true) should fail (already true)
-	swapped = provider.networkErrorLogged.CompareAndSwap(false, true)
-	assert.False(t, swapped, "repeated network error should be downgraded to Debug level")
-
-	// Reset on circuit recovery
 	provider.resetCircuit()
-	swapped = provider.networkErrorLogged.CompareAndSwap(false, true)
-	assert.True(t, swapped, "after circuit reset, first error should log at Error level again")
+
+	assert.True(t, provider.networkErrorLogged.CompareAndSwap(false, true),
+		"resetCircuit must clear the log-downgrade latch so recovery is visible at Error level")
 }
 
 // TestCircuitBreakerNetworkDuration tests the constant value is reasonable.

--- a/internal/imageprovider/network_failure_test.go
+++ b/internal/imageprovider/network_failure_test.go
@@ -2,8 +2,10 @@ package imageprovider
 
 import (
 	"fmt"
+	"io"
 	"net"
 	"net/http"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"testing/synctest"
@@ -135,6 +137,95 @@ func TestNetworkErrorOpensCircuitBreaker(t *testing.T) {
 		assert.True(t, open, "circuit should be open after the retry loop exhausts on a network error")
 		assert.Contains(t, reason, "Network/DNS failure", "reason should mention network failure")
 		assert.Contains(t, reason, "server misbehaving", "reason should contain original error")
+	})
+}
+
+// statusRoundTripper answers every request with a fixed status and counts the calls.
+type statusRoundTripper struct {
+	status int
+	body   string
+	calls  atomic.Int64
+}
+
+func (rt *statusRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.calls.Add(1)
+	body := rt.body
+	if body == "" {
+		body = "{}"
+	}
+	return &http.Response{
+		StatusCode: rt.status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Request:    req,
+	}, nil
+}
+
+// TestRateLimitStopsFurtherAttempts asserts that a 429 which opens the circuit breaker
+// also stops the retry loop.
+//
+// The breaker was checked once BEFORE the loop and never again, so a 429 on attempt 1
+// opened the circuit and attempts 2 and 3 were still sent. That tripled outbound volume
+// at precisely the moment Wikimedia was asking for less, which is the traffic profile
+// that gets a User-Agent blocked. Fails without the in-loop re-check.
+func TestRateLimitStopsFurtherAttempts(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		rt := &statusRoundTripper{status: http.StatusTooManyRequests}
+		provider := &wikiMediaProvider{
+			httpClient:    &http.Client{Transport: rt},
+			userAgent:     buildUserAgent("test"),
+			maxRetries:    3,
+			globalLimiter: rate.NewLimiter(rate.Inf, 1),
+		}
+
+		_, err := provider.queryWithRetryAndLimiter(t.Context(), "test-429",
+			map[string]string{"action": "query", "titles": "Parus major"}, nil)
+		require.Error(t, err)
+
+		open, _ := provider.isCircuitOpen()
+		require.True(t, open, "a 429 should open the circuit breaker")
+
+		assert.Equal(t, int64(1), rt.calls.Load(),
+			"once the 429 opened the circuit, no further request should have been sent")
+	})
+}
+
+// TestRetryLoopDoesNotBackOffAfterFinalAttempt asserts the loop stops as soon as the
+// last attempt fails, instead of sleeping a backoff it will never use.
+//
+// The loop slept calculateRetryDelay(attempt) unconditionally, so an exhausted fetch
+// held its caller for an extra retryMinDelay after the final attempt for nothing. With
+// synctest the virtual clock makes that wasted sleep directly observable.
+func TestRetryLoopDoesNotBackOffAfterFinalAttempt(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		// 500 is retryable and does not open the circuit, so all attempts run and the
+		// only thing under test is the trailing sleep.
+		rt := &statusRoundTripper{status: http.StatusInternalServerError}
+		provider := &wikiMediaProvider{
+			httpClient:    &http.Client{Transport: rt},
+			userAgent:     buildUserAgent("test"),
+			maxRetries:    3,
+			globalLimiter: rate.NewLimiter(rate.Inf, 1),
+		}
+
+		start := time.Now()
+		_, err := provider.queryWithRetryAndLimiter(t.Context(), "test-500",
+			map[string]string{"action": "query", "titles": "Parus major"}, nil)
+		elapsed := time.Since(start)
+		require.Error(t, err)
+
+		require.Equal(t, int64(3), rt.calls.Load(), "all three attempts should have been made")
+
+		// Backoff runs only BETWEEN attempts: delays for attempts 0 and 1, none after
+		// attempt 2. Sleeping after the final attempt would add calculateRetryDelay(2).
+		wantMax := calculateRetryDelay(0) + calculateRetryDelay(1)
+		assert.LessOrEqual(t, elapsed, wantMax,
+			"the loop must not back off after the final attempt (extra wait would be %s)",
+			calculateRetryDelay(2))
 	})
 }
 

--- a/internal/imageprovider/provider_policy_test.go
+++ b/internal/imageprovider/provider_policy_test.go
@@ -316,7 +316,7 @@ func TestRefreshEntryFallbackPolicyNone(t *testing.T) {
 	// was not used" becomes a meaningful assertion rather than a race.
 	require.Eventually(t, func() bool {
 		return primaryProvider.getFetchCount() > 0
-	}, 10*time.Second, 20*time.Millisecond, "background refresh never reached the primary provider")
+	}, backgroundFetchWaitTimeout, 20*time.Millisecond, "background refresh never reached the primary provider")
 
 	// After refresh with policy "none", primary cache must NOT have the wikimedia image.
 	// The assertion is unconditional: previously it sat inside `if err == nil`, so any

--- a/internal/imageprovider/provider_policy_test.go
+++ b/internal/imageprovider/provider_policy_test.go
@@ -1,6 +1,7 @@
 package imageprovider_test
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -120,24 +121,25 @@ func TestFallbackPolicyEnforcement(t *testing.T) {
 			primaryCache.SetRegistry(registry)
 
 			// Test Get method
-			_, err := primaryCache.Get("Parus major")
+			img, err := primaryCache.Get("Parus major")
 
+			// Whether the fallback provider was actually consulted is the user-visible
+			// symptom (a thumbnail appears or it does not). Asserting only on the
+			// returned error let a policy that silently skipped fallback pass, and the
+			// "all" branch was vacuous: err == nil || isImageNotFoundError(err) is
+			// satisfied by nearly any outcome.
 			if tt.expectFallback {
-				// With fallback enabled, the primary provider fails but fallback should work
-				// So we should get a result (no error or specific not found error)
-				assert.True(t, err == nil || isImageNotFoundError(err),
-					"Expected success or not found error with fallback enabled, got: %v", err)
+				require.NoError(t, err, "fallback provider should have satisfied the request")
+				assert.Equal(t, 1, fallbackProvider.getFetchCount(),
+					"fallback provider must be consulted when policy is %q", tt.fallbackPolicy)
+				assert.NotEmpty(t, img.URL, "fallback should have produced an image URL")
 			} else {
-				// Without fallback, we should get an error from the primary provider
-				assert.Error(t, err, "Expected error when primary provider fails and fallback is disabled")
+				require.Error(t, err, "Expected error when primary provider fails and fallback is disabled")
+				assert.Equal(t, 0, fallbackProvider.getFetchCount(),
+					"fallback provider must NOT be consulted when policy is %q", tt.fallbackPolicy)
 			}
 		})
 	}
-}
-
-// isImageNotFoundError checks if an error is an image not found error
-func isImageNotFoundError(err error) bool {
-	return err != nil && err.Error() == "image not found by provider"
 }
 
 // mockStoreWithTracking extends mockStore to track which providers had their DB
@@ -308,24 +310,41 @@ func TestRefreshEntryFallbackPolicyNone(t *testing.T) {
 	_, err := primaryCache.Get(species)
 	require.NoError(t, err)
 
-	// Wait for background refresh goroutine to complete. Since policy is "none",
-	// no observable state change occurs (no fallback, no DB update), so we must
-	// use a fixed wait. 2s is generous for CI where the goroutine does minimal work.
-	time.Sleep(2 * time.Second)
+	// Wait for the background refresh to actually consult the primary provider. This
+	// replaces a fixed 2s sleep: the primary provider's call counter is the observable
+	// signal that the refresh ran, so there is a defined point at which "the fallback
+	// was not used" becomes a meaningful assertion rather than a race.
+	require.Eventually(t, func() bool {
+		return primaryProvider.getFetchCount() > 0
+	}, 10*time.Second, 20*time.Millisecond, "background refresh never reached the primary provider")
 
-	// After refresh with policy "none", primary cache should NOT have wikimedia image
+	// After refresh with policy "none", primary cache must NOT have the wikimedia image.
+	// The assertion is unconditional: previously it sat inside `if err == nil`, so any
+	// error made the whole test vacuous. img.URL is empty when err is non-nil, which
+	// still satisfies the inequality, so no branch is needed.
 	img, err := primaryCache.Get(species)
-
-	// The image should still be the old stale one (or a negative entry)
-	if err == nil {
-		assert.NotEqual(t, "https://upload.wikimedia.org/Carduelis_flammea_CT6.jpg", img.URL,
-			"Should NOT use wikimedia fallback when policy is 'none'")
+	if err != nil {
+		require.ErrorIs(t, err, imageprovider.ErrImageNotFound,
+			"only a not-found error is acceptable here")
 	}
+	assert.NotEqual(t, "https://upload.wikimedia.org/Carduelis_flammea_CT6.jpg", img.URL,
+		"Should NOT use wikimedia fallback when policy is 'none'")
+	assert.Zero(t, fallbackProvider.getFetchCount(),
+		"wikimedia fallback provider must not be consulted when policy is 'none'")
 }
 
-// mockNotFoundProvider always returns ErrImageNotFound
-type mockNotFoundProvider struct{}
+// mockNotFoundProvider always returns ErrImageNotFound. It counts calls so tests can
+// wait for a background refresh to reach the primary provider instead of sleeping for
+// a fixed interval.
+type mockNotFoundProvider struct {
+	fetchCount atomic.Int64
+}
 
 func (m *mockNotFoundProvider) Fetch(_ string) (imageprovider.BirdImage, error) {
+	m.fetchCount.Add(1)
 	return imageprovider.BirdImage{}, imageprovider.ErrImageNotFound
+}
+
+func (m *mockNotFoundProvider) getFetchCount() int64 {
+	return m.fetchCount.Load()
 }

--- a/internal/imageprovider/startup_warmup_test.go
+++ b/internal/imageprovider/startup_warmup_test.go
@@ -12,10 +12,9 @@ import (
 	"github.com/tphakala/birdnet-go/internal/observability"
 )
 
-// negativeCacheURL mirrors the unexported imageprovider.negativeEntryMarker. It is
+// imageprovider.NegativeEntryMarker mirrors the unexported imageprovider.negativeEntryMarker. It is
 // the persisted URL of a negative ("no image anywhere") cache entry; the value is
 // effectively frozen because changing it would invalidate existing on-disk caches.
-const negativeCacheURL = "__NOT_FOUND__"
 
 // TestLoadCachedImagesWarmupPopulatesMemory is a regression test for the
 // loadCachedImages double-pointer bug (Forgejo #1311): the warmup loop stored
@@ -91,7 +90,7 @@ func TestGetWarmedNegativePrimaryConsultsFallback(t *testing.T) {
 	require.NoError(t, store.SaveImageCache(&datastore.ImageCache{
 		ScientificName: species,
 		ProviderName:   providerAvicommons,
-		URL:            negativeCacheURL,
+		URL:            imageprovider.NegativeEntryMarker,
 		CachedAt:       time.Now(),
 	}))
 	// Positive fallback (wikimedia) DB row that the fallback chain must resolve.

--- a/internal/imageprovider/wikipedia.go
+++ b/internal/imageprovider/wikipedia.go
@@ -1154,24 +1154,29 @@ func (l *wikiMediaProvider) queryWithRetryAndLimiter(ctx context.Context, reqID 
 			logger.Int("attempt", attempt+1),
 			logger.Bool("will_retry", attempt < l.maxRetries-1))
 
-		// Nothing follows the final attempt, so neither the backoff nor a breaker
-		// check is worth paying for.
-		if attempt == l.maxRetries-1 {
-			break
-		}
-
-		// This failure may itself have opened the circuit: handleCircuitBreaker does
-		// so for 403, 429 and 503. Check before sleeping, so a refused endpoint costs
-		// neither another request nor the backoff that would precede it. Checking
-		// only at the top of the next iteration still burned the full delay first.
+		// This failure may itself have opened the circuit: handleCircuitBreaker does so
+		// for 403, 429 and 503. Check before sleeping, so a refused endpoint costs
+		// neither another request nor the backoff that would precede it. Checking only
+		// at the top of the next iteration still burned the full delay first.
+		//
+		// This runs on the final attempt too, not just before a retry. The breaker
+		// error deliberately keeps its own message because telemetry suppression
+		// matches on it (internal/errors/telemetry_integration.go); returning the
+		// retry-exhausted error instead, purely because the circuit happened to open on
+		// the last attempt rather than an earlier one, would report a throttle as a
+		// novel failure.
 		if cbErr := l.checkCircuitBreaker(reqID, params); cbErr != nil {
-			// The breaker error deliberately keeps its own message: Sentry suppression
-			// matches on it (internal/errors/telemetry_integration.go). Log the failure
-			// that tripped it so the cause is not lost with the retry-exhausted path.
+			// Log the failure that tripped it, so the cause is not lost along with the
+			// retry-exhausted path's diagnostics.
 			log.Warn("Abandoning retries because the circuit breaker opened",
 				logger.Error(lastErr),
 				logger.Int("attempts_made", attempt+1))
 			return nil, cbErr
+		}
+
+		// Nothing follows the final attempt, so the backoff has nothing to wait for.
+		if attempt == l.maxRetries-1 {
+			break
 		}
 
 		waitDuration := calculateRetryDelay(attempt)

--- a/internal/imageprovider/wikipedia.go
+++ b/internal/imageprovider/wikipedia.go
@@ -1107,23 +1107,23 @@ func (l *wikiMediaProvider) queryWithRetryAndLimiter(ctx context.Context, reqID 
 		logger.String("request_id", reqID),
 		logger.String("api_action", params["action"]))
 
+	// A non-positive maxRetries would skip the loop entirely and leave lastErr nil,
+	// which the post-loop error construction dereferences.
+	if l.maxRetries <= 0 {
+		return nil, errors.Newf("invalid maxRetries %d for Wikipedia query", l.maxRetries).
+			Component("imageprovider").
+			Category(errors.CategoryNetwork).
+			Context("provider", wikiProviderName).
+			Context("request_id", reqID).
+			Build()
+	}
+
 	if err := l.checkCircuitBreaker(reqID, params); err != nil {
 		return nil, err
 	}
 
 	var lastErr error
 	for attempt := range l.maxRetries {
-		// Re-check the breaker before every retry, not only once before the loop.
-		// A 429, a policy rejection or a network failure on attempt 1 opens the
-		// circuit, and continuing regardless sent attempts 2 and 3 to an endpoint
-		// that had just told us to stop. That tripled our request volume at exactly
-		// the moment Wikimedia was asking for less of it.
-		if attempt > 0 {
-			if err := l.checkCircuitBreaker(reqID, params); err != nil {
-				return nil, err
-			}
-		}
-
 		log.Debug("Attempting Wikipedia API request",
 			logger.Int("attempt", attempt+1),
 			logger.Int("max_attempts", l.maxRetries),
@@ -1154,20 +1154,34 @@ func (l *wikiMediaProvider) queryWithRetryAndLimiter(ctx context.Context, reqID 
 			logger.Int("attempt", attempt+1),
 			logger.Bool("will_retry", attempt < l.maxRetries-1))
 
-		// Only back off when another attempt actually follows. The loop used to sleep
-		// its full backoff after the final attempt too, holding the caller for up to
-		// an extra 4s per exhausted fetch with nothing left to wait for. The log line
-		// above already computed will_retry; this honours it.
-		if attempt < l.maxRetries-1 {
-			waitDuration := calculateRetryDelay(attempt)
-			log.Debug("Waiting before retry", logger.Duration("duration", waitDuration))
-			timer := time.NewTimer(waitDuration)
-			select {
-			case <-ctx.Done():
-				timer.Stop()
-				return nil, ctx.Err()
-			case <-timer.C:
-			}
+		// Nothing follows the final attempt, so neither the backoff nor a breaker
+		// check is worth paying for.
+		if attempt == l.maxRetries-1 {
+			break
+		}
+
+		// This failure may itself have opened the circuit: handleCircuitBreaker does
+		// so for 403, 429 and 503. Check before sleeping, so a refused endpoint costs
+		// neither another request nor the backoff that would precede it. Checking
+		// only at the top of the next iteration still burned the full delay first.
+		if cbErr := l.checkCircuitBreaker(reqID, params); cbErr != nil {
+			// The breaker error deliberately keeps its own message: Sentry suppression
+			// matches on it (internal/errors/telemetry_integration.go). Log the failure
+			// that tripped it so the cause is not lost with the retry-exhausted path.
+			log.Warn("Abandoning retries because the circuit breaker opened",
+				logger.Error(lastErr),
+				logger.Int("attempts_made", attempt+1))
+			return nil, cbErr
+		}
+
+		waitDuration := calculateRetryDelay(attempt)
+		log.Debug("Waiting before retry", logger.Duration("duration", waitDuration))
+		timer := time.NewTimer(waitDuration)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
 		}
 	}
 
@@ -1338,12 +1352,7 @@ func (l *wikiMediaProvider) FetchWithContext(ctx context.Context, scientificName
 	}
 
 	// Check if this is a background operation
-	isBackground := false
-	if ctx != nil {
-		if bg, ok := ctx.Value(backgroundOperationKey).(bool); ok && bg {
-			isBackground = true
-		}
-	}
+	isBackground := isBackgroundContext(ctx)
 
 	// Only use rate limiter for background operations
 	var limiter *rate.Limiter

--- a/internal/imageprovider/wikipedia.go
+++ b/internal/imageprovider/wikipedia.go
@@ -1113,6 +1113,17 @@ func (l *wikiMediaProvider) queryWithRetryAndLimiter(ctx context.Context, reqID 
 
 	var lastErr error
 	for attempt := range l.maxRetries {
+		// Re-check the breaker before every retry, not only once before the loop.
+		// A 429, a policy rejection or a network failure on attempt 1 opens the
+		// circuit, and continuing regardless sent attempts 2 and 3 to an endpoint
+		// that had just told us to stop. That tripled our request volume at exactly
+		// the moment Wikimedia was asking for less of it.
+		if attempt > 0 {
+			if err := l.checkCircuitBreaker(reqID, params); err != nil {
+				return nil, err
+			}
+		}
+
 		log.Debug("Attempting Wikipedia API request",
 			logger.Int("attempt", attempt+1),
 			logger.Int("max_attempts", l.maxRetries),
@@ -1143,14 +1154,20 @@ func (l *wikiMediaProvider) queryWithRetryAndLimiter(ctx context.Context, reqID 
 			logger.Int("attempt", attempt+1),
 			logger.Bool("will_retry", attempt < l.maxRetries-1))
 
-		waitDuration := calculateRetryDelay(attempt)
-		log.Debug("Waiting before retry", logger.Duration("duration", waitDuration))
-		timer := time.NewTimer(waitDuration)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return nil, ctx.Err()
-		case <-timer.C:
+		// Only back off when another attempt actually follows. The loop used to sleep
+		// its full backoff after the final attempt too, holding the caller for up to
+		// an extra 4s per exhausted fetch with nothing left to wait for. The log line
+		// above already computed will_retry; this honours it.
+		if attempt < l.maxRetries-1 {
+			waitDuration := calculateRetryDelay(attempt)
+			log.Debug("Waiting before retry", logger.Duration("duration", waitDuration))
+			timer := time.NewTimer(waitDuration)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return nil, ctx.Err()
+			case <-timer.C:
+			}
 		}
 	}
 


### PR DESCRIPTION
## Why species thumbnails were failing

`DownloadAndStore` built its HTTP request with no headers at all, so Go sent its default `Go-http-client/1.1`. Wikimedia rejects that under their User-Agent policy, so the image byte download failed for **every species on every request**.

The consequences compound. `Store` was never reached, so `cache/images/wikimedia/` stayed permanently empty, and the media proxy fell through to redirecting the client to the external URL on every request forever. A browser follows that redirect with its own User-Agent and succeeds, which is why the UI looked healthy while scripts and API clients got the 403 people reported. It also meant one guaranteed-failing outbound HTTPS round trip per species per page load.

The package already knew about the policy: it cites it in a comment, validates a User-Agent, and carries a dedicated circuit-breaker duration for policy violations. It set the header on `api.php` calls only. The image byte fetch never got the same treatment.

Verified against the live CDN with the exact string this code emits:

| User-Agent | Result |
|---|---|
| `Go-http-client/1.1` | 403 |
| `BirdNETGo/<ver> (<repo URL>) Go-HTTP-Client/go1.26.5` | 200 |

The fix reuses `buildUserAgent`, the same builder the MediaWiki API path already uses, so the two cannot drift in format. It is memoized in an `atomic.Pointer` rather than a `sync.OnceValue` because `conf.Setting()` can return nil and `Version` is published after startup, so latching at first call could pin a version-less string for the process lifetime.

Two things deliberately avoided, both of which look reasonable and are wrong: the download is **not** routed through `httpclient.New`, because `httpclient.Config` has no `Transport` field and so cannot carry the SSRF `DialContext` guard this client depends on; and `httpclient`'s own default User-Agent is not reused, because it carries no version and no contact URL.

## Sending fewer requests, not more

Fixing the User-Agent *reduces* outbound traffic: previously every page load re-attempted a guaranteed-403 download per uncached species because nothing was ever cached. Each species is now fetched once per 30 days instead. Three further defects in `queryWithRetryAndLimiter` were amplifying request volume:

- **The circuit breaker was checked once before the retry loop and never again.** A 429, a policy rejection or a 503 on attempt 1 opens the circuit, and the loop sent attempts 2 and 3 anyway, to an endpoint that had just told us to stop. Three requests where one was warranted.
- **The check now runs before the backoff, not after it.** Checking at the top of the next iteration still burned the full 2s delay first.
- **The loop slept its full backoff after the final attempt,** with nothing left to wait for. The warning it logs one line earlier already computed `will_retry`; it just did not act on it. An exhausted fetch held its caller an extra 4s for nothing, and `Fetch` can make three such calls.

A non-positive `maxRetries` also panicked: the loop body would not run, leaving `lastErr` nil, and both `logAPIError` and `buildRetryExhaustedError` dereference it. Production always sets 3, but tests construct the provider directly, so it was a live trap. Now guarded.

Finally, a 401/403 escalates to Error once per cache and re-arms on the next success. Download failures are logged at Info on purpose so ordinary upstream errors do not inflate the diagnostics error count; the side effect was that a blanket condition failing every species on every request was reported at the level chosen for transient faults and never stood out.

## Test scaffolding

The package had 58.1% coverage and **zero `httptest` usage**, which is precisely why a missing request header survived. The HTTP client on `ImageFileCache` is now injectable, which is required rather than stylistic: the shared client's `DialContext` rejects every loopback IP as SSRF protection, so an `httptest` server could not reach `DownloadAndStore` at all.

Two tests were permanently skipped, one of them burning 5s per run to do it. Both mocks read the background-operation context key as an untyped string, but the key has an unexported named type and `context.Value` compares key dynamic types, so the lookup never matched and every background fetch was counted as a user fetch. There is now one production predicate that the test seam forwards to, so the two cannot diverge again.

A number of tests passed while asserting nothing and are repaired: a negative-cache test named for expiry that tested none of it and ended in a `t.Logf`; a fallback-policy test that never checked whether the fallback provider was actually invoked, which is the user-visible symptom; a test whose only assertion sat inside `if err == nil`; a circuit-breaker test that called `openCircuit` itself and so only proved that a setter sets; a metrics test labelled "pseudocode" that asserted no metrics; a helper that returned early when the cache entry was absent, so total `saveToDB` breakage stayed green for every caller. A benchmark that issued real requests to the live Wikipedia API is now opt-in.

The `goleak` ignore for `startCacheRefresh.func1` is gone. `Close()` stops that goroutine, so the ignore was hiding six tests that built a cache and never closed it.

## Reviewer notes

Two upgrade consequences worth knowing, neither a defect:

- **`GET /api/v2/media/species-image` flips from `302 Found` to `200 OK`** for wikimedia-sourced species, because the file cache now populates. For anything rendering a notification image this is an improvement (it no longer needs Wikimedia reachability), but it is a changed response for a client that special-cased the redirect.
- **`cache/images` starts growing.** Bounded in practice by species count times at most 10 MB, so tens of MB, but there is no eviction or prune path today. Cache invalidation is tracked separately.

Verification: `go test -race ./internal/imageprovider/...` passes with **no skipped tests**, coverage 58.1% to 66.3%, `golangci-lint run` reports 0 issues, and `go build ./...` is clean. The User-Agent test fails without the fix with exactly the reported symptom, and the two retry fixes are each pinned by a test that fails without them (3 outbound requests instead of 1; 8s of virtual time instead of 4s). Two tests that a mutation pass showed could not fail were rewritten and re-verified against the same mutations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image downloading reliability: stronger Wikimedia request identification (User-Agent), improved cancellation handling, safer URL checks, correct content-type/extension handling, and rejection of oversized responses.
  * Hardened permanent access-denial behavior so repeated 401/403 conditions are handled more consistently.
  * Improved retry/circuit-breaker flow by validating retry settings and exiting promptly when the circuit is open or retries are exhausted.
  * Improved background refresh behavior so stale results stay responsive while refresh proceeds safely.
* **Performance**
  * Live-network benchmarks now run only when explicitly enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
