### PR TITLE
fix(datastore): promote v2 to primary once the legacy tail is reconciled

### DIFF
--- a/internal/datastore/v2/consolidation.go
+++ b/internal/datastore/v2/consolidation.go
@@ -327,11 +327,16 @@ func ResumeConsolidation(dataDir string, log logger.Logger) (resumed bool, newPa
 	if backupExists && v2Exists && !configuredExists {
 		log.Info("resuming consolidation: renaming v2 to configured path")
 
-		// Clean up any WAL/SHM files
-		cleanupWALFiles(state.V2Path)
-		cleanupWALFiles(state.ConfiguredPath)
+		// Fold any pending v2 WAL content into the main file before renaming, then move
+		// the -wal/-shm sidecars alongside the database instead of deleting them. Blindly
+		// removing the WAL here would discard transactions committed since the last
+		// checkpoint if the original consolidation was interrupted by an unclean shutdown
+		// (issue #3991), the same hazard fixed in CheckAndConsolidateAtStartup.
+		if err := checkpointSQLiteWAL(state.V2Path, log); err != nil {
+			log.Warn("failed to checkpoint v2 WAL before resuming consolidation", logger.Error(err))
+		}
 
-		if err := os.Rename(state.V2Path, state.ConfiguredPath); err != nil {
+		if err := moveSQLiteDBFiles(state.V2Path, state.ConfiguredPath, log); err != nil {
 			return false, "", fmt.Errorf("failed to resume: rename v2 to configured path: %w", err)
 		}
 

--- a/internal/datastore/v2/startup.go
+++ b/internal/datastore/v2/startup.go
@@ -574,15 +574,26 @@ func ShouldSkipLegacyDatabase(settings *conf.Settings) bool {
 	return !state.LegacyRequired && state.MigrationStatus == entities.MigrationStatusCompleted
 }
 
-// HasUnmigratedLegacyRecords checks whether legacy records exist beyond the last
-// migrated ID after migration completed. This detects data loss from hard crashes
-// (kill -9, power loss, OOM) during the tail sync window.
+// HasUnmigratedLegacyRecords reports whether the migration is complete but some
+// legacy records are not yet safely present in v2. This detects data loss from
+// hard crashes (kill -9, power loss, OOM) during the tail sync window, and (issue
+// #3991) distinguishes that genuine straggler case from the normal, harmless
+// dual-write residue that keeps legacy notes growing after completion.
 //
-// When unmigrated records are found, the caller should:
+// It answers the question by primary key rather than by row count: because the v2
+// Detection.ID equals the originating legacy notes.id, a legacy tail record is
+// "unmigrated" only when it is actually absent from v2 (or still pending in the
+// dirty-ID set). A busy install that dual-wrote every tail record into v2 is
+// therefore reported as fully reconciled and free to promote this boot.
+//
+// When it returns true, the caller should:
 //  1. Skip database consolidation (keep files in place)
 //  2. Override v2-only mode so the worker can tail-sync the stragglers
 //
-// Best-effort: returns false on any error to avoid blocking startup.
+// It only inspects a COMPLETED migration; every earlier state and every
+// missing-database case returns false (there is nothing to promote yet). Once the
+// COMPLETED marker is confirmed, verification failures fail CLOSED (return true)
+// so an unverifiable state keeps dual-write running rather than promoting blindly.
 func HasUnmigratedLegacyRecords(settings *conf.Settings, log logger.Logger) bool {
 	if settings.Output.MySQL.Enabled {
 		return hasUnmigratedLegacyMySQL(settings, log)
@@ -655,21 +666,15 @@ func hasUnmigratedLegacySQLite(settings *conf.Settings, log logger.Logger) bool 
 	}
 	defer func() { _ = legacySQL.Close() }()
 
-	// Count legacy notes beyond the last migrated ID
-	var count int64
-	if err := legacyDB.Raw("SELECT COUNT(*) FROM notes WHERE id > ?", state.LastMigratedID).Scan(&count).Error; err != nil {
-		log.Warn("reconciliation: failed to count unmigrated legacy records", logger.Error(err))
-		return false
-	}
-
-	if count > 0 {
-		log.Warn("found unmigrated legacy records after potential crash recovery",
-			logger.Int64("count", count),
-			logger.Uint64("last_migrated_id", uint64(state.LastMigratedID)))
-		return true
-	}
-
-	return false
+	// A completed migration keeps dual-writing to legacy notes, so a raw count of
+	// notes.id > LastMigratedID is always non-zero on a busy install and is NOT a
+	// reliable signal of data loss (issue #3991). During dual-write every detection
+	// is written to BOTH legacy and v2, and the v2 Detection.ID equals the legacy
+	// notes.id, so the authoritative question is whether any legacy tail record is
+	// actually ABSENT from v2. Answer it with a targeted primary-key membership check
+	// plus the dirty-ID set. Only genuinely unreconciled records defer promotion.
+	dirtyTable := resolveSQLiteTableName(v2DB, "migration_dirty_ids", "migration_dirty_id")
+	return !legacyTailReconciledInV2(legacyDB, v2DB, state.LastMigratedID, "notes", "detections", dirtyTable, log)
 }
 
 // hasUnmigratedLegacyMySQL checks for unmigrated records in a MySQL legacy database.
@@ -716,21 +721,189 @@ func hasUnmigratedLegacyMySQL(settings *conf.Settings, log logger.Logger) bool {
 		return false
 	}
 
-	// Count legacy notes beyond the last migrated ID
-	var count int64
-	if err := db.Raw("SELECT COUNT(*) FROM notes WHERE id > ?", state.LastMigratedID).Scan(&count).Error; err != nil {
-		log.Warn("reconciliation: failed to count unmigrated MySQL legacy records", logger.Error(err))
+	// Same reasoning as the SQLite path (issue #3991): dual-write keeps legacy notes
+	// growing after completion, so a raw count is meaningless. Verify the legacy tail
+	// against v2 by primary key (v2 Detection.ID == legacy notes.id) and check the
+	// dirty-ID set. MySQL keeps both schemas in one database, so a single connection
+	// serves both the legacy and v2 queries; v2 tables carry the v2_ prefix.
+	dirtyTable := resolveMySQLTableName(db, settings.Output.MySQL.Database,
+		v2TablePrefix+"migration_dirty_ids", v2TablePrefix+"migration_dirty_id")
+	return !legacyTailReconciledInV2(db, db, state.LastMigratedID, "notes", v2TablePrefix+"detections", dirtyTable, log)
+}
+
+// tailScanBatchSize bounds how many legacy tail IDs are compared against v2 per
+// round trip. Keyset pagination over this batch keeps memory flat regardless of how
+// far the legacy tail runs past the migration watermark.
+const tailScanBatchSize = 500
+
+// tailScanMaxBatches caps the keyset scan as a defensive stop against a logic error;
+// the scan terminates naturally at the end of the (static, read-only) legacy table
+// long before this on any real database. Hitting the cap fails closed.
+const tailScanMaxBatches = 100_000
+
+// legacyTailReconciledInV2 reports whether every legacy detection beyond the
+// migration watermark is already present in v2 AND no dual-write records are still
+// pending reconciliation. It is the safe precondition for ending dual-write and
+// consolidating to v2 (issue #3991).
+//
+// legacyDB and v2DB may be the same handle (MySQL keeps both schemas in one
+// database) or two handles (SQLite keeps v2 in a separate file). dirtyTable may be
+// empty when the dirty-ID table does not exist (older schema), in which case only
+// the membership check applies. It fails CLOSED: any verification error returns
+// false so an unverifiable state keeps dual-write running rather than promoting.
+func legacyTailReconciledInV2(legacyDB, v2DB *gorm.DB, lastMigratedID uint, notesTable, detectionsTable, dirtyTable string, log logger.Logger) bool {
+	// Outstanding dirty IDs mean dual-write failed to sync some records to v2 and the
+	// worker has not reconciled them yet. Tail sync can advance LastMigratedID past a
+	// record it failed to migrate, so the membership check below would not see those;
+	// the dirty-ID set catches them.
+	if dirtyTable != "" {
+		var dirty int64
+		if err := v2DB.Table(dirtyTable).Count(&dirty).Error; err != nil {
+			log.Warn("reconciliation: failed to count dirty IDs, keeping dual-write", logger.Error(err))
+			return false
+		}
+		if dirty > 0 {
+			log.Warn("legacy tail not reconciled: dual-write records pending sync to v2",
+				logger.Int64("dirty_ids", dirty),
+				logger.Uint64("last_migrated_id", uint64(lastMigratedID)))
+			return false
+		}
+	}
+
+	missing, err := legacyTailMissingFromV2(legacyDB, v2DB, lastMigratedID, notesTable, detectionsTable)
+	if err != nil {
+		log.Warn("reconciliation: failed to verify legacy tail against v2, keeping dual-write", logger.Error(err))
 		return false
 	}
+	if missing {
+		log.Warn("legacy tail not reconciled: records absent from v2 after migration completed",
+			logger.Uint64("last_migrated_id", uint64(lastMigratedID)))
+		return false
+	}
+	return true
+}
 
-	if count > 0 {
-		log.Warn("found unmigrated legacy records after potential crash recovery (MySQL)",
-			logger.Int64("count", count),
-			logger.Uint64("last_migrated_id", uint64(state.LastMigratedID)))
-		return true
+// legacyTailMissingFromV2 reports whether any legacy notesTable.id greater than
+// lastMigratedID is absent from the v2 detectionsTable. Because the v2 Detection.ID
+// is set to the originating legacy notes.id during migration, membership is a direct
+// primary-key comparison. It iterates in keyset batches so it never loads the whole
+// tail into memory, and short-circuits on the first missing id, so a genuinely
+// behind install returns immediately. Table names come from fixed internal
+// constants, never user input.
+func legacyTailMissingFromV2(legacyDB, v2DB *gorm.DB, lastMigratedID uint, notesTable, detectionsTable string) (bool, error) {
+	cursor := lastMigratedID
+	for range tailScanMaxBatches {
+		var ids []uint
+		if err := legacyDB.Table(notesTable).
+			Where("id > ?", cursor).
+			Order("id ASC").
+			Limit(tailScanBatchSize).
+			Pluck("id", &ids).Error; err != nil {
+			return false, err
+		}
+		if len(ids) == 0 {
+			return false, nil // reached the end of the tail, nothing missing
+		}
+
+		var existing []uint
+		if err := v2DB.Table(detectionsTable).
+			Where("id IN ?", ids).
+			Pluck("id", &existing).Error; err != nil {
+			return false, err
+		}
+		if len(existing) < len(ids) {
+			return true, nil // at least one tail record is not in v2
+		}
+
+		cursor = ids[len(ids)-1]
+		if len(ids) < tailScanBatchSize {
+			return false, nil // last (partial) batch, all present
+		}
+	}
+	// Exceeded the defensive batch cap without confirming the tail is covered. Fail
+	// closed: report missing so promotion is deferred rather than risking data loss.
+	return true, nil
+}
+
+// resolveMySQLTableName returns the first of the given table names that exists in the
+// MySQL database, or empty string if none do. It mirrors resolveSQLiteTableName for
+// the MySQL information_schema, handling the migration_dirty_id -> migration_dirty_ids
+// rename from PR #2165.
+func resolveMySQLTableName(db *gorm.DB, database string, names ...string) string {
+	for _, name := range names {
+		var count int64
+		if err := db.Raw("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ? AND table_name = ?",
+			database, name).Scan(&count).Error; err == nil && count > 0 {
+			return name
+		}
+	}
+	return ""
+}
+
+// checkpointSQLiteWAL folds any pending write-ahead-log content back into the main
+// database file at dbPath so a subsequent rename carries a complete database. It runs
+// PRAGMA wal_checkpoint(TRUNCATE), which copies all WAL frames into the main file and
+// truncates the WAL to zero bytes. It opens the database read-write (a TRUNCATE
+// checkpoint needs write access) and closes it again, so it must only be called when
+// no other connection holds the file, i.e. at startup before any manager opens it.
+// A missing file is not an error (nothing to checkpoint).
+func checkpointSQLiteWAL(dbPath string, log logger.Logger) error {
+	if _, err := os.Stat(dbPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
 	}
 
-	return false
+	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	if err != nil {
+		return err
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := sqlDB.Close(); closeErr != nil {
+			log.Warn("failed to close database after WAL checkpoint",
+				logger.String("path", dbPath), logger.Error(closeErr))
+		}
+	}()
+
+	if err := db.Exec("PRAGMA wal_checkpoint(TRUNCATE)").Error; err != nil {
+		return fmt.Errorf("WAL checkpoint failed: %w", err)
+	}
+	return nil
+}
+
+// moveSQLiteDBFiles renames a SQLite database file together with its -wal and -shm
+// sidecars, so no committed WAL data is left behind or discarded during consolidation.
+// The main file rename is authoritative and its failure is returned; sidecar moves are
+// best-effort and only logged, because after a successful checkpoint the sidecars are
+// empty and after an unclean shutdown moving them alongside preserves their data.
+func moveSQLiteDBFiles(from, to string, log logger.Logger) error {
+	if err := os.Rename(from, to); err != nil {
+		return err
+	}
+	for _, suffix := range []string{"-wal", "-shm"} {
+		src := from + suffix
+		if _, err := os.Stat(src); err != nil {
+			// Source sidecar absent (e.g. checkpoint truncated it and SQLite removed the
+			// file). Remove any stale sidecar left at the destination so it is not wrongly
+			// paired with the moved database when it is next opened.
+			_ = os.Remove(to + suffix)
+			continue
+		}
+		if err := os.Rename(src, to+suffix); err != nil {
+			log.Warn("failed to move SQLite sidecar file during consolidation",
+				logger.String("from", src),
+				logger.String("to", to+suffix),
+				logger.Error(err))
+		}
+	}
+	return nil
 }
 
 // CheckSQLiteHasV2Schema checks if a SQLite database at the given path is a fully initialized v2 database.
@@ -1154,16 +1327,27 @@ func CheckAndConsolidateAtStartup(configuredPath string, log logger.Logger) (con
 		return false, fmt.Errorf("failed to write consolidation state: %w", err)
 	}
 
-	// Clean up any WAL/SHM files (defensive)
-	cleanupWALFiles(configuredPath)
-	cleanupWALFiles(v2MigrationPath)
+	// Fold any pending WAL content into the main database files BEFORE renaming, so a
+	// rename carries every committed transaction. Blindly deleting -wal/-shm (the old
+	// behaviour here) discards data written since the last checkpoint after an unclean
+	// shutdown, and this promotion fix makes consolidation actually run on busy 24/7
+	// installs where an uncheckpointed WAL is likely (issue #3991). Best-effort: log
+	// and continue, because the sidecar-preserving rename below is the real safety net.
+	if err := checkpointSQLiteWAL(configuredPath, log); err != nil {
+		log.Warn("failed to checkpoint legacy WAL before consolidation", logger.Error(err))
+	}
+	if err := checkpointSQLiteWAL(v2MigrationPath, log); err != nil {
+		log.Warn("failed to checkpoint v2 WAL before consolidation", logger.Error(err))
+	}
 
-	// Rename legacy → backup (if legacy exists)
+	// Rename legacy → backup (if legacy exists), moving its -wal/-shm sidecars along so
+	// no committed WAL data is left behind even if the checkpoint above did not fully
+	// drain it.
 	if _, err := os.Stat(configuredPath); err == nil {
 		log.Debug("renaming legacy database to backup",
 			logger.String("from", configuredPath),
 			logger.String("to", backupPath))
-		if err := os.Rename(configuredPath, backupPath); err != nil {
+		if err := moveSQLiteDBFiles(configuredPath, backupPath, log); err != nil {
 			reportConsolidationError("startupRenameLegacy", err, configuredPath, backupPath)
 			_ = DeleteConsolidationState(dataDir)
 			diagnostics.RecordConsolidation(j, v2MigrationPath, configuredPath, backupPath, "failed")
@@ -1171,18 +1355,19 @@ func CheckAndConsolidateAtStartup(configuredPath string, log logger.Logger) (con
 		}
 	}
 
-	// Rename v2 → configured path
+	// Rename v2 → configured path, moving its -wal/-shm sidecars so the promoted
+	// database carries any transactions still resident in its WAL.
 	log.Debug("renaming v2 database to configured path",
 		logger.String("from", v2MigrationPath),
 		logger.String("to", configuredPath))
-	if err := os.Rename(v2MigrationPath, configuredPath); err != nil {
+	if err := moveSQLiteDBFiles(v2MigrationPath, configuredPath, log); err != nil {
 		reportConsolidationError("startupRenameV2", err, v2MigrationPath, configuredPath)
 		rolledBack := false
 		// Rollback: restore legacy from backup if it existed
 		if _, statErr := os.Stat(backupPath); statErr == nil {
 			log.Warn("v2 rename failed, rolling back",
 				logger.Error(err))
-			if rollbackErr := os.Rename(backupPath, configuredPath); rollbackErr != nil {
+			if rollbackErr := moveSQLiteDBFiles(backupPath, configuredPath, log); rollbackErr != nil {
 				reportConsolidationError("rollbackFailed", rollbackErr, backupPath, configuredPath)
 				log.Error("rollback failed - manual intervention required",
 					logger.Error(rollbackErr))

--- a/internal/datastore/v2/startup_promotion_test.go
+++ b/internal/datastore/v2/startup_promotion_test.go
@@ -203,6 +203,34 @@ func TestLegacyTailReconciledInV2(t *testing.T) {
 
 		assert.True(t, legacyTailReconciledInV2(legacyDB, v2DB, 10, "notes", "detections", "", testStartupLogger()))
 	})
+
+	// MySQL uses ONE database handle for both the legacy notes and the prefixed
+	// v2_detections table (unlike SQLite, which uses two separate files). These
+	// cases exercise that single-handle, prefixed-table shape so the MySQL
+	// promotion path is not left untested.
+	t.Run("MySQL single-handle shape: full tail present is reconciled", func(t *testing.T) {
+		dir := t.TempDir()
+		db := openTempIDTable(t, filepath.Join(dir, "mysql.db"), "notes", seq(1, 15))
+		require.NoError(t, db.Exec("CREATE TABLE v2_detections (id INTEGER PRIMARY KEY)").Error)
+		for _, id := range seq(1, 15) {
+			require.NoError(t, db.Exec("INSERT INTO v2_detections (id) VALUES (?)", id).Error)
+		}
+		require.NoError(t, db.Exec("CREATE TABLE migration_dirty_ids (detection_id INTEGER PRIMARY KEY, created_at INTEGER)").Error)
+
+		assert.True(t, legacyTailReconciledInV2(db, db, 10, "notes", "v2_detections", "migration_dirty_ids", testStartupLogger()))
+	})
+
+	t.Run("MySQL single-handle shape: missing tail record defers", func(t *testing.T) {
+		dir := t.TempDir()
+		db := openTempIDTable(t, filepath.Join(dir, "mysql.db"), "notes", seq(1, 15))
+		require.NoError(t, db.Exec("CREATE TABLE v2_detections (id INTEGER PRIMARY KEY)").Error)
+		for _, id := range seq(1, 13) { // ids 14 and 15 never reached v2
+			require.NoError(t, db.Exec("INSERT INTO v2_detections (id) VALUES (?)", id).Error)
+		}
+		require.NoError(t, db.Exec("CREATE TABLE migration_dirty_ids (detection_id INTEGER PRIMARY KEY, created_at INTEGER)").Error)
+
+		assert.False(t, legacyTailReconciledInV2(db, db, 10, "notes", "v2_detections", "migration_dirty_ids", testStartupLogger()))
+	})
 }
 
 // sqliteSettings builds SQLite-enabled settings pointing at the given legacy path.

--- a/internal/datastore/v2/startup_promotion_test.go
+++ b/internal/datastore/v2/startup_promotion_test.go
@@ -1,0 +1,459 @@
+package v2
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+// openTempIDTable opens a fresh SQLite database at path and creates a single table
+// holding only an integer primary key, seeded with the given ids. It is used to unit
+// test the tail membership logic without the full detection schema.
+func openTempIDTable(t *testing.T, path, table string, ids []uint) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(path), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	require.NoError(t, db.Exec("CREATE TABLE "+table+" (id INTEGER PRIMARY KEY)").Error)
+	for _, id := range ids {
+		require.NoError(t, db.Exec("INSERT INTO "+table+" (id) VALUES (?)", id).Error)
+	}
+	return db
+}
+
+// seq returns the inclusive integer range [from, to] as a []uint.
+func seq(from, to uint) []uint {
+	out := make([]uint, 0, to-from+1)
+	for i := from; i <= to; i++ {
+		out = append(out, i)
+	}
+	return out
+}
+
+// insertV2DetectionIDs opens the v2 sidecar at path and inserts detection rows with the
+// given ids, filling the NOT NULL columns with dummy values. It opens its own connection
+// (foreign keys are off by default on this DSN) so it does not need the referenced label,
+// model, or source rows to exist. The v2 Detection.ID equals the legacy notes.id during
+// migration, so these ids stand in for dual-written detections already present in v2.
+func insertV2DetectionIDs(t *testing.T, path string, ids []uint) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(path), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	defer func() { require.NoError(t, sqlDB.Close()) }()
+
+	for _, id := range ids {
+		require.NoError(t, db.Exec(
+			"INSERT INTO detections (id, model_id, label_id, detected_at, confidence) VALUES (?, 1, 1, ?, 0.5)",
+			id, int64(id)).Error)
+	}
+}
+
+// insertV2DirtyIDs opens the v2 sidecar at path and inserts rows into the
+// migration_dirty_ids table, simulating dual-write records the worker has not yet
+// reconciled into v2.
+func insertV2DirtyIDs(t *testing.T, path string, ids []uint) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(path), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	defer func() { require.NoError(t, sqlDB.Close()) }()
+
+	for _, id := range ids {
+		require.NoError(t, db.Exec(
+			"INSERT INTO migration_dirty_ids (detection_id, created_at) VALUES (?, 0)", id).Error)
+	}
+}
+
+// copyFile copies src to dst, truncating dst if it already exists.
+func copyFile(t *testing.T, src, dst string) {
+	t.Helper()
+	in, err := os.Open(src) //nolint:gosec // test-controlled path
+	require.NoError(t, err)
+	defer func() { _ = in.Close() }()
+	out, err := os.Create(dst) //nolint:gosec // test-controlled path
+	require.NoError(t, err)
+	defer func() { require.NoError(t, out.Close()) }()
+	_, err = io.Copy(out, in)
+	require.NoError(t, err)
+}
+
+// TestLegacyTailMissingFromV2 unit tests the primary-key membership scan that decides
+// whether any legacy tail record is absent from v2. It uses minimal id-only tables so
+// the logic (keyset pagination, short-circuit, batch boundaries) is exercised in
+// isolation from the full detection schema.
+func TestLegacyTailMissingFromV2(t *testing.T) {
+	tests := []struct {
+		name           string
+		notes          []uint
+		detections     []uint
+		lastMigratedID uint
+		wantMissing    bool
+	}{
+		{
+			name:           "all tail records present in v2",
+			notes:          seq(1, 15),
+			detections:     seq(1, 15),
+			lastMigratedID: 10,
+			wantMissing:    false,
+		},
+		{
+			name:           "one tail record absent from v2",
+			notes:          seq(1, 15),
+			detections:     []uint{11, 12, 13, 14}, // 15 missing
+			lastMigratedID: 10,
+			wantMissing:    true,
+		},
+		{
+			name:           "no tail beyond watermark",
+			notes:          seq(1, 10),
+			detections:     nil,
+			lastMigratedID: 10,
+			wantMissing:    false,
+		},
+		{
+			name:           "v2 has only the tail, older records irrelevant",
+			notes:          seq(1, 15),
+			detections:     []uint{11, 12, 13, 14, 15},
+			lastMigratedID: 10,
+			wantMissing:    false,
+		},
+		{
+			name:           "multi-batch scan, all present",
+			notes:          seq(1, 600),
+			detections:     seq(1, 600),
+			lastMigratedID: 0,
+			wantMissing:    false,
+		},
+		{
+			name:           "multi-batch scan, gap in a later batch",
+			notes:          seq(1, 600),
+			detections:     append(seq(1, 549), seq(551, 600)...), // 550 missing (second batch)
+			lastMigratedID: 0,
+			wantMissing:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			legacyDB := openTempIDTable(t, filepath.Join(dir, "legacy.db"), "notes", tt.notes)
+			v2DB := openTempIDTable(t, filepath.Join(dir, "v2.db"), "detections", tt.detections)
+
+			missing, err := legacyTailMissingFromV2(legacyDB, v2DB, tt.lastMigratedID, "notes", "detections")
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantMissing, missing)
+		})
+	}
+}
+
+// TestLegacyTailReconciledInV2 unit tests the combined dirty-ID plus membership decision.
+func TestLegacyTailReconciledInV2(t *testing.T) {
+	t.Run("all present and no dirty IDs is reconciled", func(t *testing.T) {
+		dir := t.TempDir()
+		legacyDB := openTempIDTable(t, filepath.Join(dir, "legacy.db"), "notes", seq(1, 15))
+		v2DB := openTempIDTable(t, filepath.Join(dir, "v2.db"), "detections", seq(1, 15))
+		require.NoError(t, v2DB.Exec("CREATE TABLE migration_dirty_ids (detection_id INTEGER PRIMARY KEY, created_at INTEGER)").Error)
+
+		assert.True(t, legacyTailReconciledInV2(legacyDB, v2DB, 10, "notes", "detections", "migration_dirty_ids", testStartupLogger()))
+	})
+
+	t.Run("dirty IDs defer even when tail is present", func(t *testing.T) {
+		dir := t.TempDir()
+		legacyDB := openTempIDTable(t, filepath.Join(dir, "legacy.db"), "notes", seq(1, 15))
+		v2DB := openTempIDTable(t, filepath.Join(dir, "v2.db"), "detections", seq(1, 15))
+		require.NoError(t, v2DB.Exec("CREATE TABLE migration_dirty_ids (detection_id INTEGER PRIMARY KEY, created_at INTEGER)").Error)
+		require.NoError(t, v2DB.Exec("INSERT INTO migration_dirty_ids (detection_id, created_at) VALUES (7, 0)").Error)
+
+		assert.False(t, legacyTailReconciledInV2(legacyDB, v2DB, 10, "notes", "detections", "migration_dirty_ids", testStartupLogger()))
+	})
+
+	t.Run("missing tail record defers", func(t *testing.T) {
+		dir := t.TempDir()
+		legacyDB := openTempIDTable(t, filepath.Join(dir, "legacy.db"), "notes", seq(1, 15))
+		v2DB := openTempIDTable(t, filepath.Join(dir, "v2.db"), "detections", seq(1, 13)) // 14,15 absent
+		require.NoError(t, v2DB.Exec("CREATE TABLE migration_dirty_ids (detection_id INTEGER PRIMARY KEY, created_at INTEGER)").Error)
+
+		assert.False(t, legacyTailReconciledInV2(legacyDB, v2DB, 10, "notes", "detections", "migration_dirty_ids", testStartupLogger()))
+	})
+
+	t.Run("empty dirty table name skips dirty check", func(t *testing.T) {
+		dir := t.TempDir()
+		legacyDB := openTempIDTable(t, filepath.Join(dir, "legacy.db"), "notes", seq(1, 15))
+		v2DB := openTempIDTable(t, filepath.Join(dir, "v2.db"), "detections", seq(1, 15))
+
+		assert.True(t, legacyTailReconciledInV2(legacyDB, v2DB, 10, "notes", "detections", "", testStartupLogger()))
+	})
+}
+
+// sqliteSettings builds SQLite-enabled settings pointing at the given legacy path.
+func sqliteSettings(path string) *conf.Settings {
+	s := &conf.Settings{}
+	s.Output.SQLite.Enabled = true
+	s.Output.SQLite.Path = path
+	return s
+}
+
+// TestHasUnmigratedLegacyRecords_DualWriteResidueAllInV2 is the issue #3991 regression:
+// a completed migration that is still dual-writing keeps legacy notes growing past the
+// watermark, but those records are also written to v2. They must NOT be treated as
+// unmigrated, so promotion can proceed on this boot.
+func TestHasUnmigratedLegacyRecords_DualWriteResidueAllInV2(t *testing.T) {
+	tmpDir := t.TempDir()
+	legacyPath := filepath.Join(tmpDir, "birdnet.db")
+
+	// Legacy has 13 records; migration watermark is 10, so ids 11-13 are dual-write
+	// residue. All three are present in v2.
+	createLegacySQLite(t, legacyPath, 13)
+	createCompletedV2MigrationDB(t, tmpDir, 10)
+	insertV2DetectionIDs(t, V2MigrationPathFromConfigured(legacyPath), []uint{11, 12, 13})
+
+	hasUnmigrated := HasUnmigratedLegacyRecords(sqliteSettings(legacyPath), testStartupLogger())
+	assert.False(t, hasUnmigrated,
+		"dual-write residue already present in v2 must not block promotion (#3991)")
+}
+
+// TestHasUnmigratedLegacyRecords_PartialStragglers verifies that genuinely missing tail
+// records (present in legacy, absent from v2) still defer promotion.
+func TestHasUnmigratedLegacyRecords_PartialStragglers(t *testing.T) {
+	tmpDir := t.TempDir()
+	legacyPath := filepath.Join(tmpDir, "birdnet.db")
+
+	// Legacy has 15 records past-watermark 11-15; only 11-13 made it into v2.
+	createLegacySQLite(t, legacyPath, 15)
+	createCompletedV2MigrationDB(t, tmpDir, 10)
+	insertV2DetectionIDs(t, V2MigrationPathFromConfigured(legacyPath), []uint{11, 12, 13})
+
+	hasUnmigrated := HasUnmigratedLegacyRecords(sqliteSettings(legacyPath), testStartupLogger())
+	assert.True(t, hasUnmigrated,
+		"records present in legacy but absent from v2 must defer promotion")
+}
+
+// TestHasUnmigratedLegacyRecords_DirtyIDDefers verifies that an outstanding dirty ID
+// defers promotion even when every legacy tail record is present in v2. Tail sync can
+// advance the watermark past a record it failed to migrate, so the dirty-ID set is the
+// guard that catches it.
+func TestHasUnmigratedLegacyRecords_DirtyIDDefers(t *testing.T) {
+	tmpDir := t.TempDir()
+	legacyPath := filepath.Join(tmpDir, "birdnet.db")
+
+	createLegacySQLite(t, legacyPath, 13)
+	createCompletedV2MigrationDB(t, tmpDir, 10)
+	sidecar := V2MigrationPathFromConfigured(legacyPath)
+	insertV2DetectionIDs(t, sidecar, []uint{11, 12, 13})
+	insertV2DirtyIDs(t, sidecar, []uint{7}) // an unreconciled dual-write below the watermark
+
+	hasUnmigrated := HasUnmigratedLegacyRecords(sqliteSettings(legacyPath), testStartupLogger())
+	assert.True(t, hasUnmigrated,
+		"an outstanding dirty ID must defer promotion")
+}
+
+// TestMoveSQLiteDBFiles_PreservesSidecars proves the consolidation rename carries the
+// -wal and -shm sidecars alongside the main database instead of discarding them, so no
+// committed WAL data is lost during promotion (issue #3991).
+func TestMoveSQLiteDBFiles_PreservesSidecars(t *testing.T) {
+	dir := t.TempDir()
+	from := filepath.Join(dir, "src.db")
+	to := filepath.Join(dir, "dst.db")
+
+	require.NoError(t, os.WriteFile(from, []byte("main-db"), 0o600))
+	require.NoError(t, os.WriteFile(from+"-wal", []byte("wal-frames"), 0o600))
+	require.NoError(t, os.WriteFile(from+"-shm", []byte("shm-index"), 0o600))
+
+	require.NoError(t, moveSQLiteDBFiles(from, to, testStartupLogger()))
+
+	// Source files are gone.
+	assert.NoFileExists(t, from)
+	assert.NoFileExists(t, from+"-wal")
+	assert.NoFileExists(t, from+"-shm")
+
+	// Destination carries the main file and both sidecars with their content intact.
+	assert.FileExists(t, to)
+	walBytes, err := os.ReadFile(to + "-wal") //nolint:gosec // test-controlled path
+	require.NoError(t, err)
+	assert.Equal(t, "wal-frames", string(walBytes), "WAL sidecar content must survive the move")
+	shmBytes, err := os.ReadFile(to + "-shm") //nolint:gosec // test-controlled path
+	require.NoError(t, err)
+	assert.Equal(t, "shm-index", string(shmBytes))
+}
+
+// TestCheckpointSQLiteWAL_FoldsWALIntoMainFile proves that checkpointing folds
+// uncheckpointed WAL frames into the main database file (so a later rename of the main
+// file alone carries the data) and truncates the WAL to zero bytes.
+func TestCheckpointSQLiteWAL_FoldsWALIntoMainFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wal.db")
+
+	// Writer connection kept open (idle) so closing it does not trigger the implicit
+	// last-connection checkpoint; its committed frames stay in the on-disk -wal file.
+	writer, err := gorm.Open(sqlite.Open(path), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	require.NoError(t, err)
+	writerSQL, err := writer.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = writerSQL.Close() })
+
+	require.NoError(t, writer.Exec("PRAGMA journal_mode=WAL").Error)
+	require.NoError(t, writer.Exec("PRAGMA wal_autocheckpoint=0").Error)
+	require.NoError(t, writer.Exec("CREATE TABLE t (id INTEGER PRIMARY KEY)").Error)
+	require.NoError(t, writer.Exec("INSERT INTO t (id) VALUES (1), (2), (3)").Error)
+
+	walInfo, err := os.Stat(path + "-wal")
+	require.NoError(t, err)
+	require.Positive(t, walInfo.Size(), "precondition: WAL should hold uncheckpointed frames")
+
+	require.NoError(t, checkpointSQLiteWAL(path, testStartupLogger()))
+
+	walInfo, err = os.Stat(path + "-wal")
+	require.NoError(t, err)
+	assert.Zero(t, walInfo.Size(), "TRUNCATE checkpoint must empty the WAL file")
+
+	// A fresh reader sees the data from the main file.
+	reader, err := gorm.Open(sqlite.Open(readOnlyDSN(path)), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	require.NoError(t, err)
+	readerSQL, err := reader.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = readerSQL.Close() })
+	var count int64
+	require.NoError(t, reader.Table("t").Count(&count).Error)
+	assert.Equal(t, int64(3), count, "checkpointed rows must be readable from the main file")
+}
+
+// TestCheckAndConsolidateAtStartup_PreservesUncheckpointedV2WAL proves the end-to-end
+// promotion path does not discard committed data that lives only in the v2 sidecar's WAL
+// at consolidation time, i.e. the unclean-shutdown case that this promotion fix now
+// exposes on busy installs (issue #3991).
+func TestCheckAndConsolidateAtStartup_PreservesUncheckpointedV2WAL(t *testing.T) {
+	tmpDir := t.TempDir()
+	configuredPath := filepath.Join(tmpDir, "birdnet.db")
+	v2Path := V2MigrationPathFromConfigured(configuredPath)
+
+	// Legacy database with rows (it will be renamed to a backup) and a completed v2
+	// sidecar (checkpointed and closed by the helper).
+	createLegacySQLite(t, configuredPath, 5)
+	createCompletedV2MigrationDB(t, tmpDir, 5)
+
+	// Stage detection rows 6-8 as an uncheckpointed WAL image on the sidecar, mimicking a
+	// power loss after commit but before checkpoint.
+	stageUncheckpointedV2WAL(t, v2Path, []uint{6, 7, 8})
+
+	consolidated, err := CheckAndConsolidateAtStartup(configuredPath, testStartupLogger())
+	require.NoError(t, err)
+	require.True(t, consolidated, "a completed v2 sidecar next to a legacy DB must consolidate")
+
+	// The promoted database at the configured path must contain the WAL-resident rows.
+	promoted, err := gorm.Open(sqlite.Open(readOnlyDSN(configuredPath)), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	require.NoError(t, err)
+	promotedSQL, err := promoted.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = promotedSQL.Close() })
+
+	var count int64
+	require.NoError(t, promoted.Table("detections").Where("id IN ?", []uint{6, 7, 8}).Count(&count).Error)
+	assert.Equal(t, int64(3), count, "uncheckpointed v2 WAL rows must survive consolidation")
+}
+
+// TestResumeConsolidation_PreservesUncheckpointedV2WAL proves the interrupted-consolidation
+// resume path (Step 1 of CheckAndConsolidateAtStartup) also preserves committed data that
+// lives only in the v2 sidecar's WAL, rather than discarding it as the previous blind
+// cleanup did (issue #3991).
+func TestResumeConsolidation_PreservesUncheckpointedV2WAL(t *testing.T) {
+	tmpDir := t.TempDir()
+	configuredPath := filepath.Join(tmpDir, "birdnet.db")
+	v2Path := V2MigrationPathFromConfigured(configuredPath)
+	backupPath := filepath.Join(tmpDir, "birdnet.db.backup")
+
+	// Completed v2 sidecar with rows 6-8 staged only in its uncheckpointed WAL.
+	createCompletedV2MigrationDB(t, tmpDir, 5)
+	stageUncheckpointedV2WAL(t, v2Path, []uint{6, 7, 8})
+
+	// Interrupted consolidation at step 8: the legacy DB was already renamed to the
+	// backup, the v2 sidecar was not yet renamed to the configured path, and the
+	// configured path does not exist.
+	require.NoError(t, os.WriteFile(backupPath, []byte("legacy-backup"), 0o600))
+	require.NoError(t, WriteConsolidationState(tmpDir, &ConsolidationState{
+		LegacyPath:     configuredPath,
+		V2Path:         v2Path,
+		BackupPath:     backupPath,
+		ConfiguredPath: configuredPath,
+	}))
+
+	resumed, newPath, err := ResumeConsolidation(tmpDir, testStartupLogger())
+	require.NoError(t, err)
+	require.True(t, resumed, "an interrupted step-8 consolidation must resume")
+	assert.Equal(t, configuredPath, newPath)
+
+	promoted, err := gorm.Open(sqlite.Open(readOnlyDSN(configuredPath)), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	require.NoError(t, err)
+	promotedSQL, err := promoted.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = promotedSQL.Close() })
+
+	var count int64
+	require.NoError(t, promoted.Table("detections").Where("id IN ?", []uint{6, 7, 8}).Count(&count).Error)
+	assert.Equal(t, int64(3), count, "uncheckpointed v2 WAL rows must survive resumed consolidation")
+}
+
+// stageUncheckpointedV2WAL writes detection rows into the sidecar at path and leaves them
+// in an uncheckpointed on-disk WAL with no open connection, reproducing a crash image.
+// It snapshots the (main db, -wal) pair before the writer's clean close checkpoints them,
+// then restores that snapshot; the missing -shm is rebuilt by SQLite on the next open.
+func stageUncheckpointedV2WAL(t *testing.T, path string, ids []uint) {
+	t.Helper()
+
+	writer, err := gorm.Open(sqlite.Open(path), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, writer.Exec("PRAGMA journal_mode=WAL").Error)
+	require.NoError(t, writer.Exec("PRAGMA wal_autocheckpoint=0").Error)
+	for _, id := range ids {
+		require.NoError(t, writer.Exec(
+			"INSERT INTO detections (id, model_id, label_id, detected_at, confidence) VALUES (?, 1, 1, ?, 0.5)",
+			id, int64(id)).Error)
+	}
+
+	// Snapshot the pre-checkpoint on-disk state (main file plus populated WAL).
+	holdDir := t.TempDir()
+	heldDB := filepath.Join(holdDir, "db")
+	heldWAL := filepath.Join(holdDir, "wal")
+	copyFile(t, path, heldDB)
+	copyFile(t, path+"-wal", heldWAL)
+
+	// Clean close checkpoints and truncates the original WAL, but the snapshot above
+	// preserved the uncheckpointed image.
+	writerSQL, err := writer.DB()
+	require.NoError(t, err)
+	require.NoError(t, writerSQL.Close())
+
+	// Restore the crash image: main file plus its uncheckpointed WAL, no -shm.
+	_ = os.Remove(path + "-shm")
+	copyFile(t, heldDB, path)
+	copyFile(t, heldWAL, path+"-wal")
+}


