### PR TITLE
fix(api): require authentication for detection media endpoints in Private Mode

### DIFF
--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -175,6 +175,9 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 | GET    | `/media/species-image/info`          | `GetSpeciesImageInfo`    | ❌   | Get species image attribution      |
 | GET    | `/media/image/:scientific_name`      | `ServeSpeciesImageProxy` | ❌   | Serve cached bird image (proxy)    |
 | GET    | `/media/bird-image/:scientific_name` | `ServeSpeciesImageProxy` | ❌   | Alias for image proxy endpoint     |
+| GET    | `/audio/:id`                         | `ServeAudioByID`         | ❌   | Serve detection audio clip by ID   |
+| GET    | `/spectrogram/:id`                   | `ServeSpectrogramByID`   | ❌   | Serve detection spectrogram by ID  |
+| POST   | `/spectrogram/:id/generate`          | `GenerateSpectrogramByID` | ❌   | Trigger spectrogram generation     |
 | GET    | `/spectrogram/:id/status`            | `GetSpectrogramStatus`   | ❌   | Get spectrogram generation status  |
 | POST   | `/audio/:id/clip`                    | `ExtractAudioClipByID`   | ✅   | Extract audio clip from time range |
 
@@ -632,7 +635,7 @@ Requires enhanced (v2) database. Returns 409 Conflict if not available.
 - ✅ = Authentication required
 - ✅ publicLiveAudio = Authentication required unless `PublicAccess.LiveAudio` is enabled (dynamic per-request check)
 - 🔑 token = Token-based access - the crypto-random `stream_token` returned by `/start` acts as the credential
-- ❌ = No authentication required
+- ❌ = No authentication required in normal mode. When `Security.PrivateMode` is enabled these routes still require authentication: the whole API is gated by `PrivateModeAuth`, except the bootstrap/auth/live-audio entries in `isPrivateModeExempt`.
 - ⚡ = Rate limited
 - 🔒 = Admin only (subset of authenticated)
 

