### PR TITLE
feat(frontend): add audio download to detection search results

### DIFF
--- a/frontend/src/lib/desktop/features/detections/components/DetectionRow.svelte
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionRow.svelte
@@ -14,7 +14,7 @@
   - Confidence circle visualization
   - Status badges (verified, false positive, etc.)
   - Weather condition display
-  - Action menu wired to parent-owned handlers (review/lock/ignore/delete)
+  - Action menu wired to parent-owned handlers plus direct audio download
   - Thumbnail image support
   - Responsive design
 
@@ -40,6 +40,7 @@
   import { loggers } from '$lib/utils/logger';
   import { navigation } from '$lib/stores/navigation.svelte';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
+  import { downloadDetectionAudio } from '$lib/utils/audioDownload';
   import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
 
   const logger = loggers.ui;
@@ -315,6 +316,7 @@
     {onToggleSpecies}
     {onToggleLock}
     {onDelete}
+    onDownload={detection.clipName ? () => downloadDetectionAudio(detection) : undefined}
   />
 </td>
 

--- a/frontend/src/lib/desktop/features/detections/components/DetectionRow.test.ts
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionRow.test.ts
@@ -2,10 +2,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/svelte';
 import DetectionRow from './DetectionRow.svelte';
 import type { Detection } from '$lib/types/detection.types';
+import { downloadDetectionAudio } from '$lib/utils/audioDownload';
 
-// DetectionRow is presentational: opening the action menu and clicking an item
-// must invoke the callback the parent passed (the parent owns the actual
-// API/modal logic via useDetectionActions). These tests assert that wiring.
+// DetectionRow is presentational for mutation actions: opening the action menu
+// and clicking one must invoke the callback the parent passed. Audio download
+// is wired directly through the shared download helper.
 
 vi.mock('$lib/stores/navigation.svelte', () => ({
   navigation: {
@@ -13,6 +14,10 @@ vi.mock('$lib/stores/navigation.svelte', () => ({
     navigate: vi.fn(),
     handlePopState: vi.fn(),
   },
+}));
+
+vi.mock('$lib/utils/audioDownload', () => ({
+  downloadDetectionAudio: vi.fn(),
 }));
 
 function createMockDetection(overrides: Partial<Detection> = {}): Detection {
@@ -105,6 +110,25 @@ describe('DetectionRow action callbacks', () => {
     await openMenuAndClick(/^Incorrect$/);
 
     expect(onMarkFalsePositive).toHaveBeenCalledTimes(1);
+  });
+
+  it('downloads available audio from the action menu', async () => {
+    const detection = createMockDetection({ id: 700, clipName: 'clip_700.wav' });
+    render(DetectionRow, { props: { detection } });
+
+    await openMenuAndClick(/download/i);
+
+    expect(downloadDetectionAudio).toHaveBeenCalledExactlyOnceWith(detection);
+  });
+
+  it('omits the download action when the detection has no audio clip', async () => {
+    render(DetectionRow, {
+      props: { detection: createMockDetection({ id: 701, clipName: '' }) },
+    });
+
+    await fireEvent.click(screen.getByRole('button', { name: /actions menu/i }));
+
+    expect(screen.queryByRole('menuitem', { name: /download/i })).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/lib/utils/audioDownload.ts
+++ b/frontend/src/lib/utils/audioDownload.ts
@@ -1,9 +1,8 @@
 /**
  * audioDownload.ts
  *
- * Shared helper for downloading a detection's audio clip. Used by the dashboard
- * DetectionCard and the mobile DetectionCardMobile so the filename logic lives
- * in one place.
+ * Shared helper for downloading a detection's audio clip from detection cards
+ * and action menus, so the filename logic lives in one place.
  *
  * The actual bytes are served by GET /api/v2/audio/{id}; the `download`
  * attribute only hints the saved filename, so the sanitization here is for a


### PR DESCRIPTION
## Summary

- add the existing Download audio action to desktop detection-search result rows
- reuse the shared detection-audio download helper and omit the action when no clip exists
- cover both available-audio and missing-audio menu behavior

This uses the ID-based audio endpoint secured for Private Mode by #4083.

## Testing

- `golangci-lint run -v` (with the repository's CI build tags)
- `go test -race -short ./...` (with the repository's macOS CI build tags)
- `npm run check:all`
- `npm test -- --run` (181 files, 2,708 tests)

## Preflight Status

- [x] Reuse/efficiency review passed; uses the existing `downloadDetectionAudio` helper and `ActionMenu` hook
- [x] Correctness and edge-case review passed
- [x] Code-quality review passed after updating stale helper/test documentation found during preflight
- [x] i18n/accessibility review passed; the existing translated download label is reused
- [x] Integration wiring review passed across desktop table, mobile card, and dashboard card surfaces
- [x] Regression/backward-compatibility review passed
- [x] Full Go and frontend lint/test gates passed
- [x] Diff is limited to this single feature; no secrets, PII, TODOs, or breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an audio download option to detection action menus when an audio clip is available.
  * Updated in-app documentation to clarify audio download availability.

* **Tests**
  * Added coverage verifying successful audio downloads and hiding the option when no clip exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->