### PR TITLE
fix(gallery): reachable in-flight action reason, region-picker a11y, and reuse follow-ups

### DIFF
--- a/frontend/src/lib/desktop/features/settings/components/ModelRegionSelector.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/ModelRegionSelector.svelte
@@ -17,6 +17,7 @@
   import { t, getLocale } from '$lib/i18n';
   import { fetchModelRegions, fetchRegionCoverageMap } from '$lib/utils/modelsApi';
   import { localizedCountryNames } from '$lib/utils/countryNames';
+  import { normalizeRegionMode } from '$lib/utils/variantSelection';
   import { loggers } from '$lib/utils/logger';
   import { birdnetSettings, settingsActions } from '$lib/stores/settings';
   import type { ModelRegionsResponse, RegionOption } from '$lib/types/models';
@@ -52,12 +53,9 @@
 
   onMount(load);
 
-  // '' and absent both mean automatic (mirrors the Go omitempty field).
-  function normalizeMode(value: string | undefined): string {
-    return value ? value : 'auto';
-  }
-
-  const selected = $derived(normalizeMode($birdnetSettings?.modelRegion));
+  // '' and absent both mean automatic (mirrors the Go omitempty field); see
+  // normalizeRegionMode.
+  const selected = $derived(normalizeRegionMode($birdnetSettings?.modelRegion));
   const regions = $derived<RegionOption[]>(data?.regions ?? []);
   const isPinnedSlug = $derived(selected !== 'auto' && selected !== 'global');
   const regionsVisible = $derived(showRegions || isPinnedSlug);

--- a/frontend/src/lib/desktop/features/settings/components/ModelVariantPicker.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/ModelVariantPicker.svelte
@@ -12,7 +12,7 @@
    * (a filtering stage is never called "all"), and a context line names the region
    * the middle stage scopes to, so the list is never a silently filtered subset.
    */
-  import { untrack } from 'svelte';
+  import { untrack, tick } from 'svelte';
   import type { CatalogVariant, VariantReason } from '$lib/types/models';
   import { t } from '$lib/i18n';
   import { formatBytes, formatNumber } from '$lib/utils/formatters';
@@ -74,6 +74,10 @@
   // toggles null between opens), so capturing the mount-time recommendation state
   // is intentional. untrack makes that explicit and avoids a reactive dependency.
   let disclosure = $state<Disclosure>(untrack(() => (hasRecommended ? 'collapsed' : 'region')));
+  // Bound to the root fieldset so a disclosure reveal can move keyboard focus into
+  // the newly shown tiles instead of letting it fall to <body> when the button
+  // unmounts (see revealNext).
+  let fieldsetEl: HTMLElement | undefined;
 
   // The 'region' stage: always-relevant options, plus every global (region-less)
   // build, plus the active region's tiles. Other regions are excluded unless one
@@ -87,11 +91,16 @@
     variants.filter(v => !inAlways(v) && !!v.region && v.region !== activeRegionSlug)
   );
 
+  // The always-relevant options as a set, computed once. $derived (not a plain
+  // const) because inAlways closes over reactive props. Reused by the collapsed
+  // stage and by the disclosure-step reveal counts below.
+  const alwaysVariants = $derived(variants.filter(inAlways));
+
   // The first (or only) group of tiles rendered for the current stage. In the
   // 'all' stage this is still the region-stage set; otherStageVariants render
   // after it under their own heading.
   const visibleVariants = $derived(
-    disclosure === 'collapsed' ? variants.filter(inAlways) : regionStageVariants
+    disclosure === 'collapsed' ? alwaysVariants : regionStageVariants
   );
 
   // The disclosure button for the current stage, or null when everything is shown.
