### PR TITLE
fix(notification): guard webhook outbound requests against SSRF

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -409,6 +409,7 @@ func init() {
 	RegisterComponent("notification", "notification")
 	RegisterComponent("securefs", "securefs")
 	RegisterComponent("secrets", "secrets")
+	RegisterComponent("httpclient", "httpclient")
 	RegisterComponent("monitor", "monitor")
 	RegisterComponent("app", "app")
 	RegisterComponent("api", "api")

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -108,6 +108,19 @@ type Config struct {
 
 	// DisableCompression disables transparent gzip compression (default: false)
 	DisableCompression bool
+
+	// BlockLinkLocalAndMetadata installs an SSRF guard on the dialer that
+	// refuses connections to link-local addresses (including the
+	// 169.254.169.254 cloud metadata endpoint), the unspecified address, and
+	// known cloud metadata IPs. Loopback and private RFC1918 ranges stay
+	// reachable so on-LAN targets keep working. See ssrf.go for the policy.
+	//
+	// Note: when an outbound HTTP(S) proxy is configured via the environment,
+	// the transport dials the proxy and lets it resolve the target, so the
+	// guard validates the proxy address rather than the final destination. This
+	// is a deliberate trade-off to preserve proxy support for the common case;
+	// the guard is defense in depth, not the only control.
+	BlockLinkLocalAndMetadata bool
 }
 
 // DefaultConfig returns a Config with sensible production defaults.
@@ -162,13 +175,20 @@ func New(cfg *Config) *Client {
 		}
 	}
 
+	// Base dialer with tuned dial timeout and keep-alive.
+	baseDialer := &net.Dialer{
+		Timeout:   defaultDialTimeout,
+		KeepAlive: defaultDialKeepAlive,
+	}
+	dialContext := baseDialer.DialContext
+	if c.BlockLinkLocalAndMetadata {
+		dialContext = newGuardedDialContext(baseDialer)
+	}
+
 	// Create transport with tuned settings
 	transport := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   defaultDialTimeout,
-			KeepAlive: defaultDialKeepAlive,
-		}).DialContext,
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           dialContext,
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          c.MaxIdleConns,
 		MaxIdleConnsPerHost:   c.MaxIdleConnsPerHost,

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -115,11 +115,9 @@ type Config struct {
 	// known cloud metadata IPs. Loopback and private RFC1918 ranges stay
 	// reachable so on-LAN targets keep working. See ssrf.go for the policy.
 	//
-	// Note: when an outbound HTTP(S) proxy is configured via the environment,
-	// the transport dials the proxy and lets it resolve the target, so the
-	// guard validates the proxy address rather than the final destination. This
-	// is a deliberate trade-off to preserve proxy support for the common case;
-	// the guard is defense in depth, not the only control.
+	// Enabling this also disables environment-proxy support for the client, so
+	// a configured HTTP(S)_PROXY cannot resolve the destination on the client's
+	// behalf and bypass the guard.
 	BlockLinkLocalAndMetadata bool
 }
 
@@ -181,13 +179,21 @@ func New(cfg *Config) *Client {
 		KeepAlive: defaultDialKeepAlive,
 	}
 	dialContext := baseDialer.DialContext
