### PR TITLE
chore(deps): bump undici and fast-uri overrides to patched versions

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4812,9 +4812,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -8553,9 +8553,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -146,8 +146,8 @@
   "overrides": {
     "flatted": "3.4.2",
     "lru-cache": "11.2.7",
-    "undici": "7.28.0",
+    "undici": "7.29.0",
     "esrap": "2.2.11",
-    "fast-uri": "3.1.4"
+    "fast-uri": "3.1.5"
   }
 }


### PR DESCRIPTION
## Summary

Resolves pre-existing Dependabot security alerts on two dev-scope transitive dependencies that our own `package.json` `overrides` block was pinning below the patched versions.

- `undici` 7.28.0 -> 7.29.0 (High plus medium advisories, vulnerable `>= 7.0.0, < 7.29.0`; pulled in by jsdom in the test environment)
- `fast-uri` 3.1.4 -> 3.1.5 (High advisory, vulnerable `>= 3.0.0, < 3.1.5`; pulled in by ajv via stylelint)

Both are same-major bumps that satisfy the parents' existing ranges. `npm update` could not reach them because the overrides pin exact versions, so the fix is to bump the override values themselves. `npm install` now reports 0 vulnerabilities. These are development/build-time dependencies, not shipped to users.

## Test plan

- [x] `npm install` reports 0 vulnerabilities
- [x] Frontend `check:all` (lint, typecheck 0 errors, ast-grep scans)
- [x] 2707 unit tests pass
- [x] Production build passes