### PR TITLE
fix(models): gallery UI polish, i18n usage-scan hardening, and a11y follow-ups

### DIFF
--- a/frontend/src/lib/desktop/features/settings/components/ModelVariantPicker.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/ModelVariantPicker.svelte
@@ -133,13 +133,19 @@
 
           {#if variant.recommended && variant.reasons?.length}
             {@const recommendedReasons = topReasons(variant.reasons)}
+            <!-- Render every surfaced reason as a list item under a labeled
+                 heading: a list announces "N items" to a screen reader, so the
+                 second reason is unambiguously a second reason rather than an
+                 unrelated line. -->
             <div class="text-xs text-primary/90">
-              <p>
-                {t('analysis.gallery.variants.recommendedForHardware')}: {recommendedReasons[0]}
+              <p class="font-medium">
+                {t('analysis.gallery.variants.recommendedForHardware')}:
               </p>
-              {#if recommendedReasons.length > 1}
-                <p>{recommendedReasons[1]}</p>
-              {/if}
+              <ul class="list-disc pl-4 space-y-0.5">
+                {#each recommendedReasons as reason, i (i)}
+                  <li>{reason}</li>
+                {/each}
+              </ul>
             </div>
           {/if}
 

--- a/frontend/src/lib/desktop/features/settings/components/ModelVariantPicker.test.ts
+++ b/frontend/src/lib/desktop/features/settings/components/ModelVariantPicker.test.ts
@@ -227,4 +227,33 @@ describe('ModelVariantPicker', () => {
     expect(reasonItems).toHaveLength(1);
     expect(reasonItems[0].textContent).toContain('region.global_fallback');
   });
+
+  it('renders each of two recommended reasons as its own list item', () => {
+    const twoReasons: CatalogVariant[] = [
+      variant({
+        id: 'fp16',
+        precision: 'fp16',
+        recommended: true,
+        reasons: [
+          { code: 'backend.recommended', args: { backend: 'openvino-gpu' } },
+          { code: 'region.matched', args: { region: 'Finland' } },
+        ],
+      }),
+    ];
+    const { container } = render(ModelVariantPicker, {
+      props: {
+        variants: twoReasons,
+        selectedVariantId: 'fp16',
+        onSelect: vi.fn(),
+        idPrefix: 'p11',
+      },
+    });
+    // Two reasons must render as two distinct <li> items (not one concatenated
+    // line, and not just the first): a "render only reasons[0]" regression drops
+    // to one item, and a "join into one li" regression also fails the count.
+    const reasonItems = container.querySelectorAll('[class*="text-primary/90"] li');
+    expect(reasonItems).toHaveLength(2);
+    expect(reasonItems[0].textContent).toContain('backend.recommended');
+    expect(reasonItems[1].textContent).toContain('region.matched');
+  });
 });

--- a/frontend/src/lib/desktop/features/settings/components/ModelVariantPicker.test.ts
+++ b/frontend/src/lib/desktop/features/settings/components/ModelVariantPicker.test.ts
@@ -220,10 +220,11 @@ describe('ModelVariantPicker', () => {
         idPrefix: 'p10',
       },
     });
-    // Exactly one reason line renders; a length>1 -> length>=1 regression would
-    // render a stray empty second paragraph.
-    const reasonParagraphs = container.querySelectorAll('[class*="text-primary/90"] p');
-    expect(reasonParagraphs).toHaveLength(1);
-    expect(reasonParagraphs[0].textContent).toContain('region.global_fallback');
+    // Exactly one reason item renders; a length>1 -> length>=1 regression would
+    // render a stray empty second list item. Count the <li> reasons, not the
+    // heading, so the assertion tracks the actual reason list.
+    const reasonItems = container.querySelectorAll('[class*="text-primary/90"] li');
+    expect(reasonItems).toHaveLength(1);
+    expect(reasonItems[0].textContent).toContain('region.global_fallback');
   });
 });

