### PR TITLE
fix(api): hot-reload eBird settings instead of requiring a restart

### DIFF
--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -354,6 +354,7 @@ export type TranslationKey =
   | 'notifications.content.settings.updatingIntervals'
   | 'notifications.content.settings.reconfiguringMqtt'
   | 'notifications.content.settings.reconfiguringBirdweather'
+  | 'notifications.content.settings.reconfiguringEbird'
   | 'notifications.content.settings.reconfiguringStreams'
   | 'notifications.content.settings.reconfiguringTelemetry'
   | 'notifications.content.settings.reconfiguringPushNotifications'

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -412,6 +412,7 @@
         "updatingIntervals": "Aktualizuji intervaly detekce…",
         "reconfiguringMqtt": "Aktualizuji připojení MQTT…",
         "reconfiguringBirdweather": "Aktualizuji integraci BirdWeather…",
+        "reconfiguringEbird": "Updating eBird integration...",
         "reconfiguringStreams": "Aktualizuji audio streamy…",
         "reconfiguringTelemetry": "Aktualizuji nastavení telemetrie…",
         "reconfiguringPushNotifications": "Překonfiguruji poskytovatele push oznámení…",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -412,6 +412,7 @@
         "updatingIntervals": "Opdaterer detektionsintervaller...",
         "reconfiguringMqtt": "Opdaterer MQTT-forbindelse...",
         "reconfiguringBirdweather": "Opdaterer BirdWeather-integration...",
+        "reconfiguringEbird": "Updating eBird integration...",
         "reconfiguringStreams": "Opdaterer lydstreams...",
         "reconfiguringTelemetry": "Opdaterer telemetriindstillinger...",
         "reconfiguringPushNotifications": "Omkonfigurerer push-notifikationsudbydere...",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -412,6 +412,7 @@
         "updatingIntervals": "Erkennungsintervalle werden aktualisiert...",
         "reconfiguringMqtt": "MQTT-Verbindung wird aktualisiert...",
         "reconfiguringBirdweather": "BirdWeather-Integration wird aktualisiert...",
+        "reconfiguringEbird": "Updating eBird integration...",
         "reconfiguringStreams": "Audiostreams werden aktualisiert...",
         "reconfiguringTelemetry": "Telemetrieeinstellungen werden aktualisiert...",
         "reconfiguringPushNotifications": "Push-Benachrichtigungsanbieter werden neu konfiguriert...",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -412,6 +412,7 @@
         "updatingIntervals": "Updating detection intervals...",
         "reconfiguringMqtt": "Updating MQTT connection...",
         "reconfiguringBirdweather": "Updating BirdWeather integration...",
+        "reconfiguringEbird": "Updating eBird integration...",
         "reconfiguringStreams": "Updating audio streams...",
         "reconfiguringTelemetry": "Updating telemetry settings...",
         "reconfiguringPushNotifications": "Reconfiguring push notification providers...",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -412,6 +412,7 @@
         "updatingIntervals": "Actualizando intervalos de detección...",
         "reconfiguringMqtt": "Actualizando conexión MQTT...",
         "reconfiguringBirdweather": "Actualizando integración de BirdWeather...",
+        "reconfiguringEbird": "Updating eBird integration...",
         "reconfiguringStreams": "Actualizando flujos de audio...",
         "reconfiguringTelemetry": "Actualizando ajustes de telemetría...",
         "reconfiguringPushNotifications": "Reconfigurando proveedores de notificaciones push...",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -412,6 +412,7 @@
         "updatingIntervals": "Päivitetään havaintovälejä...",
         "reconfiguringMqtt": "Päivitetään MQTT-yhteyttä...",
         "reconfiguringBirdweather": "Päivitetään BirdWeather-integraatiota...",
+        "reconfiguringEbird": "Updating eBird integration...",
         "reconfiguringStreams": "Päivitetään äänistriimejä...",
         "reconfiguringTelemetry": "Päivitetään telemetria-asetuksia...",
         "reconfiguringPushNotifications": "Määritetään push-ilmoitusten tarjoajia uudelleen...",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -412,6 +412,7 @@
         "updatingIntervals": "Mise à jour des intervalles de détection...",
         "reconfiguringMqtt": "Mise à jour de la connexion MQTT...",
         "reconfiguringBirdweather": "Mise à jour de l'intégration BirdWeather...",
+        "reconfiguringEbird": "Updating eBird integration...",
         "reconfiguringStreams": "Mise à jour des flux audio...",
         "reconfiguringTelemetry": "Mise à jour des paramètres de télémétrie...",
         "reconfiguringPushNotifications": "Reconfiguration des fournisseurs de notifications push...",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -412,6 +412,7 @@
         "updatingIntervals": "Detektálási intervallumok frissítése...",
         "reconfiguringMqtt": "MQTT kapcsolat frissítése...",
         "reconfiguringBirdweather": "BirdWeather integráció frissítése...",
+        "reconfiguringEbird": "Updating eBird integration...",
         "reconfiguringStreams": "Hang streamek frissítése...",
         "reconfiguringTelemetry": "Telemetria beállítások frissítése...",
         "reconfiguringPushNotifications": "Push értesítési szolgáltatók újrakonfigurálása...",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -412,6 +412,7 @@
         "updatingIntervals": "Aggiornamento degli intervalli di rilevamento...",
         "reconfiguringMqtt": "Aggiornamento della connessione MQTT...",
         "reconfiguringBirdweather": "Aggiornamento dell'integrazione BirdWeather...",