### PR DESCRIPTION
## Summary

Fixes a case where a completed v2 migration never finishes cutting over: the app stays in dual-write mode forever and the UI shows "Restart Required" permanently.

The promotion gate previously decided an install was "still unmigrated" by counting legacy `notes` rows with an id past the migration watermark. In dual-write mode the app keeps appending rows to legacy `notes`, so that count is never zero, so the install is classified as unmigrated on every boot and v2 is never promoted. That is a loop: v2 will not promote while legacy has rows past the watermark, but dual-write keeps writing them until v2 is promoted.

The fix stops trusting the raw row count and instead trusts the persisted COMPLETED migration marker, gated by an actual reconciliation check: v2 is promoted only when there are no outstanding dirty (failed-to-migrate) ids AND every legacy id past the watermark is genuinely present in v2. The presence check correlates rows by `v2 Detection.ID == legacy notes.id`, the same identity the migration and dual-write paths already use, and scans the tail with keyset pagination that short-circuits on the first missing id and fails closed (stays on legacy) on any verification error or an implausibly large tail. This covers both SQLite (two database files) and MySQL (one database, `v2_` prefixed tables). The earlier states are unchanged: a legacy-only database with no completed marker stays on legacy, and a migrated database with an empty legacy residue is still recognized as v2.

