### PR TITLE
Diagnostics for hard-to-reproduce storage, DB, and analytics bugs

### DIFF
--- a/internal/datastore/analytics.go
+++ b/internal/datastore/analytics.go
@@ -720,38 +720,19 @@ func (ds *DataStore) GetHourlyDistribution(ctx context.Context, startDate, endDa
 		}
 	}
 
-	// Prepare the SQL query - exclude detections marked as false_positive
-	query := ds.DB.WithContext(ctx).Table("notes").
-		Joins("LEFT JOIN note_reviews ON notes.id = note_reviews.note_id").
-		Where("(note_reviews.verified IS NULL OR note_reviews.verified != ?)", string(entities.VerificationFalsePositive))
-
 	// Extract hour from the time field using database-specific hour format
 	hourExpr := ds.GetHourFormat()
-	query = query.Select(fmt.Sprintf("%s AS hour, COUNT(*) AS count", hourExpr))
 
-	// Apply date range filter conditionally
-	switch {
-	case startDate != "" && endDate != "":
-		query = query.Where("notes.date BETWEEN ? AND ?", startDate, endDate)
-	case startDate != "":
-		query = query.Where("notes.date >= ?", startDate)
-	case endDate != "":
-		query = query.Where("notes.date <= ?", endDate)
-		// No date filter if both are empty
-	}
-
-	// Apply species filter if provided
-	if species != "" {
-		// Try to match on either common_name or scientific_name
-		query = query.Where("notes.common_name = ? OR notes.scientific_name = ?",
-			species, species)
-	}
-
-	// Group by hour
-	query = query.Group(hourExpr)
-
-	// Order by hour
-	query = query.Order("hour ASC")
+	// Build the filtered query (exclude false positives, optional date range and
+	// species) via the shared helper, then group by hour. The same helper feeds
+	// the emptiness self-check below, so the two filter sets cannot drift.
+	query := ds.applyHourlyDistributionFilters(
+		ds.DB.WithContext(ctx).Table("notes").
+			Joins("LEFT JOIN note_reviews ON notes.id = note_reviews.note_id"),
+		startDate, endDate, species).
+		Select(fmt.Sprintf("%s AS hour, COUNT(*) AS count", hourExpr)).
+		Group(hourExpr).
+		Order("hour ASC")
 
 	// Execute the query
 	var results []HourlyDistributionData
@@ -766,7 +747,80 @@ func (ds *DataStore) GetHourlyDistribution(ctx context.Context, startDate, endDa
 			Build()
 	}
 
+	// Invariant self-check for GitHub #3388 ("Detection Patterns by Time of Day"
+	// flat at zero despite data). The failure is not an empty result: GROUP BY
+	// always yields at least one bucket per matching row. It is that detections
+	// with an unparseable time column make the hour expression evaluate to NULL,
+	// so they collapse into a bogus bucket and the by-hour chart degenerates.
+	// When any data came back, count the rows whose hour could not be extracted
+	// and warn if there are any. Skipped entirely when there is genuinely no
+	// data, so a fresh install pays nothing.
+	if len(results) > 0 {
+		ds.warnIfHoursUnparseable(ctx, startDate, endDate, species, hourExpr)
+	}
+
 	return results, nil
+}
+
+// applyHourlyDistributionFilters applies the WHERE filters shared by the hourly
+// distribution aggregation and its emptiness self-check: exclude detections
+// marked as false positive, an optional inclusive date range, and an optional
+// species match on common or scientific name. Keeping both callers on one
+// helper means the self-check counts exactly the rows the aggregation groups.
+func (ds *DataStore) applyHourlyDistributionFilters(q *gorm.DB, startDate, endDate, species string) *gorm.DB {
+	q = q.Where("(note_reviews.verified IS NULL OR note_reviews.verified != ?)", string(entities.VerificationFalsePositive))
+
+	switch {
+	case startDate != "" && endDate != "":
+		q = q.Where("notes.date BETWEEN ? AND ?", startDate, endDate)
+	case startDate != "":
+		q = q.Where("notes.date >= ?", startDate)
+	case endDate != "":
+		q = q.Where("notes.date <= ?", endDate)
+		// No date filter if both are empty
+	}
+
+	if species != "" {
+		q = q.Where("notes.common_name = ? OR notes.scientific_name = ?", species, species)
+	}
+
+	return q
+}
+
+// warnIfHoursUnparseable counts matching detections whose hour could not be
+// extracted (the hour expression evaluates to NULL, e.g. an empty or malformed
+// time column) and emits a WARN when any exist. Those rows collapse into a
+// single bogus bucket and hollow out the by-hour chart (GitHub #3388); the WARN
+// puts the evidence and the count into default logs / a support dump without a
+// live reproduction. hourExpr is an internal constant from GetHourFormat (not
+// user input), so interpolating it into the predicate is safe. A count error is
+// logged at debug and swallowed: this diagnostic path must never mask the
+// (successful) primary result.
+func (ds *DataStore) warnIfHoursUnparseable(ctx context.Context, startDate, endDate, species, hourExpr string) {
+	if hourExpr == "" {
+		return // unsupported dialect; GetHourFormat already returns empty
+	}
+	var unparseable int64
+	countQuery := ds.applyHourlyDistributionFilters(
+		ds.DB.WithContext(ctx).Table("notes").
+			Joins("LEFT JOIN note_reviews ON notes.id = note_reviews.note_id"),
+		startDate, endDate, species).
+		Where(fmt.Sprintf("%s IS NULL", hourExpr))
+	if err := countQuery.Count(&unparseable).Error; err != nil {
+		GetLogger().Debug("hourly distribution self-check count failed",
+			logger.String("operation", "get_hourly_distribution"),
+			logger.Error(err))
+		return
+	}
+	if unparseable > 0 {
+		GetLogger().Warn("hourly distribution: detections have an unparseable time and were excluded from the by-hour chart; the time column may be malformed (GitHub #3388)",
+			logger.String("operation", "get_hourly_distribution"),
+			logger.String("hour_expr", hourExpr),
+			logger.Int64("unparseable_time_rows", unparseable),
+			logger.String("start_date", startDate),
+			logger.String("end_date", endDate),
+			logger.String("species", species))
+	}
 }
 
 // GetSpeciesFirstDetectionInPeriod finds the first detection of each species within a specific date range.

--- a/internal/datastore/analytics_invariant_test.go
+++ b/internal/datastore/analytics_invariant_test.go
@@ -97,10 +97,13 @@ func TestHourlyDistributionUnparseableTimeSelfCheck(t *testing.T) {
 		seedHourlyDetection(t, ds, "08:30:00")
 		seedHourlyDetection(t, ds, "21:15:00")
 
+		var results []HourlyDistributionData
 		out := captureDatastoreLogs(t, func() {
-			_, err := ds.GetHourlyDistribution(t.Context(), "", "", "")
+			var err error
+			results, err = ds.GetHourlyDistribution(t.Context(), "", "", "")
 			require.NoError(t, err)
 		})
+		require.NotEmpty(t, results, "well-formed times must produce buckets, so the check actually runs")
 		assert.NotContains(t, out, hourlyUnparseableMsg,
 			"well-formed times must not warn")
 	})

