### PR TITLE
feat(models): variant RAM floors, benchmarks, and BirdNET v3.0 gallery availability

### DIFF
--- a/internal/classifier/birdnet_v3_onnx_test.go
+++ b/internal/classifier/birdnet_v3_onnx_test.go
@@ -117,8 +117,8 @@ func TestBirdNETV3_LoaderRegistered(t *testing.T) {
 	assert.True(t, ok, "BirdNET v3.0 must have an OpenVINO-capable secondary builder")
 }
 
-// TestBirdNETV3_CatalogEntry guards the catalog entry shape: correct repo, hidden
-// during preview, and the expected model/labels/geomodel/taxonomy companion files.
+// TestBirdNETV3_CatalogEntry guards the catalog entry shape: correct repo, visible
+// in the gallery, and the expected model/labels/geomodel/taxonomy companion files.
 func TestBirdNETV3_CatalogEntry(t *testing.T) {
 	t.Parallel()
 
@@ -127,7 +127,7 @@ func TestBirdNETV3_CatalogEntry(t *testing.T) {
 
 	assert.Equal(t, RegistryIDBirdNETV3, entry.RegistryID)
 	assert.Equal(t, "tphakala/BirdNET-v3.0-Models", entry.HuggingFaceRepo)
-	assert.True(t, entry.Hidden, "v3.0 stays hidden until GA (private HF repo, no final checksums)")
+	assert.False(t, entry.Hidden, "v3.0 is visible in the gallery (public HF repo, pinned checksums, RAM-floor gated)")
 	assert.True(t, entry.RequiresONNX)
 
 	roles := map[string]int{}

--- a/internal/classifier/model_catalog.go
+++ b/internal/classifier/model_catalog.go
@@ -129,26 +129,28 @@ var EmbeddedCatalog = []CatalogEntry{
 	// (EfficientNetV2-S backbone, 11,560 species, 32kHz/5s), paired with the v3.0
 	// geomodel range filter. The HuggingFace repo is public and the file
 	// checksums/sizes below are pinned from it, so this entry's download path is
-	// integrity-checked like every other entry. Kept Hidden until GA and until the
-	// gallery can offer the hardware and regional variant selection a model this
-	// heavy needs (the global fp32 file is 557 MB). Hidden entries are rejected by
-	// the install API (internal/api/v2/models.InstallModel), so this is catalog
-	// metadata only. The backend loader is fully functional, so v3.0 can still be
-	// enabled via config (models.enabled + birdnetv3 model/label paths) for evaluation.
+	// integrity-checked like every other entry. Now visible in the gallery: the
+	// hardware recommender (internal/classifier/recommend) plus the per-variant
+	// MinRAMMB floors below keep the heavy global fp32 (557 MB) and fp16 (279 MB)
+	// builds off hosts that cannot run them. Only the two global variants ship
+	// today; regional tiles remain a later generator pass. The entry stays
+	// labelled a developer preview so users know it is not the GA build. The
+	// backend loader is fully functional and v3.0 can also be enabled via config
+	// (models.enabled + birdnetv3 model/label paths).
 	{
 		ID:              "birdnet-v3.0",
 		Name:            "BirdNET v3.0",
-		Description:     "Global wildlife classifier using the BirdNET v3.0 architecture (11,560 species, birds and other fauna; scientific and common names)",
+		Description:     "Developer preview of the BirdNET v3.0 global wildlife classifier (11,560 species, birds and other fauna; scientific and common names). Not the GA build.",
 		Author:          "Cornell Lab of Ornithology & Chemnitz University of Technology",
 		License:         "CC-BY-SA-4.0",
-		CommercialUse:   false,
+		CommercialUse:   true,
 		Category:        CategoryWildlife,
 		Region:          "",
 		SpeciesCount:    11560,
 		Version:         "3.0",
 		GeomodelVersion: "v3",
 		RegistryID:      RegistryIDBirdNETV3,
-		Hidden:          true,
+		Hidden:          false,
 		RequiresONNX:    true,
 		UpstreamURL:     "https://github.com/birdnet-team/BirdNET-Analyzer",
 		HuggingFaceRepo: "tphakala/BirdNET-v3.0-Models",
@@ -164,12 +166,22 @@ var EmbeddedCatalog = []CatalogEntry{
 				Precision:    "fp32",
 				SpeciesCount: 11560,
 				Default:      true,
+				// RAM floor and benchmarks sourced from the acoustic-models
+				// BirdNET-v3.0-Models.models.json manifest.
+				Requirements: VariantRequirements{MinRAMMB: 800},
 				Backends: map[string]BackendSupport{
 					"onnxruntime-cpu": {Supported: true, Recommended: true},
 					"openvino-cpu":    {Supported: true, Recommended: true},
 					"openvino-gpu":    {Supported: true},
 					"cuda":            {Supported: true, Recommended: true},
 					"tensorrt":        {Supported: true, Recommended: true},
+				},
+				Benchmarks: []Benchmark{
+					{Device: "rpi5-a76", Backend: "openvino-cpu", LatencyMs: 168},
+					{Device: "rpi5-a76", Backend: "onnxruntime-cpu", LatencyMs: 363, RSSMB: 685},
+					{Device: "rpi4b-a72", Backend: "onnxruntime-cpu", LatencyMs: 874, RSSMB: 688},
+					{Device: "x86-i7-1260P", Backend: "onnxruntime-cpu", LatencyMs: 70},
+					{Device: "x86-i7-1260P", Backend: "openvino-gpu", LatencyMs: 95},
 				},
 				Files: slices.Concat([]CatalogFile{
 					{RemotePath: "full/birdnet-v3.0-preview3.1-fp32-b1.onnx", LocalName: "birdnet_v3.0_fp32.onnx", Role: RoleModel, SHA256: "05535c3ef6ce3f9e523706dd3e144cb6db96bc202e9047f4973961256acbf997", SizeBytes: 557212256},
@@ -179,12 +191,20 @@ var EmbeddedCatalog = []CatalogEntry{
 				ID:           "fp16",
 				Precision:    "fp16",
 				SpeciesCount: 11560,
+				// RAM floor, exclude token and benchmarks sourced from the
+				// acoustic-models BirdNET-v3.0-Models.models.json manifest.
+				Requirements: VariantRequirements{MinRAMMB: 1100, Excludes: []string{"openvino-gpu-intel-gen12"}},
 				Backends: map[string]BackendSupport{
 					"openvino-gpu":    {Supported: true, Recommended: true},
 					"cuda":            {Supported: true, Recommended: true},
 					"tensorrt":        {Supported: true, Recommended: true},
 					"onnxruntime-cpu": {Supported: true},
 					"openvino-cpu":    {Supported: true},
+				},
+				Benchmarks: []Benchmark{
+					{Device: "rpi5-a76", Backend: "onnxruntime-cpu", LatencyMs: 381, RSSMB: 480},
+					{Device: "rpi4b-a72", Backend: "onnxruntime-cpu", LatencyMs: 887, RSSMB: 929},
+					{Device: "x86-i7-1260P", Backend: "openvino-gpu", LatencyMs: 81},
 				},
 				Files: slices.Concat([]CatalogFile{
 					{RemotePath: "full/birdnet-v3.0-preview3.1-fp16-b1.onnx", LocalName: "birdnet_v3.0_fp16.onnx", Role: RoleModel, SHA256: "18fc932b9ac7478720ac8ca9077694b6ea62fb00675aa488e77b15e722244e67", SizeBytes: 278787557},
@@ -221,6 +241,9 @@ var EmbeddedCatalog = []CatalogEntry{
 				Precision:    "fp32",
 				SpeciesCount: 14795,
 				Default:      true,
+				// RAM floors sourced from the acoustic-models
+				// Perch-v2-Models.models.json manifest.
+				Requirements: VariantRequirements{MinRAMMB: 700},
 				Backends: map[string]BackendSupport{
 					"onnxruntime-cpu": {Supported: true, Recommended: true},
 					"cuda":            {Supported: true, Recommended: true},
@@ -234,6 +257,7 @@ var EmbeddedCatalog = []CatalogEntry{
 				ID:           "no-dft-fp32",
 				Precision:    "fp32",
 				SpeciesCount: 14795,
+				Requirements: VariantRequirements{MinRAMMB: 750},
 				Backends: map[string]BackendSupport{
 					"openvino-cpu":    {Supported: true, Recommended: true},
 					"openvino-gpu":    {Supported: true, Recommended: true},
@@ -249,7 +273,7 @@ var EmbeddedCatalog = []CatalogEntry{
 				ID:           "int8-arm",
 				Precision:    "int8",
 				SpeciesCount: 14795,
-				Requirements: VariantRequirements{Arch: []string{"aarch64"}},
+				Requirements: VariantRequirements{Arch: []string{"aarch64"}, MinRAMMB: 350},
 				Backends: map[string]BackendSupport{
 					"onnxruntime-cpu": {Supported: true, Recommended: true},
 				},
@@ -328,6 +352,9 @@ var EmbeddedCatalog = []CatalogEntry{
 				ID:        "fp32-dfttrunc",
 				Precision: "fp32",
 				Default:   true,
+				// RAM floors sourced from the acoustic-models
+				// BirdNET-v2.4.models.json manifest.
+				Requirements: VariantRequirements{MinRAMMB: 250},
 				Backends: map[string]BackendSupport{
 					"onnxruntime-cpu": {Supported: true, Recommended: true},
 					"openvino-cpu":    {Supported: true, Recommended: true},
@@ -342,7 +369,7 @@ var EmbeddedCatalog = []CatalogEntry{
 			{
 				ID:           "int8-arm-dfttrunc",
 				Precision:    "int8",
-				Requirements: VariantRequirements{Arch: []string{"aarch64"}},
+				Requirements: VariantRequirements{Arch: []string{"aarch64"}, MinRAMMB: 250},
 				Backends: map[string]BackendSupport{
 					"onnxruntime-cpu": {Supported: true, Recommended: true},
 					"openvino-cpu":    {Supported: true},

--- a/internal/classifier/model_catalog_test.go
+++ b/internal/classifier/model_catalog_test.go
@@ -476,6 +476,7 @@ func TestEmbeddedCatalog_VariantRequirementsPopulated(t *testing.T) {
 	}
 	for _, w := range benchWant {
 		t.Run(w.variantID+"/"+w.device+"/"+w.backend, func(t *testing.T) {
+			t.Parallel()
 			b, ok := findBenchmark(variantByID(t, &v30, w.variantID), w.device, w.backend)
 			require.Truef(t, ok, "%s missing benchmark %s/%s", w.variantID, w.device, w.backend)
 			assert.Equalf(t, w.latencyMs, b.LatencyMs, "%s %s/%s latency", w.variantID, w.device, w.backend)

--- a/internal/classifier/model_catalog_test.go
+++ b/internal/classifier/model_catalog_test.go
@@ -285,7 +285,7 @@ func TestCatalogByCategory(t *testing.T) {
 	}
 
 	// Verify expected counts
-	assert.Len(t, grouped[CategoryWildlife], 1, "expected 1 visible wildlife catalog entry")
+	assert.Len(t, grouped[CategoryWildlife], 2, "expected 2 visible wildlife catalog entries (perch-v2, birdnet-v3.0)")
 	assert.Empty(t, grouped[CategoryBird], "expected 0 visible bird catalog entries")
 	assert.Len(t, grouped[CategoryGeomodel], 1, "expected 1 visible geomodel catalog entry")
 	assert.Len(t, grouped[CategoryBat], 11, "expected 11 bat catalog entries")
@@ -344,11 +344,21 @@ func TestVisibleCatalog_ExcludesHiddenEntries(t *testing.T) {
 		assert.False(t, entry.Hidden, "visible catalog should not contain hidden entry %q", entry.ID)
 	}
 
-	// Hidden entries should still be findable via GetCatalogEntry
+	// birdnet-v3.0 is now visible (un-hidden): the public HF repo, pinned
+	// checksums, and per-variant RAM floors make it safe to offer in the gallery.
 	birdnetV3, ok := GetCatalogEntry("birdnet-v3.0")
 	require.True(t, ok)
-	assert.True(t, birdnetV3.Hidden)
+	assert.False(t, birdnetV3.Hidden, "birdnet-v3.0 must be visible")
+	foundV3 := false
+	for i := range visible {
+		if visible[i].ID == "birdnet-v3.0" {
+			foundV3 = true
+			break
+		}
+	}
+	assert.True(t, foundV3, "birdnet-v3.0 must appear in the visible catalog")
 
+	// Hidden entries should still be findable via GetCatalogEntry.
 	bsg, ok := GetCatalogEntry("bsg-finland")
 	require.True(t, ok)
 	assert.True(t, bsg.Hidden)
@@ -368,11 +378,11 @@ func TestVisibleCatalog_ExcludesHiddenEntries(t *testing.T) {
 			"hidden entry %q must be excluded from the visible catalog", visible[i].ID)
 	}
 
-	// Visible count should be total minus the 3 hidden entries
-	// (birdnet-v3.0, bsg-finland, and the collapsed BirdNET v2.4 foundation entry).
+	// Visible count should be total minus the 2 hidden entries
+	// (bsg-finland and the collapsed BirdNET v2.4 foundation entry).
 	// The hardcoded count is an intentional tripwire: a new hidden entry must
 	// update it, forcing a conscious check that the exclusion is intended.
-	assert.Len(t, visible, len(EmbeddedCatalog)-3)
+	assert.Len(t, visible, len(EmbeddedCatalog)-2)
 }
 
 func TestGetCatalogEntry_BSGFinland(t *testing.T) {
@@ -408,6 +418,81 @@ func TestGetCatalogEntry_BirdNETv30(t *testing.T) {
 	assert.Equal(t, "BirdNET v3.0", entry.Name)
 	assert.Equal(t, RegistryIDBirdNETV3, entry.RegistryID)
 	assert.Equal(t, CategoryWildlife, entry.Category)
+	assert.False(t, entry.Hidden, "birdnet-v3.0 is visible in the gallery")
+	assert.True(t, entry.CommercialUse, "birdnet-v3.0 is CC-BY-SA-4.0, which permits commercial use")
+}
+
+// TestEmbeddedCatalog_VariantRequirementsPopulated pins the per-variant MinRAMMB
+// floors, the fp16 exclude token, and the BirdNET v3.0 benchmark data. These
+// values are mirrored from the acoustic-models manifests and drive the hardware
+// recommender: without the RAM floors the recommender cannot keep heavy variants
+// off low-RAM hosts, and without at least two comparable benchmarks per entry the
+// latency term stays inert. Literals catch an accidental edit or a manifest drift.
+func TestEmbeddedCatalog_VariantRequirementsPopulated(t *testing.T) {
+	t.Parallel()
+
+	// Expected MinRAMMB per (entry, variant), mirrored from the manifests.
+	wantRAM := map[string]map[string]int{
+		"birdnet-v3.0": {"fp32": 800, "fp16": 1100},
+		"perch-v2":     {"fp32": 700, "no-dft-fp32": 750, "int8-arm": 350},
+		"birdnet-v2.4": {"fp32-dfttrunc": 250, "int8-arm-dfttrunc": 250},
+	}
+	for entryID, variants := range wantRAM {
+		entry, ok := GetCatalogEntry(entryID)
+		require.Truef(t, ok, "expected catalog entry %q", entryID)
+		for variantID, wantMB := range variants {
+			v := variantByID(t, &entry, variantID)
+			assert.Equalf(t, wantMB, v.Requirements.MinRAMMB, "%s/%s MinRAMMB", entryID, variantID)
+		}
+	}
+
+	// The fp16 variant excludes the known-bad Intel gen12 iGPU path.
+	v30, ok := GetCatalogEntry("birdnet-v3.0")
+	require.True(t, ok)
+	fp16 := variantByID(t, &v30, "fp16")
+	assert.Contains(t, fp16.Requirements.Excludes, "openvino-gpu-intel-gen12", "fp16 must exclude the gen12 iGPU path")
+
+	// BirdNET v3.0 is the only family with measured benchmarks. Pin every row
+	// exactly (device, backend, latency, RSS): the latencies drive the
+	// recommender's ranking, so a wrong value is a silent behavior change, not a
+	// count mismatch. Both global variants carry an rpi5-a76 onnxruntime-cpu
+	// measurement, the two comparable members the recommender needs to rank on
+	// latency.
+	fp32 := variantByID(t, &v30, "fp32")
+	assert.Len(t, fp32.Benchmarks, 5, "fp32 benchmark rows")
+	assert.Len(t, fp16.Benchmarks, 3, "fp16 benchmark rows")
+	benchWant := []struct {
+		variantID, device, backend string
+		latencyMs, rssMB           int
+	}{
+		{"fp32", "rpi5-a76", "openvino-cpu", 168, 0},
+		{"fp32", "rpi5-a76", "onnxruntime-cpu", 363, 685},
+		{"fp32", "rpi4b-a72", "onnxruntime-cpu", 874, 688},
+		{"fp32", "x86-i7-1260P", "onnxruntime-cpu", 70, 0},
+		{"fp32", "x86-i7-1260P", "openvino-gpu", 95, 0},
+		{"fp16", "rpi5-a76", "onnxruntime-cpu", 381, 480},
+		{"fp16", "rpi4b-a72", "onnxruntime-cpu", 887, 929},
+		{"fp16", "x86-i7-1260P", "openvino-gpu", 81, 0},
+	}
+	for _, w := range benchWant {
+		t.Run(w.variantID+"/"+w.device+"/"+w.backend, func(t *testing.T) {
+			b, ok := findBenchmark(variantByID(t, &v30, w.variantID), w.device, w.backend)
+			require.Truef(t, ok, "%s missing benchmark %s/%s", w.variantID, w.device, w.backend)
+			assert.Equalf(t, w.latencyMs, b.LatencyMs, "%s %s/%s latency", w.variantID, w.device, w.backend)
+			assert.Equalf(t, w.rssMB, b.RSSMB, "%s %s/%s rss", w.variantID, w.device, w.backend)
+		})
+	}
+}
+
+// findBenchmark returns the variant's benchmark measured on the given device
+// with the given backend, and whether one exists.
+func findBenchmark(v *CatalogVariant, device, backend string) (Benchmark, bool) {
+	for i := range v.Benchmarks {
+		if v.Benchmarks[i].Device == device && v.Benchmarks[i].Backend == backend {
+			return v.Benchmarks[i], true
+		}
+	}
+	return Benchmark{}, false
 }
 
 // TestEmbeddedCatalog_BirdNETv24Variants pins the identity of the collapsed hidden


### PR DESCRIPTION
## Summary

This populates per-variant hardware metadata in the model catalog and makes BirdNET v3.0 installable from the gallery.

It adds `MinRAMMB` floors to every global variant of BirdNET v3.0, Perch v2, and BirdNET v2.4, an `openvino-gpu-intel-gen12` exclude token to the v3.0 fp16 variant, and measured per-device benchmarks to the v3.0 fp32 and fp16 variants. All values are mirrored verbatim from the acoustic-models model manifests. The hardware recommender already reads these fields, but no shipped variant populated them, so the RAM hard filter never fired and rankings compressed toward the backend term.

With the RAM floors in place the recommender can keep the heavy global builds (fp32 is 557 MB, fp16 is 279 MB) off hosts that cannot run them, so the BirdNET v3.0 catalog entry is un-hidden and installable from the gallery. It stays labelled a developer preview. Its `CommercialUse` flag is corrected to true, since the model is CC-BY-SA-4.0 which permits commercial use.

Benchmarks currently exist upstream only for BirdNET v3.0; Perch v2 and v2.4 have no measured latencies in the manifests yet, so their latency ranking is unchanged.

## Notes

The recommender maps an amd64 host to a generic `x86` device class, while the manifest benchmark rows name a specific CPU (`x86-i7-1260P`), so the x86 latency rows do not yet influence ranking on amd64 hosts. The x86 rows are included for fidelity to the manifest and are consumed on ARM device classes today. Wiring up x86 device-class matching would flip the v3.0 recommendation on an Intel iGPU host from fp16 to fp32 (fp32 benchmarks faster on the CPU than fp16 on the iGPU), which is a recommender-policy decision, so it is deliberately deferred to a separate change.

## Test Plan

- [x] `go test -race ./internal/classifier/... ./internal/api/v2/models/...` passes
- [x] `golangci-lint run` reports 0 issues
- [x] New `TestEmbeddedCatalog_VariantRequirementsPopulated` pins every RAM floor, the fp16 exclude token, and all eight v3.0 benchmark rows (device, backend, latency, RSS)
- [x] Updated visible/hidden catalog counts, wildlife category count, and the v3.0 visibility/commercial-use tripwires

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * BirdNET v3.0 is now visible in the model gallery and available for commercial use.
  * Added minimum memory requirements and benchmark information for supported model variants.
  * Added memory requirements for Perch v2 and hidden BirdNET v2.4 variants.
  * Updated BirdNET v3.0’s developer-preview description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->