### PR TITLE
fix(api): enforce CSRF token despite Sec-Fetch-Site (GHSA-9fhj-f35q-w532)

### DIFF
--- a/internal/api/middleware/csrf.go
+++ b/internal/api/middleware/csrf.go
@@ -14,8 +14,8 @@ import (
 // CSRF configuration constants used by both csrf.go and csrf_token.go.
 // These are unexported since they're only used within the middleware package.
 const (
-	// CSRFContextKey is the key used to store CSRF token in the context.
-	// This must match what spa.go expects when retrieving the token.
+	// CSRFContextKey is the key used to store the CSRF token in the Echo context.
+	// EnsureCSRFToken reads it to hand the token to the SPA via /api/v2/app/config.
 	CSRFContextKey = "csrf"
 
 	// csrfCookieName is the name of the CSRF cookie.
@@ -26,6 +26,13 @@ const (
 
 	// csrfTokenLength is the length of the generated CSRF token in bytes.
 	csrfTokenLength = 32
+
+	// secFetchSiteSameOrigin and secFetchSiteNone are the Sec-Fetch-Site header
+	// values that Echo v4.15 treats as already-safe, returning before it compares
+	// the CSRF token (GHSA-9fhj-f35q-w532). NewCSRF strips these values on
+	// non-skipped requests so Echo always validates the token.
+	secFetchSiteSameOrigin = "same-origin"
+	secFetchSiteNone       = "none"
 )
 
 // pprofBasePath is the URL prefix under which the api package mounts the Go
@@ -114,12 +121,11 @@ type CSRFConfig struct {
 	// Default is 1800 (30 minutes).
 	CookieMaxAge int
 
-	// SecureCookie sets the Secure flag on the initial CSRF cookie set by Echo's
-	// middleware. Set to true when the server is configured with TLS directly.
-	// For reverse-proxy deployments (TLS terminated upstream, TLSEnabled=false),
-	// CSRFCookieRefresh overwrites the cookie with the correct Secure flag via
-	// IsSecureRequest() on every successful response, so the initial value here
-	// is only relevant for the first request before CSRFCookieRefresh runs.
+	// SecureCookie sets the Secure flag on the CSRF cookie Echo's middleware sets.
+	// Set to true when the server terminates TLS directly. For reverse-proxy
+	// deployments that terminate TLS upstream (TLSEnabled=false), the cookie is
+	// not marked Secure; making that flag request-aware (via IsSecureRequest) is a
+	// separate, pre-existing improvement tracked outside this change.
 	SecureCookie bool
 }
 
@@ -195,39 +201,6 @@ func DefaultCSRFSkipper(c echo.Context) bool {
 	return false
 }
 
-// CSRFCookieRefresh returns a middleware that refreshes the CSRF cookie expiration
-// on every non-skipped API request. The skipper should match the one used by
-// NewCSRF to ensure consistent skip behavior. If nil, DefaultCSRFSkipper is used.
-//
-// Echo v4.15.0+ introduced Sec-Fetch-Site header checks that short-circuit the
-// CSRF middleware before it reaches the cookie-setting code. This means the
-// cookie's max-age is never extended during normal same-origin browsing, causing
-// it to expire after 30 minutes. This middleware fixes that by refreshing the
-// cookie independently of the token validation path.
-func CSRFCookieRefresh(skipper middleware.Skipper) echo.MiddlewareFunc {
-	if skipper == nil {
-		skipper = DefaultCSRFSkipper
-	}
-	return func(next echo.HandlerFunc) echo.HandlerFunc {
-		return func(c echo.Context) error {
-			if skipper(c) {
-				return next(c)
-			}
-
-			err := next(c)
-
-			// On success, refresh the CSRF cookie if one exists
-			if err == nil {
-				if cookie, cookieErr := c.Cookie(csrfCookieName); cookieErr == nil && cookie.Value != "" {
-					setCSRFCookie(c, cookie.Value)
-				}
-			}
-
-			return err
-		}
-	}
-}
-
 // NewCSRF creates a CSRF middleware with the given configuration.
 // If config is nil, sensible defaults are used that match the legacy implementation.
 func NewCSRF(config *CSRFConfig) echo.MiddlewareFunc {
@@ -261,7 +234,7 @@ func NewCSRF(config *CSRFConfig) echo.MiddlewareFunc {
 		cookieMaxAge = csrfCookieMaxAge
 	}
 
-	return middleware.CSRFWithConfig(middleware.CSRFConfig{
+	echoCSRF := middleware.CSRFWithConfig(middleware.CSRFConfig{
 		Skipper:        skipper,
 		TokenLength:    tokenLength,
 		TokenLookup:    tokenLookup,
@@ -282,4 +255,26 @@ func NewCSRF(config *CSRFConfig) echo.MiddlewareFunc {
 			return echo.NewHTTPError(http.StatusForbidden, "Invalid CSRF token")
 		},
 	})
+
+	// Defense in depth against GHSA-9fhj-f35q-w532. Echo v4.15's CSRF middleware
+	// treats a request as already safe, skipping token comparison entirely, when
+	// it carries Sec-Fetch-Site: same-origin or none. Browsers forbid scripts from
+	// setting Sec-Fetch-Site, but a non-browser client that already holds a session
+	// cookie can forge it and reach state-changing routes without a token. For
+	// requests the skipper does not exempt, strip those two values before Echo
+	// inspects them so Echo always falls through to token validation, then restore
+	// the header afterward so the request is left as received. same-site and
+	// cross-site are left intact, preserving Echo's explicit cross-site block.
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		guarded := echoCSRF(next)
+		return func(c echo.Context) error {
+			if !skipper(c) {
+				if secFetchSite := c.Request().Header.Get(echo.HeaderSecFetchSite); secFetchSite == secFetchSiteSameOrigin || secFetchSite == secFetchSiteNone {
+					c.Request().Header.Del(echo.HeaderSecFetchSite)
+					defer c.Request().Header.Set(echo.HeaderSecFetchSite, secFetchSite)
+				}
+			}
+			return guarded(c)
+		}
+	}
 }

--- a/internal/api/middleware/csrf_test.go
+++ b/internal/api/middleware/csrf_test.go
@@ -2,131 +2,15 @@ package middleware
 
 import (
 	"crypto/tls"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// newTestContextWithCookie creates an Echo context with a CSRF cookie pre-set.
-func newTestContextWithCookie(t *testing.T, method, path, cookieValue string) (echo.Context, *httptest.ResponseRecorder) {
-	t.Helper()
-	e := echo.New()
-	req := httptest.NewRequest(method, path, http.NoBody)
-	if cookieValue != "" {
-		req.AddCookie(&http.Cookie{Name: csrfCookieName, Value: cookieValue})
-	}
-	rec := httptest.NewRecorder()
-	return e.NewContext(req, rec), rec
-}
-
-func TestCSRFCookieRefresh_RefreshesCookieWhenPresent(t *testing.T) {
-	t.Parallel()
-
-	c, rec := newTestContextWithCookie(t, http.MethodGet, "/api/v2/detections/1", "test-token-value")
-
-	handler := CSRFCookieRefresh(nil)(func(c echo.Context) error {
-		return nil
-	})
-
-	err := handler(c)
-	require.NoError(t, err)
-
-	cookies := rec.Result().Cookies()
-	require.Len(t, cookies, 1, "expected exactly one Set-Cookie header")
-	assert.Equal(t, csrfCookieName, cookies[0].Name)
-	assert.Equal(t, "test-token-value", cookies[0].Value)
-	assert.Equal(t, csrfCookieMaxAge, cookies[0].MaxAge)
-}
-
-func TestCSRFCookieRefresh_NoCookiePresent(t *testing.T) {
-	t.Parallel()
-
-	c, rec := newTestContext(t, http.MethodGet, "/api/v2/detections/1")
-
-	handler := CSRFCookieRefresh(nil)(func(c echo.Context) error {
-		return nil
-	})
-
-	err := handler(c)
-	require.NoError(t, err)
-
-	cookies := rec.Result().Cookies()
-	assert.Empty(t, cookies, "should not set cookie when none exists")
-}
-
-func TestCSRFCookieRefresh_SkipsStaticAssets(t *testing.T) {
-	t.Parallel()
-
-	skippedPaths := []string{
-		"/assets/style.css",
-		"/ui/assets/app.js",
-		"/health",
-		"/api/v2/media/clip.mp3",
-		"/api/v2/spectrogram/123",
-		"/api/v2/audio/456",
-	}
-
-	for _, path := range skippedPaths {
-		t.Run(path, func(t *testing.T) {
-			t.Parallel()
-
-			c, rec := newTestContextWithCookie(t, http.MethodGet, path, "test-token")
-
-			handler := CSRFCookieRefresh(nil)(func(c echo.Context) error {
-				return nil
-			})
-
-			err := handler(c)
-			require.NoError(t, err)
-
-			cookies := rec.Result().Cookies()
-			assert.Empty(t, cookies, "skipped path %s should not refresh cookie", path)
-		})
-	}
-}
-
-func TestCSRFCookieRefresh_EmptyCookieValue(t *testing.T) {
-	t.Parallel()
-
-	// AddCookie with empty value directly since helper skips empty values
-	e := echo.New()
-	req := httptest.NewRequest(http.MethodGet, "/api/v2/detections/1", http.NoBody)
-	req.AddCookie(&http.Cookie{Name: csrfCookieName, Value: ""})
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-
-	handler := CSRFCookieRefresh(nil)(func(c echo.Context) error {
-		return nil
-	})
-
-	err := handler(c)
-	require.NoError(t, err)
-
-	cookies := rec.Result().Cookies()
-	assert.Empty(t, cookies, "should not refresh cookie with empty value")
-}
-
-func TestCSRFCookieRefresh_DoesNotRefreshOnError(t *testing.T) {
-	t.Parallel()
-
-	c, rec := newTestContextWithCookie(t, http.MethodPost, "/api/v2/detections/1/review", "test-token")
-
-	handlerErr := errors.New("handler failed")
-	handler := CSRFCookieRefresh(nil)(func(c echo.Context) error {
-		return handlerErr
-	})
-
-	err := handler(c)
-	require.ErrorIs(t, err, handlerErr)
-
-	cookies := rec.Result().Cookies()
-	assert.Empty(t, cookies, "should not refresh cookie on handler error")
-}
 
 func TestDefaultCSRFSkipper(t *testing.T) {
 	t.Parallel()
@@ -336,4 +220,182 @@ func TestIsTrustedRemote(t *testing.T) {
 			assert.Equal(t, tt.expected, isTrustedRemote(tt.remoteAddr))
 		})
 	}
+}
+
+// --- GHSA-9fhj-f35q-w532: Sec-Fetch-Site CSRF bypass ---------------------------
+
+// newCSRFTestServer builds an Echo server wired with the production NewCSRF
+// middleware plus representative routes, so tests can drive real requests
+// through the middleware and Echo's HTTP error handler.
+func newCSRFTestServer() *echo.Echo {
+	e := echo.New()
+	e.Use(NewCSRF(&CSRFConfig{}))
+
+	// Non-skipped state-changing route (any method).
+	e.Any("/api/v2/settings", func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+	// Non-skipped token-provider route (mirrors /api/v2/app/config).
+	e.GET("/api/v2/app/config", func(c echo.Context) error {
+		token, err := EnsureCSRFToken(c)
+		if err != nil {
+			return err
+		}
+		return c.String(http.StatusOK, token)
+	})
+	// Skipper-exempt route (login must work before a CSRF token exists).
+	e.POST("/api/v2/auth/login", func(c echo.Context) error {
+		return c.String(http.StatusOK, "login")
+	})
+	return e
+}
+
+// TestNewCSRF_SecFetchSiteBypassBlocked verifies that a state-changing request
+// without a CSRF token is rejected regardless of the Sec-Fetch-Site header.
+// Before the fix, Sec-Fetch-Site: same-origin or none caused Echo v4.15 to skip
+// token validation entirely, letting a non-browser client that forged the header
+// call CSRF-protected routes without a token (GHSA-9fhj-f35q-w532).
+func TestNewCSRF_SecFetchSiteBypassBlocked(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		secFetchSite string
+	}{
+		{"no Sec-Fetch-Site (control)", ""},
+		{"same-origin", "same-origin"},
+		{"none", "none"},
+		{"cross-site", "cross-site"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			e := newCSRFTestServer()
+			req := httptest.NewRequest(http.MethodPost, "/api/v2/settings", http.NoBody)
+			if tt.secFetchSite != "" {
+				req.Header.Set(echo.HeaderSecFetchSite, tt.secFetchSite)
+			}
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusForbidden, rec.Code,
+				"state-changing request without a token must be rejected for Sec-Fetch-Site=%q", tt.secFetchSite)
+		})
+	}
+}
+
+// TestNewCSRF_BypassBlockedAcrossMethods confirms the strip is method-agnostic:
+// every unsafe method is forced through token validation under a forged
+// Sec-Fetch-Site: same-origin, not just POST.
+func TestNewCSRF_BypassBlockedAcrossMethods(t *testing.T) {
+	t.Parallel()
+
+	for _, method := range []string{http.MethodPut, http.MethodPatch, http.MethodDelete} {
+		t.Run(method, func(t *testing.T) {
+			t.Parallel()
+
+			e := newCSRFTestServer()
+			req := httptest.NewRequest(method, "/api/v2/settings", http.NoBody)
+			req.Header.Set(echo.HeaderSecFetchSite, "same-origin")
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusForbidden, rec.Code,
+				"%s without a token must be rejected under Sec-Fetch-Site: same-origin", method)
+		})
+	}
+}
+
+// TestNewCSRF_MismatchedTokenRejected confirms a present-but-wrong token is
+// rejected, proving the token is actually compared against the cookie rather
+// than merely required to be present.
+func TestNewCSRF_MismatchedTokenRejected(t *testing.T) {
+	t.Parallel()
+
+	e := newCSRFTestServer()
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/settings", http.NoBody)
+	req.Header.Set(echo.HeaderSecFetchSite, "same-origin")
+	req.AddCookie(&http.Cookie{Name: csrfCookieName, Value: "cookie-token-value"})
+	req.Header.Set("X-CSRF-Token", "a-different-token")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code,
+		"a token not matching the cookie must be rejected")
+}
+
+// TestNewCSRF_LegitTokenFlow verifies the SPA flow still works: the config
+// endpoint mints a real (non-sentinel) token backed by a cookie, and a
+// subsequent state-changing request presenting that token succeeds even with
+// Sec-Fetch-Site: same-origin.
+func TestNewCSRF_LegitTokenFlow(t *testing.T) {
+	t.Parallel()
+
+	e := newCSRFTestServer()
+
+	// 1. Fetch the token as a browser would (same-origin GET).
+	getReq := httptest.NewRequest(http.MethodGet, "/api/v2/app/config", http.NoBody)
+	getReq.Header.Set(echo.HeaderSecFetchSite, "same-origin")
+	getRec := httptest.NewRecorder()
+	e.ServeHTTP(getRec, getReq)
+
+	require.Equal(t, http.StatusOK, getRec.Code)
+	token := getRec.Body.String()
+	require.NotEmpty(t, token)
+	require.NotEqual(t, middleware.CSRFUsingSecFetchSite, token,
+		"config endpoint must return a real token, not Echo's Sec-Fetch-Site sentinel")
+
+	var csrfCookie *http.Cookie
+	for _, ck := range getRec.Result().Cookies() {
+		if ck.Name == csrfCookieName {
+			csrfCookie = ck
+		}
+	}
+	require.NotNil(t, csrfCookie, "config endpoint must set a CSRF cookie")
+	require.Equal(t, token, csrfCookie.Value, "returned token must match the cookie value")
+
+	// 2. Use that token on a state-changing request (same-origin).
+	postReq := httptest.NewRequest(http.MethodPost, "/api/v2/settings", http.NoBody)
+	postReq.Header.Set(echo.HeaderSecFetchSite, "same-origin")
+	postReq.Header.Set("X-CSRF-Token", token)
+	postReq.AddCookie(csrfCookie)
+	postRec := httptest.NewRecorder()
+	e.ServeHTTP(postRec, postReq)
+
+	assert.Equal(t, http.StatusOK, postRec.Code, "valid token must be accepted")
+}
+
+// TestNewCSRF_SkippedRouteUnaffected verifies skipper-exempt routes still bypass
+// CSRF (login must work before a token exists), even with Sec-Fetch-Site set.
+func TestNewCSRF_SkippedRouteUnaffected(t *testing.T) {
+	t.Parallel()
+
+	e := newCSRFTestServer()
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/auth/login", http.NoBody)
+	req.Header.Set(echo.HeaderSecFetchSite, "same-origin")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code, "skipped login route must not require a CSRF token")
+}
+
+// TestEnsureCSRFToken_IgnoresSentinel verifies EnsureCSRFToken never returns
+// Echo's Sec-Fetch-Site sentinel as if it were a usable token; it mints a real
+// token and cookie instead (GHSA-9fhj-f35q-w532 defense in depth).
+func TestEnsureCSRFToken_IgnoresSentinel(t *testing.T) {
+	t.Parallel()
+
+	c, rec := newTestContext(t, http.MethodGet, "/api/v2/app/config")
+	c.Set(CSRFContextKey, middleware.CSRFUsingSecFetchSite)
+
+	token, err := EnsureCSRFToken(c)
+	require.NoError(t, err)
+	assert.NotEqual(t, middleware.CSRFUsingSecFetchSite, token)
+	assert.NotEmpty(t, token)
+
+	cookies := rec.Result().Cookies()
+	require.Len(t, cookies, 1, "should mint a fresh CSRF cookie")
+	assert.Equal(t, token, cookies[0].Value)
 }

