### PR TITLE
feat(models): variant selection and switching in the model gallery

### DIFF
--- a/internal/api/v2/models/models.go
+++ b/internal/api/v2/models/models.go
@@ -11,6 +11,7 @@ package models
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"sort"
 	"strings"
@@ -20,6 +21,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/inference"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
@@ -295,17 +297,18 @@ func (c *Handler) InstallModel(ctx echo.Context) error {
 		return c.HandleError(ctx, nil, "model manager is not available", http.StatusServiceUnavailable)
 	}
 
-	// Parse the optional variant selection from the request body. Bind only when a
-	// body was actually sent: an absent body (the default no-variant call) installs
-	// the default variant and preserves the pre-variant call shape, whereas binding
-	// an empty body under a JSON content-type would 400. A present body naming a
-	// variant this entry does not offer is rejected up front so the client sees a
-	// 400 rather than a silent async failure over the progress stream.
+	// Parse the optional variant selection from the request body. The body is
+	// optional: an absent or empty body installs the default variant, preserving
+	// the pre-variant call shape, so an empty-body io.EOF is tolerated. Decoding the
+	// body directly (rather than ctx.Bind, which 400s an empty body under a JSON
+	// content-type, and rather than gating on ContentLength, which is -1 for chunked
+	// requests) keeps that contract robust while still binding a real chunked body.
+	// Malformed JSON is a 400 so the client sees the error synchronously rather than
+	// as a silent async failure over the progress stream. The body reader is bounded
+	// by the server's body-limit middleware.
 	var req installModelRequest
-	if ctx.Request().ContentLength != 0 {
-		if err := ctx.Bind(&req); err != nil {
-			return c.HandleError(ctx, err, "invalid request body", http.StatusBadRequest)
-		}
+	if err := json.NewDecoder(ctx.Request().Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		return c.HandleError(ctx, err, "invalid request body", http.StatusBadRequest)
 	}
 	if !classifier.VariantSelectable(&entry, req.VariantID) {
 		return c.HandleError(ctx, nil, "unknown variant "+req.VariantID+" for model "+catalogID, http.StatusBadRequest)

--- a/internal/api/v2/models/models.go
+++ b/internal/api/v2/models/models.go
@@ -78,6 +78,31 @@ type CatalogEntryResponse struct {
 	IncompatibleReason string `json:"incompatibleReason,omitempty"`
 	TotalSizeBytes     int64  `json:"totalSizeBytes"`
 	HasGeomodel        bool   `json:"hasGeomodel"`
+	// InstalledVariantID is the id of the currently installed variant, or "" when
+	// the model is not installed or is a flat (pre-variant) entry.
+	InstalledVariantID string `json:"installedVariantId,omitempty"`
+	// Variants lists the selectable hardware/regional variants of this model,
+	// omitted for flat single-variant entries.
+	Variants []CatalogVariantResponse `json:"variants,omitempty"`
+}
+
+// CatalogVariantResponse describes one selectable hardware or regional variant of
+// a catalog entry for the gallery UI.
+type CatalogVariantResponse struct {
+	ID                string `json:"id"`
+	Region            string `json:"region,omitempty"`
+	Precision         string `json:"precision,omitempty"`
+	SpeciesCount      int    `json:"speciesCount"`
+	Default           bool   `json:"default"`
+	Installed         bool   `json:"installed"`
+	SizeBytes         int64  `json:"sizeBytes"`
+	HeadlineLatencyMs int    `json:"headlineLatencyMs,omitempty"`
+}
+
+// installModelRequest is the optional JSON body of POST /models/install/:id. An
+// absent body or empty variantId installs (or switches to) the default variant.
+type installModelRequest struct {
+	VariantID string `json:"variantId"`
 }
 
 // ListModels returns classifier models that are enabled in the configuration.
@@ -147,10 +172,14 @@ func (c *Handler) GetModelCatalog(ctx echo.Context) error {
 			totalSize += f.SizeBytes
 		}
 
-		// Check install status via ModelManager.
+		// Check install status via ModelManager, capturing which variant is on disk.
 		installed := false
+		installedVariantID := ""
 		if c.ModelManager != nil {
-			installed = c.ModelManager.IsInstalled(entry.ID)
+			if vid, ok := c.ModelManager.InstalledVariantID(entry.ID); ok {
+				installed = true
+				installedVariantID = vid
+			}
 		}
 
 		// Models requiring ONNX Runtime are incompatible when ORT is absent.
@@ -178,12 +207,58 @@ func (c *Handler) GetModelCatalog(ctx echo.Context) error {
 			IncompatibleReason: incompatibleReason,
 			TotalSizeBytes:     totalSize,
 			HasGeomodel:        classifier.HasGeomodelFiles(entry),
+			InstalledVariantID: installedVariantID,
+			Variants:           buildVariantResponses(entry, installed, installedVariantID),
 		})
 	}
 
 	return ctx.JSON(http.StatusOK, map[string]any{
 		"catalog": catalog,
 	})
+}
+
+// buildVariantResponses maps a catalog entry's variants to their API form. It
+// returns nil for a flat (single-variant) entry so the field is omitted. A Legacy
+// variant (a superseded build) is hidden unless it is the one currently installed,
+// so the gallery never offers a fresh install of a deprecated build.
+func buildVariantResponses(entry *classifier.CatalogEntry, installed bool, installedVariantID string) []CatalogVariantResponse {
+	if len(entry.Variants) == 0 {
+		return nil
+	}
+	variants := make([]CatalogVariantResponse, 0, len(entry.Variants))
+	for j := range entry.Variants {
+		v := &entry.Variants[j]
+		isInstalledVariant := installed && installedVariantID == v.ID
+		if v.Legacy && !isInstalledVariant {
+			continue
+		}
+
+		var sizeBytes int64
+		for _, f := range v.Files {
+			sizeBytes += f.SizeBytes
+		}
+
+		// Headline latency: the smallest positive measured latency across this
+		// variant's benchmarks, or 0 when none were measured.
+		headlineLatencyMs := 0
+		for _, b := range v.Benchmarks {
+			if b.LatencyMs > 0 && (headlineLatencyMs == 0 || b.LatencyMs < headlineLatencyMs) {
+				headlineLatencyMs = b.LatencyMs
+			}
+		}
+
+		variants = append(variants, CatalogVariantResponse{
+			ID:                v.ID,
+			Region:            v.Region,
+			Precision:         v.Precision,
+			SpeciesCount:      v.SpeciesCount,
+			Default:           v.Default,
+			Installed:         isInstalledVariant,
+			SizeBytes:         sizeBytes,
+			HeadlineLatencyMs: headlineLatencyMs,
+		})
+	}
+	return variants
 }
 
 // GetInstalledModels returns all models that have been downloaded and installed.
@@ -220,6 +295,19 @@ func (c *Handler) InstallModel(ctx echo.Context) error {
 		return c.HandleError(ctx, nil, "model manager is not available", http.StatusServiceUnavailable)
 	}
 
+	// Parse the optional variant selection from the request body. An absent body
+	// or empty variantId installs (or switches to) the default variant, preserving
+	// the pre-variant call shape. A body naming a variant this entry does not offer
+	// is rejected up front so the client sees a 400 rather than a silent async
+	// failure over the progress stream.
+	var req installModelRequest
+	if err := ctx.Bind(&req); err != nil {
+		return c.HandleError(ctx, err, "invalid request body", http.StatusBadRequest)
+	}
+	if !classifier.VariantSelectable(&entry, req.VariantID) {
+		return c.HandleError(ctx, nil, "unknown variant "+req.VariantID+" for model "+catalogID, http.StatusBadRequest)
+	}
+
 	// Reject installation of ONNX-dependent models when ORT is unavailable.
 	if entry.RequiresONNX {
 		ortStatus := inference.CheckORTAvailability(c.CurrentSettings().BirdNET.ONNXRuntimePath)
@@ -241,9 +329,10 @@ func (c *Handler) InstallModel(ctx echo.Context) error {
 				)
 			}
 		}()