+        "reconfiguringEbird": "Updating eBird integration...",
         "reconfiguringStreams": "Aggiornamento dei flussi audio...",
         "reconfiguringTelemetry": "Aggiornamento delle impostazioni di telemetria...",
         "reconfiguringPushNotifications": "Riconfigurazione dei provider di notifica push...",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -412,6 +412,7 @@
         "updatingIntervals": "Atjaunina noteikšanas intervālus...",
         "reconfiguringMqtt": "Atjaunina MQTT savienojumu...",
         "reconfiguringBirdweather": "Atjaunina BirdWeather integrāciju...",
+        "reconfiguringEbird": "Updating eBird integration...",
         "reconfiguringStreams": "Atjaunina audio straumes...",
         "reconfiguringTelemetry": "Atjaunina telemetrijas iestatījumus...",
         "reconfiguringPushNotifications": "Pārkonfigurē push paziņojumu pakalpojumu sniedzējus...",

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -412,6 +412,7 @@
         "updatingIntervals": "Oppdaterer registreringsintervaller...",
         "reconfiguringMqtt": "Oppdaterer MQTT-tilkobling...",
         "reconfiguringBirdweather": "Oppdaterer BirdWeather-integrasjon...",
+        "reconfiguringEbird": "Updating eBird integration...",
         "reconfiguringStreams": "Oppdaterer lydstrømmer...",
         "reconfiguringTelemetry": "Oppdaterer telemetriinnstillinger...",
         "reconfiguringPushNotifications": "Konfigurerer push-varselleverandører på nytt...",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -412,6 +412,7 @@
         "updatingIntervals": "Detectie-intervallen worden bijgewerkt...",
         "reconfiguringMqtt": "MQTT-verbinding wordt bijgewerkt...",
         "reconfiguringBirdweather": "BirdWeather-integratie wordt bijgewerkt...",
+        "reconfiguringEbird": "Updating eBird integration...",
         "reconfiguringStreams": "Audiostreams worden bijgewerkt...",
         "reconfiguringTelemetry": "Telemetrie-instellingen worden bijgewerkt...",
         "reconfiguringPushNotifications": "Pushmeldingsproviders herconfigureren...",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -412,6 +412,7 @@
         "updatingIntervals": "Aktualizacja interwałów wykrywania...",
         "reconfiguringMqtt": "Aktualizacja połączenia MQTT...",
         "reconfiguringBirdweather": "Aktualizacja integracji BirdWeather...",
+        "reconfiguringEbird": "Updating eBird integration...",
         "reconfiguringStreams": "Aktualizacja strumieni audio...",
         "reconfiguringTelemetry": "Aktualizacja ustawień telemetrii...",
         "reconfiguringPushNotifications": "Rekonfigurowanie dostawców powiadomień push...",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -412,6 +412,7 @@
         "updatingIntervals": "A atualizar intervalos de deteção...",
         "reconfiguringMqtt": "A atualizar ligação MQTT...",
         "reconfiguringBirdweather": "A atualizar integração BirdWeather...",
+        "reconfiguringEbird": "Updating eBird integration...",
         "reconfiguringStreams": "A atualizar fluxos de áudio...",
         "reconfiguringTelemetry": "A atualizar definições de telemetria...",
         "reconfiguringPushNotifications": "A reconfigurar fornecedores de notificações push...",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -412,6 +412,7 @@
         "updatingIntervals": "Aktualizácia intervalov detekcie...",
         "reconfiguringMqtt": "Aktualizácia MQTT pripojenia...",
         "reconfiguringBirdweather": "Aktualizácia integrácie BirdWeather...",
+        "reconfiguringEbird": "Updating eBird integration...",
         "reconfiguringStreams": "Aktualizácia audio streamov...",
         "reconfiguringTelemetry": "Aktualizácia nastavení telemetrie...",
         "reconfiguringPushNotifications": "Rekonfigurácia poskytovateľov push notifikácií...",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -412,6 +412,7 @@
         "updatingIntervals": "Uppdaterar detektionsintervall...",
         "reconfiguringMqtt": "Uppdaterar MQTT-anslutning...",
         "reconfiguringBirdweather": "Uppdaterar BirdWeather-integration...",
+        "reconfiguringEbird": "Updating eBird integration...",
         "reconfiguringStreams": "Uppdaterar ljudströmmar...",
         "reconfiguringTelemetry": "Uppdaterar telemetriinställningar...",
         "reconfiguringPushNotifications": "Omkonfigurerar push-aviseringsleverantörer...",

