### PR TITLE
fix(frontend): prevent duplicate each key crash on system inference page

### DIFF
--- a/frontend/src/lib/desktop/views/SystemInference.svelte
+++ b/frontend/src/lib/desktop/views/SystemInference.svelte
@@ -734,7 +734,7 @@
                 >{t('system.inference.capabilitiesHelp')}</span
               >
               <div class="flex flex-wrap items-center gap-2">
-                {#each snapshot.hardware.capabilities as capability (capability)}
+                {#each snapshot.hardware.capabilities as capability}
                   <Badge variant="neutral" size="sm" text={capability} />
                 {/each}
               </div>
@@ -786,7 +786,7 @@
               {/if}
               {#if openvino.supported && openvino.devices && openvino.devices.length > 0}
                 <span class="text-xs text-muted">{t('system.inference.devices')}:</span>
-                {#each openvino.devices as device (device)}
+                {#each openvino.devices as device}
                   <Badge variant="neutral" size="sm" text={device} />
                 {/each}
               {/if}
@@ -959,7 +959,7 @@
                   </tr>
                 </thead>
                 <tbody>
-                  {#each vad.recentHits as hit (`${hit.atUnix}-${hit.source}`)}
+                  {#each vad.recentHits as hit}
                     <tr class="border-t border-[var(--border-100)]">
                       <td
                         class="py-0.5 font-mono tabular-nums text-base-content whitespace-nowrap"
@@ -1213,7 +1213,7 @@
                       </tr>
                     </thead>
                     <tbody>
-                      {#each rows as d (`${d.scientificName || d.species}-${d.atUnix}`)}
+                      {#each rows as d}
                         {@const coNames = coDetectingModels(model.id, d)}
                         <tr class="border-t border-[var(--border-100)]">
                           <td class="py-0.5 pr-2 text-base-content">
@@ -1313,7 +1313,7 @@
                   <span class="text-xs text-muted">{t('system.inference.noSources')}</span>
                 {:else}
                   <div class="flex flex-wrap gap-1.5">
-                    {#each model.sources as source (source.id)}
+                    {#each model.sources as source}
                       <Badge variant="ghost" size="sm">
                         {source.name}{#if source.type}
                           <span class="text-muted ml-1">({source.type})</span>

--- a/frontend/src/lib/desktop/views/SystemInference.test.ts
+++ b/frontend/src/lib/desktop/views/SystemInference.test.ts
@@ -324,6 +324,31 @@ describe('SystemInference', () => {
     expect(vadText).toContain('87%'); // hit probability rounded to a percentage
   });
 
+  it('renders multiple VAD hits with identical timestamps and sources without crashing', async () => {
+    const snapshot = makeSnapshot([makeModel()]);
+    snapshot.vad = {
+      enabled: true,
+      available: true,
+      loaded: true,
+      threshold: 0.35,
+      stats: { invocations: 10, avgMs: 2.0, maxMs: 5.0, speechHits: 2 },
+      recentHits: [
+        { atUnix: 1750000000, probability: 0.85, source: 'SoundCard' },
+        { atUnix: 1750000000, probability: 0.88, source: 'SoundCard' },
+      ],
+    };
+    installApi(snapshot);
+
+    const { container } = inferenceTest.render({});
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('system.inference.vad.section');
+    });
+    const vadCard = container.querySelector('[data-testid="vad-card"]');
+    expect(vadCard).not.toBeNull();
+    expect(vadCard?.textContent).toContain('SoundCard');
+  });
+
   it('shows the empty recent-speech state when there are no hits', async () => {
     const snapshot = makeSnapshot([makeModel()]);
     snapshot.vad = {
@@ -618,6 +643,36 @@ describe('SystemInference', () => {
     expect(text).toContain('81%');
     expect(text).toContain('77%');
     expect(text).not.toContain('×');
+  });
+
+  it('renders multiple detections with identical species and timestamps without crashing', async () => {
+    const now = 1750000000;
+    const model = makeModel({
+      recentDetections: [
+        {
+          species: 'European Robin',
+          scientificName: 'Erithacus rubecula',
+          confidence: 0.81,
+          atUnix: now,
+          inRange: true,
+        },
+        {
+          species: 'European Robin',
+          scientificName: 'Erithacus rubecula',
+          confidence: 0.77,
+          atUnix: now,
+          inRange: true,
+        },
+      ],
+    });
+    installApi(makeSnapshot([model]));
+
+    const { container } = inferenceTest.render({});
+
+    await waitFor(() => {
+      expect(container.textContent).toContain(model.name);
+    });
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(2);
   });
 
   it('lists other models that detected the same species within tolerance (Also column)', async () => {
@@ -1136,5 +1191,37 @@ describe('SystemInference', () => {
       expect(card?.textContent).toContain(HARDWARE_HEADING_KEY);
       expect(card?.querySelector('dl')).not.toBeNull();
     });
+
+    it('renders duplicate capability tokens without crashing', async () => {
+      installApi(
+        makeSnapshot([makeModel({})], {
+          capabilities: ['low-ram', 'low-ram'],
+        })
+      );
+
+      const { container } = inferenceTest.render({});
+
+      await waitFor(() => {
+        expect(container.textContent).toContain(ADVANCED_KEY);
+      });
+      expect(container.textContent).toContain('low-ram');
+    });
+  });
+
+  it('renders model sources with duplicate identifiers without crashing', async () => {
+    const model = makeModel({
+      sources: [
+        { id: 'mic', name: 'Microphone', type: 'soundcard', fallback: false },
+        { id: 'mic', name: 'Microphone', type: 'soundcard', fallback: false },
+      ],
+    });
+    installApi(makeSnapshot([model]));
+
+    const { container } = inferenceTest.render({});
+
+    await waitFor(() => {
+      expect(container.textContent).toContain(model.name);
+    });
+    expect(container.textContent).toContain('Microphone');
   });
 });


### PR DESCRIPTION
## Summary
Fixes an intermittent Svelte runtime error (`https://svelte.dev/e/each_key_duplicate`) on the AI Models & Inference page (`/ui/system/inference`). Several `{#each}` loops in `SystemInference.svelte` used composite keys from values that could collide (such as multiple VAD speech hits in the same second, detections sharing timestamps/names, hardware capabilities, or audio sources). These stateless blocks are converted to unkeyed iteration so Svelte reconciles by index safely without crashing the view.

## Preflight Status
- Single concern: Exactly ONE bug fix (duplicate key error on inference page)
- Preflight passed: All review passes clean
- Linters clean: `golangci-lint run -v` (0 issues) and `npm run check:all` (0 errors, 0 warnings) pass
- Tests pass: `go test -race ./...` and `npm test` (all 191 test files, 2874 tests) pass
- No unrelated changes: diff contains only `SystemInference.svelte` and `SystemInference.test.ts`
- Scope complete: complete fix with unit test coverage
- No regression/backward-compat break: no API, schema, or config changes
- Breaking changes: None
- i18n complete: no new translation keys required
- No secrets or PII in diff

## Test Plan
- [x] Ran unit tests covering duplicate VAD hits, duplicate detections, duplicate capabilities, and duplicate sources (`npm test src/lib/desktop/views/SystemInference.test.ts`)
- [x] Verified full frontend test suite (`npm test`) and type check (`npm run check:all`)
- [x] Verified Go backend tests with race detector (`go test -race ./...`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when displaying duplicate hardware capabilities, VAD hits, model detections, and model sources.
  * Duplicate entries now remain visible without causing rendering errors.

* **Tests**
  * Added regression coverage for duplicate items across system inference views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->