### PR TITLE
test(models): harden model catalog and recommender test suites

### DIFF
--- a/internal/classifier/model_catalog_regional_test.go
+++ b/internal/classifier/model_catalog_regional_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tphakala/birdnet-go/internal/classifier/region"
+	"github.com/tphakala/birdnet-go/internal/hwprofile"
 )
 
 // regionalTilesPerFamily is how many region-sliced variants the generator emits
@@ -96,7 +97,7 @@ func TestEmbeddedCatalog_RegionalVariants(t *testing.T) {
 					assert.Containsf(t, v.Requirements.Excludes, "openvino-gpu-intel-gen12", "fp16 variant %q must exclude the Iris Xe gen12 miscompile", v.ID)
 				}
 				if strings.HasPrefix(v.ID, "int8-arm@") {
-					assert.Equalf(t, []string{"aarch64"}, v.Requirements.Arch, "int8-arm variant %q must require aarch64", v.ID)
+					assert.Equalf(t, []string{hwprofile.CapAArch64}, v.Requirements.Arch, "int8-arm variant %q must require aarch64", v.ID)
 				}
 			}
 			assert.Equalf(t, regionalTilesPerFamily, regional, "%s must expose %d regional tiles", entryID, regionalTilesPerFamily)

--- a/internal/classifier/model_catalog_selection_test.go
+++ b/internal/classifier/model_catalog_selection_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/classifier/recommend"
+	"github.com/tphakala/birdnet-go/internal/hwprofile"
 )
 
 // mib is one mebibyte, matching the recommender's MinRAMMB-to-bytes conversion.
@@ -78,7 +79,7 @@ func TestRecommend_RegionalTiles(t *testing.T) {
 			// region +100, backend.recommended +40, and low-ram+int8 ram.constrained_fit
 			// +25 = 165, versus no-dft-fp32's region +100 + backend.supported +10 = 110.
 			lowRAM := 300 * mib
-			gotPerch := recommendedVariantID(&perch, []string{"aarch64", "onnxruntime-cpu", "low-ram"}, lowRAM, slug)
+			gotPerch := recommendedVariantID(&perch, []string{hwprofile.CapAArch64, hwprofile.CapONNXRuntimeCPU, hwprofile.CapLowRAM}, lowRAM, slug)
 			assert.Equalf(t, "int8-arm@"+slug, gotPerch, "low-RAM aarch64 host in %q must get the regional int8-arm slice", slug)
 			assert.Equalf(t, "regional/"+slug+"/perch_v2_"+slug+"_int8_arm.onnx", modelRemotePath(t, &perch, gotPerch),
 				"recommended perch variant must own the manifest low-ram selection path")
@@ -87,7 +88,7 @@ func TestRecommend_RegionalTiles(t *testing.T) {
 			// slice (region.matched +100 + backend.recommended +40 = 140) over the
 			// region's fp16 slice (+100 + backend.supported +10 = 110) and over the
 			// global model (which loses the fallback bonus once a slice matches).
-			gotV30 := recommendedVariantID(&v30, []string{"x86-64", "onnxruntime-cpu"}, 8*1024*mib, slug)
+			gotV30 := recommendedVariantID(&v30, []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU}, 8*1024*mib, slug)
 			assert.Equalf(t, "fp32@"+slug, gotV30, "CPU host in %q must get the regional fp32 slice", slug)
 		})
 	}