--- a/internal/api/v2/media/media.go
+++ b/internal/api/v2/media/media.go
@@ -324,10 +324,19 @@ func (c *Handler) RegisterRoutes(g *echo.Group) {
 
 	// ID-based routes using SFS. Registered on c.Echo (not the group); the
 	// GET /api/v2/audio/:id route is greedy and catches all /api/v2/audio/* paths.
-	c.Echo.GET("/api/v2/audio/:id", c.ServeAudioByID)
-	c.Echo.GET("/api/v2/spectrogram/:id", c.ServeSpectrogramByID)
-	c.Echo.GET("/api/v2/spectrogram/:id/status", c.GetSpectrogramStatus)
-	c.Echo.POST("/api/v2/spectrogram/:id/generate", c.GenerateSpectrogramByID)
+	//
+	// PrivateModeAuth is attached per-route here because these routes live on
+	// c.Echo, not the v2 group, so they do NOT inherit the group-level
+	// c.Group.Use(c.PrivateModeAuth) gate (Echo group middleware wraps only routes
+	// registered through that group). Without it, stored detection audio and
+	// spectrograms are reachable unauthenticated even when Private Mode is enabled
+	// (GHSA-c7jx-552f-94hh). PrivateModeAuth, not AuthMiddleware, is used so these
+	// read routes stay publicly reachable when Private Mode is off, matching the
+	// grouped /media/* aliases that serve the same media through the group.
+	c.Echo.GET("/api/v2/audio/:id", c.ServeAudioByID, c.PrivateModeAuth)
+	c.Echo.GET("/api/v2/spectrogram/:id", c.ServeSpectrogramByID, c.PrivateModeAuth)
+	c.Echo.GET("/api/v2/spectrogram/:id/status", c.GetSpectrogramStatus, c.PrivateModeAuth)
+	c.Echo.POST("/api/v2/spectrogram/:id/generate", c.GenerateSpectrogramByID, c.PrivateModeAuth)
 
 	// Clip extraction (requires authentication)
 	c.Echo.POST("/api/v2/audio/:id/clip", c.ExtractAudioClipByID, c.AuthMiddleware)
@@ -342,6 +351,31 @@ func (c *Handler) RegisterRoutes(g *echo.Group) {
 	g.GET("/media/audio", c.ServeAudioByQueryID)
 
 	c.LogInfoIfEnabled("Media routes initialized successfully")
+}
+
+// mediaCacheVisibility returns the Cache-Control visibility token for a served
+// media response: "private" when Private Mode is enabled, otherwise "public".
+// In Private Mode the media is access-controlled, so "private" keeps shared or
+// proxy caches from retaining it and re-serving it to unauthenticated clients
+// (GHSA-c7jx-552f-94hh). Read per request via CurrentSettings() so a hot-reload
+// toggle of Private Mode takes effect without a restart.
+func (c *Handler) mediaCacheVisibility() string {
+	if c.CurrentSettings().Security.PrivateMode {
+		return "private"
+	}
+	return "public"
+}
+
+// setPrivateAudioCacheControl marks an audio response private when Private Mode
+// is enabled so shared/proxy caches never retain access-controlled detection
+// audio, which can contain sensitive ambient speech (GHSA-c7jx-552f-94hh).
+// Audio responses carry no Cache-Control otherwise, so this is a no-op in public
+// mode and preserves the prior behavior; "private" (not "no-store") still lets
+// the requesting browser cache the clip, so playback and seeking are unaffected.
+func (c *Handler) setPrivateAudioCacheControl(ctx echo.Context) {
+	if c.CurrentSettings().Security.PrivateMode {
+		ctx.Response().Header().Set("Cache-Control", "private")
+	}
 }
 
 // translateSecureFSError handles SecureFS errors consistently across handler methods.
@@ -805,6 +839,9 @@ func (c *Handler) ServeAudioClip(ctx echo.Context) error {
 
 	setAudioContentDisposition(ctx, filepath.Base(normalizedFilename))
 
+	// In Private Mode, keep shared/proxy caches from retaining this clip.
+	c.setPrivateAudioCacheControl(ctx)
+
 	// Serve the file using SecureFS. It handles path validation and serves the file.
 	// ServeRelativeFile is expected to return appropriate echo.HTTPErrors (400, 404, 500).
 	err = c.SFS.ServeRelativeFile(ctx, normalizedFilename)
@@ -904,6 +941,9 @@ func (c *Handler) ServeAudioByID(ctx echo.Context) error {
 
 	// Ensure Accept-Ranges header is set for iOS Safari.
 	ctx.Response().Header().Set(headerAcceptRanges, acceptRangesBytes)
+
+	// In Private Mode, keep shared/proxy caches from retaining this clip.
+	c.setPrivateAudioCacheControl(ctx)
 
 	// Serve the file using SecureFS.
 	err = c.SFS.ServeRelativeFile(ctx, normalizedClipPath)
@@ -1552,7 +1592,7 @@ func (c *Handler) handleUserRequestedMode(ctx echo.Context, noteID, clipPath str
 				logger.String("path", ctx.Request().URL.Path),
 				logger.String("ip", ctx.RealIP()))
 
-			ctx.Response().Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d, immutable", SpectrogramCacheSeconds))
+			ctx.Response().Header().Set("Cache-Control", fmt.Sprintf("%s, max-age=%d, immutable", c.mediaCacheVisibility(), SpectrogramCacheSeconds))
 			err = c.SFS.ServeRelativeFile(ctx, relSpectrogramPath)
 			if err != nil {
 				if !ctx.Response().Committed {
@@ -1658,7 +1698,7 @@ func (c *Handler) handleAutoPreRenderMode(ctx echo.Context, noteID, clipPath str
 	// Set cache headers before serving - spectrograms are deterministic (same clip + params = same image)
 	// and never change once generated. This allows browsers to serve from disk cache on reload,
 	// avoiding HTTP/1.1 connection exhaustion when loading many detection cards simultaneously.
-	ctx.Response().Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d, immutable", SpectrogramCacheSeconds))
+	ctx.Response().Header().Set("Cache-Control", fmt.Sprintf("%s, max-age=%d, immutable", c.mediaCacheVisibility(), SpectrogramCacheSeconds))
 
 	// Serve the generated spectrogram using SecureFS
 	serveStart := time.Now()
@@ -1848,7 +1888,7 @@ func (c *Handler) ServeSpectrogram(ctx echo.Context) error {
 	}
 
 	// Serve the generated spectrogram using SecureFS with cache headers
-	ctx.Response().Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d, immutable", SpectrogramCacheSeconds))
+	ctx.Response().Header().Set("Cache-Control", fmt.Sprintf("%s, max-age=%d, immutable", c.mediaCacheVisibility(), SpectrogramCacheSeconds))
 	err = c.SFS.ServeRelativeFile(ctx, spectrogramPath)
 	if err != nil {
 		if !ctx.Response().Committed {
@@ -3627,6 +3667,11 @@ func (c *Handler) serveImageFile(ctx echo.Context, filePath, contentType string)
 	if contentType != "" {
 		ctx.Response().Header().Set("Content-Type", contentType)
 	}
+	// Species images are public bird reference photos keyed by scientific name
+	// (identical for every user), not access-controlled detection media, so they
+	// stay publicly cacheable even in Private Mode. Unlike the spectrogram/audio
+	// serves they are intentionally NOT routed through mediaCacheVisibility()
+	// (GHSA-c7jx-552f-94hh); this "public" is deliberate, not a missed site.
 	ctx.Response().Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", ImageCacheSeconds))
 
 	// ETag based on modification time and size

--- a/internal/api/v2/media/media_cache_control_test.go
+++ b/internal/api/v2/media/media_cache_control_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
 )
 
 // newCacheControlTestHandler builds a media Handler whose settings snapshot has
@@ -140,6 +141,101 @@ func TestServeAudioClipCacheControlPrivateInPrivateMode(t *testing.T) {
 
 			assert.Equal(t, tc.wantCacheControl, rec.Header().Get("Cache-Control"),
 				"audio Cache-Control mismatch in %s", tc.name)
+		})
+	}
+}
+
+// TestServeAudioByIDCacheControlHonorsPrivateMode drives the ID-based audio route
+// ServeAudioByID, one of the endpoints named in GHSA-c7jx-552f-94hh, and asserts
+// the Private Mode Cache-Control is wired into its response too, not only the
+// filename-based ServeAudioClip sibling. Both call the same
+// setPrivateAudioCacheControl helper but at different sites, so a regression that
+// drops the call from the ID route alone would slip past the ServeAudioClip test.
+func TestServeAudioByIDCacheControlHonorsPrivateMode(t *testing.T) {
+	testCases := []struct {
+		name             string
+		privateMode      bool
+		wantCacheControl string // exact expected header ("" means header absent)
+	}{
+		{"public mode sets no cache-control", false, ""},
+		{"private mode marks response private", true, "private"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, e, root := newCacheControlTestHandler(t, tc.privateMode)
+
+			const noteID = "42"
+			clipFilename := "clip_by_id.wav"
+			require.NoError(t, createTestAudioFile(t, filepath.Join(root, clipFilename)))
+
+			mockDS := mocks.NewMockInterface(t)
+			mockDS.EXPECT().GetNoteClipPath(noteID).Return(clipFilename, nil)
+			h.DS = mockDS
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v2/audio/"+noteID, http.NoBody)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetParamNames("id")
+			c.SetParamValues(noteID)
+
+			require.NoError(t, h.ServeAudioByID(c))
+			require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+			assert.Equal(t, tc.wantCacheControl, rec.Header().Get("Cache-Control"),
+				"audio-by-ID Cache-Control mismatch in %s", tc.name)
+		})
+	}
+}
+
+// TestServeSpectrogramByIDCacheControlHonorsPrivateMode drives the ID-based
+// spectrogram route ServeSpectrogramByID, the other advisory endpoint, with an
+// already-generated spectrogram so the serve path runs without external tools,
+// and asserts the Private Mode visibility token reaches the response. This guards
+// the ID-based serve sites that share mediaCacheVisibility() with the
+// filename-based ServeSpectrogram covered above.
+func TestServeSpectrogramByIDCacheControlHonorsPrivateMode(t *testing.T) {
+	testCases := []struct {
+		name           string
+		privateMode    bool
+		wantVisibility string
+	}{
+		{"public mode serves public cache", false, "public"},
+		{"private mode serves private cache", true, "private"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, e, root := newCacheControlTestHandler(t, tc.privateMode)
+
+			const noteID = "42"
+			audioBase := "clip_by_id"
+			require.NoError(t, createTestAudioFile(t, filepath.Join(root, audioBase+".wav")))
+			// Default raw=true with size=lg (1026px). Provide both raw and legend
+			// variants so the serve path finds the fixture regardless of raw parsing.
+			require.NoError(t, os.WriteFile(filepath.Join(root, audioBase+"_1026px.png"),
+				[]byte("id spectrogram"), 0o600))
+			require.NoError(t, os.WriteFile(filepath.Join(root, audioBase+"_1026px-legend.png"),
+				[]byte("id legend spectrogram"), 0o600))
+
+			mockDS := mocks.NewMockInterface(t)
+			mockDS.EXPECT().GetNoteClipPath(noteID).Return(audioBase+".wav", nil)
+			mockDS.EXPECT().GetNoteModelType(noteID).Return("bird", nil).Maybe()
+			h.DS = mockDS
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v2/spectrogram/"+noteID+"?size=lg", http.NoBody)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetParamNames("id")
+			c.SetParamValues(noteID)
+
+			require.NoError(t, h.ServeSpectrogramByID(c))
+			require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+			cacheControl := rec.Header().Get("Cache-Control")
+			assert.Truef(t, strings.HasPrefix(cacheControl, tc.wantVisibility+", "),
+				"spectrogram-by-ID Cache-Control must start with %q visibility in %s, got %q",
+				tc.wantVisibility, tc.name, cacheControl)
 		})
 	}
 }

--- a/internal/api/v2/media/media_cache_control_test.go
+++ b/internal/api/v2/media/media_cache_control_test.go
@@ -1,0 +1,145 @@
+// media_cache_control_test.go: coverage for the Private Mode media cache policy
+// introduced for GHSA-c7jx-552f-94hh.
+//
+// When Private Mode is enabled the stored detection media served by this domain
+// is access-controlled, so responses must be marked "private" to keep shared or
+// proxy caches from retaining a spectrogram/audio clip and re-serving it to an
+// unauthenticated client. When Private Mode is off the media is public, so the
+// long-lived "public ... immutable" caching that mitigates connection exhaustion
+// on detection-heavy pages is preserved.
+
+package media
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// newCacheControlTestHandler builds a media Handler whose settings snapshot has
+// Security.PrivateMode set to privateMode, and returns the handler, its echo
+// instance, and the SecureFS root directory tests write fixtures into. Mirrors
+// setupMediaTestEnvironment but toggles Private Mode (the setting that drives the
+// Cache-Control policy). Not parallel-safe: NewCore publishes to the process-global
+// settings snapshot that mediaCacheVisibility() reads.
+func newCacheControlTestHandler(t *testing.T, privateMode bool) (*Handler, *echo.Echo, string) {
+	t.Helper()
+	e := echo.New()
+	core := apitest.NewCore(t, apitest.WithEcho(e), apitest.WithSettingsFunc(func(s *conf.Settings) {
+		s.Security.PrivateMode = privateMode
+	}))
+	h := New(core)
+	return h, e, core.SFS.BaseDir()
+}
+
+// TestMediaCacheVisibility pins both branches of the per-request cache-visibility
+// decision that the spectrogram serve paths use to build their Cache-Control
+// header. The value is read via CurrentSettings() so a hot-reload toggle takes
+// effect without a restart; each subtest publishes its own settings snapshot.
+func TestMediaCacheVisibility(t *testing.T) {
+	t.Run("public when Private Mode is off", func(t *testing.T) {
+		h := New(apitest.NewCore(t))
+		assert.Equal(t, "public", h.mediaCacheVisibility(),
+			"media must be publicly cacheable when Private Mode is disabled")
+	})
+
+	t.Run("private when Private Mode is on", func(t *testing.T) {
+		h := New(apitest.NewCore(t, apitest.WithSettingsFunc(func(s *conf.Settings) {
+			s.Security.PrivateMode = true
+		})))
+		assert.Equal(t, "private", h.mediaCacheVisibility(),
+			"media must be marked private so shared caches do not retain it when Private Mode is enabled")
+	})
+}
+
+// TestServeSpectrogramCacheControlHonorsPrivateMode drives the real spectrogram
+// serve path (ServeSpectrogram) and asserts the emitted Cache-Control header, not
+// just the helper's return. This is the end-to-end guard that the visibility token
+// is actually wired into the served response: re-hardcoding "public" at any
+// spectrogram serve site would turn this red in Private Mode, which the pure-helper
+// test above cannot catch.
+func TestServeSpectrogramCacheControlHonorsPrivateMode(t *testing.T) {
+	testCases := []struct {
+		name           string
+		privateMode    bool
+		wantVisibility string
+	}{
+		{"public mode serves public cache", false, "public"},
+		{"private mode serves private cache", true, "private"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, e, root := newCacheControlTestHandler(t, tc.privateMode)
+
+			// Simulate an already-generated spectrogram so the serve path runs
+			// without invoking external tools. Default raw=true => audio_800px.png.
+			require.NoError(t, createTestAudioFile(t, filepath.Join(root, "audio.wav")))
+			require.NoError(t, os.WriteFile(filepath.Join(root, "audio_800px.png"),
+				[]byte("simulated spectrogram content"), 0o600))
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v2/media/spectrogram/audio.wav?width=800", http.NoBody)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetParamNames("filename")
+			c.SetParamValues("audio.wav")
+
+			require.NoError(t, h.ServeSpectrogram(c))
+			require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+			cacheControl := rec.Header().Get("Cache-Control")
+			assert.Truef(t, strings.HasPrefix(cacheControl, tc.wantVisibility+", "),
+				"spectrogram Cache-Control must start with %q visibility in %s, got %q",
+				tc.wantVisibility, tc.name, cacheControl)
+			assert.Contains(t, cacheControl, "immutable",
+				"spectrogram cache directive should retain immutable")
+		})
+	}
+}
+
+// TestServeAudioClipCacheControlPrivateInPrivateMode drives the real audio serve
+// path (ServeAudioClip) and asserts setPrivateAudioCacheControl is wired in:
+// "private" in Private Mode, and no Cache-Control at all in public mode (the prior
+// behavior). Dropping the setPrivateAudioCacheControl call would turn the Private
+// Mode case red.
+func TestServeAudioClipCacheControlPrivateInPrivateMode(t *testing.T) {
+	testCases := []struct {
+		name             string
+		privateMode      bool
+		wantCacheControl string // exact expected header ("" means header absent)
+	}{
+		{"public mode sets no cache-control", false, ""},
+		{"private mode marks response private", true, "private"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, e, root := newCacheControlTestHandler(t, tc.privateMode)
+
+			audioFilename := "clip.wav"
+			require.NoError(t, createTestAudioFile(t, filepath.Join(root, audioFilename)))
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v2/media/audio/"+audioFilename, http.NoBody)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetParamNames("filename")
+			c.SetParamValues(audioFilename)
+
+			require.NoError(t, h.ServeAudioClip(c))
+			require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+			assert.Equal(t, tc.wantCacheControl, rec.Header().Get("Cache-Control"),
+				"audio Cache-Control mismatch in %s", tc.name)
+		})
+	}
+}