-		if err := c.ModelManager.Install(c.Context(), &entry, "", "", progressChan); err != nil {
+		if err := c.ModelManager.InstallOrReplace(c.Context(), &entry, req.VariantID, "", progressChan); err != nil {
 			c.LogErrorIfEnabled("Model install failed",
 				logger.String("catalog_id", catalogID),
+				logger.String("variant_id", req.VariantID),
 				logger.Error(err),
 			)
 		}
@@ -255,6 +344,7 @@ func (c *Handler) InstallModel(ctx echo.Context) error {
 
 	return ctx.JSON(http.StatusAccepted, map[string]string{
 		"catalogId": catalogID,
+		"variantId": req.VariantID,
 		"status":    classifier.StatusDownloading,
 	})
 }

--- a/internal/api/v2/models/models.go
+++ b/internal/api/v2/models/models.go
@@ -295,14 +295,17 @@ func (c *Handler) InstallModel(ctx echo.Context) error {
 		return c.HandleError(ctx, nil, "model manager is not available", http.StatusServiceUnavailable)
 	}
 
-	// Parse the optional variant selection from the request body. An absent body
-	// or empty variantId installs (or switches to) the default variant, preserving
-	// the pre-variant call shape. A body naming a variant this entry does not offer
-	// is rejected up front so the client sees a 400 rather than a silent async
-	// failure over the progress stream.
+	// Parse the optional variant selection from the request body. Bind only when a
+	// body was actually sent: an absent body (the default no-variant call) installs
+	// the default variant and preserves the pre-variant call shape, whereas binding
+	// an empty body under a JSON content-type would 400. A present body naming a
+	// variant this entry does not offer is rejected up front so the client sees a
+	// 400 rather than a silent async failure over the progress stream.
 	var req installModelRequest
-	if err := ctx.Bind(&req); err != nil {
-		return c.HandleError(ctx, err, "invalid request body", http.StatusBadRequest)
+	if ctx.Request().ContentLength != 0 {
+		if err := ctx.Bind(&req); err != nil {
+			return c.HandleError(ctx, err, "invalid request body", http.StatusBadRequest)
+		}
 	}
 	if !classifier.VariantSelectable(&entry, req.VariantID) {
 		return c.HandleError(ctx, nil, "unknown variant "+req.VariantID+" for model "+catalogID, http.StatusBadRequest)

--- a/internal/api/v2/models/models_variants_test.go
+++ b/internal/api/v2/models/models_variants_test.go
@@ -1,0 +1,121 @@
+package models
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
+	"github.com/tphakala/birdnet-go/internal/classifier"
+)
+
+// TestGetModelCatalog_EmitsVariants verifies the catalog response exposes the
+// nested variants[] for a multi-variant entry (Perch v2), with sizes and a single
+// default variant.
+func TestGetModelCatalog_EmitsVariants(t *testing.T) {
+	core := apitest.NewCore(t)
+	h := New(core)
+	e := echo.New()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/models/catalog", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	require.NoError(t, h.GetModelCatalog(ctx))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Catalog []CatalogEntryResponse `json:"catalog"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	var perch *CatalogEntryResponse
+	for i := range resp.Catalog {
+		if resp.Catalog[i].ID == "perch-v2" {
+			perch = &resp.Catalog[i]
+			break
+		}
+	}
+	require.NotNil(t, perch, "perch-v2 must be present in the visible catalog")
+	require.Len(t, perch.Variants, 3, "perch-v2 must expose all three global variants")
+
+	byID := make(map[string]CatalogVariantResponse, len(perch.Variants))
+	defaults := 0
+	for _, v := range perch.Variants {
+		byID[v.ID] = v
+		if v.Default {
+			defaults++
+		}
+		assert.Positive(t, v.SizeBytes, "variant %s must report a size", v.ID)
+	}
+	assert.Contains(t, byID, "fp32")
+	assert.Contains(t, byID, "int8-arm")
+	assert.True(t, byID["fp32"].Default, "fp32 must be the default variant")
+	assert.Equal(t, 1, defaults, "exactly one variant may be the default")
+}
+
+// TestInstallModel_RejectsUnknownVariant verifies the install handler rejects a
+// variant the entry does not offer with 400, synchronously, before any download.
+func TestInstallModel_RejectsUnknownVariant(t *testing.T) {
+	core := apitest.NewCore(t)
+	core.ModelManager = classifier.NewModelManager(t.TempDir(), nil, nil)
+	h := New(core)
+	e := echo.New()
+
+	body := strings.NewReader(`{"variantId":"does-not-exist"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/models/install/perch-v2", body)
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("id")
+	ctx.SetParamValues("perch-v2")
+
+	require.NoError(t, h.InstallModel(ctx))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "unknown variant")
+}
+
+// TestBuildVariantResponses_LegacyHiddenUnlessInstalled verifies a superseded
+// (Legacy) variant is hidden from the gallery unless it is the installed one, and
+// that the Installed flag is set for the on-disk variant.
+func TestBuildVariantResponses_LegacyHiddenUnlessInstalled(t *testing.T) {
+	entry := &classifier.CatalogEntry{
+		ID: "x",
+		Variants: []classifier.CatalogVariant{
+			{ID: "cur", Default: true, Files: []classifier.CatalogFile{{LocalName: "cur.onnx", Role: classifier.RoleModel, SizeBytes: 10}}},
+			{ID: "old", Legacy: true, Files: []classifier.CatalogFile{{LocalName: "old.onnx", Role: classifier.RoleModel, SizeBytes: 5}}},
+		},
+	}
+
+	ids := func(vs []CatalogVariantResponse) []string {
+		out := make([]string, 0, len(vs))
+		for _, v := range vs {
+			out = append(out, v.ID)
+		}
+		return out
+	}
+
+	// Not installed: the legacy variant is hidden, none is marked installed.
+	notInstalled := buildVariantResponses(entry, false, "")
+	assert.Contains(t, ids(notInstalled), "cur")
+	assert.NotContains(t, ids(notInstalled), "old", "a legacy variant is hidden when not installed")
+	for _, v := range notInstalled {
+		assert.False(t, v.Installed)
+	}
+
+	// The legacy variant is the installed one: it stays visible and is flagged.
+	withLegacy := buildVariantResponses(entry, true, "old")
+	assert.Contains(t, ids(withLegacy), "old", "a legacy variant stays visible when it is installed")
+	for _, v := range withLegacy {
+		switch v.ID {
+		case "old":
+			assert.True(t, v.Installed, "the installed legacy variant must be flagged installed")
+		case "cur":
+			assert.False(t, v.Installed)
+		}
+	}
+}

--- a/internal/api/v2/models/models_variants_test.go
+++ b/internal/api/v2/models/models_variants_test.go
@@ -79,6 +79,28 @@ func TestInstallModel_RejectsUnknownVariant(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "unknown variant")
 }
 
+// TestInstallModel_RejectsMalformedBody verifies a malformed JSON body is
+// rejected with 400 (an empty body, by contrast, is tolerated and installs the
+// default variant).
+func TestInstallModel_RejectsMalformedBody(t *testing.T) {
+	core := apitest.NewCore(t)
+	core.ModelManager = classifier.NewModelManager(t.TempDir(), nil, nil)
+	h := New(core)
+	e := echo.New()
+
+	body := strings.NewReader(`{"variantId":`) // truncated JSON
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/models/install/perch-v2", body)
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("id")
+	ctx.SetParamValues("perch-v2")
+
+	require.NoError(t, h.InstallModel(ctx))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "invalid request body")
+}
+
 // TestBuildVariantResponses_LegacyHiddenUnlessInstalled verifies a superseded
 // (Legacy) variant is hidden from the gallery unless it is the installed one, and
 // that the Installed flag is set for the on-disk variant.

--- a/internal/classifier/model_catalog.go
+++ b/internal/classifier/model_catalog.go
@@ -665,6 +665,15 @@ func variantFilesByID(entry *CatalogEntry, variantID string) (files []CatalogFil
 	return nil, false
 }
 
+// VariantSelectable reports whether variantID names a valid selectable variant of
+// entry. An empty variantID (meaning the default variant) is always valid. It is
+// the exported form of the internal variant lookup, for API-layer validation of a
+// requested variant before an install/switch is dispatched.
+func VariantSelectable(entry *CatalogEntry, variantID string) bool {
+	_, ok := variantFilesByID(entry, variantID)
+	return ok
+}
+
 // resolveVariantDefaults returns entries with each variant entry's Files
 // populated from its default variant, so every Files consumer sees the effective
 // default variant's files. Single-variant entries (no Variants) are returned

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -160,15 +160,34 @@ func (mm *ModelManager) ScanInstalled() {
 	// before taking mm.mu; ActiveCatalog acquires its own lock.
 	catalog := ActiveCatalog()
 
+	// Snapshot settings once for the variant tie-break (which variant a family's
+	// recorded model path points at). GetSettings returns an atomic snapshot.
+	settings := conf.GetSettings()
+
 	// Phase 1: scan the filesystem under mm.mu.
 	mm.mu.Lock()
-	// Reconcile against disk: Phase 1 fully repopulates mm.installed by statting
-	// each entry's files, so clearing first drops any model whose files were
-	// removed out-of-band since the last scan. The clear and the repopulation both
-	// run under mm.mu, so a concurrent reader (RLock) never observes the empty map.
+	// Preserve in-flight installs/switches: replaceVariant swaps mm.installed and
+	// writes files after its own unlock while entry.ID stays in mm.downloading, so
+	// re-deriving those entries from disk here (both variant files may be present
+	// mid-switch) would record the wrong variant. Keep the in-flight record and
+	// skip the disk scan for those ids. Reconcile the rest against disk: Phase 1
+	// fully repopulates mm.installed by statting each entry's files, so clearing
+	// first drops any model whose files were removed out-of-band since the last
+	// scan. The clear and the repopulation both run under mm.mu, so a concurrent
+	// reader (RLock) never observes the empty map.
+	inFlight := make(map[string]InstalledModel)
+	for id := range mm.downloading {
+		if im, ok := mm.installed[id]; ok {
+			inFlight[id] = im
+		}
+	}
 	clear(mm.installed)
+	maps.Copy(mm.installed, inFlight)
 	for i := range catalog {
 		entry := &catalog[i]
+		if _, downloading := mm.downloading[entry.ID]; downloading {
+			continue
+		}
 		subdir := filepath.Join(mm.modelsDir, entry.ID)
 
 		// Variant entries: detect which hardware variant is present on disk
@@ -177,7 +196,7 @@ func (mm *ModelManager) ScanInstalled() {
 		// file, so a variant entry is never shared-only and never needs the
 		// shared-only fall-through below.
 		if len(entry.Variants) > 0 {
-			if im, ok := scanVariantEntry(entry, subdir); ok {
+			if im, ok := scanVariantEntry(entry, subdir, installedModelBasenameHint(settings, entry.RegistryID)); ok {
 				mm.installed[entry.ID] = im
 				log.Debug("Found installed model variant",
 					logger.String("catalog_id", entry.ID),
@@ -300,12 +319,31 @@ func modelAndLabelsFiles(files []CatalogFile) (modelFile, labelsFile string) {
 }
 
 // scanVariantEntry determines which variant of a variant-carrying catalog entry
-// is installed on disk under subdir. It checks the default variant first so an
-// ambiguous on-disk state (e.g. both files present after a crashed replace)
-// resolves to the default, matching pre-variant behaviour; it then falls back to
-// the remaining variants in catalog order. ok is false when no variant's model
-// file is present on disk.
-func scanVariantEntry(entry *CatalogEntry, subdir string) (InstalledModel, bool) {
+// is installed on disk under subdir. modelBasenameHint is the basename of the
+// model path recorded in settings for this family (empty when unknown): the
+// variant whose model file matches it is preferred, so an ambiguous on-disk state
+// (e.g. both files present after a crashed replace) resolves to the variant the
+// loader will actually open. It then falls back to the default variant, then the
+// remaining variants in catalog order. ok is false when no variant's model file
+// is present on disk.
+func scanVariantEntry(entry *CatalogEntry, subdir, modelBasenameHint string) (InstalledModel, bool) {
+	// Prefer the variant whose model file matches the persisted settings path.
+	// After a crashed replace both variants' files can be present on disk; the
+	// settings path is what the loader (buildPerch/buildBirdNETV3) actually opens,
+	// so aligning the detected variant to it keeps the reported install consistent
+	// with what runs, rather than silently reporting the default.
+	if modelBasenameHint != "" {
+		for i := range entry.Variants {
+			v := &entry.Variants[i]
+			mf, _ := modelAndLabelsFiles(v.Files)
+			if mf == modelBasenameHint {
+				if im, ok := installedFromVariant(entry, v, subdir); ok {
+					return im, true
+				}
+				break
+			}
+		}
+	}
 	def := defaultVariant(entry)
 	if def != nil {
 		if im, ok := installedFromVariant(entry, def, subdir); ok {
@@ -322,6 +360,31 @@ func scanVariantEntry(entry *CatalogEntry, subdir string) (InstalledModel, bool)
 		}
 	}
 	return InstalledModel{}, false
+}
+
+// installedModelBasenameHint returns the basename of the model path recorded in
+// settings for the given registry ID, or "" when settings are absent or the
+// family carries no path. It is the tie-break scanVariantEntry uses to resolve an
+// ambiguous multi-variant on-disk state to the variant the loader actually opens.
+func installedModelBasenameHint(settings *conf.Settings, registryID string) string {
+	if settings == nil {
+		return ""
+	}
+	var p string
+	switch registryID {
+	case RegistryIDBirdNETV3:
+		p = settings.BirdNETV3.ModelPath
+	case RegistryIDPerchV2:
+		p = settings.Perch.ModelPath
+	case RegistryIDBSG:
+		p = settings.BSG.ModelPath
+	case RegistryIDBat:
+		p = settings.Bat.ClassifierModel
+	}
+	if p == "" {
+		return ""
+	}
+	return filepath.Base(p)
 }
 
 // installedFromVariant builds the InstalledModel for a specific variant if its
@@ -599,6 +662,20 @@ func (mm *ModelManager) IsInstalled(catalogID string) bool {
 	return ok
 }
 
+// InstalledVariantID returns the installed variant id for catalogID and true, or
+// "" and false when the model is not installed. An installed flat (pre-variant)
+// entry reports an empty variant id with ok=true, so callers can distinguish
+// "installed, single implicit variant" from "not installed".
+func (mm *ModelManager) InstalledVariantID(catalogID string) (variantID string, ok bool) {
+	mm.mu.RLock()
+	defer mm.mu.RUnlock()
+	im, found := mm.installed[catalogID]
+	if !found {
+		return "", false
+	}
+	return im.VariantID, true
+}
+
 // scanSharedOnlyEntry checks whether a catalog entry whose files all live in
 // models/shared/ (e.g. geomodels) is installed. If all shared files exist on
 // disk, it registers the entry in mm.installed and returns true. The caller
@@ -706,6 +783,18 @@ func (mm *ModelManager) Uninstall(catalogID string) error {
 	im, installed := mm.installed[catalogID]
 	if !installed {
 		return errors.Newf("model %s is not installed", catalogID).
+			Component("classifier.model_manager").
+			Category(errors.CategoryValidation).
+			Context("catalog_id", catalogID).
+			Build()
+	}
+
+	// Refuse while a download or variant switch is in flight for this model. A
+	// concurrent replaceVariant swaps mm.installed and writes files after its own
+	// unlock; uninstalling in that window would delete the old files and clear
+	// config only for the switch to resurrect the entry as a zombie install.
+	if _, downloading := mm.downloading[catalogID]; downloading {
+		return errors.Newf("model %s is being downloaded; cannot uninstall", catalogID).
 			Component("classifier.model_manager").
 			Category(errors.CategoryValidation).
 			Context("catalog_id", catalogID).
@@ -1024,6 +1113,265 @@ func (mm *ModelManager) Reinstall(ctx context.Context, entry *CatalogEntry, base
 	return nil
 }
 
+// InstallOrReplace installs the selected variant of entry when nothing is
+// installed for it, or switches an already-installed model to a different variant
+// (download-before-delete). The installed-state check and the download
+// registration happen under a single mm.mu acquisition so a concurrent Uninstall
+// (which refuses while a download is in progress) cannot race between the check
+// and the act. An empty variantID selects the entry's default variant; an unknown
+// variant id is rejected. Re-selecting the already-installed variant is a no-op.
+// The baseURL parameter overrides the HuggingFace URL for testing.
+func (mm *ModelManager) InstallOrReplace(ctx context.Context, entry *CatalogEntry, variantID, baseURL string, progress chan<- DownloadState) error {
+	// Reject an unknown variant selection before any lock or state change.
+	if _, ok := variantFilesByID(entry, variantID); !ok {
+		return errors.Newf("unknown variant %q for model %s", variantID, entry.ID).
+			Component("classifier.model_manager").
+			Category(errors.CategoryValidation).
+			Context("catalog_id", entry.ID).
+			Context("variant_id", variantID).
+			Build()
+	}
+
+	// Resolve the effective target variant id (empty = default) for the
+	// same-variant comparison and the replace path.
+	target := variantID
+	if target == "" {
+		if v := defaultVariant(entry); v != nil {
+			target = v.ID
+		}
+	}
+
+	mm.mu.Lock()
+	if _, downloading := mm.downloading[entry.ID]; downloading {
+		mm.mu.Unlock()
+		return errors.Newf("model %s is already being downloaded", entry.ID).
+			Component("classifier.model_manager").
+			Category(errors.CategoryValidation).
+			Context("catalog_id", entry.ID).
+			Build()
+	}
+	current, installed := mm.installed[entry.ID]
+	if installed && current.VariantID == target {
+		// Idempotent: the requested variant is already the installed one.
+		mm.mu.Unlock()
+		return nil
+	}
+	if !installed {
+		// Fresh install: delegate to Install, which registers the download and owns
+		// its failure cleanup. There is no installed entry for a concurrent Uninstall
+		// to race, so releasing the lock before Install re-acquires it is safe.
+		mm.mu.Unlock()
+		return mm.Install(ctx, entry, variantID, baseURL, progress)
+	}
+	// Variant switch: register the switch atomically with the installed-state
+	// decision, so a concurrent Uninstall (which refuses while downloading) cannot
+	// slip in between the check and replaceVariant swapping mm.installed.
+	mm.downloading[entry.ID] = &DownloadState{
+		CatalogID: entry.ID,
+		Status:    StatusDownloading,
+	}
+	mm.mu.Unlock()
+
+	return mm.replaceVariant(ctx, entry, &current, target, baseURL, progress)
+}
+
+// replaceVariant switches an installed model to newVariantID using a
+// download-before-delete strategy: the new variant's files are downloaded and
+// verified first (the old model keeps running), then the old model is unloaded,
+// the install record and config are swapped to the new variant, the new model is
+// loaded, and only then are the old variant's superseded files removed. Any
+// failure before the swap leaves the old variant installed and loaded, so a
+// failed switch never strands the working model. The caller must have registered
+// entry.ID in mm.downloading; replaceVariant keeps it registered until the
+// superseded files are gone (so a concurrent ScanInstalled treats the switch as
+// in-flight) and clears it (or schedules cleanup on failure) before returning.
+func (mm *ModelManager) replaceVariant(ctx context.Context, entry *CatalogEntry, old *InstalledModel, newVariantID, baseURL string, progress chan<- DownloadState) error {
+	log := GetLogger()
+
+	// 1. Download the NEW variant's files (they coexist with the old on disk
+	//    because a family's variants use distinct model LocalNames).
+	//    cleanupOnFailure=true so a failed switch leaves no partial new files.
+	_, modelPath, labelsPath, embeddingsPath, err := mm.downloadVariantFiles(ctx, entry, newVariantID, baseURL, progress, true)
+	if err != nil {
+		// downloadVariantFiles already marked the state failed; retain it briefly
+		// for SSE pollers, then clear. The old variant is untouched and loaded.
+		time.AfterFunc(failedStateRetention, func() {
+			mm.removeDownloading(entry.ID)
+		})
+		return err
+	}
+
+	// 2. Unload the old model before activating the new one. The new files are
+	//    already on disk, so an unload failure aborts cleanly with the old variant
+	//    still installed and loaded.
+	if mm.orchestrator != nil && entry.RegistryID != "" && mm.orchestrator.IsModelLoaded(entry.RegistryID) {
+		if unloadErr := mm.orchestrator.UnloadModel(entry.RegistryID); unloadErr != nil {
+			log.Warn("Variant switch refused: model could not be unloaded (still in use)",
+				logger.String("catalog_id", entry.ID),
+				logger.String("registry_id", entry.RegistryID),
+				logger.Error(unloadErr))
+			switchErr := errors.Newf("cannot switch %s to variant %q: model still in use", entry.ID, newVariantID).
+				Component("classifier.model_manager").
+				Category(errors.CategorySystem).
+				Context("catalog_id", entry.ID).
+				Context("registry_id", entry.RegistryID).
+				Context("unload_error", unloadErr.Error()).
+				Build()
+			// The new variant's files were downloaded but never activated; remove
+			// them (keeping shared companions) so the aborted switch strands no model
+			// file. The old variant stays installed and loaded.
+			mm.removeSupersededVariantFiles(log, entry, newVariantID, old.VariantID)
+			// Report the failure over SSE: a bare removeDownloading would leave the
+			// stream to read nil-state + IsInstalled as a false success.
+			mm.markFailed(entry.ID, switchErr, progress)
+			time.AfterFunc(failedStateRetention, func() {
+				mm.removeDownloading(entry.ID)
+			})
+			return switchErr
+		}
+		mm.notifyTopologyChanged()
+	}
+
+	// 3. Swap the install record to the new variant. entry.ID stays in
+	//    mm.downloading (cleared only in step 7) so a concurrent ScanInstalled
+	//    treats the switch as in-flight until the superseded files are removed.
+	mm.mu.Lock()
+	mm.installed[entry.ID] = InstalledModel{
+		CatalogID:   entry.ID,
+		VariantID:   newVariantID,
+		ModelPath:   modelPath,
+		LabelsPath:  labelsPath,
+		InstalledAt: time.Now(),
+		Version:     entry.Version,
+	}
+	mm.mu.Unlock()
+
+	// 4. Persist the new variant's paths BEFORE loading, so buildPerch /
+	//    buildBirdNETV3 (which read settings.<family>.ModelPath first) load the new
+	//    file, and a crash/restart before step 6 still resolves the new variant.
+	mm.applyConfigForInstall(entry, modelPath, labelsPath, embeddingsPath)
+
+	// 5. Load the new variant (the old one was unloaded in step 2).
+	mm.hotLoadAfterInstall(log, entry)
+
+	// hotLoadAfterInstall only logs a load failure. If the new variant did not
+	// load, the old model is already unloaded, so completing the switch (deleting
+	// the old files and reporting success) would leave the family with no
+	// classifier loaded while the API reported success. Roll back to the previous
+	// variant instead, extending the download-before-delete guarantee to a LOAD
+	// failure. Skipped when there is no orchestrator to verify against.
+	if mm.orchestrator != nil && entry.RegistryID != "" && !mm.orchestrator.IsModelLoaded(entry.RegistryID) {
+		return mm.rollbackVariantSwitch(log, entry, old, newVariantID, progress)
+	}
+
+	// 6. Remove the OLD variant's superseded files (never shared companions).
+	mm.removeSupersededVariantFiles(log, entry, old.VariantID, newVariantID)
+
+	// 7. The switch is complete: clear the in-flight marker and report success.
+	mm.removeDownloading(entry.ID)
+	sendProgress(progress, entry.ID, StatusComplete)
+
+	log.Info("Model variant switched",
+		logger.String("catalog_id", entry.ID),
+		logger.String("from_variant", old.VariantID),
+		logger.String("to_variant", newVariantID),
+		logger.String("model_path", modelPath))
+
+	return nil
+}
+
+// rollbackVariantSwitch restores the previously-installed variant after the new
+// variant was written and activated but failed to load. It re-records the old
+// variant, re-persists its paths, reloads it, and removes the new variant's
+// now-unused files, so a load failure during a switch leaves the family running
+// its previous working variant rather than nothing. It reports the switch as
+// failed over the progress stream. The caller must have registered entry.ID in
+// mm.downloading; rollbackVariantSwitch schedules its cleanup.
+func (mm *ModelManager) rollbackVariantSwitch(log logger.Logger, entry *CatalogEntry, old *InstalledModel, newVariantID string, progress chan<- DownloadState) error {
+	log.Warn("New variant failed to load; rolling back to the previous variant",
+		logger.String("catalog_id", entry.ID),
+		logger.String("failed_variant", newVariantID),
+		logger.String("restored_variant", old.VariantID))
+
+	// Restore the install record to the old variant.
+	mm.mu.Lock()
+	mm.installed[entry.ID] = *old
+	mm.mu.Unlock()
+
+	// Re-persist the old variant's paths (step 4 wrote the new ones) and reload it.
+	// Companion files are identical across a family's variants, so the old variant's
+	// embeddings path (bat only) is derived from its own file list for completeness.
+	oldEmbeddings := ""
+	if oldFiles, ok := variantFilesByID(entry, old.VariantID); ok {
+		for _, f := range oldFiles {
+			if f.Role == RoleEmbeddings {
+				oldEmbeddings = filepath.Join(mm.modelsDir, "shared", f.LocalName)
+				break
+			}
+		}
+	}
+	mm.applyConfigForInstall(entry, old.ModelPath, old.LabelsPath, oldEmbeddings)
+	mm.hotLoadAfterInstall(log, entry)
+
+	// The new variant is unusable on this host: remove its files (keeping shared
+	// companions) so disk state matches the restored record.
+	mm.removeSupersededVariantFiles(log, entry, newVariantID, old.VariantID)
+
+	switchErr := errors.Newf("switched %s to variant %q but it failed to load; restored previous variant %q", entry.ID, newVariantID, old.VariantID).
+		Component("classifier.model_manager").
+		Category(errors.CategoryModelInit).
+		Context("catalog_id", entry.ID).
+		Context("failed_variant", newVariantID).
+		Context("restored_variant", old.VariantID).
+		Build()
+	mm.markFailed(entry.ID, switchErr, progress)
+	time.AfterFunc(failedStateRetention, func() {
+		mm.removeDownloading(entry.ID)
+	})
+	return switchErr
+}
+
+// removeSupersededVariantFiles deletes the old variant's files that the new
+// variant does not also carry, after a variant switch. A file whose LocalName the
+// new variant also uses (shared companions keep identical names across a family's
+// variants) is kept. Files with a shared role are skipped entirely and left to
+// Uninstall/cleanupSharedFiles: their lifecycle spans models, so a variant that
+// drops a companion must not globally delete a file another model still needs.
+func (mm *ModelManager) removeSupersededVariantFiles(log logger.Logger, entry *CatalogEntry, oldVariantID, newVariantID string) {
+	oldFiles, ok := variantFilesByID(entry, oldVariantID)
+	if !ok {
+		// The old variant is no longer in the catalog: its file list is unknown, so
+		// there is nothing safe to target. A leaked model file, if any, is recovered
+		// by a later scan's reconciliation rather than guessed at here.
+		return
+	}
+	newFiles, _ := variantFilesByID(entry, newVariantID)
+	keep := make(map[string]struct{}, len(newFiles))
+	for _, f := range newFiles {
+		keep[f.LocalName] = struct{}{}
+	}
+	subdir := filepath.Join(mm.modelsDir, entry.ID)
+	for _, f := range oldFiles {
+		if _, retained := keep[f.LocalName]; retained {
+			continue
+		}
+		if isSharedRole(f.Role) {
+			continue
+		}
+		path := filepath.Join(subdir, f.LocalName)
+		if rmErr := os.Remove(path); rmErr != nil && !os.IsNotExist(rmErr) {
+			log.Warn("Failed to remove superseded variant file after switch",
+				logger.String("catalog_id", entry.ID),
+				logger.String("path", path),
+				logger.Error(rmErr))
+		} else if rmErr == nil {
+			log.Info("Removed superseded variant file after switch",
+				logger.String("catalog_id", entry.ID),
+				logger.String("path", path))
+		}
+	}
+}
+
 // preflightDiskSpace reports an error when the filesystem holding the models
 // directory cannot fit totalDownloadBytes plus a safety margin, so a large
 // download fails fast instead of part-way through. It is a no-op when there is
@@ -1059,17 +1407,18 @@ func (mm *ModelManager) preflightDiskSpace(entry *CatalogEntry, filesToDownload 
 		Build()
 }
 
-// downloadModelFiles handles the actual file download, validation, recording,
-// config application, and hot-load for a catalog entry. variantID selects which
-// variant's files to download (empty = the entry's default variant); an unknown
-// variant is a backstop failure, since callers validate it first. The caller must
-// have already registered the entry in mm.downloading before calling this method.
-// On failure, downloadModelFiles calls markFailed but the caller is responsible
-// for scheduling cleanup of the download state (e.g., via time.AfterFunc).
-// When cleanupOnFailure is true (Install), newly downloaded files are removed
-// on failure. When false (Reinstall), repaired files are kept so partial
-// progress is not lost.
-func (mm *ModelManager) downloadModelFiles(ctx context.Context, entry *CatalogEntry, variantID, baseURL string, progress chan<- DownloadState, cleanupOnFailure bool) error {
+// downloadVariantFiles downloads and verifies the files for the selected variant
+// of entry into the models directory, reporting progress and returning the
+// resolved model, labels, and embeddings paths. variantID selects the variant
+// (empty = the entry's default). It deliberately does NOT record the install,
+// apply config, hot-load, or clear mm.downloading; the caller owns that lifecycle
+// so both the install path (downloadModelFiles) and the variant-replace path
+// (replaceVariant) can share the download while differing in how they activate
+// the result. The caller must have registered the entry in mm.downloading. On
+// failure it calls markFailed, and when cleanupOnFailure is true it removes the
+// files it downloaded this call (Install); when false, partial progress is kept
+// (Reinstall).
+func (mm *ModelManager) downloadVariantFiles(ctx context.Context, entry *CatalogEntry, variantID, baseURL string, progress chan<- DownloadState, cleanupOnFailure bool) (files []CatalogFile, modelPath, labelsPath, embeddingsPath string, err error) {
 	log := GetLogger()
 
 	// Resolve the files for the requested variant (empty selection = default).
@@ -1078,29 +1427,29 @@ func (mm *ModelManager) downloadModelFiles(ctx context.Context, entry *CatalogEn
 	// default variant's files.
 	files, okVariant := variantFilesByID(entry, variantID)
 	if !okVariant {
-		err := errors.Newf("unknown variant %q for model %s", variantID, entry.ID).
+		vErr := errors.Newf("unknown variant %q for model %s", variantID, entry.ID).
 			Component("classifier.model_manager").
 			Category(errors.CategoryValidation).
 			Context("catalog_id", entry.ID).
 			Context("variant_id", variantID).
 			Build()
-		mm.markFailed(entry.ID, err, progress)
-		return err
+		mm.markFailed(entry.ID, vErr, progress)
+		return nil, "", "", "", vErr
 	}
 
 	// Create model subdirectory only if the entry has non-shared files.
 	// Shared-only entries (e.g. geomodels) store all files in models/shared/.
 	subdir := filepath.Join(mm.modelsDir, entry.ID)
 	if !IsSharedOnly(entry) {
-		if err := os.MkdirAll(subdir, 0o755); err != nil {
-			mkdirErr := errors.Newf("failed to create model directory %s: %v", subdir, err).
+		if mkErr := os.MkdirAll(subdir, 0o755); mkErr != nil {
+			mkdirErr := errors.Newf("failed to create model directory %s: %v", subdir, mkErr).
 				Component("classifier.model_manager").
 				Category(errors.CategoryFileIO).
 				Context("catalog_id", entry.ID).
 				Context("directory", subdir).
 				Build()
 			mm.markFailed(entry.ID, mkdirErr, progress)
-			return mkdirErr
+			return nil, "", "", "", mkdirErr
 		}
 	}
 
@@ -1129,7 +1478,7 @@ func (mm *ModelManager) downloadModelFiles(ctx context.Context, entry *CatalogEn
 	filesToDownload := 0
 	for _, f := range files {
 		destPath := fileDestPath(f)
-		if _, err := os.Stat(destPath); err != nil {
+		if _, statErr := os.Stat(destPath); statErr != nil {
 			totalAllBytes += f.SizeBytes
 			filesToDownload++
 		} else if f.SHA256 != "" && !verifySHA256(destPath, f.SHA256) {
@@ -1147,9 +1496,9 @@ func (mm *ModelManager) downloadModelFiles(ctx context.Context, entry *CatalogEn
 	// part-way through and leaving partial files behind. No model files have been
 	// downloaded yet (the subdirectory may already exist), so no cleanup is needed
 	// on the reject path.
-	if err := mm.preflightDiskSpace(entry, filesToDownload, totalAllBytes); err != nil {
-		mm.markFailed(entry.ID, err, progress)
-		return err
+	if pfErr := mm.preflightDiskSpace(entry, filesToDownload, totalAllBytes); pfErr != nil {
+		mm.markFailed(entry.ID, pfErr, progress)
+		return nil, "", "", "", pfErr
 	}
 
 	// Resolve the HuggingFace host once per install so every file in the same
@@ -1169,14 +1518,13 @@ func (mm *ModelManager) downloadModelFiles(ctx context.Context, entry *CatalogEn
 	}
 
 	// Download each file.
-	var modelPath, labelsPath string
 	var completedBytes int64
 	fileIndex := 0
 	for _, f := range files {
 		destPath := fileDestPath(f)
 
 		// Skip download if file already exists and passes SHA256 validation.
-		if _, err := os.Stat(destPath); err == nil && !needsRedownload[destPath] {
+		if _, statErr := os.Stat(destPath); statErr == nil && !needsRedownload[destPath] {
 			log.Debug("File already exists, skipping download",
 				logger.String("catalog_id", entry.ID),
 				logger.String("path", destPath))
@@ -1216,16 +1564,16 @@ func (mm *ModelManager) downloadModelFiles(ctx context.Context, entry *CatalogEn
 		}
 		mm.mu.Unlock()
 
-		if err := mm.downloadFile(ctx, entry.ID, url, destPath, f.SHA256, completedBytes); err != nil {
+		if dlErr := mm.downloadFile(ctx, entry.ID, url, destPath, f.SHA256, completedBytes); dlErr != nil {
 			log.Error("Failed to download file",
 				logger.String("catalog_id", entry.ID),
 				logger.String("url", url),
-				logger.Error(err))
-			mm.markFailed(entry.ID, err, progress)
+				logger.Error(dlErr))
+			mm.markFailed(entry.ID, dlErr, progress)
 			if cleanupOnFailure {
 				cleanup()
 			}
-			return err
+			return nil, "", "", "", dlErr
 		}
 
 		completedBytes += f.SizeBytes
@@ -1241,6 +1589,33 @@ func (mm *ModelManager) downloadModelFiles(ctx context.Context, entry *CatalogEn
 
 	// For shared-only entries (e.g. geomodels), derive paths from shared files.
 	modelPath, labelsPath = resolveSharedPaths(files, modelPath, labelsPath, fileDestPath)
+
+	// Find embeddings path for bat models.
+	for _, f := range files {
+		if f.Role == RoleEmbeddings {
+			embeddingsPath = filepath.Join(mm.modelsDir, "shared", f.LocalName)
+			break
+		}
+	}
+
+	return files, modelPath, labelsPath, embeddingsPath, nil
+}
+
+// downloadModelFiles installs a catalog entry's selected variant: it delegates
+// the file download and verification to downloadVariantFiles, then records the
+// install, applies config, and hot-loads the model. It is the install/reinstall
+// entry point; the variant-switch path (replaceVariant) uses downloadVariantFiles
+// directly so it can interpose an unload between download and load. The caller
+// must have registered the entry in mm.downloading. cleanupOnFailure is passed
+// through: true (Install) removes newly downloaded files on failure, false
+// (Reinstall) keeps repaired files so partial progress is not lost.
+func (mm *ModelManager) downloadModelFiles(ctx context.Context, entry *CatalogEntry, variantID, baseURL string, progress chan<- DownloadState, cleanupOnFailure bool) error {
+	log := GetLogger()
+
+	_, modelPath, labelsPath, embeddingsPath, err := mm.downloadVariantFiles(ctx, entry, variantID, baseURL, progress, cleanupOnFailure)
+	if err != nil {
+		return err
+	}
 
 	// Record the installed variant: the selected one, or the default variant when
 	// the caller did not specify a selection (empty = default). This keeps the
@@ -1265,14 +1640,6 @@ func (mm *ModelManager) downloadModelFiles(ctx context.Context, entry *CatalogEn
 	delete(mm.downloading, entry.ID)
 	mm.mu.Unlock()
 
-	// Find embeddings path for bat models.
-	embeddingsPath := ""
-	for _, f := range files {
-		if f.Role == RoleEmbeddings {
-			embeddingsPath = filepath.Join(mm.modelsDir, "shared", f.LocalName)
-			break
-		}
-	}
 	mm.applyConfigForInstall(entry, modelPath, labelsPath, embeddingsPath)
 
 	mm.hotLoadAfterInstall(log, entry)

--- a/internal/classifier/model_manager_replace_test.go
+++ b/internal/classifier/model_manager_replace_test.go
@@ -1,0 +1,378 @@
+package classifier
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// TestModelManager_InstallOrReplace_InstallsWhenAbsent verifies that
+// InstallOrReplace performs a fresh install (default variant) when nothing is
+// installed for the entry.
+func TestModelManager_InstallOrReplace_InstallsWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	entry, modelsDir, srvURL := twoVariantServerEntry(t)
+	mm := NewModelManager(modelsDir, nil, nil)
+
+	require.NoError(t, mm.InstallOrReplace(t.Context(), &entry, "", srvURL, nil))
+
+	got := installedByID(t, mm, entry.ID)
+	assert.Equal(t, "fp32", got.VariantID, "an absent variant selection installs the default")
+	assert.FileExists(t, filepath.Join(modelsDir, entry.ID, "model.onnx"))
+}
+
+// TestModelManager_InstallOrReplace_SwitchesVariant verifies the
+// download-before-delete switch: after switching fp32 -> int8-arm, the new
+// variant is recorded and on disk, the superseded model file is removed, and the
+// shared companion (labels) is retained.
+func TestModelManager_InstallOrReplace_SwitchesVariant(t *testing.T) {
+	t.Parallel()
+
+	entry, modelsDir, srvURL := twoVariantServerEntry(t)
+	mm := NewModelManager(modelsDir, nil, nil)
+
+	// Install the default (fp32) first.
+	require.NoError(t, mm.InstallOrReplace(t.Context(), &entry, "", srvURL, nil))
+	require.Equal(t, "fp32", installedByID(t, mm, entry.ID).VariantID)
+
+	fp32Path := filepath.Join(modelsDir, entry.ID, "model.onnx")
+	int8Path := filepath.Join(modelsDir, entry.ID, "model_int8.onnx")
+	labelsPath := filepath.Join(modelsDir, entry.ID, "labels.txt")
+	require.FileExists(t, fp32Path)
+
+	// Switch to int8-arm.
+	require.NoError(t, mm.InstallOrReplace(t.Context(), &entry, "int8-arm", srvURL, nil))
+
+	got := installedByID(t, mm, entry.ID)
+	assert.Equal(t, "int8-arm", got.VariantID, "the switch must record the new variant")
+	assert.FileExists(t, int8Path, "the new variant's model file must be on disk")
+	_, err := os.Stat(fp32Path)
+	assert.True(t, os.IsNotExist(err), "the superseded variant's model file must be removed")
+	assert.FileExists(t, labelsPath, "the shared labels companion must be retained across the switch")
+	assert.Nil(t, mm.GetDownloadState(entry.ID), "no download state may linger after a completed switch")
+}
+
+// TestModelManager_InstallOrReplace_SameVariantIsNoOp verifies that requesting
+// the already-installed variant is an idempotent no-op.
+func TestModelManager_InstallOrReplace_SameVariantIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	entry, modelsDir, srvURL := twoVariantServerEntry(t)
+	mm := NewModelManager(modelsDir, nil, nil)
+
+	require.NoError(t, mm.InstallOrReplace(t.Context(), &entry, "", srvURL, nil))
+	require.Equal(t, "fp32", installedByID(t, mm, entry.ID).VariantID)
+
+	// Re-selecting the installed variant (by explicit id and by default) is a no-op.
+	require.NoError(t, mm.InstallOrReplace(t.Context(), &entry, "fp32", srvURL, nil))
+	require.NoError(t, mm.InstallOrReplace(t.Context(), &entry, "", srvURL, nil))
+
+	assert.Equal(t, "fp32", installedByID(t, mm, entry.ID).VariantID)
+	assert.Nil(t, mm.GetDownloadState(entry.ID))
+}
+
+// TestModelManager_InstallOrReplace_FailedSwitchKeepsOldVariant verifies
+// download-before-delete: when the new variant's download fails, the old variant
+// stays installed and its files remain intact.
+func TestModelManager_InstallOrReplace_FailedSwitchKeepsOldVariant(t *testing.T) {
+	t.Parallel()
+
+	fp32Data, labels := []byte("fp32-model"), []byte("a\nb\n")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/fp32.onnx":
+			_, _ = w.Write(fp32Data)
+		case "/labels.txt":
+			_, _ = w.Write(labels)
+		default:
+			http.NotFound(w, r) // int8.onnx is intentionally not served
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	fp32Files := []CatalogFile{
+		{RemotePath: "fp32.onnx", LocalName: "model.onnx", Role: RoleModel, SHA256: sha256Hex(fp32Data), SizeBytes: int64(len(fp32Data))},
+		{RemotePath: "labels.txt", LocalName: "labels.txt", Role: RoleLabels, SHA256: sha256Hex(labels), SizeBytes: int64(len(labels))},
+	}
+	int8Data := []byte("int8-model")
+	int8Files := []CatalogFile{
+		{RemotePath: "int8.onnx", LocalName: "model_int8.onnx", Role: RoleModel, SHA256: sha256Hex(int8Data), SizeBytes: int64(len(int8Data))},
+		{RemotePath: "labels.txt", LocalName: "labels.txt", Role: RoleLabels, SHA256: sha256Hex(labels), SizeBytes: int64(len(labels))},
+	}
+	entry := CatalogEntry{
+		ID:              "test-replace-fail",
+		Name:            "T",
+		Version:         "1.0",
+		HuggingFaceRepo: "t/r",
+		Variants: []CatalogVariant{
+			{ID: "fp32", Default: true, Files: fp32Files},
+			{ID: "int8-arm", Files: int8Files},
+		},
+		Files: fp32Files,
+	}
+
+	modelsDir := t.TempDir()
+	mm := NewModelManager(modelsDir, nil, nil)
+	require.NoError(t, mm.InstallOrReplace(t.Context(), &entry, "", srv.URL, nil))
+	fp32Path := filepath.Join(modelsDir, entry.ID, "model.onnx")
+	require.FileExists(t, fp32Path)
+
+	// The switch to int8-arm fails because int8.onnx 404s.
+	err := mm.InstallOrReplace(t.Context(), &entry, "int8-arm", srv.URL, nil)
+	require.Error(t, err)
+
+	assert.Equal(t, "fp32", installedByID(t, mm, entry.ID).VariantID,
+		"a failed switch must leave the old variant installed")
+	assert.FileExists(t, fp32Path, "a failed switch must leave the old variant's file intact")
+}
+
+// TestModelManager_UninstallRejectedWhileDownloading verifies that Uninstall
+// refuses while a download/switch is in flight, so a concurrent switch cannot
+// resurrect a zombie install.
+func TestModelManager_UninstallRejectedWhileDownloading(t *testing.T) {
+	t.Parallel()
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+
+	modelsDir := t.TempDir()
+	writeVariantModelFile(t, modelsDir, &entry, "fp32")
+
+	mm := NewModelManager(modelsDir, nil, nil)
+	mm.ScanInstalled()
+	require.True(t, mm.IsInstalled(entry.ID))
+
+	// Simulate an in-flight download/switch.
+	mm.mu.Lock()
+	mm.downloading[entry.ID] = &DownloadState{CatalogID: entry.ID, Status: StatusDownloading}
+	mm.mu.Unlock()
+
+	err := mm.Uninstall(entry.ID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "being downloaded")
+	assert.True(t, mm.IsInstalled(entry.ID), "the model must remain installed when uninstall is refused")
+}
+
+// TestModelManager_ScanInstalledPreservesInFlight verifies that a scan does not
+// drop an in-flight install/switch (present in mm.downloading) even when its
+// files are not yet on disk, so a concurrent switch is not corrupted.
+func TestModelManager_ScanInstalledPreservesInFlight(t *testing.T) {
+	t.Parallel()
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+
+	mm := NewModelManager(t.TempDir(), nil, nil)
+
+	// Simulate the mid-switch state: a new variant recorded and marked downloading
+	// with no files on disk yet.
+	mm.mu.Lock()
+	mm.installed[entry.ID] = InstalledModel{CatalogID: entry.ID, VariantID: "int8-arm"}
+	mm.downloading[entry.ID] = &DownloadState{CatalogID: entry.ID, Status: StatusDownloading}
+	mm.mu.Unlock()
+
+	mm.ScanInstalled()
+
+	got := installedByID(t, mm, entry.ID)
+	assert.Equal(t, "int8-arm", got.VariantID, "an in-flight switch must survive a concurrent scan")
+}
+
+// TestScanVariantEntry_SettingsHintBreaksTie verifies that when both variant
+// model files are present on disk (a crashed-replace remnant), the settings hint
+// resolves to the variant the loader will actually open, not merely the default.
+func TestScanVariantEntry_SettingsHintBreaksTie(t *testing.T) {
+	t.Parallel()
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+
+	modelsDir := t.TempDir()
+	subdir := filepath.Join(modelsDir, entry.ID)
+	writeVariantModelFile(t, modelsDir, &entry, "fp32")
+	writeVariantModelFile(t, modelsDir, &entry, "int8-arm")
+
+	int8Files, ok := variantFilesByID(&entry, "int8-arm")
+	require.True(t, ok)
+	int8Model, _ := modelAndLabelsFiles(int8Files)
+	require.NotEmpty(t, int8Model)
+
+	// With the hint, the non-default variant wins the tie.
+	im, ok := scanVariantEntry(&entry, subdir, int8Model)
+	require.True(t, ok)
+	assert.Equal(t, "int8-arm", im.VariantID)
+
+	// Without a hint, resolution falls back to the default variant.
+	imDefault, ok := scanVariantEntry(&entry, subdir, "")
+	require.True(t, ok)
+	assert.Equal(t, "fp32", imDefault.VariantID)
+}
+
+// TestRemoveSupersededVariantFiles_SkipsSharedRoles verifies that superseded-file
+// cleanup deletes the old variant's non-shared model file but never raw-deletes a
+// shared-role companion, even one the new variant drops.
+func TestRemoveSupersededVariantFiles_SkipsSharedRoles(t *testing.T) {
+	t.Parallel()
+
+	modelsDir := t.TempDir()
+	entry := CatalogEntry{
+		ID:      "test-superseded",
+		Version: "1.0",
+		Variants: []CatalogVariant{
+			{ID: "old", Default: true, Files: []CatalogFile{
+				{LocalName: "old_model.onnx", Role: RoleModel},
+				{LocalName: "shared_taxonomy.csv", Role: RoleTaxonomy}, // shared role, dropped by "new"
+			}},
+			{ID: "new", Files: []CatalogFile{
+				{LocalName: "new_model.onnx", Role: RoleModel},
+			}},
+		},
+	}
+
+	subdir := filepath.Join(modelsDir, entry.ID)
+	sharedDir := filepath.Join(modelsDir, "shared")
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+	require.NoError(t, os.MkdirAll(sharedDir, 0o755))
+	oldModel := filepath.Join(subdir, "old_model.onnx")
+	sharedTaxonomy := filepath.Join(sharedDir, "shared_taxonomy.csv")
+	require.NoError(t, os.WriteFile(oldModel, []byte("m"), 0o600))
+	require.NoError(t, os.WriteFile(sharedTaxonomy, []byte("t"), 0o600))
+
+	mm := NewModelManager(modelsDir, nil, nil)
+	mm.removeSupersededVariantFiles(GetLogger(), &entry, "old", "new")
+
+	_, err := os.Stat(oldModel)
+	assert.True(t, os.IsNotExist(err), "the superseded non-shared model file must be removed")
+	assert.FileExists(t, sharedTaxonomy, "a shared-role file must never be raw-deleted by superseded cleanup")
+}
+
+// TestOrchestrator_ResolveInstalledPaths_NonDefaultVariant verifies that the
+// orchestrator fallback resolves a non-default variant that is on disk, rather
+// than probing only the resolved default variant's filename.
+func TestOrchestrator_ResolveInstalledPaths_NonDefaultVariant(t *testing.T) {
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+
+	modelsDir := t.TempDir()
+	int8ModelPath := writeVariantModelFile(t, modelsDir, &entry, "int8-arm")
+
+	o := &Orchestrator{}
+	o.SetModelsDir(modelsDir)
+
+	modelPath, _, _ := o.resolveInstalledPaths(RegistryIDPerchV2)
+	assert.Equal(t, int8ModelPath, modelPath,
+		"resolveInstalledPaths must find the installed non-default variant on disk")
+}
+
+// TestModelManager_InstallOrReplace_RollsBackOnLoadFailure verifies that when the
+// new variant is downloaded and swapped in but fails to LOAD, the switch rolls
+// back to the previous variant and reports failure rather than reporting success
+// with no classifier loaded. BSG is a known registry id with no loader, so
+// LoadModel fails deterministically after the unload.
+func TestModelManager_InstallOrReplace_RollsBackOnLoadFailure(t *testing.T) {
+	entry, modelsDir, srvURL := twoVariantServerEntry(t)
+	entry.RegistryID = RegistryIDBSG
+
+	// Fake orchestrator with the model "loaded" (non-primary, nil instance so the
+	// unload closes nothing). LoadModel(BSG) has no registered loader, so the switch
+	// cannot re-load after the unload -> rollback.
+	orch := &Orchestrator{models: map[string]*modelEntry{entry.RegistryID: {}}}
+	orch.SetModelsDir(modelsDir)
+	mm := NewModelManager(modelsDir, orch, nil)
+
+	require.NoError(t, mm.InstallOrReplace(t.Context(), &entry, "", srvURL, nil))
+	require.Equal(t, "fp32", installedByID(t, mm, entry.ID).VariantID)
+	fp32Path := filepath.Join(modelsDir, entry.ID, "model.onnx")
+	int8Path := filepath.Join(modelsDir, entry.ID, "model_int8.onnx")
+	require.FileExists(t, fp32Path)
+
+	err := mm.InstallOrReplace(t.Context(), &entry, "int8-arm", srvURL, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load")
+
+	assert.Equal(t, "fp32", installedByID(t, mm, entry.ID).VariantID,
+		"a load failure must roll back to the previous variant")
+	assert.FileExists(t, fp32Path, "the previous variant's file must be kept on rollback")
+	_, statErr := os.Stat(int8Path)
+	assert.True(t, os.IsNotExist(statErr), "the failed new variant's file must be removed on rollback")
+}
+
+// TestModelManager_InstallOrReplace_UnloadFailureKeepsOldAndCleansNew verifies
+// that when the old model cannot be unloaded (it is the primary), the switch
+// aborts with the old variant intact and the freshly downloaded new files removed.
+func TestModelManager_InstallOrReplace_UnloadFailureKeepsOldAndCleansNew(t *testing.T) {
+	entry, modelsDir, srvURL := twoVariantServerEntry(t)
+	entry.RegistryID = RegistryIDBSG
+
+	// Primary models are refused by UnloadModel, forcing the unload-failure path.
+	primary := &BirdNET{ModelInfo: ModelInfo{ID: entry.RegistryID}}
+	orch := &Orchestrator{
+		ModelInfo: primary.ModelInfo,
+		models:    map[string]*modelEntry{entry.RegistryID: {instance: primary}},
+		primary:   primary,
+	}
+	orch.SetModelsDir(modelsDir)
+	mm := NewModelManager(modelsDir, orch, nil)
+
+	require.NoError(t, mm.InstallOrReplace(t.Context(), &entry, "", srvURL, nil))
+	fp32Path := filepath.Join(modelsDir, entry.ID, "model.onnx")
+	int8Path := filepath.Join(modelsDir, entry.ID, "model_int8.onnx")
+	require.FileExists(t, fp32Path)
+
+	err := mm.InstallOrReplace(t.Context(), &entry, "int8-arm", srvURL, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "still in use")
+
+	assert.Equal(t, "fp32", installedByID(t, mm, entry.ID).VariantID,
+		"an unload failure must leave the old variant installed")
+	assert.FileExists(t, fp32Path, "the old variant's file must be intact")
+	_, statErr := os.Stat(int8Path)
+	assert.True(t, os.IsNotExist(statErr), "the aborted switch's new file must be cleaned up")
+}
+
+// TestModelManager_InstallOrReplace_RejectsWhileDownloading verifies the
+// in-flight guard: a switch is refused while a download is already registered.
+func TestModelManager_InstallOrReplace_RejectsWhileDownloading(t *testing.T) {
+	t.Parallel()
+
+	entry, modelsDir, srvURL := twoVariantServerEntry(t)
+	mm := NewModelManager(modelsDir, nil, nil)
+	mm.mu.Lock()
+	mm.downloading[entry.ID] = &DownloadState{CatalogID: entry.ID, Status: StatusDownloading}
+	mm.mu.Unlock()
+
+	err := mm.InstallOrReplace(t.Context(), &entry, "int8-arm", srvURL, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already being downloaded")
+}
+
+// TestVariantSelectable covers the accept path of the exported variant validator
+// (the reject path is covered at the API layer).
+func TestVariantSelectable(t *testing.T) {
+	t.Parallel()
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+
+	assert.True(t, VariantSelectable(&entry, ""), "an empty id selects the default variant")
+	assert.True(t, VariantSelectable(&entry, "int8-arm"), "a real variant id is selectable")
+	assert.False(t, VariantSelectable(&entry, "does-not-exist"))
+}
+
+// TestInstalledModelBasenameHint covers the registry-id -> settings-path mapping
+// used by the scan tie-break.
+func TestInstalledModelBasenameHint(t *testing.T) {
+	t.Parallel()
+
+	s := &conf.Settings{}
+	s.Perch.ModelPath = "/models/perch-v2/perch_v2_int8_arm.onnx"
+	assert.Equal(t, "perch_v2_int8_arm.onnx", installedModelBasenameHint(s, RegistryIDPerchV2))
+	assert.Empty(t, installedModelBasenameHint(s, RegistryIDBirdNETV3), "a family with no recorded path yields no hint")
+	assert.Empty(t, installedModelBasenameHint(nil, RegistryIDPerchV2), "nil settings yields no hint")
+}

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -455,23 +455,38 @@ func (o *Orchestrator) resolveInstalledPaths(registryID string) (modelPath, labe
 			continue
 		}
 		subdir := filepath.Join(o.modelsDir, entry.ID)
-		var mp, lp, ep string
-		for _, f := range entry.Files {
-			switch f.Role {
-			case RoleModel:
-				mp = filepath.Join(subdir, f.LocalName)
-			case RoleLabels:
-				lp = filepath.Join(subdir, f.LocalName)
-			case RoleEmbeddings:
-				ep = filepath.Join(o.modelsDir, "shared", f.LocalName)
+
+		// A variant entry's resolved Files name the DEFAULT variant, which is not
+		// the file on disk when a non-default variant is installed. Probe each
+		// variant's own files and return the one whose model file exists (a
+		// completed switch leaves exactly one), so a non-default install still
+		// resolves here when settings carry no path. Flat entries probe entry.Files.
+		fileSets := [][]CatalogFile{entry.Files}
+		if len(entry.Variants) > 0 {
+			fileSets = make([][]CatalogFile, 0, len(entry.Variants))
+			for j := range entry.Variants {
+				fileSets = append(fileSets, entry.Variants[j].Files)
 			}
 		}
-		if mp != "" {
-			if _, err := os.Stat(mp); err == nil {
-				log.Debug("resolved model paths from gallery",
-					logger.String("registry_id", registryID),
-					logger.String("model_path", mp))
-				return mp, lp, ep
+		for _, files := range fileSets {
+			var mp, lp, ep string
+			for _, f := range files {
+				switch f.Role {
+				case RoleModel:
+					mp = filepath.Join(subdir, f.LocalName)
+				case RoleLabels:
+					lp = filepath.Join(subdir, f.LocalName)
+				case RoleEmbeddings:
+					ep = filepath.Join(o.modelsDir, "shared", f.LocalName)
+				}
+			}
+			if mp != "" {
+				if _, err := os.Stat(mp); err == nil {
+					log.Debug("resolved model paths from gallery",
+						logger.String("registry_id", registryID),
+						logger.String("model_path", mp))
+					return mp, lp, ep
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

The model catalog already carries hardware variants per entry (fp32, int8-arm, no-dft, and so on), with the schema, default resolution, and variant-aware install/scan landed in earlier PRs. This wires up the user-facing surface and the safe switching lifecycle so a variant can actually be chosen and changed.

- `POST /api/v2/models/install/:id` accepts an optional `{"variantId": "..."}` body. An absent body installs the default variant, preserving the current call shape. An unknown variant is rejected with 400 before any download starts.
- The catalog response gains `variants[]` (id, region, precision, species count, size, default/installed flags, headline benchmark latency) and `installedVariantId`, so the gallery can present the choice. Both are additive `omitempty` fields, so existing clients are unaffected.
- Switching an already-installed model to a different variant uses download-before-delete: the new variant is downloaded and verified first (the old model keeps running), then the old model is unloaded, the install record and settings are swapped, the new model is loaded, and only then are the old variant's superseded files removed. A failed download never strands the running model, and if the new variant fails to load after the swap the switch rolls back to the previous variant rather than reporting a false success with nothing loaded.

## Safety details

- `InstallOrReplace` routes install-vs-switch: a fresh install delegates to the existing `Install`; a switch registers under a single lock so the installed-state check cannot race a concurrent `Uninstall` (which now refuses while a download or switch is in flight).
- `ScanInstalled` preserves in-flight switches and breaks a both-files-present tie (a crashed switch) using the persisted per-family model path, so a crash mid-switch neither reports nor reinstalls the wrong variant.
- Superseded-file cleanup never raw-deletes shared companion files (labels, geomodel, taxonomy), whose lifecycle spans models.
- `resolveInstalledPaths` probes each variant's files, so a non-default install resolves correctly through the gallery fallback path.

## Test Plan

- [ ] `go test -race ./internal/classifier/ ./internal/api/v2/models/`
- [ ] `golangci-lint run` clean on the changed files
- [ ] Fresh install of a non-default variant, variant switch (old file removed, companion retained), failed switch leaves the old variant intact, uninstall refused while a download is in flight