### PR TITLE
fix(imageprovider): take species-image provider fetches off the request path

### DIFF
--- a/doc/wiki/guide.md
+++ b/doc/wiki/guide.md
@@ -3069,7 +3069,7 @@ Sent when a new bird detection occurs and passes all filters.
   "longitude": 24.9384,
   "clipName": "eurasian_blackbird_87p_20240115T083045Z.wav",
   "birdImage": {
-    "url": "https://example.com/bird-image.jpg",
+    "url": "/api/v2/media/image/Turdus%20merula",
     "attribution": "Image by Photographer Name",
     "license": "CC BY-SA 4.0",
     "licenseUrl": "https://creativecommons.org/licenses/by-sa/4.0/"
@@ -3078,6 +3078,13 @@ Sent when a new bird detection occurs and passes all filters.
   "eventType": "new_detection"
 }
 ```
+
+`birdImage.url` is a path on this BirdNET-Go instance, not an address on the image
+provider. It is always present, so it is not a signal that an image exists: the server
+resolves species images in the background, and the endpoint answers `503` while a fetch
+is still in flight and `404` for a species that has no image. Resolve it against your
+BirdNET-Go base URL and handle both statuses, retrying a `503` after the `Retry-After`
+it advertises.
 
 #### 3. Heartbeat Event
 
@@ -3143,7 +3150,7 @@ Perfect for web dashboards or browser-based applications:
                  <p>Confidence: ${(detection.confidence * 100).toFixed(1)}%</p>
                  <p>Time: ${detection.time}</p>
                  <p>Source: ${detection.source}</p>
-                 ${detection.birdImage?.url ? `<img src="${detection.birdImage.url}" alt="${detection.commonName}" style="max-width: 200px;">` : ""}
+                 ${detection.birdImage?.url ? `<img src="${detection.birdImage.url}" alt="${detection.commonName}" style="max-width: 200px;" onerror="this.style.display='none'">` : ""}
              `;
 
         // Add to top of list

--- a/doc/wiki/guide.md
+++ b/doc/wiki/guide.md
@@ -3128,8 +3128,11 @@ Perfect for web dashboards or browser-based applications:
     <div id="detections"></div>
 
     <script>
+      // birdImage.url is a path on the BirdNET-Go instance, so it has to be resolved
+      // against the same base URL the stream itself came from.
+      const BIRDNET_BASE_URL = "http://localhost:8080";
       const eventSource = new EventSource(
-        "http://localhost:8080/api/v2/detections/stream",
+        `${BIRDNET_BASE_URL}/api/v2/detections/stream`,
       );
       const detectionsDiv = document.getElementById("detections");
 
@@ -3150,7 +3153,7 @@ Perfect for web dashboards or browser-based applications:
                  <p>Confidence: ${(detection.confidence * 100).toFixed(1)}%</p>
                  <p>Time: ${detection.time}</p>
                  <p>Source: ${detection.source}</p>
-                 ${detection.birdImage?.url ? `<img src="${detection.birdImage.url}" alt="${detection.commonName}" style="max-width: 200px;" onerror="this.style.display='none'">` : ""}
+                 ${detection.birdImage?.url ? `<img src="${BIRDNET_BASE_URL}${detection.birdImage.url}" alt="${detection.commonName}" style="max-width: 200px;" onerror="this.style.display='none'">` : ""}
              `;
 
         // Add to top of list

--- a/frontend/src/lib/desktop/components/ui/README.md
+++ b/frontend/src/lib/desktop/components/ui/README.md
@@ -524,7 +524,7 @@ interface Props {
 Utility functions for image handling.
 
 ```typescript
