### PR TITLE
build(docker): split runtime libraries into a versioned base image

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -1,0 +1,153 @@
+name: Container base image
+
+# Builds and publishes ghcr.io/<repo>-base, the heavy, rarely-changing runtime
+# library layer (Debian packages, ONNX Runtime, TFLite C, OpenVINO runtime, Intel
+# NEO/IGC) that the application image stacks on top of via `FROM ${BASE_IMAGE}`.
+#
+# The base tag is content-addressed from the Dockerfile itself
+# (base-<sha256(Dockerfile)[:12]>), so any change to the base recipe or its pins
+# yields a new tag and forces a rebuild, while unchanged recipes always resolve to
+# an already-published tag. Application releases dedup against the immutable base
+# blobs regardless of BuildKit cache state, which is the whole point of the split.
+#
+# Triggers:
+#   - workflow_call (build-if-missing): the app publish pipeline
+#     (docker-build-push.yml) calls this before building so a release can never
+#     race a missing base. NOT triggered on push-to-main, which avoids two app
+#     builds concurrently regenerating the same base tag.
+#   - schedule (monthly) / workflow_dispatch (force): refreshes the base so Debian
+#     and ffmpeg security updates flow into a freshly built base at least monthly
+#     even when the recipe (and thus the tag) is unchanged. This is the one
+#     intentional, announced base-layer churn; between refreshes the base is stable
+#     so app releases pull only the small app-specific layers (the arch-selected
+#     models, the helper scripts, and the birdnet-go binary), not the heavy base.
+
+on:
+  workflow_call:
+    inputs:
+      force:
+        description: "Rebuild and push even if the content-addressed tag already exists"
+        required: false
+        type: boolean
+        default: false
+    outputs:
+      base-ref:
+        description: "Digest-pinned base image reference (ghcr.io/<repo>-base@sha256:...)"
+        value: ${{ jobs.base.outputs.base-ref }}
+  workflow_dispatch:
+  schedule:
+    # 04:00 UTC on the 1st of every month: refresh OS/library security patches.
+    - cron: "0 4 1 * *"
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  # Serialize base builds so a scheduled refresh and a workflow_call bootstrap
+  # cannot push the same tag concurrently with divergent (non-reproducible apt)
+  # layer digests.
+  group: base-image-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  base:
+    runs-on: ubuntu-24.04
+    outputs:
+      base-ref: ${{ steps.resolve.outputs.base-ref }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Compute base repo and content-addressed tag
+        id: meta
+        run: |
+          # Lowercase the owner/repo for a valid image ref, and append -base.
+          BASE_REPO="ghcr.io/${GITHUB_REPOSITORY,,}-base"
+          # Content-address the tag on the Dockerfile. Any recipe/pin change yields
+          # a new tag; an unchanged Dockerfile always resolves to the same tag so
+          # normal app releases reuse the already-published base.
+          TAG="base-$(sha256sum Dockerfile | cut -c1-12)"
+          echo "base-repo=${BASE_REPO}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Base image: ${BASE_REPO}:${TAG}"
+
+      - name: Login to GitHub Container Registry
+        run: |
+          for attempt in 1 2 3; do
+            if echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin; then
+              echo "GHCR login succeeded"; exit 0
+            fi
+            echo "GHCR login attempt $attempt/3 failed, retrying in 15s..."; sleep 15
+          done
+          echo "GHCR login failed after 3 attempts"; exit 1
+
+      - name: Check whether base tag already exists
+        id: exists
+        env:
+          # A scheduled or manually-dispatched run always rebuilds (refresh OS /
+          # library security patches into the existing tag). A workflow_call run
+          # rebuilds only when the caller passes force, otherwise build-if-missing.
+          FORCE: ${{ inputs.force }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          REF="${{ steps.meta.outputs.base-repo }}:${{ steps.meta.outputs.tag }}"
+          if [ "$FORCE" = "true" ] || [ "$EVENT" = "schedule" ] || [ "$EVENT" = "workflow_dispatch" ]; then
+            echo "forced rebuild (event=${EVENT}); will rebuild ${REF}"
+            echo "build=true" >> "$GITHUB_OUTPUT"
+          elif docker manifest inspect "$REF" >/dev/null 2>&1; then
+            echo "Base ${REF} already published; skipping build"
+            echo "build=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Base ${REF} missing; will build"
+            echo "build=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push base image
+        if: steps.exists.outputs.build == 'true'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          # Build only the heavy runtime-base stage; buildx skips buildenv/build
+          # (the Go compile) because runtime-base does not depend on them.
+          target: runtime-base
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.base-repo }}:${{ steps.meta.outputs.tag }}
+          # A scheduled/dispatched/forced refresh MUST bypass the layer cache,
+          # otherwise BuildKit cache-hits the unchanged `apt-get` (and download)
+          # RUN layers and the "refresh" ships byte-identical old packages, so the
+          # monthly Debian/ffmpeg security update never lands. A workflow_call
+          # build-if-missing (force=false) keeps the cache for a fast bootstrap of
+          # an unchanged recipe.
+          no-cache: ${{ inputs.force == true || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+          # Durable, base-only registry cache (never LRU-evicted like the GHA cache):
+          # keeps base layer blobs byte-stable across rebuilds when the recipe is
+          # unchanged, so a rebuild triggered by an unrelated Dockerfile edit does
+          # not churn the layers users have already pulled. cache-to still exports
+          # on a no-cache refresh, so the durable cache tracks the freshly patched
+          # layers for the next content-addressed (non-refresh) build.
+          cache-from: type=registry,ref=${{ steps.meta.outputs.base-repo }}:buildcache
+          cache-to: type=registry,ref=${{ steps.meta.outputs.base-repo }}:buildcache,mode=max
+          provenance: false
+
+      - name: Resolve digest-pinned base reference
+        id: resolve
+        run: |
+          # Pin app builds to the exact base manifest-list digest for build
+          # reproducibility: a later monthly refresh moving the tag cannot silently
+          # change what an already-built app image was built against, while the
+          # identical blobs still dedup on pull.
+          REF="${{ steps.meta.outputs.base-repo }}:${{ steps.meta.outputs.tag }}"
+          DIGEST=$(docker buildx imagetools inspect "$REF" --format '{{.Manifest.Digest}}')
+          if [ -z "$DIGEST" ]; then
+            echo "Failed to resolve digest for ${REF}" >&2; exit 1
+          fi
+          BASE_REF="${{ steps.meta.outputs.base-repo }}@${DIGEST}"
+          echo "base-ref=${BASE_REF}" >> "$GITHUB_OUTPUT"
+          echo "Resolved base reference: ${BASE_REF}"

--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -48,11 +48,17 @@ jobs:
           load: true
           tags: birdnet-go:test
           platforms: linux/amd64
-          # Reads the registry cache the publish workflow populates (anonymous,
-          # public); writes/reads the PR-scoped GHA cache. Never pushes.
+          # Reads the registry caches the publish workflows populate (anonymous,
+          # public); writes/reads the PR-scoped GHA cache. Never pushes. The
+          # -base:buildcache is required because publish app builds stack on the
+          # pre-published base and never rebuild the runtime-base stage, so the
+          # app :buildcache no longer holds the heavy base layers; this PR build
+          # rebuilds runtime-base locally (default BASE_IMAGE) and hits the base
+          # cache since the recipe is byte-identical.
           cache-from: |
             type=gha
             type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
+            type=registry,ref=ghcr.io/${{ github.repository }}-base:buildcache
           cache-to: type=gha,mode=max
           provenance: false
 
@@ -94,12 +100,16 @@ jobs:
           load: true
           tags: birdnet-go:test-arm64
           platforms: linux/arm64
-          # Reads the registry cache the publish workflow populates (anonymous,
+          # Reads the registry caches the publish workflows populate (anonymous,
           # public); writes/reads an arm64-scoped GHA cache so it never collides
-          # with the amd64 job's default-scope cache. Never pushes.
+          # with the amd64 job's default-scope cache. Never pushes. The
+          # -base:buildcache holds the heavy runtime-base layers the app
+          # :buildcache no longer carries after the base/app split (see the amd64
+          # job for the rationale).
           cache-from: |
             type=gha,scope=arm64
             type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
+            type=registry,ref=ghcr.io/${{ github.repository }}-base:buildcache
           cache-to: type=gha,mode=max,scope=arm64
           provenance: false
 

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -62,7 +62,18 @@ permissions:
   packages: write
 
 jobs:
+  # Ensure the heavy runtime base image exists before the app build. Content-
+  # addressed on the Dockerfile, so this is a no-op (manifest exists) on a normal
+  # release and only builds when the base recipe changed or was never published.
+  # Building it here (rather than on push-to-main) means the app build can never
+  # race a missing base, and there is no separate trigger to keep two concurrent
+  # app builds from regenerating the same base tag.
+  base:
+    uses: ./.github/workflows/base-image.yml
+    secrets: inherit
+
   build:
+    needs: base
     runs-on: ubuntu-24.04
     outputs:
       version: ${{ inputs.version }}
@@ -248,6 +259,7 @@ jobs:
             BUILD_VERSION=${{ inputs.version }}
             SENTRY_DSN=${{ secrets.SENTRY_DSN }}
             BUILDKIT_INLINE_CACHE=1
+            BASE_IMAGE=${{ needs.base.outputs.base-ref }}
           tags: ${{ steps.tags.outputs.ghcr-tags }}
           # OCI image labels. Set on the GHCR build; the Docker Hub mirror copies
           # the image config, so the Docker Hub tags inherit these automatically.

--- a/Dockerfile
+++ b/Dockerfile
@@ -226,7 +226,11 @@ RUN apt-get update -q && apt-get install -q -y --no-install-recommends \
 
 # ONNX Runtime (used by all arches; arm64 relies on it exclusively). onnxruntime
 # is dlopened at runtime, never linked at compile, so it is provisioned here in
-# the base rather than in the `build` stage. Installed root-owned under /usr/lib.
+# the base rather than in the `build` stage. `tar --no-same-owner` extracts the
+# archive as root (GNU tar as root otherwise restores the archive's stored UIDs),
+# so the libraries land root-owned under /usr/lib and a non-root runtime process
+# sharing an unrelated UID cannot overwrite them. The same flag is used for the
+# TFLite and OpenVINO extractions below for the same reason.
 ARG ONNXRUNTIME_VERSION
 RUN set -eu; \
     ONNX_ARCH=$(case "${TARGETPLATFORM}" in \
@@ -238,7 +242,7 @@ RUN set -eu; \
     curl -fsSL "https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRUNTIME_VERSION}/onnxruntime-linux-${ONNX_ARCH}-${ONNXRUNTIME_VERSION}.tgz" \
         -o /tmp/onnxruntime.tgz; \
     mkdir -p /tmp/onnxruntime; \
-    tar -xzf /tmp/onnxruntime.tgz -C /tmp/onnxruntime --strip-components=1; \
+    tar --no-same-owner -xzf /tmp/onnxruntime.tgz -C /tmp/onnxruntime --strip-components=1; \
     cp -a /tmp/onnxruntime/lib/libonnxruntime*.so* /usr/lib/; \
     rm -rf /tmp/onnxruntime /tmp/onnxruntime.tgz
 
@@ -259,7 +263,7 @@ RUN set -eu; \
     TF_VER="${TFLITE_VERSION#v}"; \
     echo "Downloading TFLite C library ${TFLITE_VERSION} for ${TFA}"; \
     wget -q "https://github.com/tphakala/tflite_c/releases/download/${TFLITE_VERSION}/tflite_c_${TFLITE_VERSION}_${TFA}.tar.gz" -O /tmp/tflite.tar.gz; \
-    tar -xzf /tmp/tflite.tar.gz -C /tmp; \
+    tar --no-same-owner -xzf /tmp/tflite.tar.gz -C /tmp; \
     cp -a "/tmp/libtensorflowlite_c.so.${TF_VER}" /usr/lib/; \
     ln -sf "libtensorflowlite_c.so.${TF_VER}" /usr/lib/libtensorflowlite_c.so; \
     test -e /usr/lib/libtensorflowlite_c.so; \
@@ -289,7 +293,7 @@ RUN set -eu; \
     curl -fsSL "${OV_URL}" -o /tmp/openvino.tgz; \
     echo "${OV_SHA256}  /tmp/openvino.tgz" | sha256sum -c -; \
     mkdir -p /tmp/ov; \
-    tar -xzf /tmp/openvino.tgz -C /tmp/ov --strip-components=1 \
+    tar --no-same-owner -xzf /tmp/openvino.tgz -C /tmp/ov --strip-components=1 \
         "${OV_BASE}/runtime/lib/${OV_LIBDIR}" \
         "${OV_BASE}/runtime/3rdparty/tbb/lib"; \
     OV_SRC="/tmp/ov/runtime/lib/${OV_LIBDIR}"; \
@@ -389,10 +393,17 @@ FROM models-${TARGETARCH} AS models
 # ============================================================================
 FROM ${BASE_IMAGE} AS final
 
-# Copy the arch-selected stock models. --chmod=644 makes files world-readable and
-# the layer reproducible (a pure COPY, no non-deterministic RUN); COPY creates
-# /models as 0755 (world-traversable), matching what the entrypoint expects.
-COPY --from=models --chown=root:root --chmod=644 / /models/
+# Copy the arch-selected stock models, then normalize permissions explicitly.
+# Do NOT use `COPY --chmod` here: when the source is a stage root, BuildKit applies
+# the mode to the destination directory itself, so `--chmod=644` leaves /models
+# non-traversable (0644) and a non-root runtime user gets "permission denied"
+# opening a model (Buildah instead keeps the dir 0755, so the two builders
+# disagree and a local Buildah test passes while CI/BuildKit fails). The explicit
+# chmod guarantees a traversable dir (0755) and world-readable files (0644) on
+# every builder. The single arch set is still copied once, so the ~116 MB
+# duplicate model layer stays gone.
+COPY --from=models --chown=root:root / /models/
+RUN chmod 0755 /models && find /models -mindepth 1 -type f -exec chmod 0644 {} +
 
 # Include reset_auth tool and startup scripts from the build stage.
 COPY --from=build --chmod=755 /home/dev-user/src/BirdNET-Go/reset_auth.sh /usr/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,17 @@
+# BASE_IMAGE selects the runtime base for the final app stage. It MUST be declared
+# at global scope (before the first FROM) so the `FROM ${BASE_IMAGE}` below can use
+# it. Defaults to the local `runtime-base` stage, so a from-scratch `docker build .`
+# and the PR container-test build are fully self-contained. CI publish builds
+# override it with the pre-published, digest-pinned
+# ghcr.io/tphakala/birdnet-go-base@sha256:... so app-only releases dedup against
+# immutable base layers regardless of BuildKit cache state.
+ARG BASE_IMAGE=runtime-base
+
 ARG TENSORFLOW_VERSION=2.17.1
+# TensorFlow Lite C runtime library release (github.com/tphakala/tflite_c). Kept in
+# sync with TENSORFLOW_VERSION (headers) and the Taskfile TFLITE_VERSION var; the
+# runtime-base stage downloads the matching prebuilt libtensorflowlite_c.so.
+ARG TFLITE_VERSION=v2.17.1
 ARG ONNXRUNTIME_VERSION=1.25.1
 # OpenVINO toolkit pin for the runtime libraries bundled into the images. Keep the
 # release/build in sync with the Taskfile OPENVINO_RELEASE / OPENVINO_BUILD values;
@@ -111,80 +124,48 @@ ARG PROJECT_COMMUNITY_URL
 ENV PROJECT_COMMUNITY_URL=${PROJECT_COMMUNITY_URL:-}
 
 ARG TARGETPLATFORM
-ARG ONNXRUNTIME_VERSION
 
-# Download ONNX Runtime for the target platform
-RUN ONNX_ARCH=$(case "${TARGETPLATFORM}" in \
-        "linux/amd64") echo "x64" ;; \
-        "linux/arm64") echo "aarch64" ;; \
-        *) echo "Error: unsupported platform ${TARGETPLATFORM}" >&2; exit 1 ;; \
-    esac) && \
-    echo "Downloading ONNX Runtime ${ONNXRUNTIME_VERSION} for ${ONNX_ARCH}" && \
-    curl -fsSL "https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRUNTIME_VERSION}/onnxruntime-linux-${ONNX_ARCH}-${ONNXRUNTIME_VERSION}.tgz" \
-        -o /tmp/onnxruntime.tgz && \
-    mkdir -p /tmp/onnxruntime && \
-    tar -xzf /tmp/onnxruntime.tgz -C /tmp/onnxruntime --strip-components=1 && \
-    cp /tmp/onnxruntime/lib/libonnxruntime*.so* /home/dev-user/lib/ && \
-    rm -rf /tmp/onnxruntime /tmp/onnxruntime.tgz
-
-# OpenVINO runtime provisioning for the target platform. One toolkit download
-# serves two purposes: (1) the arch-independent C API headers are staged into the
-# Taskfile OpenVINO header cache (.cache/openvino) with a matching .build-id stamp,
-# so the check-openvino task treats them as up-to-date and does not re-download
-# during the build; (2) the arch-specific runtime .so set is staged into
-# /home/dev-user/lib/openvino for the final image. Only the libraries the backend
-# needs are kept (core, C API, ONNX + IR frontends, the arch CPU plugin, the amd64
-# iGPU plugin, and TBB); the unused frontends and plugins are dropped to save size.
-# The SHA256 is verified per arch before extraction (a moved or tampered upstream
-# archive can still return HTTP 200).
+# OpenVINO C API header provisioning for the compile. The openvino-tagged backend
+# dlopens libopenvino_c at runtime, so the runtime .so set is NOT needed here (it
+# ships via the runtime-base stage below); only the arch-independent C API headers
+# are required at compile time. Stage them into the Taskfile OpenVINO header cache
+# (.cache/openvino) with a matching .build-id stamp so the check-openvino task
+# treats them as up-to-date and does not re-download during the build. The SHA256
+# is verified per arch before extraction (a moved or tampered upstream archive can
+# still return HTTP 200).
 ARG OPENVINO_RELEASE
 ARG OPENVINO_BUILD
 ARG OPENVINO_SHA256_AMD64
 ARG OPENVINO_SHA256_ARM64
 RUN set -eu; \
     case "${TARGETPLATFORM}" in \