@@ -104,7 +113,7 @@
     region?: string;
   }
   const disclosureStep = $derived.by<DisclosureStep | null>(() => {
-    const alwaysCount = variants.filter(inAlways).length;
+    const alwaysCount = alwaysVariants.length;
     if (disclosure === 'collapsed') {
       const allReveal = variants.length - alwaysCount;
       if (allReveal <= 0) return null;
@@ -151,6 +160,30 @@
   function blockedReasonText(variant: CatalogVariant): string {
     const blocker = variant.blockers?.[0];
     return blocker ? reasonText(blocker) : t('analysis.gallery.variants.incompatible');
+  }
+
+  // Advance to the next disclosure stage. When the stage that unmounts the
+  // disclosure button is reached ('all'), move keyboard focus to the first
+  // newly revealed tile, so focus does not fall to <body> when the button
+  // disappears. Snapshot the radio ids first, then diff after the reveal.
+  function revealNext(step: DisclosureStep) {
+    if (!fieldsetEl) {
+      disclosure = step.target;
+      return;
+    }
+    const radioSelector = 'input[type="radio"]';
+    const before = new Set(
+      Array.from(fieldsetEl.querySelectorAll<HTMLInputElement>(radioSelector)).map(el => el.id)
+    );
+    const unmounts = step.target === 'all';
+    disclosure = step.target;
+    if (!unmounts) return;
+    void tick().then(() => {
+      const revealed = Array.from(
+        fieldsetEl?.querySelectorAll<HTMLInputElement>(radioSelector) ?? []
+      );
+      revealed.find(el => !before.has(el.id))?.focus();
+    });
   }
 </script>
 
@@ -254,7 +287,7 @@
   </label>
 {/snippet}
 
-<fieldset class="border border-base-300 rounded-lg p-3">
+<fieldset bind:this={fieldsetEl} class="border border-base-300 rounded-lg p-3">
   <legend class="text-sm font-medium px-1">{t('analysis.gallery.variants.title')}</legend>
 
   <!-- Region context: name the region the list is scoped to, so a user always
@@ -277,12 +310,14 @@
     {/each}
 
     {#if disclosure === 'all' && otherStageVariants.length > 0}
-      <p class="text-xs font-medium text-base-content/60 mt-1">
-        {t('analysis.gallery.variants.otherRegions')}
-      </p>
-      {#each otherStageVariants as variant (variant.id)}
-        {@render variantTile(variant)}
-      {/each}
+      <div role="group" aria-labelledby="{idPrefix}-other-regions" class="flex flex-col gap-2 mt-1">
+        <p id="{idPrefix}-other-regions" class="text-xs font-medium text-base-content/60">
+          {t('analysis.gallery.variants.otherRegions')}
+        </p>
+        {#each otherStageVariants as variant (variant.id)}
+          {@render variantTile(variant)}
+        {/each}
+      </div>
     {/if}
   </div>
 
@@ -294,7 +329,7 @@
       type="button"
       class="btn btn-ghost btn-xs mt-2"
       aria-expanded="false"
-      onclick={() => (disclosure = disclosureStep.target)}
+      onclick={() => revealNext(disclosureStep)}
     >
       {disclosureStep.region
         ? t(disclosureStep.labelKey, { count: disclosureStep.count, region: disclosureStep.region })

--- a/frontend/src/lib/desktop/features/settings/components/ModelVariantPicker.test.ts
+++ b/frontend/src/lib/desktop/features/settings/components/ModelVariantPicker.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, fireEvent, cleanup } from '@testing-library/svelte';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/svelte';
 import ModelVariantPicker from './ModelVariantPicker.svelte';
 import type { CatalogVariant } from '$lib/types/models';
 
@@ -341,19 +341,23 @@ describe('ModelVariantPicker', () => {
         idPrefix: 'r1',
       },
     });
-    // Collapsed: only the recommended variant.
+    // Collapsed: only the recommended variant, and the "Other regions" heading is
+    // not shown yet (it belongs to the final stage only).
     expect(radios(container)).toHaveLength(1);
+    expect(container.textContent).not.toContain('analysis.gallery.variants.otherRegions');
     // A context line states which region is scoping the list.
     expect(container.textContent).toContain('analysis.gallery.variants.regionContext');
     // The first disclosure button is region-scoped, not "show all".
     expect(getByRole('button').textContent).toContain('analysis.gallery.variants.showRegion');
 
-    // Region stage: globals + the nordic tiles, but NOT iberia.
+    // Region stage: globals + the nordic tiles, but NOT iberia, and still no
+    // "Other regions" heading until the final stage.
     await fireEvent.click(getByRole('button'));
     expect(radioByValue(container, 'fp32')).not.toBeNull();
     expect(radioByValue(container, 'fp16@nordic')).not.toBeNull();
     expect(radioByValue(container, 'fp32@nordic')).not.toBeNull();
     expect(radioByValue(container, 'fp16@iberia')).toBeNull();
+    expect(container.textContent).not.toContain('analysis.gallery.variants.otherRegions');
 
     // The next button reveals every remaining region under an "Other regions"
     // heading, and only now is a button labeled to include all regions.
@@ -392,5 +396,49 @@ describe('ModelVariantPicker', () => {
       },
     });
     expect(container.textContent).toContain('analysis.gallery.variants.regionContextNone');
+  });
+
+  it('wraps the other-region tiles in a labelled group in the all stage', async () => {
+    const { container, getByRole } = render(ModelVariantPicker, {
+      props: {
+        variants: regionalVariants,
+        selectedVariantId: 'fp16',
+        onSelect: vi.fn(),
+        activeRegionSlug: 'nordic',
+        regionNames,
+        idPrefix: 'r5',
+      },
+    });
+    await fireEvent.click(getByRole('button')); // region stage
+    await fireEvent.click(getByRole('button')); // all stage
+    // The other-region tiles form a semantic group whose accessible name comes
+    // from the "Other regions" heading, so a screen reader announces the boundary.
+    const group = container.querySelector('[role="group"]');
+    expect(group).not.toBeNull();
+    expect(group?.getAttribute('aria-labelledby')).toBe('r5-other-regions');
+    const label = document.getElementById('r5-other-regions');
+    expect(label).not.toBeNull();
+    expect(label?.textContent).toContain('analysis.gallery.variants.otherRegions');
+  });
+
+  it('moves focus to the first newly revealed tile when the final stage unmounts the toggle', async () => {
+    const { container, getByRole } = render(ModelVariantPicker, {
+      props: {
+        variants: regionalVariants,
+        selectedVariantId: 'fp16',
+        onSelect: vi.fn(),
+        activeRegionSlug: 'nordic',
+        regionNames,
+        idPrefix: 'r6',
+      },
+    });
+    // collapsed -> region keeps the button mounted (focus stays); region -> all
+    // unmounts it, so focus is moved to the first tile that stage reveals (the
+    // first other-region tile, iberia) instead of falling to <body>.
+    await fireEvent.click(getByRole('button')); // region stage
+    await fireEvent.click(getByRole('button')); // all stage (button unmounts)
+    await waitFor(() =>
+      expect(document.activeElement).toBe(radioByValue(container, 'fp16@iberia'))
+    );
   });
 });

