### PR TITLE
feat(models): region selector and coordinate-change staleness notification

### DIFF
--- a/frontend/src/lib/desktop/features/settings/components/ModelRegionSelector.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/ModelRegionSelector.svelte
@@ -1,0 +1,332 @@
+<script lang="ts">
+  /**
+   * Region selector for the model gallery. Lets the user choose how a regional
+   * model variant is picked: Automatic (from the station location), Global (the
+   * worldwide model), or a pinned region. It is recommend-only: it never installs
+   * or switches a model, it only records the preference that install/switch flows
+   * read later.
+   *
+   * The "why-line" explains the current resolution. It derives from the SELECTED
+   * mode, not from response.resolved.source: the endpoint always returns the
+   * automatic-mode preview in `resolved` regardless of the saved mode, so the
+   * pinned/global explanations must come from the mode the user chose.
+   */
+  import { onMount } from 'svelte';
+  import { Globe, MapPin } from '@lucide/svelte';
+
+  import { t } from '$lib/i18n';
+  import { fetchModelRegions } from '$lib/utils/modelsApi';
+  import { loggers } from '$lib/utils/logger';
+  import { birdnetSettings, settingsActions } from '$lib/stores/settings';
+  import type { ModelRegionsResponse, RegionOption } from '$lib/types/models';
+
+  const logger = loggers.ui;
+
+  interface Props {
+    /** Disable all controls while settings are loading or saving. */
+    disabled?: boolean;
+  }
+
+  let { disabled = false }: Props = $props();
+
+  let data = $state<ModelRegionsResponse | null>(null);
+  let loading = $state(true);
+  let error = $state(false);
+  // User-toggled disclosure of the region list. The list is also shown whenever a
+  // specific region is pinned, so the pinned tile is visible without a click.
+  let showRegions = $state(false);
+
+  async function load() {
+    loading = true;
+    error = false;
+    try {
+      data = await fetchModelRegions();
+    } catch (err) {
+      error = true;
+      logger.error('Failed to load model regions', err, { component: 'ModelRegionSelector' });
+    } finally {
+      loading = false;
+    }
+  }
+
+  onMount(load);
+
+  // '' and absent both mean automatic (mirrors the Go omitempty field).
+  function normalizeMode(value: string | undefined): string {
+    return value ? value : 'auto';
+  }
+
+  const selected = $derived(normalizeMode($birdnetSettings?.modelRegion));
+  const regions = $derived<RegionOption[]>(data?.regions ?? []);
+  const isPinnedSlug = $derived(selected !== 'auto' && selected !== 'global');
+  const regionsVisible = $derived(showRegions || isPinnedSlug);
+
+  function knownSlug(slug: string): boolean {
+    return regions.some(r => r.slug === slug);
+  }
+
+  function regionName(slug: string): string {
+    return regions.find(r => r.slug === slug)?.name ?? slug;
+  }
+
+  // Regions arrive pre-sorted by group display, then name, then slug, so grouping
+  // consecutive options preserves the server ordering.
+  const groupedRegions = $derived.by(() => {
+    const groups: { slug: string; display: string; options: RegionOption[] }[] = [];
+    let current: { slug: string; display: string; options: RegionOption[] } | null = null;
+    for (const opt of regions) {
+      // Break on the continental group slug (a stable unique key), not the
+      // display name. A slug maps to exactly one display, and the server sorts by
+      // display then name then slug, so same-slug options stay contiguous.
+      if (!current || current.slug !== opt.group) {
+        current = { slug: opt.group, display: opt.groupDisplay, options: [] };
+        groups.push(current);
+      }
+      current.options.push(opt);
+    }
+    return groups;
+  });
+
+  function select(value: string) {
+    settingsActions.updateSection('birdnet', { modelRegion: value });
+  }
+
+  // Full i18n keys as literals so the usage checker sees each one.
+  const WHY_KEY = {
+    noLocation: 'analysis.gallery.region.why.noLocation',
+    outsideCoverage: 'analysis.gallery.region.why.outsideCoverage',
+    ambiguous: 'analysis.gallery.region.why.ambiguous',
+    resolved: 'analysis.gallery.region.why.resolved',
+    global: 'analysis.gallery.region.why.global',
+    pinned: 'analysis.gallery.region.why.pinned',
+    pinnedUnknown: 'analysis.gallery.region.why.pinnedUnknown',
+  } as const;
+
+  type WhyState = keyof typeof WHY_KEY;
+
+  interface WhyLine {
+    state: WhyState;
+    args: Record<string, unknown>; // matches t()'s params type; region names interpolate as strings
+    warn: boolean;
+    pins: string[]; // region slugs offered as one-click pin shortcuts
+    offerAuto: boolean; // show the "switch to automatic" escape hatch
+    mismatch?: string; // resolved region name for the secondary "location resolves to" line
+  }
+
+  const whyLine = $derived.by<WhyLine | null>(() => {
+    if (!data) return null;
+    const r = data.resolved;
+    const lc = data.locationConfigured;
+    const sel = selected;
+
+    if (sel === 'auto') {
+      if (!lc) return { state: 'noLocation', args: {}, warn: true, pins: [], offerAuto: false };
+      if (r.slug === '')
+        return { state: 'outsideCoverage', args: {}, warn: false, pins: [], offerAuto: false };
+      if (r.ambiguous) {
+        const runner = r.runnerUp ?? '';
+        return {
+          state: 'ambiguous',
+          args: { region: regionName(r.slug), runnerUp: regionName(runner) },
+          warn: false,
+          pins: runner ? [r.slug, runner] : [r.slug],
+          offerAuto: false,
+        };
+      }
+      return {
+        state: 'resolved',
+        args: { region: regionName(r.slug) },
+        warn: false,
+        pins: [],
+        offerAuto: false,
+      };
+    }
+
+    if (sel === 'global') {
+      return { state: 'global', args: {}, warn: false, pins: [], offerAuto: false };
+    }
+
+    // A pinned slug the current catalog does not know about (e.g. dropped upstream).
+    if (!knownSlug(sel)) {
+      return {
+        state: 'pinnedUnknown',
+        args: { region: sel },
+        warn: true,
+        pins: [],
+        offerAuto: true,
+      };
+    }
+
+    // A known pinned region. Surface a secondary line when the location resolves
+    // elsewhere, so the user understands the pin is overriding auto-detection.
+    const mismatch = lc && r.slug !== '' && r.slug !== sel ? regionName(r.slug) : undefined;
+    return {
+      state: 'pinned',
+      args: { region: regionName(sel) },
+      warn: false,
+      pins: [],
+      offerAuto: false,
+      mismatch,
+    };
+  });
+</script>
+
+<fieldset class="border border-base-300 rounded-lg p-3 mb-4">
+  <legend class="text-sm font-medium px-1">{t('analysis.gallery.region.title')}</legend>
+
+  {#if loading}
+    <div role="status" class="flex items-center gap-2 text-sm text-base-content/70">
+      <span
+        class="animate-spin h-4 w-4 border-2 border-primary border-t-transparent rounded-full"
+        aria-hidden="true"
+      ></span>
+      <span>{t('analysis.gallery.region.loading')}</span>
+    </div>
+  {:else if error}
+    <div role="alert" class="flex flex-wrap items-center gap-3 text-sm text-error">
+      <span>{t('analysis.gallery.region.loadFailed')}</span>
+      <button type="button" class="btn btn-sm btn-ghost" onclick={load}>
+        {t('analysis.gallery.retry')}
+      </button>
+    </div>
+  {:else if data}
+    <div class="flex flex-col gap-2">
+      <!-- Automatic -->
+      <label
+        for="model-region-auto"
+        class="flex items-start gap-3 rounded-md border p-2 transition-colors
+          {selected === 'auto' ? 'border-primary bg-primary/5' : 'border-base-300'}
+          {disabled ? '' : 'cursor-pointer hover:bg-base-200'}"
+      >
+        <input
+          id="model-region-auto"
+          type="radio"
+          class="radio radio-sm radio-primary mt-0.5"
+          name="model-region"
+          value="auto"
+          checked={selected === 'auto'}
+          {disabled}
+          onchange={() => select('auto')}
+        />
+        <div class="flex flex-col gap-0.5 min-w-0">
+          <span class="font-medium flex items-center gap-1.5">
+            <MapPin class="h-4 w-4" aria-hidden="true" />
+            {t('analysis.gallery.region.modeAuto')}
+          </span>
+          <span class="text-xs text-base-content/70"
+            >{t('analysis.gallery.region.modeAutoHint')}</span
+          >
+        </div>
+      </label>
+
+      <!-- Global -->
+      <label
+        for="model-region-global"
+        class="flex items-start gap-3 rounded-md border p-2 transition-colors
+          {selected === 'global' ? 'border-primary bg-primary/5' : 'border-base-300'}
+          {disabled ? '' : 'cursor-pointer hover:bg-base-200'}"
+      >
+        <input
+          id="model-region-global"
+          type="radio"
+          class="radio radio-sm radio-primary mt-0.5"
+          name="model-region"
+          value="global"
+          checked={selected === 'global'}
+          {disabled}
+          onchange={() => select('global')}
+        />
+        <div class="flex flex-col gap-0.5 min-w-0">
+          <span class="font-medium flex items-center gap-1.5">
+            <Globe class="h-4 w-4" aria-hidden="true" />
+            {t('analysis.gallery.region.modeGlobal')}
+          </span>
+          <span class="text-xs text-base-content/70"
+            >{t('analysis.gallery.region.modeGlobalHint')}</span
+          >
+        </div>
+      </label>
+
+      <!-- Pinned-region disclosure. The toggle stays mounted (it does not unmount
+           on expand), so keyboard focus is never dropped; once a region is pinned
+           the list is always shown and the toggle is unnecessary. -->
+      {#if !isPinnedSlug}
+        <button
+          type="button"
+          class="btn btn-ghost btn-xs self-start"
+          aria-expanded={showRegions}
+          aria-controls="model-region-list"
+          {disabled}
+          onclick={() => (showRegions = !showRegions)}
+        >
+          {t('analysis.gallery.region.pinLabel')}
+        </button>
+      {/if}
+      {#if regionsVisible}
+        <div id="model-region-list" class="flex flex-col gap-2 pl-1">
+          {#each groupedRegions as group (group.slug)}
+            <div class="flex flex-col gap-1">
+              <span class="text-xs font-semibold text-base-content/60 uppercase tracking-wide"
+                >{group.display}</span
+              >
+              {#each group.options as opt (opt.slug)}
+                {@const inputId = `model-region-tile-${opt.slug}`}
+                <label
+                  for={inputId}
+                  class="flex items-center gap-3 rounded-md border p-2 transition-colors
+                    {selected === opt.slug ? 'border-primary bg-primary/5' : 'border-base-300'}
+                    {disabled ? '' : 'cursor-pointer hover:bg-base-200'}"
+                >
+                  <input
+                    id={inputId}
+                    type="radio"
+                    class="radio radio-sm radio-primary"
+                    name="model-region"
+                    value={opt.slug}
+                    checked={selected === opt.slug}
+                    {disabled}
+                    onchange={() => select(opt.slug)}
+                  />
+                  <span class="flex-1 min-w-0">{opt.name}</span>
+                  {#if selected === opt.slug}
+                    <span class="badge badge-info badge-sm"
+                      >{t('analysis.gallery.region.pinnedBadge')}</span
+                    >
+                  {/if}
+                </label>
+              {/each}
+            </div>
+          {/each}
+        </div>
+      {/if}
+
+      <!-- Why-line: explains the current resolution and offers quick actions. -->
+      {#if whyLine}
+        <div role="status" class="text-xs {whyLine.warn ? 'text-warning' : 'text-base-content/70'}">
+          {t(WHY_KEY[whyLine.state], whyLine.args)}
+        </div>
+        {#if whyLine.mismatch}
+          <div class="text-xs text-base-content/60">
+            {t('analysis.gallery.region.why.pinnedMismatch', { resolved: whyLine.mismatch })}
+          </div>
+        {/if}
+        {#if whyLine.pins.length > 0}
+          <div class="flex flex-wrap gap-2">
+            {#each whyLine.pins as slug (slug)}
+              <button type="button" class="btn btn-xs" {disabled} onclick={() => select(slug)}>
+                {t('analysis.gallery.region.pinAction', { region: regionName(slug) })}
+              </button>
+            {/each}
+          </div>
+        {/if}
+        {#if whyLine.offerAuto}
+          <div>
+            <button type="button" class="btn btn-xs" {disabled} onclick={() => select('auto')}>
+              {t('analysis.gallery.region.switchToAuto')}
+            </button>
+          </div>
+        {/if}
+      {/if}
+    </div>
+  {/if}
+</fieldset>

--- a/frontend/src/lib/desktop/features/settings/components/ModelRegionSelector.test.ts
+++ b/frontend/src/lib/desktop/features/settings/components/ModelRegionSelector.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/svelte';
+import ModelRegionSelector from './ModelRegionSelector.svelte';
+import { settingsActions } from '$lib/stores/settings';
+import * as modelsApi from '$lib/utils/modelsApi';
+import type { ModelRegionsResponse, RegionResolution } from '$lib/types/models';
+
+vi.mock('$lib/utils/modelsApi');
+
+function response(overrides: Partial<ModelRegionsResponse> = {}): ModelRegionsResponse {
+  return {
+    modelRegion: 'auto',
+    locationConfigured: true,
+    resolved: { slug: 'nordic', source: 'auto', ambiguous: false },
+    regions: [
+      { slug: 'nordic', name: 'Nordic', group: 'europe', groupDisplay: 'Europe', tier: 50 },
+      { slug: 'iberia', name: 'Iberia', group: 'europe', groupDisplay: 'Europe', tier: 50 },
+      {
+        slug: 'andes',
+        name: 'Andes',
+        group: 'south-america',
+        groupDisplay: 'South America',
+        tier: 50,
+      },
+    ],
+    families: [],
+    ...overrides,
+  };
+}
+
+function resolved(overrides: Partial<RegionResolution>): RegionResolution {
+  return { slug: 'nordic', source: 'auto', ambiguous: false, ...overrides };
+}
+
+function radios(container: HTMLElement): HTMLInputElement[] {
+  return Array.from(container.querySelectorAll('input[type="radio"]'));
+}
+
+function radioByValue(container: HTMLElement, value: string): HTMLInputElement | null {
+  return container.querySelector(`input[value="${value}"]`);
+}
+
+function buttonByText(container: HTMLElement, text: string): HTMLButtonElement | null {
+  return (
+    Array.from(container.querySelectorAll('button')).find(b => b.textContent.includes(text)) ?? null
+  );
+}
+
+function setMode(mode: string) {
+  settingsActions.updateSection('birdnet', { modelRegion: mode });
+}
+
+async function renderLoaded(props: Record<string, unknown> = {}) {
+  const result = render(ModelRegionSelector, { props });
+  await waitFor(() => expect(radioByValue(result.container, 'auto')).not.toBeNull());
+  return result;
+}
+
+describe('ModelRegionSelector', () => {
+  beforeEach(() => {
+    cleanup();
+    settingsActions.resetAllSettings();
+    vi.mocked(modelsApi.fetchModelRegions).mockResolvedValue(response());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders Automatic and Global, and reveals region tiles behind the pin disclosure', async () => {
+    const { container } = await renderLoaded();
+    expect(radioByValue(container, 'auto')).not.toBeNull();
+    expect(radioByValue(container, 'global')).not.toBeNull();
+    // Region tiles hidden until the disclosure is opened.
+    expect(radioByValue(container, 'nordic')).toBeNull();
+    const pin = buttonByText(container, 'analysis.gallery.region.pinLabel');
+    expect(pin).not.toBeNull();
+    await fireEvent.click(pin as HTMLButtonElement);
+    expect(radioByValue(container, 'nordic')).not.toBeNull();
+    expect(radioByValue(container, 'iberia')).not.toBeNull();
+    expect(radioByValue(container, 'andes')).not.toBeNull();
+  });
+
+  it('state auto-no-location: prompts to set a location', async () => {
+    vi.mocked(modelsApi.fetchModelRegions).mockResolvedValue(
+      response({ locationConfigured: false })
+    );
+    const { container } = await renderLoaded();
+    expect(container.textContent).toContain('analysis.gallery.region.why.noLocation');
+  });
+
+  it('state auto-outside-coverage: explains the global fallback', async () => {
+    vi.mocked(modelsApi.fetchModelRegions).mockResolvedValue(
+      response({ resolved: resolved({ slug: '', source: 'global' }) })
+    );
+    const { container } = await renderLoaded();
+    expect(container.textContent).toContain('analysis.gallery.region.why.outsideCoverage');
+  });
+
+  it('state auto-resolved: shows the detected region line', async () => {
+    const { container } = await renderLoaded();
+    expect(container.textContent).toContain('analysis.gallery.region.why.resolved');
+  });
+
+  it('state auto-ambiguous: offers two pin shortcuts and pins the winner on click', async () => {
+    vi.mocked(modelsApi.fetchModelRegions).mockResolvedValue(
+      response({ resolved: resolved({ slug: 'nordic', ambiguous: true, runnerUp: 'iberia' }) })
+    );
+    const { container } = await renderLoaded();
+    expect(container.textContent).toContain('analysis.gallery.region.why.ambiguous');
+    const pinButtons = Array.from(container.querySelectorAll('button')).filter(b =>
+      b.textContent.includes('analysis.gallery.region.pinAction')
+    );
+    expect(pinButtons).toHaveLength(2);
+
+    const spy = vi.spyOn(settingsActions, 'updateSection');
+    await fireEvent.click(pinButtons[0]);
+    expect(spy).toHaveBeenCalledWith('birdnet', { modelRegion: 'nordic' });
+  });
+
+  it('state auto-ambiguous: the runner-up pin pins the runner-up', async () => {
+    // Fresh render: pinning the winner would flip the mode out of the ambiguous
+    // state, so the runner-up pin is exercised on its own render.
+    vi.mocked(modelsApi.fetchModelRegions).mockResolvedValue(
+      response({ resolved: resolved({ slug: 'nordic', ambiguous: true, runnerUp: 'iberia' }) })
+    );
+    const { container } = await renderLoaded();
+    const pinButtons = Array.from(container.querySelectorAll('button')).filter(b =>
+      b.textContent.includes('analysis.gallery.region.pinAction')
+    );
+    const spy = vi.spyOn(settingsActions, 'updateSection');
+    await fireEvent.click(pinButtons[1]);
+    expect(spy).toHaveBeenCalledWith('birdnet', { modelRegion: 'iberia' });
+  });
+
+  it('state global: reflects the saved global mode and checks the Global radio', async () => {
+    setMode('global');
+    const { container } = await renderLoaded();
+    expect(radioByValue(container, 'global')?.checked).toBe(true);
+    expect(container.textContent).toContain('analysis.gallery.region.why.global');
+  });
+
+  it('state pinned + mismatch: shows the pinned line, the mismatch line, and checks the tile', async () => {
+    setMode('iberia');
+    const { container } = await renderLoaded();
+    expect(radioByValue(container, 'iberia')?.checked).toBe(true); // disclosure auto-opens for a pin
+    expect(container.textContent).toContain('analysis.gallery.region.why.pinned');
+    expect(container.textContent).toContain('analysis.gallery.region.why.pinnedMismatch');
+  });
+
+  it('state pinned-unknown: warns and offers switch-to-automatic', async () => {
+    setMode('atlantis'); // not in the catalog regions
+    const { container } = await renderLoaded();
+    expect(container.textContent).toContain('analysis.gallery.region.why.pinnedUnknown');
+    const spy = vi.spyOn(settingsActions, 'updateSection');
+    const switchBtn = buttonByText(container, 'analysis.gallery.region.switchToAuto');
+    expect(switchBtn).not.toBeNull();
+    await fireEvent.click(switchBtn as HTMLButtonElement);
+    expect(spy).toHaveBeenCalledWith('birdnet', { modelRegion: 'auto' });
+  });
+
+  it('dispatches the chosen mode when Global or a region tile is selected', async () => {
+    const { container } = await renderLoaded();
+    const spy = vi.spyOn(settingsActions, 'updateSection');
+    await fireEvent.click(radioByValue(container, 'global') as HTMLInputElement);
+    expect(spy).toHaveBeenCalledWith('birdnet', { modelRegion: 'global' });
+
+    // Open the disclosure and pick a tile.
+    await fireEvent.click(
+      buttonByText(container, 'analysis.gallery.region.pinLabel') as HTMLButtonElement
+    );
+    await fireEvent.click(radioByValue(container, 'andes') as HTMLInputElement);
+    expect(spy).toHaveBeenCalledWith('birdnet', { modelRegion: 'andes' });
+  });
+
+  it('shows an error with a retry that refetches', async () => {
+    vi.mocked(modelsApi.fetchModelRegions).mockRejectedValueOnce(new Error('boom'));
+    const { container, getByRole } = render(ModelRegionSelector, {});
+    await waitFor(() => expect(getByRole('alert')).toBeTruthy());
+    expect(container.textContent).toContain('analysis.gallery.region.loadFailed');
+
+    vi.mocked(modelsApi.fetchModelRegions).mockResolvedValue(response());
+    await fireEvent.click(buttonByText(container, 'analysis.gallery.retry') as HTMLButtonElement);
+    await waitFor(() => expect(radioByValue(container, 'auto')).not.toBeNull());
+  });
+
+  it('disables every control when the disabled prop is set', async () => {
+    setMode('iberia'); // opens the disclosure so tiles render too
+    const { container } = await renderLoaded({ disabled: true });
+    for (const radio of radios(container)) {
+      expect(radio.disabled).toBe(true);
+    }
+  });
+
+  it('treats an empty modelRegion as automatic', async () => {
+    setMode('');
+    const { container } = await renderLoaded();
+    expect(radioByValue(container, 'auto')?.checked).toBe(true);
+    expect(container.textContent).toContain('analysis.gallery.region.why.resolved');
+  });
+});

--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
@@ -43,6 +43,7 @@
   import SettingsSection from '$lib/desktop/features/settings/components/SettingsSection.svelte';
   import SettingsNote from '$lib/desktop/features/settings/components/SettingsNote.svelte';
   import ModelVariantPicker from '$lib/desktop/features/settings/components/ModelVariantPicker.svelte';
+  import ModelRegionSelector from '$lib/desktop/features/settings/components/ModelRegionSelector.svelte';
   import NumberField from '$lib/desktop/components/forms/NumberField.svelte';
   import FalsePositiveFilterControl, {
     type FilterLevel,
@@ -1607,7 +1608,10 @@
       title={t('analysis.gallery.title')}
       description={t('analysis.gallery.description')}
       defaultOpen={true}
+      originalData={{ modelRegion: store.originalData.birdnet?.modelRegion ?? 'auto' }}
+      currentData={{ modelRegion: birdnet?.modelRegion ?? 'auto' }}
     >
+      <ModelRegionSelector disabled={store.isLoading || store.isSaving} />
       <SettingsTabs tabs={galleryTabs} bind:activeTab={galleryTab} showActions={false} />
     </SettingsSection>
 

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -391,6 +391,9 @@ export type TranslationKey =
   | 'notifications.content.buffer.overloadMessage' // params: dropRate, sourceName
   | 'notifications.content.ort.unavailableTitle'
   | 'notifications.content.ort.unavailableMessage' // params: requiredVersion, modelName, installGuideURL
+  | 'notifications.content.region.staleTitle'
+  | 'notifications.content.region.staleMessage' // params: modelName, oldRegion, newRegion
+  | 'notifications.content.region.staleGlobalMessage' // params: modelName, oldRegion
   | 'notifications.content.alert.firedTitle' // params: rule_name
   | 'notifications.content.alert.metricExceeded' // params: value, threshold
   | 'notifications.content.alert.detectionOccurred' // params: species_name, confidence
@@ -3846,6 +3849,25 @@ export type TranslationKey =
   | 'analysis.downloadSource.endpoint.validationMessage'
   | 'analysis.gallery.title'
   | 'analysis.gallery.description'
+  | 'analysis.gallery.region.title'
+  | 'analysis.gallery.region.modeAuto'
+  | 'analysis.gallery.region.modeAutoHint'
+  | 'analysis.gallery.region.modeGlobal'
+  | 'analysis.gallery.region.modeGlobalHint'
+  | 'analysis.gallery.region.pinLabel'
+  | 'analysis.gallery.region.pinnedBadge'
+  | 'analysis.gallery.region.pinAction' // params: region
+  | 'analysis.gallery.region.switchToAuto'
+  | 'analysis.gallery.region.loading'
+  | 'analysis.gallery.region.loadFailed'
+  | 'analysis.gallery.region.why.noLocation'
+  | 'analysis.gallery.region.why.outsideCoverage'
+  | 'analysis.gallery.region.why.ambiguous' // params: region, runnerUp
+  | 'analysis.gallery.region.why.resolved' // params: region
+  | 'analysis.gallery.region.why.global'
+  | 'analysis.gallery.region.why.pinned' // params: region
+  | 'analysis.gallery.region.why.pinnedMismatch' // params: resolved
+  | 'analysis.gallery.region.why.pinnedUnknown' // params: region
   | 'analysis.gallery.variants.title'
   | 'analysis.gallery.variants.recommended'
   | 'analysis.gallery.variants.recommendedForHardware'
@@ -4089,6 +4111,15 @@ export type TranslationParams = {
     requiredVersion: string | number;
     modelName: string | number;
     installGuideURL: string | number;
+  };
+  'notifications.content.region.staleMessage': {
+    modelName: string | number;
+    oldRegion: string | number;
+    newRegion: string | number;
+  };
+  'notifications.content.region.staleGlobalMessage': {
+    modelName: string | number;
+    oldRegion: string | number;
   };
   'notifications.content.alert.firedTitle': { rule_name: string | number };
   'notifications.content.alert.metricExceeded': {
@@ -4425,6 +4456,12 @@ export type TranslationParams = {
     version: string | number;
     species: string | number;
   };
+  'analysis.gallery.region.pinAction': { region: string | number };
+  'analysis.gallery.region.why.ambiguous': { region: string | number; runnerUp: string | number };
+  'analysis.gallery.region.why.resolved': { region: string | number };
+  'analysis.gallery.region.why.pinned': { region: string | number };
+  'analysis.gallery.region.why.pinnedMismatch': { resolved: string | number };
+  'analysis.gallery.region.why.pinnedUnknown': { region: string | number };
   'analysis.gallery.variants.showAll': { count: string | number };
   'analysis.gallery.variants.latency': { ms: string | number };
   'analysis.gallery.reasons.backendRecommended': { backend: string | number };

--- a/frontend/src/lib/stores/settings.ts
+++ b/frontend/src/lib/stores/settings.ts
@@ -74,6 +74,12 @@ export interface BirdNetSettings {
   latitude: number;
   longitude: number;
   locationConfigured: boolean; // true when location has been explicitly configured
+  /**
+   * Regional model preference for the gallery: 'auto' (resolve the best regional
+   * variant from the station location), 'global' (always the worldwide model), or
+   * a region slug. '' and absent both mean 'auto' (the Go field is omitempty).
+   */
+  modelRegion?: string;
   rangeFilter: RangeFilterSettings;
   // Host used for model downloads, e.g. https://hf-mirror.com where
   // huggingface.co is unreachable. When empty the backend falls back to the
@@ -907,6 +913,7 @@ function createEmptySettings(): SettingsFormData {
       latitude: 0,
       longitude: 0,
       locationConfigured: false,
+      modelRegion: 'auto',
       rangeFilter: {
         threshold: 0.03,
         passUnmappedSpecies: false,

--- a/frontend/src/lib/types/models.ts
+++ b/frontend/src/lib/types/models.ts
@@ -87,3 +87,44 @@ export interface DownloadProgress {
   totalFiles: number;
   error?: string;
 }
+
+/** One selectable region in the gallery region selector. Mirrors Go RegionOption. */
+export interface RegionOption {
+  slug: string;
+  name: string;
+  group: string; // continental bucket slug, for grouping in the UI
+  groupDisplay: string; // continental bucket display name
+  tier: number;
+}
+
+/**
+ * How the server resolved the configured coordinates to a region. Mirrors Go
+ * RegionResolution. The endpoint always computes this under automatic mode (a
+ * preview), so in practice `source` is 'auto' or 'global'; 'pinned' and
+ * 'pinned-fallback' exist in the contract for future per-family use. `slug` is
+ * empty when the global model applies.
+ */
+export interface RegionResolution {
+  slug: string;
+  source: 'pinned' | 'auto' | 'pinned-fallback' | 'global';
+  ambiguous: boolean;
+  runnerUp?: string;
+}
+
+/** Per-family region resolution under the configured coordinates. Mirrors Go RegionFamily. */
+export interface RegionFamily {
+  catalogId: string;
+  repo: string;
+  installed: boolean;
+  installedVariantRegion: string; // region of the installed variant, "" for a global/hardware variant
+  resolved: RegionResolution;
+}
+
+/** Response of GET /api/v2/models/regions. Mirrors Go ModelRegionsResponse. */
+export interface ModelRegionsResponse {
+  modelRegion: string; // the saved BirdNET.ModelRegion setting
+  locationConfigured: boolean;
+  resolved: RegionResolution; // what "auto" resolves to from the coordinates
+  regions: RegionOption[]; // dropdown options, union across families
+  families: RegionFamily[]; // per-family resolution
+}

--- a/frontend/src/lib/utils/modelsApi.ts
+++ b/frontend/src/lib/utils/modelsApi.ts
@@ -3,7 +3,12 @@
 // Uses the shared api utility for CSRF-protected fetch calls and
 // ReconnectingEventSource for SSE progress streams.
 
-import type { CatalogResponse, DownloadProgress, InstalledModel } from '$lib/types/models';
+import type {
+  CatalogResponse,
+  DownloadProgress,
+  InstalledModel,
+  ModelRegionsResponse,
+} from '$lib/types/models';
 import { api } from '$lib/utils/api';
 import { getLogger } from '$lib/utils/logger';
 import { buildAppUrl } from '$lib/utils/urlHelpers';
@@ -21,6 +26,16 @@ export async function fetchCatalog(): Promise<CatalogResponse> {
 /** Fetch all currently installed models. */
 export async function fetchInstalled(): Promise<InstalledModel[]> {
   return api.get<InstalledModel[]>(`${BASE}/installed`);
+}
+
+/**
+ * Fetch the region selector data for the model gallery: the saved mode, what the
+ * configured coordinates resolve to under "auto", the selectable regions, and the
+ * per-family resolution. Auth-gated on the server; the raw coordinates are never
+ * returned.
+ */
+export async function fetchModelRegions(): Promise<ModelRegionsResponse> {
+  return api.get<ModelRegionsResponse>(`${BASE}/regions`);
 }
 
 /**

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -458,6 +458,11 @@
         "unavailableTitle": "ONNX Runtime není k dispozici",
         "unavailableMessage": "ONNX Runtime {requiredVersion} je vyžadován pro {modelName}, ale nebyl nalezen. Viz průvodce instalací: {installGuideURL}"
       },
+      "region": {
+        "staleTitle": "Oblast modelu může být zastaralá",
+        "staleMessage": "{modelName} je nainstalován pro {oldRegion}, ale vaše nová poloha odpovídá {newRegion}. Varianty můžete změnit v galerii modelů v Nastavení.",
+        "staleGlobalMessage": "{modelName} je nainstalován pro {oldRegion}, ale vaše nová poloha je mimo jeho pokrytí. Na globální variantu můžete přepnout v galerii modelů v Nastavení."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Aktuální hodnota: {value} % (práh: {threshold} %)",
@@ -5283,6 +5288,29 @@
     "gallery": {
       "title": "Galerie modelů",
       "description": "Správa klasifikačních modelů pro detekci ptáků a netopýrů.",
+      "region": {
+        "title": "Oblast modelu",
+        "modeAuto": "Automaticky",
+        "modeAutoHint": "Vybrat nejlepší regionální variantu podle polohy stanice",
+        "modeGlobal": "Globální",
+        "modeGlobalHint": "Vždy používat celosvětový model",
+        "pinLabel": "Připnout konkrétní oblast",
+        "pinnedBadge": "Připnuto",
+        "pinAction": "Připnout {region}",
+        "switchToAuto": "Přepnout na automatický",
+        "loading": "Načítání oblastí...",
+        "loadFailed": "Nepodařilo se načíst data o oblastech",
+        "why": {
+          "noLocation": "Automatický výběr vyžaduje polohu stanice. Nastavte ji v Hlavním nastavení; do té doby se používá globální model.",
+          "outsideCoverage": "Vaše poloha je mimo pokrytí všech regionálních modelů, proto se používá globální model.",
+          "ambiguous": "Vaše poloha je blízko hranice mezi {region} a {runnerUp}. Automatický výběr používá {region}; připněte kteroukoli z nich pro explicitní volbu.",
+          "resolved": "Zjištěná oblast z vaší polohy: {region}.",
+          "global": "Globální model se používá vždy bez ohledu na polohu stanice.",
+          "pinned": "Připnuto k {region}. Poloha stanice nemá vliv na výběr modelu.",
+          "pinnedMismatch": "Vaše poloha v současnosti odpovídá {resolved}.",
+          "pinnedUnknown": "Připnutá oblast \"{region}\" není v aktuálním katalogu modelů k dispozici. Rodiny modelů přejdou na vaši polohu nebo globální model."
+        }
+      },
       "variants": {
         "title": "Varianta modelu",
         "recommended": "Doporučeno",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -458,6 +458,11 @@
         "unavailableTitle": "ONNX Runtime ikke tilgængelig",
         "unavailableMessage": "ONNX Runtime {requiredVersion} er påkrævet til {modelName}, men blev ikke fundet. Se installationsguiden: {installGuideURL}"
       },
+      "region": {
+        "staleTitle": "Modelregionen kan være forældet",
+        "staleMessage": "{modelName} er installeret for {oldRegion}, men din nye placering svarer til {newRegion}. Du kan skifte varianter fra modelgalleriet i Indstillinger.",
+        "staleGlobalMessage": "{modelName} er installeret for {oldRegion}, men din nye placering er uden for dens dækning. Du kan skifte til den globale variant fra modelgalleriet i Indstillinger."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Aktuel værdi: {value}% (grænse: {threshold}%)",
@@ -5283,6 +5288,29 @@
     "gallery": {
       "title": "Modelgalleri",
       "description": "Administrer klassifikatormodeller til fugle- og flagermusdetektion.",
+      "region": {
+        "title": "Modelregion",
+        "modeAuto": "Automatisk",
+        "modeAutoHint": "Vælg den bedste regionale variant ud fra stationsplaceringen",
+        "modeGlobal": "Global",
+        "modeGlobalHint": "Brug altid den verdensomspændende model",
+        "pinLabel": "Fastgør en specifik region",
+        "pinnedBadge": "Fastgjort",
+        "pinAction": "Fastgør {region}",
+        "switchToAuto": "Skift til automatisk",
+        "loading": "Indlæser regioner...",
+        "loadFailed": "Kunne ikke indlæse regionsdata",
+        "why": {
+          "noLocation": "Automatisk valg kræver en stationsplacering. Indstil den i Hovedindstillinger; den globale model bruges indtil da.",
+          "outsideCoverage": "Din placering er uden for alle regionale modellers dækning, så den globale model bruges.",
+          "ambiguous": "Din placering er tæt på grænsen mellem {region} og {runnerUp}. Automatisk valg bruger {region}; fastgør en af dem for at gøre valget eksplicit.",
+          "resolved": "Registreret region fra din placering: {region}.",
+          "global": "Den globale model bruges altid, uanset stationsplaceringen.",
+          "pinned": "Fastgjort til {region}. Stationsplaceringen påvirker ikke modelvalget.",
+          "pinnedMismatch": "Din placering svarer i øjeblikket til {resolved}.",
+          "pinnedUnknown": "Den fastgjorte region \"{region}\" er ikke tilgængelig i det aktuelle modelkatalog. Modelfamilier falder tilbage på din placering eller den globale model."
+        }
+      },
       "variants": {
         "title": "Modelvariant",
         "recommended": "Anbefalet",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -458,6 +458,11 @@
         "unavailableTitle": "ONNX Runtime nicht verfügbar",
         "unavailableMessage": "ONNX Runtime {requiredVersion} wird für {modelName} benötigt, wurde aber nicht gefunden. Siehe Installationsanleitung: {installGuideURL}"
       },
+      "region": {
+        "staleTitle": "Modellregion ist möglicherweise veraltet",
+        "staleMessage": "{modelName} ist für {oldRegion} installiert, aber Ihr neuer Standort entspricht {newRegion}. Sie können Varianten in der Modellgalerie unter Einstellungen wechseln.",
+        "staleGlobalMessage": "{modelName} ist für {oldRegion} installiert, aber Ihr neuer Standort liegt außerhalb der Abdeckung. Sie können in der Modellgalerie unter Einstellungen zur globalen Variante wechseln."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Aktueller Wert: {value}% (Schwellenwert: {threshold}%)",
@@ -5283,6 +5288,29 @@
     "gallery": {
       "title": "Modellgalerie",
       "description": "Klassifikatormodelle für Vogel- und Fledermauserkennungen verwalten.",
+      "region": {
+        "title": "Modellregion",
+        "modeAuto": "Automatisch",
+        "modeAutoHint": "Beste regionale Variante anhand des Stationsstandorts auswählen",
+        "modeGlobal": "Global",
+        "modeGlobalHint": "Immer das weltweite Modell verwenden",
+        "pinLabel": "Bestimmte Region anheften",
+        "pinnedBadge": "Angeheftet",
+        "pinAction": "{region} anheften",
+        "switchToAuto": "Auf automatisch wechseln",
+        "loading": "Regionen werden geladen...",
+        "loadFailed": "Regionsdaten konnten nicht geladen werden",
+        "why": {
+          "noLocation": "Die automatische Auswahl erfordert einen Stationsstandort. Legen Sie ihn in den Haupteinstellungen fest; bis dahin wird das globale Modell verwendet.",
+          "outsideCoverage": "Ihr Standort liegt außerhalb der Abdeckung aller regionalen Modelle, daher wird das globale Modell verwendet.",
+          "ambiguous": "Ihr Standort liegt nahe der Grenze zwischen {region} und {runnerUp}. Die automatische Auswahl verwendet {region}; heften Sie eine der beiden an, um die Auswahl explizit festzulegen.",
+          "resolved": "Aus Ihrem Standort erkannte Region: {region}.",
+          "global": "Es wird immer das globale Modell verwendet, unabhängig vom Stationsstandort.",
+          "pinned": "An {region} angeheftet. Der Stationsstandort hat keinen Einfluss auf die Modellauswahl.",
+          "pinnedMismatch": "Ihr Standort entspricht derzeit {resolved}.",
+          "pinnedUnknown": "Die angeheftete Region \"{region}\" ist im aktuellen Modellkatalog nicht verfügbar. Modellfamilien weichen auf Ihren Standort oder das globale Modell aus."
+        }
+      },
       "variants": {
         "title": "Modellvariante",
         "recommended": "Empfohlen",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -458,6 +458,11 @@
         "unavailableTitle": "ONNX Runtime Not Available",
         "unavailableMessage": "ONNX Runtime {requiredVersion} is required for {modelName} but was not found. See the install guide: {installGuideURL}"
       },
+      "region": {
+        "staleTitle": "Model region may be outdated",
+        "staleMessage": "{modelName} is installed for {oldRegion}, but your new location resolves to {newRegion}. You can switch variants from the model gallery in Settings.",
+        "staleGlobalMessage": "{modelName} is installed for {oldRegion}, but your new location is outside its coverage. You can switch to the global variant from the model gallery in Settings."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Current value: {value}% (threshold: {threshold}%)",
@@ -5283,6 +5288,29 @@
     "gallery": {
       "title": "Model Gallery",
       "description": "Manage classifier models for bird and bat detection.",
+      "region": {
+        "title": "Model region",
+        "modeAuto": "Automatic",
+        "modeAutoHint": "Pick the best regional variant from the station location",
+        "modeGlobal": "Global",
+        "modeGlobalHint": "Always use the worldwide model",
+        "pinLabel": "Pin a specific region",
+        "pinnedBadge": "Pinned",
+        "pinAction": "Pin {region}",
+        "switchToAuto": "Switch to automatic",
+        "loading": "Loading regions...",
+        "loadFailed": "Failed to load region data",
+        "why": {
+          "noLocation": "Automatic selection needs a station location. Set it in Main settings; the global model is used until then.",
+          "outsideCoverage": "Your location is outside every regional model's coverage, so the global model is used.",
+          "ambiguous": "Your location is near the border between {region} and {runnerUp}. Automatic selection uses {region}; pin either one to make the choice explicit.",
+          "resolved": "Detected region from your location: {region}.",
+          "global": "The global model is always used, regardless of the station location.",
+          "pinned": "Pinned to {region}. The station location does not affect model selection.",
+          "pinnedMismatch": "Your location currently resolves to {resolved}.",
+          "pinnedUnknown": "The pinned region \"{region}\" is not available in the current model catalog. Model families fall back to your location or the global model."
+        }
+      },
       "variants": {
         "title": "Model variant",
         "recommended": "Recommended",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -458,6 +458,11 @@
         "unavailableTitle": "ONNX Runtime no disponible",
         "unavailableMessage": "Se requiere ONNX Runtime {requiredVersion} para {modelName}, pero no se encontró. Consulte la guía de instalación: {installGuideURL}"
       },
+      "region": {
+        "staleTitle": "La región del modelo puede estar desactualizada",
+        "staleMessage": "{modelName} está instalado para {oldRegion}, pero su nueva ubicación corresponde a {newRegion}. Puede cambiar de variante desde la galería de modelos en Configuración.",
+        "staleGlobalMessage": "{modelName} está instalado para {oldRegion}, pero su nueva ubicación está fuera de su cobertura. Puede cambiar a la variante global desde la galería de modelos en Configuración."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Valor actual: {value}% (umbral: {threshold}%)",
@@ -5283,6 +5288,29 @@
     "gallery": {
       "title": "Galería de modelos",
       "description": "Gestionar modelos clasificadores para la detección de aves y murciélagos.",
+      "region": {
+        "title": "Región del modelo",
+        "modeAuto": "Automático",
+        "modeAutoHint": "Elegir la mejor variante regional según la ubicación de la estación",
+        "modeGlobal": "Global",
+        "modeGlobalHint": "Usar siempre el modelo mundial",
+        "pinLabel": "Fijar una región específica",
+        "pinnedBadge": "Fijado",
+        "pinAction": "Fijar {region}",
+        "switchToAuto": "Cambiar a automático",
+        "loading": "Cargando regiones...",
+        "loadFailed": "Error al cargar los datos de la región",
+        "why": {
+          "noLocation": "La selección automática necesita la ubicación de la estación. Configúrela en Configuración principal; hasta entonces se usará el modelo global.",
+          "outsideCoverage": "Su ubicación está fuera de la cobertura de todos los modelos regionales, por lo que se utiliza el modelo global.",
+          "ambiguous": "Su ubicación está cerca del límite entre {region} y {runnerUp}. La selección automática usa {region}; fije cualquiera de las dos para hacer la elección explícita.",
+          "resolved": "Región detectada a partir de su ubicación: {region}.",
+          "global": "Siempre se utiliza el modelo global, independientemente de la ubicación de la estación.",
+          "pinned": "Fijado a {region}. La ubicación de la estación no afecta la selección del modelo.",
+          "pinnedMismatch": "Su ubicación se resuelve actualmente como {resolved}.",
+          "pinnedUnknown": "La región fijada \"{region}\" no está disponible en el catálogo de modelos actual. Las familias de modelos recurren a su ubicación o al modelo global."
+        }
+      },
       "variants": {
         "title": "Variante de modelo",
         "recommended": "Recomendado",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -458,6 +458,11 @@
         "unavailableTitle": "ONNX Runtime ei ole käytettävissä",
         "unavailableMessage": "ONNX Runtime {requiredVersion} vaaditaan mallille {modelName}, mutta sitä ei löytynyt. Katso asennusohje: {installGuideURL}"
       },
+      "region": {
+        "staleTitle": "Mallialue saattaa olla vanhentunut",
+        "staleMessage": "{modelName} on asennettu alueelle {oldRegion}, mutta uusi sijaintisi vastaa aluetta {newRegion}. Voit vaihtaa varianttia Asetusten malligalleriasta.",
+        "staleGlobalMessage": "{modelName} on asennettu alueelle {oldRegion}, mutta uusi sijaintisi on sen kattavuusalueen ulkopuolella. Voit vaihtaa globaaliin varianttiin Asetusten malligalleriasta."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Nykyinen arvo: {value}% (raja-arvo: {threshold}%)",
@@ -5283,6 +5288,29 @@
     "gallery": {
       "title": "Malligalleria",
       "description": "Hallitse lintu- ja lepakkotunnistuksen luokittelumalleja.",
+      "region": {
+        "title": "Mallialue",
+        "modeAuto": "Automaattinen",
+        "modeAutoHint": "Valitse paras alueellinen variantti aseman sijainnin perusteella",
+        "modeGlobal": "Globaali",
+        "modeGlobalHint": "Käytä aina maailmanlaajuista mallia",
+        "pinLabel": "Kiinnitä tietty alue",
+        "pinnedBadge": "Kiinnitetty",
+        "pinAction": "Kiinnitä {region}",
+        "switchToAuto": "Vaihda automaattiseen",
+        "loading": "Ladataan alueita...",
+        "loadFailed": "Aluetietojen lataaminen epäonnistui",
+        "why": {
+          "noLocation": "Automaattinen valinta vaatii aseman sijainnin. Aseta se Pääasetuksissa; siihen asti käytetään globaalia mallia.",
+          "outsideCoverage": "Sijaintisi on kaikkien alueellisten mallien kattavuusalueen ulkopuolella, joten käytetään globaalia mallia.",
+          "ambiguous": "Sijaintisi on lähellä alueiden {region} ja {runnerUp} välistä rajaa. Automaattinen valinta käyttää aluetta {region}; tee valinnasta nimenomainen kiinnittämällä jompikumpi.",
+          "resolved": "Sijaintisi perusteella tunnistettu alue: {region}.",
+          "global": "Globaalia mallia käytetään aina aseman sijainnista riippumatta.",
+          "pinned": "Kiinnitetty alueeseen {region}. Aseman sijainti ei vaikuta mallin valintaan.",
+          "pinnedMismatch": "Sijaintisi vastaa tällä hetkellä aluetta {resolved}.",
+          "pinnedUnknown": "Kiinnitetty alue \"{region}\" ei ole saatavilla nykyisessä malliluettelossa. Malliperheet käyttävät varavaihtoehtona sijaintiasi tai globaalia mallia."
+        }
+      },
       "variants": {
         "title": "Mallivariantti",
         "recommended": "Suositeltu",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -458,6 +458,11 @@
         "unavailableTitle": "ONNX Runtime non disponible",
         "unavailableMessage": "ONNX Runtime {requiredVersion} est requis pour {modelName} mais n'a pas été trouvé. Voir le guide d'installation : {installGuideURL}"
       },
+      "region": {
+        "staleTitle": "La région du modèle est peut-être obsolète",
+        "staleMessage": "{modelName} est installé pour {oldRegion}, mais votre nouvel emplacement correspond à {newRegion}. Vous pouvez changer de variante depuis la galerie de modèles dans les Paramètres.",
+        "staleGlobalMessage": "{modelName} est installé pour {oldRegion}, mais votre nouvel emplacement est en dehors de sa couverture. Vous pouvez passer à la variante globale depuis la galerie de modèles dans les Paramètres."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Valeur actuelle : {value}% (seuil : {threshold}%)",
@@ -5283,6 +5288,29 @@
     "gallery": {
       "title": "Galerie de modèles",
       "description": "Gérer les modèles classificateurs pour la détection des oiseaux et des chauves-souris.",
+      "region": {
+        "title": "Région du modèle",
+        "modeAuto": "Automatique",
+        "modeAutoHint": "Choisir la meilleure variante régionale selon l'emplacement de la station",
+        "modeGlobal": "Global",
+        "modeGlobalHint": "Toujours utiliser le modèle mondial",
+        "pinLabel": "Épingler une région spécifique",
+        "pinnedBadge": "Épinglé",
+        "pinAction": "Épingler {region}",
+        "switchToAuto": "Passer en automatique",
+        "loading": "Chargement des régions...",
+        "loadFailed": "Échec du chargement des données de région",
+        "why": {
+          "noLocation": "La sélection automatique nécessite un emplacement de station. Définissez-le dans les Paramètres principaux ; le modèle global est utilisé jusque-là.",
+          "outsideCoverage": "Votre emplacement est en dehors de la couverture de tous les modèles régionaux, le modèle global est donc utilisé.",
+          "ambiguous": "Votre emplacement est proche de la frontière entre {region} et {runnerUp}. La sélection automatique utilise {region} ; épinglez l'une d'elles pour rendre le choix explicite.",
+          "resolved": "Région détectée à partir de votre position : {region}.",
+          "global": "Le modèle global est toujours utilisé, quel que soit l'emplacement de la station.",
+          "pinned": "Épinglé sur {region}. L'emplacement de la station n'affecte pas la sélection du modèle.",
+          "pinnedMismatch": "Votre emplacement correspond actuellement à {resolved}.",
+          "pinnedUnknown": "La région épinglée \"{region}\" n'est pas disponible dans le catalogue de modèles actuel. Les familles de modèles se rabattent sur votre emplacement ou le modèle global."
+        }
+      },
       "variants": {
         "title": "Variante du modèle",
         "recommended": "Recommandé",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -458,6 +458,11 @@
         "unavailableTitle": "Az ONNX Runtime nem elérhető",
         "unavailableMessage": "Az ONNX Runtime {requiredVersion} szükséges a(z) {modelName} modellhez, de nem található. Lásd a telepítési útmutatót: {installGuideURL}"
       },
+      "region": {
+        "staleTitle": "A modellrégió elavult lehet",
+        "staleMessage": "A(z) {modelName} a(z) {oldRegion} régióhoz van telepítve, de az új helyszíne a következőnek felel meg: {newRegion}. Változatot a Beállítások modellgalériájában válthat.",
+        "staleGlobalMessage": "A(z) {modelName} a(z) {oldRegion} régióhoz van telepítve, de az új helyszíne kívül esik a lefedettségén. A globális változatra a Beállítások modellgalériájában válthat."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Jelenlegi érték: {value}% (küszöbérték: {threshold}%)",
@@ -5283,6 +5288,29 @@
     "gallery": {
       "title": "Modellgaléria",
       "description": "Osztályozó modellek kezelése madár- és denevérdetektáláshoz.",
+      "region": {
+        "title": "Modellrégió",
+        "modeAuto": "Automatikus",
+        "modeAutoHint": "A legjobb regionális változat kiválasztása az állomás helyszíne alapján",
+        "modeGlobal": "Globális",
+        "modeGlobalHint": "Mindig a világszintű modell használata",
+        "pinLabel": "Adott régió rögzítése",
+        "pinnedBadge": "Rögzítve",
+        "pinAction": "{region} rögzítése",
+        "switchToAuto": "Váltás automatikusra",
+        "loading": "Régiók betöltése...",
+        "loadFailed": "Nem sikerült betölteni a régióadatokat",
+        "why": {
+          "noLocation": "Az automatikus kiválasztáshoz állomáshelyszín szükséges. Adja meg a Fő beállításokban; addig a globális modell kerül használatra.",
+          "outsideCoverage": "Az Ön helyszíne kívül esik az összes regionális modell lefedettségén, ezért a globális modell kerül használatra.",
+          "ambiguous": "Az Ön helyszíne {region} és {runnerUp} határának közelében található. Az automatikus kiválasztás a(z) {region} régiót használja; rögzítse valamelyiket a választás egyértelműsítéséhez.",
+          "resolved": "Helyszíne alapján észlelt régió: {region}.",
+          "global": "Mindig a globális modell van használatban, függetlenül az állomás helyszínétől.",
+          "pinned": "Rögzítve a következőhöz: {region}. Az állomás helyszíne nem befolyásolja a modellválasztást.",
+          "pinnedMismatch": "Helyszíne jelenleg a következőre oldódik fel: {resolved}.",
+          "pinnedUnknown": "A rögzített \"{region}\" régió nem érhető el a jelenlegi modellkatalógusban. A modellcsaládok visszatérnek a helyszínéhez vagy a globális modellhez."
+        }
+      },
       "variants": {
         "title": "Modellváltozat",
         "recommended": "Ajánlott",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -458,6 +458,11 @@
         "unavailableTitle": "ONNX Runtime non disponibile",
         "unavailableMessage": "ONNX Runtime {requiredVersion} è richiesto per {modelName} ma non è stato trovato. Consulta la guida all'installazione: {installGuideURL}"
       },
+      "region": {
+        "staleTitle": "La regione del modello potrebbe essere obsoleta",
+        "staleMessage": "{modelName} è installato per {oldRegion}, ma la tua nuova posizione corrisponde a {newRegion}. Puoi cambiare variante dalla galleria modelli in Impostazioni.",
+        "staleGlobalMessage": "{modelName} è installato per {oldRegion}, ma la tua nuova posizione è al di fuori della sua copertura. Puoi passare alla variante globale dalla galleria modelli in Impostazioni."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Valore attuale: {value}% (soglia: {threshold}%)",
@@ -5283,6 +5288,29 @@
     "gallery": {
       "title": "Galleria modelli",
       "description": "Gestisci i modelli di classificazione per il rilevamento di uccelli e pipistrelli.",
+      "region": {
+        "title": "Regione del modello",
+        "modeAuto": "Automatico",
+        "modeAutoHint": "Scegli la migliore variante regionale in base alla posizione della stazione",
+        "modeGlobal": "Globale",
+        "modeGlobalHint": "Usa sempre il modello mondiale",
+        "pinLabel": "Fissa una regione specifica",
+        "pinnedBadge": "Fissato",
+        "pinAction": "Fissa {region}",
+        "switchToAuto": "Passa ad automatico",
+        "loading": "Caricamento regioni...",
+        "loadFailed": "Impossibile caricare i dati della regione",
+        "why": {
+          "noLocation": "La selezione automatica richiede la posizione della stazione. Impostala nelle Impostazioni Principali; fino ad allora verrà utilizzato il modello globale.",
+          "outsideCoverage": "La tua posizione è al di fuori della copertura di qualsiasi modello regionale, pertanto viene utilizzato il modello globale.",
+          "ambiguous": "La tua posizione è vicina al confine tra {region} e {runnerUp}. La selezione automatica utilizza {region}; fissa una delle due per rendere esplicita la scelta.",
+          "resolved": "Regione rilevata dalla tua posizione: {region}.",
+          "global": "Il modello globale viene sempre utilizzato, indipendentemente dalla posizione della stazione.",
+          "pinned": "Fissato su {region}. La posizione della stazione non influisce sulla selezione del modello.",
+          "pinnedMismatch": "La tua posizione corrisponde attualmente a {resolved}.",
+          "pinnedUnknown": "La regione fissata \"{region}\" non è disponibile nell'attuale catalogo modelli. Le famiglie di modelli useranno come fallback la tua posizione o il modello globale."
+        }
+      },
       "variants": {
         "title": "Variante modello",
         "recommended": "Consigliato",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -458,6 +458,11 @@
         "unavailableTitle": "ONNX Runtime nav pieejams",
         "unavailableMessage": "ONNX Runtime {requiredVersion} ir nepieciešams modelim {modelName}, bet netika atrasts. Skatiet instalēšanas rokasgrāmatu: {installGuideURL}"
       },
+      "region": {
+        "staleTitle": "Modeļa reģions var būt novecojis",
+        "staleMessage": "{modelName} ir instalēts reģionam {oldRegion}, bet jūsu jaunā atrašanās vieta atbilst {newRegion}. Varat pārslēgt variantus no modeļu galerijas sadaļā Iestatījumi.",
+        "staleGlobalMessage": "{modelName} ir instalēts reģionam {oldRegion}, bet jūsu jaunā atrašanās vieta ir ārpus tā pārklājuma. Varat pārslēgties uz globālo variantu no modeļu galerijas sadaļā Iestatījumi."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Pašreizējā vērtība: {value}% (slieksnis: {threshold}%)",
@@ -5283,6 +5288,29 @@
     "gallery": {
       "title": "Modeļu galerija",
       "description": "Pārvaldiet klasifikācijas modeļus putnu un sikspārņu noteikšanai.",
+      "region": {
+        "title": "Modeļa reģions",
+        "modeAuto": "Automātiski",
+        "modeAutoHint": "Izvēlēties labāko reģionālo variantu pēc stacijas atrašanās vietas",
+        "modeGlobal": "Globāls",
+        "modeGlobalHint": "Vienmēr izmantot vispasaules modeli",
+        "pinLabel": "Piespraust noteiktu reģionu",
+        "pinnedBadge": "Piesprausts",
+        "pinAction": "Piespraust {region}",
+        "switchToAuto": "Pārslēgties uz automātisko",
+        "loading": "Ielādē reģionus...",
+        "loadFailed": "Neizdevās ielādēt reģiona datus",
+        "why": {
+          "noLocation": "Automātiskajai atlasei nepieciešama stacijas atrašanās vieta. Iestatiet to Galvenajos iestatījumos; līdz tam tiek izmantots globālais modelis.",
+          "outsideCoverage": "Jūsu atrašanās vieta ir ārpus visu reģionālo modeļu pārklājuma, tāpēc tiek izmantots globālais modelis.",
+          "ambiguous": "Jūsu atrašanās vieta ir tuvu robežai starp {region} un {runnerUp}. Automātiskā atlase izmanto {region}; piespraudiet kādu no tiem, lai izvēle būtu skaidra.",
+          "resolved": "Noteiktais reģions pēc jūsu atrašanās vietas: {region}.",
+          "global": "Vienmēr tiek izmantots globālais modelis neatkarīgi no stacijas atrašanās vietas.",
+          "pinned": "Piesprausts reģionam {region}. Stacijas atrašanās vieta neietekmē modeļa atlasi.",
+          "pinnedMismatch": "Jūsu atrašanās vieta pašlaik atbilst {resolved}.",
+          "pinnedUnknown": "Piespraustais reģions \"{region}\" nav pieejams pašreizējā modeļu katalogā. Modeļu saimes atgriežas pie jūsu atrašanās vietas vai globālā modeļa."
+        }
+      },
       "variants": {
         "title": "Modeļa variants",
         "recommended": "Ieteicams",

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -458,6 +458,11 @@
         "unavailableTitle": "ONNX Runtime ikke tilgjengelig",
         "unavailableMessage": "ONNX Runtime {requiredVersion} kreves for {modelName}, men ble ikke funnet. Se installasjonsveiledningen: {installGuideURL}"
       },
+      "region": {
+        "staleTitle": "Modellregionen kan være utdatert",
+        "staleMessage": "{modelName} er installert for {oldRegion}, men den nye posisjonen din tilsvarer {newRegion}. Du kan bytte varianter fra modellgalleriet i Innstillinger.",
+        "staleGlobalMessage": "{modelName} er installert for {oldRegion}, men den nye posisjonen din er utenfor dekningsområdet. Du kan bytte til den globale varianten fra modellgalleriet i Innstillinger."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Gjeldende verdi: {value}% (terskel: {threshold}%)",
@@ -5283,6 +5288,29 @@
     "gallery": {
       "title": "Modellgalleri",
       "description": "Administrer klassifikatormodeller for fugle- og flaggermusdeteksjon.",
+      "region": {
+        "title": "Modellregion",
+        "modeAuto": "Automatisk",
+        "modeAutoHint": "Velg den beste regionale varianten fra stasjonsposisjonen",
+        "modeGlobal": "Global",
+        "modeGlobalHint": "Bruk alltid den verdensomspennende modellen",
+        "pinLabel": "Fest en bestemt region",
+        "pinnedBadge": "Festet",
+        "pinAction": "Fest {region}",
+        "switchToAuto": "Bytt til automatisk",
+        "loading": "Laster regioner...",
+        "loadFailed": "Innlasting av regiondata mislyktes",
+        "why": {
+          "noLocation": "Automatisk valg krever en stasjonsposisjon. Angi den i Hovedinnstillinger; den globale modellen brukes inntil da.",
+          "outsideCoverage": "Posisjonen din er utenfor dekningsområdet til alle regionale modeller, så den globale modellen brukes.",
+          "ambiguous": "Posisjonen din er nær grensen mellom {region} og {runnerUp}. Automatisk valg bruker {region}; fest en av dem for å gjøre valget eksplisitt.",
+          "resolved": "Gjenkjent region fra posisjonen din: {region}.",
+          "global": "Den globale modellen brukes alltid, uavhengig av stasjonsposisjonen.",
+          "pinned": "Festet til {region}. Stasjonsposisjonen påvirker ikke modellvalget.",
+          "pinnedMismatch": "Posisjonen din tilsvarer for øyeblikket {resolved}.",
+          "pinnedUnknown": "Den festede regionen \"{region}\" er ikke tilgjengelig i den gjeldende modellkatalogen. Modellfamilier faller tilbake på posisjonen din eller den globale modellen."
+        }
+      },
       "variants": {
         "title": "Modellvariant",
         "recommended": "Anbefalt",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -458,6 +458,11 @@
         "unavailableTitle": "ONNX Runtime niet beschikbaar",
         "unavailableMessage": "ONNX Runtime {requiredVersion} is vereist voor {modelName}, maar werd niet gevonden. Zie de installatiegids: {installGuideURL}"
       },
+      "region": {
+        "staleTitle": "Modelregio is mogelijk verouderd",
+        "staleMessage": "{modelName} is geïnstalleerd voor {oldRegion}, maar uw nieuwe locatie komt overeen met {newRegion}. U kunt van variant wisselen via de modellengalerij in Instellingen.",
+        "staleGlobalMessage": "{modelName} is geïnstalleerd voor {oldRegion}, maar uw nieuwe locatie valt buiten de dekking. U kunt overschakelen naar de globale variant via de modellengalerij in Instellingen."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Huidige waarde: {value}% (drempelwaarde: {threshold}%)",
@@ -5283,6 +5288,29 @@
     "gallery": {
       "title": "Modellengalerij",
       "description": "Beheer classificatiemodellen voor vogel- en vleermuisdetectie.",
+      "region": {
+        "title": "Modelregio",
+        "modeAuto": "Automatisch",
+        "modeAutoHint": "Kies de beste regionale variant op basis van de stationslocatie",
+        "modeGlobal": "Globaal",
+        "modeGlobalHint": "Altijd het wereldwijde model gebruiken",
+        "pinLabel": "Een specifieke regio vastzetten",
+        "pinnedBadge": "Vastgezet",
+        "pinAction": "{region} vastzetten",
+        "switchToAuto": "Overschakelen naar automatisch",
+        "loading": "Regio's laden...",
+        "loadFailed": "Kan regiogegevens niet laden",
+        "why": {
+          "noLocation": "Automatische selectie vereist een stationslocatie. Stel deze in bij Hoofdinstellingen; tot die tijd wordt het globale model gebruikt.",
+          "outsideCoverage": "Uw locatie valt buiten de dekking van alle regionale modellen, dus wordt het globale model gebruikt.",
+          "ambiguous": "Uw locatie ligt dicht bij de grens tussen {region} en {runnerUp}. Automatische selectie gebruikt {region}; zet er een vast om de keuze expliciet te maken.",
+          "resolved": "Gedetecteerde regio op basis van uw locatie: {region}.",
+          "global": "Het globale model wordt altijd gebruikt, ongeacht de stationslocatie.",
+          "pinned": "Vastgezet op {region}. De stationslocatie heeft geen invloed op de modelselectie.",
+          "pinnedMismatch": "Uw locatie komt momenteel overeen met {resolved}.",
+          "pinnedUnknown": "De vastgezette regio \"{region}\" is niet beschikbaar in de huidige modelcatalogus. Modelfamilies vallen terug op uw locatie of het globale model."
+        }
+      },
       "variants": {
         "title": "Modelvariant",
         "recommended": "Aanbevolen",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -458,6 +458,11 @@
         "unavailableTitle": "ONNX Runtime niedostępny",
         "unavailableMessage": "ONNX Runtime {requiredVersion} jest wymagany dla {modelName}, ale nie został znaleziony. Zobacz przewodnik instalacji: {installGuideURL}"
       },
+      "region": {
+        "staleTitle": "Region modelu może być nieaktualny",
+        "staleMessage": "{modelName} jest zainstalowany dla {oldRegion}, ale Twoja nowa lokalizacja wskazuje na {newRegion}. Możesz zmienić warianty w galerii modeli w Ustawieniach.",
+        "staleGlobalMessage": "{modelName} jest zainstalowany dla {oldRegion}, ale Twoja nowa lokalizacja znajduje się poza jego zasięgiem. Możesz przełączyć się na wariant globalny w galerii modeli w Ustawieniach."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Bieżąca wartość: {value}% (próg: {threshold}%)",
@@ -5283,6 +5288,29 @@
     "gallery": {
       "title": "Galeria modeli",
       "description": "Zarządzaj modelami klasyfikatorów do detekcji ptaków i nietoperzy.",
+      "region": {
+        "title": "Region modelu",
+        "modeAuto": "Automatyczny",
+        "modeAutoHint": "Wybierz najlepszy wariant regionalny na podstawie lokalizacji stacji",
+        "modeGlobal": "Globalny",
+        "modeGlobalHint": "Zawsze używaj modelu ogólnoświatowego",
+        "pinLabel": "Przypnij określony region",
+        "pinnedBadge": "Przypięty",
+        "pinAction": "Przypnij {region}",
+        "switchToAuto": "Przełącz na automatyczny",
+        "loading": "Ładowanie regionów...",
+        "loadFailed": "Nie udało się załadować danych regionu",
+        "why": {
+          "noLocation": "Automatyczny wybór wymaga lokalizacji stacji. Ustaw ją w Ustawieniach Głównych; do tego czasu używany jest model globalny.",
+          "outsideCoverage": "Twoja lokalizacja znajduje się poza zasięgiem wszystkich modeli regionalnych, dlatego używany jest model globalny.",
+          "ambiguous": "Twoja lokalizacja znajduje się blisko granicy między {region} a {runnerUp}. Automatyczny wybór używa {region}; przypnij jeden z nich, aby dokonać jednoznacznego wyboru.",
+          "resolved": "Wykryty region na podstawie Twojej lokalizacji: {region}.",
+          "global": "Zawsze używany jest model globalny, niezależnie od lokalizacji stacji.",
+          "pinned": "Przypięto do {region}. Lokalizacja stacji nie wpływa na wybór modelu.",
+          "pinnedMismatch": "Twoja lokalizacja wskazuje obecnie na {resolved}.",
+          "pinnedUnknown": "Przypięty region \"{region}\" nie jest dostępny w bieżącym katalogu modeli. Rodziny modeli powracają do Twojej lokalizacji lub modelu globalnego."
+        }
+      },
       "variants": {
         "title": "Wariant modelu",
         "recommended": "Zalecane",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -458,6 +458,11 @@
         "unavailableTitle": "ONNX Runtime não disponível",
         "unavailableMessage": "O ONNX Runtime {requiredVersion} é necessário para {modelName}, mas não foi encontrado. Consulte o guia de instalação: {installGuideURL}"
       },
+      "region": {
+        "staleTitle": "A região do modelo pode estar desatualizada",
+        "staleMessage": "{modelName} está instalado para {oldRegion}, mas a sua nova localização corresponde a {newRegion}. Pode mudar de variante a partir da galeria de modelos nas Configurações.",
+        "staleGlobalMessage": "{modelName} está instalado para {oldRegion}, mas a sua nova localização está fora da sua cobertura. Pode mudar para a variante global a partir da galeria de modelos nas Configurações."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Valor atual: {value}% (limite: {threshold}%)",
@@ -5283,6 +5288,29 @@
     "gallery": {
       "title": "Galeria de modelos",
       "description": "Gerenciar modelos classificadores para detecção de aves e morcegos.",
+      "region": {
+        "title": "Região do modelo",
+        "modeAuto": "Automático",
+        "modeAutoHint": "Escolher a melhor variante regional a partir da localização da estação",
+        "modeGlobal": "Global",
+        "modeGlobalHint": "Usar sempre o modelo mundial",
+        "pinLabel": "Fixar uma região específica",
+        "pinnedBadge": "Fixado",
+        "pinAction": "Fixar {region}",
+        "switchToAuto": "Mudar para automático",
+        "loading": "Carregando regiões...",
+        "loadFailed": "Falha ao carregar dados da região",
+        "why": {
+          "noLocation": "A seleção automática requer a localização da estação. Defina-a nas Configurações principais; o modelo global será usado até lá.",
+          "outsideCoverage": "A sua localização está fora da cobertura de todos os modelos regionais, pelo que é utilizado o modelo global.",
+          "ambiguous": "A sua localização fica perto da fronteira entre {region} e {runnerUp}. A seleção automática utiliza {region}; fixe qualquer uma para tornar a escolha explícita.",
+          "resolved": "Região detetada a partir da sua localização: {region}.",
+          "global": "O modelo global é sempre utilizado, independentemente da localização da estação.",
+          "pinned": "Fixado em {region}. A localização da estação não afeta a seleção do modelo.",
+          "pinnedMismatch": "A sua localização corresponde atualmente a {resolved}.",
+          "pinnedUnknown": "A região fixada \"{region}\" não está disponível no catálogo de modelos atual. As famílias de modelos recorrem à sua localização ou ao modelo global."
+        }
+      },
       "variants": {
         "title": "Variante do modelo",
         "recommended": "Recomendado",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -458,6 +458,11 @@
         "unavailableTitle": "ONNX Runtime nie je k dispozícii",
         "unavailableMessage": "ONNX Runtime {requiredVersion} je vyžadovaný pre {modelName}, ale nebol nájdený. Pozrite si príručku inštalácie: {installGuideURL}"
       },
+      "region": {
+        "staleTitle": "Región modelu môže byť zastaraný",
+        "staleMessage": "{modelName} je nainštalovaný pre {oldRegion}, ale vaša nová poloha zodpovedá {newRegion}. Varianty môžete zmeniť v galérii modelov v Nastaveniach.",
+        "staleGlobalMessage": "{modelName} je nainštalovaný pre {oldRegion}, ale vaša nová poloha je mimo jeho pokrytia. Na globálny variant môžete prepnúť v galérii modelov v Nastaveniach."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Aktuálna hodnota: {value}% (prahová hodnota: {threshold}%)",
@@ -5283,6 +5288,29 @@
     "gallery": {
       "title": "Galéria modelov",
       "description": "Správa klasifikačných modelov pre detekciu vtákov a netopierov.",
+      "region": {
+        "title": "Región modelu",
+        "modeAuto": "Automaticky",
+        "modeAutoHint": "Vybrať najlepší regionálny variant podľa polohy stanice",
+        "modeGlobal": "Globálny",
+        "modeGlobalHint": "Vždy používať celosvetový model",
+        "pinLabel": "Pripnúť konkrétny región",
+        "pinnedBadge": "Pripnuté",
+        "pinAction": "Pripnúť {region}",
+        "switchToAuto": "Prepnúť na automatický",
+        "loading": "Načítavajú sa regióny...",
+        "loadFailed": "Nepodarilo sa načítať údaje o regióne",
+        "why": {
+          "noLocation": "Automatický výber vyžaduje polohu stanice. Nastavte ju v Hlavných nastaveniach; dovtedy sa používa globálny model.",
+          "outsideCoverage": "Vaša poloha je mimo pokrytia všetkých regionálnych modelov, preto sa používa globálny model.",
+          "ambiguous": "Vaša poloha je blízko hranice medzi {region} a {runnerUp}. Automatický výber používa {region}; pripnite ktorýkoľvek z nich na jednoznačnú voľbu.",
+          "resolved": "Zistený región z vašej polohy: {region}.",
+          "global": "Globálny model sa používa vždy bez ohľadu na polohu stanice.",
+          "pinned": "Pripnuté k {region}. Poloha stanice nemá vplyv na výber modelu.",
+          "pinnedMismatch": "Vaša poloha v súčasnosti zodpovedá {resolved}.",
+          "pinnedUnknown": "Pripnutý región \"{region}\" nie je dostupný v aktuálnom katalógu modelov. Rodiny modelov prejdú na vašu polohu alebo globálny model."
+        }
+      },
       "variants": {
         "title": "Variant modelu",
         "recommended": "Odporúčané",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -458,6 +458,11 @@
         "unavailableTitle": "ONNX Runtime inte tillgänglig",
         "unavailableMessage": "ONNX Runtime {requiredVersion} krävs för {modelName} men hittades inte. Se installationsguiden: {installGuideURL}"
       },
+      "region": {
+        "staleTitle": "Modellregionen kan vara föråldrad",
+        "staleMessage": "{modelName} är installerad för {oldRegion}, men din nya plats motsvarar {newRegion}. Du kan byta varianter från modellgalleriet i Inställningar.",
+        "staleGlobalMessage": "{modelName} är installerad för {oldRegion}, men din nya plats är utanför dess täckning. Du kan byta till den globala varianten från modellgalleriet i Inställningar."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Nuvarande värde: {value}% (tröskel: {threshold}%)",
@@ -5283,6 +5288,29 @@
     "gallery": {
       "title": "Modellgalleri",
       "description": "Hantera klassificeringsmodeller för fågel- och fladdermusdetektion.",
+      "region": {
+        "title": "Modellregion",
+        "modeAuto": "Automatisk",
+        "modeAutoHint": "Välj den bästa regionala varianten utifrån stationsplatsen",
+        "modeGlobal": "Global",
+        "modeGlobalHint": "Använd alltid den världsomspännande modellen",
+        "pinLabel": "Fäst en specifik region",
+        "pinnedBadge": "Fäst",
+        "pinAction": "Fäst {region}",
+        "switchToAuto": "Växla till automatisk",
+        "loading": "Laddar regioner...",
+        "loadFailed": "Kunde inte ladda regiondata",
+        "why": {
+          "noLocation": "Automatiskt val kräver en stationsplats. Ange den i Huvudinställningar; den globala modellen används fram tills dess.",
+          "outsideCoverage": "Din plats är utanför alla regionala modellers täckning, så den globala modellen används.",
+          "ambiguous": "Din plats är nära gränsen mellan {region} och {runnerUp}. Automatiskt val använder {region}; fäst någon av dem för att göra valet explicit.",
+          "resolved": "Identifierad region från din plats: {region}.",
+          "global": "Den globala modellen används alltid, oavsett stationsplats.",
+          "pinned": "Fäst till {region}. Stationsplatsen påverkar inte modellvalet.",
+          "pinnedMismatch": "Din plats motsvarar för närvarande {resolved}.",
+          "pinnedUnknown": "Den fästa regionen \"{region}\" är inte tillgänglig i den aktuella modellkatalogen. Modellfamiljer faller tillbaka på din plats eller den globala modellen."
+        }
+      },
       "variants": {
         "title": "Modellvariant",
         "recommended": "Rekommenderad",

--- a/internal/api/v2/models/models_regions.go
+++ b/internal/api/v2/models/models_regions.go
@@ -179,25 +179,11 @@ func (c *Handler) buildRegionFamilies(tables map[string]*region.Table, locationC
 			CatalogID:              e.ID,
 			Repo:                   e.HuggingFaceRepo,
 			Installed:              installed,
-			InstalledVariantRegion: variantRegion(e, installedVariantID),
+			InstalledVariantRegion: classifier.VariantRegion(e, installedVariantID),
 			Resolved:               resolved,
 		})
 	}
 	return families
-}
-
-// variantRegion returns the region slug of the entry's variant with the given
-// id, or "" when the id is empty (a flat entry) or the variant is global.
-func variantRegion(entry *classifier.CatalogEntry, variantID string) string {
-	if variantID == "" {
-		return ""
-	}
-	for i := range entry.Variants {
-		if entry.Variants[i].ID == variantID {
-			return entry.Variants[i].Region
-		}
-	}
-	return ""
 }
 
 // toRegionResolution maps a resolver Selection to its API form.

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -18,6 +18,8 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/audiocore/schedule"
+	"github.com/tphakala/birdnet-go/internal/classifier"
+	"github.com/tphakala/birdnet-go/internal/classifier/region"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/events"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
@@ -1567,12 +1569,12 @@ func validateModelRegionField(updateMap map[string]any) error {
 	if raw == nil {
 		return nil
 	}
-	region, ok := raw.(string)
+	value, ok := raw.(string)
 	if !ok {
 		return fmt.Errorf("modelRegion must be a string")
 	}
-	if region == "" || region == conf.ModelRegionAuto || region == conf.ModelRegionGlobal ||
-		conf.ModelRegionSlugPattern.MatchString(region) {
+	if value == "" || value == conf.ModelRegionAuto || value == conf.ModelRegionGlobal ||
+		conf.ModelRegionSlugPattern.MatchString(value) {
 		return nil
 	}
 	return fmt.Errorf("modelRegion must be 'auto', 'global', or a region slug")
@@ -2559,6 +2561,19 @@ func (c *Controller) handleSettingsChanges(oldSettings, currentSettings *conf.Se
 		profiling.ApplyRates(&currentSettings.Diagnostics.Profiling)
 	}
 
+	// Recommend-only region staleness check (rule D2): a station location change
+	// may make an installed regional model variant stale. Notify the user; never
+	// switch, install, or unload a model. Runs synchronously, like the toast sends
+	// above: the work is a cached region-table load, an in-memory snapshot of the
+	// installed models, a bounded geometry resolve, and a rate-limited in-memory
+	// notification. Placed after the fallible audio reconfig so an audio-reconfig
+	// failure rolls back before notifying; a later disk-save failure in the caller
+	// leaves a dismissible advisory, the same rare window the restart-required
+	// marking above already has.
+	if coordinatesChanged(oldSettings, currentSettings) {
+		c.notifyRegionStaleness(oldSettings, currentSettings)
+	}
+
 	// Trigger reconfigurations asynchronously.
 	// Capture debug flag from the settings snapshot so the goroutine never
 	// reloads settings (which may be republished by a concurrent update).
@@ -2699,12 +2714,63 @@ func rangeFilterSettingsChanged(oldSettings, currentSettings *conf.Settings) boo
 		return true
 	}
 
-	// Check for changes in BirdNET latitude and longitude
-	if oldSettings.BirdNET.Latitude != currentSettings.BirdNET.Latitude || oldSettings.BirdNET.Longitude != currentSettings.BirdNET.Longitude {
+	// Check for changes in BirdNET location (coordinates or the location-configured flag)
+	if coordinatesChanged(oldSettings, currentSettings) {
 		return true
 	}
 
 	return false
+}
+
+// coordinatesChanged reports whether the station location differs between two
+// settings snapshots: the latitude, the longitude, or the LocationConfigured
+// flag. The flag is included so that configuring a location for the first time
+// (LocationConfigured flips false->true while the coordinates may be unchanged)
+// still counts as a change, both for range-filter reload and for region
+// staleness detection.
+func coordinatesChanged(oldSettings, currentSettings *conf.Settings) bool {
+	return oldSettings.BirdNET.LocationConfigured != currentSettings.BirdNET.LocationConfigured ||
+		oldSettings.BirdNET.Latitude != currentSettings.BirdNET.Latitude ||
+		oldSettings.BirdNET.Longitude != currentSettings.BirdNET.Longitude
+}
+
+// notifyRegionStaleness runs the recommend-only region staleness detector after
+// a station location change and emits a bell notification for each installed
+// regional model variant that no longer matches the newly resolved region. Every
+// failure degrades to "no notification": it never blocks or fails the settings
+// save, and it never switches, installs, or unloads a model (rule D2).
+func (c *Controller) notifyRegionStaleness(oldSettings, currentSettings *conf.Settings) {
+	if c.ModelManager == nil {
+		return
+	}
+	tables, err := region.Tables()
+	if err != nil {
+		// Degrade to no notification. The embedded tables are immutable, so this
+		// only fails on a corrupt build (the golden region test guards that); log
+		// at debug so a real regression stays diagnosable.
+		c.LogDebugIfEnabled("region staleness check skipped: region tables unavailable", logger.Error(err))
+		return
+	}
+	installed := c.ModelManager.InstalledRegionalModels()
+	if len(installed) == 0 {
+		return
+	}
+	changes := classifier.DetectRegionStaleness(
+		tables,
+		installed,
+		currentSettings.BirdNET.ModelRegion,
+		classifier.RegionCoords{
+			Lat:        oldSettings.BirdNET.Latitude,
+			Lon:        oldSettings.BirdNET.Longitude,
+			Configured: oldSettings.BirdNET.LocationConfigured,
+		},
+		classifier.RegionCoords{
+			Lat:        currentSettings.BirdNET.Latitude,
+			Lon:        currentSettings.BirdNET.Longitude,
+			Configured: currentSettings.BirdNET.LocationConfigured,
+		},
+	)
+	classifier.NotifyRegionStaleness(changes)
 }
 
 // mqttSettingsChanged checks if MQTT settings have changed

--- a/internal/api/v2/settings_region_staleness_test.go
+++ b/internal/api/v2/settings_region_staleness_test.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/classifier"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// regionTestSettings builds a minimal settings snapshot carrying a station
+// location, for the coordinate-change and staleness tests.
+func regionTestSettings(lat, lon float64, configured bool) *conf.Settings {
+	s := &conf.Settings{}
+	s.BirdNET.Latitude = lat
+	s.BirdNET.Longitude = lon
+	s.BirdNET.LocationConfigured = configured
+	return s
+}
+
+// TestCoordinatesChanged covers the gate that drives both range-filter reload and
+// region staleness detection. The LocationConfigured leg matters: setting a
+// location for the first time can leave the numeric coordinates unchanged (e.g.
+// staying at 0,0), and that must still count as a change.
+func TestCoordinatesChanged(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		old  *conf.Settings
+		next *conf.Settings
+		want bool
+	}{
+		{"identical", regionTestSettings(60.17, 24.94, true), regionTestSettings(60.17, 24.94, true), false},
+		{"latitude changed", regionTestSettings(60.17, 24.94, true), regionTestSettings(4.61, 24.94, true), true},
+		{"longitude changed", regionTestSettings(60.17, 24.94, true), regionTestSettings(60.17, -74.08, true), true},
+		{"location configured first time, same coords", regionTestSettings(0, 0, false), regionTestSettings(0, 0, true), true},
+		{"both unconfigured, same coords", regionTestSettings(0, 0, false), regionTestSettings(0, 0, false), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, coordinatesChanged(tt.old, tt.next))
+		})
+	}
+}
+
+// TestController_notifyRegionStaleness_Guards exercises the Controller glue's
+// early-return guards (nil ModelManager, no installed regional models) so a
+// coordinate-changing save never panics when the gallery is empty. The firing
+// path (a stale installed regional variant) is covered by the pure detector and
+// notification tests in internal/classifier.
+func TestController_notifyRegionStaleness_Guards(t *testing.T) {
+	old := regionTestSettings(60.17, 24.94, true)  // Helsinki
+	next := regionTestSettings(4.61, -74.08, true) // Bogota
+
+	// Nil ModelManager: no-op, no panic.
+	c := &Controller{Core: &apicore.Core{}}
+	assert.NotPanics(t, func() { c.notifyRegionStaleness(old, next) })
+
+	// ModelManager set but nothing installed: InstalledRegionalModels is empty, so
+	// the detector is never invoked and no notification is emitted.
+	c.ModelManager = classifier.NewModelManager(t.TempDir(), nil, nil)
+	assert.NotPanics(t, func() { c.notifyRegionStaleness(old, next) })
+}

--- a/internal/classifier/model_catalog.go
+++ b/internal/classifier/model_catalog.go
@@ -674,6 +674,22 @@ func VariantSelectable(entry *CatalogEntry, variantID string) bool {
 	return ok
 }
 
+// VariantRegion returns the region slug of entry's variant with the given id, or
+// "" when the id is empty (a flat entry), or no variant matches (a hardware/global
+// variant, or an id dropped from the catalog). It is the shared lookup behind the
+// gallery region endpoint and the coordinate-change staleness detector.
+func VariantRegion(entry *CatalogEntry, variantID string) string {
+	if entry == nil || variantID == "" {
+		return ""
+	}
+	for i := range entry.Variants {
+		if entry.Variants[i].ID == variantID {
+			return entry.Variants[i].Region
+		}
+	}
+	return ""
+}
+
 // resolveVariantDefaults returns entries with each variant entry's Files
 // populated from its default variant, so every Files consumer sees the effective
 // default variant's files. Single-variant entries (no Variants) are returned

--- a/internal/classifier/region_staleness.go
+++ b/internal/classifier/region_staleness.go
@@ -1,0 +1,202 @@
+package classifier
+
+// region_staleness.go implements recommend-only detection of installed regional
+// model variants made stale by a station coordinate change, plus the bell
+// notification that surfaces them. Rule D2: it never installs, switches, or
+// unloads a model; it only tells the user a better regional slice exists so they
+// can switch it from the gallery themselves.
+
+import (
+	"fmt"
+
+	"github.com/tphakala/birdnet-go/internal/classifier/region"
+	"github.com/tphakala/birdnet-go/internal/notification"
+)
+
+// RegionStalenessChange records one installed regional model variant whose
+// region no longer matches what the newly saved coordinates resolve to.
+type RegionStalenessChange struct {
+	CatalogID string // catalog entry id of the installed model
+	ModelName string // user-facing model name, for the notification text
+	OldRegion string // display name of the installed variant's region
+	NewRegion string // display name of the newly resolved region; "" when the global model is now recommended
+}
+
+// InstalledModelRegion is a snapshot of one installed model used as detector
+// input. It is kept separate from the catalog types so DetectRegionStaleness
+// stays a pure function of its arguments and is table-testable without the
+// catalog or the model manager.
+type InstalledModelRegion struct {
+	CatalogID string // catalog entry id
+	ModelName string // user-facing model name
+	Repo      string // HuggingFace repo id, the key into the region tables
+	Region    string // installed variant's region slug; "" for a hardware/global variant
+}
+
+// RegionCoords is one coordinate snapshot for staleness detection. Configured
+// mirrors settings.BirdNET.LocationConfigured: coordinate resolution is only
+// meaningful once the user has set a station location.
+type RegionCoords struct {
+	Lat, Lon   float64
+	Configured bool
+}
+
+// DetectRegionStaleness reports which installed regional model variants are made
+// stale by a coordinate change. It is pure: given the region tables, the
+// installed-model snapshot, the ModelRegion mode, and the old and new
+// coordinates, it returns the stale variants without touching any global state.
+//
+// Recommend-only (rule D2): pinned and global modes are explicit user choices a
+// coordinate edit must not second-guess, so they never produce a change. A
+// variant is reported only when the new coordinates resolve to a region that
+// differs from BOTH the installed variant's region AND what the old coordinates
+// resolved to, which keeps a re-save, an in-region nudge, an A->B->A round trip,
+// and a pre-existing mismatch all silent.
+func DetectRegionStaleness(
+	tables map[string]*region.Table,
+	installed []InstalledModelRegion,
+	modelRegion string,
+	oldCoords, newCoords RegionCoords,
+) []RegionStalenessChange {
+	// Pinned or global mode: the user pinned a region (or forced global), so a
+	// coordinate change carries no recommendation. This intentionally silences
+	// even a pinned-fallback family (a pinned slug absent from that family's own
+	// table, where coordinates would otherwise drive selection): the explicit pin
+	// still wins over an automatic recommendation.
+	if modelRegion != region.ModeAuto && modelRegion != "" {
+		return nil
+	}
+	// Nothing to resolve against until a location is configured.
+	if !newCoords.Configured {
+		return nil
+	}
+
+	var changes []RegionStalenessChange
+	for i := range installed {
+		m := &installed[i]
+		if m.Region == "" {
+			continue // hardware/global variant: no regional slice to go stale
+		}
+		tbl, ok := tables[m.Repo]
+		if !ok || tbl == nil {
+			continue // family without a region table
+		}
+		newSel := region.Select(tbl, region.ModeAuto, newCoords.Lat, newCoords.Lon)
+		if newSel.Slug == m.Region {
+			continue // the new location still matches the installed slice
+		}
+		// Spam guard: suppress only a pre-existing mismatch, i.e. when a
+		// previously-configured location already resolved to the same region the
+		// new one does. It is gated on oldCoords.Configured so that a first-time
+		// location set is never silenced: without the gate, an unconfigured old
+		// location (oldSlug "") and a new location that resolves to the global
+		// model (Slug "") would collide and wrongly suppress the "your installed
+		// regional model no longer covers your location" recommendation.
+		if oldCoords.Configured {
+			oldSlug := region.Select(tbl, region.ModeAuto, oldCoords.Lat, oldCoords.Lon).Slug
+			if newSel.Slug == oldSlug {
+				continue
+			}
+		}
+		changes = append(changes, RegionStalenessChange{
+			CatalogID: m.CatalogID,
+			ModelName: m.ModelName,
+			OldRegion: regionDisplayName(tbl, m.Region),
+			NewRegion: regionDisplayName(tbl, newSel.Slug),
+		})
+	}
+	return changes
+}
+
+// regionDisplayName maps a region slug to its display name in tbl, falling back
+// to the slug itself when the slug is unknown. An empty slug (the global model)
+// stays empty so callers can branch on "no region".
+func regionDisplayName(tbl *region.Table, slug string) string {
+	if slug == "" || tbl == nil {
+		return slug
+	}
+	if r, ok := tbl.Regions[slug]; ok && r.Name != "" {
+		return r.Name
+	}
+	return slug
+}
+
+// NotifyRegionStaleness emits one persistent bell notification per change,
+// mirroring emitORTUnavailableNotification. It is nil-safe when the notification
+// service is not initialized. Recommend-only: it never installs, switches, or
+// unloads a model.
+func NotifyRegionStaleness(changes []RegionStalenessChange) {
+	if len(changes) == 0 {
+		return
+	}
+	svc := notification.GetService()
+	if svc == nil {
+		return
+	}
+	for i := range changes {
+		ch := &changes[i]
+		messageKey := notification.MsgModelRegionStaleMessage
+		args := map[string]any{
+			"modelName": ch.ModelName,
+			"oldRegion": ch.OldRegion,
+			"newRegion": ch.NewRegion,
+		}
+		fallbackMsg := fmt.Sprintf(
+			"%s is installed for %s, but your new location resolves to %s. You can switch variants from the model gallery in Settings.",
+			ch.ModelName, ch.OldRegion, ch.NewRegion)
+		// When the new location falls outside every regional tile the recommendation
+		// is the global variant; a dedicated message avoids rendering "resolves to "
+		// with an empty region name.
+		if ch.NewRegion == "" {
+			messageKey = notification.MsgModelRegionStaleGlobalMessage
+			args = map[string]any{
+				"modelName": ch.ModelName,
+				"oldRegion": ch.OldRegion,
+			}
+			fallbackMsg = fmt.Sprintf(
+				"%s is installed for %s, but your new location is outside its coverage. You can switch to the global variant from the model gallery in Settings.",
+				ch.ModelName, ch.OldRegion)
+		}
+		notif := notification.NewNotification(
+			notification.TypeWarning,
+			notification.PriorityMedium,
+			"Model region may be outdated",
+			fallbackMsg,
+		).
+			WithComponent("classifier").
+			WithTitleKey(notification.MsgModelRegionStaleTitle, nil).
+			WithMessageKey(messageKey, args).
+			WithDeliveryTarget("bell")
+		_ = svc.CreateWithMetadata(notif)
+	}
+}
+
+// InstalledRegionalModels snapshots the visible installed models and the region
+// slug of their installed variant ("" for hardware/global variants), as input
+// for DetectRegionStaleness. It reads catalog and manager state, so it is not
+// pure; the detector it feeds is. Hidden entries are excluded (VisibleCatalog),
+// matching the region endpoint's family scope, so a hidden installed model never
+// triggers a staleness notification.
+func (mm *ModelManager) InstalledRegionalModels() []InstalledModelRegion {
+	visible := VisibleCatalog()
+	out := make([]InstalledModelRegion, 0, len(visible))
+	// Hold one read lock for the whole scan rather than reacquiring it per entry
+	// through InstalledVariantID. VisibleCatalog already released the catalog lock
+	// before returning its copy, so there is no lock-ordering hazard here.
+	mm.mu.RLock()
+	defer mm.mu.RUnlock()
+	for i := range visible {
+		e := &visible[i]
+		im, ok := mm.installed[e.ID]
+		if !ok {
+			continue // not installed
+		}
+		out = append(out, InstalledModelRegion{
+			CatalogID: e.ID,
+			ModelName: e.Name,
+			Repo:      e.HuggingFaceRepo,
+			Region:    VariantRegion(e, im.VariantID),
+		})
+	}
+	return out
+}

--- a/internal/classifier/region_staleness_test.go
+++ b/internal/classifier/region_staleness_test.go
@@ -1,0 +1,321 @@
+package classifier
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/classifier/region"
+	"github.com/tphakala/birdnet-go/internal/notification"
+)
+
+// perchRepo is the HuggingFace repo whose embedded region table the detector
+// tests resolve against. Using the real shipped snapshot (rather than synthetic
+// boxes) keeps the geometry anchors honest.
+const perchRepo = "tphakala/Perch-v2-Models"
+
+// Coordinate anchors, verified against the embedded Perch snapshot.
+const (
+	helsinkiLat, helsinkiLon = 60.17, 24.94  // -> nordic
+	osloLat, osloLon         = 59.91, 10.75  // -> nordic
+	bogotaLat, bogotaLon     = 4.61, -74.08  // -> andes
+	madridLat, madridLon     = 40.4, -3.7    // -> iberia
+	oceanLat, oceanLon       = -40.0, -130.0 // South Pacific -> no tile (global)
+)
+
+func perchTables(t *testing.T) map[string]*region.Table {
+	t.Helper()
+	tbl, ok := region.TableForRepo(perchRepo)
+	require.True(t, ok, "embedded Perch region table must be present")
+	require.NotNil(t, tbl)
+	return map[string]*region.Table{perchRepo: tbl}
+}
+
+// installed builds a one-model snapshot on the Perch family with the given
+// installed variant region slug.
+func installed(regionSlug string) []InstalledModelRegion {
+	return []InstalledModelRegion{{
+		CatalogID: "perch-v2",
+		ModelName: "Perch v2",
+		Repo:      perchRepo,
+		Region:    regionSlug,
+	}}
+}
+
+func configured(lat, lon float64) RegionCoords {
+	return RegionCoords{Lat: lat, Lon: lon, Configured: true}
+}
+
+// TestDetectRegionStaleness_ResolutionAnchors documents the city->region anchors
+// the other cases rely on, so a snapshot rebanding fails here first with a clear
+// message rather than as a confusing miss elsewhere.
+func TestDetectRegionStaleness_ResolutionAnchors(t *testing.T) {
+	t.Parallel()
+	tbl, ok := region.TableForRepo(perchRepo)
+	require.True(t, ok)
+	assert.Equal(t, "nordic", region.Select(tbl, region.ModeAuto, helsinkiLat, helsinkiLon).Slug, "Helsinki")
+	assert.Equal(t, "nordic", region.Select(tbl, region.ModeAuto, osloLat, osloLon).Slug, "Oslo")
+	assert.Equal(t, "andes", region.Select(tbl, region.ModeAuto, bogotaLat, bogotaLon).Slug, "Bogota")
+	assert.Equal(t, "iberia", region.Select(tbl, region.ModeAuto, madridLat, madridLon).Slug, "Madrid")
+	assert.Empty(t, region.Select(tbl, region.ModeAuto, oceanLat, oceanLon).Slug, "South Pacific -> global")
+}
+
+func TestDetectRegionStaleness(t *testing.T) {
+	t.Parallel()
+	tables := perchTables(t)
+
+	tests := []struct {
+		name        string
+		installed   []InstalledModelRegion
+		modelRegion string // passed verbatim; "" exercises the empty-as-auto contract
+		old         RegionCoords
+		next        RegionCoords
+		wantCount   int
+		wantOld     string // display name, checked when wantCount == 1
+		wantNew     string
+	}{
+		{
+			name:        "coordinate flip triggers",
+			installed:   installed("nordic"),
+			modelRegion: region.ModeAuto,
+			old:         configured(helsinkiLat, helsinkiLon),
+			next:        configured(bogotaLat, bogotaLon),
+			wantCount:   1, wantOld: "Nordic", wantNew: "Andes",
+		},
+		{
+			name:        "resolves back to installed region",
+			installed:   installed("nordic"),
+			modelRegion: region.ModeAuto,
+			old:         configured(bogotaLat, bogotaLon), // was andes
+			next:        configured(helsinkiLat, helsinkiLon),
+			wantCount:   0,
+		},
+		{
+			name:        "pre-existing mismatch, resolution unchanged",
+			installed:   installed("iberia"), // user is in the nordic area with iberia installed
+			modelRegion: region.ModeAuto,
+			old:         configured(helsinkiLat, helsinkiLon),
+			next:        configured(osloLat, osloLon), // still nordic
+			wantCount:   0,
+		},
+		{
+			name:        "pinned mode never triggers",
+			installed:   installed("nordic"),
+			modelRegion: "iberia",
+			old:         configured(helsinkiLat, helsinkiLon),
+			next:        configured(bogotaLat, bogotaLon),
+			wantCount:   0,
+		},
+		{
+			name:        "global mode never triggers",
+			installed:   installed("nordic"),
+			modelRegion: region.ModeGlobal,
+			old:         configured(helsinkiLat, helsinkiLon),
+			next:        configured(bogotaLat, bogotaLon),
+			wantCount:   0,
+		},
+		{
+			name:        "empty mode treated as auto",
+			installed:   installed("nordic"),
+			modelRegion: "", // the back-compat contract: "" behaves like auto
+			old:         configured(helsinkiLat, helsinkiLon),
+			next:        configured(bogotaLat, bogotaLon),
+			wantCount:   1, wantOld: "Nordic", wantNew: "Andes",
+		},
+		{
+			name:        "hardware/global variant skipped",
+			installed:   installed(""), // empty region slug
+			modelRegion: region.ModeAuto,
+			old:         configured(helsinkiLat, helsinkiLon),
+			next:        configured(bogotaLat, bogotaLon),
+			wantCount:   0,
+		},
+		{
+			name: "family without table skipped",
+			installed: []InstalledModelRegion{{
+				CatalogID: "unknown", ModelName: "Unknown", Repo: "tphakala/Not-A-Real-Repo", Region: "nordic",
+			}},
+			modelRegion: region.ModeAuto,
+			old:         configured(helsinkiLat, helsinkiLon),
+			next:        configured(bogotaLat, bogotaLon),
+			wantCount:   0,
+		},
+		{
+			name:        "new location unconfigured skips",
+			installed:   installed("nordic"),
+			modelRegion: region.ModeAuto,
+			old:         configured(helsinkiLat, helsinkiLon),
+			next:        RegionCoords{Lat: bogotaLat, Lon: bogotaLon, Configured: false},
+			wantCount:   0,
+		},
+		{
+			name:        "first-time location set fires",
+			installed:   installed("iberia"),
+			modelRegion: region.ModeAuto,
+			old:         RegionCoords{Configured: false},
+			next:        configured(helsinkiLat, helsinkiLon), // resolves nordic, differs from iberia
+			wantCount:   1, wantOld: "Iberia", wantNew: "Nordic",
+		},
+		{
+			name:        "first-time location set resolving to global fires as region-to-global",
+			installed:   installed("iberia"),
+			modelRegion: region.ModeAuto,
+			old:         RegionCoords{Configured: false},
+			next:        configured(oceanLat, oceanLon),    // outside every tile; iberia no longer covers it
+			wantCount:   1, wantOld: "Iberia", wantNew: "", // NewRegion "" => global message
+		},
+		{
+			name:        "configured region to global fires as region-to-global",
+			installed:   installed("nordic"),
+			modelRegion: region.ModeAuto,
+			old:         configured(helsinkiLat, helsinkiLon),
+			next:        configured(oceanLat, oceanLon),
+			wantCount:   1, wantOld: "Nordic", wantNew: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			changes := DetectRegionStaleness(tables, tt.installed, tt.modelRegion, tt.old, tt.next)
+			require.Len(t, changes, tt.wantCount)
+			if tt.wantCount == 1 {
+				assert.Equal(t, tt.wantOld, changes[0].OldRegion)
+				assert.Equal(t, tt.wantNew, changes[0].NewRegion)
+			}
+		})
+	}
+}
+
+// TestDetectRegionStaleness_MultipleFamiliesIndependent verifies each installed
+// model is judged on its own, and one flipping does not drag the others in.
+func TestDetectRegionStaleness_MultipleFamiliesIndependent(t *testing.T) {
+	t.Parallel()
+	tables := perchTables(t)
+	in := []InstalledModelRegion{
+		{CatalogID: "a", ModelName: "A", Repo: perchRepo, Region: "nordic"}, // Helsinki->Bogota flips nordic->andes
+		{CatalogID: "b", ModelName: "B", Repo: perchRepo, Region: "andes"},  // Bogota still resolves andes: no change
+	}
+	changes := DetectRegionStaleness(tables, in, region.ModeAuto,
+		configured(helsinkiLat, helsinkiLon), configured(bogotaLat, bogotaLon))
+	require.Len(t, changes, 1)
+	assert.Equal(t, "a", changes[0].CatalogID)
+	assert.Equal(t, "Nordic", changes[0].OldRegion)
+	assert.Equal(t, "Andes", changes[0].NewRegion)
+}
+
+// TestModelManager_InstalledRegionalModels verifies the snapshot maps an
+// installed entry's fields through and skips uninstalled ones. A hardware variant
+// (fp32) carries no regional slug, so Region is empty; the detector then treats
+// it as non-regional.
+func TestModelManager_InstalledRegionalModels(t *testing.T) {
+	t.Parallel()
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok, "expected perch-v2 catalog entry to exist")
+	require.NotEmpty(t, entry.Variants, "perch-v2 must be a variant entry")
+
+	mm := NewModelManager(t.TempDir(), nil, nil)
+	mm.installed[entry.ID] = InstalledModel{CatalogID: entry.ID, VariantID: "fp32"}
+
+	got := mm.InstalledRegionalModels()
+
+	var perch *InstalledModelRegion
+	for i := range got {
+		assert.True(t, mm.IsInstalled(got[i].CatalogID), "only installed models should be listed")
+		if got[i].CatalogID == entry.ID {
+			perch = &got[i]
+		}
+	}
+	require.NotNil(t, perch, "installed perch-v2 should be listed")
+	assert.Equal(t, entry.Name, perch.ModelName)
+	assert.Equal(t, entry.HuggingFaceRepo, perch.Repo)
+	assert.Empty(t, perch.Region, "a hardware variant carries no regional slug")
+}
+
+// TestVariantRegion covers the shared catalog helper's branches, including the
+// nil-entry and unknown-id guards the detector snapshot relies on.
+func TestVariantRegion(t *testing.T) {
+	t.Parallel()
+	entry := &CatalogEntry{Variants: []CatalogVariant{
+		{ID: "fp32@nordic", Region: "nordic"},
+		{ID: "fp32", Region: ""},
+	}}
+	assert.Equal(t, "nordic", VariantRegion(entry, "fp32@nordic"), "regional variant returns its slug")
+	assert.Empty(t, VariantRegion(entry, "fp32"), "hardware variant has no region")
+	assert.Empty(t, VariantRegion(entry, "unknown"), "unknown id returns empty")
+	assert.Empty(t, VariantRegion(entry, ""), "empty id (flat entry) returns empty")
+	assert.Empty(t, VariantRegion(nil, "fp32@nordic"), "nil entry is safe")
+}
+
+// TestRegionDisplayName covers the slug-to-name mapping, including the
+// unknown-slug and nil-table fallbacks that the anchors above never reach.
+func TestRegionDisplayName(t *testing.T) {
+	t.Parallel()
+	tbl, ok := region.TableForRepo(perchRepo)
+	require.True(t, ok)
+	assert.Equal(t, "Nordic", regionDisplayName(tbl, "nordic"), "known slug maps to its name")
+	assert.Equal(t, "no-such-slug", regionDisplayName(tbl, "no-such-slug"), "unknown slug falls back to itself")
+	assert.Empty(t, regionDisplayName(tbl, ""), "empty slug stays empty (global)")
+	assert.Equal(t, "nordic", regionDisplayName(nil, "nordic"), "nil table falls back to the slug")
+}
+
+func TestNotifyRegionStaleness_NilChangesAndNilServiceSafe(t *testing.T) {
+	// Pin the precondition: this test only proves the nil-service path is safe when
+	// the process-global service is actually nil. It runs before EmitsPerChange
+	// (which initializes the singleton) in source order; assert it rather than rely
+	// on ordering so a -shuffle run fails loudly instead of passing vacuously.
+	require.Nil(t, notification.GetService(), "nil-service test requires an uninitialized notification service")
+
+	assert.NotPanics(t, func() { NotifyRegionStaleness(nil) })
+	assert.NotPanics(t, func() {
+		NotifyRegionStaleness([]RegionStalenessChange{
+			{CatalogID: "perch-v2", ModelName: "Perch v2", OldRegion: "Nordic", NewRegion: "Andes"},
+		})
+	})
+}
+
+// TestNotifyRegionStaleness_EmitsPerChange checks the two message-key branches
+// against a real service. It initializes the process-global service (once), so
+// it filters emitted notifications by the region title key to stay robust to any
+// other notifications present.
+func TestNotifyRegionStaleness_EmitsPerChange(t *testing.T) {
+	notification.Initialize(notification.DefaultServiceConfig())
+	svc := notification.GetService()
+	require.NotNil(t, svc)
+	// Stop the service's cleanup goroutine so the package goleak check stays clean;
+	// this test is the only one that starts the process-global notification service.
+	t.Cleanup(svc.Stop)
+
+	NotifyRegionStaleness([]RegionStalenessChange{
+		{CatalogID: "perch-v2", ModelName: "Perch v2", OldRegion: "Nordic", NewRegion: "Andes"},
+		{CatalogID: "perch-v2", ModelName: "Perch v2", OldRegion: "Nordic", NewRegion: ""},
+	})
+
+	list, err := svc.List(nil)
+	require.NoError(t, err)
+
+	var regionMsg, globalMsg, allBell bool
+	count := 0
+	allBell = true
+	for _, n := range list {
+		if n.TitleKey != notification.MsgModelRegionStaleTitle {
+			continue
+		}
+		count++
+		switch n.MessageKey {
+		case notification.MsgModelRegionStaleMessage:
+			regionMsg = true
+		case notification.MsgModelRegionStaleGlobalMessage:
+			globalMsg = true
+		}
+		if n.Type != notification.TypeWarning || n.Priority != notification.PriorityMedium {
+			allBell = false
+		}
+	}
+	assert.GreaterOrEqual(t, count, 2, "both staleness notifications should be stored")
+	assert.True(t, regionMsg, "region-to-region change should use the region message key")
+	assert.True(t, globalMsg, "region-to-global change should use the global message key")
+	assert.True(t, allBell, "notifications should be warning/medium")
+}

--- a/internal/notification/message_keys.go
+++ b/internal/notification/message_keys.go
@@ -172,4 +172,10 @@ const (
 	// ONNX Runtime availability notifications
 	MsgORTUnavailableTitle   = "notifications.content.ort.unavailableTitle"
 	MsgORTUnavailableMessage = "notifications.content.ort.unavailableMessage"
+
+	// Model region staleness notifications (coordinate change makes an installed
+	// regional model variant stale; recommend-only, never auto-switches a model)
+	MsgModelRegionStaleTitle         = "notifications.content.region.staleTitle"
+	MsgModelRegionStaleMessage       = "notifications.content.region.staleMessage"
+	MsgModelRegionStaleGlobalMessage = "notifications.content.region.staleGlobalMessage"
 )


### PR DESCRIPTION
## Summary

This ships the user-facing half of region-specific model selection in the gallery, following the earlier PR that landed the resolver, the `BirdNET.ModelRegion` setting, and `GET /api/v2/models/regions`. It is recommend-only: nothing here installs, switches, or unloads a model.

**Backend.** A new pure `DetectRegionStaleness` detector (`internal/classifier/region_staleness.go`) reports when a station-location change leaves an installed regional model variant covering the wrong area. Its spam guard fires only on a genuine coordinate-driven region change (including a first-time location set) and stays quiet on re-saves, in-region nudges, A→B→A round trips, and pre-existing mismatches. A thin `NotifyRegionStaleness` hook emits one recommend-only bell notification per change. The detector is wired into `handleSettingsChanges` on a location change, `coordinatesChanged` is extended to cover the location-configured flag, and `VariantRegion` is promoted to a shared catalog helper (deduping the models handler).

**Frontend.** A new `ModelRegionSelector.svelte` presents Automatic / Global / pinned-region choices with a why-line that explains the current resolution and one-click pin shortcuts for the ambiguous and unknown-pin cases. It adds the mirrored TypeScript types, a `fetchModelRegions` API client, the `modelRegion` setting on the store, and a full 15-locale i18n sweep.

## Test plan

- [ ] `go test -race ./internal/classifier/... ./internal/api/v2/...`
- [ ] `npm run check:all` plus the frontend Vitest suite
- [ ] In the model gallery, set a station location and confirm the region why-line updates; then move the location so an installed regional model no longer covers it and confirm the recommend-only bell notification appears.