### PR TITLE
refactor: batch low-severity tech-debt cleanups (byte-format + log-capture dedup, hourly self-check parity)

### DIFF
--- a/internal/analysis/processor/export_log_guards_test.go
+++ b/internal/analysis/processor/export_log_guards_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/logger/logtest"
 )
 
 // fallbackTestTime is a fixed timestamp so the generated clip names are
@@ -103,7 +104,7 @@ func TestResampleKeyDistinguishesRatePairs(t *testing.T) {
 // enabled with a target audionorm cannot accept, which is the branch that used
 // to emit on every single detection of an affected install.
 func TestNormalizeSkipLogsOncePerFormat(t *testing.T) {
-	logs := captureExportLogs(t)
+	logs := logtest.CaptureBuffer(t)
 	resetExportLogGuards(t)
 
 	a := newExportLogAction(t, t.TempDir(), "clip.mp3", "mp3")
@@ -139,7 +140,7 @@ func TestNormalizeSkipLogsOncePerFormat(t *testing.T) {
 //
 // This also covers the measurement-failure arm, which had no execution at all.
 func TestNormalizeSkipReasonsAreNotConflated(t *testing.T) {
-	logs := captureExportLogs(t)
+	logs := logtest.CaptureBuffer(t)
 	resetExportLogGuards(t)
 
 	const format = "mp3"
@@ -187,7 +188,7 @@ func TestNormalizeSkipReasonsAreNotConflated(t *testing.T) {
 // guard, detection_id would name only the first detection to trip a standing
 // misconfiguration, reading as if the problem belonged to that one clip.
 func TestNormalizeSkipLineOmitsDetectionID(t *testing.T) {
-	logs := captureExportLogs(t)
+	logs := logtest.CaptureBuffer(t)
 	resetExportLogGuards(t)
 
 	a := newExportLogAction(t, t.TempDir(), "clip.mp3", "mp3")
@@ -218,7 +219,7 @@ func TestNormalizeSkipLineOmitsDetectionID(t *testing.T) {
 // dropping the .do() wrapper (back to the per-detection flood this change
 // exists to stop) would not be caught by anything.
 func TestResampleFailureLogsOncePerRatePair(t *testing.T) {
-	logs := captureExportLogs(t)
+	logs := logtest.CaptureBuffer(t)
 	resetExportLogGuards(t)
 
 	a := newExportLogAction(t, t.TempDir(), "clip.mp3", "mp3")
@@ -254,7 +255,7 @@ func TestResampleFailureLogsOncePerRatePair(t *testing.T) {
 func TestNormalizedReportsWhetherMeasurementRan(t *testing.T) {
 	// Captured only to keep the guarded WARNs out of the test output; this test
 	// asserts the returned flag, not the log.
-	captureExportLogs(t)
+	logtest.CaptureBuffer(t)
 	resetExportLogGuards(t)
 
 	// Normalization off: the static gain is used, so nothing was measured.
@@ -280,7 +281,7 @@ func TestNormalizedReportsWhetherMeasurementRan(t *testing.T) {
 // the UI, so a process-wide sync.Once let the first bad value silence every
 // later, different one.
 func TestClipPathFallbackWarnsPerExportType(t *testing.T) {
-	logs := captureExportLogs(t)
+	logs := logtest.CaptureBuffer(t)
 	resetBuildClipPathFallbackOnce()
 	t.Cleanup(resetBuildClipPathFallbackOnce)
 
@@ -307,7 +308,7 @@ func TestClipPathFallbackWarnsPerExportType(t *testing.T) {
 // outright, which is the export log where naming the bird matters most. It
 // carried detection_id and clip_name only.
 func TestNoPCMSkipLineNamesSpecies(t *testing.T) {
-	logs := captureExportLogs(t)
+	logs := logtest.CaptureBuffer(t)
 
 	a := newExportLogAction(t, t.TempDir(), "clip.mp3", "mp3")
 	a.pcmData = nil
@@ -328,7 +329,7 @@ func TestNoPCMSkipLineNamesSpecies(t *testing.T) {
 // topic that did not generalise. The topic derives from the hot-reloadable
 // Realtime.MQTT.Topic setting.
 func TestMQTTNotReadyWarnsPerTopic(t *testing.T) {
-	logs := captureExportLogs(t)
+	logs := logtest.CaptureBuffer(t)
 
 	p := &Processor{}
 	for range 3 {

--- a/internal/analysis/processor/export_logging_test.go
+++ b/internal/analysis/processor/export_logging_test.go
@@ -1,9 +1,7 @@
 package processor
 
 import (
-	"bytes"
 	"context"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -20,7 +18,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/conf/conftest"
 	"github.com/tphakala/birdnet-go/internal/detection"
-	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/logger/logtest"
 )
 
 // logLineContaining returns the single captured log line carrying marker, so an
@@ -46,34 +44,6 @@ const (
 	batModelName        = "BattyBirdNET"
 	batSourceSampleRate = 256000
 )
-
-// captureExportLogs redirects the global logger to an in-memory buffer for the
-// duration of the test and returns the buffer. The processor package logs
-// through logger.Global().Module("analysis.processor"), so this captures
-// everything the export path emits. It swaps process-wide global state, so
-// tests using it must not run with t.Parallel().
-func captureExportLogs(t *testing.T) *bytes.Buffer {
-	t.Helper()
-
-	var buf bytes.Buffer
-	capture := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
-	cl, err := logger.NewCentralLogger(
-		&logger.LoggingConfig{
-			Console:      &logger.ConsoleOutput{Enabled: false},
-			FileOutput:   &logger.FileOutput{Enabled: false},
-			DefaultLevel: "debug",
-		},
-		capture,
-	)
-	require.NoError(t, err)
-	t.Cleanup(func() { assert.NoError(t, cl.Close()) })
-
-	prev := logger.Global()
-	logger.SetGlobal(cl)
-	t.Cleanup(func() { logger.SetGlobal(prev) })
-
-	return &buf
-}
 
 // newExportLogAction builds a SaveAudioAction that Execute will carry all the
 // way to an encoder: export enabled, a real output directory, and a second of
@@ -115,7 +85,7 @@ func blockOutputPath(t *testing.T, exportDir, clipName string) {
 // or FFmpeg" without the reader having to reconstruct it from the format and the
 // operator's environment.
 func TestExecute_SuccessLogNamesNativeEncoder(t *testing.T) {
-	logs := captureExportLogs(t)
+	logs := logtest.CaptureBuffer(t)
 	dir := t.TempDir()
 	a := newExportLogAction(t, dir, "clip.flac", ffmpeg.FormatFLAC)
 
@@ -141,7 +111,7 @@ func TestExecute_SuccessLogNamesNativeEncoder(t *testing.T) {
 // logger could not emit. This assertion is deliberately on the PRODUCER, against
 // the field set really written to the log.
 func TestExecute_SuccessLogNamesSpeciesForClipPathAggregation(t *testing.T) {
-	logs := captureExportLogs(t)
+	logs := logtest.CaptureBuffer(t)
 	dir := t.TempDir()
 	a := newExportLogAction(t, dir, "clip.flac", ffmpeg.FormatFLAC)
 	// Lowercase, matching what buildSaveAudioAction stores and what the sibling
@@ -166,7 +136,7 @@ func TestExecute_SuccessLogNamesSpeciesForClipPathAggregation(t *testing.T) {
 // two, and only this test would fail if the field regressed to a basename and
 // left SpeciesEntry.ClipPaths unresolvable.
 func TestExecute_SuccessLogClipPathKeepsDateSegments(t *testing.T) {
-	logs := captureExportLogs(t)
+	logs := logtest.CaptureBuffer(t)
 	dir := t.TempDir()
 	a := newExportLogAction(t, dir, "2026/07/wren.flac", ffmpeg.FormatFLAC)
 
@@ -321,7 +291,7 @@ func buildSpeciesTestSettings(t *testing.T) *conf.Settings {
 // ("my clips are too quiet") and the clip duration next to the file size ("my
 // clips are cut off"). Both used to be reachable only at Debug, or not at all.
 func TestExecute_SuccessLogCarriesGainAndDuration(t *testing.T) {
-	logs := captureExportLogs(t)
+	logs := logtest.CaptureBuffer(t)
 	dir := t.TempDir()
 	a := newExportLogAction(t, dir, "clip.wav", ffmpeg.FormatWAV)
 
@@ -356,7 +326,7 @@ func TestExecute_SuccessLogCarriesGainAndDuration(t *testing.T) {
 func TestExecute_SuccessLogCarriesBitrateForLossyFormats(t *testing.T) {
 	t.Setenv(conf.EnvNativeAACEncoder, "native")
 	resetNativeSkipOnce()
-	logs := captureExportLogs(t)
+	logs := logtest.CaptureBuffer(t)
 	dir := t.TempDir()
 	a := newExportLogAction(t, dir, "clip.m4a", ffmpeg.FormatAAC)
 
@@ -373,7 +343,7 @@ func TestExecute_SuccessLogCarriesBitrateForLossyFormats(t *testing.T) {
 // case that tells the two apart.
 func TestExecute_SuccessLogCarriesClampedBitrate(t *testing.T) {
 	resetNativeSkipOnce()
-	logs := captureExportLogs(t)
+	logs := logtest.CaptureBuffer(t)
 	dir := t.TempDir()
 	a := newExportLogAction(t, dir, "clip.opus", ffmpeg.FormatOpus)
 	a.Settings.Realtime.Audio.Export.Bitrate = "320k"
@@ -395,7 +365,7 @@ func TestExecute_SuccessLogCarriesClampedBitrate(t *testing.T) {
 func TestExecute_FailureLogNamesNativeEncoder(t *testing.T) {
 	t.Setenv(conf.EnvNativeAACEncoder, "native")
 	resetNativeSkipOnce()
-	logs := captureExportLogs(t)
+	logs := logtest.CaptureBuffer(t)
 	dir := t.TempDir()
 	blockOutputPath(t, dir, "clip.m4a")
 	a := newExportLogAction(t, dir, "clip.m4a", ffmpeg.FormatAAC)
@@ -418,7 +388,7 @@ func TestExecute_FailureLogNamesNativeEncoder(t *testing.T) {
 // job queue logs the same root cause as ERROR right afterwards. Two ERROR lines
 // for one failure would double-count and double-alert.
 func TestExecute_FailureLogIsWarnNotError(t *testing.T) {
-	logs := captureExportLogs(t)
+	logs := logtest.CaptureBuffer(t)
 	dir := t.TempDir()
 	a := newExportLogAction(t, dir, "clip.mp3", ffmpeg.FormatMP3)
 	a.Settings.Realtime.Audio.FfmpegPath = ""
@@ -438,7 +408,7 @@ func TestExecute_FailureLogIsWarnNotError(t *testing.T) {
 // The other half of the pair: the same failure on the FFmpeg path is attributed
 // to FFmpeg, so the two are distinguishable in a support log.
 func TestExecute_FailureLogNamesFFmpeg(t *testing.T) {
-	logs := captureExportLogs(t)
+	logs := logtest.CaptureBuffer(t)
 	dir := t.TempDir()
 	a := newExportLogAction(t, dir, "clip.mp3", ffmpeg.FormatMP3)
 	// No FFmpeg binary configured, so the export fails inside ffmpeg.ExportAudio.
@@ -462,7 +432,7 @@ func TestExecute_FailureLogNamesFFmpeg(t *testing.T) {
 // context already cancelled (so planNativeNormalizationGain refuses before
 // measuring), which is the shape a shutdown mid-measurement produces.
 func TestExecute_FailureBeforeGainResolutionOmitsGain(t *testing.T) {
-	logs := captureExportLogs(t)
+	logs := logtest.CaptureBuffer(t)
 	dir := t.TempDir()
 	a := newExportLogAction(t, dir, "clip.flac", ffmpeg.FormatFLAC)
 	a.Settings.Realtime.Audio.Export.Normalization = conf.NormalizationSettings{
@@ -496,7 +466,7 @@ func TestExecute_FailureBeforeGainResolutionOmitsGain(t *testing.T) {
 // instantly, and both numbers were already measured before this change; only the
 // success line consumed them.
 func TestExecute_FailureLogCarriesPhaseTimings(t *testing.T) {
-	logs := captureExportLogs(t)
+	logs := logtest.CaptureBuffer(t)
 	dir := t.TempDir()
 	a := newExportLogAction(t, dir, "clip.flac", ffmpeg.FormatFLAC)
 	blockOutputPath(t, dir, "clip.flac")
@@ -562,7 +532,7 @@ func TestRelativeClipPath(t *testing.T) {
 // is logged, matching the success line, because support logs and uploaded
 // support dumps are read by someone other than the operator.
 func TestExecute_FailureLogOmitsFullPath(t *testing.T) {
-	logs := captureExportLogs(t)
+	logs := logtest.CaptureBuffer(t)
 	dir := t.TempDir()
 	a := newExportLogAction(t, dir, "clip.mp3", ffmpeg.FormatMP3)
 	a.Settings.Realtime.Audio.FfmpegPath = ""
@@ -582,7 +552,7 @@ func TestExecute_FailureLogOmitsFullPath(t *testing.T) {
 // the context to be cancelled (see the sibling test below, which is the case
 // this one used to be testing by accident).
 func TestExecute_CancelledExportLogsAtDebug(t *testing.T) {
-	logs := captureExportLogs(t)
+	logs := logtest.CaptureBuffer(t)
 	dir := t.TempDir()
 	a := newExportLogAction(t, dir, "clip.flac", ffmpeg.FormatFLAC)
 
@@ -604,7 +574,7 @@ func TestExecute_CancelledExportLogsAtDebug(t *testing.T) {
 // asserting they had been cancelled. On a container that OOM-restarts that
 // misattributes every in-flight export failure in the restart window.
 func TestExecute_RealErrorDuringShutdownStaysAtWarn(t *testing.T) {
-	logs := captureExportLogs(t)
+	logs := logtest.CaptureBuffer(t)
 	dir := t.TempDir()
 	a := newExportLogAction(t, dir, "clip.mp3", ffmpeg.FormatMP3)
 	// Not a cancellation: FFmpeg is simply not there.
@@ -629,7 +599,7 @@ func TestExecute_RealErrorDuringShutdownStaysAtWarn(t *testing.T) {
 // deadline, and that is exactly the failure this line exists to surface. It must
 // not be filed under "cancelled" at Debug.
 func TestExecute_TimedOutExportStaysAtWarn(t *testing.T) {
-	logs := captureExportLogs(t)
+	logs := logtest.CaptureBuffer(t)
 	dir := t.TempDir()
 	a := newExportLogAction(t, dir, "clip.mp3", ffmpeg.FormatMP3)
 	a.Settings.Realtime.Audio.FfmpegPath = ""
@@ -654,7 +624,7 @@ func TestExecute_TimedOutExportStaysAtWarn(t *testing.T) {
 // on disk.
 func TestResolveExportParams_BatDowngradeIsLogged(t *testing.T) {
 	resetBatFormatDowngradeOnce()
-	logs := captureExportLogs(t)
+	logs := logtest.CaptureBuffer(t)
 	a := newExportLogAction(t, t.TempDir(), "clip.mp3", ffmpeg.FormatMP3)
 	a.modelName = batModelName
 	a.sourceSampleRate = batSourceSampleRate
@@ -672,7 +642,7 @@ func TestResolveExportParams_BatDowngradeIsLogged(t *testing.T) {
 // the other half: a DIFFERENT condition still gets its own line.)
 func TestResolveExportParams_BatDowngradeLoggedOncePerCondition(t *testing.T) {
 	resetBatFormatDowngradeOnce()
-	logs := captureExportLogs(t)
+	logs := logtest.CaptureBuffer(t)
 	a := newExportLogAction(t, t.TempDir(), "clip.mp3", ffmpeg.FormatMP3)
 	a.modelName = batModelName
 	a.sourceSampleRate = batSourceSampleRate
@@ -693,7 +663,7 @@ func TestResolveExportParams_BatDowngradeLoggedOncePerCondition(t *testing.T) {
 // since changed away from or a rate belonging to another source.
 func TestResolveExportParams_BatDowngradeLogsEachDistinctCondition(t *testing.T) {
 	resetBatFormatDowngradeOnce()
-	logs := captureExportLogs(t)
+	logs := logtest.CaptureBuffer(t)
 	a := newExportLogAction(t, t.TempDir(), "clip.mp3", ffmpeg.FormatMP3)
 	a.modelName = batModelName
 	a.sourceSampleRate = batSourceSampleRate
@@ -727,7 +697,7 @@ func TestResolveExportParams_BatDowngradeLogsEachDistinctCondition(t *testing.T)
 func TestResolveExportParams_StrandedFallbackIsWarnedOncePerCondition(t *testing.T) {
 	resetNativeSkipOnce()
 	resetStrandedFormatOnce()
-	logs := captureExportLogs(t)
+	logs := logtest.CaptureBuffer(t)
 
 	// 44.1 kHz is a rate Opus does not accept, and with no FFmpeg to fall back
 	// on there is no encoder left for the configured format.
@@ -758,7 +728,7 @@ func TestResolveExportParams_StrandedFallbackLogsEachDistinctCondition(t *testin
 	t.Setenv(conf.EnvNativeAACEncoder, "native")
 	resetNativeSkipOnce()
 	resetStrandedFormatOnce()
-	logs := captureExportLogs(t)
+	logs := logtest.CaptureBuffer(t)
 
 	a := newExportLogAction(t, t.TempDir(), "clip.opus", ffmpeg.FormatOpus)
 	a.Settings.Realtime.Audio.FfmpegPath = ""

--- a/internal/api/middleware/logging_test.go
+++ b/internal/api/middleware/logging_test.go
@@ -1,8 +1,6 @@
 package middleware
 
 import (
-	"bytes"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,34 +8,11 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/logger/logtest"
 )
 
-func captureAccessLogs(t *testing.T) *bytes.Buffer {
-	t.Helper()
-
-	var buf bytes.Buffer
-	capture := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
-	cl, err := logger.NewCentralLogger(
-		&logger.LoggingConfig{
-			Console:      &logger.ConsoleOutput{Enabled: false},
-			FileOutput:   &logger.FileOutput{Enabled: false},
-			DefaultLevel: "debug",
-		},
-		capture,
-	)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = cl.Close() })
-
-	prev := logger.Global()
-	logger.SetGlobal(cl)
-	t.Cleanup(func() { logger.SetGlobal(prev) })
-
-	return &buf
-}
-
 func TestNewRequestLogger_ScrubsHLSToken(t *testing.T) {
-	buf := captureAccessLogs(t)
+	buf := logtest.CaptureBuffer(t)
 
 	e := echo.New()
 	mw := NewRequestLogger()
@@ -92,7 +67,7 @@ func TestNewRequestLogger_ScrubsURI(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			buf := captureAccessLogs(t)
+			buf := logtest.CaptureBuffer(t)
 
 			e := echo.New()
 			mw := NewRequestLogger()

--- a/internal/api/v2/apicore/format.go
+++ b/internal/api/v2/apicore/format.go
@@ -1,19 +1,13 @@
 package apicore
 
-import "fmt"
+import "github.com/tphakala/birdnet-go/internal/formatutil"
 
 // FormatBytesUint64 formats bytes into human-readable format (for uint64 values).
 // It is shared substrate: the system domain's database-stats/backup handlers and
-// the package-api async backup handlers both render byte counts with it.
+// the package-api async backup handlers both render byte counts with it. The
+// formatting itself lives in the leaf formatutil package so this and the other
+// former copies stay in lockstep; this wrapper preserves the exported API its
+// external callers depend on.
 func FormatBytesUint64(bytes uint64) string {
-	const unit uint64 = 1024
-	if bytes < unit {
-		return fmt.Sprintf("%d B", bytes)
-	}
-	div, exp := unit, 0
-	for n := bytes / unit; n >= unit; n /= unit {
-		div *= unit
-		exp++
-	}
-	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
+	return formatutil.BytesUint64(bytes)
 }

--- a/internal/api/v2/imports/legacy_cleanup.go
+++ b/internal/api/v2/imports/legacy_cleanup.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	datastoreV2 "github.com/tphakala/birdnet-go/internal/datastore/v2"
+	"github.com/tphakala/birdnet-go/internal/formatutil"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/notification"
 	"gorm.io/gorm"
@@ -404,7 +405,7 @@ func (c *Handler) StartLegacyCleanup(ctx echo.Context) error {
 		} else {
 			c.LogInfoIfEnabled("Legacy cleanup completed successfully",
 				logger.Int64("space_reclaimed_bytes", sizeBytes),
-				logger.String("space_reclaimed", formatBytes(sizeBytes)))
+				logger.String("space_reclaimed", formatutil.Bytes(sizeBytes)))
 			c.cleanupStatus.Set(CleanupStateCompleted, "", nil, sizeBytes)
 			c.sendCleanupNotification(true, sizeBytes, "")
 		}
@@ -602,11 +603,11 @@ func (c *Handler) sendCleanupNotification(success bool, spaceReclaimed int64, er
 	if success {
 		title = "Legacy Database Cleanup Complete"
 		body = fmt.Sprintf("Successfully removed legacy database. %s disk space reclaimed.",
-			formatBytes(spaceReclaimed))
+			formatutil.Bytes(spaceReclaimed))
 		priority = notification.PriorityMedium
 		titleKey = notification.MsgCleanupCompleteTitle
 		messageKey = notification.MsgCleanupCompleteMessage
-		messageParams = map[string]any{"space": formatBytes(spaceReclaimed)}
+		messageParams = map[string]any{"space": formatutil.Bytes(spaceReclaimed)}
 	} else {
 		title = "Legacy Database Cleanup Failed"
 		body = fmt.Sprintf("Failed to remove legacy database: %s", errMsg)
@@ -629,18 +630,4 @@ func (c *Handler) sendCleanupNotification(success bool, spaceReclaimed int64, er
 	if err := notifService.CreateWithMetadata(notif); err != nil {
 		c.LogWarnIfEnabled("Failed to send cleanup notification", logger.Error(err))
 	}
-}
-
-// formatBytes converts bytes to human-readable format.
-func formatBytes(bytes int64) string {
-	const unit = 1024
-	if bytes < unit {
-		return fmt.Sprintf("%d B", bytes)
-	}
-	div, exp := int64(unit), 0
-	for n := bytes / unit; n >= unit; n /= unit {
-		div *= unit
-		exp++
-	}
-	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
 }

--- a/internal/birdweather/encode_attribution_test.go
+++ b/internal/birdweather/encode_attribution_test.go
@@ -1,7 +1,6 @@
 package birdweather
 
 import (
-	"bytes"
 	"log/slog"
 	"strings"
 	"testing"
@@ -11,36 +10,8 @@ import (
 
 	"github.com/tphakala/birdnet-go/internal/audiocore/clipenc"
 	"github.com/tphakala/birdnet-go/internal/conf"
-	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/logger/logtest"
 )
-
-// captureUploadLogs redirects the global logger to a buffer at Info level, which
-// is the level a default support dump actually contains. Anything the tests here
-// require must therefore be emitted at Info or above; a field only present at
-// Debug is not available to triage. It swaps process-wide state, so tests using
-// it must not run with t.Parallel().
-func captureUploadLogs(t *testing.T) *bytes.Buffer {
-	t.Helper()
-
-	var buf bytes.Buffer
-	capture := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
-	cl, err := logger.NewCentralLogger(
-		&logger.LoggingConfig{
-			Console:      &logger.ConsoleOutput{Enabled: false},
-			FileOutput:   &logger.FileOutput{Enabled: false},
-			DefaultLevel: "info",
-		},
-		capture,
-	)
-	require.NoError(t, err)
-	t.Cleanup(func() { assert.NoError(t, cl.Close()) })
-
-	prev := logger.Global()
-	logger.SetGlobal(cl)
-	t.Cleanup(func() { logger.SetGlobal(prev) })
-
-	return &buf
-}
 
 // TestEncodeWithNativeFLAC_LogsEncoderAttribution covers the gap that made
 // "my BirdWeather uploads are too quiet" unanswerable from a default-level
@@ -48,7 +19,11 @@ func captureUploadLogs(t *testing.T) *bytes.Buffer {
 // upload path recorded neither the encoder that ran nor the gain it applied
 // anywhere above Debug.
 func TestEncodeWithNativeFLAC_LogsEncoderAttribution(t *testing.T) {
-	logs := captureUploadLogs(t)
+	// Capture at Info, not Debug: this test's whole purpose is to prove the
+	// encoder and gain land at Info (the level a default support dump retains).
+	// A Debug capture would still see fields accidentally downgraded to Debug
+	// and hide exactly the regression this guards (GitHub #4059 supportability).
+	logs := logtest.CaptureBufferAt(t, slog.LevelInfo)
 
 	client := &BwClient{Settings: &conf.Settings{}}
 	res, err := client.encodeWithNativeFLAC(sinePCM(conf.SampleRate, -30), testTimestamp)

--- a/internal/datastore/analytics.go
+++ b/internal/datastore/analytics.go
@@ -409,27 +409,41 @@ func (ds *DataStore) GetSpeciesSummaryData(ctx context.Context, startDate, endDa
 	return summaries, nil
 }
 
+// applyHourlyAnalyticsFilters applies the WHERE filters shared by the hourly
+// analytics aggregation and its unparseable-time self-check: exclude detections
+// marked as false positive, an optional exact-date match, and an optional
+// species match on scientific or common name. Unlike the hourly-distribution
+// filters, the date match here is an exact single day, not a range. Keeping
+// both callers on one helper means the self-check counts exactly the rows the
+// aggregation groups.
+func (ds *DataStore) applyHourlyAnalyticsFilters(q *gorm.DB, date, species string) *gorm.DB {
+	q = q.Where("(note_reviews.verified IS NULL OR note_reviews.verified != ?)", string(entities.VerificationFalsePositive))
+
+	if date != "" {
+		q = q.Where("notes.date = ?", date)
+	}
+
+	if species != "" {
+		q = q.Where("notes.scientific_name = ? OR notes.common_name = ?", species, species)
+	}
+
+	return q
+}
+
 // GetHourlyAnalyticsData retrieves detection counts grouped by hour
 func (ds *DataStore) GetHourlyAnalyticsData(ctx context.Context, date, species string) ([]HourlyAnalyticsData, error) {
 	var analytics []HourlyAnalyticsData
 	hourFormat := ds.GetHourFormat()
 
-	// Base query - exclude detections marked as false_positive
-	query := ds.DB.WithContext(ctx).Table("notes").
-		Joins("LEFT JOIN note_reviews ON notes.id = note_reviews.note_id").
+	// Base query - exclude false positives plus the optional date/species
+	// filters - grouped by the dialect-specific hour expression.
+	query := ds.applyHourlyAnalyticsFilters(
+		ds.DB.WithContext(ctx).Table("notes").
+			Joins("LEFT JOIN note_reviews ON notes.id = note_reviews.note_id"),
+		date, species).
 		Select(fmt.Sprintf("%s as hour, COUNT(*) as count", hourFormat)).
-		Where("(note_reviews.verified IS NULL OR note_reviews.verified != ?)", string(entities.VerificationFalsePositive)).
 		Group(hourFormat).
 		Order("hour")
-
-	// Apply filters
-	if date != "" {
-		query = query.Where("notes.date = ?", date)
-	}
-
-	if species != "" {
-		query = query.Where("notes.scientific_name = ? OR notes.common_name = ?", species, species)
-	}
 
 	// Execute query
 	if err := query.Scan(&analytics).Error; err != nil {
@@ -440,6 +454,19 @@ func (ds *DataStore) GetHourlyAnalyticsData(ctx context.Context, date, species s
 			Context("date", date).
 			Context("species", species).
 			Build()
+	}
+
+	// Same unparseable-time invariant as GetHourlyDistribution (GitHub #3388):
+	// detections with a malformed time column collapse into the hour-0 bucket
+	// and silently hollow out this by-hour aggregation. Only run the extra COUNT
+	// when an hour-0 bucket is present, since NULL hours scan into Hour == 0.
+	if hasHourZeroBucket(analytics, func(r HourlyAnalyticsData) int { return r.Hour }) {
+		ds.warnIfHoursUnparseable(ctx, "get_hourly_analytics_data", hourFormat,
+			func(q *gorm.DB) *gorm.DB {
+				return ds.applyHourlyAnalyticsFilters(q, date, species)
+			},
+			logger.String("date", date),
+			logger.String("species", species))
 	}
 
 	return analytics, nil
@@ -751,12 +778,18 @@ func (ds *DataStore) GetHourlyDistribution(ctx context.Context, startDate, endDa
 	// flat at zero despite data). The failure is not an empty result: GROUP BY
 	// always yields at least one bucket per matching row. It is that detections
 	// with an unparseable time column make the hour expression evaluate to NULL,
-	// so they collapse into a bogus bucket and the by-hour chart degenerates.
-	// When any data came back, count the rows whose hour could not be extracted
-	// and warn if there are any. Skipped entirely when there is genuinely no
-	// data, so a fresh install pays nothing.
-	if len(results) > 0 {
-		ds.warnIfHoursUnparseable(ctx, startDate, endDate, species, hourExpr)
+	// so they collapse into the hour-0 bucket and the by-hour chart degenerates.
+	// Only run the extra COUNT when an hour-0 bucket is actually present: NULL
+	// hours scan into Hour == 0, so their absence proves there is nothing to
+	// find, and a healthy install with no midnight detections pays nothing.
+	if hasHourZeroBucket(results, func(r HourlyDistributionData) int { return r.Hour }) {
+		ds.warnIfHoursUnparseable(ctx, "get_hourly_distribution", hourExpr,
+			func(q *gorm.DB) *gorm.DB {
+				return ds.applyHourlyDistributionFilters(q, startDate, endDate, species)
+			},
+			logger.String("start_date", startDate),
+			logger.String("end_date", endDate),
+			logger.String("species", species))
 	}
 
 	return results, nil
@@ -792,35 +825,61 @@ func (ds *DataStore) applyHourlyDistributionFilters(q *gorm.DB, startDate, endDa
 // time column) and emits a WARN when any exist. Those rows collapse into a
 // single bogus bucket and hollow out the by-hour chart (GitHub #3388); the WARN
 // puts the evidence and the count into default logs / a support dump without a
-// live reproduction. hourExpr is an internal constant from GetHourFormat (not
-// user input), so interpolating it into the predicate is safe. A count error is
-// logged at debug and swallowed: this diagnostic path must never mask the
-// (successful) primary result.
-func (ds *DataStore) warnIfHoursUnparseable(ctx context.Context, startDate, endDate, species, hourExpr string) {
+// live reproduction.
+//
+// It is shared by the two by-hour aggregations (GetHourlyDistribution and its
+// sibling GetHourlyAnalyticsData). The caller passes the operation name, the
+// hour expression, and applyFilters: a closure that applies the SAME WHERE
+// filters its aggregation used, so the count matches exactly the rows that were
+// grouped and the two filter sets cannot drift. extraFields carry the
+// operation-specific context (date range, species) onto the WARN.
+//
+// hourExpr is an internal constant from GetHourFormat (not user input), so
+// interpolating it into the predicate is safe. A count error is logged at debug
+// and swallowed: this diagnostic path must never mask the (successful) primary
+// result.
+func (ds *DataStore) warnIfHoursUnparseable(ctx context.Context, operation, hourExpr string, applyFilters func(*gorm.DB) *gorm.DB, extraFields ...logger.Field) {
 	if hourExpr == "" {
 		return // unsupported dialect; GetHourFormat already returns empty
 	}
 	var unparseable int64
-	countQuery := ds.applyHourlyDistributionFilters(
+	countQuery := applyFilters(
 		ds.DB.WithContext(ctx).Table("notes").
-			Joins("LEFT JOIN note_reviews ON notes.id = note_reviews.note_id"),
-		startDate, endDate, species).
+			Joins("LEFT JOIN note_reviews ON notes.id = note_reviews.note_id")).
 		Where(fmt.Sprintf("%s IS NULL", hourExpr))
 	if err := countQuery.Count(&unparseable).Error; err != nil {
-		GetLogger().Debug("hourly distribution self-check count failed",
-			logger.String("operation", "get_hourly_distribution"),
+		GetLogger().Debug("hourly self-check count failed",
+			logger.String("operation", operation),
 			logger.Error(err))
 		return
 	}
-	if unparseable > 0 {
-		GetLogger().Warn("hourly distribution: detections have an unparseable time and were excluded from the by-hour chart; the time column may be malformed (GitHub #3388)",
-			logger.String("operation", "get_hourly_distribution"),
-			logger.String("hour_expr", hourExpr),
-			logger.Int64("unparseable_time_rows", unparseable),
-			logger.String("start_date", startDate),
-			logger.String("end_date", endDate),
-			logger.String("species", species))
+	if unparseable == 0 {
+		return
 	}
+	fields := make([]logger.Field, 0, 3+len(extraFields))
+	fields = append(fields,
+		logger.String("operation", operation),
+		logger.String("hour_expr", hourExpr),
+		logger.Int64("unparseable_time_rows", unparseable))
+	fields = append(fields, extraFields...)
+	GetLogger().Warn("detections have an unparseable time and were excluded from the by-hour chart; the time column may be malformed (GitHub #3388)", fields...)
+}
+
+// hasHourZeroBucket reports whether any aggregated row landed in the hour-0
+// bucket. Detections whose time is unparseable make the hour expression
+// evaluate to SQL NULL, which scans into the Go int Hour field as 0, so every
+// unparseable-time row collapses into the hour-0 bucket. When no hour-0 bucket
+// is present the unparseable-time self-check can be skipped entirely (its extra
+// COUNT would provably find nothing). A legitimate midnight detection also
+// lands in hour 0, so this is a necessary-but-not-sufficient gate: presence
+// means "run the check", absence means "provably none".
+func hasHourZeroBucket[T any](rows []T, hourOf func(T) int) bool {
+	for i := range rows {
+		if hourOf(rows[i]) == 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // GetSpeciesFirstDetectionInPeriod finds the first detection of each species within a specific date range.

--- a/internal/datastore/analytics_invariant_test.go
+++ b/internal/datastore/analytics_invariant_test.go
@@ -1,39 +1,16 @@
-// analytics_invariant_test.go: tests for the hourly-distribution
-// unparseable-time self-check (GitHub #3388).
+// analytics_invariant_test.go: tests for the hourly by-hour unparseable-time
+// self-check (GitHub #3388), covering both GetHourlyDistribution and its
+// sibling GetHourlyAnalyticsData.
 package datastore
 
 import (
-	"bytes"
-	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/logger/logtest"
 )
-
-// captureDatastoreLogs swaps in a process-global logger that writes to a
-// buffer, runs fn, restores the previous global, and returns what was logged.
-func captureDatastoreLogs(t *testing.T, fn func()) string {
-	t.Helper()
-	var buf bytes.Buffer
-	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
-	cfg := &logger.LoggingConfig{
-		DefaultLevel: "debug",
-		Console:      &logger.ConsoleOutput{Enabled: false},
-		FileOutput:   &logger.FileOutput{Enabled: false},
-	}
-	cl, err := logger.NewCentralLogger(cfg, handler)
-	require.NoError(t, err, "failed to create test logger")
-
-	oldGlobal := logger.Global()
-	logger.SetGlobal(cl)
-	t.Cleanup(func() { logger.SetGlobal(oldGlobal) })
-
-	fn()
-	return buf.String()
-}
 
 const hourlyUnparseableMsg = "detections have an unparseable time and were excluded from the by-hour chart"
 
@@ -57,7 +34,7 @@ func seedHourlyDetection(t *testing.T, ds *DataStore, timeVal string) {
 // trigger path (aggregation returns a bucket, but some rows are NULL-hour) is
 // exercised, not just the helper in isolation.
 func TestHourlyDistributionUnparseableTimeSelfCheck(t *testing.T) {
-	// Not parallel: captureDatastoreLogs swaps the process-global logger.
+	// Not parallel: logtest.Capture swaps the process-global logger.
 
 	t.Run("warns when some detections have an unparseable time", func(t *testing.T) {
 		ds := setupTestDB(t)
@@ -66,7 +43,7 @@ func TestHourlyDistributionUnparseableTimeSelfCheck(t *testing.T) {
 		seedHourlyDetection(t, ds, "garbage")  // malformed -> strftime NULL
 
 		var results []HourlyDistributionData
-		out := captureDatastoreLogs(t, func() {
+		out := logtest.Capture(t, func() {
 			var err error
 			results, err = ds.GetHourlyDistribution(t.Context(), "", "", "")
 			require.NoError(t, err)
@@ -74,6 +51,7 @@ func TestHourlyDistributionUnparseableTimeSelfCheck(t *testing.T) {
 		require.NotEmpty(t, results, "valid rows still produce a bucket, so the check runs")
 		assert.Contains(t, out, "level=WARN")
 		assert.Contains(t, out, hourlyUnparseableMsg)
+		assert.Contains(t, out, "operation=get_hourly_distribution")
 		assert.Contains(t, out, "unparseable_time_rows=2")
 	})
 
@@ -84,7 +62,7 @@ func TestHourlyDistributionUnparseableTimeSelfCheck(t *testing.T) {
 
 		// All rows collapse into one NULL(->0) bucket, so results is non-empty
 		// (this is the real #3388 shape) and the check still fires.
-		out := captureDatastoreLogs(t, func() {
+		out := logtest.Capture(t, func() {
 			_, err := ds.GetHourlyDistribution(t.Context(), "", "", "")
 			require.NoError(t, err)
 		})
@@ -98,7 +76,7 @@ func TestHourlyDistributionUnparseableTimeSelfCheck(t *testing.T) {
 		seedHourlyDetection(t, ds, "21:15:00")
 
 		var results []HourlyDistributionData
-		out := captureDatastoreLogs(t, func() {
+		out := logtest.Capture(t, func() {
 			var err error
 			results, err = ds.GetHourlyDistribution(t.Context(), "", "", "")
 			require.NoError(t, err)
@@ -112,9 +90,115 @@ func TestHourlyDistributionUnparseableTimeSelfCheck(t *testing.T) {
 		ds := setupTestDB(t)
 
 		var results []HourlyDistributionData
-		out := captureDatastoreLogs(t, func() {
+		out := logtest.Capture(t, func() {
 			var err error
 			results, err = ds.GetHourlyDistribution(t.Context(), "", "", "")
+			require.NoError(t, err)
+		})
+		assert.Empty(t, results)
+		assert.NotContains(t, out, hourlyUnparseableMsg,
+			"an empty database is expected, not an anomaly")
+	})
+}
+
+// TestHourlyAnalyticsUnparseableTimeSelfCheck covers the sibling self-check on
+// GetHourlyAnalyticsData (GitHub #1587 follow-up): it must WARN under exactly
+// the same unparseable-time condition, tagged with its own operation, and stay
+// silent for well-formed times, an empty database, and a midnight-only case
+// (hour-0 bucket present but no NULL rows).
+func TestHourlyAnalyticsUnparseableTimeSelfCheck(t *testing.T) {
+	// Not parallel: logtest.Capture swaps the process-global logger.
+
+	t.Run("warns when some detections have an unparseable time", func(t *testing.T) {
+		ds := setupTestDB(t)
+		seedHourlyDetection(t, ds, "08:30:00") // valid
+		seedHourlyDetection(t, ds, "")         // empty -> strftime NULL
+		seedHourlyDetection(t, ds, "garbage")  // malformed -> strftime NULL
+
+		var results []HourlyAnalyticsData
+		out := logtest.Capture(t, func() {
+			var err error
+			results, err = ds.GetHourlyAnalyticsData(t.Context(), "", "")
+			require.NoError(t, err)
+		})
+		require.NotEmpty(t, results, "valid rows still produce a bucket, so the check runs")
+		assert.Contains(t, out, "level=WARN")
+		assert.Contains(t, out, hourlyUnparseableMsg)
+		assert.Contains(t, out, "operation=get_hourly_analytics_data")
+		assert.Contains(t, out, "unparseable_time_rows=2")
+	})
+
+	t.Run("date and species filter each scope the self-check to matching rows", func(t *testing.T) {
+		ds := setupTestDB(t)
+		// The queried species on the queried date, unparseable time -> counted.
+		require.NoError(t, ds.DB.Create(&Note{
+			Date: "2024-07-15", Time: "", ScientificName: "Turdus migratorius",
+			CommonName: "American Robin", Confidence: 0.9,
+		}).Error)
+		// Same species, wrong date, also unparseable -> excluded by the DATE
+		// filter alone.
+		require.NoError(t, ds.DB.Create(&Note{
+			Date: "2024-07-16", Time: "garbage", ScientificName: "Turdus migratorius",
+			CommonName: "American Robin", Confidence: 0.9,
+		}).Error)
+		// Right date, wrong species, also unparseable -> excluded by the SPECIES
+		// filter alone. Together these prove the self-check applies BOTH filters,
+		// exactly as the aggregation does, rather than counting every
+		// unparseable row in the table.
+		require.NoError(t, ds.DB.Create(&Note{
+			Date: "2024-07-15", Time: "not-a-time", ScientificName: "Cyanocitta cristata",
+			CommonName: "Blue Jay", Confidence: 0.9,
+		}).Error)
+
+		out := logtest.Capture(t, func() {
+			_, err := ds.GetHourlyAnalyticsData(t.Context(), "2024-07-15", "Turdus migratorius")
+			require.NoError(t, err)
+		})
+		assert.Contains(t, out, hourlyUnparseableMsg)
+		assert.Contains(t, out, "operation=get_hourly_analytics_data")
+		assert.Contains(t, out, "unparseable_time_rows=1",
+			"only the row matching BOTH the date and species filter must be counted, "+
+				"not the rows excluded by date-only or species-only")
+	})
+
+	t.Run("silent on well-formed times", func(t *testing.T) {
+		ds := setupTestDB(t)
+		seedHourlyDetection(t, ds, "08:30:00")
+		seedHourlyDetection(t, ds, "21:15:00")
+
+		var results []HourlyAnalyticsData
+		out := logtest.Capture(t, func() {
+			var err error
+			results, err = ds.GetHourlyAnalyticsData(t.Context(), "", "")
+			require.NoError(t, err)
+		})
+		require.NotEmpty(t, results, "well-formed times must produce buckets, so the check actually runs")
+		assert.NotContains(t, out, hourlyUnparseableMsg, "well-formed times must not warn")
+	})
+
+	t.Run("silent on a midnight-only dataset (hour-0 bucket, no NULL rows)", func(t *testing.T) {
+		ds := setupTestDB(t)
+		seedHourlyDetection(t, ds, "00:10:00") // legitimate midnight -> hour 0
+		seedHourlyDetection(t, ds, "00:45:00")
+
+		var results []HourlyAnalyticsData
+		out := logtest.Capture(t, func() {
+			var err error
+			results, err = ds.GetHourlyAnalyticsData(t.Context(), "", "")
+			require.NoError(t, err)
+		})
+		require.NotEmpty(t, results, "midnight detections still produce an hour-0 bucket")
+		assert.NotContains(t, out, hourlyUnparseableMsg,
+			"a real midnight bucket must not be mistaken for unparseable times")
+	})
+
+	t.Run("silent on an empty database", func(t *testing.T) {
+		ds := setupTestDB(t)
+
+		var results []HourlyAnalyticsData
+		out := logtest.Capture(t, func() {
+			var err error
+			results, err = ds.GetHourlyAnalyticsData(t.Context(), "", "")
 			require.NoError(t, err)
 		})
 		assert.Empty(t, results)

--- a/internal/datastore/logger_test.go
+++ b/internal/datastore/logger_test.go
@@ -1,16 +1,13 @@
 package datastore
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"log/slog"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/logger/logtest"
 	gormlogger "gorm.io/gorm/logger"
 )
 
@@ -32,21 +29,8 @@ func TestGormLogger_Trace_ContextCancellation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Not parallel: swaps the process-global logger for the duration.
-			var buf bytes.Buffer
-			handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
-			cfg := &logger.LoggingConfig{
-				DefaultLevel: "debug",
-				Console:      &logger.ConsoleOutput{Enabled: false},
-				FileOutput:   &logger.FileOutput{Enabled: false},
-			}
-			cl, err := logger.NewCentralLogger(cfg, handler)
-			require.NoError(t, err, "failed to create test logger")
-
-			// Restore the global logger after the subtest.
-			oldGlobal := logger.Global()
-			logger.SetGlobal(cl)
-			t.Cleanup(func() { logger.SetGlobal(oldGlobal) })
+			// Not parallel: logtest.CaptureBuffer swaps the process-global logger.
+			buf := logtest.CaptureBuffer(t)
 
 			gLogger := NewGormLogger(200*time.Millisecond, gormlogger.Info, nil, "sqlite")
 
@@ -85,7 +69,7 @@ func TestGormLogger_Trace_ErrorContext(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Not parallel: captureDatastoreLogs swaps the process-global logger.
+			// Not parallel: logtest.Capture swaps the process-global logger.
 			gLogger := NewGormLogger(200*time.Millisecond, gormlogger.Info, nil, tt.dialect)
 
 			fc := func() (sql string, rowsAffected int64) {
@@ -94,7 +78,7 @@ func TestGormLogger_Trace_ErrorContext(t *testing.T) {
 			// A plain syntax-style error, not a cancellation or ErrRecordNotFound,
 			// takes the "Database query failed" branch.
 			queryErr := fmt.Errorf("Error 1064 (42000): syntax error near ')'")
-			out := captureDatastoreLogs(t, func() {
+			out := logtest.Capture(t, func() {
 				gLogger.Trace(t.Context(), time.Now(), fc, queryErr)
 			})
 			assert.Contains(t, out, "Database query failed", "a real query fault must log at error level")

--- a/internal/diskmanager/policy_common.go
+++ b/internal/diskmanager/policy_common.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/formatutil"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/observability/metrics"
 )
@@ -640,25 +641,6 @@ func (s *cleanupSummary) usageStillOverTarget() bool {
 	return s.usageThreshold > 0 && s.usageAfter != unknownUsagePercent && s.usageAfter >= s.usageThreshold
 }
 
-// humanizeBytes renders a byte count as a short human-readable string (e.g.
-// "150 MB") for the cleanup summary, so a support dump shows freed space at a
-// glance without the reader converting raw bytes. Raw bytes are logged too.
-func humanizeBytes(b int64) string {
-	const unit = 1024
-	if b < unit {
-		return fmt.Sprintf("%d B", b)
-	}
-	// exp cannot exceed 5 ('E') for any int64, but bound the loop explicitly so
-	// the prefix index can never go out of range regardless of input.
-	const prefixes = "KMGTPE"
-	div, exp := int64(unit), 0
-	for n := b / unit; n >= unit && exp < len(prefixes)-1; n /= unit {
-		div *= unit
-		exp++
-	}
-	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), prefixes[exp])
-}
-
 // appendUsageFields adds the disk-usage percentage fields to a log field slice,
 // skipping any that were not measured or do not apply (unknownUsagePercent /
 // non-positive threshold), so neither the INFO summary nor a WARN logs a
@@ -691,7 +673,7 @@ func logCleanupSummary(s *cleanupSummary) {
 		logger.Int("files_scanned", s.stats.Scanned),
 		logger.Int("files_deleted", s.stats.Deleted),
 		logger.Int64("bytes_freed", s.stats.BytesFreed),
-		logger.String("bytes_freed_human", humanizeBytes(s.stats.BytesFreed)),
+		logger.String("bytes_freed_human", formatutil.Bytes(s.stats.BytesFreed)),
 		logger.Int("locked_skipped", s.stats.LockedSkipped),
 		logger.Int("min_clips_blocked", s.stats.MinClipsBlocked),
 		logger.Int("not_eligible", s.stats.NotEligible),

--- a/internal/diskmanager/policy_common_test.go
+++ b/internal/diskmanager/policy_common_test.go
@@ -1,65 +1,13 @@
 package diskmanager
 
 import (
-	"bytes"
-	"log/slog"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/tphakala/birdnet-go/internal/logger"
+
+	"github.com/tphakala/birdnet-go/internal/logger/logtest"
 )
-
-// captureCleanupLogs swaps in a process-global logger that writes to a buffer,
-// runs fn, restores the previous global, and returns everything logged. Used to
-// assert that logCleanupSummary emits (or withholds) the WARN escalation.
-func captureCleanupLogs(t *testing.T, fn func()) string {
-	t.Helper()
-	var buf bytes.Buffer
-	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
-	cfg := &logger.LoggingConfig{
-		DefaultLevel: "debug",
-		Console:      &logger.ConsoleOutput{Enabled: false},
-		FileOutput:   &logger.FileOutput{Enabled: false},
-	}
-	cl, err := logger.NewCentralLogger(cfg, handler)
-	require.NoError(t, err, "failed to create test logger")
-
-	oldGlobal := logger.Global()
-	logger.SetGlobal(cl)
-	t.Cleanup(func() { logger.SetGlobal(oldGlobal) })
-
-	fn()
-	return buf.String()
-}
-
-// TestHumanizeBytes verifies the human-readable byte rendering used in the
-// cleanup summary line. Boundaries (exactly 1 KiB, sub-KiB) are covered so a
-// support dump reads freed space at a glance.
-func TestHumanizeBytes(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name  string
-		bytes int64
-		want  string
-	}{
-		{"zero", 0, "0 B"},
-		{"sub-kib", 512, "512 B"},
-		{"one-kib-boundary", 1024, "1.0 KB"},
-		{"kilobytes", 1536, "1.5 KB"},
-		{"megabytes", 150 * 1024 * 1024, "150.0 MB"},
-		{"gigabytes", 18 * 1024 * 1024 * 1024, "18.0 GB"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tt.want, humanizeBytes(tt.bytes))
-		})
-	}
-}
 
 // TestCleanupSummaryHitDeletionCap verifies the primary WARN predicate: a run
 // is escalated when it was rate-limited by the per-run deletion cap while
@@ -109,7 +57,7 @@ func TestCleanupSummaryUsageStillOverTarget(t *testing.T) {
 // target (the age policy). It complements the predicate unit tests by covering
 // the emission/routing the predicates feed, not just the decision.
 func TestLogCleanupSummaryWarnEmission(t *testing.T) {
-	// Not parallel: captureCleanupLogs swaps the process-global logger.
+	// Not parallel: logtest.Capture swaps the process-global logger.
 
 	t.Run("age cap-hit emits WARN without usage sentinels", func(t *testing.T) {
 		s := &cleanupSummary{
@@ -117,7 +65,7 @@ func TestLogCleanupSummaryWarnEmission(t *testing.T) {
 			duration: time.Second, maxDeletions: 1000,
 			usageBefore: unknownUsagePercent, usageAfter: unknownUsagePercent, usageThreshold: unknownUsagePercent,
 		}
-		out := captureCleanupLogs(t, func() { logCleanupSummary(s) })
+		out := logtest.Capture(t, func() { logCleanupSummary(s) })
 		assert.Contains(t, out, "level=WARN", "a capped run must escalate to WARN")
 		assert.Contains(t, out, "per-run deletion limit")
 		// The age policy has no usage measurement or target, so none of the
@@ -135,7 +83,7 @@ func TestLogCleanupSummaryWarnEmission(t *testing.T) {
 			duration: time.Second, maxDeletions: 1000,
 			usageBefore: 95, usageAfter: 94, usageThreshold: 80,
 		}
-		out := captureCleanupLogs(t, func() { logCleanupSummary(s) })
+		out := logtest.Capture(t, func() { logCleanupSummary(s) })
 		assert.Contains(t, out, "level=WARN", "finishing above target must escalate to WARN")
 		assert.Contains(t, out, "at or above the configured target")
 		assert.Contains(t, out, "usage_after_pct=94")
@@ -148,7 +96,7 @@ func TestLogCleanupSummaryWarnEmission(t *testing.T) {
 			duration: time.Second, maxDeletions: 1000,
 			usageBefore: 95, usageAfter: 70, usageThreshold: 80,
 		}
-		out := captureCleanupLogs(t, func() { logCleanupSummary(s) })
+		out := logtest.Capture(t, func() { logCleanupSummary(s) })
 		assert.Contains(t, out, "cleanup run summary", "the INFO summary is always emitted")
 		assert.NotContains(t, out, "level=WARN", "a run that reached target must not escalate")
 	})

--- a/internal/formatutil/bytes.go
+++ b/internal/formatutil/bytes.go
@@ -1,0 +1,49 @@
+// Package formatutil holds small, dependency-free formatting helpers shared
+// across the codebase. It is a leaf package (no other internal imports) so that
+// low-level packages like diskmanager can use it without creating an import
+// cycle through the API layer, where some of these helpers previously lived as
+// duplicates.
+package formatutil
+
+import "fmt"
+
+// byteUnit is the base used to step between magnitude prefixes (binary KiB, so
+// 1024), matching every prior copy of this helper so the rendered output is
+// unchanged.
+const byteUnit = 1024
+
+// bytePrefixes are the magnitude prefixes above bytes. The loop that walks them
+// is bounded by their count so the index can never run past 'E' regardless of
+// the input magnitude.
+const bytePrefixes = "KMGTPE"
+
+// Bytes renders a signed byte count as a short human-readable string (e.g.
+// "150.0 MB", "512 B"). Values below one unit are rendered as a plain byte
+// count, so a negative input is printed verbatim (e.g. "-5 B"); callers that
+// can produce negatives and want them clamped should guard before calling.
+func Bytes(b int64) string {
+	if b < byteUnit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(byteUnit), 0
+	for n := b / byteUnit; n >= byteUnit && exp < len(bytePrefixes)-1; n /= byteUnit {
+		div *= byteUnit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), bytePrefixes[exp])
+}
+
+// BytesUint64 renders an unsigned byte count as a short human-readable string,
+// identical in format to Bytes but for uint64 inputs (used where a size is
+// naturally unsigned, e.g. database and backup byte totals).
+func BytesUint64(b uint64) string {
+	if b < byteUnit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := uint64(byteUnit), 0
+	for n := b / byteUnit; n >= byteUnit && exp < len(bytePrefixes)-1; n /= byteUnit {
+		div *= byteUnit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), bytePrefixes[exp])
+}

--- a/internal/formatutil/bytes_test.go
+++ b/internal/formatutil/bytes_test.go
@@ -1,0 +1,64 @@
+package formatutil
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestBytes verifies the signed human-readable byte rendering, including the
+// sub-unit, exact-boundary, and each magnitude step, plus the negative case
+// that documents the "printed verbatim" contract.
+func TestBytes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		bytes int64
+		want  string
+	}{
+		{"zero", 0, "0 B"},
+		{"sub-kib", 512, "512 B"},
+		{"one-kib-boundary", 1024, "1.0 KB"},
+		{"kilobytes", 1536, "1.5 KB"},
+		{"megabytes", 150 * 1024 * 1024, "150.0 MB"},
+		{"gigabytes", 18 * 1024 * 1024 * 1024, "18.0 GB"},
+		{"negative-verbatim", -5, "-5 B"},
+		{"max-int64-stays-in-range", math.MaxInt64, "8.0 EB"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, Bytes(tt.bytes))
+		})
+	}
+}
+
+// TestBytesUint64 verifies the unsigned variant renders identically to Bytes
+// for shared magnitudes and stays bounded at the top of the uint64 range.
+func TestBytesUint64(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		bytes uint64
+		want  string
+	}{
+		{"zero", 0, "0 B"},
+		{"sub-kib", 512, "512 B"},
+		{"one-kib-boundary", 1024, "1.0 KB"},
+		{"kilobytes", 1536, "1.5 KB"},
+		{"megabytes", 150 * 1024 * 1024, "150.0 MB"},
+		{"gigabytes", 18 * 1024 * 1024 * 1024, "18.0 GB"},
+		{"max-uint64-stays-in-range", math.MaxUint64, "16.0 EB"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, BytesUint64(tt.bytes))
+		})
+	}
+}

--- a/internal/logger/logtest/logtest.go
+++ b/internal/logger/logtest/logtest.go
@@ -1,0 +1,91 @@
+// Package logtest provides shared test-only helpers for capturing what the
+// process-global logger emits during a test. It lives in its own importable
+// package (rather than as a _test.go helper) because a _test.go file cannot be
+// imported by other packages; several packages previously each carried a
+// near-identical copy of this swap-global-logger dance. Production code must
+// never import this package: it pulls in "testing" and swaps global state.
+//
+// It mirrors the conftest/apitest pattern already used elsewhere in the tree.
+package logtest
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// levelName maps a slog.Level to the CentralLogger DefaultLevel string, so the
+// logger's own level gate is set consistently with the capture handler's level
+// (otherwise the logger could pre-drop records the handler was asked to keep).
+func levelName(level slog.Level) string {
+	switch {
+	case level <= slog.LevelDebug:
+		return "debug"
+	case level <= slog.LevelInfo:
+		return "info"
+	case level <= slog.LevelWarn:
+		return "warn"
+	default:
+		return "error"
+	}
+}
+
+// CaptureBufferAt swaps in a process-global logger that writes to a fresh buffer
+// at the given minimum level, registers cleanups to restore the previous global
+// and close the capture logger, and returns the buffer. Use it when a test must
+// prove a field is emitted at a specific level: capturing at slog.LevelInfo
+// drops Debug records, so a regression that moves a field to Debug-only fails
+// the test (a Debug-level capture would still see it and hide the regression).
+//
+// It mutates process-wide global state, so a test using it must NOT call
+// t.Parallel().
+func CaptureBufferAt(tb testing.TB, level slog.Level) *bytes.Buffer {
+	tb.Helper()
+
+	var buf bytes.Buffer
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: level})
+	cl, err := logger.NewCentralLogger(&logger.LoggingConfig{
+		DefaultLevel: levelName(level),
+		Console:      &logger.ConsoleOutput{Enabled: false},
+		FileOutput:   &logger.FileOutput{Enabled: false},
+	}, handler)
+	if err != nil {
+		tb.Fatalf("logtest: failed to create capture logger: %v", err)
+	}
+	// Registered before the global swap so it runs last (LIFO): the global is
+	// restored first, then the capture logger is closed.
+	tb.Cleanup(func() { _ = cl.Close() })
+
+	prev := logger.Global()
+	logger.SetGlobal(cl)
+	tb.Cleanup(func() { logger.SetGlobal(prev) })
+
+	return &buf
+}
+
+// CaptureBuffer is CaptureBufferAt at debug level: it captures everything the
+// process-global logger emits. The caller runs whatever emits logs and then
+// reads buf.String(); everything routed through logger.Global() (including any
+// Module derived from it) is captured.
+//
+// It mutates process-wide global state, so a test using it must NOT call
+// t.Parallel().
+func CaptureBuffer(tb testing.TB) *bytes.Buffer {
+	tb.Helper()
+	return CaptureBufferAt(tb, slog.LevelDebug)
+}
+
+// Capture runs fn with the process-global logger swapped for a debug-level
+// buffer-backed one and returns everything fn logged. It is the convenience
+// form of CaptureBuffer for the common "run this, assert on the output" shape.
+//
+// Like CaptureBuffer it mutates global state, so callers must NOT use
+// t.Parallel().
+func Capture(tb testing.TB, fn func()) string {
+	tb.Helper()
+	buf := CaptureBuffer(tb)
+	fn()
+	return buf.String()
+}

--- a/internal/logger/logtest/logtest_test.go
+++ b/internal/logger/logtest/logtest_test.go
@@ -1,0 +1,73 @@
+package logtest_test
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/logger/logtest"
+)
+
+// TestCapture verifies that Capture routes what the process-global logger emits
+// during fn into the returned string.
+func TestCapture(t *testing.T) {
+	// Not parallel: swaps the process-global logger.
+	out := logtest.Capture(t, func() {
+		logger.Global().Module("logtest").Info("hello from logtest", logger.String("marker", "abc123"))
+	})
+	assert.Contains(t, out, "hello from logtest")
+	assert.Contains(t, out, "marker=abc123")
+}
+
+// TestCaptureBuffer verifies the buffer form captures logs emitted after the
+// swap and that the returned buffer is readable by the caller.
+func TestCaptureBuffer(t *testing.T) {
+	// Not parallel: swaps the process-global logger.
+	buf := logtest.CaptureBuffer(t)
+	logger.Global().Module("logtest").Warn("buffered line", logger.Int("n", 7))
+	out := buf.String()
+	assert.Contains(t, out, "level=WARN")
+	assert.Contains(t, out, "buffered line")
+	assert.Contains(t, out, "n=7")
+}
+
+// TestCaptureBufferAtLevel verifies that a level-scoped capture drops records
+// below the requested level. This is the property the birdweather attribution
+// test relies on: an Info capture must NOT see a Debug line, so a field
+// accidentally downgraded to Debug fails the test instead of slipping through.
+func TestCaptureBufferAtLevel(t *testing.T) {
+	// Not parallel: swaps the process-global logger.
+	buf := logtest.CaptureBufferAt(t, slog.LevelInfo)
+	log := logger.Global().Module("logtest")
+	log.Debug("debug-line-must-be-dropped")
+	log.Info("info-line-must-be-kept")
+	out := buf.String()
+	assert.NotContains(t, out, "debug-line-must-be-dropped",
+		"an Info-level capture must filter out Debug records")
+	assert.Contains(t, out, "info-line-must-be-kept")
+}
+
+// TestCaptureRestoresGlobal verifies the previous global logger is actually
+// restored after a capturing subtest's cleanup runs, by pointer identity: a
+// prior version of this test asserted only that a later capture did not contain
+// the earlier line, which holds by construction (each capture gets a fresh
+// buffer) and so proved nothing about restoration.
+func TestCaptureRestoresGlobal(t *testing.T) {
+	// Not parallel: swaps the process-global logger.
+	orig := logger.Global()
+
+	t.Run("inner", func(t *testing.T) {
+		buf := logtest.CaptureBuffer(t)
+		assert.NotSame(t, orig, logger.Global(),
+			"the global logger must be swapped for the capture logger inside the subtest")
+		logger.Global().Module("logtest").Info("inner-only")
+		assert.Contains(t, buf.String(), "inner-only")
+	})
+
+	// The inner subtest has returned, so its Cleanup has run. If SetGlobal(prev)
+	// were not registered, this would observe the un-restored capture logger.
+	assert.Same(t, orig, logger.Global(),
+		"the previous global logger must be restored after the capturing subtest")
+}

--- a/internal/weather/provider_apikey_leak_test.go
+++ b/internal/weather/provider_apikey_leak_test.go
@@ -1,8 +1,6 @@
 package weather
 
 import (
-	"bytes"
-	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -13,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
-	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/logger/logtest"
 )
 
 // sentinelAPIKey is a recognizable, non-secret token used to prove that a
@@ -21,34 +19,6 @@ import (
 // URL-safe characters so it survives URL building unescaped, making any leak
 // trivially detectable with a substring check.
 const sentinelAPIKey = "SENTINELKEY0123456789DONOTLEAK"
-
-// captureWeatherLogs redirects the global logger to an in-memory buffer for the
-// duration of the test and returns the buffer. The weather package logs through
-// logger.Global().Module("weather"), so this captures everything the providers
-// emit while a test runs. It swaps process-wide global state, so tests using it
-// must not run with t.Parallel().
-func captureWeatherLogs(t *testing.T) *bytes.Buffer {
-	t.Helper()
-
-	var buf bytes.Buffer
-	capture := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
-	cl, err := logger.NewCentralLogger(
-		&logger.LoggingConfig{
-			Console:      &logger.ConsoleOutput{Enabled: false},
-			FileOutput:   &logger.FileOutput{Enabled: false},
-			DefaultLevel: "debug",
-		},
-		capture,
-	)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = cl.Close() })
-
-	prev := logger.Global()
-	logger.SetGlobal(cl)
-	t.Cleanup(func() { logger.SetGlobal(prev) })
-
-	return &buf
-}
 
 // TestOpenWeatherProvider_TransportError_DoesNotLeakAPIKey is a regression guard
 // for the API-key-in-logs vulnerability. net/http wraps transport failures in a
@@ -58,7 +28,7 @@ func captureWeatherLogs(t *testing.T) *bytes.Buffer {
 // support dumps.
 func TestOpenWeatherProvider_TransportError_DoesNotLeakAPIKey(t *testing.T) {
 	setupHTTPMock(t)
-	logs := captureWeatherLogs(t)
+	logs := logtest.CaptureBuffer(t)
 
 	// Force every attempt's client.Do to fail at the transport layer so the
 	// provider exercises its failure-log and error-wrap paths.
@@ -84,7 +54,7 @@ func TestOpenWeatherProvider_TransportError_DoesNotLeakAPIKey(t *testing.T) {
 // scrubbed so a plain logger.Error in weather.go cannot leak it.
 func TestWundergroundProvider_TransportError_DoesNotLeakAPIKey(t *testing.T) {
 	setupHTTPMock(t)
-	logs := captureWeatherLogs(t)
+	logs := logtest.CaptureBuffer(t)
 
 	httpmock.RegisterResponder("GET", `=~^https://api\.weather\.com/v2/pws/observations/current`,
 		httpmock.NewErrorResponder(errors.NewStd("simulated transport failure")))
@@ -112,7 +82,7 @@ func TestWundergroundProvider_TransportError_DoesNotLeakAPIKey(t *testing.T) {
 // payload here is the coordinates rather than an API key.
 func TestYrNoProvider_TransportError_DoesNotLeakCoordinates(t *testing.T) {
 	setupHTTPMock(t)
-	logs := captureWeatherLogs(t)
+	logs := logtest.CaptureBuffer(t)
 
 	// Force every attempt's client.Do to fail at the transport layer so the
 	// provider exercises its failure-log and error-wrap paths.


### PR DESCRIPTION
## Summary

Four low-severity tech-debt items folded into one change. Everything is behavior-preserving except a single added WARN diagnostic. No public API changes (one exported helper is retained as a delegator), no config or schema changes.

**1. Hourly by-hour self-check parity.** `GetHourlyDistribution` already emits an invariant WARN when detections have an unparseable time column that collapses the by-hour chart (GitHub #3388). Its sibling `GetHourlyAnalyticsData` grouped by the same hour expression with no such guard. `warnIfHoursUnparseable` is generalized to take a filter closure and an operation name so both aggregations share one implementation, and the check is extended to `GetHourlyAnalyticsData`. Both call sites now gate the extra COUNT on an hour-0 bucket being present: an unparseable time makes the hour expression evaluate to SQL NULL, which scans into `Hour == 0`, so the absence of an hour-0 bucket proves there is nothing to count and the diagnostic COUNT is skipped.

**2. Byte-formatter dedup.** Three identical KMGTPE byte-formatter copies existed (`apicore.FormatBytesUint64`, `diskmanager.humanizeBytes`, and an `imports` package `formatBytes`). They are replaced by a new dependency-free leaf package `internal/formatutil` (`Bytes`, `BytesUint64`). `apicore.FormatBytesUint64` is kept as a one-line delegator so its external callers are untouched; the two unexported copies are removed and their call sites rewired. Output is byte-identical for every input range.

**3. Log-capture helper dedup.** Seven packages each carried a near-identical helper that swaps the process-global logger for a buffer and restores it on cleanup. They are consolidated into a new importable test-support package `internal/logger/logtest` (`Capture`, `CaptureBuffer`, `CaptureBufferAt`), following the existing `conftest`/`apitest` pattern. `CaptureBufferAt` preserves the one Info-level capture (the birdweather attribution test) that must not be widened to Debug, so that test's support-dump regression guard stays meaningful.

## Related Issues

Extends the unparseable-time diagnostic from GitHub #3388 to the sibling analytics query. No functional change to the retention-cleanup diagnostics from #4059.

## Test Plan

- [x] `golangci-lint run` clean on the full project (0 issues)
- [x] `go test -race` green for every touched package (formatutil, logtest, datastore, diskmanager, apicore, imports, api/middleware, birdweather, analysis/processor, weather)
- [x] New tests: `formatutil` boundary/negative/max cases; `logtest` capture, level-filtering, and global-restore; `GetHourlyAnalyticsData` unparseable-time self-check including the midnight-only (hour-0 bucket, no NULL rows) and per-filter scoping cases
- [x] Byte-formatter output verified identical to the three removed copies across int64/uint64 ranges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent formatting for file sizes and storage amounts across the application, including support for very large values and negative amounts.

* **Bug Fixes**
  * Improved hourly analytics diagnostics by detecting and reporting unparseable timestamps more consistently.
  * Ensured diagnostic checks respect the selected analytics filters.

* **Refactor**
  * Standardized logging behavior and test coverage across analytics, imports, storage, and weather integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->