+	proxy := http.ProxyFromEnvironment
 	if c.BlockLinkLocalAndMetadata {
 		dialContext = newGuardedDialContext(baseDialer)
+		// Disable environment proxies while the guard is active. A configured
+		// proxy would defeat the guard: the transport dials the proxy and lets
+		// it resolve the destination, so the target IP never reaches the guard
+		// (and with a loopback/private proxy the guard would reject the proxy
+		// itself). This mirrors the imageprovider SSRF client. Non-guarded
+		// clients keep normal ProxyFromEnvironment support.
+		proxy = nil
 	}
 
 	// Create transport with tuned settings
 	transport := &http.Transport{
-		Proxy:                 http.ProxyFromEnvironment,
+		Proxy:                 proxy,
 		DialContext:           dialContext,
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          c.MaxIdleConns,

--- a/internal/httpclient/ssrf.go
+++ b/internal/httpclient/ssrf.go
@@ -1,0 +1,150 @@
+package httpclient
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+)
+
+// ErrBlockedTarget is returned by the guarded dialer when a resolved connection
+// IP is refused by the SSRF policy (link-local, unspecified, or a known cloud
+// metadata address). It is a sentinel so callers and tests can match it with
+// errors.Is.
+var ErrBlockedTarget = errors.Newf("connection target blocked by SSRF policy").
+	Component("httpclient").
+	Category(errors.CategoryNetwork).
+	Build()
+
+// extraBlockedMetadataIPs holds cloud metadata endpoints that are NOT already
+// covered by the link-local / unspecified checks below. The canonical AWS, GCP
+// and Azure endpoint 169.254.169.254 is link-local and caught there. The two
+// entries here sit in ranges this guard otherwise allows: Alibaba Cloud
+// publishes its metadata on 100.100.100.200 (CGNAT space 100.64.0.0/10), and
+// AWS exposes the IMDS over IPv6 at fd00:ec2::254 (ULA space fc00::/7).
+var extraBlockedMetadataIPs = map[netip.Addr]struct{}{
+	netip.MustParseAddr("100.100.100.200"): {}, // Alibaba Cloud metadata service
+	netip.MustParseAddr("fd00:ec2::254"):   {}, // AWS IMDS over IPv6
+}
+
+// nat64Prefix and teredoPrefix are IPv6 transition ranges that embed an IPv4
+// address. An attacker can use them to smuggle a blocked IPv4 target (e.g.
+// 169.254.169.254) past the IPv6 link-local checks when a translation gateway
+// is present, so the embedded IPv4 is extracted and re-evaluated. 6to4
+// (2002::/16) is matched inline by its leading bytes.
+var (
+	nat64Prefix  = netip.MustParsePrefix("64:ff9b::/96") // RFC 6052 well-known NAT64
+	teredoPrefix = netip.MustParsePrefix("2001::/32")    // RFC 4380 Teredo
+)
+
+// isBlockedTargetIP reports whether ip must be refused under the webhook SSRF
+// guard.
+//
+// Blocked: link-local unicast (169.254.0.0/16, fe80::/10, which includes the
+// 169.254.169.254 cloud metadata address), link-local multicast, the
+// unspecified address (0.0.0.0, ::), the explicit cloud metadata IPs above, and
+// any of those reached through an IPv4-embedding IPv6 transition address
+// (NAT64, 6to4, Teredo).
+//
+// Deliberately allowed: loopback (127.0.0.0/8, ::1) and private RFC1918 / ULA
+// ranges. BirdNET-Go's primary webhook use is pointing at services on the
+// user's own LAN (Home Assistant, a local ntfy, a NAS), so blocking those would
+// break the common case. This guard closes the cloud-metadata exfiltration path
+// without disturbing legitimate on-LAN delivery.
+func isBlockedTargetIP(ip netip.Addr) bool {
+	if !ip.IsValid() {
+		// Fail closed: refuse anything that cannot be classified.
+		return true
+	}
+	// Fold ::ffff:a.b.c.d to its IPv4 form and drop any IPv6 zone so mapped or
+	// zoned encodings of a blocked address cannot slip past the checks below.
+	ip = ip.Unmap().WithZone("")
+	if isBlockedAddr(ip) {
+		return true
+	}
+	// Re-check any IPv4 embedded in an IPv6 transition address so a blocked
+	// IPv4 target cannot be laundered through a NAT64/6to4/Teredo gateway.
+	if v4, ok := embeddedTransitionIPv4(ip); ok && isBlockedAddr(v4) {
+		return true
+	}
+	return false
+}
+
+// isBlockedAddr applies the core policy to a single already-unmapped address:
+// link-local, unspecified, or a known cloud metadata IP.
+func isBlockedAddr(ip netip.Addr) bool {
+	if ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() {
+		return true
+	}
+	_, blocked := extraBlockedMetadataIPs[ip]
+	return blocked
+}
+
+// embeddedTransitionIPv4 returns the IPv4 address embedded in an IPv6 transition
+// address (NAT64 64:ff9b::/96, 6to4 2002::/16, or Teredo 2001:0000::/32), and
+// false when ip carries none. ip is expected to have been Unmap-ed already, so
+// plain IPv4-mapped addresses are not handled here.
+func embeddedTransitionIPv4(ip netip.Addr) (netip.Addr, bool) {
+	if !ip.Is6() {
+		return netip.Addr{}, false
+	}
+	b := ip.As16()
+	switch {
+	case nat64Prefix.Contains(ip):
+		// Last 4 bytes carry the IPv4 address.
+		return netip.AddrFrom4([4]byte{b[12], b[13], b[14], b[15]}), true
+	case b[0] == 0x20 && b[1] == 0x02:
+		// 6to4 2002:AABB:CCDD::/16: bytes 2..5 carry the IPv4 address.
+		return netip.AddrFrom4([4]byte{b[2], b[3], b[4], b[5]}), true
+	case teredoPrefix.Contains(ip):
+		// Teredo: the client IPv4 is the last 4 bytes, bit-inverted.
+		return netip.AddrFrom4([4]byte{^b[12], ^b[13], ^b[14], ^b[15]}), true
+	}
+	return netip.Addr{}, false
+}
+
+// newGuardedDialContext returns a DialContext that resolves the destination
+// host, refuses any resolved IP blocked by isBlockedTargetIP, and dials a
+// validated IP literal directly. Dialing the resolved IP (rather than the
+// hostname) closes the DNS-rebinding window: the address that was validated is
+// the exact address that is connected to.
+//
+// The guard is re-entered on every dial the transport makes, so HTTP redirects
+// to a blocked target are refused as well.
+func newGuardedDialContext(base *net.Dialer) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid dial address %q: %w", addr, err)
+		}
+
+		ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+		if err != nil {
+			return nil, fmt.Errorf("DNS lookup failed for %q: %w", host, err)
+		}
+
+		var lastErr error
+		for i := range ips {
+			addrSlice, ok := netip.AddrFromSlice(ips[i].IP)
+			if !ok {
+				continue
+			}
+			if isBlockedTargetIP(addrSlice) {
+				lastErr = fmt.Errorf("%w: %s", ErrBlockedTarget, ips[i].IP.String())
+				continue
+			}
+			conn, dialErr := base.DialContext(ctx, network, net.JoinHostPort(ips[i].IP.String(), port))
+			if dialErr != nil {
+				lastErr = dialErr
+				continue
+			}
+			return conn, nil
+		}
+		if lastErr != nil {
+			return nil, lastErr
+		}
+		return nil, fmt.Errorf("no address to connect to for host %q", host)
+	}
+}