--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.gallery.test.ts
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.gallery.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/svelte';
+import type { CatalogEntry } from '$lib/types/models';
+
+// Page-level coverage for the model-gallery install-error split:
+// a failed install must NOT blank the grid (installError is a separate banner from
+// catalogError), the banner's Retry must re-run the install (not reload the
+// catalog), and a network-shaped failure must surface the Download Source hint.
+// isNetworkDownloadError is unit-tested and fail-safe, but those page behaviors are
+// not, so they get an integration test here (AudioSettingsPage.test.ts is the
+// precedent for mocking a page's api module and rendering the whole page).
+
+// Keep isNetworkDownloadError real (it is the classifier under test); stub the I/O.
+vi.mock('$lib/utils/modelsApi', async () => {
+  const actual =
+    await vi.importActual<typeof import('$lib/utils/modelsApi')>('$lib/utils/modelsApi');
+  return {
+    ...actual,
+    fetchCatalog: vi.fn(),
+    fetchInstalled: vi.fn(),
+    installModel: vi.fn(),
+    reinstallModel: vi.fn(),
+    uninstallModel: vi.fn(),
+    subscribeInstallProgress: vi.fn(),
+    fetchModelRegions: vi.fn(),
+    fetchRegionCoverageMap: vi.fn(),
+  };
+});
+
+vi.mock('$lib/stores/models.svelte', () => ({
+  invalidateModels: vi.fn(),
+}));
+
+// The region selector fetches on mount and is irrelevant to this flow; stub it to a
+// no-op component so it does not pull in its own network calls.
+vi.mock('$lib/desktop/features/settings/components/ModelRegionSelector.svelte');
+
+// The Settings tab (not exercised here) reads these stores; provide minimal shapes
+// so the page's derived state initializes without touching a real settings load.
+vi.mock('$lib/stores/settings', async () => {
+  const { writable } = await vi.importActual<typeof import('svelte/store')>('svelte/store');
+  const settingsStore = writable({
+    isLoading: false,
+    isSaving: false,
+    error: null,
+    originalData: { birdnet: { huggingFaceEndpoint: '' } },
+    formData: { birdnet: { huggingFaceEndpoint: '' } },
+  });
+  return {
+    settingsStore,
+    settingsActions: { updateSection: vi.fn() },
+    hasUnsavedChanges: writable(false),
+    birdnetSettings: writable({
+      huggingFaceEndpoint: '',
+      threshold: 0.03,
+      sensitivity: 1,
+      overlap: 0,
+    }),
+    dynamicThresholdSettings: writable({ enabled: false }),
+    realtimeSettings: writable({}),
+    batSettings: writable({}),
+    perchSettings: writable({}),
+    birdNetV3Settings: writable({}),
+  };
+});
+
+// The other onMount loaders (locales, range filter) go through the shared api util;
+// resolve them to benign values so mount does not hit the network.
+vi.mock('$lib/utils/api', async () => {
+  const actual = await vi.importActual<typeof import('$lib/utils/api')>('$lib/utils/api');
+  return {
+    ...actual,
+    api: {
+      get: vi.fn().mockResolvedValue({}),
+      post: vi.fn().mockResolvedValue({}),
+      put: vi.fn().mockResolvedValue({}),
+      delete: vi.fn().mockResolvedValue({}),
+    },
+    getCsrfToken: vi.fn().mockReturnValue('test-csrf-token'),
+  };
+});
+
+import AnalysisSettingsPage from './AnalysisSettingsPage.svelte';
+import * as modelsApi from '$lib/utils/modelsApi';
+
+// A network-shaped download failure (matches isNetworkDownloadError's real regex).
+const NETWORK_ERROR = 'HTTP request failed for https://huggingface.co/model: connection refused';
+
+function birdEntry(overrides: Partial<CatalogEntry> = {}): CatalogEntry {
+  return {
+    id: 'test-bird',
+    name: 'Test Bird Model',
+    description: 'A test bird classifier',
+    author: 'Tester',
+    license: 'CC-BY-NC-4.0',
+    commercialUse: false,
+    category: 'bird',
+    region: '',
+    speciesCount: 100,
+    version: '1.0',
+    installed: false,
+    compatible: true,
+    totalSizeBytes: 1_000_000,
+    hasGeomodel: false,
+    ...overrides,
+  };
+}
+
+async function gotoAvailableTab(): Promise<void> {
+  // Top-level Models tab, then the Available gallery sub-tab (i18n mock echoes keys).
+  await fireEvent.click(await screen.findByRole('tab', { name: /analysis\.tabs\.models/ }));
+  await fireEvent.click(
+    await screen.findByRole('tab', { name: /analysis\.gallery\.tabs\.available/ })
+  );
+}
+
+const installButtonName = /analysis\.gallery\.install.*Test Bird Model/;
+
+describe('AnalysisSettingsPage model gallery error handling', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    // jsdom does not implement <dialog> showModal/close; polyfill so the license
+    // dialog open/close path does not throw (its content renders on licenseModel).
+    HTMLDialogElement.prototype.showModal = function showModal(this: HTMLDialogElement) {
+      this.open = true;
+    };
+    HTMLDialogElement.prototype.close = function close(this: HTMLDialogElement) {
+      this.open = false;
+    };
+    vi.mocked(modelsApi.fetchCatalog).mockResolvedValue({ catalog: [birdEntry()] });
+    vi.mocked(modelsApi.fetchInstalled).mockResolvedValue([]);
+    vi.mocked(modelsApi.fetchModelRegions).mockRejectedValue(new Error('no regions in test'));
+    vi.mocked(modelsApi.installModel).mockResolvedValue(undefined);
+    // The SSE progress stream immediately reports a network-shaped failure.
+    vi.mocked(modelsApi.subscribeInstallProgress).mockImplementation(
+      (_id, _onProgress, _onComplete, onError) => {
+        onError(NETWORK_ERROR);
+        return () => {};
+      }
+    );
+  });
+
+  it('keeps the grid rendered on install failure, shows the network hint, and retries the install (not the catalog)', async () => {
+    render(AnalysisSettingsPage);
+    await gotoAvailableTab();
+
+    // Accept the license and start the install.
+    await fireEvent.click(await screen.findByRole('button', { name: installButtonName }));
+    await fireEvent.click(
+      await screen.findByRole('button', { name: /analysis\.gallery\.license\.acceptAndInstall/ })
+    );
+
+    await waitFor(() =>
+      expect(modelsApi.installModel).toHaveBeenCalledWith('test-bird', undefined)
+    );
+
+    // The failure banner appears with the network-shaped Download Source hint.
+    await waitFor(() =>
+      expect(screen.getByText(/analysis\.gallery\.errors\.actionFailed/)).toBeInTheDocument()
+    );
+    expect(screen.getByText(/analysis\.gallery\.errors\.downloadSourceHint/)).toBeInTheDocument();
+
+    // The grid is NOT blanked: the available card's Install button is still present.
+    expect(screen.getByRole('button', { name: installButtonName })).toBeInTheDocument();
+
+    // Retry re-runs the install, and does not reload the catalog.
+    const catalogCallsBeforeRetry = vi.mocked(modelsApi.fetchCatalog).mock.calls.length;
+    await fireEvent.click(screen.getByRole('button', { name: /analysis\.gallery\.retry/ }));
+
+    await waitFor(() => expect(modelsApi.installModel).toHaveBeenCalledTimes(2));
+    expect(modelsApi.installModel).toHaveBeenLastCalledWith('test-bird', undefined);
+    expect(vi.mocked(modelsApi.fetchCatalog).mock.calls.length).toBe(catalogCallsBeforeRetry);
+  });
+});

--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
@@ -165,6 +165,11 @@
   let downloadProgress = $state<DownloadProgress | null>(null);
   let completionTimer: ReturnType<typeof setTimeout> | undefined;
 
+  // Shared DOM id for the Download Source endpoint input, referenced both by the
+  // input's own id and by scrollToDownloadSource's getElementById lookup, so the
+  // two cannot drift apart.
+  const HUGGINGFACE_ENDPOINT_ID = 'huggingface-endpoint';
+
   let licenseModel = $state<CatalogEntry | null>(null);
   // The variant preselected in the license/install dialog: the server-recommended
   // one by default, overridable by the user. Empty for flat (variant-less) entries.
@@ -959,7 +964,7 @@
     licenseModel = null;
   }
 
-  async function handleInstall() {
+  function handleInstall() {
     if (!licenseModel) return;
     // Never install a variant the recommender flagged incompatible with this host
     // (the button is disabled in this state; this guards a programmatic call too).
@@ -1075,7 +1080,7 @@
     }
   }
 
