### PR TITLE
feat(models): automatic HuggingFace mirror failover for model downloads

### DIFF
--- a/internal/analysis/birdnet_service.go
+++ b/internal/analysis/birdnet_service.go
@@ -145,6 +145,21 @@ func (a *BirdNETAnalyzer) initModelManager(bn *classifier.Orchestrator) {
 	}
 
 	a.modelManager = classifier.NewModelManager(modelsDir, bn, a.settings)
+
+	// Inject the HuggingFace endpoint resolver so model downloads fail over from
+	// a blocked canonical host (e.g. behind the Great Firewall) to the mirror.
+	// It persists the working host under the config directory so the preference
+	// survives a restart; an unresolved config dir keeps failover in memory only.
+	// Construction reads at most one small local file and does no network I/O, so
+	// it is safe here on the startup path.
+	configDir, err := conf.ResolveConfigDir()
+	if err != nil {
+		log.Warn("could not resolve config directory; HuggingFace mirror failover will not persist across restarts",
+			logger.String("service", birdNETAnalyzerName),
+			logger.Error(err))
+	}
+	a.modelManager.SetEndpointResolver(conf.NewHFEndpointResolver(configDir))
+
 	a.modelManager.ScanInstalled()
 
 	log.Info("model manager initialized",

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -72,6 +72,27 @@ type ModelManager struct {
 	// atomic pointer makes concurrent set and notify safe (the setter is
 	// exported, so a caller could re-register a callback while loads/unloads run).
 	topologyChangedCb atomic.Pointer[func()]
+
+	// endpointResolver, when set, orders the HuggingFace endpoint chain per file
+	// and remembers the host that worked, so downloads fail over from a blocked
+	// canonical host to the mirror. It is injected at startup; a nil resolver
+	// preserves the single-endpoint behavior, so callers that never inject one
+	// keep downloading from exactly one host. The atomic pointer makes the
+	// exported setter safe against concurrent installs.
+	endpointResolver atomic.Pointer[EndpointResolver]
+}
+
+// EndpointResolver orders the HuggingFace endpoint chain to try for a download
+// and records the host that served it, enabling automatic mirror failover.
+// *conf.HFEndpointResolver implements it; the interface keeps this package
+// decoupled from that concrete type and lets tests drive the failover loop.
+type EndpointResolver interface {
+	// OrderedEndpoints returns the base URLs to try, most-preferred first, for
+	// the given settings override.
+	OrderedEndpoints(configured string) []string
+	// NoteWorking records the endpoint that just served a request so later calls
+	// prefer it.
+	NoteWorking(endpoint string)
 }
 
 // InstalledModel represents a model that has been downloaded and is available.
@@ -1501,19 +1522,21 @@ func (mm *ModelManager) downloadVariantFiles(ctx context.Context, entry *Catalog
 		return nil, "", "", "", pfErr
 	}
 
-	// Resolve the HuggingFace host once per install so every file in the same
-	// install comes from the same mirror. Skipped when baseURL is set, because
-	// that path bypasses repo construction entirely.
-	var endpoint string
+	// Resolve the endpoint override once per install, for logging and for the
+	// per-file failover chain. Skipped when baseURL is set, because that path
+	// bypasses repo construction entirely.
+	var configured string
 	if baseURL == "" {
-		endpoint = mm.huggingFaceEndpoint()
-		// A non-default host is worth a log line: it can come from the
+		configured = mm.configuredHuggingFaceEndpoint()
+		// A non-default primary host is worth a log line: it can come from the
 		// HF_ENDPOINT environment variable, which the settings UI cannot show,
-		// so this is the only record of where the files actually came from.
-		if endpoint != conf.DefaultHuggingFaceEndpoint {
+		// so this is the only record of where the files actually came from. The
+		// automatic mirror fallback is not "non-default" and is logged per file
+		// only when it actually engages (see downloadModelFile).
+		if primary := mm.huggingFaceEndpoint(); primary != conf.DefaultHuggingFaceEndpoint {
 			log.Info("Downloading model files from a non-default HuggingFace host",
 				logger.String("catalog_id", entry.ID),
-				logger.String("endpoint", endpoint))
+				logger.String("endpoint", primary))
 		}
 	}
 
@@ -1538,17 +1561,11 @@ func (mm *ModelManager) downloadVariantFiles(ctx context.Context, entry *Catalog
 			continue
 		}
 
-		// Build download URL. Per-file HuggingFaceRepo overrides the entry-level repo,
-		// allowing companion files (e.g., geomodel) to live in a separate repository.
-		var url string
-		if baseURL != "" {
-			url = baseURL + "/" + f.RemotePath
-		} else {
-			repo := entry.HuggingFaceRepo
-			if f.HuggingFaceRepo != "" {
-				repo = f.HuggingFaceRepo
-			}
-			url = buildHuggingFaceURL(endpoint, repo, f.RemotePath)
+		// Per-file HuggingFaceRepo overrides the entry-level repo, allowing
+		// companion files (e.g., geomodel) to live in a separate repository.
+		repo := entry.HuggingFaceRepo
+		if f.HuggingFaceRepo != "" {
+			repo = f.HuggingFaceRepo
 		}
 
 		fileIndex++
@@ -1564,10 +1581,18 @@ func (mm *ModelManager) downloadVariantFiles(ctx context.Context, entry *Catalog
 		}
 		mm.mu.Unlock()
 
-		if dlErr := mm.downloadFile(ctx, entry.ID, url, destPath, f.SHA256, completedBytes); dlErr != nil {
+		var dlErr error
+		if baseURL != "" {
+			// Explicit base URL (test injection): no repo construction, no failover.
+			dlErr = mm.downloadFile(ctx, entry.ID, baseURL+"/"+f.RemotePath, destPath, f.SHA256, completedBytes)
+		} else {
+			dlErr = mm.downloadModelFile(ctx, entry.ID, repo, f.RemotePath, destPath, f.SHA256, completedBytes, configured)
+		}
+		if dlErr != nil {
 			log.Error("Failed to download file",
 				logger.String("catalog_id", entry.ID),
-				logger.String("url", url),
+				logger.String("repo", repo),
+				logger.String("remote_path", f.RemotePath),
 				logger.Error(dlErr))
 			mm.markFailed(entry.ID, dlErr, progress)
 			if cleanupOnFailure {
@@ -1945,6 +1970,66 @@ var downloadHTTPClient = &http.Client{
 	Timeout: 30 * time.Minute,
 }
 
+// endpointAttemptError wraps a download failure with whether it warrants trying
+// the next endpoint in the chain. A reachability failure (unreachable host,
+// reset, timeout) or a gateway status (502/503/504) is retryable; a definite
+// response such as 404, a checksum mismatch, or a local filesystem error is
+// not, because failing over would only mask a real error. downloadFile returns
+// this for its network failure sites; every other failure is a plain error,
+// which shouldFailover treats as non-retryable.
+type endpointAttemptError struct {
+	retryable bool
+	err       error
+}
+
+func (e *endpointAttemptError) Error() string { return e.err.Error() }
+func (e *endpointAttemptError) Unwrap() error { return e.err }
+
+// shouldFailover reports whether err came from a reachability failure that a
+// different endpoint might not have.
+func shouldFailover(err error) bool {
+	var ae *endpointAttemptError
+	return errors.As(err, &ae) && ae.retryable
+}
+
+// downloadModelFile downloads one catalog file, trying each endpoint in the
+// resolver's ordered chain in turn. It fails over to the next endpoint only on
+// a reachability failure (never on a definite HTTP status such as 404), and on
+// success records the working endpoint so later files in the same install skip
+// a blocked host. The per-file SHA256 in downloadFile makes a host switch safe:
+// the file is verified against the manifest checksum whichever host served it.
+//
+// The endpoint chain is resolved per file, not once per install, so a file that
+// established the mirror as sticky lets every subsequent file start there
+// instead of re-paying the blocked host's connect timeout.
+func (mm *ModelManager) downloadModelFile(ctx context.Context, catalogID, repo, remotePath, destPath, expectedSHA256 string, completedBytes int64, configured string) error {
+	endpoints := mm.orderedDownloadEndpoints(configured)
+	for i, endpoint := range endpoints {
+		url := buildHuggingFaceURL(endpoint, repo, remotePath)
+		err := mm.downloadFile(ctx, catalogID, url, destPath, expectedSHA256, completedBytes)
+		if err == nil {
+			mm.noteWorkingEndpoint(endpoint)
+			return nil
+		}
+		// Surface the error (no failover) on the last endpoint or when the
+		// failure is not a reachability problem another host could avoid.
+		if i == len(endpoints)-1 || !shouldFailover(err) {
+			return err
+		}
+		GetLogger().Warn("HuggingFace host unreachable, trying next endpoint",
+			logger.String("catalog_id", catalogID),
+			logger.String("failed_endpoint", endpoint),
+			logger.String("next_endpoint", endpoints[i+1]),
+			logger.Error(err))
+	}
+	// orderedDownloadEndpoints always returns at least one endpoint, so the loop
+	// returns before here; this only guards a future empty-chain regression.
+	return errors.Newf("no HuggingFace endpoint available for %s", repo).
+		Component("classifier.model_manager").
+		Category(errors.CategoryValidation).
+		Build()
+}
+
 // downloadFile downloads a file from url to destPath, verifying the SHA256
 // checksum. The catalogID is used to update shared download state for SSE
 // polling. completedBytes is the cumulative size of previously downloaded
@@ -1991,21 +2076,33 @@ func (mm *ModelManager) downloadFile(ctx context.Context, catalogID, url, destPa
 	}
 	resp, err := downloadHTTPClient.Do(req)
 	if err != nil {
-		return errors.Newf("HTTP request failed for %s: %v", url, err).
-			Component("classifier.model_manager").
-			Category(errors.CategoryNetwork).
-			Context("url", url).
-			Build()
+		// A transport failure (unreachable host, reset, timeout) is retryable on
+		// the next endpoint; a cancelled context is not (IsUnreachable handles the
+		// distinction).
+		return &endpointAttemptError{
+			retryable: conf.IsUnreachable(err),
+			err: errors.Newf("HTTP request failed for %s: %v", url, err).
+				Component("classifier.model_manager").
+				Category(errors.CategoryNetwork).
+				Context("url", url).
+				Build(),
+		}
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return errors.Newf("HTTP %d for %s", resp.StatusCode, url).
-			Component("classifier.model_manager").
-			Category(errors.CategoryNetwork).
-			Context("url", url).
-			Context("status", fmt.Sprintf("%d", resp.StatusCode)).
-			Build()
+		// A gateway status (502/503/504) means the origin is down and a mirror
+		// may still serve the file, so it is retryable; any other status (404,
+		// 403, 500, ...) means the host answered and failover would mask it.
+		return &endpointAttemptError{
+			retryable: conf.IsGatewayStatus(resp.StatusCode),
+			err: errors.Newf("HTTP %d for %s", resp.StatusCode, url).
+				Component("classifier.model_manager").
+				Category(errors.CategoryNetwork).
+				Context("url", url).
+				Context("status", fmt.Sprintf("%d", resp.StatusCode)).
+				Build(),
+		}
 	}
 
 	var hasher hash.Hash
@@ -2050,11 +2147,16 @@ func (mm *ModelManager) downloadFile(ctx context.Context, catalogID, url, destPa
 			break
 		}
 		if readErr != nil {
-			return errors.Newf("read error downloading %s: %v", url, readErr).
-				Component("classifier.model_manager").
-				Category(errors.CategoryNetwork).
-				Context("url", url).
-				Build()
+			// A connection dropped mid-stream (a common Great-Firewall symptom) is
+			// retryable on the next endpoint.
+			return &endpointAttemptError{
+				retryable: conf.IsUnreachable(readErr),
+				err: errors.Newf("read error downloading %s: %v", url, readErr).
+					Component("classifier.model_manager").
+					Category(errors.CategoryNetwork).
+					Context("url", url).
+					Build(),
+			}
 		}
 	}
 
@@ -2095,21 +2197,62 @@ func (mm *ModelManager) downloadFile(ctx context.Context, catalogID, url, destPa
 }
 
 // buildHuggingFaceURL constructs the download URL for a file in a HuggingFace
-// repo. The endpoint is the resolved host (see huggingFaceEndpoint) and must
-// not end in a slash.
+// repo. The endpoint is one host from the resolved download chain (see
+// orderedDownloadEndpoints / downloadModelFile) and must not end in a slash.
 func buildHuggingFaceURL(endpoint, repo, filePath string) string {
 	return endpoint + "/" + repo + "/resolve/main/" + filePath
 }
 
-// huggingFaceEndpoint resolves the HuggingFace host for this fetch. It reads
-// the live settings on every call rather than caching, so a mirror configured
-// through the UI takes effect without a restart.
+// huggingFaceEndpoint resolves the single primary HuggingFace host from the
+// current settings override. Downloads themselves use the failover chain
+// (orderedDownloadEndpoints); this is used for the non-default-host log line
+// and as the unit-tested seam for settings/HF_ENDPOINT resolution and
+// credential redaction. It reads the live settings on every call rather than
+// caching, so a mirror configured through the UI takes effect without a restart.
 func (mm *ModelManager) huggingFaceEndpoint() string {
-	var configured string
-	if current := conf.CurrentOrFallback(mm.settings); current != nil {
-		configured = current.BirdNET.HuggingFaceEndpoint
+	return conf.ResolveHuggingFaceEndpoint(mm.configuredHuggingFaceEndpoint())
+}
+
+// SetEndpointResolver injects the HuggingFace endpoint resolver used for mirror
+// failover. It is wired once at startup; passing nil disables failover and
+// restores single-endpoint downloads.
+func (mm *ModelManager) SetEndpointResolver(r EndpointResolver) {
+	if r == nil {
+		mm.endpointResolver.Store(nil)
+		return
 	}
-	return conf.ResolveHuggingFaceEndpoint(configured)
+	mm.endpointResolver.Store(&r)
+}
+
+// configuredHuggingFaceEndpoint returns the raw endpoint override from settings
+// (settings field only; the HF_ENDPOINT fallback is applied by the conf
+// resolver). It is read live so a settings change hot-reloads on the next
+// install.
+func (mm *ModelManager) configuredHuggingFaceEndpoint() string {
+	if current := conf.CurrentOrFallback(mm.settings); current != nil {
+		return current.BirdNET.HuggingFaceEndpoint
+	}
+	return ""
+}
+
+// orderedDownloadEndpoints returns the endpoint chain to try for one file,
+// most-preferred first. With a resolver injected this is the failover chain
+// (canonical then mirror, sticky endpoint first); without one it is the single
+// resolved endpoint, preserving the pre-failover behavior exactly.
+func (mm *ModelManager) orderedDownloadEndpoints(configured string) []string {
+	if p := mm.endpointResolver.Load(); p != nil {
+		return (*p).OrderedEndpoints(configured)
+	}
+	return []string{conf.ResolveHuggingFaceEndpoint(configured)}
+}
+
+// noteWorkingEndpoint records the endpoint that just served a file, so the next
+// file in the same install and later installs start from it instead of
+// re-probing a blocked host. It is a no-op without a resolver.
+func (mm *ModelManager) noteWorkingEndpoint(endpoint string) {
+	if p := mm.endpointResolver.Load(); p != nil {
+		(*p).NoteWorking(endpoint)
+	}
 }
 
 // verifySHA256 checks whether the file at path matches the expected hex-encoded

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -2196,11 +2196,15 @@ func (mm *ModelManager) downloadFile(ctx context.Context, catalogID, url, destPa
 	return nil
 }
 
+// huggingFaceResolveMainPath is the HuggingFace file-resolve path segment for a
+// repository's main revision, sitting between the repo id and the file path.
+const huggingFaceResolveMainPath = "/resolve/main/"
+
 // buildHuggingFaceURL constructs the download URL for a file in a HuggingFace
 // repo. The endpoint is one host from the resolved download chain (see
 // orderedDownloadEndpoints / downloadModelFile) and must not end in a slash.
 func buildHuggingFaceURL(endpoint, repo, filePath string) string {
-	return endpoint + "/" + repo + "/resolve/main/" + filePath
+	return endpoint + "/" + repo + huggingFaceResolveMainPath + filePath
 }
 
 // huggingFaceEndpoint resolves the single primary HuggingFace host from the

--- a/internal/classifier/model_manager_failover_test.go
+++ b/internal/classifier/model_manager_failover_test.go
@@ -1,0 +1,200 @@
+package classifier
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeEndpointResolver drives the download failover loop with an explicit chain
+// and records which endpoints were reported working.
+type fakeEndpointResolver struct {
+	endpoints []string
+	mu        sync.Mutex
+	noted     []string
+}
+
+func (f *fakeEndpointResolver) OrderedEndpoints(string) []string { return f.endpoints }
+
+func (f *fakeEndpointResolver) NoteWorking(endpoint string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.noted = append(f.noted, endpoint)
+}
+
+func (f *fakeEndpointResolver) working() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return slices.Clone(f.noted)
+}
+
+// countingServer serves fixed content with a fixed status and counts requests.
+func countingServer(t *testing.T, status int, body []byte) (url string, hits *atomic.Int64) {
+	t.Helper()
+	hits = &atomic.Int64{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		if status != http.StatusOK {
+			w.WriteHeader(status)
+			return
+		}
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL, hits
+}
+
+// unreachableURL returns a URL whose server is already closed, so a connection
+// to it is refused (a transport-level failure).
+func unreachableURL(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+	return url
+}
+
+func newFailoverManager(t *testing.T, endpoints []string) (*ModelManager, *fakeEndpointResolver) {
+	t.Helper()
+	mm := NewModelManager(t.TempDir(), nil, nil)
+	mm.downloading["m"] = &DownloadState{CatalogID: "m", Status: StatusDownloading}
+	resolver := &fakeEndpointResolver{endpoints: endpoints}
+	mm.SetEndpointResolver(resolver)
+	return mm, resolver
+}
+
+func TestDownloadModelFile_FailsOverOnUnreachableHost(t *testing.T) {
+	t.Parallel()
+	body := []byte("model-bytes")
+	mirrorURL, mirrorHits := countingServer(t, http.StatusOK, body)
+	mm, resolver := newFailoverManager(t, []string{unreachableURL(t), mirrorURL})
+	dest := filepath.Join(t.TempDir(), "model.onnx")
+
+	err := mm.downloadModelFile(t.Context(), "m", "owner/repo", "model.onnx", dest, sha256Hex(body), 0, "")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), mirrorHits.Load(), "mirror should have served the file")
+	assert.Equal(t, []string{mirrorURL}, resolver.working(), "the mirror is recorded as the working endpoint")
+}
+
+func TestDownloadModelFile_FailsOverOnGatewayStatus(t *testing.T) {
+	t.Parallel()
+	body := []byte("model-bytes")
+	badURL, badHits := countingServer(t, http.StatusServiceUnavailable, nil)
+	mirrorURL, mirrorHits := countingServer(t, http.StatusOK, body)
+	mm, resolver := newFailoverManager(t, []string{badURL, mirrorURL})
+	dest := filepath.Join(t.TempDir(), "model.onnx")
+
+	err := mm.downloadModelFile(t.Context(), "m", "owner/repo", "model.onnx", dest, sha256Hex(body), 0, "")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), badHits.Load())
+	assert.Equal(t, int64(1), mirrorHits.Load())
+	assert.Equal(t, []string{mirrorURL}, resolver.working())
+}
+
+func TestDownloadModelFile_DoesNotFailOverOn404(t *testing.T) {
+	t.Parallel()
+	primaryURL, primaryHits := countingServer(t, http.StatusNotFound, nil)
+	mirrorURL, mirrorHits := countingServer(t, http.StatusOK, []byte("unused"))
+	mm, resolver := newFailoverManager(t, []string{primaryURL, mirrorURL})
+	dest := filepath.Join(t.TempDir(), "model.onnx")
+
+	err := mm.downloadModelFile(t.Context(), "m", "owner/repo", "model.onnx", dest, "", 0, "")
+	require.Error(t, err, "a 404 means the file is genuinely missing and must be surfaced")
+	assert.Equal(t, int64(1), primaryHits.Load())
+	assert.Equal(t, int64(0), mirrorHits.Load(), "a reachable 404 must NOT trigger a mirror hop")
+	assert.Empty(t, resolver.working())
+}
+
+func TestDownloadModelFile_DoesNotFailOverOnChecksumMismatch(t *testing.T) {
+	t.Parallel()
+	primaryURL, primaryHits := countingServer(t, http.StatusOK, []byte("corrupt"))
+	mirrorURL, mirrorHits := countingServer(t, http.StatusOK, []byte("also-unused"))
+	mm, resolver := newFailoverManager(t, []string{primaryURL, mirrorURL})
+	dest := filepath.Join(t.TempDir(), "model.onnx")
+
+	// Expect the checksum of the real (different) content, so the primary's body fails verification.
+	err := mm.downloadModelFile(t.Context(), "m", "owner/repo", "model.onnx", dest, sha256Hex([]byte("expected")), 0, "")
+	require.Error(t, err, "a corrupt file must be surfaced, not masked by a mirror hop")
+	assert.Equal(t, int64(1), primaryHits.Load())
+	assert.Equal(t, int64(0), mirrorHits.Load())
+	assert.Empty(t, resolver.working())
+}
+
+func TestDownloadModelFile_SucceedsOnFirstHost(t *testing.T) {
+	t.Parallel()
+	body := []byte("model-bytes")
+	primaryURL, primaryHits := countingServer(t, http.StatusOK, body)
+	mirrorURL, mirrorHits := countingServer(t, http.StatusOK, body)
+	mm, resolver := newFailoverManager(t, []string{primaryURL, mirrorURL})
+	dest := filepath.Join(t.TempDir(), "model.onnx")
+
+	err := mm.downloadModelFile(t.Context(), "m", "owner/repo", "model.onnx", dest, sha256Hex(body), 0, "")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), primaryHits.Load())
+	assert.Equal(t, int64(0), mirrorHits.Load(), "the mirror must not be contacted when the primary works")
+	assert.Equal(t, []string{primaryURL}, resolver.working())
+}
+
+func TestDownloadModelFile_AllHostsUnreachable(t *testing.T) {
+	t.Parallel()
+	mm, resolver := newFailoverManager(t, []string{unreachableURL(t), unreachableURL(t)})
+	dest := filepath.Join(t.TempDir(), "model.onnx")
+
+	err := mm.downloadModelFile(t.Context(), "m", "owner/repo", "model.onnx", dest, "", 0, "")
+	require.Error(t, err, "both hosts unreachable must produce a clear failure")
+	assert.Empty(t, resolver.working())
+}
+
+func TestDownloadModelFile_NilResolverUsesSingleEndpoint(t *testing.T) {
+	t.Parallel()
+	body := []byte("model-bytes")
+	// A settings override yields a single endpoint; with no resolver, that host
+	// is the only one tried and there is no failover.
+	primaryURL, primaryHits := countingServer(t, http.StatusOK, body)
+	mm := NewModelManager(t.TempDir(), nil, nil)
+	mm.downloading["m"] = &DownloadState{CatalogID: "m", Status: StatusDownloading}
+	dest := filepath.Join(t.TempDir(), "model.onnx")
+
+	err := mm.downloadModelFile(t.Context(), "m", "owner/repo", "model.onnx", dest, sha256Hex(body), 0, primaryURL)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), primaryHits.Load())
+}
+
+func TestDownloadModelFile_SingleEndpointMakesOneAttempt(t *testing.T) {
+	t.Parallel()
+	// With a nil resolver the chain has one element, so a failing host is tried
+	// exactly once: there is no second host to fail over to, even though 503 is
+	// otherwise a gateway status that would trigger failover on a 2-host chain.
+	badURL, badHits := countingServer(t, http.StatusServiceUnavailable, nil)
+	mm := NewModelManager(t.TempDir(), nil, nil)
+	mm.downloading["m"] = &DownloadState{CatalogID: "m", Status: StatusDownloading}
+	dest := filepath.Join(t.TempDir(), "model.onnx")
+
+	err := mm.downloadModelFile(t.Context(), "m", "owner/repo", "model.onnx", dest, "", 0, badURL)
+	require.Error(t, err)
+	assert.Equal(t, int64(1), badHits.Load(), "a single-element chain must make exactly one attempt")
+}
+
+func TestSetEndpointResolver_NilDisablesFailover(t *testing.T) {
+	t.Parallel()
+	// Clearing the resolver reverts to the single configured endpoint with no
+	// failover, matching the pre-feature behavior. The two placeholder endpoints
+	// must never be contacted once the resolver is nil.
+	body := []byte("model-bytes")
+	primaryURL, primaryHits := countingServer(t, http.StatusOK, body)
+	mm, resolver := newFailoverManager(t, []string{"http://placeholder-a.invalid", "http://placeholder-b.invalid"})
+	mm.SetEndpointResolver(nil) // untyped nil clears the resolver
+	dest := filepath.Join(t.TempDir(), "model.onnx")
+
+	err := mm.downloadModelFile(t.Context(), "m", "owner/repo", "model.onnx", dest, sha256Hex(body), 0, primaryURL)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), primaryHits.Load())
+	assert.Empty(t, resolver.working(), "a cleared resolver must not be consulted")
+}

