### PR TITLE
feat(models): region axis for the gallery recommender and recommended-first ordering

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
@@ -68,7 +68,7 @@
   import { buildAppUrl } from '$lib/utils/urlHelpers';
   import { toastActions } from '$lib/stores/toast';
   import { formatBytes, formatNumber } from '$lib/utils/formatters';
-  import { pickPreselectedVariant } from '$lib/utils/variantSelection';
+  import { pickPreselectedVariant, reasonKey } from '$lib/utils/variantSelection';
   import { safeArrayAccess } from '$lib/utils/security';
   import { loggers } from '$lib/utils/logger';
   import { t } from '$lib/i18n';
@@ -113,6 +113,20 @@
       if (id.startsWith(prefix)) return logo;
     }
     return null;
+  }
+
+  // Render an entry-level incompatibility code (e.g. "backend.onnx_unavailable")
+  // through the same i18n reason path the variant picker uses, falling back to a
+  // generic localized line when the code is absent or has no translation, so a
+  // structured code never surfaces to the user as a raw dotted string.
+  // Entry-level codes carry no interpolation args (unlike variant reasons), so no
+  // args are threaded here; a future parameterized entry-level code would need an
+  // args field on CatalogEntryResponse.IncompatibleReason and a change here.
+  function entryIncompatibleText(code: string | undefined, fallbackKey: string): string {
+    if (!code) return t(fallbackKey);
+    const key = reasonKey(code);
+    const translated = t(key);
+    return translated === key ? t(fallbackKey) : translated;
   }
 
   // ── Page-level tab state ──────────────────────────────────────────────
@@ -1810,7 +1824,12 @@
                 class="mt-3 flex items-start gap-2 rounded-lg bg-red-500/10 p-3 text-xs text-red-700 dark:text-red-400"
               >
                 <XCircle class="h-4 w-4 shrink-0 mt-0.5" />
-                <span>{entry.incompatibleReason || t('analysis.gallery.onnxRuntimeMissing')}</span>
+                <span
+                  >{entryIncompatibleText(
+                    entry.incompatibleReason,
+                    'analysis.gallery.onnxRuntimeMissing'
+                  )}</span
+                >
               </div>
             {/if}
             <!-- Metadata grid -->
@@ -1994,7 +2013,12 @@
         class="mt-3 flex items-start gap-2 rounded-lg bg-amber-500/10 p-3 text-xs text-amber-700 dark:text-amber-400"
       >
         <TriangleAlert class="h-4 w-4 shrink-0 mt-0.5" />
-        <span>{entry.incompatibleReason || t('analysis.gallery.onnxRuntimeRequired')}</span>
+        <span
+          >{entryIncompatibleText(
+            entry.incompatibleReason,
+            'analysis.gallery.onnxRuntimeRequired'
+          )}</span
+        >
       </div>
     {/if}
 

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -3878,6 +3878,8 @@ export type TranslationKey =
   | 'analysis.gallery.variants.latency' // params: ms
   | 'analysis.gallery.reasons.backendRecommended' // params: backend
   | 'analysis.gallery.reasons.backendSupported' // params: backend
+  | 'analysis.gallery.reasons.regionMatched' // params: region
+  | 'analysis.gallery.reasons.regionGlobalFallback'
   | 'analysis.gallery.reasons.precisionFp16Native'
   | 'analysis.gallery.reasons.ramConstrainedFit'
   | 'analysis.gallery.reasons.benchmarkMeasured'
@@ -3886,6 +3888,7 @@ export type TranslationKey =
   | 'analysis.gallery.reasons.backendMissing' // params: required
   | 'analysis.gallery.reasons.ramInsufficient' // params: requiredMb
   | 'analysis.gallery.reasons.hardwareExcluded' // params: token
+  | 'analysis.gallery.reasons.backendOnnxUnavailable'
   | 'analysis.gallery.tabs.installed'
   | 'analysis.gallery.tabs.available'
   | 'analysis.gallery.loading'
