### PR TITLE
fix(models): keep the model grid visible on install failure, restore hardware capability tokens

### DIFF
--- a/frontend/src/lib/desktop/features/settings/components/ModelVariantPicker.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/ModelVariantPicker.svelte
@@ -8,7 +8,7 @@
   import type { CatalogVariant, VariantReason } from '$lib/types/models';
   import { t } from '$lib/i18n';
   import { formatBytes, formatNumber } from '$lib/utils/formatters';
-  import { reasonKey, variantLabel } from '$lib/utils/variantSelection';
+  import { translateReason, topReasons, variantLabel } from '$lib/utils/variantSelection';
 
   interface Props {
     variants: CatalogVariant[];
@@ -52,13 +52,10 @@
   );
   const hiddenCount = $derived(variants.length - visibleVariants.length);
 
+  // Fall back to the raw reason code so an unmapped reason stays inspectable
+  // rather than surfacing a dotted i18n key to the user.
   function reasonText(reason: VariantReason): string {
-    const key = reasonKey(reason.code);
-    const translated = t(key, reason.args);
-    // t returns the key itself when there is no translation; fall back to the raw
-    // reason code so an unmapped reason stays inspectable rather than surfacing a
-    // dotted i18n key to the user.
-    return translated === key ? reason.code : translated;
+    return translateReason(reason.code, reason.args, reason.code);
   }
 
   // The reason shown on a blocked option: its first blocker, or a generic
@@ -135,11 +132,15 @@
           </div>
 
           {#if variant.recommended && variant.reasons?.length}
-            <p class="text-xs text-primary/90">
-              {t('analysis.gallery.variants.recommendedForHardware')}: {reasonText(
-                variant.reasons[0]
-              )}
-            </p>
+            {@const recommendedReasons = topReasons(variant.reasons)}
+            <div class="text-xs text-primary/90">
+              <p>
+                {t('analysis.gallery.variants.recommendedForHardware')}: {recommendedReasons[0]}
+              </p>
+              {#if recommendedReasons.length > 1}
+                <p>{recommendedReasons[1]}</p>
+              {/if}
+            </div>
           {/if}
 
           {#if blocked}

--- a/frontend/src/lib/desktop/features/settings/components/ModelVariantPicker.test.ts
+++ b/frontend/src/lib/desktop/features/settings/components/ModelVariantPicker.test.ts
@@ -176,4 +176,50 @@ describe('ModelVariantPicker', () => {
     await fireEvent.click(fp32 as HTMLInputElement);
     expect(onSelect).toHaveBeenCalledWith('fp32');
   });
+
+  it('surfaces the top two recommendation reasons, including the region reason at index 1', () => {
+    const regional: CatalogVariant[] = [
+      variant({
+        id: 'fp16',
+        precision: 'fp16',
+        recommended: true,
+        reasons: [
+          { code: 'backend.recommended', args: { backend: 'openvino-gpu' } },
+          { code: 'region.matched', args: { region: 'Finland' } },
+        ],
+      }),
+    ];
+    const { container } = render(ModelVariantPicker, {
+      props: {
+        variants: regional,
+        selectedVariantId: 'fp16',
+        onSelect: vi.fn(),
+        idPrefix: 'p9',
+      },
+    });
+    // Under the echo mock both reasons render as their raw codes. The region
+    // reason sits at reasons[1], which the old single-reason render dropped.
+    expect(container.textContent).toContain('backend.recommended');
+    expect(container.textContent).toContain('region.matched');
+  });
+
+  it('renders a single reason without a second line when only one is present', () => {
+    const single: CatalogVariant[] = [
+      variant({
+        id: 'fp32',
+        precision: 'fp32',
+        recommended: true,
+        reasons: [{ code: 'region.global_fallback', args: {} }],
+      }),
+    ];
+    const { container } = render(ModelVariantPicker, {
+      props: {
+        variants: single,
+        selectedVariantId: 'fp32',
+        onSelect: vi.fn(),
+        idPrefix: 'p10',
+      },
+    });
+    expect(container.textContent).toContain('region.global_fallback');
+  });
 });

--- a/frontend/src/lib/desktop/features/settings/components/ModelVariantPicker.test.ts
+++ b/frontend/src/lib/desktop/features/settings/components/ModelVariantPicker.test.ts
@@ -220,6 +220,10 @@ describe('ModelVariantPicker', () => {
         idPrefix: 'p10',
       },
     });
-    expect(container.textContent).toContain('region.global_fallback');
+    // Exactly one reason line renders; a length>1 -> length>=1 regression would
+    // render a stray empty second paragraph.
+    const reasonParagraphs = container.querySelectorAll('[class*="text-primary/90"] p');
+    expect(reasonParagraphs).toHaveLength(1);
+    expect(reasonParagraphs[0].textContent).toContain('region.global_fallback');
   });
 });

--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
@@ -36,6 +36,7 @@
     reinstallModel,
     uninstallModel,
     subscribeInstallProgress,
+    isNetworkDownloadError,
   } from '$lib/utils/modelsApi';
   import { invalidateModels } from '$lib/stores/models.svelte';
   import SettingsTabs from '$lib/desktop/features/settings/components/SettingsTabs.svelte';
@@ -68,7 +69,7 @@
   import { buildAppUrl } from '$lib/utils/urlHelpers';
   import { toastActions } from '$lib/stores/toast';
   import { formatBytes, formatNumber } from '$lib/utils/formatters';
-  import { pickPreselectedVariant, reasonKey } from '$lib/utils/variantSelection';
+  import { pickPreselectedVariant, translateReason } from '$lib/utils/variantSelection';
   import { safeArrayAccess } from '$lib/utils/security';
   import { loggers } from '$lib/utils/logger';
   import { t } from '$lib/i18n';
@@ -118,15 +119,15 @@
   // Render an entry-level incompatibility code (e.g. "backend.onnx_unavailable")
   // through the same i18n reason path the variant picker uses, falling back to a
   // generic localized line when the code is absent or has no translation, so a
-  // structured code never surfaces to the user as a raw dotted string.
-  // Entry-level codes carry no interpolation args (unlike variant reasons), so no
-  // args are threaded here; a future parameterized entry-level code would need an
-  // args field on CatalogEntryResponse.IncompatibleReason and a change here.
-  function entryIncompatibleText(code: string | undefined, fallbackKey: string): string {
-    if (!code) return t(fallbackKey);
-    const key = reasonKey(code);
-    const translated = t(key);
-    return translated === key ? t(fallbackKey) : translated;
+  // structured code never surfaces to the user as a raw dotted string. The
+  // fallback is cause-neutral on purpose: it is only reached when the code is
+  // missing or unmapped, which is exactly when the specific cause is not known.
+  // Entry-level codes carry no interpolation args (unlike variant reasons), so
+  // undefined args are passed; a future parameterized entry-level code would need
+  // an args field on CatalogEntryResponse.IncompatibleReason and a change here.
+  function entryIncompatibleText(code: string | undefined): string {
+    const fallback = t('analysis.gallery.entryIncompatible');
+    return code ? translateReason(code, undefined, fallback) : fallback;
   }
 
   // ── Page-level tab state ──────────────────────────────────────────────
@@ -139,7 +140,24 @@
   // sections, which the visibility-filtered catalog cannot).
   let installedModels = $state<InstalledModel[]>([]);
   let loading = $state(true);
-  let error = $state<string | null>(null);
+  // Catalog loading failure: gates the two gallery tab bodies and drives the
+  // banner whose Retry re-runs loadCatalog.
+  let catalogError = $state<string | null>(null);
+
+  // A failed per-model action (install, reinstall, remove). Rendered as a
+  // dismissible banner above the gallery tabs so it never replaces the grid, and
+  // so switching tabs cannot strand it. Carries enough to offer a real Retry and,
+  // for a download-reachability failure, a pointer to the Download Source setting.
+  type GalleryActionKind = 'install' | 'reinstall' | 'remove';
+  interface GalleryActionError {
+    modelId: string;
+    modelName: string;
+    kind: GalleryActionKind;
+    message: string; // raw backend/SSE/ApiError text, kept inspectable
+    variantId?: string; // reused when retrying an install
+    network: boolean; // download could not reach the model host
+  }
+  let installError = $state<GalleryActionError | null>(null);
 
   let installingId = $state<string | null>(null);
   let deletingId = $state<string | null>(null);
@@ -905,7 +923,7 @@
   // ── Gallery functions ─────────────────────────────────────────────────
   async function loadCatalog() {
     loading = true;
-    error = null;
+    catalogError = null;
     try {
       const response = await fetchCatalog();
       catalog = response.catalog;
@@ -913,7 +931,8 @@
       // threshold sections track install/uninstall. Swallows its own errors.
       await loadInstalledModels();
     } catch (e) {
-      error = e instanceof Error ? e.message : t('analysis.gallery.errors.catalogLoadFailed');
+      catalogError =
+        e instanceof Error ? e.message : t('analysis.gallery.errors.catalogLoadFailed');
     } finally {
       loading = false;
     }
@@ -946,10 +965,18 @@
     // (the button is disabled in this state; this guards a programmatic call too).
     if (installBlocked) return;
     const modelId = licenseModel.id;
+    const modelName = licenseModel.name;
     // Only send a variantId when the entry actually offers variants; a flat entry
     // installs its single build with no variant.
     const variantId = licenseModel.variants?.length ? selectedVariantId : undefined;
     closeLicenseDialog();
+    startInstall(modelId, modelName, variantId);
+  }
+
+  // The install body, extracted so a failed install's Retry can re-run it without
+  // reopening the license dialog (the license was accepted this session).
+  async function startInstall(modelId: string, modelName: string, variantId: string | undefined) {
+    installError = null;
     installingId = modelId;
     downloadProgress = null;
 
@@ -983,16 +1010,38 @@
           }, 2000);
         },
         (err: string) => {
-          error = err;
+          installError = reportActionError(modelId, modelName, 'install', err, variantId);
           installingId = null;
           downloadProgress = null;
           progressCleanup = null;
         }
       );
     } catch (e) {
-      error = e instanceof Error ? e.message : t('analysis.gallery.errors.installFailed');
+      const message = e instanceof Error ? e.message : t('analysis.gallery.errors.installFailed');
+      installError = reportActionError(modelId, modelName, 'install', message, variantId);
       installingId = null;
     }