-        "linux/amd64") OV_SUFFIX=x86_64; OV_LIBDIR=intel64; OV_SHA256="${OPENVINO_SHA256_AMD64}"; OV_CPU_PLUGIN=libopenvino_intel_cpu_plugin.so; OV_GPU_PLUGIN=libopenvino_intel_gpu_plugin.so ;; \
-        "linux/arm64") OV_SUFFIX=arm64;  OV_LIBDIR=aarch64; OV_SHA256="${OPENVINO_SHA256_ARM64}"; OV_CPU_PLUGIN=libopenvino_arm_cpu_plugin.so;   OV_GPU_PLUGIN="" ;; \
+        "linux/amd64") OV_SUFFIX=x86_64; OV_SHA256="${OPENVINO_SHA256_AMD64}" ;; \
+        "linux/arm64") OV_SUFFIX=arm64;  OV_SHA256="${OPENVINO_SHA256_ARM64}" ;; \
         *) echo "Error: unsupported platform ${TARGETPLATFORM}" >&2; exit 1 ;; \
     esac; \
     OV_BASE="openvino_toolkit_ubuntu22_${OPENVINO_BUILD}_${OV_SUFFIX}"; \
     OV_URL="https://storage.openvinotoolkit.org/repositories/openvino/packages/${OPENVINO_RELEASE}/linux/${OV_BASE}.tgz"; \