--- a/internal/httpclient/ssrf.go
+++ b/internal/httpclient/ssrf.go
@@ -101,6 +101,11 @@ func embeddedTransitionIPv4(ip netip.Addr) (netip.Addr, bool) {
 	case teredoPrefix.Contains(ip):
 		// Teredo: the client IPv4 is the last 4 bytes, bit-inverted.
 		return netip.AddrFrom4([4]byte{^b[12], ^b[13], ^b[14], ^b[15]}), true
+	case [12]byte(b[:12]) == [12]byte{} && !ip.IsUnspecified() && !ip.IsLoopback():
+		// ::a.b.c.d IPv4-compatible IPv6 (deprecated, RFC 4291). The leading 12
+		// bytes are zero and the last 4 carry the IPv4 address. ::ffff:a.b.c.d
+		// was already folded by Unmap, and ::/:: 1 are excluded above.
+		return netip.AddrFrom4([4]byte{b[12], b[13], b[14], b[15]}), true
 	}
 	return netip.Addr{}, false
 }
@@ -130,6 +135,19 @@ func newGuardedDialContext(base *net.Dialer) func(ctx context.Context, network, 
 			addrSlice, ok := netip.AddrFromSlice(ips[i].IP)
 			if !ok {
 				continue
+			}
+			// Honor a family-specific network so an address of the wrong family
+			// is skipped rather than handed to the base dialer as a doomed dial.
+			// http.Transport uses "tcp" today, so this is normally a no-op.
+			switch network {
+			case "tcp4":
+				if !addrSlice.Unmap().Is4() {
+					continue
+				}
+			case "tcp6":
+				if addrSlice.Unmap().Is4() {
+					continue
+				}
 			}
 			if isBlockedTargetIP(addrSlice) {
 				lastErr = fmt.Errorf("%w: %s", ErrBlockedTarget, ips[i].IP.String())

--- a/internal/httpclient/ssrf_test.go
+++ b/internal/httpclient/ssrf_test.go
@@ -1,0 +1,147 @@
+package httpclient
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+)
+
+func TestIsBlockedTargetIP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		ip      string
+		blocked bool
+	}{
+		// Blocked: link-local (covers 169.254.169.254 cloud metadata).
+		{"aws/gcp/azure metadata", "169.254.169.254", true},
+		{"link-local unicast v4", "169.254.10.5", true},
+		{"link-local unicast v6", "fe80::1", true},
+		{"ipv4-mapped metadata", "::ffff:169.254.169.254", true},
+		{"alibaba metadata", "100.100.100.200", true},
+		{"aws imds ipv6", "fd00:ec2::254", true},
+		{"unspecified v4", "0.0.0.0", true},
+		{"unspecified v6", "::", true},
+
+		// Blocked: link-local metadata smuggled through IPv6 transition ranges.
+		{"nat64 metadata", "64:ff9b::a9fe:a9fe", true}, // embeds 169.254.169.254
+		{"6to4 metadata", "2002:a9fe:a9fe::", true},    // embeds 169.254.169.254
+		{"teredo metadata", "2001::5601:5601", true},   // client IPv4 inverts to 169.254.169.254
+
+		// Allowed: loopback and private ranges (on-LAN webhook targets).
+		{"loopback v4", "127.0.0.1", false},
+		{"loopback v6", "::1", false},
+		{"rfc1918 10.x", "10.0.0.1", false},
+		{"rfc1918 192.168.x", "192.168.1.10", false},
+		{"rfc1918 172.16.x", "172.16.5.4", false},
+		{"cgnat non-metadata", "100.64.0.1", false},
+		{"ula non-metadata", "fd12:3456:789a::1", false},
+		{"nat64 public", "64:ff9b::808:808", false}, // embeds 8.8.8.8, allowed
+		{"public v4", "8.8.8.8", false},
+		{"public v6", "2606:4700:4700::1111", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			addr, err := netip.ParseAddr(tt.ip)
+			require.NoError(t, err)
+			assert.Equal(t, tt.blocked, isBlockedTargetIP(addr))
+		})
+	}
+}
+
+// TestGuardedClientAllowsLoopback verifies the guard permits loopback so a
+// webhook can reach a service on the local host (the policy intentionally
+// allows loopback and RFC1918).
+func TestGuardedClientAllowsLoopback(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := DefaultConfig()
+	cfg.BlockLinkLocalAndMetadata = true
+	client := New(&cfg)
+	t.Cleanup(client.Close)
+
+	resp, err := client.Get(t.Context(), srv.URL)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestGuardedClientBlocksMetadataLiteral verifies a direct request to the cloud
+// metadata address is refused at dial time with ErrBlockedTarget.
+func TestGuardedClientBlocksMetadataLiteral(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultConfig()
+	cfg.BlockLinkLocalAndMetadata = true
+	client := New(&cfg)
+	t.Cleanup(client.Close)
+
+	resp, err := client.Get(t.Context(), "http://169.254.169.254/latest/meta-data/")
+	if resp != nil {
+		t.Cleanup(func() { _ = resp.Body.Close() })
+	}
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrBlockedTarget), "expected ErrBlockedTarget, got %v", err)
+}
+
+// TestGuardedClientBlocksRedirectToMetadata verifies the guard re-applies on
+// redirects: a loopback server that 302s to the metadata endpoint must not be
+// followed to the blocked target.
+func TestGuardedClientBlocksRedirectToMetadata(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://169.254.169.254/latest/meta-data/", http.StatusFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := DefaultConfig()
+	cfg.BlockLinkLocalAndMetadata = true
+	client := New(&cfg)
+	t.Cleanup(client.Close)
+
+	resp, err := client.Get(t.Context(), srv.URL)
+	if resp != nil {
+		t.Cleanup(func() { _ = resp.Body.Close() })
+	}
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrBlockedTarget), "expected ErrBlockedTarget on redirect, got %v", err)
+}
+
+// TestUnguardedClientDoesNotUseGuard confirms the guard is opt-in: without the
+// flag the dialer applies no SSRF policy. It targets 192.0.2.1 (RFC 5737
+// TEST-NET-1, guaranteed unrouted and never a live service) with a short
+// timeout, so the dial fails locally rather than hanging. Crucially it does NOT
+// target a real metadata address: on a cloud CI runner 169.254.169.254 would
+// answer and make the assertion flaky. Whatever the outcome, the error must not
+// be an SSRF-policy block.
+func TestUnguardedClientDoesNotUseGuard(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultConfig()
+	// BlockLinkLocalAndMetadata left false.
+	cfg.DefaultTimeout = 500 * time.Millisecond
+	client := New(&cfg)
+	t.Cleanup(client.Close)
+
+	resp, err := client.Get(t.Context(), "http://192.0.2.1/")
+	if resp != nil {
+		t.Cleanup(func() { _ = resp.Body.Close() })
+	}
+	assert.False(t, errors.Is(err, ErrBlockedTarget), "unguarded client must not apply the SSRF policy")
+}