-  async function handleReinstall(entry: CatalogEntry) {
+  function handleReinstall(entry: CatalogEntry) {
     if (reinstallingId || installingId) return;
     startReinstall(entry.id, entry.name);
   }
@@ -1133,6 +1138,11 @@
   // A remove failure offers no retry (the card's Remove button is right there).
   function retryFailedAction() {
     if (!installError) return;
+    // Defensive in-flight guard, mirroring handleReinstall: installError is only set
+    // when nothing is in flight (each start clears it, every failure resets its id),
+    // so this is currently unreachable, but it keeps the invariant explicit and
+    // survives future refactors that might retry while an action is running.
+    if (installingId || reinstallingId) return;
     const { modelId, modelName, variantId, kind } = installError;
     if (kind === 'install') startInstall(modelId, modelName, variantId);
     else if (kind === 'reinstall') startReinstall(modelId, modelName);
@@ -1146,7 +1156,7 @@
   // is the remedy for a download-reachability failure, and it lives on this same
   // Models tab, just below the gallery.
   function scrollToDownloadSource() {
-    const el = document.getElementById('huggingface-endpoint');
+    const el = document.getElementById(HUGGINGFACE_ENDPOINT_ID);
     el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
     el?.focus();
   }
@@ -1573,14 +1583,15 @@
           class="flex items-start gap-3 p-4 rounded-lg mt-4 bg-[color-mix(in_srgb,var(--color-error)_15%,transparent)] text-[var(--color-error)]"
           role="alert"
         >
-          <XCircle class="size-5 shrink-0" />
+          <XCircle class="size-5 shrink-0" aria-hidden="true" />
           <span>{rangeFilterState.error}</span>
           <button
             type="button"
             class="ml-auto inline-flex items-center justify-center p-1.5 rounded-md bg-transparent hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
+            aria-label={t('common.aria.dismissAlert')}
             onclick={() => (rangeFilterState.error = null)}
           >
-            <X class="size-4" />
+            <X class="size-4" aria-hidden="true" />
           </button>
         </div>
       {/if}
@@ -1722,14 +1733,31 @@
               <p class="font-medium text-[var(--color-base-content)]">
                 {t('analysis.gallery.errors.actionFailed', { name: installError.modelName })}
               </p>
-              <p class="mt-0.5 break-words text-[var(--color-base-content)]/80">
-                {installError.message}
-              </p>
               {#if installError.network}
-                <p class="mt-2 text-[var(--color-base-content)]/80">
+                <p class="mt-1 text-[var(--color-base-content)]/80">
                   {t('analysis.gallery.errors.downloadSourceHint')}
                 </p>
+              {:else if installError.kind === 'remove'}
+                <!-- A remove failure has no in-banner Retry (removes are not
+                     re-run from here); point the user back to the card's own
+                     Remove button so the recovery path is never left implicit. -->
+                <p class="mt-1 text-[var(--color-base-content)]/80">
+                  {t('analysis.gallery.errors.removeRetryHint')}
+                </p>
               {/if}
+              <!-- Raw backend/SSE/ApiError text is often long and technical; lead
+                   with the plain-English title (and hint where classifiable) and
+                   keep the raw message one disclosure click away. -->
+              <details class="mt-1">
+                <summary
+                  class="cursor-pointer text-[var(--color-base-content)]/70 hover:text-[var(--color-base-content)]"
+                >
+                  {t('analysis.gallery.errors.details')}
+                </summary>
+                <p class="mt-1 break-words text-[var(--color-base-content)]/80">
+                  {installError.message}
+                </p>
+              </details>
             </div>
             <button
               type="button"
@@ -1801,7 +1829,7 @@
           keeps compiling it the way the browser does.
         -->
         <TextInput
-          id="huggingface-endpoint"
+          id={HUGGINGFACE_ENDPOINT_ID}
           type="url"
           pattern="[Hh][Tt][Tt][Pp][Ss]?:\/\/[^\/?#@]+(\/[^?#]*)?"
           value={birdnet?.huggingFaceEndpoint ?? ''}
@@ -1822,6 +1850,27 @@
 {/snippet}
 
 <!-- ── Gallery: Installed Tab ────────────────────────────────────────── -->
+<!-- Shared catalog-load-error banner, rendered in both gallery tabs. A single
+     definition keeps the two tabs' error UI (markup, retry action, a11y) from
+     drifting, and its decorative icons carry aria-hidden. -->
+{#snippet catalogErrorBanner()}
+  <div
+    class="flex items-center gap-3 rounded-lg border border-[var(--color-error)]/30 bg-[var(--color-error)]/10 px-4 py-3 text-sm"
+    role="alert"
+  >
+    <AlertTriangle class="size-5 shrink-0 text-[var(--color-error)]" aria-hidden="true" />
+    <span class="text-[var(--color-base-content)]">{catalogError}</span>
+    <button
+      type="button"
+      onclick={loadCatalog}
+      class="ml-auto flex items-center gap-1.5 rounded-md bg-[var(--color-base-200)] px-3 py-1.5 text-xs font-medium text-[var(--color-base-content)] hover:bg-[var(--color-base-300)] transition-colors"
+    >
+      <RefreshCw class="size-3.5" aria-hidden="true" />
+      {t('analysis.gallery.retry')}
+    </button>
+  </div>
+{/snippet}
+
 {#snippet installedTabContent()}
   <div class="space-y-4">
     {#if loading}
@@ -1832,20 +1881,7 @@
         >
       </div>
     {:else if catalogError}
-      <div
-        class="flex items-center gap-3 rounded-lg border border-[var(--color-error)]/30 bg-[var(--color-error)]/10 px-4 py-3 text-sm"
-        role="alert"
-      >
-        <AlertTriangle class="size-5 shrink-0 text-[var(--color-error)]" />
-        <span class="text-[var(--color-base-content)]">{catalogError}</span>
-        <button
-          onclick={loadCatalog}
-          class="ml-auto flex items-center gap-1.5 rounded-md bg-[var(--color-base-200)] px-3 py-1.5 text-xs font-medium text-[var(--color-base-content)] hover:bg-[var(--color-base-300)] transition-colors"
-        >
-          <RefreshCw class="size-3.5" />
-          {t('analysis.gallery.retry')}
-        </button>
-      </div>
+      {@render catalogErrorBanner()}
     {:else}
       <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
         <!-- Built-in BirdNET model (always present) -->
@@ -1962,11 +1998,16 @@
             <!-- Incompatible warning for installed models -->
             {#if !entry.compatible}
               <div
-                class="mt-3 flex items-start gap-2 rounded-lg bg-red-500/10 p-3 text-sm text-red-700 dark:text-red-400"
+                class="mt-3 flex items-start gap-2 rounded-lg bg-[var(--color-error)]/10 p-3 text-sm"
                 role="status"
               >
-                <XCircle class="h-4 w-4 shrink-0 mt-0.5" />
-                <span>{entryIncompatibleText(entry.incompatibleReason)}</span>
+                <XCircle
+                  class="h-4 w-4 shrink-0 mt-0.5 text-[var(--color-error)]"
+                  aria-hidden="true"
+                />
+                <span class="text-[var(--color-base-content)]"
+                  >{entryIncompatibleText(entry.incompatibleReason)}</span
+                >
               </div>
             {/if}
             <!-- Metadata grid -->
@@ -2147,11 +2188,16 @@
     <!-- Incompatible warning banner -->
     {#if !entry.compatible}
       <div
-        class="mt-3 flex items-start gap-2 rounded-lg bg-amber-500/10 p-3 text-sm text-amber-700 dark:text-amber-400"
+        class="mt-3 flex items-start gap-2 rounded-lg bg-[var(--color-warning)]/10 p-3 text-sm"
         role="status"
       >
-        <TriangleAlert class="h-4 w-4 shrink-0 mt-0.5" />
-        <span>{entryIncompatibleText(entry.incompatibleReason)}</span>
+        <TriangleAlert
+          class="h-4 w-4 shrink-0 mt-0.5 text-[var(--color-warning)]"
+          aria-hidden="true"
+        />
+        <span class="text-[var(--color-base-content)]"
+          >{entryIncompatibleText(entry.incompatibleReason)}</span
+        >
       </div>
     {/if}
 
@@ -2230,20 +2276,7 @@
         >
       </div>
     {:else if catalogError}
-      <div
-        class="flex items-center gap-3 rounded-lg border border-[var(--color-error)]/30 bg-[var(--color-error)]/10 px-4 py-3 text-sm"
-        role="alert"
-      >
-        <AlertTriangle class="size-5 shrink-0 text-[var(--color-error)]" />
-        <span class="text-[var(--color-base-content)]">{catalogError}</span>
-        <button
-          onclick={loadCatalog}
-          class="ml-auto flex items-center gap-1.5 rounded-md bg-[var(--color-base-200)] px-3 py-1.5 text-xs font-medium text-[var(--color-base-content)] hover:bg-[var(--color-base-300)] transition-colors"
-        >
-          <RefreshCw class="size-3.5" />
-          {t('analysis.gallery.retry')}
-        </button>
-      </div>
+      {@render catalogErrorBanner()}
     {:else}
       <!-- Acoustic Classifiers section -->
       {#if availableWildlife.length > 0 || availableBirds.length > 0 || availableBats.length > 0}
@@ -2415,13 +2448,26 @@
             onSelect={id => (selectedVariantId = id)}
             idPrefix="license-variant"
           />
+          <!-- Plain-language help for the precision jargon (FP32/FP16/INT8) and the
+               Default-vs-Recommended distinction, for the non-technical audience. A
+               native <details> is keyboard- and touch-accessible, unlike a
+               hover-only tooltip. -->
+          <details class="mt-2 text-xs text-[var(--color-base-content)]/70">
+            <summary class="cursor-pointer hover:text-[var(--color-base-content)]">
+              {t('analysis.gallery.variants.precisionInfo')}
+            </summary>
+            <p class="mt-1">{t('analysis.gallery.variants.precisionHelp')}</p>
+          </details>
         {/if}
 
         {#if !licenseModel.commercialUse}
           <div
             class="flex items-start gap-2 rounded-lg border border-[var(--color-warning)]/30 bg-[var(--color-warning)]/10 px-3 py-2.5 text-sm"
           >
-            <ShieldAlert class="mt-0.5 size-4 shrink-0 text-[var(--color-warning)]" />
+            <ShieldAlert
+              class="mt-0.5 size-4 shrink-0 text-[var(--color-warning)]"
+              aria-hidden="true"
+            />
             <p class="text-[var(--color-base-content)]">
               {t('analysis.gallery.license.nonCommercialWarning')}
             </p>
@@ -2467,7 +2513,7 @@
     <div class="w-full max-w-md p-6">
       <div class="flex items-start gap-3">
         <div class="shrink-0 rounded-full bg-[var(--color-error)]/10 p-2">
-          <AlertTriangle class="size-5 text-[var(--color-error)]" />
+          <AlertTriangle class="size-5 text-[var(--color-error)]" aria-hidden="true" />
         </div>
         <div>
           <h3
@@ -2565,14 +2611,15 @@
           class="flex items-start gap-3 p-4 rounded-lg mb-4 bg-[color-mix(in_srgb,var(--color-error)_15%,transparent)] text-[var(--color-error)]"
           role="alert"
         >
-          <XCircle class="size-5 shrink-0" />
+          <XCircle class="size-5 shrink-0" aria-hidden="true" />
           <span>{rangeFilterState.error}</span>
           <button
             type="button"
             class="ml-auto inline-flex items-center justify-center p-1.5 rounded-md bg-transparent hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
+            aria-label={t('common.aria.dismissAlert')}
             onclick={() => (rangeFilterState.error = null)}
           >
-            <X class="size-4" />
+            <X class="size-4" aria-hidden="true" />
           </button>
         </div>
       {/if}

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -3886,6 +3886,8 @@ export type TranslationKey =
   | 'analysis.gallery.variants.incompatible'
   | 'analysis.gallery.variants.showAll' // params: count
   | 'analysis.gallery.variants.latency' // params: ms
+  | 'analysis.gallery.variants.precisionInfo'
+  | 'analysis.gallery.variants.precisionHelp'
   | 'analysis.gallery.reasons.backendRecommended' // params: backend
   | 'analysis.gallery.reasons.backendSupported' // params: backend
   | 'analysis.gallery.reasons.regionMatched' // params: region
@@ -3943,6 +3945,8 @@ export type TranslationKey =
   | 'analysis.gallery.errors.downloadSourceHint'
   | 'analysis.gallery.errors.goToDownloadSource'
   | 'analysis.gallery.errors.dismiss'
+  | 'analysis.gallery.errors.details'
+  | 'analysis.gallery.errors.removeRetryHint'
   | 'analysis.gallery.regionLabel'
   | 'analysis.gallery.speciesLabel'
   | 'analysis.gallery.reinstall'

--- a/frontend/src/lib/i18n/validateUsage.ts
+++ b/frontend/src/lib/i18n/validateUsage.ts
@@ -20,6 +20,12 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { DEFAULT_LOCALE } from './config.js';
 
+// grep -rn 't(' over the whole src/ tree emits far more than Node's 1 MiB
+// default execSync buffer. Without this the spawn throws ENOBUFS; that error was
+// previously swallowed, so the check silently scanned nothing and still exited 0.
+// 64 MiB leaves generous headroom as the codebase grows.
+const GREP_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
+
 interface UsageResult {
   usedKeys: Map<string, string[]>; // key -> [file paths]
   missingInTranslations: string[];
@@ -107,11 +113,15 @@ class UsageValidator {
       const output = execSync(`grep -rn 't(' src/ --include="*.svelte" --include="*.ts" || true`, {
         cwd: process.cwd(),
         encoding: 'utf-8',
+        maxBuffer: GREP_MAX_BUFFER_BYTES,
       });
 
       if (!output.trim()) {
-        console.log('   No translation keys found in codebase\n');
-        return;
+        // t() is ubiquitous across the codebase; an empty scan means grep itself
+        // failed, not that the code uses no translations. Fail loudly instead.
+        throw new Error(
+          'i18n usage scan produced no output; the grep scan of src/ is broken. Refusing to report a passing validation on zero scanned files.'
+        );
       }
 
       // Parse grep output: filename:linenum:content
@@ -155,12 +165,27 @@ class UsageValidator {
         }
       }
 
+      if (this.usedKeys.size === 0) {
+        // Output was non-empty but nothing parsed out as a key: the parser or the
+        // false-positive filters are broken. Fail rather than silently pass.
+        throw new Error(
+          'i18n usage scan matched grep output but extracted zero translation keys; the parser is broken. Refusing to report a passing validation.'
+        );
+      }
+
       console.log(
         `   Found ${this.usedKeys.size} unique keys in ${this.countUniqueFiles()} files\n`
       );
     } catch (error) {
-      console.error('Error scanning codebase:', error);
-      console.log('   No translation keys found in codebase\n');
+      // Never swallow: a failed scan previously reported "0 files" and still exited
+      // 0, so i18n:check-usage gave no real coverage. Surface it loudly.
+      if (error instanceof Error && error.message.startsWith('i18n usage scan')) {
+        throw error;
+      }
+      throw new Error(
+        `i18n usage scan failed: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error }
+      );
     }
   }
 

--- a/frontend/src/lib/utils/variantSelection.test.ts
+++ b/frontend/src/lib/utils/variantSelection.test.ts
@@ -11,14 +11,23 @@ import type { CatalogEntry, CatalogVariant, VariantReason } from '$lib/types/mod
 // Controlled i18n mock: only these two keys have a "translation"; every other key
 // echoes back, which is how the real t() signals an untranslated key. This lets us
 // exercise both the translated branch and the fallback branch of translateReason.
-vi.mock('$lib/i18n', () => ({
-  t: (key: string) => {
+// The mock t is a spy (declared via vi.hoisted so it exists before the hoisted
+// vi.mock runs) so a test can assert the interpolation args are forwarded to t,
+// not merely that the result is unchanged. It still echoes an unmapped key, which
+// is how the real t() signals an untranslated key.
+const { tSpy } = vi.hoisted(() => ({
+  tSpy: vi.fn((key: string, _args?: Record<string, string>) => {
     const dict: Record<string, string> = {
       'analysis.gallery.reasons.backendRecommended': 'Best for your hardware',
       'analysis.gallery.reasons.regionMatched': 'Matched to your region',
     };
+    // eslint-disable-next-line security/detect-object-injection -- test mock, key is a controlled literal
     return dict[key] ?? key;
-  },
+  }),
+}));
+
+vi.mock('$lib/i18n', () => ({
+  t: tSpy,
 }));
 
 function variant(overrides: Partial<CatalogVariant> & { id: string }): CatalogVariant {
@@ -163,11 +172,15 @@ describe('translateReason', () => {
   });
 
   it('passes interpolation args through to t', () => {
-    // regionMatched has a translation, so the translated branch is taken; the mock
-    // ignores args, but this asserts args are accepted without changing the result.
+    tSpy.mockClear();
+    // regionMatched has a translation, so the translated branch is taken. Assert
+    // the args object reaches t verbatim, not just that the result is unchanged.
     expect(translateReason('region.matched', { region: 'Finland' }, 'raw')).toBe(
       'Matched to your region'
     );
+    expect(tSpy).toHaveBeenCalledWith('analysis.gallery.reasons.regionMatched', {
+      region: 'Finland',
+    });
   });
 });
 

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -5329,7 +5329,9 @@
         "default": "Výchozí",
         "incompatible": "Není k dispozici pro váš hardware",
         "showAll": "Zobrazit všechny varianty ({count})",
-        "latency": "~{ms} ms"
+        "latency": "~{ms} ms",
+        "precisionInfo": "About precision and variants",
+        "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "reasons": {
         "backendRecommended": "Běží na {backend}, doporučeném backendu pro váš hardware",
@@ -5402,7 +5404,9 @@
         "actionFailed": "Došlo k problému s {name}",
         "downloadSourceHint": "Pokud je huggingface.co ve vaší síti blokováno nebo pomalé, nastavte zrcadlový server v sekci Zdroj stahování níže.",
         "goToDownloadSource": "Přejít na Zdroj stahování",
-        "dismiss": "Zavřít"
+        "dismiss": "Zavřít",
+        "details": "Details",
+        "removeRetryHint": "To try again, use the Remove button on the model's card."
       },
       "regionLabel": "Oblast",
       "speciesLabel": "Druhy",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -5329,7 +5329,9 @@
         "default": "Standard",
         "incompatible": "Ikke tilgængelig for din hardware",
         "showAll": "Vis alle varianter ({count})",
-        "latency": "~{ms} ms"
+        "latency": "~{ms} ms",
+        "precisionInfo": "About precision and variants",
+        "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "reasons": {
         "backendRecommended": "Kører på {backend}, den anbefalede backend til din hardware",
@@ -5402,7 +5404,9 @@
         "actionFailed": "Der opstod et problem med {name}",
         "downloadSourceHint": "Hvis huggingface.co er blokeret eller langsomt på dit netværk, kan du indstille en spejlserver i sektionen Downloadkilde nedenfor.",
         "goToDownloadSource": "Gå til Downloadkilde",
-        "dismiss": "Afvis"
+        "dismiss": "Afvis",
+        "details": "Details",
+        "removeRetryHint": "To try again, use the Remove button on the model's card."
       },
       "regionLabel": "Region",
       "speciesLabel": "Arter",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -5329,7 +5329,9 @@
         "default": "Standard",
         "incompatible": "Für Ihre Hardware nicht verfügbar",
         "showAll": "Alle Varianten anzeigen ({count})",
-        "latency": "~{ms} ms"
+        "latency": "~{ms} ms",
+        "precisionInfo": "About precision and variants",
+        "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "reasons": {
         "backendRecommended": "Läuft auf {backend}, dem empfohlenen Backend für Ihre Hardware",
@@ -5402,7 +5404,9 @@
         "actionFailed": "Es gab ein Problem mit {name}",
         "downloadSourceHint": "Wenn huggingface.co in Ihrem Netzwerk blockiert oder langsam ist, richten Sie im Abschnitt Download-Quelle unten einen Spiegelserver ein.",
         "goToDownloadSource": "Zur Download-Quelle",
-        "dismiss": "Schließen"
+        "dismiss": "Schließen",
+        "details": "Details",
+        "removeRetryHint": "To try again, use the Remove button on the model's card."
       },
       "regionLabel": "Region",
       "speciesLabel": "Arten",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -5329,7 +5329,9 @@
         "default": "Default",
         "incompatible": "Not available for your hardware",
         "showAll": "Show all variants ({count})",
-        "latency": "~{ms} ms"
+        "latency": "~{ms} ms",
+        "precisionInfo": "About precision and variants",
+        "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "reasons": {
         "backendRecommended": "Runs on {backend}, the recommended backend for your hardware",
@@ -5340,7 +5342,7 @@
         "ramConstrainedFit": "Quantized build sized for your available memory",
         "benchmarkMeasured": "Fastest on your device in measured benchmarks",
         "variantLegacy": "Superseded by a newer build",
-        "archUnsupported": "Requires a {required} CPU",
+        "archUnsupported": "Requires {required} CPU architecture",
         "backendMissing": "Needs an inference backend your build cannot reach ({required})",
         "ramInsufficient": "Needs at least {requiredMb} MB of memory",
         "hardwareExcluded": "Not supported on your hardware ({token})",
@@ -5402,7 +5404,9 @@
         "actionFailed": "There was a problem with {name}",
         "downloadSourceHint": "If huggingface.co is blocked or slow on your network, set a mirror in the Download Source section below.",
         "goToDownloadSource": "Go to Download Source",
-        "dismiss": "Dismiss"
+        "dismiss": "Dismiss",
+        "details": "Details",
+        "removeRetryHint": "To try again, use the Remove button on the model's card."
       },
       "regionLabel": "Region",
       "speciesLabel": "Species",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -5329,7 +5329,9 @@
         "default": "Predeterminado",
         "incompatible": "No disponible para tu hardware",
         "showAll": "Mostrar todas las variantes ({count})",
-        "latency": "~{ms} ms"
+        "latency": "~{ms} ms",
+        "precisionInfo": "About precision and variants",
+        "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "reasons": {
         "backendRecommended": "Se ejecuta en {backend}, el backend recomendado para tu hardware",
@@ -5402,7 +5404,9 @@
         "actionFailed": "Hubo un problema con {name}",
         "downloadSourceHint": "Si huggingface.co está bloqueado o es lento en su red, configure un servidor espejo en la sección Origen de descarga a continuación.",
         "goToDownloadSource": "Ir a Origen de descarga",
-        "dismiss": "Descartar"
+        "dismiss": "Descartar",
+        "details": "Details",
+        "removeRetryHint": "To try again, use the Remove button on the model's card."
       },
       "regionLabel": "Región",
       "speciesLabel": "Especies",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -5329,7 +5329,9 @@
         "default": "Oletus",
         "incompatible": "Ei saatavilla laitteistollesi",
         "showAll": "Näytä kaikki variantit ({count})",
-        "latency": "~{ms} ms"
+        "latency": "~{ms} ms",
+        "precisionInfo": "About precision and variants",
+        "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "reasons": {
         "backendRecommended": "Käyttää taustajärjestelmää {backend}, joka on suositeltu laitteistollesi",
@@ -5402,7 +5404,9 @@
         "actionFailed": "Kohteen {name} kanssa ilmeni ongelma",
         "downloadSourceHint": "Jos huggingface.co on estetty tai hidas verkossasi, aseta peilipalvelin alla olevaan Latauslähde-osioon.",
         "goToDownloadSource": "Siirry Latauslähteeseen",
-        "dismiss": "Sulje"
+        "dismiss": "Sulje",
+        "details": "Details",
+        "removeRetryHint": "To try again, use the Remove button on the model's card."
       },
       "regionLabel": "Alue",
       "speciesLabel": "Lajit",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -5329,7 +5329,9 @@
         "default": "Par défaut",
         "incompatible": "Non disponible pour votre matériel",
         "showAll": "Afficher toutes les variantes ({count})",
-        "latency": "~{ms} ms"
+        "latency": "~{ms} ms",
+        "precisionInfo": "About precision and variants",
+        "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "reasons": {
         "backendRecommended": "S'exécute sur {backend}, le backend recommandé pour votre matériel",
@@ -5402,7 +5404,9 @@
         "actionFailed": "Un problème est survenu avec {name}",
         "downloadSourceHint": "Si huggingface.co est bloqué ou lent sur votre réseau, définissez un miroir dans la section Source de téléchargement ci-dessous.",
         "goToDownloadSource": "Aller à la source de téléchargement",
-        "dismiss": "Ignorer"
+        "dismiss": "Ignorer",
+        "details": "Details",
+        "removeRetryHint": "To try again, use the Remove button on the model's card."
       },
       "regionLabel": "Région",
       "speciesLabel": "Espèces",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -5329,7 +5329,9 @@
         "default": "Alapértelmezett",
         "incompatible": "Nem érhető el az Ön hardveréhez",
         "showAll": "Összes változat mutatása ({count})",
-        "latency": "~{ms} ms"
+        "latency": "~{ms} ms",
+        "precisionInfo": "About precision and variants",
+        "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "reasons": {
         "backendRecommended": "Ezen fut: {backend}, amely a hardveredhez ajánlott backend",
@@ -5402,7 +5404,9 @@
         "actionFailed": "Probléma történt a következővel: {name}",
         "downloadSourceHint": "Ha a huggingface.co blokkolva van vagy lassú a hálózatán, állítson be egy tükörszervert az alábbi Letöltési forrás szakaszban.",
         "goToDownloadSource": "Ugrás a Letöltési forráshoz",
-        "dismiss": "Bezárás"
+        "dismiss": "Bezárás",
+        "details": "Details",
+        "removeRetryHint": "To try again, use the Remove button on the model's card."
       },
       "regionLabel": "Régió",
       "speciesLabel": "Fajok",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -5329,7 +5329,9 @@
         "default": "Predefinito",
         "incompatible": "Non disponibile per il tuo hardware",
         "showAll": "Mostra tutte le varianti ({count})",
-        "latency": "~{ms} ms"
+        "latency": "~{ms} ms",
+        "precisionInfo": "About precision and variants",
+        "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "reasons": {
         "backendRecommended": "Eseguito su {backend}, il backend consigliato per il tuo hardware",
@@ -5402,7 +5404,9 @@
         "actionFailed": "Si è verificato un problema con {name}",
         "downloadSourceHint": "Se huggingface.co è bloccato o lento sulla tua rete, imposta un mirror nella sezione Sorgente di download sottostante.",
         "goToDownloadSource": "Vai a Sorgente di download",
-        "dismiss": "Ignora"
+        "dismiss": "Ignora",
+        "details": "Details",
+        "removeRetryHint": "To try again, use the Remove button on the model's card."
       },
       "regionLabel": "Regione",
       "speciesLabel": "Specie",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -5329,7 +5329,9 @@
         "default": "Noklusējuma",
         "incompatible": "Nav pieejams jūsu aparatūrai",
         "showAll": "Rādīt visus variantus ({count})",
-        "latency": "~{ms} ms"
+        "latency": "~{ms} ms",
+        "precisionInfo": "About precision and variants",
+        "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "reasons": {
         "backendRecommended": "Darbojas ar {backend}, kas ir ieteicamā aizmugursistēma jūsu aparatūrai",
@@ -5402,7 +5404,9 @@
         "actionFailed": "Radās problēma ar {name}",
         "downloadSourceHint": "Ja jūsu tīklā huggingface.co ir bloķēts vai lēns, iestatiet spoguļvietni zemāk esošajā sadaļā Lejupielādes avots.",
         "goToDownloadSource": "Doties uz Lejupielādes avots",
-        "dismiss": "Noraidīt"
+        "dismiss": "Noraidīt",
+        "details": "Details",
+        "removeRetryHint": "To try again, use the Remove button on the model's card."
       },
       "regionLabel": "Reģions",
       "speciesLabel": "Sugas",

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -5329,7 +5329,9 @@
         "default": "Standard",
         "incompatible": "Ikke tilgjengelig for maskinvaren din",
         "showAll": "Vis alle varianter ({count})",
-        "latency": "~{ms} ms"
+        "latency": "~{ms} ms",
+        "precisionInfo": "About precision and variants",
+        "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "reasons": {
         "backendRecommended": "Kjører på {backend}, som er den anbefalte backenden for din maskinvare",
@@ -5402,7 +5404,9 @@
         "actionFailed": "Det oppsto et problem med {name}",
         "downloadSourceHint": "Hvis huggingface.co er blokkert eller tregt på nettverket ditt, kan du angi en speilserver i seksjonen Nedlastingskilde nedenfor.",
         "goToDownloadSource": "Gå til Nedlastingskilde",
-        "dismiss": "Avvis"
+        "dismiss": "Avvis",
+        "details": "Details",
+        "removeRetryHint": "To try again, use the Remove button on the model's card."
       },
       "regionLabel": "Region",
       "speciesLabel": "Arter",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -5329,7 +5329,9 @@
         "default": "Standaard",
         "incompatible": "Niet beschikbaar voor uw hardware",
         "showAll": "Toon alle varianten ({count})",
-        "latency": "~{ms} ms"
+        "latency": "~{ms} ms",
+        "precisionInfo": "About precision and variants",
+        "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "reasons": {
         "backendRecommended": "Draait op {backend}, de aanbevolen backend voor jouw hardware",
@@ -5402,7 +5404,9 @@
         "actionFailed": "Er is een probleem opgetreden met {name}",
         "downloadSourceHint": "Als huggingface.co geblokkeerd of traag is op uw netwerk, stel dan een spiegelserver in bij de sectie Downloadbron hieronder.",
         "goToDownloadSource": "Ga naar Downloadbron",
-        "dismiss": "Negeren"
+        "dismiss": "Negeren",
+        "details": "Details",
+        "removeRetryHint": "To try again, use the Remove button on the model's card."
       },
       "regionLabel": "Regio",
       "speciesLabel": "Soorten",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -5329,7 +5329,9 @@
         "default": "Domyślne",
         "incompatible": "Niedostępne dla Twojego sprzętu",
         "showAll": "Pokaż wszystkie warianty ({count})",
-        "latency": "~{ms} ms"
+        "latency": "~{ms} ms",
+        "precisionInfo": "About precision and variants",
+        "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "reasons": {
         "backendRecommended": "Działa na {backend}, zalecanym backendzie dla twojego sprzętu",
@@ -5402,7 +5404,9 @@
         "actionFailed": "Wystąpił problem z {name}",
         "downloadSourceHint": "Jeśli huggingface.co jest zablokowane lub działa wolno w Twojej sieci, ustaw serwer lustrzany w sekcji Źródło pobierania poniżej.",
         "goToDownloadSource": "Przejdź do Źródło pobierania",
-        "dismiss": "Odrzuć"
+        "dismiss": "Odrzuć",
+        "details": "Details",
+        "removeRetryHint": "To try again, use the Remove button on the model's card."
       },
       "regionLabel": "Region",
       "speciesLabel": "Gatunki",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -5329,7 +5329,9 @@
         "default": "Padrão",
         "incompatible": "Não disponível para o seu hardware",
         "showAll": "Mostrar todas as variantes ({count})",
-        "latency": "~{ms} ms"
+        "latency": "~{ms} ms",
+        "precisionInfo": "About precision and variants",
+        "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "reasons": {
         "backendRecommended": "Roda em {backend}, o backend recomendado para o seu hardware",
@@ -5402,7 +5404,9 @@
         "actionFailed": "Ocorreu um problema com {name}",
         "downloadSourceHint": "Se o huggingface.co estiver bloqueado ou lento em sua rede, defina um espelho na seção Origem de download abaixo.",
         "goToDownloadSource": "Ir para Origem de download",
-        "dismiss": "Dispensar"
+        "dismiss": "Dispensar",
+        "details": "Details",
+        "removeRetryHint": "To try again, use the Remove button on the model's card."
       },
       "regionLabel": "Região",
       "speciesLabel": "Espécies",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -5329,7 +5329,9 @@
         "default": "Predvolené",
         "incompatible": "Nie je k dispozícii pre váš hardvér",
         "showAll": "Zobraziť všetky varianty ({count})",
-        "latency": "~{ms} ms"
+        "latency": "~{ms} ms",
+        "precisionInfo": "About precision and variants",
+        "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "reasons": {
         "backendRecommended": "Beží na {backend}, čo je odporúčaný backend pre váš hardvér",
@@ -5402,7 +5404,9 @@
         "actionFailed": "Vyskytol sa problém s {name}",
         "downloadSourceHint": "Ak je huggingface.co vo vašej sieti zablokované alebo pomalé, nastavte zrkadlový server v sekcii Zdroj sťahovania nižšie.",
         "goToDownloadSource": "Prejsť na Zdroj sťahovania",
-        "dismiss": "Zavrieť"
+        "dismiss": "Zavrieť",
+        "details": "Details",
+        "removeRetryHint": "To try again, use the Remove button on the model's card."
       },
       "regionLabel": "Región",
       "speciesLabel": "Druhy",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -5329,7 +5329,9 @@
         "default": "Standard",
         "incompatible": "Inte tillgänglig för din hårdvara",
         "showAll": "Visa alla varianter ({count})",
-        "latency": "~{ms} ms"
+        "latency": "~{ms} ms",
+        "precisionInfo": "About precision and variants",
+        "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "reasons": {
         "backendRecommended": "Körs på {backend}, den rekommenderade backend-motorn för din hårdvara",
@@ -5402,7 +5404,9 @@
         "actionFailed": "Det uppstod ett problem med {name}",
         "downloadSourceHint": "Om huggingface.co är blockerat eller långsamt på ditt nätverk kan du ange en spegelsajt i avsnittet Nedladdningskälla nedan.",
         "goToDownloadSource": "Gå till Nedladdningskälla",
-        "dismiss": "Avfärda"
+        "dismiss": "Avfärda",
+        "details": "Details",
+        "removeRetryHint": "To try again, use the Remove button on the model's card."
       },
       "regionLabel": "Region",
       "speciesLabel": "Arter",


### PR DESCRIPTION
## Summary

A batch of low-risk model-gallery follow-ups, plus a pre-existing i18n tooling bug found alongside them. Frontend only; no Go changes.

**Model gallery UI** (`AnalysisSettingsPage`, `ModelVariantPicker`): the install-error banner now leads with a plain-English title and tucks the raw backend/SSE message behind a Details disclosure, and a remove failure points back to the card's own Remove button so the recovery path is never implicit. The two identical catalog-load-error banners are deduplicated into one shared snippet, the failed-action Retry gets a defensive in-flight guard, `handleInstall`/`handleReinstall` drop their vestigial `async`, and the download-source input id is extracted to a constant so the input and the scroll-to lookup cannot drift. Recommendation reasons now render as a labeled list (a screen reader announces them as distinct reasons), and a precision help disclosure in the license dialog explains FP32/FP16/INT8 and Default vs Recommended. The arch-unsupported reason is reworded to drop the a/an article ("Requires {required} CPU architecture"), which also reads correctly for a comma-joined token list.

**Accessibility**: decorative banner icons get `aria-hidden`, the two icon-only range-filter dismiss buttons get accessible labels, and the per-card incompatibility banners move to design tokens while keeping the message text at full `base-content` contrast (a naive token swap dropped the warning banner below WCAG AA in light mode).

**i18n tooling** (`validateUsage.ts`): the usage scan shelled out to `grep` with no `maxBuffer`, so on the current codebase it threw `ENOBUFS`, swallowed the error, and reported a passing run with zero files scanned. The buffer is raised and an empty or zero-key scan is now a hard failure, so the check fails loudly instead of silently passing.

## Test Plan

- [x] `npm run check:all` (format, lint, typecheck, ast-grep) passes
- [x] `npm test` for the affected suites passes (37 tests)
- [x] `npm run i18n:validate:full` passes (sync, generated types, usage scan)
- [x] New page-level test: a failed install keeps the model grid rendered, shows the download-source hint for a network-shaped failure, and Retry re-runs the install rather than reloading the catalog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Model variant recommendations now display all available reasons in a labeled list.
  - Added latency and precision guidance to model variant details.
  - Model gallery errors now provide clearer details, recovery hints, and retry actions.
  - Improved accessibility for alerts, dialogs, and decorative icons.
- **Bug Fixes**
  - Failed model installations can be retried without unnecessarily reloading the catalog.
  - Improved handling and reporting of localization scan failures.
- **Localization**
  - Added or updated model gallery translations across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->