### PR TITLE
fix(classifier): preserve privacy labels beyond top-k

### DIFF
--- a/internal/analysis/process.go
+++ b/internal/analysis/process.go
@@ -309,10 +309,15 @@ func ProcessData(ctx context.Context, bn *classifier.Orchestrator, bufMgr *buffe
 			Build()
 	}
 
+	// Keep lower-ranked human/dog labels available to the filters without mixing
+	// them into the normal top-ranked results used by metrics, diagnostics, and
+	// additional-prediction persistence.
+	topResults, filterSignals := classifier.SplitFilterSignals(results)
+
 	log.Debug("ProcessData inference complete",
 		logger.String("source", source),
 		logger.String("model_id", modelID),
-		logger.Int("result_count", len(results)),
+		logger.Int("result_count", len(topResults)),
 		logger.Duration("inference_duration", inferenceDuration),
 		logger.Int("sample_bytes", len(data)))
 
@@ -321,14 +326,14 @@ func ProcessData(ctx context.Context, bn *classifier.Orchestrator, bufMgr *buffe
 
 	// Record result count metric
 	if pm != nil {
-		pm.RecordBirdNETResults(source, len(results))
+		pm.RecordBirdNETResults(source, len(topResults))
 	}
 
 	// DEBUG print all BirdNET results
 	if conf.Setting().BirdNET.Debug {
 		debugThreshold := float32(0) // set to 0 for now, maybe add a config option later
 		hasHighConfidenceResults := false
-		for _, result := range results {
+		for _, result := range topResults {
 			if result.Confidence > debugThreshold {
 				hasHighConfidenceResults = true
 				break
@@ -338,7 +343,7 @@ func ProcessData(ctx context.Context, bn *classifier.Orchestrator, bufMgr *buffe
 		if hasHighConfidenceResults {
 			log.Debug("birdnet results",
 				logger.String("source", source))
-			for _, result := range results {
+			for _, result := range topResults {
 				if result.Confidence > debugThreshold {
 					log.Debug("birdnet result",
 						logger.Float64("confidence", float64(result.Confidence)),
@@ -394,7 +399,8 @@ func ProcessData(ctx context.Context, bn *classifier.Orchestrator, bufMgr *buffe
 		AudioCapturedAt: audioCapturedAt,
 		ElapsedTime:     elapsedTime,
 		PCMdata:         pcmCopy,
-		Results:         results,
+		Results:         topResults,
+		FilterSignals:   filterSignals,
 		Source:          audioSource,
 		ModelID:         modelID,
 	}
@@ -407,7 +413,7 @@ func ProcessData(ctx context.Context, bn *classifier.Orchestrator, bufMgr *buffe
 		log.Debug("ProcessData queued results",
 			logger.String("source", source),
 			logger.String("model_id", modelID),
-			logger.Int("result_count", len(results)))
+			logger.Int("result_count", len(topResults)))
 		if pm != nil {
 			pm.RecordAudioQueueOperation(source, "enqueue", "success")
 		}

--- a/internal/analysis/process.go
+++ b/internal/analysis/process.go
@@ -312,7 +312,7 @@ func ProcessData(ctx context.Context, bn *classifier.Orchestrator, bufMgr *buffe
 	// Keep lower-ranked human/dog labels available to the filters without mixing
 	// them into the normal top-ranked results used by metrics, diagnostics, and
 	// additional-prediction persistence.
-	topResults, filterSignals := classifier.SplitFilterSignals(results)
+	topResults, filterSignals := classifier.SplitFilterSignals(results, classifier.DefaultTopKResults)
 
 	log.Debug("ProcessData inference complete",
 		logger.String("source", source),

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -816,6 +816,11 @@ func (p *Processor) processDetections(item classifier.Results) {
 //
 //nolint:gocritic // hugeParam: Pass by value is intentional - avoids pointer dereferencing in hot path
 func (p *Processor) processResults(settings *conf.Settings, item classifier.Results) []Detections {
+	// Process lower-ranked human/dog signals before normal detections. They can
+	// trigger their filters but remain outside item.Results, so they cannot leak
+	// into persisted additional predictions.
+	p.processFilterSignals(settings, &item)
+
 	// Pre-allocate slice with capacity for all results
 	detections := make([]Detections, 0, len(item.Results))
 
@@ -1339,6 +1344,16 @@ func (p *Processor) handleHumanDetection(settings *conf.Settings, item classifie
 		p.detectionMutex.Lock()
 		p.LastHumanDetection[item.Source.ID] = HumanDetection{Time: item.StartTime, Trigger: metrics.TriggerLabel}
 		p.detectionMutex.Unlock()
+	}
+}
+
+// processFilterSignals applies the privacy and dog-bark handlers to signals
+// retained below the normal top-k boundary. These signals deliberately bypass
+// detection creation and additional-result persistence.
+func (p *Processor) processFilterSignals(settings *conf.Settings, item *classifier.Results) {
+	for _, result := range item.FilterSignals {
+		p.handleDogDetection(settings, *item, result)
+		p.handleHumanDetection(settings, *item, result)
 	}
 }
 

--- a/internal/analysis/processor/vocalization_labels.go
+++ b/internal/analysis/processor/vocalization_labels.go
@@ -20,76 +20,22 @@
 //  3. Perch v2 (trained on iNaturalist 2024 + FSD50K) emits AudioSet-ontology
 //     sound classes ("Speech", "Bark", "Growling", ...) that carry no "human"/
 //     "dog" token at all, and whose underscore-joined forms ("Human_voice")
-//     SplitSpeciesName mangles into "voice". Those are matched exactly against
-//     the raw label here. The Perch/AudioSet (FSD50K) human-sound classes are
-//     handled by the shared nonbird package (CategoryHuman); only the
-//     iNaturalist taxon "homo sapiens" requires a local extra-labels map.
+//     SplitSpeciesName mangles into "voice". The shared nonbird package matches
+//     those full raw labels along with the iNaturalist human and dog taxa.
 //
-// Matching is case-insensitive: the raw label is lowercased once and compared
-// against the lowercase keys / prefixes below, so a custom or future label file
-// with different casing still engages the filters.
+// Matching is case-insensitive, so a custom or future label file with different
+// casing still engages the filters.
 package processor
 
 import (
-	"strings"
-
 	"github.com/tphakala/birdnet-go/internal/labels/nonbird"
 )
-
-const (
-	// birdnetHumanLabelPrefix matches BirdNET's human classes by the English
-	// scientific portion of the raw label ("Human vocal_...", "Human non-vocal_...",
-	// "Human whistle_..."), which is the same across every locale. The trailing
-	// space is load-bearing: "human vocal" matches, but the cicada "Pacarina
-	// schumanni" (which contains the substring "human") does not.
-	birdnetHumanLabelPrefix = "human "
-	// birdnetDogLabelPrefix matches BirdNET's "Dog" class by its raw-label form
-	// "Dog_<localized common name>" (e.g. "Dog_Dog", "Dog_Hund"). The underscore
-	// is load-bearing: the class matches, but the katydid "Poecilimon doga"
-	// (which contains the substring "dog") does not.
-	birdnetDogLabelPrefix = "dog_"
-)
-
-// perchHumanExtraLabels holds human labels that the shared nonbird package does
-// not cover: iNaturalist taxa (not AudioSet/FSD50K sound classes). Keys are
-// lowercase.
-//
-//nolint:gochecknoglobals // immutable lookup table, read-only after init
-var perchHumanExtraLabels = map[string]struct{}{
-	"homo sapiens": {}, // human detected as a species (iNaturalist taxon), not a sound class
-}
-
-// perchDogLabels enumerates the raw Perch v2 labels treated as a dog by the dog
-// bark filter: the FSD50K dog sound classes plus the domestic dog taxon. Wild
-// canids (wolf, coyote, jackal) are intentionally excluded so they remain
-// detectable as wildlife rather than being suppressed as background barking.
-// "Growling" is the AudioSet child of the Dog class (dog growling), so it stays.
-// Keys are lowercase; lookups lowercase the raw label first (see isDogDetection).
-//
-//nolint:gochecknoglobals // immutable lookup table, read-only after init
-var perchDogLabels = map[string]struct{}{
-	"dog":              {}, // FSD50K dog
-	"bark":             {}, // FSD50K bark
-	"growling":         {}, // FSD50K dog growl (AudioSet child of Dog)
-	"canis familiaris": {}, // domestic dog (iNaturalist taxon)
-}
 
 // isHumanVocalization reports whether a raw classifier label represents a human
 // sound that should engage the privacy filter. rawLabel is the untransformed
 // result.Species value. Matching is case-insensitive.
-//
-// The AudioSet/FSD50K portion is delegated to the shared nonbird package
-// (nonbird.CategoryHuman). The iNaturalist taxon "homo sapiens" and the
-// BirdNET locale-stable prefix are handled locally.
 func isHumanVocalization(rawLabel string) bool {
-	if cat, ok := nonbird.CategoryOf(rawLabel); ok && cat == nonbird.CategoryHuman {
-		return true
-	}
-	lowered := strings.ToLower(rawLabel)
-	if _, ok := perchHumanExtraLabels[lowered]; ok {
-		return true
-	}
-	return strings.HasPrefix(lowered, birdnetHumanLabelPrefix)
+	return nonbird.IsHumanVocalization(rawLabel)
 }
 
 // isDogDetection reports whether a raw classifier label represents a dog for the
@@ -97,9 +43,5 @@ func isHumanVocalization(rawLabel string) bool {
 // is case-insensitive: Perch v2 classes are matched exactly; BirdNET's "Dog"
 // class is matched by the locale-stable English label prefix.
 func isDogDetection(rawLabel string) bool {
-	lowered := strings.ToLower(rawLabel)
-	if _, ok := perchDogLabels[lowered]; ok {
-		return true
-	}
-	return strings.HasPrefix(lowered, birdnetDogLabelPrefix)
+	return nonbird.IsDogDetection(rawLabel)
 }

--- a/internal/analysis/processor/vocalization_labels_test.go
+++ b/internal/analysis/processor/vocalization_labels_test.go
@@ -203,6 +203,47 @@ func TestDetectionHandlers_RecordTimestamp(t *testing.T) {
 	}
 }
 
+func TestFilterSignalsTriggerFiltersWithoutBecomingAdditionalResults(t *testing.T) {
+	t.Parallel()
+
+	const source = "src1"
+	start := time.Date(2026, 6, 19, 8, 0, 0, 0, time.UTC)
+	settings := &conf.Settings{}
+	settings.Realtime.PrivacyFilter.Enabled = true
+	settings.Realtime.PrivacyFilter.Confidence = 0.05
+	settings.Realtime.DogBarkFilter.Enabled = true
+	settings.Realtime.DogBarkFilter.Confidence = 0.05
+
+	p := &Processor{
+		LastHumanDetection: make(map[string]HumanDetection),
+		LastDogDetection:   make(map[string]time.Time),
+	}
+	item := classifier.Results{
+		StartTime: start,
+		Results: []datastore.Results{
+			{Species: "Turdus merula_Common blackbird", Confidence: 0.9},
+			{Species: "Parus major_Great tit", Confidence: 0.8},
+		},
+		FilterSignals: []datastore.Results{
+			{Species: "Speech", Confidence: 0.09},
+			{Species: "Bark", Confidence: 0.08},
+		},
+	}
+	item.Source.ID = source
+
+	p.processFilterSignals(settings, &item)
+
+	human, ok := p.LastHumanDetection[source]
+	require.True(t, ok)
+	assert.Equal(t, start, human.Time)
+	assert.Equal(t, start, p.LastDogDetection[source])
+
+	additional := convertToAdditionalResults(item.Results, "Turdus merula")
+	require.Len(t, additional, 1)
+	assert.Equal(t, "Parus major", additional[0].Species.ScientificName)
+	assert.Equal(t, "Parus major_Great tit", additional[0].RawLabel)
+}
+
 // TestPerchHumanLabelsParityWithNonbird verifies that every AudioSet/FSD50K key
 // previously handled by the processor is classified as CategoryHuman by the
 // shared nonbird package. A failure here means a coverage regression: a label

--- a/internal/analysis/processor/vocalization_labels_test.go
+++ b/internal/analysis/processor/vocalization_labels_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
@@ -220,10 +221,6 @@ func TestFilterSignalsTriggerFiltersWithoutBecomingAdditionalResults(t *testing.
 	}
 	item := classifier.Results{
 		StartTime: start,
-		Results: []datastore.Results{
-			{Species: "Turdus merula_Common blackbird", Confidence: 0.9},
-			{Species: "Parus major_Great tit", Confidence: 0.8},
-		},
 		FilterSignals: []datastore.Results{
 			{Species: "Speech", Confidence: 0.09},
 			{Species: "Bark", Confidence: 0.08},
@@ -231,17 +228,13 @@ func TestFilterSignalsTriggerFiltersWithoutBecomingAdditionalResults(t *testing.
 	}
 	item.Source.ID = source
 
-	p.processFilterSignals(settings, &item)
+	detections := p.processResults(settings, item)
 
 	human, ok := p.LastHumanDetection[source]
 	require.True(t, ok)
 	assert.Equal(t, start, human.Time)
 	assert.Equal(t, start, p.LastDogDetection[source])
-
-	additional := convertToAdditionalResults(item.Results, "Turdus merula")
-	require.Len(t, additional, 1)
-	assert.Equal(t, "Parus major", additional[0].Species.ScientificName)
-	assert.Equal(t, "Parus major_Great tit", additional[0].RawLabel)
+	assert.Empty(t, detections, "filter-only signals must not become persisted detections or additional results")
 }
 
 // TestPerchHumanLabelsParityWithNonbird verifies that every AudioSet/FSD50K key

--- a/internal/analysis/processor/vocalization_labels_test.go
+++ b/internal/analysis/processor/vocalization_labels_test.go
@@ -203,9 +203,8 @@ func TestDetectionHandlers_RecordTimestamp(t *testing.T) {
 	}
 }
 
-// TestPerchHumanLabelsParityWithNonbird verifies that every key previously in
-// perchHumanLabels (except "homo sapiens", which is the iNaturalist taxon
-// preserved in perchHumanExtraLabels) is classified as CategoryHuman by the
+// TestPerchHumanLabelsParityWithNonbird verifies that every AudioSet/FSD50K key
+// previously handled by the processor is classified as CategoryHuman by the
 // shared nonbird package. A failure here means a coverage regression: a label
 // that used to engage the privacy filter would silently stop doing so.
 func TestPerchHumanLabelsParityWithNonbird(t *testing.T) {
@@ -213,7 +212,7 @@ func TestPerchHumanLabelsParityWithNonbird(t *testing.T) {
 
 	// The complete former perchHumanLabels key set (37 entries minus "homo sapiens").
 	// "homo sapiens" is excluded: it is an iNaturalist taxon, not an AudioSet/FSD50K
-	// sound class, so nonbird does not include it. It lives in perchHumanExtraLabels.
+	// sound class, and IsHumanVocalization handles it directly.
 	oldAudioSetKeys := []string{
 		"speech",
 		"speech_synthesizer",

--- a/internal/classifier/analyze.go
+++ b/internal/classifier/analyze.go
@@ -97,7 +97,7 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 	}
 
 	// Select the top predictions while retaining labels required by downstream filters.
-	topResults := getTopKResults(results, defaultTopKResults)
+	topResults := getTopKResults(results, DefaultTopKResults)
 
 	// Log prediction timing for performance monitoring
 	duration := time.Since(start)
@@ -303,8 +303,9 @@ func getTopKResults(results []datastore.Results, k int) []datastore.Results {
 // lower-ranked signals retained solely for the privacy and dog-bark filters.
 // Model Predict implementations return the two slices as one ownership-safe
 // allocation; the analysis queue splits it before persistence processing.
-func SplitFilterSignals(results []datastore.Results) (topResults, filterSignals []datastore.Results) {
-	n := min(defaultTopKResults, len(results))
+// normalResultCount must match the limit passed to getTopKResults by the model.
+func SplitFilterSignals(results []datastore.Results, normalResultCount int) (topResults, filterSignals []datastore.Results) {
+	n := min(max(normalResultCount, 0), len(results))
 	// Cap the top slice at its length so an append by a future queue consumer
 	// cannot overwrite the adjacent filter-signal tail.
 	return results[:n:n], results[n:]

--- a/internal/classifier/analyze.go
+++ b/internal/classifier/analyze.go
@@ -216,8 +216,9 @@ func trimResultsToMax(results []datastore.Results, maxResults int) []datastore.R
 	return results
 }
 
-// getTopKResults returns the top k results plus any lower-ranked labels required
-// by the privacy or dog-bark filters. It avoids fully sorting the input array.
+// getTopKResults returns the top k results plus the strongest lower-ranked label
+// for each filter family not already represented in the top k. It avoids fully
+// sorting the input array.
 func getTopKResults(results []datastore.Results, k int) []datastore.Results {
 	if len(results) == 0 || k <= 0 {
 		return []datastore.Results{}
@@ -237,15 +238,36 @@ func getTopKResults(results []datastore.Results, k int) []datastore.Results {
 	}
 
 	// A human or dog label can score below the top-k boundary while still exceeding
-	// its filter's configured threshold. Preserve those labels so the processor can
-	// evaluate the filters instead of losing the signal during ranking. Compact the
-	// retained tail in place so the returned copy can still use one exact allocation.
-	retained := n
+	// its filter's configured threshold. One strongest signal per family is enough:
+	// both filters compare every matching label against one family-wide threshold.
+	// If the top-k prefix already contains that family, every tail score is less than
+	// or equal to the retained score and cannot change the filter decision.
+	hasHuman, hasDog := false, false
+	for i := range n {
+		hasHuman = hasHuman || nonbird.IsHumanVocalization(results[i].Species)
+		hasDog = hasDog || nonbird.IsDogDetection(results[i].Species)
+	}
+
+	var bestHuman, bestDog datastore.Results
+	haveHuman, haveDog := false, false
 	for i := n; i < len(results); i++ {
-		if shouldPreserveFilterLabel(results[i].Species) {
-			results[retained], results[i] = results[i], results[retained]
-			retained++
+		candidate := results[i]
+		if !hasHuman && nonbird.IsHumanVocalization(candidate.Species) &&
+			(!haveHuman || candidate.Confidence > bestHuman.Confidence) {
+			bestHuman, haveHuman = candidate, true
 		}
+		if !hasDog && nonbird.IsDogDetection(candidate.Species) &&
+			(!haveDog || candidate.Confidence > bestDog.Confidence) {
+			bestDog, haveDog = candidate, true
+		}
+	}
+
+	retained := n
+	if haveHuman {
+		retained++
+	}
+	if haveDog {
+		retained++
 	}
 
 	// Return a freshly-allocated copy so the result never aliases the caller's
@@ -260,7 +282,15 @@ func getTopKResults(results []datastore.Results, k int) []datastore.Results {
 	// normally small, and the upstream large-buffer reuse optimization stays intact:
 	// bn.resultsBuffer remains internal scratch that never escapes.
 	out := make([]datastore.Results, retained)
-	copy(out, results[:retained])
+	copy(out, results[:n])
+	next := n
+	if haveHuman {
+		out[next] = bestHuman
+		next++
+	}
+	if haveDog {
+		out[next] = bestDog
+	}
 
 	// The top-k prefix is already sorted. Every retained tail result ranks at or
 	// below that prefix, so sorting only the retained tail preserves the full
@@ -269,8 +299,15 @@ func getTopKResults(results []datastore.Results, k int) []datastore.Results {
 	return out
 }
 
-func shouldPreserveFilterLabel(rawLabel string) bool {
-	return nonbird.IsHumanVocalization(rawLabel) || nonbird.IsDogDetection(rawLabel)
+// SplitFilterSignals separates the normal top-k prediction set from the extra
+// lower-ranked signals retained solely for the privacy and dog-bark filters.
+// Model Predict implementations return the two slices as one ownership-safe
+// allocation; the analysis queue splits it before persistence processing.
+func SplitFilterSignals(results []datastore.Results) (topResults, filterSignals []datastore.Results) {
+	n := min(defaultTopKResults, len(results))
+	// Cap the top slice at its length so an append by a future queue consumer
+	// cannot overwrite the adjacent filter-signal tail.
+	return results[:n:n], results[n:]
 }
 
 // partialSort performs a partial sort to move the top k elements to the front.

--- a/internal/classifier/analyze.go
+++ b/internal/classifier/analyze.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/labels/nonbird"
 )
 
 // Filter structure is used for filtering predictions based on certain criteria.
@@ -95,7 +96,7 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 		return nil, err
 	}
 
-	// Use optimized top-k algorithm instead of full sort + trim
+	// Select the top predictions while retaining labels required by downstream filters.
 	topResults := getTopKResults(results, defaultTopKResults)
 
 	// Log prediction timing for performance monitoring
@@ -105,7 +106,7 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 	// Record metrics. Finish() records the single success because the span is not errored.
 	recordPredictionSuccess(span, len(topResults), start)
 
-	// Return the top 10 results
+	// Return the ranked results.
 	return topResults, nil
 }
 
@@ -215,8 +216,8 @@ func trimResultsToMax(results []datastore.Results, maxResults int) []datastore.R
 	return results
 }
 
-// getTopKResults returns the top k results without fully sorting the array.
-// Uses a partial sort algorithm that's more efficient than sorting all results.
+// getTopKResults returns the top k results plus any lower-ranked labels required
+// by the privacy or dog-bark filters. It avoids fully sorting the input array.
 func getTopKResults(results []datastore.Results, k int) []datastore.Results {
 	if len(results) == 0 || k <= 0 {
 		return []datastore.Results{}
@@ -235,21 +236,41 @@ func getTopKResults(results []datastore.Results, k int) []datastore.Results {
 		sortResults(results[:k])
 	}
 
+	// A human or dog label can score below the top-k boundary while still exceeding
+	// its filter's configured threshold. Preserve those labels so the processor can
+	// evaluate the filters instead of losing the signal during ranking. Compact the
+	// retained tail in place so the returned copy can still use one exact allocation.
+	retained := n
+	for i := n; i < len(results); i++ {
+		if shouldPreserveFilterLabel(results[i].Species) {
+			results[retained], results[i] = results[i], results[retained]
+			retained++
+		}
+	}
+
 	// Return a freshly-allocated copy so the result never aliases the caller's
 	// backing array. BirdNET.Predict passes a reused per-instance scratch buffer
 	// (bn.resultsBuffer) that the next inference window overwrites in place via
 	// pairLabelsAndConfidenceReuse; without this copy a top-K slice already handed
 	// to classifier.ResultsQueue would be mutated concurrently with the queue
 	// consumer reading it, an unsynchronized read/write data race that can corrupt
-	// queued detections. The Bat and Perch Predict paths pass
-	// freshly-allocated slices, so the copy is redundant-but-harmless there; doing
-	// it unconditionally keeps the ownership contract uniform for every model. n
-	// is small (defaultTopKResults = 10), so the copy is cheap and the upstream
-	// large-buffer reuse optimization stays intact: bn.resultsBuffer remains
-	// internal scratch that never escapes.
-	out := make([]datastore.Results, n)
-	copy(out, results[:n])
+	// queued detections. The Bat and Perch Predict paths pass freshly-allocated
+	// slices, so the copy is redundant-but-harmless there; doing it unconditionally
+	// keeps the ownership contract uniform for every model. The copied set is
+	// normally small, and the upstream large-buffer reuse optimization stays intact:
+	// bn.resultsBuffer remains internal scratch that never escapes.
+	out := make([]datastore.Results, retained)
+	copy(out, results[:retained])
+
+	// The top-k prefix is already sorted. Every retained tail result ranks at or
+	// below that prefix, so sorting only the retained tail preserves the full
+	// descending-order contract.
+	sortResults(out[n:])
 	return out
+}
+
+func shouldPreserveFilterLabel(rawLabel string) bool {
+	return nonbird.IsHumanVocalization(rawLabel) || nonbird.IsDogDetection(rawLabel)
 }
 
 // partialSort performs a partial sort to move the top k elements to the front.

--- a/internal/classifier/analyze_test.go
+++ b/internal/classifier/analyze_test.go
@@ -800,11 +800,18 @@ func TestGetTopKResults_PreservesFilterLabelsBeyondLimit(t *testing.T) {
 
 	results := getTopKResults(input, defaultTopKResults)
 
-	require.Len(t, results, defaultTopKResults+4)
+	require.Len(t, results, defaultTopKResults+2)
 	assert.Equal(t, "Human vocal_Mensch Stimme", results[defaultTopKResults].Species)
-	assert.Equal(t, "Speech", results[defaultTopKResults+1].Species)
-	assert.Equal(t, "Dog_Hund", results[defaultTopKResults+2].Species)
-	assert.Equal(t, "Bark", results[defaultTopKResults+3].Species)
+	assert.Equal(t, "Dog_Hund", results[defaultTopKResults+1].Species)
+
+	topResults, filterSignals := SplitFilterSignals(results)
+	require.Len(t, topResults, defaultTopKResults)
+	assert.Equal(t, len(topResults), cap(topResults))
+	require.Len(t, filterSignals, 2)
+	assert.Equal(t, "Human vocal_Mensch Stimme", filterSignals[0].Species)
+	assert.Equal(t, "Dog_Hund", filterSignals[1].Species)
+	assert.NotContains(t, results, datastore.Results{Species: "Speech", Confidence: 0.08})
+	assert.NotContains(t, results, datastore.Results{Species: "Bark", Confidence: 0.06})
 
 	for i := range input {
 		input[i].Species = "OVERWRITTEN"

--- a/internal/classifier/analyze_test.go
+++ b/internal/classifier/analyze_test.go
@@ -783,8 +783,8 @@ func TestGetTopKResults(t *testing.T) {
 func TestGetTopKResults_PreservesFilterLabelsBeyondLimit(t *testing.T) {
 	t.Parallel()
 
-	input := make([]datastore.Results, 0, defaultTopKResults+5)
-	for i := range defaultTopKResults {
+	input := make([]datastore.Results, 0, DefaultTopKResults+5)
+	for i := range DefaultTopKResults {
 		input = append(input, datastore.Results{
 			Species:    fmt.Sprintf("Bird %d", i+1),
 			Confidence: 0.99 - float32(i)*0.05,
@@ -798,14 +798,14 @@ func TestGetTopKResults_PreservesFilterLabelsBeyondLimit(t *testing.T) {
 		datastore.Results{Species: "Turdus merula", Confidence: 0.05},
 	)
 
-	results := getTopKResults(input, defaultTopKResults)
+	results := getTopKResults(input, DefaultTopKResults)
 
-	require.Len(t, results, defaultTopKResults+2)
-	assert.Equal(t, "Human vocal_Mensch Stimme", results[defaultTopKResults].Species)
-	assert.Equal(t, "Dog_Hund", results[defaultTopKResults+1].Species)
+	require.Len(t, results, DefaultTopKResults+2)
+	assert.Equal(t, "Human vocal_Mensch Stimme", results[DefaultTopKResults].Species)
+	assert.Equal(t, "Dog_Hund", results[DefaultTopKResults+1].Species)
 
-	topResults, filterSignals := SplitFilterSignals(results)
-	require.Len(t, topResults, defaultTopKResults)
+	topResults, filterSignals := SplitFilterSignals(results, DefaultTopKResults)
+	require.Len(t, topResults, DefaultTopKResults)
 	assert.Equal(t, len(topResults), cap(topResults))
 	require.Len(t, filterSignals, 2)
 	assert.Equal(t, "Human vocal_Mensch Stimme", filterSignals[0].Species)
@@ -816,7 +816,26 @@ func TestGetTopKResults_PreservesFilterLabelsBeyondLimit(t *testing.T) {
 	for i := range input {
 		input[i].Species = "OVERWRITTEN"
 	}
-	assert.Equal(t, "Human vocal_Mensch Stimme", results[defaultTopKResults].Species)
+	assert.Equal(t, "Human vocal_Mensch Stimme", results[DefaultTopKResults].Species)
+}
+
+func TestSplitFilterSignals_UsesRequestedNormalResultCount(t *testing.T) {
+	t.Parallel()
+
+	const normalResultCount = 3
+	input := []datastore.Results{
+		{Species: "Bird 1", Confidence: 0.9},
+		{Species: "Bird 2", Confidence: 0.8},
+		{Species: "Bird 3", Confidence: 0.7},
+		{Species: "Speech", Confidence: 0.1},
+	}
+	results := getTopKResults(input, normalResultCount)
+
+	topResults, filterSignals := SplitFilterSignals(results, normalResultCount)
+	require.Len(t, topResults, normalResultCount)
+	assert.Equal(t, len(topResults), cap(topResults))
+	require.Len(t, filterSignals, 1)
+	assert.Equal(t, "Speech", filterSignals[0].Species)
 }
 
 // TestGetTopKResults_ReturnsCopyNotAlias verifies getTopKResults returns a

--- a/internal/classifier/analyze_test.go
+++ b/internal/classifier/analyze_test.go
@@ -780,6 +780,38 @@ func TestGetTopKResults(t *testing.T) {
 	}
 }
 
+func TestGetTopKResults_PreservesFilterLabelsBeyondLimit(t *testing.T) {
+	t.Parallel()
+
+	input := make([]datastore.Results, 0, defaultTopKResults+5)
+	for i := range defaultTopKResults {
+		input = append(input, datastore.Results{
+			Species:    fmt.Sprintf("Bird %d", i+1),
+			Confidence: 0.99 - float32(i)*0.05,
+		})
+	}
+	input = append(input,
+		datastore.Results{Species: "Human vocal_Mensch Stimme", Confidence: 0.09},
+		datastore.Results{Species: "Speech", Confidence: 0.08},
+		datastore.Results{Species: "Dog_Hund", Confidence: 0.07},
+		datastore.Results{Species: "Bark", Confidence: 0.06},
+		datastore.Results{Species: "Turdus merula", Confidence: 0.05},
+	)
+
+	results := getTopKResults(input, defaultTopKResults)
+
+	require.Len(t, results, defaultTopKResults+4)
+	assert.Equal(t, "Human vocal_Mensch Stimme", results[defaultTopKResults].Species)
+	assert.Equal(t, "Speech", results[defaultTopKResults+1].Species)
+	assert.Equal(t, "Dog_Hund", results[defaultTopKResults+2].Species)
+	assert.Equal(t, "Bark", results[defaultTopKResults+3].Species)
+
+	for i := range input {
+		input[i].Species = "OVERWRITTEN"
+	}
+	assert.Equal(t, "Human vocal_Mensch Stimme", results[defaultTopKResults].Species)
+}
+
 // TestGetTopKResults_ReturnsCopyNotAlias verifies getTopKResults returns a
 // freshly-allocated slice that does not share a backing array with the input
 // buffer. This is the guarantee that closes the data race: the

--- a/internal/classifier/bat_onnx.go
+++ b/internal/classifier/bat_onnx.go
@@ -319,7 +319,7 @@ func (b *Bat) Predict(ctx context.Context, samples [][]float32) ([]datastore.Res
 	// Sort and trim before logging so top_species reflects the highest-confidence
 	// detection rather than the first label that cleared the threshold (results is
 	// in label order, not confidence order).
-	topResults := getTopKResults(results, defaultTopKResults)
+	topResults := getTopKResults(results, DefaultTopKResults)
 	if len(topResults) > 0 {
 		log.Debug("bat detections after threshold",
 			logger.Int("pre_filter", preFilterCount),

--- a/internal/classifier/birdnet_v3_onnx.go
+++ b/internal/classifier/birdnet_v3_onnx.go
@@ -261,7 +261,7 @@ func (b *BirdNETV3) Predict(ctx context.Context, samples [][]float32) ([]datasto
 	}
 
 	// Success: Finish records the single prediction because the span is not errored.
-	topResults := getTopKResults(results, defaultTopKResults)
+	topResults := getTopKResults(results, DefaultTopKResults)
 	recordPredictionSuccess(span, len(topResults), start)
 
 	return topResults, nil

--- a/internal/classifier/perch_onnx.go
+++ b/internal/classifier/perch_onnx.go
@@ -262,7 +262,7 @@ func (p *Perch) Predict(ctx context.Context, samples [][]float32) ([]datastore.R
 	}
 
 	// Success: Finish records the single prediction because the span is not errored.
-	topResults := getTopKResults(results, defaultTopKResults)
+	topResults := getTopKResults(results, DefaultTopKResults)
 	recordPredictionSuccess(span, len(topResults), start)
 
 	return topResults, nil

--- a/internal/classifier/queue.go
+++ b/internal/classifier/queue.go
@@ -11,7 +11,8 @@ type Results struct {
 	StartTime       time.Time             // Time when the analysis started (back-dated for clip export)
 	AudioCapturedAt time.Time             // Wall-clock time when the 3s audio chunk was ready for analysis
 	PCMdata         []byte                // Raw PCM audio data
-	Results         []datastore.Results   // Slice of analysis results
+	Results         []datastore.Results   // Normal top-ranked analysis results
+	FilterSignals   []datastore.Results   // Lower-ranked human/dog signals; never persisted as predictions
 	ElapsedTime     time.Duration         // Time taken for analysis
 	ClipName        string                // Name of the audio clip
 	Source          datastore.AudioSource // Audio source with ID, SafeString, and DisplayName
@@ -53,6 +54,13 @@ func (r Results) Copy() Results { //nolint:gocritic // This is a copy function, 
 		newCopy.Results = make([]datastore.Results, len(r.Results))
 		for i, result := range r.Results {
 			newCopy.Results[i] = result.Copy()
+		}
+	}
+
+	if r.FilterSignals != nil {
+		newCopy.FilterSignals = make([]datastore.Results, len(r.FilterSignals))
+		for i, result := range r.FilterSignals {
+			newCopy.FilterSignals[i] = result.Copy()
 		}
 	}
 

--- a/internal/classifier/tracing.go
+++ b/internal/classifier/tracing.go
@@ -57,7 +57,8 @@ const (
 	errTypeBatClassification   = "bat_classification"
 )
 
-// defaultTopKResults is the number of top predictions every model returns.
+// defaultTopKResults is the baseline number of top predictions every model returns.
+// Labels required by downstream privacy and dog-bark filters are retained in addition.
 const defaultTopKResults = 10
 
 // TracingSpan represents a traced operation with minimal overhead.

--- a/internal/classifier/tracing.go
+++ b/internal/classifier/tracing.go
@@ -58,7 +58,7 @@ const (
 )
 
 // defaultTopKResults is the baseline number of top predictions every model returns.
-// Labels required by downstream privacy and dog-bark filters are retained in addition.
+// The strongest missing privacy and dog-bark signal can be retained in addition.
 const defaultTopKResults = 10
 
 // TracingSpan represents a traced operation with minimal overhead.
@@ -264,7 +264,9 @@ func recordPredictionFailure(span *TracingSpan, model, errorType string, start t
 // recordPredictionSuccess records span data for a successful prediction and tags
 // it not-errored. The single success metric is recorded by Finish.
 func recordPredictionSuccess(span *TracingSpan, resultCount int, start time.Time) {
-	span.SetData(dataKeyResultCount, resultCount)
+	// Filter-only tail signals are an internal transport detail, not additional
+	// ranked predictions. Keep the existing result-count telemetry contract.
+	span.SetData(dataKeyResultCount, min(resultCount, defaultTopKResults))
 	span.SetData(dataKeyTotalDurationMs, time.Since(start).Milliseconds())
 	span.SetTag(tagKeyError, tagValueFalse)
 }

--- a/internal/classifier/tracing.go
+++ b/internal/classifier/tracing.go
@@ -57,9 +57,9 @@ const (
 	errTypeBatClassification   = "bat_classification"
 )
 
-// defaultTopKResults is the baseline number of top predictions every model returns.
+// DefaultTopKResults is the baseline number of top predictions every model returns.
 // The strongest missing privacy and dog-bark signal can be retained in addition.
-const defaultTopKResults = 10
+const DefaultTopKResults = 10
 
 // TracingSpan represents a traced operation with minimal overhead.
 // A TracingSpan must not be used from multiple goroutines concurrently.
@@ -266,7 +266,7 @@ func recordPredictionFailure(span *TracingSpan, model, errorType string, start t
 func recordPredictionSuccess(span *TracingSpan, resultCount int, start time.Time) {
 	// Filter-only tail signals are an internal transport detail, not additional
 	// ranked predictions. Keep the existing result-count telemetry contract.
-	span.SetData(dataKeyResultCount, min(resultCount, defaultTopKResults))
+	span.SetData(dataKeyResultCount, min(resultCount, DefaultTopKResults))
 	span.SetData(dataKeyTotalDurationMs, time.Since(start).Milliseconds())
 	span.SetTag(tagKeyError, tagValueFalse)
 }

--- a/internal/labels/nonbird/doc.go
+++ b/internal/labels/nonbird/doc.go
@@ -1,7 +1,7 @@
 // Package nonbird is the single source of truth for the non-bird, non-species
 // sound-event classes emitted by the Google Perch v2 (FSD50K/AudioSet) model.
 //
-// It holds 198 categorized classes and exposes two lookup paths:
+// It holds 198 categorized classes and exposes three lookup paths:
 //
 //   - Full-label lookup via [CategoryOf] and [IsNonSpeciesLabel]: matches the
 //     complete raw model label (e.g. "power_tool", "human_voice") exactly.
@@ -10,10 +10,13 @@
 //     (e.g. "Power" from "power_tool", "Engine" from "engine"). This is the
 //     lookup the image provider uses because the pipeline delivers only the
 //     first token to it.
+//   - Filter lookup via [IsHumanVocalization] and [IsDogDetection]: recognizes
+//     the full labels that must remain visible to the privacy and dog-bark filters,
+//     including locale-stable BirdNET prefixes and Perch sound classes or taxa.
 //
 // The static classes map in classes.go is the committed, hand-categorized
-// source of truth. The firstTokenSet is derived from it automatically in
-// init() so it can never drift from the data.
+// source of truth. Derived lookup indexes are built from it automatically in
+// init() so they cannot drift from the data.
 //
 // # Regenerating the candidate list
 //

--- a/internal/labels/nonbird/nonbird.go
+++ b/internal/labels/nonbird/nonbird.go
@@ -20,6 +20,14 @@ const (
 	CategoryNoise Category = "noise"
 	// CategoryDevice covers electronic devices and household appliances.
 	CategoryDevice Category = "device"
+
+	humanLabelPrefix = "human "
+	humanTaxonLabel  = "homo sapiens"
+	dogLabelPrefix   = "dog_"
+	dogLabel         = "dog"
+	dogBarkLabel     = "bark"
+	dogGrowlingLabel = "growling"
+	dogTaxonLabel    = "canis familiaris"
 )
 
 // firstTokenSet holds the first underscore-delimited token of every multi-word key in classes.
@@ -69,10 +77,10 @@ func CategoryOf(rawLabel string) (Category, bool) {
 // "Human " label prefix, Perch's human AudioSet/FSD50K classes, and the Perch
 // iNaturalist human taxon. Matching is case-insensitive.
 func IsHumanVocalization(rawLabel string) bool {
-	if hasFoldedPrefix(rawLabel, "human ") {
+	if hasFoldedPrefix(rawLabel, humanLabelPrefix) {
 		return true
 	}
-	if strings.EqualFold(rawLabel, "homo sapiens") {
+	if strings.EqualFold(rawLabel, humanTaxonLabel) {
 		return true
 	}
 	for _, label := range humanLabelsByLength[len(rawLabel)] {
@@ -88,13 +96,13 @@ func IsHumanVocalization(rawLabel string) bool {
 // locale-stable "Dog_" prefix and Perch's dog sound classes and domestic dog
 // taxon. Wild canids remain excluded. Matching is case-insensitive.
 func IsDogDetection(rawLabel string) bool {
-	if hasFoldedPrefix(rawLabel, "dog_") {
+	if hasFoldedPrefix(rawLabel, dogLabelPrefix) {
 		return true
 	}
-	return strings.EqualFold(rawLabel, "dog") ||
-		strings.EqualFold(rawLabel, "bark") ||
-		strings.EqualFold(rawLabel, "growling") ||
-		strings.EqualFold(rawLabel, "canis familiaris")
+	return strings.EqualFold(rawLabel, dogLabel) ||
+		strings.EqualFold(rawLabel, dogBarkLabel) ||
+		strings.EqualFold(rawLabel, dogGrowlingLabel) ||
+		strings.EqualFold(rawLabel, dogTaxonLabel)
 }
 
 func hasFoldedPrefix(value, prefix string) bool {

--- a/internal/labels/nonbird/nonbird.go
+++ b/internal/labels/nonbird/nonbird.go
@@ -28,11 +28,20 @@ const (
 // init() and never modified after that.
 var firstTokenSet map[string]struct{}
 
+// humanLabelsByLength groups the human sound classes in classes by label length.
+// IsHumanVocalization uses the buckets for allocation-free, case-insensitive matching
+// while the classifier scans a full prediction set for labels that must survive top-K.
+var humanLabelsByLength map[int][]string
+
 func init() {
 	firstTokenSet = make(map[string]struct{})
-	for k := range classes {
+	humanLabelsByLength = make(map[int][]string)
+	for k, category := range classes {
 		if before, _, found := strings.Cut(k, "_"); found {
 			firstTokenSet[before] = struct{}{}
+		}
+		if category == CategoryHuman {
+			humanLabelsByLength[len(k)] = append(humanLabelsByLength[len(k)], k)
 		}
 	}
 }
@@ -53,6 +62,43 @@ func Categories() []Category {
 func CategoryOf(rawLabel string) (Category, bool) {
 	cat, ok := classes[strings.ToLower(rawLabel)]
 	return cat, ok
+}
+
+// IsHumanVocalization reports whether a full raw model label represents a human
+// sound that should engage the privacy filter. It covers BirdNET's locale-stable
+// "Human " label prefix, Perch's human AudioSet/FSD50K classes, and the Perch
+// iNaturalist human taxon. Matching is case-insensitive.
+func IsHumanVocalization(rawLabel string) bool {
+	if hasFoldedPrefix(rawLabel, "human ") {
+		return true
+	}
+	if strings.EqualFold(rawLabel, "homo sapiens") {
+		return true
+	}
+	for _, label := range humanLabelsByLength[len(rawLabel)] {
+		if strings.EqualFold(rawLabel, label) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsDogDetection reports whether a full raw model label represents a domestic
+// dog sound that should engage the dog-bark filter. It covers BirdNET's
+// locale-stable "Dog_" prefix and Perch's dog sound classes and domestic dog
+// taxon. Wild canids remain excluded. Matching is case-insensitive.
+func IsDogDetection(rawLabel string) bool {
+	if hasFoldedPrefix(rawLabel, "dog_") {
+		return true
+	}
+	return strings.EqualFold(rawLabel, "dog") ||
+		strings.EqualFold(rawLabel, "bark") ||
+		strings.EqualFold(rawLabel, "growling") ||
+		strings.EqualFold(rawLabel, "canis familiaris")
+}
+
+func hasFoldedPrefix(value, prefix string) bool {
+	return len(value) >= len(prefix) && strings.EqualFold(value[:len(prefix)], prefix)
 }
 
 // IsNonSpeciesLabel reports whether rawLabel is a known non-bird sound class


### PR DESCRIPTION
Fixes #4177

## Summary

- retain the strongest human and dog signals even when they rank below the normal top-K result limit
- carry those filter-only signals separately so they cannot become stored additional predictions
- share the existing locale-safe BirdNET and Perch label recognition between ranking and processing
- add regression coverage for low-ranked localized BirdNET and Perch labels and the persistence boundary

## Root Cause

The classifier copied only the ten highest-confidence results before handing a prediction batch to the processor. Human speech can score above the configured privacy threshold while still ranking below those ten results, so the label was removed before the privacy filter could inspect it. Simply appending every matching label would also expand the stored additional-prediction set, so the filter signals need a separate path after ranking.

## Verification

- Focused baseline-versus-patched probe: passed; the pre-fix path loses lower-ranked filter signals, while the patched path retains only the strongest missing human and dog signals and keeps both out of stored additional predictions.
- Locale and collision checks: passed for BirdNET, Perch, mixed casing, and bird names containing similar substrings.
- The focused offline regression also passed with race detection; formatting and test-discovery checks passed.
- The repository's Go package tests, lint, cross-platform builds, and container checks will run in GitHub Actions because the local module cache does not contain the newly locked archives or native test dependencies.

## Preflight Status

- Reviewed reuse and performance, correctness and safety, project conventions, localization impact, queue ownership, storage behavior, integration wiring, and backward compatibility.
- No unresolved findings remain in the changed code.

## Compatibility

The existing top-K order, result-count reporting, and ownership guarantees are unchanged. At most one strongest missing signal per filter family is carried internally, while the queued normal result and stored additional-prediction sets remain capped at ten. Configuration, public APIs, and storage schemas are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Privacy and dog-bark filters now detect relevant lower-ranked audio signals, even outside the primary prediction results.
  * Human vocalization and dog-sound labels are recognized more consistently across supported label formats.

* **Bug Fixes**
  * Filter-only signals no longer appear as additional saved predictions or inflate ranked prediction metrics.
  * Improved separation between filter detections and primary prediction results, providing cleaner detection records and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->