### PR TITLE
fix(diskmanager): make retention cleanup observable and hot-reloadable

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -350,14 +350,15 @@ func (p *AudioPipelineService) Start(_ context.Context) error {
 			logger.String("operation", "rtsp_monitoring_setup"))
 	}
 
-	// Start clip cleanup monitor.
-	// Uses conf.Setting() instead of local settings for hot-reload support:
-	// retention policy can be changed at runtime via the web UI.
-	if conf.Setting().Realtime.Audio.Export.Retention.Policy != policyNone {
-		p.wg.Go(func() {
-			clipCleanupMonitor(p.done, dataStore)
-		})
-	}
+	// Start clip cleanup monitor unconditionally. It re-reads the retention
+	// policy every iteration (see the policyNone check inside the loop) so
+	// enabling retention via the web UI after startup takes effect without a
+	// restart, matching every other hot-reloadable setting here. Gating the
+	// goroutine itself on the startup-time policy would strand a config change
+	// from "none" to "age"/"usage" until the process restarts.
+	p.wg.Go(func() {
+		clipCleanupMonitor(p.done, dataStore)
+	})
 
 	// Start clip reconcile monitor. Runs unconditionally (regardless of retention
 	// policy and regardless of whether audio export is enabled) because orphaned
@@ -1725,6 +1726,14 @@ func clipCleanupMonitor(quitChan chan struct{}, dataStore datastore.Interface) {
 			currentSettings := conf.Setting()
 			exportCfg := currentSettings.Realtime.Audio.Export
 			currentPolicy := exportCfg.Retention.Policy
+
+			// Re-checked every iteration (not just at Start()) so toggling
+			// retention off/on via the web UI takes effect without a restart.
+			if currentPolicy == policyNone {
+				log.Debug("skipping clip cleanup: retention policy is none",
+					logger.String("operation", "clip_cleanup_skip"))
+				continue
+			}
 
 			if strings.TrimSpace(exportCfg.Path) == "" {
 				log.Debug("skipping clip cleanup: export path not configured",

--- a/internal/diskmanager/policy_age.go
+++ b/internal/diskmanager/policy_age.go
@@ -12,6 +12,17 @@ import (
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
+// Skip/eligibility reasons for age-based cleanup. Named constants avoid
+// stringly-typed duplication between isEligibleForAgeDeletion (which decides
+// and logs the reason) and processAgeBasedDeletionLoop (which tallies the
+// per-run cleanupStats summary from that same reason).
+const (
+	ageReasonLocked       = "locked"
+	ageReasonNotOldEnough = "not old enough"
+	ageReasonMinClips     = "minimum clip count reached"
+	ageReasonEligible     = "older than retention period and minimum count allows"
+)
+
 // formatTimeForHumans converts a Unix timestamp to a human-readable string format.
 // It returns both a formatted date/time string in local timezone and a human-readable duration.
 // Uses the system's local timezone for display consistency with file timestamps.
@@ -159,7 +170,7 @@ func AgeBasedCleanup(quit <-chan struct{}, db Interface) CleanupResult {
 	maxDeletions := maxDeletionsPerRun
 
 	// Call the helper function to process files
-	deletedCount, deletedNames, loopErr := processAgeBasedDeletionLoop(files, speciesTotalCount,
+	deletedCount, deletedNames, stats, loopErr := processAgeBasedDeletionLoop(files, speciesTotalCount,
 		minClipsPerSpecies, maxDeletions, keepSpectrograms,
 		quit, retentionCutoffUnix)
 
@@ -168,6 +179,12 @@ func AgeBasedCleanup(quit <-chan struct{}, db Interface) CleanupResult {
 
 	// Get final disk utilization
 	diskUsage, diskErr := GetDiskUsage(baseDir)
+
+	// Always emit the per-run summary, independent of the disk-usage lookup below,
+	// so the outcome of every file (deleted, locked, min-clips-blocked, not old
+	// enough, or errored) is visible even when the final usage check fails.
+	logCleanupSummary("age", stats, time.Since(startTime))
+
 	if diskErr != nil {
 		// Combine errors if getting disk usage failed after the loop
 		finalErr := fmt.Errorf("cleanup completed but failed to get disk usage: %w (loop error: %w)", diskErr, loopErr)
@@ -199,28 +216,28 @@ func AgeBasedCleanup(quit <-chan struct{}, db Interface) CleanupResult {
 }
 
 // processSingleAgeFile handles eligibility check and deletion for a single file in age-based cleanup.
-// Returns: deleted (bool), error (if deletion failed)
+// Returns: deleted (bool), the eligibility/skip reason (for cleanupStats tallying), and any deletion error.
 func processSingleAgeFile(file *FileInfo, retentionCutoffUnix int64, speciesTotalCount map[string]int,
-	minClipsPerSpecies int, keepSpectrograms bool) (deleted bool, err error) {
+	minClipsPerSpecies int, keepSpectrograms bool) (deleted bool, reason string, err error) {
 	// Check eligibility
 	eligible, reason := isEligibleForAgeDeletion(file, retentionCutoffUnix, speciesTotalCount, minClipsPerSpecies)
 	if !eligible {
 		log := GetLogger()
-		if reason != "locked" && reason != "not old enough" {
+		if reason != ageReasonLocked && reason != ageReasonNotOldEnough {
 			log.Debug("Skipping file",
 				logger.String("policy", "age"),
 				logger.String("path", file.Path),
 				logger.String("reason", reason))
 		}
-		return false, nil
+		return false, reason, nil
 	}
 
 	// Perform deletion
 	if delErr := deleteFileAndOptionalSpectrogram(file, reason, keepSpectrograms, "age"); delErr != nil {
-		return false, delErr
+		return false, reason, delErr
 	}
 
-	return true, nil
+	return true, reason, nil
 }
 
 // processAgeBasedDeletionLoop handles the core logic of iterating through files,
@@ -231,10 +248,11 @@ func processSingleAgeFile(file *FileInfo, retentionCutoffUnix int64, speciesTota
 // 3. A quit signal is received
 func processAgeBasedDeletionLoop(files []FileInfo, speciesTotalCount map[string]int,
 	minClipsPerSpecies int, maxDeletions int, keepSpectrograms bool,
-	quit <-chan struct{}, retentionCutoffUnix int64) (deletedCount int, deletedNames []string, loopErr error) {
+	quit <-chan struct{}, retentionCutoffUnix int64) (deletedCount int, deletedNames []string, stats cleanupStats, loopErr error) {
 
 	deletedCount = 0
 	errorCount := 0
+	stats.Scanned = len(files)
 
 	log := GetLogger()
 
@@ -244,33 +262,42 @@ func processAgeBasedDeletionLoop(files []FileInfo, speciesTotalCount map[string]
 			log.Info("Age-based cleanup loop interrupted by quit signal",
 				logger.String("policy", "age"),
 				logger.Int("files_deleted", deletedCount))
-			return deletedCount, deletedNames, nil // Indicate interruption, but not necessarily an error from the loop itself
+			return deletedCount, deletedNames, stats, nil // Indicate interruption, but not necessarily an error from the loop itself
 		default:
 			if deletedCount >= maxDeletions {
 				log.Debug("Reached maximum number of deletions for age-based cleanup",
 					logger.String("policy", "age"),
 					logger.Int("max_deletions", maxDeletions))
-				return deletedCount, deletedNames, nil
+				return deletedCount, deletedNames, stats, nil
 			}
 
 			file := &files[i]
-			deleted, delErr := processSingleAgeFile(file, retentionCutoffUnix, speciesTotalCount, minClipsPerSpecies, keepSpectrograms)
+			deleted, reason, delErr := processSingleAgeFile(file, retentionCutoffUnix, speciesTotalCount, minClipsPerSpecies, keepSpectrograms)
 
 			if delErr != nil {
+				stats.Errors++
 				shouldStop, loopErrTmp := handleDeletionErrorInLoop(file.Path, delErr, &errorCount, 10, "age")
 				if shouldStop {
-					return deletedCount, deletedNames, loopErrTmp
+					return deletedCount, deletedNames, stats, loopErrTmp
 				}
 				continue
 			}
 
-			if deleted {
+			switch {
+			case deleted:
+				stats.Deleted++
 				speciesTotalCount[file.Species]--
 				if speciesTotalCount[file.Species] < 0 {
 					speciesTotalCount[file.Species] = 0
 				}
 				deletedNames = append(deletedNames, file.Path)
 				deletedCount++
+			case reason == ageReasonLocked:
+				stats.LockedSkipped++
+			case reason == ageReasonMinClips:
+				stats.MinClipsBlocked++
+			default: // ageReasonNotOldEnough
+				stats.NotEligible++
 			}
 
 			runtime.Gosched()
@@ -278,7 +305,7 @@ func processAgeBasedDeletionLoop(files []FileInfo, speciesTotalCount map[string]
 	}
 
 	// Loop finished normally or due to max deletions
-	return deletedCount, deletedNames, loopErr
+	return deletedCount, deletedNames, stats, loopErr
 }
 
 // isEligibleForAgeDeletion checks if a file meets the criteria for deletion based on age policy.
@@ -291,7 +318,7 @@ func isEligibleForAgeDeletion(file *FileInfo, retentionCutoffUnix int64, species
 
 	// 1. Check if locked (reuse common helper)
 	if checkLocked(file) {
-		return false, "locked"
+		return false, ageReasonLocked
 	}
 
 	log := GetLogger()
@@ -312,7 +339,7 @@ func isEligibleForAgeDeletion(file *FileInfo, retentionCutoffUnix int64, species
 			logger.String("file_age", fileAge),
 			logger.String("cutoff_time", cutoffFormatted),
 			logger.String("cutoff_age", cutoffAge))
-		return false, "not old enough"
+		return false, ageReasonNotOldEnough
 	}
 
 	// 3. Check minimum *total* clips constraint
@@ -327,7 +354,7 @@ func isEligibleForAgeDeletion(file *FileInfo, retentionCutoffUnix int64, species
 			logger.String("path", file.Path),
 			logger.String("file_created", fileFormatted),
 			logger.String("file_age", fileAge))
-		return false, "minimum clip count reached"
+		return false, ageReasonMinClips
 	}
 
 	// If all checks pass, the file is eligible
@@ -340,5 +367,5 @@ func isEligibleForAgeDeletion(file *FileInfo, retentionCutoffUnix int64, species
 		logger.String("species", file.Species))
 
 	// If all checks pass, the file is eligible
-	return true, "older than retention period and minimum count allows"
+	return true, ageReasonEligible
 }

--- a/internal/diskmanager/policy_age_test.go
+++ b/internal/diskmanager/policy_age_test.go
@@ -611,13 +611,18 @@ func TestProcessAgeBasedDeletionLoopStats(t *testing.T) {
 		retentionCutoffUnix := time.Now().Add(-168 * time.Hour).Unix() // 7 days
 
 		// Sorted oldest-first, matching the order AgeBasedCleanup produces
-		// before calling this loop.
-		lockedFile := makeAgeTestFile(t, testDir, "locked_species", 300*time.Hour, true)
+		// before calling this loop. Each skip bucket gets a DISTINCT count
+		// (locked=2, min-clips=1, not-old-enough=3) so that a mislabel swapping
+		// two of the tally arms cannot leave the asserted struct unchanged.
+		lockedA := makeAgeTestFile(t, testDir, "locked_a", 300*time.Hour, true)
+		lockedB := makeAgeTestFile(t, testDir, "locked_b", 280*time.Hour, true)
 		oldestOfA := makeAgeTestFile(t, testDir, "species_a", 200*time.Hour, false)
 		newerOfA := makeAgeTestFile(t, testDir, "species_a", 190*time.Hour, false)
-		tooNew := makeAgeTestFile(t, testDir, "species_d", 1*time.Hour, false)
+		tooNew1 := makeAgeTestFile(t, testDir, "species_d", 3*time.Hour, false)
+		tooNew2 := makeAgeTestFile(t, testDir, "species_d", 2*time.Hour, false)
+		tooNew3 := makeAgeTestFile(t, testDir, "species_d", 1*time.Hour, false)
 
-		files := []FileInfo{lockedFile, oldestOfA, newerOfA, tooNew}
+		files := []FileInfo{lockedA, lockedB, oldestOfA, newerOfA, tooNew1, tooNew2, tooNew3}
 		speciesTotalCount := buildSpeciesTotalCountMap(files)
 
 		quitChan := make(chan struct{})
@@ -630,18 +635,19 @@ func TestProcessAgeBasedDeletionLoopStats(t *testing.T) {
 		assert.Equal(t, []string{oldestOfA.Path}, deletedNames)
 
 		assert.Equal(t, cleanupStats{
-			Scanned:         4,
+			Scanned:         7,
 			Deleted:         1,
-			LockedSkipped:   1,
+			LockedSkipped:   2,
 			MinClipsBlocked: 1,
-			NotEligible:     1,
+			NotEligible:     3,
 			Errors:          0,
 		}, stats)
 
 		assert.NoFileExists(t, oldestOfA.Path, "oldest species_a file should be deleted")
 		assert.FileExists(t, newerOfA.Path, "second species_a file should be kept (min clips)")
-		assert.FileExists(t, lockedFile.Path, "locked file should be kept")
-		assert.FileExists(t, tooNew.Path, "too-new file should be kept")
+		assert.FileExists(t, lockedA.Path, "locked file A should be kept")
+		assert.FileExists(t, lockedB.Path, "locked file B should be kept")
+		assert.FileExists(t, tooNew1.Path, "too-new file should be kept")
 	})
 
 	t.Run("deletion error is tallied without stopping the loop", func(t *testing.T) {

--- a/internal/diskmanager/policy_age_test.go
+++ b/internal/diskmanager/policy_age_test.go
@@ -581,3 +581,106 @@ func simulateAgeBasedCleanup(
 	// Return the results with dynamic disk utilization
 	return CleanupResult{Err: nil, ClipsRemoved: deletedCount, DiskUtilization: currentDiskUtilization}
 }
+
+// TestProcessAgeBasedDeletionLoopStats verifies that the per-run cleanupStats
+// summary (added for GitHub #3892 / #4059 diagnosability) correctly tallies
+// every outcome bucket without changing which files get deleted.
+func TestProcessAgeBasedDeletionLoopStats(t *testing.T) {
+	t.Parallel()
+
+	makeAgeTestFile := func(t *testing.T, dir, species string, age time.Duration, locked bool) FileInfo {
+		t.Helper()
+		// The age (in whole seconds) makes the filename unique per call even
+		// for the same species, since these FileInfo values are constructed
+		// directly rather than parsed from disk, so nothing else disambiguates
+		// same-species files sharing a directory.
+		path := filepath.Join(dir, fmt.Sprintf("%s_80p_%d.wav", species, int64(age.Seconds())))
+		require.NoError(t, os.WriteFile(path, []byte("audio"), 0o644)) //nolint:gosec // G306: Test files don't require restrictive permissions
+		return FileInfo{
+			Path:      path,
+			Species:   species,
+			Timestamp: time.Now().Add(-age),
+			Size:      5,
+			Locked:    locked,
+		}
+	}
+
+	t.Run("mixed outcomes tally correctly", func(t *testing.T) {
+		t.Parallel()
+		testDir := t.TempDir()
+		retentionCutoffUnix := time.Now().Add(-168 * time.Hour).Unix() // 7 days
+
+		// Sorted oldest-first, matching the order AgeBasedCleanup produces
+		// before calling this loop.
+		lockedFile := makeAgeTestFile(t, testDir, "locked_species", 300*time.Hour, true)
+		oldestOfA := makeAgeTestFile(t, testDir, "species_a", 200*time.Hour, false)
+		newerOfA := makeAgeTestFile(t, testDir, "species_a", 190*time.Hour, false)
+		tooNew := makeAgeTestFile(t, testDir, "species_d", 1*time.Hour, false)
+
+		files := []FileInfo{lockedFile, oldestOfA, newerOfA, tooNew}
+		speciesTotalCount := buildSpeciesTotalCountMap(files)
+
+		quitChan := make(chan struct{})
+		const minClipsPerSpecies = 1
+		deletedCount, deletedNames, stats, loopErr := processAgeBasedDeletionLoop(
+			files, speciesTotalCount, minClipsPerSpecies, maxDeletionsPerRun, false, quitChan, retentionCutoffUnix)
+
+		require.NoError(t, loopErr)
+		assert.Equal(t, 1, deletedCount, "only the oldest of species_a should be deleted")
+		assert.Equal(t, []string{oldestOfA.Path}, deletedNames)
+
+		assert.Equal(t, cleanupStats{
+			Scanned:         4,
+			Deleted:         1,
+			LockedSkipped:   1,
+			MinClipsBlocked: 1,
+			NotEligible:     1,
+			Errors:          0,
+		}, stats)
+
+		assert.NoFileExists(t, oldestOfA.Path, "oldest species_a file should be deleted")
+		assert.FileExists(t, newerOfA.Path, "second species_a file should be kept (min clips)")
+		assert.FileExists(t, lockedFile.Path, "locked file should be kept")
+		assert.FileExists(t, tooNew.Path, "too-new file should be kept")
+	})
+
+	t.Run("deletion error is tallied without stopping the loop", func(t *testing.T) {
+		t.Parallel()
+		testDir := t.TempDir()
+		retentionCutoffUnix := time.Now().Add(-168 * time.Hour).Unix()
+
+		// missingFile references a path that was never created on disk, so
+		// os.Remove fails inside deleteFileAndOptionalSpectrogram, simulating
+		// a file removed out from under the cleanup pass (e.g. by an external
+		// process) between the directory scan and the deletion attempt.
+		missingFile := FileInfo{
+			Path:      filepath.Join(testDir, "ghost_species_80p_20200102T150405Z.wav"),
+			Species:   "ghost_species",
+			Timestamp: time.Now().Add(-200 * time.Hour),
+			Size:      5,
+			Locked:    false,
+		}
+		survivingFile := makeAgeTestFile(t, testDir, "surviving_species", 200*time.Hour, false)
+
+		files := []FileInfo{missingFile, survivingFile}
+		speciesTotalCount := buildSpeciesTotalCountMap(files)
+
+		quitChan := make(chan struct{})
+		const minClipsPerSpecies = 0
+		deletedCount, deletedNames, stats, loopErr := processAgeBasedDeletionLoop(
+			files, speciesTotalCount, minClipsPerSpecies, maxDeletionsPerRun, false, quitChan, retentionCutoffUnix)
+
+		require.NoError(t, loopErr, "a single deletion error stays below the stop threshold")
+		assert.Equal(t, 1, deletedCount)
+		assert.Equal(t, []string{survivingFile.Path}, deletedNames)
+
+		assert.Equal(t, cleanupStats{
+			Scanned:         2,
+			Deleted:         1,
+			LockedSkipped:   0,
+			MinClipsBlocked: 0,
+			NotEligible:     0,
+			Errors:          1,
+		}, stats)
+	})
+}

--- a/internal/diskmanager/policy_common.go
+++ b/internal/diskmanager/policy_common.go
@@ -572,6 +572,40 @@ type CleanupResult struct {
 	DiskUtilization int   // Current disk utilization percentage after cleanup
 }
 
+// cleanupStats accumulates per-run, per-file outcome counts for a cleanup pass.
+// It is purely observational: nothing here changes deletion behavior. It exists
+// so a cleanup run that deletes nothing can be diagnosed from an INFO-level log
+// line (or a support dump) without asking the user to enable Debug logging and
+// reproduce, e.g. GitHub #3892 and #4059 where zero deletions had no visible
+// explanation in the default log output.
+//
+// The buckets do not necessarily sum to Scanned: a run can stop early (usage
+// threshold satisfied, max-deletions-per-run reached, or a quit signal), and
+// files never reached by the loop are counted in none of the buckets below.
+type cleanupStats struct {
+	Scanned         int // total eligible files considered for cleanup this run
+	Deleted         int // files actually deleted
+	LockedSkipped   int // skipped because the clip is locked/protected
+	MinClipsBlocked int // skipped because deletion would violate the minimum-clips-per-species guard
+	NotEligible     int // age: not old enough. usage: usage already below threshold when reached
+	Errors          int // deletion attempts that failed
+}
+
+// logCleanupSummary emits a single INFO-level line summarizing a completed
+// cleanup run, so the guard (if any) that prevented deletion is visible
+// without enabling Debug logging.
+func logCleanupSummary(policy string, stats cleanupStats, duration time.Duration) {
+	GetLogger().Info("cleanup run summary",
+		logger.String("policy", policy),
+		logger.Int("files_scanned", stats.Scanned),
+		logger.Int("files_deleted", stats.Deleted),
+		logger.Int("locked_skipped", stats.LockedSkipped),
+		logger.Int("min_clips_blocked", stats.MinClipsBlocked),
+		logger.Int("not_eligible", stats.NotEligible),
+		logger.Int("errors", stats.Errors),
+		logger.Duration("duration", duration))
+}
+
 // CloseLogger is a no-op for backwards compatibility.
 // The central logger manages its own lifecycle.
 func CloseLogger() error {

--- a/internal/diskmanager/policy_common.go
+++ b/internal/diskmanager/policy_common.go
@@ -579,11 +579,15 @@ type CleanupResult struct {
 // reproduce, e.g. GitHub #3892 and #4059 where zero deletions had no visible
 // explanation in the default log output.
 //
-// The buckets do not necessarily sum to Scanned: a run can stop early (usage
-// threshold satisfied, max-deletions-per-run reached, or a quit signal), and
-// files never reached by the loop are counted in none of the buckets below.
+// The buckets need not sum to Scanned, and the exact semantics differ per
+// policy. The age policy sets Scanned to the total candidate count up front, so
+// files past an early stop (max-deletions-per-run reached or a quit signal) are
+// counted in Scanned but in none of the outcome buckets. The usage policy
+// increments Scanned only for files it actually examines, and on an early stop
+// once disk usage drops below the threshold it tallies the unexamined remainder
+// into NotEligible, so for the usage policy the buckets do sum to Scanned.
 type cleanupStats struct {
-	Scanned         int // total eligible files considered for cleanup this run
+	Scanned         int // age: total candidate files this run. usage: files actually examined before an early stop
 	Deleted         int // files actually deleted
 	LockedSkipped   int // skipped because the clip is locked/protected
 	MinClipsBlocked int // skipped because deletion would violate the minimum-clips-per-species guard

--- a/internal/diskmanager/policy_usage.go
+++ b/internal/diskmanager/policy_usage.go
@@ -19,6 +19,26 @@ type Policy struct {
 	NeverCleanup       map[string]bool // Species to never cleanup
 }
 
+// Per-file outcomes for usage-based cleanup. Named constants avoid
+// stringly-typed duplication between handleUsageDeletionIteration (which
+// decides the outcome) and processUsageDeletionLoop (which tallies the
+// per-run cleanupStats summary from that outcome).
+const (
+	usageOutcomeLocked   = "locked"
+	usageOutcomeMinClips = "min_clips"
+	usageOutcomeDeleted  = "deleted"
+)
+
+// Reasons the usage-cleanup loop stops iterating before exhausting the file
+// list. Only usageStopBelowThreshold means the remaining, unvisited files are
+// genuinely not needed (usage already satisfied); the others are a run-scoped
+// limit or interruption, not a statement about those files' eligibility.
+const (
+	usageStopNone           = ""
+	usageStopBelowThreshold = "below_threshold"
+	usageStopMaxDeletions   = "max_deletions"
+)
+
 // UsageBasedCleanup removes clips from the filesystem based on disk usage and the number of clips per species.
 // This policy activates when disk usage exceeds a configured threshold percentage.
 // It prioritizes deletion based on:
@@ -120,7 +140,7 @@ func UsageBasedCleanup(quit <-chan struct{}, db Interface) CleanupResult {
 		refreshInterval:     50,                 // Refresh actual disk usage every N deletions
 		keepSpectrograms:    keepSpectrograms,
 	}
-	deletedCount, deletedNames, lastKnownGoodUsagePercent, loopErr := processUsageDeletionLoop(files, speciesMonthCount,
+	deletedCount, deletedNames, lastKnownGoodUsagePercent, stats, loopErr := processUsageDeletionLoop(files, speciesMonthCount,
 		loopParams, baseDir, // Pass the struct pointer and baseDir
 		quit)
 
@@ -132,6 +152,11 @@ func UsageBasedCleanup(quit <-chan struct{}, db Interface) CleanupResult {
 
 	// Log completion with results
 	duration := time.Since(startTime)
+
+	// Always emit the per-run summary so the outcome of every file (deleted,
+	// locked, min-clips-blocked, usage already satisfied, or errored) is
+	// visible without enabling Debug logging.
+	logCleanupSummary("usage", stats, duration)
 	if loopErr != nil {
 		GetLogger().Error("Usage-based cleanup run completed with errors",
 			logger.String("policy", "usage"),
@@ -203,7 +228,7 @@ func updateUsageStateAfterDeletion(file *FileInfo, speciesMonthCount map[string]
 // 4. A quit signal is received
 func processUsageDeletionLoop(files []FileInfo, speciesMonthCount map[string]map[string]int,
 	params *usageLoopParams, baseDir string,
-	quit <-chan struct{}) (deletedCount int, deletedNames []string, lastKnownGoodUsagePercent int, loopErr error) {
+	quit <-chan struct{}) (deletedCount int, deletedNames []string, lastKnownGoodUsagePercent int, stats cleanupStats, loopErr error) {
 
 	deletedCount = 0
 	errorCount := 0
@@ -218,7 +243,7 @@ func processUsageDeletionLoop(files []FileInfo, speciesMonthCount map[string]map
 			log.Info("Usage-based cleanup loop interrupted by quit signal",
 				logger.String("policy", "usage"),
 				logger.Int("files_deleted", deletedCount))
-			return deletedCount, deletedNames, lastKnownGoodUsagePercent, loopErr
+			return deletedCount, deletedNames, lastKnownGoodUsagePercent, stats, loopErr
 		default:
 			params.diskInfo, estimatedUsedBytes = refreshUsageDataIfNeeded(deletedCount, params.refreshInterval, baseDir, params.diskInfo, estimatedUsedBytes)
 
@@ -227,31 +252,46 @@ func processUsageDeletionLoop(files []FileInfo, speciesMonthCount map[string]map
 				lastKnownGoodUsagePercent = currentUsagePercent
 			}
 
-			if shouldStopUsageCleanup(currentUsagePercent, params.usageThreshold, deletedCount, params.maxDeletions) {
-				return deletedCount, deletedNames, lastKnownGoodUsagePercent, loopErr
+			if stop, stopReason := shouldStopUsageCleanup(currentUsagePercent, params.usageThreshold, deletedCount, params.maxDeletions); stop {
+				// Files never reached by the loop because usage already fell
+				// below threshold are genuinely not needed; a max-deletions
+				// stop is a run-scoped rate limit, not a statement about the
+				// remaining files, so it is not counted here.
+				if stopReason == usageStopBelowThreshold {
+					stats.NotEligible += len(files) - i
+				}
+				return deletedCount, deletedNames, lastKnownGoodUsagePercent, stats, loopErr
 			}
 
 			file := &files[i]
-			deleted, deletionErr := handleUsageDeletionIteration(file, speciesMonthCount, params.minClipsPerSpecies, params.keepSpectrograms, currentUsagePercent, params.usageThreshold)
+			stats.Scanned++
+			outcome, deletionErr := handleUsageDeletionIteration(file, speciesMonthCount, params.minClipsPerSpecies, params.keepSpectrograms, currentUsagePercent, params.usageThreshold)
 
 			if deletionErr != nil {
+				stats.Errors++
 				shouldStop, loopErrTmp := handleDeletionErrorInLoop(file.Path, deletionErr, &errorCount, 10, "usage")
 				if shouldStop {
-					return deletedCount, deletedNames, lastKnownGoodUsagePercent, loopErrTmp
+					return deletedCount, deletedNames, lastKnownGoodUsagePercent, stats, loopErrTmp
 				}
 				continue
 			}
 
-			if deleted {
+			switch outcome {
+			case usageOutcomeDeleted:
+				stats.Deleted++
 				estimatedUsedBytes = updateUsageStateAfterDeletion(file, speciesMonthCount, estimatedUsedBytes, params.diskInfo.TotalBytes)
 				deletedNames = append(deletedNames, file.Path)
 				deletedCount++
+			case usageOutcomeLocked:
+				stats.LockedSkipped++
+			case usageOutcomeMinClips:
+				stats.MinClipsBlocked++
 			}
 
 			runtime.Gosched()
 		}
 	}
-	return deletedCount, deletedNames, lastKnownGoodUsagePercent, loopErr
+	return deletedCount, deletedNames, lastKnownGoodUsagePercent, stats, loopErr
 }
 
 // getFinalUsagePercent calculates the final disk usage percentage, falling back if necessary.
@@ -334,18 +374,19 @@ func checkInitialUsage(baseDir string, usageThreshold int) (initialUsagePercent 
 }
 
 // handleUsageDeletionIteration processes a single file for potential deletion based on usage policy rules.
-// It returns whether the file was deleted and any critical error encountered during deletion.
-func handleUsageDeletionIteration(file *FileInfo, speciesMonthCount map[string]map[string]int, minClipsPerSpecies int, keepSpectrograms bool, currentUsagePercent, usageThreshold int) (deleted bool, deletionErr error) {
+// It returns the outcome classification (usageOutcomeDeleted means the file was deleted; see the
+// usageOutcome* constants for cleanupStats tallying) and any critical error encountered during deletion.
+func handleUsageDeletionIteration(file *FileInfo, speciesMonthCount map[string]map[string]int, minClipsPerSpecies int, keepSpectrograms bool, currentUsagePercent, usageThreshold int) (outcome string, deletionErr error) {
 	// Check if locked
 	if checkLocked(file) {
-		return false, nil
+		return usageOutcomeLocked, nil
 	}
 
 	// Check minimum clips constraint (per species per month dir)
 	// This differs from age-based policy by preserving diversity within each time period (directory)
 	subDir := filepath.Dir(file.Path)
 	if !checkMinClips(file, subDir, speciesMonthCount, minClipsPerSpecies, "usage") {
-		return false, nil
+		return usageOutcomeMinClips, nil
 	}
 
 	// Reason for deletion (used in logging)
@@ -354,11 +395,11 @@ func handleUsageDeletionIteration(file *FileInfo, speciesMonthCount map[string]m
 	// Call the common deletion function
 	if delErr := deleteFileAndOptionalSpectrogram(file, reason, keepSpectrograms, "usage"); delErr != nil {
 		// Return the error to be handled by the main loop (e.g., increment error count)
-		return false, delErr
+		return "", delErr
 	}
 
 	// Deletion successful
-	return true, nil
+	return usageOutcomeDeleted, nil
 }
 
 // sortFilesForUsage sorts files specifically for the usage-based policy.
@@ -442,8 +483,9 @@ func refreshUsageDataIfNeeded(deletedCount, refreshInterval int, baseDir string,
 }
 
 // shouldStopUsageCleanup checks if the cleanup loop should terminate based on usage threshold or max deletions.
-// Returns true if cleanup should stop, false if it should continue.
-func shouldStopUsageCleanup(currentUsagePercent, usageThreshold, deletedCount, maxDeletions int) bool {
+// Returns whether cleanup should stop, and why (see usageStop* constants) so the caller can
+// tell "usage already satisfied" apart from a run-scoped rate limit for cleanupStats tallying.
+func shouldStopUsageCleanup(currentUsagePercent, usageThreshold, deletedCount, maxDeletions int) (stop bool, reason string) {
 	log := GetLogger()
 
 	// Check if usage is still above threshold
@@ -452,7 +494,7 @@ func shouldStopUsageCleanup(currentUsagePercent, usageThreshold, deletedCount, m
 			logger.String("policy", "usage"),
 			logger.Int("current_usage", currentUsagePercent),
 			logger.Int("threshold", usageThreshold))
-		return true // Stop deleting files
+		return true, usageStopBelowThreshold // Stop deleting files
 	}
 
 	// Check if max deletions reached
@@ -460,8 +502,8 @@ func shouldStopUsageCleanup(currentUsagePercent, usageThreshold, deletedCount, m
 		log.Debug("Reached maximum number of deletions for usage-based cleanup",
 			logger.String("policy", "usage"),
 			logger.Int("max_deletions", maxDeletions))
-		return true // Stop deleting files
+		return true, usageStopMaxDeletions // Stop deleting files
 	}
 
-	return false // Continue cleanup
+	return false, usageStopNone // Continue cleanup
 }

--- a/internal/diskmanager/policy_usage_test.go
+++ b/internal/diskmanager/policy_usage_test.go
@@ -1,6 +1,7 @@
 package diskmanager
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1042,3 +1043,160 @@ func TestUsageBasedCleanupLockedFiles(t *testing.T) {
 
 // Define a variable for os.Remove to allow mocking in tests
 var osRemove = os.Remove
+
+// makeUsageTestFile creates a real file on disk (deletion touches the real
+// filesystem) and returns a matching FileInfo for use with
+// processUsageDeletionLoop's stats tests below.
+func makeUsageTestFile(t *testing.T, dir, species string, size int64, locked bool) FileInfo {
+	t.Helper()
+	path := filepath.Join(dir, fmt.Sprintf("%s_80p_%d.wav", species, size))
+	require.NoError(t, os.WriteFile(path, make([]byte, size), 0o644)) //nolint:gosec // G306: Test files don't require restrictive permissions
+	return FileInfo{
+		Path:    path,
+		Species: species,
+		Size:    size,
+		Locked:  locked,
+	}
+}
+
+// newUsageLoopTestParams builds a *usageLoopParams for the stats tests below,
+// keeping the required fields explicit at each call site.
+func newUsageLoopTestParams(totalBytes, usedBytes uint64, threshold, minClips, maxDeletions int) *usageLoopParams {
+	return &usageLoopParams{
+		diskInfo:            DiskSpaceInfo{TotalBytes: totalBytes, UsedBytes: usedBytes},
+		initialUsagePercent: calculateUsagePercent(usedBytes, totalBytes),
+		usageThreshold:      threshold,
+		minClipsPerSpecies:  minClips,
+		maxDeletions:        maxDeletions,
+		refreshInterval:     50, // large enough that these small tests never trigger a real disk refresh
+		keepSpectrograms:    true,
+	}
+}
+
+// TestProcessUsageDeletionLoopStats verifies that the per-run cleanupStats
+// summary (added for GitHub #3892 / #4059 diagnosability) correctly tallies
+// every outcome bucket, including the two distinct reasons the loop can stop
+// early (usage satisfied vs. max-deletions-per-run reached), without changing
+// which files get deleted.
+func TestProcessUsageDeletionLoopStats(t *testing.T) {
+	t.Parallel()
+
+	t.Run("usage below threshold tallies remaining files as not eligible", func(t *testing.T) {
+		t.Parallel()
+		testDir := t.TempDir()
+
+		// file1 is large enough that deleting it alone drops usage below the
+		// 80% threshold, so file2 and file3 are never evaluated.
+		file1 := makeUsageTestFile(t, testDir, "species_a", 150, false)
+		file2 := makeUsageTestFile(t, testDir, "species_b", 10, false)
+		file3 := makeUsageTestFile(t, testDir, "species_c", 10, false)
+		files := []FileInfo{file1, file2, file3}
+		speciesMonthCount := buildSpeciesSubDirCountMap(files)
+
+		params := newUsageLoopTestParams(1000, 900, 80, 0, maxDeletionsPerRun)
+		quitChan := make(chan struct{})
+		deletedCount, deletedNames, _, stats, loopErr := processUsageDeletionLoop(files, speciesMonthCount, params, testDir, quitChan)
+
+		require.NoError(t, loopErr)
+		assert.Equal(t, 1, deletedCount)
+		assert.Equal(t, []string{file1.Path}, deletedNames)
+		assert.Equal(t, cleanupStats{
+			Scanned:         1,
+			Deleted:         1,
+			LockedSkipped:   0,
+			MinClipsBlocked: 0,
+			NotEligible:     2,
+			Errors:          0,
+		}, stats)
+	})
+
+	t.Run("max deletions stop does not tally remaining files", func(t *testing.T) {
+		t.Parallel()
+		testDir := t.TempDir()
+
+		file1 := makeUsageTestFile(t, testDir, "species_a", 10, false)
+		file2 := makeUsageTestFile(t, testDir, "species_b", 10, false)
+		files := []FileInfo{file1, file2}
+		speciesMonthCount := buildSpeciesSubDirCountMap(files)
+
+		// Threshold 0 means usage can never fall "below" it, so the loop only
+		// stops because maxDeletions (1) is reached after the first file.
+		params := newUsageLoopTestParams(1000, 500, 0, 0, 1)
+		quitChan := make(chan struct{})
+		deletedCount, deletedNames, _, stats, loopErr := processUsageDeletionLoop(files, speciesMonthCount, params, testDir, quitChan)
+
+		require.NoError(t, loopErr)
+		assert.Equal(t, 1, deletedCount)
+		assert.Equal(t, []string{file1.Path}, deletedNames)
+		assert.Equal(t, cleanupStats{
+			Scanned:         1,
+			Deleted:         1,
+			LockedSkipped:   0,
+			MinClipsBlocked: 0,
+			NotEligible:     0, // file2 was never evaluated; a rate limit is not "not eligible"
+			Errors:          0,
+		}, stats)
+	})
+
+	t.Run("locked and min-clips-blocked files are tallied", func(t *testing.T) {
+		t.Parallel()
+		testDir := t.TempDir()
+
+		lockedFile := makeUsageTestFile(t, testDir, "sp_locked", 10, true)
+		minBlockedFile := makeUsageTestFile(t, testDir, "sp_min", 10, false)
+		delOld := makeUsageTestFile(t, testDir, "sp_del", 10, false)
+		delNew := makeUsageTestFile(t, testDir, "sp_del", 11, false)
+		files := []FileInfo{lockedFile, minBlockedFile, delOld, delNew}
+		speciesMonthCount := buildSpeciesSubDirCountMap(files)
+
+		// Threshold 0 keeps the loop running for the whole file list.
+		const minClipsPerSpecies = 1
+		params := newUsageLoopTestParams(1000, 500, 0, minClipsPerSpecies, maxDeletionsPerRun)
+		quitChan := make(chan struct{})
+		deletedCount, deletedNames, _, stats, loopErr := processUsageDeletionLoop(files, speciesMonthCount, params, testDir, quitChan)
+
+		require.NoError(t, loopErr)
+		assert.Equal(t, 1, deletedCount, "only the first sp_del file should clear the min-clips guard")
+		assert.Equal(t, []string{delOld.Path}, deletedNames)
+		assert.Equal(t, cleanupStats{
+			Scanned:         4,
+			Deleted:         1,
+			LockedSkipped:   1,
+			MinClipsBlocked: 2, // sp_min (always) and the second sp_del file (after the first is deleted)
+			NotEligible:     0,
+			Errors:          0,
+		}, stats)
+	})
+
+	t.Run("deletion error is tallied without stopping the loop", func(t *testing.T) {
+		t.Parallel()
+		testDir := t.TempDir()
+
+		// missingFile references a path never created on disk, so os.Remove
+		// fails inside deleteFileAndOptionalSpectrogram.
+		missingFile := FileInfo{
+			Path:    filepath.Join(testDir, "ghost_species_80p_5.wav"),
+			Species: "ghost_species",
+			Size:    5,
+			Locked:  false,
+		}
+		files := []FileInfo{missingFile}
+		speciesMonthCount := buildSpeciesSubDirCountMap(files)
+
+		params := newUsageLoopTestParams(1000, 900, 80, 0, maxDeletionsPerRun)
+		quitChan := make(chan struct{})
+		deletedCount, deletedNames, _, stats, loopErr := processUsageDeletionLoop(files, speciesMonthCount, params, testDir, quitChan)
+
+		require.NoError(t, loopErr, "a single deletion error stays below the stop threshold")
+		assert.Equal(t, 0, deletedCount)
+		assert.Empty(t, deletedNames)
+		assert.Equal(t, cleanupStats{
+			Scanned:         1,
+			Deleted:         0,
+			LockedSkipped:   0,
+			MinClipsBlocked: 0,
+			NotEligible:     0,
+			Errors:          1,
+		}, stats)
+	})
+}


### PR DESCRIPTION
## Summary

This makes audio-clip retention cleanup observable and hot-reloadable, without changing any deletion decision.

Observability: both the age and usage cleanup loops now tally per-file outcomes (files scanned, deleted, locked-skipped, min-clips-blocked, not-eligible, errors) into a shared `cleanupStats` and emit one INFO-level summary line per run via `logCleanupSummary`. Previously a run that deleted nothing left no INFO-visible explanation, so a user whose disk was filling had no way to see which guard (min-clips, age cutoff, disk threshold) was holding files back without enabling Debug logging and reproducing. The summary line adds roughly one INFO line per check interval (default 15 minutes).

Hot-reload: `clipCleanupMonitor` previously only started when the retention policy was not "none", checked once at pipeline start. Switching the policy from "none" to "age"/"usage" in the UI therefore had no effect until a restart, violating the project's hot-reload rule. The monitor now always starts and re-reads the live policy on every iteration, so a policy change takes effect on the next check interval. When the policy is "none" the loop is a cheap per-interval no-op (one Debug line, no disk scan, no DB access).

The `if deleted` blocks in both loops were converted to a small classification `switch` purely to populate the stats buckets; the deletion branch logic (species-count decrement, name append, count increment) and all early-stop and error paths are unchanged, so which files get deleted is identical to before.

## Related Issues

Relates to #3892 and #4059. These report that retention deletes nothing in specific environments. The root cause could not be confirmed from the code alone (both reporters had the policy set and had restarted, and the deletion logic is data-destructive), so this change deliberately does NOT alter deletion behavior. Instead it adds the INFO-level diagnostics needed to see the actual blocking guard in the field. Both issues stay open pending logs from the affected users; those logs should pinpoint the guard for a targeted follow-up.

## Test Plan

- [x] `go test ./internal/diskmanager/... -race` green, including new table-driven tests for the stat tallies in both loops
- [x] `go build ./internal/analysis/...` and `golangci-lint run` clean
- [x] Verified branch-by-branch that the classification refactor does not change deletion decisions or loop control flow
- [x] Verified the "none" policy path does no disk or DB work and does not busy-loop