### PR TITLE
fix(models): pin real checksums and correct paths for the BirdNET v3.0 catalog files

### DIFF
--- a/internal/classifier/model_catalog.go
+++ b/internal/classifier/model_catalog.go
@@ -73,13 +73,14 @@ var EmbeddedCatalog = []CatalogEntry{
 	// Wildlife models (multi-taxa classifiers)
 	// BirdNET v3.0 acoustic classifier (developer preview). Global GPU-native model
 	// (EfficientNetV2-S backbone, 11,560 species, 32kHz/5s), paired with the v3.0
-	// geomodel range filter. Kept Hidden until GA: the HuggingFace repo is private
-	// during preview and the file checksums/sizes are finalized in a follow-up (as
-	// was done for Perch v2), so the gallery Install path is not wired yet. The
-	// backend loader is fully functional, so v3.0 can be enabled via config
-	// (models.enabled + birdnetv3 model/label paths) for evaluation. The empty
-	// SHA256 on this hidden entry is intentional: it avoids a false checksum
-	// mismatch and, being Hidden, the entry is never installed from the gallery.
+	// geomodel range filter. The HuggingFace repo is public and the file
+	// checksums/sizes below are pinned from it, so this entry's download path is
+	// integrity-checked like every other entry. Kept Hidden until GA and until the
+	// gallery can offer the hardware and regional variant selection a model this
+	// heavy needs (the global fp32 file is 557 MB). Hidden entries are rejected by
+	// the install API (internal/api/v2/models.InstallModel), so this is catalog
+	// metadata only. The backend loader is fully functional, so v3.0 can still be
+	// enabled via config (models.enabled + birdnetv3 model/label paths) for evaluation.
 	{
 		ID:              "birdnet-v3.0",
 		Name:            "BirdNET v3.0",
@@ -98,8 +99,8 @@ var EmbeddedCatalog = []CatalogEntry{
 		UpstreamURL:     "https://github.com/birdnet-team/BirdNET-Analyzer",
 		HuggingFaceRepo: "tphakala/BirdNET-v3.0-Models",
 		Files: slices.Concat([]CatalogFile{
-			{RemotePath: "full/birdnet_v3.0_fp32.onnx", LocalName: "birdnet_v3.0_fp32.onnx", Role: RoleModel, SHA256: "", SizeBytes: 0},
-			{RemotePath: "full/birdnet_v3.0_labels.txt", LocalName: "birdnet_v3.0_labels.txt", Role: RoleLabels, SHA256: "", SizeBytes: 0},
+			{RemotePath: "full/birdnet-v3.0-preview3.1-fp32-b1.onnx", LocalName: "birdnet_v3.0_fp32.onnx", Role: RoleModel, SHA256: "05535c3ef6ce3f9e523706dd3e144cb6db96bc202e9047f4973961256acbf997", SizeBytes: 557212256},
+			{RemotePath: "full/birdnet-v3.0-preview3.1-labels-b1.txt", LocalName: "birdnet_v3.0_labels.txt", Role: RoleLabels, SHA256: "4f4ef82f1704c66cf4da9f59757c12baa34ff98863fa2627e33c302fc92997aa", SizeBytes: 461605},
 		}, geomodelFiles(), taxonomyFiles()),
 	},
 	{

--- a/internal/classifier/model_catalog_test.go
+++ b/internal/classifier/model_catalog_test.go
@@ -1,6 +1,8 @@
 package classifier
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,6 +30,35 @@ func TestEmbeddedCatalog_ValidRegistryIDs(t *testing.T) {
 		assert.NotEmpty(t, entry.RegistryID, "catalog entry %q must have a RegistryID", entry.ID)
 		_, exists := ModelRegistry[entry.RegistryID]
 		assert.True(t, exists, "catalog entry %q references unknown RegistryID %q", entry.ID, entry.RegistryID)
+	}
+}
+
+// TestEmbeddedCatalog_AllFilesHaveChecksums verifies every downloadable file in the
+// catalog carries a real SHA-256 and a non-zero size. An empty SHA-256 makes
+// verifySHA256 a no-op, so the file would be downloaded and loaded with no integrity
+// check at all; a zero size makes the download progress bar meaningless. The invariant
+// must hold for every entry, including Hidden ones, because Hidden is a UI and install
+// gate, not an integrity guarantee: a Hidden entry can still be reached by config or a
+// future un-hide, and every file the gallery can fetch must be verifiable.
+func TestEmbeddedCatalog_AllFilesHaveChecksums(t *testing.T) {
+	t.Parallel()
+
+	for _, entry := range EmbeddedCatalog {
+		for _, f := range entry.Files {
+			// Validate the checksum decodes to a 32-byte digest, not just that
+			// it is 64 characters: a 64-char non-hex string would never match a
+			// real digest and so would fail closed at download time, but it has
+			// no business being in the catalog. hex.DecodeString("") returns no
+			// error, so the length check below is what rejects an empty checksum.
+			raw, err := hex.DecodeString(f.SHA256)
+			if assert.NoErrorf(t, err,
+				"catalog entry %q file %q must carry a hex SHA-256", entry.ID, f.RemotePath) {
+				assert.Lenf(t, raw, sha256.Size,
+					"catalog entry %q file %q SHA-256 must decode to 32 bytes", entry.ID, f.RemotePath)
+			}
+			assert.Positivef(t, f.SizeBytes,
+				"catalog entry %q file %q must carry a positive SizeBytes", entry.ID, f.RemotePath)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

The BirdNET v3.0 model gallery entry shipped its two downloadable files with an empty `SHA256` and a zero `SizeBytes`, and with `RemotePath`s that never matched the published HuggingFace filenames. `verifySHA256` treats an empty expected hash as "no check", so those two files would have been fetched and loaded with no integrity verification at all, while every other catalog file is checksum-verified. The mirror-endpoint override widens who can serve those bytes, so the gap is worth closing on its own. Separately, the old paths (`full/birdnet_v3.0_fp32.onnx`, `full/birdnet_v3.0_labels.txt`) do not exist in the repo and would 404, and the zero size makes the download progress bar meaningless.

This corrects both `RemotePath`s to the real published versioned names (`full/birdnet-v3.0-preview3.1-fp32-b1.onnx` and `...-labels-b1.txt`) and pins the real `SHA256` and `SizeBytes`, verified against the HuggingFace API and the repo's published `models.json`. `LocalName` is unchanged, so nothing on disk moves and `ScanInstalled` still detects any already-present file. The entry stays `Hidden`: it is still a developer preview, the gallery cannot yet offer the hardware- and region-aware variant selection a 557 MB model needs, and the install API already rejects `Hidden` entries, so this is catalog metadata only.

It also adds `TestEmbeddedCatalog_AllFilesHaveChecksums`, a catalog-wide guard that every downloadable file carries a valid 32-byte hex `SHA256` and a positive size, so no future entry can silently reship the unverified-download gap.

## Test Plan

- [x] `go test -race ./internal/classifier/` passes, including the new guard, which fails on the pre-fix empty-checksum state
- [x] `go test -race ./internal/api/v2/models/` passes (Hidden-entry install rejection still holds)
- [x] `golangci-lint run ./...` clean (0 issues)
- [x] Checksums, sizes, and paths cross-verified against the HuggingFace API and the published model manifest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated BirdNET v3.0 preview model metadata with the correct model and label files.
  * Added verified download checksums and file sizes to improve model integrity validation.

* **Tests**
  * Added validation to ensure all catalog files include valid checksums and positive file sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->