### PR TITLE
Add support for legacy intel openvino offload devices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -298,15 +298,15 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
         "https://github.com/intel/compute-runtime/releases/download/${LEGACY_NEO_VERSION}/intel-opencl-icd-legacy1_${LEGACY_NEO_VERSION}_amd64.deb" \
         "https://github.com/intel/compute-runtime/releases/download/${LEGACY_NEO_VERSION}/intel-level-zero-gpu-legacy1_${LEGACY_ZE_GPU_VERSION}_amd64.deb" && \
       printf '%s\n' \
-        "${NEO_SHA256_IGC_CORE} intel-igc-core-2_${IGC_VERSION}_amd64.deb" \
-        "${NEO_SHA256_IGC_OPENCL} intel-igc-opencl-2_${IGC_VERSION}_amd64.deb" \
-        "${NEO_SHA256_OPENCL_ICD} intel-opencl-icd_${NEO_VERSION}-0_amd64.deb" \
-        "${NEO_SHA256_IGDGMM} libigdgmm12_${GMMLIB_VERSION}_amd64.deb" \
-        "${NEO_SHA256_ZE_GPU} libze-intel-gpu1_${NEO_VERSION}-0_amd64.deb" \
-        "${LEGACY_SHA256_IGC_CORE} intel-igc-core_${LEGACY_IGC_VERSION}_amd64.deb" \
-        "${LEGACY_SHA256_IGC_OPENCL} intel-igc-opencl_${LEGACY_IGC_VERSION}_amd64.deb" \
-        "${LEGACY_SHA256_OPENCL_ICD} intel-opencl-icd-legacy1_${LEGACY_NEO_VERSION}_amd64.deb" \
-        "${LEGACY_SHA256_ZE_GPU} intel-level-zero-gpu-legacy1_${LEGACY_ZE_GPU_VERSION}_amd64.deb" \
+        "${NEO_SHA256_IGC_CORE}  intel-igc-core-2_${IGC_VERSION}_amd64.deb" \
+        "${NEO_SHA256_IGC_OPENCL}  intel-igc-opencl-2_${IGC_VERSION}_amd64.deb" \
+        "${NEO_SHA256_OPENCL_ICD}  intel-opencl-icd_${NEO_VERSION}-0_amd64.deb" \
+        "${NEO_SHA256_IGDGMM}  libigdgmm12_${GMMLIB_VERSION}_amd64.deb" \
+        "${NEO_SHA256_ZE_GPU}  libze-intel-gpu1_${NEO_VERSION}-0_amd64.deb" \
+        "${LEGACY_SHA256_IGC_CORE}  intel-igc-core_${LEGACY_IGC_VERSION}_amd64.deb" \
+        "${LEGACY_SHA256_IGC_OPENCL}  intel-igc-opencl_${LEGACY_IGC_VERSION}_amd64.deb" \
+        "${LEGACY_SHA256_OPENCL_ICD}  intel-opencl-icd-legacy1_${LEGACY_NEO_VERSION}_amd64.deb" \
+        "${LEGACY_SHA256_ZE_GPU}  intel-level-zero-gpu-legacy1_${LEGACY_ZE_GPU_VERSION}_amd64.deb" \
         | sha256sum -c - && \
       dpkg -i *.deb && \
       rm -rf /tmp/neo /var/lib/apt/lists/*; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ ARG NEO_SHA256_ZE_GPU=8bef9f24e03f826f93c076081bda13c6ac3afbd9e42b9fb8f298fab652
 # what intel-opencl-icd-legacy1/intel-level-zero-gpu-legacy1 depend on.
 # See: https://github.com/intel/compute-runtime/blob/master/LEGACY_PLATFORMS.md
 ARG LEGACY_NEO_VERSION=24.35.30872.22
+# The level-zero-gpu package carries its own 1.3.x version string that differs
+# from the 24.35.x compute-runtime release tag it ships under.
+ARG LEGACY_ZE_GPU_VERSION=1.3.30872.22
 ARG LEGACY_IGC_TAG=igc-1.0.17537.20
 ARG LEGACY_IGC_VERSION=1.0.17537.20
 ARG LEGACY_SHA256_IGC_CORE=7f2af5b0e567a43625a748effb744d0b3c96acf805467d099e46eee617e11b2a
@@ -272,6 +275,7 @@ ARG NEO_SHA256_OPENCL_ICD
 ARG NEO_SHA256_IGDGMM
 ARG NEO_SHA256_ZE_GPU
 ARG LEGACY_NEO_VERSION
+ARG LEGACY_ZE_GPU_VERSION
 ARG LEGACY_IGC_TAG
 ARG LEGACY_IGC_VERSION
 ARG LEGACY_SHA256_IGC_CORE
@@ -292,7 +296,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
         "https://github.com/intel/intel-graphics-compiler/releases/download/${LEGACY_IGC_TAG}/intel-igc-core_${LEGACY_IGC_VERSION}_amd64.deb" \
         "https://github.com/intel/intel-graphics-compiler/releases/download/${LEGACY_IGC_TAG}/intel-igc-opencl_${LEGACY_IGC_VERSION}_amd64.deb" \
         "https://github.com/intel/compute-runtime/releases/download/${LEGACY_NEO_VERSION}/intel-opencl-icd-legacy1_${LEGACY_NEO_VERSION}_amd64.deb" \
-        "https://github.com/intel/compute-runtime/releases/download/${LEGACY_NEO_VERSION}/intel-level-zero-gpu-legacy1_1.3.30872.22_amd64.deb" && \
+        "https://github.com/intel/compute-runtime/releases/download/${LEGACY_NEO_VERSION}/intel-level-zero-gpu-legacy1_${LEGACY_ZE_GPU_VERSION}_amd64.deb" && \
       printf '%s\n' \
         "${NEO_SHA256_IGC_CORE} intel-igc-core-2_${IGC_VERSION}_amd64.deb" \
         "${NEO_SHA256_IGC_OPENCL} intel-igc-opencl-2_${IGC_VERSION}_amd64.deb" \
@@ -302,7 +306,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
         "${LEGACY_SHA256_IGC_CORE} intel-igc-core_${LEGACY_IGC_VERSION}_amd64.deb" \
         "${LEGACY_SHA256_IGC_OPENCL} intel-igc-opencl_${LEGACY_IGC_VERSION}_amd64.deb" \
         "${LEGACY_SHA256_OPENCL_ICD} intel-opencl-icd-legacy1_${LEGACY_NEO_VERSION}_amd64.deb" \
-        "${LEGACY_SHA256_ZE_GPU} intel-level-zero-gpu-legacy1_1.3.30872.22_amd64.deb" \
+        "${LEGACY_SHA256_ZE_GPU} intel-level-zero-gpu-legacy1_${LEGACY_ZE_GPU_VERSION}_amd64.deb" \
         | sha256sum -c - && \
       dpkg -i *.deb && \
       rm -rf /tmp/neo /var/lib/apt/lists/*; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ARG OPENVINO_RELEASE=2026.2
 ARG OPENVINO_BUILD=2026.2.0.21903.52ddc073857
 ARG OPENVINO_SHA256_AMD64=86896e9347cd160370d16f80fa2c49c2b7a51ec33b55cea6493c7dc7c4c61c55
 ARG OPENVINO_SHA256_ARM64=8ce45467967e22fddb83a6b72a8bd1f9bfa6f43351e1ca2eaf5251064fe17767
+
 # Intel NEO (compute-runtime) and IGC (intel-graphics-compiler) pin for
 # amd64 iGPU inference. Only used on linux/amd64; arm64 has no Intel GPU plugin.
 ARG NEO_VERSION=26.22.38646.4
@@ -18,6 +19,21 @@ ARG NEO_SHA256_IGC_OPENCL=350a52331e784bb7fb9ed42e993b5c44b7e6562fc74d2cf3102b29
 ARG NEO_SHA256_OPENCL_ICD=6fdac2e8a2aacf844ebfd90521bf7102b3ebb44f69c1bced1a9785a7ce96a3c2
 ARG NEO_SHA256_IGDGMM=6031a63d6e8a12ce61c14efc15f2c8e727061286e3820b8594e6d00615e04d54
 ARG NEO_SHA256_ZE_GPU=8bef9f24e03f826f93c076081bda13c6ac3afbd9e42b9fb8f298fab652330e2f
+
+# Legacy Intel NEO/IGC track for Gen8/Gen9/Gen11 iGPUs (e.g. Coffee Lake UHD 630).
+# Current compute-runtime releases (NEO_VERSION below) dropped support for these
+# generations starting at 24.35.30872.22; Intel ships continued support via a
+# parallel -legacy1 package track. Both tracks install side-by-side without
+# conflict as long as the legacy IGC pin (non-"-2" package names) matches exactly
+# what intel-opencl-icd-legacy1/intel-level-zero-gpu-legacy1 depend on.
+# See: https://github.com/intel/compute-runtime/blob/master/LEGACY_PLATFORMS.md
+ARG LEGACY_NEO_VERSION=24.35.30872.22
+ARG LEGACY_IGC_TAG=igc-1.0.17537.20
+ARG LEGACY_IGC_VERSION=1.0.17537.20
+ARG LEGACY_SHA256_IGC_CORE=7f2af5b0e567a43625a748effb744d0b3c96acf805467d099e46eee617e11b2a
+ARG LEGACY_SHA256_IGC_OPENCL=ac2088331d55c7de15bd57373f73630e95b40e1275934bcfd96bf0c3e03769a7
+ARG LEGACY_SHA256_OPENCL_ICD=1ac4639c148ab6c9db6bc5a7733ca40bac3782cccc5b3da8e8cb7da8e8f20b1b
+ARG LEGACY_SHA256_ZE_GPU=54d42056c627dd36eaaf3dcfad5d80fb90e9c0d65e4a4d5ab8b0e8ed1277891b
 
 FROM --platform=$BUILDPLATFORM golang:1.26-trixie AS buildenv
 
@@ -241,7 +257,7 @@ RUN cp /tmp/tflite-lib/libtensorflowlite_c.so* /usr/lib/ && \
     rm -rf /tmp/tflite-lib && \
     ldconfig
 
-# Install Intel NEO compute runtime for amd64 iGPU inference.
+# Install Intel NEO compute runtime for amd64 iGPU inference including legacy support.
 # NEO provides the OpenCL ICD that lets OpenVINO talk to the Intel iGPU when
 # /dev/dri is passed through from the host. OpenVINO libs for both arches are
 # installed via the COPY step below; this step only adds the OpenCL driver
@@ -255,25 +271,41 @@ ARG NEO_SHA256_IGC_OPENCL
 ARG NEO_SHA256_OPENCL_ICD
 ARG NEO_SHA256_IGDGMM
 ARG NEO_SHA256_ZE_GPU
+ARG LEGACY_NEO_VERSION
+ARG LEGACY_IGC_TAG
+ARG LEGACY_IGC_VERSION
+ARG LEGACY_SHA256_IGC_CORE
+ARG LEGACY_SHA256_IGC_OPENCL
+ARG LEGACY_SHA256_OPENCL_ICD
+ARG LEGACY_SHA256_ZE_GPU
+
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
-    apt-get update -q && apt-get install -q -y --no-install-recommends \
+      apt-get update -q && apt-get install -q -y --no-install-recommends \
         ocl-icd-libopencl1 libdrm2 libdrm-intel1 && \
-    mkdir -p /tmp/neo && cd /tmp/neo && \
-    wget -q \
+      mkdir -p /tmp/neo && cd /tmp/neo && \
+      wget -q \
         "https://github.com/intel/intel-graphics-compiler/releases/download/${IGC_TAG}/intel-igc-core-2_${IGC_VERSION}_amd64.deb" \
         "https://github.com/intel/intel-graphics-compiler/releases/download/${IGC_TAG}/intel-igc-opencl-2_${IGC_VERSION}_amd64.deb" \
         "https://github.com/intel/compute-runtime/releases/download/${NEO_VERSION}/intel-opencl-icd_${NEO_VERSION}-0_amd64.deb" \
         "https://github.com/intel/compute-runtime/releases/download/${NEO_VERSION}/libigdgmm12_${GMMLIB_VERSION}_amd64.deb" \
-        "https://github.com/intel/compute-runtime/releases/download/${NEO_VERSION}/libze-intel-gpu1_${NEO_VERSION}-0_amd64.deb" && \
-    printf '%s\n' \
-        "${NEO_SHA256_IGC_CORE}  intel-igc-core-2_${IGC_VERSION}_amd64.deb" \
-        "${NEO_SHA256_IGC_OPENCL}  intel-igc-opencl-2_${IGC_VERSION}_amd64.deb" \
-        "${NEO_SHA256_OPENCL_ICD}  intel-opencl-icd_${NEO_VERSION}-0_amd64.deb" \
-        "${NEO_SHA256_IGDGMM}  libigdgmm12_${GMMLIB_VERSION}_amd64.deb" \
-        "${NEO_SHA256_ZE_GPU}  libze-intel-gpu1_${NEO_VERSION}-0_amd64.deb" \
+        "https://github.com/intel/compute-runtime/releases/download/${NEO_VERSION}/libze-intel-gpu1_${NEO_VERSION}-0_amd64.deb" \
+        "https://github.com/intel/intel-graphics-compiler/releases/download/${LEGACY_IGC_TAG}/intel-igc-core_${LEGACY_IGC_VERSION}_amd64.deb" \
+        "https://github.com/intel/intel-graphics-compiler/releases/download/${LEGACY_IGC_TAG}/intel-igc-opencl_${LEGACY_IGC_VERSION}_amd64.deb" \
+        "https://github.com/intel/compute-runtime/releases/download/${LEGACY_NEO_VERSION}/intel-opencl-icd-legacy1_${LEGACY_NEO_VERSION}_amd64.deb" \
+        "https://github.com/intel/compute-runtime/releases/download/${LEGACY_NEO_VERSION}/intel-level-zero-gpu-legacy1_1.3.30872.22_amd64.deb" && \
+      printf '%s\n' \
+        "${NEO_SHA256_IGC_CORE} intel-igc-core-2_${IGC_VERSION}_amd64.deb" \
+        "${NEO_SHA256_IGC_OPENCL} intel-igc-opencl-2_${IGC_VERSION}_amd64.deb" \
+        "${NEO_SHA256_OPENCL_ICD} intel-opencl-icd_${NEO_VERSION}-0_amd64.deb" \
+        "${NEO_SHA256_IGDGMM} libigdgmm12_${GMMLIB_VERSION}_amd64.deb" \
+        "${NEO_SHA256_ZE_GPU} libze-intel-gpu1_${NEO_VERSION}-0_amd64.deb" \
+        "${LEGACY_SHA256_IGC_CORE} intel-igc-core_${LEGACY_IGC_VERSION}_amd64.deb" \
+        "${LEGACY_SHA256_IGC_OPENCL} intel-igc-opencl_${LEGACY_IGC_VERSION}_amd64.deb" \
+        "${LEGACY_SHA256_OPENCL_ICD} intel-opencl-icd-legacy1_${LEGACY_NEO_VERSION}_amd64.deb" \
+        "${LEGACY_SHA256_ZE_GPU} intel-level-zero-gpu-legacy1_1.3.30872.22_amd64.deb" \
         | sha256sum -c - && \
-    dpkg -i *.deb && \
-    rm -rf /tmp/neo /var/lib/apt/lists/*; \
+      dpkg -i *.deb && \
+      rm -rf /tmp/neo /var/lib/apt/lists/*; \
     fi
 
 # OpenVINO runtime libraries (both arches). The openvino-tagged binary dlopens


### PR DESCRIPTION
## Summary

BirdNET-Go's OpenVINO backend reports `"gpu device requested but not available"` on Intel Gen8/Gen9/Gen11 iGPUs (e.g. UHD 630 on Coffee Lake) despite correct config, working device passthrough, and correct container permissions. Root cause: the amd64 image only installs the current Intel compute-runtime track (`NEO_VERSION=26.22.38646.4`), which Intel dropped Gen8/9/11 support from starting at release `24.35.30872.22`. This PR adds the parallel `-legacy1` package track alongside the existing one, matching the approach already shipped in Frigate's image for the same reason.

## Evidence trail

- Intel's own compute-runtime docs state plainly: *"Support for Gen8, Gen9 and Gen11 devices is delivered via packages with legacy1 suffix"* ([README](https://github.com/intel/compute-runtime))
- `LEGACY_PLATFORMS.md` confirms the exact cutover point: *"Starting from release 24.35.30872.22 regular packages support Gen12 and later devices"* ([source](https://github.com/intel/compute-runtime/blob/master/LEGACY_PLATFORMS.md))
- Intel's own quality matrix for release `24.35.30872.22` explicitly lists **Coffee Lake: Legacy, OpenCL 3.0, Level Zero 1.5** — this is not an edge case, it's a documented, named platform ([release page](https://github.com/intel/compute-runtime/releases/tag/24.35.30872.22))
- Frigate ships this exact pairing already (`intel-opencl-icd` + `intel-opencl-icd-legacy1`, `intel-level-zero-gpu` + `intel-level-zero-gpu-legacy1`) — confirmed via `dpkg -l` diff against a working Frigate container on the same host/GPU as the repro below
- Diagnosis path: OpenCL ICD file, library dependencies (`ldd`), device node permissions (`drm-render`/`video` groups), and process group membership were all confirmed intact via `docker exec` before the driver-generation gap was found — `clinfo` reported `Number of platforms 0` despite every structural piece being correct, which is the documented behavior of the current-track driver on unsupported hardware (it doesn't error, it just doesn't enumerate the device)

## Repro

- Host: Intel Core i7-8700T (Coffee Lake, UHD Graphics 630, Gen9.5)
- Image: `ghcr.io/tphakala/birdnet-go:nightly`, build `20260716`
- Config: `birdnet.backend: openvino`, `birdnet.openvinodevice: gpu`, `/dev/dri/renderD128` passed through correctly, container in `drm-render` group with confirmed matching GID
- Result before fix: `WARN [birdnet] OpenVINO requested but not used; using ONNX Runtime model=BirdNET_V2.4 reason="gpu device requested but not available"`
- Result after installing the legacy1 track manually inside the running container: `INFO [birdnet] OpenVINO model initialized model=.../BirdNET_v2.4_fp32.onnx device=GPU precision=f32 species=6522 init_time=4.896277364s`

## Changes

- Added `LEGACY_NEO_VERSION`, `LEGACY_IGC_TAG`, `LEGACY_IGC_VERSION`, and matching `LEGACY_SHA256_*` build args, pinned to `24.35.30872.22` / `igc-1.0.17537.20` — the last release in the legacy track per Intel's changelog
- Extended the existing amd64 NEO install `RUN` block to download, checksum-verify, and `dpkg -i` the legacy `.deb` set alongside the current one, in the same atomic install step
- Checksums pulled directly from Intel's release page, same verification pattern the existing block already uses

## Why both tracks install without conflict

The current track uses `-2`-suffixed IGC package names (`intel-igc-core-2`, `intel-igc-opencl-2`); the legacy track depends on the original non-suffixed names at an exact pinned version (`intel-igc-core`/`intel-igc-opencl` = `1.0.17537.20`). Installing both name-sets together via a single `dpkg -i *.deb` batch satisfies both dependency chains locally without version-resolver conflicts — confirmed working in testing (an initial attempt using `apt-get install ./*.deb` instead of `dpkg -i` hit a resolver conflict trying to auto-select a mismatched IGC version; pinning the exact version and using `dpkg -i` resolved it).

## Suggested follow-up (not in this PR)

The [OpenVINO Acceleration wiki page](https://github.com/tphakala/birdnet-go/wiki/OpenVINO-Acceleration) currently states amd64 images "bundle the Intel GPU compute runtime" without noting this excludes pre-Gen12 hardware. Worth a doc update once this lands, since the wiki's own N100/N305 hardware mention suggests this project's amd64 iGPU audience skews toward exactly the class of hardware (older NUCs, small-form-factor PCs) that's most likely to hit this gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Expanded Intel GPU compatibility for legacy Gen8, Gen9, and Gen11 hardware.
  * Added support for running current and legacy Intel GPU runtimes side by side.
  * Improved container reliability by validating GPU components before installation.
  * Documented compatibility coverage for current and legacy Intel GPU runtimes, helping deployments select a suitable configuration for their hardware.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->