### PR TITLE
fix(conf): load backup keys and validate model/profiling settings

### DIFF
--- a/internal/api/v2/settings_edge_test.go
+++ b/internal/api/v2/settings_edge_test.go
@@ -31,18 +31,100 @@ func isFieldSkipped(skippedFields []any, expectedSkip string) bool {
 	return false
 }
 
-// verifySkippedFields checks that all expected fields were skipped.
-func verifySkippedFields(t *testing.T, response map[string]any, shouldSkip []string) {
+// verifySkippedFields asserts that every field in shouldSkip appears in the
+// response's skippedFields list, and that no field in shouldNotSkip does. A field
+// tagged json:"-" is never carried through the PATCH merge, so it is silently
+// ignored rather than reverted, and must therefore NOT appear in skippedFields;
+// such fields belong in shouldNotSkip.
+func verifySkippedFields(t *testing.T, response map[string]any, shouldSkip, shouldNotSkip []string) {
 	t.Helper()
-	skippedFields, ok := response["skippedFields"].([]any)
-	if !ok || len(shouldSkip) == 0 {
-		return
+
+	skippedRaw, present := response["skippedFields"]
+	skippedFields, isList := skippedRaw.([]any)
+
+	// When we expect skips, the field must be present and a list. When we only
+	// assert absence, an empty or missing list is a valid (passing) state.
+	if len(shouldSkip) > 0 {
+		require.True(t, present, "response is missing skippedFields")
+		require.True(t, isList, "skippedFields is not a list, got %T", skippedRaw)
 	}
-	t.Logf("Skipped fields: %v", skippedFields)
-	for _, expectedSkip := range shouldSkip {
-		if !isFieldSkipped(skippedFields, expectedSkip) {
-			t.Logf("Expected field %s to be skipped but it wasn't", expectedSkip)
-		}
+
+	for _, expected := range shouldSkip {
+		assert.True(t, isFieldSkipped(skippedFields, expected),
+			"expected field %q to be skipped, got %v", expected, skippedFields)
+	}
+	for _, unexpected := range shouldNotSkip {
+		assert.False(t, isFieldSkipped(skippedFields, unexpected),
+			"field %q must not be reported as skipped (json:%q fields are ignored, not reverted), got %v",
+			unexpected, "-", skippedFields)
+	}
+}
+
+// TestDiagnosticsProfilingRateValidation is the HTTP-boundary regression for the
+// diagnostics validator gap: a PATCH carrying a negative profiling rate used to
+// return 200 and persist the negative to config.yaml. It must now be rejected,
+// while a valid rate still succeeds.
+func TestDiagnosticsProfilingRateValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		payload      map[string]any
+		wantRejected bool
+	}{
+		{
+			name:         "negative block rate rejected",
+			payload:      map[string]any{"profiling": map[string]any{"blockRate": -1}},
+			wantRejected: true,
+		},
+		{
+			name:         "negative mutex fraction rejected",
+			payload:      map[string]any{"profiling": map[string]any{"mutexFraction": -5}},
+			wantRejected: true,
+		},
+		{
+			name:         "valid rates accepted",
+			payload:      map[string]any{"profiling": map[string]any{"blockRate": 10000, "mutexFraction": 100}},
+			wantRejected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			e := echo.New()
+			controller := getTestController(t, e)
+
+			body, err := json.Marshal(tt.payload)
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPatch, "/api/v2/settings/diagnostics",
+				bytes.NewReader(body))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			rec := httptest.NewRecorder()
+			ctx := e.NewContext(req, rec)
+			ctx.SetParamNames("section")
+			ctx.SetParamValues("diagnostics")
+
+			err = controller.UpdateSectionSettings(ctx)
+			if tt.wantRejected {
+				// A rejection is either a returned error or a non-2xx response;
+				// HandleError writes a 400 and returns nil today. Assert the update
+				// was NOT accepted unconditionally, so a future refactor that returns
+				// the error instead of writing it cannot make this branch vacuous.
+				accepted := err == nil && rec.Code == http.StatusOK
+				assert.Falsef(t, accepted,
+					"out-of-range rate must be rejected (err=%v, code=%d)", err, rec.Code)
+				if err == nil {
+					assert.Equal(t, http.StatusBadRequest, rec.Code,
+						"negative rate should be rejected with 400")
+				}
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, http.StatusOK, rec.Code, "valid rate should be accepted")
+			}
+		})
 	}
 }
 