--- a/internal/analysis/control_monitor.go
+++ b/internal/analysis/control_monitor.go
@@ -322,6 +322,8 @@ func (cm *ControlMonitor) handleControlSignal(signal string) {
 		cm.handleReconfigureStreams()
 	case "reconfigure_birdweather":
 		cm.handleReconfigureBirdWeather()
+	case "reconfigure_ebird":
+		cm.handleReconfigureEBird()
 	case "update_detection_intervals":
 		cm.handleUpdateDetectionIntervals()
 	case "reconfigure_sound_level":
@@ -592,6 +594,40 @@ func (cm *ControlMonitor) handleReconfigureBirdWeather() {
 	}
 
 	emitHotReload("birdweather")
+}
+
+// handleReconfigureEBird rebuilds the eBird API client from the current settings.
+// The client lives on the API controller (apicore.Core), not the processor, so
+// this delegates to the controller's thread-safe ReconfigureEBird, which reads
+// settings live and atomically swaps the client that request handlers read.
+func (cm *ControlMonitor) handleReconfigureEBird() {
+	GetLogger().Info("Reconfiguring eBird integration")
+
+	if cm.apiController == nil {
+		GetLogger().Error("API controller not available for eBird reconfiguration")
+		cm.notifyError("Failed to reconfigure eBird", errors.Newf("API controller not available").
+			Component("analysis").
+			Category(errors.CategoryConfiguration).
+			Context("operation", "reconfigure_ebird").
+			Build())
+		return
+	}
+
+	// Report the actual outcome, mirroring handleReconfigureBirdWeather, rather
+	// than reporting success unconditionally. ReconfigureEBird returns nil when
+	// eBird is disabled or misconfigured (e.g. enabled with no API key), in which
+	// case buildEBirdClient has already surfaced the specific reason.
+	if cm.apiController.ReconfigureEBird() != nil {
+		GetLogger().Info("eBird integration configured successfully")
+		cm.notifySuccess("eBird integration configured successfully")
+	} else if s := conf.Setting(); s != nil && s.Realtime.EBird.Enabled {
+		GetLogger().Warn("eBird enabled but not configured; see prior notification")
+	} else {
+		GetLogger().Info("eBird integration disabled")
+		cm.notifySuccess("eBird integration disabled")
+	}
+
+	emitHotReload("ebird")
 }
 
 // handleUpdateDetectionIntervals updates event tracking intervals for species

--- a/internal/analysis/control_monitor_ebird_test.go
+++ b/internal/analysis/control_monitor_ebird_test.go
@@ -1,0 +1,18 @@
+package analysis
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestHandleReconfigureEBirdNilController verifies the eBird reconfigure handler
+// degrades gracefully when no API controller is wired (early startup or minimal
+// test setups): it logs and returns instead of panicking or dereferencing nil.
+func TestHandleReconfigureEBirdNilController(t *testing.T) {
+	t.Parallel()
+	cm := &ControlMonitor{} // apiController is nil
+	assert.NotPanics(t, func() {
+		cm.handleReconfigureEBird()
+	})
+}

