### PR TITLE
fix(audiocore): reset RTSP restart backoff after stable recovery

### DIFF
--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -2103,8 +2103,9 @@ func (s *Stream) maybeEngageAudioOnlyFallback() bool {
 	return true
 }
 
-// conditionalFailureReset resets failures only after the process has proven
-// stable operation with substantial data reception.
+// conditionalFailureReset resets the circuit breaker failure counter and the
+// restart-backoff counter only after the process has proven stable operation
+// with substantial data reception.
 func (s *Stream) conditionalFailureReset(totalBytesReceived int64) {
 	s.cmdMu.Lock()
 	processStartTime := s.processStartTime
@@ -2131,6 +2132,42 @@ func (s *Stream) conditionalFailureReset(totalBytesReceived int64) {
 				logger.String("operation", "conditional_failure_reset"))
 		} else {
 			s.circuitMu.Unlock()
+		}
+
+		// Reset the restart count that drives the escalating restart backoff, under
+		// the same stability gate as the circuit-breaker reset above. Without this,
+		// a series of widely-spaced transient stalls keeps escalating the backoff
+		// (5s, 10s, 20s, 40s, ...) even though each fault recovered cleanly in
+		// between, which then keeps the source down long enough to trip the
+		// liveness/silence watchdog (issue #4080). Storm protection is preserved:
+		// a genuine reconnect storm never sustains the required stable window, so
+		// its restart count keeps climbing.
+		//
+		// restartCountMu is acquired separately from circuitMu, never nested, to
+		// match the sequential (non-nested) locking used elsewhere (Restart, the
+		// silence-timeout reset, the audio-only fallback) and avoid any
+		// lock-ordering hazard. It is reset independently of consecutiveFailures
+		// because other paths can drive consecutiveFailures to zero while leaving
+		// the restart count high: the circuit-breaker cooldown (isCircuitOpen /
+		// circuitCooldownRemaining) zeroes consecutiveFailures without touching
+		// restartCount, and a normal process exit calls resetFailures (zeroing
+		// consecutiveFailures) and then still runs handleRestartBackoff (which
+		// increments restartCount).
+		s.restartCountMu.Lock()
+		if s.restartCount > 0 {
+			previousRestarts := s.restartCount
+			s.restartCount = 0
+			s.restartCountMu.Unlock()
+
+			getStreamLogger().Info("resetting restart count after successful stable operation",
+				logger.String("url", s.config.safeURL()),
+				logger.Float64("runtime_seconds", timeSinceStart.Seconds()),
+				logger.Int64("total_bytes", totalBytesReceived),
+				logger.Int("previous_restarts", previousRestarts),
+				logger.String("component", "ffmpeg-stream"),
+				logger.String("operation", "conditional_failure_reset"))
+		} else {
+			s.restartCountMu.Unlock()
 		}
 	}
 }

--- a/internal/audiocore/ffmpeg/stream_test.go
+++ b/internal/audiocore/ffmpeg/stream_test.go
@@ -154,6 +154,18 @@ func (s *Stream) getTotalBytesReceivedForTest() int64 {
 	return s.totalBytesReceived
 }
 