Making promotion actually run on busy installs exposed a second hazard in consolidation: it deleted the `-wal`/`-shm` sidecars before renaming the database, which discards any transactions written since the last checkpoint after an unclean shutdown. Consolidation now checkpoints (`PRAGMA wal_checkpoint(TRUNCATE)`) and moves the sidecars alongside the main file instead of deleting them, in both the startup and resume paths.

## Related Issues

Fixes #3991.

## Test Plan

- [x] `go test ./internal/datastore/v2/... -race` green
- [x] New tests cover: a completed-but-dual-writing residue that is fully present in v2 promotes; a genuine straggler absent from v2 defers; an outstanding dirty id defers; the keyset membership boundary; the MySQL single-handle shape; and end-to-end survival of an uncheckpointed WAL through both consolidation paths
- [x] `golangci-lint run` clean; pre-existing #3947 and #3924 behaviors verified unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database startup and migration reliability by preserving committed SQLite WAL data during consolidation and recovery.
  * Prevented stale database sidecar files from being left behind after promotion.
  * Strengthened detection and reconciliation of records missed during migration, including dirty or partially migrated records.
  * Improved compatibility with both singular and plural dirty-record table layouts.
* **Tests**
  * Added comprehensive coverage for migration reconciliation, WAL recovery, sidecar preservation, and interrupted consolidation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->