### PR TITLE
fix(imageprovider): stop caching the wrong species image, and the wrong licence

### DIFF
--- a/internal/analysis/image_cache_init.go
+++ b/internal/analysis/image_cache_init.go
@@ -105,25 +105,27 @@ func selectImageProvider(log logger.Logger, registry *imageprovider.ImageProvide
 }
 
 const (
-	// warmUpRetryDelay is the first backoff after the prefetch queue declines a
-	// species. It doubles on each further attempt.
-	warmUpRetryDelay = 100 * time.Millisecond
-	// warmUpMaxRetries bounds the backoff for one species to roughly 12 seconds.
-	warmUpMaxRetries = 7
+	// warmUpRetryDelay is how long warm-up waits for the prefetch queue to drain
+	// before retrying one species: roughly the time it takes a running prefetch
+	// to finish and free its slot.
+	warmUpRetryDelay = 2 * time.Second
 	// warmUpMaxConsecutiveDrops stops the whole warm-up once this many species in
-	// a row exhaust their retries. A queue that will not drain means the cache is
-	// closing or the pipeline is stuck, and there is nothing to be gained by
-	// walking the remaining species.
-	warmUpMaxConsecutiveDrops = 2
+	// a row are refused. PrefetchAsync answers with a bare bool and declines for
+	// several unrelated reasons, only one of which is worth waiting out, so
+	// warm-up cannot tell a full queue from a closing cache or from a species
+	// whose last resolution just failed. Bounding the run of refusals is what
+	// keeps a shutting-down cache from walking the entire species list, and it
+	// costs a few seconds at most.
+	warmUpMaxConsecutiveDrops = 3
 )
 
 // warmUpImageCache pre-fetches images for species not yet in the cache.
 //
 // It schedules through the cache's own prefetch machinery rather than calling
 // the blocking Get on raw goroutines. That older loop had its own 5-slot
-// semaphore, so it ignored the cache's concurrency and queue bounds, ran on
-// context.Background() where Close's cancellation could not reach it, and was
-// untracked by the cache's WaitGroup, leaving goroutines running past Close.
+// semaphore, so it ignored the cache's concurrency and queue bounds, and its
+// fetches ran on context.Background(), untracked by the cache's WaitGroup and
+// so still running past Close.
 //
 // PrefetchAsync declines once its queue is full, so this applies backpressure
 // rather than substituting for it: a straight call per species would silently
