### PR TITLE
feat(models): add nested-variant schema to the model catalog

### DIFF
--- a/internal/classifier/catalog_loader.go
+++ b/internal/classifier/catalog_loader.go
@@ -179,8 +179,9 @@ func seedCatalog(log logger.Logger, path, embeddedChecksum string) error {
 }
 
 // validateCatalog checks that a loaded catalog is well-formed: it has at least
-// one entry, every entry has a unique non-empty id, and every file declares the
-// fields needed to download it (remote_path, local_name, role).
+// one entry, every entry has a unique non-empty id, every entry declares files
+// (directly or through variants), and every file declares the fields needed to
+// download it (remote_path, local_name, role).
 func validateCatalog(entries []CatalogEntry) error {
 	if len(entries) == 0 {
 		return errors.Newf("model catalog has no entries").
@@ -204,29 +205,96 @@ func validateCatalog(entries []CatalogEntry) error {
 				Build()
 		}
 		seen[entry.ID] = struct{}{}
-		if len(entry.Files) == 0 {
-			return errors.Newf("catalog entry %q declares no files", entry.ID).
+		if err := validateCatalogEntryFiles(entry); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateCatalogEntryFiles validates the files an entry declares, directly or
+// through variants. A variant entry stores its files under Variants, and its
+// top-level Files is empty on disk and resolved at load time, so an entry is
+// valid when it declares files in EITHER place. Every variant must have a unique
+// non-empty id and at least one file.
+func validateCatalogEntryFiles(entry *CatalogEntry) error {
+	if len(entry.Files) == 0 && len(entry.Variants) == 0 {
+		return errors.Newf("catalog entry %q declares no files or variants", entry.ID).
+			Component("classifier.catalog_loader").
+			Category(errors.CategoryValidation).
+			Build()
+	}
+	// Files and Variants are mutually exclusive: a variant entry stores its files
+	// under Variants (with an empty top-level Files, resolved at load time), so an
+	// entry carrying both would have its top-level Files silently discarded by
+	// resolveVariantDefaults. Reject it rather than lose data quietly.
+	if len(entry.Files) > 0 && len(entry.Variants) > 0 {
+		return errors.Newf("catalog entry %q declares both top-level files and variants; use one or the other (variant files live under variants[])", entry.ID).
+			Component("classifier.catalog_loader").
+			Category(errors.CategoryValidation).
+			Build()
+	}
+	if err := validateCatalogFiles(entry.ID, "", entry.Files); err != nil {
+		return err
+	}
+	seenVariants := make(map[string]struct{}, len(entry.Variants))
+	for i := range entry.Variants {
+		v := &entry.Variants[i]
+		if v.ID == "" {
+			return errors.Newf("catalog entry %q variant %d has an empty id", entry.ID, i).
 				Component("classifier.catalog_loader").
 				Category(errors.CategoryValidation).
 				Build()
 		}
-		for j := range entry.Files {
-			f := &entry.Files[j]
-			if f.RemotePath == "" || f.LocalName == "" || f.Role == "" {
-				return errors.Newf("catalog entry %q file %d is missing remote_path, local_name, or role", entry.ID, j).
-					Component("classifier.catalog_loader").
-					Category(errors.CategoryValidation).
-					Build()
-			}
+		if _, dup := seenVariants[v.ID]; dup {
+			return errors.Newf("catalog entry %q has duplicate variant id %q", entry.ID, v.ID).
+				Component("classifier.catalog_loader").
+				Category(errors.CategoryValidation).
+				Build()
 		}
+		seenVariants[v.ID] = struct{}{}
+		if len(v.Files) == 0 {
+			return errors.Newf("catalog entry %q variant %q declares no files", entry.ID, v.ID).
+				Component("classifier.catalog_loader").
+				Category(errors.CategoryValidation).
+				Build()
+		}
+		if err := validateCatalogFiles(entry.ID, v.ID, v.Files); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateCatalogFiles checks that every file declares remote_path, local_name,
+// and role. variantID is empty for an entry's top-level files and names the
+// variant otherwise, so the error points at the offending file precisely.
+func validateCatalogFiles(entryID, variantID string, files []CatalogFile) error {
+	for j := range files {
+		f := &files[j]
+		if f.RemotePath != "" && f.LocalName != "" && f.Role != "" {
+			continue
+		}
+		if variantID == "" {
+			return errors.Newf("catalog entry %q file %d is missing remote_path, local_name, or role", entryID, j).
+				Component("classifier.catalog_loader").
+				Category(errors.CategoryValidation).
+				Build()
+		}
+		return errors.Newf("catalog entry %q variant %q file %d is missing remote_path, local_name, or role", entryID, variantID, j).
+			Component("classifier.catalog_loader").
+			Category(errors.CategoryValidation).
+			Build()
 	}
 	return nil
 }
 
 // catalogChecksum returns the hex-encoded SHA-256 of the compact JSON encoding
 // of entries. The compact encoding is deterministic (fixed struct field order,
-// ordered slices, no maps), so a pristine file round-trips to the same checksum
-// it was written with, and a changed embedded catalog produces a different one.
+// ordered slices, and Go's json.Marshal sorts map keys, e.g. the
+// CatalogVariant.Backends map), so a pristine file round-trips to the same
+// checksum it was written with, and a changed embedded catalog produces a
+// different one.
 //
 // The checksum is coupled to the Go struct layout and JSON tags, not just the
 // semantic content. Reordering CatalogEntry/CatalogFile fields or renaming a tag

--- a/internal/classifier/catalog_loader_test.go
+++ b/internal/classifier/catalog_loader_test.go
@@ -184,6 +184,104 @@ func TestLoadCatalog_ValidationFailureFallsBack(t *testing.T) {
 	}
 }
 
+func TestValidateCatalog_Variants(t *testing.T) {
+	t.Parallel()
+
+	validFile := CatalogFile{RemotePath: "m.onnx", LocalName: "m.onnx", Role: RoleModel}
+	tests := []struct {
+		name    string
+		entry   CatalogEntry
+		wantErr bool
+	}{
+		{
+			name:  "variant entry with empty top-level Files is valid",
+			entry: CatalogEntry{ID: "v", Variants: []CatalogVariant{{ID: "fp32", Files: []CatalogFile{validFile}}}},
+		},
+		{
+			name:    "neither files nor variants",
+			entry:   CatalogEntry{ID: "empty"},
+			wantErr: true,
+		},
+		{
+			name:    "variant declares no files",
+			entry:   CatalogEntry{ID: "v", Variants: []CatalogVariant{{ID: "fp32"}}},
+			wantErr: true,
+		},
+		{
+			name:    "variant has empty id",
+			entry:   CatalogEntry{ID: "v", Variants: []CatalogVariant{{Files: []CatalogFile{validFile}}}},
+			wantErr: true,
+		},
+		{
+			name: "duplicate variant id",
+			entry: CatalogEntry{ID: "v", Variants: []CatalogVariant{
+				{ID: "x", Files: []CatalogFile{validFile}},
+				{ID: "x", Files: []CatalogFile{validFile}},
+			}},
+			wantErr: true,
+		},
+		{
+			name:    "variant file missing role",
+			entry:   CatalogEntry{ID: "v", Variants: []CatalogVariant{{ID: "fp32", Files: []CatalogFile{{RemotePath: "m", LocalName: "m"}}}}},
+			wantErr: true,
+		},
+		{
+			name: "both top-level files and variants",
+			entry: CatalogEntry{
+				ID:       "both",
+				Files:    []CatalogFile{validFile},
+				Variants: []CatalogVariant{{ID: "fp32", Files: []CatalogFile{validFile}}},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateCatalog([]CatalogEntry{tt.entry})
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestLoadCatalog_ResolvesVariantEntryFromFile(t *testing.T) {
+	resetActiveCatalog(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, catalogFileName)
+
+	checksum, err := catalogChecksum(EmbeddedCatalog)
+	require.NoError(t, err)
+
+	// A user added a variant entry but left the seed checksum (baseline matches the
+	// current binary), so the file loads as-is. Its Files must resolve at runtime.
+	variantEntry := CatalogEntry{
+		ID: "variant-model", Name: "Variant Model", Category: CategoryBird, Version: "1",
+		Variants: []CatalogVariant{
+			{ID: "int8", Files: []CatalogFile{{RemotePath: "m_int8.onnx", LocalName: "m_int8.onnx", Role: RoleModel}}},
+			{ID: "fp32", Default: true, Files: []CatalogFile{{RemotePath: "m_fp32.onnx", LocalName: "m_fp32.onnx", Role: RoleModel}}},
+		},
+	}
+	entries := append(slices.Clone(EmbeddedCatalog), variantEntry)
+	writeManifest(t, path, catalogManifest{
+		SchemaVersion:   catalogSchemaVersion,
+		CatalogChecksum: checksum,
+		Entries:         entries,
+	})
+
+	require.NoError(t, LoadCatalog(dir))
+
+	got, found := GetCatalogEntry("variant-model")
+	require.True(t, found, "variant entry must load and validate")
+	require.Len(t, got.Files, 1)
+	assert.Equal(t, "m_fp32.onnx", got.Files[0].LocalName, "Files must resolve to the default variant")
+	assert.Len(t, got.Variants, 2, "Variants preserved for the gallery and install path")
+}
+
 func TestLoadCatalog_RefreshesPristineFileOnChangedEmbedded(t *testing.T) {
 	resetActiveCatalog(t)
 

--- a/internal/classifier/model_catalog.go
+++ b/internal/classifier/model_catalog.go
@@ -568,13 +568,22 @@ func resolveVariantDefaults(entries []CatalogEntry) []CatalogEntry {
 	return out
 }
 
+// resolvedEmbeddedCatalog caches the variant-resolved EmbeddedCatalog for the
+// pre-LoadCatalog fallback below, so that fallback does not re-clone the catalog
+// on every read once an embedded entry carries variants. The embedded catalog is
+// immutable, so resolving it once is safe; when no entry has variants the value
+// is EmbeddedCatalog itself (resolveVariantDefaults returns its input by identity).
+var resolvedEmbeddedCatalog = sync.OnceValue(func() []CatalogEntry {
+	return resolveVariantDefaults(EmbeddedCatalog)
+})
+
 // currentCatalogLocked returns the active runtime catalog, falling back to the
 // built-in EmbeddedCatalog when no catalog has been loaded. In both cases each
 // variant entry's Files is resolved to its default variant's files. Callers must
 // hold catalogMu (read or write).
 func currentCatalogLocked() []CatalogEntry {
 	if activeCatalog == nil {
-		return resolveVariantDefaults(EmbeddedCatalog)
+		return resolvedEmbeddedCatalog()
 	}
 	return activeCatalog
 }

--- a/internal/classifier/model_catalog.go
+++ b/internal/classifier/model_catalog.go
@@ -53,7 +53,61 @@ type CatalogEntry struct {
 	RequiresONNX    bool          `json:"requires_onnx"`     // if true, model needs ONNX Runtime (not just TFLite)
 	UpstreamURL     string        `json:"upstream_url"`      // URL to the upstream project repository
 	HuggingFaceRepo string        `json:"hugging_face_repo"` // HuggingFace repository path
-	Files           []CatalogFile `json:"files"`             // files to download for this model
+	Files           []CatalogFile `json:"files"`             // files to download for this model (the resolved default variant's files when Variants is set)
+	// Variants lists hardware/regional variants of this model (fp32, int8-arm,
+	// regional slices). When non-empty, the catalog layer resolves Files to the
+	// default variant's files so every Files consumer keeps working unchanged;
+	// Variants itself is read only by the recommender, the gallery API, and the
+	// install path when the user picks a non-default variant. Omitted (nil) for
+	// single-variant models, which keep their own Files. omitempty keeps the
+	// on-disk JSON of existing single-variant entries byte-identical, so adding
+	// this field does not shift catalogChecksum or force a schema-version bump.
+	Variants []CatalogVariant `json:"variants,omitempty"`
+}
+
+// CatalogVariant describes one hardware or regional variant of a model: a
+// concrete set of files selected for a class of hosts (e.g. fp32 for CPU, an
+// int8-arm build for low-RAM ARM, or a region-sliced build). Exactly one variant
+// per entry should set Default. Resolution picks the first Default-flagged
+// variant, or the first variant when none is flagged (see defaultVariant).
+type CatalogVariant struct {
+	ID           string                    `json:"id"`                      // stable variant id (e.g. "fp32", "int8-arm", "fp32@nordic")
+	Region       string                    `json:"region"`                  // geographic region, or empty for a global variant
+	Precision    string                    `json:"precision"`               // numeric precision (e.g. "fp32", "fp16", "int8")
+	SpeciesCount int                       `json:"species_count"`           // species this variant can identify (regional slices differ from global)
+	Default      bool                      `json:"default"`                 // if true, the variant resolved into Files absent an explicit choice
+	Requirements VariantRequirements       `json:"requirements"`            // host capabilities this variant needs
+	Backends     map[string]BackendSupport `json:"backends,omitempty"`      // per-backend support, keyed by backend token (e.g. "onnxruntime-cpu")
+	Benchmarks   []Benchmark               `json:"benchmarks,omitempty"`    // measured latency/memory per device
+	Files        []CatalogFile             `json:"files"`                   // files to download for this variant
+	Legacy       bool                      `json:"legacy"`                  // if true, hidden unless already installed (superseded build)
+	SupersededBy string                    `json:"superseded_by,omitempty"` // id of the variant that replaces this one, if any
+}
+
+// VariantRequirements declares the host capabilities a variant needs. Arch and
+// Backends are any-of: a host matches when it carries at least one listed token.
+// An empty slice means "no constraint on this axis".
+type VariantRequirements struct {
+	Arch     []string `json:"arch,omitempty"`     // any-of capability tokens (e.g. "aarch64", "armv7l"); empty = any arch
+	Backends []string `json:"backends,omitempty"` // any-of backend tokens (e.g. "onnxruntime-cpu"); empty = any backend
+	MinRAMMB int      `json:"min_ram_mb"`         // minimum host RAM in MB; 0 = no floor
+	Excludes []string `json:"excludes,omitempty"` // capability tokens that disqualify a host (e.g. a known-bad GPU generation)
+}
+
+// BackendSupport records whether an inference backend runs a variant and whether
+// it is the recommended backend for it. Mirrors the manifest's per-backend map.
+type BackendSupport struct {
+	Supported   bool `json:"supported"`   // the backend can execute this variant
+	Recommended bool `json:"recommended"` // the backend is the preferred way to run this variant
+}
+
+// Benchmark is a measured latency (and optional memory) figure for a variant on
+// a specific device and backend. Used by the recommender and the gallery card.
+type Benchmark struct {
+	Device    string `json:"device"`               // device identifier (e.g. "rpi5-a76")
+	Backend   string `json:"backend"`              // backend the figure was measured with
+	LatencyMs int    `json:"latency_ms,omitempty"` // single-inference latency in milliseconds
+	RSSMB     int    `json:"rss_mb,omitempty"`     // resident memory in MB, when measured
 }
 
 // CatalogFile describes a single file within a model's HuggingFace repository.
@@ -471,12 +525,56 @@ var (
 	activeCatalog []CatalogEntry
 )
 
+// defaultVariant returns the variant resolved into Files when no explicit choice
+// is made: the one flagged Default, else the first. Returns nil for a
+// single-variant entry (len(Variants) == 0).
+func defaultVariant(entry *CatalogEntry) *CatalogVariant {
+	if len(entry.Variants) == 0 {
+		return nil
+	}
+	for i := range entry.Variants {
+		if entry.Variants[i].Default {
+			return &entry.Variants[i]
+		}
+	}
+	return &entry.Variants[0]
+}
+
+// resolveVariantDefaults returns entries with each variant entry's Files
+// populated from its default variant, so every Files consumer sees the effective
+// default variant's files. Single-variant entries (no Variants) are returned
+// unchanged. When no entry carries variants (the common case) the input slice is
+// returned as-is with no allocation; otherwise a shallow copy is made and only
+// the variant entries' Files are replaced, so the input (which may be the
+// EmbeddedCatalog global) is never mutated. Variants is preserved on every entry
+// for the gallery API and the install path.
+func resolveVariantDefaults(entries []CatalogEntry) []CatalogEntry {
+	hasVariants := false
+	for i := range entries {
+		if len(entries[i].Variants) > 0 {
+			hasVariants = true
+			break
+		}
+	}
+	if !hasVariants {
+		return entries
+	}
+	out := slices.Clone(entries)
+	for i := range out {
+		if v := defaultVariant(&out[i]); v != nil {
+			out[i].Files = v.Files
+		}
+	}
+	return out
+}
+
 // currentCatalogLocked returns the active runtime catalog, falling back to the
-// built-in EmbeddedCatalog when no catalog has been loaded. Callers must hold
-// catalogMu (read or write).
+// built-in EmbeddedCatalog when no catalog has been loaded. In both cases each
+// variant entry's Files is resolved to its default variant's files. Callers must
+// hold catalogMu (read or write).
 func currentCatalogLocked() []CatalogEntry {
 	if activeCatalog == nil {
-		return EmbeddedCatalog
+		return resolveVariantDefaults(EmbeddedCatalog)
 	}
 	return activeCatalog
 }
@@ -487,8 +585,9 @@ func currentCatalogLocked() []CatalogEntry {
 // it to inject a catalog must run serially (no t.Parallel), since it mutates
 // this package-global.
 func setActiveCatalog(entries []CatalogEntry) {
+	resolved := resolveVariantDefaults(entries)
 	catalogMu.Lock()
-	activeCatalog = entries
+	activeCatalog = resolved
 	catalogMu.Unlock()
 }
 

--- a/internal/classifier/model_catalog_test.go
+++ b/internal/classifier/model_catalog_test.go
@@ -33,33 +33,118 @@ func TestEmbeddedCatalog_ValidRegistryIDs(t *testing.T) {
 	}
 }
 
+// assertFilesHaveChecksums asserts every file carries a valid 32-byte hex SHA-256
+// and a positive size. It validates that the checksum DECODES to a 32-byte digest,
+// not just that it is 64 characters: a 64-char non-hex string would never match a
+// real digest and so would fail closed at download time, but it has no business in
+// the catalog. hex.DecodeString("") returns no error, so the length check is what
+// rejects an empty checksum. label names the entry (and variant) for failures.
+func assertFilesHaveChecksums(t *testing.T, label string, files []CatalogFile) {
+	t.Helper()
+	for _, f := range files {
+		raw, err := hex.DecodeString(f.SHA256)
+		if assert.NoErrorf(t, err,
+			"catalog %q file %q must carry a hex SHA-256", label, f.RemotePath) {
+			assert.Lenf(t, raw, sha256.Size,
+				"catalog %q file %q SHA-256 must decode to 32 bytes", label, f.RemotePath)
+		}
+		assert.Positivef(t, f.SizeBytes,
+			"catalog %q file %q must carry a positive SizeBytes", label, f.RemotePath)
+	}
+}
+
 // TestEmbeddedCatalog_AllFilesHaveChecksums verifies every downloadable file in the
 // catalog carries a real SHA-256 and a non-zero size. An empty SHA-256 makes
 // verifySHA256 a no-op, so the file would be downloaded and loaded with no integrity
 // check at all; a zero size makes the download progress bar meaningless. The invariant
 // must hold for every entry, including Hidden ones, because Hidden is a UI and install
 // gate, not an integrity guarantee: a Hidden entry can still be reached by config or a
-// future un-hide, and every file the gallery can fetch must be verifiable.
+// future un-hide, and every file the gallery can fetch must be verifiable. Variant
+// entries carry files under Variants (their top-level Files is empty and resolved at
+// load time), so both are checked.
 func TestEmbeddedCatalog_AllFilesHaveChecksums(t *testing.T) {
 	t.Parallel()
 
 	for _, entry := range EmbeddedCatalog {
-		for _, f := range entry.Files {
-			// Validate the checksum decodes to a 32-byte digest, not just that
-			// it is 64 characters: a 64-char non-hex string would never match a
-			// real digest and so would fail closed at download time, but it has
-			// no business being in the catalog. hex.DecodeString("") returns no
-			// error, so the length check below is what rejects an empty checksum.
-			raw, err := hex.DecodeString(f.SHA256)
-			if assert.NoErrorf(t, err,
-				"catalog entry %q file %q must carry a hex SHA-256", entry.ID, f.RemotePath) {
-				assert.Lenf(t, raw, sha256.Size,
-					"catalog entry %q file %q SHA-256 must decode to 32 bytes", entry.ID, f.RemotePath)
-			}
-			assert.Positivef(t, f.SizeBytes,
-				"catalog entry %q file %q must carry a positive SizeBytes", entry.ID, f.RemotePath)
+		assertFilesHaveChecksums(t, entry.ID, entry.Files)
+		for _, v := range entry.Variants {
+			assertFilesHaveChecksums(t, entry.ID+"/"+v.ID, v.Files)
 		}
 	}
+}
+
+func TestResolveVariantDefaults(t *testing.T) {
+	// setActiveCatalog mutates a package global, so this test runs serially.
+	fp32 := CatalogFile{RemotePath: "m_fp32.onnx", LocalName: "m_fp32.onnx", Role: RoleModel, SHA256: "a", SizeBytes: 10}
+	int8File := CatalogFile{RemotePath: "m_int8.onnx", LocalName: "m_int8.onnx", Role: RoleModel, SHA256: "b", SizeBytes: 5}
+
+	t.Run("resolves the default variant into Files and preserves Variants", func(t *testing.T) {
+		resetActiveCatalog(t)
+		setActiveCatalog([]CatalogEntry{{
+			ID: "multi", Name: "Multi", Category: CategoryBird, Version: "1",
+			Variants: []CatalogVariant{
+				{ID: "int8-arm", Files: []CatalogFile{int8File}},
+				{ID: "fp32", Default: true, Files: []CatalogFile{fp32}},
+			},
+		}})
+		got, ok := GetCatalogEntry("multi")
+		require.True(t, ok)
+		require.Len(t, got.Files, 1)
+		assert.Equal(t, "m_fp32.onnx", got.Files[0].LocalName, "Files must resolve to the default variant")
+		assert.Len(t, got.Variants, 2, "Variants must be preserved for the gallery and install path")
+	})
+
+	t.Run("falls back to the first variant when none is marked default", func(t *testing.T) {
+		resetActiveCatalog(t)
+		setActiveCatalog([]CatalogEntry{{
+			ID: "nodefault", Name: "NoDefault", Category: CategoryBird, Version: "1",
+			Variants: []CatalogVariant{
+				{ID: "int8-arm", Files: []CatalogFile{int8File}},
+				{ID: "fp32", Files: []CatalogFile{fp32}},
+			},
+		}})
+		got, ok := GetCatalogEntry("nodefault")
+		require.True(t, ok)
+		require.Len(t, got.Files, 1)
+		assert.Equal(t, "m_int8.onnx", got.Files[0].LocalName, "Files must resolve to the first variant")
+	})
+
+	t.Run("picks the first Default-flagged variant when several set Default", func(t *testing.T) {
+		resetActiveCatalog(t)
+		fp16 := CatalogFile{RemotePath: "m_fp16.onnx", LocalName: "m_fp16.onnx", Role: RoleModel, SHA256: "c", SizeBytes: 7}
+		setActiveCatalog([]CatalogEntry{{
+			ID: "multidefault", Name: "MultiDefault", Category: CategoryBird, Version: "1",
+			Variants: []CatalogVariant{
+				{ID: "int8-arm", Files: []CatalogFile{int8File}},
+				{ID: "fp32", Default: true, Files: []CatalogFile{fp32}},
+				{ID: "fp16", Default: true, Files: []CatalogFile{fp16}},
+			},
+		}})
+		got, ok := GetCatalogEntry("multidefault")
+		require.True(t, ok)
+		require.Len(t, got.Files, 1)
+		assert.Equal(t, "m_fp32.onnx", got.Files[0].LocalName, "the first Default-flagged variant wins deterministically")
+	})
+
+	t.Run("leaves a single-variant entry untouched", func(t *testing.T) {
+		resetActiveCatalog(t)
+		setActiveCatalog([]CatalogEntry{customEntry("plain")})
+		got, ok := GetCatalogEntry("plain")
+		require.True(t, ok)
+		require.Len(t, got.Files, 1)
+		assert.Equal(t, "plain.onnx", got.Files[0].LocalName)
+		assert.Empty(t, got.Variants)
+	})
+
+	t.Run("does not mutate the caller's entries", func(t *testing.T) {
+		resetActiveCatalog(t)
+		entries := []CatalogEntry{{
+			ID: "immut", Name: "Immut", Category: CategoryBird, Version: "1",
+			Variants: []CatalogVariant{{ID: "fp32", Default: true, Files: []CatalogFile{fp32}}},
+		}}
+		setActiveCatalog(entries)
+		assert.Empty(t, entries[0].Files, "resolution must not mutate the caller's entries (may be EmbeddedCatalog)")
+	})
 }
 
 func TestEmbeddedCatalog_HasFilesWithModelRole(t *testing.T) {


### PR DESCRIPTION
## Summary

This lands the representational foundation for hardware- and region-aware model selection: a single gallery entry can now describe multiple variants of a model (fp32, int8-arm, region-sliced builds) instead of forcing each variant to be a separate top-level entry. No shipped catalog entry gains variants in this PR, so behaviour is unchanged for existing users; this is purely the schema plus its resolution and validation, exercised by tests.

`CatalogEntry` gains a `Variants []CatalogVariant` field tagged `omitempty`. Because a nil slice is omitted, the on-disk JSON of every existing single-variant entry is byte-identical, so `catalogChecksum` is unshifted: no `catalogSchemaVersion` bump, no upgrade refresh, and no "schema version differs" warning for anyone with an existing `model-catalog.json`.

The catalog layer resolves each variant entry's `Files` to its default variant (the first `Default`-flagged variant, else the first) in `resolveVariantDefaults`, on a copy, so the roughly 17 existing `entry.Files` consumers keep working unchanged and the `EmbeddedCatalog` global is never mutated. `Variants` is preserved on every entry for the gallery API and the install path that come next.

`validateCatalog` now accepts an entry that declares its files through `Variants` (with an empty top-level `Files`), validates each variant's files and requires unique non-empty variant IDs, and rejects an entry that declares both top-level `Files` and `Variants` (which resolution would otherwise silently discard).

## Test Plan

- [x] `go test -race ./internal/classifier/` passes, including new tests for default selection, multi-`Default` determinism, first-variant fallback, the no-mutation invariant, the full load/validate/resolve path, and the variant validation rules
- [x] `golangci-lint run ./...` clean (0 issues)
- [x] The variant path is behaviour-neutral for the shipped catalog: `resolveVariantDefaults` short-circuits by identity when no entry has variants, so all existing accessors return the same entries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Catalog entries now support hardware- and region-specific model variants.
  * Variant metadata can describe requirements, backend support, benchmarks, and model files.
  * The default variant is automatically selected, with predictable fallback behavior.

* **Bug Fixes**
  * Added validation for missing or duplicate variant identifiers, invalid files, and conflicting file declarations.
  * Resolved model files now remain consistent without modifying the original catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->