### PR TITLE
feat(models): hardware-aware smart variant selector in the model gallery

### DIFF
--- a/frontend/src/lib/desktop/features/settings/components/ModelVariantPicker.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/ModelVariantPicker.svelte
@@ -1,0 +1,163 @@
+<script lang="ts">
+  /**
+   * Hardware/regional variant picker for the model gallery install dialog. The
+   * recommended variant is preselected by the caller (see pickPreselectedVariant);
+   * this component surfaces why it is recommended, lets the user override, and
+   * explains any incompatible option instead of silently disabling it.
+   */
+  import type { CatalogVariant, VariantReason } from '$lib/types/models';
+  import { t } from '$lib/i18n';
+  import { formatBytes, formatNumber } from '$lib/utils/formatters';
+  import { reasonKey, variantLabel } from '$lib/utils/variantSelection';
+
+  interface Props {
+    variants: CatalogVariant[];
+    installedVariantId?: string;
+    selectedVariantId: string;
+    // eslint-disable-next-line no-unused-vars -- the param name documents the callback contract
+    onSelect: (id: string) => void;
+    /** Disable all options while an install is in flight. */
+    disabled?: boolean;
+    /** Unique prefix for radio input ids so multiple pickers do not collide. */
+    idPrefix: string;
+  }
+
+  let {
+    variants,
+    installedVariantId,
+    selectedVariantId,
+    onSelect,
+    disabled = false,
+    idPrefix,
+  }: Props = $props();
+
+  const hasRecommended = $derived(variants.some(v => v.recommended));
+
+  // Progressive disclosure: when a recommended variant exists, collapse the
+  // other non-installed options so the smart default is what the user sees
+  // first, with manual override one click away.
+  let showAll = $state(false);
+
+  function alwaysShown(variant: CatalogVariant): boolean {
+    return (
+      variant.recommended ||
+      variant.installed ||
+      variant.id === selectedVariantId ||
+      variant.id === installedVariantId
+    );
+  }
+
+  const visibleVariants = $derived(
+    !hasRecommended || showAll ? variants : variants.filter(alwaysShown)
+  );
+  const hiddenCount = $derived(variants.length - visibleVariants.length);
+
+  function reasonText(reason: VariantReason): string {
+    const key = reasonKey(reason.code);
+    const translated = t(key, reason.args);
+    // t returns the key itself when there is no translation; fall back to the raw
+    // reason code so an unmapped reason stays inspectable rather than surfacing a
+    // dotted i18n key to the user.
+    return translated === key ? reason.code : translated;
+  }
+
+  // The reason shown on a blocked option: its first blocker, or a generic
+  // localized line when the server marked it incompatible without a structured
+  // reason, so a disabled option is never left silently unexplained.
+  function blockedReasonText(variant: CatalogVariant): string {
+    const blocker = variant.blockers?.[0];
+    return blocker ? reasonText(blocker) : t('analysis.gallery.variants.incompatible');
+  }
+</script>
+
+<fieldset class="border border-base-300 rounded-lg p-3">
+  <legend class="text-sm font-medium px-1">{t('analysis.gallery.variants.title')}</legend>
+
+  <!-- Native radios sharing a name inside the fieldset already form a labeled
+       radio group, so no explicit role/aria-label is needed here. -->
+  <div class="flex flex-col gap-2">
+    {#each visibleVariants as variant (variant.id)}
+      {@const inputId = `${idPrefix}-${variant.id}`}
+      {@const blocked = !variant.compatible}
+      <label
+        for={inputId}
+        class="flex items-start gap-3 rounded-md border p-2 transition-colors
+          {selectedVariantId === variant.id ? 'border-primary bg-primary/5' : 'border-base-300'}
+          {blocked ? 'bg-base-200/40' : 'cursor-pointer hover:bg-base-200'}"
+      >
+        <input
+          id={inputId}
+          type="radio"
+          class="radio radio-sm radio-primary mt-0.5"
+          name="{idPrefix}-variant"
+          value={variant.id}
+          checked={selectedVariantId === variant.id}
+          disabled={disabled || blocked}
+          title={blocked ? blockedReasonText(variant) : undefined}
+          aria-describedby={blocked ? `${inputId}-reason` : undefined}
+          onchange={() => onSelect(variant.id)}
+        />
+
+        <div class="flex flex-col gap-1 min-w-0 flex-1">
+          <div class="flex flex-wrap items-center gap-2">
+            <span class="font-medium">{variantLabel(variant)}</span>
+            {#if variant.recommended}
+              <span class="badge badge-primary badge-sm"
+                >{t('analysis.gallery.variants.recommended')}</span
+              >
+            {/if}
+            {#if variant.installed}
+              <span class="badge badge-info badge-sm"
+                >{t('analysis.gallery.variants.installed')}</span
+              >
+            {/if}
+            {#if variant.default}
+              <span class="badge badge-ghost badge-sm"
+                >{t('analysis.gallery.variants.default')}</span
+              >
+            {/if}
+          </div>
+
+          <div class="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-base-content/70">
+            <span>{formatBytes(variant.sizeBytes)}</span>
+            {#if variant.speciesCount > 0}
+              <span
+                >{t('analysis.gallery.species', {
+                  count: formatNumber(variant.speciesCount),
+                })}</span
+              >
+            {/if}
+            {#if variant.headlineLatencyMs && variant.headlineLatencyMs > 0}
+              <span
+                >{t('analysis.gallery.variants.latency', { ms: variant.headlineLatencyMs })}</span
+              >
+            {/if}
+          </div>
+
+          {#if variant.recommended && variant.reasons?.length}
+            <p class="text-xs text-primary/90">
+              {t('analysis.gallery.variants.recommendedForHardware')}: {reasonText(
+                variant.reasons[0]
+              )}
+            </p>
+          {/if}
+
+          {#if blocked}
+            <p id="{inputId}-reason" class="text-xs text-error">{blockedReasonText(variant)}</p>
+          {/if}
+        </div>
+      </label>
+    {/each}
+  </div>
+
+  {#if hasRecommended && hiddenCount > 0 && !showAll}
+    <button
+      type="button"
+      class="btn btn-ghost btn-xs mt-2"
+      aria-expanded={showAll}
+      onclick={() => (showAll = true)}
+    >
+      {t('analysis.gallery.variants.showAll', { count: hiddenCount })}
+    </button>
+  {/if}
+</fieldset>

--- a/frontend/src/lib/desktop/features/settings/components/ModelVariantPicker.test.ts
+++ b/frontend/src/lib/desktop/features/settings/components/ModelVariantPicker.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+import ModelVariantPicker from './ModelVariantPicker.svelte';
+import type { CatalogVariant } from '$lib/types/models';
+
+function variant(overrides: Partial<CatalogVariant> & { id: string }): CatalogVariant {
+  return {
+    speciesCount: 0,
+    default: false,
+    installed: false,
+    sizeBytes: 1000,
+    compatible: true,
+    recommended: false,
+    ...overrides,
+  };
+}
+
+const variants: CatalogVariant[] = [
+  variant({
+    id: 'fp16',
+    precision: 'fp16',
+    recommended: true,
+    reasons: [{ code: 'backend.recommended', args: { backend: 'openvino-gpu' } }],
+  }),
+  variant({ id: 'fp32', precision: 'fp32', default: true }),
+  variant({
+    id: 'int8-arm',
+    precision: 'int8',
+    compatible: false,
+    blockers: [{ code: 'arch.unsupported', args: { required: 'aarch64' } }],
+  }),
+];
+
+function radios(container: HTMLElement): HTMLInputElement[] {
+  return Array.from(container.querySelectorAll('input[type="radio"]'));
+}
+
+function radioByValue(container: HTMLElement, value: string): HTMLInputElement | null {
+  return container.querySelector(`input[value="${value}"]`);
+}
+
+describe('ModelVariantPicker', () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it('collapses non-recommended options behind a show-all toggle', () => {
+    const { container, getByRole } = render(ModelVariantPicker, {
+      props: {
+        variants,
+        selectedVariantId: 'fp16',
+        onSelect: vi.fn(),
+        idPrefix: 'p1',
+      },
+    });
+    // Only the recommended variant is shown initially.
+    expect(radios(container)).toHaveLength(1);
+    expect(radioByValue(container, 'fp16')).not.toBeNull();
+    // The toggle reveals the rest.
+    expect(getByRole('button')).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('reveals all variants when show-all is clicked', async () => {
+    const { container, getByRole } = render(ModelVariantPicker, {
+      props: {
+        variants,
+        selectedVariantId: 'fp16',
+        onSelect: vi.fn(),
+        idPrefix: 'p2',
+      },
+    });
+    await fireEvent.click(getByRole('button'));
+    expect(radios(container)).toHaveLength(3);
+  });
+
+  it('preselects the recommended variant', () => {
+    const { container } = render(ModelVariantPicker, {
+      props: {
+        variants,
+        selectedVariantId: 'fp16',
+        onSelect: vi.fn(),
+        idPrefix: 'p3',
+      },
+    });
+    expect(radioByValue(container, 'fp16')?.checked).toBe(true);
+  });
+
+  it('disables an incompatible variant and shows its blocker reason', async () => {
+    const { container, getByRole } = render(ModelVariantPicker, {
+      props: {
+        variants,
+        selectedVariantId: 'fp16',
+        onSelect: vi.fn(),
+        idPrefix: 'p4',
+      },
+    });
+    await fireEvent.click(getByRole('button')); // reveal all
+    const blocked = radioByValue(container, 'int8-arm');
+    expect(blocked?.disabled).toBe(true);
+    // reasonText falls back to the raw code when t returns the key (t is mocked to
+    // echo the key in tests), so the blocker reason renders the raw dotted code.
+    expect(container.textContent).toContain('arch.unsupported');
+  });
+
+  it('shows a generic reason for a blocked variant that has no structured blocker', async () => {
+    const noReasonVariants: CatalogVariant[] = [
+      variant({ id: 'ok', precision: 'fp32', recommended: true }),
+      variant({ id: 'blocked-no-reason', precision: 'int8', compatible: false }),
+    ];
+    const { container, getByRole } = render(ModelVariantPicker, {
+      props: {
+        variants: noReasonVariants,
+        selectedVariantId: 'ok',
+        onSelect: vi.fn(),
+        idPrefix: 'p6',
+      },
+    });
+    await fireEvent.click(getByRole('button')); // reveal all
+    const blocked = radioByValue(container, 'blocked-no-reason');
+    expect(blocked?.disabled).toBe(true);
+    // Falls back to the generic localized "incompatible" line, never left blank.
+    expect(container.textContent).toContain('analysis.gallery.variants.incompatible');
+  });
+
+  it('keeps an installed non-recommended variant visible in the collapsed view', () => {
+    const withInstalled: CatalogVariant[] = [
+      variant({ id: 'fp16', precision: 'fp16', recommended: true }),
+      variant({ id: 'int8-arm', precision: 'int8', installed: true }),
+      variant({ id: 'fp32', precision: 'fp32', default: true }),
+    ];
+    const { container } = render(ModelVariantPicker, {
+      props: {
+        variants: withInstalled,
+        installedVariantId: 'int8-arm',
+        selectedVariantId: 'fp16',
+        onSelect: vi.fn(),
+        idPrefix: 'p7',
+      },
+    });
+    // Recommended + installed shown; the plain default stays collapsed.
+    expect(radioByValue(container, 'fp16')).not.toBeNull();
+    expect(radioByValue(container, 'int8-arm')).not.toBeNull();
+    expect(radioByValue(container, 'fp32')).toBeNull();
+  });
+
+  it('shows all variants and no toggle when none is recommended', () => {
+    const noneRecommended: CatalogVariant[] = [
+      variant({ id: 'a', precision: 'fp32', default: true }),
+      variant({ id: 'b', precision: 'int8' }),
+    ];
+    const { container, queryByRole } = render(ModelVariantPicker, {
+      props: {
+        variants: noneRecommended,
+        selectedVariantId: 'a',
+        onSelect: vi.fn(),
+        idPrefix: 'p8',
+      },
+    });
+    expect(radios(container)).toHaveLength(2);
+    expect(queryByRole('button')).toBeNull();
+  });
+
+  it('fires onSelect when the user picks a different variant (manual override)', async () => {
+    const onSelect = vi.fn();
+    const { container, getByRole } = render(ModelVariantPicker, {
+      props: {
+        variants,
+        selectedVariantId: 'fp16',
+        onSelect,
+        idPrefix: 'p5',
+      },
+    });
+    await fireEvent.click(getByRole('button')); // reveal all
+    const fp32 = radioByValue(container, 'fp32');
+    expect(fp32).not.toBeNull();
+    await fireEvent.click(fp32 as HTMLInputElement);
+    expect(onSelect).toHaveBeenCalledWith('fp32');
+  });
+});

--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
@@ -42,6 +42,7 @@
   import type { TabDefinition } from '$lib/desktop/features/settings/components/SettingsTabs.svelte';
   import SettingsSection from '$lib/desktop/features/settings/components/SettingsSection.svelte';
   import SettingsNote from '$lib/desktop/features/settings/components/SettingsNote.svelte';
+  import ModelVariantPicker from '$lib/desktop/features/settings/components/ModelVariantPicker.svelte';
   import NumberField from '$lib/desktop/components/forms/NumberField.svelte';
   import FalsePositiveFilterControl, {
     type FilterLevel,
@@ -66,6 +67,7 @@
   import { buildAppUrl } from '$lib/utils/urlHelpers';
   import { toastActions } from '$lib/stores/toast';
   import { formatBytes, formatNumber } from '$lib/utils/formatters';
+  import { pickPreselectedVariant } from '$lib/utils/variantSelection';
   import { safeArrayAccess } from '$lib/utils/security';
   import { loggers } from '$lib/utils/logger';
   import { t } from '$lib/i18n';
@@ -131,6 +133,23 @@
   let completionTimer: ReturnType<typeof setTimeout> | undefined;
 
   let licenseModel = $state<CatalogEntry | null>(null);
+  // The variant preselected in the license/install dialog: the server-recommended
+  // one by default, overridable by the user. Empty for flat (variant-less) entries.
+  let selectedVariantId = $state('');
+  // The download-size row and the install target follow the selected variant when
+  // the entry has variants; otherwise they fall back to the whole-entry size.
+  const licenseSelectedVariant = $derived(
+    licenseModel?.variants?.find(v => v.id === selectedVariantId) ?? null
+  );
+  const licenseDownloadSize = $derived(
+    licenseSelectedVariant?.sizeBytes ?? licenseModel?.totalSizeBytes ?? 0
+  );
+  // Block install when the selected variant cannot run on this host (e.g. every
+  // variant is incompatible, so the preselected one is blocked). The default
+  // path preselects a compatible variant, so this only fires in the all-blocked case.
+  const installBlocked = $derived(
+    licenseSelectedVariant != null && !licenseSelectedVariant.compatible
+  );
   let removeConfirmModel = $state<CatalogEntry | null>(null);
 
   // Element bindings should NOT use $state - causes showModal() to fail
@@ -895,6 +914,9 @@
 
   function openLicenseDialog(entry: CatalogEntry) {
     licenseModel = entry;
+    // Smart default: preselect the recommended variant (falls back sensibly when
+    // there is no recommendation). Empty string for flat entries.
+    selectedVariantId = pickPreselectedVariant(entry);
     licenseDialogRef?.showModal();
   }
 
@@ -905,13 +927,19 @@
 
   async function handleInstall() {
     if (!licenseModel) return;
+    // Never install a variant the recommender flagged incompatible with this host
+    // (the button is disabled in this state; this guards a programmatic call too).
+    if (installBlocked) return;
     const modelId = licenseModel.id;
+    // Only send a variantId when the entry actually offers variants; a flat entry
+    // installs its single build with no variant.
+    const variantId = licenseModel.variants?.length ? selectedVariantId : undefined;
     closeLicenseDialog();
     installingId = modelId;
     downloadProgress = null;
 
     try {
-      await installModel(modelId);
+      await installModel(modelId, variantId);
 
       if (progressCleanup) progressCleanup();
       progressCleanup = subscribeInstallProgress(
@@ -2212,11 +2240,21 @@
                 >{t('analysis.gallery.license.downloadSize')}</th
               >
               <td class="px-4 pt-1 pb-4 text-right align-top text-[var(--color-base-content)]"
-                >{formatBytes(licenseModel.totalSizeBytes)}</td
+                >{formatBytes(licenseDownloadSize)}</td
               >
             </tr>
           </tbody>
         </table>
+
+        {#if licenseModel.variants && licenseModel.variants.length > 0}
+          <ModelVariantPicker
+            variants={licenseModel.variants}
+            installedVariantId={licenseModel.installedVariantId}
+            {selectedVariantId}
+            onSelect={id => (selectedVariantId = id)}
+            idPrefix="license-variant"
+          />
+        {/if}
 
         {#if !licenseModel.commercialUse}
           <div
@@ -2230,16 +2268,25 @@
         {/if}
       </div>
 
+      {#if installBlocked}
+        <p class="mt-4 text-sm text-[var(--color-error)]" role="alert">
+          {t('analysis.gallery.variants.incompatible')}
+        </p>
+      {/if}
       <div class="mt-6 flex justify-end gap-3">
         <button
+          type="button"
           onclick={closeLicenseDialog}
           class="rounded-lg border border-[var(--color-base-300)] px-4 py-2 text-sm font-medium text-[var(--color-base-content)] hover:bg-[var(--color-base-200)] transition-colors"
         >
           {t('common.cancel')}
         </button>
         <button
+          type="button"
           onclick={handleInstall}
-          class="inline-flex items-center gap-2 rounded-lg bg-[var(--color-primary)] px-4 py-2 text-sm font-medium text-[var(--color-primary-content)] hover:bg-[var(--color-primary)]/80 transition-colors"
+          disabled={installBlocked}
+          title={installBlocked ? t('analysis.gallery.variants.incompatible') : undefined}
+          class="inline-flex items-center gap-2 rounded-lg bg-[var(--color-primary)] px-4 py-2 text-sm font-medium text-[var(--color-primary-content)] hover:bg-[var(--color-primary)]/80 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
         >
           <Download class="size-4" />
           {t('analysis.gallery.license.acceptAndInstall')}

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -3846,6 +3846,24 @@ export type TranslationKey =
   | 'analysis.downloadSource.endpoint.validationMessage'
   | 'analysis.gallery.title'
   | 'analysis.gallery.description'
+  | 'analysis.gallery.variants.title'
+  | 'analysis.gallery.variants.recommended'
+  | 'analysis.gallery.variants.recommendedForHardware'
+  | 'analysis.gallery.variants.installed'
+  | 'analysis.gallery.variants.default'
+  | 'analysis.gallery.variants.incompatible'
+  | 'analysis.gallery.variants.showAll' // params: count
+  | 'analysis.gallery.variants.latency' // params: ms
+  | 'analysis.gallery.reasons.backendRecommended' // params: backend
+  | 'analysis.gallery.reasons.backendSupported' // params: backend
+  | 'analysis.gallery.reasons.precisionFp16Native'
+  | 'analysis.gallery.reasons.ramConstrainedFit'
+  | 'analysis.gallery.reasons.benchmarkMeasured'
+  | 'analysis.gallery.reasons.variantLegacy'
+  | 'analysis.gallery.reasons.archUnsupported' // params: required
+  | 'analysis.gallery.reasons.backendMissing' // params: required
+  | 'analysis.gallery.reasons.ramInsufficient' // params: requiredMb
+  | 'analysis.gallery.reasons.hardwareExcluded' // params: token
   | 'analysis.gallery.tabs.installed'
   | 'analysis.gallery.tabs.available'
   | 'analysis.gallery.loading'
@@ -4407,6 +4425,14 @@ export type TranslationParams = {
     version: string | number;
     species: string | number;
   };
+  'analysis.gallery.variants.showAll': { count: string | number };
+  'analysis.gallery.variants.latency': { ms: string | number };
+  'analysis.gallery.reasons.backendRecommended': { backend: string | number };
+  'analysis.gallery.reasons.backendSupported': { backend: string | number };
+  'analysis.gallery.reasons.archUnsupported': { required: string | number };
+  'analysis.gallery.reasons.backendMissing': { required: string | number };
+  'analysis.gallery.reasons.ramInsufficient': { requiredMb: string | number };
+  'analysis.gallery.reasons.hardwareExcluded': { token: string | number };
   'analysis.gallery.species': { count: string | number };
   'analysis.gallery.removeDialog.title': { name: string | number };
 };

--- a/frontend/src/lib/types/models.ts
+++ b/frontend/src/lib/types/models.ts
@@ -3,6 +3,38 @@
 // These types mirror the Go structs in internal/classifier/model_manager.go
 // and the API response types in internal/api/v2/models.go.
 
+/**
+ * A structured, localizable reason for a variant's recommendation or
+ * incompatibility. `code` is an i18n key stem (e.g. "backend.recommended"), never
+ * an English sentence; `args` carries values interpolated into the localized text.
+ */
+export interface VariantReason {
+  code: string;
+  args?: Record<string, string>;
+}
+
+/**
+ * One selectable hardware or regional variant of a catalog entry. Mirrors the
+ * Go CatalogVariantResponse (internal/api/v2/models/models.go). The
+ * `compatible`/`recommended`/`reasons`/`blockers` fields are populated only when
+ * the request is eligible for hardware recommendations; otherwise `compatible`
+ * defaults to true and the reason lists are absent.
+ */
+export interface CatalogVariant {
+  id: string;
+  region?: string;
+  precision?: string;
+  speciesCount: number;
+  default: boolean;
+  installed: boolean;
+  sizeBytes: number;
+  headlineLatencyMs?: number;
+  compatible: boolean;
+  recommended: boolean;
+  reasons?: VariantReason[];
+  blockers?: VariantReason[];
+}
+
 /** A model entry in the catalog, enriched with install/compat status. */
 export interface CatalogEntry {
   id: string;
@@ -21,6 +53,12 @@ export interface CatalogEntry {
   incompatibleReason?: string;
   totalSizeBytes: number;
   hasGeomodel: boolean;
+  /** Selectable hardware/regional variants, absent for flat single-variant entries. */
+  variants?: CatalogVariant[];
+  /** The id of the currently installed variant, or absent when not installed or flat. */
+  installedVariantId?: string;
+  /** The variant the gallery preselects for this host, absent when not eligible. */
+  recommendedVariantId?: string;
 }
 
 /** Response wrapper for the catalog endpoint. */
@@ -35,6 +73,8 @@ export interface InstalledModel {
   labelsPath: string;
   installedAt: string;
   version: string;
+  /** The installed variant id, absent for flat (pre-variant) entries. */
+  variantId?: string;
 }
 
 /** Progress state for an ongoing model download, sent via SSE. */

--- a/frontend/src/lib/utils/modelsApi.ts
+++ b/frontend/src/lib/utils/modelsApi.ts
@@ -23,9 +23,14 @@ export async function fetchInstalled(): Promise<InstalledModel[]> {
   return api.get<InstalledModel[]>(`${BASE}/installed`);
 }
 
-/** Start an asynchronous model install. Returns once the server accepts the request. */
-export async function installModel(id: string): Promise<void> {
-  await api.post(`${BASE}/install/${encodeURIComponent(id)}`);
+/**
+ * Start an asynchronous model install. Returns once the server accepts the
+ * request. When `variantId` is given the server installs (or switches to) that
+ * hardware/regional variant; omitting it installs the entry's default variant.
+ */
+export async function installModel(id: string, variantId?: string): Promise<void> {
+  const body = variantId ? { variantId } : undefined;
+  await api.post(`${BASE}/install/${encodeURIComponent(id)}`, body);
 }
 
 /** Remove an installed model from disk. */

--- a/frontend/src/lib/utils/variantSelection.test.ts
+++ b/frontend/src/lib/utils/variantSelection.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { pickPreselectedVariant, reasonKey, variantLabel } from './variantSelection';
+import type { CatalogEntry, CatalogVariant } from '$lib/types/models';
+
+function variant(overrides: Partial<CatalogVariant> & { id: string }): CatalogVariant {
+  return {
+    speciesCount: 0,
+    default: false,
+    installed: false,
+    sizeBytes: 0,
+    compatible: true,
+    recommended: false,
+    ...overrides,
+  };
+}
+
+function entry(overrides: Partial<CatalogEntry>): CatalogEntry {
+  return {
+    id: 'e',
+    name: 'E',
+    description: '',
+    author: '',
+    license: '',
+    commercialUse: false,
+    category: 'wildlife',
+    region: '',
+    speciesCount: 0,
+    version: '1',
+    installed: false,
+    compatible: true,
+    totalSizeBytes: 0,
+    hasGeomodel: false,
+    ...overrides,
+  };
+}
+
+describe('pickPreselectedVariant', () => {
+  it('returns empty string when the entry has no variants', () => {
+    expect(pickPreselectedVariant(entry({}))).toBe('');
+  });
+
+  it('prefers the recommended variant', () => {
+    const e = entry({
+      recommendedVariantId: 'fp16',
+      installedVariantId: 'fp32',
+      variants: [
+        variant({ id: 'fp32', default: true }),
+        variant({ id: 'fp16', recommended: true }),
+      ],
+    });
+    expect(pickPreselectedVariant(e)).toBe('fp16');
+  });
+
+  it('falls back to the installed variant when no recommendation', () => {
+    const e = entry({
+      installedVariantId: 'int8-arm',
+      variants: [
+        variant({ id: 'fp32', default: true }),
+        variant({ id: 'int8-arm', installed: true }),
+      ],
+    });
+    expect(pickPreselectedVariant(e)).toBe('int8-arm');
+  });
+
+  it('falls back to the default variant', () => {
+    const e = entry({
+      variants: [variant({ id: 'a' }), variant({ id: 'fp32', default: true })],
+    });
+    expect(pickPreselectedVariant(e)).toBe('fp32');
+  });
+
+  it('falls back to the first compatible variant when there is no default', () => {
+    const e = entry({
+      variants: [
+        variant({ id: 'blocked', compatible: false }),
+        variant({ id: 'ok', compatible: true }),
+      ],
+    });
+    expect(pickPreselectedVariant(e)).toBe('ok');
+  });
+
+  it('falls back to the first variant when none is default or compatible', () => {
+    const e = entry({
+      variants: [
+        variant({ id: 'first', compatible: false }),
+        variant({ id: 'second', compatible: false }),
+      ],
+    });
+    expect(pickPreselectedVariant(e)).toBe('first');
+  });
+
+  it('ignores a stale recommended id that is not in the variant list', () => {
+    const e = entry({
+      recommendedVariantId: 'gone',
+      variants: [variant({ id: 'fp32', default: true })],
+    });
+    expect(pickPreselectedVariant(e)).toBe('fp32');
+  });
+});
+
+describe('reasonKey', () => {
+  it.each([
+    ['backend.recommended', 'analysis.gallery.reasons.backendRecommended'],
+    ['backend.supported', 'analysis.gallery.reasons.backendSupported'],
+    ['precision.fp16_native', 'analysis.gallery.reasons.precisionFp16Native'],
+    ['ram.constrained_fit', 'analysis.gallery.reasons.ramConstrainedFit'],
+    ['variant.legacy', 'analysis.gallery.reasons.variantLegacy'],
+    ['arch.unsupported', 'analysis.gallery.reasons.archUnsupported'],
+    ['ram.insufficient', 'analysis.gallery.reasons.ramInsufficient'],
+    ['hardware.excluded', 'analysis.gallery.reasons.hardwareExcluded'],
+  ])('maps %s to %s', (code, key) => {
+    expect(reasonKey(code)).toBe(key);
+  });
+});
+
+describe('variantLabel', () => {
+  it('uppercases the precision', () => {
+    expect(variantLabel(variant({ id: 'fp32', precision: 'fp32' }))).toBe('FP32');
+  });
+
+  it('disambiguates variants that share a precision by the non-precision id part', () => {
+    expect(variantLabel(variant({ id: 'no-dft-fp32', precision: 'fp32' }))).toBe('FP32 (no-dft)');
+    expect(variantLabel(variant({ id: 'int8-arm', precision: 'int8' }))).toBe('INT8 (arm)');
+  });
+
+  it('appends the region when set', () => {
+    expect(variantLabel(variant({ id: 'fp16', precision: 'fp16', region: 'Finland' }))).toBe(
+      'FP16 (Finland)'
+    );
+  });
+
+  it('falls back to the id when precision is absent', () => {
+    expect(variantLabel(variant({ id: 'custom' }))).toBe('custom');
+  });
+});

--- a/frontend/src/lib/utils/variantSelection.ts
+++ b/frontend/src/lib/utils/variantSelection.ts
@@ -1,0 +1,76 @@
+// Pure helpers for the model gallery variant picker. No Svelte, no I/O, so they
+// are trivially unit-testable.
+
+import type { CatalogEntry, CatalogVariant } from '$lib/types/models';
+
+/**
+ * Choose the variant the gallery preselects for an entry. This is the "smart by
+ * default" decision: the server-recommended variant when present, else the
+ * installed one, else the catalog default, else the first compatible one, else
+ * the first variant. Returns '' when the entry has no variants.
+ *
+ * Each id is checked against the actual variant list so a stale recommended or
+ * installed id (e.g. a variant hidden because it is Legacy) falls through to the
+ * next rule instead of selecting nothing.
+ */
+export function pickPreselectedVariant(entry: CatalogEntry): string {
+  const variants = entry.variants ?? [];
+  if (variants.length === 0) return '';
+
+  const has = (id: string | undefined): id is string =>
+    id !== undefined && variants.some(v => v.id === id);
+
+  if (has(entry.recommendedVariantId)) return entry.recommendedVariantId;
+  if (has(entry.installedVariantId)) return entry.installedVariantId;
+
+  // Prefer a compatible variant so the dialog never opens with a blocked one
+  // preselected while a runnable variant exists: compatible default, else any
+  // compatible, else the default, else the first. When every variant is blocked
+  // the first is returned and the install control is disabled by the dialog.
+  const preferred =
+    variants.find(v => v.default && v.compatible) ??
+    variants.find(v => v.compatible) ??
+    variants.find(v => v.default) ??
+    variants[0];
+  return preferred.id;
+}
+
+/**
+ * Map a structured reason code to its i18n key stem under
+ * `analysis.gallery.reasons`. Both dot and underscore separators become
+ * camelCase boundaries, so "precision.fp16_native" -> "precisionFp16Native".
+ * Callers render the reason via `t(reasonKey(code), args)`. When the key has no
+ * translation `t` returns the key string itself, so callers fall back to the raw
+ * `code` to keep an untranslated reason inspectable (see ModelVariantPicker's
+ * reasonText).
+ */
+export function reasonKey(code: string): string {
+  const stem = code
+    .split(/[._]/)
+    .filter(Boolean)
+    .map((segment, index) =>
+      index === 0 ? segment : segment.charAt(0).toUpperCase() + segment.slice(1)
+    )
+    .join('');
+  return `analysis.gallery.reasons.${stem}`;
+}
+
+/**
+ * Human-facing label for a variant: the precision uppercased, with the part of
+ * the id that is not the precision appended in parentheses so variants sharing a
+ * precision stay distinguishable (e.g. "fp32" -> "FP32", "no-dft-fp32" ->
+ * "FP32 (no-dft)", "int8-arm" -> "INT8 (arm)"). Falls back to the raw id when the
+ * variant carries no precision. The region, when set, is appended last.
+ */
+export function variantLabel(variant: CatalogVariant): string {
+  const precision = variant.precision?.toUpperCase() ?? '';
+  const extra = variant.id
+    .split(/[-_]/)
+    .filter(segment => segment !== '' && segment.toLowerCase() !== variant.precision?.toLowerCase())
+    .join('-');
+  let base = precision || variant.id;
+  if (precision && extra) {
+    base = `${precision} (${extra})`;
+  }
+  return variant.region ? `${base} (${variant.region})` : base;
+}

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -5283,6 +5283,28 @@
     "gallery": {
       "title": "Galerie modelů",
       "description": "Správa klasifikačních modelů pro detekci ptáků a netopýrů.",
+      "variants": {
+        "title": "Varianta modelu",
+        "recommended": "Doporučeno",
+        "recommendedForHardware": "Nejlepší pro váš hardware",
+        "installed": "Nainstalováno",
+        "default": "Výchozí",
+        "incompatible": "Není k dispozici pro váš hardware",
+        "showAll": "Zobrazit všechny varianty ({count})",
+        "latency": "~{ms} ms"
+      },
+      "reasons": {
+        "backendRecommended": "Běží na {backend}, doporučeném backendu pro váš hardware",
+        "backendSupported": "Běží na {backend}",
+        "precisionFp16Native": "Verze s poloviční přesností odpovídající vašemu procesoru",
+        "ramConstrainedFit": "Kvantizovaná verze optimalizovaná pro vaši dostupnou paměť",
+        "benchmarkMeasured": "Nejrychlejší na vašem zařízení podle měření výkonu",
+        "variantLegacy": "Nahrazeno novější verzí",
+        "archUnsupported": "Vyžaduje procesor {required}",
+        "backendMissing": "Vyžaduje inferenční backend, který není dostupný ({required})",
+        "ramInsufficient": "Vyžaduje alespoň {requiredMb} MB paměti",
+        "hardwareExcluded": "Nepodporováno na vašem hardwaru ({token})"
+      },
       "tabs": {
         "installed": "Nainstalované",
         "available": "Dostupné"

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -5283,6 +5283,28 @@
     "gallery": {
       "title": "Modelgalleri",
       "description": "Administrer klassifikatormodeller til fugle- og flagermusdetektion.",
+      "variants": {
+        "title": "Modelvariant",
+        "recommended": "Anbefalet",
+        "recommendedForHardware": "Bedst til din hardware",
+        "installed": "Installeret",
+        "default": "Standard",
+        "incompatible": "Ikke tilgængelig for din hardware",
+        "showAll": "Vis alle varianter ({count})",
+        "latency": "~{ms} ms"
+      },
+      "reasons": {
+        "backendRecommended": "Kører på {backend}, den anbefalede backend til din hardware",
+        "backendSupported": "Kører på {backend}",
+        "precisionFp16Native": "Halvpræcisionsversion, der passer til din CPU",
+        "ramConstrainedFit": "Kvantiseret version tilpasset din tilgængelige hukommelse",
+        "benchmarkMeasured": "Hurtigst på din enhed i udførte benchmarks",
+        "variantLegacy": "Erstattet af en nyere version",
+        "archUnsupported": "Kræver en {required} CPU",
+        "backendMissing": "Kræver en inference backend, som din version ikke kan nå ({required})",
+        "ramInsufficient": "Kræver mindst {requiredMb} MB hukommelse",
+        "hardwareExcluded": "Understøttes ikke på din hardware ({token})"
+      },
       "tabs": {
         "installed": "Installerede",
         "available": "Tilgængelige"

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -5283,6 +5283,28 @@
     "gallery": {
       "title": "Modellgalerie",
       "description": "Klassifikatormodelle für Vogel- und Fledermauserkennungen verwalten.",
+      "variants": {
+        "title": "Modellvariante",
+        "recommended": "Empfohlen",
+        "recommendedForHardware": "Am besten für Ihre Hardware",
+        "installed": "Installiert",
+        "default": "Standard",
+        "incompatible": "Für Ihre Hardware nicht verfügbar",
+        "showAll": "Alle Varianten anzeigen ({count})",
+        "latency": "~{ms} ms"
+      },
+      "reasons": {
+        "backendRecommended": "Läuft auf {backend}, dem empfohlenen Backend für Ihre Hardware",
+        "backendSupported": "Läuft auf {backend}",
+        "precisionFp16Native": "Half-Precision-Build, abgestimmt auf Ihren Prozessor",
+        "ramConstrainedFit": "Quantisierter Build, optimiert für Ihren verfügbaren Speicher",
+        "benchmarkMeasured": "Am schnellsten auf Ihrem Gerät laut Benchmarks",
+        "variantLegacy": "Durch einen neueren Build ersetzt",
+        "archUnsupported": "Erfordert einen {required}-Prozessor",
+        "backendMissing": "Benötigt ein Inference-Backend, das nicht erreichbar ist ({required})",
+        "ramInsufficient": "Benötigt mindestens {requiredMb} MB Speicher",
+        "hardwareExcluded": "Wird von Ihrer Hardware nicht unterstützt ({token})"
+      },
       "tabs": {
         "installed": "Installiert",
         "available": "Verfügbar"

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -5283,6 +5283,28 @@
     "gallery": {
       "title": "Model Gallery",
       "description": "Manage classifier models for bird and bat detection.",
+      "variants": {
+        "title": "Model variant",
+        "recommended": "Recommended",
+        "recommendedForHardware": "Best for your hardware",
+        "installed": "Installed",
+        "default": "Default",
+        "incompatible": "Not available for your hardware",
+        "showAll": "Show all variants ({count})",
+        "latency": "~{ms} ms"
+      },
+      "reasons": {
+        "backendRecommended": "Runs on {backend}, the recommended backend for your hardware",
+        "backendSupported": "Runs on {backend}",
+        "precisionFp16Native": "Half-precision build matched to your CPU",
+        "ramConstrainedFit": "Quantized build sized for your available memory",
+        "benchmarkMeasured": "Fastest on your device in measured benchmarks",
+        "variantLegacy": "Superseded by a newer build",
+        "archUnsupported": "Requires a {required} CPU",
+        "backendMissing": "Needs an inference backend your build cannot reach ({required})",
+        "ramInsufficient": "Needs at least {requiredMb} MB of memory",
+        "hardwareExcluded": "Not supported on your hardware ({token})"
+      },
       "tabs": {
         "installed": "Installed",
         "available": "Available"

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -5283,6 +5283,28 @@
     "gallery": {
       "title": "Galería de modelos",
       "description": "Gestionar modelos clasificadores para la detección de aves y murciélagos.",
+      "variants": {
+        "title": "Variante de modelo",
+        "recommended": "Recomendado",
+        "recommendedForHardware": "Ideal para tu hardware",
+        "installed": "Instalado",
+        "default": "Predeterminado",
+        "incompatible": "No disponible para tu hardware",
+        "showAll": "Mostrar todas las variantes ({count})",
+        "latency": "~{ms} ms"
+      },
+      "reasons": {
+        "backendRecommended": "Se ejecuta en {backend}, el backend recomendado para tu hardware",
+        "backendSupported": "Se ejecuta en {backend}",
+        "precisionFp16Native": "Versión de media precisión adaptada a tu procesador",
+        "ramConstrainedFit": "Versión cuantizada ajustada a tu memoria disponible",
+        "benchmarkMeasured": "El más rápido en tu dispositivo según pruebas de rendimiento",
+        "variantLegacy": "Reemplazado por una versión más reciente",
+        "archUnsupported": "Requiere un procesador {required}",
+        "backendMissing": "Necesita un backend de inferencia que tu versión no puede alcanzar ({required})",
+        "ramInsufficient": "Necesita al menos {requiredMb} MB de memoria",
+        "hardwareExcluded": "No compatible con tu hardware ({token})"
+      },
       "tabs": {
         "installed": "Instalados",
         "available": "Disponibles"

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -5283,6 +5283,28 @@
     "gallery": {
       "title": "Malligalleria",
       "description": "Hallitse lintu- ja lepakkotunnistuksen luokittelumalleja.",
+      "variants": {
+        "title": "Mallivariantti",
+        "recommended": "Suositeltu",
+        "recommendedForHardware": "Paras laitteistollesi",
+        "installed": "Asennettu",
+        "default": "Oletus",
+        "incompatible": "Ei saatavilla laitteistollesi",
+        "showAll": "Näytä kaikki variantit ({count})",
+        "latency": "~{ms} ms"
+      },
+      "reasons": {
+        "backendRecommended": "Käyttää taustajärjestelmää {backend}, joka on suositeltu laitteistollesi",
+        "backendSupported": "Käyttää taustajärjestelmää {backend}",
+        "precisionFp16Native": "Puolitarkkuusmalli (fp16), optimoitu suorittimellesi",
+        "ramConstrainedFit": "Kvantisoitu malli, mitoitettu käytettävissä olevalle muistillesi",
+        "benchmarkMeasured": "Laitteesi nopein suorituskykytestien perusteella",
+        "variantLegacy": "Korvattu uudemmalla versiolla",
+        "archUnsupported": "Vaatii {required}-suorittimen",
+        "backendMissing": "Vaatii inferenssin taustajärjestelmän, joka ei ole käytettävissä ({required})",
+        "ramInsufficient": "Vaatii vähintään {requiredMb} MB muistia",
+        "hardwareExcluded": "Ei tue laitteistoasi ({token})"
+      },
       "tabs": {
         "installed": "Asennetut",
         "available": "Saatavilla"

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -5283,6 +5283,28 @@
     "gallery": {
       "title": "Galerie de modèles",
       "description": "Gérer les modèles classificateurs pour la détection des oiseaux et des chauves-souris.",
+      "variants": {
+        "title": "Variante du modèle",
+        "recommended": "Recommandé",
+        "recommendedForHardware": "Le meilleur pour votre matériel",
+        "installed": "Installé",
+        "default": "Par défaut",
+        "incompatible": "Non disponible pour votre matériel",
+        "showAll": "Afficher toutes les variantes ({count})",
+        "latency": "~{ms} ms"
+      },
+      "reasons": {
+        "backendRecommended": "S'exécute sur {backend}, le backend recommandé pour votre matériel",
+        "backendSupported": "S'exécute sur {backend}",
+        "precisionFp16Native": "Version en demi-précision adaptée à votre processeur",
+        "ramConstrainedFit": "Version quantifiée ajustée à votre mémoire disponible",
+        "benchmarkMeasured": "Le plus rapide sur votre appareil d'après les tests",
+        "variantLegacy": "Remplacé par une version plus récente",
+        "archUnsupported": "Nécessite un processeur {required}",
+        "backendMissing": "Nécessite un backend d'inférence inaccessible ({required})",
+        "ramInsufficient": "Nécessite au moins {requiredMb} MB de mémoire",
+        "hardwareExcluded": "Non pris en charge par votre matériel ({token})"
+      },
       "tabs": {
         "installed": "Installés",
         "available": "Disponibles"

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -5283,6 +5283,28 @@
     "gallery": {
       "title": "Modellgaléria",
       "description": "Osztályozó modellek kezelése madár- és denevérdetektáláshoz.",
+      "variants": {
+        "title": "Modellváltozat",
+        "recommended": "Ajánlott",
+        "recommendedForHardware": "A legjobb a hardveredhez",
+        "installed": "Telepítve",
+        "default": "Alapértelmezett",
+        "incompatible": "Nem érhető el az Ön hardveréhez",
+        "showAll": "Összes változat mutatása ({count})",
+        "latency": "~{ms} ms"
+      },
+      "reasons": {
+        "backendRecommended": "Ezen fut: {backend}, amely a hardveredhez ajánlott backend",
+        "backendSupported": "Ezen fut: {backend}",
+        "precisionFp16Native": "A CPU-hoz igazított félpontosságú (fp16) build",
+        "ramConstrainedFit": "A rendelkezésre álló memóriához méretezett kvantált build",
+        "benchmarkMeasured": "Mérések alapján a leggyorsabb az eszközödön",
+        "variantLegacy": "Egy újabb build váltotta fel",
+        "archUnsupported": "Egy {required} CPU szükséges hozzá",
+        "backendMissing": "Olyan következtetési backendet igényel, amelyet a build nem ér el ({required})",
+        "ramInsufficient": "Legalább {requiredMb} MB memória szükséges",
+        "hardwareExcluded": "Nem támogatott a hardvereden ({token})"
+      },
       "tabs": {
         "installed": "Telepített",
         "available": "Elérhető"

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -5283,6 +5283,28 @@
     "gallery": {
       "title": "Galleria modelli",
       "description": "Gestisci i modelli di classificazione per il rilevamento di uccelli e pipistrelli.",
+      "variants": {
+        "title": "Variante modello",
+        "recommended": "Consigliato",
+        "recommendedForHardware": "Il migliore per il tuo hardware",
+        "installed": "Installato",
+        "default": "Predefinito",
+        "incompatible": "Non disponibile per il tuo hardware",
+        "showAll": "Mostra tutte le varianti ({count})",
+        "latency": "~{ms} ms"
+      },
+      "reasons": {
+        "backendRecommended": "Eseguito su {backend}, il backend consigliato per il tuo hardware",
+        "backendSupported": "Eseguito su {backend}",
+        "precisionFp16Native": "Versione a mezza precisione adatta al tuo processore",
+        "ramConstrainedFit": "Versione quantizzata ottimizzata per la tua memoria disponibile",
+        "benchmarkMeasured": "Il più veloce sul tuo dispositivo secondo i benchmark",
+        "variantLegacy": "Sostituito da una versione più recente",
+        "archUnsupported": "Richiede un processore {required}",
+        "backendMissing": "Richiede un backend di inferenza che la tua versione non può raggiungere ({required})",
+        "ramInsufficient": "Richiede almeno {requiredMb} MB di memoria",
+        "hardwareExcluded": "Non supportato dal tuo hardware ({token})"
+      },
       "tabs": {
         "installed": "Installati",
         "available": "Disponibili"

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -5283,6 +5283,28 @@
     "gallery": {
       "title": "Modeļu galerija",
       "description": "Pārvaldiet klasifikācijas modeļus putnu un sikspārņu noteikšanai.",
+      "variants": {
+        "title": "Modeļa variants",
+        "recommended": "Ieteicams",
+        "recommendedForHardware": "Labākais jūsu aparatūrai",
+        "installed": "Instalēts",
+        "default": "Noklusējuma",
+        "incompatible": "Nav pieejams jūsu aparatūrai",
+        "showAll": "Rādīt visus variantus ({count})",
+        "latency": "~{ms} ms"
+      },
+      "reasons": {
+        "backendRecommended": "Darbojas ar {backend}, kas ir ieteicamā aizmugursistēma jūsu aparatūrai",
+        "backendSupported": "Darbojas ar {backend}",
+        "precisionFp16Native": "Pusprecizitātes versija, kas pielāgota jūsu procesoram",
+        "ramConstrainedFit": "Kvantizēta versija, kas pielāgota jūsu pieejamajai atmiņai",
+        "benchmarkMeasured": "Ātrākais jūsu ierīcē saskaņā ar veiktspējas testiem",
+        "variantLegacy": "Aizstāts ar jaunāku versiju",
+        "archUnsupported": "Nepieciešams {required} procesors",
+        "backendMissing": "Nepieciešama inferences aizmugursistēma, ko jūsu versija nevar sasniegt ({required})",
+        "ramInsufficient": "Nepieciešami vismaz {requiredMb} MB atmiņas",
+        "hardwareExcluded": "Nav atbalstīts jūsu aparatūrā ({token})"
+      },
       "tabs": {
         "installed": "Instalētie",
         "available": "Pieejamie"

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -5283,6 +5283,28 @@
     "gallery": {
       "title": "Modellgalleri",
       "description": "Administrer klassifikatormodeller for fugle- og flaggermusdeteksjon.",
+      "variants": {
+        "title": "Modellvariant",
+        "recommended": "Anbefalt",
+        "recommendedForHardware": "Best for din maskinvare",
+        "installed": "Installert",
+        "default": "Standard",
+        "incompatible": "Ikke tilgjengelig for maskinvaren din",
+        "showAll": "Vis alle varianter ({count})",
+        "latency": "~{ms} ms"
+      },
+      "reasons": {
+        "backendRecommended": "Kjører på {backend}, som er den anbefalte backenden for din maskinvare",
+        "backendSupported": "Kjører på {backend}",
+        "precisionFp16Native": "Halvpresisjonsversjon tilpasset din CPU",
+        "ramConstrainedFit": "Kvantisert versjon tilpasset ditt tilgjengelige minne",
+        "benchmarkMeasured": "Raskest på din enhet i utførte ytelsestester",
+        "variantLegacy": "Erstattet av en nyere versjon",
+        "archUnsupported": "Krever en {required} CPU",
+        "backendMissing": "Krever en inference-backend som versjonen din ikke når ({required})",
+        "ramInsufficient": "Krever minst {requiredMb} MB minne",
+        "hardwareExcluded": "Støttes ikke på din maskinvare ({token})"
+      },
       "tabs": {
         "installed": "Installert",
         "available": "Tilgjengelig"

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -5283,6 +5283,28 @@
     "gallery": {
       "title": "Modellengalerij",
       "description": "Beheer classificatiemodellen voor vogel- en vleermuisdetectie.",
+      "variants": {
+        "title": "Modelvariant",
+        "recommended": "Aanbevolen",
+        "recommendedForHardware": "Beste voor jouw hardware",
+        "installed": "Geïnstalleerd",
+        "default": "Standaard",
+        "incompatible": "Niet beschikbaar voor uw hardware",
+        "showAll": "Toon alle varianten ({count})",
+        "latency": "~{ms} ms"
+      },
+      "reasons": {
+        "backendRecommended": "Draait op {backend}, de aanbevolen backend voor jouw hardware",
+        "backendSupported": "Draait op {backend}",
+        "precisionFp16Native": "Halve-precisie versie afgestemd op je processor",
+        "ramConstrainedFit": "Gekwantiseerde versie aangepast aan je beschikbare geheugen",
+        "benchmarkMeasured": "Snelste op jouw apparaat in gemeten benchmarks",
+        "variantLegacy": "Vervangen door een nieuwere versie",
+        "archUnsupported": "Vereist een {required} processor",
+        "backendMissing": "Heeft een inference backend nodig die je installatie niet kan bereiken ({required})",
+        "ramInsufficient": "Heeft minimaal {requiredMb} MB geheugen nodig",
+        "hardwareExcluded": "Niet ondersteund op jouw hardware ({token})"
+      },
       "tabs": {
         "installed": "Geïnstalleerd",
         "available": "Beschikbaar"

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -5283,6 +5283,28 @@
     "gallery": {
       "title": "Galeria modeli",
       "description": "Zarządzaj modelami klasyfikatorów do detekcji ptaków i nietoperzy.",
+      "variants": {
+        "title": "Wariant modelu",
+        "recommended": "Zalecane",
+        "recommendedForHardware": "Najlepsze dla twojego sprzętu",
+        "installed": "Zainstalowany",
+        "default": "Domyślne",
+        "incompatible": "Niedostępne dla Twojego sprzętu",
+        "showAll": "Pokaż wszystkie warianty ({count})",
+        "latency": "~{ms} ms"
+      },
+      "reasons": {
+        "backendRecommended": "Działa na {backend}, zalecanym backendzie dla twojego sprzętu",
+        "backendSupported": "Działa na {backend}",
+        "precisionFp16Native": "Wersja o połowicznej precyzji dopasowana do twojego procesora",
+        "ramConstrainedFit": "Skwantyzowana wersja dopasowana do dostępnej pamięci",
+        "benchmarkMeasured": "Najszybszy na twoim urządzeniu w przeprowadzonych testach",
+        "variantLegacy": "Zastąpiony nowszą wersją",
+        "archUnsupported": "Wymaga procesora {required}",
+        "backendMissing": "Wymaga backendu wnioskowania, który jest niedostępny ({required})",
+        "ramInsufficient": "Wymaga co najmniej {requiredMb} MB pamięci",
+        "hardwareExcluded": "Brak wsparcia na twoim sprzęcie ({token})"
+      },
       "tabs": {
         "installed": "Zainstalowane",
         "available": "Dostępne"

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -5283,6 +5283,28 @@
     "gallery": {
       "title": "Galeria de modelos",
       "description": "Gerenciar modelos classificadores para detecção de aves e morcegos.",
+      "variants": {
+        "title": "Variante do modelo",
+        "recommended": "Recomendado",
+        "recommendedForHardware": "Ideal para o seu hardware",
+        "installed": "Instalado",
+        "default": "Padrão",
+        "incompatible": "Não disponível para o seu hardware",
+        "showAll": "Mostrar todas as variantes ({count})",
+        "latency": "~{ms} ms"
+      },
+      "reasons": {
+        "backendRecommended": "Roda em {backend}, o backend recomendado para o seu hardware",
+        "backendSupported": "Roda em {backend}",
+        "precisionFp16Native": "Versão de meia precisão ajustada para o seu processador",
+        "ramConstrainedFit": "Versão quantizada otimizada para a memória disponível",
+        "benchmarkMeasured": "O mais rápido no seu dispositivo segundo os testes de desempenho",
+        "variantLegacy": "Substituído por uma versão mais recente",
+        "archUnsupported": "Requer um processador {required}",
+        "backendMissing": "Necessita de um backend de inferência que a sua versão não consegue alcançar ({required})",
+        "ramInsufficient": "Necessita de pelo menos {requiredMb} MB de memória",
+        "hardwareExcluded": "Não suportado no seu hardware ({token})"
+      },
       "tabs": {
         "installed": "Instalados",
         "available": "Disponíveis"

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -5283,6 +5283,28 @@
     "gallery": {
       "title": "Galéria modelov",
       "description": "Správa klasifikačných modelov pre detekciu vtákov a netopierov.",
+      "variants": {
+        "title": "Variant modelu",
+        "recommended": "Odporúčané",
+        "recommendedForHardware": "Najlepšie pre váš hardvér",
+        "installed": "Nainštalovaný",
+        "default": "Predvolené",
+        "incompatible": "Nie je k dispozícii pre váš hardvér",
+        "showAll": "Zobraziť všetky varianty ({count})",
+        "latency": "~{ms} ms"
+      },
+      "reasons": {
+        "backendRecommended": "Beží na {backend}, čo je odporúčaný backend pre váš hardvér",
+        "backendSupported": "Beží na {backend}",
+        "precisionFp16Native": "Verzia s polovičnou presnosťou zodpovedajúca vášmu procesoru",
+        "ramConstrainedFit": "Kvantizovaná verzia optimalizovaná pre vašu dostupnú pamäť",
+        "benchmarkMeasured": "Najrýchlejší na vašom zariadení podľa meraní výkonu",
+        "variantLegacy": "Nahradené novšou verziou",
+        "archUnsupported": "Vyžaduje procesor {required}",
+        "backendMissing": "Vyžaduje inferenčný backend, ktorý nie je dostupný ({required})",
+        "ramInsufficient": "Vyžaduje aspoň {requiredMb} MB pamäte",
+        "hardwareExcluded": "Nepodporované na vašom hardvéri ({token})"
+      },
       "tabs": {
         "installed": "Nainštalované",
         "available": "Dostupné"

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -5283,6 +5283,28 @@
     "gallery": {
       "title": "Modellgalleri",
       "description": "Hantera klassificeringsmodeller för fågel- och fladdermusdetektion.",
+      "variants": {
+        "title": "Modellvariant",
+        "recommended": "Rekommenderad",
+        "recommendedForHardware": "Bäst för din hårdvara",
+        "installed": "Installerad",
+        "default": "Standard",
+        "incompatible": "Inte tillgänglig för din hårdvara",
+        "showAll": "Visa alla varianter ({count})",
+        "latency": "~{ms} ms"
+      },
+      "reasons": {
+        "backendRecommended": "Körs på {backend}, den rekommenderade backend-motorn för din hårdvara",
+        "backendSupported": "Körs på {backend}",
+        "precisionFp16Native": "Halvprecisionsbygge anpassat för din CPU",
+        "ramConstrainedFit": "Kvantiserat bygge anpassat för ditt tillgängliga minne",
+        "benchmarkMeasured": "Snabbast på din enhet enligt prestandatester",
+        "variantLegacy": "Ersatt av en nyare version",
+        "archUnsupported": "Kräver en {required} CPU",
+        "backendMissing": "Kräver en inference-backend som din version inte kan nå ({required})",
+        "ramInsufficient": "Kräver minst {requiredMb} MB minne",
+        "hardwareExcluded": "Stöds inte på din hårdvara ({token})"
+      },
       "tabs": {
         "installed": "Installerade",
         "available": "Tillgängliga"

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -468,9 +468,6 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	// (c.media.ServeSpeciesImageProxy). They are passed as bound method values; c
 	// is fully constructed here, so the method values are stable for its lifetime.
 	c.species = species.New(c.Core, c.loadCommonNameMap, c.media.ServeSpeciesImageProxy)
-	// The models handler needs only the shared core (ModelManager and the
-	// settings/error/log/goroutine helpers all promote from it).
-	c.models = models.New(c.Core)
 	// The support handler needs only the shared core (settings, datastore, V2
 	// manager, and the error/log/goroutine helpers all promote from it).
 	c.support = support.New(c.Core)
@@ -549,6 +546,15 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	// Settings/AuthMiddleware helpers promote from c.Core; the live audio-level
 	// channel is wired later via SetAudioLevelChan.
 	c.audio = audioapi.New(c.Core, c.authService)
+
+	// Construct the models domain handler AFTER the functional options are applied
+	// so it captures the post-option authService. The catalog endpoint uses it to
+	// gate the hardware-derived recommendation fields to authenticated (or
+	// auth-not-required) requests, so an anonymous caller on an auth-enabled
+	// instance does not learn the host's hardware profile. authService never
+	// changes after this point, so capturing it here is behaviorally identical to
+	// a per-request read; every other models dependency promotes from c.Core.
+	c.models = models.New(c.Core, c.authService)
 
 	// Log auth configuration status
 	log := GetLogger()

--- a/internal/api/v2/models/models.go
+++ b/internal/api/v2/models/models.go
@@ -45,7 +45,9 @@ type Handler struct {
 	// is an injectable seam: nil means "use the default live probe"
 	// (defaultHardwareProfile), and tests set it to synthetic hardware. A
 	// per-Handler field rather than a package global, so tests stay parallel-safe.
-	hardwareProfile func(onnxRuntimePath string) hwprofile.Profile
+	// It receives the request's already-probed ONNX Runtime status so the default
+	// probe does not re-check ORT that GetModelCatalog just checked.
+	hardwareProfile func(ort inference.ORTStatus) hwprofile.Profile
 }
 
 // New builds a models Handler around the shared core and the facade-injected
@@ -212,7 +214,7 @@ func (c *Handler) GetModelCatalog(ctx echo.Context) error {
 	var recsByVariant map[string]map[string]recommend.Recommendation
 	var recommendedVariant map[string]string
 	if c.recommendationsAllowed(ctx) {
-		recsByVariant, recommendedVariant = c.rankCatalog(visible)
+		recsByVariant, recommendedVariant = c.rankCatalog(visible, ortStatus)
 	}
 
 	for i := range visible {
@@ -340,12 +342,12 @@ func (c *Handler) recommendationsAllowed(ctx echo.Context) bool {
 // rankCatalog computes the per-host variant recommendations for the visible
 // catalog, indexed by catalog ID then variant ID, plus the recommended variant
 // per entry.
-func (c *Handler) rankCatalog(entries []classifier.CatalogEntry) (byVariant map[string]map[string]recommend.Recommendation, recommended map[string]string) {
+func (c *Handler) rankCatalog(entries []classifier.CatalogEntry, ort inference.ORTStatus) (byVariant map[string]map[string]recommend.Recommendation, recommended map[string]string) {
 	profileFn := c.hardwareProfile
 	if profileFn == nil {
 		profileFn = defaultHardwareProfile
 	}
-	profile := profileFn(c.CurrentSettings().BirdNET.ONNXRuntimePath)
+	profile := profileFn(ort)
 	recs := recommend.Rank(recommend.Input{
 		Capabilities:  profile.Capabilities(),
 		TotalRAMBytes: profile.TotalRAMBytes,
@@ -370,13 +372,13 @@ func (c *Handler) rankCatalog(entries []classifier.CatalogEntry) (byVariant map[
 	return byVariant, recommended
 }
 
-// defaultHardwareProfile resolves the live host profile with per-request backend
-// probes, mirroring the inference-status endpoint (internal/api/v2/system/
-// inference_status.go): the ONNX Runtime path comes from settings so a
-// hot-reloaded runtime path is honored, and the OpenVINO device list feeds GPU
-// capability derivation. It is the production value of the hardwareProfile seam.
-func defaultHardwareProfile(onnxRuntimePath string) hwprofile.Profile {
-	ort := inference.CheckORTAvailability(onnxRuntimePath)
+// defaultHardwareProfile resolves the live host profile from the already-probed
+// ONNX Runtime status plus a per-request OpenVINO device probe, mirroring the
+// inference-status endpoint (internal/api/v2/system/inference_status.go). The ORT
+// status is passed in (probed once per request by GetModelCatalog) rather than
+// re-probed here, and the OpenVINO device list feeds GPU capability derivation.
+// It is the production value of the hardwareProfile seam.
+func defaultHardwareProfile(ort inference.ORTStatus) hwprofile.Profile {
 	ov := inference.CheckOpenVINOAvailability()
 	var devices []string
 	if ov.Supported {

--- a/internal/api/v2/models/models.go
+++ b/internal/api/v2/models/models.go
@@ -18,10 +18,13 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/api/auth"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/classifier"
+	"github.com/tphakala/birdnet-go/internal/classifier/recommend"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/hwprofile"
 	"github.com/tphakala/birdnet-go/internal/inference"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
@@ -31,13 +34,26 @@ import (
 // carries atomic/lock-bearing fields and must never be copied by value.
 type Handler struct {
 	*apicore.Core
+	// authService gates the hardware-derived recommendation fields on the public
+	// catalog endpoint to authenticated (or auth-not-required) requests, so an
+	// anonymous caller on an auth-enabled instance cannot read the host's hardware
+	// profile. nil in tests and when WithAuthService was not injected, in which
+	// case enrichment is computed unconditionally (there is no auth boundary to
+	// protect).
+	authService auth.Service
+	// hardwareProfile resolves the host inference profile for the recommender. It
+	// is an injectable seam: nil means "use the default live probe"
+	// (defaultHardwareProfile), and tests set it to synthetic hardware. A
+	// per-Handler field rather than a package global, so tests stay parallel-safe.
+	hardwareProfile func(onnxRuntimePath string) hwprofile.Profile
 }
 
-// New builds a models Handler around the shared core. The models handlers need
-// only the shared *apicore.Core (ModelManager, settings, error/log helpers and
-// the goroutine plumbing), so there are no facade-owned dependencies to inject.
-func New(core *apicore.Core) *Handler {
-	return &Handler{Core: core}
+// New builds a models Handler around the shared core and the facade-injected
+// auth service. The auth service is read only to gate the catalog endpoint's
+// hardware-recommendation fields; every other dependency (ModelManager,
+// settings, error/log helpers, goroutine plumbing) promotes from *apicore.Core.
+func New(core *apicore.Core, authService auth.Service) *Handler {
+	return &Handler{Core: core, authService: authService}
 }
 
 // RegisterRoutes registers all model-related API endpoints on the supplied API
@@ -86,6 +102,10 @@ type CatalogEntryResponse struct {
 	// Variants lists the selectable hardware/regional variants of this model,
 	// omitted for flat single-variant entries.
 	Variants []CatalogVariantResponse `json:"variants,omitempty"`
+	// RecommendedVariantID is the variant the gallery preselects for this host.
+	// Omitted for flat entries and when the request is not eligible for hardware
+	// recommendations (an unauthenticated request on an auth-enabled instance).
+	RecommendedVariantID string `json:"recommendedVariantId,omitempty"`
 }
 
 // CatalogVariantResponse describes one selectable hardware or regional variant of
@@ -99,6 +119,25 @@ type CatalogVariantResponse struct {
 	Installed         bool   `json:"installed"`
 	SizeBytes         int64  `json:"sizeBytes"`
 	HeadlineLatencyMs int    `json:"headlineLatencyMs,omitempty"`
+	// Compatible reports whether this variant can run on the host. It defaults to
+	// true (no hardware evaluation performed) so a client that did not receive
+	// recommendations does not render every variant as incompatible.
+	Compatible bool `json:"compatible"`
+	// Recommended marks the single variant the gallery preselects for this host.
+	Recommended bool `json:"recommended"`
+	// Reasons explain the recommendation score; Blockers explain incompatibility.
+	// Both are structured codes the frontend localizes, omitted when the request
+	// is not eligible for hardware recommendations.
+	Reasons  []VariantReasonResponse `json:"reasons,omitempty"`
+	Blockers []VariantReasonResponse `json:"blockers,omitempty"`
+}
+
+// VariantReasonResponse is a structured, localizable reason for a variant's
+// compatibility or recommendation. Code is an i18n key stem (never an English
+// sentence); Args carries the values the frontend interpolates into the string.
+type VariantReasonResponse struct {
+	Code string            `json:"code"`
+	Args map[string]string `json:"args,omitempty"`
 }
 
 // installModelRequest is the optional JSON body of POST /models/install/:id. An
@@ -165,6 +204,17 @@ func (c *Handler) GetModelCatalog(ctx echo.Context) error {
 	// Check ORT availability once, reuse for all entries that require ONNX.
 	ortStatus := inference.CheckORTAvailability(c.CurrentSettings().BirdNET.ONNXRuntimePath)
 
+	// Hardware recommendations are gated to authenticated (or auth-not-required)
+	// requests, so an anonymous caller on an auth-enabled instance cannot read the
+	// host's hardware profile from this public endpoint. When enrichment is off,
+	// recsByVariant/recommendedVariant stay nil and every variant reports the
+	// neutral Compatible=true with no reasons.
+	var recsByVariant map[string]map[string]recommend.Recommendation
+	var recommendedVariant map[string]string
+	if c.recommendationsAllowed(ctx) {
+		recsByVariant, recommendedVariant = c.rankCatalog(visible)
+	}
+
 	for i := range visible {
 		entry := &visible[i]
 
@@ -193,24 +243,25 @@ func (c *Handler) GetModelCatalog(ctx echo.Context) error {
 		}
 
 		catalog = append(catalog, CatalogEntryResponse{
-			ID:                 entry.ID,
-			Name:               entry.Name,
-			Description:        entry.Description,
-			Author:             entry.Author,
-			License:            entry.License,
-			CommercialUse:      entry.CommercialUse,
-			Category:           entry.Category,
-			Region:             entry.Region,
-			SpeciesCount:       entry.SpeciesCount,
-			Version:            entry.Version,
-			UpstreamURL:        entry.UpstreamURL,
-			Installed:          installed,
-			Compatible:         compatible,
-			IncompatibleReason: incompatibleReason,
-			TotalSizeBytes:     totalSize,
-			HasGeomodel:        classifier.HasGeomodelFiles(entry),
-			InstalledVariantID: installedVariantID,
-			Variants:           buildVariantResponses(entry, installed, installedVariantID),
+			ID:                   entry.ID,
+			Name:                 entry.Name,
+			Description:          entry.Description,
+			Author:               entry.Author,
+			License:              entry.License,
+			CommercialUse:        entry.CommercialUse,
+			Category:             entry.Category,
+			Region:               entry.Region,
+			SpeciesCount:         entry.SpeciesCount,
+			Version:              entry.Version,
+			UpstreamURL:          entry.UpstreamURL,
+			Installed:            installed,
+			Compatible:           compatible,
+			IncompatibleReason:   incompatibleReason,
+			TotalSizeBytes:       totalSize,
+			HasGeomodel:          classifier.HasGeomodelFiles(entry),
+			InstalledVariantID:   installedVariantID,
+			RecommendedVariantID: recommendedVariant[entry.ID],
+			Variants:             buildVariantResponses(entry, installed, installedVariantID, recsByVariant[entry.ID]),
 		})
 	}
 
@@ -219,11 +270,14 @@ func (c *Handler) GetModelCatalog(ctx echo.Context) error {
 	})
 }
 
-// buildVariantResponses maps a catalog entry's variants to their API form. It
-// returns nil for a flat (single-variant) entry so the field is omitted. A Legacy
-// variant (a superseded build) is hidden unless it is the one currently installed,
-// so the gallery never offers a fresh install of a deprecated build.
-func buildVariantResponses(entry *classifier.CatalogEntry, installed bool, installedVariantID string) []CatalogVariantResponse {
+// buildVariantResponses maps a catalog entry's variants to their API form,
+// joining in the per-variant recommendations when recs is non-nil (recs is nil
+// when the request is not eligible for hardware recommendations, and is keyed by
+// variant ID). It returns nil for a flat (single-variant) entry so the field is
+// omitted, and hides a Legacy (superseded) variant unless it is the one
+// currently installed, so the gallery never offers a fresh install of a
+// deprecated build.
+func buildVariantResponses(entry *classifier.CatalogEntry, installed bool, installedVariantID string, recs map[string]recommend.Recommendation) []CatalogVariantResponse {
 	if len(entry.Variants) == 0 {
 		return nil
 	}
@@ -249,7 +303,7 @@ func buildVariantResponses(entry *classifier.CatalogEntry, installed bool, insta
 			}
 		}
 
-		variants = append(variants, CatalogVariantResponse{
+		resp := CatalogVariantResponse{
 			ID:                v.ID,
 			Region:            v.Region,
 			Precision:         v.Precision,
@@ -258,9 +312,97 @@ func buildVariantResponses(entry *classifier.CatalogEntry, installed bool, insta
 			Installed:         isInstalledVariant,
 			SizeBytes:         sizeBytes,
 			HeadlineLatencyMs: headlineLatencyMs,
-		})
+			// Neutral default: without a recommendation the variant is not claimed
+			// incompatible. Overwritten below when recommendations are present.
+			Compatible: true,
+		}
+		if rec, ok := recs[v.ID]; ok {
+			resp.Compatible = rec.Compatible
+			resp.Recommended = rec.Recommended
+			resp.Reasons = toReasonResponses(rec.Reasons)
+			resp.Blockers = toReasonResponses(rec.Blockers)
+		}
+		variants = append(variants, resp)
 	}
 	return variants
+}
+
+// recommendationsAllowed reports whether this request may receive the
+// hardware-derived recommendation fields. Auth-not-required (a home LAN with
+// auth disabled, or a subnet-bypass client) and authenticated requests both
+// qualify; an anonymous request on an auth-enabled instance does not. A nil
+// authService (tests, or WithAuthService not injected) allows enrichment,
+// because there is then no auth boundary whose leak we are guarding.
+func (c *Handler) recommendationsAllowed(ctx echo.Context) bool {
+	return c.authService == nil || c.authService.IsAuthenticated(ctx)
+}
+
+// rankCatalog computes the per-host variant recommendations for the visible
+// catalog, indexed by catalog ID then variant ID, plus the recommended variant
+// per entry.
+func (c *Handler) rankCatalog(entries []classifier.CatalogEntry) (byVariant map[string]map[string]recommend.Recommendation, recommended map[string]string) {
+	profileFn := c.hardwareProfile
+	if profileFn == nil {
+		profileFn = defaultHardwareProfile
+	}
+	profile := profileFn(c.CurrentSettings().BirdNET.ONNXRuntimePath)
+	recs := recommend.Rank(recommend.Input{
+		Capabilities:  profile.Capabilities(),
+		TotalRAMBytes: profile.TotalRAMBytes,
+		DeviceClass:   recommend.DeviceClass(profile.Board.Tier, profile.Arch),
+		Entries:       entries,
+	})
+
+	byVariant = make(map[string]map[string]recommend.Recommendation, len(entries))
+	recommended = make(map[string]string)
+	for i := range recs {
+		r := &recs[i]
+		m := byVariant[r.CatalogID]
+		if m == nil {
+			m = make(map[string]recommend.Recommendation)
+			byVariant[r.CatalogID] = m
+		}
+		m[r.VariantID] = *r
+		if r.Recommended {
+			recommended[r.CatalogID] = r.VariantID
+		}
+	}
+	return byVariant, recommended
+}
+
+// defaultHardwareProfile resolves the live host profile with per-request backend
+// probes, mirroring the inference-status endpoint (internal/api/v2/system/
+// inference_status.go): the ONNX Runtime path comes from settings so a
+// hot-reloaded runtime path is honored, and the OpenVINO device list feeds GPU
+// capability derivation. It is the production value of the hardwareProfile seam.
+func defaultHardwareProfile(onnxRuntimePath string) hwprofile.Profile {
+	ort := inference.CheckORTAvailability(onnxRuntimePath)
+	ov := inference.CheckOpenVINOAvailability()
+	var devices []string
+	if ov.Supported {
+		for _, d := range []string{inference.OVDeviceCPU, inference.OVDeviceGPU} {
+			if inference.OpenVINOHasDevice(d) {
+				devices = append(devices, d)
+			}
+		}
+	}
+	return hwprofile.Hardware().WithBackends(hwprofile.Backends{
+		TFLite:   hwprofile.BackendStatus{Available: hwprofile.TFLiteLinked()},
+		ONNX:     hwprofile.BackendStatus{Available: ort.Available, Initialized: ort.Initialized, Version: ort.Version},
+		OpenVINO: hwprofile.OpenVINOStatus{Supported: ov.Supported, Active: ov.Active, Devices: devices},
+	})
+}
+
+// toReasonResponses maps recommender reasons to their API form.
+func toReasonResponses(reasons []recommend.Reason) []VariantReasonResponse {
+	if len(reasons) == 0 {
+		return nil
+	}
+	out := make([]VariantReasonResponse, len(reasons))
+	for i := range reasons {
+		out[i] = VariantReasonResponse{Code: reasons[i].Code, Args: reasons[i].Args}
+	}
+	return out
 }
 
 // GetInstalledModels returns all models that have been downloaded and installed.

--- a/internal/api/v2/models/models_recommend_test.go
+++ b/internal/api/v2/models/models_recommend_test.go
@@ -1,0 +1,165 @@
+package models
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/auth"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
+	"github.com/tphakala/birdnet-go/internal/classifier/recommend"
+	"github.com/tphakala/birdnet-go/internal/hwprofile"
+)
+
+// stubAuth is a minimal auth.Service double that answers only IsAuthenticated.
+// It embeds the interface so it satisfies auth.Service without spelling out the
+// other methods; the catalog handler calls only IsAuthenticated, so the nil
+// embedded interface is never dereferenced.
+type stubAuth struct {
+	auth.Service
+	authenticated bool
+	called        bool
+}
+
+func (s *stubAuth) IsAuthenticated(echo.Context) bool {
+	s.called = true
+	return s.authenticated
+}
+
+// amd64ONNXProfile is a synthetic host profile: 64-bit x86 with the ONNX Runtime
+// backend available and ample RAM. Its Capabilities() are {x86-64, onnxruntime-cpu}.
+func amd64ONNXProfile() hwprofile.Profile {
+	return hwprofile.Profile{
+		Arch:          "amd64",
+		TotalRAMBytes: 16 * 1024 * 1024 * 1024,
+		Backends:      hwprofile.Backends{ONNX: hwprofile.BackendStatus{Available: true}},
+	}
+}
+
+// catalogRequest issues GET /models/catalog against the handler and returns the
+// decoded catalog.
+func catalogRequest(t *testing.T, h *Handler) []CatalogEntryResponse {
+	t.Helper()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/models/catalog", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	require.NoError(t, h.GetModelCatalog(ctx))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Catalog []CatalogEntryResponse `json:"catalog"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	return resp.Catalog
+}
+
+func findEntry(catalog []CatalogEntryResponse, id string) *CatalogEntryResponse {
+	for i := range catalog {
+		if catalog[i].ID == id {
+			return &catalog[i]
+		}
+	}
+	return nil
+}
+
+func findVariant(entry *CatalogEntryResponse, id string) *CatalogVariantResponse {
+	for i := range entry.Variants {
+		if entry.Variants[i].ID == id {
+			return &entry.Variants[i]
+		}
+	}
+	return nil
+}
+
+func TestGetModelCatalog_MarksRecommendedVariant(t *testing.T) {
+	core := apitest.NewCore(t)
+	h := New(core, nil) // nil authService -> enrichment allowed
+	h.hardwareProfile = func(string) hwprofile.Profile { return amd64ONNXProfile() }
+
+	perch := findEntry(catalogRequest(t, h), "perch-v2")
+	require.NotNil(t, perch)
+	assert.Equal(t, "fp32", perch.RecommendedVariantID, "fp32 is the recommended variant on amd64 with ONNX only")
+
+	fp32 := findVariant(perch, "fp32")
+	require.NotNil(t, fp32)
+	assert.True(t, fp32.Recommended)
+	assert.True(t, fp32.Compatible)
+	require.NotEmpty(t, fp32.Reasons, "the recommended variant carries a why-line reason")
+	assert.Equal(t, recommend.ReasonBackendRecommended, fp32.Reasons[0].Code, "fp32 runs on its recommended ONNX backend")
+
+	// Exactly one recommended variant per entry.
+	recommended := 0
+	for _, v := range perch.Variants {
+		if v.Recommended {
+			recommended++
+		}
+	}
+	assert.Equal(t, 1, recommended)
+}
+
+func TestGetModelCatalog_BlockedVariantCarriesBlockers(t *testing.T) {
+	core := apitest.NewCore(t)
+	h := New(core, nil)
+	h.hardwareProfile = func(string) hwprofile.Profile { return amd64ONNXProfile() }
+
+	perch := findEntry(catalogRequest(t, h), "perch-v2")
+	require.NotNil(t, perch)
+
+	int8Variant := findVariant(perch, "int8-arm")
+	require.NotNil(t, int8Variant, "the aarch64-only variant is still listed, just blocked")
+	assert.False(t, int8Variant.Compatible, "int8-arm requires aarch64, unavailable on amd64")
+	assert.False(t, int8Variant.Recommended)
+	require.NotEmpty(t, int8Variant.Blockers)
+	assert.Equal(t, recommend.BlockerArchUnsupported, int8Variant.Blockers[0].Code)
+}
+
+func TestGetModelCatalog_FlatEntriesUnchanged(t *testing.T) {
+	core := apitest.NewCore(t)
+	h := New(core, nil)
+	h.hardwareProfile = func(string) hwprofile.Profile { return amd64ONNXProfile() }
+
+	catalog := catalogRequest(t, h)
+	// A geomodel is a flat (variant-less) entry.
+	geomodel := findEntry(catalog, "birdnet-geomodel-v3")
+	require.NotNil(t, geomodel, "the geomodel entry must be present")
+	assert.Nil(t, geomodel.Variants, "flat entries carry no variants")
+	assert.Empty(t, geomodel.RecommendedVariantID, "flat entries carry no recommendation")
+}
+
+func TestGetModelCatalog_AuthGatedForUnauthenticated(t *testing.T) {
+	core := apitest.NewCore(t)
+	stub := &stubAuth{authenticated: false}
+	h := New(core, stub)
+	h.hardwareProfile = func(string) hwprofile.Profile {
+		t.Fatal("hardware profile must not be probed for an unauthenticated request")
+		return hwprofile.Profile{}
+	}
+
+	perch := findEntry(catalogRequest(t, h), "perch-v2")
+	require.NotNil(t, perch)
+	assert.True(t, stub.called, "the auth gate must be consulted")
+	assert.Empty(t, perch.RecommendedVariantID, "no recommendation leaks to an unauthenticated request")
+	for _, v := range perch.Variants {
+		assert.False(t, v.Recommended, "variant %s must not be marked recommended", v.ID)
+		assert.True(t, v.Compatible, "variant %s reports the neutral compatible=true", v.ID)
+		assert.Empty(t, v.Reasons, "variant %s leaks no reasons", v.ID)
+		assert.Empty(t, v.Blockers, "variant %s leaks no blockers", v.ID)
+	}
+}
+
+func TestGetModelCatalog_AuthenticatedGetsRecommendations(t *testing.T) {
+	core := apitest.NewCore(t)
+	stub := &stubAuth{authenticated: true}
+	h := New(core, stub)
+	h.hardwareProfile = func(string) hwprofile.Profile { return amd64ONNXProfile() }
+
+	perch := findEntry(catalogRequest(t, h), "perch-v2")
+	require.NotNil(t, perch)
+	assert.True(t, stub.called)
+	assert.Equal(t, "fp32", perch.RecommendedVariantID, "an authenticated request receives the recommendation")
+}

--- a/internal/api/v2/models/models_recommend_test.go
+++ b/internal/api/v2/models/models_recommend_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/classifier/recommend"
 	"github.com/tphakala/birdnet-go/internal/hwprofile"
+	"github.com/tphakala/birdnet-go/internal/inference"
 )
 
 // stubAuth is a minimal auth.Service double that answers only IsAuthenticated.
@@ -79,7 +80,7 @@ func findVariant(entry *CatalogEntryResponse, id string) *CatalogVariantResponse
 func TestGetModelCatalog_MarksRecommendedVariant(t *testing.T) {
 	core := apitest.NewCore(t)
 	h := New(core, nil) // nil authService -> enrichment allowed
-	h.hardwareProfile = func(string) hwprofile.Profile { return amd64ONNXProfile() }
+	h.hardwareProfile = func(inference.ORTStatus) hwprofile.Profile { return amd64ONNXProfile() }
 
 	perch := findEntry(catalogRequest(t, h), "perch-v2")
 	require.NotNil(t, perch)
@@ -105,7 +106,7 @@ func TestGetModelCatalog_MarksRecommendedVariant(t *testing.T) {
 func TestGetModelCatalog_BlockedVariantCarriesBlockers(t *testing.T) {
 	core := apitest.NewCore(t)
 	h := New(core, nil)
-	h.hardwareProfile = func(string) hwprofile.Profile { return amd64ONNXProfile() }
+	h.hardwareProfile = func(inference.ORTStatus) hwprofile.Profile { return amd64ONNXProfile() }
 
 	perch := findEntry(catalogRequest(t, h), "perch-v2")
 	require.NotNil(t, perch)
@@ -121,7 +122,7 @@ func TestGetModelCatalog_BlockedVariantCarriesBlockers(t *testing.T) {
 func TestGetModelCatalog_FlatEntriesUnchanged(t *testing.T) {
 	core := apitest.NewCore(t)
 	h := New(core, nil)
-	h.hardwareProfile = func(string) hwprofile.Profile { return amd64ONNXProfile() }
+	h.hardwareProfile = func(inference.ORTStatus) hwprofile.Profile { return amd64ONNXProfile() }
 
 	catalog := catalogRequest(t, h)
 	// A geomodel is a flat (variant-less) entry.
@@ -135,7 +136,7 @@ func TestGetModelCatalog_AuthGatedForUnauthenticated(t *testing.T) {
 	core := apitest.NewCore(t)
 	stub := &stubAuth{authenticated: false}
 	h := New(core, stub)
-	h.hardwareProfile = func(string) hwprofile.Profile {
+	h.hardwareProfile = func(inference.ORTStatus) hwprofile.Profile {
 		t.Fatal("hardware profile must not be probed for an unauthenticated request")
 		return hwprofile.Profile{}
 	}
@@ -156,7 +157,7 @@ func TestGetModelCatalog_AuthenticatedGetsRecommendations(t *testing.T) {
 	core := apitest.NewCore(t)
 	stub := &stubAuth{authenticated: true}
 	h := New(core, stub)
-	h.hardwareProfile = func(string) hwprofile.Profile { return amd64ONNXProfile() }
+	h.hardwareProfile = func(inference.ORTStatus) hwprofile.Profile { return amd64ONNXProfile() }
 
 	perch := findEntry(catalogRequest(t, h), "perch-v2")
 	require.NotNil(t, perch)

--- a/internal/api/v2/models/models_test.go
+++ b/internal/api/v2/models/models_test.go
@@ -17,7 +17,7 @@ import (
 func TestModelsRouteRegistration(t *testing.T) {
 	e := echo.New()
 	core := apitest.NewCore(t, apitest.WithEcho(e))
-	h := New(core)
+	h := New(core, nil)
 
 	h.RegisterRoutes(core.Group)
 
@@ -40,7 +40,7 @@ func TestModelsRouteRegistration(t *testing.T) {
 // unused model.
 func TestInstallModel_RejectsHiddenEntries(t *testing.T) {
 	core := apitest.NewCore(t)
-	h := New(core)
+	h := New(core, nil)
 	e := echo.New()
 
 	hiddenIDs := []string{"birdnet-v2.4"}

--- a/internal/api/v2/models/models_variants_test.go
+++ b/internal/api/v2/models/models_variants_test.go
@@ -19,7 +19,7 @@ import (
 // default variant.
 func TestGetModelCatalog_EmitsVariants(t *testing.T) {
 	core := apitest.NewCore(t)
-	h := New(core)
+	h := New(core, nil)
 	e := echo.New()
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/models/catalog", http.NoBody)
@@ -63,7 +63,7 @@ func TestGetModelCatalog_EmitsVariants(t *testing.T) {
 func TestInstallModel_RejectsUnknownVariant(t *testing.T) {
 	core := apitest.NewCore(t)
 	core.ModelManager = classifier.NewModelManager(t.TempDir(), nil, nil)
-	h := New(core)
+	h := New(core, nil)
 	e := echo.New()
 
 	body := strings.NewReader(`{"variantId":"does-not-exist"}`)
@@ -85,7 +85,7 @@ func TestInstallModel_RejectsUnknownVariant(t *testing.T) {
 func TestInstallModel_RejectsMalformedBody(t *testing.T) {
 	core := apitest.NewCore(t)
 	core.ModelManager = classifier.NewModelManager(t.TempDir(), nil, nil)
-	h := New(core)
+	h := New(core, nil)
 	e := echo.New()
 
 	body := strings.NewReader(`{"variantId":`) // truncated JSON
@@ -122,7 +122,7 @@ func TestBuildVariantResponses_LegacyHiddenUnlessInstalled(t *testing.T) {
 	}
 
 	// Not installed: the legacy variant is hidden, none is marked installed.
-	notInstalled := buildVariantResponses(entry, false, "")
+	notInstalled := buildVariantResponses(entry, false, "", nil)
 	assert.Contains(t, ids(notInstalled), "cur")
 	assert.NotContains(t, ids(notInstalled), "old", "a legacy variant is hidden when not installed")
 	for _, v := range notInstalled {
@@ -130,7 +130,7 @@ func TestBuildVariantResponses_LegacyHiddenUnlessInstalled(t *testing.T) {
 	}
 
 	// The legacy variant is the installed one: it stays visible and is flagged.
-	withLegacy := buildVariantResponses(entry, true, "old")
+	withLegacy := buildVariantResponses(entry, true, "old", nil)
 	assert.Contains(t, ids(withLegacy), "old", "a legacy variant stays visible when it is installed")
 	for _, v := range withLegacy {
 		switch v.ID {

--- a/internal/classifier/recommend/recommend.go
+++ b/internal/classifier/recommend/recommend.go
@@ -9,8 +9,8 @@
 package recommend
 
 import (
+	"cmp"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -254,8 +254,14 @@ func evaluateVariant(catalogID string, v *classifier.CatalogVariant, in *Input, 
 	if len(v.Requirements.Arch) > 0 && !anyPresent(v.Requirements.Arch, in.Capabilities) {
 		blockers = append(blockers, Reason{Code: BlockerArchUnsupported, Args: joinArg("required", v.Requirements.Arch)})
 	}
+	// The explicit Requirements.Backends any-of filter and the backendTerm
+	// candidates-empty check below both mean "this host reaches no usable backend
+	// for the variant". A variant that trips both must still surface a single
+	// backend.missing blocker, so the second occurrence is suppressed.
+	backendMissing := false
 	if len(v.Requirements.Backends) > 0 && !anyPresent(v.Requirements.Backends, in.Capabilities) {
 		blockers = append(blockers, Reason{Code: BlockerBackendMissing, Args: joinArg("required", v.Requirements.Backends)})
+		backendMissing = true
 	}
 	// The RAM filter applies only when host RAM is known (TotalRAMBytes > 0).
 	// When memory detection failed, hwprofile reports 0; an unknown RAM figure is
@@ -276,7 +282,9 @@ func evaluateVariant(catalogID string, v *classifier.CatalogVariant, in *Input, 
 	// records the rank used to break score ties.
 	backendRank := backendRankUnavailable
 	if term, missing := backendTerm(v, in.Capabilities); missing {
-		blockers = append(blockers, Reason{Code: BlockerBackendMissing, Args: joinArg("required", backendKeys(v.Backends))})
+		if !backendMissing {
+			blockers = append(blockers, Reason{Code: BlockerBackendMissing, Args: joinArg("required", backendKeys(v.Backends))})
+		}
 	} else if term.applies {
 		score += term.score
 		reasons = append(reasons, Reason{Code: term.code, Args: map[string]string{"backend": term.backend}})
@@ -455,21 +463,24 @@ func latencyRange(latencies map[string]int) (minLat, maxLat int) {
 // sortScored orders variants best-first: compatible before blocked, then higher
 // score, then better backend rank, then smaller download, then variant id.
 func sortScored(scoredVariants []scoredVariant) {
-	sort.SliceStable(scoredVariants, func(a, b int) bool {
-		x, y := &scoredVariants[a], &scoredVariants[b]
+	slices.SortStableFunc(scoredVariants, func(x, y scoredVariant) int {
 		if x.rec.Compatible != y.rec.Compatible {
-			return x.rec.Compatible
+			if x.rec.Compatible {
+				return -1
+			}
+			return 1
 		}
-		if x.rec.Score != y.rec.Score {
-			return x.rec.Score > y.rec.Score
+		// Score is ranked descending, so y is compared against x.
+		if c := cmp.Compare(y.rec.Score, x.rec.Score); c != 0 {
+			return c
 		}
-		if x.backendRank != y.backendRank {
-			return x.backendRank < y.backendRank
+		if c := cmp.Compare(x.backendRank, y.backendRank); c != 0 {
+			return c
 		}
-		if x.sizeBytes != y.sizeBytes {
-			return x.sizeBytes < y.sizeBytes
+		if c := cmp.Compare(x.sizeBytes, y.sizeBytes); c != 0 {
+			return c
 		}
-		return x.rec.VariantID < y.rec.VariantID
+		return cmp.Compare(x.rec.VariantID, y.rec.VariantID)
 	})
 }
 

--- a/internal/classifier/recommend/recommend.go
+++ b/internal/classifier/recommend/recommend.go
@@ -1,0 +1,537 @@
+// Package recommend ranks the hardware variants of a model catalog entry
+// against a host's detected capabilities, so the gallery can preselect the
+// variant best suited to the machine while still letting the user override.
+//
+// It is deliberately pure: no I/O, no globals, no clock. The same Input always
+// yields the same output, so the whole hardware matrix is table-testable
+// without any hardware. The region axis is intentionally absent; a future region
+// resolver will slot into the score without rescaling the terms defined here.
+package recommend
+
+import (
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/tphakala/birdnet-go/internal/classifier"
+	"github.com/tphakala/birdnet-go/internal/hwprofile"
+)
+
+// Score terms. Kept as named constants (no magic numbers) and spaced so the
+// future region terms (+100 matched / +50 global fallback) slot between the
+// hard signals and the modifiers without reordering anything.
+const (
+	// scoreBackendRecommended is added when the best host-available backend is
+	// the manifest's Recommended way to run the variant.
+	scoreBackendRecommended = 40
+	// scoreBackendSupported is added when the variant runs on a host-available
+	// backend that is merely Supported, not Recommended.
+	scoreBackendSupported = 10
+	// scoreFP16Native rewards an fp16 variant on a host with native
+	// half-precision SIMD.
+	scoreFP16Native = 15
+	// scoreRAMConstrainedFit rewards an int8 variant on a memory-constrained
+	// host, where the quantized build is the one that fits.
+	scoreRAMConstrainedFit = 25
+	// scoreLegacyPenalty demotes a superseded build far below any live variant
+	// while still letting it be reported when it is the one installed.
+	scoreLegacyPenalty = -1000
+	// benchmarkMaxScore is the score of the fastest measured variant in an entry
+	// when at least two variants carry a comparable benchmark.
+	benchmarkMaxScore = 20
+	// benchmarkNonMemberScore is the flat score of a variant with no comparable
+	// benchmark, used only when other variants in the entry do have one.
+	benchmarkNonMemberScore = 10
+	// benchmarkMinMembers is the number of comparable benchmarks an entry needs
+	// before the benchmark term contributes anything; below it the term is 0 for
+	// every variant, because a single measurement cannot be scaled.
+	benchmarkMinMembers = 2
+)
+
+// Reason codes. Structured codes, never English sentences: the frontend maps
+// each to an i18n key, so no user-facing wording lives in the backend.
+const (
+	// ReasonBackendRecommended marks the variant as running on its recommended
+	// backend for this host. Arg "backend" names that backend.
+	ReasonBackendRecommended = "backend.recommended"
+	// ReasonBackendSupported marks the variant as running on a supported (not
+	// recommended) backend for this host. Arg "backend" names that backend.
+	ReasonBackendSupported = "backend.supported"
+	// ReasonPrecisionFP16Native marks an fp16 variant matched to native
+	// half-precision SIMD.
+	ReasonPrecisionFP16Native = "precision.fp16_native"
+	// ReasonRAMConstrainedFit marks an int8 variant matched to a low-RAM host.
+	ReasonRAMConstrainedFit = "ram.constrained_fit"
+	// ReasonVariantLegacy marks a superseded build.
+	ReasonVariantLegacy = "variant.legacy"
+	// ReasonBenchmarkMeasured marks a variant scored from a real measurement on
+	// this device class.
+	ReasonBenchmarkMeasured = "benchmark.measured"
+)
+
+// Blocker codes. A variant with any blocker is incompatible with the host.
+const (
+	// BlockerArchUnsupported means the variant requires a CPU architecture the
+	// host does not have. Arg "required" lists the accepted tokens.
+	BlockerArchUnsupported = "arch.unsupported"
+	// BlockerBackendMissing means the variant needs a backend the host cannot
+	// reach, either by explicit requirement or because none of its supported
+	// backends are available here. Arg "required" lists the accepted tokens.
+	BlockerBackendMissing = "backend.missing"
+	// BlockerRAMInsufficient means the host has less memory than the variant
+	// needs. Arg "requiredMb" is the floor in MB.
+	BlockerRAMInsufficient = "ram.insufficient"
+	// BlockerHardwareExcluded means the host carries a capability token the
+	// variant explicitly excludes (e.g. a known-bad GPU generation). Arg "token"
+	// names it.
+	BlockerHardwareExcluded = "hardware.excluded"
+)
+
+// Device classes, the benchmark Device identifiers a host maps to. Kept here
+// rather than in the manifest because they are a property of the running host,
+// derived from its board tier and architecture.
+const (
+	deviceClassRPi5 = "rpi5-a76"
+	deviceClassRPi4 = "rpi4b-a72"
+	deviceClassRPi3 = "rpi3b-a53"
+	deviceClassX86  = "x86"
+
+	boardTierPi5 = "pi5"
+	boardTierPi4 = "pi4"
+	boardTierPi3 = "pi3"
+
+	archAMD64 = "amd64"
+
+	precisionFP16 = "fp16"
+	precisionINT8 = "int8"
+
+	bytesPerMB = 1 << 20
+)
+
+// backendPreference orders backends from most to least preferred, so a tie on
+// score is broken toward the faster execution path. cuda and tensorrt lead the
+// order for completeness; no BirdNET-Go build emits those host tokens yet, so
+// in practice the decision is among the OpenVINO and ONNX Runtime backends.
+var backendPreference = []string{
+	"cuda",
+	"tensorrt",
+	hwprofile.CapOpenVINOGPU,
+	hwprofile.CapOpenVINOCPU,
+	hwprofile.CapONNXRuntimeCPU,
+	hwprofile.CapTFLite,
+}
+
+// backendRankUnavailable is the sort rank of a variant that resolved no
+// host-available backend, so it sorts after every variant that did. It is a
+// var only because len of a slice is not a compile-time constant; it is never
+// reassigned.
+var backendRankUnavailable = len(backendPreference)
+
+// Reason is a structured, renderable explanation for a scoring decision or a
+// hard-filter failure. Args carry the values the frontend interpolates into the
+// localized string (e.g. {"backend": "openvino-gpu"}).
+type Reason struct {
+	Code string            `json:"code"`
+	Args map[string]string `json:"args,omitempty"`
+}
+
+// Recommendation is the verdict for one variant of one catalog entry.
+type Recommendation struct {
+	// CatalogID and VariantID identify the variant this verdict is about.
+	CatalogID string
+	VariantID string
+	// Score ranks variants within their entry; higher is better. It is only
+	// meaningful relative to the other variants of the same entry.
+	Score int
+	// Compatible is true when the variant has no blockers, i.e. it can run on
+	// this host.
+	Compatible bool
+	// Recommended is true for the single best compatible variant of its entry,
+	// the one the gallery preselects. At most one per entry.
+	Recommended bool
+	// Reasons explain the score, for the gallery's "why" line.
+	Reasons []Reason
+	// Blockers explain incompatibility, for a disabled option's inline text.
+	Blockers []Reason
+}
+
+// Input is the host profile plus the catalog to rank against.
+type Input struct {
+	// Capabilities are the host capability tokens (hwprofile.Profile.Capabilities()).
+	Capabilities []string
+	// TotalRAMBytes is the effective memory ceiling, 0 when unknown.
+	TotalRAMBytes int64
+	// DeviceClass is the benchmark device identifier for this host, "" when the
+	// host maps to no benchmarked class.
+	DeviceClass string
+	// Entries is the visible catalog to evaluate.
+	Entries []classifier.CatalogEntry
+}
+
+// DeviceClass maps a host's board tier and Go architecture to the benchmark
+// Device identifier the manifests use, or "" when the host matches no
+// benchmarked class (in which case the benchmark term contributes nothing).
+func DeviceClass(boardTier, goArch string) string {
+	switch boardTier {
+	case boardTierPi5:
+		return deviceClassRPi5
+	case boardTierPi4:
+		return deviceClassRPi4
+	case boardTierPi3:
+		return deviceClassRPi3
+	}
+	if goArch == archAMD64 {
+		return deviceClassX86
+	}
+	return ""
+}
+
+// Rank evaluates every variant of every entry and returns the verdicts grouped
+// by entry in input order, ranked best-first within each entry. Flat entries
+// (no variants) produce nothing. Input is never mutated.
+func Rank(in Input) []Recommendation {
+	out := make([]Recommendation, 0)
+	for i := range in.Entries {
+		entry := &in.Entries[i]
+		if len(entry.Variants) == 0 {
+			continue
+		}
+		out = append(out, rankEntry(entry, &in)...)
+	}
+	return out
+}
+
+// rankEntry ranks the variants of a single entry, marking the top compatible
+// one Recommended.
+func rankEntry(entry *classifier.CatalogEntry, in *Input) []Recommendation {
+	bench := benchmarkScores(entry, in)
+
+	scoredVariants := make([]scoredVariant, 0, len(entry.Variants))
+	for j := range entry.Variants {
+		v := &entry.Variants[j]
+		scoredVariants = append(scoredVariants, evaluateVariant(entry.ID, v, in, bench[v.ID]))
+	}
+
+	sortScored(scoredVariants)
+
+	recs := make([]Recommendation, len(scoredVariants))
+	recommendedChosen := false
+	for k := range scoredVariants {
+		rec := scoredVariants[k].rec
+		// A Legacy (superseded) variant is never recommended for a fresh install:
+		// the gallery hides it (buildVariantResponses) unless it is the installed
+		// one, so recommending it would point at a variant absent from the client's
+		// variant list. When the only compatible variant is Legacy, the entry gets
+		// no recommendation, which is correct.
+		if !recommendedChosen && rec.Compatible && !scoredVariants[k].legacy {
+			rec.Recommended = true
+			recommendedChosen = true
+		}
+		recs[k] = rec
+	}
+	return recs
+}
+
+// scoredVariant pairs a verdict with the sort keys that break ties among
+// equally scored variants, plus the legacy flag that keeps a superseded build
+// out of the Recommended slot.
+type scoredVariant struct {
+	rec         Recommendation
+	backendRank int
+	sizeBytes   int64
+	legacy      bool
+}
+
+// evaluateVariant computes the verdict for one variant: its blockers (hard
+// filters), its score terms, and the sort keys used to break ties.
+func evaluateVariant(catalogID string, v *classifier.CatalogVariant, in *Input, bench benchmarkResult) scoredVariant {
+	var reasons, blockers []Reason
+	score := 0
+
+	// Hard filters. Each failure is a blocker; a variant with any blocker is
+	// incompatible regardless of its score.
+	if len(v.Requirements.Arch) > 0 && !anyPresent(v.Requirements.Arch, in.Capabilities) {
+		blockers = append(blockers, Reason{Code: BlockerArchUnsupported, Args: joinArg("required", v.Requirements.Arch)})
+	}
+	if len(v.Requirements.Backends) > 0 && !anyPresent(v.Requirements.Backends, in.Capabilities) {
+		blockers = append(blockers, Reason{Code: BlockerBackendMissing, Args: joinArg("required", v.Requirements.Backends)})
+	}
+	// The RAM filter applies only when host RAM is known (TotalRAMBytes > 0).
+	// When memory detection failed, hwprofile reports 0; an unknown RAM figure is
+	// deliberately treated as "do not block", because hiding a model from a user
+	// whose RAM probe failed is worse than optimistically offering it. The low-RAM
+	// score bonus is likewise inert on unknown RAM, since its CapLowRAM token is
+	// only emitted when TotalRAMBytes is both known and below the threshold.
+	if v.Requirements.MinRAMMB > 0 && in.TotalRAMBytes > 0 && in.TotalRAMBytes < int64(v.Requirements.MinRAMMB)*bytesPerMB {
+		blockers = append(blockers, Reason{Code: BlockerRAMInsufficient, Args: map[string]string{"requiredMb": strconv.Itoa(v.Requirements.MinRAMMB)}})
+	}
+	for _, ex := range v.Requirements.Excludes {
+		if slices.Contains(in.Capabilities, ex) {
+			blockers = append(blockers, Reason{Code: BlockerHardwareExcluded, Args: map[string]string{"token": ex}})
+		}
+	}
+
+	// Backend term. Scores the variant on the best host-available backend and
+	// records the rank used to break score ties.
+	backendRank := backendRankUnavailable
+	if term, missing := backendTerm(v, in.Capabilities); missing {
+		blockers = append(blockers, Reason{Code: BlockerBackendMissing, Args: joinArg("required", backendKeys(v.Backends))})
+	} else if term.applies {
+		score += term.score
+		reasons = append(reasons, Reason{Code: term.code, Args: map[string]string{"backend": term.backend}})
+		backendRank = preferenceRank(term.backend)
+	}
+
+	// Modifiers.
+	if slices.Contains(in.Capabilities, hwprofile.CapFP16Native) && v.Precision == precisionFP16 {
+		score += scoreFP16Native
+		reasons = append(reasons, Reason{Code: ReasonPrecisionFP16Native})
+	}
+	if slices.Contains(in.Capabilities, hwprofile.CapLowRAM) && v.Precision == precisionINT8 {
+		score += scoreRAMConstrainedFit
+		reasons = append(reasons, Reason{Code: ReasonRAMConstrainedFit})
+	}
+	if v.Legacy {
+		score += scoreLegacyPenalty
+		reasons = append(reasons, Reason{Code: ReasonVariantLegacy})
+	}
+	if bench.applies {
+		score += bench.score
+		if bench.member {
+			reasons = append(reasons, Reason{Code: ReasonBenchmarkMeasured})
+		}
+	}
+
+	return scoredVariant{
+		rec: Recommendation{
+			CatalogID:  catalogID,
+			VariantID:  v.ID,
+			Score:      score,
+			Compatible: len(blockers) == 0,
+			Reasons:    reasons,
+			Blockers:   blockers,
+		},
+		backendRank: backendRank,
+		sizeBytes:   variantSize(v),
+		legacy:      v.Legacy,
+	}
+}
+
+// backendTermResult is the outcome of scoring the backend axis for a variant.
+type backendTermResult struct {
+	applies bool   // a backend term was produced
+	score   int    // scoreBackendRecommended or scoreBackendSupported
+	code    string // the matching reason code
+	backend string // the best host-available backend that was chosen
+}
+
+// backendTerm scores a variant on the best backend the host can reach. It
+// returns missing=true when the variant declares backends but the host reaches
+// none of them (a hard filter). A variant with no backend information at all
+// (an empty map, as a user-edited catalog may carry) produces neither a term
+// nor a blocker, so custom entries are never wrongly filtered.
+func backendTerm(v *classifier.CatalogVariant, caps []string) (result backendTermResult, missing bool) {
+	if len(v.Backends) == 0 {
+		return backendTermResult{}, false
+	}
+
+	candidates := make([]string, 0, len(v.Backends))
+	recommended := make([]string, 0, len(v.Backends))
+	for backend, support := range v.Backends {
+		if !support.Supported || !slices.Contains(caps, backend) {
+			continue
+		}
+		candidates = append(candidates, backend)
+		if support.Recommended {
+			recommended = append(recommended, backend)
+		}
+	}
+
+	if len(candidates) == 0 {
+		return backendTermResult{}, true
+	}
+
+	// The best backend is chosen from the recommended set when it is non-empty,
+	// never from the wider candidate set. Otherwise a variant merely Supported
+	// (not Recommended) on a high-preference backend would score as if that were
+	// its recommended path, mis-ranking it against a sibling that truly
+	// recommends that backend.
+	if len(recommended) > 0 {
+		return backendTermResult{applies: true, score: scoreBackendRecommended, code: ReasonBackendRecommended, backend: preferredBackend(recommended)}, false
+	}
+	return backendTermResult{applies: true, score: scoreBackendSupported, code: ReasonBackendSupported, backend: preferredBackend(candidates)}, false
+}
+
+// benchmarkResult is the benchmark term for one variant within its entry.
+type benchmarkResult struct {
+	applies bool // the entry had enough comparable benchmarks for the term to count
+	member  bool // this variant carried a comparable benchmark
+	score   int
+}
+
+// benchmarkScores computes the benchmark term for every variant of an entry.
+// The term compares only benchmarks measured on the host's device class with a
+// backend the host can reach. When fewer than benchmarkMinMembers variants have
+// such a benchmark, the term is zero for all, because a lone measurement cannot
+// be scaled into a ranking.
+func benchmarkScores(entry *classifier.CatalogEntry, in *Input) map[string]benchmarkResult {
+	out := make(map[string]benchmarkResult, len(entry.Variants))
+	if in.DeviceClass == "" {
+		return out
+	}
+
+	latencies := make(map[string]int, len(entry.Variants))
+	for j := range entry.Variants {
+		v := &entry.Variants[j]
+		if lat, ok := comparableLatency(v, in); ok {
+			latencies[v.ID] = lat
+		}
+	}
+	if len(latencies) < benchmarkMinMembers {
+		return out
+	}
+
+	minLat, maxLat := latencyRange(latencies)
+	for j := range entry.Variants {
+		v := &entry.Variants[j]
+		lat, member := latencies[v.ID]
+		if !member {
+			out[v.ID] = benchmarkResult{applies: true, member: false, score: benchmarkNonMemberScore}
+			continue
+		}
+		out[v.ID] = benchmarkResult{applies: true, member: true, score: scaleBenchmark(lat, minLat, maxLat)}
+	}
+	return out
+}
+
+// comparableLatency returns the smallest latency this variant measured on the
+// host's device class with a host-reachable backend.
+func comparableLatency(v *classifier.CatalogVariant, in *Input) (latency int, ok bool) {
+	best := 0
+	found := false
+	for i := range v.Benchmarks {
+		b := &v.Benchmarks[i]
+		if b.Device != in.DeviceClass || b.LatencyMs <= 0 || !slices.Contains(in.Capabilities, b.Backend) {
+			continue
+		}
+		if !found || b.LatencyMs < best {
+			best = b.LatencyMs
+			found = true
+		}
+	}
+	return best, found
+}
+
+// scaleBenchmark maps a latency to a score in [0, benchmarkMaxScore], fastest
+// highest. When every member shares one latency the range is degenerate and all
+// members are equally best.
+func scaleBenchmark(latency, minLat, maxLat int) int {
+	if maxLat == minLat {
+		return benchmarkMaxScore
+	}
+	return benchmarkMaxScore * (maxLat - latency) / (maxLat - minLat)
+}
+
+// latencyRange returns the min and max of a non-empty latency set.
+func latencyRange(latencies map[string]int) (minLat, maxLat int) {
+	first := true
+	for _, lat := range latencies {
+		if first {
+			minLat, maxLat = lat, lat
+			first = false
+			continue
+		}
+		if lat < minLat {
+			minLat = lat
+		}
+		if lat > maxLat {
+			maxLat = lat
+		}
+	}
+	return minLat, maxLat
+}
+
+// sortScored orders variants best-first: compatible before blocked, then higher
+// score, then better backend rank, then smaller download, then variant id.
+func sortScored(scoredVariants []scoredVariant) {
+	sort.SliceStable(scoredVariants, func(a, b int) bool {
+		x, y := &scoredVariants[a], &scoredVariants[b]
+		if x.rec.Compatible != y.rec.Compatible {
+			return x.rec.Compatible
+		}
+		if x.rec.Score != y.rec.Score {
+			return x.rec.Score > y.rec.Score
+		}
+		if x.backendRank != y.backendRank {
+			return x.backendRank < y.backendRank
+		}
+		if x.sizeBytes != y.sizeBytes {
+			return x.sizeBytes < y.sizeBytes
+		}
+		return x.rec.VariantID < y.rec.VariantID
+	})
+}
+
+// preferredBackend returns the highest-preference backend among the given set.
+// The candidate slices are built by ranging a map, so ties on preference rank
+// (two backends outside backendPreference, both ranking backendRankUnavailable)
+// are broken lexically to keep Rank deterministic regardless of map order.
+func preferredBackend(backends []string) string {
+	best := backends[0]
+	bestRank := preferenceRank(best)
+	for _, b := range backends[1:] {
+		if r := preferenceRank(b); r < bestRank || (r == bestRank && b < best) {
+			best, bestRank = b, r
+		}
+	}
+	return best
+}
+
+// preferenceRank returns the sort rank of a backend (lower is preferred), or
+// backendRankUnavailable for a backend outside the known order.
+func preferenceRank(backend string) int {
+	if i := slices.Index(backendPreference, backend); i >= 0 {
+		return i
+	}
+	return backendRankUnavailable
+}
+
+// backendKeys returns the sorted supported-backend keys of a backend support
+// map, for a stable "required" argument on the backend.missing blocker. Only
+// Supported backends are listed: a key marked Supported:false is not a viable
+// target, so naming it as "required" would mislead.
+func backendKeys(backends map[string]classifier.BackendSupport) []string {
+	keys := make([]string, 0, len(backends))
+	for backend, support := range backends {
+		if support.Supported {
+			keys = append(keys, backend)
+		}
+	}
+	slices.Sort(keys)
+	return keys
+}
+
+// variantSize sums the download size of a variant's files.
+func variantSize(v *classifier.CatalogVariant) int64 {
+	var total int64
+	for i := range v.Files {
+		total += v.Files[i].SizeBytes
+	}
+	return total
+}
+
+// anyPresent reports whether any of the required tokens is present in have.
+func anyPresent(required, have []string) bool {
+	for _, r := range required {
+		if slices.Contains(have, r) {
+			return true
+		}
+	}
+	return false
+}
+
+// joinArg builds a single-entry arg map joining tokens with commas.
+func joinArg(key string, tokens []string) map[string]string {
+	return map[string]string{key: strings.Join(tokens, ",")}
+}

--- a/internal/classifier/recommend/recommend_test.go
+++ b/internal/classifier/recommend/recommend_test.go
@@ -1,0 +1,541 @@
+package recommend
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/classifier"
+	"github.com/tphakala/birdnet-go/internal/hwprofile"
+)
+
+// realEntry returns a copy of a real catalog entry by ID, so the matrix tests
+// assert against the actual shipped Backends maps rather than a hand-copy that
+// could drift from them.
+func realEntry(t *testing.T, id string) classifier.CatalogEntry {
+	t.Helper()
+	for i := range classifier.EmbeddedCatalog {
+		if classifier.EmbeddedCatalog[i].ID == id {
+			return classifier.EmbeddedCatalog[i]
+		}
+	}
+	t.Fatalf("catalog entry %q not found", id)
+	return classifier.CatalogEntry{}
+}
+
+// recommendedVariant returns the variant marked Recommended for a catalog ID,
+// or "" when none is (no compatible variant).
+func recommendedVariant(recs []Recommendation, catalogID string) string {
+	for i := range recs {
+		if recs[i].CatalogID == catalogID && recs[i].Recommended {
+			return recs[i].VariantID
+		}
+	}
+	return ""
+}
+
+// variantRec returns the verdict for one variant, and whether it was found.
+func variantRec(recs []Recommendation, catalogID, variantID string) (Recommendation, bool) {
+	for i := range recs {
+		if recs[i].CatalogID == catalogID && recs[i].VariantID == variantID {
+			return recs[i], true
+		}
+	}
+	return Recommendation{}, false
+}
+
+const (
+	ramHigh = 16 * 1024 * 1024 * 1024
+	ramLow  = 1536 * 1024 * 1024 // below the 2 GiB low-ram threshold
+)
+
+func TestRank_HardwareMatrix(t *testing.T) {
+	t.Parallel()
+
+	perch := realEntry(t, "perch-v2")
+	v3 := realEntry(t, "birdnet-v3.0")
+
+	tests := []struct {
+		name        string
+		caps        []string
+		ram         int64
+		deviceClass string
+		entries     []classifier.CatalogEntry
+		// wantRecommended maps catalogID -> expected recommended variant ID.
+		wantRecommended map[string]string
+		// wantBlocked lists (catalogID, variantID) pairs expected incompatible.
+		wantBlocked [][2]string
+	}{
+		{
+			name:        "amd64 onnx only",
+			caps:        []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU},
+			ram:         ramHigh,
+			deviceClass: deviceClassX86,
+			entries:     []classifier.CatalogEntry{perch, v3},
+			wantRecommended: map[string]string{
+				"perch-v2":     "fp32",
+				"birdnet-v3.0": "fp32",
+			},
+			wantBlocked: [][2]string{{"perch-v2", "int8-arm"}},
+		},
+		{
+			name:        "amd64 openvino cpu",
+			caps:        []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU, hwprofile.CapOpenVINOCPU},
+			ram:         ramHigh,
+			deviceClass: deviceClassX86,
+			entries:     []classifier.CatalogEntry{perch, v3},
+			wantRecommended: map[string]string{
+				"perch-v2":     "no-dft-fp32",
+				"birdnet-v3.0": "fp32",
+			},
+		},
+		{
+			name:        "amd64 intel igpu",
+			caps:        []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU, hwprofile.CapOpenVINOCPU, hwprofile.CapOpenVINOGPU},
+			ram:         ramHigh,
+			deviceClass: deviceClassX86,
+			entries:     []classifier.CatalogEntry{perch, v3},
+			wantRecommended: map[string]string{
+				"perch-v2":     "no-dft-fp32",
+				"birdnet-v3.0": "fp16",
+			},
+		},
+		{
+			// Pi5: no low-ram bonus, so int8-arm ties fp32 on score and wins on
+			// smaller size. This is the documented empty-data behavior; a catalog
+			// benchmark pass will rank fp32 higher on the A76.
+			name:        "aarch64 pi5",
+			caps:        []string{hwprofile.CapAArch64, hwprofile.CapAArch64A76, hwprofile.CapONNXRuntimeCPU, hwprofile.CapFP16Native},
+			ram:         8 * 1024 * 1024 * 1024,
+			deviceClass: deviceClassRPi5,
+			entries:     []classifier.CatalogEntry{perch},
+			wantRecommended: map[string]string{
+				"perch-v2": "int8-arm",
+			},
+		},
+		{
+			name:        "aarch64 pi4 low ram",
+			caps:        []string{hwprofile.CapAArch64, hwprofile.CapONNXRuntimeCPU, hwprofile.CapLowRAM},
+			ram:         ramLow,
+			deviceClass: deviceClassRPi4,
+			entries:     []classifier.CatalogEntry{perch},
+			wantRecommended: map[string]string{
+				"perch-v2": "int8-arm",
+			},
+		},
+		{
+			name:        "armv7l 32bit blocks aarch64 variant",
+			caps:        []string{"armv7l", hwprofile.CapONNXRuntimeCPU},
+			ram:         ramLow,
+			deviceClass: "",
+			entries:     []classifier.CatalogEntry{perch},
+			wantRecommended: map[string]string{
+				"perch-v2": "fp32",
+			},
+			wantBlocked: [][2]string{{"perch-v2", "int8-arm"}},
+		},
+		{
+			name:        "no backend tokens blocks everything",
+			caps:        []string{hwprofile.CapX86_64},
+			ram:         ramHigh,
+			deviceClass: deviceClassX86,
+			entries:     []classifier.CatalogEntry{perch},
+			wantRecommended: map[string]string{
+				"perch-v2": "", // no compatible variant
+			},
+			wantBlocked: [][2]string{{"perch-v2", "fp32"}, {"perch-v2", "no-dft-fp32"}, {"perch-v2", "int8-arm"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			recs := Rank(Input{
+				Capabilities:  tt.caps,
+				TotalRAMBytes: tt.ram,
+				DeviceClass:   tt.deviceClass,
+				Entries:       tt.entries,
+			})
+			for catalogID, want := range tt.wantRecommended {
+				assert.Equalf(t, want, recommendedVariant(recs, catalogID), "recommended variant for %s", catalogID)
+			}
+			for _, pair := range tt.wantBlocked {
+				rec, ok := variantRec(recs, pair[0], pair[1])
+				require.Truef(t, ok, "variant %s/%s should be present", pair[0], pair[1])
+				assert.Falsef(t, rec.Compatible, "variant %s/%s should be blocked", pair[0], pair[1])
+				assert.NotEmptyf(t, rec.Blockers, "blocked variant %s/%s should carry blockers", pair[0], pair[1])
+			}
+		})
+	}
+}
+
+func TestRank_Blockers(t *testing.T) {
+	t.Parallel()
+
+	entry := classifier.CatalogEntry{
+		ID: "synthetic",
+		Variants: []classifier.CatalogVariant{
+			{
+				ID:           "arch-only",
+				Requirements: classifier.VariantRequirements{Arch: []string{hwprofile.CapAArch64}},
+				Backends:     map[string]classifier.BackendSupport{hwprofile.CapONNXRuntimeCPU: {Supported: true, Recommended: true}},
+			},
+			{
+				ID:           "backend-required",
+				Requirements: classifier.VariantRequirements{Backends: []string{hwprofile.CapOpenVINOGPU}},
+				Backends:     map[string]classifier.BackendSupport{hwprofile.CapONNXRuntimeCPU: {Supported: true, Recommended: true}},
+			},
+			{
+				ID:           "ram-hungry",
+				Requirements: classifier.VariantRequirements{MinRAMMB: 4096},
+				Backends:     map[string]classifier.BackendSupport{hwprofile.CapONNXRuntimeCPU: {Supported: true, Recommended: true}},
+			},
+			{
+				ID:           "excluded",
+				Requirements: classifier.VariantRequirements{Excludes: []string{"openvino-gpu-intel-gen12"}},
+				Backends:     map[string]classifier.BackendSupport{hwprofile.CapONNXRuntimeCPU: {Supported: true, Recommended: true}},
+			},
+			{
+				ID:       "no-available-backend",
+				Backends: map[string]classifier.BackendSupport{hwprofile.CapOpenVINOGPU: {Supported: true, Recommended: true}},
+			},
+		},
+	}
+
+	recs := Rank(Input{
+		Capabilities:  []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU, "openvino-gpu-intel-gen12"},
+		TotalRAMBytes: ramLow, // 1.5 GiB, below the 4 GiB floor
+		DeviceClass:   deviceClassX86,
+		Entries:       []classifier.CatalogEntry{entry},
+	})
+
+	wantCode := map[string]string{
+		"arch-only":            BlockerArchUnsupported,
+		"backend-required":     BlockerBackendMissing,
+		"ram-hungry":           BlockerRAMInsufficient,
+		"excluded":             BlockerHardwareExcluded,
+		"no-available-backend": BlockerBackendMissing,
+	}
+	for variantID, code := range wantCode {
+		rec, ok := variantRec(recs, "synthetic", variantID)
+		require.Truef(t, ok, "variant %s present", variantID)
+		assert.Falsef(t, rec.Compatible, "variant %s incompatible", variantID)
+		assert.Truef(t, hasBlocker(&rec, code), "variant %s carries blocker %s (got %+v)", variantID, code, rec.Blockers)
+	}
+
+	// The RAM blocker carries the required floor as an arg.
+	ramRec, _ := variantRec(recs, "synthetic", "ram-hungry")
+	assert.Equal(t, "4096", blockerArg(&ramRec, BlockerRAMInsufficient, "requiredMb"))
+}
+
+func TestRank_BenchmarkScaling(t *testing.T) {
+	t.Parallel()
+
+	// Three variants on the same recommended backend so score ties, letting the
+	// benchmark term decide. Latencies 100 / 300 / 500 on rpi5-a76.
+	backend := map[string]classifier.BackendSupport{hwprofile.CapONNXRuntimeCPU: {Supported: true, Recommended: true}}
+	entry := classifier.CatalogEntry{
+		ID: "bench",
+		Variants: []classifier.CatalogVariant{
+			{ID: "fast", Backends: backend, Benchmarks: []classifier.Benchmark{{Device: deviceClassRPi5, Backend: hwprofile.CapONNXRuntimeCPU, LatencyMs: 100}}},
+			{ID: "mid", Backends: backend, Benchmarks: []classifier.Benchmark{{Device: deviceClassRPi5, Backend: hwprofile.CapONNXRuntimeCPU, LatencyMs: 300}}},
+			{ID: "slow", Backends: backend, Benchmarks: []classifier.Benchmark{{Device: deviceClassRPi5, Backend: hwprofile.CapONNXRuntimeCPU, LatencyMs: 500}}},
+		},
+	}
+	recs := Rank(Input{
+		Capabilities: []string{hwprofile.CapAArch64, hwprofile.CapONNXRuntimeCPU},
+		DeviceClass:  deviceClassRPi5,
+		Entries:      []classifier.CatalogEntry{entry},
+	})
+	assert.Equal(t, "fast", recommendedVariant(recs, "bench"), "fastest measured variant wins")
+
+	// Fewer than two comparable benchmarks: term is zero for all, so the tie
+	// falls through to size then id.
+	single := classifier.CatalogEntry{
+		ID: "bench-single",
+		Variants: []classifier.CatalogVariant{
+			{ID: "a", Backends: backend, Benchmarks: []classifier.Benchmark{{Device: deviceClassRPi5, Backend: hwprofile.CapONNXRuntimeCPU, LatencyMs: 999}}},
+			{ID: "b", Backends: backend},
+		},
+	}
+	recsSingle := Rank(Input{
+		Capabilities: []string{hwprofile.CapAArch64, hwprofile.CapONNXRuntimeCPU},
+		DeviceClass:  deviceClassRPi5,
+		Entries:      []classifier.CatalogEntry{single},
+	})
+	// Equal size (no files), equal score, tie broken lexically -> "a".
+	assert.Equal(t, "a", recommendedVariant(recsSingle, "bench-single"))
+	recA, _ := variantRec(recsSingle, "bench-single", "a")
+	assert.False(t, hasReason(&recA, ReasonBenchmarkMeasured), "single benchmark contributes no measured reason")
+}
+
+func TestRank_TieBreaks(t *testing.T) {
+	t.Parallel()
+
+	// Equal score and equal backend rank: smaller download wins.
+	backend := map[string]classifier.BackendSupport{hwprofile.CapONNXRuntimeCPU: {Supported: true, Recommended: true}}
+	entry := classifier.CatalogEntry{
+		ID: "tie",
+		Variants: []classifier.CatalogVariant{
+			{ID: "big", Backends: backend, Files: []classifier.CatalogFile{{SizeBytes: 900}}},
+			{ID: "small", Backends: backend, Files: []classifier.CatalogFile{{SizeBytes: 100}}},
+		},
+	}
+	recs := Rank(Input{
+		Capabilities: []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU},
+		Entries:      []classifier.CatalogEntry{entry},
+	})
+	assert.Equal(t, "small", recommendedVariant(recs, "tie"))
+}
+
+func TestRank_BestBackendFromRecommendedSet(t *testing.T) {
+	t.Parallel()
+
+	// A variant Supported (not Recommended) on the high-preference openvino-gpu,
+	// but Recommended on the lower openvino-cpu, must be scored via openvino-cpu.
+	gpuSupportedCPURecommended := classifier.CatalogVariant{
+		ID: "cpu-rec",
+		Backends: map[string]classifier.BackendSupport{
+			hwprofile.CapOpenVINOGPU: {Supported: true},
+			hwprofile.CapOpenVINOCPU: {Supported: true, Recommended: true},
+		},
+	}
+	// A sibling Recommended on openvino-gpu should outrank it on backend rank.
+	gpuRecommended := classifier.CatalogVariant{
+		ID: "gpu-rec",
+		Backends: map[string]classifier.BackendSupport{
+			hwprofile.CapOpenVINOGPU: {Supported: true, Recommended: true},
+			hwprofile.CapOpenVINOCPU: {Supported: true},
+		},
+	}
+	entry := classifier.CatalogEntry{ID: "backend-choice", Variants: []classifier.CatalogVariant{gpuSupportedCPURecommended, gpuRecommended}}
+	recs := Rank(Input{
+		Capabilities: []string{hwprofile.CapX86_64, hwprofile.CapOpenVINOCPU, hwprofile.CapOpenVINOGPU},
+		Entries:      []classifier.CatalogEntry{entry},
+	})
+	assert.Equal(t, "gpu-rec", recommendedVariant(recs, "backend-choice"))
+
+	cpuRec, _ := variantRec(recs, "backend-choice", "cpu-rec")
+	assert.Equal(t, hwprofile.CapOpenVINOCPU, reasonArg(&cpuRec, ReasonBackendRecommended, "backend"), "scored via its recommended backend, not the higher-preference supported one")
+}
+
+func TestRank_LegacyDemoted(t *testing.T) {
+	t.Parallel()
+
+	backend := map[string]classifier.BackendSupport{hwprofile.CapONNXRuntimeCPU: {Supported: true, Recommended: true}}
+	entry := classifier.CatalogEntry{
+		ID: "legacy-test",
+		Variants: []classifier.CatalogVariant{
+			{ID: "current", Backends: backend},
+			{ID: "old", Legacy: true, Backends: backend},
+		},
+	}
+	recs := Rank(Input{
+		Capabilities: []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU},
+		Entries:      []classifier.CatalogEntry{entry},
+	})
+	assert.Equal(t, "current", recommendedVariant(recs, "legacy-test"))
+	oldRec, _ := variantRec(recs, "legacy-test", "old")
+	assert.True(t, hasReason(&oldRec, ReasonVariantLegacy))
+	assert.Negative(t, oldRec.Score, "legacy penalty drives the score negative")
+}
+
+func TestRank_EmptyVariantsProducesNothing(t *testing.T) {
+	t.Parallel()
+
+	flat := classifier.CatalogEntry{ID: "flat", Files: []classifier.CatalogFile{{SizeBytes: 10}}}
+	recs := Rank(Input{
+		Capabilities: []string{hwprofile.CapX86_64},
+		Entries:      []classifier.CatalogEntry{flat},
+	})
+	assert.Empty(t, recs)
+}
+
+func TestRank_EmptyBackendsMapNotBlocked(t *testing.T) {
+	t.Parallel()
+
+	// A user-edited entry with no backend metadata must not be filtered out.
+	entry := classifier.CatalogEntry{
+		ID:       "user-catalog",
+		Variants: []classifier.CatalogVariant{{ID: "plain"}},
+	}
+	recs := Rank(Input{
+		Capabilities: []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU},
+		Entries:      []classifier.CatalogEntry{entry},
+	})
+	rec, ok := variantRec(recs, "user-catalog", "plain")
+	require.True(t, ok)
+	assert.True(t, rec.Compatible, "no backend info means no blocker")
+	assert.Empty(t, rec.Reasons, "no backend info means no backend term")
+	assert.True(t, rec.Recommended, "the only compatible variant is recommended")
+}
+
+func TestRank_PureInputNotMutated(t *testing.T) {
+	t.Parallel()
+
+	perch := realEntry(t, "perch-v2")
+	in := Input{
+		Capabilities:  []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU},
+		TotalRAMBytes: ramHigh,
+		DeviceClass:   deviceClassX86,
+		Entries:       []classifier.CatalogEntry{perch},
+	}
+	before := len(in.Entries[0].Variants)
+	beforeCaps := slices.Clone(in.Capabilities)
+
+	_ = Rank(in)
+
+	assert.Len(t, in.Entries[0].Variants, before, "entry variants unchanged")
+	assert.Equal(t, beforeCaps, in.Capabilities, "capabilities unchanged")
+}
+
+func TestRank_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	perch := realEntry(t, "perch-v2")
+	v3 := realEntry(t, "birdnet-v3.0")
+	in := Input{
+		Capabilities:  []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU, hwprofile.CapOpenVINOCPU, hwprofile.CapOpenVINOGPU},
+		TotalRAMBytes: ramHigh,
+		DeviceClass:   deviceClassX86,
+		Entries:       []classifier.CatalogEntry{perch, v3},
+	}
+	first := Rank(in)
+	for range 20 {
+		assert.Equal(t, first, Rank(in), "Rank is deterministic across repeated calls")
+	}
+}
+
+func TestDeviceClass(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		boardTier string
+		goArch    string
+		want      string
+	}{
+		{"pi5", "arm64", deviceClassRPi5},
+		{"pi4", "arm64", deviceClassRPi4},
+		{"pi3", "arm64", deviceClassRPi3},
+		{"", "amd64", deviceClassX86},
+		{"", "arm64", ""},
+		{"", "arm", ""},
+	}
+	for _, tt := range tests {
+		assert.Equalf(t, tt.want, DeviceClass(tt.boardTier, tt.goArch), "DeviceClass(%q, %q)", tt.boardTier, tt.goArch)
+	}
+}
+
+func TestRank_FP16NativeBonus(t *testing.T) {
+	t.Parallel()
+
+	// birdnet-v3.0 has an fp16 variant; on an fp16-native ARM host it earns the
+	// precision bonus. This is the case the matrix test could not reach (perch-v2
+	// has no fp16 variant).
+	v3 := realEntry(t, "birdnet-v3.0")
+	recs := Rank(Input{
+		Capabilities: []string{hwprofile.CapAArch64, hwprofile.CapAArch64A76, hwprofile.CapONNXRuntimeCPU, hwprofile.CapFP16Native},
+		DeviceClass:  deviceClassRPi5,
+		Entries:      []classifier.CatalogEntry{v3},
+	})
+	fp16, ok := variantRec(recs, "birdnet-v3.0", "fp16")
+	require.True(t, ok)
+	assert.True(t, fp16.Compatible)
+	assert.True(t, hasReason(&fp16, ReasonPrecisionFP16Native), "fp16 variant on an fp16-native host gets the precision bonus (reasons: %+v)", fp16.Reasons)
+}
+
+func TestRank_LowRAMInt8Bonus(t *testing.T) {
+	t.Parallel()
+
+	backend := map[string]classifier.BackendSupport{hwprofile.CapONNXRuntimeCPU: {Supported: true, Recommended: true}}
+	// int8 is the LARGER file, so absent the low-RAM bonus fp32 wins on the size
+	// tie-break. The bonus is what must flip the pick to int8, isolating it from
+	// the size effect that confounds the real-catalog case.
+	entry := classifier.CatalogEntry{
+		ID: "ram-test",
+		Variants: []classifier.CatalogVariant{
+			{ID: "fp32", Precision: "fp32", Backends: backend, Files: []classifier.CatalogFile{{SizeBytes: 100}}},
+			{ID: "int8", Precision: precisionINT8, Backends: backend, Files: []classifier.CatalogFile{{SizeBytes: 200}}},
+		},
+	}
+
+	lowRAM := Rank(Input{
+		Capabilities:  []string{hwprofile.CapAArch64, hwprofile.CapONNXRuntimeCPU, hwprofile.CapLowRAM},
+		TotalRAMBytes: ramLow,
+		Entries:       []classifier.CatalogEntry{entry},
+	})
+	assert.Equal(t, "int8", recommendedVariant(lowRAM, "ram-test"), "low-RAM host prefers the int8 build despite its larger size")
+	int8Rec, _ := variantRec(lowRAM, "ram-test", "int8")
+	assert.True(t, hasReason(&int8Rec, ReasonRAMConstrainedFit))
+
+	fullRAM := Rank(Input{
+		Capabilities:  []string{hwprofile.CapAArch64, hwprofile.CapONNXRuntimeCPU},
+		TotalRAMBytes: ramHigh,
+		Entries:       []classifier.CatalogEntry{entry},
+	})
+	assert.Equal(t, "fp32", recommendedVariant(fullRAM, "ram-test"), "without the low-RAM bonus the smaller fp32 wins")
+}
+
+func TestRank_LegacyNotRecommended(t *testing.T) {
+	t.Parallel()
+
+	backend := map[string]classifier.BackendSupport{hwprofile.CapONNXRuntimeCPU: {Supported: true, Recommended: true}}
+	// The only compatible variant is Legacy; because the gallery hides legacy
+	// variants, the recommender must not point at it, so the entry gets no
+	// recommendation rather than one the client cannot see.
+	entry := classifier.CatalogEntry{
+		ID: "legacy-only",
+		Variants: []classifier.CatalogVariant{
+			{ID: "old", Legacy: true, Backends: backend},
+			{ID: "new", Requirements: classifier.VariantRequirements{Arch: []string{hwprofile.CapAArch64}}, Backends: backend},
+		},
+	}
+	recs := Rank(Input{
+		Capabilities: []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU}, // amd64: "new" (aarch64-only) is blocked
+		Entries:      []classifier.CatalogEntry{entry},
+	})
+	assert.Empty(t, recommendedVariant(recs, "legacy-only"), "a Legacy-only entry gets no recommendation")
+	oldRec, ok := variantRec(recs, "legacy-only", "old")
+	require.True(t, ok)
+	assert.True(t, oldRec.Compatible, "the legacy variant is still compatible, just not recommended")
+	assert.False(t, oldRec.Recommended)
+}
+
+// --- test helpers ---
+
+func hasBlocker(rec *Recommendation, code string) bool {
+	for _, b := range rec.Blockers {
+		if b.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func hasReason(rec *Recommendation, code string) bool {
+	for _, r := range rec.Reasons {
+		if r.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func reasonArg(rec *Recommendation, code, arg string) string {
+	for _, r := range rec.Reasons {
+		if r.Code == code {
+			return r.Args[arg]
+		}
+	}
+	return ""
+}
+
+func blockerArg(rec *Recommendation, code, arg string) string {
+	for _, b := range rec.Blockers {
+		if b.Code == code {
+			return b.Args[arg]
+		}
+	}
+	return ""
+}

--- a/internal/classifier/recommend/recommend_test.go
+++ b/internal/classifier/recommend/recommend_test.go
@@ -502,6 +502,40 @@ func TestRank_LegacyNotRecommended(t *testing.T) {
 	assert.False(t, oldRec.Recommended)
 }
 
+func TestRank_BackendMissingNotDuplicated(t *testing.T) {
+	t.Parallel()
+
+	// A variant that both requires a backend the host lacks (Requirements.Backends)
+	// AND whose Backends map has no host-available candidate trips both the hard
+	// filter and the backend-term missing path. It must still yield exactly one
+	// backend.missing blocker, not two.
+	entry := classifier.CatalogEntry{
+		ID: "dup",
+		Variants: []classifier.CatalogVariant{
+			{
+				ID:           "needs-gpu",
+				Requirements: classifier.VariantRequirements{Backends: []string{hwprofile.CapOpenVINOGPU}},
+				Backends:     map[string]classifier.BackendSupport{hwprofile.CapOpenVINOGPU: {Supported: true, Recommended: true}},
+			},
+		},
+	}
+	recs := Rank(Input{
+		Capabilities: []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU}, // no openvino-gpu
+		Entries:      []classifier.CatalogEntry{entry},
+	})
+	rec, ok := variantRec(recs, "dup", "needs-gpu")
+	require.True(t, ok)
+	assert.False(t, rec.Compatible)
+
+	count := 0
+	for _, b := range rec.Blockers {
+		if b.Code == BlockerBackendMissing {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "backend.missing must appear once, not duplicated (blockers: %+v)", rec.Blockers)
+}
+
 // --- test helpers ---
 
 func hasBlocker(rec *Recommendation, code string) bool {


### PR DESCRIPTION
## What this does

The model gallery now recommends the optimal model variant for the user's detected hardware and preselects it in the install dialog, while always allowing a manual override. It never auto-installs: the recommendation is a preselection plus a badge plus a short "why" line, and every download still goes through the explicit license confirm.

On an OpenVINO host the gallery preselects the OpenVINO build, on an Intel iGPU the fp16 build, on a low-RAM Raspberry Pi the int8 ARM build, and it marks (and explains) any variant that cannot run on the machine instead of silently disabling it.

## Backend

- New pure package `internal/classifier/recommend`: `Rank()` scores every catalog variant against the host capability tokens from `internal/hwprofile`, producing structured blocker codes (`arch.unsupported`, `backend.missing`, `ram.insufficient`, `hardware.excluded`) and reason codes. No I/O, no globals, no clock, so the whole hardware matrix is table-tested without hardware. The best backend is chosen from the recommended set and ties break deterministically.
- `GET /api/v2/models/catalog` gains additive per-variant `compatible`, `recommended`, `reasons[]` and `blockers[]`, plus an entry-level `recommendedVariantId`. All fields are additive; older clients ignore them.
- The hardware-derived fields are gated behind authentication: an anonymous request on an auth-enabled instance gets the flat catalog and cannot read the host profile, while an auth-disabled home LAN still gets recommendations. The entry-level ONNX-runtime `compatible` flag is unchanged and stays public.
- The host profile is resolved through an injectable seam so tests supply synthetic hardware; the default probes ONNX Runtime and OpenVINO per request, honoring a hot-reloaded runtime path.

## Frontend

- New `ModelVariantPicker`: the recommended variant is preselected and explained, incompatible options are disabled with a visible reason (never silently disabled), the rest sit behind a progressive-disclosure toggle, and variants that share a precision stay distinguishable (e.g. "FP32 (no-dft)").
- `installModel(id, variantId?)`, variant types, and install-dialog wiring; the Install button is disabled with a reason when the selected variant cannot run on the host.
- New user-facing strings translated across all 15 locales.

## Testing

- Go: recommender hardware matrix against the real catalog, every blocker code, benchmark scaling, tie-breaks, purity, empty-backends safety, the FP16-native and low-RAM-int8 score bonuses, and the Legacy-not-recommended rule; API tests for recommended-variant marking, blocker exposure, flat-entry passthrough, and the auth gate.
- Frontend: unit tests for the selection helper and the picker (preselection, override, blocked-option reason, generic fallback, progressive disclosure, installed-variant visibility).
- Rendered the gallery in a real browser (Playwright) and confirmed the install dialog: recommended variant preselected with badge and "Best for your hardware" reason, Default badge, blocked variant greyed with its reason, and progressive disclosure.

## Scope

This ships smart install-time selection. Keeping multiple variants installed at once with an in-settings switcher, and regional model selection (which depends on upstream region metadata), are deliberate follow-ups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added model variant selection to analysis settings with recommendations, compatibility details, installation status, download sizes, and localized explanations.
  * Automatically recommends variants based on available hardware and backend support.
  * Incompatible variants are clearly marked and cannot be installed.
  * Installed and legacy variants remain visible when relevant, with additional options available through “Show all.”
  * Added localized variant labels and recommendation messages across supported languages.

* **Tests**
  * Added coverage for variant selection, recommendation ranking, visibility, compatibility, and installation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->