--- a/internal/api/v2/private_mode_media_authz_test.go
+++ b/internal/api/v2/private_mode_media_authz_test.go
@@ -1,0 +1,229 @@
+// private_mode_media_authz_test.go: regression tests for GHSA-c7jx-552f-94hh.
+//
+// The stored-detection-media routes GET /api/v2/audio/:id,
+// GET /api/v2/spectrogram/:id, GET /api/v2/spectrogram/:id/status and
+// POST /api/v2/spectrogram/:id/generate are registered directly on the root Echo
+// instance (media.RegisterRoutes uses c.Echo, not the v2 group), so they do NOT
+// inherit the group-level c.Group.Use(c.PrivateModeAuth) gate. They therefore
+// carry PrivateModeAuth as per-route middleware. These tests drive real requests
+// through the production route tree (NewWithOptions with a real auth middleware)
+// to prove that, when Private Mode is enabled, an unauthenticated request is
+// rejected before the handler runs, and that public (non-private) installs keep
+// serving the same routes without authentication.
+
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/sessions"
+	"github.com/labstack/echo/v4"
+	"github.com/markbates/goth/gothic"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/auth"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
+	"github.com/tphakala/birdnet-go/internal/imageprovider"
+	"github.com/tphakala/birdnet-go/internal/notification"
+	"github.com/tphakala/birdnet-go/internal/observability"
+	"github.com/tphakala/birdnet-go/internal/security/securitytest"
+	"github.com/tphakala/birdnet-go/internal/suncalc"
+)
+
+// newMediaAuthzTestEnv builds a controller with the full /api/v2 route tree,
+// BasicAuth enabled, and Security.PrivateMode set to privateMode. A pre-router
+// hook forces the client IP off-subnet so the auth middleware's LAN bypass never
+// kicks in and an unauthenticated request is a genuine guest. It mirrors
+// newSettingsAuthTestEnv (settings_public_dashboard_test.go) but toggles
+// PrivateMode, which is the setting that gates the media-by-ID routes.
+func newMediaAuthzTestEnv(t *testing.T, privateMode bool) *echo.Echo {
+	t.Helper()
+
+	securityConfig := conf.Security{
+		SessionSecret: "test-session-secret-32-chars-long",
+		PrivateMode:   privateMode,
+		BasicAuth: conf.BasicAuth{
+			Enabled:        true,
+			Password:       "testpassword",
+			ClientID:       "test-client",
+			AuthCodeExp:    5 * time.Minute,
+			AccessTokenExp: 24 * time.Hour,
+		},
+	}
+
+	e := echo.New()
+
+	// Force the client IP off-subnet so IsAuthRequired() returns true regardless
+	// of the SubnetBypass configuration (TEST-NET-3 per RFC 5737).
+	e.Pre(func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			c.Request().RemoteAddr = "203.0.113.42:54321"
+			return next(c)
+		}
+	})
+
+	mockDS := mocks.NewMockInterface(t)
+	mockDS.EXPECT().PruneAppEvents(mock.Anything, mock.Anything).Return(int64(0), nil).Maybe()
+
+	settings := &conf.Settings{
+		Version: "1.0.0-test",
+		WebServer: conf.WebServerSettings{
+			Debug: true,
+		},
+		Realtime: conf.RealtimeSettings{
+			Audio: conf.AudioSettings{
+				Export: conf.ExportSettings{
+					Path: t.TempDir(),
+				},
+			},
+		},
+		Security: securityConfig,
+		BirdNET: conf.BirdNETConfig{
+			Latitude:  testHelsinkiLatitude,
+			Longitude: testHelsinkiLongitude,
+		},
+	}
+
+	mockImageProvider := &apitest.MockImageProvider{}
+	mockImageProvider.On("Fetch", mock.Anything).
+		Return(imageprovider.BirdImage{}, nil).Maybe()
+
+	birdImageCache := &imageprovider.BirdImageCache{}
+	birdImageCache.SetImageProvider(mockImageProvider)
+
+	sunCalc := suncalc.NewSunCalc(testHelsinkiLatitude, testHelsinkiLongitude)
+	controlChan := make(chan string, testControlChannelBuf)
+	mockMetrics, err := observability.NewMetrics()
+	require.NoError(t, err, "Failed to create test metrics")
+
+	oauth2Server := securitytest.NewOAuth2ServerForTesting(t, settings)
+	authService := auth.NewSecurityAdapter(oauth2Server)
+	authMw := auth.NewMiddleware(authService)
+
+	// Save and restore gothic.Store to avoid leaking session state between tests.
+	prevGothicStore := gothic.Store
+	gothic.Store = sessions.NewCookieStore([]byte(settings.Security.SessionSecret))
+	t.Cleanup(func() {
+		gothic.Store = prevGothicStore
+	})
+
+	// Isolated per-test notification service so the controller never depends on
+	// the process-global singleton. Stopped via t.Cleanup so its cleanupLoop
+	// goroutine does not leak (TestMain runs a goleak gate).
+	notifService := notification.NewService(notification.DefaultServiceConfig())
+	t.Cleanup(notifService.Stop)
+
+	controller, err := NewWithOptions(
+		e, mockDS, settings, birdImageCache, sunCalc, controlChan, mockMetrics,
+		true, // initializeRoutes - register full /api/v2 route tree
+		WithAuthMiddleware(authMw.Authenticate),
+		WithAuthService(authService),
+		WithNotificationService(notifService),
+	)
+	require.NoError(t, err, "Failed to create test API controller with auth")
+
+	t.Cleanup(func() {
+		controller.Shutdown()
+		close(controlChan)
+	})
+
+	return e
+}
+
+// mediaByIDRoutes is the set of stored-detection-media endpoints that the
+// advisory found reachable without authentication in Private Mode. They are
+// registered on c.Echo (not the v2 group) and so must carry PrivateModeAuth
+// per-route. A numeric ID is used so the request reaches the auth gate on the
+// exact path an attacker would iterate (e.g. /api/v2/audio/1239).
+var mediaByIDRoutes = []struct {
+	method string
+	path   string
+}{
+	{http.MethodGet, "/api/v2/audio/1"},
+	{http.MethodGet, "/api/v2/spectrogram/1"},
+	{http.MethodGet, "/api/v2/spectrogram/1/status"},
+	{http.MethodPost, "/api/v2/spectrogram/1/generate"},
+}
+
+// TestPrivateMode_MediaByIDRoutes_RequireAuth asserts that with Private Mode
+// enabled, an unauthenticated request to each media-by-ID route is rejected with
+// 401 before the handler runs. This is the core regression guard for
+// GHSA-c7jx-552f-94hh: before the fix these routes bypassed PrivateModeAuth and
+// returned stored detection media (or, for /generate, spawned server-side work)
+// to anonymous clients. Auth short-circuits ahead of the handler, so no
+// datastore interaction occurs.
+func TestPrivateMode_MediaByIDRoutes_RequireAuth(t *testing.T) {
+	e := newMediaAuthzTestEnv(t, true)
+
+	for _, tc := range mediaByIDRoutes {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, http.NoBody)
+			// No session cookie, no Authorization header, off-subnet IP -> guest.
+			// httptest.NewRequest sets no Accept header, so the auth middleware
+			// takes its API-client branch and returns 401 (a browser request with
+			// Accept: text/html would instead get a 302 login redirect). This models
+			// the attacker iterating numeric IDs (e.g. /api/v2/audio/1239).
+			rec := httptest.NewRecorder()
+
+			e.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusUnauthorized, rec.Code,
+				"%s %s must return 401 to an unauthenticated request when Private Mode is enabled, got: %s",
+				tc.method, tc.path, rec.Body.String())
+		})
+	}
+}
+
+// TestPublicMode_MediaByIDRoutes_RemainPublic guards the other direction: when
+// Private Mode is OFF the same routes must stay reachable without authentication,
+// so the fix does not break the default public read-only dashboard. Using a
+// non-numeric ID makes each handler fail its numeric-ID validation with 400
+// before any datastore access, which proves the request reached the handler
+// (i.e. was NOT auth-gated). A 401 here would mean the routes were wrongly gated
+// with AuthMiddleware instead of PrivateModeAuth.
+func TestPublicMode_MediaByIDRoutes_RemainPublic(t *testing.T) {
+	e := newMediaAuthzTestEnv(t, false)
+
+	for _, tc := range mediaByIDRoutes {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			// Non-numeric ID: rejected by numeric validation (400) before any DS call.
+			path := replaceLastIDSegment(tc.path)
+			req := httptest.NewRequest(tc.method, path, http.NoBody)
+			rec := httptest.NewRecorder()
+
+			e.ServeHTTP(rec, req)
+
+			assert.NotEqual(t, http.StatusUnauthorized, rec.Code,
+				"%s %s must NOT require auth when Private Mode is off (public dashboard), got: %s",
+				tc.method, path, rec.Body.String())
+			assert.Equal(t, http.StatusBadRequest, rec.Code,
+				"%s %s with a non-numeric ID should reach the handler and return 400, got: %s",
+				tc.method, path, rec.Body.String())
+		})
+	}
+}
+
+// replaceLastIDSegment swaps the numeric "1" id segment for a non-numeric value
+// so the handler's numeric validation rejects it (400) before touching the
+// datastore. The routes are /api/v2/audio/1, /api/v2/spectrogram/1,
+// /api/v2/spectrogram/1/status and /api/v2/spectrogram/1/generate.
+func replaceLastIDSegment(path string) string {
+	switch path {
+	case "/api/v2/audio/1":
+		return "/api/v2/audio/not-a-number"
+	case "/api/v2/spectrogram/1":
+		return "/api/v2/spectrogram/not-a-number"
+	case "/api/v2/spectrogram/1/status":
+		return "/api/v2/spectrogram/not-a-number/status"
+	case "/api/v2/spectrogram/1/generate":
+		return "/api/v2/spectrogram/not-a-number/generate"
+	default:
+		return path
+	}
+}