@@ -300,45 +382,49 @@ func TestFieldPermissionEnforcement(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		section     string
-		update      any
-		description string
-		shouldSkip  []string
+		name          string
+		section       string
+		update        any
+		description   string
+		shouldSkip    []string
+		shouldNotSkip []string
 	}{
 		{
-			name:    "Runtime fields in BirdNET",
+			name:    "Labels is ignored, not skipped",
 			section: "birdnet",
 			update: map[string]any{
-				"labels": []string{"test1", "test2"}, // Runtime field
+				"labels": []string{"test1", "test2"}, // Runtime field, json:"-"
 			},
-			description: "Should skip runtime-only fields",
-			shouldSkip:  []string{"Labels"},
+			// Labels is tagged json:"-", so the PATCH merge never carries it and it
+			// is never reverted: it must NOT appear in skippedFields. (A PUT walk
+			// would list it as runtime-only; a PATCH cannot.)
+			description:   "json:\"-\" field is silently ignored on PATCH",
+			shouldNotSkip: []string{"Labels"},
 		},
 		{
 			name:    "RangeFilter runtime fields",
 			section: "birdnet",
 			update: map[string]any{
 				"rangeFilter": map[string]any{
-					"species":     []string{"test species"}, // Runtime field
-					"lastUpdated": "2024-01-01T00:00:00Z",   // Runtime field
+					"species":     []string{"test species"}, // Runtime field (yaml:"-", json present)
+					"lastUpdated": "2024-01-01T00:00:00Z",   // Runtime field (yaml:"-", json present)
 					"threshold":   0.05,                     // Allowed field
 				},
 			},
-			description: "Should skip runtime fields in nested objects",
+			description: "reachable runtime fields are reverted and reported as skipped",
 			shouldSkip:  []string{"Species", "LastUpdated"},
 		},
 		{
-			name:    "Audio runtime fields",
+			name:    "SoxAudioTypes is ignored, not skipped",
 			section: "audio",
 			update: map[string]any{
-				"soxAudioTypes": []string{"wav", "mp3"}, // Runtime field
+				"soxAudioTypes": []string{"wav", "mp3"}, // Runtime field, json:"-"
 				"export": map[string]any{
 					"enabled": true, // Allowed field
 				},
 			},
-			description: "Should skip SoxAudioTypes runtime field",
-			shouldSkip:  []string{"SoxAudioTypes"},
+			description:   "json:\"-\" field is silently ignored on PATCH",
+			shouldNotSkip: []string{"SoxAudioTypes"},
 		},
 	}
 
