### PR TITLE
fix(classifier): cover the model path self-heal and resolve each file set once

### DIFF
--- a/internal/classifier/model_manager_test.go
+++ b/internal/classifier/model_manager_test.go
@@ -127,7 +127,7 @@ func writeVariantModelFile(t *testing.T, modelsDir string, entry *CatalogEntry, 
 	subdir := filepath.Join(modelsDir, entry.ID)
 	require.NoError(t, os.MkdirAll(subdir, 0o755))
 	modelPath := filepath.Join(subdir, modelName)
-	require.NoError(t, os.WriteFile(modelPath, []byte("fake-onnx-data"), 0o644))
+	require.NoError(t, os.WriteFile(modelPath, []byte("fake-onnx-data"), 0o600))
 	return modelPath
 }
 

--- a/internal/classifier/model_path_reconcile.go
+++ b/internal/classifier/model_path_reconcile.go
@@ -64,11 +64,16 @@ func (o *Orchestrator) deferPathCorrection(registryID string, resolved modelFile
 //
 // The resolution is threaded out of build* rather than recomputed here for two
 // reasons. It avoids resolving the same file set twice per load, and, more
-// importantly, it removes the disagreement window: the model constructor runs
-// between a build-time and a load-time resolution and takes real time, so an
-// external writer (a concurrent gallery install, uninstall or variant switch)
-// could otherwise make the second resolution differ from the set the model was
-// actually built from, and this repair would persist those other paths.
+// importantly, it removes the window BETWEEN THE TWO RESOLUTIONS: recomputing
+// here would resolve a second time after the model constructor (which takes real
+// time), so an external writer (a concurrent gallery install, uninstall or
+// variant switch) could otherwise make that second resolution differ from the set
+// the model was actually built from, and this repair would persist those other
+// paths. Threading the build's own resolution therefore guarantees the repair
+// persists the set the instance was actually built from. It does NOT close the
+// gap between resolving and persisting the paths (the drain still runs later, so
+// the persisted set can lag a gallery change that lands after the build); it only
+// removes the disagreement between two resolutions of the same load.
 //
 // ReloadSecondaryModels calls build* directly and never calls this, which is
 // what keeps a backend or device swap from rewriting the user's paths: the

--- a/internal/classifier/model_path_reconcile.go
+++ b/internal/classifier/model_path_reconcile.go
@@ -58,29 +58,30 @@ func (o *Orchestrator) deferPathCorrection(registryID string, resolved modelFile
 	})
 }
 
-// queuePathCorrectionIfFallback resolves the family's paths and, when the
-// gallery fallback was used, queues the configuration repair. The loaders call
-// this after a successful build.
+// queuePathCorrection queues the configuration repair when the build resolved
+// through the gallery fallback. The loaders call it after a successful build,
+// passing the resolution their builder already computed.
 //
-// It re-runs the resolution the builder already performed rather than threading
-// the result out through build*, because build* is shared with
-// ReloadSecondaryModels, where a settings write is explicitly unwanted: a
-// backend or device swap must not rewrite the user's paths. The re-resolution is
-// a handful of read-only stats (presence classification, sibling recovery and
-// the installed-paths probe together) and cannot disagree with the build, since
-// nothing between them writes to the filesystem: the model constructor in
-// between opens the model and reads the label file, but writes nothing.
+// The resolution is threaded out of build* rather than recomputed here for two
+// reasons. It avoids resolving the same file set twice per load, and, more
+// importantly, it removes the disagreement window: the model constructor runs
+// between a build-time and a load-time resolution and takes real time, so an
+// external writer (a concurrent gallery install, uninstall or variant switch)
+// could otherwise make the second resolution differ from the set the model was
+// actually built from, and this repair would persist those other paths.
 //