--- a/internal/api/middleware/csrf_token.go
+++ b/internal/api/middleware/csrf_token.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
@@ -54,8 +55,12 @@ func GenerateCSRFToken() (string, error) {
 //  2. Use token from existing CSRF cookie
 //  3. Generate a new token and set the cookie
 func EnsureCSRFToken(ctx echo.Context) (string, error) {
-	// First, check if middleware already set a token
-	if token, ok := ctx.Get(CSRFContextKey).(string); ok && token != "" {
+	// First, check if middleware already set a real token. Echo v4.15 stores the
+	// sentinel middleware.CSRFUsingSecFetchSite in this key when it accepts a
+	// request via Sec-Fetch-Site without minting a token. NewCSRF strips that
+	// header so the sentinel should never reach here, but guard against handing it
+	// to the SPA as if it were a usable token (GHSA-9fhj-f35q-w532).
+	if token, ok := ctx.Get(CSRFContextKey).(string); ok && token != "" && token != middleware.CSRFUsingSecFetchSite {
 		return token, nil
 	}
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -455,15 +455,13 @@ func (s *Server) setupMiddleware() {
 	// CORS middleware
 	s.echo.Use(mw.NewCORS(securityConfig))
 
-	// CSRF protection middleware (uses centralized logger)
+	// CSRF protection middleware (uses centralized logger). NewCSRF neutralizes
+	// Echo v4.15's Sec-Fetch-Site short-circuit so every non-skipped state-changing
+	// request is token-validated, and Echo's token path refreshes the cookie's
+	// expiry on each request (GHSA-9fhj-f35q-w532).
 	s.echo.Use(mw.NewCSRF(&mw.CSRFConfig{
 		SecureCookie: s.config.TLSEnabled,
 	}))
-
-	// Refresh CSRF cookie expiration on every API request.
-	// Echo v4.15's Sec-Fetch-Site check short-circuits before the built-in
-	// cookie refresh code, so the cookie expires after 30 minutes without this.
-	s.echo.Use(mw.CSRFCookieRefresh(nil))
 
 	// Body limit middleware
 	s.echo.Use(mw.NewBodyLimit(s.config.BodyLimit))

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -577,9 +577,9 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	c.Group.Use(c.LoggingMiddleware())      // Use custom structured logging middleware
 	c.Group.Use(c.PrivateModeAuth)          // Gate all API endpoints behind auth when PrivateMode is enabled
 
-	// NOTE: CSRF token is provided by the /app/config endpoint using middleware.EnsureCSRFToken()
-	// which handles Echo v4.15.0's Sec-Fetch-Site optimization that may skip token generation
-	// for same-origin requests. Global CSRF middleware in server.go handles validation.
+	// NOTE: CSRF token is provided by the /app/config endpoint using middleware.EnsureCSRFToken().
+	// The global CSRF middleware in server.go strips Sec-Fetch-Site: same-origin/none so Echo
+	// always runs its token path and validates state-changing requests (GHSA-9fhj-f35q-w532).
 
 	// Initialize start time for uptime tracking
 	now := time.Now()

--- a/internal/api/v2/app/app.go
+++ b/internal/api/v2/app/app.go
@@ -140,9 +140,9 @@ func (c *Handler) GetAppConfig(ctx echo.Context) error {
 	ctx.Response().Header().Set("Pragma", "no-cache")
 	ctx.Response().Header().Set("Expires", "0")
 
-	// Ensure CSRF token is available, generating one if the middleware didn't.
-	// Echo v4.15.0's Sec-Fetch-Site optimization may skip token generation for
-	// same-origin requests, but this endpoint must always provide a token.
+	// Ensure a CSRF token is available for the SPA. The CSRF middleware forces
+	// Echo's token path (GHSA-9fhj-f35q-w532), so a real token is normally already
+	// in context; EnsureCSRFToken is the backstop that always returns one here.
 	csrfToken, err := middleware.EnsureCSRFToken(ctx)
 	if err != nil {
 		c.LogWarnIfEnabled("Failed to generate CSRF token", logger.Error(err))


### PR DESCRIPTION
## Summary

Echo v4.15's CSRF middleware treats `Sec-Fetch-Site: same-origin` or `none` as already-safe and returns before comparing the CSRF token, so a non-browser client that sets that header while holding a session cookie can call CSRF-protected routes without a token. Echo is already on the latest v4.15.4 and offers no configuration knob to force validation, so this neutralizes the short-circuit in `NewCSRF`: for requests the skipper does not exempt it strips a `same-origin`/`none` `Sec-Fetch-Site` value before Echo inspects it, so Echo always falls through to its token-validation path, then restores the header. `same-site` and `cross-site` are left intact, preserving Echo's explicit cross-site block.

`EnsureCSRFToken` now ignores Echo's `Sec-Fetch-Site` sentinel so the SPA is never handed the sentinel as if it were a usable token.

This also removes `CSRFCookieRefresh`. It re-set the cookie after the handler had already committed the response, which is a no-op in production. With the short-circuit neutralized, Echo's own token path refreshes the cookie's expiry before commit on every non-skipped request, so the workaround is no longer needed.

## Security

Addresses GHSA-9fhj-f35q-w532, reported by @sec-reex. The CSRF token check was skipped when `Sec-Fetch-Site` was `same-origin` or `none`. Severity is low: as the reporter notes, this is not a browser CSRF (browsers forbid scripts from setting `Sec-Fetch-Site`, and no browser-origin cross-site request was demonstrated); it is a defense-in-depth erosion for a non-browser client that can set the header while already holding a session cookie. Thanks to @sec-reex for the report.

## Test Plan

- [x] `go test -race ./internal/api/middleware/ ./internal/api/v2/app/... ./internal/api/`
- [x] `golangci-lint run ./internal/api/...` reports 0 issues
- [x] New regression tests: bypass blocked across all `Sec-Fetch-Site` values and unsafe methods (POST/PUT/PATCH/DELETE), the legitimate token round-trip under `same-origin`, the skipped-route exemption, a mismatched-token rejection, and the `EnsureCSRFToken` sentinel guard