--- a/internal/conf/huggingface_chain.go
+++ b/internal/conf/huggingface_chain.go
@@ -1,0 +1,263 @@
+// huggingface_chain.go adds automatic mirror failover on top of the single
+// endpoint resolved by huggingface.go.
+//
+// huggingface.co is unreachable from some networks (notably behind the Great
+// Firewall), where hf-mirror.com serves the same repositories. When no endpoint
+// override is configured, callers try the canonical host first and fail over to
+// the mirror on a network-level failure, so a fresh install works out of the box
+// without the user having to discover and set a mirror. An explicit HF_ENDPOINT
+// or settings override stays authoritative: it is the only endpoint tried, so a
+// deliberately chosen mirror is never second-guessed.
+//
+// Nothing here performs network I/O at construction time; the resolver only
+// reads a small local state file, so it is safe on the startup path of a host
+// with no route out.
+package conf
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+const (
+	// FallbackHuggingFaceMirror is the community mirror tried automatically after
+	// the canonical host when no endpoint override is configured. It proxies both
+	// the /api/ (commit lookup) and /resolve/ (file download) surfaces, so SHA
+	// pinning and file downloads both work through it. This is an additive
+	// default, not a host allowlist: an explicit override still wins and disables
+	// failover entirely.
+	FallbackHuggingFaceMirror = "https://hf-mirror.com"
+
+	// hfStickyRevalidateInterval is how long a working endpoint stays preferred
+	// before the chain re-probes from the top. It bounds how long the client
+	// stays pinned to the mirror after the canonical host recovers.
+	hfStickyRevalidateInterval = 30 * time.Minute
+
+	// remoteCatalogStateDir is the subdirectory of the config directory that
+	// holds remote-catalog state files. The sticky-endpoint file lives here; a
+	// later phase adds the remote catalog cache and its refresh state under the
+	// same directory.
+	remoteCatalogStateDir = "remote-catalog"
+
+	// hfEndpointStateFile records the last endpoint that worked. It is a
+	// dedicated file so a later remote-catalog refresh state can use its own
+	// file under remoteCatalogStateDir without either clobbering the other.
+	hfEndpointStateFile = "endpoint_state.json"
+)
+
+// ResolveHuggingFaceEndpointChain returns the ordered list of base URLs to try
+// for HuggingFace fetches, most-preferred first.
+//
+//   - A configured override (settings field, then HF_ENDPOINT) that validates is
+//     authoritative: the returned chain is exactly that one endpoint, so failover
+//     never retargets a deliberately chosen mirror.
+//   - With no override, the chain is the canonical host followed by the mirror,
+//     so a blocked canonical host fails over automatically.
+//   - An invalid override degrades to the default chain, matching
+//     ResolveHuggingFaceEndpoint. The warning is logged there, not here, to avoid
+//     logging the same rejection twice.
+//
+// Every element is normalized without a trailing slash, so callers can append
+// "/" + path. This never performs network I/O.
+func ResolveHuggingFaceEndpointChain(configured string) []string {
+	raw := strings.TrimSpace(configured)
+	if raw == "" {
+		raw = strings.TrimSpace(os.Getenv(HuggingFaceEndpointEnvVar))
+	}
+	if raw != "" {
+		if endpoint, err := normalizeHuggingFaceEndpoint(raw); err == nil {
+			return []string{endpoint}
+		}
+	}
+	return []string{DefaultHuggingFaceEndpoint, FallbackHuggingFaceMirror}
+}
+
+// IsUnreachable reports whether err, returned by an HTTP client's Do or by a
+// response-body read, means the host could not be reached, so a caller walking
+// an endpoint chain should fail over to the next endpoint.
+//
+// An HTTP client returns a non-nil error from Do only when no response was
+// obtained: a DNS failure, a refused or reset connection, a TLS error, an HTTP/2
+// GOAWAY, or a timeout. A completed response, including 404 or 500, comes back
+// with a nil error and its status in the response, so this function is never
+// used to classify a status code (see IsGatewayStatus for that). Because every
+// such error is a transport failure, this returns true for any non-nil error
+// with a single exception: context.Canceled, which means the caller deliberately
+// aborted (a cancelled install, not a blocked host) and must not trigger
+// failover. A deadline being exceeded is not excepted: a bounded timeout firing
+// is exactly the blocked-host signal that failover exists for.
+func IsUnreachable(err error) bool {
+	if err == nil {
+		return false
+	}
+	return !errors.Is(err, context.Canceled)
+}
+
+// IsGatewayStatus reports whether an HTTP status warrants failing over to the
+// next endpoint. 502, 503 and 504 mean the origin (not the requested file) is
+// unavailable, so a mirror may still serve the file. A 404 is deliberately not
+// included: it means the host is reachable and the file is genuinely absent,
+// which failover would only mask.
+func IsGatewayStatus(status int) bool {
+	switch status {
+	case http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
+// HFEndpointResolver orders the endpoint chain for each fetch and remembers the
+// endpoint that last worked, so once the canonical host is found to be blocked
+// the client goes straight to the mirror for subsequent files and later
+// installs instead of paying the connect timeout every time.
+//
+// The sticky endpoint is persisted so the preference survives a restart. All
+// methods are safe for concurrent use.
+type HFEndpointResolver struct {
+	mu        sync.Mutex
+	sticky    string
+	stickyAt  time.Time
+	now       func() time.Time
+	statePath string // empty disables persistence (in-memory only)
+}
+
+// hfEndpointState is the on-disk shape of the sticky endpoint.
+type hfEndpointState struct {
+	Endpoint  string    `json:"endpoint"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+// NewHFEndpointResolver builds a resolver whose sticky state persists under
+// configDir. An empty configDir keeps the sticky preference in memory only.
+// Construction reads at most one small local file and never touches the network,
+// so it is safe on the startup path.
+func NewHFEndpointResolver(configDir string) *HFEndpointResolver {
+	r := &HFEndpointResolver{now: time.Now}
+	if configDir != "" {
+		r.statePath = filepath.Join(configDir, remoteCatalogStateDir, hfEndpointStateFile)
+		r.load()
+	}
+	return r
+}
+
+// OrderedEndpoints returns the endpoint chain for configured, with the sticky
+// endpoint moved to the front when it is still a member of the chain and has
+// not gone stale. An explicit override yields a single-element chain, so sticky
+// ordering does not apply and no failover happens.
+func (r *HFEndpointResolver) OrderedEndpoints(configured string) []string {
+	chain := ResolveHuggingFaceEndpointChain(configured)
+	if len(chain) < 2 {
+		return chain
+	}
+
+	r.mu.Lock()
+	sticky, stickyAt := r.sticky, r.stickyAt
+	r.mu.Unlock()
+
+	if sticky == "" || r.now().Sub(stickyAt) >= hfStickyRevalidateInterval {
+		return chain
+	}
+	idx := slices.Index(chain, sticky)
+	if idx <= 0 {
+		// Sticky is not in the chain, or already at the front: nothing to reorder.
+		return chain
+	}
+	ordered := make([]string, 0, len(chain))
+	ordered = append(ordered, sticky)
+	for i, ep := range chain {
+		if i != idx {
+			ordered = append(ordered, ep)
+		}
+	}
+	return ordered
+}
+
+// NoteWorking records endpoint as the one that last served a request, so later
+// calls prefer it, and persists the preference best-effort.
+func (r *HFEndpointResolver) NoteWorking(endpoint string) {
+	if endpoint == "" {
+		return
+	}
+	r.mu.Lock()
+	changed := r.sticky != endpoint
+	r.sticky = endpoint
+	r.stickyAt = r.now()
+	state := hfEndpointState{Endpoint: r.sticky, UpdatedAt: r.stickyAt}
+	r.mu.Unlock()
+
+	// Persist only when the endpoint changed, to avoid rewriting the file on
+	// every downloaded file within one install.
+	if changed {
+		r.save(state)
+	}
+}
+
+// load reads the persisted sticky endpoint, ignoring any error: a missing or
+// unreadable file simply means no preference yet.
+func (r *HFEndpointResolver) load() {
+	data, err := os.ReadFile(r.statePath)
+	if err != nil {
+		return
+	}
+	var state hfEndpointState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return
+	}
+	// Only trust a persisted endpoint that still validates, so a stale or
+	// tampered file can never retarget downloads at an arbitrary host.
+	if normalized, err := normalizeHuggingFaceEndpoint(state.Endpoint); err == nil {
+		r.sticky = normalized
+		r.stickyAt = state.UpdatedAt
+	}
+}
+
+// save writes the sticky endpoint atomically, best-effort. A failure is logged
+// at debug level and otherwise ignored: losing the preference only costs one
+// extra connect attempt after a restart.
+func (r *HFEndpointResolver) save(state hfEndpointState) {
+	if r.statePath == "" {
+		return
+	}
+	dir := filepath.Dir(r.statePath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		GetLogger().Debug("could not create HuggingFace endpoint state directory",
+			logger.String("dir", dir), logger.Error(err))
+		return
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		return
+	}
+	tmp, err := os.CreateTemp(dir, hfEndpointStateFile+".*.tmp")
+	if err != nil {
+		GetLogger().Debug("could not create HuggingFace endpoint state temp file",
+			logger.String("dir", dir), logger.Error(err))
+		return
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return
+	}
+	if err := os.Rename(tmpPath, r.statePath); err != nil {
+		_ = os.Remove(tmpPath)
+		GetLogger().Debug("could not persist HuggingFace endpoint state",
+			logger.String("path", r.statePath), logger.Error(err))
+	}
+}

--- a/internal/conf/huggingface_chain.go
+++ b/internal/conf/huggingface_chain.go
@@ -43,6 +43,14 @@ const (
 	// stays pinned to the mirror after the canonical host recovers.
 	hfStickyRevalidateInterval = 30 * time.Minute
 
+	// stickyPersistCadence bounds how stale the persisted sticky freshness may
+	// get relative to actual use. NoteWorking persists on an endpoint change and
+	// otherwise at most once per cadence, so continued use of the same host keeps
+	// the on-disk UpdatedAt current without rewriting the file on every file in
+	// an install. It is well under hfStickyRevalidateInterval so a restart
+	// shortly after a successful download does not re-probe a blocked host.
+	stickyPersistCadence = 5 * time.Minute
+
 	// remoteCatalogStateDir is the subdirectory of the config directory that
 	// holds remote-catalog state files. The sticky-endpoint file lives here; a
 	// later phase adds the remote catalog cache and its refresh state under the
@@ -125,11 +133,12 @@ func IsGatewayStatus(status int) bool {
 // The sticky endpoint is persisted so the preference survives a restart. All
 // methods are safe for concurrent use.
 type HFEndpointResolver struct {
-	mu        sync.Mutex
-	sticky    string
-	stickyAt  time.Time
-	now       func() time.Time
-	statePath string // empty disables persistence (in-memory only)
+	mu          sync.Mutex
+	sticky      string
+	stickyAt    time.Time
+	lastSavedAt time.Time // when the sticky state was last persisted
+	now         func() time.Time
+	statePath   string // empty disables persistence (in-memory only)
 }
 
 // hfEndpointState is the on-disk shape of the sticky endpoint.
@@ -193,12 +202,21 @@ func (r *HFEndpointResolver) NoteWorking(endpoint string) {
 	changed := r.sticky != endpoint
 	r.sticky = endpoint
 	r.stickyAt = r.now()
+	// Persist on an endpoint change, and otherwise at most once per cadence, so
+	// continued success on the same host keeps the persisted freshness current.
+	// Persisting only on change would freeze the on-disk UpdatedAt at the first
+	// mirror success, so a restart more than the revalidate interval after that
+	// first success would re-probe the blocked canonical host even though the
+	// mirror was used seconds ago. Files within one install complete well inside
+	// the cadence, so this still writes at most once per install.
+	needSave := changed || r.stickyAt.Sub(r.lastSavedAt) >= stickyPersistCadence
+	if needSave {
+		r.lastSavedAt = r.stickyAt
+	}
 	state := hfEndpointState{Endpoint: r.sticky, UpdatedAt: r.stickyAt}
 	r.mu.Unlock()
 
-	// Persist only when the endpoint changed, to avoid rewriting the file on
-	// every downloaded file within one install.
-	if changed {
+	if needSave {
 		r.save(state)
 	}
 }
@@ -219,6 +237,7 @@ func (r *HFEndpointResolver) load() {
 	if normalized, err := normalizeHuggingFaceEndpoint(state.Endpoint); err == nil {
 		r.sticky = normalized
 		r.stickyAt = state.UpdatedAt
+		r.lastSavedAt = state.UpdatedAt
 	}
 }
 

--- a/internal/conf/huggingface_chain_test.go
+++ b/internal/conf/huggingface_chain_test.go
@@ -1,0 +1,206 @@
+package conf
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveHuggingFaceEndpointChain(t *testing.T) {
+	// Env-mutating: cannot run in parallel with other env users.
+	tests := []struct {
+		name       string
+		configured string
+		env        string
+		want       []string
+	}{
+		{
+			name: "no override yields canonical then mirror",
+			want: []string{DefaultHuggingFaceEndpoint, FallbackHuggingFaceMirror},
+		},
+		{
+			name:       "settings override is authoritative and single",
+			configured: "https://settings-mirror.example.com",
+			want:       []string{"https://settings-mirror.example.com"},
+		},
+		{
+			name: "env override is authoritative and single",
+			env:  "https://hf-mirror.com",
+			want: []string{"https://hf-mirror.com"},
+		},
+		{
+			name:       "settings override wins over env",
+			configured: "https://settings-mirror.example.com",
+			env:        "https://env-mirror.example.com",
+			want:       []string{"https://settings-mirror.example.com"},
+		},
+		{
+			name:       "invalid override degrades to the default chain",
+			configured: "not a url",
+			want:       []string{DefaultHuggingFaceEndpoint, FallbackHuggingFaceMirror},
+		},
+		{
+			name:       "override with credentials is rejected and degrades to the chain",
+			configured: "https://user:pw@mirror.example.com",
+			want:       []string{DefaultHuggingFaceEndpoint, FallbackHuggingFaceMirror},
+		},
+		{
+			name:       "trailing slash is trimmed on an override",
+			configured: "https://mirror.example.com/",
+			want:       []string{"https://mirror.example.com"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(HuggingFaceEndpointEnvVar, tt.env)
+			assert.Equal(t, tt.want, ResolveHuggingFaceEndpointChain(tt.configured))
+		})
+	}
+}
+
+func TestIsUnreachable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil is reachable", err: nil, want: false},
+		{name: "cancelled context does not fail over", err: context.Canceled, want: false},
+		{name: "wrapped cancelled context does not fail over", err: fmt.Errorf("dial: %w", context.Canceled), want: false},
+		{name: "deadline exceeded fails over", err: context.DeadlineExceeded, want: true},
+		{name: "dns error fails over", err: &net.DNSError{Err: "no such host", Name: "huggingface.co"}, want: true},
+		{name: "op error fails over", err: &net.OpError{Op: "dial", Err: fmt.Errorf("connection refused")}, want: true},
+		{name: "opaque transport error fails over", err: fmt.Errorf("http2: server sent GOAWAY"), want: true},
+		{name: "eof fails over", err: fmt.Errorf("unexpected EOF"), want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, IsUnreachable(tt.err))
+		})
+	}
+}
+
+func TestIsGatewayStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		status int
+		want   bool
+	}{
+		{status: 200, want: false},
+		{status: 404, want: false}, // reachable, file genuinely missing: must NOT fail over
+		{status: 403, want: false},
+		{status: 429, want: false},
+		{status: 500, want: false},
+		{status: 502, want: true},
+		{status: 503, want: true},
+		{status: 504, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("status-%d", tt.status), func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, IsGatewayStatus(tt.status))
+		})
+	}
+}
+
+func TestHFEndpointResolver_OrderedEndpoints_NoOverride(t *testing.T) {
+	t.Setenv(HuggingFaceEndpointEnvVar, "")
+
+	t.Run("top-first with no sticky", func(t *testing.T) {
+		r := NewHFEndpointResolver("")
+		assert.Equal(t, []string{DefaultHuggingFaceEndpoint, FallbackHuggingFaceMirror}, r.OrderedEndpoints(""))
+	})
+
+	t.Run("sticky mirror moves to the front within the interval", func(t *testing.T) {
+		base := time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC)
+		r := NewHFEndpointResolver("")
+		r.now = func() time.Time { return base }
+		r.NoteWorking(FallbackHuggingFaceMirror)
+		assert.Equal(t, []string{FallbackHuggingFaceMirror, DefaultHuggingFaceEndpoint}, r.OrderedEndpoints(""))
+	})
+
+	t.Run("stale sticky re-probes from the top", func(t *testing.T) {
+		base := time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC)
+		now := base
+		r := NewHFEndpointResolver("")
+		r.now = func() time.Time { return now }
+		r.NoteWorking(FallbackHuggingFaceMirror)
+		now = base.Add(hfStickyRevalidateInterval + time.Minute) // past the window
+		assert.Equal(t, []string{DefaultHuggingFaceEndpoint, FallbackHuggingFaceMirror}, r.OrderedEndpoints(""))
+	})
+}
+
+func TestHFEndpointResolver_OrderedEndpoints_ExplicitOverrideIgnoresSticky(t *testing.T) {
+	t.Setenv(HuggingFaceEndpointEnvVar, "")
+	base := time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC)
+	r := NewHFEndpointResolver("")
+	r.now = func() time.Time { return base }
+	// Even with a sticky mirror recorded, an explicit override is the only host.
+	r.NoteWorking(FallbackHuggingFaceMirror)
+	assert.Equal(t, []string{"https://settings-mirror.example.com"},
+		r.OrderedEndpoints("https://settings-mirror.example.com"))
+}
+
+func TestHFEndpointResolver_StickyPersistsAcrossRestart(t *testing.T) {
+	t.Setenv(HuggingFaceEndpointEnvVar, "")
+	dir := t.TempDir()
+
+	first := NewHFEndpointResolver(dir)
+	first.NoteWorking(FallbackHuggingFaceMirror)
+
+	// A fresh resolver over the same config dir loads the persisted preference.
+	second := NewHFEndpointResolver(dir)
+	assert.Equal(t, []string{FallbackHuggingFaceMirror, DefaultHuggingFaceEndpoint}, second.OrderedEndpoints(""))
+
+	// The state file lives under the remote-catalog subdir, not the config root.
+	_, err := os.Stat(filepath.Join(dir, remoteCatalogStateDir, hfEndpointStateFile))
+	require.NoError(t, err)
+}
+
+func TestHFEndpointResolver_EmptyConfigDirIsInMemoryOnly(t *testing.T) {
+	t.Setenv(HuggingFaceEndpointEnvVar, "")
+	r := NewHFEndpointResolver("")
+	r.NoteWorking(FallbackHuggingFaceMirror) // must not panic without a state path
+	assert.Equal(t, []string{FallbackHuggingFaceMirror, DefaultHuggingFaceEndpoint}, r.OrderedEndpoints(""))
+}
+
+func TestHFEndpointResolver_LoadValidatesPersistedEndpoint(t *testing.T) {
+	t.Setenv(HuggingFaceEndpointEnvVar, "")
+
+	// writeState persists a state file with a fresh timestamp, so staleness can
+	// never confound whether the endpoint was accepted on load.
+	writeState := func(t *testing.T, endpoint string) string {
+		t.Helper()
+		dir := t.TempDir()
+		stateDir := filepath.Join(dir, remoteCatalogStateDir)
+		require.NoError(t, os.MkdirAll(stateDir, 0o755))
+		state := fmt.Sprintf(`{"endpoint":%q,"updatedAt":%q}`, endpoint, time.Now().UTC().Format(time.RFC3339))
+		require.NoError(t, os.WriteFile(filepath.Join(stateDir, hfEndpointStateFile), []byte(state), 0o600))
+		return dir
+	}
+
+	// The assertions read r.sticky directly (white-box) so they discriminate
+	// acceptance from rejection: removing the validation in load() would flip
+	// the negative case and fail the test.
+	t.Run("credentialed endpoint is rejected on load", func(t *testing.T) {
+		r := NewHFEndpointResolver(writeState(t, "https://user:pw@evil.example.com"))
+		assert.Empty(t, r.sticky, "a credentialed persisted endpoint must not retarget downloads")
+	})
+
+	t.Run("valid persisted endpoint is loaded (positive control)", func(t *testing.T) {
+		r := NewHFEndpointResolver(writeState(t, FallbackHuggingFaceMirror))
+		assert.Equal(t, FallbackHuggingFaceMirror, r.sticky)
+	})
+}

--- a/internal/conf/huggingface_chain_test.go
+++ b/internal/conf/huggingface_chain_test.go
@@ -169,6 +169,37 @@ func TestHFEndpointResolver_StickyPersistsAcrossRestart(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestHFEndpointResolver_SameEndpointUseRefreshesPersistedFreshness(t *testing.T) {
+	t.Setenv(HuggingFaceEndpointEnvVar, "")
+	dir := t.TempDir()
+	base := time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC)
+
+	// First install fails over to the mirror and persists {mirror, base}.
+	r1 := NewHFEndpointResolver(dir)
+	r1.now = func() time.Time { return base }
+	r1.NoteWorking(FallbackHuggingFaceMirror)
+
+	// A later install keeps using the mirror (unchanged endpoint) past the
+	// persist cadence, so the persisted freshness is refreshed to that time.
+	laterUse := base.Add(25 * time.Minute) // > stickyPersistCadence
+	r1.now = func() time.Time { return laterUse }
+	r1.NoteWorking(FallbackHuggingFaceMirror)
+
+	// Restart shortly after that later use. The original {mirror, base} record
+	// would be stale by now (restart-base > revalidate interval) and re-probe,
+	// so the mirror staying preferred proves the same-endpoint use re-persisted
+	// freshness.
+	restart := laterUse.Add(10 * time.Minute)
+	require.Greater(t, restart.Sub(base), hfStickyRevalidateInterval,
+		"the first persisted record must be stale at restart for this test to prove the refresh")
+	require.Less(t, restart.Sub(laterUse), hfStickyRevalidateInterval,
+		"the refreshed record must still be fresh at restart")
+
+	r2 := NewHFEndpointResolver(dir)
+	r2.now = func() time.Time { return restart }
+	assert.Equal(t, []string{FallbackHuggingFaceMirror, DefaultHuggingFaceEndpoint}, r2.OrderedEndpoints(""))
+}
+
 func TestHFEndpointResolver_EmptyConfigDirIsInMemoryOnly(t *testing.T) {
 	t.Setenv(HuggingFaceEndpointEnvVar, "")
 	r := NewHFEndpointResolver("")


### PR DESCRIPTION
## What

Adds automatic failover to the hf-mirror.com HuggingFace mirror for model file downloads. When the canonical host (huggingface.co) is unreachable, notably behind the Great Firewall, a model install now transparently falls over to the community mirror, so a fresh install works out of the box without the user having to discover and set `HF_ENDPOINT`.

## Why

`HF_ENDPOINT` and the Download Source setting already let a user point downloads at a mirror manually, but an unconfigured user behind a blocked huggingface.co just gets a failed install with no hint. This makes the common case work automatically while keeping an explicit override authoritative.

## How

- New endpoint chain resolver in `internal/conf`: with no override the chain is `[huggingface.co, hf-mirror.com]`; an explicit `HF_ENDPOINT` or settings override yields a single-element chain (authoritative, no failover).
- Failover triggers only on a transport-level failure (unreachable host, connection reset, timeout, TLS error, HTTP/2 GOAWAY, mid-stream EOF) or a `502`/`503`/`504` gateway status. It never fails over on a completed HTTP response such as `404` (the file is genuinely missing) or on a checksum mismatch.
- A sticky last-working endpoint, persisted under the config dir, means the blocked-host connect timeout is paid at most once per install; later files in the same install and later installs start from the mirror that worked.
- Per-file SHA-256 verification (unchanged) makes a mid-install host switch safe: whichever host serves a file, it is verified against the manifest checksum.

## Offline-first

BirdNET-Go must work with no internet. Preserved and tested: the resolver does no network I/O at construction (the startup path stays network-free), a nil resolver reproduces the previous single-endpoint behavior exactly, and the model gallery still works with no network at all.

## Notes

- All users, not only those behind the Great Firewall, now get a `config/remote-catalog/endpoint_state.json` written on the first successful model download. It is additive and best-effort (a write failure is swallowed) and never affects which host serves a file when the canonical host is reachable.
- The mirror host is a hardcoded default constant, not user-controlled; it is only tried when the canonical host actually fails, and served bytes are SHA-256 verified.

## Testing

- New `internal/conf` tests: chain composition, `IsUnreachable`/`IsGatewayStatus` truth tables, sticky ordering with an injected clock, persistence across restart, and rejection of a tampered/credentialed state file (asserted white-box with a positive control).
- New `internal/classifier` failover tests: failover on transport failure and on 503; no failover on 404 or checksum mismatch (mirror never contacted); sticky endpoint recorded; both-hosts-down surfaces a clear error; single-element chain makes exactly one attempt; `SetEndpointResolver(nil)` reverts to single-endpoint.
- `golangci-lint` clean on the changed packages; `go test -race` green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic Hugging Face mirror failover for model downloads.
  - Downloads now retry unreachable services and gateway errors using alternate endpoints.
  - Successful endpoints are prioritized for future downloads.
  - Explicit endpoint settings continue to take precedence.
  - Endpoint preferences can persist across application restarts when storage is available.

- **Bug Fixes**
  - Prevented retries for definitive errors such as missing files, checksum mismatches, and filesystem failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->