### PR TITLE
feat(models): disk-space preflight before download and reconcile installed scan

### DIFF
--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/diskmanager"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
@@ -42,6 +43,12 @@ const (
 // downloading map so SSE pollers can observe the failure before cleanup.
 const failedStateRetention = 30 * time.Second
 
+// diskSpaceMarginBytes is the free-space headroom required beyond a download's
+// total size before an install proceeds. It absorbs filesystem overhead and
+// leaves a little slack on small SD cards, which matter here: variants run from
+// 38 MB (int8-arm v2.4) to 557 MB (global v3.0 fp32) against Pi storage.
+const diskSpaceMarginBytes int64 = 64 << 20 // 64 MiB
+
 // ModelManager handles the lifecycle of downloadable models.
 type ModelManager struct {
 	modelsDir    string
@@ -51,6 +58,12 @@ type ModelManager struct {
 	settingsMu   sync.Mutex // serializes clone-mutate-publish cycles on settings
 	installed    map[string]InstalledModel
 	downloading  map[string]*DownloadState
+
+	// freeSpaceFn reports the bytes available on the filesystem holding a given
+	// path. It is a field so tests can force the insufficient-space branch of the
+	// install preflight without exhausting a real disk. NewModelManager wires it
+	// to diskmanager.GetAvailableSpace.
+	freeSpaceFn func(string) (uint64, error)
 
 	// topologyChangedCb, when set, is invoked after a successful model load or
 	// unload so observers (e.g. the metrics SSE stream) can signal that the
@@ -102,6 +115,7 @@ func NewModelManager(modelsDir string, orchestrator *Orchestrator, settings *con
 		settings:     settings,
 		installed:    make(map[string]InstalledModel),
 		downloading:  make(map[string]*DownloadState),
+		freeSpaceFn:  diskmanager.GetAvailableSpace,
 	}
 }
 
@@ -148,6 +162,11 @@ func (mm *ModelManager) ScanInstalled() {
 
 	// Phase 1: scan the filesystem under mm.mu.
 	mm.mu.Lock()
+	// Reconcile against disk: Phase 1 fully repopulates mm.installed by statting
+	// each entry's files, so clearing first drops any model whose files were
+	// removed out-of-band since the last scan. The clear and the repopulation both
+	// run under mm.mu, so a concurrent reader (RLock) never observes the empty map.
+	clear(mm.installed)
 	for i := range catalog {
 		entry := &catalog[i]
 		subdir := filepath.Join(mm.modelsDir, entry.ID)
@@ -1005,6 +1024,36 @@ func (mm *ModelManager) Reinstall(ctx context.Context, entry *CatalogEntry, base
 	return nil
 }
 
+// preflightDiskSpace reports an error when the filesystem holding the models
+// directory cannot fit totalDownloadBytes plus a safety margin, so a large
+// download fails fast instead of part-way through. It is a no-op when there is
+// nothing to download. A free-space probe error fails open (returns nil): an
+// inability to measure free space must not block an otherwise-valid install.
+func (mm *ModelManager) preflightDiskSpace(entry *CatalogEntry, filesToDownload int, totalDownloadBytes int64) error {
+	if filesToDownload == 0 || mm.freeSpaceFn == nil {
+		return nil
+	}
+	free, err := mm.freeSpaceFn(mm.modelsDir)
+	if err != nil {
+		GetLogger().Debug("Free-space check failed; proceeding with install",
+			logger.String("catalog_id", entry.ID),
+			logger.Error(err))
+		return nil
+	}
+	needed := totalDownloadBytes + diskSpaceMarginBytes
+	if free >= uint64(needed) {
+		return nil
+	}
+	return errors.Newf("insufficient disk space to install %s: need %d bytes (incl. %d margin), have %d",
+		entry.ID, needed, diskSpaceMarginBytes, free).
+		Component("classifier.model_manager").
+		Category(errors.CategoryDiskUsage).
+		Context("catalog_id", entry.ID).
+		Context("needed_bytes", needed).
+		Context("free_bytes", free).
+		Build()
+}
+
 // downloadModelFiles handles the actual file download, validation, recording,
 // config application, and hot-load for a catalog entry. variantID selects which
 // variant's files to download (empty = the entry's default variant); an unknown
@@ -1086,6 +1135,15 @@ func (mm *ModelManager) downloadModelFiles(ctx context.Context, entry *CatalogEn
 			totalAllBytes += f.SizeBytes
 			filesToDownload++
 		}
+	}
+
+	// Disk-space preflight: fail fast if the filesystem cannot hold the files we
+	// are about to download (variants run up to 557 MB), rather than filling it
+	// part-way through and leaving partial files behind. Nothing has been written
+	// yet, so no cleanup is needed on the reject path.
+	if err := mm.preflightDiskSpace(entry, filesToDownload, totalAllBytes); err != nil {
+		mm.markFailed(entry.ID, err, progress)
+		return err
 	}
 
 	// Resolve the HuggingFace host once per install so every file in the same

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -1027,10 +1027,15 @@ func (mm *ModelManager) Reinstall(ctx context.Context, entry *CatalogEntry, base
 // preflightDiskSpace reports an error when the filesystem holding the models
 // directory cannot fit totalDownloadBytes plus a safety margin, so a large
 // download fails fast instead of part-way through. It is a no-op when there is
-// nothing to download. A free-space probe error fails open (returns nil): an
-// inability to measure free space must not block an otherwise-valid install.
+// nothing to download or the total is not positive (a catalog that does not
+// declare usable size_bytes, so there is nothing to check). A free-space probe
+// error fails open (returns nil): an inability to measure free space must not
+// block an otherwise-valid install.
 func (mm *ModelManager) preflightDiskSpace(entry *CatalogEntry, filesToDownload int, totalDownloadBytes int64) error {
-	if filesToDownload == 0 || mm.freeSpaceFn == nil {
+	// A non-positive total means the sizes are unknown (or a hand-edited catalog
+	// carries a bad value); skip rather than cast a negative total to a huge
+	// uint64 below and reject spuriously.
+	if filesToDownload == 0 || totalDownloadBytes <= 0 || mm.freeSpaceFn == nil {
 		return nil
 	}
 	free, err := mm.freeSpaceFn(mm.modelsDir)
@@ -1139,8 +1144,9 @@ func (mm *ModelManager) downloadModelFiles(ctx context.Context, entry *CatalogEn
 
 	// Disk-space preflight: fail fast if the filesystem cannot hold the files we
 	// are about to download (variants run up to 557 MB), rather than filling it
-	// part-way through and leaving partial files behind. Nothing has been written
-	// yet, so no cleanup is needed on the reject path.
+	// part-way through and leaving partial files behind. No model files have been
+	// downloaded yet (the subdirectory may already exist), so no cleanup is needed
+	// on the reject path.
 	if err := mm.preflightDiskSpace(entry, filesToDownload, totalAllBytes); err != nil {
 		mm.markFailed(entry.ID, err, progress)
 		return err

--- a/internal/classifier/model_manager_test.go
+++ b/internal/classifier/model_manager_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/conf/conftest"
+	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
 // Test URL paths used in httptest handlers.
@@ -199,6 +200,155 @@ func TestModelManager_ScanInstalled_VariantEntryNoFileNotInstalled(t *testing.T)
 	mm.ScanInstalled()
 
 	assert.False(t, mm.IsInstalled(entry.ID), "a variant entry with no model file on disk must not be installed")
+}
+
+// flatServerEntry builds a synthetic flat (single-variant) catalog entry plus an
+// httptest server that serves its model and labels files, for exercising the
+// install download path. Returns the entry, a fresh modelsDir, and the server
+// base URL. Both files carry real SHA-256 checksums so the download path's
+// verification succeeds.
+func flatServerEntry(t *testing.T) (entry CatalogEntry, modelsDir, srvURL string) {
+	t.Helper()
+	modelContent := []byte("fake-onnx-model-binary-data")
+	labelsContent := []byte("species_a\nspecies_b\n")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case testPathModelsONNX:
+			_, _ = w.Write(modelContent)
+		case testPathModelsLabels:
+			_, _ = w.Write(labelsContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	files := []CatalogFile{
+		{RemotePath: "models/test.onnx", LocalName: "test.onnx", Role: RoleModel, SHA256: sha256Hex(modelContent), SizeBytes: int64(len(modelContent))},
+		{RemotePath: "models/labels.txt", LocalName: "labels.txt", Role: RoleLabels, SHA256: sha256Hex(labelsContent), SizeBytes: int64(len(labelsContent))},
+	}
+	entry = CatalogEntry{
+		ID:              "test-preflight",
+		Name:            "Test Preflight Model",
+		Version:         "1.0",
+		HuggingFaceRepo: "test/repo",
+		Files:           files,
+	}
+	return entry, t.TempDir(), srv.URL
+}
+
+func TestModelManager_Install_RejectsInsufficientDiskSpace(t *testing.T) {
+	t.Parallel()
+
+	entry, modelsDir, srvURL := flatServerEntry(t)
+	mm := NewModelManager(modelsDir, nil, nil)
+	// Report far less free space than the download needs, so the preflight rejects.
+	mm.freeSpaceFn = func(string) (uint64, error) { return 1024, nil }
+
+	err := mm.Install(t.Context(), &entry, "", srvURL, nil)
+	require.Error(t, err, "install must be rejected when free space is below the download total")
+	assert.Contains(t, err.Error(), "disk space", "the error should name the disk-space shortfall")
+	assert.False(t, mm.IsInstalled(entry.ID), "a preflight-rejected install must not be recorded")
+	_, statErr := os.Stat(filepath.Join(modelsDir, entry.ID, "test.onnx"))
+	assert.True(t, os.IsNotExist(statErr), "no model file should be written when the preflight rejects the install")
+
+	// The rejection is surfaced through the retained download state, which is what
+	// SSE pollers read, so the user learns why the install stopped.
+	st := mm.GetDownloadState(entry.ID)
+	require.NotNil(t, st, "a rejected install must leave a retained failed download state for SSE pollers")
+	assert.Equal(t, StatusFailed, st.Status, "the retained state must be marked failed")
+	assert.Contains(t, st.Error, "disk space", "the retained failure must carry the disk-space reason")
+}
+
+func TestModelManager_Install_DiskSpaceBoundary(t *testing.T) {
+	t.Parallel()
+
+	// The preflight proceeds when free space is exactly the required amount and
+	// rejects one byte short, pinning the `>=` comparison against an off-by-one or
+	// inverted-operator regression.
+	tests := []struct {
+		name      string
+		freeDelta int64 // free space relative to the required amount
+		wantErr   bool
+	}{
+		{name: "exactly enough", freeDelta: 0, wantErr: false},
+		{name: "one byte short", freeDelta: -1, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			entry, modelsDir, srvURL := flatServerEntry(t)
+			var total int64
+			for _, f := range entry.Files {
+				total += f.SizeBytes
+			}
+			free := uint64(total + diskSpaceMarginBytes + tc.freeDelta)
+			mm := NewModelManager(modelsDir, nil, nil)
+			mm.freeSpaceFn = func(string) (uint64, error) { return free, nil }
+
+			err := mm.Install(t.Context(), &entry, "", srvURL, nil)
+			if tc.wantErr {
+				require.Error(t, err, "one byte below the requirement must be rejected")
+				assert.False(t, mm.IsInstalled(entry.ID))
+			} else {
+				require.NoError(t, err, "exactly the required free space must be accepted")
+				assert.True(t, mm.IsInstalled(entry.ID))
+			}
+		})
+	}
+}
+
+func TestModelManager_Install_SucceedsWithAmpleDiskSpace(t *testing.T) {
+	t.Parallel()
+
+	entry, modelsDir, srvURL := flatServerEntry(t)
+	mm := NewModelManager(modelsDir, nil, nil)
+	// Ample free space: the preflight must not block a valid install.
+	mm.freeSpaceFn = func(string) (uint64, error) { return 1 << 40, nil } // 1 TiB
+
+	require.NoError(t, mm.Install(t.Context(), &entry, "", srvURL, nil))
+	assert.True(t, mm.IsInstalled(entry.ID), "install should succeed when free space exceeds the download total")
+}
+
+func TestModelManager_Install_ProceedsWhenDiskCheckErrors(t *testing.T) {
+	t.Parallel()
+
+	entry, modelsDir, srvURL := flatServerEntry(t)
+	mm := NewModelManager(modelsDir, nil, nil)
+	// A failing free-space probe must fail open: the install proceeds rather than
+	// being blocked by an inability to measure free space.
+	mm.freeSpaceFn = func(string) (uint64, error) {
+		return 0, errors.Newf("simulated statfs failure").Build()
+	}
+
+	require.NoError(t, mm.Install(t.Context(), &entry, "", srvURL, nil))
+	assert.True(t, mm.IsInstalled(entry.ID), "a free-space probe error must not block the install (fail open)")
+}
+
+func TestModelManager_ScanInstalled_PrunesRemovedModel(t *testing.T) {
+	t.Parallel()
+
+	entry, ok := GetCatalogEntry("battybirdnet-eu")
+	require.True(t, ok, "expected battybirdnet-eu catalog entry to exist")
+	modelFileName := modelRoleLocalName(t, entry.Files)
+
+	modelsDir := t.TempDir()
+	subdir := filepath.Join(modelsDir, entry.ID)
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+	modelPath := filepath.Join(subdir, modelFileName)
+	require.NoError(t, os.WriteFile(modelPath, []byte("fake-onnx-data"), 0o644))
+
+	mm := NewModelManager(modelsDir, nil, nil)
+	mm.ScanInstalled()
+	require.True(t, mm.IsInstalled(entry.ID), "the model should be detected while its file is on disk")
+
+	// Remove the model out-of-band, then rescan: the stale entry must be pruned.
+	require.NoError(t, os.RemoveAll(subdir))
+	mm.ScanInstalled()
+
+	assert.False(t, mm.IsInstalled(entry.ID), "a model whose files were removed out-of-band must be pruned on rescan")
+	for _, im := range mm.ListInstalled() {
+		assert.NotEqual(t, entry.ID, im.CatalogID, "the pruned model must not remain in the installed list")
+	}
 }
 
 func TestModelManager_Install_RecordsDefaultVariantID(t *testing.T) {

--- a/internal/classifier/model_manager_test.go
+++ b/internal/classifier/model_manager_test.go
@@ -259,6 +259,23 @@ func TestModelManager_Install_RejectsInsufficientDiskSpace(t *testing.T) {
 	assert.Contains(t, st.Error, "disk space", "the retained failure must carry the disk-space reason")
 }
 
+func TestModelManager_Install_SkipsPreflightWhenSizeUnknown(t *testing.T) {
+	t.Parallel()
+
+	entry, modelsDir, srvURL := flatServerEntry(t)
+	// A catalog that does not declare sizes (size_bytes == 0) gives the preflight
+	// nothing to check, so it must fail open and let the install proceed rather
+	// than reject on the bare margin. (Files still download and verify by SHA.)
+	for i := range entry.Files {
+		entry.Files[i].SizeBytes = 0
+	}
+	mm := NewModelManager(modelsDir, nil, nil)
+	mm.freeSpaceFn = func(string) (uint64, error) { return 1, nil } // effectively no free space
+
+	require.NoError(t, mm.Install(t.Context(), &entry, "", srvURL, nil))
+	assert.True(t, mm.IsInstalled(entry.ID), "an unknown-size install must not be blocked by the preflight")
+}
+
 func TestModelManager_Install_DiskSpaceBoundary(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Two robustness improvements to the model gallery install/scan path.

## Disk-space preflight

Before downloading a model's files, `downloadModelFiles` now checks that the filesystem holding the models directory can hold the pending download plus a 64 MiB margin, and fails fast otherwise. Model variants run from about 38 MB to 557 MB, so on a small SD card a too-small disk previously filled part-way through a large download and left partial files behind. The free-space probe is injected (`freeSpaceFn`, defaulting to `diskmanager.GetAvailableSpace`) and fails open: if free space cannot be measured, the install proceeds rather than being blocked. It runs for both Install and Reinstall, and a Reinstall that has nothing to re-download skips it.

## Reconcile ScanInstalled against disk

The scan now clears the installed map before repopulating it from disk, so a model whose files were removed out-of-band is pruned instead of lingering as installed. The clear and the repopulation both run under the manager lock, so no reader ever observes a transient empty map. `ScanInstalled` is startup-only today, so this is behavior-neutral in production and corrects any future re-scan.

## Behavior change (release note)

A model install now requires 64 MiB free beyond the download size and is rejected below that. This is a safety margin: leaving less than that free on a Pi tends to break database, log, and HLS writes shortly afterward anyway. The check fails open on a probe error, so it never blocks an install it cannot measure.

## Tests

`go test -race` covers preflight rejection, ample space, fail-open on a probe error, the `free == needed` boundary (which pins the comparison against an off-by-one or inverted-operator regression), and out-of-band removal pruning.

## Scope

This is the self-contained, immediately-useful part of the remaining variant-lifecycle work. Variant-switch robustness (download-before-delete replace, path resolution for a non-default installed variant, leaked-file GC) is deferred to land alongside the gallery variant selector, since no non-default variant is reachable from the API today.