### PR TITLE
feat(models): consume x86 benchmarks in the recommender and keep fp16 on GPU hosts

### DIFF
--- a/internal/classifier/gen/main.go
+++ b/internal/classifier/gen/main.go
@@ -158,10 +158,11 @@ type labelChecksum struct {
 }
 
 const (
-	labelsSidecar   = "gen/manifests/labels-checksums.json"
-	outputFile      = "model_catalog_regional_gen.go"
-	expectedRegions = 39
-	regionalPerFam  = 78 // 39 regions x 2 variants
+	labelsSidecar     = "gen/manifests/labels-checksums.json"
+	outputFile        = "model_catalog_regional_gen.go"
+	expectedRegions   = 39
+	variantsPerRegion = 2 // each region ships two precision variants
+	regionalPerFam    = expectedRegions * variantsPerRegion
 )
 
 func main() {
@@ -418,11 +419,11 @@ func render(v *genVariant) string {
 	b.WriteString("Requirements: VariantRequirements{")
 	var reqs []string
 	if len(v.arch) > 0 {
-		reqs = append(reqs, "Arch: "+stringSliceLit(v.arch))
+		reqs = append(reqs, fmt.Sprintf("Arch: %#v", v.arch))
 	}
 	reqs = append(reqs, fmt.Sprintf("MinRAMMB: %d", v.minRAMMB))
 	if len(v.excludes) > 0 {
-		reqs = append(reqs, "Excludes: "+stringSliceLit(v.excludes))
+		reqs = append(reqs, fmt.Sprintf("Excludes: %#v", v.excludes))
 	}
 	b.WriteString(strings.Join(reqs, ", "))
 	b.WriteString("},\n")
@@ -471,14 +472,6 @@ func render(v *genVariant) string {
 
 	b.WriteString("},\n")
 	return b.String()
-}
-
-func stringSliceLit(s []string) string {
-	quoted := make([]string, len(s))
-	for i, v := range s {
-		quoted[i] = fmt.Sprintf("%q", v)
-	}
-	return "[]string{" + strings.Join(quoted, ", ") + "}"
 }
 
 func loadManifest(pathname string) (*manifest, error) {

--- a/internal/classifier/model_catalog_gen_consistency_test.go
+++ b/internal/classifier/model_catalog_gen_consistency_test.go
@@ -3,6 +3,8 @@ package classifier
 import (
 	"encoding/json"
 	"os"
+	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,13 +20,34 @@ import (
 func TestRegionalVariants_MatchManifest(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
+	// Derive the regional families from the catalog itself (an entry is regional
+	// when any of its variants carries a Region), so a future third regional
+	// family is covered without editing this test. The manifest filename follows
+	// the vendoring convention: the HuggingFace repo's base name plus
+	// ".models.json".
+	type famCase struct {
 		entryID      string
 		manifestFile string
-	}{
-		{"birdnet-v3.0", "gen/manifests/BirdNET-v3.0-Models.models.json"},
-		{"perch-v2", "gen/manifests/Perch-v2-Models.models.json"},
 	}
+	var cases []famCase
+	for i := range EmbeddedCatalog {
+		e := &EmbeddedCatalog[i]
+		regional := false
+		for j := range e.Variants {
+			if e.Variants[j].Region != "" {
+				regional = true
+				break
+			}
+		}
+		if !regional {
+			continue
+		}
+		cases = append(cases, famCase{
+			entryID:      e.ID,
+			manifestFile: filepath.Join("gen", "manifests", path.Base(e.HuggingFaceRepo)+".models.json"),
+		})
+	}
+	require.GreaterOrEqualf(t, len(cases), 2, "expected at least the birdnet-v3.0 and perch-v2 regional families")
 
 	for _, tc := range cases {
 		t.Run(tc.entryID, func(t *testing.T) {
@@ -71,6 +94,27 @@ func TestRegionalVariants_MatchManifest(t *testing.T) {
 				assert.Equalf(t, e.SizeBytes, model.SizeBytes, "model size for %q", e.Path)
 				require.NotNilf(t, e.Requirements, "manifest entry %q must carry requirements", e.Path)
 				assert.Equalf(t, e.Requirements.MinRAMMB, v.Requirements.MinRAMMB, "RAM floor for %q", e.Path)
+
+				// Precision, normalized the same way the generator does.
+				assert.Equalf(t, normalizeManifestPrecision(e.Precision), v.Precision, "precision for %q", e.Path)
+
+				// SpeciesCount: v3.0 supplies classes in the manifest; Perch omits it
+				// and the region table fills it in, so there we only assert it is set.
+				if e.Classes != nil {
+					assert.Equalf(t, *e.Classes, v.SpeciesCount, "species count for %q", e.Path)
+				} else {
+					assert.Positivef(t, v.SpeciesCount, "species count for %q must be populated", e.Path)
+				}
+
+				// Arch is derived by the generator: the int8-arm build is aarch64-only.
+				var wantArch []string
+				if e.Variant == "int8-arm" {
+					wantArch = []string{"aarch64"}
+				}
+				assert.ElementsMatchf(t, wantArch, v.Requirements.Arch, "arch for %q", e.Path)
+
+				// Excludes pass through verbatim from the manifest requirements.
+				assert.ElementsMatchf(t, e.Requirements.Excludes, v.Requirements.Excludes, "excludes for %q", e.Path)
 			}
 			assert.Equalf(t, regionalTilesPerFamily, regional, "manifest %s must describe %d regional tiles", tc.manifestFile, regionalTilesPerFamily)
 			assert.Lenf(t, byModelPath, regionalTilesPerFamily, "%s must expose exactly %d regional model paths", tc.entryID, regionalTilesPerFamily)
@@ -82,13 +126,27 @@ func TestRegionalVariants_MatchManifest(t *testing.T) {
 type testManifest struct {
 	Models []struct {
 		Path         string `json:"path"`
+		Variant      string `json:"variant"`
+		Precision    string `json:"precision"`
 		Region       string `json:"region"`
+		Classes      *int   `json:"classes"`
 		SHA256       string `json:"sha256"`
 		SizeBytes    int64  `json:"size_bytes"`
 		Requirements *struct {
-			MinRAMMB int `json:"min_ram_mb"`
+			MinRAMMB int      `json:"min_ram_mb"`
+			Excludes []string `json:"excludes"`
 		} `json:"requirements"`
 	} `json:"models"`
+}
+
+// normalizeManifestPrecision mirrors the generator's normalizePrecision, kept as
+// an independent restatement so a change to that mapping is caught here rather
+// than silently agreeing with the generator.
+func normalizeManifestPrecision(p string) string {
+	if p == "int8-arm" {
+		return "int8"
+	}
+	return p
 }
 
 func loadTestManifest(t *testing.T, pathname string) *testManifest {

--- a/internal/classifier/model_catalog_gen_consistency_test.go
+++ b/internal/classifier/model_catalog_gen_consistency_test.go
@@ -95,6 +95,10 @@ func TestRegionalVariants_MatchManifest(t *testing.T) {
 				require.NotNilf(t, e.Requirements, "manifest entry %q must carry requirements", e.Path)
 				assert.Equalf(t, e.Requirements.MinRAMMB, v.Requirements.MinRAMMB, "RAM floor for %q", e.Path)
 
+				// The generated variant ID is the manifest variant token joined to
+				// the region slug (generator: e.Variant + "@" + e.Region).
+				assert.Equalf(t, e.Variant+"@"+e.Region, v.ID, "variant ID for %q", e.Path)
+
 				// Precision, normalized the same way the generator does.
 				assert.Equalf(t, normalizeManifestPrecision(e.Precision), v.Precision, "precision for %q", e.Path)
 

--- a/internal/classifier/recommend/recommend.go
+++ b/internal/classifier/recommend/recommend.go
@@ -48,6 +48,9 @@ const (
 	// scoreFP16Native rewards an fp16 variant on a host with native
 	// half-precision SIMD.
 	scoreFP16Native = 15
+	// scoreFP16GPUPreferredHeadroom is the margin above benchmarkMaxScore that
+	// keeps fp16 winning outright rather than on the backend-rank tie-break.
+	scoreFP16GPUPreferredHeadroom = 5
 	// scoreFP16GPUPreferred keeps fp16 the preferred build when the variant's
 	// best host path is a recommended GPU backend. fp16 is the deliberate size
 	// lever for GPU hosts: half the download of fp32 and numerically equivalent
@@ -59,7 +62,7 @@ const (
 	// assumes a regional fp16 slice always has a global fp16 sibling (true in
 	// shipped catalog data), so the term cannot promote a wrong-region slice past
 	// every global variant.
-	scoreFP16GPUPreferred = benchmarkMaxScore + 5
+	scoreFP16GPUPreferred = benchmarkMaxScore + scoreFP16GPUPreferredHeadroom
 	// scoreRAMConstrainedFit rewards an int8 variant on a memory-constrained
 	// host, where the quantized build is the one that fits.
 	scoreRAMConstrainedFit = 25
@@ -399,8 +402,13 @@ func evaluateVariant(catalogID string, v *classifier.CatalogVariant, in *Input, 
 	// Keep fp16 the preferred build when its recommended backend on this host is
 	// a GPU, so a faster CPU benchmark on the fp32 sibling cannot flip the pick
 	// away from the deliberate GPU size lever (fp16 is half the download and
-	// numerically equivalent here). See scoreFP16GPUPreferred.
-	if gpuRecommended && v.Precision == precisionFP16 {
+	// numerically equivalent here). See scoreFP16GPUPreferred. Scoped to x86: the
+	// benchmark flip this counteracts arises only from the x86 CPU benchmark rows,
+	// and CapOpenVINOGPU is not architecture-gated (hwprofile emits it from the
+	// device probe alone), so requiring the x86 capability keeps the lever off any
+	// non-x86 host, where its calibration has not been validated.
+	if gpuRecommended && v.Precision == precisionFP16 &&
+		slices.Contains(in.Capabilities, hwprofile.CapX86_64) {
 		score += scoreFP16GPUPreferred
 		reasons = append(reasons, Reason{Code: ReasonPrecisionFP16GPUPreferred})
 	}

--- a/internal/classifier/recommend/recommend.go
+++ b/internal/classifier/recommend/recommend.go
@@ -48,6 +48,18 @@ const (
 	// scoreFP16Native rewards an fp16 variant on a host with native
 	// half-precision SIMD.
 	scoreFP16Native = 15
+	// scoreFP16GPUPreferred keeps fp16 the preferred build when the variant's
+	// best host path is a recommended GPU backend. fp16 is the deliberate size
+	// lever for GPU hosts: half the download of fp32 and numerically equivalent
+	// for this use, and running on the GPU frees the CPU for the audio pipeline,
+	// so a CPU latency benchmark must not flip the pick to fp32. The value is
+	// derived from benchmarkMaxScore, the largest advantage the latency term can
+	// ever hand a sibling, plus a small headroom so fp16 wins outright instead of
+	// leaning on the backend-rank tie-break. Like scoreRegionGlobalFallback, this
+	// assumes a regional fp16 slice always has a global fp16 sibling (true in
+	// shipped catalog data), so the term cannot promote a wrong-region slice past
+	// every global variant.
+	scoreFP16GPUPreferred = benchmarkMaxScore + 5
 	// scoreRAMConstrainedFit rewards an int8 variant on a memory-constrained
 	// host, where the quantized build is the one that fits.
 	scoreRAMConstrainedFit = 25
@@ -84,6 +96,9 @@ const (
 	// ReasonPrecisionFP16Native marks an fp16 variant matched to native
 	// half-precision SIMD.
 	ReasonPrecisionFP16Native = "precision.fp16_native"
+	// ReasonPrecisionFP16GPUPreferred marks an fp16 variant kept preferred
+	// because its recommended backend on this host runs on a GPU.
+	ReasonPrecisionFP16GPUPreferred = "precision.fp16_gpu_preferred"
 	// ReasonRAMConstrainedFit marks an int8 variant matched to a low-RAM host.
 	ReasonRAMConstrainedFit = "ram.constrained_fit"
 	// ReasonVariantLegacy marks a superseded build.
@@ -126,6 +141,12 @@ const (
 
 	archAMD64 = "amd64"
 
+	// backendCUDA and backendTensorRT are GPU backend tokens named here so
+	// backendPreference and gpuBackendTokens share one definition rather than
+	// repeating raw strings. The other backend tokens come from hwprofile.
+	backendCUDA     = "cuda"
+	backendTensorRT = "tensorrt"
+
 	precisionFP16 = "fp16"
 	precisionINT8 = "int8"
 
@@ -137,8 +158,8 @@ const (
 // order for completeness; no BirdNET-Go build emits those host tokens yet, so
 // in practice the decision is among the OpenVINO and ONNX Runtime backends.
 var backendPreference = []string{
-	"cuda",
-	"tensorrt",
+	backendCUDA,
+	backendTensorRT,
 	hwprofile.CapOpenVINOGPU,
 	hwprofile.CapOpenVINOCPU,
 	hwprofile.CapONNXRuntimeCPU,
@@ -150,6 +171,18 @@ var backendPreference = []string{
 // var only because len of a slice is not a compile-time constant; it is never
 // reassigned.
 var backendRankUnavailable = len(backendPreference)
+
+// gpuBackendTokens are the backend tokens that execute inference on a GPU
+// rather than the host CPU. Used to gate scoreFP16GPUPreferred, which keeps
+// fp16 preferred only when the variant's recommended path is one of these.
+// Keep this the GPU subset of backendPreference above: a new GPU backend added
+// there must be added here too, or the fp16 size lever will not fire for it.
+var gpuBackendTokens = []string{backendCUDA, backendTensorRT, hwprofile.CapOpenVINOGPU}
+
+// isGPUBackend reports whether a backend token executes inference on a GPU.
+func isGPUBackend(backend string) bool {
+	return slices.Contains(gpuBackendTokens, backend)
+}
 
 // Reason is a structured, renderable explanation for a scoring decision or a
 // hard-filter failure. Args carry the values the frontend interpolates into the
@@ -329,6 +362,9 @@ func evaluateVariant(catalogID string, v *classifier.CatalogVariant, in *Input, 
 	// Backend term. Scores the variant on the best host-available backend and
 	// records the rank used to break score ties.
 	backendRank := backendRankUnavailable
+	// gpuRecommended is set when the variant's Recommended backend on this host
+	// runs on a GPU, gating the fp16 size-lever modifier below.
+	gpuRecommended := false
 	if term, missing := backendTerm(v, in.Capabilities); missing {
 		if !backendMissing {
 			blockers = append(blockers, Reason{Code: BlockerBackendMissing, Args: joinArg("required", backendKeys(v.Backends))})
@@ -337,6 +373,7 @@ func evaluateVariant(catalogID string, v *classifier.CatalogVariant, in *Input, 
 		score += term.score
 		reasons = append(reasons, Reason{Code: term.code, Args: map[string]string{"backend": term.backend}})
 		backendRank = preferenceRank(term.backend)
+		gpuRecommended = term.code == ReasonBackendRecommended && isGPUBackend(term.backend)
 	}
 
 	// Region term. A regional slice matching the host's resolved region is the
@@ -358,6 +395,14 @@ func evaluateVariant(catalogID string, v *classifier.CatalogVariant, in *Input, 
 	if slices.Contains(in.Capabilities, hwprofile.CapFP16Native) && v.Precision == precisionFP16 {
 		score += scoreFP16Native
 		reasons = append(reasons, Reason{Code: ReasonPrecisionFP16Native})
+	}
+	// Keep fp16 the preferred build when its recommended backend on this host is
+	// a GPU, so a faster CPU benchmark on the fp32 sibling cannot flip the pick
+	// away from the deliberate GPU size lever (fp16 is half the download and
+	// numerically equivalent here). See scoreFP16GPUPreferred.
+	if gpuRecommended && v.Precision == precisionFP16 {
+		score += scoreFP16GPUPreferred
+		reasons = append(reasons, Reason{Code: ReasonPrecisionFP16GPUPreferred})
 	}
 	if slices.Contains(in.Capabilities, hwprofile.CapLowRAM) && v.Precision == precisionINT8 {
 		score += scoreRAMConstrainedFit
@@ -483,7 +528,7 @@ func comparableLatency(v *classifier.CatalogVariant, in *Input) (latency int, ok
 	found := false
 	for i := range v.Benchmarks {
 		b := &v.Benchmarks[i]
-		if b.Device != in.DeviceClass || b.LatencyMs <= 0 || !slices.Contains(in.Capabilities, b.Backend) {
+		if !deviceMatches(b.Device, in.DeviceClass) || b.LatencyMs <= 0 || !slices.Contains(in.Capabilities, b.Backend) {
 			continue
 		}
 		if !found || b.LatencyMs < best {
@@ -492,6 +537,19 @@ func comparableLatency(v *classifier.CatalogVariant, in *Input) (latency int, ok
 		}
 	}
 	return best, found
+}
+
+// deviceMatches reports whether a benchmark's Device identifier applies to the
+// host's device class. ARM classes name exact benchmark devices (rpi5-a76,
+// rpi4b-a72), so they match by equality. The generic x86 class covers any
+// x86-* benchmark device, because amd64 hosts are not binned into specific CPU
+// models the way Pi board tiers are; the trailing hyphen keeps a token like
+// "x8600" from matching.
+func deviceMatches(benchDevice, deviceClass string) bool {
+	if deviceClass == deviceClassX86 {
+		return benchDevice == deviceClassX86 || strings.HasPrefix(benchDevice, deviceClassX86+"-")
+	}
+	return benchDevice == deviceClass
 }
 
 // scaleBenchmark maps a latency to a score in [0, benchmarkMaxScore], fastest

--- a/internal/classifier/recommend/recommend_test.go
+++ b/internal/classifier/recommend/recommend_test.go
@@ -303,6 +303,47 @@ func TestRank_GPUFP16PreferredOverFasterCPUFP32(t *testing.T) {
 	}
 }
 
+func TestRank_FP16GPULeverIsX86Only(t *testing.T) {
+	t.Parallel()
+
+	// A hypothetical non-x86 host that still reports a recommended GPU backend
+	// (CapOpenVINOGPU is not architecture-gated in hwprofile, so this is possible
+	// in principle). The fp16 GPU size lever must NOT fire there: the x86
+	// CPU-vs-iGPU benchmark flip it counteracts cannot arise off x86, and its
+	// calibration is unvalidated on other architectures.
+	backend := map[string]classifier.BackendSupport{
+		hwprofile.CapOpenVINOGPU: {Supported: true, Recommended: true},
+	}
+	entry := classifier.CatalogEntry{
+		ID: "fp16-gpu",
+		Variants: []classifier.CatalogVariant{
+			{ID: "fp16", Precision: "fp16", Backends: backend},
+			{ID: "fp32", Precision: "fp32", Backends: backend},
+		},
+	}
+	arm := Rank(&Input{
+		Capabilities: []string{hwprofile.CapAArch64, hwprofile.CapOpenVINOGPU},
+		DeviceClass:  deviceClassRPi5,
+		Entries:      []classifier.CatalogEntry{entry},
+	})
+	armFP16, ok := variantRec(arm, "fp16-gpu", "fp16")
+	require.True(t, ok)
+	assert.False(t, hasReason(&armFP16, ReasonPrecisionFP16GPUPreferred),
+		"the fp16 GPU lever must not fire on a non-x86 host")
+
+	// Sanity: the same entry on an x86 host with a recommended GPU DOES get the
+	// lever, so this is not vacuously passing because the lever is dead everywhere.
+	x86 := Rank(&Input{
+		Capabilities: []string{hwprofile.CapX86_64, hwprofile.CapOpenVINOGPU},
+		DeviceClass:  deviceClassX86,
+		Entries:      []classifier.CatalogEntry{entry},
+	})
+	x86FP16, ok := variantRec(x86, "fp16-gpu", "fp16")
+	require.True(t, ok)
+	assert.True(t, hasReason(&x86FP16, ReasonPrecisionFP16GPUPreferred),
+		"the fp16 GPU lever fires on an x86 host with a recommended GPU backend")
+}
+
 func TestRank_Blockers(t *testing.T) {
 	t.Parallel()
 

--- a/internal/classifier/recommend/recommend_test.go
+++ b/internal/classifier/recommend/recommend_test.go
@@ -170,6 +170,139 @@ func TestRank_HardwareMatrix(t *testing.T) {
 	}
 }
 
+func TestDeviceMatches(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		benchDevice string
+		deviceClass string
+		want        bool
+	}{
+		{"x86-i7-1260P", deviceClassX86, true},
+		{deviceClassX86, deviceClassX86, true},
+		{"x86-n100", deviceClassX86, true},
+		{"x8600", deviceClassX86, false}, // no separating hyphen: not an x86 device
+		{deviceClassRPi5, deviceClassRPi5, true},
+		{deviceClassRPi5, deviceClassRPi4, false},
+		{deviceClassRPi5, deviceClassX86, false},
+		{"x86-i7-1260P", deviceClassRPi5, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.benchDevice+"/"+tt.deviceClass, func(t *testing.T) {
+			t.Parallel()
+			assert.Equalf(t, tt.want, deviceMatches(tt.benchDevice, tt.deviceClass),
+				"deviceMatches(%q, %q)", tt.benchDevice, tt.deviceClass)
+		})
+	}
+}
+
+func TestRank_X86BenchmarkPrefixMatch(t *testing.T) {
+	t.Parallel()
+
+	// Two variants on the same recommended CPU backend so their scores tie, with
+	// x86-i7-1260P benchmark rows the amd64 host must now consume via the x86
+	// device-class prefix match. Before the fix these rows were ignored on x86 and
+	// the tie fell through to size/id; now the faster measured one must win.
+	backend := map[string]classifier.BackendSupport{hwprofile.CapONNXRuntimeCPU: {Supported: true, Recommended: true}}
+	// IDs are chosen so the lexical id tie-break (ascending) would pick the
+	// SLOWER variant: if the x86 rows were not consumed the two scores tie and
+	// "a-slow" would win, so asserting "z-fast" wins makes the winner assertion
+	// itself catch a regression of the prefix match, not just the reason assertion.
+	entry := classifier.CatalogEntry{
+		ID: "x86-bench",
+		Variants: []classifier.CatalogVariant{
+			{ID: "z-fast", Backends: backend, Benchmarks: []classifier.Benchmark{{Device: "x86-i7-1260P", Backend: hwprofile.CapONNXRuntimeCPU, LatencyMs: 50}}},
+			{ID: "a-slow", Backends: backend, Benchmarks: []classifier.Benchmark{{Device: "x86-i7-1260P", Backend: hwprofile.CapONNXRuntimeCPU, LatencyMs: 150}}},
+		},
+	}
+	recs := Rank(&Input{
+		Capabilities: []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU},
+		DeviceClass:  deviceClassX86,
+		Entries:      []classifier.CatalogEntry{entry},
+	})
+	assert.Equal(t, "z-fast", recommendedVariant(recs, "x86-bench"), "faster x86 benchmark wins after prefix match, beating the lexical id tie-break")
+	fastRec, ok := variantRec(recs, "x86-bench", "z-fast")
+	require.True(t, ok)
+	assert.True(t, hasReason(&fastRec, ReasonBenchmarkMeasured), "x86 benchmark row is consumed on an amd64 host")
+}
+
+func TestRank_GPUFP16PreferredOverFasterCPUFP32(t *testing.T) {
+	t.Parallel()
+
+	// Uses the real birdnet-v3.0 entry so the assertion tracks the shipped
+	// benchmark rows: fp32 measures 70 ms on CPU, fp16 81 ms on the iGPU, so the
+	// raw latency term favors fp32 on a GPU host. The size lever must keep fp16.
+	v3 := realEntry(t, "birdnet-v3.0")
+
+	tests := []struct {
+		name            string
+		caps            []string
+		resolvedRegion  string
+		wantRecommended string
+		// wantFP16Lever is the variant expected to carry the fp16 GPU-preferred
+		// reason, or "" when no variant should.
+		wantFP16Lever string
+	}{
+		{
+			name:            "igpu keeps fp16 over faster cpu fp32",
+			caps:            []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU, hwprofile.CapOpenVINOCPU, hwprofile.CapOpenVINOGPU},
+			wantRecommended: "fp16",
+			wantFP16Lever:   "fp16",
+		},
+		{
+			// No GPU backend reachable: fp16's recommended path is not a GPU, so the
+			// lever stays inert and the faster fp32 CPU build is the correct pick.
+			name:            "no gpu falls back to fp32",
+			caps:            []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU, hwprofile.CapOpenVINOCPU},
+			wantRecommended: "fp32",
+			wantFP16Lever:   "",
+		},
+		{
+			// The lever applies at the regional level too: with nordic resolved,
+			// fp16@nordic must stay ahead of the faster-on-CPU fp32@nordic.
+			name:            "igpu keeps fp16 regional slice",
+			caps:            []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU, hwprofile.CapOpenVINOCPU, hwprofile.CapOpenVINOGPU},
+			resolvedRegion:  "nordic",
+			wantRecommended: "fp16@nordic",
+			wantFP16Lever:   "fp16@nordic",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			recs := Rank(&Input{
+				Capabilities:   tt.caps,
+				TotalRAMBytes:  ramHigh,
+				DeviceClass:    deviceClassX86,
+				ResolvedRegion: tt.resolvedRegion,
+				Entries:        []classifier.CatalogEntry{v3},
+			})
+			assert.Equalf(t, tt.wantRecommended, recommendedVariant(recs, "birdnet-v3.0"), "recommended variant")
+
+			// The fp32 sibling must carry a measured benchmark, proving the x86 rows
+			// are actually consumed; otherwise the test could pass vacuously if the
+			// prefix match regressed.
+			fp32ID := "fp32"
+			if tt.resolvedRegion != "" {
+				fp32ID = "fp32@" + tt.resolvedRegion
+			}
+			fp32Rec, ok := variantRec(recs, "birdnet-v3.0", fp32ID)
+			require.Truef(t, ok, "variant %s present", fp32ID)
+			assert.Truef(t, hasReason(&fp32Rec, ReasonBenchmarkMeasured), "%s consumes the x86 benchmark row", fp32ID)
+
+			if tt.wantFP16Lever != "" {
+				leverRec, ok := variantRec(recs, "birdnet-v3.0", tt.wantFP16Lever)
+				require.Truef(t, ok, "variant %s present", tt.wantFP16Lever)
+				assert.Truef(t, hasReason(&leverRec, ReasonPrecisionFP16GPUPreferred), "%s carries the fp16 GPU-preferred reason", tt.wantFP16Lever)
+			} else {
+				fp16Rec, ok := variantRec(recs, "birdnet-v3.0", "fp16")
+				require.True(t, ok)
+				assert.False(t, hasReason(&fp16Rec, ReasonPrecisionFP16GPUPreferred), "lever must not fire without a recommended GPU path")
+			}
+		})
+	}
+}
+
 func TestRank_Blockers(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

The model recommender maps amd64 hosts to device class `x86`, but the catalog benchmark rows name a specific CPU `x86-i7-1260P`, and `comparableLatency` did a strict device-string equality check. So x86 benchmark rows were never consumed on amd64 hosts and the latency term stayed inert there (ARM matched exactly and already worked). This adds a `deviceMatches` helper that prefix-matches `x86-*` for the `x86` class while keeping exact match for the ARM classes, and uses it in `comparableLatency`. ARM ranking is byte-identical.

## The fp16-vs-fp32 policy

Consuming those rows on their own would flip the recommended `birdnet-v3.0` variant from fp16 to fp32 on an Intel iGPU host, because fp32 benchmarks faster on the CPU (70 ms) than fp16 on the iGPU (81 ms). That contradicts the design intent that fp16 is the GPU size lever (279 MB vs 557 MB fp32) and that running on the iGPU frees the CPU for the audio pipeline. This adds a deterministic `scoreFP16GPUPreferred` term that keeps fp16 preferred when its recommended backend on the host is a GPU. It is gated so it never fires for fp32, for a Supported-only (not Recommended) GPU backend, or for a blocked GPU path, and it is inert on ARM (no ARM host emits a GPU backend token). New reason code `precision.fp16_gpu_preferred`; the frontend already falls back to the raw code for an unmapped reason, and a localized string will follow in the frontend gallery change.

Verified against the shipped catalog data: the existing hardware-matrix expectations still hold (amd64 onnx-only and openvino-cpu recommend fp32; amd64 Intel iGPU recommends fp16, now held by the lever rather than by an inert benchmark term).

## Also folded in (same package, low risk)

- Generator: replace the hand-rolled `stringSliceLit` with `fmt.Sprintf("%#v", ...)` (byte-identical generated output, verified by `go generate` + a clean drift diff) and name the `regionalPerFam` factor as `expectedRegions * variantsPerRegion`.
- Generator consistency test: derive the regional families from the catalog itself (so a future third regional family is covered automatically) and assert Precision, SpeciesCount, Arch, and Excludes against the manifest, not only the checksum, size, region, and RAM floor.

## Tests

New table tests: `TestDeviceMatches`, `TestRank_X86BenchmarkPrefixMatch` (asserts the x86 rows are actually consumed), and `TestRank_GPUFP16PreferredOverFasterCPUFP32` (iGPU keeps fp16, no-GPU falls back to fp32, and the regional slice keeps fp16@nordic). The recommend package is at 98.9% coverage with every changed function at 100%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved model recommendations by detecting supported GPU backends and favoring FP16 variants when appropriate.
  * Expanded benchmark matching for generic x86 devices while preserving precise ARM device matching.
  * Improved recommendations across regional model variants and fallback scenarios.
* **Quality**
  * Added validation to ensure model catalogs consistently report precision, architecture, species counts, variants, and excluded requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->