### PR TITLE
feat(models): variant-aware gallery cards, within-model optimize, built-in v2.4 as a variant

### DIFF
--- a/frontend/src/lib/desktop/features/settings/components/OptimizeReviewDialog.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/OptimizeReviewDialog.svelte
@@ -9,7 +9,7 @@
   import type { OptimizeOffer } from '$lib/utils/variantSelection';
   import { variantLabel, variantHardwareLabel } from '$lib/utils/variantSelection';
   import { t } from '$lib/i18n';
-  import { ArrowRight, Check, Loader2, Sparkles, X } from '@lucide/svelte';
+  import { ArrowRight, Check, Loader2, Sparkles, TriangleAlert, X } from '@lucide/svelte';
 
   interface Props {
     /** Whether the dialog is open. The parent controls it; native closes call onClose. */
@@ -22,6 +22,8 @@
     applyingId: string | null;
     /** Entry ids applied in this session (marked done in the list). */
     appliedIds: Set<string>;
+    /** Entry ids whose apply failed this session (marked failed, re-appliable). */
+    failedIds: Set<string>;
     onApply: (_offer: OptimizeOffer) => void;
     onApplyAll: () => void;
     onClose: () => void;
@@ -34,6 +36,7 @@
     inFlight,
     applyingId,
     appliedIds,
+    failedIds,
     onApply,
     onApplyAll,
     onClose,
@@ -96,6 +99,7 @@
         {#each offers as offer (offer.entry.id)}
           {@const applying = applyingId === offer.entry.id}
           {@const applied = appliedIds.has(offer.entry.id)}
+          {@const failed = failedIds.has(offer.entry.id)}
           <li
             class="rounded-lg border border-[var(--color-base-300)] bg-[var(--color-base-200)] p-3"
           >
@@ -106,6 +110,10 @@
                 </p>
                 <div
                   class="mt-1 flex flex-wrap items-center gap-1.5 text-xs text-[var(--color-base-content)]/80"
+                  aria-label={t('analysis.gallery.optimize.fromTo', {
+                    from: variantLabel(offer.from, regionNames),
+                    to: variantLabel(offer.to, regionNames),
+                  })}
                 >
                   <span>{variantLabel(offer.from, regionNames)}</span>
                   <span
@@ -145,15 +153,25 @@
                     {t('analysis.gallery.optimize.applying')}
                   </span>
                 {:else}
-                  <button
-                    type="button"
-                    onclick={() => onApply(offer)}
-                    disabled={inFlight}
-                    title={inFlight ? t('analysis.gallery.actionInProgress') : undefined}
-                    class="inline-flex items-center gap-1.5 rounded-md bg-[var(--color-primary)] px-3 py-1.5 text-xs font-medium text-[var(--color-primary-content)] transition-colors hover:bg-[var(--color-primary)]/80 disabled:cursor-not-allowed disabled:opacity-50"
-                  >
-                    {t('analysis.gallery.optimize.apply')}
-                  </button>
+                  <div class="flex flex-col items-end gap-1">
+                    {#if failed}
+                      <span
+                        class="inline-flex items-center gap-1 text-xs font-medium text-[var(--color-error)]"
+                      >
+                        <TriangleAlert class="size-3.5" />
+                        {t('analysis.gallery.optimize.applyFailed')}
+                      </span>
+                    {/if}
+                    <button
+                      type="button"
+                      onclick={() => onApply(offer)}
+                      disabled={inFlight}
+                      title={inFlight ? t('analysis.gallery.actionInProgress') : undefined}
+                      class="inline-flex items-center gap-1.5 rounded-md bg-[var(--color-primary)] px-3 py-1.5 text-xs font-medium text-[var(--color-primary-content)] transition-colors hover:bg-[var(--color-primary)]/80 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {failed ? t('analysis.gallery.retry') : t('analysis.gallery.optimize.apply')}
+                    </button>
+                  </div>
                 {/if}
               </div>
             </div>

--- a/frontend/src/lib/desktop/features/settings/components/OptimizeReviewDialog.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/OptimizeReviewDialog.svelte
@@ -100,6 +100,9 @@
           {@const applying = applyingId === offer.entry.id}
           {@const applied = appliedIds.has(offer.entry.id)}
           {@const failed = failedIds.has(offer.entry.id)}
+          {@const fromLabel = offer.from
+            ? variantLabel(offer.from, regionNames)
+            : (offer.entry.installedVariantId ?? '')}
           <li
             class="rounded-lg border border-[var(--color-base-300)] bg-[var(--color-base-200)] p-3"
           >
@@ -111,16 +114,18 @@
                 <div
                   class="mt-1 flex flex-wrap items-center gap-1.5 text-xs text-[var(--color-base-content)]/80"
                   aria-label={t('analysis.gallery.optimize.fromTo', {
-                    from: variantLabel(offer.from, regionNames),
+                    from: fromLabel,
                     to: variantLabel(offer.to, regionNames),
                   })}
                 >
-                  <span>{variantLabel(offer.from, regionNames)}</span>
-                  <span
-                    class="inline-flex items-center gap-0.5 rounded-full bg-[var(--color-base-300)] px-1.5 py-0.5"
-                  >
-                    {variantHardwareLabel(offer.from)}
-                  </span>
+                  <span>{fromLabel}</span>
+                  {#if offer.from}
+                    <span
+                      class="inline-flex items-center gap-0.5 rounded-full bg-[var(--color-base-300)] px-1.5 py-0.5"
+                    >
+                      {variantHardwareLabel(offer.from)}
+                    </span>
+                  {/if}
                   <ArrowRight class="size-3.5 shrink-0" aria-hidden="true" />
                   <span class="font-medium text-[var(--color-base-content)]"
                     >{variantLabel(offer.to, regionNames)}</span

--- a/frontend/src/lib/desktop/features/settings/components/OptimizeReviewDialog.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/OptimizeReviewDialog.svelte
@@ -1,0 +1,187 @@
+<script lang="ts">
+  // Review dialog for the model gallery "optimize" flow. Lists the within-model
+  // offers (a faster or better-matched build of a model the user already has) with
+  // a from -> to variant summary, hardware chips, and the recommendation reasons,
+  // and lets the user apply one or all of them. Apply is entirely within-model, so
+  // the license never changes (see the license note); the swap reuses the same
+  // install/variant-swap flow as a normal install, so no new consent is needed.
+
+  import type { OptimizeOffer } from '$lib/utils/variantSelection';
+  import { variantLabel, variantHardwareLabel } from '$lib/utils/variantSelection';
+  import { t } from '$lib/i18n';
+  import { ArrowRight, Check, Loader2, Sparkles, X } from '@lucide/svelte';
+
+  interface Props {
+    /** Whether the dialog is open. The parent controls it; native closes call onClose. */
+    open: boolean;
+    offers: OptimizeOffer[];
+    regionNames: ReadonlyMap<string, string>;
+    /** True while any gallery action is in flight (blocks concurrent applies). */
+    inFlight: boolean;
+    /** Entry id currently being applied, or null. */
+    applyingId: string | null;
+    /** Entry ids applied in this session (marked done in the list). */
+    appliedIds: Set<string>;
+    onApply: (_offer: OptimizeOffer) => void;
+    onApplyAll: () => void;
+    onClose: () => void;
+  }
+
+  let {
+    open,
+    offers,
+    regionNames,
+    inFlight,
+    applyingId,
+    appliedIds,
+    onApply,
+    onApplyAll,
+    onClose,
+  }: Props = $props();
+
+  // Element binding is a plain let (not $state): native <dialog> is driven
+  // imperatively via showModal()/close(), never re-rendered from this reference.
+  let dialogEl: HTMLDialogElement | null = null;
+
+  // Reflect the `open` prop onto the native dialog. showModal()/close() are
+  // idempotent, so re-running on unrelated prop changes is harmless.
+  $effect(() => {
+    if (open) dialogEl?.showModal();
+    else dialogEl?.close();
+  });
+
+  // Offers still worth applying: an offer whose entry was already applied this
+  // session drops out on the next catalog reload, but guard here too so a mid-batch
+  // re-render never shows an applied row as still actionable.
+  const pending = $derived(offers.filter(o => !appliedIds.has(o.entry.id)));
+</script>
+
+<dialog
+  bind:this={dialogEl}
+  onclose={() => {
+    if (open) onClose();
+  }}
+  class="m-auto w-full max-w-lg rounded-xl border border-[var(--color-base-300)] bg-[var(--color-base-100)] p-0 shadow-xl backdrop:bg-black/50"
+  aria-labelledby="optimize-dialog-title"
+>
+  <div class="p-6">
+    <div class="flex items-start justify-between gap-3">
+      <h3
+        id="optimize-dialog-title"
+        class="flex items-center gap-2 text-lg font-semibold text-[var(--color-base-content)]"
+      >
+        <Sparkles class="size-5 text-[var(--color-primary)]" aria-hidden="true" />
+        {t('analysis.gallery.optimize.dialogTitle')}
+      </h3>
+      <button
+        type="button"
+        onclick={onClose}
+        aria-label={t('analysis.gallery.errors.dismiss')}
+        class="inline-flex items-center justify-center rounded-md p-1.5 bg-transparent hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
+      >
+        <X class="size-4" />
+      </button>
+    </div>
+
+    <p class="mt-2 text-sm text-[var(--color-base-content)]/70">
+      {t('analysis.gallery.optimize.licenseNote')}
+    </p>
+
+    {#if offers.length === 0}
+      <p class="mt-4 text-sm text-[var(--color-base-content)]/80">
+        {t('analysis.gallery.optimize.upToDate')}
+      </p>
+    {:else}
+      <ul class="mt-4 space-y-3">
+        {#each offers as offer (offer.entry.id)}
+          {@const applying = applyingId === offer.entry.id}
+          {@const applied = appliedIds.has(offer.entry.id)}
+          <li
+            class="rounded-lg border border-[var(--color-base-300)] bg-[var(--color-base-200)] p-3"
+          >
+            <div class="flex items-center justify-between gap-3">
+              <div class="min-w-0 flex-1">
+                <p class="truncate text-sm font-medium text-[var(--color-base-content)]">
+                  {offer.entry.name}
+                </p>
+                <div
+                  class="mt-1 flex flex-wrap items-center gap-1.5 text-xs text-[var(--color-base-content)]/80"
+                >
+                  <span>{variantLabel(offer.from, regionNames)}</span>
+                  <span
+                    class="inline-flex items-center gap-0.5 rounded-full bg-[var(--color-base-300)] px-1.5 py-0.5"
+                  >
+                    {variantHardwareLabel(offer.from)}
+                  </span>
+                  <ArrowRight class="size-3.5 shrink-0" aria-hidden="true" />
+                  <span class="font-medium text-[var(--color-base-content)]"
+                    >{variantLabel(offer.to, regionNames)}</span
+                  >
+                  <span
+                    class="inline-flex items-center gap-0.5 rounded-full bg-[var(--color-primary)]/15 px-1.5 py-0.5 text-[var(--color-primary)]"
+                  >
+                    {variantHardwareLabel(offer.to)}
+                  </span>
+                </div>
+                {#if offer.reasons.length > 0}
+                  <p class="mt-1 text-xs text-[var(--color-base-content)]/70">
+                    {offer.reasons.join(' · ')}
+                  </p>
+                {/if}
+              </div>
+              <div class="shrink-0">
+                {#if applied}
+                  <span
+                    class="inline-flex items-center gap-1 text-xs font-medium text-[var(--color-success)]"
+                  >
+                    <Check class="size-3.5" />
+                    {t('analysis.gallery.optimize.applied')}
+                  </span>
+                {:else if applying}
+                  <span
+                    class="inline-flex items-center gap-1 text-xs font-medium text-[var(--color-base-content)]/80"
+                  >
+                    <Loader2 class="size-3.5 animate-spin" />
+                    {t('analysis.gallery.optimize.applying')}
+                  </span>
+                {:else}
+                  <button
+                    type="button"
+                    onclick={() => onApply(offer)}
+                    disabled={inFlight}
+                    title={inFlight ? t('analysis.gallery.actionInProgress') : undefined}
+                    class="inline-flex items-center gap-1.5 rounded-md bg-[var(--color-primary)] px-3 py-1.5 text-xs font-medium text-[var(--color-primary-content)] transition-colors hover:bg-[var(--color-primary)]/80 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {t('analysis.gallery.optimize.apply')}
+                  </button>
+                {/if}
+              </div>
+            </div>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+
+    <div class="mt-6 flex justify-end gap-3">
+      <button
+        type="button"
+        onclick={onClose}
+        class="rounded-lg border border-[var(--color-base-300)] px-4 py-2 text-sm font-medium text-[var(--color-base-content)] hover:bg-[var(--color-base-200)] transition-colors"
+      >
+        {t('common.close')}
+      </button>
+      {#if pending.length > 1}
+        <button
+          type="button"
+          onclick={onApplyAll}
+          disabled={inFlight}
+          title={inFlight ? t('analysis.gallery.actionInProgress') : undefined}
+          class="inline-flex items-center gap-2 rounded-lg bg-[var(--color-primary)] px-4 py-2 text-sm font-medium text-[var(--color-primary-content)] hover:bg-[var(--color-primary)]/80 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <Sparkles class="size-4" />
+          {t('analysis.gallery.optimize.applyAll')}
+        </button>
+      {/if}
+    </div>
+  </div>
+</dialog>

--- a/frontend/src/lib/desktop/features/settings/components/OptimizeReviewDialog.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/OptimizeReviewDialog.svelte
@@ -46,6 +46,13 @@
   // imperatively via showModal()/close(), never re-rendered from this reference.
   let dialogEl: HTMLDialogElement | null = null;
 
+  // Id of the live status line that explains why Apply is blocked while another
+  // gallery action runs. Apply/Apply-all reference it via aria-describedby and stay
+  // tab-focusable (aria-disabled, not native disabled) so the reason is reachable by
+  // keyboard and screen readers, and visible on touch devices where a title tooltip
+  // never appears (see frontend/CLAUDE.md "No Ambiguous Disabled States").
+  const IN_FLIGHT_STATUS_ID = 'optimize-inflight-status';
+
   // Reflect the `open` prop onto the native dialog. showModal()/close() are
   // idempotent, so re-running on unrelated prop changes is harmless.
   $effect(() => {
@@ -79,7 +86,7 @@
       <button
         type="button"
         onclick={onClose}
-        aria-label={t('analysis.gallery.errors.dismiss')}
+        aria-label={t('common.close')}
         class="inline-flex items-center justify-center rounded-md p-1.5 bg-transparent hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
       >
         <X class="size-4" />
@@ -89,6 +96,19 @@
     <p class="mt-2 text-sm text-[var(--color-base-content)]/70">
       {t('analysis.gallery.optimize.licenseNote')}
     </p>
+
+    <!-- Live reason line: why Apply is blocked while another gallery action runs.
+         Referenced by the Apply/Apply-all buttons' aria-describedby, so the reason
+         reaches keyboard, screen-reader and touch users (no hover tooltip needed). -->
+    {#if inFlight}
+      <p
+        id={IN_FLIGHT_STATUS_ID}
+        role="status"
+        class="mt-2 text-xs text-[var(--color-base-content)]/70"
+      >
+        {t('analysis.gallery.actionInProgress')}
+      </p>
+    {/if}
 
     {#if offers.length === 0}
       <p class="mt-4 text-sm text-[var(--color-base-content)]/80">
@@ -103,6 +123,7 @@
           {@const fromLabel = offer.from
             ? variantLabel(offer.from, regionNames)
             : (offer.entry.installedVariantId ?? '')}
+          {@const toLabel = variantLabel(offer.to, regionNames)}
           <li
             class="rounded-lg border border-[var(--color-base-300)] bg-[var(--color-base-200)] p-3"
           >
@@ -115,7 +136,7 @@
                   class="mt-1 flex flex-wrap items-center gap-1.5 text-xs text-[var(--color-base-content)]/80"
                   aria-label={t('analysis.gallery.optimize.fromTo', {
                     from: fromLabel,
-                    to: variantLabel(offer.to, regionNames),
+                    to: toLabel,
                   })}
                 >
                   <span>{fromLabel}</span>
@@ -127,9 +148,7 @@
                     </span>
                   {/if}
                   <ArrowRight class="size-3.5 shrink-0" aria-hidden="true" />
-                  <span class="font-medium text-[var(--color-base-content)]"
-                    >{variantLabel(offer.to, regionNames)}</span
-                  >
+                  <span class="font-medium text-[var(--color-base-content)]">{toLabel}</span>
                   <span
                     class="inline-flex items-center gap-0.5 rounded-full bg-[var(--color-primary)]/15 px-1.5 py-0.5 text-[var(--color-primary)]"
                   >
@@ -169,10 +188,17 @@
                     {/if}
                     <button
                       type="button"
-                      onclick={() => onApply(offer)}
-                      disabled={inFlight}
+                      onclick={e => {
+                        if (inFlight) {
+                          e.preventDefault();
+                          return;
+                        }
+                        onApply(offer);
+                      }}
+                      aria-disabled={inFlight ? 'true' : undefined}
+                      aria-describedby={inFlight ? IN_FLIGHT_STATUS_ID : undefined}
                       title={inFlight ? t('analysis.gallery.actionInProgress') : undefined}
-                      class="inline-flex items-center gap-1.5 rounded-md bg-[var(--color-primary)] px-3 py-1.5 text-xs font-medium text-[var(--color-primary-content)] transition-colors hover:bg-[var(--color-primary)]/80 disabled:cursor-not-allowed disabled:opacity-50"
+                      class="inline-flex items-center gap-1.5 rounded-md bg-[var(--color-primary)] px-3 py-1.5 text-xs font-medium text-[var(--color-primary-content)] transition-colors hover:bg-[var(--color-primary)]/80 aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
                     >
                       {failed ? t('analysis.gallery.retry') : t('analysis.gallery.optimize.apply')}
                     </button>
@@ -183,6 +209,16 @@
           </li>
         {/each}
       </ul>
+
+      <!-- Plain-language help for the precision jargon (FP32/FP16/INT8) shown in the
+           from -> to summary, mirroring the license dialog's disclosure. A native
+           <details> is keyboard- and touch-accessible, unlike a hover tooltip. -->
+      <details class="mt-3 text-xs text-[var(--color-base-content)]/70">
+        <summary class="cursor-pointer hover:text-[var(--color-base-content)]">
+          {t('analysis.gallery.variants.precisionInfo')}
+        </summary>
+        <p class="mt-1">{t('analysis.gallery.variants.precisionHelp')}</p>
+      </details>
     {/if}
 
     <div class="mt-6 flex justify-end gap-3">
@@ -196,10 +232,17 @@
       {#if pending.length > 1}
         <button
           type="button"
-          onclick={onApplyAll}
-          disabled={inFlight}
+          onclick={e => {
+            if (inFlight) {
+              e.preventDefault();
+              return;
+            }
+            onApplyAll();
+          }}
+          aria-disabled={inFlight ? 'true' : undefined}
+          aria-describedby={inFlight ? IN_FLIGHT_STATUS_ID : undefined}
           title={inFlight ? t('analysis.gallery.actionInProgress') : undefined}
-          class="inline-flex items-center gap-2 rounded-lg bg-[var(--color-primary)] px-4 py-2 text-sm font-medium text-[var(--color-primary-content)] hover:bg-[var(--color-primary)]/80 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+          class="inline-flex items-center gap-2 rounded-lg bg-[var(--color-primary)] px-4 py-2 text-sm font-medium text-[var(--color-primary-content)] hover:bg-[var(--color-primary)]/80 transition-colors aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
         >
           <Sparkles class="size-4" />
           {t('analysis.gallery.optimize.applyAll')}

--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.gallery.test.ts
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.gallery.test.ts
@@ -430,7 +430,9 @@ describe('AnalysisSettingsPage model gallery optimize + permanent card', () => {
       screen.queryByRole('button', { name: /analysis\.gallery\.reinstall.*BirdNET v2\.4/ })
     ).toBeNull();
 
-    // The built-in badge is shown (also used as the baseline hardware chip).
-    expect(screen.getAllByText('analysis.gallery.builtIn').length).toBeGreaterThan(0);
+    // The built-in label appears at least twice on the permanent card: the footer
+    // built-in badge and the baseline hardware chip. (The review dialog, also in the
+    // DOM, renders it again for the offer's from-variant, so assert a lower bound.)
+    expect(screen.getAllByText('analysis.gallery.builtIn').length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.gallery.test.ts
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.gallery.test.ts
@@ -322,3 +322,115 @@ describe('AnalysisSettingsPage model gallery in-flight guard and region refetch'
     );
   });
 });
+
+describe('AnalysisSettingsPage model gallery optimize + permanent card', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    settingsStore.update(s => ({
+      ...s,
+      originalData: {
+        ...s.originalData,
+        birdnet: { ...s.originalData.birdnet, modelRegion: undefined },
+      },
+    }));
+    vi.mocked(modelsApi.fetchInstalled).mockResolvedValue([]);
+    vi.mocked(modelsApi.fetchModelRegions).mockRejectedValue(new Error('no regions in test'));
+  });
+
+  // A permanent BirdNET v2.4 entry installed on its BuiltIn baseline, with a faster
+  // DFT build recommended for this host (so it carries an optimize offer).
+  function v24Installed(overrides: Partial<CatalogEntry> = {}): CatalogEntry {
+    return birdEntry({
+      id: 'birdnet-v2.4',
+      name: 'BirdNET v2.4',
+      installed: true,
+      permanent: true,
+      installedVariantId: 'builtin',
+      recommendedVariantId: 'fp32-dfttrunc',
+      variants: [
+        {
+          id: 'builtin',
+          builtIn: true,
+          default: true,
+          installed: true,
+          speciesCount: 6522,
+          sizeBytes: 0,
+          compatible: true,
+          recommended: false,
+        },
+        {
+          id: 'fp32-dfttrunc',
+          precision: 'fp32',
+          default: false,
+          installed: false,
+          speciesCount: 6522,
+          sizeBytes: 54_000_000,
+          compatible: true,
+          recommended: true,
+          reasons: [{ code: 'backend.recommended', args: { backend: 'onnxruntime-cpu' } }],
+        },
+      ],
+      ...overrides,
+    });
+  }
+
+  it('shows the optimize banner when an installed model has a better variant, and dismisses it', async () => {
+    vi.mocked(modelsApi.fetchCatalog).mockResolvedValue({ catalog: [v24Installed()] });
+    render(AnalysisSettingsPage);
+    await fireEvent.click(await screen.findByRole('tab', { name: /analysis\.tabs\.models/ }));
+
+    // The banner is visible with the Review action.
+    expect(await screen.findByText('analysis.gallery.optimize.bannerTitle')).toBeInTheDocument();
+    const review = await screen.findByRole('button', {
+      name: /analysis\.gallery\.optimize\.review/,
+    });
+
+    // Review opens the dialog.
+    await fireEvent.click(review);
+    expect(await screen.findByText('analysis.gallery.optimize.dialogTitle')).toBeInTheDocument();
+
+    // Dismiss hides the banner for the session.
+    await fireEvent.click(
+      await screen.findByRole('button', { name: /analysis\.gallery\.optimize\.dismiss/ })
+    );
+    await waitFor(() =>
+      expect(screen.queryByText('analysis.gallery.optimize.bannerTitle')).toBeNull()
+    );
+  });
+
+  it('shows no optimize banner when the installed variant is already the recommended one', async () => {
+    vi.mocked(modelsApi.fetchCatalog).mockResolvedValue({
+      catalog: [v24Installed({ installedVariantId: 'fp32-dfttrunc' })],
+    });
+    render(AnalysisSettingsPage);
+    await fireEvent.click(await screen.findByRole('tab', { name: /analysis\.tabs\.models/ }));
+    // Give the card grid time to render, then assert the banner never appears.
+    await screen.findByRole('tab', { name: /analysis\.gallery\.tabs\.installed/ });
+    expect(screen.queryByText('analysis.gallery.optimize.bannerTitle')).toBeNull();
+  });
+
+  it('renders the permanent card with a built-in badge, no Remove/Reinstall, and an Optimize action', async () => {
+    vi.mocked(modelsApi.fetchCatalog).mockResolvedValue({ catalog: [v24Installed()] });
+    render(AnalysisSettingsPage);
+    await fireEvent.click(await screen.findByRole('tab', { name: /analysis\.tabs\.models/ }));
+
+    // The Optimize (swap) action is present on the permanent card.
+    expect(
+      await screen.findByRole('button', {
+        name: /analysis\.gallery\.optimize\.swap.*BirdNET v2\.4/,
+      })
+    ).toBeInTheDocument();
+
+    // The permanent model cannot be removed or reinstalled from its card.
+    expect(
+      screen.queryByRole('button', { name: /analysis\.gallery\.remove.*BirdNET v2\.4/ })
+    ).toBeNull();
+    expect(
+      screen.queryByRole('button', { name: /analysis\.gallery\.reinstall.*BirdNET v2\.4/ })
+    ).toBeNull();
+
+    // The built-in badge is shown (also used as the baseline hardware chip).
+    expect(screen.getAllByText('analysis.gallery.builtIn').length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
@@ -30,6 +30,7 @@
   import { downloadBlob } from '$lib/utils/fileHelpers';
   import type {
     CatalogEntry,
+    CatalogVariant,
     DownloadProgress,
     InstalledModel,
     ModelRegionsResponse,
@@ -79,7 +80,11 @@
     pickPreselectedVariant,
     translateReason,
     normalizeRegionMode,
+    optimizeOffers,
+    variantHardwareLabel,
+    type OptimizeOffer,
   } from '$lib/utils/variantSelection';
+  import OptimizeReviewDialog from '$lib/desktop/features/settings/components/OptimizeReviewDialog.svelte';
   import { safeArrayAccess } from '$lib/utils/security';
   import { loggers } from '$lib/utils/logger';
   import { t } from '$lib/i18n';
@@ -99,6 +104,7 @@
     XCircle,
     X,
     Check,
+    Sparkles,
     Settings as SettingsIcon,
   } from '@lucide/svelte';
 
@@ -320,7 +326,130 @@
   const hasBirdNetV3Model = $derived(installedModels.some(m => m.catalogId === 'birdnet-v3.0'));
 
   // ── Derived catalog views ─────────────────────────────────────────────
-  const installedEntries = $derived(catalog.filter(e => e.installed));
+  // Installed models, with the permanent built-in classifier (BirdNET v2.4) sorted
+  // first so it heads the list where the old hardcoded static card used to sit.
+  // JS sort is stable, so the remaining entries keep their catalog order.
+  const installedEntries = $derived(
+    catalog.filter(e => e.installed).sort((a, b) => Number(!!b.permanent) - Number(!!a.permanent))
+  );
+
+  // ── Within-model "optimize" offers ────────────────────────────────────
+  // Derived entirely client-side from the catalog: an installed model whose
+  // host-recommended variant differs from the installed one and is compatible.
+  const offers = $derived(optimizeOffers(catalog));
+  const offerByEntry = $derived(new Map(offers.map(o => [o.entry.id, o])));
+
+  // Session-scoped banner dismissal, guarded so a private-window/blocked
+  // sessionStorage never throws (see frontend/CLAUDE.md).
+  const OPTIMIZE_BANNER_DISMISS_KEY = 'birdnet.optimizeBannerDismissed';
+  function readOptimizeDismissed(): boolean {
+    try {
+      return sessionStorage.getItem(OPTIMIZE_BANNER_DISMISS_KEY) === '1';
+    } catch {
+      return false;
+    }
+  }
+  let optimizeBannerDismissed = $state(readOptimizeDismissed());
+  function dismissOptimizeBanner() {
+    optimizeBannerDismissed = true;
+    try {
+      sessionStorage.setItem(OPTIMIZE_BANNER_DISMISS_KEY, '1');
+    } catch {
+      /* sessionStorage unavailable: dismissal is in-memory only for this session */
+    }
+  }
+
+  // Review dialog + apply-flow state. Applies reuse the normal install/variant-swap
+  // path (startInstall); a within-model swap never changes the license, so no extra
+  // consent is needed beyond the review dialog itself.
+  let optimizeReviewOpen = $state(false);
+  let appliedOptimizeIds = $state(new Set<string>());
+  // The entry id whose optimize swap is in flight (drives the dialog's per-row
+  // spinner) and the sequential apply-all queue of entry ids still to apply.
+  let optimizeApplyingId = $state<string | null>(null);
+  let applyAllQueue = $state<string[]>([]);
+  // Plain (untracked) marker so the completion effect can detect installingId
+  // transitioning back to null without re-triggering itself.
+  let lastInstallingId: string | null = null;
+
+  function openOptimizeReview() {
+    optimizeReviewOpen = true;
+  }
+  function closeOptimizeReview() {
+    optimizeReviewOpen = false;
+  }
+
+  // Apply one offer: start the within-model swap to its recommended variant.
+  function applyOffer(offer: OptimizeOffer) {
+    if (galleryActionInFlight) return;
+    optimizeApplyingId = offer.entry.id;
+    startInstall(offer.entry.id, offer.entry.name, offer.to.id);
+  }
+
+  // Apply every current offer, sequentially: queue their entry ids and start the
+  // first; the completion effect below advances the queue as each swap finishes.
+  function applyAllOffers() {
+    if (galleryActionInFlight) return;
+    applyAllQueue = offers.map(o => o.entry.id);
+    applyNextInQueue();
+  }
+  function applyNextInQueue() {
+    while (applyAllQueue.length > 0) {
+      const nextId = applyAllQueue[0];
+      const offer = offers.find(o => o.entry.id === nextId);
+      if (offer && !appliedOptimizeIds.has(nextId)) {
+        optimizeApplyingId = nextId;
+        startInstall(offer.entry.id, offer.entry.name, offer.to.id);
+        return;
+      }
+      applyAllQueue = applyAllQueue.slice(1);
+    }
+  }
+
+  // Detect an optimize swap completing (installingId returns to null after being
+  // set to the applying id): mark it applied on success, then advance the batch
+  // queue. A failed swap (installError names the id) is not marked applied but still
+  // advances the queue so one failure does not stall the rest.
+  $effect(() => {
+    const current = installingId;
+    if (lastInstallingId !== null && current === null && lastInstallingId === optimizeApplyingId) {
+      const done = lastInstallingId;
+      optimizeApplyingId = null;
+      const failed = installError?.modelId === done;
+      if (!failed) appliedOptimizeIds = new Set(appliedOptimizeIds).add(done);
+      if (applyAllQueue[0] === done) {
+        applyAllQueue = applyAllQueue.slice(1);
+        applyNextInQueue();
+      }
+    }
+    lastInstallingId = current;
+  });
+
+  // Choose which variant a card should describe: the installed variant on the
+  // Installed tab, the host-recommended (else default) variant on the Available tab.
+  // Returns null for a flat (variant-less) entry.
+  function displayVariantFor(
+    entry: CatalogEntry,
+    mode: 'available' | 'installed'
+  ): CatalogVariant | null {
+    const variants = entry.variants ?? [];
+    if (variants.length === 0) return null;
+    if (mode === 'installed') {
+      return variants.find(v => v.id === entry.installedVariantId) ?? null;
+    }
+    return (
+      variants.find(v => v.id === entry.recommendedVariantId) ??
+      variants.find(v => v.default) ??
+      null
+    );
+  }
+
+  // The region display for a variant-bearing entry's card: the variant's region
+  // name (localized), or the "Global" label when the variant is global.
+  function displayRegionName(variant: CatalogVariant | null): string {
+    if (!variant?.region) return t('analysis.gallery.regionGlobal');
+    return regionNameMap.get(variant.region) ?? variant.region;
+  }
   const availableWildlife = $derived(
     catalog.filter(e => !e.installed && e.category === 'wildlife')
   );
@@ -1927,6 +2056,35 @@
         </p>
       {/if}
 
+      <!-- Optimize banner: one or more installed models have a faster or
+           better-matched build available for this host. Dismissible for the
+           session; opens the review dialog. -->
+      {#if offers.length > 0 && !optimizeBannerDismissed}
+        <div
+          class="mb-4 flex flex-wrap items-center gap-3 rounded-lg border border-[var(--color-primary)]/30 bg-[var(--color-primary)]/10 px-4 py-3 text-sm"
+          role="status"
+        >
+          <Sparkles class="size-5 shrink-0 text-[var(--color-primary)]" aria-hidden="true" />
+          <p class="min-w-0 flex-1 font-medium text-[var(--color-base-content)]">
+            {t('analysis.gallery.optimize.bannerTitle', { count: offers.length })}
+          </p>
+          <button
+            type="button"
+            onclick={openOptimizeReview}
+            class="inline-flex items-center gap-1.5 rounded-md bg-[var(--color-primary)] px-3 py-1.5 text-xs font-medium text-[var(--color-primary-content)] transition-colors hover:bg-[var(--color-primary)]/80"
+          >
+            {t('analysis.gallery.optimize.review')}
+          </button>
+          <button
+            type="button"
+            onclick={dismissOptimizeBanner}
+            class="inline-flex items-center gap-1.5 rounded-md bg-[var(--color-base-200)] px-3 py-1.5 text-xs font-medium text-[var(--color-base-content)] transition-colors hover:bg-[var(--color-base-300)]"
+          >
+            {t('analysis.gallery.optimize.dismiss')}
+          </button>
+        </div>
+      {/if}
+
       <SettingsTabs tabs={galleryTabs} bind:activeTab={galleryTab} showActions={false} />
     </SettingsSection>
 
@@ -2003,6 +2161,43 @@
   </div>
 {/snippet}
 
+<!-- Variant-aware metadata rows for a gallery card: region, species count, and a
+     friendly hardware chip, all describing the RELEVANT variant (the installed one
+     on the Installed tab, the recommended one on the Available tab) rather than the
+     entry-level globals. Flat (variant-less) entries keep the entry region/species. -->
+{#snippet cardMetaRows(entry: CatalogEntry, mode: 'available' | 'installed')}
+  {@const dv = displayVariantFor(entry, mode)}
+  {#if entry.variants && entry.variants.length > 0}
+    <div class="text-[var(--color-base-content)]/80">{t('analysis.gallery.regionLabel')}</div>
+    <div class="text-[var(--color-base-content)]/80">{displayRegionName(dv)}</div>
+    <div class="text-[var(--color-base-content)]/80">{t('analysis.gallery.speciesLabel')}</div>
+    <div class="text-[var(--color-base-content)]/80">
+      {t('analysis.gallery.species', { count: dv?.speciesCount || entry.speciesCount })}
+    </div>
+    <div class="text-[var(--color-base-content)]/80">{t('analysis.gallery.hardwareLabel')}</div>
+    <div>
+      {#if dv}
+        <span
+          class="inline-flex items-center gap-1 rounded-full bg-[var(--color-base-300)] px-2 py-0.5 text-xs text-[var(--color-base-content)]"
+        >
+          {variantHardwareLabel(dv)}
+        </span>
+      {:else}
+        <span class="text-[var(--color-base-content)]/80">-</span>
+      {/if}
+    </div>
+  {:else}
+    {#if entry.region}
+      <div class="text-[var(--color-base-content)]/80">{t('analysis.gallery.regionLabel')}</div>
+      <div class="text-[var(--color-base-content)]/80">{entry.region}</div>
+    {/if}
+    <div class="text-[var(--color-base-content)]/80">{t('analysis.gallery.speciesLabel')}</div>
+    <div class="text-[var(--color-base-content)]/80">
+      {t('analysis.gallery.species', { count: entry.speciesCount })}
+    </div>
+  {/if}
+{/snippet}
+
 {#snippet installedTabContent()}
   <div class="space-y-4">
     {#if loading}
@@ -2016,38 +2211,10 @@
       {@render catalogErrorBanner()}
     {:else}
       <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-        <!-- Built-in BirdNET model (always present) -->
-        <div
-          class="rounded-lg border border-[var(--color-base-300)] bg-[var(--color-base-200)] p-4"
-        >
-          <div class="flex items-start gap-3">
-            <img src={logoBirdnet} alt="" class="size-10 shrink-0 rounded-lg" />
-            <div class="min-w-0 flex-1">
-              <h4 class="text-sm font-semibold text-[var(--color-base-content)]">BirdNET v2.4</h4>
-              <p class="mt-0.5 line-clamp-2 text-xs text-[var(--color-base-content)]/80">
-                {t('analysis.gallery.builtInDescription')}
-              </p>
-              <p class="mt-1 text-xs text-[var(--color-base-content)]/80">
-                Cornell Lab of Ornithology / Chemnitz University
-              </p>
-            </div>
-          </div>
-          <div
-            class="mt-3 flex items-center justify-between border-t border-[var(--color-base-300)] pt-3"
-          >
-            <div class="flex items-center gap-2 text-xs text-[var(--color-base-content)]/80">
-              <span>v2.4</span>
-              <span>{t('analysis.gallery.species', { count: '6,000+' })}</span>
-            </div>
-            <span
-              class="inline-flex items-center gap-1 rounded-full bg-[var(--color-primary)]/15 px-2.5 py-0.5 text-xs font-medium text-[var(--color-primary)]"
-            >
-              {t('analysis.gallery.builtIn')}
-            </span>
-          </div>
-        </div>
-
-        <!-- Installed additional models -->
+        <!-- Installed models. The permanent built-in classifier (BirdNET v2.4) sorts
+             first and renders a built-in badge instead of Remove/Reinstall; every
+             installed model with a better host-recommended variant shows an Optimize
+             action. -->
         {#each installedEntries as entry (entry.id)}
           {@const isDeleting = deletingId === entry.id}
           {@const isReinstalling = reinstallingId === entry.id}
@@ -2058,6 +2225,10 @@
                button's own running state. -->
           {@const reinstallPaused = galleryActionInFlight && !isReinstalling}
           {@const removePaused = galleryActionInFlight && !isDeleting}
+          {@const offer = offerByEntry.get(entry.id)}
+          {@const isSwapping = installingId === entry.id}
+          {@const optimizePaused = galleryActionInFlight && !isSwapping}
+          {@const cardProgress = reinstallProgress ?? (isSwapping ? downloadProgress : null)}
           {@const logo = getModelLogo(entry.id)}
           <div
             class="rounded-lg border border-[var(--color-base-300)] bg-[var(--color-base-200)] p-4"
@@ -2096,20 +2267,24 @@
               </div>
             </div>
             <!-- Progress bar (shown during reinstall, not for companion entries) -->
-            {#if reinstallProgress}
+            {#if cardProgress}
               <div class="mt-3 space-y-1.5">
-                {#if reinstallProgress.status === 'complete'}
+                {#if cardProgress.status === 'complete'}
                   <div
                     class="flex items-center gap-2 text-sm font-medium text-[var(--color-success)]"
                   >
                     <Check class="h-4 w-4" />
-                    <span>{t('analysis.gallery.reinstallComplete')}</span>
+                    <span
+                      >{isSwapping
+                        ? t('analysis.gallery.progress.complete')
+                        : t('analysis.gallery.reinstallComplete')}</span
+                    >
                   </div>
                 {:else}
                   <div class="h-2 w-full overflow-hidden rounded-full bg-[var(--color-base-300)]">
                     <div
                       class="h-full rounded-full bg-[var(--color-primary)] transition-all duration-300"
-                      style:width="{progressPercent(reinstallProgress)}%"
+                      style:width="{progressPercent(cardProgress)}%"
                     ></div>
                   </div>
                   <div
@@ -2117,15 +2292,15 @@
                   >
                     <span>
                       {statusLabel(
-                        reinstallProgress.status
-                      )}{#if reinstallProgress.status === 'downloading' && reinstallProgress.totalFiles > 1}
-                        ({reinstallProgress.currentFile}/{reinstallProgress.totalFiles})
+                        cardProgress.status
+                      )}{#if cardProgress.status === 'downloading' && cardProgress.totalFiles > 1}
+                        ({cardProgress.currentFile}/{cardProgress.totalFiles})
                       {/if}
                     </span>
-                    {#if reinstallProgress.status === 'downloading' && reinstallProgress.totalBytes > 0}
+                    {#if cardProgress.status === 'downloading' && cardProgress.totalBytes > 0}
                       <span>
-                        {formatBytes(reinstallProgress.downloadedBytes)} / {formatBytes(
-                          reinstallProgress.totalBytes
+                        {formatBytes(cardProgress.downloadedBytes)} / {formatBytes(
+                          cardProgress.totalBytes
                         )}
                       </span>
                     {/if}
@@ -2152,18 +2327,7 @@
             <div
               class="mt-3 grid grid-cols-2 gap-x-4 gap-y-1 border-t border-[var(--color-base-300)] pt-3 text-xs"
             >
-              {#if entry.region}
-                <div class="text-[var(--color-base-content)]/80">
-                  {t('analysis.gallery.regionLabel')}
-                </div>
-                <div class="text-[var(--color-base-content)]/80">{entry.region}</div>
-              {/if}
-              <div class="text-[var(--color-base-content)]/80">
-                {t('analysis.gallery.speciesLabel')}
-              </div>
-              <div class="text-[var(--color-base-content)]/80">
-                {t('analysis.gallery.species', { count: entry.speciesCount })}
-              </div>
+              {@render cardMetaRows(entry, 'installed')}
               <div class="text-[var(--color-base-content)]/80">
                 {t('analysis.gallery.license.license')}
               </div>
@@ -2197,66 +2361,114 @@
                 </span>
               </div>
             {/if}
-            <!-- Action footer -->
+            <!-- Optimize badge: a faster/better-matched build is available here. -->
+            {#if offer}
+              <div class="mt-2">
+                <span
+                  class="inline-flex items-center gap-1 rounded-full bg-[var(--color-primary)]/15 px-2.5 py-0.5 text-xs font-medium text-[var(--color-primary)]"
+                  title={t('analysis.gallery.optimize.badgeTitle')}
+                >
+                  <Sparkles class="size-3" aria-hidden="true" />
+                  {t('analysis.gallery.optimize.badgeTitle')}
+                </span>
+              </div>
+            {/if}
+            <!-- Action footer. The permanent built-in classifier shows a built-in
+                 badge instead of Remove and hides Reinstall; only its variant can be
+                 swapped (the Optimize action). -->
             <div class="mt-3 flex items-center justify-end gap-2">
-              <button
-                type="button"
-                onclick={e => {
-                  if (reinstallPaused) {
-                    e.preventDefault();
-                    return;
-                  }
-                  handleReinstall(entry);
-                }}
-                disabled={isReinstalling}
-                aria-disabled={reinstallPaused ? 'true' : undefined}
-                aria-describedby={reinstallPaused ? GALLERY_ACTION_STATUS_ID : undefined}
-                title={reinstallPaused ? t('analysis.gallery.actionInProgress') : undefined}
-                class={cn(
-                  'inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-[var(--color-base-content)]/80 transition-colors',
-                  isReinstalling || reinstallPaused
-                    ? 'opacity-50'
-                    : 'hover:bg-[var(--color-base-300)]',
-                  reinstallPaused && 'cursor-not-allowed'
-                )}
-                aria-label="{t('analysis.gallery.reinstall')} {entry.name}"
-              >
-                {#if isReinstalling}
-                  <Loader2 class="size-3.5 animate-spin" />
-                  {t('analysis.gallery.reinstalling')}
-                {:else}
-                  <RefreshCw class="size-3.5" />
-                  {t('analysis.gallery.reinstall')}
-                {/if}
-              </button>
-              <button
-                type="button"
-                onclick={e => {
-                  if (removePaused) {
-                    e.preventDefault();
-                    return;
-                  }
-                  openRemoveDialog(entry);
-                }}
-                disabled={isDeleting}
-                aria-disabled={removePaused ? 'true' : undefined}
-                aria-describedby={removePaused ? GALLERY_ACTION_STATUS_ID : undefined}
-                title={removePaused ? t('analysis.gallery.actionInProgress') : undefined}
-                class={cn(
-                  'inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-[var(--color-error)] transition-colors',
-                  isDeleting || removePaused ? 'opacity-50' : 'hover:bg-[var(--color-error)]/10',
-                  removePaused && 'cursor-not-allowed'
-                )}
-                aria-label="{t('analysis.gallery.remove')} {entry.name}"
-              >
-                {#if isDeleting}
-                  <Loader2 class="size-3.5 animate-spin" />
-                  {t('analysis.gallery.removing')}
-                {:else}
-                  <Trash2 class="size-3.5" />
-                  {t('analysis.gallery.remove')}
-                {/if}
-              </button>
+              {#if offer}
+                <button
+                  type="button"
+                  onclick={e => {
+                    if (optimizePaused) {
+                      e.preventDefault();
+                      return;
+                    }
+                    openLicenseDialog(entry);
+                  }}
+                  disabled={isSwapping}
+                  aria-disabled={optimizePaused ? 'true' : undefined}
+                  aria-describedby={optimizePaused ? GALLERY_ACTION_STATUS_ID : undefined}
+                  title={optimizePaused ? t('analysis.gallery.actionInProgress') : undefined}
+                  class={cn(
+                    'inline-flex items-center gap-1.5 rounded-md bg-[var(--color-primary)] px-2.5 py-1.5 text-xs font-medium text-[var(--color-primary-content)] transition-colors',
+                    optimizePaused
+                      ? 'cursor-not-allowed opacity-50'
+                      : 'hover:bg-[var(--color-primary)]/80'
+                  )}
+                  aria-label="{t('analysis.gallery.optimize.swap')} {entry.name}"
+                >
+                  <Sparkles class="size-3.5" aria-hidden="true" />
+                  {t('analysis.gallery.optimize.swap')}
+                </button>
+              {/if}
+              {#if entry.permanent}
+                <span
+                  class="inline-flex items-center gap-1 rounded-full bg-[var(--color-primary)]/15 px-2.5 py-0.5 text-xs font-medium text-[var(--color-primary)]"
+                >
+                  {t('analysis.gallery.builtIn')}
+                </span>
+              {:else}
+                <button
+                  type="button"
+                  onclick={e => {
+                    if (reinstallPaused) {
+                      e.preventDefault();
+                      return;
+                    }
+                    handleReinstall(entry);
+                  }}
+                  disabled={isReinstalling}
+                  aria-disabled={reinstallPaused ? 'true' : undefined}
+                  aria-describedby={reinstallPaused ? GALLERY_ACTION_STATUS_ID : undefined}
+                  title={reinstallPaused ? t('analysis.gallery.actionInProgress') : undefined}
+                  class={cn(
+                    'inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-[var(--color-base-content)]/80 transition-colors',
+                    isReinstalling || reinstallPaused
+                      ? 'opacity-50'
+                      : 'hover:bg-[var(--color-base-300)]',
+                    reinstallPaused && 'cursor-not-allowed'
+                  )}
+                  aria-label="{t('analysis.gallery.reinstall')} {entry.name}"
+                >
+                  {#if isReinstalling}
+                    <Loader2 class="size-3.5 animate-spin" />
+                    {t('analysis.gallery.reinstalling')}
+                  {:else}
+                    <RefreshCw class="size-3.5" />
+                    {t('analysis.gallery.reinstall')}
+                  {/if}
+                </button>
+                <button
+                  type="button"
+                  onclick={e => {
+                    if (removePaused) {
+                      e.preventDefault();
+                      return;
+                    }
+                    openRemoveDialog(entry);
+                  }}
+                  disabled={isDeleting}
+                  aria-disabled={removePaused ? 'true' : undefined}
+                  aria-describedby={removePaused ? GALLERY_ACTION_STATUS_ID : undefined}
+                  title={removePaused ? t('analysis.gallery.actionInProgress') : undefined}
+                  class={cn(
+                    'inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-[var(--color-error)] transition-colors',
+                    isDeleting || removePaused ? 'opacity-50' : 'hover:bg-[var(--color-error)]/10',
+                    removePaused && 'cursor-not-allowed'
+                  )}
+                  aria-label="{t('analysis.gallery.remove')} {entry.name}"
+                >
+                  {#if isDeleting}
+                    <Loader2 class="size-3.5 animate-spin" />
+                    {t('analysis.gallery.removing')}
+                  {:else}
+                    <Trash2 class="size-3.5" />
+                    {t('analysis.gallery.remove')}
+                  {/if}
+                </button>
+              {/if}
             </div>
           </div>
         {/each}
@@ -2378,14 +2590,7 @@
     <div
       class="mt-3 grid grid-cols-2 gap-x-4 gap-y-1 border-t border-[var(--color-base-300)] pt-3 text-xs"
     >
-      {#if entry.region}
-        <div class="text-[var(--color-base-content)]/80">{t('analysis.gallery.regionLabel')}</div>
-        <div class="text-[var(--color-base-content)]">{entry.region}</div>
-      {/if}
-      <div class="text-[var(--color-base-content)]/80">{t('analysis.gallery.speciesLabel')}</div>
-      <div class="text-[var(--color-base-content)]">
-        {t('analysis.gallery.species', { count: entry.speciesCount })}
-      </div>
+      {@render cardMetaRows(entry, 'available')}
       <div class="text-[var(--color-base-content)]/80">{t('analysis.gallery.license.license')}</div>
       <div>
         {#if entry.commercialUse}
@@ -2737,6 +2942,19 @@
     </div>
   {/if}
 </dialog>
+
+<!-- Optimize Review Dialog -->
+<OptimizeReviewDialog
+  open={optimizeReviewOpen}
+  {offers}
+  regionNames={regionNameMap}
+  inFlight={galleryActionInFlight}
+  applyingId={optimizeApplyingId}
+  appliedIds={appliedOptimizeIds}
+  onApply={applyOffer}
+  onApplyAll={applyAllOffers}
+  onClose={closeOptimizeReview}
+/>
 
 <!-- Range Filter Species Modal -->
 {#if rangeFilterState.showModal}

--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
@@ -405,7 +405,7 @@
   function applyNextInQueue() {
     while (applyAllQueue.length > 0) {
       const nextId = applyAllQueue[0];
-      const offer = offers.find(o => o.entry.id === nextId);
+      const offer = offerByEntry.get(nextId);
       if (offer && !appliedOptimizeIds.has(nextId)) {
         optimizeApplyingId = nextId;
         startInstall(offer.entry.id, offer.entry.name, offer.to.id);
@@ -2936,12 +2936,14 @@
 
       <div class="mt-6 flex justify-end gap-3">
         <button
+          type="button"
           onclick={closeRemoveDialog}
           class="rounded-lg border border-[var(--color-base-300)] px-4 py-2 text-sm font-medium text-[var(--color-base-content)] hover:bg-[var(--color-base-200)] transition-colors"
         >
           {t('common.cancel')}
         </button>
         <button
+          type="button"
           onclick={handleUninstall}
           class="inline-flex items-center gap-2 rounded-lg bg-[var(--color-error)] px-4 py-2 text-sm font-medium text-white hover:bg-[var(--color-error)]/80 transition-colors"
         >

--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
@@ -364,6 +364,9 @@
   // consent is needed beyond the review dialog itself.
   let optimizeReviewOpen = $state(false);
   let appliedOptimizeIds = $state(new Set<string>());
+  // Entry ids whose optimize swap failed this session (drives the dialog's per-row
+  // failed marker); the shared installError banner carries the detail.
+  let failedOptimizeIds = $state(new Set<string>());
   // The entry id whose optimize swap is in flight (drives the dialog's per-row
   // spinner) and the sequential apply-all queue of entry ids still to apply.
   let optimizeApplyingId = $state<string | null>(null);
@@ -379,9 +382,15 @@
     optimizeReviewOpen = false;
   }
 
-  // Apply one offer: start the within-model swap to its recommended variant.
+  // Apply one offer: start the within-model swap to its recommended variant. Clear
+  // any prior failed marker for it so a retry shows progress, not the stale failure.
   function applyOffer(offer: OptimizeOffer) {
     if (galleryActionInFlight) return;
+    if (failedOptimizeIds.has(offer.entry.id)) {
+      const next = new Set(failedOptimizeIds);
+      next.delete(offer.entry.id);
+      failedOptimizeIds = next;
+    }
     optimizeApplyingId = offer.entry.id;
     startInstall(offer.entry.id, offer.entry.name, offer.to.id);
   }
@@ -416,7 +425,8 @@
       const done = lastInstallingId;
       optimizeApplyingId = null;
       const failed = installError?.modelId === done;
-      if (!failed) appliedOptimizeIds = new Set(appliedOptimizeIds).add(done);
+      if (failed) failedOptimizeIds = new Set(failedOptimizeIds).add(done);
+      else appliedOptimizeIds = new Set(appliedOptimizeIds).add(done);
       if (applyAllQueue[0] === done) {
         applyAllQueue = applyAllQueue.slice(1);
         applyNextInQueue();
@@ -2951,6 +2961,7 @@
   inFlight={galleryActionInFlight}
   applyingId={optimizeApplyingId}
   appliedIds={appliedOptimizeIds}
+  failedIds={failedOptimizeIds}
   onApply={applyOffer}
   onApplyAll={applyAllOffers}
   onClose={closeOptimizeReview}

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -3963,6 +3963,26 @@ export type TranslationKey =
   | 'analysis.gallery.reinstallComplete'
   | 'analysis.gallery.geomodelBadge'
   | 'analysis.gallery.entryIncompatible'
+  | 'analysis.gallery.regionGlobal'
+  | 'analysis.gallery.hardwareLabel'
+  | 'analysis.gallery.hardware.gpu'
+  | 'analysis.gallery.hardware.intelGpu'
+  | 'analysis.gallery.hardware.armCpu'
+  | 'analysis.gallery.hardware.cpu'
+  | 'analysis.gallery.optimize.bannerTitle' // params: count
+  | 'analysis.gallery.optimize.review'
+  | 'analysis.gallery.optimize.dismiss'
+  | 'analysis.gallery.optimize.badgeTitle'
+  | 'analysis.gallery.optimize.swap'
+  | 'analysis.gallery.optimize.dialogTitle'
+  | 'analysis.gallery.optimize.fromTo' // params: from, to
+  | 'analysis.gallery.optimize.apply'
+  | 'analysis.gallery.optimize.applyAll'
+  | 'analysis.gallery.optimize.applying'
+  | 'analysis.gallery.optimize.applied'
+  | 'analysis.gallery.optimize.applyFailed'
+  | 'analysis.gallery.optimize.upToDate'
+  | 'analysis.gallery.optimize.licenseNote'
   | 'analysis.bird.title'
   | 'analysis.bird.description'
   | 'analysis.bat.title'
@@ -4511,6 +4531,8 @@ export type TranslationParams = {
   'analysis.gallery.species': { count: string | number };
   'analysis.gallery.removeDialog.title': { name: string | number };
   'analysis.gallery.errors.actionFailed': { name: string | number };
+  'analysis.gallery.optimize.bannerTitle': { count: string | number };
+  'analysis.gallery.optimize.fromTo': { from: string | number; to: string | number };
 };
 
 /**

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -3915,7 +3915,6 @@ export type TranslationKey =
   | 'analysis.gallery.loading'
   | 'analysis.gallery.retry'
   | 'analysis.gallery.builtIn'
-  | 'analysis.gallery.builtInDescription'
   | 'analysis.gallery.species' // params: count
   | 'analysis.gallery.install'
   | 'analysis.gallery.installing'

--- a/frontend/src/lib/types/models.ts
+++ b/frontend/src/lib/types/models.ts
@@ -27,6 +27,8 @@ export interface CatalogVariant {
   speciesCount: number;
   default: boolean;
   installed: boolean;
+  /** True for the embedded baseline variant (the built-in BirdNET v2.4 model); it carries no downloadable files. */
+  builtIn?: boolean;
   sizeBytes: number;
   headlineLatencyMs?: number;
   compatible: boolean;
@@ -53,6 +55,8 @@ export interface CatalogEntry {
   incompatibleReason?: string;
   totalSizeBytes: number;
   hasGeomodel: boolean;
+  /** True for the permanent built-in BirdNET v2.4 model: always installed, never uninstallable, only its variant may be swapped. */
+  permanent?: boolean;
   /** Selectable hardware/regional variants, absent for flat single-variant entries. */
   variants?: CatalogVariant[];
   /** The id of the currently installed variant, or absent when not installed or flat. */

--- a/frontend/src/lib/utils/variantSelection.test.ts
+++ b/frontend/src/lib/utils/variantSelection.test.ts
@@ -6,6 +6,9 @@ import {
   translateReason,
   topReasons,
   normalizeRegionMode,
+  variantHardwareClass,
+  variantHardwareLabel,
+  optimizeOffers,
 } from './variantSelection';
 import type { CatalogEntry, CatalogVariant, VariantReason } from '$lib/types/models';
 
@@ -195,6 +198,142 @@ describe('variantLabel', () => {
     expect(variantLabel(variant({ id: 'fp32@nordic', precision: 'fp32', region: 'nordic' }))).toBe(
       'FP32 (nordic)'
     );
+  });
+
+  it('returns the localized built-in label for a BuiltIn variant, not the raw id', () => {
+    expect(variantLabel(variant({ id: 'builtin', builtIn: true }))).toBe(
+      'analysis.gallery.builtIn'
+    );
+  });
+});
+
+describe('variantHardwareClass', () => {
+  it('classifies the BuiltIn baseline as built-in', () => {
+    expect(variantHardwareClass(variant({ id: 'builtin', builtIn: true }))).toBe('builtIn');
+  });
+
+  it('maps cuda/tensorrt backends to a discrete GPU', () => {
+    const cuda = variant({
+      id: 'fp32',
+      reasons: [{ code: 'backend.recommended', args: { backend: 'cuda' } }],
+    });
+    const trt = variant({
+      id: 'fp32',
+      reasons: [{ code: 'backend.recommended', args: { backend: 'tensorrt' } }],
+    });
+    expect(variantHardwareClass(cuda)).toBe('gpu');
+    expect(variantHardwareClass(trt)).toBe('gpu');
+  });
+
+  it('maps the openvino-gpu backend to an Intel GPU', () => {
+    const ov = variant({
+      id: 'fp32',
+      reasons: [{ code: 'backend.recommended', args: { backend: 'openvino-gpu' } }],
+    });
+    expect(variantHardwareClass(ov)).toBe('intelGpu');
+  });
+
+  it('prefers the recommended backend reason over any other backend reason', () => {
+    const v = variant({
+      id: 'fp32',
+      reasons: [
+        { code: 'backend.available', args: { backend: 'onnxruntime-cpu' } },
+        { code: 'backend.recommended', args: { backend: 'cuda' } },
+      ],
+    });
+    expect(variantHardwareClass(v)).toBe('gpu');
+  });
+
+  it('falls back to the id/precision when no backend reason is present', () => {
+    // An unauthenticated request carries no reasons: an "arm" id or int8 precision
+    // marks an ARM CPU build, everything else a generic CPU.
+    expect(variantHardwareClass(variant({ id: 'int8-arm-dfttrunc', precision: 'int8' }))).toBe(
+      'armCpu'
+    );
+    expect(variantHardwareClass(variant({ id: 'int8-something', precision: 'int8' }))).toBe(
+      'armCpu'
+    );
+    expect(variantHardwareClass(variant({ id: 'fp32-dfttrunc', precision: 'fp32' }))).toBe('cpu');
+  });
+});
+
+describe('variantHardwareLabel', () => {
+  it('uses the built-in label for the baseline and the hardware key otherwise', () => {
+    expect(variantHardwareLabel(variant({ id: 'builtin', builtIn: true }))).toBe(
+      'analysis.gallery.builtIn'
+    );
+    expect(
+      variantHardwareLabel(
+        variant({
+          id: 'fp32',
+          reasons: [{ code: 'backend.recommended', args: { backend: 'cuda' } }],
+        })
+      )
+    ).toBe('analysis.gallery.hardware.gpu');
+    expect(variantHardwareLabel(variant({ id: 'fp32-dfttrunc', precision: 'fp32' }))).toBe(
+      'analysis.gallery.hardware.cpu'
+    );
+  });
+});
+
+describe('optimizeOffers', () => {
+  // A permanent-style entry: installed on its BuiltIn baseline, with a faster DFT
+  // build recommended for this host.
+  function v24Entry(overrides: Partial<CatalogEntry> = {}): CatalogEntry {
+    return entry({
+      id: 'birdnet-v2.4',
+      installed: true,
+      permanent: true,
+      installedVariantId: 'builtin',
+      recommendedVariantId: 'fp32-dfttrunc',
+      variants: [
+        variant({ id: 'builtin', builtIn: true, default: true, installed: true }),
+        variant({
+          id: 'fp32-dfttrunc',
+          precision: 'fp32',
+          compatible: true,
+          recommended: true,
+          reasons: [{ code: 'backend.recommended', args: { backend: 'onnxruntime-cpu' } }],
+        }),
+      ],
+      ...overrides,
+    });
+  }
+
+  it('offers a swap when the recommended variant differs from the installed one', () => {
+    const offers = optimizeOffers([v24Entry()]);
+    expect(offers).toHaveLength(1);
+    expect(offers[0].entry.id).toBe('birdnet-v2.4');
+    expect(offers[0].from.id).toBe('builtin');
+    expect(offers[0].to.id).toBe('fp32-dfttrunc');
+    expect(offers[0].reasons.length).toBeGreaterThan(0);
+  });
+
+  it('makes no offer when the installed variant is already the recommended one', () => {
+    const e = v24Entry({ installedVariantId: 'fp32-dfttrunc' });
+    expect(optimizeOffers([e])).toHaveLength(0);
+  });
+
+  it('makes no offer when the recommended variant is incompatible', () => {
+    const e = v24Entry();
+    const rec = e.variants?.find(v => v.id === 'fp32-dfttrunc');
+    if (rec) rec.compatible = false;
+    expect(optimizeOffers([e])).toHaveLength(0);
+  });
+
+  it('makes no offer for a flat (variant-less) entry', () => {
+    const flat = entry({ id: 'geo', installed: true, recommendedVariantId: undefined });
+    expect(optimizeOffers([flat])).toHaveLength(0);
+  });
+
+  it('makes no offer when there is no recommendation (e.g. an unauthenticated request)', () => {
+    const e = v24Entry({ recommendedVariantId: undefined });
+    expect(optimizeOffers([e])).toHaveLength(0);
+  });
+
+  it('makes no offer for an entry that is not installed', () => {
+    const e = v24Entry({ installed: false });
+    expect(optimizeOffers([e])).toHaveLength(0);
   });
 });
 

--- a/frontend/src/lib/utils/variantSelection.test.ts
+++ b/frontend/src/lib/utils/variantSelection.test.ts
@@ -244,15 +244,14 @@ describe('variantHardwareClass', () => {
     expect(variantHardwareClass(v)).toBe('gpu');
   });
 
-  it('falls back to the id/precision when no backend reason is present', () => {
-    // An unauthenticated request carries no reasons: an "arm" id or int8 precision
-    // marks an ARM CPU build, everything else a generic CPU.
+  it('falls back to the id when no backend reason is present, using only the arm token', () => {
+    // An unauthenticated request carries no reasons: an "arm" id marks an ARM CPU
+    // build, everything else a generic CPU. Precision alone is NOT used: an INT8 id
+    // without "arm" (e.g. a future x86 INT8 build) must not be mislabeled ARM.
     expect(variantHardwareClass(variant({ id: 'int8-arm-dfttrunc', precision: 'int8' }))).toBe(
       'armCpu'
     );
-    expect(variantHardwareClass(variant({ id: 'int8-something', precision: 'int8' }))).toBe(
-      'armCpu'
-    );
+    expect(variantHardwareClass(variant({ id: 'int8-x86', precision: 'int8' }))).toBe('cpu');
     expect(variantHardwareClass(variant({ id: 'fp32-dfttrunc', precision: 'fp32' }))).toBe('cpu');
   });
 });
@@ -304,7 +303,7 @@ describe('optimizeOffers', () => {
     const offers = optimizeOffers([v24Entry()]);
     expect(offers).toHaveLength(1);
     expect(offers[0].entry.id).toBe('birdnet-v2.4');
-    expect(offers[0].from.id).toBe('builtin');
+    expect(offers[0].from?.id).toBe('builtin');
     expect(offers[0].to.id).toBe('fp32-dfttrunc');
     expect(offers[0].reasons.length).toBeGreaterThan(0);
   });
@@ -334,6 +333,17 @@ describe('optimizeOffers', () => {
   it('makes no offer for an entry that is not installed', () => {
     const e = v24Entry({ installed: false });
     expect(optimizeOffers([e])).toHaveLength(0);
+  });
+
+  it('still offers a swap when the installed variant was dropped from the catalog', () => {
+    // The installed variant id no longer matches any catalog variant (deprecated and
+    // removed): the offer must still surface so the user moves off the dead variant,
+    // with a null `from` (its label is unavailable).
+    const e = v24Entry({ installedVariantId: 'legacy-gone' });
+    const offers = optimizeOffers([e]);
+    expect(offers).toHaveLength(1);
+    expect(offers[0].from).toBeNull();
+    expect(offers[0].to.id).toBe('fp32-dfttrunc');
   });
 });
 

--- a/frontend/src/lib/utils/variantSelection.ts
+++ b/frontend/src/lib/utils/variantSelection.ts
@@ -103,6 +103,9 @@ export function variantLabel(
   variant: CatalogVariant,
   regionNames?: ReadonlyMap<string, string>
 ): string {
+  // The embedded baseline carries no precision or descriptive id ("builtin"), so
+  // give it its own localized label rather than showing the raw id.
+  if (variant.builtIn) return t('analysis.gallery.builtIn');
   const precision = variant.precision?.toUpperCase() ?? '';
   // Derive the non-precision descriptor from the id. Strip any "@region" suffix
   // first (the region is appended separately) so a regional id like
@@ -124,6 +127,96 @@ export function variantLabel(
   // it is not.
   const regionDisplay = regionNames?.get(variant.region) ?? variant.region;
   return `${base} (${regionDisplay})`;
+}
+
+/**
+ * A friendly hardware class for a variant, used to render a hardware chip on the
+ * gallery card. 'builtIn' is the embedded baseline; the rest describe the execution
+ * target the variant is recommended for on this host.
+ */
+export type VariantHardwareClass = 'builtIn' | 'gpu' | 'intelGpu' | 'armCpu' | 'cpu';
+
+/**
+ * The recommended (or otherwise chosen) execution backend token for a variant,
+ * taken from its recommendation reasons. Prefers the `backend.recommended` reason,
+ * then any reason carrying a `backend` arg. Returns undefined when the request was
+ * not eligible for recommendations (no reasons), so callers fall back to id parsing.
+ */
+function chosenBackendToken(variant: CatalogVariant): string | undefined {
+  const reasons = variant.reasons ?? [];
+  const recommended = reasons.find(r => r.code === 'backend.recommended' && r.args?.backend);
+  if (recommended?.args?.backend) return recommended.args.backend;
+  const anyBackend = reasons.find(r => r.args?.backend);
+  return anyBackend?.args?.backend;
+}
+
+/**
+ * Derive a friendly hardware class for a variant entirely client-side. The BuiltIn
+ * baseline is its own class. Otherwise the chosen backend token decides: a CUDA or
+ * TensorRT path is a discrete GPU, an OpenVINO GPU path is an Intel GPU. When no
+ * backend token is available (an unauthenticated request carries no reasons), the
+ * variant id/precision is the fallback: an "arm" descriptor or INT8 precision marks
+ * an ARM CPU build, everything else is a generic CPU.
+ */
+export function variantHardwareClass(variant: CatalogVariant): VariantHardwareClass {
+  if (variant.builtIn) return 'builtIn';
+  const backend = chosenBackendToken(variant);
+  if (backend === 'cuda' || backend === 'tensorrt') return 'gpu';
+  if (backend === 'openvino-gpu') return 'intelGpu';
+  const id = variant.id.toLowerCase();
+  if (id.includes('arm') || variant.precision?.toLowerCase() === 'int8') return 'armCpu';
+  return 'cpu';
+}
+
+/**
+ * Localized hardware chip label for a variant. The BuiltIn baseline uses the
+ * built-in label; every other class maps to `analysis.gallery.hardware.<class>`.
+ */
+export function variantHardwareLabel(variant: CatalogVariant): string {
+  const cls = variantHardwareClass(variant);
+  if (cls === 'builtIn') return t('analysis.gallery.builtIn');
+  return t(`analysis.gallery.hardware.${cls}`);
+}
+
+/**
+ * A within-model "optimize" offer: an installed model whose recommended variant for
+ * this host differs from the installed one and is compatible. `from` is the
+ * installed variant, `to` the recommended one, and `reasons` the localized headline
+ * reasons for the recommendation. Offers are always same-model (a better build of a
+ * model the user already has), never cross-model.
+ */
+export interface OptimizeOffer {
+  entry: CatalogEntry;
+  from: CatalogVariant;
+  to: CatalogVariant;
+  reasons: string[];
+}
+
+/**
+ * Derive the within-model optimize offers from the catalog, entirely client-side.
+ * An entry qualifies when it is installed, carries variants, its installed variant
+ * differs from the host-recommended variant, and that recommended variant is
+ * compatible and present in the list. The permanent BirdNET v2.4 model participates
+ * like any other installed model (its BuiltIn baseline is the installed variant when
+ * no DFT build is active).
+ */
+export function optimizeOffers(catalog: CatalogEntry[]): OptimizeOffer[] {
+  const offers: OptimizeOffer[] = [];
+  for (const entry of catalog) {
+    const variants = entry.variants ?? [];
+    if (variants.length === 0 || !entry.installed) continue;
+
+    const installedId = entry.installedVariantId;
+    const recommendedId = entry.recommendedVariantId;
+    if (!installedId || !recommendedId || installedId === recommendedId) continue;
+
+    const to = variants.find(v => v.id === recommendedId);
+    const from = variants.find(v => v.id === installedId);
+    if (!to || !from || !to.compatible) continue;
+
+    offers.push({ entry, from, to, reasons: topReasons(to.reasons) });
+  }
+  return offers;
 }
 
 /**

--- a/frontend/src/lib/utils/variantSelection.ts
+++ b/frontend/src/lib/utils/variantSelection.ts
@@ -155,16 +155,17 @@ function chosenBackendToken(variant: CatalogVariant): string | undefined {
  * baseline is its own class. Otherwise the chosen backend token decides: a CUDA or
  * TensorRT path is a discrete GPU, an OpenVINO GPU path is an Intel GPU. When no
  * backend token is available (an unauthenticated request carries no reasons), the
- * variant id/precision is the fallback: an "arm" descriptor or INT8 precision marks
- * an ARM CPU build, everything else is a generic CPU.
+ * variant id is the fallback: an "arm" descriptor marks an ARM CPU build, everything
+ * else is a generic CPU. Precision alone is NOT used: an INT8 build is not
+ * necessarily ARM (a future x86 INT8 variant would be mislabeled), so only the
+ * explicit "arm" token in the id classifies as ARM.
  */
 export function variantHardwareClass(variant: CatalogVariant): VariantHardwareClass {
   if (variant.builtIn) return 'builtIn';
   const backend = chosenBackendToken(variant);
   if (backend === 'cuda' || backend === 'tensorrt') return 'gpu';
   if (backend === 'openvino-gpu') return 'intelGpu';
-  const id = variant.id.toLowerCase();
-  if (id.includes('arm') || variant.precision?.toLowerCase() === 'int8') return 'armCpu';
+  if (variant.id.toLowerCase().includes('arm')) return 'armCpu';
   return 'cpu';
 }
 
@@ -187,7 +188,13 @@ export function variantHardwareLabel(variant: CatalogVariant): string {
  */
 export interface OptimizeOffer {
   entry: CatalogEntry;
-  from: CatalogVariant;
+  /**
+   * The installed variant being replaced, or null when the installed variant id is
+   * no longer in the catalog (a build deprecated and dropped). The offer still
+   * surfaces in that case, precisely so the user can move off the dead variant; only
+   * the "from" label is unavailable.
+   */
+  from: CatalogVariant | null;
   to: CatalogVariant;
   reasons: string[];
 }
@@ -211,8 +218,10 @@ export function optimizeOffers(catalog: CatalogEntry[]): OptimizeOffer[] {
     if (!installedId || !recommendedId || installedId === recommendedId) continue;
 
     const to = variants.find(v => v.id === recommendedId);
-    const from = variants.find(v => v.id === installedId);
-    if (!to || !from || !to.compatible) continue;
+    if (!to?.compatible) continue;
+    // `from` may be absent when the installed variant was dropped from the catalog;
+    // the offer still stands (move off the dead variant onto the recommendation).
+    const from = variants.find(v => v.id === installedId) ?? null;
 
     offers.push({ entry, from, to, reasons: topReasons(to.reasons) });
   }

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -5423,7 +5423,31 @@
       "reinstalling": "Přeinstalování…",
       "reinstallComplete": "Soubory úspěšně ověřeny",
       "geomodelBadge": "Obsahuje BirdNET v3.0 geomodel",
-      "entryIncompatible": "Tento model není v tomto systému k dispozici."
+      "entryIncompatible": "Tento model není v tomto systému k dispozici.",
+      "regionGlobal": "Global",
+      "hardwareLabel": "Hardware",
+      "hardware": {
+        "gpu": "GPU",
+        "intelGpu": "Intel GPU",
+        "armCpu": "ARM CPU",
+        "cpu": "CPU"
+      },
+      "optimize": {
+        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
+        "review": "Review",
+        "dismiss": "Dismiss",
+        "badgeTitle": "A faster build is available for your hardware",
+        "swap": "Optimize",
+        "dialogTitle": "Optimize your models",
+        "fromTo": "{from} to {to}",
+        "apply": "Apply",
+        "applyAll": "Apply all",
+        "applying": "Applying...",
+        "applied": "Applied",
+        "applyFailed": "Failed to apply",
+        "upToDate": "All your models are already optimized for this hardware.",
+        "licenseNote": "Swapping stays within the same model, so its license does not change."
+      }
     },
     "bird": {
       "title": "Detekce ptáků",

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -5364,7 +5364,6 @@
       "loading": "Načítání modelů…",
       "retry": "Zkusit znovu",
       "builtIn": "Vestavěný",
-      "builtInDescription": "Vestavěný klasifikátor ptačích druhů od týmu BirdNET.",
       "species": "{count} druhů",
       "install": "Nainstalovat",
       "installing": "Instaluji…",

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -5424,7 +5424,7 @@
       "reinstallComplete": "Soubory úspěšně ověřeny",
       "geomodelBadge": "Obsahuje BirdNET v3.0 geomodel",
       "entryIncompatible": "Tento model není v tomto systému k dispozici.",
-      "regionGlobal": "Global",
+      "regionGlobal": "Globální",
       "hardwareLabel": "Hardware",
       "hardware": {
         "gpu": "GPU",
@@ -5433,20 +5433,20 @@
         "cpu": "CPU"
       },
       "optimize": {
-        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
-        "review": "Review",
-        "dismiss": "Dismiss",
-        "badgeTitle": "A faster build is available for your hardware",
-        "swap": "Optimize",
-        "dialogTitle": "Optimize your models",
-        "fromTo": "{from} to {to}",
-        "apply": "Apply",
-        "applyAll": "Apply all",
-        "applying": "Applying...",
-        "applied": "Applied",
-        "applyFailed": "Failed to apply",
-        "upToDate": "All your models are already optimized for this hardware.",
-        "licenseNote": "Swapping stays within the same model, so its license does not change."
+        "bannerTitle": "{count, plural, one {# model může běžet rychleji na vašem hardwaru} few {# modely mohou běžet rychleji na vašem hardwaru} many {# modelů může běžet rychleji na vašem hardwaru} other {# modelů může běžet rychleji na vašem hardwaru}}",
+        "review": "Zkontrolovat",
+        "dismiss": "Zavřít",
+        "badgeTitle": "Pro váš hardware je k dispozici rychlejší sestavení",
+        "swap": "Optimalizovat",
+        "dialogTitle": "Optimalizovat modely",
+        "fromTo": "{from} na {to}",
+        "apply": "Použít",
+        "applyAll": "Použít vše",
+        "applying": "Aplikování...",
+        "applied": "Použito",
+        "applyFailed": "Použití se nezdařilo",
+        "upToDate": "Všechny vaše modely jsou již pro tento hardware optimalizovány.",
+        "licenseNote": "Záměna probíhá v rámci stejného modelu, takže se jeho licence nemění."
       }
     },
     "bird": {

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -5423,7 +5423,31 @@
       "reinstalling": "Geninstallerer...",
       "reinstallComplete": "Filer verificeret succesfuldt",
       "geomodelBadge": "Inkluderer BirdNET v3.0 geomodel",
-      "entryIncompatible": "Denne model er ikke tilgængelig på dette system."
+      "entryIncompatible": "Denne model er ikke tilgængelig på dette system.",
+      "regionGlobal": "Global",
+      "hardwareLabel": "Hardware",
+      "hardware": {
+        "gpu": "GPU",
+        "intelGpu": "Intel GPU",
+        "armCpu": "ARM CPU",
+        "cpu": "CPU"
+      },
+      "optimize": {
+        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
+        "review": "Review",
+        "dismiss": "Dismiss",
+        "badgeTitle": "A faster build is available for your hardware",
+        "swap": "Optimize",
+        "dialogTitle": "Optimize your models",
+        "fromTo": "{from} to {to}",
+        "apply": "Apply",
+        "applyAll": "Apply all",
+        "applying": "Applying...",
+        "applied": "Applied",
+        "applyFailed": "Failed to apply",
+        "upToDate": "All your models are already optimized for this hardware.",
+        "licenseNote": "Swapping stays within the same model, so its license does not change."
+      }
     },
     "bird": {
       "title": "Fugleregistrering",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -5364,7 +5364,6 @@
       "loading": "Indlæser modeller...",
       "retry": "Prøv igen",
       "builtIn": "Indbygget",
-      "builtInDescription": "Indbygget fuglearts-klassifikator fra BirdNET-teamet.",
       "species": "{count} arter",
       "install": "Installer",
       "installing": "Installerer...",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -5433,20 +5433,20 @@
         "cpu": "CPU"
       },
       "optimize": {
-        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
-        "review": "Review",
-        "dismiss": "Dismiss",
-        "badgeTitle": "A faster build is available for your hardware",
-        "swap": "Optimize",
-        "dialogTitle": "Optimize your models",
-        "fromTo": "{from} to {to}",
-        "apply": "Apply",
-        "applyAll": "Apply all",
-        "applying": "Applying...",
-        "applied": "Applied",
-        "applyFailed": "Failed to apply",
-        "upToDate": "All your models are already optimized for this hardware.",
-        "licenseNote": "Swapping stays within the same model, so its license does not change."
+        "bannerTitle": "{count, plural, one {# model kan køre hurtigere på din hardware} other {# modeller kan køre hurtigere på din hardware}}",
+        "review": "Gennemgå",
+        "dismiss": "Afvis",
+        "badgeTitle": "Et hurtigere build er tilgængeligt til din hardware",
+        "swap": "Optimer",
+        "dialogTitle": "Optimer dine modeller",
+        "fromTo": "{from} til {to}",
+        "apply": "Anvend",
+        "applyAll": "Anvend alle",
+        "applying": "Anvender...",
+        "applied": "Anvendt",
+        "applyFailed": "Kunne ikke anvende",
+        "upToDate": "Alle dine modeller er allerede optimeret til denne hardware.",
+        "licenseNote": "Udskiftning forbliver inden for den samme model, så licensen ændres ikke."
       }
     },
     "bird": {

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -5433,20 +5433,20 @@
         "cpu": "CPU"
       },
       "optimize": {
-        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
-        "review": "Review",
-        "dismiss": "Dismiss",
-        "badgeTitle": "A faster build is available for your hardware",
-        "swap": "Optimize",
-        "dialogTitle": "Optimize your models",
-        "fromTo": "{from} to {to}",
-        "apply": "Apply",
-        "applyAll": "Apply all",
-        "applying": "Applying...",
-        "applied": "Applied",
-        "applyFailed": "Failed to apply",
-        "upToDate": "All your models are already optimized for this hardware.",
-        "licenseNote": "Swapping stays within the same model, so its license does not change."
+        "bannerTitle": "{count, plural, one {# Modell kann auf Ihrer Hardware schneller ausgeführt werden} other {# Modelle können auf Ihrer Hardware schneller ausgeführt werden}}",
+        "review": "Überprüfen",
+        "dismiss": "Verwerfen",
+        "badgeTitle": "Für Ihre Hardware ist ein schnellerer Build verfügbar",
+        "swap": "Optimieren",
+        "dialogTitle": "Modelle optimieren",
+        "fromTo": "{from} zu {to}",
+        "apply": "Anwenden",
+        "applyAll": "Alle anwenden",
+        "applying": "Wird angewendet...",
+        "applied": "Angewendet",
+        "applyFailed": "Fehler beim Anwenden",
+        "upToDate": "Alle Ihre Modelle sind für diese Hardware bereits optimiert.",
+        "licenseNote": "Der Wechsel erfolgt innerhalb desselben Modells, daher ändert sich die Lizenz nicht."
       }
     },
     "bird": {

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -5364,7 +5364,6 @@
       "loading": "Modelle werden geladen...",
       "retry": "Wiederholen",
       "builtIn": "Integriert",
-      "builtInDescription": "Integrierter Vogelartenklassifikator des BirdNET-Teams.",
       "species": "{count} Arten",
       "install": "Installieren",
       "installing": "Wird installiert...",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -5423,7 +5423,31 @@
       "reinstalling": "Wird neu installiert...",
       "reinstallComplete": "Dateien erfolgreich überprüft",
       "geomodelBadge": "Enthält BirdNET v3.0 Geomodell",
-      "entryIncompatible": "Dieses Modell ist auf diesem System nicht verfügbar."
+      "entryIncompatible": "Dieses Modell ist auf diesem System nicht verfügbar.",
+      "regionGlobal": "Global",
+      "hardwareLabel": "Hardware",
+      "hardware": {
+        "gpu": "GPU",
+        "intelGpu": "Intel GPU",
+        "armCpu": "ARM CPU",
+        "cpu": "CPU"
+      },
+      "optimize": {
+        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
+        "review": "Review",
+        "dismiss": "Dismiss",
+        "badgeTitle": "A faster build is available for your hardware",
+        "swap": "Optimize",
+        "dialogTitle": "Optimize your models",
+        "fromTo": "{from} to {to}",
+        "apply": "Apply",
+        "applyAll": "Apply all",
+        "applying": "Applying...",
+        "applied": "Applied",
+        "applyFailed": "Failed to apply",
+        "upToDate": "All your models are already optimized for this hardware.",
+        "licenseNote": "Swapping stays within the same model, so its license does not change."
+      }
     },
     "bird": {
       "title": "Vogelerkennung",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -5423,7 +5423,31 @@
       "reinstalling": "Reinstalling...",
       "reinstallComplete": "Files verified successfully",
       "geomodelBadge": "Includes BirdNET v3.0 geomodel",
-      "entryIncompatible": "This model is not available on this system."
+      "entryIncompatible": "This model is not available on this system.",
+      "regionGlobal": "Global",
+      "hardwareLabel": "Hardware",
+      "hardware": {
+        "gpu": "GPU",
+        "intelGpu": "Intel GPU",
+        "armCpu": "ARM CPU",
+        "cpu": "CPU"
+      },
+      "optimize": {
+        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
+        "review": "Review",
+        "dismiss": "Dismiss",
+        "badgeTitle": "A faster build is available for your hardware",
+        "swap": "Optimize",
+        "dialogTitle": "Optimize your models",
+        "fromTo": "{from} to {to}",
+        "apply": "Apply",
+        "applyAll": "Apply all",
+        "applying": "Applying...",
+        "applied": "Applied",
+        "applyFailed": "Failed to apply",
+        "upToDate": "All your models are already optimized for this hardware.",
+        "licenseNote": "Swapping stays within the same model, so its license does not change."
+      }
     },
     "bird": {
       "title": "Bird Detection",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -5364,7 +5364,6 @@
       "loading": "Loading models...",
       "retry": "Retry",
       "builtIn": "Built-in",
-      "builtInDescription": "Built-in bird species classifier by the BirdNET team.",
       "species": "{count} species",
       "install": "Install",
       "installing": "Installing...",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -5423,7 +5423,31 @@
       "reinstalling": "Reinstalando...",
       "reinstallComplete": "Archivos verificados correctamente",
       "geomodelBadge": "Incluye BirdNET v3.0 geomodel",
-      "entryIncompatible": "Este modelo no está disponible en este sistema."
+      "entryIncompatible": "Este modelo no está disponible en este sistema.",
+      "regionGlobal": "Global",
+      "hardwareLabel": "Hardware",
+      "hardware": {
+        "gpu": "GPU",
+        "intelGpu": "Intel GPU",
+        "armCpu": "ARM CPU",
+        "cpu": "CPU"
+      },
+      "optimize": {
+        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
+        "review": "Review",
+        "dismiss": "Dismiss",
+        "badgeTitle": "A faster build is available for your hardware",
+        "swap": "Optimize",
+        "dialogTitle": "Optimize your models",
+        "fromTo": "{from} to {to}",
+        "apply": "Apply",
+        "applyAll": "Apply all",
+        "applying": "Applying...",
+        "applied": "Applied",
+        "applyFailed": "Failed to apply",
+        "upToDate": "All your models are already optimized for this hardware.",
+        "licenseNote": "Swapping stays within the same model, so its license does not change."
+      }
     },
     "bird": {
       "title": "Detección de aves",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -5433,20 +5433,20 @@
         "cpu": "CPU"
       },
       "optimize": {
-        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
-        "review": "Review",
-        "dismiss": "Dismiss",
-        "badgeTitle": "A faster build is available for your hardware",
-        "swap": "Optimize",
-        "dialogTitle": "Optimize your models",
-        "fromTo": "{from} to {to}",
-        "apply": "Apply",
-        "applyAll": "Apply all",
-        "applying": "Applying...",
-        "applied": "Applied",
-        "applyFailed": "Failed to apply",
-        "upToDate": "All your models are already optimized for this hardware.",
-        "licenseNote": "Swapping stays within the same model, so its license does not change."
+        "bannerTitle": "{count, plural, one {# modelo puede funcionar más rápido en tu hardware} other {# modelos pueden funcionar más rápido en tu hardware}}",
+        "review": "Revisar",
+        "dismiss": "Descartar",
+        "badgeTitle": "Hay una compilación más rápida disponible para tu hardware",
+        "swap": "Optimizar",
+        "dialogTitle": "Optimizar tus modelos",
+        "fromTo": "{from} a {to}",
+        "apply": "Aplicar",
+        "applyAll": "Aplicar todo",
+        "applying": "Aplicando...",
+        "applied": "Aplicado",
+        "applyFailed": "Error al aplicar",
+        "upToDate": "Todos tus modelos ya están optimizados para este hardware.",
+        "licenseNote": "El cambio se realiza dentro del mismo modelo, por lo que su licencia no cambia."
       }
     },
     "bird": {

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -5364,7 +5364,6 @@
       "loading": "Cargando modelos...",
       "retry": "Reintentar",
       "builtIn": "Integrado",
-      "builtInDescription": "Clasificador de especies de aves integrado del equipo BirdNET.",
       "species": "{count} especies",
       "install": "Instalar",
       "installing": "Instalando...",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -5364,7 +5364,6 @@
       "loading": "Ladataan malleja...",
       "retry": "Yritä uudelleen",
       "builtIn": "Sisäänrakennettu",
-      "builtInDescription": "BirdNET-tiimin sisäänrakennettu lintulajien luokittelija.",
       "species": "{count} lajia",
       "install": "Asenna",
       "installing": "Asennetaan...",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -5423,7 +5423,31 @@
       "reinstalling": "Asennetaan uudelleen...",
       "reinstallComplete": "Tiedostot tarkistettu onnistuneesti",
       "geomodelBadge": "Sisältää BirdNET v3.0 -geomallin",
-      "entryIncompatible": "Tämä malli ei ole saatavilla tässä järjestelmässä."
+      "entryIncompatible": "Tämä malli ei ole saatavilla tässä järjestelmässä.",
+      "regionGlobal": "Global",
+      "hardwareLabel": "Hardware",
+      "hardware": {
+        "gpu": "GPU",
+        "intelGpu": "Intel GPU",
+        "armCpu": "ARM CPU",
+        "cpu": "CPU"
+      },
+      "optimize": {
+        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
+        "review": "Review",
+        "dismiss": "Dismiss",
+        "badgeTitle": "A faster build is available for your hardware",
+        "swap": "Optimize",
+        "dialogTitle": "Optimize your models",
+        "fromTo": "{from} to {to}",
+        "apply": "Apply",
+        "applyAll": "Apply all",
+        "applying": "Applying...",
+        "applied": "Applied",
+        "applyFailed": "Failed to apply",
+        "upToDate": "All your models are already optimized for this hardware.",
+        "licenseNote": "Swapping stays within the same model, so its license does not change."
+      }
     },
     "bird": {
       "title": "Lintuhavainnot",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -5424,8 +5424,8 @@
       "reinstallComplete": "Tiedostot tarkistettu onnistuneesti",
       "geomodelBadge": "Sisältää BirdNET v3.0 -geomallin",
       "entryIncompatible": "Tämä malli ei ole saatavilla tässä järjestelmässä.",
-      "regionGlobal": "Global",
-      "hardwareLabel": "Hardware",
+      "regionGlobal": "Globaali",
+      "hardwareLabel": "Laitteisto",
       "hardware": {
         "gpu": "GPU",
         "intelGpu": "Intel GPU",
@@ -5433,20 +5433,20 @@
         "cpu": "CPU"
       },
       "optimize": {
-        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
-        "review": "Review",
-        "dismiss": "Dismiss",
-        "badgeTitle": "A faster build is available for your hardware",
-        "swap": "Optimize",
-        "dialogTitle": "Optimize your models",
-        "fromTo": "{from} to {to}",
-        "apply": "Apply",
-        "applyAll": "Apply all",
-        "applying": "Applying...",
-        "applied": "Applied",
-        "applyFailed": "Failed to apply",
-        "upToDate": "All your models are already optimized for this hardware.",
-        "licenseNote": "Swapping stays within the same model, so its license does not change."
+        "bannerTitle": "{count, plural, one {# malli voi toimia nopeammin laitteistollasi} other {# mallia voi toimia nopeammin laitteistollasi}}",
+        "review": "Tarkista",
+        "dismiss": "Hylkää",
+        "badgeTitle": "Laitteistollesi on saatavilla nopeampi versio",
+        "swap": "Optimoi",
+        "dialogTitle": "Optimoi mallisi",
+        "fromTo": "{from} -> {to}",
+        "apply": "Käytä",
+        "applyAll": "Käytä kaikkia",
+        "applying": "Käytetään...",
+        "applied": "Käytetty",
+        "applyFailed": "Käyttö epäonnistui",
+        "upToDate": "Kaikki mallisi on jo optimoitu tälle laitteistolle.",
+        "licenseNote": "Vaihto tapahtuu saman mallin sisällä, joten sen lisenssi ei muutu."
       }
     },
     "bird": {

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -5425,7 +5425,7 @@
       "geomodelBadge": "Inclut le BirdNET v3.0 geomodel",
       "entryIncompatible": "Ce modèle n'est pas disponible sur ce système.",
       "regionGlobal": "Global",
-      "hardwareLabel": "Hardware",
+      "hardwareLabel": "Matériel",
       "hardware": {
         "gpu": "GPU",
         "intelGpu": "Intel GPU",
@@ -5433,20 +5433,20 @@
         "cpu": "CPU"
       },
       "optimize": {
-        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
-        "review": "Review",
-        "dismiss": "Dismiss",
-        "badgeTitle": "A faster build is available for your hardware",
-        "swap": "Optimize",
-        "dialogTitle": "Optimize your models",
-        "fromTo": "{from} to {to}",
-        "apply": "Apply",
-        "applyAll": "Apply all",
-        "applying": "Applying...",
-        "applied": "Applied",
-        "applyFailed": "Failed to apply",
-        "upToDate": "All your models are already optimized for this hardware.",
-        "licenseNote": "Swapping stays within the same model, so its license does not change."
+        "bannerTitle": "{count, plural, one {# modèle peut fonctionner plus rapidement sur votre matériel} other {# modèles peuvent fonctionner plus rapidement sur votre matériel}}",
+        "review": "Examiner",
+        "dismiss": "Ignorer",
+        "badgeTitle": "Une version plus rapide est disponible pour votre matériel",
+        "swap": "Optimiser",
+        "dialogTitle": "Optimiser vos modèles",
+        "fromTo": "{from} vers {to}",
+        "apply": "Appliquer",
+        "applyAll": "Tout appliquer",
+        "applying": "Application...",
+        "applied": "Appliqué",
+        "applyFailed": "Échec de l'application",
+        "upToDate": "Tous vos modèles sont déjà optimisés pour ce matériel.",
+        "licenseNote": "Le changement reste au sein du même modèle, sa licence ne change donc pas."
       }
     },
     "bird": {

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -5423,7 +5423,31 @@
       "reinstalling": "Réinstallation...",
       "reinstallComplete": "Fichiers vérifiés avec succès",
       "geomodelBadge": "Inclut le BirdNET v3.0 geomodel",
-      "entryIncompatible": "Ce modèle n'est pas disponible sur ce système."
+      "entryIncompatible": "Ce modèle n'est pas disponible sur ce système.",
+      "regionGlobal": "Global",
+      "hardwareLabel": "Hardware",
+      "hardware": {
+        "gpu": "GPU",
+        "intelGpu": "Intel GPU",
+        "armCpu": "ARM CPU",
+        "cpu": "CPU"
+      },
+      "optimize": {
+        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
+        "review": "Review",
+        "dismiss": "Dismiss",
+        "badgeTitle": "A faster build is available for your hardware",
+        "swap": "Optimize",
+        "dialogTitle": "Optimize your models",
+        "fromTo": "{from} to {to}",
+        "apply": "Apply",
+        "applyAll": "Apply all",
+        "applying": "Applying...",
+        "applied": "Applied",
+        "applyFailed": "Failed to apply",
+        "upToDate": "All your models are already optimized for this hardware.",
+        "licenseNote": "Swapping stays within the same model, so its license does not change."
+      }
     },
     "bird": {
       "title": "Détection des oiseaux",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -5364,7 +5364,6 @@
       "loading": "Chargement des modèles...",
       "retry": "Réessayer",
       "builtIn": "Intégré",
-      "builtInDescription": "Classificateur d'espèces d'oiseaux intégré par l'équipe BirdNET.",
       "species": "{count} espèces",
       "install": "Installer",
       "installing": "Installation...",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -5424,8 +5424,8 @@
       "reinstallComplete": "Fájlok sikeresen ellenőrizve",
       "geomodelBadge": "Tartalmazza a BirdNET v3.0 geomodellt",
       "entryIncompatible": "Ez a modell nem érhető el ezen a rendszeren.",
-      "regionGlobal": "Global",
-      "hardwareLabel": "Hardware",
+      "regionGlobal": "Globális",
+      "hardwareLabel": "Hardver",
       "hardware": {
         "gpu": "GPU",
         "intelGpu": "Intel GPU",
@@ -5433,20 +5433,20 @@
         "cpu": "CPU"
       },
       "optimize": {
-        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
-        "review": "Review",
-        "dismiss": "Dismiss",
-        "badgeTitle": "A faster build is available for your hardware",
-        "swap": "Optimize",
-        "dialogTitle": "Optimize your models",
-        "fromTo": "{from} to {to}",
-        "apply": "Apply",
-        "applyAll": "Apply all",
-        "applying": "Applying...",
-        "applied": "Applied",
-        "applyFailed": "Failed to apply",
-        "upToDate": "All your models are already optimized for this hardware.",
-        "licenseNote": "Swapping stays within the same model, so its license does not change."
+        "bannerTitle": "{count, plural, one {# modell gyorsabban futhat a hardvereden} other {# modell gyorsabban futhat a hardvereden}}",
+        "review": "Áttekintés",
+        "dismiss": "Elutasítás",
+        "badgeTitle": "Egy gyorsabb verzió érhető el a hardveredhez",
+        "swap": "Optimalizálás",
+        "dialogTitle": "Modellek optimalizálása",
+        "fromTo": "{from} -> {to}",
+        "apply": "Alkalmazás",
+        "applyAll": "Összes alkalmazása",
+        "applying": "Alkalmazás...",
+        "applied": "Alkalmazva",
+        "applyFailed": "Nem sikerült alkalmazni",
+        "upToDate": "Minden modelled optimalizálva van erre a hardverre.",
+        "licenseNote": "A csere ugyanazon a modellen belül marad, így a licence nem változik."
       }
     },
     "bird": {

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -5423,7 +5423,31 @@
       "reinstalling": "Újratelepítés...",
       "reinstallComplete": "Fájlok sikeresen ellenőrizve",
       "geomodelBadge": "Tartalmazza a BirdNET v3.0 geomodellt",
-      "entryIncompatible": "Ez a modell nem érhető el ezen a rendszeren."
+      "entryIncompatible": "Ez a modell nem érhető el ezen a rendszeren.",
+      "regionGlobal": "Global",
+      "hardwareLabel": "Hardware",
+      "hardware": {
+        "gpu": "GPU",
+        "intelGpu": "Intel GPU",
+        "armCpu": "ARM CPU",
+        "cpu": "CPU"
+      },
+      "optimize": {
+        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
+        "review": "Review",
+        "dismiss": "Dismiss",
+        "badgeTitle": "A faster build is available for your hardware",
+        "swap": "Optimize",
+        "dialogTitle": "Optimize your models",
+        "fromTo": "{from} to {to}",
+        "apply": "Apply",
+        "applyAll": "Apply all",
+        "applying": "Applying...",
+        "applied": "Applied",
+        "applyFailed": "Failed to apply",
+        "upToDate": "All your models are already optimized for this hardware.",
+        "licenseNote": "Swapping stays within the same model, so its license does not change."
+      }
     },
     "bird": {
       "title": "Madárészlelés",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -5364,7 +5364,6 @@
       "loading": "Modellek betöltése...",
       "retry": "Újra",
       "builtIn": "Beépített",
-      "builtInDescription": "A BirdNET csapat beépített madárfaj-osztályozója.",
       "species": "{count} faj",
       "install": "Telepítés",
       "installing": "Telepítés...",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -5424,7 +5424,7 @@
       "reinstallComplete": "File verificati con successo",
       "geomodelBadge": "Include il geomodel BirdNET v3.0",
       "entryIncompatible": "Questo modello non è disponibile su questo sistema.",
-      "regionGlobal": "Global",
+      "regionGlobal": "Globale",
       "hardwareLabel": "Hardware",
       "hardware": {
         "gpu": "GPU",
@@ -5433,20 +5433,20 @@
         "cpu": "CPU"
       },
       "optimize": {
-        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
-        "review": "Review",
-        "dismiss": "Dismiss",
-        "badgeTitle": "A faster build is available for your hardware",
-        "swap": "Optimize",
-        "dialogTitle": "Optimize your models",
-        "fromTo": "{from} to {to}",
-        "apply": "Apply",
-        "applyAll": "Apply all",
-        "applying": "Applying...",
-        "applied": "Applied",
-        "applyFailed": "Failed to apply",
-        "upToDate": "All your models are already optimized for this hardware.",
-        "licenseNote": "Swapping stays within the same model, so its license does not change."
+        "bannerTitle": "{count, plural, one {# modello può funzionare più velocemente sul tuo hardware} other {# modelli possono funzionare più velocemente sul tuo hardware}}",
+        "review": "Controlla",
+        "dismiss": "Ignora",
+        "badgeTitle": "È disponibile una versione più veloce per il tuo hardware",
+        "swap": "Ottimizza",
+        "dialogTitle": "Ottimizza i tuoi modelli",
+        "fromTo": "{from} a {to}",
+        "apply": "Applica",
+        "applyAll": "Applica tutti",
+        "applying": "Applicazione...",
+        "applied": "Applicato",
+        "applyFailed": "Applicazione non riuscita",
+        "upToDate": "Tutti i tuoi modelli sono già ottimizzati per questo hardware.",
+        "licenseNote": "La sostituzione rimane all'interno dello stesso modello, quindi la sua licenza non cambia."
       }
     },
     "bird": {

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -5364,7 +5364,6 @@
       "loading": "Caricamento modelli...",
       "retry": "Riprova",
       "builtIn": "Integrato",
-      "builtInDescription": "Classificatore di specie di uccelli integrato dal team BirdNET.",
       "species": "{count} specie",
       "install": "Installa",
       "installing": "Installazione...",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -5423,7 +5423,31 @@
       "reinstalling": "Reinstallazione...",
       "reinstallComplete": "File verificati con successo",
       "geomodelBadge": "Include il geomodel BirdNET v3.0",
-      "entryIncompatible": "Questo modello non è disponibile su questo sistema."
+      "entryIncompatible": "Questo modello non è disponibile su questo sistema.",
+      "regionGlobal": "Global",
+      "hardwareLabel": "Hardware",
+      "hardware": {
+        "gpu": "GPU",
+        "intelGpu": "Intel GPU",
+        "armCpu": "ARM CPU",
+        "cpu": "CPU"
+      },
+      "optimize": {
+        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
+        "review": "Review",
+        "dismiss": "Dismiss",
+        "badgeTitle": "A faster build is available for your hardware",
+        "swap": "Optimize",
+        "dialogTitle": "Optimize your models",
+        "fromTo": "{from} to {to}",
+        "apply": "Apply",
+        "applyAll": "Apply all",
+        "applying": "Applying...",
+        "applied": "Applied",
+        "applyFailed": "Failed to apply",
+        "upToDate": "All your models are already optimized for this hardware.",
+        "licenseNote": "Swapping stays within the same model, so its license does not change."
+      }
     },
     "bird": {
       "title": "Rilevamento uccelli",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -5424,8 +5424,8 @@
       "reinstallComplete": "Faili veiksmīgi pārbaudīti",
       "geomodelBadge": "Ietver BirdNET v3.0 ģeomodelis",
       "entryIncompatible": "Šis modelis nav pieejams šajā sistēmā.",
-      "regionGlobal": "Global",
-      "hardwareLabel": "Hardware",
+      "regionGlobal": "Globāls",
+      "hardwareLabel": "Aparatūra",
       "hardware": {
         "gpu": "GPU",
         "intelGpu": "Intel GPU",
@@ -5433,20 +5433,20 @@
         "cpu": "CPU"
       },
       "optimize": {
-        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
-        "review": "Review",
-        "dismiss": "Dismiss",
-        "badgeTitle": "A faster build is available for your hardware",
-        "swap": "Optimize",
-        "dialogTitle": "Optimize your models",
-        "fromTo": "{from} to {to}",
-        "apply": "Apply",
-        "applyAll": "Apply all",
-        "applying": "Applying...",
-        "applied": "Applied",
-        "applyFailed": "Failed to apply",
-        "upToDate": "All your models are already optimized for this hardware.",
-        "licenseNote": "Swapping stays within the same model, so its license does not change."
+        "bannerTitle": "{count, plural, zero {# modeļu var darboties ātrāk jūsu aparatūrā} one {# modelis var darboties ātrāk jūsu aparatūrā} other {# modeļi var darboties ātrāk jūsu aparatūrā}}",
+        "review": "Pārskatīt",
+        "dismiss": "Noraidīt",
+        "badgeTitle": "Jūsu aparatūrai ir pieejama ātrāka versija",
+        "swap": "Optimizēt",
+        "dialogTitle": "Optimizējiet savus modeļus",
+        "fromTo": "{from} uz {to}",
+        "apply": "Lietot",
+        "applyAll": "Lietot visu",
+        "applying": "Lieto...",
+        "applied": "Lietots",
+        "applyFailed": "Neizdevās lietot",
+        "upToDate": "Visi jūsu modeļi jau ir optimizēti šai aparatūrai.",
+        "licenseNote": "Aizstāšana notiek viena modeļa ietvaros, tāpēc tā licence nemainās."
       }
     },
     "bird": {

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -5364,7 +5364,6 @@
       "loading": "Ielādē modeļus...",
       "retry": "Mēģināt vēlreiz",
       "builtIn": "Iebūvēts",
-      "builtInDescription": "BirdNET komandas iebūvēts putnu sugu klasifikators.",
       "species": "{count} sugas",
       "install": "Instalēt",
       "installing": "Instalē...",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -5423,7 +5423,31 @@
       "reinstalling": "Pārinstalē...",
       "reinstallComplete": "Faili veiksmīgi pārbaudīti",
       "geomodelBadge": "Ietver BirdNET v3.0 ģeomodelis",
-      "entryIncompatible": "Šis modelis nav pieejams šajā sistēmā."
+      "entryIncompatible": "Šis modelis nav pieejams šajā sistēmā.",
+      "regionGlobal": "Global",
+      "hardwareLabel": "Hardware",
+      "hardware": {
+        "gpu": "GPU",
+        "intelGpu": "Intel GPU",
+        "armCpu": "ARM CPU",
+        "cpu": "CPU"
+      },
+      "optimize": {
+        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
+        "review": "Review",
+        "dismiss": "Dismiss",
+        "badgeTitle": "A faster build is available for your hardware",
+        "swap": "Optimize",
+        "dialogTitle": "Optimize your models",
+        "fromTo": "{from} to {to}",
+        "apply": "Apply",
+        "applyAll": "Apply all",
+        "applying": "Applying...",
+        "applied": "Applied",
+        "applyFailed": "Failed to apply",
+        "upToDate": "All your models are already optimized for this hardware.",
+        "licenseNote": "Swapping stays within the same model, so its license does not change."
+      }
     },
     "bird": {
       "title": "Putnu noteikšana",

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -5425,7 +5425,7 @@
       "geomodelBadge": "Inkluderer BirdNET v3.0 geomodell",
       "entryIncompatible": "Denne modellen er ikke tilgjengelig på dette systemet.",
       "regionGlobal": "Global",
-      "hardwareLabel": "Hardware",
+      "hardwareLabel": "Maskinvare",
       "hardware": {
         "gpu": "GPU",
         "intelGpu": "Intel GPU",
@@ -5433,20 +5433,20 @@
         "cpu": "CPU"
       },
       "optimize": {
-        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
-        "review": "Review",
-        "dismiss": "Dismiss",
-        "badgeTitle": "A faster build is available for your hardware",
-        "swap": "Optimize",
-        "dialogTitle": "Optimize your models",
-        "fromTo": "{from} to {to}",
-        "apply": "Apply",
-        "applyAll": "Apply all",
-        "applying": "Applying...",
-        "applied": "Applied",
-        "applyFailed": "Failed to apply",
-        "upToDate": "All your models are already optimized for this hardware.",
-        "licenseNote": "Swapping stays within the same model, so its license does not change."
+        "bannerTitle": "{count, plural, one {# modell kan kjøre raskere på maskinvaren din} other {# modeller kan kjøre raskere på maskinvaren din}}",
+        "review": "Gjennomgå",
+        "dismiss": "Avvis",
+        "badgeTitle": "Et raskere bygg er tilgjengelig for maskinvaren din",
+        "swap": "Optimer",
+        "dialogTitle": "Optimer modellene dine",
+        "fromTo": "{from} til {to}",
+        "apply": "Bruk",
+        "applyAll": "Bruk alle",
+        "applying": "Bruker...",
+        "applied": "Brukt",
+        "applyFailed": "Kunne ikke bruke",
+        "upToDate": "Alle modellene dine er allerede optimert for denne maskinvaren.",
+        "licenseNote": "Byttet skjer innenfor samme modell, så lisensen endres ikke."
       }
     },
     "bird": {

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -5364,7 +5364,6 @@
       "loading": "Laster modeller...",
       "retry": "Prøv igjen",
       "builtIn": "Innebygd",
-      "builtInDescription": "Innebygd fuglearts-klassifikator fra BirdNET-teamet.",
       "species": "{count} arter",
       "install": "Installer",
       "installing": "Installerer...",

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -5423,7 +5423,31 @@
       "reinstalling": "Reinstallerer...",
       "reinstallComplete": "Filer verifisert",
       "geomodelBadge": "Inkluderer BirdNET v3.0 geomodell",
-      "entryIncompatible": "Denne modellen er ikke tilgjengelig på dette systemet."
+      "entryIncompatible": "Denne modellen er ikke tilgjengelig på dette systemet.",
+      "regionGlobal": "Global",
+      "hardwareLabel": "Hardware",
+      "hardware": {
+        "gpu": "GPU",
+        "intelGpu": "Intel GPU",
+        "armCpu": "ARM CPU",
+        "cpu": "CPU"
+      },
+      "optimize": {
+        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
+        "review": "Review",
+        "dismiss": "Dismiss",
+        "badgeTitle": "A faster build is available for your hardware",
+        "swap": "Optimize",
+        "dialogTitle": "Optimize your models",
+        "fromTo": "{from} to {to}",
+        "apply": "Apply",
+        "applyAll": "Apply all",
+        "applying": "Applying...",
+        "applied": "Applied",
+        "applyFailed": "Failed to apply",
+        "upToDate": "All your models are already optimized for this hardware.",
+        "licenseNote": "Swapping stays within the same model, so its license does not change."
+      }
     },
     "bird": {
       "title": "Fugledeteksjon",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -5423,7 +5423,31 @@
       "reinstalling": "Opnieuw installeren...",
       "reinstallComplete": "Bestanden succesvol geverifieerd",
       "geomodelBadge": "Bevat BirdNET v3.0 geomodel",
-      "entryIncompatible": "Dit model is niet beschikbaar op dit systeem."
+      "entryIncompatible": "Dit model is niet beschikbaar op dit systeem.",
+      "regionGlobal": "Global",
+      "hardwareLabel": "Hardware",
+      "hardware": {
+        "gpu": "GPU",
+        "intelGpu": "Intel GPU",
+        "armCpu": "ARM CPU",
+        "cpu": "CPU"
+      },
+      "optimize": {
+        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
+        "review": "Review",
+        "dismiss": "Dismiss",
+        "badgeTitle": "A faster build is available for your hardware",
+        "swap": "Optimize",
+        "dialogTitle": "Optimize your models",
+        "fromTo": "{from} to {to}",
+        "apply": "Apply",
+        "applyAll": "Apply all",
+        "applying": "Applying...",
+        "applied": "Applied",
+        "applyFailed": "Failed to apply",
+        "upToDate": "All your models are already optimized for this hardware.",
+        "licenseNote": "Swapping stays within the same model, so its license does not change."
+      }
     },
     "bird": {
       "title": "Vogeldetectie",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -5364,7 +5364,6 @@
       "loading": "Modellen laden...",
       "retry": "Opnieuw proberen",
       "builtIn": "Ingebouwd",
-      "builtInDescription": "Ingebouwde vogelsoortclassificator van het BirdNET-team.",
       "species": "{count} soorten",
       "install": "Installeren",
       "installing": "Installeren...",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -5424,7 +5424,7 @@
       "reinstallComplete": "Bestanden succesvol geverifieerd",
       "geomodelBadge": "Bevat BirdNET v3.0 geomodel",
       "entryIncompatible": "Dit model is niet beschikbaar op dit systeem.",
-      "regionGlobal": "Global",
+      "regionGlobal": "Globaal",
       "hardwareLabel": "Hardware",
       "hardware": {
         "gpu": "GPU",
@@ -5433,20 +5433,20 @@
         "cpu": "CPU"
       },
       "optimize": {
-        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
-        "review": "Review",
-        "dismiss": "Dismiss",
-        "badgeTitle": "A faster build is available for your hardware",
-        "swap": "Optimize",
-        "dialogTitle": "Optimize your models",
-        "fromTo": "{from} to {to}",
-        "apply": "Apply",
-        "applyAll": "Apply all",
-        "applying": "Applying...",
-        "applied": "Applied",
-        "applyFailed": "Failed to apply",
-        "upToDate": "All your models are already optimized for this hardware.",
-        "licenseNote": "Swapping stays within the same model, so its license does not change."
+        "bannerTitle": "{count, plural, one {# model kan sneller werken op jouw hardware} other {# modellen kunnen sneller werken op jouw hardware}}",
+        "review": "Controleren",
+        "dismiss": "Afwijzen",
+        "badgeTitle": "Er is een snellere build beschikbaar voor jouw hardware",
+        "swap": "Optimaliseren",
+        "dialogTitle": "Optimaliseer jouw modellen",
+        "fromTo": "{from} naar {to}",
+        "apply": "Toepassen",
+        "applyAll": "Alles toepassen",
+        "applying": "Toepassen...",
+        "applied": "Toegepast",
+        "applyFailed": "Toepassen mislukt",
+        "upToDate": "Al jouw modellen zijn al geoptimaliseerd voor deze hardware.",
+        "licenseNote": "Het wisselen blijft binnen hetzelfde model, dus de licentie verandert niet."
       }
     },
     "bird": {

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -5423,7 +5423,31 @@
       "reinstalling": "Ponowna instalacja...",
       "reinstallComplete": "Pliki zweryfikowane pomyślnie",
       "geomodelBadge": "Zawiera BirdNET v3.0 geomodel",
-      "entryIncompatible": "Ten model nie jest dostępny w tym systemie."
+      "entryIncompatible": "Ten model nie jest dostępny w tym systemie.",
+      "regionGlobal": "Global",
+      "hardwareLabel": "Hardware",
+      "hardware": {
+        "gpu": "GPU",
+        "intelGpu": "Intel GPU",
+        "armCpu": "ARM CPU",
+        "cpu": "CPU"
+      },
+      "optimize": {
+        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
+        "review": "Review",
+        "dismiss": "Dismiss",
+        "badgeTitle": "A faster build is available for your hardware",
+        "swap": "Optimize",
+        "dialogTitle": "Optimize your models",
+        "fromTo": "{from} to {to}",
+        "apply": "Apply",
+        "applyAll": "Apply all",
+        "applying": "Applying...",
+        "applied": "Applied",
+        "applyFailed": "Failed to apply",
+        "upToDate": "All your models are already optimized for this hardware.",
+        "licenseNote": "Swapping stays within the same model, so its license does not change."
+      }
     },
     "bird": {
       "title": "Wykrywanie ptaków",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -5424,8 +5424,8 @@
       "reinstallComplete": "Pliki zweryfikowane pomyślnie",
       "geomodelBadge": "Zawiera BirdNET v3.0 geomodel",
       "entryIncompatible": "Ten model nie jest dostępny w tym systemie.",
-      "regionGlobal": "Global",
-      "hardwareLabel": "Hardware",
+      "regionGlobal": "Globalny",
+      "hardwareLabel": "Sprzęt",
       "hardware": {
         "gpu": "GPU",
         "intelGpu": "Intel GPU",
@@ -5433,20 +5433,20 @@
         "cpu": "CPU"
       },
       "optimize": {
-        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
-        "review": "Review",
-        "dismiss": "Dismiss",
-        "badgeTitle": "A faster build is available for your hardware",
-        "swap": "Optimize",
-        "dialogTitle": "Optimize your models",
-        "fromTo": "{from} to {to}",
-        "apply": "Apply",
-        "applyAll": "Apply all",
-        "applying": "Applying...",
-        "applied": "Applied",
-        "applyFailed": "Failed to apply",
-        "upToDate": "All your models are already optimized for this hardware.",
-        "licenseNote": "Swapping stays within the same model, so its license does not change."
+        "bannerTitle": "{count, plural, one {# model może działać szybciej na twoim sprzęcie} few {# modele mogą działać szybciej na twoim sprzęcie} many {# modeli może działać szybciej na twoim sprzęcie} other {# modeli może działać szybciej na twoim sprzęcie}}",
+        "review": "Przejrzyj",
+        "dismiss": "Odrzuć",
+        "badgeTitle": "Dla twojego sprzętu dostępna jest szybsza wersja",
+        "swap": "Optymalizuj",
+        "dialogTitle": "Zoptymalizuj swoje modele",
+        "fromTo": "{from} na {to}",
+        "apply": "Zastosuj",
+        "applyAll": "Zastosuj wszystko",
+        "applying": "Stosowanie...",
+        "applied": "Zastosowano",
+        "applyFailed": "Nie udało się zastosować",
+        "upToDate": "Wszystkie twoje modele są już zoptymalizowane pod kątem tego sprzętu.",
+        "licenseNote": "Zamiana odbywa się w ramach tego samego modelu, więc jego licencja nie ulega zmianie."
       }
     },
     "bird": {

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -5364,7 +5364,6 @@
       "loading": "Ładowanie modeli...",
       "retry": "Ponów",
       "builtIn": "Wbudowany",
-      "builtInDescription": "Wbudowany klasyfikator gatunków ptaków zespołu BirdNET.",
       "species": "{count} gatunków",
       "install": "Zainstaluj",
       "installing": "Instalowanie...",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -5433,20 +5433,20 @@
         "cpu": "CPU"
       },
       "optimize": {
-        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
-        "review": "Review",
-        "dismiss": "Dismiss",
-        "badgeTitle": "A faster build is available for your hardware",
-        "swap": "Optimize",
-        "dialogTitle": "Optimize your models",
-        "fromTo": "{from} to {to}",
-        "apply": "Apply",
-        "applyAll": "Apply all",
-        "applying": "Applying...",
-        "applied": "Applied",
-        "applyFailed": "Failed to apply",
-        "upToDate": "All your models are already optimized for this hardware.",
-        "licenseNote": "Swapping stays within the same model, so its license does not change."
+        "bannerTitle": "{count, plural, one {# modelo pode funcionar mais rápido no seu hardware} other {# modelos podem funcionar mais rápido no seu hardware}}",
+        "review": "Revisar",
+        "dismiss": "Descartar",
+        "badgeTitle": "Está disponível uma versão mais rápida para o seu hardware",
+        "swap": "Otimizar",
+        "dialogTitle": "Otimizar os seus modelos",
+        "fromTo": "{from} para {to}",
+        "apply": "Aplicar",
+        "applyAll": "Aplicar tudo",
+        "applying": "A aplicar...",
+        "applied": "Aplicado",
+        "applyFailed": "Falha ao aplicar",
+        "upToDate": "Todos os seus modelos já estão otimizados para este hardware.",
+        "licenseNote": "A troca permanece dentro do mesmo modelo, pelo que a sua licença não é alterada."
       }
     },
     "bird": {

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -5364,7 +5364,6 @@
       "loading": "Carregando modelos...",
       "retry": "Tentar novamente",
       "builtIn": "Integrado",
-      "builtInDescription": "Classificador de espécies de aves integrado pela equipe BirdNET.",
       "species": "{count} espécies",
       "install": "Instalar",
       "installing": "Instalando...",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -5423,7 +5423,31 @@
       "reinstalling": "Reinstalando...",
       "reinstallComplete": "Ficheiros verificados com sucesso",
       "geomodelBadge": "Inclui BirdNET v3.0 geomodel",
-      "entryIncompatible": "Este modelo não está disponível neste sistema."
+      "entryIncompatible": "Este modelo não está disponível neste sistema.",
+      "regionGlobal": "Global",
+      "hardwareLabel": "Hardware",
+      "hardware": {
+        "gpu": "GPU",
+        "intelGpu": "Intel GPU",
+        "armCpu": "ARM CPU",
+        "cpu": "CPU"
+      },
+      "optimize": {
+        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
+        "review": "Review",
+        "dismiss": "Dismiss",
+        "badgeTitle": "A faster build is available for your hardware",
+        "swap": "Optimize",
+        "dialogTitle": "Optimize your models",
+        "fromTo": "{from} to {to}",
+        "apply": "Apply",
+        "applyAll": "Apply all",
+        "applying": "Applying...",
+        "applied": "Applied",
+        "applyFailed": "Failed to apply",
+        "upToDate": "All your models are already optimized for this hardware.",
+        "licenseNote": "Swapping stays within the same model, so its license does not change."
+      }
     },
     "bird": {
       "title": "Deteção de aves",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -5364,7 +5364,6 @@
       "loading": "Načítavajú sa modely...",
       "retry": "Skúsiť znova",
       "builtIn": "Vstavaný",
-      "builtInDescription": "Vstavaný klasifikátor vtáčích druhov od tímu BirdNET.",
       "species": "{count} druhov",
       "install": "Inštalovať",
       "installing": "Inštaluje sa...",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -5424,8 +5424,8 @@
       "reinstallComplete": "Súbory úspešne overené",
       "geomodelBadge": "Obsahuje BirdNET v3.0 geomodel",
       "entryIncompatible": "Tento model nie je v tomto systéme k dispozícii.",
-      "regionGlobal": "Global",
-      "hardwareLabel": "Hardware",
+      "regionGlobal": "Globálny",
+      "hardwareLabel": "Hardvér",
       "hardware": {
         "gpu": "GPU",
         "intelGpu": "Intel GPU",
@@ -5433,20 +5433,20 @@
         "cpu": "CPU"
       },
       "optimize": {
-        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
-        "review": "Review",
-        "dismiss": "Dismiss",
-        "badgeTitle": "A faster build is available for your hardware",
-        "swap": "Optimize",
-        "dialogTitle": "Optimize your models",
-        "fromTo": "{from} to {to}",
-        "apply": "Apply",
-        "applyAll": "Apply all",
-        "applying": "Applying...",
-        "applied": "Applied",
-        "applyFailed": "Failed to apply",
-        "upToDate": "All your models are already optimized for this hardware.",
-        "licenseNote": "Swapping stays within the same model, so its license does not change."
+        "bannerTitle": "{count, plural, one {# model môže bežať rýchlejšie na vašom hardvéri} few {# modely môžu bežať rýchlejšie na vašom hardvéri} many {# modelov môže bežať rýchlejšie na vašom hardvéri} other {# modelov môže bežať rýchlejšie na vašom hardvéri}}",
+        "review": "Skontrolovať",
+        "dismiss": "Zrušiť",
+        "badgeTitle": "Pre váš hardvér je k dispozícii rýchlejšie zostavenie",
+        "swap": "Optimalizovať",
+        "dialogTitle": "Optimalizovať vaše modely",
+        "fromTo": "{from} na {to}",
+        "apply": "Použiť",
+        "applyAll": "Použiť všetko",
+        "applying": "Aplikuje sa...",
+        "applied": "Použité",
+        "applyFailed": "Použitie sa nepodarilo",
+        "upToDate": "Všetky vaše modely sú už pre tento hardvér optimalizované.",
+        "licenseNote": "Výmena prebieha v rámci rovnakého modelu, takže sa jeho licencia nemení."
       }
     },
     "bird": {

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -5423,7 +5423,31 @@
       "reinstalling": "Preinštalovanie...",
       "reinstallComplete": "Súbory úspešne overené",
       "geomodelBadge": "Obsahuje BirdNET v3.0 geomodel",
-      "entryIncompatible": "Tento model nie je v tomto systéme k dispozícii."
+      "entryIncompatible": "Tento model nie je v tomto systéme k dispozícii.",
+      "regionGlobal": "Global",
+      "hardwareLabel": "Hardware",
+      "hardware": {
+        "gpu": "GPU",
+        "intelGpu": "Intel GPU",
+        "armCpu": "ARM CPU",
+        "cpu": "CPU"
+      },
+      "optimize": {
+        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
+        "review": "Review",
+        "dismiss": "Dismiss",
+        "badgeTitle": "A faster build is available for your hardware",
+        "swap": "Optimize",
+        "dialogTitle": "Optimize your models",
+        "fromTo": "{from} to {to}",
+        "apply": "Apply",
+        "applyAll": "Apply all",
+        "applying": "Applying...",
+        "applied": "Applied",
+        "applyFailed": "Failed to apply",
+        "upToDate": "All your models are already optimized for this hardware.",
+        "licenseNote": "Swapping stays within the same model, so its license does not change."
+      }
     },
     "bird": {
       "title": "Detekcia vtákov",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -5425,7 +5425,7 @@
       "geomodelBadge": "Inkluderar BirdNET v3.0 geomodell",
       "entryIncompatible": "Den här modellen är inte tillgänglig på detta system.",
       "regionGlobal": "Global",
-      "hardwareLabel": "Hardware",
+      "hardwareLabel": "Hårdvara",
       "hardware": {
         "gpu": "GPU",
         "intelGpu": "Intel GPU",
@@ -5433,20 +5433,20 @@
         "cpu": "CPU"
       },
       "optimize": {
-        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
-        "review": "Review",
-        "dismiss": "Dismiss",
-        "badgeTitle": "A faster build is available for your hardware",
-        "swap": "Optimize",
-        "dialogTitle": "Optimize your models",
-        "fromTo": "{from} to {to}",
-        "apply": "Apply",
-        "applyAll": "Apply all",
-        "applying": "Applying...",
-        "applied": "Applied",
-        "applyFailed": "Failed to apply",
-        "upToDate": "All your models are already optimized for this hardware.",
-        "licenseNote": "Swapping stays within the same model, so its license does not change."
+        "bannerTitle": "{count, plural, one {# modell kan köras snabbare på din hårdvara} other {# modeller kan köras snabbare på din hårdvara}}",
+        "review": "Granska",
+        "dismiss": "Avfärda",
+        "badgeTitle": "Ett snabbare bygge är tillgängligt för din hårdvara",
+        "swap": "Optimera",
+        "dialogTitle": "Optimera dina modeller",
+        "fromTo": "{from} till {to}",
+        "apply": "Tillämpa",
+        "applyAll": "Tillämpa alla",
+        "applying": "Tillämpar...",
+        "applied": "Tillämpad",
+        "applyFailed": "Kunde inte tillämpa",
+        "upToDate": "Alla dina modeller är redan optimerade för denna hårdvara.",
+        "licenseNote": "Bytet sker inom samma modell, så dess licens ändras inte."
       }
     },
     "bird": {

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -5423,7 +5423,31 @@
       "reinstalling": "Installerar om...",
       "reinstallComplete": "Filer verifierade",
       "geomodelBadge": "Inkluderar BirdNET v3.0 geomodell",
-      "entryIncompatible": "Den här modellen är inte tillgänglig på detta system."
+      "entryIncompatible": "Den här modellen är inte tillgänglig på detta system.",
+      "regionGlobal": "Global",
+      "hardwareLabel": "Hardware",
+      "hardware": {
+        "gpu": "GPU",
+        "intelGpu": "Intel GPU",
+        "armCpu": "ARM CPU",
+        "cpu": "CPU"
+      },
+      "optimize": {
+        "bannerTitle": "{count, plural, one {# model can run faster on your hardware} other {# models can run faster on your hardware}}",
+        "review": "Review",
+        "dismiss": "Dismiss",
+        "badgeTitle": "A faster build is available for your hardware",
+        "swap": "Optimize",
+        "dialogTitle": "Optimize your models",
+        "fromTo": "{from} to {to}",
+        "apply": "Apply",
+        "applyAll": "Apply all",
+        "applying": "Applying...",
+        "applied": "Applied",
+        "applyFailed": "Failed to apply",
+        "upToDate": "All your models are already optimized for this hardware.",
+        "licenseNote": "Swapping stays within the same model, so its license does not change."
+      }
     },
     "bird": {
       "title": "Fågeldetektering",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -5364,7 +5364,6 @@
       "loading": "Laddar modeller...",
       "retry": "Försök igen",
       "builtIn": "Inbyggd",
-      "builtInDescription": "Inbyggd fågelartsklassificerare från BirdNET-teamet.",
       "species": "{count} arter",
       "install": "Installera",
       "installing": "Installerar...",

--- a/internal/api/v2/models/models.go
+++ b/internal/api/v2/models/models.go
@@ -109,6 +109,10 @@ type CatalogEntryResponse struct {
 	IncompatibleReason string `json:"incompatibleReason,omitempty"`
 	TotalSizeBytes     int64  `json:"totalSizeBytes"`
 	HasGeomodel        bool   `json:"hasGeomodel"`
+	// Permanent marks the built-in BirdNET v2.4 classifier: always installed, never
+	// uninstallable, only its variant may be swapped. The gallery renders a built-in
+	// badge instead of Remove/Reinstall for it.
+	Permanent bool `json:"permanent,omitempty"`
 	// InstalledVariantID is the id of the currently installed variant, or "" when
 	// the model is not installed or is a flat (pre-variant) entry.
 	InstalledVariantID string `json:"installedVariantId,omitempty"`
@@ -124,14 +128,17 @@ type CatalogEntryResponse struct {
 // CatalogVariantResponse describes one selectable hardware or regional variant of
 // a catalog entry for the gallery UI.
 type CatalogVariantResponse struct {
-	ID                string `json:"id"`
-	Region            string `json:"region,omitempty"`
-	Precision         string `json:"precision,omitempty"`
-	SpeciesCount      int    `json:"speciesCount"`
-	Default           bool   `json:"default"`
-	Installed         bool   `json:"installed"`
-	SizeBytes         int64  `json:"sizeBytes"`
-	HeadlineLatencyMs int    `json:"headlineLatencyMs,omitempty"`
+	ID           string `json:"id"`
+	Region       string `json:"region,omitempty"`
+	Precision    string `json:"precision,omitempty"`
+	SpeciesCount int    `json:"speciesCount"`
+	Default      bool   `json:"default"`
+	Installed    bool   `json:"installed"`
+	// BuiltIn marks the embedded baseline variant (the built-in BirdNET v2.4 model).
+	// It carries no downloadable files; the gallery labels it and shows no size.
+	BuiltIn           bool  `json:"builtIn,omitempty"`
+	SizeBytes         int64 `json:"sizeBytes"`
+	HeadlineLatencyMs int   `json:"headlineLatencyMs,omitempty"`
 	// Compatible reports whether this variant can run on the host. It defaults to
 	// true (no hardware evaluation performed) so a client that did not receive
 	// recommendations does not render every variant as incompatible.
@@ -281,6 +288,7 @@ func (c *Handler) GetModelCatalog(ctx echo.Context) error {
 			IncompatibleReason:   incompatibleReason,
 			TotalSizeBytes:       totalSize,
 			HasGeomodel:          classifier.HasGeomodelFiles(entry),
+			Permanent:            classifier.IsPermanentEntry(entry),
 			InstalledVariantID:   installedVariantID,
 			RecommendedVariantID: recommendedVariant[entry.ID],
 			Variants:             buildVariantResponses(entry, installed, installedVariantID, recsByVariant[entry.ID]),
@@ -348,6 +356,7 @@ func buildVariantResponses(entry *classifier.CatalogEntry, installed bool, insta
 			SpeciesCount:      v.SpeciesCount,
 			Default:           v.Default,
 			Installed:         isInstalledVariant,
+			BuiltIn:           v.BuiltIn,
 			SizeBytes:         sizeBytes,
 			HeadlineLatencyMs: headlineLatencyMs,
 			// Neutral default: without a recommendation the variant is not claimed
@@ -466,10 +475,10 @@ func (c *Handler) InstallModel(ctx echo.Context) error {
 		return c.HandleError(ctx, nil, "unknown catalog ID: "+catalogID, http.StatusNotFound)
 	}
 
-	// Hidden entries are foundation-only: excluded from the gallery and not meant
-	// to be installed by ID. Some (the DFT-truncated BirdNET v2.4 variants) carry
-	// the permanent registry ID, which Uninstall then refuses, so an inadvertent
-	// install would leave an unremovable, unused model on disk. Reject them here.
+	// Hidden entries are foundation-only: excluded from the gallery and not meant to
+	// be installed by ID. The permanent BirdNET v2.4 entry is intentionally NOT
+	// hidden: it is always installed, and an install request against it is a
+	// within-model variant swap routed to InstallOrReplace -> replacePrimaryVariant.
 	if entry.Hidden {
 		return c.HandleError(ctx, nil, "catalog entry "+catalogID+" is not available for installation", http.StatusNotFound)
 	}
@@ -495,8 +504,13 @@ func (c *Handler) InstallModel(ctx echo.Context) error {
 		return c.HandleError(ctx, nil, "unknown variant "+req.VariantID+" for model "+catalogID, http.StatusBadRequest)
 	}
 
-	// Reject installation of ONNX-dependent models when ORT is unavailable.
-	if entry.RequiresONNX {
+	// Reject installation of ONNX-dependent models when ORT is unavailable. The gate
+	// is variant-scoped: an entry may be ORT-free overall (e.g. BirdNET v2.4, whose
+	// BuiltIn baseline runs on the embedded TFLite model) yet expose ONNX-only
+	// variants (the DFT-truncated builds). VariantNeedsONNX refines the entry-level
+	// flag so swapping to the embedded baseline is never blocked, while selecting an
+	// ONNX build still requires the runtime.
+	if entry.RequiresONNX || classifier.VariantNeedsONNX(&entry, req.VariantID) {
 		ortStatus := inference.CheckORTAvailability(c.CurrentSettings().BirdNET.ONNXRuntimePath)
 		if !ortStatus.Available {
 			return c.HandleError(ctx, nil,
@@ -553,6 +567,14 @@ func (c *Handler) ReinstallModel(ctx echo.Context) error {
 	// Hidden entries are foundation-only and not installable by ID (see InstallModel).
 	if entry.Hidden {
 		return c.HandleError(ctx, nil, "catalog entry "+catalogID+" is not available for installation", http.StatusNotFound)
+	}
+
+	// The permanent BirdNET v2.4 entry is now visible (so its variant can be
+	// swapped), but reinstall has no meaning for it: the BuiltIn baseline has no
+	// downloadable files, and a DFT variant is (re)acquired by swapping to it via
+	// InstallOrReplace. Refuse reinstall explicitly rather than let it fall through.
+	if classifier.IsPermanentEntry(&entry) {
+		return c.HandleError(ctx, nil, "the built-in "+entry.Name+" model cannot be reinstalled", http.StatusConflict)
 	}
 
 	if c.ModelManager == nil {

--- a/internal/api/v2/models/models_recommend_test.go
+++ b/internal/api/v2/models/models_recommend_test.go
@@ -103,6 +103,101 @@ func TestGetModelCatalog_MarksRecommendedVariant(t *testing.T) {
 	assert.Equal(t, 1, recommended)
 }
 
+// TestGetModelCatalog_BirdNETv24RecommendedVariant covers the permanent BirdNET
+// v2.4 entry now that it is visible and carries a BuiltIn baseline plus two
+// DFT-truncated builds. The recommended variant per host class drives whether the
+// gallery offers an in-place optimize swap: when the host's recommended variant is
+// the installed one there is no offer, and the BuiltIn baseline must not win the
+// backend/size tie-break on an ORT-capable host (its ONNX backend is not marked
+// recommended precisely so a real DFT build beats it there).
+func TestGetModelCatalog_BirdNETv24RecommendedVariant(t *testing.T) {
+	// aarch64 host with the ONNX Runtime and low RAM (1 GB): passes the 250 MB
+	// variant floor but is tagged low-ram, and the arch-specific INT8 build applies.
+	aarch64LowRAMONNX := hwprofile.Profile{
+		Arch:          "arm64",
+		TotalRAMBytes: 1 * 1024 * 1024 * 1024,
+		Backends:      hwprofile.Backends{ONNX: hwprofile.BackendStatus{Available: true}},
+	}
+	// amd64 host with only TFLite linked (no ONNX Runtime): the DFT builds are ONNX
+	// and blocked, so the embedded BuiltIn baseline is the only runnable variant.
+	amd64TFLiteOnly := hwprofile.Profile{
+		Arch:          "amd64",
+		TotalRAMBytes: 16 * 1024 * 1024 * 1024,
+		Backends:      hwprofile.Backends{TFLite: hwprofile.BackendStatus{Available: true}},
+	}
+	// amd64 host with OpenVINO including a GPU device: the FP32 DFT build runs on
+	// OpenVINO, the INT8 build is aarch64-only, and the baseline has no OpenVINO path.
+	amd64OpenVINOGPU := hwprofile.Profile{
+		Arch:          "amd64",
+		TotalRAMBytes: 16 * 1024 * 1024 * 1024,
+		Backends: hwprofile.Backends{
+			OpenVINO: hwprofile.OpenVINOStatus{Supported: true, Devices: []string{"GPU"}},
+		},
+	}
+
+	cases := []struct {
+		name    string
+		profile hwprofile.Profile
+		want    string
+	}{
+		{"amd64+ONNX -> fp32-dfttrunc", amd64ONNXProfile(), "fp32-dfttrunc"},
+		{"tflite-only -> builtin baseline", amd64TFLiteOnly, "builtin"},
+		{"aarch64 low-RAM ONNX -> int8-arm-dfttrunc", aarch64LowRAMONNX, "int8-arm-dfttrunc"},
+		{"amd64 openvino-gpu -> fp32-dfttrunc", amd64OpenVINOGPU, "fp32-dfttrunc"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			core := apitest.NewCore(t)
+			h := New(core, nil)
+			profile := tc.profile
+			h.hardwareProfile = func(inference.ORTStatus) hwprofile.Profile { return profile }
+
+			v24 := findEntry(catalogRequest(t, h), "birdnet-v2.4")
+			require.NotNil(t, v24, "birdnet-v2.4 must be visible in the catalog")
+			assert.True(t, v24.Permanent, "birdnet-v2.4 must be marked permanent")
+			assert.Equal(t, tc.want, v24.RecommendedVariantID, "recommended v2.4 variant for %s", tc.name)
+
+			// Exactly one recommended variant, and it is the one named.
+			recommended := 0
+			for _, v := range v24.Variants {
+				if v.Recommended {
+					recommended++
+					assert.Equal(t, tc.want, v.ID)
+				}
+			}
+			assert.Equal(t, 1, recommended, "exactly one recommended v2.4 variant")
+
+			// The built-in baseline variant is always present and flagged BuiltIn.
+			builtin := findVariant(v24, "builtin")
+			require.NotNil(t, builtin, "the built-in baseline variant must always be listed")
+			assert.True(t, builtin.BuiltIn, "baseline variant must carry the BuiltIn flag")
+			assert.Zero(t, builtin.SizeBytes, "the built-in baseline has no downloadable size")
+		})
+	}
+}
+
+// TestGetModelCatalog_BirdNETv24BuiltinInstalledNoOffer verifies that on a
+// TFLite-only host the recommended variant is the BuiltIn baseline, so a host
+// running the baseline sees installedVariantId == recommendedVariantId (the
+// client-side optimize offer is then suppressed).
+func TestGetModelCatalog_BirdNETv24BuiltinInstalledNoOffer(t *testing.T) {
+	core := apitest.NewCore(t)
+	h := New(core, nil)
+	h.hardwareProfile = func(inference.ORTStatus) hwprofile.Profile {
+		return hwprofile.Profile{
+			Arch:          "amd64",
+			TotalRAMBytes: 16 * 1024 * 1024 * 1024,
+			Backends:      hwprofile.Backends{TFLite: hwprofile.BackendStatus{Available: true}},
+		}
+	}
+
+	v24 := findEntry(catalogRequest(t, h), "birdnet-v2.4")
+	require.NotNil(t, v24)
+	assert.Equal(t, "builtin", v24.RecommendedVariantID,
+		"on a TFLite-only host the baseline is recommended, so a baseline install is already optimal")
+}
+
 func TestGetModelCatalog_BlockedVariantCarriesBlockers(t *testing.T) {
 	core := apitest.NewCore(t)
 	h := New(core, nil)

--- a/internal/api/v2/models/models_test.go
+++ b/internal/api/v2/models/models_test.go
@@ -36,16 +36,13 @@ func TestModelsRouteRegistration(t *testing.T) {
 }
 
 // TestInstallModel_RejectsHiddenEntries verifies that hidden, foundation-only
-// catalog entries (the collapsed BirdNET v2.4 DFT-truncated entry) cannot be
-// installed or reinstalled by ID. It carries the permanent registry ID, which
-// Uninstall refuses, so allowing an install-by-ID would leave an unremovable,
-// unused model.
+// catalog entries (e.g. bsg-finland) cannot be installed or reinstalled by ID.
 func TestInstallModel_RejectsHiddenEntries(t *testing.T) {
 	core := apitest.NewCore(t)
 	h := New(core, nil)
 	e := echo.New()
 
-	hiddenIDs := []string{"birdnet-v2.4"}
+	hiddenIDs := []string{"bsg-finland"}
 	for _, id := range hiddenIDs {
 		t.Run(id, func(t *testing.T) {
 			// Install must be rejected with 404 before touching the model manager.
@@ -69,4 +66,22 @@ func TestInstallModel_RejectsHiddenEntries(t *testing.T) {
 			assert.Contains(t, rec.Body.String(), "not available for installation")
 		})
 	}
+}
+
+// TestReinstallModel_RejectsPermanentEntry verifies that the permanent, now-visible
+// BirdNET v2.4 entry cannot be reinstalled: its BuiltIn baseline has no downloadable
+// files, and a DFT variant is acquired by swapping to it via install, not reinstall.
+func TestReinstallModel_RejectsPermanentEntry(t *testing.T) {
+	core := apitest.NewCore(t)
+	h := New(core, nil)
+	e := echo.New()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/models/reinstall/birdnet-v2.4", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("id")
+	ctx.SetParamValues("birdnet-v2.4")
+	require.NoError(t, h.ReinstallModel(ctx))
+	assert.Equal(t, http.StatusConflict, rec.Code, "reinstall of the permanent v2.4 entry must be refused")
+	assert.Contains(t, rec.Body.String(), "cannot be reinstalled")
 }

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -1276,7 +1276,7 @@ func (bn *BirdNET) validateModelAndLabels() error {
 
 // ReloadModel safely reloads the BirdNET model and labels while handling ongoing analysis
 func (bn *BirdNET) ReloadModel() error {
-	err := bn.reloadModelInternal()
+	err := bn.reloadModelInternal(false)
 	if err == nil {
 		// Return freed native pages to the OS. Both backends free native memory in
 		// Close(), but libc may retain freed pages. FreeOSMemory hints the
@@ -1288,7 +1288,34 @@ func (bn *BirdNET) ReloadModel() error {
 	return err
 }
 
-func (bn *BirdNET) reloadModelInternal() error {
+// reloadForVariantSwap reloads the primary model in place, opting into a changed
+// (or cleared) model file path. It is the primary-model counterpart to the generic
+// variant-replace flow: the gallery uses it to switch the permanent BirdNET v2.4
+// classifier between its embedded BuiltIn baseline and a DFT-truncated ONNX build
+// WITHOUT a full pipeline restart. Unlike ReloadModel (which treats a path change as
+// a model-identity change requiring an orchestrator restart), this accepts a new
+// CustomPath, and a cleared BirdNET.ModelPath re-resolves the stock embedded
+// identity. The model ID stays BirdNET_V2.4 across the swap, so the orchestrator's
+// re-key is a no-op. Callers must have already persisted the new BirdNET.ModelPath
+// (or cleared it) so currentSettings() observes the target file. Transactional
+// rollback is inherited from reloadModelInternal.
+func (bn *BirdNET) reloadForVariantSwap() error {
+	err := bn.reloadModelInternal(true)
+	if err == nil {
+		debug.FreeOSMemory()
+	}
+	return err
+}
+
+// reloadModelInternal reloads the primary classifier in place under bn.mu, with
+// transactional rollback to the previously-serving model on any failure. When
+// allowPathChange is false (the settings-reload path, ReloadModel), a change of the
+// resolved model file path is treated as a model-identity change and refused so the
+// caller performs an orchestrator restart instead. When true (the variant-swap
+// path, reloadForVariantSwap), a changed CustomPath is accepted in place and a
+// cleared BirdNET.ModelPath re-resolves the stock embedded identity; a change of
+// model ID (a different BirdNET version) is still refused.
+func (bn *BirdNET) reloadModelInternal(allowPathChange bool) error {
 	bn.Debug("Acquiring mutex for model reload")
 	bn.mu.Lock()
 	defer bn.mu.Unlock()
@@ -1346,9 +1373,12 @@ func (bn *BirdNET) reloadModelInternal() error {
 			logger.String("model_id", oldModelInfo.ID))
 	}
 
-	// Check if model version changed; if so, the orchestrator must handle
-	// the switch via pipeline cold restart, not ReloadModel.
-	if bn.Settings.BirdNET.Version != "" {
+	// Resolve the target identity from config. A model version or file-path change
+	// requires the orchestrator to cold-restart the pipeline rather than reload in
+	// place, so those are refused here on the settings-reload path (allowPathChange
+	// false) and accepted on the variant-swap path (allowPathChange true).
+	switch {
+	case bn.Settings.BirdNET.Version != "":
 		newInfo, ok := ResolveBirdNETVersion(bn.Settings.BirdNET.Version)
 		if !ok {
 			rollback()
@@ -1366,7 +1396,10 @@ func (bn *BirdNET) reloadModelInternal() error {
 		// misreads it as a model change requiring an orchestrator restart, so in-place
 		// hot-reloads fail and roll back.
 		newInfo = remapV24ToONNXOnARM64(&newInfo, runtime.GOARCH, tfliteBackendAvailable, findModelPathInStandardPaths)
-		if newInfo.ID != bn.ModelInfo.ID || newInfo.CustomPath != bn.ModelInfo.CustomPath {
+		// A change of model ID (a different BirdNET version) always requires an
+		// orchestrator restart. A change of only the CustomPath (same ID) is refused
+		// on the settings-reload path but accepted in place on the variant-swap path.
+		if newInfo.ID != bn.ModelInfo.ID || (!allowPathChange && newInfo.CustomPath != bn.ModelInfo.CustomPath) {
 			rollback()
 			return errors.Newf("model identity changed from %s to %s: requires orchestrator restart", bn.ModelInfo.ID, newInfo.ID).
 				Component("birdnet").
@@ -1377,14 +1410,15 @@ func (bn *BirdNET) reloadModelInternal() error {
 				Build()
 		}
 		bn.ModelInfo = newInfo
-	} else if bn.Settings.BirdNET.ModelPath != "" {
+	case bn.Settings.BirdNET.ModelPath != "":
 		// Birdnet-slot model: re-derive the canonical BirdNET_V2.4 identity from
 		// the configured path (mirrors NewBirdNET Tier 3). The ID stays
 		// BirdNET_V2.4 across reloads, so only a change of the model file path is
 		// treated as a model change requiring an orchestrator restart; a no-op
-		// reload (e.g. a locale change) stays in-place.
+		// reload (e.g. a locale change) stays in-place. On the variant-swap path a
+		// changed path IS the intended swap, so it is accepted in place.
 		newInfo := customBirdNETV24ModelInfo(bn.Settings.BirdNET.ModelPath)
-		if newInfo.CustomPath != bn.ModelInfo.CustomPath {
+		if !allowPathChange && newInfo.CustomPath != bn.ModelInfo.CustomPath {
 			rollback()
 			return errors.Newf("birdnet model file changed from %q to %q: requires orchestrator restart", bn.ModelInfo.CustomPath, newInfo.CustomPath).
 				Component("birdnet").
@@ -1394,6 +1428,14 @@ func (bn *BirdNET) reloadModelInternal() error {
 				Context("requested_model_path", newInfo.CustomPath).
 				Build()
 		}
+		bn.ModelInfo = newInfo
+	case allowPathChange:
+		// Variant-swap path with a CLEARED BirdNET.ModelPath: the user reverted to
+		// the embedded BuiltIn baseline. Re-resolve the stock classifier identity
+		// (mirrors NewBirdNET Tier 4 + the arm64 v2.4->ONNX remap) so the in-place
+		// reload rebuilds the embedded model rather than keeping the old CustomPath.
+		newInfo := defaultClassifierModelInfo(runtime.GOARCH, findModelPathInStandardPaths)
+		newInfo = remapV24ToONNXOnARM64(&newInfo, runtime.GOARCH, tfliteBackendAvailable, findModelPathInStandardPaths)
 		bn.ModelInfo = newInfo
 	}
 

--- a/internal/classifier/catalog_loader.go
+++ b/internal/classifier/catalog_loader.go
@@ -238,6 +238,7 @@ func validateCatalogEntryFiles(entry *CatalogEntry) error {
 		return err
 	}
 	seenVariants := make(map[string]struct{}, len(entry.Variants))
+	builtInCount := 0
 	for i := range entry.Variants {
 		v := &entry.Variants[i]
 		if v.ID == "" {
@@ -253,6 +254,30 @@ func validateCatalogEntryFiles(entry *CatalogEntry) error {
 				Build()
 		}
 		seenVariants[v.ID] = struct{}{}
+
+		// BuiltIn baseline variants (the embedded primary model) are exempt from the
+		// no-files and model-role checks below: they carry no files because there is
+		// nothing to download, and ScanInstalled reports them installed
+		// unconditionally rather than by a model file on disk. Enforce instead that a
+		// BuiltIn variant carries NO files (its files would never be used) and that at
+		// most one variant per entry is BuiltIn.
+		if v.BuiltIn {
+			builtInCount++
+			if builtInCount > 1 {
+				return errors.Newf("catalog entry %q declares more than one built-in variant; at most one is allowed", entry.ID).
+					Component("classifier.catalog_loader").
+					Category(errors.CategoryValidation).
+					Build()
+			}
+			if len(v.Files) > 0 {
+				return errors.Newf("catalog entry %q built-in variant %q must declare no files", entry.ID, v.ID).
+					Component("classifier.catalog_loader").
+					Category(errors.CategoryValidation).
+					Build()
+			}
+			continue
+		}
+
 		if len(v.Files) == 0 {
 			return errors.Newf("catalog entry %q variant %q declares no files", entry.ID, v.ID).
 				Component("classifier.catalog_loader").

--- a/internal/classifier/catalog_loader_test.go
+++ b/internal/classifier/catalog_loader_test.go
@@ -239,6 +239,34 @@ func TestValidateCatalog_Variants(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "built-in baseline with no files is valid",
+			entry: CatalogEntry{ID: "v", Variants: []CatalogVariant{
+				{ID: "builtin", BuiltIn: true, Default: true},
+				{ID: "fp32", Files: []CatalogFile{validFile}},
+			}},
+		},
+		{
+			name: "built-in baseline may be the only variant",
+			entry: CatalogEntry{ID: "v", Variants: []CatalogVariant{
+				{ID: "builtin", BuiltIn: true, Default: true},
+			}},
+		},
+		{
+			name: "built-in variant carrying files is rejected",
+			entry: CatalogEntry{ID: "v", Variants: []CatalogVariant{
+				{ID: "builtin", BuiltIn: true, Files: []CatalogFile{validFile}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "more than one built-in variant is rejected",
+			entry: CatalogEntry{ID: "v", Variants: []CatalogVariant{
+				{ID: "builtin", BuiltIn: true, Default: true},
+				{ID: "builtin2", BuiltIn: true},
+			}},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/classifier/model_catalog.go
+++ b/internal/classifier/model_catalog.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/hwprofile"
 )
 
 // Catalog category constants.
@@ -17,6 +18,12 @@ const (
 	CategoryBat      = "bat"
 	CategoryGeomodel = "geomodel"
 )
+
+// birdnetV24SpeciesCount is the number of species in the embedded BirdNET v2.4
+// label set (data/labels/V2.4). The v2.4 entry reports this at the entry and
+// per-variant level because no labels file is downloaded, so the runtime count is
+// known statically. It matches the embedded label file's expected line count.
+const birdnetV24SpeciesCount = 6522
 
 // CatalogFile role constants.
 const (
@@ -82,6 +89,13 @@ type CatalogVariant struct {
 	Files        []CatalogFile             `json:"files"`                   // files to download for this variant
 	Legacy       bool                      `json:"legacy"`                  // if true, hidden unless already installed (superseded build)
 	SupersededBy string                    `json:"superseded_by,omitempty"` // id of the variant that replaces this one, if any
+	// BuiltIn marks the embedded baseline variant of a permanent model (the
+	// BirdNET v2.4 classifier shipped inside the binary). A BuiltIn variant carries
+	// no files (nothing to download), is always reported installed by ScanInstalled,
+	// and is exempt from the catalog's no-files / model-role validation. At most one
+	// variant per entry may set it. omitempty keeps the on-disk JSON of every other
+	// entry byte-identical, so adding this field does not shift catalogChecksum.
+	BuiltIn bool `json:"built_in,omitempty"`
 }
 
 // VariantRequirements declares the host capabilities a variant needs. Arch and
@@ -310,50 +324,68 @@ var EmbeddedCatalog = []CatalogEntry{
 		},
 	},
 
-	// BirdNET v2.4 DFT-truncated variants: opt-in, faster drop-in ONNX builds for the
-	// primary classifier, represented as one Hidden entry with hardware variants.
-	// DFT-bin truncation drops the mel-DFT bins the filterbank discards, so the output
-	// is bit-exact (single classification head, unchanged labels) while CPU/OpenVINO
-	// inference is about 1.4-2x faster. The files are published under NEW HuggingFace
-	// filenames, so existing installs are untouched.
+	// BirdNET v2.4, the permanent primary classifier, wired into its own variant set.
+	// The embedded default (shipped inside the binary) is represented as a BuiltIn
+	// baseline variant; the two DFT-truncated ONNX builds are opt-in, faster drop-in
+	// alternatives. DFT-bin truncation drops the mel-DFT bins the filterbank discards,
+	// so the output is bit-exact (single classification head, unchanged labels) while
+	// CPU/OpenVINO inference is about 1.4-2x faster. The ONNX files are published under
+	// NEW HuggingFace filenames, so existing installs are untouched.
 	//
-	// The entry is Hidden on purpose. The primary BirdNET v2.4 classifier is resolved
-	// at startup from config and the standard model paths (see NewBirdNET), NOT from
-	// the gallery, and nothing in the install path wires an installed file into
-	// BirdNET.ModelPath or hot-swaps the primary model. A visible "Install" button
-	// would therefore download a file that nothing activates. So this entry only
-	// records the authoritative checksums, sizes, and repo paths as a catalog
-	// foundation; a future primary-variant selector (tracked separately) will make the
-	// variants selectable. RegistryID is the permanent BirdNET v2.4 ID because these
-	// variants ARE that model in alternate files: being Hidden they are never
-	// hot-loaded (there is no secondary loader for the primary), and Uninstall
-	// refuses the entry via the permanent-model guard. Labels are the embedded v2.4 set (data/labels/V2.4),
-	// so no labels file is downloaded. If a power user points birdnet.modelpath at a
-	// manually fetched file, the primary loader uses it as-is (remapV24ToONNXOnARM64
-	// honors an explicit CustomPath).
+	// The entry is visible so the gallery can offer an in-place "optimize" swap between
+	// the builtin baseline and a compatible DFT-truncated build. The primary BirdNET
+	// v2.4 classifier is resolved at startup from config and the standard model paths
+	// (see NewBirdNET), NOT from a generic gallery loader, so the swap runs through a
+	// dedicated primary-reload path (ModelManager.replacePrimaryVariant ->
+	// Orchestrator.ReloadPrimaryForVariantSwap), not the generic replaceVariant flow.
+	// RegistryID is the permanent BirdNET v2.4 ID: the model is always installed (the
+	// BuiltIn baseline needs no files), it is never hot-loaded by loadInstalledModels
+	// (there is no secondary loader for the primary), and Uninstall refuses the entry
+	// via the permanent-model guard, so only its variant may change. Labels are the
+	// embedded v2.4 set (data/labels/V2.4), so no labels file is downloaded.
 	{
-		ID:              "birdnet-v2.4",
-		Name:            "BirdNET v2.4 (DFT-truncated)",
-		Description:     "Drop-in BirdNET v2.4 classifier with DFT-bin truncation: bit-exact output, about 1.4-2x faster CPU and OpenVINO inference. FP32 for OpenVINO/CPU (A76/Pi5, amd64, Intel iGPU); INT8 for low-RAM ARM via ONNX Runtime (Pi4/Pi3).",
-		Author:          "Cornell Lab of Ornithology & Chemnitz University of Technology",
-		License:         "CC-BY-NC-SA-4.0",
-		CommercialUse:   false,
-		Category:        CategoryBird,
-		Region:          "",
-		SpeciesCount:    0, // determined at runtime from the embedded v2.4 labels (no labels file is downloaded)
-		Version:         "2.4",
-		RegistryID:      permanentRegistryID,
-		Hidden:          true,
-		RequiresONNX:    true,
+		ID:            "birdnet-v2.4",
+		Name:          "BirdNET v2.4",
+		Description:   "The built-in BirdNET v2.4 classifier. Optionally swap in a DFT-truncated build for bit-exact output at about 1.4-2x faster CPU and OpenVINO inference: FP32 for OpenVINO/CPU (A76/Pi5, amd64, Intel iGPU); INT8 for low-RAM ARM via ONNX Runtime (Pi4/Pi3).",
+		Author:        "Cornell Lab of Ornithology & Chemnitz University of Technology",
+		License:       "CC-BY-NC-SA-4.0",
+		CommercialUse: false,
+		Category:      CategoryBird,
+		Region:        "",
+		SpeciesCount:  birdnetV24SpeciesCount,
+		Version:       "2.4",
+		RegistryID:    permanentRegistryID,
+		Hidden:        false,
+		// RequiresONNX is now per-variant: the BuiltIn baseline runs on the embedded
+		// TFLite model (no ONNX Runtime needed); the DFT-truncated builds are ONNX
+		// (see VariantNeedsONNX, which the install ORT gate consults per variant).
+		RequiresONNX:    false,
 		UpstreamURL:     "https://github.com/birdnet-team/BirdNET-Analyzer",
 		HuggingFaceRepo: "tphakala/BirdNET-v2.4",
 		// No labels/companions: v2.4 uses the embedded label set. Variant Files are
-		// the model file only.
+		// the model file only (and none for the BuiltIn baseline).
 		Variants: []CatalogVariant{
 			{
-				ID:        "fp32-dfttrunc",
-				Precision: "fp32",
-				Default:   true,
+				// BuiltIn baseline: the embedded v2.4 model that ships inside the
+				// binary. No files (nothing to download), always installed. It does NOT
+				// mark any ONNX backend Recommended: a 0-byte size tie-break would let
+				// this file-less variant beat a real DFT build and suppress the optimize
+				// offer, so it advertises only tflite as recommended (the embedded path)
+				// with onnxruntime-cpu merely supported.
+				ID:      "builtin",
+				BuiltIn: true,
+				Default: true,
+				// The embedded model identifies the full v2.4 label set.
+				SpeciesCount: birdnetV24SpeciesCount,
+				Backends: map[string]BackendSupport{
+					"tflite":          {Supported: true, Recommended: true},
+					"onnxruntime-cpu": {Supported: true},
+				},
+			},
+			{
+				ID:           "fp32-dfttrunc",
+				Precision:    "fp32",
+				SpeciesCount: birdnetV24SpeciesCount,
 				// RAM floors sourced from the acoustic-models
 				// BirdNET-v2.4.models.json manifest.
 				Requirements: VariantRequirements{MinRAMMB: 250},
@@ -371,6 +403,7 @@ var EmbeddedCatalog = []CatalogEntry{
 			{
 				ID:           "int8-arm-dfttrunc",
 				Precision:    "int8",
+				SpeciesCount: birdnetV24SpeciesCount,
 				Requirements: VariantRequirements{Arch: []string{"aarch64"}, MinRAMMB: 250},
 				Backends: map[string]BackendSupport{
 					"onnxruntime-cpu": {Supported: true, Recommended: true},
@@ -701,6 +734,69 @@ func variantFilesByID(entry *CatalogEntry, variantID string) (files []CatalogFil
 func VariantSelectable(entry *CatalogEntry, variantID string) bool {
 	_, ok := variantFilesByID(entry, variantID)
 	return ok
+}
+
+// IsPermanentEntry reports whether entry is the permanent built-in BirdNET v2.4
+// classifier. The permanent entry is always installed, can only have its variant
+// swapped (never uninstalled), and swaps through the dedicated primary-reload path
+// rather than the generic variant-replace flow.
+func IsPermanentEntry(entry *CatalogEntry) bool {
+	return entry != nil && entry.RegistryID == permanentRegistryID
+}
+
+// builtInVariant returns the entry's BuiltIn baseline variant (the embedded
+// primary model), or nil when the entry has none. Catalog validation guarantees at
+// most one BuiltIn variant per entry.
+func builtInVariant(entry *CatalogEntry) *CatalogVariant {
+	if entry == nil {
+		return nil
+	}
+	for i := range entry.Variants {
+		if entry.Variants[i].BuiltIn {
+			return &entry.Variants[i]
+		}
+	}
+	return nil
+}
+
+// resolveVariant returns the variant of entry with the given id, resolving an empty
+// id to the default variant. It returns nil for a flat entry (no variants) or when
+// the id matches no variant.
+func resolveVariant(entry *CatalogEntry, variantID string) *CatalogVariant {
+	if entry == nil || len(entry.Variants) == 0 {
+		return nil
+	}
+	if variantID == "" {
+		return defaultVariant(entry)
+	}
+	for i := range entry.Variants {
+		if entry.Variants[i].ID == variantID {
+			return &entry.Variants[i]
+		}
+	}
+	return nil
+}
+
+// VariantNeedsONNX reports whether running the given variant of entry requires the
+// ONNX Runtime. A BuiltIn baseline (the embedded v2.4 TFLite model) never does. A
+// variant that advertises support for the TFLite backend can also run without ORT.
+// Otherwise the variant is an ONNX build and needs the runtime. For a flat entry or
+// an unknown variant id it falls back to the entry-level RequiresONNX flag. This is
+// the per-variant refinement of the entry-level ORT gate: a v2.4 entry is no longer
+// RequiresONNX at the entry level, so the install path consults this to gate only
+// the DFT-truncated ONNX variants, never the embedded baseline.
+func VariantNeedsONNX(entry *CatalogEntry, variantID string) bool {
+	v := resolveVariant(entry, variantID)
+	if v == nil {
+		return entry != nil && entry.RequiresONNX
+	}
+	if v.BuiltIn {
+		return false
+	}
+	if _, ok := v.Backends[hwprofile.CapTFLite]; ok {
+		return false
+	}
+	return true
 }
 
 // VariantRegion returns the region slug of entry's variant with the given id, or

--- a/internal/classifier/model_catalog_test.go
+++ b/internal/classifier/model_catalog_test.go
@@ -217,6 +217,14 @@ func TestEmbeddedCatalog_HasFilesWithModelRole(t *testing.T) {
 		// time. Every variant must ship files including a model-role file.
 		if len(entry.Variants) > 0 {
 			for _, v := range entry.Variants {
+				// BuiltIn baseline variants (the embedded primary model) carry no
+				// files: there is nothing to download and ScanInstalled reports them
+				// installed unconditionally. Every other variant must ship a
+				// model-role file.
+				if v.BuiltIn {
+					assert.Emptyf(t, v.Files, "catalog entry %q built-in variant %q must declare no files", entry.ID, v.ID)
+					continue
+				}
 				require.NotEmptyf(t, v.Files, "catalog entry %q variant %q has no files", entry.ID, v.ID)
 				assert.Truef(t, hasModelRoleFile(v.Files),
 					"catalog entry %q variant %q has no file with role \"model\"", entry.ID, v.ID)
@@ -268,8 +276,10 @@ func TestCatalogByCategory(t *testing.T) {
 
 	grouped := CatalogByCategory()
 
-	// Should have wildlife, bat, and geomodel categories (bird entries are currently hidden)
+	// Should have wildlife, bird, bat, and geomodel categories. The only visible bird
+	// entry is birdnet-v2.4 (bsg-finland stays hidden).
 	require.Contains(t, grouped, CategoryWildlife)
+	require.Contains(t, grouped, CategoryBird)
 	require.Contains(t, grouped, CategoryBat)
 	require.Contains(t, grouped, CategoryGeomodel)
 
@@ -284,9 +294,13 @@ func TestCatalogByCategory(t *testing.T) {
 		assert.Equal(t, CategoryGeomodel, entry.Category)
 	}
 
+	for _, entry := range grouped[CategoryBird] {
+		assert.Equal(t, CategoryBird, entry.Category)
+	}
+
 	// Verify expected counts
 	assert.Len(t, grouped[CategoryWildlife], 2, "expected 2 visible wildlife catalog entries (perch-v2, birdnet-v3.0)")
-	assert.Empty(t, grouped[CategoryBird], "expected 0 visible bird catalog entries")
+	assert.Len(t, grouped[CategoryBird], 1, "expected 1 visible bird catalog entry (birdnet-v2.4)")
 	assert.Len(t, grouped[CategoryGeomodel], 1, "expected 1 visible geomodel catalog entry")
 	assert.Len(t, grouped[CategoryBat], 11, "expected 11 bat catalog entries")
 }
@@ -363,8 +377,15 @@ func TestVisibleCatalog_ExcludesHiddenEntries(t *testing.T) {
 	require.True(t, ok)
 	assert.True(t, bsg.Hidden)
 
-	// The collapsed BirdNET v2.4 entry is a hidden foundation entry.
-	hiddenFoundation := []string{"birdnet-v2.4"}
+	// The BirdNET v2.4 entry is now visible (un-hidden): it is wired into its own
+	// variant set (embedded BuiltIn baseline + DFT-truncated builds) so the gallery
+	// can offer an in-place optimize swap. bsg-finland remains the only hidden
+	// foundation entry.
+	birdnetV24, ok := GetCatalogEntry("birdnet-v2.4")
+	require.True(t, ok)
+	assert.False(t, birdnetV24.Hidden, "birdnet-v2.4 must be visible")
+
+	hiddenFoundation := []string{"bsg-finland"}
 	for _, id := range hiddenFoundation {
 		entry, ok := GetCatalogEntry(id)
 		require.True(t, ok, "expected to find hidden catalog entry %q", id)
@@ -378,11 +399,11 @@ func TestVisibleCatalog_ExcludesHiddenEntries(t *testing.T) {
 			"hidden entry %q must be excluded from the visible catalog", visible[i].ID)
 	}
 
-	// Visible count should be total minus the 2 hidden entries
-	// (bsg-finland and the collapsed BirdNET v2.4 foundation entry).
-	// The hardcoded count is an intentional tripwire: a new hidden entry must
-	// update it, forcing a conscious check that the exclusion is intended.
-	assert.Len(t, visible, len(EmbeddedCatalog)-2)
+	// Visible count should be total minus the 1 hidden entry (bsg-finland; the
+	// BirdNET v2.4 entry is now visible). The hardcoded count is an intentional
+	// tripwire: a new hidden entry must update it, forcing a conscious check that the
+	// exclusion is intended.
+	assert.Len(t, visible, len(EmbeddedCatalog)-1)
 }
 
 func TestGetCatalogEntry_BSGFinland(t *testing.T) {
@@ -508,32 +529,44 @@ func TestEmbeddedCatalog_BirdNETv24Variants(t *testing.T) {
 	entry, ok := GetCatalogEntry("birdnet-v2.4")
 	require.True(t, ok, "expected to find catalog entry birdnet-v2.4")
 	assert.Equal(t, CategoryBird, entry.Category, "birdnet-v2.4 must be a bird model")
-	assert.True(t, entry.Hidden, "birdnet-v2.4 must be hidden (no primary-variant selector yet)")
-	assert.True(t, entry.RequiresONNX, "birdnet-v2.4 must require ONNX")
+	assert.False(t, entry.Hidden, "birdnet-v2.4 must be visible (wired into its variant set)")
+	assert.False(t, entry.RequiresONNX, "birdnet-v2.4 ORT need is per-variant, not entry-level")
 	assert.Equal(t, permanentRegistryID, entry.RegistryID,
 		"birdnet-v2.4 must map to the permanent BirdNET v2.4 registry ID")
 	assert.Equal(t, "tphakala/BirdNET-v2.4", entry.HuggingFaceRepo, "birdnet-v2.4 repo")
+	assert.Equal(t, birdnetV24SpeciesCount, entry.SpeciesCount,
+		"birdnet-v2.4 must report the embedded label count")
 
 	cases := []struct {
-		variantID  string
-		remotePath string
-		sha256     string
-		sizeBytes  int64
-		isDefault  bool
+		variantID    string
+		builtIn      bool
+		remotePath   string
+		sha256       string
+		sizeBytes    int64
+		isDefault    bool
+		speciesCount int
 	}{
 		{
-			variantID:  "fp32-dfttrunc",
-			remotePath: "BirdNET_v2.4_fp32_dfttrunc.onnx",
-			sha256:     "3b72e88b3ad0c310a41adabccf8cf75b1a05daeeb40884ebd38038c91d0e423d",
-			sizeBytes:  54068648,
-			isDefault:  true,
+			variantID:    "builtin",
+			builtIn:      true,
+			isDefault:    true,
+			speciesCount: birdnetV24SpeciesCount,
 		},
 		{
-			variantID:  "int8-arm-dfttrunc",
-			remotePath: "BirdNET_v2.4_int8_arm_dfttrunc.onnx",
-			sha256:     "7550498ba996064feca12005ff4133eb1d35741c4061376e7a987d8227518893",
-			sizeBytes:  38727042,
-			isDefault:  false,
+			variantID:    "fp32-dfttrunc",
+			remotePath:   "BirdNET_v2.4_fp32_dfttrunc.onnx",
+			sha256:       "3b72e88b3ad0c310a41adabccf8cf75b1a05daeeb40884ebd38038c91d0e423d",
+			sizeBytes:    54068648,
+			isDefault:    false,
+			speciesCount: birdnetV24SpeciesCount,
+		},
+		{
+			variantID:    "int8-arm-dfttrunc",
+			remotePath:   "BirdNET_v2.4_int8_arm_dfttrunc.onnx",
+			sha256:       "7550498ba996064feca12005ff4133eb1d35741c4061376e7a987d8227518893",
+			sizeBytes:    38727042,
+			isDefault:    false,
+			speciesCount: birdnetV24SpeciesCount,
 		},
 	}
 	require.Lenf(t, entry.Variants, len(cases), "birdnet-v2.4 must have exactly %d variants", len(cases))
@@ -542,10 +575,21 @@ func TestEmbeddedCatalog_BirdNETv24Variants(t *testing.T) {
 	for i, tc := range cases {
 		v := entry.Variants[i]
 		assert.Equalf(t, tc.variantID, v.ID, "variant %d id", i)
+		assert.Equalf(t, tc.builtIn, v.BuiltIn, "variant %q BuiltIn flag", tc.variantID)
 		assert.Equalf(t, tc.isDefault, v.Default, "variant %q default flag", tc.variantID)
 		assert.Falsef(t, v.Legacy, "variant %q must not be Legacy", tc.variantID)
+		assert.Equalf(t, tc.speciesCount, v.SpeciesCount, "variant %q species count", tc.variantID)
 		if v.Default {
 			defaults++
+		}
+		if tc.builtIn {
+			assert.Emptyf(t, v.Files, "variant %q (built-in) must carry no files", tc.variantID)
+			// The built-in baseline must NOT recommend an ONNX backend: a 0-byte size
+			// tie-break would otherwise let it beat a real DFT build and suppress the
+			// optimize offer. It advertises tflite as the recommended path.
+			assert.Truef(t, v.Backends["tflite"].Recommended, "built-in variant must recommend tflite")
+			assert.Falsef(t, v.Backends["onnxruntime-cpu"].Recommended, "built-in variant must not recommend ORT")
+			continue
 		}
 		require.Lenf(t, v.Files, 1, "variant %q must have exactly one (model) file", tc.variantID)
 		f := v.Files[0]
@@ -556,6 +600,40 @@ func TestEmbeddedCatalog_BirdNETv24Variants(t *testing.T) {
 		assert.Equalf(t, tc.sizeBytes, f.SizeBytes, "variant %q size", tc.variantID)
 	}
 	assert.Equal(t, 1, defaults, "birdnet-v2.4 must have exactly one Default variant")
+}
+
+// TestVariantNeedsONNX covers the per-variant ORT gate: the BuiltIn baseline runs
+// on the embedded TFLite model (no ORT), the DFT-truncated builds are ONNX-only, and
+// an empty id resolves to the default (baseline) variant.
+func TestVariantNeedsONNX(t *testing.T) {
+	t.Parallel()
+
+	v24, ok := GetCatalogEntry("birdnet-v2.4")
+	require.True(t, ok)
+
+	assert.False(t, VariantNeedsONNX(&v24, "builtin"), "the embedded baseline runs on TFLite, no ORT")
+	assert.False(t, VariantNeedsONNX(&v24, ""), "empty id resolves to the default (baseline), no ORT")
+	assert.True(t, VariantNeedsONNX(&v24, "fp32-dfttrunc"), "the FP32 DFT build is ONNX-only")
+	assert.True(t, VariantNeedsONNX(&v24, "int8-arm-dfttrunc"), "the INT8 DFT build is ONNX-only")
+
+	// A flat ONNX entry (unknown variant id) falls back to the entry-level flag.
+	perch, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+	assert.True(t, VariantNeedsONNX(&perch, "fp32"), "perch fp32 is an ONNX variant")
+}
+
+// TestIsPermanentEntry verifies the permanent-entry predicate.
+func TestIsPermanentEntry(t *testing.T) {
+	t.Parallel()
+
+	v24, ok := GetCatalogEntry("birdnet-v2.4")
+	require.True(t, ok)
+	assert.True(t, IsPermanentEntry(&v24), "birdnet-v2.4 is the permanent entry")
+
+	perch, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+	assert.False(t, IsPermanentEntry(&perch), "perch-v2 is not permanent")
+	assert.False(t, IsPermanentEntry(nil), "nil is not permanent")
 }
 
 // TestEmbeddedCatalog_GlobalVariantResolution verifies the multi-variant global
@@ -673,6 +751,12 @@ func TestEmbeddedCatalog_VariantFilesSelfContained(t *testing.T) {
 		require.NotEmptyf(t, entry.Variants, "entry %q expected to carry variants", entry.ID)
 		for j := range entry.Variants {
 			v := &entry.Variants[j]
+			// The BuiltIn baseline (embedded primary model) carries no files by
+			// design; it is not a downloadable, self-contained variant.
+			if v.BuiltIn {
+				assert.Emptyf(t, v.Files, "%s/%s built-in variant must carry no files", entry.ID, v.ID)
+				continue
+			}
 			roles := fileRoles(v.Files)
 			assert.Truef(t, roles[RoleModel], "%s/%s must carry a model file", entry.ID, v.ID)
 			if wantCompanions {

--- a/internal/classifier/model_catalog_test.go
+++ b/internal/classifier/model_catalog_test.go
@@ -616,10 +616,22 @@ func TestVariantNeedsONNX(t *testing.T) {
 	assert.True(t, VariantNeedsONNX(&v24, "fp32-dfttrunc"), "the FP32 DFT build is ONNX-only")
 	assert.True(t, VariantNeedsONNX(&v24, "int8-arm-dfttrunc"), "the INT8 DFT build is ONNX-only")
 
-	// A flat ONNX entry (unknown variant id) falls back to the entry-level flag.
+	// A known ONNX variant resolves through the variant branch.
 	perch, ok := GetCatalogEntry("perch-v2")
 	require.True(t, ok)
 	assert.True(t, VariantNeedsONNX(&perch, "fp32"), "perch fp32 is an ONNX variant")
+
+	// An unknown variant id falls back to the entry-level RequiresONNX flag.
+	assert.True(t, VariantNeedsONNX(&perch, "no-such-variant"),
+		"an unknown variant id on an ONNX entry falls back to the entry flag")
+	assert.False(t, VariantNeedsONNX(&v24, "no-such-variant"),
+		"an unknown variant id on v2.4 falls back to its false entry flag")
+
+	// A flat entry (no variants) uses the entry-level flag directly.
+	bsg, ok := GetCatalogEntry("bsg-finland")
+	require.True(t, ok)
+	require.Empty(t, bsg.Variants, "bsg-finland is a flat entry")
+	assert.True(t, VariantNeedsONNX(&bsg, ""), "a flat ONNX entry needs ORT")
 }
 
 // TestIsPermanentEntry verifies the permanent-entry predicate.

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -348,6 +348,41 @@ func modelAndLabelsFiles(files []CatalogFile) (modelFile, labelsFile string) {
 // remaining variants in catalog order. ok is false when no variant's model file
 // is present on disk.
 func scanVariantEntry(entry *CatalogEntry, subdir, modelBasenameHint string) (InstalledModel, bool) {
+	// Permanent entry with a BuiltIn baseline (BirdNET v2.4): the model is ALWAYS
+	// installed, but which variant is active is decided by the settings hint alone,
+	// NOT by which files happen to be on disk. A non-empty hint that matches a
+	// DFT-truncated variant's file (present on disk) selects it; anything else
+	// resolves to the BuiltIn baseline with an empty ModelPath. This inverts the
+	// usual "any file present -> that variant" fall-through: a stale DFT file left on
+	// disk after the user reverted to the baseline (BirdNET.ModelPath cleared) must
+	// NOT be reported as the active variant, because the primary loader opens the
+	// embedded model, not that file.
+	if builtin := builtInVariant(entry); builtin != nil {
+		if modelBasenameHint != "" {
+			for i := range entry.Variants {
+				v := &entry.Variants[i]
+				if v.BuiltIn {
+					continue
+				}
+				mf, _ := modelAndLabelsFiles(v.Files)
+				if mf == modelBasenameHint {
+					if im, ok := installedFromVariant(entry, v, subdir); ok {
+						return im, true
+					}
+					break
+				}
+			}
+		}
+		// Baseline: always installed, no model path (the embedded model is used).
+		return InstalledModel{
+			CatalogID:   entry.ID,
+			VariantID:   builtin.ID,
+			ModelPath:   "",
+			InstalledAt: time.Now(),
+			Version:     entry.Version,
+		}, true
+	}
+
 	// Prefer the variant whose model file matches the persisted settings path.
 	// After a crashed replace both variants' files can be present on disk; the
 	// settings path is what the loader (buildPerch/buildBirdNETV3) actually opens,
@@ -393,6 +428,11 @@ func installedModelBasenameHint(settings *conf.Settings, registryID string) stri
 	}
 	var p string
 	switch registryID {
+	case permanentRegistryID:
+		// The permanent BirdNET v2.4 classifier: its selected DFT-truncated file
+		// (if any) is recorded in BirdNET.ModelPath. An empty path means the
+		// embedded BuiltIn baseline is active.
+		p = settings.BirdNET.ModelPath
 	case RegistryIDBirdNETV3:
 		p = settings.BirdNETV3.ModelPath
 	case RegistryIDPerchV2:
@@ -655,6 +695,14 @@ func (mm *ModelManager) loadInstalledModels(log logger.Logger, installedIDs []st
 	for _, catalogID := range installedIDs {
 		entry, found := GetCatalogEntry(catalogID)
 		if !found || entry.RegistryID == "" {
+			continue
+		}
+		// The permanent BirdNET v2.4 classifier is the primary model, resolved at
+		// startup by NewBirdNET, not loaded through the orchestrator's secondary
+		// loaders. It has no ModelLoaders entry, so calling LoadModel would only log
+		// a spurious "failed to load" warning. Skip it: it is always "installed" but
+		// never hot-loaded here.
+		if entry.RegistryID == permanentRegistryID {
 			continue
 		}
 		if mm.orchestrator.IsModelLoaded(entry.RegistryID) {
@@ -1172,6 +1220,30 @@ func (mm *ModelManager) InstallOrReplace(ctx context.Context, entry *CatalogEntr
 			Build()
 	}
 	current, installed := mm.installed[entry.ID]
+
+	// Permanent primary model (BirdNET v2.4): always "installed", and its variant is
+	// swapped through the dedicated primary-reload path, never the generic
+	// orchestrator unload/load. If ScanInstalled has not run yet, treat the current
+	// state as the embedded BuiltIn baseline so the swap still has a rollback target.
+	if IsPermanentEntry(entry) {
+		if !installed {
+			current = InstalledModel{CatalogID: entry.ID, Version: entry.Version}
+			if b := builtInVariant(entry); b != nil {
+				current.VariantID = b.ID
+			}
+		}
+		if current.VariantID == target {
+			mm.mu.Unlock()
+			return nil
+		}
+		mm.downloading[entry.ID] = &DownloadState{
+			CatalogID: entry.ID,
+			Status:    StatusDownloading,
+		}
+		mm.mu.Unlock()
+		return mm.replacePrimaryVariant(ctx, entry, &current, target, baseURL, progress)
+	}
+
 	if installed && current.VariantID == target {
 		// Idempotent: the requested variant is already the installed one.
 		mm.mu.Unlock()
@@ -1350,6 +1422,153 @@ func (mm *ModelManager) rollbackVariantSwitch(log logger.Logger, entry *CatalogE
 		mm.removeDownloading(entry.ID)
 	})
 	return switchErr
+}
+
+// replacePrimaryVariant swaps the permanent primary classifier (BirdNET v2.4)
+// between its embedded BuiltIn baseline and a DFT-truncated ONNX build, in place,
+// without a pipeline restart. It mirrors replaceVariant's download-before-delete and
+// rollback discipline, but the primary cannot be orchestrator-unloaded/loaded, so it
+// activates through the dedicated primary-reload path
+// (Orchestrator.ReloadPrimaryForVariantSwap). The target's files (none for the
+// BuiltIn baseline) are fetched first while the old model keeps running, then
+// BirdNET.ModelPath is set (or cleared for the baseline) and the primary is reloaded.
+// A reload failure restores the previous variant's config and record; the running
+// model was already kept alive by reloadModelInternal's transactional rollback, so a
+// failed swap never strands the classifier. The caller must have registered entry.ID
+// in mm.downloading; replacePrimaryVariant clears it (or schedules cleanup on
+// failure) before returning.
+func (mm *ModelManager) replacePrimaryVariant(ctx context.Context, entry *CatalogEntry, old *InstalledModel, newVariantID, baseURL string, progress chan<- DownloadState) error {
+	log := GetLogger()
+
+	targetIsBuiltIn := false
+	if v := resolveVariant(entry, newVariantID); v != nil {
+		targetIsBuiltIn = v.BuiltIn
+	}
+
+	// 1. Acquire the new variant's model file. The BuiltIn baseline is embedded, so
+	//    there is nothing to download; a DFT build is fetched (the old model keeps
+	//    running) and removed on a failed switch.
+	newModelPath := ""
+	if !targetIsBuiltIn {
+		_, modelPath, _, _, err := mm.downloadVariantFiles(ctx, entry, newVariantID, baseURL, progress, true)
+		if err != nil {
+			// downloadVariantFiles already marked the state failed; retain it briefly
+			// for SSE pollers, then clear. The old variant is untouched and running.
+			time.AfterFunc(failedStateRetention, func() {
+				mm.removeDownloading(entry.ID)
+			})
+			return err
+		}
+		newModelPath = modelPath
+	}
+
+	// 2. Swap the install record to the new variant. entry.ID stays in
+	//    mm.downloading (cleared in step 6) so a concurrent ScanInstalled treats the
+	//    switch as in-flight until the superseded files are removed.
+	mm.mu.Lock()
+	mm.installed[entry.ID] = InstalledModel{
+		CatalogID:   entry.ID,
+		VariantID:   newVariantID,
+		ModelPath:   newModelPath,
+		InstalledAt: time.Now(),
+		Version:     entry.Version,
+	}
+	mm.mu.Unlock()
+
+	// 3. Persist BirdNET.ModelPath (set for a DFT build, cleared for the baseline)
+	//    BEFORE reloading, so the primary loader resolves the new file and a
+	//    crash/restart before step 4 still resolves the new variant.
+	mm.applyConfigForPrimarySwap(newModelPath)
+
+	// 4. Activate the new variant by reloading the primary in place. A reload failure
+	//    rolls back (the running model was already kept alive transactionally).
+	if mm.orchestrator != nil {
+		if reloadErr := mm.orchestrator.ReloadPrimaryForVariantSwap(); reloadErr != nil {
+			return mm.rollbackPrimaryVariantSwap(log, entry, old, newVariantID, reloadErr, progress)
+		}
+		mm.notifyTopologyChanged()
+	}
+
+	// 5. Remove the OLD variant's superseded files. Safe for builtin ids: the
+	//    BuiltIn baseline carries no files, so nothing is targeted when the old
+	//    variant was the baseline, and its files are removed when the old variant was
+	//    a DFT build superseded by the baseline.
+	mm.removeSupersededVariantFiles(log, entry, old.VariantID, newVariantID)
+
+	// 6. The switch is complete: clear the in-flight marker and report success.
+	mm.removeDownloading(entry.ID)
+	sendProgress(progress, entry.ID, StatusComplete)
+
+	log.Info("Primary model variant switched",
+		logger.String("catalog_id", entry.ID),
+		logger.String("from_variant", old.VariantID),
+		logger.String("to_variant", newVariantID),
+		logger.String("model_path", newModelPath))
+
+	return nil
+}
+
+// rollbackPrimaryVariantSwap restores the previously-active primary variant after a
+// failed reload of the new one. reloadModelInternal already kept the previous model
+// serving via its transactional rollback, so this only re-records the old variant,
+// re-persists its config, and removes the new variant's now-unused files; it does
+// NOT reload again (that would put a working model at risk for no gain). It reports
+// the swap as failed over the progress stream. The caller must have registered
+// entry.ID in mm.downloading; rollbackPrimaryVariantSwap schedules its cleanup.
+func (mm *ModelManager) rollbackPrimaryVariantSwap(log logger.Logger, entry *CatalogEntry, old *InstalledModel, newVariantID string, cause error, progress chan<- DownloadState) error {
+	log.Warn("New primary variant failed to reload; rolled back to the previous variant",
+		logger.String("catalog_id", entry.ID),
+		logger.String("failed_variant", newVariantID),
+		logger.String("restored_variant", old.VariantID),
+		logger.Error(cause))
+
+	// Restore the install record and re-persist the old variant's config (step 3
+	// wrote the new path). The running model is already the old one.
+	mm.mu.Lock()
+	mm.installed[entry.ID] = *old
+	mm.mu.Unlock()
+	mm.applyConfigForPrimarySwap(old.ModelPath)
+
+	// The new variant is unusable on this host: remove its downloaded files (none for
+	// the BuiltIn baseline) so disk state matches the restored record.
+	mm.removeSupersededVariantFiles(log, entry, newVariantID, old.VariantID)
+
+	switchErr := errors.Newf("switched %s to variant %q but it failed to load; restored previous variant %q", entry.ID, newVariantID, old.VariantID).
+		Component("classifier.model_manager").
+		Category(errors.CategoryModelInit).
+		Context("catalog_id", entry.ID).
+		Context("failed_variant", newVariantID).
+		Context("restored_variant", old.VariantID).
+		Context("reload_error", cause.Error()).
+		Build()
+	mm.markFailed(entry.ID, switchErr, progress)
+	time.AfterFunc(failedStateRetention, func() {
+		mm.removeDownloading(entry.ID)
+	})
+	return switchErr
+}
+
+// applyConfigForPrimarySwap persists the primary classifier's selected model file
+// path for a within-model BirdNET v2.4 variant swap: it sets BirdNET.ModelPath to
+// the new DFT-truncated file, or clears it (empty modelPath) to revert to the
+// embedded BuiltIn baseline. It never touches BirdNET.LabelPath: the v2.4 label set
+// is embedded and identical across variants, so a swap must not disturb a
+// user-configured custom label path. Uses clone-mutate-publish + SaveSettings so the
+// change survives restarts and is visible to concurrent readers.
+func (mm *ModelManager) applyConfigForPrimarySwap(modelPath string) {
+	if mm.settings == nil {
+		return
+	}
+	mm.settingsMu.Lock()
+	defer mm.settingsMu.Unlock()
+
+	updated := conf.CloneSettings(conf.GetSettings())
+	updated.BirdNET.ModelPath = modelPath
+	conf.StoreSettings(updated)
+	if err := conf.SaveSettings(); err != nil {
+		GetLogger().Warn("Failed to persist settings after primary variant swap",
+			logger.Error(err))
+	}
 }
 
 // removeSupersededVariantFiles deletes the old variant's files that the new

--- a/internal/classifier/model_manager_primary_swap_test.go
+++ b/internal/classifier/model_manager_primary_swap_test.go
@@ -13,6 +13,19 @@ import (
 	"github.com/tphakala/birdnet-go/internal/conf/conftest"
 )
 
+// isolateTestConfig points conf.ConfigPath at a throwaway file under t.TempDir()
+// and restores the original in cleanup. Without it, applyConfigForPrimarySwap ->
+// conf.SaveSettings resolves the default user config path and overwrites the
+// developer's real ~/.config/birdnet-go/config.yaml during the test run.
+func isolateTestConfig(t *testing.T) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte{}, 0o600))
+	orig := conf.ConfigPath
+	conf.ConfigPath = path
+	t.Cleanup(func() { conf.ConfigPath = orig })
+}
+
 // permanentSwapEntry builds a synthetic permanent (BirdNET v2.4-style) catalog
 // entry with a file-less BuiltIn baseline and one downloadable DFT-truncated
 // variant served by a local test server. It mirrors the real birdnet-v2.4 shape
@@ -77,6 +90,7 @@ func TestModelManager_ScanInstalled_PermanentBaseline(t *testing.T) {
 
 	origSettings := conf.GetSettings()
 	t.Cleanup(func() { conf.StoreSettings(origSettings) })
+	isolateTestConfig(t)
 
 	cases := []struct {
 		name        string
@@ -130,6 +144,7 @@ func TestModelManager_PrimarySwap_BaselineToDFT(t *testing.T) {
 
 	origSettings := conf.GetSettings()
 	t.Cleanup(func() { conf.StoreSettings(origSettings) })
+	isolateTestConfig(t)
 
 	settings := conftest.GetTestSettings()
 	settings.BirdNET.LabelPath = "/custom/labels.txt" // must survive the swap
@@ -160,6 +175,7 @@ func TestModelManager_PrimarySwap_DFTToBaseline(t *testing.T) {
 
 	origSettings := conf.GetSettings()
 	t.Cleanup(func() { conf.StoreSettings(origSettings) })
+	isolateTestConfig(t)
 
 	settings := conftest.GetTestSettings()
 	conf.StoreSettings(settings)
@@ -195,6 +211,7 @@ func TestModelManager_PrimarySwap_SameVariantIsNoOp(t *testing.T) {
 
 	origSettings := conf.GetSettings()
 	t.Cleanup(func() { conf.StoreSettings(origSettings) })
+	isolateTestConfig(t)
 
 	settings := conftest.GetTestSettings()
 	conf.StoreSettings(settings)
@@ -220,6 +237,7 @@ func TestModelManager_PrimarySwap_RollbackOnReloadFailure(t *testing.T) {
 
 	origSettings := conf.GetSettings()
 	t.Cleanup(func() { conf.StoreSettings(origSettings) })
+	isolateTestConfig(t)
 
 	settings := conftest.GetTestSettings()
 	conf.StoreSettings(settings)

--- a/internal/classifier/model_manager_primary_swap_test.go
+++ b/internal/classifier/model_manager_primary_swap_test.go
@@ -1,0 +1,242 @@
+package classifier
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/conf/conftest"
+)
+
+// permanentSwapEntry builds a synthetic permanent (BirdNET v2.4-style) catalog
+// entry with a file-less BuiltIn baseline and one downloadable DFT-truncated
+// variant served by a local test server. It mirrors the real birdnet-v2.4 shape
+// (RegistryID == permanentRegistryID) so InstallOrReplace routes it through the
+// dedicated primary-swap path, while using a small payload with a matching checksum
+// so the download verifies without the real multi-MB model file.
+func permanentSwapEntry(t *testing.T) (entry CatalogEntry, modelsDir, srvURL, dftLocalName string) {
+	t.Helper()
+
+	dftData := []byte("fake-dft-truncated-onnx-model")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/dft.onnx" {
+			_, _ = w.Write(dftData)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	dftLocalName = "BirdNET_v2.4_fp32_dfttrunc.onnx"
+	entry = CatalogEntry{
+		ID:              "test-primary-v2.4",
+		Name:            "Test Primary v2.4",
+		Version:         "2.4",
+		Category:        CategoryBird,
+		RegistryID:      permanentRegistryID,
+		HuggingFaceRepo: "t/v2.4",
+		SpeciesCount:    birdnetV24SpeciesCount,
+		Variants: []CatalogVariant{
+			{
+				ID:           "builtin",
+				BuiltIn:      true,
+				Default:      true,
+				SpeciesCount: birdnetV24SpeciesCount,
+				Backends: map[string]BackendSupport{
+					"tflite":          {Supported: true, Recommended: true},
+					"onnxruntime-cpu": {Supported: true},
+				},
+			},
+			{
+				ID:        "fp32-dfttrunc",
+				Precision: "fp32",
+				Files: []CatalogFile{
+					{RemotePath: "dft.onnx", LocalName: dftLocalName, Role: RoleModel, SHA256: sha256Hex(dftData), SizeBytes: int64(len(dftData))},
+				},
+			},
+		},
+	}
+	return entry, t.TempDir(), srv.URL, dftLocalName
+}
+
+// TestModelManager_ScanInstalled_PermanentBaseline exercises the stale-file
+// inversion in scanVariantEntry for the real birdnet-v2.4 entry: the BuiltIn
+// baseline is always reported installed, a settings hint pointing at a DFT file
+// present on disk promotes that variant, and a leftover DFT file with a cleared
+// BirdNET.ModelPath must NOT be reported (the loader opens the embedded model).
+func TestModelManager_ScanInstalled_PermanentBaseline(t *testing.T) {
+	// Not parallel: mutates global settings via conf.StoreSettings.
+	entry, ok := GetCatalogEntry("birdnet-v2.4")
+	require.True(t, ok)
+	dftLocal := modelRoleLocalName(t, variantByID(t, &entry, "fp32-dfttrunc").Files)
+
+	origSettings := conf.GetSettings()
+	t.Cleanup(func() { conf.StoreSettings(origSettings) })
+
+	cases := []struct {
+		name        string
+		writeDFT    bool
+		hintToDFT   bool
+		wantVariant string
+		wantPath    string // "" means empty (embedded baseline)
+	}{
+		{"no files, empty hint -> baseline", false, false, "builtin", ""},
+		{"dft on disk + hint -> dft variant", true, true, "fp32-dfttrunc", "set"},
+		{"stale dft on disk + empty hint -> baseline (inversion)", true, false, "builtin", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			modelsDir := t.TempDir()
+			dftPath := filepath.Join(modelsDir, entry.ID, dftLocal)
+			if tc.writeDFT {
+				require.NoError(t, os.MkdirAll(filepath.Dir(dftPath), 0o755))
+				require.NoError(t, os.WriteFile(dftPath, []byte("dft"), 0o644))
+			}
+
+			settings := conftest.GetTestSettings()
+			if tc.hintToDFT {
+				settings.BirdNET.ModelPath = dftPath
+			}
+			conf.StoreSettings(settings)
+
+			mm := NewModelManager(modelsDir, nil, settings)
+			mm.ScanInstalled()
+
+			im := installedByID(t, mm, entry.ID)
+			assert.Equal(t, tc.wantVariant, im.VariantID, "resolved variant")
+			if tc.wantPath == "" {
+				assert.Empty(t, im.ModelPath, "baseline must report an empty model path")
+			} else {
+				assert.Equal(t, dftPath, im.ModelPath, "DFT variant must report its file path")
+			}
+		})
+	}
+}
+
+// TestModelManager_PrimarySwap_BaselineToDFT verifies swapping the permanent
+// primary model from its BuiltIn baseline to a DFT-truncated build: the file is
+// downloaded, the install record and BirdNET.ModelPath point at it, and LabelPath is
+// untouched. The orchestrator is nil, so the reload step is skipped (treated as a
+// successful activation for the state-transition assertions).
+func TestModelManager_PrimarySwap_BaselineToDFT(t *testing.T) {
+	// Not parallel: mutates global settings via conf.StoreSettings.
+	entry, modelsDir, srvURL, dftLocalName := permanentSwapEntry(t)
+
+	origSettings := conf.GetSettings()
+	t.Cleanup(func() { conf.StoreSettings(origSettings) })
+
+	settings := conftest.GetTestSettings()
+	settings.BirdNET.LabelPath = "/custom/labels.txt" // must survive the swap
+	conf.StoreSettings(settings)
+	mm := NewModelManager(modelsDir, nil, settings)
+
+	require.NoError(t, mm.InstallOrReplace(t.Context(), &entry, "fp32-dfttrunc", srvURL, nil))
+
+	got := installedByID(t, mm, entry.ID)
+	assert.Equal(t, "fp32-dfttrunc", got.VariantID, "the DFT variant must be recorded")
+	dftPath := filepath.Join(modelsDir, entry.ID, dftLocalName)
+	assert.Equal(t, dftPath, got.ModelPath, "the install record must point at the downloaded file")
+	assert.FileExists(t, dftPath, "the DFT model file must be on disk")
+
+	current := conf.GetSettings()
+	assert.Equal(t, dftPath, current.BirdNET.ModelPath, "BirdNET.ModelPath must select the DFT file")
+	assert.Equal(t, "/custom/labels.txt", current.BirdNET.LabelPath, "a primary swap must never touch LabelPath")
+	assert.Nil(t, mm.GetDownloadState(entry.ID), "no download state may linger after a completed swap")
+}
+
+// TestModelManager_PrimarySwap_DFTToBaseline verifies reverting from a
+// DFT-truncated build back to the BuiltIn baseline: no download happens,
+// BirdNET.ModelPath is cleared, the install record reports the baseline with an
+// empty path, and the superseded DFT file is removed from disk.
+func TestModelManager_PrimarySwap_DFTToBaseline(t *testing.T) {
+	// Not parallel: mutates global settings via conf.StoreSettings.
+	entry, modelsDir, srvURL, dftLocalName := permanentSwapEntry(t)
+
+	origSettings := conf.GetSettings()
+	t.Cleanup(func() { conf.StoreSettings(origSettings) })
+
+	settings := conftest.GetTestSettings()
+	conf.StoreSettings(settings)
+	mm := NewModelManager(modelsDir, nil, settings)
+
+	// Start on the DFT build.
+	require.NoError(t, mm.InstallOrReplace(t.Context(), &entry, "fp32-dfttrunc", srvURL, nil))
+	dftPath := filepath.Join(modelsDir, entry.ID, dftLocalName)
+	require.FileExists(t, dftPath)
+	require.Equal(t, dftPath, conf.GetSettings().BirdNET.ModelPath)
+
+	// Revert to the baseline (empty variant id resolves to the default = builtin).
+	require.NoError(t, mm.InstallOrReplace(t.Context(), &entry, "builtin", srvURL, nil))
+
+	got := installedByID(t, mm, entry.ID)
+	assert.Equal(t, "builtin", got.VariantID, "the baseline must be recorded")
+	assert.Empty(t, got.ModelPath, "the baseline install record carries no model path")
+
+	current := conf.GetSettings()
+	assert.Empty(t, current.BirdNET.ModelPath, "reverting to the baseline must clear BirdNET.ModelPath")
+
+	_, err := os.Stat(dftPath)
+	assert.True(t, os.IsNotExist(err), "the superseded DFT file must be removed when reverting to the baseline")
+	assert.Nil(t, mm.GetDownloadState(entry.ID))
+}
+
+// TestModelManager_PrimarySwap_SameVariantIsNoOp verifies that selecting the
+// already-active primary variant is an idempotent no-op that neither downloads nor
+// changes config.
+func TestModelManager_PrimarySwap_SameVariantIsNoOp(t *testing.T) {
+	// Not parallel: mutates global settings via conf.StoreSettings.
+	entry, modelsDir, srvURL, _ := permanentSwapEntry(t)
+
+	origSettings := conf.GetSettings()
+	t.Cleanup(func() { conf.StoreSettings(origSettings) })
+
+	settings := conftest.GetTestSettings()
+	conf.StoreSettings(settings)
+	mm := NewModelManager(modelsDir, nil, settings)
+
+	// Nothing installed yet: the permanent entry defaults to its BuiltIn baseline,
+	// so requesting the baseline (by default and by id) is a no-op.
+	require.NoError(t, mm.InstallOrReplace(t.Context(), &entry, "", srvURL, nil))
+	require.NoError(t, mm.InstallOrReplace(t.Context(), &entry, "builtin", srvURL, nil))
+
+	assert.Empty(t, conf.GetSettings().BirdNET.ModelPath, "a no-op baseline swap must not set a model path")
+	assert.Nil(t, mm.GetDownloadState(entry.ID))
+}
+
+// TestModelManager_PrimarySwap_RollbackOnReloadFailure verifies the transactional
+// rollback: when the primary reload fails, the swap restores the previous variant's
+// record and config and removes the newly downloaded file. The reload is forced to
+// fail with a primary-less test orchestrator (ReloadPrimaryForVariantSwap returns
+// "primary model not available").
+func TestModelManager_PrimarySwap_RollbackOnReloadFailure(t *testing.T) {
+	// Not parallel: mutates global settings via conf.StoreSettings.
+	entry, modelsDir, srvURL, dftLocalName := permanentSwapEntry(t)
+
+	origSettings := conf.GetSettings()
+	t.Cleanup(func() { conf.StoreSettings(origSettings) })
+
+	settings := conftest.GetTestSettings()
+	conf.StoreSettings(settings)
+
+	orch := newTestOrchestrator(t) // no primary -> ReloadPrimaryForVariantSwap errors
+	mm := NewModelManager(modelsDir, orch, settings)
+
+	err := mm.InstallOrReplace(t.Context(), &entry, "fp32-dfttrunc", srvURL, nil)
+	require.Error(t, err, "a failed primary reload must surface as an error")
+
+	got := installedByID(t, mm, entry.ID)
+	assert.Equal(t, "builtin", got.VariantID, "a failed swap must restore the baseline record")
+
+	current := conf.GetSettings()
+	assert.Empty(t, current.BirdNET.ModelPath, "a failed swap must restore the (empty) baseline model path")
+
+	dftPath := filepath.Join(modelsDir, entry.ID, dftLocalName)
+	_, statErr := os.Stat(dftPath)
+	assert.True(t, os.IsNotExist(statErr), "a failed swap must remove the newly downloaded file")
+}

--- a/internal/classifier/model_manager_test.go
+++ b/internal/classifier/model_manager_test.go
@@ -65,11 +65,18 @@ func TestModelManager_ScanInstalled(t *testing.T) {
 
 	assert.True(t, mm.IsInstalled(entry.ID), "expected %s to be detected as installed", entry.ID)
 
-	installed := mm.ListInstalled()
-	require.Len(t, installed, 1)
-	assert.Equal(t, entry.ID, installed[0].CatalogID)
-	assert.Equal(t, modelPath, installed[0].ModelPath)
-	assert.Equal(t, entry.Version, installed[0].Version)
+	// The permanent BirdNET v2.4 baseline is always reported installed, so the bat
+	// model is looked up by id rather than by position.
+	im := installedByID(t, mm, entry.ID)
+	assert.Equal(t, entry.ID, im.CatalogID)
+	assert.Equal(t, modelPath, im.ModelPath)
+	assert.Equal(t, entry.Version, im.Version)
+
+	// The built-in v2.4 primary classifier is always installed (embedded baseline).
+	assert.True(t, mm.IsInstalled("birdnet-v2.4"), "built-in BirdNET v2.4 must always be installed")
+	v24 := installedByID(t, mm, "birdnet-v2.4")
+	assert.Equal(t, "builtin", v24.VariantID, "v2.4 baseline variant id")
+	assert.Empty(t, v24.ModelPath, "v2.4 baseline has no model path (embedded)")
 }
 
 // variantByID returns the variant with the given id from entry, failing the
@@ -628,26 +635,21 @@ func TestModelManager_ListInstalled(t *testing.T) {
 func TestModelManager_UninstallRejectsPermanent(t *testing.T) {
 	t.Parallel()
 
+	// The permanent BirdNET v2.4 entry is now a real, visible catalog entry whose
+	// BuiltIn baseline is always installed. Uninstall must still refuse it: only its
+	// variant may be swapped, never removed.
+	entry, ok := GetCatalogEntry("birdnet-v2.4")
+	require.True(t, ok, "birdnet-v2.4 must be present in the catalog")
+	require.Equal(t, permanentRegistryID, entry.RegistryID, "birdnet-v2.4 must carry the permanent registry id")
+
 	mm := NewModelManager(t.TempDir(), nil, nil)
+	mm.ScanInstalled()
+	require.True(t, mm.IsInstalled("birdnet-v2.4"), "the built-in baseline must always be installed")
 
-	// Find a catalog entry whose RegistryID maps to BirdNET_V2.4.
-	var permanentID string
-	for _, entry := range EmbeddedCatalog {
-		if entry.RegistryID == permanentRegistryID {
-			permanentID = entry.ID
-			break
-		}
-	}
-
-	// If no catalog entry maps to BirdNET_V2.4, the test is not applicable
-	// (the permanent model is embedded, not downloadable). Skip gracefully.
-	if permanentID == "" {
-		t.Skip("no catalog entry maps to permanentRegistryID; nothing to test")
-	}
-
-	err := mm.Uninstall(permanentID)
+	err := mm.Uninstall("birdnet-v2.4")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot uninstall")
+	assert.True(t, mm.IsInstalled("birdnet-v2.4"), "the permanent model must remain installed after a refused uninstall")
 }
 
 func TestModelManager_UninstallNotInstalled(t *testing.T) {

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -1180,6 +1180,27 @@ func (o *Orchestrator) RunFilterProcess(dateStr string, week float32) {
 // Acquires the per-model lock before reload to prevent concurrent inference,
 // then the write lock to re-key the models map.
 func (o *Orchestrator) ReloadModel() error {
+	return o.reloadPrimaryModel(func(primary *BirdNET) error { return primary.ReloadModel() })
+}
+
+// ReloadPrimaryForVariantSwap reloads the primary classifier in place for a
+// within-model variant swap (the gallery "optimize" flow for the permanent BirdNET
+// v2.4 model), accepting a changed or cleared model file path that ReloadModel would
+// refuse as a model-identity change. It shares reloadPrimaryModel's locking and
+// shared-state re-sync, differing only in delegating to BirdNET.reloadForVariantSwap
+// (allowPathChange=true). The model ID is invariant across a v2.4 variant swap, so
+// the re-key is a no-op in practice. Transactional rollback to the previous model
+// lives in reloadModelInternal, so a failed swap leaves the previous variant serving.
+func (o *Orchestrator) ReloadPrimaryForVariantSwap() error {
+	return o.reloadPrimaryModel(func(primary *BirdNET) error { return primary.reloadForVariantSwap() })
+}
+
+// reloadPrimaryModel performs the shared locking, per-instance reload, shared-state
+// re-sync, and models-map re-key for a primary-model reload. It delegates the actual
+// per-instance reload to reload(primary); ReloadModel passes BirdNET.ReloadModel (a
+// settings reload, path change refused) and ReloadPrimaryForVariantSwap passes
+// BirdNET.reloadForVariantSwap (an in-place variant swap, path change accepted).
+func (o *Orchestrator) reloadPrimaryModel(reload func(primary *BirdNET) error) error {
 	// Step 1: acquire per-model lock to prevent concurrent inference during reload.
 	o.mu.RLock()
 	primary := o.primary
@@ -1208,7 +1229,7 @@ func (o *Orchestrator) ReloadModel() error {
 	func() {
 		entry.mu.Lock()
 		defer entry.mu.Unlock()
-		reloadErr = primary.ReloadModel()
+		reloadErr = reload(primary)
 	}()
 	if reloadErr != nil {
 		return reloadErr


### PR DESCRIPTION
Folds three coupled model-gallery improvements into one PR.

## A. Variant-aware cards

Gallery cards now describe the RELEVANT variant instead of entry-level globals: the recommended variant on the Available tab, the installed variant on the Installed tab. Each card shows that variant's region (its region name, or a localized "Global"), its sliced species count, and a friendly hardware chip (GPU / Intel GPU / ARM CPU / CPU) derived entirely client-side from the recommendation backend token (with an id/precision fallback). This fixes the previously blank region row and the wrong (global) species count on variant-bearing cards.

## B. Within-model optimize

A new client-side-derived offer surfaces when an installed model has a faster or better-matched build for this host: it exists iff the entry is installed, has variants, its installed variant differs from the host-recommended one, and the recommended variant is compatible. It is strictly same-model (a better build of a model you already have), never cross-model, and needs no new endpoint (`POST /models/install/:id` with a variantId already routes to the swap path). Surfaced as a dismissable top banner, a per-card Optimize badge and action, and a review dialog listing each offer with a from -> to summary, hardware chips, and reasons, plus per-row Apply and a sequential Apply-all. A within-model swap never changes the license, so the existing install/consent flow is reused unchanged.

## C. Built-in BirdNET v2.4 wired into its variant set

The hardcoded static v2.4 card is replaced by the real `birdnet-v2.4` catalog entry, un-hidden, with the embedded default represented as a `BuiltIn` baseline variant so v2.4 participates in optimize. The entry is always installed (the baseline needs no files) and stays permanent: Uninstall keeps refusing it, and only its variant may change. Because the primary classifier cannot be swapped through the generic variant-replace path (the orchestrator refuses to unload the primary and there is no BirdNET_V2.4 model loader), a dedicated transactional primary-reload path is added: `reloadModelInternal(allowPathChange)` + `Orchestrator.ReloadPrimaryForVariantSwap` and `ModelManager.replacePrimaryVariant`, with download-before-delete, config set/clear that never touches the label path, and full rollback (the previous model keeps serving on failure). The install ORT gate becomes variant-scoped, so swapping to the embedded TFLite baseline is never blocked while an ONNX DFT build still requires the runtime.

## Notes

- No schema bump: `BuiltIn`/`Permanent` are additive/omitempty; the catalog checksum shifts and self-heals for pristine catalogs, and user-edited catalogs degrade gracefully.
- v2.4 optimize is hardware-axis only (no regional v2.4 builds exist).
- New i18n keys under `analysis.gallery.*` added to en.json and translated across all locales; generated types committed.
- A pre-push multi-agent review (correctness, wiring, regression, i18n, tests, UX, performance) plus two independent Gemini reviews ran on the change; findings addressed or filed as follow-ups.

## Testing

- Backend: catalog pin + BuiltIn validation, ScanInstalled baseline table with stale-file inversion, primary-swap suite including reload-failure rollback, v2.4 recommender matrix, permanent uninstall/reinstall refusal, variant-scoped ONNX gate (`go test -race`, testify, table-driven).
- Frontend: optimizeOffers matrix, hardware-class/label matrix, built-in label, plus component tests for banner visibility/dismiss and the permanent card hiding Remove/Reinstall.
- A win11-qa v2.4-swap smoke test is recommended before release to exercise the real primary reload+rollback on Windows (the success path is model-dependent and not unit-covered).

https://claude.ai/code/session_011BRR9AErTBdfj3tzUn67Gf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added model optimization recommendations in Analysis Settings, with hardware-aware alternatives and explanations.
  - Review and apply optimizations individually or in bulk, with progress, retry, success, and failure states.
  - Added support for built-in, permanently installed models and variant switching.
  - Model cards now show hardware compatibility, optimization status, built-in badges, and license information.
- **Localization**
  - Added translated optimization, compatibility, hardware, region, status, and licensing messages across supported languages.
- **Bug Fixes**
  - Prevented removal or reinstallation of permanently installed models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->