### PR TITLE
feat(models): detect the installed model variant during scan and install

### DIFF
--- a/internal/classifier/catalog_loader.go
+++ b/internal/classifier/catalog_loader.go
@@ -262,6 +262,17 @@ func validateCatalogEntryFiles(entry *CatalogEntry) error {
 		if err := validateCatalogFiles(entry.ID, v.ID, v.Files); err != nil {
 			return err
 		}
+		// Every hardware variant must carry a model-role file. ScanInstalled
+		// detects a variant install by that file's presence on disk, so a
+		// model-less variant would be silently undetectable; rejecting it here
+		// keeps the "variant entries always carry a model role" invariant that the
+		// scan relies on (a shared-only entry must stay flat, not declare variants).
+		if modelFile, _ := modelAndLabelsFiles(v.Files); modelFile == "" {
+			return errors.Newf("catalog entry %q variant %q has no model-role file; every hardware variant must carry a model file", entry.ID, v.ID).
+				Component("classifier.catalog_loader").
+				Category(errors.CategoryValidation).
+				Build()
+		}
 	}
 	return nil
 }

--- a/internal/classifier/catalog_loader_test.go
+++ b/internal/classifier/catalog_loader_test.go
@@ -226,6 +226,11 @@ func TestValidateCatalog_Variants(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "variant without a model-role file",
+			entry:   CatalogEntry{ID: "v", Variants: []CatalogVariant{{ID: "fp32", Files: []CatalogFile{{RemotePath: "l.txt", LocalName: "l.txt", Role: RoleLabels}}}}},
+			wantErr: true,
+		},
+		{
 			name: "both top-level files and variants",
 			entry: CatalogEntry{
 				ID:       "both",

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -63,7 +63,13 @@ type ModelManager struct {
 
 // InstalledModel represents a model that has been downloaded and is available.
 type InstalledModel struct {
-	CatalogID   string    `json:"catalogId"`
+	CatalogID string `json:"catalogId"`
+	// VariantID is the id of the installed hardware variant (e.g. "fp32",
+	// "int8-arm"). Empty means a flat, pre-variant entry with a single implicit
+	// variant. It is recorded at install time (from the default variant) and
+	// re-derived from disk on every ScanInstalled; it is never persisted, so no
+	// on-disk migration is needed for existing installs.
+	VariantID   string    `json:"variantId,omitempty"`
 	ModelPath   string    `json:"modelPath"`
 	LabelsPath  string    `json:"labelsPath"`
 	InstalledAt time.Time `json:"installedAt"`
@@ -146,16 +152,23 @@ func (mm *ModelManager) ScanInstalled() {
 		entry := &catalog[i]
 		subdir := filepath.Join(mm.modelsDir, entry.ID)
 
-		modelFile := ""
-		labelsFile := ""
-		for _, f := range entry.Files {
-			if f.Role == RoleModel {
-				modelFile = f.LocalName
+		// Variant entries: detect which hardware variant is present on disk
+		// (the default variant's filename alone would miss a non-default install).
+		// Invariant: every variant carries a model-role file and shared-only
+		// entries (geomodels) never declare variants, so a variant entry never
+		// needs the shared-only fall-through below.
+		if len(entry.Variants) > 0 {
+			if im, ok := scanVariantEntry(entry, subdir); ok {
+				mm.installed[entry.ID] = im
+				log.Debug("Found installed model variant",
+					logger.String("catalog_id", entry.ID),
+					logger.String("variant_id", im.VariantID),
+					logger.String("path", im.ModelPath))
 			}
-			if f.Role == RoleLabels {
-				labelsFile = f.LocalName
-			}
+			continue
 		}
+
+		modelFile, labelsFile := modelAndLabelsFiles(entry.Files)
 
 		// Shared-only entries (e.g. geomodels): all files live in models/shared/.
 		// Detect these by checking that every file is a shared role and all exist.
@@ -250,6 +263,72 @@ func (mm *ModelManager) ScanInstalled() {
 		// where a new binary adds geomodel support to existing models.
 		mm.ensureGeomodelConfig(log, installedIDs)
 	}
+}
+
+// modelAndLabelsFiles extracts the model and labels file LocalNames from a list
+// of catalog files. Either return value is empty when the corresponding role is
+// absent (e.g. shared-only entries have no model role).
+func modelAndLabelsFiles(files []CatalogFile) (modelFile, labelsFile string) {
+	for _, f := range files {
+		switch f.Role {
+		case RoleModel:
+			modelFile = f.LocalName
+		case RoleLabels:
+			labelsFile = f.LocalName
+		}
+	}
+	return modelFile, labelsFile
+}
+
+// scanVariantEntry determines which variant of a variant-carrying catalog entry
+// is installed on disk under subdir. It checks the default variant first so an
+// ambiguous on-disk state (e.g. both files present after a crashed replace)
+// resolves to the default, matching pre-variant behaviour; it then falls back to
+// the remaining variants in catalog order. ok is false when no variant's model
+// file is present on disk.
+func scanVariantEntry(entry *CatalogEntry, subdir string) (InstalledModel, bool) {
+	def := defaultVariant(entry)
+	if def != nil {
+		if im, ok := installedFromVariant(entry, def, subdir); ok {
+			return im, true
+		}
+	}
+	for i := range entry.Variants {
+		v := &entry.Variants[i]
+		if def != nil && v.ID == def.ID {
+			continue
+		}
+		if im, ok := installedFromVariant(entry, v, subdir); ok {
+			return im, true
+		}
+	}
+	return InstalledModel{}, false
+}
+
+// installedFromVariant builds the InstalledModel for a specific variant if its
+// model file exists on disk under subdir. ok is false when the variant carries
+// no model role or its model file is absent.
+func installedFromVariant(entry *CatalogEntry, v *CatalogVariant, subdir string) (InstalledModel, bool) {
+	modelFile, labelsFile := modelAndLabelsFiles(v.Files)
+	if modelFile == "" {
+		return InstalledModel{}, false
+	}
+	modelPath := filepath.Join(subdir, modelFile)
+	if _, err := os.Stat(modelPath); err != nil {
+		return InstalledModel{}, false
+	}
+	labelsPath := ""
+	if labelsFile != "" {
+		labelsPath = filepath.Join(subdir, labelsFile)
+	}
+	return InstalledModel{
+		CatalogID:   entry.ID,
+		VariantID:   v.ID,
+		ModelPath:   modelPath,
+		LabelsPath:  labelsPath,
+		InstalledAt: fileModTime(modelPath),
+		Version:     entry.Version,
+	}, true
 }
 
 // geomodelOrphanAction is the decision the orphan self-heal makes for a
@@ -1036,10 +1115,21 @@ func (mm *ModelManager) downloadModelFiles(ctx context.Context, entry *CatalogEn
 	// For shared-only entries (e.g. geomodels), derive paths from shared files.
 	modelPath, labelsPath = resolveSharedPaths(entry, modelPath, labelsPath, fileDestPath)
 
+	// The install path downloads the resolved default variant's files, so record
+	// that variant's id (empty for a flat entry). This keeps the install record in
+	// sync with what ScanInstalled later derives from disk. When variant selection
+	// lands (the primary-variant selector), this must record the SELECTED variant's
+	// id, not the default.
+	variantID := ""
+	if v := defaultVariant(entry); v != nil {
+		variantID = v.ID
+	}
+
 	// Record as installed.
 	mm.mu.Lock()
 	mm.installed[entry.ID] = InstalledModel{
 		CatalogID:   entry.ID,
+		VariantID:   variantID,
 		ModelPath:   modelPath,
 		LabelsPath:  labelsPath,
 		InstalledAt: time.Now(),

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -154,9 +154,9 @@ func (mm *ModelManager) ScanInstalled() {
 
 		// Variant entries: detect which hardware variant is present on disk
 		// (the default variant's filename alone would miss a non-default install).
-		// Invariant: every variant carries a model-role file and shared-only
-		// entries (geomodels) never declare variants, so a variant entry never
-		// needs the shared-only fall-through below.
+		// validateCatalogEntryFiles guarantees every variant carries a model-role
+		// file, so a variant entry is never shared-only and never needs the
+		// shared-only fall-through below.
 		if len(entry.Variants) > 0 {
 			if im, ok := scanVariantEntry(entry, subdir); ok {
 				mm.installed[entry.ID] = im

--- a/internal/classifier/model_manager_test.go
+++ b/internal/classifier/model_manager_test.go
@@ -71,6 +71,184 @@ func TestModelManager_ScanInstalled(t *testing.T) {
 	assert.Equal(t, entry.Version, installed[0].Version)
 }
 
+// variantByID returns the variant with the given id from entry, failing the
+// test if it is absent.
+func variantByID(t *testing.T, entry *CatalogEntry, id string) *CatalogVariant {
+	t.Helper()
+	for i := range entry.Variants {
+		if entry.Variants[i].ID == id {
+			return &entry.Variants[i]
+		}
+	}
+	t.Fatalf("variant %q not found in entry %s", id, entry.ID)
+	return nil
+}
+
+// modelRoleLocalName returns the LocalName of the RoleModel file in files.
+func modelRoleLocalName(t *testing.T, files []CatalogFile) string {
+	t.Helper()
+	for _, f := range files {
+		if f.Role == RoleModel {
+			return f.LocalName
+		}
+	}
+	t.Fatalf("no model-role file found in %d files", len(files))
+	return ""
+}
+
+// installedByID returns the InstalledModel recorded for catalogID, failing the
+// test if it is not present in the installed list.
+func installedByID(t *testing.T, mm *ModelManager, catalogID string) InstalledModel {
+	t.Helper()
+	for _, im := range mm.ListInstalled() {
+		if im.CatalogID == catalogID {
+			return im
+		}
+	}
+	t.Fatalf("model %s not found in installed list", catalogID)
+	return InstalledModel{}
+}
+
+// writeVariantModelFile writes a placeholder model file for the given variant of
+// a catalog entry into its on-disk subdirectory, mimicking an install of that
+// specific variant. It returns the full path to the written model file.
+func writeVariantModelFile(t *testing.T, modelsDir string, entry *CatalogEntry, variantID string) string {
+	t.Helper()
+	v := variantByID(t, entry, variantID)
+	modelName := modelRoleLocalName(t, v.Files)
+	subdir := filepath.Join(modelsDir, entry.ID)
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+	modelPath := filepath.Join(subdir, modelName)
+	require.NoError(t, os.WriteFile(modelPath, []byte("fake-onnx-data"), 0o644))
+	return modelPath
+}
+
+func TestModelManager_ScanInstalled_DetectsDefaultVariant(t *testing.T) {
+	t.Parallel()
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok, "expected perch-v2 catalog entry to exist")
+	require.NotEmpty(t, entry.Variants, "perch-v2 must be a variant entry")
+
+	modelsDir := t.TempDir()
+	modelPath := writeVariantModelFile(t, modelsDir, &entry, "fp32")
+
+	mm := NewModelManager(modelsDir, nil, nil)
+	mm.ScanInstalled()
+
+	require.True(t, mm.IsInstalled(entry.ID), "default variant install should be detected")
+	got := installedByID(t, mm, entry.ID)
+	assert.Equal(t, "fp32", got.VariantID, "default variant id should be recorded")
+	assert.Equal(t, modelPath, got.ModelPath, "model path should point at the default variant file")
+}
+
+func TestModelManager_ScanInstalled_DetectsNonDefaultVariant(t *testing.T) {
+	t.Parallel()
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok, "expected perch-v2 catalog entry to exist")
+
+	// Only the non-default int8-arm variant's model file exists on disk. The
+	// default variant's filename is absent, so a default-only scan would miss it.
+	modelsDir := t.TempDir()
+	modelPath := writeVariantModelFile(t, modelsDir, &entry, "int8-arm")
+
+	mm := NewModelManager(modelsDir, nil, nil)
+	mm.ScanInstalled()
+
+	require.True(t, mm.IsInstalled(entry.ID), "non-default variant install should be detected")
+	got := installedByID(t, mm, entry.ID)
+	assert.Equal(t, "int8-arm", got.VariantID, "installed variant id should be the on-disk variant")
+	assert.Equal(t, modelPath, got.ModelPath, "model path should point at the installed variant file")
+}
+
+func TestModelManager_ScanInstalled_ZeroVariantEntryHasEmptyVariantID(t *testing.T) {
+	t.Parallel()
+
+	entry, ok := GetCatalogEntry("battybirdnet-eu")
+	require.True(t, ok, "expected battybirdnet-eu catalog entry to exist")
+	require.Empty(t, entry.Variants, "battybirdnet-eu is expected to be a flat, zero-variant entry")
+
+	modelFileName := modelRoleLocalName(t, entry.Files)
+	modelsDir := t.TempDir()
+	subdir := filepath.Join(modelsDir, entry.ID)
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(subdir, modelFileName), []byte("fake-onnx-data"), 0o644))
+
+	mm := NewModelManager(modelsDir, nil, nil)
+	mm.ScanInstalled()
+
+	require.True(t, mm.IsInstalled(entry.ID))
+	got := installedByID(t, mm, entry.ID)
+	assert.Empty(t, got.VariantID, "flat entries must record an empty variant id")
+}
+
+func TestModelManager_ScanInstalled_VariantEntryNoFileNotInstalled(t *testing.T) {
+	t.Parallel()
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok, "expected perch-v2 catalog entry to exist")
+	require.NotEmpty(t, entry.Variants, "perch-v2 must be a variant entry")
+
+	// The entry's subdirectory exists but carries no variant model file, so no
+	// variant is present on disk and the entry must not be reported installed.
+	modelsDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(modelsDir, entry.ID), 0o755))
+
+	mm := NewModelManager(modelsDir, nil, nil)
+	mm.ScanInstalled()
+
+	assert.False(t, mm.IsInstalled(entry.ID), "a variant entry with no model file on disk must not be installed")
+}
+
+func TestModelManager_Install_RecordsDefaultVariantID(t *testing.T) {
+	t.Parallel()
+
+	modelContent := []byte("fake-onnx-model-binary-data")
+	labelsContent := []byte("species_a\nspecies_b\n")
+	modelChecksum := sha256Hex(modelContent)
+	labelsChecksum := sha256Hex(labelsContent)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case testPathModelsONNX:
+			_, _ = w.Write(modelContent)
+		case testPathModelsLabels:
+			_, _ = w.Write(labelsContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	// A resolved variant entry: Files carries the default variant's files (as
+	// resolveVariantDefaults would produce) and Variants names that default.
+	files := []CatalogFile{
+		{RemotePath: "models/test.onnx", LocalName: "test.onnx", Role: RoleModel, SHA256: modelChecksum, SizeBytes: int64(len(modelContent))},
+		{RemotePath: "models/labels.txt", LocalName: "labels.txt", Role: RoleLabels, SHA256: labelsChecksum, SizeBytes: int64(len(labelsContent))},
+	}
+	entry := CatalogEntry{
+		ID:              "test-variant-install",
+		Name:            "Test Variant Model",
+		Version:         "1.0",
+		HuggingFaceRepo: "test/repo",
+		// Non-default variant first so this proves the install records the DEFAULT
+		// variant (via Default: true), not merely the first one in the slice.
+		Variants: []CatalogVariant{
+			{ID: "int8-arm", Files: files},
+			{ID: "fp32", Default: true, Files: files},
+		},
+		Files: files,
+	}
+
+	mm := NewModelManager(t.TempDir(), nil, nil)
+	require.NoError(t, mm.Install(t.Context(), &entry, srv.URL, nil))
+
+	require.True(t, mm.IsInstalled(entry.ID))
+	got := installedByID(t, mm, entry.ID)
+	assert.Equal(t, "fp32", got.VariantID, "install must record the default variant id, matching what ScanInstalled derives")
+}
+
 func TestModelManager_IsInstalled(t *testing.T) {
 	t.Parallel()
 

--- a/internal/classifier/model_manager_test.go
+++ b/internal/classifier/model_manager_test.go
@@ -219,7 +219,7 @@ func TestModelManager_Install_RecordsDefaultVariantID(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	}))
-	defer srv.Close()
+	t.Cleanup(srv.Close)
 
 	// A resolved variant entry: Files carries the default variant's files (as
 	// resolveVariantDefaults would produce) and Variants names that default.


### PR DESCRIPTION
## Summary

Makes the model manager variant-aware at scan and install time so a non-default hardware model variant is detected on disk and recorded on the installed model, without changing behaviour for flat or default installs. The catalog already describes hardware variants (nested-variant schema in #4076, real variant data in #4077), but the runtime could previously only ever detect the default variant's filename.

`InstalledModel` gains `VariantID`: it is recorded at install time (from the default variant) and re-derived from disk on every `ScanInstalled`, never persisted, so existing installs need no migration. `ScanInstalled` now detects which variant of a variant-carrying catalog entry is present on disk, checking the default first and then the rest in catalog order. Flat and shared-only entries are unchanged and keep an empty `VariantID`. The field surfaces additively (`omitempty`) in `GET /api/v2/models/installed`.

This is the foundation slice of the model-gallery variant lifecycle. It is behaviour-neutral: an existing flat install (BattyBirdNET, geomodel, BSG) and today's default Perch v2 (fp32) install resolve to the same paths as before, now with `VariantID` populated. Installing a non-default variant is not yet reachable (no variant selector in the install API), so this only adds detection and recording. Variant-aware uninstall and replace (download-before-delete), orphan recovery, disk preflight, and the API and UI variant selector follow in later PRs.

## Test Plan

- [x] `go test -race ./internal/classifier/ ./internal/api/v2/models/`
- [x] `golangci-lint run` (full project, 0 issues)
- [x] New unit tests: default-variant detection, non-default-variant detection, flat entry keeps an empty variant id, install records the default variant id, and a variant entry with no model file on disk is not installed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Installed models now retain hardware variant information.
  * Model detection recognizes both default and alternate hardware variants.
  * Variant-aware installations record the selected default variant.

* **Bug Fixes**
  * Improved handling of models without variants.
  * Model entries lacking required files are no longer reported as installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->