-    echo "Downloading OpenVINO ${OPENVINO_BUILD} (${OV_SUFFIX})"; \
+    echo "Downloading OpenVINO ${OPENVINO_BUILD} (${OV_SUFFIX}) headers"; \
     curl -fsSL "${OV_URL}" -o /tmp/openvino.tgz; \
     echo "${OV_SHA256}  /tmp/openvino.tgz" | sha256sum -c -; \
     mkdir -p /tmp/ov; \
-    tar -xzf /tmp/openvino.tgz -C /tmp/ov --strip-components=1 \
-        "${OV_BASE}/runtime/include" \
-        "${OV_BASE}/runtime/lib/${OV_LIBDIR}" \
-        "${OV_BASE}/runtime/3rdparty/tbb/lib"; \
+    tar -xzf /tmp/openvino.tgz -C /tmp/ov --strip-components=1 "${OV_BASE}/runtime/include"; \
     mkdir -p .cache/openvino; \
     rm -rf .cache/openvino/include; \
     cp -a /tmp/ov/runtime/include .cache/openvino/include; \
     test -f .cache/openvino/include/openvino/c/openvino.h; \
     printf '%s\n' "${OPENVINO_BUILD}" > .cache/openvino/.build-id; \
-    mkdir -p /home/dev-user/lib/openvino; \
-    OV_SRC="/tmp/ov/runtime/lib/${OV_LIBDIR}"; \
-    cp -a "${OV_SRC}"/libopenvino.so* /home/dev-user/lib/openvino/; \
-    cp -a "${OV_SRC}"/libopenvino_c.so* /home/dev-user/lib/openvino/; \
-    cp -a "${OV_SRC}"/libopenvino_onnx_frontend.so* /home/dev-user/lib/openvino/; \
-    cp -a "${OV_SRC}"/libopenvino_ir_frontend.so* /home/dev-user/lib/openvino/; \
-    cp -a "${OV_SRC}/${OV_CPU_PLUGIN}"* /home/dev-user/lib/openvino/; \
-    if [ -n "${OV_GPU_PLUGIN}" ]; then cp -a "${OV_SRC}/${OV_GPU_PLUGIN}"* /home/dev-user/lib/openvino/; fi; \
-    find /tmp/ov/runtime/3rdparty/tbb/lib -name '*.so*' -exec cp -a {} /home/dev-user/lib/openvino/ \; ; \
-    test -e /home/dev-user/lib/openvino/libtbb.so.12; \
-    rm -rf /tmp/openvino.tgz /tmp/ov; \
-    echo "Staged OpenVINO runtime libraries: $(ls /home/dev-user/lib/openvino | wc -l) entries"
+    rm -rf /tmp/openvino.tgz /tmp/ov
 
 # Build assets and compile BirdNET-Go (non-embedded, TFLite/ONNX + native OpenVINO).
