### PR TITLE
fix(analysis,datastore): key dynamic thresholds by species, not model label

### DIFF
--- a/internal/analysis/database_migration.go
+++ b/internal/analysis/database_migration.go
@@ -85,7 +85,7 @@ func setupMigrationWorker(cfg *migrationSetupConfig) error {
 	// Create repositories for auxiliary data migration
 	weatherRepo := repository.NewWeatherRepository(v2DB, nil, cfg.useV2Prefix, isMySQL)
 	imageCacheRepo := repository.NewImageCacheRepository(v2DB, nil, labelRepo, cfg.useV2Prefix, isMySQL)
-	thresholdRepo := repository.NewDynamicThresholdRepository(v2DB, nil, labelRepo, cfg.useV2Prefix, isMySQL)
+	thresholdRepo := repository.NewDynamicThresholdRepository(v2DB, nil, cfg.useV2Prefix, isMySQL)
 	notificationRepo := repository.NewNotificationHistoryRepository(v2DB, nil, labelRepo, cfg.useV2Prefix, isMySQL)
 
 	// Create the legacy detection repository
@@ -500,7 +500,7 @@ func initializeV2OnlyMode(settings *conf.Settings) (*v2only.Datastore, error) {
 	sourceRepo := repository.NewAudioSourceRepository(v2DB, nil, useV2Prefix, isMySQL)
 	weatherRepo := repository.NewWeatherRepository(v2DB, nil, useV2Prefix, isMySQL)
 	imageCacheRepo := repository.NewImageCacheRepository(v2DB, nil, labelRepo, useV2Prefix, isMySQL)
-	thresholdRepo := repository.NewDynamicThresholdRepository(v2DB, nil, labelRepo, useV2Prefix, isMySQL)
+	thresholdRepo := repository.NewDynamicThresholdRepository(v2DB, nil, useV2Prefix, isMySQL)
 	notificationRepo := repository.NewNotificationHistoryRepository(v2DB, nil, labelRepo, useV2Prefix, isMySQL)
 	appEventRepo := repository.NewAppEventRepository(v2DB, nil, useV2Prefix, isMySQL)
 
@@ -525,7 +525,7 @@ func initializeV2OnlyMode(settings *conf.Settings) (*v2only.Datastore, error) {
 		AppEvent:       appEventRepo,
 		Logger:         log,
 		Timezone:       time.Local,
-		Labels:         settings.BirdNET.Labels, // For GetThresholdEvents workaround (#1907)
+		Labels:         settings.BirdNET.Labels, // For common<->scientific name-map resolution
 		SpeciesCodeMap: scientificIndex,
 	})
 	if err != nil {

--- a/internal/analysis/processor/dynamic_threshold.go
+++ b/internal/analysis/processor/dynamic_threshold.go
@@ -42,6 +42,13 @@ type DynamicThreshold struct {
 	BaseThreshold  float64
 	ScientificName string
 	LastLearnedAt  time.Time // Tracks when the last threshold learning event occurred to prevent multiple learnings within a single detection window
+	// FirstCreated records when this species threshold was first initialized. Persisted
+	// once and never overwritten on re-flush, so it reflects true creation time (#4195).
+	FirstCreated time.Time
+	// LastTriggered records the last time an approved high-confidence detection reinforced
+	// this threshold; initialized to the creation time. Persisted so the stored value
+	// reflects a real trigger rather than the periodic flush time (#4195).
+	LastTriggered time.Time
 }
 
 // effectiveDynamicThreshold computes the applied threshold from a model-specific
@@ -58,6 +65,13 @@ func effectiveDynamicThreshold(base float64, level int, minThreshold float64) fl
 
 // addSpeciesToDynamicThresholds adds a species to the dynamic thresholds map if it doesn't already exist.
 func (p *Processor) addSpeciesToDynamicThresholds(speciesLowercase, scientificName string, baseThreshold float32) {
+	// The species (lowercase common name) is the identity key, in memory and when
+	// persisted (#4195). Never admit an empty key: it cannot be persisted and would
+	// simulate learning for a phantom species that silently consumes memory.
+	if speciesLowercase == "" {
+		return
+	}
+
 	settings := p.currentSettings()
 
 	// Lock the mutex to ensure thread-safe access to the DynamicThresholds map
@@ -73,13 +87,16 @@ func (p *Processor) addSpeciesToDynamicThresholds(speciesLowercase, scientificNa
 			log := GetLogger()
 			log.Debug("Initializing dynamic threshold", logger.String("species", speciesLowercase))
 		}
+		now := time.Now()
 		p.DynamicThresholds[speciesLowercase] = &DynamicThreshold{
 			Level:          0,
 			BaseThreshold:  float64(baseThreshold),
-			Timer:          time.Now(),
+			Timer:          now,
 			HighConfCount:  0,
 			ValidHours:     settings.Realtime.DynamicThreshold.ValidHours,
 			ScientificName: scientificName,
+			FirstCreated:   now,
+			LastTriggered:  now,
 		}
 	} else if existing.ScientificName == "" && scientificName != "" {
 		// Update scientific name if it was missing
@@ -138,9 +155,9 @@ func (p *Processor) getAdjustedConfidenceThreshold(speciesLowercase string, base
 	return float32(effectiveDynamicThreshold(float64(baseThreshold), dt.Level, minThreshold))
 }
 
-// recordThresholdEvent saves a threshold change event to the database (BG-59)
-// scientificName is required for v2only datastore to correctly resolve the Label FK.
-// See issue #1907 for context on why both names are needed.
+// recordThresholdEvent saves a threshold change event to the database (BG-59).
+// Events are keyed by species (lowercase common name); scientificName is stored as
+// display metadata only, not used to resolve any model/label (#4195).
 func (p *Processor) recordThresholdEvent(speciesName, scientificName string, previousLevel, newLevel int, previousValue, newValue float64, changeReason string, confidence float64) {
 	if p.Ds == nil {
 		return
@@ -148,7 +165,7 @@ func (p *Processor) recordThresholdEvent(speciesName, scientificName string, pre
 
 	event := &datastore.ThresholdEvent{
 		SpeciesName:    speciesName,
-		ScientificName: scientificName, // Used by v2only for correct label resolution (#1907)
+		ScientificName: scientificName, // display metadata only (#4195)
 		PreviousLevel:  previousLevel,
 		NewLevel:       newLevel,
 		PreviousValue:  previousValue,
@@ -243,6 +260,7 @@ func (p *Processor) LearnFromApprovedDetection(speciesLowercase, scientificName 
 
 	dt.HighConfCount++
 	dt.LastLearnedAt = now
+	dt.LastTriggered = now // real trigger time, persisted instead of the flush time (#4195)
 
 	// Adjust the dynamic threshold based on the number of high-confidence detections
 	switch dt.HighConfCount {
@@ -284,8 +302,10 @@ func (p *Processor) updateDynamicThreshold(modelID, commonName string, confidenc
 		// Check if the species already has a dynamic threshold. The entry is keyed
 		// per species; modelID still selects the model-specific base to compare the
 		// detection confidence against before extending the timer.
-		// Note: scientific name not available in this context, but common name lookup is sufficient
-		if dt, exists := p.DynamicThresholds[commonName]; exists && confidence > float64(p.getBaseConfidenceThreshold(settings, commonName, "", modelID)) {
+		// Note: scientific name not available in this context, but common name lookup is sufficient.
+		// Lowercase the key to match how entries are stored (addSpeciesToDynamicThresholds);
+		// otherwise a title-cased common name misses and the timer is never extended.
+		if dt, exists := p.DynamicThresholds[strings.ToLower(commonName)]; exists && confidence > float64(p.getBaseConfidenceThreshold(settings, commonName, "", modelID)) {
 			// Update the timer to extend the threshold's validity
 			// Note: dt is a pointer, so this directly mutates the struct in the map
 			dt.Timer = time.Now().Add(time.Duration(dt.ValidHours) * time.Hour)
@@ -458,6 +478,9 @@ func (p *Processor) GetDynamicThresholdData() []DynamicThresholdData {
 			BaseThreshold:  dt.BaseThreshold,
 			HighConfCount:  dt.HighConfCount,
 			ExpiresAt:      dt.Timer,
+			FirstCreated:   dt.FirstCreated,
+			LastTriggered:  dt.LastTriggered,
+			TriggerCount:   dt.HighConfCount,
 			IsActive:       dt.Timer.After(now),
 		})
 	}
@@ -474,6 +497,9 @@ type DynamicThresholdData struct {
 	BaseThreshold  float64   `json:"baseThreshold"` // model-global base of the model that last learned (display only)
 	HighConfCount  int       `json:"highConfCount"`
 	ExpiresAt      time.Time `json:"expiresAt"`
+	FirstCreated   time.Time `json:"firstCreated"`  // real creation time (#4195)
+	LastTriggered  time.Time `json:"lastTriggered"` // real last-trigger time (#4195)
+	TriggerCount   int       `json:"triggerCount"`
 	IsActive       bool      `json:"isActive"`
 }
 

--- a/internal/analysis/processor/threshold_persistence.go
+++ b/internal/analysis/processor/threshold_persistence.go
@@ -137,10 +137,13 @@ func (p *Processor) convertThresholdsForPersistence(settings *conf.Settings) (db
 
 	for speciesName, threshold := range p.DynamicThresholds {
 		// The species (lowercase common name) is the persistence key. An empty key
-		// cannot be stored; skip it rather than aborting the whole batch (#4195).
+		// cannot be stored; route it into the eviction path instead of only skipping,
+		// so a stray entry cannot linger in memory forever unpersisted. This is defense
+		// in depth: addSpeciesToDynamicThresholds already rejects empty keys (#4195).
 		if speciesName == "" {
-			GetLogger().Warn("Skipping dynamic threshold with empty species key during persistence",
+			GetLogger().Warn("Evicting dynamic threshold with empty species key during persistence",
 				logger.String("operation", "persist_dynamic_thresholds"))
+			expiredSpecies = append(expiredSpecies, speciesName)
 			continue
 		}
 

--- a/internal/analysis/processor/threshold_persistence.go
+++ b/internal/analysis/processor/threshold_persistence.go
@@ -95,6 +95,8 @@ func (p *Processor) loadDynamicThresholdsFromDB() error {
 			HighConfCount:  dbThreshold.HighConfCount,
 			ValidHours:     dbThreshold.ValidHours,
 			ScientificName: dbThreshold.ScientificName,
+			FirstCreated:   dbThreshold.FirstCreated,
+			LastTriggered:  dbThreshold.LastTriggered,
 		}
 		loadedCount++
 
@@ -134,6 +136,14 @@ func (p *Processor) convertThresholdsForPersistence(settings *conf.Settings) (db
 	minThreshold := settings.Realtime.DynamicThreshold.Min
 
 	for speciesName, threshold := range p.DynamicThresholds {
+		// The species (lowercase common name) is the persistence key. An empty key
+		// cannot be stored; skip it rather than aborting the whole batch (#4195).
+		if speciesName == "" {
+			GetLogger().Warn("Skipping dynamic threshold with empty species key during persistence",
+				logger.String("operation", "persist_dynamic_thresholds"))
+			continue
+		}
+
 		if now.After(threshold.Timer) {
 			expiredSpecies = append(expiredSpecies, speciesName)
 			if settings.Realtime.DynamicThreshold.Debug {
@@ -145,6 +155,18 @@ func (p *Processor) convertThresholdsForPersistence(settings *conf.Settings) (db
 			continue
 		}
 
+		// Preserve the real per-entry timestamps instead of stamping the flush time,
+		// so first_created/last_triggered reflect actual events (#4195). Fall back to
+		// now for entries created before these fields existed.
+		firstCreated := threshold.FirstCreated
+		if firstCreated.IsZero() {
+			firstCreated = now
+		}
+		lastTriggered := threshold.LastTriggered
+		if lastTriggered.IsZero() {
+			lastTriggered = firstCreated
+		}
+
 		dbThresholds = append(dbThresholds, datastore.DynamicThreshold{
 			SpeciesName:    speciesName,
 			ScientificName: threshold.ScientificName,
@@ -154,8 +176,8 @@ func (p *Processor) convertThresholdsForPersistence(settings *conf.Settings) (db
 			HighConfCount:  threshold.HighConfCount,
 			ValidHours:     threshold.ValidHours,
 			ExpiresAt:      threshold.Timer,
-			LastTriggered:  now,
-			FirstCreated:   now,
+			LastTriggered:  lastTriggered,
+			FirstCreated:   firstCreated,
 			UpdatedAt:      now,
 			TriggerCount:   threshold.HighConfCount,
 		})

--- a/internal/analysis/processor/threshold_persistence_test.go
+++ b/internal/analysis/processor/threshold_persistence_test.go
@@ -899,6 +899,7 @@ func TestDrainPendingResetsRequeuesOnFailure(t *testing.T) {
 // FirstCreated/LastTriggered from the in-memory struct instead of stamping the flush time,
 // falls back to now for zero values, and skips empty-species keys without aborting.
 func TestConvertThresholdsForPersistence_PreservesTimestamps(t *testing.T) {
+	t.Parallel()
 	p := createTestProcessor()
 	settings := p.currentSettings()
 
@@ -916,15 +917,16 @@ func TestConvertThresholdsForPersistence_PreservesTimestamps(t *testing.T) {
 		FirstCreated:   firstCreated,
 		LastTriggered:  lastTriggered,
 	}
-	// An empty-key entry must be skipped, not persisted, and must not abort the batch.
+	// An empty-key entry must not be persisted, must not abort the batch, and must be
+	// routed into the eviction path so it cannot linger in memory forever.
 	p.DynamicThresholds[""] = &DynamicThreshold{
 		Level: 1, Timer: future, ValidHours: 48, FirstCreated: firstCreated, LastTriggered: lastTriggered,
 	}
 
 	dbThresholds, expired := p.convertThresholdsForPersistence(settings)
 
-	require.Empty(t, expired)
-	require.Len(t, dbThresholds, 1, "empty-key entry must be skipped")
+	require.Len(t, dbThresholds, 1, "empty-key entry must not be persisted")
+	assert.Equal(t, []string{""}, expired, "empty-key entry must be routed to eviction")
 	got := dbThresholds[0]
 	assert.Equal(t, "american crow", got.SpeciesName)
 	// The flush time is now; the real values are hours in the past, so a regression that
@@ -936,6 +938,7 @@ func TestConvertThresholdsForPersistence_PreservesTimestamps(t *testing.T) {
 // TestConvertThresholdsForPersistence_ZeroTimestampFallback verifies that an in-memory
 // entry with zero FirstCreated/LastTriggered falls back to now (never persisted as zero).
 func TestConvertThresholdsForPersistence_ZeroTimestampFallback(t *testing.T) {
+	t.Parallel()
 	p := createTestProcessor()
 	p.DynamicThresholds["blue jay"] = &DynamicThreshold{
 		Level: 1, BaseThreshold: 0.7, Timer: time.Now().Add(24 * time.Hour), ValidHours: 48,

--- a/internal/analysis/processor/threshold_persistence_test.go
+++ b/internal/analysis/processor/threshold_persistence_test.go
@@ -893,3 +893,58 @@ func TestDrainPendingResetsRequeuesOnFailure(t *testing.T) {
 			"pendingResets should remain empty after successful reset-all")
 	})
 }
+
+// TestConvertThresholdsForPersistence_PreservesTimestamps verifies the #4195 timestamp
+// fix at the processor layer: convertThresholdsForPersistence copies the real per-entry
+// FirstCreated/LastTriggered from the in-memory struct instead of stamping the flush time,
+// falls back to now for zero values, and skips empty-species keys without aborting.
+func TestConvertThresholdsForPersistence_PreservesTimestamps(t *testing.T) {
+	p := createTestProcessor()
+	settings := p.currentSettings()
+
+	firstCreated := time.Now().Add(-72 * time.Hour)
+	lastTriggered := time.Now().Add(-90 * time.Minute)
+	future := time.Now().Add(24 * time.Hour)
+
+	p.DynamicThresholds["american crow"] = &DynamicThreshold{
+		Level:          2,
+		BaseThreshold:  0.7,
+		Timer:          future,
+		HighConfCount:  3,
+		ValidHours:     48,
+		ScientificName: "Corvus brachyrhynchos",
+		FirstCreated:   firstCreated,
+		LastTriggered:  lastTriggered,
+	}
+	// An empty-key entry must be skipped, not persisted, and must not abort the batch.
+	p.DynamicThresholds[""] = &DynamicThreshold{
+		Level: 1, Timer: future, ValidHours: 48, FirstCreated: firstCreated, LastTriggered: lastTriggered,
+	}
+
+	dbThresholds, expired := p.convertThresholdsForPersistence(settings)
+
+	require.Empty(t, expired)
+	require.Len(t, dbThresholds, 1, "empty-key entry must be skipped")
+	got := dbThresholds[0]
+	assert.Equal(t, "american crow", got.SpeciesName)
+	// The flush time is now; the real values are hours in the past, so a regression that
+	// stamped now (the #4195 bug) would fail these tight bounds.
+	assert.WithinDuration(t, firstCreated, got.FirstCreated, time.Second, "FirstCreated must be the real per-entry value, not the flush time")
+	assert.WithinDuration(t, lastTriggered, got.LastTriggered, time.Second, "LastTriggered must be the real per-entry value, not the flush time")
+}
+
+// TestConvertThresholdsForPersistence_ZeroTimestampFallback verifies that an in-memory
+// entry with zero FirstCreated/LastTriggered falls back to now (never persisted as zero).
+func TestConvertThresholdsForPersistence_ZeroTimestampFallback(t *testing.T) {
+	p := createTestProcessor()
+	p.DynamicThresholds["blue jay"] = &DynamicThreshold{
+		Level: 1, BaseThreshold: 0.7, Timer: time.Now().Add(24 * time.Hour), ValidHours: 48,
+	}
+
+	dbThresholds, _ := p.convertThresholdsForPersistence(p.currentSettings())
+	require.Len(t, dbThresholds, 1)
+	got := dbThresholds[0]
+	assert.False(t, got.FirstCreated.IsZero(), "zero FirstCreated must fall back to now")
+	assert.WithinDuration(t, time.Now(), got.FirstCreated, 5*time.Second)
+	assert.Equal(t, got.FirstCreated, got.LastTriggered, "zero LastTriggered falls back to FirstCreated")
+}

--- a/internal/api/v2/dynamicthresholds/dynamicthresholds.go
+++ b/internal/api/v2/dynamicthresholds/dynamicthresholds.go
@@ -140,15 +140,24 @@ func (c *Handler) requireProcessor(ctx echo.Context) (*processor.Processor, erro
 // applyMemoryOverlay updates a threshold response with in-memory data.
 // This centralizes the logic for overlaying current processor state onto
 // database records, ensuring API responses reflect the most current state.
-func applyMemoryOverlay(response *DynamicThresholdResponse, level, highConfCount int, currentValue float64, expiresAt time.Time, isActive bool, scientificName string) {
-	response.Level = level
-	response.CurrentValue = currentValue
-	response.HighConfCount = highConfCount
-	response.ExpiresAt = expiresAt
-	response.IsActive = isActive
+func applyMemoryOverlay(response *DynamicThresholdResponse, md *processor.DynamicThresholdData) {
+	response.Level = md.Level
+	response.CurrentValue = md.CurrentValue
+	response.HighConfCount = md.HighConfCount
+	response.ExpiresAt = md.ExpiresAt
+	response.IsActive = md.IsActive
+	// Real per-entry timestamps and trigger count from memory (#4195); non-zero only
+	// once the fields have been populated by learning, so keep any DB value otherwise.
+	if !md.FirstCreated.IsZero() {
+		response.FirstCreated = md.FirstCreated
+	}
+	if !md.LastTriggered.IsZero() {
+		response.LastTriggered = md.LastTriggered
+	}
+	response.TriggerCount = md.TriggerCount
 	// Use scientific name from memory if it's missing in the database response.
-	if response.ScientificName == "" && scientificName != "" {
-		response.ScientificName = scientificName
+	if response.ScientificName == "" && md.ScientificName != "" {
+		response.ScientificName = md.ScientificName
 	}
 }
 
@@ -246,15 +255,16 @@ func (c *Handler) addMemoryThresholds(thresholdMap map[string]*DynamicThresholdR
 	}
 	memoryData := proc.GetDynamicThresholdData()
 
-	for _, dt := range memoryData {
+	for i := range memoryData {
+		dt := &memoryData[i]
 		key := strings.ToLower(dt.SpeciesName)
 		if existing, exists := thresholdMap[key]; exists {
 			// Update existing entry with in-memory values
-			applyMemoryOverlay(existing, dt.Level, dt.HighConfCount, dt.CurrentValue, dt.ExpiresAt, dt.IsActive, dt.ScientificName)
+			applyMemoryOverlay(existing, dt)
 		} else {
-			// Add new entry from memory. BaseThreshold and CurrentValue are derived
-			// from the model that last learned this species (display only); the
-			// applied threshold is computed live per model during detection.
+			// Add new entry from memory. BaseThreshold and CurrentValue are display-only
+			// (the base of whichever model last learned this species); the applied
+			// threshold is computed live per model during detection (#4173, #4195).
 			thresholdMap[key] = &DynamicThresholdResponse{
 				SpeciesName:    dt.SpeciesName,
 				ScientificName: dt.ScientificName,
@@ -263,6 +273,9 @@ func (c *Handler) addMemoryThresholds(thresholdMap map[string]*DynamicThresholdR
 				BaseThreshold:  dt.BaseThreshold,
 				HighConfCount:  dt.HighConfCount,
 				ExpiresAt:      dt.ExpiresAt,
+				FirstCreated:   dt.FirstCreated,
+				LastTriggered:  dt.LastTriggered,
+				TriggerCount:   dt.TriggerCount,
 				IsActive:       dt.IsActive,
 			}
 		}
@@ -339,9 +352,11 @@ func (c *Handler) GetDynamicThreshold(ctx echo.Context) error {
 	// Snapshot c.Processor to avoid a TOCTOU race between the nil check and usage.
 	proc := c.Processor
 	if proc != nil {
-		for _, md := range proc.GetDynamicThresholdData() {
+		memData := proc.GetDynamicThresholdData()
+		for i := range memData {
+			md := &memData[i]
 			if strings.EqualFold(md.SpeciesName, species) {
-				applyMemoryOverlay(&response, md.Level, md.HighConfCount, md.CurrentValue, md.ExpiresAt, md.IsActive, md.ScientificName)
+				applyMemoryOverlay(&response, md)
 				break
 			}
 		}

--- a/internal/datastore/v2/entities/dynamic_threshold.go
+++ b/internal/datastore/v2/entities/dynamic_threshold.go
@@ -3,22 +3,26 @@ package entities
 import "time"
 
 // DynamicThreshold stores learned detection thresholds.
-// LabelID links to the species label for normalized storage.
+//
+// Tracking is per species and model-independent (see #4173, #4195): the row is
+// keyed by SpeciesName (lowercase common name), the same key the processor uses
+// in memory. ScientificName is carried as display metadata only (thumbnails);
+// it is not part of the identity and may be empty. There is deliberately no
+// model/label foreign key: any model's high-confidence detection advances the
+// same species-level state.
 type DynamicThreshold struct {
-	ID            uint      `gorm:"primaryKey"`
-	LabelID       uint      `gorm:"uniqueIndex;not null"`
-	Level         int       `gorm:"not null;default:0"` // Adjustment level (0-3)
-	CurrentValue  float64   `gorm:"not null"`           // Current threshold value
-	BaseThreshold float64   `gorm:"not null"`           // Original base threshold for reference
-	HighConfCount int       `gorm:"not null;default:0"` // Count of high-confidence detections
-	ValidHours    int       `gorm:"not null"`           // Hours until expiry
-	ExpiresAt     time.Time `gorm:"index;not null"`     // When this threshold expires
-	LastTriggered time.Time `gorm:"index;not null"`     // Last time threshold was triggered
-	FirstCreated  time.Time `gorm:"not null"`           // When first created
-	TriggerCount  int       `gorm:"not null;default:0"` // Total number of times triggered
-	CreatedAt     time.Time `gorm:"autoCreateTime"`
-	UpdatedAt     time.Time `gorm:"autoUpdateTime"`
-
-	// Relationship
-	Label *Label `gorm:"foreignKey:LabelID"`
+	ID             uint      `gorm:"primaryKey"`
+	SpeciesName    string    `gorm:"uniqueIndex;not null;size:200"` // Lowercase common name (identity key)
+	ScientificName string    `gorm:"size:200"`                      // Display metadata only (thumbnails); may be empty
+	Level          int       `gorm:"not null;default:0"`            // Adjustment level (0-3)
+	CurrentValue   float64   `gorm:"not null"`                      // Current threshold value
+	BaseThreshold  float64   `gorm:"not null"`                      // Original base threshold for reference
+	HighConfCount  int       `gorm:"not null;default:0"`            // Count of high-confidence detections
+	ValidHours     int       `gorm:"not null"`                      // Hours until expiry
+	ExpiresAt      time.Time `gorm:"index;not null"`                // When this threshold expires
+	LastTriggered  time.Time `gorm:"index;not null"`                // Last time threshold was triggered
+	FirstCreated   time.Time `gorm:"not null"`                      // When first created
+	TriggerCount   int       `gorm:"not null;default:0"`            // Total number of times triggered
+	CreatedAt      time.Time `gorm:"autoCreateTime"`
+	UpdatedAt      time.Time `gorm:"autoUpdateTime"`
 }

--- a/internal/datastore/v2/entities/threshold_event.go
+++ b/internal/datastore/v2/entities/threshold_event.go
@@ -3,18 +3,19 @@ package entities
 import "time"
 
 // ThresholdEvent records threshold adjustment history.
-// LabelID links to the species label for normalized storage.
+//
+// Keyed by SpeciesName (lowercase common name), model-independent (see #4195).
+// ScientificName is display metadata only and may be empty; there is no
+// model/label foreign key.
 type ThresholdEvent struct {
-	ID            uint      `gorm:"primaryKey"`
-	LabelID       uint      `gorm:"index;not null"`
-	PreviousLevel int       `gorm:"not null"`         // Level before change
-	NewLevel      int       `gorm:"not null"`         // Level after change
-	PreviousValue float64   `gorm:"not null"`         // Threshold value before change
-	NewValue      float64   `gorm:"not null"`         // Threshold value after change
-	ChangeReason  string    `gorm:"size:50;not null"` // "high_confidence", "expiry", "manual_reset"
-	Confidence    float64   `gorm:"default:0"`        // Detection confidence that triggered change
-	CreatedAt     time.Time `gorm:"index;autoCreateTime"`
-
-	// Relationship
-	Label *Label `gorm:"foreignKey:LabelID"`
+	ID             uint      `gorm:"primaryKey"`
+	SpeciesName    string    `gorm:"index;not null;size:200"` // Lowercase common name (identity key)
+	ScientificName string    `gorm:"size:200"`                // Display metadata only; may be empty
+	PreviousLevel  int       `gorm:"not null"`                // Level before change
+	NewLevel       int       `gorm:"not null"`                // Level after change
+	PreviousValue  float64   `gorm:"not null"`                // Threshold value before change
+	NewValue       float64   `gorm:"not null"`                // Threshold value after change
+	ChangeReason   string    `gorm:"size:50;not null"`        // "high_confidence", "expiry", "manual_reset"
+	Confidence     float64   `gorm:"default:0"`               // Detection confidence that triggered change
+	CreatedAt      time.Time `gorm:"index;autoCreateTime"`
 }

--- a/internal/datastore/v2/manager.go
+++ b/internal/datastore/v2/manager.go
@@ -319,6 +319,33 @@ func v2Entities() []any {
 	}
 }
 
+// dropStaleThresholdTables recreates the dynamic_thresholds and threshold_events tables
+// when they still carry the pre-#4195 label_id column. Those tables were re-keyed from a
+// model-scoped label foreign key to species_name (lowercase common name); since GORM's
+// AutoMigrate is additive and cannot drop the old NOT NULL/unique label_id column, a stale
+// table would reject every new insert. Existing rows are intentionally discarded (#4195):
+// dynamic thresholds are short-lived and relearned. The GORM migrator resolves the physical
+// (prefix-aware) table name from the entity, so this is dialect- and prefix-agnostic.
+func dropStaleThresholdTables(db *gorm.DB, log logger.Logger) error {
+	mig := db.Migrator()
+	// entities.ThresholdEvent, then entities.DynamicThreshold. "label_id" is checked as a raw
+	// column name (the field no longer exists on the struct), so HasColumn probes the physical
+	// table for a leftover label_id column.
+	for _, tbl := range []any{&entities.ThresholdEvent{}, &entities.DynamicThreshold{}} {
+		if !mig.HasTable(tbl) || !mig.HasColumn(tbl, "label_id") {
+			continue
+		}
+		if err := mig.DropTable(tbl); err != nil {
+			return fmt.Errorf("failed to drop stale threshold table for re-keying: %w", err)
+		}
+		if log != nil {
+			log.Info("recreated threshold table to key on species_name (#4195)",
+				logger.String("operation", "drop_stale_threshold_tables"))
+		}
+	}
+	return nil
+}
+
 // Initialize creates the schema and seeds initial data.
 func (m *SQLiteManager) Initialize() error {
 	// Rename tables that changed names in PR #2165 (TableName() overrides removed).
@@ -335,6 +362,13 @@ func (m *SQLiteManager) Initialize() error {
 				logger.Error(err),
 				logger.String("operation", "cleanup_legacy_contamination"))
 		}
+	}
+
+	// Re-key threshold tables on species_name if they still carry the legacy label_id
+	// column; AutoMigrate cannot drop it, so recreate them (#4195). Rows are discarded.
+	if err := dropStaleThresholdTables(m.db, m.log); err != nil {
+		reportInitFailure("sqlite", "dropStaleThresholdTables", err, m.dbPath)
+		return err
 	}
 
 	// Run GORM auto-migrations for all entities

--- a/internal/datastore/v2/manager_test.go
+++ b/internal/datastore/v2/manager_test.go
@@ -968,3 +968,45 @@ func TestSQLiteManager_Close_NilsOutDB(t *testing.T) {
 
 	assert.Nil(t, mgr.DB(), "DB should be nil after Close to prevent stale reference queries")
 }
+
+// TestDropStaleThresholdTables verifies the #4195 schema-recreate migration: a
+// pre-#4195 threshold table carrying a label_id column is dropped so AutoMigrate can
+// recreate it keyed on species_name, while fresh and already-migrated tables are left
+// untouched.
+func TestDropStaleThresholdTables(t *testing.T) {
+	mgr, err := NewSQLiteManager(Config{DataDir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mgr.Close() })
+	db := mgr.DB()
+	require.NotNil(t, db)
+
+	// Simulate the pre-#4195 schema: threshold tables keyed through a label_id FK.
+	require.NoError(t, db.Exec(`CREATE TABLE dynamic_thresholds (id INTEGER PRIMARY KEY, label_id INTEGER NOT NULL, level INTEGER)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE threshold_events (id INTEGER PRIMARY KEY, label_id INTEGER NOT NULL)`).Error)
+	require.True(t, db.Migrator().HasColumn(&entities.DynamicThreshold{}, "label_id"))
+	require.True(t, db.Migrator().HasColumn(&entities.ThresholdEvent{}, "label_id"))
+
+	// Drop the stale tables, then let AutoMigrate recreate them in the new shape.
+	require.NoError(t, dropStaleThresholdTables(db, nil))
+	require.NoError(t, db.AutoMigrate(&entities.DynamicThreshold{}, &entities.ThresholdEvent{}))
+
+	assert.True(t, db.Migrator().HasColumn(&entities.DynamicThreshold{}, "species_name"), "recreated table must be keyed on species_name")
+	assert.False(t, db.Migrator().HasColumn(&entities.DynamicThreshold{}, "label_id"), "stale label_id column must be gone")
+	assert.True(t, db.Migrator().HasColumn(&entities.ThresholdEvent{}, "species_name"))
+	assert.False(t, db.Migrator().HasColumn(&entities.ThresholdEvent{}, "label_id"))
+
+	// An insert on the new schema must succeed.
+	require.NoError(t, db.Exec(`INSERT INTO dynamic_thresholds (species_name, level, current_value, base_threshold, high_conf_count, valid_hours, expires_at, last_triggered, first_created, trigger_count) VALUES ('great tit', 1, 0.7, 0.8, 1, 24, '2099-01-01', '2099-01-01', '2099-01-01', 1)`).Error)
+
+	// Idempotency: a second call on the already-migrated table (no label_id) is a no-op
+	// and must not drop the table or its row.
+	require.NoError(t, dropStaleThresholdTables(db, nil))
+	assert.True(t, db.Migrator().HasColumn(&entities.DynamicThreshold{}, "species_name"), "already-migrated table must be untouched")
+	var count int64
+	require.NoError(t, db.Table("dynamic_thresholds").Count(&count).Error)
+	assert.Equal(t, int64(1), count, "already-migrated row must survive an idempotent call")
+
+	// Fresh install: tables absent -> no-op, no error.
+	require.NoError(t, db.Migrator().DropTable(&entities.DynamicThreshold{}, &entities.ThresholdEvent{}))
+	require.NoError(t, dropStaleThresholdTables(db, nil))
+}

--- a/internal/datastore/v2/migration/testutil/assertions.go
+++ b/internal/datastore/v2/migration/testutil/assertions.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -202,19 +203,16 @@ func AssertHourlyWeatherMatches(t *testing.T, legacy *datastore.HourlyWeather, v
 }
 
 // AssertDynamicThresholdMatches verifies that a V2 DynamicThreshold matches a legacy DynamicThreshold.
-// The v2 DynamicThreshold should have its Label preloaded for species name comparison.
+// Thresholds are keyed per species (lowercase common name), model-independent (#4195).
 func AssertDynamicThresholdMatches(t *testing.T, legacy *datastore.DynamicThreshold, v2 *entities.DynamicThreshold) {
 	t.Helper()
 
 	require.NotNil(t, legacy, "legacy threshold should not be nil")
 	require.NotNil(t, v2, "v2 threshold should not be nil")
 
-	// Compare scientific name via label relationship
-	if v2.Label != nil && v2.Label.ScientificName != "" {
-		assert.Equal(t, legacy.ScientificName, v2.Label.ScientificName, "scientific_name should match (via label)")
-	} else {
-		assert.NotZero(t, v2.LabelID, "label_id should be set if Label not preloaded")
-	}
+	// Species (lowercase common name) is the identity key.
+	assert.Equal(t, strings.ToLower(legacy.SpeciesName), v2.SpeciesName, "species_name should match")
+	assert.Equal(t, legacy.ScientificName, v2.ScientificName, "scientific_name should match")
 	assert.Equal(t, legacy.Level, v2.Level, "level should match")
 	assert.InDelta(t, legacy.CurrentValue, v2.CurrentValue, floatDelta, "current_value should match")
 	assert.InDelta(t, legacy.BaseThreshold, v2.BaseThreshold, floatDelta, "base_threshold should match")
@@ -229,17 +227,14 @@ func AssertDynamicThresholdMatches(t *testing.T, legacy *datastore.DynamicThresh
 }
 
 // AssertThresholdEventMatches verifies that a V2 ThresholdEvent matches a legacy ThresholdEvent.
-// Note: The legacy ThresholdEvent.SpeciesName is the common name (lowercase), while the V2 event
-// is linked to a label containing the scientific name. These are different by design - the species
-// relationship is verified implicitly through the parent DynamicThreshold migration.
+// Both are keyed by species (lowercase common name), model-independent (#4195).
 func AssertThresholdEventMatches(t *testing.T, legacy *datastore.ThresholdEvent, v2 *entities.ThresholdEvent) {
 	t.Helper()
 
 	require.NotNil(t, legacy, "legacy threshold event should not be nil")
 	require.NotNil(t, v2, "v2 threshold event should not be nil")
 
-	// Verify label relationship exists (species matching is verified at parent threshold level)
-	assert.NotZero(t, v2.LabelID, "label_id should be set")
+	assert.Equal(t, strings.ToLower(legacy.SpeciesName), v2.SpeciesName, "species_name should match")
 	assert.Equal(t, legacy.PreviousLevel, v2.PreviousLevel, "previous_level should match")
 	assert.Equal(t, legacy.NewLevel, v2.NewLevel, "new_level should match")
 	assert.InDelta(t, legacy.PreviousValue, v2.PreviousValue, floatDelta, "previous_value should match")

--- a/internal/datastore/v2/migration/testutil/assertions_test.go
+++ b/internal/datastore/v2/migration/testutil/assertions_test.go
@@ -255,7 +255,7 @@ func TestAssertDynamicThresholdMatches_Success(t *testing.T) {
 
 	legacy := &datastore.DynamicThreshold{
 		ID:             1,
-		SpeciesName:    "american robin",
+		SpeciesName:    "American Robin", // mixed-case so the helper's ToLower is load-bearing
 		ScientificName: testSpeciesTurdus,
 		Level:          1,
 		CurrentValue:   0.75,
@@ -268,20 +268,19 @@ func TestAssertDynamicThresholdMatches_Success(t *testing.T) {
 		TriggerCount:   10,
 	}
 
-	sciName := testSpeciesTurdus
 	v2 := &entities.DynamicThreshold{
-		ID:            100, // V2 ID can differ
-		LabelID:       1,
-		Level:         1,
-		CurrentValue:  0.75,
-		BaseThreshold: 0.65,
-		HighConfCount: 5,
-		ValidHours:    24,
-		ExpiresAt:     expiresAt,
-		LastTriggered: now,
-		FirstCreated:  now.Add(-7 * 24 * time.Hour),
-		TriggerCount:  10,
-		Label:         &entities.Label{ID: 1, ScientificName: sciName},
+		ID:             100, // V2 ID can differ
+		SpeciesName:    "american robin",
+		ScientificName: testSpeciesTurdus,
+		Level:          1,
+		CurrentValue:   0.75,
+		BaseThreshold:  0.65,
+		HighConfCount:  5,
+		ValidHours:     24,
+		ExpiresAt:      expiresAt,
+		LastTriggered:  now,
+		FirstCreated:   now.Add(-7 * 24 * time.Hour),
+		TriggerCount:   10,
 	}
 
 	AssertDynamicThresholdMatches(t, legacy, v2)
@@ -450,4 +449,31 @@ func TestAssertDetectionMatches_ConfidenceMismatch(t *testing.T) {
 
 	AssertDetectionMatches(mockT, legacy, v2)
 	assert.True(t, mockT.Failed(), "should fail on confidence mismatch")
+}
+
+func TestAssertThresholdEventMatches_Success(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	legacy := &datastore.ThresholdEvent{
+		SpeciesName:   "American Robin", // mixed-case so the helper's ToLower is load-bearing
+		PreviousLevel: 0,
+		NewLevel:      1,
+		PreviousValue: 0.8,
+		NewValue:      0.6,
+		ChangeReason:  "high_confidence",
+		Confidence:    0.95,
+		CreatedAt:     now,
+	}
+	v2 := &entities.ThresholdEvent{
+		ID:            100,
+		SpeciesName:   "american robin",
+		PreviousLevel: 0,
+		NewLevel:      1,
+		PreviousValue: 0.8,
+		NewValue:      0.6,
+		ChangeReason:  "high_confidence",
+		Confidence:    0.95,
+		CreatedAt:     now,
+	}
+	AssertThresholdEventMatches(t, legacy, v2)
 }

--- a/internal/datastore/v2/migration/testutil/setup.go
+++ b/internal/datastore/v2/migration/testutil/setup.go
@@ -194,7 +194,7 @@ func (ctx *TestContext) setupV2DB(t *testing.T, tmpDir string) {
 	ctx.SourceRepo = repository.NewAudioSourceRepository(db, nil, false, false)
 	ctx.WeatherRepo = repository.NewWeatherRepository(db, nil, false, false)
 	ctx.ImageCacheRepo = repository.NewImageCacheRepository(db, nil, ctx.LabelRepo, false, false)
-	ctx.ThresholdRepo = repository.NewDynamicThresholdRepository(db, nil, ctx.LabelRepo, false, false)
+	ctx.ThresholdRepo = repository.NewDynamicThresholdRepository(db, nil, false, false)
 	ctx.NotificationRepo = repository.NewNotificationHistoryRepository(db, nil, ctx.LabelRepo, false, false)
 
 	// Populate lookup tables for V2 normalized schema

--- a/internal/datastore/v2/migration/worker_auxiliary.go
+++ b/internal/datastore/v2/migration/worker_auxiliary.go
@@ -309,7 +309,8 @@ func (m *AuxiliaryMigrator) migrateImageCaches(ctx context.Context, result *Auxi
 }
 
 // migrateDynamicThresholds migrates all dynamic thresholds and their events.
-// Resolves scientific names to label IDs for the normalized schema.
+// Thresholds are keyed per species (lowercase common name) and model-independent
+// (#4195), so this is a direct 1:1 copy from the legacy store; no label resolution.
 func (m *AuxiliaryMigrator) migrateDynamicThresholds(ctx context.Context, result *AuxiliaryMigrationResult) {
 	if m.thresholdRepo == nil {
 		m.logger.Debug("threshold repo not configured, skipping")
@@ -330,56 +331,39 @@ func (m *AuxiliaryMigrator) migrateDynamicThresholds(ctx context.Context, result
 		return
 	}
 
-	// Batch resolve all labels to avoid N+1 queries
-	speciesSet := make(map[string]struct{})
-	for i := range legacyThresholds {
-		speciesSet[legacyThresholds[i].ScientificName] = struct{}{}
-	}
-	speciesNames := slices.Collect(maps.Keys(speciesSet))
-
-	labelMap, err := m.labelRepo.BatchGetOrCreate(ctx, speciesNames, m.defaultModelID, m.speciesLabelTypeID, m.avesClassID)
-	if err != nil {
-		m.logger.Warn("failed to batch resolve labels for thresholds", logger.Error(err))
-		result.Thresholds.Error = err
-		return
-	}
-
 	for i := range legacyThresholds {
 		threshold := &legacyThresholds[i]
-
-		// Look up label from pre-resolved map
-		label, ok := labelMap[threshold.ScientificName]
-		if !ok {
-			m.logger.Warn("label not found after batch creation",
-				logger.String("species", threshold.SpeciesName),
-				logger.String("scientific_name", threshold.ScientificName))
+		speciesName := strings.ToLower(threshold.SpeciesName)
+		if speciesName == "" {
+			m.logger.Warn("skipping legacy threshold with empty species name")
 			result.Thresholds.Skipped++
 			continue
 		}
 
 		v2Threshold := entities.DynamicThreshold{
-			LabelID:       label.ID,
-			Level:         threshold.Level,
-			CurrentValue:  threshold.CurrentValue,
-			BaseThreshold: threshold.BaseThreshold,
-			HighConfCount: threshold.HighConfCount,
-			ValidHours:    threshold.ValidHours,
-			ExpiresAt:     threshold.ExpiresAt,
-			LastTriggered: threshold.LastTriggered,
-			FirstCreated:  threshold.FirstCreated,
-			TriggerCount:  threshold.TriggerCount,
+			SpeciesName:    speciesName,
+			ScientificName: threshold.ScientificName,
+			Level:          threshold.Level,
+			CurrentValue:   threshold.CurrentValue,
+			BaseThreshold:  threshold.BaseThreshold,
+			HighConfCount:  threshold.HighConfCount,
+			ValidHours:     threshold.ValidHours,
+			ExpiresAt:      threshold.ExpiresAt,
+			LastTriggered:  threshold.LastTriggered,
+			FirstCreated:   threshold.FirstCreated,
+			TriggerCount:   threshold.TriggerCount,
 		}
 		if err := m.thresholdRepo.SaveDynamicThreshold(ctx, &v2Threshold); err != nil {
 			m.logger.Warn("failed to migrate threshold",
-				logger.String("species", threshold.SpeciesName),
+				logger.String("species", speciesName),
 				logger.Error(err))
 			result.Thresholds.Skipped++
 			continue
 		}
 		result.Thresholds.Migrated++
 
-		// Migrate threshold events for this species using the resolved label ID
-		m.migrateThresholdEvents(ctx, threshold.SpeciesName, label.ID, result)
+		// Migrate threshold events for this species
+		m.migrateThresholdEvents(ctx, threshold.SpeciesName, result)
 	}
 
 	m.logger.Info("dynamic threshold migration completed",
@@ -388,9 +372,8 @@ func (m *AuxiliaryMigrator) migrateDynamicThresholds(ctx context.Context, result
 		logger.Int("skipped", result.Thresholds.Skipped))
 }
 
-// migrateThresholdEvents migrates threshold events for a species.
-// Uses the pre-resolved labelID to avoid repeated label lookups.
-func (m *AuxiliaryMigrator) migrateThresholdEvents(ctx context.Context, speciesName string, labelID uint, result *AuxiliaryMigrationResult) {
+// migrateThresholdEvents migrates threshold events for a species (1:1 copy, #4195).
+func (m *AuxiliaryMigrator) migrateThresholdEvents(ctx context.Context, speciesName string, result *AuxiliaryMigrationResult) {
 	// Get events from legacy (limit to 100 most recent)
 	legacyEvents, err := m.legacyStore.GetThresholdEvents(speciesName, 100)
 	if err != nil {
@@ -404,18 +387,24 @@ func (m *AuxiliaryMigrator) migrateThresholdEvents(ctx context.Context, speciesN
 		return
 	}
 
+	lower := strings.ToLower(speciesName)
+	if lower == "" {
+		return
+	}
+
 	result.ThresholdEvents.Total += len(legacyEvents)
 	for i := range legacyEvents {
 		event := &legacyEvents[i]
 		v2Event := &entities.ThresholdEvent{
-			LabelID:       labelID,
-			PreviousLevel: event.PreviousLevel,
-			NewLevel:      event.NewLevel,
-			PreviousValue: event.PreviousValue,
-			NewValue:      event.NewValue,
-			ChangeReason:  event.ChangeReason,
-			Confidence:    event.Confidence,
-			CreatedAt:     event.CreatedAt,
+			SpeciesName:    lower,
+			ScientificName: event.ScientificName,
+			PreviousLevel:  event.PreviousLevel,
+			NewLevel:       event.NewLevel,
+			PreviousValue:  event.PreviousValue,
+			NewValue:       event.NewValue,
+			ChangeReason:   event.ChangeReason,
+			Confidence:     event.Confidence,
+			CreatedAt:      event.CreatedAt,
 		}
 		if err := m.thresholdRepo.SaveThresholdEvent(ctx, v2Event); err != nil {
 			m.logger.Warn("failed to migrate threshold event",

--- a/internal/datastore/v2/mysql_manager.go
+++ b/internal/datastore/v2/mysql_manager.go
@@ -110,6 +110,14 @@ func (m *MySQLManager) Initialize() error {
 	// fell back to legacy mode due to the PR #2165 table name mismatch.
 	m.cleanupLegacySchemaContamination()
 
+	// Re-key threshold tables on species_name if they still carry the legacy label_id
+	// column; AutoMigrate cannot drop it, so recreate them (#4195). Rows are discarded.
+	// The GORM migrator respects the v2_ NamingStrategy prefix when resolving table names.
+	if err := dropStaleThresholdTables(m.db, m.log); err != nil {
+		reportInitFailure("mysql", "dropStaleThresholdTables", err, m.config.Host, m.config.Database, m.config.Username)
+		return err
+	}
+
 	// Run GORM auto-migrations for all entities using the shared canonical list.
 	// Tables will be created with v2_ prefix due to NamingStrategy.
 	err := m.db.AutoMigrate(v2Entities()...)
@@ -254,7 +262,8 @@ func (m *MySQLManager) Delete() error {
 		prefix + "alert_actions",
 		prefix + "alert_conditions",
 		prefix + "alert_rules",
-		// Auxiliary tables that reference labels (must drop before labels)
+		// Auxiliary tables dropped before labels. image_caches and notification_histories
+		// reference labels; threshold tables no longer do since #4195 but stay grouped here.
 		prefix + "image_caches",
 		prefix + "threshold_events",
 		prefix + "dynamic_thresholds",

--- a/internal/datastore/v2/repository/dynamic_threshold_impl.go
+++ b/internal/datastore/v2/repository/dynamic_threshold_impl.go
@@ -11,11 +11,30 @@ import (
 	"gorm.io/gorm/clause"
 )
 
+// thresholdConflictColumns lists the columns the batch/single upsert overwrites on
+// a species_name conflict. It deliberately EXCLUDES species_name (the conflict key),
+// first_created (set once on INSERT, never trampled) and created_at (GORM autoCreateTime),
+// so periodic re-flushes preserve the true creation timestamp. See #4195.
+var thresholdConflictColumns = []string{
+	"scientific_name",
+	"level",
+	"current_value",
+	"base_threshold",
+	"high_conf_count",
+	"valid_hours",
+	"expires_at",
+	"last_triggered",
+	"trigger_count",
+	"updated_at",
+}
+
 // dynamicThresholdRepository implements DynamicThresholdRepository.
+//
+// Thresholds and events are keyed per species (lowercase common name) and are
+// model-independent (#4173, #4195); there is no label/model foreign key.
 type dynamicThresholdRepository struct {
 	db          *gorm.DB
 	metrics     *datastore.Metrics
-	labelRepo   LabelRepository
 	useV2Prefix bool
 	isMySQL     bool // For API consistency; currently unused here (used by detection_impl.go for dialect-specific SQL)
 }
@@ -24,14 +43,12 @@ type dynamicThresholdRepository struct {
 // Parameters:
 //   - db: GORM database connection
 //   - metrics: optional DatastoreMetrics for retry observability (nil-safe)
-//   - labelRepo: LabelRepository for resolving species names to label IDs
 //   - useV2Prefix: true to use v2_ table prefix (MySQL migration mode)
 //   - isMySQL: true for MySQL dialect (affects date/time SQL expressions)
-func NewDynamicThresholdRepository(db *gorm.DB, metrics *datastore.Metrics, labelRepo LabelRepository, useV2Prefix, isMySQL bool) DynamicThresholdRepository {
+func NewDynamicThresholdRepository(db *gorm.DB, metrics *datastore.Metrics, useV2Prefix, isMySQL bool) DynamicThresholdRepository {
 	return &dynamicThresholdRepository{
 		db:          db,
 		metrics:     metrics,
-		labelRepo:   labelRepo,
 		useV2Prefix: useV2Prefix,
 		isMySQL:     isMySQL,
 	}
@@ -51,52 +68,26 @@ func (r *dynamicThresholdRepository) eventTable() string {
 	return tableThresholdEvents
 }
 
-// ensureLabelRepo returns an error if labelRepo is nil.
-// This guards against misconfiguration that would cause nil pointer panics.
-func (r *dynamicThresholdRepository) ensureLabelRepo() error {
-	if r.labelRepo == nil {
-		return errors.NewStd("label repository not configured for threshold repository")
-	}
-	return nil
-}
-
-// SaveDynamicThreshold saves or updates a dynamic threshold (upsert).
-// The threshold.LabelID must be set by the caller.
+// SaveDynamicThreshold saves or updates a dynamic threshold (upsert on species_name).
 func (r *dynamicThresholdRepository) SaveDynamicThreshold(ctx context.Context, threshold *entities.DynamicThreshold) error {
-	if threshold.LabelID == 0 {
-		return errors.NewStd("dynamic threshold LabelID must be set before saving")
+	if threshold.SpeciesName == "" {
+		return errors.NewStd("dynamic threshold SpeciesName must be set before saving")
 	}
 	return datastore.RetryOnLock(ctx, "v2_save_dynamic_threshold", func() error {
 		return r.db.WithContext(ctx).Table(r.thresholdTable()).
 			Clauses(clause.OnConflict{
-				Columns:   []clause.Column{{Name: "label_id"}},
-				UpdateAll: true,
+				Columns:   []clause.Column{{Name: "species_name"}},
+				DoUpdates: clause.AssignmentColumns(thresholdConflictColumns),
 			}).
 			Create(threshold).Error
 	}, r.metrics)
 }
 
-// GetDynamicThreshold retrieves a threshold by species name (scientific name).
-// Internally resolves the species name to label IDs (cross-model) for the lookup.
-// Returns the first matching threshold if multiple models have thresholds for this species.
+// GetDynamicThreshold retrieves a threshold by species name (lowercase common name).
 func (r *dynamicThresholdRepository) GetDynamicThreshold(ctx context.Context, speciesName string) (*entities.DynamicThreshold, error) {
-	if err := r.ensureLabelRepo(); err != nil {
-		return nil, err
-	}
-	// Resolve species name to label IDs (cross-model lookup)
-	labelIDs, err := r.labelRepo.GetLabelIDsByScientificName(ctx, speciesName)
-	if err != nil {
-		return nil, err
-	}
-	if len(labelIDs) == 0 {
-		return nil, ErrDynamicThresholdNotFound
-	}
-
 	var threshold entities.DynamicThreshold
-	err = r.db.WithContext(ctx).Table(r.thresholdTable()).
-		Preload("Label.Model").
-		Preload("Label").
-		Where("label_id IN ?", labelIDs).
+	err := r.db.WithContext(ctx).Table(r.thresholdTable()).
+		Where("species_name = ?", speciesName).
 		First(&threshold).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, ErrDynamicThresholdNotFound
@@ -104,7 +95,6 @@ func (r *dynamicThresholdRepository) GetDynamicThreshold(ctx context.Context, sp
 	if err != nil {
 		return nil, err
 	}
-
 	return &threshold, nil
 }
 
@@ -112,9 +102,7 @@ func (r *dynamicThresholdRepository) GetDynamicThreshold(ctx context.Context, sp
 func (r *dynamicThresholdRepository) GetAllDynamicThresholds(ctx context.Context, limit ...int) ([]entities.DynamicThreshold, error) {
 	var thresholds []entities.DynamicThreshold
 	query := r.db.WithContext(ctx).Table(r.thresholdTable()).
-		Preload("Label.Model").
-		Preload("Label").
-		Order("label_id ASC")
+		Order("species_name ASC")
 	if len(limit) > 0 && limit[0] > 0 {
 		query = query.Limit(limit[0])
 	}
@@ -122,25 +110,12 @@ func (r *dynamicThresholdRepository) GetAllDynamicThresholds(ctx context.Context
 	return thresholds, err
 }
 
-// DeleteDynamicThreshold deletes thresholds by species name (scientific name).
-// Deletes across all models that have thresholds for this species.
+// DeleteDynamicThreshold deletes a threshold by species name (lowercase common name).
 func (r *dynamicThresholdRepository) DeleteDynamicThreshold(ctx context.Context, speciesName string) error {
-	if err := r.ensureLabelRepo(); err != nil {
-		return err
-	}
-	// Resolve species name to label IDs (cross-model lookup)
-	labelIDs, err := r.labelRepo.GetLabelIDsByScientificName(ctx, speciesName)
-	if err != nil {
-		return err
-	}
-	if len(labelIDs) == 0 {
-		return ErrDynamicThresholdNotFound
-	}
-
 	var rowsAffected int64
-	err = datastore.RetryOnLock(ctx, "v2_delete_dynamic_threshold", func() error {
+	err := datastore.RetryOnLock(ctx, "v2_delete_dynamic_threshold", func() error {
 		result := r.db.WithContext(ctx).Table(r.thresholdTable()).
-			Where("label_id IN ?", labelIDs).
+			Where("species_name = ?", speciesName).
 			Delete(&entities.DynamicThreshold{})
 		if result.Error != nil {
 			return result.Error
@@ -173,25 +148,12 @@ func (r *dynamicThresholdRepository) DeleteExpiredDynamicThresholds(ctx context.
 	return rowsAffected, err
 }
 
-// UpdateDynamicThresholdExpiry updates the expiry time for thresholds.
-// Updates across all models that have thresholds for this species.
+// UpdateDynamicThresholdExpiry updates the expiry time for a threshold by species name.
 func (r *dynamicThresholdRepository) UpdateDynamicThresholdExpiry(ctx context.Context, speciesName string, expiresAt time.Time) error {
-	if err := r.ensureLabelRepo(); err != nil {
-		return err
-	}
-	// Resolve species name to label IDs (cross-model lookup)
-	labelIDs, err := r.labelRepo.GetLabelIDsByScientificName(ctx, speciesName)
-	if err != nil {
-		return err
-	}
-	if len(labelIDs) == 0 {
-		return ErrDynamicThresholdNotFound
-	}
-
 	var rowsAffected int64
-	err = datastore.RetryOnLock(ctx, "v2_update_dynamic_threshold_expiry", func() error {
+	err := datastore.RetryOnLock(ctx, "v2_update_dynamic_threshold_expiry", func() error {
 		result := r.db.WithContext(ctx).Table(r.thresholdTable()).
-			Where("label_id IN ?", labelIDs).
+			Where("species_name = ?", speciesName).
 			Update("expires_at", expiresAt)
 		if result.Error != nil {
 			return result.Error
@@ -208,23 +170,22 @@ func (r *dynamicThresholdRepository) UpdateDynamicThresholdExpiry(ctx context.Co
 	return nil
 }
 
-// BatchSaveDynamicThresholds saves multiple thresholds in a batch (upsert).
-// All thresholds must have LabelID set.
+// BatchSaveDynamicThresholds saves multiple thresholds in a batch (upsert on species_name).
 func (r *dynamicThresholdRepository) BatchSaveDynamicThresholds(ctx context.Context, thresholds []entities.DynamicThreshold) error {
 	if len(thresholds) == 0 {
 		return nil
 	}
-	// Validate all have LabelID set
+	// Validate all have SpeciesName set (the identity key must be non-empty).
 	for i := range thresholds {
-		if thresholds[i].LabelID == 0 {
-			return errors.NewStd("all thresholds must have LabelID set before batch save")
+		if thresholds[i].SpeciesName == "" {
+			return errors.NewStd("all thresholds must have SpeciesName set before batch save")
 		}
 	}
 	return datastore.RetryOnLock(ctx, "v2_batch_save_dynamic_thresholds", func() error {
 		return r.db.WithContext(ctx).Table(r.thresholdTable()).
 			Clauses(clause.OnConflict{
-				Columns:   []clause.Column{{Name: "label_id"}},
-				UpdateAll: true,
+				Columns:   []clause.Column{{Name: "species_name"}},
+				DoUpdates: clause.AssignmentColumns(thresholdConflictColumns),
 			}).
 			CreateInBatches(thresholds, 100).Error
 	}, r.metrics)
@@ -289,51 +250,23 @@ func (r *dynamicThresholdRepository) GetDynamicThresholdStats(ctx context.Contex
 }
 
 // SaveThresholdEvent saves a threshold event.
-// The event.LabelID must be set by the caller.
 func (r *dynamicThresholdRepository) SaveThresholdEvent(ctx context.Context, event *entities.ThresholdEvent) error {
-	if event.LabelID == 0 {
-		return errors.NewStd("threshold event LabelID must be set before saving")
+	if event.SpeciesName == "" {
+		return errors.NewStd("threshold event SpeciesName must be set before saving")
 	}
 	return datastore.RetryOnLock(ctx, "v2_save_threshold_event", func() error {
 		return r.db.WithContext(ctx).Table(r.eventTable()).Create(event).Error
 	}, r.metrics)
 }
 
-// GetThresholdEvents retrieves events for a species (by scientific name).
-// Retrieves events across all models that have events for this species.
+// GetThresholdEvents retrieves events for a species (lowercase common name).
 func (r *dynamicThresholdRepository) GetThresholdEvents(ctx context.Context, speciesName string, limit int) ([]entities.ThresholdEvent, error) {
-	if err := r.ensureLabelRepo(); err != nil {
-		return nil, err
-	}
-	// Resolve species name to label IDs (cross-model lookup)
-	labelIDs, err := r.labelRepo.GetLabelIDsByScientificName(ctx, speciesName)
-	if err != nil {
-		return nil, err
-	}
-	if len(labelIDs) == 0 {
-		return []entities.ThresholdEvent{}, nil
-	}
-
 	var events []entities.ThresholdEvent
+	// id DESC is a unique tiebreaker so events sharing a created_at truncate
+	// deterministically under the limit (coarse clocks collide at high rates).
 	query := r.db.WithContext(ctx).Table(r.eventTable()).
-		Preload("Label.Model").
-		Preload("Label").
-		Where("label_id IN ?", labelIDs).
-		Order("created_at DESC")
-	if limit > 0 {
-		query = query.Limit(limit)
-	}
-	err = query.Find(&events).Error
-	return events, err
-}
-
-// GetRecentThresholdEvents retrieves the most recent events across all species.
-func (r *dynamicThresholdRepository) GetRecentThresholdEvents(ctx context.Context, limit int) ([]entities.ThresholdEvent, error) {
-	var events []entities.ThresholdEvent
-	query := r.db.WithContext(ctx).Table(r.eventTable()).
-		Preload("Label.Model").
-		Preload("Label").
-		Order("created_at DESC")
+		Where("species_name = ?", speciesName).
+		Order("created_at DESC, id DESC")
 	if limit > 0 {
 		query = query.Limit(limit)
 	}
@@ -341,24 +274,25 @@ func (r *dynamicThresholdRepository) GetRecentThresholdEvents(ctx context.Contex
 	return events, err
 }
 
-// DeleteThresholdEvents deletes all events for a species (by scientific name).
-// Deletes events across all models that have events for this species.
-func (r *dynamicThresholdRepository) DeleteThresholdEvents(ctx context.Context, speciesName string) error {
-	if err := r.ensureLabelRepo(); err != nil {
-		return err
+// GetRecentThresholdEvents retrieves the most recent events across all species.
+func (r *dynamicThresholdRepository) GetRecentThresholdEvents(ctx context.Context, limit int) ([]entities.ThresholdEvent, error) {
+	var events []entities.ThresholdEvent
+	// id DESC is a unique tiebreaker so events sharing a created_at truncate
+	// deterministically under the limit.
+	query := r.db.WithContext(ctx).Table(r.eventTable()).
+		Order("created_at DESC, id DESC")
+	if limit > 0 {
+		query = query.Limit(limit)
 	}
-	// Resolve species name to label IDs (cross-model lookup)
-	labelIDs, err := r.labelRepo.GetLabelIDsByScientificName(ctx, speciesName)
-	if err != nil {
-		return err
-	}
-	if len(labelIDs) == 0 {
-		return nil // Nothing to delete
-	}
+	err := query.Find(&events).Error
+	return events, err
+}
 
+// DeleteThresholdEvents deletes all events for a species (lowercase common name).
+func (r *dynamicThresholdRepository) DeleteThresholdEvents(ctx context.Context, speciesName string) error {
 	return datastore.RetryOnLock(ctx, "v2_delete_threshold_events", func() error {
 		return r.db.WithContext(ctx).Table(r.eventTable()).
-			Where("label_id IN ?", labelIDs).
+			Where("species_name = ?", speciesName).
 			Delete(&entities.ThresholdEvent{}).Error
 	}, r.metrics)
 }

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -23,7 +23,6 @@ import (
 	"maps"
 	"math"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -194,7 +193,7 @@ type Config struct {
 	ChiropteraClassID  *uint // "Chiroptera" taxonomic class ID (optional)
 
 	// Labels provides species label mappings in "ScientificName_CommonName" format.
-	// Used to build speciesMap for GetThresholdEvents workaround. See issue #1907.
+	// Used to build the species name map for common<->scientific name resolution.
 	Labels []string
 
 	// SpeciesCodeMap maps scientific names to eBird species codes.
@@ -349,8 +348,7 @@ func New(cfg *Config) (*Datastore, error) {
 }
 
 // buildNameMaps parses BirdNET labels ("ScientificName_CommonName" format)
-// into lookup maps for common name resolution.
-// See issue #1907 for context on species map usage.
+// into lookup maps for common<->scientific name resolution.
 // When resolver is non-nil, each label's common name is overridden by the
 // resolver (authoritative/localized); labels the resolver does not cover keep
 // their embedded common name. This keeps the reverse (search) maps consistent
@@ -3539,10 +3537,16 @@ func (ds *Datastore) civilDawnMinuteLookup() civilDawnMinuteLookup {
 // Dynamic Threshold Methods
 // ============================================================
 
-// thresholdScientificName extracts the scientific name from a threshold's label.
-func thresholdScientificName(t *entities.DynamicThreshold) string {
-	if t.Label != nil && t.Label.ScientificName != "" {
-		return detection.ExtractScientificName(t.Label.ScientificName)
+// displayScientificName returns the scientific name for display metadata, preferring
+// the stored column and falling back to resolving it from the species (common) name
+// when empty. Scientific name is display-only metadata since #4195; thresholds and
+// events are keyed by species (lowercase common name), not by a model-scoped label.
+func (ds *Datastore) displayScientificName(speciesName, stored string) string {
+	if stored != "" {
+		return stored
+	}
+	if resolved := ds.resolveToScientificName(speciesName); resolved != speciesName {
+		return resolved
 	}
 	return ""
 }
@@ -3604,44 +3608,39 @@ func (ds *Datastore) resolveToScientificName(name string) string {
 	return name
 }
 
-// SaveDynamicThreshold saves a dynamic threshold.
-// Resolves the scientific name to a label ID before saving.
+// SaveDynamicThreshold saves a dynamic threshold, keyed by species (lowercase common
+// name). Model-independent: no label resolution (#4195).
 func (ds *Datastore) SaveDynamicThreshold(threshold *datastore.DynamicThreshold) error {
 	if ds.threshold == nil {
 		return fmt.Errorf("threshold repository not configured")
 	}
 	ctx := context.Background()
 
-	// Resolve scientific name to label ID using default model
-	label, err := ds.label.GetOrCreate(ctx, threshold.ScientificName, ds.defaultModelID, ds.speciesLabelTypeID, ds.avesClassID)
-	if err != nil {
-		return fmt.Errorf("failed to resolve label for threshold: %w", err)
-	}
-
 	v2Threshold := &entities.DynamicThreshold{
-		LabelID:       label.ID,
-		Level:         threshold.Level,
-		CurrentValue:  threshold.CurrentValue,
-		BaseThreshold: threshold.BaseThreshold,
-		HighConfCount: threshold.HighConfCount,
-		ValidHours:    threshold.ValidHours,
-		ExpiresAt:     threshold.ExpiresAt,
-		LastTriggered: threshold.LastTriggered,
-		FirstCreated:  threshold.FirstCreated,
-		TriggerCount:  threshold.TriggerCount,
+		SpeciesName:    strings.ToLower(threshold.SpeciesName),
+		ScientificName: threshold.ScientificName,
+		Level:          threshold.Level,
+		CurrentValue:   threshold.CurrentValue,
+		BaseThreshold:  threshold.BaseThreshold,
+		HighConfCount:  threshold.HighConfCount,
+		ValidHours:     threshold.ValidHours,
+		ExpiresAt:      threshold.ExpiresAt,
+		LastTriggered:  threshold.LastTriggered,
+		FirstCreated:   threshold.FirstCreated,
+		TriggerCount:   threshold.TriggerCount,
 	}
 	return ds.threshold.SaveDynamicThreshold(ctx, v2Threshold)
 }
 
 // GetDynamicThreshold retrieves a dynamic threshold by species name.
-// Thresholds are tracked per species; the v2 schema scopes them through LabelID.
+// Thresholds are keyed by species (lowercase common name); model-independent (#4195).
 func (ds *Datastore) GetDynamicThreshold(speciesName string) (*datastore.DynamicThreshold, error) {
 	if ds.threshold == nil {
 		return nil, fmt.Errorf("threshold repository not configured")
 	}
 	ctx := context.Background()
-	// Resolve to scientific name in case caller passes a common name
-	t, err := ds.threshold.GetDynamicThreshold(ctx, ds.resolveToScientificName(speciesName))
+	// Thresholds are keyed by species (lowercase common name); look up directly.
+	t, err := ds.threshold.GetDynamicThreshold(ctx, strings.ToLower(speciesName))
 	if err != nil {
 		// Not-found is a benign result, not a DB fault. Wrap it as a CategoryNotFound
 		// EnhancedError (never CategoryDatabase, so it is not surfaced to Sentry as a
@@ -3664,11 +3663,10 @@ func (ds *Datastore) GetDynamicThreshold(speciesName string) (*datastore.Dynamic
 			Context("operation", "get_dynamic_threshold").
 			Build()
 	}
-	scientificName := thresholdScientificName(t)
 	return &datastore.DynamicThreshold{
 		ID:             t.ID,
-		SpeciesName:    strings.ToLower(ds.resolveCommonName(scientificName)),
-		ScientificName: scientificName,
+		SpeciesName:    t.SpeciesName,
+		ScientificName: ds.displayScientificName(t.SpeciesName, t.ScientificName),
 		Level:          t.Level,
 		CurrentValue:   t.CurrentValue,
 		BaseThreshold:  t.BaseThreshold,
@@ -3699,11 +3697,10 @@ func (ds *Datastore) GetAllDynamicThresholds(limit ...int) ([]datastore.DynamicT
 	result := make([]datastore.DynamicThreshold, 0, len(v2Thresholds))
 	for i := range v2Thresholds {
 		t := &v2Thresholds[i]
-		scientificName := thresholdScientificName(t)
 		result = append(result, datastore.DynamicThreshold{
 			ID:             t.ID,
-			SpeciesName:    strings.ToLower(ds.resolveCommonName(scientificName)),
-			ScientificName: scientificName,
+			SpeciesName:    t.SpeciesName,
+			ScientificName: ds.displayScientificName(t.SpeciesName, t.ScientificName),
 			Level:          t.Level,
 			CurrentValue:   t.CurrentValue,
 			BaseThreshold:  t.BaseThreshold,
@@ -3725,7 +3722,7 @@ func (ds *Datastore) DeleteDynamicThreshold(speciesName string) error {
 		return fmt.Errorf("threshold repository not configured")
 	}
 	ctx := context.Background()
-	return ds.threshold.DeleteDynamicThreshold(ctx, ds.resolveToScientificName(speciesName))
+	return ds.threshold.DeleteDynamicThreshold(ctx, strings.ToLower(speciesName))
 }
 
 // DeleteExpiredDynamicThresholds deletes expired thresholds.
@@ -3743,11 +3740,11 @@ func (ds *Datastore) UpdateDynamicThresholdExpiry(speciesName string, expiresAt 
 		return fmt.Errorf("threshold repository not configured")
 	}
 	ctx := context.Background()
-	return ds.threshold.UpdateDynamicThresholdExpiry(ctx, ds.resolveToScientificName(speciesName), expiresAt)
+	return ds.threshold.UpdateDynamicThresholdExpiry(ctx, strings.ToLower(speciesName), expiresAt)
 }
 
-// BatchSaveDynamicThresholds saves multiple thresholds.
-// Resolves scientific names to label IDs before saving.
+// BatchSaveDynamicThresholds saves multiple thresholds, keyed by species
+// (lowercase common name); model-independent, no label resolution (#4195).
 func (ds *Datastore) BatchSaveDynamicThresholds(thresholds []datastore.DynamicThreshold) error {
 	if ds.threshold == nil {
 		return fmt.Errorf("threshold repository not configured")
@@ -3757,40 +3754,22 @@ func (ds *Datastore) BatchSaveDynamicThresholds(thresholds []datastore.DynamicTh
 	}
 	ctx := context.Background()
 
-	// Collect all scientific names for batch resolution
-	names := make([]string, 0, len(thresholds))
-	for i := range thresholds {
-		if thresholds[i].ScientificName != "" {
-			names = append(names, thresholds[i].ScientificName)
-		}
-	}
-
-	// Batch resolve all labels in one operation using default model
-	labels, err := ds.label.BatchGetOrCreate(ctx, names, ds.defaultModelID, ds.speciesLabelTypeID, ds.avesClassID)
-	if err != nil {
-		return fmt.Errorf("failed to resolve labels for thresholds: %w", err)
-	}
-
-	// Build v2 thresholds with resolved label IDs
+	// Build v2 thresholds keyed by species (lowercase common name); model-independent (#4195).
 	v2Thresholds := make([]entities.DynamicThreshold, 0, len(thresholds))
 	for i := range thresholds {
 		t := &thresholds[i]
-		label := labels[t.ScientificName]
-		if label == nil {
-			return fmt.Errorf("label not found for threshold %s", t.ScientificName)
-		}
-
 		v2Thresholds = append(v2Thresholds, entities.DynamicThreshold{
-			LabelID:       label.ID,
-			Level:         t.Level,
-			CurrentValue:  t.CurrentValue,
-			BaseThreshold: t.BaseThreshold,
-			HighConfCount: t.HighConfCount,
-			ValidHours:    t.ValidHours,
-			ExpiresAt:     t.ExpiresAt,
-			LastTriggered: t.LastTriggered,
-			FirstCreated:  t.FirstCreated,
-			TriggerCount:  t.TriggerCount,
+			SpeciesName:    strings.ToLower(t.SpeciesName),
+			ScientificName: t.ScientificName,
+			Level:          t.Level,
+			CurrentValue:   t.CurrentValue,
+			BaseThreshold:  t.BaseThreshold,
+			HighConfCount:  t.HighConfCount,
+			ValidHours:     t.ValidHours,
+			ExpiresAt:      t.ExpiresAt,
+			LastTriggered:  t.LastTriggered,
+			FirstCreated:   t.FirstCreated,
+			TriggerCount:   t.TriggerCount,
 		})
 	}
 	return ds.threshold.BatchSaveDynamicThresholds(ctx, v2Thresholds)
@@ -3826,125 +3805,59 @@ func (ds *Datastore) GetDynamicThresholdStats() (totalCount, activeCount, atMini
 // Threshold Event Methods
 // ============================================================
 
-// eventSpeciesName extracts the species name from an event's label.
-// Handles legacy concatenated "ScientificName_CommonName" format.
-func eventSpeciesName(e *entities.ThresholdEvent) string {
-	if e.Label != nil && e.Label.ScientificName != "" {
-		return detection.ExtractScientificName(e.Label.ScientificName)
-	}
-	return ""
-}
-
-// SaveThresholdEvent saves a threshold event.
-// Uses event.ScientificName (if provided) for correct label resolution in V2 schema.
-// Falls back to event.SpeciesName (common name) for backward compatibility with
-// events created before #1907 fix.
+// SaveThresholdEvent saves a threshold event, keyed by species (lowercase common
+// name); model-independent (#4195). ScientificName is stored as display metadata.
 func (ds *Datastore) SaveThresholdEvent(event *datastore.ThresholdEvent) error {
 	if ds.threshold == nil {
 		return fmt.Errorf("threshold repository not configured")
 	}
 	ctx := context.Background()
 
-	// Use ScientificName if available (new behavior after #1907 fix),
-	// otherwise fall back to SpeciesName (common name) for backward compatibility.
-	labelName := event.ScientificName
-	if labelName == "" {
-		// Fallback for events without ScientificName populated.
-		// This creates incorrect labels but maintains backward compatibility.
-		labelName = event.SpeciesName
-	}
-
-	label, err := ds.label.GetOrCreate(ctx, labelName, ds.defaultModelID, ds.speciesLabelTypeID, ds.avesClassID)
-	if err != nil {
-		return fmt.Errorf("failed to resolve label for event: %w", err)
-	}
-
 	v2Event := &entities.ThresholdEvent{
-		LabelID:       label.ID,
-		PreviousLevel: event.PreviousLevel,
-		NewLevel:      event.NewLevel,
-		PreviousValue: event.PreviousValue,
-		NewValue:      event.NewValue,
-		ChangeReason:  event.ChangeReason,
-		Confidence:    event.Confidence,
-		CreatedAt:     event.CreatedAt,
+		SpeciesName:    strings.ToLower(event.SpeciesName),
+		ScientificName: event.ScientificName,
+		PreviousLevel:  event.PreviousLevel,
+		NewLevel:       event.NewLevel,
+		PreviousValue:  event.PreviousValue,
+		NewValue:       event.NewValue,
+		ChangeReason:   event.ChangeReason,
+		Confidence:     event.Confidence,
+		CreatedAt:      event.CreatedAt,
 	}
 	return ds.threshold.SaveThresholdEvent(ctx, v2Event)
 }
 
-// GetThresholdEvents retrieves threshold events for a species.
-// WORKAROUND(#1907): Prior to the fix, events were saved with labels created from common names
-// (e.g., "american robin" stored as scientific_name). After the fix, events are saved with
-// correct scientific names (e.g., "Turdus migratorius"). This method queries both label types
-// to return all events during the transition period.
-// TODO: Remove this workaround when legacy database support is dropped. At that point,
-// clean up orphaned common-name labels and simplify to a single query using scientific name.
+// GetThresholdEvents retrieves threshold events for a species (lowercase common name).
+// Events are keyed by species and ordered/limited by the repository (#4195).
 func (ds *Datastore) GetThresholdEvents(speciesName string, limit int) ([]datastore.ThresholdEvent, error) {
 	if ds.threshold == nil {
 		return []datastore.ThresholdEvent{}, nil
 	}
 	ctx := context.Background()
 
-	// Query 1: Try with the provided name (common name) - finds legacy/incorrectly saved events
-	v2Events, err := ds.threshold.GetThresholdEvents(ctx, speciesName, limit)
+	v2Events, err := ds.threshold.GetThresholdEvents(ctx, strings.ToLower(speciesName), limit)
 	if err != nil {
 		return nil, errors.New(err).
 			Component("datastore").
 			Category(errors.CategoryDatabase).
 			Context("operation", "get_threshold_events").
-			Context("query_type", "common_name").
 			Build()
 	}
 
-	// Query 2: If we can resolve to scientific name, also query with that
-	// This finds correctly saved events (after #1907 fix)
-	// Resolve through resolveToScientificName so this shares the reverse map's NFC-folded
-	// normalization; a decomposed (NFD) localized name must match the NFC-folded keys.
-	if scientificName := ds.resolveToScientificName(speciesName); scientificName != speciesName {
-		sciEvents, err := ds.threshold.GetThresholdEvents(ctx, scientificName, limit)
-		if err != nil {
-			return nil, errors.New(err).
-				Component("datastore").
-				Category(errors.CategoryDatabase).
-				Context("operation", "get_threshold_events").
-				Context("query_type", "scientific_name").
-				Build()
-		}
-		v2Events = append(v2Events, sciEvents...)
-	}
-
-	// Note: Deduplication not needed - each event has exactly one LabelID,
-	// so queries for different labels return disjoint result sets.
-	uniqueEvents := v2Events
-
-	// Sort by CreatedAt DESC (most recent first). Tie-break on ID so events sharing a
-	// timestamp truncate deterministically when the limit is applied below.
-	sort.Slice(uniqueEvents, func(i, j int) bool {
-		if uniqueEvents[i].CreatedAt.Equal(uniqueEvents[j].CreatedAt) {
-			return uniqueEvents[i].ID > uniqueEvents[j].ID
-		}
-		return uniqueEvents[i].CreatedAt.After(uniqueEvents[j].CreatedAt)
-	})
-
-	// Apply limit after merge
-	if limit > 0 && len(uniqueEvents) > limit {
-		uniqueEvents = uniqueEvents[:limit]
-	}
-
-	// Convert to datastore.ThresholdEvent
-	result := make([]datastore.ThresholdEvent, 0, len(uniqueEvents))
-	for i := range uniqueEvents {
-		e := &uniqueEvents[i]
+	result := make([]datastore.ThresholdEvent, 0, len(v2Events))
+	for i := range v2Events {
+		e := &v2Events[i]
 		result = append(result, datastore.ThresholdEvent{
-			ID:            e.ID,
-			SpeciesName:   eventSpeciesName(e),
-			PreviousLevel: e.PreviousLevel,
-			NewLevel:      e.NewLevel,
-			PreviousValue: e.PreviousValue,
-			NewValue:      e.NewValue,
-			ChangeReason:  e.ChangeReason,
-			Confidence:    e.Confidence,
-			CreatedAt:     e.CreatedAt,
+			ID:             e.ID,
+			SpeciesName:    e.SpeciesName,
+			ScientificName: ds.displayScientificName(e.SpeciesName, e.ScientificName),
+			PreviousLevel:  e.PreviousLevel,
+			NewLevel:       e.NewLevel,
+			PreviousValue:  e.PreviousValue,
+			NewValue:       e.NewValue,
+			ChangeReason:   e.ChangeReason,
+			Confidence:     e.Confidence,
+			CreatedAt:      e.CreatedAt,
 		})
 	}
 	return result, nil
@@ -3968,55 +3881,33 @@ func (ds *Datastore) GetRecentThresholdEvents(limit int) ([]datastore.ThresholdE
 	for i := range v2Events {
 		e := &v2Events[i]
 		result = append(result, datastore.ThresholdEvent{
-			ID:            e.ID,
-			SpeciesName:   eventSpeciesName(e),
-			PreviousLevel: e.PreviousLevel,
-			NewLevel:      e.NewLevel,
-			PreviousValue: e.PreviousValue,
-			NewValue:      e.NewValue,
-			ChangeReason:  e.ChangeReason,
-			Confidence:    e.Confidence,
-			CreatedAt:     e.CreatedAt,
+			ID:             e.ID,
+			SpeciesName:    e.SpeciesName,
+			ScientificName: ds.displayScientificName(e.SpeciesName, e.ScientificName),
+			PreviousLevel:  e.PreviousLevel,
+			NewLevel:       e.NewLevel,
+			PreviousValue:  e.PreviousValue,
+			NewValue:       e.NewValue,
+			ChangeReason:   e.ChangeReason,
+			Confidence:     e.Confidence,
+			CreatedAt:      e.CreatedAt,
 		})
 	}
 	return result, nil
 }
 
-// DeleteThresholdEvents deletes threshold events for a species.
-// WORKAROUND(#1907): mirrors GetThresholdEvents' dual lookup. It deletes events saved
-// under BOTH the provided name (legacy common-name labels) AND the resolved scientific
-// name (post-#1907 labels). Without the common-name pass, legacy events survive the
-// delete and GetThresholdEvents resurfaces them on the next read.
-// TODO: Collapse to a single scientific-name delete when the #1907 workaround is removed
-// (after legacy common-name labels have been migrated).
+// DeleteThresholdEvents deletes threshold events for a species (lowercase common name).
 func (ds *Datastore) DeleteThresholdEvents(speciesName string) error {
 	if ds.threshold == nil {
 		return nil
 	}
 	ctx := context.Background()
-
-	// Delete by the provided name first - matches legacy/incorrectly saved events
-	// whose label scientific_name actually holds the common name.
-	if err := ds.threshold.DeleteThresholdEvents(ctx, speciesName); err != nil {
+	if err := ds.threshold.DeleteThresholdEvents(ctx, strings.ToLower(speciesName)); err != nil {
 		return errors.New(err).
 			Component("datastore").
 			Category(errors.CategoryDatabase).
 			Context("operation", "delete_threshold_events").
-			Context("query_type", "common_name").
 			Build()
-	}
-
-	// Also delete by the resolved scientific name when it differs - matches
-	// correctly saved events (after the #1907 fix).
-	if scientificName := ds.resolveToScientificName(speciesName); scientificName != speciesName {
-		if err := ds.threshold.DeleteThresholdEvents(ctx, scientificName); err != nil {
-			return errors.New(err).
-				Component("datastore").
-				Category(errors.CategoryDatabase).
-				Context("operation", "delete_threshold_events").
-				Context("query_type", "scientific_name").
-				Build()
-		}
 	}
 	return nil
 }

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -83,7 +83,7 @@ func buildConfigForManager(t *testing.T, manager v2.Manager, testLogger logger.L
 	sourceRepo := repository.NewAudioSourceRepository(db, nil, false, isMySQL)
 	weatherRepo := repository.NewWeatherRepository(db, nil, false, isMySQL)
 	imageCacheRepo := repository.NewImageCacheRepository(db, nil, labelRepo, false, isMySQL)
-	thresholdRepo := repository.NewDynamicThresholdRepository(db, nil, labelRepo, false, isMySQL)
+	thresholdRepo := repository.NewDynamicThresholdRepository(db, nil, false, isMySQL)
 	notificationRepo := repository.NewNotificationHistoryRepository(db, nil, labelRepo, false, isMySQL)
 
 	return &Config{
@@ -248,21 +248,6 @@ func (r nilInjectingLabelRepository) GetByIDs(ctx context.Context, ids []uint) (
 	return labels, nil
 }
 
-// errInjectingThresholdRepository wraps a DynamicThresholdRepository and forces
-// GetThresholdEvents to fail for one species, used to prove the second
-// (scientific-name) query error is propagated rather than swallowed.
-type errInjectingThresholdRepository struct {
-	repository.DynamicThresholdRepository
-	failOnSpecies string
-}
-
-func (r errInjectingThresholdRepository) GetThresholdEvents(ctx context.Context, speciesName string, limit int) ([]entities.ThresholdEvent, error) {
-	if speciesName == r.failOnSpecies {
-		return nil, fmt.Errorf("injected DB failure for %q", speciesName)
-	}
-	return r.DynamicThresholdRepository.GetThresholdEvents(ctx, speciesName, limit)
-}
-
 func TestV2OnlyDatastore_Open(t *testing.T) {
 	ds, cleanup := setupTestDatastore(t)
 	defer cleanup()
@@ -400,11 +385,9 @@ func TestV2OnlyDatastore_DynamicThreshold(t *testing.T) {
 	ds, cleanup := setupTestDatastore(t)
 	defer cleanup()
 
-	// Note: With LabelID normalization, lookups are now by scientific name.
-	// The SpeciesName field is still populated from the Label for compatibility.
 	threshold := &datastore.DynamicThreshold{
-		SpeciesName:    "Passer domesticus", // Will be derived from Label
-		ScientificName: "Passer domesticus",
+		SpeciesName:    "great tit",
+		ScientificName: "Parus major",
 		Level:          1,
 		CurrentValue:   0.7,
 		BaseThreshold:  0.6,
@@ -421,11 +404,11 @@ func TestV2OnlyDatastore_DynamicThreshold(t *testing.T) {
 	err := ds.SaveDynamicThreshold(threshold)
 	require.NoError(t, err)
 
-	// Get threshold by scientific name
-	retrieved, err := ds.GetDynamicThreshold("Passer domesticus")
+	// Get threshold by common name
+	retrieved, err := ds.GetDynamicThreshold("great tit")
 	require.NoError(t, err)
-	assert.Equal(t, "passer domesticus", retrieved.SpeciesName)
-	assert.Equal(t, "Passer domesticus", retrieved.ScientificName)
+	assert.Equal(t, "great tit", retrieved.SpeciesName)
+	assert.Equal(t, "Parus major", retrieved.ScientificName)
 	assert.Equal(t, 1, retrieved.Level)
 	assert.InDelta(t, 0.7, retrieved.CurrentValue, 0.001)
 
@@ -433,9 +416,11 @@ func TestV2OnlyDatastore_DynamicThreshold(t *testing.T) {
 	all, err := ds.GetAllDynamicThresholds()
 	require.NoError(t, err)
 	assert.Len(t, all, 1)
+	assert.Equal(t, "great tit", all[0].SpeciesName)
+	assert.Equal(t, "Parus major", all[0].ScientificName)
 
-	// Delete threshold by scientific name
-	err = ds.DeleteDynamicThreshold("Passer domesticus")
+	// Delete threshold by common name
+	err = ds.DeleteDynamicThreshold("great tit")
 	require.NoError(t, err)
 
 	// Verify deletion
@@ -445,19 +430,14 @@ func TestV2OnlyDatastore_DynamicThreshold(t *testing.T) {
 }
 
 // TestV2OnlyDatastore_DynamicThreshold_CommonNameDisplay verifies that
-// GetDynamicThreshold and GetAllDynamicThresholds return common names
-// in SpeciesName when a label mapping exists (Bug 1 fix).
+// SpeciesName round-trips as the stored lowercase common name and
+// ScientificName round-trips as stored metadata.
 func TestV2OnlyDatastore_DynamicThreshold_CommonNameDisplay(t *testing.T) {
-	labels := []string{
-		"Parus major_Great Tit",
-		"Turdus merula_Eurasian Blackbird",
-	}
-	ds, cleanup := setupTestDatastoreWithLabels(t, labels)
+	ds, cleanup := setupTestDatastore(t)
 	defer cleanup()
 
-	// Save threshold using scientific name (as the processor does)
 	threshold := &datastore.DynamicThreshold{
-		SpeciesName:    "Parus major",
+		SpeciesName:    "great tit",
 		ScientificName: "Parus major",
 		Level:          2,
 		CurrentValue:   0.5,
@@ -473,31 +453,28 @@ func TestV2OnlyDatastore_DynamicThreshold_CommonNameDisplay(t *testing.T) {
 	err := ds.SaveDynamicThreshold(threshold)
 	require.NoError(t, err)
 
-	// GetDynamicThreshold should return common name in SpeciesName
-	retrieved, err := ds.GetDynamicThreshold("Parus major")
+	// GetDynamicThreshold should return lowercase common name and stored scientific name
+	retrieved, err := ds.GetDynamicThreshold("great tit")
 	require.NoError(t, err)
-	assert.Equal(t, "great tit", retrieved.SpeciesName, "SpeciesName should be common name")
-	assert.Equal(t, "Parus major", retrieved.ScientificName, "ScientificName should stay scientific")
+	assert.Equal(t, "great tit", retrieved.SpeciesName)
+	assert.Equal(t, "Parus major", retrieved.ScientificName)
 
-	// GetAllDynamicThresholds should also return common name
+	// GetAllDynamicThresholds should also return lowercase common name and stored scientific name
 	all, err := ds.GetAllDynamicThresholds()
 	require.NoError(t, err)
 	require.Len(t, all, 1)
-	assert.Equal(t, "great tit", all[0].SpeciesName, "SpeciesName should be common name in list")
-	assert.Equal(t, "Parus major", all[0].ScientificName, "ScientificName should stay scientific in list")
+	assert.Equal(t, "great tit", all[0].SpeciesName)
+	assert.Equal(t, "Parus major", all[0].ScientificName)
 }
 
 // TestV2OnlyDatastore_DynamicThreshold_SpeciesNameRetrieval verifies that
-// GetAllDynamicThresholds and GetDynamicThreshold return common names.
+// GetAllDynamicThresholds and GetDynamicThreshold return lowercase common names.
 func TestV2OnlyDatastore_DynamicThreshold_SpeciesNameRetrieval(t *testing.T) {
-	labels := []string{
-		"Parus major_Great Tit",
-	}
-	ds, cleanup := setupTestDatastoreWithLabels(t, labels)
+	ds, cleanup := setupTestDatastore(t)
 	defer cleanup()
 
 	threshold := &datastore.DynamicThreshold{
-		SpeciesName:    "Parus major",
+		SpeciesName:    "great tit",
 		ScientificName: "Parus major",
 		Level:          2,
 		CurrentValue:   0.5,
@@ -518,29 +495,25 @@ func TestV2OnlyDatastore_DynamicThreshold_SpeciesNameRetrieval(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, all, 1)
 	assert.Equal(t, "great tit", all[0].SpeciesName,
-		"SpeciesName must be lowercase to match processor convention")
+		"SpeciesName must be lowercase")
+	assert.Equal(t, "Parus major", all[0].ScientificName)
 
 	// GetDynamicThreshold (single lookup) must also return lowercase common name
-	single, err := ds.GetDynamicThreshold("Parus major")
+	single, err := ds.GetDynamicThreshold("great tit")
 	require.NoError(t, err)
 	assert.Equal(t, "great tit", single.SpeciesName,
 		"Single lookup SpeciesName must be lowercase")
+	assert.Equal(t, "Parus major", single.ScientificName)
 }
 
 // TestV2OnlyDatastore_DynamicThreshold_DeleteByCommonName verifies that
-// DeleteDynamicThreshold works when called with a common name (Bug 2 fix).
-// The processor uses lowercase common names as map keys and passes them
-// to the datastore's delete method.
+// DeleteDynamicThreshold deletes by common name.
 func TestV2OnlyDatastore_DynamicThreshold_DeleteByCommonName(t *testing.T) {
-	labels := []string{
-		"Parus major_Great Tit",
-	}
-	ds, cleanup := setupTestDatastoreWithLabels(t, labels)
+	ds, cleanup := setupTestDatastore(t)
 	defer cleanup()
 
-	// Save threshold with scientific name
 	threshold := &datastore.DynamicThreshold{
-		SpeciesName:    "Parus major",
+		SpeciesName:    "great tit",
 		ScientificName: "Parus major",
 		Level:          1,
 		CurrentValue:   0.6,
@@ -559,7 +532,7 @@ func TestV2OnlyDatastore_DynamicThreshold_DeleteByCommonName(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, all, 1)
 
-	// Delete using lowercase common name (what the processor sends after Bug 1 fix)
+	// Delete using common name
 	err = ds.DeleteDynamicThreshold("great tit")
 	require.NoError(t, err)
 
@@ -569,18 +542,14 @@ func TestV2OnlyDatastore_DynamicThreshold_DeleteByCommonName(t *testing.T) {
 	assert.Empty(t, all, "threshold should be deleted when using common name")
 }
 
-// TestV2OnlyDatastore_DynamicThreshold_GetByCommonName verifies that
-// GetDynamicThreshold works when called with a common name.
+// TestV2OnlyDatastore_DynamicThreshold_GetByCommonName verifies case-insensitive
+// retrieval of dynamic thresholds.
 func TestV2OnlyDatastore_DynamicThreshold_GetByCommonName(t *testing.T) {
-	labels := []string{
-		"Parus major_Great Tit",
-	}
-	ds, cleanup := setupTestDatastoreWithLabels(t, labels)
+	ds, cleanup := setupTestDatastore(t)
 	defer cleanup()
 
-	// Save threshold with scientific name
 	threshold := &datastore.DynamicThreshold{
-		SpeciesName:    "Parus major",
+		SpeciesName:    "great tit",
 		ScientificName: "Parus major",
 		Level:          1,
 		CurrentValue:   0.6,
@@ -594,23 +563,44 @@ func TestV2OnlyDatastore_DynamicThreshold_GetByCommonName(t *testing.T) {
 	err := ds.SaveDynamicThreshold(threshold)
 	require.NoError(t, err)
 
-	// Retrieve using lowercase common name
-	retrieved, err := ds.GetDynamicThreshold("great tit")
+	// Retrieve using mixed-case common name
+	retrieved, err := ds.GetDynamicThreshold("Great Tit")
 	require.NoError(t, err)
 	assert.Equal(t, "great tit", retrieved.SpeciesName)
 	assert.Equal(t, "Parus major", retrieved.ScientificName)
 }
 
 // TestV2OnlyDatastore_DynamicThreshold_FallbackWithoutMapping verifies that
-// when no label mapping exists, SpeciesName falls back to scientific name
-// (existing behavior preserved).
+// with no name maps configured, a stored empty ScientificName stays empty,
+// while a stored non-empty ScientificName round-trips.
 func TestV2OnlyDatastore_DynamicThreshold_FallbackWithoutMapping(t *testing.T) {
-	// No labels - empty maps
 	ds, cleanup := setupTestDatastore(t)
 	defer cleanup()
 
-	threshold := &datastore.DynamicThreshold{
-		SpeciesName:    "Passer domesticus",
+	// Case 1: Stored empty ScientificName stays empty
+	emptySci := &datastore.DynamicThreshold{
+		SpeciesName:    "great tit",
+		ScientificName: "",
+		Level:          1,
+		CurrentValue:   0.7,
+		BaseThreshold:  0.6,
+		ValidHours:     24,
+		ExpiresAt:      time.Now().Add(24 * time.Hour),
+		LastTriggered:  time.Now(),
+		FirstCreated:   time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+	err := ds.SaveDynamicThreshold(emptySci)
+	require.NoError(t, err)
+
+	retrievedEmpty, err := ds.GetDynamicThreshold("great tit")
+	require.NoError(t, err)
+	assert.Equal(t, "great tit", retrievedEmpty.SpeciesName)
+	assert.Empty(t, retrievedEmpty.ScientificName, "stored empty scientific name should stay empty without name maps")
+
+	// Case 2: Stored non-empty ScientificName round-trips
+	withSci := &datastore.DynamicThreshold{
+		SpeciesName:    "house sparrow",
 		ScientificName: "Passer domesticus",
 		Level:          1,
 		CurrentValue:   0.7,
@@ -621,25 +611,23 @@ func TestV2OnlyDatastore_DynamicThreshold_FallbackWithoutMapping(t *testing.T) {
 		FirstCreated:   time.Now(),
 		UpdatedAt:      time.Now(),
 	}
-	err := ds.SaveDynamicThreshold(threshold)
+	err = ds.SaveDynamicThreshold(withSci)
 	require.NoError(t, err)
 
-	// Without label mapping, should fall back to scientific name
-	retrieved, err := ds.GetDynamicThreshold("Passer domesticus")
+	retrievedWith, err := ds.GetDynamicThreshold("house sparrow")
 	require.NoError(t, err)
-	assert.Equal(t, "passer domesticus", retrieved.SpeciesName, "should fallback to scientific name")
-	assert.Equal(t, "Passer domesticus", retrieved.ScientificName)
+	assert.Equal(t, "house sparrow", retrievedWith.SpeciesName)
+	assert.Equal(t, "Passer domesticus", retrievedWith.ScientificName)
 }
 
 // TestV2OnlyDatastore_DynamicThreshold_UpdateExpiryByCommonName verifies that
 // UpdateDynamicThresholdExpiry works when called with a common name.
 func TestV2OnlyDatastore_DynamicThreshold_UpdateExpiryByCommonName(t *testing.T) {
-	labels := []string{"Parus major_Great Tit"}
-	ds, cleanup := setupTestDatastoreWithLabels(t, labels)
+	ds, cleanup := setupTestDatastore(t)
 	defer cleanup()
 
 	threshold := &datastore.DynamicThreshold{
-		SpeciesName:    "Parus major",
+		SpeciesName:    "great tit",
 		ScientificName: "Parus major",
 		Level:          1,
 		CurrentValue:   0.6,
@@ -659,7 +647,7 @@ func TestV2OnlyDatastore_DynamicThreshold_UpdateExpiryByCommonName(t *testing.T)
 	require.NoError(t, err, "UpdateDynamicThresholdExpiry should work with common name")
 
 	// Verify the expiry was updated
-	retrieved, err := ds.GetDynamicThreshold("Parus major")
+	retrieved, err := ds.GetDynamicThreshold("great tit")
 	require.NoError(t, err)
 	assert.WithinDuration(t, newExpiry, retrieved.ExpiresAt, time.Second, "expiry should be updated")
 }
@@ -667,27 +655,9 @@ func TestV2OnlyDatastore_DynamicThreshold_UpdateExpiryByCommonName(t *testing.T)
 // TestV2OnlyDatastore_DynamicThreshold_DeleteEventsByCommonName verifies that
 // DeleteThresholdEvents works when called with a common name.
 func TestV2OnlyDatastore_DynamicThreshold_DeleteEventsByCommonName(t *testing.T) {
-	labels := []string{"Parus major_Great Tit"}
-	ds, cleanup := setupTestDatastoreWithLabels(t, labels)
+	ds, cleanup := setupTestDatastore(t)
 	defer cleanup()
 
-	// Save a threshold first (needed for event's label resolution)
-	threshold := &datastore.DynamicThreshold{
-		SpeciesName:    "Parus major",
-		ScientificName: "Parus major",
-		Level:          1,
-		CurrentValue:   0.6,
-		BaseThreshold:  0.8,
-		ValidHours:     12,
-		ExpiresAt:      time.Now().Add(12 * time.Hour),
-		LastTriggered:  time.Now(),
-		FirstCreated:   time.Now(),
-		UpdatedAt:      time.Now(),
-	}
-	err := ds.SaveDynamicThreshold(threshold)
-	require.NoError(t, err)
-
-	// Save an event using scientific name (as the processor does after #1907)
 	event := &datastore.ThresholdEvent{
 		SpeciesName:    "great tit",
 		ScientificName: "Parus major",
@@ -699,11 +669,11 @@ func TestV2OnlyDatastore_DynamicThreshold_DeleteEventsByCommonName(t *testing.T)
 		Confidence:     0.95,
 		CreatedAt:      time.Now(),
 	}
-	err = ds.SaveThresholdEvent(event)
+	err := ds.SaveThresholdEvent(event)
 	require.NoError(t, err)
 
 	// Verify event exists
-	events, err := ds.GetThresholdEvents("Parus major", 10)
+	events, err := ds.GetThresholdEvents("great tit", 10)
 	require.NoError(t, err)
 	require.NotEmpty(t, events, "event should exist before delete")
 
@@ -712,61 +682,62 @@ func TestV2OnlyDatastore_DynamicThreshold_DeleteEventsByCommonName(t *testing.T)
 	require.NoError(t, err, "DeleteThresholdEvents should work with common name")
 
 	// Verify events are deleted
-	events, err = ds.GetThresholdEvents("Parus major", 10)
+	events, err = ds.GetThresholdEvents("great tit", 10)
 	require.NoError(t, err)
 	assert.Empty(t, events, "events should be deleted when using common name")
 }
 
-// TestV2OnlyDatastore_DeleteThresholdEvents_LegacyCommonNameLabel pins the read/delete
-// symmetry: an event saved under a legacy common-name-shaped label (its scientific_name
-// column actually holds the common name, mimicking pre-#1907 mis-saved data) must
-// be deleted, not just the post-#1907 scientific-name-shaped event. On the pre-fix
-// code DeleteThresholdEvents resolved only to the scientific name, so the legacy
-// event survived and GetThresholdEvents resurfaced it on the next read.
-func TestV2OnlyDatastore_DeleteThresholdEvents_LegacyCommonNameLabel(t *testing.T) {
-	ds, cleanup := setupTestDatastoreWithLabels(t, []string{"Parus major_Great Tit"})
+// TestV2OnlyDatastore_DynamicThreshold_FirstCreatedPreservedOnUpsert verifies that
+// first_created timestamp is preserved across upsert conflicts.
+func TestV2OnlyDatastore_DynamicThreshold_FirstCreatedPreservedOnUpsert(t *testing.T) {
+	ds, cleanup := setupTestDatastore(t)
 	defer cleanup()
 
-	// Legacy mis-saved event: an empty ScientificName forces SaveThresholdEvent's
-	// fallback to use the common name, creating a label whose scientific_name = "great tit".
-	legacy := &datastore.ThresholdEvent{
-		SpeciesName:   "great tit",
-		PreviousLevel: 0,
-		NewLevel:      1,
-		PreviousValue: 0.8,
-		NewValue:      0.6,
-		ChangeReason:  "high_confidence",
-		Confidence:    0.95,
-		CreatedAt:     time.Now(),
-	}
-	require.NoError(t, ds.SaveThresholdEvent(legacy))
+	t0 := time.Now().Add(-72 * time.Hour)
+	t1 := time.Now().Add(-1 * time.Hour)
 
-	// Correctly-shaped event (post-#1907): label scientific_name = "Parus major".
-	correct := &datastore.ThresholdEvent{
-		SpeciesName:    "great tit",
-		ScientificName: "Parus major",
-		PreviousLevel:  1,
-		NewLevel:       2,
-		PreviousValue:  0.6,
-		NewValue:       0.5,
-		ChangeReason:   "high_confidence",
-		Confidence:     0.97,
-		CreatedAt:      time.Now().Add(time.Second),
-	}
-	require.NoError(t, ds.SaveThresholdEvent(correct))
-
-	// The dual-read by common name surfaces both label shapes before delete.
-	events, err := ds.GetThresholdEvents("great tit", 10)
+	err := ds.BatchSaveDynamicThresholds([]datastore.DynamicThreshold{
+		{
+			SpeciesName:    "great tit",
+			ScientificName: "Parus major",
+			Level:          1,
+			CurrentValue:   0.7,
+			BaseThreshold:  0.8,
+			HighConfCount:  1,
+			ValidHours:     24,
+			ExpiresAt:      time.Now().Add(24 * time.Hour),
+			FirstCreated:   t0,
+			LastTriggered:  t1,
+			TriggerCount:   1,
+		},
+	})
 	require.NoError(t, err)
-	require.Len(t, events, 2, "both legacy and correct events should be visible before delete")
 
-	// Delete by common name must remove BOTH shapes (the read/delete symmetry fix).
-	require.NoError(t, ds.DeleteThresholdEvents("great tit"))
+	t2 := time.Now()
+	t3 := time.Now()
 
-	// Nothing should reappear on the next read.
-	events, err = ds.GetThresholdEvents("great tit", 10)
+	err = ds.BatchSaveDynamicThresholds([]datastore.DynamicThreshold{
+		{
+			SpeciesName:    "great tit",
+			ScientificName: "Parus major",
+			Level:          2,
+			CurrentValue:   0.7,
+			BaseThreshold:  0.8,
+			HighConfCount:  1,
+			ValidHours:     24,
+			ExpiresAt:      time.Now().Add(24 * time.Hour),
+			FirstCreated:   t2,
+			LastTriggered:  t3,
+			TriggerCount:   1,
+		},
+	})
 	require.NoError(t, err)
-	assert.Empty(t, events, "legacy common-name event must not survive the delete")
+
+	retrieved, err := ds.GetDynamicThreshold("great tit")
+	require.NoError(t, err)
+	assert.WithinDuration(t, t0, retrieved.FirstCreated, time.Second, "first_created must be preserved across upsert")
+	assert.Equal(t, 2, retrieved.Level)
+	assert.WithinDuration(t, t3, retrieved.LastTriggered, time.Second, "last_triggered must be updated across upsert")
 }
 
 func TestV2OnlyDatastore_ImageCache(t *testing.T) {
@@ -949,11 +920,11 @@ func TestV2OnlyDatastore_ThresholdReads_ErrorTelemetry(t *testing.T) {
 // TestV2OnlyDatastore_ThresholdEvent_Retrieval verifies that GetThresholdEvents and
 // GetRecentThresholdEvents return events for the species.
 func TestV2OnlyDatastore_ThresholdEvent_Retrieval(t *testing.T) {
-	ds, cleanup := setupTestDatastoreWithLabels(t, []string{"Parus major_Great Tit"})
+	ds, cleanup := setupTestDatastore(t)
 	defer cleanup()
 
 	event := &datastore.ThresholdEvent{
-		SpeciesName:   "Parus major",
+		SpeciesName:   "parus major",
 		PreviousLevel: 0,
 		NewLevel:      1,
 		PreviousValue: 0.6,
@@ -964,111 +935,15 @@ func TestV2OnlyDatastore_ThresholdEvent_Retrieval(t *testing.T) {
 	}
 	require.NoError(t, ds.SaveThresholdEvent(event))
 
-	events, err := ds.GetThresholdEvents("Parus major", 10)
+	events, err := ds.GetThresholdEvents("parus major", 10)
 	require.NoError(t, err)
 	require.Len(t, events, 1)
-	assert.Equal(t, "Parus major", events[0].SpeciesName)
+	assert.Equal(t, "parus major", events[0].SpeciesName)
 
 	recent, err := ds.GetRecentThresholdEvents(10)
 	require.NoError(t, err)
 	require.Len(t, recent, 1)
-	assert.Equal(t, "Parus major", recent[0].SpeciesName)
-}
-
-// TestV2OnlyDatastore_GetThresholdEvents_ResolvesScientificName covers the
-// second (scientific-name) query path: a common-name input resolves to a
-// different scientific name, so the merge query runs and finds events stored
-// under the scientific name.
-func TestV2OnlyDatastore_GetThresholdEvents_ResolvesScientificName(t *testing.T) {
-	ds, cleanup := setupTestDatastoreWithLabels(t, []string{"Parus major_Great Tit"})
-	defer cleanup()
-
-	// Save an event under the scientific name (the correctly-saved, post-#1907 shape).
-	event := &datastore.ThresholdEvent{
-		SpeciesName:   "Parus major",
-		PreviousLevel: 0,
-		NewLevel:      1,
-		PreviousValue: 0.6,
-		NewValue:      0.7,
-		ChangeReason:  "high_confidence",
-		Confidence:    0.95,
-		CreatedAt:     time.Now(),
-	}
-	require.NoError(t, ds.SaveThresholdEvent(event))
-
-	// Query by the common name. resolveToScientificName("Great Tit") -> "Parus major",
-	// so the second query runs and finds the event stored under the scientific name.
-	events, err := ds.GetThresholdEvents("Great Tit", 10)
-	require.NoError(t, err)
-	require.Len(t, events, 1)
-	assert.Equal(t, "Parus major", events[0].SpeciesName)
-}
-
-// TestV2OnlyDatastore_GetThresholdEvents_SecondQueryError pins the #1010 fix:
-// a DB failure on the second (scientific-name) query must surface, not be
-// swallowed and returned as an empty/partial success.
-func TestV2OnlyDatastore_GetThresholdEvents_SecondQueryError(t *testing.T) {
-	cfg, cfgCleanup := buildTestConfig(t, []string{"Parus major_Great Tit"})
-	defer cfgCleanup()
-
-	// Fail only the scientific-name (second) query; the common-name (first)
-	// query still succeeds, isolating the previously-swallowed error path.
-	cfg.Threshold = errInjectingThresholdRepository{
-		DynamicThresholdRepository: cfg.Threshold,
-		failOnSpecies:              "Parus major",
-	}
-
-	ds, err := New(cfg)
-	require.NoError(t, err)
-	defer func() { _ = ds.Close() }()
-
-	// resolveToScientificName("Great Tit") -> "Parus major", so the second query
-	// runs and the injected error must propagate. Assert on the injected message so
-	// the test pins the second (scientific-name) query as the failing one, not just
-	// any error.
-	_, err = ds.GetThresholdEvents("Great Tit", 10)
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "injected DB failure")
-}
-
-// TestV2OnlyDatastore_GetThresholdEvents_SameTimestampTieBreak pins the
-// CreatedAt/ID sort tie-break. The per-query LIMIT is applied in SQL, so a
-// single query cannot exercise the Go-side sort; the tie-break only governs how
-// the MERGED result of the two queries (common-name + scientific-name) is
-// truncated. We store one event found by Query 1 (a legacy common-name label)
-// and one found by Query 2 (the resolved scientific name) sharing a timestamp,
-// then assert the higher-ID event wins truncation to one row.
-func TestV2OnlyDatastore_GetThresholdEvents_SameTimestampTieBreak(t *testing.T) {
-	ds, cleanup := setupTestDatastoreWithLabels(t, []string{"Parus major_Great Tit"})
-	defer cleanup()
-
-	ts := time.Now()
-	// Query 1 finds this event (label scientific_name == the common-name input).
-	require.NoError(t, ds.SaveThresholdEvent(&datastore.ThresholdEvent{
-		SpeciesName: "Great Tit", NewLevel: 1, NewValue: 0.7, ChangeReason: "legacy", Confidence: 0.95, CreatedAt: ts,
-	}))
-	// Query 2 finds this event (label scientific_name == resolved scientific name).
-	require.NoError(t, ds.SaveThresholdEvent(&datastore.ThresholdEvent{
-		SpeciesName: "Parus major", NewLevel: 1, NewValue: 0.7, ChangeReason: "correct", Confidence: 0.95, CreatedAt: ts,
-	}))
-
-	// Both events come back from the merge; learn the higher ID (saved second).
-	all, err := ds.GetThresholdEvents("Great Tit", 10)
-	require.NoError(t, err)
-	require.Len(t, all, 2)
-	maxID := all[0].ID
-	for _, e := range all[1:] {
-		if e.ID > maxID {
-			maxID = e.ID
-		}
-	}
-
-	// Truncating the same-timestamp merge to one row must deterministically keep
-	// the higher ID via the tie-break.
-	top, err := ds.GetThresholdEvents("Great Tit", 1)
-	require.NoError(t, err)
-	require.Len(t, top, 1)
-	assert.Equal(t, maxID, top[0].ID)
+	assert.Equal(t, "parus major", recent[0].SpeciesName)
 }
 
 func TestV2OnlyDatastore_SearchNotes(t *testing.T) {
@@ -2091,4 +1966,91 @@ func TestV2OnlyDatastore_GetSpeciesDiversityData_TimezoneBucketing(t *testing.T)
 	none, err := ds.GetSpeciesDiversityData(ctx, "2024-06-14", "2024-06-14")
 	require.NoError(t, err)
 	assert.Empty(t, none, "detection must not bucket on the UTC date when the configured zone is UTC+5")
+}
+
+// TestV2OnlyDatastore_GetThresholdEvents_OrderingAndLimit verifies events are returned
+// most-recent-first (created_at DESC) and that the limit truncates to the newest (#4195).
+func TestV2OnlyDatastore_GetThresholdEvents_OrderingAndLimit(t *testing.T) {
+	ds, cleanup := setupTestDatastore(t)
+	defer cleanup()
+
+	base := time.Now().Truncate(time.Second)
+	offsets := []time.Duration{0, time.Minute, 2 * time.Minute}
+	for i, off := range offsets {
+		require.NoError(t, ds.SaveThresholdEvent(&datastore.ThresholdEvent{
+			SpeciesName:  "great tit",
+			NewLevel:     i + 1,
+			NewValue:     0.7,
+			ChangeReason: "high_confidence",
+			Confidence:   0.95,
+			CreatedAt:    base.Add(off),
+		}))
+	}
+
+	events, err := ds.GetThresholdEvents("great tit", 10)
+	require.NoError(t, err)
+	require.Len(t, events, 3)
+	// Descending by created_at: newest first.
+	assert.Equal(t, base.Add(2*time.Minute).Unix(), events[0].CreatedAt.Unix(), "newest event must be first")
+	assert.Equal(t, base.Unix(), events[2].CreatedAt.Unix(), "oldest event must be last")
+
+	// Limit truncates to the newest.
+	top, err := ds.GetThresholdEvents("great tit", 1)
+	require.NoError(t, err)
+	require.Len(t, top, 1)
+	assert.Equal(t, base.Add(2*time.Minute).Unix(), top[0].CreatedAt.Unix())
+}
+
+// TestV2OnlyDatastore_GetThresholdEvents_SameTimestampTiebreak verifies the id DESC
+// tiebreaker makes same-created_at truncation deterministic under the limit (#4195).
+func TestV2OnlyDatastore_GetThresholdEvents_SameTimestampTiebreak(t *testing.T) {
+	ds, cleanup := setupTestDatastore(t)
+	defer cleanup()
+
+	ts := time.Now().Truncate(time.Second)
+	require.NoError(t, ds.SaveThresholdEvent(&datastore.ThresholdEvent{
+		SpeciesName: "great tit", NewLevel: 1, NewValue: 0.7, ChangeReason: "first", Confidence: 0.9, CreatedAt: ts,
+	}))
+	require.NoError(t, ds.SaveThresholdEvent(&datastore.ThresholdEvent{
+		SpeciesName: "great tit", NewLevel: 2, NewValue: 0.6, ChangeReason: "second", Confidence: 0.9, CreatedAt: ts,
+	}))
+
+	all, err := ds.GetThresholdEvents("great tit", 10)
+	require.NoError(t, err)
+	require.Len(t, all, 2)
+	// Under "created_at DESC, id DESC" the higher id (saved second) sorts first.
+	assert.Greater(t, all[0].ID, all[1].ID, "same-timestamp events must order by id DESC")
+
+	top, err := ds.GetThresholdEvents("great tit", 1)
+	require.NoError(t, err)
+	require.Len(t, top, 1)
+	assert.Equal(t, all[0].ID, top[0].ID, "same-timestamp truncation must deterministically keep the higher id")
+}
+
+// TestV2OnlyDatastore_DynamicThreshold_EmptySpeciesRejected verifies the empty-key guard:
+// a save with an empty species key is rejected by the repository rather than silently
+// keying a row on the empty string (#4195).
+func TestV2OnlyDatastore_DynamicThreshold_EmptySpeciesRejected(t *testing.T) {
+	ds, cleanup := setupTestDatastore(t)
+	defer cleanup()
+
+	err := ds.SaveDynamicThreshold(&datastore.DynamicThreshold{
+		SpeciesName:   "",
+		Level:         1,
+		CurrentValue:  0.7,
+		BaseThreshold: 0.8,
+		ValidHours:    24,
+		ExpiresAt:     time.Now().Add(24 * time.Hour),
+	})
+	require.Error(t, err, "empty species name must be rejected")
+
+	batchErr := ds.BatchSaveDynamicThresholds([]datastore.DynamicThreshold{{
+		SpeciesName:   "",
+		Level:         1,
+		CurrentValue:  0.7,
+		BaseThreshold: 0.8,
+		ValidHours:    24,
+		ExpiresAt:     time.Now().Add(24 * time.Hour),
+	}})
+	require.Error(t, batchErr, "empty species name must be rejected in batch save")
 }

--- a/internal/datastore/v2only/fresh_install.go
+++ b/internal/datastore/v2only/fresh_install.go
@@ -124,7 +124,7 @@ func InitializeFreshInstall(settings *conf.Settings, log logger.Logger, speciesC
 	sourceRepo := repository.NewAudioSourceRepository(db, nil, useV2Prefix, isMySQL)
 	weatherRepo := repository.NewWeatherRepository(db, nil, useV2Prefix, isMySQL)
 	imageCacheRepo := repository.NewImageCacheRepository(db, nil, labelRepo, useV2Prefix, isMySQL)
-	thresholdRepo := repository.NewDynamicThresholdRepository(db, nil, labelRepo, useV2Prefix, isMySQL)
+	thresholdRepo := repository.NewDynamicThresholdRepository(db, nil, useV2Prefix, isMySQL)
 	notificationRepo := repository.NewNotificationHistoryRepository(db, nil, labelRepo, useV2Prefix, isMySQL)
 	appEventRepo := repository.NewAppEventRepository(db, nil, useV2Prefix, isMySQL)
 	labelTypeRepo := repository.NewLabelTypeRepository(db, nil, useV2Prefix)


### PR DESCRIPTION
## Summary

On a multi-model install, every `dynamic_thresholds` and `threshold_events` row was attributed to the wrong model's label. Since #4173, dynamic thresholds are tracked per species and are model-independent (the in-memory map is keyed by lowercase common name), but the v2 datastore still persisted these rows through a model-scoped `label_id` foreign key resolved via the default model (BirdNET 2.4). So every row landed on the default model's label regardless of which model actually learned it, including species that model never detected and even when it was not assigned to any audio source. This is a data-attribution and diagnostics problem, not a detection bug.

The fix re-keys both tables on `species_name` (lowercase common name), matching the in-memory map, the API merge, and the legacy v1 schema, and drops the `label_id` foreign key along with all label resolution (including the dual-query workaround from #1907). A pre-AutoMigrate step recreates the two tables when the legacy `label_id` column is present; existing rows are intentionally discarded and relearned, since thresholds are short-lived and expire within their validity window. This works on both SQLite and MySQL and honors the MySQL coexistence table prefix.

It also fixes a secondary bug: `first_created` and `last_triggered` were stamped with the flush time on every periodic persist and then overwritten by the upsert, so all rows shared a single timestamp. Both fields are now tracked on the in-memory struct, set at initialization and on each learn event, preserved on persist, and `first_created` is excluded from the upsert update set so it reflects true creation time. Threshold-event ordering also gains a unique `id DESC` tiebreaker so same-timestamp events truncate deterministically under a limit.

## Related Issues

Fixes #4195

## Test Plan

- [x] `go test -race` passes for datastore v2, v2only, processor, and the dynamic-thresholds API packages
- [x] `golangci-lint run` reports zero issues on the changed packages
- [x] New regression tests: `first_created` preserved across upsert; processor-side timestamp preservation and zero-value fallback; the schema-recreate migration (drop stale `label_id` table, recreate on `species_name`, idempotency, fresh-install no-op); event ordering, limit, and same-timestamp tiebreak; empty-species-key rejection
- [ ] Manual: on a multi-model install, confirm new threshold and event rows resolve to the learning species and that `first_created` / `last_triggered` differ per row

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dynamic thresholds now track creation time, last-triggered time, and trigger count.
  * Thresholds and events use normalized common species names, while retaining scientific names for display.
  * API responses include expanded threshold timing and trigger information.
* **Bug Fixes**
  * Preserved per-threshold timestamps during storage and updates.
  * Improved event ordering and rejected invalid empty species keys.
  * Legacy threshold tables are safely recreated during database initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->