--- a/internal/api/v2/analytics/insights.go
+++ b/internal/api/v2/analytics/insights.go
@@ -345,7 +345,10 @@ func (c *Handler) GetExpectedTodayRegional(ctx echo.Context) error {
 }
 
 func (c *Handler) getExpectedTodayRegionalImpl(ctx echo.Context) error {
-	if c.EBirdClient == nil {
+	// Load the eBird client once; it may be swapped concurrently by a settings
+	// hot-reload (ReconfigureEBird), so reuse this pointer for the whole request.
+	client := c.EBird()
+	if client == nil {
 		return ctx.JSON(http.StatusOK, ExpectedTodayRegionalResponse{
 			Species:   []RegionalSpeciesItem{},
 			Available: false,
@@ -371,7 +374,7 @@ func (c *Handler) getExpectedTodayRegionalImpl(ctx echo.Context) error {
 	reqCtx, cancel := context.WithTimeout(ctx.Request().Context(), insightsQueryTimeout)
 	defer cancel()
 
-	observations, err := c.EBirdClient.GetRecentObservations(reqCtx, lat, lng, 14)
+	observations, err := client.GetRecentObservations(reqCtx, lat, lng, 14)
 	if err != nil {
 		return c.handleAnalyticsQueryError(ctx, err, "eBird observations", "Failed to query eBird observations")
 	}

--- a/internal/api/v2/apicore/core.go
+++ b/internal/api/v2/apicore/core.go
@@ -251,6 +251,12 @@ func (c *Core) EBird() *ebird.Client {
 // on a live settings change. The client is cheap to build (no network I/O).
 func (c *Core) buildEBirdClient(settings *conf.Settings) *ebird.Client {
 	log := GetLogger()
+	if settings == nil {
+		// Defensive: conf.Setting() can return nil if settings cannot be loaded.
+		// Treat it as "no eBird client" rather than dereferencing a nil settings.
+		log.Warn("Cannot build eBird client: settings unavailable")
+		return nil
+	}
 	if !settings.Realtime.EBird.Enabled {
 		log.Debug("eBird integration disabled")
 		return nil

--- a/internal/api/v2/apicore/core.go
+++ b/internal/api/v2/apicore/core.go
@@ -71,11 +71,17 @@ type Core struct {
 	BirdImageCache *imageprovider.BirdImageCache
 	SunCalc        *suncalc.SunCalc
 	Processor      *processor.Processor
-	EBirdClient    *ebird.Client
-	TaxonomyDB     *classifier.TaxonomyDatabase
-	SFS            *securefs.SecureFS     // SecureFS instance for media
-	APILogger      logger.Logger          // Structured logger for API operations
-	Metrics        *observability.Metrics // Shared metrics instance
+	// eBirdClient holds the eBird API client as a lock-free atomic pointer so it
+	// can be rebuilt live when Realtime.EBird settings change (see ReconfigureEBird)
+	// while concurrent request handlers read it via EBird(). Same copy-on-write
+	// pattern as Settings/Engine/AudioWatchdog. nil when eBird is disabled or
+	// misconfigured. Read it exactly once per request via EBird() and reuse the
+	// loaded pointer; do not call EBird() twice and assume the same instance.
+	eBirdClient atomic.Pointer[ebird.Client]
+	TaxonomyDB  *classifier.TaxonomyDatabase
+	SFS         *securefs.SecureFS     // SecureFS instance for media
+	APILogger   logger.Logger          // Structured logger for API operations
+	Metrics     *observability.Metrics // Shared metrics instance
 
 	// AuthMiddleware is the authentication middleware function (injected from server
 	// via WithAuthMiddleware). Read by PrivateModeAuth, GetAuthMiddleware, and the
@@ -223,38 +229,77 @@ func NewCore(e *echo.Echo, ds datastore.Interface, settings *conf.Settings,
 	// Initialize SSE manager
 	c.SSEManager = NewSSEManager()
 
-	// Initialize eBird client if enabled
-	log := GetLogger()
-	if settings.Realtime.EBird.Enabled {
-		if settings.Realtime.EBird.APIKey == "" {
-			// Create notification for missing API key
-			// The Build() method automatically publishes to the event bus for notifications
-			_ = errors.Newf("eBird integration enabled but API key not configured").
-				Category(errors.CategoryConfiguration).
-				Context("setting", "realtime.ebird.apikey").
-				Component("ebird").
-				Build()
-			log.Warn("eBird integration enabled but API key not configured")
-		} else {
-			ebirdConfig := ebird.Config{
-				APIKey:   settings.Realtime.EBird.APIKey,
-				CacheTTL: time.Duration(settings.Realtime.EBird.CacheTTL) * time.Hour,
-			}
-			ebirdClient, err := ebird.NewClient(ebirdConfig)
-			if err != nil {
-				// Initialization error - already enhanced by ebird.NewClient
-				log.Warn("Failed to initialize eBird client", logger.Error(err))
-				// Continue without eBird client - it's not critical
-			} else {
-				c.EBirdClient = ebirdClient
-				log.Info("Initialized eBird API client")
-			}
-		}
-	} else {
-		log.Debug("eBird integration disabled")
-	}
+	// Initialize eBird client if enabled. Stored atomically so it can be rebuilt
+	// live on a settings change (ReconfigureEBird) without racing request readers.
+	c.eBirdClient.Store(c.buildEBirdClient(settings))
 
 	return c, nil
+}
+
+// EBird returns the current eBird API client, or nil when eBird is disabled or
+// misconfigured. Callers MUST load it once and reuse the returned pointer for the
+// whole request; the client can be swapped concurrently by ReconfigureEBird, so
+// re-reading it mid-request risks a nil after a check.
+func (c *Core) EBird() *ebird.Client {
+	return c.eBirdClient.Load()
+}
+
+// buildEBirdClient constructs an eBird API client from the given settings, or
+// returns nil when eBird is disabled, the API key is missing, or construction
+// fails. It is used both at startup and by ReconfigureEBird, so the same
+// enabled/misconfigured handling (including the missing-key notification) applies
+// on a live settings change. The client is cheap to build (no network I/O).
+func (c *Core) buildEBirdClient(settings *conf.Settings) *ebird.Client {
+	log := GetLogger()
+	if !settings.Realtime.EBird.Enabled {
+		log.Debug("eBird integration disabled")
+		return nil
+	}
+	if settings.Realtime.EBird.APIKey == "" {
+		// Notify about the missing API key. The Build() method automatically
+		// publishes to the event bus for notifications, so enabling eBird without
+		// a key via the UI surfaces the problem immediately.
+		_ = errors.Newf("eBird integration enabled but API key not configured").
+			Category(errors.CategoryConfiguration).
+			Context("setting", "realtime.ebird.apikey").
+			Component("ebird").
+			Build()
+		log.Warn("eBird integration enabled but API key not configured")
+		return nil
+	}
+	ebirdConfig := ebird.Config{
+		APIKey:   settings.Realtime.EBird.APIKey,
+		CacheTTL: time.Duration(settings.Realtime.EBird.CacheTTL) * time.Hour,
+	}
+	ebirdClient, err := ebird.NewClient(ebirdConfig)
+	if err != nil {
+		// Initialization error - already enhanced by ebird.NewClient.
+		// Continue without an eBird client - it's not critical.
+		log.Warn("Failed to initialize eBird client", logger.Error(err))
+		return nil
+	}
+	log.Info("Initialized eBird API client")
+	return ebirdClient
+}
+
+// ReconfigureEBird rebuilds the eBird API client from the current settings and
+// swaps it in atomically, so changes made via the UI take effect without a
+// restart. It reads settings live via conf.Setting() and is safe to call from the
+// control-monitor goroutine while request handlers read the client via EBird().
+// It returns the resulting client, which is nil when eBird is disabled or
+// misconfigured, so the caller can report the outcome accurately.
+//
+// The previous client is intentionally NOT Closed here. Close() stops its
+// rate-limiter ticker, and ebird.Client.doRequest blocks on a bare receive from
+// that ticker while holding the client mutex, so stopping it under an in-flight
+// request would hang that request (and every other caller waiting on the mutex)
+// forever. Requests that already loaded the old pointer keep using its live
+// limiter; once the last reference is dropped, Go's runtime garbage-collects the
+// orphaned ticker (the same reliance on Go 1.23+ timer GC used in internal/weather).
+func (c *Core) ReconfigureEBird() *ebird.Client {
+	client := c.buildEBirdClient(conf.Setting())
+	c.eBirdClient.Store(client)
+	return client
 }
 
 // resolveAndValidateMediaPath resolves a potentially relative media path and ensures it exists as a directory.

--- a/internal/api/v2/apicore/ebird_test.go
+++ b/internal/api/v2/apicore/ebird_test.go
@@ -1,0 +1,93 @@
+package apicore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// ebirdTestSettings builds a minimal settings snapshot with the eBird section
+// configured as requested. CacheTTL is fixed so it does not influence results.
+func ebirdTestSettings(enabled bool, apiKey string) *conf.Settings {
+	s := &conf.Settings{}
+	s.Realtime.EBird.Enabled = enabled
+	s.Realtime.EBird.APIKey = apiKey
+	s.Realtime.EBird.CacheTTL = 24
+	return s
+}
+
+// TestBuildEBirdClient covers the three construction outcomes: disabled and
+// misconfigured both yield nil (eBird stays unavailable), while an enabled
+// integration with an API key yields a client.
+func TestBuildEBirdClient(t *testing.T) {
+	t.Parallel()
+	c := &Core{}
+	tests := []struct {
+		name     string
+		settings *conf.Settings
+		wantNil  bool
+	}{
+		{"disabled returns nil", ebirdTestSettings(false, "test-api-key"), true},
+		{"enabled without api key returns nil", ebirdTestSettings(true, ""), true},
+		{"enabled with api key returns client", ebirdTestSettings(true, "test-api-key"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := c.buildEBirdClient(tt.settings)
+			if tt.wantNil {
+				assert.Nil(t, got)
+			} else {
+				assert.NotNil(t, got)
+			}
+		})
+	}
+}
+
+// TestCoreEBirdAccessor verifies the atomic accessor: nil on a zero-value Core,
+// returns the stored client, and reflects a stored nil.
+func TestCoreEBirdAccessor(t *testing.T) {
+	t.Parallel()
+	c := &Core{}
+	assert.Nil(t, c.EBird(), "EBird() must be nil on a zero-value Core")
+
+	client := c.buildEBirdClient(ebirdTestSettings(true, "test-api-key"))
+	require.NotNil(t, client)
+	c.eBirdClient.Store(client)
+	assert.Same(t, client, c.EBird(), "EBird() must return the stored client")
+
+	c.eBirdClient.Store(nil)
+	assert.Nil(t, c.EBird(), "EBird() must be nil after storing nil")
+}
+
+// TestReconfigureEBird exercises the live-reconfigure path end to end against the
+// global settings singleton: enabling builds a client, changing the key rebuilds
+// it, and disabling clears it. This is the behaviour that makes eBird settings
+// take effect without a restart (issue #4102).
+func TestReconfigureEBird(t *testing.T) {
+	// Not parallel: mutates the global conf singleton via conf.StoreSettings.
+	orig := conf.Setting()
+	t.Cleanup(func() { conf.StoreSettings(orig) })
+
+	c := &Core{}
+
+	// Enabling eBird with a key makes the client available live. ReconfigureEBird
+	// returns the newly built client, which must be the one EBird() then serves.
+	conf.StoreSettings(ebirdTestSettings(true, "test-api-key"))
+	first := c.ReconfigureEBird()
+	require.NotNil(t, first, "eBird client must be built after enabling with a key")
+	assert.Same(t, first, c.EBird(), "ReconfigureEBird must store the client it returns")
+
+	// Changing the API key rebuilds the client as a new instance.
+	conf.StoreSettings(ebirdTestSettings(true, "different-key"))
+	second := c.ReconfigureEBird()
+	require.NotNil(t, second)
+	assert.NotSame(t, first, second, "changing eBird settings must rebuild the client")
+
+	// Disabling clears the client and returns nil.
+	conf.StoreSettings(ebirdTestSettings(false, ""))
+	assert.Nil(t, c.ReconfigureEBird(), "disabling eBird must return nil")
+	assert.Nil(t, c.EBird(), "disabling eBird must clear the client")
+}

--- a/internal/api/v2/apicore/ebird_test.go
+++ b/internal/api/v2/apicore/ebird_test.go
@@ -68,7 +68,9 @@ func TestCoreEBirdAccessor(t *testing.T) {
 // take effect without a restart (issue #4102).
 func TestReconfigureEBird(t *testing.T) {
 	// Not parallel: mutates the global conf singleton via conf.StoreSettings.
-	orig := conf.Setting()
+	// Snapshot with GetSettings (reads the published pointer) rather than Setting
+	// (which can lazily load from disk and add I/O and log noise to a unit test).
+	orig := conf.GetSettings()
 	t.Cleanup(func() { conf.StoreSettings(orig) })
 
 	c := &Core{}

--- a/internal/api/v2/hotreload_coverage_test.go
+++ b/internal/api/v2/hotreload_coverage_test.go
@@ -180,7 +180,7 @@ var hotReloadRegistry = map[string]hotReloadEntry{
 	"Realtime.Birdweather": {categories: []hotReloadCategory{hotReloadFresh}, action: "reconfigure_birdweather"},
 
 	// -- eBird --
-	"Realtime.EBird": {categories: []hotReloadCategory{hotReloadFresh}},
+	"Realtime.EBird": {categories: []hotReloadCategory{hotReloadFresh}, action: "reconfigure_ebird"},
 
 	// -- OpenWeather (runtime, yaml:"-") --
 	"Realtime.OpenWeather": {categories: []hotReloadCategory{hotReloadRuntime}},

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -2494,6 +2494,7 @@ var settingsChangeChecks = []settingsChangeCheck{
 	{"Dynamic thresholds", "reconfigure_dynamic_thresholds", dynamicThresholdEnabledChanged, "Reconfiguring dynamic thresholds...", notification.MsgSettingsReconfiguringDynamicThresholds, ToastTypeInfo, toastDurationMedium},
 	{"MQTT", "reconfigure_mqtt", mqttSettingsChanged, "Reconfiguring MQTT connection...", notification.MsgSettingsReconfiguringMqtt, ToastTypeInfo, toastDurationMedium},
 	{"BirdWeather", "reconfigure_birdweather", birdWeatherSettingsChanged, "Reconfiguring BirdWeather integration...", notification.MsgSettingsReconfiguringBirdweather, ToastTypeInfo, toastDurationMedium},
+	{"eBird", "reconfigure_ebird", ebirdSettingsChanged, "Reconfiguring eBird integration...", notification.MsgSettingsReconfiguringEbird, ToastTypeInfo, toastDurationMedium},
 	{"Streams", "reconfigure_rtsp_sources", streamsSettingsChanged, "Reconfiguring audio streams...", notification.MsgSettingsReconfiguringStreams, ToastTypeInfo, toastDurationMedium},
 	{"Telemetry", "reconfigure_telemetry", telemetrySettingsChanged, "Reconfiguring telemetry settings...", notification.MsgSettingsReconfiguringTelemetry, ToastTypeInfo, toastDurationShort},
 	{"Species tracking", "reconfigure_species_tracking", speciesTrackingSettingsChanged, "Reconfiguring species tracking...", notification.MsgSettingsReconfiguringSpeciesTracking, ToastTypeInfo, toastDurationShort},
@@ -2864,6 +2865,14 @@ func birdWeatherSettingsChanged(oldSettings, currentSettings *conf.Settings) boo
 	}
 
 	return false
+}
+
+// ebirdSettingsChanged reports whether any eBird setting changed. The eBird API
+// client is rebuilt live from these settings (apicore.Core.ReconfigureEBird via
+// the reconfigure_ebird control action), so a change triggers a live reconfigure
+// rather than a restart prompt.
+func ebirdSettingsChanged(oldSettings, currentSettings *conf.Settings) bool {
+	return !reflect.DeepEqual(oldSettings.Realtime.EBird, currentSettings.Realtime.EBird)
 }
 
 // pushNotificationSettingsChanged checks if push notification settings have changed.

--- a/internal/api/v2/settings_ebird_test.go
+++ b/internal/api/v2/settings_ebird_test.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// TestEbirdSettingsChanged verifies the eBird change detector. eBird hot-reloads
+// (registry category `fresh`, reconfigure_ebird action), so any change to the
+// section must be detected to trigger a live reconfigure, and identical settings
+// must report no change so an unrelated save does not needlessly rebuild the client.
+func TestEbirdSettingsChanged(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		mutate  func(s *conf.Settings)
+		changed bool
+	}{
+		{
+			name:    "enabled toggle is a change",
+			mutate:  func(s *conf.Settings) { s.Realtime.EBird.Enabled = !s.Realtime.EBird.Enabled },
+			changed: true,
+		},
+		{
+			name:    "api key change is a change",
+			mutate:  func(s *conf.Settings) { s.Realtime.EBird.APIKey = "ebird-key-changed-xyz" },
+			changed: true,
+		},
+		{
+			name:    "cache ttl change is a change",
+			mutate:  func(s *conf.Settings) { s.Realtime.EBird.CacheTTL += 12 },
+			changed: true,
+		},
+		{
+			name:    "unrelated field is not an eBird change",
+			mutate:  func(s *conf.Settings) { s.Realtime.Birdweather.ID = "somethingelse" },
+			changed: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			base := apitest.NewValidTestSettings()
+			updated := conf.CloneSettings(base)
+			tt.mutate(updated)
+
+			assert.Equal(t, tt.changed, ebirdSettingsChanged(base, updated),
+				"detector result mismatch for %q", tt.name)
+			assert.False(t, ebirdSettingsChanged(base, conf.CloneSettings(base)),
+				"detector reported a change for identical settings in %q", tt.name)
+		})
+	}
+}

--- a/internal/api/v2/species/species.go
+++ b/internal/api/v2/species/species.go
@@ -135,13 +135,17 @@ type taxonomyLookupResult struct {
 // under both, 56 only under the current name and 27 only under the legacy one. Trying
 // one name alone therefore drops the taxonomy block for a knowable species.
 func (c *Handler) lookupTaxonomyEitherName(ctx context.Context, primary, secondary string) *taxonomyLookupResult {
-	if result := c.lookupTaxonomyTree(ctx, primary); result != nil {
+	// Load the eBird client once so both name attempts use the same snapshot; it can
+	// be swapped concurrently by a settings hot-reload (ReconfigureEBird), and a
+	// per-call reload could otherwise make the second attempt use a different client.
+	client := c.EBird()
+	if result := c.lookupTaxonomyTree(ctx, client, primary); result != nil {
 		return result
 	}
 	if strings.EqualFold(primary, secondary) {
 		return nil
 	}
-	return c.lookupTaxonomyTree(ctx, secondary)
+	return c.lookupTaxonomyTree(ctx, client, secondary)
 }
 
 // resolveEitherName localizes a common name under whichever of the two scientific names
@@ -159,7 +163,7 @@ func (c *Handler) resolveEitherName(bn *classifier.Orchestrator, primary, second
 
 // lookupTaxonomyTree attempts to find taxonomy for a species, trying local DB first then eBird.
 // Returns nil result (not error) if taxonomy is unavailable from both sources.
-func (c *Handler) lookupTaxonomyTree(ctx context.Context, scientificName string) *taxonomyLookupResult {
+func (c *Handler) lookupTaxonomyTree(ctx context.Context, client *ebird.Client, scientificName string) *taxonomyLookupResult {
 	// Try local taxonomy database first (fast, no network)
 	if c.TaxonomyDB != nil {
 		tree, err := c.TaxonomyDB.BuildFamilyTree(scientificName)
@@ -170,9 +174,8 @@ func (c *Handler) lookupTaxonomyTree(ctx context.Context, scientificName string)
 		c.Debug("Local taxonomy lookup failed for %s: %v, falling back to eBird API", scientificName, err)
 	}
 
-	// Fall back to eBird API. Load the client once; it may be swapped concurrently
-	// by a settings hot-reload (ReconfigureEBird).
-	if client := c.EBird(); client != nil {
+	// Fall back to eBird API using the client snapshot the caller loaded.
+	if client != nil {
 		tree, err := client.BuildFamilyTree(ctx, scientificName)
 		if err != nil {
 			c.Debug("Failed to get taxonomy info from eBird for species %s: %v", scientificName, err)

--- a/internal/api/v2/species/species.go
+++ b/internal/api/v2/species/species.go
@@ -2,7 +2,7 @@
 // /api/v2/species/* and /api/v2/taxonomy/* endpoints (species info, rarity, the
 // all-species picker list, the species dictionary, thumbnails, and genus/family/
 // tree taxonomy lookups). The Handler embeds *apicore.Core by pointer so the
-// shared dependencies and helpers (Processor, TaxonomyDB, EBirdClient,
+// shared dependencies and helpers (Processor, TaxonomyDB, the EBird() accessor,
 // BirdImageCache, CurrentLocale, HandleError, the logging helpers) promote onto
 // it; the facade constructs one Handler and calls RegisterRoutes to wire the
 // routes in their existing order.
@@ -170,9 +170,10 @@ func (c *Handler) lookupTaxonomyTree(ctx context.Context, scientificName string)
 		c.Debug("Local taxonomy lookup failed for %s: %v, falling back to eBird API", scientificName, err)
 	}
 
-	// Fall back to eBird API
-	if c.EBirdClient != nil {
-		tree, err := c.EBirdClient.BuildFamilyTree(ctx, scientificName)
+	// Fall back to eBird API. Load the client once; it may be swapped concurrently
+	// by a settings hot-reload (ReconfigureEBird).
+	if client := c.EBird(); client != nil {
+		tree, err := client.BuildFamilyTree(ctx, scientificName)
 		if err != nil {
 			c.Debug("Failed to get taxonomy info from eBird for species %s: %v", scientificName, err)
 			return nil
@@ -652,14 +653,20 @@ func (c *Handler) GetSpeciesTaxonomy(ctx echo.Context) error {
 // getDetailedTaxonomy retrieves detailed taxonomy information
 // Tries local database first, falls back to eBird API if needed
 func (c *Handler) getDetailedTaxonomy(ctx context.Context, scientificName, locale string, includeSubspecies, includeHierarchy bool) (*TaxonomyInfo, error) {
+	// Load the eBird client once for the whole request and thread it through the
+	// helpers below. The client can be swapped concurrently by a settings
+	// hot-reload (ReconfigureEBird); re-reading it in each helper would risk a
+	// nil-after-check TOCTOU across method boundaries.
+	client := c.EBird()
+
 	// Try local taxonomy database first
-	if info := c.tryLocalTaxonomy(ctx, scientificName, locale, includeSubspecies, includeHierarchy); info != nil {
+	if info := c.tryLocalTaxonomy(ctx, client, scientificName, locale, includeSubspecies, includeHierarchy); info != nil {
 		return info, nil
 	}
 
 	// Fall back to eBird API
-	if c.EBirdClient != nil {
-		return c.getEBirdTaxonomy(ctx, scientificName, locale, includeSubspecies)
+	if client != nil {
+		return c.getEBirdTaxonomy(ctx, client, scientificName, locale, includeSubspecies)
 	}
 
 	// Neither local DB nor eBird API available
@@ -673,7 +680,7 @@ func (c *Handler) getDetailedTaxonomy(ctx context.Context, scientificName, local
 
 // tryLocalTaxonomy attempts to retrieve taxonomy from the local database.
 // Returns nil if local DB is unavailable or lookup fails.
-func (c *Handler) tryLocalTaxonomy(ctx context.Context, scientificName, locale string, includeSubspecies, includeHierarchy bool) *TaxonomyInfo {
+func (c *Handler) tryLocalTaxonomy(ctx context.Context, client *ebird.Client, scientificName, locale string, includeSubspecies, includeHierarchy bool) *TaxonomyInfo {
 	if c.TaxonomyDB == nil {
 		return nil
 	}
@@ -698,7 +705,7 @@ func (c *Handler) tryLocalTaxonomy(ctx context.Context, scientificName, locale s
 	}
 
 	// Enhance with eBird data if needed
-	c.enhanceWithEBirdData(ctx, info, scientificName, locale, includeSubspecies)
+	c.enhanceWithEBirdData(ctx, client, info, scientificName, locale, includeSubspecies)
 
 	return info
 }
@@ -719,13 +726,13 @@ func convertToTaxonomyHierarchy(tree *ebird.TaxonomyTree) TaxonomyHierarchy {
 }
 
 // enhanceWithEBirdData adds subspecies and locale data from eBird API to local taxonomy info.
-func (c *Handler) enhanceWithEBirdData(ctx context.Context, info *TaxonomyInfo, scientificName, locale string, includeSubspecies bool) {
-	if c.EBirdClient == nil || (!includeSubspecies && locale == "") {
+func (c *Handler) enhanceWithEBirdData(ctx context.Context, client *ebird.Client, info *TaxonomyInfo, scientificName, locale string, includeSubspecies bool) {
+	if client == nil || (!includeSubspecies && locale == "") {
 		return
 	}
 
 	c.Debug("Enhancing local taxonomy data with eBird API for subspecies/locale")
-	ebirdInfo, err := c.getEBirdTaxonomy(ctx, scientificName, locale, includeSubspecies)
+	ebirdInfo, err := c.getEBirdTaxonomy(ctx, client, scientificName, locale, includeSubspecies)
 	if err != nil {
 		return
 	}
@@ -743,9 +750,9 @@ func (c *Handler) enhanceWithEBirdData(ctx context.Context, info *TaxonomyInfo, 
 }
 
 // getEBirdTaxonomy retrieves taxonomy information from eBird API
-func (c *Handler) getEBirdTaxonomy(ctx context.Context, scientificName, locale string, includeSubspecies bool) (*TaxonomyInfo, error) {
+func (c *Handler) getEBirdTaxonomy(ctx context.Context, client *ebird.Client, scientificName, locale string, includeSubspecies bool) (*TaxonomyInfo, error) {
 	// Get full taxonomy data with locale if specified
-	taxonomyData, err := c.EBirdClient.GetTaxonomy(ctx, locale)
+	taxonomyData, err := client.GetTaxonomy(ctx, locale)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/v2/species/taxonomy_test.go
+++ b/internal/api/v2/species/taxonomy_test.go
@@ -306,7 +306,7 @@ func TestGetSpeciesTaxonomyLocalDB(t *testing.T) {
 	taxonomyDB, err := classifier.LoadTaxonomyDatabase()
 	require.NoError(t, err, "Failed to load taxonomy database")
 
-	c := &Handler{Core: &apicore.Core{TaxonomyDB: taxonomyDB, EBirdClient: nil}}
+	c := &Handler{Core: &apicore.Core{TaxonomyDB: taxonomyDB}}
 	c.Settings.Store(apitest.NewValidTestSettings())
 
 	tests := []struct {
@@ -359,7 +359,7 @@ func TestGetSpeciesTaxonomyLocalDB(t *testing.T) {
 func TestGetSpeciesTaxonomyWithoutLocalDB(t *testing.T) {
 	t.Parallel()
 
-	c := &Handler{Core: &apicore.Core{TaxonomyDB: nil, EBirdClient: nil}}
+	c := &Handler{Core: &apicore.Core{TaxonomyDB: nil}}
 	c.Settings.Store(apitest.NewValidTestSettings())
 
 	// This should fail gracefully

--- a/internal/notification/message_keys.go
+++ b/internal/notification/message_keys.go
@@ -35,6 +35,7 @@ const (
 	MsgSettingsUpdatingIntervals              = "notifications.content.settings.updatingIntervals"
 	MsgSettingsReconfiguringMqtt              = "notifications.content.settings.reconfiguringMqtt"
 	MsgSettingsReconfiguringBirdweather       = "notifications.content.settings.reconfiguringBirdweather"
+	MsgSettingsReconfiguringEbird             = "notifications.content.settings.reconfiguringEbird"
 	MsgSettingsReconfiguringStreams           = "notifications.content.settings.reconfiguringStreams"
 	MsgSettingsReconfiguringTelemetry         = "notifications.content.settings.reconfiguringTelemetry"
 	MsgSettingsReconfiguringSpeciesTracking   = "notifications.content.settings.reconfiguringSpeciesTracking"


### PR DESCRIPTION
Fixes #4102.

Enabling eBird in the UI (API key + enabled) did nothing until a full restart, because the eBird API client was built once at startup and never rebuilt. The taxonomy fallback added in #4099 then failed with "taxonomy data not available" while the client stayed nil. The hot-reload registry already declared `Realtime.EBird` as `hotReloadFresh`, so the code was out of step with its own contract.

This wires eBird into the same live-reconfigure path that MQTT and BirdWeather already use, so the setting takes effect immediately without a restart.

## What changed

- The eBird client now lives in an `atomic.Pointer` on `apicore.Core`. Request handlers read it once via `EBird()` and thread that pointer through the taxonomy helpers, so a concurrent reconfigure cannot cause a nil-after-check between a `!= nil` guard and a later use.
- A new `ebirdSettingsChanged` detector plus a `reconfigure_ebird` entry in `settingsChangeChecks` dispatches to the control monitor, which rebuilds the client live via `Core.ReconfigureEBird` (reads settings live, atomic swap).
- The old client is intentionally not `Close()`d on swap. `Close()` stops the rate-limiter ticker, and `doRequest` blocks on a bare receive from that ticker under a mutex, so stopping it under an in-flight request would hang that request (and every other caller waiting on the mutex) forever. In-flight requests keep their loaded pointer; once the last reference drops, the orphaned ticker is garbage-collected on Go 1.23+.
- The reconfigure reports the actual outcome (configured, disabled, or enabled-but-misconfigured) instead of a blanket success, matching `handleReconfigureBirdWeather`. Enabling eBird without an API key surfaces the existing missing-key notification and no longer also reports success.
- Adds the `reconfiguringEbird` toast key across all locales.

## Testing

- New unit tests for `buildEBirdClient` (disabled / missing-key / enabled), the atomic accessor, `ReconfigureEBird` (enable rebuilds, key change swaps to a new instance, disable clears), the `ebirdSettingsChanged` detector, and the nil-controller guard.
- `go test -race` on the touched packages, `golangci-lint` (0 issues), `gofmt`, and the i18n sync/type checks all pass locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * eBird integration settings can now be updated without restarting the application.
  * The app detects changes to eBird enablement, API credentials, and cache settings, then refreshes the integration automatically.
  * Added a notification indicating when eBird integration is being updated.

* **Localization**
  * Added the update notification across supported languages.

* **Bug Fixes**
  * Improved stability during eBird updates, including safer handling when the integration is unavailable or still processing requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->