-// Must be called with o.mu held. It only resolves paths and appends to the
-// pending queue; neither takes o.mu, so it is safe under the loaders' write
-// lock. The settings write itself happens later, in the drainer, after o.mu is
-// released.
-func (o *Orchestrator) queuePathCorrectionIfFallback(registryID string, configured modelFileSet, needEmbeddings bool) {
-	resolved, usedFallback := o.resolveFamilyPaths(registryID, configured, needEmbeddings)
-	if !usedFallback {
+// ReloadSecondaryModels calls build* directly and never calls this, which is
+// what keeps a backend or device swap from rewriting the user's paths: the
+// reload path simply discards the resolution.
+//
+// Must be called with o.mu held. It only appends to the pending queue, which
+// does not take o.mu, so it is safe under the loaders' write lock. The settings
+// write itself happens later, in the drainer, after o.mu is released.
+func (o *Orchestrator) queuePathCorrection(registryID string, res pathResolution) {
+	if !res.usedFallback {
 		return
 	}
-	o.deferPathCorrection(registryID, resolved)
+	o.deferPathCorrection(registryID, res.resolved)
 }
 
 // runPendingPathCorrections drains the queued configuration repairs, rewriting
@@ -96,7 +97,7 @@ func (o *Orchestrator) queuePathCorrectionIfFallback(registryID string, configur
 //
 // Must be called with o.mu NOT held: the snapshot-and-clear below takes o.mu
 // itself, and o.mu is not reentrant. (isGalleryManagedPath, reached from
-// applyPathCorrection, does NOT take o.mu; it is the drain that does.)
+// planPathCorrection, does NOT take o.mu; it is the drain that does.)
 func (o *Orchestrator) runPendingPathCorrections() {
 	o.mu.Lock()
 	pending := o.pendingPathCorrections

--- a/internal/classifier/model_path_resolution.go
+++ b/internal/classifier/model_path_resolution.go
@@ -57,6 +57,26 @@ func (s modelFileSet) allPresentOnDisk(needEmbeddings bool) bool {
 // above, so it classifies as presenceMissing (repairable), NOT indeterminate.
 // The guard against that rewriting a user's own path is the gallery-layout
 // requirement in isGalleryManagedPath, not this classification.
+// pathResolution carries resolveFamilyPaths' outcome out of a model builder so
+// the loader can act on it without resolving a second time.
+//
+// The builder and the loader need different halves of the same resolution: the
+// builder needs the resolved paths to construct from, and the loader needs to
+// know whether the gallery fallback was used so it can queue the configuration
+// repair. Resolving twice would not only duplicate the stat work, it would open
+// a window: the model constructor runs between the two resolutions and takes
+// real time for an ONNX session, so a concurrent gallery install, uninstall or
+// variant switch could make the second resolution disagree with the first, and
+// the repair would then persist paths the model was NOT built from.
+type pathResolution struct {
+	// resolved is the file set the model was actually built from.
+	resolved modelFileSet
+	// usedFallback reports whether a configured path was CONFIRMED missing and
+	// the gallery set was substituted, i.e. whether the configuration is stale
+	// and may be repaired. See resolveFamilyPaths' second return value.
+	usedFallback bool
+}
+
 type diskPresence int
 
 const (
@@ -256,8 +276,11 @@ func (o *Orchestrator) resolveSiblingSet(registryID, modelPath string) (set mode
 	// model loaders, which hold o.mu.Lock(), and sync.RWMutex is not reentrant:
 	// acquiring a read lock here self-deadlocks the loader. This mirrors
 	// resolveInstalledPaths, which reads the same field on the same call path.
-	// The field is written once at construction and again by SetModelsDir before
-	// the pipeline starts, so it is stable by the time any of this runs.
+	// The read is safe because the CALLER's lock already excludes the only writers:
+	// the constructor writes o.modelsDir before o is published, and SetModelsDir
+	// writes it under o.mu.Lock(). That is a stronger guarantee than "it is set
+	// early and never changes again", and it keeps holding if a models-directory
+	// change is ever made dynamic.
 	modelsDir := o.modelsDir
 
 	base := filepath.Base(modelPath)
@@ -330,10 +353,14 @@ func declaresModelFile(files []CatalogFile, localName string) bool {
 //
 // Takes no Orchestrator lock: it reads only its arguments and the ActiveCatalog
 // snapshot (whose accessor takes its own unrelated catalogMu). It is called only
-// from planPathCorrection, after the loaders have released o.mu. It would in
-// fact be safe on a loader path today, but keep it off one: the drainer that
-// reaches it DOES take o.mu, so moving the pair inward reintroduces the
-// self-deadlock this branch already shipped once.
+// from planPathCorrection, which the drainer reaches after the loaders have
+// released o.mu.
+//
+// Calling THIS function under a loader's o.mu would be safe, since it takes no
+// orchestrator lock. What must not move inside a loader is its caller chain's
+// entry point, runPendingPathCorrections: that drainer takes o.mu itself to
+// snapshot and clear the queue, and o.mu is not reentrant, so draining under the
+// loaders' write lock self-deadlocks the load. Keep the drain where it is.
 func (o *Orchestrator) isGalleryManagedPath(registryID, path string) bool {
 	if path == "" {
 		return false

--- a/internal/classifier/model_path_resolution.go
+++ b/internal/classifier/model_path_resolution.go
@@ -57,26 +57,6 @@ func (s modelFileSet) allPresentOnDisk(needEmbeddings bool) bool {
 // above, so it classifies as presenceMissing (repairable), NOT indeterminate.
 // The guard against that rewriting a user's own path is the gallery-layout
 // requirement in isGalleryManagedPath, not this classification.
-// pathResolution carries resolveFamilyPaths' outcome out of a model builder so
-// the loader can act on it without resolving a second time.
-//
-// The builder and the loader need different halves of the same resolution: the
-// builder needs the resolved paths to construct from, and the loader needs to
-// know whether the gallery fallback was used so it can queue the configuration
-// repair. Resolving twice would not only duplicate the stat work, it would open
-// a window: the model constructor runs between the two resolutions and takes
-// real time for an ONNX session, so a concurrent gallery install, uninstall or
-// variant switch could make the second resolution disagree with the first, and
-// the repair would then persist paths the model was NOT built from.
-type pathResolution struct {
-	// resolved is the file set the model was actually built from.
-	resolved modelFileSet
-	// usedFallback reports whether a configured path was CONFIRMED missing and
-	// the gallery set was substituted, i.e. whether the configuration is stale
-	// and may be repaired. See resolveFamilyPaths' second return value.
-	usedFallback bool
-}
-
 type diskPresence int
 
 const (
@@ -92,6 +72,29 @@ const (
 	// path reports ErrNotExist and is therefore presenceMissing, not this.
 	presenceIndeterminate
 )
+
+// pathResolution carries resolveFamilyPaths' outcome out of a model builder so
+// the loader can act on it without resolving a second time.
+//
+// The builder and the loader need different halves of the same resolution: the
+// builder needs the resolved paths to construct from, and the loader needs to
+// know whether the gallery fallback was used so it can queue the configuration
+// repair. Resolving twice would not only duplicate the stat work, it would open
+// a window BETWEEN THE TWO RESOLUTIONS: the model constructor runs between them
+// and takes real time for an ONNX session, so a concurrent gallery install,
+// uninstall or variant switch could make the second resolution disagree with the
+// first, and the repair would then persist paths the model was NOT built from.
+// Threading keeps the two resolutions from disagreeing; it does not close the gap
+// between resolving and persisting (the drain still runs later), so the persisted
+// set can still lag a gallery change that lands after the build.
+type pathResolution struct {
+	// resolved is the file set the model was actually built from.
+	resolved modelFileSet
+	// usedFallback reports whether a configured path was CONFIRMED missing and
+	// the gallery set was substituted, i.e. whether the configuration is stale
+	// and may be repaired. See resolveFamilyPaths' second return value.
+	usedFallback bool
+}
 
 // nonEmptyMembersPresence classifies whether every NON-EMPTY required member of
 // the set exists on disk. An empty member is skipped, not treated as missing:
@@ -234,11 +237,10 @@ func (o *Orchestrator) resolveFamilyPaths(registryID string, configured modelFil
 		return configured, false
 	}
 
-	// Debug, not Info: this fires once per build and once more when the loader
-	// re-resolves to decide whether the configuration needs repairing, and the
-	// noteworthy outcomes already log at Info from planPathCorrection (either the
-	// repair itself, or the decision to leave a non-gallery path alone). Falling
-	// back for an empty configured path is the normal, uninteresting case.
+	// Debug, not Info: this fires once per build, and the noteworthy outcomes
+	// already log at Info from planPathCorrection (either the repair itself, or
+	// the decision to leave a non-gallery path alone). Falling back for an empty
+	// configured path is the normal, uninteresting case.
 	GetLogger().Debug("configured model path is missing on disk, falling back to the installed model",
 		logger.String("registry_id", registryID),
 		logger.String("configured_model_path", configured.model),
@@ -276,11 +278,17 @@ func (o *Orchestrator) resolveSiblingSet(registryID, modelPath string) (set mode
 	// model loaders, which hold o.mu.Lock(), and sync.RWMutex is not reentrant:
 	// acquiring a read lock here self-deadlocks the loader. This mirrors
 	// resolveInstalledPaths, which reads the same field on the same call path.
-	// The read is safe because the CALLER's lock already excludes the only writers:
-	// the constructor writes o.modelsDir before o is published, and SetModelsDir
-	// writes it under o.mu.Lock(). That is a stronger guarantee than "it is set
-	// early and never changes again", and it keeps holding if a models-directory
-	// change is ever made dynamic.
+	// The read is safe today because o.modelsDir is effectively immutable once the
+	// pipeline is running: the constructor writes it before o is published, and
+	// SetModelsDir (its only other writer, under o.mu.Lock()) is called at most
+	// once, from NewModelManager, before the pipeline starts; cmd/benchmark and
+	// cmd/rangefilter construct an Orchestrator and never call it at all. The
+	// loader path additionally holds o.mu, but is not the only reader: the reload
+	// path (ReloadSecondaryModels, which calls the builders after releasing o.mu)
+	// reads it here and via resolveInstalledPaths with no lock, and the correction
+	// drainer reads it via isGalleryManagedPath with no lock. Making the models
+	// directory dynamic would therefore require revisiting all three lock-free
+	// readers, not just adding a lock here.
 	modelsDir := o.modelsDir
 
 	base := filepath.Base(modelPath)
@@ -351,10 +359,12 @@ func declaresModelFile(files []CatalogFile, localName string) bool {
 // shares a catalog file name (for example /mnt/nas/models/perch_v2_labels.txt,
 // whose parent directory is "models", not the entry ID) does NOT qualify.
 //
-// Takes no Orchestrator lock: it reads only its arguments and the ActiveCatalog
-// snapshot (whose accessor takes its own unrelated catalogMu). It is called only
-// from planPathCorrection, which the drainer reaches after the loaders have
-// released o.mu.
+// Takes no Orchestrator lock. Besides its arguments it reads o.modelsDir (in the
+// o.modelsDir == "" guard and in filepath.Base(o.modelsDir) in the grandparent
+// check) and the ActiveCatalog snapshot (whose accessor takes its own unrelated
+// catalogMu). It is called only from planPathCorrection, which the drainer
+// reaches after the loaders have released o.mu, so this o.modelsDir read holds no
+// orchestrator lock; it is safe for the reason resolveSiblingSet documents.
 //
 // Calling THIS function under a loader's o.mu would be safe, since it takes no
 // orchestrator lock. What must not move inside a loader is its caller chain's

--- a/internal/classifier/model_path_resolution_test.go
+++ b/internal/classifier/model_path_resolution_test.go
@@ -400,14 +400,14 @@ func TestResolveFamilyPaths_IndeterminateFallsBackWithoutRepair(t *testing.T) {
 		"the model still resolves to the installed gallery model so analysis can run")
 	assert.Equal(t, installedLabels, got.labels)
 
-	o.queuePathCorrectionIfFallback(RegistryIDPerchV2, indeterminate, false)
+	o.queuePathCorrection(RegistryIDPerchV2, pathResolution{resolved: got, usedFallback: usedFallback})
 	assert.Empty(t, o.pendingPathCorrections,
 		"an indeterminate path must not queue a config repair")
 }
 
-// TestQueuePathCorrectionIfFallback_HealthySetQueuesNothing is the negative for
+// TestQueuePathCorrection_HealthySetQueuesNothing is the negative for
 // the self-heal: a fully present configured set must not queue any repair.
-func TestQueuePathCorrectionIfFallback_HealthySetQueuesNothing(t *testing.T) {
+func TestQueuePathCorrection_HealthySetQueuesNothing(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -440,10 +440,138 @@ func TestQueuePathCorrectionIfFallback_HealthySetQueuesNothing(t *testing.T) {
 	assert.Equal(t, configured, got,
 		"a healthy configured set must be returned verbatim, never swapped for the installed gallery variant")
 
-	o.queuePathCorrectionIfFallback(RegistryIDPerchV2, configured, false)
+	o.queuePathCorrection(RegistryIDPerchV2, pathResolution{resolved: got, usedFallback: usedFallback})
 
 	assert.Empty(t, o.pendingPathCorrections,
 		"a healthy, fully-present configured set must not queue a config repair")
+}
+
+// TestPathCorrection_QueuedThenDrainedRepairsConfig is the POSITIVE test for the
+// self-heal. It covers the middle of the chain that the two negative tests above
+// and TestApplyPathCorrection_PersistsRepairedPaths leave uncovered: that a stale
+// configured set is actually QUEUED, and that draining the queue actually
+// APPLIES the repair.
+//
+// Without it the entire self-heal can be deleted in silence. Two mutations leave
+// the rest of the suite green: reducing queuePathCorrection to a no-op, and
+// reducing runPendingPathCorrections to snapshot-and-discard. Models would still
+// load either way, because the runtime fallback is covered separately, so nothing
+// would look broken; but config.yaml would never be repaired, the stale basename
+// would keep feeding installedModelBasenameHint, and affected users would fall
+// back again on every restart forever.
+//
+// The scenario is the one GitHub #4201 and #4204 report: the models directory
+// prefix changed (a different container HOME), so the configured paths still have
+// the gallery's <models dir>/<entry ID>/<local name> shape but point under the OLD
+// root and no longer exist.
+func TestPathCorrection_QueuedThenDrainedRepairsConfig(t *testing.T) {
+	// Not parallel: mutates the conf global settings, conf.ConfigPath, the
+	// process-level persistence switch, and the global notification service.
+	redirectConfigFile(t)
+
+	// A diagnostic command may have disabled persistence process-wide; this test
+	// asserts the persisting path, so pin the switch for its duration.
+	SetPathCorrectionPersistenceDisabled(false)
+	t.Cleanup(func() { SetPathCorrectionPersistenceDisabled(false) })
+
+	// The reconciled notification is the user's only signal that a repair
+	// happened, and it had no coverage at all (only the user-owned SUBSTITUTED
+	// case was asserted, in TestApplyPathCorrection_UserOwnedSubstitutionNotifies).
+	//
+	// NOTE: this pins the emitter, not the delivery. On the real startup path the
+	// drain runs inside NewOrchestrator, which completes BEFORE the notification
+	// service is initialized, so notification.GetService() is nil there and the
+	// notification is silently dropped. That is a separate, pre-existing defect;
+	// green here does NOT mean a user sees the bell on startup.
+	notification.ResetForTest()
+	t.Cleanup(notification.ResetForTest)
+	notification.Initialize(notification.DefaultServiceConfig())
+	svc := notification.GetService()
+	require.NotNil(t, svc)
+	t.Cleanup(svc.Stop)
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+
+	// Name the directory "models" so filepath.Base matches production. That base
+	// name is what isGalleryManagedPath compares against, so it lets the stale
+	// path below sit under a DIFFERENT root and still qualify as gallery-managed,
+	// which is the whole point of the changed-HOME case.
+	modelsDir := filepath.Join(t.TempDir(), "models")
+	installedModel := writeVariantModelFile(t, modelsDir, &entry, "fp32")
+	installedLabels := writeVariantLabelsFile(t, modelsDir, &entry, "fp32")
+
+	o := &Orchestrator{}
+	o.SetModelsDir(modelsDir)
+
+	// The same gallery layout under the OLD root: right shape, absent on disk.
+	staleDir := filepath.Join(t.TempDir(), "models", entry.ID)
+	configured := modelFileSet{
+		model:  filepath.Join(staleDir, filepath.Base(installedModel)),
+		labels: filepath.Join(staleDir, filepath.Base(installedLabels)),
+	}
+
+	stale := &conf.Settings{}
+	stale.Perch.ModelPath = configured.model
+	stale.Perch.LabelPath = configured.labels
+	origSettings := conf.GetSettings()
+	conf.StoreSettings(stale)
+	t.Cleanup(func() { conf.StoreSettings(origSettings) })
+
+	// 1. The resolution reports a repairable fallback onto the installed variant.
+	resolved, usedFallback := o.resolveFamilyPaths(RegistryIDPerchV2, configured, false)
+	require.True(t, usedFallback,
+		"a confirmed-missing gallery path must be reported as repairable")
+	require.Equal(t, installedModel, resolved.model)
+	require.Equal(t, installedLabels, resolved.labels)
+
+	// 2. Queueing records it. A queuePathCorrection that never queues fails here.
+	o.queuePathCorrection(RegistryIDPerchV2, pathResolution{resolved: resolved, usedFallback: usedFallback})
+	require.Len(t, o.pendingPathCorrections, 1,
+		"a repairable fallback must queue exactly one correction")
+	assert.Equal(t, RegistryIDPerchV2, o.pendingPathCorrections[0].registryID)
+	assert.Equal(t, resolved, o.pendingPathCorrections[0].resolved,
+		"the queued correction must carry the set the model was actually built from")
+
+	// 3. Draining applies it. A runPendingPathCorrections that snapshots and
+	// discards fails here.
+	o.runPendingPathCorrections()
+
+	assert.Empty(t, o.pendingPathCorrections,
+		"the drain must clear the queue so a later drain cannot rewrite config again")
+
+	got := conf.GetSettings()
+	require.NotNil(t, got)
+	assert.Equal(t, installedModel, got.Perch.ModelPath,
+		"the drain must repair the stale model path in the published snapshot")
+	assert.Equal(t, installedLabels, got.Perch.LabelPath,
+		"the labels path is repaired as part of the same atomic set")
+
+	data, err := os.ReadFile(conf.ConfigPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), installedModel,
+		"the repair must reach config.yaml, otherwise the fallback repeats on every restart")
+	assert.NotContains(t, string(data), configured.model,
+		"the stale path must not survive in the persisted config")
+
+	// 4. The repair is announced. A silent repair leaves someone who lost
+	// detections for days with no explanation, which is the whole reason
+	// emitPathReconciledNotification exists.
+	list, err := svc.List(nil)
+	require.NoError(t, err)
+	var reconciled, substituted bool
+	for _, n := range list {
+		switch n.TitleKey {
+		case notification.MsgModelPathReconciledTitle:
+			reconciled = true
+		case notification.MsgModelPathSubstitutedTitle:
+			substituted = true
+		}
+	}
+	assert.True(t, reconciled,
+		"a persisted repair must emit the reconciled notification")
+	assert.False(t, substituted,
+		"config WAS rewritten, so the substituted notification must not fire")
 }
 
 // TestIsGalleryManagedPath gates the automatic config repair: only paths the
@@ -1062,10 +1190,11 @@ func TestResolveFamilyPaths_SafeUnderOrchestratorLock(t *testing.T) {
 		}, false)
 
 		// Queueing a correction is also done under the lock.
-		o.queuePathCorrectionIfFallback(RegistryIDPerchV2, modelFileSet{
+		stale, usedFallback := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
 			model:  "/nonexistent/perch_v2.onnx",
 			labels: "/nonexistent/perch_v2_labels.txt",
 		}, false)
+		o.queuePathCorrection(RegistryIDPerchV2, pathResolution{resolved: stale, usedFallback: usedFallback})
 	}()
 
 	select {

--- a/internal/classifier/model_path_resolution_test.go
+++ b/internal/classifier/model_path_resolution_test.go
@@ -475,14 +475,10 @@ func TestPathCorrection_QueuedThenDrainedRepairsConfig(t *testing.T) {
 	t.Cleanup(func() { SetPathCorrectionPersistenceDisabled(false) })
 
 	// The reconciled notification is the user's only signal that a repair
-	// happened, and it had no coverage at all (only the user-owned SUBSTITUTED
+	// happened, and it had no positive coverage (only the user-owned SUBSTITUTED
 	// case was asserted, in TestApplyPathCorrection_UserOwnedSubstitutionNotifies).
 	//
-	// NOTE: this pins the emitter, not the delivery. On the real startup path the
-	// drain runs inside NewOrchestrator, which completes BEFORE the notification
-	// service is initialized, so notification.GetService() is nil there and the
-	// notification is silently dropped. That is a separate, pre-existing defect;
-	// green here does NOT mean a user sees the bell on startup.
+	// This assertion pins the emitter, not the whole delivery pipeline.
 	notification.ResetForTest()
 	t.Cleanup(notification.ResetForTest)
 	notification.Initialize(notification.DefaultServiceConfig())
@@ -572,6 +568,84 @@ func TestPathCorrection_QueuedThenDrainedRepairsConfig(t *testing.T) {
 		"a persisted repair must emit the reconciled notification")
 	assert.False(t, substituted,
 		"config WAS rewritten, so the substituted notification must not fire")
+}
+
+// TestRunPendingPathCorrections_DrainsEveryQueuedFamily pins that the drain
+// applies EVERY queued correction, not only the first. The Bat family is the
+// second correction on purpose: its three-path set (classifier, labels, shared
+// embedding extractor) is otherwise never exercised through queue+drain. A drain
+// that stops after pending[0] would repair the first family and leave the second
+// family's stale config untouched, which is invisible to the rest of the suite.
+func TestRunPendingPathCorrections_DrainsEveryQueuedFamily(t *testing.T) {
+	// Not parallel: mutates the conf global settings, conf.ConfigPath, and the
+	// process-level persistence switch.
+	redirectConfigFile(t)
+
+	SetPathCorrectionPersistenceDisabled(false)
+	t.Cleanup(func() { SetPathCorrectionPersistenceDisabled(false) })
+
+	perchEntry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+	batEntry := firstBatCatalogEntry(t)
+
+	// Installed gallery variants under a "models" root, so the resolved sets point
+	// at real, distinct files. Name the directory "models" so filepath.Base matches
+	// production and the stale gallery-managed paths below qualify.
+	modelsDir := filepath.Join(t.TempDir(), "models")
+	installedPerchModel := writeVariantModelFile(t, modelsDir, &perchEntry, "fp32")
+	installedPerchLabels := writeVariantLabelsFile(t, modelsDir, &perchEntry, "fp32")
+	batModel, batLabels, batEmb := writeBatGalleryFiles(t, modelsDir, batEntry)
+
+	o := &Orchestrator{}
+	o.SetModelsDir(modelsDir)
+
+	// Stale, gallery-managed configured paths for BOTH families: the same
+	// <models>/<entry ID>/<local name> (and <models>/shared/<local name>) shape,
+	// but under an OLD root that no longer exists (the changed-container-HOME case).
+	// isGalleryManagedPath qualifies them (grandparent base is "models"), and they
+	// differ from the resolved sets, so each family's correction is a real change.
+	staleRoot := filepath.Join(t.TempDir(), "models")
+	stale := &conf.Settings{}
+	stale.Perch.ModelPath = filepath.Join(staleRoot, perchEntry.ID, filepath.Base(installedPerchModel))
+	stale.Perch.LabelPath = filepath.Join(staleRoot, perchEntry.ID, filepath.Base(installedPerchLabels))
+	stale.Bat.ClassifierModel = filepath.Join(staleRoot, batEntry.ID, filepath.Base(batModel))
+	stale.Bat.LabelPath = filepath.Join(staleRoot, batEntry.ID, filepath.Base(batLabels))
+	stale.Bat.EmbeddingModel = filepath.Join(staleRoot, "shared", filepath.Base(batEmb))
+
+	origSettings := conf.GetSettings()
+	conf.StoreSettings(stale)
+	t.Cleanup(func() { conf.StoreSettings(origSettings) })
+
+	// Queue Perch first, Bat second. A drain that applies only pending[0] would
+	// repair Perch and leave the whole Bat set stale.
+	o.queuePathCorrection(RegistryIDPerchV2, pathResolution{
+		resolved:     modelFileSet{model: installedPerchModel, labels: installedPerchLabels},
+		usedFallback: true,
+	})
+	o.queuePathCorrection(RegistryIDBat, pathResolution{
+		resolved:     modelFileSet{model: batModel, labels: batLabels, embeddings: batEmb},
+		usedFallback: true,
+	})
+	require.Len(t, o.pendingPathCorrections, 2, "both families must be queued")
+
+	o.runPendingPathCorrections()
+
+	assert.Empty(t, o.pendingPathCorrections, "the drain must clear the queue")
+
+	got := conf.GetSettings()
+	require.NotNil(t, got)
+
+	// The first queued family (pending[0]) is repaired.
+	assert.Equal(t, installedPerchModel, got.Perch.ModelPath)
+	assert.Equal(t, installedPerchLabels, got.Perch.LabelPath)
+
+	// The second queued family (pending[1]) must be repaired by the SAME drain,
+	// all three paths. A drain that stops after pending[0] fails these.
+	assert.Equal(t, batModel, got.Bat.ClassifierModel,
+		"the second queued family must be repaired by the same drain, not skipped")
+	assert.Equal(t, batLabels, got.Bat.LabelPath)
+	assert.Equal(t, batEmb, got.Bat.EmbeddingModel,
+		"the shared embedding extractor is part of the second family's set")
 }
 
 // TestIsGalleryManagedPath gates the automatic config repair: only paths the

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -1606,7 +1606,10 @@ var openvinoCapableSecondaryBuilders = map[string]secondaryModelBuilder{
 	RegistryIDBirdNETV3: func(o *Orchestrator, settings *conf.Settings, threads int) (ModelInstance, error) {
 		// Explicit nil-on-error return avoids the typed-nil interface trap (a
 		// nil *BirdNETV3 wrapped in a non-nil ModelInstance).
-		m, err := o.buildBirdNETV3(settings, threads)
+		// The path resolution is deliberately discarded: a backend or device swap
+		// must never rewrite the user's configured paths, so the reload path does
+		// not call queuePathCorrection.
+		m, _, err := o.buildBirdNETV3(settings, threads)
 		if err != nil {
 			return nil, err
 		}
@@ -1615,7 +1618,8 @@ var openvinoCapableSecondaryBuilders = map[string]secondaryModelBuilder{
 	RegistryIDPerchV2: func(o *Orchestrator, settings *conf.Settings, threads int) (ModelInstance, error) {
 		// Explicit nil-on-error return avoids the typed-nil interface trap (a
 		// nil *Perch wrapped in a non-nil ModelInstance).
-		p, err := o.buildPerch(settings, threads)
+		// The path resolution is deliberately discarded (see buildBirdNETV3 above).
+		p, _, err := o.buildPerch(settings, threads)
 		if err != nil {
 			return nil, err
 		}
@@ -1624,7 +1628,8 @@ var openvinoCapableSecondaryBuilders = map[string]secondaryModelBuilder{
 	RegistryIDBat: func(o *Orchestrator, settings *conf.Settings, threads int) (ModelInstance, error) {
 		// Explicit nil-on-error return avoids the typed-nil interface trap (a
 		// nil *Bat wrapped in a non-nil ModelInstance).
-		b, err := o.buildBat(settings, threads)
+		// The path resolution is deliberately discarded (see buildBirdNETV3 above).
+		b, _, err := o.buildBat(settings, threads)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -258,12 +258,22 @@ func NewOrchestrator(settings *conf.Settings) (*Orchestrator, error) {
 // geomodel auto-selection, and registers the taxonomy resolver if
 // taxonomy.csv is available on disk.
 func (o *Orchestrator) SetModelsDir(dir string) {
-	// Guard the o.modelsDir write and the o.primary read under o.mu: o.modelsDir
-	// is read by resolveInstalledPaths (always under o.mu via the model loaders),
-	// and o.primary is cleared by Delete() under o.mu.Lock(). Release before the
-	// downstream calls, which take their own locks. registerTaxonomyResolver in
-	// particular acquires o.mu.RLock() internally, so holding o.mu here would
-	// self-deadlock (the RWMutex is not reentrant).
+	// Guard the o.modelsDir write and the o.primary read under o.mu: the model
+	// loaders read o.modelsDir under o.mu, and o.primary is cleared by Delete()
+	// under o.mu.Lock().
+	//
+	// The write is guarded, but NOT every read is, so this lock alone is not what
+	// makes the field safe. resolveInstalledPaths, resolveSiblingSet and
+	// isGalleryManagedPath all read o.modelsDir with NO lock held: the first two on
+	// the ReloadSecondaryModels path (which releases o.mu before calling the model
+	// builders) and the third on the config-correction drain path. Those reads are
+	// safe only because this setter runs at most once, before the pipeline starts.
+	// See resolveSiblingSet for the full rationale and for what making the models
+	// directory dynamic would require.
+	//
+	// Release before the downstream calls, which take their own locks.
+	// registerTaxonomyResolver in particular acquires o.mu.RLock() internally, so
+	// holding o.mu here would self-deadlock (the RWMutex is not reentrant).
 	o.mu.Lock()
 	o.modelsDir = dir
 	primary := o.primary
@@ -1399,9 +1409,10 @@ func (o *Orchestrator) ReloadSecondaryModels() error {
 	threadAlloc := o.computeThreadAllocation(settings, primaryID)
 
 	// The builders below run outside o.mu. They construct from the settings
-	// snapshot and may read o.modelsDir (via resolveInstalledPaths), which is set
-	// once at startup by SetModelsDir before the pipeline (and thus this reload
-	// path) starts, so the read is safe without o.mu.
+	// snapshot and may read o.modelsDir (via resolveInstalledPaths and
+	// resolveSiblingSet), which is set once at startup by SetModelsDir before the
+	// pipeline (and thus this reload path) starts, so the read is safe without
+	// o.mu. See resolveSiblingSet for the full rationale on this lock-free read.
 
 	var firstErr error
 	for _, ref := range refs {
@@ -1618,7 +1629,7 @@ var openvinoCapableSecondaryBuilders = map[string]secondaryModelBuilder{
 	RegistryIDPerchV2: func(o *Orchestrator, settings *conf.Settings, threads int) (ModelInstance, error) {
 		// Explicit nil-on-error return avoids the typed-nil interface trap (a
 		// nil *Perch wrapped in a non-nil ModelInstance).
-		// The path resolution is deliberately discarded (see buildBirdNETV3 above).
+		// The path resolution is deliberately discarded (see the BirdNET v3.0 entry above).
 		p, _, err := o.buildPerch(settings, threads)
 		if err != nil {
 			return nil, err
@@ -1628,7 +1639,7 @@ var openvinoCapableSecondaryBuilders = map[string]secondaryModelBuilder{
 	RegistryIDBat: func(o *Orchestrator, settings *conf.Settings, threads int) (ModelInstance, error) {
 		// Explicit nil-on-error return avoids the typed-nil interface trap (a
 		// nil *Bat wrapped in a non-nil ModelInstance).
-		// The path resolution is deliberately discarded (see buildBirdNETV3 above).
+		// The path resolution is deliberately discarded (see the BirdNET v3.0 entry above).
 		b, _, err := o.buildBat(settings, threads)
 		if err != nil {
 			return nil, err

--- a/internal/classifier/orchestrator_bat_onnx.go
+++ b/internal/classifier/orchestrator_bat_onnx.go
@@ -14,18 +14,24 @@ import (
 //
 // The settings snapshot is passed in (rather than read inside) so the caller builds
 // with the exact settings it gated the reload decision on.
-func (o *Orchestrator) buildBat(settings *conf.Settings, threads int) (*Bat, error) {
-	paths, _ := o.resolveFamilyPaths(RegistryIDBat, modelFileSet{
+//
+// The path resolution is returned alongside the instance so loadBat can decide
+// whether to repair a stale configuration without resolving a second time (see
+// pathResolution). ReloadSecondaryModels discards it, which is what keeps a
+// backend or device swap from rewriting the user's paths.
+func (o *Orchestrator) buildBat(settings *conf.Settings, threads int) (*Bat, pathResolution, error) {
+	resolved, usedFallback := o.resolveFamilyPaths(RegistryIDBat, modelFileSet{
 		model:      settings.Bat.ClassifierModel,
 		labels:     settings.Bat.LabelPath,
 		embeddings: settings.Bat.EmbeddingModel,
 	}, true)
-	classifierModel := paths.model
-	labelPath := paths.labels
-	embeddingModel := paths.embeddings
+	res := pathResolution{resolved: resolved, usedFallback: usedFallback}
+	classifierModel := resolved.model
+	labelPath := resolved.labels
+	embeddingModel := resolved.embeddings
 
 	if classifierModel == "" || labelPath == "" || embeddingModel == "" {
-		return nil, errors.Newf("bat model files not installed or configured").
+		return nil, res, errors.Newf("bat model files not installed or configured").
 			Component("classifier.orchestrator").
 			Category(errors.CategoryModelInit).
 			Context("model", RegistryIDBat).
@@ -33,7 +39,7 @@ func (o *Orchestrator) buildBat(settings *conf.Settings, threads int) (*Bat, err
 	}
 
 	if err := checkORTOrFail(settings.BirdNET.ONNXRuntimePath, "Bat model", RegistryIDBat, "classifier.orchestrator"); err != nil {
-		return nil, err
+		return nil, res, err
 	}
 
 	cfg := BatModelConfig{
@@ -50,14 +56,14 @@ func (o *Orchestrator) buildBat(settings *conf.Settings, threads int) (*Bat, err
 
 	bat, err := NewBat(&cfg)
 	if err != nil {
-		return nil, errors.New(err).
+		return nil, res, errors.New(err).
 			Component("classifier.orchestrator").
 			Category(errors.CategoryModelInit).
 			Context("model", RegistryIDBat).
 			Build()
 	}
 
-	return bat, nil
+	return bat, res, nil
 }
 
 // loadBat creates and registers a bat detection model instance from settings.
@@ -71,7 +77,7 @@ func (o *Orchestrator) loadBat(threads int) error {
 	settings := o.currentSettings()
 	before := o.captureRSSBefore()
 
-	bat, err := o.buildBat(settings, threads)
+	bat, res, err := o.buildBat(settings, threads)
 	if err != nil {
 		return err
 	}
@@ -81,12 +87,10 @@ func (o *Orchestrator) loadBat(threads int) error {
 		backend:  secondaryTripletFor(settings),
 	}
 	// Queue a config repair when the model loaded from the gallery fallback
-	// because the configured path was stale. Drained after o.mu is released.
-	o.queuePathCorrectionIfFallback(RegistryIDBat, modelFileSet{
-		model:      settings.Bat.ClassifierModel,
-		labels:     settings.Bat.LabelPath,
-		embeddings: settings.Bat.EmbeddingModel,
-	}, true)
+	// because the configured path was stale. Uses the resolution the build
+	// already performed, so the repair can only ever persist the paths this
+	// instance was actually built from. Drained after o.mu is released.
+	o.queuePathCorrection(RegistryIDBat, res)
 
 	// Defer the warm-up + RSS measurement until the caller releases o.mu, so the
 	// warm-up inference runs via the serialized inference path instead of stalling

--- a/internal/classifier/orchestrator_bat_onnx.go
+++ b/internal/classifier/orchestrator_bat_onnx.go
@@ -19,6 +19,9 @@ import (
 // whether to repair a stale configuration without resolving a second time (see
 // pathResolution). ReloadSecondaryModels discards it, which is what keeps a
 // backend or device swap from rewriting the user's paths.
+//
+// The returned resolution is meaningful only when err == nil; every error return
+// yields the zero pathResolution{}.
 func (o *Orchestrator) buildBat(settings *conf.Settings, threads int) (*Bat, pathResolution, error) {
 	resolved, usedFallback := o.resolveFamilyPaths(RegistryIDBat, modelFileSet{
 		model:      settings.Bat.ClassifierModel,
@@ -31,7 +34,7 @@ func (o *Orchestrator) buildBat(settings *conf.Settings, threads int) (*Bat, pat
 	embeddingModel := resolved.embeddings
 
 	if classifierModel == "" || labelPath == "" || embeddingModel == "" {
-		return nil, res, errors.Newf("bat model files not installed or configured").
+		return nil, pathResolution{}, errors.Newf("bat model files not installed or configured").
 			Component("classifier.orchestrator").
 			Category(errors.CategoryModelInit).
 			Context("model", RegistryIDBat).
@@ -39,7 +42,7 @@ func (o *Orchestrator) buildBat(settings *conf.Settings, threads int) (*Bat, pat
 	}
 
 	if err := checkORTOrFail(settings.BirdNET.ONNXRuntimePath, "Bat model", RegistryIDBat, "classifier.orchestrator"); err != nil {
-		return nil, res, err
+		return nil, pathResolution{}, err
 	}
 
 	cfg := BatModelConfig{
@@ -56,7 +59,7 @@ func (o *Orchestrator) buildBat(settings *conf.Settings, threads int) (*Bat, pat
 
 	bat, err := NewBat(&cfg)
 	if err != nil {
-		return nil, res, errors.New(err).
+		return nil, pathResolution{}, errors.New(err).
 			Component("classifier.orchestrator").
 			Category(errors.CategoryModelInit).
 			Context("model", RegistryIDBat).

--- a/internal/classifier/orchestrator_birdnet_v3_onnx.go
+++ b/internal/classifier/orchestrator_birdnet_v3_onnx.go
@@ -20,6 +20,9 @@ import (
 // decide whether to repair a stale configuration without resolving a second time
 // (see pathResolution). ReloadSecondaryModels discards it, which is what keeps a
 // backend or device swap from rewriting the user's paths.
+//
+// The returned resolution is meaningful only when err == nil; every error return
+// yields the zero pathResolution{}.
 func (o *Orchestrator) buildBirdNETV3(settings *conf.Settings, threads int) (*BirdNETV3, pathResolution, error) {
 	resolved, usedFallback := o.resolveFamilyPaths(RegistryIDBirdNETV3, modelFileSet{
 		model:  settings.BirdNETV3.ModelPath,
@@ -30,7 +33,7 @@ func (o *Orchestrator) buildBirdNETV3(settings *conf.Settings, threads int) (*Bi
 	labelPath := resolved.labels
 
 	if modelPath == "" || labelPath == "" {
-		return nil, res, errors.Newf("BirdNET v3.0 model files not installed or configured").
+		return nil, pathResolution{}, errors.Newf("BirdNET v3.0 model files not installed or configured").
 			Component("classifier.orchestrator").
 			Category(errors.CategoryModelInit).
 			Context("model", RegistryIDBirdNETV3).
@@ -38,7 +41,7 @@ func (o *Orchestrator) buildBirdNETV3(settings *conf.Settings, threads int) (*Bi
 	}
 
 	if err := checkORTOrFail(settings.BirdNET.ONNXRuntimePath, "BirdNET v3.0", RegistryIDBirdNETV3, "classifier.orchestrator"); err != nil {
-		return nil, res, err
+		return nil, pathResolution{}, err
 	}
 
 	cfg := BirdNETV3Config{
@@ -53,7 +56,7 @@ func (o *Orchestrator) buildBirdNETV3(settings *conf.Settings, threads int) (*Bi
 
 	model, err := NewBirdNETV3(&cfg)
 	if err != nil {
-		return nil, res, errors.New(err).
+		return nil, pathResolution{}, errors.New(err).
 			Component("classifier.orchestrator").
 			Category(errors.CategoryModelInit).
 			Context("model", RegistryIDBirdNETV3).

--- a/internal/classifier/orchestrator_birdnet_v3_onnx.go
+++ b/internal/classifier/orchestrator_birdnet_v3_onnx.go
@@ -15,16 +15,22 @@ import (
 //
 // The settings snapshot is passed in (rather than read inside) so the caller
 // builds with the exact settings it gated the reload decision on.
-func (o *Orchestrator) buildBirdNETV3(settings *conf.Settings, threads int) (*BirdNETV3, error) {
-	paths, _ := o.resolveFamilyPaths(RegistryIDBirdNETV3, modelFileSet{
+//
+// The path resolution is returned alongside the instance so loadBirdNETV3 can
+// decide whether to repair a stale configuration without resolving a second time
+// (see pathResolution). ReloadSecondaryModels discards it, which is what keeps a
+// backend or device swap from rewriting the user's paths.
+func (o *Orchestrator) buildBirdNETV3(settings *conf.Settings, threads int) (*BirdNETV3, pathResolution, error) {
+	resolved, usedFallback := o.resolveFamilyPaths(RegistryIDBirdNETV3, modelFileSet{
 		model:  settings.BirdNETV3.ModelPath,
 		labels: settings.BirdNETV3.LabelPath,
 	}, false)
-	modelPath := paths.model
-	labelPath := paths.labels
+	res := pathResolution{resolved: resolved, usedFallback: usedFallback}
+	modelPath := resolved.model
+	labelPath := resolved.labels
 
 	if modelPath == "" || labelPath == "" {
-		return nil, errors.Newf("BirdNET v3.0 model files not installed or configured").
+		return nil, res, errors.Newf("BirdNET v3.0 model files not installed or configured").
 			Component("classifier.orchestrator").
 			Category(errors.CategoryModelInit).
 			Context("model", RegistryIDBirdNETV3).
@@ -32,7 +38,7 @@ func (o *Orchestrator) buildBirdNETV3(settings *conf.Settings, threads int) (*Bi
 	}
 
 	if err := checkORTOrFail(settings.BirdNET.ONNXRuntimePath, "BirdNET v3.0", RegistryIDBirdNETV3, "classifier.orchestrator"); err != nil {
-		return nil, err
+		return nil, res, err
 	}
 
 	cfg := BirdNETV3Config{
@@ -47,14 +53,14 @@ func (o *Orchestrator) buildBirdNETV3(settings *conf.Settings, threads int) (*Bi
 
 	model, err := NewBirdNETV3(&cfg)
 	if err != nil {
-		return nil, errors.New(err).
+		return nil, res, errors.New(err).
 			Component("classifier.orchestrator").
 			Category(errors.CategoryModelInit).
 			Context("model", RegistryIDBirdNETV3).
 			Build()
 	}
 
-	return model, nil
+	return model, res, nil
 }
 
 // loadBirdNETV3 creates and registers a BirdNET v3.0 model instance from settings.
@@ -67,7 +73,7 @@ func (o *Orchestrator) loadBirdNETV3(threads int) error {
 	// ReloadSecondaryModels rebuilds it only when the backend/device changes.
 	settings := o.currentSettings()
 	before := o.captureRSSBefore()
-	model, err := o.buildBirdNETV3(settings, threads)
+	model, res, err := o.buildBirdNETV3(settings, threads)
 	if err != nil {
 		return err
 	}
@@ -77,11 +83,10 @@ func (o *Orchestrator) loadBirdNETV3(threads int) error {
 		backend:  secondaryTripletFor(settings),
 	}
 	// Queue a config repair when the model loaded from the gallery fallback
-	// because the configured path was stale. Drained after o.mu is released.
-	o.queuePathCorrectionIfFallback(RegistryIDBirdNETV3, modelFileSet{
-		model:  settings.BirdNETV3.ModelPath,
-		labels: settings.BirdNETV3.LabelPath,
-	}, false)
+	// because the configured path was stale. Uses the resolution the build
+	// already performed, so the repair can only ever persist the paths this
+	// instance was actually built from. Drained after o.mu is released.
+	o.queuePathCorrection(RegistryIDBirdNETV3, res)
 
 	// Defer the warm-up + RSS measurement until the caller releases o.mu, so the
 	// warm-up inference runs via the serialized inference path instead of stalling

--- a/internal/classifier/orchestrator_perch_onnx.go
+++ b/internal/classifier/orchestrator_perch_onnx.go
@@ -20,6 +20,9 @@ import (
 // whether to repair a stale configuration without resolving a second time (see
 // pathResolution). ReloadSecondaryModels discards it, which is what keeps a
 // backend or device swap from rewriting the user's paths.
+//
+// The returned resolution is meaningful only when err == nil; every error return
+// yields the zero pathResolution{}.
 func (o *Orchestrator) buildPerch(settings *conf.Settings, threads int) (*Perch, pathResolution, error) {
 	resolved, usedFallback := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
 		model:  settings.Perch.ModelPath,
@@ -30,7 +33,7 @@ func (o *Orchestrator) buildPerch(settings *conf.Settings, threads int) (*Perch,
 	labelPath := resolved.labels
 
 	if modelPath == "" || labelPath == "" {
-		return nil, res, errors.Newf("Perch v2 model files not installed or configured").
+		return nil, pathResolution{}, errors.Newf("Perch v2 model files not installed or configured").
 			Component("classifier.orchestrator").
 			Category(errors.CategoryModelInit).
 			Context("model", RegistryIDPerchV2).
@@ -38,7 +41,7 @@ func (o *Orchestrator) buildPerch(settings *conf.Settings, threads int) (*Perch,
 	}
 
 	if err := checkORTOrFail(settings.BirdNET.ONNXRuntimePath, "Perch v2", RegistryIDPerchV2, "classifier.orchestrator"); err != nil {
-		return nil, res, err
+		return nil, pathResolution{}, err
 	}
 
 	cfg := PerchConfig{
@@ -53,7 +56,7 @@ func (o *Orchestrator) buildPerch(settings *conf.Settings, threads int) (*Perch,
 
 	perch, err := NewPerch(&cfg)
 	if err != nil {
-		return nil, res, errors.New(err).
+		return nil, pathResolution{}, errors.New(err).
 			Component("classifier.orchestrator").
 			Category(errors.CategoryModelInit).
 			Context("model", RegistryIDPerchV2).

--- a/internal/classifier/orchestrator_perch_onnx.go
+++ b/internal/classifier/orchestrator_perch_onnx.go
@@ -15,16 +15,22 @@ import (
 //
 // The settings snapshot is passed in (rather than read inside) so the caller
 // builds with the exact settings it gated the reload decision on.
-func (o *Orchestrator) buildPerch(settings *conf.Settings, threads int) (*Perch, error) {
-	paths, _ := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
+//
+// The path resolution is returned alongside the instance so loadPerch can decide
+// whether to repair a stale configuration without resolving a second time (see
+// pathResolution). ReloadSecondaryModels discards it, which is what keeps a
+// backend or device swap from rewriting the user's paths.
+func (o *Orchestrator) buildPerch(settings *conf.Settings, threads int) (*Perch, pathResolution, error) {
+	resolved, usedFallback := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
 		model:  settings.Perch.ModelPath,
 		labels: settings.Perch.LabelPath,
 	}, false)
-	modelPath := paths.model
-	labelPath := paths.labels
+	res := pathResolution{resolved: resolved, usedFallback: usedFallback}
+	modelPath := resolved.model
+	labelPath := resolved.labels
 
 	if modelPath == "" || labelPath == "" {
-		return nil, errors.Newf("Perch v2 model files not installed or configured").
+		return nil, res, errors.Newf("Perch v2 model files not installed or configured").
 			Component("classifier.orchestrator").
 			Category(errors.CategoryModelInit).
 			Context("model", RegistryIDPerchV2).
@@ -32,7 +38,7 @@ func (o *Orchestrator) buildPerch(settings *conf.Settings, threads int) (*Perch,
 	}
 
 	if err := checkORTOrFail(settings.BirdNET.ONNXRuntimePath, "Perch v2", RegistryIDPerchV2, "classifier.orchestrator"); err != nil {
-		return nil, err
+		return nil, res, err
 	}
 
 	cfg := PerchConfig{
@@ -47,14 +53,14 @@ func (o *Orchestrator) buildPerch(settings *conf.Settings, threads int) (*Perch,
 
 	perch, err := NewPerch(&cfg)
 	if err != nil {
-		return nil, errors.New(err).
+		return nil, res, errors.New(err).
 			Component("classifier.orchestrator").
 			Category(errors.CategoryModelInit).
 			Context("model", RegistryIDPerchV2).
 			Build()
 	}
 
-	return perch, nil
+	return perch, res, nil
 }
 
 // loadPerch creates and registers a Perch v2 model instance from settings.
@@ -67,7 +73,7 @@ func (o *Orchestrator) loadPerch(threads int) error {
 	// when the backend/device actually changes (Forgejo #1119).
 	settings := o.currentSettings()
 	before := o.captureRSSBefore()
-	perch, err := o.buildPerch(settings, threads)
+	perch, res, err := o.buildPerch(settings, threads)
 	if err != nil {
 		return err
 	}
@@ -77,11 +83,10 @@ func (o *Orchestrator) loadPerch(threads int) error {
 		backend:  secondaryTripletFor(settings),
 	}
 	// Queue a config repair when the model loaded from the gallery fallback
-	// because the configured path was stale. Drained after o.mu is released.
-	o.queuePathCorrectionIfFallback(RegistryIDPerchV2, modelFileSet{
-		model:  settings.Perch.ModelPath,
-		labels: settings.Perch.LabelPath,
-	}, false)
+	// because the configured path was stale. Uses the resolution the build
+	// already performed, so the repair can only ever persist the paths this
+	// instance was actually built from. Drained after o.mu is released.
+	o.queuePathCorrection(RegistryIDPerchV2, res)
 
 	// Defer the warm-up + RSS measurement until the caller releases o.mu, so the
 	// warm-up inference runs via the serialized inference path instead of stalling


### PR DESCRIPTION
## Summary

Follow-ups to #4207, which taught the three secondary classifier loaders (Perch v2, BirdNET v3.0, Bat) to recover when the model path in config.yaml points at a file that no longer exists, and to self-heal the stale configuration afterwards.

**Adds the positive test for the self-heal chain.** The suite covered the two negative cases and the apply endpoint called directly with a hand-built correction, but nothing asserted that a stale set is ever queued or that draining the queue ever applies the repair. Both halves could be reduced to no-ops with the whole suite still green: models would keep loading through the runtime fallback so nothing would look broken, while config.yaml was never repaired and the stale basename kept feeding the installed-variant hint on every restart. The new test walks resolve, queue, drain, and asserts the published snapshot, the persisted config.yaml and the reconciled notification. Every assertion was mutation-verified against the corresponding no-op. A second test pins that the drain applies every queued correction rather than only the first, which matters on a real startup where several models are enabled; the bat family is the second correction on purpose, because its three-path set is otherwise never exercised through queue and drain.

**Resolves each file set once per load instead of twice.** `buildPerch`, `buildBirdNETV3` and `buildBat` now return the resolution alongside the instance, and the loaders consume it rather than recomputing it. Besides removing duplicate stat work this closes a real window: the model constructor runs between what used to be two resolutions and takes real time for an ONNX session, so a concurrent gallery install, uninstall or variant switch could make the second resolution disagree with the set the model was actually built from, and the repair would then persist those other paths. `ReloadSecondaryModels` still discards the resolution, which is what keeps a backend or device swap from rewriting the user's paths. The builders now return the zero resolution on every error path, since a populated value there contradicted the invariant that a correction is queued only after a successful build.

**Corrects the model-path lock rationale**, which was stated three different ways across two files and was wrong in two of them. The claim that the caller's lock excludes every writer does not hold, because `ReloadSecondaryModels` calls the builders after releasing the orchestrator lock, and the setter's own comment carried the same falsehood attached to the write. Both now state one rationale, and all three lock-free readers are named so that making the models directory dynamic cannot be attempted without finding them. Also fixes a doc comment that claimed `isGalleryManagedPath` reads only its arguments and the catalog snapshot when it reads the models directory too, a type declaration that had been inserted inside another type's doc comment and silently orphaned it, and a stale justification written in terms of the second resolution this PR removes.

## Related Issues

Relates to #4207. Closes #4210.

Not included, and deliberately so: the primary classifier still has no stale-path fallback under the same conditions. Scope was split after review found that `reloadModelInternal` also re-derives model identity from the raw setting and refuses the reload when it disagrees, so a correct fix has to span construction and the hot-reload identity gate together. That is wider than this change and gets its own PR.

## Test Plan

- [x] `go build ./...`, `go vet`, `gofmt` clean
- [x] `go test -race ./internal/classifier/...` green
- [x] `golangci-lint run` reports 0 issues project-wide
- [x] Full build-tag matrix (8 combinations) green on the changed packages
- [x] Mutation-verified: a no-op queue, a snapshot-and-discard drain, a removed reconciled notification, and a drain that applies only the first correction each make the new tests fail
- [x] Verified against the original reproduction with the real Perch v2 model: a stale gallery path under a changed models-directory root loads, self-heals config.yaml for model and labels as one set, and the next start is a clean no-op