+func (s *Stream) getRestartCountForTest() int {
+	s.restartCountMu.Lock()
+	defer s.restartCountMu.Unlock()
+	return s.restartCount
+}
+
+func (s *Stream) setRestartCountForTest(count int) {
+	s.restartCountMu.Lock()
+	defer s.restartCountMu.Unlock()
+	s.restartCount = count
+}
+
 func (s *Stream) getStreamCreatedAtForTest() time.Time {
 	s.streamCreatedAtMu.RLock()
 	defer s.streamCreatedAtMu.RUnlock()
@@ -728,14 +740,20 @@ func TestStream_ConditionalFailureReset(t *testing.T) {
 
 	stream := newTestStream(t)
 
-	// Set up: failures, process start time, and bytes.
+	// Set up: failures, restart count, process start time, and bytes.
 	stream.setConsecutiveFailures(5)
+	stream.setRestartCountForTest(4)
 	stream.setProcessStartTimeForTest(time.Now().Add(-circuitBreakerMinStabilityTime - time.Second))
 	stream.setTotalBytesReceivedForTest(circuitBreakerMinStabilityBytes + 1)
 
 	stream.conditionalFailureReset(stream.getTotalBytesReceivedForTest())
 
 	assert.Equal(t, 0, stream.getConsecutiveFailures(), "Failures should be reset after stable operation")
+	// The restart count drives the escalating restart backoff. It must be reset
+	// alongside the circuit breaker after sustained stable operation, otherwise
+	// widely-spaced transient stalls keep escalating the backoff even though each
+	// fault recovered cleanly (issue #4080).
+	assert.Equal(t, 0, stream.getRestartCountForTest(), "Restart count should be reset after stable operation")
 }
 
 func TestStream_ConditionalFailureReset_NotEnoughTime(t *testing.T) {
@@ -744,12 +762,14 @@ func TestStream_ConditionalFailureReset_NotEnoughTime(t *testing.T) {
 	stream := newTestStream(t)
 
 	stream.setConsecutiveFailures(5)
+	stream.setRestartCountForTest(4)
 	stream.setProcessStartTimeForTest(time.Now().Add(-5 * time.Second))
 	stream.setTotalBytesReceivedForTest(circuitBreakerMinStabilityBytes + 1)
 
 	stream.conditionalFailureReset(stream.getTotalBytesReceivedForTest())
 
 	assert.Equal(t, 5, stream.getConsecutiveFailures(), "Failures should NOT be reset without enough runtime")
+	assert.Equal(t, 4, stream.getRestartCountForTest(), "Restart count should NOT be reset without enough runtime")
 }
 
 func TestStream_ConditionalFailureReset_NotEnoughBytes(t *testing.T) {
@@ -758,12 +778,107 @@ func TestStream_ConditionalFailureReset_NotEnoughBytes(t *testing.T) {
 	stream := newTestStream(t)
 
 	stream.setConsecutiveFailures(5)
+	stream.setRestartCountForTest(4)
 	stream.setProcessStartTimeForTest(time.Now().Add(-circuitBreakerMinStabilityTime - time.Second))
 	stream.setTotalBytesReceivedForTest(100)
 
 	stream.conditionalFailureReset(100)
 
 	assert.Equal(t, 5, stream.getConsecutiveFailures(), "Failures should NOT be reset without enough bytes")
+	assert.Equal(t, 4, stream.getRestartCountForTest(), "Restart count should NOT be reset without enough bytes")
+}
+
+// TestStream_ConditionalFailureReset_RestartCount is the focused regression for
+// issue #4080: the restart backoff escalates across widely-spaced transient
+// stalls because the circuit breaker's failure counter is reset on stable
+// recovery while the restart count that drives the backoff duration is not.
+// conditionalFailureReset must clear the restart count under the same stability
+// gate, and independently of whether the circuit breaker still has failures to
+// clear (the circuit-breaker cooldown and normal process exits can drive
+// consecutiveFailures to zero while the restart count stays high).
+func TestStream_ConditionalFailureReset_RestartCount(t *testing.T) {
+	t.Parallel()
+
+	const stableAge = -circuitBreakerMinStabilityTime - time.Second
+	const unstableAge = -5 * time.Second
+
+	tests := []struct {
+		name                 string
+		processStartAge      time.Duration
+		processStartZero     bool
+		totalBytes           int64
+		initialRestartCount  int
+		initialFailures      int
+		wantRestartCount     int
+		wantConsecutiveFails int
+	}{
+		{
+			name:                 "stable operation resets restart count and failures",
+			processStartAge:      stableAge,
+			totalBytes:           circuitBreakerMinStabilityBytes + 1,
+			initialRestartCount:  4,
+			initialFailures:      3,
+			wantRestartCount:     0,
+			wantConsecutiveFails: 0,
+		},
+		{
+			name:                 "stable operation resets restart count even when failures already zero",
+			processStartAge:      stableAge,
+			totalBytes:           circuitBreakerMinStabilityBytes + 1,
+			initialRestartCount:  4,
+			initialFailures:      0,
+			wantRestartCount:     0,
+			wantConsecutiveFails: 0,
+		},
+		{
+			name:                 "not enough runtime leaves restart count untouched",
+			processStartAge:      unstableAge,
+			totalBytes:           circuitBreakerMinStabilityBytes + 1,
+			initialRestartCount:  4,
+			initialFailures:      3,
+			wantRestartCount:     4,
+			wantConsecutiveFails: 3,
+		},
+		{
+			name:                 "not enough bytes leaves restart count untouched",
+			processStartAge:      stableAge,
+			totalBytes:           circuitBreakerMinStabilityBytes - 1,
+			initialRestartCount:  4,
+			initialFailures:      3,
+			wantRestartCount:     4,
+			wantConsecutiveFails: 3,
+		},
+		{
+			name:                 "zero process start time is a no-op",
+			processStartZero:     true,
+			totalBytes:           circuitBreakerMinStabilityBytes + 1,
+			initialRestartCount:  4,
+			initialFailures:      3,
+			wantRestartCount:     4,
+			wantConsecutiveFails: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			stream := newTestStream(t)
+
+			stream.setConsecutiveFailures(tt.initialFailures)
+			stream.setRestartCountForTest(tt.initialRestartCount)
+			if tt.processStartZero {
+				stream.setProcessStartTimeForTest(time.Time{})
+			} else {
+				stream.setProcessStartTimeForTest(time.Now().Add(tt.processStartAge))
+			}
+			stream.setTotalBytesReceivedForTest(tt.totalBytes)
+
+			stream.conditionalFailureReset(tt.totalBytes)
+
+			assert.Equal(t, tt.wantRestartCount, stream.getRestartCountForTest(), "restart count")
+			assert.Equal(t, tt.wantConsecutiveFails, stream.getConsecutiveFailures(), "consecutive failures")
+		})
+	}
 }
 
 func TestValidateTimeout(t *testing.T) {


### PR DESCRIPTION
The FFmpeg stream keeps two independent failure counters: `restartCount`, which drives the escalating restart backoff (5s/10s/20s/40s...), and `consecutiveFailures`, which drives the circuit breaker. `conditionalFailureReset` runs on every audio frame and, once the process proves stable (at least 30 seconds of uptime and at least 100KB received), reset `consecutiveFailures` but left `restartCount` untouched.

As a result a series of widely-spaced transient stalls kept escalating the backoff even though each fault recovered cleanly in between. The long backoff eventually kept the source down long enough to trip the liveness/silence watchdog, turning a minor fault into roughly 5x more downtime than the fault itself.

This resets `restartCount` under the same stability gate as the circuit-breaker reset, so genuine sustained recovery clears the accumulated backoff. Storm protection is preserved: a genuine reconnect storm never sustains the 30s + 100KB window, so its restart count keeps climbing and the escalating backoff still engages. Both stability inputs are per-process, so a flapping source must independently earn the stable window before its backoff decays.

`restartCountMu` is acquired sequentially with `circuitMu`, never nested, matching the existing locking discipline in the surrounding reset paths.

## Testing

Extended the existing `conditionalFailureReset` tests and added a deterministic table-driven regression (`TestStream_ConditionalFailureReset_RestartCount`) covering the reset, both gate-fail no-ops, the failures-already-zero independence case, and the zero-start-time no-op. `go test -race ./internal/audiocore/ffmpeg/...` passes.

Fixes #4080.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stable stream operation now resets accumulated restart backoff along with circuit-breaker failures.
  * Restart backoff is preserved when stability requirements are not met, preventing premature recovery.

* **Tests**
  * Added coverage for stable recovery, insufficient runtime or data, existing zero failures, and missing process-start times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->