@@ -4466,6 +4469,7 @@ export type TranslationParams = {
   'analysis.gallery.variants.latency': { ms: string | number };
   'analysis.gallery.reasons.backendRecommended': { backend: string | number };
   'analysis.gallery.reasons.backendSupported': { backend: string | number };
+  'analysis.gallery.reasons.regionMatched': { region: string | number };
   'analysis.gallery.reasons.archUnsupported': { required: string | number };
   'analysis.gallery.reasons.backendMissing': { required: string | number };
   'analysis.gallery.reasons.ramInsufficient': { requiredMb: string | number };

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -5324,6 +5324,8 @@
       "reasons": {
         "backendRecommended": "Běží na {backend}, doporučeném backendu pro váš hardware",
         "backendSupported": "Běží na {backend}",
+        "regionMatched": "Odpovídá vaší oblasti ({region})",
+        "regionGlobalFallback": "Globální model pro vaši polohu",
         "precisionFp16Native": "Verze s poloviční přesností odpovídající vašemu procesoru",
         "ramConstrainedFit": "Kvantizovaná verze optimalizovaná pro vaši dostupnou paměť",
         "benchmarkMeasured": "Nejrychlejší na vašem zařízení podle měření výkonu",
@@ -5331,7 +5333,8 @@
         "archUnsupported": "Vyžaduje procesor {required}",
         "backendMissing": "Vyžaduje inferenční backend, který není dostupný ({required})",
         "ramInsufficient": "Vyžaduje alespoň {requiredMb} MB paměti",
-        "hardwareExcluded": "Nepodporováno na vašem hardwaru ({token})"
+        "hardwareExcluded": "Nepodporováno na vašem hardwaru ({token})",
+        "backendOnnxUnavailable": "Vyžaduje ONNX Runtime, který není v tomto systému k dispozici"
       },
       "tabs": {
         "installed": "Nainstalované",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -5324,6 +5324,8 @@
       "reasons": {
         "backendRecommended": "Kører på {backend}, den anbefalede backend til din hardware",
         "backendSupported": "Kører på {backend}",
+        "regionMatched": "Matchet til din region ({region})",
+        "regionGlobalFallback": "Global model til din placering",
         "precisionFp16Native": "Halvpræcisionsversion, der passer til din CPU",
         "ramConstrainedFit": "Kvantiseret version tilpasset din tilgængelige hukommelse",
         "benchmarkMeasured": "Hurtigst på din enhed i udførte benchmarks",
@@ -5331,7 +5333,8 @@
         "archUnsupported": "Kræver en {required} CPU",
         "backendMissing": "Kræver en inference backend, som din version ikke kan nå ({required})",
         "ramInsufficient": "Kræver mindst {requiredMb} MB hukommelse",
-        "hardwareExcluded": "Understøttes ikke på din hardware ({token})"
+        "hardwareExcluded": "Understøttes ikke på din hardware ({token})",
+        "backendOnnxUnavailable": "Kræver ONNX Runtime, som ikke er tilgængelig på dette system"
       },
       "tabs": {
         "installed": "Installerede",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -5324,6 +5324,8 @@
       "reasons": {
         "backendRecommended": "Läuft auf {backend}, dem empfohlenen Backend für Ihre Hardware",
         "backendSupported": "Läuft auf {backend}",
+        "regionMatched": "Abgestimmt auf Ihre Region ({region})",
+        "regionGlobalFallback": "Globales Modell für Ihren Standort",
         "precisionFp16Native": "Half-Precision-Build, abgestimmt auf Ihren Prozessor",
         "ramConstrainedFit": "Quantisierter Build, optimiert für Ihren verfügbaren Speicher",
         "benchmarkMeasured": "Am schnellsten auf Ihrem Gerät laut Benchmarks",
@@ -5331,7 +5333,8 @@
         "archUnsupported": "Erfordert einen {required}-Prozessor",
         "backendMissing": "Benötigt ein Inference-Backend, das nicht erreichbar ist ({required})",
         "ramInsufficient": "Benötigt mindestens {requiredMb} MB Speicher",
-        "hardwareExcluded": "Wird von Ihrer Hardware nicht unterstützt ({token})"
+        "hardwareExcluded": "Wird von Ihrer Hardware nicht unterstützt ({token})",
+        "backendOnnxUnavailable": "Erfordert ONNX Runtime, das auf diesem System nicht verfügbar ist"
       },
       "tabs": {
         "installed": "Installiert",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -5324,6 +5324,8 @@
       "reasons": {
         "backendRecommended": "Runs on {backend}, the recommended backend for your hardware",
         "backendSupported": "Runs on {backend}",
+        "regionMatched": "Matched to your region ({region})",
+        "regionGlobalFallback": "Global model for your location",
         "precisionFp16Native": "Half-precision build matched to your CPU",
         "ramConstrainedFit": "Quantized build sized for your available memory",
         "benchmarkMeasured": "Fastest on your device in measured benchmarks",
@@ -5331,7 +5333,8 @@
         "archUnsupported": "Requires a {required} CPU",
         "backendMissing": "Needs an inference backend your build cannot reach ({required})",
         "ramInsufficient": "Needs at least {requiredMb} MB of memory",
-        "hardwareExcluded": "Not supported on your hardware ({token})"
+        "hardwareExcluded": "Not supported on your hardware ({token})",
+        "backendOnnxUnavailable": "Requires ONNX Runtime, which isn't available on this system"
       },
       "tabs": {
         "installed": "Installed",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -5324,6 +5324,8 @@
       "reasons": {
         "backendRecommended": "Se ejecuta en {backend}, el backend recomendado para tu hardware",
         "backendSupported": "Se ejecuta en {backend}",
+        "regionMatched": "Adaptado a tu región ({region})",
+        "regionGlobalFallback": "Modelo global para tu ubicación",
         "precisionFp16Native": "Versión de media precisión adaptada a tu procesador",
         "ramConstrainedFit": "Versión cuantizada ajustada a tu memoria disponible",
         "benchmarkMeasured": "El más rápido en tu dispositivo según pruebas de rendimiento",
@@ -5331,7 +5333,8 @@
         "archUnsupported": "Requiere un procesador {required}",
         "backendMissing": "Necesita un backend de inferencia que tu versión no puede alcanzar ({required})",
         "ramInsufficient": "Necesita al menos {requiredMb} MB de memoria",
-        "hardwareExcluded": "No compatible con tu hardware ({token})"
+        "hardwareExcluded": "No compatible con tu hardware ({token})",
+        "backendOnnxUnavailable": "Requiere ONNX Runtime, que no está disponible en este sistema"
       },
       "tabs": {
         "installed": "Instalados",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -5324,6 +5324,8 @@
       "reasons": {
         "backendRecommended": "Käyttää taustajärjestelmää {backend}, joka on suositeltu laitteistollesi",
         "backendSupported": "Käyttää taustajärjestelmää {backend}",
+        "regionMatched": "Sovitettu alueellesi ({region})",
+        "regionGlobalFallback": "Globaali malli sijainnillesi",
         "precisionFp16Native": "Puolitarkkuusmalli (fp16), optimoitu suorittimellesi",
         "ramConstrainedFit": "Kvantisoitu malli, mitoitettu käytettävissä olevalle muistillesi",
         "benchmarkMeasured": "Laitteesi nopein suorituskykytestien perusteella",
@@ -5331,7 +5333,8 @@
         "archUnsupported": "Vaatii {required}-suorittimen",
         "backendMissing": "Vaatii inferenssin taustajärjestelmän, joka ei ole käytettävissä ({required})",
         "ramInsufficient": "Vaatii vähintään {requiredMb} MB muistia",
-        "hardwareExcluded": "Ei tue laitteistoasi ({token})"
+        "hardwareExcluded": "Ei tue laitteistoasi ({token})",
+        "backendOnnxUnavailable": "Vaatii ONNX Runtimen, joka ei ole käytettävissä tässä järjestelmässä"
       },
       "tabs": {
         "installed": "Asennetut",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -5324,6 +5324,8 @@
       "reasons": {
         "backendRecommended": "S'exécute sur {backend}, le backend recommandé pour votre matériel",
         "backendSupported": "S'exécute sur {backend}",
+        "regionMatched": "Adapté à votre région ({region})",
+        "regionGlobalFallback": "Modèle global pour votre emplacement",
         "precisionFp16Native": "Version en demi-précision adaptée à votre processeur",
         "ramConstrainedFit": "Version quantifiée ajustée à votre mémoire disponible",
         "benchmarkMeasured": "Le plus rapide sur votre appareil d'après les tests",
@@ -5331,7 +5333,8 @@
         "archUnsupported": "Nécessite un processeur {required}",
         "backendMissing": "Nécessite un backend d'inférence inaccessible ({required})",
         "ramInsufficient": "Nécessite au moins {requiredMb} MB de mémoire",
-        "hardwareExcluded": "Non pris en charge par votre matériel ({token})"
+        "hardwareExcluded": "Non pris en charge par votre matériel ({token})",
+        "backendOnnxUnavailable": "Nécessite ONNX Runtime, qui n'est pas disponible sur ce système"
       },
       "tabs": {
         "installed": "Installés",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -5324,6 +5324,8 @@
       "reasons": {
         "backendRecommended": "Ezen fut: {backend}, amely a hardveredhez ajánlott backend",
         "backendSupported": "Ezen fut: {backend}",
+        "regionMatched": "A régiódhoz igazítva ({region})",
+        "regionGlobalFallback": "Globális modell a helyszínedhez",
         "precisionFp16Native": "A CPU-hoz igazított félpontosságú (fp16) build",
         "ramConstrainedFit": "A rendelkezésre álló memóriához méretezett kvantált build",
         "benchmarkMeasured": "Mérések alapján a leggyorsabb az eszközödön",
@@ -5331,7 +5333,8 @@
         "archUnsupported": "Egy {required} CPU szükséges hozzá",
         "backendMissing": "Olyan következtetési backendet igényel, amelyet a build nem ér el ({required})",
         "ramInsufficient": "Legalább {requiredMb} MB memória szükséges",
-        "hardwareExcluded": "Nem támogatott a hardvereden ({token})"
+        "hardwareExcluded": "Nem támogatott a hardvereden ({token})",
+        "backendOnnxUnavailable": "ONNX Runtime szükséges, amely nem érhető el ezen a rendszeren"
       },
       "tabs": {
         "installed": "Telepített",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -5324,6 +5324,8 @@
       "reasons": {
         "backendRecommended": "Eseguito su {backend}, il backend consigliato per il tuo hardware",
         "backendSupported": "Eseguito su {backend}",
+        "regionMatched": "Adattato alla tua regione ({region})",
+        "regionGlobalFallback": "Modello globale per la tua posizione",
         "precisionFp16Native": "Versione a mezza precisione adatta al tuo processore",
         "ramConstrainedFit": "Versione quantizzata ottimizzata per la tua memoria disponibile",
         "benchmarkMeasured": "Il più veloce sul tuo dispositivo secondo i benchmark",
@@ -5331,7 +5333,8 @@
         "archUnsupported": "Richiede un processore {required}",
         "backendMissing": "Richiede un backend di inferenza che la tua versione non può raggiungere ({required})",
         "ramInsufficient": "Richiede almeno {requiredMb} MB di memoria",
-        "hardwareExcluded": "Non supportato dal tuo hardware ({token})"
+        "hardwareExcluded": "Non supportato dal tuo hardware ({token})",
+        "backendOnnxUnavailable": "Richiede ONNX Runtime, che non è disponibile su questo sistema"
       },
       "tabs": {
         "installed": "Installati",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -5324,6 +5324,8 @@
       "reasons": {
         "backendRecommended": "Darbojas ar {backend}, kas ir ieteicamā aizmugursistēma jūsu aparatūrai",
         "backendSupported": "Darbojas ar {backend}",
+        "regionMatched": "Pielāgots jūsu reģionam ({region})",
+        "regionGlobalFallback": "Globālais modelis jūsu atrašanās vietai",
         "precisionFp16Native": "Pusprecizitātes versija, kas pielāgota jūsu procesoram",
         "ramConstrainedFit": "Kvantizēta versija, kas pielāgota jūsu pieejamajai atmiņai",
         "benchmarkMeasured": "Ātrākais jūsu ierīcē saskaņā ar veiktspējas testiem",
@@ -5331,7 +5333,8 @@
         "archUnsupported": "Nepieciešams {required} procesors",
         "backendMissing": "Nepieciešama inferences aizmugursistēma, ko jūsu versija nevar sasniegt ({required})",
         "ramInsufficient": "Nepieciešami vismaz {requiredMb} MB atmiņas",
-        "hardwareExcluded": "Nav atbalstīts jūsu aparatūrā ({token})"
+        "hardwareExcluded": "Nav atbalstīts jūsu aparatūrā ({token})",
+        "backendOnnxUnavailable": "Nepieciešams ONNX Runtime, kas šajā sistēmā nav pieejams"
       },
       "tabs": {
         "installed": "Instalētie",

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -5324,6 +5324,8 @@
       "reasons": {
         "backendRecommended": "Kjører på {backend}, som er den anbefalte backenden for din maskinvare",
         "backendSupported": "Kjører på {backend}",
+        "regionMatched": "Tilpasset din region ({region})",
+        "regionGlobalFallback": "Global modell for din posisjon",
         "precisionFp16Native": "Halvpresisjonsversjon tilpasset din CPU",
         "ramConstrainedFit": "Kvantisert versjon tilpasset ditt tilgjengelige minne",
         "benchmarkMeasured": "Raskest på din enhet i utførte ytelsestester",
@@ -5331,7 +5333,8 @@
         "archUnsupported": "Krever en {required} CPU",
         "backendMissing": "Krever en inference-backend som versjonen din ikke når ({required})",
         "ramInsufficient": "Krever minst {requiredMb} MB minne",
-        "hardwareExcluded": "Støttes ikke på din maskinvare ({token})"
+        "hardwareExcluded": "Støttes ikke på din maskinvare ({token})",
+        "backendOnnxUnavailable": "Krever ONNX Runtime, som ikke er tilgjengelig på dette systemet"
       },
       "tabs": {
         "installed": "Installert",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -5324,6 +5324,8 @@
       "reasons": {
         "backendRecommended": "Draait op {backend}, de aanbevolen backend voor jouw hardware",
         "backendSupported": "Draait op {backend}",
+        "regionMatched": "Afgestemd op jouw regio ({region})",
+        "regionGlobalFallback": "Globaal model voor jouw locatie",
         "precisionFp16Native": "Halve-precisie versie afgestemd op je processor",
         "ramConstrainedFit": "Gekwantiseerde versie aangepast aan je beschikbare geheugen",
         "benchmarkMeasured": "Snelste op jouw apparaat in gemeten benchmarks",
@@ -5331,7 +5333,8 @@
         "archUnsupported": "Vereist een {required} processor",
         "backendMissing": "Heeft een inference backend nodig die je installatie niet kan bereiken ({required})",
         "ramInsufficient": "Heeft minimaal {requiredMb} MB geheugen nodig",
-        "hardwareExcluded": "Niet ondersteund op jouw hardware ({token})"
+        "hardwareExcluded": "Niet ondersteund op jouw hardware ({token})",
+        "backendOnnxUnavailable": "Vereist ONNX Runtime, dat niet beschikbaar is op dit systeem"
       },
       "tabs": {
         "installed": "Geïnstalleerd",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -5324,6 +5324,8 @@
       "reasons": {
         "backendRecommended": "Działa na {backend}, zalecanym backendzie dla twojego sprzętu",
         "backendSupported": "Działa na {backend}",
+        "regionMatched": "Dopasowano do twojego regionu ({region})",
+        "regionGlobalFallback": "Globalny model dla twojej lokalizacji",
         "precisionFp16Native": "Wersja o połowicznej precyzji dopasowana do twojego procesora",
         "ramConstrainedFit": "Skwantyzowana wersja dopasowana do dostępnej pamięci",
         "benchmarkMeasured": "Najszybszy na twoim urządzeniu w przeprowadzonych testach",
@@ -5331,7 +5333,8 @@
         "archUnsupported": "Wymaga procesora {required}",
         "backendMissing": "Wymaga backendu wnioskowania, który jest niedostępny ({required})",
         "ramInsufficient": "Wymaga co najmniej {requiredMb} MB pamięci",
-        "hardwareExcluded": "Brak wsparcia na twoim sprzęcie ({token})"
+        "hardwareExcluded": "Brak wsparcia na twoim sprzęcie ({token})",
+        "backendOnnxUnavailable": "Wymaga ONNX Runtime, który nie jest dostępny w tym systemie"
       },
       "tabs": {
         "installed": "Zainstalowane",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -5324,6 +5324,8 @@
       "reasons": {
         "backendRecommended": "Roda em {backend}, o backend recomendado para o seu hardware",
         "backendSupported": "Roda em {backend}",
+        "regionMatched": "Adaptado à sua região ({region})",
+        "regionGlobalFallback": "Modelo global para a sua localização",
         "precisionFp16Native": "Versão de meia precisão ajustada para o seu processador",
         "ramConstrainedFit": "Versão quantizada otimizada para a memória disponível",
         "benchmarkMeasured": "O mais rápido no seu dispositivo segundo os testes de desempenho",
@@ -5331,7 +5333,8 @@
         "archUnsupported": "Requer um processador {required}",
         "backendMissing": "Necessita de um backend de inferência que a sua versão não consegue alcançar ({required})",
         "ramInsufficient": "Necessita de pelo menos {requiredMb} MB de memória",
-        "hardwareExcluded": "Não suportado no seu hardware ({token})"
+        "hardwareExcluded": "Não suportado no seu hardware ({token})",
+        "backendOnnxUnavailable": "Requer ONNX Runtime, que não está disponível neste sistema"
       },
       "tabs": {
         "installed": "Instalados",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -5324,6 +5324,8 @@
       "reasons": {
         "backendRecommended": "Beží na {backend}, čo je odporúčaný backend pre váš hardvér",
         "backendSupported": "Beží na {backend}",
+        "regionMatched": "Prispôsobené vášmu regiónu ({region})",
+        "regionGlobalFallback": "Globálny model pre vašu polohu",
         "precisionFp16Native": "Verzia s polovičnou presnosťou zodpovedajúca vášmu procesoru",
         "ramConstrainedFit": "Kvantizovaná verzia optimalizovaná pre vašu dostupnú pamäť",
         "benchmarkMeasured": "Najrýchlejší na vašom zariadení podľa meraní výkonu",
@@ -5331,7 +5333,8 @@
         "archUnsupported": "Vyžaduje procesor {required}",
         "backendMissing": "Vyžaduje inferenčný backend, ktorý nie je dostupný ({required})",
         "ramInsufficient": "Vyžaduje aspoň {requiredMb} MB pamäte",
-        "hardwareExcluded": "Nepodporované na vašom hardvéri ({token})"
+        "hardwareExcluded": "Nepodporované na vašom hardvéri ({token})",
+        "backendOnnxUnavailable": "Vyžaduje ONNX Runtime, ktorý nie je v tomto systéme k dispozícii"
       },
       "tabs": {
         "installed": "Nainštalované",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -5324,6 +5324,8 @@
       "reasons": {
         "backendRecommended": "Körs på {backend}, den rekommenderade backend-motorn för din hårdvara",
         "backendSupported": "Körs på {backend}",
+        "regionMatched": "Anpassad för din region ({region})",
+        "regionGlobalFallback": "Global modell för din plats",
         "precisionFp16Native": "Halvprecisionsbygge anpassat för din CPU",
         "ramConstrainedFit": "Kvantiserat bygge anpassat för ditt tillgängliga minne",
         "benchmarkMeasured": "Snabbast på din enhet enligt prestandatester",
@@ -5331,7 +5333,8 @@
         "archUnsupported": "Kräver en {required} CPU",
         "backendMissing": "Kräver en inference-backend som din version inte kan nå ({required})",
         "ramInsufficient": "Kräver minst {requiredMb} MB minne",
-        "hardwareExcluded": "Stöds inte på din hårdvara ({token})"
+        "hardwareExcluded": "Stöds inte på din hårdvara ({token})",
+        "backendOnnxUnavailable": "Kräver ONNX Runtime, som inte är tillgängligt på detta system"
       },
       "tabs": {
         "installed": "Installerade",

--- a/internal/api/v2/models/models.go
+++ b/internal/api/v2/models/models.go
@@ -83,19 +83,26 @@ type ModelListItem struct {
 
 // CatalogEntryResponse represents a model in the catalog API response.
 type CatalogEntryResponse struct {
-	ID                 string `json:"id"`
-	Name               string `json:"name"`
-	Description        string `json:"description"`
-	Author             string `json:"author"`
-	License            string `json:"license"`
-	CommercialUse      bool   `json:"commercialUse"`
-	Category           string `json:"category"`
-	Region             string `json:"region"`
-	SpeciesCount       int    `json:"speciesCount"`
-	Version            string `json:"version"`
-	UpstreamURL        string `json:"upstreamUrl,omitempty"`
-	Installed          bool   `json:"installed"`
-	Compatible         bool   `json:"compatible"`
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	Description   string `json:"description"`
+	Author        string `json:"author"`
+	License       string `json:"license"`
+	CommercialUse bool   `json:"commercialUse"`
+	Category      string `json:"category"`
+	Region        string `json:"region"`
+	SpeciesCount  int    `json:"speciesCount"`
+	Version       string `json:"version"`
+	UpstreamURL   string `json:"upstreamUrl,omitempty"`
+	Installed     bool   `json:"installed"`
+	Compatible    bool   `json:"compatible"`
+	// IncompatibleReason is a structured, localizable code (an i18n key stem such
+	// as "backend.onnx_unavailable"), never a raw English message, so the fully
+	// i18n'd gallery can translate it; a client renders it through the same reason
+	// path as the variant reasons, falling back to the code. The specific
+	// underlying error (e.g. which ONNX Runtime library was missing) is not in
+	// this passive listing; it is returned in full when the user attempts to
+	// install the model.
 	IncompatibleReason string `json:"incompatibleReason,omitempty"`
 	TotalSizeBytes     int64  `json:"totalSizeBytes"`
 	HasGeomodel        bool   `json:"hasGeomodel"`
@@ -198,6 +205,15 @@ func (c *Handler) ListModels(ctx echo.Context) error {
 	return ctx.JSON(http.StatusOK, models)
 }
 
+// incompatibleReasonONNXUnavailable is the structured, localizable code set on
+// an entry that needs ONNX Runtime when the host has none. It replaces the raw
+// ORT error string (which the i18n'd gallery could not translate) and renders
+// through the same reasonKey path as the variant reasons, with a fallback to the
+// code itself. It is an entry-level signal (gated on RequiresONNX here, not a
+// per-variant blocker), so it lives in this package rather than the recommender's
+// variant vocabulary.
+const incompatibleReasonONNXUnavailable = "backend.onnx_unavailable"
+
 // GetModelCatalog returns the embedded model catalog enriched with install
 // status and compatibility information.
 func (c *Handler) GetModelCatalog(ctx echo.Context) error {
@@ -242,7 +258,7 @@ func (c *Handler) GetModelCatalog(ctx echo.Context) error {
 		incompatibleReason := ""
 		if entry.RequiresONNX && !ortStatus.Available {
 			compatible = false
-			incompatibleReason = ortStatus.Error
+			incompatibleReason = incompatibleReasonONNXUnavailable
 		}
 
 		catalog = append(catalog, CatalogEntryResponse{
@@ -265,6 +281,22 @@ func (c *Handler) GetModelCatalog(ctx echo.Context) error {
 			InstalledVariantID:   installedVariantID,
 			RecommendedVariantID: recommendedVariant[entry.ID],
 			Variants:             buildVariantResponses(entry, installed, installedVariantID, recsByVariant[entry.ID]),
+		})
+	}
+
+	// Recommended-first ordering for the Available tab: entries with a compatible
+	// hardware recommendation sort ahead of entries with none, catalog order
+	// preserved within each group (stable sort). A flat entry (no variants) is
+	// never ranked by the recommender, so it counts as recommendable to keep it
+	// from sinking below variant-bearing entries; the sort only demotes a
+	// variant-bearing entry whose every variant is incompatible with this host.
+	// Applied only when recommendations were computed (an eligible request); an
+	// ineligible caller keeps the stable default catalog order.
+	if recommendedVariant != nil {
+		sort.SliceStable(catalog, func(i, j int) bool {
+			ri := recommendedVariant[catalog[i].ID] != "" || len(catalog[i].Variants) == 0
+			rj := recommendedVariant[catalog[j].ID] != "" || len(catalog[j].Variants) == 0
+			return ri && !rj
 		})
 	}
 
@@ -349,11 +381,12 @@ func (c *Handler) rankCatalog(entries []classifier.CatalogEntry, ort inference.O
 		profileFn = defaultHardwareProfile
 	}
 	profile := profileFn(ort)
-	recs := recommend.Rank(recommend.Input{
-		Capabilities:  profile.Capabilities(),
-		TotalRAMBytes: profile.TotalRAMBytes,
-		DeviceClass:   recommend.DeviceClass(profile.Board.Tier, profile.Arch),
-		Entries:       entries,
+	recs := recommend.Rank(&recommend.Input{
+		Capabilities:   profile.Capabilities(),
+		TotalRAMBytes:  profile.TotalRAMBytes,
+		DeviceClass:    recommend.DeviceClass(profile.Board.Tier, profile.Arch),
+		ResolvedRegion: c.resolveRecommendRegion(),
+		Entries:        entries,
 	})
 
 	byVariant = make(map[string]map[string]recommend.Recommendation, len(entries))

--- a/internal/api/v2/models/models_recommend_test.go
+++ b/internal/api/v2/models/models_recommend_test.go
@@ -164,3 +164,36 @@ func TestGetModelCatalog_AuthenticatedGetsRecommendations(t *testing.T) {
 	assert.True(t, stub.called)
 	assert.Equal(t, "fp32", perch.RecommendedVariantID, "an authenticated request receives the recommendation")
 }
+
+func TestGetModelCatalog_RecommendedFirstOrdering(t *testing.T) {
+	core := apitest.NewCore(t)
+	h := New(core, nil) // nil authService -> enrichment allowed, so the sort runs
+	// A host with no usable inference backend: every variant-bearing entry has
+	// all variants blocked and is therefore not recommendable, while flat entries
+	// (no variants) stay recommendable. The catalog response must place all
+	// recommendable entries ahead of the non-recommendable ones.
+	h.hardwareProfile = func(inference.ORTStatus) hwprofile.Profile {
+		return hwprofile.Profile{Arch: "amd64", TotalRAMBytes: 16 * 1024 * 1024 * 1024}
+	}
+
+	catalog := catalogRequest(t, h)
+	require.NotEmpty(t, catalog)
+
+	recommendable := func(e *CatalogEntryResponse) bool {
+		return len(e.Variants) == 0 || e.RecommendedVariantID != ""
+	}
+
+	var haveRec, haveNon, seenNon bool
+	for i := range catalog {
+		if recommendable(&catalog[i]) {
+			haveRec = true
+			assert.Falsef(t, seenNon, "recommendable entry %q sorted after a non-recommendable one", catalog[i].ID)
+		} else {
+			haveNon = true
+			seenNon = true
+		}
+	}
+	// The fixture must exercise both groups, or the ordering assertion is vacuous.
+	require.True(t, haveRec, "expected at least one recommendable entry (flat entries)")
+	require.True(t, haveNon, "expected at least one non-recommendable entry (no backend blocks variant entries)")
+}

--- a/internal/api/v2/models/models_regions.go
+++ b/internal/api/v2/models/models_regions.go
@@ -112,6 +112,40 @@ func representativeTable(tables map[string]*region.Table) *region.Table {
 	return tables[repos[0]]
 }
 
+// resolveRecommendRegion resolves the single region slug the recommender scores
+// against, matching the top-level resolution in GetModelRegions. All families
+// share identical geometry (a region-package test enforces it), so a
+// representative table's resolution is the detected region for every entry.
+// A pinned region is an explicit choice independent of coordinates and is
+// honored even before a station location is configured; auto resolution needs
+// coordinates and otherwise stays on the global model (mirroring GetModelRegions,
+// which keeps an unconfigured station off any tile). Returns "" (the global
+// model) when the location is unconfigured under auto/global mode, no tile
+// applies, or region data is unavailable. This runs per request, so a coordinate
+// or ModelRegion change takes effect on the next gallery load without a restart.
+func (c *Handler) resolveRecommendRegion() string {
+	s := c.CurrentSettings()
+	tables, err := region.Tables()
+	if err != nil {
+		return "" // recommender falls back to global scoring; non-fatal
+	}
+	rep := representativeTable(tables)
+	if rep == nil {
+		return ""
+	}
+	// Auto resolution needs coordinates; without a configured location only an
+	// explicit pin selects a region. region.Select owns the mode classification,
+	// so ask it and honor just the coordinate-independent pinned outcome (its
+	// SourcePinned result), avoiding a null-island auto resolution.
+	if !s.BirdNET.LocationConfigured {
+		if sel := region.Select(rep, s.BirdNET.ModelRegion, 0, 0); sel.Source == region.SourcePinned {
+			return sel.Slug
+		}
+		return ""
+	}
+	return region.Select(rep, s.BirdNET.ModelRegion, s.BirdNET.Latitude, s.BirdNET.Longitude).Slug
+}
+
 // buildRegionOptions flattens the embedded tables into a deduplicated, sorted
 // list of dropdown options. Tables are visited in sorted repo order so that, for
 // a slug shared across families, the display metadata is taken deterministically

--- a/internal/api/v2/models/models_regions_test.go
+++ b/internal/api/v2/models/models_regions_test.go
@@ -134,3 +134,65 @@ func TestModelRegionConstantsMatchResolver(t *testing.T) {
 	assert.Equal(t, region.ModeAuto, conf.ModelRegionAuto, "auto mode constant drifted")
 	assert.Equal(t, region.ModeGlobal, conf.ModelRegionGlobal, "global mode constant drifted")
 }
+
+// TestResolveRecommendRegion covers the slug the recommender scores against for
+// each ModelRegion mode. It mutates process-global settings via WithSettingsFunc,
+// so it must not run in parallel.
+func TestResolveRecommendRegion(t *testing.T) {
+	// A valid slug from the embedded table, for the pinned cases, taken from the
+	// data rather than hardcoded so a future slug rename does not silently pass.
+	tables, err := region.Tables()
+	require.NoError(t, err)
+	rep := representativeTable(tables)
+	require.NotNil(t, rep)
+	var validSlug string
+	for slug := range rep.Regions {
+		validSlug = slug
+		break
+	}
+	require.NotEmpty(t, validSlug)
+
+	resolve := func(t *testing.T, mutate func(*conf.Settings)) string {
+		t.Helper()
+		core := apitest.NewCore(t, apitest.WithSettingsFunc(mutate))
+		return New(core, nil).resolveRecommendRegion()
+	}
+
+	t.Run("auto with configured coordinates resolves a region", func(t *testing.T) {
+		got := resolve(t, func(s *conf.Settings) {
+			s.BirdNET.Latitude = 4.7 // Bogota, inside a region tile
+			s.BirdNET.Longitude = -74.1
+			s.BirdNET.LocationConfigured = true
+			s.BirdNET.ModelRegion = conf.ModelRegionAuto
+		})
+		assert.NotEmpty(t, got, "configured coordinates over land resolve to a region")
+	})
+
+	t.Run("global mode yields the global model", func(t *testing.T) {
+		got := resolve(t, func(s *conf.Settings) {
+			s.BirdNET.Latitude = 4.7
+			s.BirdNET.Longitude = -74.1
+			s.BirdNET.LocationConfigured = true
+			s.BirdNET.ModelRegion = conf.ModelRegionGlobal
+		})
+		assert.Empty(t, got, "global mode opts out of regional selection")
+	})
+
+	t.Run("no configured location under auto yields the global model", func(t *testing.T) {
+		got := resolve(t, func(s *conf.Settings) {
+			s.BirdNET.Latitude = 4.7 // coordinates present but not marked configured
+			s.BirdNET.Longitude = -74.1
+			s.BirdNET.LocationConfigured = false
+			s.BirdNET.ModelRegion = conf.ModelRegionAuto
+		})
+		assert.Empty(t, got, "auto resolution requires a configured location")
+	})
+
+	t.Run("pinned region is honored without a configured location", func(t *testing.T) {
+		got := resolve(t, func(s *conf.Settings) {
+			s.BirdNET.LocationConfigured = false
+			s.BirdNET.ModelRegion = validSlug
+		})
+		assert.Equal(t, validSlug, got, "an explicit region pin does not require coordinates")
+	})
+}

--- a/internal/classifier/recommend/recommend.go
+++ b/internal/classifier/recommend/recommend.go
@@ -4,8 +4,9 @@
 //
 // It is deliberately pure: no I/O, no globals, no clock. The same Input always
 // yields the same output, so the whole hardware matrix is table-testable
-// without any hardware. The region axis is intentionally absent; a future region
-// resolver will slot into the score without rescaling the terms defined here.
+// without any hardware. The region axis reads Input.ResolvedRegion (resolved by
+// the caller from the host coordinates and the ModelRegion setting); the engine
+// itself performs no geometry.
 package recommend
 
 import (
@@ -18,9 +19,9 @@ import (
 	"github.com/tphakala/birdnet-go/internal/hwprofile"
 )
 
-// Score terms. Kept as named constants (no magic numbers) and spaced so the
-// future region terms (+100 matched / +50 global fallback) slot between the
-// hard signals and the modifiers without reordering anything.
+// Score terms. Kept as named constants (no magic numbers). The region terms
+// (+100 matched / +50 global fallback) sit between the hard signals and the
+// per-variant modifiers.
 const (
 	// scoreBackendRecommended is added when the best host-available backend is
 	// the manifest's Recommended way to run the variant.
@@ -28,6 +29,22 @@ const (
 	// scoreBackendSupported is added when the variant runs on a host-available
 	// backend that is merely Supported, not Recommended.
 	scoreBackendSupported = 10
+	// scoreRegionMatched is added when the variant's regional slice matches the
+	// host's resolved region. It is the strongest single term because a regional
+	// slice is numerically identical to the global model on the species it keeps
+	// while cutting peak RSS and latency, so a matching regional variant should
+	// win over any global one.
+	scoreRegionMatched = 100
+	// scoreRegionGlobalFallback is added to a global variant when no regional
+	// slice matches the host (either no region resolved, or the entry ships no
+	// slice for the resolved region). It sits below scoreRegionMatched so a
+	// matching regional variant always outranks the global one, and above the
+	// per-variant precision modifiers so a wrong-region slice cannot outscore the
+	// global model on those alone. (A wrong-region slice that also diverged from
+	// the global sibling in backend support could in principle exceed this margin,
+	// but a region slice mirrors its global sibling's precision and backend, so
+	// that case does not arise in shipped catalog data.)
+	scoreRegionGlobalFallback = 50
 	// scoreFP16Native rewards an fp16 variant on a host with native
 	// half-precision SIMD.
 	scoreFP16Native = 15
@@ -58,6 +75,12 @@ const (
 	// ReasonBackendSupported marks the variant as running on a supported (not
 	// recommended) backend for this host. Arg "backend" names that backend.
 	ReasonBackendSupported = "backend.supported"
+	// ReasonRegionMatched marks a regional variant matching the host's resolved
+	// region. Arg "region" names the slug.
+	ReasonRegionMatched = "region.matched"
+	// ReasonRegionGlobalFallback marks the global variant chosen because no
+	// regional slice matches the host.
+	ReasonRegionGlobalFallback = "region.global_fallback"
 	// ReasonPrecisionFP16Native marks an fp16 variant matched to native
 	// half-precision SIMD.
 	ReasonPrecisionFP16Native = "precision.fp16_native"
@@ -165,6 +188,12 @@ type Input struct {
 	// DeviceClass is the benchmark device identifier for this host, "" when the
 	// host maps to no benchmarked class.
 	DeviceClass string
+	// ResolvedRegion is the region slug the host's coordinates resolved to under
+	// the active ModelRegion mode, or "" when the global model applies (no
+	// coordinates, ModeGlobal, or no tile contains the point). A variant whose
+	// Region equals this slug is the regional match; a global variant (Region
+	// "") earns the fallback bonus whenever no regional slice matches.
+	ResolvedRegion string
 	// Entries is the visible catalog to evaluate.
 	Entries []classifier.CatalogEntry
 }
@@ -189,15 +218,16 @@ func DeviceClass(boardTier, goArch string) string {
 
 // Rank evaluates every variant of every entry and returns the verdicts grouped
 // by entry in input order, ranked best-first within each entry. Flat entries
-// (no variants) produce nothing. Input is never mutated.
-func Rank(in Input) []Recommendation {
+// (no variants) produce nothing. Input is never mutated; it is taken by pointer
+// only to avoid copying the (now region-aware) struct on every call.
+func Rank(in *Input) []Recommendation {
 	out := make([]Recommendation, 0)
 	for i := range in.Entries {
 		entry := &in.Entries[i]
 		if len(entry.Variants) == 0 {
 			continue
 		}
-		out = append(out, rankEntry(entry, &in)...)
+		out = append(out, rankEntry(entry, in)...)
 	}
 	return out
 }
@@ -207,10 +237,25 @@ func Rank(in Input) []Recommendation {
 func rankEntry(entry *classifier.CatalogEntry, in *Input) []Recommendation {
 	bench := benchmarkScores(entry, in)
 
+	// A global variant is the region fallback unless this entry actually ships a
+	// slice for the resolved region. Computing it once here (rather than per
+	// variant) keeps the global variant from earning the fallback bonus when a
+	// matching regional slice exists, and keeps a wrong-region slice from
+	// outscoring the global model on hardware terms when no slice matches.
+	hasMatchingRegion := false
+	if in.ResolvedRegion != "" {
+		for j := range entry.Variants {
+			if entry.Variants[j].Region == in.ResolvedRegion {
+				hasMatchingRegion = true
+				break
+			}
+		}
+	}
+
 	scoredVariants := make([]scoredVariant, 0, len(entry.Variants))
 	for j := range entry.Variants {
 		v := &entry.Variants[j]
-		scoredVariants = append(scoredVariants, evaluateVariant(entry.ID, v, in, bench[v.ID]))
+		scoredVariants = append(scoredVariants, evaluateVariant(entry.ID, v, in, bench[v.ID], hasMatchingRegion))
 	}
 
 	sortScored(scoredVariants)
@@ -245,7 +290,10 @@ type scoredVariant struct {
 
 // evaluateVariant computes the verdict for one variant: its blockers (hard
 // filters), its score terms, and the sort keys used to break ties.
-func evaluateVariant(catalogID string, v *classifier.CatalogVariant, in *Input, bench benchmarkResult) scoredVariant {
+// hasMatchingRegion reports whether the variant's entry ships a slice matching
+// the host's resolved region, which decides whether a global variant earns the
+// region fallback bonus (see rankEntry).
+func evaluateVariant(catalogID string, v *classifier.CatalogVariant, in *Input, bench benchmarkResult, hasMatchingRegion bool) scoredVariant {
 	var reasons, blockers []Reason
 	score := 0
 
@@ -289,6 +337,21 @@ func evaluateVariant(catalogID string, v *classifier.CatalogVariant, in *Input, 
 		score += term.score
 		reasons = append(reasons, Reason{Code: term.code, Args: map[string]string{"backend": term.backend}})
 		backendRank = preferenceRank(term.backend)
+	}
+
+	// Region term. A regional slice matching the host's resolved region is the
+	// strongest correctness signal. A global variant earns the fallback bonus
+	// whenever no slice matches the host (no region resolved, or the entry ships
+	// no slice for the resolved region), so it always outranks a wrong-region
+	// slice, which earns nothing here. Scored after the backend term so the
+	// backend reason stays the headline (reasons[0]) the gallery renders.
+	switch {
+	case in.ResolvedRegion != "" && v.Region == in.ResolvedRegion:
+		score += scoreRegionMatched
+		reasons = append(reasons, Reason{Code: ReasonRegionMatched, Args: map[string]string{"region": v.Region}})
+	case v.Region == "" && (in.ResolvedRegion == "" || !hasMatchingRegion):
+		score += scoreRegionGlobalFallback
+		reasons = append(reasons, Reason{Code: ReasonRegionGlobalFallback})
 	}
 
 	// Modifiers.

--- a/internal/classifier/recommend/recommend_test.go
+++ b/internal/classifier/recommend/recommend_test.go
@@ -151,7 +151,7 @@ func TestRank_HardwareMatrix(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			recs := Rank(Input{
+			recs := Rank(&Input{
 				Capabilities:  tt.caps,
 				TotalRAMBytes: tt.ram,
 				DeviceClass:   tt.deviceClass,
@@ -203,7 +203,7 @@ func TestRank_Blockers(t *testing.T) {
 		},
 	}
 
-	recs := Rank(Input{
+	recs := Rank(&Input{
 		Capabilities:  []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU, "openvino-gpu-intel-gen12"},
 		TotalRAMBytes: ramLow, // 1.5 GiB, below the 4 GiB floor
 		DeviceClass:   deviceClassX86,
@@ -243,7 +243,7 @@ func TestRank_BenchmarkScaling(t *testing.T) {
 			{ID: "slow", Backends: backend, Benchmarks: []classifier.Benchmark{{Device: deviceClassRPi5, Backend: hwprofile.CapONNXRuntimeCPU, LatencyMs: 500}}},
 		},
 	}
-	recs := Rank(Input{
+	recs := Rank(&Input{
 		Capabilities: []string{hwprofile.CapAArch64, hwprofile.CapONNXRuntimeCPU},
 		DeviceClass:  deviceClassRPi5,
 		Entries:      []classifier.CatalogEntry{entry},
@@ -259,7 +259,7 @@ func TestRank_BenchmarkScaling(t *testing.T) {
 			{ID: "b", Backends: backend},
 		},
 	}
-	recsSingle := Rank(Input{
+	recsSingle := Rank(&Input{
 		Capabilities: []string{hwprofile.CapAArch64, hwprofile.CapONNXRuntimeCPU},
 		DeviceClass:  deviceClassRPi5,
 		Entries:      []classifier.CatalogEntry{single},
@@ -282,7 +282,7 @@ func TestRank_TieBreaks(t *testing.T) {
 			{ID: "small", Backends: backend, Files: []classifier.CatalogFile{{SizeBytes: 100}}},
 		},
 	}
-	recs := Rank(Input{
+	recs := Rank(&Input{
 		Capabilities: []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU},
 		Entries:      []classifier.CatalogEntry{entry},
 	})
@@ -310,7 +310,7 @@ func TestRank_BestBackendFromRecommendedSet(t *testing.T) {
 		},
 	}
 	entry := classifier.CatalogEntry{ID: "backend-choice", Variants: []classifier.CatalogVariant{gpuSupportedCPURecommended, gpuRecommended}}
-	recs := Rank(Input{
+	recs := Rank(&Input{
 		Capabilities: []string{hwprofile.CapX86_64, hwprofile.CapOpenVINOCPU, hwprofile.CapOpenVINOGPU},
 		Entries:      []classifier.CatalogEntry{entry},
 	})
@@ -331,7 +331,7 @@ func TestRank_LegacyDemoted(t *testing.T) {
 			{ID: "old", Legacy: true, Backends: backend},
 		},
 	}
-	recs := Rank(Input{
+	recs := Rank(&Input{
 		Capabilities: []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU},
 		Entries:      []classifier.CatalogEntry{entry},
 	})
@@ -345,7 +345,7 @@ func TestRank_EmptyVariantsProducesNothing(t *testing.T) {
 	t.Parallel()
 
 	flat := classifier.CatalogEntry{ID: "flat", Files: []classifier.CatalogFile{{SizeBytes: 10}}}
-	recs := Rank(Input{
+	recs := Rank(&Input{
 		Capabilities: []string{hwprofile.CapX86_64},
 		Entries:      []classifier.CatalogEntry{flat},
 	})
@@ -360,15 +360,120 @@ func TestRank_EmptyBackendsMapNotBlocked(t *testing.T) {
 		ID:       "user-catalog",
 		Variants: []classifier.CatalogVariant{{ID: "plain"}},
 	}
-	recs := Rank(Input{
+	recs := Rank(&Input{
 		Capabilities: []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU},
 		Entries:      []classifier.CatalogEntry{entry},
 	})
 	rec, ok := variantRec(recs, "user-catalog", "plain")
 	require.True(t, ok)
 	assert.True(t, rec.Compatible, "no backend info means no blocker")
-	assert.Empty(t, rec.Reasons, "no backend info means no backend term")
+	assert.False(t, hasReason(&rec, ReasonBackendRecommended), "no backend info means no backend term")
+	assert.False(t, hasReason(&rec, ReasonBackendSupported), "no backend info means no backend term")
+	// A global variant with no region resolved still earns the global fallback,
+	// which is the only reason present here.
+	assert.True(t, hasReason(&rec, ReasonRegionGlobalFallback), "global variant, no region resolved")
 	assert.True(t, rec.Recommended, "the only compatible variant is recommended")
+}
+
+// regionEntry builds a synthetic entry with one global variant plus one variant
+// per given region slug, for the region-axis tests. Variants carry no hardware
+// requirements, so they are all compatible and the region term is isolated. The
+// global variant's download is the largest and the regional ones are 1 byte, so
+// a bare hardware tie-break (which prefers the smaller download) would favor a
+// regional variant; the region term must override that.
+func regionEntry(globalSize int64, regions ...string) classifier.CatalogEntry {
+	e := classifier.CatalogEntry{
+		ID: "regional-model",
+		Variants: []classifier.CatalogVariant{
+			{ID: "global", Files: []classifier.CatalogFile{{SizeBytes: globalSize}}},
+		},
+	}
+	for _, r := range regions {
+		e.Variants = append(e.Variants, classifier.CatalogVariant{
+			ID:     "slice-" + r,
+			Region: r,
+			Files:  []classifier.CatalogFile{{SizeBytes: 1}},
+		})
+	}
+	return e
+}
+
+func TestRank_RegionMatched(t *testing.T) {
+	t.Parallel()
+
+	entry := regionEntry(100, "iberia", "amazonia")
+	recs := Rank(&Input{
+		Capabilities:   []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU},
+		ResolvedRegion: "iberia",
+		Entries:        []classifier.CatalogEntry{entry},
+	})
+
+	assert.Equal(t, "slice-iberia", recommendedVariant(recs, "regional-model"), "the matching regional slice wins")
+
+	iberia, ok := variantRec(recs, "regional-model", "slice-iberia")
+	require.True(t, ok)
+	assert.True(t, hasReason(&iberia, ReasonRegionMatched))
+	assert.Equal(t, "iberia", reasonArg(&iberia, ReasonRegionMatched, "region"))
+
+	// A matching regional slice suppresses the global fallback: the global variant
+	// earns no region reason when the entry ships the resolved region.
+	global, ok := variantRec(recs, "regional-model", "global")
+	require.True(t, ok)
+	assert.False(t, hasReason(&global, ReasonRegionGlobalFallback), "global fallback suppressed when a slice matches")
+	assert.False(t, hasReason(&global, ReasonRegionMatched))
+
+	// A non-matching slice earns nothing on the region axis.
+	amazonia, ok := variantRec(recs, "regional-model", "slice-amazonia")
+	require.True(t, ok)
+	assert.False(t, hasReason(&amazonia, ReasonRegionMatched))
+	assert.False(t, hasReason(&amazonia, ReasonRegionGlobalFallback))
+}
+
+func TestRank_RegionGlobalFallback(t *testing.T) {
+	t.Parallel()
+
+	entry := regionEntry(100, "iberia")
+	recs := Rank(&Input{
+		Capabilities:   []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU},
+		ResolvedRegion: "", // no region resolved (global mode, or no coordinates)
+		Entries:        []classifier.CatalogEntry{entry},
+	})
+
+	assert.Equal(t, "global", recommendedVariant(recs, "regional-model"), "global wins the +50 fallback when no region resolves")
+
+	global, ok := variantRec(recs, "regional-model", "global")
+	require.True(t, ok)
+	assert.True(t, hasReason(&global, ReasonRegionGlobalFallback))
+
+	slice, ok := variantRec(recs, "regional-model", "slice-iberia")
+	require.True(t, ok)
+	assert.False(t, hasReason(&slice, ReasonRegionMatched), "no region resolved means no regional match")
+}
+
+func TestRank_RegionResolvedButNoMatchingSlice(t *testing.T) {
+	t.Parallel()
+
+	// The resolved region (amazonia) has no slice in this entry. The global model
+	// must still beat the wrong-region iberia slice, even though iberia is the
+	// smaller download and would win a bare hardware tie-break. This is the
+	// mis-recommendation hazard the global fallback is designed to close.
+	entry := regionEntry(100, "iberia")
+	recs := Rank(&Input{
+		Capabilities:   []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU},
+		ResolvedRegion: "amazonia",
+		Entries:        []classifier.CatalogEntry{entry},
+	})
+
+	assert.Equal(t, "global", recommendedVariant(recs, "regional-model"), "global fallback beats a wrong-region slice")
+
+	global, ok := variantRec(recs, "regional-model", "global")
+	require.True(t, ok)
+	assert.True(t, hasReason(&global, ReasonRegionGlobalFallback))
+
+	slice, ok := variantRec(recs, "regional-model", "slice-iberia")
+	require.True(t, ok)
+	assert.False(t, hasReason(&slice, ReasonRegionMatched))
+	assert.False(t, hasReason(&slice, ReasonRegionGlobalFallback))
 }
 
 func TestRank_PureInputNotMutated(t *testing.T) {
@@ -384,7 +489,7 @@ func TestRank_PureInputNotMutated(t *testing.T) {
 	before := len(in.Entries[0].Variants)
 	beforeCaps := slices.Clone(in.Capabilities)
 
-	_ = Rank(in)
+	_ = Rank(&in)
 
 	assert.Len(t, in.Entries[0].Variants, before, "entry variants unchanged")
 	assert.Equal(t, beforeCaps, in.Capabilities, "capabilities unchanged")
@@ -401,9 +506,9 @@ func TestRank_Deterministic(t *testing.T) {
 		DeviceClass:   deviceClassX86,
 		Entries:       []classifier.CatalogEntry{perch, v3},
 	}
-	first := Rank(in)
+	first := Rank(&in)
 	for range 20 {
-		assert.Equal(t, first, Rank(in), "Rank is deterministic across repeated calls")
+		assert.Equal(t, first, Rank(&in), "Rank is deterministic across repeated calls")
 	}
 }
 
@@ -434,7 +539,7 @@ func TestRank_FP16NativeBonus(t *testing.T) {
 	// precision bonus. This is the case the matrix test could not reach (perch-v2
 	// has no fp16 variant).
 	v3 := realEntry(t, "birdnet-v3.0")
-	recs := Rank(Input{
+	recs := Rank(&Input{
 		Capabilities: []string{hwprofile.CapAArch64, hwprofile.CapAArch64A76, hwprofile.CapONNXRuntimeCPU, hwprofile.CapFP16Native},
 		DeviceClass:  deviceClassRPi5,
 		Entries:      []classifier.CatalogEntry{v3},
@@ -460,7 +565,7 @@ func TestRank_LowRAMInt8Bonus(t *testing.T) {
 		},
 	}
 
-	lowRAM := Rank(Input{
+	lowRAM := Rank(&Input{
 		Capabilities:  []string{hwprofile.CapAArch64, hwprofile.CapONNXRuntimeCPU, hwprofile.CapLowRAM},
 		TotalRAMBytes: ramLow,
 		Entries:       []classifier.CatalogEntry{entry},
@@ -469,7 +574,7 @@ func TestRank_LowRAMInt8Bonus(t *testing.T) {
 	int8Rec, _ := variantRec(lowRAM, "ram-test", "int8")
 	assert.True(t, hasReason(&int8Rec, ReasonRAMConstrainedFit))
 
-	fullRAM := Rank(Input{
+	fullRAM := Rank(&Input{
 		Capabilities:  []string{hwprofile.CapAArch64, hwprofile.CapONNXRuntimeCPU},
 		TotalRAMBytes: ramHigh,
 		Entries:       []classifier.CatalogEntry{entry},
@@ -491,7 +596,7 @@ func TestRank_LegacyNotRecommended(t *testing.T) {
 			{ID: "new", Requirements: classifier.VariantRequirements{Arch: []string{hwprofile.CapAArch64}}, Backends: backend},
 		},
 	}
-	recs := Rank(Input{
+	recs := Rank(&Input{
 		Capabilities: []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU}, // amd64: "new" (aarch64-only) is blocked
 		Entries:      []classifier.CatalogEntry{entry},
 	})
@@ -519,7 +624,7 @@ func TestRank_BackendMissingNotDuplicated(t *testing.T) {
 			},
 		},
 	}
-	recs := Rank(Input{
+	recs := Rank(&Input{
 		Capabilities: []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU}, // no openvino-gpu
 		Entries:      []classifier.CatalogEntry{entry},
 	})


### PR DESCRIPTION
## What

Completes the region axis of the hardware- and region-aware model gallery recommender. The hardware axis and the region resolver already shipped; this wires the resolved region into the pure ranker, sorts the gallery recommended-first, and converts the entry-level incompatibility message to a translatable code.

## Changes

**Recommender (`internal/classifier/recommend`)**

- New `Input.ResolvedRegion` and two additive score terms: `region.matched` (+100) when a variant's regional slice matches the host's resolved region, and `region.global_fallback` (+50) for the global variant when no slice matches.
- A per-entry `hasMatchingRegion` precompute keeps the global fallback firing whenever the entry ships no matching slice, so a wrong-region slice can never outrank the global model on hardware terms alone.
- `Rank` now takes `*Input` (the struct grew past gocritic's hugeParam threshold); the documented "Input is never mutated" contract is unchanged and still covered by a test.

**API (`internal/api/v2/models`)**

- `resolveRecommendRegion` resolves the region slug from settings, honoring a pinned region even without coordinates and otherwise gating auto-resolution on a configured location, delegating the mode classification to the shared `region.Select`.
- `GetModelCatalog` sorts entries recommended-first (stable, recommendation-eligible requests only) and reports the ONNX-unavailable case as the structured code `backend.onnx_unavailable` instead of a raw, untranslatable ONNX Runtime error string. The specific error is still returned in full on an install attempt.

**Frontend**

- The entry-level incompatibility now renders through the i18n reason path with a localized fallback, so a structured code is never shown raw.
- Three new `analysis.gallery.reasons.*` keys, translated across all 15 locales.

## Testing

Region-matched scoring is engine-only until regional variants land in the catalog, so it is validated with synthetic-catalog table tests, including a regression test proving a wrong-region slice never outranks the global model, plus tests for the recommended-first ordering and the region resolver (including the pinned-without-coordinates path). `go test -race`, `golangci-lint`, frontend typecheck and unit tests all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model recommendations now prioritize entries compatible with the device and available backends.
  * Recommendations account for regional availability, with clear explanations for regional matches and global fallbacks.
  * Model incompatibility reasons are shown as localized, user-friendly messages.

* **Localization**
  * Added translated recommendation and compatibility messages across supported languages.

* **Bug Fixes**
  * Replaced raw technical runtime errors with understandable localized explanations.
  * Improved ordering of recommended models in the catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->