### PR TITLE
fix(media): preserve request timeout errors

### DIFF
--- a/internal/api/v2/media/media.go
+++ b/internal/api/v2/media/media.go
@@ -470,7 +470,7 @@ func (c *Handler) translateSecureFSError(ctx echo.Context, err error, userMsg st
 			logger.Bool("tunneled", isTunneled),
 			logger.String("tunnel_provider", tunnelProvider),
 		)
-		return c.HandleError(ctx, err, "Request timed out", http.StatusRequestTimeout)
+		return c.HandleError(ctx, err, requestTimeoutMsg, http.StatusRequestTimeout)
 	case errors.Is(err, context.Canceled):
 		c.LogInfoIfEnabled("Request canceled by client",
 			logger.Error(err),

--- a/internal/api/v2/media/media.go
+++ b/internal/api/v2/media/media.go
@@ -65,6 +65,7 @@ const (
 const (
 	headerAcceptRanges = "Accept-Ranges"
 	acceptRangesBytes  = "bytes"
+	requestTimeoutMsg  = "Request timed out"
 )
 
 // Cache duration in seconds for HTTP Cache-Control headers on media responses.
@@ -510,7 +511,7 @@ func (c *Handler) handleRequestContextError(ctx echo.Context) (bool, error) {
 	case errors.Is(requestErr, context.Canceled):
 		return true, nil
 	case errors.Is(requestErr, context.DeadlineExceeded):
-		return true, c.translateSecureFSError(ctx, requestErr, "Request timed out")
+		return true, c.translateSecureFSError(ctx, requestErr, requestTimeoutMsg)
 	default:
 		return false, nil
 	}

--- a/internal/api/v2/media/media.go
+++ b/internal/api/v2/media/media.go
@@ -501,6 +501,21 @@ func (c *Handler) translateAudioServeError(ctx echo.Context, err error, userMsg 
 	return c.translateSecureFSError(ctx, err, userMsg)
 }
 
+// handleRequestContextError distinguishes a disconnected client from a request
+// deadline. Canceled requests need no response, while server-side deadlines must
+// remain visible as timeout failures.
+func (c *Handler) handleRequestContextError(ctx echo.Context) (bool, error) {
+	requestErr := ctx.Request().Context().Err()
+	switch {
+	case errors.Is(requestErr, context.Canceled):
+		return true, nil
+	case errors.Is(requestErr, context.DeadlineExceeded):
+		return true, c.translateSecureFSError(ctx, requestErr, "Request timed out")
+	default:
+		return false, nil
+	}
+}
+
 // parseRawParameter parses the raw query parameter for spectrogram generation.
 // It defaults to true for backward compatibility with existing cached spectrograms.
 // Accepts: "true", "false", "1", "0", "t", "f", "yes", "no", "on", "off"
@@ -1128,8 +1143,8 @@ func (c *Handler) ExtractAudioClipByID(ctx echo.Context) error {
 		FFmpegPath: c.CurrentSettings().Realtime.Audio.FfmpegPath,
 	})
 	if err != nil {
-		if ctx.Request().Context().Err() != nil {
-			return nil // Client disconnected
+		if handled, contextErr := c.handleRequestContextError(ctx); handled {
+			return contextErr
 		}
 		c.logTranscodeFailure(noteID, "media_clip_transcode_failed", req.Format, filters, err)
 		return c.HandleError(ctx, err, "Failed to extract audio clip", http.StatusInternalServerError)
@@ -1270,8 +1285,8 @@ func (c *Handler) ProcessAudioByID(ctx echo.Context) error {
 
 	if err := ffmpeg.ProcessAudioToFile(ctx.Request().Context(), absolutePath,
 		c.CurrentSettings().Realtime.Audio.FfmpegPath, filters, tmpPath); err != nil {
-		if ctx.Request().Context().Err() != nil {
-			return nil // Client disconnected
+		if handled, contextErr := c.handleRequestContextError(ctx); handled {
+			return contextErr
 		}
 		c.logTranscodeFailure(noteID, "media_processed_audio_failed", processedAudioFormat, &filters, err)
 		return c.HandleError(ctx, err, "Failed to process audio", http.StatusInternalServerError)
@@ -1388,8 +1403,8 @@ func (c *Handler) ProcessedSpectrogramByID(ctx echo.Context) error {
 
 	if err := ffmpeg.ProcessAudioToFile(ctx.Request().Context(), absolutePath,
 		c.CurrentSettings().Realtime.Audio.FfmpegPath, filters, tmpPath); err != nil {
-		if ctx.Request().Context().Err() != nil {
-			return nil // Client disconnected
+		if handled, contextErr := c.handleRequestContextError(ctx); handled {
+			return contextErr
 		}
 		c.logTranscodeFailure(noteID, "media_processed_spectrogram_failed", processedAudioFormat, &filters, err)
 		return c.HandleError(ctx, err, "Failed to process audio", http.StatusInternalServerError)
@@ -1411,8 +1426,8 @@ func (c *Handler) ProcessedSpectrogramByID(ctx echo.Context) error {
 	profileOpt := spectrogram.WithFrequencyProfile(c.resolveDetectionFrequencyProfile(noteID))
 
 	if err := c.spectrogramGenerator.GenerateFromFile(ctx.Request().Context(), tmpPath, tmpSpectrogramPath, params.width, params.raw, profileOpt); err != nil {
-		if ctx.Request().Context().Err() != nil {
-			return nil
+		if handled, contextErr := c.handleRequestContextError(ctx); handled {
+			return contextErr
 		}
 		return c.HandleError(ctx, err, "Failed to generate spectrogram", http.StatusInternalServerError)
 	}

--- a/internal/api/v2/media/request_context_error_test.go
+++ b/internal/api/v2/media/request_context_error_test.go
@@ -1,0 +1,69 @@
+package media
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
+)
+
+func TestHandleRequestContextError(t *testing.T) {
+	tests := []struct {
+		name        string
+		requestCtx  func(*testing.T) context.Context
+		wantHandled bool
+		wantStatus  int
+	}{
+		{
+			name:        "active request",
+			requestCtx:  (*testing.T).Context,
+			wantHandled: false,
+			wantStatus:  http.StatusOK,
+		},
+		{
+			name: "client canceled",
+			requestCtx: func(t *testing.T) context.Context {
+				t.Helper()
+				ctx, cancel := context.WithCancel(t.Context())
+				cancel()
+				return ctx
+			},
+			wantHandled: true,
+			wantStatus:  http.StatusOK,
+		},
+		{
+			name: "deadline exceeded",
+			requestCtx: func(t *testing.T) context.Context {
+				t.Helper()
+				ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
+				cancel()
+				return ctx
+			},
+			wantHandled: true,
+			wantStatus:  http.StatusRequestTimeout,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := echo.New()
+			h := New(apitest.NewCore(t, apitest.WithEcho(e)))
+			req := httptest.NewRequest(http.MethodGet, "/api/v2/media/test", http.NoBody).
+				WithContext(tt.requestCtx(t))
+			rec := httptest.NewRecorder()
+			ctx := e.NewContext(req, rec)
+
+			handled, err := h.handleRequestContextError(ctx)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantHandled, handled)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

I separated canceled media requests from request deadlines so server-side timeouts are no longer silently treated as client disconnects.

## Changes

- preserve the no-response behavior for canceled clients
- translate expired request deadlines into the existing HTTP 408 timeout response
- apply the same handling across clip extraction, audio processing, and processed spectrogram generation
- add regression coverage for active, canceled, and expired request contexts

## Testing

- `go test -tags noembed,skipfrontend,notflite,goaac_simd -race ./internal/api/v2/media -count=1`
- `golangci-lint run --build-tags=noembed,skipfrontend,notflite,goaac_simd ./internal/api/v2/media/...`
- `go vet -tags noembed,skipfrontend,notflite,goaac_simd ./internal/api/v2/media`
- `git diff --check`

The full native TensorFlow Lite build and repository-wide suite are deferred to CI because the local environment does not provide the required TensorFlow Lite C headers and library.

## Preflight Status

I reviewed the complete diff for reuse, correctness and safety, code quality, integration consistency, and backward compatibility. The change is limited to one bug fix, introduces no user-facing strings, and leaves no unresolved preflight findings.

## Related Issues

Fixes #4085


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of canceled media-processing requests so interrupted operations end cleanly without unnecessary responses.
  * Requests that exceed their deadline now return a clear request-timeout response.
  * Audio extraction, processed-audio generation, and spectrogram processing now handle cancellation and timeout conditions consistently.
  * Improved error handling provides more reliable behavior across media-processing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->