--- a/internal/datastore/analytics_invariant_test.go
+++ b/internal/datastore/analytics_invariant_test.go
@@ -1,0 +1,121 @@
+// analytics_invariant_test.go: tests for the hourly-distribution
+// unparseable-time self-check (GitHub #3388).
+package datastore
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// captureDatastoreLogs swaps in a process-global logger that writes to a
+// buffer, runs fn, restores the previous global, and returns what was logged.
+func captureDatastoreLogs(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	cfg := &logger.LoggingConfig{
+		DefaultLevel: "debug",
+		Console:      &logger.ConsoleOutput{Enabled: false},
+		FileOutput:   &logger.FileOutput{Enabled: false},
+	}
+	cl, err := logger.NewCentralLogger(cfg, handler)
+	require.NoError(t, err, "failed to create test logger")
+
+	oldGlobal := logger.Global()
+	logger.SetGlobal(cl)
+	t.Cleanup(func() { logger.SetGlobal(oldGlobal) })
+
+	fn()
+	return buf.String()
+}
+
+const hourlyUnparseableMsg = "detections have an unparseable time and were excluded from the by-hour chart"
+
+// seedHourlyDetection inserts a detection with the given time value (which may
+// be empty or malformed to exercise the unparseable-time path).
+func seedHourlyDetection(t *testing.T, ds *DataStore, timeVal string) {
+	t.Helper()
+	require.NoError(t, ds.DB.Create(&Note{
+		Date:           "2024-07-15",
+		Time:           timeVal,
+		ScientificName: "Turdus migratorius",
+		CommonName:     "American Robin",
+		Confidence:     0.9,
+	}).Error)
+}
+
+// TestHourlyDistributionUnparseableTimeSelfCheck covers the #3388 invariant: the
+// WARN fires only when matching detections have a time the hour expression
+// cannot parse (NULL hour), and stays silent for well-formed times or an empty
+// database. It goes through the real GetHourlyDistribution entry point so the
+// trigger path (aggregation returns a bucket, but some rows are NULL-hour) is
+// exercised, not just the helper in isolation.
+func TestHourlyDistributionUnparseableTimeSelfCheck(t *testing.T) {
+	// Not parallel: captureDatastoreLogs swaps the process-global logger.
+
+	t.Run("warns when some detections have an unparseable time", func(t *testing.T) {
+		ds := setupTestDB(t)
+		seedHourlyDetection(t, ds, "08:30:00") // valid
+		seedHourlyDetection(t, ds, "")         // empty -> strftime NULL
+		seedHourlyDetection(t, ds, "garbage")  // malformed -> strftime NULL
+
+		var results []HourlyDistributionData
+		out := captureDatastoreLogs(t, func() {
+			var err error
+			results, err = ds.GetHourlyDistribution(t.Context(), "", "", "")
+			require.NoError(t, err)
+		})
+		require.NotEmpty(t, results, "valid rows still produce a bucket, so the check runs")
+		assert.Contains(t, out, "level=WARN")
+		assert.Contains(t, out, hourlyUnparseableMsg)
+		assert.Contains(t, out, "unparseable_time_rows=2")
+	})
+
+	t.Run("warns even when every detection has an unparseable time", func(t *testing.T) {
+		ds := setupTestDB(t)
+		seedHourlyDetection(t, ds, "")         // NULL hour
+		seedHourlyDetection(t, ds, "not-time") // NULL hour
+
+		// All rows collapse into one NULL(->0) bucket, so results is non-empty
+		// (this is the real #3388 shape) and the check still fires.
+		out := captureDatastoreLogs(t, func() {
+			_, err := ds.GetHourlyDistribution(t.Context(), "", "", "")
+			require.NoError(t, err)
+		})
+		assert.Contains(t, out, hourlyUnparseableMsg)
+		assert.Contains(t, out, "unparseable_time_rows=2")
+	})
+
+	t.Run("silent on well-formed times", func(t *testing.T) {
+		ds := setupTestDB(t)
+		seedHourlyDetection(t, ds, "08:30:00")
+		seedHourlyDetection(t, ds, "21:15:00")
+
+		out := captureDatastoreLogs(t, func() {
+			_, err := ds.GetHourlyDistribution(t.Context(), "", "", "")
+			require.NoError(t, err)
+		})
+		assert.NotContains(t, out, hourlyUnparseableMsg,
+			"well-formed times must not warn")
+	})
+
+	t.Run("silent on an empty database", func(t *testing.T) {
+		ds := setupTestDB(t)
+
+		var results []HourlyDistributionData
+		out := captureDatastoreLogs(t, func() {
+			var err error
+			results, err = ds.GetHourlyDistribution(t.Context(), "", "", "")
+			require.NoError(t, err)
+		})
+		assert.Empty(t, results)
+		assert.NotContains(t, out, hourlyUnparseableMsg,
+			"an empty database is expected, not an anomaly")
+	})
+}

--- a/internal/datastore/logger.go
+++ b/internal/datastore/logger.go
@@ -35,14 +35,23 @@ type GormLogger struct {
 	SlowThreshold time.Duration
 	LogLevel      gormlogger.LogLevel
 	metrics       *Metrics
+	// dialect names the SQL backend ("sqlite", "mysql") so a failed-query log
+	// line says which engine produced the error. Some SQL faults are dialect
+	// specific (e.g. a MySQL-only syntax error, GitHub #3833); without this the
+	// triager cannot tell the MySQL path from the SQLite path. Empty for a
+	// dialect-agnostic logger (management/index operations), in which case the
+	// field is omitted from the log line.
+	dialect string
 }
 
