### PR TITLE
fix(frontend): download detection audio by ID

### DIFF
--- a/frontend/src/lib/desktop/views/DetectionDetail.svelte
+++ b/frontend/src/lib/desktop/views/DetectionDetail.svelte
@@ -690,7 +690,7 @@
       {#if det.clipName}
         <div class="meta-section">
           <a
-            href={buildAppUrl(`/api/v2/media/audio/${det.clipName}`)}
+            href={buildAppUrl(`/api/v2/audio/${det.id}`)}
             download
             class="meta-download"
             aria-label={t('detections.detail.aria.downloadAudioClip', { name: displayName })}

--- a/frontend/src/lib/desktop/views/DetectionDetail.test.ts
+++ b/frontend/src/lib/desktop/views/DetectionDetail.test.ts
@@ -123,3 +123,43 @@ describe('DetectionDetail stale-response race (#978)', () => {
     expect(container.textContent).not.toContain(STALE_SCIENTIFIC);
   });
 });
+
+describe('DetectionDetail audio download', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the ID-based endpoint when downloading the original audio', async () => {
+    const detection = makeDetection({
+      id: 1239,
+      scientificName: 'Phalaenoptilus nuttallii',
+      commonName: 'Common Poorwill',
+      clipName: 'phalaenoptilus_nuttallii_88p_20260720T051601Z.m4a',
+    });
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: RequestInfo | URL) => {
+        if (String(input).includes('/api/v2/detections/1239')) {
+          return Promise.resolve(jsonResponse(detection));
+        }
+        return Promise.resolve(jsonResponse({}));
+      })
+    );
+
+    const { container } = detailTest.render({ detectionId: '1239' });
+
+    await waitFor(() => {
+      expect(container.querySelector('a.meta-download')).not.toBeNull();
+    });
+
+    const downloadLink = container.querySelector<HTMLAnchorElement>('a.meta-download');
+    expect(downloadLink?.getAttribute('href')).toBe('/api/v2/audio/1239');
+    expect(downloadLink).toHaveAttribute('download');
+  });
+});

--- a/frontend/src/lib/desktop/views/DetectionDetail.test.ts
+++ b/frontend/src/lib/desktop/views/DetectionDetail.test.ts
@@ -160,6 +160,8 @@ describe('DetectionDetail audio download', () => {
 
     const downloadLink = container.querySelector<HTMLAnchorElement>('a.meta-download');
     expect(downloadLink?.getAttribute('href')).toBe('/api/v2/audio/1239');
-    expect(downloadLink).toHaveAttribute('download');
+    // Keep the attribute valueless so the response's Content-Disposition header
+    // supplies the canonical filename and extension.
+    expect(downloadLink).toHaveAttribute('download', '');
   });
 });


### PR DESCRIPTION
## Summary

- fix the Detection Details “Download audio” link by using the detection ID endpoint instead of the filename endpoint
- preserve the browser download behavior and server-provided original filename/extension
- add a regression test that verifies the exact ID-based URL and download attribute

This uses the ID-based audio endpoint secured for Private Mode by #4083.

## Testing

- `golangci-lint run -v` (with the repository's CI build tags)
- `go test -race -short ./...` (with the repository's macOS CI build tags)
- `npm run check:all`
- `npm test -- --run` (181 files, 2,707 tests)

## Preflight Status

- [x] Reuse/efficiency review passed; reuses the established ID-based audio endpoint and `buildAppUrl`
- [x] Correctness and edge-case review passed
- [x] Code-quality review passed
- [x] i18n/accessibility review passed; existing translated label and aria label are preserved
- [x] Integration wiring review passed; the URL matches the detail-page player and backend route
- [x] Regression/backward-compatibility review passed; the filename endpoint remains available to existing clients
- [x] Full Go and frontend lint/test gates passed
- [x] Diff is limited to this single bug fix; no secrets, PII, TODOs, or breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated audio downloads in detection details to use the modern ID-based API endpoint for more reliable access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Release notes
- audience: user
- summary: Fix the "Download audio" link on the detection details page so it reliably saves the clip, using the ID-based audio endpoint that resolves the correct file and original filename
- feature: none
- breaking: none
- config: none
- schema: none