--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.gallery.test.ts
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.gallery.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, beforeAll, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/svelte';
 import type { CatalogEntry } from '$lib/types/models';
 
@@ -83,6 +83,7 @@ vi.mock('$lib/utils/api', async () => {
 import AnalysisSettingsPage from './AnalysisSettingsPage.svelte';
 import * as modelsApi from '$lib/utils/modelsApi';
 import { settingsStore } from '$lib/stores/settings';
+import { toastActions } from '$lib/stores/toast';
 
 // A network-shaped download failure (matches isNetworkDownloadError's real regex).
 const NETWORK_ERROR = 'HTTP request failed for https://huggingface.co/model: connection refused';
@@ -117,18 +118,22 @@ async function gotoAvailableTab(): Promise<void> {
 
 const installButtonName = /analysis\.gallery\.install.*Test Bird Model/;
 
+// jsdom does not implement <dialog> showModal/close; polyfill them once so the
+// license and remove dialogs' open/close paths do not throw. The prototype patch
+// is idempotent, so a single file-scope beforeAll covers both describe blocks.
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal = function showModal(this: HTMLDialogElement) {
+    this.open = true;
+  };
+  HTMLDialogElement.prototype.close = function close(this: HTMLDialogElement) {
+    this.open = false;
+  };
+});
+
 describe('AnalysisSettingsPage model gallery error handling', () => {
   beforeEach(() => {
     cleanup();
     vi.clearAllMocks();
-    // jsdom does not implement <dialog> showModal/close; polyfill so the license
-    // dialog open/close path does not throw (its content renders on licenseModel).
-    HTMLDialogElement.prototype.showModal = function showModal(this: HTMLDialogElement) {
-      this.open = true;
-    };
-    HTMLDialogElement.prototype.close = function close(this: HTMLDialogElement) {
-      this.open = false;
-    };
     vi.mocked(modelsApi.fetchCatalog).mockResolvedValue({ catalog: [birdEntry()] });
     vi.mocked(modelsApi.fetchInstalled).mockResolvedValue([]);
     vi.mocked(modelsApi.fetchModelRegions).mockRejectedValue(new Error('no regions in test'));
@@ -179,12 +184,6 @@ describe('AnalysisSettingsPage model gallery in-flight guard and region refetch'
   beforeEach(() => {
     cleanup();
     vi.clearAllMocks();
-    HTMLDialogElement.prototype.showModal = function showModal(this: HTMLDialogElement) {
-      this.open = true;
-    };
-    HTMLDialogElement.prototype.close = function close(this: HTMLDialogElement) {
-      this.open = false;
-    };
     // Reset the saved region so each test starts from the 'auto' baseline
     // (undefined modelRegion resolves to 'auto' in the page).
     settingsStore.update(s => ({
@@ -198,7 +197,7 @@ describe('AnalysisSettingsPage model gallery in-flight guard and region refetch'
     vi.mocked(modelsApi.fetchModelRegions).mockRejectedValue(new Error('no regions in test'));
   });
 
-  it('disables install on another card while a reinstall is in flight (shared in-flight guard)', async () => {
+  it('cross-disables another card while a reinstall is in flight, keeping the reason reachable', async () => {
     // One installed model (has a Reinstall control) and one available (has Install).
     vi.mocked(modelsApi.fetchCatalog).mockResolvedValue({
       catalog: [birdEntry({ id: 'inst', name: 'Installed Model', installed: true }), birdEntry()],
@@ -209,19 +208,47 @@ describe('AnalysisSettingsPage model gallery in-flight guard and region refetch'
     render(AnalysisSettingsPage);
     await fireEvent.click(await screen.findByRole('tab', { name: /analysis\.tabs\.models/ }));
 
-    // Start a reinstall from the installed sub-tab (the default gallery sub-tab).
+    // Positive control: before any action starts, the Available card's Install is
+    // enabled and carries no aria-disabled (so the assertions below prove a change).
+    await fireEvent.click(
+      await screen.findByRole('tab', { name: /analysis\.gallery\.tabs\.available/ })
+    );
+    const installBefore = await screen.findByRole('button', { name: installButtonName });
+    expect(installBefore).toBeEnabled();
+    expect(installBefore).not.toHaveAttribute('aria-disabled');
+
+    // Back to Installed and start a reinstall that never resolves.
+    await fireEvent.click(
+      await screen.findByRole('tab', { name: /analysis\.gallery\.tabs\.installed/ })
+    );
     await fireEvent.click(
       await screen.findByRole('button', {
         name: /analysis\.gallery\.reinstall.*Installed Model/,
       })
     );
 
-    // Switch to Available: the Install button must be disabled while the reinstall runs.
+    // On Available, Install is cross-disabled via aria-disabled (NOT native
+    // disabled, so it stays tab-focusable), points at the shared status line, and
+    // that live line explains why actions are paused.
     await fireEvent.click(
       await screen.findByRole('tab', { name: /analysis\.gallery\.tabs\.available/ })
     );
     const installBtn = await screen.findByRole('button', { name: installButtonName });
-    await waitFor(() => expect(installBtn).toBeDisabled());
+    await waitFor(() => expect(installBtn).toHaveAttribute('aria-disabled', 'true'));
+    expect(installBtn).toBeEnabled();
+    expect(installBtn).toHaveAttribute('aria-describedby', 'gallery-action-status');
+    const status = document.getElementById('gallery-action-status');
+    expect(status).not.toBeNull();
+    expect(status?.textContent).toContain('analysis.gallery.actionInProgress');
+
+    // Behavioral proof, not just the ARIA attributes: clicking the cross-disabled
+    // Install must NOT open the license dialog. If the onclick guard
+    // (e.preventDefault(); return) regressed to native-clickable, openLicenseDialog
+    // would fire and the accept-and-install button would appear.
+    await fireEvent.click(installBtn);
+    expect(
+      screen.queryByRole('button', { name: /analysis\.gallery\.license\.acceptAndInstall/ })
+    ).toBeNull();
   });
 
   it('re-fetches the catalog when the saved model region changes, but not on unrelated saves', async () => {
@@ -254,5 +281,44 @@ describe('AnalysisSettingsPage model gallery in-flight guard and region refetch'
     await Promise.resolve();
     await Promise.resolve();
     expect(modelsApi.fetchCatalog).toHaveBeenCalledTimes(2);
+
+    // Positive control: the region effect is still live after the unrelated save,
+    // so a further region change must trigger a third fetch (the no-op above did
+    // not tear the subscription down).
+    settingsStore.update(s => ({
+      ...s,
+      originalData: {
+        ...s.originalData,
+        birdnet: { ...s.originalData.birdnet, modelRegion: 'iberia' },
+      },
+    }));
+    await waitFor(() => expect(modelsApi.fetchCatalog).toHaveBeenCalledTimes(3));
+  });
+
+  it('shows a success toast after a model is removed', async () => {
+    vi.mocked(modelsApi.fetchCatalog).mockResolvedValue({
+      catalog: [birdEntry({ id: 'inst', name: 'Installed Model', installed: true })],
+    });
+    vi.mocked(modelsApi.uninstallModel).mockResolvedValue(undefined);
+
+    render(AnalysisSettingsPage);
+    // Installed is the default gallery sub-tab, so the card Remove is reachable directly.
+    await fireEvent.click(await screen.findByRole('tab', { name: /analysis\.tabs\.models/ }));
+    await fireEvent.click(
+      await screen.findByRole('button', { name: /analysis\.gallery\.remove.*Installed Model/ })
+    );
+
+    // Confirm in the dialog. Its Remove button carries no model-name suffix, so an
+    // exact-string name matches only it, not the card's aria-labelled button.
+    await fireEvent.click(screen.getByRole('button', { name: 'analysis.gallery.remove' }));
+
+    await waitFor(() => expect(modelsApi.uninstallModel).toHaveBeenCalledWith('inst'));
+    // The toast fires only after the post-remove catalog reload resolves, so wait
+    // for it rather than asserting synchronously on the uninstall call.
+    await waitFor(() =>
+      expect(toastActions.success).toHaveBeenCalledWith(
+        expect.stringContaining('analysis.gallery.removeSuccess')
+      )
+    );
   });
 });

--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
@@ -75,7 +75,11 @@
   import { buildAppUrl } from '$lib/utils/urlHelpers';
   import { toastActions } from '$lib/stores/toast';
   import { formatBytes, formatNumber } from '$lib/utils/formatters';
-  import { pickPreselectedVariant, translateReason } from '$lib/utils/variantSelection';
+  import {
+    pickPreselectedVariant,
+    translateReason,
+    normalizeRegionMode,
+  } from '$lib/utils/variantSelection';
   import { safeArrayAccess } from '$lib/utils/security';
   import { loggers } from '$lib/utils/logger';
   import { t } from '$lib/i18n';
@@ -179,6 +183,12 @@
     installingId !== null || reinstallingId !== null || deletingId !== null
   );
 
+  // Shared DOM id for the "actions paused" status line rendered while any gallery
+  // action is in flight. Every cross-action-disabled button points its
+  // aria-describedby here so a keyboard/screen-reader user hears why it is
+  // blocked; the line is rendered exactly when a button references it.
+  const GALLERY_ACTION_STATUS_ID = 'gallery-action-status';
+
   // Model regions, for localized region names in variant labels and the
   // region-aware picker. Fetched once on mount; a failure degrades to raw slugs.
   let regionsData = $state<ModelRegionsResponse | null>(null);
@@ -237,7 +247,7 @@
   // instantly, before any save. Note: until a save the server-computed
   // recommended flags still reflect the SAVED region, so the recommended variant
   // may lag the live selection; the effect below re-fetches on save to reconcile.
-  const liveModelRegion = $derived(birdnet?.modelRegion ? birdnet.modelRegion : 'auto');
+  const liveModelRegion = $derived(normalizeRegionMode(birdnet?.modelRegion));
   const activeRegionSlug = $derived.by<string>(() => {
     if (!regionsData) return '';
     if (liveModelRegion === 'global') return '';
@@ -252,7 +262,7 @@
   const savedModelRegion = $derived.by<string | null>(() => {
     const b = store.originalData.birdnet;
     if (!b) return null; // settings not loaded yet
-    return b.modelRegion ? b.modelRegion : 'auto';
+    return normalizeRegionMode(b.modelRegion);
   });
 
   // Re-fetch the catalog when the SAVED region changes mid-session (a save), so
@@ -1176,6 +1186,7 @@
       await uninstallModel(modelId);
       invalidateModels();
       await loadCatalog();
+      toastActions.success(t('analysis.gallery.removeSuccess', { name: modelName }));
     } catch (e) {
       const message = e instanceof Error ? e.message : t('analysis.gallery.errors.removeFailed');
       // A remove failure never involves a download, so it is never network-shaped.
@@ -1822,8 +1833,8 @@
       title={t('analysis.gallery.title')}
       description={t('analysis.gallery.description')}
       defaultOpen={true}
-      originalData={{ modelRegion: store.originalData.birdnet?.modelRegion ?? 'auto' }}
-      currentData={{ modelRegion: birdnet?.modelRegion ?? 'auto' }}
+      originalData={{ modelRegion: normalizeRegionMode(store.originalData.birdnet?.modelRegion) }}
+      currentData={{ modelRegion: normalizeRegionMode(birdnet?.modelRegion) }}
     >
       <ModelRegionSelector disabled={store.isLoading || store.isSaving} />
 
@@ -1900,6 +1911,20 @@
             </div>
           {/if}
         </div>
+      {/if}
+
+      {#if galleryActionInFlight}
+        <!-- One shared, live status line naming why the other cards' actions are
+             blocked. Touch users get no tooltip and aria-disabled buttons carry no
+             native title semantics, so this line (referenced via aria-describedby)
+             is how the reason reaches keyboard, screen-reader and tablet users. -->
+        <p
+          id={GALLERY_ACTION_STATUS_ID}
+          role="status"
+          class="mb-3 text-xs text-[var(--color-base-content)]/70"
+        >
+          {t('analysis.gallery.actionInProgress')}
+        </p>
       {/if}
 
       <SettingsTabs tabs={galleryTabs} bind:activeTab={galleryTab} showActions={false} />
@@ -2027,6 +2052,12 @@
           {@const isDeleting = deletingId === entry.id}
           {@const isReinstalling = reinstallingId === entry.id}
           {@const reinstallProgress = isReinstalling ? downloadProgress : null}
+          <!-- "Paused" = another gallery action is running, so THIS button is
+               cross-disabled (vs its own in-progress spinner). aria-disabled keeps
+               it tab-focusable to read the reason; native disabled stays for the
+               button's own running state. -->
+          {@const reinstallPaused = galleryActionInFlight && !isReinstalling}
+          {@const removePaused = galleryActionInFlight && !isDeleting}
           {@const logo = getModelLogo(entry.id)}
           <div
             class="rounded-lg border border-[var(--color-base-300)] bg-[var(--color-base-200)] p-4"
@@ -2170,12 +2201,24 @@
             <div class="mt-3 flex items-center justify-end gap-2">
               <button
                 type="button"
-                onclick={() => handleReinstall(entry)}
-                disabled={galleryActionInFlight}
-                title={galleryActionInFlight && !isReinstalling
-                  ? t('analysis.gallery.actionInProgress')
-                  : undefined}
-                class="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-[var(--color-base-content)]/80 hover:bg-[var(--color-base-300)] transition-colors disabled:opacity-50"
+                onclick={e => {
+                  if (reinstallPaused) {
+                    e.preventDefault();
+                    return;
+                  }
+                  handleReinstall(entry);
+                }}
+                disabled={isReinstalling}
+                aria-disabled={reinstallPaused ? 'true' : undefined}
+                aria-describedby={reinstallPaused ? GALLERY_ACTION_STATUS_ID : undefined}
+                title={reinstallPaused ? t('analysis.gallery.actionInProgress') : undefined}
+                class={cn(
+                  'inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-[var(--color-base-content)]/80 transition-colors',
+                  isReinstalling || reinstallPaused
+                    ? 'opacity-50'
+                    : 'hover:bg-[var(--color-base-300)]',
+                  reinstallPaused && 'cursor-not-allowed'
+                )}
                 aria-label="{t('analysis.gallery.reinstall')} {entry.name}"
               >
                 {#if isReinstalling}
@@ -2188,12 +2231,22 @@
               </button>
               <button
                 type="button"
-                onclick={() => openRemoveDialog(entry)}
-                disabled={galleryActionInFlight}
-                title={galleryActionInFlight && !isDeleting
-                  ? t('analysis.gallery.actionInProgress')
-                  : undefined}
-                class="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-[var(--color-error)] hover:bg-[var(--color-error)]/10 transition-colors disabled:opacity-50"
+                onclick={e => {
+                  if (removePaused) {
+                    e.preventDefault();
+                    return;
+                  }
+                  openRemoveDialog(entry);
+                }}
+                disabled={isDeleting}
+                aria-disabled={removePaused ? 'true' : undefined}
+                aria-describedby={removePaused ? GALLERY_ACTION_STATUS_ID : undefined}
+                title={removePaused ? t('analysis.gallery.actionInProgress') : undefined}
+                class={cn(
+                  'inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-[var(--color-error)] transition-colors',
+                  isDeleting || removePaused ? 'opacity-50' : 'hover:bg-[var(--color-error)]/10',
+                  removePaused && 'cursor-not-allowed'
+                )}
                 aria-label="{t('analysis.gallery.remove')} {entry.name}"
               >
                 {#if isDeleting}
@@ -2221,6 +2274,11 @@
 {#snippet modelCard(entry: CatalogEntry)}
   {@const isInstalling = installingId === entry.id}
   {@const progress = isInstalling ? downloadProgress : null}
+  <!-- Paused only when this Install would otherwise be available: another action
+       is running, this one is not, and the entry is compatible. Incompatible
+       entries keep their permanent native-disabled state (explained by the banner
+       above), never a transient "action in progress" reason. -->
+  {@const installPaused = galleryActionInFlight && !isInstalling && entry.compatible}
   {@const logo = getModelLogo(entry.id)}
   <div
     class={cn(
@@ -2365,12 +2423,24 @@
     <div class="mt-auto flex items-center justify-end pt-3">
       <button
         type="button"
-        onclick={() => openLicenseDialog(entry)}
-        disabled={!entry.compatible || galleryActionInFlight}
-        title={galleryActionInFlight && !isInstalling
-          ? t('analysis.gallery.actionInProgress')
-          : undefined}
-        class="inline-flex items-center gap-1.5 rounded-md bg-[var(--color-primary)] px-3 py-1.5 text-xs font-medium text-[var(--color-primary-content)] hover:bg-[var(--color-primary)]/80 transition-colors disabled:opacity-50"
+        onclick={e => {
+          if (installPaused) {
+            e.preventDefault();
+            return;
+          }
+          openLicenseDialog(entry);
+        }}
+        disabled={!entry.compatible || isInstalling}
+        aria-disabled={installPaused ? 'true' : undefined}
+        aria-describedby={installPaused ? GALLERY_ACTION_STATUS_ID : undefined}
+        title={installPaused ? t('analysis.gallery.actionInProgress') : undefined}
+        class={cn(
+          'inline-flex items-center gap-1.5 rounded-md bg-[var(--color-primary)] px-3 py-1.5 text-xs font-medium text-[var(--color-primary-content)] transition-colors',
+          !entry.compatible || isInstalling || installPaused
+            ? 'opacity-50'
+            : 'hover:bg-[var(--color-primary)]/80',
+          installPaused && 'cursor-not-allowed'
+        )}
         aria-label="{t('analysis.gallery.install')} {entry.name}"
       >
         {#if isInstalling}

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -3895,6 +3895,7 @@ export type TranslationKey =
   | 'analysis.gallery.variants.precisionInfo'
   | 'analysis.gallery.variants.precisionHelp'
   | 'analysis.gallery.actionInProgress'
+  | 'analysis.gallery.removeSuccess' // params: name
   | 'analysis.gallery.reasons.backendRecommended' // params: backend
   | 'analysis.gallery.reasons.backendSupported' // params: backend
   | 'analysis.gallery.reasons.regionMatched' // params: region
@@ -4499,6 +4500,7 @@ export type TranslationParams = {
   'analysis.gallery.variants.showAllRegions': { count: string | number };
   'analysis.gallery.variants.regionContext': { region: string | number };
   'analysis.gallery.variants.latency': { ms: string | number };
+  'analysis.gallery.removeSuccess': { name: string | number };
   'analysis.gallery.reasons.backendRecommended': { backend: string | number };
   'analysis.gallery.reasons.backendSupported': { backend: string | number };
   'analysis.gallery.reasons.regionMatched': { region: string | number };

--- a/frontend/src/lib/utils/variantSelection.test.ts
+++ b/frontend/src/lib/utils/variantSelection.test.ts
@@ -5,6 +5,7 @@ import {
   variantLabel,
   translateReason,
   topReasons,
+  normalizeRegionMode,
 } from './variantSelection';
 import type { CatalogEntry, CatalogVariant, VariantReason } from '$lib/types/models';
 
@@ -242,5 +243,22 @@ describe('topReasons', () => {
     expect(
       topReasons([reason('backend.recommended'), reason('region.matched'), reason('extra.one')])
     ).toEqual(['Best for your hardware', 'Matched to your region']);
+  });
+});
+
+describe('normalizeRegionMode', () => {
+  it('collapses empty string, null and undefined to the automatic mode', () => {
+    // '', null and undefined all mean "automatic" (the Go ModelRegion omitempty
+    // field), so they must normalize identically or the settings dirty-check would
+    // flag a logical no-op as an edit.
+    expect(normalizeRegionMode('')).toBe('auto');
+    expect(normalizeRegionMode(undefined)).toBe('auto');
+    expect(normalizeRegionMode(null)).toBe('auto');
+  });
+
+  it('passes a concrete region mode through unchanged', () => {
+    expect(normalizeRegionMode('auto')).toBe('auto');
+    expect(normalizeRegionMode('global')).toBe('global');
+    expect(normalizeRegionMode('nordic')).toBe('nordic');
   });
 });

--- a/frontend/src/lib/utils/variantSelection.ts
+++ b/frontend/src/lib/utils/variantSelection.ts
@@ -125,3 +125,24 @@ export function variantLabel(
   const regionDisplay = regionNames?.get(variant.region) ?? variant.region;
   return `${base} (${regionDisplay})`;
 }
+
+/**
+ * The canonical "automatic" region mode. An empty string, null, and undefined
+ * all mean automatic in the gallery, mirroring the Go `ModelRegion` field's
+ * `omitempty` (an unset region is omitted from JSON entirely).
+ */
+export const DEFAULT_REGION_MODE = 'auto';
+
+/**
+ * Normalize a stored region mode to its canonical form: '', null and undefined
+ * all collapse to 'auto', while a concrete slug or 'global' passes through
+ * unchanged. Centralizing this keeps the live/saved region derivations and the
+ * settings dirty-check from drifting apart (comparing a raw '' against a
+ * user-selected 'auto' would otherwise flag a logical no-op as an edit).
+ */
+export function normalizeRegionMode(value: string | undefined | null): string {
+  // Intentional falsy check: '' is a valid "automatic" sentinel too, not just
+  // null/undefined, so it must collapse to DEFAULT_REGION_MODE as well.
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- '' also means automatic
+  return value || DEFAULT_REGION_MODE;
+}

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -5340,6 +5340,7 @@
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "actionInProgress": "Počkejte na dokončení probíhající instalace, přeinstalace nebo odstranění modelu",
+      "removeSuccess": "Removed {name}",
       "reasons": {
         "backendRecommended": "Běží na {backend}, doporučeném backendu pro váš hardware",
         "backendSupported": "Běží na {backend}",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -5340,6 +5340,7 @@
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "actionInProgress": "Vent på, at den aktuelle installation, geninstallation eller fjernelse af modellen fuldføres",
+      "removeSuccess": "Removed {name}",
       "reasons": {
         "backendRecommended": "Kører på {backend}, den anbefalede backend til din hardware",
         "backendSupported": "Kører på {backend}",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -5340,6 +5340,7 @@
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "actionInProgress": "Warten Sie, bis die aktuelle Modellinstallation, Neuinstallation oder Entfernung abgeschlossen ist",
+      "removeSuccess": "Removed {name}",
       "reasons": {
         "backendRecommended": "Läuft auf {backend}, dem empfohlenen Backend für Ihre Hardware",
         "backendSupported": "Läuft auf {backend}",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -5333,13 +5333,14 @@
         "showHardware": "Show hardware variants ({count})",
         "showAllRegions": "Show all variants, including other regions ({count})",
         "regionContext": "Regional variants shown for {region}, set by the model region selection above",
-        "regionContextNone": "Regional variants are available. Pick a region in the model region selection above, or show all variants.",
+        "regionContextNone": "Regional variants are available. Pick a region in the model region selection above to scope them to your area.",
         "otherRegions": "Other regions",
         "latency": "~{ms} ms",
         "precisionInfo": "About precision and variants",
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "actionInProgress": "Wait for the current model install, reinstall, or remove to finish",
+      "removeSuccess": "Removed {name}",
       "reasons": {
         "backendRecommended": "Runs on {backend}, the recommended backend for your hardware",
         "backendSupported": "Runs on {backend}",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -5340,6 +5340,7 @@
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "actionInProgress": "Espera a que termine la instalación, reinstalación o eliminación del modelo actual",
+      "removeSuccess": "Removed {name}",
       "reasons": {
         "backendRecommended": "Se ejecuta en {backend}, el backend recomendado para tu hardware",
         "backendSupported": "Se ejecuta en {backend}",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -5340,6 +5340,7 @@
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "actionInProgress": "Odota, että nykyisen mallin asennus, uudelleenasennus tai poisto valmistuu",
+      "removeSuccess": "Removed {name}",
       "reasons": {
         "backendRecommended": "Käyttää taustajärjestelmää {backend}, joka on suositeltu laitteistollesi",
         "backendSupported": "Käyttää taustajärjestelmää {backend}",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -5340,6 +5340,7 @@
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "actionInProgress": "Attendez la fin de l'installation, de la réinstallation ou de la suppression du modèle en cours",
+      "removeSuccess": "Removed {name}",
       "reasons": {
         "backendRecommended": "S'exécute sur {backend}, le backend recommandé pour votre matériel",
         "backendSupported": "S'exécute sur {backend}",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -5340,6 +5340,7 @@
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "actionInProgress": "Várd meg a modell jelenlegi telepítésének, újratelepítésének vagy eltávolításának befejezését",
+      "removeSuccess": "Removed {name}",
       "reasons": {
         "backendRecommended": "Ezen fut: {backend}, amely a hardveredhez ajánlott backend",
         "backendSupported": "Ezen fut: {backend}",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -5340,6 +5340,7 @@
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "actionInProgress": "Attendi il completamento dell'installazione, reinstallazione o rimozione del modello corrente",
+      "removeSuccess": "Removed {name}",
       "reasons": {
         "backendRecommended": "Eseguito su {backend}, il backend consigliato per il tuo hardware",
         "backendSupported": "Eseguito su {backend}",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -5340,6 +5340,7 @@
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "actionInProgress": "Pagaidiet, līdz beidzas pašreizējā modeļa instalēšana, pārinstalēšana vai noņemšana",
+      "removeSuccess": "Removed {name}",
       "reasons": {
         "backendRecommended": "Darbojas ar {backend}, kas ir ieteicamā aizmugursistēma jūsu aparatūrai",
         "backendSupported": "Darbojas ar {backend}",

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -5340,6 +5340,7 @@
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "actionInProgress": "Vent til den pågående installasjonen, reinstallasjonen eller fjerningen av modellen er ferdig",
+      "removeSuccess": "Removed {name}",
       "reasons": {
         "backendRecommended": "Kjører på {backend}, som er den anbefalte backenden for din maskinvare",
         "backendSupported": "Kjører på {backend}",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -5340,6 +5340,7 @@
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "actionInProgress": "Wacht tot de huidige installatie, herinstallatie of verwijdering van het model is voltooid",
+      "removeSuccess": "Removed {name}",
       "reasons": {
         "backendRecommended": "Draait op {backend}, de aanbevolen backend voor jouw hardware",
         "backendSupported": "Draait op {backend}",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -5340,6 +5340,7 @@
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "actionInProgress": "Poczekaj na zakończenie bieżącej instalacji, ponownej instalacji lub usunięcia modelu",
+      "removeSuccess": "Removed {name}",
       "reasons": {
         "backendRecommended": "Działa na {backend}, zalecanym backendzie dla twojego sprzętu",
         "backendSupported": "Działa na {backend}",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -5340,6 +5340,7 @@
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "actionInProgress": "Aguarde a conclusão da instalação, reinstalação ou remoção do modelo atual",
+      "removeSuccess": "Removed {name}",
       "reasons": {
         "backendRecommended": "Roda em {backend}, o backend recomendado para o seu hardware",
         "backendSupported": "Roda em {backend}",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -5340,6 +5340,7 @@
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "actionInProgress": "Počkajte na dokončenie prebiehajúcej inštalácie, preinštalovania alebo odstránenia modelu",
+      "removeSuccess": "Removed {name}",
       "reasons": {
         "backendRecommended": "Beží na {backend}, čo je odporúčaný backend pre váš hardvér",
         "backendSupported": "Beží na {backend}",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -5340,6 +5340,7 @@
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
       },
       "actionInProgress": "Vänta tills den pågående installationen, ominstallationen eller borttagningen av modellen är klar",
+      "removeSuccess": "Removed {name}",
       "reasons": {
         "backendRecommended": "Körs på {backend}, den rekommenderade backend-motorn för din hårdvara",
         "backendSupported": "Körs på {backend}",


### PR DESCRIPTION
Batch of accessibility, UX, reuse, and test follow-ups on the model-gallery region-aware variant picker. No behavior change to model selection or installation beyond the fixes noted below.

## Accessibility and UX

- The gallery action buttons (Install, Reinstall, Remove) previously went native-`disabled` while any other action was in flight, so the "why is this blocked" reason was only reachable through a `title` tooltip: invisible on touch and unreadable by a screen reader, since a native-disabled button drops out of the tab order. They now use `aria-disabled` for that cross-action state plus a single shared `role="status"` line that every paused button points at via `aria-describedby`, so the reason reaches keyboard, screen-reader, and touch users. Native `disabled` is kept only for a button's own in-progress state and for the permanently incompatible Install case. Disabled-looking buttons also no longer light up on hover.
- The "Other regions" variant tiles are wrapped in a `role="group"` labelled by their heading.
- When the "show all" disclosure button unmounts, keyboard focus now moves to the first newly revealed tile instead of falling back to `<body>`.
- A success toast now confirms a model removal (install and reinstall already had a completion state).
- Softened the no-region context copy so it no longer implies a "show all" action the button does not offer.

## Reuse and a latent bug fix

- Extracted a shared `normalizeRegionMode` helper and routed the five region-mode normalizations through it. This also fixes a false "unsaved changes" indicator: the change-detection sites used `?? 'auto'` (which leaves `''` as `''`), so a saved empty region compared unequal to a user-selected `'auto'` even though the backend treats both as automatic (the `ModelRegion` field is `omitempty`).
- `alwaysVariants` is computed once in `ModelVariantPicker` instead of being re-filtered in two derivations.

## Tests

Rewrote the in-flight guard test for the `aria-disabled` behavior, asserting the ARIA attributes, that the button stays focusable, and, behaviorally, that clicking it does not start the action. Added group-semantics and focus-move tests, a region-refetch liveness assertion, a remove-toast test, and a `normalizeRegionMode` unit test. Hoisted the duplicated dialog polyfill to a file-scope `beforeAll`.

Frontend gate is green locally: `npm run check:all`, the full Vitest suite, `test:a11y`, and the i18n sync / type / usage checks.