-// NewGormLogger creates a new GORM logger instance
-func NewGormLogger(slowThreshold time.Duration, logLevel gormlogger.LogLevel, metrics *Metrics) *GormLogger {
+// NewGormLogger creates a new GORM logger instance. dialect names the SQL
+// backend ("sqlite"/"mysql"); pass "" for a dialect-agnostic logger.
+func NewGormLogger(slowThreshold time.Duration, logLevel gormlogger.LogLevel, metrics *Metrics, dialect string) *GormLogger {
 	return &GormLogger{
 		SlowThreshold: slowThreshold,
 		LogLevel:      logLevel,
 		metrics:       metrics,
+		dialect:       dialect,
 	}
 }
 
@@ -125,21 +134,36 @@ func (l *GormLogger) Trace(ctx context.Context, begin time.Time, fc func() (sql 
 		// Sanitize SQL for logging (collapse whitespace)
 		sanitized := sanitizeSQL(sql)
 
-		// Log and create enhanced error
-		enhancedErr := errors.New(err).
+		// Log and create enhanced error. Carry the dialect and the parsed
+		// operation/table so a dialect-specific SQL fault (GitHub #3833: a
+		// MySQL-only syntax error) is attributable to its engine and query
+		// without a live reproduction.
+		errBuilder := errors.New(err).
 			Component("datastore").
 			Category(errors.CategoryDatabase).
 			Context("operation", "sql_query").
+			Context("sql_operation", operation).
+			Context("sql_table", table).
 			Context("sql", sanitized).
 			Context("duration_ms", elapsed.Milliseconds()).
-			Context("original_error_type", fmt.Sprintf("%T", err)).
-			Build()
+			Context("original_error_type", fmt.Sprintf("%T", err))
+		if l.dialect != "" {
+			errBuilder = errBuilder.Context("dialect", l.dialect)
+		}
+		enhancedErr := errBuilder.Build()
 
-		GetLogger().Error("Database query failed",
+		errFields := []logger.Field{
 			logger.Error(enhancedErr),
 			logger.String("sql", sanitized),
+			logger.String("sql_operation", operation),
+			logger.String("sql_table", table),
 			logger.Duration("duration", elapsed),
-			logger.Int64("rows_affected", rows))
+			logger.Int64("rows_affected", rows),
+		}
+		if l.dialect != "" {
+			errFields = append(errFields, logger.String("dialect", l.dialect))
+		}
+		GetLogger().Error("Database query failed", errFields...)
 
 		// Record error metric
 		if l.metrics != nil {

--- a/internal/datastore/logger_test.go
+++ b/internal/datastore/logger_test.go
@@ -85,21 +85,7 @@ func TestGormLogger_Trace_ErrorContext(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Not parallel: swaps the process-global logger for the duration.
-			var buf bytes.Buffer
-			handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
-			cfg := &logger.LoggingConfig{
-				DefaultLevel: "debug",
-				Console:      &logger.ConsoleOutput{Enabled: false},
-				FileOutput:   &logger.FileOutput{Enabled: false},
-			}
-			cl, err := logger.NewCentralLogger(cfg, handler)
-			require.NoError(t, err, "failed to create test logger")
-
-			oldGlobal := logger.Global()
-			logger.SetGlobal(cl)
-			t.Cleanup(func() { logger.SetGlobal(oldGlobal) })
-
+			// Not parallel: captureDatastoreLogs swaps the process-global logger.
 			gLogger := NewGormLogger(200*time.Millisecond, gormlogger.Info, nil, tt.dialect)
 
 			fc := func() (sql string, rowsAffected int64) {
@@ -108,9 +94,9 @@ func TestGormLogger_Trace_ErrorContext(t *testing.T) {
 			// A plain syntax-style error, not a cancellation or ErrRecordNotFound,
 			// takes the "Database query failed" branch.
 			queryErr := fmt.Errorf("Error 1064 (42000): syntax error near ')'")
-			gLogger.Trace(t.Context(), time.Now(), fc, queryErr)
-
-			out := buf.String()
+			out := captureDatastoreLogs(t, func() {
+				gLogger.Trace(t.Context(), time.Now(), fc, queryErr)
+			})
 			assert.Contains(t, out, "Database query failed", "a real query fault must log at error level")
 			assert.Contains(t, out, "sql_operation=select", "the parsed SQL operation must be attached")
 			assert.Contains(t, out, "sql_table=notes", "the parsed SQL table must be attached")

--- a/internal/datastore/logger_test.go
+++ b/internal/datastore/logger_test.go
@@ -3,6 +3,7 @@ package datastore
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"log/slog"
 	"testing"
 	"time"
@@ -47,7 +48,7 @@ func TestGormLogger_Trace_ContextCancellation(t *testing.T) {
 			logger.SetGlobal(cl)
 			t.Cleanup(func() { logger.SetGlobal(oldGlobal) })
 
-			gLogger := NewGormLogger(200*time.Millisecond, gormlogger.Info, nil)
+			gLogger := NewGormLogger(200*time.Millisecond, gormlogger.Info, nil, "sqlite")
 
 			// Trace selects its branch from the err argument, not the context.
 			fc := func() (sql string, rowsAffected int64) {
@@ -61,6 +62,63 @@ func TestGormLogger_Trace_ContextCancellation(t *testing.T) {
 			assert.NotContains(t, output, "Database query failed", "%s must not be reported as a query failure", tt.name)
 			assert.Contains(t, output, "level=DEBUG", "%s must be logged at debug level", tt.name)
 			assert.Contains(t, output, "Query canceled or timed out", "%s should be logged as a debug message", tt.name)
+		})
+	}
+}
+
+// TestGormLogger_Trace_ErrorContext verifies that a genuine (non-cancellation,
+// non-record-not-found) query failure is logged as "Database query failed" with
+// the dialect and the parsed SQL operation/table attached, so a dialect-specific
+// fault (GitHub #3833) is attributable to its engine and query from the logs or
+// a support dump. Also verifies the dialect field is omitted for a
+// dialect-agnostic logger.
+func TestGormLogger_Trace_ErrorContext(t *testing.T) {
+	tests := []struct {
+		name          string
+		dialect       string
+		wantDialect   bool
+		dialectSubstr string
+	}{
+		{name: "mysql dialect is logged", dialect: "mysql", wantDialect: true, dialectSubstr: "dialect=mysql"},
+		{name: "empty dialect is omitted", dialect: "", wantDialect: false, dialectSubstr: "dialect="},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Not parallel: swaps the process-global logger for the duration.
+			var buf bytes.Buffer
+			handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+			cfg := &logger.LoggingConfig{
+				DefaultLevel: "debug",
+				Console:      &logger.ConsoleOutput{Enabled: false},
+				FileOutput:   &logger.FileOutput{Enabled: false},
+			}
+			cl, err := logger.NewCentralLogger(cfg, handler)
+			require.NoError(t, err, "failed to create test logger")
+
+			oldGlobal := logger.Global()
+			logger.SetGlobal(cl)
+			t.Cleanup(func() { logger.SetGlobal(oldGlobal) })
+
+			gLogger := NewGormLogger(200*time.Millisecond, gormlogger.Info, nil, tt.dialect)
+
+			fc := func() (sql string, rowsAffected int64) {
+				return "SELECT * FROM notes WHERE id = ?", 0
+			}
+			// A plain syntax-style error, not a cancellation or ErrRecordNotFound,
+			// takes the "Database query failed" branch.
+			queryErr := fmt.Errorf("Error 1064 (42000): syntax error near ')'")
+			gLogger.Trace(t.Context(), time.Now(), fc, queryErr)
+
+			out := buf.String()
+			assert.Contains(t, out, "Database query failed", "a real query fault must log at error level")
+			assert.Contains(t, out, "sql_operation=select", "the parsed SQL operation must be attached")
+			assert.Contains(t, out, "sql_table=notes", "the parsed SQL table must be attached")
+			if tt.wantDialect {
+				assert.Contains(t, out, tt.dialectSubstr, "the dialect must be logged when known")
+			} else {
+				assert.NotContains(t, out, tt.dialectSubstr, "the dialect field must be omitted when unknown")
+			}
 		})
 	}
 }

--- a/internal/datastore/manage.go
+++ b/internal/datastore/manage.go
@@ -29,7 +29,7 @@ const (
 // createGormLogger configures and returns a new GORM logger instance.
 func createGormLogger() gormlogger.Interface {
 	// Use our custom GORM logger with metrics support
-	return NewGormLogger(DefaultSlowQueryThreshold, gormlogger.Warn, nil)
+	return NewGormLogger(DefaultSlowQueryThreshold, gormlogger.Warn, nil, "")
 }
 
 // getSQLiteIndexInfo executes PRAGMA index_info for a given SQLite index name,

--- a/internal/datastore/mysql.go
+++ b/internal/datastore/mysql.go
@@ -67,10 +67,10 @@ func (store *MySQLStore) Open() (retErr error) {
 	var gormLogger gormlogger.Interface
 	if store.Settings.Debug {
 		// Use debug log level
-		gormLogger = NewGormLogger(1*time.Second, gormlogger.Info, store.metrics)
+		gormLogger = NewGormLogger(1*time.Second, gormlogger.Info, store.metrics, "mysql")
 	} else {
 		// Use default settings with metrics
-		gormLogger = NewGormLogger(1*time.Second, gormlogger.Warn, store.metrics)
+		gormLogger = NewGormLogger(1*time.Second, gormlogger.Warn, store.metrics, "mysql")
 	}
 
 	// Open the MySQL database

--- a/internal/datastore/sqlite.go
+++ b/internal/datastore/sqlite.go
@@ -246,10 +246,10 @@ func (s *SQLiteStore) Open() (retErr error) {
 	var gormLogger gormlogger.Interface
 	if s.Settings.Debug {
 		// Use debug log level with lower slow threshold
-		gormLogger = NewGormLogger(500*time.Millisecond, gormlogger.Info, s.metrics)
+		gormLogger = NewGormLogger(500*time.Millisecond, gormlogger.Info, s.metrics, "sqlite")
 	} else {
 		// Use default settings with metrics
-		gormLogger = NewGormLogger(500*time.Millisecond, gormlogger.Warn, s.metrics)
+		gormLogger = NewGormLogger(500*time.Millisecond, gormlogger.Warn, s.metrics, "sqlite")
 	}
 
 	// Build DSN with pragmas as query parameters so they apply to every

--- a/internal/diskmanager/policy_age.go
+++ b/internal/diskmanager/policy_age.go
@@ -183,7 +183,22 @@ func AgeBasedCleanup(quit <-chan struct{}, db Interface) CleanupResult {
 	// Always emit the per-run summary, independent of the disk-usage lookup below,
 	// so the outcome of every file (deleted, locked, min-clips-blocked, not old
 	// enough, or errored) is visible even when the final usage check fails.
-	logCleanupSummary("age", stats, time.Since(startTime))
+	// The age policy has no usage target, so usageBefore/usageThreshold are not
+	// applicable; usageAfter is reported when the final lookup succeeded.
+	usageAfter := unknownUsagePercent
+	if diskErr == nil {
+		usageAfter = int(diskUsage)
+	}
+	logCleanupSummary(&cleanupSummary{
+		policy:           "age",
+		stats:            stats,
+		duration:         time.Since(startTime),
+		keepSpectrograms: keepSpectrograms,
+		maxDeletions:     maxDeletions,
+		usageBefore:      unknownUsagePercent,
+		usageAfter:       usageAfter,
+		usageThreshold:   unknownUsagePercent,
+	})
 
 	if diskErr != nil {
 		// Combine errors if getting disk usage failed after the loop
@@ -265,9 +280,19 @@ func processAgeBasedDeletionLoop(files []FileInfo, speciesTotalCount map[string]
 			return deletedCount, deletedNames, stats, nil // Indicate interruption, but not necessarily an error from the loop itself
 		default:
 			if deletedCount >= maxDeletions {
+				// Only flag the run as rate-limited if at least one unvisited
+				// file is still old enough to delete. files is sorted oldest
+				// first, so if the next file is newer than the cutoff, every
+				// remaining file is too and the cap did not actually cut age
+				// work short (avoids a spurious WARN when eligible-count happens
+				// to equal maxDeletions).
+				if files[i].Timestamp.Unix() < retentionCutoffUnix {
+					stats.CapHit = true
+				}
 				log.Debug("Reached maximum number of deletions for age-based cleanup",
 					logger.String("policy", "age"),
-					logger.Int("max_deletions", maxDeletions))
+					logger.Int("max_deletions", maxDeletions),
+					logger.Bool("cap_hit", stats.CapHit))
 				return deletedCount, deletedNames, stats, nil
 			}
 
@@ -286,6 +311,7 @@ func processAgeBasedDeletionLoop(files []FileInfo, speciesTotalCount map[string]
 			switch {
 			case deleted:
 				stats.Deleted++
+				stats.BytesFreed += file.Size
 				speciesTotalCount[file.Species]--
 				if speciesTotalCount[file.Species] < 0 {
 					speciesTotalCount[file.Species] = 0

--- a/internal/diskmanager/policy_age_test.go
+++ b/internal/diskmanager/policy_age_test.go
@@ -641,6 +641,7 @@ func TestProcessAgeBasedDeletionLoopStats(t *testing.T) {
 			MinClipsBlocked: 1,
 			NotEligible:     3,
 			Errors:          0,
+			BytesFreed:      5, // one 5-byte file deleted
 		}, stats)
 
 		assert.NoFileExists(t, oldestOfA.Path, "oldest species_a file should be deleted")
@@ -687,6 +688,65 @@ func TestProcessAgeBasedDeletionLoopStats(t *testing.T) {
 			MinClipsBlocked: 0,
 			NotEligible:     0,
 			Errors:          1,
+			BytesFreed:      5, // the one surviving file (5 bytes) deleted; the ghost errored
 		}, stats)
+	})
+
+	t.Run("deletion cap sets CapHit with candidates remaining", func(t *testing.T) {
+		t.Parallel()
+		testDir := t.TempDir()
+		retentionCutoffUnix := time.Now().Add(-168 * time.Hour).Unix() // 7 days
+
+		// Three eligible old files, but a per-run cap of 2. The loop deletes 2
+		// and then, with a third candidate still to examine, hits the cap and
+		// must flag the run as rate-limited (GitHub #4059 signal).
+		f1 := makeAgeTestFile(t, testDir, "species_a", 300*time.Hour, false)
+		f2 := makeAgeTestFile(t, testDir, "species_a", 290*time.Hour, false)
+		f3 := makeAgeTestFile(t, testDir, "species_a", 280*time.Hour, false)
+		files := []FileInfo{f1, f2, f3}
+		speciesTotalCount := buildSpeciesTotalCountMap(files)
+
+		quitChan := make(chan struct{})
+		const (
+			minClipsPerSpecies = 0
+			maxDeletions       = 2
+		)
+		deletedCount, deletedNames, stats, loopErr := processAgeBasedDeletionLoop(
+			files, speciesTotalCount, minClipsPerSpecies, maxDeletions, false, quitChan, retentionCutoffUnix)
+
+		require.NoError(t, loopErr)
+		assert.Equal(t, 2, deletedCount, "only maxDeletions files should be deleted")
+		assert.Len(t, deletedNames, 2)
+		assert.True(t, stats.CapHit, "hitting the per-run cap with a candidate remaining must set CapHit")
+		assert.Equal(t, int64(10), stats.BytesFreed, "two 5-byte files deleted")
+		assert.Equal(t, 2, stats.Deleted)
+	})
+
+	t.Run("BytesFreed counts audio only, not the deleted spectrogram", func(t *testing.T) {
+		t.Parallel()
+		testDir := t.TempDir()
+		retentionCutoffUnix := time.Now().Add(-168 * time.Hour).Unix()
+
+		// One deletable audio file (5 bytes) with a companion spectrogram PNG
+		// that is much larger. With keepSpectrograms=false the PNG is deleted
+		// too, but BytesFreed intentionally accounts for the audio size only
+		// (the loop never stats the PNG), so the assertion documents that
+		// contract and guards against a future change that assumes byte parity.
+		audio := makeAgeTestFile(t, testDir, "sp_audio", 200*time.Hour, false)
+		pngPath := strings.TrimSuffix(audio.Path, filepath.Ext(audio.Path)) + ".png"
+		require.NoError(t, os.WriteFile(pngPath, make([]byte, 1000), 0o644)) //nolint:gosec // G306: test file
+
+		files := []FileInfo{audio}
+		speciesTotalCount := buildSpeciesTotalCountMap(files)
+		quitChan := make(chan struct{})
+		const minClipsPerSpecies = 0
+		deletedCount, _, stats, loopErr := processAgeBasedDeletionLoop(
+			files, speciesTotalCount, minClipsPerSpecies, maxDeletionsPerRun, false /* keepSpectrograms */, quitChan, retentionCutoffUnix)
+
+		require.NoError(t, loopErr)
+		assert.Equal(t, 1, deletedCount)
+		assert.NoFileExists(t, audio.Path, "audio file should be deleted")
+		assert.NoFileExists(t, pngPath, "spectrogram should also be deleted when keepSpectrograms is false")
+		assert.Equal(t, int64(5), stats.BytesFreed, "BytesFreed counts the 5-byte audio file, not the 1000-byte PNG")
 	})
 }

--- a/internal/diskmanager/policy_age_test.go
+++ b/internal/diskmanager/policy_age_test.go
@@ -722,6 +722,36 @@ func TestProcessAgeBasedDeletionLoopStats(t *testing.T) {
 		assert.Equal(t, 2, stats.Deleted)
 	})
 
+	t.Run("deletion cap does not set CapHit when the remaining file is too new", func(t *testing.T) {
+		t.Parallel()
+		testDir := t.TempDir()
+		retentionCutoffUnix := time.Now().Add(-168 * time.Hour).Unix() // 7 days
+
+		// Two deletable old files and one too-new file, with a cap of 2. The
+		// loop deletes both old files, then hits the cap at the third (newer
+		// than the cutoff). Because files are sorted oldest-first, that newer
+		// file means no age-eligible work remains, so CapHit must stay false:
+		// this exercises the guard that avoids a spurious cap WARN when the
+		// eligible count happens to equal maxDeletions.
+		old1 := makeAgeTestFile(t, testDir, "species_a", 300*time.Hour, false)
+		old2 := makeAgeTestFile(t, testDir, "species_a", 290*time.Hour, false)
+		tooNew := makeAgeTestFile(t, testDir, "species_a", 1*time.Hour, false)
+		files := []FileInfo{old1, old2, tooNew}
+		speciesTotalCount := buildSpeciesTotalCountMap(files)
+
+		quitChan := make(chan struct{})
+		const (
+			minClipsPerSpecies = 0
+			maxDeletions       = 2
+		)
+		deletedCount, _, stats, loopErr := processAgeBasedDeletionLoop(
+			files, speciesTotalCount, minClipsPerSpecies, maxDeletions, false, quitChan, retentionCutoffUnix)
+
+		require.NoError(t, loopErr)
+		assert.Equal(t, 2, deletedCount, "both old files deleted, cap reached")
+		assert.False(t, stats.CapHit, "the remaining file is too new, so the cap did not cut eligible work short")
+	})
+
 	t.Run("BytesFreed counts audio only, not the deleted spectrogram", func(t *testing.T) {
 		t.Parallel()
 		testDir := t.TempDir()

--- a/internal/diskmanager/policy_common.go
+++ b/internal/diskmanager/policy_common.go
@@ -587,27 +587,148 @@ type CleanupResult struct {
 // once disk usage drops below the threshold it tallies the unexamined remainder
 // into NotEligible, so for the usage policy the buckets do sum to Scanned.
 type cleanupStats struct {
-	Scanned         int // age: total candidate files this run. usage: files actually examined before an early stop
-	Deleted         int // files actually deleted
-	LockedSkipped   int // skipped because the clip is locked/protected
-	MinClipsBlocked int // skipped because deletion would violate the minimum-clips-per-species guard
-	NotEligible     int // age: not old enough. usage: usage already below threshold when reached
-	Errors          int // deletion attempts that failed
+	Scanned         int   // age: total candidate files this run. usage: files actually examined before an early stop
+	Deleted         int   // files actually deleted
+	LockedSkipped   int   // skipped because the clip is locked/protected
+	MinClipsBlocked int   // skipped because deletion would violate the minimum-clips-per-species guard
+	NotEligible     int   // age: not old enough. usage: usage already below threshold when reached
+	Errors          int   // deletion attempts that failed
+	BytesFreed      int64 // total size of the audio files actually deleted this run
+	// CapHit reports that the run deleted the maximum allowed this cycle
+	// (maxDeletionsPerRun) and stopped with deletable work still remaining, i.e.
+	// it was rate-limited rather than reaching the end of the work. It is the
+	// signal that distinguishes "nothing left to delete" from "hit the per-run
+	// limit, come back next cycle" on high-volume installs (GitHub #4059), and
+	// it is what justifies the WARN in logCleanupSummary. The age loop guards on
+	// age eligibility of the next unvisited file before setting it (files are
+	// sorted oldest-first); the usage loop sets it only on a genuine
+	// max-deletions stop, never when usage already fell below target.
+	CapHit bool
+}
+
+// unknownUsagePercent marks a disk-usage percentage that could not be measured
+// (the usage lookup failed) or that does not apply to a policy. It keeps those
+// fields out of the summary line rather than logging a misleading 0%.
+const unknownUsagePercent = -1
+
+// cleanupSummary bundles everything logCleanupSummary needs to describe one
+// completed cleanup run. It is purely observational; none of these fields feed
+// back into deletion behavior.
+type cleanupSummary struct {
+	policy           string
+	stats            cleanupStats
+	duration         time.Duration
+	keepSpectrograms bool // when true, .png spectrograms are left on disk beside deleted audio (GitHub #4059)
+	maxDeletions     int  // the per-run deletion cap that produced stats.CapHit
+	usageBefore      int  // disk usage % at run start; unknownUsagePercent if not measured/applicable
+	usageAfter       int  // disk usage % at run end; unknownUsagePercent if not measured
+	usageThreshold   int  // target usage %; <= 0 means not applicable (age policy)
+}
+
+// hitDeletionCap reports that the run was rate-limited by the per-run deletion
+// cap while candidate files remained. This is the primary WARN condition.
+func (s *cleanupSummary) hitDeletionCap() bool { return s.stats.CapHit }
+
+// usageStillOverTarget reports that a usage-based run finished with the disk
+// still at or above its configured target, despite not hitting the cap. It is
+// only meaningful for the usage policy (usageThreshold > 0) and when the final
+// usage was actually measured.
+func (s *cleanupSummary) usageStillOverTarget() bool {
+	return s.usageThreshold > 0 && s.usageAfter != unknownUsagePercent && s.usageAfter >= s.usageThreshold
+}
+
+// humanizeBytes renders a byte count as a short human-readable string (e.g.
+// "150 MB") for the cleanup summary, so a support dump shows freed space at a
+// glance without the reader converting raw bytes. Raw bytes are logged too.
+func humanizeBytes(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	// exp cannot exceed 5 ('E') for any int64, but bound the loop explicitly so
+	// the prefix index can never go out of range regardless of input.
+	const prefixes = "KMGTPE"
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit && exp < len(prefixes)-1; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), prefixes[exp])
+}
+
+// appendUsageFields adds the disk-usage percentage fields to a log field slice,
+// skipping any that were not measured or do not apply (unknownUsagePercent /
+// non-positive threshold), so neither the INFO summary nor a WARN logs a
+// misleading -1 for a policy that has no usage target (e.g. the age policy).
+func appendUsageFields(fields []logger.Field, s *cleanupSummary) []logger.Field {
+	if s.usageBefore != unknownUsagePercent {
+		fields = append(fields, logger.Int("usage_before_pct", s.usageBefore))
+	}
+	if s.usageAfter != unknownUsagePercent {
+		fields = append(fields, logger.Int("usage_after_pct", s.usageAfter))
+	}
+	if s.usageThreshold > 0 {
+		fields = append(fields, logger.Int("usage_threshold_pct", s.usageThreshold))
+	}
+	return fields
 }
 
 // logCleanupSummary emits a single INFO-level line summarizing a completed
-// cleanup run, so the guard (if any) that prevented deletion is visible
-// without enabling Debug logging.
-func logCleanupSummary(policy string, stats cleanupStats, duration time.Duration) {
-	GetLogger().Info("cleanup run summary",
-		logger.String("policy", policy),
-		logger.Int("files_scanned", stats.Scanned),
-		logger.Int("files_deleted", stats.Deleted),
-		logger.Int("locked_skipped", stats.LockedSkipped),
-		logger.Int("min_clips_blocked", stats.MinClipsBlocked),
-		logger.Int("not_eligible", stats.NotEligible),
-		logger.Int("errors", stats.Errors),
-		logger.Duration("duration", duration))
+// cleanup run, so the guard (if any) that prevented deletion is visible without
+// enabling Debug logging. When the run was rate-limited by the per-run deletion
+// cap, or when a usage-based run finished with the disk still at or above the
+// configured target, it additionally emits a WARN so the "cleanup ran but disk
+// stays full" condition (GitHub #4059, #3892) is loud in default logs and in a
+// support dump rather than requiring a live Debug reproduction.
+func logCleanupSummary(s *cleanupSummary) {
+	log := GetLogger()
+
+	fields := []logger.Field{
+		logger.String("policy", s.policy),
+		logger.Int("files_scanned", s.stats.Scanned),
+		logger.Int("files_deleted", s.stats.Deleted),
+		logger.Int64("bytes_freed", s.stats.BytesFreed),
+		logger.String("bytes_freed_human", humanizeBytes(s.stats.BytesFreed)),
+		logger.Int("locked_skipped", s.stats.LockedSkipped),
+		logger.Int("min_clips_blocked", s.stats.MinClipsBlocked),
+		logger.Int("not_eligible", s.stats.NotEligible),
+		logger.Int("errors", s.stats.Errors),
+		logger.Bool("keep_spectrograms", s.keepSpectrograms),
+		logger.Bool("cap_hit", s.stats.CapHit),
+		logger.Int("max_deletions", s.maxDeletions),
+		logger.Duration("duration", s.duration),
+	}
+	log.Info("cleanup run summary", appendUsageFields(fields, s)...)
+
+	switch {
+	case s.hitDeletionCap():
+		// The run deleted up to the cap with deletable work still remaining. On
+		// a busy install the disk can keep filling faster than a single capped
+		// run drains it; surfacing this is what turns #4059 from "auto-delete
+		// does nothing" into an explained, actionable state.
+		warnFields := []logger.Field{
+			logger.String("policy", s.policy),
+			logger.Int("files_deleted", s.stats.Deleted),
+			logger.Int("max_deletions", s.maxDeletions),
+			logger.Bool("keep_spectrograms", s.keepSpectrograms),
+		}
+		log.Warn("retention cleanup reached the per-run deletion limit with deletable clips remaining; if clips keep accumulating, disk may not reach target until later runs",
+			appendUsageFields(warnFields, s)...)
+	case s.usageStillOverTarget():
+		// Usage-based run finished without hitting the cap, yet the disk is
+		// still at or above target. Something other than the rate limit is
+		// preventing deletions (all remaining clips locked, min-clips guard,
+		// or spectrograms retained under keep_spectrograms).
+		warnFields := []logger.Field{
+			logger.String("policy", s.policy),
+			logger.Int("files_deleted", s.stats.Deleted),
+			logger.Int("locked_skipped", s.stats.LockedSkipped),
+			logger.Int("min_clips_blocked", s.stats.MinClipsBlocked),
+			logger.Bool("keep_spectrograms", s.keepSpectrograms),
+		}
+		log.Warn("usage-based cleanup finished with disk still at or above the configured target",
+			appendUsageFields(warnFields, s)...)
+	}
 }
 
 // CloseLogger is a no-op for backwards compatibility.

--- a/internal/diskmanager/policy_common.go
+++ b/internal/diskmanager/policy_common.go
@@ -595,14 +595,17 @@ type cleanupStats struct {
 	Errors          int   // deletion attempts that failed
 	BytesFreed      int64 // total size of the audio files actually deleted this run
 	// CapHit reports that the run deleted the maximum allowed this cycle
-	// (maxDeletionsPerRun) and stopped with deletable work still remaining, i.e.
+	// (maxDeletionsPerRun) and stopped with candidate work still remaining, i.e.
 	// it was rate-limited rather than reaching the end of the work. It is the
 	// signal that distinguishes "nothing left to delete" from "hit the per-run
 	// limit, come back next cycle" on high-volume installs (GitHub #4059), and
 	// it is what justifies the WARN in logCleanupSummary. The age loop guards on
 	// age eligibility of the next unvisited file before setting it (files are
 	// sorted oldest-first); the usage loop sets it only on a genuine
-	// max-deletions stop, never when usage already fell below target.
+	// max-deletions stop, never when usage already fell below target. A remaining
+	// candidate can still be individually locked or min-clips-blocked, so CapHit
+	// means "the cap cut the run short", not "more clips are guaranteed
+	// deletable"; the WARN wording is phrased accordingly.
 	CapHit bool
 }
 
@@ -700,6 +703,9 @@ func logCleanupSummary(s *cleanupSummary) {
 	}
 	log.Info("cleanup run summary", appendUsageFields(fields, s)...)
 
+	// At most one WARN fires. Cap-hit takes precedence over still-over-target
+	// because it names a concrete, actionable cause (the per-run limit), whereas
+	// over-target is the more general symptom a cap-hit already explains.
 	switch {
 	case s.hitDeletionCap():
 		// The run deleted up to the cap with deletable work still remaining. On
@@ -712,7 +718,7 @@ func logCleanupSummary(s *cleanupSummary) {
 			logger.Int("max_deletions", s.maxDeletions),
 			logger.Bool("keep_spectrograms", s.keepSpectrograms),
 		}
-		log.Warn("retention cleanup reached the per-run deletion limit with deletable clips remaining; if clips keep accumulating, disk may not reach target until later runs",
+		log.Warn("retention cleanup reached the per-run deletion limit and stopped before examining all candidates; if clips keep accumulating, disk may not reach target until later runs",
 			appendUsageFields(warnFields, s)...)
 	case s.usageStillOverTarget():
 		// Usage-based run finished without hitting the cap, yet the disk is

--- a/internal/diskmanager/policy_common_test.go
+++ b/internal/diskmanager/policy_common_test.go
@@ -1,0 +1,150 @@
+package diskmanager
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// captureCleanupLogs swaps in a process-global logger that writes to a buffer,
+// runs fn, restores the previous global, and returns everything logged. Used to
+// assert that logCleanupSummary emits (or withholds) the WARN escalation.
+func captureCleanupLogs(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	cfg := &logger.LoggingConfig{
+		DefaultLevel: "debug",
+		Console:      &logger.ConsoleOutput{Enabled: false},
+		FileOutput:   &logger.FileOutput{Enabled: false},
+	}
+	cl, err := logger.NewCentralLogger(cfg, handler)
+	require.NoError(t, err, "failed to create test logger")
+
+	oldGlobal := logger.Global()
+	logger.SetGlobal(cl)
+	t.Cleanup(func() { logger.SetGlobal(oldGlobal) })
+
+	fn()
+	return buf.String()
+}
+
+// TestHumanizeBytes verifies the human-readable byte rendering used in the
+// cleanup summary line. Boundaries (exactly 1 KiB, sub-KiB) are covered so a
+// support dump reads freed space at a glance.
+func TestHumanizeBytes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		bytes int64
+		want  string
+	}{
+		{"zero", 0, "0 B"},
+		{"sub-kib", 512, "512 B"},
+		{"one-kib-boundary", 1024, "1.0 KB"},
+		{"kilobytes", 1536, "1.5 KB"},
+		{"megabytes", 150 * 1024 * 1024, "150.0 MB"},
+		{"gigabytes", 18 * 1024 * 1024 * 1024, "18.0 GB"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, humanizeBytes(tt.bytes))
+		})
+	}
+}
+
+// TestCleanupSummaryHitDeletionCap verifies the primary WARN predicate: a run
+// is escalated when it was rate-limited by the per-run deletion cap while
+// candidate files still remained (GitHub #4059).
+func TestCleanupSummaryHitDeletionCap(t *testing.T) {
+	t.Parallel()
+
+	capped := cleanupSummary{stats: cleanupStats{CapHit: true}}
+	uncapped := cleanupSummary{stats: cleanupStats{CapHit: false}}
+	assert.True(t, capped.hitDeletionCap(), "a capped run must escalate")
+	assert.False(t, uncapped.hitDeletionCap(), "an uncapped run must not escalate on the cap predicate")
+}
+
+// TestCleanupSummaryUsageStillOverTarget verifies the secondary WARN predicate:
+// a usage-based run that finished without hitting the cap but left the disk at
+// or above its configured target. The predicate must not fire for the age
+// policy (no target) or when the final usage could not be measured.
+func TestCleanupSummaryUsageStillOverTarget(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		usageAfter     int
+		usageThreshold int
+		want           bool
+	}{
+		{"over target", 95, 80, true},
+		{"exactly at target", 80, 80, true},
+		{"under target", 70, 80, false},
+		{"no target (age policy)", 95, unknownUsagePercent, false},
+		{"zero target treated as not applicable", 95, 0, false},
+		{"usage not measured", unknownUsagePercent, 80, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := cleanupSummary{usageAfter: tt.usageAfter, usageThreshold: tt.usageThreshold}
+			assert.Equal(t, tt.want, s.usageStillOverTarget())
+		})
+	}
+}
+
+// TestLogCleanupSummaryWarnEmission verifies that logCleanupSummary actually
+// emits a WARN for each escalation condition, stays quiet on a healthy run, and
+// never logs the unknownUsagePercent (-1) sentinel for a policy without a usage
+// target (the age policy). It complements the predicate unit tests by covering
+// the emission/routing the predicates feed, not just the decision.
+func TestLogCleanupSummaryWarnEmission(t *testing.T) {
+	// Not parallel: captureCleanupLogs swaps the process-global logger.
+
+	t.Run("age cap-hit emits WARN without usage sentinels", func(t *testing.T) {
+		s := &cleanupSummary{
+			policy: "age", stats: cleanupStats{Scanned: 3, Deleted: 3, BytesFreed: 15, CapHit: true},
+			duration: time.Second, maxDeletions: 1000,
+			usageBefore: unknownUsagePercent, usageAfter: unknownUsagePercent, usageThreshold: unknownUsagePercent,
+		}
+		out := captureCleanupLogs(t, func() { logCleanupSummary(s) })
+		assert.Contains(t, out, "level=WARN", "a capped run must escalate to WARN")
+		assert.Contains(t, out, "per-run deletion limit")
+		assert.NotContains(t, out, "-1", "the -1 usage sentinel must not appear for the age policy")
+		assert.NotContains(t, out, "usage_threshold_pct", "age policy has no usage target to log")
+	})
+
+	t.Run("usage over-target emits WARN with usage fields", func(t *testing.T) {
+		s := &cleanupSummary{
+			policy: "usage", stats: cleanupStats{Scanned: 10, Deleted: 2, BytesFreed: 2048},
+			duration: time.Second, maxDeletions: 1000,
+			usageBefore: 95, usageAfter: 94, usageThreshold: 80,
+		}
+		out := captureCleanupLogs(t, func() { logCleanupSummary(s) })
+		assert.Contains(t, out, "level=WARN", "finishing above target must escalate to WARN")
+		assert.Contains(t, out, "at or above the configured target")
+		assert.Contains(t, out, "usage_after_pct=94")
+		assert.Contains(t, out, "usage_threshold_pct=80")
+	})
+
+	t.Run("healthy usage run does not WARN", func(t *testing.T) {
+		s := &cleanupSummary{
+			policy: "usage", stats: cleanupStats{Scanned: 10, Deleted: 10, BytesFreed: 4096},
+			duration: time.Second, maxDeletions: 1000,
+			usageBefore: 95, usageAfter: 70, usageThreshold: 80,
+		}
+		out := captureCleanupLogs(t, func() { logCleanupSummary(s) })
+		assert.Contains(t, out, "cleanup run summary", "the INFO summary is always emitted")
+		assert.NotContains(t, out, "level=WARN", "a run that reached target must not escalate")
+	})
+}

--- a/internal/diskmanager/policy_common_test.go
+++ b/internal/diskmanager/policy_common_test.go
@@ -120,7 +120,12 @@ func TestLogCleanupSummaryWarnEmission(t *testing.T) {
 		out := captureCleanupLogs(t, func() { logCleanupSummary(s) })
 		assert.Contains(t, out, "level=WARN", "a capped run must escalate to WARN")
 		assert.Contains(t, out, "per-run deletion limit")
-		assert.NotContains(t, out, "-1", "the -1 usage sentinel must not appear for the age policy")
+		// The age policy has no usage measurement or target, so none of the
+		// usage_*_pct fields (which would carry the -1 sentinel) must be logged.
+		// Assert the keys are absent rather than the bare "-1" substring, which
+		// also occurs in the slog timestamp on many dates/timezones.
+		assert.NotContains(t, out, "usage_before_pct", "age policy has no usage measurement to log")
+		assert.NotContains(t, out, "usage_after_pct", "age policy has no usage measurement to log")
 		assert.NotContains(t, out, "usage_threshold_pct", "age policy has no usage target to log")
 	})
 

--- a/internal/diskmanager/policy_usage.go
+++ b/internal/diskmanager/policy_usage.go
@@ -155,8 +155,19 @@ func UsageBasedCleanup(quit <-chan struct{}, db Interface) CleanupResult {
 
 	// Always emit the per-run summary so the outcome of every file (deleted,
 	// locked, min-clips-blocked, usage already satisfied, or errored) is
-	// visible without enabling Debug logging.
-	logCleanupSummary("usage", stats, duration)
+	// visible without enabling Debug logging. Usage before/after and the target
+	// threshold drive the WARN that fires when a run cannot bring the disk back
+	// under target (GitHub #4059, #3892).
+	logCleanupSummary(&cleanupSummary{
+		policy:           "usage",
+		stats:            stats,
+		duration:         duration,
+		keepSpectrograms: keepSpectrograms,
+		maxDeletions:     maxDeletionsPerRun,
+		usageBefore:      initialUsagePercent,
+		usageAfter:       finalUsagePercent,
+		usageThreshold:   usageThreshold,
+	})
 	if loopErr != nil {
 		GetLogger().Error("Usage-based cleanup run completed with errors",
 			logger.String("policy", "usage"),
@@ -260,6 +271,12 @@ func processUsageDeletionLoop(files []FileInfo, speciesMonthCount map[string]map
 				if stopReason == usageStopBelowThreshold {
 					stats.NotEligible += len(files) - i
 				}
+				if stopReason == usageStopMaxDeletions {
+					// Rate-limited: reached the per-run deletion cap before usage
+					// fell under target and before examining all files. Flag it
+					// for the summary WARN.
+					stats.CapHit = true
+				}
 				return deletedCount, deletedNames, lastKnownGoodUsagePercent, stats, loopErr
 			}
 
@@ -279,6 +296,7 @@ func processUsageDeletionLoop(files []FileInfo, speciesMonthCount map[string]map
 			switch outcome {
 			case usageOutcomeDeleted:
 				stats.Deleted++
+				stats.BytesFreed += file.Size
 				estimatedUsedBytes = updateUsageStateAfterDeletion(file, speciesMonthCount, estimatedUsedBytes, params.diskInfo.TotalBytes)
 				deletedNames = append(deletedNames, file.Path)
 				deletedCount++

--- a/internal/diskmanager/policy_usage_test.go
+++ b/internal/diskmanager/policy_usage_test.go
@@ -1107,6 +1107,7 @@ func TestProcessUsageDeletionLoopStats(t *testing.T) {
 			MinClipsBlocked: 0,
 			NotEligible:     2,
 			Errors:          0,
+			BytesFreed:      150, // the one deleted file's size
 		}, stats)
 	})
 
@@ -1135,6 +1136,8 @@ func TestProcessUsageDeletionLoopStats(t *testing.T) {
 			MinClipsBlocked: 0,
 			NotEligible:     0, // file2 was never evaluated; a rate limit is not "not eligible"
 			Errors:          0,
+			BytesFreed:      10,   // the one deleted file's size
+			CapHit:          true, // stopped at maxDeletions (1) with file2 still remaining
 		}, stats)
 	})
 
@@ -1165,6 +1168,7 @@ func TestProcessUsageDeletionLoopStats(t *testing.T) {
 			MinClipsBlocked: 2, // sp_min (always) and the second sp_del file (after the first is deleted)
 			NotEligible:     0,
 			Errors:          0,
+			BytesFreed:      10, // the one deleted file's size
 		}, stats)
 	})
 


