### PR TITLE
fix(classifier,analysis,api): recover from stale model paths and register gallery models with running sources

### DIFF
--- a/cmd/benchmark/benchmark.go
+++ b/cmd/benchmark/benchmark.go
@@ -89,6 +89,13 @@ type benchmarkResults struct {
 }
 
 func runInferenceBenchmark(settings *conf.Settings, results *benchmarkResults) error {
+	// This is a read-only diagnostic: never rewrite the user's config.yaml if a
+	// configured model path turns out to be stale. Must be set BEFORE
+	// NewOrchestrator, because the first path-correction drain runs inside
+	// construction. The runtime fallback still resolves stale paths so the
+	// benchmark can run.
+	classifier.SetPathCorrectionPersistenceDisabled(true)
+
 	// Initialize BirdNET
 	bn, err := classifier.NewOrchestrator(settings)
 	if err != nil {

--- a/cmd/rangefilter/print.go
+++ b/cmd/rangefilter/print.go
@@ -15,6 +15,13 @@ func PrintCommand(settings *conf.Settings) *cobra.Command {
 		Use:   "print",
 		Short: "Print BirdNET range filter results",
 		Run: func(cmd *cobra.Command, args []string) {
+			// This is a read-only diagnostic: never rewrite the user's config.yaml if
+			// a configured model path turns out to be stale. Must be set BEFORE
+			// NewOrchestrator, because the first path-correction drain runs inside
+			// construction. The runtime fallback still resolves stale paths so the
+			// filter can run.
+			classifier.SetPathCorrectionPersistenceDisabled(true)
+
 			bn, err := classifier.NewOrchestrator(settings)
 			if err != nil {
 				fmt.Printf("Error initializing BirdNET: %v\n", err)

--- a/frontend/src/lib/desktop/features/system/inference.types.ts
+++ b/frontend/src/lib/desktop/features/system/inference.types.ts
@@ -132,6 +132,13 @@ export interface ModelSource {
   name: string;
   type?: string;
   fallback?: boolean;
+  /**
+   * True when settings assign this source to the model but the audio router is
+   * not actually feeding it, so the model produces no detections for it. The
+   * status used to report attachment from configuration alone, which showed a
+   * model as running while it analyzed nothing.
+   */
+  notRunning?: boolean;
 }
 
 /** Ring-buffer metric keys used to look up per-model time series. */

--- a/frontend/src/lib/desktop/views/SystemInference.svelte
+++ b/frontend/src/lib/desktop/views/SystemInference.svelte
@@ -1321,12 +1321,22 @@
                 {:else}
                   <div class="flex flex-wrap gap-1.5">
                     {#each model.sources as source}
-                      <Badge variant="ghost" size="sm">
+                      <Badge
+                        variant={source.notRunning ? 'error' : 'ghost'}
+                        size="sm"
+                        title={source.notRunning
+                          ? t('system.inference.sourceNotRunningTooltip')
+                          : undefined}
+                      >
                         {source.name}{#if source.type}
                           <span class="text-muted ml-1">({source.type})</span>
                         {/if}{#if source.fallback}
                           <span class="text-muted ml-1">
                             - {t('system.inference.primaryFallback')}
+                          </span>
+                        {/if}{#if source.notRunning}
+                          <span class="ml-1">
+                            - {t('system.inference.sourceNotRunning')}
                           </span>
                         {/if}
                       </Badge>

--- a/frontend/src/lib/desktop/views/SystemInference.svelte
+++ b/frontend/src/lib/desktop/views/SystemInference.svelte
@@ -1320,16 +1320,21 @@
                   <span class="text-xs text-muted">{t('system.inference.noSources')}</span>
                 {:else}
                   <div class="flex flex-wrap gap-1.5">
-                    {#each model.sources as source}
+                    {#each model.sources as source, sourceIdx}
+                      {@const notRunningHelpId = `source-not-running-${model.id}-${sourceIdx}`}
                       <Badge
                         variant={source.notRunning ? 'error' : 'ghost'}
+                        outline={source.notRunning}
                         size="sm"
                         title={source.notRunning
                           ? t('system.inference.sourceNotRunningTooltip')
                           : undefined}
+                        aria-describedby={source.notRunning ? notRunningHelpId : undefined}
                       >
                         {source.name}{#if source.type}
-                          <span class="text-muted ml-1">({source.type})</span>
+                          <span class={source.notRunning ? 'ml-1' : 'text-muted ml-1'}
+                            >({source.type})</span
+                          >
                         {/if}{#if source.fallback}
                           <span class="text-muted ml-1">
                             - {t('system.inference.primaryFallback')}
@@ -1340,6 +1345,11 @@
                           </span>
                         {/if}
                       </Badge>
+                      {#if source.notRunning}
+                        <span id={notRunningHelpId} class="sr-only">
+                          {t('system.inference.sourceNotRunningTooltip')}
+                        </span>
+                      {/if}
                     {/each}
                   </div>
                 {/if}

--- a/frontend/src/lib/desktop/views/SystemInference.test.ts
+++ b/frontend/src/lib/desktop/views/SystemInference.test.ts
@@ -260,6 +260,139 @@ describe('SystemInference', () => {
     expect(text).toContain('Front Yard');
   });
 
+  // The "not analyzing" source chip. The i18n stub returns the key for unmapped
+  // strings, so assertions target the key names. The Badge component renders a
+  // <span>; its error+outline variant is identified by the CSS custom property
+  // classes, and its help text is an sr-only span referenced by aria-describedby.
+  describe('not-analyzing source chip', () => {
+    /** The Badge outer spans that carry the not-running help association. */
+    function notRunningBadges(container: HTMLElement): HTMLSpanElement[] {
+      return Array.from(
+        container.querySelectorAll<HTMLSpanElement>('span[aria-describedby^="source-not-running-"]')
+      );
+    }
+
+    it('renders the not-analyzing label and error styling when notRunning is true', async () => {
+      const model = makeModel({
+        sources: [
+          { id: 'mic1', name: 'Front Yard', type: 'soundcard', fallback: false, notRunning: true },
+        ],
+      });
+      installApi(makeSnapshot([model]));
+
+      const { container } = inferenceTest.render({});
+
+      await waitFor(() => {
+        expect(container.textContent).toContain('Front Yard');
+      });
+
+      expect(container.textContent).toContain('system.inference.sourceNotRunning');
+
+      const badges = notRunningBadges(container);
+      expect(badges).toHaveLength(1);
+      const badge = badges[0];
+      // error + outline variant classes from Badge.svelte.
+      expect(badge.className).toContain('text-[var(--color-error)]');
+      expect(badge.className).toContain('border-[var(--color-error)]');
+      expect(badge.getAttribute('title')).toBe('system.inference.sourceNotRunningTooltip');
+    });
+
+    it('omits the not-analyzing label and error styling when notRunning is ABSENT (omitempty contract)', async () => {
+      // notRunning is omitted entirely, mirroring Go's json:"notRunning,omitempty".
+      const model = makeModel({
+        sources: [{ id: 'mic1', name: 'Front Yard', type: 'soundcard', fallback: false }],
+      });
+      installApi(makeSnapshot([model]));
+
+      const { container } = inferenceTest.render({});
+
+      await waitFor(() => {
+        expect(container.textContent).toContain('Front Yard');
+      });
+
+      // No label and no tooltip anywhere (the label key is also a prefix of the
+      // tooltip key, so a single absence assertion covers both).
+      expect(container.textContent).not.toContain('system.inference.sourceNotRunning');
+      expect(notRunningBadges(container)).toHaveLength(0);
+    });
+
+    it('behaves like the absent case when notRunning is false', async () => {
+      const model = makeModel({
+        sources: [
+          { id: 'mic1', name: 'Front Yard', type: 'soundcard', fallback: false, notRunning: false },
+        ],
+      });
+      installApi(makeSnapshot([model]));
+
+      const { container } = inferenceTest.render({});
+
+      await waitFor(() => {
+        expect(container.textContent).toContain('Front Yard');
+      });
+
+      expect(container.textContent).not.toContain('system.inference.sourceNotRunning');
+      expect(notRunningBadges(container)).toHaveLength(0);
+    });
+
+    it('associates aria-describedby with a real element that carries the tooltip text', async () => {
+      const model = makeModel({
+        sources: [
+          { id: 'mic1', name: 'Front Yard', type: 'soundcard', fallback: false, notRunning: true },
+        ],
+      });
+      installApi(makeSnapshot([model]));
+
+      const { container } = inferenceTest.render({});
+
+      await waitFor(() => {
+        expect(container.textContent).toContain('Front Yard');
+      });
+
+      const badge = notRunningBadges(container)[0];
+      const helpId = badge.getAttribute('aria-describedby');
+      expect(helpId).toBeTruthy();
+      const help = container.querySelector(`[id="${helpId}"]`);
+      expect(help).not.toBeNull();
+      expect(help?.textContent).toContain('system.inference.sourceNotRunningTooltip');
+    });
+
+    it('renders the label once and generates unique help ids when only one of several sources is not running', async () => {
+      const model = makeModel({
+        sources: [
+          { id: 'a', name: 'Front Yard', type: 'soundcard', fallback: false },
+          { id: 'b', name: 'Back Yard', type: 'rtsp', fallback: false, notRunning: true },
+          { id: 'c', name: 'Garage', type: 'soundcard', fallback: false },
+        ],
+      });
+      installApi(makeSnapshot([model]));
+
+      const { container } = inferenceTest.render({});
+
+      await waitFor(() => {
+        expect(container.textContent).toContain('Back Yard');
+      });
+
+      // Exactly one source is flagged, so exactly one badge carries the association
+      // and one help element exists.
+      const badges = notRunningBadges(container);
+      expect(badges).toHaveLength(1);
+
+      const helpSpans = Array.from(
+        container.querySelectorAll<HTMLElement>('span[id^="source-not-running-"]')
+      );
+      const ids = helpSpans.map(s => s.id);
+      expect(ids).toHaveLength(1);
+      // Guards the duplicate-id family behind issue #4190: every generated id is unique.
+      expect(new Set(ids).size).toBe(ids.length);
+
+      // Every aria-describedby resolves to an element that actually exists.
+      for (const badge of badges) {
+        const helpId = badge.getAttribute('aria-describedby');
+        expect(container.querySelector(`[id="${helpId}"]`)).not.toBeNull();
+      }
+    });
+  });
+
   // These tests run against the i18n stub in src/test/setup.ts, which returns the
   // key for any unmapped string, so assertions target the rendered key names
   // (system.inference.vad.*) plus the data values, not the English text.

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -394,7 +394,7 @@ export type TranslationKey =
   | 'notifications.content.region.staleTitle'
   | 'notifications.content.region.staleMessage' // params: modelName, oldRegion, newRegion
   | 'notifications.content.region.staleGlobalMessage' // params: modelName, oldRegion
-  | 'notifications.content.modelPath.reconciledTitle'
+  | 'notifications.content.modelPath.reconciledTitle' // params: modelName
   | 'notifications.content.modelPath.reconciledMessage' // params: modelName, modelPath
   | 'notifications.content.modelPath.notRegisteredTitle' // params: sourceName
   | 'notifications.content.modelPath.notRegisteredMessage' // params: models, sourceName
@@ -4210,6 +4210,7 @@ export type TranslationParams = {
     modelName: string | number;
     oldRegion: string | number;
   };
+  'notifications.content.modelPath.reconciledTitle': { modelName: string | number };
   'notifications.content.modelPath.reconciledMessage': {
     modelName: string | number;
     modelPath: string | number;

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -394,6 +394,10 @@ export type TranslationKey =
   | 'notifications.content.region.staleTitle'
   | 'notifications.content.region.staleMessage' // params: modelName, oldRegion, newRegion
   | 'notifications.content.region.staleGlobalMessage' // params: modelName, oldRegion
+  | 'notifications.content.modelPath.reconciledTitle'
+  | 'notifications.content.modelPath.reconciledMessage' // params: modelName, modelPath
+  | 'notifications.content.modelPath.notRegisteredTitle' // params: sourceName
+  | 'notifications.content.modelPath.notRegisteredMessage' // params: models, sourceName
   | 'notifications.content.alert.firedTitle' // params: rule_name
   | 'notifications.content.alert.metricExceeded' // params: value, threshold
   | 'notifications.content.alert.detectionOccurred' // params: species_name, confidence
@@ -1366,6 +1370,8 @@ export type TranslationKey =
   | 'system.inference.sources'
   | 'system.inference.noSources'
   | 'system.inference.primaryFallback'
+  | 'system.inference.sourceNotRunning'
+  | 'system.inference.sourceNotRunningTooltip'
   | 'system.inference.notMeasured'
   | 'system.inference.unitMs'
   | 'system.inference.unitKhz'
@@ -4203,6 +4209,15 @@ export type TranslationParams = {
   'notifications.content.region.staleGlobalMessage': {
     modelName: string | number;
     oldRegion: string | number;
+  };
+  'notifications.content.modelPath.reconciledMessage': {
+    modelName: string | number;
+    modelPath: string | number;
+  };
+  'notifications.content.modelPath.notRegisteredTitle': { sourceName: string | number };
+  'notifications.content.modelPath.notRegisteredMessage': {
+    models: string | number;
+    sourceName: string | number;
   };
   'notifications.content.alert.firedTitle': { rule_name: string | number };
   'notifications.content.alert.metricExceeded': {

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -396,6 +396,8 @@ export type TranslationKey =
   | 'notifications.content.region.staleGlobalMessage' // params: modelName, oldRegion
   | 'notifications.content.modelPath.reconciledTitle' // params: modelName
   | 'notifications.content.modelPath.reconciledMessage' // params: modelName, modelPath
+  | 'notifications.content.modelPath.substitutedTitle' // params: modelName
+  | 'notifications.content.modelPath.substitutedMessage' // params: modelName, modelPath
   | 'notifications.content.modelPath.notRegisteredTitle' // params: sourceName
   | 'notifications.content.modelPath.notRegisteredMessage' // params: models, sourceName
   | 'notifications.content.alert.firedTitle' // params: rule_name
@@ -4212,6 +4214,11 @@ export type TranslationParams = {
   };
   'notifications.content.modelPath.reconciledTitle': { modelName: string | number };
   'notifications.content.modelPath.reconciledMessage': {
+    modelName: string | number;
+    modelPath: string | number;
+  };
+  'notifications.content.modelPath.substitutedTitle': { modelName: string | number };
+  'notifications.content.modelPath.substitutedMessage': {
     modelName: string | number;
     modelPath: string | number;
   };

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -466,6 +466,8 @@
       "modelPath": {
         "reconciledTitle": "Cesty k souborům modelu {modelName} opraveny",
         "reconciledMessage": "Nakonfigurované cesty k souborům pro {modelName} byly zastaralé a byly opraveny tak, aby odpovídaly nainstalovanému modelu v {modelPath}.",
+        "substitutedTitle": "Nakonfigurovaný soubor modelu pro {modelName} nebyl nalezen",
+        "substitutedMessage": "Soubor modelu nakonfigurovaný pro {modelName} nebyl na disku nalezen, proto se místo něj používá nainstalovaný model v {modelPath}. Vaše konfigurace zůstala nezměněna.",
         "notRegisteredTitle": "Model neanalyzuje {sourceName}",
         "notRegisteredMessage": "{models} je přiřazen ke zdroji zvuku \"{sourceName}\", ale momentálně nepřijímá zvuk, takže nevytváří detekce. Otevřete galerii modelů v Nastavení a zkontrolujte jeho stav."
       },

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -468,8 +468,8 @@
         "reconciledMessage": "Nakonfigurované cesty k souborům pro {modelName} byly zastaralé a byly opraveny tak, aby odpovídaly nainstalovanému modelu v {modelPath}.",
         "substitutedTitle": "Nakonfigurovaný soubor modelu pro {modelName} nebyl nalezen",
         "substitutedMessage": "Soubor modelu nakonfigurovaný pro {modelName} nebyl na disku nalezen, proto se místo něj používá nainstalovaný model v {modelPath}. Vaše konfigurace zůstala nezměněna.",
-        "notRegisteredTitle": "Model neanalyzuje {sourceName}",
-        "notRegisteredMessage": "{models} je přiřazen ke zdroji zvuku \"{sourceName}\", ale momentálně nepřijímá zvuk, takže nevytváří detekce. Otevřete galerii modelů v Nastavení a zkontrolujte jeho stav."
+        "notRegisteredTitle": "Žádný model neanalyzuje {sourceName}",
+        "notRegisteredMessage": "K {models} na zdroji zvuku \"{sourceName}\" se nedostává žádný zvuk, takže se nevytvářejí žádné detekce. Otevřete galerii modelů v Nastavení a zkontrolujte stav."
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -463,6 +463,12 @@
         "staleMessage": "{modelName} je nainstalován pro {oldRegion}, ale vaše nová poloha odpovídá {newRegion}. Varianty můžete změnit v galerii modelů v Nastavení.",
         "staleGlobalMessage": "{modelName} je nainstalován pro {oldRegion}, ale vaše nová poloha je mimo jeho pokrytí. Na globální variantu můžete přepnout v galerii modelů v Nastavení."
       },
+      "modelPath": {
+        "reconciledTitle": "Cesta k souboru modelu opravena",
+        "reconciledMessage": "Nakonfigurovaná cesta k souboru pro {modelName} odkazovala na soubor, který již neexistuje. Nyní se používá nainstalovaný model v {modelPath}.",
+        "notRegisteredTitle": "Model neanalyzuje {sourceName}",
+        "notRegisteredMessage": "{models} je přiřazen ke zdroji zvuku \"{sourceName}\", ale nepřijímá zvuk, takže nevytváří detekce. Model pravděpodobně není nainstalován nebo se jej nepodařilo načíst. Zkontrolujte galerii modelů v Nastavení."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Aktuální hodnota: {value} % (práh: {threshold} %)",
@@ -1767,6 +1773,8 @@
       "sources": "Zdroje zvuku",
       "noSources": "Žádné připojené zdroje",
       "primaryFallback": "primární (záložní)",
+      "sourceNotRunning": "neběží",
+      "sourceNotRunningTooltip": "Tento zdroj je v nastavení přiřazen k modelu, ale jeho zvuk se k modelu nedostává, takže nevytváří žádné detekce.",
       "notMeasured": "n/a",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -464,10 +464,10 @@
         "staleGlobalMessage": "{modelName} je nainstalován pro {oldRegion}, ale vaše nová poloha je mimo jeho pokrytí. Na globální variantu můžete přepnout v galerii modelů v Nastavení."
       },
       "modelPath": {
-        "reconciledTitle": "Cesta k souboru modelu opravena",
-        "reconciledMessage": "Nakonfigurovaná cesta k souboru pro {modelName} odkazovala na soubor, který již neexistuje. Nyní se používá nainstalovaný model v {modelPath}.",
+        "reconciledTitle": "Cesty k souborům modelu {modelName} opraveny",
+        "reconciledMessage": "Nakonfigurované cesty k souborům pro {modelName} byly zastaralé a byly opraveny tak, aby odpovídaly nainstalovanému modelu v {modelPath}.",
         "notRegisteredTitle": "Model neanalyzuje {sourceName}",
-        "notRegisteredMessage": "{models} je přiřazen ke zdroji zvuku \"{sourceName}\", ale nepřijímá zvuk, takže nevytváří detekce. Model pravděpodobně není nainstalován nebo se jej nepodařilo načíst. Zkontrolujte galerii modelů v Nastavení."
+        "notRegisteredMessage": "{models} je přiřazen ke zdroji zvuku \"{sourceName}\", ale momentálně nepřijímá zvuk, takže nevytváří detekce. Otevřete galerii modelů v Nastavení a zkontrolujte jeho stav."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1773,8 +1773,8 @@
       "sources": "Zdroje zvuku",
       "noSources": "Žádné připojené zdroje",
       "primaryFallback": "primární (záložní)",
-      "sourceNotRunning": "neběží",
-      "sourceNotRunningTooltip": "Tento zdroj je v nastavení přiřazen k modelu, ale jeho zvuk se k modelu nedostává, takže nevytváří žádné detekce.",
+      "sourceNotRunning": "neanalyzuje",
+      "sourceNotRunningTooltip": "Tento zdroj je v nastavení přiřazen k modelu, ale jeho zvuk se k modelu nedostává, takže nevytváří žádné detekce. Otevřete galerii modelů v Nastavení a zkontrolujte jeho stav.",
       "notMeasured": "n/a",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -463,6 +463,12 @@
         "staleMessage": "{modelName} er installeret for {oldRegion}, men din nye placering svarer til {newRegion}. Du kan skifte varianter fra modelgalleriet i Indstillinger.",
         "staleGlobalMessage": "{modelName} er installeret for {oldRegion}, men din nye placering er uden for dens dækning. Du kan skifte til den globale variant fra modelgalleriet i Indstillinger."
       },
+      "modelPath": {
+        "reconciledTitle": "Modelfilsti repareret",
+        "reconciledMessage": "Den konfigurerede filsti for {modelName} pegede på en fil, der ikke længere eksisterer. Den bruger nu den installerede model på {modelPath}.",
+        "notRegisteredTitle": "Model analyserer ikke {sourceName}",
+        "notRegisteredMessage": "{models} er tildelt lydkilden \"{sourceName}\", men modtager ikke lyd, så den producerer ikke detektioner. Modellen er sandsynligvis ikke installeret eller kunne ikke indlæses. Tjek modelgalleriet i Indstillinger."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Aktuel værdi: {value}% (grænse: {threshold}%)",
@@ -1767,6 +1773,8 @@
       "sources": "Lydkilder",
       "noSources": "Ingen kilder tilsluttet",
       "primaryFallback": "primær (fallback)",
+      "sourceNotRunning": "kører ikke",
+      "sourceNotRunningTooltip": "Denne kilde er tildelt modellen i indstillingerne, men dens lyd når ikke modellen, så den producerer ingen detektioner.",
       "notMeasured": "n/a",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -464,10 +464,10 @@
         "staleGlobalMessage": "{modelName} er installeret for {oldRegion}, men din nye placering er uden for dens dækning. Du kan skifte til den globale variant fra modelgalleriet i Indstillinger."
       },
       "modelPath": {
-        "reconciledTitle": "Modelfilsti repareret",
-        "reconciledMessage": "Den konfigurerede filsti for {modelName} pegede på en fil, der ikke længere eksisterer. Den bruger nu den installerede model på {modelPath}.",
+        "reconciledTitle": "Modelfilstier repareret for {modelName}",
+        "reconciledMessage": "De konfigurerede filstier for {modelName} var forældede og er blevet repareret, så de matcher den installerede model på {modelPath}.",
         "notRegisteredTitle": "Model analyserer ikke {sourceName}",
-        "notRegisteredMessage": "{models} er tildelt lydkilden \"{sourceName}\", men modtager ikke lyd, så den producerer ikke detektioner. Modellen er sandsynligvis ikke installeret eller kunne ikke indlæses. Tjek modelgalleriet i Indstillinger."
+        "notRegisteredMessage": "{models} er tildelt lydkilden \"{sourceName}\", men modtager i øjeblikket ikke lyd, så den producerer ikke detektioner. Åbn modelgalleriet i Indstillinger for at tjekke dens status."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1773,8 +1773,8 @@
       "sources": "Lydkilder",
       "noSources": "Ingen kilder tilsluttet",
       "primaryFallback": "primær (fallback)",
-      "sourceNotRunning": "kører ikke",
-      "sourceNotRunningTooltip": "Denne kilde er tildelt modellen i indstillingerne, men dens lyd når ikke modellen, så den producerer ingen detektioner.",
+      "sourceNotRunning": "analyserer ikke",
+      "sourceNotRunningTooltip": "Denne kilde er tildelt modellen i indstillingerne, men dens lyd når ikke modellen, så den producerer ingen detektioner. Åbn modelgalleriet i Indstillinger for at tjekke dens status.",
       "notMeasured": "n/a",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -466,6 +466,8 @@
       "modelPath": {
         "reconciledTitle": "Modelfilstier repareret for {modelName}",
         "reconciledMessage": "De konfigurerede filstier for {modelName} var forældede og er blevet repareret, så de matcher den installerede model på {modelPath}.",
+        "substitutedTitle": "Den konfigurerede modelfil for {modelName} blev ikke fundet",
+        "substitutedMessage": "Modelfilen, der er konfigureret til {modelName}, blev ikke fundet på disken, så den installerede model på {modelPath} bruges i stedet. Din konfiguration blev ikke ændret.",
         "notRegisteredTitle": "Model analyserer ikke {sourceName}",
         "notRegisteredMessage": "{models} er tildelt lydkilden \"{sourceName}\", men modtager i øjeblikket ikke lyd, så den producerer ikke detektioner. Åbn modelgalleriet i Indstillinger for at tjekke dens status."
       },

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -468,8 +468,8 @@
         "reconciledMessage": "De konfigurerede filstier for {modelName} var forældede og er blevet repareret, så de matcher den installerede model på {modelPath}.",
         "substitutedTitle": "Den konfigurerede modelfil for {modelName} blev ikke fundet",
         "substitutedMessage": "Modelfilen, der er konfigureret til {modelName}, blev ikke fundet på disken, så den installerede model på {modelPath} bruges i stedet. Din konfiguration blev ikke ændret.",
-        "notRegisteredTitle": "Model analyserer ikke {sourceName}",
-        "notRegisteredMessage": "{models} er tildelt lydkilden \"{sourceName}\", men modtager i øjeblikket ikke lyd, så den producerer ikke detektioner. Åbn modelgalleriet i Indstillinger for at tjekke dens status."
+        "notRegisteredTitle": "Ingen model analyserer {sourceName}",
+        "notRegisteredMessage": "Ingen lyd når {models} på lydkilden \"{sourceName}\", så der produceres ingen detektioner. Åbn modelgalleriet i Indstillinger for at tjekke status."
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -464,10 +464,10 @@
         "staleGlobalMessage": "{modelName} ist für {oldRegion} installiert, aber Ihr neuer Standort liegt außerhalb der Abdeckung. Sie können in der Modellgalerie unter Einstellungen zur globalen Variante wechseln."
       },
       "modelPath": {
-        "reconciledTitle": "Modell-Dateipfad repariert",
-        "reconciledMessage": "Der konfigurierte Dateipfad für {modelName} verwies auf eine Datei, die nicht mehr existiert. Es wird nun das installierte Modell unter {modelPath} verwendet.",
+        "reconciledTitle": "Modell-Dateipfade für {modelName} repariert",
+        "reconciledMessage": "Die konfigurierten Dateipfade für {modelName} waren veraltet und wurden repariert, um mit dem installierten Modell unter {modelPath} übereinzustimmen.",
         "notRegisteredTitle": "Modell analysiert {sourceName} nicht",
-        "notRegisteredMessage": "{models} ist der Audioquelle \"{sourceName}\" zugewiesen, empfängt jedoch kein Audio und erzeugt daher keine Erkennungen. Das Modell ist höchstwahrscheinlich nicht installiert oder konnte nicht geladen werden. Überprüfen Sie die Modellgalerie unter Einstellungen."
+        "notRegisteredMessage": "{models} ist der Audioquelle \"{sourceName}\" zugewiesen, empfängt derzeit jedoch kein Audio und erzeugt daher keine Erkennungen. Öffnen Sie die Modellgalerie unter Einstellungen, um den Status zu überprüfen."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1773,8 +1773,8 @@
       "sources": "Audioquellen",
       "noSources": "Keine Quellen verbunden",
       "primaryFallback": "Primär (Fallback)",
-      "sourceNotRunning": "Läuft nicht",
-      "sourceNotRunningTooltip": "Diese Quelle ist dem Modell in den Einstellungen zugewiesen, aber ihre Audiodaten erreichen das Modell nicht, sodass keine Erkennungen erzeugt werden.",
+      "sourceNotRunning": "analysiert nicht",
+      "sourceNotRunningTooltip": "Diese Quelle ist dem Modell in den Einstellungen zugewiesen, aber ihre Audiodaten erreichen das Modell nicht, sodass keine Erkennungen erzeugt werden. Öffnen Sie die Modellgalerie unter Einstellungen, um den Status zu überprüfen.",
       "notMeasured": "n.v.",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -463,6 +463,12 @@
         "staleMessage": "{modelName} ist für {oldRegion} installiert, aber Ihr neuer Standort entspricht {newRegion}. Sie können Varianten in der Modellgalerie unter Einstellungen wechseln.",
         "staleGlobalMessage": "{modelName} ist für {oldRegion} installiert, aber Ihr neuer Standort liegt außerhalb der Abdeckung. Sie können in der Modellgalerie unter Einstellungen zur globalen Variante wechseln."
       },
+      "modelPath": {
+        "reconciledTitle": "Modell-Dateipfad repariert",
+        "reconciledMessage": "Der konfigurierte Dateipfad für {modelName} verwies auf eine Datei, die nicht mehr existiert. Es wird nun das installierte Modell unter {modelPath} verwendet.",
+        "notRegisteredTitle": "Modell analysiert {sourceName} nicht",
+        "notRegisteredMessage": "{models} ist der Audioquelle \"{sourceName}\" zugewiesen, empfängt jedoch kein Audio und erzeugt daher keine Erkennungen. Das Modell ist höchstwahrscheinlich nicht installiert oder konnte nicht geladen werden. Überprüfen Sie die Modellgalerie unter Einstellungen."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Aktueller Wert: {value}% (Schwellenwert: {threshold}%)",
@@ -1767,6 +1773,8 @@
       "sources": "Audioquellen",
       "noSources": "Keine Quellen verbunden",
       "primaryFallback": "Primär (Fallback)",
+      "sourceNotRunning": "Läuft nicht",
+      "sourceNotRunningTooltip": "Diese Quelle ist dem Modell in den Einstellungen zugewiesen, aber ihre Audiodaten erreichen das Modell nicht, sodass keine Erkennungen erzeugt werden.",
       "notMeasured": "n.v.",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -466,6 +466,8 @@
       "modelPath": {
         "reconciledTitle": "Modell-Dateipfade für {modelName} repariert",
         "reconciledMessage": "Die konfigurierten Dateipfade für {modelName} waren veraltet und wurden repariert, um mit dem installierten Modell unter {modelPath} übereinzustimmen.",
+        "substitutedTitle": "Konfigurierte Modelldatei für {modelName} wurde nicht gefunden",
+        "substitutedMessage": "Die für {modelName} konfigurierte Modelldatei wurde nicht auf dem Datenträger gefunden, daher wird stattdessen das installierte Modell unter {modelPath} verwendet. Ihre Konfiguration wurde nicht verändert.",
         "notRegisteredTitle": "Modell analysiert {sourceName} nicht",
         "notRegisteredMessage": "{models} ist der Audioquelle \"{sourceName}\" zugewiesen, empfängt derzeit jedoch kein Audio und erzeugt daher keine Erkennungen. Öffnen Sie die Modellgalerie unter Einstellungen, um den Status zu überprüfen."
       },

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -468,8 +468,8 @@
         "reconciledMessage": "Die konfigurierten Dateipfade für {modelName} waren veraltet und wurden repariert, um mit dem installierten Modell unter {modelPath} übereinzustimmen.",
         "substitutedTitle": "Konfigurierte Modelldatei für {modelName} wurde nicht gefunden",
         "substitutedMessage": "Die für {modelName} konfigurierte Modelldatei wurde nicht auf dem Datenträger gefunden, daher wird stattdessen das installierte Modell unter {modelPath} verwendet. Ihre Konfiguration wurde nicht verändert.",
-        "notRegisteredTitle": "Modell analysiert {sourceName} nicht",
-        "notRegisteredMessage": "{models} ist der Audioquelle \"{sourceName}\" zugewiesen, empfängt derzeit jedoch kein Audio und erzeugt daher keine Erkennungen. Öffnen Sie die Modellgalerie unter Einstellungen, um den Status zu überprüfen."
+        "notRegisteredTitle": "Kein Modell analysiert {sourceName}",
+        "notRegisteredMessage": "Kein Audio erreicht {models} an der Audioquelle \"{sourceName}\", sodass keine Erkennungen erzeugt werden. Öffnen Sie die Modellgalerie unter Einstellungen, um den Status zu überprüfen."
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -466,6 +466,8 @@
       "modelPath": {
         "reconciledTitle": "Model file paths repaired for {modelName}",
         "reconciledMessage": "Configured file paths for {modelName} were out of date and have been repaired to match the installed model at {modelPath}.",
+        "substitutedTitle": "Configured model file for {modelName} was not found",
+        "substitutedMessage": "The model file configured for {modelName} was not found on disk, so the installed model at {modelPath} is being used instead. Your configuration was left unchanged.",
         "notRegisteredTitle": "Model is not analyzing {sourceName}",
         "notRegisteredMessage": "{models} is assigned to audio source \"{sourceName}\" but is not currently receiving audio, so it is not producing detections. Open the model gallery in Settings to check its status."
       },

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -463,6 +463,12 @@
         "staleMessage": "{modelName} is installed for {oldRegion}, but your new location resolves to {newRegion}. You can switch variants from the model gallery in Settings.",
         "staleGlobalMessage": "{modelName} is installed for {oldRegion}, but your new location is outside its coverage. You can switch to the global variant from the model gallery in Settings."
       },
+      "modelPath": {
+        "reconciledTitle": "Model file path repaired",
+        "reconciledMessage": "The configured file path for {modelName} pointed to a file that no longer exists. It now uses the installed model at {modelPath}.",
+        "notRegisteredTitle": "Model is not analyzing {sourceName}",
+        "notRegisteredMessage": "{models} is assigned to audio source \"{sourceName}\" but is not receiving audio, so it is not producing detections. The model is most likely not installed or failed to load. Check the model gallery in Settings."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Current value: {value}% (threshold: {threshold}%)",
@@ -1767,6 +1773,8 @@
       "sources": "Audio sources",
       "noSources": "No sources attached",
       "primaryFallback": "primary (fallback)",
+      "sourceNotRunning": "not running",
+      "sourceNotRunningTooltip": "This source is assigned to the model in settings, but its audio is not reaching the model, so it produces no detections.",
       "notMeasured": "n/a",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -468,8 +468,8 @@
         "reconciledMessage": "Configured file paths for {modelName} were out of date and have been repaired to match the installed model at {modelPath}.",
         "substitutedTitle": "Configured model file for {modelName} was not found",
         "substitutedMessage": "The model file configured for {modelName} was not found on disk, so the installed model at {modelPath} is being used instead. Your configuration was left unchanged.",
-        "notRegisteredTitle": "Model is not analyzing {sourceName}",
-        "notRegisteredMessage": "{models} is assigned to audio source \"{sourceName}\" but is not currently receiving audio, so it is not producing detections. Open the model gallery in Settings to check its status."
+        "notRegisteredTitle": "No model is analyzing {sourceName}",
+        "notRegisteredMessage": "No audio is reaching {models} on audio source \"{sourceName}\", so no detections are produced. Open the model gallery in Settings to check status."
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -464,10 +464,10 @@
         "staleGlobalMessage": "{modelName} is installed for {oldRegion}, but your new location is outside its coverage. You can switch to the global variant from the model gallery in Settings."
       },
       "modelPath": {
-        "reconciledTitle": "Model file path repaired",
-        "reconciledMessage": "The configured file path for {modelName} pointed to a file that no longer exists. It now uses the installed model at {modelPath}.",
+        "reconciledTitle": "Model file paths repaired for {modelName}",
+        "reconciledMessage": "Configured file paths for {modelName} were out of date and have been repaired to match the installed model at {modelPath}.",
         "notRegisteredTitle": "Model is not analyzing {sourceName}",
-        "notRegisteredMessage": "{models} is assigned to audio source \"{sourceName}\" but is not receiving audio, so it is not producing detections. The model is most likely not installed or failed to load. Check the model gallery in Settings."
+        "notRegisteredMessage": "{models} is assigned to audio source \"{sourceName}\" but is not currently receiving audio, so it is not producing detections. Open the model gallery in Settings to check its status."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1773,8 +1773,8 @@
       "sources": "Audio sources",
       "noSources": "No sources attached",
       "primaryFallback": "primary (fallback)",
-      "sourceNotRunning": "not running",
-      "sourceNotRunningTooltip": "This source is assigned to the model in settings, but its audio is not reaching the model, so it produces no detections.",
+      "sourceNotRunning": "not analyzing",
+      "sourceNotRunningTooltip": "This source is assigned to the model in settings, but its audio is not reaching the model, so it produces no detections. Open the model gallery in Settings to check its status.",
       "notMeasured": "n/a",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -466,6 +466,8 @@
       "modelPath": {
         "reconciledTitle": "Rutas de archivo del modelo reparadas para {modelName}",
         "reconciledMessage": "Las rutas de archivo configuradas para {modelName} estaban desactualizadas y se han reparado para coincidir con el modelo instalado en {modelPath}.",
+        "substitutedTitle": "No se encontró el archivo de modelo configurado para {modelName}",
+        "substitutedMessage": "El archivo de modelo configurado para {modelName} no se encontró en el disco, por lo que en su lugar se está usando el modelo instalado en {modelPath}. Su configuración no se modificó.",
         "notRegisteredTitle": "El modelo no está analizando {sourceName}",
         "notRegisteredMessage": "{models} está asignado a la fuente de audio \"{sourceName}\", pero actualmente no está recibiendo audio, por lo que no genera detecciones. Abra la galería de modelos en Configuración para comprobar su estado."
       },

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -463,6 +463,12 @@
         "staleMessage": "{modelName} está instalado para {oldRegion}, pero su nueva ubicación corresponde a {newRegion}. Puede cambiar de variante desde la galería de modelos en Configuración.",
         "staleGlobalMessage": "{modelName} está instalado para {oldRegion}, pero su nueva ubicación está fuera de su cobertura. Puede cambiar a la variante global desde la galería de modelos en Configuración."
       },
+      "modelPath": {
+        "reconciledTitle": "Ruta del archivo del modelo reparada",
+        "reconciledMessage": "La ruta de archivo configurada para {modelName} apuntaba a un archivo que ya no existe. Ahora se utiliza el modelo instalado en {modelPath}.",
+        "notRegisteredTitle": "El modelo no está analizando {sourceName}",
+        "notRegisteredMessage": "{models} está asignado a la fuente de audio \"{sourceName}\", pero no está recibiendo audio, por lo que no genera detecciones. Es muy probable que el modelo no esté instalado o no se haya podido cargar. Revisa la galería de modelos en Configuración."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Valor actual: {value}% (umbral: {threshold}%)",
@@ -1767,6 +1773,8 @@
       "sources": "Fuentes de audio",
       "noSources": "No hay fuentes conectadas",
       "primaryFallback": "principal (respaldo)",
+      "sourceNotRunning": "no está en ejecución",
+      "sourceNotRunningTooltip": "Esta fuente está asignada al modelo en la configuración, pero su audio no llega al modelo, por lo que no genera detecciones.",
       "notMeasured": "n/d",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -468,8 +468,8 @@
         "reconciledMessage": "Las rutas de archivo configuradas para {modelName} estaban desactualizadas y se han reparado para coincidir con el modelo instalado en {modelPath}.",
         "substitutedTitle": "No se encontró el archivo de modelo configurado para {modelName}",
         "substitutedMessage": "El archivo de modelo configurado para {modelName} no se encontró en el disco, por lo que en su lugar se está usando el modelo instalado en {modelPath}. Su configuración no se modificó.",
-        "notRegisteredTitle": "El modelo no está analizando {sourceName}",
-        "notRegisteredMessage": "{models} está asignado a la fuente de audio \"{sourceName}\", pero actualmente no está recibiendo audio, por lo que no genera detecciones. Abra la galería de modelos en Configuración para comprobar su estado."
+        "notRegisteredTitle": "Ningún modelo está analizando {sourceName}",
+        "notRegisteredMessage": "No llega audio a {models} en la fuente de audio \"{sourceName}\", por lo que no se generan detecciones. Abra la galería de modelos en Configuración para comprobar el estado."
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -464,10 +464,10 @@
         "staleGlobalMessage": "{modelName} está instalado para {oldRegion}, pero su nueva ubicación está fuera de su cobertura. Puede cambiar a la variante global desde la galería de modelos en Configuración."
       },
       "modelPath": {
-        "reconciledTitle": "Ruta del archivo del modelo reparada",
-        "reconciledMessage": "La ruta de archivo configurada para {modelName} apuntaba a un archivo que ya no existe. Ahora se utiliza el modelo instalado en {modelPath}.",
+        "reconciledTitle": "Rutas de archivo del modelo reparadas para {modelName}",
+        "reconciledMessage": "Las rutas de archivo configuradas para {modelName} estaban desactualizadas y se han reparado para coincidir con el modelo instalado en {modelPath}.",
         "notRegisteredTitle": "El modelo no está analizando {sourceName}",
-        "notRegisteredMessage": "{models} está asignado a la fuente de audio \"{sourceName}\", pero no está recibiendo audio, por lo que no genera detecciones. Es muy probable que el modelo no esté instalado o no se haya podido cargar. Revisa la galería de modelos en Configuración."
+        "notRegisteredMessage": "{models} está asignado a la fuente de audio \"{sourceName}\", pero actualmente no está recibiendo audio, por lo que no genera detecciones. Abra la galería de modelos en Configuración para comprobar su estado."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1773,8 +1773,8 @@
       "sources": "Fuentes de audio",
       "noSources": "No hay fuentes conectadas",
       "primaryFallback": "principal (respaldo)",
-      "sourceNotRunning": "no está en ejecución",
-      "sourceNotRunningTooltip": "Esta fuente está asignada al modelo en la configuración, pero su audio no llega al modelo, por lo que no genera detecciones.",
+      "sourceNotRunning": "no está analizando",
+      "sourceNotRunningTooltip": "Esta fuente está asignada al modelo en la configuración, pero su audio no llega al modelo, por lo que no genera detecciones. Abra la galería de modelos en Configuración para comprobar su estado.",
       "notMeasured": "n/d",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -463,6 +463,12 @@
         "staleMessage": "{modelName} on asennettu alueelle {oldRegion}, mutta uusi sijaintisi vastaa aluetta {newRegion}. Voit vaihtaa varianttia Asetusten malligalleriasta.",
         "staleGlobalMessage": "{modelName} on asennettu alueelle {oldRegion}, mutta uusi sijaintisi on sen kattavuusalueen ulkopuolella. Voit vaihtaa globaaliin varianttiin Asetusten malligalleriasta."
       },
+      "modelPath": {
+        "reconciledTitle": "Mallitiedoston polku korjattu",
+        "reconciledMessage": "Mallille {modelName} määritetty tiedostopolku osoitti tiedostoon, jota ei ole enää olemassa. Nyt käytetään asennettua mallia sijainnissa {modelPath}.",
+        "notRegisteredTitle": "Malli ei analysoi kohdetta {sourceName}",
+        "notRegisteredMessage": "{models} on liitetty äänilähteeseen \"{sourceName}\", mutta se ei vastaanota ääntä, joten se ei tuota havaintoja. Mallia ei todennäköisesti ole asennettu tai sen lataaminen epäonnistui. Tarkista Asetusten malligalleria."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Nykyinen arvo: {value}% (raja-arvo: {threshold}%)",
@@ -1767,6 +1773,8 @@
       "sources": "Äänilähteet",
       "noSources": "Ei liitettyjä lähteitä",
       "primaryFallback": "ensisijainen (vara)",
+      "sourceNotRunning": "ei käynnissä",
+      "sourceNotRunningTooltip": "Tämä lähde on liitetty malliin asetuksissa, mutta sen ääni ei saavu mallille, joten se ei tuota havaintoja.",
       "notMeasured": "-",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -468,8 +468,8 @@
         "reconciledMessage": "Mallille {modelName} määritetyt tiedostopolut olivat vanhentuneet, ja ne korjattiin vastaamaan asennettua mallia sijainnissa {modelPath}.",
         "substitutedTitle": "Mallille {modelName} määritettyä mallitiedostoa ei löytynyt",
         "substitutedMessage": "Mallille {modelName} määritettyä mallitiedostoa ei löytynyt levyltä, joten sen sijaan käytetään asennettua mallia sijainnissa {modelPath}. Asetuksiasi ei muutettu.",
-        "notRegisteredTitle": "Malli ei analysoi kohdetta {sourceName}",
-        "notRegisteredMessage": "{models} on liitetty äänilähteeseen \"{sourceName}\", mutta se ei tällä hetkellä vastaanota ääntä, joten se ei tuota havaintoja. Avaa Asetusten malligalleria tarkistaaksesi sen tilan."
+        "notRegisteredTitle": "Mikään malli ei analysoi kohdetta {sourceName}",
+        "notRegisteredMessage": "Ääni ei tavoita kohdetta {models} äänilähteessä \"{sourceName}\", joten havaintoja ei tuoteta. Avaa Asetusten malligalleria tarkistaaksesi tilan."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1775,8 +1775,8 @@
       "sources": "Äänilähteet",
       "noSources": "Ei liitettyjä lähteitä",
       "primaryFallback": "ensisijainen (vara)",
-      "sourceNotRunning": "ei analysoi",
-      "sourceNotRunningTooltip": "Tämä lähde on liitetty malliin asetuksissa, mutta sen ääni ei saavu mallille, joten se ei tuota havaintoja. Avaa Asetusten malligalleria tarkistaaksesi sen tilan.",
+      "sourceNotRunning": "ei analysoida",
+      "sourceNotRunningTooltip": "Tämä lähde on liitetty malliin asetuksissa, mutta sen ääni ei tavoita mallia, joten se ei tuota havaintoja. Avaa Asetusten malligalleria tarkistaaksesi sen tilan.",
       "notMeasured": "-",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -464,10 +464,10 @@
         "staleGlobalMessage": "{modelName} on asennettu alueelle {oldRegion}, mutta uusi sijaintisi on sen kattavuusalueen ulkopuolella. Voit vaihtaa globaaliin varianttiin Asetusten malligalleriasta."
       },
       "modelPath": {
-        "reconciledTitle": "Mallitiedoston polku korjattu",
-        "reconciledMessage": "Mallille {modelName} määritetty tiedostopolku osoitti tiedostoon, jota ei ole enää olemassa. Nyt käytetään asennettua mallia sijainnissa {modelPath}.",
+        "reconciledTitle": "Mallin {modelName} tiedostopolut korjattu",
+        "reconciledMessage": "Mallille {modelName} määritetyt tiedostopolut olivat vanhentuneet, ja ne korjattiin vastaamaan asennettua mallia sijainnissa {modelPath}.",
         "notRegisteredTitle": "Malli ei analysoi kohdetta {sourceName}",
-        "notRegisteredMessage": "{models} on liitetty äänilähteeseen \"{sourceName}\", mutta se ei vastaanota ääntä, joten se ei tuota havaintoja. Mallia ei todennäköisesti ole asennettu tai sen lataaminen epäonnistui. Tarkista Asetusten malligalleria."
+        "notRegisteredMessage": "{models} on liitetty äänilähteeseen \"{sourceName}\", mutta se ei tällä hetkellä vastaanota ääntä, joten se ei tuota havaintoja. Avaa Asetusten malligalleria tarkistaaksesi sen tilan."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1773,8 +1773,8 @@
       "sources": "Äänilähteet",
       "noSources": "Ei liitettyjä lähteitä",
       "primaryFallback": "ensisijainen (vara)",
-      "sourceNotRunning": "ei käynnissä",
-      "sourceNotRunningTooltip": "Tämä lähde on liitetty malliin asetuksissa, mutta sen ääni ei saavu mallille, joten se ei tuota havaintoja.",
+      "sourceNotRunning": "ei analysoi",
+      "sourceNotRunningTooltip": "Tämä lähde on liitetty malliin asetuksissa, mutta sen ääni ei saavu mallille, joten se ei tuota havaintoja. Avaa Asetusten malligalleria tarkistaaksesi sen tilan.",
       "notMeasured": "-",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -466,6 +466,8 @@
       "modelPath": {
         "reconciledTitle": "Mallin {modelName} tiedostopolut korjattu",
         "reconciledMessage": "Mallille {modelName} määritetyt tiedostopolut olivat vanhentuneet, ja ne korjattiin vastaamaan asennettua mallia sijainnissa {modelPath}.",
+        "substitutedTitle": "Mallille {modelName} määritettyä mallitiedostoa ei löytynyt",
+        "substitutedMessage": "Mallille {modelName} määritettyä mallitiedostoa ei löytynyt levyltä, joten sen sijaan käytetään asennettua mallia sijainnissa {modelPath}. Asetuksiasi ei muutettu.",
         "notRegisteredTitle": "Malli ei analysoi kohdetta {sourceName}",
         "notRegisteredMessage": "{models} on liitetty äänilähteeseen \"{sourceName}\", mutta se ei tällä hetkellä vastaanota ääntä, joten se ei tuota havaintoja. Avaa Asetusten malligalleria tarkistaaksesi sen tilan."
       },

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -466,6 +466,8 @@
       "modelPath": {
         "reconciledTitle": "Chemins de fichiers du modèle réparés pour {modelName}",
         "reconciledMessage": "Les chemins de fichiers configurés pour {modelName} étaient obsolètes et ont été réparés pour correspondre au modèle installé à l'emplacement {modelPath}.",
+        "substitutedTitle": "Le fichier de modèle configuré pour {modelName} est introuvable",
+        "substitutedMessage": "Le fichier de modèle configuré pour {modelName} est introuvable sur le disque, le modèle installé à l'emplacement {modelPath} est donc utilisé à la place. Votre configuration n'a pas été modifiée.",
         "notRegisteredTitle": "Le modèle n'analyse pas {sourceName}",
         "notRegisteredMessage": "{models} est assigné à la source audio \"{sourceName}\" mais ne reçoit actuellement pas d'audio, il ne produit donc aucune détection. Ouvrez la galerie de modèles dans les Paramètres pour vérifier son état."
       },

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -464,10 +464,10 @@
         "staleGlobalMessage": "{modelName} est installé pour {oldRegion}, mais votre nouvel emplacement est en dehors de sa couverture. Vous pouvez passer à la variante globale depuis la galerie de modèles dans les Paramètres."
       },
       "modelPath": {
-        "reconciledTitle": "Chemin du fichier de modèle réparé",
-        "reconciledMessage": "Le chemin de fichier configuré pour {modelName} pointait vers un fichier qui n'existe plus. Le modèle installé à l'emplacement {modelPath} est désormais utilisé.",
+        "reconciledTitle": "Chemins de fichiers du modèle réparés pour {modelName}",
+        "reconciledMessage": "Les chemins de fichiers configurés pour {modelName} étaient obsolètes et ont été réparés pour correspondre au modèle installé à l'emplacement {modelPath}.",
         "notRegisteredTitle": "Le modèle n'analyse pas {sourceName}",
-        "notRegisteredMessage": "{models} est assigné à la source audio \"{sourceName}\" mais ne reçoit pas d'audio, il ne produit donc aucune détection. Le modèle n'est très probablement pas installé ou n'a pas pu être chargé. Consultez la galerie de modèles dans les Paramètres."
+        "notRegisteredMessage": "{models} est assigné à la source audio \"{sourceName}\" mais ne reçoit actuellement pas d'audio, il ne produit donc aucune détection. Ouvrez la galerie de modèles dans les Paramètres pour vérifier son état."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1773,8 +1773,8 @@
       "sources": "Sources audio",
       "noSources": "Aucune source attachée",
       "primaryFallback": "primaire (secours)",
-      "sourceNotRunning": "ne fonctionne pas",
-      "sourceNotRunningTooltip": "Cette source est assignée au modèle dans les paramètres, mais son audio ne parvient pas au modèle, elle ne produit donc aucune détection.",
+      "sourceNotRunning": "n'analyse pas",
+      "sourceNotRunningTooltip": "Cette source est assignée au modèle dans les paramètres, mais son audio ne parvient pas au modèle, elle ne produit donc aucune détection. Ouvrez la galerie de modèles dans les Paramètres pour vérifier son état.",
       "notMeasured": "n/d",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -463,6 +463,12 @@
         "staleMessage": "{modelName} est installé pour {oldRegion}, mais votre nouvel emplacement correspond à {newRegion}. Vous pouvez changer de variante depuis la galerie de modèles dans les Paramètres.",
         "staleGlobalMessage": "{modelName} est installé pour {oldRegion}, mais votre nouvel emplacement est en dehors de sa couverture. Vous pouvez passer à la variante globale depuis la galerie de modèles dans les Paramètres."
       },
+      "modelPath": {
+        "reconciledTitle": "Chemin du fichier de modèle réparé",
+        "reconciledMessage": "Le chemin de fichier configuré pour {modelName} pointait vers un fichier qui n'existe plus. Le modèle installé à l'emplacement {modelPath} est désormais utilisé.",
+        "notRegisteredTitle": "Le modèle n'analyse pas {sourceName}",
+        "notRegisteredMessage": "{models} est assigné à la source audio \"{sourceName}\" mais ne reçoit pas d'audio, il ne produit donc aucune détection. Le modèle n'est très probablement pas installé ou n'a pas pu être chargé. Consultez la galerie de modèles dans les Paramètres."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Valeur actuelle : {value}% (seuil : {threshold}%)",
@@ -1767,6 +1773,8 @@
       "sources": "Sources audio",
       "noSources": "Aucune source attachée",
       "primaryFallback": "primaire (secours)",
+      "sourceNotRunning": "ne fonctionne pas",
+      "sourceNotRunningTooltip": "Cette source est assignée au modèle dans les paramètres, mais son audio ne parvient pas au modèle, elle ne produit donc aucune détection.",
       "notMeasured": "n/d",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -468,8 +468,8 @@
         "reconciledMessage": "Les chemins de fichiers configurés pour {modelName} étaient obsolètes et ont été réparés pour correspondre au modèle installé à l'emplacement {modelPath}.",
         "substitutedTitle": "Le fichier de modèle configuré pour {modelName} est introuvable",
         "substitutedMessage": "Le fichier de modèle configuré pour {modelName} est introuvable sur le disque, le modèle installé à l'emplacement {modelPath} est donc utilisé à la place. Votre configuration n'a pas été modifiée.",
-        "notRegisteredTitle": "Le modèle n'analyse pas {sourceName}",
-        "notRegisteredMessage": "{models} est assigné à la source audio \"{sourceName}\" mais ne reçoit actuellement pas d'audio, il ne produit donc aucune détection. Ouvrez la galerie de modèles dans les Paramètres pour vérifier son état."
+        "notRegisteredTitle": "Aucun modèle n'analyse {sourceName}",
+        "notRegisteredMessage": "Aucun audio ne parvient à {models} sur la source audio \"{sourceName}\", aucune détection n'est donc produite. Ouvrez la galerie de modèles dans les Paramètres pour vérifier l'état."
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -466,6 +466,8 @@
       "modelPath": {
         "reconciledTitle": "A(z) {modelName} modell fájlelérési útjai javítva",
         "reconciledMessage": "A(z) {modelName} beállított fájlelérési útjai elavultak voltak, és javításra kerültek, hogy megfeleljenek a(z) {modelPath} helyen telepített modellnek.",
+        "substitutedTitle": "A(z) {modelName} modellhez beállított modellfájl nem található",
+        "substitutedMessage": "A(z) {modelName} modellhez beállított modellfájl nem található a lemezen, ezért helyette a(z) {modelPath} helyen telepített modell van használatban. A konfigurációja változatlan maradt.",
         "notRegisteredTitle": "A modell nem elemzi a következőt: {sourceName}",
         "notRegisteredMessage": "A(z) {models} hozzá van rendelve a(z) \"{sourceName}\" hangforráshoz, de jelenleg nem kap hangot, így nem készít detektálásokat. Nyissa meg a modellgalériát a Beállításokban az állapotának ellenőrzéséhez."
       },

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -463,6 +463,12 @@
         "staleMessage": "A(z) {modelName} a(z) {oldRegion} régióhoz van telepítve, de az új helyszíne a következőnek felel meg: {newRegion}. Változatot a Beállítások modellgalériájában válthat.",
         "staleGlobalMessage": "A(z) {modelName} a(z) {oldRegion} régióhoz van telepítve, de az új helyszíne kívül esik a lefedettségén. A globális változatra a Beállítások modellgalériájában válthat."
       },
+      "modelPath": {
+        "reconciledTitle": "A modellfájl elérési útja javítva",
+        "reconciledMessage": "A(z) {modelName} beállított fájlelérési útja olyan fájlra mutatott, amely már nem létezik. Most a(z) {modelPath} helyen található telepített modellt használja.",
+        "notRegisteredTitle": "A modell nem elemzi a következőt: {sourceName}",
+        "notRegisteredMessage": "A(z) {models} hozzá van rendelve a(z) \"{sourceName}\" hangforráshoz, de nem kap hangot, így nem készít detektálásokat. A modell valószínűleg nincs telepítve, vagy nem sikerült betölteni. Ellenőrizze a modellgalériát a Beállításokban."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Jelenlegi érték: {value}% (küszöbérték: {threshold}%)",
@@ -1767,6 +1773,8 @@
       "sources": "Hangforrások",
       "noSources": "Nincs csatlakoztatott hangforrás",
       "primaryFallback": "elsődleges (tartalék)",
+      "sourceNotRunning": "nem fut",
+      "sourceNotRunningTooltip": "Ez a forrás hozzá van rendelve a modellhez a beállításokban, de a hangja nem jut el a modellhez, így nem készít észleléseket.",
       "notMeasured": "n/a",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -464,10 +464,10 @@
         "staleGlobalMessage": "A(z) {modelName} a(z) {oldRegion} régióhoz van telepítve, de az új helyszíne kívül esik a lefedettségén. A globális változatra a Beállítások modellgalériájában válthat."
       },
       "modelPath": {
-        "reconciledTitle": "A modellfájl elérési útja javítva",
-        "reconciledMessage": "A(z) {modelName} beállított fájlelérési útja olyan fájlra mutatott, amely már nem létezik. Most a(z) {modelPath} helyen található telepített modellt használja.",
+        "reconciledTitle": "A(z) {modelName} modell fájlelérési útjai javítva",
+        "reconciledMessage": "A(z) {modelName} beállított fájlelérési útjai elavultak voltak, és javításra kerültek, hogy megfeleljenek a(z) {modelPath} helyen telepített modellnek.",
         "notRegisteredTitle": "A modell nem elemzi a következőt: {sourceName}",
-        "notRegisteredMessage": "A(z) {models} hozzá van rendelve a(z) \"{sourceName}\" hangforráshoz, de nem kap hangot, így nem készít detektálásokat. A modell valószínűleg nincs telepítve, vagy nem sikerült betölteni. Ellenőrizze a modellgalériát a Beállításokban."
+        "notRegisteredMessage": "A(z) {models} hozzá van rendelve a(z) \"{sourceName}\" hangforráshoz, de jelenleg nem kap hangot, így nem készít detektálásokat. Nyissa meg a modellgalériát a Beállításokban az állapotának ellenőrzéséhez."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1773,8 +1773,8 @@
       "sources": "Hangforrások",
       "noSources": "Nincs csatlakoztatott hangforrás",
       "primaryFallback": "elsődleges (tartalék)",
-      "sourceNotRunning": "nem fut",
-      "sourceNotRunningTooltip": "Ez a forrás hozzá van rendelve a modellhez a beállításokban, de a hangja nem jut el a modellhez, így nem készít észleléseket.",
+      "sourceNotRunning": "nem elemzi",
+      "sourceNotRunningTooltip": "Ez a forrás hozzá van rendelve a modellhez a beállításokban, de a hangja nem jut el a modellhez, így nem készít észleléseket. Nyissa meg a modellgalériát a Beállításokban az állapotának ellenőrzéséhez.",
       "notMeasured": "n/a",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -468,8 +468,8 @@
         "reconciledMessage": "A(z) {modelName} beállított fájlelérési útjai elavultak voltak, és javításra kerültek, hogy megfeleljenek a(z) {modelPath} helyen telepített modellnek.",
         "substitutedTitle": "A(z) {modelName} modellhez beállított modellfájl nem található",
         "substitutedMessage": "A(z) {modelName} modellhez beállított modellfájl nem található a lemezen, ezért helyette a(z) {modelPath} helyen telepített modell van használatban. A konfigurációja változatlan maradt.",
-        "notRegisteredTitle": "A modell nem elemzi a következőt: {sourceName}",
-        "notRegisteredMessage": "A(z) {models} hozzá van rendelve a(z) \"{sourceName}\" hangforráshoz, de jelenleg nem kap hangot, így nem készít detektálásokat. Nyissa meg a modellgalériát a Beállításokban az állapotának ellenőrzéséhez."
+        "notRegisteredTitle": "Egyetlen modell sem elemzi a következőt: {sourceName}",
+        "notRegisteredMessage": "Nem jut el hang a(z) {models} számára a(z) \"{sourceName}\" hangforráson, így nem jönnek létre detektálások. Nyissa meg a modellgalériát a Beállításokban az állapot ellenőrzéséhez."
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -464,10 +464,10 @@
         "staleGlobalMessage": "{modelName} è installato per {oldRegion}, ma la tua nuova posizione è al di fuori della sua copertura. Puoi passare alla variante globale dalla galleria modelli in Impostazioni."
       },
       "modelPath": {
-        "reconciledTitle": "Percorso del file del modello riparato",
-        "reconciledMessage": "Il percorso del file configurato per {modelName} puntava a un file che non esiste più. Ora viene utilizzato il modello installato in {modelPath}.",
+        "reconciledTitle": "Percorsi dei file del modello riparati per {modelName}",
+        "reconciledMessage": "I percorsi dei file configurati per {modelName} erano obsoleti e sono stati riparati per corrispondere al modello installato in {modelPath}.",
         "notRegisteredTitle": "Il modello non sta analizzando {sourceName}",
-        "notRegisteredMessage": "{models} è assegnato alla sorgente audio \"{sourceName}\" ma non riceve audio, quindi non produce rilevamenti. Molto probabilmente il modello non è installato o non è stato possibile caricarlo. Controlla la galleria modelli in Impostazioni."
+        "notRegisteredMessage": "{models} è assegnato alla sorgente audio \"{sourceName}\" ma al momento non riceve audio, quindi non produce rilevamenti. Apra la galleria dei modelli in Impostazioni per verificarne lo stato."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1773,8 +1773,8 @@
       "sources": "Sorgenti audio",
       "noSources": "Nessuna sorgente collegata",
       "primaryFallback": "principale (fallback)",
-      "sourceNotRunning": "non in esecuzione",
-      "sourceNotRunningTooltip": "Questa sorgente è assegnata al modello nelle impostazioni, ma il suo audio non raggiunge il modello, quindi non produce rilevamenti.",
+      "sourceNotRunning": "non sta analizzando",
+      "sourceNotRunningTooltip": "Questa sorgente è assegnata al modello nelle impostazioni, ma il suo audio non raggiunge il modello, quindi non produce rilevamenti. Apra la galleria dei modelli in Impostazioni per verificarne lo stato.",
       "notMeasured": "n/d",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -463,6 +463,12 @@
         "staleMessage": "{modelName} è installato per {oldRegion}, ma la tua nuova posizione corrisponde a {newRegion}. Puoi cambiare variante dalla galleria modelli in Impostazioni.",
         "staleGlobalMessage": "{modelName} è installato per {oldRegion}, ma la tua nuova posizione è al di fuori della sua copertura. Puoi passare alla variante globale dalla galleria modelli in Impostazioni."
       },
+      "modelPath": {
+        "reconciledTitle": "Percorso del file del modello riparato",
+        "reconciledMessage": "Il percorso del file configurato per {modelName} puntava a un file che non esiste più. Ora viene utilizzato il modello installato in {modelPath}.",
+        "notRegisteredTitle": "Il modello non sta analizzando {sourceName}",
+        "notRegisteredMessage": "{models} è assegnato alla sorgente audio \"{sourceName}\" ma non riceve audio, quindi non produce rilevamenti. Molto probabilmente il modello non è installato o non è stato possibile caricarlo. Controlla la galleria modelli in Impostazioni."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Valore attuale: {value}% (soglia: {threshold}%)",
@@ -1767,6 +1773,8 @@
       "sources": "Sorgenti audio",
       "noSources": "Nessuna sorgente collegata",
       "primaryFallback": "principale (fallback)",
+      "sourceNotRunning": "non in esecuzione",
+      "sourceNotRunningTooltip": "Questa sorgente è assegnata al modello nelle impostazioni, ma il suo audio non raggiunge il modello, quindi non produce rilevamenti.",
       "notMeasured": "n/d",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -468,8 +468,8 @@
         "reconciledMessage": "I percorsi dei file configurati per {modelName} erano obsoleti e sono stati riparati per corrispondere al modello installato in {modelPath}.",
         "substitutedTitle": "File del modello configurato per {modelName} non trovato",
         "substitutedMessage": "Il file del modello configurato per {modelName} non è stato trovato sul disco, quindi viene utilizzato il modello installato in {modelPath}. La tua configurazione non è stata modificata.",
-        "notRegisteredTitle": "Il modello non sta analizzando {sourceName}",
-        "notRegisteredMessage": "{models} è assegnato alla sorgente audio \"{sourceName}\" ma al momento non riceve audio, quindi non produce rilevamenti. Apra la galleria dei modelli in Impostazioni per verificarne lo stato."
+        "notRegisteredTitle": "Nessun modello sta analizzando {sourceName}",
+        "notRegisteredMessage": "Nessun audio raggiunge {models} sulla sorgente audio \"{sourceName}\", quindi non vengono prodotti rilevamenti. Apri la galleria dei modelli in Impostazioni per verificare lo stato."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1776,7 +1776,7 @@
       "noSources": "Nessuna sorgente collegata",
       "primaryFallback": "principale (fallback)",
       "sourceNotRunning": "non sta analizzando",
-      "sourceNotRunningTooltip": "Questa sorgente è assegnata al modello nelle impostazioni, ma il suo audio non raggiunge il modello, quindi non produce rilevamenti. Apra la galleria dei modelli in Impostazioni per verificarne lo stato.",
+      "sourceNotRunningTooltip": "Questa sorgente è assegnata al modello nelle impostazioni, ma il suo audio non raggiunge il modello, quindi non produce rilevamenti. Apri la galleria dei modelli in Impostazioni per verificarne lo stato.",
       "notMeasured": "n/d",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -466,6 +466,8 @@
       "modelPath": {
         "reconciledTitle": "Percorsi dei file del modello riparati per {modelName}",
         "reconciledMessage": "I percorsi dei file configurati per {modelName} erano obsoleti e sono stati riparati per corrispondere al modello installato in {modelPath}.",
+        "substitutedTitle": "File del modello configurato per {modelName} non trovato",
+        "substitutedMessage": "Il file del modello configurato per {modelName} non è stato trovato sul disco, quindi viene utilizzato il modello installato in {modelPath}. La tua configurazione non è stata modificata.",
         "notRegisteredTitle": "Il modello non sta analizzando {sourceName}",
         "notRegisteredMessage": "{models} è assegnato alla sorgente audio \"{sourceName}\" ma al momento non riceve audio, quindi non produce rilevamenti. Apra la galleria dei modelli in Impostazioni per verificarne lo stato."
       },

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -466,6 +466,8 @@
       "modelPath": {
         "reconciledTitle": "Modeļa {modelName} failu ceļi salaboti",
         "reconciledMessage": "Konfigurētie failu ceļi modelim {modelName} bija novecojuši un tika salaboti, lai atbilstu instalētajam modelim vietā {modelPath}.",
+        "substitutedTitle": "Konfigurētais {modelName} modeļa fails netika atrasts",
+        "substitutedMessage": "Modelim {modelName} konfigurētais faila ceļš netika atrasts diskā, tāpēc tā vietā tiek izmantots instalētais modelis {modelPath}. Jūsu konfigurācija netika mainīta.",
         "notRegisteredTitle": "Modelis neanalizē {sourceName}",
         "notRegisteredMessage": "{models} ir piešķirts audio avotam \"{sourceName}\", bet pašlaik nesaņem audio, tāpēc neveic noteikšanas. Atveriet modeļu galeriju sadaļā Iestatījumi, lai pārbaudītu tā statusu."
       },

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -463,6 +463,12 @@
         "staleMessage": "{modelName} ir instalēts reģionam {oldRegion}, bet jūsu jaunā atrašanās vieta atbilst {newRegion}. Varat pārslēgt variantus no modeļu galerijas sadaļā Iestatījumi.",
         "staleGlobalMessage": "{modelName} ir instalēts reģionam {oldRegion}, bet jūsu jaunā atrašanās vieta ir ārpus tā pārklājuma. Varat pārslēgties uz globālo variantu no modeļu galerijas sadaļā Iestatījumi."
       },
+      "modelPath": {
+        "reconciledTitle": "Modeļa faila ceļš salabots",
+        "reconciledMessage": "Konfigurētais faila ceļš modelim {modelName} norādīja uz failu, kas vairs neeksistē. Tagad tiek izmantots instalētais modelis vietā {modelPath}.",
+        "notRegisteredTitle": "Modelis neanalizē {sourceName}",
+        "notRegisteredMessage": "{models} ir piešķirts audio avotam \"{sourceName}\", bet nesaņem audio, tāpēc neveic noteikšanas. Modelis, visticamāk, nav instalēts vai to neizdevās ielādēt. Pārbaudiet modeļu galeriju sadaļā Iestatījumi."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Pašreizējā vērtība: {value}% (slieksnis: {threshold}%)",
@@ -1767,6 +1773,8 @@
       "sources": "Audio avoti",
       "noSources": "Nav pievienotu avotu",
       "primaryFallback": "primārais (rezerves)",
+      "sourceNotRunning": "nedarbojas",
+      "sourceNotRunningTooltip": "Šis avots ir piešķirts modelim iestatījumos, bet tā audio nesasniedz modeli, tāpēc tas neveic noteikšanas.",
       "notMeasured": "n/p",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -464,10 +464,10 @@
         "staleGlobalMessage": "{modelName} ir instalēts reģionam {oldRegion}, bet jūsu jaunā atrašanās vieta ir ārpus tā pārklājuma. Varat pārslēgties uz globālo variantu no modeļu galerijas sadaļā Iestatījumi."
       },
       "modelPath": {
-        "reconciledTitle": "Modeļa faila ceļš salabots",
-        "reconciledMessage": "Konfigurētais faila ceļš modelim {modelName} norādīja uz failu, kas vairs neeksistē. Tagad tiek izmantots instalētais modelis vietā {modelPath}.",
+        "reconciledTitle": "Modeļa {modelName} failu ceļi salaboti",
+        "reconciledMessage": "Konfigurētie failu ceļi modelim {modelName} bija novecojuši un tika salaboti, lai atbilstu instalētajam modelim vietā {modelPath}.",
         "notRegisteredTitle": "Modelis neanalizē {sourceName}",
-        "notRegisteredMessage": "{models} ir piešķirts audio avotam \"{sourceName}\", bet nesaņem audio, tāpēc neveic noteikšanas. Modelis, visticamāk, nav instalēts vai to neizdevās ielādēt. Pārbaudiet modeļu galeriju sadaļā Iestatījumi."
+        "notRegisteredMessage": "{models} ir piešķirts audio avotam \"{sourceName}\", bet pašlaik nesaņem audio, tāpēc neveic noteikšanas. Atveriet modeļu galeriju sadaļā Iestatījumi, lai pārbaudītu tā statusu."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1773,8 +1773,8 @@
       "sources": "Audio avoti",
       "noSources": "Nav pievienotu avotu",
       "primaryFallback": "primārais (rezerves)",
-      "sourceNotRunning": "nedarbojas",
-      "sourceNotRunningTooltip": "Šis avots ir piešķirts modelim iestatījumos, bet tā audio nesasniedz modeli, tāpēc tas neveic noteikšanas.",
+      "sourceNotRunning": "neanalizē",
+      "sourceNotRunningTooltip": "Šis avots ir piešķirts modelim iestatījumos, bet tā audio nesasniedz modeli, tāpēc tas neveic noteikšanas. Atveriet modeļu galeriju sadaļā Iestatījumi, lai pārbaudītu tā statusu.",
       "notMeasured": "n/p",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -468,8 +468,8 @@
         "reconciledMessage": "Konfigurētie failu ceļi modelim {modelName} bija novecojuši un tika salaboti, lai atbilstu instalētajam modelim vietā {modelPath}.",
         "substitutedTitle": "Konfigurētais {modelName} modeļa fails netika atrasts",
         "substitutedMessage": "Modelim {modelName} konfigurētais faila ceļš netika atrasts diskā, tāpēc tā vietā tiek izmantots instalētais modelis {modelPath}. Jūsu konfigurācija netika mainīta.",
-        "notRegisteredTitle": "Modelis neanalizē {sourceName}",
-        "notRegisteredMessage": "{models} ir piešķirts audio avotam \"{sourceName}\", bet pašlaik nesaņem audio, tāpēc neveic noteikšanas. Atveriet modeļu galeriju sadaļā Iestatījumi, lai pārbaudītu tā statusu."
+        "notRegisteredTitle": "Neviens modelis neanalizē {sourceName}",
+        "notRegisteredMessage": "Audio nesasniedz {models} audio avotā \"{sourceName}\", tāpēc noteikšanas netiek veiktas. Atveriet modeļu galeriju sadaļā Iestatījumi, lai pārbaudītu statusu."
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -466,6 +466,8 @@
       "modelPath": {
         "reconciledTitle": "Modellfilstier reparert for {modelName}",
         "reconciledMessage": "De konfigurerte filstiene for {modelName} var utdaterte og har blitt reparert for å samsvare med den installerte modellen på {modelPath}.",
+        "substitutedTitle": "Fant ikke den konfigurerte modellfilen for {modelName}",
+        "substitutedMessage": "Modellfilen som er konfigurert for {modelName}, ble ikke funnet på disken, så den installerte modellen på {modelPath} brukes i stedet. Konfigurasjonen din ble ikke endret.",
         "notRegisteredTitle": "Modellen analyserer ikke {sourceName}",
         "notRegisteredMessage": "{models} er tilordnet lydkilden \"{sourceName}\", men mottar for øyeblikket ikke lyd og produserer derfor ikke registreringer. Åpne modellgalleriet i Innstillinger for å sjekke statusen."
       },

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -464,10 +464,10 @@
         "staleGlobalMessage": "{modelName} er installert for {oldRegion}, men den nye posisjonen din er utenfor dekningsområdet. Du kan bytte til den globale varianten fra modellgalleriet i Innstillinger."
       },
       "modelPath": {
-        "reconciledTitle": "Modellfilsti reparert",
-        "reconciledMessage": "Den konfigurerte filstien for {modelName} pekte på en fil som ikke lenger eksisterer. Den bruker nå den installerte modellen på {modelPath}.",
+        "reconciledTitle": "Modellfilstier reparert for {modelName}",
+        "reconciledMessage": "De konfigurerte filstiene for {modelName} var utdaterte og har blitt reparert for å samsvare med den installerte modellen på {modelPath}.",
         "notRegisteredTitle": "Modellen analyserer ikke {sourceName}",
-        "notRegisteredMessage": "{models} er tilordnet lydkilden \"{sourceName}\", men mottar ikke lyd og produserer derfor ikke registreringer. Modellen er mest sannsynlig ikke installert eller kunne ikke lastes inn. Sjekk modellgalleriet i Innstillinger."
+        "notRegisteredMessage": "{models} er tilordnet lydkilden \"{sourceName}\", men mottar for øyeblikket ikke lyd og produserer derfor ikke registreringer. Åpne modellgalleriet i Innstillinger for å sjekke statusen."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1773,8 +1773,8 @@
       "sources": "Lydkilder",
       "noSources": "Ingen kilder tilkoblet",
       "primaryFallback": "primær (fallback)",
-      "sourceNotRunning": "kjører ikke",
-      "sourceNotRunningTooltip": "Denne kilden er tilordnet modellen i innstillingene, men lyden når ikke modellen, så den produserer ingen registreringer.",
+      "sourceNotRunning": "analyserer ikke",
+      "sourceNotRunningTooltip": "Denne kilden er tilordnet modellen i innstillingene, men lyden når ikke modellen, så den produserer ingen registreringer. Åpne modellgalleriet i Innstillinger for å sjekke statusen.",
       "notMeasured": "n/a",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -463,6 +463,12 @@
         "staleMessage": "{modelName} er installert for {oldRegion}, men den nye posisjonen din tilsvarer {newRegion}. Du kan bytte varianter fra modellgalleriet i Innstillinger.",
         "staleGlobalMessage": "{modelName} er installert for {oldRegion}, men den nye posisjonen din er utenfor dekningsområdet. Du kan bytte til den globale varianten fra modellgalleriet i Innstillinger."
       },
+      "modelPath": {
+        "reconciledTitle": "Modellfilsti reparert",
+        "reconciledMessage": "Den konfigurerte filstien for {modelName} pekte på en fil som ikke lenger eksisterer. Den bruker nå den installerte modellen på {modelPath}.",
+        "notRegisteredTitle": "Modellen analyserer ikke {sourceName}",
+        "notRegisteredMessage": "{models} er tilordnet lydkilden \"{sourceName}\", men mottar ikke lyd og produserer derfor ikke registreringer. Modellen er mest sannsynlig ikke installert eller kunne ikke lastes inn. Sjekk modellgalleriet i Innstillinger."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Gjeldende verdi: {value}% (terskel: {threshold}%)",
@@ -1767,6 +1773,8 @@
       "sources": "Lydkilder",
       "noSources": "Ingen kilder tilkoblet",
       "primaryFallback": "primær (fallback)",
+      "sourceNotRunning": "kjører ikke",
+      "sourceNotRunningTooltip": "Denne kilden er tilordnet modellen i innstillingene, men lyden når ikke modellen, så den produserer ingen registreringer.",
       "notMeasured": "n/a",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -468,8 +468,8 @@
         "reconciledMessage": "De konfigurerte filstiene for {modelName} var utdaterte og har blitt reparert for å samsvare med den installerte modellen på {modelPath}.",
         "substitutedTitle": "Fant ikke den konfigurerte modellfilen for {modelName}",
         "substitutedMessage": "Modellfilen som er konfigurert for {modelName}, ble ikke funnet på disken, så den installerte modellen på {modelPath} brukes i stedet. Konfigurasjonen din ble ikke endret.",
-        "notRegisteredTitle": "Modellen analyserer ikke {sourceName}",
-        "notRegisteredMessage": "{models} er tilordnet lydkilden \"{sourceName}\", men mottar for øyeblikket ikke lyd og produserer derfor ikke registreringer. Åpne modellgalleriet i Innstillinger for å sjekke statusen."
+        "notRegisteredTitle": "Ingen modell analyserer {sourceName}",
+        "notRegisteredMessage": "Ingen lyd når {models} på lydkilden \"{sourceName}\", så det produseres ingen registreringer. Åpne modellgalleriet i Innstillinger for å sjekke status."
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -466,6 +466,8 @@
       "modelPath": {
         "reconciledTitle": "Bestandspaden van model hersteld voor {modelName}",
         "reconciledMessage": "De geconfigureerde bestandspaden voor {modelName} waren verouderd en zijn hersteld om overeen te komen met het geïnstalleerde model op {modelPath}.",
+        "substitutedTitle": "Geconfigureerd modelbestand voor {modelName} niet gevonden",
+        "substitutedMessage": "Het voor {modelName} geconfigureerde modelbestand is niet op de schijf gevonden, dus wordt in plaats daarvan het geïnstalleerde model op {modelPath} gebruikt. Uw configuratie is ongewijzigd gebleven.",
         "notRegisteredTitle": "Model analyseert {sourceName} niet",
         "notRegisteredMessage": "{models} is toegewezen aan audiobron \"{sourceName}\", maar ontvangt momenteel geen audio en produceert daarom geen detecties. Open de modellengalerij in Instellingen om de status te controleren."
       },

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -463,6 +463,12 @@
         "staleMessage": "{modelName} is geïnstalleerd voor {oldRegion}, maar uw nieuwe locatie komt overeen met {newRegion}. U kunt van variant wisselen via de modellengalerij in Instellingen.",
         "staleGlobalMessage": "{modelName} is geïnstalleerd voor {oldRegion}, maar uw nieuwe locatie valt buiten de dekking. U kunt overschakelen naar de globale variant via de modellengalerij in Instellingen."
       },
+      "modelPath": {
+        "reconciledTitle": "Bestandspad van model hersteld",
+        "reconciledMessage": "Het geconfigureerde bestandspad voor {modelName} verwees naar een bestand dat niet meer bestaat. Er wordt nu gebruikgemaakt van het geïnstalleerde model op {modelPath}.",
+        "notRegisteredTitle": "Model analyseert {sourceName} niet",
+        "notRegisteredMessage": "{models} is toegewezen aan audiobron \"{sourceName}\", maar ontvangt geen audio en produceert daarom geen detecties. Het model is hoogstwaarschijnlijk niet geïnstalleerd of kon niet worden geladen. Controleer de modellengalerij in Instellingen."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Huidige waarde: {value}% (drempelwaarde: {threshold}%)",
@@ -1767,6 +1773,8 @@
       "sources": "Audiobronnen",
       "noSources": "Geen bronnen verbonden",
       "primaryFallback": "primair (fallback)",
+      "sourceNotRunning": "draait niet",
+      "sourceNotRunningTooltip": "Deze bron is in de instellingen toegewezen aan het model, maar de audio bereikt het model niet, waardoor het geen detecties produceert.",
       "notMeasured": "n/b",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -468,8 +468,8 @@
         "reconciledMessage": "De geconfigureerde bestandspaden voor {modelName} waren verouderd en zijn hersteld om overeen te komen met het geïnstalleerde model op {modelPath}.",
         "substitutedTitle": "Geconfigureerd modelbestand voor {modelName} niet gevonden",
         "substitutedMessage": "Het voor {modelName} geconfigureerde modelbestand is niet op de schijf gevonden, dus wordt in plaats daarvan het geïnstalleerde model op {modelPath} gebruikt. Uw configuratie is ongewijzigd gebleven.",
-        "notRegisteredTitle": "Model analyseert {sourceName} niet",
-        "notRegisteredMessage": "{models} is toegewezen aan audiobron \"{sourceName}\", maar ontvangt momenteel geen audio en produceert daarom geen detecties. Open de modellengalerij in Instellingen om de status te controleren."
+        "notRegisteredTitle": "Geen model analyseert {sourceName}",
+        "notRegisteredMessage": "Er bereikt geen audio {models} op audiobron \"{sourceName}\", waardoor er geen detecties worden geproduceerd. Open de modellengalerij in Instellingen om de status te controleren."
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -464,10 +464,10 @@
         "staleGlobalMessage": "{modelName} is geïnstalleerd voor {oldRegion}, maar uw nieuwe locatie valt buiten de dekking. U kunt overschakelen naar de globale variant via de modellengalerij in Instellingen."
       },
       "modelPath": {
-        "reconciledTitle": "Bestandspad van model hersteld",
-        "reconciledMessage": "Het geconfigureerde bestandspad voor {modelName} verwees naar een bestand dat niet meer bestaat. Er wordt nu gebruikgemaakt van het geïnstalleerde model op {modelPath}.",
+        "reconciledTitle": "Bestandspaden van model hersteld voor {modelName}",
+        "reconciledMessage": "De geconfigureerde bestandspaden voor {modelName} waren verouderd en zijn hersteld om overeen te komen met het geïnstalleerde model op {modelPath}.",
         "notRegisteredTitle": "Model analyseert {sourceName} niet",
-        "notRegisteredMessage": "{models} is toegewezen aan audiobron \"{sourceName}\", maar ontvangt geen audio en produceert daarom geen detecties. Het model is hoogstwaarschijnlijk niet geïnstalleerd of kon niet worden geladen. Controleer de modellengalerij in Instellingen."
+        "notRegisteredMessage": "{models} is toegewezen aan audiobron \"{sourceName}\", maar ontvangt momenteel geen audio en produceert daarom geen detecties. Open de modellengalerij in Instellingen om de status te controleren."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1773,8 +1773,8 @@
       "sources": "Audiobronnen",
       "noSources": "Geen bronnen verbonden",
       "primaryFallback": "primair (fallback)",
-      "sourceNotRunning": "draait niet",
-      "sourceNotRunningTooltip": "Deze bron is in de instellingen toegewezen aan het model, maar de audio bereikt het model niet, waardoor het geen detecties produceert.",
+      "sourceNotRunning": "analyseert niet",
+      "sourceNotRunningTooltip": "Deze bron is in de instellingen toegewezen aan het model, maar de audio bereikt het model niet, waardoor het geen detecties produceert. Open de modellengalerij in Instellingen om de status te controleren.",
       "notMeasured": "n/b",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -463,6 +463,12 @@
         "staleMessage": "{modelName} jest zainstalowany dla {oldRegion}, ale Twoja nowa lokalizacja wskazuje na {newRegion}. Możesz zmienić warianty w galerii modeli w Ustawieniach.",
         "staleGlobalMessage": "{modelName} jest zainstalowany dla {oldRegion}, ale Twoja nowa lokalizacja znajduje się poza jego zasięgiem. Możesz przełączyć się na wariant globalny w galerii modeli w Ustawieniach."
       },
+      "modelPath": {
+        "reconciledTitle": "Ścieżka pliku modelu naprawiona",
+        "reconciledMessage": "Skonfigurowana ścieżka pliku dla {modelName} wskazywała na plik, który już nie istnieje. Teraz używany jest zainstalowany model w {modelPath}.",
+        "notRegisteredTitle": "Model nie analizuje {sourceName}",
+        "notRegisteredMessage": "{models} jest przypisany do źródła audio \"{sourceName}\", ale nie odbiera dźwięku, więc nie generuje detekcji. Model najprawdopodobniej nie jest zainstalowany lub nie udało się go załadować. Sprawdź galerię modeli w Ustawieniach."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Bieżąca wartość: {value}% (próg: {threshold}%)",
@@ -1767,6 +1773,8 @@
       "sources": "Źródła audio",
       "noSources": "Brak podłączonych źródeł",
       "primaryFallback": "podstawowy (zapasowy)",
+      "sourceNotRunning": "nie działa",
+      "sourceNotRunningTooltip": "To źródło jest przypisane do modelu w ustawieniach, ale jego dźwięk nie dociera do modelu, więc nie generuje detekcji.",
       "notMeasured": "n/d",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -464,10 +464,10 @@
         "staleGlobalMessage": "{modelName} jest zainstalowany dla {oldRegion}, ale Twoja nowa lokalizacja znajduje się poza jego zasięgiem. Możesz przełączyć się na wariant globalny w galerii modeli w Ustawieniach."
       },
       "modelPath": {
-        "reconciledTitle": "Ścieżka pliku modelu naprawiona",
-        "reconciledMessage": "Skonfigurowana ścieżka pliku dla {modelName} wskazywała na plik, który już nie istnieje. Teraz używany jest zainstalowany model w {modelPath}.",
+        "reconciledTitle": "Ścieżki plików modelu {modelName} naprawione",
+        "reconciledMessage": "Skonfigurowane ścieżki plików dla {modelName} były nieaktualne i zostały naprawione, aby pasowały do zainstalowanego modelu w {modelPath}.",
         "notRegisteredTitle": "Model nie analizuje {sourceName}",
-        "notRegisteredMessage": "{models} jest przypisany do źródła audio \"{sourceName}\", ale nie odbiera dźwięku, więc nie generuje detekcji. Model najprawdopodobniej nie jest zainstalowany lub nie udało się go załadować. Sprawdź galerię modeli w Ustawieniach."
+        "notRegisteredMessage": "{models} jest przypisany do źródła audio \"{sourceName}\", ale obecnie nie odbiera dźwięku, więc nie generuje detekcji. Otwórz galerię modeli w Ustawieniach, aby sprawdzić jego stan."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1773,8 +1773,8 @@
       "sources": "Źródła audio",
       "noSources": "Brak podłączonych źródeł",
       "primaryFallback": "podstawowy (zapasowy)",
-      "sourceNotRunning": "nie działa",
-      "sourceNotRunningTooltip": "To źródło jest przypisane do modelu w ustawieniach, ale jego dźwięk nie dociera do modelu, więc nie generuje detekcji.",
+      "sourceNotRunning": "nie analizuje",
+      "sourceNotRunningTooltip": "To źródło jest przypisane do modelu w ustawieniach, ale jego dźwięk nie dociera do modelu, więc nie generuje detekcji. Otwórz galerię modeli w Ustawieniach, aby sprawdzić jego stan.",
       "notMeasured": "n/d",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -468,8 +468,8 @@
         "reconciledMessage": "Skonfigurowane ścieżki plików dla {modelName} były nieaktualne i zostały naprawione, aby pasowały do zainstalowanego modelu w {modelPath}.",
         "substitutedTitle": "Nie znaleziono skonfigurowanego pliku modelu dla {modelName}",
         "substitutedMessage": "Skonfigurowany plik modelu dla {modelName} nie został znaleziony na dysku, dlatego zamiast niego używany jest zainstalowany model w lokalizacji {modelPath}. Twoja konfiguracja pozostała niezmieniona.",
-        "notRegisteredTitle": "Model nie analizuje {sourceName}",
-        "notRegisteredMessage": "{models} jest przypisany do źródła audio \"{sourceName}\", ale obecnie nie odbiera dźwięku, więc nie generuje detekcji. Otwórz galerię modeli w Ustawieniach, aby sprawdzić jego stan."
+        "notRegisteredTitle": "Żaden model nie analizuje {sourceName}",
+        "notRegisteredMessage": "Żaden dźwięk nie dociera do {models} na źródle audio \"{sourceName}\", więc nie są generowane żadne detekcje. Otwórz galerię modeli w Ustawieniach, aby sprawdzić stan."
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -466,6 +466,8 @@
       "modelPath": {
         "reconciledTitle": "Ścieżki plików modelu {modelName} naprawione",
         "reconciledMessage": "Skonfigurowane ścieżki plików dla {modelName} były nieaktualne i zostały naprawione, aby pasowały do zainstalowanego modelu w {modelPath}.",
+        "substitutedTitle": "Nie znaleziono skonfigurowanego pliku modelu dla {modelName}",
+        "substitutedMessage": "Skonfigurowany plik modelu dla {modelName} nie został znaleziony na dysku, dlatego zamiast niego używany jest zainstalowany model w lokalizacji {modelPath}. Twoja konfiguracja pozostała niezmieniona.",
         "notRegisteredTitle": "Model nie analizuje {sourceName}",
         "notRegisteredMessage": "{models} jest przypisany do źródła audio \"{sourceName}\", ale obecnie nie odbiera dźwięku, więc nie generuje detekcji. Otwórz galerię modeli w Ustawieniach, aby sprawdzić jego stan."
       },

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -468,8 +468,8 @@
         "reconciledMessage": "Os caminhos de ficheiro configurados para {modelName} estavam desatualizados e foram reparados para corresponder ao modelo instalado em {modelPath}.",
         "substitutedTitle": "Ficheiro de modelo configurado para {modelName} não encontrado",
         "substitutedMessage": "O ficheiro de modelo configurado para {modelName} não foi encontrado no disco, pelo que o modelo instalado em {modelPath} está a ser utilizado em vez disso. A sua configuração não foi alterada.",
-        "notRegisteredTitle": "O modelo não está a analisar {sourceName}",
-        "notRegisteredMessage": "{models} está atribuído à fonte de áudio \"{sourceName}\", mas atualmente não está a receber áudio, pelo que não está a produzir deteções. Abra a galeria de modelos nas Configurações para verificar o seu estado."
+        "notRegisteredTitle": "Nenhum modelo está a analisar {sourceName}",
+        "notRegisteredMessage": "Nenhum áudio está a chegar a {models} na fonte de áudio \"{sourceName}\", pelo que não são produzidas deteções. Abra a galeria de modelos nas Configurações para verificar o estado."
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -463,6 +463,12 @@
         "staleMessage": "{modelName} está instalado para {oldRegion}, mas a sua nova localização corresponde a {newRegion}. Pode mudar de variante a partir da galeria de modelos nas Configurações.",
         "staleGlobalMessage": "{modelName} está instalado para {oldRegion}, mas a sua nova localização está fora da sua cobertura. Pode mudar para a variante global a partir da galeria de modelos nas Configurações."
       },
+      "modelPath": {
+        "reconciledTitle": "Caminho do ficheiro do modelo reparado",
+        "reconciledMessage": "O caminho de ficheiro configurado para {modelName} apontava para um ficheiro que já não existe. Agora utiliza o modelo instalado em {modelPath}.",
+        "notRegisteredTitle": "O modelo não está a analisar {sourceName}",
+        "notRegisteredMessage": "{models} está atribuído à fonte de áudio \"{sourceName}\", mas não está a receber áudio, pelo que não está a produzir deteções. O modelo muito provavelmente não está instalado ou falhou ao carregar. Verifique a galeria de modelos nas Configurações."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Valor atual: {value}% (limite: {threshold}%)",
@@ -1767,6 +1773,8 @@
       "sources": "Fontes de áudio",
       "noSources": "Nenhuma fonte conectada",
       "primaryFallback": "primária (reserva)",
+      "sourceNotRunning": "não está em execução",
+      "sourceNotRunningTooltip": "Esta fonte está atribuída ao modelo nas configurações, mas o seu áudio não está a chegar ao modelo, pelo que não produz deteções.",
       "notMeasured": "n/d",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -464,10 +464,10 @@
         "staleGlobalMessage": "{modelName} está instalado para {oldRegion}, mas a sua nova localização está fora da sua cobertura. Pode mudar para a variante global a partir da galeria de modelos nas Configurações."
       },
       "modelPath": {
-        "reconciledTitle": "Caminho do ficheiro do modelo reparado",
-        "reconciledMessage": "O caminho de ficheiro configurado para {modelName} apontava para um ficheiro que já não existe. Agora utiliza o modelo instalado em {modelPath}.",
+        "reconciledTitle": "Caminhos dos ficheiros do modelo reparados para {modelName}",
+        "reconciledMessage": "Os caminhos de ficheiro configurados para {modelName} estavam desatualizados e foram reparados para corresponder ao modelo instalado em {modelPath}.",
         "notRegisteredTitle": "O modelo não está a analisar {sourceName}",
-        "notRegisteredMessage": "{models} está atribuído à fonte de áudio \"{sourceName}\", mas não está a receber áudio, pelo que não está a produzir deteções. O modelo muito provavelmente não está instalado ou falhou ao carregar. Verifique a galeria de modelos nas Configurações."
+        "notRegisteredMessage": "{models} está atribuído à fonte de áudio \"{sourceName}\", mas atualmente não está a receber áudio, pelo que não está a produzir deteções. Abra a galeria de modelos nas Configurações para verificar o seu estado."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1773,8 +1773,8 @@
       "sources": "Fontes de áudio",
       "noSources": "Nenhuma fonte conectada",
       "primaryFallback": "primária (reserva)",
-      "sourceNotRunning": "não está em execução",
-      "sourceNotRunningTooltip": "Esta fonte está atribuída ao modelo nas configurações, mas o seu áudio não está a chegar ao modelo, pelo que não produz deteções.",
+      "sourceNotRunning": "não está a analisar",
+      "sourceNotRunningTooltip": "Esta fonte está atribuída ao modelo nas configurações, mas o seu áudio não está a chegar ao modelo, pelo que não produz deteções. Abra a galeria de modelos nas Configurações para verificar o seu estado.",
       "notMeasured": "n/d",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -466,6 +466,8 @@
       "modelPath": {
         "reconciledTitle": "Caminhos dos ficheiros do modelo reparados para {modelName}",
         "reconciledMessage": "Os caminhos de ficheiro configurados para {modelName} estavam desatualizados e foram reparados para corresponder ao modelo instalado em {modelPath}.",
+        "substitutedTitle": "Ficheiro de modelo configurado para {modelName} não encontrado",
+        "substitutedMessage": "O ficheiro de modelo configurado para {modelName} não foi encontrado no disco, pelo que o modelo instalado em {modelPath} está a ser utilizado em vez disso. A sua configuração não foi alterada.",
         "notRegisteredTitle": "O modelo não está a analisar {sourceName}",
         "notRegisteredMessage": "{models} está atribuído à fonte de áudio \"{sourceName}\", mas atualmente não está a receber áudio, pelo que não está a produzir deteções. Abra a galeria de modelos nas Configurações para verificar o seu estado."
       },

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -463,6 +463,12 @@
         "staleMessage": "{modelName} je nainštalovaný pre {oldRegion}, ale vaša nová poloha zodpovedá {newRegion}. Varianty môžete zmeniť v galérii modelov v Nastaveniach.",
         "staleGlobalMessage": "{modelName} je nainštalovaný pre {oldRegion}, ale vaša nová poloha je mimo jeho pokrytia. Na globálny variant môžete prepnúť v galérii modelov v Nastaveniach."
       },
+      "modelPath": {
+        "reconciledTitle": "Cesta k súboru modelu opravená",
+        "reconciledMessage": "Nakonfigurovaná cesta k súboru pre {modelName} odkazovala na súbor, ktorý už neexistuje. Teraz sa používa nainštalovaný model v {modelPath}.",
+        "notRegisteredTitle": "Model neanalyzuje {sourceName}",
+        "notRegisteredMessage": "{models} je priradený k zvukovému zdroju \"{sourceName}\", ale neprijíma zvuk, takže nevytvára detekcie. Model pravdepodobne nie je nainštalovaný alebo sa ho nepodarilo načítať. Skontrolujte galériu modelov v Nastaveniach."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Aktuálna hodnota: {value}% (prahová hodnota: {threshold}%)",
@@ -1767,6 +1773,8 @@
       "sources": "Zdroje zvuku",
       "noSources": "Žiadne pripojené zdroje",
       "primaryFallback": "primárny (záložný)",
+      "sourceNotRunning": "nebeží",
+      "sourceNotRunningTooltip": "Tento zdroj je v nastaveniach priradený k modelu, ale jeho zvuk sa k modelu nedostáva, takže nevytvára žiadne detekcie.",
       "notMeasured": "n/a",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -468,8 +468,8 @@
         "reconciledMessage": "Nakonfigurované cesty k súborom pre {modelName} boli zastarané a boli opravené tak, aby zodpovedali nainštalovanému modelu v {modelPath}.",
         "substitutedTitle": "Nakonfigurovaný súbor modelu pre {modelName} sa nenašiel",
         "substitutedMessage": "Súbor modelu nakonfigurovaný pre {modelName} sa na disku nenašiel, preto sa namiesto neho používa nainštalovaný model v {modelPath}. Vaša konfigurácia zostala nezmenená.",
-        "notRegisteredTitle": "Model neanalyzuje {sourceName}",
-        "notRegisteredMessage": "{models} je priradený k zvukovému zdroju \"{sourceName}\", ale momentálne neprijíma zvuk, takže nevytvára detekcie. Otvorte galériu modelov v Nastaveniach a skontrolujte jeho stav."
+        "notRegisteredTitle": "Žiadny model neanalyzuje {sourceName}",
+        "notRegisteredMessage": "K {models} na zvukovom zdroji \"{sourceName}\" sa nedostáva žiadny zvuk, takže sa nevytvárajú žiadne detekcie. Otvorte galériu modelov v Nastaveniach a skontrolujte stav."
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -466,6 +466,8 @@
       "modelPath": {
         "reconciledTitle": "Cesty k súborom modelu {modelName} opravené",
         "reconciledMessage": "Nakonfigurované cesty k súborom pre {modelName} boli zastarané a boli opravené tak, aby zodpovedali nainštalovanému modelu v {modelPath}.",
+        "substitutedTitle": "Nakonfigurovaný súbor modelu pre {modelName} sa nenašiel",
+        "substitutedMessage": "Súbor modelu nakonfigurovaný pre {modelName} sa na disku nenašiel, preto sa namiesto neho používa nainštalovaný model v {modelPath}. Vaša konfigurácia zostala nezmenená.",
         "notRegisteredTitle": "Model neanalyzuje {sourceName}",
         "notRegisteredMessage": "{models} je priradený k zvukovému zdroju \"{sourceName}\", ale momentálne neprijíma zvuk, takže nevytvára detekcie. Otvorte galériu modelov v Nastaveniach a skontrolujte jeho stav."
       },

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -464,10 +464,10 @@
         "staleGlobalMessage": "{modelName} je nainštalovaný pre {oldRegion}, ale vaša nová poloha je mimo jeho pokrytia. Na globálny variant môžete prepnúť v galérii modelov v Nastaveniach."
       },
       "modelPath": {
-        "reconciledTitle": "Cesta k súboru modelu opravená",
-        "reconciledMessage": "Nakonfigurovaná cesta k súboru pre {modelName} odkazovala na súbor, ktorý už neexistuje. Teraz sa používa nainštalovaný model v {modelPath}.",
+        "reconciledTitle": "Cesty k súborom modelu {modelName} opravené",
+        "reconciledMessage": "Nakonfigurované cesty k súborom pre {modelName} boli zastarané a boli opravené tak, aby zodpovedali nainštalovanému modelu v {modelPath}.",
         "notRegisteredTitle": "Model neanalyzuje {sourceName}",
-        "notRegisteredMessage": "{models} je priradený k zvukovému zdroju \"{sourceName}\", ale neprijíma zvuk, takže nevytvára detekcie. Model pravdepodobne nie je nainštalovaný alebo sa ho nepodarilo načítať. Skontrolujte galériu modelov v Nastaveniach."
+        "notRegisteredMessage": "{models} je priradený k zvukovému zdroju \"{sourceName}\", ale momentálne neprijíma zvuk, takže nevytvára detekcie. Otvorte galériu modelov v Nastaveniach a skontrolujte jeho stav."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1773,8 +1773,8 @@
       "sources": "Zdroje zvuku",
       "noSources": "Žiadne pripojené zdroje",
       "primaryFallback": "primárny (záložný)",
-      "sourceNotRunning": "nebeží",
-      "sourceNotRunningTooltip": "Tento zdroj je v nastaveniach priradený k modelu, ale jeho zvuk sa k modelu nedostáva, takže nevytvára žiadne detekcie.",
+      "sourceNotRunning": "neanalyzuje",
+      "sourceNotRunningTooltip": "Tento zdroj je v nastaveniach priradený k modelu, ale jeho zvuk sa k modelu nedostáva, takže nevytvára žiadne detekcie. Otvorte galériu modelov v Nastaveniach a skontrolujte jeho stav.",
       "notMeasured": "n/a",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -463,6 +463,12 @@
         "staleMessage": "{modelName} är installerad för {oldRegion}, men din nya plats motsvarar {newRegion}. Du kan byta varianter från modellgalleriet i Inställningar.",
         "staleGlobalMessage": "{modelName} är installerad för {oldRegion}, men din nya plats är utanför dess täckning. Du kan byta till den globala varianten från modellgalleriet i Inställningar."
       },
+      "modelPath": {
+        "reconciledTitle": "Modellens filsökväg reparerad",
+        "reconciledMessage": "Den konfigurerade filsökvägen för {modelName} pekade på en fil som inte längre finns. Den använder nu den installerade modellen på {modelPath}.",
+        "notRegisteredTitle": "Modellen analyserar inte {sourceName}",
+        "notRegisteredMessage": "{models} är tilldelad ljudkällan \"{sourceName}\", men tar inte emot ljud och producerar därför inga detektioner. Modellen är med största sannolikhet inte installerad eller kunde inte laddas. Kontrollera modellgalleriet i Inställningar."
+      },
       "alert": {
         "firedTitle": "{rule_name}",
         "metricExceeded": "Nuvarande värde: {value}% (tröskel: {threshold}%)",
@@ -1767,6 +1773,8 @@
       "sources": "Ljudkällor",
       "noSources": "Inga källor anslutna",
       "primaryFallback": "primär (reserv)",
+      "sourceNotRunning": "körs inte",
+      "sourceNotRunningTooltip": "Denna källa är tilldelad modellen i inställningarna, men dess ljud når inte modellen, så den producerar inga detektioner.",
       "notMeasured": "-",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -464,10 +464,10 @@
         "staleGlobalMessage": "{modelName} är installerad för {oldRegion}, men din nya plats är utanför dess täckning. Du kan byta till den globala varianten från modellgalleriet i Inställningar."
       },
       "modelPath": {
-        "reconciledTitle": "Modellens filsökväg reparerad",
-        "reconciledMessage": "Den konfigurerade filsökvägen för {modelName} pekade på en fil som inte längre finns. Den använder nu den installerade modellen på {modelPath}.",
+        "reconciledTitle": "Modellens filsökvägar reparerade för {modelName}",
+        "reconciledMessage": "De konfigurerade filsökvägarna för {modelName} var inaktuella och har reparerats för att matcha den installerade modellen på {modelPath}.",
         "notRegisteredTitle": "Modellen analyserar inte {sourceName}",
-        "notRegisteredMessage": "{models} är tilldelad ljudkällan \"{sourceName}\", men tar inte emot ljud och producerar därför inga detektioner. Modellen är med största sannolikhet inte installerad eller kunde inte laddas. Kontrollera modellgalleriet i Inställningar."
+        "notRegisteredMessage": "{models} är tilldelad ljudkällan \"{sourceName}\", men tar för närvarande inte emot ljud och producerar därför inga detektioner. Öppna modellgalleriet i Inställningar för att kontrollera dess status."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1773,8 +1773,8 @@
       "sources": "Ljudkällor",
       "noSources": "Inga källor anslutna",
       "primaryFallback": "primär (reserv)",
-      "sourceNotRunning": "körs inte",
-      "sourceNotRunningTooltip": "Denna källa är tilldelad modellen i inställningarna, men dess ljud når inte modellen, så den producerar inga detektioner.",
+      "sourceNotRunning": "analyserar inte",
+      "sourceNotRunningTooltip": "Denna källa är tilldelad modellen i inställningarna, men dess ljud når inte modellen, så den producerar inga detektioner. Öppna modellgalleriet i Inställningar för att kontrollera dess status.",
       "notMeasured": "-",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -468,8 +468,8 @@
         "reconciledMessage": "De konfigurerade filsökvägarna för {modelName} var inaktuella och har reparerats för att matcha den installerade modellen på {modelPath}.",
         "substitutedTitle": "Den konfigurerade modellfilen för {modelName} hittades inte",
         "substitutedMessage": "Modellfilen som konfigurerats för {modelName} hittades inte på disken, så den installerade modellen på {modelPath} används i stället. Din konfiguration lämnades oförändrad.",
-        "notRegisteredTitle": "Modellen analyserar inte {sourceName}",
-        "notRegisteredMessage": "{models} är tilldelad ljudkällan \"{sourceName}\", men tar för närvarande inte emot ljud och producerar därför inga detektioner. Öppna modellgalleriet i Inställningar för att kontrollera dess status."
+        "notRegisteredTitle": "Ingen modell analyserar {sourceName}",
+        "notRegisteredMessage": "Inget ljud når {models} på ljudkällan \"{sourceName}\", så det produceras inga detektioner. Öppna modellgalleriet i Inställningar för att kontrollera status."
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -466,6 +466,8 @@
       "modelPath": {
         "reconciledTitle": "Modellens filsökvägar reparerade för {modelName}",
         "reconciledMessage": "De konfigurerade filsökvägarna för {modelName} var inaktuella och har reparerats för att matcha den installerade modellen på {modelPath}.",
+        "substitutedTitle": "Den konfigurerade modellfilen för {modelName} hittades inte",
+        "substitutedMessage": "Modellfilen som konfigurerats för {modelName} hittades inte på disken, så den installerade modellen på {modelPath} används i stället. Din konfiguration lämnades oförändrad.",
         "notRegisteredTitle": "Modellen analyserar inte {sourceName}",
         "notRegisteredMessage": "{models} är tilldelad ljudkällan \"{sourceName}\", men tar för närvarande inte emot ljud och producerar därför inga detektioner. Öppna modellgalleriet i Inställningar för att kontrollera dess status."
       },

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -965,7 +965,8 @@ func (p *AudioPipelineService) registerConsumersForSources(sourceIDs []string, s
 		// Resolve per-source model targets. Fall back to primary if the
 		// source has no configured models or none could be resolved.
 		modelInfos, skippedModels := resolveModelTargets(sourceModelMap[sid], allModelInfos)
-		if len(modelInfos) == 0 {
+		usedPrimaryFallback := len(modelInfos) == 0
+		if usedPrimaryFallback {
 			modelInfos = primaryTargets
 		}
 
@@ -1038,7 +1039,17 @@ func (p *AudioPipelineService) registerConsumersForSources(sourceIDs []string, s
 		if !bufferRouteOK {
 			registered = nil
 		}
-		reportUnregisteredModels(modelMgr, sourceName, skippedModels, modelInfos, registered)
+		// Report only models the configuration actually assigns. When the source
+		// resolved to no loaded target and fell back to the primary, the user
+		// assigned nothing here, so naming the built-in primary as "assigned to this
+		// source" would be false, and it points the user at a gallery entry that
+		// offers no action for a permanent model. Genuinely assigned but unresolvable
+		// models still reach the user through skippedModels.
+		assigned := modelInfos
+		if usedPrimaryFallback {
+			assigned = nil
+		}
+		reportUnregisteredModels(modelMgr, sourceName, skippedModels, assigned, registered)
 
 		if !consumerOK {
 			// The buffer consumer never came up; skip wiring the audio-level route,
@@ -1690,6 +1701,24 @@ func resolveModelTargets(configModelIDs []string, loadedModels map[string]classi
 // did register, so nothing looks broken, and the only trace is a warning in a
 // log file. Users have lost a model for days this way (GitHub #4201, #4204).
 func reportUnregisteredModels(mm *classifier.ModelManager, sourceName string, skipped []string, resolved []classifier.ModelInfo, allocated map[string]bool) {
+	notRegistered := unregisteredModelNames(mm, skipped, resolved, allocated)
+	if len(notRegistered) > 0 {
+		notifyModelsNotRegistered(sourceName, notRegistered)
+	}
+}
+
+// unregisteredModelNames returns the display names of models that will not
+// analyze this source, so the caller can tell the user which ones are affected.
+//
+// A model mid-download is omitted deliberately: a reinstall briefly leaves the
+// model unregistered, and naming it there would report a genuine outage for what
+// is a transient and self-resolving state, and would arm the renotify window
+// against the real failure that might follow.
+//
+// Split out from reportUnregisteredModels so the selection is testable without a
+// notification service: notifyModelsNotRegistered returns early when none is
+// registered, which would otherwise make the decision unobservable.
+func unregisteredModelNames(mm *classifier.ModelManager, skipped []string, resolved []classifier.ModelInfo, allocated map[string]bool) []string {
 	notRegistered := make([]string, 0, len(skipped)+len(resolved))
 	for _, s := range skipped {
 		if modelIsDownloading(mm, s) {
@@ -1706,9 +1735,7 @@ func reportUnregisteredModels(mm *classifier.ModelManager, sourceName string, sk
 		}
 		notRegistered = append(notRegistered, modelDisplayName(resolved[i].ID))
 	}
-	if len(notRegistered) > 0 {
-		notifyModelsNotRegistered(sourceName, notRegistered)
-	}
+	return notRegistered
 }
 
 // modelDisplayName resolves a config ID or registry ID to the user-facing model

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -895,6 +895,35 @@ func (p *AudioPipelineService) removeAllSoundLevelConsumers(operation string) {
 	}
 }
 
+// wireSourceBufferRoute creates the buffer consumer for a source and adds its
+// route to the audio router. consumerOK is false when NewBufferConsumer fails, in
+// which case the caller skips the source entirely (as it did before this was
+// extracted); routeOK is false when the consumer OR its route could not be built,
+// meaning no model on the source is actually analyzing it. Both failures are
+// logged here. Extracted from registerConsumersForSources purely to keep that
+// function under the cognitive-complexity limit; the behaviour is unchanged.
+func (p *AudioPipelineService) wireSourceBufferRoute(sid, sourceName string, sourceSampleRate int, gainDB float64, targets []ModelTarget, currentSettings *conf.Settings, operation string) (consumerOK, routeOK bool) {
+	log := audiocore.GetLogger()
+	bc, bcErr := NewBufferConsumer(
+		fmt.Sprintf("buffer_%s", sid),
+		p.engine.BufferManager(),
+		sourceSampleRate, conf.BitDepth, 1,
+		targets,
+	)
+	if bcErr != nil {
+		log.Warn("failed to create buffer consumer",
+			logger.String("source_id", sid), logger.Error(bcErr), logger.String("operation", operation))
+		return false, false
+	}
+	bcChain := equalizer.ResolveAndBuildFilterChain(currentSettings, sourceName, sourceSampleRate)
+	if routeErr := p.engine.Router().AddRoute(sid, bc, sourceSampleRate, gainDB, bcChain); routeErr != nil {
+		log.Warn("failed to add buffer route",
+			logger.String("source_id", sid), logger.Error(routeErr), logger.String("operation", operation))
+		return true, false
+	}
+	return true, true
+}
+
 // registerConsumersForSources registers BufferConsumer and AudioLevelConsumer
 // on the AudioRouter for each source ID. The sourceModelMap carries the
 // config-level model IDs for each source so that buffer consumers fan out to
@@ -915,6 +944,10 @@ func (p *AudioPipelineService) registerConsumersForSources(sourceIDs []string, s
 
 	bufMgr := p.engine.BufferManager()
 	currentSettings := conf.Setting()
+
+	// Used to suppress false "not analyzing" alarms for a model that is merely
+	// mid-download or mid-reinstall (see reportUnregisteredModels).
+	modelMgr := p.bnAnalyzer.ModelManager()
 
 	for _, sid := range sourceIDs {
 		// Look up per-source gain from the registry.
@@ -986,29 +1019,31 @@ func (p *AudioPipelineService) registerConsumersForSources(sourceIDs []string, s
 			logger.Int("model_count", len(targets)),
 			logger.String("operation", operation))
 
-		reportUnregisteredModels(sourceName, skippedModels, modelInfos, allocatedModels)
-
 		// Use per-source sample rate when available; fall back to global constant.
 		sourceSampleRate := conf.SampleRate
 		if src != nil && src.SampleRate > 0 {
 			sourceSampleRate = src.SampleRate
 		}
 
-		bc, bcErr := NewBufferConsumer(
-			fmt.Sprintf("buffer_%s", sid),
-			p.engine.BufferManager(),
-			sourceSampleRate, conf.BitDepth, 1,
-			targets,
-		)
-		if bcErr != nil {
-			log.Warn("failed to create buffer consumer",
-				logger.String("source_id", sid), logger.Error(bcErr), logger.String("operation", operation))
-			continue
+		consumerOK, bufferRouteOK := p.wireSourceBufferRoute(
+			sid, sourceName, sourceSampleRate, gainDB, targets, currentSettings, operation)
+
+		// Report models the source assigns but that will not analyze it, AFTER the
+		// buffer consumer and its route are attached, so a consumer- or route-build
+		// failure is included rather than silently missed. When the buffer route did
+		// not come up, no target on this source runs, so report every resolved model;
+		// otherwise report only the ones that did not register (unresolved, or buffer
+		// allocation failed).
+		registered := allocatedModels
+		if !bufferRouteOK {
+			registered = nil
 		}
-		bcChain := equalizer.ResolveAndBuildFilterChain(currentSettings, sourceName, sourceSampleRate)
-		if routeErr := p.engine.Router().AddRoute(sid, bc, sourceSampleRate, gainDB, bcChain); routeErr != nil {
-			log.Warn("failed to add buffer route",
-				logger.String("source_id", sid), logger.Error(routeErr), logger.String("operation", operation))
+		reportUnregisteredModels(modelMgr, sourceName, skippedModels, modelInfos, registered)
+
+		if !consumerOK {
+			// The buffer consumer never came up; skip wiring the audio-level route,
+			// matching the original early-out for this source.
+			continue
 		}
 
 		alc, alcOutCh := NewAudioLevelConsumer("audio_level_"+sid, sourceSampleRate, conf.BitDepth, 1)
@@ -1645,19 +1680,75 @@ func resolveModelTargets(configModelIDs []string, loadedModels map[string]classi
 // because they never loaded (skipped) or because their analysis buffer could
 // not be allocated (absent from allocated).
 //
+// A model with a gallery download or reinstall in flight is intentionally NOT
+// reported: a reinstall unloads the model and only then downloads (minutes) and
+// reloads, so the debounced reconfigure runs while the model is legitimately
+// absent. Reporting it would raise a false "not analyzing" alarm and, worse, arm
+// the suppression window against a genuine failure in the same period.
+//
 // The shortfall is otherwise silent: detection keeps working for the models that
 // did register, so nothing looks broken, and the only trace is a warning in a
 // log file. Users have lost a model for days this way (GitHub #4201, #4204).
-func reportUnregisteredModels(sourceName string, skipped []string, resolved []classifier.ModelInfo, allocated map[string]bool) {
-	notRegistered := slices.Clone(skipped)
-	for i := range resolved {
-		if !allocated[resolved[i].ID] {
-			notRegistered = append(notRegistered, resolved[i].ID)
+func reportUnregisteredModels(mm *classifier.ModelManager, sourceName string, skipped []string, resolved []classifier.ModelInfo, allocated map[string]bool) {
+	notRegistered := make([]string, 0, len(skipped)+len(resolved))
+	for _, s := range skipped {
+		if modelIsDownloading(mm, s) {
+			continue
 		}
+		notRegistered = append(notRegistered, modelDisplayName(s))
+	}
+	for i := range resolved {
+		if allocated[resolved[i].ID] {
+			continue
+		}
+		if modelIsDownloading(mm, resolved[i].ID) {
+			continue
+		}
+		notRegistered = append(notRegistered, modelDisplayName(resolved[i].ID))
 	}
 	if len(notRegistered) > 0 {
 		notifyModelsNotRegistered(sourceName, notRegistered)
 	}
+}
+
+// modelDisplayName resolves a config ID or registry ID to the user-facing model
+// name (the same name the path-reconcile notification uses), so the
+// not-analyzing notification and its suppression key use ONE namespace rather
+// than mixing config IDs (from skipped) with registry IDs (from resolved).
+func modelDisplayName(modelID string) string {
+	registryID, ok := classifier.ResolveConfigModelID(modelID)
+	if !ok {
+		// modelID was not a config alias; treat it as an already-resolved registry ID.
+		registryID = modelID
+	}
+	if info, ok := classifier.ModelRegistry[registryID]; ok && info.Name != "" {
+		return info.Name
+	}
+	return modelID
+}
+
+// modelIsDownloading reports whether the model identified by modelID (a config
+// ID such as "perch_v2", or an already-resolved registry ID) has a gallery
+// download or reinstall in progress. A registry ID can back several catalog
+// entries (regional or hardware variants), and the download map is keyed by the
+// installed entry's catalog ID, so every catalog entry for the registry ID is
+// checked.
+func modelIsDownloading(mm *classifier.ModelManager, modelID string) bool {
+	if mm == nil {
+		return false
+	}
+	registryID, ok := classifier.ResolveConfigModelID(modelID)
+	if !ok {
+		// modelID was not a config alias; treat it as an already-resolved registry ID.
+		registryID = modelID
+	}
+	catalog := classifier.ActiveCatalog()
+	for i := range catalog {
+		if catalog[i].RegistryID == registryID && mm.GetDownloadState(catalog[i].ID) != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // startWeatherPolling initializes and starts the weather polling routine.

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -931,7 +931,7 @@ func (p *AudioPipelineService) registerConsumersForSources(sourceIDs []string, s
 
 		// Resolve per-source model targets. Fall back to primary if the
 		// source has no configured models or none could be resolved.
-		modelInfos := resolveModelTargets(sourceModelMap[sid], allModelInfos)
+		modelInfos, skippedModels := resolveModelTargets(sourceModelMap[sid], allModelInfos)
 		if len(modelInfos) == 0 {
 			modelInfos = primaryTargets
 		}
@@ -985,6 +985,8 @@ func (p *AudioPipelineService) registerConsumersForSources(sourceIDs []string, s
 			logger.String("models", strings.Join(modelIDs, ", ")),
 			logger.Int("model_count", len(targets)),
 			logger.String("operation", operation))
+
+		reportUnregisteredModels(sourceName, skippedModels, modelInfos, allocatedModels)
 
 		// Use per-source sample rate when available; fall back to global constant.
 		sourceSampleRate := conf.SampleRate
@@ -1609,18 +1611,20 @@ func deallocateStaleAnalysisBuffers(bufMgr *buffer.Manager, sourceID string, des
 }
 
 // resolveModelTargets converts config-level model IDs to ModelTarget entries
-// using the loaded model registry. Unknown or unloaded models are skipped
-// with a warning log.
-func resolveModelTargets(configModelIDs []string, loadedModels map[string]classifier.ModelInfo) []classifier.ModelInfo {
+// using the loaded model registry. Unknown or unloaded models are skipped with a
+// warning log, and reported to the caller through skipped so the omission can be
+// surfaced to the user instead of only reaching a log file.
+func resolveModelTargets(configModelIDs []string, loadedModels map[string]classifier.ModelInfo) (targets []classifier.ModelInfo, skipped []string) {
 	if len(configModelIDs) == 0 {
-		return nil
+		return nil, nil
 	}
-	targets := make([]classifier.ModelInfo, 0, len(configModelIDs))
+	targets = make([]classifier.ModelInfo, 0, len(configModelIDs))
 	for _, configID := range configModelIDs {
 		registryID, known := classifier.ResolveConfigModelID(configID)
 		if !known {
 			GetLogger().Warn("unknown model ID in source config, skipping",
 				logger.String("config_id", configID))
+			skipped = append(skipped, configID)
 			continue
 		}
 		info, loaded := loadedModels[registryID]
@@ -1628,11 +1632,32 @@ func resolveModelTargets(configModelIDs []string, loadedModels map[string]classi
 			GetLogger().Warn("model configured for source but not loaded",
 				logger.String("config_id", configID),
 				logger.String("registry_id", registryID))
+			skipped = append(skipped, configID)
 			continue
 		}
 		targets = append(targets, info)
 	}
-	return targets
+	return targets, skipped
+}
+
+// reportUnregisteredModels raises a user-visible notification for models that a
+// source's configuration assigns but which will not receive its audio, either
+// because they never loaded (skipped) or because their analysis buffer could
+// not be allocated (absent from allocated).
+//
+// The shortfall is otherwise silent: detection keeps working for the models that
+// did register, so nothing looks broken, and the only trace is a warning in a
+// log file. Users have lost a model for days this way (GitHub #4201, #4204).
+func reportUnregisteredModels(sourceName string, skipped []string, resolved []classifier.ModelInfo, allocated map[string]bool) {
+	notRegistered := slices.Clone(skipped)
+	for i := range resolved {
+		if !allocated[resolved[i].ID] {
+			notRegistered = append(notRegistered, resolved[i].ID)
+		}
+	}
+	if len(notRegistered) > 0 {
+		notifyModelsNotRegistered(sourceName, notRegistered)
+	}
 }
 
 // startWeatherPolling initializes and starts the weather polling routine.

--- a/internal/analysis/audio_pipeline_service_test.go
+++ b/internal/analysis/audio_pipeline_service_test.go
@@ -41,10 +41,10 @@ func TestResolveModelTargets_EmptyInput(t *testing.T) {
 	loaded := map[string]classifier.ModelInfo{
 		"BirdNET_V2.4": {ID: "BirdNET_V2.4", Spec: classifier.ModelSpec{SampleRate: 48000}},
 	}
-	targets := resolveModelTargets(nil, loaded)
+	targets, _ := resolveModelTargets(nil, loaded)
 	assert.Empty(t, targets, "nil config IDs should return nil")
 
-	targets = resolveModelTargets([]string{}, loaded)
+	targets, _ = resolveModelTargets([]string{}, loaded)
 	assert.Empty(t, targets, "empty config IDs should return empty")
 }
 
@@ -59,7 +59,7 @@ func TestResolveModelTargets_SingleModel(t *testing.T) {
 		},
 	}
 
-	targets := resolveModelTargets([]string{"birdnet"}, loaded)
+	targets, _ := resolveModelTargets([]string{"birdnet"}, loaded)
 	require.Len(t, targets, 1)
 	assert.Equal(t, "BirdNET_V2.4", targets[0].ID)
 	assert.Equal(t, 48000, targets[0].Spec.SampleRate)
@@ -79,7 +79,7 @@ func TestResolveModelTargets_MultiModel(t *testing.T) {
 		},
 	}
 
-	targets := resolveModelTargets([]string{"birdnet", "perch_v2"}, loaded)
+	targets, _ := resolveModelTargets([]string{"birdnet", "perch_v2"}, loaded)
 	require.Len(t, targets, 2)
 
 	// Collect results into a map for order-independent assertion.
@@ -102,7 +102,7 @@ func TestResolveModelTargets_UnknownConfigID(t *testing.T) {
 	}
 
 	// "unknown_model" is not in configToRegistryID, so it should be skipped.
-	targets := resolveModelTargets([]string{"unknown_model"}, loaded)
+	targets, _ := resolveModelTargets([]string{"unknown_model"}, loaded)
 	assert.Empty(t, targets)
 }
 
@@ -117,7 +117,7 @@ func TestResolveModelTargets_KnownButNotLoaded(t *testing.T) {
 		},
 	}
 
-	targets := resolveModelTargets([]string{"birdnet", "perch_v2"}, loaded)
+	targets, _ := resolveModelTargets([]string{"birdnet", "perch_v2"}, loaded)
 	require.Len(t, targets, 1, "only birdnet should resolve, perch_v2 is not loaded")
 	assert.Equal(t, "BirdNET_V2.4", targets[0].ID)
 }
@@ -217,4 +217,38 @@ func TestClassifyExportDir(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestResolveModelTargets_ReportsSkippedModels covers the reporting half of the
+// GitHub #4201 / #4204 fix: a model the config assigns to a source but which is
+// not loaded must be handed back to the caller, not merely logged, so the user
+// can be told the source is running with fewer models than they configured.
+func TestResolveModelTargets_ReportsSkippedModels(t *testing.T) {
+	t.Parallel()
+
+	loaded := map[string]classifier.ModelInfo{
+		"BirdNET_V2.4": {ID: "BirdNET_V2.4", Spec: classifier.ModelSpec{SampleRate: 48000}},
+	}
+
+	t.Run("configured but not loaded is reported", func(t *testing.T) {
+		t.Parallel()
+		targets, skipped := resolveModelTargets([]string{"birdnet", "perch_v2"}, loaded)
+		require.Len(t, targets, 1)
+		assert.Equal(t, "BirdNET_V2.4", targets[0].ID)
+		assert.Equal(t, []string{"perch_v2"}, skipped)
+	})
+
+	t.Run("unknown model ID is reported", func(t *testing.T) {
+		t.Parallel()
+		targets, skipped := resolveModelTargets([]string{"birdnet", "not_a_model"}, loaded)
+		require.Len(t, targets, 1)
+		assert.Equal(t, []string{"not_a_model"}, skipped)
+	})
+
+	t.Run("all models loaded reports nothing", func(t *testing.T) {
+		t.Parallel()
+		targets, skipped := resolveModelTargets([]string{"birdnet"}, loaded)
+		require.Len(t, targets, 1)
+		assert.Empty(t, skipped)
+	})
 }

--- a/internal/analysis/audio_pipeline_service_test.go
+++ b/internal/analysis/audio_pipeline_service_test.go
@@ -252,3 +252,45 @@ func TestResolveModelTargets_ReportsSkippedModels(t *testing.T) {
 		assert.Empty(t, skipped)
 	})
 }
+
+// TestUnregisteredModelNames_PrimaryFallbackIsNotReportedAsAssigned pins the
+// rule that only models the configuration actually assigns are named to the
+// user. When a source resolves to no loaded target, registerConsumersForSources
+// falls back to the primary model; the user assigned nothing there, so naming
+// the built-in primary as "assigned to this audio source" would be false and
+// would point the user at a gallery entry offering no action for a permanent
+// model. Caught on PR review by two independent reviewers.
+func TestUnregisteredModelNames_PrimaryFallbackIsNotReportedAsAssigned(t *testing.T) {
+	t.Parallel()
+
+	primary := []classifier.ModelInfo{{ID: "BirdNET_V2.4"}}
+
+	t.Run("a primary-fallback set is passed as nil and reports nothing", func(t *testing.T) {
+		t.Parallel()
+		// The call site passes assigned=nil when usedPrimaryFallback is true.
+		got := unregisteredModelNames(nil, nil, nil, nil)
+		assert.Empty(t, got, "a source that assigns no model must produce no report")
+	})
+
+	t.Run("an explicitly assigned model that did not register is reported", func(t *testing.T) {
+		t.Parallel()
+		got := unregisteredModelNames(nil, nil, primary, nil)
+		require.Len(t, got, 1, "an assigned but unallocated model must be reported")
+		assert.Equal(t, modelDisplayName("BirdNET_V2.4"), got[0])
+	})
+
+	t.Run("an allocated model is not reported", func(t *testing.T) {
+		t.Parallel()
+		got := unregisteredModelNames(nil, nil, primary, map[string]bool{"BirdNET_V2.4": true})
+		assert.Empty(t, got, "a model with an analysis buffer is analyzing and must not be reported")
+	})
+
+	t.Run("config-assigned but unresolvable models are still reported", func(t *testing.T) {
+		t.Parallel()
+		// skipped carries models the configuration names but that never resolved,
+		// which stay reportable even when the resolved set came from the fallback.
+		got := unregisteredModelNames(nil, []string{"perch_v2"}, nil, nil)
+		require.Len(t, got, 1)
+		assert.Equal(t, modelDisplayName("perch_v2"), got[0])
+	})
+}

--- a/internal/analysis/model_registration_notify.go
+++ b/internal/analysis/model_registration_notify.go
@@ -1,0 +1,69 @@
+package analysis
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/notification"
+)
+
+// modelNotRegisteredRenotifyInterval is how long the same source-and-models
+// combination stays suppressed after being reported. Source registration runs
+// on every start and on every settings-driven reconfigure, so an unresolved
+// problem would otherwise raise a fresh notification on each pass, and a stream
+// that reconnects in a loop would bury the notification list.
+const modelNotRegisteredRenotifyInterval = 6 * time.Hour
+
+var modelNotRegisteredSeen sync.Map // key: source + models, value: time.Time of last notification
+
+// notifyModelsNotRegistered reports that models assigned to an audio source are
+// not receiving its audio, either because they never loaded or because their
+// analysis buffer could not be allocated.
+//
+// This condition used to be invisible. registerConsumersForSources skips such a
+// model with a log warning and, when a source ends up with no targets at all,
+// silently falls back to the primary model, so the pipeline starts looking
+// healthy while analyzing with fewer models than configured. The reporters of
+// GitHub #4201 and #4204 each lost a model for days before noticing by
+// accident.
+func notifyModelsNotRegistered(sourceName string, modelIDs []string) {
+	if len(modelIDs) == 0 {
+		return
+	}
+	svc := notification.GetService()
+	if svc == nil {
+		return
+	}
+
+	models := strings.Join(modelIDs, ", ")
+	key := sourceName + "\x00" + models
+	now := time.Now()
+	if last, ok := modelNotRegisteredSeen.Load(key); ok {
+		if t, isTime := last.(time.Time); isTime && now.Sub(t) < modelNotRegisteredRenotifyInterval {
+			return
+		}
+	}
+	modelNotRegisteredSeen.Store(key, now)
+
+	notif := notification.NewNotification(
+		notification.TypeWarning,
+		notification.PriorityHigh,
+		fmt.Sprintf("Model not analyzing %s", sourceName),
+		fmt.Sprintf("%s is assigned to audio source %q but is not receiving audio, so it is not producing "+
+			"detections. The model is most likely not installed or failed to load. Check the model gallery "+
+			"in Settings.", models, sourceName),
+	).
+		WithComponent("analysis.audio_pipeline").
+		WithTitleKey(notification.MsgModelNotRegisteredTitle, map[string]any{
+			"sourceName": sourceName,
+		}).
+		WithMessageKey(notification.MsgModelNotRegisteredMessage, map[string]any{
+			"sourceName": sourceName,
+			"models":     models,
+		}).
+		WithDeliveryTarget("bell")
+
+	_ = svc.CreateWithMetadata(notif)
+}

--- a/internal/analysis/model_registration_notify.go
+++ b/internal/analysis/model_registration_notify.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/notification"
 )
 
@@ -45,15 +46,18 @@ func notifyModelsNotRegistered(sourceName string, modelIDs []string) {
 			return
 		}
 	}
-	modelNotRegisteredSeen.Store(key, now)
 
 	notif := notification.NewNotification(
 		notification.TypeWarning,
-		notification.PriorityHigh,
+		notification.PriorityMedium,
 		fmt.Sprintf("Model not analyzing %s", sourceName),
-		fmt.Sprintf("%s is assigned to audio source %q but is not receiving audio, so it is not producing "+
-			"detections. The model is most likely not installed or failed to load. Check the model gallery "+
-			"in Settings.", models, sourceName),
+		// State only what is known: the model is assigned but not currently
+		// receiving audio. The old "most likely not installed or failed to load"
+		// was wrong for the allocation-failure branch, and worse in the
+		// primary-fallback case where it could tell the user the built-in BirdNET
+		// model is not installed.
+		fmt.Sprintf("%s is assigned to audio source %q but is not currently receiving audio, so it is not "+
+			"producing detections. Open the model gallery in Settings to check its status.", models, sourceName),
 	).
 		WithComponent("analysis.audio_pipeline").
 		WithTitleKey(notification.MsgModelNotRegisteredTitle, map[string]any{
@@ -65,5 +69,16 @@ func notifyModelsNotRegistered(sourceName string, modelIDs []string) {
 		}).
 		WithDeliveryTarget("bell")
 
-	_ = svc.CreateWithMetadata(notif)
+	// Arm the 6h suppression window only after the notification is actually
+	// created. The service rate-limits, so storing the key before the create (or
+	// on a failed create) would silence a genuine condition for six hours behind a
+	// notification the user never saw.
+	if err := svc.CreateWithMetadata(notif); err != nil {
+		GetLogger().Warn("failed to create model-not-registered notification",
+			logger.String("source", sourceName),
+			logger.String("models", models),
+			logger.Error(err))
+		return
+	}
+	modelNotRegisteredSeen.Store(key, now)
 }

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -171,9 +171,12 @@ type Controller struct {
 	// topologyReconfigureTimer debounces the audio-source reconfigure triggered
 	// by a model topology change (see OnModelTopologyChanged). A gallery variant
 	// switch fires the callback twice and each reconfigure re-probes every RTSP
-	// stream, so the two are coalesced into one.
-	topologyReconfigureMu    sync.Mutex
-	topologyReconfigureTimer *time.Timer
+	// stream, so the two are coalesced into one. topologyReconfigureShutdown is
+	// set under topologyReconfigureMu by Shutdown so a callback that fires during
+	// teardown does not re-arm the timer.
+	topologyReconfigureMu       sync.Mutex
+	topologyReconfigureTimer    *time.Timer
+	topologyReconfigureShutdown bool
 
 	// DisableSaveSettings prevents persisting settings changes to disk.
 	// When set to true, all settings modifications remain in memory only.
@@ -806,6 +809,18 @@ func (c *Controller) Shutdown() {
 	if c.alerts != nil {
 		c.alerts.Shutdown()
 	}
+
+	// Stop the topology-reconfigure debounce timer and mark it shut down so a
+	// model-topology callback that fires during teardown does not re-arm it. Done
+	// under topologyReconfigureMu, the same lock scheduleAudioSourceReconfigure
+	// takes, so the flag and the timer stay consistent.
+	c.topologyReconfigureMu.Lock()
+	c.topologyReconfigureShutdown = true
+	if c.topologyReconfigureTimer != nil {
+		c.topologyReconfigureTimer.Stop()
+		c.topologyReconfigureTimer = nil
+	}
+	c.topologyReconfigureMu.Unlock()
 
 	// Cancel context to stop all goroutines, then wait for them to finish.
 	c.Cancel()

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -168,6 +168,13 @@ type Controller struct {
 
 	controlChan chan string
 
+	// topologyReconfigureTimer debounces the audio-source reconfigure triggered
+	// by a model topology change (see OnModelTopologyChanged). A gallery variant
+	// switch fires the callback twice and each reconfigure re-probes every RTSP
+	// stream, so the two are coalesced into one.
+	topologyReconfigureMu    sync.Mutex
+	topologyReconfigureTimer *time.Timer
+
 	// DisableSaveSettings prevents persisting settings changes to disk.
 	// When set to true, all settings modifications remain in memory only.
 	// This is primarily used in testing but can be used in production for read-only mode.
@@ -347,10 +354,11 @@ func WithAudioEngine(e *engine.AudioEngine) Option {
 func WithModelManager(mm *classifier.ModelManager) Option {
 	return func(c *Controller) {
 		c.ModelManager = mm
-		// Wire the topology-changed callback so model add/remove broadcasts over
-		// the metrics SSE stream. The method value binds c; c.MetricsStore is read
-		// lazily at call time, so option ordering is irrelevant.
-		mm.SetTopologyChangedCallback(c.BroadcastInferenceTopologyChanged)
+		// Wire the topology-changed callback so a model add/remove both broadcasts
+		// over the metrics SSE stream AND re-registers the model against running
+		// audio sources. The method value binds c; c.MetricsStore and c.controlChan
+		// are read lazily at call time, so option ordering is irrelevant.
+		mm.SetTopologyChangedCallback(c.OnModelTopologyChanged)
 	}
 }
 

--- a/internal/api/v2/system/inference_status.go
+++ b/internal/api/v2/system/inference_status.go
@@ -730,27 +730,31 @@ func buildSourceAttachments(settings *conf.Settings, models []classifier.ModelIn
 		// to every assigned+loaded model (see analysis.resolveModelTargets), so the
 		// status view must attach the source to all of them, not just the first.
 		live, haveLive := running[name]
-		matched := false
+		resolvedToLoaded := false
 		for _, cm := range configModels {
 			regID, ok := classifier.ResolveConfigModelID(cm)
 			if !ok || !loaded[regID] {
 				continue
 			}
+			// A configured model that resolves to a loaded model is a target,
+			// regardless of whether it currently has an analysis buffer. This mirrors
+			// the pipeline: resolveModelTargets filters on loaded, so a loaded target
+			// here is exactly what stops registerConsumersForSources from falling back.
+			resolvedToLoaded = true
 			// Surface the source either way, but say which it is: a model the router
 			// really feeds, or one the config assigns that gets no audio.
 			notRunning := haveLive && !live[regID]
 			out[regID] = append(out[regID], ModelSourceInfo{
 				ID: name, Name: name, Type: sourceType, Fallback: false, NotRunning: notRunning,
 			})
-			if !notRunning {
-				matched = true
-			}
 		}
-		// Nothing the config assigns is actually analyzing this source: the primary
-		// model picks it up as the runtime fallback (see registerConsumersForSources,
-		// which falls back to the primary when a source resolves to no targets), so
-		// surface it there with Fallback=true.
-		if !matched && primaryID != "" {
+		// The runtime falls back to the primary model only when a source resolves to
+		// NO loaded target (see registerConsumersForSources). Liveness does not enter
+		// that decision: a configured model that is loaded but currently has no
+		// analysis buffer is still the resolved target (surfaced with NotRunning
+		// above), not replaced by a primary-fallback row the runtime never creates.
+		// Keying the fallback on resolvedToLoaded restores parity with the pipeline.
+		if !resolvedToLoaded && primaryID != "" {
 			out[primaryID] = append(out[primaryID], ModelSourceInfo{ID: name, Name: name, Type: sourceType, Fallback: true})
 		}
 	}
@@ -772,9 +776,24 @@ func buildSourceAttachments(settings *conf.Settings, models []classifier.ModelIn
 // The buffer manager is the ground truth here, not the router's route table:
 // the router holds a single multiplexing BufferConsumer per source and cannot
 // say which models sit behind it, whereas an analysis buffer exists for exactly
-// the (source, model) pairs registerConsumersForSources allocated. That is the
-// same state sourceModelsChanged diffs, so the status view and the pipeline's
-// own reconfigure decision agree on what is running.
+// the (source, model) pairs currently set up to analyze. The invariant: a buffer
+// exists for (source, model) iff that model is configured to analyze that source
+// and is loaded. Buffers are created by bufMgr.AllocateAnalysis (three call
+// sites: the initial per-source registration, a later model-change reconfigure,
+// and the engine's own pre-allocation of the primary model's buffer in
+// AddSource) and removed by deallocateStaleAnalysisBuffers. That is the same
+// state sourceModelsChanged diffs, so the status view and the pipeline's own
+// reconfigure decision agree on what is running.
+//
+// Two source states are reported as "no live evidence" (the key is left absent,
+// so the caller keeps the unmarked config-derived view) rather than as negative:
+//   - A DisplayName shared by more than one registry source. DisplayName is
+//     unique only within audio.sources and within rtsp.streams, never across
+//     them; on a collision a live set cannot be mapped to one config entry, so
+//     the key is dropped rather than risk marking a healthy model not running.
+//   - An empty buffer set. A source is in the registry from AddSource before its
+//     buffers are allocated, so an empty set is INDETERMINATE ("not yet"), not a
+//     claim that the source runs nothing.
 //
 // Returns nil when the audio engine is not wired up (before the pipeline starts,
 // or in tests), which the caller reads as "no live evidence available".
@@ -793,9 +812,24 @@ func (c *Handler) runningModelsBySource() map[string]map[string]bool {
 	}
 
 	sources := registry.List()
+
+	// Count DisplayName occurrences first so a name shared by more than one
+	// registry source can be dropped entirely below (see the doc comment).
+	nameCounts := make(map[string]int, len(sources))
+	for _, src := range sources {
+		if src == nil {
+			continue
+		}
+		nameCounts[src.DisplayName]++
+	}
+
 	out := make(map[string]map[string]bool, len(sources))
 	for _, src := range sources {
 		if src == nil {
+			continue
+		}
+		// Collision: cannot map a live set to a single config entry, so omit it.
+		if nameCounts[src.DisplayName] > 1 {
 			continue
 		}
 		// Key by DisplayName: it is what the registry carries for both audio
@@ -804,6 +838,13 @@ func (c *Handler) runningModelsBySource() map[string]map[string]bool {
 		models := make(map[string]bool)
 		for modelID := range bufMgr.AnalysisBuffers(src.ID) {
 			models[modelID] = true
+		}
+		// An empty buffer set is indeterminate (source registered, buffers not yet
+		// allocated), so omit the source: the caller then reads haveLive=false for
+		// it and keeps the unmarked config-derived view rather than reporting every
+		// assigned model as not running.
+		if len(models) == 0 {
+			continue
 		}
 		out[src.DisplayName] = models
 	}

--- a/internal/api/v2/system/inference_status.go
+++ b/internal/api/v2/system/inference_status.go
@@ -254,6 +254,14 @@ type ModelSourceInfo struct {
 	Name     string `json:"name"`
 	Type     string `json:"type,omitempty"`
 	Fallback bool   `json:"fallback,omitempty"`
+	// NotRunning marks a source that the configuration assigns to this model but
+	// whose audio does not actually reach it, because the audio router has no
+	// analysis buffer for the pair. That happens when the model failed to load or
+	// its buffer allocation failed, and it used to be invisible: the status
+	// reported the model as attached purely because the config said so, so the UI
+	// showed a model running while it analyzed nothing (GitHub #4201, #4204).
+	// Omitted when the source really is attached.
+	NotRunning bool `json:"notRunning,omitempty"`
 }
 
 // ModelMetricKeys carries the Prometheus-style metric key names for a model's
@@ -494,7 +502,7 @@ func (c *Handler) GetInferenceStatus(ctx echo.Context) error {
 		loadFailures = orch.LoadFailures()
 	}
 	counters := classifier.GetInferenceCounters().PeekAll()
-	attachments := buildSourceAttachments(settings, infos, primaryID)
+	attachments := buildSourceAttachments(settings, infos, primaryID, c.runningModelsBySource())
 
 	// Compute per-model device, backend, precision, and schedule status from the
 	// live orchestrator. The device/backend/precision triplet is read in one
@@ -697,11 +705,20 @@ func sortInferenceModelsByName(models []InferenceModelStatus) {
 }
 
 // buildSourceAttachments computes, per loaded model registry ID, the audio
-// sources attached to it from configuration. A source whose Models resolve to a
-// loaded model attaches there; a source with no resolvable model falls back to
-// the primary model with Fallback=true. Live registry enrichment (DisplayName,
-// State) is deferred to Phase 2; Phase 1 uses config identity.
-func buildSourceAttachments(settings *conf.Settings, models []classifier.ModelInfo, primaryID string) map[string][]ModelSourceInfo {
+// sources attached to it. A source whose Models resolve to a loaded model
+// attaches there; a source with no resolvable model falls back to the primary
+// model with Fallback=true.
+//
+// running carries the audio router's actual per-source model set, keyed by
+// source display name (see (*Handler).runningModelsBySource). Configuration
+// alone is not evidence that a model analyzes a source: the router fans a
+// source out only to the models it has allocated an analysis buffer for, and a
+// model can be configured, loaded, and still receive nothing. Reporting from
+// config alone is what let the UI show Perch running while it analyzed no audio
+// (GitHub #4201, #4204). When running is nil the audio engine is not available
+// (the pipeline has not started, or this is a test), and the config-derived
+// view is the best answer available, so it is used unmarked.
+func buildSourceAttachments(settings *conf.Settings, models []classifier.ModelInfo, primaryID string, running map[string]map[string]bool) map[string][]ModelSourceInfo {
 	loaded := make(map[string]bool, len(models))
 	for i := range models {
 		loaded[models[i].ID] = true
@@ -712,17 +729,27 @@ func buildSourceAttachments(settings *conf.Settings, models []classifier.ModelIn
 		// A source can feed several models at once. The runtime fans its audio out
 		// to every assigned+loaded model (see analysis.resolveModelTargets), so the
 		// status view must attach the source to all of them, not just the first.
+		live, haveLive := running[name]
 		matched := false
 		for _, cm := range configModels {
 			regID, ok := classifier.ResolveConfigModelID(cm)
 			if !ok || !loaded[regID] {
 				continue
 			}
-			out[regID] = append(out[regID], ModelSourceInfo{ID: name, Name: name, Type: sourceType, Fallback: false})
-			matched = true
+			// Surface the source either way, but say which it is: a model the router
+			// really feeds, or one the config assigns that gets no audio.
+			notRunning := haveLive && !live[regID]
+			out[regID] = append(out[regID], ModelSourceInfo{
+				ID: name, Name: name, Type: sourceType, Fallback: false, NotRunning: notRunning,
+			})
+			if !notRunning {
+				matched = true
+			}
 		}
-		// No assigned model resolved to a loaded one: the primary model analyzes the
-		// source as the runtime fallback, so surface it there with Fallback=true.
+		// Nothing the config assigns is actually analyzing this source: the primary
+		// model picks it up as the runtime fallback (see registerConsumersForSources,
+		// which falls back to the primary when a source resolves to no targets), so
+		// surface it there with Fallback=true.
 		if !matched && primaryID != "" {
 			out[primaryID] = append(out[primaryID], ModelSourceInfo{ID: name, Name: name, Type: sourceType, Fallback: true})
 		}
@@ -735,6 +762,50 @@ func buildSourceAttachments(settings *conf.Settings, models []classifier.ModelIn
 	for i := range settings.Realtime.RTSP.Streams {
 		st := settings.Realtime.RTSP.Streams[i]
 		attach(st.Name, st.Type, st.Models)
+	}
+	return out
+}
+
+// runningModelsBySource reports which models the audio router actually feeds,
+// keyed by source display name then registry model ID.
+//
+// The buffer manager is the ground truth here, not the router's route table:
+// the router holds a single multiplexing BufferConsumer per source and cannot
+// say which models sit behind it, whereas an analysis buffer exists for exactly
+// the (source, model) pairs registerConsumersForSources allocated. That is the
+// same state sourceModelsChanged diffs, so the status view and the pipeline's
+// own reconfigure decision agree on what is running.
+//
+// Returns nil when the audio engine is not wired up (before the pipeline starts,
+// or in tests), which the caller reads as "no live evidence available".
+func (c *Handler) runningModelsBySource() map[string]map[string]bool {
+	if c == nil || c.Core == nil {
+		return nil
+	}
+	eng := c.Engine.Load()
+	if eng == nil {
+		return nil
+	}
+	registry := eng.Registry()
+	bufMgr := eng.BufferManager()
+	if registry == nil || bufMgr == nil {
+		return nil
+	}
+
+	sources := registry.List()
+	out := make(map[string]map[string]bool, len(sources))
+	for _, src := range sources {
+		if src == nil {
+			continue
+		}
+		// Key by DisplayName: it is what the registry carries for both audio
+		// sources and RTSP streams, and it is what the config-side attachment
+		// above uses as the source name.
+		models := make(map[string]bool)
+		for modelID := range bufMgr.AnalysisBuffers(src.ID) {
+			models[modelID] = true
+		}
+		out[src.DisplayName] = models
 	}
 	return out
 }

--- a/internal/api/v2/system/inference_status.go
+++ b/internal/api/v2/system/inference_status.go
@@ -755,7 +755,15 @@ func buildSourceAttachments(settings *conf.Settings, models []classifier.ModelIn
 		// above), not replaced by a primary-fallback row the runtime never creates.
 		// Keying the fallback on resolvedToLoaded restores parity with the pipeline.
 		if !resolvedToLoaded && primaryID != "" {
-			out[primaryID] = append(out[primaryID], ModelSourceInfo{ID: name, Name: name, Type: sourceType, Fallback: true})
+			// The fallback row describes the primary model that actually analyzes this
+			// source, so it carries the same liveness verdict as a resolved row. A
+			// primary whose own analysis buffer is absent is not analyzing either, and
+			// reporting it as healthy is the "looks running while analyzing nothing"
+			// state this endpoint exists to remove.
+			out[primaryID] = append(out[primaryID], ModelSourceInfo{
+				ID: name, Name: name, Type: sourceType, Fallback: true,
+				NotRunning: haveLive && !live[primaryID],
+			})
 		}
 	}
 

--- a/internal/api/v2/system/inference_status_test.go
+++ b/internal/api/v2/system/inference_status_test.go
@@ -47,7 +47,7 @@ func TestBuildSourceAttachments(t *testing.T) {
 		{Name: "Cam1", Type: "rtsp", Models: []string{"unknown_model"}}, // unresolved: falls back to primary
 	}
 
-	got := buildSourceAttachments(settings, models, primaryID)
+	got := buildSourceAttachments(settings, models, primaryID, nil)
 
 	// Perch_V2 should have exactly Front Yard, attached without fallback.
 	perch := got[classifier.RegistryIDPerchV2]
@@ -84,7 +84,7 @@ func TestBuildSourceAttachments_ResolvesButNotLoaded(t *testing.T) {
 		{Name: "Studio", Models: []string{conf.ModelIDPerchV2}},
 	}
 
-	got := buildSourceAttachments(settings, models, primaryID)
+	got := buildSourceAttachments(settings, models, primaryID, nil)
 
 	// Perch_V2 should have NO attachments (not loaded).
 	perch := got[classifier.RegistryIDPerchV2]
@@ -120,7 +120,7 @@ func TestBuildSourceAttachments_MultiModelSourceAttachesAll(t *testing.T) {
 		{Name: "Äänikortti", Models: []string{conf.ModelIDBirdNET, conf.ModelIDPerchV2, conf.ModelIDBat}},
 	}
 
-	got := buildSourceAttachments(settings, models, primaryID)
+	got := buildSourceAttachments(settings, models, primaryID, nil)
 
 	// Every assigned, loaded model must show the source, none as a fallback.
 	for _, id := range []string{primaryID, classifier.RegistryIDPerchV2, classifier.RegistryIDBat} {
@@ -648,4 +648,89 @@ func TestHardwareInfo_JSONContract(t *testing.T) {
 	for _, key := range []string{"board", "accelerators", "totalRamBytes", "physicalCores", "capabilities"} {
 		assert.NotContains(t, empty, key, "added key %q must be omitted when unset", key)
 	}
+}
+
+// TestBuildSourceAttachments_LiveRouterState verifies that the status view
+// reports what the audio router is actually doing rather than what the config
+// asks for. A model that is loaded and assigned but that receives no audio must
+// be marked NotRunning instead of being presented as running: reporting it as
+// running is what hid the model-loading failure behind GitHub #4201 and #4204
+// for days.
+func TestBuildSourceAttachments_LiveRouterState(t *testing.T) {
+	t.Parallel()
+
+	const primaryID = classifier.DefaultModelVersion
+	models := []classifier.ModelInfo{
+		{ID: primaryID},
+		{ID: classifier.RegistryIDPerchV2},
+	}
+
+	settings := &conf.Settings{}
+	settings.Realtime.Audio.Sources = []conf.AudioSourceConfig{
+		{Name: "Front Yard", Models: []string{conf.ModelIDBirdNET, conf.ModelIDPerchV2}},
+	}
+
+	t.Run("assigned but not routed is marked not running", func(t *testing.T) {
+		t.Parallel()
+
+		// The router feeds only BirdNET, though the config assigns Perch too.
+		running := map[string]map[string]bool{
+			"Front Yard": {primaryID: true},
+		}
+
+		got := buildSourceAttachments(settings, models, primaryID, running)
+
+		perch := got[classifier.RegistryIDPerchV2]
+		require.Len(t, perch, 1)
+		assert.True(t, perch[0].NotRunning,
+			"a model that receives no audio must not be reported as running")
+
+		prim := got[primaryID]
+		require.Len(t, prim, 1)
+		assert.False(t, prim[0].NotRunning, "BirdNET really is routed")
+		assert.False(t, prim[0].Fallback,
+			"BirdNET is genuinely assigned here, so it is not a fallback attachment")
+	})
+
+	t.Run("routed models are reported as running", func(t *testing.T) {
+		t.Parallel()
+
+		running := map[string]map[string]bool{
+			"Front Yard": {primaryID: true, classifier.RegistryIDPerchV2: true},
+		}
+
+		got := buildSourceAttachments(settings, models, primaryID, running)
+
+		perch := got[classifier.RegistryIDPerchV2]
+		require.Len(t, perch, 1)
+		assert.False(t, perch[0].NotRunning)
+	})
+
+	t.Run("no model routed falls back to the primary", func(t *testing.T) {
+		t.Parallel()
+
+		// The source is known to the router but has no analysis buffers at all.
+		running := map[string]map[string]bool{"Front Yard": {}}
+
+		got := buildSourceAttachments(settings, models, primaryID, running)
+
+		// Both assigned models report as not running, and the primary additionally
+		// picks the source up as the runtime fallback, mirroring what
+		// registerConsumersForSources does when a source resolves to no targets.
+		prim := got[primaryID]
+		require.Len(t, prim, 2)
+		assert.True(t, prim[0].NotRunning, "the assigned-but-idle BirdNET entry")
+		assert.True(t, prim[1].Fallback, "the primary fallback entry")
+	})
+
+	t.Run("nil live state keeps the config-derived view unmarked", func(t *testing.T) {
+		t.Parallel()
+
+		got := buildSourceAttachments(settings, models, primaryID, nil)
+
+		perch := got[classifier.RegistryIDPerchV2]
+		require.Len(t, perch, 1)
+		assert.False(t, perch[0].NotRunning,
+			"without live evidence nothing may be claimed to be broken")
+	})
 }

--- a/internal/api/v2/system/inference_status_test.go
+++ b/internal/api/v2/system/inference_status_test.go
@@ -706,21 +706,27 @@ func TestBuildSourceAttachments_LiveRouterState(t *testing.T) {
 		assert.False(t, perch[0].NotRunning)
 	})
 
-	t.Run("no model routed falls back to the primary", func(t *testing.T) {
+	t.Run("assigned models loaded but idle do not invent a primary fallback", func(t *testing.T) {
 		t.Parallel()
 
-		// The source is known to the router but has no analysis buffers at all.
+		// The source is known to the router but has no analysis buffers at all, so
+		// both assigned models are idle. Both still resolve to LOADED models, so the
+		// runtime does NOT fall back to the primary: registerConsumersForSources
+		// falls back only when a source resolves to no loaded target. The status
+		// must not invent a fallback row the runtime never creates.
 		running := map[string]map[string]bool{"Front Yard": {}}
 
 		got := buildSourceAttachments(settings, models, primaryID, running)
 
-		// Both assigned models report as not running, and the primary additionally
-		// picks the source up as the runtime fallback, mirroring what
-		// registerConsumersForSources does when a source resolves to no targets.
 		prim := got[primaryID]
-		require.Len(t, prim, 2)
-		assert.True(t, prim[0].NotRunning, "the assigned-but-idle BirdNET entry")
-		assert.True(t, prim[1].Fallback, "the primary fallback entry")
+		require.Len(t, prim, 1, "only the genuine BirdNET assignment, no invented fallback row")
+		assert.True(t, prim[0].NotRunning, "BirdNET is assigned but idle")
+		assert.False(t, prim[0].Fallback,
+			"BirdNET is a genuine assignment here, not a runtime fallback")
+
+		perch := got[classifier.RegistryIDPerchV2]
+		require.Len(t, perch, 1)
+		assert.True(t, perch[0].NotRunning, "Perch is assigned but idle")
 	})
 
 	t.Run("nil live state keeps the config-derived view unmarked", func(t *testing.T) {
@@ -733,4 +739,58 @@ func TestBuildSourceAttachments_LiveRouterState(t *testing.T) {
 		assert.False(t, perch[0].NotRunning,
 			"without live evidence nothing may be claimed to be broken")
 	})
+
+	t.Run("source absent from a non-nil running map stays unmarked", func(t *testing.T) {
+		t.Parallel()
+
+		// running is non-nil but does not contain "Front Yard": the branch a
+		// DisplayName collision or an omitted (empty-buffer) source lands in. Without
+		// live evidence for THIS source, nothing may be marked not running, even
+		// though live evidence exists for a different source.
+		running := map[string]map[string]bool{"A Different Source": {primaryID: true}}
+
+		got := buildSourceAttachments(settings, models, primaryID, running)
+
+		perch := got[classifier.RegistryIDPerchV2]
+		require.Len(t, perch, 1)
+		assert.False(t, perch[0].NotRunning,
+			"a source absent from a non-nil running map has no live evidence")
+
+		prim := got[primaryID]
+		require.Len(t, prim, 1)
+		assert.False(t, prim[0].NotRunning)
+	})
+}
+
+// TestBuildSourceAttachments_RTSPStream covers an RTSP stream source (the
+// reporters run RTSP; only audio.sources were covered before). An assigned model
+// that the router does not feed for the stream is marked NotRunning.
+func TestBuildSourceAttachments_RTSPStream(t *testing.T) {
+	t.Parallel()
+
+	const primaryID = classifier.DefaultModelVersion
+	models := []classifier.ModelInfo{
+		{ID: primaryID},
+		{ID: classifier.RegistryIDPerchV2},
+	}
+
+	settings := &conf.Settings{}
+	settings.Realtime.RTSP.Streams = []conf.StreamConfig{
+		{Name: "Cam1", Type: "rtsp", Models: []string{conf.ModelIDBirdNET, conf.ModelIDPerchV2}},
+	}
+
+	// The router feeds only BirdNET for this stream; Perch is assigned but idle.
+	running := map[string]map[string]bool{"Cam1": {primaryID: true}}
+
+	got := buildSourceAttachments(settings, models, primaryID, running)
+
+	perch := got[classifier.RegistryIDPerchV2]
+	require.Len(t, perch, 1)
+	assert.Equal(t, "Cam1", perch[0].Name)
+	assert.Equal(t, "rtsp", perch[0].Type)
+	assert.True(t, perch[0].NotRunning, "the assigned but unrouted Perch model on the RTSP stream")
+
+	prim := got[primaryID]
+	require.Len(t, prim, 1)
+	assert.False(t, prim[0].NotRunning, "BirdNET is genuinely routed for the stream")
 }

--- a/internal/api/v2/system/inference_status_test.go
+++ b/internal/api/v2/system/inference_status_test.go
@@ -794,3 +794,72 @@ func TestBuildSourceAttachments_RTSPStream(t *testing.T) {
 	require.Len(t, prim, 1)
 	assert.False(t, prim[0].NotRunning, "BirdNET is genuinely routed for the stream")
 }
+
+// TestBuildSourceAttachments_FallbackRowCarriesLiveness pins that the
+// primary-fallback attachment is subject to the same liveness verdict as an
+// explicitly assigned row. A source that resolves to no loaded target is
+// analyzed by the primary model, so if the primary's own analysis buffer is
+// absent the source is not being analyzed at all. Reporting that row as healthy
+// reproduces the "looks running while analyzing nothing" state this endpoint
+// exists to remove, just on the fallback branch. Caught on PR review.
+func TestBuildSourceAttachments_FallbackRowCarriesLiveness(t *testing.T) {
+	t.Parallel()
+
+	const primaryID = classifier.DefaultModelVersion
+	// Only the primary is loaded, so a source assigning Perch resolves to nothing
+	// and takes the primary-fallback branch.
+	models := []classifier.ModelInfo{{ID: primaryID}}
+
+	settings := &conf.Settings{}
+	settings.Realtime.Audio.Sources = []conf.AudioSourceConfig{
+		{Name: "Front Yard", Models: []string{conf.ModelIDPerchV2}},
+	}
+
+	t.Run("fallback row is marked not running when the primary has no buffer", func(t *testing.T) {
+		t.Parallel()
+
+		// The router knows this source and feeds some other model on it, but not the
+		// primary, so live evidence exists and it says the primary is not fed.
+		running := map[string]map[string]bool{
+			"Front Yard": {"SomeOtherModel": true},
+		}
+
+		got := buildSourceAttachments(settings, models, primaryID, running)
+
+		prim := got[primaryID]
+		require.Len(t, prim, 1)
+		assert.True(t, prim[0].Fallback, "this row is the primary fallback")
+		assert.True(t, prim[0].NotRunning,
+			"the primary analyzes this source, so an absent primary buffer means it is not analyzing")
+	})
+
+	t.Run("fallback row is running when the primary is routed", func(t *testing.T) {
+		t.Parallel()
+
+		running := map[string]map[string]bool{
+			"Front Yard": {primaryID: true},
+		}
+
+		got := buildSourceAttachments(settings, models, primaryID, running)
+
+		prim := got[primaryID]
+		require.Len(t, prim, 1)
+		assert.True(t, prim[0].Fallback)
+		assert.False(t, prim[0].NotRunning,
+			"the primary really is routed for this source")
+	})
+
+	t.Run("fallback row makes no claim without live evidence", func(t *testing.T) {
+		t.Parallel()
+
+		// A nil router map means the pipeline has not reported yet. Absence of
+		// evidence must not be rendered as a failure.
+		got := buildSourceAttachments(settings, models, primaryID, nil)
+
+		prim := got[primaryID]
+		require.Len(t, prim, 1)
+		assert.True(t, prim[0].Fallback)
+		assert.False(t, prim[0].NotRunning,
+			"with no live evidence the row must not assert that the model is failing")
+	})
+}

--- a/internal/api/v2/system_routes.go
+++ b/internal/api/v2/system_routes.go
@@ -2,6 +2,8 @@
 package api
 
 import (
+	"time"
+
 	"github.com/tphakala/birdnet-go/internal/api/v2/system"
 	"github.com/tphakala/birdnet-go/internal/observability"
 )
@@ -85,4 +87,68 @@ func (c *Controller) HealthEventBuffer() *observability.HealthEventBuffer {
 		return nil
 	}
 	return c.system.HealthEventBuffer()
+}
+
+// modelTopologyReconfigureDebounce coalesces the audio-source reconfigure that
+// follows a model topology change. A gallery variant switch fires the topology
+// callback twice (once when the old variant unloads, once when the new one
+// loads), and each reconfigure re-probes every enabled RTSP stream with ffprobe,
+// so reacting to both would double that cost for no benefit.
+const modelTopologyReconfigureDebounce = 2 * time.Second
+
+// OnModelTopologyChanged reacts to a model being loaded into or unloaded from
+// the orchestrator at runtime, which happens when the user installs, reinstalls,
+// switches the variant of, or removes a model in the gallery.
+//
+// It does two things. It broadcasts over the metrics SSE stream so open clients
+// re-fetch the inference snapshot, and it asks the audio pipeline to reconcile
+// its per-source model registration.
+//
+// The second half is the fix for GitHub issues #4201 and #4204. Loading a model
+// into the orchestrator does not attach it to anything: the audio router fans a
+// source out to the models registered for it, and that registration is computed
+// only at startup and when settings change. So a model installed from the
+// gallery while the server ran would load, report itself as installed, and then
+// receive no audio at all until the user toggled the model assignment on the
+// source to force a reconfigure. Signalling reconfigure_audio_sources here runs
+// the same diff the settings path uses: sourceModelsChanged compares each
+// source's allocated analysis buffers against the models the config asks for
+// that are actually loaded, so a newly loaded model shows up as a change and
+// the source is re-registered. An unload is handled by the same diff in reverse.
+func (c *Controller) OnModelTopologyChanged() {
+	if c == nil {
+		return
+	}
+	c.BroadcastInferenceTopologyChanged()
+	c.scheduleAudioSourceReconfigure()
+}
+
+// scheduleAudioSourceReconfigure starts or resets the debounce timer that sends
+// the audio-source reconfigure signal, mirroring the debounce the MQTT
+// discovery publisher uses for source-registry churn.
+func (c *Controller) scheduleAudioSourceReconfigure() {
+	c.topologyReconfigureMu.Lock()
+	defer c.topologyReconfigureMu.Unlock()
+
+	if c.topologyReconfigureTimer != nil {
+		c.topologyReconfigureTimer.Stop()
+	}
+	c.topologyReconfigureTimer = time.AfterFunc(modelTopologyReconfigureDebounce, func() {
+		c.sendAudioSourceReconfigure()
+	})
+}
+
+// sendAudioSourceReconfigure delivers the reconfigure signal without blocking.
+// The control channel is buffered and drained by the control monitor; if it is
+// momentarily full, dropping the signal is preferable to stalling the caller,
+// and the log records that a reconfigure was missed.
+func (c *Controller) sendAudioSourceReconfigure() {
+	if c.controlChan == nil {
+		return
+	}
+	select {
+	case c.controlChan <- actionReconfigureAudioSources:
+	default:
+		GetLogger().Warn("control channel full, skipping audio source reconfigure after model topology change")
+	}
 }

--- a/internal/api/v2/system_routes.go
+++ b/internal/api/v2/system_routes.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/api/v2/system"
+	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/observability"
 )
 
@@ -130,6 +131,13 @@ func (c *Controller) scheduleAudioSourceReconfigure() {
 	c.topologyReconfigureMu.Lock()
 	defer c.topologyReconfigureMu.Unlock()
 
+	// Do not re-arm once the controller is shutting down: Shutdown has already
+	// stopped the timer under this lock, and a fresh timer would fire into a
+	// controller whose context is cancelled and whose control channel is closed.
+	if c.topologyReconfigureShutdown {
+		return
+	}
+
 	if c.topologyReconfigureTimer != nil {
 		c.topologyReconfigureTimer.Stop()
 	}
@@ -138,17 +146,33 @@ func (c *Controller) scheduleAudioSourceReconfigure() {
 	})
 }
 
-// sendAudioSourceReconfigure delivers the reconfigure signal without blocking.
-// The control channel is buffered and drained by the control monitor; if it is
-// momentarily full, dropping the signal is preferable to stalling the caller,
-// and the log records that a reconfigure was missed.
+// sendAudioSourceReconfigure delivers the reconfigure signal to the control
+// monitor. The channel has capacity 1 and the monitor drains it synchronously,
+// so dropping the signal when the channel is momentarily full would lose it
+// permanently and recreate the exact bug this reconfigure exists to fix (a
+// gallery model that loads but never receives audio). The caller is the debounce
+// timer goroutine, so blocking until the monitor drains the channel is harmless.
+// It mirrors the send shape sendReconfigActions uses: a select on the send
+// versus the controller context being cancelled.
+//
+// The deferred recover is load-bearing. On shutdown internal/analysis closes the
+// control channel; the Controller holds a copy of that same (now closed) channel,
+// so the c.controlChan == nil guard never fires (only analysis nils its OWN
+// field). A send on a closed channel is always ready, so select would pick it
+// over the Done case and panic; recover absorbs that during the shutdown window.
 func (c *Controller) sendAudioSourceReconfigure() {
+	defer func() {
+		if r := recover(); r != nil {
+			c.LogWarnIfEnabled("Recovered from send on closed controlChan during audio source reconfigure",
+				logger.Any("panic", r))
+		}
+	}()
+
 	if c.controlChan == nil {
 		return
 	}
 	select {
+	case <-c.Context().Done():
 	case c.controlChan <- actionReconfigureAudioSources:
-	default:
-		GetLogger().Warn("control channel full, skipping audio source reconfigure after model topology change")
 	}
 }

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -49,13 +49,21 @@ const failedStateRetention = 30 * time.Second
 // 38 MB (int8-arm v2.4) to 557 MB (global v3.0 fp32) against Pi storage.
 const diskSpaceMarginBytes int64 = 64 << 20 // 64 MiB
 
+// settingsWriteMu serializes clone-mutate-publish cycles on the global conf
+// settings across the whole classifier package. Every writer reads
+// conf.GetSettings(), mutates a clone, and publishes it with conf.StoreSettings.
+// Without one shared lock two such cycles interleave and the second clobbers the
+// first's write. It is package-level rather than a ModelManager field because
+// the Orchestrator's stale-path repair (applyPathCorrection) is a writer too and
+// must serialize against ModelManager's install/uninstall config writers.
+var settingsWriteMu sync.Mutex
+
 // ModelManager handles the lifecycle of downloadable models.
 type ModelManager struct {
 	modelsDir    string
 	orchestrator *Orchestrator
 	settings     *conf.Settings // nil sentinel: non-nil means config sync is enabled
 	mu           sync.RWMutex
-	settingsMu   sync.Mutex // serializes clone-mutate-publish cycles on settings
 	installed    map[string]InstalledModel
 	downloading  map[string]*DownloadState
 
@@ -268,7 +276,7 @@ func (mm *ModelManager) ScanInstalled() {
 
 	// Phase 2: sync Models.Enabled and load models (lock-free).
 	if mm.settings != nil {
-		mm.settingsMu.Lock()
+		settingsWriteMu.Lock()
 		updated := conf.CloneSettings(conf.GetSettings())
 		changed := false
 
@@ -312,7 +320,7 @@ func (mm *ModelManager) ScanInstalled() {
 					logger.Error(err))
 			}
 		}
-		mm.settingsMu.Unlock()
+		settingsWriteMu.Unlock()
 
 		mm.loadInstalledModels(log, installedIDs)
 
@@ -585,18 +593,18 @@ func (mm *ModelManager) applyInstalledGeomodelConfig(log logger.Logger, entry *C
 		}
 	}
 
-	// Decide and write under settingsMu so the already-matches check and the
+	// Decide and write under settingsWriteMu so the already-matches check and the
 	// store operate on one consistent snapshot. Reading outside the lock would
 	// let a concurrent install/uninstall publish a newer config between the
 	// check and the store, overwriting it with stale data.
-	mm.settingsMu.Lock()
+	settingsWriteMu.Lock()
 	current := conf.GetSettings()
 	rf := current.BirdNET.RangeFilter
 	if rf.Model == entry.GeomodelVersion &&
 		rf.ModelPath == expectedModelPath &&
 		rf.LabelsPath == expectedLabelsPath {
 		// Config already set; initializeMetaModel handled it at startup.
-		mm.settingsMu.Unlock()
+		settingsWriteMu.Unlock()
 		return
 	}
 
@@ -615,7 +623,7 @@ func (mm *ModelManager) applyInstalledGeomodelConfig(log logger.Logger, entry *C
 			logger.String("catalog_id", catalogID),
 			logger.Error(err))
 	}
-	mm.settingsMu.Unlock()
+	settingsWriteMu.Unlock()
 
 	if err := mm.orchestrator.ReloadRangeFilter(); err != nil {
 		log.Warn("Failed to reload range filter after geomodel config update",
@@ -649,17 +657,17 @@ func (mm *ModelManager) healOrphanGeomodelConfig(log logger.Logger) {
 		}
 	}
 
-	// Decide and write under settingsMu so the decision and the store operate on
+	// Decide and write under settingsWriteMu so the decision and the store operate on
 	// one consistent snapshot. Reading the config outside the lock would let a
 	// concurrent install publish a valid geomodel config between the decision
 	// and the store, after which a stale "clear" would wipe it. The filesystem
 	// check above is independent of settings, so it stays outside the lock.
-	mm.settingsMu.Lock()
+	settingsWriteMu.Lock()
 	current := conf.GetSettings()
 	rf := current.BirdNET.RangeFilter
 	action := decideGeomodelOrphanAction(&rf, expectedModelPath, expectedLabelsPath, filesPresent)
 	if action == geomodelOrphanNone {
-		mm.settingsMu.Unlock()
+		settingsWriteMu.Unlock()
 		return
 	}
 
@@ -682,7 +690,7 @@ func (mm *ModelManager) healOrphanGeomodelConfig(log logger.Logger) {
 		log.Warn("Failed to persist orphan geomodel config self-heal",
 			logger.Error(err))
 	}
-	mm.settingsMu.Unlock()
+	settingsWriteMu.Unlock()
 
 	if err := mm.orchestrator.ReloadRangeFilter(); err != nil {
 		log.Warn("Failed to reload range filter after orphan geomodel self-heal",
@@ -1565,8 +1573,8 @@ func (mm *ModelManager) applyConfigForPrimarySwap(modelPath string) {
 	if mm.settings == nil {
 		return
 	}
-	mm.settingsMu.Lock()
-	defer mm.settingsMu.Unlock()
+	settingsWriteMu.Lock()
+	defer settingsWriteMu.Unlock()
 
 	updated := conf.CloneSettings(conf.GetSettings())
 	updated.BirdNET.ModelPath = modelPath
@@ -1991,7 +1999,7 @@ func (mm *ModelManager) removeDownloading(catalogID string) {
 
 // applyConfigForInstall updates settings to reflect a newly installed model.
 // Only fields with non-empty paths are set. The caller must hold no locks
-// other than mm.settingsMu (acquired internally).
+// other than settingsWriteMu (acquired internally).
 // Uses clone-mutate-publish so the shared settings snapshot is never mutated
 // in place. Settings are persisted to disk via conf.SaveSettings so changes
 // survive restarts and are visible to concurrent readers through conf.Setting().
@@ -2000,8 +2008,8 @@ func (mm *ModelManager) applyConfigForInstall(entry *CatalogEntry, modelPath, la
 		return
 	}
 
-	mm.settingsMu.Lock()
-	defer mm.settingsMu.Unlock()
+	settingsWriteMu.Lock()
+	defer settingsWriteMu.Unlock()
 
 	updated := conf.CloneSettings(conf.GetSettings())
 
@@ -2081,8 +2089,8 @@ func (mm *ModelManager) applyConfigForUninstall(entry *CatalogEntry) {
 		return
 	}
 
-	mm.settingsMu.Lock()
-	defer mm.settingsMu.Unlock()
+	settingsWriteMu.Lock()
+	defer settingsWriteMu.Unlock()
 
 	updated := conf.CloneSettings(conf.GetSettings())
 	retainAlias := false

--- a/internal/classifier/model_path_reconcile.go
+++ b/internal/classifier/model_path_reconcile.go
@@ -2,11 +2,35 @@ package classifier
 
 import (
 	"fmt"
+	"sync/atomic"
 
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/notification"
 )
+
+// pathCorrectionPersistenceDisabled, when true, suppresses the config.yaml write
+// (and the reconciled notification) in applyPathCorrection process-wide. The
+// runtime fallback still resolves stale paths so analysis can run; only the
+// PERSISTENCE of the correction is skipped.
+//
+// It is a process-level switch rather than an Orchestrator field on purpose: the
+// first correction drain runs INSIDE NewOrchestrator (loadAdditionalModels ->
+// runPendingPathCorrections), so a per-instance flag set after construction would
+// be too late to stop that write. Read-only diagnostic commands (benchmark,
+// rangefilter print) set it BEFORE constructing the Orchestrator so they never
+// rewrite the user's configuration. The default (false) preserves the self-heal
+// on the real serve path.
+var pathCorrectionPersistenceDisabled atomic.Bool
+
+// SetPathCorrectionPersistenceDisabled toggles whether stale model-path
+// corrections are persisted to config.yaml. Diagnostic commands call it with true
+// before NewOrchestrator so a read-only command leaves the user's config
+// untouched; the runtime fallback stays active either way. Passing false restores
+// the default self-heal behaviour (also used by tests to reset the switch).
+func SetPathCorrectionPersistenceDisabled(disabled bool) {
+	pathCorrectionPersistenceDisabled.Store(disabled)
+}
 
 // pendingPathCorrection records that a model was loaded from the gallery
 // fallback rather than from the paths configured in settings, so the stale
@@ -41,9 +65,11 @@ func (o *Orchestrator) deferPathCorrection(registryID string, resolved modelFile
 // It re-runs the resolution the builder already performed rather than threading
 // the result out through build*, because build* is shared with
 // ReloadSecondaryModels, where a settings write is explicitly unwanted: a
-// backend or device swap must not rewrite the user's paths. The re-resolution
-// costs at most three os.Stat calls and cannot disagree with the build, since
-// nothing between them touches the filesystem.
+// backend or device swap must not rewrite the user's paths. The re-resolution is
+// a handful of read-only stats (presence classification, sibling recovery and
+// the installed-paths probe together) and cannot disagree with the build, since
+// nothing between them writes to the filesystem: the model constructor in
+// between opens the model and reads the label file, but writes nothing.
 //
 // Must be called with o.mu held. It only resolves paths and appends to the
 // pending queue; neither takes o.mu, so it is safe under the loaders' write
@@ -100,7 +126,31 @@ func (o *Orchestrator) applyPathCorrection(pc *pendingPathCorrection) {
 	}
 
 	updated, changed := o.planPathCorrection(current, pc)
+
+	if pathCorrectionPersistenceDisabled.Load() {
+		// A read-only diagnostic command (benchmark, rangefilter print) is running.
+		// The model already loaded from the runtime fallback, so analysis works; we
+		// only skip rewriting config.yaml and any user-facing notification, so the
+		// command leaves no side effect on the user's configuration.
+		GetLogger().Info("stale model path resolved via fallback; persistence disabled, leaving config.yaml untouched",
+			logger.String("registry_id", pc.registryID),
+			logger.String("resolved_model_path", pc.resolved.model))
+		return
+	}
+
 	if !changed {
+		// planPathCorrection returns a nil snapshot only when it ABANDONED a real
+		// correction: applyPathCorrection is only called for families that used the
+		// gallery fallback, so a non-empty configured path was substituted at
+		// runtime, but the path is user-owned and must not be rewritten. The model
+		// is now running a different (installed) model than the user configured;
+		// that would otherwise be entirely silent, since emitPathReconciledNotification
+		// fires only when config was rewritten. Tell the user instead. A non-nil
+		// snapshot with changed==false is a genuine no-op (the paths already
+		// matched), so stay quiet there.
+		if updated == nil {
+			emitPathSubstitutedNotification(pc.registryID, pc.resolved.model)
+		}
 		return
 	}
 
@@ -127,45 +177,78 @@ func (o *Orchestrator) planPathCorrection(current *conf.Settings, pc *pendingPat
 	log := GetLogger()
 	updated = conf.CloneSettings(current)
 
-	// repair decides whether one field may be rewritten. An empty configured
-	// value is deliberately left alone: the fallback already handles it and has
-	// always been the supported way to let the gallery own a path, so filling it
-	// in would only add another absolute path to go stale later. A non-empty
-	// value is rewritten only when it is one the gallery itself wrote, so a
-	// user's hand-configured custom model is never taken over.
-	repair := func(field *string, resolved string) {
-		if resolved == "" || *field == "" || *field == resolved {
-			return
-		}
-		if !o.isGalleryManagedPath(pc.registryID, *field) {
-			log.Info("configured model path is missing but is not gallery-managed, leaving it untouched",
-				logger.String("registry_id", pc.registryID),
-				logger.String("configured_path", *field))
-			return
-		}
-		log.Info("repairing stale gallery model path in configuration",
-			logger.String("registry_id", pc.registryID),
-			logger.String("old_path", *field),
-			logger.String("new_path", resolved))
-		*field = resolved
-		changed = true
+	// fieldCorrection pairs one settings field (a pointer into the clone above)
+	// with the resolved value the runtime actually built the model from.
+	type fieldCorrection struct {
+		field    *string
+		resolved string
 	}
 
+	var fields []fieldCorrection
 	switch pc.registryID {
 	case RegistryIDPerchV2:
-		repair(&updated.Perch.ModelPath, pc.resolved.model)
-		repair(&updated.Perch.LabelPath, pc.resolved.labels)
+		fields = []fieldCorrection{
+			{&updated.Perch.ModelPath, pc.resolved.model},
+			{&updated.Perch.LabelPath, pc.resolved.labels},
+		}
 	case RegistryIDBirdNETV3:
-		repair(&updated.BirdNETV3.ModelPath, pc.resolved.model)
-		repair(&updated.BirdNETV3.LabelPath, pc.resolved.labels)
+		fields = []fieldCorrection{
+			{&updated.BirdNETV3.ModelPath, pc.resolved.model},
+			{&updated.BirdNETV3.LabelPath, pc.resolved.labels},
+		}
 	case RegistryIDBat:
 		// The bat family carries three paths; the shared embedding extractor is
 		// part of the set and goes stale with the rest.
-		repair(&updated.Bat.ClassifierModel, pc.resolved.model)
-		repair(&updated.Bat.LabelPath, pc.resolved.labels)
-		repair(&updated.Bat.EmbeddingModel, pc.resolved.embeddings)
+		fields = []fieldCorrection{
+			{&updated.Bat.ClassifierModel, pc.resolved.model},
+			{&updated.Bat.LabelPath, pc.resolved.labels},
+			{&updated.Bat.EmbeddingModel, pc.resolved.embeddings},
+		}
 	default:
-		return current, false
+		// Unknown registry: nothing to plan. Return nil rather than current so no
+		// caller can mutate the live published snapshot through the result.
+		return nil, false
+	}
+
+	// A resolved set is atomic: model, labels and (for bat) the shared embedding
+	// extractor all come from ONE installed variant. The correction must be
+	// all-or-nothing, so decide every field's verdict FIRST, then write. Writing
+	// only the gallery-managed fields while leaving a user-owned field alone would
+	// persist a cross-variant hybrid (a gallery model paired with the user's own
+	// labels); the next start would see every member present, classify the set
+	// presenceComplete, and use that hybrid verbatim with no fallback and no
+	// repair. That is exactly the outcome resolveFamilyPaths' design prevents.
+	//
+	// A field is a candidate for rewriting only when it actually DIFFERS: a
+	// non-empty configured value that is not already the resolved value. An empty
+	// configured value is deliberately left alone (the fallback already handles it
+	// and it has always been the supported way to let the gallery own a path), and
+	// a value already equal to the resolved one needs no change.
+	var toWrite []fieldCorrection
+	for _, fc := range fields {
+		if fc.resolved == "" || *fc.field == "" || *fc.field == fc.resolved {
+			continue
+		}
+		if !o.isGalleryManagedPath(pc.registryID, *fc.field) {
+			// One user-owned differing field vetoes the WHOLE correction. Because the
+			// resolved set is atomic, writing the gallery-managed fields while leaving
+			// this one alone is exactly the cross-variant hybrid described above. Leave
+			// config untouched and let the runtime fallback keep handling it.
+			log.Info("configured model path is user-owned, abandoning the whole correction to avoid a cross-variant config",
+				logger.String("registry_id", pc.registryID),
+				logger.String("user_owned_path", *fc.field))
+			return nil, false
+		}
+		toWrite = append(toWrite, fc)
+	}
+
+	for _, fc := range toWrite {
+		log.Info("repairing stale gallery model path in configuration",
+			logger.String("registry_id", pc.registryID),
+			logger.String("old_path", *fc.field),
+			logger.String("new_path", fc.resolved))
+		*fc.field = fc.resolved
+		changed = true
 	}
 
 	return updated, changed
@@ -207,5 +290,60 @@ func emitPathReconciledNotification(registryID, modelPath string) {
 		}).
 		WithDeliveryTarget("bell")
 
-	_ = svc.CreateWithMetadata(notif)
+	// CreateWithMetadata is rate limited and returns an error when the notification
+	// is dropped. Log it rather than discarding: a batch of family repairs could
+	// otherwise silently swallow the only user-visible signal that a repair
+	// happened, which is the whole point of this notification. Mirrors
+	// notifyModelsNotRegistered's handling of the same call.
+	if err := svc.CreateWithMetadata(notif); err != nil {
+		GetLogger().Warn("failed to create model-path-reconciled notification",
+			logger.String("registry_id", registryID),
+			logger.String("model_path", modelPath),
+			logger.Error(err))
+	}
+}
+
+// emitPathSubstitutedNotification tells the user that a configured model file was
+// not found and the installed gallery model is being used at runtime instead,
+// while their configuration was deliberately left unchanged (the configured path
+// is user-owned, so the self-heal must not take it over). Without this the
+// substitution is entirely silent: the user keeps getting detections, but from a
+// model they never chose, and the reconciled notification never fires because
+// config was not rewritten.
+func emitPathSubstitutedNotification(registryID, modelPath string) {
+	svc := notification.GetService()
+	if svc == nil {
+		return
+	}
+
+	modelName := registryID
+	if info, ok := ModelRegistry[registryID]; ok && info.Name != "" {
+		modelName = info.Name
+	}
+
+	notif := notification.NewNotification(
+		notification.TypeWarning,
+		notification.PriorityMedium,
+		fmt.Sprintf("Configured model file for %s was not found", modelName),
+		fmt.Sprintf("The model file configured for %s was not found on disk, so the installed model at %s "+
+			"is being used instead. Your configuration was left unchanged.", modelName, modelPath),
+	).
+		WithComponent("classifier").
+		WithTitleKey(notification.MsgModelPathSubstitutedTitle, map[string]any{
+			"modelName": modelName,
+		}).
+		WithMessageKey(notification.MsgModelPathSubstitutedMessage, map[string]any{
+			"modelName": modelName,
+			"modelPath": modelPath,
+		}).
+		WithDeliveryTarget("bell")
+
+	// CreateWithMetadata is rate limited and returns an error when the notification
+	// is dropped. Log it rather than discarding, matching emitPathReconciledNotification.
+	if err := svc.CreateWithMetadata(notif); err != nil {
+		GetLogger().Warn("failed to create model-path-substituted notification",
+			logger.String("registry_id", registryID),
+			logger.String("model_path", modelPath),
+			logger.Error(err))
+	}
 }

--- a/internal/classifier/model_path_reconcile.go
+++ b/internal/classifier/model_path_reconcile.go
@@ -1,0 +1,196 @@
+package classifier
+
+import (
+	"fmt"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/notification"
+)
+
+// pendingPathCorrection records that a model was loaded from the gallery
+// fallback rather than from the paths configured in settings, so the stale
+// configuration can be repaired once o.mu is released.
+type pendingPathCorrection struct {
+	registryID string
+	resolved   modelFileSet
+}
+
+// deferPathCorrection queues a configuration repair for a model that loaded via
+// the gallery fallback. Called by the secondary model loaders while they hold
+// o.mu; the repair itself runs in runPendingPathCorrections after the lock is
+// released.
+//
+// Queued only AFTER the model has built successfully. The constructors open the
+// ONNX session and validate the label count against the model's output tensor,
+// so a set that builds is a set that genuinely belongs together. Queueing before
+// the build could persist paths that turn out to be unusable.
+//
+// Must be called with o.mu held.
+func (o *Orchestrator) deferPathCorrection(registryID string, resolved modelFileSet) {
+	o.pendingPathCorrections = append(o.pendingPathCorrections, pendingPathCorrection{
+		registryID: registryID,
+		resolved:   resolved,
+	})
+}
+
+// queuePathCorrectionIfFallback resolves the family's paths and, when the
+// gallery fallback was used, queues the configuration repair. The loaders call
+// this after a successful build.
+//
+// It re-runs the resolution the builder already performed rather than threading
+// the result out through build*, because build* is shared with
+// ReloadSecondaryModels, where a settings write is explicitly unwanted: a
+// backend or device swap must not rewrite the user's paths. The re-resolution
+// costs at most three os.Stat calls and cannot disagree with the build, since
+// nothing between them touches the filesystem.
+//
+// Must be called with o.mu held (it only appends to the pending queue; the
+// gallery-managed check that takes o.mu runs later in the drainer).
+func (o *Orchestrator) queuePathCorrectionIfFallback(registryID string, configured modelFileSet, needEmbeddings bool) {
+	resolved, usedFallback := o.resolveFamilyPaths(registryID, configured, needEmbeddings)
+	if !usedFallback {
+		return
+	}
+	o.deferPathCorrection(registryID, resolved)
+}
+
+// runPendingPathCorrections drains the queued configuration repairs, rewriting
+// stale gallery paths in settings so the next start loads directly instead of
+// falling back again.
+//
+// This is the self-heal for GitHub issues #4201 and #4204: a user who upgrades
+// to a build containing this fix gets their config.yaml corrected on the first
+// start, with no manual edit and no reinstall from the gallery. Without it the
+// bad path would survive every restart, and it would keep feeding
+// installedModelBasenameHint, which ScanInstalled uses to decide which variant
+// is installed when more than one variant's files are present.
+//
+// Safe to call with o.mu NOT held (it must not be: the drain and
+// isGalleryManagedPath both acquire o.mu).
+func (o *Orchestrator) runPendingPathCorrections() {
+	o.mu.Lock()
+	pending := o.pendingPathCorrections
+	o.pendingPathCorrections = nil
+	o.mu.Unlock()
+
+	for i := range pending {
+		o.applyPathCorrection(&pending[i])
+	}
+}
+
+// applyPathCorrection rewrites one family's stale gallery paths in settings and
+// persists them, using the clone-mutate-publish protocol every other settings
+// writer follows.
+func (o *Orchestrator) applyPathCorrection(pc *pendingPathCorrection) {
+	current := conf.GetSettings()
+	if current == nil {
+		return
+	}
+
+	updated, changed := o.planPathCorrection(current, pc)
+	if !changed {
+		return
+	}
+
+	conf.StoreSettings(updated)
+	if err := conf.SaveSettings(); err != nil {
+		// The in-memory snapshot still carries the corrected paths, so the running
+		// process is consistent; only the repair's persistence is lost, and the
+		// next start repeats the fallback and tries again.
+		GetLogger().Warn("failed to persist repaired model paths",
+			logger.String("registry_id", pc.registryID),
+			logger.Error(err))
+		return
+	}
+
+	emitPathReconciledNotification(pc.registryID, pc.resolved.model)
+}
+
+// planPathCorrection produces the corrected settings snapshot for one family and
+// reports whether anything actually changed. It is separated from the persisting
+// half of applyPathCorrection so the decision (which fields may be rewritten and
+// which must be left alone) is testable without touching the filesystem or the
+// developer's own configuration file.
+func (o *Orchestrator) planPathCorrection(current *conf.Settings, pc *pendingPathCorrection) (updated *conf.Settings, changed bool) {
+	log := GetLogger()
+	updated = conf.CloneSettings(current)
+
+	// repair decides whether one field may be rewritten. An empty configured
+	// value is deliberately left alone: the fallback already handles it and has
+	// always been the supported way to let the gallery own a path, so filling it
+	// in would only add another absolute path to go stale later. A non-empty
+	// value is rewritten only when it is one the gallery itself wrote, so a
+	// user's hand-configured custom model is never taken over.
+	repair := func(field *string, resolved string) {
+		if resolved == "" || *field == "" || *field == resolved {
+			return
+		}
+		if !o.isGalleryManagedPath(pc.registryID, *field) {
+			log.Info("configured model path is missing but is not gallery-managed, leaving it untouched",
+				logger.String("registry_id", pc.registryID),
+				logger.String("configured_path", *field))
+			return
+		}
+		log.Info("repairing stale gallery model path in configuration",
+			logger.String("registry_id", pc.registryID),
+			logger.String("old_path", *field),
+			logger.String("new_path", resolved))
+		*field = resolved
+		changed = true
+	}
+
+	switch pc.registryID {
+	case RegistryIDPerchV2:
+		repair(&updated.Perch.ModelPath, pc.resolved.model)
+		repair(&updated.Perch.LabelPath, pc.resolved.labels)
+	case RegistryIDBirdNETV3:
+		repair(&updated.BirdNETV3.ModelPath, pc.resolved.model)
+		repair(&updated.BirdNETV3.LabelPath, pc.resolved.labels)
+	case RegistryIDBat:
+		// The bat family carries three paths; the shared embedding extractor is
+		// part of the set and goes stale with the rest.
+		repair(&updated.Bat.ClassifierModel, pc.resolved.model)
+		repair(&updated.Bat.LabelPath, pc.resolved.labels)
+		repair(&updated.Bat.EmbeddingModel, pc.resolved.embeddings)
+	default:
+		return current, false
+	}
+
+	return updated, changed
+}
+
+// emitPathReconciledNotification tells the user that a broken model path was
+// repaired. A silent repair would leave someone who lost detections for days
+// with no explanation, and the notification is the signal a support dump needs
+// to show that this state occurred at all.
+func emitPathReconciledNotification(registryID, modelPath string) {
+	svc := notification.GetService()
+	if svc == nil {
+		return
+	}
+
+	modelName := registryID
+	if info, ok := ModelRegistry[registryID]; ok && info.Name != "" {
+		modelName = info.Name
+	}
+
+	notif := notification.NewNotification(
+		notification.TypeInfo,
+		notification.PriorityMedium,
+		fmt.Sprintf("Model path repaired for %s", modelName),
+		fmt.Sprintf("The configured file path for %s pointed at a file that no longer exists. "+
+			"It has been updated to the installed model at %s.", modelName, modelPath),
+	).
+		WithComponent("classifier").
+		WithTitleKey(notification.MsgModelPathReconciledTitle, map[string]any{
+			"modelName": modelName,
+		}).
+		WithMessageKey(notification.MsgModelPathReconciledMessage, map[string]any{
+			"modelName": modelName,
+			"modelPath": modelPath,
+		}).
+		WithDeliveryTarget("bell")
+
+	_ = svc.CreateWithMetadata(notif)
+}

--- a/internal/classifier/model_path_reconcile.go
+++ b/internal/classifier/model_path_reconcile.go
@@ -125,8 +125,6 @@ func (o *Orchestrator) applyPathCorrection(pc *pendingPathCorrection) {
 		return
 	}
 
-	updated, changed := o.planPathCorrection(current, pc)
-
 	if pathCorrectionPersistenceDisabled.Load() {
 		// A read-only diagnostic command (benchmark, rangefilter print) is running.
 		// The model already loaded from the runtime fallback, so analysis works; we
@@ -137,6 +135,8 @@ func (o *Orchestrator) applyPathCorrection(pc *pendingPathCorrection) {
 			logger.String("resolved_model_path", pc.resolved.model))
 		return
 	}
+
+	updated, changed := o.planPathCorrection(current, pc)
 
 	if !changed {
 		// planPathCorrection returns a nil snapshot only when it ABANDONED a real

--- a/internal/classifier/model_path_reconcile.go
+++ b/internal/classifier/model_path_reconcile.go
@@ -45,8 +45,10 @@ func (o *Orchestrator) deferPathCorrection(registryID string, resolved modelFile
 // costs at most three os.Stat calls and cannot disagree with the build, since
 // nothing between them touches the filesystem.
 //
-// Must be called with o.mu held (it only appends to the pending queue; the
-// gallery-managed check that takes o.mu runs later in the drainer).
+// Must be called with o.mu held. It only resolves paths and appends to the
+// pending queue; neither takes o.mu, so it is safe under the loaders' write
+// lock. The settings write itself happens later, in the drainer, after o.mu is
+// released.
 func (o *Orchestrator) queuePathCorrectionIfFallback(registryID string, configured modelFileSet, needEmbeddings bool) {
 	resolved, usedFallback := o.resolveFamilyPaths(registryID, configured, needEmbeddings)
 	if !usedFallback {
@@ -66,8 +68,9 @@ func (o *Orchestrator) queuePathCorrectionIfFallback(registryID string, configur
 // installedModelBasenameHint, which ScanInstalled uses to decide which variant
 // is installed when more than one variant's files are present.
 //
-// Safe to call with o.mu NOT held (it must not be: the drain and
-// isGalleryManagedPath both acquire o.mu).
+// Must be called with o.mu NOT held: the snapshot-and-clear below takes o.mu
+// itself, and o.mu is not reentrant. (isGalleryManagedPath, reached from
+// applyPathCorrection, does NOT take o.mu; it is the drain that does.)
 func (o *Orchestrator) runPendingPathCorrections() {
 	o.mu.Lock()
 	pending := o.pendingPathCorrections
@@ -81,8 +84,16 @@ func (o *Orchestrator) runPendingPathCorrections() {
 
 // applyPathCorrection rewrites one family's stale gallery paths in settings and
 // persists them, using the clone-mutate-publish protocol every other settings
-// writer follows.
+// writer follows. It serializes against ModelManager's install/uninstall config
+// writers through the package-level settingsWriteMu.
 func (o *Orchestrator) applyPathCorrection(pc *pendingPathCorrection) {
+	settingsWriteMu.Lock()
+	defer settingsWriteMu.Unlock()
+
+	// Re-read INSIDE the critical section. Reading conf.GetSettings() before
+	// taking the lock is the load-bearing half of the bug: a concurrent
+	// ModelManager writer could publish between that read and our StoreSettings,
+	// and our clone (built from the stale snapshot) would then clobber its write.
 	current := conf.GetSettings()
 	if current == nil {
 		return
@@ -178,9 +189,13 @@ func emitPathReconciledNotification(registryID, modelPath string) {
 	notif := notification.NewNotification(
 		notification.TypeInfo,
 		notification.PriorityMedium,
-		fmt.Sprintf("Model path repaired for %s", modelName),
-		fmt.Sprintf("The configured file path for %s pointed at a file that no longer exists. "+
-			"It has been updated to the installed model at %s.", modelName, modelPath),
+		fmt.Sprintf("Model file paths repaired for %s", modelName),
+		// Worded to cover both branches: the model path itself may have gone stale,
+		// or (in sibling recovery) the model exists and it was the labels or shared
+		// embeddings path that changed. modelPath names the installed model the set
+		// was reconciled against.
+		fmt.Sprintf("Configured file paths for %s were out of date and have been repaired to match "+
+			"the installed model at %s.", modelName, modelPath),
 	).
 		WithComponent("classifier").
 		WithTitleKey(notification.MsgModelPathReconciledTitle, map[string]any{

--- a/internal/classifier/model_path_resolution.go
+++ b/internal/classifier/model_path_resolution.go
@@ -49,9 +49,14 @@ func (s modelFileSet) allPresentOnDisk(needEmbeddings bool) bool {
 // diskPresence classifies the on-disk state of a required member set. It
 // separates a member that is confirmed absent (fs.ErrNotExist), which marks the
 // configured set stale and worth repairing, from a member that could not be
-// stat'd for another reason (EACCES, EIO, a stale NFS handle) such as an
-// external volume that has not finished mounting. The latter must not trigger a
-// permanent config rewrite, because the file may well reappear.
+// stat'd for another reason (EACCES, EIO, a stale NFS handle, a half-initialised
+// mount that reports EIO). The latter must not trigger a permanent config
+// rewrite, because the file may well reappear.
+//
+// Note the boundary: a FULLY unmounted path reports ErrNotExist, not one of the
+// above, so it classifies as presenceMissing (repairable), NOT indeterminate.
+// The guard against that rewriting a user's own path is the gallery-layout
+// requirement in isGalleryManagedPath, not this classification.
 type diskPresence int
 
 const (
@@ -61,8 +66,10 @@ const (
 	// absent (fs.ErrNotExist) and no member was indeterminate.
 	presenceMissing
 	// presenceIndeterminate means at least one non-empty required member could
-	// not be stat'd for a reason other than absence. It dominates presenceMissing
-	// so a transient error is never mistaken for a stale path.
+	// not be stat'd for a reason OTHER than absence (a permissions failure, an I/O
+	// error, a half-initialised mount reporting EIO). It dominates presenceMissing
+	// so a transient error is never mistaken for a stale path. A fully unmounted
+	// path reports ErrNotExist and is therefore presenceMissing, not this.
 	presenceIndeterminate
 )
 
@@ -138,7 +145,25 @@ func (o *Orchestrator) resolveFamilyPaths(registryID string, configured modelFil
 			return configured, false
 		}
 		filled := configured
-		m, l, e := o.resolveInstalledPaths(registryID)
+
+		// Fill the empty members, anchoring on the variant the configuration
+		// NAMES rather than on whichever variant the catalog lists first. When
+		// configured.model matches a catalog variant, resolveSiblingSet supplies
+		// its companion files from the SAME variant, so an empty labels member is
+		// filled with that model's own labels. Anchoring on resolveInstalledPaths
+		// instead can pair a configured regional model with a different variant's
+		// labels (say a global build that is also installed); for bat, whose label
+		// files are per-region with region-specific counts, a count coincidence
+		// then silently mislabels. resolveSiblingSet returns ok=false when
+		// configured.model is empty or names no catalog variant, so the
+		// resolveInstalledPaths fallback preserves the previous behaviour for
+		// those cases.
+		var m, l, e string
+		if sibling, ok := o.resolveSiblingSet(registryID, configured.model); ok {
+			m, l, e = sibling.model, sibling.labels, sibling.embeddings
+		} else {
+			m, l, e = o.resolveInstalledPaths(registryID)
+		}
 		if filled.model == "" {
 			filled.model = m
 		}
@@ -152,11 +177,15 @@ func (o *Orchestrator) resolveFamilyPaths(registryID string, configured modelFil
 	}
 
 	// A non-empty configured path is missing or unreadable. Only a CONFIRMED
-	// absence (presenceMissing) marks the set stale and may rewrite config; an
-	// unreadable member (presenceIndeterminate, an external volume slow to mount)
-	// still falls back at runtime so analysis can run, but must NOT persist a
-	// repair, or a transient error rewrites config.yaml permanently. repairable
-	// carries that distinction to both fallback returns below.
+	// absence (presenceMissing) marks the set stale and may rewrite config; a
+	// member that is unreadable for a reason OTHER than absence
+	// (presenceIndeterminate: a permissions failure, an I/O error, a
+	// half-initialised mount reporting EIO) still falls back at runtime so
+	// analysis can run, but must NOT persist a repair, or a transient error
+	// rewrites config.yaml permanently. repairable carries that distinction to
+	// both fallback returns below. (A fully unmounted path reports ErrNotExist, so
+	// it is presenceMissing here; isGalleryManagedPath is what stops that rewrite
+	// from taking over a user's own path.)
 	repairable := presence == presenceMissing
 
 	// Before the generic gallery probe, try to keep the variant the configured
@@ -312,6 +341,27 @@ func (o *Orchestrator) isGalleryManagedPath(registryID, path string) bool {
 
 	base := filepath.Base(path)
 	parent := filepath.Base(filepath.Dir(path))
+
+	// Require the grandparent directory to be the models directory itself (its base
+	// name, normally "models"). Matching only base + parent would qualify any path
+	// that merely MIRRORS the gallery layout, e.g. /mnt/nas/perch-v2/perch_v2.onnx:
+	// a NAS or USB mount that is late at boot yields ENOENT (the mountpoint exists
+	// but is empty), which classifies as presenceMissing with repairable=true, so a
+	// user who moved their models to a NAS but left a local gallery copy would have
+	// the NAS path permanently rewritten. Dropping only the models-directory PREFIX
+	// (not its base name) still handles the changed-container-HOME case the issues
+	// report, because base(modelsDir) stays "models" across a HOME change, while a
+	// look-alike under a different grandparent ("nas") is rejected. This matches the
+	// stricter precedent in Settings.MigrateOrphanGeomodelRangeFilter
+	// (internal/conf/range_filter_migration.go), which acts only on exact
+	// gallery-managed paths and never touches custom or hand-edited ones.
+	if o.modelsDir == "" {
+		return false
+	}
+	grandparent := filepath.Base(filepath.Dir(filepath.Dir(path)))
+	if grandparent != filepath.Base(o.modelsDir) {
+		return false
+	}
 
 	catalog := ActiveCatalog()
 	for i := range catalog {

--- a/internal/classifier/model_path_resolution.go
+++ b/internal/classifier/model_path_resolution.go
@@ -1,10 +1,11 @@
 package classifier
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 
+	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
@@ -45,30 +46,118 @@ func (s modelFileSet) allPresentOnDisk(needEmbeddings bool) bool {
 	return true
 }
 
+// diskPresence classifies the on-disk state of a required member set. It
+// separates a member that is confirmed absent (fs.ErrNotExist), which marks the
+// configured set stale and worth repairing, from a member that could not be
+// stat'd for another reason (EACCES, EIO, a stale NFS handle) such as an
+// external volume that has not finished mounting. The latter must not trigger a
+// permanent config rewrite, because the file may well reappear.
+type diskPresence int
+
+const (
+	// presenceComplete means every non-empty required member exists on disk.
+	presenceComplete diskPresence = iota
+	// presenceMissing means at least one non-empty required member is confirmed
+	// absent (fs.ErrNotExist) and no member was indeterminate.
+	presenceMissing
+	// presenceIndeterminate means at least one non-empty required member could
+	// not be stat'd for a reason other than absence. It dominates presenceMissing
+	// so a transient error is never mistaken for a stale path.
+	presenceIndeterminate
+)
+
+// nonEmptyMembersPresence classifies whether every NON-EMPTY required member of
+// the set exists on disk. An empty member is skipped, not treated as missing:
+// leaving a path empty is the supported way to let the gallery own it, so an
+// empty member is not a stale member. This is what distinguishes an empty
+// configured path (fill it from the gallery, keep the rest) from a stale one (a
+// non-empty path that has gone missing, which makes the whole set stale).
+//
+// A member that is unreadable for a reason other than absence yields
+// presenceIndeterminate, which dominates: a single unreadable member classifies
+// the whole set as indeterminate so a slow-to-mount volume is never mistaken for
+// a stale configuration.
+func (s modelFileSet) nonEmptyMembersPresence(needEmbeddings bool) diskPresence {
+	paths := []string{s.model, s.labels}
+	if needEmbeddings {
+		paths = append(paths, s.embeddings)
+	}
+	sawMissing := false
+	for _, p := range paths {
+		if p == "" {
+			continue
+		}
+		if _, err := os.Stat(p); err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				sawMissing = true
+				continue
+			}
+			return presenceIndeterminate
+		}
+	}
+	if sawMissing {
+		return presenceMissing
+	}
+	return presenceComplete
+}
+
 // resolveFamilyPaths decides which file set a secondary model family should be
 // built from, choosing between the paths configured in settings and the variant
 // the model gallery has installed on disk.
 //
-// The configured set is honoured only when it is complete AND every one of its
-// files exists. Otherwise the whole configured set is discarded and the gallery
-// set is used INSTEAD, as a unit. Resolving per file would be wrong: pairing a
-// configured model path from one variant with a fallback label path from
-// another yields a model and a label file that describe different species sets,
-// which either fails late with a label-count mismatch or, when the counts
-// happen to agree, silently mislabels every detection.
+// A configured member left EMPTY is filled from the gallery (the supported way
+// to let the gallery own a path); the other configured members are kept. When a
+// non-empty configured member is CONFIRMED missing on disk, the whole configured
+// set is discarded and the gallery set is used INSTEAD, as a unit. Resolving per
+// file would be wrong: pairing a configured model path from one variant with a
+// fallback label path from another yields a model and a label file that describe
+// different species sets, which either fails late with a label-count mismatch
+// or, when the counts happen to agree, silently mislabels every detection.
 //
-// The second return value reports whether the returned set came from the
-// gallery fallback, so the caller can reconcile the stale configuration once
-// the model has actually loaded (see Orchestrator.deferPathCorrection).
+// The second return value reports whether the returned set should reconcile the
+// stale configuration (see Orchestrator.deferPathCorrection). It is true only
+// when a configured path was confirmed missing. A configured path that is merely
+// unreadable right now (an external volume that has not finished mounting) still
+// falls back so the model can run, but returns false so the transient state is
+// never persisted to config.yaml.
 //
 // A configured path that points at a file which does not exist is the state
 // GitHub issues #4201 and #4204 describe: a gallery variant switch or a change
 // of container HOME leaves settings pointing at a file that is no longer there,
 // and before this fallback the model simply never loaded again.
 func (o *Orchestrator) resolveFamilyPaths(registryID string, configured modelFileSet, needEmbeddings bool) (resolved modelFileSet, usedFallback bool) {
-	if configured.allPresentOnDisk(needEmbeddings) {
-		return configured, false
+	presence := configured.nonEmptyMembersPresence(needEmbeddings)
+
+	// An empty configured member is not a stale member: leaving a path empty is
+	// the supported way to let the gallery own it. When every NON-EMPTY
+	// configured member exists on disk, keep the configured set and fill only the
+	// empty members from the gallery (main's behaviour). usedFallback stays false:
+	// nothing configured went stale, so there is nothing to repair.
+	if presence == presenceComplete {
+		if configured.complete(needEmbeddings) {
+			return configured, false
+		}
+		filled := configured
+		m, l, e := o.resolveInstalledPaths(registryID)
+		if filled.model == "" {
+			filled.model = m
+		}
+		if filled.labels == "" {
+			filled.labels = l
+		}
+		if needEmbeddings && filled.embeddings == "" {
+			filled.embeddings = e
+		}
+		return filled, false
 	}
+
+	// A non-empty configured path is missing or unreadable. Only a CONFIRMED
+	// absence (presenceMissing) marks the set stale and may rewrite config; an
+	// unreadable member (presenceIndeterminate, an external volume slow to mount)
+	// still falls back at runtime so analysis can run, but must NOT persist a
+	// repair, or a transient error rewrites config.yaml permanently. repairable
+	// carries that distinction to both fallback returns below.
+	repairable := presence == presenceMissing
 
 	// Before the generic gallery probe, try to keep the variant the configured
 	// model file names. When only a companion file went missing (a partial
@@ -82,7 +171,7 @@ func (o *Orchestrator) resolveFamilyPaths(registryID string, configured modelFil
 		GetLogger().Debug("recovered the configured variant's companion files",
 			logger.String("registry_id", registryID),
 			logger.String("model_path", sameVariant.model))
-		return sameVariant, true
+		return sameVariant, repairable
 	}
 
 	m, l, e := o.resolveInstalledPaths(registryID)
@@ -106,7 +195,7 @@ func (o *Orchestrator) resolveFamilyPaths(registryID string, configured modelFil
 		logger.String("configured_model_path", configured.model),
 		logger.String("resolved_model_path", fallback.model))
 
-	return fallback, true
+	return fallback, repairable
 }
 
 // resolveSiblingSet rebuilds a family's complete file set from the variant that
@@ -125,6 +214,12 @@ func (o *Orchestrator) resolveSiblingSet(registryID, modelPath string) (set mode
 		return modelFileSet{}, false
 	}
 	if _, err := os.Stat(modelPath); err != nil {
+		// Any stat error skips recovery: without confirming the model file exists
+		// there is nothing to anchor the companion files to. A non-ErrNotExist
+		// error (an unreadable volume) is treated the same as absence here, so a
+		// half-mounted volume never yields a spurious sibling set. Suppressing the
+		// config repair for the merely-unreadable case is the caller's job, via the
+		// presenceIndeterminate classification from nonEmptyMembersPresence.
 		return modelFileSet{}, false
 	}
 
@@ -193,44 +288,53 @@ func declaresModelFile(files []CatalogFile, localName string) bool {
 // mounted yet) is indistinguishable from a stale one at the filesystem level.
 // So repair only what the gallery itself wrote.
 //
-// A path qualifies when it sits under the gallery models directory, or when its
-// basename matches a file name the catalog declares for the family. The second
-// test is what catches the case the issues report: the models directory prefix
-// changed (a different container HOME), so the stale path no longer sits under
-// the current models directory, yet the file name is unmistakably ours.
-// Unlike resolveSiblingSet, this one DOES take o.mu, because it is called only
-// from planPathCorrection, which runs after the loaders have released the lock.
-// Do not call it from a builder or a loader.
+// A path qualifies only when BOTH hold: its basename is a LocalName the catalog
+// entry for registryID declares, AND its parent directory's base name is that
+// entry's ID (or "shared" for a shared-role file such as the embedding
+// extractor). Matching on the parent directory's base name rather than the full
+// models-directory prefix is what catches the case the issues report: the models
+// directory prefix changed (a different container HOME), so the stale path no
+// longer sits under the current models directory, yet it still lives in a
+// gallery-shaped <entry ID>/<local name> layout. A user's own copy that merely
+// shares a catalog file name (for example /mnt/nas/models/perch_v2_labels.txt,
+// whose parent directory is "models", not the entry ID) does NOT qualify.
+//
+// Takes no Orchestrator lock: it reads only its arguments and the ActiveCatalog
+// snapshot (whose accessor takes its own unrelated catalogMu). It is called only
+// from planPathCorrection, after the loaders have released o.mu. It would in
+// fact be safe on a loader path today, but keep it off one: the drainer that
+// reaches it DOES take o.mu, so moving the pair inward reintroduces the
+// self-deadlock this branch already shipped once.
 func (o *Orchestrator) isGalleryManagedPath(registryID, path string) bool {
 	if path == "" {
 		return false
 	}
 
-	o.mu.RLock()
-	modelsDir := o.modelsDir
-	o.mu.RUnlock()
-
-	if modelsDir != "" {
-		if rel, err := filepath.Rel(modelsDir, path); err == nil && !strings.HasPrefix(rel, "..") {
-			return true
-		}
-	}
-
 	base := filepath.Base(path)
+	parent := filepath.Base(filepath.Dir(path))
+
 	catalog := ActiveCatalog()
 	for i := range catalog {
 		entry := &catalog[i]
 		if entry.RegistryID != registryID {
 			continue
 		}
-		for _, f := range entry.Files {
-			if f.LocalName == base {
-				return true
-			}
+		// Check the entry's own files and every variant's files as a union: the
+		// stale configured path could name any installed variant's file.
+		fileSets := [][]CatalogFile{entry.Files}
+		for j := range entry.Variants {
+			fileSets = append(fileSets, entry.Variants[j].Files)
 		}
-		for i := range entry.Variants {
-			for _, f := range entry.Variants[i].Files {
-				if f.LocalName == base {
+		for _, files := range fileSets {
+			for _, f := range files {
+				if f.LocalName != base {
+					continue
+				}
+				expectedParent := entry.ID
+				if isSharedRole(f.Role) {
+					expectedParent = "shared"
+				}
+				if parent == expectedParent {
 					return true
 				}
 			}

--- a/internal/classifier/model_path_resolution.go
+++ b/internal/classifier/model_path_resolution.go
@@ -1,0 +1,240 @@
+package classifier
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// modelFileSet is the complete on-disk file set a secondary model family needs.
+// The families differ in how many of the three are required: Perch v2 and
+// BirdNET v3.0 need model+labels, Bat additionally needs a shared embedding
+// extractor. Embeddings is empty (and not required) for the first two.
+type modelFileSet struct {
+	model      string
+	labels     string
+	embeddings string
+}
+
+// complete reports whether every required member of the set is populated.
+// needEmbeddings is true only for the bat family.
+func (s modelFileSet) complete(needEmbeddings bool) bool {
+	if s.model == "" || s.labels == "" {
+		return false
+	}
+	return !needEmbeddings || s.embeddings != ""
+}
+
+// allPresentOnDisk reports whether every required member exists on disk. A set
+// that is not complete() is never present.
+func (s modelFileSet) allPresentOnDisk(needEmbeddings bool) bool {
+	if !s.complete(needEmbeddings) {
+		return false
+	}
+	paths := []string{s.model, s.labels}
+	if needEmbeddings {
+		paths = append(paths, s.embeddings)
+	}
+	for _, p := range paths {
+		if _, err := os.Stat(p); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+// resolveFamilyPaths decides which file set a secondary model family should be
+// built from, choosing between the paths configured in settings and the variant
+// the model gallery has installed on disk.
+//
+// The configured set is honoured only when it is complete AND every one of its
+// files exists. Otherwise the whole configured set is discarded and the gallery
+// set is used INSTEAD, as a unit. Resolving per file would be wrong: pairing a
+// configured model path from one variant with a fallback label path from
+// another yields a model and a label file that describe different species sets,
+// which either fails late with a label-count mismatch or, when the counts
+// happen to agree, silently mislabels every detection.
+//
+// The second return value reports whether the returned set came from the
+// gallery fallback, so the caller can reconcile the stale configuration once
+// the model has actually loaded (see Orchestrator.deferPathCorrection).
+//
+// A configured path that points at a file which does not exist is the state
+// GitHub issues #4201 and #4204 describe: a gallery variant switch or a change
+// of container HOME leaves settings pointing at a file that is no longer there,
+// and before this fallback the model simply never loaded again.
+func (o *Orchestrator) resolveFamilyPaths(registryID string, configured modelFileSet, needEmbeddings bool) (resolved modelFileSet, usedFallback bool) {
+	if configured.allPresentOnDisk(needEmbeddings) {
+		return configured, false
+	}
+
+	// Before the generic gallery probe, try to keep the variant the configured
+	// model file names. When only a companion file went missing (a partial
+	// cleanup, a half-finished variant switch that left both variants' models on
+	// disk), the generic probe returns whichever variant the catalog lists first,
+	// which can be a superseded one. That is a consistent pair, so nothing fails
+	// loudly, but the user silently ends up running a different regional model
+	// than the one they chose.
+	if sameVariant, ok := o.resolveSiblingSet(registryID, configured.model); ok &&
+		sameVariant.allPresentOnDisk(needEmbeddings) {
+		GetLogger().Debug("recovered the configured variant's companion files",
+			logger.String("registry_id", registryID),
+			logger.String("model_path", sameVariant.model))
+		return sameVariant, true
+	}
+
+	m, l, e := o.resolveInstalledPaths(registryID)
+	fallback := modelFileSet{model: m, labels: l, embeddings: e}
+
+	// Nothing installed to fall back to. Return the configured set unchanged so
+	// the caller reports its existing "not installed or configured" error, and so
+	// a set that is merely unreadable right now (an unmounted volume) is not
+	// replaced by an empty one.
+	if !fallback.complete(needEmbeddings) {
+		return configured, false
+	}
+
+	// Debug, not Info: this fires once per build and once more when the loader
+	// re-resolves to decide whether the configuration needs repairing, and the
+	// noteworthy outcomes already log at Info from planPathCorrection (either the
+	// repair itself, or the decision to leave a non-gallery path alone). Falling
+	// back for an empty configured path is the normal, uninteresting case.
+	GetLogger().Debug("configured model path is missing on disk, falling back to the installed model",
+		logger.String("registry_id", registryID),
+		logger.String("configured_model_path", configured.model),
+		logger.String("resolved_model_path", fallback.model))
+
+	return fallback, true
+}
+
+// resolveSiblingSet rebuilds a family's complete file set from the variant that
+// modelPath names, taking the companion files from modelPath's own directory.
+//
+// It exists so a family whose model file is present but whose labels went
+// missing recovers the RIGHT variant rather than whichever one the catalog
+// happens to list first. The embedding extractor is shared across a family's
+// variants and lives in the gallery's shared/ directory, so it is resolved from
+// there rather than beside the model.
+//
+// Returns ok=false when modelPath is empty, does not exist, or does not match
+// any catalog variant for the family.
+func (o *Orchestrator) resolveSiblingSet(registryID, modelPath string) (set modelFileSet, ok bool) {
+	if modelPath == "" {
+		return modelFileSet{}, false
+	}
+	if _, err := os.Stat(modelPath); err != nil {
+		return modelFileSet{}, false
+	}
+
+	// Read o.modelsDir WITHOUT taking o.mu. resolveFamilyPaths runs inside the
+	// model loaders, which hold o.mu.Lock(), and sync.RWMutex is not reentrant:
+	// acquiring a read lock here self-deadlocks the loader. This mirrors
+	// resolveInstalledPaths, which reads the same field on the same call path.
+	// The field is written once at construction and again by SetModelsDir before
+	// the pipeline starts, so it is stable by the time any of this runs.
+	modelsDir := o.modelsDir
+
+	base := filepath.Base(modelPath)
+	dir := filepath.Dir(modelPath)
+
+	catalog := ActiveCatalog()
+	for i := range catalog {
+		entry := &catalog[i]
+		if entry.RegistryID != registryID {
+			continue
+		}
+		fileSets := [][]CatalogFile{entry.Files}
+		if len(entry.Variants) > 0 {
+			fileSets = fileSets[:0]
+			for j := range entry.Variants {
+				fileSets = append(fileSets, entry.Variants[j].Files)
+			}
+		}
+		for _, files := range fileSets {
+			if !declaresModelFile(files, base) {
+				continue
+			}
+			candidate := modelFileSet{model: modelPath}
+			for _, f := range files {
+				switch f.Role {
+				case RoleLabels:
+					candidate.labels = filepath.Join(dir, f.LocalName)
+				case RoleEmbeddings:
+					if modelsDir != "" {
+						candidate.embeddings = filepath.Join(modelsDir, "shared", f.LocalName)
+					}
+				}
+			}
+			return candidate, true
+		}
+	}
+	return modelFileSet{}, false
+}
+
+// declaresModelFile reports whether files contains a model-role entry named
+// localName.
+func declaresModelFile(files []CatalogFile, localName string) bool {
+	for _, f := range files {
+		if f.Role == RoleModel && f.LocalName == localName {
+			return true
+		}
+	}
+	return false
+}
+
+// isGalleryManagedPath reports whether path looks like a file the model gallery
+// owns, rather than a custom model the user configured by hand.
+//
+// This gates the automatic configuration repair in planPathCorrection.
+// Rewriting a user's own path would silently take their custom model away, and
+// a path that is temporarily unreadable (an external volume that has not
+// mounted yet) is indistinguishable from a stale one at the filesystem level.
+// So repair only what the gallery itself wrote.
+//
+// A path qualifies when it sits under the gallery models directory, or when its
+// basename matches a file name the catalog declares for the family. The second
+// test is what catches the case the issues report: the models directory prefix
+// changed (a different container HOME), so the stale path no longer sits under
+// the current models directory, yet the file name is unmistakably ours.
+// Unlike resolveSiblingSet, this one DOES take o.mu, because it is called only
+// from planPathCorrection, which runs after the loaders have released the lock.
+// Do not call it from a builder or a loader.
+func (o *Orchestrator) isGalleryManagedPath(registryID, path string) bool {
+	if path == "" {
+		return false
+	}
+
+	o.mu.RLock()
+	modelsDir := o.modelsDir
+	o.mu.RUnlock()
+
+	if modelsDir != "" {
+		if rel, err := filepath.Rel(modelsDir, path); err == nil && !strings.HasPrefix(rel, "..") {
+			return true
+		}
+	}
+
+	base := filepath.Base(path)
+	catalog := ActiveCatalog()
+	for i := range catalog {
+		entry := &catalog[i]
+		if entry.RegistryID != registryID {
+			continue
+		}
+		for _, f := range entry.Files {
+			if f.LocalName == base {
+				return true
+			}
+		}
+		for i := range entry.Variants {
+			for _, f := range entry.Variants[i].Files {
+				if f.LocalName == base {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/internal/classifier/model_path_resolution_test.go
+++ b/internal/classifier/model_path_resolution_test.go
@@ -23,6 +23,63 @@ func labelsRoleLocalName(t *testing.T, files []CatalogFile) string {
 	return ""
 }
 
+// embeddingsRoleLocalName returns the embeddings file name a catalog entry
+// declares.
+func embeddingsRoleLocalName(t *testing.T, files []CatalogFile) string {
+	t.Helper()
+	for _, f := range files {
+		if f.Role == RoleEmbeddings {
+			return f.LocalName
+		}
+	}
+	t.Fatalf("entry declares no embeddings file")
+	return ""
+}
+
+// firstBatCatalogEntry returns the first catalog entry whose registry ID is the
+// bat family, so a test does not hard-code a regional variant that may change.
+func firstBatCatalogEntry(t *testing.T) *CatalogEntry {
+	t.Helper()
+	catalog := ActiveCatalog()
+	for i := range catalog {
+		if catalog[i].RegistryID == RegistryIDBat {
+			return &catalog[i]
+		}
+	}
+	t.Fatalf("no bat catalog entry found")
+	return nil
+}
+
+// writeBatGalleryFiles writes a flat bat catalog entry's model and labels into
+// its per-model subdirectory and its shared embedding extractor into
+// models/shared/, mimicking an installed bat model in the gallery layout, and
+// returns the three paths.
+func writeBatGalleryFiles(t *testing.T, modelsDir string, entry *CatalogEntry) (model, labels, embeddings string) {
+	t.Helper()
+	subdir := filepath.Join(modelsDir, entry.ID)
+	sharedDir := filepath.Join(modelsDir, "shared")
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+	require.NoError(t, os.MkdirAll(sharedDir, 0o755))
+	for i := range entry.Files {
+		f := &entry.Files[i]
+		switch f.Role {
+		case RoleModel:
+			model = filepath.Join(subdir, f.LocalName)
+			require.NoError(t, os.WriteFile(model, []byte("m"), 0o600))
+		case RoleLabels:
+			labels = filepath.Join(subdir, f.LocalName)
+			require.NoError(t, os.WriteFile(labels, []byte("l"), 0o600))
+		case RoleEmbeddings:
+			embeddings = filepath.Join(sharedDir, f.LocalName)
+			require.NoError(t, os.WriteFile(embeddings, []byte("e"), 0o600))
+		}
+	}
+	require.NotEmpty(t, model, "bat entry declares a model file")
+	require.NotEmpty(t, labels, "bat entry declares a labels file")
+	require.NotEmpty(t, embeddings, "bat entry declares an embeddings file")
+	return model, labels, embeddings
+}
+
 // writeVariantLabelsFile writes a placeholder labels file for a catalog variant
 // and returns its path.
 func writeVariantLabelsFile(t *testing.T, modelsDir string, entry *CatalogEntry, variantID string) string {
@@ -41,6 +98,17 @@ func writeVariantLabelsFile(t *testing.T, modelsDir string, entry *CatalogEntry,
 func TestResolveFamilyPaths_ConfiguredSetPresentIsUsedVerbatim(t *testing.T) {
 	t.Parallel()
 
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+
+	// A real installed gallery variant whose paths DIFFER from the configured
+	// custom set. Without an installed variant a wrong fallback would return the
+	// same (unchanged) configured set and the assertion could not tell the two
+	// apart; with one installed, a wrong fallback returns these gallery paths.
+	modelsDir := t.TempDir()
+	installedModel := writeVariantModelFile(t, modelsDir, &entry, "fp32")
+	writeVariantLabelsFile(t, modelsDir, &entry, "fp32")
+
 	dir := t.TempDir()
 	model := filepath.Join(dir, "custom.onnx")
 	labels := filepath.Join(dir, "custom_labels.txt")
@@ -48,7 +116,7 @@ func TestResolveFamilyPaths_ConfiguredSetPresentIsUsedVerbatim(t *testing.T) {
 	require.NoError(t, os.WriteFile(labels, []byte("l"), 0o600))
 
 	o := &Orchestrator{}
-	o.SetModelsDir(t.TempDir())
+	o.SetModelsDir(modelsDir)
 
 	got, usedFallback := o.resolveFamilyPaths(RegistryIDPerchV2,
 		modelFileSet{model: model, labels: labels}, false)
@@ -56,6 +124,8 @@ func TestResolveFamilyPaths_ConfiguredSetPresentIsUsedVerbatim(t *testing.T) {
 	assert.False(t, usedFallback, "a present configured set must not trigger the fallback")
 	assert.Equal(t, model, got.model)
 	assert.Equal(t, labels, got.labels)
+	assert.NotEqual(t, installedModel, got.model,
+		"the configured custom model must be used verbatim, not the installed gallery variant")
 }
 
 // TestResolveFamilyPaths_MissingConfiguredPathFallsBackToInstalled covers the
@@ -84,13 +154,17 @@ func TestResolveFamilyPaths_MissingConfiguredPathFallsBackToInstalled(t *testing
 	assert.Equal(t, installedLabels, got.labels)
 }
 
-// TestResolveFamilyPaths_PartiallyMissingSetIsReplacedAsAUnit is the regression
-// test for the mismatch that per-file resolution produces. With only the labels
-// path stale, a per-file fallback keeps the configured model (variant A) and
-// takes the labels from whichever variant the gallery probe finds first
-// (variant B). That pairing either fails with a label-count mismatch or, when
-// two variants happen to declare the same count, silently mislabels every
-// detection. The whole set must move together.
+// TestResolveFamilyPaths_PartiallyMissingSetIsReplacedAsAUnit checks that when a
+// non-catalog configured model is present but its labels are missing, the whole
+// set is discarded for the installed gallery set rather than pairing the
+// configured model with fallback labels (which would either fail with a
+// label-count mismatch or silently mislabel every detection).
+//
+// The configured model here is a STRAY file whose basename matches no catalog
+// variant, so resolveSiblingSet finds no match and the generic gallery probe
+// supplies the whole replacement set. The cross-variant recovery path (where the
+// configured model IS a catalog variant and only a companion is missing) is
+// covered separately by TestResolveFamilyPaths_KeepsConfiguredVariantWhenOnlyCompanionIsMissing.
 func TestResolveFamilyPaths_PartiallyMissingSetIsReplacedAsAUnit(t *testing.T) {
 	t.Parallel()
 
@@ -98,12 +172,13 @@ func TestResolveFamilyPaths_PartiallyMissingSetIsReplacedAsAUnit(t *testing.T) {
 	require.True(t, ok)
 
 	modelsDir := t.TempDir()
-	// Only the fp32 variant is installed; the configured model path names a
-	// different variant's file that still exists on disk.
+	// Only the fp32 variant is installed.
 	installedModel := writeVariantModelFile(t, modelsDir, &entry, "fp32")
 	installedLabels := writeVariantLabelsFile(t, modelsDir, &entry, "fp32")
 
 	strayDir := t.TempDir()
+	// A file name that matches no catalog variant, so this exercises the
+	// unknown-file branch (no sibling recovery), not the cross-variant branch.
 	strayModel := filepath.Join(strayDir, "perch_v2_other_variant.onnx")
 	require.NoError(t, os.WriteFile(strayModel, []byte("m"), 0o600))
 
@@ -152,6 +227,13 @@ func TestResolveFamilyPaths_NothingInstalledKeepsConfiguredSet(t *testing.T) {
 func TestResolveFamilyPaths_BatEmbeddingsParticipateInAtomicity(t *testing.T) {
 	t.Parallel()
 
+	batEntry := firstBatCatalogEntry(t)
+
+	modelsDir := t.TempDir()
+	// A real installed bat gallery variant so the fallback is observable: without
+	// it the missing embedding could not be distinguished from a set kept as-is.
+	galleryModel, galleryLabels, galleryEmb := writeBatGalleryFiles(t, modelsDir, batEntry)
+
 	dir := t.TempDir()
 	model := filepath.Join(dir, "bat.onnx")
 	labels := filepath.Join(dir, "bat_labels.txt")
@@ -159,8 +241,11 @@ func TestResolveFamilyPaths_BatEmbeddingsParticipateInAtomicity(t *testing.T) {
 	require.NoError(t, os.WriteFile(labels, []byte("l"), 0o600))
 
 	o := &Orchestrator{}
-	o.SetModelsDir(t.TempDir()) // empty gallery: nothing to fall back to
+	o.SetModelsDir(modelsDir)
 
+	// Present classifier and labels, but a missing (non-empty) embedding path: the
+	// set is stale and must be replaced WHOLE by the installed gallery set, not
+	// left pairing two configured paths with a fallback embedding.
 	configured := modelFileSet{
 		model:      model,
 		labels:     labels,
@@ -168,14 +253,139 @@ func TestResolveFamilyPaths_BatEmbeddingsParticipateInAtomicity(t *testing.T) {
 	}
 	got, usedFallback := o.resolveFamilyPaths(RegistryIDBat, configured, true)
 
-	// No installed bat model, so the configured set comes back untouched, but the
-	// point is that allPresentOnDisk rejected it rather than accepting two of three.
-	assert.False(t, usedFallback)
-	assert.Equal(t, configured, got)
+	require.True(t, usedFallback, "a missing embedding member makes the whole set stale")
+	assert.Equal(t, galleryModel, got.model,
+		"the classifier moves with the set; it must not be kept while the embeddings are replaced")
+	assert.Equal(t, galleryLabels, got.labels)
+	assert.Equal(t, galleryEmb, got.embeddings)
+	assert.NotEqual(t, model, got.model,
+		"keeping the configured classifier while replacing the embeddings would mismatch the set")
+
+	// The invariants the atomicity rests on.
 	assert.False(t, configured.allPresentOnDisk(true),
 		"a set with a missing embedding model must not count as present")
 	assert.True(t, modelFileSet{model: model, labels: labels}.allPresentOnDisk(false),
 		"the same two files are a complete set for a family that needs no embeddings")
+}
+
+// TestResolveFamilyPaths_EmptyMemberFilledMissingMemberReplaced pins A1's rule:
+// an EMPTY configured member is filled from the gallery with no repair (it is the
+// supported gallery-owns-it convention), whereas a MISSING non-empty member makes
+// the whole set stale and triggers the fallback + repair.
+func TestResolveFamilyPaths_EmptyMemberFilledMissingMemberReplaced(t *testing.T) {
+	t.Parallel()
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+
+	modelsDir := t.TempDir()
+	installedModel := writeVariantModelFile(t, modelsDir, &entry, "fp32")
+	installedLabels := writeVariantLabelsFile(t, modelsDir, &entry, "fp32")
+
+	o := &Orchestrator{}
+	o.SetModelsDir(modelsDir)
+
+	t.Run("empty member is filled from the gallery without a repair", func(t *testing.T) {
+		t.Parallel()
+		got, usedFallback := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
+			model:  installedModel, // present
+			labels: "",             // empty: the gallery owns it
+		}, false)
+		assert.False(t, usedFallback, "an empty member is not stale, so no repair is queued")
+		assert.Equal(t, installedModel, got.model, "the present configured model is kept")
+		assert.Equal(t, installedLabels, got.labels, "the empty labels member is filled from the gallery")
+	})
+
+	t.Run("a missing non-empty member replaces the set with a repair", func(t *testing.T) {
+		t.Parallel()
+		got, usedFallback := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
+			model:  "/nonexistent/perch_v2.onnx",
+			labels: "/nonexistent/perch_v2_labels.txt",
+		}, false)
+		assert.True(t, usedFallback, "a missing non-empty member is stale and queues a repair")
+		assert.Equal(t, installedModel, got.model)
+	})
+}
+
+// TestResolveFamilyPaths_IndeterminateFallsBackWithoutRepair pins A2's third
+// outcome: a configured path that is unreadable for a reason OTHER than absence
+// (here ENOTDIR, standing in for a volume that has not finished mounting) still
+// falls back at runtime so analysis can run, but must NOT rewrite config.
+func TestResolveFamilyPaths_IndeterminateFallsBackWithoutRepair(t *testing.T) {
+	t.Parallel()
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+
+	modelsDir := t.TempDir()
+	installedModel := writeVariantModelFile(t, modelsDir, &entry, "fp32")
+	installedLabels := writeVariantLabelsFile(t, modelsDir, &entry, "fp32")
+
+	// A regular file used as a path prefix makes os.Stat return ENOTDIR, which is
+	// indeterminate (not a confirmed absence).
+	dir := t.TempDir()
+	regular := filepath.Join(dir, "not-a-dir")
+	require.NoError(t, os.WriteFile(regular, []byte("x"), 0o600))
+	indeterminate := modelFileSet{
+		model:  filepath.Join(regular, "perch_v2.onnx"),
+		labels: filepath.Join(regular, "perch_v2_labels.txt"),
+	}
+
+	o := &Orchestrator{}
+	o.SetModelsDir(modelsDir)
+
+	got, usedFallback := o.resolveFamilyPaths(RegistryIDPerchV2, indeterminate, false)
+
+	assert.False(t, usedFallback,
+		"an unreadable path is indeterminate: fall back at runtime but do NOT rewrite config")
+	assert.Equal(t, installedModel, got.model,
+		"the model still resolves to the installed gallery model so analysis can run")
+	assert.Equal(t, installedLabels, got.labels)
+
+	o.queuePathCorrectionIfFallback(RegistryIDPerchV2, indeterminate, false)
+	assert.Empty(t, o.pendingPathCorrections,
+		"an indeterminate path must not queue a config repair")
+}
+
+// TestQueuePathCorrectionIfFallback_HealthySetQueuesNothing is the negative for
+// the self-heal: a fully present configured set must not queue any repair.
+func TestQueuePathCorrectionIfFallback_HealthySetQueuesNothing(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	model := filepath.Join(dir, "custom.onnx")
+	labels := filepath.Join(dir, "custom_labels.txt")
+	require.NoError(t, os.WriteFile(model, []byte("m"), 0o600))
+	require.NoError(t, os.WriteFile(labels, []byte("l"), 0o600))
+
+	// A real gallery variant must be installed, otherwise this test cannot fail:
+	// with an empty models directory the fallback also returns the configured set
+	// and queues nothing, so removing the healthy-set early return entirely would
+	// still leave the assertion below green.
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+	modelsDir := t.TempDir()
+	writeVariantModelFile(t, modelsDir, &entry, "fp32")
+	writeVariantLabelsFile(t, modelsDir, &entry, "fp32")
+
+	o := &Orchestrator{}
+	o.SetModelsDir(modelsDir)
+
+	configured := modelFileSet{model: model, labels: labels}
+
+	// Assert the resolution itself, not only the queue. Queueing is keyed on a
+	// CONFIRMED-missing member, so a healthy set queues nothing down several
+	// different code paths; without this the test cannot tell the healthy-set
+	// early return from a fallback that happened to keep repairable false.
+	got, usedFallback := o.resolveFamilyPaths(RegistryIDPerchV2, configured, false)
+	assert.False(t, usedFallback)
+	assert.Equal(t, configured, got,
+		"a healthy configured set must be returned verbatim, never swapped for the installed gallery variant")
+
+	o.queuePathCorrectionIfFallback(RegistryIDPerchV2, configured, false)
+
+	assert.Empty(t, o.pendingPathCorrections,
+		"a healthy, fully-present configured set must not queue a config repair")
 }
 
 // TestIsGalleryManagedPath gates the automatic config repair: only paths the
@@ -192,19 +402,36 @@ func TestIsGalleryManagedPath(t *testing.T) {
 	o := &Orchestrator{}
 	o.SetModelsDir(modelsDir)
 
-	t.Run("path under the models directory is gallery managed", func(t *testing.T) {
+	t.Run("catalog file in the entry-ID subdir under the models directory is gallery managed", func(t *testing.T) {
 		t.Parallel()
-		p := filepath.Join(modelsDir, "perch-v2", "anything.onnx")
+		p := filepath.Join(modelsDir, "perch-v2", galleryName)
 		assert.True(t, o.isGalleryManagedPath(RegistryIDPerchV2, p))
 	})
 
-	t.Run("catalog file name outside the models directory is gallery managed", func(t *testing.T) {
+	t.Run("catalog file name in an entry-ID directory outside the models directory is gallery managed", func(t *testing.T) {
 		t.Parallel()
 		// This is the shape the issues report: the models directory prefix changed
 		// (a different container HOME), so the stale path no longer sits under the
-		// current models dir, but the file name is unmistakably ours.
+		// current models dir, but the parent directory is still the entry ID and the
+		// file name is unmistakably ours.
 		p := "/home/someone-else/.config/birdnet-go/models/perch-v2/" + galleryName
 		assert.True(t, o.isGalleryManagedPath(RegistryIDPerchV2, p))
+	})
+
+	t.Run("a catalog file name in a non-entry directory is NOT gallery managed", func(t *testing.T) {
+		t.Parallel()
+		// The basename is a real catalog file name, but the parent directory is
+		// "models", not the entry ID, so this is the user's own copy and must not be
+		// taken over. This is the false match the tightened rule closes.
+		assert.False(t, o.isGalleryManagedPath(RegistryIDPerchV2, "/mnt/nas/models/"+galleryName))
+	})
+
+	t.Run("a non-catalog file name under the entry-ID subdir is NOT gallery managed", func(t *testing.T) {
+		t.Parallel()
+		// Correct parent directory but a basename the catalog never declares: a
+		// user's custom model dropped into the gallery subdir is still theirs.
+		p := filepath.Join(modelsDir, "perch-v2", "anything.onnx")
+		assert.False(t, o.isGalleryManagedPath(RegistryIDPerchV2, p))
 	})
 
 	t.Run("a user's custom model is not gallery managed", func(t *testing.T) {
@@ -228,6 +455,7 @@ func TestPlanPathCorrection(t *testing.T) {
 	entry, ok := GetCatalogEntry("perch-v2")
 	require.True(t, ok)
 	galleryName := modelRoleLocalName(t, variantByID(t, &entry, "fp32").Files)
+	galleryLabelsName := labelsRoleLocalName(t, variantByID(t, &entry, "fp32").Files)
 
 	newModel := "/models/perch-v2/perch_v2_reunion_no_dft.onnx"
 	newLabels := "/models/perch-v2/perch_v2_reunion_labels.txt"
@@ -239,11 +467,14 @@ func TestPlanPathCorrection(t *testing.T) {
 		o.SetModelsDir(t.TempDir())
 
 		current := &conf.Settings{}
-		// A path the gallery wrote, under a models directory prefix that no longer
-		// applies: exactly the state a container HOME change leaves behind.
+		// Paths the gallery wrote, under a models directory prefix that no longer
+		// applies: exactly the state a container HOME change leaves behind. Both use
+		// real catalog file names so the tightened isGalleryManagedPath recognises
+		// them.
 		stalePath := "/home/birdnet/.config/birdnet-go/models/perch-v2/" + galleryName
+		staleLabels := "/home/birdnet/.config/birdnet-go/models/perch-v2/" + galleryLabelsName
 		current.Perch.ModelPath = stalePath
-		current.Perch.LabelPath = "/home/birdnet/.config/birdnet-go/models/perch-v2/perch_v2_labels.txt"
+		current.Perch.LabelPath = staleLabels
 
 		updated, changed := o.planPathCorrection(current, &pendingPathCorrection{
 			registryID: RegistryIDPerchV2,
@@ -252,6 +483,8 @@ func TestPlanPathCorrection(t *testing.T) {
 
 		require.True(t, changed)
 		assert.Equal(t, newModel, updated.Perch.ModelPath)
+		assert.Equal(t, newLabels, updated.Perch.LabelPath,
+			"the stale labels path must be repaired too, not only the model path")
 		assert.NotSame(t, current, updated, "the published snapshot must be a clone, never mutated in place")
 		assert.Equal(t, stalePath, current.Perch.ModelPath,
 			"the input snapshot must be left untouched")
@@ -296,14 +529,21 @@ func TestPlanPathCorrection(t *testing.T) {
 	t.Run("bat repairs all three paths including embeddings", func(t *testing.T) {
 		t.Parallel()
 
+		batEntry := firstBatCatalogEntry(t)
+
 		modelsDir := t.TempDir()
 		o := &Orchestrator{}
 		o.SetModelsDir(modelsDir)
 
+		// The stale paths must be gallery-managed for the repair to fire: model and
+		// labels live in <modelsDir>/<entry ID>/ under their catalog file names, the
+		// shared embedding extractor in <modelsDir>/shared/. The tightened
+		// isGalleryManagedPath rule (parent directory base name plus a declared
+		// LocalName) recognises exactly this layout.
 		current := &conf.Settings{}
-		current.Bat.ClassifierModel = filepath.Join(modelsDir, "stale_classifier.onnx")
-		current.Bat.LabelPath = filepath.Join(modelsDir, "stale_labels.txt")
-		current.Bat.EmbeddingModel = filepath.Join(modelsDir, "shared", "stale_embeddings.onnx")
+		current.Bat.ClassifierModel = filepath.Join(modelsDir, batEntry.ID, modelRoleLocalName(t, batEntry.Files))
+		current.Bat.LabelPath = filepath.Join(modelsDir, batEntry.ID, labelsRoleLocalName(t, batEntry.Files))
+		current.Bat.EmbeddingModel = filepath.Join(modelsDir, "shared", embeddingsRoleLocalName(t, batEntry.Files))
 
 		updated, changed := o.planPathCorrection(current, &pendingPathCorrection{
 			registryID: RegistryIDBat,
@@ -319,6 +559,33 @@ func TestPlanPathCorrection(t *testing.T) {
 		assert.Equal(t, "/models/bat/labels.txt", updated.Bat.LabelPath)
 		assert.Equal(t, "/models/shared/embeddings.onnx", updated.Bat.EmbeddingModel,
 			"the shared embedding extractor goes stale with the rest of the set")
+	})
+
+	t.Run("birdnet v3 repairs model and labels", func(t *testing.T) {
+		t.Parallel()
+
+		v3, okV3 := GetCatalogEntry("birdnet-v3.0")
+		require.True(t, okV3)
+		v3Model := modelRoleLocalName(t, variantByID(t, &v3, "fp32").Files)
+		v3Labels := labelsRoleLocalName(t, variantByID(t, &v3, "fp32").Files)
+
+		o := &Orchestrator{}
+		o.SetModelsDir(t.TempDir())
+
+		current := &conf.Settings{}
+		current.BirdNETV3.ModelPath = "/home/birdnet/.config/birdnet-go/models/birdnet-v3.0/" + v3Model
+		current.BirdNETV3.LabelPath = "/home/birdnet/.config/birdnet-go/models/birdnet-v3.0/" + v3Labels
+
+		newV3Model := "/models/birdnet-v3.0/other.onnx"
+		newV3Labels := "/models/birdnet-v3.0/other_labels.txt"
+		updated, changed := o.planPathCorrection(current, &pendingPathCorrection{
+			registryID: RegistryIDBirdNETV3,
+			resolved:   modelFileSet{model: newV3Model, labels: newV3Labels},
+		})
+
+		require.True(t, changed)
+		assert.Equal(t, newV3Model, updated.BirdNETV3.ModelPath)
+		assert.Equal(t, newV3Labels, updated.BirdNETV3.LabelPath)
 	})
 
 	t.Run("an unknown registry ID changes nothing", func(t *testing.T) {
@@ -338,6 +605,56 @@ func TestPlanPathCorrection(t *testing.T) {
 		assert.False(t, changed)
 		assert.Same(t, current, updated)
 	})
+}
+
+// TestApplyPathCorrection_PersistsRepairedPaths exercises applyPathCorrection end
+// to end (StoreSettings + SaveSettings). It pins that StoreSettings runs BEFORE
+// SaveSettings: SaveSettings persists whatever StoreSettings last published, so
+// reversing them would write the stale snapshot and the file would still hold the
+// old paths. redirectConfigFile points conf.SaveSettings at a temp file so the
+// developer's own ~/.config/birdnet-go/config.yaml is never touched.
+func TestApplyPathCorrection_PersistsRepairedPaths(t *testing.T) {
+	// Not parallel: mutates the conf global settings and conf.ConfigPath.
+	redirectConfigFile(t)
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+	galleryName := modelRoleLocalName(t, variantByID(t, &entry, "fp32").Files)
+	galleryLabelsName := labelsRoleLocalName(t, variantByID(t, &entry, "fp32").Files)
+
+	modelsDir := t.TempDir()
+	o := &Orchestrator{}
+	o.SetModelsDir(modelsDir)
+
+	// Stale gallery-managed paths published as the current settings.
+	stale := &conf.Settings{}
+	stalePath := filepath.Join(modelsDir, "perch-v2", galleryName)
+	stale.Perch.ModelPath = stalePath
+	stale.Perch.LabelPath = filepath.Join(modelsDir, "perch-v2", galleryLabelsName)
+	conf.StoreSettings(stale)
+	t.Cleanup(func() { conf.StoreSettings(nil) })
+
+	newModel := "/models/perch-v2/perch_v2_reunion_no_dft.onnx"
+	newLabels := "/models/perch-v2/perch_v2_reunion_labels.txt"
+	o.applyPathCorrection(&pendingPathCorrection{
+		registryID: RegistryIDPerchV2,
+		resolved:   modelFileSet{model: newModel, labels: newLabels},
+	})
+
+	// The published snapshot carries the repaired paths.
+	got := conf.GetSettings()
+	require.NotNil(t, got)
+	assert.Equal(t, newModel, got.Perch.ModelPath)
+	assert.Equal(t, newLabels, got.Perch.LabelPath)
+
+	// And so does the persisted file. If SaveSettings ran BEFORE StoreSettings it
+	// would have persisted the stale snapshot instead.
+	data, err := os.ReadFile(conf.ConfigPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), newModel,
+		"the persisted config must carry the repaired path; StoreSettings must run before SaveSettings")
+	assert.NotContains(t, string(data), stalePath,
+		"the stale model path must not survive in the persisted config")
 }
 
 // TestResolveFamilyPaths_KeepsConfiguredVariantWhenOnlyCompanionIsMissing

--- a/internal/classifier/model_path_resolution_test.go
+++ b/internal/classifier/model_path_resolution_test.go
@@ -3,12 +3,14 @@ package classifier
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/notification"
 )
 
 // labelsRoleLocalName returns the labels file name a catalog variant declares.
@@ -307,12 +309,68 @@ func TestResolveFamilyPaths_EmptyMemberFilledMissingMemberReplaced(t *testing.T)
 	})
 }
 
+// TestResolveFamilyPaths_EmptyMemberFilledFromConfiguredVariant asserts that when
+// a configured model names a REGIONAL variant present on disk and its labels
+// member is empty, the empty labels are filled from that SAME variant, not from a
+// different installed variant (a global build) that the catalog happens to list
+// first. For bat, whose label files are per-region with region-specific counts, a
+// count coincidence would otherwise silently mislabel every detection.
+func TestResolveFamilyPaths_EmptyMemberFilledFromConfiguredVariant(t *testing.T) {
+	t.Parallel()
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+
+	modelsDir := t.TempDir()
+	// A global build is installed and is listed FIRST in the catalog, so
+	// resolveInstalledPaths returns its labels (perch_v2_labels.txt).
+	writeVariantModelFile(t, modelsDir, &entry, "fp32")
+	globalLabels := writeVariantLabelsFile(t, modelsDir, &entry, "fp32")
+
+	// The configuration names a regional variant, also installed, whose labels
+	// file is region-specific and distinct from the global one.
+	const regionalVariant = "no-dft-fp32@reunion"
+	regionalModel := writeVariantModelFile(t, modelsDir, &entry, regionalVariant)
+	regionalLabels := writeVariantLabelsFile(t, modelsDir, &entry, regionalVariant)
+	require.NotEqual(t, globalLabels, regionalLabels,
+		"the two variants must declare distinct labels files for this test to mean anything")
+
+	o := &Orchestrator{}
+	o.SetModelsDir(modelsDir)
+
+	// Configured model present (regional), labels empty: presenceComplete, so the
+	// empty labels member is filled. It must be filled from the regional model's
+	// own variant.
+	got, usedFallback := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
+		model:  regionalModel,
+		labels: "",
+	}, false)
+
+	assert.False(t, usedFallback, "an empty member is filled, not a stale fallback")
+	assert.Equal(t, regionalModel, got.model, "the configured regional model is kept")
+	assert.Equal(t, regionalLabels, got.labels,
+		"empty labels must be filled from the SAME variant the configured model names")
+	assert.NotEqual(t, globalLabels, got.labels,
+		"filling from the catalog-first global variant would mislabel the regional model")
+}
+
 // TestResolveFamilyPaths_IndeterminateFallsBackWithoutRepair pins A2's third
 // outcome: a configured path that is unreadable for a reason OTHER than absence
 // (here ENOTDIR, standing in for a volume that has not finished mounting) still
 // falls back at runtime so analysis can run, but must NOT rewrite config.
 func TestResolveFamilyPaths_IndeterminateFallsBackWithoutRepair(t *testing.T) {
 	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		// This test provokes the indeterminate branch with a path whose intermediate
+		// component is a regular file, which yields ENOTDIR on Linux and macOS. On
+		// Windows the same stat reports ERROR_PATH_NOT_FOUND, which Go maps to
+		// fs.ErrNotExist, so nonEmptyMembersPresence returns presenceMissing rather
+		// than presenceIndeterminate: repairable becomes true and both assertions
+		// below would fail. os.Chmod is not an alternative (it is a no-op on Windows,
+		// which would make the test pass vacuously).
+		t.Skip("ENOTDIR-via-file-prefix is ERROR_PATH_NOT_FOUND on Windows, mapped to fs.ErrNotExist")
+	}
 
 	entry, ok := GetCatalogEntry("perch-v2")
 	require.True(t, ok)
@@ -398,7 +456,10 @@ func TestIsGalleryManagedPath(t *testing.T) {
 	require.True(t, ok)
 	galleryName := modelRoleLocalName(t, variantByID(t, &entry, "fp32").Files)
 
-	modelsDir := t.TempDir()
+	// The models directory's base name is "models", as it is in production
+	// (~/.config/birdnet-go/models). isGalleryManagedPath now requires a candidate
+	// path's grandparent directory to match this base name.
+	modelsDir := filepath.Join(t.TempDir(), "models")
 	o := &Orchestrator{}
 	o.SetModelsDir(modelsDir)
 
@@ -443,6 +504,26 @@ func TestIsGalleryManagedPath(t *testing.T) {
 		t.Parallel()
 		assert.False(t, o.isGalleryManagedPath(RegistryIDPerchV2, ""))
 	})
+
+	t.Run("a NAS-mirror path that only mimics the gallery layout is NOT gallery managed", func(t *testing.T) {
+		t.Parallel()
+		// Correct basename and entry-ID parent, but the grandparent is "nas", not the
+		// models directory. This is the "moved my models to a NAS but left the local
+		// copy" migration: a late mount yields ENOENT (presenceMissing), and without
+		// the grandparent check the user's NAS path would be permanently rewritten to
+		// the local gallery copy.
+		assert.False(t, o.isGalleryManagedPath(RegistryIDPerchV2, "/mnt/nas/perch-v2/"+galleryName))
+	})
+
+	t.Run("a shared-role file under the models directory is gallery managed", func(t *testing.T) {
+		t.Parallel()
+		// The shared embedding extractor lives in <models>/shared/, so its grandparent
+		// is the models directory and it still qualifies.
+		batEntry := firstBatCatalogEntry(t)
+		embName := embeddingsRoleLocalName(t, batEntry.Files)
+		p := filepath.Join(modelsDir, "shared", embName)
+		assert.True(t, o.isGalleryManagedPath(RegistryIDBat, p))
+	})
 }
 
 // TestPlanPathCorrection covers the automatic configuration repair. It exercises
@@ -464,7 +545,9 @@ func TestPlanPathCorrection(t *testing.T) {
 		t.Parallel()
 
 		o := &Orchestrator{}
-		o.SetModelsDir(t.TempDir())
+		// Base name "models" so the changed-HOME stale paths below (grandparent
+		// "models") satisfy the grandparent requirement in isGalleryManagedPath.
+		o.SetModelsDir(filepath.Join(t.TempDir(), "models"))
 
 		current := &conf.Settings{}
 		// Paths the gallery wrote, under a models directory prefix that no longer
@@ -570,7 +653,7 @@ func TestPlanPathCorrection(t *testing.T) {
 		v3Labels := labelsRoleLocalName(t, variantByID(t, &v3, "fp32").Files)
 
 		o := &Orchestrator{}
-		o.SetModelsDir(t.TempDir())
+		o.SetModelsDir(filepath.Join(t.TempDir(), "models"))
 
 		current := &conf.Settings{}
 		current.BirdNETV3.ModelPath = "/home/birdnet/.config/birdnet-go/models/birdnet-v3.0/" + v3Model
@@ -603,7 +686,59 @@ func TestPlanPathCorrection(t *testing.T) {
 		})
 
 		assert.False(t, changed)
-		assert.Same(t, current, updated)
+		assert.Nil(t, updated,
+			"an unknown registry returns nil, never the live published snapshot")
+	})
+
+	t.Run("a mixed set with one user-owned field is abandoned whole", func(t *testing.T) {
+		t.Parallel()
+
+		o := &Orchestrator{}
+		o.SetModelsDir(filepath.Join(t.TempDir(), "models"))
+
+		// The model path is a stale gallery-managed path (would be rewritten on its
+		// own); the labels path is the user's own custom file. Both DIFFER from the
+		// resolved set. Because a resolved set is atomic, rewriting only the model
+		// while keeping the custom labels would persist a cross-variant hybrid, so
+		// the whole correction must be abandoned.
+		current := &conf.Settings{}
+		current.Perch.ModelPath = "/home/birdnet/.config/birdnet-go/models/perch-v2/" + galleryName
+		current.Perch.LabelPath = "/srv/my-models/my_own_labels.txt"
+
+		updated, changed := o.planPathCorrection(current, &pendingPathCorrection{
+			registryID: RegistryIDPerchV2,
+			resolved:   modelFileSet{model: newModel, labels: newLabels},
+		})
+
+		assert.False(t, changed,
+			"a user-owned field must veto the whole correction, not just its own field")
+		assert.Nil(t, updated,
+			"an abandoned correction returns nil so the gallery-managed model is never written")
+	})
+
+	t.Run("a gallery path already equal to the resolved value is not rewritten", func(t *testing.T) {
+		t.Parallel()
+
+		o := &Orchestrator{}
+		o.SetModelsDir(filepath.Join(t.TempDir(), "models"))
+
+		// Gallery-managed paths that ALREADY equal the resolved set. There is nothing
+		// to change: the no-op guard must skip a field whose value already matches,
+		// so the plan reports changed==false rather than "rewriting" a field to the
+		// value it already holds.
+		samePath := "/home/birdnet/.config/birdnet-go/models/perch-v2/" + galleryName
+		sameLabels := "/home/birdnet/.config/birdnet-go/models/perch-v2/" + galleryLabelsName
+		current := &conf.Settings{}
+		current.Perch.ModelPath = samePath
+		current.Perch.LabelPath = sameLabels
+
+		_, changed := o.planPathCorrection(current, &pendingPathCorrection{
+			registryID: RegistryIDPerchV2,
+			resolved:   modelFileSet{model: samePath, labels: sameLabels},
+		})
+
+		assert.False(t, changed,
+			"a configured path already equal to the resolved value is not a change")
 	})
 }
 
@@ -631,8 +766,9 @@ func TestApplyPathCorrection_PersistsRepairedPaths(t *testing.T) {
 	stalePath := filepath.Join(modelsDir, "perch-v2", galleryName)
 	stale.Perch.ModelPath = stalePath
 	stale.Perch.LabelPath = filepath.Join(modelsDir, "perch-v2", galleryLabelsName)
+	origSettings := conf.GetSettings()
 	conf.StoreSettings(stale)
-	t.Cleanup(func() { conf.StoreSettings(nil) })
+	t.Cleanup(func() { conf.StoreSettings(origSettings) })
 
 	newModel := "/models/perch-v2/perch_v2_reunion_no_dft.onnx"
 	newLabels := "/models/perch-v2/perch_v2_reunion_labels.txt"
@@ -655,6 +791,188 @@ func TestApplyPathCorrection_PersistsRepairedPaths(t *testing.T) {
 		"the persisted config must carry the repaired path; StoreSettings must run before SaveSettings")
 	assert.NotContains(t, string(data), stalePath,
 		"the stale model path must not survive in the persisted config")
+}
+
+// TestApplyPathCorrection_NoWriteWhenNothingChanged pins the redundant-write
+// short-circuit: when planPathCorrection reports no change (the configured paths
+// already equal the resolved set), applyPathCorrection must NOT publish a new
+// snapshot and must NOT persist config.yaml. Without the `if !changed { return }`
+// guard the whole package stays green while a StoreSettings + SaveSettings runs
+// on a plan that changed nothing.
+func TestApplyPathCorrection_NoWriteWhenNothingChanged(t *testing.T) {
+	// Not parallel: mutates the conf global settings and conf.ConfigPath.
+	redirectConfigFile(t)
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+	galleryName := modelRoleLocalName(t, variantByID(t, &entry, "fp32").Files)
+	galleryLabelsName := labelsRoleLocalName(t, variantByID(t, &entry, "fp32").Files)
+
+	modelsDir := t.TempDir()
+	o := &Orchestrator{}
+	o.SetModelsDir(modelsDir)
+
+	// Gallery-managed paths published as current, and the resolved set is the SAME:
+	// there is nothing to repair, so planPathCorrection reports changed==false.
+	same := &conf.Settings{}
+	same.Perch.ModelPath = filepath.Join(modelsDir, "perch-v2", galleryName)
+	same.Perch.LabelPath = filepath.Join(modelsDir, "perch-v2", galleryLabelsName)
+
+	origSettings := conf.GetSettings()
+	conf.StoreSettings(same)
+	t.Cleanup(func() { conf.StoreSettings(origSettings) })
+
+	before, err := os.ReadFile(conf.ConfigPath)
+	require.NoError(t, err)
+
+	o.applyPathCorrection(&pendingPathCorrection{
+		registryID: RegistryIDPerchV2,
+		resolved:   modelFileSet{model: same.Perch.ModelPath, labels: same.Perch.LabelPath},
+	})
+
+	assert.Same(t, same, conf.GetSettings(),
+		"nothing changed, so applyPathCorrection must not publish a new snapshot")
+	after, err := os.ReadFile(conf.ConfigPath)
+	require.NoError(t, err)
+	assert.Equal(t, before, after,
+		"nothing changed, so applyPathCorrection must not persist config.yaml")
+}
+
+// TestApplyPathCorrection_PersistenceDisabledSkipsWrite covers the read-only
+// diagnostic path (benchmark, rangefilter print): a stale gallery path still
+// resolves via the runtime fallback, but with persistence disabled the correction
+// is NOT written to config.yaml and no new snapshot is published.
+func TestApplyPathCorrection_PersistenceDisabledSkipsWrite(t *testing.T) {
+	// Not parallel: mutates the conf global settings, conf.ConfigPath, and the
+	// process-level persistence switch.
+	redirectConfigFile(t)
+
+	SetPathCorrectionPersistenceDisabled(true)
+	t.Cleanup(func() { SetPathCorrectionPersistenceDisabled(false) })
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+	galleryLabelsName := labelsRoleLocalName(t, variantByID(t, &entry, "fp32").Files)
+
+	// An installed gallery variant so the fallback has something to resolve to. Base
+	// name "models" so the stale gallery-managed path below satisfies the
+	// grandparent requirement in isGalleryManagedPath.
+	modelsDir := filepath.Join(t.TempDir(), "models")
+	installedModel := writeVariantModelFile(t, modelsDir, &entry, "fp32")
+	installedLabels := writeVariantLabelsFile(t, modelsDir, &entry, "fp32")
+
+	o := &Orchestrator{}
+	o.SetModelsDir(modelsDir)
+
+	// A stale, gallery-managed configured model (a regional variant's declared file
+	// name, so isGalleryManagedPath qualifies it) that is confirmed missing on disk.
+	// The labels member already equals the resolved labels, so only the model would
+	// be rewritten: planPathCorrection reports a real change on the serve path.
+	stale := &conf.Settings{}
+	stale.Perch.ModelPath = filepath.Join(modelsDir, "perch-v2", "perch_v2_reunion_no_dft.onnx")
+	stale.Perch.LabelPath = filepath.Join(modelsDir, "perch-v2", galleryLabelsName)
+
+	// The runtime fallback still resolves the missing path to the installed model,
+	// independent of persistence.
+	resolved, usedFallback := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
+		model:  stale.Perch.ModelPath,
+		labels: stale.Perch.LabelPath,
+	}, false)
+	require.True(t, usedFallback, "a confirmed-missing configured path must still fall back")
+	assert.Equal(t, installedModel, resolved.model,
+		"the fallback still resolves the model so analysis can run")
+	assert.Equal(t, installedLabels, resolved.labels)
+
+	origSettings := conf.GetSettings()
+	conf.StoreSettings(stale)
+	t.Cleanup(func() { conf.StoreSettings(origSettings) })
+
+	before, err := os.ReadFile(conf.ConfigPath)
+	require.NoError(t, err)
+
+	o.applyPathCorrection(&pendingPathCorrection{
+		registryID: RegistryIDPerchV2,
+		resolved:   resolved,
+	})
+
+	assert.Same(t, stale, conf.GetSettings(),
+		"persistence disabled: applyPathCorrection must not publish a new snapshot")
+	after, err := os.ReadFile(conf.ConfigPath)
+	require.NoError(t, err)
+	assert.Equal(t, before, after,
+		"persistence disabled: conf.SaveSettings must not run and config.yaml must be unchanged")
+}
+
+// TestApplyPathCorrection_UserOwnedSubstitutionNotifies covers the silent-runtime
+// -substitution gap: a user's custom model path is confirmed missing, so the
+// gallery fallback runs a different model, but the config is (correctly) NOT
+// rewritten because the path is user-owned. Without a notification the user runs a
+// model they never chose with no signal. applyPathCorrection must emit the
+// substituted notification (distinct from the reconciled one) and leave config
+// untouched.
+func TestApplyPathCorrection_UserOwnedSubstitutionNotifies(t *testing.T) {
+	// Not parallel: mutates conf globals, conf.ConfigPath, the persistence switch,
+	// and the process-global notification service.
+	redirectConfigFile(t)
+
+	SetPathCorrectionPersistenceDisabled(false)
+
+	notification.ResetForTest()
+	t.Cleanup(notification.ResetForTest)
+	notification.Initialize(notification.DefaultServiceConfig())
+	svc := notification.GetService()
+	require.NotNil(t, svc)
+	t.Cleanup(svc.Stop)
+
+	modelsDir := filepath.Join(t.TempDir(), "models")
+	o := &Orchestrator{}
+	o.SetModelsDir(modelsDir)
+
+	// A user's own model path (not gallery-managed): the self-heal must not rewrite
+	// it, so planPathCorrection abandons the correction and returns a nil snapshot.
+	current := &conf.Settings{}
+	current.Perch.ModelPath = "/srv/my-models/my_own_perch.onnx"
+	current.Perch.LabelPath = "/srv/my-models/my_own_labels.txt"
+
+	origSettings := conf.GetSettings()
+	conf.StoreSettings(current)
+	t.Cleanup(func() { conf.StoreSettings(origSettings) })
+
+	before, err := os.ReadFile(conf.ConfigPath)
+	require.NoError(t, err)
+
+	// The fallback resolved to the installed gallery model, differing from the
+	// configured (missing) custom path.
+	o.applyPathCorrection(&pendingPathCorrection{
+		registryID: RegistryIDPerchV2,
+		resolved: modelFileSet{
+			model:  filepath.Join(modelsDir, "perch-v2", "perch_v2.onnx"),
+			labels: filepath.Join(modelsDir, "perch-v2", "perch_v2_labels.txt"),
+		},
+	})
+
+	list, err := svc.List(nil)
+	require.NoError(t, err)
+	var substituted, reconciled bool
+	for _, n := range list {
+		switch n.TitleKey {
+		case notification.MsgModelPathSubstitutedTitle:
+			substituted = true
+		case notification.MsgModelPathReconciledTitle:
+			reconciled = true
+		}
+	}
+	assert.True(t, substituted,
+		"a user-owned path substituted at runtime must produce the substituted notification")
+	assert.False(t, reconciled,
+		"config was not rewritten, so the reconciled notification must NOT fire")
+
+	assert.Same(t, current, conf.GetSettings(),
+		"a user-owned path must not be rewritten, so no new snapshot is published")
+	after, err := os.ReadFile(conf.ConfigPath)
+	require.NoError(t, err)
+	assert.Equal(t, before, after,
+		"a user-owned path must not be persisted; config.yaml must be unchanged")
 }
 
 // TestResolveFamilyPaths_KeepsConfiguredVariantWhenOnlyCompanionIsMissing

--- a/internal/classifier/model_path_resolution_test.go
+++ b/internal/classifier/model_path_resolution_test.go
@@ -1,0 +1,441 @@
+package classifier
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// labelsRoleLocalName returns the labels file name a catalog variant declares.
+func labelsRoleLocalName(t *testing.T, files []CatalogFile) string {
+	t.Helper()
+	for _, f := range files {
+		if f.Role == RoleLabels {
+			return f.LocalName
+		}
+	}
+	t.Fatalf("variant declares no labels file")
+	return ""
+}
+
+// writeVariantLabelsFile writes a placeholder labels file for a catalog variant
+// and returns its path.
+func writeVariantLabelsFile(t *testing.T, modelsDir string, entry *CatalogEntry, variantID string) string {
+	t.Helper()
+	v := variantByID(t, entry, variantID)
+	subdir := filepath.Join(modelsDir, entry.ID)
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+	labelsPath := filepath.Join(subdir, labelsRoleLocalName(t, v.Files))
+	require.NoError(t, os.WriteFile(labelsPath, []byte("Species1\n"), 0o600))
+	return labelsPath
+}
+
+// TestResolveFamilyPaths_ConfiguredSetPresentIsUsedVerbatim asserts that a
+// complete, on-disk configured set is honoured and no gallery lookup replaces
+// it, so a user's custom model keeps working.
+func TestResolveFamilyPaths_ConfiguredSetPresentIsUsedVerbatim(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	model := filepath.Join(dir, "custom.onnx")
+	labels := filepath.Join(dir, "custom_labels.txt")
+	require.NoError(t, os.WriteFile(model, []byte("m"), 0o600))
+	require.NoError(t, os.WriteFile(labels, []byte("l"), 0o600))
+
+	o := &Orchestrator{}
+	o.SetModelsDir(t.TempDir())
+
+	got, usedFallback := o.resolveFamilyPaths(RegistryIDPerchV2,
+		modelFileSet{model: model, labels: labels}, false)
+
+	assert.False(t, usedFallback, "a present configured set must not trigger the fallback")
+	assert.Equal(t, model, got.model)
+	assert.Equal(t, labels, got.labels)
+}
+
+// TestResolveFamilyPaths_MissingConfiguredPathFallsBackToInstalled covers the
+// GitHub #4201 / #4204 case: settings point at a file that is no longer on disk
+// while a gallery variant is installed. Before the fix the model never loaded.
+func TestResolveFamilyPaths_MissingConfiguredPathFallsBackToInstalled(t *testing.T) {
+	t.Parallel()
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+
+	modelsDir := t.TempDir()
+	installedModel := writeVariantModelFile(t, modelsDir, &entry, "fp32")
+	installedLabels := writeVariantLabelsFile(t, modelsDir, &entry, "fp32")
+
+	o := &Orchestrator{}
+	o.SetModelsDir(modelsDir)
+
+	got, usedFallback := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
+		model:  "/nonexistent/perch_v2.onnx",
+		labels: "/nonexistent/perch_v2_labels.txt",
+	}, false)
+
+	assert.True(t, usedFallback, "a missing configured path must trigger the fallback")
+	assert.Equal(t, installedModel, got.model)
+	assert.Equal(t, installedLabels, got.labels)
+}
+
+// TestResolveFamilyPaths_PartiallyMissingSetIsReplacedAsAUnit is the regression
+// test for the mismatch that per-file resolution produces. With only the labels
+// path stale, a per-file fallback keeps the configured model (variant A) and
+// takes the labels from whichever variant the gallery probe finds first
+// (variant B). That pairing either fails with a label-count mismatch or, when
+// two variants happen to declare the same count, silently mislabels every
+// detection. The whole set must move together.
+func TestResolveFamilyPaths_PartiallyMissingSetIsReplacedAsAUnit(t *testing.T) {
+	t.Parallel()
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+
+	modelsDir := t.TempDir()
+	// Only the fp32 variant is installed; the configured model path names a
+	// different variant's file that still exists on disk.
+	installedModel := writeVariantModelFile(t, modelsDir, &entry, "fp32")
+	installedLabels := writeVariantLabelsFile(t, modelsDir, &entry, "fp32")
+
+	strayDir := t.TempDir()
+	strayModel := filepath.Join(strayDir, "perch_v2_other_variant.onnx")
+	require.NoError(t, os.WriteFile(strayModel, []byte("m"), 0o600))
+
+	o := &Orchestrator{}
+	o.SetModelsDir(modelsDir)
+
+	got, usedFallback := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
+		model:  strayModel,                                    // exists
+		labels: filepath.Join(strayDir, "missing_labels.txt"), // does not
+	}, false)
+
+	require.True(t, usedFallback)
+	assert.Equal(t, installedModel, got.model,
+		"the configured model must be discarded with its missing labels, not paired with fallback labels")
+	assert.Equal(t, installedLabels, got.labels)
+	assert.NotEqual(t, strayModel, got.model,
+		"pairing a configured model with fallback labels from another variant mislabels detections")
+}
+
+// TestResolveFamilyPaths_NothingInstalledKeepsConfiguredSet asserts that when
+// the gallery has nothing to offer, the configured set is returned untouched so
+// the caller still reports its "not installed or configured" error. Returning
+// an empty set here would also destroy the caller's error context, and a set
+// that is only temporarily unreadable (an unmounted volume) must not be
+// silently blanked.
+func TestResolveFamilyPaths_NothingInstalledKeepsConfiguredSet(t *testing.T) {
+	t.Parallel()
+
+	o := &Orchestrator{}
+	o.SetModelsDir(t.TempDir())
+
+	configured := modelFileSet{
+		model:  "/nonexistent/perch_v2.onnx",
+		labels: "/nonexistent/perch_v2_labels.txt",
+	}
+	got, usedFallback := o.resolveFamilyPaths(RegistryIDPerchV2, configured, false)
+
+	assert.False(t, usedFallback)
+	assert.Equal(t, configured, got)
+}
+
+// TestResolveFamilyPaths_BatEmbeddingsParticipateInAtomicity asserts the bat
+// family treats its shared embedding extractor as part of the set: a present
+// classifier and labels with a missing embedding model must still replace the
+// whole set rather than keep two of three configured paths.
+func TestResolveFamilyPaths_BatEmbeddingsParticipateInAtomicity(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	model := filepath.Join(dir, "bat.onnx")
+	labels := filepath.Join(dir, "bat_labels.txt")
+	require.NoError(t, os.WriteFile(model, []byte("m"), 0o600))
+	require.NoError(t, os.WriteFile(labels, []byte("l"), 0o600))
+
+	o := &Orchestrator{}
+	o.SetModelsDir(t.TempDir()) // empty gallery: nothing to fall back to
+
+	configured := modelFileSet{
+		model:      model,
+		labels:     labels,
+		embeddings: filepath.Join(dir, "missing_embeddings.onnx"),
+	}
+	got, usedFallback := o.resolveFamilyPaths(RegistryIDBat, configured, true)
+
+	// No installed bat model, so the configured set comes back untouched, but the
+	// point is that allPresentOnDisk rejected it rather than accepting two of three.
+	assert.False(t, usedFallback)
+	assert.Equal(t, configured, got)
+	assert.False(t, configured.allPresentOnDisk(true),
+		"a set with a missing embedding model must not count as present")
+	assert.True(t, modelFileSet{model: model, labels: labels}.allPresentOnDisk(false),
+		"the same two files are a complete set for a family that needs no embeddings")
+}
+
+// TestIsGalleryManagedPath gates the automatic config repair: only paths the
+// gallery owns may be rewritten, so a user's hand-configured custom model is
+// never taken over.
+func TestIsGalleryManagedPath(t *testing.T) {
+	t.Parallel()
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+	galleryName := modelRoleLocalName(t, variantByID(t, &entry, "fp32").Files)
+
+	modelsDir := t.TempDir()
+	o := &Orchestrator{}
+	o.SetModelsDir(modelsDir)
+
+	t.Run("path under the models directory is gallery managed", func(t *testing.T) {
+		t.Parallel()
+		p := filepath.Join(modelsDir, "perch-v2", "anything.onnx")
+		assert.True(t, o.isGalleryManagedPath(RegistryIDPerchV2, p))
+	})
+
+	t.Run("catalog file name outside the models directory is gallery managed", func(t *testing.T) {
+		t.Parallel()
+		// This is the shape the issues report: the models directory prefix changed
+		// (a different container HOME), so the stale path no longer sits under the
+		// current models dir, but the file name is unmistakably ours.
+		p := "/home/someone-else/.config/birdnet-go/models/perch-v2/" + galleryName
+		assert.True(t, o.isGalleryManagedPath(RegistryIDPerchV2, p))
+	})
+
+	t.Run("a user's custom model is not gallery managed", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, o.isGalleryManagedPath(RegistryIDPerchV2, "/srv/my-models/my_own_perch.onnx"))
+	})
+
+	t.Run("empty path is not gallery managed", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, o.isGalleryManagedPath(RegistryIDPerchV2, ""))
+	})
+}
+
+// TestPlanPathCorrection covers the automatic configuration repair. It exercises
+// planPathCorrection rather than applyPathCorrection deliberately: the latter
+// calls conf.SaveSettings, which would write to the developer's own
+// ~/.config/birdnet-go/config.yaml when the test runs outside a container.
+func TestPlanPathCorrection(t *testing.T) {
+	t.Parallel()
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+	galleryName := modelRoleLocalName(t, variantByID(t, &entry, "fp32").Files)
+
+	newModel := "/models/perch-v2/perch_v2_reunion_no_dft.onnx"
+	newLabels := "/models/perch-v2/perch_v2_reunion_labels.txt"
+
+	t.Run("stale gallery path is repaired", func(t *testing.T) {
+		t.Parallel()
+
+		o := &Orchestrator{}
+		o.SetModelsDir(t.TempDir())
+
+		current := &conf.Settings{}
+		// A path the gallery wrote, under a models directory prefix that no longer
+		// applies: exactly the state a container HOME change leaves behind.
+		stalePath := "/home/birdnet/.config/birdnet-go/models/perch-v2/" + galleryName
+		current.Perch.ModelPath = stalePath
+		current.Perch.LabelPath = "/home/birdnet/.config/birdnet-go/models/perch-v2/perch_v2_labels.txt"
+
+		updated, changed := o.planPathCorrection(current, &pendingPathCorrection{
+			registryID: RegistryIDPerchV2,
+			resolved:   modelFileSet{model: newModel, labels: newLabels},
+		})
+
+		require.True(t, changed)
+		assert.Equal(t, newModel, updated.Perch.ModelPath)
+		assert.NotSame(t, current, updated, "the published snapshot must be a clone, never mutated in place")
+		assert.Equal(t, stalePath, current.Perch.ModelPath,
+			"the input snapshot must be left untouched")
+	})
+
+	t.Run("a user's custom path is left alone", func(t *testing.T) {
+		t.Parallel()
+
+		o := &Orchestrator{}
+		o.SetModelsDir(t.TempDir())
+
+		current := &conf.Settings{}
+		current.Perch.ModelPath = "/srv/my-models/my_own_perch.onnx"
+		current.Perch.LabelPath = "/srv/my-models/my_own_labels.txt"
+
+		_, changed := o.planPathCorrection(current, &pendingPathCorrection{
+			registryID: RegistryIDPerchV2,
+			resolved:   modelFileSet{model: newModel, labels: newLabels},
+		})
+
+		assert.False(t, changed,
+			"a custom model path must never be taken over: it may simply be on a volume that is not mounted yet")
+	})
+
+	t.Run("an empty path is not filled in", func(t *testing.T) {
+		t.Parallel()
+
+		o := &Orchestrator{}
+		o.SetModelsDir(t.TempDir())
+
+		current := &conf.Settings{} // both paths empty: the gallery already owns them
+
+		_, changed := o.planPathCorrection(current, &pendingPathCorrection{
+			registryID: RegistryIDPerchV2,
+			resolved:   modelFileSet{model: newModel, labels: newLabels},
+		})
+
+		assert.False(t, changed,
+			"an empty path already resolves through the gallery; writing an absolute path back would only go stale again")
+	})
+
+	t.Run("bat repairs all three paths including embeddings", func(t *testing.T) {
+		t.Parallel()
+
+		modelsDir := t.TempDir()
+		o := &Orchestrator{}
+		o.SetModelsDir(modelsDir)
+
+		current := &conf.Settings{}
+		current.Bat.ClassifierModel = filepath.Join(modelsDir, "stale_classifier.onnx")
+		current.Bat.LabelPath = filepath.Join(modelsDir, "stale_labels.txt")
+		current.Bat.EmbeddingModel = filepath.Join(modelsDir, "shared", "stale_embeddings.onnx")
+
+		updated, changed := o.planPathCorrection(current, &pendingPathCorrection{
+			registryID: RegistryIDBat,
+			resolved: modelFileSet{
+				model:      "/models/bat/classifier.onnx",
+				labels:     "/models/bat/labels.txt",
+				embeddings: "/models/shared/embeddings.onnx",
+			},
+		})
+
+		require.True(t, changed)
+		assert.Equal(t, "/models/bat/classifier.onnx", updated.Bat.ClassifierModel)
+		assert.Equal(t, "/models/bat/labels.txt", updated.Bat.LabelPath)
+		assert.Equal(t, "/models/shared/embeddings.onnx", updated.Bat.EmbeddingModel,
+			"the shared embedding extractor goes stale with the rest of the set")
+	})
+
+	t.Run("an unknown registry ID changes nothing", func(t *testing.T) {
+		t.Parallel()
+
+		o := &Orchestrator{}
+		o.SetModelsDir(t.TempDir())
+
+		current := &conf.Settings{}
+		current.Perch.ModelPath = "/models/perch-v2/perch_v2.onnx"
+
+		updated, changed := o.planPathCorrection(current, &pendingPathCorrection{
+			registryID: "Not_A_Model",
+			resolved:   modelFileSet{model: newModel, labels: newLabels},
+		})
+
+		assert.False(t, changed)
+		assert.Same(t, current, updated)
+	})
+}
+
+// TestResolveFamilyPaths_KeepsConfiguredVariantWhenOnlyCompanionIsMissing
+// asserts that losing a companion file does not silently switch the user to a
+// different regional variant. Two variants' model files can coexist on disk
+// after a partial cleanup or an interrupted variant switch, and the generic
+// gallery probe returns whichever the catalog lists first. That pairing is
+// internally consistent, so nothing fails loudly, and the user ends up running a
+// model for the wrong region without being told.
+func TestResolveFamilyPaths_KeepsConfiguredVariantWhenOnlyCompanionIsMissing(t *testing.T) {
+	t.Parallel()
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+	require.GreaterOrEqual(t, len(entry.Variants), 2, "this test needs at least two variants")
+
+	// Pick two variants that declare distinct model file names.
+	first := entry.Variants[0]
+	var second CatalogVariant
+	for i := 1; i < len(entry.Variants); i++ {
+		if modelRoleLocalName(t, entry.Variants[i].Files) != modelRoleLocalName(t, first.Files) {
+			second = entry.Variants[i]
+			break
+		}
+	}
+	require.NotEmpty(t, second.ID, "expected a second variant with a distinct model file")
+
+	modelsDir := t.TempDir()
+	// Both variants' models are on disk; only the SECOND variant is the one the
+	// configuration names, and only its labels file is missing.
+	writeVariantModelFile(t, modelsDir, &entry, first.ID)
+	writeVariantLabelsFile(t, modelsDir, &entry, first.ID)
+	configuredModel := writeVariantModelFile(t, modelsDir, &entry, second.ID)
+	expectedLabels := writeVariantLabelsFile(t, modelsDir, &entry, second.ID)
+
+	o := &Orchestrator{}
+	o.SetModelsDir(modelsDir)
+
+	got, _ := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
+		model:  configuredModel,
+		labels: filepath.Join(modelsDir, entry.ID, "gone_labels.txt"),
+	}, false)
+
+	assert.Equal(t, configuredModel, got.model,
+		"the variant the configuration names must be kept when its own files are recoverable")
+	assert.Equal(t, expectedLabels, got.labels,
+		"companion files must come from the SAME variant, not from whichever the catalog lists first")
+}
+
+// TestResolveFamilyPaths_SafeUnderOrchestratorLock guards the lock protocol.
+// resolveFamilyPaths runs inside the secondary model loaders, which hold
+// o.mu.Lock(). sync.RWMutex is not reentrant, so any read lock taken on that
+// path self-deadlocks the whole load: the model never loads, the audio pipeline
+// never registers it, and the process hangs at startup with no error. A first
+// cut of resolveSiblingSet did exactly that, and the unit tests passed because
+// they called it without the lock held.
+func TestResolveFamilyPaths_SafeUnderOrchestratorLock(t *testing.T) {
+	t.Parallel()
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+
+	modelsDir := t.TempDir()
+	installedModel := writeVariantModelFile(t, modelsDir, &entry, "fp32")
+	writeVariantLabelsFile(t, modelsDir, &entry, "fp32")
+
+	o := &Orchestrator{}
+	o.SetModelsDir(modelsDir)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// Exactly how the loaders call it.
+		o.mu.Lock()
+		defer o.mu.Unlock()
+
+		// Fallback path: configured file is absent.
+		_, _ = o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
+			model:  "/nonexistent/perch_v2.onnx",
+			labels: "/nonexistent/perch_v2_labels.txt",
+		}, false)
+
+		// Sibling-recovery path: configured model present, companion missing.
+		_, _ = o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
+			model:  installedModel,
+			labels: filepath.Join(modelsDir, entry.ID, "gone_labels.txt"),
+		}, false)
+
+		// Queueing a correction is also done under the lock.
+		o.queuePathCorrectionIfFallback(RegistryIDPerchV2, modelFileSet{
+			model:  "/nonexistent/perch_v2.onnx",
+			labels: "/nonexistent/perch_v2_labels.txt",
+		}, false)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("resolveFamilyPaths deadlocked while o.mu was held; it must not acquire o.mu")
+	}
+}

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -117,9 +117,12 @@ type Orchestrator struct {
 
 	// pendingPathCorrections queues configuration repairs recorded by model
 	// loaders while they hold o.mu. Drained by runPendingPathCorrections after
-	// o.mu is released, because applying one writes config.yaml (file I/O) and
-	// consults isGalleryManagedPath, which takes o.mu itself. Appended only under
-	// o.mu.Lock(); snapshotted and cleared under o.mu by the drainer.
+	// o.mu is released, because the drainer itself takes o.mu to snapshot and
+	// clear this queue, and o.mu is not reentrant; applying one also writes
+	// config.yaml (file I/O). (isGalleryManagedPath, reached from the apply step,
+	// takes NO orchestrator lock; the drainer's own snapshot-and-clear is what
+	// requires the deferral.) Appended only under o.mu.Lock(); snapshotted and
+	// cleared under o.mu by the drainer.
 	pendingPathCorrections []pendingPathCorrection
 }
 
@@ -2131,11 +2134,12 @@ func (o *Orchestrator) loadAdditionalModels(threadAlloc map[string]int) error {
 		o.runPendingWarmups()
 	}
 
-	// Drain the queued configuration repairs once, AFTER the loop. Applying one
-	// writes config.yaml, so batching them means three stale families produce a
-	// single write instead of three. Unlike the warm-up drain above, the config
-	// write has no per-model RSS measurement to keep accurate, so it does not need
-	// to run inside the loop.
+	// Drain the queued configuration repairs AFTER the loop. Each pending family
+	// still does its own config.yaml write (there is no coalescing here); draining
+	// outside the loop keeps those writes out of the per-model RSS measurement
+	// window, the same reason the warm-up drain above runs where it does. Unlike
+	// the warm-up drain, the config write has no per-model RSS measurement of its
+	// own to keep accurate, so it does not need to run inside the loop.
 	o.runPendingPathCorrections()
 
 	return nil

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -114,6 +114,13 @@ type Orchestrator struct {
 	// instead of stalling PredictModel on o.mu. Appended only
 	// under o.mu.Lock(); snapshotted and cleared under o.mu by the drainer.
 	pendingWarmups []pendingWarmup
+
+	// pendingPathCorrections queues configuration repairs recorded by model
+	// loaders while they hold o.mu. Drained by runPendingPathCorrections after
+	// o.mu is released, because applying one writes config.yaml (file I/O) and
+	// consults isGalleryManagedPath, which takes o.mu itself. Appended only under
+	// o.mu.Lock(); snapshotted and cleared under o.mu by the drainer.
+	pendingPathCorrections []pendingPathCorrection
 }
 
 // pendingWarmup defers a freshly-registered model's warm-up + RSS measurement
@@ -171,6 +178,20 @@ func NewOrchestrator(settings *conf.Settings) (*Orchestrator, error) {
 		models:   map[string]*modelEntry{},
 		modelRSS: make(map[string]int64),
 	}
+
+	// Resolve the gallery models directory up front, before loadAdditionalModels
+	// runs below. ModelManager also sets it (via SetModelsDir) but is constructed
+	// only after this constructor returns, so without this the secondary loaders
+	// see an empty o.modelsDir on their very first attempt and resolveInstalledPaths
+	// cannot find an installed model. That made the fallback for a missing
+	// configured path structurally impossible at startup (GitHub #4201, #4204).
+	// Assigned directly rather than through SetModelsDir: o.primary is not set yet,
+	// so the resolver wiring SetModelsDir performs has nothing to attach to. The
+	// later SetModelsDir call still does that wiring.
+	if modelsDir, ok := settings.ResolveModelsDir(); ok {
+		o.modelsDir = modelsDir
+	}
+
 	rssBefore := o.captureRSSBefore()
 
 	bn, err := NewBirdNET(settings, primaryInfo)
@@ -1631,6 +1652,11 @@ func (o *Orchestrator) LoadModel(registryID string) error {
 	// warm-up and then fails cannot orphan an entry in the queue for a later load.
 	defer o.runPendingWarmups()
 
+	// Drain any queued configuration repair on the same terms: loaders queue it
+	// under o.mu, and applying it writes config.yaml, so it must run after the
+	// lock is released.
+	defer o.runPendingPathCorrections()
+
 	// Build and register the model under o.mu (loaders write directly to
 	// o.models).
 	if err := func() error {
@@ -2091,6 +2117,7 @@ func (o *Orchestrator) loadAdditionalModels(threadAlloc map[string]int) error {
 		// loop) keeps RSS accounting accurate: this model's RSS-after is measured
 		// before the next model allocates its arena.
 		o.runPendingWarmups()
+		o.runPendingPathCorrections()
 	}
 
 	return nil

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -185,9 +185,17 @@ func NewOrchestrator(settings *conf.Settings) (*Orchestrator, error) {
 	// see an empty o.modelsDir on their very first attempt and resolveInstalledPaths
 	// cannot find an installed model. That made the fallback for a missing
 	// configured path structurally impossible at startup (GitHub #4201, #4204).
-	// Assigned directly rather than through SetModelsDir: o.primary is not set yet,
-	// so the resolver wiring SetModelsDir performs has nothing to attach to. The
-	// later SetModelsDir call still does that wiring.
+	// Assigned directly rather than through SetModelsDir. SetModelsDir would run
+	// registerTaxonomyResolver, which appends a taxonomy resolver to
+	// o.nameResolvers, but the constructor overwrites that slice wholesale a few
+	// lines below (o.nameResolvers = []NameResolver{ofResolver, resolver}), so the
+	// registration would just be discarded. Its primary.SetModelsDir propagation is
+	// also skipped here, since o.primary is not set yet. No lock is needed for this
+	// write: o is not published until the constructor returns, so no other goroutine
+	// can observe it. On the analysis startup path ModelManager later calls
+	// SetModelsDir, which redoes both the resolver wiring and the primary
+	// propagation; cmd/benchmark and cmd/rangefilter construct an Orchestrator and
+	// never call SetModelsDir.
 	if modelsDir, ok := settings.ResolveModelsDir(); ok {
 		o.modelsDir = modelsDir
 	}
@@ -1644,18 +1652,22 @@ func (o *Orchestrator) LoadModel(registryID string) error {
 			Build()
 	}
 
+	// Drain any queued configuration repair after o.mu is released: loaders queue
+	// it under o.mu, and applying it writes config.yaml, so it must run outside the
+	// lock. Registered BEFORE the warm-up drain so that, defers being LIFO, it runs
+	// AFTER the warm-ups. The config write must not land inside the window the
+	// per-model RSS delta measures (see runPendingWarmups), matching the drain
+	// order in loadAdditionalModels (warm-ups first, config write after).
+	defer o.runPendingPathCorrections()
+
 	// Drain the deferred warm-up after o.mu is released, on every return path.
 	// Loaders queue the warm-up via deferWarmup while holding o.mu; running it
 	// here (outside o.mu, via the serialized inference path) is what keeps a
 	// runtime install from stalling live inference. Deferring it
 	// (rather than calling it only on success) guarantees a loader that queues a
 	// warm-up and then fails cannot orphan an entry in the queue for a later load.
+	// Registered LAST so it runs FIRST (LIFO).
 	defer o.runPendingWarmups()
-
-	// Drain any queued configuration repair on the same terms: loaders queue it
-	// under o.mu, and applying it writes config.yaml, so it must run after the
-	// lock is released.
-	defer o.runPendingPathCorrections()
 
 	// Build and register the model under o.mu (loaders write directly to
 	// o.models).
@@ -2117,8 +2129,14 @@ func (o *Orchestrator) loadAdditionalModels(threadAlloc map[string]int) error {
 		// loop) keeps RSS accounting accurate: this model's RSS-after is measured
 		// before the next model allocates its arena.
 		o.runPendingWarmups()
-		o.runPendingPathCorrections()
 	}
+
+	// Drain the queued configuration repairs once, AFTER the loop. Applying one
+	// writes config.yaml, so batching them means three stale families produce a
+	// single write instead of three. Unlike the warm-up drain above, the config
+	// write has no per-model RSS measurement to keep accurate, so it does not need
+	// to run inside the loop.
+	o.runPendingPathCorrections()
 
 	return nil
 }

--- a/internal/classifier/orchestrator_bat_onnx.go
+++ b/internal/classifier/orchestrator_bat_onnx.go
@@ -15,22 +15,14 @@ import (
 // The settings snapshot is passed in (rather than read inside) so the caller builds
 // with the exact settings it gated the reload decision on.
 func (o *Orchestrator) buildBat(settings *conf.Settings, threads int) (*Bat, error) {
-	classifierModel := settings.Bat.ClassifierModel
-	labelPath := settings.Bat.LabelPath
-	embeddingModel := settings.Bat.EmbeddingModel
-
-	if classifierModel == "" || labelPath == "" || embeddingModel == "" {
-		m, l, e := o.resolveInstalledPaths(RegistryIDBat)
-		if classifierModel == "" {
-			classifierModel = m
-		}
-		if labelPath == "" {
-			labelPath = l
-		}
-		if embeddingModel == "" {
-			embeddingModel = e
-		}
-	}
+	paths, _ := o.resolveFamilyPaths(RegistryIDBat, modelFileSet{
+		model:      settings.Bat.ClassifierModel,
+		labels:     settings.Bat.LabelPath,
+		embeddings: settings.Bat.EmbeddingModel,
+	}, true)
+	classifierModel := paths.model
+	labelPath := paths.labels
+	embeddingModel := paths.embeddings
 
 	if classifierModel == "" || labelPath == "" || embeddingModel == "" {
 		return nil, errors.Newf("bat model files not installed or configured").
@@ -92,6 +84,14 @@ func (o *Orchestrator) loadBat(threads int) error {
 	// warm-up inference runs via the serialized inference path instead of stalling
 	// live inference on o.mu. The entry is registered above first
 	// so the drainer can find it by key.
+	// Queue a config repair when the model loaded from the gallery fallback
+	// because the configured path was stale. Drained after o.mu is released.
+	o.queuePathCorrectionIfFallback(RegistryIDBat, modelFileSet{
+		model:      settings.Bat.ClassifierModel,
+		labels:     settings.Bat.LabelPath,
+		embeddings: settings.Bat.EmbeddingModel,
+	}, true)
+
 	o.deferWarmup(bat.ModelID(), before)
 
 	GetLogger().Info("Bat model loaded into Orchestrator",

--- a/internal/classifier/orchestrator_bat_onnx.go
+++ b/internal/classifier/orchestrator_bat_onnx.go
@@ -80,10 +80,6 @@ func (o *Orchestrator) loadBat(threads int) error {
 		instance: bat,
 		backend:  secondaryTripletFor(settings),
 	}
-	// Defer the warm-up + RSS measurement until the caller releases o.mu, so the
-	// warm-up inference runs via the serialized inference path instead of stalling
-	// live inference on o.mu. The entry is registered above first
-	// so the drainer can find it by key.
 	// Queue a config repair when the model loaded from the gallery fallback
 	// because the configured path was stale. Drained after o.mu is released.
 	o.queuePathCorrectionIfFallback(RegistryIDBat, modelFileSet{
@@ -92,6 +88,10 @@ func (o *Orchestrator) loadBat(threads int) error {
 		embeddings: settings.Bat.EmbeddingModel,
 	}, true)
 
+	// Defer the warm-up + RSS measurement until the caller releases o.mu, so the
+	// warm-up inference runs via the serialized inference path instead of stalling
+	// live inference on o.mu. The entry is registered above first
+	// so the drainer can find it by key.
 	o.deferWarmup(bat.ModelID(), before)
 
 	GetLogger().Info("Bat model loaded into Orchestrator",

--- a/internal/classifier/orchestrator_birdnet_v3_onnx.go
+++ b/internal/classifier/orchestrator_birdnet_v3_onnx.go
@@ -76,10 +76,6 @@ func (o *Orchestrator) loadBirdNETV3(threads int) error {
 		instance: model,
 		backend:  secondaryTripletFor(settings),
 	}
-	// Defer the warm-up + RSS measurement until the caller releases o.mu, so the
-	// warm-up inference runs via the serialized inference path instead of stalling
-	// live inference on o.mu. The entry is registered above first so the drainer
-	// can find it by key.
 	// Queue a config repair when the model loaded from the gallery fallback
 	// because the configured path was stale. Drained after o.mu is released.
 	o.queuePathCorrectionIfFallback(RegistryIDBirdNETV3, modelFileSet{
@@ -87,6 +83,10 @@ func (o *Orchestrator) loadBirdNETV3(threads int) error {
 		labels: settings.BirdNETV3.LabelPath,
 	}, false)
 
+	// Defer the warm-up + RSS measurement until the caller releases o.mu, so the
+	// warm-up inference runs via the serialized inference path instead of stalling
+	// live inference on o.mu. The entry is registered above first so the drainer
+	// can find it by key.
 	o.deferWarmup(model.ModelID(), before)
 
 	// No separate name resolver needed. BirdNET v3.0 labels carry both the

--- a/internal/classifier/orchestrator_birdnet_v3_onnx.go
+++ b/internal/classifier/orchestrator_birdnet_v3_onnx.go
@@ -16,18 +16,12 @@ import (
 // The settings snapshot is passed in (rather than read inside) so the caller
 // builds with the exact settings it gated the reload decision on.
 func (o *Orchestrator) buildBirdNETV3(settings *conf.Settings, threads int) (*BirdNETV3, error) {
-	modelPath := settings.BirdNETV3.ModelPath
-	labelPath := settings.BirdNETV3.LabelPath
-
-	if modelPath == "" || labelPath == "" {
-		m, l, _ := o.resolveInstalledPaths(RegistryIDBirdNETV3)
-		if modelPath == "" {
-			modelPath = m
-		}
-		if labelPath == "" {
-			labelPath = l
-		}
-	}
+	paths, _ := o.resolveFamilyPaths(RegistryIDBirdNETV3, modelFileSet{
+		model:  settings.BirdNETV3.ModelPath,
+		labels: settings.BirdNETV3.LabelPath,
+	}, false)
+	modelPath := paths.model
+	labelPath := paths.labels
 
 	if modelPath == "" || labelPath == "" {
 		return nil, errors.Newf("BirdNET v3.0 model files not installed or configured").
@@ -86,6 +80,13 @@ func (o *Orchestrator) loadBirdNETV3(threads int) error {
 	// warm-up inference runs via the serialized inference path instead of stalling
 	// live inference on o.mu. The entry is registered above first so the drainer
 	// can find it by key.
+	// Queue a config repair when the model loaded from the gallery fallback
+	// because the configured path was stale. Drained after o.mu is released.
+	o.queuePathCorrectionIfFallback(RegistryIDBirdNETV3, modelFileSet{
+		model:  settings.BirdNETV3.ModelPath,
+		labels: settings.BirdNETV3.LabelPath,
+	}, false)
+
 	o.deferWarmup(model.ModelID(), before)
 
 	// No separate name resolver needed. BirdNET v3.0 labels carry both the

--- a/internal/classifier/orchestrator_perch_onnx.go
+++ b/internal/classifier/orchestrator_perch_onnx.go
@@ -16,18 +16,12 @@ import (
 // The settings snapshot is passed in (rather than read inside) so the caller
 // builds with the exact settings it gated the reload decision on.
 func (o *Orchestrator) buildPerch(settings *conf.Settings, threads int) (*Perch, error) {
-	modelPath := settings.Perch.ModelPath
-	labelPath := settings.Perch.LabelPath
-
-	if modelPath == "" || labelPath == "" {
-		m, l, _ := o.resolveInstalledPaths(RegistryIDPerchV2)
-		if modelPath == "" {
-			modelPath = m
-		}
-		if labelPath == "" {
-			labelPath = l
-		}
-	}
+	paths, _ := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
+		model:  settings.Perch.ModelPath,
+		labels: settings.Perch.LabelPath,
+	}, false)
+	modelPath := paths.model
+	labelPath := paths.labels
 
 	if modelPath == "" || labelPath == "" {
 		return nil, errors.Newf("Perch v2 model files not installed or configured").
@@ -82,6 +76,13 @@ func (o *Orchestrator) loadPerch(threads int) error {
 		instance: perch,
 		backend:  secondaryTripletFor(settings),
 	}
+	// Queue a config repair when the model loaded from the gallery fallback
+	// because the configured path was stale. Drained after o.mu is released.
+	o.queuePathCorrectionIfFallback(RegistryIDPerchV2, modelFileSet{
+		model:  settings.Perch.ModelPath,
+		labels: settings.Perch.LabelPath,
+	}, false)
+
 	// Defer the warm-up + RSS measurement until the caller releases o.mu, so the
 	// warm-up inference runs via the serialized inference path instead of stalling
 	// live inference on o.mu. The entry is registered above first

--- a/internal/notification/message_keys.go
+++ b/internal/notification/message_keys.go
@@ -177,4 +177,15 @@ const (
 	MsgModelRegionStaleTitle         = "notifications.content.region.staleTitle"
 	MsgModelRegionStaleMessage       = "notifications.content.region.staleMessage"
 	MsgModelRegionStaleGlobalMessage = "notifications.content.region.staleGlobalMessage"
+
+	// Model path reconciliation notifications (a configured model file path
+	// pointed at a file that no longer exists and was repaired to the installed
+	// gallery model)
+	MsgModelPathReconciledTitle   = "notifications.content.modelPath.reconciledTitle"
+	MsgModelPathReconciledMessage = "notifications.content.modelPath.reconciledMessage"
+
+	// Model registration notifications (a model assigned to an audio source is
+	// not receiving audio, so it produces no detections)
+	MsgModelNotRegisteredTitle   = "notifications.content.modelPath.notRegisteredTitle"
+	MsgModelNotRegisteredMessage = "notifications.content.modelPath.notRegisteredMessage"
 )

--- a/internal/notification/message_keys.go
+++ b/internal/notification/message_keys.go
@@ -184,6 +184,13 @@ const (
 	MsgModelPathReconciledTitle   = "notifications.content.modelPath.reconciledTitle"
 	MsgModelPathReconciledMessage = "notifications.content.modelPath.reconciledMessage"
 
+	// Model path substitution notifications (a configured model file path pointed
+	// at a file that no longer exists; the installed gallery model was used at
+	// runtime instead, but the configuration was deliberately left unchanged
+	// because the path is user-owned)
+	MsgModelPathSubstitutedTitle   = "notifications.content.modelPath.substitutedTitle"
+	MsgModelPathSubstitutedMessage = "notifications.content.modelPath.substitutedMessage"
+
 	// Model registration notifications (a model assigned to an audio source is
 	// not receiving audio, so it produces no detections)
 	MsgModelNotRegisteredTitle   = "notifications.content.modelPath.notRegisteredTitle"


### PR DESCRIPTION
## Summary

Perch v2 stopped running after a container restart and only came back after a gallery reinstall plus a manual deselect and reselect of the model against the audio source. Three independent defects combined to produce that, and this fixes all three.

**Loading.** `buildPerch`, `buildBirdNETV3` and `buildBat` fell back to the installed gallery model only when the configured path string was empty. A non-empty path pointing at a file that no longer exists therefore blocked the model permanently, and the retry-after-gallery-scan recovery could not help because it re-read the same configuration. That is what a gallery variant switch, or a container HOME change that invalidates a stored absolute path, produced in practice. The three loaders now resolve model, labels and embeddings as one atomic set, discarding the whole configured set when a member is confirmed missing, so a configured model can never be paired with another variant's labels. When only a companion file is missing, the variant the configuration names is preferred over whichever the catalog lists first, so a partial cleanup does not silently switch the user to a different regional model. The models directory is now resolved in `NewOrchestrator`, before the secondary loaders run; it was previously set only when `ModelManager` was constructed afterwards, which left the fallback with nothing to find on its first attempt.

**Self-heal.** After a model loads from the fallback, the stale path in `config.yaml` is rewritten to the resolved one and the user is notified, so an existing install repairs itself on the first start after the update with no manual edit and no reinstall. The guard is deliberately conservative: only paths the gallery itself wrote are rewritten, a path is never cleared when nothing was found, only `fs.ErrNotExist` counts as absent so a permissions failure or a half-initialised mount falls back at runtime without touching configuration, and the whole correction is abandoned if any single field turns out to be user-owned rather than repairing the rest around it.

**Registration.** A model loaded at runtime by the gallery was never attached to already-running audio sources. The topology-changed callback only drove an SSE broadcast, so an installed model received no audio until some unrelated settings change forced a reconfigure. It now also signals `reconfigure_audio_sources`, debounced so a variant switch reconfigures once rather than twice.

**Visibility.** The inference status reported a source as attached to a model from configuration alone, so the UI could show a model running while it analyzed nothing, which is why the original problem went unnoticed for days. Attachment is now read from the audio router's actual per-source analysis buffers, and a source that is assigned but not fed is marked `notRunning` in the API and badged in the UI. A model that configuration assigns to a source but that never reaches the router now raises a notification instead of only a log line.

## Data-loss paths closed during review

The first implementation of the self-heal introduced three ways to lose a user's configuration. Two were confirmed by running a real instance, not only by reading the code, and all three are fixed here.

The repair was atomic when resolving but not when persisting: each path field was vetoed independently, so a family with one gallery-managed path and one custom path was written back as a cross-variant hybrid of gallery model plus user labels. That hybrid then looks healthy on every later start, because both files exist, so it is never re-examined.

`isGalleryManagedPath` accepted any path whose basename and parent directory name matched the gallery layout, deliberately dropping the models-directory prefix so a changed container HOME would still match. That also accepted a user's own mirror of the layout. An absent network mount reports `ErrNotExist` rather than a permission error, so such a path classified as stale and, with a local copy present, was permanently replaced. The predicate now also requires the grandparent to be the models directory, matching the stricter precedent already set by `MigrateOrphanGeomodelRangeFilter`.

Constructing an `Orchestrator` drains the correction queue, so `benchmark` and `range print` rewrote `config.yaml` as a side effect of two read-only diagnostic commands. Both now suppress persistence before construction, which is the only point early enough, because the first drain happens inside `NewOrchestrator` itself.

Separately, a fallback that could not be persisted was silent: the model was substituted but nothing was reported, because the notification only fired when the config was actually rewritten. A user whose custom path went missing therefore ran the stock gallery model with detections attributed to a model they never chose. A distinct notification now covers that case in all 16 locales.

## Testing

`go build ./...`, `golangci-lint run` and `npm run check:all` are clean, and `go test -race` passes across the touched packages. The change adds roughly 1000 lines of tests covering each resolution outcome separately: a healthy configured set used verbatim, a missing path falling back, a partially missing set replaced as a unit, an empty member filled while a missing member is replaced, a companion-only miss keeping the configured variant, an indeterminate stat error falling back without repairing configuration, bat embeddings participating in atomicity, and resolution under the orchestrator lock. Two config-write short-circuits that no existing test could kill are now covered, and the frontend gains five tests for the new badge including the absent-versus-false contract that `omitempty` creates.

Beyond unit tests, the fix was validated against a real instance driven by the genuine 409 MB Perch artifacts, with a scenario that reproduces the reported failure on `main` and passes here. The same harness covers the three data-loss guards above; each one fails on a build without the fix and passes with it, so the scenarios discriminate rather than merely passing.

The `presenceIndeterminate` test is skipped on Windows, where `ERROR_PATH_NOT_FOUND` maps to `fs.ErrNotExist` and inverts the branch under test. Two test failures visible on this branch, `TestGetInferenceStatus_HTTP200` under `-tags noembed,skipfrontend,notflite` and the ntfy tests under `-tags integration`, are equally present on `main`, verified against a clean worktree, so they are not introduced here.

## Known follow-ups, not addressed here

The new "not analyzing" badge measures 3.76:1 contrast in light theme and 3.70:1 in dark against an 11px label, so it does not meet the WCAG AA 4.5:1 requirement for normal text. Its explanation is also reachable only by hover, since nothing in the card is focusable, which leaves keyboard and touch users with a red chip and no cause. The card header can additionally read "Idle" while the badge reads "not analyzing", and the remediation copy points at the model gallery, which has no per-source liveness view. These are visual and copy decisions rather than correctness ones, so they are left for a follow-up rather than folded into an already large change.

## Related Issues

Fixes #4201
Fixes #4204

Supersedes #4205, which addresses a subset of this by adding `os.Stat` existence checks to the same three loaders. That approach resolves each file independently, which is the cross-variant pairing this change specifically prevents, and it does not cover the registration or visibility halves of the reported problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery for missing or outdated model files, with notifications when paths are repaired or substituted.
  * Inference status now identifies configured audio sources that are not currently receiving audio.
  * Added diagnostics and tooltips explaining inactive model sources.
  * Model and audio-source changes now refresh inference status automatically.

* **Bug Fixes**
  * Read-only diagnostics no longer modify saved configuration while resolving model paths.
  * Improved handling of incomplete, unavailable, or unloaded model configurations.

* **Localization**
  * Added translations for model-path notifications and inactive-source status across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Release notes
- audience: user
- summary: Perch v2 and other secondary models no longer stop working after a container restart or a model variant switch, and a model installed from the gallery now starts analyzing straight away instead of staying silent until an unrelated settings change
- feature: hardware- and region-aware model gallery
- breaking: none
- config: no new settings keys. Behaviour change worth noting in the notes: when a gallery-installed model path in config.yaml points at a file that no longer exists, BirdNET-Go now repairs that path automatically on startup and tells the user. Only paths the gallery itself wrote are touched, never a custom path, and nothing is rewritten when the file is merely unreadable rather than confirmed missing. As with any settings write, the rewrite reformats config.yaml and does not preserve comments
- schema: none
