### PR TITLE
feat(models): plain hardware labels and preview flag in the gallery

### DIFF
--- a/frontend/src/lib/desktop/features/settings/components/ModelVariantPicker.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/ModelVariantPicker.svelte
@@ -13,10 +13,16 @@
    * the middle stage scopes to, so the list is never a silently filtered subset.
    */
   import { untrack, tick } from 'svelte';
+  import { ChevronDown, Search } from '@lucide/svelte';
   import type { CatalogVariant, VariantReason } from '$lib/types/models';
   import { t } from '$lib/i18n';
   import { formatBytes, formatNumber } from '$lib/utils/formatters';
-  import { translateReason, topReasons, variantLabel } from '$lib/utils/variantSelection';
+  import {
+    translateReason,
+    topReasons,
+    variantLabel,
+    variantHardwareLabel,
+  } from '$lib/utils/variantSelection';
 
   interface Props {
     variants: CatalogVariant[];
@@ -78,6 +84,27 @@
   // the newly shown tiles instead of letting it fall to <body> when the button
   // unmounts (see revealNext).
   let fieldsetEl: HTMLElement | undefined;
+  // Free-text filter for the "other regions" list in the 'all' stage, so a user can
+  // jump straight to a region instead of scrolling the full ~70-tile set. Bound to
+  // the search input revealed with that stage.
+  let otherRegionQuery = $state('');
+  let regionSearchEl = $state<HTMLInputElement | undefined>(undefined);
+  // The scrollable "other regions" grid, so ArrowDown from the search box can move
+  // focus into the filtered tiles. Without this bridge a keyboard user is stranded:
+  // the radio group uses native roving tabindex, so the only tabbable radio is the
+  // checked one (which sits above the search box), and Tab from the search skips the
+  // filtered tiles (they are tabindex=-1) straight out of the fieldset.
+  let otherRegionsGridEl = $state<HTMLElement | undefined>(undefined);
+
+  // Move focus from the region filter into the first filtered tile on ArrowDown.
+  function focusFirstFilteredTile(e: KeyboardEvent): void {
+    if (e.key !== 'ArrowDown') return;
+    const first = otherRegionsGridEl?.querySelector<HTMLInputElement>('input[type="radio"]');
+    if (first) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
 
   // The 'region' stage: always-relevant options, plus every global (region-less)
   // build, plus the active region's tiles. Other regions are excluded unless one
@@ -90,6 +117,17 @@
   const otherStageVariants = $derived(
     variants.filter(v => !inAlways(v) && !!v.region && v.region !== activeRegionSlug)
   );
+  // The 'other regions' tiles narrowed by the free-text filter, matched against the
+  // localized region name and the raw slug. An empty query shows them all.
+  const filteredOtherVariants = $derived.by(() => {
+    const q = otherRegionQuery.trim().toLowerCase();
+    if (!q) return otherStageVariants;
+    return otherStageVariants.filter(v => {
+      const slug = v.region ?? '';
+      const name = (regionNames?.get(slug) ?? slug).toLowerCase();
+      return name.includes(q) || slug.toLowerCase().includes(q);
+    });
+  });
 
   // The always-relevant options as a set, computed once. $derived (not a plain
   // const) because inAlways closes over reactive props. Reused by the collapsed
@@ -179,6 +217,14 @@
     disclosure = step.target;
     if (!unmounts) return;
     void tick().then(() => {
+      // The 'all' stage reveals the region filter box: move focus there so a
+      // keyboard user lands on the search field instead of skipping past it into
+      // the tiles. Fall back to the first newly revealed tile if no box rendered
+      // (no other-region tiles hidden).
+      if (regionSearchEl) {
+        regionSearchEl.focus();
+        return;
+      }
       const revealed = Array.from(
         fieldsetEl?.querySelectorAll<HTMLInputElement>(radioSelector) ?? []
       );
@@ -235,7 +281,10 @@
 
     <div class="flex flex-col gap-1 min-w-0 flex-1">
       <div class="flex flex-wrap items-center gap-2">
-        <span class="font-medium">{variantLabel(variant, regionNames)}</span>
+        <!-- Primary label is the plain hardware target (e.g. "AMD64 CPU", "GPU
+             (NVIDIA)"), never raw precision. The precision/descriptor/region reads
+             as muted technical detail on the line below. -->
+        <span class="font-medium">{variantHardwareLabel(variant)}</span>
         {#if variant.recommended}
           <span class="badge badge-primary badge-sm"
             >{t('analysis.gallery.variants.recommended')}</span
@@ -250,6 +299,9 @@
       </div>
 
       <div class="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-base-content/70">
+        {#if !variant.builtIn}
+          <span>{variantLabel(variant, regionNames)}</span>
+        {/if}
         <span>{formatBytes(variant.sizeBytes)}</span>
         {#if variant.speciesCount > 0}
           <span
@@ -310,30 +362,67 @@
     {/each}
 
     {#if disclosure === 'all' && otherStageVariants.length > 0}
-      <div role="group" aria-labelledby="{idPrefix}-other-regions" class="flex flex-col gap-2 mt-1">
-        <p id="{idPrefix}-other-regions" class="text-xs font-medium text-base-content/60">
-          {t('analysis.gallery.variants.otherRegions')}
-        </p>
-        {#each otherStageVariants as variant (variant.id)}
-          {@render variantTile(variant)}
-        {/each}
+      <div role="group" aria-labelledby="{idPrefix}-other-regions" class="mt-1 flex flex-col gap-2">
+        <div class="flex flex-wrap items-center justify-between gap-2">
+          <p id="{idPrefix}-other-regions" class="text-xs font-medium text-base-content/60">
+            {t('analysis.gallery.variants.otherRegions')}
+          </p>
+          <label class="relative">
+            <Search
+              class="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-base-content/50"
+              aria-hidden="true"
+            />
+            <input
+              bind:this={regionSearchEl}
+              bind:value={otherRegionQuery}
+              onkeydown={focusFirstFilteredTile}
+              type="text"
+              class="input input-sm input-bordered w-44 pl-7"
+              placeholder={t('analysis.gallery.variants.filterPlaceholder')}
+              aria-label={t('analysis.gallery.variants.filterAria')}
+            />
+          </label>
+        </div>
+        <!-- Height-capped and scrollable so the full ~70-tile set never blows out
+             the dialog; two columns on wider dialogs use the space. -->
+        {#if filteredOtherVariants.length > 0}
+          <div
+            bind:this={otherRegionsGridEl}
+            class="grid max-h-64 grid-cols-1 gap-2 overflow-y-auto pr-1 sm:grid-cols-2"
+          >
+            {#each filteredOtherVariants as variant (variant.id)}
+              {@render variantTile(variant)}
+            {/each}
+          </div>
+        {:else}
+          <p class="py-4 text-center text-xs text-base-content/60" role="status">
+            {t('analysis.gallery.variants.filterNoMatch', { query: otherRegionQuery })}
+          </p>
+        {/if}
       </div>
     {/if}
   </div>
 
   {#if disclosureStep}
-    <!-- The disclosure button only renders while more variants remain hidden (it
-         unmounts once everything is shown), so it always reveals collapsed
-         content: aria-expanded is a constant "false". -->
+    <!-- Prominent, full-width disclosure so the "show more variants" control is easy
+         to spot. It only renders while more variants remain hidden (it unmounts once
+         everything is shown), so it always reveals collapsed content: aria-expanded
+         is a constant "false". -->
     <button
       type="button"
-      class="btn btn-ghost btn-xs mt-2"
+      class="btn btn-outline btn-block mt-3 justify-between font-medium"
       aria-expanded="false"
       onclick={() => revealNext(disclosureStep)}
     >
-      {disclosureStep.region
-        ? t(disclosureStep.labelKey, { count: disclosureStep.count, region: disclosureStep.region })
-        : t(disclosureStep.labelKey, { count: disclosureStep.count })}
+      <span>
+        {disclosureStep.region
+          ? t(disclosureStep.labelKey, {
+              count: disclosureStep.count,
+              region: disclosureStep.region,
+            })
+          : t(disclosureStep.labelKey, { count: disclosureStep.count })}
+      </span>
+      <ChevronDown class="h-4 w-4" aria-hidden="true" />
     </button>
   {/if}
 </fieldset>

--- a/frontend/src/lib/desktop/features/settings/components/ModelVariantPicker.test.ts
+++ b/frontend/src/lib/desktop/features/settings/components/ModelVariantPicker.test.ts
@@ -421,7 +421,7 @@ describe('ModelVariantPicker', () => {
     expect(label?.textContent).toContain('analysis.gallery.variants.otherRegions');
   });
 
-  it('moves focus to the first newly revealed tile when the final stage unmounts the toggle', async () => {
+  it('moves focus to the region filter when the final stage reveals it', async () => {
     const { container, getByRole } = render(ModelVariantPicker, {
       props: {
         variants: regionalVariants,
@@ -433,10 +433,37 @@ describe('ModelVariantPicker', () => {
       },
     });
     // collapsed -> region keeps the button mounted (focus stays); region -> all
-    // unmounts it, so focus is moved to the first tile that stage reveals (the
-    // first other-region tile, iberia) instead of falling to <body>.
+    // reveals the "other regions" panel with its filter box, so focus moves to that
+    // search input (a keyboard user filters first, then ArrowDowns into the tiles)
+    // instead of falling to <body> when the toggle unmounts.
     await fireEvent.click(getByRole('button')); // region stage
     await fireEvent.click(getByRole('button')); // all stage (button unmounts)
+    const search = container.querySelector('input[type="text"]');
+    expect(search).not.toBeNull();
+    await waitFor(() => expect(document.activeElement).toBe(search));
+  });
+
+  it('bridges keyboard focus from the region filter into the first tile on ArrowDown', async () => {
+    const { container, getByRole } = render(ModelVariantPicker, {
+      props: {
+        variants: regionalVariants,
+        selectedVariantId: 'fp16',
+        onSelect: vi.fn(),
+        activeRegionSlug: 'nordic',
+        regionNames,
+        idPrefix: 'r7',
+      },
+    });
+    await fireEvent.click(getByRole('button')); // region stage
+    await fireEvent.click(getByRole('button')); // all stage
+    const search = container.querySelector('input[type="text"]');
+    expect(search).not.toBeNull();
+    // The native radio group uses roving tabindex, so Tab from the search would skip
+    // the tiles; ArrowDown must bridge focus into the first other-region tile.
+    if (search instanceof HTMLInputElement) {
+      search.focus();
+      await fireEvent.keyDown(search, { key: 'ArrowDown' });
+    }
     await waitFor(() =>
       expect(document.activeElement).toBe(radioByValue(container, 'fp16@iberia'))
     );

--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.gallery.test.ts
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.gallery.test.ts
@@ -101,6 +101,7 @@ function birdEntry(overrides: Partial<CatalogEntry> = {}): CatalogEntry {
     region: '',
     speciesCount: 100,
     version: '1.0',
+    channel: 'stable',
     installed: false,
     compatible: true,
     totalSizeBytes: 1_000_000,

--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.gallery.test.ts
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.gallery.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, beforeAll, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/svelte';
 import type { CatalogEntry } from '$lib/types/models';
+import { CHANNEL_STABLE } from '$lib/utils/variantSelection';
 
 // Page-level coverage for the model-gallery install-error split:
 // a failed install must NOT blank the grid (installError is a separate banner from
@@ -101,7 +102,7 @@ function birdEntry(overrides: Partial<CatalogEntry> = {}): CatalogEntry {
     region: '',
     speciesCount: 100,
     version: '1.0',
-    channel: 'stable',
+    channel: CHANNEL_STABLE,
     installed: false,
     compatible: true,
     totalSizeBytes: 1_000_000,

--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
@@ -84,6 +84,7 @@
     GLOBAL_REGION_MODE,
     optimizeOffers,
     variantHardwareLabel,
+    CHANNEL_PREVIEW,
     type OptimizeOffer,
   } from '$lib/utils/variantSelection';
   import OptimizeReviewDialog from '$lib/desktop/features/settings/components/OptimizeReviewDialog.svelte';
@@ -2260,7 +2261,26 @@
                 </div>
               {/if}
               <div class="min-w-0 flex-1">
-                <h4 class="text-sm font-semibold text-[var(--color-base-content)]">{entry.name}</h4>
+                <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+                  <h4 class="text-sm font-semibold text-[var(--color-base-content)]">
+                    {entry.name}
+                  </h4>
+                  {#if entry.channel === CHANNEL_PREVIEW}
+                    <span
+                      class="inline-flex items-center rounded-full bg-[var(--color-warning)]/15 px-2 py-0.5 text-xs font-bold uppercase tracking-wide text-[var(--color-warning)]"
+                    >
+                      {t('analysis.gallery.preview.badge')}
+                    </span>
+                  {/if}
+                  {#if entry.buildLabel}
+                    <span class="font-mono text-xs text-[var(--color-base-content)]/70">
+                      {t('analysis.gallery.preview.buildLabel', {
+                        version: entry.version,
+                        build: entry.buildLabel,
+                      })}
+                    </span>
+                  {/if}
+                </div>
                 <p class="mt-0.5 line-clamp-2 text-xs text-[var(--color-base-content)]/80">
                   {entry.description}
                 </p>
@@ -2526,9 +2546,26 @@
         </div>
       {/if}
       <div class="min-w-0 flex-1">
-        <h4 class="text-sm font-semibold text-[var(--color-base-content)]">
-          {entry.name}
-        </h4>
+        <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <h4 class="text-sm font-semibold text-[var(--color-base-content)]">
+            {entry.name}
+          </h4>
+          {#if entry.channel === CHANNEL_PREVIEW}
+            <span
+              class="inline-flex items-center rounded-full bg-[var(--color-warning)]/15 px-2 py-0.5 text-xs font-bold uppercase tracking-wide text-[var(--color-warning)]"
+            >
+              {t('analysis.gallery.preview.badge')}
+            </span>
+          {/if}
+          {#if entry.buildLabel}
+            <span class="font-mono text-xs text-[var(--color-base-content)]/70">
+              {t('analysis.gallery.preview.buildLabel', {
+                version: entry.version,
+                build: entry.buildLabel,
+              })}
+            </span>
+          {/if}
+        </div>
         <p class="mt-0.5 line-clamp-2 text-xs text-[var(--color-base-content)]/80">
           {entry.description}
         </p>
@@ -2546,6 +2583,23 @@
         {/if}
       </div>
     </div>
+
+    <!-- Developer-preview notice: v3.0 and any future preview build are flagged as
+         not the final GA release so users know what they are installing. -->
+    {#if entry.channel === CHANNEL_PREVIEW}
+      <div
+        class="mt-3 flex items-start gap-2 rounded-lg bg-[var(--color-warning)]/10 p-3 text-xs"
+        role="note"
+      >
+        <TriangleAlert
+          class="h-4 w-4 shrink-0 mt-0.5 text-[var(--color-warning)]"
+          aria-hidden="true"
+        />
+        <span class="text-[var(--color-base-content)]"
+          >{t('analysis.gallery.preview.cardNotice')}</span
+        >
+      </div>
+    {/if}
 
     <!-- Progress bar (shown during install, not for companion entries) -->
     {#if progress}
@@ -2769,7 +2823,7 @@
 <!-- License Acceptance Dialog -->
 <dialog
   bind:this={licenseDialogRef}
-  class="m-auto w-full max-w-md rounded-xl border border-[var(--color-base-300)] bg-[var(--color-base-100)] p-0 shadow-xl backdrop:bg-black/50"
+  class="m-auto w-full max-w-3xl rounded-xl border border-[var(--color-base-300)] bg-[var(--color-base-100)] p-0 shadow-xl backdrop:bg-black/50"
   aria-labelledby="license-dialog-title"
 >
   {#if licenseModel}
@@ -2777,6 +2831,22 @@
       <h3 id="license-dialog-title" class="text-lg font-semibold text-[var(--color-base-content)]">
         {t('analysis.gallery.license.title')}
       </h3>
+      {#if licenseModel.channel === CHANNEL_PREVIEW}
+        <div
+          class="mt-4 flex items-start gap-2 rounded-lg bg-[var(--color-warning)]/10 p-3 text-sm"
+          role="note"
+        >
+          <TriangleAlert
+            class="h-4 w-4 shrink-0 mt-0.5 text-[var(--color-warning)]"
+            aria-hidden="true"
+          />
+          <span class="text-[var(--color-base-content)]">
+            {t('analysis.gallery.preview.dialogNotice', {
+              build: licenseModel.buildLabel ?? licenseModel.version,
+            })}
+          </span>
+        </div>
+      {/if}
       <div class="mt-4 space-y-3">
         <table
           class="w-full overflow-hidden rounded-lg border-separate border-spacing-0 bg-[var(--color-base-200)] text-sm"

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -3895,6 +3895,9 @@ export type TranslationKey =
   | 'analysis.gallery.variants.regionContext' // params: region
   | 'analysis.gallery.variants.regionContextNone'
   | 'analysis.gallery.variants.otherRegions'
+  | 'analysis.gallery.variants.filterPlaceholder'
+  | 'analysis.gallery.variants.filterAria'
+  | 'analysis.gallery.variants.filterNoMatch' // params: query
   | 'analysis.gallery.variants.latency' // params: ms
   | 'analysis.gallery.variants.precisionInfo'
   | 'analysis.gallery.variants.precisionHelp'
@@ -3965,12 +3968,20 @@ export type TranslationKey =
   | 'analysis.gallery.reinstalling'
   | 'analysis.gallery.reinstallComplete'
   | 'analysis.gallery.geomodelBadge'
+  | 'analysis.gallery.preview.badge'
+  | 'analysis.gallery.preview.buildLabel' // params: version, build
+  | 'analysis.gallery.preview.cardNotice'
+  | 'analysis.gallery.preview.dialogNotice' // params: build
   | 'analysis.gallery.entryIncompatible'
   | 'analysis.gallery.regionGlobal'
   | 'analysis.gallery.hardwareLabel'
   | 'analysis.gallery.hardware.gpu'
+  | 'analysis.gallery.hardware.gpuNvidia'
+  | 'analysis.gallery.hardware.gpuIntel'
   | 'analysis.gallery.hardware.intelGpu'
   | 'analysis.gallery.hardware.armCpu'
+  | 'analysis.gallery.hardware.amd64Cpu'
+  | 'analysis.gallery.hardware.arm64Cpu'
   | 'analysis.gallery.hardware.cpu'
   | 'analysis.gallery.optimize.bannerTitle' // params: count
   | 'analysis.gallery.optimize.review'
@@ -4522,6 +4533,7 @@ export type TranslationParams = {
   'analysis.gallery.variants.showHardware': { count: string | number };
   'analysis.gallery.variants.showAllRegions': { count: string | number };
   'analysis.gallery.variants.regionContext': { region: string | number };
+  'analysis.gallery.variants.filterNoMatch': { query: string | number };
   'analysis.gallery.variants.latency': { ms: string | number };
   'analysis.gallery.removeSuccess': { name: string | number };
   'analysis.gallery.reasons.backendRecommended': { backend: string | number };
@@ -4534,6 +4546,8 @@ export type TranslationParams = {
   'analysis.gallery.species': { count: string | number };
   'analysis.gallery.removeDialog.title': { name: string | number };
   'analysis.gallery.errors.actionFailed': { name: string | number };
+  'analysis.gallery.preview.buildLabel': { version: string | number; build: string | number };
+  'analysis.gallery.preview.dialogNotice': { build: string | number };
   'analysis.gallery.optimize.bannerTitle': { count: string | number };
   'analysis.gallery.optimize.fromTo': { from: string | number; to: string | number };
 };

--- a/frontend/src/lib/types/models.ts
+++ b/frontend/src/lib/types/models.ts
@@ -37,7 +37,7 @@ export interface CatalogVariant {
   blockers?: VariantReason[];
   /**
    * Coarse hardware-target token for the plain-language chip (never raw precision):
-   * one of 'gpuNvidia' | 'gpuIntel' | 'amd64Cpu' | 'arm64Cpu' | 'cpu' | 'builtIn'.
+   * one of 'gpuNvidia' | 'gpuIntel' | 'amd64Cpu' | 'arm64Cpu' | 'armCpu' | 'cpu' | 'builtIn'.
    * Computed server-side from the host arch and chosen backend; absent on an older
    * server, in which case the client derives a coarser class from the id.
    */

--- a/frontend/src/lib/types/models.ts
+++ b/frontend/src/lib/types/models.ts
@@ -1,7 +1,7 @@
 // Type definitions for the model gallery API.
 //
 // These types mirror the Go structs in internal/classifier/model_manager.go
-// and the API response types in internal/api/v2/models.go.
+// and the API response types in internal/api/v2/models/models.go.
 
 /**
  * A structured, localizable reason for a variant's recommendation or
@@ -35,6 +35,13 @@ export interface CatalogVariant {
   recommended: boolean;
   reasons?: VariantReason[];
   blockers?: VariantReason[];
+  /**
+   * Coarse hardware-target token for the plain-language chip (never raw precision):
+   * one of 'gpuNvidia' | 'gpuIntel' | 'amd64Cpu' | 'arm64Cpu' | 'cpu' | 'builtIn'.
+   * Computed server-side from the host arch and chosen backend; absent on an older
+   * server, in which case the client derives a coarser class from the id.
+   */
+  hardwareClass?: string;
 }
 
 /** A model entry in the catalog, enriched with install/compat status. */
@@ -49,6 +56,10 @@ export interface CatalogEntry {
   region: string;
   speciesCount: number;
   version: string;
+  /** Release channel: 'stable' for a GA build, 'preview' for a developer preview the gallery flags as not-GA. Always present. */
+  channel: string;
+  /** Human-facing build tag shown next to the version for a non-stable channel (e.g. 'preview3.1'); absent for stable releases. */
+  buildLabel?: string;
   upstreamUrl?: string;
   installed: boolean;
   compatible: boolean;

--- a/frontend/src/lib/utils/variantSelection.test.ts
+++ b/frontend/src/lib/utils/variantSelection.test.ts
@@ -58,6 +58,7 @@ function entry(overrides: Partial<CatalogEntry>): CatalogEntry {
     region: '',
     speciesCount: 0,
     version: '1',
+    channel: 'stable',
     installed: false,
     compatible: true,
     totalSizeBytes: 0,
@@ -271,6 +272,29 @@ describe('variantHardwareLabel', () => {
     ).toBe('analysis.gallery.hardware.gpu');
     expect(variantHardwareLabel(variant({ id: 'fp32-dfttrunc', precision: 'fp32' }))).toBe(
       'analysis.gallery.hardware.cpu'
+    );
+  });
+
+  it('prefers the server-computed hardwareClass token over the client-derived class', () => {
+    // The id/reasons would derive a generic cpu, but the arch-explicit server token wins.
+    expect(variantHardwareLabel(variant({ id: 'fp32', hardwareClass: 'amd64Cpu' }))).toBe(
+      'analysis.gallery.hardware.amd64Cpu'
+    );
+    // Server token wins even when the reasons point at a GPU backend.
+    expect(
+      variantHardwareLabel(
+        variant({
+          id: 'fp16',
+          hardwareClass: 'arm64Cpu',
+          reasons: [{ code: 'backend.recommended', args: { backend: 'cuda' } }],
+        })
+      )
+    ).toBe('analysis.gallery.hardware.arm64Cpu');
+  });
+
+  it('falls back to the client-derived class when the server omits the token', () => {
+    expect(variantHardwareLabel(variant({ id: 'int8-arm', precision: 'int8' }))).toBe(
+      'analysis.gallery.hardware.armCpu'
     );
   });
 });

--- a/frontend/src/lib/utils/variantSelection.test.ts
+++ b/frontend/src/lib/utils/variantSelection.test.ts
@@ -9,6 +9,7 @@ import {
   variantHardwareClass,
   variantHardwareLabel,
   optimizeOffers,
+  CHANNEL_STABLE,
 } from './variantSelection';
 import type { CatalogEntry, CatalogVariant, VariantReason } from '$lib/types/models';
 
@@ -58,7 +59,7 @@ function entry(overrides: Partial<CatalogEntry>): CatalogEntry {
     region: '',
     speciesCount: 0,
     version: '1',
-    channel: 'stable',
+    channel: CHANNEL_STABLE,
     installed: false,
     compatible: true,
     totalSizeBytes: 0,

--- a/frontend/src/lib/utils/variantSelection.ts
+++ b/frontend/src/lib/utils/variantSelection.ts
@@ -130,9 +130,15 @@ export function variantLabel(
 }
 
 /**
- * A friendly hardware class for a variant, used to render a hardware chip on the
- * gallery card. 'builtIn' is the embedded baseline; the rest describe the execution
- * target the variant is recommended for on this host.
+ * A friendly hardware class for a variant, used as the CLIENT-SIDE FALLBACK when the
+ * server omits its authoritative hardwareClass token (an older server). 'builtIn' is
+ * the embedded baseline; the rest describe the execution target the variant is
+ * recommended for on this host.
+ *
+ * NOTE: this client vocabulary ('gpu'/'intelGpu'/'armCpu') intentionally differs from
+ * the server's ('gpuNvidia'/'gpuIntel'/'arm64Cpu'); both sets have keys under
+ * `analysis.gallery.hardware.*` and both must be kept. Do NOT delete the client-vocab
+ * keys as "unused": they are the labels for the old-server fallback path below.
  */
 export type VariantHardwareClass = 'builtIn' | 'gpu' | 'intelGpu' | 'armCpu' | 'cpu';
 
@@ -170,11 +176,19 @@ export function variantHardwareClass(variant: CatalogVariant): VariantHardwareCl
 }
 
 /**
- * Localized hardware chip label for a variant. The BuiltIn baseline uses the
- * built-in label; every other class maps to `analysis.gallery.hardware.<class>`.
+ * Localized hardware chip label for a variant, the plain-language answer to "which
+ * hardware is this build for" that replaces raw precision (FP16/FP32) as the primary
+ * label. Prefers the server-computed `hardwareClass` token, which is authoritative
+ * because it is derived from the live host architecture and the chosen backend (so a
+ * CPU build reads "AMD64 CPU" or "ARM64 CPU" as appropriate); falls back to the
+ * coarser client-side class when an older server omits the token. Either token maps
+ * to `analysis.gallery.hardware.<token>`, except the built-in baseline.
  */
 export function variantHardwareLabel(variant: CatalogVariant): string {
-  const cls = variantHardwareClass(variant);
+  // The server omits hardwareClass (omitempty) rather than sending "", so nullish
+  // coalescing is the correct fallback: only an absent token falls through to the
+  // coarser client-side class.
+  const cls = variant.hardwareClass ?? variantHardwareClass(variant);
   if (cls === 'builtIn') return t('analysis.gallery.builtIn');
   return t(`analysis.gallery.hardware.${cls}`);
 }
@@ -227,6 +241,13 @@ export function optimizeOffers(catalog: CatalogEntry[]): OptimizeOffer[] {
   }
   return offers;
 }
+
+/**
+ * The catalog release channel marking a developer-preview (not-GA) build. The gallery
+ * flags an entry on this channel with a PREVIEW badge and a not-GA notice. Mirrors the
+ * Go `classifier.ChannelPreview` constant.
+ */
+export const CHANNEL_PREVIEW = 'preview';
 
 /**
  * The canonical "automatic" region mode. An empty string, null, and undefined

--- a/frontend/src/lib/utils/variantSelection.ts
+++ b/frontend/src/lib/utils/variantSelection.ts
@@ -250,6 +250,13 @@ export function optimizeOffers(catalog: CatalogEntry[]): OptimizeOffer[] {
 export const CHANNEL_PREVIEW = 'preview';
 
 /**
+ * The catalog release channel marking a stable (GA) build, the default an entry
+ * without an explicit channel resolves to. Mirrors the Go `classifier.ChannelStable`
+ * constant.
+ */
+export const CHANNEL_STABLE = 'stable';
+
+/**
  * The canonical "automatic" region mode. An empty string, null, and undefined
  * all mean automatic in the gallery, mirroring the Go `ModelRegion` field's
  * `omitempty` (an unset region is omitted from JSON entirely).

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -5339,6 +5339,9 @@
         "regionContext": "Zobrazeny regionální varianty pro {region}, nastaveno výběrem oblasti modelu výše",
         "regionContextNone": "K dispozici jsou regionální varianty. Vyberte oblast ve výběru oblasti modelu výše, nebo zobrazte všechny varianty.",
         "otherRegions": "Ostatní oblasti",
+        "filterPlaceholder": "Filtrovat oblasti",
+        "filterAria": "Filtrovat verze přizpůsobené oblastem",
+        "filterNoMatch": "Žádné oblasti neodpovídají \"{query}\"",
         "latency": "~{ms} ms",
         "precisionInfo": "About precision and variants",
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
@@ -5426,13 +5429,23 @@
       "reinstalling": "Přeinstalování…",
       "reinstallComplete": "Soubory úspěšně ověřeny",
       "geomodelBadge": "Obsahuje BirdNET v3.0 geomodel",
+      "preview": {
+        "badge": "Náhled",
+        "buildLabel": "{version} · {build}",
+        "cardNotice": "Vývojářský náhled, nejedná se o finální verzi. Jde o rané sestavení pro testování; výsledky se mohou před stabilní verzí změnit.",
+        "dialogNotice": "Instalujete vývojářský náhled ({build}). Hodí se k vyzkoušení, ale zatím se nedoporučuje jako váš jediný klasifikátor."
+      },
       "entryIncompatible": "Tento model není v tomto systému k dispozici.",
       "regionGlobal": "Globální",
       "hardwareLabel": "Hardware",
       "hardware": {
         "gpu": "GPU",
+        "gpuNvidia": "GPU (NVIDIA)",
+        "gpuIntel": "GPU (Intel)",
         "intelGpu": "Intel GPU",
         "armCpu": "ARM CPU",
+        "amd64Cpu": "AMD64 CPU",
+        "arm64Cpu": "ARM64 CPU",
         "cpu": "CPU"
       },
       "optimize": {

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -5339,6 +5339,9 @@
         "regionContext": "Regionale varianter vises for {region}, angivet af valget af modelregion ovenfor",
         "regionContextNone": "Regionale varianter er tilgængelige. Vælg en region i valget af modelregion ovenfor, eller vis alle varianter.",
         "otherRegions": "Andre regioner",
+        "filterPlaceholder": "Filtrer regioner",
+        "filterAria": "Filtrer regionstilpassede versioner",
+        "filterNoMatch": "Ingen regioner matcher \"{query}\"",
         "latency": "~{ms} ms",
         "precisionInfo": "About precision and variants",
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
@@ -5426,13 +5429,23 @@
       "reinstalling": "Geninstallerer...",
       "reinstallComplete": "Filer verificeret succesfuldt",
       "geomodelBadge": "Inkluderer BirdNET v3.0 geomodel",
+      "preview": {
+        "badge": "Forhåndsvisning",
+        "buildLabel": "{version} · {build}",
+        "cardNotice": "Forhåndsvisning til udviklere, ikke den endelige udgivelse. Dette er en tidlig version til test; resultaterne kan ændre sig inden den stabile version.",
+        "dialogNotice": "Du er ved at installere en forhåndsvisning til udviklere ({build}). Den er fin til at afprøve, men anbefales endnu ikke som din eneste klassifikator."
+      },
       "entryIncompatible": "Denne model er ikke tilgængelig på dette system.",
       "regionGlobal": "Global",
       "hardwareLabel": "Hardware",
       "hardware": {
         "gpu": "GPU",
+        "gpuNvidia": "GPU (NVIDIA)",
+        "gpuIntel": "GPU (Intel)",
         "intelGpu": "Intel GPU",
         "armCpu": "ARM CPU",
+        "amd64Cpu": "AMD64 CPU",
+        "arm64Cpu": "ARM64 CPU",
         "cpu": "CPU"
       },
       "optimize": {

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -5339,6 +5339,9 @@
         "regionContext": "Regionale Varianten angezeigt für {region}, festgelegt durch die Auswahl der Modellregion oben",
         "regionContextNone": "Regionale Varianten sind verfügbar. Wählen Sie oben eine Region in der Modellregionsauswahl oder zeigen Sie alle Varianten an.",
         "otherRegions": "Andere Regionen",
+        "filterPlaceholder": "Regionen filtern",
+        "filterAria": "Auf Regionen abgestimmte Builds filtern",
+        "filterNoMatch": "Keine Regionen entsprechen \"{query}\"",
         "latency": "~{ms} ms",
         "precisionInfo": "About precision and variants",
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
@@ -5426,13 +5429,23 @@
       "reinstalling": "Wird neu installiert...",
       "reinstallComplete": "Dateien erfolgreich überprüft",
       "geomodelBadge": "Enthält BirdNET v3.0 Geomodell",
+      "preview": {
+        "badge": "Vorschau",
+        "buildLabel": "{version} · {build}",
+        "cardNotice": "Entwicklervorschau, keine finale Version. Dies ist ein früher Build zum Testen; Ergebnisse können sich vor der stabilen Version ändern.",
+        "dialogNotice": "Sie installieren eine Entwicklervorschau ({build}). Zum Ausprobieren geeignet, aber noch nicht als einziger Klassifikator empfohlen."
+      },
       "entryIncompatible": "Dieses Modell ist auf diesem System nicht verfügbar.",
       "regionGlobal": "Global",
       "hardwareLabel": "Hardware",
       "hardware": {
         "gpu": "GPU",
+        "gpuNvidia": "GPU (NVIDIA)",
+        "gpuIntel": "GPU (Intel)",
         "intelGpu": "Intel GPU",
         "armCpu": "ARM CPU",
+        "amd64Cpu": "AMD64 CPU",
+        "arm64Cpu": "ARM64 CPU",
         "cpu": "CPU"
       },
       "optimize": {

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -5339,6 +5339,9 @@
         "regionContext": "Regional variants shown for {region}, set by the model region selection above",
         "regionContextNone": "Regional variants are available. Pick a region in the model region selection above to scope them to your area.",
         "otherRegions": "Other regions",
+        "filterPlaceholder": "Filter regions",
+        "filterAria": "Filter region-tuned builds",
+        "filterNoMatch": "No regions match \"{query}\"",
         "latency": "~{ms} ms",
         "precisionInfo": "About precision and variants",
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
@@ -5426,13 +5429,23 @@
       "reinstalling": "Reinstalling...",
       "reinstallComplete": "Files verified successfully",
       "geomodelBadge": "Includes BirdNET v3.0 geomodel",
+      "preview": {
+        "badge": "Preview",
+        "buildLabel": "{version} · {build}",
+        "cardNotice": "Developer preview, not the final release. This is an early build for testing; results may change before the stable version.",
+        "dialogNotice": "You are installing a developer preview ({build}). Fine for trying it out, but not recommended as your only classifier yet."
+      },
       "entryIncompatible": "This model is not available on this system.",
       "regionGlobal": "Global",
       "hardwareLabel": "Hardware",
       "hardware": {
         "gpu": "GPU",
+        "gpuNvidia": "GPU (NVIDIA)",
+        "gpuIntel": "GPU (Intel)",
         "intelGpu": "Intel GPU",
         "armCpu": "ARM CPU",
+        "amd64Cpu": "AMD64 CPU",
+        "arm64Cpu": "ARM64 CPU",
         "cpu": "CPU"
       },
       "optimize": {

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -5339,6 +5339,9 @@
         "regionContext": "Variantes regionales mostradas para {region}, definidas por la selección de región del modelo arriba",
         "regionContextNone": "Hay variantes regionales disponibles. Elige una región en la selección de región del modelo arriba o muestra todas las variantes.",
         "otherRegions": "Otras regiones",
+        "filterPlaceholder": "Filtrar regiones",
+        "filterAria": "Filtrar versiones adaptadas a regiones",
+        "filterNoMatch": "Ninguna región coincide con \"{query}\"",
         "latency": "~{ms} ms",
         "precisionInfo": "About precision and variants",
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
@@ -5426,13 +5429,23 @@
       "reinstalling": "Reinstalando...",
       "reinstallComplete": "Archivos verificados correctamente",
       "geomodelBadge": "Incluye BirdNET v3.0 geomodel",
+      "preview": {
+        "badge": "Vista previa",
+        "buildLabel": "{version} · {build}",
+        "cardNotice": "Vista previa para desarrolladores, no es la versión final. Esta es una versión preliminar para pruebas; los resultados pueden cambiar antes de la versión estable.",
+        "dialogNotice": "Estás instalando una versión preliminar para desarrolladores ({build}). Está bien para probarla, pero aún no se recomienda como tu único clasificador."
+      },
       "entryIncompatible": "Este modelo no está disponible en este sistema.",
       "regionGlobal": "Global",
       "hardwareLabel": "Hardware",
       "hardware": {
         "gpu": "GPU",
+        "gpuNvidia": "GPU (NVIDIA)",
+        "gpuIntel": "GPU (Intel)",
         "intelGpu": "Intel GPU",
         "armCpu": "ARM CPU",
+        "amd64Cpu": "AMD64 CPU",
+        "arm64Cpu": "ARM64 CPU",
         "cpu": "CPU"
       },
       "optimize": {

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -5339,6 +5339,9 @@
         "regionContext": "Alueelliset variantit näytetään alueelle {region}, määritetty yllä olevalla mallialueen valinnalla",
         "regionContextNone": "Alueellisia variantteja on saatavilla. Valitse alue yllä olevasta mallialueen valinnasta tai näytä kaikki variantit.",
         "otherRegions": "Muut alueet",
+        "filterPlaceholder": "Suodata alueita",
+        "filterAria": "Suodata aluekohtaisia versioita",
+        "filterNoMatch": "Mikään alue ei vastaa hakua \"{query}\"",
         "latency": "~{ms} ms",
         "precisionInfo": "About precision and variants",
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
@@ -5426,13 +5429,23 @@
       "reinstalling": "Asennetaan uudelleen...",
       "reinstallComplete": "Tiedostot tarkistettu onnistuneesti",
       "geomodelBadge": "Sisältää BirdNET v3.0 -geomallin",
+      "preview": {
+        "badge": "Esiversio",
+        "buildLabel": "{version} · {build}",
+        "cardNotice": "Kehittäjien esiversio, ei lopullinen julkaisu. Tämä on varhainen versio testausta varten; tulokset voivat muuttua ennen vakaata versiota.",
+        "dialogNotice": "Olet asentamassa kehittäjien esiversiota ({build}). Se soveltuu kokeiluun, mutta sitä ei vielä suositella ainoaksi luokittelijaksi."
+      },
       "entryIncompatible": "Tämä malli ei ole saatavilla tässä järjestelmässä.",
       "regionGlobal": "Globaali",
       "hardwareLabel": "Laitteisto",
       "hardware": {
         "gpu": "GPU",
+        "gpuNvidia": "GPU (NVIDIA)",
+        "gpuIntel": "GPU (Intel)",
         "intelGpu": "Intel GPU",
         "armCpu": "ARM CPU",
+        "amd64Cpu": "AMD64 CPU",
+        "arm64Cpu": "ARM64 CPU",
         "cpu": "CPU"
       },
       "optimize": {

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -5339,6 +5339,9 @@
         "regionContext": "Variantes régionales affichées pour {region}, définies par la sélection de région du modèle ci-dessus",
         "regionContextNone": "Des variantes régionales sont disponibles. Choisissez une région dans la sélection de région du modèle ci-dessus ou affichez toutes les variantes.",
         "otherRegions": "Autres régions",
+        "filterPlaceholder": "Filtrer les régions",
+        "filterAria": "Filtrer les versions adaptées aux régions",
+        "filterNoMatch": "Aucune région ne correspond à \"{query}\"",
         "latency": "~{ms} ms",
         "precisionInfo": "About precision and variants",
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
@@ -5426,13 +5429,23 @@
       "reinstalling": "Réinstallation...",
       "reinstallComplete": "Fichiers vérifiés avec succès",
       "geomodelBadge": "Inclut le BirdNET v3.0 geomodel",
+      "preview": {
+        "badge": "Aperçu",
+        "buildLabel": "{version} · {build}",
+        "cardNotice": "Aperçu développeur, pas la version finale. Il s'agit d'une version préliminaire pour les tests; les résultats peuvent changer avant la version stable.",
+        "dialogNotice": "Vous installez un aperçu développeur ({build}). Idéal pour tester, mais pas encore recommandé comme classificateur unique."
+      },
       "entryIncompatible": "Ce modèle n'est pas disponible sur ce système.",
       "regionGlobal": "Global",
       "hardwareLabel": "Matériel",
       "hardware": {
         "gpu": "GPU",
+        "gpuNvidia": "GPU (NVIDIA)",
+        "gpuIntel": "GPU (Intel)",
         "intelGpu": "Intel GPU",
         "armCpu": "ARM CPU",
+        "amd64Cpu": "AMD64 CPU",
+        "arm64Cpu": "ARM64 CPU",
         "cpu": "CPU"
       },
       "optimize": {

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -5339,6 +5339,9 @@
         "regionContext": "Megjelenített regionális változatok ehhez: {region}, a fenti modellrégió-választás alapján",
         "regionContextNone": "Elérhetők regionális változatok. Válassz egy régiót a fenti modellrégió-választásban, vagy jelenítsd meg az összes változatot.",
         "otherRegions": "Egyéb régiók",
+        "filterPlaceholder": "Régiók szűrése",
+        "filterAria": "Régióra szabott buildek szűrése",
+        "filterNoMatch": "Egyetlen régió sem felel meg ennek: \"{query}\"",
         "latency": "~{ms} ms",
         "precisionInfo": "About precision and variants",
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
@@ -5426,13 +5429,23 @@
       "reinstalling": "Újratelepítés...",
       "reinstallComplete": "Fájlok sikeresen ellenőrizve",
       "geomodelBadge": "Tartalmazza a BirdNET v3.0 geomodellt",
+      "preview": {
+        "badge": "Előzetes",
+        "buildLabel": "{version} · {build}",
+        "cardNotice": "Fejlesztői előzetes, nem végleges kiadás. Ez egy korai tesztverzió; az eredmények a stabil verzió előtt még változhatnak.",
+        "dialogNotice": "Fejlesztői előzetest ({build}) készülsz telepíteni. Kipróbálásra jó, de egyelőre nem ajánlott egyedüli osztályozóként használni."
+      },
       "entryIncompatible": "Ez a modell nem érhető el ezen a rendszeren.",
       "regionGlobal": "Globális",
       "hardwareLabel": "Hardver",
       "hardware": {
         "gpu": "GPU",
+        "gpuNvidia": "GPU (NVIDIA)",
+        "gpuIntel": "GPU (Intel)",
         "intelGpu": "Intel GPU",
         "armCpu": "ARM CPU",
+        "amd64Cpu": "AMD64 CPU",
+        "arm64Cpu": "ARM64 CPU",
         "cpu": "CPU"
       },
       "optimize": {

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -5339,6 +5339,9 @@
         "regionContext": "Varianti regionali mostrate per {region}, impostate dalla selezione della regione del modello sopra",
         "regionContextNone": "Sono disponibili varianti regionali. Scegli una regione nella selezione della regione del modello sopra, oppure mostra tutte le varianti.",
         "otherRegions": "Altre regioni",
+        "filterPlaceholder": "Filtra regioni",
+        "filterAria": "Filtra le versioni ottimizzate per regione",
+        "filterNoMatch": "Nessuna regione corrisponde a \"{query}\"",
         "latency": "~{ms} ms",
         "precisionInfo": "About precision and variants",
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
@@ -5426,13 +5429,23 @@
       "reinstalling": "Reinstallazione...",
       "reinstallComplete": "File verificati con successo",
       "geomodelBadge": "Include il geomodel BirdNET v3.0",
+      "preview": {
+        "badge": "Anteprima",
+        "buildLabel": "{version} · {build}",
+        "cardNotice": "Anteprima per sviluppatori, non è la versione finale. Questa è una versione preliminare per i test; i risultati potrebbero cambiare prima della versione stabile.",
+        "dialogNotice": "Stai installando un'anteprima per sviluppatori ({build}). Va bene per provarla, ma non è ancora consigliata come unico classificatore."
+      },
       "entryIncompatible": "Questo modello non è disponibile su questo sistema.",
       "regionGlobal": "Globale",
       "hardwareLabel": "Hardware",
       "hardware": {
         "gpu": "GPU",
+        "gpuNvidia": "GPU (NVIDIA)",
+        "gpuIntel": "GPU (Intel)",
         "intelGpu": "Intel GPU",
         "armCpu": "ARM CPU",
+        "amd64Cpu": "AMD64 CPU",
+        "arm64Cpu": "ARM64 CPU",
         "cpu": "CPU"
       },
       "optimize": {

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -5339,6 +5339,9 @@
         "regionContext": "Reģionālie varianti parādīti reģionam {region}, iestatīti ar modeļa reģiona izvēli augstāk",
         "regionContextNone": "Ir pieejami reģionālie varianti. Izvēlieties reģionu modeļa reģiona izvēlē augstāk vai rādiet visus variantus.",
         "otherRegions": "Citi reģioni",
+        "filterPlaceholder": "Filtrēt reģionus",
+        "filterAria": "Filtrēt reģioniem pielāgotās versijas",
+        "filterNoMatch": "Neviens reģions neatbilst \"{query}\"",
         "latency": "~{ms} ms",
         "precisionInfo": "About precision and variants",
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
@@ -5426,13 +5429,23 @@
       "reinstalling": "Pārinstalē...",
       "reinstallComplete": "Faili veiksmīgi pārbaudīti",
       "geomodelBadge": "Ietver BirdNET v3.0 ģeomodelis",
+      "preview": {
+        "badge": "Priekšskatījums",
+        "buildLabel": "{version} · {build}",
+        "cardNotice": "Izstrādātāja priekšskatījums, nav galīgais laidiens. Šī ir agrīna versija testēšanai; rezultāti var mainīties pirms stabilās versijas.",
+        "dialogNotice": "Jūs instalējat izstrādātāja priekšskatījumu ({build}). Piemērots izmēģināšanai, taču vēl nav ieteicams kā jūsu vienīgais klasifikators."
+      },
       "entryIncompatible": "Šis modelis nav pieejams šajā sistēmā.",
       "regionGlobal": "Globāls",
       "hardwareLabel": "Aparatūra",
       "hardware": {
         "gpu": "GPU",
+        "gpuNvidia": "GPU (NVIDIA)",
+        "gpuIntel": "GPU (Intel)",
         "intelGpu": "Intel GPU",
         "armCpu": "ARM CPU",
+        "amd64Cpu": "AMD64 CPU",
+        "arm64Cpu": "ARM64 CPU",
         "cpu": "CPU"
       },
       "optimize": {

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -5339,6 +5339,9 @@
         "regionContext": "Regionale varianter vises for {region}, angitt av valget av modellregion ovenfor",
         "regionContextNone": "Regionale varianter er tilgjengelige. Velg en region i modellregionvalget ovenfor, eller vis alle varianter.",
         "otherRegions": "Andre regioner",
+        "filterPlaceholder": "Filtrer regioner",
+        "filterAria": "Filtrer regiontilpassede bygg",
+        "filterNoMatch": "Ingen regioner matcher \"{query}\"",
         "latency": "~{ms} ms",
         "precisionInfo": "About precision and variants",
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
@@ -5426,13 +5429,23 @@
       "reinstalling": "Reinstallerer...",
       "reinstallComplete": "Filer verifisert",
       "geomodelBadge": "Inkluderer BirdNET v3.0 geomodell",
+      "preview": {
+        "badge": "Forhåndsvisning",
+        "buildLabel": "{version} · {build}",
+        "cardNotice": "Forhåndsvisning for utviklere, ikke den endelige utgivelsen. Dette er et tidlig bygg for testing; resultatene kan endre seg før den stabile versjonen.",
+        "dialogNotice": "Du installerer en forhåndsvisning for utviklere ({build}). Fin til å prøve ut, men anbefales ikke som din eneste klassifikator ennå."
+      },
       "entryIncompatible": "Denne modellen er ikke tilgjengelig på dette systemet.",
       "regionGlobal": "Global",
       "hardwareLabel": "Maskinvare",
       "hardware": {
         "gpu": "GPU",
+        "gpuNvidia": "GPU (NVIDIA)",
+        "gpuIntel": "GPU (Intel)",
         "intelGpu": "Intel GPU",
         "armCpu": "ARM CPU",
+        "amd64Cpu": "AMD64 CPU",
+        "arm64Cpu": "ARM64 CPU",
         "cpu": "CPU"
       },
       "optimize": {

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -5339,6 +5339,9 @@
         "regionContext": "Regionale varianten getoond voor {region}, ingesteld door de modelregioselectie hierboven",
         "regionContextNone": "Er zijn regionale varianten beschikbaar. Kies een regio in de modelregioselectie hierboven, of toon alle varianten.",
         "otherRegions": "Andere regio's",
+        "filterPlaceholder": "Regio's filteren",
+        "filterAria": "Filter op regio afgestemde versies",
+        "filterNoMatch": "Geen regio's komen overeen met \"{query}\"",
         "latency": "~{ms} ms",
         "precisionInfo": "About precision and variants",
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
@@ -5426,13 +5429,23 @@
       "reinstalling": "Opnieuw installeren...",
       "reinstallComplete": "Bestanden succesvol geverifieerd",
       "geomodelBadge": "Bevat BirdNET v3.0 geomodel",
+      "preview": {
+        "badge": "Voorvertoning",
+        "buildLabel": "{version} · {build}",
+        "cardNotice": "Voorvertoning voor ontwikkelaars, niet de definitieve versie. Dit is een vroege versie om te testen; resultaten kunnen veranderen voor de stabiele versie.",
+        "dialogNotice": "Je installeert een voorvertoning voor ontwikkelaars ({build}). Handig om uit te proberen, maar nog niet aanbevolen als je enige classificator."
+      },
       "entryIncompatible": "Dit model is niet beschikbaar op dit systeem.",
       "regionGlobal": "Globaal",
       "hardwareLabel": "Hardware",
       "hardware": {
         "gpu": "GPU",
+        "gpuNvidia": "GPU (NVIDIA)",
+        "gpuIntel": "GPU (Intel)",
         "intelGpu": "Intel GPU",
         "armCpu": "ARM CPU",
+        "amd64Cpu": "AMD64 CPU",
+        "arm64Cpu": "ARM64 CPU",
         "cpu": "CPU"
       },
       "optimize": {

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -5339,6 +5339,9 @@
         "regionContext": "Warianty regionalne wyświetlane dla {region}, ustawione powyższym wyborem regionu modelu",
         "regionContextNone": "Dostępne są warianty regionalne. Wybierz region w powyższym wyborze regionu modelu lub pokaż wszystkie warianty.",
         "otherRegions": "Inne regiony",
+        "filterPlaceholder": "Filtruj regiony",
+        "filterAria": "Filtruj kompilacje dopasowane do regionu",
+        "filterNoMatch": "Brak regionów pasujących do \"{query}\"",
         "latency": "~{ms} ms",
         "precisionInfo": "About precision and variants",
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
@@ -5426,13 +5429,23 @@
       "reinstalling": "Ponowna instalacja...",
       "reinstallComplete": "Pliki zweryfikowane pomyślnie",
       "geomodelBadge": "Zawiera BirdNET v3.0 geomodel",
+      "preview": {
+        "badge": "Wersja zapoznawcza",
+        "buildLabel": "{version} · {build}",
+        "cardNotice": "Wersja zapoznawcza dla deweloperów, to nie jest wydanie ostateczne. Jest to wczesna kompilacja do testów; wyniki mogą ulec zmianie przed wersją stabilną.",
+        "dialogNotice": "Instalujesz wersję zapoznawczą dla deweloperów ({build}). Nadaje się do wypróbowania, ale nie jest jeszcze zalecana jako jedyny klasyfikator."
+      },
       "entryIncompatible": "Ten model nie jest dostępny w tym systemie.",
       "regionGlobal": "Globalny",
       "hardwareLabel": "Sprzęt",
       "hardware": {
         "gpu": "GPU",
+        "gpuNvidia": "GPU (NVIDIA)",
+        "gpuIntel": "GPU (Intel)",
         "intelGpu": "Intel GPU",
         "armCpu": "ARM CPU",
+        "amd64Cpu": "AMD64 CPU",
+        "arm64Cpu": "ARM64 CPU",
         "cpu": "CPU"
       },
       "optimize": {

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -5339,6 +5339,9 @@
         "regionContext": "Variantes regionais mostradas para {region}, definidas pela seleção de região do modelo acima",
         "regionContextNone": "Variantes regionais estão disponíveis. Escolha uma região na seleção de região do modelo acima ou mostre todas as variantes.",
         "otherRegions": "Outras regiões",
+        "filterPlaceholder": "Filtrar regiões",
+        "filterAria": "Filtrar versões ajustadas por região",
+        "filterNoMatch": "Nenhuma região corresponde a \"{query}\"",
         "latency": "~{ms} ms",
         "precisionInfo": "About precision and variants",
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
@@ -5426,13 +5429,23 @@
       "reinstalling": "Reinstalando...",
       "reinstallComplete": "Ficheiros verificados com sucesso",
       "geomodelBadge": "Inclui BirdNET v3.0 geomodel",
+      "preview": {
+        "badge": "Prévia",
+        "buildLabel": "{version} · {build}",
+        "cardNotice": "Prévia para desenvolvedores, não é a versão final. Esta é uma versão inicial para testes; os resultados podem mudar antes da versão estável.",
+        "dialogNotice": "Você está instalando uma prévia para desenvolvedores ({build}). É útil para testes, mas ainda não é recomendada como seu único classificador."
+      },
       "entryIncompatible": "Este modelo não está disponível neste sistema.",
       "regionGlobal": "Global",
       "hardwareLabel": "Hardware",
       "hardware": {
         "gpu": "GPU",
+        "gpuNvidia": "GPU (NVIDIA)",
+        "gpuIntel": "GPU (Intel)",
         "intelGpu": "Intel GPU",
         "armCpu": "ARM CPU",
+        "amd64Cpu": "AMD64 CPU",
+        "arm64Cpu": "ARM64 CPU",
         "cpu": "CPU"
       },
       "optimize": {

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -5339,6 +5339,9 @@
         "regionContext": "Zobrazené regionálne varianty pre {region}, nastavené výberom regiónu modelu vyššie",
         "regionContextNone": "K dispozícii sú regionálne varianty. Vyberte región vo výbere regiónu modelu vyššie alebo zobrazte všetky varianty.",
         "otherRegions": "Ostatné regióny",
+        "filterPlaceholder": "Filtrovať regióny",
+        "filterAria": "Filtrovať verzie prispôsobené regiónom",
+        "filterNoMatch": "Žiadne regióny nezodpovedajú \"{query}\"",
         "latency": "~{ms} ms",
         "precisionInfo": "About precision and variants",
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
@@ -5426,13 +5429,23 @@
       "reinstalling": "Preinštalovanie...",
       "reinstallComplete": "Súbory úspešne overené",
       "geomodelBadge": "Obsahuje BirdNET v3.0 geomodel",
+      "preview": {
+        "badge": "Náhľad",
+        "buildLabel": "{version} · {build}",
+        "cardNotice": "Vývojársky náhľad, nejde o finálnu verziu. Ide o rané zostavenie na testovanie; výsledky sa pred stabilnou verziou môžu zmeniť.",
+        "dialogNotice": "Inštalujete vývojársky náhľad ({build}). Je vhodný na vyskúšanie, ale zatiaľ sa neodporúča ako váš jediný klasifikátor."
+      },
       "entryIncompatible": "Tento model nie je v tomto systéme k dispozícii.",
       "regionGlobal": "Globálny",
       "hardwareLabel": "Hardvér",
       "hardware": {
         "gpu": "GPU",
+        "gpuNvidia": "GPU (NVIDIA)",
+        "gpuIntel": "GPU (Intel)",
         "intelGpu": "Intel GPU",
         "armCpu": "ARM CPU",
+        "amd64Cpu": "AMD64 CPU",
+        "arm64Cpu": "ARM64 CPU",
         "cpu": "CPU"
       },
       "optimize": {

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -5339,6 +5339,9 @@
         "regionContext": "Regionala varianter visas för {region}, inställt via modellregionsvalet ovan",
         "regionContextNone": "Regionala varianter är tillgängliga. Välj en region i modellregionsvalet ovan, eller visa alla varianter.",
         "otherRegions": "Andra regioner",
+        "filterPlaceholder": "Filtrera regioner",
+        "filterAria": "Filtrera regionsanpassade byggen",
+        "filterNoMatch": "Inga regioner matchar \"{query}\"",
         "latency": "~{ms} ms",
         "precisionInfo": "About precision and variants",
         "precisionHelp": "Precision (FP32, FP16, INT8) trades accuracy for size and speed: FP32 is most accurate, INT8 is smallest and fastest. Recommended is the best match for your detected hardware; Default is the model's standard build."
@@ -5426,13 +5429,23 @@
       "reinstalling": "Installerar om...",
       "reinstallComplete": "Filer verifierade",
       "geomodelBadge": "Inkluderar BirdNET v3.0 geomodell",
+      "preview": {
+        "badge": "Förhandsvisning",
+        "buildLabel": "{version} · {build}",
+        "cardNotice": "Förhandsvisning för utvecklare, inte den slutgiltiga versionen. Detta är ett tidigt bygge för testning; resultaten kan ändras före den stabila versionen.",
+        "dialogNotice": "Du installerar en förhandsvisning för utvecklare ({build}). Fungerar bra för att prova på, men rekommenderas inte som din enda klassificerare ännu."
+      },
       "entryIncompatible": "Den här modellen är inte tillgänglig på detta system.",
       "regionGlobal": "Global",
       "hardwareLabel": "Hårdvara",
       "hardware": {
         "gpu": "GPU",
+        "gpuNvidia": "GPU (NVIDIA)",
+        "gpuIntel": "GPU (Intel)",
         "intelGpu": "Intel GPU",
         "armCpu": "ARM CPU",
+        "amd64Cpu": "AMD64 CPU",
+        "arm64Cpu": "ARM64 CPU",
         "cpu": "CPU"
       },
       "optimize": {

--- a/internal/api/v2/models/models.go
+++ b/internal/api/v2/models/models.go
@@ -96,9 +96,16 @@ type CatalogEntryResponse struct {
 	Region        string `json:"region"`
 	SpeciesCount  int    `json:"speciesCount"`
 	Version       string `json:"version"`
-	UpstreamURL   string `json:"upstreamUrl,omitempty"`
-	Installed     bool   `json:"installed"`
-	Compatible    bool   `json:"compatible"`
+	// Channel is the release channel: "stable" for a GA build, "preview" for a
+	// developer-preview build the gallery flags as not the final release. Always
+	// populated (defaults to "stable") so the frontend never has to guess.
+	Channel string `json:"channel"`
+	// BuildLabel is a human-facing build tag shown next to Version for a non-stable
+	// channel (e.g. "preview3.1"); omitted for stable releases.
+	BuildLabel  string `json:"buildLabel,omitempty"`
+	UpstreamURL string `json:"upstreamUrl,omitempty"`
+	Installed   bool   `json:"installed"`
+	Compatible  bool   `json:"compatible"`
 	// IncompatibleReason is a structured, localizable code (an i18n key stem such
 	// as "backend.onnx_unavailable"), never a raw English message, so the fully
 	// i18n'd gallery can translate it; a client renders it through the same reason
@@ -150,6 +157,14 @@ type CatalogVariantResponse struct {
 	// is not eligible for hardware recommendations.
 	Reasons  []VariantReasonResponse `json:"reasons,omitempty"`
 	Blockers []VariantReasonResponse `json:"blockers,omitempty"`
+	// HardwareClass is a coarse, localizable token naming the hardware this variant
+	// targets, for the gallery's plain-language chip (never raw precision like
+	// "fp16"). One of: "gpuNvidia", "gpuIntel", "amd64Cpu", "arm64Cpu", "cpu",
+	// "builtIn". The frontend maps it to analysis.gallery.hardware.<token>.
+	// The CPU tokens are made architecture-explicit from the host arch when the
+	// request is eligible for recommendations; otherwise the intrinsic "cpu"/"gpu"
+	// class (from the variant's own recommended backends) is emitted.
+	HardwareClass string `json:"hardwareClass,omitempty"`
 }
 
 // VariantReasonResponse is a structured, localizable reason for a variant's
@@ -240,8 +255,12 @@ func (c *Handler) GetModelCatalog(ctx echo.Context) error {
 	// neutral Compatible=true with no reasons.
 	var recsByVariant map[string]map[string]recommend.Recommendation
 	var recommendedVariant map[string]string
+	// hostArch stays "" for an ineligible request, so the hardware-class tokens
+	// degrade to the architecture-neutral "cpu"/"gpu" class rather than leaking the
+	// host architecture on the public endpoint.
+	hostArch := ""
 	if c.recommendationsAllowed(ctx) {
-		recsByVariant, recommendedVariant = c.rankCatalog(visible, ortStatus)
+		recsByVariant, recommendedVariant, hostArch = c.rankCatalog(visible, ortStatus)
 	}
 
 	for i := range visible {
@@ -282,6 +301,8 @@ func (c *Handler) GetModelCatalog(ctx echo.Context) error {
 			Region:               entry.Region,
 			SpeciesCount:         entry.SpeciesCount,
 			Version:              entry.Version,
+			Channel:              channelOrDefault(entry.Channel),
+			BuildLabel:           entry.BuildLabel,
 			UpstreamURL:          entry.UpstreamURL,
 			Installed:            installed,
 			Compatible:           compatible,
@@ -291,7 +312,7 @@ func (c *Handler) GetModelCatalog(ctx echo.Context) error {
 			Permanent:            classifier.IsPermanentEntry(entry),
 			InstalledVariantID:   installedVariantID,
 			RecommendedVariantID: recommendedVariant[entry.ID],
-			Variants:             buildVariantResponses(entry, installed, installedVariantID, recsByVariant[entry.ID]),
+			Variants:             buildVariantResponses(entry, installed, installedVariantID, recsByVariant[entry.ID], hostArch),
 		})
 	}
 
@@ -323,7 +344,7 @@ func (c *Handler) GetModelCatalog(ctx echo.Context) error {
 // omitted, and hides a Legacy (superseded) variant unless it is the one
 // currently installed, so the gallery never offers a fresh install of a
 // deprecated build.
-func buildVariantResponses(entry *classifier.CatalogEntry, installed bool, installedVariantID string, recs map[string]recommend.Recommendation) []CatalogVariantResponse {
+func buildVariantResponses(entry *classifier.CatalogEntry, installed bool, installedVariantID string, recs map[string]recommend.Recommendation, hostArch string) []CatalogVariantResponse {
 	if len(entry.Variants) == 0 {
 		return nil
 	}
@@ -363,15 +384,169 @@ func buildVariantResponses(entry *classifier.CatalogEntry, installed bool, insta
 			// incompatible. Overwritten below when recommendations are present.
 			Compatible: true,
 		}
-		if rec, ok := recs[v.ID]; ok {
+		rec, hasRec := recs[v.ID]
+		if hasRec {
 			resp.Compatible = rec.Compatible
 			resp.Recommended = rec.Recommended
 			resp.Reasons = toReasonResponses(rec.Reasons)
 			resp.Blockers = toReasonResponses(rec.Blockers)
 		}
+		resp.HardwareClass = variantHardwareClass(v, &rec, hasRec, hostArch)
 		variants = append(variants, resp)
 	}
 	return variants
+}
+
+// Hardware-class tokens emitted on CatalogVariantResponse.HardwareClass. The
+// frontend maps each to a localized chip via analysis.gallery.hardware.<token>,
+// so the vocabulary stays locale-owned client-side while the classification (which
+// needs the live host arch and the chosen backend) is authoritative here.
+const (
+	hwClassBuiltIn   = "builtIn"
+	hwClassGPUNvidia = "gpuNvidia"
+	hwClassGPUIntel  = "gpuIntel"
+	hwClassAMD64CPU  = "amd64Cpu"
+	hwClassARM64CPU  = "arm64Cpu"
+	hwClassARMCPU    = "armCpu"
+	hwClassCPU       = "cpu"
+)
+
+// Backend tokens used when classifying a variant's hardware target. The OpenVINO
+// and ONNX tokens are sourced from their canonical owner (hwprofile) so a rename
+// there is a compile error here rather than a silent misclassification; cuda and
+// tensorrt have no exported source (recommend's copies are unexported), so they
+// mirror those tokens as literals.
+const (
+	backendCUDA        = "cuda"
+	backendTensorRT    = "tensorrt"
+	backendOpenVINOGPU = hwprofile.CapOpenVINOGPU
+	backendONNXCPU     = hwprofile.CapONNXRuntimeCPU
+	backendOpenVINOCPU = hwprofile.CapOpenVINOCPU
+)
+
+// channelOrDefault normalizes an empty release channel to the stable channel so
+// the API always reports a concrete channel and the frontend never has to guess
+// what an absent channel means.
+func channelOrDefault(channel string) string {
+	if channel == "" {
+		return classifier.ChannelStable
+	}
+	return channel
+}
+
+// variantHardwareClass derives the coarse hardware-target token for a variant's
+// gallery chip (never raw precision). It prefers the backend the recommender chose
+// for THIS host, so the chip matches how the variant will actually run for the
+// viewer, and falls back to the variant's own recommended backends when no host
+// recommendation is present (an ineligible request, a blocked variant with no
+// reasons, or a flat entry). GPU builds report the discrete-vs-Intel split; a CPU
+// build is made architecture-explicit (amd64Cpu/arm64Cpu) from an ARM-only variant
+// requirement or, failing that, the host arch, and stays the generic "cpu" when the
+// host arch is unknown. The built-in baseline wins over everything.
+func variantHardwareClass(v *classifier.CatalogVariant, rec *recommend.Recommendation, hasRec bool, hostArch string) string {
+	if v.BuiltIn {
+		return hwClassBuiltIn
+	}
+	backend := ""
+	if hasRec {
+		backend = recommendedBackendToken(rec.Reasons)
+	}
+	if backend == "" {
+		backend = intrinsicGPUBackend(v.Backends)
+	}
+	switch backend {
+	case backendCUDA, backendTensorRT:
+		return hwClassGPUNvidia
+	case backendOpenVINOGPU:
+		return hwClassGPUIntel
+	}
+	// A CPU-class build. Make the arch explicit: an ARM-restricted variant is
+	// labelled by the ARM width it targets (arm64Cpu vs armCpu), regardless of host;
+	// otherwise the arch-neutral CPU build is labelled for the viewer's host arch
+	// (accurate because the gallery is host-specific), or stays the generic "cpu"
+	// when the host arch is unknown (an ineligible request).
+	if armClass := variantARMClass(v); armClass != "" {
+		return armClass
+	}
+	switch hostArch {
+	case archARM64:
+		return hwClassARM64CPU
+	case archARM:
+		return hwClassARMCPU
+	case archAMD64:
+		return hwClassAMD64CPU
+	}
+	return hwClassCPU
+}
+
+// Host architecture identifiers (runtime.GOARCH), mirrored from hwprofile so the
+// CPU-class token can be made architecture-explicit.
+const (
+	archAMD64 = "amd64"
+	archARM64 = "arm64"
+	archARM   = "arm"
+)
+
+// recommendedBackendToken extracts the chosen backend token from a variant's
+// recommendation reasons: the explicit backend.recommended reason, else the first
+// reason carrying a backend arg. Mirrors the frontend chosenBackendToken fallback.
+func recommendedBackendToken(reasons []recommend.Reason) string {
+	fallback := ""
+	for i := range reasons {
+		b := reasons[i].Args["backend"]
+		if b == "" {
+			continue
+		}
+		if reasons[i].Code == recommend.ReasonBackendRecommended {
+			return b
+		}
+		if fallback == "" {
+			fallback = b
+		}
+	}
+	return fallback
+}
+
+// intrinsicGPUBackend returns the variant's recommended GPU backend token when the
+// variant is a GPU-oriented build (recommended on a GPU backend and NOT recommended
+// on any CPU backend), else "" so it classifies as a CPU build. A build recommended
+// on both CPU and GPU (e.g. a general fp32) is treated as a CPU build: the CPU is
+// its plain-language target and the GPU-optimized build is offered as a separate
+// variant.
+func intrinsicGPUBackend(backends map[string]classifier.BackendSupport) string {
+	if backends[backendONNXCPU].Recommended || backends[backendOpenVINOCPU].Recommended {
+		return ""
+	}
+	switch {
+	case backends[backendCUDA].Recommended || backends[backendTensorRT].Recommended:
+		return backendCUDA
+	case backends[backendOpenVINOGPU].Recommended:
+		return backendOpenVINOGPU
+	}
+	return ""
+}
+
+// variantARMClass returns the ARM CPU class a variant is restricted to, or "" when
+// it is not ARM-restricted. It reads the arch requirement: a 64-bit ARM token (the
+// aarch64 family "aarch64"/"aarch64-a76", or "arm64") yields arm64Cpu; a 32-bit ARM
+// token ("arm"/"armv7l"/"armhf") yields armCpu, so a 32-bit host is never mislabelled
+// as ARM64. For older entries that predate arch requirements it falls back to an
+// "arm" token in the variant id (the catalog's arm builds are 64-bit, e.g.
+// "int8-arm"), yielding arm64Cpu.
+func variantARMClass(v *classifier.CatalogVariant) string {
+	for _, a := range v.Requirements.Arch {
+		lower := strings.ToLower(a)
+		if strings.HasPrefix(lower, "aarch") || lower == archARM64 {
+			return hwClassARM64CPU
+		}
+		if strings.Contains(lower, "arm") {
+			return hwClassARMCPU
+		}
+	}
+	if strings.Contains(strings.ToLower(v.ID), "arm") {
+		return hwClassARM64CPU
+	}
+	return ""
 }
 
 // recommendationsAllowed reports whether this request may receive the
@@ -387,12 +562,13 @@ func (c *Handler) recommendationsAllowed(ctx echo.Context) bool {
 // rankCatalog computes the per-host variant recommendations for the visible
 // catalog, indexed by catalog ID then variant ID, plus the recommended variant
 // per entry.
-func (c *Handler) rankCatalog(entries []classifier.CatalogEntry, ort inference.ORTStatus) (byVariant map[string]map[string]recommend.Recommendation, recommended map[string]string) {
+func (c *Handler) rankCatalog(entries []classifier.CatalogEntry, ort inference.ORTStatus) (byVariant map[string]map[string]recommend.Recommendation, recommended map[string]string, hostArch string) {
 	profileFn := c.hardwareProfile
 	if profileFn == nil {
 		profileFn = defaultHardwareProfile
 	}
 	profile := profileFn(ort)
+	hostArch = profile.Arch
 	recs := recommend.Rank(&recommend.Input{
 		Capabilities:   profile.Capabilities(),
 		TotalRAMBytes:  profile.TotalRAMBytes,
@@ -415,7 +591,7 @@ func (c *Handler) rankCatalog(entries []classifier.CatalogEntry, ort inference.O
 			recommended[r.CatalogID] = r.VariantID
 		}
 	}
-	return byVariant, recommended
+	return byVariant, recommended, hostArch
 }
 
 // defaultHardwareProfile resolves the live host profile from the already-probed

--- a/internal/api/v2/models/models.go
+++ b/internal/api/v2/models/models.go
@@ -159,8 +159,8 @@ type CatalogVariantResponse struct {
 	Blockers []VariantReasonResponse `json:"blockers,omitempty"`
 	// HardwareClass is a coarse, localizable token naming the hardware this variant
 	// targets, for the gallery's plain-language chip (never raw precision like
-	// "fp16"). One of: "gpuNvidia", "gpuIntel", "amd64Cpu", "arm64Cpu", "cpu",
-	// "builtIn". The frontend maps it to analysis.gallery.hardware.<token>.
+	// "fp16"). One of: "gpuNvidia", "gpuIntel", "amd64Cpu", "arm64Cpu", "armCpu",
+	// "cpu", "builtIn". The frontend maps it to analysis.gallery.hardware.<token>.
 	// The CPU tokens are made architecture-explicit from the host arch when the
 	// request is eligible for recommendations; otherwise the intrinsic "cpu"/"gpu"
 	// class (from the variant's own recommended backends) is emitted.
@@ -493,7 +493,7 @@ const (
 func recommendedBackendToken(reasons []recommend.Reason) string {
 	fallback := ""
 	for i := range reasons {
-		b := reasons[i].Args["backend"]
+		b := reasons[i].Args[recommend.ReasonArgBackend]
 		if b == "" {
 			continue
 		}

--- a/internal/api/v2/models/models_hardware_class_test.go
+++ b/internal/api/v2/models/models_hardware_class_test.go
@@ -15,7 +15,7 @@ import (
 func backendRecommendedReason(backend string) recommend.Reason {
 	return recommend.Reason{
 		Code: recommend.ReasonBackendRecommended,
-		Args: map[string]string{"backend": backend},
+		Args: map[string]string{recommend.ReasonArgBackend: backend},
 	}
 }
 
@@ -179,15 +179,15 @@ func TestRecommendedBackendToken(t *testing.T) {
 
 	// Prefers the explicit backend.recommended reason over any other backend-bearing one.
 	assert.Equal(t, backendCUDA, recommendedBackendToken([]recommend.Reason{
-		{Code: "backend.supported", Args: map[string]string{"backend": backendOpenVINOGPU}},
-		{Code: recommend.ReasonBackendRecommended, Args: map[string]string{"backend": backendCUDA}},
+		{Code: recommend.ReasonBackendSupported, Args: map[string]string{recommend.ReasonArgBackend: backendOpenVINOGPU}},
+		{Code: recommend.ReasonBackendRecommended, Args: map[string]string{recommend.ReasonArgBackend: backendCUDA}},
 	}), "the backend.recommended reason wins over a plain backend-bearing reason")
 
 	// Falls back to the first reason carrying a backend arg when no backend.recommended
 	// reason is present (the fallback accumulator path).
 	assert.Equal(t, backendOpenVINOGPU, recommendedBackendToken([]recommend.Reason{
 		{Code: "region.matched", Args: map[string]string{"region": "nordic"}},
-		{Code: "backend.supported", Args: map[string]string{"backend": backendOpenVINOGPU}},
+		{Code: recommend.ReasonBackendSupported, Args: map[string]string{recommend.ReasonArgBackend: backendOpenVINOGPU}},
 	}), "falls back to the first backend-bearing reason")
 
 	// No backend-bearing reason yields the empty token (the intrinsic path then decides).

--- a/internal/api/v2/models/models_hardware_class_test.go
+++ b/internal/api/v2/models/models_hardware_class_test.go
@@ -186,12 +186,12 @@ func TestRecommendedBackendToken(t *testing.T) {
 	// Falls back to the first reason carrying a backend arg when no backend.recommended
 	// reason is present (the fallback accumulator path).
 	assert.Equal(t, backendOpenVINOGPU, recommendedBackendToken([]recommend.Reason{
-		{Code: "region.matched", Args: map[string]string{"region": "nordic"}},
+		{Code: recommend.ReasonRegionMatched, Args: map[string]string{"region": "nordic"}},
 		{Code: recommend.ReasonBackendSupported, Args: map[string]string{recommend.ReasonArgBackend: backendOpenVINOGPU}},
 	}), "falls back to the first backend-bearing reason")
 
 	// No backend-bearing reason yields the empty token (the intrinsic path then decides).
 	assert.Empty(t, recommendedBackendToken([]recommend.Reason{
-		{Code: "region.matched", Args: map[string]string{"region": "nordic"}},
+		{Code: recommend.ReasonRegionMatched, Args: map[string]string{"region": "nordic"}},
 	}))
 }

--- a/internal/api/v2/models/models_hardware_class_test.go
+++ b/internal/api/v2/models/models_hardware_class_test.go
@@ -1,0 +1,197 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tphakala/birdnet-go/internal/classifier"
+	"github.com/tphakala/birdnet-go/internal/classifier/recommend"
+)
+
+// backendRecommendedReason builds the structured reason the recommender attaches
+// to name the backend it chose for the host, used to drive host-relative
+// hardware-class classification in the tests below.
+func backendRecommendedReason(backend string) recommend.Reason {
+	return recommend.Reason{
+		Code: recommend.ReasonBackendRecommended,
+		Args: map[string]string{"backend": backend},
+	}
+}
+
+func TestChannelOrDefault(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, classifier.ChannelStable, channelOrDefault(""), "an empty channel defaults to stable")
+	assert.Equal(t, classifier.ChannelStable, channelOrDefault(classifier.ChannelStable))
+	assert.Equal(t, classifier.ChannelPreview, channelOrDefault(classifier.ChannelPreview))
+}
+
+func TestVariantHardwareClass(t *testing.T) {
+	t.Parallel()
+
+	// A GPU-oriented build: recommended on GPU backends, only supported on CPU.
+	gpuBackends := map[string]classifier.BackendSupport{
+		backendCUDA:        {Supported: true, Recommended: true},
+		backendTensorRT:    {Supported: true, Recommended: true},
+		backendOpenVINOGPU: {Supported: true, Recommended: true},
+		backendONNXCPU:     {Supported: true},
+	}
+	// An Intel-GPU-only build.
+	intelGPUBackends := map[string]classifier.BackendSupport{
+		backendOpenVINOGPU: {Supported: true, Recommended: true},
+	}
+	// A general CPU build: recommended on CPU (and also runnable on GPU). Its plain
+	// target is the CPU; the GPU-optimized build is a separate variant.
+	cpuBackends := map[string]classifier.BackendSupport{
+		backendONNXCPU:  {Supported: true, Recommended: true},
+		backendCUDA:     {Supported: true, Recommended: true},
+		backendTensorRT: {Supported: true, Recommended: true},
+	}
+	// A CPU build recommended ONLY on the OpenVINO CPU backend, to exercise the
+	// openvino-cpu operand of intrinsicGPUBackend (the onnxruntime-cpu operand
+	// short-circuits it in cpuBackends above).
+	openvinoCPUBackends := map[string]classifier.BackendSupport{
+		backendOpenVINOCPU: {Supported: true, Recommended: true},
+	}
+
+	tests := []struct {
+		name     string
+		variant  classifier.CatalogVariant
+		rec      recommend.Recommendation
+		hasRec   bool
+		hostArch string
+		want     string
+	}{
+		{
+			name:    "built-in baseline wins over everything",
+			variant: classifier.CatalogVariant{ID: "builtin", BuiltIn: true, Backends: gpuBackends},
+			want:    hwClassBuiltIn,
+		},
+		{
+			name:     "host chose CUDA -> NVIDIA GPU",
+			variant:  classifier.CatalogVariant{ID: "fp16", Backends: gpuBackends},
+			rec:      recommend.Recommendation{Compatible: true, Reasons: []recommend.Reason{backendRecommendedReason(backendCUDA)}},
+			hasRec:   true,
+			hostArch: archAMD64,
+			want:     hwClassGPUNvidia,
+		},
+		{
+			name:     "host chose OpenVINO GPU -> Intel GPU",
+			variant:  classifier.CatalogVariant{ID: "fp16", Backends: gpuBackends},
+			rec:      recommend.Recommendation{Compatible: true, Reasons: []recommend.Reason{backendRecommendedReason(backendOpenVINOGPU)}},
+			hasRec:   true,
+			hostArch: archAMD64,
+			want:     hwClassGPUIntel,
+		},
+		{
+			name:     "host chose a CPU backend on amd64 -> AMD64 CPU",
+			variant:  classifier.CatalogVariant{ID: "fp32", Backends: cpuBackends},
+			rec:      recommend.Recommendation{Compatible: true, Reasons: []recommend.Reason{backendRecommendedReason(backendONNXCPU)}},
+			hasRec:   true,
+			hostArch: archAMD64,
+			want:     hwClassAMD64CPU,
+		},
+		{
+			name:     "host chose a CPU backend on arm64 -> ARM64 CPU",
+			variant:  classifier.CatalogVariant{ID: "fp32", Backends: cpuBackends},
+			rec:      recommend.Recommendation{Compatible: true, Reasons: []recommend.Reason{backendRecommendedReason(backendONNXCPU)}},
+			hasRec:   true,
+			hostArch: archARM64,
+			want:     hwClassARM64CPU,
+		},
+		{
+			name:     "arm-only variant is ARM64 CPU regardless of host arch",
+			variant:  classifier.CatalogVariant{ID: "int8-arm", Requirements: classifier.VariantRequirements{Arch: []string{"aarch64"}}, Backends: cpuBackends},
+			rec:      recommend.Recommendation{Compatible: true, Reasons: []recommend.Reason{backendRecommendedReason(backendONNXCPU)}},
+			hasRec:   true,
+			hostArch: archAMD64,
+			want:     hwClassARM64CPU,
+		},
+		{
+			name:    "no recommendation, intrinsic GPU build -> Intel GPU",
+			variant: classifier.CatalogVariant{ID: "fp16", Backends: intelGPUBackends},
+			want:    hwClassGPUIntel,
+		},
+		{
+			name:    "no recommendation, no host arch, CPU build -> generic cpu",
+			variant: classifier.CatalogVariant{ID: "fp32", Backends: cpuBackends},
+			want:    hwClassCPU,
+		},
+		{
+			name:     "blocked GPU variant with no reasons falls back to intrinsic NVIDIA GPU",
+			variant:  classifier.CatalogVariant{ID: "fp16", Backends: gpuBackends},
+			rec:      recommend.Recommendation{Compatible: false, Blockers: []recommend.Reason{{Code: "ram.insufficient"}}},
+			hasRec:   true,
+			hostArch: archAMD64,
+			want:     hwClassGPUNvidia,
+		},
+		{
+			name:     "no recommendation, openvino-cpu-only build classifies as CPU (arch from host)",
+			variant:  classifier.CatalogVariant{ID: "fp32", Backends: openvinoCPUBackends},
+			hostArch: archAMD64,
+			want:     hwClassAMD64CPU,
+		},
+		{
+			name:     "explicit non-ARM arch requirement is not ARM-only (host arch decides)",
+			variant:  classifier.CatalogVariant{ID: "fp32", Requirements: classifier.VariantRequirements{Arch: []string{archAMD64}}, Backends: cpuBackends},
+			rec:      recommend.Recommendation{Compatible: true, Reasons: []recommend.Reason{backendRecommendedReason(backendONNXCPU)}},
+			hasRec:   true,
+			hostArch: archAMD64,
+			want:     hwClassAMD64CPU,
+		},
+		{
+			name:     "aarch64 micro-arch requirement (aarch64-a76) is still ARM64 CPU",
+			variant:  classifier.CatalogVariant{ID: "fp32", Requirements: classifier.VariantRequirements{Arch: []string{"aarch64-a76"}}, Backends: cpuBackends},
+			rec:      recommend.Recommendation{Compatible: true, Reasons: []recommend.Reason{backendRecommendedReason(backendONNXCPU)}},
+			hasRec:   true,
+			hostArch: archAMD64,
+			want:     hwClassARM64CPU,
+		},
+		{
+			name:     "32-bit ARM (armv7l) requirement is ARM CPU, not ARM64",
+			variant:  classifier.CatalogVariant{ID: "int8", Requirements: classifier.VariantRequirements{Arch: []string{"armv7l"}}, Backends: cpuBackends},
+			rec:      recommend.Recommendation{Compatible: true, Reasons: []recommend.Reason{backendRecommendedReason(backendONNXCPU)}},
+			hasRec:   true,
+			hostArch: archARM64,
+			want:     hwClassARMCPU,
+		},
+		{
+			name:     "arch-neutral CPU build on a 32-bit ARM host is ARM CPU, not ARM64",
+			variant:  classifier.CatalogVariant{ID: "fp32", Backends: cpuBackends},
+			rec:      recommend.Recommendation{Compatible: true, Reasons: []recommend.Reason{backendRecommendedReason(backendONNXCPU)}},
+			hasRec:   true,
+			hostArch: archARM,
+			want:     hwClassARMCPU,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := variantHardwareClass(&tt.variant, &tt.rec, tt.hasRec, tt.hostArch)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRecommendedBackendToken(t *testing.T) {
+	t.Parallel()
+
+	// Prefers the explicit backend.recommended reason over any other backend-bearing one.
+	assert.Equal(t, backendCUDA, recommendedBackendToken([]recommend.Reason{
+		{Code: "backend.supported", Args: map[string]string{"backend": backendOpenVINOGPU}},
+		{Code: recommend.ReasonBackendRecommended, Args: map[string]string{"backend": backendCUDA}},
+	}), "the backend.recommended reason wins over a plain backend-bearing reason")
+
+	// Falls back to the first reason carrying a backend arg when no backend.recommended
+	// reason is present (the fallback accumulator path).
+	assert.Equal(t, backendOpenVINOGPU, recommendedBackendToken([]recommend.Reason{
+		{Code: "region.matched", Args: map[string]string{"region": "nordic"}},
+		{Code: "backend.supported", Args: map[string]string{"backend": backendOpenVINOGPU}},
+	}), "falls back to the first backend-bearing reason")
+
+	// No backend-bearing reason yields the empty token (the intrinsic path then decides).
+	assert.Empty(t, recommendedBackendToken([]recommend.Reason{
+		{Code: "region.matched", Args: map[string]string{"region": "nordic"}},
+	}))
+}

--- a/internal/api/v2/models/models_variants_test.go
+++ b/internal/api/v2/models/models_variants_test.go
@@ -127,15 +127,16 @@ func TestBuildVariantResponses_LegacyHiddenUnlessInstalled(t *testing.T) {
 	}
 
 	// Not installed: the legacy variant is hidden, none is marked installed.
-	notInstalled := buildVariantResponses(entry, false, "", nil)
+	notInstalled := buildVariantResponses(entry, false, "", nil, "")
 	assert.Contains(t, ids(notInstalled), "cur")
 	assert.NotContains(t, ids(notInstalled), "old", "a legacy variant is hidden when not installed")
 	for _, v := range notInstalled {
 		assert.False(t, v.Installed)
+		assert.NotEmpty(t, v.HardwareClass, "buildVariantResponses must populate a hardware-class token on every variant")
 	}
 
 	// The legacy variant is the installed one: it stays visible and is flagged.
-	withLegacy := buildVariantResponses(entry, true, "old", nil)
+	withLegacy := buildVariantResponses(entry, true, "old", nil, "")
 	assert.Contains(t, ids(withLegacy), "old", "a legacy variant stays visible when it is installed")
 	for _, v := range withLegacy {
 		switch v.ID {

--- a/internal/classifier/birdnet_v3_onnx_test.go
+++ b/internal/classifier/birdnet_v3_onnx_test.go
@@ -130,6 +130,20 @@ func TestBirdNETV3_CatalogEntry(t *testing.T) {
 	assert.False(t, entry.Hidden, "v3.0 is visible in the gallery (public HF repo, pinned checksums, RAM-floor gated)")
 	assert.True(t, entry.RequiresONNX)
 
+	// v3.0 ships as a developer preview: the gallery flags it as not the GA build
+	// and surfaces the build tag (which otherwise lives only in the file paths).
+	assert.Equal(t, ChannelPreview, entry.Channel, "v3.0 is a developer-preview release")
+	assert.Equal(t, "preview3.1", entry.BuildLabel, "v3.0 surfaces its preview build tag")
+
+	// A stable (GA) sibling must leave Channel/BuildLabel empty, so its on-disk JSON
+	// stays byte-identical and adding these omitempty fields does not shift the
+	// stable entry's contribution to catalogChecksum (the invariant model_catalog.go
+	// documents). Guards against a stray Channel: "stable" being added to a GA entry.
+	perch, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok, "perch-v2 catalog entry must exist")
+	assert.Empty(t, perch.Channel, "a stable entry must not set Channel (omitempty byte-identity)")
+	assert.Empty(t, perch.BuildLabel, "a stable entry must not set BuildLabel")
+
 	roles := map[string]int{}
 	for _, f := range entry.Files {
 		roles[f.Role]++

--- a/internal/classifier/model_catalog.go
+++ b/internal/classifier/model_catalog.go
@@ -41,6 +41,14 @@ const (
 	RoleTaxonomy       = "taxonomy"
 )
 
+// Model release channels. An empty CatalogEntry.Channel means a stable (GA)
+// release; ChannelPreview marks a developer-preview build the gallery labels as
+// not the final GA build.
+const (
+	ChannelStable  = "stable"
+	ChannelPreview = "preview"
+)
+
 // CatalogEntry describes a downloadable model available in the model gallery.
 //
 // The snake_case JSON tags define the on-disk schema for the user-editable
@@ -49,16 +57,24 @@ const (
 // serialize this struct directly; it maps to a separate camelCase response
 // type (see internal/api/v2/models.go), so these tags do not affect the API.
 type CatalogEntry struct {
-	ID              string        `json:"id"`                // unique catalog identifier (e.g., "battybirdnet-eu")
-	Name            string        `json:"name"`              // user-facing display name
-	Description     string        `json:"description"`       // short description of the model
-	Author          string        `json:"author"`            // model author or organization
-	License         string        `json:"license"`           // license identifier (e.g., "Apache-2.0")
-	CommercialUse   bool          `json:"commercial_use"`    // whether commercial use is permitted
-	Category        string        `json:"category"`          // "wildlife", "bird", "bat", or "geomodel"
-	Region          string        `json:"region"`            // geographic region, or empty for global models
-	SpeciesCount    int           `json:"species_count"`     // number of species the model can identify
-	Version         string        `json:"version"`           // model version string
+	ID            string `json:"id"`             // unique catalog identifier (e.g., "battybirdnet-eu")
+	Name          string `json:"name"`           // user-facing display name
+	Description   string `json:"description"`    // short description of the model
+	Author        string `json:"author"`         // model author or organization
+	License       string `json:"license"`        // license identifier (e.g., "Apache-2.0")
+	CommercialUse bool   `json:"commercial_use"` // whether commercial use is permitted
+	Category      string `json:"category"`       // "wildlife", "bird", "bat", or "geomodel"
+	Region        string `json:"region"`         // geographic region, or empty for global models
+	SpeciesCount  int    `json:"species_count"`  // number of species the model can identify
+	Version       string `json:"version"`        // model version string
+	// Channel marks a non-stable release. "" (or "stable") is the normal GA build;
+	// "preview" marks a developer-preview build the gallery flags as not the GA
+	// build. omitempty keeps every stable entry's on-disk JSON byte-identical, so
+	// adding this field does not shift catalogChecksum or force a schema-version bump.
+	Channel string `json:"channel,omitempty"`
+	// BuildLabel is a human-facing build tag shown next to Version for a non-stable
+	// channel (e.g. "preview3.1"). Empty for stable releases. omitempty as above.
+	BuildLabel      string        `json:"build_label,omitempty"`
 	GeomodelVersion string        `json:"geomodel_version"`  // geomodel range filter version (e.g., "v3"); empty if no geomodel
 	RegistryID      string        `json:"registry_id"`       // maps to a ModelRegistry key; empty if loader not yet implemented
 	Hidden          bool          `json:"hidden"`            // if true, entry is excluded from the gallery UI
@@ -159,16 +175,21 @@ var EmbeddedCatalog = []CatalogEntry{
 	// backend loader is fully functional and v3.0 can also be enabled via config
 	// (models.enabled + birdnetv3 model/label paths).
 	{
-		ID:              "birdnet-v3.0",
-		Name:            "BirdNET v3.0",
-		Description:     "Developer preview of the BirdNET v3.0 global wildlife classifier (11,560 species, birds and other fauna; scientific and common names). Not the GA build.",
-		Author:          "Cornell Lab of Ornithology & Chemnitz University of Technology",
-		License:         "CC-BY-SA-4.0",
-		CommercialUse:   true,
-		Category:        CategoryWildlife,
-		Region:          "",
-		SpeciesCount:    11560,
-		Version:         "3.0",
+		ID:            "birdnet-v3.0",
+		Name:          "BirdNET v3.0",
+		Description:   "Developer preview of the BirdNET v3.0 global wildlife classifier (11,560 species, birds and other fauna; scientific and common names). Not the GA build.",
+		Author:        "Cornell Lab of Ornithology & Chemnitz University of Technology",
+		License:       "CC-BY-SA-4.0",
+		CommercialUse: true,
+		Category:      CategoryWildlife,
+		Region:        "",
+		SpeciesCount:  11560,
+		Version:       "3.0",
+		// Developer-preview build: the gallery shows a PREVIEW badge and a not-GA
+		// notice, and surfaces this tag (which otherwise lives only inside the
+		// preview3.1 file paths below) so users know it is not the final release.
+		Channel:         ChannelPreview,
+		BuildLabel:      "preview3.1",
 		GeomodelVersion: "v3",
 		RegistryID:      RegistryIDBirdNETV3,
 		Hidden:          false,

--- a/internal/classifier/recommend/recommend.go
+++ b/internal/classifier/recommend/recommend.go
@@ -81,6 +81,12 @@ const (
 	benchmarkMinMembers = 2
 )
 
+// ReasonArgBackend is the Args key naming the backend a backend.* reason refers to
+// (e.g. {ReasonArgBackend: "openvino-gpu"}). Consumers read the chosen backend from
+// this key; keeping it a shared constant stops the producer and its consumers
+// drifting on the literal.
+const ReasonArgBackend = "backend"
+
 // Reason codes. Structured codes, never English sentences: the frontend maps
 // each to an i18n key, so no user-facing wording lives in the backend.
 const (
@@ -374,7 +380,7 @@ func evaluateVariant(catalogID string, v *classifier.CatalogVariant, in *Input, 
 		}
 	} else if term.applies {
 		score += term.score
-		reasons = append(reasons, Reason{Code: term.code, Args: map[string]string{"backend": term.backend}})
+		reasons = append(reasons, Reason{Code: term.code, Args: map[string]string{ReasonArgBackend: term.backend}})
 		backendRank = preferenceRank(term.backend)
 		gpuRecommended = term.code == ReasonBackendRecommended && isGPUBackend(term.backend)
 	}


### PR DESCRIPTION
## Summary

Model-variant rows in the gallery led with raw `FP16` / `FP32` precision, which a non-technical user cannot map to their machine. This replaces that primary label with a plain-language chip naming the hardware each build targets (AMD64 CPU, ARM64 CPU, ARM CPU, GPU (NVIDIA), GPU (Intel), Built-in). Precision stays as muted secondary detail next to the download size, so advanced users keep it.

The chip is computed server-side, where the live host architecture and the chosen inference backend are known, and emitted as a coarse `hardwareClass` token on the catalog variant response. The frontend maps the token to a localized label and falls back to a coarser client-side class when talking to an older server. Because the gallery is host-specific, a CPU build reads as AMD64/ARM64/ARM CPU for the viewer's own host, and an ARM-restricted variant is labelled by the ARM width it targets so a 32-bit host is never shown as ARM64.

The BirdNET v3.0 developer-preview build is now flagged as not the final GA release. The catalog entry gains a `channel` and a `buildLabel` (the real `preview3.1` tag, which previously lived only inside the model file paths), and the gallery shows a PREVIEW badge, the build tag, and a not-GA notice on the card and at the top of the install dialog. The two fields are additive and `omitempty`, so a stable entry's on-disk JSON stays byte-identical and its catalog checksum is unchanged.

The install dialog was cramped, so it is widened; the small, easy-to-miss disclosure control is now a prominent full-width button; and the long "other regions" variant list moves into a height-capped, scrollable, filterable panel. A keyboard user can filter and then ArrowDown from the search box into the filtered tiles.

## Related Issues

None.

## Test Plan

- [ ] Go: `go test -race ./internal/api/v2/models/... ./internal/classifier/` (hardware-class classification, preview fields, byte-identity guard)
- [ ] Frontend: `npm run check:all` and the ModelVariantPicker / variantSelection / gallery Vitest suites
- [ ] Manual: open Settings > Analysis > Models; confirm the v3.0 card shows the PREVIEW badge and build tag, the install dialog shows hardware-named variants with the preview notice, and the region filter works by keyboard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added searchable filtering for model variants by region, including no-match messaging and improved keyboard navigation.
  * Model options now show clearer hardware-specific GPU and CPU architecture labels.
  * Added release-channel and build information to model cards and installation dialogs.
  * Preview models now display badges and installation warnings.
* **Localization**
  * Added translations for regional filtering, preview notices, build labels, and hardware options across supported languages.
* **Accessibility**
  * Improved focus behavior when expanding regional options and navigating filtered results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->