### PR DESCRIPTION
## Summary

When Private Mode is enabled, four stored-detection-media endpoints were reachable without authentication because they were registered on the root Echo instance rather than the `/api/v2` group, so they never inherited the group's `PrivateModeAuth` gate:

- `GET /api/v2/audio/:id`
- `GET /api/v2/spectrogram/:id`
- `GET /api/v2/spectrogram/:id/status`
- `POST /api/v2/spectrogram/:id/generate`

This PR attaches `PrivateModeAuth` to each of these routes so they require authentication when Private Mode is on, while staying publicly reachable in normal mode (matching the grouped `/media/*` aliases that already serve the same media through the group). It also marks spectrogram and audio responses `private` when Private Mode is enabled, so shared or proxy caches do not retain access-controlled media after a session ends.

## Who is affected

Only installations running with Private Mode enabled. Default (public) installations are byte-identical: `PrivateModeAuth` is a pass-through when Private Mode is off, and the `Cache-Control` header is unchanged in normal mode.

## Behavior change (release note)

In Private Mode, external clients that fetch these endpoints without a session cookie or bearer token will now receive `401`. Browsers are unaffected: the SPA loads audio and spectrograms same-origin, so the session cookie is sent automatically, and the spectrogram generate call already sends the CSRF token. Any external integration that previously relied on unauthenticated access in Private Mode must now authenticate (session cookie or `Authorization: Bearer <token>`).

## Tests

- Facade-level regression test: the four routes return `401` to an unauthenticated request in Private Mode, and remain reachable (not `401`) in public mode. Verified to fail when the fix is reverted.
- Serve-path tests asserting the `Cache-Control` visibility (`private` in Private Mode, `public` for spectrograms in normal mode) is actually emitted on the served response.

## Credit

Reported by @ejhnsn via private security advisory GHSA-c7jx-552f-94hh.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public API endpoints for retrieving audio, retrieving spectrograms, and generating spectrograms by detection ID.
* **Bug Fixes**
  * Improved media access controls when Private Mode is enabled.
  * Updated audio and spectrogram caching to protect private media while preserving public access where appropriate.
* **Documentation**
  * Clarified authentication requirements for media endpoints and Private Mode exemptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->