### PR TITLE
feat(models): region resolver and ModelRegion setting for the gallery

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -206,6 +206,25 @@ tasks:
     status:
       - '[ -f "{{.AVICOMMONS_JSON_FILE}}" ]'
 
+  sync-region-snapshots:
+    desc: Refresh the embedded region snapshots from a sibling acoustic-models checkout
+    vars:
+      ACOUSTIC_MODELS_DIR: '{{.ACOUSTIC_MODELS_DIR | default "../acoustic-models"}}'
+      REGION_DATA_DIR: internal/classifier/region/data
+    cmds:
+      - |
+        SRC="{{.ACOUSTIC_MODELS_DIR}}/models/manifests"
+        if [ ! -d "$SRC" ]; then
+          echo "acoustic-models manifests not found at $SRC" >&2
+          echo "Set ACOUSTIC_MODELS_DIR to your acoustic-models checkout." >&2
+          exit 1
+        fi
+        for f in Perch-v2-Models.regions.json BirdNET-v3.0-Models.regions.json; do
+          cp "$SRC/$f" "{{.REGION_DATA_DIR}}/$f"
+          echo "synced $f"
+        done
+        echo "Refreshed region snapshots. If tiers changed, update golden_tier_test.go."
+
   generate-species-dict:
     desc: Regenerate per-locale species dictionaries from the OpenFauna dataset
     cmds:

--- a/config.schema.json
+++ b/config.schema.json
@@ -498,6 +498,10 @@
         "huggingfaceendpoint": {
           "type": "string",
           "description": "model download host, e.g. \"https://hf-mirror.com\" where huggingface.co is blocked; empty falls back to $HF_ENDPOINT then https://huggingface.co"
+        },
+        "modelregion": {
+          "type": "string",
+          "description": "regional model preference: \"auto\" (resolve from coordinates, default), \"global\" (always global models), or a region slug pin (e.g. \"iberia\"); empty is treated as \"auto\""
         }
       },
       "additionalProperties": false,

--- a/doc/wiki/configuration-reference.md
+++ b/doc/wiki/configuration-reference.md
@@ -74,6 +74,7 @@ BirdNET configuration
 | `birdnet.backend` | string | inference backend preference: "auto" (default), "onnx", or "openvino" |
 | `birdnet.openvinodevice` | string | OpenVINO device preference: "auto" (default), "cpu", or "gpu" |
 | `birdnet.huggingfaceendpoint` | string | model download host, e.g. "https://hf-mirror.com" where huggingface.co is blocked; empty falls back to $HF_ENDPOINT then https://huggingface.co |
+| `birdnet.modelregion` | string | regional model preference: "auto" (resolve from coordinates, default), "global" (always global models), or a region slug pin (e.g. "iberia"); empty is treated as "auto" |
 
 ## perch
 

--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -548,6 +548,7 @@ Requires enhanced (v2) database. Returns 409 Conflict if not available.
 | ------ | ------------------------------ | ----------------------- | ---- | ----------------------------------------------------- |
 | GET    | `/models`                      | `ListModels`            | ❌   | List available classifier models                      |
 | GET    | `/models/catalog`              | `GetModelCatalog`       | ❌   | Model gallery catalog with install status             |
+| GET    | `/models/regions`              | `GetModelRegions`       | ✅   | Region selector data: selectable regions, the auto-resolved region for the configured coordinates, and per-family resolution (auth-gated; never echoes raw coordinates) |
 | GET    | `/models/installed`            | `GetInstalledModels`    | ❌   | List downloaded models                                |
 | POST   | `/models/install/:id`          | `InstallModel`          | ✅   | Download and install a catalog model                  |
 | POST   | `/models/reinstall/:id`        | `ReinstallModel`        | ✅   | Re-download missing/corrupt files for installed model |