@@ -136,7 +138,7 @@ func warmUpImageCache(cache *imageprovider.BirdImageCache, species []string) {
 	log := GetLogger()
 	log.Info("starting image cache warm-up", logger.Int("species_count", len(species)))
 
-	scheduled, dropped, consecutiveDrops := 0, 0, 0
+	scheduled, consecutiveDrops := 0, 0
 	for _, name := range species {
 		if warmUpSchedule(cache, name) {
 			scheduled++
@@ -144,11 +146,13 @@ func warmUpImageCache(cache *imageprovider.BirdImageCache, species []string) {
 			continue
 		}
 
-		dropped++
 		consecutiveDrops++
 		log.Debug("warm-up could not schedule a species", logger.String("species", name))
 		if consecutiveDrops >= warmUpMaxConsecutiveDrops {
-			log.Info("stopping image cache warm-up: the prefetch queue is not draining",
+			// Deliberately not blamed on the queue: the refusal carries no
+			// reason, and a closing cache, a species in backoff and a full queue
+			// are indistinguishable from here.
+			log.Info("stopping image cache warm-up: prefetches are being declined",
 				logger.Int("scheduled", scheduled),
 				logger.Int("not_scheduled", len(species)-scheduled))
 			return
@@ -157,21 +161,22 @@ func warmUpImageCache(cache *imageprovider.BirdImageCache, species []string) {
 
 	log.Info("image cache warm-up scheduled",
 		logger.Int("scheduled", scheduled),
-		logger.Int("not_scheduled", dropped))
+		logger.Int("not_scheduled", len(species)-scheduled))
 }
 
-// warmUpSchedule registers one species for prefetching, backing off while the
-// queue is full. It reports whether the species was accepted.
+// warmUpSchedule registers one species for prefetching, waiting once for the
+// queue to drain.
+//
+// A single retry is deliberate. If the refusal is queue pressure, a slot frees
+// as running prefetches complete. If it is anything else no amount of waiting
+// helps: a species backed off after a failed resolution holds that marker for
+// longer than any retry ladder worth running, and the request path resolves it
+// on demand anyway. The previous exponential ladder spent 12.7 seconds per
+// species discovering that, and burned it again on every species after Close.
 func warmUpSchedule(cache *imageprovider.BirdImageCache, name string) bool {
-	delay := warmUpRetryDelay
-	for attempt := 0; ; attempt++ {
-		if cache.PrefetchAsync(name) {
-			return true
-		}
-		if attempt >= warmUpMaxRetries {
-			return false
-		}
-		time.Sleep(delay)
-		delay *= 2
+	if cache.PrefetchAsync(name) {
+		return true
 	}
+	time.Sleep(warmUpRetryDelay)
+	return cache.PrefetchAsync(name)
 }

--- a/internal/analysis/image_cache_init.go
+++ b/internal/analysis/image_cache_init.go
@@ -1,13 +1,11 @@
 package analysis
 
 import (
-	"fmt"
-	"sync"
+	"time"
 
 	"github.com/tphakala/birdnet-go/internal/api"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
-	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/observability"
@@ -106,8 +104,30 @@ func selectImageProvider(log logger.Logger, registry *imageprovider.ImageProvide
 	return fallback
 }
 
+const (
+	// warmUpRetryDelay is the first backoff after the prefetch queue declines a
+	// species. It doubles on each further attempt.
+	warmUpRetryDelay = 100 * time.Millisecond
+	// warmUpMaxRetries bounds the backoff for one species to roughly 12 seconds.
+	warmUpMaxRetries = 7
+	// warmUpMaxConsecutiveDrops stops the whole warm-up once this many species in
+	// a row exhaust their retries. A queue that will not drain means the cache is
+	// closing or the pipeline is stuck, and there is nothing to be gained by
+	// walking the remaining species.
+	warmUpMaxConsecutiveDrops = 2
+)
+
 // warmUpImageCache pre-fetches images for species not yet in the cache.
-// Runs in a background goroutine with bounded concurrency.
+//
+// It schedules through the cache's own prefetch machinery rather than calling
+// the blocking Get on raw goroutines. That older loop had its own 5-slot
+// semaphore, so it ignored the cache's concurrency and queue bounds, ran on
+// context.Background() where Close's cancellation could not reach it, and was
+// untracked by the cache's WaitGroup, leaving goroutines running past Close.
+//
+// PrefetchAsync declines once its queue is full, so this applies backpressure
+// rather than substituting for it: a straight call per species would silently
+// drop everything past the queue cap on a large install.
 func warmUpImageCache(cache *imageprovider.BirdImageCache, species []string) {
 	if len(species) == 0 {
 		return
@@ -116,40 +136,42 @@ func warmUpImageCache(cache *imageprovider.BirdImageCache, species []string) {
 	log := GetLogger()
 	log.Info("starting image cache warm-up", logger.Int("species_count", len(species)))
 
-	const maxConcurrent = 5
-	sem := make(chan struct{}, maxConcurrent)
-	var wg sync.WaitGroup
-
+	scheduled, dropped, consecutiveDrops := 0, 0, 0
 	for _, name := range species {
-		wg.Add(1)
-		go func(sciName string) {
-			defer wg.Done()
-			defer func() {
-				if r := recover(); r != nil {
-					panicErr := fmt.Errorf("panic in image cache warm-up: %v", r)
-					log.Error("panic in image cache warm-up",
-						logger.String("species", sciName),
-						logger.Any("panic", r))
-					_ = errors.New(panicErr).
-						Component("analysis.image_cache").
-						Category(errors.CategorySystem).
-						Context("operation", "image_cache_warmup_panic").
-						Context("species", sciName).
-						Priority(errors.PriorityCritical).
-						Build()
-				}
-			}()
-			sem <- struct{}{}
-			defer func() { <-sem }()
+		if warmUpSchedule(cache, name) {
+			scheduled++
+			consecutiveDrops = 0
+			continue
+		}
 
-			if _, err := cache.Get(sciName); err != nil {
-				log.Debug("warm-up fetch failed",
-					logger.String("species", sciName),
-					logger.Error(err))
-			}
-		}(name)
+		dropped++
+		consecutiveDrops++
+		log.Debug("warm-up could not schedule a species", logger.String("species", name))
+		if consecutiveDrops >= warmUpMaxConsecutiveDrops {
+			log.Info("stopping image cache warm-up: the prefetch queue is not draining",
+				logger.Int("scheduled", scheduled),
+				logger.Int("not_scheduled", len(species)-scheduled))
+			return
+		}
 	}
 
-	wg.Wait()
-	log.Info("image cache warm-up complete", logger.Int("species_count", len(species)))
+	log.Info("image cache warm-up scheduled",
+		logger.Int("scheduled", scheduled),
+		logger.Int("not_scheduled", dropped))
+}
+
+// warmUpSchedule registers one species for prefetching, backing off while the
+// queue is full. It reports whether the species was accepted.
+func warmUpSchedule(cache *imageprovider.BirdImageCache, name string) bool {
+	delay := warmUpRetryDelay
+	for attempt := 0; ; attempt++ {
+		if cache.PrefetchAsync(name) {
+			return true
+		}
+		if attempt >= warmUpMaxRetries {
+			return false
+		}
+		time.Sleep(delay)
+		delay *= 2
+	}
 }

--- a/internal/analysis/processor/actions_composite.go
+++ b/internal/analysis/processor/actions_composite.go
@@ -148,6 +148,9 @@ func getBirdImageFromCache(detectionCtx *DetectionContext, cache *imageprovider.
 			logger.String("species", commonName),
 			logger.String("scientific_name", scientificName),
 			logger.String("operation", "check_bird_image_cache"))
+		// Published like any other verdict, so the later actions of this
+		// detection do not each repeat the same warning.
+		detectionCtx.StoreBirdImage(&imageprovider.BirdImage{})
 		return imageprovider.BirdImage{}
 	}
 

--- a/internal/analysis/processor/actions_composite.go
+++ b/internal/analysis/processor/actions_composite.go
@@ -122,9 +122,10 @@ func buildTimeoutError(action Action, timeout time.Duration, step, total int) er
 		Build()
 }
 
-// getBirdImageFromCache retrieves already-cached bird image metadata for MqttAction
-// and SSEAction. Returns an empty BirdImage if the cache is nil or nothing is cached
-// yet, in which case a background fetch is scheduled for the next detection.
+// getBirdImageFromCache retrieves already-cached bird image metadata for the
+// detection-pipeline actions. Returns an empty BirdImage if the cache is nil or
+// nothing is cached yet, in which case a background fetch is scheduled for the
+// next detection.
 //
 // This deliberately does NOT fetch on the caller's goroutine. Both callers run inside
 // the CompositeAction that chains Database -> SSE -> MQTT under a 30s timeout, and a
@@ -133,7 +134,14 @@ func buildTimeoutError(action Action, timeout time.Duration, step, total int) er
 // actions_database.go; Sentry BIRDNET-GO-WD); the image lookup was the same hazard
 // left behind. Attribution metadata is best-effort here: the URL the consumers
 // publish is the media-proxy URL, which does not depend on this lookup succeeding.
-func getBirdImageFromCache(cache *imageprovider.BirdImageCache, scientificName, commonName, correlationID string) imageprovider.BirdImage {
+// It also resolves at most once per detection: the result is published to the
+// shared DetectionContext so the Database, SSE and MQTT actions of one
+// CompositeAction share a single lookup instead of each making their own.
+func getBirdImageFromCache(detectionCtx *DetectionContext, cache *imageprovider.BirdImageCache, scientificName, commonName, correlationID string) imageprovider.BirdImage {
+	if img, resolved := detectionCtx.LoadBirdImage(); resolved {
+		return img
+	}
+
 	if cache == nil {
 		GetLogger().Warn("BirdImageCache is nil, cannot fetch image",
 			logger.String("detection_id", correlationID),
@@ -144,13 +152,17 @@ func getBirdImageFromCache(cache *imageprovider.BirdImageCache, scientificName, 
 	}
 
 	birdImage, found, negative := cache.GetCached(scientificName)
-	if found {
-		return birdImage
+	if !found {
+		birdImage = imageprovider.BirdImage{}
+		if !negative {
+			cache.PrefetchAsync(scientificName)
+		}
 	}
-	if !negative {
-		cache.PrefetchAsync(scientificName)
-	}
-	return imageprovider.BirdImage{}
+
+	// Published even when empty: that is the verdict the later actions need, and
+	// it also keeps them from re-queueing the prefetch this call just scheduled.
+	detectionCtx.StoreBirdImage(&birdImage)
+	return birdImage
 }
 
 // Execute runs all actions sequentially, stopping on first error

--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -326,18 +326,15 @@ func (a *DatabaseAction) populateEventMetadata(detectionEvent events.DetectionEv
 	// unreachable from there for the typical home-LAN install, whether it is
 	// root-relative or an absolute one built from a private host. The provider URL is a
 	// public CDN address and is the only form that renders. Tracked separately.
-	if a.processor != nil && a.processor.BirdImageCache != nil {
-		birdImage, found, negative := a.processor.BirdImageCache.GetCached(a.Result.Species.ScientificName)
-		switch {
-		case found && birdImage.URL != "":
+	// Shared with the SSE and MQTT actions of the same CompositeAction through the
+	// detection context, so one detection costs one lookup rather than three. The
+	// helper also schedules the prefetch when nothing is cached yet, so that this
+	// notification carries no image but the next detection of the species can.
+	if a.processor != nil {
+		birdImage := getBirdImageFromCache(a.DetectionCtx, a.processor.BirdImageCache,
+			a.Result.Species.ScientificName, a.Result.Species.CommonName, a.CorrelationID)
+		if birdImage.URL != "" {
 			metadata["image_url"] = birdImage.URL
-		case !negative:
-			// Nothing cached yet, so this notification carries no image. Warm it for
-			// the next detection of this species instead of blocking on it here.
-			// Gated on !negative, matching the sibling call sites: a species every
-			// provider has already failed for would otherwise re-queue a prefetch on
-			// every single detection, and a noise class fires constantly.
-			a.processor.BirdImageCache.PrefetchAsync(a.Result.Species.ScientificName)
 		}
 	}
 }

--- a/internal/analysis/processor/actions_integrations.go
+++ b/internal/analysis/processor/actions_integrations.go
@@ -234,7 +234,7 @@ func (a *MqttAction) Execute(_ context.Context, data any) error {
 	}
 
 	// Get bird image of detected bird using the shared helper
-	birdImage := getBirdImageFromCache(a.BirdImageCache, a.Result.Species.ScientificName, a.Result.Species.CommonName, a.CorrelationID)
+	birdImage := getBirdImageFromCache(a.DetectionCtx, a.BirdImageCache, a.Result.Species.ScientificName, a.Result.Species.CommonName, a.CorrelationID)
 	// The URL stays the provider's upstream address. An MQTT subscriber is not a
 	// browser with an origin to resolve against, and the usual consumer (Home
 	// Assistant, a dashboard, an automation forwarding the image to a phone) may be
@@ -448,7 +448,7 @@ func (a *SSEAction) Execute(_ context.Context, data any) error {
 	// Get bird image of detected bird using the shared helper. NewSSEDetectionData
 	// substitutes the media-proxy URL, so only the attribution metadata is taken
 	// from here.
-	birdImage := getBirdImageFromCache(a.BirdImageCache, a.Result.Species.ScientificName, a.Result.Species.CommonName, a.CorrelationID)
+	birdImage := getBirdImageFromCache(a.DetectionCtx, a.BirdImageCache, a.Result.Species.ScientificName, a.Result.Species.CommonName, a.CorrelationID)
 
 	// Convert Result to Note for SSEBroadcaster (backward compatible SSE payload)
 	note := datastore.NoteFromResult(&a.Result)

--- a/internal/analysis/processor/actions_types.go
+++ b/internal/analysis/processor/actions_types.go
@@ -52,6 +52,39 @@ type DetectionContext struct {
 	// This flag is available for any late consumers that need to know whether the
 	// audio file exists on disk.
 	ClipSaved atomic.Bool
+
+	// birdImage holds the species image resolved once per detection, so the
+	// Database, SSE and MQTT actions of a single CompositeAction do not each
+	// repeat the lookup. Three independent lookups per detection meant three
+	// SQLite reads for a cold species, on a path whose whole purpose is to stay
+	// off slow work. A stored empty BirdImage is a resolved verdict of "nothing
+	// available", which is why it is a pointer: nil means nobody has looked yet.
+	birdImage atomic.Pointer[imageprovider.BirdImage]
+}
+
+// StoreBirdImage records the image resolution for this detection, including the
+// negative result. Callers must store even an empty image, since that is what
+// tells the later actions the lookup has already happened. The value is copied,
+// so the caller keeps ownership of what it passes.
+func (d *DetectionContext) StoreBirdImage(img *imageprovider.BirdImage) {
+	if d == nil || img == nil {
+		return
+	}
+	stored := *img
+	d.birdImage.Store(&stored)
+}
+
+// LoadBirdImage returns the image resolved earlier in this detection and whether
+// a resolution has happened at all.
+func (d *DetectionContext) LoadBirdImage() (img imageprovider.BirdImage, resolved bool) {
+	if d == nil {
+		return imageprovider.BirdImage{}, false
+	}
+	stored := d.birdImage.Load()
+	if stored == nil {
+		return imageprovider.BirdImage{}, false
+	}
+	return *stored, true
 }
 
 // Action is the base interface for all actions that can be executed.

--- a/internal/analysis/processor/image_proxy_boundary_test.go
+++ b/internal/analysis/processor/image_proxy_boundary_test.go
@@ -144,7 +144,7 @@ func TestGetBirdImageFromCache_DoesNotBlock(t *testing.T) {
 
 	done := make(chan imageprovider.BirdImage, 1)
 	go func() {
-		done <- getBirdImageFromCache(cache, "Turdus merula", "Eurasian Blackbird", "test-correlation")
+		done <- getBirdImageFromCache(&DetectionContext{}, cache, "Turdus merula", "Eurasian Blackbird", "test-correlation")
 	}()
 
 	select {
@@ -153,4 +153,43 @@ func TestGetBirdImageFromCache_DoesNotBlock(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("getBirdImageFromCache blocked on the image provider")
 	}
+}
+
+// TestGetBirdImageFromCache_ResolvesOncePerDetection pins the shared lookup.
+//
+// CompositeAction runs Database, then SSE, then MQTT for one detection, and each
+// of the three used to resolve the species image independently. The prefetch
+// deduplicates, so what multiplied was the database read: three per detection for
+// a cold species, on a path whose whole purpose is to stay off slow work.
+func TestGetBirdImageFromCache_ResolvesOncePerDetection(t *testing.T) {
+	t.Parallel()
+
+	detectionCtx := &DetectionContext{}
+	cache := newStallingCache(t)
+
+	// First action resolves. The cache is empty and the provider stalls, so the
+	// verdict is an empty image, which is exactly the case that must be shared:
+	// the later actions have to learn "already looked, nothing there".
+	first := getBirdImageFromCache(detectionCtx, cache, "Turdus merula", "Eurasian Blackbird", "test-correlation")
+	assert.Empty(t, first.URL)
+
+	stored, resolved := detectionCtx.LoadBirdImage()
+	require.True(t, resolved, "the verdict must be published for the later actions")
+	assert.Empty(t, stored.URL)
+
+	// A resolved image is handed straight back, without the cache being consulted:
+	// passing a nil cache would log and return empty if the lookup ran again.
+	detectionCtx.StoreBirdImage(&imageprovider.BirdImage{URL: "https://example.invalid/blackbird.jpg"})
+	second := getBirdImageFromCache(detectionCtx, nil, "Turdus merula", "Eurasian Blackbird", "test-correlation")
+	assert.Equal(t, "https://example.invalid/blackbird.jpg", second.URL,
+		"later actions in the same detection reuse the resolution instead of repeating it")
+}
+
+// TestGetBirdImageFromCache_WithoutADetectionContext keeps the helper usable
+// outside a CompositeAction, where there is nothing to share through.
+func TestGetBirdImageFromCache_WithoutADetectionContext(t *testing.T) {
+	t.Parallel()
+
+	img := getBirdImageFromCache(nil, newStallingCache(t), "Turdus merula", "Eurasian Blackbird", "test")
+	assert.Empty(t, img.URL)
 }

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -568,16 +568,41 @@ func matchesPathSegment(s, pattern string) bool {
 	}
 }
 
-// detectCategory automatically detects error category based on error message and component
-func detectCategory(err error, component string) ErrorCategory {
-	// First check if the error implements CategorizedError interface
-	if catErr, ok := stderrors.AsType[CategorizedError](err); ok {
-		return catErr.ErrorCategory()
+// CategoryOf returns the category an error already carries, or the empty
+// category when it carries none.
+//
+// This accessor exists because "return the category this error already carries"
+// kept being rewritten: the package exported IsCategory, IsNetwork and IsNotFound
+// but no way to read the category itself, so callers that needed to preserve a
+// cause's category across a wrap open-coded it. Preserving it matters because
+// telemetry suppression and category-based matching both key on it: re-tagging a
+// network throttle as an image-fetch failure turns a suppressed transient into a
+// per-species Sentry event.
+func CategoryOf(err error) ErrorCategory {
+	if err == nil {
+		return ""
 	}
 
-	// Check if it's already an EnhancedError with a category
+	// The interface comes first: a cause can carry a category without being an
+	// *EnhancedError.
+	if catErr, ok := stderrors.AsType[CategorizedError](err); ok {
+		if category := catErr.ErrorCategory(); category != "" {
+			return category
+		}
+	}
+
 	if enhErr, ok := stderrors.AsType[*EnhancedError](err); ok && enhErr.Category != "" {
 		return enhErr.Category
+	}
+
+	return ""
+}
+
+// detectCategory automatically detects error category based on error message and component
+func detectCategory(err error, component string) ErrorCategory {
+	// An error that already carries a category keeps it.
+	if category := CategoryOf(err); category != "" {
+		return category
 	}
 
 	// Fall back to string-based heuristics

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -572,9 +572,11 @@ func matchesPathSegment(s, pattern string) bool {
 // category when it carries none.
 //
 // This accessor exists because "return the category this error already carries"
-// kept being rewritten: the package exported IsCategory, IsNetwork and IsNotFound
-// but no way to read the category itself, so callers that needed to preserve a
-// cause's category across a wrap open-coded it. Preserving it matters because
+// kept being rewritten. (*EnhancedError).GetCategory reads one error's own
+// field and returns a string; this is package-level, unwraps the chain, honours
+// the CategorizedError interface, and returns the typed ErrorCategory, which is
+// what a caller preserving a cause's category across a wrap actually needs.
+// Preserving it matters because
 // telemetry suppression and category-based matching both key on it: re-tagging a
 // network throttle as an image-fetch failure turns a suppressed transient into a
 // per-species Sentry event.

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/tphakala/birdnet-go/internal/branding"
 )
 
 const (
@@ -34,9 +36,24 @@ const (
 	defaultDialTimeout           = 30 * time.Second
 	defaultDialKeepAlive         = 30 * time.Second
 
-	// Default User-Agent
-	defaultUserAgent = "BirdNET-Go"
+	// userAgentName is the leading token of the default User-Agent.
+	//
+	// Do not "correct" this to the hyphenated project name. Wikimedia's edge
+	// refuses any User-Agent whose leading token is "birdnet-go",
+	// case-insensitively, on both upload.wikimedia.org and api.php, even when
+	// the rest of the header is fully policy-compliant with a version and a
+	// contact URL. Nothing routes Wikimedia traffic through this client today,
+	// so the hyphenated form was a latent trap rather than an active bug: any
+	// future code that did would get a hard 403 with a confusing symptom.
+	userAgentName = "BirdNETGo"
 )
+
+// defaultUserAgent returns the User-Agent used when a Config does not set one.
+// The contact URL follows the same robot-policy convention as the image
+// provider's, and resolves to a fork's own repository when rebranded.
+func defaultUserAgent() string {
+	return userAgentName + " (" + branding.RepoURL() + ")"
+}
 
 // Client is a production-grade HTTP client with context management and timeouts.
 // It wraps the standard http.Client with additional features for reliability.
@@ -97,7 +114,7 @@ type Config struct {
 func DefaultConfig() Config {
 	return Config{
 		DefaultTimeout:        DefaultTimeout,
-		UserAgent:             defaultUserAgent,
+		UserAgent:             defaultUserAgent(),
 		MaxIdleConns:          defaultMaxIdleConns,
 		MaxIdleConnsPerHost:   defaultMaxIdleConnsPerHost,
 		IdleConnTimeout:       defaultIdleConnTimeout,
@@ -123,7 +140,7 @@ func New(cfg *Config) *Client {
 			c.DefaultTimeout = DefaultTimeout
 		}
 		if c.UserAgent == "" {
-			c.UserAgent = defaultUserAgent
+			c.UserAgent = defaultUserAgent()
 		}
 		if c.MaxIdleConns == 0 {
 			c.MaxIdleConns = defaultMaxIdleConns

--- a/internal/httpclient/client_test.go
+++ b/internal/httpclient/client_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -21,7 +22,9 @@ func TestNew(t *testing.T) {
 
 		require.NotNil(t, client, "expected non-nil client")
 		assert.Equal(t, DefaultTimeout, client.defaultTimeout, "expected default timeout")
-		assert.Equal(t, defaultUserAgent, client.userAgent, "expected default user agent")
+		assert.Equal(t, defaultUserAgent(), client.userAgent, "expected default user agent")
+		assert.NotContains(t, strings.ToLower(client.userAgent), "birdnet-go/",
+			"the leading token must not be the hyphenated project name: Wikimedia's edge refuses it")
 	})
 
 	t.Run("custom config", func(t *testing.T) {

--- a/internal/httpclient/client_test.go
+++ b/internal/httpclient/client_test.go
@@ -23,8 +23,15 @@ func TestNew(t *testing.T) {
 		require.NotNil(t, client, "expected non-nil client")
 		assert.Equal(t, DefaultTimeout, client.defaultTimeout, "expected default timeout")
 		assert.Equal(t, defaultUserAgent(), client.userAgent, "expected default user agent")
-		assert.NotContains(t, strings.ToLower(client.userAgent), "birdnet-go/",
-			"the leading token must not be the hyphenated project name: Wikimedia's edge refuses it")
+		// The rule is about the LEADING TOKEN, so assert on that and not on a
+		// substring: searching the whole header for "birdnet-go/" passes for the
+		// literal "BirdNET-Go" this guards against, and fails spuriously when the
+		// configured repo URL happens to end in "birdnet-go/".
+		leadingToken, _, _ := strings.Cut(client.userAgent, " ")
+		assert.Equal(t, userAgentName, leadingToken,
+			"Wikimedia's edge refuses any User-Agent whose leading token is the hyphenated project name")
+		assert.NotContains(t, strings.ToLower(leadingToken), "-",
+			"the leading token must not be hyphenated")
 	})
 
 	t.Run("custom config", func(t *testing.T) {

--- a/internal/imageprovider/avicommons.go
+++ b/internal/imageprovider/avicommons.go
@@ -69,8 +69,11 @@ var (
 	// answers ".../by/4.0/de/" with a 301 to the German TRANSLATION of the
 	// international deed rather than a 404; it is the display name that would be
 	// false. A port on an unported version is therefore dropped.
+	// 2.1 is absent for the same reason it is absent above: it is checked only
+	// after aviCommonsKnownVersions has already accepted the version, so an
+	// entry here would be unreachable.
 	aviCommonsPortedVersions = map[string]bool{
-		"1.0": true, "2.0": true, "2.1": true, "2.5": true, "3.0": true,
+		"1.0": true, "2.0": true, "2.5": true, "3.0": true,
 	}
 
 	// aviCommonsLicenseFamilies maps a normalized license family to its display

--- a/internal/imageprovider/avicommons.go
+++ b/internal/imageprovider/avicommons.go
@@ -52,11 +52,22 @@ var (
 	// "CC BY-NC 3.0-de".
 	aviCommonsPortToken = regexp.MustCompile(`^[a-z]{2,3}$`)
 
-	// aviCommonsKnownVersions are the versions Creative Commons actually
+	// aviCommonsKnownVersions are the unported versions Creative Commons actually
 	// published. A license string carrying anything else names no real license,
 	// so its version is dropped rather than turned into a deed URL that 404s.
+	//
+	// 2.1 is absent deliberately: it exists only as jurisdiction ports (AU, JP,
+	// ES, CA), so an unported 2.1 deed URL does not resolve.
 	aviCommonsKnownVersions = map[string]bool{
-		"1.0": true, "2.0": true, "2.1": true, "2.5": true, "3.0": true, "4.0": true,
+		"1.0": true, "2.0": true, "2.5": true, "3.0": true, "4.0": true,
+	}
+
+	// aviCommonsPortedVersions are the versions Creative Commons ported to
+	// jurisdictions. Porting ended with 3.0: the 4.0 suite was written to be
+	// international and was never ported, so ".../by/4.0/de/" is a 404. A port
+	// on any other version is therefore not a real license and is dropped.
+	aviCommonsPortedVersions = map[string]bool{
+		"1.0": true, "2.0": true, "2.1": true, "2.5": true, "3.0": true,
 	}
 
 	// aviCommonsLicenseFamilies maps a normalized license family to its display
@@ -252,10 +263,11 @@ func (p *AviCommonsProvider) Fetch(scientificName string) (BirdImage, error) {
 //	"CC0 2.0"         -> "cc0",      "2.0", ""
 //
 // The version used to be stripped and thrown away, which is what made every
-// entry render as 4.0 with a link to legal text that does not govern it. The
-// ported codes defeated the strip entirely (the trailing "-de" moved the
-// version off the end of the string), so they fell through to the unknown
-// branch and rendered the raw code with no license URL at all.
+// entry whose code ended in a version render as 4.0, with a link to legal text
+// that does not govern it. The 22 ported codes did not even get that far: the
+// trailing "-de" moved the version off the end of the string and defeated the
+// strip, so they fell through to the unknown branch and rendered the raw code
+// with no license URL at all.
 func parseAviCommonsLicense(code string) (family, version, port string) {
 	// Fold whitespace to hyphens so "CC BY-NC 3.0-de" and "cc-by-nc-3.0-de"
 	// tokenize identically.
@@ -324,7 +336,7 @@ func mapAviCommonsLicense(code string) (name, url string) {
 
 	name = licenseFamily.display + " " + version
 	url = "https://creativecommons.org/licenses/" + licenseFamily.slug + "/" + version + "/"
-	if port != "" {
+	if port != "" && aviCommonsPortedVersions[version] {
 		name += " " + strings.ToUpper(port)
 		url += port + "/"
 	}

--- a/internal/imageprovider/avicommons.go
+++ b/internal/imageprovider/avicommons.go
@@ -64,8 +64,11 @@ var (
 
 	// aviCommonsPortedVersions are the versions Creative Commons ported to
 	// jurisdictions. Porting ended with 3.0: the 4.0 suite was written to be
-	// international and was never ported, so ".../by/4.0/de/" is a 404. A port
-	// on any other version is therefore not a real license and is dropped.
+	// international and was never ported, so "CC BY 4.0 DE" names a license that
+	// does not exist. The URL is not the tell, because creativecommons.org
+	// answers ".../by/4.0/de/" with a 301 to the German TRANSLATION of the
+	// international deed rather than a 404; it is the display name that would be
+	// false. A port on an unported version is therefore dropped.
 	aviCommonsPortedVersions = map[string]bool{
 		"1.0": true, "2.0": true, "2.1": true, "2.5": true, "3.0": true,
 	}

--- a/internal/imageprovider/avicommons.go
+++ b/internal/imageprovider/avicommons.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -46,9 +45,30 @@ var (
 	// loggedUnknownLicenses tracks unknown license codes to avoid repeated warnings.
 	loggedUnknownLicenses sync.Map
 
-	// aviCommonsVersionSuffix matches a trailing version number like " 3.0" or " 4"
-	// on license display names (e.g. "CC BY 3.0"). Compiled once at package load.
-	aviCommonsVersionSuffix = regexp.MustCompile(`\s+\d+(\.\d+)?$`)
+	// aviCommonsVersionToken matches a Creative Commons version number.
+	aviCommonsVersionToken = regexp.MustCompile(`^\d+(\.\d+)?$`)
+
+	// aviCommonsPortToken matches a jurisdiction port suffix, the "de" of
+	// "CC BY-NC 3.0-de".
+	aviCommonsPortToken = regexp.MustCompile(`^[a-z]{2,3}$`)
+
+	// aviCommonsKnownVersions are the versions Creative Commons actually
+	// published. A license string carrying anything else names no real license,
+	// so its version is dropped rather than turned into a deed URL that 404s.
+	aviCommonsKnownVersions = map[string]bool{
+		"1.0": true, "2.0": true, "2.1": true, "2.5": true, "3.0": true, "4.0": true,
+	}
+
+	// aviCommonsLicenseFamilies maps a normalized license family to its display
+	// prefix and the path segment of its deed URL.
+	aviCommonsLicenseFamilies = map[string]struct{ display, slug string }{
+		"cc-by":       {"CC BY", "by"},
+		"cc-by-sa":    {"CC BY-SA", "by-sa"},
+		"cc-by-nd":    {"CC BY-ND", "by-nd"},
+		"cc-by-nc":    {"CC BY-NC", "by-nc"},
+		"cc-by-nc-sa": {"CC BY-NC-SA", "by-nc-sa"},
+		"cc-by-nc-nd": {"CC BY-NC-ND", "by-nc-nd"},
+	}
 )
 
 // NewAviCommonsProvider creates a new provider instance using data from the provided filesystem.
@@ -220,56 +240,65 @@ func (p *AviCommonsProvider) Fetch(scientificName string) (BirdImage, error) {
 	}, nil
 }
 
-// normalizeAviCommonsLicense converts raw license strings from the Avicommons
-// dataset into canonical slug form so the lookup switch works for both legacy
-// slug codes ("cc-by-nc") and display-name variants like "CC BY 3.0" or
-// "CC BY-NC-SA 4.0" observed in production data.
+// parseAviCommonsLicense splits a raw Avicommons license string into its
+// license family, version and jurisdiction port.
 //
-// The normalization pipeline is:
-//  1. Trim surrounding whitespace.
-//  2. Lowercase the whole string for case-insensitive matching.
-//  3. Strip any trailing version suffix (e.g. " 3.0", " 4").
-//  4. Replace remaining inner whitespace with hyphens.
+// The dataset mixes versionless slugs with display names, and 22 entries use
+// jurisdiction-ported codes. Examples:
 //
-// Examples:
+//	"cc-by-nc"        -> "cc-by-nc", "",    ""
+//	"CC BY 3.0"       -> "cc-by",    "3.0", ""
+//	"CC BY-NC 3.0-de" -> "cc-by-nc", "3.0", "de"
+//	"CC0 2.0"         -> "cc0",      "2.0", ""
 //
-//	"CC BY 3.0"       -> "cc-by"
-//	"CC BY-NC-SA 4.0" -> "cc-by-nc-sa"
-//	"CC0 3.0"         -> "cc0"
-//	"cc-by-nc"        -> "cc-by-nc" (unchanged)
-func normalizeAviCommonsLicense(code string) string {
-	normalized := strings.ToLower(strings.TrimSpace(code))
-	normalized = aviCommonsVersionSuffix.ReplaceAllString(normalized, "")
-	normalized = strings.TrimSpace(normalized)
-	// Collapse any internal whitespace runs to a single hyphen so
-	// "cc by  nc" becomes "cc-by-nc" rather than "cc-by--nc".
-	normalized = strings.Join(strings.Fields(normalized), "-")
-	return normalized
+// The version used to be stripped and thrown away, which is what made every
+// entry render as 4.0 with a link to legal text that does not govern it. The
+// ported codes defeated the strip entirely (the trailing "-de" moved the
+// version off the end of the string), so they fell through to the unknown
+// branch and rendered the raw code with no license URL at all.
+func parseAviCommonsLicense(code string) (family, version, port string) {
+	// Fold whitespace to hyphens so "CC BY-NC 3.0-de" and "cc-by-nc-3.0-de"
+	// tokenize identically.
+	tokens := strings.Split(strings.Join(strings.Fields(strings.ToLower(code)), "-"), "-")
+	for len(tokens) > 0 && tokens[len(tokens)-1] == "" {
+		tokens = tokens[:len(tokens)-1]
+	}
+	if len(tokens) == 0 {
+		return "", "", ""
+	}
+
+	// A port is only a port when a version precedes it. Without that guard the
+	// "nd" of "cc-by-nd" would be read as a jurisdiction.
+	last := len(tokens) - 1
+	if last >= 1 && aviCommonsPortToken.MatchString(tokens[last]) && aviCommonsVersionToken.MatchString(tokens[last-1]) {
+		port = tokens[last]
+		tokens = tokens[:last]
+		last--
+	}
+	if last >= 1 && aviCommonsVersionToken.MatchString(tokens[last]) {
+		version = tokens[last]
+		tokens = tokens[:last]
+	}
+
+	return strings.Join(tokens, "-"), version, port
 }
 
 // mapAviCommonsLicense converts Avicommons license codes to display names and
-// canonical URLs. Both slug-style codes (e.g. "cc-by-nc") and display-name
-// variants (e.g. "CC BY-NC 4.0") are accepted — see normalizeAviCommonsLicense.
-// Unknown codes return the raw input as the name with an empty URL and log a
-// one-shot warning so the Sentry noise in bug reports stays bounded.
+// deed URLs, preserving the version and jurisdiction the dataset actually
+// carries. Unknown families return the raw input as the name with an empty URL
+// and log a one-shot warning so the Sentry noise in bug reports stays bounded.
 func mapAviCommonsLicense(code string) (name, url string) {
-	// No logging needed here as it's a pure function
-	switch normalizeAviCommonsLicense(code) {
-	case "cc-by":
-		return "CC BY 4.0", "https://creativecommons.org/licenses/by/4.0/"
-	case "cc-by-sa":
-		return "CC BY-SA 4.0", "https://creativecommons.org/licenses/by-sa/4.0/"
-	case "cc-by-nd":
-		return "CC BY-ND 4.0", "https://creativecommons.org/licenses/by-nd/4.0/"
-	case "cc-by-nc":
-		return "CC BY-NC 4.0", "https://creativecommons.org/licenses/by-nc/4.0/"
-	case "cc-by-nc-sa":
-		return "CC BY-NC-SA 4.0", "https://creativecommons.org/licenses/by-nc-sa/4.0/"
-	case "cc-by-nc-nd":
-		return "CC BY-NC-ND 4.0", "https://creativecommons.org/licenses/by-nc-nd/4.0/"
-	case "cc0":
+	family, version, port := parseAviCommonsLicense(code)
+
+	// CC0 was published once, as 1.0, and was never ported to a jurisdiction.
+	// The versions and ports some entries carry ("CC0 2.5-au") therefore name no
+	// real license, and the 1.0 deed is the only truthful answer for all of them.
+	if family == "cc0" {
 		return "CC0 1.0 Universal", "https://creativecommons.org/publicdomain/zero/1.0/"
-	default:
+	}
+
+	licenseFamily, known := aviCommonsLicenseFamilies[family]
+	if !known {
 		// Log only once per unknown code
 		if _, loaded := loggedUnknownLicenses.LoadOrStore(code, true); !loaded {
 			GetLogger().Warn("Unknown Avicommons license code encountered",
@@ -278,14 +307,35 @@ func mapAviCommonsLicense(code string) (name, url string) {
 		}
 		return code, ""
 	}
+
+	if !aviCommonsKnownVersions[version] {
+		// The family is recognizable but the version is not one Creative Commons
+		// published, so it is dropped rather than turned into a deed URL that
+		// does not resolve. The version-neutral license page is still correct.
+		if version != "" {
+			if _, loaded := loggedUnknownLicenses.LoadOrStore(code, true); !loaded {
+				GetLogger().Warn("Unrecognized Creative Commons version in Avicommons license code",
+					logger.String("license_code", code),
+					logger.String("action", "omitting_version"))
+			}
+		}
+		return licenseFamily.display, "https://creativecommons.org/licenses/" + licenseFamily.slug + "/"
+	}
+
+	name = licenseFamily.display + " " + version
+	url = "https://creativecommons.org/licenses/" + licenseFamily.slug + "/" + version + "/"
+	if port != "" {
+		name += " " + strings.ToUpper(port)
+		url += port + "/"
+	}
+	return name, url
 }
 
 // CreateAviCommonsCache creates a new BirdImageCache with the AviCommons image provider.
 func CreateAviCommonsCache(dataFs fs.FS, metrics *observability.Metrics, store datastore.Interface) (*BirdImageCache, error) {
 	log := GetLogger().With(logger.String("provider", aviCommonsProviderName))
 	log.Info("Creating AviCommons cache")
-	settings := conf.Setting()
-	debug := settings.Realtime.Dashboard.Thumbnails.Debug
+	debug := thumbnailSettings().Debug
 
 	// Create the AviCommons provider using the embedded file system
 	provider, err := NewAviCommonsProvider(dataFs, debug)

--- a/internal/imageprovider/avicommons_test.go
+++ b/internal/imageprovider/avicommons_test.go
@@ -136,12 +136,16 @@ func TestParseAviCommonsLicense(t *testing.T) {
 // so they fell through to the unknown branch and rendered the raw code with no
 // license URL at all, plus one Warn per unique code straight into Sentry.
 func TestMapAviCommonsLicense_CoversTheShippedDataset(t *testing.T) {
-	t.Parallel()
+	// No t.Parallel(): mapAviCommonsLicense mutates the package-global
+	// loggedUnknownLicenses, the same reason the sibling test above gives.
 
-	// Read from the repository rather than through internal/api's embed: that
-	// package imports this one, so an import cycle rules the embed out here.
-	data, err := os.ReadFile(filepath.Join("..", "..", "data", "latest.json"))
-	require.NoError(t, err, "the shipped Avicommons dataset must be readable")
+	// data/latest.json inside THIS package is the file main.go embeds
+	// (//go:embed internal/imageprovider/data/latest.json). The repo-root copy
+	// is a different, larger file that nothing ships, so asserting against it
+	// would guard data the binary never sees. Read directly rather than through
+	// internal/api's embed, which imports this package.
+	data, err := os.ReadFile(filepath.Join("data", "latest.json"))
+	require.NoError(t, err, "the embedded Avicommons dataset must be readable")
 
 	var entries []struct {
 		License string `json:"license"`

--- a/internal/imageprovider/avicommons_test.go
+++ b/internal/imageprovider/avicommons_test.go
@@ -2,15 +2,21 @@
 package imageprovider
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-// TestMapAviCommonsLicense covers both the historical slug-style license
-// codes and the display-name variants observed in production data. The
-// normalization helper should fold things like "CC BY 3.0" onto the same
-// canonical "cc-by" case so the switch returns proper names and URLs.
+// TestMapAviCommonsLicense covers the historical slug-style license codes, the
+// display-name variants and the jurisdiction-ported codes observed in
+// production data. The version a code carries must survive into both the
+// display name and the deed URL: every non-4.0 entry used to render as 4.0
+// with a link to legal text that does not govern it, and CC 2.0/3.0 differ
+// from 4.0 on attribution, ShareAlike compatibility and the cure period.
 //
 // Note: this test intentionally does NOT call t.Parallel() because
 // mapAviCommonsLicense mutates the package-global loggedUnknownLicenses
@@ -19,18 +25,6 @@ import (
 // sequentially.
 func TestMapAviCommonsLicense(t *testing.T) {
 	const (
-		ccBYName        = "CC BY 4.0"
-		ccBYURL         = "https://creativecommons.org/licenses/by/4.0/"
-		ccBYSAName      = "CC BY-SA 4.0"
-		ccBYSAURL       = "https://creativecommons.org/licenses/by-sa/4.0/"
-		ccBYNDName      = "CC BY-ND 4.0"
-		ccBYNDURL       = "https://creativecommons.org/licenses/by-nd/4.0/"
-		ccBYNCName      = "CC BY-NC 4.0"
-		ccBYNCURL       = "https://creativecommons.org/licenses/by-nc/4.0/"
-		ccBYNCSAName    = "CC BY-NC-SA 4.0"
-		ccBYNCSAURL     = "https://creativecommons.org/licenses/by-nc-sa/4.0/"
-		ccBYNCNDName    = "CC BY-NC-ND 4.0"
-		ccBYNCNDURL     = "https://creativecommons.org/licenses/by-nc-nd/4.0/"
 		cc0Name         = "CC0 1.0 Universal"
 		cc0URL          = "https://creativecommons.org/publicdomain/zero/1.0/"
 		unknownLicense  = "completely-bogus"
@@ -43,28 +37,41 @@ func TestMapAviCommonsLicense(t *testing.T) {
 		wantName string
 		wantURL  string
 	}{
-		// Legacy slug-style codes — must continue to work unchanged.
-		{name: "slug cc-by", input: "cc-by", wantName: ccBYName, wantURL: ccBYURL},
-		{name: "slug cc-by-sa", input: "cc-by-sa", wantName: ccBYSAName, wantURL: ccBYSAURL},
-		{name: "slug cc-by-nd", input: "cc-by-nd", wantName: ccBYNDName, wantURL: ccBYNDURL},
-		{name: "slug cc-by-nc", input: "cc-by-nc", wantName: ccBYNCName, wantURL: ccBYNCURL},
-		{name: "slug cc-by-nc-sa", input: "cc-by-nc-sa", wantName: ccBYNCSAName, wantURL: ccBYNCSAURL},
-		{name: "slug cc-by-nc-nd", input: "cc-by-nc-nd", wantName: ccBYNCNDName, wantURL: ccBYNCNDURL},
+		// Legacy slug-style codes carry no version, so none is asserted. The
+		// version-neutral license page is the honest link for them.
+		{name: "slug cc-by", input: "cc-by", wantName: "CC BY", wantURL: "https://creativecommons.org/licenses/by/"},
+		{name: "slug cc-by-sa", input: "cc-by-sa", wantName: "CC BY-SA", wantURL: "https://creativecommons.org/licenses/by-sa/"},
+		{name: "slug cc-by-nd", input: "cc-by-nd", wantName: "CC BY-ND", wantURL: "https://creativecommons.org/licenses/by-nd/"},
+		{name: "slug cc-by-nc", input: "cc-by-nc", wantName: "CC BY-NC", wantURL: "https://creativecommons.org/licenses/by-nc/"},
+		{name: "slug cc-by-nc-sa", input: "cc-by-nc-sa", wantName: "CC BY-NC-SA", wantURL: "https://creativecommons.org/licenses/by-nc-sa/"},
+		{name: "slug cc-by-nc-nd", input: "cc-by-nc-nd", wantName: "CC BY-NC-ND", wantURL: "https://creativecommons.org/licenses/by-nc-nd/"},
 		{name: "slug cc0", input: "cc0", wantName: cc0Name, wantURL: cc0URL},
 
-		// Production display-name variants that used to fall through to the
-		// WARN-logging default branch (Forgejo #387).
-		{name: "display CC BY 3.0", input: "CC BY 3.0", wantName: ccBYName, wantURL: ccBYURL},
-		{name: "display CC BY-NC 2.0", input: "CC BY-NC 2.0", wantName: ccBYNCName, wantURL: ccBYNCURL},
-		{name: "display CC BY-NC 3.0", input: "CC BY-NC 3.0", wantName: ccBYNCName, wantURL: ccBYNCURL},
-		{name: "display CC BY-NC-SA 4.0", input: "CC BY-NC-SA 4.0", wantName: ccBYNCSAName, wantURL: ccBYNCSAURL},
-		{name: "display CC BY-SA 4.0", input: "CC BY-SA 4.0", wantName: ccBYSAName, wantURL: ccBYSAURL},
+		// Production display-name variants. The version must be preserved: these
+		// used to be reported as 4.0 whatever they said.
+		{name: "display CC BY 3.0", input: "CC BY 3.0", wantName: "CC BY 3.0", wantURL: "https://creativecommons.org/licenses/by/3.0/"},
+		{name: "display CC BY-NC 2.0", input: "CC BY-NC 2.0", wantName: "CC BY-NC 2.0", wantURL: "https://creativecommons.org/licenses/by-nc/2.0/"},
+		{name: "display CC BY-NC 2.5", input: "CC BY-NC 2.5", wantName: "CC BY-NC 2.5", wantURL: "https://creativecommons.org/licenses/by-nc/2.5/"},
+		{name: "display CC BY-NC-SA 4.0", input: "CC BY-NC-SA 4.0", wantName: "CC BY-NC-SA 4.0", wantURL: "https://creativecommons.org/licenses/by-nc-sa/4.0/"},
+		{name: "display CC BY-SA 4.0", input: "CC BY-SA 4.0", wantName: "CC BY-SA 4.0", wantURL: "https://creativecommons.org/licenses/by-sa/4.0/"},
+		{name: "display CC BY-NC 1.0", input: "CC BY-NC 1.0", wantName: "CC BY-NC 1.0", wantURL: "https://creativecommons.org/licenses/by-nc/1.0/"},
+
+		// Jurisdiction-ported codes. These used to defeat the version strip
+		// entirely and render the raw code with no license URL at all.
+		{name: "ported CC BY-NC 3.0-de", input: "CC BY-NC 3.0-de", wantName: "CC BY-NC 3.0 DE", wantURL: "https://creativecommons.org/licenses/by-nc/3.0/de/"},
+		{name: "ported CC BY 3.0-us", input: "CC BY 3.0-us", wantName: "CC BY 3.0 US", wantURL: "https://creativecommons.org/licenses/by/3.0/us/"},
+		{name: "ported CC BY-SA 3.0-nz", input: "CC BY-SA 3.0-nz", wantName: "CC BY-SA 3.0 NZ", wantURL: "https://creativecommons.org/licenses/by-sa/3.0/nz/"},
+		{name: "ported CC BY-NC 2.5-br", input: "CC BY-NC 2.5-br", wantName: "CC BY-NC 2.5 BR", wantURL: "https://creativecommons.org/licenses/by-nc/2.5/br/"},
+
+		// CC0 exists only as 1.0 and was never ported, so the versions and ports
+		// the dataset carries for it name no real license.
 		{name: "display CC0 3.0", input: "CC0 3.0", wantName: cc0Name, wantURL: cc0URL},
+		{name: "ported CC0 2.5-au", input: "CC0 2.5-au", wantName: cc0Name, wantURL: cc0URL},
 
 		// Edge cases.
-		{name: "whitespace around CC BY", input: "  CC BY  ", wantName: ccBYName, wantURL: ccBYURL},
-		{name: "high version cc-by-99.99", input: "cc-by 99.99", wantName: ccBYName, wantURL: ccBYURL},
-		{name: "mixed case CC-BY-NC", input: "CC-BY-NC", wantName: ccBYNCName, wantURL: ccBYNCURL},
+		{name: "whitespace around CC BY", input: "  CC BY  ", wantName: "CC BY", wantURL: "https://creativecommons.org/licenses/by/"},
+		{name: "unpublished version drops the version", input: "cc-by 99.99", wantName: "CC BY", wantURL: "https://creativecommons.org/licenses/by/"},
+		{name: "mixed case CC-BY-NC", input: "CC-BY-NC", wantName: "CC BY-NC", wantURL: "https://creativecommons.org/licenses/by-nc/"},
 
 		// Unknowns: raw code returned as name, URL empty. The one-shot WARN
 		// logging path is exercised implicitly; we just assert the return.
@@ -82,31 +89,77 @@ func TestMapAviCommonsLicense(t *testing.T) {
 	}
 }
 
-// TestNormalizeAviCommonsLicense pins the exact output of the normalization
-// helper so future changes don't silently shift the canonical form.
-func TestNormalizeAviCommonsLicense(t *testing.T) {
+// TestParseAviCommonsLicense pins how a raw license string is split, in
+// particular that a jurisdiction port is only recognized behind a version so
+// the "nd" of "cc-by-nd" is not mistaken for one.
+func TestParseAviCommonsLicense(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name  string
-		input string
-		want  string
+		name        string
+		input       string
+		wantFamily  string
+		wantVersion string
+		wantPort    string
 	}{
-		{name: "already normalized", input: "cc-by-nc", want: "cc-by-nc"},
-		{name: "display variant", input: "CC BY 3.0", want: "cc-by"},
-		{name: "display compound", input: "CC BY-NC-SA 4.0", want: "cc-by-nc-sa"},
-		{name: "zero with version", input: "CC0 3.0", want: "cc0"},
-		{name: "extra whitespace", input: "  CC BY  ", want: "cc-by"},
-		{name: "no version", input: "CC BY", want: "cc-by"},
-		{name: "spaces collapsed", input: "cc  by  nc", want: "cc-by-nc"},
-		{name: "unknown preserved", input: "completely-bogus", want: "completely-bogus"},
+		{name: "already normalized", input: "cc-by-nc", wantFamily: "cc-by-nc"},
+		{name: "display variant", input: "CC BY 3.0", wantFamily: "cc-by", wantVersion: "3.0"},
+		{name: "display compound", input: "CC BY-NC-SA 4.0", wantFamily: "cc-by-nc-sa", wantVersion: "4.0"},
+		{name: "zero with version", input: "CC0 3.0", wantFamily: "cc0", wantVersion: "3.0"},
+		{name: "extra whitespace", input: "  CC BY  ", wantFamily: "cc-by"},
+		{name: "no version", input: "CC BY", wantFamily: "cc-by"},
+		{name: "spaces collapsed", input: "cc  by  nc", wantFamily: "cc-by-nc"},
+		{name: "no-derivatives is not a jurisdiction", input: "cc-by-nd", wantFamily: "cc-by-nd"},
+		{name: "ported", input: "CC BY-NC 3.0-de", wantFamily: "cc-by-nc", wantVersion: "3.0", wantPort: "de"},
+		{name: "ported no-derivatives", input: "CC BY-NC-ND 3.0-de", wantFamily: "cc-by-nc-nd", wantVersion: "3.0", wantPort: "de"},
+		{name: "unknown preserved", input: "completely-bogus", wantFamily: "completely-bogus"},
+		{name: "empty", input: "", wantFamily: ""},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			assert.Equal(t, tt.want, normalizeAviCommonsLicense(tt.input))
+			family, version, port := parseAviCommonsLicense(tt.input)
+			assert.Equal(t, tt.wantFamily, family, "family mismatch for input %q", tt.input)
+			assert.Equal(t, tt.wantVersion, version, "version mismatch for input %q", tt.input)
+			assert.Equal(t, tt.wantPort, port, "port mismatch for input %q", tt.input)
 		})
 	}
+}
+
+// TestMapAviCommonsLicense_CoversTheShippedDataset walks every distinct license
+// string in the embedded dataset and requires each to produce a deed URL.
+//
+// This is the assertion the jurisdiction-ported codes needed: 22 entries use
+// codes like "CC BY-NC 3.0-de", whose trailing "-de" defeated the version strip,
+// so they fell through to the unknown branch and rendered the raw code with no
+// license URL at all, plus one Warn per unique code straight into Sentry.
+func TestMapAviCommonsLicense_CoversTheShippedDataset(t *testing.T) {
+	t.Parallel()
+
+	// Read from the repository rather than through internal/api's embed: that
+	// package imports this one, so an import cycle rules the embed out here.
+	data, err := os.ReadFile(filepath.Join("..", "..", "data", "latest.json"))
+	require.NoError(t, err, "the shipped Avicommons dataset must be readable")
+
+	var entries []struct {
+		License string `json:"license"`
+	}
+	require.NoError(t, json.Unmarshal(data, &entries))
+	require.NotEmpty(t, entries)
+
+	seen := make(map[string]bool)
+	for i := range entries {
+		code := entries[i].License
+		if code == "" || seen[code] {
+			continue
+		}
+		seen[code] = true
+
+		name, url := mapAviCommonsLicense(code)
+		assert.NotEmpty(t, name, "license %q produced no display name", code)
+		assert.NotEmpty(t, url, "license %q produced no deed URL", code)
+	}
+	require.NotEmpty(t, seen, "the dataset should carry license codes")
 }

--- a/internal/imageprovider/cache_pressure_test.go
+++ b/internal/imageprovider/cache_pressure_test.go
@@ -327,3 +327,29 @@ func TestGetCachedLocal_StaleMemoryEntryIsRefreshed(t *testing.T) {
 		t.Fatal("no refresh was scheduled for the stale memory entry, so nothing can ever re-derive it")
 	}
 }
+
+// TestScheduleRefresh_IsBounded pins the cap on background refreshes.
+//
+// Refreshes do not pass through the prefetch semaphore, so without a bound a
+// dashboard rendering many stale species spawns one goroutine per species, each
+// parked on the provider's global rate limiter.
+func TestScheduleRefresh_IsBounded(t *testing.T) {
+	t.Parallel()
+
+	provider := newBlockingProvider(t)
+	cache := InitCache(wikiProviderName, provider, nil, nil)
+	t.Cleanup(func() { assert.NoError(t, cache.Close()) })
+
+	// Every refresh parks in the provider, so none of them frees its slot.
+	for i := range maxQueuedRefreshes + 25 {
+		cache.scheduleRefresh(fmt.Sprintf("Species %d", i))
+	}
+
+	assert.LessOrEqual(t, cache.refreshQueued.Load(), int64(maxQueuedRefreshes),
+		"registered refreshes must stay within their budget")
+
+	// The budget is separate from the prefetch one, so a burst of refreshes must
+	// not consume the queue that resolves species nothing is known about.
+	assert.True(t, cache.PrefetchAsync("Turdus merula"),
+		"a saturated refresh budget must not starve prefetches")
+}

--- a/internal/imageprovider/cache_pressure_test.go
+++ b/internal/imageprovider/cache_pressure_test.go
@@ -6,6 +6,7 @@
 package imageprovider
 
 import (
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -14,23 +15,24 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
-// countingStore records how many image-cache reads reach the database and serves
+// dbReadCountingStore records how many image-cache reads reach the database and serves
 // nothing, so a lookup that consults it is visible as a count.
-type countingStore struct {
+type dbReadCountingStore struct {
 	datastore.Interface
 	reads atomic.Int64
 }
 
-func (s *countingStore) GetImageCache(datastore.ImageCacheQuery) (*datastore.ImageCache, error) {
+func (s *dbReadCountingStore) GetImageCache(datastore.ImageCacheQuery) (*datastore.ImageCache, error) {
 	s.reads.Add(1)
 	return nil, datastore.ErrImageCacheNotFound
 }
 
-func (s *countingStore) SaveImageCache(*datastore.ImageCache) error { return nil }
+func (s *dbReadCountingStore) SaveImageCache(*datastore.ImageCache) error { return nil }
 
-func (s *countingStore) GetAllImageCaches(string) ([]datastore.ImageCache, error) {
+func (s *dbReadCountingStore) GetAllImageCaches(string) ([]datastore.ImageCache, error) {
 	return nil, nil
 }
 
@@ -43,7 +45,7 @@ func TestGetCachedLocal_DoesNotRepeatADatabaseMissPerPoll(t *testing.T) {
 	t.Parallel()
 
 	const species = "Turdus merula"
-	store := &countingStore{}
+	store := &dbReadCountingStore{}
 	cache := &BirdImageCache{providerName: wikiProviderName, store: store}
 
 	// The first lookup reads the database and finds nothing.
@@ -138,41 +140,142 @@ func TestRecentlyAttempted_ExpiresLazily(t *testing.T) {
 	assert.False(t, stillStored, "an expired marker is dropped rather than re-checked forever")
 }
 
-// TestCheckCachedEntryAfterLock_PositiveEntriesExpire is the memory-cache TTL.
+// TestCheckCachedEntryAfterLock_ServesAStalePositiveEntry pins the memory-cache
+// TTL decision.
 //
-// A positive memory entry used to be returned with no staleness check at all, so
-// once a wrong image landed in dataMap nothing on the request path could
-// re-derive it for the process lifetime, and clearing the database cache still
-// handed back the same wrong image.
-func TestCheckCachedEntryAfterLock_PositiveEntriesExpire(t *testing.T) {
+// A stale positive entry is served rather than discarded, exactly as a stale
+// database row is, and the caller schedules the refresh that re-derives it.
+// Deleting it here instead would make every request for a species older than
+// the TTL pay a fresh SQLite read, because the row is the same age and is
+// promoted back with the same timestamp, so the next lookup expires it again;
+// and on a store-less or corruption-latched cache it would throw away the only
+// copy the process has.
+func TestCheckCachedEntryAfterLock_ServesAStalePositiveEntry(t *testing.T) {
 	t.Parallel()
 
 	const species = "Turdus merula"
 	cache := &BirdImageCache{providerName: wikiProviderName}
 	log := GetLogger()
 
-	fresh := &BirdImage{
-		URL:            "https://example.invalid/blackbird.jpg",
+	stale := &BirdImage{
+		URL:            "https://127.0.0.1/blackbird.jpg",
 		ScientificName: species,
-		CachedAt:       time.Now(),
+		CachedAt:       time.Now().Add(-defaultCacheTTL - time.Hour),
 	}
-	cache.dataMap.Store(species, fresh)
+	cache.dataMap.Store(species, stale)
 
 	img, found, shouldReturn, err := cache.checkCachedEntryAfterLock(species, log)
 	require.NoError(t, err)
-	assert.True(t, found)
+	assert.True(t, found, "a stale image is still an image")
 	assert.False(t, shouldReturn)
-	assert.Equal(t, fresh.URL, img.URL)
-
-	stale := *fresh
-	stale.CachedAt = time.Now().Add(-defaultCacheTTL - time.Hour)
-	cache.dataMap.Store(species, &stale)
-
-	_, found, shouldReturn, err = cache.checkCachedEntryAfterLock(species, log)
-	require.NoError(t, err)
-	assert.False(t, found, "an expired positive entry is not an answer")
-	assert.False(t, shouldReturn)
+	assert.Equal(t, stale.URL, img.URL)
 	_, stillInMemory := cache.dataMap.Load(species)
-	assert.False(t, stillInMemory,
-		"the expired entry is dropped so the database, which schedules the refresh, is consulted")
+	assert.True(t, stillInMemory, "the entry must not be discarded; the refresh replaces it")
+}
+
+// TestCheckCachedEntryAfterLock_NegativeEntriesExpire keeps the other half of
+// the TTL: a negative entry that has aged out is not an answer.
+func TestCheckCachedEntryAfterLock_NegativeEntriesExpire(t *testing.T) {
+	t.Parallel()
+
+	const species = "Turdus merula"
+	cache := &BirdImageCache{providerName: wikiProviderName}
+	log := GetLogger()
+
+	fresh := &BirdImage{URL: negativeEntryMarker, ScientificName: species, CachedAt: time.Now()}
+	cache.dataMap.Store(species, fresh)
+	_, _, shouldReturn, err := cache.checkCachedEntryAfterLock(species, log)
+	require.Error(t, err)
+	assert.True(t, shouldReturn, "a live negative entry is a definitive answer")
+
+	expired := *fresh
+	expired.CachedAt = time.Now().Add(-negativeCacheTTL - time.Minute)
+	cache.dataMap.Store(species, &expired)
+	_, found, shouldReturn, err := cache.checkCachedEntryAfterLock(species, log)
+	require.NoError(t, err)
+	assert.False(t, found)
+	assert.False(t, shouldReturn, "an expired negative entry must let the caller re-derive")
+	_, stillInMemory := cache.dataMap.Load(species)
+	assert.False(t, stillInMemory)
+}
+
+// TestRecordMarkerIsBounded pins the cap on the marker maps.
+//
+// The keys are caller-supplied scientific names that the media endpoints pass
+// straight through, so the key space is request traffic rather than the label
+// set. Both markers are pure optimizations, so clearing is always safe.
+func TestRecordMarkerIsBounded(t *testing.T) {
+	t.Parallel()
+
+	cache := &BirdImageCache{providerName: wikiProviderName}
+	for i := range maxMarkerEntries + 100 {
+		cache.recordDBAbsent(fmt.Sprintf("Species %d", i))
+	}
+
+	live := 0
+	cache.dbAbsent.Range(func(_, _ any) bool { live++; return true })
+	assert.LessOrEqual(t, live, maxMarkerEntries,
+		"the marker map must stay bounded however many distinct names arrive")
+	assert.Positive(t, live, "clearing must not leave the map permanently empty")
+}
+
+// failingProvider always fails with a transient error, which is the case
+// runPrefetch must record a backoff for.
+type failingProvider struct{ calls atomic.Int64 }
+
+func (p *failingProvider) Fetch(scientificName string) (BirdImage, error) {
+	p.calls.Add(1)
+	return BirdImage{}, errors.Newf("simulated transient provider failure").
+		Component("imageprovider").
+		Category(errors.CategoryNetwork).
+		Build()
+}
+
+// TestRunPrefetch_RecordsBackoffOnTransientFailure covers the production wiring
+// of the backoff, not just the marker helpers.
+//
+// Without it the retry rate is the client's: the proxy answers 503 with a
+// Retry-After, and every poll would schedule a fresh goroutine and a fresh
+// provider attempt because nothing recorded that the last one had just failed.
+func TestRunPrefetch_RecordsBackoffOnTransientFailure(t *testing.T) {
+	t.Parallel()
+
+	const species = "Turdus merula"
+	provider := &failingProvider{}
+	cache := InitCache(wikiProviderName, provider, nil, nil)
+	t.Cleanup(func() { assert.NoError(t, cache.Close()) })
+
+	require.True(t, cache.PrefetchAsync(species))
+	require.Eventually(t, func() bool { return provider.calls.Load() > 0 },
+		2*time.Second, 5*time.Millisecond, "the prefetch should reach the provider")
+	require.Eventually(t, func() bool { return cache.recentlyAttempted(species) },
+		2*time.Second, 5*time.Millisecond,
+		"a transient provider failure must arm the backoff, or the client sets the retry rate")
+
+	assert.False(t, cache.PrefetchAsync(species),
+		"the next poll must be declined while the backoff is live")
+}
+
+// TestRunPrefetch_ClearsMarkersOnSuccess is the other half: the backoff must not
+// outlive the condition it was recorded for.
+func TestRunPrefetch_ClearsMarkersOnSuccess(t *testing.T) {
+	t.Parallel()
+
+	const species = "Turdus merula"
+	cache := InitCache(wikiProviderName, &recordingProvider{
+		fetched: make(chan string, 1),
+		result:  BirdImage{URL: "https://127.0.0.1/blackbird.jpg", ScientificName: species},
+	}, nil, nil)
+	t.Cleanup(func() { assert.NoError(t, cache.Close()) })
+
+	cache.recordFailedAttempt(species)
+	cache.recordDBAbsent(species)
+	require.True(t, cache.recentlyAttempted(species))
+
+	cache.clearResolutionMarkers(species)
+	require.True(t, cache.PrefetchAsync(species))
+	require.Eventually(t, func() bool {
+		return !cache.recentlyAttempted(species) && !cache.dbKnownAbsent(species)
+	}, 2*time.Second, 5*time.Millisecond,
+		"a resolved species must not keep either marker")
 }

--- a/internal/imageprovider/cache_pressure_test.go
+++ b/internal/imageprovider/cache_pressure_test.go
@@ -1,0 +1,178 @@
+// cache_pressure_test.go covers what an unresolved or stale species costs per
+// request under the retry contract introduced with the non-blocking proxy.
+//
+// The proxy answers 503 with a Retry-After and the client polls, so anything the
+// request path does per lookup is done once per poll, per species, forever.
+package imageprovider
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/datastore"
+)
+
+// countingStore records how many image-cache reads reach the database and serves
+// nothing, so a lookup that consults it is visible as a count.
+type countingStore struct {
+	datastore.Interface
+	reads atomic.Int64
+}
+
+func (s *countingStore) GetImageCache(datastore.ImageCacheQuery) (*datastore.ImageCache, error) {
+	s.reads.Add(1)
+	return nil, datastore.ErrImageCacheNotFound
+}
+
+func (s *countingStore) SaveImageCache(*datastore.ImageCache) error { return nil }
+
+func (s *countingStore) GetAllImageCaches(string) ([]datastore.ImageCache, error) {
+	return nil, nil
+}
+
+// TestGetCachedLocal_DoesNotRepeatADatabaseMissPerPoll is the steady-poll guard.
+//
+// Every request for an unresolved species used to reach SQLite, and the client's
+// retry schedule decides how often that is. On a cold dashboard with ~20
+// unresolved species that is several SELECTs per second on a 1-core Pi.
+func TestGetCachedLocal_DoesNotRepeatADatabaseMissPerPoll(t *testing.T) {
+	t.Parallel()
+
+	const species = "Turdus merula"
+	store := &countingStore{}
+	cache := &BirdImageCache{providerName: wikiProviderName, store: store}
+
+	// The first lookup reads the database and finds nothing.
+	_, found, negative := cache.getCachedLocal(species)
+	assert.False(t, found)
+	assert.False(t, negative)
+	require.Equal(t, int64(1), store.reads.Load())
+
+	// Subsequent polls within the window trust that miss.
+	for range 5 {
+		_, found, negative = cache.getCachedLocal(species)
+		assert.False(t, found, "an unresolved species stays unresolved")
+		assert.False(t, negative, "and must not be reported as 'no image exists'")
+	}
+	assert.Equal(t, int64(1), store.reads.Load(), "polling must not cost one SELECT per poll")
+
+	// A resolution clears the marker and the database is authoritative again.
+	cache.clearResolutionMarkers(species)
+	_, _, _ = cache.getCachedLocal(species)
+	assert.Equal(t, int64(2), store.reads.Load())
+}
+
+// TestGetCachedLocal_AStaleRowIsStillServedWhileItRefreshes is the guard against
+// over-applying the shortcut.
+//
+// A species with a stale but perfectly servable row also has a refresh in
+// flight. Suppressing its database read on that basis would answer 503 for an
+// image already on disk, which is worse than the load it saves.
+func TestGetCachedLocal_AStaleRowIsStillServedWhileItRefreshes(t *testing.T) {
+	t.Parallel()
+
+	const species = "Turdus merula"
+	store := &staleEntryStore{entry: &datastore.ImageCache{
+		ScientificName: species,
+		ProviderName:   wikiProviderName,
+		URL:            "https://127.0.0.1/blackbird.jpg",
+		CachedAt:       time.Now().Add(-defaultCacheTTL - time.Hour),
+	}}
+	cache := InitCache(wikiProviderName, &recordingProvider{fetched: make(chan string, 1)}, nil, store)
+	t.Cleanup(func() { assert.NoError(t, cache.Close()) })
+
+	// The first lookup serves the stale row and registers a refresh, which is
+	// what puts the species into the in-flight prefetch set.
+	for range 3 {
+		img, found, negative := cache.getCachedLocal(species)
+		assert.True(t, found, "a stale row is still an image")
+		assert.False(t, negative)
+		assert.Equal(t, "https://127.0.0.1/blackbird.jpg", img.URL)
+	}
+}
+
+// TestPrefetchAsync_BacksOffAfterAFailedAttempt is the other half: without a
+// marker, every client retry scheduled a fresh goroutine and a fresh provider
+// attempt, so the retry rate was set by the client rather than by us.
+func TestPrefetchAsync_BacksOffAfterAFailedAttempt(t *testing.T) {
+	t.Parallel()
+
+	const species = "Turdus merula"
+	cache := InitCache(wikiProviderName, &recordingProvider{fetched: make(chan string, 1)}, nil, nil)
+	t.Cleanup(func() { assert.NoError(t, cache.Close()) })
+
+	require.True(t, cache.PrefetchAsync(species), "the first attempt is scheduled")
+
+	cache.recordFailedAttempt(species)
+	for range 5 {
+		assert.False(t, cache.PrefetchAsync(species),
+			"a species whose resolution just failed must not be re-attempted on every poll")
+	}
+
+	cache.clearResolutionMarkers(species)
+	assert.True(t, cache.PrefetchAsync(species), "the backoff must expire, not latch")
+}
+
+// TestRecentlyAttempted_ExpiresLazily pins that the marker is a backoff and not a
+// second negative cache: a failed attempt is usually transient, so it has to age
+// out on its own.
+func TestRecentlyAttempted_ExpiresLazily(t *testing.T) {
+	t.Parallel()
+
+	const species = "Turdus merula"
+	cache := &BirdImageCache{providerName: wikiProviderName}
+
+	assert.False(t, cache.recentlyAttempted(species), "nothing is known yet")
+
+	cache.recordFailedAttempt(species)
+	assert.True(t, cache.recentlyAttempted(species))
+
+	// Backdate past the window rather than sleeping for it.
+	cache.recentAttempts.Store(species, time.Now().Add(-recentAttemptTTL-time.Second))
+	assert.False(t, cache.recentlyAttempted(species))
+	_, stillStored := cache.recentAttempts.Load(species)
+	assert.False(t, stillStored, "an expired marker is dropped rather than re-checked forever")
+}
+
+// TestCheckCachedEntryAfterLock_PositiveEntriesExpire is the memory-cache TTL.
+//
+// A positive memory entry used to be returned with no staleness check at all, so
+// once a wrong image landed in dataMap nothing on the request path could
+// re-derive it for the process lifetime, and clearing the database cache still
+// handed back the same wrong image.
+func TestCheckCachedEntryAfterLock_PositiveEntriesExpire(t *testing.T) {
+	t.Parallel()
+
+	const species = "Turdus merula"
+	cache := &BirdImageCache{providerName: wikiProviderName}
+	log := GetLogger()
+
+	fresh := &BirdImage{
+		URL:            "https://example.invalid/blackbird.jpg",
+		ScientificName: species,
+		CachedAt:       time.Now(),
+	}
+	cache.dataMap.Store(species, fresh)
+
+	img, found, shouldReturn, err := cache.checkCachedEntryAfterLock(species, log)
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.False(t, shouldReturn)
+	assert.Equal(t, fresh.URL, img.URL)
+
+	stale := *fresh
+	stale.CachedAt = time.Now().Add(-defaultCacheTTL - time.Hour)
+	cache.dataMap.Store(species, &stale)
+
+	_, found, shouldReturn, err = cache.checkCachedEntryAfterLock(species, log)
+	require.NoError(t, err)
+	assert.False(t, found, "an expired positive entry is not an answer")
+	assert.False(t, shouldReturn)
+	_, stillInMemory := cache.dataMap.Load(species)
+	assert.False(t, stillInMemory,
+		"the expired entry is dropped so the database, which schedules the refresh, is consulted")
+}

--- a/internal/imageprovider/cache_pressure_test.go
+++ b/internal/imageprovider/cache_pressure_test.go
@@ -258,24 +258,72 @@ func TestRunPrefetch_RecordsBackoffOnTransientFailure(t *testing.T) {
 
 // TestRunPrefetch_ClearsMarkersOnSuccess is the other half: the backoff must not
 // outlive the condition it was recorded for.
+//
+// The markers are recorded while the prefetch is parked inside the provider, so
+// only runPrefetch's own clear can satisfy the assertion. Recording them before
+// scheduling would make the check vacuous: the predicate would already hold at
+// the first tick, and deleting the production clear would leave the test green.
 func TestRunPrefetch_ClearsMarkersOnSuccess(t *testing.T) {
 	t.Parallel()
 
 	const species = "Turdus merula"
-	cache := InitCache(wikiProviderName, &recordingProvider{
-		fetched: make(chan string, 1),
-		result:  BirdImage{URL: "https://127.0.0.1/blackbird.jpg", ScientificName: species},
-	}, nil, nil)
+	provider := newBlockingProvider(t)
+	provider.result = BirdImage{URL: "https://127.0.0.1/blackbird.jpg", ScientificName: species}
+	cache := InitCache(wikiProviderName, provider, nil, nil)
 	t.Cleanup(func() { assert.NoError(t, cache.Close()) })
 
+	require.True(t, cache.PrefetchAsync(species))
+	require.Eventually(t, func() bool { return provider.calls.Load() > 0 },
+		2*time.Second, 5*time.Millisecond, "the prefetch must be parked in the provider")
+
+	// Recorded mid-flight, so the production clear is the only thing that can
+	// remove them.
 	cache.recordFailedAttempt(species)
 	cache.recordDBAbsent(species)
 	require.True(t, cache.recentlyAttempted(species))
+	require.True(t, cache.dbKnownAbsent(species))
 
-	cache.clearResolutionMarkers(species)
-	require.True(t, cache.PrefetchAsync(species))
+	close(provider.release)
+
 	require.Eventually(t, func() bool {
 		return !cache.recentlyAttempted(species) && !cache.dbKnownAbsent(species)
 	}, 2*time.Second, 5*time.Millisecond,
 		"a resolved species must not keep either marker")
+}
+
+// TestGetCachedLocal_StaleMemoryEntryIsRefreshed is the closure test for serving
+// a stale positive entry instead of deleting it.
+//
+// Serving it is only correct if the refresh that re-derives it is still
+// scheduled. Without that the entry stays resident for the whole 30-day TTL and
+// nothing on the request path can correct it, which is the exact condition the
+// memory TTL exists to end: a wrong image immortal in memory.
+func TestGetCachedLocal_StaleMemoryEntryIsRefreshed(t *testing.T) {
+	t.Parallel()
+
+	const species = "Turdus merula"
+	provider := &recordingProvider{
+		fetched: make(chan string, 1),
+		result:  BirdImage{URL: "https://127.0.0.1/fresh.jpg", ScientificName: species},
+	}
+	cache := InitCache(wikiProviderName, provider, nil, nil)
+	t.Cleanup(func() { assert.NoError(t, cache.Close()) })
+
+	cache.dataMap.Store(species, &BirdImage{
+		URL:            "https://127.0.0.1/stale.jpg",
+		ScientificName: species,
+		CachedAt:       time.Now().Add(-defaultCacheTTL - time.Hour),
+	})
+
+	img, found, negative := cache.getCachedLocal(species)
+	require.True(t, found, "a stale entry is still served")
+	assert.False(t, negative)
+	assert.Equal(t, "https://127.0.0.1/stale.jpg", img.URL)
+
+	select {
+	case got := <-provider.fetched:
+		assert.Equal(t, species, got, "serving a stale entry must also schedule its refresh")
+	case <-time.After(2 * time.Second):
+		t.Fatal("no refresh was scheduled for the stale memory entry, so nothing can ever re-derive it")
+	}
 }

--- a/internal/imageprovider/cache_resilience_test.go
+++ b/internal/imageprovider/cache_resilience_test.go
@@ -23,7 +23,7 @@ type emptyNameProvider struct {
 func (p *emptyNameProvider) Fetch(scientificName string) (imageprovider.BirdImage, error) {
 	p.fetchCount.Add(1)
 	return imageprovider.BirdImage{
-		URL:         fmt.Sprintf("http://example.com/%s.jpg", scientificName),
+		URL:         fmt.Sprintf("http://127.0.0.1/%s.jpg", scientificName),
 		LicenseName: "CC BY 4.0",
 		AuthorName:  "Test Author",
 		CachedAt:    time.Now(),

--- a/internal/imageprovider/cache_validation_test.go
+++ b/internal/imageprovider/cache_validation_test.go
@@ -207,7 +207,7 @@ func TestBackgroundRefreshIsolation(t *testing.T) {
 	err = mockStore.SaveImageCache(&datastore.ImageCache{
 		ScientificName: species,
 		ProviderName:   "wikimedia",
-		URL:            "http://example.com/old.jpg",
+		URL:            "http://127.0.0.1/old.jpg",
 		CachedAt:       staleTime,
 	})
 	require.NoError(t, err, "Failed to save stale cache entry")
@@ -227,7 +227,7 @@ func TestBackgroundRefreshIsolation(t *testing.T) {
 	require.NoError(t, err, "Failed to get image")
 	assert.Less(t, duration, userLatencyBudget,
 		"user request blocked on the background provider fetch (%s delay)", providerFetchDelay)
-	assert.Equal(t, "http://example.com/old.jpg", img.URL, "Expected stale URL")
+	assert.Equal(t, "http://127.0.0.1/old.jpg", img.URL, "Expected stale URL")
 
 	// Background refresh must actually run. Poll rather than sleep a fixed interval.
 	assert.Eventually(t, func() bool {

--- a/internal/imageprovider/filecache.go
+++ b/internal/imageprovider/filecache.go
@@ -3,7 +3,6 @@ package imageprovider
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -14,7 +13,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/httpclient"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -67,13 +65,21 @@ var imageHTTPClient = func() *http.Client {
 	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 		host, port, err := net.SplitHostPort(addr)
 		if err != nil {
-			return nil, fmt.Errorf("invalid address %q: %w", addr, err)
+			return nil, errors.Newf("invalid address %q: %w", addr, err).
+				Component("imageprovider").
+				Category(errors.CategoryNetwork).
+				Context("operation", "split_dial_address").
+				Build()
 		}
 
 		// Resolve the hostname to IPs and validate them.
 		ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
 		if err != nil {
-			return nil, fmt.Errorf("DNS lookup failed for %q: %w", host, err)
+			return nil, errors.Newf("DNS lookup failed for %q: %w", host, err).
+				Component("imageprovider").
+				Category(errors.CategoryNetwork).
+				Context("operation", "dns_lookup").
+				Build()
 		}
 
 		// Dial the first safe resolved IP directly to prevent TOCTOU/DNS rebinding.
@@ -91,61 +97,33 @@ var imageHTTPClient = func() *http.Client {
 			return conn, nil
 		}
 		if lastErr != nil {
-			return nil, fmt.Errorf("failed to connect to %q: %w", host, lastErr)
+			return nil, errors.Newf("failed to connect to %q: %w", host, lastErr).
+				Component("imageprovider").
+				Category(errors.CategoryNetwork).
+				Context("operation", "dial_image_host").
+				Build()
 		}
-		return nil, fmt.Errorf("no safe IP addresses for host %q", host)
+		return nil, errors.Newf("no safe IP addresses for host %q", host).
+			Component("imageprovider").
+			Category(errors.CategoryNetwork).
+			Context("operation", "dial_image_host").
+			Build()
 	}
 	return &http.Client{
 		Timeout:   10 * time.Second,
 		Transport: transport,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 3 {
-				return fmt.Errorf("too many redirects")
+				return errors.Newf("too many redirects").
+					Component("imageprovider").
+					Category(errors.CategoryNetwork).
+					Context("operation", "follow_image_redirect").
+					Build()
 			}
 			return nil
 		},
 	}
 }()
-
-// cachedImageUserAgent memoizes the image-download User-Agent. It is an atomic.Pointer
-// rather than a sync.OnceValue because conf.Setting() can return nil, and Version is
-// published after startup: latching at first call could pin a version-less string for
-// the process lifetime. Only a non-empty version is memoized, so an early call does not
-// poison the value.
-var cachedImageUserAgent atomic.Pointer[string]
-
-// currentAppVersion returns the running application version. It is empty both when
-// conf.Setting() returns nil (the config failed to load) and when Version has not been
-// published yet; callers only need "not yet usable", so the two are equivalent here.
-func currentAppVersion() string {
-	if settings := conf.Setting(); settings != nil {
-		return settings.Version
-	}
-	return ""
-}
-
-// imageDownloadUserAgent returns a User-Agent for the image byte download that satisfies
-// the Wikimedia Foundation User-Agent policy.
-//
-// Wikimedia answers 403 to Go's default "Go-http-client/1.1", so the byte fetch needs the
-// same policy-compliant header the MediaWiki API path already sends. Reusing
-// buildUserAgent keeps the two in one format.
-//
-// Do not "correct" userAgentName to the hyphenated project name: Wikimedia refuses any
-// User-Agent starting with "BirdNET-Go", so the current hyphen-less spelling is the one
-// that works. See internal/imageprovider/wikipedia.go for where that name is defined.
-func imageDownloadUserAgent() string {
-	if ua := cachedImageUserAgent.Load(); ua != nil {
-		return *ua
-	}
-	version := currentAppVersion()
-	ua := buildUserAgent(version)
-	if version != "" {
-		// CompareAndSwap rather than Store so concurrent first callers publish once.
-		cachedImageUserAgent.CompareAndSwap(nil, &ua)
-	}
-	return ua
-}
 
 // ImageFileCache manages disk-based image caching organized by provider.
 type ImageFileCache struct {
@@ -233,6 +211,9 @@ func NewImageFileCache(basePath string) *ImageFileCache {
 // between the request and the log, which is exactly the wrong thing to do in a
 // diagnostic about which User-Agent was refused.
 func (c *ImageFileCache) logPermanentImageRejection(statusCode int, provider, scientificName, imageURL, userAgent string) {
+	// Narrower than openDownloadCooldown's {401, 403, 429} on purpose: 429 is the
+	// host asking us to slow down, which the cooldown handles quietly, while 401
+	// and 403 are the host refusing us and are worth one escalated log.
 	if statusCode != http.StatusForbidden && statusCode != http.StatusUnauthorized {
 		return
 	}
@@ -248,6 +229,32 @@ func (c *ImageFileCache) logPermanentImageRejection(statusCode int, provider, sc
 	)
 }
 
+// cacheFileError wraps a disk-cache filesystem failure.
+//
+// This file used to build every one of its errors with a bare fmt.Errorf and
+// never imported internal/errors, so a permanently empty image cache reached
+// Sentry as nothing at all: the only signal was a log line.
+func cacheFileError(err error, operation, provider, scientificName string) error {
+	return errors.New(err).
+		Component("imageprovider").
+		Category(errors.CategoryImageCache).
+		Context("provider", provider).
+		Context("scientific_name", scientificName).
+		Context("operation", operation).
+		Build()
+}
+
+// downloadError wraps a failure on the image byte-download path.
+func downloadError(err error, operation, provider, imageURL string) error {
+	return errors.New(err).
+		Component("imageprovider").
+		Category(errors.CategoryNetwork).
+		Context("provider", provider).
+		Context("image_url", imageURL).
+		Context("operation", operation).
+		Build()
+}
+
 // normalizeSpeciesName converts a species name to a filesystem-safe form:
 // lowercase with spaces replaced by underscores.
 func normalizeSpeciesName(name string) string {
@@ -259,11 +266,19 @@ func normalizeSpeciesName(name string) string {
 // filepath.IsLocal for comprehensive validation.
 func validatePathComponent(component string) error {
 	if strings.ContainsAny(component, "/\\") {
-		return fmt.Errorf("path component contains separator: %q", component)
+		return errors.Newf("path component contains separator: %q", component).
+			Component("imageprovider").
+			Category(errors.CategoryValidation).
+			Context("operation", "validate_path_component").
+			Build()
 	}
 	cleaned := filepath.Clean(component)
 	if !filepath.IsLocal(cleaned) {
-		return fmt.Errorf("path component is not local: %q", component)
+		return errors.Newf("path component is not local: %q", component).
+			Component("imageprovider").
+			Category(errors.CategoryValidation).
+			Context("operation", "validate_path_component").
+			Build()
 	}
 	return nil
 }
@@ -289,11 +304,22 @@ func extensionFromContentType(contentType string) string {
 // It returns the directory path and the base filename (without extension).
 func (c *ImageFileCache) buildPath(provider, scientificName string) (dir, namePrefix string, err error) {
 	if err := validatePathComponent(provider); err != nil {
-		return "", "", fmt.Errorf("invalid provider: %w", err)
+		return "", "", errors.Newf("invalid provider: %w", err).
+			Component("imageprovider").
+			Category(errors.CategoryValidation).
+			Context("provider", provider).
+			Context("operation", "validate_provider_path").
+			Build()
 	}
 	normalized := normalizeSpeciesName(scientificName)
 	if err := validatePathComponent(normalized); err != nil {
-		return "", "", fmt.Errorf("invalid species name: %w", err)
+		return "", "", errors.Newf("invalid species name: %w", err).
+			Component("imageprovider").
+			Category(errors.CategoryValidation).
+			Context("provider", provider).
+			Context("scientific_name", scientificName).
+			Context("operation", "validate_species_path").
+			Build()
 	}
 	dir = filepath.Join(c.basePath, provider)
 	namePrefix = normalized
@@ -312,11 +338,11 @@ func (c *ImageFileCache) Store(provider, scientificName string, data []byte, sou
 
 	dir, namePrefix, err := c.buildPath(provider, scientificName)
 	if err != nil {
-		return "", "", fmt.Errorf("build path: %w", err)
+		return "", "", cacheFileError(err, "build_cache_path", provider, scientificName)
 	}
 
 	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return "", "", fmt.Errorf("create cache directory: %w", err)
+		return "", "", cacheFileError(err, "create_cache_directory", provider, scientificName)
 	}
 
 	// Prefer upstream Content-Type; fall back to sniffing if missing or generic.
@@ -330,23 +356,24 @@ func (c *ImageFileCache) Store(provider, scientificName string, data []byte, sou
 	// Atomic write: write to temp file then rename.
 	tmpFile, err := os.CreateTemp(dir, namePrefix+"-*.tmp")
 	if err != nil {
-		return "", "", fmt.Errorf("create temp file: %w", err)
+		return "", "", cacheFileError(err, "create_temp_file", provider, scientificName)
 	}
 	tmpPath := tmpFile.Name()
+	// Unconditional cleanup rather than one removal per error branch: after a
+	// successful rename the path no longer exists and this is a no-op, while a
+	// branch added later cannot silently start orphaning temp files.
+	defer func() { _ = os.Remove(tmpPath) }()
 
 	if _, writeErr := tmpFile.Write(data); writeErr != nil {
 		_ = tmpFile.Close()
-		_ = os.Remove(tmpPath)
-		return "", "", fmt.Errorf("write temp file: %w", writeErr)
+		return "", "", cacheFileError(writeErr, "write_temp_file", provider, scientificName)
 	}
 	if closeErr := tmpFile.Close(); closeErr != nil {
-		_ = os.Remove(tmpPath)
-		return "", "", fmt.Errorf("close temp file: %w", closeErr)
+		return "", "", cacheFileError(closeErr, "close_temp_file", provider, scientificName)
 	}
 
 	if renameErr := os.Rename(tmpPath, finalPath); renameErr != nil {
-		_ = os.Remove(tmpPath)
-		return "", "", fmt.Errorf("rename temp file: %w", renameErr)
+		return "", "", cacheFileError(renameErr, "rename_temp_file", provider, scientificName)
 	}
 
 	// Remove stale files with different extensions (e.g. old .png when new file is .jpg).
@@ -377,7 +404,7 @@ func (c *ImageFileCache) Store(provider, scientificName string, data []byte, sou
 func (c *ImageFileCache) Get(provider, scientificName string) (path, contentType string, fresh bool, err error) {
 	dir, namePrefix, err := c.buildPath(provider, scientificName)
 	if err != nil {
-		return "", "", false, fmt.Errorf("build path: %w", err)
+		return "", "", false, cacheFileError(err, "build_cache_path", provider, scientificName)
 	}
 
 	for _, ext := range knownExtensions {
@@ -452,14 +479,19 @@ func (fc *ImageFileCache) DownloadAndStore(ctx context.Context, provider, scient
 		// A refused host stays refused for the cooldown. Checked before anything
 		// else so a blanket rejection costs neither a request nor a semaphore slot.
 		if deadline, open := fc.downloadBlockedUntil(provider); open {
-			return nil, fmt.Errorf("%w: retry after %s", ErrImageDownloadBlocked, deadline.UTC().Format(time.RFC3339))
+			return nil, errors.Newf("%w: retry after %s", ErrImageDownloadBlocked, deadline.UTC().Format(time.RFC3339)).
+				Component("imageprovider").
+				Category(errors.CategoryImageFetch).
+				Context("provider", provider).
+				Context("operation", "image_download_cooldown").
+				Build()
 		}
 
 		// Build the User-Agent before taking a semaphore slot. It can reach
 		// conf.Setting(), whose slow path takes a package-global lock and can read from
 		// disk, and doing that while holding one of only five download slots would
 		// serialize unrelated downloads behind it.
-		userAgent := imageDownloadUserAgent()
+		userAgent := appUserAgent()
 
 		// An already-cancelled context must not acquire a slot and issue a request.
 		// With a free semaphore both select cases are ready and the choice is random,
@@ -478,30 +510,42 @@ func (fc *ImageFileCache) DownloadAndStore(ctx context.Context, provider, scient
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, imageURL, http.NoBody) //nolint:gosec // URL comes from trusted DB entries, not user input
 		if err != nil {
-			return nil, fmt.Errorf("failed to create image request: %w", err)
+			return nil, downloadError(err, "create_image_request", provider, imageURL)
 		}
 		// Required: Wikimedia rejects Go's default User-Agent with 403.
 		req.Header.Set("User-Agent", userAgent)
 		resp, err := fc.httpClient.Do(req)
 		if err != nil {
-			return nil, fmt.Errorf("failed to download image: %w", err)
+			return nil, downloadError(err, "download_image", provider, imageURL)
 		}
 		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode != http.StatusOK {
 			fc.logPermanentImageRejection(resp.StatusCode, provider, scientificName, imageURL, userAgent)
 			fc.openDownloadCooldown(resp.StatusCode, provider)
-			return nil, fmt.Errorf("non-200 status downloading image: %d", resp.StatusCode)
+			return nil, errors.Newf("non-200 status downloading image: %d", resp.StatusCode).
+				Component("imageprovider").
+				Category(errors.CategoryNetwork).
+				Context("provider", provider).
+				Context("http_status", resp.StatusCode).
+				Context("operation", "download_image").
+				Build()
 		}
 
 		// Limit read size to prevent OOM from malicious or malformed responses.
 		limited := io.LimitReader(resp.Body, maxImageSize+1)
 		data, err := io.ReadAll(limited)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read image body: %w", err)
+			return nil, downloadError(err, "read_image_body", provider, imageURL)
 		}
 		if len(data) > maxImageSize {
-			return nil, fmt.Errorf("image exceeds maximum size of %d bytes", maxImageSize)
+			return nil, errors.Newf("image exceeds maximum size of %d bytes", maxImageSize).
+				Component("imageprovider").
+				Category(errors.CategoryLimit).
+				Context("provider", provider).
+				Context("max_image_size", maxImageSize).
+				Context("operation", "download_image").
+				Build()
 		}
 
 		upstreamCT := resp.Header.Get("Content-Type")
@@ -523,7 +567,12 @@ func (fc *ImageFileCache) DownloadAndStore(ctx context.Context, provider, scient
 	}
 	dr, ok := result.(*downloadResult)
 	if !ok {
-		return "", "", fmt.Errorf("unexpected download result type %T", result)
+		return "", "", errors.Newf("unexpected download result type %T", result).
+			Component("imageprovider").
+			Category(errors.CategorySystem).
+			Context("provider", provider).
+			Context("operation", "download_and_store").
+			Build()
 	}
 	return dr.path, dr.contentType, nil
 }

--- a/internal/imageprovider/filecache.go
+++ b/internal/imageprovider/filecache.go
@@ -3,6 +3,7 @@ package imageprovider
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -65,21 +66,13 @@ var imageHTTPClient = func() *http.Client {
 	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 		host, port, err := net.SplitHostPort(addr)
 		if err != nil {
-			return nil, errors.Newf("invalid address %q: %w", addr, err).
-				Component("imageprovider").
-				Category(errors.CategoryNetwork).
-				Context("operation", "split_dial_address").
-				Build()
+			return nil, fmt.Errorf("invalid address %q: %w", addr, err)
 		}
 
 		// Resolve the hostname to IPs and validate them.
 		ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
 		if err != nil {
-			return nil, errors.Newf("DNS lookup failed for %q: %w", host, err).
-				Component("imageprovider").
-				Category(errors.CategoryNetwork).
-				Context("operation", "dns_lookup").
-				Build()
+			return nil, fmt.Errorf("DNS lookup failed for %q: %w", host, err)
 		}
 
 		// Dial the first safe resolved IP directly to prevent TOCTOU/DNS rebinding.
@@ -97,28 +90,16 @@ var imageHTTPClient = func() *http.Client {
 			return conn, nil
 		}
 		if lastErr != nil {
-			return nil, errors.Newf("failed to connect to %q: %w", host, lastErr).
-				Component("imageprovider").
-				Category(errors.CategoryNetwork).
-				Context("operation", "dial_image_host").
-				Build()
+			return nil, fmt.Errorf("failed to connect to %q: %w", host, lastErr)
 		}
-		return nil, errors.Newf("no safe IP addresses for host %q", host).
-			Component("imageprovider").
-			Category(errors.CategoryNetwork).
-			Context("operation", "dial_image_host").
-			Build()
+		return nil, fmt.Errorf("no safe IP addresses for host %q", host)
 	}
 	return &http.Client{
 		Timeout:   10 * time.Second,
 		Transport: transport,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 3 {
-				return errors.Newf("too many redirects").
-					Component("imageprovider").
-					Category(errors.CategoryNetwork).
-					Context("operation", "follow_image_redirect").
-					Build()
+				return fmt.Errorf("too many redirects")
 			}
 			return nil
 		},
@@ -229,28 +210,23 @@ func (c *ImageFileCache) logPermanentImageRejection(statusCode int, provider, sc
 	)
 }
 
-// cacheFileError wraps a disk-cache filesystem failure.
+// cacheFileError wraps a disk-cache filesystem failure, which is the one class
+// of failure in this file worth reporting.
 //
-// This file used to build every one of its errors with a bare fmt.Errorf and
-// never imported internal/errors, so a permanently empty image cache reached
-// Sentry as nothing at all: the only signal was a log line.
+// A permanently empty image cache used to reach Sentry as nothing at all, since
+// every error here was a bare fmt.Errorf and the only signal was a log line.
+// The transient paths - DNS, dial, HTTP status, the download cooldown - are
+// deliberately NOT built through this: ErrorBuilder.Build reports to telemetry
+// unconditionally, so doing so would emit one event per attempt for exactly the
+// throttling and blanket-refusal conditions that already have a cooldown and a
+// once-per-cache escalated log. It would also stack two or three reports on one
+// failure, since a wrapped EnhancedError is reported again by each wrap.
 func cacheFileError(err error, operation, provider, scientificName string) error {
 	return errors.New(err).
 		Component("imageprovider").
 		Category(errors.CategoryImageCache).
 		Context("provider", provider).
 		Context("scientific_name", scientificName).
-		Context("operation", operation).
-		Build()
-}
-
-// downloadError wraps a failure on the image byte-download path.
-func downloadError(err error, operation, provider, imageURL string) error {
-	return errors.New(err).
-		Component("imageprovider").
-		Category(errors.CategoryNetwork).
-		Context("provider", provider).
-		Context("image_url", imageURL).
 		Context("operation", operation).
 		Build()
 }
@@ -266,19 +242,11 @@ func normalizeSpeciesName(name string) string {
 // filepath.IsLocal for comprehensive validation.
 func validatePathComponent(component string) error {
 	if strings.ContainsAny(component, "/\\") {
-		return errors.Newf("path component contains separator: %q", component).
-			Component("imageprovider").
-			Category(errors.CategoryValidation).
-			Context("operation", "validate_path_component").
-			Build()
+		return fmt.Errorf("path component contains separator: %q", component)
 	}
 	cleaned := filepath.Clean(component)
 	if !filepath.IsLocal(cleaned) {
-		return errors.Newf("path component is not local: %q", component).
-			Component("imageprovider").
-			Category(errors.CategoryValidation).
-			Context("operation", "validate_path_component").
-			Build()
+		return fmt.Errorf("path component is not local: %q", component)
 	}
 	return nil
 }
@@ -304,22 +272,11 @@ func extensionFromContentType(contentType string) string {
 // It returns the directory path and the base filename (without extension).
 func (c *ImageFileCache) buildPath(provider, scientificName string) (dir, namePrefix string, err error) {
 	if err := validatePathComponent(provider); err != nil {
-		return "", "", errors.Newf("invalid provider: %w", err).
-			Component("imageprovider").
-			Category(errors.CategoryValidation).
-			Context("provider", provider).
-			Context("operation", "validate_provider_path").
-			Build()
+		return "", "", fmt.Errorf("invalid provider: %w", err)
 	}
 	normalized := normalizeSpeciesName(scientificName)
 	if err := validatePathComponent(normalized); err != nil {
-		return "", "", errors.Newf("invalid species name: %w", err).
-			Component("imageprovider").
-			Category(errors.CategoryValidation).
-			Context("provider", provider).
-			Context("scientific_name", scientificName).
-			Context("operation", "validate_species_path").
-			Build()
+		return "", "", fmt.Errorf("invalid species name: %w", err)
 	}
 	dir = filepath.Join(c.basePath, provider)
 	namePrefix = normalized
@@ -338,7 +295,7 @@ func (c *ImageFileCache) Store(provider, scientificName string, data []byte, sou
 
 	dir, namePrefix, err := c.buildPath(provider, scientificName)
 	if err != nil {
-		return "", "", cacheFileError(err, "build_cache_path", provider, scientificName)
+		return "", "", fmt.Errorf("build path: %w", err)
 	}
 
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -404,7 +361,7 @@ func (c *ImageFileCache) Store(provider, scientificName string, data []byte, sou
 func (c *ImageFileCache) Get(provider, scientificName string) (path, contentType string, fresh bool, err error) {
 	dir, namePrefix, err := c.buildPath(provider, scientificName)
 	if err != nil {
-		return "", "", false, cacheFileError(err, "build_cache_path", provider, scientificName)
+		return "", "", false, fmt.Errorf("build path: %w", err)
 	}
 
 	for _, ext := range knownExtensions {
@@ -479,12 +436,7 @@ func (fc *ImageFileCache) DownloadAndStore(ctx context.Context, provider, scient
 		// A refused host stays refused for the cooldown. Checked before anything
 		// else so a blanket rejection costs neither a request nor a semaphore slot.
 		if deadline, open := fc.downloadBlockedUntil(provider); open {
-			return nil, errors.Newf("%w: retry after %s", ErrImageDownloadBlocked, deadline.UTC().Format(time.RFC3339)).
-				Component("imageprovider").
-				Category(errors.CategoryImageFetch).
-				Context("provider", provider).
-				Context("operation", "image_download_cooldown").
-				Build()
+			return nil, fmt.Errorf("%w: retry after %s", ErrImageDownloadBlocked, deadline.UTC().Format(time.RFC3339))
 		}
 
 		// Build the User-Agent before taking a semaphore slot. It can reach
@@ -510,42 +462,30 @@ func (fc *ImageFileCache) DownloadAndStore(ctx context.Context, provider, scient
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, imageURL, http.NoBody) //nolint:gosec // URL comes from trusted DB entries, not user input
 		if err != nil {
-			return nil, downloadError(err, "create_image_request", provider, imageURL)
+			return nil, fmt.Errorf("failed to create image request: %w", err)
 		}
 		// Required: Wikimedia rejects Go's default User-Agent with 403.
 		req.Header.Set("User-Agent", userAgent)
 		resp, err := fc.httpClient.Do(req)
 		if err != nil {
-			return nil, downloadError(err, "download_image", provider, imageURL)
+			return nil, fmt.Errorf("failed to download image: %w", err)
 		}
 		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode != http.StatusOK {
 			fc.logPermanentImageRejection(resp.StatusCode, provider, scientificName, imageURL, userAgent)
 			fc.openDownloadCooldown(resp.StatusCode, provider)
-			return nil, errors.Newf("non-200 status downloading image: %d", resp.StatusCode).
-				Component("imageprovider").
-				Category(errors.CategoryNetwork).
-				Context("provider", provider).
-				Context("http_status", resp.StatusCode).
-				Context("operation", "download_image").
-				Build()
+			return nil, fmt.Errorf("non-200 status downloading image: %d", resp.StatusCode)
 		}
 
 		// Limit read size to prevent OOM from malicious or malformed responses.
 		limited := io.LimitReader(resp.Body, maxImageSize+1)
 		data, err := io.ReadAll(limited)
 		if err != nil {
-			return nil, downloadError(err, "read_image_body", provider, imageURL)
+			return nil, fmt.Errorf("failed to read image body: %w", err)
 		}
 		if len(data) > maxImageSize {
-			return nil, errors.Newf("image exceeds maximum size of %d bytes", maxImageSize).
-				Component("imageprovider").
-				Category(errors.CategoryLimit).
-				Context("provider", provider).
-				Context("max_image_size", maxImageSize).
-				Context("operation", "download_image").
-				Build()
+			return nil, fmt.Errorf("image exceeds maximum size of %d bytes", maxImageSize)
 		}
 
 		upstreamCT := resp.Header.Get("Content-Type")
@@ -567,12 +507,7 @@ func (fc *ImageFileCache) DownloadAndStore(ctx context.Context, provider, scient
 	}
 	dr, ok := result.(*downloadResult)
 	if !ok {
-		return "", "", errors.Newf("unexpected download result type %T", result).
-			Component("imageprovider").
-			Category(errors.CategorySystem).
-			Context("provider", provider).
-			Context("operation", "download_and_store").
-			Build()
+		return "", "", fmt.Errorf("unexpected download result type %T", result)
 	}
 	return dr.path, dr.contentType, nil
 }

--- a/internal/imageprovider/filecache.go
+++ b/internal/imageprovider/filecache.go
@@ -217,7 +217,8 @@ func (c *ImageFileCache) logPermanentImageRejection(statusCode int, provider, sc
 // every error here was a bare fmt.Errorf and the only signal was a log line.
 // The transient paths - DNS, dial, HTTP status, the download cooldown - are
 // deliberately NOT built through this: ErrorBuilder.Build reports to telemetry
-// unconditionally, so doing so would emit one event per attempt for exactly the
+// whenever reporting is active, so doing so would emit one event per attempt for
+// exactly the
 // throttling and blanket-refusal conditions that already have a cooldown and a
 // once-per-cache escalated log. It would also stack two or three reports on one
 // failure, since a wrapped EnhancedError is reported again by each wrap.

--- a/internal/imageprovider/filecache_test.go
+++ b/internal/imageprovider/filecache_test.go
@@ -23,7 +23,7 @@ func TestImageFileCache_StoreAndGet(t *testing.T) {
 	// Minimal valid JPEG: FFD8FF header triggers image/jpeg detection.
 	jpegData := []byte{0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46}
 
-	storedPath, storeCT, err := cache.Store("wikimedia", "Parus major", jpegData, "https://example.com/img.jpg", "image/jpeg")
+	storedPath, storeCT, err := cache.Store("wikimedia", "Parus major", jpegData, "https://127.0.0.1/img.jpg", "image/jpeg")
 	require.NoError(t, err)
 	assert.Contains(t, storedPath, "parus_major.jpg")
 	assert.Equal(t, "image/jpeg", storeCT)
@@ -378,7 +378,7 @@ func TestImageFileCache_DetectsContentType(t *testing.T) {
 
 	cache := NewImageFileCache(filepath.Join(t.TempDir(), "cache"))
 
-	storedPath, storedCT, err := cache.Store("wikimedia", "Cyanistes caeruleus", pngBytes, "https://example.com/img.png", "")
+	storedPath, storedCT, err := cache.Store("wikimedia", "Cyanistes caeruleus", pngBytes, "https://127.0.0.1/img.png", "")
 	require.NoError(t, err)
 	assert.Equal(t, ".png", filepath.Ext(storedPath), "expected .png extension")
 	assert.Equal(t, "image/png", storedCT)

--- a/internal/imageprovider/helpers_test.go
+++ b/internal/imageprovider/helpers_test.go
@@ -1,3 +1,12 @@
+// Image URLs in this package's tests point at 127.0.0.1 on purpose.
+//
+// A cached image URL is not inert: a refresh hands it to DownloadAndStore, which
+// really fetches it. With hosts like upload.wikimedia.org and example.com in the
+// fixtures, running the test suite opened live connections to those hosts, and a
+// keep-alive connection still idle when the package finished failed the
+// TestMain goroutine-leak check at random. The SSRF dialer rejects a loopback
+// literal before resolving or dialing anything, so these URLs stay opaque
+// strings and the suite touches no network.
 package imageprovider
 
 import (
@@ -87,12 +96,12 @@ func TestFindStaleEntriesSkipsNegativeEntries(t *testing.T) {
 	entries := []datastore.ImageCache{
 		{
 			ScientificName: "Turdus merula",
-			URL:            "https://example.com/blackbird.jpg",
+			URL:            "https://127.0.0.1/blackbird.jpg",
 			CachedAt:       now.Add(-defaultCacheTTL - time.Hour),
 		},
 		{
 			ScientificName: "Parus major",
-			URL:            "https://example.com/great-tit.jpg",
+			URL:            "https://127.0.0.1/great-tit.jpg",
 			CachedAt:       now.Add(-time.Hour),
 		},
 		{
@@ -128,21 +137,21 @@ func TestDbEntryToBirdImage(t *testing.T) {
 			entry: &datastore.ImageCache{
 				ScientificName: "Parus major",
 				ProviderName:   "wikimedia",
-				URL:            "http://example.com/parus.jpg",
+				URL:            "http://127.0.0.1/parus.jpg",
 				LicenseName:    "CC BY-SA 4.0",
 				LicenseURL:     "http://creativecommons.org/licenses/by-sa/4.0/",
 				AuthorName:     "John Doe",
-				AuthorURL:      "http://example.com/johndoe",
+				AuthorURL:      "http://127.0.0.1/johndoe",
 				CachedAt:       cachedTime,
 			},
 			want: BirdImage{
 				ScientificName: "Parus major",
 				SourceProvider: "wikimedia",
-				URL:            "http://example.com/parus.jpg",
+				URL:            "http://127.0.0.1/parus.jpg",
 				LicenseName:    "CC BY-SA 4.0",
 				LicenseURL:     "http://creativecommons.org/licenses/by-sa/4.0/",
 				AuthorName:     "John Doe",
-				AuthorURL:      "http://example.com/johndoe",
+				AuthorURL:      "http://127.0.0.1/johndoe",
 				CachedAt:       cachedTime,
 			},
 		},
@@ -166,13 +175,13 @@ func TestDbEntryToBirdImage(t *testing.T) {
 			entry: &datastore.ImageCache{
 				ScientificName: "Turdus merula",
 				ProviderName:   "avicommons",
-				URL:            "http://example.com/blackbird.jpg",
+				URL:            "http://127.0.0.1/blackbird.jpg",
 				CachedAt:       cachedTime,
 			},
 			want: BirdImage{
 				ScientificName: "Turdus merula",
 				SourceProvider: "avicommons",
-				URL:            "http://example.com/blackbird.jpg",
+				URL:            "http://127.0.0.1/blackbird.jpg",
 				CachedAt:       cachedTime,
 			},
 		},
@@ -425,7 +434,7 @@ func TestBirdImageIsNegativeEntry(t *testing.T) {
 	}{
 		{
 			name: "positive entry",
-			img:  BirdImage{URL: "http://example.com/bird.jpg"},
+			img:  BirdImage{URL: "http://127.0.0.1/bird.jpg"},
 			want: false,
 		},
 		{
@@ -460,7 +469,7 @@ func TestBirdImageGetTTL(t *testing.T) {
 	}{
 		{
 			name: "positive entry gets default TTL",
-			img:  BirdImage{URL: "http://example.com/bird.jpg"},
+			img:  BirdImage{URL: "http://127.0.0.1/bird.jpg"},
 			want: defaultCacheTTL,
 		},
 		{

--- a/internal/imageprovider/imageprovider.go
+++ b/internal/imageprovider/imageprovider.go
@@ -108,14 +108,25 @@ type contextFetcher interface {
 	FetchWithContext(ctx context.Context, scientificName string) (BirdImage, error)
 }
 
+// thumbnailSettings returns the dashboard thumbnail configuration, or its zero
+// value when settings are unavailable.
+//
+// conf.Setting() returns nil when the configuration fails to load, and a hot
+// reload can publish nil, so every read in this package has to tolerate it.
+// Several sites dereferenced the result directly, which panics on a path that
+// is reachable from any non-main entry point.
+func thumbnailSettings() conf.Thumbnails {
+	settings := conf.Setting()
+	if settings == nil {
+		return conf.Thumbnails{}
+	}
+	return settings.Realtime.Dashboard.Thumbnails
+}
+
 // normalizedFallbackPolicy reads the configured fallback policy, trimmed and
 // lowercased, so that "All" or a stray trailing space is not read as "off".
 func normalizedFallbackPolicy() string {
-	settings := conf.Setting()
-	if settings == nil {
-		return ""
-	}
-	return strings.ToLower(strings.TrimSpace(settings.Realtime.Dashboard.Thumbnails.FallbackPolicy))
+	return strings.ToLower(strings.TrimSpace(thumbnailSettings().FallbackPolicy))
 }
 
 // fetchFromProvider calls the provider's context-aware Fetch when it has one and falls
@@ -256,6 +267,21 @@ type BirdImageCache struct {
 	// name, so a dashboard asking for thirty uncached thumbnails schedules at
 	// most one fetch per species rather than one per request.
 	prefetching sync.Map
+	// recentAttempts maps a scientific name to the time.Time its last background
+	// resolution failed. It is the backoff the retry contract needs: the proxy
+	// answers 503 + Retry-After and the client polls, so without it every poll
+	// scheduled a fresh goroutine and a fresh provider attempt, and the retry
+	// rate was set by the client rather than by us.
+	recentAttempts sync.Map
+	// dbAbsent maps a scientific name to the time.Time a database read last found
+	// no row for it at all. It exists to keep the same client polling from
+	// costing one SQLite SELECT per poll for a species nothing is known about.
+	//
+	// Deliberately recorded only on that exact observation, and not on "a
+	// resolution is in progress": a species with a stale but perfectly servable
+	// row also has a refresh in flight, and suppressing its database read would
+	// answer 503 for an image we hold.
+	dbAbsent sync.Map
 	// prefetchQueued counts registered prefetches (queued plus running) so an
 	// unbounded species list cannot spawn an unbounded number of goroutines.
 	prefetchQueued atomic.Int64
@@ -321,7 +347,8 @@ const (
 	negativeEntryMarker = "__NOT_FOUND__"           // Special URL marker for negative cache entries
 
 	// Configuration constants
-	fallbackPolicyAll = "all" // Fallback policy to allow all providers
+	fallbackPolicyAll = "all"  // Fallback policy to allow all providers
+	providerAuto      = "auto" // Image provider setting meaning "pick one"
 
 	// Performance threshold constants
 	dbCacheLookupSlowThreshold = 50 * time.Millisecond  // Threshold for slow DB cache lookups
@@ -835,7 +862,6 @@ func (c *BirdImageCache) tryGo(fn func()) bool {
 func InitCache(providerName string, e ImageProvider, t *observability.Metrics, store datastore.Interface) *BirdImageCache {
 	log := GetLogger().With(logger.String("provider", providerName))
 	log.Info("Initializing image cache")
-	settings := conf.Setting()
 
 	quit := make(chan struct{})
 
@@ -849,7 +875,7 @@ func InitCache(providerName string, e ImageProvider, t *observability.Metrics, s
 	cache := &BirdImageCache{
 		providerName: providerName, // Set provider name
 		metrics:      imageProviderMetrics,
-		debug:        settings.Realtime.Dashboard.Thumbnails.Debug, // Keep for potential checks
+		debug:        thumbnailSettings().Debug, // Keep for potential checks
 		store:        store,
 		fileCache:    NewImageFileCache(imageCacheDir),
 		quit:         quit,
@@ -1162,14 +1188,27 @@ func (c *BirdImageCache) checkCachedEntryAfterLock(scientificName string, log lo
 		return BirdImage{}, false, false, nil
 	}
 
+	// Both positive and negative memory entries expire. Positive ones used to be
+	// returned unconditionally, so once a wrong image landed in dataMap nothing
+	// on the request path could re-derive it for the process lifetime, and
+	// clearing the DB cache still handed back the same wrong image. Expiring
+	// here falls through to the DB, which serves the row and schedules the
+	// refresh, so staleness is handled in exactly one place.
+	cutoff := time.Now().Add(-imgPtr.GetTTL())
+	expired := imgPtr.CachedAt.Before(cutoff)
+
 	if !imgPtr.IsNegativeEntry() {
+		if expired {
+			log.Debug("Memory cache entry expired, removing from memory")
+			c.dataMap.Delete(scientificName)
+			return BirdImage{}, false, false, nil
+		}
 		log.Debug("Initialization check: found in memory cache after acquiring lock")
 		return *imgPtr, true, false, nil
 	}
 
 	// Handle negative entry
-	cutoff := time.Now().Add(-imgPtr.GetTTL())
-	if imgPtr.CachedAt.Before(cutoff) {
+	if expired {
 		log.Debug("Negative cache entry expired, removing from memory")
 		c.dataMap.Delete(scientificName)
 		return BirdImage{}, false, false, nil
@@ -1466,6 +1505,14 @@ func (c *BirdImageCache) getCachedLocal(scientificName string) (img BirdImage, f
 		return memImg, true, false
 	}
 
+	// Nothing in memory, and a read a moment ago found no row either. Under the
+	// 503 + Retry-After contract the client polls, so without this every poll for
+	// a species nothing is known about costs its own SQLite SELECT: on a cold
+	// dashboard with ~20 unresolved species, several per second on a 1-core Pi.
+	if c.dbKnownAbsent(scientificName) {
+		return BirdImage{}, false, false
+	}
+
 	dbImage, dbErr := c.loadFromDBCache(scientificName)
 	if isRealError(dbErr) {
 		// Do not fold a DB fault into "no image": that answer is cached by the
@@ -1477,6 +1524,10 @@ func (c *BirdImageCache) getCachedLocal(scientificName string) (img BirdImage, f
 		return BirdImage{}, false, false
 	}
 	if dbImage == nil {
+		// Remember the miss so the client's polling does not repeat this read
+		// every few seconds.
+		c.recordDBAbsent(scientificName)
+
 		// Nothing is known yet. The exhausted marker is consulted only here, AFTER
 		// memory and the DB: it records that every provider failed within the TTL
 		// window, and it must never pre-empt a live cache entry for the species.
@@ -1485,6 +1536,9 @@ func (c *BirdImageCache) getCachedLocal(scientificName string) (img BirdImage, f
 		}
 		return BirdImage{}, false, false
 	}
+
+	// A row exists, so any earlier "no row" observation is stale.
+	c.dbAbsent.Delete(scientificName)
 
 	if dbImage.IsNegativeEntry() {
 		// An expired negative entry is not an answer; let the caller re-fetch.
@@ -1550,6 +1604,12 @@ func (c *BirdImageCache) PrefetchAsync(scientificName string) bool {
 	// bounding semaphore nor the cancellable parent context, so a prefetch there
 	// would be unbounded and un-stoppable. Decline rather than degrade.
 	if c.prefetchSem == nil || c.bgCtx == nil {
+		return false
+	}
+	// The previous attempt failed too recently to be worth repeating. Without
+	// this the client's retry schedule became the provider retry schedule, since
+	// nothing but a not-found answer was ever recorded.
+	if c.recentlyAttempted(scientificName) {
 		return false
 	}
 
@@ -1632,9 +1692,16 @@ func (c *BirdImageCache) runPrefetch(scientificName string, log logger.Logger) {
 
 	img, err := c.GetWithContext(ctx, scientificName)
 	if err != nil {
+		// A not-found answer is already durable in the negative cache; anything
+		// else is a failed attempt and needs its own short backoff, or the next
+		// client poll schedules an identical attempt immediately.
+		if !errors.Is(err, ErrImageNotFound) {
+			c.recordFailedAttempt(scientificName)
+		}
 		log.Debug("Background image prefetch did not resolve", logger.Error(err))
 		return
 	}
+	c.clearResolutionMarkers(scientificName)
 	if img.URL == "" || img.IsNegativeEntry() || c.fileCache == nil {
 		return
 	}
@@ -1847,21 +1914,14 @@ func (c *BirdImageCache) enhanceFetchError(fetchErr error, scientificName string
 		if _, hasName := enhancedErr.Context["scientific_name"]; hasName {
 			return enhancedErr
 		}
-		// Missing context — wrap in a new error preserving the original category
-		// to avoid changing CategoryNetwork to CategoryImageFetch (which would
-		// cause false positives in errors.Is(err, ErrImageNotFound))
-		return errors.New(fetchErr).
-			Component("imageprovider").
-			Category(enhancedErr.Category).
-			Context("provider", c.providerName).
-			Context("scientific_name", scientificName).
-			Context("operation", "provider_fetch").
-			Build()
 	}
-	// Plain error — wrap with full context
+
+	// Wrap with full context, preserving whatever category the cause carries so
+	// a CategoryNetwork throttle is not re-tagged as CategoryImageFetch (which
+	// would cause false positives in errors.Is(err, ErrImageNotFound)).
 	return errors.New(fetchErr).
 		Component("imageprovider").
-		Category(errors.CategoryImageFetch).
+		Category(causeCategory(fetchErr, errors.CategoryImageFetch)).
 		Context("provider", c.providerName).
 		Context("scientific_name", scientificName).
 		Context("operation", "provider_fetch").
@@ -2014,6 +2074,75 @@ func (c *BirdImageCache) isSpeciesExhausted(scientificName string) bool {
 	return true
 }
 
+// recentAttemptTTL bounds how often a species whose last background resolution
+// failed is attempted again, and how long a database miss for it is trusted.
+//
+// It is deliberately much shorter than negativeCacheTTL: a negative entry means
+// "the providers answered, and the answer is no image", which is durable, while
+// these markers mean "the attempt failed" and "there was no row a moment ago",
+// which are both usually transient.
+const recentAttemptTTL = 30 * time.Second
+
+// markerLive reports whether a marker map holds a timestamp for this species
+// that is still within recentAttemptTTL, expiring it lazily if not.
+func markerLive(markers *sync.Map, scientificName string) bool {
+	if scientificName == "" {
+		return false
+	}
+	v, ok := markers.Load(scientificName)
+	if !ok {
+		return false
+	}
+	stamp, ok := v.(time.Time)
+	if !ok {
+		// Defensive: unexpected type, drop the bogus entry.
+		markers.Delete(scientificName)
+		return false
+	}
+	if time.Since(stamp) > recentAttemptTTL {
+		markers.Delete(scientificName) // lazy expiration
+		return false
+	}
+	return true
+}
+
+// recordFailedAttempt notes that a background resolution for this species just
+// failed, so the next attempt is deferred by recentAttemptTTL.
+func (c *BirdImageCache) recordFailedAttempt(scientificName string) {
+	if scientificName == "" {
+		return
+	}
+	c.recentAttempts.Store(scientificName, time.Now())
+}
+
+// clearResolutionMarkers drops both short-lived markers after a resolution
+// succeeds, so neither the prefetch backoff nor the database-miss shortcut
+// outlives the condition it was recorded for.
+func (c *BirdImageCache) clearResolutionMarkers(scientificName string) {
+	c.recentAttempts.Delete(scientificName)
+	c.dbAbsent.Delete(scientificName)
+}
+
+// recentlyAttempted reports whether a background resolution for this species
+// failed within the backoff window.
+func (c *BirdImageCache) recentlyAttempted(scientificName string) bool {
+	return markerLive(&c.recentAttempts, scientificName)
+}
+
+// recordDBAbsent notes that a database read found no row for this species.
+func (c *BirdImageCache) recordDBAbsent(scientificName string) {
+	if scientificName == "" {
+		return
+	}
+	c.dbAbsent.Store(scientificName, time.Now())
+}
+
+// dbKnownAbsent reports whether a recent database read found no row for this
+// species, so the request path can answer "unresolved" without repeating it.
+func (c *BirdImageCache) dbKnownAbsent(scientificName string) bool {
+	return markerLive(&c.dbAbsent, scientificName)
+}
+
 // synthesizeExhaustedResponse returns the short-circuit response used when a
 // species is already known to be exhausted. It mirrors the value returned by
 // the primary-provider negative path so callers do not need to distinguish
@@ -2105,14 +2234,17 @@ func (c *BirdImageCache) tryFallbackProviders(ctx context.Context, scientificNam
 		//
 		// CORRECTNESS GATE: only record exhaustion when at least one
 		// fallback was actually tried AND every failure was an
-		// ErrImageNotFound. The caller (Get -> tryFallbackOnGetError) only
-		// invokes this function after the primary returned
-		// ErrImageNotFound, so by construction every observed error in
-		// this run is "not found" when allFallbacksNotFound is true.
-		// Without this gate, a transient outage on a fallback (network
-		// timeout, DB error, provider init failure) would mask the
-		// species for the full TTL window, hiding real issues and
-		// suppressing legitimate retries.
+		// ErrImageNotFound.
+		//
+		// The gate cannot be relaxed on the premise that the primary already
+		// returned ErrImageNotFound: Get calls tryFallbackOnGetError for any
+		// primary error, not only a not-found one. Only the sole consumer's own
+		// additional check keeps that premise true today, so the gate is what
+		// actually guarantees it here.
+		//
+		// Without it, a transient outage on a fallback (network timeout, DB
+		// error, provider init failure) would mask the species for the full TTL
+		// window, hiding real issues and suppressing legitimate retries.
 		if anyFallbackTried && allFallbacksNotFound {
 			c.recordSpeciesExhausted(scientificName)
 		}

--- a/internal/imageprovider/imageprovider.go
+++ b/internal/imageprovider/imageprovider.go
@@ -126,7 +126,7 @@ func thumbnailSettings() conf.Thumbnails {
 // normalizedFallbackPolicy reads the configured fallback policy, trimmed and
 // lowercased, so that "All" or a stray trailing space is not read as "off".
 func normalizedFallbackPolicy() string {
-	return strings.ToLower(strings.TrimSpace(thumbnailSettings().FallbackPolicy))
+	return normalizeProviderName(thumbnailSettings().FallbackPolicy)
 }
 
 // normalizeProviderName folds a configured provider name for comparison.
@@ -653,6 +653,22 @@ func (c *BirdImageCache) processStaleEntriesInBatches(staleEntries []string) {
 			}
 			c.refreshEntry(scientificName)
 		}
+	}
+}
+
+// scheduleRefresh registers a background refresh for a species already served
+// from cache, deduplicated against any prefetch already in flight. The dedup
+// entry is rolled back if the goroutine could not be started, so a species is
+// never left marked as refreshing when nothing is.
+func (c *BirdImageCache) scheduleRefresh(scientificName string) {
+	if _, alreadyQueued := c.prefetching.LoadOrStore(scientificName, struct{}{}); alreadyQueued {
+		return
+	}
+	if !c.tryGo(func() {
+		defer c.prefetching.Delete(scientificName)
+		c.refreshEntry(scientificName)
+	}) {
+		c.prefetching.Delete(scientificName)
 	}
 }
 
@@ -1520,6 +1536,15 @@ func (c *BirdImageCache) getCachedLocal(scientificName string) (img BirdImage, f
 	case isNegativeEntry:
 		return BirdImage{}, false, true
 	case foundInMemory:
+		// Serving a stale entry without scheduling its refresh would leave a
+		// wrong image resident for the process lifetime, which is the whole
+		// condition the memory TTL exists to end. Both sibling sites that serve
+		// a stale positive pair it with this same scheduling.
+		if isCacheEntryStale(memImg.CachedAt, false) {
+			log.Debug("Serving a stale memory cache entry and refreshing it in the background",
+				logger.Time("cached_at", memImg.CachedAt))
+			c.scheduleRefresh(scientificName)
+		}
 		return memImg, true, false
 	}
 
@@ -1607,15 +1632,7 @@ func (c *BirdImageCache) getCachedLocal(scientificName string) (img BirdImage, f
 	if isCacheEntryStale(dbImage.CachedAt, false) {
 		log.Debug("Serving a stale DB cache entry and refreshing it in the background",
 			logger.Time("cached_at", dbImage.CachedAt))
-		if _, alreadyQueued := c.prefetching.LoadOrStore(scientificName, struct{}{}); !alreadyQueued {
-			scheduled := c.tryGo(func() {
-				defer c.prefetching.Delete(scientificName)
-				c.refreshEntry(scientificName)
-			})
-			if !scheduled {
-				c.prefetching.Delete(scientificName)
-			}
-		}
+		c.scheduleRefresh(scientificName)
 	}
 
 	return *dbImage, true, false
@@ -1730,11 +1747,13 @@ func (c *BirdImageCache) runPrefetch(scientificName string, log logger.Logger) {
 		// else is a failed attempt and needs its own short backoff, or the next
 		// client poll schedules an identical attempt immediately.
 		//
-		// Except a context error: ctx here is bgCtx plus prefetchTimeout, so a
-		// cancellation means this cache is shutting down, not that the species
-		// is hard to resolve, and recording it would back the species off for
-		// the first 30 seconds of the next run.
-		if ctx.Err() == nil && !errors.Is(err, ErrImageNotFound) {
+		// Cancellation, and only cancellation, is exempt: ctx is bgCtx plus
+		// prefetchTimeout, so a Canceled means this cache is shutting down and
+		// recording it would back the species off for the first 30 seconds of
+		// the next run. A DeadlineExceeded is the opposite case - the provider
+		// chain took longer than prefetchTimeout, which is a hung or throttled
+		// upstream and precisely what the backoff is for.
+		if !errors.Is(ctx.Err(), context.Canceled) && !errors.Is(err, ErrImageNotFound) {
 			c.recordFailedAttempt(scientificName)
 		}
 		log.Debug("Background image prefetch did not resolve", logger.Error(err))
@@ -1826,15 +1845,7 @@ func (c *BirdImageCache) handleDBCacheHit(scientificName string, dbImage *BirdIm
 	if isCacheEntryStale(dbImage.CachedAt, false) {
 		log.Debug("DB cache entry is stale, returning stale data and triggering background refresh",
 			logger.Time("cached_at", dbImage.CachedAt))
-		if _, alreadyQueued := c.prefetching.LoadOrStore(scientificName, struct{}{}); !alreadyQueued {
-			scheduled := c.tryGo(func() {
-				defer c.prefetching.Delete(scientificName)
-				c.refreshEntry(scientificName)
-			})
-			if !scheduled {
-				c.prefetching.Delete(scientificName)
-			}
-		}
+		c.scheduleRefresh(scientificName)
 	} else {
 		log.Debug("Image loaded from DB cache")
 	}
@@ -2160,9 +2171,13 @@ func markerLive(markers *sync.Map, scientificName string) bool {
 // accounting and cannot itself become a source of error.
 const maxMarkerEntries = 8192
 
-// recordMarker stamps a marker map, clearing it first if it has grown past the
-// bound. count tracks insertions since the last clear rather than live size, so
-// it is an upper bound on the entries retained, which is all the bound needs.
+// recordMarker stamps a marker map, clearing it whole once the insertion count
+// since the last clear passes the bound.
+//
+// count is not the live size: deletions do not decrement it, and concurrent
+// callers can both trip the bound and clear. So the map is kept near the bound
+// rather than strictly under it, which is all that is needed here, since both
+// markers are optimizations whose loss costs one database read.
 func recordMarker(markers *sync.Map, count *atomic.Int64, scientificName string) {
 	if scientificName == "" {
 		return

--- a/internal/imageprovider/imageprovider.go
+++ b/internal/imageprovider/imageprovider.go
@@ -306,6 +306,9 @@ type BirdImageCache struct {
 	// prefetchQueued counts registered prefetches (queued plus running) so an
 	// unbounded species list cannot spawn an unbounded number of goroutines.
 	prefetchQueued atomic.Int64
+	// refreshQueued does the same for background refreshes of entries that were
+	// served from cache. See maxQueuedRefreshes for why it is a separate budget.
+	refreshQueued atomic.Int64
 	// prefetchSem bounds how many prefetches contact a provider at once. The
 	// providers are themselves rate limited, so a small number is enough to keep
 	// the pipeline busy without piling up connections.
@@ -656,18 +659,41 @@ func (c *BirdImageCache) processStaleEntriesInBatches(staleEntries []string) {
 	}
 }
 
+// maxQueuedRefreshes bounds background refreshes of entries that were served
+// from cache.
+//
+// Refreshes do not pass through the prefetch semaphore, so without a bound a
+// dashboard rendering many stale species spawns one goroutine per species, each
+// parked on the provider's global rate limiter. The bound is separate from
+// maxQueuedPrefetches rather than shared with it so a burst of refreshes cannot
+// starve the prefetches that resolve species nothing is known about, which are
+// what a user is actually waiting on.
+const maxQueuedRefreshes = 64
+
 // scheduleRefresh registers a background refresh for a species already served
 // from cache, deduplicated against any prefetch already in flight. The dedup
-// entry is rolled back if the goroutine could not be started, so a species is
-// never left marked as refreshing when nothing is.
+// entry and the queue slot are both rolled back if the goroutine could not be
+// started, so a species is never left marked as refreshing when nothing is.
+//
+// Declining is safe: the entry was served, and the hourly sweep and the next
+// request both remain able to refresh it.
 func (c *BirdImageCache) scheduleRefresh(scientificName string) {
 	if _, alreadyQueued := c.prefetching.LoadOrStore(scientificName, struct{}{}); alreadyQueued {
 		return
 	}
+	if c.refreshQueued.Add(1) > maxQueuedRefreshes {
+		c.refreshQueued.Add(-1)
+		c.prefetching.Delete(scientificName)
+		return
+	}
 	if !c.tryGo(func() {
-		defer c.prefetching.Delete(scientificName)
+		defer func() {
+			c.refreshQueued.Add(-1)
+			c.prefetching.Delete(scientificName)
+		}()
 		c.refreshEntry(scientificName)
 	}) {
+		c.refreshQueued.Add(-1)
 		c.prefetching.Delete(scientificName)
 	}
 }

--- a/internal/imageprovider/imageprovider.go
+++ b/internal/imageprovider/imageprovider.go
@@ -129,6 +129,22 @@ func normalizedFallbackPolicy() string {
 	return strings.ToLower(strings.TrimSpace(thumbnailSettings().FallbackPolicy))
 }
 
+// normalizeProviderName folds a configured provider name for comparison.
+func normalizeProviderName(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
+// normalizedImageProvider reads the configured image provider, folded.
+//
+// It exists for the same reason as normalizedFallbackPolicy: the fetch gate and
+// the refresh gate must agree about which provider is configured, and they
+// previously each folded the field their own way. The refresh gate has to stay
+// a subset of the fetch gate, and two independent normalizations are how that
+// relationship silently breaks.
+func normalizedImageProvider() string {
+	return normalizeProviderName(thumbnailSettings().ImageProvider)
+}
+
 // fetchFromProvider calls the provider's context-aware Fetch when it has one and falls
 // back to the context-free Fetch otherwise. Without this, a cancelled caller still
 // waits out the provider's full retry and rate-limit budget.
@@ -282,6 +298,11 @@ type BirdImageCache struct {
 	// row also has a refresh in flight, and suppressing its database read would
 	// answer 503 for an image we hold.
 	dbAbsent sync.Map
+	// recentAttemptsCount and dbAbsentCount count insertions since each map was
+	// last cleared, so the maps can be bounded without per-entry accounting.
+	// See maxMarkerEntries for why a bound is needed at all.
+	recentAttemptsCount atomic.Int64
+	dbAbsentCount       atomic.Int64
 	// prefetchQueued counts registered prefetches (queued plus running) so an
 	// unbounded species list cannot spawn an unbounded number of goroutines.
 	prefetchQueued atomic.Int64
@@ -1188,21 +1209,18 @@ func (c *BirdImageCache) checkCachedEntryAfterLock(scientificName string, log lo
 		return BirdImage{}, false, false, nil
 	}
 
-	// Both positive and negative memory entries expire. Positive ones used to be
-	// returned unconditionally, so once a wrong image landed in dataMap nothing
-	// on the request path could re-derive it for the process lifetime, and
-	// clearing the DB cache still handed back the same wrong image. Expiring
-	// here falls through to the DB, which serves the row and schedules the
-	// refresh, so staleness is handled in exactly one place.
 	cutoff := time.Now().Add(-imgPtr.GetTTL())
 	expired := imgPtr.CachedAt.Before(cutoff)
 
 	if !imgPtr.IsNegativeEntry() {
-		if expired {
-			log.Debug("Memory cache entry expired, removing from memory")
-			c.dataMap.Delete(scientificName)
-			return BirdImage{}, false, false, nil
-		}
+		// A stale positive entry is still served, exactly as a stale DB row is;
+		// the caller schedules the refresh that re-derives it. Deleting it here
+		// instead would make every request for a species older than the TTL pay
+		// a fresh SQLite read, because the DB row is the same age and gets
+		// promoted back into memory with the same timestamp, so the next lookup
+		// expires it again. That loop never converges while the provider is
+		// unreachable, and on a store-less or corruption-latched cache it would
+		// discard the only copy of the image the process has.
 		log.Debug("Initialization check: found in memory cache after acquiring lock")
 		return *imgPtr, true, false, nil
 	}
@@ -1509,7 +1527,17 @@ func (c *BirdImageCache) getCachedLocal(scientificName string) (img BirdImage, f
 	// 503 + Retry-After contract the client polls, so without this every poll for
 	// a species nothing is known about costs its own SQLite SELECT: on a cold
 	// dashboard with ~20 unresolved species, several per second on a 1-core Pi.
+	//
+	// The exhausted marker is re-checked here rather than skipped with the read.
+	// It is the one verdict the shortcut can lose: it is consulted inside the
+	// no-row branch below, so bypassing that branch would turn a definitive "no
+	// image" (404, cacheable) into "not resolved yet" (503 + a scheduled
+	// prefetch) for the marker's lifetime, and would skip GetCached's fallback
+	// sweep, which runs only on a negative verdict.
 	if c.dbKnownAbsent(scientificName) {
+		if c.isSpeciesExhausted(scientificName) {
+			return BirdImage{}, false, true
+		}
 		return BirdImage{}, false, false
 	}
 
@@ -1525,8 +1553,14 @@ func (c *BirdImageCache) getCachedLocal(scientificName string) (img BirdImage, f
 	}
 	if dbImage == nil {
 		// Remember the miss so the client's polling does not repeat this read
-		// every few seconds.
-		c.recordDBAbsent(scientificName)
+		// every few seconds. Only a genuine "the database answered, and it holds
+		// no row" counts: loadFromDBCache also reports a miss when it did not
+		// consult the database at all (shutting down, corruption latched, no
+		// store configured), and recording those would assert an observation
+		// that never happened and would re-arm the marker on every lookup.
+		if c.dbWasConsulted() {
+			c.recordDBAbsent(scientificName)
+		}
 
 		// Nothing is known yet. The exhausted marker is consulted only here, AFTER
 		// memory and the DB: it records that every provider failed within the TTL
@@ -1695,7 +1729,12 @@ func (c *BirdImageCache) runPrefetch(scientificName string, log logger.Logger) {
 		// A not-found answer is already durable in the negative cache; anything
 		// else is a failed attempt and needs its own short backoff, or the next
 		// client poll schedules an identical attempt immediately.
-		if !errors.Is(err, ErrImageNotFound) {
+		//
+		// Except a context error: ctx here is bgCtx plus prefetchTimeout, so a
+		// cancellation means this cache is shutting down, not that the species
+		// is hard to resolve, and recording it would back the species off for
+		// the first 30 seconds of the next run.
+		if ctx.Err() == nil && !errors.Is(err, ErrImageNotFound) {
 			c.recordFailedAttempt(scientificName)
 		}
 		log.Debug("Background image prefetch did not resolve", logger.Error(err))
@@ -2106,13 +2145,39 @@ func markerLive(markers *sync.Map, scientificName string) bool {
 	return true
 }
 
-// recordFailedAttempt notes that a background resolution for this species just
-// failed, so the next attempt is deferred by recentAttemptTTL.
-func (c *BirdImageCache) recordFailedAttempt(scientificName string) {
+// maxMarkerEntries bounds each marker map.
+//
+// The keys are scientific names supplied by the caller: the media endpoints
+// hand the client's string straight to GetCached and PrefetchAsync, so the key
+// space is request traffic rather than the model's label set, and a marker map
+// with only lazy expiry would grow at request rate. Measured at ~150 B per
+// distinct name, an unbounded map reaches ~100 MB in 250k distinct requests,
+// which a 512 MB target does not survive.
+//
+// Both markers are pure optimizations: declining to record one, or dropping the
+// whole set, only costs a database read or an earlier retry. So the bound is
+// enforced by clearing rather than by evicting, which needs no per-entry
+// accounting and cannot itself become a source of error.
+const maxMarkerEntries = 8192
+
+// recordMarker stamps a marker map, clearing it first if it has grown past the
+// bound. count tracks insertions since the last clear rather than live size, so
+// it is an upper bound on the entries retained, which is all the bound needs.
+func recordMarker(markers *sync.Map, count *atomic.Int64, scientificName string) {
 	if scientificName == "" {
 		return
 	}
-	c.recentAttempts.Store(scientificName, time.Now())
+	if count.Add(1) > maxMarkerEntries {
+		markers.Clear()
+		count.Store(1)
+	}
+	markers.Store(scientificName, time.Now())
+}
+
+// recordFailedAttempt notes that a background resolution for this species just
+// failed, so the next attempt is deferred by recentAttemptTTL.
+func (c *BirdImageCache) recordFailedAttempt(scientificName string) {
+	recordMarker(&c.recentAttempts, &c.recentAttemptsCount, scientificName)
 }
 
 // clearResolutionMarkers drops both short-lived markers after a resolution
@@ -2129,12 +2194,17 @@ func (c *BirdImageCache) recentlyAttempted(scientificName string) bool {
 	return markerLive(&c.recentAttempts, scientificName)
 }
 
+// dbWasConsulted reports whether a database read could actually have reached the
+// store. loadFromDBCache reports the same ErrCacheMiss whether the row is
+// genuinely absent or the read never happened, and only the former is an
+// observation about the species.
+func (c *BirdImageCache) dbWasConsulted() bool {
+	return c.store != nil && !c.closed.Load() && !c.dbCorrupted.Load()
+}
+
 // recordDBAbsent notes that a database read found no row for this species.
 func (c *BirdImageCache) recordDBAbsent(scientificName string) {
-	if scientificName == "" {
-		return
-	}
-	c.dbAbsent.Store(scientificName, time.Now())
+	recordMarker(&c.dbAbsent, &c.dbAbsentCount, scientificName)
 }
 
 // dbKnownAbsent reports whether a recent database read found no row for this
@@ -2266,9 +2336,12 @@ func (img *BirdImage) EstimateSize() int {
 	return size
 }
 
-// MemoryUsage estimates the total memory usage of the cache maps.
-// Includes both the per-species image data map and the exhausted-species
-// short-circuit map so cache metrics reflect the full footprint.
+// MemoryUsage estimates the total memory usage of the cache's per-species maps:
+// the image data map plus the three timestamp maps (exhausted species, and the
+// two short-lived resolution markers).
+//
+// The in-flight bookkeeping maps (initializing, prefetching) are not counted;
+// they hold only entries for work currently in progress.
 func (c *BirdImageCache) MemoryUsage() int {
 	totalSize := 0
 	c.dataMap.Range(func(key, value any) bool {
@@ -2280,16 +2353,18 @@ func (c *BirdImageCache) MemoryUsage() int {
 		}
 		return true
 	})
-	c.exhaustedSpecies.Range(func(key, value any) bool {
-		if scientificName, ok := key.(string); ok {
-			totalSize += len(scientificName)
-		}
-		// Each entry stores a time.Time (24 bytes on 64-bit). Use a constant
-		// here to avoid an unsafe.Sizeof import for one constant value.
-		const timeStructBytes = 24
-		totalSize += timeStructBytes
-		return true
-	})
+	// Each timestamp map entry stores a time.Time (24 bytes on 64-bit). Use a
+	// constant here to avoid an unsafe.Sizeof import for one constant value.
+	const timeStructBytes = 24
+	for _, markers := range []*sync.Map{&c.exhaustedSpecies, &c.recentAttempts, &c.dbAbsent} {
+		markers.Range(func(key, value any) bool {
+			if scientificName, ok := key.(string); ok {
+				totalSize += len(scientificName)
+			}
+			totalSize += timeStructBytes
+			return true
+		})
+	}
 	return totalSize
 }
 

--- a/internal/imageprovider/imageprovider_bench_test.go
+++ b/internal/imageprovider/imageprovider_bench_test.go
@@ -346,16 +346,17 @@ func BenchmarkCacheRefreshCycle(b *testing.B) {
 		}
 	}
 
-	cache, err := imageprovider.CreateDefaultCache(metrics, mockStore)
-	if err != nil {
-		b.Fatalf("Failed to create cache: %v", err)
-	}
+	// InitCache with the mock already installed, not CreateDefaultCache followed
+	// by SetImageProvider: the refresh goroutine starts immediately, and if it
+	// reaches shouldSkipRefresh while the lazy Wikipedia provider is still in
+	// place it returns and does not run again for an hour, so the poll below
+	// would never see a fetch. Same reason TestBirdImageCacheRefresh gives.
+	cache := imageprovider.InitCache("wikimedia", mockProvider, metrics, mockStore)
 	defer func() {
 		if err := cache.Close(); err != nil {
 			b.Errorf("Failed to close cache: %v", err)
 		}
 	}()
-	cache.SetImageProvider(mockProvider)
 
 	// Wait until the refresh cycle has actually started working rather than
 	// sleeping for a duration guessed from refreshDelay. The sweep waits

--- a/internal/imageprovider/imageprovider_bench_test.go
+++ b/internal/imageprovider/imageprovider_bench_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
@@ -125,7 +127,7 @@ func BenchmarkCacheMissWithDBHit(b *testing.B) {
 		if err := mockStore.SaveImageCache(&datastore.ImageCache{
 			ScientificName: species,
 			ProviderName:   "wikimedia",
-			URL:            fmt.Sprintf("http://example.com/%s.jpg", species),
+			URL:            fmt.Sprintf("http://127.0.0.1/%s.jpg", species),
 			CachedAt:       time.Now(),
 		}); err != nil {
 			b.Fatalf("Failed to pre-populate DB store: %v", err)
@@ -256,19 +258,6 @@ func BenchmarkRateLimitedFetch(b *testing.B) {
 		b.Fatalf("Failed to create WikiMedia provider: %v", err)
 	}
 
-	mockStore := newMockStore()
-	metrics, err := observability.NewMetrics()
-	if err != nil {
-		b.Fatalf("Failed to create metrics: %v", err)
-	}
-
-	cache := imageprovider.InitCache("wikimedia", provider, metrics, mockStore)
-	defer func() {
-		if err := cache.Close(); err != nil {
-			b.Errorf("Failed to close cache: %v", err)
-		}
-	}()
-
 	// Test species that are likely to exist in Wikipedia
 	testSpecies := []string{
 		"Turdus merula",
@@ -350,7 +339,7 @@ func BenchmarkCacheRefreshCycle(b *testing.B) {
 		if err := mockStore.SaveImageCache(&datastore.ImageCache{
 			ScientificName: species,
 			ProviderName:   "wikimedia",
-			URL:            fmt.Sprintf("http://example.com/old_%s.jpg", species),
+			URL:            fmt.Sprintf("http://127.0.0.1/old_%s.jpg", species),
 			CachedAt:       staleTime,
 		}); err != nil {
 			b.Fatalf("Failed to save stale cache entry: %v", err)
@@ -368,8 +357,13 @@ func BenchmarkCacheRefreshCycle(b *testing.B) {
 	}()
 	cache.SetImageProvider(mockProvider)
 
-	// Let refresh cycle run
-	time.Sleep(2 * time.Second)
+	// Wait until the refresh cycle has actually started working rather than
+	// sleeping for a duration guessed from refreshDelay. The sweep waits
+	// refreshDelay (2s) before each entry, so the first fetch lands just past
+	// that; poll for it with headroom instead of racing the boundary.
+	require.Eventually(b, func() bool { return mockProvider.getFetchCount() > 0 },
+		10*time.Second, 50*time.Millisecond,
+		"the background refresh sweep should have started fetching stale entries")
 
 	b.ReportAllocs()
 

--- a/internal/imageprovider/imageprovider_test.go
+++ b/internal/imageprovider/imageprovider_test.go
@@ -991,11 +991,14 @@ func TestUserRequestsNotRateLimited(t *testing.T) {
 
 	duration := time.Since(start)
 
-	// If rate limiting was applied (2 req/s), 10 requests would take at least 5 seconds.
-	// This bound catches rate limiting on the user-request path; the provider is a 1ms mock, so it is a coarse ceiling.
-	assert.LessOrEqual(t, duration, 30*time.Second, "User requests appear to be rate limited. Duration: %v, expected < 30s", duration)
+	// Rate limiting at 2 req/s would put 10 requests at 5 seconds or more, so the
+	// bound has to sit below that to detect it at all. The provider is a 1ms
+	// mock, so the real figure is milliseconds and 4s is pure CI headroom.
+	const rateLimitDetectionBound = 4 * time.Second
+	assert.LessOrEqual(t, duration, rateLimitDetectionBound,
+		"User requests appear to be rate limited. Duration: %v, expected < %v", duration, rateLimitDetectionBound)
 
-	t.Logf("10 user requests completed in %v (no rate limiting, threshold: 4s)", duration)
+	t.Logf("10 user requests completed in %v (no rate limiting, threshold: %v)", duration, rateLimitDetectionBound)
 }
 
 // populateStaleEntries adds stale cache entries to the store to trigger background refresh.

--- a/internal/imageprovider/imageprovider_test.go
+++ b/internal/imageprovider/imageprovider_test.go
@@ -63,7 +63,7 @@ func (m *mockImageProvider) Fetch(scientificName string) (imageprovider.BirdImag
 	}
 
 	// Generate consistent URL for the same fetch count
-	url := fmt.Sprintf("http://example.com/%s_%d.jpg", scientificName, currentCount)
+	url := fmt.Sprintf("http://127.0.0.1/%s_%d.jpg", scientificName, currentCount)
 
 	m.mu.Lock()
 	m.lastURL = url
@@ -75,7 +75,7 @@ func (m *mockImageProvider) Fetch(scientificName string) (imageprovider.BirdImag
 		LicenseName:    "CC BY-SA 4.0",
 		LicenseURL:     "https://creativecommons.org/licenses/by-sa/4.0/",
 		AuthorName:     fmt.Sprintf("Mock Author %d", currentCount),
-		AuthorURL:      "http://example.com/author",
+		AuthorURL:      "http://127.0.0.1/author",
 		CachedAt:       time.Now(),
 	}, nil
 }
@@ -101,11 +101,26 @@ func (m *mockStore) GetAllTestEntries() []*datastore.ImageCache {
 }
 
 // Implement only the methods we need for testing
+// copyImageCache returns a copy of a stored mock row so callers cannot mutate
+// the mock database in place.
+func copyImageCache(img *datastore.ImageCache) *datastore.ImageCache {
+	if img == nil {
+		return nil
+	}
+	cp := *img
+	return &cp
+}
+
 func (m *mockStore) GetImageCache(query datastore.ImageCacheQuery) (*datastore.ImageCache, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	if img, ok := m.images[query.ScientificName+"_"+query.ProviderName]; ok {
-		return img, nil
+		// Copy: SaveImageCache copies on write, but handing out the stored
+		// pointer let code under test mutate this mock DB row in place. That
+		// matters now that the negative-cache tests assert exact DB-vs-provider
+		// call counts, and a background refresh mutating the returned struct
+		// while the test reads it is a latent -race hit.
+		return copyImageCache(img), nil
 	}
 	return nil, datastore.ErrImageCacheNotFound
 }
@@ -160,7 +175,7 @@ func (m *mockStore) GetImageCacheBatch(providerName string, scientificNames []st
 	for _, name := range scientificNames {
 		key := name + "_" + providerName
 		if img, exists := m.images[key]; exists {
-			result[name] = img
+			result[name] = copyImageCache(img)
 		}
 	}
 
@@ -613,11 +628,11 @@ func TestCreateDefaultCache(t *testing.T) {
 func TestBirdImageEstimateSize(t *testing.T) {
 	t.Parallel()
 	img := imageprovider.BirdImage{
-		URL:         "http://example.com/bird.jpg",
+		URL:         "http://127.0.0.1/bird.jpg",
 		LicenseName: "CC BY-SA 4.0",
 		LicenseURL:  "https://creativecommons.org/licenses/by-sa/4.0/",
 		AuthorName:  "Test Author",
-		AuthorURL:   "http://example.com/author",
+		AuthorURL:   "http://127.0.0.1/author",
 		CachedAt:    time.Now(),
 	}
 
@@ -733,11 +748,11 @@ func TestBirdImageCacheRefresh(t *testing.T) {
 	// Create a cache entry that's older than TTL
 	oldEntry := &datastore.ImageCache{
 		ScientificName: "Turdus merula",
-		URL:            "http://example.com/old.jpg",
+		URL:            "http://127.0.0.1/old.jpg",
 		LicenseName:    "CC BY-SA 4.0",
 		LicenseURL:     "https://creativecommons.org/licenses/by-sa/4.0/",
 		AuthorName:     "Old Author",
-		AuthorURL:      "http://example.com/old-author",
+		AuthorURL:      "http://127.0.0.1/old-author",
 		CachedAt:       time.Now().Add(-31 * 24 * time.Hour), // 31 days old
 		ProviderName:   "wikimedia",                          // Add provider name to match the default cache provider
 	}
@@ -976,10 +991,9 @@ func TestUserRequestsNotRateLimited(t *testing.T) {
 
 	duration := time.Since(start)
 
-	// If rate limiting was applied (2 req/s), 10 requests would take at least 5 seconds
-	// Without rate limiting, it should complete much faster (allowing for actual API latency)
-	// Increase timeout to 4 seconds to account for network variability
-	assert.LessOrEqual(t, duration, 4*time.Second, "User requests appear to be rate limited. Duration: %v, expected < 4s", duration)
+	// If rate limiting was applied (2 req/s), 10 requests would take at least 5 seconds.
+	// This bound catches rate limiting on the user-request path; the provider is a 1ms mock, so it is a coarse ceiling.
+	assert.LessOrEqual(t, duration, 30*time.Second, "User requests appear to be rate limited. Duration: %v, expected < 30s", duration)
 
 	t.Logf("10 user requests completed in %v (no rate limiting, threshold: 4s)", duration)
 }
@@ -993,7 +1007,7 @@ func populateStaleEntries(t *testing.T, store *mockStore, count int) {
 		err := store.SaveImageCache(&datastore.ImageCache{
 			ScientificName: species,
 			ProviderName:   "wikimedia",
-			URL:            fmt.Sprintf("http://example.com/old_%s.jpg", species),
+			URL:            fmt.Sprintf("http://127.0.0.1/old_%s.jpg", species),
 			CachedAt:       staleTime,
 		})
 		require.NoError(t, err, "Failed to save stale cache entry")

--- a/internal/imageprovider/lookup_correctness_test.go
+++ b/internal/imageprovider/lookup_correctness_test.go
@@ -1,0 +1,405 @@
+// lookup_correctness_test.go covers the Wikipedia lookup contract: which answers
+// count as "this species has no image" and which do not.
+//
+// The distinction is load-bearing. A not-found verdict is persisted as a
+// negative cache entry, so classifying a transient provider failure as one marks
+// the species image-less for the whole negative TTL, and classifying a
+// redirect-to-genus as a success caches an image of the wrong bird.
+package imageprovider
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/conf/conftest"
+	"github.com/tphakala/birdnet-go/internal/errors"
+)
+
+// writeJSON is the shape every MediaWiki stub in this file answers with.
+func writeJSON(w http.ResponseWriter, body string) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(body))
+}
+
+// TestRedirectLeftSpecies is the unit-level half of root cause C2.
+//
+// Redirect following has to stay on, because most bird articles are titled by
+// common name and a scientific name only resolves through its redirect. What
+// must not pass is a redirect up the taxonomy: Wikipedia sends a species with no
+// article of its own to its genus or family article, whose pageimage is
+// routinely a distribution map or a congener.
+func TestRedirectLeftSpecies(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		species    string
+		redirects  []wikiRedirect
+		wantLeft   bool
+		wantTarget string
+	}{
+		{
+			name:    "no redirect",
+			species: "Turdus merula",
+		},
+		{
+			name:      "common-name article is what redirects are for",
+			species:   "Turdus merula",
+			redirects: []wikiRedirect{{From: "Turdus merula", To: "Common blackbird"}},
+		},
+		{
+			name:      "single-word common name",
+			species:   "Opisthocomus hoazin",
+			redirects: []wikiRedirect{{From: "Opisthocomus hoazin", To: "Hoatzin"}},
+		},
+		{
+			name:       "genus article",
+			species:    "Delichon urbicum",
+			redirects:  []wikiRedirect{{From: "Delichon urbicum", To: "Delichon"}},
+			wantLeft:   true,
+			wantTarget: "Delichon",
+		},
+		{
+			name:       "family article",
+			species:    "Delichon urbicum",
+			redirects:  []wikiRedirect{{From: "Delichon urbicum", To: "Hirundinidae"}},
+			wantLeft:   true,
+			wantTarget: "Hirundinidae",
+		},
+		{
+			name:       "subfamily article",
+			species:    "Delichon urbicum",
+			redirects:  []wikiRedirect{{From: "Delichon urbicum", To: "Hirundininae"}},
+			wantLeft:   true,
+			wantTarget: "Hirundininae",
+		},
+		{
+			name:       "order article",
+			species:    "Delichon urbicum",
+			redirects:  []wikiRedirect{{From: "Delichon urbicum", To: "Passeriformes"}},
+			wantLeft:   true,
+			wantTarget: "Passeriformes",
+		},
+		{
+			name:      "underscores and case are title syntax, not a different page",
+			species:   "Turdus merula",
+			redirects: []wikiRedirect{{From: "Turdus_merula", To: "Common_blackbird"}},
+		},
+		{
+			name:    "chained redirect ending on the genus",
+			species: "Delichon urbica",
+			redirects: []wikiRedirect{
+				{From: "Delichon urbica", To: "Delichon urbicum"},
+				{From: "Delichon urbicum", To: "Delichon"},
+			},
+			wantLeft:   true,
+			wantTarget: "Delichon",
+		},
+		{
+			name:      "a synonym redirect to another binomial is fine",
+			species:   "Delichon urbica",
+			redirects: []wikiRedirect{{From: "Delichon urbica", To: "Delichon urbicum"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			target, left := redirectLeftSpecies(tt.species, tt.redirects)
+			assert.Equal(t, tt.wantLeft, left, "redirect verdict for %q", tt.species)
+			assert.Equal(t, tt.wantTarget, target)
+		})
+	}
+}
+
+// TestQueryThumbnail_RedirectToGenusIsNotAnImage is the end-to-end half of C2.
+//
+// The lookup succeeds at the HTTP level, which is exactly why this was so
+// durable: a positive entry was written, and the taxonomy-synonym map, which is
+// only consulted on failure, never got a chance to correct it.
+func TestQueryThumbnail_RedirectToGenusIsNotAnImage(t *testing.T) {
+	t.Parallel()
+
+	provider := newTestWikiProvider(t, func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, `{"query":{
+			"redirects":[{"from":"Delichon urbicum","to":"Delichon"}],
+			"pages":[{"title":"Delichon","pageimage":"Delichon_distribution.png",
+			          "thumbnail":{"source":"https://example.invalid/map.png"}}]}}`)
+	})
+
+	url, file, err := provider.queryThumbnail(t.Context(), "test", "Delichon urbicum", nil)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrImageNotFound,
+		"a genus article's image is not this species' image, and the synonym retry only runs on not-found")
+	assert.Empty(t, url)
+	assert.Empty(t, file)
+}
+
+// TestQueryThumbnail_MissingPageImageStillYieldsTheThumbnail covers the discarded
+// thumbnail: pageimage is only the key for the second, attribution query, and the
+// caller already falls back to "Unknown" attribution.
+func TestQueryThumbnail_MissingPageImageStillYieldsTheThumbnail(t *testing.T) {
+	t.Parallel()
+
+	provider := newTestWikiProvider(t, func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, `{"query":{"pages":[{"title":"Turdus merula",
+			"thumbnail":{"source":"https://example.invalid/blackbird.jpg"}}]}}`)
+	})
+
+	url, file, err := provider.queryThumbnail(t.Context(), "test", "Turdus merula", nil)
+
+	require.NoError(t, err, "a usable free thumbnail must not be thrown away for want of an attribution key")
+	assert.Equal(t, "https://example.invalid/blackbird.jpg", url)
+	assert.Empty(t, file, "no pageimage means no file page to ask for attribution")
+}
+
+// TestFetch_MissingPageImageUsesUnknownAttribution checks the whole fetch, since
+// the attribution query has to be skipped rather than failed.
+func TestFetch_MissingPageImageUsesUnknownAttribution(t *testing.T) {
+	t.Parallel()
+
+	var requests int
+	provider := newTestWikiProvider(t, func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		writeJSON(w, `{"query":{"pages":[{"title":"Turdus merula",
+			"thumbnail":{"source":"https://example.invalid/blackbird.jpg"}}]}}`)
+	})
+
+	img, err := provider.fetchWithLimiter(t.Context(), "Turdus merula", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.invalid/blackbird.jpg", img.URL)
+	assert.Equal(t, unknownMetadataValue, img.AuthorName)
+	assert.Equal(t, unknownMetadataValue, img.LicenseName)
+	assert.Equal(t, 1, requests, "with no pageimage there is no file page to query")
+}
+
+// TestQueryAndGetFirstPage_StructuredErrorIsNotNotFound is the negative-cache
+// poisoning guard. MediaWiki returns ratelimited, maxlag and readonly with HTTP
+// 200 and no query object, so reading a nil query as "no such species" turned a
+// Wikipedia throttling window into durable __NOT_FOUND__ rows.
+func TestQueryAndGetFirstPage_StructuredErrorIsNotNotFound(t *testing.T) {
+	t.Parallel()
+
+	provider := newTestWikiProvider(t, func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, `{"error":{"code":"ratelimited","info":"You've exceeded your rate limit."}}`)
+	})
+
+	page, redirects, err := provider.queryAndGetFirstPageWithLimiter(t.Context(), "test",
+		map[string]string{"titles": "Turdus merula"}, nil)
+
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrImageNotFound,
+		"a refused request must not be cached as 'this species has no image'")
+	assert.Equal(t, errors.CategoryNetwork, errors.CategoryOf(err))
+	assert.Nil(t, page)
+	assert.Nil(t, redirects)
+
+	open, _ := provider.isCircuitOpen()
+	assert.True(t, open, "a rate-limit error arrives with HTTP 200, so only this path can trip the breaker")
+}
+
+// TestQueryAndGetFirstPage_MissingPageIsNotFound is the other half: with
+// formatversion=2 an absent title is reported as pages:[{missing:true}], and that
+// one genuinely is a not-found.
+func TestQueryAndGetFirstPage_MissingPageIsNotFound(t *testing.T) {
+	t.Parallel()
+
+	provider := newTestWikiProvider(t, func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, `{"query":{"pages":[{"title":"Nonexistent species","missing":true}]}}`)
+	})
+
+	page, _, err := provider.queryAndGetFirstPageWithLimiter(t.Context(), "test",
+		map[string]string{"titles": "Nonexistent species"}, nil)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrImageNotFound)
+	assert.Nil(t, page)
+}
+
+// TestQueryAndGetFirstPage_InvalidTitleIsNotFound covers the API error codes that
+// mean the title can never resolve, which are the only ones worth caching.
+func TestQueryAndGetFirstPage_InvalidTitleIsNotFound(t *testing.T) {
+	t.Parallel()
+
+	provider := newTestWikiProvider(t, func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, `{"error":{"code":"invalidtitle","info":"Bad title"}}`)
+	})
+
+	_, _, err := provider.queryAndGetFirstPageWithLimiter(t.Context(), "test",
+		map[string]string{"titles": "["}, nil)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrImageNotFound)
+}
+
+// TestClassifyForbiddenBody is the request-amplification guard.
+//
+// The classifier used to match the bare tokens "rate" and "limit", which also
+// occur inside "corporate", "moderate" and "unlimited". A hard block whose page
+// contained any of those got the 60-second rate-limit breaker instead of the
+// five-minute block breaker, so the app resumed hammering a host that had just
+// refused it.
+func TestClassifyForbiddenBody(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body string
+		want wikiErrorType
+	}{
+		{name: "user-agent policy", body: "your user-agent is not allowed", want: wikiErrorUserAgent},
+		{name: "robot policy", body: "see our robot policy", want: wikiErrorUserAgent},
+		{name: "rate limit prose", body: "you have hit our rate limit", want: wikiErrorRateLimit},
+		{name: "ratelimited api code", body: `{"code":"ratelimited"}`, want: wikiErrorRateLimit},
+		{name: "too many requests", body: "too many requests, slow down", want: wikiErrorRateLimit},
+		{name: "throttled", body: "your client is being throttled", want: wikiErrorRateLimit},
+		{name: "corporate is not a rate limit", body: "contact our corporate office", want: wikiErrorBlocked},
+		{name: "moderate is not a rate limit", body: "this request was moderated", want: wikiErrorBlocked},
+		{name: "unlimited is not a rate limit", body: "unlimited access requires approval", want: wikiErrorBlocked},
+		{name: "plain block", body: "access denied", want: wikiErrorBlocked},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, classifyForbiddenBody(tt.body))
+		})
+	}
+}
+
+// TestWikiFetchAllowed pins the configuration gate.
+//
+// It mutates the global settings, so it must not run in parallel with anything
+// that reads them.
+func TestWikiFetchAllowed(t *testing.T) {
+	prev := conf.GetSettings()
+	t.Cleanup(func() { conftest.SetTestSettings(prev) })
+
+	newSettings := func(provider, fallback string) *conf.Settings {
+		return conftest.NewTestSettings().WithImageProvider(provider, fallback).Build()
+	}
+
+	tests := []struct {
+		name        string
+		settings    *conf.Settings
+		wantAllowed bool
+	}{
+		{name: "wikimedia is the provider", settings: newSettings("wikimedia", "none"), wantAllowed: true},
+		{name: "auto may elect wikimedia", settings: newSettings("auto", "none"), wantAllowed: true},
+		{name: "unset provider behaves as auto", settings: newSettings("", "none"), wantAllowed: true},
+		{name: "another provider with fallback off", settings: newSettings("avicommons", "none")},
+		{name: "another provider with fallback on", settings: newSettings("avicommons", "all"), wantAllowed: true},
+		// Both of these used to read as "off" on the fetch side while the refresh
+		// side, which lowercased and trimmed, read them as "on".
+		{name: "capitalised policy", settings: newSettings("avicommons", "All"), wantAllowed: true},
+		{name: "policy with a trailing space", settings: newSettings("avicommons", "all "), wantAllowed: true},
+		// Settings are nil only before the config loads or when loading failed.
+		// Allowing traffic in that window contradicts a configured fallbackpolicy.
+		{name: "no settings fails closed", settings: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// No t.Parallel(): these mutate the settings global.
+			conftest.SetTestSettings(tt.settings)
+
+			allowed, reason := wikiFetchAllowed()
+			assert.Equal(t, tt.wantAllowed, allowed)
+			if !allowed {
+				assert.NotEmpty(t, reason, "a refusal must say why")
+			}
+		})
+	}
+}
+
+// TestShouldRefreshCacheImpliesFetchAllowed is the invariant that matters between
+// the two gates: the hourly refresh must never be enabled while the fetches it
+// schedules are denied. It used to be, both through the case-sensitivity
+// mismatch and through accepting a provider name as a policy value.
+func TestShouldRefreshCacheImpliesFetchAllowed(t *testing.T) {
+	prev := conf.GetSettings()
+	t.Cleanup(func() { conftest.SetTestSettings(prev) })
+
+	lazy := NewLazyWikiMediaProvider()
+	for _, provider := range []string{"wikimedia", "avicommons", "auto", "", "WikiMedia"} {
+		for _, policy := range []string{"none", "all", "All", "all ", "wikimedia", ""} {
+			conftest.SetTestSettings(conftest.NewTestSettings().WithImageProvider(provider, policy).Build())
+
+			if lazy.ShouldRefreshCache() {
+				allowed, _ := wikiFetchAllowed()
+				assert.True(t, allowed,
+					"refresh enabled but fetch denied for provider=%q policy=%q", provider, policy)
+			}
+		}
+	}
+}
+
+// TestFetch_QueriesTheSynonymFirst pins the inversion.
+//
+// A configured taxonomy synonym is the user asserting that the primary name is
+// the wrong one to ask Wikipedia for. Consulting it only after a failure meant
+// it could not fix the case it exists for: a lookup that succeeds under the
+// primary name and returns the wrong image.
+func TestFetch_QueriesTheSynonymFirst(t *testing.T) {
+	t.Parallel()
+
+	const (
+		birdnetName = "Accipiter gentilis"
+		synonymName = "Astur gentilis"
+	)
+	synonym, hasSynonym := GetTaxonomySynonym(birdnetName)
+	require.True(t, hasSynonym, "this test needs a name carrying a built-in synonym")
+	require.Equal(t, synonymName, synonym)
+
+	var titles []string
+	provider := newTestWikiProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		title := r.URL.Query().Get("titles")
+		titles = append(titles, title)
+		writeJSON(w, `{"query":{"pages":[{"title":"`+title+`",
+			"thumbnail":{"source":"https://example.invalid/goshawk.jpg"}}]}}`)
+	})
+
+	img, err := provider.fetchWithLimiter(t.Context(), birdnetName, nil)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, titles)
+	assert.Equal(t, synonymName, titles[0], "the synonym is queried first, not as a retry")
+	assert.Len(t, titles, 1, "a successful synonym lookup must not also query the original name")
+	assert.Equal(t, birdnetName, img.ScientificName,
+		"the result is still keyed by the name the caller asked for")
+}
+
+// TestFetch_FallsBackToTheOriginalNameWhenTheSynonymMisses keeps the inversion
+// from costing coverage: the synonym may itself be the stale name.
+func TestFetch_FallsBackToTheOriginalNameWhenTheSynonymMisses(t *testing.T) {
+	t.Parallel()
+
+	const birdnetName = "Accipiter gentilis"
+
+	var titles []string
+	provider := newTestWikiProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		title := r.URL.Query().Get("titles")
+		titles = append(titles, title)
+		if title != birdnetName {
+			writeJSON(w, `{"query":{"pages":[{"title":"`+title+`","missing":true}]}}`)
+			return
+		}
+		writeJSON(w, `{"query":{"pages":[{"title":"`+title+`",
+			"thumbnail":{"source":"https://example.invalid/goshawk.jpg"}}]}}`)
+	})
+
+	img, err := provider.fetchWithLimiter(t.Context(), birdnetName, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.invalid/goshawk.jpg", img.URL)
+	require.Len(t, titles, 2)
+	assert.Equal(t, birdnetName, titles[1], "the original name is still tried when the synonym misses")
+}

--- a/internal/imageprovider/lookup_correctness_test.go
+++ b/internal/imageprovider/lookup_correctness_test.go
@@ -9,6 +9,9 @@ package imageprovider
 
 import (
 	"net/http"
+	"slices"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,6 +22,27 @@ import (
 	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
+// titleRecorder collects the titles a stub handler was asked for. The handler
+// runs on the server's goroutine, and a loopback socket is not a happens-before
+// edge, so the slice needs its own lock; wikipedia_http_test.go uses atomic
+// counters for the same reason.
+type titleRecorder struct {
+	mu     sync.Mutex
+	titles []string
+}
+
+func (r *titleRecorder) add(title string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.titles = append(r.titles, title)
+}
+
+func (r *titleRecorder) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return slices.Clone(r.titles)
+}
+
 // writeJSON is the shape every MediaWiki stub in this file answers with.
 func writeJSON(w http.ResponseWriter, body string) {
 	w.Header().Set("Content-Type", "application/json")
@@ -28,10 +52,16 @@ func writeJSON(w http.ResponseWriter, body string) {
 // TestRedirectLeftSpecies is the unit-level half of root cause C2.
 //
 // Redirect following has to stay on, because most bird articles are titled by
-// common name and a scientific name only resolves through its redirect. What
-// must not pass is a redirect up the taxonomy: Wikipedia sends a species with no
-// article of its own to its genus or family article, whose pageimage is
-// routinely a distribution map or a congener.
+// common name and a scientific name only resolves through its redirect
+// (measured: 548 of 550 shipped species redirect). What must not pass is a
+// redirect up to a family or order article, whose pageimage is a different
+// bird or a distribution map.
+//
+// A redirect to the bare genus deliberately DOES pass: a monotypic genus keeps
+// one combined article at the genus title and that article's image is this
+// species' image, so rejecting it would discard a correct photo and, because
+// the rejection is reported as ErrImageNotFound, persist the species as
+// image-less for the negative TTL.
 func TestRedirectLeftSpecies(t *testing.T) {
 	t.Parallel()
 
@@ -57,11 +87,16 @@ func TestRedirectLeftSpecies(t *testing.T) {
 			redirects: []wikiRedirect{{From: "Opisthocomus hoazin", To: "Hoatzin"}},
 		},
 		{
-			name:       "genus article",
-			species:    "Delichon urbicum",
-			redirects:  []wikiRedirect{{From: "Delichon urbicum", To: "Delichon"}},
-			wantLeft:   true,
-			wantTarget: "Delichon",
+			// Every single-word redirect target in a 550-species live sample was
+			// one of these, and none was a genus article.
+			name:      "measured single-word common names",
+			species:   "Lullula arborea",
+			redirects: []wikiRedirect{{From: "Lullula arborea", To: "Woodlark"}},
+		},
+		{
+			name:      "genus article passes: it may be a monotypic genus",
+			species:   "Steatornis caripensis",
+			redirects: []wikiRedirect{{From: "Steatornis caripensis", To: "Steatornis"}},
 		},
 		{
 			name:       "family article",
@@ -85,24 +120,57 @@ func TestRedirectLeftSpecies(t *testing.T) {
 			wantTarget: "Passeriformes",
 		},
 		{
+			name:       "disambiguated family article is still a family article",
+			species:    "Accipiter nisus",
+			redirects:  []wikiRedirect{{From: "Accipiter nisus", To: "Accipitridae (family)"}},
+			wantLeft:   true,
+			wantTarget: "Accipitridae (family)",
+		},
+		{
+			name:       "underscored family title",
+			species:    "Accipiter nisus",
+			redirects:  []wikiRedirect{{From: "Accipiter nisus", To: "Accipitridae_(family)"}},
+			wantLeft:   true,
+			wantTarget: "Accipitridae_(family)",
+		},
+		{
 			name:      "underscores and case are title syntax, not a different page",
 			species:   "Turdus merula",
 			redirects: []wikiRedirect{{From: "Turdus_merula", To: "Common_blackbird"}},
 		},
 		{
-			name:    "chained redirect ending on the genus",
+			name:    "chained redirect ending on a family",
 			species: "Delichon urbica",
 			redirects: []wikiRedirect{
 				{From: "Delichon urbica", To: "Delichon urbicum"},
-				{From: "Delichon urbicum", To: "Delichon"},
+				{From: "Delichon urbicum", To: "Hirundinidae"},
 			},
 			wantLeft:   true,
-			wantTarget: "Delichon",
+			wantTarget: "Hirundinidae",
 		},
 		{
 			name:      "a synonym redirect to another binomial is fine",
 			species:   "Delichon urbica",
 			redirects: []wikiRedirect{{From: "Delichon urbica", To: "Delichon urbicum"}},
+		},
+		{
+			// A cycle must not spin and must fail open, keeping the image.
+			name:    "cycle fails open",
+			species: "Turdus merula",
+			redirects: []wikiRedirect{
+				{From: "Turdus merula", To: "Blackbird"},
+				{From: "Blackbird", To: "Turdus merula"},
+			},
+		},
+		{
+			name:      "self redirect fails open",
+			species:   "Turdus merula",
+			redirects: []wikiRedirect{{From: "Turdus merula", To: "Turdus merula"}},
+		},
+		{
+			name:      "empty target fails open",
+			species:   "Turdus merula",
+			redirects: []wikiRedirect{{From: "Turdus merula", To: ""}},
 		},
 	}
 
@@ -117,18 +185,29 @@ func TestRedirectLeftSpecies(t *testing.T) {
 	}
 }
 
-// TestQueryThumbnail_RedirectToGenusIsNotAnImage is the end-to-end half of C2.
+// TestResolveRedirectTargetEmptyIsSafe pins the guard on the only indexing
+// expression in the function, which its single caller currently makes
+// unreachable.
+func TestResolveRedirectTargetEmptyIsSafe(t *testing.T) {
+	t.Parallel()
+
+	assert.NotPanics(t, func() {
+		assert.Empty(t, resolveRedirectTarget("Turdus merula", nil))
+	})
+}
+
+// TestQueryThumbnail_RedirectToFamilyIsNotAnImage is the end-to-end half of C2.
 //
 // The lookup succeeds at the HTTP level, which is exactly why this was so
 // durable: a positive entry was written, and the taxonomy-synonym map, which is
 // only consulted on failure, never got a chance to correct it.
-func TestQueryThumbnail_RedirectToGenusIsNotAnImage(t *testing.T) {
+func TestQueryThumbnail_RedirectToFamilyIsNotAnImage(t *testing.T) {
 	t.Parallel()
 
 	provider := newTestWikiProvider(t, func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(w, `{"query":{
-			"redirects":[{"from":"Delichon urbicum","to":"Delichon"}],
-			"pages":[{"title":"Delichon","pageimage":"Delichon_distribution.png",
+			"redirects":[{"from":"Delichon urbicum","to":"Hirundinidae"}],
+			"pages":[{"title":"Hirundinidae","pageimage":"Hirundinidae_distribution.png",
 			          "thumbnail":{"source":"https://example.invalid/map.png"}}]}}`)
 	})
 
@@ -136,7 +215,7 @@ func TestQueryThumbnail_RedirectToGenusIsNotAnImage(t *testing.T) {
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrImageNotFound,
-		"a genus article's image is not this species' image, and the synonym retry only runs on not-found")
+		"a family article's image is not this species' image, and the synonym retry only runs on not-found")
 	assert.Empty(t, url)
 	assert.Empty(t, file)
 }
@@ -164,9 +243,9 @@ func TestQueryThumbnail_MissingPageImageStillYieldsTheThumbnail(t *testing.T) {
 func TestFetch_MissingPageImageUsesUnknownAttribution(t *testing.T) {
 	t.Parallel()
 
-	var requests int
+	var requests atomic.Int64
 	provider := newTestWikiProvider(t, func(w http.ResponseWriter, _ *http.Request) {
-		requests++
+		requests.Add(1)
 		writeJSON(w, `{"query":{"pages":[{"title":"Turdus merula",
 			"thumbnail":{"source":"https://example.invalid/blackbird.jpg"}}]}}`)
 	})
@@ -177,7 +256,7 @@ func TestFetch_MissingPageImageUsesUnknownAttribution(t *testing.T) {
 	assert.Equal(t, "https://example.invalid/blackbird.jpg", img.URL)
 	assert.Equal(t, unknownMetadataValue, img.AuthorName)
 	assert.Equal(t, unknownMetadataValue, img.LicenseName)
-	assert.Equal(t, 1, requests, "with no pageimage there is no file page to query")
+	assert.Equal(t, int64(1), requests.Load(), "with no pageimage there is no file page to query")
 }
 
 // TestQueryAndGetFirstPage_StructuredErrorIsNotNotFound is the negative-cache
@@ -301,9 +380,6 @@ func TestWikiFetchAllowed(t *testing.T) {
 		// side, which lowercased and trimmed, read them as "on".
 		{name: "capitalised policy", settings: newSettings("avicommons", "All"), wantAllowed: true},
 		{name: "policy with a trailing space", settings: newSettings("avicommons", "all "), wantAllowed: true},
-		// Settings are nil only before the config loads or when loading failed.
-		// Allowing traffic in that window contradicts a configured fallbackpolicy.
-		{name: "no settings fails closed", settings: nil},
 	}
 
 	for _, tt := range tests {
@@ -318,6 +394,18 @@ func TestWikiFetchAllowed(t *testing.T) {
 			}
 		})
 	}
+
+	// Settings are nil only before the config loads or when loading failed.
+	// Allowing outbound traffic in that window contradicts a configured
+	// fallbackpolicy. Asserted through the seam because conf.Setting() lazy-loads
+	// from disk, so installing nil in the global does NOT produce a nil read: a
+	// subtest that tried would pass on the loaded config's policy instead, and
+	// stay green with the guard removed.
+	t.Run("no settings fails closed", func(t *testing.T) {
+		allowed, reason := wikiFetchAllowedFor(nil)
+		assert.False(t, allowed, "an unreadable configuration must not permit outbound fetches")
+		assert.Equal(t, reasonSettingsUnavailable, reason)
+	})
 }
 
 // TestShouldRefreshCacheImpliesFetchAllowed is the invariant that matters between
@@ -325,21 +413,27 @@ func TestWikiFetchAllowed(t *testing.T) {
 // schedules are denied. It used to be, both through the case-sensitivity
 // mismatch and through accepting a provider name as a policy value.
 func TestShouldRefreshCacheImpliesFetchAllowed(t *testing.T) {
+	// No t.Parallel(): mutates the settings global.
 	prev := conf.GetSettings()
 	t.Cleanup(func() { conftest.SetTestSettings(prev) })
 
 	lazy := NewLazyWikiMediaProvider()
+	refreshEnabled := 0
 	for _, provider := range []string{"wikimedia", "avicommons", "auto", "", "WikiMedia"} {
 		for _, policy := range []string{"none", "all", "All", "all ", "wikimedia", ""} {
 			conftest.SetTestSettings(conftest.NewTestSettings().WithImageProvider(provider, policy).Build())
 
 			if lazy.ShouldRefreshCache() {
+				refreshEnabled++
 				allowed, _ := wikiFetchAllowed()
 				assert.True(t, allowed,
 					"refresh enabled but fetch denied for provider=%q policy=%q", provider, policy)
 			}
 		}
 	}
+	// Without this the whole matrix passes vacuously if ShouldRefreshCache ever
+	// starts returning false everywhere.
+	require.Positive(t, refreshEnabled, "the matrix must exercise the refresh-enabled case")
 }
 
 // TestFetch_QueriesTheSynonymFirst pins the inversion.
@@ -359,10 +453,10 @@ func TestFetch_QueriesTheSynonymFirst(t *testing.T) {
 	require.True(t, hasSynonym, "this test needs a name carrying a built-in synonym")
 	require.Equal(t, synonymName, synonym)
 
-	var titles []string
+	var titles titleRecorder
 	provider := newTestWikiProvider(t, func(w http.ResponseWriter, r *http.Request) {
 		title := r.URL.Query().Get("titles")
-		titles = append(titles, title)
+		titles.add(title)
 		writeJSON(w, `{"query":{"pages":[{"title":"`+title+`",
 			"thumbnail":{"source":"https://example.invalid/goshawk.jpg"}}]}}`)
 	})
@@ -370,9 +464,10 @@ func TestFetch_QueriesTheSynonymFirst(t *testing.T) {
 	img, err := provider.fetchWithLimiter(t.Context(), birdnetName, nil)
 
 	require.NoError(t, err)
-	require.NotEmpty(t, titles)
-	assert.Equal(t, synonymName, titles[0], "the synonym is queried first, not as a retry")
-	assert.Len(t, titles, 1, "a successful synonym lookup must not also query the original name")
+	got := titles.snapshot()
+	require.NotEmpty(t, got)
+	assert.Equal(t, synonymName, got[0], "the synonym is queried first, not as a retry")
+	assert.Len(t, got, 1, "a successful synonym lookup must not also query the original name")
 	assert.Equal(t, birdnetName, img.ScientificName,
 		"the result is still keyed by the name the caller asked for")
 }
@@ -384,10 +479,10 @@ func TestFetch_FallsBackToTheOriginalNameWhenTheSynonymMisses(t *testing.T) {
 
 	const birdnetName = "Accipiter gentilis"
 
-	var titles []string
+	var titles titleRecorder
 	provider := newTestWikiProvider(t, func(w http.ResponseWriter, r *http.Request) {
 		title := r.URL.Query().Get("titles")
-		titles = append(titles, title)
+		titles.add(title)
 		if title != birdnetName {
 			writeJSON(w, `{"query":{"pages":[{"title":"`+title+`","missing":true}]}}`)
 			return
@@ -400,6 +495,7 @@ func TestFetch_FallsBackToTheOriginalNameWhenTheSynonymMisses(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "https://example.invalid/goshawk.jpg", img.URL)
-	require.Len(t, titles, 2)
-	assert.Equal(t, birdnetName, titles[1], "the original name is still tried when the synonym misses")
+	got := titles.snapshot()
+	require.Len(t, got, 2)
+	assert.Equal(t, birdnetName, got[1], "the original name is still tried when the synonym misses")
 }

--- a/internal/imageprovider/lookup_correctness_test.go
+++ b/internal/imageprovider/lookup_correctness_test.go
@@ -120,18 +120,26 @@ func TestRedirectLeftSpecies(t *testing.T) {
 			wantTarget: "Passeriformes",
 		},
 		{
-			name:       "disambiguated family article is still a family article",
-			species:    "Accipiter nisus",
-			redirects:  []wikiRedirect{{From: "Accipiter nisus", To: "Accipitridae (family)"}},
-			wantLeft:   true,
-			wantTarget: "Accipitridae (family)",
+			// Only a single-word target is tested, so a qualified title passes.
+			// Wikipedia keeps bird families at the bare name, so this shape does
+			// not arise; the alternative, testing every word, rejects the nine
+			// binomials below and is the worse trade by far.
+			name:      "a qualified title is not tested",
+			species:   "Accipiter nisus",
+			redirects: []wikiRedirect{{From: "Accipiter nisus", To: "Accipitridae (family)"}},
 		},
 		{
-			name:       "underscored family title",
-			species:    "Accipiter nisus",
-			redirects:  []wikiRedirect{{From: "Accipiter nisus", To: "Accipitridae_(family)"}},
-			wantLeft:   true,
-			wantTarget: "Accipitridae_(family)",
+			// Regression guard. These epithets are Latin genitives that happen to
+			// end in a supra-generic suffix. Nine such binomials are in the
+			// shipped V2.4 label set, and rejecting one caches it as "no image".
+			name:      "a binomial whose epithet ends in -inae is not a higher taxon",
+			species:   "Pyrrhura emma",
+			redirects: []wikiRedirect{{From: "Pyrrhura emma", To: "Pyrrhura molinae"}},
+		},
+		{
+			name:      "a binomial whose epithet ends in -idae is not a higher taxon",
+			species:   "Setophaga petechia",
+			redirects: []wikiRedirect{{From: "Setophaga petechia", To: "Setophaga adelaidae"}},
 		},
 		{
 			name:      "underscores and case are title syntax, not a different page",

--- a/internal/imageprovider/lookup_correctness_test.go
+++ b/internal/imageprovider/lookup_correctness_test.go
@@ -8,11 +8,13 @@
 package imageprovider
 
 import (
+	"context"
 	"net/http"
 	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -506,4 +508,58 @@ func TestFetch_FallsBackToTheOriginalNameWhenTheSynonymMisses(t *testing.T) {
 	got := titles.snapshot()
 	require.Len(t, got, 2)
 	assert.Equal(t, birdnetName, got[1], "the original name is still tried when the synonym misses")
+}
+
+// TestWikiFetchAllowedFor_DecidesFromItsArgument pins the seam's contract.
+//
+// The fallback-policy half used to be read from the global settings while the
+// provider half came from the argument, so a caller passing anything other than
+// the global got a verdict spliced from two sources.
+func TestWikiFetchAllowedFor_DecidesFromItsArgument(t *testing.T) {
+	// No t.Parallel(): installs a global to prove the argument overrides it.
+	prev := conf.GetSettings()
+	t.Cleanup(func() { conftest.SetTestSettings(prev) })
+
+	// Global says fallback is off; the argument says it is on.
+	conftest.SetTestSettings(conftest.NewTestSettings().WithImageProvider("avicommons", "none").Build())
+	passed := conftest.NewTestSettings().WithImageProvider("avicommons", "all").Build()
+
+	allowed, _ := wikiFetchAllowedFor(passed)
+	assert.True(t, allowed, "the decision must come from the settings passed in, not the global")
+
+	// And the reverse, so the assertion cannot pass by reading the global.
+	conftest.SetTestSettings(conftest.NewTestSettings().WithImageProvider("avicommons", "all").Build())
+	denied := conftest.NewTestSettings().WithImageProvider("avicommons", "none").Build()
+
+	allowed, reason := wikiFetchAllowedFor(denied)
+	assert.False(t, allowed)
+	assert.NotEmpty(t, reason)
+}
+
+// TestEnsureInitialized_AcquisitionIsCancellable covers the other half of the
+// same hazard: a caller with a short deadline must be able to give up rather
+// than block on another caller's config wait, which runs for up to 10 seconds.
+func TestEnsureInitialized_AcquisitionIsCancellable(t *testing.T) {
+	t.Parallel()
+
+	lazy := NewLazyWikiMediaProvider()
+	// Hold the slot, as an in-flight initialization would.
+	lazy.initSem <- struct{}{}
+	t.Cleanup(func() { <-lazy.initSem })
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		_, err := lazy.ensureInitialized(ctx)
+		done <- err
+	}()
+
+	cancel()
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled,
+			"a caller that gives up must not wait out the holder's config wait")
+	case <-time.After(2 * time.Second):
+		t.Fatal("ensureInitialized blocked on the init slot after its context was cancelled")
+	}
 }

--- a/internal/imageprovider/negative_cache_test.go
+++ b/internal/imageprovider/negative_cache_test.go
@@ -209,7 +209,7 @@ func (m *mockProviderWithNotFound) Fetch(scientificName string) (imageprovider.B
 
 	// Return a valid image for other species
 	return imageprovider.BirdImage{
-		URL:            "http://example.com/" + scientificName + ".jpg",
+		URL:            "http://127.0.0.1/" + scientificName + ".jpg",
 		ScientificName: scientificName,
 		AuthorName:     "Test Author",
 		LicenseName:    "CC-BY",

--- a/internal/imageprovider/network_failure_test.go
+++ b/internal/imageprovider/network_failure_test.go
@@ -119,7 +119,6 @@ func TestNetworkErrorOpensCircuitBreaker(t *testing.T) {
 		rt := &dnsFailureRoundTripper{}
 		provider := &wikiMediaProvider{
 			httpClient:    &http.Client{Transport: rt},
-			userAgent:     buildUserAgent("test"),
 			maxRetries:    1,
 			globalLimiter: rate.NewLimiter(rate.Inf, 1),
 		}
@@ -164,7 +163,6 @@ func TestRateLimitStopsFurtherAttempts(t *testing.T) {
 		rt := &statusRoundTripper{status: http.StatusTooManyRequests}
 		provider := &wikiMediaProvider{
 			httpClient:    &http.Client{Transport: rt},
-			userAgent:     buildUserAgent("test"),
 			maxRetries:    3,
 			globalLimiter: rate.NewLimiter(rate.Inf, 1),
 		}
@@ -210,7 +208,6 @@ func TestRetryLoopDoesNotBackOffAfterFinalAttempt(t *testing.T) {
 		rt := &statusRoundTripper{status: http.StatusInternalServerError}
 		provider := &wikiMediaProvider{
 			httpClient:    &http.Client{Transport: rt},
-			userAgent:     buildUserAgent("test"),
 			maxRetries:    3,
 			globalLimiter: rate.NewLimiter(rate.Inf, 1),
 		}
@@ -281,7 +278,6 @@ func TestQueryWithNonPositiveMaxRetriesReturnsError(t *testing.T) {
 			rt := &statusRoundTripper{status: http.StatusOK}
 			provider := &wikiMediaProvider{
 				httpClient:    &http.Client{Transport: rt},
-				userAgent:     buildUserAgent("test"),
 				maxRetries:    maxRetries,
 				globalLimiter: rate.NewLimiter(rate.Inf, 1),
 			}

--- a/internal/imageprovider/provider_policy_test.go
+++ b/internal/imageprovider/provider_policy_test.go
@@ -188,7 +188,7 @@ func TestRefreshEntryFallbackToDBCache(t *testing.T) {
 	require.NoError(t, store.SaveImageCache(&datastore.ImageCache{
 		ScientificName: species,
 		ProviderName:   providerAvicommons,
-		URL:            "http://old.example.com/redpoll.jpg",
+		URL:            "http://127.0.0.1/redpoll.jpg",
 		AuthorName:     "Old Author",
 		LicenseName:    "CC BY-SA 4.0",
 		CachedAt:       staleTime,
@@ -198,7 +198,7 @@ func TestRefreshEntryFallbackToDBCache(t *testing.T) {
 	require.NoError(t, store.SaveImageCache(&datastore.ImageCache{
 		ScientificName: species,
 		ProviderName:   providerWikimedia,
-		URL:            "https://upload.wikimedia.org/Carduelis_flammea_CT6.jpg",
+		URL:            "https://127.0.0.1/Carduelis_flammea_CT6.jpg",
 		AuthorName:     "Cephas",
 		LicenseName:    "CC BY-SA 3.0",
 		LicenseURL:     "https://creativecommons.org/licenses/by-sa/3.0/",
@@ -225,7 +225,7 @@ func TestRefreshEntryFallbackToDBCache(t *testing.T) {
 	// The Get itself returns stale data immediately.
 	img, err := primaryCache.Get(species)
 	require.NoError(t, err, "Get should return stale data without error")
-	assert.Equal(t, "http://old.example.com/redpoll.jpg", img.URL, "Should return stale data initially")
+	assert.Equal(t, "http://127.0.0.1/redpoll.jpg", img.URL, "Should return stale data initially")
 
 	// Poll for the background refresh to land the DB write, which is the actual
 	// observable the assertions below check. The refresh goroutine updates the
@@ -240,14 +240,14 @@ func TestRefreshEntryFallbackToDBCache(t *testing.T) {
 			ProviderName:   providerAvicommons,
 		})
 		return err == nil && dbEntry != nil &&
-			dbEntry.URL == "https://upload.wikimedia.org/Carduelis_flammea_CT6.jpg" &&
+			dbEntry.URL == "https://127.0.0.1/Carduelis_flammea_CT6.jpg" &&
 			dbEntry.CachedAt.After(staleTime)
 	}, 5*time.Second, 50*time.Millisecond, "Background refresh should persist wikimedia fallback URL to DB")
 
 	// Verify full attribution after refresh
 	img2, err := primaryCache.Get(species)
 	require.NoError(t, err, "Get after refresh should succeed")
-	assert.Equal(t, "https://upload.wikimedia.org/Carduelis_flammea_CT6.jpg", img2.URL,
+	assert.Equal(t, "https://127.0.0.1/Carduelis_flammea_CT6.jpg", img2.URL,
 		"Should have fallback wikimedia URL after refresh")
 	assert.Equal(t, "Cephas", img2.AuthorName, "Should preserve wikimedia attribution")
 	assert.Equal(t, "CC BY-SA 3.0", img2.LicenseName, "Should preserve wikimedia license")
@@ -258,7 +258,7 @@ func TestRefreshEntryFallbackToDBCache(t *testing.T) {
 		ProviderName:   providerAvicommons,
 	})
 	require.NoError(t, err, "DB should have updated avicommons entry")
-	assert.Equal(t, "https://upload.wikimedia.org/Carduelis_flammea_CT6.jpg", dbEntry.URL,
+	assert.Equal(t, "https://127.0.0.1/Carduelis_flammea_CT6.jpg", dbEntry.URL,
 		"DB entry under avicommons should have wikimedia URL")
 	assert.True(t, dbEntry.CachedAt.After(staleTime),
 		"DB entry should have fresh timestamp")
@@ -280,7 +280,7 @@ func TestRefreshEntryFallbackPolicyNone(t *testing.T) {
 	require.NoError(t, store.SaveImageCache(&datastore.ImageCache{
 		ScientificName: species,
 		ProviderName:   providerAvicommons,
-		URL:            "http://old.example.com/redpoll.jpg",
+		URL:            "http://127.0.0.1/redpoll.jpg",
 		CachedAt:       time.Now().Add(-31 * 24 * time.Hour),
 	}))
 
@@ -288,7 +288,7 @@ func TestRefreshEntryFallbackPolicyNone(t *testing.T) {
 	require.NoError(t, store.SaveImageCache(&datastore.ImageCache{
 		ScientificName: species,
 		ProviderName:   providerWikimedia,
-		URL:            "https://upload.wikimedia.org/Carduelis_flammea_CT6.jpg",
+		URL:            "https://127.0.0.1/Carduelis_flammea_CT6.jpg",
 		AuthorName:     "Cephas",
 		CachedAt:       time.Now().Add(-5 * 24 * time.Hour),
 	}))
@@ -327,7 +327,7 @@ func TestRefreshEntryFallbackPolicyNone(t *testing.T) {
 		require.ErrorIs(t, err, imageprovider.ErrImageNotFound,
 			"only a not-found error is acceptable here")
 	}
-	assert.NotEqual(t, "https://upload.wikimedia.org/Carduelis_flammea_CT6.jpg", img.URL,
+	assert.NotEqual(t, "https://127.0.0.1/Carduelis_flammea_CT6.jpg", img.URL,
 		"Should NOT use wikimedia fallback when policy is 'none'")
 	assert.Zero(t, fallbackProvider.getFetchCount(),
 		"wikimedia fallback provider must not be consulted when policy is 'none'")

--- a/internal/imageprovider/startup_warmup_test.go
+++ b/internal/imageprovider/startup_warmup_test.go
@@ -38,7 +38,7 @@ func TestLoadCachedImagesWarmupPopulatesMemory(t *testing.T) {
 		require.NoError(t, store.SaveImageCache(&datastore.ImageCache{
 			ScientificName: s,
 			ProviderName:   providerWikimedia, // matches CreateDefaultCache's provider name
-			URL:            "https://example.com/" + s + ".jpg",
+			URL:            "https://127.0.0.1/" + s + ".jpg",
 			AuthorName:     "Test Author",
 			LicenseName:    "CC BY-SA 4.0",
 			CachedAt:       time.Now(),

--- a/internal/imageprovider/startup_warmup_test.go
+++ b/internal/imageprovider/startup_warmup_test.go
@@ -97,7 +97,7 @@ func TestGetWarmedNegativePrimaryConsultsFallback(t *testing.T) {
 	require.NoError(t, store.SaveImageCache(&datastore.ImageCache{
 		ScientificName: species,
 		ProviderName:   providerWikimedia,
-		URL:            "https://wiki.example.com/sparrow.jpg",
+		URL:            "https://127.0.0.1/sparrow.jpg",
 		AuthorName:     "Cephas",
 		LicenseName:    "CC BY-SA 3.0",
 		CachedAt:       time.Now(),
@@ -118,7 +118,7 @@ func TestGetWarmedNegativePrimaryConsultsFallback(t *testing.T) {
 
 	img, err := primaryCache.Get(species)
 	require.NoError(t, err, "a warmed negative primary entry must not block the fallback")
-	assert.Equal(t, "https://wiki.example.com/sparrow.jpg", img.URL,
+	assert.Equal(t, "https://127.0.0.1/sparrow.jpg", img.URL,
 		"Get must return the fallback provider's image, not the primary's negative entry")
 }
 
@@ -154,7 +154,7 @@ func TestGetDBFallbackHonorsPolicy(t *testing.T) {
 			require.NoError(t, store.SaveImageCache(&datastore.ImageCache{
 				ScientificName: species,
 				ProviderName:   providerWikimedia,
-				URL:            "https://wiki.example.com/parus.jpg",
+				URL:            "https://127.0.0.1/parus.jpg",
 				CachedAt:       time.Now(),
 			}))
 
@@ -175,7 +175,7 @@ func TestGetDBFallbackHonorsPolicy(t *testing.T) {
 			img, err := primaryCache.Get(species)
 			if tc.expectImage {
 				require.NoError(t, err, "policy=all should resolve via the fallback DB row")
-				assert.Equal(t, "https://wiki.example.com/parus.jpg", img.URL,
+				assert.Equal(t, "https://127.0.0.1/parus.jpg", img.URL,
 					"Get must return the fallback provider's cached image")
 				assert.True(t, store.WasProviderQueried(providerWikimedia),
 					"fallback provider DB must be consulted under policy=all")

--- a/internal/imageprovider/useragent.go
+++ b/internal/imageprovider/useragent.go
@@ -1,0 +1,97 @@
+// useragent.go: the outbound User-Agent shared by every HTTP path in this
+// package.
+//
+// This used to live in wikipedia.go under a Wikimedia-robot-policy comment, but
+// the provider-agnostic image download in filecache.go depends on it too, so it
+// belongs in a neutral file.
+package imageprovider
+
+import (
+	"fmt"
+	"runtime"
+	"sync/atomic"
+
+	"github.com/tphakala/birdnet-go/internal/branding"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+const (
+	// User-Agent constants following Wikimedia robot policy
+	// https://foundation.wikimedia.org/wiki/Policy:Wikimedia_Foundation_User-Agent_Policy
+	// The contact URL is resolved at runtime from the branding package (see
+	// buildUserAgent) so forks identify themselves rather than the upstream repo.
+	//
+	// Do not "correct" userAgentName to the hyphenated project name. Wikimedia's
+	// edge refuses any User-Agent whose leading token is "birdnet-go",
+	// case-insensitively, on both upload.wikimedia.org and api.php, even when
+	// the header is otherwise fully policy-compliant. The hyphen-less spelling
+	// is the one that works.
+	userAgentName    = "BirdNETGo"
+	userAgentLibrary = "Go-HTTP-Client"
+)
+
+// cachedAppUserAgent memoizes the User-Agent. It is an atomic.Pointer rather
+// than a sync.OnceValue because conf.Setting() can return nil, and Version is
+// published after startup: latching at first call could pin a version-less
+// string for the process lifetime. Only a non-empty version is memoized, so an
+// early call does not poison the value.
+var cachedAppUserAgent atomic.Pointer[string]
+
+// currentAppVersion returns the running application version. It is empty both when
+// conf.Setting() returns nil (the config failed to load) and when Version has not been
+// published yet; callers only need "not yet usable", so the two are equivalent here.
+func currentAppVersion() string {
+	if settings := conf.Setting(); settings != nil {
+		return settings.Version
+	}
+	return ""
+}
+
+// buildUserAgent constructs a user-agent string that complies with Wikimedia's
+// robot policy.
+func buildUserAgent(appVersion string) string {
+	if appVersion == "" {
+		appVersion = "unknown"
+	}
+
+	goVersion := runtime.Version()
+
+	// Format: BirdNETGo/1.0.0 (https://github.com/tphakala/birdnet-go) Go-HTTP-Client/go1.21.0
+	return fmt.Sprintf("%s/%s (%s) %s/%s",
+		userAgentName, appVersion, branding.RepoURL(), userAgentLibrary, goVersion)
+}
+
+// appUserAgent returns the User-Agent for every outbound request this package
+// makes, both the MediaWiki API calls and the image byte downloads.
+//
+// Wikimedia answers 403 to Go's default "Go-http-client/1.1", so the byte fetch
+// needs the same policy-compliant header the API path sends. Resolving it here
+// also makes both paths self-heal: the API provider used to latch the string at
+// construction, so one built before main.go published Version sent
+// "BirdNETGo/unknown" for the whole process lifetime.
+func appUserAgent() string {
+	if ua := cachedAppUserAgent.Load(); ua != nil {
+		return *ua
+	}
+	version := currentAppVersion()
+	ua := buildUserAgent(version)
+	if version != "" {
+		// CompareAndSwap rather than Store so concurrent first callers publish once.
+		cachedAppUserAgent.CompareAndSwap(nil, &ua)
+	}
+	return ua
+}
+
+// logUserAgentValidation logs the constructed user-agent for debugging purposes.
+func logUserAgentValidation(appVersion string) {
+	GetLogger().Debug("Wikipedia user-agent validation",
+		logger.String("provider", wikiProviderName),
+		logger.String("user_agent", buildUserAgent(appVersion)),
+		logger.String("complies_with_policy", "https://foundation.wikimedia.org/wiki/Policy:User-Agent_policy"),
+		logger.String("contains_app_name", userAgentName),
+		logger.String("contains_version", appVersion),
+		logger.String("contains_contact", branding.RepoURL()),
+		logger.String("contains_library", userAgentLibrary),
+		logger.String("go_version", runtime.Version()))
+}

--- a/internal/imageprovider/useragent_test.go
+++ b/internal/imageprovider/useragent_test.go
@@ -1,0 +1,50 @@
+package imageprovider
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/conf/conftest"
+)
+
+// TestAppUserAgent_DoesNotLatchAVersionlessString covers the behaviour the
+// memoization exists for.
+//
+// The provider used to build its User-Agent once at construction, so one built
+// before main.go published Version sent "BirdNETGo/unknown" for the whole
+// process lifetime. appUserAgent memoizes only a non-empty version, so an early
+// call cannot poison the value.
+//
+// No t.Parallel(): mutates the settings global and the package-level memo.
+func TestAppUserAgent_DoesNotLatchAVersionlessString(t *testing.T) {
+	prevSettings := conf.GetSettings()
+	prevUA := cachedAppUserAgent.Load()
+	t.Cleanup(func() {
+		conftest.SetTestSettings(prevSettings)
+		cachedAppUserAgent.Store(prevUA)
+	})
+
+	cachedAppUserAgent.Store(nil)
+
+	versionless := conftest.NewTestSettings().Build()
+	versionless.Version = ""
+	conftest.SetTestSettings(versionless)
+
+	early := appUserAgent()
+	require.Contains(t, early, userAgentName)
+	assert.Contains(t, early, "unknown", "with no version published the token is a placeholder")
+	assert.Nil(t, cachedAppUserAgent.Load(), "a placeholder must not be memoized")
+
+	published := conftest.NewTestSettings().Build()
+	published.Version = "1.2.3-test"
+	conftest.SetTestSettings(published)
+
+	assert.Contains(t, appUserAgent(), "1.2.3-test",
+		"the User-Agent must pick up the version once it is published")
+	assert.NotContains(t, appUserAgent(), "unknown")
+	assert.Equal(t, userAgentName, strings.Split(appUserAgent(), "/")[0])
+}

--- a/internal/imageprovider/wikipedia.go
+++ b/internal/imageprovider/wikipedia.go
@@ -10,14 +10,12 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/tphakala/birdnet-go/internal/branding"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/httpclient"
@@ -29,13 +27,6 @@ import (
 const (
 	wikiProviderName = "wikimedia"
 	wikipediaAPIURL  = "https://en.wikipedia.org/w/api.php"
-
-	// User-Agent constants following Wikimedia robot policy
-	// https://foundation.wikimedia.org/wiki/Policy:Wikimedia_Foundation_User-Agent_Policy
-	// The contact URL is resolved at runtime from the branding package (see
-	// buildUserAgent) so forks identify themselves rather than the upstream repo.
-	userAgentName    = "BirdNETGo"
-	userAgentLibrary = "Go-HTTP-Client"
 
 	// Circuit breaker timeout durations
 	circuitBreakerRateLimitDuration      = 60 * time.Second // Rate limit circuit breaker duration
@@ -59,6 +50,10 @@ const (
 	retryMinDelay       = 2 * time.Second
 	configWaitTimeout   = 10 * time.Second
 	configCheckInterval = 100 * time.Millisecond
+	// lazyInitRetryInterval bounds how often a failed lazy initialization is
+	// retried, so a provider that lost the race with config loading at boot
+	// recovers instead of staying dead for the process lifetime.
+	lazyInitRetryInterval = 1 * time.Minute
 
 	// Response body size limits
 	responseBodyPreviewLimit = 200 // Bytes to show in error messages
@@ -73,15 +68,49 @@ const (
 	// Error detection strings (lowercase for case-insensitive comparison)
 	errorStringUserAgent   = "user-agent"
 	errorStringRobotPolicy = "robot policy"
-	errorStringRate        = "rate"
-	errorStringLimit       = "limit"
-	errorStringThrottle    = "throttl"
 	errorStringBlocked     = "blocked"
 	errorStringBanned      = "banned"
 	errorStringDenied      = "denied"
 	errorStringHTMLDoctype = "<!DOCTYPE"
 	errorStringHTMLTag     = "<html"
+
+	// Rate-limit phrases, matched against a lowercased response body.
+	//
+	// These used to be the bare tokens "rate" and "limit", which also match
+	// ordinary prose in an HTML error page: "corporate", "moderate",
+	// "unlimited". A hard block whose page happened to contain any of those was
+	// classified as a throttle and got the 60s breaker instead of the 5-minute
+	// block breaker, so the app resumed hammering a host that had just refused
+	// it. Match phrases, not fragments of unrelated words.
+	errorStringRateLimit   = "rate limit"        // prose form
+	errorStringRateLimited = "ratelimit"         // MediaWiki API error code "ratelimited"
+	errorStringTooManyReqs = "too many requests" // HTTP 429 prose
+	errorStringThrottle    = "throttl"
 )
+
+// mentionsRateLimit reports whether a lowercased response body names a rate
+// limit. See the errorString* block above for why this is phrase-based.
+func mentionsRateLimit(bodyLower string) bool {
+	return strings.Contains(bodyLower, errorStringRateLimit) ||
+		strings.Contains(bodyLower, errorStringRateLimited) ||
+		strings.Contains(bodyLower, errorStringTooManyReqs) ||
+		strings.Contains(bodyLower, errorStringThrottle)
+}
+
+// classifyForbiddenBody classifies the body of an HTTP 403 from the Wikimedia
+// edge. Both the circuit-breaker path (handleForbiddenError) and the
+// error-reporting path (detectWikipediaErrorType) need this verdict, and they
+// used to derive it independently with two copies of the same substring checks.
+func classifyForbiddenBody(bodyLower string) wikiErrorType {
+	switch {
+	case strings.Contains(bodyLower, errorStringUserAgent) || strings.Contains(bodyLower, errorStringRobotPolicy):
+		return wikiErrorUserAgent
+	case mentionsRateLimit(bodyLower):
+		return wikiErrorRateLimit
+	default:
+		return wikiErrorBlocked
+	}
+}
 
 // wikiMediaProvider implements the ImageProvider interface for Wikipedia.
 type wikiMediaProvider struct {
@@ -91,7 +120,6 @@ type wikiMediaProvider struct {
 	// circuit breaker, response classification) could only be exercised against the
 	// live Wikipedia API, which is why that coverage was deferred.
 	apiURL            string
-	userAgent         string // User-Agent header value (cached for reuse)
 	debug             bool
 	globalLimiter     *rate.Limiter // Global rate limiter for ALL Wikipedia requests (1 req/sec)
 	backgroundLimiter *rate.Limiter // Additional limiter for background operations
@@ -131,18 +159,32 @@ type wikiAPIError struct {
 	Info string `json:"info"`
 }
 
-// wikiQuery models the "query" object of a MediaWiki response. Redirects and
-// Normalized are retained as raw messages because only their presence/count is
-// used, for diagnostic logging.
+// wikiQuery models the "query" object of a MediaWiki response. Normalized is
+// retained as raw messages because only its count is used, for diagnostic
+// logging; Redirects is typed because the redirect target decides whether the
+// answered page is still about the species we asked for.
 type wikiQuery struct {
 	Pages      []wikiPage        `json:"pages"`
-	Redirects  []json.RawMessage `json:"redirects"`
+	Redirects  []wikiRedirect    `json:"redirects"`
 	Normalized []json.RawMessage `json:"normalized"`
+}
+
+// wikiRedirect models one hop of the "redirects" array: the title we asked for
+// and the title the API answered with.
+type wikiRedirect struct {
+	From string `json:"from"`
+	To   string `json:"to"`
 }
 
 // wikiPage models a single page entry from a MediaWiki query response.
 type wikiPage struct {
-	Title     string          `json:"title"`
+	Title string `json:"title"`
+	// Missing is how formatversion=2 reports a title that has no article. It has
+	// to be modelled explicitly: without it the only "no such page" signal the
+	// code could see was a nil query object, which the API also produces for
+	// structured errors on HTTP 200 (ratelimited, maxlag, readonly). Conflating
+	// the two persisted a rate-limit window as a durable __NOT_FOUND__ row.
+	Missing   bool            `json:"missing"`
 	Thumbnail *wikiThumbnail  `json:"thumbnail"`
 	PageImage string          `json:"pageimage"`
 	ImageInfo []wikiImageInfo `json:"imageinfo"`
@@ -272,7 +314,7 @@ func (l *wikiMediaProvider) waitForGlobalRateLimit(ctx context.Context) error {
 
 // validateUserAgent ensures the User-Agent is set.
 func (l *wikiMediaProvider) validateUserAgent() error {
-	if l.userAgent == "" {
+	if appUserAgent() == "" {
 		GetLogger().Error("User-Agent is empty! This will cause Wikipedia to reject the request",
 			logger.String("provider", wikiProviderName))
 		return errors.Newf("User-Agent not set for Wikipedia provider").
@@ -328,13 +370,17 @@ func (l *wikiMediaProvider) createHTTPRequest(ctx context.Context, fullURL strin
 			Build()
 	}
 
-	req.Header.Set("User-Agent", l.userAgent)
+	// Resolved per request, not latched at construction: a provider built
+	// before main.go publishes Version would otherwise send "BirdNETGo/unknown"
+	// for the whole process lifetime, while the image-download path self-heals.
+	userAgent := appUserAgent()
+	req.Header.Set("User-Agent", userAgent)
 	req.Header.Set("Accept", "application/json")
 
 	GetLogger().Debug("Setting User-Agent for Wikipedia API request",
 		logger.String("provider", wikiProviderName),
-		logger.String("user_agent", l.userAgent),
-		logger.Int("user_agent_length", len(l.userAgent)),
+		logger.String("user_agent", userAgent),
+		logger.Int("user_agent_length", len(userAgent)),
 		logger.String("url", fullURL))
 
 	if l.debug {
@@ -416,13 +462,12 @@ func (l *wikiMediaProvider) handleCircuitBreaker(statusCode int, bodyStr string)
 
 // handleForbiddenError classifies and handles HTTP 403 errors.
 func (l *wikiMediaProvider) handleForbiddenError(bodyStr string) {
-	bodyLower := strings.ToLower(bodyStr)
 	truncated := truncateResponseBody(bodyStr, responseBodyPreviewLimit)
 
-	switch {
-	case strings.Contains(bodyLower, errorStringUserAgent) || strings.Contains(bodyLower, errorStringRobotPolicy):
+	switch classifyForbiddenBody(strings.ToLower(bodyStr)) {
+	case wikiErrorUserAgent:
 		l.openCircuit(circuitBreakerUserAgentDuration, fmt.Sprintf("User-Agent policy violation (HTTP 403): %s", truncated))
-	case strings.Contains(bodyLower, errorStringRate) || strings.Contains(bodyLower, errorStringLimit):
+	case wikiErrorRateLimit:
 		l.openCircuit(circuitBreakerRateLimitDuration, fmt.Sprintf("Rate limited (HTTP 403): %s", truncated))
 	default:
 		l.openCircuit(circuitBreakerBlockedDuration, fmt.Sprintf("Access blocked (HTTP 403): %s", truncated))
@@ -486,9 +531,14 @@ func (l *wikiMediaProvider) handleJSONParseError(body []byte, parseErr error) er
 // preventing race conditions during startup where conf.Setting() might return nil
 // or have an empty Version field.
 type LazyWikiMediaProvider struct {
-	once     sync.Once
+	mu       sync.Mutex
 	provider *wikiMediaProvider
-	initErr  error
+	// lastErr and nextRetry replace a sync.Once. The Once latched the first
+	// initialization error for the whole process lifetime, so a config wait that
+	// timed out at boot (10s, plausible on a slow Pi) left the provider
+	// permanently dead, with no retry and no log after the first line.
+	lastErr   error
+	nextRetry time.Time
 }
 
 // NewLazyWikiMediaProvider creates a new lazy-initialized Wikipedia provider.
@@ -499,39 +549,62 @@ func NewLazyWikiMediaProvider() *LazyWikiMediaProvider {
 
 // ensureInitialized creates the actual provider on first use, with validation.
 // It uses sync.Once to ensure thread-safe single initialization.
-func (l *LazyWikiMediaProvider) ensureInitialized() error {
-	l.once.Do(func() {
-		log := GetLogger().With(logger.String("provider", wikiProviderName))
-		// Wait for valid configuration (with timeout)
-		if !l.waitForValidConfig(configWaitTimeout) {
-			l.initErr = errors.Newf("configuration not available after timeout").
-				Component("imageprovider").
-				Category(errors.CategoryConfiguration).
-				Context("provider", wikiProviderName).
-				Context("operation", "lazy_init_timeout").
-				Build()
-			log.Error("LazyWikiMediaProvider: Configuration not available after timeout")
-			return
-		}
+func (l *LazyWikiMediaProvider) ensureInitialized(ctx context.Context) (*wikiMediaProvider, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
 
-		// Create the actual provider with valid configuration
-		l.provider, l.initErr = NewWikiMediaProvider()
-		if l.initErr != nil {
-			log.Error("LazyWikiMediaProvider: Failed to create provider", logger.Error(l.initErr))
-		} else {
-			log.Info("LazyWikiMediaProvider: Successfully initialized provider")
-		}
-	})
-	return l.initErr
+	if l.provider != nil {
+		return l.provider, nil
+	}
+	if l.lastErr != nil && time.Now().Before(l.nextRetry) {
+		return nil, l.lastErr
+	}
+
+	log := GetLogger().With(logger.String("provider", wikiProviderName))
+
+	// Wait for valid configuration (with timeout)
+	if !l.waitForValidConfig(ctx, configWaitTimeout) {
+		l.failInit(errors.Newf("configuration not available after timeout").
+			Component("imageprovider").
+			Category(errors.CategoryConfiguration).
+			Context("provider", wikiProviderName).
+			Context("operation", "lazy_init_timeout").
+			Build())
+		log.Error("LazyWikiMediaProvider: Configuration not available after timeout",
+			logger.Duration("retry_after", lazyInitRetryInterval))
+		return nil, l.lastErr
+	}
+
+	// Create the actual provider with valid configuration
+	provider, err := NewWikiMediaProvider()
+	if err != nil {
+		l.failInit(err)
+		log.Error("LazyWikiMediaProvider: Failed to create provider",
+			logger.Error(err),
+			logger.Duration("retry_after", lazyInitRetryInterval))
+		return nil, err
+	}
+
+	l.provider = provider
+	l.lastErr = nil
+	log.Info("LazyWikiMediaProvider: Successfully initialized provider")
+	return provider, nil
+}
+
+// failInit records an initialization failure and schedules the next attempt.
+// Callers must hold l.mu.
+func (l *LazyWikiMediaProvider) failInit(err error) {
+	l.lastErr = err
+	l.nextRetry = time.Now().Add(lazyInitRetryInterval)
 }
 
 // waitForValidConfig waits until configuration is available with a valid version.
-func (l *LazyWikiMediaProvider) waitForValidConfig(timeout time.Duration) bool {
+func (l *LazyWikiMediaProvider) waitForValidConfig(ctx context.Context, timeout time.Duration) bool {
 	deadline := time.Now().Add(timeout)
 	ticker := time.NewTicker(configCheckInterval)
 	defer ticker.Stop()
 
-	for time.Now().Before(deadline) {
+	for {
 		settings := conf.Setting()
 		if settings != nil && settings.Version != "" {
 			GetLogger().Debug("LazyWikiMediaProvider: Valid configuration detected",
@@ -539,25 +612,42 @@ func (l *LazyWikiMediaProvider) waitForValidConfig(timeout time.Duration) bool {
 				logger.String("version", settings.Version))
 			return true
 		}
-		<-ticker.C
+		if !time.Now().Before(deadline) {
+			return false
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-ticker.C:
+		}
 	}
-	return false
 }
 
 // Fetch implements the ImageProvider interface with lazy initialization.
+//
+// A context-free Fetch is treated as a foreground fetch, matching
+// wikiMediaProvider.Fetch: it passes the process-global limiter but not the
+// more conservative background one.
 func (l *LazyWikiMediaProvider) Fetch(scientificName string) (BirdImage, error) {
-	if err := l.ensureInitialized(); err != nil {
-		return BirdImage{}, err
-	}
-	return l.provider.Fetch(scientificName)
+	return l.FetchWithContext(context.Background(), scientificName)
 }
 
 // FetchWithContext implements context-aware fetching with lazy initialization.
 func (l *LazyWikiMediaProvider) FetchWithContext(ctx context.Context, scientificName string) (BirdImage, error) {
-	if err := l.ensureInitialized(); err != nil {
+	// The configuration gate runs before initialization. Initializing first meant
+	// a call that policy forbids still paid the config wait and emitted the full
+	// "Initializing WikiMedia provider" log block, which is very likely what was
+	// reported as Wikimedia activity despite `fallbackpolicy: none`.
+	if allowed, reason := wikiFetchAllowed(); !allowed {
+		logWikiFetchBlocked(scientificName, reason)
+		return BirdImage{}, ErrProviderNotConfigured
+	}
+
+	provider, err := l.ensureInitialized(ctx)
+	if err != nil {
 		return BirdImage{}, err
 	}
-	return l.provider.FetchWithContext(ctx, scientificName)
+	return provider.FetchWithContext(ctx, scientificName)
 }
 
 // ShouldRefreshCache implements ProviderStatusChecker interface.
@@ -565,19 +655,22 @@ func (l *LazyWikiMediaProvider) FetchWithContext(ctx context.Context, scientific
 // without requiring full provider initialization. This allows the provider to be registered
 // for UI discovery while preventing unnecessary cache operations when disabled.
 func (l *LazyWikiMediaProvider) ShouldRefreshCache() bool {
-	settings := conf.Setting()
-	if settings == nil {
-		return false
-	}
-
-	// Check if WikiMedia is configured as primary provider
-	if settings.Realtime.Dashboard.Thumbnails.ImageProvider == wikiProviderName {
+	// This is deliberately narrower than wikiFetchAllowed, which also permits
+	// "auto" and an unset provider because auto may elect WikiMedia. Refreshing
+	// is worth doing only when WikiMedia is actually in use, and under auto it
+	// is elected only if no other provider registers.
+	//
+	// What it must never be is BROADER than the fetch gate, or the hourly sweep
+	// schedules fetches that are all denied. It used to be, in two ways: it
+	// lowercased and trimmed the policy while the fetch side compared verbatim,
+	// so `fallbackpolicy: All` enabled the refresh while every fetch it
+	// scheduled was rejected; and it accepted a provider name ("wikimedia") as a
+	// value of the policy field, which is a category error with the same effect.
+	// Both conditions below imply wikiFetchAllowed, by construction.
+	if strings.EqualFold(strings.TrimSpace(thumbnailSettings().ImageProvider), wikiProviderName) {
 		return true
 	}
-
-	// Check if WikiMedia is configured as fallback provider
-	fallback := strings.ToLower(strings.TrimSpace(settings.Realtime.Dashboard.Thumbnails.FallbackPolicy))
-	return fallback == wikiProviderName || fallback == fallbackPolicyAll
+	return normalizedFallbackPolicy() == fallbackPolicyAll
 }
 
 // truncateResponseBody truncates a response body string to a specified length for logging.
@@ -587,35 +680,6 @@ func truncateResponseBody(body string, maxLength int) string {
 		return body
 	}
 	return body[:maxLength] + "..."
-}
-
-// buildUserAgent constructs a user-agent string that complies with Wikimedia's robot policy.
-// Format: <client name>/<version> (<contact information>) <library/framework name>/<version>
-// Reference: https://foundation.wikimedia.org/wiki/Policy:Wikimedia_Foundation_User-Agent_Policy
-func buildUserAgent(appVersion string) string {
-	if appVersion == "" {
-		appVersion = "unknown"
-	}
-
-	goVersion := runtime.Version()
-
-	// Format: BirdNET-Go/1.0.0 (https://github.com/tphakala/birdnet-go) Go-HTTP-Client/go1.21.0
-	return fmt.Sprintf("%s/%s (%s) %s/%s",
-		userAgentName, appVersion, branding.RepoURL(), userAgentLibrary, goVersion)
-}
-
-// logUserAgentValidation logs the constructed user-agent for debugging purposes
-func logUserAgentValidation(appVersion string) {
-	userAgent := buildUserAgent(appVersion)
-	GetLogger().Debug("Wikipedia user-agent validation",
-		logger.String("provider", wikiProviderName),
-		logger.String("user_agent", userAgent),
-		logger.String("complies_with_policy", "https://foundation.wikimedia.org/wiki/Policy:User-Agent_policy"),
-		logger.String("contains_app_name", userAgentName),
-		logger.String("contains_version", appVersion),
-		logger.String("contains_contact", branding.RepoURL()),
-		logger.String("contains_library", userAgentLibrary),
-		logger.String("go_version", runtime.Version()))
 }
 
 // htmlToText extracts the visible text content from an HTML fragment or
@@ -689,13 +753,14 @@ func detectWikipediaErrorType(statusCode int, responseBody []byte, contentType s
 	case http.StatusTooManyRequests:
 		return wikiErrorRateLimit, "Rate limit exceeded (HTTP 429)"
 	case http.StatusForbidden:
-		if strings.Contains(bodyLower, errorStringUserAgent) || strings.Contains(bodyLower, errorStringRobotPolicy) {
+		switch classifyForbiddenBody(bodyLower) {
+		case wikiErrorUserAgent:
 			return wikiErrorUserAgent, "User-Agent policy violation"
-		}
-		if strings.Contains(bodyLower, errorStringRate) || strings.Contains(bodyLower, errorStringLimit) {
+		case wikiErrorRateLimit:
 			return wikiErrorRateLimit, "Rate limit exceeded (403 with rate limit message)"
+		default:
+			return wikiErrorBlocked, "Access blocked (HTTP 403)"
 		}
-		return wikiErrorBlocked, "Access blocked (HTTP 403)"
 	case http.StatusServiceUnavailable:
 		return wikiErrorTemporary, "Service temporarily unavailable (HTTP 503)"
 	}
@@ -706,9 +771,7 @@ func detectWikipediaErrorType(statusCode int, responseBody []byte, contentType s
 		errorMsgLower := strings.ToLower(errorMsg)
 
 		// Check for rate limiting keywords in HTML content
-		if strings.Contains(errorMsgLower, errorStringRate+" "+errorStringLimit) ||
-			strings.Contains(errorMsgLower, "too many requests") ||
-			strings.Contains(errorMsgLower, errorStringThrottle) {
+		if mentionsRateLimit(errorMsgLower) {
 			return wikiErrorRateLimit, "Rate limit detected in HTML response"
 		}
 
@@ -835,7 +898,7 @@ func (l *wikiMediaProvider) classifyParseFailure(reqID, fullURL string, attempt 
 	case wikiErrorUserAgent:
 		// User-agent policy violation - open circuit breaker
 		l.openCircuit(circuitBreakerUserAgentDuration, "User-Agent policy violation")
-		return checkUserAgentPolicyViolation(reqID, failure.statusCode, body, l.userAgent)
+		return checkUserAgentPolicyViolation(reqID, failure.statusCode, body, appUserAgent())
 
 	case wikiErrorTemporary:
 		// Temporary error - continue with retry logic but with longer backoff
@@ -927,20 +990,21 @@ func logAPISuccess(reqID, species, operation string) {
 func NewWikiMediaProvider() (*wikiMediaProvider, error) {
 	log := GetLogger().With(logger.String("provider", wikiProviderName))
 	log.Info("Initializing WikiMedia provider")
-	settings := conf.Setting()
+	debug := thumbnailSettings().Debug
+	appVersion := currentAppVersion()
 
 	// Log debug mode if configured
-	if settings.Realtime.Dashboard.Thumbnails.Debug {
+	if debug {
 		log.Info("Debug mode enabled for WikiMedia provider",
 			logger.Bool("debug", true))
 	}
 
-	// Build and validate user-agent
-	userAgent := buildUserAgent(settings.Version)
-	logUserAgentValidation(settings.Version)
+	// Log the user-agent. It is resolved per request rather than stored here, so
+	// this is a diagnostic snapshot rather than the value that will be sent.
+	logUserAgentValidation(appVersion)
 	log.Info("WikiMedia provider initialization - user-agent constructed",
-		logger.String("user_agent", userAgent),
-		logger.String("app_version", settings.Version))
+		logger.String("user_agent", buildUserAgent(appVersion)),
+		logger.String("app_version", appVersion))
 
 	// Clone DefaultTransport (per golang/go#26013) to inherit proxy support and
 	// dial timeouts, then override pool/timeout settings for Wikipedia API usage.
@@ -969,8 +1033,7 @@ func NewWikiMediaProvider() (*wikiMediaProvider, error) {
 	return &wikiMediaProvider{
 		httpClient:        httpClient,
 		apiURL:            wikipediaAPIURL,
-		userAgent:         userAgent,
-		debug:             settings.Realtime.Dashboard.Thumbnails.Debug,
+		debug:             debug,
 		globalLimiter:     globalLimiter,
 		backgroundLimiter: backgroundLimiter,
 		maxRetries:        defaultMaxRetries,
@@ -1260,7 +1323,7 @@ func logFirstPageContent(page *wikiPage, fullURL string) {
 }
 
 // queryAndGetFirstPageWithLimiter queries Wikipedia with given parameters using the specified rate limiter.
-func (l *wikiMediaProvider) queryAndGetFirstPageWithLimiter(ctx context.Context, reqID string, params map[string]string, limiter *rate.Limiter) (*wikiPage, error) {
+func (l *wikiMediaProvider) queryAndGetFirstPageWithLimiter(ctx context.Context, reqID string, params map[string]string, limiter *rate.Limiter) (page *wikiPage, redirects []wikiRedirect, err error) {
 	log := GetLogger().With(
 		logger.String("provider", wikiProviderName),
 		logger.String("request_id", reqID),
@@ -1272,52 +1335,116 @@ func (l *wikiMediaProvider) queryAndGetFirstPageWithLimiter(ctx context.Context,
 
 	resp, err := l.queryWithRetryAndLimiter(ctx, reqID, params, limiter)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	logRawResponse(resp, fullURL)
 	log.Debug("Parsing pages from API response")
 
-	if resp.Query == nil {
+	// A structured error object means the API refused the request, not that the
+	// species has no page. MediaWiki returns these with HTTP 200 for
+	// ratelimited, maxlag and readonly, so classifying them as "not found" is
+	// what let a Wikipedia throttling window persist as durable __NOT_FOUND__
+	// rows for every species queried during it.
+	if resp.Error != nil {
 		logQueryMissingError(resp, params, fullURL)
-		return nil, imageNotFoundFor(params["titles"], wikiProviderName, "wiki_query_missing")
+		return nil, nil, l.wikiAPIErrorFor(resp.Error, params["titles"], reqID)
+	}
+
+	if resp.Query == nil {
+		// With formatversion=2 an absent page is reported as
+		// pages:[{missing:true}], so a nil query with no error object is a
+		// malformed response rather than a missing species. Report it as such:
+		// a not-found verdict here would be cached as "this species has no
+		// image" for the full negative TTL.
+		logQueryMissingError(resp, params, fullURL)
+		return nil, nil, errors.Newf("Wikipedia response contained neither a query nor an error object").
+			Component("imageprovider").
+			Category(errors.CategoryNetwork).
+			Context("provider", wikiProviderName).
+			Context("request_id", reqID).
+			Context("scientific_name", params["titles"]).
+			Context("operation", "wiki_query_missing").
+			Build()
 	}
 
 	if len(resp.Query.Pages) == 0 {
 		logNoPages(resp, params, fullURL)
-		return nil, imageNotFoundFor(params["titles"], wikiProviderName, "wiki_pages_empty")
+		return nil, nil, imageNotFoundFor(params["titles"], wikiProviderName, "wiki_pages_empty")
 	}
 
-	logFirstPageContent(&resp.Query.Pages[0], fullURL)
+	first := &resp.Query.Pages[0]
+	if first.Missing {
+		log.Debug("Wikipedia reports no such page", logger.String("title", first.Title))
+		return nil, nil, imageNotFoundFor(params["titles"], wikiProviderName, "wiki_page_missing")
+	}
+
+	logFirstPageContent(first, fullURL)
 	logAPISuccess(reqID, params["titles"], "get_first_page")
 
-	return &resp.Query.Pages[0], nil
+	return first, resp.Query.Redirects, nil
 }
 
-// isAllowedToFetch checks if the WikiMedia provider is allowed to make requests
-// based on the current configuration. This prevents unnecessary API calls to Wikipedia
-// when the provider is not configured for use.
-func (l *wikiMediaProvider) isAllowedToFetch() (allowed bool, reason string) {
+// wikiAPIErrorFor converts a MediaWiki structured error object into an error.
+//
+// Only codes meaning "this title can never resolve" are reported as
+// ErrImageNotFound, because that is the verdict the cache persists as a
+// negative entry. Everything else is a provider-side failure that must not be
+// recorded as "this species has no image". A rate-limit code additionally opens
+// the circuit breaker: these arrive with HTTP 200, so the status-code path that
+// normally trips the breaker never sees them.
+func (l *wikiMediaProvider) wikiAPIErrorFor(apiErr *wikiAPIError, title, reqID string) error {
+	code := strings.ToLower(strings.TrimSpace(apiErr.Code))
+
+	switch code {
+	case "invalidtitle", "missingtitle", "nosuchpageid":
+		return imageNotFoundFor(title, wikiProviderName, "wiki_api_"+code)
+	}
+
+	if mentionsRateLimit(code) || mentionsRateLimit(strings.ToLower(apiErr.Info)) {
+		l.openCircuit(circuitBreakerRateLimitDuration,
+			fmt.Sprintf("Rate limited (API error %s): %s", apiErr.Code,
+				truncateResponseBody(apiErr.Info, responseBodyPreviewLimit)))
+	}
+
+	return errors.Newf("Wikipedia API error %s: %s", apiErr.Code,
+		truncateResponseBody(apiErr.Info, responseBodyPreviewLimit)).
+		Component("imageprovider").
+		Category(errors.CategoryNetwork).
+		Context("provider", wikiProviderName).
+		Context("request_id", reqID).
+		Context("scientific_name", title).
+		Context("api_error_code", apiErr.Code).
+		Context("operation", "wiki_api_error").
+		Build()
+}
+
+// wikiFetchAllowed reports whether the WikiMedia provider is allowed to make
+// requests under the current configuration. This prevents unnecessary API calls
+// to Wikipedia when the provider is not configured for use. It is a package
+// function rather than a method so the lazy wrapper can consult it before
+// paying for initialization.
+func wikiFetchAllowed() (allowed bool, reason string) {
 	settings := conf.Setting()
 	if settings == nil {
-		// If settings are not available, allow for backward compatibility
-		return true, ""
+		// Fail closed. Settings are nil only before the config loads or when
+		// loading failed, and permitting outbound Wikipedia traffic in that
+		// window contradicts a configured `fallbackpolicy: none`. The sibling
+		// refresh gate already failed closed on the same condition.
+		return false, "settings unavailable"
 	}
 
 	thumbnails := settings.Realtime.Dashboard.Thumbnails
 
-	// Case 1: WikiMedia is explicitly configured as the provider
-	if thumbnails.ImageProvider == wikiProviderName {
+	// Cases 1 and 2: WikiMedia is the configured provider, or auto mode may
+	// select it (it does when no other provider registers).
+	switch strings.ToLower(strings.TrimSpace(thumbnails.ImageProvider)) {
+	case wikiProviderName, providerAuto, "":
 		return true, ""
 	}
 
-	// Case 2: Auto mode may select WikiMedia
-	if thumbnails.ImageProvider == "auto" || thumbnails.ImageProvider == "" {
-		return true, ""
-	}
-
-	// Case 3: WikiMedia can be used as a fallback
-	if thumbnails.FallbackPolicy == fallbackPolicyAll {
+	// Case 3: WikiMedia can be used as a fallback.
+	if normalizedFallbackPolicy() == fallbackPolicyAll {
 		return true, ""
 	}
 
@@ -1327,19 +1454,22 @@ func (l *wikiMediaProvider) isAllowedToFetch() (allowed bool, reason string) {
 	return false, reason
 }
 
+// logWikiFetchBlocked records a fetch refused by configuration.
+func logWikiFetchBlocked(scientificName, reason string) {
+	GetLogger().Debug("WikiMedia fetch blocked by configuration",
+		logger.String("provider", wikiProviderName),
+		logger.String("scientific_name", scientificName),
+		logger.String("config_reason", reason),
+		logger.String("hint", "WikiMedia is not the configured provider and fallback is disabled"))
+}
+
 // FetchWithContext retrieves the bird image for a given scientific name using a context.
 // All requests pass through the global 1 req/s limiter; background operations also
 // use an additional background-specific limiter for more conservative rate limiting.
 func (l *wikiMediaProvider) FetchWithContext(ctx context.Context, scientificName string) (BirdImage, error) {
 	// Check if we're allowed to make requests to WikiMedia
-	if allowed, reason := l.isAllowedToFetch(); !allowed {
-		GetLogger().Debug("WikiMedia fetch blocked by configuration",
-			logger.String("provider", wikiProviderName),
-			logger.String("scientific_name", scientificName),
-			logger.String("config_reason", reason),
-			logger.String("context", "background_operation"),
-			logger.String("hint", "WikiMedia is not the configured provider and fallback is disabled"))
-
+	if allowed, reason := wikiFetchAllowed(); !allowed {
+		logWikiFetchBlocked(scientificName, reason)
 		return BirdImage{}, ErrProviderNotConfigured
 	}
 
@@ -1365,13 +1495,8 @@ func (l *wikiMediaProvider) FetchWithContext(ctx context.Context, scientificName
 // means neither the retry backoff nor the limiter wait can be cancelled.
 func (l *wikiMediaProvider) Fetch(scientificName string) (BirdImage, error) {
 	// Check if we're allowed to make requests to WikiMedia
-	if allowed, reason := l.isAllowedToFetch(); !allowed {
-		GetLogger().Debug("WikiMedia fetch blocked by configuration",
-			logger.String("provider", wikiProviderName),
-			logger.String("scientific_name", scientificName),
-			logger.String("config_reason", reason),
-			logger.String("hint", "WikiMedia is not the configured provider and fallback is disabled"))
-
+	if allowed, reason := wikiFetchAllowed(); !allowed {
+		logWikiFetchBlocked(scientificName, reason)
 		return BirdImage{}, ErrProviderNotConfigured
 	}
 
@@ -1397,15 +1522,27 @@ func (l *wikiMediaProvider) fetchWithLimiter(ctx context.Context, scientificName
 		logger.String("rate_limit_type", rateLimitType),
 		logger.String("diagnostic_info", "beginning_wikipedia_image_fetch_operation"))
 
-	thumbnailURL, thumbnailSourceFile, err := l.queryThumbnail(ctx, reqID, scientificName, limiter)
-	if errors.Is(err, ErrImageNotFound) {
-		// If thumbnail not found, try taxonomy synonym before giving up
-		if synonym, hasSynonym := GetTaxonomySynonym(scientificName); hasSynonym {
-			log.Debug("Retrying Wikipedia fetch with taxonomy synonym",
-				logger.String("original_name", scientificName),
-				logger.String("synonym", synonym))
-			thumbnailURL, thumbnailSourceFile, err = l.queryThumbnail(ctx, reqID, synonym, limiter)
-		}
+	// A configured taxonomy synonym is the user asserting that the primary name
+	// is the wrong one to ask Wikipedia for, so it goes first. Consulting it
+	// only after a failure was backwards, and meant it could not fix the case it
+	// is added for: a lookup that succeeds under the primary name and returns
+	// the wrong image. The original name is still tried if the synonym misses,
+	// so this costs no extra request in the common case.
+	queryName := scientificName
+	synonym, hasSynonym := GetTaxonomySynonym(scientificName)
+	if hasSynonym {
+		log.Debug("Querying Wikipedia with the configured taxonomy synonym first",
+			logger.String("original_name", scientificName),
+			logger.String("synonym", synonym))
+		queryName = synonym
+	}
+
+	thumbnailURL, thumbnailSourceFile, err := l.queryThumbnail(ctx, reqID, queryName, limiter)
+	if hasSynonym && errors.Is(err, ErrImageNotFound) {
+		log.Debug("Synonym had no usable thumbnail, retrying with the original name",
+			logger.String("original_name", scientificName),
+			logger.String("synonym", synonym))
+		thumbnailURL, thumbnailSourceFile, err = l.queryThumbnail(ctx, reqID, scientificName, limiter)
 	}
 	if err != nil {
 		return BirdImage{}, err
@@ -1414,6 +1551,14 @@ func (l *wikiMediaProvider) fetchWithLimiter(ctx context.Context, scientificName
 		logger.String("thumbnail_url", thumbnailURL),
 		logger.String("source_file", thumbnailSourceFile))
 
+	// Without a pageimage filename there is no file page to ask, so the
+	// attribution query is skipped rather than failed. The thumbnail itself is
+	// usable and is what the user came for.
+	if thumbnailSourceFile == "" {
+		log.Debug("No pageimage filename, using default attribution")
+		return l.buildBirdImage(reqID, scientificName, thumbnailURL, unknownAuthorInfo()), nil
+	}
+
 	authorInfo, err := l.queryAuthorInfo(ctx, reqID, thumbnailSourceFile, limiter)
 	if err != nil {
 		// If it's just a "not found" error, continue with default author info
@@ -1421,12 +1566,7 @@ func (l *wikiMediaProvider) fetchWithLimiter(ctx context.Context, scientificName
 		if errors.Is(err, ErrImageNotFound) {
 			log.Debug("Author info not available, using defaults")
 			// Use default author info rather than failing
-			authorInfo = &wikiMediaAuthor{
-				name:        unknownMetadataValue,
-				URL:         "",
-				licenseName: unknownMetadataValue,
-				licenseURL:  "",
-			}
+			authorInfo = unknownAuthorInfo()
 		} else {
 			// This is a real error (network, API issues), so we should report it.
 			//
@@ -1453,7 +1593,27 @@ func (l *wikiMediaProvider) fetchWithLimiter(ctx context.Context, scientificName
 		logger.String("author", authorInfo.name),
 		logger.String("license", authorInfo.licenseName))
 
-	result := BirdImage{
+	return l.buildBirdImage(reqID, scientificName, thumbnailURL, authorInfo), nil
+}
+
+// unknownAuthorInfo is the attribution used when Wikipedia has no usable
+// metadata for an otherwise usable thumbnail.
+func unknownAuthorInfo() *wikiMediaAuthor {
+	return &wikiMediaAuthor{
+		name:        unknownMetadataValue,
+		URL:         "",
+		licenseName: unknownMetadataValue,
+		licenseURL:  "",
+	}
+}
+
+// buildBirdImage assembles the result and emits the success log shared by the
+// with-attribution and without-attribution paths.
+func (l *wikiMediaProvider) buildBirdImage(reqID, scientificName, thumbnailURL string, authorInfo *wikiMediaAuthor) BirdImage {
+	// Enhanced success logging with complete operation summary
+	logAPISuccess(reqID, scientificName, "complete_fetch_operation")
+
+	return BirdImage{
 		URL:            thumbnailURL,
 		ScientificName: scientificName,
 		AuthorName:     authorInfo.name,
@@ -1462,11 +1622,6 @@ func (l *wikiMediaProvider) fetchWithLimiter(ctx context.Context, scientificName
 		LicenseURL:     authorInfo.licenseURL,
 		SourceProvider: wikiProviderName, // Set the provider name
 	}
-
-	// Enhanced success logging with complete operation summary
-	logAPISuccess(reqID, scientificName, "complete_fetch_operation")
-
-	return result, nil
 }
 
 // queryThumbnail queries Wikipedia for the thumbnail image of the given scientific name.
@@ -1487,10 +1642,13 @@ func (l *wikiMediaProvider) queryThumbnail(ctx context.Context, reqID, scientifi
 		"pilicense":     "free",
 		"titles":        scientificName,
 		"pithumbsize":   "400",
-		"redirects":     "",
+		// Redirect following stays on: most bird articles are titled by common
+		// name, so a scientific name usually only resolves through its redirect.
+		// The redirect target is validated below instead.
+		"redirects": "",
 	}
 
-	page, err := l.queryAndGetFirstPageWithLimiter(ctx, reqID, params, limiter)
+	page, redirects, err := l.queryAndGetFirstPageWithLimiter(ctx, reqID, params, limiter)
 	if err != nil {
 		// Log based on error type
 		if errors.Is(err, ErrImageNotFound) {
@@ -1514,6 +1672,12 @@ func (l *wikiMediaProvider) queryThumbnail(ctx context.Context, reqID, scientifi
 		return "", "", enhancedErr
 	}
 
+	if target, left := redirectLeftSpecies(scientificName, redirects); left {
+		log.Debug("Discarding thumbnail from a redirect to a broader taxon",
+			logger.String("redirect_target", target))
+		return "", "", imageNotFoundFor(scientificName, wikiProviderName, "wiki_redirect_left_species")
+	}
+
 	if page.Thumbnail == nil || page.Thumbnail.Source == "" {
 		log.Debug("No thumbnail URL found in page data")
 		// This is common for pages without images or with non-free images
@@ -1522,19 +1686,107 @@ func (l *wikiMediaProvider) queryThumbnail(ctx context.Context, reqID, scientifi
 	}
 	thumbnailURL = page.Thumbnail.Source
 
-	if page.PageImage == "" {
-		log.Debug("No pageimage filename found in page data")
-		// This is common for pages without proper image metadata
-		// Don't create telemetry noise - treat as "not found"
-		return "", "", imageNotFoundFor(scientificName, wikiProviderName, "wiki_no_pageimage")
-	}
+	// An empty pageimage filename is not a reason to throw the thumbnail away.
+	// It is only the key for the second, attribution query, and the caller
+	// already falls back to "Unknown" attribution when that query fails.
 	fileName = page.PageImage
+	if fileName == "" {
+		log.Debug("No pageimage filename in page data; serving the thumbnail without attribution metadata")
+	}
 
 	log.Debug("Successfully retrieved thumbnail URL and filename",
 		logger.String("url", thumbnailURL),
 		logger.String("filename", fileName))
 
 	return thumbnailURL, fileName, nil
+}
+
+// supraGenericSuffixes are the endings of scientific names above genus rank.
+// A single-word article title carrying one of these is a family, subfamily,
+// superfamily or order article, never a species article.
+//
+// The tribe suffix "-ini" is deliberately absent: it is short enough to end an
+// ordinary word, and tribe-level redirects are rare next to genus and family
+// ones, so including it would risk discarding a valid single-word common-name
+// article for very little gain.
+var supraGenericSuffixes = []string{"idae", "inae", "oidea", "iformes", "aceae"}
+
+// redirectLeftSpecies reports whether the API followed a redirect from the
+// requested species to an article about a broader taxon.
+//
+// Wikipedia redirects a species that has no article of its own up to its genus
+// or family article, and that article's pageimage is routinely a distribution
+// map or a congener. The lookup still succeeds, so the wrong image was written
+// as a positive cache entry and the taxonomy-synonym map, which is consulted
+// only on failure, never got a chance to correct it. That is how a wrong image
+// became permanent.
+//
+// The check costs no extra request: a redirect to a higher rank has a target
+// that is a single word which is either the genus of the queried binomial or
+// carries a supra-generic rank suffix. Multi-word targets are common-name
+// articles and are exactly what redirect following is for, so they pass.
+func redirectLeftSpecies(scientificName string, redirects []wikiRedirect) (target string, left bool) {
+	if len(redirects) == 0 {
+		return "", false
+	}
+
+	target = resolveRedirectTarget(scientificName, redirects)
+	if target == "" || strings.EqualFold(target, scientificName) {
+		return "", false
+	}
+
+	// Multi-word targets are common-name (or binomial) articles.
+	if strings.ContainsAny(target, " _") {
+		return "", false
+	}
+
+	genus, _, isBinomial := strings.Cut(scientificName, " ")
+	if isBinomial && strings.EqualFold(target, genus) {
+		return target, true
+	}
+
+	targetLower := strings.ToLower(target)
+	for _, suffix := range supraGenericSuffixes {
+		if strings.HasSuffix(targetLower, suffix) {
+			return target, true
+		}
+	}
+
+	return "", false
+}
+
+// resolveRedirectTarget walks the redirect chain from the requested title.
+// MediaWiki does not follow double redirects, so the chain is normally one hop;
+// the loop is bounded anyway. If no hop starts at the requested title, the last
+// reported target is used, which covers the case where the API normalized the
+// title before redirecting it.
+func resolveRedirectTarget(scientificName string, redirects []wikiRedirect) string {
+	current := scientificName
+	for range redirects {
+		next := ""
+		for i := range redirects {
+			if titlesEqual(redirects[i].From, current) {
+				next = redirects[i].To
+				break
+			}
+		}
+		if next == "" {
+			break
+		}
+		current = next
+	}
+
+	if titlesEqual(current, scientificName) {
+		return redirects[len(redirects)-1].To
+	}
+	return current
+}
+
+// titlesEqual compares two MediaWiki titles, which treat underscore and space
+// as the same character and are case-insensitive on the first letter only.
+// Case-insensitive comparison throughout is close enough for this purpose.
+func titlesEqual(a, b string) bool {
+	return strings.EqualFold(strings.ReplaceAll(a, "_", " "), strings.ReplaceAll(b, "_", " "))
 }
 
 // queryAuthorInfo queries Wikipedia for the author information of the given thumbnail URL.
@@ -1557,7 +1809,7 @@ func (l *wikiMediaProvider) queryAuthorInfo(ctx context.Context, reqID, thumbnai
 		"redirects":     "",
 	}
 
-	page, err := l.queryAndGetFirstPageWithLimiter(ctx, reqID, params, limiter)
+	page, _, err := l.queryAndGetFirstPageWithLimiter(ctx, reqID, params, limiter)
 	if err != nil {
 		// Log based on error type
 		if errors.Is(err, ErrImageNotFound) {
@@ -1642,18 +1894,8 @@ func (l *wikiMediaProvider) queryAuthorInfo(ctx context.Context, reqID, thumbnai
 // CategoryNetwork throttle as CategoryImageFetch turns a suppressed transient into a
 // per-species Sentry event.
 func causeCategory(err error, fallback errors.ErrorCategory) errors.ErrorCategory {
-	// Check the interface first, mirroring internal/errors.detectCategory: a cause can
-	// carry a category without being an *EnhancedError, and re-tagging one of those to
-	// the fallback is exactly the suppression regression this helper exists to prevent.
-	var categorized errors.CategorizedError
-	if errors.As(err, &categorized) {
-		if category := categorized.ErrorCategory(); category != "" {
-			return category
-		}
-	}
-	var enhanced *errors.EnhancedError
-	if errors.As(err, &enhanced) && enhanced.Category != "" {
-		return enhanced.Category
+	if category := errors.CategoryOf(err); category != "" {
+		return category
 	}
 	return fallback
 }

--- a/internal/imageprovider/wikipedia.go
+++ b/internal/imageprovider/wikipedia.go
@@ -518,7 +518,13 @@ func (l *wikiMediaProvider) handleJSONParseError(body []byte, parseErr error) er
 // preventing race conditions during startup where conf.Setting() might return nil
 // or have an empty Version field.
 type LazyWikiMediaProvider struct {
-	mu       sync.Mutex
+	// initSem is a one-slot semaphore rather than a sync.Mutex so that
+	// acquisition is cancellable. Initialization waits up to configWaitTimeout
+	// for the configuration, and a caller with a shorter deadline (the
+	// new-species image warm allows 3s) must be able to give up rather than
+	// block on a lock for another caller's full wait. Same reason the
+	// per-species init lock is a buffered channel.
+	initSem  chan struct{}
 	provider *wikiMediaProvider
 	// lastErr and nextRetry replace a sync.Once. The Once latched the first
 	// initialization error for the whole process lifetime, so a config wait that
@@ -531,15 +537,18 @@ type LazyWikiMediaProvider struct {
 // NewLazyWikiMediaProvider creates a new lazy-initialized Wikipedia provider.
 // The actual provider creation is deferred until first use.
 func NewLazyWikiMediaProvider() *LazyWikiMediaProvider {
-	return &LazyWikiMediaProvider{}
+	return &LazyWikiMediaProvider{initSem: make(chan struct{}, 1)}
 }
 
 // ensureInitialized creates the actual provider on first use, with validation.
 // A mutex plus a retry deadline, rather than a sync.Once: the Once latched the
 // first failure for the process lifetime (see the struct fields).
 func (l *LazyWikiMediaProvider) ensureInitialized(ctx context.Context) (*wikiMediaProvider, error) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
+	release, err := l.acquireInit(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 
 	if l.provider != nil {
 		return l.provider, nil
@@ -590,8 +599,23 @@ func (l *LazyWikiMediaProvider) ensureInitialized(ctx context.Context) (*wikiMed
 	return provider, nil
 }
 
+// acquireInit takes the one-slot init semaphore, abandoning the attempt if the
+// caller's context ends first. A zero-valued provider (only tests build one)
+// has no semaphore, so it falls back to an uncontended acquire.
+func (l *LazyWikiMediaProvider) acquireInit(ctx context.Context) (release func(), err error) {
+	if l.initSem == nil {
+		return func() {}, nil
+	}
+	select {
+	case l.initSem <- struct{}{}:
+		return func() { <-l.initSem }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
 // failInit records an initialization failure and schedules the next attempt.
-// Callers must hold l.mu.
+// Callers must hold the init semaphore.
 func (l *LazyWikiMediaProvider) failInit(err error) {
 	l.lastErr = err
 	l.nextRetry = time.Now().Add(lazyInitRetryInterval)
@@ -1457,8 +1481,11 @@ func wikiFetchAllowedFor(settings *conf.Settings) (allowed bool, reason string) 
 		return true, ""
 	}
 
-	// Case 3: WikiMedia can be used as a fallback.
-	if normalizedFallbackPolicy() == fallbackPolicyAll {
+	// Case 3: WikiMedia can be used as a fallback. Read from the settings passed
+	// in, not through normalizedFallbackPolicy, which re-reads the global: a
+	// seam that decided half its answer from its argument and half from a global
+	// would give a caller passing anything else a spliced verdict.
+	if normalizeProviderName(thumbnails.FallbackPolicy) == fallbackPolicyAll {
 		return true, ""
 	}
 

--- a/internal/imageprovider/wikipedia.go
+++ b/internal/imageprovider/wikipedia.go
@@ -611,6 +611,12 @@ func (l *LazyWikiMediaProvider) waitForValidConfig(ctx context.Context, timeout 
 				logger.String("version", settings.Version))
 			return true
 		}
+		// Caller first: when both its context and our deadline have expired, the
+		// caller giving up is the truthful answer, and it is the one that must
+		// not be recorded as a configuration failure.
+		if ctx.Err() != nil {
+			return false
+		}
 		if !time.Now().Before(deadline) {
 			return false
 		}
@@ -1759,26 +1765,27 @@ func redirectLeftSpecies(scientificName string, redirects []wikiRedirect) (targe
 		return "", false
 	}
 
-	// Every word is tested, not just a single-word title, so that a
-	// parenthetically disambiguated or otherwise qualified taxon article
-	// ("Accipitridae (family)") is caught too. This is safe because no English
-	// common name and no binomial has a word ending in a supra-generic suffix.
-	for word := range strings.FieldsFuncSeq(strings.ToLower(target), isTitleSeparator) {
-		for _, suffix := range supraGenericSuffixes {
-			if strings.HasSuffix(word, suffix) {
-				return target, true
-			}
+	// Only a single-word target is tested. A supra-generic name is one word, and
+	// a binomial is two, so this cannot reject a species article.
+	//
+	// Testing every word instead would: nine binomials in the shipped label set
+	// carry a Latin genitive epithet that ends in one of these suffixes
+	// (Pyrrhura molinae, Setophaga adelaidae, Crypturellus duidae and six more),
+	// so a synonym redirect landing on one of them would be discarded and, since
+	// the rejection is reported as ErrImageNotFound, cached as "no image". No
+	// common name in that label set collides.
+	if strings.ContainsAny(target, " _") {
+		return "", false
+	}
+
+	targetLower := strings.ToLower(target)
+	for _, suffix := range supraGenericSuffixes {
+		if strings.HasSuffix(targetLower, suffix) {
+			return target, true
 		}
 	}
 
 	return "", false
-}
-
-// isTitleSeparator reports whether r separates words in a MediaWiki title.
-// Underscore is title syntax for a space, and parentheses delimit a
-// disambiguating qualifier.
-func isTitleSeparator(r rune) bool {
-	return r == ' ' || r == '_' || r == '(' || r == ')'
 }
 
 // resolveRedirectTarget walks the redirect chain from the requested title.

--- a/internal/imageprovider/wikipedia.go
+++ b/internal/imageprovider/wikipedia.go
@@ -46,8 +46,12 @@ const (
 	backgroundRateLimitPerSecond = 1 // Requests per second for background operations
 
 	// Retry and delay configuration
-	defaultMaxRetries   = 3
-	retryMinDelay       = 2 * time.Second
+	defaultMaxRetries = 3
+	retryMinDelay     = 2 * time.Second
+	// reasonSettingsUnavailable is the refusal reason recorded when the
+	// configuration itself could not be read, as distinct from a policy choice.
+	reasonSettingsUnavailable = "settings unavailable"
+
 	configWaitTimeout   = 10 * time.Second
 	configCheckInterval = 100 * time.Millisecond
 	// lazyInitRetryInterval bounds how often a failed lazy initialization is
@@ -179,11 +183,13 @@ type wikiRedirect struct {
 // wikiPage models a single page entry from a MediaWiki query response.
 type wikiPage struct {
 	Title string `json:"title"`
-	// Missing is how formatversion=2 reports a title that has no article. It has
-	// to be modelled explicitly: without it the only "no such page" signal the
-	// code could see was a nil query object, which the API also produces for
-	// structured errors on HTTP 200 (ratelimited, maxlag, readonly). Conflating
-	// the two persisted a rate-limit window as a durable __NOT_FOUND__ row.
+	// Missing is how formatversion=2 reports a title that has no article, and
+	// modelling it gives that case a first-class verdict instead of inferring it
+	// further down from an absent thumbnail. The separate defect it is often
+	// confused with, a nil query object being read as "no such species" when the
+	// API also produces one for a structured error on HTTP 200 (ratelimited,
+	// maxlag, readonly), is fixed by the explicit error branch in
+	// queryAndGetFirstPageWithLimiter, not by this field.
 	Missing   bool            `json:"missing"`
 	Thumbnail *wikiThumbnail  `json:"thumbnail"`
 	PageImage string          `json:"pageimage"`
@@ -269,10 +275,6 @@ func (l *wikiMediaProvider) makeAPIRequest(ctx context.Context, params map[strin
 		return nil, err
 	}
 
-	if err := l.validateUserAgent(); err != nil {
-		return nil, err
-	}
-
 	fullURL, err := l.buildRequestURL(params)
 	if err != nil {
 		return nil, err
@@ -309,21 +311,6 @@ func (l *wikiMediaProvider) waitForGlobalRateLimit(ctx context.Context) error {
 			Build()
 	}
 	GetLogger().Debug("Global rate limiter wait completed", logger.String("provider", wikiProviderName))
-	return nil
-}
-
-// validateUserAgent ensures the User-Agent is set.
-func (l *wikiMediaProvider) validateUserAgent() error {
-	if appUserAgent() == "" {
-		GetLogger().Error("User-Agent is empty! This will cause Wikipedia to reject the request",
-			logger.String("provider", wikiProviderName))
-		return errors.Newf("User-Agent not set for Wikipedia provider").
-			Component("imageprovider").
-			Category(errors.CategoryConfiguration).
-			Context("provider", wikiProviderName).
-			Context("operation", "missing_user_agent").
-			Build()
-	}
 	return nil
 }
 
@@ -548,7 +535,8 @@ func NewLazyWikiMediaProvider() *LazyWikiMediaProvider {
 }
 
 // ensureInitialized creates the actual provider on first use, with validation.
-// It uses sync.Once to ensure thread-safe single initialization.
+// A mutex plus a retry deadline, rather than a sync.Once: the Once latched the
+// first failure for the process lifetime (see the struct fields).
 func (l *LazyWikiMediaProvider) ensureInitialized(ctx context.Context) (*wikiMediaProvider, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -564,6 +552,17 @@ func (l *LazyWikiMediaProvider) ensureInitialized(ctx context.Context) (*wikiMed
 
 	// Wait for valid configuration (with timeout)
 	if !l.waitForValidConfig(ctx, configWaitTimeout) {
+		// THIS caller gave up, which says nothing about whether the
+		// configuration will ever arrive. Recording it would arm the retry
+		// deadline and refuse every other caller for a minute on the strength of
+		// one short-lived context: warmSpeciesImage, for instance, allows only
+		// 3s. Report the cancellation and leave the provider re-attemptable.
+		if err := ctx.Err(); err != nil {
+			log.Debug("LazyWikiMediaProvider: initialization abandoned by the caller",
+				logger.Error(err))
+			return nil, err
+		}
+
 		l.failInit(errors.Newf("configuration not available after timeout").
 			Component("imageprovider").
 			Category(errors.CategoryConfiguration).
@@ -667,7 +666,7 @@ func (l *LazyWikiMediaProvider) ShouldRefreshCache() bool {
 	// scheduled was rejected; and it accepted a provider name ("wikimedia") as a
 	// value of the policy field, which is a category error with the same effect.
 	// Both conditions below imply wikiFetchAllowed, by construction.
-	if strings.EqualFold(strings.TrimSpace(thumbnailSettings().ImageProvider), wikiProviderName) {
+	if normalizedImageProvider() == wikiProviderName {
 		return true
 	}
 	return normalizedFallbackPolicy() == fallbackPolicyAll
@@ -794,10 +793,13 @@ func checkUserAgentPolicyViolation(reqID string, statusCode int, responseBody []
 		return nil
 	}
 
-	// Convert to lowercase once for efficient comparison
+	// Single-sourced with the circuit-breaker and error-reporting paths. This
+	// used to re-derive the verdict from raw substrings, which its only caller
+	// had already obtained from classifyForbiddenBody; if the two ever diverged
+	// this returned nil, no permanent failure was reported, and the retry loop
+	// kept hammering a host that had just refused the User-Agent.
 	bodyStr := string(responseBody)
-	bodyLower := strings.ToLower(bodyStr)
-	if !strings.Contains(bodyLower, errorStringUserAgent) && !strings.Contains(bodyLower, errorStringRobotPolicy) {
+	if classifyForbiddenBody(strings.ToLower(bodyStr)) != wikiErrorUserAgent {
 		return nil
 	}
 
@@ -1001,9 +1003,10 @@ func NewWikiMediaProvider() (*wikiMediaProvider, error) {
 
 	// Log the user-agent. It is resolved per request rather than stored here, so
 	// this is a diagnostic snapshot rather than the value that will be sent.
+	userAgent := buildUserAgent(appVersion)
 	logUserAgentValidation(appVersion)
 	log.Info("WikiMedia provider initialization - user-agent constructed",
-		logger.String("user_agent", buildUserAgent(appVersion)),
+		logger.String("user_agent", userAgent),
 		logger.String("app_version", appVersion))
 
 	// Clone DefaultTransport (per golang/go#26013) to inherit proxy support and
@@ -1401,14 +1404,13 @@ func (l *wikiMediaProvider) wikiAPIErrorFor(apiErr *wikiAPIError, title, reqID s
 		return imageNotFoundFor(title, wikiProviderName, "wiki_api_"+code)
 	}
 
+	info := truncateResponseBody(apiErr.Info, responseBodyPreviewLimit)
 	if mentionsRateLimit(code) || mentionsRateLimit(strings.ToLower(apiErr.Info)) {
 		l.openCircuit(circuitBreakerRateLimitDuration,
-			fmt.Sprintf("Rate limited (API error %s): %s", apiErr.Code,
-				truncateResponseBody(apiErr.Info, responseBodyPreviewLimit)))
+			fmt.Sprintf("Rate limited (API error %s): %s", apiErr.Code, info))
 	}
 
-	return errors.Newf("Wikipedia API error %s: %s", apiErr.Code,
-		truncateResponseBody(apiErr.Info, responseBodyPreviewLimit)).
+	return errors.Newf("Wikipedia API error %s: %s", apiErr.Code, info).
 		Component("imageprovider").
 		Category(errors.CategoryNetwork).
 		Context("provider", wikiProviderName).
@@ -1425,20 +1427,26 @@ func (l *wikiMediaProvider) wikiAPIErrorFor(apiErr *wikiAPIError, title, reqID s
 // function rather than a method so the lazy wrapper can consult it before
 // paying for initialization.
 func wikiFetchAllowed() (allowed bool, reason string) {
-	settings := conf.Setting()
+	return wikiFetchAllowedFor(conf.Setting())
+}
+
+// wikiFetchAllowedFor is wikiFetchAllowed's decision with the settings passed
+// in. It exists as a seam: conf.Setting() lazy-loads from disk on a nil global,
+// so the nil branch below cannot be reached by clearing the global in a test.
+func wikiFetchAllowedFor(settings *conf.Settings) (allowed bool, reason string) {
 	if settings == nil {
 		// Fail closed. Settings are nil only before the config loads or when
 		// loading failed, and permitting outbound Wikipedia traffic in that
 		// window contradicts a configured `fallbackpolicy: none`. The sibling
 		// refresh gate already failed closed on the same condition.
-		return false, "settings unavailable"
+		return false, reasonSettingsUnavailable
 	}
 
 	thumbnails := settings.Realtime.Dashboard.Thumbnails
 
 	// Cases 1 and 2: WikiMedia is the configured provider, or auto mode may
 	// select it (it does when no other provider registers).
-	switch strings.ToLower(strings.TrimSpace(thumbnails.ImageProvider)) {
+	switch normalizeProviderName(thumbnails.ImageProvider) {
 	case wikiProviderName, providerAuto, "":
 		return true, ""
 	}
@@ -1455,12 +1463,21 @@ func wikiFetchAllowed() (allowed bool, reason string) {
 }
 
 // logWikiFetchBlocked records a fetch refused by configuration.
+//
+// The hint is derived from the reason rather than fixed: the settings-unavailable
+// refusal is a config-load failure, not a thumbnail-settings choice, and pointing
+// an operator at the thumbnail settings for it would misdirect the one person
+// most likely to be reading this line.
 func logWikiFetchBlocked(scientificName, reason string) {
+	hint := "WikiMedia is not the configured provider and fallback is disabled"
+	if reason == reasonSettingsUnavailable {
+		hint = "the configuration could not be read; fetches stay disabled until it loads"
+	}
 	GetLogger().Debug("WikiMedia fetch blocked by configuration",
 		logger.String("provider", wikiProviderName),
 		logger.String("scientific_name", scientificName),
 		logger.String("config_reason", reason),
-		logger.String("hint", "WikiMedia is not the configured provider and fallback is disabled"))
+		logger.String("hint", hint))
 }
 
 // FetchWithContext retrieves the bird image for a given scientific name using a context.
@@ -1701,58 +1718,67 @@ func (l *wikiMediaProvider) queryThumbnail(ctx context.Context, reqID, scientifi
 	return thumbnailURL, fileName, nil
 }
 
-// supraGenericSuffixes are the endings of scientific names above genus rank.
-// A single-word article title carrying one of these is a family, subfamily,
-// superfamily or order article, never a species article.
+// supraGenericSuffixes are the endings of zoological names above genus rank:
+// family, subfamily, superfamily and order. A word carrying one of these names
+// a taxon containing many species, so an article titled with it is never a
+// single species' article.
 //
 // The tribe suffix "-ini" is deliberately absent: it is short enough to end an
-// ordinary word, and tribe-level redirects are rare next to genus and family
-// ones, so including it would risk discarding a valid single-word common-name
-// article for very little gain.
-var supraGenericSuffixes = []string{"idae", "inae", "oidea", "iformes", "aceae"}
+// ordinary English word, so it could discard a valid common-name article.
+var supraGenericSuffixes = []string{"idae", "inae", "oidea", "iformes"}
 
 // redirectLeftSpecies reports whether the API followed a redirect from the
-// requested species to an article about a broader taxon.
+// requested species up to an article about a broader taxon.
 //
-// Wikipedia redirects a species that has no article of its own up to its genus
-// or family article, and that article's pageimage is routinely a distribution
-// map or a congener. The lookup still succeeds, so the wrong image was written
-// as a positive cache entry and the taxonomy-synonym map, which is consulted
-// only on failure, never got a chance to correct it. That is how a wrong image
-// became permanent.
+// Redirect following itself has to stay on: most bird articles are titled by
+// common name, so a scientific name usually resolves only through its redirect.
+// Measured against 550 species of the shipped label set on the live API, 548
+// redirect. What must not pass is a redirect to a family or order article,
+// whose pageimage is a different bird or a distribution map. That lookup
+// succeeds, so the wrong image is written as a positive cache entry, and the
+// taxonomy-synonym map cannot correct it: it used to be consulted only after a
+// failure, and although the synonym is now tried first, a species absent from
+// the map still has no second path.
 //
-// The check costs no extra request: a redirect to a higher rank has a target
-// that is a single word which is either the genus of the queried binomial or
-// carries a supra-generic rank suffix. Multi-word targets are common-name
-// articles and are exactly what redirect following is for, so they pass.
+// The test is deliberately narrow, because the rejection is reported as
+// ErrImageNotFound and therefore persists as a negative cache entry: only a
+// supra-generic rank name is rejected, and no species article can carry one.
+// A target equal to the queried genus is NOT rejected, because a monotypic
+// genus keeps one combined article at the bare genus title and that article's
+// image is this species' image. In the same 550-species measurement every
+// single-word redirect target was an English common name (Woodlark, Garganey,
+// Weka) and none was a genus article, so that clause would have cost correct
+// images for no observed benefit.
 func redirectLeftSpecies(scientificName string, redirects []wikiRedirect) (target string, left bool) {
 	if len(redirects) == 0 {
 		return "", false
 	}
 
 	target = resolveRedirectTarget(scientificName, redirects)
-	if target == "" || strings.EqualFold(target, scientificName) {
+	if target == "" || titlesEqual(target, scientificName) {
 		return "", false
 	}
 
-	// Multi-word targets are common-name (or binomial) articles.
-	if strings.ContainsAny(target, " _") {
-		return "", false
-	}
-
-	genus, _, isBinomial := strings.Cut(scientificName, " ")
-	if isBinomial && strings.EqualFold(target, genus) {
-		return target, true
-	}
-
-	targetLower := strings.ToLower(target)
-	for _, suffix := range supraGenericSuffixes {
-		if strings.HasSuffix(targetLower, suffix) {
-			return target, true
+	// Every word is tested, not just a single-word title, so that a
+	// parenthetically disambiguated or otherwise qualified taxon article
+	// ("Accipitridae (family)") is caught too. This is safe because no English
+	// common name and no binomial has a word ending in a supra-generic suffix.
+	for word := range strings.FieldsFuncSeq(strings.ToLower(target), isTitleSeparator) {
+		for _, suffix := range supraGenericSuffixes {
+			if strings.HasSuffix(word, suffix) {
+				return target, true
+			}
 		}
 	}
 
 	return "", false
+}
+
+// isTitleSeparator reports whether r separates words in a MediaWiki title.
+// Underscore is title syntax for a space, and parentheses delimit a
+// disambiguating qualifier.
+func isTitleSeparator(r rune) bool {
+	return r == ' ' || r == '_' || r == '(' || r == ')'
 }
 
 // resolveRedirectTarget walks the redirect chain from the requested title.
@@ -1761,6 +1787,10 @@ func redirectLeftSpecies(scientificName string, redirects []wikiRedirect) (targe
 // reported target is used, which covers the case where the API normalized the
 // title before redirecting it.
 func resolveRedirectTarget(scientificName string, redirects []wikiRedirect) string {
+	if len(redirects) == 0 {
+		return ""
+	}
+
 	current := scientificName
 	for range redirects {
 		next := ""

--- a/internal/imageprovider/wikipedia_http_test.go
+++ b/internal/imageprovider/wikipedia_http_test.go
@@ -27,7 +27,6 @@ func newTestWikiProvider(t *testing.T, handler http.HandlerFunc) *wikiMediaProvi
 	return &wikiMediaProvider{
 		httpClient: server.Client(),
 		apiURL:     server.URL,
-		userAgent:  buildUserAgent("1.2.3-test"),
 		// A very high limit keeps the tests fast while still exercising the limiter
 		// call sites; the production value is 1 req/s.
 		globalLimiter: rate.NewLimiter(rate.Inf, 1),

--- a/internal/imageprovider/wikipedia_json_test.go
+++ b/internal/imageprovider/wikipedia_json_test.go
@@ -13,7 +13,7 @@ func TestWikiAPIResponseThumbnailDecode(t *testing.T) {
 
 	body := []byte(`{"query":{"pages":[{
 		"title":"Turdus merula",
-		"thumbnail":{"source":"https://upload.wikimedia.org/x.jpg","width":400,"height":300},
+		"thumbnail":{"source":"https://127.0.0.1/x.jpg","width":400,"height":300},
 		"pageimage":"Common_Blackbird.jpg"
 	}]}}`)
 
@@ -24,7 +24,7 @@ func TestWikiAPIResponseThumbnailDecode(t *testing.T) {
 
 	page := resp.Query.Pages[0]
 	require.NotNil(t, page.Thumbnail)
-	assert.Equal(t, "https://upload.wikimedia.org/x.jpg", page.Thumbnail.Source)
+	assert.Equal(t, "https://127.0.0.1/x.jpg", page.Thumbnail.Source)
 	assert.Equal(t, "Common_Blackbird.jpg", page.PageImage)
 }
 

--- a/internal/imageprovider/wikipedia_json_test.go
+++ b/internal/imageprovider/wikipedia_json_test.go
@@ -98,8 +98,11 @@ func TestWikiAPIResponseErrorDecode(t *testing.T) {
 func TestWikiAPIResponseRedirectsNormalizedDecode(t *testing.T) {
 	t.Parallel()
 
-	// redirects/normalized are only used by len() in diagnostics, but the json
-	// tags must stay correct so the counts are non-zero when present.
+	// Normalized is only counted, for diagnostics. Redirects is decoded for its
+	// TARGET, which decides whether the answered page is still about the species
+	// we asked for, so its field tags are asserted: a wrong tag would leave the
+	// length at 1 while every target read as empty, silently disabling the
+	// redirect guard rather than failing anything.
 	body := []byte(`{"query":{
 		"redirects":[{"from":"Parus caeruleus","to":"Cyanistes caeruleus"}],
 		"normalized":[{"from":"parus","to":"Parus"}],
@@ -109,8 +112,30 @@ func TestWikiAPIResponseRedirectsNormalizedDecode(t *testing.T) {
 	var resp wikiAPIResponse
 	require.NoError(t, json.Unmarshal(body, &resp))
 	require.NotNil(t, resp.Query)
-	assert.Len(t, resp.Query.Redirects, 1)
+	require.Len(t, resp.Query.Redirects, 1)
+	assert.Equal(t, "Parus caeruleus", resp.Query.Redirects[0].From, "the redirects[].from tag must decode")
+	assert.Equal(t, "Cyanistes caeruleus", resp.Query.Redirects[0].To, "the redirects[].to tag must decode")
 	assert.Len(t, resp.Query.Normalized, 1)
+}
+
+// TestWikiAPIResponseMissingFlag pins the decode of the field that separates a
+// genuinely absent article, which is cached as a durable negative entry, from a
+// structured API error, which must not be.
+func TestWikiAPIResponseMissingFlag(t *testing.T) {
+	t.Parallel()
+
+	var resp wikiAPIResponse
+	require.NoError(t, json.Unmarshal([]byte(
+		`{"query":{"pages":[{"title":"Nonexistent species","missing":true}]}}`), &resp))
+	require.NotNil(t, resp.Query)
+	require.Len(t, resp.Query.Pages, 1)
+	assert.True(t, resp.Query.Pages[0].Missing, "the pages[].missing tag must decode")
+
+	var present wikiAPIResponse
+	require.NoError(t, json.Unmarshal([]byte(
+		`{"query":{"pages":[{"title":"Turdus merula"}]}}`), &present))
+	require.Len(t, present.Query.Pages, 1)
+	assert.False(t, present.Query.Pages[0].Missing, "an ordinary page must not decode as missing")
 }
 
 func TestWikiAPIResponseMissingFields(t *testing.T) {


### PR DESCRIPTION
The species-image lookup could succeed and still return an image of a different bird, and because it succeeded the result was written as a positive cache entry that nothing on the request path could re-derive. This fixes the lookup, the licence attribution, and the load the non-blocking proxy's retry contract put on SQLite.

Follow-on from #4045 and #4046. Nothing here changes the proxy's HTTP contract.

## Lookup correctness

**A configured taxonomy synonym is queried first.** It used to be consulted only after a failure, which meant it could not fix the case users add it for: a lookup that succeeds under the primary name and returns the wrong image. The original name is still tried if the synonym misses, so this costs no extra request in the common case.

**A usable free thumbnail is no longer discarded** when the `pageimage` filename is absent. That filename is only the key for the second, attribution query, and the caller already falls back to "Unknown" attribution when that query fails.

**A structured MediaWiki error is no longer read as "no such species".** Those arrive with HTTP 200 for `ratelimited`, `maxlag` and `readonly`, and a nil query object was being reported as `ErrImageNotFound`, which the cache persists. A Wikipedia throttling window therefore wrote durable `__NOT_FOUND__` rows for every species queried during it. A missing page is now modelled explicitly, the way `formatversion=2` reports it, and a rate-limit error opens the circuit breaker that the status-code path never sees because these arrive with a 200.

**The 403 classifier matched the bare tokens `rate` and `limit`**, which also occur inside "corporate", "moderate" and "unlimited", so a hard block whose page contained any of them got the 60-second breaker instead of the five-minute one and the app resumed hammering a host that had just refused it. It now matches phrases, and all three copies of that verdict are routed through one classifier.

**Redirect targets are validated**, narrowly. Redirect following has to stay on: measured against 550 species of the shipped label set on the live API, 548 resolve only through their redirect. What is rejected is a target carrying a supra-generic rank suffix, which cannot be a species article. A redirect to the bare genus is deliberately *not* rejected, because a monotypic genus keeps one combined article there and that article's image is the species' image. Details and the measurement are in the second commit; the redirect-to-genus case the original analysis predicted did not occur once in 550 species.

**`LazyWikiMediaProvider` no longer latches its init error** for the process lifetime. A config wait that timed out at boot left the provider permanently dead with no retry and no further log. A caller that abandons the wait through its own context is also no longer recorded as a configuration failure, which would have refused every other caller for a minute on the strength of one 3-second deadline.

## Configuration gates

The fetch gate failed open on nil settings, permitting Wikipedia traffic during the startup window regardless of policy; it now fails closed like its sibling. The policy and the provider name are each read through one normalizing helper, so `fallbackpolicy: All` or a trailing space no longer enables the hourly refresh while every fetch it schedules is denied, and the refresh gate stops accepting a provider name as a policy value. The lazy provider checks policy before initializing, so a denied call no longer pays the config wait and emits the full initialization log block.

## Cache and load

**A stale positive memory entry is served and refreshed** rather than returned forever. It previously had no TTL at all, so a wrong image that reached memory could not be re-derived for the process lifetime.

**A database miss is remembered briefly.** Under the 503 + `Retry-After` contract the client polls, so every poll for an unresolved species cost its own SQLite SELECT: on a cold dashboard with ~20 unresolved species, several per second on a 1-core Pi. Measured at 998 ns → 538 ns per unresolved-species lookup, 17 → 9 allocations, with no change to the warm-hit path. A stale but servable row is deliberately not covered by this, and the shortcut still consults the exhausted marker so a definitive "no image" stays a cacheable 404.

**A background resolution that fails transiently now backs off.** Nothing was recorded for a non-not-found failure, so the client's retry schedule became the provider retry schedule.

Both markers are bounded. They are keyed by the scientific name the media endpoints take from the client, so the key space is request traffic rather than the label set; unbounded, that is ~150 bytes per distinct name and ~100 MB per 250k distinct requests, which a 512 MB target does not survive.

## Attribution

AviCommons licence versions are preserved instead of stripped. 5,568 of the 9,841 shipped entries carry a version other than 4.0 and every one of them rendered as 4.0, linking legal text that does not govern the image. The 22 jurisdiction-ported codes defeated the version strip entirely and rendered the raw code with no licence URL at all. CC0 maps to 1.0, the only version it was published as, and a jurisdiction port is accepted only on a version Creative Commons actually ported.

Verified on a QA instance against the live API, with the image cache cleared so rows are re-derived:

| Species | Dataset | Before | After |
|---|---|---|---|
| Goura victoria | CC BY-NC 3.0-de | *(no licence URL)* | CC BY-NC 3.0 DE → `licenses/by-nc/3.0/de/` |
| Eudyptes sclateri | CC BY-SA 3.0-nz | *(no licence URL)* | CC BY-SA 3.0 NZ → `licenses/by-sa/3.0/nz/` |
| Campephilus principalis | CC BY 3.0-us | *(no licence URL)* | CC BY 3.0 US → `licenses/by/3.0/us/` |
| Cygnus cygnus | CC BY-NC 2.5 | CC BY-NC 4.0 | CC BY-NC 2.5 → `licenses/by-nc/2.5/` |
| Turdus merula | CC BY-SA 2.5 | CC BY-SA 4.0 | CC BY-SA 2.5 → `licenses/by-sa/2.5/` |
| Parus major | CC BY-NC 3.0 | CC BY-NC 4.0 | CC BY-NC 3.0 → `licenses/by-nc/3.0/` |

Every emitted deed URL was confirmed to resolve.

**Existing installs keep their stored licence** until the row's 30-day TTL expires, because the value is a persisted column. Re-deriving those rows belongs with the cache-invalidation work rather than here.

## Callers and hygiene

Warm-up schedules through the cache's own prefetch machinery with backpressure instead of calling the blocking `Get` on untracked goroutines that `Close` could not interrupt. One image lookup per detection, shared through `DetectionContext`, rather than one each in the Database, SSE and MQTT actions. `errors.CategoryOf` replaces the third in-tree copy of "return the category this error already carries". Disk-cache failures now reach telemetry, which is what made a permanently empty image cache invisible; the transient network paths deliberately do not, since `Build()` reports unconditionally and doing so would emit one event per attempt for exactly the conditions that already have a cooldown.

The image User-Agent moves to a provider-neutral file and is resolved per request, so a provider built before the version is published no longer sends `BirdNETGo/unknown` for the whole process. `httpclient`'s default User-Agent stops being the hyphenated project name, which Wikimedia's edge refuses by prefix; nothing routes Wikimedia traffic through that client today, so this defuses a trap rather than fixing a live bug.

## Verification

`golangci-lint` clean, `go test -race` green across the touched packages, and repeated runs stable.

Image URLs in this package's test fixtures now point at a loopback literal. A cached URL is not inert (a refresh really fetches it), so the suite was opening live connections to `upload.wikimedia.org` and `example.com`, and a keep-alive connection still idle at the end failed the goroutine-leak check at random. Confirmed against an `origin/main` worktree that this predated the branch, and that no outbound traffic remains.

On a QA instance: cold miss answers 503 in ~2.6 ms, a genuinely absent species settles to a cacheable 404 in ~1.4 ms, and thumbnails serve as JPEG bytes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved image lookup with background refreshes, stale-image support, retry backoff, and reduced repeated requests.
  * Improved Wikipedia image results, including safer redirect handling, thumbnail preservation, and attribution fallbacks.
  * Added more accurate Creative Commons license names and links, including version and jurisdiction details.
  * Standardized outbound service identification for more compliant requests.

* **Bug Fixes**
  * Prevented repeated image lookups during a single detection.
  * Improved handling of missing pages, rate limits, and temporary provider failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->