-# The noembed_linux_* targets default OPENVINO=true, and the runtime libraries
-# staged above ship in the final image so the backend can dlopen libopenvino_c.
-# The backend self-gates (non-A76 arm64, or amd64 without Intel GPU drivers) and
-# falls back to ONNX Runtime, so enabling it here is safe for every deployment.
-# OPENVINO_BUILD is passed through to the task so the check-openvino header-cache
-# guard compares against the SAME build id this stage staged into .cache/openvino
-# above. That makes the guard a guaranteed no-op (no re-download) and keeps the
-# compiled-against headers and the shipped runtime .so set on one version even if
-# the Taskfile default and this Dockerfile ARG ever drift.
+# The noembed_linux_* targets default OPENVINO=true and download the TFLite C
+# library (linked via CGO_LDFLAGS -ltensorflowlite_c) into DOCKER_LIB_DIR for the
+# compile. The runtime .so sets (ONNX, TFLite, OpenVINO) ship via the runtime-base
+# stage, not from here. The backend self-gates (non-A76 arm64, or amd64 without
+# Intel GPU drivers) and falls back to ONNX Runtime, so enabling OpenVINO here is
+# safe for every deployment. OPENVINO_BUILD is passed through to the task so the
+# check-openvino header-cache guard compares against the SAME build id this stage
+# staged into .cache/openvino above, making the guard a guaranteed no-op.
 # Note: frontend-build (including Tailwind) is handled as a dependency of noembed_* tasks
 RUN --mount=type=cache,target=/go/pkg/mod,uid=10001,gid=10001 \
     --mount=type=cache,target=/home/dev-user/.cache/go-build,uid=10001,gid=10001 \