--- a/internal/httpclient/ssrf_test.go
+++ b/internal/httpclient/ssrf_test.go
@@ -32,9 +32,10 @@ func TestIsBlockedTargetIP(t *testing.T) {
 		{"unspecified v6", "::", true},
 
 		// Blocked: link-local metadata smuggled through IPv6 transition ranges.
-		{"nat64 metadata", "64:ff9b::a9fe:a9fe", true}, // embeds 169.254.169.254
-		{"6to4 metadata", "2002:a9fe:a9fe::", true},    // embeds 169.254.169.254
-		{"teredo metadata", "2001::5601:5601", true},   // client IPv4 inverts to 169.254.169.254
+		{"nat64 metadata", "64:ff9b::a9fe:a9fe", true},    // embeds 169.254.169.254
+		{"6to4 metadata", "2002:a9fe:a9fe::", true},       // embeds 169.254.169.254
+		{"teredo metadata", "2001::5601:5601", true},      // client IPv4 inverts to 169.254.169.254
+		{"ipv4-compatible metadata", "::a9fe:a9fe", true}, // deprecated ::a.b.c.d embeds 169.254.169.254
 
 		// Allowed: loopback and private ranges (on-LAN webhook targets).
 		{"loopback v4", "127.0.0.1", false},
@@ -44,7 +45,8 @@ func TestIsBlockedTargetIP(t *testing.T) {
 		{"rfc1918 172.16.x", "172.16.5.4", false},
 		{"cgnat non-metadata", "100.64.0.1", false},
 		{"ula non-metadata", "fd12:3456:789a::1", false},
-		{"nat64 public", "64:ff9b::808:808", false}, // embeds 8.8.8.8, allowed
+		{"nat64 public", "64:ff9b::808:808", false},    // embeds 8.8.8.8, allowed
+		{"ipv4-compatible public", "::808:808", false}, // ::8.8.8.8, allowed
 		{"public v4", "8.8.8.8", false},
 		{"public v6", "2606:4700:4700::1111", false},
 	}
@@ -121,6 +123,30 @@ func TestGuardedClientBlocksRedirectToMetadata(t *testing.T) {
 	}
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrBlockedTarget), "expected ErrBlockedTarget on redirect, got %v", err)
+}
+
+// TestGuardedClientIgnoresProxyForMetadata confirms a configured environment
+// proxy cannot be used to bypass the guard: enabling the guard disables proxy
+// support, so a metadata request is still blocked at dial time rather than
+// tunneled through the proxy. Not parallel: it sets a process env var.
+func TestGuardedClientIgnoresProxyForMetadata(t *testing.T) {
+	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:1/")
+	t.Setenv("HTTP_PROXY", "http://127.0.0.1:1/")
+
+	cfg := DefaultConfig()
+	cfg.BlockLinkLocalAndMetadata = true
+	cfg.DefaultTimeout = 2 * time.Second
+	client := New(&cfg)
+	t.Cleanup(client.Close)
+
+	// Uses https so a live proxy would be reached via CONNECT; with the guard
+	// enabled the proxy is disabled and the metadata IP is blocked directly.
+	resp, err := client.Get(t.Context(), "https://169.254.169.254/latest/meta-data/")
+	if resp != nil {
+		t.Cleanup(func() { _ = resp.Body.Close() })
+	}
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrBlockedTarget), "expected ErrBlockedTarget with proxy set, got %v", err)
 }
 
 // TestUnguardedClientDoesNotUseGuard confirms the guard is opt-in: without the

