### PR TITLE
fix: four Sentry-triage bug fixes (analytics NULL scan, label scanner, extension telemetry, model ID aliases)

### DIFF
--- a/frontend/src/lib/telemetry/sentry.test.ts
+++ b/frontend/src/lib/telemetry/sentry.test.ts
@@ -240,6 +240,26 @@ describe('beforeSend privacy filtering', () => {
     expect(result).toBeNull();
   });
 
+  it('drops errors from every recognized extension scheme', () => {
+    const prefixes = [
+      'webkit-masked-url://hidden/',
+      'chrome-extension://abcdef/content.js',
+      'moz-extension://uuid/inject.js',
+      'safari-extension://com.example/script.js',
+      'safari-web-extension://UUID/content.js',
+    ];
+    for (const filename of prefixes) {
+      const event = {
+        type: undefined,
+        exception: {
+          values: [{ type: 'Error', stacktrace: { frames: [{ function: 'x', filename }] } }],
+        },
+      } as Sentry.ErrorEvent;
+      const result = beforeSend?.(event, {} as Sentry.EventHint);
+      expect(result, `expected ${filename} to be dropped`).toBeNull();
+    }
+  });
+
   it('keeps errors that have at least one app frame among extension frames', () => {
     const event = {
       type: undefined,

--- a/frontend/src/lib/telemetry/sentry.test.ts
+++ b/frontend/src/lib/telemetry/sentry.test.ts
@@ -201,6 +201,75 @@ describe('beforeSend privacy filtering', () => {
     expect(result).toBeNull();
   });
 
+  it('drops errors whose frames are all Safari extension (webkit-masked-url)', () => {
+    const event = {
+      type: undefined,
+      exception: {
+        values: [
+          {
+            type: 'TypeError',
+            stacktrace: {
+              frames: [
+                { function: 'shouldBeEnabled', filename: 'webkit-masked-url://hidden/' },
+                { function: 'updateState', filename: 'webkit-masked-url://hidden/' },
+              ],
+            },
+          },
+        ],
+      },
+    } as Sentry.ErrorEvent;
+    const result = beforeSend?.(event, {} as Sentry.EventHint);
+    expect(result).toBeNull();
+  });
+
+  it('drops errors from chrome-extension frames', () => {
+    const event = {
+      type: undefined,
+      exception: {
+        values: [
+          {
+            type: 'Error',
+            stacktrace: {
+              frames: [{ function: 'inject', filename: 'chrome-extension://abcdef/content.js' }],
+            },
+          },
+        ],
+      },
+    } as Sentry.ErrorEvent;
+    const result = beforeSend?.(event, {} as Sentry.EventHint);
+    expect(result).toBeNull();
+  });
+
+  it('keeps errors that have at least one app frame among extension frames', () => {
+    const event = {
+      type: undefined,
+      exception: {
+        values: [
+          {
+            type: 'TypeError',
+            stacktrace: {
+              frames: [
+                { function: 'extThing', filename: 'webkit-masked-url://hidden/' },
+                { function: 'renderDashboard', filename: '/ui/assets/index-abc123.js' },
+              ],
+            },
+          },
+        ],
+      },
+    } as Sentry.ErrorEvent;
+    const result = beforeSend?.(event, {} as Sentry.EventHint);
+    expect(result).not.toBeNull();
+  });
+
+  it('keeps errors that carry no stack frames', () => {
+    const event = {
+      type: undefined,
+      exception: { values: [{ type: 'Error', value: 'real app error' }] },
+    } as Sentry.ErrorEvent;
+    const result = beforeSend?.(event, {} as Sentry.EventHint);
+    expect(result).not.toBeNull();
+  });
+
   it('drops ResizeObserver loop errors', () => {
     const error = new Error('ResizeObserver loop completed with undelivered notifications');
     const event = { type: undefined } as Sentry.ErrorEvent;

--- a/frontend/src/lib/telemetry/sentry.ts
+++ b/frontend/src/lib/telemetry/sentry.ts
@@ -106,6 +106,54 @@ function hasNoDiagnosticValue(hint: Sentry.EventHint): boolean {
 }
 
 /**
+ * URL scheme prefixes that identify a stack frame as injected browser-extension
+ * or otherwise cross-origin-masked code rather than our own app bundle. Safari
+ * rewrites extension and cross-origin script URLs to `webkit-masked-url://`;
+ * Chromium and Firefox expose their extension origins directly.
+ */
+const EXTENSION_FRAME_PREFIXES = [
+  'webkit-masked-url:',
+  'chrome-extension:',
+  'moz-extension:',
+  'safari-extension:',
+  'safari-web-extension:',
+];
+
+/** Does this stack-frame filename/path belong to injected extension code? */
+function isExtensionFrame(location: string | undefined): boolean {
+  if (!location) return false;
+  return EXTENSION_FRAME_PREFIXES.some(prefix => location.startsWith(prefix));
+}
+
+/**
+ * Check whether an error originates entirely from a browser extension. Safari
+ * extensions (and other injected content scripts) run in the page context, so
+ * their unhandled rejections are captured by our global handlers even though
+ * they are not our code. When every stack frame is extension-injected, the
+ * event carries no signal about BirdNET-Go and is dropped (Sentry
+ * BIRDNET-GO-2EM: `shouldBeEnabled` at `webkit-masked-url://hidden/`).
+ */
+function isBrowserExtensionError(event: Sentry.ErrorEvent): boolean {
+  const values = event.exception?.values;
+  if (!values || values.length === 0) return false;
+
+  let sawFrame = false;
+  for (const value of values) {
+    const frames = value.stacktrace?.frames;
+    if (!frames) continue;
+    for (const frame of frames) {
+      sawFrame = true;
+      // Any frame from our own bundle means this is not pure extension noise.
+      if (!isExtensionFrame(frame.filename) && !isExtensionFrame(frame.abs_path)) {
+        return false;
+      }
+    }
+  }
+
+  return sawFrame;
+}
+
+/**
  * Initialize Sentry with privacy filtering.
  * Called once from appState.svelte.ts when telemetry is enabled.
  */
@@ -259,6 +307,10 @@ function beforeSend(event: Sentry.ErrorEvent, hint: Sentry.EventHint): Sentry.Er
 
   // Drop events with no diagnostic value (empty/generic messages, browser noise)
   if (hasNoDiagnosticValue(hint)) return null;
+
+  // Drop errors thrown entirely by injected browser-extension code (Safari
+  // masks these as webkit-masked-url); they are not BirdNET-Go bugs.
+  if (isBrowserExtensionError(event)) return null;
 
   // 1. Strip user data (Sentry auto-collects IP)
   delete event.user;

--- a/frontend/src/lib/telemetry/sentry.ts
+++ b/frontend/src/lib/telemetry/sentry.ts
@@ -132,6 +132,16 @@ function isExtensionFrame(location: string | undefined): boolean {
  * they are not our code. When every stack frame is extension-injected, the
  * event carries no signal about BirdNET-Go and is dropped (Sentry
  * BIRDNET-GO-2EM: `shouldBeEnabled` at `webkit-masked-url://hidden/`).
+ *
+ * This assumes the app bundle is served same-origin, which is the standard
+ * deployment: Safari's `webkit-masked-url:` masking then applies only to
+ * extension and cross-origin scripts, so real BirdNET-Go frames keep their
+ * `/ui/assets/...` paths and short-circuit the drop. A non-standard deployment
+ * serving assets cross-origin without `Timing-Allow-Origin` would let Safari
+ * mask app frames too, so a genuine error could be dropped; that is an accepted
+ * loss of telemetry visibility, not a user-facing regression. Requiring an
+ * explicit `*-extension:` frame instead would fail to drop the reported case,
+ * whose frames are all `webkit-masked-url:`.
  */
 function isBrowserExtensionError(event: Sentry.ErrorEvent): boolean {
   const values = event.exception?.values;

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -724,8 +724,12 @@ func (bn *BirdNET) loadEmbeddedLabels() error {
 
 	data := result.Data
 
-	// Read the labels line by line
+	// Read the labels line by line. Grow the scan buffer past bufio's default
+	// 64 KiB line cap: a label file with an overlong line or no line breaks at
+	// all otherwise fails with "bufio.Scanner: token too long" (Sentry
+	// BIRDNET-GO-2FF).
 	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 0, labelScannerInitialBufBytes), labelScannerMaxLineBytes)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line != "" {
@@ -835,6 +839,8 @@ func (bn *BirdNET) logMissingTaxonomyCodes() {
 
 func (bn *BirdNET) loadLabelsFromText(file *os.File) error {
 	scanner := bufio.NewScanner(file)
+	// Grow past bufio's default 64 KiB line cap; see loadLabels for rationale.
+	scanner.Buffer(make([]byte, 0, labelScannerInitialBufBytes), labelScannerMaxLineBytes)
 	for scanner.Scan() {
 		bn.Settings.BirdNET.Labels = append(bn.Settings.BirdNET.Labels, strings.TrimSpace(scanner.Text()))
 	}

--- a/internal/classifier/birdnet_v3.go
+++ b/internal/classifier/birdnet_v3.go
@@ -17,8 +17,15 @@ const utf8BOM = "\uFEFF"
 // Label scanner buffer sizes. Labels are short ("SciName_CommonName"), but the
 // buffer is grown beyond bufio's default 64 KiB line cap defensively.
 const (
-	labelScannerInitialBufBytes = 64 * 1024   // initial scan buffer (64 KiB)
-	labelScannerMaxLineBytes    = 1024 * 1024 // max label line length (1 MiB)
+	// maxLabelLineBytes is the largest label line we support (1 MiB).
+	maxLabelLineBytes           = 1024 * 1024
+	labelScannerInitialBufBytes = 64 * 1024 // initial scan buffer (64 KiB)
+	// labelScannerMaxLineBytes is the bufio.Scanner token cap. It is
+	// maxLabelLineBytes + 2 because Scanner needs its max strictly greater than
+	// the longest token (it must read past the line, or hit EOF, to terminate
+	// it): a line of exactly maxLabelLineBytes, with or without a CR/LF
+	// terminator, otherwise fails with "bufio.Scanner: token too long".
+	labelScannerMaxLineBytes = maxLabelLineBytes + 2
 )
 
 // ParseBirdNETV3Labels parses a BirdNET v3.0 label file.

--- a/internal/classifier/label_loading_external_test.go
+++ b/internal/classifier/label_loading_external_test.go
@@ -3,6 +3,7 @@ package classifier
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,6 +47,25 @@ func TestLoadExternalLabels_LiteralPath(t *testing.T) {
 	bn := newExternalLabelBirdNET(labelPath)
 	require.NoError(t, bn.loadLabels())
 	assert.Equal(t, twoLabelsExpected, bn.Settings.BirdNET.Labels)
+}
+
+// TestLoadExternalLabels_LongLine guards loadLabelsFromText against the default
+// bufio.Scanner 64 KiB token cap: an external label file with a line longer than
+// that previously failed with "bufio.Scanner: token too long" (Sentry
+// BIRDNET-GO-2FF). The grown scanner buffer must parse it without error.
+func TestLoadExternalLabels_LongLine(t *testing.T) {
+	t.Parallel()
+
+	longLabel := strings.Repeat("A", 70*1024) // past the 64 KiB default
+	dir := t.TempDir()
+	labelPath := filepath.Join(dir, "labels.txt")
+	require.NoError(t, os.WriteFile(labelPath, []byte(longLabel+"\nParus major_Great Tit\n"), 0o644))
+
+	bn := newExternalLabelBirdNET(labelPath)
+	require.NoError(t, bn.loadLabels(), "scanner buffer must accommodate lines beyond the 64 KiB default")
+	require.Len(t, bn.Settings.BirdNET.Labels, 2)
+	assert.Equal(t, longLabel, bn.Settings.BirdNET.Labels[0])
+	assert.Equal(t, "Parus major_Great Tit", bn.Settings.BirdNET.Labels[1])
 }
 
 // TestLoadExternalLabels_ExpandsEnvVar verifies that loadExternalLabels expands

--- a/internal/classifier/label_loading_external_test.go
+++ b/internal/classifier/label_loading_external_test.go
@@ -56,7 +56,7 @@ func TestLoadExternalLabels_LiteralPath(t *testing.T) {
 func TestLoadExternalLabels_LongLine(t *testing.T) {
 	t.Parallel()
 
-	longLabel := strings.Repeat("A", 70*1024) // past the 64 KiB default
+	longLabel := strings.Repeat("A", longLabelTestBytes) // past the 64 KiB default
 	dir := t.TempDir()
 	labelPath := filepath.Join(dir, "labels.txt")
 	require.NoError(t, os.WriteFile(labelPath, []byte(longLabel+"\nParus major_Great Tit\n"), 0o644))

--- a/internal/classifier/model_registry.go
+++ b/internal/classifier/model_registry.go
@@ -144,9 +144,10 @@ var ModelRegistry = map[string]ModelInfo{
 		Description:      "Global model with 6522 species",
 		Spec:             ModelSpec{SampleRate: 48000, ClipLength: 3 * time.Second},
 		// The primary alias (index 0) is the canonical form ConfigAliasForRegistry
-		// writes back; the hyphenated "birdnet-v2.4" mirrors the model catalog entry
-		// ID so a config that carries the catalog-style ID still validates and resolves.
-		ConfigAliases:    []string{conf.ModelIDBirdNET, "birdnet-v2.4"},
+		// writes back; the hyphenated catalog form (conf.ModelID*Catalog) mirrors the
+		// model catalog entry ID so a config that carries the catalog-style ID still
+		// validates and resolves. conf.MigrateModelIDAliases canonicalizes it on load.
+		ConfigAliases: []string{conf.ModelIDBirdNET, conf.ModelIDBirdNETCatalog},
 		SupportedLocales: []string{"af", "ar", "bg", "ca", "cs", "da", "de", "el", "en-uk", "en-us", "es",
 			"et", "fi", "fr", "he", "hr", "hu", "id", "is", "it", "ja", "ko", "lt", "lv", "ml", "nl",
 			"no", "pl", "pt", "pt-br", "pt-pt", "ro", "ru", "sk", "sl", "sr", "sv", "th", "tr", "uk", "zh"},
@@ -162,9 +163,9 @@ var ModelRegistry = map[string]ModelInfo{
 		DetectionVersion: "3.0",
 		Description:      "BirdNET v3.0 model (32kHz, 5s clips, embeddings)", // NumSpecies omitted: determined at runtime from label file
 		Spec:             ModelSpec{SampleRate: 32000, ClipLength: 5 * time.Second},
-		// Hyphenated "birdnet-v3.0" mirrors the catalog entry ID; the underscore
-		// primary stays canonical for write-back. See BirdNET v2.4 entry above.
-		ConfigAliases:    []string{conf.ModelIDBirdNETV3, "birdnet-v3.0"},
+		// Catalog form mirrors the catalog entry ID; the underscore primary stays
+		// canonical for write-back. See BirdNET v2.4 entry above.
+		ConfigAliases: []string{conf.ModelIDBirdNETV3, conf.ModelIDBirdNETV3Catalog},
 		SupportedLocales: []string{"af", "ar", "bg", "ca", "cs", "da", "de", "el", "en-uk", "en-us", "es",
 			"et", "fi", "fr", "he", "hr", "hu", "id", "is", "it", "ja", "ko", "lt", "lv", "ml", "nl",
 			"no", "pl", "pt", "pt-br", "pt-pt", "ro", "ru", "sk", "sl", "sr", "sv", "th", "tr", "uk", "zh"},
@@ -178,11 +179,11 @@ var ModelRegistry = map[string]ModelInfo{
 		DetectionVersion: "V2",
 		Description:      "Perch v2 multi-taxa model with ~14,795 species including birds, insects, amphibians, and mammals (scientific names only)",
 		Spec:             ModelSpec{SampleRate: 32000, ClipLength: 5 * time.Second},
-		// Hyphenated "perch-v2" mirrors the catalog entry ID; the underscore primary
-		// stays canonical for write-back. Reported via Sentry (BIRDNET-GO-2FZ), where
-		// a config carried "perch-v2" and was rejected as an unknown model ID.
-		ConfigAliases:    []string{conf.ModelIDPerchV2, "perch-v2"},
-		NumSpecies:       14795,
+		// Catalog form mirrors the catalog entry ID; the underscore primary stays
+		// canonical for write-back. Reported via Sentry (BIRDNET-GO-2FZ), where a
+		// config carried "perch-v2" and was rejected as an unknown model ID.
+		ConfigAliases: []string{conf.ModelIDPerchV2, conf.ModelIDPerchV2Catalog},
+		NumSpecies:    14795,
 	},
 	RegistryIDBat: {
 		ID:               RegistryIDBat,
@@ -202,7 +203,9 @@ var ModelRegistry = map[string]ModelInfo{
 		DetectionVersion: "4.4",
 		Description:      "Regional bird classifier optimized for Finnish bird species",
 		Spec:             ModelSpec{SampleRate: 48000, ClipLength: 3 * time.Second},
-		ConfigAliases:    []string{conf.ModelIDBSG},
+		// Catalog form "bsg-finland" mirrors the catalog entry ID; "bsg" stays
+		// canonical for write-back. See BirdNET v2.4 entry above.
+		ConfigAliases: []string{conf.ModelIDBSG, conf.ModelIDBSGCatalog},
 	},
 }
 

--- a/internal/classifier/model_registry.go
+++ b/internal/classifier/model_registry.go
@@ -143,7 +143,10 @@ var ModelRegistry = map[string]ModelInfo{
 		DetectionVersion: "2.4",
 		Description:      "Global model with 6522 species",
 		Spec:             ModelSpec{SampleRate: 48000, ClipLength: 3 * time.Second},
-		ConfigAliases:    []string{conf.ModelIDBirdNET},
+		// The primary alias (index 0) is the canonical form ConfigAliasForRegistry
+		// writes back; the hyphenated "birdnet-v2.4" mirrors the model catalog entry
+		// ID so a config that carries the catalog-style ID still validates and resolves.
+		ConfigAliases:    []string{conf.ModelIDBirdNET, "birdnet-v2.4"},
 		SupportedLocales: []string{"af", "ar", "bg", "ca", "cs", "da", "de", "el", "en-uk", "en-us", "es",
 			"et", "fi", "fr", "he", "hr", "hu", "id", "is", "it", "ja", "ko", "lt", "lv", "ml", "nl",
 			"no", "pl", "pt", "pt-br", "pt-pt", "ro", "ru", "sk", "sl", "sr", "sv", "th", "tr", "uk", "zh"},
@@ -159,7 +162,9 @@ var ModelRegistry = map[string]ModelInfo{
 		DetectionVersion: "3.0",
 		Description:      "BirdNET v3.0 model (32kHz, 5s clips, embeddings)", // NumSpecies omitted: determined at runtime from label file
 		Spec:             ModelSpec{SampleRate: 32000, ClipLength: 5 * time.Second},
-		ConfigAliases:    []string{conf.ModelIDBirdNETV3},
+		// Hyphenated "birdnet-v3.0" mirrors the catalog entry ID; the underscore
+		// primary stays canonical for write-back. See BirdNET v2.4 entry above.
+		ConfigAliases:    []string{conf.ModelIDBirdNETV3, "birdnet-v3.0"},
 		SupportedLocales: []string{"af", "ar", "bg", "ca", "cs", "da", "de", "el", "en-uk", "en-us", "es",
 			"et", "fi", "fr", "he", "hr", "hu", "id", "is", "it", "ja", "ko", "lt", "lv", "ml", "nl",
 			"no", "pl", "pt", "pt-br", "pt-pt", "ro", "ru", "sk", "sl", "sr", "sv", "th", "tr", "uk", "zh"},
@@ -173,7 +178,10 @@ var ModelRegistry = map[string]ModelInfo{
 		DetectionVersion: "V2",
 		Description:      "Perch v2 multi-taxa model with ~14,795 species including birds, insects, amphibians, and mammals (scientific names only)",
 		Spec:             ModelSpec{SampleRate: 32000, ClipLength: 5 * time.Second},
-		ConfigAliases:    []string{conf.ModelIDPerchV2},
+		// Hyphenated "perch-v2" mirrors the catalog entry ID; the underscore primary
+		// stays canonical for write-back. Reported via Sentry (BIRDNET-GO-2FZ), where
+		// a config carried "perch-v2" and was rejected as an unknown model ID.
+		ConfigAliases:    []string{conf.ModelIDPerchV2, "perch-v2"},
 		NumSpecies:       14795,
 	},
 	RegistryIDBat: {

--- a/internal/classifier/model_registry_test.go
+++ b/internal/classifier/model_registry_test.go
@@ -333,6 +333,23 @@ func TestKnownConfigIDs_AllModels(t *testing.T) {
 	assert.True(t, ids["bat"], "bat config ID should be known")
 	assert.True(t, ids["bsg"], "bsg config ID should be known")
 	assert.False(t, ids["unknown"], "unknown config ID should not be known")
+
+	// Hyphenated catalog-style IDs are accepted as secondary aliases so a config
+	// carrying the catalog entry ID does not trip an "unknown model ID" warning.
+	assert.True(t, ids["perch-v2"], "perch-v2 catalog-style ID should be known")
+	assert.True(t, ids["birdnet-v3.0"], "birdnet-v3.0 catalog-style ID should be known")
+	assert.True(t, ids["birdnet-v2.4"], "birdnet-v2.4 catalog-style ID should be known")
+}
+
+func TestConfigAliasForRegistry_ReturnsCanonicalPrimary(t *testing.T) {
+	t.Parallel()
+
+	// The write-back alias must stay the canonical underscore form even though the
+	// hyphenated catalog ID is an accepted secondary alias, so ScanInstalled never
+	// rewrites models.enabled to the catalog-style spelling.
+	assert.Equal(t, "perch_v2", ConfigAliasForRegistry(RegistryIDPerchV2))
+	assert.Equal(t, "birdnet_v3.0", ConfigAliasForRegistry(RegistryIDBirdNETV3))
+	assert.Equal(t, "birdnet", ConfigAliasForRegistry("BirdNET_V2.4"))
 }
 
 func TestResolveConfigModelID_AllModels(t *testing.T) {
@@ -351,6 +368,9 @@ func TestResolveConfigModelID_AllModels(t *testing.T) {
 		{"bsg resolves", "bsg", RegistryIDBSG, true},
 		{"case insensitive bat", "BAT", RegistryIDBat, true},
 		{"case insensitive bsg", "BSG", RegistryIDBSG, true},
+		{"perch-v2 catalog id resolves", "perch-v2", RegistryIDPerchV2, true},
+		{"birdnet-v3.0 catalog id resolves", "birdnet-v3.0", RegistryIDBirdNETV3, true},
+		{"birdnet-v2.4 catalog id resolves", "birdnet-v2.4", "BirdNET_V2.4", true},
 		{"unknown returns false", "nonexistent", "", false},
 	}
 

--- a/internal/classifier/model_registry_test.go
+++ b/internal/classifier/model_registry_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/detection"
 )
 
@@ -339,6 +340,30 @@ func TestKnownConfigIDs_AllModels(t *testing.T) {
 	assert.True(t, ids["perch-v2"], "perch-v2 catalog-style ID should be known")
 	assert.True(t, ids["birdnet-v3.0"], "birdnet-v3.0 catalog-style ID should be known")
 	assert.True(t, ids["birdnet-v2.4"], "birdnet-v2.4 catalog-style ID should be known")
+	assert.True(t, ids["bsg-finland"], "bsg-finland catalog-style ID should be known")
+}
+
+// TestKnownConfigIDs_MatchesConfValidAudioModels is a drift guard. conf.ValidAudioModels
+// (and the applyModelValidation fallback set it mirrors) is hand-maintained because the
+// conf package cannot import classifier. If a future registry alias is added without
+// updating the conf-side maps, "perch-v2"-style IDs would validate in one path and be
+// rejected in another. This test fails when the two sets diverge, forcing both to move
+// together. The empty-string default is ValidAudioModels-only and excluded.
+func TestKnownConfigIDs_MatchesConfValidAudioModels(t *testing.T) {
+	t.Parallel()
+
+	known := KnownConfigIDs()
+	for id := range known {
+		assert.True(t, conf.ValidAudioModels[id],
+			"config ID %q is in classifier.KnownConfigIDs() but missing from conf.ValidAudioModels", id)
+	}
+	for id := range conf.ValidAudioModels {
+		if id == "" {
+			continue // ValidAudioModels-only sentinel for the default model
+		}
+		assert.True(t, known[id],
+			"config ID %q is in conf.ValidAudioModels but missing from classifier.KnownConfigIDs()", id)
+	}
 }
 
 func TestConfigAliasForRegistry_ReturnsCanonicalPrimary(t *testing.T) {
@@ -350,6 +375,7 @@ func TestConfigAliasForRegistry_ReturnsCanonicalPrimary(t *testing.T) {
 	assert.Equal(t, "perch_v2", ConfigAliasForRegistry(RegistryIDPerchV2))
 	assert.Equal(t, "birdnet_v3.0", ConfigAliasForRegistry(RegistryIDBirdNETV3))
 	assert.Equal(t, "birdnet", ConfigAliasForRegistry("BirdNET_V2.4"))
+	assert.Equal(t, "bsg", ConfigAliasForRegistry(RegistryIDBSG))
 }
 
 func TestResolveConfigModelID_AllModels(t *testing.T) {
@@ -371,6 +397,7 @@ func TestResolveConfigModelID_AllModels(t *testing.T) {
 		{"perch-v2 catalog id resolves", "perch-v2", RegistryIDPerchV2, true},
 		{"birdnet-v3.0 catalog id resolves", "birdnet-v3.0", RegistryIDBirdNETV3, true},
 		{"birdnet-v2.4 catalog id resolves", "birdnet-v2.4", "BirdNET_V2.4", true},
+		{"bsg-finland catalog id resolves", "bsg-finland", RegistryIDBSG, true},
 		{"unknown returns false", "nonexistent", "", false},
 	}
 

--- a/internal/classifier/perch.go
+++ b/internal/classifier/perch.go
@@ -17,6 +17,9 @@ const perchDatasetMarker = "inat2024_fsd50k"
 // Empty lines are skipped. Returns the list of scientific names.
 func ParsePerchLabels(data []byte) ([]string, error) {
 	scanner := bufio.NewScanner(bytes.NewReader(data))
+	// Grow past bufio's default 64 KiB line cap so an overlong or newline-free
+	// label file does not fail with "bufio.Scanner: token too long".
+	scanner.Buffer(make([]byte, 0, labelScannerInitialBufBytes), labelScannerMaxLineBytes)
 	var labels []string
 	firstLine := true
 

--- a/internal/classifier/perch_test.go
+++ b/internal/classifier/perch_test.go
@@ -40,7 +40,7 @@ func TestParsePerchLabels_EmptyInput(t *testing.T) {
 func TestParsePerchLabels_HeaderOnly(t *testing.T) {
 	t.Parallel()
 
-	labels, err := ParsePerchLabels([]byte("inat2024_fsd50k\n"))
+	labels, err := ParsePerchLabels([]byte(perchDatasetMarker + "\n"))
 	require.NoError(t, err)
 	assert.Empty(t, labels)
 }
@@ -55,7 +55,7 @@ func TestParsePerchLabels_LongLine(t *testing.T) {
 
 	// A label line comfortably larger than bufio's default 64 KiB cap.
 	longLabel := strings.Repeat("A", 70*1024)
-	input := "inat2024_fsd50k\n" + longLabel + "\nAcanthis flammea\n"
+	input := perchDatasetMarker + "\n" + longLabel + "\nAcanthis flammea\n"
 
 	labels, err := ParsePerchLabels([]byte(input))
 	require.NoError(t, err, "scanner buffer must accommodate lines beyond the 64 KiB default")

--- a/internal/classifier/perch_test.go
+++ b/internal/classifier/perch_test.go
@@ -1,6 +1,7 @@
 package classifier
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,4 +43,23 @@ func TestParsePerchLabels_HeaderOnly(t *testing.T) {
 	labels, err := ParsePerchLabels([]byte("inat2024_fsd50k\n"))
 	require.NoError(t, err)
 	assert.Empty(t, labels)
+}
+
+// TestParsePerchLabels_LongLine guards against the default bufio.Scanner 64 KiB
+// token cap: a label file with a line longer than that (or effectively no line
+// breaks) previously failed with "bufio.Scanner: token too long" (Sentry
+// BIRDNET-GO-2FF). The scanner buffer is grown to labelScannerMaxLineBytes so a
+// single line up to 1 MiB parses without error.
+func TestParsePerchLabels_LongLine(t *testing.T) {
+	t.Parallel()
+
+	// A label line comfortably larger than bufio's default 64 KiB cap.
+	longLabel := strings.Repeat("A", 70*1024)
+	input := "inat2024_fsd50k\n" + longLabel + "\nAcanthis flammea\n"
+
+	labels, err := ParsePerchLabels([]byte(input))
+	require.NoError(t, err, "scanner buffer must accommodate lines beyond the 64 KiB default")
+	require.Len(t, labels, 2)
+	assert.Equal(t, longLabel, labels[0])
+	assert.Equal(t, "Acanthis flammea", labels[1])
 }

--- a/internal/classifier/perch_test.go
+++ b/internal/classifier/perch_test.go
@@ -8,6 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// longLabelTestBytes is a label-line length comfortably past bufio's default
+// 64 KiB token cap, used by the label-scanner regression tests in this package.
+const longLabelTestBytes = 70 * 1024
+
 func TestParsePerchLabels(t *testing.T) {
 	t.Parallel()
 
@@ -54,7 +58,7 @@ func TestParsePerchLabels_LongLine(t *testing.T) {
 	t.Parallel()
 
 	// A label line comfortably larger than bufio's default 64 KiB cap.
-	longLabel := strings.Repeat("A", 70*1024)
+	longLabel := strings.Repeat("A", longLabelTestBytes)
 	input := perchDatasetMarker + "\n" + longLabel + "\nAcanthis flammea\n"
 
 	labels, err := ParsePerchLabels([]byte(input))
@@ -62,4 +66,22 @@ func TestParsePerchLabels_LongLine(t *testing.T) {
 	require.Len(t, labels, 2)
 	assert.Equal(t, longLabel, labels[0])
 	assert.Equal(t, "Acanthis flammea", labels[1])
+}
+
+// TestParsePerchLabels_MaxLengthLine verifies a label of exactly the supported
+// maxLabelLineBytes parses for every line terminator. bufio.Scanner needs its
+// token cap strictly above the longest token, so labelScannerMaxLineBytes is
+// maxLabelLineBytes+2; without that reserve a full-length line fails with
+// "token too long" (regression guard for the scanner-limit boundary).
+func TestParsePerchLabels_MaxLengthLine(t *testing.T) {
+	t.Parallel()
+
+	maxLabel := strings.Repeat("A", maxLabelLineBytes)
+	for _, term := range []string{"", "\n", "\r\n"} {
+		input := perchDatasetMarker + "\n" + maxLabel + term
+		labels, err := ParsePerchLabels([]byte(input))
+		require.NoError(t, err, "a maxLabelLineBytes line with terminator %q must parse", term)
+		require.Len(t, labels, 1)
+		assert.Equal(t, maxLabel, labels[0])
+	}
 }

--- a/internal/conf/consts.go
+++ b/internal/conf/consts.go
@@ -20,6 +20,7 @@ const (
 	ModelIDBirdNETCatalog   = "birdnet-v2.4"
 	ModelIDBirdNETV3Catalog = "birdnet-v3.0"
 	ModelIDPerchV2Catalog   = "perch-v2"
+	ModelIDBSGCatalog       = "bsg-finland"
 
 	SampleRate     = 48000 // Sample rate of the audio fed to BirdNET Analyzer
 	BitDepth       = 16    // Bit depth of the audio fed to BirdNET Analyzer

--- a/internal/conf/consts.go
+++ b/internal/conf/consts.go
@@ -11,6 +11,16 @@ const (
 	ModelIDBat       = "bat"
 	ModelIDBSG       = "bsg"
 
+	// Catalog-style model IDs mirror the hyphenated model *catalog* entry IDs
+	// (classifier/model_catalog.go) and are accepted as aliases for the canonical
+	// underscore IDs above, so a config that carries the catalog-style spelling
+	// still validates. Keep in sync with the secondary ConfigAliases in
+	// classifier/model_registry.go. See Sentry BIRDNET-GO-2FZ (a config with
+	// "perch-v2" was rejected as an unknown model ID).
+	ModelIDBirdNETCatalog   = "birdnet-v2.4"
+	ModelIDBirdNETV3Catalog = "birdnet-v3.0"
+	ModelIDPerchV2Catalog   = "perch-v2"
+
 	SampleRate     = 48000 // Sample rate of the audio fed to BirdNET Analyzer
 	BitDepth       = 16    // Bit depth of the audio fed to BirdNET Analyzer
 	NumChannels    = 1     // Number of channels of the audio fed to BirdNET Analyzer

--- a/internal/conf/migrations.go
+++ b/internal/conf/migrations.go
@@ -399,6 +399,96 @@ func normalizeRTSPStreamEnabledDefaults(rawStreams any) ([]any, bool) {
 	return normalized, true
 }
 
+// catalogModelIDAliases maps a hyphenated model *catalog* entry ID
+// (classifier/model_catalog.go) to its canonical config-level ID. Keys are
+// lowercase for case-insensitive matching. Bat is intentionally absent: it has
+// many regional catalog IDs mapping to one registry entry, so there is no
+// single canonical spelling to normalize toward.
+var catalogModelIDAliases = map[string]string{
+	ModelIDBirdNETCatalog:   ModelIDBirdNET,
+	ModelIDBirdNETV3Catalog: ModelIDBirdNETV3,
+	ModelIDPerchV2Catalog:   ModelIDPerchV2,
+	ModelIDBSGCatalog:       ModelIDBSG,
+}
+
+// canonicalizeModelID returns the canonical config ID for a catalog-style
+// (hyphenated) model ID, or the input unchanged when it is not an alias.
+// Matching is case-insensitive; the returned canonical form preserves the
+// registry's own casing.
+func canonicalizeModelID(id string) string {
+	if canonical, ok := catalogModelIDAliases[strings.ToLower(id)]; ok {
+		return canonical
+	}
+	return id
+}
+
+// normalizeModelIDList rewrites catalog-style model IDs to their canonical form
+// and drops any case-insensitive duplicate that the rewrite (or a pre-existing
+// mixed-spelling config) produced, preserving first-seen order. Returns the
+// normalized slice and whether anything changed.
+func normalizeModelIDList(ids []string) ([]string, bool) {
+	if len(ids) == 0 {
+		return ids, false
+	}
+	out := make([]string, 0, len(ids))
+	seen := make(map[string]bool, len(ids))
+	changed := false
+	for _, id := range ids {
+		canonical := canonicalizeModelID(id)
+		if canonical != id {
+			changed = true
+		}
+		key := strings.ToLower(canonical)
+		if seen[key] {
+			changed = true // a duplicate was collapsed
+			continue
+		}
+		seen[key] = true
+		out = append(out, canonical)
+	}
+	return out, changed
+}
+
+// MigrateModelIDAliases canonicalizes catalog-style (hyphenated) model IDs in
+// models.enabled and in every source/stream model list to their underscore/
+// short config IDs. A user who hand-edits a config with the catalog spelling
+// (e.g. "perch-v2") is otherwise left with an entry that validation and
+// resolution accept as an alias but that model install/uninstall bookkeeping
+// (which keys on the canonical alias) would duplicate on install and fail to
+// remove on uninstall. Normalizing at load keeps a single canonical spelling
+// persisted so that lifecycle code stays consistent. Returns true if any value
+// changed. See Sentry BIRDNET-GO-2FZ.
+func (s *Settings) MigrateModelIDAliases() bool {
+	changed := false
+
+	if normalized, did := normalizeModelIDList(s.Models.Enabled); did {
+		s.Models.Enabled = normalized
+		changed = true
+	}
+
+	for i := range s.Realtime.Audio.Sources {
+		src := &s.Realtime.Audio.Sources[i]
+		if canonical := canonicalizeModelID(src.Model); canonical != src.Model {
+			src.Model = canonical
+			changed = true
+		}
+		if normalized, did := normalizeModelIDList(src.Models); did {
+			src.Models = normalized
+			changed = true
+		}
+	}
+
+	for i := range s.Realtime.RTSP.Streams {
+		stream := &s.Realtime.RTSP.Streams[i]
+		if normalized, did := normalizeModelIDList(stream.Models); did {
+			stream.Models = normalized
+			changed = true
+		}
+	}
+
+	return changed
+}
+
 // ValidateModelConfig checks model-related configuration for errors and
 // warnings. Returns a slice of warning/error strings. Fatal errors are
 // prefixed with "error:"; non-fatal issues with "warning:".
@@ -450,16 +540,15 @@ func (s *Settings) ValidateModelConfig(knownIDs map[string]bool, checkSourceRefs
 // errors are collected and returned together so the user can fix them in
 // one pass.
 func (s *Settings) applyModelValidation() error {
-	// Default known IDs - matches classifier.KnownConfigIDs() at compile time.
-	// This fallback is used during config loading before the classifier package
-	// is available. The orchestrator re-validates with the authoritative list.
-	// Includes the hyphenated catalog-style aliases (see consts.go) so a config
-	// carrying a catalog ID does not warn on the early-load path.
-	knownIDs := map[string]bool{
-		ModelIDBirdNET: true, ModelIDBirdNETV3: true, ModelIDPerchV2: true, ModelIDBat: true, ModelIDBSG: true,
-		ModelIDBirdNETCatalog: true, ModelIDBirdNETV3Catalog: true, ModelIDPerchV2Catalog: true,
-	}
-	modelIssues := s.ValidateModelConfig(knownIDs, false)
+	// Fallback known-ID set used during config loading before the classifier
+	// package is available; the orchestrator re-validates with the authoritative
+	// classifier.KnownConfigIDs() later. Reuse ValidAudioModels (the same
+	// canonical + catalog-alias set, kept in lockstep with the registry by
+	// TestKnownConfigIDs_MatchesConfValidAudioModels) rather than hand-maintaining
+	// a third copy that could drift. The extra "" default key is harmless here
+	// because models.enabled never contains an empty entry. ValidateModelConfig
+	// only reads the map.
+	modelIssues := s.ValidateModelConfig(ValidAudioModels, false)
 	var fatalErrors []string
 	for _, issue := range modelIssues {
 		if strings.HasPrefix(issue, "error:") {

--- a/internal/conf/migrations.go
+++ b/internal/conf/migrations.go
@@ -453,7 +453,12 @@ func (s *Settings) applyModelValidation() error {
 	// Default known IDs - matches classifier.KnownConfigIDs() at compile time.
 	// This fallback is used during config loading before the classifier package
 	// is available. The orchestrator re-validates with the authoritative list.
-	knownIDs := map[string]bool{ModelIDBirdNET: true, ModelIDBirdNETV3: true, ModelIDPerchV2: true, ModelIDBat: true, ModelIDBSG: true}
+	// Includes the hyphenated catalog-style aliases (see consts.go) so a config
+	// carrying a catalog ID does not warn on the early-load path.
+	knownIDs := map[string]bool{
+		ModelIDBirdNET: true, ModelIDBirdNETV3: true, ModelIDPerchV2: true, ModelIDBat: true, ModelIDBSG: true,
+		ModelIDBirdNETCatalog: true, ModelIDBirdNETV3Catalog: true, ModelIDPerchV2Catalog: true,
+	}
 	modelIssues := s.ValidateModelConfig(knownIDs, false)
 	var fatalErrors []string
 	for _, issue := range modelIssues {

--- a/internal/conf/multi_model_config_test.go
+++ b/internal/conf/multi_model_config_test.go
@@ -127,6 +127,29 @@ func TestValidateModelConfig_SkipSourceRefsAtEarlyLoading(t *testing.T) {
 	assert.Empty(t, warnings, "source reference checks should be skipped when checkSourceRefs is false")
 }
 
+func TestApplyModelValidation_AcceptsCatalogAliases(t *testing.T) {
+	t.Parallel()
+
+	// A config carrying the hyphenated catalog-style model IDs must validate on
+	// the early-load path without an "unknown model ID" warning. Regression for
+	// Sentry BIRDNET-GO-2FZ.
+	settings := &Settings{}
+	settings.Models.Enabled = []string{"birdnet", "perch-v2", "birdnet-v3.0", "birdnet-v2.4"}
+
+	err := settings.applyModelValidation()
+	require.NoError(t, err)
+	assert.Empty(t, settings.ValidationWarnings, "catalog-style model IDs should not warn")
+}
+
+func TestValidAudioModels_AcceptsCatalogAliases(t *testing.T) {
+	t.Parallel()
+
+	// A per-source model set to a hyphenated catalog ID must not fail startup.
+	assert.True(t, ValidAudioModels["perch-v2"])
+	assert.True(t, ValidAudioModels["birdnet-v3.0"])
+	assert.True(t, ValidAudioModels["birdnet-v2.4"])
+}
+
 func TestBirdNETConfig_VersionField(t *testing.T) {
 	t.Parallel()
 	settings := &Settings{}

--- a/internal/conf/multi_model_config_test.go
+++ b/internal/conf/multi_model_config_test.go
@@ -150,6 +150,52 @@ func TestValidAudioModels_AcceptsCatalogAliases(t *testing.T) {
 	assert.True(t, ValidAudioModels["birdnet-v2.4"])
 }
 
+func TestMigrateModelIDAliases_CanonicalizesCatalogIDs(t *testing.T) {
+	t.Parallel()
+
+	settings := &Settings{}
+	settings.Models.Enabled = []string{"birdnet", "perch-v2", "birdnet-v3.0"}
+	settings.Realtime.Audio.Sources = []AudioSourceConfig{
+		{Name: "Mic1", Model: "perch-v2", Models: []string{"birdnet-v2.4", "bsg-finland"}},
+	}
+	settings.Realtime.RTSP.Streams = []StreamConfig{
+		{URL: "rtsp://x", Models: []string{"perch-v2"}},
+	}
+
+	changed := settings.MigrateModelIDAliases()
+	require.True(t, changed, "catalog-style IDs should be normalized")
+
+	assert.Equal(t, []string{"birdnet", "perch_v2", "birdnet_v3.0"}, settings.Models.Enabled)
+	assert.Equal(t, "perch_v2", settings.Realtime.Audio.Sources[0].Model)
+	assert.Equal(t, []string{"birdnet", "bsg"}, settings.Realtime.Audio.Sources[0].Models)
+	assert.Equal(t, []string{"perch_v2"}, settings.Realtime.RTSP.Streams[0].Models)
+
+	// Idempotent: a second pass over already-canonical config changes nothing.
+	assert.False(t, settings.MigrateModelIDAliases(), "normalized config should be a no-op")
+}
+
+func TestMigrateModelIDAliases_CollapsesMixedSpellingDuplicates(t *testing.T) {
+	t.Parallel()
+
+	settings := &Settings{}
+	// Both spellings of the same model, plus a case variant, collapse to one canonical entry.
+	settings.Models.Enabled = []string{"perch-v2", "perch_v2", "PERCH-V2", "birdnet"}
+
+	changed := settings.MigrateModelIDAliases()
+	require.True(t, changed)
+	assert.Equal(t, []string{"perch_v2", "birdnet"}, settings.Models.Enabled)
+}
+
+func TestMigrateModelIDAliases_NoChangeForCanonicalConfig(t *testing.T) {
+	t.Parallel()
+
+	settings := &Settings{}
+	settings.Models.Enabled = []string{"birdnet", "perch_v2"}
+	settings.Realtime.Audio.Sources = []AudioSourceConfig{{Name: "Mic1", Models: []string{"birdnet"}}}
+
+	assert.False(t, settings.MigrateModelIDAliases(), "already-canonical config must not report a change")
+}
+
 func TestBirdNETConfig_VersionField(t *testing.T) {
 	t.Parallel()
 	settings := &Settings{}

--- a/internal/conf/storage.go
+++ b/internal/conf/storage.go
@@ -123,6 +123,14 @@ func Load() (*Settings, error) {
 		persistMigration(settings, "stream enabled defaults")
 	}
 
+	// Canonicalize catalog-style model IDs (e.g. "perch-v2" -> "perch_v2") so a
+	// hand-edited config persists a single canonical spelling and model
+	// install/uninstall bookkeeping stays consistent. Runs before validation so
+	// the normalized IDs are what gets checked.
+	if settings.MigrateModelIDAliases() {
+		persistMigration(settings, "model ID aliases")
+	}
+
 	// Validate multi-model configuration
 	if err := settings.applyModelValidation(); err != nil {
 		return nil, err

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -73,6 +73,11 @@ var ValidAudioModels = map[string]bool{
 	ModelIDPerchV2:   true,
 	ModelIDBat:       true,
 	ModelIDBSG:       true,
+	// Catalog-style aliases (see consts.go) so a source model set to the
+	// hyphenated catalog ID validates rather than failing startup.
+	ModelIDBirdNETCatalog:   true,
+	ModelIDBirdNETV3Catalog: true,
+	ModelIDPerchV2Catalog:   true,
 }
 
 // ValidationError is the set of fatal validation findings produced by

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -78,6 +78,7 @@ var ValidAudioModels = map[string]bool{
 	ModelIDBirdNETCatalog:   true,
 	ModelIDBirdNETV3Catalog: true,
 	ModelIDPerchV2Catalog:   true,
+	ModelIDBSGCatalog:       true,
 }
 
 // ValidationError is the set of fatal validation findings produced by

--- a/internal/datastore/analytics.go
+++ b/internal/datastore/analytics.go
@@ -249,8 +249,8 @@ func (ds *DataStore) GetSpeciesSummaryData(ctx context.Context, startDate, endDa
 			COUNT(*) as count,
 			MIN(%s) as first_seen,
 			MAX(%s) as last_seen,
-			AVG(notes.confidence) as avg_confidence,
-			MAX(notes.confidence) as max_confidence
+			COALESCE(AVG(notes.confidence), 0) as avg_confidence,
+			COALESCE(MAX(notes.confidence), 0) as max_confidence
 		FROM notes
 		LEFT JOIN note_reviews ON notes.id = note_reviews.note_id
 	`, dateTimeFormat, dateTimeFormat)

--- a/internal/datastore/analytics_test.go
+++ b/internal/datastore/analytics_test.go
@@ -286,6 +286,49 @@ func TestGetSpeciesSummaryData(t *testing.T) {
 		assert.Empty(t, nsCommon.CommonName, "NULL common_name should be converted to empty string")
 		assert.Equal(t, "nulcom", nsCommon.SpeciesCode)
 	})
+
+	t.Run("NULL confidence handling", func(t *testing.T) {
+		t.Parallel()
+		ds := setupTestDB(t)
+
+		// A species whose only detection has a NULL confidence makes AVG()/MAX()
+		// return NULL for that GROUP BY group. Scanning NULL into a plain float64
+		// fails with "converting NULL to float64 is unsupported", which aborts the
+		// entire summary, not just the affected species. Regression test for the
+		// avg_confidence/max_confidence COALESCE guard.
+		result := ds.DB.Exec(`
+			INSERT INTO notes (date, time, scientific_name, common_name, species_code, confidence)
+			VALUES (?, ?, ?, ?, ?, NULL)
+		`, "2024-01-22", "10:00:00", "Nullus confidencia", "Null Confidence Bird", "nulcon")
+		require.NoError(t, result.Error)
+
+		// A normal note with real confidence alongside it.
+		err := ds.DB.Create(&Note{
+			Date:           "2024-01-22",
+			Time:           "11:00:00",
+			ScientificName: "Normal species",
+			CommonName:     "Normal Bird",
+			SpeciesCode:    "norbird",
+			Confidence:     0.85,
+		}).Error
+		require.NoError(t, err)
+
+		summaries, err := ds.GetSpeciesSummaryData(t.Context(), "", "")
+		require.NoError(t, err, "Query should handle NULL confidence without error")
+		require.Len(t, summaries, 2)
+
+		nullConf := findSpeciesByScientificName(summaries, "Nullus confidencia")
+		require.NotNil(t, nullConf)
+		assert.Equal(t, 1, nullConf.Count)
+		assert.InDelta(t, 0.0, nullConf.AvgConfidence, 0.001, "NULL avg_confidence should default to 0")
+		assert.InDelta(t, 0.0, nullConf.MaxConfidence, 0.001, "NULL max_confidence should default to 0")
+
+		// The normal species must still report its real values.
+		normal := findSpeciesByScientificName(summaries, "Normal species")
+		require.NotNil(t, normal)
+		assert.InDelta(t, 0.85, normal.AvgConfidence, 0.001)
+		assert.InDelta(t, 0.85, normal.MaxConfidence, 0.001)
+	})
 }
 
 // TestGetSpeciesSummaryDataTimeFormat tests that the time parsing works correctly

--- a/internal/inference/onnx/labels.go
+++ b/internal/inference/onnx/labels.go
@@ -46,8 +46,15 @@ func loadLabelsFromBytes(data []byte, ext string) ([]string, error) {
 // (Sentry BIRDNET-GO-2FF). Defined locally because the onnx package must not
 // import the classifier package where the sibling constants live.
 const (
-	labelScannerInitialBufBytes = 64 * 1024   // initial scan buffer (64 KiB)
-	labelScannerMaxLineBytes    = 1024 * 1024 // max label line length (1 MiB)
+	// maxLabelLineBytes is the largest label line we support (1 MiB).
+	maxLabelLineBytes           = 1024 * 1024
+	labelScannerInitialBufBytes = 64 * 1024 // initial scan buffer (64 KiB)
+	// labelScannerMaxLineBytes is the bufio.Scanner token cap, maxLabelLineBytes
+	// + 2 because Scanner needs its max strictly greater than the longest token
+	// (it must read past the line, or hit EOF, to terminate it): a line of
+	// exactly maxLabelLineBytes, with or without a CR/LF terminator, otherwise
+	// fails with "bufio.Scanner: token too long".
+	labelScannerMaxLineBytes = maxLabelLineBytes + 2
 )
 
 func loadLabelsText(data []byte) ([]string, error) {

--- a/internal/inference/onnx/labels.go
+++ b/internal/inference/onnx/labels.go
@@ -40,9 +40,20 @@ func loadLabelsFromBytes(data []byte, ext string) ([]string, error) {
 	}
 }
 
+// Label scanner buffer sizes. A label line is short ("SciName_CommonName"),
+// but the buffer is grown past bufio's default 64 KiB token cap so an overlong
+// or newline-free label file does not fail with "bufio.Scanner: token too long"
+// (Sentry BIRDNET-GO-2FF). Defined locally because the onnx package must not
+// import the classifier package where the sibling constants live.
+const (
+	labelScannerInitialBufBytes = 64 * 1024   // initial scan buffer (64 KiB)
+	labelScannerMaxLineBytes    = 1024 * 1024 // max label line length (1 MiB)
+)
+
 func loadLabelsText(data []byte) ([]string, error) {
 	var labels []string
 	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 0, labelScannerInitialBufBytes), labelScannerMaxLineBytes)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line != "" {

--- a/internal/inference/onnx/labels_test.go
+++ b/internal/inference/onnx/labels_test.go
@@ -1,0 +1,36 @@
+package onnx
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoadLabelsText_LongLine guards against the default bufio.Scanner 64 KiB
+// token cap: a plain-text label file with a line longer than that (or with no
+// line breaks) previously failed with "bufio.Scanner: token too long" (Sentry
+// BIRDNET-GO-2FF). The scanner buffer is grown to labelScannerMaxLineBytes so a
+// single line up to 1 MiB parses without error.
+func TestLoadLabelsText_LongLine(t *testing.T) {
+	t.Parallel()
+
+	longLabel := strings.Repeat("A", 70*1024) // comfortably past the 64 KiB default
+	input := []byte(longLabel + "\nTurdus migratorius_American Robin\n")
+
+	labels, err := loadLabelsText(input)
+	require.NoError(t, err, "scanner buffer must accommodate lines beyond the 64 KiB default")
+	require.Len(t, labels, 2)
+	assert.Equal(t, longLabel, labels[0])
+	assert.Equal(t, "Turdus migratorius_American Robin", labels[1])
+}
+
+// TestLoadLabelsText_SkipsBlankLines confirms normal parsing is unchanged.
+func TestLoadLabelsText_SkipsBlankLines(t *testing.T) {
+	t.Parallel()
+
+	labels, err := loadLabelsText([]byte("Turdus migratorius_American Robin\n\nCyanocitta cristata_Blue Jay\n"))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Turdus migratorius_American Robin", "Cyanocitta cristata_Blue Jay"}, labels)
+}

--- a/internal/inference/onnx/labels_test.go
+++ b/internal/inference/onnx/labels_test.go
@@ -8,6 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// longLabelTestBytes is a label-line length comfortably past bufio's default
+// 64 KiB token cap, used by the label-scanner regression tests.
+const longLabelTestBytes = 70 * 1024
+
 // TestLoadLabelsText_LongLine guards against the default bufio.Scanner 64 KiB
 // token cap: a plain-text label file with a line longer than that (or with no
 // line breaks) previously failed with "bufio.Scanner: token too long" (Sentry
@@ -16,7 +20,7 @@ import (
 func TestLoadLabelsText_LongLine(t *testing.T) {
 	t.Parallel()
 
-	longLabel := strings.Repeat("A", 70*1024) // comfortably past the 64 KiB default
+	longLabel := strings.Repeat("A", longLabelTestBytes) // comfortably past the 64 KiB default
 	input := []byte(longLabel + "\nTurdus migratorius_American Robin\n")
 
 	labels, err := loadLabelsText(input)
@@ -24,6 +28,23 @@ func TestLoadLabelsText_LongLine(t *testing.T) {
 	require.Len(t, labels, 2)
 	assert.Equal(t, longLabel, labels[0])
 	assert.Equal(t, "Turdus migratorius_American Robin", labels[1])
+}
+
+// TestLoadLabelsText_MaxLengthLine verifies a label of exactly the supported
+// maxLabelLineBytes parses for every line terminator. labelScannerMaxLineBytes
+// is maxLabelLineBytes+2 because bufio.Scanner needs its token cap strictly
+// above the longest token; without the reserve a full-length line fails with
+// "token too long" (regression guard for the scanner-limit boundary).
+func TestLoadLabelsText_MaxLengthLine(t *testing.T) {
+	t.Parallel()
+
+	maxLabel := strings.Repeat("A", maxLabelLineBytes)
+	for _, term := range []string{"", "\n", "\r\n"} {
+		labels, err := loadLabelsText([]byte(maxLabel + term))
+		require.NoError(t, err, "a maxLabelLineBytes line with terminator %q must parse", term)
+		require.Len(t, labels, 1)
+		assert.Equal(t, maxLabel, labels[0])
+	}
 }
 
 // TestLoadLabelsText_SkipsBlankLines confirms normal parsing is unchanged.


### PR DESCRIPTION
## Summary

Four independent bug fixes surfaced by Sentry telemetry triage, plus the follow-up hardening a pre-push review found on them.

**Species summary analytics crash on NULL confidence (BIRDNET-GO-2EN).** `GetSpeciesSummaryData` selected `AVG(notes.confidence)` and `MAX(notes.confidence)` into plain `float64` fields. When every detection in a `scientific_name` group has a NULL confidence, both aggregates return NULL and the scan fails with "converting NULL to float64 is unsupported", aborting the entire species summary rather than just the affected species. Both aggregates are now wrapped in `COALESCE(..., 0)`, matching the existing guards on `common_name` and `species_code`.

**Label loader crash on overlong lines (BIRDNET-GO-2FF).** Several label parsers read files with a default `bufio.Scanner`, whose 64 KiB token cap fails with "bufio.Scanner: token too long" on a label file with an overlong line or no line breaks. The BirdNET v3.0 parser already guarded against this; the same buffer is now applied to the three remaining classifier scanners and to the ONNX text-label parser (which parses the same label files).

**Browser-extension errors polluting frontend telemetry (BIRDNET-GO-2EM).** A Safari extension throwing an unhandled rejection in the page was captured by the frontend Sentry SDK and surfaced as a "TypeError ... shouldBeEnabled" issue whose functions and property names exist nowhere in the codebase (Safari masks such frames as `webkit-masked-url://`). A `beforeSend` filter now drops an event when it has stack frames and every frame originates from an extension scheme (`webkit-masked-url`, `chrome-extension`, `moz-extension`, `safari-extension`, `safari-web-extension`); an event with at least one app frame, or none at all, is kept.

**Catalog-style model IDs rejected and mishandled (BIRDNET-GO-2FZ).** The model catalog uses hyphenated entry IDs (`perch-v2`, `birdnet-v3.0`, `birdnet-v2.4`, `bsg-finland`) while the config-level model IDs use underscores or short names (`perch_v2`, `birdnet_v3.0`, `birdnet`, `bsg`). A config carrying the catalog spelling was rejected as an unknown model ID, and once accepted as an alias it would still be duplicated on model install and left dangling on uninstall, because install/uninstall bookkeeping keys on the canonical primary alias. The hyphenated forms are now accepted as secondary aliases (write-back stays canonical), and a new load-time migration canonicalizes them in `models.enabled` and every source/stream model list so a single canonical spelling persists and lifecycle bookkeeping stays consistent. Bat is intentionally excluded because its many regional catalog IDs map to one registry entry.

## Tests

Regression tests accompany every fix and were each verified to fail on the pre-fix code: the NULL-confidence summary, the overlong-line scanner guards (perch, external-label, and ONNX paths), all five extension-scheme prefixes for the telemetry filter, catalog-ID validation/resolution and canonical write-back, the alias-normalization migration (canonicalize, collapse mixed-spelling duplicates, no-op, idempotent), and a drift guard that fails if the registry alias set and the config-side validation set diverge.

## Preflight Status

- Single concern per fix; four related Sentry-triage fixes bundled into one PR by request.
- `go test -race` passes for datastore, classifier, conf, and inference/onnx.
- `golangci-lint` clean on all changed Go packages; `gofmt` clean.
- Frontend `npm run check:all` passes (typecheck, lint, format, ast-grep, 43 telemetry tests).
- No config/API/DB schema changes; the new config migration is additive and canonicalizes on load only.
- No user-facing regressions: the SQL fix turns a hard crash into a valid response, the alias acceptance only widens what validates, and the telemetry filter drops only non-app errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for catalog-style model identifiers, including hyphenated names, with automatic migration to canonical settings.
  - Improved compatibility with large or unusually formatted model label files.

- **Bug Fixes**
  - Prevented browser-extension-only errors from being sent to telemetry while preserving actionable application errors.
  - Species summaries now display zero confidence when no confidence data is available.
  - Improved handling of long, newline-free label entries across supported model formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->