### PR TITLE
feat(models): install, uninstall, and reinstall a selected model variant

### DIFF
--- a/internal/api/v2/models/models.go
+++ b/internal/api/v2/models/models.go
@@ -241,7 +241,7 @@ func (c *Handler) InstallModel(ctx echo.Context) error {
 				)
 			}
 		}()
-		if err := c.ModelManager.Install(c.Context(), &entry, "", progressChan); err != nil {
+		if err := c.ModelManager.Install(c.Context(), &entry, "", "", progressChan); err != nil {
 			c.LogErrorIfEnabled("Model install failed",
 				logger.String("catalog_id", catalogID),
 				logger.Error(err),

--- a/internal/classifier/model_catalog.go
+++ b/internal/classifier/model_catalog.go
@@ -648,10 +648,11 @@ func defaultVariant(entry *CatalogEntry) *CatalogVariant {
 }
 
 // variantFilesByID returns the file list for the given variant of an entry. An
-// empty variantID, or an entry with no variants, yields the entry's resolved
-// (default) Files, preserving the pre-variant behaviour. A non-empty variantID
-// that matches no variant reports ok=false so callers can reject a stale or
-// unknown selection rather than operate on the wrong files.
+// empty variantID yields the entry's resolved (default) Files, preserving the
+// pre-variant behaviour. A non-empty variantID selects the matching variant's
+// files; if it matches no variant (including any non-empty id on an entry with no
+// variants), it reports ok=false so callers can reject a stale or unknown
+// selection rather than operate on the wrong files.
 func variantFilesByID(entry *CatalogEntry, variantID string) (files []CatalogFile, ok bool) {
 	if variantID == "" {
 		return entry.Files, true

--- a/internal/classifier/model_catalog.go
+++ b/internal/classifier/model_catalog.go
@@ -647,6 +647,23 @@ func defaultVariant(entry *CatalogEntry) *CatalogVariant {
 	return &entry.Variants[0]
 }
 
+// variantFilesByID returns the file list for the given variant of an entry. An
+// empty variantID, or an entry with no variants, yields the entry's resolved
+// (default) Files, preserving the pre-variant behaviour. A non-empty variantID
+// that matches no variant reports ok=false so callers can reject a stale or
+// unknown selection rather than operate on the wrong files.
+func variantFilesByID(entry *CatalogEntry, variantID string) (files []CatalogFile, ok bool) {
+	if variantID == "" {
+		return entry.Files, true
+	}
+	for i := range entry.Variants {
+		if entry.Variants[i].ID == variantID {
+			return entry.Variants[i].Files, true
+		}
+	}
+	return nil, false
+}
+
 // resolveVariantDefaults returns entries with each variant entry's Files
 // populated from its default variant, so every Files consumer sees the effective
 // default variant's files. Single-variant entries (no Variants) are returned

--- a/internal/classifier/model_catalog_test.go
+++ b/internal/classifier/model_catalog_test.go
@@ -9,6 +9,57 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestVariantFilesByID(t *testing.T) {
+	t.Parallel()
+
+	modelFile := CatalogFile{RemotePath: "m.onnx", LocalName: "m.onnx", Role: RoleModel}
+	int8File := CatalogFile{RemotePath: "m_int8.onnx", LocalName: "m_int8.onnx", Role: RoleModel}
+	flatEntry := CatalogEntry{ID: "flat", Files: []CatalogFile{modelFile}}
+	variantEntry := CatalogEntry{ID: "v", Variants: []CatalogVariant{
+		{ID: "fp32", Default: true, Files: []CatalogFile{modelFile}},
+		{ID: "int8-arm", Files: []CatalogFile{int8File}},
+	}}
+
+	t.Run("empty variant id returns entry Files", func(t *testing.T) {
+		t.Parallel()
+		files, ok := variantFilesByID(&flatEntry, "")
+		require.True(t, ok)
+		assert.Equal(t, flatEntry.Files, files)
+	})
+
+	t.Run("empty variant id on a variant entry returns top-level Files", func(t *testing.T) {
+		t.Parallel()
+		// On a resolved entry, top-level Files is the default variant's files.
+		files, ok := variantFilesByID(&variantEntry, "")
+		require.True(t, ok)
+		assert.Equal(t, variantEntry.Files, files)
+	})
+
+	t.Run("selects the named non-default variant", func(t *testing.T) {
+		t.Parallel()
+		files, ok := variantFilesByID(&variantEntry, "int8-arm")
+		require.True(t, ok)
+		require.Len(t, files, 1)
+		assert.Equal(t, "m_int8.onnx", files[0].LocalName)
+	})
+
+	t.Run("unknown variant id reports not found", func(t *testing.T) {
+		t.Parallel()
+		files, ok := variantFilesByID(&variantEntry, "does-not-exist")
+		assert.False(t, ok)
+		assert.Nil(t, files)
+	})
+
+	t.Run("non-empty variant id on a flat entry reports not found", func(t *testing.T) {
+		t.Parallel()
+		// A flat entry has no variants, so any non-empty selection is unknown and
+		// must be rejected rather than silently resolving to the flat Files.
+		files, ok := variantFilesByID(&flatEntry, "int8-arm")
+		assert.False(t, ok)
+		assert.Nil(t, files)
+	})
+}
+
 func TestEmbeddedCatalog_UniqueIDs(t *testing.T) {
 	t.Parallel()
 

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -684,7 +684,8 @@ func (mm *ModelManager) Uninstall(catalogID string) error {
 	mm.mu.Lock()
 	defer mm.mu.Unlock()
 
-	if _, installed := mm.installed[catalogID]; !installed {
+	im, installed := mm.installed[catalogID]
+	if !installed {
 		return errors.Newf("model %s is not installed", catalogID).
 			Component("classifier.model_manager").
 			Category(errors.CategoryValidation).
@@ -719,8 +720,22 @@ func (mm *ModelManager) Uninstall(catalogID string) error {
 
 	var deleteErr error
 
+	// Delete the INSTALLED variant's model and data files, not the resolved
+	// default, so a non-default install is not orphaned. If the installed variant
+	// id is unknown (e.g. dropped from the catalog), its file list is unknown, so
+	// fall back to the recorded on-disk model path: that is the actual installed
+	// file, whereas the default file list would name a different file and orphan
+	// it. Any data files of a dropped variant are unknown and left in place.
+	deleteFiles, okVariant := variantFilesByID(&entry, im.VariantID)
+	if !okVariant {
+		deleteFiles = nil
+		if im.ModelPath != "" {
+			deleteFiles = []CatalogFile{{LocalName: filepath.Base(im.ModelPath), Role: RoleModel}}
+		}
+	}
+
 	// Delete model ONNX files and associated data files (calibration, distribution, etc.).
-	for _, f := range entry.Files {
+	for _, f := range deleteFiles {
 		if f.Role == RoleModel || f.Role == RoleData {
 			path := filepath.Join(subdir, f.LocalName)
 			err := os.Remove(path)
@@ -847,11 +862,25 @@ func (mm *ModelManager) cleanupSharedFiles(log logger.Logger, catalogID string, 
 	}
 }
 
-// Install downloads all files for a catalog entry and records it as installed.
-// The baseURL parameter overrides the HuggingFace URL for testing; pass an
-// empty string to use the default HuggingFace URL constructed from the entry's
-// repo. Progress is reported via the channel if non-nil.
-func (mm *ModelManager) Install(ctx context.Context, entry *CatalogEntry, baseURL string, progress chan<- DownloadState) error {
+// Install downloads the selected variant's files for a catalog entry and records
+// it as installed. variantID selects the hardware variant to install; an empty
+// string installs the entry's default variant, and an unknown variant id is
+// rejected before any download starts. The baseURL parameter overrides the
+// HuggingFace URL for testing; pass an empty string to use the default
+// HuggingFace URL constructed from the entry's repo. Progress is reported via the
+// channel if non-nil.
+func (mm *ModelManager) Install(ctx context.Context, entry *CatalogEntry, variantID, baseURL string, progress chan<- DownloadState) error {
+	// Reject an unknown variant selection before taking any lock or registering a
+	// download, so a bad selection cannot leave a lingering in-progress state.
+	if _, ok := variantFilesByID(entry, variantID); !ok {
+		return errors.Newf("unknown variant %q for model %s", variantID, entry.ID).
+			Component("classifier.model_manager").
+			Category(errors.CategoryValidation).
+			Context("catalog_id", entry.ID).
+			Context("variant_id", variantID).
+			Build()
+	}
+
 	// Check if already installed or already downloading.
 	mm.mu.Lock()
 	if _, ok := mm.installed[entry.ID]; ok {
@@ -878,7 +907,7 @@ func (mm *ModelManager) Install(ctx context.Context, entry *CatalogEntry, baseUR
 	}
 	mm.mu.Unlock()
 
-	if err := mm.downloadModelFiles(ctx, entry, baseURL, progress, true); err != nil {
+	if err := mm.downloadModelFiles(ctx, entry, variantID, baseURL, progress, true); err != nil {
 		// Keep failed state briefly for SSE pollers, then clean up.
 		time.AfterFunc(failedStateRetention, func() {
 			mm.removeDownloading(entry.ID)
@@ -896,7 +925,8 @@ func (mm *ModelManager) Install(ctx context.Context, entry *CatalogEntry, baseUR
 func (mm *ModelManager) Reinstall(ctx context.Context, entry *CatalogEntry, baseURL string, progress chan<- DownloadState) error {
 	// Check that the model IS installed (opposite of Install's guard).
 	mm.mu.Lock()
-	if _, ok := mm.installed[entry.ID]; !ok {
+	im, ok := mm.installed[entry.ID]
+	if !ok {
 		mm.mu.Unlock()
 		return errors.Newf("model %s is not installed", entry.ID).
 			Component("classifier.model_manager").
@@ -910,6 +940,21 @@ func (mm *ModelManager) Reinstall(ctx context.Context, entry *CatalogEntry, base
 			Component("classifier.model_manager").
 			Category(errors.CategoryValidation).
 			Context("catalog_id", entry.ID).
+			Build()
+	}
+
+	// Reinstall repairs the INSTALLED variant, so resolve and validate it BEFORE
+	// unloading the model. A stale variant id (e.g. the variant was dropped from
+	// the catalog) then fails cleanly here rather than after the unload, which
+	// would strand the running model unloaded until a restart.
+	reinstallVariantID := im.VariantID
+	if _, resolvable := variantFilesByID(entry, reinstallVariantID); !resolvable {
+		mm.mu.Unlock()
+		return errors.Newf("cannot reinstall %s: installed variant %q is no longer in the catalog", entry.ID, reinstallVariantID).
+			Component("classifier.model_manager").
+			Category(errors.CategoryValidation).
+			Context("catalog_id", entry.ID).
+			Context("variant_id", reinstallVariantID).
 			Build()
 	}
 
@@ -949,7 +994,7 @@ func (mm *ModelManager) Reinstall(ctx context.Context, entry *CatalogEntry, base
 		mm.notifyTopologyChanged()
 	}
 
-	if err := mm.downloadModelFiles(ctx, entry, baseURL, progress, false); err != nil {
+	if err := mm.downloadModelFiles(ctx, entry, reinstallVariantID, baseURL, progress, false); err != nil {
 		// Keep failed state briefly for SSE pollers, then clean up.
 		time.AfterFunc(failedStateRetention, func() {
 			mm.removeDownloading(entry.ID)
@@ -961,15 +1006,33 @@ func (mm *ModelManager) Reinstall(ctx context.Context, entry *CatalogEntry, base
 }
 
 // downloadModelFiles handles the actual file download, validation, recording,
-// config application, and hot-load for a catalog entry. The caller must have
-// already registered the entry in mm.downloading before calling this method.
+// config application, and hot-load for a catalog entry. variantID selects which
+// variant's files to download (empty = the entry's default variant); an unknown
+// variant is a backstop failure, since callers validate it first. The caller must
+// have already registered the entry in mm.downloading before calling this method.
 // On failure, downloadModelFiles calls markFailed but the caller is responsible
 // for scheduling cleanup of the download state (e.g., via time.AfterFunc).
 // When cleanupOnFailure is true (Install), newly downloaded files are removed
 // on failure. When false (Reinstall), repaired files are kept so partial
 // progress is not lost.
-func (mm *ModelManager) downloadModelFiles(ctx context.Context, entry *CatalogEntry, baseURL string, progress chan<- DownloadState, cleanupOnFailure bool) error {
+func (mm *ModelManager) downloadModelFiles(ctx context.Context, entry *CatalogEntry, variantID, baseURL string, progress chan<- DownloadState, cleanupOnFailure bool) error {
 	log := GetLogger()
+
+	// Resolve the files for the requested variant (empty selection = default).
+	// An unknown variant should already have been rejected by the caller; treat
+	// it as a failure here too, as a backstop, rather than silently installing the
+	// default variant's files.
+	files, okVariant := variantFilesByID(entry, variantID)
+	if !okVariant {
+		err := errors.Newf("unknown variant %q for model %s", variantID, entry.ID).
+			Component("classifier.model_manager").
+			Category(errors.CategoryValidation).
+			Context("catalog_id", entry.ID).
+			Context("variant_id", variantID).
+			Build()
+		mm.markFailed(entry.ID, err, progress)
+		return err
+	}
 
 	// Create model subdirectory only if the entry has non-shared files.
 	// Shared-only entries (e.g. geomodels) store all files in models/shared/.
@@ -1010,7 +1073,7 @@ func (mm *ModelManager) downloadModelFiles(ctx context.Context, entry *CatalogEn
 	needsRedownload := make(map[string]bool)
 	var totalAllBytes int64
 	filesToDownload := 0
-	for _, f := range entry.Files {
+	for _, f := range files {
 		destPath := fileDestPath(f)
 		if _, err := os.Stat(destPath); err != nil {
 			totalAllBytes += f.SizeBytes
@@ -1045,7 +1108,7 @@ func (mm *ModelManager) downloadModelFiles(ctx context.Context, entry *CatalogEn
 	var modelPath, labelsPath string
 	var completedBytes int64
 	fileIndex := 0
-	for _, f := range entry.Files {
+	for _, f := range files {
 		destPath := fileDestPath(f)
 
 		// Skip download if file already exists and passes SHA256 validation.
@@ -1113,23 +1176,23 @@ func (mm *ModelManager) downloadModelFiles(ctx context.Context, entry *CatalogEn
 	}
 
 	// For shared-only entries (e.g. geomodels), derive paths from shared files.
-	modelPath, labelsPath = resolveSharedPaths(entry, modelPath, labelsPath, fileDestPath)
+	modelPath, labelsPath = resolveSharedPaths(files, modelPath, labelsPath, fileDestPath)
 
-	// The install path downloads the resolved default variant's files, so record
-	// that variant's id (empty for a flat entry). This keeps the install record in
-	// sync with what ScanInstalled later derives from disk. When variant selection
-	// lands (the primary-variant selector), this must record the SELECTED variant's
-	// id, not the default.
-	variantID := ""
-	if v := defaultVariant(entry); v != nil {
-		variantID = v.ID
+	// Record the installed variant: the selected one, or the default variant when
+	// the caller did not specify a selection (empty = default). This keeps the
+	// install record in sync with what ScanInstalled later derives from disk.
+	recordedVariant := variantID
+	if recordedVariant == "" {
+		if v := defaultVariant(entry); v != nil {
+			recordedVariant = v.ID
+		}
 	}
 
 	// Record as installed.
 	mm.mu.Lock()
 	mm.installed[entry.ID] = InstalledModel{
 		CatalogID:   entry.ID,
-		VariantID:   variantID,
+		VariantID:   recordedVariant,
 		ModelPath:   modelPath,
 		LabelsPath:  labelsPath,
 		InstalledAt: time.Now(),
@@ -1140,7 +1203,7 @@ func (mm *ModelManager) downloadModelFiles(ctx context.Context, entry *CatalogEn
 
 	// Find embeddings path for bat models.
 	embeddingsPath := ""
-	for _, f := range entry.Files {
+	for _, f := range files {
 		if f.Role == RoleEmbeddings {
 			embeddingsPath = filepath.Join(mm.modelsDir, "shared", f.LocalName)
 			break
@@ -1184,12 +1247,14 @@ func (mm *ModelManager) hotLoadAfterInstall(log logger.Logger, entry *CatalogEnt
 }
 
 // resolveSharedPaths fills in modelPath and labelsPath for shared-only entries
-// (e.g. geomodels) that have no RoleModel or RoleLabels files.
-func resolveSharedPaths(entry *CatalogEntry, modelPath, labelsPath string, destPath func(CatalogFile) string) (resolvedModel, resolvedLabels string) {
+// (e.g. geomodels) that have no RoleModel or RoleLabels files. It takes the
+// resolved variant file list rather than the entry so no default-variant Files
+// reference leaks into the download path.
+func resolveSharedPaths(files []CatalogFile, modelPath, labelsPath string, destPath func(CatalogFile) string) (resolvedModel, resolvedLabels string) {
 	if modelPath != "" {
 		return modelPath, labelsPath
 	}
-	for _, f := range entry.Files {
+	for _, f := range files {
 		switch f.Role {
 		case RoleGeomodelModel:
 			modelPath = destPath(f)

--- a/internal/classifier/model_manager_test.go
+++ b/internal/classifier/model_manager_test.go
@@ -242,11 +242,202 @@ func TestModelManager_Install_RecordsDefaultVariantID(t *testing.T) {
 	}
 
 	mm := NewModelManager(t.TempDir(), nil, nil)
-	require.NoError(t, mm.Install(t.Context(), &entry, srv.URL, nil))
+	require.NoError(t, mm.Install(t.Context(), &entry, "", srv.URL, nil))
 
 	require.True(t, mm.IsInstalled(entry.ID))
 	got := installedByID(t, mm, entry.ID)
 	assert.Equal(t, "fp32", got.VariantID, "install must record the default variant id, matching what ScanInstalled derives")
+}
+
+func TestModelManager_UninstallNonDefaultVariant(t *testing.T) {
+	t.Parallel()
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+
+	// Synthetic non-default install: only the int8-arm variant's model file on disk.
+	modelsDir := t.TempDir()
+	modelPath := writeVariantModelFile(t, modelsDir, &entry, "int8-arm")
+
+	mm := NewModelManager(modelsDir, nil, nil)
+	mm.ScanInstalled()
+	require.True(t, mm.IsInstalled(entry.ID))
+	require.Equal(t, "int8-arm", installedByID(t, mm, entry.ID).VariantID)
+
+	require.NoError(t, mm.Uninstall(entry.ID))
+	assert.False(t, mm.IsInstalled(entry.ID))
+	_, err := os.Stat(modelPath)
+	assert.True(t, os.IsNotExist(err), "the installed non-default variant's model file must be deleted")
+}
+
+// twoVariantServerEntry builds a synthetic two-variant catalog entry (default
+// "fp32" and non-default "int8-arm" with DISTINCT model LocalNames) plus an
+// httptest server that serves each variant's files, so a test can tell which
+// variant was actually downloaded. Returns the entry, a fresh modelsDir, and the
+// server base URL.
+func twoVariantServerEntry(t *testing.T) (entry CatalogEntry, modelsDir, srvURL string) {
+	t.Helper()
+	fp32Data, int8Data, labels := []byte("fp32-model"), []byte("int8-model"), []byte("a\nb\n")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/fp32.onnx":
+			_, _ = w.Write(fp32Data)
+		case "/int8.onnx":
+			_, _ = w.Write(int8Data)
+		case "/labels.txt":
+			_, _ = w.Write(labels)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	fp32Files := []CatalogFile{
+		{RemotePath: "fp32.onnx", LocalName: "model.onnx", Role: RoleModel, SHA256: sha256Hex(fp32Data), SizeBytes: int64(len(fp32Data))},
+		{RemotePath: "labels.txt", LocalName: "labels.txt", Role: RoleLabels, SHA256: sha256Hex(labels), SizeBytes: int64(len(labels))},
+	}
+	int8Files := []CatalogFile{
+		{RemotePath: "int8.onnx", LocalName: "model_int8.onnx", Role: RoleModel, SHA256: sha256Hex(int8Data), SizeBytes: int64(len(int8Data))},
+		{RemotePath: "labels.txt", LocalName: "labels.txt", Role: RoleLabels, SHA256: sha256Hex(labels), SizeBytes: int64(len(labels))},
+	}
+	entry = CatalogEntry{
+		ID:              "test-variant-writepath",
+		Name:            "T",
+		Version:         "1.0",
+		HuggingFaceRepo: "t/r",
+		Variants: []CatalogVariant{
+			{ID: "fp32", Default: true, Files: fp32Files},
+			{ID: "int8-arm", Files: int8Files},
+		},
+		Files: fp32Files,
+	}
+	return entry, t.TempDir(), srv.URL
+}
+
+func TestModelManager_InstallSelectsNonDefaultVariant(t *testing.T) {
+	t.Parallel()
+
+	entry, modelsDir, srvURL := twoVariantServerEntry(t)
+	mm := NewModelManager(modelsDir, nil, nil)
+
+	require.NoError(t, mm.Install(t.Context(), &entry, "int8-arm", srvURL, nil))
+
+	got := installedByID(t, mm, entry.ID)
+	assert.Equal(t, "int8-arm", got.VariantID, "the selected variant id must be recorded")
+	// The selected variant's model file is on disk; the default's is not.
+	_, err := os.Stat(filepath.Join(modelsDir, entry.ID, "model_int8.onnx"))
+	require.NoError(t, err, "the selected (int8-arm) variant file must be downloaded")
+	_, err = os.Stat(filepath.Join(modelsDir, entry.ID, "model.onnx"))
+	assert.True(t, os.IsNotExist(err), "the default (fp32) variant file must NOT be downloaded")
+}
+
+func TestModelManager_InstallUnknownVariantErrors(t *testing.T) {
+	t.Parallel()
+
+	entry, modelsDir, srvURL := twoVariantServerEntry(t)
+	mm := NewModelManager(modelsDir, nil, nil)
+
+	err := mm.Install(t.Context(), &entry, "does-not-exist", srvURL, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown variant")
+	assert.False(t, mm.IsInstalled(entry.ID), "a rejected variant must not be recorded as installed")
+	assert.Nil(t, mm.GetDownloadState(entry.ID), "a rejected variant must not leave a lingering download state")
+}
+
+func TestModelManager_ReinstallRepairsInstalledVariant(t *testing.T) {
+	t.Parallel()
+
+	entry, modelsDir, srvURL := twoVariantServerEntry(t)
+	mm := NewModelManager(modelsDir, nil, nil)
+	require.NoError(t, mm.Install(t.Context(), &entry, "int8-arm", srvURL, nil))
+
+	int8Path := filepath.Join(modelsDir, entry.ID, "model_int8.onnx")
+	require.NoError(t, os.Remove(int8Path))
+
+	require.NoError(t, mm.Reinstall(t.Context(), &entry, srvURL, nil))
+
+	_, err := os.Stat(int8Path)
+	require.NoError(t, err, "reinstall must re-fetch the INSTALLED variant's file")
+	_, err = os.Stat(filepath.Join(modelsDir, entry.ID, "model.onnx"))
+	assert.True(t, os.IsNotExist(err), "reinstall must not fetch the default variant instead")
+}
+
+func TestModelManager_ReinstallStaleVariantValidatesBeforeUnload(t *testing.T) {
+	t.Parallel()
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+	require.NotEmpty(t, entry.RegistryID)
+
+	// Load the model as the primary: UnloadModel refuses the primary, so if the
+	// stale-variant check ran AFTER the unload step the error would be "model
+	// still in use". Getting the pre-unload "no longer in the catalog" error, with
+	// the model still loaded, proves the check runs BEFORE the unload, so a running
+	// model is never stranded.
+	primaryBN := &BirdNET{ModelInfo: ModelInfo{ID: entry.RegistryID}}
+	orch := &Orchestrator{
+		ModelInfo: primaryBN.ModelInfo,
+		models:    map[string]*modelEntry{entry.RegistryID: {instance: primaryBN}},
+		primary:   primaryBN,
+	}
+	mm := NewModelManager(t.TempDir(), orch, nil)
+	// Simulate an install whose variant was later dropped from the catalog.
+	mm.installed[entry.ID] = InstalledModel{CatalogID: entry.ID, VariantID: "gone"}
+
+	entryCopy := entry
+	err := mm.Reinstall(t.Context(), &entryCopy, "http://unused.invalid", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no longer in the catalog", "must fail the pre-unload variant check, not the post-unload 'model still in use' path")
+	assert.True(t, mm.IsInstalled(entry.ID), "a stale-variant reinstall must leave the install in place")
+	assert.True(t, orch.IsModelLoaded(entry.RegistryID), "the running model must remain loaded (never unloaded)")
+}
+
+func TestModelManager_UninstallStaleVariantDeletesRecordedFile(t *testing.T) {
+	t.Parallel()
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+
+	modelsDir := t.TempDir()
+	subdir := filepath.Join(modelsDir, entry.ID)
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+	// A model file whose variant id is no longer in the catalog.
+	stalePath := filepath.Join(subdir, "perch_v2_gone.onnx")
+	require.NoError(t, os.WriteFile(stalePath, []byte("data"), 0o644))
+
+	mm := NewModelManager(modelsDir, nil, nil)
+	// Simulate an install whose variant was later dropped from the catalog.
+	mm.installed[entry.ID] = InstalledModel{CatalogID: entry.ID, VariantID: "gone", ModelPath: stalePath}
+
+	require.NoError(t, mm.Uninstall(entry.ID))
+	assert.False(t, mm.IsInstalled(entry.ID))
+	_, err := os.Stat(stalePath)
+	assert.True(t, os.IsNotExist(err), "a stale variant's recorded on-disk model file must be deleted, not orphaned")
+}
+
+func TestModelManager_DownloadModelFilesRejectsUnknownVariant(t *testing.T) {
+	t.Parallel()
+
+	files := []CatalogFile{{RemotePath: "m.onnx", LocalName: "m.onnx", Role: RoleModel, SHA256: "x", SizeBytes: 1}}
+	entry := CatalogEntry{
+		ID:       "test-backstop",
+		Variants: []CatalogVariant{{ID: "fp32", Default: true, Files: files}},
+		Files:    files,
+	}
+	modelsDir := t.TempDir()
+	mm := NewModelManager(modelsDir, nil, nil)
+	// Callers register the download before calling downloadModelFiles; mimic that
+	// so the backstop's markFailed has a state to update.
+	mm.downloading[entry.ID] = &DownloadState{CatalogID: entry.ID, Status: StatusDownloading}
+
+	err := mm.downloadModelFiles(t.Context(), &entry, "bogus", "", nil, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown variant")
+
+	state := mm.GetDownloadState(entry.ID)
+	require.NotNil(t, state)
+	assert.Equal(t, StatusFailed, state.Status, "the backstop must mark the download failed")
+	_, statErr := os.Stat(filepath.Join(modelsDir, entry.ID))
+	assert.True(t, os.IsNotExist(statErr), "no subdirectory should be created for a rejected variant")
 }
 
 func TestModelManager_IsInstalled(t *testing.T) {
@@ -526,7 +717,7 @@ func TestModelManager_Install(t *testing.T) {
 	mm := NewModelManager(modelsDir, nil, nil)
 
 	progress := make(chan DownloadState, 100)
-	err := mm.Install(t.Context(), &entry, srv.URL, progress)
+	err := mm.Install(t.Context(), &entry, "", srv.URL, progress)
 	require.NoError(t, err)
 
 	// Verify installed.
@@ -570,7 +761,7 @@ func TestModelManager_Install_AlreadyInstalled(t *testing.T) {
 		Name: "Already Installed",
 	}
 
-	err := mm.Install(t.Context(), &entry, "", nil)
+	err := mm.Install(t.Context(), &entry, "", "", nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already installed")
 }
@@ -612,7 +803,7 @@ func TestModelManager_Install_SharedEmbeddings(t *testing.T) {
 	modelsDir := t.TempDir()
 	mm := NewModelManager(modelsDir, nil, nil)
 
-	err := mm.Install(t.Context(), &entry, srv.URL, nil)
+	err := mm.Install(t.Context(), &entry, "", srv.URL, nil)
 	require.NoError(t, err)
 
 	// Embeddings should be in shared/, not in the model subdirectory.
@@ -649,7 +840,7 @@ func TestModelManager_Install_ConcurrentDownloadRejected(t *testing.T) {
 		Name: "Concurrent Test",
 	}
 
-	err := mm.Install(t.Context(), &entry, "", nil)
+	err := mm.Install(t.Context(), &entry, "", "", nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already being downloaded")
 }
@@ -939,7 +1130,7 @@ func TestModelManager_Install_SharedGeomodel(t *testing.T) {
 	modelsDir := t.TempDir()
 	mm := NewModelManager(modelsDir, nil, nil)
 
-	err := mm.Install(t.Context(), &entry, srv.URL, nil)
+	err := mm.Install(t.Context(), &entry, "", srv.URL, nil)
 	require.NoError(t, err)
 
 	// Geomodel files should be in shared/, not in the model subdirectory.
@@ -999,7 +1190,7 @@ func TestModelManager_Install_GeomodelSkipsExisting(t *testing.T) {
 	}
 
 	mm := NewModelManager(modelsDir, nil, nil)
-	err := mm.Install(t.Context(), &entry, srv.URL, nil)
+	err := mm.Install(t.Context(), &entry, "", srv.URL, nil)
 	require.NoError(t, err)
 
 	// The server returns 404 for geomodel.onnx, so if Install tried to
@@ -1196,7 +1387,7 @@ func TestModelManager_Install_GeomodelConfigWiring(t *testing.T) {
 	conf.StoreSettings(settings)
 	mm := NewModelManager(modelsDir, nil, settings)
 
-	err := mm.Install(t.Context(), &entry, srv.URL, nil)
+	err := mm.Install(t.Context(), &entry, "", srv.URL, nil)
 	require.NoError(t, err)
 
 	// Verify range filter config was set.
@@ -1254,7 +1445,7 @@ func TestModelManager_Uninstall_GeomodelConfigClearing(t *testing.T) {
 	mm := NewModelManager(modelsDir, nil, settings)
 
 	// Install to set config.
-	err := mm.Install(t.Context(), &entry, srv.URL, nil)
+	err := mm.Install(t.Context(), &entry, "", srv.URL, nil)
 	require.NoError(t, err)
 
 	current := conf.GetSettings()
@@ -1423,7 +1614,7 @@ func TestModelManager_Install_RedownloadsCorruptSharedFile(t *testing.T) {
 	}
 
 	mm := NewModelManager(modelsDir, nil, nil)
-	err := mm.Install(t.Context(), &entry, srv.URL, nil)
+	err := mm.Install(t.Context(), &entry, "", srv.URL, nil)
 	require.NoError(t, err)
 
 	// Verify the corrupt file was replaced with correct content.
@@ -1479,7 +1670,7 @@ func TestModelManager_Install_GeomodelVersionWiring(t *testing.T) {
 	conf.StoreSettings(settings)
 	mm := NewModelManager(modelsDir, nil, settings)
 
-	err := mm.Install(t.Context(), &entry, srv.URL, nil)
+	err := mm.Install(t.Context(), &entry, "", srv.URL, nil)
 	require.NoError(t, err)
 
 	current := conf.GetSettings()
@@ -1698,7 +1889,7 @@ func TestModelManager_Install_UsesConfiguredEndpoint(t *testing.T) {
 
 	// baseURL is empty so the download path builds URLs from the endpoint and
 	// the repo, which is what a real install does.
-	require.NoError(t, mm.Install(t.Context(), &entry, "", nil))
+	require.NoError(t, mm.Install(t.Context(), &entry, "", "", nil))
 
 	assert.True(t, mm.IsInstalled("test-mirror-install"))
 
@@ -1749,7 +1940,7 @@ func TestModelManager_Reinstall(t *testing.T) {
 	mm := NewModelManager(modelsDir, nil, nil)
 
 	// Install first.
-	err := mm.Install(t.Context(), &entry, srv.URL, nil)
+	err := mm.Install(t.Context(), &entry, "", srv.URL, nil)
 	require.NoError(t, err)
 	require.True(t, mm.IsInstalled("test-reinstall-model"))
 
@@ -1832,7 +2023,7 @@ func TestModelManager_Reinstall_SkipsValidFiles(t *testing.T) {
 	mm := NewModelManager(modelsDir, nil, nil)
 
 	// Install first.
-	err := mm.Install(t.Context(), &entry, srv.URL, nil)
+	err := mm.Install(t.Context(), &entry, "", srv.URL, nil)
 	require.NoError(t, err)
 	require.True(t, mm.IsInstalled("test-reinstall-skip"))
 


### PR DESCRIPTION
## Summary

Makes the model manager's write path variant-aware: it can install a selected model variant, and it resolves on-disk files from the installed variant rather than the resolved-default file list, so uninstalling or reinstalling a non-default variant no longer operates on the wrong (default) filenames. This is the write-path middle slice of the model-gallery variant lifecycle, building on the scan-side foundation in #4078.

`variantFilesByID` resolves a variant's files by id (an empty selection or a flat entry yields the entry's resolved default files; an unknown id is rejected). `Install` gains a `variantId` parameter and validates it before taking any lock or registering a download; `downloadModelFiles` downloads the selected variant's files and records that variant's id. `Reinstall` reinstalls the installed variant, and validates it against the catalog **before** unloading the model, so a stale installed variant (one dropped from the catalog) fails cleanly instead of leaving the running model unloaded until a restart. `Uninstall` deletes the installed variant's model and data files, falling back to the default file list if the installed variant id is unknown. Companion files (geomodel, taxonomy, embeddings) are identical across a family's variants, so the shared-file cleanup and geomodel-config paths deliberately continue to use the entry's default file list.

This PR is behaviour-neutral for every existing install: a flat entry (BattyBirdNET, geomodels, bat models) and today's default Perch v2 (fp32) install resolve to exactly the same files as before, because an empty or default variant id resolves to the entry's default `Files`. Installing a non-default variant is not yet reachable from the API (the install handler passes an empty selection); the API `variantId` body field, the `variants[]` response, and the gallery UI selector are a later PR. Download-before-delete Replace, the orchestrator path-push (VariantID as the source of truth for runtime path resolution), disk preflight, `ScanInstalled` garbage collection of leaked variant files, and orphan recovery are deferred to the next PR in this series.

The plan was reviewed by an independent model before implementation, which caught the Reinstall validate-before-unload ordering (an offline-stranding hazard) and a `resolveSharedPaths` signature that still referenced the entry's default files; both are incorporated.

## Test Plan

- [x] `go test -race ./internal/classifier/ ./internal/api/v2/models/`
- [x] `golangci-lint run` (full project, 0 issues)
- [x] New unit tests: variant-file resolution (empty/found/unknown, and a non-empty id on a flat entry is rejected); install selects the non-default variant (downloads its file, not the default's); install of an unknown variant errors with no lingering download state; reinstall re-fetches the installed variant (not the default); reinstall of a stale variant is rejected before the model is unloaded (verified with a loaded primary, so the running model is never stranded); uninstall of a non-default variant deletes the correct file; uninstall of a stale variant deletes the recorded on-disk file rather than orphaning it; the download-path variant backstop marks the download failed; existing default/flat install, reinstall, and uninstall tests unchanged and green