@@ -96,7 +97,7 @@ func TestRecommend_RegionalTiles(t *testing.T) {
 	// the global variant wins on its fallback bonus.
 	t.Run("global-host-picks-global", func(t *testing.T) {
 		t.Parallel()
-		caps := []string{"x86-64", "onnxruntime-cpu"}
+		caps := []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU}
 		high := 8 * 1024 * mib
 
 		gotV30 := recommendedVariantID(&v30, caps, high, "")
@@ -125,13 +126,13 @@ func TestRecommend_V30GlobalSelection(t *testing.T) {
 		caps     []string
 		wantPath string // manifest selection value
 	}{
-		{"x86-64/onnxruntime", []string{"x86-64", "onnxruntime-cpu"}, "full/birdnet-v3.0-preview3.1-fp32-b1.onnx"},
-		{"x86-64/openvino-cpu", []string{"x86-64", "onnxruntime-cpu", "openvino-cpu"}, "full/birdnet-v3.0-preview3.1-fp32-b1.onnx"},
-		{"x86-64/openvino-gpu", []string{"x86-64", "onnxruntime-cpu", "openvino-cpu", "openvino-gpu"}, "full/birdnet-v3.0-preview3.1-fp16-b1.onnx"},
-		{"aarch64-a76/openvino", []string{"aarch64", "aarch64-a76", "onnxruntime-cpu", "openvino-cpu"}, "full/birdnet-v3.0-preview3.1-fp32-b1.onnx"},
-		{"aarch64/onnxruntime", []string{"aarch64", "onnxruntime-cpu"}, "full/birdnet-v3.0-preview3.1-fp32-b1.onnx"},
-		{"cuda", []string{"x86-64", "onnxruntime-cpu", "cuda"}, "full/birdnet-v3.0-preview3.1-fp16-b1.onnx"},
-		{"tensorrt", []string{"x86-64", "onnxruntime-cpu", "cuda", "tensorrt"}, "full/birdnet-v3.0-preview3.1-fp16-b1.onnx"},
+		{"x86-64/onnxruntime", []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU}, "full/birdnet-v3.0-preview3.1-fp32-b1.onnx"},
+		{"x86-64/openvino-cpu", []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU, hwprofile.CapOpenVINOCPU}, "full/birdnet-v3.0-preview3.1-fp32-b1.onnx"},
+		{"x86-64/openvino-gpu", []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU, hwprofile.CapOpenVINOCPU, hwprofile.CapOpenVINOGPU}, "full/birdnet-v3.0-preview3.1-fp16-b1.onnx"},
+		{"aarch64-a76/openvino", []string{hwprofile.CapAArch64, hwprofile.CapAArch64A76, hwprofile.CapONNXRuntimeCPU, hwprofile.CapOpenVINOCPU}, "full/birdnet-v3.0-preview3.1-fp32-b1.onnx"},
+		{"aarch64/onnxruntime", []string{hwprofile.CapAArch64, hwprofile.CapONNXRuntimeCPU}, "full/birdnet-v3.0-preview3.1-fp32-b1.onnx"},
+		{"cuda", []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU, "cuda"}, "full/birdnet-v3.0-preview3.1-fp16-b1.onnx"},
+		{"tensorrt", []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU, "cuda", "tensorrt"}, "full/birdnet-v3.0-preview3.1-fp16-b1.onnx"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/classifier/recommend/recommend_test.go
+++ b/internal/classifier/recommend/recommend_test.go
@@ -196,6 +196,33 @@ func TestDeviceMatches(t *testing.T) {
 	}
 }
 
+// TestIsGPUBackend pins the gpuBackendTokens membership that gates the fp16 GPU
+// size lever. The lever is otherwise exercised only through openvino-gpu, so
+// cuda and tensorrt membership is untested (no current build emits those
+// tokens); this direct table catches a future edit that drops one of the three
+// GPU tokens from the set, or adds a CPU token to it.
+func TestIsGPUBackend(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		backend string
+		want    bool
+	}{
+		{backendCUDA, true},
+		{backendTensorRT, true},
+		{hwprofile.CapOpenVINOGPU, true},
+		{hwprofile.CapONNXRuntimeCPU, false},
+		{hwprofile.CapOpenVINOCPU, false},
+		{hwprofile.CapTFLite, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.backend, func(t *testing.T) {
+			t.Parallel()
+			assert.Equalf(t, tt.want, isGPUBackend(tt.backend), "isGPUBackend(%q)", tt.backend)
+		})
+	}
+}
+
 func TestRank_X86BenchmarkPrefixMatch(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Test-only hardening of the model catalog and recommender suites that shipped with the recent BirdNET v3.0 / Perch v2 regional-model work. No production code changes.

## What this does

**New `TestIsGPUBackend`.** Adds a direct table test that pins the membership of `gpuBackendTokens` (`cuda`, `tensorrt`, `openvino-gpu`), the GPU subset that gates the fp16 size lever in the recommender. That lever was previously exercised only through `openvino-gpu`, so `cuda` and `tensorrt` membership was never tested (no current build emits those tokens, so it was latent). The table now fails directly if a GPU token is dropped from the set, or a CPU token is added to it.

**Capability tokens as constants.** Replaces hard-coded host-capability string literals in the catalog selection and regional tests (`x86-64`, `aarch64`, `aarch64-a76`, `onnxruntime-cpu`, `openvino-cpu`, `openvino-gpu`, `low-ram`) with the corresponding `hwprofile.Cap*` constants, so a capability-token rename fails to compile instead of silently drifting the tests. Tokens with no exported constant (`cuda`/`tensorrt`, precision strings, the per-generation Intel GPU prefix) are deliberately left as literals.

## Verification

- `go test -race ./internal/classifier/... ./internal/hwprofile/...` passes
- `golangci-lint run ./...` reports 0 issues
- `TestIsGPUBackend` runs all six subtests and gives 100% coverage of `isGPUBackend`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved validation of hardware capability detection across regional and global model recommendations.
  - Added coverage to confirm GPU backends are correctly recognized, while CPU-only and mobile inference options remain classified appropriately.
  - Standardized test coverage around supported ARM architecture and hardware capabilities for more reliable model selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->