### PR TITLE
fix(container): stop /dev/snd chmod errors under rootless Podman (#724)

### DIFF
--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -11,8 +11,9 @@ SKIP_CHOWN="$(echo "${SKIP_CHOWN:-false}" | tr '[:upper:]' '[:lower:]')"
 
 # SKIP_DEVICE_PERMS: set to "true" to skip all /dev/snd and /dev/dri permission
 # and group adjustments. Useful when the container runtime already grants device
-# access (for example rootless Podman with --group-add keep-groups), or to skip
-# the device fixups entirely (for example on read-only device mounts).
+# access (for example rootless Podman with --userns=keep-id --group-add
+# keep-groups), or to skip the device fixups entirely (for example on read-only
+# device mounts).
 SKIP_DEVICE_PERMS="$(echo "${SKIP_DEVICE_PERMS:-false}" | tr '[:upper:]' '[:lower:]')"
 
 echo "Starting BirdNET-Go with UID:$APP_UID, GID:$APP_GID"

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -9,6 +9,12 @@ APP_USER="birdnet"
 # SKIP_CHOWN: set to "true" to skip all ownership changes (useful for NFS mounts)
 SKIP_CHOWN="$(echo "${SKIP_CHOWN:-false}" | tr '[:upper:]' '[:lower:]')"
 
+# SKIP_DEVICE_PERMS: set to "true" to skip all /dev/snd and /dev/dri permission
+# and group adjustments. Useful when the container runtime already grants device
+# access (for example rootless Podman with --group-add keep-groups), or to
+# silence device fixups on read-only device mounts.
+SKIP_DEVICE_PERMS="$(echo "${SKIP_DEVICE_PERMS:-false}" | tr '[:upper:]' '[:lower:]')"
+
 echo "Starting BirdNET-Go with UID:$APP_UID, GID:$APP_GID"
 
 # Check ownership of a path and chown only if it differs from expected UID:GID.
@@ -36,11 +42,35 @@ check_and_chown() {
     fi
 }
 
+# Kernel UID mapping table for the current process, read by is_rootless_userns below.
+PROC_UID_MAP="/proc/self/uid_map"
+
+# Detect whether "root" is only root inside a user namespace, i.e. rootless
+# Podman/Docker (or dockerd with userns-remap). Such a namespaced fake root has
+# no capability over host-owned device nodes, so chmod on /dev/snd or /dev/dri
+# always fails with EPERM and only spams errors. Real (rootful) root maps
+# "0 0 4294967295" in uid_map; a namespaced root maps container UID 0 to a
+# nonzero host UID. If uid_map is unreadable we assume real root and keep the
+# previous behavior.
+is_rootless_userns() {
+    local host_uid_for_root
+    host_uid_for_root=$(awk '$1 == 0 { print $2; exit }' "$PROC_UID_MAP" 2>/dev/null) || true
+    [ -n "$host_uid_for_root" ] && [ "$host_uid_for_root" != "0" ]
+}
+
 # Detect if we're running as root or in rootless mode
 CURRENT_UID=$(id -u)
 RUNNING_AS_ROOT=false
 if [ "$CURRENT_UID" -eq 0 ]; then
     RUNNING_AS_ROOT=true
+fi
+
+# True when UID 0 is a namespaced fake root (rootless Podman/Docker). Only
+# meaningful when RUNNING_AS_ROOT is true; an arbitrary non-zero UID never
+# reaches the privileged device paths below.
+ROOTLESS_USERNS=false
+if [ "$RUNNING_AS_ROOT" = true ] && is_rootless_userns; then
+    ROOTLESS_USERNS=true
 fi
 
 # Only perform privileged operations if running as root
@@ -167,21 +197,43 @@ else
     echo "No TZ environment variable set, using container default (UTC)"
 fi
 
-# If audio device present, ensure permissions are correct
+# If audio device present, ensure permissions are correct. Only real (rootful)
+# root can chmod the host-owned nodes; a rootless user namespace cannot (skipped
+# below), and a plain non-root UID (--userns=keep-id or a K8s arbitrary UID)
+# relies on host audio-group membership from --group-add keep-groups, so it
+# matches no branch here and is a deliberate no-op.
 if [ -d "/dev/snd" ]; then
-    if [ "$RUNNING_AS_ROOT" = true ]; then
-        # Add user to audio group
+    if [ "$SKIP_DEVICE_PERMS" = "true" ]; then
+        echo "SKIP_DEVICE_PERMS is set, skipping /dev/snd permission setup"
+    elif [ "$RUNNING_AS_ROOT" = true ] && [ "$ROOTLESS_USERNS" = false ]; then
+        # Rootful root: add the app user to the audio group and open the nodes.
         if getent group audio >/dev/null; then
             adduser "$USER_NAME" audio || true
         fi
         # Make device accessible
         chmod -R a+rw /dev/snd || true
+    elif [ "$ROOTLESS_USERNS" = true ]; then
+        # A namespaced fake root cannot chmod host-owned /dev/snd nodes; attempting
+        # it only prints "Operation not permitted" for every node. Skip it and tell
+        # the user the invocation that actually grants audio in rootless Podman.
+        echo "Note: rootless container detected; skipping /dev/snd permission setup."
+        echo "      For sound card access in rootless Podman, run the container with:"
+        echo "        --userns=keep-id --group-add keep-groups --device /dev/snd"
+        echo "      and make sure your host user is a member of the 'audio' group."
     fi
 fi
 
 # If Intel GPU device present, add user to render group for OpenVINO iGPU inference
 if [ -d "/dev/dri" ]; then
-    if [ "$RUNNING_AS_ROOT" = true ]; then
+    if [ "$SKIP_DEVICE_PERMS" = "true" ]; then
+        echo "SKIP_DEVICE_PERMS is set, skipping /dev/dri group setup"
+    elif [ "$RUNNING_AS_ROOT" = true ]; then
+        # Unlike the /dev/snd chmod above, these addgroup/adduser operations edit
+        # the container's own group database, need no capability over the host
+        # device node, and stay silent under a rootless user namespace, so they
+        # are intentionally NOT gated on ROOTLESS_USERNS. Under dockerd
+        # userns-remap this setup can still grant the render group that OpenVINO
+        # iGPU offload relies on.
         # Detect the actual GID of the first render node on the host; it varies
         # across distributions (105, 109, 44, 989 …) and Docker preserves the
         # host GID when passing --device /dev/dri. Using a hardcoded GID would
@@ -207,9 +259,11 @@ if [ -d "/dev/dri" ]; then
             fi
         fi
     else
-        # Rootless: cannot create or join groups. Intel iGPU access still works if
-        # the container user was started already in the host render group (e.g. via
-        # --group-add on docker run). This is a heads-up, not an error.
+        # Non-root UID (--userns=keep-id or a K8s arbitrary UID): cannot create or
+        # join groups. Intel iGPU access still works if the container user was
+        # started already in the host render group (e.g. via --group-add
+        # keep-groups or --group-add on the run command). This is a heads-up, not
+        # an error.
         echo "Note: /dev/dri present but running rootless; relying on pre-set render group membership for Intel iGPU access"
     fi
 fi

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -11,8 +11,8 @@ SKIP_CHOWN="$(echo "${SKIP_CHOWN:-false}" | tr '[:upper:]' '[:lower:]')"
 
 # SKIP_DEVICE_PERMS: set to "true" to skip all /dev/snd and /dev/dri permission
 # and group adjustments. Useful when the container runtime already grants device
-# access (for example rootless Podman with --group-add keep-groups), or to
-# silence device fixups on read-only device mounts.
+# access (for example rootless Podman with --group-add keep-groups), or to skip
+# the device fixups entirely (for example on read-only device mounts).
 SKIP_DEVICE_PERMS="$(echo "${SKIP_DEVICE_PERMS:-false}" | tr '[:upper:]' '[:lower:]')"
 
 echo "Starting BirdNET-Go with UID:$APP_UID, GID:$APP_GID"
@@ -47,11 +47,11 @@ PROC_UID_MAP="/proc/self/uid_map"
 
 # Detect whether "root" is only root inside a user namespace, i.e. rootless
 # Podman/Docker (or dockerd with userns-remap). Such a namespaced fake root has
-# no capability over host-owned device nodes, so chmod on /dev/snd or /dev/dri
-# always fails with EPERM and only spams errors. Real (rootful) root maps
-# "0 0 4294967295" in uid_map; a namespaced root maps container UID 0 to a
-# nonzero host UID. If uid_map is unreadable we assume real root and keep the
-# previous behavior.
+# no capability over host-owned device nodes, so a chmod on the host-owned
+# /dev/snd nodes always fails with EPERM and only spams errors. Real (rootful)
+# root maps "0 0 4294967295" in uid_map; a namespaced root maps container UID 0
+# to a nonzero host UID. If uid_map is unreadable we assume real root and keep
+# the previous behavior.
 is_rootless_userns() {
     local host_uid_for_root
     host_uid_for_root=$(awk '$1 == 0 { print $2; exit }' "$PROC_UID_MAP" 2>/dev/null) || true
@@ -264,7 +264,7 @@ if [ -d "/dev/dri" ]; then
         # started already in the host render group (e.g. via --group-add
         # keep-groups or --group-add on the run command). This is a heads-up, not
         # an error.
-        echo "Note: /dev/dri present but running rootless; relying on pre-set render group membership for Intel iGPU access"
+        echo "Note: /dev/dri present but running as a non-root user; relying on pre-set render group membership for Intel iGPU access"
     fi
 fi
 

--- a/Podman/README.md
+++ b/Podman/README.md
@@ -72,7 +72,7 @@ Note that `--group-add keep-groups` on its own is not enough with the default co
 
 `--group-add keep-groups` requires the `crun` OCI runtime: it works by telling the runtime to skip the `setgroups` call so the container keeps the host's supplementary groups, and `runc` does not implement that annotation. Podman uses `crun` by default on the distributions this project targets, so this is usually already the case; check yours with `podman info --format '{{.Host.OCIRuntime.Name}}'`.
 
-Set `SKIP_DEVICE_PERMS=true` to make the entrypoint skip all `/dev/snd` and `/dev/dri` permission handling, for example when your runtime configuration already grants device access or when you want the device fixups silenced entirely.
+Set `SKIP_DEVICE_PERMS=true` to make the entrypoint skip all `/dev/snd` and `/dev/dri` permission handling, for example when your runtime configuration already grants device access or when you want to skip the device fixups entirely. The entrypoint still prints a one-line confirmation that the flag took effect, mirroring `SKIP_CHOWN`.
 
 ## Compatibility
 

--- a/Podman/README.md
+++ b/Podman/README.md
@@ -70,6 +70,8 @@ podman run -d --name birdnet-go \
 
 Note that `--group-add keep-groups` on its own is not enough with the default configuration: the entrypoint drops privileges with `gosu`, which clears the inherited `audio` group, so the sound card becomes inaccessible after the drop. Adding `--userns=keep-id` (as above) avoids the privilege drop and is the reliable recipe.
 
+`--group-add keep-groups` requires the `crun` OCI runtime: it works by telling the runtime to skip the `setgroups` call so the container keeps the host's supplementary groups, and `runc` does not implement that annotation. Podman uses `crun` by default on the distributions this project targets, so this is usually already the case; check yours with `podman info --format '{{.Host.OCIRuntime.Name}}'`.
+
 Set `SKIP_DEVICE_PERMS=true` to make the entrypoint skip all `/dev/snd` and `/dev/dri` permission handling, for example when your runtime configuration already grants device access or when you want the device fixups silenced entirely.
 
 ## Compatibility

--- a/Podman/README.md
+++ b/Podman/README.md
@@ -33,11 +33,9 @@ Copy the appropriate example file to `.env` and customize for your setup.
 
 ## Entrypoint Script
 
-- **`entrypoint-podman.sh`** - Podman-optimized entrypoint script
-  - Handles both rootful and rootless container execution
-  - Uses gosu for privilege dropping in rootful mode
-  - Includes pre-flight checks (disk space, config writability)
-  - Timezone configuration support via TZ environment variable
+The published container images use the shared entrypoint baked in from `Docker/entrypoint.sh`, which already handles both rootful and rootless execution under Docker and Podman (user/group setup, device permissions, timezone, and pre-flight checks for disk space and config writability).
+
+- **`entrypoint-podman.sh`** - kept for reference only. It is **not** part of the published images and is not wired into any compose or Quadlet file, so it does not run in normal deployments.
 
 ## Installation
 
@@ -54,6 +52,25 @@ The script will:
 3. Detect and handle any existing Docker installations
 4. Set up Quadlet systemd integration
 5. Configure and start BirdNET-Go
+
+## Rootless Audio Access
+
+Rootless Podman runs the container inside a user namespace. Host-owned `/dev/snd` nodes appear as `nobody:nogroup` inside that namespace, and the container's "root" is an unprivileged host user that cannot change their permissions. Older images tried anyway and printed `chmod: changing permissions of '/dev/snd/...': Operation not permitted` for every node. The entrypoint now detects the rootless user namespace, skips that futile fixup, and prints a short note instead of the error spam.
+
+To actually capture audio in rootless Podman, keep your host user identity and its supplementary groups inside the container with `--userns=keep-id --group-add keep-groups`. Your host user must be a member of the host `audio` group. With `keep-id` the app runs directly as your host UID (not as a namespaced fake root), so the entrypoint takes its rootless path and does not drop privileges, which preserves the `audio` group membership that `keep-groups` provides:
+
+```bash
+podman run -d --name birdnet-go \
+  --userns=keep-id --group-add keep-groups \
+  --device /dev/snd \
+  -p 8080:8080 \
+  -v ./config:/config -v ./data:/data \
+  ghcr.io/tphakala/birdnet-go:nightly
+```
+
+Note that `--group-add keep-groups` on its own is not enough with the default configuration: the entrypoint drops privileges with `gosu`, which clears the inherited `audio` group, so the sound card becomes inaccessible after the drop. Adding `--userns=keep-id` (as above) avoids the privilege drop and is the reliable recipe.
+
+Set `SKIP_DEVICE_PERMS=true` to make the entrypoint skip all `/dev/snd` and `/dev/dri` permission handling, for example when your runtime configuration already grants device access or when you want the device fixups silenced entirely.
 
 ## Compatibility
 


### PR DESCRIPTION
## Summary

Rootless Podman users saw a wall of `chmod: changing permissions of '/dev/snd/...': Operation not permitted` on every startup (#724). Under rootless Podman the container process runs as UID 0 inside a user namespace, so the entrypoint's root check passed and it tried `chmod -R a+rw /dev/snd`, but a namespaced fake root has no capability over host-owned device nodes, so it failed on every node and never accomplished anything.

## Why the noise happened

`id -u` is `0` inside a rootless user namespace, so the old `RUNNING_AS_ROOT` gate could not tell "real root" from "namespaced fake root". The chmod ran and failed on every node. This change reads `/proc/self/uid_map` to distinguish them (real root maps `0 0 4294967295`; a namespaced root maps container UID 0 to a nonzero host UID).

## What changed

- Detect the rootless user namespace and skip the futile `/dev/snd` chmod, printing one short note with the working recipe instead of an error per device node.
- The rootful path (real Docker/Podman as root) is unchanged: it still adds the app user to the `audio` group and opens `/dev/snd`.
- New `SKIP_DEVICE_PERMS=true` env var to opt out of all `/dev/snd` and `/dev/dri` permission handling, mirroring the existing `SKIP_CHOWN`.
- The `/dev/dri` (Intel iGPU) render-group setup only edits the container's own group database, needs no host capability, and is silent under a user namespace, so it keeps running under rootless and is gated only by `SKIP_DEVICE_PERMS`. This preserves iGPU access under dockerd userns-remap.
- `Podman/README.md`: documents the working rootless audio recipe and corrects a stale note implying `entrypoint-podman.sh` is used by the image.

## Rootless audio recipe

For sound card access in rootless Podman, run with `--userns=keep-id --group-add keep-groups --device /dev/snd` and make sure the host user is in the host `audio` group. With `keep-id` the app runs as the host UID (not a namespaced fake root), so the entrypoint takes its rootless path and does not drop privileges, which preserves the `audio` group that `keep-groups` conveys. `--group-add keep-groups` on its own is not enough with the default config, because the `gosu` privilege drop clears the inherited group.

## Testing

Verified with rootless podman 5.4.2 against the dev image with the patched entrypoint, on a host with real sound cards:

| Scenario | Result |
| --- | --- |
| default rootless | no error spam; prints the guidance note |
| `SKIP_DEVICE_PERMS=true` / `TRUE` | skips `/dev/snd` and `/dev/dri` setup, no note |
| `--userns=keep-id --group-add keep-groups` | audio device readable and writable by the app |
| rootful (real root) | chmod still runs, device opened, `/dev/dri` group added, no regression |

`shellcheck -S style` and `bash -n` clean.

Fixes #724


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration to skip audio device permission changes when explicitly disabled or when running in a rootless user namespace.
  * Improved support for rootless container audio access and GPU render-group setup.

* **Documentation**
  * Added Podman guidance for `keep-id`, `keep-groups`, host audio permissions, privilege dropping, and device-permission configuration.
  * Clarified which container entrypoint is used in published images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->