-export function handleBirdImageError(e: Event): void;
+export function handleBirdImageError(e: Event): boolean;
 ```
 
 **Usage:**
@@ -541,6 +541,13 @@ export function handleBirdImageError(e: Event): void;
 
 - Bird-specific error handling
 - Automatic placeholder fallback
+- Bounded retry of the original URL, because the media proxy answers "not resolved
+  yet" for a species whose image is still being fetched in the background. Each retry
+  loads the URL into a detached probe image first and only swaps the visible `src` on
+  success, so the placeholder does not flicker for a species that has no image at all.
+- Returns `true` while a retry is pending. A caller that blacklists failed URLs, or
+  that replaces the `<img>` with an error state, must honour this: removing the element
+  cancels the retry it just scheduled.
 
 ---
 

--- a/frontend/src/lib/desktop/components/ui/image-utils.test.ts
+++ b/frontend/src/lib/desktop/components/ui/image-utils.test.ts
@@ -1,17 +1,34 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import { handleBirdImageError } from './image-utils';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import {
+  handleBirdImageError,
+  THUMBNAIL_RETRY_DELAYS_MS,
+  BIRD_PLACEHOLDER_PATH,
+} from './image-utils';
 import { setBasePath, resetBasePath } from '$lib/utils/urlHelpers';
+
+/**
+ * Builds an <img> attached to the document, because the retry only restores the src of
+ * an element still in the DOM: a detached element means the row was destroyed and its
+ * thumbnail no longer matters.
+ */
+function mountImage(src: string): globalThis.HTMLImageElement {
+  const img = document.createElement('img');
+  img.src = src;
+  document.body.appendChild(img);
+  return img;
+}
 
 describe('handleBirdImageError', () => {
   afterEach(() => {
     resetBasePath();
+    document.body.innerHTML = '';
   });
 
   it('rewrites src to the placeholder asset', () => {
     const img = document.createElement('img');
     handleBirdImageError({ currentTarget: img } as unknown as Event);
 
-    expect(img.src).toContain('/ui/assets/bird-placeholder.svg');
+    expect(img.src).toContain(BIRD_PLACEHOLDER_PATH);
   });
 
   it('includes the configured base path when one is set (regression)', () => {
@@ -22,7 +39,7 @@ describe('handleBirdImageError', () => {
     const img = document.createElement('img');
     handleBirdImageError({ currentTarget: img } as unknown as Event);
 
-    expect(img.src).toContain('/birdnet/ui/assets/bird-placeholder.svg');
+    expect(img.src).toContain(`/birdnet${BIRD_PLACEHOLDER_PATH}`);
   });
 
   it('does not re-swap when the src is already the placeholder (avoids an onerror loop)', () => {
@@ -30,11 +47,141 @@ describe('handleBirdImageError', () => {
     // First failure swaps to the placeholder.
     handleBirdImageError({ currentTarget: img } as unknown as Event);
     const afterFirst = img.src;
-    expect(afterFirst).toContain('/ui/assets/bird-placeholder.svg');
+    expect(afterFirst).toContain(BIRD_PLACEHOLDER_PATH);
 
     // A subsequent error (e.g. the placeholder asset itself failing) is a no-op: the
     // guard returns early instead of re-assigning src, which would re-fire onerror.
     handleBirdImageError({ currentTarget: img } as unknown as Event);
     expect(img.src).toBe(afterFirst);
+  });
+});
+
+/**
+ * Retry behaviour.
+ *
+ * The media proxy no longer resolves an image on the request path, so a species that is
+ * not cached yet answers "not yet" rather than eventually returning bytes. Without a
+ * retry the placeholder is permanent until a hard refresh, which on a cold cache means
+ * silhouettes across the whole page.
+ */
+describe('handleBirdImageError retries', () => {
+  const THUMBNAIL_URL = 'http://localhost/api/v2/media/image/Turdus%20merula';
+
+  /** Probe images created by the retry timer, newest last. */
+  let probes: MockProbe[];
+
+  /**
+   * Stands in for the detached Image() the retry uses to test the URL before touching
+   * the visible element. jsdom never loads anything, so the test drives the outcome.
+   */
+  class MockProbe {
+    onload: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    #src = '';
+
+    constructor() {
+      probes.push(this);
+    }
+
+    get src(): string {
+      return this.#src;
+    }
+
+    set src(value: string) {
+      this.#src = value;
+    }
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    probes = [];
+    vi.stubGlobal('Image', MockProbe);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    document.body.innerHTML = '';
+    resetBasePath();
+  });
+
+  it('reports that a retry is pending so callers do not blacklist the URL', () => {
+    const img = mountImage(THUMBNAIL_URL);
+    expect(handleBirdImageError({ currentTarget: img } as unknown as Event)).toBe(true);
+  });
+
+  it('restores the original src only after a probe confirms the image loads', () => {
+    const img = mountImage(THUMBNAIL_URL);
+    handleBirdImageError({ currentTarget: img } as unknown as Event);
+    expect(img.src).toContain(BIRD_PLACEHOLDER_PATH);
+
+    vi.advanceTimersByTime((THUMBNAIL_RETRY_DELAYS_MS.at(0) ?? 0) * 2);
+
+    // The probe is loading; the visible element must still show the placeholder. This
+    // is the anti-flicker property: assigning the visible src speculatively would
+    // blink a broken image on every attempt for a species that has no image at all.
+    expect(probes).toHaveLength(1);
+    expect(probes.at(0)?.src).toBe(THUMBNAIL_URL);
+    expect(img.src).toContain(BIRD_PLACEHOLDER_PATH);
+
+    probes.at(0)?.onload?.();
+    expect(img.src).toBe(THUMBNAIL_URL);
+  });
+
+  it('backs off across every configured attempt and then gives up', () => {
+    const img = mountImage(THUMBNAIL_URL);
+    handleBirdImageError({ currentTarget: img } as unknown as Event);
+
+    for (const [index, delay] of THUMBNAIL_RETRY_DELAYS_MS.entries()) {
+      // The schedule is jittered, so advance past the upper bound of the window.
+      vi.advanceTimersByTime(delay * 2);
+      expect(probes).toHaveLength(index + 1);
+      probes.at(index)?.onerror?.();
+    }
+
+    // Retries exhausted: no further timer is armed, so the species settles on the
+    // placeholder instead of polling forever.
+    vi.advanceTimersByTime(600000);
+    expect(probes).toHaveLength(THUMBNAIL_RETRY_DELAYS_MS.length);
+    expect(img.src).toContain(BIRD_PLACEHOLDER_PATH);
+  });
+
+  it('reports no pending retry once the attempts are spent', () => {
+    const img = mountImage(THUMBNAIL_URL);
+    handleBirdImageError({ currentTarget: img } as unknown as Event);
+
+    for (const delay of THUMBNAIL_RETRY_DELAYS_MS) {
+      vi.advanceTimersByTime(delay * 2);
+      probes.at(-1)?.onerror?.();
+    }
+
+    // A further error on the same URL must report false so DetectionRow can finally
+    // record the failure and stop rendering the element.
+    img.src = THUMBNAIL_URL;
+    expect(handleBirdImageError({ currentTarget: img } as unknown as Event)).toBe(false);
+  });
+
+  it('does not touch an element that was reused for a different species', () => {
+    const img = mountImage(THUMBNAIL_URL);
+    handleBirdImageError({ currentTarget: img } as unknown as Event);
+
+    // The row is recycled before the retry fires, which is routine in a scrolling list.
+    const otherUrl = 'http://localhost/api/v2/media/image/Parus%20major';
+    img.src = otherUrl;
+
+    vi.advanceTimersByTime((THUMBNAIL_RETRY_DELAYS_MS.at(0) ?? 0) * 2);
+
+    expect(probes).toHaveLength(0);
+    expect(img.src).toBe(otherUrl);
+  });
+
+  it('does not restore the src of an element removed from the document', () => {
+    const img = mountImage(THUMBNAIL_URL);
+    handleBirdImageError({ currentTarget: img } as unknown as Event);
+    img.remove();
+
+    vi.advanceTimersByTime((THUMBNAIL_RETRY_DELAYS_MS.at(0) ?? 0) * 2);
+
+    expect(probes).toHaveLength(0);
   });
 });

--- a/frontend/src/lib/desktop/components/ui/image-utils.ts
+++ b/frontend/src/lib/desktop/components/ui/image-utils.ts
@@ -147,5 +147,11 @@ export function handleBirdImageError(e: Event): boolean {
 
   const failedUrl = target.src;
   target.src = buildAppUrl(BIRD_PLACEHOLDER_PATH);
+
+  // An element that is not in the document has nothing to retry into: the timer would
+  // fire, find it still detached, and do nothing. Skipping keeps real timers from
+  // outliving an unmounted component.
+  if (!target.isConnected) return false;
+
   return scheduleThumbnailRetry(target, failedUrl);
 }

--- a/frontend/src/lib/desktop/components/ui/image-utils.ts
+++ b/frontend/src/lib/desktop/components/ui/image-utils.ts
@@ -4,20 +4,148 @@
 
 import { buildAppUrl } from '$lib/utils/urlHelpers';
 
-/**
- * Handles bird thumbnail image load errors by replacing failed images with a bird placeholder
- * @param e - The error event from the bird thumbnail image element
- */
 /** Static asset path of the bird-silhouette placeholder (before base-path resolution). */
-const BIRD_PLACEHOLDER_PATH = '/ui/assets/bird-placeholder.svg';
+export const BIRD_PLACEHOLDER_PATH = '/ui/assets/bird-placeholder.svg';
 
-export function handleBirdImageError(e: Event): void {
+/**
+ * Delays, in milliseconds, before each retry of a failed thumbnail.
+ *
+ * The media proxy no longer fetches from an image provider on the request path, so a
+ * species whose image is not cached yet answers "not yet" and only becomes available
+ * once a background fetch completes, which can take several seconds behind the
+ * provider's rate limiter. Without a retry the placeholder is permanent until a hard
+ * refresh, so a cold cache renders silhouettes across the whole page.
+ *
+ * The schedule is finite on purpose: the point is to cover the window a background
+ * fetch realistically lands in, not to poll indefinitely. It brackets the measured
+ * cold-cache tail (30 dashboard thumbnails all resolved within about 80 seconds on a
+ * 2-core QA VM), because a species whose fetch lands after the last attempt settles on
+ * the placeholder with no further recovery short of a reload. The first delay is at or
+ * beyond the server's advertised Retry-After.
+ *
+ * Exported for tests so a tuning change does not silently break them against a
+ * hardcoded copy.
+ */
+export const THUMBNAIL_RETRY_DELAYS_MS = [5000, 15000, 40000, 60000];
+
+/**
+ * Jitter applied to each delay, as a fraction. Every thumbnail on a page fails within
+ * the same few hundred milliseconds, so an unjittered schedule sends all of their
+ * retries in one burst, competing with the very background fetches they are waiting
+ * on.
+ */
+const THUMBNAIL_RETRY_JITTER = 0.3;
+
+interface RetryState {
+  /** The thumbnail URL that failed, restored on the next attempt. */
+  url: string;
+  /** How many retries have already been scheduled for this URL. */
+  attempts: number;
+  /** Pending timer, cancelled if the element is reused for a different image. */
+  timer: ReturnType<typeof globalThis.setTimeout> | undefined;
+}
+
+/**
+ * Per-element retry bookkeeping. A WeakMap keeps this from pinning detached <img>
+ * elements alive: a row scrolled out of a virtualized list is collected along with
+ * its entry.
+ */
+const retryStates = new WeakMap<globalThis.HTMLImageElement, RetryState>();
+
+function isPlaceholder(src: string): boolean {
+  // Match the stable path with includes() so a base path or any query/hash suffix
+  // (dev server, CDN, cache-busting) can't defeat the check.
+  return src.includes(BIRD_PLACEHOLDER_PATH);
+}
+
+/**
+ * Schedules the next retry for a failed thumbnail, if any attempts remain.
+ *
+ * The retry loads the URL into a DETACHED probe image first and only assigns the
+ * visible element's src once the probe reports success. Assigning the visible src
+ * directly would swap the placeholder out on every attempt, so a species that
+ * genuinely has no image would flash a broken image three times before settling.
+ *
+ * The probe re-requests the SAME URL, deliberately without a cache-busting parameter,
+ * because the server distinguishes the two failure modes with cache headers: a species
+ * with no image answers 404 with a long max-age, so the probe is served from the
+ * browser's own HTTP cache with no network hop, while a species still being fetched
+ * answers 503 with no-store, so the probe actually reaches the server. An <img> error
+ * event exposes no status code, which is why the cache does that discrimination.
+ *
+ * @returns true when a retry was scheduled.
+ */
+function scheduleThumbnailRetry(target: globalThis.HTMLImageElement, failedUrl: string): boolean {
+  const existing = retryStates.get(target);
+  const attempts = existing?.url === failedUrl ? existing.attempts : 0;
+  // .at() rather than an index expression: it is typed as possibly-undefined, so the
+  // exhausted case has to be handled instead of silently yielding NaN.
+  const baseDelay = THUMBNAIL_RETRY_DELAYS_MS.at(attempts);
+
+  if (existing?.timer !== undefined) {
+    globalThis.clearTimeout(existing.timer);
+  }
+
+  if (baseDelay === undefined) {
+    // Retries exhausted. Keep the state so a later error on the same URL is not
+    // treated as a fresh first failure.
+    retryStates.set(target, { url: failedUrl, attempts, timer: undefined });
+    return false;
+  }
+
+  const delay = baseDelay * (1 + (Math.random() * 2 - 1) * THUMBNAIL_RETRY_JITTER);
+
+  const timer = globalThis.setTimeout(() => {
+    const state = retryStates.get(target);
+    if (state) state.timer = undefined;
+    // Anything other than "still showing the placeholder for this URL" means the
+    // element was reused for a different detection, and touching its src now would
+    // swap in the wrong bird.
+    if (!target.isConnected || !isPlaceholder(target.src)) return;
+
+    // isPlaceholder alone cannot tell "the placeholder for THIS url" from "the
+    // placeholder for some other species", because it is one shared asset path. Both
+    // probe callbacks therefore re-check that this element's retry state still
+    // belongs to the URL this probe was started for: a virtualized row reused for a
+    // different detection would otherwise be painted with the previous bird, and the
+    // dead chain would take over the new species' retry budget.
+    const stillOurs = () => retryStates.get(target)?.url === failedUrl;
+
+    const probe = new globalThis.Image();
+    probe.onload = () => {
+      if (!stillOurs() || !target.isConnected || !isPlaceholder(target.src)) return;
+      target.src = failedUrl;
+    };
+    // Still failing: fall through to the next delay, or stop if this was the last.
+    probe.onerror = () => {
+      if (!stillOurs()) return;
+      scheduleThumbnailRetry(target, failedUrl);
+    };
+    probe.src = failedUrl;
+  }, delay);
+
+  retryStates.set(target, { url: failedUrl, attempts: attempts + 1, timer });
+  return true;
+}
+
+/**
+ * Swaps a failed bird thumbnail for the placeholder and, for a bounded number of
+ * attempts, schedules a retry of the original URL.
+ *
+ * @param e - The error event from the bird thumbnail image element
+ * @returns true when a retry is pending, so callers that blacklist failed URLs can
+ *          hold off until the retries are actually exhausted.
+ */
+export function handleBirdImageError(e: Event): boolean {
   const target = e.currentTarget as globalThis.HTMLImageElement;
+
   // Guard against an infinite onerror loop if the placeholder asset itself fails to
-  // load. Match the stable path with includes() so a base path or any query/hash
-  // suffix (dev server, CDN, cache-busting) can't defeat the check. Using this rather
-  // than nulling target.onerror keeps error handling working for a reused <img> whose
-  // bound src later changes to a new (potentially also-failing) thumbnail.
-  if (target.src.includes(BIRD_PLACEHOLDER_PATH)) return;
+  // load. Using this rather than nulling target.onerror keeps error handling working
+  // for a reused <img> whose bound src later changes to a new (potentially
+  // also-failing) thumbnail.
+  if (isPlaceholder(target.src)) return false;
+
+  const failedUrl = target.src;
   target.src = buildAppUrl(BIRD_PLACEHOLDER_PATH);
+  return scheduleThumbnailRetry(target, failedUrl);
 }

--- a/frontend/src/lib/desktop/features/dashboard/components/BirdThumbnailPopup.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/BirdThumbnailPopup.svelte
@@ -260,10 +260,14 @@
     imageError = false;
   }
 
-  // Handle image load error - wraps imported handler and updates component state
+  // Handle image load error - wraps imported handler and updates component state.
+  // A pending retry must NOT flip imageError: that branch replaces the <img> with the
+  // "image not available" state, removing the very element the retry targets, so the
+  // popup would permanently claim absence for a species whose image is merely still
+  // being fetched.
   function handleImageError(event: Event) {
-    handleBirdImageError(event);
     imageLoaded = false;
+    if (handleBirdImageError(event)) return;
     imageError = true;
   }
 

--- a/frontend/src/lib/desktop/features/dashboard/components/CurrentlyHearingCard.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/CurrentlyHearingCard.svelte
@@ -18,6 +18,7 @@ Props:
   import { t } from '$lib/i18n';
   import type { PendingDetection } from '$lib/types/pending.types';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
+  import { handleBirdImageError } from '$lib/desktop/components/ui/image-utils';
   import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
   import { settingsStore } from '$lib/stores/settings';
 
@@ -180,10 +181,16 @@ Props:
         >
           <!-- Thumbnail -->
           {#if detection.thumbnail}
+            <!-- The thumbnail URL is now emitted unconditionally, so this <img> is
+                 always rendered and a species with no cached image would otherwise
+                 show the browser's broken-image icon where the initials badge used to
+                 be. handleBirdImageError substitutes the shared silhouette and retries
+                 while a background fetch is still in flight. -->
             <img
               src={buildAppUrl(detection.thumbnail)}
               alt={displayName}
               class="h-8 aspect-[4/3] rounded-md object-cover"
+              onerror={handleBirdImageError}
             />
           {:else}
             <div

--- a/frontend/src/lib/desktop/features/detections/components/DetectionRow.svelte
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionRow.svelte
@@ -123,7 +123,12 @@
     thumbnailLoader.setLoading(false);
   }
 
-  function handleThumbnailError() {
+  // `retryPending` comes from handleBirdImageError, which retries a thumbnail a
+  // bounded number of times. Blacklisting the URL removes the <img> from the DOM,
+  // which would cancel those retries: a species whose image is still being fetched
+  // server-side would then show the broken-image state until a hard refresh.
+  function handleThumbnailError(retryPending: boolean) {
+    if (retryPending) return;
     const currentUrl = getThumbnailUrl(detection.scientificName);
     thumbnailLoader.markUrlFailed(currentUrl);
   }
@@ -252,8 +257,7 @@
             class:opacity-0={thumbnailLoader.loading}
             onload={handleThumbnailLoad}
             onerror={e => {
-              handleThumbnailError();
-              handleBirdImageError(e);
+              handleThumbnailError(handleBirdImageError(e));
             }}
           />
         {/if}

--- a/frontend/src/lib/desktop/views/DetectionDetail.svelte
+++ b/frontend/src/lib/desktop/views/DetectionDetail.svelte
@@ -258,8 +258,15 @@
     }
   }
 
+  /**
+   * Delays before re-requesting attribution that answered "not resolved yet".
+   * Deliberately shorter and fewer than the thumbnail's own schedule: attribution is
+   * supporting detail, and the image itself is what the user is waiting on.
+   */
+  const ATTRIBUTION_RETRY_DELAYS_MS = [5000, 15000, 40000];
+
   // Fetch image attribution metadata
-  async function fetchImageAttribution() {
+  async function fetchImageAttribution(attempt = 0) {
     if (!detection?.scientificName?.trim()) return;
 
     attributionController?.abort();
@@ -277,6 +284,18 @@
         const data = await response.json();
         if (signal.aborted) return;
         imageAttribution = data as ImageAttribution;
+        return;
+      }
+      // 503 means the image is still being resolved in the background, not that it
+      // has no attribution. Without a retry the CC-BY/CC-BY-SA photo that the
+      // thumbnail's own retry recovers seconds later would be displayed with no
+      // author or licence credit, which is a licensing problem and not merely a
+      // cosmetic one.
+      if (response.status === 503 && attempt < ATTRIBUTION_RETRY_DELAYS_MS.length) {
+        const delay = ATTRIBUTION_RETRY_DELAYS_MS.at(attempt) ?? 0;
+        globalThis.setTimeout(() => {
+          if (!signal.aborted) void fetchImageAttribution(attempt + 1);
+        }, delay);
       }
     } catch (error) {
       if (signal.aborted || (error instanceof Error && error.name === 'AbortError')) return;

--- a/frontend/src/lib/desktop/views/DetectionDetail.svelte
+++ b/frontend/src/lib/desktop/views/DetectionDetail.svelte
@@ -173,6 +173,7 @@
       speciesController?.abort();
       taxonomyController?.abort();
       attributionController?.abort();
+      cancelAttributionRetry();
     };
   });
 
@@ -265,11 +266,27 @@
    */
   const ATTRIBUTION_RETRY_DELAYS_MS = [5000, 15000, 40000];
 
+  /**
+   * Pending 503 retry. Tracked separately from attributionController because the
+   * controller is released as soon as its request settles: without this the scheduled
+   * retry would still fire after the view was unmounted or navigated to a different
+   * detection, since aborting the (already-nulled) controller could no longer reach it.
+   */
+  let attributionRetryTimer: ReturnType<typeof globalThis.setTimeout> | undefined;
+
+  function cancelAttributionRetry() {
+    if (attributionRetryTimer !== undefined) {
+      globalThis.clearTimeout(attributionRetryTimer);
+      attributionRetryTimer = undefined;
+    }
+  }
+
   // Fetch image attribution metadata
   async function fetchImageAttribution(attempt = 0) {
     if (!detection?.scientificName?.trim()) return;
 
     attributionController?.abort();
+    cancelAttributionRetry();
     const controller = new AbortController();
     attributionController = controller;
     const { signal } = controller;
@@ -293,9 +310,13 @@
       // cosmetic one.
       if (response.status === 503 && attempt < ATTRIBUTION_RETRY_DELAYS_MS.length) {
         const delay = ATTRIBUTION_RETRY_DELAYS_MS.at(attempt) ?? 0;
-        globalThis.setTimeout(() => {
+        attributionRetryTimer = globalThis.setTimeout(() => {
+          attributionRetryTimer = undefined;
           if (!signal.aborted) void fetchImageAttribution(attempt + 1);
         }, delay);
+        // Return before the finally block releases the controller, so this request's
+        // signal stays reachable and an abort can still cancel the pending retry.
+        return;
       }
     } catch (error) {
       if (signal.aborted || (error instanceof Error && error.name === 'AbortError')) return;

--- a/frontend/src/lib/desktop/views/Search.svelte
+++ b/frontend/src/lib/desktop/views/Search.svelte
@@ -907,6 +907,9 @@
                           )}
                           alt={displayName || t('search.detailsPanel.unknownSpecies')}
                           class="w-full h-full object-cover"
+                          onload={e => {
+                            (e.currentTarget as HTMLImageElement).classList.remove('p-2');
+                          }}
                           onerror={e => {
                             (e.currentTarget as HTMLImageElement).classList.add('p-2');
                             handleBirdImageError(e);
@@ -1113,6 +1116,9 @@
                                 )}
                                 alt={displayName || t('search.detailsPanel.unknownSpecies')}
                                 class="w-full h-full object-cover"
+                                onload={e => {
+                                  (e.currentTarget as HTMLImageElement).classList.remove('p-2');
+                                }}
                                 onerror={e => {
                                   (e.currentTarget as HTMLImageElement).classList.add('p-2');
                                   handleBirdImageError(e);

--- a/frontend/src/lib/desktop/views/Search.svelte
+++ b/frontend/src/lib/desktop/views/Search.svelte
@@ -908,9 +908,8 @@
                           alt={displayName || t('search.detailsPanel.unknownSpecies')}
                           class="w-full h-full object-cover"
                           onerror={e => {
-                            const target = e.currentTarget as HTMLImageElement;
-                            target.src = buildAppUrl('/ui/assets/bird-placeholder.svg');
-                            target.classList.add('p-2');
+                            (e.currentTarget as HTMLImageElement).classList.add('p-2');
+                            handleBirdImageError(e);
                           }}
                           loading="lazy"
                           decoding="async"
@@ -1115,9 +1114,8 @@
                                 alt={displayName || t('search.detailsPanel.unknownSpecies')}
                                 class="w-full h-full object-cover"
                                 onerror={e => {
-                                  const target = e.currentTarget as HTMLImageElement;
-                                  target.src = buildAppUrl('/ui/assets/bird-placeholder.svg');
-                                  target.classList.add('p-2');
+                                  (e.currentTarget as HTMLImageElement).classList.add('p-2');
+                                  handleBirdImageError(e);
                                 }}
                                 loading="lazy"
                                 decoding="async"

--- a/internal/analysis/processor/actions_composite.go
+++ b/internal/analysis/processor/actions_composite.go
@@ -122,9 +122,17 @@ func buildTimeoutError(action Action, timeout time.Duration, step, total int) er
 		Build()
 }
 
-// getBirdImageFromCache retrieves a bird image from cache with proper error handling and logging.
-// This helper consolidates duplicate image retrieval logic used by MqttAction and SSEAction.
-// Returns an empty BirdImage if the cache is nil or if retrieval fails.
+// getBirdImageFromCache retrieves already-cached bird image metadata for MqttAction
+// and SSEAction. Returns an empty BirdImage if the cache is nil or nothing is cached
+// yet, in which case a background fetch is scheduled for the next detection.
+//
+// This deliberately does NOT fetch on the caller's goroutine. Both callers run inside
+// the CompositeAction that chains Database -> SSE -> MQTT under a 30s timeout, and a
+// cold species can take minutes to resolve through the provider chain. Audio export
+// was moved out of this CompositeAction for exactly this reason (see the note in
+// actions_database.go; Sentry BIRDNET-GO-WD); the image lookup was the same hazard
+// left behind. Attribution metadata is best-effort here: the URL the consumers
+// publish is the media-proxy URL, which does not depend on this lookup succeeding.
 func getBirdImageFromCache(cache *imageprovider.BirdImageCache, scientificName, commonName, correlationID string) imageprovider.BirdImage {
 	if cache == nil {
 		GetLogger().Warn("BirdImageCache is nil, cannot fetch image",
@@ -135,18 +143,14 @@ func getBirdImageFromCache(cache *imageprovider.BirdImageCache, scientificName, 
 		return imageprovider.BirdImage{}
 	}
 
-	birdImage, err := cache.Get(scientificName)
-	if err != nil {
-		GetLogger().Warn("Error getting bird image from cache",
-			logger.String("detection_id", correlationID),
-			logger.Error(err),
-			logger.String("species", commonName),
-			logger.String("scientific_name", scientificName),
-			logger.String("operation", "get_bird_image"))
-		return imageprovider.BirdImage{}
+	birdImage, found, negative := cache.GetCached(scientificName)
+	if found {
+		return birdImage
 	}
-
-	return birdImage
+	if !negative {
+		cache.PrefetchAsync(scientificName)
+	}
+	return imageprovider.BirdImage{}
 }
 
 // Execute runs all actions sequentially, stopping on first error

--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -218,7 +218,7 @@ func (a *DatabaseAction) ExecuteContext(ctx context.Context, _ any) error {
 	}
 
 	// After successful save, publish detection event to the event bus.
-	a.publishDetectionEvent(isNewSpecies, daysSinceFirstSeen, novelty)
+	a.publishDetectionEvent(ctx, isNewSpecies, daysSinceFirstSeen, novelty)
 
 	// NOTE: Audio export is intentionally NOT performed here.
 	// It runs as a separate action (SaveAudioAction) outside the CompositeAction
@@ -314,9 +314,25 @@ func (a *DatabaseAction) populateEventMetadata(detectionEvent events.DetectionEv
 		}
 	}
 
+	// Cached-only lookup. The previous BirdImageCache.Get here was a synchronous,
+	// uncancellable provider fetch inside the CompositeAction whose 30s timeout this
+	// file's own note (see the audio-export comment above) records as the reason slow
+	// work was moved out of it. A cold species could take minutes.
+	//
+	// The URL stays the provider's upstream address rather than becoming a media-proxy
+	// URL. This metadata reaches notification templates as bg_image_url and ends up in
+	// Discord rich embeds and webhook payloads, and those are fetched server-side by
+	// the notification service, from outside the user's network. A BirdNET-Go URL is
+	// unreachable from there for the typical home-LAN install, whether it is
+	// root-relative or an absolute one built from a private host. The provider URL is a
+	// public CDN address and is the only form that renders. Tracked separately.
 	if a.processor != nil && a.processor.BirdImageCache != nil {
-		if birdImage, err := a.processor.BirdImageCache.Get(a.Result.Species.ScientificName); err == nil && birdImage.URL != "" {
+		if birdImage, found, _ := a.processor.BirdImageCache.GetCached(a.Result.Species.ScientificName); found && birdImage.URL != "" {
 			metadata["image_url"] = birdImage.URL
+		} else {
+			// Nothing cached yet, so this notification carries no image. Warm it for
+			// the next detection of this species instead of blocking on it here.
+			a.processor.BirdImageCache.PrefetchAsync(a.Result.Species.ScientificName)
 		}
 	}
 }
@@ -345,10 +361,48 @@ func (a *DatabaseAction) recordNotificationSent(notificationTime time.Time) {
 	}
 }
 
+// newSpeciesImageWait bounds how long a new-species notification will wait for its
+// image to resolve. It is short relative to the enclosing CompositeAction's 30s
+// timeout, so a throttled provider degrades to a notification without an image
+// rather than putting the whole Database -> SSE -> MQTT chain at risk.
+const newSpeciesImageWait = 3 * time.Second
+
+// warmSpeciesImage resolves this detection's species image, waiting at most
+// newSpeciesImageWait, so that the caller's subsequent GetCached lookup can succeed.
+//
+// This is the one image lookup that is still allowed to wait, and only for a new
+// species. Every other path in this file and its siblings is cached-only, because a
+// cold species can otherwise occupy the provider chain for minutes. A new species is
+// rare by construction (once per species, ever) and is precisely the detection whose
+// notification an image matters most for.
+func (a *DatabaseAction) warmSpeciesImage(ctx context.Context) {
+	if a.processor == nil || a.processor.BirdImageCache == nil {
+		return
+	}
+	scientificName := a.Result.Species.ScientificName
+	if scientificName == "" {
+		return
+	}
+	if _, found, _ := a.processor.BirdImageCache.GetCached(scientificName); found {
+		return
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, newSpeciesImageWait)
+	defer cancel()
+	if _, err := a.processor.BirdImageCache.GetWithContext(waitCtx, scientificName); err != nil {
+		GetLogger().Debug("New species image did not resolve within the notification wait",
+			logger.String("component", "analysis.processor.actions"),
+			logger.String("detection_id", a.CorrelationID),
+			logger.String("scientific_name", scientificName),
+			logger.Duration("waited", newSpeciesImageWait),
+			logger.Error(err))
+	}
+}
+
 // publishDetectionEvent publishes a detection event to the event bus.
 // All detections are published so that alert rules on detection.occurred can fire.
 // New species detections additionally go through suppression and notification recording.
-func (a *DatabaseAction) publishDetectionEvent(isNewSpecies bool, daysSinceFirstSeen int, novelty species.NoveltyStatus) {
+func (a *DatabaseAction) publishDetectionEvent(ctx context.Context, isNewSpecies bool, daysSinceFirstSeen int, novelty species.NoveltyStatus) {
 	if !events.IsInitialized() {
 		return
 	}
@@ -361,6 +415,15 @@ func (a *DatabaseAction) publishDetectionEvent(isNewSpecies bool, daysSinceFirst
 	if isNewSpecies {
 		suppress, notificationTime := a.shouldSuppressNewSpeciesNotification()
 		if !suppress {
+			// A new species is, by definition, absent from the image cache: the
+			// startup warm-up only covers previously detected species. Without a
+			// brief wait here the notification for the one detection users most
+			// want an image for would never carry one. Bounded so that a slow or
+			// throttled provider cannot push the surrounding CompositeAction
+			// towards its 30s timeout, and only on this branch: ordinary
+			// detections stay entirely off the provider path.
+			a.warmSpeciesImage(ctx)
+
 			detectionEvent := a.createDetectionEvent(true, daysSinceFirstSeen)
 			if detectionEvent != nil {
 				a.populateEventMetadata(detectionEvent, novelty)

--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -327,11 +327,16 @@ func (a *DatabaseAction) populateEventMetadata(detectionEvent events.DetectionEv
 	// root-relative or an absolute one built from a private host. The provider URL is a
 	// public CDN address and is the only form that renders. Tracked separately.
 	if a.processor != nil && a.processor.BirdImageCache != nil {
-		if birdImage, found, _ := a.processor.BirdImageCache.GetCached(a.Result.Species.ScientificName); found && birdImage.URL != "" {
+		birdImage, found, negative := a.processor.BirdImageCache.GetCached(a.Result.Species.ScientificName)
+		switch {
+		case found && birdImage.URL != "":
 			metadata["image_url"] = birdImage.URL
-		} else {
+		case !negative:
 			// Nothing cached yet, so this notification carries no image. Warm it for
 			// the next detection of this species instead of blocking on it here.
+			// Gated on !negative, matching the sibling call sites: a species every
+			// provider has already failed for would otherwise re-queue a prefetch on
+			// every single detection, and a noise class fires constantly.
 			a.processor.BirdImageCache.PrefetchAsync(a.Result.Species.ScientificName)
 		}
 	}

--- a/internal/analysis/processor/actions_integrations.go
+++ b/internal/analysis/processor/actions_integrations.go
@@ -235,6 +235,12 @@ func (a *MqttAction) Execute(_ context.Context, data any) error {
 
 	// Get bird image of detected bird using the shared helper
 	birdImage := getBirdImageFromCache(a.BirdImageCache, a.Result.Species.ScientificName, a.Result.Species.CommonName, a.CorrelationID)
+	// The URL stays the provider's upstream address. An MQTT subscriber is not a
+	// browser with an origin to resolve against, and the usual consumer (Home
+	// Assistant, a dashboard, an automation forwarding the image to a phone) may be
+	// off the LAN entirely, so a media-proxy URL is unusable there for the same
+	// reason it is unusable in a notification embed. Tracked separately along with
+	// the notification case.
 
 	// Get detection ID from shared context (set by DatabaseAction in CompositeAction sequence)
 	var detectionID uint
@@ -439,7 +445,9 @@ func (a *SSEAction) Execute(_ context.Context, data any) error {
 		}
 	}
 
-	// Get bird image of detected bird using the shared helper
+	// Get bird image of detected bird using the shared helper. NewSSEDetectionData
+	// substitutes the media-proxy URL, so only the attribution metadata is taken
+	// from here.
 	birdImage := getBirdImageFromCache(a.BirdImageCache, a.Result.Species.ScientificName, a.Result.Species.CommonName, a.CorrelationID)
 
 	// Convert Result to Note for SSEBroadcaster (backward compatible SSE payload)

--- a/internal/analysis/processor/detection_event_test.go
+++ b/internal/analysis/processor/detection_event_test.go
@@ -173,7 +173,7 @@ func TestPublishDetectionEvent_OrdinaryDetection(t *testing.T) {
 		CorrelationID: "test-ordinary-det",
 	}
 
-	action.publishDetectionEvent(false, 30, species.NoveltyStatus{})
+	action.publishDetectionEvent(t.Context(), false, 30, species.NoveltyStatus{})
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		received := consumer.GetReceivedEvents()
@@ -201,7 +201,7 @@ func TestPublishDetectionEvent_InactiveNoveltyOmitsEpisodeSentinel(t *testing.T)
 		CorrelationID: "test-inactive-novelty",
 	}
 
-	action.publishDetectionEvent(false, 30, species.NoveltyStatus{
+	action.publishDetectionEvent(t.Context(), false, 30, species.NoveltyStatus{
 		DaysSinceLastSeen:    0,
 		NoveltyEpisodeDays:   inactiveNoveltyEpisodeDays,
 		NoveltyEpisodeActive: false,
@@ -229,7 +229,7 @@ func TestPublishDetectionEvent_ActiveNoveltyIncludesSameDayLastSeen(t *testing.T
 	}
 
 	episodeStart := time.Date(2026, 5, 23, 8, 0, 0, 0, time.UTC)
-	action.publishDetectionEvent(false, 30, species.NoveltyStatus{
+	action.publishDetectionEvent(t.Context(), false, 30, species.NoveltyStatus{
 		DaysSinceLastSeen:    0,
 		NoveltyEpisodeDays:   12,
 		NoveltyEpisodeStart:  episodeStart,
@@ -259,7 +259,7 @@ func TestPublishDetectionEvent_NewSpecies(t *testing.T) {
 		CorrelationID: "test-new-species-det",
 	}
 
-	action.publishDetectionEvent(true, 0, species.NoveltyStatus{})
+	action.publishDetectionEvent(t.Context(), true, 0, species.NoveltyStatus{})
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		received := consumer.GetReceivedEvents()
@@ -305,7 +305,7 @@ func TestPublishDetectionEvent_SuppressedNewSpecies(t *testing.T) {
 		NewSpeciesTracker: tracker,
 	}
 
-	action.publishDetectionEvent(true, 0, species.NoveltyStatus{})
+	action.publishDetectionEvent(t.Context(), true, 0, species.NoveltyStatus{})
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		received := consumer.GetReceivedEvents()
@@ -332,7 +332,7 @@ func TestPublishDetectionEvent_NoEventBus(t *testing.T) {
 
 	// Should not panic when event bus is not initialized
 	assert.NotPanics(t, func() {
-		action.publishDetectionEvent(false, 10, species.NoveltyStatus{})
-		action.publishDetectionEvent(true, 0, species.NoveltyStatus{})
+		action.publishDetectionEvent(t.Context(), false, 10, species.NoveltyStatus{})
+		action.publishDetectionEvent(t.Context(), true, 0, species.NoveltyStatus{})
 	})
 }

--- a/internal/analysis/processor/image_proxy_boundary_test.go
+++ b/internal/analysis/processor/image_proxy_boundary_test.go
@@ -15,11 +15,6 @@ import (
 // stallingImageProvider parks every Fetch until released, so a caller that still
 // resolves an image on its own goroutine hangs the test instead of merely running
 // slowly.
-//
-// It parks on a channel rather than a bare select{} so the fetch can be released at
-// cleanup. fetchFromProvider runs a context-free provider on its own goroutine and
-// abandons it on cancellation, so a permanently-parked Fetch would outlive the test
-// and fail the package's goleak check.
 type stallingImageProvider struct {
 	enteredOnce sync.Once
 	entered     chan struct{}
@@ -42,6 +37,21 @@ func (p *stallingImageProvider) Fetch(scientificName string) (imageprovider.Bird
 	return imageprovider.BirdImage{}, imageprovider.ErrImageNotFound
 }
 
+// newStallingCache builds a cache around a provider that never returns.
+//
+// Deliberately NOT imageprovider.InitCache: that reads conf.Setting(), which
+// lazy-loads settings from disk when the global is unset and publishes them over
+// whatever this package's other tests installed, breaking every sibling test that
+// reads settings. Nothing under test here needs the parts InitCache supplies; the
+// prefetch machinery it would enable is covered in the imageprovider package, where
+// InitCache is the subject rather than incidental setup.
+func newStallingCache(t *testing.T) *imageprovider.BirdImageCache {
+	t.Helper()
+	cache := &imageprovider.BirdImageCache{}
+	cache.SetImageProvider(newStallingImageProvider(t))
+	return cache
+}
+
 // TestGetThumbnailURL_DoesNotConsultTheCache is the regression test for a stall that
 // reached far beyond thumbnails.
 //
@@ -54,8 +64,8 @@ func TestGetThumbnailURL_DoesNotConsultTheCache(t *testing.T) {
 	t.Parallel()
 
 	stalling := newStallingImageProvider(t)
-	cache := imageprovider.InitCache("wikimedia", stalling, nil, nil)
-	t.Cleanup(func() { assert.NoError(t, cache.Close()) })
+	cache := &imageprovider.BirdImageCache{}
+	cache.SetImageProvider(stalling)
 
 	p := &Processor{BirdImageCache: cache}
 
@@ -98,9 +108,7 @@ func TestGetThumbnailURL_EmitsAURLWithNoCacheConfigured(t *testing.T) {
 func TestPopulateEventMetadata_DoesNotBlockOnTheProvider(t *testing.T) {
 	t.Parallel()
 
-	stalling := newStallingImageProvider(t)
-	cache := imageprovider.InitCache("wikimedia", stalling, nil, nil)
-	t.Cleanup(func() { assert.NoError(t, cache.Close()) })
+	cache := newStallingCache(t)
 
 	action := &DatabaseAction{processor: &Processor{BirdImageCache: cache}}
 	action.Result.Species.ScientificName = "Turdus merula"
@@ -124,10 +132,25 @@ func TestPopulateEventMetadata_DoesNotBlockOnTheProvider(t *testing.T) {
 	// Nothing is cached, so no image is advertised at all rather than a URL that has
 	// not been resolved yet.
 	assert.NotContains(t, event.GetMetadata(), "image_url")
+}
+
+// TestGetBirdImageFromCache_DoesNotBlock covers the helper both the SSE and MQTT
+// actions use, which runs inside the same CompositeAction. A cache miss must return
+// promptly with an empty image rather than resolving one on the caller's goroutine.
+func TestGetBirdImageFromCache_DoesNotBlock(t *testing.T) {
+	t.Parallel()
+
+	cache := newStallingCache(t)
+
+	done := make(chan imageprovider.BirdImage, 1)
+	go func() {
+		done <- getBirdImageFromCache(cache, "Turdus merula", "Eurasian Blackbird", "test-correlation")
+	}()
 
 	select {
-	case <-stalling.entered:
+	case img := <-done:
+		assert.Empty(t, img.URL, "a miss yields an empty image, not a resolved one")
 	case <-time.After(2 * time.Second):
-		t.Fatal("a cache miss should have scheduled a background prefetch")
+		t.Fatal("getBirdImageFromCache blocked on the image provider")
 	}
 }

--- a/internal/analysis/processor/image_proxy_boundary_test.go
+++ b/internal/analysis/processor/image_proxy_boundary_test.go
@@ -1,0 +1,133 @@
+package processor
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/analysis/species"
+	"github.com/tphakala/birdnet-go/internal/events"
+	"github.com/tphakala/birdnet-go/internal/imageprovider"
+)
+
+// stallingImageProvider parks every Fetch until released, so a caller that still
+// resolves an image on its own goroutine hangs the test instead of merely running
+// slowly.
+//
+// It parks on a channel rather than a bare select{} so the fetch can be released at
+// cleanup. fetchFromProvider runs a context-free provider on its own goroutine and
+// abandons it on cancellation, so a permanently-parked Fetch would outlive the test
+// and fail the package's goleak check.
+type stallingImageProvider struct {
+	enteredOnce sync.Once
+	entered     chan struct{}
+	release     chan struct{}
+}
+
+func newStallingImageProvider(t *testing.T) *stallingImageProvider {
+	t.Helper()
+	p := &stallingImageProvider{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	t.Cleanup(func() { close(p.release) })
+	return p
+}
+
+func (p *stallingImageProvider) Fetch(scientificName string) (imageprovider.BirdImage, error) {
+	p.enteredOnce.Do(func() { close(p.entered) })
+	<-p.release
+	return imageprovider.BirdImage{}, imageprovider.ErrImageNotFound
+}
+
+// TestGetThumbnailURL_DoesNotConsultTheCache is the regression test for a stall that
+// reached far beyond thumbnails.
+//
+// getThumbnailURL used to call BirdImageCache.Get purely as an existence predicate,
+// choosing between the proxy URL and an empty string. That call is a synchronous,
+// uncancellable provider fetch, and it ran under pendingMutex.RLock and, through the
+// 1s-ticker caller in processor.go, under the exclusive Lock. One cold species could
+// therefore stall pending-detection processing for as long as the provider took.
+func TestGetThumbnailURL_DoesNotConsultTheCache(t *testing.T) {
+	t.Parallel()
+
+	stalling := newStallingImageProvider(t)
+	cache := imageprovider.InitCache("wikimedia", stalling, nil, nil)
+	t.Cleanup(func() { assert.NoError(t, cache.Close()) })
+
+	p := &Processor{BirdImageCache: cache}
+
+	done := make(chan string, 1)
+	go func() { done <- p.getThumbnailURL("Turdus merula") }()
+
+	select {
+	case got := <-done:
+		assert.Equal(t, imageprovider.ProxyImageURL("Turdus merula"), got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("getThumbnailURL blocked on the image provider")
+	}
+
+	select {
+	case <-stalling.entered:
+		t.Fatal("getThumbnailURL reached the image provider")
+	default:
+	}
+}
+
+// TestGetThumbnailURL_EmitsAURLWithNoCacheConfigured asserts the URL is unconditional.
+// Returning "" for an unresolved species is what let a detection reach the client with
+// no image reference at all, which the frontend cannot recover from.
+func TestGetThumbnailURL_EmitsAURLWithNoCacheConfigured(t *testing.T) {
+	t.Parallel()
+
+	p := &Processor{}
+	assert.Equal(t, imageprovider.ProxyImageURL("Parus major"), p.getThumbnailURL("Parus major"))
+}
+
+// TestPopulateEventMetadata_DoesNotBlockOnTheProvider pins the de-blocking half of the
+// change on the detection-save path: no provider fetch inside the CompositeAction,
+// whose 30s timeout this file's siblings document as the reason slow work was moved out
+// of it.
+//
+// The URL itself deliberately stays the provider's upstream address: this metadata
+// becomes bg_image_url in Discord and webhook payloads, which the notification service
+// fetches server-side from outside the user's network, where no BirdNET-Go URL resolves
+// for a home-LAN install.
+func TestPopulateEventMetadata_DoesNotBlockOnTheProvider(t *testing.T) {
+	t.Parallel()
+
+	stalling := newStallingImageProvider(t)
+	cache := imageprovider.InitCache("wikimedia", stalling, nil, nil)
+	t.Cleanup(func() { assert.NoError(t, cache.Close()) })
+
+	action := &DatabaseAction{processor: &Processor{BirdImageCache: cache}}
+	action.Result.Species.ScientificName = "Turdus merula"
+	action.Result.Species.CommonName = "Eurasian Blackbird"
+
+	event, err := events.NewDetectionEvent("Eurasian Blackbird", "Turdus merula", 0.9, "", true, 1)
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	go func() {
+		action.populateEventMetadata(event, species.NoveltyStatus{})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("populateEventMetadata blocked on the image provider")
+	}
+
+	// Nothing is cached, so no image is advertised at all rather than a URL that has
+	// not been resolved yet.
+	assert.NotContains(t, event.GetMetadata(), "image_url")
+
+	select {
+	case <-stalling.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("a cache miss should have scheduled a background prefetch")
+	}
+}

--- a/internal/analysis/processor/pending_broadcast.go
+++ b/internal/analysis/processor/pending_broadcast.go
@@ -155,16 +155,17 @@ func (p *Processor) SnapshotVisiblePending() []SSEPendingDetection {
 	return result
 }
 
-// getThumbnailURL returns the thumbnail URL for a species from the bird image cache.
-// Returns empty string if the cache is unavailable or the species has no image.
+// getThumbnailURL returns the media-proxy URL for a species thumbnail.
+//
+// The URL is emitted unconditionally, matching every REST producer
+// (analytics.buildThumbnailURL). It used to call BirdImageCache.Get purely as an
+// existence predicate, choosing between this same URL and an empty string. That
+// probe was a synchronous, uncancellable provider fetch running under
+// pendingMutex.RLock and, via the caller at processor.go, under the exclusive Lock
+// that a 1s ticker drives, so one cold species could stall pending-detection
+// processing for as long as the provider took. The proxy already answers "not found"
+// for a species with no image, which is where that decision belongs.
 func (p *Processor) getThumbnailURL(scientificName string) string {
-	if p.BirdImageCache == nil {
-		return ""
-	}
-	img, err := p.BirdImageCache.Get(scientificName)
-	if err != nil || img.IsNegativeEntry() || img.URL == "" {
-		return ""
-	}
 	return imageprovider.ProxyImageURL(scientificName)
 }
 

--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -178,6 +178,18 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 | GET    | `/spectrogram/:id/status`            | `GetSpectrogramStatus`   | ❌   | Get spectrogram generation status  |
 | POST   | `/audio/:id/clip`                    | `ExtractAudioClipByID`   | ✅   | Extract audio clip from time range |
 
+**Pending species image (`503 + Retry-After`).** The image endpoints never contact an
+image provider on the request goroutine: a cold species can take minutes to resolve
+through the provider chain, and thirty queued thumbnail requests also exhaust a
+browser's per-host connection budget, which is what made the whole UI appear frozen. A
+species whose image is not cached yet therefore answers **503** with `Retry-After: 5`
+and `Cache-Control: no-store`, and a background fetch is scheduled; a species that is
+known to have no image answers **404** with a long `max-age`. The two cache directives
+are load-bearing: an `<img>` error event exposes no status code, so the browser's own
+HTTP cache is what lets a client retry cheaply (the 404 is served from cache with no
+network hop, the 503 reaches the server). The proxy is a hard boundary and never
+redirects a client to the upstream image host.
+
 **Pending clip handling (`503 + Retry-After`).** A detection's DB record and SSE
 broadcast are emitted before its audio clip is written, and with Extended Capture the
 clip write is deferred until the capture tail is recorded (up to the capture-buffer

--- a/internal/api/v2/apicore/sse.go
+++ b/internal/api/v2/apicore/sse.go
@@ -147,17 +147,22 @@ func NewSSEDetectionData(note *datastore.Note, birdImage *imageprovider.BirdImag
 		}
 	}
 
-	// Map bird image with proper camelCase tags
+	// The image URL always points at the media proxy, never at the upstream host.
+	// The proxy is the only URL whose availability this process controls, and it is
+	// the same URL every REST producer emits, so a species cannot render on one
+	// surface and fail on another. It is set unconditionally: the attribution
+	// metadata below may be absent while the image itself is still being resolved in
+	// the background, and an empty URL would make the client give up permanently.
+	det.BirdImage = SSEBirdImage{
+		URL:            imageprovider.ProxyImageURL(note.ScientificName),
+		ScientificName: note.ScientificName,
+	}
 	if birdImage != nil {
-		det.BirdImage = SSEBirdImage{
-			URL:            birdImage.URL,
-			ScientificName: birdImage.ScientificName,
-			LicenseName:    birdImage.LicenseName,
-			LicenseURL:     birdImage.LicenseURL,
-			AuthorName:     birdImage.AuthorName,
-			AuthorURL:      birdImage.AuthorURL,
-			SourceProvider: birdImage.SourceProvider,
-		}
+		det.BirdImage.LicenseName = birdImage.LicenseName
+		det.BirdImage.LicenseURL = birdImage.LicenseURL
+		det.BirdImage.AuthorName = birdImage.AuthorName
+		det.BirdImage.AuthorURL = birdImage.AuthorURL
+		det.BirdImage.SourceProvider = birdImage.SourceProvider
 	}
 
 	return det

--- a/internal/api/v2/apicore/sse_bird_image_test.go
+++ b/internal/api/v2/apicore/sse_bird_image_test.go
@@ -1,0 +1,54 @@
+package apicore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/imageprovider"
+)
+
+// TestNewSSEDetectionData_AlwaysEmitsProxyURL pins the proxy boundary on the SSE feed.
+//
+// The stream used to publish whatever URL the image provider returned, so a detection
+// could carry a raw upload.wikimedia.org address while the REST API published a proxy
+// URL for the same species. That is also why a species could render on one surface and
+// not another. The proxy URL is the only address whose availability this process
+// controls and whose cache policy it sets.
+func TestNewSSEDetectionData_AlwaysEmitsProxyURL(t *testing.T) {
+	t.Parallel()
+
+	note := &datastore.Note{ScientificName: "Turdus merula", CommonName: "Eurasian Blackbird"}
+
+	t.Run("with provider metadata", func(t *testing.T) {
+		t.Parallel()
+
+		det := NewSSEDetectionData(note, &imageprovider.BirdImage{
+			URL:            "https://upload.wikimedia.org/raw.jpg",
+			ScientificName: "Turdus merula",
+			AuthorName:     "Someone",
+			LicenseName:    "CC BY-SA 4.0",
+			SourceProvider: "wikimedia",
+		})
+
+		assert.Equal(t, imageprovider.ProxyImageURL("Turdus merula"), det.BirdImage.URL)
+		assert.NotContains(t, det.BirdImage.URL, "upload.wikimedia.org")
+		// Attribution still comes from the provider; only the URL is substituted.
+		assert.Equal(t, "Someone", det.BirdImage.AuthorName)
+		assert.Equal(t, "CC BY-SA 4.0", det.BirdImage.LicenseName)
+	})
+
+	t.Run("without provider metadata", func(t *testing.T) {
+		t.Parallel()
+
+		// The image is not resolved yet: the SSE producers no longer fetch on the
+		// detection-save path, so this is now the common case for a new species. The
+		// URL must still be emitted, or the client has nothing to load and shows a
+		// placeholder that never recovers.
+		det := NewSSEDetectionData(note, nil)
+
+		assert.Equal(t, imageprovider.ProxyImageURL("Turdus merula"), det.BirdImage.URL)
+		assert.Equal(t, "Turdus merula", det.BirdImage.ScientificName)
+		assert.Empty(t, det.BirdImage.AuthorName)
+	})
+}

--- a/internal/api/v2/media/media.go
+++ b/internal/api/v2/media/media.go
@@ -77,6 +77,12 @@ const (
 
 	// SpectrogramCacheSeconds is the cache duration for spectrograms in seconds
 	SpectrogramCacheSeconds = 2592000 // 30 days
+
+	// ImagePendingRetryAfterSeconds is the Retry-After advertised when a species
+	// image is not cached yet and a background fetch has been scheduled. It is short
+	// because the common case is a fast provider hit; a species queued behind the
+	// provider's rate limiter simply needs more than one retry.
+	ImagePendingRetryAfterSeconds = 5
 )
 
 // isClipNotFoundErr reports whether err indicates the audio clip or its parent
@@ -197,6 +203,10 @@ var (
 
 	// Image errors
 	ErrImageProviderNotAvailable = errors.NewStd("image provider not available")
+
+	// ErrImageNotResolvedYet reports that a species image is being fetched in the
+	// background and is not available yet. It is a transient condition, not a failure.
+	ErrImageNotResolvedYet = errors.NewStd("species image is not resolved yet")
 
 	// Sentinel errors for nilnil cases
 	ErrSpectrogramExists       = errors.NewStd("spectrogram already exists")
@@ -3447,13 +3457,13 @@ func (c *Handler) GetSpeciesImageInfo(ctx echo.Context) error {
 		return c.HandleError(ctx, ErrImageProviderNotAvailable, "Image service unavailable", http.StatusServiceUnavailable)
 	}
 
-	birdImage, err := cache.Get(scientificName)
-	if err != nil {
-		if errors.Is(err, imageprovider.ErrImageNotFound) {
-			ctx.Response().Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", NotFoundCacheSeconds))
-			return c.HandleError(ctx, err, "Image not found for species", http.StatusNotFound)
-		}
-		return c.HandleError(ctx, err, "Failed to fetch species image info", http.StatusInternalServerError)
+	birdImage, found, negative := cache.GetCached(scientificName)
+	switch {
+	case negative:
+		return c.respondImageNotFound(ctx)
+	case !found:
+		cache.PrefetchAsync(scientificName)
+		return c.respondImagePendingJSON(ctx, scientificName)
 	}
 
 	ctx.Response().Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", ImageCacheSeconds))
@@ -3467,10 +3477,64 @@ func (c *Handler) GetSpeciesImageInfo(ctx echo.Context) error {
 	})
 }
 
+// respondImageNotFound answers "this species has no image", cacheable by the browser.
+// A cached 404 is what keeps a species that genuinely has no image from re-requesting
+// on every render, and it is what makes the client-side retry cheap: the retry is
+// served from the browser's own HTTP cache without reaching the network.
+func (c *Handler) respondImageNotFound(ctx echo.Context) error {
+	ctx.Response().Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", NotFoundCacheSeconds))
+	return c.HandleError(ctx, imageprovider.ErrImageNotFound, "Image not found for species", http.StatusNotFound)
+}
+
+// respondImagePending answers "not yet, try again shortly" for a species whose image
+// is being resolved on a background goroutine.
+//
+// Deliberately not routed through HandleError: that reports every status >= 500 to
+// Sentry, and a cold dashboard requesting thirty uncached thumbnails would emit
+// thirty events for what is ordinary first-load behaviour.
+//
+// no-store is load-bearing. It is the only thing that distinguishes this response
+// from the cacheable 404 above for a client that cannot read a status code from an
+// <img> error event: a retry of a pending image reaches the server, a retry of a
+// missing image does not.
+func (c *Handler) respondImagePending(ctx echo.Context, scientificName string) error {
+	return c.respondImagePendingWithBody(ctx, scientificName, false)
+}
+
+// respondImagePendingJSON is respondImagePending for the JSON metadata endpoint, which
+// returns the project-standard ErrorResponse body so a client parsing every response
+// as JSON gets a document to back off on rather than a parse error.
+func (c *Handler) respondImagePendingJSON(ctx echo.Context, scientificName string) error {
+	return c.respondImagePendingWithBody(ctx, scientificName, true)
+}
+
+func (c *Handler) respondImagePendingWithBody(ctx echo.Context, scientificName string, withJSONBody bool) error {
+	c.LogDebugIfEnabled("Species image not cached yet, background fetch scheduled",
+		logger.String("scientific_name", scientificName))
+	header := ctx.Response().Header()
+	header.Set("Retry-After", strconv.Itoa(ImagePendingRetryAfterSeconds))
+	header.Set("Cache-Control", "no-store")
+	if withJSONBody {
+		return ctx.JSON(http.StatusServiceUnavailable,
+			c.NewErrorResponse(ErrImageNotResolvedYet, "Image is not resolved yet", http.StatusServiceUnavailable))
+	}
+	return ctx.NoContent(http.StatusServiceUnavailable)
+}
+
 // ServeSpeciesImageProxy serves a cached bird image by scientific name.
-// If the image is cached locally, it serves the file with browser cache headers.
-// If not cached, it fetches from the provider, caches, and serves.
-// Falls back to 302 redirect to external URL if local fetch fails.
+//
+// The proxy is a hard boundary: it serves bytes from the local cache or it says
+// "not found" / "not yet", but it never redirects a client to the upstream image
+// host. That keeps every consumer (browser, MQTT subscriber, notification target)
+// pointed at one URL whose availability this process controls.
+//
+// It never contacts an image provider on the request goroutine. BirdImageCache.Get
+// is uncancellable and, for a cold species, bounded only by the provider's retry and
+// rate-limit budget (worst case minutes); running it here is what froze the UI, since
+// ~30 queued thumbnail requests also exhaust the browser's per-host connection
+// budget and starve unrelated API calls and the SSE stream. A cold miss instead
+// schedules a background fetch and returns 503 immediately.
+//
 // Route: GET /media/image/:scientific_name
 // Route: GET /media/bird-image/:scientific_name (alias)
 func (c *Handler) ServeSpeciesImageProxy(ctx echo.Context) error {
@@ -3494,27 +3558,21 @@ func (c *Handler) ServeSpeciesImageProxy(ctx echo.Context) error {
 		return c.HandleError(ctx, ErrImageProviderNotAvailable, "Image service unavailable", http.StatusServiceUnavailable)
 	}
 
-	// Look up metadata to know which provider owns this image
-	birdImage, err := cache.Get(scientificName)
-	if err != nil {
-		if errors.Is(err, imageprovider.ErrImageNotFound) {
-			ctx.Response().Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", NotFoundCacheSeconds))
-			return c.HandleError(ctx, err, "Image not found for species", http.StatusNotFound)
-		}
-		return c.HandleError(ctx, err, "Failed to fetch species image", http.StatusInternalServerError)
+	// Cached-only lookup: never contacts a provider, so this cannot block.
+	birdImage, found, negative := cache.GetCached(scientificName)
+	switch {
+	case negative:
+		return c.respondImageNotFound(ctx)
+	case !found:
+		cache.PrefetchAsync(scientificName)
+		return c.respondImagePending(ctx, scientificName)
 	}
 
-	// Negative cache entries have no real image URL
-	if birdImage.IsNegativeEntry() || birdImage.URL == "" {
-		ctx.Response().Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", NotFoundCacheSeconds))
-		return c.HandleError(ctx, imageprovider.ErrImageNotFound, "Image not found for species", http.StatusNotFound)
-	}
-
-	// Get the file cache from the BirdImageCache
 	fileCache := cache.GetFileCache()
 	if fileCache == nil {
-		// No file cache configured, redirect to external URL
-		return ctx.Redirect(http.StatusFound, birdImage.URL)
+		// Without a file cache the proxy has no bytes to serve and, as a hard
+		// boundary, will not hand the client an external URL instead.
+		return c.respondImagePending(ctx, scientificName)
 	}
 
 	provider := birdImage.SourceProvider
@@ -3535,29 +3593,21 @@ func (c *Handler) ServeSpeciesImageProxy(ctx echo.Context) error {
 		return c.serveImageFile(ctx, cachedPath, contentType)
 	}
 
-	// File not cached or stale - download it
-	newPath, newCT, dlErr := fileCache.DownloadAndStore(ctx.Request().Context(), provider, scientificName, birdImage.URL)
-	if dlErr != nil {
-		// Graceful degradation: serve stale file if available, otherwise redirect
-		if cachedPath != "" {
-			c.LogDebugIfEnabled("Download failed, serving stale cached image",
-				logger.String("scientific_name", scientificName),
-				logger.String("path", cachedPath),
-				logger.Error(dlErr))
-			return c.serveImageFile(ctx, cachedPath, contentType)
-		}
-		c.LogInfoIfEnabled("File cache download failed, redirecting to external URL",
+	// The bytes are missing or stale. Downloading them here would put the request
+	// back on the network path the rest of this handler exists to avoid, and
+	// DownloadAndStore runs its shared work on the first caller's context, so one
+	// aborted tab would cancel the download for every concurrent waiter. Schedule it
+	// on the cache's own goroutine instead.
+	cache.PrefetchAsync(scientificName)
+
+	if cachedPath != "" {
+		c.LogDebugIfEnabled("Serving stale cached image while refreshing in the background",
 			logger.String("scientific_name", scientificName),
-			logger.String("url", birdImage.URL),
-			logger.Error(dlErr))
-		return ctx.Redirect(http.StatusFound, birdImage.URL)
+			logger.String("path", cachedPath))
+		return c.serveImageFile(ctx, cachedPath, contentType)
 	}
 
-	c.LogDebugIfEnabled("Serving freshly downloaded image",
-		logger.String("scientific_name", scientificName),
-		logger.String("path", newPath),
-		logger.String("content_type", newCT))
-	return c.serveImageFile(ctx, newPath, newCT)
+	return c.respondImagePending(ctx, scientificName)
 }
 
 // serveImageFile serves a cached image file with appropriate cache headers.

--- a/internal/api/v2/media/media_test.go
+++ b/internal/api/v2/media/media_test.go
@@ -14,7 +14,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1495,25 +1494,17 @@ func TestSpeciesImageColdMiss_ReturnsPendingNot500(t *testing.T) {
 func TestSpeciesImageColdMiss_ConcurrentRequestsAllReturnPromptly(t *testing.T) {
 	t.Attr("component", "media")
 
+	e := echo.New()
+	controller := New(apitest.NewCore(t, apitest.WithEcho(e)))
+
 	blocked := make(chan struct{})
 	t.Cleanup(func() { close(blocked) })
-	var fetches atomic.Int64
-	provider := &apitest.TestImageProvider{
+	controller.BirdImageCache.SetImageProvider(&apitest.TestImageProvider{
 		FetchFunc: func(scientificName string) (imageprovider.BirdImage, error) {
-			fetches.Add(1)
 			<-blocked
 			return imageprovider.BirdImage{}, imageprovider.ErrImageNotFound
 		},
-	}
-	// Built via InitCache rather than the shared mock: PrefetchAsync declines to
-	// schedule on a cache assembled outside InitCache, because such a cache has
-	// neither the bounding semaphore nor the cancellable parent context. Observing the
-	// dedup therefore needs the real thing.
-	cache := imageprovider.InitCache("wikimedia", provider, nil, nil)
-	t.Cleanup(func() { assert.NoError(t, cache.Close()) })
-
-	e := echo.New()
-	controller := New(apitest.NewCore(t, apitest.WithEcho(e), apitest.WithBirdImageCache(cache)))
+	})
 
 	const concurrency = 10
 	codes := make(chan int, concurrency)
@@ -1543,14 +1534,10 @@ func TestSpeciesImageColdMiss_ConcurrentRequestsAllReturnPromptly(t *testing.T) 
 		assert.Equal(t, http.StatusServiceUnavailable, code)
 	}
 
-	// wg.Wait() returns as soon as the handlers return, which is well before the
-	// background prefetch reaches the provider. Waiting for the first fetch and then
-	// asserting no second one ever arrives is what makes a broken dedup fail: a bare
-	// "at most one" check immediately after the handlers is satisfied by zero.
-	require.Eventually(t, func() bool { return fetches.Load() >= 1 }, 3*time.Second, 10*time.Millisecond,
-		"the cold miss should have scheduled a background fetch")
-	require.Never(t, func() bool { return fetches.Load() > 1 }, 500*time.Millisecond, 20*time.Millisecond,
-		"ten requests for one cold species must not schedule ten provider fetches")
+	// Prefetch deduplication is asserted where it lives, in
+	// TestPrefetchAsync_DeduplicatesBySpecies. What this test owns is the handler
+	// contract: every concurrent request answers immediately instead of queueing
+	// behind one fetch, which is what exhausted the browser's connection budget.
 }
 
 // TestServeSpeciesImageProxy_NeverRedirects asserts the D2 boundary for a species that

--- a/internal/api/v2/media/media_test.go
+++ b/internal/api/v2/media/media_test.go
@@ -3,6 +3,7 @@
 package media
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -10,8 +11,10 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1360,6 +1363,11 @@ func TestIsValidFilename(t *testing.T) {
 // TestSpeciesImageNotFound_Returns404 verifies that image endpoints return HTTP 404
 // (not 500) when the image provider has no image for a species.
 // Regression test for GitHub issue #2201.
+//
+// The negative cache entry is primed up front because the handlers no longer consult
+// a provider on the request goroutine: a species nothing is known about yet answers
+// 503 "not yet" (see TestSpeciesImageColdMiss_ReturnsPendingNot500) and only becomes
+// a 404 once the lookup has actually concluded there is no image.
 func TestSpeciesImageNotFound_Returns404(t *testing.T) {
 	t.Attr("component", "media")
 	t.Attr("type", "regression")
@@ -1376,6 +1384,11 @@ func TestSpeciesImageNotFound_Returns404(t *testing.T) {
 		},
 	}
 	controller.BirdImageCache.SetImageProvider(notFoundProvider)
+
+	// Resolve the species once so the negative entry exists, making the handler
+	// assertions below independent of background prefetch timing.
+	_, err := controller.BirdImageCache.Get("Nonexistus fictus")
+	require.ErrorIs(t, err, imageprovider.ErrImageNotFound)
 
 	tests := []struct {
 		name    string
@@ -1426,6 +1439,193 @@ func TestSpeciesImageNotFound_Returns404(t *testing.T) {
 				"Response body should indicate image was not found")
 		})
 	}
+}
+
+// TestSpeciesImageColdMiss_ReturnsPendingNot500 pins the cold-miss contract that the
+// whole de-blocking change rests on.
+//
+// A species nothing is cached for must answer immediately with 503 plus a Retry-After
+// and, critically, Cache-Control: no-store. An <img> error event carries no status
+// code, so no-store is the only thing that tells a retrying browser this failure is
+// transient: a cacheable 404 is served from its own HTTP cache without a network hop,
+// while this response is re-requested and can succeed once the background fetch lands.
+//
+// It must never be a 500. apicore reports every status >= 500 to Sentry, and a cold
+// dashboard requests dozens of uncached thumbnails at once.
+func TestSpeciesImageColdMiss_ReturnsPendingNot500(t *testing.T) {
+	t.Attr("component", "media")
+
+	e := echo.New()
+	controller := New(apitest.NewCore(t, apitest.WithEcho(e)))
+
+	// A provider that never returns lets the assertion prove the handler did not wait
+	// for it: if the fetch were still on the request path, this test would hang.
+	blocked := make(chan struct{})
+	t.Cleanup(func() { close(blocked) })
+	controller.BirdImageCache.SetImageProvider(&apitest.TestImageProvider{
+		FetchFunc: func(scientificName string) (imageprovider.BirdImage, error) {
+			<-blocked
+			return imageprovider.BirdImage{}, imageprovider.ErrImageNotFound
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/media/image/Coldus%20missus", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("scientific_name")
+	ctx.SetParamValues("Coldus missus")
+
+	require.NoError(t, controller.ServeSpeciesImageProxy(ctx))
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Equal(t, strconv.Itoa(ImagePendingRetryAfterSeconds), rec.Header().Get("Retry-After"))
+	assert.Equal(t, "no-store", rec.Header().Get("Cache-Control"),
+		"a pending image must not be cached, or the client retry never reaches the server")
+	assert.Empty(t, rec.Header().Get("Location"),
+		"the proxy is a hard boundary and must never redirect to the upstream image host")
+}
+
+// TestSpeciesImageColdMiss_ConcurrentRequestsAllReturnPromptly is the shape that
+// actually reproduced the reported freeze: a dashboard asking for the same uncached
+// species from several connections at once.
+//
+// Every one of them must answer immediately. Queueing them behind the first request's
+// fetch is what exhausted the browser's per-host connection budget and starved
+// unrelated API calls and the SSE stream.
+func TestSpeciesImageColdMiss_ConcurrentRequestsAllReturnPromptly(t *testing.T) {
+	t.Attr("component", "media")
+
+	blocked := make(chan struct{})
+	t.Cleanup(func() { close(blocked) })
+	var fetches atomic.Int64
+	provider := &apitest.TestImageProvider{
+		FetchFunc: func(scientificName string) (imageprovider.BirdImage, error) {
+			fetches.Add(1)
+			<-blocked
+			return imageprovider.BirdImage{}, imageprovider.ErrImageNotFound
+		},
+	}
+	// Built via InitCache rather than the shared mock: PrefetchAsync declines to
+	// schedule on a cache assembled outside InitCache, because such a cache has
+	// neither the bounding semaphore nor the cancellable parent context. Observing the
+	// dedup therefore needs the real thing.
+	cache := imageprovider.InitCache("wikimedia", provider, nil, nil)
+	t.Cleanup(func() { assert.NoError(t, cache.Close()) })
+
+	e := echo.New()
+	controller := New(apitest.NewCore(t, apitest.WithEcho(e), apitest.WithBirdImageCache(cache)))
+
+	const concurrency = 10
+	codes := make(chan int, concurrency)
+	var wg sync.WaitGroup
+	for range concurrency {
+		wg.Go(func() {
+			req := httptest.NewRequest(http.MethodGet, "/api/v2/media/image/Coldus%20missus", http.NoBody)
+			rec := httptest.NewRecorder()
+			ctx := e.NewContext(req, rec)
+			ctx.SetParamNames("scientific_name")
+			ctx.SetParamValues("Coldus missus")
+			_ = controller.ServeSpeciesImageProxy(ctx)
+			codes <- rec.Code
+		})
+	}
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("concurrent cold-miss requests queued behind the provider fetch")
+	}
+
+	close(codes)
+	for code := range codes {
+		assert.Equal(t, http.StatusServiceUnavailable, code)
+	}
+
+	// wg.Wait() returns as soon as the handlers return, which is well before the
+	// background prefetch reaches the provider. Waiting for the first fetch and then
+	// asserting no second one ever arrives is what makes a broken dedup fail: a bare
+	// "at most one" check immediately after the handlers is satisfied by zero.
+	require.Eventually(t, func() bool { return fetches.Load() >= 1 }, 3*time.Second, 10*time.Millisecond,
+		"the cold miss should have scheduled a background fetch")
+	require.Never(t, func() bool { return fetches.Load() > 1 }, 500*time.Millisecond, 20*time.Millisecond,
+		"ten requests for one cold species must not schedule ten provider fetches")
+}
+
+// TestServeSpeciesImageProxy_NeverRedirects asserts the D2 boundary for a species that
+// IS resolved but whose bytes are not on disk. This used to 302 to the provider's own
+// URL, which handed clients an address whose availability this process does not
+// control and which API clients (unlike browsers) were refused outright.
+func TestServeSpeciesImageProxy_NeverRedirects(t *testing.T) {
+	t.Attr("component", "media")
+
+	e := echo.New()
+	controller := New(apitest.NewCore(t, apitest.WithEcho(e)))
+	controller.BirdImageCache.SetImageProvider(&apitest.TestImageProvider{
+		FetchFunc: func(scientificName string) (imageprovider.BirdImage, error) {
+			return imageprovider.BirdImage{
+				URL:            "https://upload.wikimedia.org/does-not-matter.jpg",
+				ScientificName: scientificName,
+				SourceProvider: "wikimedia",
+			}, nil
+		},
+	})
+
+	// Resolve the metadata so the handler takes the "cached, but no bytes" branch.
+	_, err := controller.BirdImageCache.Get("Turdus merula")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/media/image/Turdus%20merula", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("scientific_name")
+	ctx.SetParamValues("Turdus merula")
+
+	require.NoError(t, controller.ServeSpeciesImageProxy(ctx))
+
+	// Pin the positive contract, not just "not a 302": NotEqual(302) would also pass
+	// for a 200 or a 500, so it cannot tell the boundary being held from the handler
+	// having failed some other way.
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Equal(t, "no-store", rec.Header().Get("Cache-Control"))
+	assert.Empty(t, rec.Header().Get("Location"),
+		"the proxy must never hand the client the upstream image host")
+	assert.NotContains(t, rec.Body.String(), "upload.wikimedia.org",
+		"the upstream URL must not leak to the client")
+}
+
+// TestGetSpeciesImageInfo_ColdMissReturnsPendingJSON covers the metadata endpoint's
+// half of the same contract. It differs from the image endpoint deliberately: this one
+// is consumed by fetch() rather than an <img>, so it must return a parseable body for
+// a client that reads every response as JSON.
+func TestGetSpeciesImageInfo_ColdMissReturnsPendingJSON(t *testing.T) {
+	t.Attr("component", "media")
+
+	e := echo.New()
+	controller := New(apitest.NewCore(t, apitest.WithEcho(e)))
+
+	blocked := make(chan struct{})
+	t.Cleanup(func() { close(blocked) })
+	controller.BirdImageCache.SetImageProvider(&apitest.TestImageProvider{
+		FetchFunc: func(scientificName string) (imageprovider.BirdImage, error) {
+			<-blocked
+			return imageprovider.BirdImage{}, imageprovider.ErrImageNotFound
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/media/species-image/info?name=Coldus+missus", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	require.NoError(t, controller.GetSpeciesImageInfo(ctx))
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Equal(t, strconv.Itoa(ImagePendingRetryAfterSeconds), rec.Header().Get("Retry-After"))
+	assert.Equal(t, "no-store", rec.Header().Get("Cache-Control"))
+	assert.NotEmpty(t, rec.Body.String(), "a JSON endpoint must not answer with an empty body")
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
 }
 
 // TestGetSpectrogramLogger tests that the spectrogram logger is never nil

--- a/internal/api/v2/sse_contract_test.go
+++ b/internal/api/v2/sse_contract_test.go
@@ -309,7 +309,10 @@ func TestSSEContract_DetectionPayload_FieldNames(t *testing.T) {
 		birdImage, ok := payload[sseContractFields.BirdImage].(map[string]any)
 		require.True(t, ok, "birdImage must be an object")
 
-		assert.Equal(t, "https://example.com/bird.jpg", birdImage[sseContractFields.BirdImageURL],
+		// The stream publishes the media-proxy URL, not the provider's upstream URL,
+		// so a species renders identically here and through the REST API and cannot
+		// be left pointing at a host whose availability this process does not control.
+		assert.Equal(t, imageprovider.ProxyImageURL("Parus major"), birdImage[sseContractFields.BirdImageURL],
 			"SSE API CONTRACT: birdImage.url value mismatch")
 		assert.Equal(t, "CC BY-SA 4.0", birdImage[sseContractFields.BirdImageLicenseName],
 			"SSE API CONTRACT: birdImage.licenseName value mismatch")
@@ -380,7 +383,7 @@ func TestSSEContract_FrontendAccessPaths(t *testing.T) {
 
 		url, exists := birdImage["url"]
 		require.True(t, exists, "FRONTEND BROKEN: Cannot access data.birdImage.url")
-		assert.Equal(t, "https://example.com/bird.jpg", url)
+		assert.Equal(t, imageprovider.ProxyImageURL("Parus major"), url)
 	})
 
 	t.Run("Frontend can access detection ID", func(t *testing.T) {
@@ -943,8 +946,10 @@ func TestSSEContract_BirdImage_AllSubFields(t *testing.T) {
 		birdImage, ok := birdImageRaw.(map[string]any)
 		require.True(t, ok, "SSE API CONTRACT: birdImage must be an object")
 
-		// Verify all fields are present and have correct values
-		assert.Equal(t, "https://example.com/bird.jpg", birdImage["url"],
+		// Verify all fields are present and have correct values. The URL is the
+		// media-proxy URL, not the provider's upstream address: see the note on the
+		// nil-image case below.
+		assert.Equal(t, imageprovider.ProxyImageURL("Parus major"), birdImage["url"],
 			"SSE API CONTRACT: birdImage.url value must match")
 		assert.Equal(t, "Parus major", birdImage["scientificName"],
 			"SSE API CONTRACT: birdImage.scientificName value must match")
@@ -1009,11 +1014,16 @@ func TestSSEContract_BirdImage_AllSubFields(t *testing.T) {
 		birdImage, ok := birdImageRaw.(map[string]any)
 		require.True(t, ok, "SSE API CONTRACT: birdImage must be an object")
 
-		// url field should be present but empty (no omitempty on url)
+		// The URL is now derived from the detection's scientific name rather than from
+		// the resolved image, so it is present even when no image has been resolved
+		// yet. That is deliberate: since the proxy stopped fetching on the request
+		// path, "not resolved yet" is the normal state at broadcast time, and an empty
+		// URL would tell the client there is no image rather than not yet. The proxy
+		// answers 404 for a species that genuinely has none.
 		urlVal, urlExists := birdImage["url"]
-		assert.True(t, urlExists, "SSE API CONTRACT: birdImage.url key must exist even when empty")
-		assert.Empty(t, urlVal,
-			"SSE API CONTRACT: birdImage.url must be empty when no image provided")
+		assert.True(t, urlExists, "SSE API CONTRACT: birdImage.url key must exist")
+		assert.Equal(t, imageprovider.ProxyImageURL("Parus major"), urlVal,
+			"SSE API CONTRACT: birdImage.url must be the media-proxy URL even with no image resolved")
 	})
 }
 
@@ -1156,7 +1166,7 @@ func TestSSEContract_AllFieldValues_RoundTrip(t *testing.T) {
 		bi, ok := payload["birdImage"].(map[string]any)
 		require.True(t, ok, "birdImage must be an object")
 
-		assert.Equal(t, "https://example.com/bird.jpg", bi["url"])
+		assert.Equal(t, imageprovider.ProxyImageURL("Parus major"), bi["url"])
 		assert.Equal(t, "Parus major", bi["scientificName"])
 		assert.Equal(t, "CC BY-SA 4.0", bi["licenseName"])
 		assert.Equal(t, "https://creativecommons.org/licenses/by-sa/4.0/", bi["licenseURL"])

--- a/internal/imageprovider/deblocking_test.go
+++ b/internal/imageprovider/deblocking_test.go
@@ -1,0 +1,415 @@
+package imageprovider
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+)
+
+// blockingProvider parks every Fetch until released, so a test can prove a caller did
+// not wait for the provider rather than merely that it was fast.
+type blockingProvider struct {
+	release chan struct{}
+	calls   atomic.Int64
+	// cancelled records that a parked fetch actually observed its context being
+	// cancelled, so a test can assert the cancellation path rather than merely that
+	// the caller stopped waiting.
+	cancelled atomic.Bool
+	result    BirdImage
+	err       error
+}
+
+func newBlockingProvider(t *testing.T) *blockingProvider {
+	t.Helper()
+	p := &blockingProvider{release: make(chan struct{})}
+	// Released on cleanup so a parked fetch cannot outlive the test and trip goleak.
+	t.Cleanup(func() {
+		select {
+		case <-p.release:
+		default:
+			close(p.release)
+		}
+	})
+	return p
+}
+
+func (p *blockingProvider) Fetch(scientificName string) (BirdImage, error) {
+	p.calls.Add(1)
+	<-p.release
+	return p.result, p.err
+}
+
+func (p *blockingProvider) FetchWithContext(ctx context.Context, scientificName string) (BirdImage, error) {
+	p.calls.Add(1)
+	select {
+	case <-p.release:
+		return p.result, p.err
+	case <-ctx.Done():
+		p.cancelled.Store(true)
+		return BirdImage{}, ctx.Err()
+	}
+}
+
+// newDeblockingCache builds a cache with no datastore, so every lookup that is not in
+// the memory map exercises the "nothing cached" path.
+func newDeblockingCache(t *testing.T, provider ImageProvider) *BirdImageCache {
+	t.Helper()
+	cache := InitCache(wikiProviderName, provider, nil, nil)
+	t.Cleanup(func() { assert.NoError(t, cache.Close()) })
+	return cache
+}
+
+// TestGetWithContext_CancellationUnblocksCaller is the core of the de-blocking work:
+// before it, BirdImageCache.Get took no context, so a caller that had already given up
+// still waited out the provider's full retry and rate-limit budget (minutes for a cold
+// species behind the 1 req/s global limiter).
+func TestGetWithContext_CancellationUnblocksCaller(t *testing.T) {
+	t.Parallel()
+
+	provider := newBlockingProvider(t)
+	cache := newDeblockingCache(t, provider)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		_, err := cache.GetWithContext(ctx, "Turdus merula")
+		done <- err
+	}()
+
+	// Wait until the provider is actually parked, so the cancellation below is
+	// unblocking a real in-flight fetch rather than racing the goroutine's start.
+	require.Eventually(t, func() bool { return provider.calls.Load() > 0 }, 2*time.Second, 5*time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("GetWithContext did not return after its context was cancelled")
+	}
+}
+
+// TestGetWithContext_CancellationUnblocksLockWaiter covers the second half of the same
+// problem: a caller can be stuck waiting for ANOTHER goroutine's fetch. The per-species
+// initialization lock used to be a sync.Mutex, whose acquisition cannot be abandoned,
+// so a request arriving during a cold fetch inherited that fetch's full duration.
+func TestGetWithContext_CancellationUnblocksLockWaiter(t *testing.T) {
+	t.Parallel()
+
+	provider := newBlockingProvider(t)
+	cache := newDeblockingCache(t, provider)
+
+	// First caller takes the lock and parks in the provider.
+	go func() { _, _ = cache.Get("Turdus merula") }()
+	require.Eventually(t, func() bool { return provider.calls.Load() > 0 }, 2*time.Second, 5*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		_, err := cache.GetWithContext(ctx, "Turdus merula")
+		done <- err
+	}()
+
+	cancel()
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("a caller waiting on the initialization lock ignored its cancelled context")
+	}
+}
+
+// TestGetCached_NeverCallsProvider pins the property the HTTP handlers depend on.
+func TestGetCached_NeverCallsProvider(t *testing.T) {
+	t.Parallel()
+
+	provider := newBlockingProvider(t)
+	cache := newDeblockingCache(t, provider)
+
+	img, found, negative := cache.GetCached("Turdus merula")
+
+	assert.False(t, found)
+	assert.False(t, negative)
+	assert.Empty(t, img.URL)
+	assert.Zero(t, provider.calls.Load(), "GetCached must not reach the provider")
+}
+
+// TestGetCached_DoesNotWaitForAnInFlightFetch asserts that a species someone else is
+// already fetching reports "not cached" instead of queueing behind that fetch. Waiting
+// there is exactly what a request goroutine must never do.
+func TestGetCached_DoesNotWaitForAnInFlightFetch(t *testing.T) {
+	t.Parallel()
+
+	provider := newBlockingProvider(t)
+	cache := newDeblockingCache(t, provider)
+
+	go func() { _, _ = cache.Get("Turdus merula") }()
+	require.Eventually(t, func() bool { return provider.calls.Load() > 0 }, 2*time.Second, 5*time.Millisecond)
+
+	type result struct {
+		found    bool
+		negative bool
+	}
+	returned := make(chan result, 1)
+	go func() {
+		_, found, negative := cache.GetCached("Turdus merula")
+		returned <- result{found: found, negative: negative}
+	}()
+
+	select {
+	case got := <-returned:
+		assert.False(t, got.found)
+		assert.False(t, got.negative,
+			"a species being fetched is indeterminate, not negative: reporting negative would "+
+				"make the handler answer a 404 the browser caches for a day")
+	case <-time.After(2 * time.Second):
+		t.Fatal("GetCached blocked on an in-flight fetch")
+	}
+}
+
+// TestGetCached_ReportsStates walks the three answers callers switch on.
+func TestGetCached_ReportsStates(t *testing.T) {
+	t.Parallel()
+
+	cache := newDeblockingCache(t, newBlockingProvider(t))
+
+	t.Run("positive memory entry", func(t *testing.T) {
+		cache.dataMap.Store("Parus major", &BirdImage{
+			URL:            "https://example.invalid/parus.jpg",
+			ScientificName: "Parus major",
+			CachedAt:       time.Now(),
+		})
+		img, found, negative := cache.GetCached("Parus major")
+		assert.True(t, found)
+		assert.False(t, negative)
+		assert.Equal(t, "https://example.invalid/parus.jpg", img.URL)
+	})
+
+	t.Run("fresh negative entry", func(t *testing.T) {
+		cache.dataMap.Store("Nullus avis", &BirdImage{
+			URL:            negativeEntryMarker,
+			ScientificName: "Nullus avis",
+			CachedAt:       time.Now(),
+		})
+		_, found, negative := cache.GetCached("Nullus avis")
+		assert.False(t, found)
+		assert.True(t, negative, "a valid negative entry is a definitive answer, not a miss")
+	})
+
+	t.Run("expired negative entry re-opens the lookup", func(t *testing.T) {
+		cache.dataMap.Store("Expirus avis", &BirdImage{
+			URL:            negativeEntryMarker,
+			ScientificName: "Expirus avis",
+			CachedAt:       time.Now().Add(-2 * negativeCacheTTL),
+		})
+		_, found, negative := cache.GetCached("Expirus avis")
+		assert.False(t, found)
+		assert.False(t, negative,
+			"an expired negative entry must not be reported as an answer, or the species can never recover")
+	})
+
+	t.Run("exhausted species", func(t *testing.T) {
+		cache.recordSpeciesExhausted("Exhaustus avis")
+		_, found, negative := cache.GetCached("Exhaustus avis")
+		assert.False(t, found)
+		assert.True(t, negative)
+	})
+
+	t.Run("empty name", func(t *testing.T) {
+		_, found, negative := cache.GetCached("")
+		assert.False(t, found)
+		assert.False(t, negative)
+	})
+}
+
+// TestPrefetchAsync_DeduplicatesBySpecies is the property that keeps a dashboard
+// rendering thirty uncached thumbnails from scheduling thirty provider fetches.
+func TestPrefetchAsync_DeduplicatesBySpecies(t *testing.T) {
+	t.Parallel()
+
+	provider := newBlockingProvider(t)
+	cache := newDeblockingCache(t, provider)
+
+	var wg sync.WaitGroup
+	for range 30 {
+		wg.Go(func() { cache.PrefetchAsync("Turdus merula") })
+	}
+	wg.Wait()
+
+	require.Eventually(t, func() bool { return provider.calls.Load() > 0 }, 2*time.Second, 5*time.Millisecond)
+	// Never, not a settle sleep: a broken dedup would report a count above 1 at some
+	// point during the window, whereas a sleep that is simply too short reports 1 and
+	// passes. The failure direction has to be a red test, not a green one.
+	require.Never(t, func() bool { return provider.calls.Load() > 1 }, 500*time.Millisecond, 10*time.Millisecond,
+		"concurrent prefetches for one species must collapse to a single provider fetch")
+}
+
+// TestPrefetchAsync_ReleasesItsDedupSlot asserts the bookkeeping is not one-shot: a
+// species must be prefetchable again once its prefetch finishes, or a failed first
+// attempt would permanently prevent a retry.
+func TestPrefetchAsync_ReleasesItsDedupSlot(t *testing.T) {
+	t.Parallel()
+
+	provider := newBlockingProvider(t)
+	provider.err = ErrImageNotFound
+	close(provider.release) // resolve immediately
+	cache := newDeblockingCache(t, provider)
+
+	require.True(t, cache.PrefetchAsync("Turdus merula"))
+	require.Eventually(t, func() bool {
+		_, stillQueued := cache.prefetching.Load("Turdus merula")
+		return !stillQueued
+	}, 2*time.Second, 5*time.Millisecond, "the dedup entry must be cleared when the prefetch finishes")
+
+	assert.Zero(t, cache.prefetchQueued.Load(), "the queue counter must return to zero")
+}
+
+// TestPrefetchAsync_RejectedAfterClose guards the shutdown path: tryGo refuses to add
+// to the WaitGroup once Close has started, and the counter and dedup map must be
+// unwound when it does, or the cache would leak a permanent "in flight" entry.
+func TestPrefetchAsync_RejectedAfterClose(t *testing.T) {
+	t.Parallel()
+
+	provider := newBlockingProvider(t)
+	close(provider.release)
+	cache := InitCache(wikiProviderName, provider, nil, nil)
+	require.NoError(t, cache.Close())
+
+	assert.False(t, cache.PrefetchAsync("Turdus merula"))
+	_, queued := cache.prefetching.Load("Turdus merula")
+	assert.False(t, queued)
+	assert.Zero(t, cache.prefetchQueued.Load())
+}
+
+// TestGetCached_StaleDBEntryIsServedAndRefreshed guards a regression the cached-only
+// path could easily have introduced.
+//
+// The blocking path served a stale positive DB entry AND spawned a background refresh.
+// GetCached reports found=true for a stale entry, so its caller schedules nothing;
+// without the refresh spawned here, a stale image would only ever be corrected by the
+// hourly sweep.
+func TestGetCached_StaleDBEntryIsServedAndRefreshed(t *testing.T) {
+	t.Parallel()
+
+	refreshed := make(chan string, 1)
+	provider := &recordingProvider{fetched: refreshed, result: BirdImage{
+		URL:            "https://example.invalid/fresh.jpg",
+		ScientificName: "Turdus merula",
+	}}
+
+	store := &staleEntryStore{entry: &datastore.ImageCache{
+		ScientificName: "Turdus merula",
+		ProviderName:   wikiProviderName,
+		URL:            "https://example.invalid/stale.jpg",
+		CachedAt:       time.Now().Add(-2 * defaultCacheTTL),
+	}}
+
+	cache := InitCache(wikiProviderName, provider, nil, store)
+	t.Cleanup(func() { assert.NoError(t, cache.Close()) })
+	// loadCachedImages primes dataMap from the store, which would short-circuit the DB
+	// branch under test.
+	cache.dataMap.Delete("Turdus merula")
+
+	img, found, negative := cache.GetCached("Turdus merula")
+
+	require.True(t, found, "a stale positive entry is still served rather than withheld")
+	assert.False(t, negative)
+	assert.Equal(t, "https://example.invalid/stale.jpg", img.URL)
+
+	select {
+	case <-refreshed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("a stale entry must schedule a background refresh, as the blocking path did")
+	}
+}
+
+// TestPrefetchAsync_HonoursTheQueueCap asserts the backstop against a pathological
+// caller, and specifically that a rejected request leaves no bookkeeping behind: a
+// leaked dedup entry would mark a species as permanently in flight.
+func TestPrefetchAsync_HonoursTheQueueCap(t *testing.T) {
+	t.Parallel()
+
+	provider := newBlockingProvider(t)
+	cache := newDeblockingCache(t, provider)
+
+	// Saturate the counter directly rather than scheduling 256 real prefetches.
+	cache.prefetchQueued.Store(maxQueuedPrefetches)
+
+	assert.False(t, cache.PrefetchAsync("Turdus merula"))
+	_, queued := cache.prefetching.Load("Turdus merula")
+	assert.False(t, queued, "a rejected prefetch must not leave a dedup entry behind")
+	assert.Equal(t, int64(maxQueuedPrefetches), cache.prefetchQueued.Load(),
+		"a rejected prefetch must not consume a queue slot")
+}
+
+// staleEntryStore serves one image-cache row and accepts writes. datastore.Interface is
+// embedded rather than implemented: any method this test does not expect the cache to
+// call panics on the nil interface, which is a louder failure than a silent zero value.
+type staleEntryStore struct {
+	datastore.Interface
+	entry *datastore.ImageCache
+}
+
+func (s *staleEntryStore) GetImageCache(query datastore.ImageCacheQuery) (*datastore.ImageCache, error) {
+	if query.ScientificName == s.entry.ScientificName && query.ProviderName == s.entry.ProviderName {
+		return s.entry, nil
+	}
+	return nil, datastore.ErrImageCacheNotFound
+}
+
+func (s *staleEntryStore) SaveImageCache(*datastore.ImageCache) error { return nil }
+
+// GetAllImageCaches deliberately reports nothing, so loadCachedImages does not prime
+// dataMap and the DB branch under test is actually reached.
+func (s *staleEntryStore) GetAllImageCaches(string) ([]datastore.ImageCache, error) {
+	return nil, nil
+}
+
+// recordingProvider reports each species it was asked to fetch.
+type recordingProvider struct {
+	fetched chan string
+	result  BirdImage
+}
+
+func (p *recordingProvider) Fetch(scientificName string) (BirdImage, error) {
+	select {
+	case p.fetched <- scientificName:
+	default:
+	}
+	return p.result, nil
+}
+
+// TestClose_DoesNotWaitForAParkedPrefetch is why bgCancel runs before wg.Wait: a
+// prefetch can be parked in the provider for minutes, and Close must not inherit that.
+func TestClose_DoesNotWaitForAParkedPrefetch(t *testing.T) {
+	t.Parallel()
+
+	provider := newBlockingProvider(t)
+	cache := InitCache(wikiProviderName, provider, nil, nil)
+	t.Cleanup(func() { assert.NoError(t, cache.Close()) })
+
+	require.True(t, cache.PrefetchAsync("Turdus merula"))
+	require.Eventually(t, func() bool { return provider.calls.Load() > 0 }, 2*time.Second, 5*time.Millisecond)
+
+	closed := make(chan error, 1)
+	go func() { closed <- cache.Close() }()
+
+	select {
+	case err := <-closed:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("Close blocked on an in-flight prefetch instead of cancelling it")
+	}
+
+	// Close returning promptly is necessary but not sufficient: assert the prefetch
+	// actually saw bgCtx being cancelled, rather than Close having merely stopped
+	// waiting for it.
+	assert.Eventually(t, provider.cancelled.Load, 2*time.Second, 5*time.Millisecond,
+		"the parked prefetch must observe bgCtx being cancelled")
+}

--- a/internal/imageprovider/filecache.go
+++ b/internal/imageprovider/filecache.go
@@ -10,10 +10,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/httpclient"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"golang.org/x/sync/singleflight"
@@ -31,6 +33,12 @@ const (
 
 	// defaultFileCacheTTL is the default time-to-live for cached image files.
 	defaultFileCacheTTL = 30 * 24 * time.Hour
+
+	// imageDownloadBlockDuration is how long the byte-download path stops issuing
+	// requests to a provider after it refuses one. Defined AS the MediaWiki API path's
+	// User-Agent breaker rather than as a copy of its value, so a single policy block
+	// backs both paths off for the same length of time and the two cannot drift.
+	imageDownloadBlockDuration = circuitBreakerUserAgentDuration
 )
 
 // knownExtensions lists the file extensions tried when looking up cached images.
@@ -153,6 +161,49 @@ type ImageFileCache struct {
 	// wikiMediaProvider.networkErrorLogged is cleared by resetCircuit: a
 	// never-reset process-global latch would hide a second block entirely.
 	rejectionLogged atomic.Bool
+	// blockedUntil holds a per-provider cooldown deadline (provider -> time.Time)
+	// after the image host refuses a download. Unlike the MediaWiki API path, which
+	// opens a circuit on a policy rejection, the byte-download path had no breaker
+	// at all: a blanket 403 meant one guaranteed-failing request per uncached
+	// species on every page load, forever, which is the traffic profile that earns
+	// a block in the first place.
+	blockedUntil sync.Map
+}
+
+// ErrImageDownloadBlocked is returned instead of issuing a request while the
+// per-provider download cooldown is open.
+var ErrImageDownloadBlocked = errors.Newf("image downloads are cooling down after a host rejection").
+	Component("imageprovider").
+	Category(errors.CategoryNetwork).
+	Build()
+
+// downloadBlockedUntil reports the open cooldown deadline for a provider, if any.
+func (c *ImageFileCache) downloadBlockedUntil(provider string) (deadline time.Time, open bool) {
+	val, ok := c.blockedUntil.Load(provider)
+	if !ok {
+		return time.Time{}, false
+	}
+	deadline, ok = val.(time.Time)
+	if !ok || !time.Now().Before(deadline) {
+		return time.Time{}, false
+	}
+	return deadline, true
+}
+
+// openDownloadCooldown suppresses further downloads for a provider after a refusal.
+// Only statuses that indicate the host is refusing us rather than missing one file
+// arm it: a 404 is about a single image and must not stop the rest.
+func (c *ImageFileCache) openDownloadCooldown(statusCode int, provider string) {
+	switch statusCode {
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusTooManyRequests:
+	default:
+		return
+	}
+	c.blockedUntil.Store(provider, time.Now().Add(imageDownloadBlockDuration))
+	GetLogger().Warn("Suppressing image downloads after a host refusal",
+		logger.String("provider", provider),
+		logger.Int("status", statusCode),
+		logger.Duration("cooldown", imageDownloadBlockDuration))
 }
 
 // NewImageFileCache creates a new ImageFileCache rooted at basePath.
@@ -388,10 +439,22 @@ type downloadResult struct {
 // DownloadAndStore fetches image bytes from imageURL, stores to disk, deduplicating concurrent requests.
 // The provided context is used for the HTTP request and semaphore acquisition, enabling cancellation.
 // Returns the cached file path and the resolved content type.
+//
+// IMPORTANT: singleflight runs the shared work on the FIRST caller's context, so
+// every waiter inherits that caller's cancellation. Only pass a context that outlives
+// a single consumer: a detached background context, never a request context. If an
+// HTTP handler ever calls this directly again, one browser aborting a thumbnail
+// cancels the download for every other waiter on the same species.
 func (fc *ImageFileCache) DownloadAndStore(ctx context.Context, provider, scientificName, imageURL string) (filePath, contentType string, err error) {
 	key := provider + "/" + normalizeSpeciesName(scientificName)
 
 	result, err, _ := fc.sfGroup.Do(key, func() (any, error) {
+		// A refused host stays refused for the cooldown. Checked before anything
+		// else so a blanket rejection costs neither a request nor a semaphore slot.
+		if deadline, open := fc.downloadBlockedUntil(provider); open {
+			return nil, fmt.Errorf("%w: retry after %s", ErrImageDownloadBlocked, deadline.UTC().Format(time.RFC3339))
+		}
+
 		// Build the User-Agent before taking a semaphore slot. It can reach
 		// conf.Setting(), whose slow path takes a package-global lock and can read from
 		// disk, and doing that while holding one of only five download slots would
@@ -427,6 +490,7 @@ func (fc *ImageFileCache) DownloadAndStore(ctx context.Context, provider, scient
 
 		if resp.StatusCode != http.StatusOK {
 			fc.logPermanentImageRejection(resp.StatusCode, provider, scientificName, imageURL, userAgent)
+			fc.openDownloadCooldown(resp.StatusCode, provider)
 			return nil, fmt.Errorf("non-200 status downloading image: %d", resp.StatusCode)
 		}
 
@@ -446,8 +510,10 @@ func (fc *ImageFileCache) DownloadAndStore(ctx context.Context, provider, scient
 			return nil, storeErr
 		}
 
-		// A success means any earlier rejection is over, so re-arm the escalated log.
+		// A success means any earlier rejection is over, so re-arm the escalated log
+		// and lift the cooldown rather than waiting out its remaining time.
 		fc.rejectionLogged.Store(false)
+		fc.blockedUntil.Delete(provider)
 
 		return &downloadResult{path: path, contentType: ct}, nil
 	})

--- a/internal/imageprovider/filecache_test.go
+++ b/internal/imageprovider/filecache_test.go
@@ -422,16 +422,111 @@ func TestDownloadAndStore_PermanentRejectionLatch(t *testing.T) {
 	assert.True(t, cache.rejectionLogged.Load(), "a 403 must latch the escalated log")
 
 	// A second rejection must not re-escalate, which is what keeps the log quiet.
+	// The cooldown armed by the first 403 is lifted first: this test is about the log
+	// latch, and leaving the cooldown open would short-circuit the request before it
+	// could reach the logging path at all.
+	cache.blockedUntil.Delete("wikimedia")
 	_, _, err = cache.DownloadAndStore(t.Context(), "wikimedia", "Rejected two", server.URL+"/b.jpg")
 	require.Error(t, err)
 	assert.True(t, cache.rejectionLogged.Load(), "latch stays set while rejections continue")
 
 	// A success clears it, so a later block is visible again rather than silent forever.
+	cache.blockedUntil.Delete("wikimedia")
 	status.Store(http.StatusOK)
 	_, _, err = cache.DownloadAndStore(t.Context(), "wikimedia", "Recovered", server.URL+"/c.jpg")
 	require.NoError(t, err)
 	assert.False(t, cache.rejectionLogged.Load(),
 		"a successful download must re-arm the escalation, mirroring resetCircuit")
+}
+
+// TestDownloadAndStore_RefusalOpensCooldown covers the breaker the byte-download path
+// never had.
+//
+// The MediaWiki API path opens a circuit on a policy rejection, but the image download
+// path retried on every request forever: with the proxy re-attempting a download for
+// any species whose file is missing, a blanket 403 meant one guaranteed-failing
+// outbound request per uncached species on every page load, indefinitely. That is the
+// traffic profile that earns a block in the first place.
+func TestDownloadAndStore_RefusalOpensCooldown(t *testing.T) {
+	t.Parallel()
+
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusTooManyRequests} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			t.Parallel()
+
+			var requests atomic.Int64
+			cache, server := newServedCache(t, func(w http.ResponseWriter, _ *http.Request) {
+				requests.Add(1)
+				w.WriteHeader(status)
+			})
+
+			_, _, err := cache.DownloadAndStore(t.Context(), "wikimedia", "Parus major", server.URL+"/a.jpg")
+			require.Error(t, err)
+			require.Equal(t, int64(1), requests.Load())
+
+			// A different species: the refusal is about the host, not the file, so this
+			// must not reach the network at all.
+			_, _, err = cache.DownloadAndStore(t.Context(), "wikimedia", "Turdus merula", server.URL+"/b.jpg")
+			require.ErrorIs(t, err, ErrImageDownloadBlocked)
+			assert.Equal(t, int64(1), requests.Load(),
+				"a refused host must not be contacted again during the cooldown")
+
+			// The cooldown is per provider, so an unrelated provider keeps working.
+			_, _, err = cache.DownloadAndStore(t.Context(), "avicommons", "Turdus merula", server.URL+"/c.jpg")
+			require.NotErrorIs(t, err, ErrImageDownloadBlocked)
+			assert.Equal(t, int64(2), requests.Load())
+		})
+	}
+}
+
+// TestDownloadAndStore_SuccessClearsCooldown asserts recovery does not have to wait out
+// the full cooldown once the host is serving us again.
+func TestDownloadAndStore_SuccessClearsCooldown(t *testing.T) {
+	t.Parallel()
+
+	var status atomic.Int64
+	status.Store(http.StatusForbidden)
+	cache, server := newServedCache(t, func(w http.ResponseWriter, _ *http.Request) {
+		if code := int(status.Load()); code != http.StatusOK {
+			w.WriteHeader(code)
+			return
+		}
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write([]byte{0xFF, 0xD8, 0xFF, 0xE0})
+	})
+
+	_, _, err := cache.DownloadAndStore(t.Context(), "wikimedia", "Parus major", server.URL+"/a.jpg")
+	require.Error(t, err)
+	_, open := cache.downloadBlockedUntil("wikimedia")
+	require.True(t, open)
+
+	// Simulate the cooldown elapsing rather than sleeping for ten minutes.
+	cache.blockedUntil.Store("wikimedia", time.Now().Add(-time.Second))
+	_, open = cache.downloadBlockedUntil("wikimedia")
+	require.False(t, open, "an elapsed deadline must not count as an open cooldown")
+
+	status.Store(http.StatusOK)
+	_, _, err = cache.DownloadAndStore(t.Context(), "wikimedia", "Turdus merula", server.URL+"/b.jpg")
+	require.NoError(t, err)
+
+	_, open = cache.downloadBlockedUntil("wikimedia")
+	assert.False(t, open, "a successful download must clear the cooldown")
+}
+
+// TestDownloadAndStore_NotFoundDoesNotOpenCooldown keeps the breaker scoped to host
+// refusals. A 404 is about one image; suppressing every other species because one file
+// moved would be a far worse failure than the one being prevented.
+func TestDownloadAndStore_NotFoundDoesNotOpenCooldown(t *testing.T) {
+	t.Parallel()
+
+	cache, server := newServedCache(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	_, _, err := cache.DownloadAndStore(t.Context(), "wikimedia", "Parus major", server.URL+"/a.jpg")
+	require.Error(t, err)
+	_, open := cache.downloadBlockedUntil("wikimedia")
+	assert.False(t, open)
 }
 
 // TestDownloadAndStore_TransientStatusDoesNotLatch asserts the escalation is reserved for

--- a/internal/imageprovider/helpers_test.go
+++ b/internal/imageprovider/helpers_test.go
@@ -407,7 +407,7 @@ func TestBuildDebugURL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := buildDebugURL(tt.params)
+			got := (&wikiMediaProvider{}).buildDebugURL(tt.params)
 			require.NotEmpty(t, got, "buildDebugURL should not return empty string")
 			tt.check(t, got)
 		})

--- a/internal/imageprovider/imageprovider.go
+++ b/internal/imageprovider/imageprovider.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"maps"
 	"net/url"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -100,6 +101,75 @@ type ProviderStatusChecker interface {
 	ShouldRefreshCache() bool
 }
 
+// contextFetcher is implemented by providers that accept a context. It is not part of
+// ImageProvider because that interface is the stable extension point for third-party
+// providers; this is an optional capability probed at call time.
+type contextFetcher interface {
+	FetchWithContext(ctx context.Context, scientificName string) (BirdImage, error)
+}
+
+// normalizedFallbackPolicy reads the configured fallback policy, trimmed and
+// lowercased, so that "All" or a stray trailing space is not read as "off".
+func normalizedFallbackPolicy() string {
+	settings := conf.Setting()
+	if settings == nil {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(settings.Realtime.Dashboard.Thumbnails.FallbackPolicy))
+}
+
+// fetchFromProvider calls the provider's context-aware Fetch when it has one and falls
+// back to the context-free Fetch otherwise. Without this, a cancelled caller still
+// waits out the provider's full retry and rate-limit budget.
+//
+// A provider that only implements the context-free Fetch cannot be interrupted, so its
+// call runs on its own goroutine and the caller abandons it when ctx is done. That
+// goroutine may outlive the caller, but the alternative is worse: every waiter,
+// including Close's WaitGroup and one of the bounded prefetch slots, would be held for
+// as long as a third-party provider chooses to block. The abandoned result is dropped
+// via a buffered channel so the goroutine always completes rather than parking on an
+// unread send.
+func fetchFromProvider(ctx context.Context, provider ImageProvider, scientificName string) (BirdImage, error) {
+	if ctxProvider, ok := provider.(contextFetcher); ok {
+		return ctxProvider.FetchWithContext(ctx, scientificName)
+	}
+
+	type fetchOutcome struct {
+		img BirdImage
+		err error
+	}
+	done := make(chan fetchOutcome, 1)
+	go func() {
+		// This goroutine can outlive its caller, so a panic here has no request
+		// handler above it to recover: it would take the process down. The
+		// startup warm-up installs the same guard around this call.
+		defer func() {
+			if r := recover(); r != nil {
+				GetLogger().Error("Recovered from a panic in an image provider fetch",
+					logger.String("scientific_name", scientificName),
+					logger.Any("panic", r))
+				done <- fetchOutcome{err: errors.Newf("image provider panicked: %v", r).
+					Component("imageprovider").
+					Category(errors.CategoryImageProvider).
+					Context("scientific_name", scientificName).
+					Build()}
+			}
+		}()
+		img, err := provider.Fetch(scientificName)
+		done <- fetchOutcome{img: img, err: err}
+	}()
+
+	select {
+	case outcome := <-done:
+		return outcome.img, outcome.err
+	case <-ctx.Done():
+		GetLogger().Debug("Abandoning a context-free provider fetch after cancellation",
+			logger.String("scientific_name", scientificName),
+			logger.Error(ctx.Err()))
+		return BirdImage{}, ctx.Err()
+	}
+}
+
 // BirdImage represents a cached bird image with its metadata and attribution information
 type BirdImage struct {
 	URL            string    // Direct URL to the bird image
@@ -171,6 +241,24 @@ type BirdImageCache struct {
 	// "Human vocal" that no image provider will ever resolve, eliminating
 	// repeated SQLite reads on every detection cycle.
 	exhaustedSpecies sync.Map
+	// bgCtx is the parent context for every fetch this cache runs on its own
+	// goroutines. It is deliberately detached from any request context: a
+	// prefetch scheduled by an HTTP handler must outlive the response, which a
+	// derived request context would not. bgCancel runs first in Close() so
+	// wg.Wait() cannot block for the full prefetchTimeout.
+	bgCtx    context.Context
+	bgCancel context.CancelFunc
+	// prefetching deduplicates in-flight background prefetches by scientific
+	// name, so a dashboard asking for thirty uncached thumbnails schedules at
+	// most one fetch per species rather than one per request.
+	prefetching sync.Map
+	// prefetchQueued counts registered prefetches (queued plus running) so an
+	// unbounded species list cannot spawn an unbounded number of goroutines.
+	prefetchQueued atomic.Int64
+	// prefetchSem bounds how many prefetches contact a provider at once. The
+	// providers are themselves rate limited, so a small number is enough to keep
+	// the pipeline busy without piling up connections.
+	prefetchSem chan struct{}
 }
 
 // GetFileCache returns the file cache instance, or nil if not configured.
@@ -183,10 +271,21 @@ func (c *BirdImageCache) GetProviderName() string {
 	return c.providerName
 }
 
+// proxyImagePathPrefix is the route prefix ProxyImageURL builds on.
+const proxyImagePathPrefix = "/api/v2/media/image/"
+
 // ProxyImageURL generates the proxy URL for serving a cached bird image.
+//
+// An empty or whitespace-only name yields an empty string rather than
+// "/api/v2/media/image/", which matches no route and which the handler answers with
+// 400. Guarding at this single choke point covers every producer, several of which
+// emit the URL unconditionally and have no name check of their own.
 func ProxyImageURL(scientificName string) string {
-	encoded := url.PathEscape(scientificName)
-	return fmt.Sprintf("/api/v2/media/image/%s", encoded)
+	trimmed := strings.TrimSpace(scientificName)
+	if trimmed == "" {
+		return ""
+	}
+	return proxyImagePathPrefix + url.PathEscape(trimmed)
 }
 
 // GetLogger returns the package logger for the imageprovider module
@@ -224,6 +323,22 @@ const (
 	dbCacheLookupSlowThreshold = 50 * time.Millisecond  // Threshold for slow DB cache lookups
 	providerFetchSlowThreshold = 100 * time.Millisecond // Threshold for slow provider fetch operations
 	totalFetchSlowThreshold    = 200 * time.Millisecond // Threshold for slow total fetch operations
+
+	// Background prefetch constants.
+	//
+	// prefetchTimeout bounds one background species fetch. It is generous
+	// because the worst realistic case is three MediaWiki calls behind a
+	// process-global 1 req/s limiter, each retried with backoff; the point of
+	// the bound is that a fetch cannot live forever, not that it be quick.
+	prefetchTimeout = 3 * time.Minute
+	// maxConcurrentPrefetches bounds provider concurrency. The Wikipedia
+	// provider serializes on a 1 req/s global limiter regardless, so a larger
+	// number would only park more goroutines on the same lock.
+	maxConcurrentPrefetches = 4
+	// maxQueuedPrefetches caps registered-but-unfinished prefetches. It is a
+	// backstop against a pathological caller (a page listing thousands of
+	// species), not an expected limit.
+	maxQueuedPrefetches = 256
 )
 
 // fallbackProviders defines the ordered list of providers to try when the primary provider fails.
@@ -513,20 +628,10 @@ func (c *BirdImageCache) refreshEntry(scientificName string) {
 	// Fetch new image with background context to use more restrictive rate limiting
 	log.Debug("Fetching new image data from provider (background refresh)")
 
-	// Check if provider supports context-aware fetching
-	var birdImage BirdImage
-	var err error
-
-	if ctxProvider, ok := provider.(interface {
-		FetchWithContext(ctx context.Context, scientificName string) (BirdImage, error)
-	}); ok {
-		// Use background context for refresh operations
-		ctx := context.WithValue(context.Background(), backgroundOperationKey, true)
-		birdImage, err = ctxProvider.FetchWithContext(ctx, scientificName)
-	} else {
-		// Fallback to regular fetch
-		birdImage, err = provider.Fetch(scientificName)
-	}
+	// Refreshes are marked as background operations so the provider applies its
+	// more conservative background rate limiter on top of the global one.
+	ctx := context.WithValue(c.backgroundContext(), backgroundOperationKey, true)
+	birdImage, err := fetchFromProvider(ctx, provider, scientificName)
 
 	if err != nil {
 		// Check if it's already an enhanced error, if not enhance it
@@ -665,7 +770,7 @@ func (c *BirdImageCache) tryRefreshFallback(scientificName string) (BirdImage, b
 	// Tier 2: Fetch from fallback providers via network (only if DB had nothing valid)
 	log.Debug("Background refresh: no valid fallback in DB, trying network fetch")
 	triedProviders := map[string]bool{c.providerName: true}
-	return c.tryFallbackProviders(scientificName, triedProviders)
+	return c.tryFallbackProviders(c.backgroundContext(), scientificName, triedProviders)
 }
 
 // Close stops the cache refresh routine, waits for in-flight DB operations to
@@ -688,6 +793,13 @@ func (c *BirdImageCache) Close() error {
 	}
 	c.closed.Store(true)
 	c.closeMu.Unlock()
+
+	// Cancel background fetches before waiting on the WaitGroup. A prefetch may be
+	// parked on the provider's rate limiter for minutes; without this, Close would
+	// block for the full prefetchTimeout.
+	if c.bgCancel != nil {
+		c.bgCancel()
+	}
 
 	if c.quit != nil {
 		log.Debug("Closing quit channel")
@@ -729,6 +841,8 @@ func InitCache(providerName string, e ImageProvider, t *observability.Metrics, s
 		imageProviderMetrics = t.ImageProvider
 	}
 
+	bgCtx, bgCancel := context.WithCancel(context.Background())
+
 	cache := &BirdImageCache{
 		providerName: providerName, // Set provider name
 		metrics:      imageProviderMetrics,
@@ -736,6 +850,9 @@ func InitCache(providerName string, e ImageProvider, t *observability.Metrics, s
 		store:        store,
 		fileCache:    NewImageFileCache(imageCacheDir),
 		quit:         quit,
+		bgCtx:        bgCtx,
+		bgCancel:     bgCancel,
+		prefetchSem:  make(chan struct{}, maxConcurrentPrefetches),
 	}
 
 	// Store the provider using atomic pointer
@@ -1059,23 +1176,19 @@ func (c *BirdImageCache) checkCachedEntryAfterLock(scientificName string, log lo
 	return BirdImage{}, true, true, imageNotFoundFor(scientificName, c.providerName, "negative_cache_hit")
 }
 
-// tryInitialize ensures only one goroutine initializes a species image using mutexes.
-// It returns the image, a boolean indicating if it was found in cache (true) or fetched (false), and an error.
-func (c *BirdImageCache) tryInitialize(scientificName string) (BirdImage, bool, error) {
+// tryInitialize ensures only one goroutine initializes a species image using a
+// per-species lock. It returns the image, a boolean indicating if it was found in
+// cache (true) or fetched (false), and an error.
+func (c *BirdImageCache) tryInitialize(ctx context.Context, scientificName string) (BirdImage, bool, error) {
 	log := GetLogger().With(
 		logger.String("provider", c.providerName),
 		logger.String("scientific_name", scientificName))
 
-	muInterface, _ := c.Initializing.LoadOrStore(scientificName, &sync.Mutex{})
-	mu := muInterface.(*sync.Mutex)
-	mu.Lock()
-	// Do not delete the mutex from the map on unlock. A goroutine that has already
-	// run LoadOrStore but not yet acquired the lock holds a reference to this
-	// mutex; deleting it lets a later goroutine LoadOrStore a fresh mutex and fetch
-	// concurrently with that waiter, defeating the single-initialization guarantee.
-	// The map is bounded by the number of distinct species ever queried, so the
-	// retained mutexes are a negligible, fixed cost.
-	defer mu.Unlock()
+	release, err := c.acquireInitLock(ctx, scientificName)
+	if err != nil {
+		return BirdImage{}, false, err
+	}
+	defer release()
 
 	log.Debug("Acquired initialization lock")
 
@@ -1085,8 +1198,58 @@ func (c *BirdImageCache) tryInitialize(scientificName string) (BirdImage, bool, 
 	}
 
 	log.Debug("Not in cache after lock, proceeding to fetch/store")
-	img, err = c.fetchAndStore(scientificName)
+	img, err = c.fetchAndStore(ctx, scientificName)
 	return img, false, err
+}
+
+// initLock returns the per-species initialization lock, creating it on first use.
+//
+// A buffered channel is used rather than a sync.Mutex so that waiting for the lock
+// can be abandoned when the caller's context is cancelled. Without that, a request
+// arriving while another goroutine holds the lock inherits the holder's full,
+// uncancellable fetch duration.
+//
+// Do not delete the entry from the map on release. A goroutine that has already run
+// LoadOrStore but not yet acquired the lock holds a reference to this channel;
+// deleting it lets a later goroutine LoadOrStore a fresh one and fetch concurrently
+// with that waiter, defeating the single-initialization guarantee. The map is bounded
+// by the number of distinct species ever queried, so the retained channels are a
+// negligible, fixed cost.
+func (c *BirdImageCache) initLock(scientificName string) chan struct{} {
+	// Load before LoadOrStore. The channel is an argument, so LoadOrStore evaluates
+	// make() on every call even when the entry already exists, allocating a channel
+	// that is immediately garbage. Measured at 128 B / 2 allocs / ~96ns per call
+	// versus 0 B / 0 allocs / ~10ns for the Load-first form, on a path that now runs
+	// once per thumbnail request. LoadOrStore still resolves the create race.
+	if val, ok := c.Initializing.Load(scientificName); ok {
+		return val.(chan struct{})
+	}
+	val, _ := c.Initializing.LoadOrStore(scientificName, make(chan struct{}, 1))
+	return val.(chan struct{})
+}
+
+// acquireInitLock blocks until the per-species initialization lock is held or ctx is
+// done. The returned function releases the lock and must be called exactly once.
+func (c *BirdImageCache) acquireInitLock(ctx context.Context, scientificName string) (release func(), err error) {
+	lock := c.initLock(scientificName)
+	select {
+	case lock <- struct{}{}:
+		return func() { <-lock }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// tryAcquireInitLock acquires the per-species initialization lock without blocking.
+// A failed acquisition means another goroutine is already fetching this species.
+func (c *BirdImageCache) tryAcquireInitLock(scientificName string) (release func(), ok bool) {
+	lock := c.initLock(scientificName)
+	select {
+	case lock <- struct{}{}:
+		return func() { <-lock }, true
+	default:
+		return nil, false
+	}
 }
 
 // logInitializeError logs the initialization error if it's not ErrImageNotFound.
@@ -1111,7 +1274,7 @@ func (c *BirdImageCache) logInitializeError(err error, scientificName string, lo
 
 // tryFallbackOnGetError attempts to get the image from fallback providers on error.
 // Returns (image, found).
-func (c *BirdImageCache) tryFallbackOnGetError(err error, scientificName string, log logger.Logger) (BirdImage, bool) {
+func (c *BirdImageCache) tryFallbackOnGetError(ctx context.Context, err error, scientificName string, log logger.Logger) (BirdImage, bool) {
 	settings := conf.Setting()
 	if settings.Realtime.Dashboard.Thumbnails.FallbackPolicy != fallbackPolicyAll {
 		log.Debug("Primary provider failed but fallback policy is 'none'",
@@ -1127,7 +1290,7 @@ func (c *BirdImageCache) tryFallbackOnGetError(err error, scientificName string,
 	triedProviders := map[string]bool{c.providerName: true}
 	log.Debug("Primary provider failed, attempting fallback (policy: all)",
 		logger.Error(err))
-	fallbackImg, found := c.tryFallbackProviders(scientificName, triedProviders)
+	fallbackImg, found := c.tryFallbackProviders(ctx, scientificName, triedProviders)
 	if found {
 		log.Debug("Image found via fallback provider",
 			logger.String("fallback_provider", fallbackImg.SourceProvider))
@@ -1138,7 +1301,18 @@ func (c *BirdImageCache) tryFallbackOnGetError(err error, scientificName string,
 }
 
 // Get retrieves a bird image from the cache, fetching if necessary.
+//
+// Get can block for as long as the provider chain takes, which for a cold species is
+// bounded only by the provider's own retry and rate-limit budget. Do NOT call it from
+// an HTTP handler or from inside a lock; use GetCached plus PrefetchAsync there.
 func (c *BirdImageCache) Get(scientificName string) (BirdImage, error) {
+	return c.GetWithContext(context.Background(), scientificName)
+}
+
+// GetWithContext is Get with cancellation. The context bounds the wait for the
+// per-species initialization lock and is passed to providers that implement
+// FetchWithContext.
+func (c *BirdImageCache) GetWithContext(ctx context.Context, scientificName string) (BirdImage, error) {
 	if scientificName == "" {
 		return BirdImage{}, imageNotFoundFor("", c.providerName, "get_empty_name")
 	}
@@ -1148,7 +1322,7 @@ func (c *BirdImageCache) Get(scientificName string) (BirdImage, error) {
 		logger.String("scientific_name", scientificName))
 	log.Debug("Get image request received")
 
-	img, foundInCache, err := c.tryInitialize(scientificName)
+	img, foundInCache, err := c.tryInitialize(ctx, scientificName)
 	if err != nil {
 		c.logInitializeError(err, scientificName, log)
 		// If every provider has already been exhausted for this species
@@ -1168,7 +1342,7 @@ func (c *BirdImageCache) Get(scientificName string) (BirdImage, error) {
 			log.Debug("Species already exhausted by all providers, skipping fallback chain")
 			return c.synthesizeExhaustedResponse(scientificName)
 		}
-		if fallbackImg, found := c.tryFallbackOnGetError(err, scientificName, log); found {
+		if fallbackImg, found := c.tryFallbackOnGetError(ctx, err, scientificName, log); found {
 			return fallbackImg, nil
 		}
 		return BirdImage{}, err
@@ -1186,8 +1360,304 @@ func (c *BirdImageCache) Get(scientificName string) (BirdImage, error) {
 	return img, nil
 }
 
+// backgroundContext returns the cache's detached parent context for work that must
+// outlive any request. A cache assembled outside InitCache (only tests do this) has
+// none, so fall back to a plain background context rather than panicking.
+func (c *BirdImageCache) backgroundContext() context.Context {
+	if c.bgCtx == nil {
+		return context.Background()
+	}
+	return c.bgCtx
+}
+
+// GetCached resolves a species image without ever contacting a provider, so it is
+// safe on an HTTP request goroutine and inside a lock.
+//
+// It reports one of three states:
+//   - found=true, negative=false: img is a usable image (memory or DB cache).
+//   - negative=true: the species is known to have no image for now. Callers should
+//     answer "not found" rather than schedule work.
+//   - found=false, negative=false: nothing is cached. Callers should answer "try
+//     again shortly" and schedule PrefetchAsync.
+//
+// A species another goroutine is currently fetching reports not-cached rather than
+// waiting for that fetch, which is the whole point: waiting is what blocked the
+// request path.
+func (c *BirdImageCache) GetCached(scientificName string) (img BirdImage, found, negative bool) {
+	img, found, negative = c.getCachedLocal(scientificName)
+	if found || !negative {
+		return img, found, negative
+	}
+
+	// This cache says "no image". Under fallbackpolicy: all that is not the final
+	// answer, because the blocking path this replaces consulted the other registered
+	// providers on exactly this outcome (Get -> tryFallbackOnGetError). Reporting the
+	// primary's negative entry as definitive would answer 404 with a 24h browser
+	// cache for every species the primary lacks but a fallback has, permanently
+	// hiding images the user enabled fallbacks to get.
+	if normalizedFallbackPolicy() != fallbackPolicyAll {
+		return img, found, negative
+	}
+	registry := c.GetRegistry()
+	if registry == nil {
+		return img, found, negative
+	}
+
+	var fallbackImg BirdImage
+	var fallbackFound bool
+	registry.RangeProviders(func(name string, other *BirdImageCache) bool {
+		if other == nil || name == c.providerName {
+			return true
+		}
+		// getCachedLocal, not GetCached: the sweep must not recurse back into
+		// another cache's own fallback sweep.
+		if otherImg, otherFound, _ := other.getCachedLocal(scientificName); otherFound {
+			fallbackImg, fallbackFound = otherImg, true
+			return false
+		}
+		return true
+	})
+	if fallbackFound {
+		return fallbackImg, true, false
+	}
+
+	// No fallback has it cached either. Only an exhausted marker, recorded once the
+	// whole chain has actually run to completion, makes "no image" definitive.
+	// Otherwise report indeterminate so the caller schedules a prefetch, which runs
+	// the full chain including the fallbacks.
+	if c.isSpeciesExhausted(scientificName) {
+		return BirdImage{}, false, true
+	}
+	return BirdImage{}, false, false
+}
+
+// getCachedLocal resolves a species image from THIS cache's memory and DB only. It
+// never contacts a provider and never consults another registered provider.
+func (c *BirdImageCache) getCachedLocal(scientificName string) (img BirdImage, found, negative bool) {
+	if scientificName == "" {
+		return BirdImage{}, false, false
+	}
+
+	release, ok := c.tryAcquireInitLock(scientificName)
+	if !ok {
+		// A fetch is in flight. Report not-cached without scheduling anything: the
+		// in-flight fetch will populate the cache.
+		return BirdImage{}, false, false
+	}
+	defer release()
+
+	// Built here rather than at the top of the function: the early returns above are
+	// the common case once the cache is warm, and logger.With concatenates its fields
+	// eagerly with no level gate, so constructing it up front cost more than the rest
+	// of the lookup on a path that now runs once per thumbnail request.
+	log := GetLogger().With(
+		logger.String("provider", c.providerName),
+		logger.String("scientific_name", scientificName))
+
+	// checkCachedEntryAfterLock's third result is shouldReturnError, which today is
+	// true only for a valid negative entry. Named for what this function does with it.
+	memImg, foundInMemory, isNegativeEntry, _ := c.checkCachedEntryAfterLock(scientificName, log)
+	switch {
+	case isNegativeEntry:
+		return BirdImage{}, false, true
+	case foundInMemory:
+		return memImg, true, false
+	}
+
+	dbImage, dbErr := c.loadFromDBCache(scientificName)
+	if isRealError(dbErr) {
+		// Do not fold a DB fault into "no image": that answer is cached by the
+		// browser for a day. Report indeterminate so the caller says "try again"
+		// instead, and make the fault visible rather than silently degrading every
+		// thumbnail request.
+		log.Warn("Error reading the image DB cache, reporting the species as unresolved",
+			logger.Error(dbErr))
+		return BirdImage{}, false, false
+	}
+	if dbImage == nil {
+		// Nothing is known yet. The exhausted marker is consulted only here, AFTER
+		// memory and the DB: it records that every provider failed within the TTL
+		// window, and it must never pre-empt a live cache entry for the species.
+		if c.isSpeciesExhausted(scientificName) {
+			return BirdImage{}, false, true
+		}
+		return BirdImage{}, false, false
+	}
+
+	if dbImage.IsNegativeEntry() {
+		// An expired negative entry is not an answer; let the caller re-fetch.
+		if !isNonAvianClass(scientificName) && isCacheEntryStale(dbImage.CachedAt, true) {
+			return BirdImage{}, false, false
+		}
+		c.dataMap.Store(scientificName, dbImage)
+		return BirdImage{}, false, true
+	}
+
+	if dbImage.URL == "" {
+		return BirdImage{}, false, false
+	}
+
+	// Mirrors handleDBCacheHit: a memory miss served from the DB is a cache miss.
+	// Without this the metric would read zero, since GetCached is now the only
+	// lookup on the request, SSE and MQTT paths.
+	if c.metrics != nil {
+		c.metrics.IncrementCacheMisses()
+	}
+
+	// Promote to memory so subsequent lookups skip the DB. Stored BEFORE spawning the
+	// refresh below: the go statement is a happens-before edge, so the refresh's own
+	// store is guaranteed to land after this one and cannot be clobbered back to
+	// stale. Same ordering, and same reason, as handleDBCacheHit.
+	c.dataMap.Store(scientificName, dbImage)
+
+	// A stale entry is still served, but it must also be refreshed, exactly as the
+	// blocking path did. Callers see found=true and therefore schedule nothing
+	// themselves, so without this a stale image would only ever be corrected by the
+	// hourly sweep.
+	if isCacheEntryStale(dbImage.CachedAt, false) {
+		log.Debug("Serving a stale DB cache entry and refreshing it in the background",
+			logger.Time("cached_at", dbImage.CachedAt))
+		if _, alreadyQueued := c.prefetching.LoadOrStore(scientificName, struct{}{}); !alreadyQueued {
+			scheduled := c.tryGo(func() {
+				defer c.prefetching.Delete(scientificName)
+				c.refreshEntry(scientificName)
+			})
+			if !scheduled {
+				c.prefetching.Delete(scientificName)
+			}
+		}
+	}
+
+	return *dbImage, true, false
+}
+
+// PrefetchAsync resolves a species image on a background goroutine and, on success,
+// makes sure its bytes are on disk. It never blocks the caller and is deduplicated by
+// species, so thirty concurrent requests for the same cold species schedule one fetch.
+//
+// It returns true when a prefetch is now in flight for the species (whether scheduled
+// by this call or already running).
+func (c *BirdImageCache) PrefetchAsync(scientificName string) bool {
+	if scientificName == "" {
+		return false
+	}
+	if c.closed.Load() {
+		return false
+	}
+	// A cache assembled outside InitCache (only tests do this) has neither the
+	// bounding semaphore nor the cancellable parent context, so a prefetch there
+	// would be unbounded and un-stoppable. Decline rather than degrade.
+	if c.prefetchSem == nil || c.bgCtx == nil {
+		return false
+	}
+
+	// Reserve a queue slot BEFORE claiming the dedup entry. Claiming first would let a
+	// second caller be told "already queued" by the very registration that is about to
+	// be rolled back for exceeding the cap, so the species would be reported as in
+	// flight while nothing ran.
+	if c.prefetchQueued.Add(1) > maxQueuedPrefetches {
+		c.prefetchQueued.Add(-1)
+		GetLogger().Debug("Prefetch queue is full, dropping request",
+			logger.String("provider", c.providerName),
+			logger.String("scientific_name", scientificName),
+			logger.Int("max_queued", maxQueuedPrefetches))
+		return false
+	}
+
+	if _, alreadyQueued := c.prefetching.LoadOrStore(scientificName, struct{}{}); alreadyQueued {
+		c.prefetchQueued.Add(-1)
+		return true
+	}
+
+	// Only now, past both early returns, is the logger worth building: it is captured
+	// by the goroutine below and used for the whole prefetch.
+	log := GetLogger().With(
+		logger.String("provider", c.providerName),
+		logger.String("scientific_name", scientificName))
+
+	scheduled := c.tryGo(func() {
+		defer func() {
+			c.prefetchQueued.Add(-1)
+			c.prefetching.Delete(scientificName)
+		}()
+		c.runPrefetch(scientificName, log)
+	})
+	if !scheduled {
+		c.prefetchQueued.Add(-1)
+		c.prefetching.Delete(scientificName)
+		return false
+	}
+	return true
+}
+
+// runPrefetch performs one background species resolution. It runs on a goroutine
+// tracked by the cache WaitGroup, so every wait it performs must be cancellable via
+// bgCtx or Close would hang.
+func (c *BirdImageCache) runPrefetch(scientificName string, log logger.Logger) {
+	// A provider panic on this goroutine has no handler above it to recover.
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("Recovered from a panic during a background image prefetch",
+				logger.Any("panic", r))
+		}
+	}()
+
+	bg := c.backgroundContext()
+	if c.prefetchSem != nil {
+		select {
+		case c.prefetchSem <- struct{}{}:
+			defer func() { <-c.prefetchSem }()
+		case <-bg.Done():
+			return
+		}
+	}
+
+	// Another goroutine is already fetching this species (a foreground Get, or the
+	// hourly refresh sweep). GetCached reports "not cached" while that lock is held,
+	// so the handler schedules a prefetch that would otherwise sit on one of the few
+	// slots for the whole prefetchTimeout waiting for work that is already underway.
+	if release, ok := c.tryAcquireInitLock(scientificName); ok {
+		release()
+	} else {
+		log.Debug("Skipping prefetch: a fetch for this species is already in flight")
+		return
+	}
+
+	// The timeout starts here rather than at scheduling time so a request queued
+	// behind the semaphore is not charged for its wait.
+	ctx, cancel := context.WithTimeout(bg, prefetchTimeout)
+	defer cancel()
+
+	img, err := c.GetWithContext(ctx, scientificName)
+	if err != nil {
+		log.Debug("Background image prefetch did not resolve", logger.Error(err))
+		return
+	}
+	if img.URL == "" || img.IsNegativeEntry() || c.fileCache == nil {
+		return
+	}
+
+	provider := img.SourceProvider
+	if provider == "" {
+		provider = c.providerName
+	}
+
+	// storeSuccessfulFetch already downloads the bytes for a freshly fetched image,
+	// so only download here when the file is actually missing or stale. Without this
+	// check a cache hit in GetWithContext would re-download on every prefetch.
+	if path, _, fresh, getErr := c.fileCache.Get(provider, scientificName); getErr == nil && path != "" && fresh {
+		return
+	}
+
+	if _, _, dlErr := c.fileCache.DownloadAndStore(ctx, provider, scientificName, img.URL); dlErr != nil {
+		log.Info("Background image prefetch failed to download image bytes", logger.Error(dlErr))
+		return
+	}
+	log.Debug("Background image prefetch completed")
+}
+
 // fetchAndStore tries to load from DB, then fetches from the provider if necessary, and stores the result.
-func (c *BirdImageCache) fetchAndStore(scientificName string) (BirdImage, error) {
+func (c *BirdImageCache) fetchAndStore(ctx context.Context, scientificName string) (BirdImage, error) {
 	fetchStart := time.Now()
 	log := GetLogger().With(
 		logger.String("provider", c.providerName),
@@ -1214,7 +1684,7 @@ func (c *BirdImageCache) fetchAndStore(scientificName string) (BirdImage, error)
 	}
 
 	// 2. Not in DB or DB load failed, fetch from the actual provider
-	return c.fetchSingleFromProvider(scientificName, fetchStart)
+	return c.fetchSingleFromProvider(ctx, scientificName, fetchStart)
 }
 
 // getDBCacheError returns the appropriate error for a DB cache result.
@@ -1248,9 +1718,15 @@ func (c *BirdImageCache) handleDBCacheHit(scientificName string, dbImage *BirdIm
 	if isCacheEntryStale(dbImage.CachedAt, false) {
 		log.Debug("DB cache entry is stale, returning stale data and triggering background refresh",
 			logger.Time("cached_at", dbImage.CachedAt))
-		c.tryGo(func() {
-			c.refreshEntry(scientificName)
-		})
+		if _, alreadyQueued := c.prefetching.LoadOrStore(scientificName, struct{}{}); !alreadyQueued {
+			scheduled := c.tryGo(func() {
+				defer c.prefetching.Delete(scientificName)
+				c.refreshEntry(scientificName)
+			})
+			if !scheduled {
+				c.prefetching.Delete(scientificName)
+			}
+		}
 	} else {
 		log.Debug("Image loaded from DB cache")
 	}
@@ -1281,7 +1757,7 @@ func (c *BirdImageCache) handleNegativeDBEntry(scientificName string, dbImage *B
 }
 
 // fetchSingleFromProvider fetches an image from the provider when not found in cache.
-func (c *BirdImageCache) fetchSingleFromProvider(scientificName string, fetchStart time.Time) (BirdImage, error) {
+func (c *BirdImageCache) fetchSingleFromProvider(ctx context.Context, scientificName string, fetchStart time.Time) (BirdImage, error) {
 	log := GetLogger().With(
 		logger.String("provider", c.providerName),
 		logger.String("scientific_name", scientificName))
@@ -1293,7 +1769,7 @@ func (c *BirdImageCache) fetchSingleFromProvider(scientificName string, fetchSta
 	}
 
 	providerStart := time.Now()
-	fetchedImage, fetchErr := provider.Fetch(scientificName)
+	fetchedImage, fetchErr := fetchFromProvider(ctx, provider, scientificName)
 	providerDuration := time.Since(providerStart)
 
 	c.logSlowOperation("Provider fetch", scientificName, providerDuration, providerFetchSlowThreshold)
@@ -1459,7 +1935,7 @@ func (c *BirdImageCache) downloadImageToFileCache(scientificName string, img *Bi
 		provider = c.providerName
 	}
 
-	if _, _, err := c.fileCache.DownloadAndStore(context.Background(), provider, scientificName, img.URL); err != nil {
+	if _, _, err := c.fileCache.DownloadAndStore(c.backgroundContext(), provider, scientificName, img.URL); err != nil {
 		// File cache populates lazily; the image is already in the in-memory and
 		// DB caches, so a download failure here just means the proxy will refetch
 		// on the next request. Logged at info to keep the diagnostics health
@@ -1545,7 +2021,7 @@ func (c *BirdImageCache) synthesizeExhaustedResponse(scientificName string) (Bir
 }
 
 // tryFallbackProviders attempts to get the image from other registered providers.
-func (c *BirdImageCache) tryFallbackProviders(scientificName string, triedProviders map[string]bool) (BirdImage, bool) {
+func (c *BirdImageCache) tryFallbackProviders(ctx context.Context, scientificName string, triedProviders map[string]bool) (BirdImage, bool) {
 	log := GetLogger().With(logger.String("scientific_name", scientificName))
 	log.Debug("Trying fallback providers")
 	registry := c.GetRegistry()
@@ -1585,7 +2061,7 @@ func (c *BirdImageCache) tryFallbackProviders(scientificName string, triedProvid
 
 		// Instead of calling Get (which would recursively try fallbacks), use fetchAndStore directly
 		// to avoid the fallback chain and potential infinite loop
-		img, err := cache.fetchAndStore(scientificName)
+		img, err := cache.fetchAndStore(ctx, scientificName)
 		if err != nil {
 			if errors.Is(err, ErrImageNotFound) {
 				log.Info("Fallback provider has no image",

--- a/internal/imageprovider/imageprovider.go
+++ b/internal/imageprovider/imageprovider.go
@@ -230,9 +230,13 @@ type BirdImageCache struct {
 	// (and the refresh path short-circuits too) without touching the DB, so the cache continues
 	// to serve fresh fetches from the provider instead of generating an
 	// unbounded stream of Sentry events (Forgejo #762, BIRDNET-GO-ZR/ZS).
-	dbCorrupted  atomic.Bool
-	wg           sync.WaitGroup                        // Tracks in-flight DB and background operations
-	Initializing sync.Map                              // Track which species are being initialized
+	dbCorrupted atomic.Bool
+	wg          sync.WaitGroup // Tracks in-flight DB and background operations
+	// initializing holds the per-species initialization lock (see initLock). It is
+	// unexported because its value is a synchronization primitive whose type is an
+	// implementation detail: exporting it invited an unchecked type assertion on a map
+	// any caller could write a different type into.
+	initializing sync.Map
 	registry     atomic.Pointer[ImageProviderRegistry] // Use atomic pointer
 	// exhaustedSpecies tracks species whose primary + fallback providers have
 	// all returned "not found" within the current TTL window. It maps a
@@ -727,8 +731,7 @@ func (c *BirdImageCache) tryRefreshFallback(scientificName string) (BirdImage, b
 		logger.String("provider", c.providerName),
 		logger.String("scientific_name", scientificName))
 
-	settings := conf.Setting()
-	if settings.Realtime.Dashboard.Thumbnails.FallbackPolicy != fallbackPolicyAll {
+	if normalizedFallbackPolicy() != fallbackPolicyAll {
 		return BirdImage{}, false
 	}
 
@@ -1221,10 +1224,10 @@ func (c *BirdImageCache) initLock(scientificName string) chan struct{} {
 	// that is immediately garbage. Measured at 128 B / 2 allocs / ~96ns per call
 	// versus 0 B / 0 allocs / ~10ns for the Load-first form, on a path that now runs
 	// once per thumbnail request. LoadOrStore still resolves the create race.
-	if val, ok := c.Initializing.Load(scientificName); ok {
+	if val, ok := c.initializing.Load(scientificName); ok {
 		return val.(chan struct{})
 	}
-	val, _ := c.Initializing.LoadOrStore(scientificName, make(chan struct{}, 1))
+	val, _ := c.initializing.LoadOrStore(scientificName, make(chan struct{}, 1))
 	return val.(chan struct{})
 }
 
@@ -1275,8 +1278,7 @@ func (c *BirdImageCache) logInitializeError(err error, scientificName string, lo
 // tryFallbackOnGetError attempts to get the image from fallback providers on error.
 // Returns (image, found).
 func (c *BirdImageCache) tryFallbackOnGetError(ctx context.Context, err error, scientificName string, log logger.Logger) (BirdImage, bool) {
-	settings := conf.Setting()
-	if settings.Realtime.Dashboard.Thumbnails.FallbackPolicy != fallbackPolicyAll {
+	if normalizedFallbackPolicy() != fallbackPolicyAll {
 		log.Debug("Primary provider failed but fallback policy is 'none'",
 			logger.Error(err))
 		return BirdImage{}, false

--- a/internal/imageprovider/wikipedia.go
+++ b/internal/imageprovider/wikipedia.go
@@ -49,7 +49,6 @@ const (
 	httpClientIdleConnTimeout = 90 * time.Second
 	httpClientTLSTimeout      = 10 * time.Second
 	httpClientMaxIdleConns    = 10
-	diagnosticRequestTimeout  = 10 * time.Second
 
 	// Rate limiting configuration
 	globalRateLimitPerSecond     = 1 // Requests per second for global rate limiter
@@ -86,8 +85,13 @@ const (
 
 // wikiMediaProvider implements the ImageProvider interface for Wikipedia.
 type wikiMediaProvider struct {
-	httpClient        *http.Client // Standard HTTP client for API requests
-	userAgent         string       // User-Agent header value (cached for reuse)
+	httpClient *http.Client // Standard HTTP client for API requests
+	// apiURL is the MediaWiki endpoint. It exists so tests can point the provider at
+	// an httptest server: without a seam, every HTTP path in this file (retry loop,
+	// circuit breaker, response classification) could only be exercised against the
+	// live Wikipedia API, which is why that coverage was deferred.
+	apiURL            string
+	userAgent         string // User-Agent header value (cached for reuse)
 	debug             bool
 	globalLimiter     *rate.Limiter // Global rate limiter for ALL Wikipedia requests (1 req/sec)
 	backgroundLimiter *rate.Limiter // Additional limiter for background operations
@@ -237,7 +241,7 @@ func (l *wikiMediaProvider) makeAPIRequest(ctx context.Context, params map[strin
 		return nil, err
 	}
 
-	body, statusCode, err := l.executeHTTPRequest(req)
+	body, statusCode, contentType, err := l.executeHTTPRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +250,7 @@ func (l *wikiMediaProvider) makeAPIRequest(ctx context.Context, params map[strin
 		return nil, l.handleHTTPStatusError(statusCode, string(body))
 	}
 
-	return l.parseJSONResponse(body)
+	return l.parseJSONResponse(body, statusCode, contentType)
 }
 
 // waitForGlobalRateLimit waits for the global rate limiter if configured.
@@ -283,7 +287,7 @@ func (l *wikiMediaProvider) validateUserAgent() error {
 
 // buildRequestURL constructs the full API URL with query parameters.
 func (l *wikiMediaProvider) buildRequestURL(params map[string]string) (string, error) {
-	u, err := url.Parse(wikipediaAPIURL)
+	u, err := url.Parse(l.endpoint())
 	if err != nil {
 		return "", errors.New(err).
 			Component("imageprovider").
@@ -299,6 +303,15 @@ func (l *wikiMediaProvider) buildRequestURL(params map[string]string) (string, e
 	}
 	u.RawQuery = q.Encode()
 	return u.String(), nil
+}
+
+// endpoint returns the MediaWiki API URL this provider talks to, defaulting to
+// Wikipedia so a zero-valued provider still behaves as before.
+func (l *wikiMediaProvider) endpoint() string {
+	if l.apiURL == "" {
+		return wikipediaAPIURL
+	}
+	return l.apiURL
 }
 
 // createHTTPRequest creates an HTTP request with proper headers. The context is
@@ -334,10 +347,10 @@ func (l *wikiMediaProvider) createHTTPRequest(ctx context.Context, fullURL strin
 }
 
 // executeHTTPRequest executes the HTTP request and returns the body and status code.
-func (l *wikiMediaProvider) executeHTTPRequest(req *http.Request) (body []byte, statusCode int, err error) {
+func (l *wikiMediaProvider) executeHTTPRequest(req *http.Request) (body []byte, statusCode int, contentType string, err error) {
 	resp, err := l.httpClient.Do(req)
 	if err != nil {
-		return nil, 0, errors.New(err).
+		return nil, 0, "", errors.New(err).
 			Component("imageprovider").
 			Category(errors.CategoryNetwork).
 			Context("provider", wikiProviderName).
@@ -351,9 +364,11 @@ func (l *wikiMediaProvider) executeHTTPRequest(req *http.Request) (body []byte, 
 		}
 	}()
 
+	contentType = resp.Header.Get("Content-Type")
+
 	body, err = io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, resp.StatusCode, errors.New(err).
+		return nil, resp.StatusCode, contentType, errors.New(err).
 			Component("imageprovider").
 			Category(errors.CategoryNetwork).
 			Context("provider", wikiProviderName).
@@ -362,7 +377,7 @@ func (l *wikiMediaProvider) executeHTTPRequest(req *http.Request) (body []byte, 
 			Build()
 	}
 
-	return body, resp.StatusCode, nil
+	return body, resp.StatusCode, contentType, nil
 }
 
 // handleHTTPStatusError processes non-200 HTTP status codes.
@@ -415,14 +430,35 @@ func (l *wikiMediaProvider) handleForbiddenError(bodyStr string) {
 }
 
 // parseJSONResponse parses the response body as JSON into the typed response.
-func (l *wikiMediaProvider) parseJSONResponse(body []byte) (*wikiAPIResponse, error) {
+func (l *wikiMediaProvider) parseJSONResponse(body []byte, statusCode int, contentType string) (*wikiAPIResponse, error) {
 	var resp wikiAPIResponse
 	if err := json.Unmarshal(body, &resp); err != nil {
-		return nil, l.handleJSONParseError(body, err)
+		// Attach the response that failed to parse. The retry loop classifies it
+		// from this copy; re-requesting the same URL to "diagnose" the failure
+		// doubled outbound traffic at exactly the moment Wikipedia was throttling.
+		return nil, &wikiParseFailureError{
+			statusCode:  statusCode,
+			contentType: contentType,
+			body:        body,
+			err:         l.handleJSONParseError(body, err),
+		}
 	}
 	resp.raw = body
 	return &resp, nil
 }
+
+// wikiParseFailureError carries the unparseable response alongside the parse error so the
+// retry loop can classify it (rate limit, block, transient) without issuing a second
+// request for the same URL.
+type wikiParseFailureError struct {
+	statusCode  int
+	contentType string
+	body        []byte
+	err         error
+}
+
+func (e *wikiParseFailureError) Error() string { return e.err.Error() }
+func (e *wikiParseFailureError) Unwrap() error { return e.err }
 
 // handleJSONParseError handles JSON parsing errors with context.
 func (l *wikiMediaProvider) handleJSONParseError(body []byte, parseErr error) error {
@@ -724,89 +760,36 @@ func checkUserAgentPolicyViolation(reqID string, statusCode int, responseBody []
 		Build()
 }
 
-// makeRateLimitedRequest makes a rate-limited HTTP request to the given URL.
-// This ensures all requests, including diagnostic requests, respect the global rate limiter.
-// The context is used for rate limiting, cancellation, and deadlines.
-func (l *wikiMediaProvider) makeRateLimitedRequest(ctx context.Context, requestURL string) (*http.Response, error) {
-	// Apply global rate limiting - ALL requests must respect the 1 req/sec limit
-	if l.globalLimiter != nil {
-		if err := l.globalLimiter.Wait(ctx); err != nil {
-			return nil, errors.New(err).
-				Component("imageprovider").
-				Category(errors.CategoryNetwork).
-				Context("provider", wikiProviderName).
-				Context("operation", "global_rate_limit_wait").
-				Build()
-		}
-		GetLogger().Debug("Global rate limiter wait completed for diagnostic request",
-			logger.String("provider", wikiProviderName))
-	}
-
-	// Create and execute request
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, http.NoBody)
-	if err != nil {
-		return nil, errors.New(err).
-			Component("imageprovider").
-			Category(errors.CategoryNetwork).
-			Context("provider", wikiProviderName).
-			Context("operation", "create_diagnostic_request").
-			Build()
-	}
-	req.Header.Set("User-Agent", l.userAgent)
-
-	httpClient := &http.Client{Timeout: diagnosticRequestTimeout}
-	return httpClient.Do(req)
-}
-
-// handleJSONParsingError handles JSON parsing errors by making a rate-limited diagnostic request
-// Always performs diagnostics to identify rate limiting and other error types
-func (l *wikiMediaProvider) handleJSONParsingError(ctx context.Context, reqID, fullURL string, origErr error, attempt int) error {
+// classifyParseFailure diagnoses a response that could not be parsed as JSON and
+// decides whether it is a permanent condition that must abort the retry loop.
+//
+// It classifies the response the caller already has. The previous implementation
+// re-issued the same GET to the same URL purely for diagnostics, which doubled
+// outbound traffic in precisely the situation the diagnosis was for: Wikipedia
+// throttling or blocking us. A returned non-nil error stops the retries.
+func (l *wikiMediaProvider) classifyParseFailure(reqID, fullURL string, attempt int, failure *wikiParseFailureError) error {
 	log := GetLogger().With(
 		logger.String("provider", wikiProviderName),
 		logger.String("request_id", reqID),
 		logger.Int("attempt", attempt+1),
 		logger.Int("max_attempts", l.maxRetries))
 
-	// Always make a diagnostic request to identify the actual error type
-	// This is important to detect rate limiting and blocking
-	// Use rate-limited request to ensure all requests respect the global limiter
-
-	debugResp, debugErr := l.makeRateLimitedRequest(ctx, fullURL)
-	if debugErr != nil {
-		log.Debug("Unable to diagnose API error",
-			logger.String("diagnostic_error", debugErr.Error()),
-			logger.String("original_error", origErr.Error()))
-		return nil // Continue with normal retry logic
-	}
-
-	defer func() {
-		if closeErr := debugResp.Body.Close(); closeErr != nil {
-			log.Debug("Failed to close debug response body", logger.Error(closeErr))
-		}
-	}()
-
-	body, readErr := io.ReadAll(debugResp.Body)
-	if readErr != nil {
-		log.Debug("Failed to read debug response body", logger.Error(readErr))
-		return nil // Continue with normal retry logic
-	}
-
-	// Detect error type
-	errorType, errorMsg := detectWikipediaErrorType(debugResp.StatusCode, body, debugResp.Header.Get("Content-Type"))
+	body := failure.body
+	errorType, errorMsg := detectWikipediaErrorType(failure.statusCode, body, failure.contentType)
 
 	// Log error details based on severity
 	logFields := []logger.Field{
 		logger.Int("error_type", int(errorType)),
 		logger.String("error_message", errorMsg),
-		logger.Int("status_code", debugResp.StatusCode),
-		logger.String("content_type", debugResp.Header.Get("Content-Type")),
+		logger.Int("status_code", failure.statusCode),
+		logger.String("content_type", failure.contentType),
 		logger.String("requested_url", fullURL),
 	}
 
 	switch {
 	case errorType == wikiErrorRateLimit || errorType == wikiErrorBlocked || errorType == wikiErrorUserAgent:
 		log.Error("Wikipedia API error diagnosed", logFields...)
-	case debugResp.StatusCode != http.StatusOK:
+	case failure.statusCode != http.StatusOK:
 		log.Warn("Wikipedia API error diagnosed", logFields...)
 	default:
 		log.Debug("Wikipedia API error diagnosed", logFields...)
@@ -829,7 +812,7 @@ func (l *wikiMediaProvider) handleJSONParsingError(ctx context.Context, reqID, f
 			Context("provider", wikiProviderName).
 			Context("request_id", reqID).
 			Context("operation", "rate_limit_exceeded").
-			Context("status_code", debugResp.StatusCode).
+			Context("status_code", failure.statusCode).
 			Context("error_message", errorMsg).
 			Context("permanent_failure", true).
 			Context("retry_after", "60s"). // Suggest retry after 60 seconds
@@ -844,7 +827,7 @@ func (l *wikiMediaProvider) handleJSONParsingError(ctx context.Context, reqID, f
 			Context("provider", wikiProviderName).
 			Context("request_id", reqID).
 			Context("operation", "access_blocked").
-			Context("status_code", debugResp.StatusCode).
+			Context("status_code", failure.statusCode).
 			Context("error_message", errorMsg).
 			Context("permanent_failure", true).
 			Build()
@@ -852,7 +835,7 @@ func (l *wikiMediaProvider) handleJSONParsingError(ctx context.Context, reqID, f
 	case wikiErrorUserAgent:
 		// User-agent policy violation - open circuit breaker
 		l.openCircuit(circuitBreakerUserAgentDuration, "User-Agent policy violation")
-		return checkUserAgentPolicyViolation(reqID, debugResp.StatusCode, body, l.userAgent)
+		return checkUserAgentPolicyViolation(reqID, failure.statusCode, body, l.userAgent)
 
 	case wikiErrorTemporary:
 		// Temporary error - continue with retry logic but with longer backoff
@@ -985,6 +968,7 @@ func NewWikiMediaProvider() (*wikiMediaProvider, error) {
 
 	return &wikiMediaProvider{
 		httpClient:        httpClient,
+		apiURL:            wikipediaAPIURL,
 		userAgent:         userAgent,
 		debug:             settings.Realtime.Dashboard.Thumbnails.Debug,
 		globalLimiter:     globalLimiter,
@@ -1047,16 +1031,19 @@ func logSuccessfulAPIResponse(resp *wikiAPIResponse) {
 			logger.Int("response_size", len(resp.raw)))
 }
 
-// handleJSONParsingErrorIfNeeded checks for JSON parsing errors and handles them appropriately.
-func (l *wikiMediaProvider) handleJSONParsingErrorIfNeeded(ctx context.Context, err error, reqID, fullURL string, attempt int) error {
-	if !strings.Contains(err.Error(), "invalid character") || !strings.Contains(err.Error(), "looking for beginning of value") {
+// handleJSONParsingErrorIfNeeded classifies a JSON parse failure and returns a
+// non-nil error when the response indicates a permanent condition that retrying would
+// only make worse.
+//
+// The gate is the failure type rather than substrings of the error message: matching
+// on "invalid character" and "looking for beginning of value" silently stopped
+// applying whenever the wrapping text changed.
+func (l *wikiMediaProvider) handleJSONParsingErrorIfNeeded(err error, reqID, fullURL string, attempt int) error {
+	var failure *wikiParseFailureError
+	if !errors.As(err, &failure) {
 		return nil
 	}
-
-	if policyErr := l.handleJSONParsingError(ctx, reqID, fullURL, err, attempt); policyErr != nil {
-		return policyErr
-	}
-	return nil
+	return l.classifyParseFailure(reqID, fullURL, attempt, failure)
 }
 
 // calculateRetryDelay calculates the delay before the next retry using exponential backoff.
@@ -1142,8 +1129,8 @@ func (l *wikiMediaProvider) queryWithRetryAndLimiter(ctx context.Context, reqID 
 			return resp, nil
 		}
 
-		fullURL := buildDebugURL(params)
-		if policyErr := l.handleJSONParsingErrorIfNeeded(ctx, err, reqID, fullURL, attempt); policyErr != nil {
+		fullURL := l.buildDebugURL(params)
+		if policyErr := l.handleJSONParsingErrorIfNeeded(err, reqID, fullURL, attempt); policyErr != nil {
 			return nil, policyErr
 		}
 
@@ -1202,12 +1189,12 @@ func (l *wikiMediaProvider) queryWithRetryAndLimiter(ctx context.Context, reqID 
 }
 
 // buildDebugURL constructs a URL string for debug logging purposes.
-func buildDebugURL(params map[string]string) string {
+func (l *wikiMediaProvider) buildDebugURL(params map[string]string) string {
 	queryParams := make([]string, 0, len(params))
 	for k, v := range params {
 		queryParams = append(queryParams, k+"="+url.QueryEscape(v))
 	}
-	return wikipediaAPIURL + "?" + strings.Join(queryParams, "&")
+	return l.endpoint() + "?" + strings.Join(queryParams, "&")
 }
 
 // logRawResponse logs the raw API response at debug level for troubleshooting.
@@ -1280,7 +1267,7 @@ func (l *wikiMediaProvider) queryAndGetFirstPageWithLimiter(ctx context.Context,
 		logger.String("api_action", params["action"]),
 		logger.String("titles", params["titles"]))
 
-	fullURL := buildDebugURL(params)
+	fullURL := l.buildDebugURL(params)
 	log.Debug("Querying Wikipedia API", logger.String("debug_full_url", fullURL))
 
 	resp, err := l.queryWithRetryAndLimiter(ctx, reqID, params, limiter)
@@ -1370,7 +1357,12 @@ func (l *wikiMediaProvider) FetchWithContext(ctx context.Context, scientificName
 
 // Fetch retrieves the bird image for a given scientific name.
 // It queries for the thumbnail and author information, then constructs a BirdImage.
-// User requests through this method are not rate limited.
+//
+// Every request made through this method still passes the process-global 1 req/s
+// limiter; what it skips is the additional, more conservative background limiter that
+// FetchWithContext applies to sweep operations. Prefer FetchWithContext: this method
+// exists for the context-free ImageProvider interface, and its context.Background()
+// means neither the retry backoff nor the limiter wait can be cancelled.
 func (l *wikiMediaProvider) Fetch(scientificName string) (BirdImage, error) {
 	// Check if we're allowed to make requests to WikiMedia
 	if allowed, reason := l.isAllowedToFetch(); !allowed {
@@ -1436,11 +1428,18 @@ func (l *wikiMediaProvider) fetchWithLimiter(ctx context.Context, scientificName
 				licenseURL:  "",
 			}
 		} else {
-			// This is a real error (network, API issues), so we should report it
+			// This is a real error (network, API issues), so we should report it.
+			//
+			// Wrap the cause instead of replacing it. Building a fresh error here
+			// dropped both the cause's CategoryNetwork tag and the "wikipedia api
+			// circuit breaker open" text that internal/errors/telemetry_integration.go
+			// matches on to suppress rate-limit noise, so a transient throttle was
+			// reported to Sentry once per species. Same rationale as the wrapping at
+			// imageprovider.go enhanceFetchError.
 			log.Error("Failed to fetch author info", logger.Error(err))
-			enhancedErr := errors.Newf("unable to retrieve image attribution for species: %s", scientificName).
+			enhancedErr := errors.Newf("unable to retrieve image attribution for species %s: %w", scientificName, err).
 				Component("imageprovider").
-				Category(errors.CategoryImageFetch).
+				Category(causeCategory(err, errors.CategoryImageFetch)).
 				Context("provider", wikiProviderName).
 				Context("request_id", reqID).
 				Context("scientific_name", scientificName).
@@ -1635,6 +1634,28 @@ func (l *wikiMediaProvider) queryAuthorInfo(ctx context.Context, reqID, thumbnai
 		licenseName: licenseName,
 		licenseURL:  licenseURL,
 	}, nil
+}
+
+// causeCategory returns the error category already carried by err, falling back to
+// fallback for a plain error. Preserving the cause's category matters because
+// telemetry suppression and errors.Is matching both key on it: re-tagging a
+// CategoryNetwork throttle as CategoryImageFetch turns a suppressed transient into a
+// per-species Sentry event.
+func causeCategory(err error, fallback errors.ErrorCategory) errors.ErrorCategory {
+	// Check the interface first, mirroring internal/errors.detectCategory: a cause can
+	// carry a category without being an *EnhancedError, and re-tagging one of those to
+	// the fallback is exactly the suppression regression this helper exists to prevent.
+	var categorized errors.CategorizedError
+	if errors.As(err, &categorized) {
+		if category := categorized.ErrorCategory(); category != "" {
+			return category
+		}
+	}
+	var enhanced *errors.EnhancedError
+	if errors.As(err, &enhanced) && enhanced.Category != "" {
+		return enhanced.Category
+	}
+	return fallback
 }
 
 // parseAuthorFromHTML extracts author name and URL from HTML, with fallbacks.

--- a/internal/imageprovider/wikipedia_http_test.go
+++ b/internal/imageprovider/wikipedia_http_test.go
@@ -1,0 +1,198 @@
+package imageprovider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+)
+
+// newTestWikiProvider returns a provider pointed at a local httptest server.
+//
+// Every HTTP path in wikipedia.go (the retry loop, the circuit breaker, response
+// classification) previously had no coverage because the endpoint was a package
+// constant, so exercising it meant calling the live Wikipedia API. apiURL exists as
+// the seam that makes these paths testable.
+func newTestWikiProvider(t *testing.T, handler http.HandlerFunc) *wikiMediaProvider {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	return &wikiMediaProvider{
+		httpClient: server.Client(),
+		apiURL:     server.URL,
+		userAgent:  buildUserAgent("1.2.3-test"),
+		// A very high limit keeps the tests fast while still exercising the limiter
+		// call sites; the production value is 1 req/s.
+		globalLimiter: rate.NewLimiter(rate.Inf, 1),
+		maxRetries:    defaultMaxRetries,
+	}
+}
+
+// TestQueryWithRetry_RetriesThenSucceeds pins the happy retry path and, importantly,
+// that a success resets the circuit breaker rather than leaving it half-open.
+func TestQueryWithRetry_RetriesThenSucceeds(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	provider := newTestWikiProvider(t, func(w http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"query":{"pages":[{"title":"Turdus merula"}]}}`))
+	})
+	// The production backoff is seconds; the retry behaviour under test is the
+	// sequencing, not the wait.
+	provider.maxRetries = 2
+
+	resp, err := provider.queryWithRetryAndLimiter(t.Context(), "test", map[string]string{
+		"action": "query",
+		"titles": "Turdus merula",
+	}, nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, int64(2), calls.Load())
+
+	open, _ := provider.isCircuitOpen()
+	assert.False(t, open, "a successful response must reset the circuit")
+}
+
+// TestQueryWithRetry_RateLimitAbandonsRemainingAttempts is the request-amplification
+// guard: a 429 opens the circuit breaker, and the retry loop must stop rather than
+// spend its remaining attempts hammering a host that just told us to back off.
+func TestQueryWithRetry_RateLimitAbandonsRemainingAttempts(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	provider := newTestWikiProvider(t, func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusTooManyRequests)
+	})
+
+	_, err := provider.queryWithRetryAndLimiter(t.Context(), "test", map[string]string{
+		"action": "query",
+		"titles": "Turdus merula",
+	}, nil)
+
+	require.Error(t, err)
+	assert.Equal(t, int64(1), calls.Load(),
+		"a 429 opens the circuit, so attempts 2 and 3 must not fire")
+
+	open, reason := provider.isCircuitOpen()
+	assert.True(t, open)
+	assert.Contains(t, reason, "429")
+
+	// The breaker's own message is what internal/errors telemetry suppression matches
+	// on, so it must survive rather than being replaced by a retry-exhausted error.
+	assert.Contains(t, err.Error(), "circuit breaker open")
+}
+
+// TestQueryWithRetry_CircuitOpenSkipsTheRequestEntirely asserts the pre-loop check
+// still short-circuits, so an already-open breaker costs no outbound traffic.
+func TestQueryWithRetry_CircuitOpenSkipsTheRequestEntirely(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	provider := newTestWikiProvider(t, func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusOK)
+	})
+	provider.openCircuit(time.Minute, "test block")
+
+	_, err := provider.queryWithRetryAndLimiter(t.Context(), "test", map[string]string{"action": "query"}, nil)
+
+	require.Error(t, err)
+	assert.Zero(t, calls.Load())
+}
+
+// TestQueryWithRetry_ContextCancellationStopsRetrying asserts the backoff is
+// interruptible. Fetch used to pass context.Background(), whose Done() channel is nil
+// and can therefore never be selected, so neither the backoff nor the limiter wait
+// could be abandoned.
+func TestQueryWithRetry_ContextCancellationStopsRetrying(t *testing.T) {
+	t.Parallel()
+
+	provider := newTestWikiProvider(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		_, err := provider.queryWithRetryAndLimiter(ctx, "test", map[string]string{"action": "query"}, nil)
+		done <- err
+	}()
+
+	// The first attempt fails fast and the loop enters its 2s backoff; cancelling
+	// there must return immediately rather than waiting the backoff out.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		// The specific error matters: require.Error alone is satisfied by the 500 that
+		// already happened, so the assertion would pass even if the backoff ran to
+		// completion and the cancellation was never observed.
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(1500 * time.Millisecond):
+		t.Fatal("a cancelled context did not interrupt the retry backoff")
+	}
+}
+
+// TestQueryWithRetry_UnparseableResponseIsNotRefetched is the regression test for the
+// diagnostic double-request: an HTML error page served with HTTP 200 used to trigger a
+// second GET of the same URL purely to classify it, doubling outbound traffic at
+// exactly the moment Wikipedia was throttling. The classification now runs on the
+// response already in hand.
+func TestQueryWithRetry_UnparseableResponseIsNotRefetched(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	provider := newTestWikiProvider(t, func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<!DOCTYPE html><html><body><h1>Access blocked</h1></body></html>"))
+	})
+	provider.maxRetries = 1
+
+	_, err := provider.queryWithRetryAndLimiter(t.Context(), "test", map[string]string{"action": "query"}, nil)
+
+	require.Error(t, err)
+	assert.Equal(t, int64(1), calls.Load(),
+		"classifying an unparseable response must not issue a second request for it")
+}
+
+// TestQueryWithRetry_NonPositiveMaxRetries guards the nil-dereference that a
+// non-positive maxRetries used to cause: the loop body never ran, leaving lastErr nil
+// for the post-loop error construction to dereference.
+func TestQueryWithRetry_NonPositiveMaxRetries(t *testing.T) {
+	t.Parallel()
+
+	provider := newTestWikiProvider(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	provider.maxRetries = 0
+
+	_, err := provider.queryWithRetryAndLimiter(t.Context(), "test", map[string]string{"action": "query"}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid maxRetries")
+}
+
+// TestBuildUserAgent_IncludesVersion covers the memoized User-Agent branch that was
+// unreachable in tests because Settings.Version is empty in the test binary.
+func TestBuildUserAgent_IncludesVersion(t *testing.T) {
+	t.Parallel()
+
+	ua := buildUserAgent("1.2.3-test")
+	assert.Contains(t, ua, "1.2.3-test")
+	assert.Contains(t, ua, userAgentName)
+}

--- a/internal/mqtt/dto.go
+++ b/internal/mqtt/dto.go
@@ -104,6 +104,12 @@ func NewMQTTEventDTO(r *detection.Result) *MQTTEventDTO {
 }
 
 // SetBirdImage adds bird image data to the DTO.
+//
+// The URL published is the provider's upstream address, not the media-proxy URL the
+// REST API and SSE stream use. An MQTT subscriber is not a browser with an origin to
+// resolve a root-relative path against, and it may be off the LAN entirely, so the
+// proxy URL would be unusable. An absent URL means no image is known, which is a
+// truthful signal a subscriber can act on.
 func (dto *MQTTEventDTO) SetBirdImage(img *imageprovider.BirdImage) {
 	if img == nil || img.URL == "" {
 		return

--- a/internal/mqtt/dto_bird_image_test.go
+++ b/internal/mqtt/dto_bird_image_test.go
@@ -1,0 +1,49 @@
+package mqtt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/imageprovider"
+)
+
+// TestSetBirdImage_PublishesTheUpstreamURL pins the deliberate exception to the media
+// proxy boundary.
+//
+// The REST API and the SSE stream publish a media-proxy URL, because their consumer is
+// a same-origin browser. An MQTT subscriber is not: it has no origin to resolve a
+// root-relative path against, and the usual consumer may be off the LAN entirely, so
+// the provider's public URL is the only form it can render.
+func TestSetBirdImage_PublishesTheUpstreamURL(t *testing.T) {
+	t.Parallel()
+
+	dto := &MQTTEventDTO{}
+	dto.SetBirdImage(&imageprovider.BirdImage{
+		URL:            "https://upload.wikimedia.org/raw.jpg",
+		ScientificName: "Turdus merula",
+		AuthorName:     "Someone",
+		SourceProvider: "wikimedia",
+	})
+
+	require.NotNil(t, dto.BirdImage)
+	assert.Equal(t, "https://upload.wikimedia.org/raw.jpg", dto.BirdImage.URL)
+	assert.NotEqual(t, imageprovider.ProxyImageURL("Turdus merula"), dto.BirdImage.URL,
+		"an MQTT subscriber cannot resolve a root-relative proxy URL")
+	assert.Equal(t, "Someone", dto.BirdImage.AuthorName)
+}
+
+// TestSetBirdImage_OmitsTheBlockWithoutAURL asserts that an unresolved image is
+// reported by omission. That is a truthful signal a subscriber can branch on, and it
+// is the normal state right after a detection now that nothing fetches on the save
+// path.
+func TestSetBirdImage_OmitsTheBlockWithoutAURL(t *testing.T) {
+	t.Parallel()
+
+	dto := &MQTTEventDTO{}
+	dto.SetBirdImage(nil)
+	assert.Nil(t, dto.BirdImage)
+
+	dto.SetBirdImage(&imageprovider.BirdImage{ScientificName: "Parus major"})
+	assert.Nil(t, dto.BirdImage, "a species with no resolved image publishes no image block")
+}


### PR DESCRIPTION
A cold species image could take minutes to resolve. `BirdImageCache.Get` took no context, so the Wikipedia provider chain was uncancellable and unbounded: up to three API calls behind a process-global 1 req/s limiter, each retried three times with 2s/2s/4s backoff on a 30s HTTP timeout. That call ran on the media proxy's request goroutine, under `pendingMutex` in the SSE pending-detection path, and inside the `CompositeAction` whose 30s timeout is the documented reason audio export was moved out of it. Thirty uncached dashboard thumbnails also parked a browser's entire per-host connection budget, which is why this presented as the whole UI freezing rather than as slow images.

Fixes #1232's "UI blocks for minutes", and addresses the 429 reports in discussion #3330.

## Measured, before and after

On a 2-core QA VM with the provider chain actually engaged (`imageprovider: wikimedia`, `fallbackpolicy: all`), requesting thirty uncached dashboard thumbnails at once:

| | before | after |
|---|---|---|
| slowest single request | blocks on the provider chain | **7.8 ms** |
| all thirty resolved | n/a, the requests are the fetch | ~80 s, in the background |

Every request is answered immediately; the same provider work still happens, just not on a request goroutine. The 80 seconds is the 1 req/s limiter doing its job, which is exactly the cost that used to be charged to the browser.

## What changed

**The media proxy is a hard boundary.** Both `302` fallbacks to the upstream image host are gone. A species with nothing cached answers `503` with `Retry-After: 5` and `Cache-Control: no-store`; one that is known to have no image answers `404` with a long `max-age`. Those two cache directives are load-bearing rather than incidental: an `<img>` error event exposes no status code, so the browser's own HTTP cache is what makes a blind client retry cheap for the terminal case (served from cache, no network hop) and effective for the transient one. The `503` deliberately bypasses `HandleError`, because apicore reports every status >= 500 to Sentry and a cold dashboard would otherwise emit thirty events per load.

**`internal/imageprovider` gains a non-blocking surface.** `GetWithContext` plumbs a context to the provider, and the per-species initialization lock moves from a `sync.Mutex` to a buffered channel so a caller can abandon a wait it no longer needs. `GetCached` consults memory and the DB only, never a provider, and never blocks; under `fallbackpolicy: all` it also sweeps the other registered providers' caches, because the blocking path it replaces consulted them on exactly this outcome. `PrefetchAsync` runs the fetch on a background goroutine, deduplicated per species, bounded by a semaphore and a queue cap, under a detached context that `Close` cancels before it waits.

**Three more request-amplification fixes**, same "stop hammering the provider" goal:

- The image-byte download path gains the circuit breaker it never had. A blanket 403 used to mean one guaranteed-failing outbound request per uncached species on every page load, forever, which is the traffic profile that earns a block in the first place.
- The MediaWiki path stops re-issuing the same GET purely to diagnose a JSON parse failure. That doubled outbound traffic at precisely the moment Wikipedia was throttling us; the response is now classified from the copy already in hand.
- An author-info failure wraps its cause instead of replacing it, so a throttle keeps the `CategoryNetwork` tag and breaker text that telemetry suppression matches on. It was previously reported to Sentry once per species during a rate-limit episode.

**Frontend: a cold miss must not be terminal.** `handleBirdImageError` previously swapped in the placeholder permanently, and `DetectionRow` recorded failed URLs specifically to prevent retries, so without this a cold cache would render silhouettes everywhere until a hard refresh. It now retries on a bounded, jittered schedule that brackets the measured cold-cache tail, loading each attempt into a detached probe image first so the placeholder does not flicker for a species that genuinely has no image. Components that defeated a retry by unmounting the `<img>` (`BirdThumbnailPopup`), by hand-rolling the placeholder swap (`Search`), or by rendering a raw `<img>` with no error handler (`CurrentlyHearingCard`) now go through the shared helper. `DetectionDetail` retries attribution on a `503` rather than silently dropping the CC-BY author and licence credit for a photo it does go on to display.

## Deliberate exception, and it is the interesting one

Notification metadata and the MQTT payload keep the provider's **upstream** URL rather than the proxy URL. Both are consumed off-process: Discord fetches an embed image server-side and re-hosts it, and an MQTT subscriber has no origin to resolve a root-relative path against. For the typical home-LAN install no BirdNET-Go URL is reachable from either, whether root-relative or absolute from a private host, so the provider's public CDN address is the only form that renders. The in-app surfaces (REST and SSE) carry the proxy URL, which is where a single controlled address actually buys something.

This is a narrowing of what was originally specified, recorded rather than applied silently, and it is tracked for a proper decision.

## Behaviour changes worth knowing about

- `GET /media/image/:scientific_name` no longer 302s. A client that relied on being redirected to the upstream host must now handle `503` + `Retry-After`.
- `GET /media/species-image/info` returns `503` with the standard JSON error body on a cold miss instead of blocking.
- The SSE `birdImage.url` is now the proxy URL and is always present, so it is no longer usable as a "an image exists" flag. The proxy answers `404` for a species that has none. `doc/wiki/guide.md` is updated, including the sample consumer, which was wrong in both respects.
- `handleBirdImageError` returns `boolean`. All fourteen existing call sites remain source-compatible.

## Verification

- `go test -race` across `imageprovider`, `api/...`, `mqtt`, `notification`, `alerting`: green. `golangci-lint run`: 0 issues. `npm run check:all`: clean.
- New tests cover cancellation actually being observed (not merely that a call returned), the three `GetCached` states including the stale-DB refresh, prefetch dedup/cap/shutdown, the download cooldown, the cold-miss and never-redirect contracts, and the frontend retry including the element-recycled and probe-in-flight cases.
- `wikiMediaProvider` gains an API base-URL seam, so its retry loop, circuit breaker and response classification are now testable against `httptest` rather than only against live Wikipedia.
- End-to-end on a QA VM as described above, plus confirmation that no `Location` header is emitted on any path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Species images now use a local media-proxy URL in SSE detection events.
  * Unavailable images return a temporary pending response with retry guidance instead of blocking or redirecting.
  * Image loading automatically retries briefly unavailable thumbnails and safely falls back when no image exists.
  * Improved handling of image attribution and background image loading.

* **Bug Fixes**
  * Prevented broken-image states during retries and virtualized list updates.
  * Added safer cancellation and timeout behavior for image retrieval.

* **Documentation**
  * Updated SSE and media endpoint guidance, including pending-image status handling and client retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->