### PR TITLE
fix(models): batched low-severity gate follow-ups (HF failover, notflite tests, region-mode constants)

### DIFF
--- a/frontend/src/lib/desktop/features/settings/components/ModelRegionSelector.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/ModelRegionSelector.svelte
@@ -17,7 +17,11 @@
   import { t, getLocale } from '$lib/i18n';
   import { fetchModelRegions, fetchRegionCoverageMap } from '$lib/utils/modelsApi';
   import { localizedCountryNames } from '$lib/utils/countryNames';
-  import { normalizeRegionMode } from '$lib/utils/variantSelection';
+  import {
+    normalizeRegionMode,
+    DEFAULT_REGION_MODE,
+    GLOBAL_REGION_MODE,
+  } from '$lib/utils/variantSelection';
   import { loggers } from '$lib/utils/logger';
   import { birdnetSettings, settingsActions } from '$lib/stores/settings';
   import type { ModelRegionsResponse, RegionOption } from '$lib/types/models';
@@ -57,7 +61,9 @@
   // normalizeRegionMode.
   const selected = $derived(normalizeRegionMode($birdnetSettings?.modelRegion));
   const regions = $derived<RegionOption[]>(data?.regions ?? []);
-  const isPinnedSlug = $derived(selected !== 'auto' && selected !== 'global');
+  const isPinnedSlug = $derived(
+    selected !== DEFAULT_REGION_MODE && selected !== GLOBAL_REGION_MODE
+  );
   const regionsVisible = $derived(showRegions || isPinnedSlug);
 
   function knownSlug(slug: string): boolean {
@@ -118,7 +124,7 @@
     const lc = data.locationConfigured;
     const sel = selected;
 
-    if (sel === 'auto') {
+    if (sel === DEFAULT_REGION_MODE) {
       if (!lc) return { state: 'noLocation', args: {}, warn: true, pins: [], offerAuto: false };
       if (r.slug === '')
         return { state: 'outsideCoverage', args: {}, warn: false, pins: [], offerAuto: false };
@@ -141,7 +147,7 @@
       };
     }
 
-    if (sel === 'global') {
+    if (sel === GLOBAL_REGION_MODE) {
       return { state: 'global', args: {}, warn: false, pins: [], offerAuto: false };
     }
 
@@ -175,8 +181,8 @@
   // slug. Global, no-location, outside-coverage, and unknown pins have no map.
   const activeSlug = $derived.by<string>(() => {
     if (!data) return '';
-    if (selected === 'global') return '';
-    if (selected === 'auto') return data.locationConfigured ? data.resolved.slug : '';
+    if (selected === GLOBAL_REGION_MODE) return '';
+    if (selected === DEFAULT_REGION_MODE) return data.locationConfigured ? data.resolved.slug : '';
     return knownSlug(selected) ? selected : '';
   });
 
@@ -298,7 +304,7 @@
       <label
         for="model-region-auto"
         class="flex items-start gap-3 rounded-md border p-2 transition-colors
-          {selected === 'auto' ? 'border-primary bg-primary/5' : 'border-base-300'}
+          {selected === DEFAULT_REGION_MODE ? 'border-primary bg-primary/5' : 'border-base-300'}
           {disabled ? '' : 'cursor-pointer hover:bg-base-200'}"
       >
         <input
@@ -307,9 +313,9 @@
           class="radio radio-sm radio-primary mt-0.5"
           name="model-region"
           value="auto"
-          checked={selected === 'auto'}
+          checked={selected === DEFAULT_REGION_MODE}
           {disabled}
-          onchange={() => select('auto')}
+          onchange={() => select(DEFAULT_REGION_MODE)}
         />
         <div class="flex flex-col gap-0.5 min-w-0">
           <span class="font-medium flex items-center gap-1.5">
@@ -326,7 +332,7 @@
       <label
         for="model-region-global"
         class="flex items-start gap-3 rounded-md border p-2 transition-colors
-          {selected === 'global' ? 'border-primary bg-primary/5' : 'border-base-300'}
+          {selected === GLOBAL_REGION_MODE ? 'border-primary bg-primary/5' : 'border-base-300'}
           {disabled ? '' : 'cursor-pointer hover:bg-base-200'}"
       >
         <input
@@ -335,9 +341,9 @@
           class="radio radio-sm radio-primary mt-0.5"
           name="model-region"
           value="global"
-          checked={selected === 'global'}
+          checked={selected === GLOBAL_REGION_MODE}
           {disabled}
-          onchange={() => select('global')}
+          onchange={() => select(GLOBAL_REGION_MODE)}
         />
         <div class="flex flex-col gap-0.5 min-w-0">
           <span class="font-medium flex items-center gap-1.5">
@@ -424,7 +430,12 @@
         {/if}
         {#if whyLine.offerAuto}
           <div>
-            <button type="button" class="btn btn-xs" {disabled} onclick={() => select('auto')}>
+            <button
+              type="button"
+              class="btn btn-xs"
+              {disabled}
+              onclick={() => select(DEFAULT_REGION_MODE)}
+            >
               {t('analysis.gallery.region.switchToAuto')}
             </button>
           </div>

--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.gallery.test.ts
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.gallery.test.ts
@@ -84,6 +84,7 @@ import AnalysisSettingsPage from './AnalysisSettingsPage.svelte';
 import * as modelsApi from '$lib/utils/modelsApi';
 import { settingsStore } from '$lib/stores/settings';
 import { toastActions } from '$lib/stores/toast';
+import { t } from '$lib/i18n';
 
 // A network-shaped download failure (matches isNetworkDownloadError's real regex).
 const NETWORK_ERROR = 'HTTP request failed for https://huggingface.co/model: connection refused';
@@ -320,6 +321,10 @@ describe('AnalysisSettingsPage model gallery in-flight guard and region refetch'
         expect.stringContaining('analysis.gallery.removeSuccess')
       )
     );
+    // The i18n mock echoes the key and strips params, so the toast string alone
+    // cannot prove the model name is interpolated. Assert on the t() call itself
+    // that the {name} param is passed through, closing that gap (#1566).
+    expect(t).toHaveBeenCalledWith('analysis.gallery.removeSuccess', { name: 'Installed Model' });
   });
 });
 