### PR DESCRIPTION
## Summary

Three behavior-neutral diagnostics changes that make hard-to-reproduce user bug reports diagnosable from default logs and support dumps, without asking the reporter for a live Debug reproduction. Each extends existing observability (the retention change builds directly on #4168) and changes no deletion, query, or control-flow behavior.

Retention cleanup summary: the per-run summary now reports bytes freed (raw and human-readable), whether the run hit the per-run deletion cap, disk usage before/after, and keep_spectrograms. A WARN fires when a run is rate-limited by the cap, or a usage-based run finishes with the disk still at or above target. This turns "auto-delete does nothing" (#4059) and "age retention deletes nothing" (#3892) into an explained, actionable state in normal logs. Deletion behavior is unchanged.

Failed-query logs: the "Database query failed" line now carries the SQL dialect and the parsed operation/table. A dialect-specific fault (a MySQL-only Error 1064 syntax error, #3833) is now attributable to its engine and its query straight from the logs or a support dump. The dialect is threaded into the GORM logger at construction and omitted from the line for the dialect-agnostic management logger.

Hourly distribution self-check: when the "Detection Patterns by Time of Day" chart renders flat at zero despite data (#3388), the cause is detections whose time column is unparseable, so the hour expression evaluates to NULL and they collapse into a bogus bucket. After a successful aggregation that returned data, a filtered COUNT of NULL-hour rows runs and warns when any exist, putting the malformed-time count in default logs. It is skipped when there is genuinely no data, so a fresh install pays nothing.

## Related Issues

Relates to #4059, #3892, #3833, #3388

## Test Plan

- [x] `go test -race` on `internal/diskmanager` and `internal/datastore`
- [x] `golangci-lint run` clean on both packages
- [x] Verified the previously CI-fragile summary assertion under `TZ=Etc/GMT+10`
- [x] New tests cover: bytes-freed accounting (audio only), cap-hit true and false boundaries, WARN emission and sentinel omission, dialect present/omitted, and the unparseable-time WARN via the real query entry point