--- a/internal/notification/push_webhook.go
+++ b/internal/notification/push_webhook.go
@@ -51,9 +51,6 @@ const (
 	// defaultWebhookTimeout is the default timeout for webhook HTTP requests
 	defaultWebhookTimeout = 30 * time.Second
 
-	// maxErrorBodySize limits error response body reading to prevent memory issues
-	maxErrorBodySize = 1024
-
 	// Webhook authentication type constants
 	authTypeNone   = "none"
 	authTypeBearer = "bearer"
@@ -224,6 +221,10 @@ func NewWebhookProvider(name string, enabled bool, endpoints []WebhookEndpoint, 
 	cfg := httpclient.DefaultConfig()
 	cfg.UserAgent = "BirdNET-Go-Webhook/1.0"
 	cfg.DefaultTimeout = defaultWebhookTimeout
+	// Refuse link-local and cloud metadata targets (e.g. 169.254.169.254) at
+	// dial time. RFC1918 and loopback stay reachable so on-LAN webhook targets
+	// keep working. See httpclient/ssrf.go.
+	cfg.BlockLinkLocalAndMetadata = true
 	wp.client = httpclient.New(&cfg)
 
 	return wp, nil
@@ -550,9 +551,13 @@ func (w *WebhookProvider) sendToEndpoint(ctx context.Context, endpoint *WebhookE
 
 	// Check response status
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		// Read error response body for better diagnostics
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
-		httpErr := errors.Newf("webhook returned status %d: %s", resp.StatusCode, string(body)).Component("notification").Category(errors.CategoryNetwork).Context("status_code", resp.StatusCode).Build()
+		// Deliberately do NOT read or log the response body. A webhook URL is
+		// operator-configured and can point at an internal service, so echoing
+		// the upstream body into the error (which reaches logs and telemetry)
+		// would leak that service's response. The status code is enough to
+		// diagnose a delivery failure. The deferred drain above still empties
+		// the body so the connection can be reused.
+		httpErr := errors.Newf("webhook returned status %d", resp.StatusCode).Component("notification").Category(errors.CategoryNetwork).Context("status_code", resp.StatusCode).Build()
 
 		// Report telemetry for HTTP errors
 		if w.telemetry != nil {


### PR DESCRIPTION
## Summary

Webhook notification endpoints are operator-configured URLs, and the outbound requests carried no IP validation, so a configured URL could reach link-local and cloud metadata addresses (169.254.169.254 and friends) or other hosts reachable from the BirdNET-Go host. This adds a dial-time guard so the webhook provider cannot be pointed at those targets, while keeping ordinary LAN delivery working.

The guard lives in `internal/httpclient` as an opt-in `Config.BlockLinkLocalAndMetadata` flag and is enabled only for the webhook provider. When on, the dialer resolves the destination, refuses link-local, unspecified, and known cloud metadata IPs, then dials the validated IP literal directly so a hostname cannot rebind to a blocked address between validation and connect. It also decodes IPv4 embedded in IPv6 transition addresses (NAT64, 6to4, Teredo) so a blocked IPv4 cannot be smuggled through a translation gateway, and folds IPv4-mapped IPv6 first.

Loopback and private RFC1918 / ULA ranges stay reachable on purpose. BirdNET-Go's common webhook use is a service on the user's own LAN (Home Assistant, a local ntfy, a NAS), so blocking those would break the normal case. The guard closes the cloud-metadata exfiltration path without disturbing on-LAN delivery, and it re-applies on HTTP redirects.

Separately, the webhook status-error path no longer echoes the upstream response body into the returned error. That error reaches logs and telemetry, so echoing an internal service's response could leak it even when the target IP is allowed.

Other `httpclient` callers are unaffected: the flag defaults off, and the only production caller that enables it is the webhook provider.

## Behavioral note

A webhook explicitly pointed at a link-local or cloud metadata address now fails at dial time by design. Loopback and RFC1918 targets are unchanged.

## Test Plan

- [x] `go test -race ./internal/httpclient/... ./internal/notification/...`
- [x] `golangci-lint run` on the changed packages (0 issues)
- [x] Table tests cover link-local, IPv4-mapped, NAT64/6to4/Teredo, AWS IPv6 IMDS, Alibaba metadata, unspecified, plus loopback/RFC1918/CGNAT/public allowed cases
- [x] Integration tests: guard allows loopback, blocks a metadata literal, blocks a redirect to metadata, and is a no-op when disabled

Credit: tonghuaroot for reporting the missing outbound IP validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional protection setting that blocks requests to link-local and cloud metadata destinations.
  * Protection also applies when requests are redirected, helping prevent unsafe destination access.
* **Bug Fixes**
  * Webhook requests now enforce destination protections while continuing to support loopback and private network addresses.
  * Webhook error messages no longer expose upstream response bodies; connections remain reusable.
* **Tests**
  * Added coverage for blocked destinations, permitted network ranges, redirects, and default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->