--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
@@ -80,6 +80,8 @@
     pickPreselectedVariant,
     translateReason,
     normalizeRegionMode,
+    DEFAULT_REGION_MODE,
+    GLOBAL_REGION_MODE,
     optimizeOffers,
     variantHardwareLabel,
     type OptimizeOffer,
@@ -256,8 +258,8 @@
   const liveModelRegion = $derived(normalizeRegionMode(birdnet?.modelRegion));
   const activeRegionSlug = $derived.by<string>(() => {
     if (!regionsData) return '';
-    if (liveModelRegion === 'global') return '';
-    if (liveModelRegion === 'auto')
+    if (liveModelRegion === GLOBAL_REGION_MODE) return '';
+    if (liveModelRegion === DEFAULT_REGION_MODE)
       return regionsData.locationConfigured ? regionsData.resolved.slug : '';
     return regionNameMap.has(liveModelRegion) ? liveModelRegion : '';
   });

--- a/frontend/src/lib/utils/variantSelection.ts
+++ b/frontend/src/lib/utils/variantSelection.ts
@@ -236,6 +236,14 @@ export function optimizeOffers(catalog: CatalogEntry[]): OptimizeOffer[] {
 export const DEFAULT_REGION_MODE = 'auto';
 
 /**
+ * The explicit "global" region mode: force the location-independent global
+ * variant regardless of the configured location. Distinct from
+ * DEFAULT_REGION_MODE ('auto', which resolves from the location) and from a
+ * concrete region slug. Mirrors the Go `ModelRegionGlobal` sentinel.
+ */
+export const GLOBAL_REGION_MODE = 'global';
+
+/**
  * Normalize a stored region mode to its canonical form: '', null and undefined
  * all collapse to 'auto', while a concrete slug or 'global' passes through
  * unchanged. Centralizing this keeps the live/saved region derivations and the

--- a/internal/analysis/birdnet_service.go
+++ b/internal/analysis/birdnet_service.go
@@ -36,11 +36,18 @@ func (a *BirdNETAnalyzer) Name() string {
 // Start initializes the BirdNET interpreter and builds the species range filter.
 // Model initialization failures are non-retryable (missing files, insufficient resources).
 func (a *BirdNETAnalyzer) Start(_ context.Context) error {
+	// Resolve the config directory once and thread it through: both the catalog
+	// load and the model manager's endpoint-resolver persistence live under it,
+	// and ResolveConfigDir does filesystem work, so resolving it a single time
+	// avoids a duplicate probe. It returns "" on error; each consumer logs the
+	// consequence with the shared error.
+	configDir, configDirErr := conf.ResolveConfigDir()
+
 	// Load the user-editable model catalog before constructing the orchestrator
 	// so every catalog consumer (range-filter setup, the gallery API, the
 	// installed-model scan) sees the same active catalog. Non-fatal: any failure
 	// falls back to the built-in embedded catalog.
-	a.loadModelCatalog()
+	a.loadModelCatalog(configDir, configDirErr)
 
 	bn, err := classifier.NewOrchestrator(a.settings)
 	if err != nil {
@@ -68,7 +75,7 @@ func (a *BirdNETAnalyzer) Start(_ context.Context) error {
 
 	// Initialize ModelManager for the model gallery. Failure is non-fatal
 	// because the gallery is an optional feature; core detection still works.
-	a.initModelManager(bn)
+	a.initModelManager(bn, configDir, configDirErr)
 
 	return nil
 }
@@ -117,14 +124,13 @@ func (a *BirdNETAnalyzer) ModelManager() *classifier.ModelManager {
 // (conf.Settings.ResolveModelsDir); both coincide on a default install but can
 // differ for a system (/etc) or --config install. Failure is non-fatal: the
 // built-in embedded catalog is used and startup continues.
-func (a *BirdNETAnalyzer) loadModelCatalog() {
+func (a *BirdNETAnalyzer) loadModelCatalog(configDir string, resolveErr error) {
 	log := GetLogger()
 
-	configDir, err := conf.ResolveConfigDir()
-	if err != nil {
+	if resolveErr != nil {
 		log.Warn("could not resolve config directory; using built-in model catalog",
 			logger.String("service", birdNETAnalyzerName),
-			logger.Error(err))
+			logger.Error(resolveErr))
 		return
 	}
 	if err := classifier.LoadCatalog(configDir); err != nil {
@@ -134,7 +140,7 @@ func (a *BirdNETAnalyzer) loadModelCatalog() {
 	}
 }
 
-func (a *BirdNETAnalyzer) initModelManager(bn *classifier.Orchestrator) {
+func (a *BirdNETAnalyzer) initModelManager(bn *classifier.Orchestrator, configDir string, resolveErr error) {
 	log := GetLogger()
 
 	modelsDir, ok := a.settings.ResolveModelsDir()
@@ -148,15 +154,14 @@ func (a *BirdNETAnalyzer) initModelManager(bn *classifier.Orchestrator) {
 
 	// Inject the HuggingFace endpoint resolver so model downloads fail over from
 	// a blocked canonical host (e.g. behind the Great Firewall) to the mirror.
-	// It persists the working host under the config directory so the preference
-	// survives a restart; an unresolved config dir keeps failover in memory only.
-	// Construction reads at most one small local file and does no network I/O, so
-	// it is safe here on the startup path.
-	configDir, err := conf.ResolveConfigDir()
-	if err != nil {
+	// It persists the working host under the config directory (resolved once in
+	// Start) so the preference survives a restart; an unresolved config dir keeps
+	// failover in memory only. Construction reads at most one small local file and
+	// does no network I/O, so it is safe here on the startup path.
+	if resolveErr != nil {
 		log.Warn("could not resolve config directory; HuggingFace mirror failover will not persist across restarts",
 			logger.String("service", birdNETAnalyzerName),
-			logger.Error(err))
+			logger.Error(resolveErr))
 	}
 	a.modelManager.SetEndpointResolver(conf.NewHFEndpointResolver(configDir))
 

--- a/internal/classifier/birdnet_test.go
+++ b/internal/classifier/birdnet_test.go
@@ -513,6 +513,13 @@ const testV24TFLiteModelPath = "data/BirdNET_GLOBAL_6K_V2.4_Model_FP32.tflite"
 func TestNewBirdNET_LocaleNormalization(t *testing.T) {
 	t.Parallel()
 
+	// This test constructs a TFLite v2.4 model to exercise locale normalization.
+	// A notflite build has no TFLite backend, so construction errors instead of
+	// running; skip so those builds stay green. See #1553.
+	if !tfliteBackendAvailable {
+		t.Skip("TFLite backend not linked (notflite build); locale normalization uses a TFLite v2.4 model")
+	}
+
 	tests := []struct {
 		name       string
 		input      string

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -2189,10 +2189,35 @@ func (mm *ModelManager) applyConfigForUninstall(entry *CatalogEntry) {
 // sent to the progress channel during a download.
 const progressInterval = 1 << 20 // 1 MiB
 
-// downloadHTTPClient is used for model file downloads with a generous timeout
-// to accommodate large files on slow connections.
+// downloadResponseHeaderTimeout bounds how long a connected host may take to
+// send response headers before the download fails over to the next endpoint. It
+// guards the slowloris / partial-block tail case where a host completes TCP+TLS
+// then stalls: without it, such a host would hold the full 30-minute total
+// budget before failover. The response body remains bounded only by the total
+// Timeout, which is deliberately generous for large model files.
+const downloadResponseHeaderTimeout = 30 * time.Second
+
+// newDownloadTransport clones http.DefaultTransport and sets a
+// ResponseHeaderTimeout so a stalled host does not defer mirror failover.
+func newDownloadTransport() http.RoundTripper {
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		// DefaultTransport is *http.Transport in practice; if that ever changes,
+		// keep the default rather than losing connection pooling and proxy support.
+		return http.DefaultTransport
+	}
+	tr := base.Clone()
+	tr.ResponseHeaderTimeout = downloadResponseHeaderTimeout
+	return tr
+}
+
+// downloadHTTPClient is used for model file downloads with a generous total
+// timeout to accommodate large files on slow connections. Its transport adds a
+// ResponseHeaderTimeout (see downloadResponseHeaderTimeout) so a host that
+// connects then stalls fails over promptly instead of holding the whole budget.
 var downloadHTTPClient = &http.Client{
-	Timeout: 30 * time.Minute,
+	Timeout:   30 * time.Minute,
+	Transport: newDownloadTransport(),
 }
 
 // endpointAttemptError wraps a download failure with whether it warrants trying

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -2211,12 +2211,16 @@ func newDownloadTransport() http.RoundTripper {
 	return tr
 }
 
+// downloadTotalTimeout is the overall budget for a single model-file download,
+// deliberately generous so a large file on a slow connection can complete.
+const downloadTotalTimeout = 30 * time.Minute
+
 // downloadHTTPClient is used for model file downloads with a generous total
 // timeout to accommodate large files on slow connections. Its transport adds a
 // ResponseHeaderTimeout (see downloadResponseHeaderTimeout) so a host that
 // connects then stalls fails over promptly instead of holding the whole budget.
 var downloadHTTPClient = &http.Client{
-	Timeout:   30 * time.Minute,
+	Timeout:   downloadTotalTimeout,
 	Transport: newDownloadTransport(),
 }
 

--- a/internal/classifier/model_manager_failover_test.go
+++ b/internal/classifier/model_manager_failover_test.go
@@ -85,17 +85,34 @@ func TestDownloadModelFile_FailsOverOnUnreachableHost(t *testing.T) {
 
 func TestDownloadModelFile_FailsOverOnGatewayStatus(t *testing.T) {
 	t.Parallel()
-	body := []byte("model-bytes")
-	badURL, badHits := countingServer(t, http.StatusServiceUnavailable, nil)
-	mirrorURL, mirrorHits := countingServer(t, http.StatusOK, body)
-	mm, resolver := newFailoverManager(t, []string{badURL, mirrorURL})
-	dest := filepath.Join(t.TempDir(), "model.onnx")
+	// Every gateway status (502/503/504) means the origin is down while the host
+	// itself answered, so a mirror may still serve the file. Drive each one end to
+	// end through downloadModelFile, not just IsGatewayStatus, so the whole
+	// failover path is proven for all three, not only the 503 case.
+	statuses := []struct {
+		name   string
+		status int
+	}{
+		{"502 bad gateway", http.StatusBadGateway},
+		{"503 service unavailable", http.StatusServiceUnavailable},
+		{"504 gateway timeout", http.StatusGatewayTimeout},
+	}
+	for _, tc := range statuses {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			body := []byte("model-bytes")
+			badURL, badHits := countingServer(t, tc.status, nil)
+			mirrorURL, mirrorHits := countingServer(t, http.StatusOK, body)
+			mm, resolver := newFailoverManager(t, []string{badURL, mirrorURL})
+			dest := filepath.Join(t.TempDir(), "model.onnx")
 
-	err := mm.downloadModelFile(t.Context(), "m", "owner/repo", "model.onnx", dest, sha256Hex(body), 0, "")
-	require.NoError(t, err)
-	assert.Equal(t, int64(1), badHits.Load())
-	assert.Equal(t, int64(1), mirrorHits.Load())
-	assert.Equal(t, []string{mirrorURL}, resolver.working())
+			err := mm.downloadModelFile(t.Context(), "m", "owner/repo", "model.onnx", dest, sha256Hex(body), 0, "")
+			require.NoError(t, err)
+			assert.Equal(t, int64(1), badHits.Load())
+			assert.Equal(t, int64(1), mirrorHits.Load())
+			assert.Equal(t, []string{mirrorURL}, resolver.working())
+		})
+	}
 }
 
 func TestDownloadModelFile_DoesNotFailOverOn404(t *testing.T) {

--- a/internal/classifier/range_filter_dispatch_test.go
+++ b/internal/classifier/range_filter_dispatch_test.go
@@ -111,7 +111,11 @@ func TestHasNativeRangeFilter(t *testing.T) {
 		modelID string
 		want    bool
 	}{
-		{name: "BirdNET v2.4 has embedded TFLite range filter", modelID: "BirdNET_V2.4", want: true},
+		// The embedded MData range filter is a TFLite artifact, so v2.4 only has a
+		// native fallback when the TFLite backend is linked. Under the notflite tag
+		// hasNativeRangeFilter returns false, so the expectation tracks the backend
+		// rather than asserting true unconditionally (same notflite hygiene as #1553).
+		{name: "BirdNET v2.4 has embedded TFLite range filter", modelID: "BirdNET_V2.4", want: tfliteBackendAvailable},
 		{name: "Perch v2 has no native range filter", modelID: RegistryIDPerchV2, want: false},
 		{name: "BirdNET v3.0 has no native range filter", modelID: RegistryIDBirdNETV3, want: false},
 	}

--- a/internal/conf/huggingface.go
+++ b/internal/conf/huggingface.go
@@ -45,11 +45,8 @@ const (
 //
 // The result never ends in a slash, so callers can append "/" + path.
 func ResolveHuggingFaceEndpoint(configured string) string {
-	raw, source := configured, endpointSourceSettings
-	if strings.TrimSpace(raw) == "" {
-		raw, source = os.Getenv(HuggingFaceEndpointEnvVar), HuggingFaceEndpointEnvVar
-	}
-	if strings.TrimSpace(raw) == "" {
+	raw, source, hasValue := huggingFaceOverrideSource(configured)
+	if !hasValue {
 		return DefaultHuggingFaceEndpoint
 	}
 
@@ -66,6 +63,23 @@ func ResolveHuggingFaceEndpoint(configured string) string {
 		return DefaultHuggingFaceEndpoint
 	}
 	return endpoint
+}
+
+// huggingFaceOverrideSource returns the raw HuggingFace endpoint override in
+// effect and where it came from, preferring the configured settings value over
+// the HuggingFaceEndpointEnvVar environment variable. hasValue is false when
+// neither is set (after trimming), so the caller applies its own default. raw is
+// returned untrimmed so a caller can echo the exact rejected value in a log or
+// error; normalizeHuggingFaceEndpoint trims internally. Centralizing the
+// settings-then-env precedence here keeps ResolveHuggingFaceEndpoint and
+// ResolveHuggingFaceEndpointChain from silently diverging if the precedence
+// order ever changes.
+func huggingFaceOverrideSource(configured string) (raw, source string, hasValue bool) {
+	raw, source = configured, endpointSourceSettings
+	if strings.TrimSpace(raw) == "" {
+		raw, source = os.Getenv(HuggingFaceEndpointEnvVar), HuggingFaceEndpointEnvVar
+	}
+	return raw, source, strings.TrimSpace(raw) != ""
 }
 
 // normalizeHuggingFaceEndpoint trims and validates an endpoint override,

--- a/internal/conf/huggingface_chain.go
+++ b/internal/conf/huggingface_chain.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"strings"
 	"sync"
 	"time"
 
@@ -78,11 +77,7 @@ const (
 // Every element is normalized without a trailing slash, so callers can append
 // "/" + path. This never performs network I/O.
 func ResolveHuggingFaceEndpointChain(configured string) []string {
-	raw := strings.TrimSpace(configured)
-	if raw == "" {
-		raw = strings.TrimSpace(os.Getenv(HuggingFaceEndpointEnvVar))
-	}
-	if raw != "" {
+	if raw, _, hasValue := huggingFaceOverrideSource(configured); hasValue {
 		if endpoint, err := normalizeHuggingFaceEndpoint(raw); err == nil {
 			return []string{endpoint}
 		}
@@ -268,10 +263,14 @@ func (r *HFEndpointResolver) save(state hfEndpointState) {
 	if _, err := tmp.Write(data); err != nil {
 		_ = tmp.Close()
 		_ = os.Remove(tmpPath)
+		GetLogger().Debug("could not write HuggingFace endpoint state temp file",
+			logger.String("path", tmpPath), logger.Error(err))
 		return
 	}
 	if err := tmp.Close(); err != nil {
 		_ = os.Remove(tmpPath)
+		GetLogger().Debug("could not close HuggingFace endpoint state temp file",
+			logger.String("path", tmpPath), logger.Error(err))
 		return
 	}
 	if err := os.Rename(tmpPath, r.statePath); err != nil {


### PR DESCRIPTION
## Summary

Folds several deferred low-severity cleanups from earlier model-gallery reviews into one change. It is a behavior-preserving refactor plus test hygiene; existing users see no functional difference.

**HuggingFace endpoint resolution.** Extracts a shared `huggingFaceOverrideSource` helper so `ResolveHuggingFaceEndpoint` and `ResolveHuggingFaceEndpointChain` share the settings-then-`HF_ENDPOINT` precedence and cannot silently diverge if that order ever changes. The resolved endpoint, the chain contents, the warn-on-invalid behavior (only the single resolver warns; the chain falls back silently), and the redacted log value are all unchanged.

**Download resilience.** The model-download HTTP client now uses a `Transport` cloned from `http.DefaultTransport` with a `ResponseHeaderTimeout` of 30s, so a host that completes TCP+TLS then stalls before sending response headers fails over to the mirror promptly instead of holding the full 30-minute budget. The response body remains bounded only by the total timeout, so legitimate slow large-file downloads are unaffected. The endpoint-state `save()` path now logs its previously-silent temp-file write/close failures at debug level, matching its other branches.

**Startup.** The config directory is resolved once in `Start` and threaded into `loadModelCatalog` and `initModelManager` rather than being resolved twice; each consumer's on-error behavior is preserved exactly.

**Tests.** `TestNewBirdNET_LocaleNormalization` and the BirdNET v2.4 case of `TestHasNativeRangeFilter` now respect the `notflite` build tag (they assume a linked TFLite backend), so ONNX-only builds stay green. Gateway-status failover is now driven end to end for 502 and 504, not only 503, via a table-driven test.

**Frontend.** The region-mode string literals are centralized as `DEFAULT_REGION_MODE` and `GLOBAL_REGION_MODE` and used at the comparison sites in the region selector and analysis settings page (the DOM `value=` attributes stay literal). A param-aware assertion confirms the remove-success toast interpolates the model name.

## Test Plan

- [x] `go test` (default build) and `go test -tags notflite` green for internal/classifier and internal/conf
- [x] `golangci-lint run` on changed packages: 0 issues
- [x] `npm run check:all` (typecheck, eslint, stylelint, ast-grep): clean
- [x] Frontend unit tests for the region selector, gallery page, and variant helpers pass
- [x] Pre-push quality gate: no Critical/High/Medium findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved model download responsiveness by detecting stalled server responses sooner.
  - Enhanced download reliability by automatically switching to an available mirror when a server is temporarily unavailable.
  - Improved handling of custom model-hosting endpoints and fallback mirrors.
  - Clarified region selection behavior, including automatic and global modes.
  - Improved diagnostics when model configuration cannot be located.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->