@@ -193,28 +174,31 @@ RUN --mount=type=cache,target=/go/pkg/mod,uid=10001,gid=10001 \
     echo "Building non-embedded version with BUILD_VERSION=${BUILD_VERSION}" && \
     BUILD_VERSION="${BUILD_VERSION}" SENTRY_DSN="${SENTRY_DSN}" PROJECT_NAME="${PROJECT_NAME}" PROJECT_REPO_URL="${PROJECT_REPO_URL}" PROJECT_COMMUNITY_URL="${PROJECT_COMMUNITY_URL}" DOCKER_LIB_DIR=/home/dev-user/lib task noembed_${TARGET} OPENVINO_BUILD="${OPENVINO_BUILD}"
 
-# Create final image using a multi-platform base image
-FROM --platform=$TARGETPLATFORM debian:trixie-slim
-
-# Copy stock model files to /models. arm64 ships ONNX-only stock models (the
-# reduced-memory INT8-ARM default); other arches ship the TFLite models. Stage all
-# candidates in one cacheable layer, then keep only the set for the target
-# architecture. Custom models are supplied by the user at runtime, not shipped here.
-RUN mkdir -p /models /tmp/allmodels
-COPY --from=build /home/dev-user/src/BirdNET-Go/internal/classifier/data/*.tflite /tmp/allmodels/
-COPY --from=build /home/dev-user/src/BirdNET-Go/internal/classifier/data/*.onnx /tmp/allmodels/
+# ============================================================================
+# runtime-base: the heavy, rarely-changing runtime library layer.
+#
+# This stage is published separately as ghcr.io/<repo>-base:base-<sha> (the tag is
+# content-addressed on this Dockerfile; see .github/workflows/base-image.yml). The
+# final app stage below does `FROM ${BASE_IMAGE}` where BASE_IMAGE defaults to this
+# local stage (so a from-scratch `docker build .` and the PR container-test build
+# are fully self-contained), and CI publish builds override BASE_IMAGE with the
+# pre-published base pinned by digest so app-only releases stack only the
+# model/script/binary layers on top of immutable base blobs (structural layer
+# dedup, independent of BuildKit cache state).
+#
+# It downloads its own runtime .so sets rather than copying from the `build`
+# stage, so building `--target runtime-base` never drags in the Go compile. The
+# pins are the top-of-file ARGs (the single source of truth); content-addressing
+# the base tag on this Dockerfile means any pin change yields a new base tag and a
+# rebuild, so the shipped runtime libs never drift from what the binary linked and
+# compiled against.
+# ============================================================================
+FROM --platform=$TARGETPLATFORM debian:trixie-slim AS runtime-base
 ARG TARGETPLATFORM
-RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
-        cp /tmp/allmodels/*.onnx /models/; \
-    else \
-        cp /tmp/allmodels/*.tflite /models/; \
-    fi && \
-    chmod -R a+r /models/ && \
-    chmod a+x /models && \
-    rm -rf /tmp/allmodels
 
 # Install ALSA library and SOX for audio processing, tini (a tiny init run as
-# PID 1, see the ENTRYPOINT note below), and other system utilities for debugging
+# PID 1, see the final-stage ENTRYPOINT note), and other system utilities for
+# debugging.
 RUN apt-get update -q && apt-get install -q -y --no-install-recommends \
     adduser \
     ca-certificates \
@@ -240,31 +224,89 @@ RUN apt-get update -q && apt-get install -q -y --no-install-recommends \
     tini \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy ONNX Runtime libraries (used by all arches; arm64 relies on them exclusively).
-# --chown=root:root because COPY --from preserves the build-stage owner (dev-user,
-# UID 10001); system libraries must be root-owned so a runtime process cannot
-# overwrite them if it happens to share that UID.
-COPY --chown=root:root --from=build /home/dev-user/lib/libonnxruntime*.so* /usr/lib/
+# ONNX Runtime (used by all arches; arm64 relies on it exclusively). onnxruntime
+# is dlopened at runtime, never linked at compile, so it is provisioned here in
+# the base rather than in the `build` stage. Installed root-owned under /usr/lib.
+ARG ONNXRUNTIME_VERSION
+RUN set -eu; \
+    ONNX_ARCH=$(case "${TARGETPLATFORM}" in \
+        "linux/amd64") echo "x64" ;; \
+        "linux/arm64") echo "aarch64" ;; \
+        *) echo "Error: unsupported platform ${TARGETPLATFORM}" >&2; exit 1 ;; \
+    esac); \
+    echo "Downloading ONNX Runtime ${ONNXRUNTIME_VERSION} for ${ONNX_ARCH}"; \
+    curl -fsSL "https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRUNTIME_VERSION}/onnxruntime-linux-${ONNX_ARCH}-${ONNXRUNTIME_VERSION}.tgz" \
+        -o /tmp/onnxruntime.tgz; \
+    mkdir -p /tmp/onnxruntime; \
+    tar -xzf /tmp/onnxruntime.tgz -C /tmp/onnxruntime --strip-components=1; \
+    cp -a /tmp/onnxruntime/lib/libonnxruntime*.so* /usr/lib/; \
+    rm -rf /tmp/onnxruntime /tmp/onnxruntime.tgz
 
-# TensorFlow Lite C library: installed for all arches. The stock default classifier
-# is ONNX on arm64 (reduced memory) and TFLite on amd64, but every arch links
-# libtensorflowlite_c so a user-supplied custom `.tflite` model path loads in any
-# container. No TFLite interpreter is created unless a .tflite model is actually
-# loaded, so the arm64 memory win for the ONNX default is preserved.
-# Stage then cp (not a direct COPY) so cp dereferences the build-stage soname
-# symlinks into regular files under /usr/lib; cp runs as root here, so the installed
-# libraries are root-owned. Fail the build loudly if the library is missing.
-COPY --from=build /home/dev-user/lib/libtensorflowlite_c.so* /tmp/tflite-lib/
-RUN cp /tmp/tflite-lib/libtensorflowlite_c.so* /usr/lib/ && \
-    test -e /usr/lib/libtensorflowlite_c.so && \
-    rm -rf /tmp/tflite-lib && \
-    ldconfig
+# TensorFlow Lite C runtime library: installed for all arches. The stock default
+# classifier is ONNX on arm64 (reduced memory) and TFLite on amd64, but every arch
+# ships libtensorflowlite_c so a user-supplied custom `.tflite` model path loads in
+# any container. No TFLite interpreter is created unless a .tflite model is actually
+# loaded, so the arm64 memory win for the ONNX default is preserved. Downloaded from
+# the same prebuilt release the Taskfile download-tflite task uses; the bare soname
+# symlink is created so a bare-soname dlopen/link resolves.
+ARG TFLITE_VERSION
+RUN set -eu; \
+    TFA=$(case "${TARGETPLATFORM}" in \
+        "linux/amd64") echo "linux_amd64" ;; \
+        "linux/arm64") echo "linux_arm64" ;; \
+        *) echo "Error: unsupported platform ${TARGETPLATFORM}" >&2; exit 1 ;; \
+    esac); \
+    TF_VER="${TFLITE_VERSION#v}"; \
+    echo "Downloading TFLite C library ${TFLITE_VERSION} for ${TFA}"; \
+    wget -q "https://github.com/tphakala/tflite_c/releases/download/${TFLITE_VERSION}/tflite_c_${TFLITE_VERSION}_${TFA}.tar.gz" -O /tmp/tflite.tar.gz; \
+    tar -xzf /tmp/tflite.tar.gz -C /tmp; \
+    cp -a "/tmp/libtensorflowlite_c.so.${TF_VER}" /usr/lib/; \
+    ln -sf "libtensorflowlite_c.so.${TF_VER}" /usr/lib/libtensorflowlite_c.so; \
+    test -e /usr/lib/libtensorflowlite_c.so; \
+    rm -rf /tmp/tflite.tar.gz "/tmp/libtensorflowlite_c.so.${TF_VER}"
+
+# OpenVINO runtime libraries (both arches). The openvino-tagged binary dlopens
+# libopenvino_c at runtime and self-gates: a non-A76 arm64 CPU, or an amd64 host
+# without Intel GPU drivers, falls back to ONNX Runtime cleanly. Only the libraries
+# the backend needs are kept (core, C API, ONNX + IR frontends, the arch CPU plugin,
+# the amd64 iGPU plugin, and TBB); the unused frontends and plugins are dropped to
+# save size. The SHA256 is verified per arch before extraction (a moved or tampered
+# upstream archive can still return HTTP 200). Symlinks are preserved so the
+# bare-soname dlopen resolves.
+ARG OPENVINO_RELEASE
+ARG OPENVINO_BUILD
+ARG OPENVINO_SHA256_AMD64
+ARG OPENVINO_SHA256_ARM64
+RUN set -eu; \
+    case "${TARGETPLATFORM}" in \
+        "linux/amd64") OV_SUFFIX=x86_64; OV_LIBDIR=intel64; OV_SHA256="${OPENVINO_SHA256_AMD64}"; OV_CPU_PLUGIN=libopenvino_intel_cpu_plugin.so; OV_GPU_PLUGIN=libopenvino_intel_gpu_plugin.so ;; \
+        "linux/arm64") OV_SUFFIX=arm64;  OV_LIBDIR=aarch64; OV_SHA256="${OPENVINO_SHA256_ARM64}"; OV_CPU_PLUGIN=libopenvino_arm_cpu_plugin.so;   OV_GPU_PLUGIN="" ;; \
+        *) echo "Error: unsupported platform ${TARGETPLATFORM}" >&2; exit 1 ;; \
+    esac; \
+    OV_BASE="openvino_toolkit_ubuntu22_${OPENVINO_BUILD}_${OV_SUFFIX}"; \
+    OV_URL="https://storage.openvinotoolkit.org/repositories/openvino/packages/${OPENVINO_RELEASE}/linux/${OV_BASE}.tgz"; \
+    echo "Downloading OpenVINO ${OPENVINO_BUILD} (${OV_SUFFIX}) runtime"; \
+    curl -fsSL "${OV_URL}" -o /tmp/openvino.tgz; \
+    echo "${OV_SHA256}  /tmp/openvino.tgz" | sha256sum -c -; \
+    mkdir -p /tmp/ov; \
+    tar -xzf /tmp/openvino.tgz -C /tmp/ov --strip-components=1 \
+        "${OV_BASE}/runtime/lib/${OV_LIBDIR}" \
+        "${OV_BASE}/runtime/3rdparty/tbb/lib"; \
+    OV_SRC="/tmp/ov/runtime/lib/${OV_LIBDIR}"; \
+    cp -a "${OV_SRC}"/libopenvino.so* /usr/lib/; \
+    cp -a "${OV_SRC}"/libopenvino_c.so* /usr/lib/; \
+    cp -a "${OV_SRC}"/libopenvino_onnx_frontend.so* /usr/lib/; \
+    cp -a "${OV_SRC}"/libopenvino_ir_frontend.so* /usr/lib/; \
+    cp -a "${OV_SRC}/${OV_CPU_PLUGIN}"* /usr/lib/; \
+    if [ -n "${OV_GPU_PLUGIN}" ]; then cp -a "${OV_SRC}/${OV_GPU_PLUGIN}"* /usr/lib/; fi; \
+    find /tmp/ov/runtime/3rdparty/tbb/lib -name '*.so*' -exec cp -a {} /usr/lib/ \; ; \
+    test -e /usr/lib/libtbb.so.12; \
+    rm -rf /tmp/openvino.tgz /tmp/ov
 
 # Install Intel NEO compute runtime for amd64 iGPU inference including legacy support.
 # NEO provides the OpenCL ICD that lets OpenVINO talk to the Intel iGPU when
-# /dev/dri is passed through from the host. OpenVINO libs for both arches are
-# installed via the COPY step below; this step only adds the OpenCL driver
-# stack required exclusively on amd64 Intel hardware.
+# /dev/dri is passed through from the host. This step only runs on linux/amd64;
+# arm64 has no Intel GPU plugin.
 ARG NEO_VERSION
 ARG IGC_VERSION
 ARG IGC_TAG
@@ -312,27 +354,50 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
       rm -rf /tmp/neo /var/lib/apt/lists/*; \
     fi
 
-# OpenVINO runtime libraries (both arches). The openvino-tagged binary dlopens
-# libopenvino_c at runtime and self-gates: a non-A76 arm64 CPU, or an amd64 host
-# without Intel GPU drivers, falls back to ONNX Runtime cleanly. The staging dir
-# holds the arch-appropriate set (see the build stage), with symlinks preserved so
-# the bare-soname dlopen resolves; ldconfig then refreshes the loader cache.
-# --chown=root:root because COPY --from preserves the build-stage owner (dev-user,
-# UID 10001); system libraries must be root-owned (see the ONNX Runtime copy above).
-COPY --chown=root:root --from=build /home/dev-user/lib/openvino/ /usr/lib/
+# Refresh the loader cache once all runtime libraries are installed.
 RUN ldconfig
 
-# Include reset_auth tool from build stage
-COPY --from=build /home/dev-user/src/BirdNET-Go/reset_auth.sh /usr/bin/
-RUN chmod +x /usr/bin/reset_auth.sh
+# ============================================================================
+# Stock model selection. arm64 ships ONNX-only stock models (the reduced-memory
+# INT8-ARM default); other arches ship the TFLite models. Each arch's set is
+# assembled in its own `scratch` stage and a single reproducible COPY pulls the
+# selected set into the final image, so the image never carries the other arch's
+# models or a duplicated copy (a plain COPY, unlike a stage-then-`cp`+`rm`, adds
+# no whiteout-masked duplicate layer). Custom models are supplied by the user at
+# runtime under /data/models, not shipped here.
+# ============================================================================
+FROM scratch AS models-amd64
+COPY --from=build /home/dev-user/src/BirdNET-Go/internal/classifier/data/*.tflite /
 
-# Add entrypoint script for dynamic user creation
-COPY --from=build /home/dev-user/src/BirdNET-Go/Docker/entrypoint.sh /usr/bin/
-RUN chmod +x /usr/bin/entrypoint.sh
+FROM scratch AS models-arm64
+COPY --from=build /home/dev-user/src/BirdNET-Go/internal/classifier/data/*.onnx /
 
-# Add startup wrapper script for error capture and display
-COPY --from=build /home/dev-user/src/BirdNET-Go/Docker/startup-wrapper.sh /usr/bin/
-RUN chmod +x /usr/bin/startup-wrapper.sh
+# TARGETARCH is a predefined build arg (amd64/arm64), automatically in scope for
+# FROM, so it selects the matching scratch stage without an explicit declaration.
+FROM models-${TARGETARCH} AS models
+
+# ============================================================================
+# Final application image. BASE_IMAGE defaults to the local runtime-base stage
+# (self-contained builds: local `docker build`, PR container-test, first build);
+# CI publish builds override it with the pre-published base pinned by digest
+# (ghcr.io/<repo>-base@sha256:..., resolved from the content-addressed base-<sha>
+# tag) so app-only releases dedup against the immutable base layers. Everything
+# the base already installed (apt packages, ONNX/TFLite/OpenVINO runtime libs,
+# Intel NEO) is inherited; this stage only adds the arch-selected models, helper
+# scripts, and the birdnet-go binary. BASE_IMAGE is declared at global scope near
+# the top of this file.
+# ============================================================================
+FROM ${BASE_IMAGE} AS final
+
+# Copy the arch-selected stock models. --chmod=644 makes files world-readable and
+# the layer reproducible (a pure COPY, no non-deterministic RUN); COPY creates
+# /models as 0755 (world-traversable), matching what the entrypoint expects.
+COPY --from=models --chown=root:root --chmod=644 / /models/
+
+# Include reset_auth tool and startup scripts from the build stage.
+COPY --from=build --chmod=755 /home/dev-user/src/BirdNET-Go/reset_auth.sh /usr/bin/
+COPY --from=build --chmod=755 /home/dev-user/src/BirdNET-Go/Docker/entrypoint.sh /usr/bin/
+COPY --from=build --chmod=755 /home/dev-user/src/BirdNET-Go/Docker/startup-wrapper.sh /usr/bin/
 
 # Create config and data directories with proper permissions for rootless compatibility
 # Make them world-writable so non-root users can create subdirectories


### PR DESCRIPTION
## Summary

Splits the container image into a separately-published, content-addressed **base image** (the heavy, rarely-changing runtime libraries) and a thin **app image** that stacks only the models, scripts, and the `birdnet-go` binary on top. This makes the small update delta structural rather than dependent on BuildKit cache surviving between releases, and fixes a ~116 MB model-layer duplication.

### Why

Measured on the published `ghcr.io/tphakala/birdnet-go` image: a normal release already ships only a ~38 MB binary-layer delta to returning users (OCI layers are content-addressed and CI's BuildKit cache keeps the heavy library layers' digests stable). But that steady state is fragile: the ONNX/OpenVINO/apt/NEO layers are produced by non-reproducible `RUN` steps, so whenever the BuildKit cache is evicted (GHA cache is a ~10 GB LRU) or `debian:trixie-slim` bumps, a single release regenerates ~460 MB (amd64) of library layers with fresh digests and forces every user to re-download them. On a nightly-building repo with a Raspberry-Pi-heavy, bandwidth-constrained user base that is a real regression.

### What changed

- **Base/app split via a dynamic base (`Dockerfile`).** The heavy runtime libraries move into a new `runtime-base` stage. The final stage is `FROM ${BASE_IMAGE}`, where `BASE_IMAGE` defaults to the local `runtime-base` stage (so `docker build .` and the PR `container-test` build stay fully self-contained), and CI publish builds override it with the pre-published base **pinned by digest**. `runtime-base` does its own downloads and never copies from the Go `build` stage, so building `--target runtime-base` skips the Go/frontend compile.
- **Content-addressed base tag (`.github/workflows/base-image.yml`, new).** The base tag is `base-<sha256(Dockerfile)[:12]>`, so any recipe or pin change yields a new tag and a rebuild (no manual version bump, no drift between the libs the binary compiled/linked against and what ships). Published for `linux/amd64,linux/arm64`. Triggers: `workflow_call` (build-if-missing, called by the app pipeline), plus `schedule` (monthly) and `workflow_dispatch` that force a rebuild so Debian/ffmpeg security updates flow into the base at least monthly. A durable base-only registry cache keeps the base blobs byte-stable when only the app stage changes.
- **App pipeline wiring (`.github/workflows/docker-build-push.yml`).** A new `base` job ensures the base exists (a no-op manifest check on a normal release) and resolves it to a digest, which the app `build` consumes via `--build-arg BASE_IMAGE=...@sha256:...`. No push-to-main base trigger, so two concurrent app builds can never race a missing base. Callers (`release-build.yml`, `docker-build.yml`) need no changes.
- **PR build cache (`.github/workflows/container-test.yml`).** Because publish app builds stack on the pre-published base and never rebuild `runtime-base`, the app `:buildcache` no longer holds the heavy base layers. The PR container-test jobs (which build `runtime-base` locally from the default `BASE_IMAGE`) now also read the durable `-base:buildcache`, so PR builds keep hitting the cache for the base layers.
- **Monthly refresh actually patches.** The scheduled/dispatched base rebuild passes `no-cache`, otherwise BuildKit would cache-hit the unchanged `apt-get` layer and the "refresh" would ship the same old packages; build-if-missing bootstraps keep the cache for speed.
- **Model-layer dedup (`Dockerfile`).** Replaced the stage-into-`/tmp/allmodels` then `cp`+`rm` (which shipped the tflite models, the onnx models, and a whiteout-masked duplicate of the selected set) with arch-selected `scratch` stages and a single reproducible `COPY --chmod=644`. Drops ~116 MB per arch and removes a non-reproducible layer.

### What this deliberately does NOT do

- It does not move libraries into a Docker volume (volumes never travel with `docker pull`; that was a premise correction, not a viable mechanism).
- It does not reduce first-pull size beyond the model dedup (the amd64-only ~207 MB Intel NEO/iGPU stack split was considered and deferred pending demand).

Existing users pay the one-time full re-download once on the first release built on the new base (already smaller after the model fix); subsequent releases pull only the ~38 MB binary layer, now guaranteed rather than cache-dependent.

## Test plan

- Built the `runtime-base` stage natively (arm64) and verified ONNX Runtime, TFLite C (with soname symlink), OpenVINO (core/C/frontends/CPU plugin/TBB) and all system tools are present and `ldconfig`-resolvable.
- Built the full app image on the prebuilt base (override path) and verified the arch-selected models land in `/models` (dir 0755, files 0644), scripts and binary present, entrypoint unchanged.
- Verified empirically that `COPY --chmod=644 / /models/` creates `/models` at 0755 (traversable) with 0644 files, and that `FROM models-${TARGETARCH}` selects the correct per-arch model set.
- `container-test.yml` builds the full self-contained image (amd64 + arm64) on this PR and runs the arbitrary-UID, custom-.tflite, and tini-PID1 smoke tests.
- YAML validated for all three workflows.
- Reviewed through the pre-push gate (reuse, correctness, quality, integration wiring, regression) plus a Gemini cross-check. Regression review programmatically confirmed the new image ships the byte-identical apt package set, OpenVINO/NEO libs, ONNX Runtime, TFLite soname resolution, `/models` permissions, and all final-stage metadata as the old image.

## Follow-ups (not in this PR)

- Pin SHA256 checksums for the ONNX Runtime and TFLite C downloads to match the OpenVINO block (a pre-existing gap replicated from the Taskfile, which also pins only OpenVINO).
- Optionally narrow the base-tag hash to the base-relevant portion of the Dockerfile so an app-stage-only edit does not mint a new base tag (cheap today thanks to the durable base cache), and add a build-time assert that the Dockerfile TFLite/ONNX version ARGs match the Taskfile vars.