--- a/internal/api/v2/hotreload_coverage_test.go
+++ b/internal/api/v2/hotreload_coverage_test.go
@@ -70,6 +70,10 @@ var hotReloadRegistry = map[string]hotReloadEntry{
 	// Read fresh by the model manager on every download, so a mirror change
 	// applies to the next install with no reload or restart.
 	"BirdNET.HuggingFaceEndpoint": {categories: []hotReloadCategory{hotReloadFresh}},
+	// Read fresh by the regions endpoint per request; nothing caches it at
+	// startup and it does not drive model loading, so no reload or restart is
+	// needed.
+	"BirdNET.ModelRegion": {categories: []hotReloadCategory{hotReloadFresh}},
 
 	// --- Perch ---
 	// Parent is restart: model/label path and locale changes reload the model.

--- a/internal/api/v2/models/models.go
+++ b/internal/api/v2/models/models.go
@@ -64,6 +64,7 @@ func New(core *apicore.Core, authService auth.Service) *Handler {
 func (c *Handler) RegisterRoutes(g *echo.Group) {
 	g.GET("/models", c.ListModels)
 	g.GET("/models/catalog", c.GetModelCatalog)
+	g.GET("/models/regions", c.GetModelRegions, c.AuthMiddleware)
 	g.GET("/models/installed", c.GetInstalledModels)
 	g.POST("/models/install/:id", c.InstallModel, c.AuthMiddleware)
 	g.POST("/models/reinstall/:id", c.ReinstallModel, c.AuthMiddleware)

--- a/internal/api/v2/models/models_regions.go
+++ b/internal/api/v2/models/models_regions.go
@@ -1,0 +1,211 @@
+package models
+
+import (
+	"cmp"
+	"maps"
+	"net/http"
+	"slices"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/tphakala/birdnet-go/internal/classifier"
+	"github.com/tphakala/birdnet-go/internal/classifier/region"
+)
+
+// RegionOption is one selectable region in the gallery dropdown.
+type RegionOption struct {
+	Slug         string `json:"slug"`
+	Name         string `json:"name"`
+	Group        string `json:"group"`        // continental bucket slug, for grouping in the UI
+	GroupDisplay string `json:"groupDisplay"` // continental bucket display name
+	Tier         int    `json:"tier"`
+}
+
+// RegionResolution is the coordinate-resolution outcome the UI renders as the
+// "detected region" why-line. Slug is empty when the global model applies.
+type RegionResolution struct {
+	Slug      string `json:"slug"`
+	Source    string `json:"source"`
+	Ambiguous bool   `json:"ambiguous"`
+	RunnerUp  string `json:"runnerUp,omitempty"`
+}
+
+// RegionFamily reports how one installed-or-available model family resolves under
+// the configured coordinates, so the UI can surface a per-family difference (the
+// D8 divergence case). Today all families share geometry and resolve identically.
+type RegionFamily struct {
+	CatalogID              string           `json:"catalogId"`
+	Repo                   string           `json:"repo"`
+	Installed              bool             `json:"installed"`
+	InstalledVariantRegion string           `json:"installedVariantRegion"` // region of the installed variant, "" for a global/hardware variant
+	Resolved               RegionResolution `json:"resolved"`
+}
+
+// ModelRegionsResponse is the payload of GET /api/v2/models/regions. It never
+// echoes the raw coordinates back; only the resolved region slug leaves the
+// server, so the endpoint reveals no more location precision than the region
+// tiles themselves.
+type ModelRegionsResponse struct {
+	ModelRegion        string           `json:"modelRegion"`        // the saved BirdNET.ModelRegion setting
+	LocationConfigured bool             `json:"locationConfigured"` // whether the station location is set
+	Resolved           RegionResolution `json:"resolved"`           // what "auto" resolves to from the coordinates
+	Regions            []RegionOption   `json:"regions"`            // dropdown options, union across families
+	Families           []RegionFamily   `json:"families"`           // per-family resolution
+}
+
+// GetModelRegions returns the region table for the gallery region selector: the
+// selectable regions, what the configured coordinates resolve to under "auto"
+// (regardless of the saved mode, so the UI can preview an unsaved choice), and
+// the per-family resolution. It is auth-gated because the resolved region and
+// per-family fields are derived from the user's coordinates (approximate
+// location); on an auth-disabled install the middleware passes through. The raw
+// coordinates are never echoed back.
+func (c *Handler) GetModelRegions(ctx echo.Context) error {
+	s := c.CurrentSettings()
+
+	tables, err := region.Tables()
+	if err != nil {
+		return c.HandleError(ctx, err, "region data unavailable", http.StatusInternalServerError)
+	}
+
+	// Coordinate resolution is only meaningful once the user has set a station
+	// location. Until then, auto resolves to the global model. Gating on
+	// LocationConfigured (rather than trusting that the 0,0 default falls outside
+	// every tile) keeps an unconfigured station on the global model even if a
+	// future tile ever covers the null-island origin.
+	families := c.buildRegionFamilies(tables, s.BirdNET.LocationConfigured, s.BirdNET.Latitude, s.BirdNET.Longitude)
+
+	resolved := RegionResolution{Source: string(region.SourceGlobal)}
+	if s.BirdNET.LocationConfigured {
+		// All families carry identical geometry (enforced by a region-package
+		// test), so any family's auto resolution is the detected region. Reuse the
+		// first to avoid a redundant sweep, falling back to a representative table
+		// only when no visible family maps to a region table.
+		switch {
+		case len(families) > 0:
+			resolved = families[0].Resolved
+		default:
+			if rep := representativeTable(tables); rep != nil {
+				sel := region.Select(rep, region.ModeAuto, s.BirdNET.Latitude, s.BirdNET.Longitude)
+				resolved = toRegionResolution(&sel)
+			}
+		}
+	}
+
+	return ctx.JSON(http.StatusOK, ModelRegionsResponse{
+		ModelRegion:        s.BirdNET.ModelRegion,
+		LocationConfigured: s.BirdNET.LocationConfigured,
+		Resolved:           resolved,
+		Regions:            buildRegionOptions(tables),
+		Families:           families,
+	})
+}
+
+// representativeTable picks a deterministic table from the embedded set (lowest
+// repo id), used for the geometry-only top-level resolution. Returns nil when no
+// table is embedded.
+func representativeTable(tables map[string]*region.Table) *region.Table {
+	repos := slices.Sorted(maps.Keys(tables))
+	if len(repos) == 0 {
+		return nil
+	}
+	return tables[repos[0]]
+}
+
+// buildRegionOptions flattens the embedded tables into a deduplicated, sorted
+// list of dropdown options. Tables are visited in sorted repo order so that, for
+// a slug shared across families, the display metadata is taken deterministically
+// from the lowest-keyed repo (matching representativeTable) rather than from a
+// random map-iteration winner. Ordering is by group display, then name, then
+// slug (a unique final tiebreaker) for a stable UI.
+func buildRegionOptions(tables map[string]*region.Table) []RegionOption {
+	seen := make(map[string]RegionOption)
+	for _, repo := range slices.Sorted(maps.Keys(tables)) {
+		tbl := tables[repo]
+		for slug := range tbl.Regions {
+			if _, ok := seen[slug]; ok {
+				continue
+			}
+			r := tbl.Regions[slug]
+			seen[slug] = RegionOption{
+				Slug:         slug,
+				Name:         r.Name,
+				Group:        r.Group,
+				GroupDisplay: r.GroupDisplay,
+				Tier:         r.Tier,
+			}
+		}
+	}
+	options := slices.Collect(maps.Values(seen))
+	slices.SortFunc(options, func(a, b RegionOption) int {
+		if c := cmp.Compare(a.GroupDisplay, b.GroupDisplay); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(a.Name, b.Name); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Slug, b.Slug)
+	})
+	return options
+}
+
+// buildRegionFamilies reports per-family resolution for every visible catalog
+// entry whose HuggingFace repo has a region table. When the station location is
+// not configured, coordinate resolution is skipped and every family reports the
+// global model, matching how auto falls back without coordinates.
+func (c *Handler) buildRegionFamilies(tables map[string]*region.Table, locationConfigured bool, lat, lon float64) []RegionFamily {
+	visible := classifier.VisibleCatalog()
+	families := make([]RegionFamily, 0, len(visible))
+	for i := range visible {
+		e := &visible[i]
+		tbl, ok := tables[e.HuggingFaceRepo]
+		if !ok {
+			continue
+		}
+		installed := false
+		installedVariantID := ""
+		if c.ModelManager != nil {
+			if vid, ok := c.ModelManager.InstalledVariantID(e.ID); ok {
+				installed = true
+				installedVariantID = vid
+			}
+		}
+		resolved := RegionResolution{Source: string(region.SourceGlobal)}
+		if locationConfigured {
+			sel := region.Select(tbl, region.ModeAuto, lat, lon)
+			resolved = toRegionResolution(&sel)
+		}
+		families = append(families, RegionFamily{
+			CatalogID:              e.ID,
+			Repo:                   e.HuggingFaceRepo,
+			Installed:              installed,
+			InstalledVariantRegion: variantRegion(e, installedVariantID),
+			Resolved:               resolved,
+		})
+	}
+	return families
+}
+
+// variantRegion returns the region slug of the entry's variant with the given
+// id, or "" when the id is empty (a flat entry) or the variant is global.
+func variantRegion(entry *classifier.CatalogEntry, variantID string) string {
+	if variantID == "" {
+		return ""
+	}
+	for i := range entry.Variants {
+		if entry.Variants[i].ID == variantID {
+			return entry.Variants[i].Region
+		}
+	}
+	return ""
+}
+
+// toRegionResolution maps a resolver Selection to its API form.
+func toRegionResolution(sel *region.Selection) RegionResolution {
+	return RegionResolution{
+		Slug:      sel.Slug,
+		Source:    string(sel.Source),
+		Ambiguous: sel.Ambiguous,
+		RunnerUp:  sel.RunnerUp,
+	}
+}

--- a/internal/api/v2/models/models_regions_test.go
+++ b/internal/api/v2/models/models_regions_test.go
@@ -1,0 +1,136 @@
+package models
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
+	"github.com/tphakala/birdnet-go/internal/classifier/region"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// expectedRegionCount is the number of tiles each family publishes; the dropdown
+// union carries exactly this many because families share a slug set.
+const expectedRegionCount = 39
+
+// getRegions calls GetModelRegions directly and decodes the response.
+func getRegions(t *testing.T, mutate func(*conf.Settings)) ModelRegionsResponse {
+	t.Helper()
+	core := apitest.NewCore(t, apitest.WithSettingsFunc(mutate))
+	h := New(core, nil)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/models/regions", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	require.NoError(t, h.GetModelRegions(ctx))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// The endpoint must never echo the raw coordinates back; only the resolved
+	// slug leaves the server. Guard both the latitude and the longitude of the
+	// Bogota fixture used below.
+	body := rec.Body.String()
+	assert.NotContains(t, body, "-74.1", "raw longitude must not leak")
+	assert.NotContains(t, body, "4.7", "raw latitude must not leak")
+
+	var resp ModelRegionsResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	return resp
+}
+
+// TestGetModelRegions_AutoResolves confirms the auto resolution, the dropdown
+// union, the echoed setting, and the per-family projection.
+//
+// These endpoint tests do NOT use t.Parallel(): the handler reads settings from
+// the process-global snapshot that apitest publishes, so parallel tests each
+// publishing different coordinates would clobber one another.
+func TestGetModelRegions_AutoResolves(t *testing.T) {
+	resp := getRegions(t, func(s *conf.Settings) {
+		s.BirdNET.Latitude = 4.7 // Bogota
+		s.BirdNET.Longitude = -74.1
+		s.BirdNET.LocationConfigured = true
+		s.BirdNET.ModelRegion = conf.ModelRegionAuto
+	})
+
+	assert.Equal(t, conf.ModelRegionAuto, resp.ModelRegion)
+	assert.True(t, resp.LocationConfigured)
+	assert.Equal(t, "andes", resp.Resolved.Slug, "Bogota resolves to andes")
+	assert.Equal(t, string(region.SourceAuto), resp.Resolved.Source)
+	assert.Len(t, resp.Regions, expectedRegionCount, "dropdown union covers every tile")
+
+	// The options are sorted and each carries display metadata.
+	for _, o := range resp.Regions {
+		assert.NotEmpty(t, o.Slug)
+		assert.NotEmpty(t, o.Name)
+		assert.Contains(t, []int{region.TierContinental, region.TierRegional, region.TierLocal}, o.Tier)
+	}
+
+	// The per-family projection resolves each installed-or-available family. The
+	// visible catalog carries at least the Perch v2 family (which has a region
+	// table), and every family shares geometry, so each resolves to andes here.
+	require.NotEmpty(t, resp.Families, "at least one family maps to a region table")
+	for _, f := range resp.Families {
+		assert.NotEmpty(t, f.CatalogID)
+		assert.NotEmpty(t, f.Repo)
+		assert.Equal(t, "andes", f.Resolved.Slug, "family %s resolves to andes", f.CatalogID)
+	}
+}
+
+// TestGetModelRegions_Ambiguous confirms the ambiguous border case surfaces a
+// runner-up.
+func TestGetModelRegions_Ambiguous(t *testing.T) {
+	resp := getRegions(t, func(s *conf.Settings) {
+		s.BirdNET.Latitude = 2.0
+		s.BirdNET.Longitude = -71.0
+		s.BirdNET.LocationConfigured = true
+	})
+	assert.Equal(t, "andes", resp.Resolved.Slug)
+	assert.True(t, resp.Resolved.Ambiguous, "the border point is ambiguous")
+	assert.Equal(t, "amazonia", resp.Resolved.RunnerUp)
+}
+
+// TestGetModelRegions_GlobalStillPreviews confirms that under the global setting
+// the endpoint still reports what auto would resolve to, so the UI can preview a
+// mode the user has not saved. The saved mode is echoed separately.
+func TestGetModelRegions_GlobalStillPreviews(t *testing.T) {
+	resp := getRegions(t, func(s *conf.Settings) {
+		s.BirdNET.Latitude = 4.7
+		s.BirdNET.Longitude = -74.1
+		s.BirdNET.LocationConfigured = true
+		s.BirdNET.ModelRegion = conf.ModelRegionGlobal
+	})
+	assert.Equal(t, conf.ModelRegionGlobal, resp.ModelRegion, "saved mode echoed")
+	assert.Equal(t, "andes", resp.Resolved.Slug, "resolved is always the auto preview")
+}
+
+// TestGetModelRegions_NoLocation confirms an unconfigured location yields the
+// global model even when coordinates that WOULD resolve are present: the gate is
+// the LocationConfigured flag, not the geography of the 0,0 default.
+func TestGetModelRegions_NoLocation(t *testing.T) {
+	resp := getRegions(t, func(s *conf.Settings) {
+		s.BirdNET.Latitude = 4.7 // Bogota coordinates that resolve to andes...
+		s.BirdNET.Longitude = -74.1
+		s.BirdNET.LocationConfigured = false // ...but the location is not configured
+	})
+	assert.False(t, resp.LocationConfigured)
+	assert.Empty(t, resp.Resolved.Slug, "unconfigured location uses the global model")
+	assert.Equal(t, string(region.SourceGlobal), resp.Resolved.Source)
+	for _, f := range resp.Families {
+		assert.Empty(t, f.Resolved.Slug, "family %s is global when location unconfigured", f.CatalogID)
+	}
+}
+
+// TestModelRegionConstantsMatchResolver is the drift guard for keeping the conf
+// mode constants (defined independently so conf stays free of a classifier
+// dependency) equal to the resolver's mode vocabulary.
+func TestModelRegionConstantsMatchResolver(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, region.ModeAuto, conf.ModelRegionAuto, "auto mode constant drifted")
+	assert.Equal(t, region.ModeGlobal, conf.ModelRegionGlobal, "global mode constant drifted")
+}

--- a/internal/api/v2/models/models_test.go
+++ b/internal/api/v2/models/models_test.go
@@ -24,6 +24,7 @@ func TestModelsRouteRegistration(t *testing.T) {
 	expectedRoutes := []string{
 		"GET /api/v2/models",
 		"GET /api/v2/models/catalog",
+		"GET /api/v2/models/regions",
 		"GET /api/v2/models/installed",
 		"POST /api/v2/models/install/:id",
 		"POST /api/v2/models/reinstall/:id",

--- a/internal/api/v2/routes_enumeration_test.go
+++ b/internal/api/v2/routes_enumeration_test.go
@@ -96,6 +96,7 @@ var goldenRoutes = []string{
 	"GET /api/v2/models/catalog",
 	"GET /api/v2/models/install/:id/progress",
 	"GET /api/v2/models/installed",
+	"GET /api/v2/models/regions",
 	"GET /api/v2/notifications",
 	"GET /api/v2/notifications/:id",
 	"GET /api/v2/notifications/check-ntfy-server",

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -1539,20 +1539,28 @@ func validateBirdNETSection(data json.RawMessage) error {
 // bad one is a 400. "auto", "global", the empty string, and a well-formed region
 // slug are accepted; an unknown but well-formed slug is allowed because the
 // per-family resolver degrades it gracefully.
+//
+// The key match is case-insensitive on purpose: encoding/json binds struct
+// fields case-insensitively, so a payload key like "modelregion" still reaches
+// BirdNETConfig.ModelRegion on merge. Matching only the exact "modelRegion" key
+// would let a case-variant key slip past this check and persist an unvalidated
+// value.
 func validateModelRegionField(updateMap map[string]any) error {
-	raw, ok := updateMap["modelRegion"]
-	if !ok || raw == nil {
-		return nil
+	for key, raw := range updateMap {
+		if !strings.EqualFold(key, "modelRegion") || raw == nil {
+			continue
+		}
+		region, ok := raw.(string)
+		if !ok {
+			return fmt.Errorf("modelRegion must be a string")
+		}
+		if region == "" || region == conf.ModelRegionAuto || region == conf.ModelRegionGlobal ||
+			conf.ModelRegionSlugPattern.MatchString(region) {
+			continue
+		}
+		return fmt.Errorf("modelRegion must be 'auto', 'global', or a region slug")
 	}
-	region, ok := raw.(string)
-	if !ok {
-		return fmt.Errorf("modelRegion must be a string")
-	}
-	if region == "" || region == conf.ModelRegionAuto || region == conf.ModelRegionGlobal ||
-		conf.ModelRegionSlugPattern.MatchString(region) {
-		return nil
-	}
-	return fmt.Errorf("modelRegion must be 'auto', 'global', or a region slug")
+	return nil
 }
 
 // validateWebServerSection validates WebServer settings including LiveStream fields.

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -1546,21 +1546,36 @@ func validateBirdNETSection(data json.RawMessage) error {
 // would let a case-variant key slip past this check and persist an unvalidated
 // value.
 func validateModelRegionField(updateMap map[string]any) error {
-	for key, raw := range updateMap {
-		if !strings.EqualFold(key, "modelRegion") || raw == nil {
-			continue
+	var matched []string
+	for key := range updateMap {
+		if strings.EqualFold(key, "modelRegion") {
+			matched = append(matched, key)
 		}
-		region, ok := raw.(string)
-		if !ok {
-			return fmt.Errorf("modelRegion must be a string")
-		}
-		if region == "" || region == conf.ModelRegionAuto || region == conf.ModelRegionGlobal ||
-			conf.ModelRegionSlugPattern.MatchString(region) {
-			continue
-		}
-		return fmt.Errorf("modelRegion must be 'auto', 'global', or a region slug")
 	}
-	return nil
+	switch len(matched) {
+	case 0:
+		return nil
+	case 1:
+		// single key, validated below
+	default:
+		// More than one case-variant of the key (e.g. "modelRegion" and
+		// "modelregion"). json binds one of them ambiguously on merge, so reject
+		// the payload rather than silently pick one.
+		return fmt.Errorf("modelRegion specified multiple times with different key casing")
+	}
+	raw := updateMap[matched[0]]
+	if raw == nil {
+		return nil
+	}
+	region, ok := raw.(string)
+	if !ok {
+		return fmt.Errorf("modelRegion must be a string")
+	}
+	if region == "" || region == conf.ModelRegionAuto || region == conf.ModelRegionGlobal ||
+		conf.ModelRegionSlugPattern.MatchString(region) {
+		return nil
+	}
+	return fmt.Errorf("modelRegion must be 'auto', 'global', or a region slug")
 }
 
 // validateWebServerSection validates WebServer settings including LiveStream fields.

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -1527,7 +1527,32 @@ func validateBirdNETSection(data json.RawMessage) error {
 	if err := validateFloatInRange(updateMap, "latitude", minLatitude, maxLatitude, "latitude"); err != nil {
 		return err
 	}
-	return validateFloatInRange(updateMap, "longitude", minLongitude, maxLongitude, "longitude")
+	if err := validateFloatInRange(updateMap, "longitude", minLongitude, maxLongitude, "longitude"); err != nil {
+		return err
+	}
+	return validateModelRegionField(updateMap)
+}
+
+// validateModelRegionField rejects a malformed modelRegion in a PATCH/PUT
+// payload. Unlike the startup validator (which warns and normalizes an aged
+// config), a value submitted through the API is expected to be well-formed, so a
+// bad one is a 400. "auto", "global", the empty string, and a well-formed region
+// slug are accepted; an unknown but well-formed slug is allowed because the
+// per-family resolver degrades it gracefully.
+func validateModelRegionField(updateMap map[string]any) error {
+	raw, ok := updateMap["modelRegion"]
+	if !ok || raw == nil {
+		return nil
+	}
+	region, ok := raw.(string)
+	if !ok {
+		return fmt.Errorf("modelRegion must be a string")
+	}
+	if region == "" || region == conf.ModelRegionAuto || region == conf.ModelRegionGlobal ||
+		conf.ModelRegionSlugPattern.MatchString(region) {
+		return nil
+	}
+	return fmt.Errorf("modelRegion must be 'auto', 'global', or a region slug")
 }
 
 // validateWebServerSection validates WebServer settings including LiveStream fields.

--- a/internal/api/v2/settings_model_region_test.go
+++ b/internal/api/v2/settings_model_region_test.go
@@ -78,3 +78,18 @@ func TestPatchModelRegionRejectsCaseVariantKey(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
 	assert.Contains(t, response["error"], "modelRegion must be")
 }
+
+// TestPatchModelRegionRejectsDuplicateCaseKeys rejects a payload carrying the
+// key under two different casings, whose bind order json resolves ambiguously.
+func TestPatchModelRegionRejectsDuplicateCaseKeys(t *testing.T) {
+	e := echo.New()
+	controller := getTestController(t, e)
+	controller.Settings.Load().WebServer.Debug = true // expose the raw error field
+
+	rec := patchBirdNET(t, controller, e, map[string]any{"modelRegion": "auto", "modelregion": "iberia"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "duplicate case-variant keys must be rejected")
+
+	var response map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	assert.Contains(t, response["error"], "multiple times")
+}

--- a/internal/api/v2/settings_model_region_test.go
+++ b/internal/api/v2/settings_model_region_test.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// patchBirdNET PATCHes the birdnet settings section with the given body and
+// returns the recorder.
+func patchBirdNET(t *testing.T, controller *Controller, e *echo.Echo, body map[string]any) *httptest.ResponseRecorder {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v2/settings/birdnet", bytes.NewReader(raw))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("section")
+	ctx.SetParamValues("birdnet")
+
+	require.NoError(t, controller.UpdateSectionSettings(ctx))
+	return rec
+}
+
+// TestPatchModelRegionRoundTrip verifies a well-formed region slug persists
+// through a PATCH of the birdnet section.
+func TestPatchModelRegionRoundTrip(t *testing.T) {
+	e := echo.New()
+	controller := getTestController(t, e)
+
+	rec := patchBirdNET(t, controller, e, map[string]any{"modelRegion": "iberia"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "iberia", controller.Settings.Load().BirdNET.ModelRegion,
+		"modelRegion must persist after PATCH")
+
+	// The mode values round-trip too.
+	rec = patchBirdNET(t, controller, e, map[string]any{"modelRegion": "global"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "global", controller.Settings.Load().BirdNET.ModelRegion)
+}
+
+// TestPatchModelRegionRejectsMalformed verifies a malformed region value is a
+// 400 through the API (unlike the startup validator, which normalizes it).
+func TestPatchModelRegionRejectsMalformed(t *testing.T) {
+	e := echo.New()
+	controller := getTestController(t, e)
+	controller.Settings.Load().WebServer.Debug = true // expose the raw error field
+
+	rec := patchBirdNET(t, controller, e, map[string]any{"modelRegion": "Bad Region!"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var response map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	assert.Contains(t, response["error"], "modelRegion must be")
+}

--- a/internal/api/v2/settings_model_region_test.go
+++ b/internal/api/v2/settings_model_region_test.go
@@ -61,3 +61,20 @@ func TestPatchModelRegionRejectsMalformed(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
 	assert.Contains(t, response["error"], "modelRegion must be")
 }
+
+// TestPatchModelRegionRejectsCaseVariantKey guards the case-insensitive key
+// match: encoding/json binds a case-variant key like "modelregion" to
+// BirdNETConfig.ModelRegion on merge, so the validator must reject a malformed
+// value under any casing, not only the exact "modelRegion" key.
+func TestPatchModelRegionRejectsCaseVariantKey(t *testing.T) {
+	e := echo.New()
+	controller := getTestController(t, e)
+	controller.Settings.Load().WebServer.Debug = true // expose the raw error field
+
+	rec := patchBirdNET(t, controller, e, map[string]any{"modelregion": "Bad Region!"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "a malformed case-variant key must not bypass validation")
+
+	var response map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	assert.Contains(t, response["error"], "modelRegion must be")
+}

--- a/internal/classifier/region/data/BirdNET-v3.0-Models.regions.json
+++ b/internal/classifier/region/data/BirdNET-v3.0-Models.regions.json
@@ -1,0 +1,1260 @@
+{
+  "schema": 1,
+  "repo": "tphakala/BirdNET-v3.0-Models",
+  "updated": "2026-08-14",
+  "regions": {
+    "nordic": {
+      "name": "Nordic",
+      "group": "europe",
+      "group_display": "Europe",
+      "realm": "palearctic",
+      "tier": 50,
+      "bboxes": [
+        [
+          53.1,
+          72.66,
+          3.32,
+          32.05
+        ]
+      ],
+      "centroid": [
+        62.88,
+        17.685
+      ],
+      "countries": {
+        "core": [
+          "AX",
+          "DK",
+          "FI",
+          "NO",
+          "SE"
+        ],
+        "partial": []
+      },
+      "classes": 422
+    },
+    "british-isles": {
+      "name": "British Isles",
+      "group": "europe",
+      "group_display": "Europe",
+      "realm": "palearctic",
+      "tier": 50,
+      "bboxes": [
+        [
+          49.5,
+          61.0,
+          -11.0,
+          2.5
+        ]
+      ],
+      "centroid": [
+        55.25,
+        -4.25
+      ],
+      "countries": {
+        "core": [
+          "GB",
+          "IE",
+          "IM"
+        ],
+        "partial": [
+          "GG"
+        ]
+      },
+      "classes": 559
+    },
+    "central-europe": {
+      "name": "Central Europe",
+      "group": "europe",
+      "group_display": "Europe",
+      "realm": "palearctic",
+      "tier": 50,
+      "bboxes": [
+        [
+          45.0,
+          55.5,
+          2.0,
+          24.0
+        ]
+      ],
+      "centroid": [
+        50.25,
+        13.0
+      ],
+      "countries": {
+        "core": [
+          "AT",
+          "BE",
+          "CH",
+          "CZ",
+          "DE",
+          "FR",
+          "HR",
+          "HU",
+          "LI",
+          "LU",
+          "NL",
+          "PL",
+          "SI",
+          "SK"
+        ],
+        "partial": [
+          "BA",
+          "DK",
+          "IT",
+          "LT",
+          "RO",
+          "RS"
+        ]
+      },
+      "classes": 644
+    },
+    "baltics": {
+      "name": "Baltics",
+      "group": "europe",
+      "group_display": "Europe",
+      "realm": "palearctic",
+      "tier": 50,
+      "bboxes": [
+        [
+          53.5,
+          59.8,
+          20.0,
+          30.0
+        ]
+      ],
+      "centroid": [
+        56.65,
+        25.0
+      ],
+      "countries": {
+        "core": [
+          "BY",
+          "EE",
+          "LT",
+          "LV",
+          "RU"
+        ],
+        "partial": []
+      },
+      "classes": 438
+    },
+    "iberia": {
+      "name": "Iberia",
+      "group": "europe",
+      "group_display": "Europe",
+      "realm": "palearctic",
+      "tier": 50,
+      "bboxes": [
+        [
+          35.5,
+          44.5,
+          -10.0,
+          3.5
+        ]
+      ],
+      "centroid": [
+        40.0,
+        -3.25
+      ],
+      "countries": {
+        "core": [
+          "AD",
+          "ES",
+          "PT"
+        ],
+        "partial": [
+          "FR"
+        ]
+      },
+      "classes": 627
+    },
+    "southern-europe": {
+      "name": "Southern Europe",
+      "group": "europe",
+      "group_display": "Europe",
+      "realm": "palearctic",
+      "tier": 50,
+      "bboxes": [
+        [
+          36.0,
+          47.0,
+          6.0,
+          29.0
+        ]
+      ],
+      "centroid": [
+        41.5,
+        17.5
+      ],
+      "countries": {
+        "core": [
+          "AL",
+          "BA",
+          "BG",
+          "GR",
+          "HR",
+          "IT",
+          "MC",
+          "ME",
+          "MK",
+          "MT",
+          "RO",
+          "RS",
+          "SI",
+          "SM",
+          "VA",
+          "XK"
+        ],
+        "partial": [
+          "CH",
+          "HU",
+          "TN",
+          "TR"
+        ]
+      },
+      "classes": 616
+    },
+    "eastern-europe": {
+      "name": "Eastern Europe",
+      "group": "europe",
+      "group_display": "Europe",
+      "realm": "palearctic",
+      "tier": 50,
+      "bboxes": [
+        [
+          44.0,
+          53.0,
+          22.0,
+          40.0
+        ]
+      ],
+      "centroid": [
+        48.5,
+        31.0
+      ],
+      "countries": {
+        "core": [
+          "MD",
+          "RO",
+          "RU",
+          "UA"
+        ],
+        "partial": [
+          "BY",
+          "PL"
+        ]
+      },
+      "classes": 518
+    },
+    "western-palearctic": {
+      "name": "Western Palearctic",
+      "group": "europe",
+      "group_display": "Europe",
+      "realm": "palearctic",
+      "tier": 10,
+      "bboxes": [
+        [
+          35.0,
+          71.0,
+          -11.0,
+          45.0
+        ],
+        [
+          26.0,
+          40.0,
+          -32.0,
+          -13.0
+        ],
+        [
+          20.0,
+          37.0,
+          -13.0,
+          37.0
+        ],
+        [
+          30.0,
+          42.0,
+          34.0,
+          50.0
+        ],
+        [
+          12.0,
+          32.0,
+          34.0,
+          60.0
+        ]
+      ],
+      "centroid": [
+        41.5,
+        14.0
+      ],
+      "countries": {
+        "core": [
+          "AD",
+          "AE",
+          "AL",
+          "AM",
+          "AT",
+          "AX",
+          "AZ",
+          "BA",
+          "BE",
+          "BG",
+          "BH",
+          "BY",
+          "CH",
+          "CY",
+          "CZ",
+          "DE",
+          "DK",
+          "DZ",
+          "EE",
+          "EG",
+          "EH",
+          "ER",
+          "ES",
+          "FI",
+          "FO",
+          "FR",
+          "GB",
+          "GE",
+          "GG",
+          "GR",
+          "HR",
+          "HU",
+          "IE",
+          "IL",
+          "IM",
+          "IQ",
+          "IR",
+          "IT",
+          "JE",
+          "JO",
+          "KW",
+          "LB",
+          "LI",
+          "LT",
+          "LU",
+          "LV",
+          "LY",
+          "MA",
+          "MC",
+          "MD",
+          "ME",
+          "MK",
+          "MR",
+          "MT",
+          "NE",
+          "NL",
+          "NO",
+          "OM",
+          "PL",
+          "PS",
+          "PT",
+          "QA",
+          "RO",
+          "RS",
+          "SA",
+          "SD",
+          "SE",
+          "SI",
+          "SK",
+          "SM",
+          "SY",
+          "TD",
+          "TN",
+          "TR",
+          "UA",
+          "VA",
+          "XK",
+          "YE"
+        ],
+        "partial": [
+          "DJ",
+          "ET",
+          "ML",
+          "RU",
+          "TM"
+        ]
+      },
+      "classes": 801
+    },
+    "iceland": {
+      "name": "Iceland",
+      "group": "europe",
+      "group_display": "Europe",
+      "realm": "palearctic",
+      "tier": 90,
+      "bboxes": [
+        [
+          63.0,
+          67.0,
+          -25.0,
+          -13.0
+        ]
+      ],
+      "centroid": [
+        65.0,
+        -19.0
+      ],
+      "countries": {
+        "core": [
+          "IS"
+        ],
+        "partial": []
+      },
+      "classes": 391
+    },
+    "svalbard": {
+      "name": "Svalbard",
+      "group": "europe",
+      "group_display": "Europe",
+      "realm": "palearctic",
+      "tier": 90,
+      "bboxes": [
+        [
+          74.0,
+          81.0,
+          9.0,
+          34.0
+        ]
+      ],
+      "centroid": [
+        77.5,
+        21.5
+      ],
+      "countries": {
+        "core": [
+          "SJ"
+        ],
+        "partial": []
+      },
+      "classes": 280
+    },
+    "canary-islands": {
+      "name": "Canary Islands",
+      "group": "europe",
+      "group_display": "Europe",
+      "realm": "palearctic",
+      "tier": 90,
+      "bboxes": [
+        [
+          27.0,
+          29.8,
+          -18.5,
+          -13.0
+        ]
+      ],
+      "centroid": [
+        28.4,
+        -15.75
+      ],
+      "countries": {
+        "core": [
+          "ES",
+          "MA"
+        ],
+        "partial": []
+      },
+      "classes": 388
+    },
+    "madeira": {
+      "name": "Madeira",
+      "group": "europe",
+      "group_display": "Europe",
+      "realm": "palearctic",
+      "tier": 90,
+      "bboxes": [
+        [
+          32.3,
+          33.2,
+          -17.4,
+          -16.2
+        ]
+      ],
+      "centroid": [
+        32.75,
+        -16.8
+      ],
+      "countries": {
+        "core": [
+          "PT"
+        ],
+        "partial": []
+      },
+      "classes": 255
+    },
+    "azores": {
+      "name": "Azores",
+      "group": "europe",
+      "group_display": "Europe",
+      "realm": "palearctic",
+      "tier": 90,
+      "bboxes": [
+        [
+          36.5,
+          40.0,
+          -31.5,
+          -24.8
+        ]
+      ],
+      "centroid": [
+        38.25,
+        -28.15
+      ],
+      "countries": {
+        "core": [
+          "PT"
+        ],
+        "partial": []
+      },
+      "classes": 224
+    },
+    "south-asia-peninsular": {
+      "name": "South India & Sri Lanka",
+      "group": "asia",
+      "group_display": "Asia",
+      "realm": "indomalayan",
+      "tier": 50,
+      "bboxes": [
+        [
+          5.5,
+          21.0,
+          72.0,
+          88.0
+        ]
+      ],
+      "centroid": [
+        13.25,
+        80.0
+      ],
+      "countries": {
+        "core": [
+          "IN",
+          "LK"
+        ],
+        "partial": []
+      },
+      "classes": 644
+    },
+    "indo-gangetic": {
+      "name": "Indo-Gangetic Plain",
+      "group": "asia",
+      "group_display": "Asia",
+      "realm": "indomalayan",
+      "tier": 50,
+      "bboxes": [
+        [
+          21.0,
+          30.0,
+          68.0,
+          90.0
+        ]
+      ],
+      "centroid": [
+        25.5,
+        79.0
+      ],
+      "countries": {
+        "core": [
+          "BD",
+          "BT",
+          "IN",
+          "NP",
+          "PK"
+        ],
+        "partial": [
+          "CN"
+        ]
+      },
+      "classes": 814
+    },
+    "himalaya": {
+      "name": "Himalaya",
+      "group": "asia",
+      "group_display": "Asia",
+      "realm": "indomalayan",
+      "tier": 50,
+      "bboxes": [
+        [
+          27.0,
+          36.0,
+          72.0,
+          97.0
+        ]
+      ],
+      "centroid": [
+        31.5,
+        84.5
+      ],
+      "countries": {
+        "core": [
+          "BT",
+          "CN",
+          "IN",
+          "NP"
+        ],
+        "partial": [
+          "PK"
+        ]
+      },
+      "classes": 812
+    },
+    "japan": {
+      "name": "Japan",
+      "group": "asia",
+      "group_display": "Asia",
+      "realm": "palearctic",
+      "tier": 50,
+      "bboxes": [
+        [
+          30.0,
+          46.0,
+          128.0,
+          146.0
+        ]
+      ],
+      "centroid": [
+        38.0,
+        137.0
+      ],
+      "countries": {
+        "core": [
+          "JP",
+          "KR"
+        ],
+        "partial": [
+          "CN",
+          "KP",
+          "RU"
+        ]
+      },
+      "classes": 577
+    },
+    "china-northeast": {
+      "name": "China (Northeast)",
+      "group": "asia",
+      "group_display": "Asia",
+      "realm": "palearctic",
+      "tier": 50,
+      "bboxes": [
+        [
+          38.0,
+          54.0,
+          115.0,
+          135.0
+        ]
+      ],
+      "centroid": [
+        46.0,
+        125.0
+      ],
+      "countries": {
+        "core": [
+          "CN",
+          "KP",
+          "RU"
+        ],
+        "partial": [
+          "MN"
+        ]
+      },
+      "classes": 650
+    },
+    "china-north-central": {
+      "name": "China (North-Central)",
+      "group": "asia",
+      "group_display": "Asia",
+      "realm": "palearctic",
+      "tier": 50,
+      "bboxes": [
+        [
+          33.0,
+          42.0,
+          106.0,
+          122.0
+        ]
+      ],
+      "centroid": [
+        37.5,
+        114.0
+      ],
+      "countries": {
+        "core": [
+          "CN"
+        ],
+        "partial": []
+      },
+      "classes": 752
+    },
+    "china-southeast": {
+      "name": "China (Southeast)",
+      "group": "asia",
+      "group_display": "Asia",
+      "realm": "indomalayan",
+      "tier": 50,
+      "bboxes": [
+        [
+          20.0,
+          31.0,
+          106.0,
+          122.0
+        ]
+      ],
+      "centroid": [
+        25.5,
+        114.0
+      ],
+      "countries": {
+        "core": [
+          "CN",
+          "HK",
+          "MO",
+          "TW"
+        ],
+        "partial": []
+      },
+      "classes": 808
+    },
+    "china-southwest": {
+      "name": "China (Southwest)",
+      "group": "asia",
+      "group_display": "Asia",
+      "realm": "palearctic",
+      "tier": 50,
+      "bboxes": [
+        [
+          22.0,
+          34.0,
+          97.0,
+          108.0
+        ]
+      ],
+      "centroid": [
+        28.0,
+        102.5
+      ],
+      "countries": {
+        "core": [
+          "CN"
+        ],
+        "partial": [
+          "MM",
+          "VN"
+        ]
+      },
+      "classes": 816
+    },
+    "tibet": {
+      "name": "Tibetan Plateau",
+      "group": "asia",
+      "group_display": "Asia",
+      "realm": "palearctic",
+      "tier": 50,
+      "bboxes": [
+        [
+          29.0,
+          37.0,
+          79.0,
+          99.0
+        ]
+      ],
+      "centroid": [
+        33.0,
+        89.0
+      ],
+      "countries": {
+        "core": [
+          "CN"
+        ],
+        "partial": [
+          "NP"
+        ]
+      },
+      "classes": 811
+    },
+    "north-america-east": {
+      "name": "North America (East)",
+      "group": "north-america",
+      "group_display": "North America",
+      "realm": "nearctic",
+      "tier": 50,
+      "bboxes": [
+        [
+          25.0,
+          50.0,
+          -95.0,
+          -60.0
+        ]
+      ],
+      "centroid": [
+        37.5,
+        -77.5
+      ],
+      "countries": {
+        "core": [
+          "BM",
+          "CA",
+          "US"
+        ],
+        "partial": []
+      },
+      "classes": 800
+    },
+    "north-america-west": {
+      "name": "North America (West)",
+      "group": "north-america",
+      "group_display": "North America",
+      "realm": "nearctic",
+      "tier": 50,
+      "bboxes": [
+        [
+          31.0,
+          55.0,
+          -125.0,
+          -100.0
+        ]
+      ],
+      "centroid": [
+        43.0,
+        -112.5
+      ],
+      "countries": {
+        "core": [
+          "CA",
+          "US"
+        ],
+        "partial": []
+      },
+      "classes": 802
+    },
+    "amazonia": {
+      "name": "Amazonia",
+      "group": "south-america",
+      "group_display": "South America",
+      "realm": "neotropic",
+      "tier": 50,
+      "bboxes": [
+        [
+          -13.0,
+          10.0,
+          -79.0,
+          -44.0
+        ]
+      ],
+      "centroid": [
+        -1.5,
+        -61.5
+      ],
+      "countries": {
+        "core": [
+          "BR",
+          "CO",
+          "EC",
+          "GY",
+          "PE",
+          "SR",
+          "TT",
+          "VE"
+        ],
+        "partial": [
+          "BO",
+          "PA"
+        ]
+      },
+      "classes": 809
+    },
+    "andes": {
+      "name": "Andes",
+      "group": "south-america",
+      "group_display": "South America",
+      "realm": "neotropic",
+      "tier": 50,
+      "bboxes": [
+        [
+          -40.0,
+          12.0,
+          -81.0,
+          -62.0
+        ]
+      ],
+      "centroid": [
+        -14.0,
+        -71.5
+      ],
+      "countries": {
+        "core": [
+          "AR",
+          "AW",
+          "BO",
+          "BR",
+          "CL",
+          "CO",
+          "CW",
+          "EC",
+          "GD",
+          "PA",
+          "PE",
+          "VE"
+        ],
+        "partial": []
+      },
+      "classes": 809
+    },
+    "eastern-brazil": {
+      "name": "Eastern Brazil",
+      "group": "south-america",
+      "group_display": "South America",
+      "realm": "neotropic",
+      "tier": 50,
+      "bboxes": [
+        [
+          -33.0,
+          -2.0,
+          -60.0,
+          -34.0
+        ]
+      ],
+      "centroid": [
+        -17.5,
+        -47.0
+      ],
+      "countries": {
+        "core": [
+          "BR",
+          "PY",
+          "UY"
+        ],
+        "partial": [
+          "AR"
+        ]
+      },
+      "classes": 812
+    },
+    "southern-cone": {
+      "name": "Southern Cone",
+      "group": "south-america",
+      "group_display": "South America",
+      "realm": "neotropic",
+      "tier": 50,
+      "bboxes": [
+        [
+          -56.0,
+          -20.0,
+          -77.0,
+          -53.0
+        ]
+      ],
+      "centroid": [
+        -38.0,
+        -65.0
+      ],
+      "countries": {
+        "core": [
+          "AR",
+          "CL",
+          "FK",
+          "PY",
+          "UY"
+        ],
+        "partial": [
+          "BO",
+          "BR"
+        ]
+      },
+      "classes": 807
+    },
+    "galapagos": {
+      "name": "Galapagos",
+      "group": "south-america",
+      "group_display": "South America",
+      "realm": "neotropic",
+      "tier": 90,
+      "bboxes": [
+        [
+          -1.6,
+          1.8,
+          -92.0,
+          -89.0
+        ]
+      ],
+      "centroid": [
+        0.1,
+        -90.5
+      ],
+      "countries": {
+        "core": [
+          "EC"
+        ],
+        "partial": []
+      },
+      "classes": 136
+    },
+    "southern-africa": {
+      "name": "Southern Africa",
+      "group": "africa",
+      "group_display": "Africa",
+      "realm": "afrotropic",
+      "tier": 50,
+      "bboxes": [
+        [
+          -35.0,
+          -17.0,
+          15.0,
+          33.0
+        ]
+      ],
+      "centroid": [
+        -26.0,
+        24.0
+      ],
+      "countries": {
+        "core": [
+          "BW",
+          "LS",
+          "NA",
+          "SZ",
+          "ZA",
+          "ZW"
+        ],
+        "partial": []
+      },
+      "classes": 802
+    },
+    "reunion": {
+      "name": "Reunion",
+      "group": "africa",
+      "group_display": "Africa",
+      "realm": "afrotropic",
+      "tier": 90,
+      "bboxes": [
+        [
+          -21.7,
+          -20.7,
+          55.0,
+          56.2
+        ]
+      ],
+      "centroid": [
+        -21.2,
+        55.6
+      ],
+      "countries": {
+        "core": [
+          "RE"
+        ],
+        "partial": []
+      },
+      "classes": 73
+    },
+    "mauritius": {
+      "name": "Mauritius",
+      "group": "africa",
+      "group_display": "Africa",
+      "realm": "afrotropic",
+      "tier": 90,
+      "bboxes": [
+        [
+          -20.6,
+          -19.9,
+          57.2,
+          57.9
+        ]
+      ],
+      "centroid": [
+        -20.25,
+        57.55
+      ],
+      "countries": {
+        "core": [
+          "MU"
+        ],
+        "partial": []
+      },
+      "classes": 72
+    },
+    "seychelles": {
+      "name": "Seychelles",
+      "group": "africa",
+      "group_display": "Africa",
+      "realm": "afrotropic",
+      "tier": 90,
+      "bboxes": [
+        [
+          -5.0,
+          -3.7,
+          55.2,
+          56.0
+        ]
+      ],
+      "centroid": [
+        -4.35,
+        55.6
+      ],
+      "countries": {
+        "core": [
+          "SC"
+        ],
+        "partial": []
+      },
+      "classes": 115
+    },
+    "cape-verde": {
+      "name": "Cape Verde",
+      "group": "africa",
+      "group_display": "Africa",
+      "realm": "afrotropic",
+      "tier": 90,
+      "bboxes": [
+        [
+          14.7,
+          17.3,
+          -25.5,
+          -22.6
+        ]
+      ],
+      "centroid": [
+        16.0,
+        -24.05
+      ],
+      "countries": {
+        "core": [
+          "CV"
+        ],
+        "partial": []
+      },
+      "classes": 143
+    },
+    "sao-tome-principe": {
+      "name": "Sao Tome & Principe",
+      "group": "africa",
+      "group_display": "Africa",
+      "realm": "afrotropic",
+      "tier": 90,
+      "bboxes": [
+        [
+          -0.7,
+          2.0,
+          6.2,
+          7.7
+        ]
+      ],
+      "centroid": [
+        0.65,
+        6.95
+      ],
+      "countries": {
+        "core": [
+          "ST"
+        ],
+        "partial": []
+      },
+      "classes": 110
+    },
+    "australia-east": {
+      "name": "Australia (Southeast)",
+      "group": "oceania",
+      "group_display": "Oceania",
+      "realm": "australasian",
+      "tier": 50,
+      "bboxes": [
+        [
+          -44.0,
+          -24.0,
+          138.0,
+          154.0
+        ]
+      ],
+      "centroid": [
+        -34.0,
+        146.0
+      ],
+      "countries": {
+        "core": [
+          "AU"
+        ],
+        "partial": []
+      },
+      "classes": 708
+    },
+    "new-zealand": {
+      "name": "New Zealand",
+      "group": "oceania",
+      "group_display": "Oceania",
+      "realm": "australasian",
+      "tier": 50,
+      "bboxes": [
+        [
+          -48.0,
+          -34.0,
+          166.0,
+          179.0
+        ]
+      ],
+      "centroid": [
+        -41.0,
+        172.5
+      ],
+      "countries": {
+        "core": [
+          "NZ"
+        ],
+        "partial": []
+      },
+      "classes": 266
+    },
+    "hawaii": {
+      "name": "Hawaii",
+      "group": "oceania",
+      "group_display": "Oceania",
+      "realm": "oceanian",
+      "tier": 90,
+      "bboxes": [
+        [
+          18.0,
+          23.0,
+          -161.0,
+          -154.0
+        ]
+      ],
+      "centroid": [
+        20.5,
+        -157.5
+      ],
+      "countries": {
+        "core": [
+          "US"
+        ],
+        "partial": []
+      },
+      "classes": 272
+    },
+    "new-caledonia": {
+      "name": "New Caledonia",
+      "group": "oceania",
+      "group_display": "Oceania",
+      "realm": "australasian",
+      "tier": 90,
+      "bboxes": [
+        [
+          -22.8,
+          -19.5,
+          163.5,
+          168.2
+        ]
+      ],
+      "centroid": [
+        -21.15,
+        165.85
+      ],
+      "countries": {
+        "core": [
+          "NC"
+        ],
+        "partial": []
+      },
+      "classes": 168
+    }
+  }
+}

--- a/internal/classifier/region/data/Perch-v2-Models.regions.json
+++ b/internal/classifier/region/data/Perch-v2-Models.regions.json
@@ -1,0 +1,1260 @@
+{
+  "schema": 1,
+  "repo": "tphakala/Perch-v2-Models",
+  "updated": "2026-08-14",
+  "regions": {
+    "nordic": {
+      "name": "Nordic",
+      "group": "europe",
+      "group_display": "Europe",
+      "realm": "palearctic",
+      "tier": 50,
+      "bboxes": [
+        [
+          53.1,
+          72.66,
+          3.32,
+          32.05
+        ]
+      ],
+      "centroid": [
+        62.88,
+        17.685
+      ],
+      "countries": {
+        "core": [
+          "AX",
+          "DK",
+          "FI",
+          "NO",
+          "SE"
+        ],
+        "partial": []
+      },
+      "classes": 638
+    },
+    "british-isles": {
+      "name": "British Isles",
+      "group": "europe",
+      "group_display": "Europe",
+      "realm": "palearctic",
+      "tier": 50,
+      "bboxes": [
+        [
+          49.5,
+          61.0,
+          -11.0,
+          2.5
+        ]
+      ],
+      "centroid": [
+        55.25,
+        -4.25
+      ],
+      "countries": {
+        "core": [
+          "GB",
+          "IE",
+          "IM"
+        ],
+        "partial": [
+          "GG"
+        ]
+      },
+      "classes": 776
+    },
+    "central-europe": {
+      "name": "Central Europe",
+      "group": "europe",
+      "group_display": "Europe",
+      "realm": "palearctic",
+      "tier": 50,
+      "bboxes": [
+        [
+          45.0,
+          55.5,
+          2.0,
+          24.0
+        ]
+      ],
+      "centroid": [
+        50.25,
+        13.0
+      ],
+      "countries": {
+        "core": [
+          "AT",
+          "BE",
+          "CH",
+          "CZ",
+          "DE",
+          "FR",
+          "HR",
+          "HU",
+          "LI",
+          "LU",
+          "NL",
+          "PL",
+          "SI",
+          "SK"
+        ],
+        "partial": [
+          "BA",
+          "DK",
+          "IT",
+          "LT",
+          "RO",
+          "RS"
+        ]
+      },
+      "classes": 873
+    },
+    "baltics": {
+      "name": "Baltics",
+      "group": "europe",
+      "group_display": "Europe",
+      "realm": "palearctic",
+      "tier": 50,
+      "bboxes": [
+        [
+          53.5,
+          59.8,
+          20.0,
+          30.0
+        ]
+      ],
+      "centroid": [
+        56.65,
+        25.0
+      ],
+      "countries": {
+        "core": [
+          "BY",
+          "EE",
+          "LT",
+          "LV",
+          "RU"
+        ],
+        "partial": []
+      },
+      "classes": 655
+    },
+    "iberia": {
+      "name": "Iberia",
+      "group": "europe",
+      "group_display": "Europe",
+      "realm": "palearctic",
+      "tier": 50,
+      "bboxes": [
+        [
+          35.5,
+          44.5,
+          -10.0,
+          3.5
+        ]
+      ],
+      "centroid": [
+        40.0,
+        -3.25
+      ],
+      "countries": {
+        "core": [
+          "AD",
+          "ES",
+          "PT"
+        ],
+        "partial": [
+          "FR"
+        ]
+      },
+      "classes": 856
+    },
+    "southern-europe": {
+      "name": "Southern Europe",
+      "group": "europe",
+      "group_display": "Europe",
+      "realm": "palearctic",
+      "tier": 50,
+      "bboxes": [
+        [
+          36.0,
+          47.0,
+          6.0,
+          29.0
+        ]
+      ],
+      "centroid": [
+        41.5,
+        17.5
+      ],
+      "countries": {
+        "core": [
+          "AL",
+          "BA",
+          "BG",
+          "GR",
+          "HR",
+          "IT",
+          "MC",
+          "ME",
+          "MK",
+          "MT",
+          "RO",
+          "RS",
+          "SI",
+          "SM",
+          "VA",
+          "XK"
+        ],
+        "partial": [
+          "CH",
+          "HU",
+          "TN",
+          "TR"
+        ]
+      },
+      "classes": 839
+    },
+    "eastern-europe": {
+      "name": "Eastern Europe",
+      "group": "europe",
+      "group_display": "Europe",
+      "realm": "palearctic",
+      "tier": 50,
+      "bboxes": [
+        [
+          44.0,
+          53.0,
+          22.0,
+          40.0
+        ]
+      ],
+      "centroid": [
+        48.5,
+        31.0
+      ],
+      "countries": {
+        "core": [
+          "MD",
+          "RO",
+          "RU",
+          "UA"
+        ],
+        "partial": [
+          "BY",
+          "PL"
+        ]
+      },
+      "classes": 739
+    },
+    "western-palearctic": {
+      "name": "Western Palearctic",
+      "group": "europe",
+      "group_display": "Europe",
+      "realm": "palearctic",
+      "tier": 10,
+      "bboxes": [
+        [
+          35.0,
+          71.0,
+          -11.0,
+          45.0
+        ],
+        [
+          26.0,
+          40.0,
+          -32.0,
+          -13.0
+        ],
+        [
+          20.0,
+          37.0,
+          -13.0,
+          37.0
+        ],
+        [
+          30.0,
+          42.0,
+          34.0,
+          50.0
+        ],
+        [
+          12.0,
+          32.0,
+          34.0,
+          60.0
+        ]
+      ],
+      "centroid": [
+        41.5,
+        14.0
+      ],
+      "countries": {
+        "core": [
+          "AD",
+          "AE",
+          "AL",
+          "AM",
+          "AT",
+          "AX",
+          "AZ",
+          "BA",
+          "BE",
+          "BG",
+          "BH",
+          "BY",
+          "CH",
+          "CY",
+          "CZ",
+          "DE",
+          "DK",
+          "DZ",
+          "EE",
+          "EG",
+          "EH",
+          "ER",
+          "ES",
+          "FI",
+          "FO",
+          "FR",
+          "GB",
+          "GE",
+          "GG",
+          "GR",
+          "HR",
+          "HU",
+          "IE",
+          "IL",
+          "IM",
+          "IQ",
+          "IR",
+          "IT",
+          "JE",
+          "JO",
+          "KW",
+          "LB",
+          "LI",
+          "LT",
+          "LU",
+          "LV",
+          "LY",
+          "MA",
+          "MC",
+          "MD",
+          "ME",
+          "MK",
+          "MR",
+          "MT",
+          "NE",
+          "NL",
+          "NO",
+          "OM",
+          "PL",
+          "PS",
+          "PT",
+          "QA",
+          "RO",
+          "RS",
+          "SA",
+          "SD",
+          "SE",
+          "SI",
+          "SK",
+          "SM",
+          "SY",
+          "TD",
+          "TN",
+          "TR",
+          "UA",
+          "VA",
+          "XK",
+          "YE"
+        ],
+        "partial": [
+          "DJ",
+          "ET",
+          "ML",
+          "RU",
+          "TM"
+        ]
+      },
+      "classes": 1599
+    },
+    "iceland": {
+      "name": "Iceland",
+      "group": "europe",
+      "group_display": "Europe",
+      "realm": "palearctic",
+      "tier": 90,
+      "bboxes": [
+        [
+          63.0,
+          67.0,
+          -25.0,
+          -13.0
+        ]
+      ],
+      "centroid": [
+        65.0,
+        -19.0
+      ],
+      "countries": {
+        "core": [
+          "IS"
+        ],
+        "partial": []
+      },
+      "classes": 591
+    },
+    "svalbard": {
+      "name": "Svalbard",
+      "group": "europe",
+      "group_display": "Europe",
+      "realm": "palearctic",
+      "tier": 90,
+      "bboxes": [
+        [
+          74.0,
+          81.0,
+          9.0,
+          34.0
+        ]
+      ],
+      "centroid": [
+        77.5,
+        21.5
+      ],
+      "countries": {
+        "core": [
+          "SJ"
+        ],
+        "partial": []
+      },
+      "classes": 480
+    },
+    "canary-islands": {
+      "name": "Canary Islands",
+      "group": "europe",
+      "group_display": "Europe",
+      "realm": "palearctic",
+      "tier": 90,
+      "bboxes": [
+        [
+          27.0,
+          29.8,
+          -18.5,
+          -13.0
+        ]
+      ],
+      "centroid": [
+        28.4,
+        -15.75
+      ],
+      "countries": {
+        "core": [
+          "ES",
+          "MA"
+        ],
+        "partial": []
+      },
+      "classes": 598
+    },
+    "madeira": {
+      "name": "Madeira",
+      "group": "europe",
+      "group_display": "Europe",
+      "realm": "palearctic",
+      "tier": 90,
+      "bboxes": [
+        [
+          32.3,
+          33.2,
+          -17.4,
+          -16.2
+        ]
+      ],
+      "centroid": [
+        32.75,
+        -16.8
+      ],
+      "countries": {
+        "core": [
+          "PT"
+        ],
+        "partial": []
+      },
+      "classes": 459
+    },
+    "azores": {
+      "name": "Azores",
+      "group": "europe",
+      "group_display": "Europe",
+      "realm": "palearctic",
+      "tier": 90,
+      "bboxes": [
+        [
+          36.5,
+          40.0,
+          -31.5,
+          -24.8
+        ]
+      ],
+      "centroid": [
+        38.25,
+        -28.15
+      ],
+      "countries": {
+        "core": [
+          "PT"
+        ],
+        "partial": []
+      },
+      "classes": 426
+    },
+    "south-asia-peninsular": {
+      "name": "South India & Sri Lanka",
+      "group": "asia",
+      "group_display": "Asia",
+      "realm": "indomalayan",
+      "tier": 50,
+      "bboxes": [
+        [
+          5.5,
+          21.0,
+          72.0,
+          88.0
+        ]
+      ],
+      "centroid": [
+        13.25,
+        80.0
+      ],
+      "countries": {
+        "core": [
+          "IN",
+          "LK"
+        ],
+        "partial": []
+      },
+      "classes": 879
+    },
+    "indo-gangetic": {
+      "name": "Indo-Gangetic Plain",
+      "group": "asia",
+      "group_display": "Asia",
+      "realm": "indomalayan",
+      "tier": 50,
+      "bboxes": [
+        [
+          21.0,
+          30.0,
+          68.0,
+          90.0
+        ]
+      ],
+      "centroid": [
+        25.5,
+        79.0
+      ],
+      "countries": {
+        "core": [
+          "BD",
+          "BT",
+          "IN",
+          "NP",
+          "PK"
+        ],
+        "partial": [
+          "CN"
+        ]
+      },
+      "classes": 1406
+    },
+    "himalaya": {
+      "name": "Himalaya",
+      "group": "asia",
+      "group_display": "Asia",
+      "realm": "indomalayan",
+      "tier": 50,
+      "bboxes": [
+        [
+          27.0,
+          36.0,
+          72.0,
+          97.0
+        ]
+      ],
+      "centroid": [
+        31.5,
+        84.5
+      ],
+      "countries": {
+        "core": [
+          "BT",
+          "CN",
+          "IN",
+          "NP"
+        ],
+        "partial": [
+          "PK"
+        ]
+      },
+      "classes": 1407
+    },
+    "japan": {
+      "name": "Japan",
+      "group": "asia",
+      "group_display": "Asia",
+      "realm": "palearctic",
+      "tier": 50,
+      "bboxes": [
+        [
+          30.0,
+          46.0,
+          128.0,
+          146.0
+        ]
+      ],
+      "centroid": [
+        38.0,
+        137.0
+      ],
+      "countries": {
+        "core": [
+          "JP",
+          "KR"
+        ],
+        "partial": [
+          "CN",
+          "KP",
+          "RU"
+        ]
+      },
+      "classes": 799
+    },
+    "china-northeast": {
+      "name": "China (Northeast)",
+      "group": "asia",
+      "group_display": "Asia",
+      "realm": "palearctic",
+      "tier": 50,
+      "bboxes": [
+        [
+          38.0,
+          54.0,
+          115.0,
+          135.0
+        ]
+      ],
+      "centroid": [
+        46.0,
+        125.0
+      ],
+      "countries": {
+        "core": [
+          "CN",
+          "KP",
+          "RU"
+        ],
+        "partial": [
+          "MN"
+        ]
+      },
+      "classes": 877
+    },
+    "china-north-central": {
+      "name": "China (North-Central)",
+      "group": "asia",
+      "group_display": "Asia",
+      "realm": "palearctic",
+      "tier": 50,
+      "bboxes": [
+        [
+          33.0,
+          42.0,
+          106.0,
+          122.0
+        ]
+      ],
+      "centroid": [
+        37.5,
+        114.0
+      ],
+      "countries": {
+        "core": [
+          "CN"
+        ],
+        "partial": []
+      },
+      "classes": 976
+    },
+    "china-southeast": {
+      "name": "China (Southeast)",
+      "group": "asia",
+      "group_display": "Asia",
+      "realm": "indomalayan",
+      "tier": 50,
+      "bboxes": [
+        [
+          20.0,
+          31.0,
+          106.0,
+          122.0
+        ]
+      ],
+      "centroid": [
+        25.5,
+        114.0
+      ],
+      "countries": {
+        "core": [
+          "CN",
+          "HK",
+          "MO",
+          "TW"
+        ],
+        "partial": []
+      },
+      "classes": 1373
+    },
+    "china-southwest": {
+      "name": "China (Southwest)",
+      "group": "asia",
+      "group_display": "Asia",
+      "realm": "palearctic",
+      "tier": 50,
+      "bboxes": [
+        [
+          22.0,
+          34.0,
+          97.0,
+          108.0
+        ]
+      ],
+      "centroid": [
+        28.0,
+        102.5
+      ],
+      "countries": {
+        "core": [
+          "CN"
+        ],
+        "partial": [
+          "MM",
+          "VN"
+        ]
+      },
+      "classes": 1409
+    },
+    "tibet": {
+      "name": "Tibetan Plateau",
+      "group": "asia",
+      "group_display": "Asia",
+      "realm": "palearctic",
+      "tier": 50,
+      "bboxes": [
+        [
+          29.0,
+          37.0,
+          79.0,
+          99.0
+        ]
+      ],
+      "centroid": [
+        33.0,
+        89.0
+      ],
+      "countries": {
+        "core": [
+          "CN"
+        ],
+        "partial": [
+          "NP"
+        ]
+      },
+      "classes": 1407
+    },
+    "north-america-east": {
+      "name": "North America (East)",
+      "group": "north-america",
+      "group_display": "North America",
+      "realm": "nearctic",
+      "tier": 50,
+      "bboxes": [
+        [
+          25.0,
+          50.0,
+          -95.0,
+          -60.0
+        ]
+      ],
+      "centroid": [
+        37.5,
+        -77.5
+      ],
+      "countries": {
+        "core": [
+          "BM",
+          "CA",
+          "US"
+        ],
+        "partial": []
+      },
+      "classes": 999
+    },
+    "north-america-west": {
+      "name": "North America (West)",
+      "group": "north-america",
+      "group_display": "North America",
+      "realm": "nearctic",
+      "tier": 50,
+      "bboxes": [
+        [
+          31.0,
+          55.0,
+          -125.0,
+          -100.0
+        ]
+      ],
+      "centroid": [
+        43.0,
+        -112.5
+      ],
+      "countries": {
+        "core": [
+          "CA",
+          "US"
+        ],
+        "partial": []
+      },
+      "classes": 1002
+    },
+    "amazonia": {
+      "name": "Amazonia",
+      "group": "south-america",
+      "group_display": "South America",
+      "realm": "neotropic",
+      "tier": 50,
+      "bboxes": [
+        [
+          -13.0,
+          10.0,
+          -79.0,
+          -44.0
+        ]
+      ],
+      "centroid": [
+        -1.5,
+        -61.5
+      ],
+      "countries": {
+        "core": [
+          "BR",
+          "CO",
+          "EC",
+          "GY",
+          "PE",
+          "SR",
+          "TT",
+          "VE"
+        ],
+        "partial": [
+          "BO",
+          "PA"
+        ]
+      },
+      "classes": 3388
+    },
+    "andes": {
+      "name": "Andes",
+      "group": "south-america",
+      "group_display": "South America",
+      "realm": "neotropic",
+      "tier": 50,
+      "bboxes": [
+        [
+          -40.0,
+          12.0,
+          -81.0,
+          -62.0
+        ]
+      ],
+      "centroid": [
+        -14.0,
+        -71.5
+      ],
+      "countries": {
+        "core": [
+          "AR",
+          "AW",
+          "BO",
+          "BR",
+          "CL",
+          "CO",
+          "CW",
+          "EC",
+          "GD",
+          "PA",
+          "PE",
+          "VE"
+        ],
+        "partial": []
+      },
+      "classes": 3535
+    },
+    "eastern-brazil": {
+      "name": "Eastern Brazil",
+      "group": "south-america",
+      "group_display": "South America",
+      "realm": "neotropic",
+      "tier": 50,
+      "bboxes": [
+        [
+          -33.0,
+          -2.0,
+          -60.0,
+          -34.0
+        ]
+      ],
+      "centroid": [
+        -17.5,
+        -47.0
+      ],
+      "countries": {
+        "core": [
+          "BR",
+          "PY",
+          "UY"
+        ],
+        "partial": [
+          "AR"
+        ]
+      },
+      "classes": 2184
+    },
+    "southern-cone": {
+      "name": "Southern Cone",
+      "group": "south-america",
+      "group_display": "South America",
+      "realm": "neotropic",
+      "tier": 50,
+      "bboxes": [
+        [
+          -56.0,
+          -20.0,
+          -77.0,
+          -53.0
+        ]
+      ],
+      "centroid": [
+        -38.0,
+        -65.0
+      ],
+      "countries": {
+        "core": [
+          "AR",
+          "CL",
+          "FK",
+          "PY",
+          "UY"
+        ],
+        "partial": [
+          "BO",
+          "BR"
+        ]
+      },
+      "classes": 1855
+    },
+    "galapagos": {
+      "name": "Galapagos",
+      "group": "south-america",
+      "group_display": "South America",
+      "realm": "neotropic",
+      "tier": 90,
+      "bboxes": [
+        [
+          -1.6,
+          1.8,
+          -92.0,
+          -89.0
+        ]
+      ],
+      "centroid": [
+        0.1,
+        -90.5
+      ],
+      "countries": {
+        "core": [
+          "EC"
+        ],
+        "partial": []
+      },
+      "classes": 336
+    },
+    "southern-africa": {
+      "name": "Southern Africa",
+      "group": "africa",
+      "group_display": "Africa",
+      "realm": "afrotropic",
+      "tier": 50,
+      "bboxes": [
+        [
+          -35.0,
+          -17.0,
+          15.0,
+          33.0
+        ]
+      ],
+      "centroid": [
+        -26.0,
+        24.0
+      ],
+      "countries": {
+        "core": [
+          "BW",
+          "LS",
+          "NA",
+          "SZ",
+          "ZA",
+          "ZW"
+        ],
+        "partial": []
+      },
+      "classes": 1002
+    },
+    "reunion": {
+      "name": "Reunion",
+      "group": "africa",
+      "group_display": "Africa",
+      "realm": "afrotropic",
+      "tier": 90,
+      "bboxes": [
+        [
+          -21.7,
+          -20.7,
+          55.0,
+          56.2
+        ]
+      ],
+      "centroid": [
+        -21.2,
+        55.6
+      ],
+      "countries": {
+        "core": [
+          "RE"
+        ],
+        "partial": []
+      },
+      "classes": 274
+    },
+    "mauritius": {
+      "name": "Mauritius",
+      "group": "africa",
+      "group_display": "Africa",
+      "realm": "afrotropic",
+      "tier": 90,
+      "bboxes": [
+        [
+          -20.6,
+          -19.9,
+          57.2,
+          57.9
+        ]
+      ],
+      "centroid": [
+        -20.25,
+        57.55
+      ],
+      "countries": {
+        "core": [
+          "MU"
+        ],
+        "partial": []
+      },
+      "classes": 272
+    },
+    "seychelles": {
+      "name": "Seychelles",
+      "group": "africa",
+      "group_display": "Africa",
+      "realm": "afrotropic",
+      "tier": 90,
+      "bboxes": [
+        [
+          -5.0,
+          -3.7,
+          55.2,
+          56.0
+        ]
+      ],
+      "centroid": [
+        -4.35,
+        55.6
+      ],
+      "countries": {
+        "core": [
+          "SC"
+        ],
+        "partial": []
+      },
+      "classes": 318
+    },
+    "cape-verde": {
+      "name": "Cape Verde",
+      "group": "africa",
+      "group_display": "Africa",
+      "realm": "afrotropic",
+      "tier": 90,
+      "bboxes": [
+        [
+          14.7,
+          17.3,
+          -25.5,
+          -22.6
+        ]
+      ],
+      "centroid": [
+        16.0,
+        -24.05
+      ],
+      "countries": {
+        "core": [
+          "CV"
+        ],
+        "partial": []
+      },
+      "classes": 346
+    },
+    "sao-tome-principe": {
+      "name": "Sao Tome & Principe",
+      "group": "africa",
+      "group_display": "Africa",
+      "realm": "afrotropic",
+      "tier": 90,
+      "bboxes": [
+        [
+          -0.7,
+          2.0,
+          6.2,
+          7.7
+        ]
+      ],
+      "centroid": [
+        0.65,
+        6.95
+      ],
+      "countries": {
+        "core": [
+          "ST"
+        ],
+        "partial": []
+      },
+      "classes": 324
+    },
+    "australia-east": {
+      "name": "Australia (Southeast)",
+      "group": "oceania",
+      "group_display": "Oceania",
+      "realm": "australasian",
+      "tier": 50,
+      "bboxes": [
+        [
+          -44.0,
+          -24.0,
+          138.0,
+          154.0
+        ]
+      ],
+      "centroid": [
+        -34.0,
+        146.0
+      ],
+      "countries": {
+        "core": [
+          "AU"
+        ],
+        "partial": []
+      },
+      "classes": 946
+    },
+    "new-zealand": {
+      "name": "New Zealand",
+      "group": "oceania",
+      "group_display": "Oceania",
+      "realm": "australasian",
+      "tier": 50,
+      "bboxes": [
+        [
+          -48.0,
+          -34.0,
+          166.0,
+          179.0
+        ]
+      ],
+      "centroid": [
+        -41.0,
+        172.5
+      ],
+      "countries": {
+        "core": [
+          "NZ"
+        ],
+        "partial": []
+      },
+      "classes": 486
+    },
+    "hawaii": {
+      "name": "Hawaii",
+      "group": "oceania",
+      "group_display": "Oceania",
+      "realm": "oceanian",
+      "tier": 90,
+      "bboxes": [
+        [
+          18.0,
+          23.0,
+          -161.0,
+          -154.0
+        ]
+      ],
+      "centroid": [
+        20.5,
+        -157.5
+      ],
+      "countries": {
+        "core": [
+          "US"
+        ],
+        "partial": []
+      },
+      "classes": 478
+    },
+    "new-caledonia": {
+      "name": "New Caledonia",
+      "group": "oceania",
+      "group_display": "Oceania",
+      "realm": "australasian",
+      "tier": 90,
+      "bboxes": [
+        [
+          -22.8,
+          -19.5,
+          163.5,
+          168.2
+        ]
+      ],
+      "centroid": [
+        -21.15,
+        165.85
+      ],
+      "countries": {
+        "core": [
+          "NC"
+        ],
+        "partial": []
+      },
+      "classes": 377
+    }
+  }
+}

--- a/internal/classifier/region/data/README.md
+++ b/internal/classifier/region/data/README.md
@@ -19,7 +19,7 @@ per-tile `classes` count differs between families.
 
 Refresh from a sibling `acoustic-models` checkout with:
 
-```
+```sh
 task sync-region-snapshots
 ```
 

--- a/internal/classifier/region/data/README.md
+++ b/internal/classifier/region/data/README.md
@@ -1,0 +1,29 @@
+# Embedded region snapshots
+
+These `*.regions.json` files are a build-time snapshot of the region geometry
+each model family publishes on HuggingFace. They let the region resolver turn a
+user's coordinates into a regional tile fully offline, and are the permanent
+offline fallback the design requires. A later phase adds a remote fetch that
+overrides this snapshot at runtime.
+
+## Provenance
+
+Do not hand-edit these files. They are generated upstream in the
+`acoustic-models` repository by `scripts/perch-slice/make_regions_json.py`
+(schema documented there), from the authoritative geometry in
+`scripts/perch-slice/regions.py`. Every family is generated from the same
+geometry, so their tile sets and tiers stay in step by construction; only the
+per-tile `classes` count differs between families.
+
+## Refreshing
+
+Refresh from a sibling `acoustic-models` checkout with:
+
+```
+task sync-region-snapshots
+```
+
+When a refresh genuinely changes the geometry (a tier reband, a new or removed
+tile), update the golden tier table in `golden_tier_test.go` in the same commit
+and say why in the commit message. That test is what turns an accidental change
+into a CI failure rather than a silent regression.

--- a/internal/classifier/region/embed.go
+++ b/internal/classifier/region/embed.go
@@ -1,0 +1,102 @@
+package region
+
+import (
+	"embed"
+	"encoding/json"
+	"io/fs"
+	"sync"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+)
+
+// snapshotFS holds the build-time region snapshots, one regions.json per model
+// family. Refresh them from the acoustic-models checkout with the Taskfile
+// `sync-region-snapshots` task; see data/README.md. Adding a family is a
+// drop-in: the loader keys tables by each file's own repo field, so no code
+// change is needed.
+//
+//go:embed data/*.regions.json
+var snapshotFS embed.FS
+
+// snapshotDir is the directory inside snapshotFS holding the embedded snapshots.
+const snapshotDir = "data"
+
+// loadTables parses every embedded snapshot once. It is wrapped in
+// sync.OnceValues so the first caller pays the parse cost and later callers get
+// the cached result. A parse or validation failure of an embedded file is a
+// build defect (the package tests exercise this), so it surfaces as an error
+// rather than a panic; callers then fall back to the global model.
+var loadTables = sync.OnceValues(func() (map[string]*Table, error) {
+	entries, err := fs.ReadDir(snapshotFS, snapshotDir)
+	if err != nil {
+		return nil, errors.New(err).
+			Component("classifier.region").
+			Category(errors.CategoryValidation).
+			Context("operation", "read_snapshot_dir").
+			Build()
+	}
+	tables := make(map[string]*Table, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := snapshotDir + "/" + e.Name()
+		data, rerr := snapshotFS.ReadFile(name)
+		if rerr != nil {
+			return nil, errors.New(rerr).
+				Component("classifier.region").
+				Category(errors.CategoryValidation).
+				Context("operation", "read_snapshot").
+				Context("file", name).
+				Build()
+		}
+		var t Table
+		if uerr := json.Unmarshal(data, &t); uerr != nil {
+			return nil, errors.New(uerr).
+				Component("classifier.region").
+				Category(errors.CategoryValidation).
+				Context("operation", "parse_snapshot").
+				Context("file", name).
+				Build()
+		}
+		if verr := t.validate(); verr != nil {
+			return nil, verr
+		}
+		if _, dup := tables[t.Repo]; dup {
+			return nil, errors.Newf("duplicate region snapshot for repo %q", t.Repo).
+				Component("classifier.region").
+				Category(errors.CategoryValidation).
+				Context("operation", "load_snapshots").
+				Build()
+		}
+		tables[t.Repo] = &t
+	}
+	if len(tables) == 0 {
+		return nil, errors.Newf("no region snapshots embedded").
+			Component("classifier.region").
+			Category(errors.CategoryValidation).
+			Context("operation", "load_snapshots").
+			Build()
+	}
+	return tables, nil
+})
+
+// Tables returns every embedded region table keyed by its HuggingFace repo id.
+// The returned map is shared and must not be mutated.
+func Tables() (map[string]*Table, error) {
+	return loadTables()
+}
+
+// TableForRepo returns the region table for a HuggingFace repo id. ok is false
+// when no snapshot describes that repo (a family with no region table), in which
+// case the caller falls back to the global model. An embedded-snapshot load
+// failure also reports ok=false, so a corrupt snapshot degrades to global rather
+// than propagating an error into the hot path.
+func TableForRepo(repo string) (t *Table, ok bool) {
+	tables, err := loadTables()
+	if err != nil {
+		return nil, false
+	}
+	t, ok = tables[repo]
+	return t, ok
+}

--- a/internal/classifier/region/golden_tier_test.go
+++ b/internal/classifier/region/golden_tier_test.go
@@ -1,0 +1,75 @@
+package region
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// goldenTiers is the authoritative slug-to-tier banding of all 39 tiles. It is a
+// literal snapshot of the shipped geometry: any reband, rename, addition, or
+// removal in a refreshed regions.json changes this comparison and fails CI, so a
+// tier change is never silent. When a refresh legitimately changes the geometry,
+// update this map in the same commit and say why.
+var goldenTiers = map[string]int{
+	"amazonia":              TierRegional,
+	"andes":                 TierRegional,
+	"australia-east":        TierRegional,
+	"azores":                TierLocal,
+	"baltics":               TierRegional,
+	"british-isles":         TierRegional,
+	"canary-islands":        TierLocal,
+	"cape-verde":            TierLocal,
+	"central-europe":        TierRegional,
+	"china-north-central":   TierRegional,
+	"china-northeast":       TierRegional,
+	"china-southeast":       TierRegional,
+	"china-southwest":       TierRegional,
+	"eastern-brazil":        TierRegional,
+	"eastern-europe":        TierRegional,
+	"galapagos":             TierLocal,
+	"hawaii":                TierLocal,
+	"himalaya":              TierRegional,
+	"iberia":                TierRegional,
+	"iceland":               TierLocal,
+	"indo-gangetic":         TierRegional,
+	"japan":                 TierRegional,
+	"madeira":               TierLocal,
+	"mauritius":             TierLocal,
+	"new-caledonia":         TierLocal,
+	"new-zealand":           TierRegional,
+	"nordic":                TierRegional,
+	"north-america-east":    TierRegional,
+	"north-america-west":    TierRegional,
+	"reunion":               TierLocal,
+	"sao-tome-principe":     TierLocal,
+	"seychelles":            TierLocal,
+	"south-asia-peninsular": TierRegional,
+	"southern-africa":       TierRegional,
+	"southern-cone":         TierRegional,
+	"southern-europe":       TierRegional,
+	"svalbard":              TierLocal,
+	"tibet":                 TierRegional,
+	"western-palearctic":    TierContinental,
+}
+
+// TestGoldenTierTable asserts every embedded family matches the golden banding
+// exactly, tile for tile. It runs against all families because D8 assumes their
+// geometry stays in step; a family that changes a tier or drops a tile fails here.
+func TestGoldenTierTable(t *testing.T) {
+	t.Parallel()
+	tables, err := Tables()
+	require.NoError(t, err)
+
+	for repo, tbl := range tables {
+		t.Run(repo, func(t *testing.T) {
+			t.Parallel()
+			got := make(map[string]int, len(tbl.Regions))
+			for slug, r := range tbl.Regions {
+				got[slug] = r.Tier
+			}
+			assert.Equal(t, goldenTiers, got, "tier banding for %s drifted from golden", repo)
+		})
+	}
+}

--- a/internal/classifier/region/region.go
+++ b/internal/classifier/region/region.go
@@ -1,0 +1,172 @@
+// Package region turns a user's latitude/longitude into the regional model tile
+// that best covers it, for the hardware- and region-aware model gallery.
+//
+// It is a pure leaf: it imports only the standard library, embed, and
+// internal/errors. It deliberately does NOT import internal/classifier or
+// internal/conf, so the catalog layer, the settings layer, and both API layers
+// can depend on it without any import cycle. The mode vocabulary (auto / global)
+// is owned here and aliased by internal/conf, keeping a single source of truth.
+//
+// The region geometry is generated upstream (acoustic-models) and published as a
+// regions.json per model family. A build-time snapshot of each family's table is
+// embedded (see embed.go and data/), so region resolution works fully offline;
+// a later phase overrides the snapshot with a fetched copy.
+package region
+
+import (
+	"encoding/json"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+)
+
+// snapshotSchema is the regions.json schema version this package understands. A
+// snapshot declaring any other value is rejected at load time.
+const snapshotSchema = 1
+
+// Tier bands classify a tile by geographic specificity. Higher wins: a point
+// inside both a continental and a regional tile resolves to the regional one.
+// The values are assigned upstream from bbox area and are read from the
+// snapshot, never recomputed here; they are named so the validator and tests
+// can reason about them without magic numbers.
+const (
+	// TierContinental covers a continent-scale tile (upstream: bbox area above
+	// 1500 deg^2).
+	TierContinental = 10
+	// TierRegional covers a regional tile (upstream: 150 to 1500 deg^2).
+	TierRegional = 50
+	// TierLocal covers a local tile (upstream: below 150 deg^2).
+	TierLocal = 90
+)
+
+// bboxFields is the number of elements in a bbox JSON array:
+// [lat_min, lat_max, lon_min, lon_max].
+const bboxFields = 4
+
+// Coordinate bounds used to sanity-check a snapshot at load time.
+const (
+	minLat = -90.0
+	maxLat = 90.0
+	minLon = -180.0
+	maxLon = 180.0
+)
+
+// Table is the parsed region snapshot for one model family (one HuggingFace
+// repo). Its Regions map is keyed by region slug (e.g. "iberia").
+type Table struct {
+	Schema  int               `json:"schema"`
+	Repo    string            `json:"repo"`    // HuggingFace repo id this table describes
+	Updated string            `json:"updated"` // upstream generation date (YYYY-MM-DD)
+	Regions map[string]Region `json:"regions"`
+}
+
+// Region is one tile of a family's region table.
+type Region struct {
+	Name         string    `json:"name"`          // display name (e.g. "Iberia")
+	Group        string    `json:"group"`         // continental bucket slug (e.g. "europe")
+	GroupDisplay string    `json:"group_display"` // continental bucket display name (e.g. "Europe")
+	Realm        string    `json:"realm"`         // biogeographic realm
+	Tier         int       `json:"tier"`          // specificity band; see the Tier constants
+	BBoxes       []BBox    `json:"bboxes"`        // disjoint axis-aligned boxes covering the tile
+	Centroid     []float64 `json:"centroid"`      // [lat, lon] of the tile centroid
+	Countries    Countries `json:"countries"`     // ISO 3166-1 alpha-2 country codes
+	Classes      int       `json:"classes"`       // species this tile's model can identify
+}
+
+// Countries lists the ISO 3166-1 alpha-2 codes a tile covers, split into fully
+// covered (core) and partially covered (partial) countries.
+type Countries struct {
+	Core    []string `json:"core"`
+	Partial []string `json:"partial"`
+}
+
+// BBox is a latitude/longitude-aligned box. In regions.json it is encoded as a
+// 4-element array [lat_min, lat_max, lon_min, lon_max]. Upstream guarantees no
+// box crosses the antimeridian (lon_min <= lon_max always), which the load-time
+// validator re-asserts and on which Contains relies.
+type BBox struct {
+	LatMin float64
+	LatMax float64
+	LonMin float64
+	LonMax float64
+}
+
+// UnmarshalJSON decodes the [lat_min, lat_max, lon_min, lon_max] array form.
+func (b *BBox) UnmarshalJSON(data []byte) error {
+	var raw []float64
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return errors.New(err).
+			Component("classifier.region").
+			Category(errors.CategoryValidation).
+			Context("operation", "unmarshal_bbox").
+			Build()
+	}
+	if len(raw) != bboxFields {
+		return errors.Newf("bbox must have %d elements, got %d", bboxFields, len(raw)).
+			Component("classifier.region").
+			Category(errors.CategoryValidation).
+			Context("operation", "unmarshal_bbox").
+			Build()
+	}
+	b.LatMin, b.LatMax, b.LonMin, b.LonMax = raw[0], raw[1], raw[2], raw[3]
+	return nil
+}
+
+// Contains reports whether (lat, lon) falls inside the box, inclusive on all
+// four edges. A point exactly on a border belongs to the box (and to both boxes
+// that share that border), which the resolver's tier and depth logic then
+// disambiguates.
+func (b BBox) Contains(lat, lon float64) bool {
+	return lat >= b.LatMin && lat <= b.LatMax && lon >= b.LonMin && lon <= b.LonMax
+}
+
+// validate checks a freshly parsed snapshot for the invariants the resolver
+// relies on. It is called at load time; a failure means the embedded snapshot is
+// malformed, which is a build defect surfaced by the package tests. The returned
+// error names the offending slug so a bad refresh is easy to locate.
+func (t *Table) validate() error {
+	fail := func(msg, slug string) error {
+		return errors.Newf("region snapshot %q: %s", t.Repo, msg).
+			Component("classifier.region").
+			Category(errors.CategoryValidation).
+			Context("operation", "validate_snapshot").
+			Context("slug", slug).
+			Build()
+	}
+	if t.Schema != snapshotSchema {
+		return fail("unsupported schema version", "")
+	}
+	if t.Repo == "" {
+		return fail("empty repo", "")
+	}
+	if len(t.Regions) == 0 {
+		return fail("no regions", "")
+	}
+	for slug := range t.Regions {
+		r := t.Regions[slug]
+		if len(r.BBoxes) == 0 {
+			return fail("region has no bboxes", slug)
+		}
+		switch r.Tier {
+		case TierContinental, TierRegional, TierLocal:
+		default:
+			return fail("region has an unknown tier", slug)
+		}
+		for _, b := range r.BBoxes {
+			if b.LatMin > b.LatMax {
+				return fail("bbox has lat_min > lat_max", slug)
+			}
+			// Re-assert the upstream antimeridian guarantee: a box that wrapped
+			// past 180 would report lon_min > lon_max and break Contains.
+			if b.LonMin > b.LonMax {
+				return fail("bbox has lon_min > lon_max (antimeridian crossing)", slug)
+			}
+			if b.LatMin < minLat || b.LatMax > maxLat || b.LonMin < minLon || b.LonMax > maxLon {
+				return fail("bbox coordinate out of range", slug)
+			}
+		}
+		if len(r.Centroid) != centroidLen {
+			return fail("centroid must have 2 elements", slug)
+		}
+	}
+	return nil
+}

--- a/internal/classifier/region/region_test.go
+++ b/internal/classifier/region/region_test.go
@@ -1,0 +1,117 @@
+package region
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// expectedTileCount is the number of regional tiles each family publishes.
+const expectedTileCount = 39
+
+// TestTablesLoad confirms both embedded snapshots parse, validate, and describe
+// the two expected families.
+func TestTablesLoad(t *testing.T) {
+	t.Parallel()
+	tables, err := Tables()
+	require.NoError(t, err, "embedded snapshots must load")
+	require.Len(t, tables, 2, "two families are embedded")
+
+	for _, repo := range []string{perchRepo, birdnetRepo} {
+		tbl, ok := tables[repo]
+		require.True(t, ok, "table for %s must be embedded", repo)
+		assert.Equal(t, snapshotSchema, tbl.Schema, "schema version")
+		assert.Equal(t, repo, tbl.Repo, "self-describing repo id")
+		assert.Len(t, tbl.Regions, expectedTileCount, "tile count for %s", repo)
+	}
+}
+
+// TestCrossFamilyGeometryIdentity documents the invariant the D8 shared setting
+// relies on today: both families publish identical geometry, tiers, and slug
+// sets, differing only in per-tile class counts. The resolver never assumes this
+// (it resolves per family), but a future divergence should be a conscious change
+// that trips this test.
+func TestCrossFamilyGeometryIdentity(t *testing.T) {
+	t.Parallel()
+	perch, ok := TableForRepo(perchRepo)
+	require.True(t, ok)
+	birdnet, ok := TableForRepo(birdnetRepo)
+	require.True(t, ok)
+
+	require.Len(t, birdnet.Regions, len(perch.Regions), "same tile count")
+	for slug, pr := range perch.Regions {
+		br, ok := birdnet.Regions[slug]
+		require.True(t, ok, "slug %s present in both families", slug)
+		assert.Equal(t, pr.Tier, br.Tier, "tier for %s", slug)
+		assert.Equal(t, pr.BBoxes, br.BBoxes, "bboxes for %s", slug)
+		assert.Equal(t, pr.Centroid, br.Centroid, "centroid for %s", slug)
+		// Display fields must match too: the gallery dropdown dedupes a shared
+		// slug by taking one family's Name/Group/GroupDisplay, so a divergence
+		// here would make the dropdown label depend on family order.
+		assert.Equal(t, pr.Name, br.Name, "name for %s", slug)
+		assert.Equal(t, pr.Group, br.Group, "group for %s", slug)
+		assert.Equal(t, pr.GroupDisplay, br.GroupDisplay, "group display for %s", slug)
+	}
+}
+
+// TestBBoxUnmarshalArity confirms the 4-element array decodes and any other
+// arity is rejected.
+func TestBBoxUnmarshalArity(t *testing.T) {
+	t.Parallel()
+	var b BBox
+	require.NoError(t, json.Unmarshal([]byte(`[10, 20, 30, 40]`), &b))
+	assert.Equal(t, BBox{LatMin: 10, LatMax: 20, LonMin: 30, LonMax: 40}, b)
+
+	for _, bad := range []string{`[10, 20, 30]`, `[10, 20, 30, 40, 50]`, `[]`} {
+		assert.Error(t, json.Unmarshal([]byte(bad), &b), "arity %s must error", bad)
+	}
+}
+
+// TestValidateRejectsBadSnapshot spot-checks the load-time validator on the
+// invariants the resolver depends on.
+func TestValidateRejectsBadSnapshot(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		tbl  Table
+	}{
+		{"bad schema", Table{Schema: 99, Repo: "r", Regions: map[string]Region{"a": okRegion()}}},
+		{"empty repo", Table{Schema: snapshotSchema, Repo: "", Regions: map[string]Region{"a": okRegion()}}},
+		{"no regions", Table{Schema: snapshotSchema, Repo: "r", Regions: map[string]Region{}}},
+		{"no bboxes", Table{Schema: snapshotSchema, Repo: "r", Regions: map[string]Region{
+			"a": {Tier: TierRegional, Centroid: []float64{0, 0}},
+		}}},
+		{"unknown tier", Table{Schema: snapshotSchema, Repo: "r", Regions: map[string]Region{
+			"a": {Tier: 42, BBoxes: []BBox{{}}, Centroid: []float64{0, 0}},
+		}}},
+		{"antimeridian crossing", Table{Schema: snapshotSchema, Repo: "r", Regions: map[string]Region{
+			"a": {Tier: TierRegional, BBoxes: []BBox{{LatMin: 0, LatMax: 1, LonMin: 170, LonMax: -170}}, Centroid: []float64{0, 0}},
+		}}},
+		{"lat inverted", Table{Schema: snapshotSchema, Repo: "r", Regions: map[string]Region{
+			"a": {Tier: TierRegional, BBoxes: []BBox{{LatMin: 10, LatMax: 0, LonMin: 0, LonMax: 1}}, Centroid: []float64{0, 0}},
+		}}},
+		{"bad centroid", Table{Schema: snapshotSchema, Repo: "r", Regions: map[string]Region{
+			"a": {Tier: TierRegional, BBoxes: []BBox{{}}, Centroid: []float64{0}},
+		}}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Error(t, tc.tbl.validate())
+		})
+	}
+
+	valid := Table{Schema: snapshotSchema, Repo: "r", Regions: map[string]Region{"a": okRegion()}}
+	assert.NoError(t, valid.validate(), "a well-formed snapshot validates")
+}
+
+// okRegion returns a minimal valid region for validator tests.
+func okRegion() Region {
+	return Region{
+		Tier:     TierRegional,
+		BBoxes:   []BBox{{LatMin: 0, LatMax: 1, LonMin: 0, LonMax: 1}},
+		Centroid: []float64{0.5, 0.5},
+	}
+}

--- a/internal/classifier/region/resolve.go
+++ b/internal/classifier/region/resolve.go
@@ -1,0 +1,206 @@
+package region
+
+import (
+	"cmp"
+	"math"
+	"slices"
+)
+
+// Mode values for the shared BirdNET.ModelRegion setting. internal/conf aliases
+// these so the setting layer and the resolver share one vocabulary. Any value
+// that is not a mode is treated as a pinned region slug.
+const (
+	// ModeAuto resolves the region from the configured coordinates, falling back
+	// to the global model when nothing resolves. The empty string is treated as
+	// ModeAuto for backward compatibility with configs written before this field
+	// existed.
+	ModeAuto = "auto"
+	// ModeGlobal always prefers the global model regardless of coordinates.
+	ModeGlobal = "global"
+)
+
+const (
+	// earthRadiusKm is the mean Earth radius used for great-circle distances.
+	earthRadiusKm = 6371.0
+	// ambiguityDepthRatio marks a resolution ambiguous when the same-tier
+	// runner-up penetrates at least this fraction as deeply as the winner (the
+	// "within 15 percent" border band). Being a ratio, the band scales with the
+	// overlap: a large overlap yields a wide band, a sliver a tight one.
+	ambiguityDepthRatio = 0.85
+	// centroidLen is the number of elements in a Centroid array [lat, lon].
+	centroidLen = 2
+)
+
+// Source records how a Selection was reached: the rung of the mode / D8 fallback
+// ladder that produced it.
+type Source string
+
+const (
+	// SourcePinned means the stored slug exists in this family's table and was
+	// used directly; coordinates were not consulted.
+	SourcePinned Source = "pinned"
+	// SourceAuto means the region was resolved from coordinates under ModeAuto.
+	SourceAuto Source = "auto"
+	// SourcePinnedFallback means a stored slug was absent from this family's
+	// table, so coordinates were used instead (the D8 per-family fallback).
+	SourcePinnedFallback Source = "pinned-fallback"
+	// SourceGlobal means the global model is used: ModeGlobal, no tile resolved,
+	// or the end of the fallback ladder.
+	SourceGlobal Source = "global"
+)
+
+// Match is one candidate tile that contains the resolved point, carrying the
+// tier used to rank it and the penetration depth used to break ties within a
+// tier.
+type Match struct {
+	Slug    string
+	Tier    int
+	DepthKm float64
+}
+
+// Selection is the outcome of applying a ModelRegion mode to one family's table.
+// A zero Slug means "use this family's global model". Ambiguous is set when a
+// same-tier runner-up falls inside the border band, in which case RunnerUp names
+// it and the UI surfaces both for the user to pin.
+type Selection struct {
+	Slug      string
+	Source    Source
+	Ambiguous bool
+	RunnerUp  string
+	Matches   []Match // full candidate list from coordinate resolution, best first
+}
+
+// radians converts degrees to radians.
+func radians(deg float64) float64 { return deg * math.Pi / 180 }
+
+// haversineKm returns the great-circle distance in kilometres between two
+// points given in degrees.
+func haversineKm(lat1, lon1, lat2, lon2 float64) float64 {
+	p1, p2 := radians(lat1), radians(lat2)
+	dp := radians(lat2 - lat1)
+	dl := radians(lon2 - lon1)
+	sinDp := math.Sin(dp / 2)
+	sinDl := math.Sin(dl / 2)
+	a := sinDp*sinDp + math.Cos(p1)*math.Cos(p2)*sinDl*sinDl
+	return 2 * earthRadiusKm * math.Asin(math.Min(1, math.Sqrt(a)))
+}
+
+// depthKm is the penetration depth of a contained point within one box: the
+// great-circle distance to the nearest of the four edges, measured to the
+// point's orthogonal projection onto each edge. Using haversine (rather than a
+// flat degree count) is what makes a longitude degree shrink toward the poles,
+// so a point near the top of a high-latitude tile like Svalbard is not treated
+// as if it sat on the equator. The caller guarantees the box contains the point.
+func (b BBox) depthKm(lat, lon float64) float64 {
+	south := haversineKm(lat, lon, b.LatMin, lon)
+	north := haversineKm(lat, lon, b.LatMax, lon)
+	west := haversineKm(lat, lon, lat, b.LonMin)
+	east := haversineKm(lat, lon, lat, b.LonMax)
+	return math.Min(math.Min(south, north), math.Min(west, east))
+}
+
+// Resolve returns the tiles whose bboxes contain (lat, lon), filtered to the
+// single highest tier present and sorted by penetration depth descending
+// (deepest first), with slug ascending as a deterministic tiebreaker over map
+// iteration order. It returns nil when no tile contains the point, which the
+// caller reads as "use the global model".
+//
+// Tier resolves nesting (a regional tile inside a continental one wins on tier);
+// depth resolves partial overlap between same-tier tiles (the point sitting
+// deeper inside one of two overlapping tiles wins).
+func (t *Table) Resolve(lat, lon float64) []Match {
+	if t == nil {
+		return nil
+	}
+	var candidates []Match
+	for slug := range t.Regions {
+		r := t.Regions[slug]
+		depth := math.Inf(-1)
+		for _, b := range r.BBoxes {
+			// Bboxes are disjoint, so a point is contained in at most one box of a
+			// tile; take the deepest containing box. Known limitation of the bbox
+			// model (not polygon geometry): a point exactly on the internal seam
+			// between two adjacent boxes of the same tile reads as depth 0 in each,
+			// so a different same-tier tile overlapping that seam could win the
+			// depth tiebreak. Tier resolves the common nesting case first, and an
+			// exact-seam coincidence is negligible in practice.
+			if b.Contains(lat, lon) {
+				if d := b.depthKm(lat, lon); d > depth {
+					depth = d
+				}
+			}
+		}
+		if math.IsInf(depth, -1) {
+			continue // no box of this tile contains the point
+		}
+		candidates = append(candidates, Match{Slug: slug, Tier: r.Tier, DepthKm: depth})
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+	bestTier := candidates[0].Tier
+	for _, c := range candidates[1:] {
+		if c.Tier > bestTier {
+			bestTier = c.Tier
+		}
+	}
+	candidates = slices.DeleteFunc(candidates, func(m Match) bool { return m.Tier != bestTier })
+	slices.SortFunc(candidates, func(a, b Match) int {
+		if c := cmp.Compare(b.DepthKm, a.DepthKm); c != 0 { // depth descending
+			return c
+		}
+		return cmp.Compare(a.Slug, b.Slug) // slug ascending, deterministic
+	})
+	return candidates
+}
+
+// Ambiguous reports whether the top two matches (already filtered to one tier by
+// Resolve) fall within the border band, i.e. the runner-up penetrates at least
+// ambiguityDepthRatio as deeply as the winner. It compares only rank 1 and rank
+// 2: a three-way border overlap is rare enough that surfacing the top two is the
+// right UX, and the winner is unchanged regardless.
+func Ambiguous(matches []Match) bool {
+	return len(matches) >= 2 && matches[1].DepthKm >= ambiguityDepthRatio*matches[0].DepthKm
+}
+
+// Select applies a ModelRegion mode to one family's table and returns the
+// resulting Selection. It implements the three modes and the D8 per-family
+// fallback ladder:
+//
+//   - ModeGlobal (or "global"): always the global model.
+//   - ModeAuto (or ""): resolve from coordinates; global when nothing resolves.
+//   - a pinned slug: use it if this family has that slug; otherwise fall back to
+//     coordinate resolution in this family's table; otherwise the global model.
+//
+// Passing a nil table degrades to the global model, matching TableForRepo's
+// not-ok contract.
+func Select(t *Table, modelRegion string, lat, lon float64) Selection {
+	switch modelRegion {
+	case ModeGlobal:
+		return Selection{Source: SourceGlobal}
+	case ModeAuto, "":
+		return selectionFromMatches(t.Resolve(lat, lon), SourceAuto)
+	default: // pinned slug
+		if t != nil {
+			if _, ok := t.Regions[modelRegion]; ok {
+				return Selection{Slug: modelRegion, Source: SourcePinned}
+			}
+		}
+		return selectionFromMatches(t.Resolve(lat, lon), SourcePinnedFallback)
+	}
+}
+
+// selectionFromMatches turns a coordinate-resolution result into a Selection,
+// attaching the ambiguity band and, when present, the runner-up. An empty
+// result becomes the global model regardless of the requested source.
+func selectionFromMatches(matches []Match, src Source) Selection {
+	if len(matches) == 0 {
+		return Selection{Source: SourceGlobal}
+	}
+	sel := Selection{Slug: matches[0].Slug, Source: src, Matches: matches}
+	if Ambiguous(matches) {
+		sel.Ambiguous = true
+		sel.RunnerUp = matches[1].Slug
+	}
+	return sel
+}

--- a/internal/classifier/region/resolve_test.go
+++ b/internal/classifier/region/resolve_test.go
@@ -1,0 +1,224 @@
+package region
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	perchRepo   = "tphakala/Perch-v2-Models"
+	birdnetRepo = "tphakala/BirdNET-v3.0-Models"
+)
+
+// perchTable loads the embedded Perch v2 region table, the shared geometry the
+// resolver tests exercise (all families carry identical geometry; see
+// TestCrossFamilyGeometryIdentity).
+func perchTable(t *testing.T) *Table {
+	t.Helper()
+	tbl, ok := TableForRepo(perchRepo)
+	require.True(t, ok, "perch region snapshot must be embedded")
+	return tbl
+}
+
+// TestResolve covers the geometry cases that pin the tier-then-depth algorithm,
+// including the two named regression cases from issue #1468.
+func TestResolve(t *testing.T) {
+	t.Parallel()
+	tbl := perchTable(t)
+
+	tests := []struct {
+		name      string
+		lat, lon  float64
+		wantTop   string // "" means no tile resolves (caller uses global)
+		wantTier  int
+		ambiguous bool
+		runnerUp  string
+	}{
+		{
+			// Bogota sits in both andes and amazonia (both tier 50). Centroid
+			// distance and bbox area both wrongly pick amazonia; only penetration
+			// depth is right, and andes is the deeper containment.
+			name: "bogota resolves to andes on depth", lat: 4.7, lon: -74.1,
+			wantTop: "andes", wantTier: TierRegional,
+		},
+		{
+			// Madrid sits in both iberia (tier 50) and western-palearctic (tier
+			// 10, which geometrically contains iberia). Tier picks iberia; pure
+			// depth would wrongly pick western-palearctic.
+			name: "madrid resolves to iberia on tier", lat: 40, lon: -3.5,
+			wantTop: "iberia", wantTier: TierRegional,
+		},
+		{
+			// A second tier-decides case: Helsinki is in nordic (50) and
+			// western-palearctic (10).
+			name: "helsinki resolves to nordic on tier", lat: 60.17, lon: 24.94,
+			wantTop: "nordic", wantTier: TierRegional,
+		},
+		{
+			// A single high-latitude tile. The depth here is a haversine tell:
+			// an equirectangular approximation fails to shrink longitude at 78N.
+			name: "svalbard single tile high latitude", lat: 78.0, lon: 20.0,
+			wantTop: "svalbard", wantTier: TierLocal,
+		},
+		{
+			// Deeper into the andes/amazonia overlap the two depths fall within
+			// the border band, so the resolution is ambiguous.
+			name: "border overlap is ambiguous", lat: 2.0, lon: -71.0,
+			wantTop: "andes", wantTier: TierRegional, ambiguous: true, runnerUp: "amazonia",
+		},
+		{
+			name: "null island resolves to nothing", lat: 0, lon: 0,
+			wantTop: "",
+		},
+		{
+			// No tile covers the geographic pole, so it degrades to global. This
+			// also documents the cos(lat)=0 depth singularity is never reached in
+			// practice.
+			name: "north pole resolves to nothing", lat: 90, lon: 0,
+			wantTop: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			matches := tbl.Resolve(tc.lat, tc.lon)
+			if tc.wantTop == "" {
+				assert.Empty(t, matches, "expected no tile to resolve")
+				return
+			}
+			require.NotEmpty(t, matches, "expected a tile to resolve")
+			assert.Equal(t, tc.wantTop, matches[0].Slug, "top match slug")
+			assert.Equal(t, tc.wantTier, matches[0].Tier, "top match tier")
+			assert.Equal(t, tc.ambiguous, Ambiguous(matches), "ambiguity band")
+			if tc.runnerUp != "" {
+				require.GreaterOrEqual(t, len(matches), 2, "expected a runner-up")
+				assert.Equal(t, tc.runnerUp, matches[1].Slug, "runner-up slug")
+			}
+		})
+	}
+}
+
+// TestResolveDepths asserts the exact penetration depths behind the regression
+// cases, so an implementation drift (equirectangular distance, wrong edge)
+// changes a number and fails here even if the winning slug happens to survive.
+func TestResolveDepths(t *testing.T) {
+	t.Parallel()
+	tbl := perchTable(t)
+
+	const tolKm = 0.5
+	matches := tbl.Resolve(4.7, -74.1) // Bogota
+	require.Len(t, matches, 2)
+	assert.Equal(t, "andes", matches[0].Slug)
+	assert.InDelta(t, 764.66, matches[0].DepthKm, tolKm, "andes depth at Bogota")
+	assert.Equal(t, "amazonia", matches[1].Slug)
+	assert.InDelta(t, 543.02, matches[1].DepthKm, tolKm, "amazonia depth at Bogota")
+
+	// Svalbard: 253.93 km with haversine; an equirectangular approximation
+	// yields 333.5 km via the wrong edge and fails this assertion.
+	sv := tbl.Resolve(78.0, 20.0)
+	require.Len(t, sv, 1)
+	assert.InDelta(t, 253.93, sv[0].DepthKm, tolKm, "svalbard depth (haversine tell)")
+}
+
+// TestBBoxContainsEdgeIsInclusive confirms a point exactly on a border belongs
+// to the box, with depth 0.
+func TestBBoxContainsEdgeIsInclusive(t *testing.T) {
+	t.Parallel()
+	b := BBox{LatMin: 10, LatMax: 20, LonMin: 30, LonMax: 40}
+	assert.True(t, b.Contains(10, 35), "point on the south edge is inside")
+	assert.True(t, b.Contains(20, 40), "corner is inside")
+	assert.False(t, b.Contains(9.9, 35), "point below the south edge is outside")
+	assert.InDelta(t, 0.0, b.depthKm(10, 35), 1e-9, "depth on an edge is zero")
+}
+
+// TestSelectModes covers the three ModelRegion modes and the D8 per-family
+// fallback ladder against the real Perch table.
+func TestSelectModes(t *testing.T) {
+	t.Parallel()
+	tbl := perchTable(t)
+	const bogotaLat, bogotaLon = 4.7, -74.1
+
+	t.Run("auto and empty behave identically", func(t *testing.T) {
+		t.Parallel()
+		auto := Select(tbl, ModeAuto, bogotaLat, bogotaLon)
+		empty := Select(tbl, "", bogotaLat, bogotaLon)
+		assert.Equal(t, "andes", auto.Slug)
+		assert.Equal(t, SourceAuto, auto.Source)
+		assert.Equal(t, auto.Slug, empty.Slug)
+		assert.Equal(t, auto.Source, empty.Source)
+	})
+
+	t.Run("global short-circuits coordinates", func(t *testing.T) {
+		t.Parallel()
+		sel := Select(tbl, ModeGlobal, bogotaLat, bogotaLon)
+		assert.Empty(t, sel.Slug, "global uses the global model")
+		assert.Equal(t, SourceGlobal, sel.Source)
+	})
+
+	t.Run("pinned slug present ignores coordinates", func(t *testing.T) {
+		t.Parallel()
+		sel := Select(tbl, "iberia", bogotaLat, bogotaLon)
+		assert.Equal(t, "iberia", sel.Slug)
+		assert.Equal(t, SourcePinned, sel.Source)
+	})
+
+	t.Run("auto with no tile falls back to global", func(t *testing.T) {
+		t.Parallel()
+		sel := Select(tbl, ModeAuto, 0, 0)
+		assert.Empty(t, sel.Slug)
+		assert.Equal(t, SourceGlobal, sel.Source)
+	})
+}
+
+// TestSelectD8Fallback exercises the per-family fallback for a stored slug that
+// is absent from a family's table, using a synthetic table missing andes.
+func TestSelectD8Fallback(t *testing.T) {
+	t.Parallel()
+	tbl := perchTable(t)
+
+	// A divergent family: same geometry but without the andes tile.
+	divergent := &Table{Schema: snapshotSchema, Repo: "tphakala/Divergent", Regions: map[string]Region{}}
+	for slug := range tbl.Regions {
+		if slug == "andes" {
+			continue
+		}
+		divergent.Regions[slug] = tbl.Regions[slug]
+	}
+
+	t.Run("pinned absent falls back to coordinates in this table", func(t *testing.T) {
+		t.Parallel()
+		// Stored slug andes is absent here; Bogota coordinates still sit inside
+		// amazonia, so resolution finds it via the fallback.
+		sel := Select(divergent, "andes", 4.7, -74.1)
+		assert.Equal(t, "amazonia", sel.Slug)
+		assert.Equal(t, SourcePinnedFallback, sel.Source)
+	})
+
+	t.Run("pinned absent with no coverage falls back to global", func(t *testing.T) {
+		t.Parallel()
+		sel := Select(divergent, "andes", 0, 0)
+		assert.Empty(t, sel.Slug)
+		assert.Equal(t, SourceGlobal, sel.Source)
+	})
+
+	t.Run("divergence does not break a family that has the slug", func(t *testing.T) {
+		t.Parallel()
+		// The same stored slug resolves normally against the real family, proving
+		// per-family resolution is independent.
+		realFamily := Select(tbl, "andes", 4.7, -74.1)
+		assert.Equal(t, "andes", realFamily.Slug)
+		assert.Equal(t, SourcePinned, realFamily.Source)
+	})
+}
+
+// TestSelectNilTable confirms a missing family degrades to the global model
+// rather than panicking.
+func TestSelectNilTable(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, SourceGlobal, Select(nil, ModeAuto, 4.7, -74.1).Source)
+	assert.Equal(t, SourceGlobal, Select(nil, "iberia", 4.7, -74.1).Source)
+	assert.Equal(t, SourceGlobal, Select(nil, ModeGlobal, 4.7, -74.1).Source)
+}

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"iter"
+	"regexp"
 	"strings"
 	"time"
 
@@ -1300,6 +1301,7 @@ type BirdNETConfig struct {
 	Backend             string              `yaml:"backend,omitempty" json:"backend,omitempty"`                         // inference backend preference: "auto" (default), "onnx", or "openvino"
 	OpenVINODevice      string              `yaml:"openvinodevice,omitempty" json:"openVinoDevice,omitempty"`           // OpenVINO device preference: "auto" (default), "cpu", or "gpu"
 	HuggingFaceEndpoint string              `yaml:"huggingfaceendpoint,omitempty" json:"huggingFaceEndpoint,omitempty"` // model download host, e.g. "https://hf-mirror.com" where huggingface.co is blocked; empty falls back to $HF_ENDPOINT then https://huggingface.co
+	ModelRegion         string              `yaml:"modelregion,omitempty" json:"modelRegion,omitempty"`                 // regional model preference: "auto" (resolve from coordinates, default), "global" (always global models), or a region slug pin (e.g. "iberia"); empty is treated as "auto"
 }
 
 // Inference backend preferences for BirdNET.Backend.
@@ -1317,6 +1319,25 @@ const (
 	OVDeviceCPU  = "cpu"
 	OVDeviceGPU  = "gpu"
 )
+
+// Model region preferences for BirdNET.ModelRegion. "auto" resolves the regional
+// model from the configured coordinates and falls back to the global model when
+// nothing resolves; "global" always prefers the global model; any other value is
+// a pinned region slug. An empty string is treated as "auto". These mirror the
+// resolver's mode vocabulary in internal/classifier/region (ModeAuto/ModeGlobal),
+// kept as independent literals so this foundational config package stays free of a
+// classifier dependency; a drift-guard test asserts they stay equal.
+const (
+	ModelRegionAuto   = "auto"
+	ModelRegionGlobal = "global"
+)
+
+// ModelRegionSlugPattern validates a pinned region slug: lowercase alphanumeric
+// segments joined by single hyphens (e.g. "iberia", "north-america-east"). It is
+// syntactic only; an unknown but well-formed slug is accepted, because the
+// per-family resolver degrades an unknown slug to coordinates then global, and a
+// slug may be valid for a model family added later.
+var ModelRegionSlugPattern = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
 
 // RangeFilterSettings contains settings for the range filter
 type RangeFilterSettings struct {

--- a/internal/conf/config.yaml
+++ b/internal/conf/config.yaml
@@ -161,6 +161,7 @@ birdnet:
       threshold: 0.01     # rangefilter species occurrence threshold
   modelpath: ""           # path to external model file (empty for embedded)
   labelpath: ""           # path to external label file (empty for embedded)
+  modelregion: auto       # regional model preference: auto (from coordinates), global (all species), or a region slug (e.g. iberia)
   usexnnpack: true        # true to use XNNPACK delegate for inference acceleration
 
 # Optional taxonomy synonym overrides for image lookups.

--- a/internal/conf/config_openvino_test.go
+++ b/internal/conf/config_openvino_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBirdNETBackendPreferenceField(t *testing.T) {
@@ -46,4 +47,45 @@ func TestValidateOpenVINODevice(t *testing.T) {
 	res := ValidateBirdNETSettings(cfg)
 	assert.True(t, hasDeviceWarning(res), "an unknown openvinodevice must warn")
 	assert.True(t, res.Valid, "an unknown openvinodevice must not invalidate the config")
+}
+
+// TestValidateModelRegion verifies that the modes, empty, and well-formed slugs
+// (including ones unknown to the embedded tables) are accepted, while a malformed
+// value warns and normalizes to auto without invalidating the config.
+func TestValidateModelRegion(t *testing.T) {
+	t.Parallel()
+	hasRegionWarning := func(r ValidationResult) bool {
+		for _, w := range r.Warnings {
+			if strings.Contains(w, "modelregion") {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Empty, both modes, and well-formed slugs (a known one and a not-yet-known
+	// one) are all accepted syntactically without a warning.
+	normalizedRegion := func(t *testing.T, res ValidationResult) string {
+		t.Helper()
+		require.NotNil(t, res.Normalized)
+		norm, ok := res.Normalized.(*BirdNETConfig)
+		require.True(t, ok, "Normalized must be a *BirdNETConfig")
+		return norm.ModelRegion
+	}
+
+	for _, region := range []string{"", ModelRegionAuto, ModelRegionGlobal, "iberia", "north-america-east", "future-family-slug"} {
+		cfg := &BirdNETConfig{ModelRegion: region}
+		res := ValidateBirdNETSettings(cfg)
+		assert.Falsef(t, hasRegionWarning(res), "region %q must be accepted without a warning", region)
+		assert.Equalf(t, region, normalizedRegion(t, res), "region %q must be left unchanged", region)
+	}
+
+	// A malformed value warns, stays valid, and normalizes to auto.
+	for _, bad := range []string{"Iberia!", "north america", "UPPER", "-leading", "trailing-"} {
+		cfg := &BirdNETConfig{ModelRegion: bad}
+		res := ValidateBirdNETSettings(cfg)
+		assert.Truef(t, hasRegionWarning(res), "malformed region %q must warn", bad)
+		assert.Truef(t, res.Valid, "malformed region %q must not invalidate the config", bad)
+		assert.Equalf(t, ModelRegionAuto, normalizedRegion(t, res), "malformed region %q must normalize to auto", bad)
+	}
 }

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -82,6 +82,7 @@ func setDefaultConfig() {
 	viper.SetDefault("birdnet.longitude", 0.000)
 	viper.SetDefault("birdnet.modelpath", "")
 	viper.SetDefault("birdnet.labelpath", "")
+	viper.SetDefault("birdnet.modelregion", ModelRegionAuto)
 	viper.SetDefault("birdnet.usexnnpack", true)
 	viper.SetDefault("taxonomysynonyms", map[string]string{})
 

--- a/internal/conf/validate_services.go
+++ b/internal/conf/validate_services.go
@@ -74,6 +74,18 @@ func ValidateBirdNETSettings(cfg *BirdNETConfig) ValidationResult {
 			fmt.Sprintf("BirdNET openvinodevice '%s' is not recognised; must be 'auto', 'cpu', or 'gpu' - will use 'auto'", cfg.OpenVINODevice))
 	}
 
+	// ModelRegion must be "auto", "global", or a well-formed region slug when
+	// non-empty. Validation is syntactic only: a well-formed but unknown slug is
+	// accepted (the per-family resolver degrades it to coordinates then global,
+	// and it may be valid for a family added later). A malformed value normalizes
+	// to "auto" so an aged or hand-edited config never blocks startup.
+	if cfg.ModelRegion != "" && cfg.ModelRegion != ModelRegionAuto && cfg.ModelRegion != ModelRegionGlobal &&
+		!ModelRegionSlugPattern.MatchString(cfg.ModelRegion) {
+		result.Warnings = append(result.Warnings,
+			fmt.Sprintf("BirdNET modelregion '%s' is not a valid region; must be 'auto', 'global', or a region slug - will use 'auto'", cfg.ModelRegion))
+		normalized.ModelRegion = ModelRegionAuto
+	}
+
 	checkRange(&result, cfg.RangeFilter.Threshold, 0, 1, "RangeFilter threshold must be between 0 and 1")
 
 	// Locale validation and normalization (pure transformation)


### PR DESCRIPTION
## Summary

This adds the backend for region-specific model selection in the model gallery: a resolver that turns a station's coordinates into the regional model tile that best covers it, a hot-reloadable `BirdNET.ModelRegion` setting, and an auth-gated endpoint that backs the gallery region selector. It is the first of two PRs for this phase; the coordinate-change staleness notification and the Svelte selector UI follow in a second PR. This is recommend-only: nothing here auto-installs or hot-swaps a model.

## What is in it

New pure-leaf package `internal/classifier/region`. It resolves a coordinate tier-first, then by penetration depth: a regional tile wins over a continental one that geometrically contains it, and among same-tier tiles the one the point sits deepest inside wins. Distances are great-circle so a degree of longitude shrinks correctly toward the poles. A same-tier runner-up within 15 percent of the winner's depth is surfaced as ambiguous so the UI can offer both. The 39-tile geometry for each model family ships as a build-time snapshot embedded from the published `regions.json`, refreshable via `task sync-region-snapshots`, with a golden tier table that fails CI if a tile is silently rebanded.

`settings.BirdNET.ModelRegion` accepts `auto` (resolve from the configured coordinates), `global` (always the global model), or a pinned region slug. Resolution is per model family against that family's own table, so a stored slug absent from one family degrades to coordinates and then to that family's global model without breaking the others. The setting is hot-reloadable and validated (a malformed value warns and normalizes to `auto` at startup, and is rejected with 400 through the settings API).

New endpoint `GET /api/v2/models/regions` returns the selectable regions, what the coordinates resolve to under auto (so the UI can preview an unsaved choice), and the per-family resolution. It is auth-gated because the resolved fields derive from the user's approximate location, and it never echoes the raw coordinates back. Coordinate resolution is gated on whether a station location has actually been configured, so an unconfigured station stays on the global model.

## Test plan

- [x] `go test -race ./internal/classifier/region/ ./internal/conf/` and the full `./internal/api/v2/...` suite pass
- [x] Named regression cases: Bogota resolves to `andes` (depth beats the geometrically-larger `amazonia`), Madrid resolves to `iberia` (tier beats the containing `western-palearctic`)
- [x] Golden 39-tile tier table asserted against both model families; cross-family geometry identity asserted
- [x] `golangci-lint run` clean; generated config schema and route goldens regenerated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added regional model selection based on location, global coverage, or a specified region.
  * Added regional model catalogs for supported model families.
  * Added an authenticated API endpoint to view available regions and current model resolution.
  * Regional settings can be changed without restarting the application.

* **Documentation**
  * Documented the new configuration option and regional models API.
  * Added guidance for refreshing regional data.

* **Bug Fixes**
  * Added validation and safe fallback behavior for invalid or unavailable regional selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->