### PR TITLE
fix(dashboard): show species thumbnails in the summary table by default

### DIFF
--- a/internal/conf/config.yaml
+++ b/internal/conf/config.yaml
@@ -222,7 +222,7 @@ realtime:
   dashboard:
     thumbnails:
       debug: false        # true to enable debug mode for image provider
-      summary: false      # show thumbnails on summary table
+      summary: true       # show thumbnails on summary table
       recent: true        # show thumbnails on recent table
       imageprovider: avicommons # preferred image provider: avicommons, wikimedia, auto
       fallbackpolicy: none # fallback policy: none (no fallback), all (try all available providers)

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -166,7 +166,7 @@ func setDefaultConfig() {
 
 	// Dashboard thumbnails configuration
 	viper.SetDefault("realtime.dashboard.thumbnails.debug", false)
-	viper.SetDefault("realtime.dashboard.thumbnails.summary", false)
+	viper.SetDefault("realtime.dashboard.thumbnails.summary", true)
 	viper.SetDefault("realtime.dashboard.thumbnails.recent", true)
 	viper.SetDefault("realtime.dashboard.thumbnails.imageprovider", "avicommons")
 	viper.SetDefault("realtime.dashboard.thumbnails.fallbackpolicy", "none")


### PR DESCRIPTION
The backend defaults `realtime.dashboard.thumbnails.summary` to `false`, while the frontend falls back to `?? true` when the key is absent (`DashboardPage.svelte:518`). `Summary bool` has no `omitempty` json tag, so `false` is always serialized explicitly and that frontend fallback can never fire. A fresh install therefore renders initials badges on the dashboard summary table while the recent detections table and the detection details both show real thumbnails.

That is the exact symptom split in #3401: image present in detection details, placeholder on the overview, with no image-pipeline defect involved.

This aligns the backend default with the frontend's, in both the viper defaults and the shipped config template.

Existing installs are untouched: they already carry `summary: false` in their config file, so viper's default never applies to them and nobody's explicit choice is overridden. Users on an existing install get the thumbnails by toggling the setting in Settings > User Interface.

Verified: `go test ./internal/conf/...` passes and `golangci-lint run ./internal/conf/...` is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Thumbnail summaries are now enabled by default in the realtime dashboard’s summary table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->