+  }
+
+  // Build a GalleryActionError, classifying whether a mirror endpoint could help.
+  function reportActionError(
+    modelId: string,
+    modelName: string,
+    kind: GalleryActionKind,
+    message: string,
+    variantId?: string
+  ): GalleryActionError {
+    return {
+      modelId,
+      modelName,
+      kind,
+      message,
+      variantId,
+      // A remove failure never involves a download, so it is never network-shaped;
+      // enforce that structurally rather than trusting the delete error's text not
+      // to contain a download-error substring.
+      network: kind !== 'remove' && isNetworkDownloadError(message),
+    };
   }
 
   function openRemoveDialog(entry: CatalogEntry) {
@@ -1008,7 +1057,9 @@
   async function handleUninstall() {
     if (!removeConfirmModel) return;
     const modelId = removeConfirmModel.id;
+    const modelName = removeConfirmModel.name;
     closeRemoveDialog();
+    installError = null;
     deletingId = modelId;
 
     try {
@@ -1016,7 +1067,9 @@
       invalidateModels();
       await loadCatalog();
     } catch (e) {
-      error = e instanceof Error ? e.message : t('analysis.gallery.errors.removeFailed');
+      const message = e instanceof Error ? e.message : t('analysis.gallery.errors.removeFailed');
+      // A remove failure never involves a download, so it is never network-shaped.
+      installError = reportActionError(modelId, modelName, 'remove', message);
     } finally {
       deletingId = null;
     }
@@ -1024,21 +1077,27 @@
 
   async function handleReinstall(entry: CatalogEntry) {
     if (reinstallingId || installingId) return;
-    reinstallingId = entry.id;
+    startReinstall(entry.id, entry.name);
+  }
+
+  // The reinstall body, extracted so a failed reinstall's Retry can re-run it.
+  async function startReinstall(modelId: string, modelName: string) {
+    installError = null;
+    reinstallingId = modelId;
     downloadProgress = null;
 
     try {
-      await reinstallModel(entry.id);
+      await reinstallModel(modelId);
 
       if (progressCleanup) progressCleanup();
       progressCleanup = subscribeInstallProgress(
-        entry.id,
+        modelId,
         (progress: DownloadProgress) => {
           downloadProgress = progress;
         },
         () => {
           downloadProgress = {
-            catalogId: entry.id,
+            catalogId: modelId,
             status: 'complete',
             downloadedBytes: 0,
             totalBytes: 0,
@@ -1048,7 +1107,7 @@
           progressCleanup = null;
           clearTimeout(completionTimer);
           completionTimer = setTimeout(() => {
-            if (reinstallingId === entry.id) {
+            if (reinstallingId === modelId) {
               reinstallingId = null;
               downloadProgress = null;
             }
@@ -1057,16 +1116,39 @@
           }, 2000);
         },
         (err: string) => {
-          error = err;
+          installError = reportActionError(modelId, modelName, 'reinstall', err);
           reinstallingId = null;
           downloadProgress = null;
           progressCleanup = null;
         }
       );
     } catch (e) {
-      error = e instanceof Error ? e.message : t('analysis.gallery.errors.installFailed');
+      const message = e instanceof Error ? e.message : t('analysis.gallery.errors.installFailed');
+      installError = reportActionError(modelId, modelName, 'reinstall', message);
       reinstallingId = null;
     }
+  }
+
+  // Re-run whichever action failed; the stored error object carries what is needed.
+  // A remove failure offers no retry (the card's Remove button is right there).
+  function retryFailedAction() {
+    if (!installError) return;
+    const { modelId, modelName, variantId, kind } = installError;
+    if (kind === 'install') startInstall(modelId, modelName, variantId);
+    else if (kind === 'reinstall') startReinstall(modelId, modelName);
+  }
+
+  function dismissInstallError() {
+    installError = null;
+  }
+
+  // Bring the Download Source setting into view and focus it: the mirror endpoint
+  // is the remedy for a download-reachability failure, and it lives on this same
+  // Models tab, just below the gallery.
+  function scrollToDownloadSource() {
+    const el = document.getElementById('huggingface-endpoint');
+    el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    el?.focus();
   }
 
   /** Compute download percentage for progress bar */
@@ -1626,6 +1708,65 @@
       currentData={{ modelRegion: birdnet?.modelRegion ?? 'auto' }}
     >
       <ModelRegionSelector disabled={store.isLoading || store.isSaving} />
+
+      <!-- A failed install/reinstall/remove surfaces here, above the gallery tabs,
+           so it never replaces the model grid and stays visible across tabs. -->
+      {#if installError}
+        <div
+          class="mt-4 flex flex-col gap-2 rounded-lg border border-[var(--color-error)]/30 bg-[var(--color-error)]/10 px-4 py-3 text-sm"
+          role="alert"
+        >
+          <div class="flex items-start gap-3">
+            <AlertTriangle class="size-5 shrink-0 text-[var(--color-error)]" aria-hidden="true" />
+            <div class="min-w-0 flex-1">
+              <p class="font-medium text-[var(--color-base-content)]">
+                {t('analysis.gallery.errors.actionFailed', { name: installError.modelName })}
+              </p>
+              <p class="mt-0.5 break-words text-[var(--color-base-content)]/80">
+                {installError.message}
+              </p>
+              {#if installError.network}
+                <p class="mt-2 text-[var(--color-base-content)]/80">
+                  {t('analysis.gallery.errors.downloadSourceHint')}
+                </p>
+              {/if}
+            </div>
+            <button
+              type="button"
+              class="ml-auto inline-flex items-center justify-center rounded-md p-1.5 bg-transparent hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
+              aria-label={t('analysis.gallery.errors.dismiss')}
+              onclick={dismissInstallError}
+            >
+              <X class="size-4" />
+            </button>
+          </div>
+          {#if installError.kind !== 'remove' || installError.network}
+            <div class="flex flex-wrap items-center gap-2 pl-8">
+              {#if installError.kind !== 'remove'}
+                <button
+                  type="button"
+                  class="inline-flex items-center gap-1.5 rounded-md bg-[var(--color-base-200)] px-3 py-1.5 text-xs font-medium text-[var(--color-base-content)] hover:bg-[var(--color-base-300)] transition-colors"
+                  onclick={retryFailedAction}
+                >
+                  <RefreshCw class="size-3.5" aria-hidden="true" />
+                  {t('analysis.gallery.retry')}
+                </button>
+              {/if}
+              {#if installError.network}
+                <button
+                  type="button"
+                  class="inline-flex items-center gap-1.5 rounded-md bg-[var(--color-base-200)] px-3 py-1.5 text-xs font-medium text-[var(--color-base-content)] hover:bg-[var(--color-base-300)] transition-colors"
+                  onclick={scrollToDownloadSource}
+                >
+                  <SettingsIcon class="size-3.5" aria-hidden="true" />
+                  {t('analysis.gallery.errors.goToDownloadSource')}
+                </button>
+              {/if}
+            </div>
+          {/if}
+        </div>
+      {/if}
+
       <SettingsTabs tabs={galleryTabs} bind:activeTab={galleryTab} showActions={false} />
     </SettingsSection>
 
@@ -1690,13 +1831,13 @@
           >{t('analysis.gallery.loading')}</span
         >
       </div>
-    {:else if error}
+    {:else if catalogError}
       <div
         class="flex items-center gap-3 rounded-lg border border-[var(--color-error)]/30 bg-[var(--color-error)]/10 px-4 py-3 text-sm"
         role="alert"
       >
         <AlertTriangle class="size-5 shrink-0 text-[var(--color-error)]" />
-        <span class="text-[var(--color-base-content)]">{error}</span>
+        <span class="text-[var(--color-base-content)]">{catalogError}</span>
         <button
           onclick={loadCatalog}
           class="ml-auto flex items-center gap-1.5 rounded-md bg-[var(--color-base-200)] px-3 py-1.5 text-xs font-medium text-[var(--color-base-content)] hover:bg-[var(--color-base-300)] transition-colors"
@@ -1821,15 +1962,11 @@
             <!-- Incompatible warning for installed models -->
             {#if !entry.compatible}
               <div
-                class="mt-3 flex items-start gap-2 rounded-lg bg-red-500/10 p-3 text-xs text-red-700 dark:text-red-400"
+                class="mt-3 flex items-start gap-2 rounded-lg bg-red-500/10 p-3 text-sm text-red-700 dark:text-red-400"
+                role="status"
               >
                 <XCircle class="h-4 w-4 shrink-0 mt-0.5" />
-                <span
-                  >{entryIncompatibleText(
-                    entry.incompatibleReason,
-                    'analysis.gallery.onnxRuntimeMissing'
-                  )}</span
-                >
+                <span>{entryIncompatibleText(entry.incompatibleReason)}</span>
               </div>
             {/if}
             <!-- Metadata grid -->
@@ -2010,15 +2147,11 @@
     <!-- Incompatible warning banner -->
     {#if !entry.compatible}
       <div
-        class="mt-3 flex items-start gap-2 rounded-lg bg-amber-500/10 p-3 text-xs text-amber-700 dark:text-amber-400"
+        class="mt-3 flex items-start gap-2 rounded-lg bg-amber-500/10 p-3 text-sm text-amber-700 dark:text-amber-400"
+        role="status"
       >
         <TriangleAlert class="h-4 w-4 shrink-0 mt-0.5" />
-        <span
-          >{entryIncompatibleText(
-            entry.incompatibleReason,
-            'analysis.gallery.onnxRuntimeRequired'
-          )}</span
-        >
+        <span>{entryIncompatibleText(entry.incompatibleReason)}</span>
       </div>
     {/if}
 
@@ -2096,13 +2229,13 @@
           >{t('analysis.gallery.loading')}</span
         >
       </div>
-    {:else if error}
+    {:else if catalogError}
       <div
         class="flex items-center gap-3 rounded-lg border border-[var(--color-error)]/30 bg-[var(--color-error)]/10 px-4 py-3 text-sm"
         role="alert"
       >
         <AlertTriangle class="size-5 shrink-0 text-[var(--color-error)]" />
-        <span class="text-[var(--color-base-content)]">{error}</span>
+        <span class="text-[var(--color-base-content)]">{catalogError}</span>
         <button
           onclick={loadCatalog}
           class="ml-auto flex items-center gap-1.5 rounded-md bg-[var(--color-base-200)] px-3 py-1.5 text-xs font-medium text-[var(--color-base-content)] hover:bg-[var(--color-base-300)] transition-colors"

--- a/frontend/src/lib/desktop/features/system/inference.types.ts
+++ b/frontend/src/lib/desktop/features/system/inference.types.ts
@@ -73,11 +73,11 @@ export interface InferenceHardware {
   /**
    * Capability tokens this host matches, in the model manifests' vocabulary.
    *
-   * No UI reads this: the row that rendered the tokens was removed, because
-   * every one of them is derived from a fact the card already states. The field
-   * is kept to mirror the server contract, which still sends it, so a raw call
-   * to the endpoint remains a usable diagnostic for which model builds a host
-   * matches. Do not treat it as dead and delete it without dropping the Go
+   * Rendered by SystemInference's Advanced disclosure on the hardware card. Most
+   * tokens duplicate a fact the card already states, but two do not and are only
+   * visible here: `low-ram` (set below the RAM threshold in
+   * internal/hwprofile/capabilities.go) and `openvino-gpu-intel-gen<N>` (the
+   * per-generation Intel GPU token). Do not delete this without dropping the Go
    * field too (internal/api/v2/system/inference_status.go).
    */
   capabilities?: string[];

--- a/frontend/src/lib/desktop/views/SystemInference.svelte
+++ b/frontend/src/lib/desktop/views/SystemInference.svelte
@@ -698,6 +698,36 @@
             </dd>
           {/each}
         </dl>
+
+        <!-- Advanced: the raw capability tokens this host matches in the model
+             manifests' vocabulary. Collapsed by default, it is token soup for a
+             casual user, but the low-ram and per-generation Intel GPU tokens are
+             not derivable from any other fact on this card, so this is the only
+             place a user can see the tokens that decided which model was picked. -->
+        {#if snapshot.hardware.capabilities?.length}
+          <details class="mt-3 pt-3 border-t border-[var(--border-100)]">
+            <summary class="text-sm text-muted cursor-pointer">
+              {t('system.inference.advanced')}
+            </summary>
+            <div class="mt-2 flex items-start gap-3">
+              <span
+                class="text-sm text-muted shrink-0"
+                title={t('system.inference.capabilitiesHelp')}
+                aria-describedby="hw-capabilities-help"
+              >
+                {t('system.inference.capabilities')}
+              </span>
+              <span id="hw-capabilities-help" class="sr-only"
+                >{t('system.inference.capabilitiesHelp')}</span
+              >
+              <div class="flex flex-wrap items-center gap-2">
+                {#each snapshot.hardware.capabilities as capability (capability)}
+                  <Badge variant="neutral" size="sm" text={capability} />
+                {/each}
+              </div>
+            </div>
+          </details>
+        {/if}
       </div>
 
       <!-- Inference backends -->

--- a/frontend/src/lib/desktop/views/SystemInference.svelte
+++ b/frontend/src/lib/desktop/views/SystemInference.svelte
@@ -98,6 +98,7 @@
   // places can drift apart silently: the reference just stops resolving, with no
   // error anywhere and nothing visible to a sighted reader.
   const FP16_HELP_ID = 'help-fp16';
+  const HARDWARE_CAPABILITIES_HELP_ID = 'hw-capabilities-help';
 
   interface MetricPoint {
     timestamp: string;
@@ -713,11 +714,11 @@
               <span
                 class="text-sm text-muted shrink-0"
                 title={t('system.inference.capabilitiesHelp')}
-                aria-describedby="hw-capabilities-help"
+                aria-describedby={HARDWARE_CAPABILITIES_HELP_ID}
               >
                 {t('system.inference.capabilities')}
               </span>
-              <span id="hw-capabilities-help" class="sr-only"
+              <span id={HARDWARE_CAPABILITIES_HELP_ID} class="sr-only"
                 >{t('system.inference.capabilitiesHelp')}</span
               >
               <div class="flex flex-wrap items-center gap-2">

--- a/frontend/src/lib/desktop/views/SystemInference.test.ts
+++ b/frontend/src/lib/desktop/views/SystemInference.test.ts
@@ -978,4 +978,56 @@ describe('SystemInference', () => {
       expect(container.textContent).toContain('system.inference.gpuReasonUnknown');
     });
   });
+
+  describe('hardware capability tokens (Advanced disclosure)', () => {
+    // The mocked t() returns the key, so these are the strings that reach the DOM.
+    const ADVANCED_KEY = 'system.inference.advanced';
+    const CAPABILITIES_KEY = 'system.inference.capabilities';
+    const HARDWARE_HEADING_KEY = 'system.inference.sectionHardware';
+
+    it('hides the disclosure when the host reports no capability tokens', async () => {
+      installApi(makeSnapshot([makeModel({})], {})); // fixture omits capabilities
+
+      const { container } = inferenceTest.render({});
+
+      await waitFor(() => {
+        expect(container.textContent).toContain(HARDWARE_HEADING_KEY);
+      });
+      expect(container.textContent).not.toContain(ADVANCED_KEY);
+    });
+
+    it('reveals the tokens as badges when the host reports them', async () => {
+      installApi(
+        makeSnapshot([makeModel({})], {
+          capabilities: ['low-ram', 'openvino-gpu-intel-gen12'],
+        })
+      );
+
+      const { container } = inferenceTest.render({});
+
+      await waitFor(() => {
+        expect(container.textContent).toContain(ADVANCED_KEY);
+      });
+      expect(container.textContent).toContain(CAPABILITIES_KEY);
+      // The two non-derivable tokens this feature exists to surface.
+      expect(container.textContent).toContain('low-ram');
+      expect(container.textContent).toContain('openvino-gpu-intel-gen12');
+    });
+
+    // Placement, not just presence: the tokens describe the host, so the
+    // disclosure must live in the Hardware card (the definition-list card), not
+    // the Backends card. This fails if it is moved next to the FP16 footer.
+    it('places the disclosure in the Hardware card', async () => {
+      installApi(makeSnapshot([makeModel({})], { capabilities: ['low-ram'] }));
+
+      const { container } = inferenceTest.render({});
+
+      await waitFor(() => {
+        expect(container.textContent).toContain(ADVANCED_KEY);
+      });
+      const card = container.querySelector('details')?.closest('div.rounded-xl');
+      expect(card?.textContent).toContain(HARDWARE_HEADING_KEY);
+      expect(card?.querySelector('dl')).not.toBeNull();
+    });
+  });
 });

--- a/frontend/src/lib/desktop/views/SystemInference.test.ts
+++ b/frontend/src/lib/desktop/views/SystemInference.test.ts
@@ -1008,6 +1008,8 @@ describe('SystemInference', () => {
       await waitFor(() => {
         expect(container.textContent).toContain(ADVANCED_KEY);
       });
+      // The disclosure must be collapsed by default (token soup stays hidden).
+      expect(container.querySelector('details[open]')).toBeNull();
       expect(container.textContent).toContain(CAPABILITIES_KEY);
       // The two non-derivable tokens this feature exists to surface.
       expect(container.textContent).toContain('low-ram');

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -1307,6 +1307,9 @@ export type TranslationKey =
   | 'system.inference.fp16'
   | 'system.inference.fp16Supported'
   | 'system.inference.fp16Unsupported'
+  | 'system.inference.advanced'
+  | 'system.inference.capabilities'
+  | 'system.inference.capabilitiesHelp'
   | 'system.inference.backendTflite'
   | 'system.inference.backendOnnx'
   | 'system.inference.backendOpenvino'
@@ -3936,15 +3939,17 @@ export type TranslationKey =
   | 'analysis.gallery.errors.catalogLoadFailed'
   | 'analysis.gallery.errors.installFailed'
   | 'analysis.gallery.errors.removeFailed'
+  | 'analysis.gallery.errors.actionFailed' // params: name
+  | 'analysis.gallery.errors.downloadSourceHint'
+  | 'analysis.gallery.errors.goToDownloadSource'
+  | 'analysis.gallery.errors.dismiss'
   | 'analysis.gallery.regionLabel'
   | 'analysis.gallery.speciesLabel'
   | 'analysis.gallery.reinstall'
   | 'analysis.gallery.reinstalling'
   | 'analysis.gallery.reinstallComplete'
   | 'analysis.gallery.geomodelBadge'
-  | 'analysis.gallery.onnxRuntimeRequired'
-  | 'analysis.gallery.onnxRuntimeMissing'
-  | 'analysis.gallery.unavailable'
+  | 'analysis.gallery.entryIncompatible'
   | 'analysis.bird.title'
   | 'analysis.bird.description'
   | 'analysis.bat.title'
@@ -4487,6 +4492,7 @@ export type TranslationParams = {
   'analysis.gallery.reasons.hardwareExcluded': { token: string | number };
   'analysis.gallery.species': { count: string | number };
   'analysis.gallery.removeDialog.title': { name: string | number };
+  'analysis.gallery.errors.actionFailed': { name: string | number };
 };
 
 /**

--- a/frontend/src/lib/utils/modelsApi.test.ts
+++ b/frontend/src/lib/utils/modelsApi.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { isNetworkDownloadError } from './modelsApi';
+
+describe('isNetworkDownloadError', () => {
+  // The three CategoryNetwork download-failure formats the backend emits
+  // (internal/classifier/model_manager.go), which a mirror endpoint could remedy.
+  it.each([
+    'HTTP request failed for https://huggingface.co/repo/file: dial tcp: connection refused',
+    'HTTP 403 for https://huggingface.co/repo/file',
+    'HTTP 429 for https://huggingface.co/repo/file',
+    'HTTP 503 for https://hf-mirror.com/repo/file',
+    'read error downloading https://huggingface.co/repo/file: unexpected EOF',
+  ])('matches a network-shaped download failure: %s', msg => {
+    expect(isNetworkDownloadError(msg)).toBe(true);
+  });
+
+  // Failures a mirror cannot fix, so the hint must not be offered.
+  it.each([
+    'Connection to server lost', // frontend-generated: the BirdNET-Go server dropped
+    'checksum mismatch for model.onnx',
+    'install timed out or failed before progress could be tracked',
+    'no space left on device',
+    '',
+  ])('does not match a non-network failure: %s', msg => {
+    expect(isNetworkDownloadError(msg)).toBe(false);
+  });
+});

--- a/frontend/src/lib/utils/modelsApi.ts
+++ b/frontend/src/lib/utils/modelsApi.ts
@@ -68,6 +68,25 @@ export async function reinstallModel(id: string): Promise<void> {
   await api.post(`${BASE}/reinstall/${encodeURIComponent(id)}`);
 }
 
+// The server reports model-download failures as raw strings (EnhancedError.Error()
+// forwards the bare message). These three shapes are exactly the CategoryNetwork
+// download failures a mirror endpoint can remedy (internal/classifier/model_manager.go):
+//   "HTTP request failed for <url>: <cause>"  (DNS, connection refused, TLS, timeout)
+//   "HTTP <status> for <url>"                 (host blocked the request or rate-limited)
+//   "read error downloading <url>: <cause>"   (connection dropped mid-transfer)
+// Deliberately NOT matched: the frontend-generated "Connection to server lost"
+// (the BirdNET-Go server dropped, not the model host, so a mirror will not help),
+// checksum/disk errors, and generic install-timeout messages. A miss only omits the
+// mirror hint, so the check fails safe. A structured error category on the download
+// state is the cleaner long-term fix and is tracked separately.
+const NETWORK_DOWNLOAD_ERROR = /HTTP request failed for |HTTP \d{3} for |read error downloading /;
+
+/** True when a model-install failure message looks like a reachability problem the
+ * configurable download source (mirror endpoint) could work around. */
+export function isNetworkDownloadError(message: string): boolean {
+  return NETWORK_DOWNLOAD_ERROR.test(message);
+}
+
 /**
  * Subscribe to SSE progress events for an ongoing model install.
  *

--- a/frontend/src/lib/utils/variantSelection.test.ts
+++ b/frontend/src/lib/utils/variantSelection.test.ts
@@ -1,6 +1,25 @@
-import { describe, it, expect } from 'vitest';
-import { pickPreselectedVariant, reasonKey, variantLabel } from './variantSelection';
-import type { CatalogEntry, CatalogVariant } from '$lib/types/models';
+import { describe, it, expect, vi } from 'vitest';
+import {
+  pickPreselectedVariant,
+  reasonKey,
+  variantLabel,
+  translateReason,
+  topReasons,
+} from './variantSelection';
+import type { CatalogEntry, CatalogVariant, VariantReason } from '$lib/types/models';
+
+// Controlled i18n mock: only these two keys have a "translation"; every other key
+// echoes back, which is how the real t() signals an untranslated key. This lets us
+// exercise both the translated branch and the fallback branch of translateReason.
+vi.mock('$lib/i18n', () => ({
+  t: (key: string) => {
+    const dict: Record<string, string> = {
+      'analysis.gallery.reasons.backendRecommended': 'Best for your hardware',
+      'analysis.gallery.reasons.regionMatched': 'Matched to your region',
+    };
+    return dict[key] ?? key;
+  },
+}));
 
 function variant(overrides: Partial<CatalogVariant> & { id: string }): CatalogVariant {
   return {
@@ -131,5 +150,49 @@ describe('variantLabel', () => {
 
   it('falls back to the id when precision is absent', () => {
     expect(variantLabel(variant({ id: 'custom' }))).toBe('custom');
+  });
+});
+
+describe('translateReason', () => {
+  it('returns the translation when the reason code maps to a real key', () => {
+    expect(translateReason('backend.recommended', undefined, 'raw')).toBe('Best for your hardware');
+  });
+
+  it('returns the fallback when the reason code has no translation', () => {
+    expect(translateReason('some.unmapped_code', undefined, 'raw-fallback')).toBe('raw-fallback');
+  });
+
+  it('passes interpolation args through to t', () => {
+    // regionMatched has a translation, so the translated branch is taken; the mock
+    // ignores args, but this asserts args are accepted without changing the result.
+    expect(translateReason('region.matched', { region: 'Finland' }, 'raw')).toBe(
+      'Matched to your region'
+    );
+  });
+});
+
+describe('topReasons', () => {
+  const reason = (code: string): VariantReason => ({ code });
+
+  it('returns an empty array for no reasons', () => {
+    expect(topReasons(undefined)).toEqual([]);
+    expect(topReasons([])).toEqual([]);
+  });
+
+  it('localizes a single reason', () => {
+    expect(topReasons([reason('backend.recommended')])).toEqual(['Best for your hardware']);
+  });
+
+  it('surfaces the region reason that sits at index 1, not just the headline', () => {
+    expect(topReasons([reason('backend.recommended'), reason('region.matched')])).toEqual([
+      'Best for your hardware',
+      'Matched to your region',
+    ]);
+  });
+
+  it('caps at the limit and falls back to the raw code for unmapped reasons', () => {
+    expect(
+      topReasons([reason('backend.recommended'), reason('region.matched'), reason('extra.one')])
+    ).toEqual(['Best for your hardware', 'Matched to your region']);
   });
 });

--- a/frontend/src/lib/utils/variantSelection.ts
+++ b/frontend/src/lib/utils/variantSelection.ts
@@ -1,7 +1,9 @@
-// Pure helpers for the model gallery variant picker. No Svelte, no I/O, so they
-// are trivially unit-testable.
+// Helpers for the model gallery variant picker. Dependency-light and
+// unit-testable; the only non-pure import is `t` for reason localization, which
+// every test environment mocks (see src/test/setup.ts).
 
-import type { CatalogEntry, CatalogVariant } from '$lib/types/models';
+import type { CatalogEntry, CatalogVariant, VariantReason } from '$lib/types/models';
+import { t } from '$lib/i18n';
 
 /**
  * Choose the variant the gallery preselects for an entry. This is the "smart by
@@ -53,6 +55,36 @@ export function reasonKey(code: string): string {
     )
     .join('');
   return `analysis.gallery.reasons.${stem}`;
+}
+
+/**
+ * Localize a structured reason code, returning `fallback` when the code has no
+ * translation. Unifies the two former copies of this pattern (the variant
+ * picker's `reasonText`, which falls back to the raw code, and the gallery's
+ * entry-level banner, which falls back to a generic localized line): each caller
+ * passes the fallback string it wants. `t` returns the key itself for an unmapped
+ * key, which is how "no translation" is detected.
+ */
+export function translateReason(
+  code: string,
+  args: Record<string, string> | undefined,
+  fallback: string
+): string {
+  const key = reasonKey(code);
+  const translated = t(key, args);
+  return translated === key ? fallback : translated;
+}
+
+/**
+ * Localize the top `limit` reasons of a recommended variant, each on the raw code
+ * as fallback. The recommender orders the backend reason first (the headline) and
+ * appends `region.matched` second, so rendering only the first hides the region
+ * match on a recommended regional variant; surfacing the top two fixes that.
+ * Returns the localized strings as an array so the caller controls layout.
+ */
+export function topReasons(reasons: VariantReason[] | undefined, limit = 2): string[] {
+  if (!reasons?.length) return [];
+  return reasons.slice(0, limit).map(r => translateReason(r.code, r.args, r.code));
 }
 
 /**

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -1706,6 +1706,9 @@
       "fp16": "FP16",
       "fp16Supported": "FP16 podporováno",
       "fp16Unsupported": "FP16 nepodporováno",
+      "advanced": "Pokročilé",
+      "capabilities": "Schopnosti",
+      "capabilitiesHelp": "Hardwarové značky používané k přiřazení tohoto počítače k dostupným sestavením modelů.",
       "backendTflite": "TensorFlow Lite",
       "backendOnnx": "ONNX Runtime",
       "backendOpenvino": "OpenVINO",
@@ -5341,7 +5344,7 @@
         "backendMissing": "Vyžaduje inferenční backend, který není dostupný ({required})",
         "ramInsufficient": "Vyžaduje alespoň {requiredMb} MB paměti",
         "hardwareExcluded": "Nepodporováno na vašem hardwaru ({token})",
-        "backendOnnxUnavailable": "Vyžaduje ONNX Runtime, který není v tomto systému k dispozici"
+        "backendOnnxUnavailable": "Vyžaduje ONNX Runtime, který není v tomto systému k dispozici. Obrazy Docker a archivy vydání jej obsahují; viz instalační příručka ONNX Runtime."
       },
       "tabs": {
         "installed": "Nainstalované",
@@ -5395,7 +5398,11 @@
       "errors": {
         "catalogLoadFailed": "Nepodařilo se načíst katalog modelů",
         "installFailed": "Nepodařilo se spustit instalaci modelu",
-        "removeFailed": "Nepodařilo se odstranit model"
+        "removeFailed": "Nepodařilo se odstranit model",
+        "actionFailed": "Došlo k problému s {name}",
+        "downloadSourceHint": "Pokud je huggingface.co ve vaší síti blokováno nebo pomalé, nastavte zrcadlový server v sekci Zdroj stahování níže.",
+        "goToDownloadSource": "Přejít na Zdroj stahování",
+        "dismiss": "Zavřít"
       },
       "regionLabel": "Oblast",
       "speciesLabel": "Druhy",
@@ -5403,9 +5410,7 @@
       "reinstalling": "Přeinstalování…",
       "reinstallComplete": "Soubory úspěšně ověřeny",
       "geomodelBadge": "Obsahuje BirdNET v3.0 geomodel",
-      "onnxRuntimeRequired": "Vyžaduje ONNX Runtime, který není v tomto systému k dispozici.",
-      "onnxRuntimeMissing": "ONNX Runtime není k dispozici. Tento model nelze spustit.",
-      "unavailable": "Nedostupné"
+      "entryIncompatible": "Tento model není v tomto systému k dispozici."
     },
     "bird": {
       "title": "Detekce ptáků",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -1706,6 +1706,9 @@
       "fp16": "FP16",
       "fp16Supported": "FP16 understøttet",
       "fp16Unsupported": "FP16 ikke understøttet",
+      "advanced": "Avanceret",
+      "capabilities": "Egenskaber",
+      "capabilitiesHelp": "Hardware-tags, der bruges til at matche denne maskine med de tilgængelige modelbygninger.",
       "backendTflite": "TensorFlow Lite",
       "backendOnnx": "ONNX Runtime",
       "backendOpenvino": "OpenVINO",
@@ -5341,7 +5344,7 @@
         "backendMissing": "Kræver en inference backend, som din version ikke kan nå ({required})",
         "ramInsufficient": "Kræver mindst {requiredMb} MB hukommelse",
         "hardwareExcluded": "Understøttes ikke på din hardware ({token})",
-        "backendOnnxUnavailable": "Kræver ONNX Runtime, som ikke er tilgængelig på dette system"
+        "backendOnnxUnavailable": "Kræver ONNX Runtime, som ikke er tilgængelig på dette system. Docker-images og udgivelsespakker indeholder det; se installationsvejledningen til ONNX Runtime."
       },
       "tabs": {
         "installed": "Installerede",
@@ -5395,7 +5398,11 @@
       "errors": {
         "catalogLoadFailed": "Kunne ikke indlæse modelkatalog",
         "installFailed": "Kunne ikke starte modelinstallation",
-        "removeFailed": "Kunne ikke fjerne model"
+        "removeFailed": "Kunne ikke fjerne model",
+        "actionFailed": "Der opstod et problem med {name}",
+        "downloadSourceHint": "Hvis huggingface.co er blokeret eller langsomt på dit netværk, kan du indstille en spejlserver i sektionen Downloadkilde nedenfor.",
+        "goToDownloadSource": "Gå til Downloadkilde",
+        "dismiss": "Afvis"
       },
       "regionLabel": "Region",
       "speciesLabel": "Arter",
@@ -5403,9 +5410,7 @@
       "reinstalling": "Geninstallerer...",
       "reinstallComplete": "Filer verificeret succesfuldt",
       "geomodelBadge": "Inkluderer BirdNET v3.0 geomodel",
-      "onnxRuntimeRequired": "Kræver ONNX Runtime, som ikke er tilgængelig på dette system.",
-      "onnxRuntimeMissing": "ONNX Runtime er ikke tilgængelig. Denne model kan ikke køre.",
-      "unavailable": "Ikke tilgængelig"
+      "entryIncompatible": "Denne model er ikke tilgængelig på dette system."
     },
     "bird": {
       "title": "Fugleregistrering",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -1706,6 +1706,9 @@
       "fp16": "FP16",
       "fp16Supported": "FP16 unterstützt",
       "fp16Unsupported": "FP16 nicht unterstützt",
+      "advanced": "Erweitert",
+      "capabilities": "Fähigkeiten",
+      "capabilitiesHelp": "Hardware-Tags, die verwendet werden, um diesen Rechner mit den verfügbaren Modell-Builds abzugleichen.",
       "backendTflite": "TensorFlow Lite",
       "backendOnnx": "ONNX Runtime",
       "backendOpenvino": "OpenVINO",
@@ -5341,7 +5344,7 @@
         "backendMissing": "Benötigt ein Inference-Backend, das nicht erreichbar ist ({required})",
         "ramInsufficient": "Benötigt mindestens {requiredMb} MB Speicher",
         "hardwareExcluded": "Wird von Ihrer Hardware nicht unterstützt ({token})",
-        "backendOnnxUnavailable": "Erfordert ONNX Runtime, das auf diesem System nicht verfügbar ist"
+        "backendOnnxUnavailable": "Erfordert ONNX Runtime, das auf diesem System nicht verfügbar ist. Docker-Images und Release-Tarballs enthalten es; siehe die Installationsanleitung für ONNX Runtime."
       },
       "tabs": {
         "installed": "Installiert",
@@ -5395,7 +5398,11 @@
       "errors": {
         "catalogLoadFailed": "Modellkatalog konnte nicht geladen werden",
         "installFailed": "Modellinstallation konnte nicht gestartet werden",
-        "removeFailed": "Modell konnte nicht entfernt werden"
+        "removeFailed": "Modell konnte nicht entfernt werden",
+        "actionFailed": "Es gab ein Problem mit {name}",
+        "downloadSourceHint": "Wenn huggingface.co in Ihrem Netzwerk blockiert oder langsam ist, richten Sie im Abschnitt Download-Quelle unten einen Spiegelserver ein.",
+        "goToDownloadSource": "Zur Download-Quelle",
+        "dismiss": "Schließen"
       },
       "regionLabel": "Region",
       "speciesLabel": "Arten",
@@ -5403,9 +5410,7 @@
       "reinstalling": "Wird neu installiert...",
       "reinstallComplete": "Dateien erfolgreich überprüft",
       "geomodelBadge": "Enthält BirdNET v3.0 Geomodell",
-      "onnxRuntimeRequired": "Erfordert ONNX Runtime, das auf diesem System nicht verfügbar ist.",
-      "onnxRuntimeMissing": "ONNX Runtime ist nicht verfügbar. Dieses Modell kann nicht ausgeführt werden.",
-      "unavailable": "Nicht verfügbar"
+      "entryIncompatible": "Dieses Modell ist auf diesem System nicht verfügbar."
     },
     "bird": {
       "title": "Vogelerkennung",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -1706,6 +1706,9 @@
       "fp16": "FP16",
       "fp16Supported": "FP16 supported",
       "fp16Unsupported": "FP16 not supported",
+      "advanced": "Advanced",
+      "capabilities": "Capabilities",
+      "capabilitiesHelp": "Hardware tags used to match this machine against the available model builds.",
       "backendTflite": "TensorFlow Lite",
       "backendOnnx": "ONNX Runtime",
       "backendOpenvino": "OpenVINO",
@@ -5341,7 +5344,7 @@
         "backendMissing": "Needs an inference backend your build cannot reach ({required})",
         "ramInsufficient": "Needs at least {requiredMb} MB of memory",
         "hardwareExcluded": "Not supported on your hardware ({token})",
-        "backendOnnxUnavailable": "Requires ONNX Runtime, which isn't available on this system"
+        "backendOnnxUnavailable": "Requires ONNX Runtime, which isn't available on this system. Docker images and release tarballs include it; see the ONNX Runtime installation guide."
       },
       "tabs": {
         "installed": "Installed",
@@ -5395,7 +5398,11 @@
       "errors": {
         "catalogLoadFailed": "Failed to load model catalog",
         "installFailed": "Failed to start model installation",
-        "removeFailed": "Failed to remove model"
+        "removeFailed": "Failed to remove model",
+        "actionFailed": "There was a problem with {name}",
+        "downloadSourceHint": "If huggingface.co is blocked or slow on your network, set a mirror in the Download Source section below.",
+        "goToDownloadSource": "Go to Download Source",
+        "dismiss": "Dismiss"
       },
       "regionLabel": "Region",
       "speciesLabel": "Species",
@@ -5403,9 +5410,7 @@
       "reinstalling": "Reinstalling...",
       "reinstallComplete": "Files verified successfully",
       "geomodelBadge": "Includes BirdNET v3.0 geomodel",
-      "onnxRuntimeRequired": "Requires ONNX Runtime which is not available on this system.",
-      "onnxRuntimeMissing": "ONNX Runtime is not available. This model cannot run.",
-      "unavailable": "Unavailable"
+      "entryIncompatible": "This model is not available on this system."
     },
     "bird": {
       "title": "Bird Detection",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -1706,6 +1706,9 @@
       "fp16": "FP16",
       "fp16Supported": "FP16 soportado",
       "fp16Unsupported": "FP16 no soportado",
+      "advanced": "Avanzado",
+      "capabilities": "Capacidades",
+      "capabilitiesHelp": "Etiquetas de hardware utilizadas para hacer coincidir este equipo con las versiones de modelos disponibles.",
       "backendTflite": "TensorFlow Lite",
       "backendOnnx": "ONNX Runtime",
       "backendOpenvino": "OpenVINO",
@@ -5341,7 +5344,7 @@
         "backendMissing": "Necesita un backend de inferencia que tu versión no puede alcanzar ({required})",
         "ramInsufficient": "Necesita al menos {requiredMb} MB de memoria",
         "hardwareExcluded": "No compatible con tu hardware ({token})",
-        "backendOnnxUnavailable": "Requiere ONNX Runtime, que no está disponible en este sistema"
+        "backendOnnxUnavailable": "Requiere ONNX Runtime, que no está disponible en este sistema. Las imágenes de Docker y los paquetes comprimidos de la versión lo incluyen; consulte la guía de instalación de ONNX Runtime."
       },
       "tabs": {
         "installed": "Instalados",
@@ -5395,7 +5398,11 @@
       "errors": {
         "catalogLoadFailed": "No se pudo cargar el catálogo de modelos",
         "installFailed": "No se pudo iniciar la instalación del modelo",
-        "removeFailed": "No se pudo eliminar el modelo"
+        "removeFailed": "No se pudo eliminar el modelo",
+        "actionFailed": "Hubo un problema con {name}",
+        "downloadSourceHint": "Si huggingface.co está bloqueado o es lento en su red, configure un servidor espejo en la sección Origen de descarga a continuación.",
+        "goToDownloadSource": "Ir a Origen de descarga",
+        "dismiss": "Descartar"
       },
       "regionLabel": "Región",
       "speciesLabel": "Especies",
@@ -5403,9 +5410,7 @@
       "reinstalling": "Reinstalando...",
       "reinstallComplete": "Archivos verificados correctamente",
       "geomodelBadge": "Incluye BirdNET v3.0 geomodel",
-      "onnxRuntimeRequired": "Requiere ONNX Runtime, que no está disponible en este sistema.",
-      "onnxRuntimeMissing": "ONNX Runtime no está disponible. Este modelo no puede ejecutarse.",
-      "unavailable": "No disponible"
+      "entryIncompatible": "Este modelo no está disponible en este sistema."
     },
     "bird": {
       "title": "Detección de aves",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -1706,6 +1706,9 @@
       "fp16": "FP16",
       "fp16Supported": "FP16 tuettu",
       "fp16Unsupported": "FP16 ei tuettu",
+      "advanced": "Lisätiedot",
+      "capabilities": "Ominaisuudet",
+      "capabilitiesHelp": "Laitteistotunnisteet, joita käytetään tämän laitteen sovittamiseen saatavilla oleviin malliversioihin.",
       "backendTflite": "TensorFlow Lite",
       "backendOnnx": "ONNX Runtime",
       "backendOpenvino": "OpenVINO",
@@ -5341,7 +5344,7 @@
         "backendMissing": "Vaatii inferenssin taustajärjestelmän, joka ei ole käytettävissä ({required})",
         "ramInsufficient": "Vaatii vähintään {requiredMb} MB muistia",
         "hardwareExcluded": "Ei tue laitteistoasi ({token})",
-        "backendOnnxUnavailable": "Vaatii ONNX Runtimen, joka ei ole käytettävissä tässä järjestelmässä"
+        "backendOnnxUnavailable": "Vaatii ONNX Runtimen, joka ei ole käytettävissä tässä järjestelmässä. Docker-kuvat ja julkaisupaketit sisältävät sen; katso ONNX Runtimen asennusohje."
       },
       "tabs": {
         "installed": "Asennetut",
@@ -5395,7 +5398,11 @@
       "errors": {
         "catalogLoadFailed": "Malliluettelon lataaminen epäonnistui",
         "installFailed": "Mallin asennuksen käynnistäminen epäonnistui",
-        "removeFailed": "Mallin poistaminen epäonnistui"
+        "removeFailed": "Mallin poistaminen epäonnistui",
+        "actionFailed": "Kohteen {name} kanssa ilmeni ongelma",
+        "downloadSourceHint": "Jos huggingface.co on estetty tai hidas verkossasi, aseta peilipalvelin alla olevaan Latauslähde-osioon.",
+        "goToDownloadSource": "Siirry Latauslähteeseen",
+        "dismiss": "Sulje"
       },
       "regionLabel": "Alue",
       "speciesLabel": "Lajit",
@@ -5403,9 +5410,7 @@
       "reinstalling": "Asennetaan uudelleen...",
       "reinstallComplete": "Tiedostot tarkistettu onnistuneesti",
       "geomodelBadge": "Sisältää BirdNET v3.0 -geomallin",
-      "onnxRuntimeRequired": "Vaatii ONNX Runtimen, joka ei ole käytettävissä tässä järjestelmässä.",
-      "onnxRuntimeMissing": "ONNX Runtime ei ole käytettävissä. Tätä mallia ei voi suorittaa.",
-      "unavailable": "Ei käytettävissä"
+      "entryIncompatible": "Tämä malli ei ole saatavilla tässä järjestelmässä."
     },
     "bird": {
       "title": "Lintuhavainnot",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -1706,6 +1706,9 @@
       "fp16": "FP16",
       "fp16Supported": "FP16 pris en charge",
       "fp16Unsupported": "FP16 non pris en charge",
+      "advanced": "Avancé",
+      "capabilities": "Capacités",
+      "capabilitiesHelp": "Balises matérielles utilisées pour faire correspondre cette machine aux versions de modèles disponibles.",
       "backendTflite": "TensorFlow Lite",
       "backendOnnx": "ONNX Runtime",
       "backendOpenvino": "OpenVINO",
@@ -5341,7 +5344,7 @@
         "backendMissing": "Nécessite un backend d'inférence inaccessible ({required})",
         "ramInsufficient": "Nécessite au moins {requiredMb} MB de mémoire",
         "hardwareExcluded": "Non pris en charge par votre matériel ({token})",
-        "backendOnnxUnavailable": "Nécessite ONNX Runtime, qui n'est pas disponible sur ce système"
+        "backendOnnxUnavailable": "Nécessite ONNX Runtime, qui n'est pas disponible sur ce système. Les images Docker et les archives de publication l'incluent; consultez le guide d'installation d'ONNX Runtime."
       },
       "tabs": {
         "installed": "Installés",
@@ -5395,7 +5398,11 @@
       "errors": {
         "catalogLoadFailed": "Impossible de charger le catalogue de modèles",
         "installFailed": "Impossible de démarrer l'installation du modèle",
-        "removeFailed": "Impossible de supprimer le modèle"
+        "removeFailed": "Impossible de supprimer le modèle",
+        "actionFailed": "Un problème est survenu avec {name}",
+        "downloadSourceHint": "Si huggingface.co est bloqué ou lent sur votre réseau, définissez un miroir dans la section Source de téléchargement ci-dessous.",
+        "goToDownloadSource": "Aller à la source de téléchargement",
+        "dismiss": "Ignorer"
       },
       "regionLabel": "Région",
       "speciesLabel": "Espèces",
@@ -5403,9 +5410,7 @@
       "reinstalling": "Réinstallation...",
       "reinstallComplete": "Fichiers vérifiés avec succès",
       "geomodelBadge": "Inclut le BirdNET v3.0 geomodel",
-      "onnxRuntimeRequired": "Nécessite ONNX Runtime qui n'est pas disponible sur ce système.",
-      "onnxRuntimeMissing": "ONNX Runtime n'est pas disponible. Ce modèle ne peut pas fonctionner.",
-      "unavailable": "Indisponible"
+      "entryIncompatible": "Ce modèle n'est pas disponible sur ce système."
     },
     "bird": {
       "title": "Détection des oiseaux",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -1706,6 +1706,9 @@
       "fp16": "FP16",
       "fp16Supported": "FP16 támogatott",
       "fp16Unsupported": "FP16 nem támogatott",
+      "advanced": "Speciális",
+      "capabilities": "Képességek",
+      "capabilitiesHelp": "Hardvercímkék, amelyek a gép és az elérhető modellverziók párosítására szolgálnak.",
       "backendTflite": "TensorFlow Lite",
       "backendOnnx": "ONNX Runtime",
       "backendOpenvino": "OpenVINO",
@@ -5341,7 +5344,7 @@
         "backendMissing": "Olyan következtetési backendet igényel, amelyet a build nem ér el ({required})",
         "ramInsufficient": "Legalább {requiredMb} MB memória szükséges",
         "hardwareExcluded": "Nem támogatott a hardvereden ({token})",
-        "backendOnnxUnavailable": "ONNX Runtime szükséges, amely nem érhető el ezen a rendszeren"
+        "backendOnnxUnavailable": "ONNX Runtime szükséges, amely nem érhető el ezen a rendszeren. A Docker-lemezképek és a kiadási csomagok tartalmazzák; lásd az ONNX Runtime telepítési útmutatóját."
       },
       "tabs": {
         "installed": "Telepített",
@@ -5395,7 +5398,11 @@
       "errors": {
         "catalogLoadFailed": "Nem sikerült betölteni a modellkatalógust",
         "installFailed": "Nem sikerült elindítani a modell telepítését",
-        "removeFailed": "Nem sikerült eltávolítani a modellt"
+        "removeFailed": "Nem sikerült eltávolítani a modellt",
+        "actionFailed": "Probléma történt a következővel: {name}",
+        "downloadSourceHint": "Ha a huggingface.co blokkolva van vagy lassú a hálózatán, állítson be egy tükörszervert az alábbi Letöltési forrás szakaszban.",
+        "goToDownloadSource": "Ugrás a Letöltési forráshoz",
+        "dismiss": "Bezárás"
       },
       "regionLabel": "Régió",
       "speciesLabel": "Fajok",
@@ -5403,9 +5410,7 @@
       "reinstalling": "Újratelepítés...",
       "reinstallComplete": "Fájlok sikeresen ellenőrizve",
       "geomodelBadge": "Tartalmazza a BirdNET v3.0 geomodellt",
-      "onnxRuntimeRequired": "ONNX Runtime szükséges, amely nem elérhető ezen a rendszeren.",
-      "onnxRuntimeMissing": "Az ONNX Runtime nem elérhető. Ez a modell nem futtatható.",
-      "unavailable": "Nem elérhető"
+      "entryIncompatible": "Ez a modell nem érhető el ezen a rendszeren."
     },
     "bird": {
       "title": "Madárészlelés",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -1706,6 +1706,9 @@
       "fp16": "FP16",
       "fp16Supported": "FP16 supportato",
       "fp16Unsupported": "FP16 non supportato",
+      "advanced": "Avanzate",
+      "capabilities": "Funzionalità",
+      "capabilitiesHelp": "Tag hardware utilizzati per associare questa macchina alle versioni dei modelli disponibili.",
       "backendTflite": "TensorFlow Lite",
       "backendOnnx": "ONNX Runtime",
       "backendOpenvino": "OpenVINO",
@@ -5341,7 +5344,7 @@
         "backendMissing": "Richiede un backend di inferenza che la tua versione non può raggiungere ({required})",
         "ramInsufficient": "Richiede almeno {requiredMb} MB di memoria",
         "hardwareExcluded": "Non supportato dal tuo hardware ({token})",
-        "backendOnnxUnavailable": "Richiede ONNX Runtime, che non è disponibile su questo sistema"
+        "backendOnnxUnavailable": "Richiede ONNX Runtime, che non è disponibile su questo sistema. Le immagini Docker e i pacchetti di rilascio lo includono; consulta la guida all'installazione di ONNX Runtime."
       },
       "tabs": {
         "installed": "Installati",
@@ -5395,7 +5398,11 @@
       "errors": {
         "catalogLoadFailed": "Impossibile caricare il catalogo dei modelli",
         "installFailed": "Impossibile avviare l'installazione del modello",
-        "removeFailed": "Impossibile rimuovere il modello"
+        "removeFailed": "Impossibile rimuovere il modello",
+        "actionFailed": "Si è verificato un problema con {name}",
+        "downloadSourceHint": "Se huggingface.co è bloccato o lento sulla tua rete, imposta un mirror nella sezione Sorgente di download sottostante.",
+        "goToDownloadSource": "Vai a Sorgente di download",
+        "dismiss": "Ignora"
       },
       "regionLabel": "Regione",
       "speciesLabel": "Specie",
@@ -5403,9 +5410,7 @@
       "reinstalling": "Reinstallazione...",
       "reinstallComplete": "File verificati con successo",
       "geomodelBadge": "Include il geomodel BirdNET v3.0",
-      "onnxRuntimeRequired": "Richiede ONNX Runtime che non è disponibile su questo sistema.",
-      "onnxRuntimeMissing": "ONNX Runtime non è disponibile. Questo modello non può essere eseguito.",
-      "unavailable": "Non disponibile"
+      "entryIncompatible": "Questo modello non è disponibile su questo sistema."
     },
     "bird": {
       "title": "Rilevamento uccelli",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -1706,6 +1706,9 @@
       "fp16": "FP16",
       "fp16Supported": "FP16 atbalstīts",
       "fp16Unsupported": "FP16 netiek atbalstīts",
+      "advanced": "Papildu",
+      "capabilities": "Iespējas",
+      "capabilitiesHelp": "Aparatūras tagi, ko izmanto, lai saskaņotu šo datoru ar pieejamajiem modeļu būvējumiem.",
       "backendTflite": "TensorFlow Lite",
       "backendOnnx": "ONNX Runtime",
       "backendOpenvino": "OpenVINO",
@@ -5341,7 +5344,7 @@
         "backendMissing": "Nepieciešama inferences aizmugursistēma, ko jūsu versija nevar sasniegt ({required})",
         "ramInsufficient": "Nepieciešami vismaz {requiredMb} MB atmiņas",
         "hardwareExcluded": "Nav atbalstīts jūsu aparatūrā ({token})",
-        "backendOnnxUnavailable": "Nepieciešams ONNX Runtime, kas šajā sistēmā nav pieejams"
+        "backendOnnxUnavailable": "Nepieciešams ONNX Runtime, kas šajā sistēmā nav pieejams. Docker attēli un laidiena arhīvi to iekļauj; skatiet ONNX Runtime instalēšanas pamācību."
       },
       "tabs": {
         "installed": "Instalētie",
@@ -5395,7 +5398,11 @@
       "errors": {
         "catalogLoadFailed": "Neizdevās ielādēt modeļu katalogu",
         "installFailed": "Neizdevās sākt modeļa instalēšanu",
-        "removeFailed": "Neizdevās noņemt modeli"
+        "removeFailed": "Neizdevās noņemt modeli",
+        "actionFailed": "Radās problēma ar {name}",
+        "downloadSourceHint": "Ja jūsu tīklā huggingface.co ir bloķēts vai lēns, iestatiet spoguļvietni zemāk esošajā sadaļā Lejupielādes avots.",
+        "goToDownloadSource": "Doties uz Lejupielādes avots",
+        "dismiss": "Noraidīt"
       },
       "regionLabel": "Reģions",
       "speciesLabel": "Sugas",
@@ -5403,9 +5410,7 @@
       "reinstalling": "Pārinstalē...",
       "reinstallComplete": "Faili veiksmīgi pārbaudīti",
       "geomodelBadge": "Ietver BirdNET v3.0 ģeomodelis",
-      "onnxRuntimeRequired": "Nepieciešams ONNX Runtime, kas šajā sistēmā nav pieejams.",
-      "onnxRuntimeMissing": "ONNX Runtime nav pieejams. Šo modeli nevar palaist.",
-      "unavailable": "Nav pieejams"
+      "entryIncompatible": "Šis modelis nav pieejams šajā sistēmā."
     },
     "bird": {
       "title": "Putnu noteikšana",

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -1706,6 +1706,9 @@
       "fp16": "FP16",
       "fp16Supported": "FP16 støttes",
       "fp16Unsupported": "FP16 støttes ikke",
+      "advanced": "Avansert",
+      "capabilities": "Egenskaper",
+      "capabilitiesHelp": "Maskinvare-tags som brukes til å matche denne maskinen mot tilgjengelige modellbygg.",
       "backendTflite": "TensorFlow Lite",
       "backendOnnx": "ONNX Runtime",
       "backendOpenvino": "OpenVINO",
@@ -5341,7 +5344,7 @@
         "backendMissing": "Krever en inference-backend som versjonen din ikke når ({required})",
         "ramInsufficient": "Krever minst {requiredMb} MB minne",
         "hardwareExcluded": "Støttes ikke på din maskinvare ({token})",
-        "backendOnnxUnavailable": "Krever ONNX Runtime, som ikke er tilgjengelig på dette systemet"
+        "backendOnnxUnavailable": "Krever ONNX Runtime, som ikke er tilgjengelig på dette systemet. Docker-images og utgivelsesarkiver inkluderer det; se installasjonsveiledningen for ONNX Runtime."
       },
       "tabs": {
         "installed": "Installert",
@@ -5395,7 +5398,11 @@
       "errors": {
         "catalogLoadFailed": "Innlasting av modellkatalog mislyktes",
         "installFailed": "Oppstart av modellinstallasjon mislyktes",
-        "removeFailed": "Fjerning av modell mislyktes"
+        "removeFailed": "Fjerning av modell mislyktes",
+        "actionFailed": "Det oppsto et problem med {name}",
+        "downloadSourceHint": "Hvis huggingface.co er blokkert eller tregt på nettverket ditt, kan du angi en speilserver i seksjonen Nedlastingskilde nedenfor.",
+        "goToDownloadSource": "Gå til Nedlastingskilde",
+        "dismiss": "Avvis"
       },
       "regionLabel": "Region",
       "speciesLabel": "Arter",
@@ -5403,9 +5410,7 @@
       "reinstalling": "Reinstallerer...",
       "reinstallComplete": "Filer verifisert",
       "geomodelBadge": "Inkluderer BirdNET v3.0 geomodell",
-      "onnxRuntimeRequired": "Krever ONNX Runtime som ikke er tilgjengelig på dette systemet.",
-      "onnxRuntimeMissing": "ONNX Runtime er ikke tilgjengelig. Denne modellen kan ikke kjøres.",
-      "unavailable": "Ikke tilgjengelig"
+      "entryIncompatible": "Denne modellen er ikke tilgjengelig på dette systemet."
     },
     "bird": {
       "title": "Fugledeteksjon",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -1706,6 +1706,9 @@
       "fp16": "FP16",
       "fp16Supported": "FP16 ondersteund",
       "fp16Unsupported": "FP16 niet ondersteund",
+      "advanced": "Geavanceerd",
+      "capabilities": "Mogelijkheden",
+      "capabilitiesHelp": "Hardware-tags die worden gebruikt om deze machine te koppelen aan de beschikbare model-builds.",
       "backendTflite": "TensorFlow Lite",
       "backendOnnx": "ONNX Runtime",
       "backendOpenvino": "OpenVINO",
@@ -5341,7 +5344,7 @@
         "backendMissing": "Heeft een inference backend nodig die je installatie niet kan bereiken ({required})",
         "ramInsufficient": "Heeft minimaal {requiredMb} MB geheugen nodig",
         "hardwareExcluded": "Niet ondersteund op jouw hardware ({token})",
-        "backendOnnxUnavailable": "Vereist ONNX Runtime, dat niet beschikbaar is op dit systeem"
+        "backendOnnxUnavailable": "Vereist ONNX Runtime, dat niet beschikbaar is op dit systeem. Docker-images en release-archieven bevatten dit; zie de ONNX Runtime-installatiehandleiding."
       },
       "tabs": {
         "installed": "Geïnstalleerd",
@@ -5395,7 +5398,11 @@
       "errors": {
         "catalogLoadFailed": "Kan modelcatalogus niet laden",
         "installFailed": "Kan modelinstallatie niet starten",
-        "removeFailed": "Kan model niet verwijderen"
+        "removeFailed": "Kan model niet verwijderen",
+        "actionFailed": "Er is een probleem opgetreden met {name}",
+        "downloadSourceHint": "Als huggingface.co geblokkeerd of traag is op uw netwerk, stel dan een spiegelserver in bij de sectie Downloadbron hieronder.",
+        "goToDownloadSource": "Ga naar Downloadbron",
+        "dismiss": "Negeren"
       },
       "regionLabel": "Regio",
       "speciesLabel": "Soorten",
@@ -5403,9 +5410,7 @@
       "reinstalling": "Opnieuw installeren...",
       "reinstallComplete": "Bestanden succesvol geverifieerd",
       "geomodelBadge": "Bevat BirdNET v3.0 geomodel",
-      "onnxRuntimeRequired": "Vereist ONNX Runtime dat niet beschikbaar is op dit systeem.",
-      "onnxRuntimeMissing": "ONNX Runtime is niet beschikbaar. Dit model kan niet worden uitgevoerd.",
-      "unavailable": "Niet beschikbaar"
+      "entryIncompatible": "Dit model is niet beschikbaar op dit systeem."
     },
     "bird": {
       "title": "Vogeldetectie",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -1706,6 +1706,9 @@
       "fp16": "FP16",
       "fp16Supported": "FP16 obsługiwane",
       "fp16Unsupported": "FP16 nieobsługiwane",
+      "advanced": "Zaawansowane",
+      "capabilities": "Możliwości",
+      "capabilitiesHelp": "Tagi sprzętowe używane do dopasowania tej maszyny do dostępnych kompilacji modeli.",
       "backendTflite": "TensorFlow Lite",
       "backendOnnx": "ONNX Runtime",
       "backendOpenvino": "OpenVINO",
@@ -5341,7 +5344,7 @@
         "backendMissing": "Wymaga backendu wnioskowania, który jest niedostępny ({required})",
         "ramInsufficient": "Wymaga co najmniej {requiredMb} MB pamięci",
         "hardwareExcluded": "Brak wsparcia na twoim sprzęcie ({token})",
-        "backendOnnxUnavailable": "Wymaga ONNX Runtime, który nie jest dostępny w tym systemie"
+        "backendOnnxUnavailable": "Wymaga ONNX Runtime, który nie jest dostępny w tym systemie. Obrazy Docker i archiwa wydań go zawierają; zobacz instrukcję instalacji ONNX Runtime."
       },
       "tabs": {
         "installed": "Zainstalowane",
@@ -5395,7 +5398,11 @@
       "errors": {
         "catalogLoadFailed": "Nie udało się załadować katalogu modeli",
         "installFailed": "Nie udało się rozpocząć instalacji modelu",
-        "removeFailed": "Nie udało się usunąć modelu"
+        "removeFailed": "Nie udało się usunąć modelu",
+        "actionFailed": "Wystąpił problem z {name}",
+        "downloadSourceHint": "Jeśli huggingface.co jest zablokowane lub działa wolno w Twojej sieci, ustaw serwer lustrzany w sekcji Źródło pobierania poniżej.",
+        "goToDownloadSource": "Przejdź do Źródło pobierania",
+        "dismiss": "Odrzuć"
       },
       "regionLabel": "Region",
       "speciesLabel": "Gatunki",
@@ -5403,9 +5410,7 @@
       "reinstalling": "Ponowna instalacja...",
       "reinstallComplete": "Pliki zweryfikowane pomyślnie",
       "geomodelBadge": "Zawiera BirdNET v3.0 geomodel",
-      "onnxRuntimeRequired": "Wymaga ONNX Runtime, który nie jest dostępny w tym systemie.",
-      "onnxRuntimeMissing": "ONNX Runtime nie jest dostępny. Ten model nie może działać.",
-      "unavailable": "Niedostępne"
+      "entryIncompatible": "Ten model nie jest dostępny w tym systemie."
     },
     "bird": {
       "title": "Wykrywanie ptaków",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -1706,6 +1706,9 @@
       "fp16": "FP16",
       "fp16Supported": "FP16 suportado",
       "fp16Unsupported": "FP16 não suportado",
+      "advanced": "Avançado",
+      "capabilities": "Capacidades",
+      "capabilitiesHelp": "Tags de hardware usadas para corresponder esta máquina com as compilações de modelo disponíveis.",
       "backendTflite": "TensorFlow Lite",
       "backendOnnx": "ONNX Runtime",
       "backendOpenvino": "OpenVINO",
@@ -5341,7 +5344,7 @@
         "backendMissing": "Necessita de um backend de inferência que a sua versão não consegue alcançar ({required})",
         "ramInsufficient": "Necessita de pelo menos {requiredMb} MB de memória",
         "hardwareExcluded": "Não suportado no seu hardware ({token})",
-        "backendOnnxUnavailable": "Requer ONNX Runtime, que não está disponível neste sistema"
+        "backendOnnxUnavailable": "Requer ONNX Runtime, que não está disponível neste sistema. Imagens Docker e arquivos compactados de lançamento o incluem; consulte o guia de instalação do ONNX Runtime."
       },
       "tabs": {
         "installed": "Instalados",
@@ -5395,7 +5398,11 @@
       "errors": {
         "catalogLoadFailed": "Falha ao carregar o catálogo de modelos",
         "installFailed": "Falha ao iniciar a instalação do modelo",
-        "removeFailed": "Falha ao remover o modelo"
+        "removeFailed": "Falha ao remover o modelo",
+        "actionFailed": "Ocorreu um problema com {name}",
+        "downloadSourceHint": "Se o huggingface.co estiver bloqueado ou lento em sua rede, defina um espelho na seção Origem de download abaixo.",
+        "goToDownloadSource": "Ir para Origem de download",
+        "dismiss": "Dispensar"
       },
       "regionLabel": "Região",
       "speciesLabel": "Espécies",
@@ -5403,9 +5410,7 @@
       "reinstalling": "Reinstalando...",
       "reinstallComplete": "Ficheiros verificados com sucesso",
       "geomodelBadge": "Inclui BirdNET v3.0 geomodel",
-      "onnxRuntimeRequired": "Requer ONNX Runtime que não está disponível neste sistema.",
-      "onnxRuntimeMissing": "O ONNX Runtime não está disponível. Este modelo não pode ser executado.",
-      "unavailable": "Indisponível"
+      "entryIncompatible": "Este modelo não está disponível neste sistema."
     },
     "bird": {
       "title": "Deteção de aves",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -1706,6 +1706,9 @@
       "fp16": "FP16",
       "fp16Supported": "FP16 podporované",
       "fp16Unsupported": "FP16 nepodporované",
+      "advanced": "Pokročilé",
+      "capabilities": "Schopnosti",
+      "capabilitiesHelp": "Hardvérové značky používané na priradenie tohto počítača k dostupným zostaveniam modelov.",
       "backendTflite": "TensorFlow Lite",
       "backendOnnx": "ONNX Runtime",
       "backendOpenvino": "OpenVINO",
@@ -5341,7 +5344,7 @@
         "backendMissing": "Vyžaduje inferenčný backend, ktorý nie je dostupný ({required})",
         "ramInsufficient": "Vyžaduje aspoň {requiredMb} MB pamäte",
         "hardwareExcluded": "Nepodporované na vašom hardvéri ({token})",
-        "backendOnnxUnavailable": "Vyžaduje ONNX Runtime, ktorý nie je v tomto systéme k dispozícii"
+        "backendOnnxUnavailable": "Vyžaduje ONNX Runtime, ktorý nie je v tomto systéme k dispozícii. Obrazy Docker a archívy vydaní ho obsahujú; pozrite si návod na inštaláciu ONNX Runtime."
       },
       "tabs": {
         "installed": "Nainštalované",
@@ -5395,7 +5398,11 @@
       "errors": {
         "catalogLoadFailed": "Nepodarilo sa načítať katalóg modelov",
         "installFailed": "Nepodarilo sa spustiť inštaláciu modelu",
-        "removeFailed": "Nepodarilo sa odstrániť model"
+        "removeFailed": "Nepodarilo sa odstrániť model",
+        "actionFailed": "Vyskytol sa problém s {name}",
+        "downloadSourceHint": "Ak je huggingface.co vo vašej sieti zablokované alebo pomalé, nastavte zrkadlový server v sekcii Zdroj sťahovania nižšie.",
+        "goToDownloadSource": "Prejsť na Zdroj sťahovania",
+        "dismiss": "Zavrieť"
       },
       "regionLabel": "Región",
       "speciesLabel": "Druhy",
@@ -5403,9 +5410,7 @@
       "reinstalling": "Preinštalovanie...",
       "reinstallComplete": "Súbory úspešne overené",
       "geomodelBadge": "Obsahuje BirdNET v3.0 geomodel",
-      "onnxRuntimeRequired": "Vyžaduje ONNX Runtime, ktorý nie je v tomto systéme k dispozícii.",
-      "onnxRuntimeMissing": "ONNX Runtime nie je k dispozícii. Tento model nie je možné spustiť.",
-      "unavailable": "Nedostupné"
+      "entryIncompatible": "Tento model nie je v tomto systéme k dispozícii."
     },
     "bird": {
       "title": "Detekcia vtákov",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -1706,6 +1706,9 @@
       "fp16": "FP16",
       "fp16Supported": "FP16 stöds",
       "fp16Unsupported": "FP16 stöds inte",
+      "advanced": "Avancerat",
+      "capabilities": "Egenskaper",
+      "capabilitiesHelp": "Hårdvarutaggar som används för att matcha denna maskin mot tillgängliga modellbyggen.",
       "backendTflite": "TensorFlow Lite",
       "backendOnnx": "ONNX Runtime",
       "backendOpenvino": "OpenVINO",
@@ -5341,7 +5344,7 @@
         "backendMissing": "Kräver en inference-backend som din version inte kan nå ({required})",
         "ramInsufficient": "Kräver minst {requiredMb} MB minne",
         "hardwareExcluded": "Stöds inte på din hårdvara ({token})",
-        "backendOnnxUnavailable": "Kräver ONNX Runtime, som inte är tillgängligt på detta system"
+        "backendOnnxUnavailable": "Kräver ONNX Runtime, som inte är tillgängligt på detta system. Docker-avbilder och versionsarkiv innehåller det; se installationsguiden för ONNX Runtime."
       },
       "tabs": {
         "installed": "Installerade",
@@ -5395,7 +5398,11 @@
       "errors": {
         "catalogLoadFailed": "Kunde inte ladda modellkatalogen",
         "installFailed": "Kunde inte starta modellinstallation",
-        "removeFailed": "Kunde inte ta bort modell"
+        "removeFailed": "Kunde inte ta bort modell",
+        "actionFailed": "Det uppstod ett problem med {name}",
+        "downloadSourceHint": "Om huggingface.co är blockerat eller långsamt på ditt nätverk kan du ange en spegelsajt i avsnittet Nedladdningskälla nedan.",
+        "goToDownloadSource": "Gå till Nedladdningskälla",
+        "dismiss": "Avfärda"
       },
       "regionLabel": "Region",
       "speciesLabel": "Arter",
@@ -5403,9 +5410,7 @@
       "reinstalling": "Installerar om...",
       "reinstallComplete": "Filer verifierade",
       "geomodelBadge": "Inkluderar BirdNET v3.0 geomodell",
-      "onnxRuntimeRequired": "Kräver ONNX Runtime som inte är tillgängligt på detta system.",
-      "onnxRuntimeMissing": "ONNX Runtime är inte tillgängligt. Denna modell kan inte köras.",
-      "unavailable": "Ej tillgänglig"
+      "entryIncompatible": "Den här modellen är inte tillgänglig på detta system."
     },
     "bird": {
       "title": "Fågeldetektering",


### PR DESCRIPTION
## Summary

Three related fixes to the model gallery and the AI Models settings surface.

**Install failures no longer blank the model grid.** The gallery shared one `error` state between catalog loading and per-model install/reinstall/remove, and both gallery tab bodies were gated on it, so any install failure replaced the entire grid with a red banner that switching tabs did not clear, and its Retry reloaded the catalog rather than retrying the install. The state is now split: `catalogError` gates the grid (its Retry reloads the catalog, which is what that banner does), while install, reinstall, and remove failures surface in a dismissible banner above the gallery tabs, so the grid stays usable. That banner's Retry re-runs the actual failed action (the install/reinstall bodies were extracted so it can), and when the failure is a download-reachability problem it also offers a jump to the Download Source setting, which is the mirror-endpoint remedy for a blocked or throttled host.

**The AI Models hardware card regains its capability tokens.** They were removed as derivable from other card facts, but `low-ram` and the per-generation Intel GPU token are not derivable from anything else the card shows, so a user asking why a smaller variant was recommended had no way to see the token that decided it. They return behind a collapsed Advanced disclosure, so casual users are not shown token soup.

**Recommendation reasons are deduplicated and the region reason is no longer hidden.** The reason-localization pattern that was duplicated in two places is factored into `translateReason`/`topReasons`, and the variant picker now renders the top two recommendation reasons instead of only the first, so a matched region (which the recommender appends second) actually shows on a recommended regional variant. The entry-level incompatibility fallback is consolidated to one cause-neutral key and three now-dead keys are removed.

## Test Plan

- [x] `npm run check:all` (prettier, eslint, stylelint, svelte-check, ast-grep) green
- [x] Full frontend suite green (`npx vitest run`), including new unit tests for `translateReason`/`topReasons`, `isNetworkDownloadError`, and the capability-token disclosure, plus the top-two-reasons render
- [x] `npm run test:a11y` green
- [x] i18n in sync (`i18n:sync:check`, `generate:i18n-types:check`); all 15 locales translated
- [ ] Manual: trigger a model install failure and confirm the grid stays rendered, the banner Retry re-runs the install, and a network-shaped failure surfaces the Download Source pointer
- [ ] Manual: confirm the Advanced disclosure on the AI Models card lists the capability tokens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an expandable Advanced section showing detected inference hardware capabilities.
  - Recommended model variants now display up to two localized selection reasons.
  - Added clearer model incompatibility guidance and links to download-source settings.

- **Bug Fixes**
  - Improved model installation, retry, dismissal, and network-error handling.
  - Separated gallery loading errors from model action errors.
  - Added installation guidance for missing ONNX Runtime support.

- **Localization**
  - Updated translated messages across supported languages for capabilities, incompatibilities, and model-management errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->