### PR TITLE
chore: ignore local agent override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ tmp
 *.exe
 *.off
 *.local.md
+/AGENTS.override.md
 model/labels_en.txt
 model/labels_fi.txt
 output/soundscape.wav.txt


### PR DESCRIPTION
## Summary

- Ignore the root `AGENTS.override.md` so contributors can keep local Codex instructions without accidentally committing them.

## Preflight Status

- **Scope:** Single-purpose change; only `.gitignore` is modified.
- **Review:** The root-anchored rule ignores only `AGENTS.override.md` at the repository root. No runtime code, API, config behavior, secrets, or PII are involved.
- **Diff checks:** `git diff --check` passed; `git check-ignore -v AGENTS.override.md` resolves to the new rule; the override remains untracked.
- **Go lint:** `golangci-lint` v2.12.2 completed with 0 issues using the repository's non-embedded local build tags. The unchanged tree has one existing frontend ESLint warning.
- **Frontend checks:** `npm run check:all` passed; `npm test -- --run` passed all 2,878 tests.
- **Go tests:** The provisioned TFLite race suite passed broadly. Its only local failure is the unchanged FFmpeg normalization test under FFmpeg 9.0.1 (`TestExtractClip_Filters/normalize_filter`, exit 234); hosted CI is the authoritative supported-runner check.
- **Breaking changes:** None.
- **Secondary-model cross-validation:** Not used for this one-line, non-runtime ignore rule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project ignore settings to exclude the root-level `AGENTS.override.md` file from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->