### PR TITLE
fix(processor): track dynamic thresholds per species, not per model

### DIFF
--- a/internal/analysis/control_monitor.go
+++ b/internal/analysis/control_monitor.go
@@ -343,8 +343,6 @@ func (cm *ControlMonitor) handleControlSignal(signal string) {
 		cm.handleRebuildExtendedCapture()
 	case "reconfigure_audio_sources":
 		cm.handleReconfigureAudioSources()
-	case "recalculate_dynamic_thresholds":
-		cm.handleRecalculateDynamicThresholds()
 	case "reconfigure_dynamic_thresholds":
 		cm.handleReconfigureDynamicThresholds()
 	case schedule.SignalReconfigureQuietHours:
@@ -1020,16 +1018,6 @@ func (cm *ControlMonitor) handleReconfigureAudioSources() {
 	// Source reassignment changes the inference topology; notify the metrics SSE stream.
 	if cm.apiController != nil {
 		cm.apiController.BroadcastInferenceTopologyChanged()
-	}
-}
-
-// handleRecalculateDynamicThresholds recalculates all dynamic threshold CurrentValue entries
-// when the global BirdNET.Threshold changes. The stored absolute values are recomputed
-// from each species' current level/tier and the new base threshold.
-func (cm *ControlMonitor) handleRecalculateDynamicThresholds() {
-	if cm.proc != nil {
-		cm.proc.RecalculateDynamicThresholds()
-		emitHotReload("dynamic_thresholds")
 	}
 }
 

--- a/internal/analysis/processor/dynamic_threshold.go
+++ b/internal/analysis/processor/dynamic_threshold.go
@@ -23,61 +23,59 @@ const (
 	changeReasonExpiry         = "expiry"          // Threshold reset due to timer expiration
 )
 
-// defaultModelID is the model identity used when no explicit model ID is provided.
-const defaultModelID = "BirdNET"
-
-// dynamicThresholdKey creates a composite key for scoping thresholds per model.
-// The key format is "modelID:speciesLowercase".
-func dynamicThresholdKey(modelID, speciesLowercase string) string {
-	if modelID == "" {
-		modelID = defaultModelID
-	}
-	return modelID + ":" + speciesLowercase
-}
-
-// splitDynamicThresholdKey splits a composite key back into modelID and species name.
-// Returns (modelID, speciesName). If the key has no separator, returns (defaultModelID, key).
-func splitDynamicThresholdKey(key string) (modelID, speciesName string) {
-	parts := strings.SplitN(key, ":", 2)
-	if len(parts) == 2 {
-		return parts[0], parts[1]
-	}
-	return defaultModelID, key
-}
-
 // DynamicThreshold represents the dynamic threshold configuration for a species.
+//
+// Tracking is per species, not per model: the learned state (Level, HighConfCount,
+// Timer) means "this species is confirmed present at this location", which is
+// model-independent. Any model's approved high-confidence detection advances the
+// shared level. The applied threshold is computed live at read time from the
+// caller's model-specific base and the shared level (see getAdjustedConfidenceThreshold),
+// so no absolute value is stored.
 type DynamicThreshold struct {
-	Level          int
-	CurrentValue   float64
-	Timer          time.Time
-	HighConfCount  int
-	ValidHours     int
+	Level         int
+	Timer         time.Time
+	HighConfCount int
+	ValidHours    int
+	// BaseThreshold is the model-global base of the model that last learned this
+	// species. It is display/persistence metadata only and is NEVER used to compute
+	// the applied threshold; that always uses the caller's live per-model base.
+	BaseThreshold  float64
 	ScientificName string
 	LastLearnedAt  time.Time // Tracks when the last threshold learning event occurred to prevent multiple learnings within a single detection window
 }
 
+// effectiveDynamicThreshold computes the applied threshold from a model-specific
+// base and the species' shared learned level, clamped to the configured minimum.
+// At level 0 the multiplier is 1.0, so this returns base (clamped), preserving the
+// no-adjustment default.
+func effectiveDynamicThreshold(base float64, level int, minThreshold float64) float64 {
+	value := base * levelMultiplier(level)
+	if value < minThreshold {
+		value = minThreshold
+	}
+	return value
+}
+
 // addSpeciesToDynamicThresholds adds a species to the dynamic thresholds map if it doesn't already exist.
-func (p *Processor) addSpeciesToDynamicThresholds(modelID, speciesLowercase, scientificName string, baseThreshold float32) {
+func (p *Processor) addSpeciesToDynamicThresholds(speciesLowercase, scientificName string, baseThreshold float32) {
 	settings := p.currentSettings()
 
 	// Lock the mutex to ensure thread-safe access to the DynamicThresholds map
 	p.thresholdsMutex.Lock()
 	defer p.thresholdsMutex.Unlock()
 
-	key := dynamicThresholdKey(modelID, speciesLowercase)
-
 	// Check if the species already has a dynamic threshold
-	existing, exists := p.DynamicThresholds[key]
+	existing, exists := p.DynamicThresholds[speciesLowercase]
 
 	// If it doesn't exist, initialize it
 	if !exists {
 		if settings.Realtime.DynamicThreshold.Debug {
 			log := GetLogger()
-			log.Debug("Initializing dynamic threshold", logger.String("species", speciesLowercase), logger.String("model_id", modelID))
+			log.Debug("Initializing dynamic threshold", logger.String("species", speciesLowercase))
 		}
-		p.DynamicThresholds[key] = &DynamicThreshold{
+		p.DynamicThresholds[speciesLowercase] = &DynamicThreshold{
 			Level:          0,
-			CurrentValue:   float64(baseThreshold),
+			BaseThreshold:  float64(baseThreshold),
 			Timer:          time.Now(),
 			HighConfCount:  0,
 			ValidHours:     settings.Realtime.DynamicThreshold.ValidHours,
@@ -94,22 +92,21 @@ func (p *Processor) addSpeciesToDynamicThresholds(modelID, speciesLowercase, sci
 // in LearnFromApprovedDetection() when a detection is approved.
 // Note: This function may reset expired thresholds as a side effect.
 // If isCustomThreshold is true (species has a user-configured threshold), the function returns it unchanged.
-func (p *Processor) getAdjustedConfidenceThreshold(modelID, speciesLowercase string, baseThreshold float32, isCustomThreshold bool) float32 {
+func (p *Processor) getAdjustedConfidenceThreshold(speciesLowercase string, baseThreshold float32, isCustomThreshold bool) float32 {
 	// If this is a custom user-configured threshold, respect it and don't apply dynamic adjustments.
 	if isCustomThreshold {
 		return baseThreshold
 	}
 
 	settings := p.currentSettings()
+	minThreshold := settings.Realtime.DynamicThreshold.Min
 
 	// Lock the mutex to ensure thread-safe access to the DynamicThresholds map
 	p.thresholdsMutex.Lock()
 	defer p.thresholdsMutex.Unlock()
 
-	key := dynamicThresholdKey(modelID, speciesLowercase)
-
 	// Get the dynamic threshold for the species
-	dt, exists := p.DynamicThresholds[key]
+	dt, exists := p.DynamicThresholds[speciesLowercase]
 
 	// If it doesn't exist, return the base threshold
 	if !exists {
@@ -121,43 +118,37 @@ func (p *Processor) getAdjustedConfidenceThreshold(modelID, speciesLowercase str
 	// Check for expired thresholds and reset if needed
 	// Guard ensures we only reset if not already at base state (prevents redundant work)
 	if now.After(dt.Timer) && (dt.Level > 0 || dt.HighConfCount > 0) {
-		// Track previous state for event recording
+		// Track previous state for event recording. The applied value is derived, so
+		// reconstruct the pre-reset value from this caller's base and the old level.
 		previousLevel := dt.Level
-		previousValue := dt.CurrentValue
+		previousValue := effectiveDynamicThreshold(float64(baseThreshold), previousLevel, minThreshold)
 
 		dt.Level = 0
-		dt.CurrentValue = float64(baseThreshold)
 		dt.HighConfCount = 0
 		dt.LastLearnedAt = time.Time{}
+		dt.BaseThreshold = float64(baseThreshold)
 
 		if previousLevel != 0 {
-			p.recordThresholdEvent(speciesLowercase, dt.ScientificName, modelID, previousLevel, 0, previousValue, dt.CurrentValue, changeReasonExpiry, 0)
+			resetValue := effectiveDynamicThreshold(float64(baseThreshold), 0, minThreshold)
+			p.recordThresholdEvent(speciesLowercase, dt.ScientificName, previousLevel, 0, previousValue, resetValue, changeReasonExpiry, 0)
 		}
 	}
 
-	// Apply minimum threshold enforcement
-	if dt.CurrentValue < settings.Realtime.DynamicThreshold.Min {
-		dt.CurrentValue = settings.Realtime.DynamicThreshold.Min
-	}
-
-	return float32(dt.CurrentValue)
+	// Compute the applied threshold live from this model's base and the shared level.
+	return float32(effectiveDynamicThreshold(float64(baseThreshold), dt.Level, minThreshold))
 }
 
 // recordThresholdEvent saves a threshold change event to the database (BG-59)
 // scientificName is required for v2only datastore to correctly resolve the Label FK.
 // See issue #1907 for context on why both names are needed.
-func (p *Processor) recordThresholdEvent(speciesName, scientificName, modelName string, previousLevel, newLevel int, previousValue, newValue float64, changeReason string, confidence float64) {
+func (p *Processor) recordThresholdEvent(speciesName, scientificName string, previousLevel, newLevel int, previousValue, newValue float64, changeReason string, confidence float64) {
 	if p.Ds == nil {
 		return
-	}
-	if modelName == "" {
-		modelName = defaultModelID
 	}
 
 	event := &datastore.ThresholdEvent{
 		SpeciesName:    speciesName,
 		ScientificName: scientificName, // Used by v2only for correct label resolution (#1907)
-		ModelName:      modelName,
 		PreviousLevel:  previousLevel,
 		NewLevel:       newLevel,
 		PreviousValue:  previousValue,
@@ -185,7 +176,10 @@ func (p *Processor) recordThresholdEvent(speciesName, scientificName, modelName 
 // approved high-confidence detection. This should only be called when a detection has
 // been confirmed (approved), not when first detected. This ensures that false positives
 // (discarded detections) do not trigger threshold learning.
-func (p *Processor) LearnFromApprovedDetection(modelID, speciesLowercase, scientificName string, confidence float32) {
+// baseThreshold is the model-specific base for the model that produced this
+// detection (already computed by the caller); it is recorded as display metadata
+// and used to compute the recorded event value, never to key the entry.
+func (p *Processor) LearnFromApprovedDetection(speciesLowercase, scientificName string, confidence, baseThreshold float32) {
 	settings := p.currentSettings()
 	if !settings.Realtime.DynamicThreshold.Enabled {
 		return
@@ -202,11 +196,6 @@ func (p *Processor) LearnFromApprovedDetection(modelID, speciesLowercase, scient
 		return
 	}
 
-	// Use the model-global threshold as base (species has no custom threshold).
-	// Perch v2 / BirdNET v3.0 with their override enabled seed from their own
-	// threshold, Bat from the bat threshold, every other model from BirdNET.
-	baseThreshold := modelGlobalConfidenceThreshold(settings, modelID)
-
 	// Calculate learning cooldown based on detection window duration
 	// This prevents multiple threshold learnings within a single detection event
 	captureLength := time.Duration(settings.Realtime.Audio.Export.Length) * time.Second
@@ -218,31 +207,39 @@ func (p *Processor) LearnFromApprovedDetection(modelID, speciesLowercase, scient
 	}
 
 	// Ensure species exists in threshold map (reuses existing initialization logic)
-	p.addSpeciesToDynamicThresholds(modelID, speciesLowercase, scientificName, baseThreshold)
+	p.addSpeciesToDynamicThresholds(speciesLowercase, scientificName, baseThreshold)
 
 	p.thresholdsMutex.Lock()
 	defer p.thresholdsMutex.Unlock()
 
-	key := dynamicThresholdKey(modelID, speciesLowercase)
-	dt := p.DynamicThresholds[key]
+	dt := p.DynamicThresholds[speciesLowercase]
 	if dt == nil {
 		// Species was removed concurrently (e.g., via ResetDynamicThreshold)
 		// Skip learning for this edge case
 		return
 	}
 
+	minThreshold := settings.Realtime.DynamicThreshold.Min
 	now := time.Now()
 	previousLevel := dt.Level
-	previousValue := dt.CurrentValue
+	previousValue := effectiveDynamicThreshold(dt.BaseThreshold, previousLevel, minThreshold)
 
 	// Always extend the timer when we see an approved high-confidence detection
 	dt.Timer = now.Add(time.Duration(dt.ValidHours) * time.Hour)
 
-	// Only learn if enough time has passed since last learning
-	// This ensures learnings happen across different detection events, not within a single window
+	// Only learn if enough time has passed since last learning.
+	// This ensures learnings happen across different detection events, not within a
+	// single window. It also collapses the multiple contributing models of one
+	// approval (processApprovedDetection loops over them) into a single level
+	// increment: the first model sets LastLearnedAt, the rest only extend the timer.
 	if !dt.LastLearnedAt.IsZero() && now.Sub(dt.LastLearnedAt) < learningCooldown {
 		return
 	}
+
+	// Record the model-specific base of the model that actually learned (display
+	// metadata). Set inside the learn block, after the cooldown gate, so the
+	// contributing models skipped by the cooldown do not overwrite it nondeterministically.
+	dt.BaseThreshold = float64(baseThreshold)
 
 	dt.HighConfCount++
 	dt.LastLearnedAt = now
@@ -257,17 +254,13 @@ func (p *Processor) LearnFromApprovedDetection(modelID, speciesLowercase, scient
 		// Level 3 is the maximum reduction; any count >= 3 stays at this level
 		dt.Level = 3
 	}
-	dt.CurrentValue = float64(baseThreshold) * levelMultiplier(dt.Level)
 
-	// Apply minimum threshold clamp
-	if dt.CurrentValue < settings.Realtime.DynamicThreshold.Min {
-		dt.CurrentValue = settings.Realtime.DynamicThreshold.Min
-	}
+	newValue := effectiveDynamicThreshold(dt.BaseThreshold, dt.Level, minThreshold)
 
 	// Record event if level changed
 	if dt.Level != previousLevel {
-		p.recordThresholdEvent(speciesLowercase, dt.ScientificName, modelID, previousLevel, dt.Level,
-			previousValue, dt.CurrentValue, changeReasonHighConfidence, float64(confidence))
+		p.recordThresholdEvent(speciesLowercase, dt.ScientificName, previousLevel, dt.Level,
+			previousValue, newValue, changeReasonHighConfidence, float64(confidence))
 	}
 
 	if settings.Realtime.DynamicThreshold.Debug {
@@ -276,7 +269,7 @@ func (p *Processor) LearnFromApprovedDetection(modelID, speciesLowercase, scient
 			logger.String("species", speciesLowercase),
 			logger.Float32("confidence", confidence),
 			logger.Int("level", dt.Level),
-			logger.Float64("threshold", dt.CurrentValue))
+			logger.Float64("threshold", newValue))
 	}
 }
 
@@ -288,11 +281,11 @@ func (p *Processor) updateDynamicThreshold(modelID, commonName string, confidenc
 		p.thresholdsMutex.Lock()
 		defer p.thresholdsMutex.Unlock()
 
-		key := dynamicThresholdKey(modelID, commonName)
-
-		// Check if the species already has a dynamic threshold
+		// Check if the species already has a dynamic threshold. The entry is keyed
+		// per species; modelID still selects the model-specific base to compare the
+		// detection confidence against before extending the timer.
 		// Note: scientific name not available in this context, but common name lookup is sufficient
-		if dt, exists := p.DynamicThresholds[key]; exists && confidence > float64(p.getBaseConfidenceThreshold(settings, commonName, "", modelID)) {
+		if dt, exists := p.DynamicThresholds[commonName]; exists && confidence > float64(p.getBaseConfidenceThreshold(settings, commonName, "", modelID)) {
 			// Update the timer to extend the threshold's validity
 			// Note: dt is a pointer, so this directly mutates the struct in the map
 			dt.Timer = time.Now().Add(time.Duration(dt.ValidHours) * time.Hour)
@@ -365,15 +358,10 @@ func (p *Processor) ResetDynamicThreshold(speciesName string) error {
 	// memory clear and DB delete. See drainPendingResets for the pattern.
 	p.thresholdsMutex.Lock()
 
-	// Remove all model-scoped entries for this species from the in-memory map.
-	// Record only the species name (not composite key) in pendingResets since
-	// DeleteDynamicThreshold operates on species name and deletes across all models.
-	for key := range p.DynamicThresholds {
-		_, keySpecies := splitDynamicThresholdKey(key)
-		if keySpecies == speciesName {
-			delete(p.DynamicThresholds, key)
-		}
-	}
+	// Remove the species entry from the in-memory map. Entries are keyed per
+	// species, so a single delete clears it; DeleteDynamicThreshold likewise
+	// operates on the species name.
+	delete(p.DynamicThresholds, speciesName)
 	if p.pendingResets != nil {
 		p.pendingResets[speciesName] = struct{}{}
 	}
@@ -455,22 +443,19 @@ func (p *Processor) GetDynamicThresholdData() []DynamicThresholdData {
 	p.thresholdsMutex.RLock()
 	defer p.thresholdsMutex.RUnlock()
 
-	// Snapshot settings once so the reported base threshold matches the model-aware
-	// value the recalculation path uses (Bat/Perch/BirdNET v3.0 can each differ).
+	// Snapshot settings once so the derived values reflect a single consistent view.
 	settings := p.currentSettings()
+	minThreshold := settings.Realtime.DynamicThreshold.Min
 	data := make([]DynamicThresholdData, 0, len(p.DynamicThresholds))
 	now := time.Now()
 
-	for compositeKey, dt := range p.DynamicThresholds {
-		// Extract model name and species name from composite key "modelID:species"
-		modelName, speciesName := splitDynamicThresholdKey(compositeKey)
+	for speciesName, dt := range p.DynamicThresholds {
 		data = append(data, DynamicThresholdData{
 			SpeciesName:    speciesName,
 			ScientificName: dt.ScientificName,
-			ModelName:      modelName,
 			Level:          dt.Level,
-			CurrentValue:   dt.CurrentValue,
-			BaseThreshold:  float64(modelGlobalConfidenceThreshold(settings, modelName)),
+			CurrentValue:   effectiveDynamicThreshold(dt.BaseThreshold, dt.Level, minThreshold),
+			BaseThreshold:  dt.BaseThreshold,
 			HighConfCount:  dt.HighConfCount,
 			ExpiresAt:      dt.Timer,
 			IsActive:       dt.Timer.After(now),
@@ -484,18 +469,17 @@ func (p *Processor) GetDynamicThresholdData() []DynamicThresholdData {
 type DynamicThresholdData struct {
 	SpeciesName    string    `json:"speciesName"`
 	ScientificName string    `json:"scientificName"`
-	ModelName      string    `json:"modelName"`
 	Level          int       `json:"level"`
-	CurrentValue   float64   `json:"currentValue"`
-	BaseThreshold  float64   `json:"baseThreshold"` // model-aware global base this entry derives from
+	CurrentValue   float64   `json:"currentValue"`  // derived from BaseThreshold and Level at read time
+	BaseThreshold  float64   `json:"baseThreshold"` // model-global base of the model that last learned (display only)
 	HighConfCount  int       `json:"highConfCount"`
 	ExpiresAt      time.Time `json:"expiresAt"`
 	IsActive       bool      `json:"isActive"`
 }
 
 // levelMultiplier returns the threshold multiplier for a given level.
-// This centralizes the level-to-multiplier mapping used by both LearnFromApprovedDetection
-// and RecalculateDynamicThresholds to avoid duplication.
+// This centralizes the level-to-multiplier mapping used by LearnFromApprovedDetection
+// and effectiveDynamicThreshold to avoid duplication.
 func levelMultiplier(level int) float64 {
 	switch level {
 	case 1:
@@ -506,57 +490,5 @@ func levelMultiplier(level int) float64 {
 		return thresholdLevel3Multiplier
 	default:
 		return 1.0 // Level 0 = no reduction
-	}
-}
-
-// RecalculateDynamicThresholds recomputes all CurrentValue entries based on each
-// entry's model-specific base threshold (see modelGlobalConfidenceThreshold).
-// This must be called when any model-global base threshold changes so that stored
-// absolute values remain consistent with each species' level/tier.
-// Species with custom per-species thresholds are not present in the dynamic thresholds
-// map (they are filtered out in LearnFromApprovedDetection), so no special handling is needed.
-func (p *Processor) RecalculateDynamicThresholds() {
-	log := GetLogger()
-	settings := p.currentSettings()
-	minThreshold := settings.Realtime.DynamicThreshold.Min
-
-	p.thresholdsMutex.Lock()
-	defer p.thresholdsMutex.Unlock()
-
-	recalculated := 0
-	for key, dt := range p.DynamicThresholds {
-		// The base threshold is model-specific: Perch v2 / BirdNET v3.0 with their
-		// override enabled use their own base, Bat uses the bat base, and every
-		// other model uses the primary BirdNET base.
-		modelID, species := splitDynamicThresholdKey(key)
-		newBase := float64(modelGlobalConfidenceThreshold(settings, modelID))
-		oldValue := dt.CurrentValue
-		newValue := newBase * levelMultiplier(dt.Level)
-
-		// Apply minimum threshold clamp
-		if newValue < minThreshold {
-			newValue = minThreshold
-		}
-
-		if oldValue != newValue {
-			dt.CurrentValue = newValue
-			recalculated++
-
-			if settings.Realtime.DynamicThreshold.Debug {
-				log.Debug("Recalculated dynamic threshold for new base",
-					logger.String("species", species),
-					logger.String("model_id", modelID),
-					logger.Int("level", dt.Level),
-					logger.Float64("old_value", oldValue),
-					logger.Float64("new_value", newValue),
-					logger.Float64("new_base", newBase))
-			}
-		}
-	}
-
-	if recalculated > 0 {
-		log.Info("Recalculated dynamic thresholds for new base threshold",
-			logger.Int("recalculated", recalculated),
-			logger.Int("total", len(p.DynamicThresholds)))
 	}
 }

--- a/internal/analysis/processor/dynamic_threshold_test.go
+++ b/internal/analysis/processor/dynamic_threshold_test.go
@@ -1,4 +1,9 @@
-// dynamic_threshold_test.go: Unit tests for dynamic threshold functionality
+// dynamic_threshold_test.go: Unit tests for dynamic threshold functionality.
+//
+// Dynamic thresholds are tracked PER SPECIES (not per model): the learned state is
+// keyed by the lowercase common name, any model's approved high-confidence detection
+// advances the shared level, and the applied threshold is computed live from the
+// caller's model-specific base and the shared level.
 package processor
 
 import (
@@ -7,61 +12,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
-
-// testModelID is the default model identifier used in threshold tests.
-const testModelID = "BirdNET_V2.4"
-
-// testThresholdKey builds the composite key used for direct map assertions in tests.
-func testThresholdKey(species string) string {
-	return dynamicThresholdKey(testModelID, species)
-}
-
-// TestRecalculateDynamicThresholds_PerModelBase verifies that each dynamic
-// threshold entry recomputes against its own model's base threshold: a Perch v2
-// entry with the Perch override enabled uses the Perch base, while a BirdNET
-// entry uses the primary BirdNET base, rather than both using BirdNET.Threshold.
-func TestRecalculateDynamicThresholds_PerModelBase(t *testing.T) {
-	p := newTestProcessor()
-	p.Settings.BirdNET.Threshold = 0.80
-	p.Settings.Perch = conf.PerchConfig{OverrideThreshold: true, Threshold: 0.40}
-
-	// Both entries at level 1 (multiplier 0.75). Seed CurrentValue with the old
-	// BirdNET-derived value so a per-model recompute must move the Perch entry.
-	birdKey := dynamicThresholdKey(testModelID, "american robin")
-	perchKey := dynamicThresholdKey(classifier.RegistryIDPerchV2, "eurasian wren")
-	future := time.Now().Add(time.Hour)
-	p.DynamicThresholds[birdKey] = &DynamicThreshold{Level: 1, CurrentValue: 0.80 * 0.75, Timer: future}
-	p.DynamicThresholds[perchKey] = &DynamicThreshold{Level: 1, CurrentValue: 0.80 * 0.75, Timer: future}
-
-	p.RecalculateDynamicThresholds()
-
-	assert.InDelta(t, 0.80*0.75, p.DynamicThresholds[birdKey].CurrentValue, 0.001,
-		"BirdNET entry should recompute off the BirdNET base 0.80")
-	assert.InDelta(t, 0.40*0.75, p.DynamicThresholds[perchKey].CurrentValue, 0.001,
-		"Perch entry with override should recompute off the Perch base 0.40, not BirdNET 0.80")
-}
-
-// TestLearnFromApprovedDetection_PerModelBase verifies dynamic-threshold learning
-// seeds from the model-specific base: a Perch v2 species with the Perch override
-// enabled learns off the Perch threshold, not BirdNET.Threshold.
-func TestLearnFromApprovedDetection_PerModelBase(t *testing.T) {
-	p := newTestProcessor()
-	p.Settings.BirdNET.Threshold = 0.80
-	p.Settings.Perch = conf.PerchConfig{OverrideThreshold: true, Threshold: 0.40}
-
-	p.LearnFromApprovedDetection(classifier.RegistryIDPerchV2, "eurasian wren", "Troglodytes troglodytes", 0.95)
-
-	key := dynamicThresholdKey(classifier.RegistryIDPerchV2, "eurasian wren")
-	dt := p.DynamicThresholds[key]
-	if assert.NotNil(t, dt, "Perch dynamic threshold entry should be created") {
-		assert.Equal(t, 1, dt.Level, "first learning should reach level 1")
-		assert.InDelta(t, 0.40*0.75, dt.CurrentValue, 0.001,
-			"Perch learning should seed off the Perch base 0.40, not BirdNET 0.80")
-	}
-}
 
 // newTestProcessor creates a Processor with default settings for dynamic threshold testing
 func newTestProcessor() *Processor {
@@ -104,7 +56,7 @@ func TestCustomThresholdRespected(t *testing.T) {
 		},
 	}
 
-	adjusted := p.getAdjustedConfidenceThreshold(testModelID, "american robin", 0.95, true)
+	adjusted := p.getAdjustedConfidenceThreshold("american robin", 0.95, true)
 
 	assert.InDelta(t, 0.95, adjusted, 0.001, "Custom threshold should be returned unchanged")
 }
@@ -114,34 +66,33 @@ func TestCustomThresholdRespected(t *testing.T) {
 func TestDynamicThresholdNotInitialized(t *testing.T) {
 	p := newTestProcessor()
 
-	adjusted := p.getAdjustedConfidenceThreshold(testModelID, "new species", 0.80, false)
+	adjusted := p.getAdjustedConfidenceThreshold("new species", 0.80, false)
 
 	assert.InDelta(t, 0.80, adjusted, 0.001, "Should return base threshold if no dynamic threshold exists")
 }
 
-// TestGetAdjustedThresholdReadsCurrentValue verifies that getAdjustedConfidenceThreshold
-// returns the current threshold value without modifying it (read-only behavior)
-func TestGetAdjustedThresholdReadsCurrentValue(t *testing.T) {
+// TestGetAdjustedThresholdDerivesValue verifies that getAdjustedConfidenceThreshold
+// derives the applied value from the caller's base and the stored level, without
+// mutating the learned state (read-only behavior).
+func TestGetAdjustedThresholdDerivesValue(t *testing.T) {
 	p := newTestProcessor()
 
-	key := testThresholdKey("test species")
 	// Pre-set a threshold at Level 2
-	p.DynamicThresholds[key] = &DynamicThreshold{
+	p.DynamicThresholds["test species"] = &DynamicThreshold{
 		Level:          2,
-		CurrentValue:   0.40,
+		BaseThreshold:  0.80,
 		Timer:          time.Now().Add(1 * time.Hour),
 		HighConfCount:  2,
 		ValidHours:     24,
 		ScientificName: "Testus speciesus",
 	}
 
-	// Call getAdjustedConfidenceThreshold
-	adjusted := p.getAdjustedConfidenceThreshold(testModelID, "test species", 0.80, false)
+	// Level 2 multiplier is 0.50, so base 0.80 -> 0.40.
+	adjusted := p.getAdjustedConfidenceThreshold("test species", 0.80, false)
 
-	// Should return current value without learning (no level change)
-	assert.InDelta(t, 0.40, adjusted, 0.001, "Should return current threshold value")
-	assert.Equal(t, 2, p.DynamicThresholds[key].Level, "Level should remain unchanged")
-	assert.Equal(t, 2, p.DynamicThresholds[key].HighConfCount, "HighConfCount should remain unchanged")
+	assert.InDelta(t, 0.40, adjusted, 0.001, "Should derive current threshold value from base and level")
+	assert.Equal(t, 2, p.DynamicThresholds["test species"].Level, "Level should remain unchanged")
+	assert.Equal(t, 2, p.DynamicThresholds["test species"].HighConfCount, "HighConfCount should remain unchanged")
 }
 
 // TestGetAdjustedThresholdDoesNotLearn verifies that getAdjustedConfidenceThreshold
@@ -150,16 +101,14 @@ func TestGetAdjustedThresholdDoesNotLearn(t *testing.T) {
 	p := newTestProcessor()
 
 	// Initialize species at Level 0
-	p.addSpeciesToDynamicThresholds(testModelID, "test species", "Testus speciesus", 0.80)
+	p.addSpeciesToDynamicThresholds("test species", "Testus speciesus", 0.80)
 
-	// Call getAdjustedConfidenceThreshold (no longer takes confidence)
-	adjusted := p.getAdjustedConfidenceThreshold(testModelID, "test species", 0.80, false)
+	adjusted := p.getAdjustedConfidenceThreshold("test species", 0.80, false)
 
-	key := testThresholdKey("test species")
 	// Should NOT trigger learning - stays at base threshold
 	assert.InDelta(t, 0.80, adjusted, 0.001, "Should return base threshold (no learning)")
-	assert.Equal(t, 0, p.DynamicThresholds[key].Level, "Level should remain 0")
-	assert.Equal(t, 0, p.DynamicThresholds[key].HighConfCount, "HighConfCount should remain 0")
+	assert.Equal(t, 0, p.DynamicThresholds["test species"].Level, "Level should remain 0")
+	assert.Equal(t, 0, p.DynamicThresholds["test species"].HighConfCount, "HighConfCount should remain 0")
 }
 
 // TestGetAdjustedThresholdResetsExpiredThreshold verifies that expired thresholds
@@ -167,24 +116,22 @@ func TestGetAdjustedThresholdDoesNotLearn(t *testing.T) {
 func TestGetAdjustedThresholdResetsExpiredThreshold(t *testing.T) {
 	p := newTestProcessor()
 
-	key := testThresholdKey("test species")
 	// Set up an expired threshold at Level 2
-	p.DynamicThresholds[key] = &DynamicThreshold{
+	p.DynamicThresholds["test species"] = &DynamicThreshold{
 		Level:          2,
-		CurrentValue:   0.40,
+		BaseThreshold:  0.80,
 		Timer:          time.Now().Add(-1 * time.Hour), // Expired
 		HighConfCount:  2,
 		ValidHours:     24,
 		ScientificName: "Testus speciesus",
 	}
 
-	// Call getAdjustedConfidenceThreshold
-	adjusted := p.getAdjustedConfidenceThreshold(testModelID, "test species", 0.80, false)
+	adjusted := p.getAdjustedConfidenceThreshold("test species", 0.80, false)
 
 	// Should reset to base threshold
 	assert.InDelta(t, 0.80, adjusted, 0.001, "Expired threshold should reset to base")
-	assert.Equal(t, 0, p.DynamicThresholds[key].Level, "Level should reset to 0")
-	assert.Equal(t, 0, p.DynamicThresholds[key].HighConfCount, "HighConfCount should reset to 0")
+	assert.Equal(t, 0, p.DynamicThresholds["test species"].Level, "Level should reset to 0")
+	assert.Equal(t, 0, p.DynamicThresholds["test species"].HighConfCount, "HighConfCount should reset to 0")
 }
 
 // =============================================================================
@@ -197,56 +144,59 @@ func TestLearnFromApprovedDetectionLevels(t *testing.T) {
 	p := newTestProcessor()
 
 	baseThreshold := float32(0.80)
-	p.addSpeciesToDynamicThresholds(testModelID, "test species", "Testus speciesus", baseThreshold)
+	p.addSpeciesToDynamicThresholds("test species", "Testus speciesus", baseThreshold)
 
-	key := testThresholdKey("test species")
-
-	// Level 1: First approved high-confidence detection (75%)
-	p.LearnFromApprovedDetection(testModelID, "test species", "Testus speciesus", 0.95)
-	assert.Equal(t, 1, p.DynamicThresholds[key].Level, "Level should be 1 after first learning")
-	assert.InDelta(t, 0.60, p.DynamicThresholds[key].CurrentValue, 0.001, "Value should be 75% of base")
+	// Level 1: First approved high-confidence detection (75% of base)
+	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95, baseThreshold)
+	assert.Equal(t, 1, p.DynamicThresholds["test species"].Level, "Level should be 1 after first learning")
+	assert.InDelta(t, 0.60, p.getAdjustedConfidenceThreshold("test species", baseThreshold, false), 0.001,
+		"Applied value should be 75% of base")
 
 	// Simulate time passing beyond the learning cooldown
-	p.DynamicThresholds[key].LastLearnedAt = time.Now().Add(-15 * time.Second)
+	p.DynamicThresholds["test species"].LastLearnedAt = time.Now().Add(-15 * time.Second)
 
-	// Level 2: Second approved high-confidence detection (50%)
-	p.LearnFromApprovedDetection(testModelID, "test species", "Testus speciesus", 0.95)
-	assert.Equal(t, 2, p.DynamicThresholds[key].Level, "Level should be 2 after second learning")
-	assert.InDelta(t, 0.40, p.DynamicThresholds[key].CurrentValue, 0.001, "Value should be 50% of base")
+	// Level 2: Second approved high-confidence detection (50% of base)
+	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95, baseThreshold)
+	assert.Equal(t, 2, p.DynamicThresholds["test species"].Level, "Level should be 2 after second learning")
+	assert.InDelta(t, 0.40, p.getAdjustedConfidenceThreshold("test species", baseThreshold, false), 0.001,
+		"Applied value should be 50% of base")
 
 	// Simulate more time passing
-	p.DynamicThresholds[key].LastLearnedAt = time.Now().Add(-15 * time.Second)
+	p.DynamicThresholds["test species"].LastLearnedAt = time.Now().Add(-15 * time.Second)
 
-	// Level 3: Third approved high-confidence detection (25%)
-	p.LearnFromApprovedDetection(testModelID, "test species", "Testus speciesus", 0.95)
-	assert.Equal(t, 3, p.DynamicThresholds[key].Level, "Level should be 3 after third learning")
-	assert.InDelta(t, 0.20, p.DynamicThresholds[key].CurrentValue, 0.001, "Value should be 25% of base")
+	// Level 3: Third approved high-confidence detection (25% of base)
+	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95, baseThreshold)
+	assert.Equal(t, 3, p.DynamicThresholds["test species"].Level, "Level should be 3 after third learning")
+	assert.InDelta(t, 0.20, p.getAdjustedConfidenceThreshold("test species", baseThreshold, false), 0.001,
+		"Applied value should be 25% of base")
 }
 
 // TestLearnFromApprovedDetectionCooldown verifies that rapid approved detections
-// within the same detection window don't cause multiple threshold reductions
+// within the same detection window don't cause multiple threshold reductions. The
+// cooldown is model-independent, so it is also what collapses the several contributing
+// models of one approval into a single level increment (each call after the first
+// falls inside the cooldown); TestDynamicThresholds_SharedAcrossModels covers the
+// per-species sharing itself.
 func TestLearnFromApprovedDetectionCooldown(t *testing.T) {
 	p := newTestProcessor()
 
 	baseThreshold := float32(0.80)
-	p.addSpeciesToDynamicThresholds(testModelID, "test species", "Testus speciesus", baseThreshold)
-
-	key := testThresholdKey("test species")
+	p.addSpeciesToDynamicThresholds("test species", "Testus speciesus", baseThreshold)
 
 	// First approved detection triggers Level 1
-	p.LearnFromApprovedDetection(testModelID, "test species", "Testus speciesus", 0.95)
-	assert.Equal(t, 1, p.DynamicThresholds[key].Level, "First approval should trigger Level 1")
-	assert.Equal(t, 1, p.DynamicThresholds[key].HighConfCount, "HighConfCount should be 1")
+	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95, baseThreshold)
+	assert.Equal(t, 1, p.DynamicThresholds["test species"].Level, "First approval should trigger Level 1")
+	assert.Equal(t, 1, p.DynamicThresholds["test species"].HighConfCount, "HighConfCount should be 1")
 
 	// Immediate second approval should NOT trigger Level 2 (cooldown not expired)
-	p.LearnFromApprovedDetection(testModelID, "test species", "Testus speciesus", 0.95)
-	assert.Equal(t, 1, p.DynamicThresholds[key].Level, "Level should stay at 1 during cooldown")
-	assert.Equal(t, 1, p.DynamicThresholds[key].HighConfCount, "HighConfCount should stay at 1")
+	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95, baseThreshold)
+	assert.Equal(t, 1, p.DynamicThresholds["test species"].Level, "Level should stay at 1 during cooldown")
+	assert.Equal(t, 1, p.DynamicThresholds["test species"].HighConfCount, "HighConfCount should stay at 1")
 
 	// Immediate third approval should also NOT trigger Level 3
-	p.LearnFromApprovedDetection(testModelID, "test species", "Testus speciesus", 0.95)
-	assert.Equal(t, 1, p.DynamicThresholds[key].Level, "Level should still be 1")
-	assert.Equal(t, 1, p.DynamicThresholds[key].HighConfCount, "HighConfCount should still be 1")
+	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95, baseThreshold)
+	assert.Equal(t, 1, p.DynamicThresholds["test species"].Level, "Level should still be 1")
+	assert.Equal(t, 1, p.DynamicThresholds["test species"].HighConfCount, "HighConfCount should still be 1")
 }
 
 // TestLearnFromApprovedDetectionIgnoresLowConfidence verifies that low-confidence
@@ -256,16 +206,15 @@ func TestLearnFromApprovedDetectionIgnoresLowConfidence(t *testing.T) {
 	p.Settings.Realtime.DynamicThreshold.Trigger = 0.90
 
 	baseThreshold := float32(0.80)
-	p.addSpeciesToDynamicThresholds(testModelID, "test species", "Testus speciesus", baseThreshold)
-
-	key := testThresholdKey("test species")
+	p.addSpeciesToDynamicThresholds("test species", "Testus speciesus", baseThreshold)
 
 	// Low confidence (below trigger) should not learn
-	p.LearnFromApprovedDetection(testModelID, "test species", "Testus speciesus", 0.85)
+	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.85, baseThreshold)
 
-	assert.Equal(t, 0, p.DynamicThresholds[key].Level, "Level should remain 0 for low confidence")
-	assert.Equal(t, 0, p.DynamicThresholds[key].HighConfCount, "HighConfCount should remain 0")
-	assert.InDelta(t, 0.80, p.DynamicThresholds[key].CurrentValue, 0.001, "Value should remain at base")
+	assert.Equal(t, 0, p.DynamicThresholds["test species"].Level, "Level should remain 0 for low confidence")
+	assert.Equal(t, 0, p.DynamicThresholds["test species"].HighConfCount, "HighConfCount should remain 0")
+	assert.InDelta(t, 0.80, p.getAdjustedConfidenceThreshold("test species", baseThreshold, false), 0.001,
+		"Applied value should remain at base")
 }
 
 // TestLearnFromApprovedDetectionIgnoresCustomThreshold verifies that species
@@ -279,14 +228,12 @@ func TestLearnFromApprovedDetectionIgnoresCustomThreshold(t *testing.T) {
 	}
 
 	// Initialize threshold
-	p.addSpeciesToDynamicThresholds(testModelID, "american robin", "Turdus migratorius", 0.95)
-
-	key := testThresholdKey("american robin")
+	p.addSpeciesToDynamicThresholds("american robin", "Turdus migratorius", 0.95)
 
 	// High confidence approval should not learn (has custom threshold)
-	p.LearnFromApprovedDetection(testModelID, "american robin", "Turdus migratorius", 0.98)
+	p.LearnFromApprovedDetection("american robin", "Turdus migratorius", 0.98, 0.95)
 
-	assert.Equal(t, 0, p.DynamicThresholds[key].Level, "Level should remain 0 for custom threshold")
+	assert.Equal(t, 0, p.DynamicThresholds["american robin"].Level, "Level should remain 0 for custom threshold")
 }
 
 // TestLearnFromApprovedDetectionMinimumFloor verifies that dynamic threshold
@@ -296,21 +243,20 @@ func TestLearnFromApprovedDetectionMinimumFloor(t *testing.T) {
 	p.Settings.Realtime.DynamicThreshold.Min = 0.30 // Higher minimum
 
 	baseThreshold := float32(0.80)
-	p.addSpeciesToDynamicThresholds(testModelID, "test species", "Testus speciesus", baseThreshold)
-
-	key := testThresholdKey("test species")
+	p.addSpeciesToDynamicThresholds("test species", "Testus speciesus", baseThreshold)
 
 	// Trigger Level 3 (25% of 0.80 = 0.20, which is below min of 0.30)
 	for i := range 3 {
 		if i > 0 {
 			// Simulate time passing beyond cooldown for subsequent detections
-			p.DynamicThresholds[key].LastLearnedAt = time.Now().Add(-15 * time.Second)
+			p.DynamicThresholds["test species"].LastLearnedAt = time.Now().Add(-15 * time.Second)
 		}
-		p.LearnFromApprovedDetection(testModelID, "test species", "Testus speciesus", 0.95)
+		p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95, baseThreshold)
 	}
 
 	// Should respect minimum
-	assert.InDelta(t, 0.30, p.DynamicThresholds[key].CurrentValue, 0.001, "Should not go below configured minimum")
+	assert.InDelta(t, 0.30, p.getAdjustedConfidenceThreshold("test species", baseThreshold, false), 0.001,
+		"Applied value should not go below configured minimum")
 }
 
 // TestLearnFromApprovedDetectionInitializesIfMissing verifies that the function
@@ -318,15 +264,13 @@ func TestLearnFromApprovedDetectionMinimumFloor(t *testing.T) {
 func TestLearnFromApprovedDetectionInitializesIfMissing(t *testing.T) {
 	p := newTestProcessor()
 
-	key := testThresholdKey("new species")
-
 	// Don't call addSpeciesToDynamicThresholds - let LearnFromApprovedDetection create it
-	p.LearnFromApprovedDetection(testModelID, "new species", "Newus speciesus", 0.95)
+	p.LearnFromApprovedDetection("new species", "Newus speciesus", 0.95, 0.80)
 
 	// Should have created the entry and learned
-	assert.NotNil(t, p.DynamicThresholds[key], "Should create threshold entry")
-	assert.Equal(t, 1, p.DynamicThresholds[key].Level, "Level should be 1")
-	assert.Equal(t, "Newus speciesus", p.DynamicThresholds[key].ScientificName, "ScientificName should be set")
+	assert.NotNil(t, p.DynamicThresholds["new species"], "Should create threshold entry")
+	assert.Equal(t, 1, p.DynamicThresholds["new species"].Level, "Level should be 1")
+	assert.Equal(t, "Newus speciesus", p.DynamicThresholds["new species"].ScientificName, "ScientificName should be set")
 }
 
 // TestLearnFromApprovedDetectionExtendsTimer verifies that approved high-confidence
@@ -336,19 +280,17 @@ func TestLearnFromApprovedDetectionExtendsTimer(t *testing.T) {
 	p.Settings.Realtime.DynamicThreshold.ValidHours = 12
 
 	baseThreshold := float32(0.80)
-	p.addSpeciesToDynamicThresholds(testModelID, "test species", "Testus speciesus", baseThreshold)
-
-	key := testThresholdKey("test species")
+	p.addSpeciesToDynamicThresholds("test species", "Testus speciesus", baseThreshold)
 
 	// Set timer to soon
 	oldTimer := time.Now().Add(1 * time.Hour)
-	p.DynamicThresholds[key].Timer = oldTimer
+	p.DynamicThresholds["test species"].Timer = oldTimer
 
 	// Approve a high-confidence detection
-	p.LearnFromApprovedDetection(testModelID, "test species", "Testus speciesus", 0.95)
+	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95, baseThreshold)
 
 	// Timer should be extended to 12 hours from now
-	newTimer := p.DynamicThresholds[key].Timer
+	newTimer := p.DynamicThresholds["test species"].Timer
 	assert.True(t, newTimer.After(oldTimer), "Timer should be extended")
 	assert.True(t, newTimer.After(time.Now().Add(11*time.Hour)), "Timer should be ~12 hours in future")
 }
@@ -359,14 +301,12 @@ func TestLearnFromApprovedDetectionWhenDisabled(t *testing.T) {
 	p := newTestProcessor()
 	p.Settings.Realtime.DynamicThreshold.Enabled = false
 
-	p.addSpeciesToDynamicThresholds(testModelID, "test species", "Testus speciesus", 0.80)
-
-	key := testThresholdKey("test species")
+	p.addSpeciesToDynamicThresholds("test species", "Testus speciesus", 0.80)
 
 	// Should not learn when disabled
-	p.LearnFromApprovedDetection(testModelID, "test species", "Testus speciesus", 0.95)
+	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95, 0.80)
 
-	assert.Equal(t, 0, p.DynamicThresholds[key].Level, "Should not learn when disabled")
+	assert.Equal(t, 0, p.DynamicThresholds["test species"].Level, "Should not learn when disabled")
 }
 
 // =============================================================================
@@ -379,24 +319,22 @@ func TestDiscardedDetectionDoesNotTriggerLearning(t *testing.T) {
 	p := newTestProcessor()
 
 	baseThreshold := float32(0.80)
-	p.addSpeciesToDynamicThresholds(testModelID, "test species", "Testus speciesus", baseThreshold)
-
-	key := testThresholdKey("test species")
+	p.addSpeciesToDynamicThresholds("test species", "Testus speciesus", baseThreshold)
 
 	// Step 1: Get threshold (this is called during detection filtering)
 	// With the fix, this should NOT trigger learning
-	adjusted := p.getAdjustedConfidenceThreshold(testModelID, "test species", baseThreshold, false)
+	adjusted := p.getAdjustedConfidenceThreshold("test species", baseThreshold, false)
 
 	// Threshold should still be at base level (no learning yet)
 	assert.InDelta(t, 0.80, adjusted, 0.001, "Threshold should be at base (no learning during filtering)")
-	assert.Equal(t, 0, p.DynamicThresholds[key].Level, "Level should be 0")
+	assert.Equal(t, 0, p.DynamicThresholds["test species"].Level, "Level should be 0")
 
-	// Step 2: Detection is discarded as false positive
-	// No call to LearnFromApprovedDetection
+	// Step 2: Detection is discarded as false positive; no call to LearnFromApprovedDetection.
 
 	// Final state: threshold should still be at base level
-	assert.Equal(t, 0, p.DynamicThresholds[key].Level, "Level should remain 0 after discard")
-	assert.InDelta(t, 0.80, p.DynamicThresholds[key].CurrentValue, 0.001, "Value should remain at base")
+	assert.Equal(t, 0, p.DynamicThresholds["test species"].Level, "Level should remain 0 after discard")
+	assert.InDelta(t, 0.80, p.getAdjustedConfidenceThreshold("test species", baseThreshold, false), 0.001,
+		"Applied value should remain at base")
 }
 
 // TestApprovedDetectionTriggersLearning verifies that approved detections
@@ -405,230 +343,66 @@ func TestApprovedDetectionTriggersLearning(t *testing.T) {
 	p := newTestProcessor()
 
 	baseThreshold := float32(0.80)
-	p.addSpeciesToDynamicThresholds(testModelID, "test species", "Testus speciesus", baseThreshold)
-
-	key := testThresholdKey("test species")
+	p.addSpeciesToDynamicThresholds("test species", "Testus speciesus", baseThreshold)
 
 	// Step 1: Get threshold (during detection filtering)
-	adjusted := p.getAdjustedConfidenceThreshold(testModelID, "test species", baseThreshold, false)
+	adjusted := p.getAdjustedConfidenceThreshold("test species", baseThreshold, false)
 	assert.InDelta(t, 0.80, adjusted, 0.001, "Threshold at base during filtering")
 
 	// Step 2: Detection is approved
-	p.LearnFromApprovedDetection(testModelID, "test species", "Testus speciesus", 0.95)
+	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95, baseThreshold)
 
 	// Final state: threshold should now be at Level 1
-	assert.Equal(t, 1, p.DynamicThresholds[key].Level, "Level should be 1 after approval")
-	assert.InDelta(t, 0.60, p.DynamicThresholds[key].CurrentValue, 0.001, "Value should be 75% of base")
+	assert.Equal(t, 1, p.DynamicThresholds["test species"].Level, "Level should be 1 after approval")
+	assert.InDelta(t, 0.60, p.getAdjustedConfidenceThreshold("test species", baseThreshold, false), 0.001,
+		"Applied value should be 75% of base")
 }
 
 // =============================================================================
-// Tests for cross-model threshold isolation
+// Tests for per-species (cross-model) sharing
 // =============================================================================
 
-// TestDynamicThresholds_CrossModelIsolation verifies that thresholds from
-// different models are independent and do not contaminate each other.
-func TestDynamicThresholds_CrossModelIsolation(t *testing.T) {
+// TestDynamicThresholds_SharedAcrossModels verifies the intended behavior after the
+// per-model to per-species change: a species is tracked once, any model's approved
+// high-confidence detection advances the shared level, and each model applies that
+// shared level against its own base threshold.
+func TestDynamicThresholds_SharedAcrossModels(t *testing.T) {
 	p := newTestProcessor()
 
-	// Add threshold for BirdNET
-	p.addSpeciesToDynamicThresholds("BirdNET_V2.4", "robin", "Turdus migratorius", 0.6)
+	const species = "robin"
+	const birdnetBase = float32(0.80)
+	const perchBase = float32(0.40)
 
-	// Add threshold for Perch
-	p.addSpeciesToDynamicThresholds("Perch_V2", "robin", "Turdus migratorius", 0.4)
+	// A single detection approved by the BirdNET model.
+	p.LearnFromApprovedDetection(species, "Turdus migratorius", 0.95, birdnetBase)
 
-	// Verify they're independent
-	birdnetThreshold := p.getAdjustedConfidenceThreshold("BirdNET_V2.4", "robin", 0.6, false)
-	perchThreshold := p.getAdjustedConfidenceThreshold("Perch_V2", "robin", 0.4, false)
+	// Exactly one entry exists for the species (no per-model duplication).
+	assert.Len(t, p.DynamicThresholds, 1, "there should be a single per-species entry")
+	dt := p.DynamicThresholds[species]
+	if !assert.NotNil(t, dt, "shared entry should exist") {
+		return
+	}
+	assert.Equal(t, 1, dt.Level, "one approval advances the shared level to 1")
 
-	assert.InDelta(t, 0.6, float64(birdnetThreshold), 0.01, "BirdNET threshold should be independent")
-	assert.InDelta(t, 0.4, float64(perchThreshold), 0.01, "Perch threshold should be independent")
-
-	// Learn from BirdNET model only
-	p.LearnFromApprovedDetection("BirdNET_V2.4", "robin", "Turdus migratorius", 0.95)
-
-	birdnetKey := dynamicThresholdKey("BirdNET_V2.4", "robin")
-	perchKey := dynamicThresholdKey("Perch_V2", "robin")
-
-	// BirdNET should have leveled up
-	assert.Equal(t, 1, p.DynamicThresholds[birdnetKey].Level, "BirdNET level should increase")
-
-	// Perch should be unaffected
-	assert.Equal(t, 0, p.DynamicThresholds[perchKey].Level, "Perch level should remain 0")
+	// The shared level (1 -> 0.75 multiplier) applies against each model's own base.
+	assert.InDelta(t, 0.60, p.getAdjustedConfidenceThreshold(species, birdnetBase, false), 0.001,
+		"BirdNET reads 75% of its base 0.80")
+	assert.InDelta(t, 0.30, p.getAdjustedConfidenceThreshold(species, perchBase, false), 0.001,
+		"Perch reads 75% of its base 0.40 from the same shared level")
 }
 
-// TestDynamicThresholdKey verifies composite key creation and splitting
-func TestDynamicThresholdKey(t *testing.T) {
-	t.Run("CreatesKey", func(t *testing.T) {
-		key := dynamicThresholdKey("BirdNET_V2.4", "robin")
-		assert.Equal(t, "BirdNET_V2.4:robin", key)
-	})
+// TestLearnFromApprovedDetectionRecordsBase verifies that learning records the
+// model-specific base passed by the caller as display metadata.
+func TestLearnFromApprovedDetectionRecordsBase(t *testing.T) {
+	p := newTestProcessor()
 
-	t.Run("DefaultsEmptyModel", func(t *testing.T) {
-		key := dynamicThresholdKey("", "robin")
-		assert.Equal(t, "BirdNET:robin", key)
-	})
+	p.LearnFromApprovedDetection("eurasian wren", "Troglodytes troglodytes", 0.95, 0.40)
 
-	t.Run("SplitsKey", func(t *testing.T) {
-		modelID, species := splitDynamicThresholdKey("BirdNET_V2.4:robin")
-		assert.Equal(t, "BirdNET_V2.4", modelID)
-		assert.Equal(t, "robin", species)
-	})
-
-	t.Run("SplitsKeyWithNoSeparator", func(t *testing.T) {
-		modelID, species := splitDynamicThresholdKey("robin")
-		assert.Equal(t, defaultModelID, modelID)
-		assert.Equal(t, "robin", species)
-	})
-
-	t.Run("Roundtrip", func(t *testing.T) {
-		original := dynamicThresholdKey("Perch_V2", "american robin")
-		modelID, species := splitDynamicThresholdKey(original)
-		assert.Equal(t, "Perch_V2", modelID)
-		assert.Equal(t, "american robin", species)
-	})
-}
-
-// =============================================================================
-// Tests for RecalculateDynamicThresholds
-// =============================================================================
-
-// TestRecalculateDynamicThresholds verifies that changing the global base threshold
-// causes all existing dynamic threshold CurrentValue entries to be recalculated
-// while preserving each species' level/tier.
-func TestRecalculateDynamicThresholds(t *testing.T) {
-	t.Run("RecalculatesAllLevels", func(t *testing.T) {
-		p := newTestProcessor()
-		// Old base was 0.80, set up species at different levels
-		// Use composite keys for the map
-		p.DynamicThresholds[dynamicThresholdKey(testModelID, "species_level0")] = &DynamicThreshold{
-			Level:          0,
-			CurrentValue:   0.80, // 100% of 0.80
-			Timer:          time.Now().Add(1 * time.Hour),
-			HighConfCount:  0,
-			ValidHours:     24,
-			ScientificName: "Speciesus zerous",
-		}
-		p.DynamicThresholds[dynamicThresholdKey(testModelID, "species_level1")] = &DynamicThreshold{
-			Level:          1,
-			CurrentValue:   0.60, // 75% of 0.80
-			Timer:          time.Now().Add(1 * time.Hour),
-			HighConfCount:  1,
-			ValidHours:     24,
-			ScientificName: "Speciesus firstus",
-		}
-		p.DynamicThresholds[dynamicThresholdKey(testModelID, "species_level2")] = &DynamicThreshold{
-			Level:          2,
-			CurrentValue:   0.40, // 50% of 0.80
-			Timer:          time.Now().Add(1 * time.Hour),
-			HighConfCount:  2,
-			ValidHours:     24,
-			ScientificName: "Speciesus secondus",
-		}
-		p.DynamicThresholds[dynamicThresholdKey(testModelID, "species_level3")] = &DynamicThreshold{
-			Level:          3,
-			CurrentValue:   0.20, // 25% of 0.80
-			Timer:          time.Now().Add(1 * time.Hour),
-			HighConfCount:  3,
-			ValidHours:     24,
-			ScientificName: "Speciesus thirdus",
-		}
-
-		// Change the base threshold from 0.80 to 0.60
-		p.Settings.BirdNET.Threshold = 0.60
-
-		p.RecalculateDynamicThresholds()
-
-		// Verify all values were recalculated with the new base
-		assert.InDelta(t, 0.60, p.DynamicThresholds[dynamicThresholdKey(testModelID, "species_level0")].CurrentValue, 0.001,
-			"Level 0: should be 100%% of new base 0.60")
-		assert.InDelta(t, 0.45, p.DynamicThresholds[dynamicThresholdKey(testModelID, "species_level1")].CurrentValue, 0.001,
-			"Level 1: should be 75%% of new base 0.60")
-		assert.InDelta(t, 0.30, p.DynamicThresholds[dynamicThresholdKey(testModelID, "species_level2")].CurrentValue, 0.001,
-			"Level 2: should be 50%% of new base 0.60")
-		assert.InDelta(t, 0.20, p.DynamicThresholds[dynamicThresholdKey(testModelID, "species_level3")].CurrentValue, 0.001,
-			"Level 3: should be clamped to min 0.20 (25%% of 0.60 = 0.15 < min)")
-
-		// Verify levels are preserved
-		assert.Equal(t, 0, p.DynamicThresholds[dynamicThresholdKey(testModelID, "species_level0")].Level)
-		assert.Equal(t, 1, p.DynamicThresholds[dynamicThresholdKey(testModelID, "species_level1")].Level)
-		assert.Equal(t, 2, p.DynamicThresholds[dynamicThresholdKey(testModelID, "species_level2")].Level)
-		assert.Equal(t, 3, p.DynamicThresholds[dynamicThresholdKey(testModelID, "species_level3")].Level)
-	})
-
-	t.Run("RespectsMinimumThreshold", func(t *testing.T) {
-		p := newTestProcessor()
-		p.Settings.Realtime.DynamicThreshold.Min = 0.30
-
-		p.DynamicThresholds[dynamicThresholdKey(testModelID, "species_level3")] = &DynamicThreshold{
-			Level:          3,
-			CurrentValue:   0.30, // Was clamped to min 0.30 (25% of 0.80 = 0.20 < 0.30)
-			Timer:          time.Now().Add(1 * time.Hour),
-			HighConfCount:  3,
-			ValidHours:     24,
-			ScientificName: "Speciesus thirdus",
-		}
-
-		// Lower the base threshold
-		p.Settings.BirdNET.Threshold = 0.60
-
-		p.RecalculateDynamicThresholds()
-
-		// 25% of 0.60 = 0.15, but min is 0.30
-		assert.InDelta(t, 0.30, p.DynamicThresholds[dynamicThresholdKey(testModelID, "species_level3")].CurrentValue, 0.001,
-			"Should be clamped to configured minimum")
-	})
-
-	t.Run("EmptyMapIsNoOp", func(t *testing.T) {
-		p := newTestProcessor()
-		p.Settings.BirdNET.Threshold = 0.60
-
-		// Should not panic or error with empty map
-		p.RecalculateDynamicThresholds()
-
-		assert.Empty(t, p.DynamicThresholds)
-	})
-
-	t.Run("NoChangeWhenBaseUnchanged", func(t *testing.T) {
-		p := newTestProcessor()
-		// Base is already 0.80
-
-		p.DynamicThresholds[dynamicThresholdKey(testModelID, "species_level1")] = &DynamicThreshold{
-			Level:          1,
-			CurrentValue:   0.60, // 75% of 0.80 - already correct
-			Timer:          time.Now().Add(1 * time.Hour),
-			HighConfCount:  1,
-			ValidHours:     24,
-			ScientificName: "Speciesus firstus",
-		}
-
-		p.RecalculateDynamicThresholds()
-
-		// Value should remain the same
-		assert.InDelta(t, 0.60, p.DynamicThresholds[dynamicThresholdKey(testModelID, "species_level1")].CurrentValue, 0.001,
-			"Should remain unchanged when base is the same")
-	})
-
-	t.Run("HigherBaseThreshold", func(t *testing.T) {
-		p := newTestProcessor()
-
-		p.DynamicThresholds[dynamicThresholdKey(testModelID, "species_level2")] = &DynamicThreshold{
-			Level:          2,
-			CurrentValue:   0.40, // 50% of 0.80
-			Timer:          time.Now().Add(1 * time.Hour),
-			HighConfCount:  2,
-			ValidHours:     24,
-			ScientificName: "Speciesus secondus",
-		}
-
-		// Increase the base threshold from 0.80 to 1.00
-		p.Settings.BirdNET.Threshold = 1.00
-
-		p.RecalculateDynamicThresholds()
-
-		// 50% of 1.00 = 0.50
-		assert.InDelta(t, 0.50, p.DynamicThresholds[dynamicThresholdKey(testModelID, "species_level2")].CurrentValue, 0.001,
-			"Level 2: should be 50%% of new base 1.00")
-	})
+	dt := p.DynamicThresholds["eurasian wren"]
+	if assert.NotNil(t, dt, "entry should be created") {
+		assert.Equal(t, 1, dt.Level, "first learning should reach level 1")
+		assert.InDelta(t, 0.40, dt.BaseThreshold, 0.001, "recorded base should be the caller's model base")
+	}
 }
 
 // TestLevelMultiplier verifies the level-to-multiplier mapping is correct
@@ -649,6 +423,32 @@ func TestLevelMultiplier(t *testing.T) {
 		t.Run(fmt.Sprintf("Level%d", tt.level), func(t *testing.T) {
 			t.Parallel()
 			assert.InDelta(t, tt.expected, levelMultiplier(tt.level), 0.001)
+		})
+	}
+}
+
+// TestEffectiveDynamicThreshold verifies the derived-value helper: base times the
+// level multiplier, clamped to the minimum.
+func TestEffectiveDynamicThreshold(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     float64
+		level    int
+		min      float64
+		expected float64
+	}{
+		{"level 0 returns base", 0.80, 0, 0.20, 0.80},
+		{"level 1 is 75% of base", 0.80, 1, 0.20, 0.60},
+		{"level 2 is 50% of base", 0.80, 2, 0.20, 0.40},
+		{"level 3 is 25% of base", 0.80, 3, 0.20, 0.20},
+		{"clamped to min", 0.80, 3, 0.30, 0.30},
+		{"per-model base", 0.40, 1, 0.20, 0.30},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.InDelta(t, tt.expected, effectiveDynamicThreshold(tt.base, tt.level, tt.min), 0.001)
 		})
 	}
 }

--- a/internal/analysis/processor/mock_datastore_test.go
+++ b/internal/analysis/processor/mock_datastore_test.go
@@ -329,7 +329,7 @@ func (m *ActionMockDatastore) SearchDetections(_ *datastore.SearchFilters) ([]da
 func (m *ActionMockDatastore) SaveDynamicThreshold(_ *datastore.DynamicThreshold) error {
 	return nil
 }
-func (m *ActionMockDatastore) GetDynamicThreshold(_, _ string) (*datastore.DynamicThreshold, error) {
+func (m *ActionMockDatastore) GetDynamicThreshold(_ string) (*datastore.DynamicThreshold, error) {
 	// Returns ErrNoteReviewNotFound as a generic "not found" sentinel.
 	// This stub method is not exercised by action execution tests.
 	return nil, datastore.ErrNoteReviewNotFound

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -1037,7 +1037,7 @@ func (p *Processor) shouldFilterDetection(settings *conf.Settings, result datast
 		// Use lookupSpeciesConfig to support both common name and scientific name lookups
 		config, exists := lookupSpeciesConfig(settings.Realtime.Species.Config, commonName, scientificName)
 		isCustomThreshold := exists && config.Threshold > 0
-		confidenceThreshold = p.getAdjustedConfidenceThreshold(modelID, speciesLowercase, baseThreshold, isCustomThreshold)
+		confidenceThreshold = p.getAdjustedConfidenceThreshold(speciesLowercase, baseThreshold, isCustomThreshold)
 	} else {
 		confidenceThreshold = baseThreshold
 	}
@@ -1586,7 +1586,7 @@ func (p *Processor) processApprovedDetection(item *PendingDetection, speciesName
 	for modelID, contrib := range item.ModelContributions {
 		baseThreshold := float64(p.getBaseConfidenceThreshold(settings, speciesName, scientificName, modelID))
 		if contrib.MaxConfidence >= baseThreshold {
-			p.LearnFromApprovedDetection(modelID, speciesName, scientificName, float32(contrib.MaxConfidence))
+			p.LearnFromApprovedDetection(speciesName, scientificName, float32(contrib.MaxConfidence), float32(baseThreshold))
 		}
 	}
 

--- a/internal/analysis/processor/processor_hot_reload_test.go
+++ b/internal/analysis/processor/processor_hot_reload_test.go
@@ -40,7 +40,12 @@ func TestCurrentSettings_ReturnsGlobalWhenPublished(t *testing.T) {
 	assert.InDelta(t, 0.99, got.BirdNET.Threshold, 0.001)
 }
 
-func TestRecalculateDynamicThresholds_ReadsGlobalSettings(t *testing.T) {
+// TestDynamicThreshold_AppliesLiveBaseWithoutRecalc verifies that a base-threshold
+// change takes effect immediately at the next detection with no recalculation step.
+// The applied value is derived at read time from the caller's live per-model base and
+// the shared level, so the recalc machinery that previously rewrote stored absolute
+// values is no longer needed.
+func TestDynamicThreshold_AppliesLiveBaseWithoutRecalc(t *testing.T) {
 	// Start with base threshold 0.80
 	initial := &conf.Settings{
 		BirdNET: conf.BirdNETConfig{Threshold: 0.80},
@@ -59,16 +64,20 @@ func TestRecalculateDynamicThresholds_ReadsGlobalSettings(t *testing.T) {
 		pendingResets:     make(map[string]struct{}),
 	}
 
-	// Add a species at level 1 (75% of base)
-	key := dynamicThresholdKey("model1", "species_a")
-	p.DynamicThresholds[key] = &DynamicThreshold{
+	// Add a species at level 1. BaseThreshold is display metadata; the applied value
+	// comes from the caller's live base, not this stored field.
+	p.DynamicThresholds["species_a"] = &DynamicThreshold{
 		Level:          1,
-		CurrentValue:   0.60, // 75% of 0.80
+		BaseThreshold:  0.80,
 		Timer:          time.Now().Add(1 * time.Hour),
 		ScientificName: "Speciesus testus",
 	}
 
-	// Simulate UI changing threshold to 0.40 via global settings
+	// Before: with the caller's base at 0.80, level 1 applies 75% -> 0.60.
+	assert.InDelta(t, 0.60, p.getAdjustedConfidenceThreshold("species_a", 0.80, false), 0.01,
+		"expected 75% of base 0.80 = 0.60")
+
+	// Simulate the UI lowering the threshold to 0.40 via global settings.
 	updated := &conf.Settings{
 		BirdNET:  conf.BirdNETConfig{Threshold: 0.40},
 		Realtime: initial.Realtime,
@@ -76,11 +85,10 @@ func TestRecalculateDynamicThresholds_ReadsGlobalSettings(t *testing.T) {
 	conf.StoreSettings(updated)
 	t.Cleanup(func() { conf.StoreSettings(nil) })
 
-	// Recalculate should use the NEW base (0.40), not old (0.80)
-	p.RecalculateDynamicThresholds()
-
-	assert.InDelta(t, 0.30, p.DynamicThresholds[key].CurrentValue, 0.01,
-		"expected 75% of new base 0.40 = 0.30")
+	// After: the next read with the new base (0.40) applies 75% -> 0.30 immediately,
+	// with no recalculation call.
+	assert.InDelta(t, 0.30, p.getAdjustedConfidenceThreshold("species_a", 0.40, false), 0.01,
+		"expected 75% of new base 0.40 = 0.30 with no recalc step")
 }
 
 func TestCalculateMinDetections_ReadsGlobalSettings(t *testing.T) {

--- a/internal/analysis/processor/threshold_persistence.go
+++ b/internal/analysis/processor/threshold_persistence.go
@@ -68,20 +68,29 @@ func (p *Processor) loadDynamicThresholdsFromDB() error {
 			if settings.Realtime.DynamicThreshold.Debug {
 				GetLogger().Debug("Skipping expired threshold",
 					logger.String("species", dbThreshold.SpeciesName),
-					logger.String("model", dbThreshold.ModelName),
 					logger.Time("expires_at", dbThreshold.ExpiresAt),
 					logger.String("operation", "load_dynamic_thresholds"))
 			}
 			continue
 		}
 
-		// Reconstruct composite key from DB fields
-		key := dynamicThresholdKey(dbThreshold.ModelName, strings.ToLower(dbThreshold.SpeciesName))
+		// Thresholds are keyed per species (lowercase common name).
+		key := strings.ToLower(dbThreshold.SpeciesName)
+
+		// Defensive merge: the DB should hold one row per species after migration,
+		// but if a stray duplicate slips through, keep the more-advanced state
+		// (higher level; tie broken by the later expiry) rather than clobbering.
+		if existing, ok := p.DynamicThresholds[key]; ok {
+			if dbThreshold.Level < existing.Level ||
+				(dbThreshold.Level == existing.Level && !dbThreshold.ExpiresAt.After(existing.Timer)) {
+				continue
+			}
+		}
 
 		// Convert database model to in-memory representation
 		p.DynamicThresholds[key] = &DynamicThreshold{
 			Level:          dbThreshold.Level,
-			CurrentValue:   dbThreshold.CurrentValue,
+			BaseThreshold:  dbThreshold.BaseThreshold,
 			Timer:          dbThreshold.ExpiresAt,
 			HighConfCount:  dbThreshold.HighConfCount,
 			ValidHours:     dbThreshold.ValidHours,
@@ -92,9 +101,8 @@ func (p *Processor) loadDynamicThresholdsFromDB() error {
 		if settings.Realtime.DynamicThreshold.Debug {
 			GetLogger().Debug("Loaded dynamic threshold",
 				logger.String("species", dbThreshold.SpeciesName),
-				logger.String("model", dbThreshold.ModelName),
 				logger.Int("threshold_level", dbThreshold.Level),
-				logger.Float64("current_value", dbThreshold.CurrentValue),
+				logger.Float64("base_threshold", dbThreshold.BaseThreshold),
 				logger.Time("expires_at", dbThreshold.ExpiresAt),
 				logger.String("operation", "load_dynamic_thresholds"))
 		}
@@ -123,29 +131,26 @@ func (p *Processor) convertThresholdsForPersistence(settings *conf.Settings) (db
 	dbThresholds = make([]datastore.DynamicThreshold, 0, len(p.DynamicThresholds))
 	expiredSpecies = make([]string, 0)
 
-	for compositeKey, threshold := range p.DynamicThresholds {
+	minThreshold := settings.Realtime.DynamicThreshold.Min
+
+	for speciesName, threshold := range p.DynamicThresholds {
 		if now.After(threshold.Timer) {
-			expiredSpecies = append(expiredSpecies, compositeKey)
+			expiredSpecies = append(expiredSpecies, speciesName)
 			if settings.Realtime.DynamicThreshold.Debug {
 				GetLogger().Debug("Found expired threshold during persistence",
-					logger.String("key", compositeKey),
+					logger.String("species", speciesName),
 					logger.Time("expires_at", threshold.Timer),
 					logger.String("operation", "persist_dynamic_thresholds"))
 			}
 			continue
 		}
 
-		// Extract model name and species name from composite key
-		modelName, speciesName := splitDynamicThresholdKey(compositeKey)
-
-		baseThreshold := p.getBaseConfidenceThreshold(settings, speciesName, "", modelName)
 		dbThresholds = append(dbThresholds, datastore.DynamicThreshold{
 			SpeciesName:    speciesName,
-			ModelName:      modelName,
 			ScientificName: threshold.ScientificName,
 			Level:          threshold.Level,
-			CurrentValue:   threshold.CurrentValue,
-			BaseThreshold:  float64(baseThreshold),
+			CurrentValue:   effectiveDynamicThreshold(threshold.BaseThreshold, threshold.Level, minThreshold),
+			BaseThreshold:  threshold.BaseThreshold,
 			HighConfCount:  threshold.HighConfCount,
 			ValidHours:     threshold.ValidHours,
 			ExpiresAt:      threshold.Timer,

--- a/internal/analysis/processor/threshold_persistence_test.go
+++ b/internal/analysis/processor/threshold_persistence_test.go
@@ -208,12 +208,7 @@ func (m *MockDatastore) SaveDynamicThreshold(threshold *datastore.DynamicThresho
 	return nil
 }
 
-func (m *MockDatastore) GetDynamicThreshold(speciesName, modelName string) (*datastore.DynamicThreshold, error) {
-	key := speciesName + ":" + modelName
-	if threshold, exists := m.thresholds[key]; exists {
-		return threshold, nil
-	}
-	// Fall back to species-only lookup for backward compatibility in tests
+func (m *MockDatastore) GetDynamicThreshold(speciesName string) (*datastore.DynamicThreshold, error) {
 	if threshold, exists := m.thresholds[speciesName]; exists {
 		return threshold, nil
 	}
@@ -478,12 +473,11 @@ func TestLoadDynamicThresholdsFromDB(t *testing.T) {
 		p := createTestProcessor()
 		mockDs := p.Ds.(*MockDatastore)
 
-		// Pre-populate mock database with valid thresholds
+		// Pre-populate mock database with valid thresholds (keyed per species)
 		now := time.Now()
 		mockDs.thresholds = map[string]*datastore.DynamicThreshold{
 			"american crow": {
 				SpeciesName:   "american crow",
-				ModelName:     "BirdNET",
 				Level:         1,
 				CurrentValue:  0.75,
 				BaseThreshold: 0.7,
@@ -495,7 +489,6 @@ func TestLoadDynamicThresholdsFromDB(t *testing.T) {
 			},
 			"blue jay": {
 				SpeciesName:   "blue jay",
-				ModelName:     "BirdNET",
 				Level:         2,
 				CurrentValue:  0.8,
 				BaseThreshold: 0.7,
@@ -512,21 +505,19 @@ func TestLoadDynamicThresholdsFromDB(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, p.DynamicThresholds, 2)
 
-		// Verify american crow threshold (composite key: "BirdNET:american crow")
-		crowKey := dynamicThresholdKey("BirdNET", "american crow")
-		crowThreshold := p.DynamicThresholds[crowKey]
+		// Verify american crow threshold (keyed by species name)
+		crowThreshold := p.DynamicThresholds["american crow"]
 		require.NotNil(t, crowThreshold)
 		assert.Equal(t, 1, crowThreshold.Level)
-		assert.InDelta(t, 0.75, crowThreshold.CurrentValue, 0.001)
+		assert.InDelta(t, 0.7, crowThreshold.BaseThreshold, 0.001, "BaseThreshold loads from DB")
 		assert.Equal(t, 5, crowThreshold.HighConfCount)
 		assert.Equal(t, 48, crowThreshold.ValidHours)
 
-		// Verify blue jay threshold (composite key: "BirdNET:blue jay")
-		jayKey := dynamicThresholdKey("BirdNET", "blue jay")
-		jayThreshold := p.DynamicThresholds[jayKey]
+		// Verify blue jay threshold (keyed by species name)
+		jayThreshold := p.DynamicThresholds["blue jay"]
 		require.NotNil(t, jayThreshold)
 		assert.Equal(t, 2, jayThreshold.Level)
-		assert.InDelta(t, 0.8, jayThreshold.CurrentValue, 0.001)
+		assert.InDelta(t, 0.7, jayThreshold.BaseThreshold, 0.001, "BaseThreshold loads from DB")
 		assert.Equal(t, 10, jayThreshold.HighConfCount)
 	})
 
@@ -538,14 +529,12 @@ func TestLoadDynamicThresholdsFromDB(t *testing.T) {
 		mockDs.thresholds = map[string]*datastore.DynamicThreshold{
 			"american crow": {
 				SpeciesName:  "american crow",
-				ModelName:    "BirdNET",
 				Level:        1,
 				CurrentValue: 0.75,
 				ExpiresAt:    now.Add(24 * time.Hour), // Valid
 			},
 			"blue jay": {
 				SpeciesName:  "blue jay",
-				ModelName:    "BirdNET",
 				Level:        2,
 				CurrentValue: 0.8,
 				ExpiresAt:    now.Add(-1 * time.Hour), // Expired
@@ -556,10 +545,8 @@ func TestLoadDynamicThresholdsFromDB(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Len(t, p.DynamicThresholds, 1, "Should only load non-expired threshold")
-		crowKey := dynamicThresholdKey("BirdNET", "american crow")
-		jayKey := dynamicThresholdKey("BirdNET", "blue jay")
-		assert.Contains(t, p.DynamicThresholds, crowKey)
-		assert.NotContains(t, p.DynamicThresholds, jayKey)
+		assert.Contains(t, p.DynamicThresholds, "american crow")
+		assert.NotContains(t, p.DynamicThresholds, "blue jay")
 	})
 }
 
@@ -570,19 +557,17 @@ func TestPersistDynamicThresholds(t *testing.T) {
 		mockDs := p.Ds.(*MockDatastore)
 
 		now := time.Now()
-		// Add thresholds to in-memory map using composite keys
-		crowKey := dynamicThresholdKey("BirdNET", "american crow")
-		jayKey := dynamicThresholdKey("BirdNET", "blue jay")
-		p.DynamicThresholds[crowKey] = &DynamicThreshold{
+		// Add thresholds to in-memory map (keyed per species)
+		p.DynamicThresholds["american crow"] = &DynamicThreshold{
 			Level:         1,
-			CurrentValue:  0.75,
+			BaseThreshold: 0.75,
 			Timer:         now.Add(24 * time.Hour),
 			HighConfCount: 5,
 			ValidHours:    48,
 		}
-		p.DynamicThresholds[jayKey] = &DynamicThreshold{
+		p.DynamicThresholds["blue jay"] = &DynamicThreshold{
 			Level:         2,
-			CurrentValue:  0.8,
+			BaseThreshold: 0.8,
 			Timer:         now.Add(48 * time.Hour),
 			HighConfCount: 10,
 			ValidHours:    48,
@@ -598,9 +583,8 @@ func TestPersistDynamicThresholds(t *testing.T) {
 		savedCrow := mockDs.thresholds["american crow"]
 		require.NotNil(t, savedCrow)
 		assert.Equal(t, 1, savedCrow.Level)
-		assert.InDelta(t, 0.75, savedCrow.CurrentValue, 0.001)
+		assert.InDelta(t, 0.75, savedCrow.BaseThreshold, 0.001, "BaseThreshold should be persisted")
 		assert.Equal(t, 5, savedCrow.HighConfCount)
-		assert.Equal(t, "BirdNET", savedCrow.ModelName, "ModelName should be persisted")
 	})
 
 	t.Run("EmptyThresholdsMap", func(t *testing.T) {
@@ -618,25 +602,23 @@ func TestPersistDynamicThresholds(t *testing.T) {
 		mockDs := p.Ds.(*MockDatastore)
 
 		now := time.Now()
-		crowKey := dynamicThresholdKey("BirdNET", "american crow")
-		jayKey := dynamicThresholdKey("BirdNET", "blue jay")
-		p.DynamicThresholds[crowKey] = &DynamicThreshold{
-			Level:        1,
-			CurrentValue: 0.75,
-			Timer:        now.Add(24 * time.Hour), // Valid
+		p.DynamicThresholds["american crow"] = &DynamicThreshold{
+			Level:         1,
+			BaseThreshold: 0.75,
+			Timer:         now.Add(24 * time.Hour), // Valid
 		}
-		p.DynamicThresholds[jayKey] = &DynamicThreshold{
-			Level:        2,
-			CurrentValue: 0.8,
-			Timer:        now.Add(-1 * time.Hour), // Expired
+		p.DynamicThresholds["blue jay"] = &DynamicThreshold{
+			Level:         2,
+			BaseThreshold: 0.8,
+			Timer:         now.Add(-1 * time.Hour), // Expired
 		}
 
 		err := p.persistDynamicThresholds(t.Context())
 
 		require.NoError(t, err)
 		assert.Len(t, p.DynamicThresholds, 1, "Expired threshold should be removed from memory")
-		assert.Contains(t, p.DynamicThresholds, crowKey)
-		assert.NotContains(t, p.DynamicThresholds, jayKey)
+		assert.Contains(t, p.DynamicThresholds, "american crow")
+		assert.NotContains(t, p.DynamicThresholds, "blue jay")
 
 		// Only valid threshold should be saved to database
 		assert.Len(t, mockDs.thresholds, 1)
@@ -651,11 +633,10 @@ func TestFlushDynamicThresholds(t *testing.T) {
 		mockDs := p.Ds.(*MockDatastore)
 
 		now := time.Now()
-		crowKey := dynamicThresholdKey("BirdNET", "american crow")
-		p.DynamicThresholds[crowKey] = &DynamicThreshold{
-			Level:        1,
-			CurrentValue: 0.75,
-			Timer:        now.Add(24 * time.Hour),
+		p.DynamicThresholds["american crow"] = &DynamicThreshold{
+			Level:         1,
+			BaseThreshold: 0.75,
+			Timer:         now.Add(24 * time.Hour),
 		}
 
 		err := p.FlushDynamicThresholds()
@@ -754,35 +735,30 @@ func (e NoSuchTableError) Error() string {
 	return "no such table: " + e.TableName
 }
 
-// TestBatchSaveWithBaseThreshold tests that base threshold is preserved
+// TestBatchSaveWithBaseThreshold verifies the in-memory BaseThreshold (the model
+// base recorded at last learn) round-trips through persistence, and that the saved
+// CurrentValue is derived from it and the level.
 func TestBatchSaveWithBaseThreshold(t *testing.T) {
 	t.Run("PreserveBaseThreshold", func(t *testing.T) {
 		p := createTestProcessor()
 		mockDs := p.Ds.(*MockDatastore)
 
-		// Set custom threshold in settings
-		p.Settings.Realtime.Species.Config = map[string]conf.SpeciesConfig{
-			"american crow": {
-				Threshold: 0.65,
-			},
-		}
-
 		now := time.Now()
-		crowKey := dynamicThresholdKey("BirdNET", "american crow")
-		p.DynamicThresholds[crowKey] = &DynamicThreshold{
-			Level:        1,
-			CurrentValue: 0.75,
-			Timer:        now.Add(24 * time.Hour),
+		p.DynamicThresholds["american crow"] = &DynamicThreshold{
+			Level:         1,
+			BaseThreshold: 0.65,
+			Timer:         now.Add(24 * time.Hour),
 		}
 
 		err := p.persistDynamicThresholds(t.Context())
 
 		require.NoError(t, err)
 
-		// Verify base threshold was calculated and saved (BatchSave stores by species name)
+		// Verify base threshold round-trips and CurrentValue is derived (75% of 0.65).
 		savedThreshold := mockDs.thresholds["american crow"]
 		require.NotNil(t, savedThreshold)
-		assert.InDelta(t, 0.65, savedThreshold.BaseThreshold, 0.001, "Base threshold should match custom config")
+		assert.InDelta(t, 0.65, savedThreshold.BaseThreshold, 0.001, "BaseThreshold should round-trip")
+		assert.InDelta(t, 0.65*0.75, savedThreshold.CurrentValue, 0.001, "CurrentValue derived from base and level")
 	})
 }
 

--- a/internal/api/v2/dynamicthresholds/dynamicthresholds.go
+++ b/internal/api/v2/dynamicthresholds/dynamicthresholds.go
@@ -62,7 +62,6 @@ func (c *Handler) RegisterRoutes(g *echo.Group) {
 type DynamicThresholdResponse struct {
 	SpeciesName    string    `json:"speciesName"`
 	ScientificName string    `json:"scientificName"`
-	ModelName      string    `json:"modelName,omitempty"`
 	Level          int       `json:"level"`
 	CurrentValue   float64   `json:"currentValue"`
 	BaseThreshold  float64   `json:"baseThreshold"`
@@ -78,7 +77,6 @@ type DynamicThresholdResponse struct {
 type ThresholdEventResponse struct {
 	ID            uint      `json:"id"`
 	SpeciesName   string    `json:"speciesName"`
-	ModelName     string    `json:"modelName,omitempty"`
 	PreviousLevel int       `json:"previousLevel"`
 	NewLevel      int       `json:"newLevel"`
 	PreviousValue float64   `json:"previousValue"`
@@ -221,12 +219,11 @@ func (c *Handler) addDatabaseThresholds(thresholdMap map[string]*DynamicThreshol
 	now := time.Now()
 	for i := range dbThresholds {
 		dt := &dbThresholds[i]
-		// Use composite key to prevent overwrite when multiple models have thresholds for the same species.
-		mapKey := strings.ToLower(dt.ModelName) + ":" + strings.ToLower(dt.SpeciesName)
+		// Keyed per species (tracking is per species, not per model).
+		mapKey := strings.ToLower(dt.SpeciesName)
 		thresholdMap[mapKey] = &DynamicThresholdResponse{
 			SpeciesName:    dt.SpeciesName,
 			ScientificName: dt.ScientificName,
-			ModelName:      dt.ModelName,
 			Level:          dt.Level,
 			CurrentValue:   dt.CurrentValue,
 			BaseThreshold:  dt.BaseThreshold,
@@ -250,18 +247,17 @@ func (c *Handler) addMemoryThresholds(thresholdMap map[string]*DynamicThresholdR
 	memoryData := proc.GetDynamicThresholdData()
 
 	for _, dt := range memoryData {
-		key := strings.ToLower(dt.ModelName) + ":" + strings.ToLower(dt.SpeciesName)
+		key := strings.ToLower(dt.SpeciesName)
 		if existing, exists := thresholdMap[key]; exists {
 			// Update existing entry with in-memory values
 			applyMemoryOverlay(existing, dt.Level, dt.HighConfCount, dt.CurrentValue, dt.ExpiresAt, dt.IsActive, dt.ScientificName)
 		} else {
-			// Add new entry from memory. BaseThreshold is model-aware (Perch v2 /
-			// BirdNET v3.0 override, Bat, or the primary BirdNET base) so the
-			// displayed base matches the value the recalculation path applies.
+			// Add new entry from memory. BaseThreshold and CurrentValue are derived
+			// from the model that last learned this species (display only); the
+			// applied threshold is computed live per model during detection.
 			thresholdMap[key] = &DynamicThresholdResponse{
 				SpeciesName:    dt.SpeciesName,
 				ScientificName: dt.ScientificName,
-				ModelName:      dt.ModelName,
 				Level:          dt.Level,
 				CurrentValue:   dt.CurrentValue,
 				BaseThreshold:  dt.BaseThreshold,
@@ -319,9 +315,8 @@ func (c *Handler) GetDynamicThreshold(ctx echo.Context) error {
 		return err
 	}
 
-	// Try to get from database; optional model query param scopes the lookup
-	model := ctx.QueryParam("model")
-	dt, err := c.DS.GetDynamicThreshold(species, model)
+	// Thresholds are tracked per species; look up the single row for this species.
+	dt, err := c.DS.GetDynamicThreshold(species)
 	if err != nil {
 		return c.HandleErrorWithNotFound(ctx, err, "Threshold not found", "Failed to get threshold")
 	}
@@ -329,7 +324,6 @@ func (c *Handler) GetDynamicThreshold(ctx echo.Context) error {
 	response := DynamicThresholdResponse{
 		SpeciesName:    dt.SpeciesName,
 		ScientificName: dt.ScientificName,
-		ModelName:      dt.ModelName,
 		Level:          dt.Level,
 		CurrentValue:   dt.CurrentValue,
 		BaseThreshold:  dt.BaseThreshold,
@@ -378,7 +372,6 @@ func (c *Handler) GetThresholdEvents(ctx echo.Context) error {
 		response[i] = ThresholdEventResponse{
 			ID:            events[i].ID,
 			SpeciesName:   events[i].SpeciesName,
-			ModelName:     events[i].ModelName,
 			PreviousLevel: events[i].PreviousLevel,
 			NewLevel:      events[i].NewLevel,
 			PreviousValue: events[i].PreviousValue,

--- a/internal/api/v2/dynamicthresholds/dynamicthresholds_test.go
+++ b/internal/api/v2/dynamicthresholds/dynamicthresholds_test.go
@@ -25,11 +25,10 @@ func TestGetMergedThresholdData_NoDuplicates(t *testing.T) {
 	now := time.Now()
 	expires := now.Add(24 * time.Hour)
 
-	// Database returns Title Case species name with ModelName (as resolveCommonName does)
+	// Database returns Title Case species name (as resolveCommonName does)
 	mockDS.EXPECT().GetAllDynamicThresholds().Return([]datastore.DynamicThreshold{
 		{
 			SpeciesName:    "Tawny Owl",
-			ModelName:      "BirdNET",
 			ScientificName: "Strix aluco",
 			Level:          1,
 			CurrentValue:   0.45,
@@ -39,15 +38,15 @@ func TestGetMergedThresholdData_NoDuplicates(t *testing.T) {
 		},
 	}, nil)
 
-	// Processor memory stores with composite key "modelID:speciesLowercase"
+	// Processor memory stores with species key
 	proc := &processor.Processor{
 		Settings: &conf.Settings{
 			BirdNET: conf.BirdNETConfig{Threshold: 0.6},
 		},
 		DynamicThresholds: map[string]*processor.DynamicThreshold{
-			"BirdNET:tawny owl": {
+			"tawny owl": {
 				Level:          2,
-				CurrentValue:   0.3,
+				BaseThreshold:  0.6,
 				Timer:          expires,
 				HighConfCount:  2,
 				ValidHours:     24,
@@ -97,9 +96,9 @@ func TestGetMergedThresholdData_MemoryOnlySpecies(t *testing.T) {
 			BirdNET: conf.BirdNETConfig{Threshold: 0.6},
 		},
 		DynamicThresholds: map[string]*processor.DynamicThreshold{
-			"BirdNET:eurasian blue tit": {
+			"eurasian blue tit": {
 				Level:          1,
-				CurrentValue:   0.45,
+				BaseThreshold:  0.6,
 				Timer:          expires,
 				HighConfCount:  1,
 				ValidHours:     24,
@@ -134,7 +133,6 @@ func TestGetMergedThresholdData_DatabaseOnlySpecies(t *testing.T) {
 	mockDS.EXPECT().GetAllDynamicThresholds().Return([]datastore.DynamicThreshold{
 		{
 			SpeciesName:    "Common Blackbird",
-			ModelName:      "BirdNET",
 			ScientificName: "Turdus merula",
 			Level:          1,
 			CurrentValue:   0.45,
@@ -186,7 +184,7 @@ func TestGetDynamicThreshold_NotFoundStatus(t *testing.T) {
 			Component("datastore").
 			Category(errors.CategoryNotFound).
 			Build()
-		mockDS.EXPECT().GetDynamicThreshold(species, "").Return(nil, notFound)
+		mockDS.EXPECT().GetDynamicThreshold(species).Return(nil, notFound)
 
 		rec := serveGetDynamicThreshold(t, e, handler, species)
 		assert.Equal(t, http.StatusNotFound, rec.Code,
@@ -198,7 +196,7 @@ func TestGetDynamicThreshold_NotFoundStatus(t *testing.T) {
 		// The pre-fix v2only behavior: a bare, unclassified sentinel. The handler
 		// cannot tell it is a benign not-found, so it falls through to 500. This is
 		// the #1068 bug, pinned so a future unwrapped return is caught at the handler.
-		mockDS.EXPECT().GetDynamicThreshold(species, "").
+		mockDS.EXPECT().GetDynamicThreshold(species).
 			Return(nil, errors.NewStd("dynamic threshold not found"))
 
 		rec := serveGetDynamicThreshold(t, e, handler, species)

--- a/internal/api/v2/hotreload_coverage_test.go
+++ b/internal/api/v2/hotreload_coverage_test.go
@@ -47,10 +47,9 @@ var hotReloadRegistry = map[string]hotReloadEntry{
 	// --- BirdNET ---
 	"BirdNET.Debug":       {categories: []hotReloadCategory{hotReloadFresh}},
 	"BirdNET.Sensitivity": {categories: []hotReloadCategory{hotReloadFresh}},
-	"BirdNET.Threshold": {
-		categories: []hotReloadCategory{hotReloadFresh},
-		action:     "recalculate_dynamic_thresholds",
-	},
+	// The base threshold is read live per detection; the dynamic threshold applies
+	// it against the shared per-species level at read time, so no recalc action fires.
+	"BirdNET.Threshold":          {categories: []hotReloadCategory{hotReloadFresh}},
 	"BirdNET.Overlap":            {categories: []hotReloadCategory{hotReloadFresh}},
 	"BirdNET.Longitude":          {categories: []hotReloadCategory{hotReloadDisplay}, action: "rebuild_range_filter"},
 	"BirdNET.Latitude":           {categories: []hotReloadCategory{hotReloadDisplay}, action: "rebuild_range_filter"},
@@ -77,37 +76,22 @@ var hotReloadRegistry = map[string]hotReloadEntry{
 
 	// --- Perch ---
 	// Parent is restart: model/label path and locale changes reload the model.
-	// The threshold override + value are read live by the processor, so they
-	// hot-reload and only need a dynamic-threshold recalculation.
-	"Perch": {categories: []hotReloadCategory{hotReloadRestart}},
-	"Perch.Threshold": {
-		categories: []hotReloadCategory{hotReloadFresh},
-		action:     "recalculate_dynamic_thresholds",
-	},
-	"Perch.OverrideThreshold": {
-		categories: []hotReloadCategory{hotReloadFresh},
-		action:     "recalculate_dynamic_thresholds",
-	},
+	// The threshold override + value are read live by the processor at detection
+	// time, so they hot-reload with no dynamic-threshold recalc action.
+	"Perch":                   {categories: []hotReloadCategory{hotReloadRestart}},
+	"Perch.Threshold":         {categories: []hotReloadCategory{hotReloadFresh}},
+	"Perch.OverrideThreshold": {categories: []hotReloadCategory{hotReloadFresh}},
 
 	// --- BirdNET v3.0 ---
-	"BirdNETV3": {categories: []hotReloadCategory{hotReloadRestart}},
-	"BirdNETV3.Threshold": {
-		categories: []hotReloadCategory{hotReloadFresh},
-		action:     "recalculate_dynamic_thresholds",
-	},
-	"BirdNETV3.OverrideThreshold": {
-		categories: []hotReloadCategory{hotReloadFresh},
-		action:     "recalculate_dynamic_thresholds",
-	},
+	"BirdNETV3":                   {categories: []hotReloadCategory{hotReloadRestart}},
+	"BirdNETV3.Threshold":         {categories: []hotReloadCategory{hotReloadFresh}},
+	"BirdNETV3.OverrideThreshold": {categories: []hotReloadCategory{hotReloadFresh}},
 
 	// --- Bat ---
 	"Bat": {categories: []hotReloadCategory{hotReloadFresh}},
-	// The bat dynamic-threshold base is now model-aware, so a bat threshold change
-	// must recalculate existing bat dynamic thresholds (mirrors BirdNET.Threshold).
-	"Bat.Threshold": {
-		categories: []hotReloadCategory{hotReloadFresh},
-		action:     "recalculate_dynamic_thresholds",
-	},
+	// The bat base threshold is read live per detection like the other model bases,
+	// so a change takes effect at the next detection with no recalc action.
+	"Bat.Threshold": {categories: []hotReloadCategory{hotReloadFresh}},
 
 	// --- BSG ---
 	"BSG": {categories: []hotReloadCategory{hotReloadRestart}},

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -2452,7 +2452,6 @@ var settingsChangeChecks = []settingsChangeCheck{
 	{"BirdNET", "reload_birdnet", birdnetSettingsChanged, "Reloading BirdNET model with new settings...", notification.MsgSettingsReloadingBirdnet, ToastTypeInfo, toastDurationLong},
 	{"Range filter", "rebuild_range_filter", rangeFilterSettingsChanged, "Rebuilding species range filter...", notification.MsgSettingsRebuildingRangeFilter, ToastTypeInfo, toastDurationMedium},
 	{"Species interval", "update_detection_intervals", intervalSettingsChanged, "Updating detection intervals...", notification.MsgSettingsUpdatingIntervals, ToastTypeInfo, toastDurationShort},
-	{"Base threshold", "recalculate_dynamic_thresholds", baseThresholdChanged, "Recalculating dynamic thresholds...", notification.MsgSettingsRecalculatingThresholds, ToastTypeInfo, toastDurationShort},
 	{"Dynamic thresholds", "reconfigure_dynamic_thresholds", dynamicThresholdEnabledChanged, "Reconfiguring dynamic thresholds...", notification.MsgSettingsReconfiguringDynamicThresholds, ToastTypeInfo, toastDurationMedium},
 	{"MQTT", "reconfigure_mqtt", mqttSettingsChanged, "Reconfiguring MQTT connection...", notification.MsgSettingsReconfiguringMqtt, ToastTypeInfo, toastDurationMedium},
 	{"BirdWeather", "reconfigure_birdweather", birdWeatherSettingsChanged, "Reconfiguring BirdWeather integration...", notification.MsgSettingsReconfiguringBirdweather, ToastTypeInfo, toastDurationMedium},
@@ -2667,21 +2666,6 @@ func birdnetSettingsChanged(oldSettings, currentSettings *conf.Settings) bool {
 	}
 
 	return false
-}
-
-// baseThresholdChanged checks if any model-global confidence base threshold has
-// changed. When one does, dynamic threshold CurrentValue entries must be
-// recalculated since they store absolute values derived from the base threshold.
-// This covers the primary BirdNET threshold, the Bat threshold, and the Perch v2
-// and BirdNET v3.0 override toggles and values, which all feed
-// modelGlobalConfidenceThreshold.
-func baseThresholdChanged(oldSettings, currentSettings *conf.Settings) bool {
-	return oldSettings.BirdNET.Threshold != currentSettings.BirdNET.Threshold ||
-		oldSettings.Bat.Threshold != currentSettings.Bat.Threshold ||
-		oldSettings.Perch.OverrideThreshold != currentSettings.Perch.OverrideThreshold ||
-		oldSettings.Perch.Threshold != currentSettings.Perch.Threshold ||
-		oldSettings.BirdNETV3.OverrideThreshold != currentSettings.BirdNETV3.OverrideThreshold ||
-		oldSettings.BirdNETV3.Threshold != currentSettings.BirdNETV3.Threshold
 }
 
 // dynamicThresholdEnabledChanged checks if the DynamicThreshold.Enabled flag was toggled.

--- a/internal/datastore/dynamic_threshold.go
+++ b/internal/datastore/dynamic_threshold.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/tphakala/birdnet-go/internal/detection"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"gorm.io/gorm"
@@ -22,18 +21,16 @@ func (ds *DataStore) SaveDynamicThreshold(threshold *DynamicThreshold) error {
 	if threshold.SpeciesName == "" {
 		return validationError("species name cannot be empty", "species_name", "")
 	}
-	if threshold.ModelName == "" {
-		threshold.ModelName = detection.DefaultModelName
-	}
 
 	// Timestamps
 	now := time.Now()
 	threshold.UpdatedAt = now
 
-	// Upsert: set FirstCreated only on INSERT; always update other fields
+	// Upsert: set FirstCreated only on INSERT; always update other fields.
+	// Thresholds are keyed per species (one row per species, not per model).
 	return RetryOnLock(context.Background(), "save_dynamic_threshold", func() error {
 		threshold.ID = 0 // Reset ID for retry safety with FirstOrCreate
-		result := ds.DB.Where("species_name = ? AND model_name = ?", threshold.SpeciesName, threshold.ModelName).
+		result := ds.DB.Where("species_name = ?", threshold.SpeciesName).
 			Attrs(DynamicThreshold{
 				FirstCreated: now, // Only set on INSERT
 			}).
@@ -51,17 +48,15 @@ func (ds *DataStore) SaveDynamicThreshold(threshold *DynamicThreshold) error {
 	}, ds.getMetrics())
 }
 
-// GetDynamicThreshold retrieves a dynamic threshold for a specific species and model
-func (ds *DataStore) GetDynamicThreshold(speciesName, modelName string) (*DynamicThreshold, error) {
+// GetDynamicThreshold retrieves the dynamic threshold for a species.
+// Thresholds are tracked per species (one row per species, not per model).
+func (ds *DataStore) GetDynamicThreshold(speciesName string) (*DynamicThreshold, error) {
 	if speciesName == "" {
 		return nil, validationError("species name cannot be empty", "species_name", "")
 	}
-	if modelName == "" {
-		modelName = detection.DefaultModelName
-	}
 
 	var threshold DynamicThreshold
-	err := ds.DB.Where("species_name = ? AND model_name = ?", speciesName, modelName).First(&threshold).Error
+	err := ds.DB.Where("species_name = ?", speciesName).First(&threshold).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, errors.Newf("dynamic threshold not found").
@@ -397,13 +392,10 @@ func (ds *DataStore) BatchSaveDynamicThresholds(thresholds []DynamicThreshold) e
 		return nil // Nothing to save
 	}
 
-	// Validate and default all entries before starting transaction
+	// Validate all entries before starting transaction
 	for i := range thresholds {
 		if thresholds[i].SpeciesName == "" {
 			return validationError("species name cannot be empty", "index", i)
-		}
-		if thresholds[i].ModelName == "" {
-			thresholds[i].ModelName = detection.DefaultModelName
 		}
 	}
 
@@ -424,7 +416,7 @@ func (ds *DataStore) BatchSaveDynamicThresholds(thresholds []DynamicThreshold) e
 		// This is much more efficient than multiple FirstOrCreate calls
 		// GORM's OnConflict clause handles SQLite's INSERT...ON CONFLICT DO UPDATE
 		result := tx.Clauses(clause.OnConflict{
-			Columns: []clause.Column{{Name: "species_name"}, {Name: "model_name"}},
+			Columns: []clause.Column{{Name: "species_name"}},
 			DoUpdates: clause.AssignmentColumns([]string{
 				"level",
 				"current_value",

--- a/internal/datastore/dynamic_threshold_migrate.go
+++ b/internal/datastore/dynamic_threshold_migrate.go
@@ -1,0 +1,207 @@
+// dynamic_threshold_migrate.go: one-time migration from per-model to per-species
+// dynamic threshold tracking.
+//
+// Historically dynamic thresholds were keyed by (species_name, model_name) via the
+// composite unique index idx_dt_species_model, so a species detected by several
+// models produced one row per model. Tracking is now per species (the learned
+// "confirmed present" state is model-independent), so this migration consolidates
+// the existing per-model rows to one row per species and removes the model_name
+// columns before AutoMigrate creates the new single-column unique index.
+package datastore
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/logger"
+	"gorm.io/gorm"
+)
+
+// legacyDynamicThresholdRow mirrors the pre-migration dynamic_thresholds schema,
+// including the model_name column that per-species tracking removes. It is used
+// only to read and rewrite existing rows during the migration.
+type legacyDynamicThresholdRow struct {
+	ID             uint
+	SpeciesName    string
+	ModelName      string
+	ScientificName string
+	Level          int
+	CurrentValue   float64
+	BaseThreshold  float64
+	HighConfCount  int
+	ValidHours     int
+	ExpiresAt      time.Time
+	LastTriggered  time.Time
+	FirstCreated   time.Time
+	UpdatedAt      time.Time
+	TriggerCount   int
+}
+
+// TableName pins the row struct to the dynamic_thresholds table.
+func (legacyDynamicThresholdRow) TableName() string { return "dynamic_thresholds" }
+
+// migrateDynamicThresholdsToPerSpecies consolidates per-model dynamic threshold
+// rows to one row per species and drops the model_name columns. It is idempotent
+// (a no-op once model_name is gone) and a no-op on a fresh install. It must run
+// after reconcileLegacyUniqueIndexes and before AutoMigrate, so AutoMigrate finds
+// no duplicates when it creates the new unique(species_name) index.
+func migrateDynamicThresholdsToPerSpecies(db *gorm.DB, log logger.Logger) error {
+	m := db.Migrator()
+
+	// Fresh install: nothing to migrate.
+	if !m.HasTable("dynamic_thresholds") {
+		return nil
+	}
+	// Already migrated: the model_name column is gone. HasColumn inspects the live
+	// table by name (the model only resolves the table name), so the current
+	// entity, which no longer declares model_name, is the right thing to pass.
+	if !m.HasColumn(&DynamicThreshold{}, "model_name") {
+		return nil
+	}
+
+	log.Info("Migrating dynamic thresholds to per-species tracking")
+
+	// 1. Consolidate per-model rows to one row per species.
+	if err := consolidateDynamicThresholdRows(db, log); err != nil {
+		// Safety valve: dynamic thresholds are ephemeral, re-learnable state that
+		// expires within ValidHours. Rather than brick startup on a later unique-index
+		// creation failure, clear the table so AutoMigrate can succeed. The learned
+		// state simply rebuilds from new detections.
+		log.Warn("dynamic threshold consolidation failed; clearing table so migration can proceed",
+			logger.Error(err))
+		if derr := db.Exec("DELETE FROM dynamic_thresholds").Error; derr != nil {
+			return fmt.Errorf("clear dynamic_thresholds after consolidation failure: %w", derr)
+		}
+	}
+
+	// 2. Drop the composite unique index. Required before dropping model_name on
+	//    SQLite, where a column referenced by an index cannot be dropped.
+	if m.HasIndex(&DynamicThreshold{}, "idx_dt_species_model") {
+		if err := m.DropIndex(&DynamicThreshold{}, "idx_dt_species_model"); err != nil {
+			log.Warn("failed to drop legacy composite index idx_dt_species_model", logger.Error(err))
+		}
+	}
+
+	// 3. Drop the model_name columns via native ALTER TABLE DROP COLUMN. Both SQLite
+	//    (3.35+) and MySQL accept this identical syntax; it avoids GORM's SQLite
+	//    table-recreation path, which mishandles a raw-created legacy table. Best-effort:
+	//    a lingering column is harmless because the legacy schema declares it NOT NULL
+	//    DEFAULT 'BirdNET', so inserts that omit it use the default.
+	if err := db.Exec("ALTER TABLE dynamic_thresholds DROP COLUMN model_name").Error; err != nil {
+		log.Warn("failed to drop model_name from dynamic_thresholds", logger.Error(err))
+	}
+	if m.HasColumn(&ThresholdEvent{}, "model_name") {
+		if err := db.Exec("ALTER TABLE threshold_events DROP COLUMN model_name").Error; err != nil {
+			log.Warn("failed to drop model_name from threshold_events", logger.Error(err))
+		}
+	}
+
+	log.Info("Dynamic thresholds migrated to per-species tracking")
+	return nil
+}
+
+// consolidateDynamicThresholdRows collapses all rows for the same species (matched
+// case-insensitively) into a single row, run in one transaction.
+func consolidateDynamicThresholdRows(db *gorm.DB, log logger.Logger) error {
+	var rows []legacyDynamicThresholdRow
+	if err := db.Find(&rows).Error; err != nil {
+		return fmt.Errorf("load dynamic_thresholds for consolidation: %w", err)
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+
+	groups := make(map[string][]legacyDynamicThresholdRow, len(rows))
+	for i := range rows {
+		key := strings.ToLower(rows[i].SpeciesName)
+		groups[key] = append(groups[key], rows[i])
+	}
+
+	consolidated := 0
+	err := db.Transaction(func(tx *gorm.DB) error {
+		for _, group := range groups {
+			if len(group) == 1 {
+				continue // already a single row for this species
+			}
+			winner := consolidateDynamicThresholdGroup(group)
+
+			ids := make([]uint, 0, len(group))
+			for i := range group {
+				ids = append(ids, group[i].ID)
+			}
+			// Delete every row in the group, then insert the merged winner, so
+			// case-variant species names also collapse onto one lowercase row.
+			if err := tx.Where("id IN ?", ids).Delete(&legacyDynamicThresholdRow{}).Error; err != nil {
+				return err
+			}
+			winner.ID = 0
+			if err := tx.Create(&winner).Error; err != nil {
+				return err
+			}
+			consolidated++
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if consolidated > 0 {
+		log.Info("Consolidated per-model dynamic thresholds to per-species",
+			logger.Int("species_consolidated", consolidated))
+	}
+	return nil
+}
+
+// consolidateDynamicThresholdGroup merges a group of per-model rows for one species.
+// The winner is the row with the highest learned level (ties broken by the later
+// expiry, then the later update); counters and timestamps are merged across the
+// group so the strongest confirmation from any model becomes the species' state.
+func consolidateDynamicThresholdGroup(group []legacyDynamicThresholdRow) legacyDynamicThresholdRow {
+	winner := group[0]
+	for i := 1; i < len(group); i++ {
+		r := group[i]
+		switch {
+		case r.Level != winner.Level:
+			if r.Level > winner.Level {
+				winner = r
+			}
+		case !r.ExpiresAt.Equal(winner.ExpiresAt):
+			if r.ExpiresAt.After(winner.ExpiresAt) {
+				winner = r
+			}
+		case r.UpdatedAt.After(winner.UpdatedAt):
+			winner = r
+		}
+	}
+
+	// Merge aggregate fields across the whole group. Counters use max (not sum):
+	// each per-model row counted the same audio once per model, so summing would
+	// inflate the learned state.
+	for i := range group {
+		r := &group[i]
+		if r.ExpiresAt.After(winner.ExpiresAt) {
+			winner.ExpiresAt = r.ExpiresAt
+		}
+		if r.HighConfCount > winner.HighConfCount {
+			winner.HighConfCount = r.HighConfCount
+		}
+		if r.TriggerCount > winner.TriggerCount {
+			winner.TriggerCount = r.TriggerCount
+		}
+		if r.LastTriggered.After(winner.LastTriggered) {
+			winner.LastTriggered = r.LastTriggered
+		}
+		if !r.FirstCreated.IsZero() && (winner.FirstCreated.IsZero() || r.FirstCreated.Before(winner.FirstCreated)) {
+			winner.FirstCreated = r.FirstCreated
+		}
+		if winner.ScientificName == "" && r.ScientificName != "" {
+			winner.ScientificName = r.ScientificName
+		}
+	}
+
+	winner.SpeciesName = strings.ToLower(winner.SpeciesName)
+	winner.UpdatedAt = time.Now()
+	return winner
+}

--- a/internal/datastore/dynamic_threshold_migrate.go
+++ b/internal/datastore/dynamic_threshold_migrate.go
@@ -120,9 +120,20 @@ func consolidateDynamicThresholdRows(db *gorm.DB, log logger.Logger) error {
 
 	consolidated := 0
 	err := db.Transaction(func(tx *gorm.DB) error {
-		for _, group := range groups {
+		for key, group := range groups {
 			if len(group) == 1 {
-				continue // already a single row for this species
+				// Single row: normalize its species_name to the lowercase key if it
+				// differs, so the new case-sensitive unique(species_name) index and the
+				// processor's lowercase lookups agree (a mixed-case legacy row would
+				// otherwise let a later lowercase insert create a duplicate).
+				if group[0].SpeciesName != key {
+					if err := tx.Model(&legacyDynamicThresholdRow{}).
+						Where("id = ?", group[0].ID).
+						Update("species_name", key).Error; err != nil {
+						return err
+					}
+				}
+				continue
 			}
 			winner := consolidateDynamicThresholdGroup(group)
 

--- a/internal/datastore/dynamic_threshold_migrate_test.go
+++ b/internal/datastore/dynamic_threshold_migrate_test.go
@@ -123,6 +123,25 @@ func TestMigrateDynamicThresholdsToPerSpecies_Consolidates(t *testing.T) {
 		base, base, base, base).Error, "duplicate species insert must violate the unique index")
 }
 
+func TestMigrateDynamicThresholdsToPerSpecies_NormalizesSingleMixedCaseRow(t *testing.T) {
+	t.Parallel()
+	db := openSQLiteTestDB(t)
+	createLegacyDynamicThresholdTable(t, db)
+
+	// A lone legacy row with a mixed-case species name (no other row for the taxon).
+	insertLegacyRow(t, db, "American Crow", "BirdNET_V2.4", 2, 3, 3, time.Now().Add(time.Hour))
+
+	require.NoError(t, migrateDynamicThresholdsToPerSpecies(db, GetLogger()))
+	require.NoError(t, db.AutoMigrate(&DynamicThreshold{}))
+
+	var all []DynamicThreshold
+	require.NoError(t, db.Find(&all).Error)
+	require.Len(t, all, 1)
+	assert.Equal(t, "american crow", all[0].SpeciesName,
+		"a single mixed-case legacy row must be lowercased so it matches processor lookups")
+	assert.Equal(t, 2, all[0].Level, "learned state is preserved during normalization")
+}
+
 func TestMigrateDynamicThresholdsToPerSpecies_Idempotent(t *testing.T) {
 	t.Parallel()
 	db := openSQLiteTestDB(t)

--- a/internal/datastore/dynamic_threshold_migrate_test.go
+++ b/internal/datastore/dynamic_threshold_migrate_test.go
@@ -1,0 +1,160 @@
+package datastore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// legacyDynamicThresholdEntity mirrors the pre-migration DynamicThreshold schema
+// (with model_name and the composite unique index). Migrating it with GORM
+// reproduces exactly the on-disk schema production shipped, so the migration test
+// exercises a realistic starting point rather than a hand-rolled table.
+type legacyDynamicThresholdEntity struct {
+	ID             uint      `gorm:"primaryKey"`
+	SpeciesName    string    `gorm:"uniqueIndex:idx_dt_species_model;not null;size:200"`
+	ModelName      string    `gorm:"uniqueIndex:idx_dt_species_model;not null;size:100;default:'BirdNET'"`
+	ScientificName string    `gorm:"size:200"`
+	Level          int       `gorm:"not null;default:0"`
+	CurrentValue   float64   `gorm:"not null"`
+	BaseThreshold  float64   `gorm:"not null"`
+	HighConfCount  int       `gorm:"not null;default:0"`
+	ValidHours     int       `gorm:"not null"`
+	ExpiresAt      time.Time `gorm:"index;not null"`
+	LastTriggered  time.Time `gorm:"index;not null"`
+	FirstCreated   time.Time `gorm:"not null"`
+	UpdatedAt      time.Time `gorm:"not null"`
+	TriggerCount   int       `gorm:"not null;default:0"`
+}
+
+func (legacyDynamicThresholdEntity) TableName() string { return "dynamic_thresholds" }
+
+// createLegacyDynamicThresholdTable builds the pre-migration dynamic_thresholds
+// table via GORM AutoMigrate, matching how production created it.
+func createLegacyDynamicThresholdTable(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	require.NoError(t, db.AutoMigrate(&legacyDynamicThresholdEntity{}))
+}
+
+// insertLegacyRow inserts one per-model dynamic threshold row into the legacy table.
+func insertLegacyRow(t *testing.T, db *gorm.DB, species, model string, level, highConf, triggerCount int, expiresAt time.Time) {
+	t.Helper()
+	now := time.Now()
+	require.NoError(t, db.Create(&legacyDynamicThresholdEntity{
+		SpeciesName:    species,
+		ModelName:      model,
+		ScientificName: "Sci " + species,
+		Level:          level,
+		CurrentValue:   0.5,
+		BaseThreshold:  0.5,
+		HighConfCount:  highConf,
+		ValidHours:     24,
+		ExpiresAt:      expiresAt,
+		LastTriggered:  now,
+		FirstCreated:   now,
+		UpdatedAt:      now,
+		TriggerCount:   triggerCount,
+	}).Error)
+}
+
+func TestMigrateDynamicThresholdsToPerSpecies_Consolidates(t *testing.T) {
+	t.Parallel()
+	db := openSQLiteTestDB(t)
+	createLegacyDynamicThresholdTable(t, db)
+
+	base := time.Now()
+	// Three per-model rows for one species with differing levels/expiries/counters.
+	// The highest counters (9/7) live on a NON-winning (level-1) row and the latest
+	// expiry on another non-winner, so the assertions below fail unless the max-merge
+	// actually runs across the whole group rather than just copying the winner's fields.
+	insertLegacyRow(t, db, "pajulintu", "BirdNET_V2.4", 1, 9, 7, base.Add(1*time.Hour))
+	insertLegacyRow(t, db, "pajulintu", "BirdNET_V3.0", 3, 5, 5, base.Add(2*time.Hour))
+	insertLegacyRow(t, db, "pajulintu", "Perch_V2", 1, 1, 1, base.Add(3*time.Hour))
+	// A species with a single row is left as-is.
+	insertLegacyRow(t, db, "tikli", "BirdNET_V2.4", 2, 4, 4, base.Add(1*time.Hour))
+
+	require.NoError(t, migrateDynamicThresholdsToPerSpecies(db, GetLogger()))
+
+	// AutoMigrate to the new schema must now succeed (no duplicates, creates the
+	// single-column unique index).
+	require.NoError(t, db.AutoMigrate(&DynamicThreshold{}))
+
+	// One row per species.
+	var all []DynamicThreshold
+	require.NoError(t, db.Order("species_name ASC").Find(&all).Error)
+	require.Len(t, all, 2, "should consolidate to one row per species")
+
+	bySpecies := map[string]DynamicThreshold{}
+	for _, r := range all {
+		bySpecies[r.SpeciesName] = r
+	}
+
+	// Winner is the highest-level row (level 3), but counters merge via max across the
+	// whole group (9/7 from the level-1 row, not the winner's 5/5) and expiry is the
+	// latest (+3h from a third row), proving the merge is independent of winner selection.
+	paju := bySpecies["pajulintu"]
+	assert.Equal(t, 3, paju.Level, "highest level wins")
+	assert.Equal(t, 9, paju.HighConfCount, "high-conf count merged via max from a non-winning row")
+	assert.Equal(t, 7, paju.TriggerCount, "trigger count merged via max from a non-winning row")
+	assert.WithinDuration(t, base.Add(3*time.Hour), paju.ExpiresAt, time.Second, "latest expiry wins")
+
+	assert.Equal(t, 2, bySpecies["tikli"].Level, "single-row species is preserved")
+
+	// The model_name column and composite index are gone; the new unique index exists.
+	assert.False(t, db.Migrator().HasColumn(&DynamicThreshold{}, "model_name"),
+		"model_name column should be dropped")
+	indexes := sqliteIndexNames(t, db, "dynamic_thresholds")
+	assert.NotContains(t, indexes, "idx_dt_species_model", "composite index should be dropped")
+	assert.Contains(t, indexes, "idx_dynamic_thresholds_species_name", "new unique index should exist")
+
+	// The unique index enforces one row per species: re-inserting updates, not duplicates.
+	require.NoError(t, db.Exec(`INSERT INTO dynamic_thresholds
+		(species_name, scientific_name, level, current_value, base_threshold, high_conf_count,
+		 valid_hours, expires_at, last_triggered, first_created, updated_at, trigger_count)
+		VALUES ('newbird','Sci new',1,0.5,0.5,1,24,?,?,?,?,1)`,
+		base, base, base, base).Error)
+	require.Error(t, db.Exec(`INSERT INTO dynamic_thresholds
+		(species_name, scientific_name, level, current_value, base_threshold, high_conf_count,
+		 valid_hours, expires_at, last_triggered, first_created, updated_at, trigger_count)
+		VALUES ('newbird','Sci new',2,0.4,0.5,2,24,?,?,?,?,2)`,
+		base, base, base, base).Error, "duplicate species insert must violate the unique index")
+}
+
+func TestMigrateDynamicThresholdsToPerSpecies_Idempotent(t *testing.T) {
+	t.Parallel()
+	db := openSQLiteTestDB(t)
+	createLegacyDynamicThresholdTable(t, db)
+
+	base := time.Now()
+	insertLegacyRow(t, db, "pajulintu", "BirdNET_V2.4", 1, 2, 2, base.Add(1*time.Hour))
+	insertLegacyRow(t, db, "pajulintu", "Perch_V2", 2, 3, 3, base.Add(2*time.Hour))
+
+	require.NoError(t, migrateDynamicThresholdsToPerSpecies(db, GetLogger()))
+	require.NoError(t, db.AutoMigrate(&DynamicThreshold{}))
+
+	var afterFirst int64
+	require.NoError(t, db.Model(&DynamicThreshold{}).Count(&afterFirst).Error)
+	assert.Equal(t, int64(1), afterFirst)
+
+	// A second run is a no-op (model_name column already gone).
+	require.NoError(t, migrateDynamicThresholdsToPerSpecies(db, GetLogger()))
+
+	var afterSecond int64
+	require.NoError(t, db.Model(&DynamicThreshold{}).Count(&afterSecond).Error)
+	assert.Equal(t, afterFirst, afterSecond, "second migration run must be a no-op")
+}
+
+func TestMigrateDynamicThresholdsToPerSpecies_FreshInstall(t *testing.T) {
+	t.Parallel()
+	db := openSQLiteTestDB(t)
+
+	// No dynamic_thresholds table exists yet: migration is a no-op, not an error.
+	require.NoError(t, migrateDynamicThresholdsToPerSpecies(db, GetLogger()))
+
+	// A fresh AutoMigrate then creates the per-species schema cleanly.
+	require.NoError(t, db.AutoMigrate(&DynamicThreshold{}))
+	assert.False(t, db.Migrator().HasColumn(&DynamicThreshold{}, "model_name"))
+}

--- a/internal/datastore/dynamic_threshold_test.go
+++ b/internal/datastore/dynamic_threshold_test.go
@@ -126,7 +126,7 @@ func TestGetDynamicThreshold(t *testing.T) {
 		require.NoError(t, err)
 
 		// Retrieve it
-		retrieved, err := ds.GetDynamicThreshold("cardinal", "")
+		retrieved, err := ds.GetDynamicThreshold("cardinal")
 
 		require.NoError(t, err)
 		require.NotNil(t, retrieved)
@@ -139,7 +139,7 @@ func TestGetDynamicThreshold(t *testing.T) {
 	t.Run("GetNonExistentThreshold", func(t *testing.T) {
 		ds := setupDynamicThresholdTestDB(t)
 
-		threshold, err := ds.GetDynamicThreshold("nonexistent", "")
+		threshold, err := ds.GetDynamicThreshold("nonexistent")
 
 		require.Error(t, err)
 		assert.Nil(t, threshold)
@@ -150,7 +150,7 @@ func TestGetDynamicThreshold(t *testing.T) {
 	t.Run("RejectEmptySpeciesName", func(t *testing.T) {
 		ds := setupDynamicThresholdTestDB(t)
 
-		threshold, err := ds.GetDynamicThreshold("", "")
+		threshold, err := ds.GetDynamicThreshold("")
 
 		require.Error(t, err)
 		assert.Nil(t, threshold)
@@ -247,7 +247,7 @@ func TestDeleteDynamicThreshold(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify deletion
-		retrieved, err := ds.GetDynamicThreshold("sparrow", "")
+		retrieved, err := ds.GetDynamicThreshold("sparrow")
 		require.Error(t, err)
 		assert.Nil(t, retrieved)
 	})
@@ -382,7 +382,7 @@ func TestUpdateDynamicThresholdExpiry(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify update
-		retrieved, err := ds.GetDynamicThreshold("chickadee", "")
+		retrieved, err := ds.GetDynamicThreshold("chickadee")
 		require.NoError(t, err)
 		assert.True(t, retrieved.ExpiresAt.After(originalExpiry))
 		assert.WithinDuration(t, newExpiry, retrieved.ExpiresAt, time.Second)
@@ -488,7 +488,7 @@ func TestBatchSaveDynamicThresholds(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify update
-		retrieved, err := ds.GetDynamicThreshold("robin", "")
+		retrieved, err := ds.GetDynamicThreshold("robin")
 		require.NoError(t, err)
 		assert.Equal(t, 2, retrieved.Level)
 		assert.InDelta(t, 0.8, retrieved.CurrentValue, 0.001)

--- a/internal/datastore/index_reconcile_test.go
+++ b/internal/datastore/index_reconcile_test.go
@@ -57,17 +57,61 @@ func sqliteIndexNames(t *testing.T, db *gorm.DB, table string) []string {
 	return names
 }
 
-// TestReconcileLegacyUniqueIndexes_SQLite_DropsStaleSpeciesName verifies the
-// reconciler drops a pre-multi-model UNIQUE(species_name) index on
-// dynamic_thresholds (the exact legacy shape behind the SQLite
-// UNIQUE-constraint insert failures).
-func TestReconcileLegacyUniqueIndexes_SQLite_DropsStaleSpeciesName(t *testing.T) {
+// TestReconcileLegacyUniqueIndexes_SQLite_DropsStalePrecursor verifies the
+// reconciler drops a pre-composite single-column unique index when an entity
+// declares a composite unique index (such as NotificationHistory on
+// scientific_name + notification_type).
+func TestReconcileLegacyUniqueIndexes_SQLite_DropsStalePrecursor(t *testing.T) {
 	t.Parallel()
 
 	db := openSQLiteTestDB(t)
 
-	// Seed the legacy-shaped table: DynamicThreshold columns + a stale single-column
-	// unique index on species_name (no composite idx_dt_species_model yet).
+	// Seed the legacy-shaped table: NotificationHistory columns + a stale single-column
+	// unique index on scientific_name (no composite idx_notification_history_species_type yet).
+	require.NoError(t, db.Exec(`
+		CREATE TABLE notification_histories (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			scientific_name TEXT NOT NULL,
+			notification_type TEXT NOT NULL DEFAULT 'new_species',
+			last_sent DATETIME NOT NULL,
+			expires_at DATETIME NOT NULL,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL
+		)
+	`).Error)
+	require.NoError(t, db.Exec(`CREATE UNIQUE INDEX idx_nh_species_legacy ON notification_histories(scientific_name)`).Error)
+
+	// Run the reconciler against the current NotificationHistory entity definition.
+	require.NoError(t, reconcileLegacyUniqueIndexes(db, "sqlite", "", []any{&NotificationHistory{}}))
+
+	// Stale single-column unique index must be gone.
+	indexes := sqliteIndexNames(t, db, "notification_histories")
+	assert.NotContains(t, indexes, "idx_nh_species_legacy",
+		"reconciler should have dropped legacy single-column precursor index")
+}
+
+// TestReconcileLegacyUniqueIndexes_SQLite_PreservesDeclared verifies the
+// reconciler leaves the declared unique index alone.
+func TestReconcileLegacyUniqueIndexes_SQLite_PreservesDeclared(t *testing.T) {
+	t.Parallel()
+
+	db := openSQLiteTestDB(t)
+	require.NoError(t, db.AutoMigrate(&DynamicThreshold{}))
+
+	require.NoError(t, reconcileLegacyUniqueIndexes(db, "sqlite", "", []any{&DynamicThreshold{}}))
+
+	indexes := sqliteIndexNames(t, db, "dynamic_thresholds")
+	assert.Contains(t, indexes, "idx_dynamic_thresholds_species_name",
+		"declared unique index must survive reconciliation")
+}
+
+// TestReconcileLegacyUniqueIndexes_SQLite_PreservesCompositeSuperset verifies the
+// reconciler leaves a live composite idx_dt_species_model alone since it is an
+// undeclared superset of the declared single-column species_name index.
+func TestReconcileLegacyUniqueIndexes_SQLite_PreservesCompositeSuperset(t *testing.T) {
+	t.Parallel()
+
+	db := openSQLiteTestDB(t)
 	require.NoError(t, db.Exec(`
 		CREATE TABLE dynamic_thresholds (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -86,48 +130,13 @@ func TestReconcileLegacyUniqueIndexes_SQLite_DropsStaleSpeciesName(t *testing.T)
 			trigger_count INTEGER NOT NULL DEFAULT 0
 		)
 	`).Error)
-	require.NoError(t, db.Exec(`CREATE UNIQUE INDEX idx_dt_species_legacy ON dynamic_thresholds(species_name)`).Error)
-
-	// Run the reconciler against the current DynamicThreshold entity definition.
-	require.NoError(t, reconcileLegacyUniqueIndexes(db, "sqlite", "", []any{&DynamicThreshold{}}))
-
-	// Stale single-column unique index must be gone.
-	indexes := sqliteIndexNames(t, db, "dynamic_thresholds")
-	assert.NotContains(t, indexes, "idx_dt_species_legacy",
-		"reconciler should have dropped legacy UNIQUE(species_name) index")
-}
-
-// TestReconcileLegacyUniqueIndexes_SQLite_PreservesComposite verifies the
-// reconciler leaves the declared composite idx_dt_species_model alone.
-func TestReconcileLegacyUniqueIndexes_SQLite_PreservesComposite(t *testing.T) {
-	t.Parallel()
-
-	db := openSQLiteTestDB(t)
-	require.NoError(t, db.AutoMigrate(&DynamicThreshold{}))
+	require.NoError(t, db.Exec(`CREATE UNIQUE INDEX idx_dt_species_model ON dynamic_thresholds(species_name, model_name)`).Error)
 
 	require.NoError(t, reconcileLegacyUniqueIndexes(db, "sqlite", "", []any{&DynamicThreshold{}}))
 
 	indexes := sqliteIndexNames(t, db, "dynamic_thresholds")
 	assert.Contains(t, indexes, "idx_dt_species_model",
-		"declared composite unique index must survive reconciliation")
-}
-
-// TestReconcileLegacyUniqueIndexes_SQLite_DropsStaleModelName covers the
-// alternative legacy shape where the stale unique index was on model_name
-// alone (paranoia: the MySQL 1062 error displays 'BirdNET' as the duplicate
-// value, hinting this layout is possible in the wild).
-func TestReconcileLegacyUniqueIndexes_SQLite_DropsStaleModelName(t *testing.T) {
-	t.Parallel()
-
-	db := openSQLiteTestDB(t)
-	require.NoError(t, db.AutoMigrate(&DynamicThreshold{}))
-	require.NoError(t, db.Exec(`CREATE UNIQUE INDEX idx_dt_model_legacy ON dynamic_thresholds(model_name)`).Error)
-
-	require.NoError(t, reconcileLegacyUniqueIndexes(db, "sqlite", "", []any{&DynamicThreshold{}}))
-
-	indexes := sqliteIndexNames(t, db, "dynamic_thresholds")
-	assert.NotContains(t, indexes, "idx_dt_model_legacy")
-	assert.Contains(t, indexes, "idx_dt_species_model")
+		"composite unique index must be left alone as undeclared superset")
 }
 
 // TestReconcileLegacyUniqueIndexes_SQLite_FreshInstall verifies the
@@ -195,7 +204,7 @@ func TestReconcileLegacyUniqueIndexes_SQLite_IgnoresAutoIndex(t *testing.T) {
 
 // TestReconcileLegacyUniqueIndexes_SQLite_PreservesSuperset verifies the
 // reconciler does NOT drop a stricter admin-added unique index whose
-// column set is a superset of a declared composite. Preserving such
+// column set is a superset of a declared unique index. Preserving such
 // constraints is required so the reconciler cannot relax uniqueness rules
 // the operator explicitly imposed.
 func TestReconcileLegacyUniqueIndexes_SQLite_PreservesSuperset(t *testing.T) {
@@ -204,10 +213,10 @@ func TestReconcileLegacyUniqueIndexes_SQLite_PreservesSuperset(t *testing.T) {
 	db := openSQLiteTestDB(t)
 	require.NoError(t, db.AutoMigrate(&DynamicThreshold{}))
 	// Simulated admin-added stricter constraint: composite over declared
-	// (species_name, model_name) plus an extra column.
+	// species_name plus an extra column (scientific_name).
 	require.NoError(t, db.Exec(`
 		CREATE UNIQUE INDEX idx_dt_admin_superset
-		ON dynamic_thresholds(species_name, model_name, scientific_name)
+		ON dynamic_thresholds(species_name, scientific_name)
 	`).Error)
 
 	require.NoError(t, reconcileLegacyUniqueIndexes(db, "sqlite", "", []any{&DynamicThreshold{}}))
@@ -215,8 +224,8 @@ func TestReconcileLegacyUniqueIndexes_SQLite_PreservesSuperset(t *testing.T) {
 	indexes := sqliteIndexNames(t, db, "dynamic_thresholds")
 	assert.Contains(t, indexes, "idx_dt_admin_superset",
 		"superset unique index must be preserved (not a legacy precursor)")
-	assert.Contains(t, indexes, "idx_dt_species_model",
-		"declared composite must still be present")
+	assert.Contains(t, indexes, "idx_dynamic_thresholds_species_name",
+		"declared unique index must still be present")
 }
 
 // TestReconcileLegacyUniqueIndexes_SQLite_PreservesUnrelated verifies the

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -247,7 +247,7 @@ type Interface interface {
 	SearchDetections(filters *SearchFilters) ([]DetectionRecord, int, error)
 	// Dynamic Threshold methods
 	SaveDynamicThreshold(threshold *DynamicThreshold) error
-	GetDynamicThreshold(speciesName, modelName string) (*DynamicThreshold, error)
+	GetDynamicThreshold(speciesName string) (*DynamicThreshold, error)
 	GetAllDynamicThresholds(limit ...int) ([]DynamicThreshold, error) // Optional limit parameter
 	DeleteDynamicThreshold(speciesName string) error
 	DeleteExpiredDynamicThresholds(before time.Time) (int64, error) // Returns count deleted

--- a/internal/datastore/manage.go
+++ b/internal/datastore/manage.go
@@ -328,6 +328,14 @@ func performAutoMigration(db *gorm.DB, debug bool, dbType, dbName string) error 
 			logger.Error(err))
 	}
 
+	// Consolidate per-model dynamic thresholds to per-species before AutoMigrate
+	// creates the new unique(species_name) index, so it finds no duplicates. Runs
+	// after the reconciler (which leaves the composite index alone, being a superset
+	// of the new declared index) and is a no-op on fresh or already-migrated DBs.
+	if err := migrateDynamicThresholdsToPerSpecies(db, migrationLogger); err != nil {
+		return err
+	}
+
 	// Validate and fix schema if needed
 	if err := validateAndFixSchema(db, dbType, dbName, debug, migrationLogger); err != nil {
 		return err

--- a/internal/datastore/mocks/mock_Interface.go
+++ b/internal/datastore/mocks/mock_Interface.go
@@ -2328,9 +2328,9 @@ func (_c *MockInterface_GetDetectionTrends_Call) RunAndReturn(run func(context.C
 	return _c
 }
 
-// GetDynamicThreshold provides a mock function with given fields: speciesName, modelName
-func (_m *MockInterface) GetDynamicThreshold(speciesName string, modelName string) (*datastore.DynamicThreshold, error) {
-	ret := _m.Called(speciesName, modelName)
+// GetDynamicThreshold provides a mock function with given fields: speciesName
+func (_m *MockInterface) GetDynamicThreshold(speciesName string) (*datastore.DynamicThreshold, error) {
+	ret := _m.Called(speciesName)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetDynamicThreshold")
@@ -2338,19 +2338,19 @@ func (_m *MockInterface) GetDynamicThreshold(speciesName string, modelName strin
 
 	var r0 *datastore.DynamicThreshold
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string, string) (*datastore.DynamicThreshold, error)); ok {
-		return rf(speciesName, modelName)
+	if rf, ok := ret.Get(0).(func(string) (*datastore.DynamicThreshold, error)); ok {
+		return rf(speciesName)
 	}
-	if rf, ok := ret.Get(0).(func(string, string) *datastore.DynamicThreshold); ok {
-		r0 = rf(speciesName, modelName)
+	if rf, ok := ret.Get(0).(func(string) *datastore.DynamicThreshold); ok {
+		r0 = rf(speciesName)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*datastore.DynamicThreshold)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = rf(speciesName, modelName)
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(speciesName)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2365,14 +2365,13 @@ type MockInterface_GetDynamicThreshold_Call struct {
 
 // GetDynamicThreshold is a helper method to define mock.On call
 //   - speciesName string
-//   - modelName string
-func (_e *MockInterface_Expecter) GetDynamicThreshold(speciesName interface{}, modelName interface{}) *MockInterface_GetDynamicThreshold_Call {
-	return &MockInterface_GetDynamicThreshold_Call{Call: _e.mock.On("GetDynamicThreshold", speciesName, modelName)}
+func (_e *MockInterface_Expecter) GetDynamicThreshold(speciesName interface{}) *MockInterface_GetDynamicThreshold_Call {
+	return &MockInterface_GetDynamicThreshold_Call{Call: _e.mock.On("GetDynamicThreshold", speciesName)}
 }
 
-func (_c *MockInterface_GetDynamicThreshold_Call) Run(run func(speciesName string, modelName string)) *MockInterface_GetDynamicThreshold_Call {
+func (_c *MockInterface_GetDynamicThreshold_Call) Run(run func(speciesName string)) *MockInterface_GetDynamicThreshold_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string))
+		run(args[0].(string))
 	})
 	return _c
 }
@@ -2382,7 +2381,7 @@ func (_c *MockInterface_GetDynamicThreshold_Call) Return(_a0 *datastore.DynamicT
 	return _c
 }
 
-func (_c *MockInterface_GetDynamicThreshold_Call) RunAndReturn(run func(string, string) (*datastore.DynamicThreshold, error)) *MockInterface_GetDynamicThreshold_Call {
+func (_c *MockInterface_GetDynamicThreshold_Call) RunAndReturn(run func(string) (*datastore.DynamicThreshold, error)) *MockInterface_GetDynamicThreshold_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/datastore/model.go
+++ b/internal/datastore/model.go
@@ -205,34 +205,32 @@ type DetectionRecord struct {
 // users experience a sudden drop in detections after restart when learned thresholds are lost.
 type DynamicThreshold struct {
 	ID             uint      `gorm:"primaryKey"`
-	SpeciesName    string    `gorm:"uniqueIndex:idx_dt_species_model;not null;size:200"`                   // Common name (lowercase)
-	ModelName      string    `gorm:"uniqueIndex:idx_dt_species_model;not null;size:100;default:'BirdNET'"` // Model that produced this threshold
-	ScientificName string    `gorm:"size:200"`                                                             // Scientific name for thumbnails
-	Level          int       `gorm:"not null;default:0"`                                                   // Adjustment level (0-3)
-	CurrentValue   float64   `gorm:"not null"`                                                             // Current threshold value
-	BaseThreshold  float64   `gorm:"not null"`                                                             // Original base threshold for reference
-	HighConfCount  int       `gorm:"not null;default:0"`                                                   // Count of high-confidence detections
-	ValidHours     int       `gorm:"not null"`                                                             // Hours until expiry
-	ExpiresAt      time.Time `gorm:"index;not null"`                                                       // When this threshold expires
-	LastTriggered  time.Time `gorm:"index;not null"`                                                       // Last time threshold was triggered
-	FirstCreated   time.Time `gorm:"not null"`                                                             // When first created
-	UpdatedAt      time.Time `gorm:"not null"`                                                             // Last update time
-	TriggerCount   int       `gorm:"not null;default:0"`                                                   // Total number of times triggered (for statistics)
+	SpeciesName    string    `gorm:"uniqueIndex;not null;size:200"` // Common name (lowercase); tracking is per species, not per model
+	ScientificName string    `gorm:"size:200"`                      // Scientific name for thumbnails
+	Level          int       `gorm:"not null;default:0"`            // Adjustment level (0-3)
+	CurrentValue   float64   `gorm:"not null"`                      // Current threshold value
+	BaseThreshold  float64   `gorm:"not null"`                      // model-global base of the model that last learned (display only)
+	HighConfCount  int       `gorm:"not null;default:0"`            // Count of high-confidence detections
+	ValidHours     int       `gorm:"not null"`                      // Hours until expiry
+	ExpiresAt      time.Time `gorm:"index;not null"`                // When this threshold expires
+	LastTriggered  time.Time `gorm:"index;not null"`                // Last time threshold was triggered
+	FirstCreated   time.Time `gorm:"not null"`                      // When first created
+	UpdatedAt      time.Time `gorm:"not null"`                      // Last update time
+	TriggerCount   int       `gorm:"not null;default:0"`            // Total number of times triggered (for statistics)
 }
 
 // ThresholdEvent records each change to a dynamic threshold for audit/history purposes.
 // This enables the frontend to display a timeline of threshold adjustments per species.
 type ThresholdEvent struct {
 	ID            uint      `gorm:"primaryKey"`
-	SpeciesName   string    `gorm:"index;not null;size:200"`             // Common name (lowercase)
-	ModelName     string    `gorm:"not null;size:100;default:'BirdNET'"` // Model that produced this event
-	PreviousLevel int       `gorm:"not null"`                            // Level before change
-	NewLevel      int       `gorm:"not null"`                            // Level after change
-	PreviousValue float64   `gorm:"not null"`                            // Threshold value before change
-	NewValue      float64   `gorm:"not null"`                            // Threshold value after change
-	ChangeReason  string    `gorm:"not null;size:50"`                    // "high_confidence", "expiry", "manual_reset"
-	Confidence    float64   `gorm:"default:0"`                           // Detection confidence that triggered change (if applicable)
-	CreatedAt     time.Time `gorm:"index;not null"`                      // When the event occurred
+	SpeciesName   string    `gorm:"index;not null;size:200"` // Common name (lowercase); events are per species, not per model
+	PreviousLevel int       `gorm:"not null"`                // Level before change
+	NewLevel      int       `gorm:"not null"`                // Level after change
+	PreviousValue float64   `gorm:"not null"`                // Threshold value before change
+	NewValue      float64   `gorm:"not null"`                // Threshold value after change
+	ChangeReason  string    `gorm:"not null;size:50"`        // "high_confidence", "expiry", "manual_reset"
+	Confidence    float64   `gorm:"default:0"`               // Detection confidence that triggered change (if applicable)
+	CreatedAt     time.Time `gorm:"index;not null"`          // When the event occurred
 
 	// ScientificName is a virtual field (not persisted in legacy DB) used by v2only
 	// datastore to correctly resolve the Label foreign key. The processor populates

--- a/internal/datastore/v2/migration/testutil/setup.go
+++ b/internal/datastore/v2/migration/testutil/setup.go
@@ -793,7 +793,7 @@ func (s *testLegacyInterface) SearchDetections(_ *datastore.SearchFilters) ([]da
 	return nil, 0, nil
 }
 func (s *testLegacyInterface) SaveDynamicThreshold(_ *datastore.DynamicThreshold) error { return nil }
-func (s *testLegacyInterface) GetDynamicThreshold(_, _ string) (*datastore.DynamicThreshold, error) {
+func (s *testLegacyInterface) GetDynamicThreshold(_ string) (*datastore.DynamicThreshold, error) {
 	return nil, nil //nolint:nilnil // stub
 }
 func (s *testLegacyInterface) DeleteDynamicThreshold(_ string) error { return nil }

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -3547,17 +3547,6 @@ func thresholdScientificName(t *entities.DynamicThreshold) string {
 	return ""
 }
 
-// labelModelName constructs the classifier-style model ID ("Name_VVersion") from a
-// label's associated AIModel, used for both threshold records and threshold events.
-// Requires the caller's query to preload Label.Model; falls back to the default
-// BirdNET model identifier when the label or model is absent.
-func labelModelName(l *entities.Label) string {
-	if l != nil && l.Model != nil && l.Model.Name != "" {
-		return l.Model.Name + "_V" + l.Model.Version
-	}
-	return detection.DefaultModelName + "_V" + detection.DefaultModelVersion
-}
-
 // resolveCommonName maps a scientific name to its common name using the
 // pre-built name maps. Falls back to the scientific name if no mapping exists.
 // Handles legacy concatenated "ScientificName_CommonName" format by extracting
@@ -3644,10 +3633,9 @@ func (ds *Datastore) SaveDynamicThreshold(threshold *datastore.DynamicThreshold)
 	return ds.threshold.SaveDynamicThreshold(ctx, v2Threshold)
 }
 
-// GetDynamicThreshold retrieves a dynamic threshold by scientific name and model.
-// Note: modelName is accepted for interface compatibility but not used in the v2 schema
-// because v2 thresholds are scoped through LabelID (which is already per-model).
-func (ds *Datastore) GetDynamicThreshold(speciesName, _ string) (*datastore.DynamicThreshold, error) {
+// GetDynamicThreshold retrieves a dynamic threshold by species name.
+// Thresholds are tracked per species; the v2 schema scopes them through LabelID.
+func (ds *Datastore) GetDynamicThreshold(speciesName string) (*datastore.DynamicThreshold, error) {
 	if ds.threshold == nil {
 		return nil, fmt.Errorf("threshold repository not configured")
 	}
@@ -3681,7 +3669,6 @@ func (ds *Datastore) GetDynamicThreshold(speciesName, _ string) (*datastore.Dyna
 		ID:             t.ID,
 		SpeciesName:    strings.ToLower(ds.resolveCommonName(scientificName)),
 		ScientificName: scientificName,
-		ModelName:      labelModelName(t.Label),
 		Level:          t.Level,
 		CurrentValue:   t.CurrentValue,
 		BaseThreshold:  t.BaseThreshold,
@@ -3717,7 +3704,6 @@ func (ds *Datastore) GetAllDynamicThresholds(limit ...int) ([]datastore.DynamicT
 			ID:             t.ID,
 			SpeciesName:    strings.ToLower(ds.resolveCommonName(scientificName)),
 			ScientificName: scientificName,
-			ModelName:      labelModelName(t.Label),
 			Level:          t.Level,
 			CurrentValue:   t.CurrentValue,
 			BaseThreshold:  t.BaseThreshold,
@@ -3952,7 +3938,6 @@ func (ds *Datastore) GetThresholdEvents(speciesName string, limit int) ([]datast
 		result = append(result, datastore.ThresholdEvent{
 			ID:            e.ID,
 			SpeciesName:   eventSpeciesName(e),
-			ModelName:     labelModelName(e.Label),
 			PreviousLevel: e.PreviousLevel,
 			NewLevel:      e.NewLevel,
 			PreviousValue: e.PreviousValue,
@@ -3985,7 +3970,6 @@ func (ds *Datastore) GetRecentThresholdEvents(limit int) ([]datastore.ThresholdE
 		result = append(result, datastore.ThresholdEvent{
 			ID:            e.ID,
 			SpeciesName:   eventSpeciesName(e),
-			ModelName:     labelModelName(e.Label),
 			PreviousLevel: e.PreviousLevel,
 			NewLevel:      e.NewLevel,
 			PreviousValue: e.PreviousValue,

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -422,7 +422,7 @@ func TestV2OnlyDatastore_DynamicThreshold(t *testing.T) {
 	require.NoError(t, err)
 
 	// Get threshold by scientific name
-	retrieved, err := ds.GetDynamicThreshold("Passer domesticus", "")
+	retrieved, err := ds.GetDynamicThreshold("Passer domesticus")
 	require.NoError(t, err)
 	assert.Equal(t, "passer domesticus", retrieved.SpeciesName)
 	assert.Equal(t, "Passer domesticus", retrieved.ScientificName)
@@ -474,7 +474,7 @@ func TestV2OnlyDatastore_DynamicThreshold_CommonNameDisplay(t *testing.T) {
 	require.NoError(t, err)
 
 	// GetDynamicThreshold should return common name in SpeciesName
-	retrieved, err := ds.GetDynamicThreshold("Parus major", "")
+	retrieved, err := ds.GetDynamicThreshold("Parus major")
 	require.NoError(t, err)
 	assert.Equal(t, "great tit", retrieved.SpeciesName, "SpeciesName should be common name")
 	assert.Equal(t, "Parus major", retrieved.ScientificName, "ScientificName should stay scientific")
@@ -487,11 +487,9 @@ func TestV2OnlyDatastore_DynamicThreshold_CommonNameDisplay(t *testing.T) {
 	assert.Equal(t, "Parus major", all[0].ScientificName, "ScientificName should stay scientific in list")
 }
 
-// TestV2OnlyDatastore_DynamicThreshold_ModelName verifies that
-// GetAllDynamicThresholds and GetDynamicThreshold return ModelName
-// constructed from the Label's AIModel (e.g., "BirdNET_V2.4").
-// Regression test for GitHub issue #2902.
-func TestV2OnlyDatastore_DynamicThreshold_ModelName(t *testing.T) {
+// TestV2OnlyDatastore_DynamicThreshold_SpeciesNameRetrieval verifies that
+// GetAllDynamicThresholds and GetDynamicThreshold return common names.
+func TestV2OnlyDatastore_DynamicThreshold_SpeciesNameRetrieval(t *testing.T) {
 	labels := []string{
 		"Parus major_Great Tit",
 	}
@@ -501,7 +499,6 @@ func TestV2OnlyDatastore_DynamicThreshold_ModelName(t *testing.T) {
 	threshold := &datastore.DynamicThreshold{
 		SpeciesName:    "Parus major",
 		ScientificName: "Parus major",
-		ModelName:      "BirdNET_V2.4",
 		Level:          2,
 		CurrentValue:   0.5,
 		BaseThreshold:  0.8,
@@ -516,20 +513,16 @@ func TestV2OnlyDatastore_DynamicThreshold_ModelName(t *testing.T) {
 	err := ds.SaveDynamicThreshold(threshold)
 	require.NoError(t, err)
 
-	// GetAllDynamicThresholds must return non-empty ModelName
+	// GetAllDynamicThresholds must return lowercase common name
 	all, err := ds.GetAllDynamicThresholds()
 	require.NoError(t, err)
 	require.Len(t, all, 1)
-	assert.Equal(t, "BirdNET_V2.4", all[0].ModelName,
-		"ModelName must be constructed from Label's Model (Name_VVersion)")
 	assert.Equal(t, "great tit", all[0].SpeciesName,
 		"SpeciesName must be lowercase to match processor convention")
 
-	// GetDynamicThreshold (single lookup) must also return ModelName
-	single, err := ds.GetDynamicThreshold("Parus major", "")
+	// GetDynamicThreshold (single lookup) must also return lowercase common name
+	single, err := ds.GetDynamicThreshold("Parus major")
 	require.NoError(t, err)
-	assert.Equal(t, "BirdNET_V2.4", single.ModelName,
-		"Single lookup must also return ModelName")
 	assert.Equal(t, "great tit", single.SpeciesName,
 		"Single lookup SpeciesName must be lowercase")
 }
@@ -602,7 +595,7 @@ func TestV2OnlyDatastore_DynamicThreshold_GetByCommonName(t *testing.T) {
 	require.NoError(t, err)
 
 	// Retrieve using lowercase common name
-	retrieved, err := ds.GetDynamicThreshold("great tit", "")
+	retrieved, err := ds.GetDynamicThreshold("great tit")
 	require.NoError(t, err)
 	assert.Equal(t, "great tit", retrieved.SpeciesName)
 	assert.Equal(t, "Parus major", retrieved.ScientificName)
@@ -632,7 +625,7 @@ func TestV2OnlyDatastore_DynamicThreshold_FallbackWithoutMapping(t *testing.T) {
 	require.NoError(t, err)
 
 	// Without label mapping, should fall back to scientific name
-	retrieved, err := ds.GetDynamicThreshold("Passer domesticus", "")
+	retrieved, err := ds.GetDynamicThreshold("Passer domesticus")
 	require.NoError(t, err)
 	assert.Equal(t, "passer domesticus", retrieved.SpeciesName, "should fallback to scientific name")
 	assert.Equal(t, "Passer domesticus", retrieved.ScientificName)
@@ -666,7 +659,7 @@ func TestV2OnlyDatastore_DynamicThreshold_UpdateExpiryByCommonName(t *testing.T)
 	require.NoError(t, err, "UpdateDynamicThresholdExpiry should work with common name")
 
 	// Verify the expiry was updated
-	retrieved, err := ds.GetDynamicThreshold("Parus major", "")
+	retrieved, err := ds.GetDynamicThreshold("Parus major")
 	require.NoError(t, err)
 	assert.WithinDuration(t, newExpiry, retrieved.ExpiresAt, time.Second, "expiry should be updated")
 }
@@ -912,7 +905,7 @@ func TestV2OnlyDatastore_ThresholdReads_ErrorTelemetry(t *testing.T) {
 		// reachable via errors.Is (EnhancedError.Unwrap) and the CategoryNotFound
 		// "dynamic threshold not found" message is suppressed from Sentry, so it is never
 		// surfaced as a database error (#1019).
-		_, err := ds.GetDynamicThreshold("Parus major", "")
+		_, err := ds.GetDynamicThreshold("Parus major")
 		require.Error(t, err)
 		require.ErrorIs(t, err, repository.ErrDynamicThresholdNotFound,
 			"not-found sentinel must propagate so callers can distinguish a benign miss from a genuine DB fault")
@@ -939,7 +932,7 @@ func TestV2OnlyDatastore_ThresholdReads_ErrorTelemetry(t *testing.T) {
 			assert.Equal(t, string(errors.CategoryDatabase), ee.GetCategory(), "%s must tag database category", op)
 		}
 
-		_, errGet := ds.GetDynamicThreshold("Parus major", "")
+		_, errGet := ds.GetDynamicThreshold("Parus major")
 		assertDatastoreWrapped(t, errGet, "GetDynamicThreshold")
 
 		_, errAll := ds.GetAllDynamicThresholds()
@@ -953,12 +946,9 @@ func TestV2OnlyDatastore_ThresholdReads_ErrorTelemetry(t *testing.T) {
 	})
 }
 
-// TestV2OnlyDatastore_ThresholdEvent_ModelName verifies that GetThresholdEvents and
-// GetRecentThresholdEvents return ModelName constructed from the event Label's AIModel
-// (e.g., "BirdNET_V2.4"), the event-side parallel of the GitHub #2902 record fix.
-// Regression test for #1025: events previously returned an empty ModelName because the
-// repository only preloaded Label (not Label.Model) and the converter never set it.
-func TestV2OnlyDatastore_ThresholdEvent_ModelName(t *testing.T) {
+// TestV2OnlyDatastore_ThresholdEvent_Retrieval verifies that GetThresholdEvents and
+// GetRecentThresholdEvents return events for the species.
+func TestV2OnlyDatastore_ThresholdEvent_Retrieval(t *testing.T) {
 	ds, cleanup := setupTestDatastoreWithLabels(t, []string{"Parus major_Great Tit"})
 	defer cleanup()
 
@@ -977,14 +967,12 @@ func TestV2OnlyDatastore_ThresholdEvent_ModelName(t *testing.T) {
 	events, err := ds.GetThresholdEvents("Parus major", 10)
 	require.NoError(t, err)
 	require.Len(t, events, 1)
-	assert.Equal(t, "BirdNET_V2.4", events[0].ModelName,
-		"event ModelName must be constructed from the Label's Model (Name_VVersion)")
+	assert.Equal(t, "Parus major", events[0].SpeciesName)
 
 	recent, err := ds.GetRecentThresholdEvents(10)
 	require.NoError(t, err)
 	require.Len(t, recent, 1)
-	assert.Equal(t, "BirdNET_V2.4", recent[0].ModelName,
-		"recent event ModelName must be constructed from the Label's Model")
+	assert.Equal(t, "Parus major", recent[0].SpeciesName)
 }
 
 // TestV2OnlyDatastore_GetThresholdEvents_ResolvesScientificName covers the

--- a/internal/imageprovider/imageprovider_test.go
+++ b/internal/imageprovider/imageprovider_test.go
@@ -273,7 +273,7 @@ func (m *mockStore) SearchDetections(filters *datastore.SearchFilters) ([]datast
 
 // Dynamic threshold methods
 func (m *mockStore) SaveDynamicThreshold(threshold *datastore.DynamicThreshold) error { return nil }
-func (m *mockStore) GetDynamicThreshold(speciesName, modelName string) (*datastore.DynamicThreshold, error) {
+func (m *mockStore) GetDynamicThreshold(speciesName string) (*datastore.DynamicThreshold, error) {
 	return nil, fmt.Errorf("not found")
 }
 func (m *mockStore) GetAllDynamicThresholds(limit ...int) ([]datastore.DynamicThreshold, error) {

--- a/internal/notification/message_keys.go
+++ b/internal/notification/message_keys.go
@@ -40,7 +40,6 @@ const (
 	MsgSettingsReconfiguringTelemetry         = "notifications.content.settings.reconfiguringTelemetry"
 	MsgSettingsReconfiguringSpeciesTracking   = "notifications.content.settings.reconfiguringSpeciesTracking"
 	MsgSettingsReconfiguringPushNotifications = "notifications.content.settings.reconfiguringPushNotifications"
-	MsgSettingsRecalculatingThresholds        = "notifications.content.settings.recalculatingThresholds"
 	MsgSettingsReconfiguringDynamicThresholds = "notifications.content.settings.reconfiguringDynamicThresholds"
 	MsgSettingsWebserverRestart               = "notifications.content.settings.webserverRestartRequired"
 	MsgSettingsOauthRestart                   = "notifications.content.settings.oauthRestartRequired"


### PR DESCRIPTION
## Summary

Dynamic threshold learning was keyed by a composite `modelID:species` key, so a species detected by multiple models produced one "learned species" row per model. On a multi-model setup (BirdNET v2.4 + v3.0 + Perch v2 on one audio source) the Settings > Species list showed each species several times.

This tracks dynamic thresholds per species instead. The learned state (level, high-confidence count, timer) is shared across models; any model's approved high-confidence detection advances it. The applied threshold is computed live at read time as `base(model) * levelMultiplier(level)` clamped to the configured minimum, so each model still scales the shared level against its own base. The per-model base override for Perch v2 / BirdNET v3.0 is preserved (only the learned level is shared, not the base).

Because applied values are now derived from live settings, the stored absolute `CurrentValue` and the base-threshold recalculation machinery are removed: a base-threshold change takes effect at the next detection with no bookkeeping.

A startup migration consolidates existing per-model rows into one row per species (highest level wins, counters merged by max, latest expiry) and drops the `model_name` columns before AutoMigrate creates the new `unique(species_name)` index. It is idempotent, a no-op on fresh installs, and clears the ephemeral (TTL-bounded, re-learnable) table rather than failing startup if consolidation errors.

## Behavior change

For multi-model users, a species confirmed by one model now lowers the effective threshold for all models (each against its own base). Single-model users are unaffected. The dynamic-thresholds API no longer returns the `modelName` field or accepts the `model` query param; the shipped frontend never used either.

## Test Plan

- [x] `go build ./...`, `golangci-lint run` (0 issues), `go test -race` across processor / datastore / api / imageprovider / notification
- [x] New migration tests: consolidation (highest-level wins, max counters, latest expiry), idempotence, fresh-install
- [x] New behavior tests: shared-across-models single entry with per-model base at read time; live base applied with no recalc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dynamic thresholds are now shared by species across detection models.
  * Thresholds automatically reflect the current configured base value when read.
  * Existing threshold data is migrated and consolidated safely during upgrade.
* **Changes**
  * Dynamic-threshold API responses and lookups are now species-based; model names are no longer included.
  * Threshold recalculation notifications and manual recalculation behavior have been removed.
* **Bug Fixes**
  * Improved threshold persistence, expiration, minimum clamping, and cross-model consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->