@@ -361,11 +447,7 @@ func TestFieldPermissionEnforcement(t *testing.T) {
 			ctx.SetParamValues(tt.section)
 
 			err = controller.UpdateSectionSettings(ctx)
-
-			if err != nil {
-				t.Logf("Update failed: %v", err)
-				return
-			}
+			require.NoError(t, err, "UpdateSectionSettings returned an error")
 
 			assert.Equal(t, http.StatusOK, rec.Code)
 
@@ -373,7 +455,7 @@ func TestFieldPermissionEnforcement(t *testing.T) {
 			err = json.Unmarshal(rec.Body.Bytes(), &response)
 			require.NoError(t, err)
 
-			verifySkippedFields(t, response, tt.shouldSkip)
+			verifySkippedFields(t, response, tt.shouldSkip, tt.shouldNotSkip)
 		})
 	}
 }

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1753,14 +1753,14 @@ type ImportConfig struct {
 
 // BackupConfig contains backup-related configuration
 type BackupConfig struct {
-	Enabled        bool                   `yaml:"enabled" json:"enabled"`                // Global flag to enable or disable the entire backup system. If false, no backups (manual or scheduled) will occur.
-	Debug          bool                   `yaml:"debug" json:"debug"`                    // If true, enables detailed debug logging for backup operations.
-	Encryption     bool                   `yaml:"encryption" json:"encryption"`          // If true, enables encryption for backup archives. Requires EncryptionKey to be set.
-	EncryptionKey  string                 `yaml:"encryption_key" json:"encryptionKey"`   // Base64-encoded encryption key used for AES-256-GCM encryption of backup archives. Must be kept secret and safe.
-	SanitizeConfig bool                   `yaml:"sanitize_config" json:"sanitizeConfig"` // If true, sensitive information (like passwords, API keys) will be removed from the configuration file copy that is included in the backup archive.
-	Retention      BackupRetention        `yaml:"retention" json:"retention"`            // Defines policies for how long and how many backups are kept.
-	Targets        []BackupTarget         `yaml:"targets" json:"targets"`                // A list of configured backup targets (destinations) where backup archives will be stored.
-	Schedules      []BackupScheduleConfig `yaml:"schedules" json:"schedules"`            // A list of schedules (e.g., daily, weekly) that define when automatic backups should run.
+	Enabled        bool                   `yaml:"enabled" json:"enabled"`                                               // Global flag to enable or disable the entire backup system. If false, no backups (manual or scheduled) will occur.
+	Debug          bool                   `yaml:"debug" json:"debug"`                                                   // If true, enables detailed debug logging for backup operations.
+	Encryption     bool                   `yaml:"encryption" json:"encryption"`                                         // If true, enables encryption for backup archives. Requires EncryptionKey to be set.
+	EncryptionKey  string                 `yaml:"encryption_key" json:"encryptionKey" mapstructure:"encryption_key"`    // Base64-encoded encryption key used for AES-256-GCM encryption of backup archives. Must be kept secret and safe.
+	SanitizeConfig bool                   `yaml:"sanitize_config" json:"sanitizeConfig" mapstructure:"sanitize_config"` // If true, sensitive information (like passwords, API keys) will be removed from the configuration file copy that is included in the backup archive.
+	Retention      BackupRetention        `yaml:"retention" json:"retention"`                                           // Defines policies for how long and how many backups are kept.
+	Targets        []BackupTarget         `yaml:"targets" json:"targets"`                                               // A list of configured backup targets (destinations) where backup archives will be stored.
+	Schedules      []BackupScheduleConfig `yaml:"schedules" json:"schedules"`                                           // A list of schedules (e.g., daily, weekly) that define when automatic backups should run.
 
 	// OperationTimeouts defines timeouts for various backup operations
 	OperationTimeouts struct {

--- a/internal/conf/config_yaml_tags_test.go
+++ b/internal/conf/config_yaml_tags_test.go
@@ -186,28 +186,35 @@ func checkViperReachable(t reflect.Type, path string, visited map[reflect.Type]b
 		fieldPath := fmt.Sprintf("%s.%s", path, f.Name)
 
 		yamlKey, _, _ := strings.Cut(f.Tag.Get("yaml"), ",")
-		mapstructureTag := f.Tag.Get("mapstructure")
+		mapstructureTag, hasMapstructure := f.Tag.Lookup("mapstructure")
+		mapstructureKey, _, _ := strings.Cut(mapstructureTag, ",")
 
 		// A field with no yaml tag is loaded and saved under the same lowercased
 		// field name, so it is inherently reachable. A yaml:"-" field is runtime
 		// only and never loaded. Neither can be dropped by the mismatch this guards.
 		if yamlKey != "" && yamlKey != "-" {
+			// Work out the key viper decodes this field under and compare it to the
+			// yaml save key, since that is the exact contract: what SaveSettings
+			// writes must be what Load reads back. mapstructure matches its key
+			// (the part before any options) case-insensitively; an empty key,
+			// including mapstructure:",squash", falls back to the Go field name,
+			// which is also viper's behavior with no tag at all. mapstructure:"-"
+			// excludes the field from decoding entirely.
 			switch {
-			case mapstructureTag == "-":
-				// The key is written to yaml on save but mapstructure:"-" tells
-				// viper to skip it on decode, so it never loads back: the same
-				// save-but-not-load asymmetry, made explicit.
+			case hasMapstructure && mapstructureKey == "-":
 				*unreachable = append(*unreachable,
 					fmt.Sprintf("%s (yaml:%q is saved but mapstructure:%q skips it on load)",
 						fieldPath, yamlKey, "-"))
-			case mapstructureTag == "" && !strings.EqualFold(f.Name, yamlKey):
-				// No mapstructure tag, and the field name does not case-fold to the
-				// yaml key, so viper matches neither. (A non-empty mapstructure tag,
-				// including ",squash" for embedded structs, tells viper how to match
-				// and is treated as reachable.)
-				*unreachable = append(*unreachable,
-					fmt.Sprintf("%s (yaml:%q does not case-fold to field name and has no mapstructure tag)",
-						fieldPath, yamlKey))
+			default:
+				decodeKey := mapstructureKey
+				if decodeKey == "" {
+					decodeKey = f.Name
+				}
+				if !strings.EqualFold(decodeKey, yamlKey) {
+					*unreachable = append(*unreachable,
+						fmt.Sprintf("%s (yaml:%q is saved but viper decodes it under %q; add or fix the mapstructure tag)",
+							fieldPath, yamlKey, decodeKey))
+				}
 			}
 		}
 

--- a/internal/conf/config_yaml_tags_test.go
+++ b/internal/conf/config_yaml_tags_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -95,6 +96,144 @@ func checkType(t reflect.Type, path string, visited map[reflect.Type]bool, missi
 		}
 
 		recurseInto(f.Type, fieldPath, visited, missing)
+	}
+}
+
+// TestAllSettingsYAMLKeysReachableByViper verifies that every field in the
+// Settings tree carrying a yaml: key can actually be decoded by viper on load.
+// conf.Load calls viper.Unmarshal with no TagName, so mapstructure matches on the
+// mapstructure: tag when present, otherwise on the Go field name compared
+// case-insensitively against the config key. The yaml: tag does NOT participate in
+// loading. A field whose yaml key does not case-fold to its Go field name (e.g. a
+// snake_case key like encryption_key) and carries no mapstructure: tag is silently
+// dropped on load, even though SaveSettings writes it correctly through the yaml
+// tag, so the value appears to persist and then quietly resets on the next load.
+//
+// This is the load-side sibling of TestAllSettingsStructsHaveYAMLTags, which only
+// guards the save side. It is checked for every field in the hierarchy, not just
+// leaves: an intermediate struct/slice/map field that is unreachable drops its
+// whole block.
+func TestAllSettingsYAMLKeysReachableByViper(t *testing.T) {
+	t.Parallel()
+
+	var unreachable []string
+	visited := make(map[reflect.Type]bool)
+	checkViperReachable(reflect.TypeFor[Settings](), "Settings", visited, &unreachable)
+
+	for _, u := range unreachable {
+		t.Logf("yaml key unreachable by viper: %s", u)
+	}
+
+	require.Empty(t, unreachable,
+		"found %d field(s) whose yaml key viper cannot decode on load;\n"+
+			"add a mapstructure: tag matching the yaml key (see BackupConfig.EncryptionKey)",
+		len(unreachable))
+}
+
+// TestViperDecodesBackupMapstructureKeys is the behavioral anchor for
+// TestAllSettingsYAMLKeysReachableByViper. That test models mapstructure's
+// key-matching rule by reflection; this one drives the real viper.Unmarshal path
+// (the same DecodeHook Load uses) over a snake_case config and asserts the two
+// fields the reflection guard protects actually load. It pins the hand-rolled
+// model against actual loader semantics for these keys, so the model cannot
+// silently drift. Without the mapstructure tags added in config.go, viper drops
+// these snake_case keys and both assertions fail.
+func TestViperDecodesBackupMapstructureKeys(t *testing.T) {
+	t.Parallel()
+
+	const yamlCfg = `
+backup:
+  encryption: true
+  encryption_key: "c2VjcmV0LWtleQ=="
+  sanitize_config: true
+`
+	v := viper.New()
+	v.SetConfigType("yaml")
+	require.NoError(t, v.ReadConfig(strings.NewReader(yamlCfg)))
+
+	var settings Settings
+	require.NoError(t, v.Unmarshal(&settings, viper.DecodeHook(DurationDecodeHook())))
+
+	assert.Equal(t, "c2VjcmV0LWtleQ==", settings.Backup.EncryptionKey,
+		"backup.encryption_key must decode through its mapstructure tag")
+	assert.True(t, settings.Backup.SanitizeConfig,
+		"backup.sanitize_config must decode through its mapstructure tag")
+}
+
+// checkViperReachable walks a struct type and records any field whose yaml key
+// cannot be matched by mapstructure during viper.Unmarshal. See
+// TestAllSettingsYAMLKeysReachableByViper for the invariant.
+func checkViperReachable(t reflect.Type, path string, visited map[reflect.Type]bool, unreachable *[]string) {
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct || visited[t] {
+		return
+	}
+	visited[t] = true
+
+	// Only recurse into project-owned or anonymous (inline) structs; stdlib and
+	// third-party types (e.g. time.Time) are decoded by their own hooks.
+	if t.PkgPath() != "" && !strings.HasPrefix(t.PkgPath(), projectModulePath) {
+		return
+	}
+
+	for f := range t.Fields() {
+		if !f.IsExported() {
+			continue
+		}
+
+		fieldPath := fmt.Sprintf("%s.%s", path, f.Name)
+
+		yamlKey, _, _ := strings.Cut(f.Tag.Get("yaml"), ",")
+		mapstructureTag := f.Tag.Get("mapstructure")
+
+		// A field with no yaml tag is loaded and saved under the same lowercased
+		// field name, so it is inherently reachable. A yaml:"-" field is runtime
+		// only and never loaded. Neither can be dropped by the mismatch this guards.
+		if yamlKey != "" && yamlKey != "-" {
+			switch {
+			case mapstructureTag == "-":
+				// The key is written to yaml on save but mapstructure:"-" tells
+				// viper to skip it on decode, so it never loads back: the same
+				// save-but-not-load asymmetry, made explicit.
+				*unreachable = append(*unreachable,
+					fmt.Sprintf("%s (yaml:%q is saved but mapstructure:%q skips it on load)",
+						fieldPath, yamlKey, "-"))
+			case mapstructureTag == "" && !strings.EqualFold(f.Name, yamlKey):
+				// No mapstructure tag, and the field name does not case-fold to the
+				// yaml key, so viper matches neither. (A non-empty mapstructure tag,
+				// including ",squash" for embedded structs, tells viper how to match
+				// and is treated as reachable.)
+				*unreachable = append(*unreachable,
+					fmt.Sprintf("%s (yaml:%q does not case-fold to field name and has no mapstructure tag)",
+						fieldPath, yamlKey))
+			}
+		}
+
+		reachRecurse(f.Type, fieldPath, visited, unreachable)
+	}
+}
+
+// reachRecurse resolves the element type for pointers, slices, and maps, then
+// walks nested structs for viper reachability.
+func reachRecurse(ft reflect.Type, path string, visited map[reflect.Type]bool, unreachable *[]string) {
+	for ft.Kind() == reflect.Pointer {
+		ft = ft.Elem()
+	}
+
+	switch ft.Kind() {
+	case reflect.Struct:
+		checkViperReachable(ft, path, visited, unreachable)
+	case reflect.Slice, reflect.Array:
+		// Recurse into the element type rather than checking only for a struct, so
+		// nested containers ([][]T, []map[string]T) are unwrapped too. reachRecurse
+		// strips pointers at its head, so []*T is still handled.
+		reachRecurse(ft.Elem(), path+"[]", visited, unreachable)
+	case reflect.Map:
+		reachRecurse(ft.Elem(), path+"[value]", visited, unreachable)
+	default:
+		// Scalar types need no recursion.
 	}
 }
 

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -279,9 +279,93 @@ func ValidateSettings(settings *Settings) error {
 		ve.Errors = append(ve.Errors, err.Error())
 	}
 
+	// Validate diagnostics profiling sampling rates. Negative rates are inert at
+	// runtime (ResolvedBlockRate/ResolvedMutexFraction clamp <= 0 to off), but a
+	// negative persisted to config.yaml misrepresents what is active, so the API
+	// write paths reject it. On Load, normalizeProfiling has already zeroed a
+	// negative before this runs, so a config file never trips this.
+	if err := validateProfilingSettings(&settings.Diagnostics.Profiling); err != nil {
+		ve.Errors = append(ve.Errors, err.Error())
+	}
+
+	// Validate per-model confidence thresholds (bat, perch, birdnetv3). An
+	// out-of-range threshold changes detection gating (>= 1 drops everything,
+	// <= 0 drops nothing), so it is rejected on every write path and on load. The
+	// frontend already constrains these to 0.01-0.99; this closes the raw-API gap.
+	if err := validateModelThresholds(settings); err != nil {
+		ve.Errors = append(ve.Errors, err.Error())
+	}
+
 	// If there are any errors, return the ValidationError
 	if len(ve.Errors) > 0 {
 		return ve
+	}
+	return nil
+}
+
+// minModelThreshold and maxModelThreshold bound the per-model confidence
+// thresholds. The inclusive 0..1 range and the NaN/Inf rejection match the
+// species-config threshold check in validateSpeciesConfig (validate_realtime.go)
+// and the BirdNET/RangeFilter threshold checks in validate_services.go, which is
+// the same reason checkRange guards NaN: a NaN comparison is always false and
+// would otherwise slip past the bounds test. defaultModelThreshold is what an
+// out-of-range value is reset to on load (see normalizeModelThresholds).
+const (
+	minModelThreshold     = 0.0
+	maxModelThreshold     = 1.0
+	defaultModelThreshold = 0.5
+)
+
+// validateProfilingSettings rejects negative pprof sampling rates. The values are
+// clamped to "off" at the point of use, but a negative in config.yaml is
+// misleading, so the settings API refuses to persist one. Positive-but-large
+// values are deliberately allowed: the point-of-use clamp bounds them, and an
+// operator may legitimately want a coarse-but-expensive rate.
+func validateProfilingSettings(p *ProfilingConfig) error {
+	if p == nil {
+		return nil
+	}
+	if p.BlockRate < 0 {
+		return errors.Newf("diagnostics.profiling.blockRate must be >= 0 (0 disables), got %d", p.BlockRate).
+			Category(errors.CategoryValidation).
+			Context("validation_type", "profiling-block-rate").
+			Build()
+	}
+	if p.MutexFraction < 0 {
+		return errors.Newf("diagnostics.profiling.mutexFraction must be >= 0 (0 disables), got %d", p.MutexFraction).
+			Category(errors.CategoryValidation).
+			Context("validation_type", "profiling-mutex-fraction").
+			Build()
+	}
+	return nil
+}
+
+// validateModelThresholds checks the per-model confidence thresholds are within
+// the inclusive 0..1 range. Validated unconditionally, even when a model's
+// OverrideThreshold is false, so an out-of-range value cannot lie dormant in
+// config.yaml and bite when the override is later enabled. NaN and Inf are
+// rejected explicitly: a NaN comparison is always false, so without the guard a
+// NaN threshold (reachable from a hand-edited config.yaml, since YAML decodes
+// .nan/.inf to float64) would pass the bounds test and silently gate out every
+// detection. On the Load path normalizeModelThresholds has already reset such a
+// value to the default before this runs; on the API path this rejects it.
+func validateModelThresholds(settings *Settings) error {
+	checks := []struct {
+		name  string
+		value float64
+	}{
+		{"bat.threshold", settings.Bat.Threshold},
+		{"perch.threshold", settings.Perch.Threshold},
+		{"birdnetv3.threshold", settings.BirdNETV3.Threshold},
+	}
+	for _, c := range checks {
+		if math.IsNaN(c.value) || math.IsInf(c.value, 0) || c.value < minModelThreshold || c.value > maxModelThreshold {
+			return errors.Newf("%s must be between %.2f and %.2f, got %v",
+				c.name, minModelThreshold, maxModelThreshold, c.value).
+				Category(errors.CategoryValidation).
+				Context("validation_type", "model-threshold").
+				Build()
+		}
 	}
 	return nil
 }

--- a/internal/conf/validate_incomplete.go
+++ b/internal/conf/validate_incomplete.go
@@ -47,6 +47,7 @@ package conf
 
 import (
 	"fmt"
+	"math"
 	"slices"
 	"strings"
 	"time"
@@ -68,6 +69,7 @@ const (
 	warnComponentLowMemory    = "lowmemory"
 	warnComponentModels       = "models"
 	warnComponentStreams      = "streams"
+	warnComponentDiagnostics  = "diagnostics"
 )
 
 // recordValidationWarning logs a non-fatal configuration finding and records it on
@@ -106,6 +108,54 @@ func normalizeIncompleteFeatures(s *Settings) {
 	s.normalizeRealtimeFeatures()
 	s.normalizeSpeciesTracking()
 	s.normalizeWebServer()
+	s.normalizeProfiling()
+	s.normalizeModelThresholds()
+}
+
+// normalizeModelThresholds resets an out-of-range per-model confidence threshold
+// (bat, perch, birdnetv3) to the documented default on load, recording a warning.
+// Unlike a never-written zero, an out-of-range or NaN/Inf threshold changes
+// detection gating, so ValidateSettings rejects it. But ValidateSettings is fatal
+// on Load (storage.go), and refusing to boot over a threshold takes away the web
+// UI that is the only practical way to fix it, crash-looping a headless install.
+// A value could reach config.yaml from a hand-edit or from the raw settings API
+// before it validated these fields. So, as with normalizeProfiling, the Load path
+// repairs the value to a working default and warns; the settings API path (which
+// does not run this pass) still rejects it outright so the operator sees the error.
+func (s *Settings) normalizeModelThresholds() {
+	reset := func(name string, v *float64) {
+		if math.IsNaN(*v) || math.IsInf(*v, 0) || *v < minModelThreshold || *v > maxModelThreshold {
+			s.recordValidationWarning(warnComponentModels,
+				"%s threshold %v is outside [%.2f, %.2f]; using the default %.2f (set a value in range to use it)",
+				name, *v, minModelThreshold, maxModelThreshold, defaultModelThreshold)
+			*v = defaultModelThreshold
+		}
+	}
+	reset("bat", &s.Bat.Threshold)
+	reset("perch", &s.Perch.Threshold)
+	reset("birdnetv3", &s.BirdNETV3.Threshold)
+}
+
+// normalizeProfiling zeroes negative pprof sampling rates on load. A negative rate
+// is a value the runtime already ignores: ResolvedBlockRate and
+// ResolvedMutexFraction treat any value <= 0 as "off", so a stored negative is
+// inert. Following the file policy for values the runtime ignores (rule 3),
+// normalize it to the 0 it effectively means, recording a warning, rather than
+// refusing to boot over it. The settings API still rejects a negative outright via
+// validateProfilingSettings, because there the operator can act on the error; this
+// pass runs only on Load.
+func (s *Settings) normalizeProfiling() {
+	p := &s.Diagnostics.Profiling
+	if p.BlockRate < 0 {
+		s.recordValidationWarning(warnComponentDiagnostics,
+			"profiling block rate %d is negative and does nothing; using 0 (disabled)", p.BlockRate)
+		p.BlockRate = 0
+	}
+	if p.MutexFraction < 0 {
+		s.recordValidationWarning(warnComponentDiagnostics,
+			"profiling mutex fraction %d is negative and does nothing; using 0 (disabled)", p.MutexFraction)
+		p.MutexFraction = 0
+	}
 }
 
 // normalizeOAuthProviders disables OAuth providers that cannot authenticate anyone.

--- a/internal/conf/validate_profiling_threshold_test.go
+++ b/internal/conf/validate_profiling_threshold_test.go
@@ -1,0 +1,224 @@
+package conf
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateProfilingSettings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		profiling   ProfilingConfig
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:      "zero rates disable sampling and pass",
+			profiling: ProfilingConfig{BlockRate: 0, MutexFraction: 0},
+		},
+		{
+			name:      "positive rates pass",
+			profiling: ProfilingConfig{BlockRate: 10000, MutexFraction: 100},
+		},
+		{
+			name:      "large positive rate passes (clamped at point of use)",
+			profiling: ProfilingConfig{BlockRate: 1_000_000_000_000_000, MutexFraction: 1},
+		},
+		{
+			name:        "negative block rate rejected",
+			profiling:   ProfilingConfig{BlockRate: -1, MutexFraction: 100},
+			wantErr:     true,
+			errContains: "blockRate must be >= 0",
+		},
+		{
+			name:        "negative mutex fraction rejected",
+			profiling:   ProfilingConfig{BlockRate: 0, MutexFraction: -5},
+			wantErr:     true,
+			errContains: "mutexFraction must be >= 0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := tt.profiling
+			err := validateProfilingSettings(&p)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestValidateProfilingSettings_Nil(t *testing.T) {
+	t.Parallel()
+	require.NoError(t, validateProfilingSettings(nil))
+}
+
+func TestValidateModelThresholds(t *testing.T) {
+	t.Parallel()
+
+	// base returns a Settings with all three model thresholds at a valid default.
+	base := func() *Settings {
+		s := &Settings{}
+		s.Bat.Threshold = 0.5
+		s.Perch.Threshold = 0.5
+		s.BirdNETV3.Threshold = 0.5
+		return s
+	}
+
+	tests := []struct {
+		name        string
+		mutate      func(s *Settings)
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:   "all defaults pass",
+			mutate: func(*Settings) {},
+		},
+		{
+			name:   "boundary values 0 and 1 pass",
+			mutate: func(s *Settings) { s.Bat.Threshold = 0; s.Perch.Threshold = 1 },
+		},
+		{
+			name:        "bat threshold above 1 rejected",
+			mutate:      func(s *Settings) { s.Bat.Threshold = 5.0 },
+			wantErr:     true,
+			errContains: "bat.threshold must be between",
+		},
+		{
+			name:        "perch threshold below 0 rejected",
+			mutate:      func(s *Settings) { s.Perch.Threshold = -1 },
+			wantErr:     true,
+			errContains: "perch.threshold must be between",
+		},
+		{
+			name:        "birdnetv3 threshold above 1 rejected",
+			mutate:      func(s *Settings) { s.BirdNETV3.Threshold = 1.5 },
+			wantErr:     true,
+			errContains: "birdnetv3.threshold must be between",
+		},
+		{
+			name:        "NaN threshold rejected (comparison would silently pass)",
+			mutate:      func(s *Settings) { s.Bat.Threshold = math.NaN() },
+			wantErr:     true,
+			errContains: "bat.threshold must be between",
+		},
+		{
+			name:        "positive infinity threshold rejected",
+			mutate:      func(s *Settings) { s.Perch.Threshold = math.Inf(1) },
+			wantErr:     true,
+			errContains: "perch.threshold must be between",
+		},
+		{
+			name: "out-of-range perch rejected even when override is off",
+			mutate: func(s *Settings) {
+				s.Perch.OverrideThreshold = false
+				s.Perch.Threshold = 2.0
+			},
+			wantErr:     true,
+			errContains: "perch.threshold must be between",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := base()
+			tt.mutate(s)
+			err := validateModelThresholds(s)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestNormalizeProfiling verifies the load-path leniency: a negative rate is
+// silently normalized to 0 (disabled) with a recorded warning, so an aged config
+// boots instead of being rejected, while the API path still rejects it.
+func TestNormalizeProfiling(t *testing.T) {
+	t.Parallel()
+
+	t.Run("negative rates normalized to zero with warnings", func(t *testing.T) {
+		t.Parallel()
+		s := &Settings{}
+		s.Diagnostics.Profiling.BlockRate = -1
+		s.Diagnostics.Profiling.MutexFraction = -5
+
+		s.normalizeProfiling()
+
+		assert.Equal(t, 0, s.Diagnostics.Profiling.BlockRate)
+		assert.Equal(t, 0, s.Diagnostics.Profiling.MutexFraction)
+		assert.Len(t, s.ValidationWarnings, 2)
+
+		// After normalization the strict validator no longer fires.
+		require.NoError(t, validateProfilingSettings(&s.Diagnostics.Profiling))
+	})
+
+	t.Run("valid rates untouched and no warnings", func(t *testing.T) {
+		t.Parallel()
+		s := &Settings{}
+		s.Diagnostics.Profiling.BlockRate = 10000
+		s.Diagnostics.Profiling.MutexFraction = 100
+
+		s.normalizeProfiling()
+
+		assert.Equal(t, 10000, s.Diagnostics.Profiling.BlockRate)
+		assert.Equal(t, 100, s.Diagnostics.Profiling.MutexFraction)
+		assert.Empty(t, s.ValidationWarnings)
+	})
+}
+
+// TestNormalizeModelThresholds verifies the load-path leniency for out-of-range
+// model thresholds: they are reset to the default with a warning so an aged config
+// boots, while an in-range value is left untouched. After normalization the strict
+// validator must pass (no boot-brick).
+func TestNormalizeModelThresholds(t *testing.T) {
+	t.Parallel()
+
+	t.Run("out-of-range and NaN thresholds reset to default with warnings", func(t *testing.T) {
+		t.Parallel()
+		s := &Settings{}
+		s.Bat.Threshold = 1.5  // above range
+		s.Perch.Threshold = -1 // below range
+		s.BirdNETV3.Threshold = math.NaN()
+
+		s.normalizeModelThresholds()
+
+		assert.InEpsilon(t, defaultModelThreshold, s.Bat.Threshold, 1e-9)
+		assert.InEpsilon(t, defaultModelThreshold, s.Perch.Threshold, 1e-9)
+		assert.InEpsilon(t, defaultModelThreshold, s.BirdNETV3.Threshold, 1e-9)
+		assert.Len(t, s.ValidationWarnings, 3)
+
+		// The strict validator must now pass, i.e. an aged config would boot.
+		require.NoError(t, validateModelThresholds(s))
+	})
+
+	t.Run("in-range thresholds untouched and no warnings", func(t *testing.T) {
+		t.Parallel()
+		s := &Settings{}
+		s.Bat.Threshold = 0 // boundary, valid
+		s.Perch.Threshold = 0.5
+		s.BirdNETV3.Threshold = 1 // boundary, valid
+
+		s.normalizeModelThresholds()
+
+		assert.Zero(t, s.Bat.Threshold)
+		assert.InEpsilon(t, 0.5, s.Perch.Threshold, 1e-9)
+		assert.InEpsilon(t, 1.0, s.BirdNETV3.Threshold, 1e-9)
+		assert.Empty(t, s.ValidationWarnings)
+	})
+}


### PR DESCRIPTION
## Summary

Four config-integrity fixes in the settings write and load paths, folded into one change.

Backup `encryption_key` and `sanitize_config` never loaded from `config.yaml`. Their snake_case yaml keys do not case-fold to the Go field names and they carried no `mapstructure` tag, so viper dropped them on every load while `SaveSettings` kept rewriting the zero value back (the value appeared to persist, then quietly reset on the next start). This adds the `mapstructure` tags and a reflection guard test that fails on any settings field whose yaml key viper cannot decode, plus a behavioral anchor test that runs the real `viper.Unmarshal` path so the guard's model cannot drift from actual loader semantics.

Adds validation for the per-model confidence thresholds (bat, perch, birdnetv3) and the pprof profiling sampling rates, which the settings API and the config loader previously accepted out of range. An out-of-range threshold silently changes detection gating (>= 1 drops everything, <= 0 drops nothing) and a negative profiling rate misrepresents what is active. Both are now rejected on the settings API. On load, where a validation error is fatal to boot, an aged config is repaired rather than rejected: negative profiling rates clamp to 0 (disabled) and out-of-range thresholds reset to the 0.5 default, each with a visible warning, so an existing install still starts. NaN and Inf are rejected as well, since a NaN comparison is always false and would otherwise slip past the bounds check.

Fixes a field-permission test whose helper only logged instead of asserting, so it passed regardless of whether protected fields were enforced. It now asserts both that reachable runtime fields are reverted and that `json:"-"` fields are ignored rather than reported as skipped.

## Test Plan
- [x] `go test -race ./internal/conf/ ./internal/api/v2/`
- [x] `golangci-lint run` clean on the changed packages
- [x] New reflection guard test goes red when a `mapstructure` tag is removed (verified)
- [x] New validators and load-path normalizers covered by table tests (NaN/Inf, boundaries, out-of-range, negative rates)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for profiling rates, rejecting negative values.
  * Added validation for model confidence thresholds, including handling invalid, infinite, and undefined values.
  * Invalid settings are now safely normalized with warnings and valid values preserved.
  * Fixed loading of snake_case backup configuration options.
  * Improved settings field handling so unsupported fields are ignored correctly.
* **Tests**
  * Expanded coverage for configuration validation, field permissions, and configuration loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->