### PR TITLE
fix(models): Worldwide card icon box stretched full width, pushing text outside the card

### DIFF
--- a/frontend/src/lib/desktop/features/settings/components/ModelRegionSelector.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/ModelRegionSelector.svelte
@@ -414,8 +414,11 @@
                 if (!disabled) select(GLOBAL_REGION_MODE);
               }}
             />
+            <!-- Center the icon with flex, NOT the `grid` class: a global
+                 `.drawer-content .grid { width: 100% }` rule would otherwise stretch
+                 this fixed-size box to full width and push the text out of the card. -->
             <span
-              class="flex-none grid place-items-center h-12 w-16 rounded-md bg-primary/10 text-primary"
+              class="flex-none flex items-center justify-center h-12 w-16 rounded-md bg-primary/10 text-primary"
               aria-hidden="true"
             >
               <Globe class="h-7 w-7" />

--- a/frontend/src/lib/desktop/features/settings/components/ModelRegionSelector.test.ts
+++ b/frontend/src/lib/desktop/features/settings/components/ModelRegionSelector.test.ts
@@ -188,6 +188,21 @@ describe('ModelRegionSelector', () => {
     expect(container.textContent).toContain('analysis.gallery.region.worldwideResourceNote');
   });
 
+  it('the Worldwide icon box avoids the grid class so the global .drawer-content .grid rule cannot stretch it', async () => {
+    // Regression guard: a global `.drawer-content .grid { width: 100% }` rule
+    // stretched a `grid`-classed fixed-size box to full width, pushing the card
+    // text outside the card. The icon wrapper must center with flex, not `grid`.
+    const { container } = await renderLoaded();
+    await fireEvent.click(radioByValue(container, 'manual') as HTMLInputElement);
+    const label = (radioByValue(container, 'global') as HTMLInputElement).closest(
+      'label'
+    ) as HTMLElement;
+    const iconWrap = label.querySelector('span[aria-hidden="true"]') as HTMLElement;
+    expect(iconWrap).not.toBeNull();
+    expect(iconWrap.classList.contains('grid')).toBe(false);
+    expect(iconWrap.classList.contains('flex')).toBe(true);
+  });
+
   it('selecting a region card saves that region slug', async () => {
     const { container } = await renderLoaded();
     await fireEvent.click(radioByValue(container, 'manual') as HTMLInputElement);


### PR DESCRIPTION
## Summary

The Worldwide region card (in the model region selector's Manual view) rendered its title and resource note outside the card border. Root cause: the globe icon wrapper centered its icon with the Tailwind `grid` class, and a global `.drawer-content .grid { width: 100% }` rule (the settings page renders inside a drawer) stretched that fixed-size `h-12 w-16` box to full width. That collapsed the text column to zero and pushed the title and note past the card edge.

The fix centers the icon with flex (`flex items-center justify-center`) instead of the `grid` class, so the global drawer rule no longer matches and the box keeps its intended 64px width. Verified in a real browser against a running instance: the icon returns to 64px and nothing overflows. Adds a regression test asserting the icon wrapper does not use the `grid` class.

This is a follow-up fix to PR #4158.

## Test Plan

- [ ] `npm run check:all` passes
- [ ] `npx vitest run src/lib/desktop/features/settings/components/ModelRegionSelector.test.ts` passes (includes the new grid-class guard)
- [ ] Settings > AI Models > Manual region select: the Worldwide card renders its title, subtitle, and resource note inside the card with the globe icon at its normal size