### PR TITLE
fix(classifier): give the primary classifier a stale-path fallback and stop silent model substitution

### DIFF
--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -398,6 +398,9 @@ export type TranslationKey =
   | 'notifications.content.modelPath.reconciledMessage' // params: modelName, modelPath
   | 'notifications.content.modelPath.substitutedTitle' // params: modelName
   | 'notifications.content.modelPath.substitutedMessage' // params: modelName, modelPath
+  | 'notifications.content.modelPath.unreadableTitle' // params: modelName
+  | 'notifications.content.modelPath.unreadableMessage' // params: modelName, modelPath
+  | 'notifications.content.modelPath.builtinMessage' // params: modelName
   | 'notifications.content.modelPath.notRegisteredTitle' // params: sourceName
   | 'notifications.content.modelPath.notRegisteredMessage' // params: models, sourceName
   | 'notifications.content.alert.firedTitle' // params: rule_name
@@ -4222,6 +4225,12 @@ export type TranslationParams = {
     modelName: string | number;
     modelPath: string | number;
   };
+  'notifications.content.modelPath.unreadableTitle': { modelName: string | number };
+  'notifications.content.modelPath.unreadableMessage': {
+    modelName: string | number;
+    modelPath: string | number;
+  };
+  'notifications.content.modelPath.builtinMessage': { modelName: string | number };
   'notifications.content.modelPath.notRegisteredTitle': { sourceName: string | number };
   'notifications.content.modelPath.notRegisteredMessage': {
     models: string | number;

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -468,6 +468,9 @@
         "reconciledMessage": "Nakonfigurované cesty k souborům pro {modelName} byly zastaralé a byly opraveny tak, aby odpovídaly nainstalovanému modelu v {modelPath}.",
         "substitutedTitle": "Nakonfigurovaný soubor modelu pro {modelName} nebyl nalezen",
         "substitutedMessage": "Soubor modelu nakonfigurovaný pro {modelName} nebyl na disku nalezen, proto se místo něj používá nainstalovaný model v {modelPath}. Vaše konfigurace zůstala nezměněna.",
+        "unreadableTitle": "Nakonfigurovaný soubor modelu pro {modelName} se nepodařilo přečíst",
+        "unreadableMessage": "Soubor modelu nakonfigurovaný pro {modelName} existuje, ale nepodařilo se jej přečíst, proto se místo něj používá nainstalovaný model v {modelPath}. Vaše konfigurace zůstala nezměněna. Zkontrolujte oprávnění souboru a zda je jeho úložiště připojeno.",
+        "builtinMessage": "Soubor modelu nakonfigurovaný pro {modelName} nebyl na disku nalezen a není k dispozici žádný nainstalovaný model, který by jej nahradil, proto se místo něj používá vestavěný model. Vaše konfigurace zůstala nezměněna.",
         "notRegisteredTitle": "Žádný model neanalyzuje {sourceName}",
         "notRegisteredMessage": "K {models} na zdroji zvuku \"{sourceName}\" se nedostává žádný zvuk, takže se nevytvářejí žádné detekce. Otevřete galerii modelů v Nastavení a zkontrolujte stav."
       },

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -469,7 +469,7 @@
         "substitutedTitle": "Nakonfigurovaný soubor modelu pro {modelName} nebyl nalezen",
         "substitutedMessage": "Soubor modelu nakonfigurovaný pro {modelName} nebyl na disku nalezen, proto se místo něj používá nainstalovaný model v {modelPath}. Vaše konfigurace zůstala nezměněna.",
         "unreadableTitle": "Nakonfigurovaný soubor modelu pro {modelName} se nepodařilo přečíst",
-        "unreadableMessage": "Soubor modelu nakonfigurovaný pro {modelName} existuje, ale nepodařilo se jej přečíst, proto se místo něj používá nainstalovaný model v {modelPath}. Vaše konfigurace zůstala nezměněna. Zkontrolujte oprávnění souboru a zda je jeho úložiště připojeno.",
+        "unreadableMessage": "Soubor modelu nakonfigurovaný pro {modelName} existuje, ale nepodařilo se jej přečíst, proto se místo něj používá nainstalovaný model v {modelPath}. Vaše konfigurace zůstala nezměněna. Zkontrolujte oprávnění souboru a to, zda je jeho úložiště připojeno.",
         "builtinMessage": "Soubor modelu nakonfigurovaný pro {modelName} nebyl na disku nalezen a není k dispozici žádný nainstalovaný model, který by jej nahradil, proto se místo něj používá vestavěný model. Vaše konfigurace zůstala nezměněna.",
         "notRegisteredTitle": "Žádný model neanalyzuje {sourceName}",
         "notRegisteredMessage": "K {models} na zdroji zvuku \"{sourceName}\" se nedostává žádný zvuk, takže se nevytvářejí žádné detekce. Otevřete galerii modelů v Nastavení a zkontrolujte stav."

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -468,6 +468,9 @@
         "reconciledMessage": "De konfigurerede filstier for {modelName} var forældede og er blevet repareret, så de matcher den installerede model på {modelPath}.",
         "substitutedTitle": "Den konfigurerede modelfil for {modelName} blev ikke fundet",
         "substitutedMessage": "Modelfilen, der er konfigureret til {modelName}, blev ikke fundet på disken, så den installerede model på {modelPath} bruges i stedet. Din konfiguration blev ikke ændret.",
+        "unreadableTitle": "Den konfigurerede modelfil for {modelName} kunne ikke læses",
+        "unreadableMessage": "Modelfilen, der er konfigureret til {modelName}, findes, men kunne ikke læses, så den installerede model på {modelPath} bruges i stedet. Din konfiguration blev ikke ændret. Kontrollér filens tilladelser, og at dens lager er monteret.",
+        "builtinMessage": "Modelfilen, der er konfigureret til {modelName}, blev ikke fundet på disken, og der er ingen installeret model tilgængelig til at erstatte den, så den indbyggede model bruges i stedet. Din konfiguration blev ikke ændret.",
         "notRegisteredTitle": "Ingen model analyserer {sourceName}",
         "notRegisteredMessage": "Ingen lyd når {models} på lydkilden \"{sourceName}\", så der produceres ingen detektioner. Åbn modelgalleriet i Indstillinger for at tjekke status."
       },

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -470,7 +470,7 @@
         "substitutedMessage": "Die für {modelName} konfigurierte Modelldatei wurde nicht auf dem Datenträger gefunden, daher wird stattdessen das installierte Modell unter {modelPath} verwendet. Ihre Konfiguration wurde nicht verändert.",
         "unreadableTitle": "Konfigurierte Modelldatei für {modelName} konnte nicht gelesen werden",
         "unreadableMessage": "Die für {modelName} konfigurierte Modelldatei ist vorhanden, konnte aber nicht gelesen werden, daher wird stattdessen das installierte Modell unter {modelPath} verwendet. Ihre Konfiguration wurde nicht verändert. Überprüfen Sie die Dateiberechtigungen und ob der Speicher eingebunden ist.",
-        "builtinMessage": "Die für {modelName} konfigurierte Modelldatei wurde nicht auf dem Datenträger gefunden und es ist kein installiertes Modell als Ersatz verfügbar, daher wird stattdessen das eingebaute Modell verwendet. Ihre Konfiguration wurde nicht verändert.",
+        "builtinMessage": "Die für {modelName} konfigurierte Modelldatei wurde nicht auf dem Datenträger gefunden und es ist kein installiertes Modell als Ersatz verfügbar, daher wird stattdessen das integrierte Modell verwendet. Ihre Konfiguration wurde nicht verändert.",
         "notRegisteredTitle": "Kein Modell analysiert {sourceName}",
         "notRegisteredMessage": "Kein Audio erreicht {models} an der Audioquelle \"{sourceName}\", sodass keine Erkennungen erzeugt werden. Öffnen Sie die Modellgalerie unter Einstellungen, um den Status zu überprüfen."
       },

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -468,6 +468,9 @@
         "reconciledMessage": "Die konfigurierten Dateipfade für {modelName} waren veraltet und wurden repariert, um mit dem installierten Modell unter {modelPath} übereinzustimmen.",
         "substitutedTitle": "Konfigurierte Modelldatei für {modelName} wurde nicht gefunden",
         "substitutedMessage": "Die für {modelName} konfigurierte Modelldatei wurde nicht auf dem Datenträger gefunden, daher wird stattdessen das installierte Modell unter {modelPath} verwendet. Ihre Konfiguration wurde nicht verändert.",
+        "unreadableTitle": "Konfigurierte Modelldatei für {modelName} konnte nicht gelesen werden",
+        "unreadableMessage": "Die für {modelName} konfigurierte Modelldatei ist vorhanden, konnte aber nicht gelesen werden, daher wird stattdessen das installierte Modell unter {modelPath} verwendet. Ihre Konfiguration wurde nicht verändert. Überprüfen Sie die Dateiberechtigungen und ob der Speicher eingebunden ist.",
+        "builtinMessage": "Die für {modelName} konfigurierte Modelldatei wurde nicht auf dem Datenträger gefunden und es ist kein installiertes Modell als Ersatz verfügbar, daher wird stattdessen das eingebaute Modell verwendet. Ihre Konfiguration wurde nicht verändert.",
         "notRegisteredTitle": "Kein Modell analysiert {sourceName}",
         "notRegisteredMessage": "Kein Audio erreicht {models} an der Audioquelle \"{sourceName}\", sodass keine Erkennungen erzeugt werden. Öffnen Sie die Modellgalerie unter Einstellungen, um den Status zu überprüfen."
       },

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -468,6 +468,9 @@
         "reconciledMessage": "Configured file paths for {modelName} were out of date and have been repaired to match the installed model at {modelPath}.",
         "substitutedTitle": "Configured model file for {modelName} was not found",
         "substitutedMessage": "The model file configured for {modelName} was not found on disk, so the installed model at {modelPath} is being used instead. Your configuration was left unchanged.",
+        "unreadableTitle": "Configured model file for {modelName} could not be read",
+        "unreadableMessage": "The model file configured for {modelName} exists but could not be read, so the installed model at {modelPath} is being used instead. Your configuration was left unchanged. Check the file's permissions and that its storage is mounted.",
+        "builtinMessage": "The model file configured for {modelName} was not found on disk and no installed model is available to replace it, so the built-in model is being used instead. Your configuration was left unchanged.",
         "notRegisteredTitle": "No model is analyzing {sourceName}",
         "notRegisteredMessage": "No audio is reaching {models} on audio source \"{sourceName}\", so no detections are produced. Open the model gallery in Settings to check status."
       },

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -468,6 +468,9 @@
         "reconciledMessage": "Las rutas de archivo configuradas para {modelName} estaban desactualizadas y se han reparado para coincidir con el modelo instalado en {modelPath}.",
         "substitutedTitle": "No se encontró el archivo de modelo configurado para {modelName}",
         "substitutedMessage": "El archivo de modelo configurado para {modelName} no se encontró en el disco, por lo que en su lugar se está usando el modelo instalado en {modelPath}. Su configuración no se modificó.",
+        "unreadableTitle": "No se pudo leer el archivo de modelo configurado para {modelName}",
+        "unreadableMessage": "El archivo de modelo configurado para {modelName} existe pero no se pudo leer, por lo que en su lugar se está usando el modelo instalado en {modelPath}. Su configuración no se modificó. Compruebe los permisos del archivo y que su almacenamiento esté montado.",
+        "builtinMessage": "El archivo de modelo configurado para {modelName} no se encontró en el disco y no hay ningún modelo instalado disponible para reemplazarlo, por lo que en su lugar se está usando el modelo integrado. Su configuración no se modificó.",
         "notRegisteredTitle": "Ningún modelo está analizando {sourceName}",
         "notRegisteredMessage": "No llega audio a {models} en la fuente de audio \"{sourceName}\", por lo que no se generan detecciones. Abra la galería de modelos en Configuración para comprobar el estado."
       },

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -469,7 +469,7 @@
         "substitutedTitle": "Mallille {modelName} määritettyä mallitiedostoa ei löytynyt",
         "substitutedMessage": "Mallille {modelName} määritettyä mallitiedostoa ei löytynyt levyltä, joten sen sijaan käytetään asennettua mallia sijainnissa {modelPath}. Asetuksiasi ei muutettu.",
         "unreadableTitle": "Mallille {modelName} määritettyä mallitiedostoa ei voitu lukea",
-        "unreadableMessage": "Mallille {modelName} määritetty mallitiedosto on olemassa, mutta sitä ei voitu lukea, joten sen sijaan käytetään asennettua mallia sijainnissa {modelPath}. Asetuksiasi ei muutettu. Tarkista tiedoston käyttöoikeudet ja että sen tallennustila on liitetty.",
+        "unreadableMessage": "Mallille {modelName} määritetty mallitiedosto on olemassa, mutta sitä ei voitu lukea, joten sen sijaan käytetään asennettua mallia sijainnissa {modelPath}. Asetuksiasi ei muutettu. Tarkista tiedoston käyttöoikeudet ja se, että sen tallennustila on liitetty.",
         "builtinMessage": "Mallille {modelName} määritettyä mallitiedostoa ei löytynyt levyltä eikä korvaavaa asennettua mallia ole saatavilla, joten sen sijaan käytetään sisäänrakennettua mallia. Asetuksiasi ei muutettu.",
         "notRegisteredTitle": "Mikään malli ei analysoi kohdetta {sourceName}",
         "notRegisteredMessage": "Ääni ei tavoita kohdetta {models} äänilähteessä \"{sourceName}\", joten havaintoja ei tuoteta. Avaa Asetusten malligalleria tarkistaaksesi tilan."

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -468,6 +468,9 @@
         "reconciledMessage": "Mallille {modelName} määritetyt tiedostopolut olivat vanhentuneet, ja ne korjattiin vastaamaan asennettua mallia sijainnissa {modelPath}.",
         "substitutedTitle": "Mallille {modelName} määritettyä mallitiedostoa ei löytynyt",
         "substitutedMessage": "Mallille {modelName} määritettyä mallitiedostoa ei löytynyt levyltä, joten sen sijaan käytetään asennettua mallia sijainnissa {modelPath}. Asetuksiasi ei muutettu.",
+        "unreadableTitle": "Mallille {modelName} määritettyä mallitiedostoa ei voitu lukea",
+        "unreadableMessage": "Mallille {modelName} määritetty mallitiedosto on olemassa, mutta sitä ei voitu lukea, joten sen sijaan käytetään asennettua mallia sijainnissa {modelPath}. Asetuksiasi ei muutettu. Tarkista tiedoston käyttöoikeudet ja että sen tallennustila on liitetty.",
+        "builtinMessage": "Mallille {modelName} määritettyä mallitiedostoa ei löytynyt levyltä eikä korvaavaa asennettua mallia ole saatavilla, joten sen sijaan käytetään sisäänrakennettua mallia. Asetuksiasi ei muutettu.",
         "notRegisteredTitle": "Mikään malli ei analysoi kohdetta {sourceName}",
         "notRegisteredMessage": "Ääni ei tavoita kohdetta {models} äänilähteessä \"{sourceName}\", joten havaintoja ei tuoteta. Avaa Asetusten malligalleria tarkistaaksesi tilan."
       },

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -468,6 +468,9 @@
         "reconciledMessage": "Les chemins de fichiers configurés pour {modelName} étaient obsolètes et ont été réparés pour correspondre au modèle installé à l'emplacement {modelPath}.",
         "substitutedTitle": "Le fichier de modèle configuré pour {modelName} est introuvable",
         "substitutedMessage": "Le fichier de modèle configuré pour {modelName} est introuvable sur le disque, le modèle installé à l'emplacement {modelPath} est donc utilisé à la place. Votre configuration n'a pas été modifiée.",
+        "unreadableTitle": "Le fichier de modèle configuré pour {modelName} n'a pas pu être lu",
+        "unreadableMessage": "Le fichier de modèle configuré pour {modelName} existe mais n'a pas pu être lu, le modèle installé à l'emplacement {modelPath} est donc utilisé à la place. Votre configuration n'a pas été modifiée. Vérifiez les permissions du fichier et que son stockage est monté.",
+        "builtinMessage": "Le fichier de modèle configuré pour {modelName} est introuvable sur le disque et aucun modèle installé n'est disponible pour le remplacer, le modèle intégré est donc utilisé à la place. Votre configuration n'a pas été modifiée.",
         "notRegisteredTitle": "Aucun modèle n'analyse {sourceName}",
         "notRegisteredMessage": "Aucun audio ne parvient à {models} sur la source audio \"{sourceName}\", aucune détection n'est donc produite. Ouvrez la galerie de modèles dans les Paramètres pour vérifier l'état."
       },

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -468,6 +468,9 @@
         "reconciledMessage": "A(z) {modelName} beállított fájlelérési útjai elavultak voltak, és javításra kerültek, hogy megfeleljenek a(z) {modelPath} helyen telepített modellnek.",
         "substitutedTitle": "A(z) {modelName} modellhez beállított modellfájl nem található",
         "substitutedMessage": "A(z) {modelName} modellhez beállított modellfájl nem található a lemezen, ezért helyette a(z) {modelPath} helyen telepített modell van használatban. A konfigurációja változatlan maradt.",
+        "unreadableTitle": "A(z) {modelName} modellhez beállított modellfájlt nem sikerült beolvasni",
+        "unreadableMessage": "A(z) {modelName} modellhez beállított modellfájl létezik, de nem sikerült beolvasni, ezért helyette a(z) {modelPath} helyen telepített modell van használatban. A konfigurációja változatlan maradt. Ellenőrizze a fájl jogosultságait és azt, hogy a tárolója csatolva van-e.",
+        "builtinMessage": "A(z) {modelName} modellhez beállított modellfájl nem található a lemezen, és nem érhető el telepített modell a helyettesítésére, ezért helyette a beépített modell van használatban. A konfigurációja változatlan maradt.",
         "notRegisteredTitle": "Egyetlen modell sem elemzi a következőt: {sourceName}",
         "notRegisteredMessage": "Nem jut el hang a(z) {models} számára a(z) \"{sourceName}\" hangforráson, így nem jönnek létre detektálások. Nyissa meg a modellgalériát a Beállításokban az állapot ellenőrzéséhez."
       },

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -468,6 +468,9 @@
         "reconciledMessage": "I percorsi dei file configurati per {modelName} erano obsoleti e sono stati riparati per corrispondere al modello installato in {modelPath}.",
         "substitutedTitle": "File del modello configurato per {modelName} non trovato",
         "substitutedMessage": "Il file del modello configurato per {modelName} non è stato trovato sul disco, quindi viene utilizzato il modello installato in {modelPath}. La tua configurazione non è stata modificata.",
+        "unreadableTitle": "Impossibile leggere il file del modello configurato per {modelName}",
+        "unreadableMessage": "Il file del modello configurato per {modelName} esiste ma non è stato possibile leggerlo, quindi viene utilizzato il modello installato in {modelPath}. La tua configurazione non è stata modificata. Controlla i permessi del file e che il suo spazio di archiviazione sia montato.",
+        "builtinMessage": "Il file del modello configurato per {modelName} non è stato trovato sul disco e nessun modello installato è disponibile per sostituirlo, quindi viene utilizzato il modello integrato. La tua configurazione non è stata modificata.",
         "notRegisteredTitle": "Nessun modello sta analizzando {sourceName}",
         "notRegisteredMessage": "Nessun audio raggiunge {models} sulla sorgente audio \"{sourceName}\", quindi non vengono prodotti rilevamenti. Apri la galleria dei modelli in Impostazioni per verificare lo stato."
       },

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -468,6 +468,9 @@
         "reconciledMessage": "Konfigurētie failu ceļi modelim {modelName} bija novecojuši un tika salaboti, lai atbilstu instalētajam modelim vietā {modelPath}.",
         "substitutedTitle": "Konfigurētais {modelName} modeļa fails netika atrasts",
         "substitutedMessage": "Modelim {modelName} konfigurētais faila ceļš netika atrasts diskā, tāpēc tā vietā tiek izmantots instalētais modelis {modelPath}. Jūsu konfigurācija netika mainīta.",
+        "unreadableTitle": "Konfigurēto modeļa failu modelim {modelName} nevarēja nolasīt",
+        "unreadableMessage": "Modelim {modelName} konfigurētais modeļa fails pastāv, taču to nevarēja nolasīt, tāpēc tā vietā tiek izmantots instalētais modelis {modelPath}. Jūsu konfigurācija netika mainīta. Pārbaudiet faila atļaujas un to, vai tā krātuve ir montēta.",
+        "builtinMessage": "Modelim {modelName} konfigurētais modeļa fails netika atrasts diskā un nav pieejams neviens instalēts modelis tā aizstāšanai, tāpēc tā vietā tiek izmantots iebūvētais modelis. Jūsu konfigurācija netika mainīta.",
         "notRegisteredTitle": "Neviens modelis neanalizē {sourceName}",
         "notRegisteredMessage": "Audio nesasniedz {models} audio avotā \"{sourceName}\", tāpēc noteikšanas netiek veiktas. Atveriet modeļu galeriju sadaļā Iestatījumi, lai pārbaudītu statusu."
       },

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -468,6 +468,9 @@
         "reconciledMessage": "De konfigurerte filstiene for {modelName} var utdaterte og har blitt reparert for å samsvare med den installerte modellen på {modelPath}.",
         "substitutedTitle": "Fant ikke den konfigurerte modellfilen for {modelName}",
         "substitutedMessage": "Modellfilen som er konfigurert for {modelName}, ble ikke funnet på disken, så den installerte modellen på {modelPath} brukes i stedet. Konfigurasjonen din ble ikke endret.",
+        "unreadableTitle": "Kunne ikke lese den konfigurerte modellfilen for {modelName}",
+        "unreadableMessage": "Modellfilen som er konfigurert for {modelName}, finnes, men kunne ikke leses, så den installerte modellen på {modelPath} brukes i stedet. Konfigurasjonen din ble ikke endret. Sjekk filens tillatelser og at lagringen er montert.",
+        "builtinMessage": "Modellfilen som er konfigurert for {modelName}, ble ikke funnet på disken, og ingen installert modell er tilgjengelig for å erstatte den, så den innebygde modellen brukes i stedet. Konfigurasjonen din ble ikke endret.",
         "notRegisteredTitle": "Ingen modell analyserer {sourceName}",
         "notRegisteredMessage": "Ingen lyd når {models} på lydkilden \"{sourceName}\", så det produseres ingen registreringer. Åpne modellgalleriet i Innstillinger for å sjekke status."
       },

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -468,6 +468,9 @@
         "reconciledMessage": "De geconfigureerde bestandspaden voor {modelName} waren verouderd en zijn hersteld om overeen te komen met het geïnstalleerde model op {modelPath}.",
         "substitutedTitle": "Geconfigureerd modelbestand voor {modelName} niet gevonden",
         "substitutedMessage": "Het voor {modelName} geconfigureerde modelbestand is niet op de schijf gevonden, dus wordt in plaats daarvan het geïnstalleerde model op {modelPath} gebruikt. Uw configuratie is ongewijzigd gebleven.",
+        "unreadableTitle": "Geconfigureerd modelbestand voor {modelName} kon niet worden gelezen",
+        "unreadableMessage": "Het voor {modelName} geconfigureerde modelbestand bestaat, maar kon niet worden gelezen, dus wordt in plaats daarvan het geïnstalleerde model op {modelPath} gebruikt. Uw configuratie is ongewijzigd gebleven. Controleer de bestandsmachtigingen en of de opslag is gekoppeld.",
+        "builtinMessage": "Het voor {modelName} geconfigureerde modelbestand is niet op de schijf gevonden en er is geen geïnstalleerd model beschikbaar om het te vervangen, dus wordt in plaats daarvan het ingebouwde model gebruikt. Uw configuratie is ongewijzigd gebleven.",
         "notRegisteredTitle": "Geen model analyseert {sourceName}",
         "notRegisteredMessage": "Er bereikt geen audio {models} op audiobron \"{sourceName}\", waardoor er geen detecties worden geproduceerd. Open de modellengalerij in Instellingen om de status te controleren."
       },

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -468,6 +468,9 @@
         "reconciledMessage": "Skonfigurowane ścieżki plików dla {modelName} były nieaktualne i zostały naprawione, aby pasowały do zainstalowanego modelu w {modelPath}.",
         "substitutedTitle": "Nie znaleziono skonfigurowanego pliku modelu dla {modelName}",
         "substitutedMessage": "Skonfigurowany plik modelu dla {modelName} nie został znaleziony na dysku, dlatego zamiast niego używany jest zainstalowany model w lokalizacji {modelPath}. Twoja konfiguracja pozostała niezmieniona.",
+        "unreadableTitle": "Nie udało się odczytać skonfigurowanego pliku modelu dla {modelName}",
+        "unreadableMessage": "Skonfigurowany plik modelu dla {modelName} istnieje, ale nie udało się go odczytać, dlatego zamiast niego używany jest zainstalowany model w lokalizacji {modelPath}. Twoja konfiguracja pozostała niezmieniona. Sprawdź uprawnienia pliku oraz to, czy pamięć masowa jest zamontowana.",
+        "builtinMessage": "Skonfigurowany plik modelu dla {modelName} nie został znaleziony na dysku i żaden zainstalowany model nie jest dostępny, aby go zastąpić, dlatego zamiast niego używany jest wbudowany model. Twoja konfiguracja pozostała niezmieniona.",
         "notRegisteredTitle": "Żaden model nie analizuje {sourceName}",
         "notRegisteredMessage": "Żaden dźwięk nie dociera do {models} na źródle audio \"{sourceName}\", więc nie są generowane żadne detekcje. Otwórz galerię modeli w Ustawieniach, aby sprawdzić stan."
       },

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -468,6 +468,9 @@
         "reconciledMessage": "Os caminhos de ficheiro configurados para {modelName} estavam desatualizados e foram reparados para corresponder ao modelo instalado em {modelPath}.",
         "substitutedTitle": "Ficheiro de modelo configurado para {modelName} não encontrado",
         "substitutedMessage": "O ficheiro de modelo configurado para {modelName} não foi encontrado no disco, pelo que o modelo instalado em {modelPath} está a ser utilizado em vez disso. A sua configuração não foi alterada.",
+        "unreadableTitle": "Não foi possível ler o ficheiro de modelo configurado para {modelName}",
+        "unreadableMessage": "O ficheiro de modelo configurado para {modelName} existe, mas não pôde ser lido, pelo que o modelo instalado em {modelPath} está a ser utilizado em vez disso. A sua configuração não foi alterada. Verifique as permissões do ficheiro e se o seu armazenamento está montado.",
+        "builtinMessage": "O ficheiro de modelo configurado para {modelName} não foi encontrado no disco e não existe nenhum modelo instalado disponível para o substituir, pelo que o modelo integrado está a ser utilizado em vez disso. A sua configuração não foi alterada.",
         "notRegisteredTitle": "Nenhum modelo está a analisar {sourceName}",
         "notRegisteredMessage": "Nenhum áudio está a chegar a {models} na fonte de áudio \"{sourceName}\", pelo que não são produzidas deteções. Abra a galeria de modelos nas Configurações para verificar o estado."
       },

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -468,6 +468,9 @@
         "reconciledMessage": "Nakonfigurované cesty k súborom pre {modelName} boli zastarané a boli opravené tak, aby zodpovedali nainštalovanému modelu v {modelPath}.",
         "substitutedTitle": "Nakonfigurovaný súbor modelu pre {modelName} sa nenašiel",
         "substitutedMessage": "Súbor modelu nakonfigurovaný pre {modelName} sa na disku nenašiel, preto sa namiesto neho používa nainštalovaný model v {modelPath}. Vaša konfigurácia zostala nezmenená.",
+        "unreadableTitle": "Nakonfigurovaný súbor modelu pre {modelName} sa nepodarilo prečítať",
+        "unreadableMessage": "Súbor modelu nakonfigurovaný pre {modelName} existuje, ale nepodarilo sa ho prečítať, preto sa namiesto neho používa nainštalovaný model v {modelPath}. Vaša konfigurácia zostala nezmenená. Skontrolujte oprávnenia súboru a či je jeho úložisko pripojené.",
+        "builtinMessage": "Súbor modelu nakonfigurovaný pre {modelName} sa na disku nenašiel a nie je k dispozícii žiadny nainštalovaný model, ktorý by ho nahradil, preto sa namiesto neho používa vstavaný model. Vaša konfigurácia zostala nezmenená.",
         "notRegisteredTitle": "Žiadny model neanalyzuje {sourceName}",
         "notRegisteredMessage": "K {models} na zvukovom zdroji \"{sourceName}\" sa nedostáva žiadny zvuk, takže sa nevytvárajú žiadne detekcie. Otvorte galériu modelov v Nastaveniach a skontrolujte stav."
       },

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -469,7 +469,7 @@
         "substitutedTitle": "Nakonfigurovaný súbor modelu pre {modelName} sa nenašiel",
         "substitutedMessage": "Súbor modelu nakonfigurovaný pre {modelName} sa na disku nenašiel, preto sa namiesto neho používa nainštalovaný model v {modelPath}. Vaša konfigurácia zostala nezmenená.",
         "unreadableTitle": "Nakonfigurovaný súbor modelu pre {modelName} sa nepodarilo prečítať",
-        "unreadableMessage": "Súbor modelu nakonfigurovaný pre {modelName} existuje, ale nepodarilo sa ho prečítať, preto sa namiesto neho používa nainštalovaný model v {modelPath}. Vaša konfigurácia zostala nezmenená. Skontrolujte oprávnenia súboru a či je jeho úložisko pripojené.",
+        "unreadableMessage": "Súbor modelu nakonfigurovaný pre {modelName} existuje, ale nepodarilo sa ho prečítať, preto sa namiesto neho používa nainštalovaný model v {modelPath}. Vaša konfigurácia zostala nezmenená. Skontrolujte oprávnenia súboru a to, či je jeho úložisko pripojené.",
         "builtinMessage": "Súbor modelu nakonfigurovaný pre {modelName} sa na disku nenašiel a nie je k dispozícii žiadny nainštalovaný model, ktorý by ho nahradil, preto sa namiesto neho používa vstavaný model. Vaša konfigurácia zostala nezmenená.",
         "notRegisteredTitle": "Žiadny model neanalyzuje {sourceName}",
         "notRegisteredMessage": "K {models} na zvukovom zdroji \"{sourceName}\" sa nedostáva žiadny zvuk, takže sa nevytvárajú žiadne detekcie. Otvorte galériu modelov v Nastaveniach a skontrolujte stav."

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -468,6 +468,9 @@
         "reconciledMessage": "De konfigurerade filsökvägarna för {modelName} var inaktuella och har reparerats för att matcha den installerade modellen på {modelPath}.",
         "substitutedTitle": "Den konfigurerade modellfilen för {modelName} hittades inte",
         "substitutedMessage": "Modellfilen som konfigurerats för {modelName} hittades inte på disken, så den installerade modellen på {modelPath} används i stället. Din konfiguration lämnades oförändrad.",
+        "unreadableTitle": "Den konfigurerade modellfilen för {modelName} kunde inte läsas",
+        "unreadableMessage": "Modellfilen som konfigurerats för {modelName} finns men kunde inte läsas, så den installerade modellen på {modelPath} används i stället. Din konfiguration lämnades oförändrad. Kontrollera filens behörigheter och att dess lagring är monterad.",
+        "builtinMessage": "Modellfilen som konfigurerats för {modelName} hittades inte på disken och det finns ingen installerad modell tillgänglig att ersätta den med, så den inbyggda modellen används i stället. Din konfiguration lämnades oförändrad.",
         "notRegisteredTitle": "Ingen modell analyserar {sourceName}",
         "notRegisteredMessage": "Inget ljud når {models} på ljudkällan \"{sourceName}\", så det produceras inga detektioner. Öppna modellgalleriet i Inställningar för att kontrollera status."
       },

--- a/internal/classifier/analyze.go
+++ b/internal/classifier/analyze.go
@@ -32,14 +32,14 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 	settings := bn.currentSettings()
 	start := time.Now()
 
-	// The three ModelContext decorations below deliberately report the CONFIGURED
-	// path (settings.BirdNET.ModelPath), not bn.configuredModelPath(), even though
-	// every load-path site reports the resolved one. After a stale-path recovery
-	// the two differ, so this telemetry names a file the instance is not running.
-	// That is knowingly accepted: the first decoration runs BEFORE bn.mu is taken
-	// below, and bn.primaryPath is written under bn.mu by reloadModelInternal, so
-	// reading the resolved value here would be a data race. Reporting the resolved
-	// path needs a lock-free published copy alongside bn.identity.
+	// The decoration below reports the CONFIGURED path
+	// (settings.BirdNET.ModelPath), not bn.configuredModelPath(), and that is
+	// deliberate: this runs BEFORE bn.mu is taken, and bn.primaryPath is written
+	// under bn.mu by reloadModelInternal, so reading the resolved value here would
+	// be a data race. Reporting the resolved path on THIS path needs a lock-free
+	// published copy alongside bn.identity. The two decorations after the lock do
+	// report the resolved path, since after a stale-path recovery the configured
+	// one names a file the instance is not running.
 	//
 	// Guard against empty sample slice. Pre-inference rejections are tagged but
 	// not counted as predictions.
@@ -60,7 +60,7 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 		span.markErrored(errTypeClassifierNil)
 		return nil, errors.Newf("classifier backend is not initialized").
 			Category(errors.CategoryModelInit).
-			ModelContext(settings.BirdNET.ModelPath, modelID).
+			ModelContext(bn.configuredModelPath(), modelID).
 			Build()
 	}
 
@@ -70,7 +70,7 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 	if err != nil {
 		err = errors.New(err).
 			Category(errors.CategoryAudio).
-			ModelContext(settings.BirdNET.ModelPath, modelID).
+			ModelContext(bn.configuredModelPath(), modelID).
 			Context("sample_length", len(sample[0])).
 			Timing("prediction-invoke", time.Since(invokeStart)).
 			Build()

--- a/internal/classifier/analyze.go
+++ b/internal/classifier/analyze.go
@@ -32,6 +32,15 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 	settings := bn.currentSettings()
 	start := time.Now()
 
+	// The three ModelContext decorations below deliberately report the CONFIGURED
+	// path (settings.BirdNET.ModelPath), not bn.configuredModelPath(), even though
+	// every load-path site reports the resolved one. After a stale-path recovery
+	// the two differ, so this telemetry names a file the instance is not running.
+	// That is knowingly accepted: the first decoration runs BEFORE bn.mu is taken
+	// below, and bn.primaryPath is written under bn.mu by reloadModelInternal, so
+	// reading the resolved value here would be a data race. Reporting the resolved
+	// path needs a lock-free published copy alongside bn.identity.
+	//
 	// Guard against empty sample slice. Pre-inference rejections are tagged but
 	// not counted as predictions.
 	if len(sample) == 0 || len(sample[0]) == 0 {

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -1563,13 +1563,17 @@ func (bn *BirdNET) reloadModelInternal(allowPathChange bool) error {
 		// loudly rather than silently swapping models) while the running detector is
 		// untouched. The variant-swap path is excluded because there a cleared path
 		// IS the intended revert, handled by the next case.
+		// Captured BEFORE rollback(): rollback restores bn.Settings to the previous
+		// snapshot, so reading the path after it would name the OLD configured file
+		// and assert that a healthy path is unusable.
+		configuredPath := bn.Settings.BirdNET.ModelPath
 		rollback()
-		return errors.Newf("configured birdnet model file %q is no longer usable and no installed variant can replace it: requires orchestrator restart", bn.Settings.BirdNET.ModelPath).
+		return errors.Newf("configured birdnet model file %q is no longer usable and no installed variant can replace it: requires orchestrator restart", configuredPath).
 			Component("birdnet").
 			Category(errors.CategoryModelInit).
 			Context("operation", "reload_model").
 			Context("current_model_path", bn.ModelInfo.CustomPath).
-			Context("configured_model_path", bn.Settings.BirdNET.ModelPath).
+			Context("configured_model_path", configuredPath).
 			Build()
 	case allowPathChange:
 		// Variant-swap path with a CLEARED BirdNET.ModelPath: the user reverted to

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -88,6 +88,22 @@ type BirdNET struct {
 	TaxonomyPath        string              // Path to custom taxonomy file, if used
 	modelVersion        string              // Human-readable model version string (per-instance to avoid shared global state)
 	modelsDir           string              // base directory for gallery-installed models (set by Orchestrator)
+	// primaryPath is the outcome of resolving settings.BirdNET.ModelPath for this
+	// instance: which primary classifier model file it actually loads from, and
+	// whether that differs from what the user configured. resolved.model differs
+	// from the configured value only when the configured file is confirmed absent
+	// (an installed variant replaces it, or it resolves to empty so the built-in
+	// baseline runs). Every load-path consumer reads it via configuredModelPath()
+	// so identity resolution, backend dispatch and the actual file open can never
+	// disagree about which file is being loaded.
+	//
+	// settings.BirdNET.ModelPath itself is NEVER mutated; the repair goes through
+	// the orchestrator's correction queue, which reads the substituted/repairable
+	// flags kept here. Written under mu by reloadModelInternal, like ModelInfo.
+	primaryPath pathResolution
+	// resolvePrimary re-resolves primaryPath on a hot reload. Nil outside the
+	// orchestrator path, in which case the configured value is used verbatim.
+	resolvePrimary primaryPathResolver
 	// runtime holds the live device/backend/precision triplet (see runtimeInfo),
 	// published by each initialize*Model path via setRuntimeInfo and restored by the
 	// reload rollback. It is deliberately kept OFF bn.mu: inference holds bn.mu for
@@ -140,17 +156,49 @@ func (bn *BirdNET) updateSettings(s *conf.Settings) {
 	bn.settingsAtomic.Store(s)
 }
 
+// configuredModelPath returns the primary classifier model file this instance
+// actually loads from. Prefer it over reading settings.BirdNET.ModelPath directly
+// anywhere on the load path: after a stale-path recovery the two differ, and a
+// consumer left on the raw value would dispatch a backend, name a model, or open
+// a file that disagrees with the one the instance was built from.
+//
+// settings.BirdNET.ModelPath remains the right thing to read where the question
+// is genuinely "what did the user configure" rather than "what are we running":
+// the settings API's change detection is one such caller.
+func (bn *BirdNET) configuredModelPath() string {
+	return bn.primaryPath.resolved.model
+}
+
+// resolvePrimaryOrConfigured applies a primaryPathResolver, treating a nil
+// resolver as "use the configured path verbatim". Kept as one helper so the
+// construction path and the reload path cannot drift apart on the nil case.
+func resolvePrimaryOrConfigured(resolve primaryPathResolver, configured string) pathResolution {
+	if resolve == nil {
+		return pathResolution{resolved: modelFileSet{model: configured}}
+	}
+	return resolve(configured)
+}
+
 // NewBirdNET initializes a new BirdNET instance with given settings.
 // If modelInfo is non-nil it is used directly (orchestrator path); otherwise
 // the function walks a 4-tier resolution chain: config version > filename > default.
-func NewBirdNET(settings *conf.Settings, modelInfo *ModelInfo) (*BirdNET, error) {
+func NewBirdNET(settings *conf.Settings, modelInfo *ModelInfo, resolvePrimary primaryPathResolver) (*BirdNET, error) {
 	bn := &BirdNET{
-		Settings:     settings,
-		TaxonomyPath: "", // Default to embedded taxonomy
-		modelVersion: defaultModelVersionString,
-		speciesCache: make(map[string]*speciesCacheEntry),
+		Settings:       settings,
+		TaxonomyPath:   "", // Default to embedded taxonomy
+		modelVersion:   defaultModelVersionString,
+		speciesCache:   make(map[string]*speciesCacheEntry),
+		resolvePrimary: resolvePrimary,
 	}
 	bn.settingsAtomic.Store(settings)
+
+	// Resolve the configured primary model path BEFORE the identity tier switch,
+	// so a stale path is recovered rather than carried into the identity. Resolving
+	// here (not inside a tier) is what makes the "recovered to empty" case behave
+	// exactly as if no path had ever been configured: Tier 3 stops firing, Tier 4
+	// resolves the default, and remapV24ToONNXOnARM64 (which returns early on a
+	// non-empty CustomPath) is free to remap arm64 to the INT8 ONNX build.
+	bn.primaryPath = resolvePrimaryOrConfigured(resolvePrimary, settings.BirdNET.ModelPath)
 
 	// Resolve model identity via the resolution chain
 	var err error
@@ -169,17 +217,17 @@ func NewBirdNET(settings *conf.Settings, modelInfo *ModelInfo) (*BirdNET, error)
 				Build()
 		}
 		bn.ModelInfo = info
-		if settings.BirdNET.ModelPath != "" {
-			bn.ModelInfo.CustomPath = settings.BirdNET.ModelPath
+		if p := bn.configuredModelPath(); p != "" {
+			bn.ModelInfo.CustomPath = p
 		}
-	case settings.BirdNET.ModelPath != "":
+	case bn.configuredModelPath() != "":
 		// Tier 3: explicit model path in the birdnet config section. Any model in
 		// the birdnet slot is a BirdNET v2.4-type classifier, so it inherits the
 		// canonical BirdNET_V2.4 identity regardless of filename (BirdNET v3.0 is
 		// selected via birdnet.version, not by a filename here). Keeping the ID
 		// canonical ensures the per-source model-set join matches the loaded model
 		// so the primary classifier gets a buffer monitor and inference starts.
-		bn.ModelInfo = customBirdNETV24ModelInfo(settings.BirdNET.ModelPath)
+		bn.ModelInfo = customBirdNETV24ModelInfo(bn.configuredModelPath())
 	default:
 		// Tier 4: default classifier. On arm64 (container images ship the
 		// INT8-ARM ONNX model alongside the binary) this resolves to the
@@ -246,7 +294,7 @@ func NewBirdNET(settings *conf.Settings, modelInfo *ModelInfo) (*BirdNET, error)
 			Component("birdnet").
 			Category(errors.CategoryModelInit).
 			Context("operation", "load_labels").
-			ModelContext(settings.BirdNET.ModelPath, bn.ModelInfo.ID).
+			ModelContext(bn.configuredModelPath(), bn.ModelInfo.ID).
 			Context("locale", settings.BirdNET.Locale).
 			Build()
 	}
@@ -256,7 +304,7 @@ func NewBirdNET(settings *conf.Settings, modelInfo *ModelInfo) (*BirdNET, error)
 			Component("birdnet").
 			Category(errors.CategoryModelInit).
 			Context("operation", "initialize_model").
-			ModelContext(settings.BirdNET.ModelPath, bn.ModelInfo.ID).
+			ModelContext(bn.configuredModelPath(), bn.ModelInfo.ID).
 			Build()
 	}
 
@@ -285,7 +333,7 @@ func NewBirdNET(settings *conf.Settings, modelInfo *ModelInfo) (*BirdNET, error)
 			Component("birdnet").
 			Category(errors.CategoryModelInit).
 			Context("operation", "validate_model_and_labels").
-			ModelContext(settings.BirdNET.ModelPath, bn.ModelInfo.ID).
+			ModelContext(bn.configuredModelPath(), bn.ModelInfo.ID).
 			Build()
 	}
 
@@ -310,7 +358,11 @@ func isONNXModel(path string) bool {
 // arm64 INT8 default, whose model path is empty and whose file is carried in
 // ModelInfo.CustomPath).
 func (bn *BirdNET) usesONNXBackend() bool {
-	return isONNXModel(bn.Settings.BirdNET.ModelPath) || bn.ModelInfo.Backend == BackendONNX
+	// The RESOLVED path, not the configured one: this drives backend dispatch, so
+	// it must describe the file initializeONNXModel / initializeTFLiteModel will
+	// actually open. After a recovery those differ, and dispatching on the stale
+	// string could send a recovered .onnx file to the TFLite backend.
+	return isONNXModel(bn.configuredModelPath()) || bn.ModelInfo.Backend == BackendONNX
 }
 
 // initializeModel loads and initializes the primary BirdNET model.
@@ -342,7 +394,7 @@ func (bn *BirdNET) initializeTFLiteModel() error {
 	if err != nil {
 		return errors.New(err).
 			Category(errors.CategoryModelLoad).
-			ModelContext(bn.Settings.BirdNET.ModelPath, bn.ModelInfo.ID).
+			ModelContext(bn.configuredModelPath(), bn.ModelInfo.ID).
 			Timing("model-load", time.Since(start)).
 			Build()
 	}
@@ -361,7 +413,7 @@ func (bn *BirdNET) initializeTFLiteModel() error {
 	if err != nil {
 		return errors.New(err).
 			Category(errors.CategoryModelInit).
-			ModelContext(bn.Settings.BirdNET.ModelPath, bn.ModelInfo.ID).
+			ModelContext(bn.configuredModelPath(), bn.ModelInfo.ID).
 			Context("model_size_mb", len(modelData)/1024/1024).
 			Context("use_xnnpack", bn.Settings.BirdNET.UseXNNPACK).
 			Timing("model-init", time.Since(start)).
@@ -377,8 +429,8 @@ func (bn *BirdNET) initializeTFLiteModel() error {
 	// Update the human-readable model version string for display when a custom
 	// model path is provided. Model identity (ModelInfo.ID) is never modified
 	// here, as it was fully resolved by NewBirdNET's 4-tier resolution chain.
-	if bn.Settings.BirdNET.ModelPath != "" {
-		bn.modelVersion = bn.Settings.BirdNET.ModelPath
+	if p := bn.configuredModelPath(); p != "" {
+		bn.modelVersion = p
 	}
 
 	// Log model initialization details
@@ -814,7 +866,9 @@ func (bn *BirdNET) logMissingTaxonomyCodes() {
 	complete, missing := IsTaxonomyComplete(bn.TaxonomyMap, bn.Settings.BirdNET.Labels)
 	if !complete {
 		// For custom models, provide more detailed information about missing taxonomy codes
-		if bn.Settings.BirdNET.ModelPath != "" || bn.Settings.BirdNET.LabelPath != "" {
+		// The resolved path: after a recovery to the built-in baseline nothing custom
+		// is loaded any more, so calling it a custom model would misdescribe it.
+		if bn.configuredModelPath() != "" || bn.Settings.BirdNET.LabelPath != "" {
 			bn.Debug("Custom model/labels detected: %d species are missing from the taxonomy data", len(missing))
 			bn.Debug("Placeholder taxonomy codes will be generated for these species")
 		} else {
@@ -1201,16 +1255,19 @@ func tryLoadModelFromStandardPaths(modelName, modelType string) (data []byte, pa
 func (bn *BirdNET) loadModel() ([]byte, error) {
 	start := time.Now()
 
-	// If a specific model path is configured, use it
-	if bn.Settings.BirdNET.ModelPath != "" {
-		modelPath := bn.Settings.BirdNET.ModelPath
+	// If a specific model path is configured, use it. configuredModelPath, not the
+	// raw setting: a configured path that was confirmed missing has already been
+	// resolved to the installed variant, or to empty so the branches below load the
+	// standard-path or embedded baseline instead of failing the whole construction.
+	if configuredPath := bn.configuredModelPath(); configuredPath != "" {
+		modelPath := configuredPath
 		// Expand environment variables and ~ prefix
 		modelPath = os.ExpandEnv(modelPath)
 		modelPath, err := conf.ExpandTildePath(modelPath)
 		if err != nil {
 			return nil, errors.New(err).
 				Category(errors.CategoryFileIO).
-				Context("path", bn.Settings.BirdNET.ModelPath).
+				Context("path", configuredPath).
 				Build()
 		}
 
@@ -1261,7 +1318,7 @@ func (bn *BirdNET) validateModelAndLabels() error {
 		return errors.Newf("label count mismatch: model expects %d classes but label file has %d labels",
 			modelOutputSize, labelCount).
 			Category(errors.CategoryValidation).
-			ModelContext(bn.Settings.BirdNET.ModelPath, bn.ModelInfo.ID).
+			ModelContext(bn.configuredModelPath(), bn.ModelInfo.ID).
 			Context("expected_labels", modelOutputSize).
 			Context("actual_labels", labelCount).
 			Context("locale", bn.Settings.BirdNET.Locale).
@@ -1367,6 +1424,21 @@ func (bn *BirdNET) reloadModelInternal(allowPathChange bool) error {
 	// failed attempt instead of the previous (still-serving) model.
 	oldRuntime := bn.runtime.Load()
 	oldModelVersion := bn.modelVersion
+	oldPrimaryPath := bn.primaryPath
+
+	// Re-resolve the configured primary path for THIS reload, exactly as
+	// NewBirdNET does at construction. Without this the identity checks below would
+	// compare a re-derived identity built from the RAW configured string against a
+	// live identity built from the RECOVERED one, and a start that successfully
+	// recovered a stale path would fail its very next settings reload (a locale
+	// change, a threshold edit) with "requires orchestrator restart". A user who hit
+	// the original stale-path bug would get a second, louder bug on their next save.
+	//
+	// The resolution is deterministic, so recovered resolves to recovered both
+	// before and after the correction is persisted, and neither ordering produces a
+	// spurious veto. A genuine user edit to a different existing file still
+	// resolves to itself and is still refused on the settings-reload path.
+	bn.primaryPath = resolvePrimaryOrConfigured(bn.resolvePrimary, bn.Settings.BirdNET.ModelPath)
 
 	rollback := func() {
 		if bn.classifier != nil && bn.classifier != oldClassifier {
@@ -1388,6 +1460,10 @@ func (bn *BirdNET) reloadModelInternal(allowPathChange bool) error {
 		// rather than the failed attempt.
 		bn.runtime.Store(oldRuntime)
 		bn.modelVersion = oldModelVersion
+		// Restore the resolved primary path with the rest of the identity, or a
+		// rolled-back reload would leave the still-serving model described by, and
+		// later reloads comparing against, the failed attempt's path.
+		bn.primaryPath = oldPrimaryPath
 		// Republish the getter-visible identity from the restored ModelInfo /
 		// modelVersion so ModelID/ModelName/ModelVersion/Spec revert too.
 		bn.publishIdentity()
@@ -1415,7 +1491,7 @@ func (bn *BirdNET) reloadModelInternal(allowPathChange bool) error {
 				Context("version", bn.Settings.BirdNET.Version).
 				Build()
 		}
-		newInfo.CustomPath = bn.Settings.BirdNET.ModelPath
+		newInfo.CustomPath = bn.configuredModelPath()
 		// Mirror NewBirdNET (the remap at construction): on arm64 a v2.4 TFLite model
 		// resolved from version:"2.4" is remapped to the INT8 ONNX entry. Without this, a
 		// no-op reload re-resolves to the TFLite entry, and the identity check below
@@ -1436,14 +1512,14 @@ func (bn *BirdNET) reloadModelInternal(allowPathChange bool) error {
 				Build()
 		}
 		bn.ModelInfo = newInfo
-	case bn.Settings.BirdNET.ModelPath != "":
+	case bn.configuredModelPath() != "":
 		// Birdnet-slot model: re-derive the canonical BirdNET_V2.4 identity from
-		// the configured path (mirrors NewBirdNET Tier 3). The ID stays
+		// the resolved path (mirrors NewBirdNET Tier 3). The ID stays
 		// BirdNET_V2.4 across reloads, so only a change of the model file path is
 		// treated as a model change requiring an orchestrator restart; a no-op
 		// reload (e.g. a locale change) stays in-place. On the variant-swap path a
 		// changed path IS the intended swap, so it is accepted in place.
-		newInfo := customBirdNETV24ModelInfo(bn.Settings.BirdNET.ModelPath)
+		newInfo := customBirdNETV24ModelInfo(bn.configuredModelPath())
 		if !allowPathChange && newInfo.CustomPath != bn.ModelInfo.CustomPath {
 			rollback()
 			return errors.Newf("birdnet model file changed from %q to %q: requires orchestrator restart", bn.ModelInfo.CustomPath, newInfo.CustomPath).

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -180,8 +180,14 @@ func resolvePrimaryOrConfigured(resolve primaryPathResolver, configured string) 
 }
 
 // NewBirdNET initializes a new BirdNET instance with given settings.
-// If modelInfo is non-nil it is used directly (orchestrator path); otherwise
-// the function walks a 4-tier resolution chain: config version > filename > default.
+// If modelInfo is non-nil it is used directly; otherwise the function walks a
+// 4-tier resolution chain: config version > filename > default. Every production
+// caller currently passes nil (NewOrchestrator stopped pre-seeding the identity,
+// so that Tier 2 sees the RESOLVED path), leaving Tier 1 unused for now.
+//
+// resolvePrimary supplies the stale-path recovery for the primary model file. A
+// nil resolver means "use the configured path verbatim", which is the behaviour
+// every caller without an orchestrator keeps.
 func NewBirdNET(settings *conf.Settings, modelInfo *ModelInfo, resolvePrimary primaryPathResolver) (*BirdNET, error) {
 	bn := &BirdNET{
 		Settings:       settings,
@@ -1531,6 +1537,40 @@ func (bn *BirdNET) reloadModelInternal(allowPathChange bool) error {
 				Build()
 		}
 		bn.ModelInfo = newInfo
+	case !allowPathChange && bn.primaryPath.substituted &&
+		oldPrimaryPath.resolved.model != "" && bn.primaryPath.resolved.model == "":
+		// The file this instance is RUNNING has gone away: the previous resolution
+		// named a real file, this one resolves to nothing (confirmed absent with no
+		// usable installed variant). A substitution onto a real file has a non-empty
+		// configuredModelPath and is handled by the case above.
+		//
+		// The old-vs-new comparison is what makes this precise, and it is load
+		// bearing. Testing bn.primaryPath.substituted alone would also fire in the
+		// STEADY STATE after a successful startup recovery onto the built-in
+		// baseline: config keeps the stale path (the recovery is deliberately not
+		// repairable there), so every reload re-resolves to the same empty result,
+		// and every settings save would fail forever. That is precisely the
+		// second-order bug the re-resolution above exists to prevent, and it would
+		// hit exactly the users this whole recovery is for.
+		//
+		// Falling through would instead be silent corruption: no case matches,
+		// bn.ModelInfo keeps naming the vanished file, initializeModel loads the
+		// baseline underneath it, and the reload reports success while every
+		// subsequent detection is attributed to a model that is not running.
+		//
+		// Refuse, and let the transactional rollback keep the ALREADY-LOADED model
+		// serving. That preserves the pre-recovery outcome (a settings save fails
+		// loudly rather than silently swapping models) while the running detector is
+		// untouched. The variant-swap path is excluded because there a cleared path
+		// IS the intended revert, handled by the next case.
+		rollback()
+		return errors.Newf("configured birdnet model file %q is no longer usable and no installed variant can replace it: requires orchestrator restart", bn.Settings.BirdNET.ModelPath).
+			Component("birdnet").
+			Category(errors.CategoryModelInit).
+			Context("operation", "reload_model").
+			Context("current_model_path", bn.ModelInfo.CustomPath).
+			Context("configured_model_path", bn.Settings.BirdNET.ModelPath).
+			Build()
 	case allowPathChange:
 		// Variant-swap path with a CLEARED BirdNET.ModelPath: the user reverted to
 		// the embedded BuiltIn baseline. Re-resolve the stock classifier identity so

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -1489,12 +1489,17 @@ func (bn *BirdNET) reloadModelInternal(allowPathChange bool) error {
 	case bn.Settings.BirdNET.Version != "":
 		newInfo, ok := ResolveBirdNETVersion(bn.Settings.BirdNET.Version)
 		if !ok {
+			// Captured BEFORE rollback(), for the same reason as the case below:
+			// rollback restores bn.Settings to the previous snapshot, so reading the
+			// version afterwards reports the PREVIOUS (valid) version as unknown, or
+			// an empty string when the user had not set one.
+			requestedVersion := bn.Settings.BirdNET.Version
 			rollback()
-			return errors.Newf("unknown BirdNET version: %s", bn.Settings.BirdNET.Version).
+			return errors.Newf("unknown BirdNET version: %s", requestedVersion).
 				Component("birdnet").
 				Category(errors.CategoryModelInit).
 				Context("operation", "reload_model").
-				Context("version", bn.Settings.BirdNET.Version).
+				Context("version", requestedVersion).
 				Build()
 		}
 		newInfo.CustomPath = bn.configuredModelPath()

--- a/internal/classifier/birdnet_test.go
+++ b/internal/classifier/birdnet_test.go
@@ -551,7 +551,9 @@ func TestNewBirdNET_LocaleNormalization(t *testing.T) {
 			settings.BirdNET.Version = "2.4"
 			settings.BirdNET.ModelPath = testV24TFLiteModelPath
 
-			bn, err := NewBirdNET(settings, nil)
+			// nil resolver: no orchestrator here, so the configured path is used
+			// verbatim, which is exactly the pre-recovery behaviour this test asserts.
+			bn, err := NewBirdNET(settings, nil, nil)
 			if bn != nil {
 				t.Cleanup(bn.Delete)
 			}

--- a/internal/classifier/model_onnx.go
+++ b/internal/classifier/model_onnx.go
@@ -17,8 +17,8 @@ import (
 // the default in CustomPath avoids mutating settings.BirdNET.ModelPath, which
 // would make the default indistinguishable from a user override.
 func (bn *BirdNET) onnxModelPath() string {
-	if bn.Settings.BirdNET.ModelPath != "" {
-		return bn.Settings.BirdNET.ModelPath
+	if p := bn.configuredModelPath(); p != "" {
+		return p
 	}
 	return bn.ModelInfo.CustomPath
 }

--- a/internal/classifier/model_onnx.go
+++ b/internal/classifier/model_onnx.go
@@ -13,7 +13,9 @@ import (
 
 // onnxModelPath resolves the ONNX classifier model file: the explicit config
 // model path when set, otherwise ModelInfo.CustomPath (set by the arm64 default
-// resolver, defaultClassifierModelInfo). Returns "" when neither is set. Keeping
+// resolver, defaultClassifierModelInfo). The first value is the RESOLVED
+// configured path (see BirdNET.configuredModelPath), not the raw setting.
+// Returns "" when neither is set. Keeping
 // the default in CustomPath avoids mutating settings.BirdNET.ModelPath, which
 // would make the default indistinguishable from a user override.
 func (bn *BirdNET) onnxModelPath() string {

--- a/internal/classifier/model_path_reconcile.go
+++ b/internal/classifier/model_path_reconcile.go
@@ -38,6 +38,12 @@ func SetPathCorrectionPersistenceDisabled(disabled bool) {
 type pendingPathCorrection struct {
 	registryID string
 	resolved   modelFileSet
+	// repairable carries pathResolution.repairable through the queue: true only
+	// when the configured path was CONFIRMED absent, so config.yaml may be
+	// rewritten. When false the model still runs from a substitute, but the
+	// configuration is left exactly as the user wrote it and only the
+	// substituted notification fires.
+	repairable bool
 }
 
 // deferPathCorrection queues a configuration repair for a model that loaded via
@@ -51,10 +57,11 @@ type pendingPathCorrection struct {
 // the build could persist paths that turn out to be unusable.
 //
 // Must be called with o.mu held.
-func (o *Orchestrator) deferPathCorrection(registryID string, resolved modelFileSet) {
+func (o *Orchestrator) deferPathCorrection(registryID string, resolved modelFileSet, repairable bool) {
 	o.pendingPathCorrections = append(o.pendingPathCorrections, pendingPathCorrection{
 		registryID: registryID,
 		resolved:   resolved,
+		repairable: repairable,
 	})
 }
 
@@ -83,10 +90,16 @@ func (o *Orchestrator) deferPathCorrection(registryID string, resolved modelFile
 // does not take o.mu, so it is safe under the loaders' write lock. The settings
 // write itself happens later, in the drainer, after o.mu is released.
 func (o *Orchestrator) queuePathCorrection(registryID string, res pathResolution) {
-	if !res.usedFallback {
+	// Queue on substituted, not on repairable. A substitution that may NOT rewrite
+	// config (an unreadable configured path: a permissions change on a NAS mount,
+	// a volume that is slow to come up) still means the user is running a model
+	// they did not choose, and the drain is the only place that tells them. Before
+	// this, nothing was queued for that case, so applyPathCorrection was never
+	// reached and the substitution was visible only as a single Debug line.
+	if !res.substituted {
 		return
 	}
-	o.deferPathCorrection(registryID, res.resolved)
+	o.deferPathCorrection(registryID, res.resolved, res.repairable)
 }
 
 // runPendingPathCorrections drains the queued configuration repairs, rewriting
@@ -142,22 +155,31 @@ func (o *Orchestrator) applyPathCorrection(pc *pendingPathCorrection) {
 		return
 	}
 
-	updated, changed := o.planPathCorrection(current, pc)
+	updated, outcome := o.planPathCorrection(current, pc)
 
-	if !changed {
-		// planPathCorrection returns a nil snapshot only when it ABANDONED a real
-		// correction: applyPathCorrection is only called for families that used the
-		// gallery fallback, so a non-empty configured path was substituted at
-		// runtime, but the path is user-owned and must not be rewritten. The model
-		// is now running a different (installed) model than the user configured;
-		// that would otherwise be entirely silent, since emitPathReconciledNotification
-		// fires only when config was rewritten. Tell the user instead. A non-nil
-		// snapshot with changed==false is a genuine no-op (the paths already
-		// matched), so stay quiet there.
-		if updated == nil {
-			emitPathSubstitutedNotification(pc.registryID, pc.resolved.model)
-		}
+	switch outcome {
+	case correctionNoop:
+		// The configured paths already match what the model was built from. Nothing
+		// to write and nothing to say.
 		return
+	case correctionSubstituted:
+		// The model is running a DIFFERENT (installed) model than the user
+		// configured, and the configuration was deliberately left alone: either the
+		// configured path is user-owned, or the failure to read it was not a
+		// confirmed absence and must not be persisted. Either way this would
+		// otherwise be entirely silent, since emitPathReconciledNotification fires
+		// only when config was rewritten. Tell the user instead.
+		emitPathSubstitutedNotification(pc)
+		return
+	case correctionUnknownFamily:
+		// No settings mapping for this registry ID, so there is nothing to plan.
+		// Distinct from correctionSubstituted on purpose: the model did not
+		// substitute anything the user would recognise, it is the SELF-HEAL that has
+		// a gap, so this is a developer-facing log and never a user-facing warning.
+		GetLogger().Warn("no settings mapping for model family; skipping path correction",
+			logger.String("registry_id", pc.registryID))
+		return
+	case correctionRewrite:
 	}
 
 	conf.StoreSettings(updated)
@@ -174,12 +196,39 @@ func (o *Orchestrator) applyPathCorrection(pc *pendingPathCorrection) {
 	emitPathReconciledNotification(pc.registryID, pc.resolved.model)
 }
 
+// correctionOutcome is what applyPathCorrection should DO with a planned
+// correction. It replaces an earlier (updated *conf.Settings, changed bool) pair
+// in which a nil snapshot meant two different things (an abandoned user-owned
+// correction, and an unknown registry ID) that shared one user-facing signal, so
+// adding a loader for a family with no settings mapping would have emitted a
+// warning about a model file that was never missing.
+type correctionOutcome int
+
+const (
+	// correctionRewrite: the returned snapshot carries repaired paths and should be
+	// stored, persisted, and reported with the reconciled notification.
+	correctionRewrite correctionOutcome = iota
+	// correctionNoop: the configuration already matches what was built. Stay quiet.
+	correctionNoop
+	// correctionSubstituted: the model is running a substitute, and config must be
+	// left alone (the path is user-owned, or the read failure was not a confirmed
+	// absence). Emit the substituted notification; write nothing.
+	correctionSubstituted
+	// correctionUnknownFamily: no settings mapping exists for the registry ID.
+	// Developer-facing only; never a user-facing notification.
+	correctionUnknownFamily
+)
+
 // planPathCorrection produces the corrected settings snapshot for one family and
-// reports whether anything actually changed. It is separated from the persisting
-// half of applyPathCorrection so the decision (which fields may be rewritten and
-// which must be left alone) is testable without touching the filesystem or the
+// reports what should be done with it. It is separated from the persisting half
+// of applyPathCorrection so the decision (which fields may be rewritten and which
+// must be left alone) is testable without touching the filesystem or the
 // developer's own configuration file.
-func (o *Orchestrator) planPathCorrection(current *conf.Settings, pc *pendingPathCorrection) (updated *conf.Settings, changed bool) {
+//
+// The returned snapshot is meaningful only for correctionRewrite; every other
+// outcome returns nil so no caller can mutate the live published snapshot through
+// the result.
+func (o *Orchestrator) planPathCorrection(current *conf.Settings, pc *pendingPathCorrection) (updated *conf.Settings, outcome correctionOutcome) {
 	log := GetLogger()
 	updated = conf.CloneSettings(current)
 
@@ -192,6 +241,16 @@ func (o *Orchestrator) planPathCorrection(current *conf.Settings, pc *pendingPat
 
 	var fields []fieldCorrection
 	switch pc.registryID {
+	case permanentRegistryID:
+		// The primary BirdNET v2.4 slot carries ONE gallery-managed path. Its label
+		// set is embedded and identical across variants, which is why
+		// applyConfigForPrimarySwap sets BirdNET.ModelPath alone and documents that
+		// it never touches BirdNET.LabelPath: a user-configured custom label path
+		// must survive a variant swap. Repairing LabelPath here would break that
+		// contract, so the primary family is deliberately model-only.
+		fields = []fieldCorrection{
+			{&updated.BirdNET.ModelPath, pc.resolved.model},
+		}
 	case RegistryIDPerchV2:
 		fields = []fieldCorrection{
 			{&updated.Perch.ModelPath, pc.resolved.model},
@@ -213,7 +272,16 @@ func (o *Orchestrator) planPathCorrection(current *conf.Settings, pc *pendingPat
 	default:
 		// Unknown registry: nothing to plan. Return nil rather than current so no
 		// caller can mutate the live published snapshot through the result.
-		return nil, false
+		return nil, correctionUnknownFamily
+	}
+
+	// A substitution that is not repairable must never reach the field loop: the
+	// configured path was not CONFIRMED absent (a permissions failure, an I/O
+	// error, a half-initialised mount), so rewriting config.yaml would make a
+	// transient condition permanent. The model is still running a substitute, so
+	// the user is told; the configuration is left byte-for-byte as they wrote it.
+	if !pc.repairable {
+		return nil, correctionSubstituted
 	}
 
 	// A resolved set is atomic: model, labels and (for bat) the shared embedding
@@ -243,9 +311,13 @@ func (o *Orchestrator) planPathCorrection(current *conf.Settings, pc *pendingPat
 			log.Info("configured model path is user-owned, abandoning the whole correction to avoid a cross-variant config",
 				logger.String("registry_id", pc.registryID),
 				logger.String("user_owned_path", *fc.field))
-			return nil, false
+			return nil, correctionSubstituted
 		}
 		toWrite = append(toWrite, fc)
+	}
+
+	if len(toWrite) == 0 {
+		return nil, correctionNoop
 	}
 
 	for _, fc := range toWrite {
@@ -254,10 +326,9 @@ func (o *Orchestrator) planPathCorrection(current *conf.Settings, pc *pendingPat
 			logger.String("old_path", *fc.field),
 			logger.String("new_path", fc.resolved))
 		*fc.field = fc.resolved
-		changed = true
 	}
 
-	return updated, changed
+	return updated, correctionRewrite
 }
 
 // emitPathReconciledNotification tells the user that a broken model path was
@@ -309,36 +380,74 @@ func emitPathReconciledNotification(registryID, modelPath string) {
 	}
 }
 
-// emitPathSubstitutedNotification tells the user that a configured model file was
-// not found and the installed gallery model is being used at runtime instead,
-// while their configuration was deliberately left unchanged (the configured path
-// is user-owned, so the self-heal must not take it over). Without this the
-// substitution is entirely silent: the user keeps getting detections, but from a
-// model they never chose, and the reconciled notification never fires because
-// config was not rewritten.
-func emitPathSubstitutedNotification(registryID, modelPath string) {
+// emitPathSubstitutedNotification tells the user that the model they configured
+// is not the model that is running, while their configuration was deliberately
+// left unchanged. Without this the substitution is entirely silent: the user
+// keeps getting detections, but from a model they never chose, and the reconciled
+// notification never fires because config was not rewritten. That is the same
+// failure shape as a model that is assigned but never loaded, which cost one
+// reporter days of detections before a missing dashboard panel gave it away.
+func emitPathSubstitutedNotification(pc *pendingPathCorrection) {
 	svc := notification.GetService()
 	if svc == nil {
 		return
 	}
+
+	registryID := pc.registryID
+	modelPath := pc.resolved.model
 
 	modelName := registryID
 	if info, ok := ModelRegistry[registryID]; ok && info.Name != "" {
 		modelName = info.Name
 	}
 
+	// Three substitutions reach here and they are NOT interchangeable to a user
+	// trying to fix their install, so each gets its own wording. The case is
+	// derived from the pending record rather than carried as a separate field, so
+	// there is no fourth piece of state that can drift out of step with the two
+	// that already decide the behaviour.
+	//
+	//   repairable, non-empty resolved: the file is CONFIRMED absent and an
+	//     installed model replaced it, but the configured path is user-owned so the
+	//     repair was abandoned. "Was not found" is exactly right.
+	//   not repairable, non-empty resolved: the file could not be READ (a
+	//     permissions change, an I/O error, a half-mounted volume). Telling this
+	//     user it "was not found" sends them looking in the wrong place.
+	//   empty resolved: the primary classifier's configured file is absent and
+	//     nothing is installed to replace it, so the BUILT-IN model is running.
+	//     There is no installed path to name.
+	title := fmt.Sprintf("Configured model file for %s was not found", modelName)
+	titleKey := notification.MsgModelPathSubstitutedTitle
+	body := fmt.Sprintf("The model file configured for %s was not found on disk, so the installed model at %s "+
+		"is being used instead. Your configuration was left unchanged.", modelName, modelPath)
+	bodyKey := notification.MsgModelPathSubstitutedMessage
+
+	switch {
+	case modelPath == "":
+		body = fmt.Sprintf("The model file configured for %s was not found on disk and no installed model is "+
+			"available to replace it, so the built-in model is being used instead. Your configuration was "+
+			"left unchanged.", modelName)
+		bodyKey = notification.MsgModelPathBuiltinMessage
+	case !pc.repairable:
+		title = fmt.Sprintf("Configured model file for %s could not be read", modelName)
+		titleKey = notification.MsgModelPathUnreadableTitle
+		body = fmt.Sprintf("The model file configured for %s exists but could not be read, so the installed "+
+			"model at %s is being used instead. Your configuration was left unchanged. Check the file's "+
+			"permissions and that its storage is mounted.", modelName, modelPath)
+		bodyKey = notification.MsgModelPathUnreadableMessage
+	}
+
 	notif := notification.NewNotification(
 		notification.TypeWarning,
 		notification.PriorityMedium,
-		fmt.Sprintf("Configured model file for %s was not found", modelName),
-		fmt.Sprintf("The model file configured for %s was not found on disk, so the installed model at %s "+
-			"is being used instead. Your configuration was left unchanged.", modelName, modelPath),
+		title,
+		body,
 	).
 		WithComponent("classifier").
-		WithTitleKey(notification.MsgModelPathSubstitutedTitle, map[string]any{
+		WithTitleKey(titleKey, map[string]any{
 			"modelName": modelName,
 		}).
-		WithMessageKey(notification.MsgModelPathSubstitutedMessage, map[string]any{
+		WithMessageKey(bodyKey, map[string]any{
 			"modelName": modelName,
 			"modelPath": modelPath,
 		}).

--- a/internal/classifier/model_path_reconcile.go
+++ b/internal/classifier/model_path_reconcile.go
@@ -436,15 +436,16 @@ func emitPathSubstitutedNotification(pc *pendingPathCorrection) {
 		modelName = info.Name
 	}
 
-	// Three substitutions reach here and they are NOT interchangeable to a user
-	// trying to fix their install, so each gets its own wording. The case is
-	// derived from the pending record rather than carried as a separate field, so
-	// there is no fourth piece of state that can drift out of step with the two
-	// that already decide the behaviour.
+	// Substitutions reaching here are NOT interchangeable to a user trying to fix
+	// their install, so each gets its own wording. The unreadable case is carried as
+	// an explicit flag rather than derived: "not repairable" has more than one
+	// cause, and deriving from it told a user whose file was absent to go and check
+	// its permissions.
 	//
-	//   repairable, non-empty resolved: the file is CONFIRMED absent and an
-	//     installed model replaced it, but the configured path is user-owned so the
-	//     repair was abandoned. "Was not found" is exactly right.
+	//   default, non-empty resolved: the file is CONFIRMED absent and an installed
+	//     model replaced it, but config was left alone, either because the
+	//     configured path is user-owned or because it is not written in the form it
+	//     resolves to. "Was not found" is exactly right for all of those.
 	//   unreadable: the file could not be READ (a permissions change, an I/O error,
 	//     a half-mounted volume). Telling this user it "was not found" sends them
 	//     looking in the wrong place. Keyed on an explicit flag, because "not

--- a/internal/classifier/model_path_reconcile.go
+++ b/internal/classifier/model_path_reconcile.go
@@ -32,9 +32,10 @@ func SetPathCorrectionPersistenceDisabled(disabled bool) {
 	pathCorrectionPersistenceDisabled.Store(disabled)
 }
 
-// pendingPathCorrection records that a model was loaded from the gallery
-// fallback rather than from the paths configured in settings, so the stale
-// configuration can be repaired once o.mu is released.
+// pendingPathCorrection records that a model was loaded from a different file set
+// than the one configured (the gallery fallback, or for the primary the built-in
+// baseline), so the user can be told and, where it is safe, the stale
+// configuration repaired once o.mu is released.
 type pendingPathCorrection struct {
 	registryID string
 	resolved   modelFileSet
@@ -44,30 +45,39 @@ type pendingPathCorrection struct {
 	// configuration is left exactly as the user wrote it and only the
 	// substituted notification fires.
 	repairable bool
+	// unreadable carries pathResolution.unreadable so the notification can tell a
+	// present-but-unreadable file apart from an absent one.
+	unreadable bool
 }
 
-// deferPathCorrection queues a configuration repair for a model that loaded via
-// the gallery fallback. Called by the secondary model loaders while they hold
-// o.mu; the repair itself runs in runPendingPathCorrections after the lock is
-// released.
+// deferPathCorrection queues a configuration repair for a model that loaded from
+// a different file set than the one configured. Called by the secondary model
+// loaders while they hold o.mu, and by NewOrchestrator for the primary before the
+// orchestrator is published; the repair itself runs in runPendingPathCorrections
+// after the lock is released.
 //
 // Queued only AFTER the model has built successfully. The constructors open the
 // ONNX session and validate the label count against the model's output tensor,
 // so a set that builds is a set that genuinely belongs together. Queueing before
 // the build could persist paths that turn out to be unusable.
 //
-// Must be called with o.mu held.
-func (o *Orchestrator) deferPathCorrection(registryID string, resolved modelFileSet, repairable bool) {
+// Must be called either with o.mu held, or before o is published (the
+// NewOrchestrator case), since it appends to a slice no other goroutine can yet
+// observe.
+func (o *Orchestrator) deferPathCorrection(registryID string, res pathResolution) {
 	o.pendingPathCorrections = append(o.pendingPathCorrections, pendingPathCorrection{
 		registryID: registryID,
-		resolved:   resolved,
-		repairable: repairable,
+		resolved:   res.resolved,
+		repairable: res.repairable,
+		unreadable: res.unreadable,
 	})
 }
 
-// queuePathCorrection queues the configuration repair when the build resolved
-// through the gallery fallback. The loaders call it after a successful build,
-// passing the resolution their builder already computed.
+// queuePathCorrection queues the follow-up when a model resolved to a different
+// file set than the one configured. The secondary loaders call it after a
+// successful build, passing the resolution their builder already computed;
+// NewOrchestrator calls it for the primary, whose substitute may be the built-in
+// baseline rather than a gallery file.
 //
 // The resolution is threaded out of build* rather than recomputed here for two
 // reasons. It avoids resolving the same file set twice per load, and, more
@@ -86,7 +96,8 @@ func (o *Orchestrator) deferPathCorrection(registryID string, resolved modelFile
 // what keeps a backend or device swap from rewriting the user's paths: the
 // reload path simply discards the resolution.
 //
-// Must be called with o.mu held. It only appends to the pending queue, which
+// Must be called either with o.mu held (the loaders) or before o is published
+// (NewOrchestrator, for the primary). It only appends to the pending queue, which
 // does not take o.mu, so it is safe under the loaders' write lock. The settings
 // write itself happens later, in the drainer, after o.mu is released.
 func (o *Orchestrator) queuePathCorrection(registryID string, res pathResolution) {
@@ -99,7 +110,7 @@ func (o *Orchestrator) queuePathCorrection(registryID string, res pathResolution
 	if !res.substituted {
 		return
 	}
-	o.deferPathCorrection(registryID, res.resolved, res.repairable)
+	o.deferPathCorrection(registryID, res)
 }
 
 // runPendingPathCorrections drains the queued configuration repairs, rewriting
@@ -173,13 +184,31 @@ func (o *Orchestrator) applyPathCorrection(pc *pendingPathCorrection) {
 		return
 	case correctionUnknownFamily:
 		// No settings mapping for this registry ID, so there is nothing to plan.
-		// Distinct from correctionSubstituted on purpose: the model did not
-		// substitute anything the user would recognise, it is the SELF-HEAL that has
-		// a gap, so this is a developer-facing log and never a user-facing warning.
+		// Distinct from correctionSubstituted on purpose: a substitution did happen,
+		// but the thing at fault is the SELF-HEAL (no settings mapping for this
+		// family), not the user's configuration, so this is a developer-facing log
+		// and never a user-facing warning.
 		GetLogger().Warn("no settings mapping for model family; skipping path correction",
 			logger.String("registry_id", pc.registryID))
 		return
 	case correctionRewrite:
+		// Fall through to the write below.
+	default:
+		// Not reachable today. Guarded anyway because the write below is the only
+		// destructive action in this file: an outcome nobody enumerated must never
+		// reach it by falling out of the switch.
+		GetLogger().Warn("unrecognised path-correction outcome; not writing configuration",
+			logger.String("registry_id", pc.registryID),
+			logger.Int("outcome", int(outcome)))
+		return
+	}
+
+	if updated == nil {
+		// Defensive: correctionRewrite always carries a snapshot. StoreSettings(nil)
+		// would publish a nil settings pointer process-wide.
+		GetLogger().Warn("path-correction rewrite produced no settings snapshot; skipping write",
+			logger.String("registry_id", pc.registryID))
+		return
 	}
 
 	conf.StoreSettings(updated)
@@ -199,17 +228,23 @@ func (o *Orchestrator) applyPathCorrection(pc *pendingPathCorrection) {
 // correctionOutcome is what applyPathCorrection should DO with a planned
 // correction. It replaces an earlier (updated *conf.Settings, changed bool) pair
 // in which a nil snapshot meant two different things (an abandoned user-owned
-// correction, and an unknown registry ID) that shared one user-facing signal, so
-// adding a loader for a family with no settings mapping would have emitted a
-// warning about a model file that was never missing.
+// correction, and an unknown registry ID) that shared one user-facing signal.
+// That collision became reachable once the queue gate widened from repairable to
+// substituted: adding a loader for a family with no settings mapping would then
+// emit a user-facing warning for what is really a gap in the self-heal.
 type correctionOutcome int
 
 const (
+	// correctionNoop: the configuration already matches what was built. Stay quiet.
+	//
+	// Deliberately the ZERO value. The alternative, correctionRewrite first, makes
+	// "write the user's config.yaml" the outcome you get from a forgotten
+	// assignment or a naked return on the named result below, which is the one
+	// outcome that must never happen by accident.
+	correctionNoop correctionOutcome = iota
 	// correctionRewrite: the returned snapshot carries repaired paths and should be
 	// stored, persisted, and reported with the reconciled notification.
-	correctionRewrite correctionOutcome = iota
-	// correctionNoop: the configuration already matches what was built. Stay quiet.
-	correctionNoop
+	correctionRewrite
 	// correctionSubstituted: the model is running a substitute, and config must be
 	// left alone (the path is user-owned, or the read failure was not a confirmed
 	// absence). Emit the substituted notification; write nothing.
@@ -410,9 +445,10 @@ func emitPathSubstitutedNotification(pc *pendingPathCorrection) {
 	//   repairable, non-empty resolved: the file is CONFIRMED absent and an
 	//     installed model replaced it, but the configured path is user-owned so the
 	//     repair was abandoned. "Was not found" is exactly right.
-	//   not repairable, non-empty resolved: the file could not be READ (a
-	//     permissions change, an I/O error, a half-mounted volume). Telling this
-	//     user it "was not found" sends them looking in the wrong place.
+	//   unreadable: the file could not be READ (a permissions change, an I/O error,
+	//     a half-mounted volume). Telling this user it "was not found" sends them
+	//     looking in the wrong place. Keyed on an explicit flag, because "not
+	//     repairable" alone also covers a path we simply decline to rewrite.
 	//   empty resolved: the primary classifier's configured file is absent and
 	//     nothing is installed to replace it, so the BUILT-IN model is running.
 	//     There is no installed path to name.
@@ -428,7 +464,7 @@ func emitPathSubstitutedNotification(pc *pendingPathCorrection) {
 			"available to replace it, so the built-in model is being used instead. Your configuration was "+
 			"left unchanged.", modelName)
 		bodyKey = notification.MsgModelPathBuiltinMessage
-	case !pc.repairable:
+	case pc.unreadable:
 		title = fmt.Sprintf("Configured model file for %s could not be read", modelName)
 		titleKey = notification.MsgModelPathUnreadableTitle
 		body = fmt.Sprintf("The model file configured for %s exists but could not be read, so the installed "+

--- a/internal/classifier/model_path_resolution.go
+++ b/internal/classifier/model_path_resolution.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/inference"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
@@ -103,6 +104,14 @@ type pathResolution struct {
 	// half-initialised mount) is substituted but NOT repairable, so a transient
 	// failure never rewrites config.yaml permanently.
 	repairable bool
+	// unreadable distinguishes the ONE substitution cause that is not an absence:
+	// the configured file is present but could not be read (a permissions change,
+	// an I/O error, a half-initialised mount). It is carried explicitly rather than
+	// derived from repairable, because "not repairable" has more than one cause:
+	// the primary also declines to repair a path whose written form differs from
+	// its expanded form, and telling that user their file "could not be read" would
+	// send them to check permissions on a file that is simply gone.
+	unreadable bool
 }
 
 // nonEmptyMembersPresence classifies whether every NON-EMPTY required member of
@@ -235,7 +244,7 @@ func (o *Orchestrator) resolveFamilyPaths(registryID string, configured modelFil
 		GetLogger().Debug("recovered the configured variant's companion files",
 			logger.String("registry_id", registryID),
 			logger.String("model_path", sameVariant.model))
-		return pathResolution{resolved: sameVariant, substituted: true, repairable: repairable}
+		return pathResolution{resolved: sameVariant, substituted: true, repairable: repairable, unreadable: presence == presenceIndeterminate}
 	}
 
 	m, l, e := o.resolveInstalledPaths(registryID)
@@ -258,7 +267,7 @@ func (o *Orchestrator) resolveFamilyPaths(registryID string, configured modelFil
 		logger.String("configured_model_path", configured.model),
 		logger.String("resolved_model_path", fallback.model))
 
-	return pathResolution{resolved: fallback, substituted: true, repairable: repairable}
+	return pathResolution{resolved: fallback, substituted: true, repairable: repairable, unreadable: presence == presenceIndeterminate}
 }
 
 // resolveSiblingSet rebuilds a family's complete file set from the variant that
@@ -383,6 +392,65 @@ func declaresModelFile(files []CatalogFile, localName string) bool {
 // entry point, runPendingPathCorrections: that drainer takes o.mu itself to
 // snapshot and clear the queue, and o.mu is not reentrant, so draining under the
 // loaders' write lock self-deadlocks the load. Keep the drain where it is.
+func (o *Orchestrator) isGalleryManagedPath(registryID, path string) bool {
+	if path == "" {
+		return false
+	}
+
+	base := filepath.Base(path)
+	parent := filepath.Base(filepath.Dir(path))
+
+	// Require the grandparent directory to be the models directory itself (its base
+	// name, normally "models"). Matching only base + parent would qualify any path
+	// that merely MIRRORS the gallery layout, e.g. /mnt/nas/perch-v2/perch_v2.onnx:
+	// a NAS or USB mount that is late at boot yields ENOENT (the mountpoint exists
+	// but is empty), which classifies as presenceMissing with repairable=true, so a
+	// user who moved their models to a NAS but left a local gallery copy would have
+	// the NAS path permanently rewritten. Dropping only the models-directory PREFIX
+	// (not its base name) still handles the changed-container-HOME case the issues
+	// report, because base(modelsDir) stays "models" across a HOME change, while a
+	// look-alike under a different grandparent ("nas") is rejected. This matches the
+	// stricter precedent in Settings.MigrateOrphanGeomodelRangeFilter
+	// (internal/conf/range_filter_migration.go), which acts only on exact
+	// gallery-managed paths and never touches custom or hand-edited ones.
+	if o.modelsDir == "" {
+		return false
+	}
+	grandparent := filepath.Base(filepath.Dir(filepath.Dir(path)))
+	if grandparent != filepath.Base(o.modelsDir) {
+		return false
+	}
+
+	catalog := ActiveCatalog()
+	for i := range catalog {
+		entry := &catalog[i]
+		if entry.RegistryID != registryID {
+			continue
+		}
+		// Check the entry's own files and every variant's files as a union: the
+		// stale configured path could name any installed variant's file.
+		fileSets := [][]CatalogFile{entry.Files}
+		for j := range entry.Variants {
+			fileSets = append(fileSets, entry.Variants[j].Files)
+		}
+		for _, files := range fileSets {
+			for _, f := range files {
+				if f.LocalName != base {
+					continue
+				}
+				expectedParent := entry.ID
+				if isSharedRole(f.Role) {
+					expectedParent = "shared"
+				}
+				if parent == expectedParent {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
 // primaryPathResolver resolves the configured primary classifier model path to
 // the file the instance should actually load from. It is injected into NewBirdNET
 // rather than called from it because the resolution needs the models directory
@@ -448,15 +516,32 @@ func (o *Orchestrator) resolvePrimaryModelPath(configured string) pathResolution
 		return keep
 	}
 
-	// CONFIRMED absent. Recover to the installed gallery variant when there is one.
-	if installed, _, _ := o.resolveInstalledPaths(permanentRegistryID); installed != "" {
+	// CONFIRMED absent. Recover to the installed gallery variant when there is one
+	// AND that variant can actually run on this host.
+	if installed, _, _ := o.resolveInstalledPaths(permanentRegistryID); installed != "" && o.primaryVariantUsable(installed) {
 		GetLogger().Info("configured primary model path is missing on disk, recovering the installed variant",
 			logger.String("configured_model_path", configured),
 			logger.String("resolved_model_path", installed))
 		return pathResolution{
-			resolved:    modelFileSet{model: installed},
+			resolved: modelFileSet{model: installed},
+			// Repairable only when the configured string is literally what it
+			// resolves to. A configured "$HOME/..." or "~/..." can still match the
+			// gallery layout, and rewriting it would flatten the variable into the
+			// absolute path it happens to expand to today, so the path would stop
+			// following HOME on the next container start. That is the exact
+			// fragility this recovery exists to undo, so the runtime substitution
+			// stands but the config rewrite does not.
+			//
+			// The guard lives here rather than in isGalleryManagedPath because that
+			// helper serves all four families from ONE call site. Putting it there
+			// would change the three secondaries' behaviour, which this change has no
+			// business touching: they would stop repairing a $VAR path and instead
+			// warn about it on every single start, forever. Note the runtime
+			// substitution is identical either way, so refusing the rewrite does not
+			// give those users their own model back; it only trades a one-time repair
+			// for a permanent notification.
 			substituted: true,
-			repairable:  true,
+			repairable:  configured == expanded,
 		}
 	}
 
@@ -477,75 +562,40 @@ func (o *Orchestrator) resolvePrimaryModelPath(configured string) pathResolution
 	return pathResolution{substituted: true}
 }
 
-func (o *Orchestrator) isGalleryManagedPath(registryID, path string) bool {
-	if path == "" {
-		return false
+// primaryVariantUsable reports whether an installed primary variant can actually
+// be loaded on this host.
+//
+// The BuiltIn baseline declares no files, so resolveInstalledPaths can only ever
+// return a DFT-truncated ONNX build for this family. Recovering onto one where
+// ONNX Runtime is unavailable would turn a recoverable stale path into a hard
+// startup failure, which is precisely the outcome this recovery exists to
+// prevent: initializeModel has no TFLite fallback once usesONNXBackend is true.
+// Reporting false makes the caller fall through to the built-in baseline, which
+// always loads.
+//
+// CheckORTAvailability is used rather than checkORTOrFail because this is a
+// probe, not a load: checkORTOrFail logs and raises a user notification, which
+// would be wrong for a path we are choosing NOT to take.
+func (o *Orchestrator) primaryVariantUsable(modelPath string) bool {
+	if !isONNXModel(modelPath) {
+		return true
 	}
-
-	// Never take over a path whose WRITTEN form differs from its expanded form. A
-	// configured "$HOME/models/perch-v2/perch_v2.onnx" or "~/models/..." matches
-	// the gallery layout on base, parent and grandparent, so without this guard the
-	// repair would rewrite it to the absolute path it happens to expand to today.
-	// That silently flattens the variable, and the path then stops following HOME
-	// on the next container start, which is the exact fragility this self-heal
-	// exists to recover from (GitHub #4201, #4204). An expansion error is treated
-	// the same way, since a path that cannot be expanded cannot be reasoned about.
-	// The guard can only PREVENT a rewrite, never cause one: the runtime fallback
-	// still runs and the substituted notification still tells the user.
-	if expanded, err := conf.ExpandTildePath(os.ExpandEnv(path)); err != nil || expanded != path {
-		return false
+	// An empty configured runtime path is the normal "use the system default"
+	// value, so a missing settings snapshot degrades to that rather than to a
+	// refusal: returning false here would disable the whole recovery for any
+	// caller that has not published settings yet.
+	var ortPath string
+	if settings := o.currentSettings(); settings != nil {
+		ortPath = settings.BirdNET.ONNXRuntimePath
 	}
-
-	base := filepath.Base(path)
-	parent := filepath.Base(filepath.Dir(path))
-
-	// Require the grandparent directory to be the models directory itself (its base
-	// name, normally "models"). Matching only base + parent would qualify any path
-	// that merely MIRRORS the gallery layout, e.g. /mnt/nas/perch-v2/perch_v2.onnx:
-	// a NAS or USB mount that is late at boot yields ENOENT (the mountpoint exists
-	// but is empty), which classifies as presenceMissing with repairable=true, so a
-	// user who moved their models to a NAS but left a local gallery copy would have
-	// the NAS path permanently rewritten. Dropping only the models-directory PREFIX
-	// (not its base name) still handles the changed-container-HOME case the issues
-	// report, because base(modelsDir) stays "models" across a HOME change, while a
-	// look-alike under a different grandparent ("nas") is rejected. This matches the
-	// stricter precedent in Settings.MigrateOrphanGeomodelRangeFilter
-	// (internal/conf/range_filter_migration.go), which acts only on exact
-	// gallery-managed paths and never touches custom or hand-edited ones.
-	if o.modelsDir == "" {
-		return false
+	available := o.ortAvailable
+	if available == nil {
+		available = func(path string) bool { return inference.CheckORTAvailability(path).Available }
 	}
-	grandparent := filepath.Base(filepath.Dir(filepath.Dir(path)))
-	if grandparent != filepath.Base(o.modelsDir) {
-		return false
+	if available(ortPath) {
+		return true
 	}
-
-	catalog := ActiveCatalog()
-	for i := range catalog {
-		entry := &catalog[i]
-		if entry.RegistryID != registryID {
-			continue
-		}
-		// Check the entry's own files and every variant's files as a union: the
-		// stale configured path could name any installed variant's file.
-		fileSets := [][]CatalogFile{entry.Files}
-		for j := range entry.Variants {
-			fileSets = append(fileSets, entry.Variants[j].Files)
-		}
-		for _, files := range fileSets {
-			for _, f := range files {
-				if f.LocalName != base {
-					continue
-				}
-				expectedParent := entry.ID
-				if isSharedRole(f.Role) {
-					expectedParent = "shared"
-				}
-				if parent == expectedParent {
-					return true
-				}
-			}
-		}
-	}
+	GetLogger().Warn("installed primary variant needs ONNX Runtime, which is unavailable; using the built-in model instead",
+		logger.String("model_path", modelPath))
 	return false
 }

--- a/internal/classifier/model_path_resolution.go
+++ b/internal/classifier/model_path_resolution.go
@@ -392,6 +392,15 @@ func declaresModelFile(files []CatalogFile, localName string) bool {
 // entry point, runPendingPathCorrections: that drainer takes o.mu itself to
 // snapshot and clear the queue, and o.mu is not reentrant, so draining under the
 // loaders' write lock self-deadlocks the load. Keep the drain where it is.
+// openVINOLoads reports whether the OpenVINO runtime can actually be opened.
+// Split out for the ovLoadable test seam; see Orchestrator.ovLoadable.
+func (o *Orchestrator) openVINOLoads(libraryPath string) bool {
+	if o.ovLoadable != nil {
+		return o.ovLoadable(libraryPath)
+	}
+	return inference.InitOpenVINO(libraryPath) == nil
+}
+
 func (o *Orchestrator) isGalleryManagedPath(registryID, path string) bool {
 	if path == "" {
 		return false
@@ -579,9 +588,11 @@ func (o *Orchestrator) resolvePrimaryModelPath(configured string) pathResolution
 // the embedded model and telling the user no installed model was available, which
 // is false.
 //
-// CheckORTAvailability is used rather than checkORTOrFail because this is a probe,
-// not a load: checkORTOrFail logs and raises a user notification, which would be
-// wrong for a path we are choosing NOT to take.
+// CheckORTAvailability is used rather than checkORTOrFail because the latter logs
+// and raises a user notification, which would be wrong for a path we are choosing
+// NOT to take. Note the OpenVINO leg below is a real load rather than a pure
+// probe: InitOpenVINO memoizes success, and there is no way to answer "would this
+// load" without trying.
 func (o *Orchestrator) primaryVariantUsable(modelPath string) bool {
 	if !isONNXModel(modelPath) {
 		return true
@@ -595,14 +606,21 @@ func (o *Orchestrator) primaryVariantUsable(modelPath string) bool {
 		settings = &conf.Settings{}
 	}
 
-	// OpenVINO first, mirroring initializeModel's own order.
+	// OpenVINO first, mirroring initializeModel's own order. Eligibility alone is
+	// NOT enough: initializeModel also falls through to ONNX Runtime when OpenVINO
+	// is eligible but FAILS TO LOAD, and openVINOPlanFor's CPU branch answers yes
+	// from the CPU's f16 support without ever opening the library. Accepting a
+	// variant on eligibility would therefore hand a host with a broken or missing
+	// OpenVINO library straight to the ONNX path it has no runtime for, which is
+	// the hard startup failure this gate exists to prevent, reached from the other
+	// side. So the plan must be usable AND the library must actually load.
 	if _, ok, _ := openVINOPlanFor(
 		settings.BirdNET.Backend,
 		settings.BirdNET.OpenVINODevice,
 		DefaultModelVersion,
 		settings.BirdNET.OpenVINOPath,
 		birdnetLogitsOutputIndex,
-	); ok {
+	); ok && o.openVINOLoads(settings.BirdNET.OpenVINOPath) {
 		return true
 	}
 

--- a/internal/classifier/model_path_resolution.go
+++ b/internal/classifier/model_path_resolution.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
@@ -90,10 +91,18 @@ const (
 type pathResolution struct {
 	// resolved is the file set the model was actually built from.
 	resolved modelFileSet
-	// usedFallback reports whether a configured path was CONFIRMED missing and
-	// the gallery set was substituted, i.e. whether the configuration is stale
-	// and may be repaired. See resolveFamilyPaths' second return value.
-	usedFallback bool
+	// substituted reports that the runtime built from a DIFFERENT file set than
+	// the non-empty configured one. Filling an EMPTY configured member from the
+	// gallery is NOT a substitution: leaving a path empty is the supported way to
+	// let the gallery own it, so nothing the user chose was replaced.
+	substituted bool
+	// repairable reports that the substitution came from a CONFIRMED absence
+	// (ErrNotExist), so the stale configuration MAY be rewritten. It is never true
+	// unless substituted is also true. A member that is unreadable for some OTHER
+	// reason (presenceIndeterminate: a permissions failure, an I/O error, a
+	// half-initialised mount) is substituted but NOT repairable, so a transient
+	// failure never rewrites config.yaml permanently.
+	repairable bool
 }
 
 // nonEmptyMembersPresence classifies whether every NON-EMPTY required member of
@@ -144,28 +153,31 @@ func (s modelFileSet) nonEmptyMembersPresence(needEmbeddings bool) diskPresence 
 // different species sets, which either fails late with a label-count mismatch
 // or, when the counts happen to agree, silently mislabels every detection.
 //
-// The second return value reports whether the returned set should reconcile the
-// stale configuration (see Orchestrator.deferPathCorrection). It is true only
-// when a configured path was confirmed missing. A configured path that is merely
-// unreadable right now (an external volume that has not finished mounting) still
-// falls back so the model can run, but returns false so the transient state is
-// never persisted to config.yaml.
+// The returned pathResolution carries two independent flags. substituted reports
+// that a NON-EMPTY configured set was replaced at runtime, so the user is running
+// a model they did not choose and must be told; repairable reports that the
+// substitution came from a CONFIRMED absence, so the stale configuration may also
+// be rewritten (see Orchestrator.deferPathCorrection). A configured path that is
+// merely unreadable right now (an external volume that has not finished mounting)
+// still falls back so the model can run, and is reported as substituted, but is
+// NOT repairable, so the transient state is never persisted to config.yaml.
 //
 // A configured path that points at a file which does not exist is the state
 // GitHub issues #4201 and #4204 describe: a gallery variant switch or a change
 // of container HOME leaves settings pointing at a file that is no longer there,
 // and before this fallback the model simply never loaded again.
-func (o *Orchestrator) resolveFamilyPaths(registryID string, configured modelFileSet, needEmbeddings bool) (resolved modelFileSet, usedFallback bool) {
+func (o *Orchestrator) resolveFamilyPaths(registryID string, configured modelFileSet, needEmbeddings bool) pathResolution {
 	presence := configured.nonEmptyMembersPresence(needEmbeddings)
 
 	// An empty configured member is not a stale member: leaving a path empty is
 	// the supported way to let the gallery own it. When every NON-EMPTY
 	// configured member exists on disk, keep the configured set and fill only the
-	// empty members from the gallery (main's behaviour). usedFallback stays false:
-	// nothing configured went stale, so there is nothing to repair.
+	// empty members from the gallery (main's behaviour). Neither flag is set:
+	// nothing configured went stale, so there is nothing to repair and nothing the
+	// user chose was replaced.
 	if presence == presenceComplete {
 		if configured.complete(needEmbeddings) {
-			return configured, false
+			return pathResolution{resolved: configured}
 		}
 		filled := configured
 
@@ -196,7 +208,7 @@ func (o *Orchestrator) resolveFamilyPaths(registryID string, configured modelFil
 		if needEmbeddings && filled.embeddings == "" {
 			filled.embeddings = e
 		}
-		return filled, false
+		return pathResolution{resolved: filled}
 	}
 
 	// A non-empty configured path is missing or unreadable. Only a CONFIRMED
@@ -223,7 +235,7 @@ func (o *Orchestrator) resolveFamilyPaths(registryID string, configured modelFil
 		GetLogger().Debug("recovered the configured variant's companion files",
 			logger.String("registry_id", registryID),
 			logger.String("model_path", sameVariant.model))
-		return sameVariant, repairable
+		return pathResolution{resolved: sameVariant, substituted: true, repairable: repairable}
 	}
 
 	m, l, e := o.resolveInstalledPaths(registryID)
@@ -234,7 +246,7 @@ func (o *Orchestrator) resolveFamilyPaths(registryID string, configured modelFil
 	// a set that is merely unreadable right now (an unmounted volume) is not
 	// replaced by an empty one.
 	if !fallback.complete(needEmbeddings) {
-		return configured, false
+		return pathResolution{resolved: configured}
 	}
 
 	// Debug, not Info: this fires once per build, and the noteworthy outcomes
@@ -246,7 +258,7 @@ func (o *Orchestrator) resolveFamilyPaths(registryID string, configured modelFil
 		logger.String("configured_model_path", configured.model),
 		logger.String("resolved_model_path", fallback.model))
 
-	return fallback, repairable
+	return pathResolution{resolved: fallback, substituted: true, repairable: repairable}
 }
 
 // resolveSiblingSet rebuilds a family's complete file set from the variant that
@@ -371,8 +383,116 @@ func declaresModelFile(files []CatalogFile, localName string) bool {
 // entry point, runPendingPathCorrections: that drainer takes o.mu itself to
 // snapshot and clear the queue, and o.mu is not reentrant, so draining under the
 // loaders' write lock self-deadlocks the load. Keep the drain where it is.
+// primaryPathResolver resolves the configured primary classifier model path to
+// the file the instance should actually load from. It is injected into NewBirdNET
+// rather than called from it because the resolution needs the models directory
+// and the catalog, which live on the Orchestrator: NewOrchestrator assigns
+// o.modelsDir before it constructs the primary, while bn.modelsDir is still empty
+// at that point (ModelManager sets it later, via SetModelsDir).
+//
+// A nil resolver means "use the configured path verbatim", which is what every
+// direct construction (tests, and any caller with no orchestrator) keeps.
+type primaryPathResolver func(configured string) pathResolution
+
+// resolvePrimaryModelPath gives the primary BirdNET v2.4 slot the stale-path
+// recovery the three secondary families got for GitHub #4201 and #4204. Without
+// it, a configured primary path that no longer exists (a gallery variant switch,
+// or a container HOME change that invalidates a stored absolute path) makes
+// NewBirdNET fail outright, so there is no analysis at all rather than one
+// missing optional model.
+//
+// The primary is deliberately NOT a modelFileSet family. Its label set is
+// embedded and identical across v2.4 variants, which is why
+// applyConfigForPrimarySwap writes BirdNET.ModelPath alone and documents that it
+// never touches BirdNET.LabelPath: a user-configured custom label path must
+// survive a variant swap. So there is exactly one path to resolve and no
+// cross-variant pairing hazard to protect against.
+func (o *Orchestrator) resolvePrimaryModelPath(configured string) pathResolution {
+	if configured == "" {
+		// No configured path at all: the Tier-4 default (the embedded model, or the
+		// standard-path INT8 ONNX build on arm64). Nothing to resolve, nothing to
+		// repair, and nothing was substituted.
+		return pathResolution{}
+	}
+
+	keep := pathResolution{resolved: modelFileSet{model: configured}}
+
+	// Stat the EXPANDED path: loadModel and initializeONNXModel both expand before
+	// opening, so statting the raw string would classify every configured "$VAR/..."
+	// or "~/..." path as missing and substitute a model out from under the user.
+	expanded, err := conf.ExpandTildePath(os.ExpandEnv(configured))
+	if err != nil {
+		// A path that cannot even be expanded is not one we can reason about. Keep
+		// it and let the existing load error report it.
+		return keep
+	}
+
+	if _, statErr := os.Stat(expanded); statErr == nil {
+		return keep
+	} else if !errors.Is(statErr, fs.ErrNotExist) {
+		// Unreadable for a reason OTHER than absence: a permissions change, an I/O
+		// error, a half-initialised mount. This is the ONE place the primary
+		// deliberately behaves differently from the secondaries, which do fall back
+		// on this signal (see resolveFamilyPaths).
+		//
+		// A secondary that fails to load costs one optional overlay for the session.
+		// Swapping the PRIMARY on an ambiguous signal would silently run the stock
+		// baseline in place of the regional or custom model the user chose, and every
+		// detection written while that lasted would be attributed to the wrong model.
+		// A transient unreadable file is far more likely to clear on its own than a
+		// polluted detection history is to be noticed, so the primary keeps the
+		// configured path and lets the existing load error surface.
+		GetLogger().Warn("configured primary model path is unreadable; keeping it rather than substituting a different model",
+			logger.String("model_path", configured),
+			logger.Error(statErr))
+		return keep
+	}
+
+	// CONFIRMED absent. Recover to the installed gallery variant when there is one.
+	if installed, _, _ := o.resolveInstalledPaths(permanentRegistryID); installed != "" {
+		GetLogger().Info("configured primary model path is missing on disk, recovering the installed variant",
+			logger.String("configured_model_path", configured),
+			logger.String("resolved_model_path", installed))
+		return pathResolution{
+			resolved:    modelFileSet{model: installed},
+			substituted: true,
+			repairable:  true,
+		}
+	}
+
+	// Nothing installed to recover to. Resolve to EMPTY so the identity tiers
+	// behave exactly as if the user had never configured a path: Tier 3 stops
+	// firing, Tier 4 resolves the default, and remapV24ToONNXOnARM64 (which returns
+	// early on a non-empty CustomPath) is free to remap arm64 to the standard-path
+	// INT8 ONNX model. Before this the primary simply failed to construct and took
+	// the whole pipeline down with it.
+	//
+	// substituted, but NOT repairable: there is no correct path to write. Writing
+	// the empty string would discard the user's own setting, so re-mounting the
+	// volume or reinstalling the variant restores their model on the next start.
+	// The user is told through the built-in variant of the substituted
+	// notification.
+	GetLogger().Warn("configured primary model path is missing and no installed variant is available; using the built-in model",
+		logger.String("configured_model_path", configured))
+	return pathResolution{substituted: true}
+}
+
 func (o *Orchestrator) isGalleryManagedPath(registryID, path string) bool {
 	if path == "" {
+		return false
+	}
+
+	// Never take over a path whose WRITTEN form differs from its expanded form. A
+	// configured "$HOME/models/perch-v2/perch_v2.onnx" or "~/models/..." matches
+	// the gallery layout on base, parent and grandparent, so without this guard the
+	// repair would rewrite it to the absolute path it happens to expand to today.
+	// That silently flattens the variable, and the path then stops following HOME
+	// on the next container start, which is the exact fragility this self-heal
+	// exists to recover from (GitHub #4201, #4204). An expansion error is treated
+	// the same way, since a path that cannot be expanded cannot be reasoned about.
+	// The guard can only PREVENT a rewrite, never cause one: the runtime fallback
+	// still runs and the substituted notification still tells the user.
+	if expanded, err := conf.ExpandTildePath(os.ExpandEnv(path)); err != nil || expanded != path {
 		return false
 	}
 

--- a/internal/classifier/model_path_resolution.go
+++ b/internal/classifier/model_path_resolution.go
@@ -566,36 +566,55 @@ func (o *Orchestrator) resolvePrimaryModelPath(configured string) pathResolution
 // be loaded on this host.
 //
 // The BuiltIn baseline declares no files, so resolveInstalledPaths can only ever
-// return a DFT-truncated ONNX build for this family. Recovering onto one where
-// ONNX Runtime is unavailable would turn a recoverable stale path into a hard
-// startup failure, which is precisely the outcome this recovery exists to
-// prevent: initializeModel has no TFLite fallback once usesONNXBackend is true.
-// Reporting false makes the caller fall through to the built-in baseline, which
-// always loads.
+// return a DFT-truncated ONNX build for this family. Recovering onto one that
+// cannot load would turn a recoverable stale path into a hard startup failure,
+// which is precisely the outcome this recovery exists to prevent. Reporting false
+// makes the caller fall through to the built-in baseline, which always loads.
 //
-// CheckORTAvailability is used rather than checkORTOrFail because this is a
-// probe, not a load: checkORTOrFail logs and raises a user notification, which
-// would be wrong for a path we are choosing NOT to take.
+// "Can load" is deliberately NOT "ONNX Runtime is available". initializeModel
+// tries OPENVINO FIRST for the v2.4 identity and only falls through to ONNX
+// Runtime when OpenVINO declines, so an openvino-tagged build on an A76/Pi5 or an
+// Intel iGPU runs these variants with no ORT installed at all. Gating on ORT alone
+// would refuse a variant that would have loaded, silently dropping such a host to
+// the embedded model and telling the user no installed model was available, which
+// is false.
+//
+// CheckORTAvailability is used rather than checkORTOrFail because this is a probe,
+// not a load: checkORTOrFail logs and raises a user notification, which would be
+// wrong for a path we are choosing NOT to take.
 func (o *Orchestrator) primaryVariantUsable(modelPath string) bool {
 	if !isONNXModel(modelPath) {
 		return true
 	}
+
 	// An empty configured runtime path is the normal "use the system default"
 	// value, so a missing settings snapshot degrades to that rather than to a
-	// refusal: returning false here would disable the whole recovery for any
-	// caller that has not published settings yet.
-	var ortPath string
-	if settings := o.currentSettings(); settings != nil {
-		ortPath = settings.BirdNET.ONNXRuntimePath
+	// refusal.
+	settings := o.currentSettings()
+	if settings == nil {
+		settings = &conf.Settings{}
 	}
+
+	// OpenVINO first, mirroring initializeModel's own order.
+	if _, ok, _ := openVINOPlanFor(
+		settings.BirdNET.Backend,
+		settings.BirdNET.OpenVINODevice,
+		DefaultModelVersion,
+		settings.BirdNET.OpenVINOPath,
+		birdnetLogitsOutputIndex,
+	); ok {
+		return true
+	}
+
 	available := o.ortAvailable
 	if available == nil {
 		available = func(path string) bool { return inference.CheckORTAvailability(path).Available }
 	}
-	if available(ortPath) {
+	if available(settings.BirdNET.ONNXRuntimePath) {
 		return true
 	}
-	GetLogger().Warn("installed primary variant needs ONNX Runtime, which is unavailable; using the built-in model instead",
+
+	GetLogger().Warn("installed primary variant cannot load on this host (no OpenVINO plan and no ONNX Runtime); using the built-in model instead",
 		logger.String("model_path", modelPath))
 	return false
 }

--- a/internal/classifier/model_path_resolution.go
+++ b/internal/classifier/model_path_resolution.go
@@ -392,15 +392,6 @@ func declaresModelFile(files []CatalogFile, localName string) bool {
 // entry point, runPendingPathCorrections: that drainer takes o.mu itself to
 // snapshot and clear the queue, and o.mu is not reentrant, so draining under the
 // loaders' write lock self-deadlocks the load. Keep the drain where it is.
-// openVINOLoads reports whether the OpenVINO runtime can actually be opened.
-// Split out for the ovLoadable test seam; see Orchestrator.ovLoadable.
-func (o *Orchestrator) openVINOLoads(libraryPath string) bool {
-	if o.ovLoadable != nil {
-		return o.ovLoadable(libraryPath)
-	}
-	return inference.InitOpenVINO(libraryPath) == nil
-}
-
 func (o *Orchestrator) isGalleryManagedPath(registryID, path string) bool {
 	if path == "" {
 		return false
@@ -635,4 +626,13 @@ func (o *Orchestrator) primaryVariantUsable(modelPath string) bool {
 	GetLogger().Warn("installed primary variant cannot load on this host (no OpenVINO plan and no ONNX Runtime); using the built-in model instead",
 		logger.String("model_path", modelPath))
 	return false
+}
+
+// openVINOLoads reports whether the OpenVINO runtime can actually be opened.
+// Split out for the ovLoadable test seam; see Orchestrator.ovLoadable.
+func (o *Orchestrator) openVINOLoads(libraryPath string) bool {
+	if o.ovLoadable != nil {
+		return o.ovLoadable(libraryPath)
+	}
+	return inference.InitOpenVINO(libraryPath) == nil
 }

--- a/internal/classifier/model_path_resolution_test.go
+++ b/internal/classifier/model_path_resolution_test.go
@@ -123,7 +123,8 @@ func TestResolveFamilyPaths_ConfiguredSetPresentIsUsedVerbatim(t *testing.T) {
 	res := o.resolveFamilyPaths(RegistryIDPerchV2,
 		modelFileSet{model: model, labels: labels}, false)
 
-	assert.False(t, res.repairable, "a present configured set must not trigger the fallback")
+	assert.False(t, res.substituted, "a present configured set must not be substituted")
+	assert.False(t, res.repairable, "and nothing may be rewritten")
 	assert.Equal(t, model, res.resolved.model)
 	assert.Equal(t, labels, res.resolved.labels)
 	assert.NotEqual(t, installedModel, res.resolved.model,
@@ -151,7 +152,8 @@ func TestResolveFamilyPaths_MissingConfiguredPathFallsBackToInstalled(t *testing
 		labels: "/nonexistent/perch_v2_labels.txt",
 	}, false)
 
-	assert.True(t, res.repairable, "a missing configured path must trigger the fallback")
+	assert.True(t, res.substituted, "a missing configured path must substitute the installed set")
+	assert.True(t, res.repairable, "a CONFIRMED absence may also rewrite config")
 	assert.Equal(t, installedModel, res.resolved.model)
 	assert.Equal(t, installedLabels, res.resolved.labels)
 }
@@ -192,6 +194,7 @@ func TestResolveFamilyPaths_PartiallyMissingSetIsReplacedAsAUnit(t *testing.T) {
 		labels: filepath.Join(strayDir, "missing_labels.txt"), // does not
 	}, false)
 
+	require.True(t, res.substituted)
 	require.True(t, res.repairable)
 	assert.Equal(t, installedModel, res.resolved.model,
 		"the configured model must be discarded with its missing labels, not paired with fallback labels")
@@ -218,6 +221,8 @@ func TestResolveFamilyPaths_NothingInstalledKeepsConfiguredSet(t *testing.T) {
 	}
 	res := o.resolveFamilyPaths(RegistryIDPerchV2, configured, false)
 
+	assert.False(t, res.substituted,
+		"nothing was installed to substitute, so the user is still running what they configured")
 	assert.False(t, res.repairable)
 	assert.Equal(t, configured, res.resolved)
 }
@@ -255,6 +260,7 @@ func TestResolveFamilyPaths_BatEmbeddingsParticipateInAtomicity(t *testing.T) {
 	}
 	res := o.resolveFamilyPaths(RegistryIDBat, configured, true)
 
+	require.True(t, res.substituted, "a missing embedding member substitutes the whole set")
 	require.True(t, res.repairable, "a missing embedding member makes the whole set stale")
 	assert.Equal(t, galleryModel, res.resolved.model,
 		"the classifier moves with the set; it must not be kept while the embeddings are replaced")
@@ -293,6 +299,8 @@ func TestResolveFamilyPaths_EmptyMemberFilledMissingMemberReplaced(t *testing.T)
 			model:  installedModel, // present
 			labels: "",             // empty: the gallery owns it
 		}, false)
+		assert.False(t, res.substituted,
+			"filling an EMPTY member from the gallery is not a substitution: nothing the user chose was replaced")
 		assert.False(t, res.repairable, "an empty member is not stale, so no repair is queued")
 		assert.Equal(t, installedModel, res.resolved.model, "the present configured model is kept")
 		assert.Equal(t, installedLabels, res.resolved.labels, "the empty labels member is filled from the gallery")
@@ -304,6 +312,7 @@ func TestResolveFamilyPaths_EmptyMemberFilledMissingMemberReplaced(t *testing.T)
 			model:  "/nonexistent/perch_v2.onnx",
 			labels: "/nonexistent/perch_v2_labels.txt",
 		}, false)
+		assert.True(t, res.substituted, "a missing non-empty member replaces what the user chose")
 		assert.True(t, res.repairable, "a missing non-empty member is stale and queues a repair")
 		assert.Equal(t, installedModel, res.resolved.model)
 	})
@@ -346,6 +355,7 @@ func TestResolveFamilyPaths_EmptyMemberFilledFromConfiguredVariant(t *testing.T)
 		labels: "",
 	}, false)
 
+	assert.False(t, res.substituted, "an empty member is filled, not substituted")
 	assert.False(t, res.repairable, "an empty member is filled, not a stale fallback")
 	assert.Equal(t, regionalModel, res.resolved.model, "the configured regional model is kept")
 	assert.Equal(t, regionalLabels, res.resolved.labels,
@@ -465,6 +475,11 @@ func TestApplyPathCorrection_UnreadableNotifiesWithoutRewriting(t *testing.T) {
 		registryID: RegistryIDPerchV2,
 		resolved:   modelFileSet{model: installedModel, labels: installedLabels},
 		repairable: false,
+		// Stated explicitly: "not repairable" alone no longer selects the
+		// could-not-be-read wording, because the primary also declines to rewrite a
+		// path whose written form differs from its expanded form, and that file is
+		// absent rather than unreadable.
+		unreadable: true,
 	})
 
 	after, err := os.ReadFile(conf.ConfigPath)
@@ -604,6 +619,7 @@ func TestPathCorrection_QueuedThenDrainedRepairsConfig(t *testing.T) {
 
 	// 1. The resolution reports a repairable fallback onto the installed variant.
 	res := o.resolveFamilyPaths(RegistryIDPerchV2, configured, false)
+	require.True(t, res.substituted, "a confirmed-missing gallery path substitutes the installed set")
 	require.True(t, res.repairable,
 		"a confirmed-missing gallery path must be reported as repairable")
 	require.Equal(t, installedModel, res.resolved.model)

--- a/internal/classifier/model_path_resolution_test.go
+++ b/internal/classifier/model_path_resolution_test.go
@@ -120,13 +120,13 @@ func TestResolveFamilyPaths_ConfiguredSetPresentIsUsedVerbatim(t *testing.T) {
 	o := &Orchestrator{}
 	o.SetModelsDir(modelsDir)
 
-	got, usedFallback := o.resolveFamilyPaths(RegistryIDPerchV2,
+	res := o.resolveFamilyPaths(RegistryIDPerchV2,
 		modelFileSet{model: model, labels: labels}, false)
 
-	assert.False(t, usedFallback, "a present configured set must not trigger the fallback")
-	assert.Equal(t, model, got.model)
-	assert.Equal(t, labels, got.labels)
-	assert.NotEqual(t, installedModel, got.model,
+	assert.False(t, res.repairable, "a present configured set must not trigger the fallback")
+	assert.Equal(t, model, res.resolved.model)
+	assert.Equal(t, labels, res.resolved.labels)
+	assert.NotEqual(t, installedModel, res.resolved.model,
 		"the configured custom model must be used verbatim, not the installed gallery variant")
 }
 
@@ -146,14 +146,14 @@ func TestResolveFamilyPaths_MissingConfiguredPathFallsBackToInstalled(t *testing
 	o := &Orchestrator{}
 	o.SetModelsDir(modelsDir)
 
-	got, usedFallback := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
+	res := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
 		model:  "/nonexistent/perch_v2.onnx",
 		labels: "/nonexistent/perch_v2_labels.txt",
 	}, false)
 
-	assert.True(t, usedFallback, "a missing configured path must trigger the fallback")
-	assert.Equal(t, installedModel, got.model)
-	assert.Equal(t, installedLabels, got.labels)
+	assert.True(t, res.repairable, "a missing configured path must trigger the fallback")
+	assert.Equal(t, installedModel, res.resolved.model)
+	assert.Equal(t, installedLabels, res.resolved.labels)
 }
 
 // TestResolveFamilyPaths_PartiallyMissingSetIsReplacedAsAUnit checks that when a
@@ -187,16 +187,16 @@ func TestResolveFamilyPaths_PartiallyMissingSetIsReplacedAsAUnit(t *testing.T) {
 	o := &Orchestrator{}
 	o.SetModelsDir(modelsDir)
 
-	got, usedFallback := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
+	res := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
 		model:  strayModel,                                    // exists
 		labels: filepath.Join(strayDir, "missing_labels.txt"), // does not
 	}, false)
 
-	require.True(t, usedFallback)
-	assert.Equal(t, installedModel, got.model,
+	require.True(t, res.repairable)
+	assert.Equal(t, installedModel, res.resolved.model,
 		"the configured model must be discarded with its missing labels, not paired with fallback labels")
-	assert.Equal(t, installedLabels, got.labels)
-	assert.NotEqual(t, strayModel, got.model,
+	assert.Equal(t, installedLabels, res.resolved.labels)
+	assert.NotEqual(t, strayModel, res.resolved.model,
 		"pairing a configured model with fallback labels from another variant mislabels detections")
 }
 
@@ -216,10 +216,10 @@ func TestResolveFamilyPaths_NothingInstalledKeepsConfiguredSet(t *testing.T) {
 		model:  "/nonexistent/perch_v2.onnx",
 		labels: "/nonexistent/perch_v2_labels.txt",
 	}
-	got, usedFallback := o.resolveFamilyPaths(RegistryIDPerchV2, configured, false)
+	res := o.resolveFamilyPaths(RegistryIDPerchV2, configured, false)
 
-	assert.False(t, usedFallback)
-	assert.Equal(t, configured, got)
+	assert.False(t, res.repairable)
+	assert.Equal(t, configured, res.resolved)
 }
 
 // TestResolveFamilyPaths_BatEmbeddingsParticipateInAtomicity asserts the bat
@@ -253,14 +253,14 @@ func TestResolveFamilyPaths_BatEmbeddingsParticipateInAtomicity(t *testing.T) {
 		labels:     labels,
 		embeddings: filepath.Join(dir, "missing_embeddings.onnx"),
 	}
-	got, usedFallback := o.resolveFamilyPaths(RegistryIDBat, configured, true)
+	res := o.resolveFamilyPaths(RegistryIDBat, configured, true)
 
-	require.True(t, usedFallback, "a missing embedding member makes the whole set stale")
-	assert.Equal(t, galleryModel, got.model,
+	require.True(t, res.repairable, "a missing embedding member makes the whole set stale")
+	assert.Equal(t, galleryModel, res.resolved.model,
 		"the classifier moves with the set; it must not be kept while the embeddings are replaced")
-	assert.Equal(t, galleryLabels, got.labels)
-	assert.Equal(t, galleryEmb, got.embeddings)
-	assert.NotEqual(t, model, got.model,
+	assert.Equal(t, galleryLabels, res.resolved.labels)
+	assert.Equal(t, galleryEmb, res.resolved.embeddings)
+	assert.NotEqual(t, model, res.resolved.model,
 		"keeping the configured classifier while replacing the embeddings would mismatch the set")
 
 	// The invariants the atomicity rests on.
@@ -289,23 +289,23 @@ func TestResolveFamilyPaths_EmptyMemberFilledMissingMemberReplaced(t *testing.T)
 
 	t.Run("empty member is filled from the gallery without a repair", func(t *testing.T) {
 		t.Parallel()
-		got, usedFallback := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
+		res := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
 			model:  installedModel, // present
 			labels: "",             // empty: the gallery owns it
 		}, false)
-		assert.False(t, usedFallback, "an empty member is not stale, so no repair is queued")
-		assert.Equal(t, installedModel, got.model, "the present configured model is kept")
-		assert.Equal(t, installedLabels, got.labels, "the empty labels member is filled from the gallery")
+		assert.False(t, res.repairable, "an empty member is not stale, so no repair is queued")
+		assert.Equal(t, installedModel, res.resolved.model, "the present configured model is kept")
+		assert.Equal(t, installedLabels, res.resolved.labels, "the empty labels member is filled from the gallery")
 	})
 
 	t.Run("a missing non-empty member replaces the set with a repair", func(t *testing.T) {
 		t.Parallel()
-		got, usedFallback := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
+		res := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
 			model:  "/nonexistent/perch_v2.onnx",
 			labels: "/nonexistent/perch_v2_labels.txt",
 		}, false)
-		assert.True(t, usedFallback, "a missing non-empty member is stale and queues a repair")
-		assert.Equal(t, installedModel, got.model)
+		assert.True(t, res.repairable, "a missing non-empty member is stale and queues a repair")
+		assert.Equal(t, installedModel, res.resolved.model)
 	})
 }
 
@@ -341,16 +341,16 @@ func TestResolveFamilyPaths_EmptyMemberFilledFromConfiguredVariant(t *testing.T)
 	// Configured model present (regional), labels empty: presenceComplete, so the
 	// empty labels member is filled. It must be filled from the regional model's
 	// own variant.
-	got, usedFallback := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
+	res := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
 		model:  regionalModel,
 		labels: "",
 	}, false)
 
-	assert.False(t, usedFallback, "an empty member is filled, not a stale fallback")
-	assert.Equal(t, regionalModel, got.model, "the configured regional model is kept")
-	assert.Equal(t, regionalLabels, got.labels,
+	assert.False(t, res.repairable, "an empty member is filled, not a stale fallback")
+	assert.Equal(t, regionalModel, res.resolved.model, "the configured regional model is kept")
+	assert.Equal(t, regionalLabels, res.resolved.labels,
 		"empty labels must be filled from the SAME variant the configured model names")
-	assert.NotEqual(t, globalLabels, got.labels,
+	assert.NotEqual(t, globalLabels, res.resolved.labels,
 		"filling from the catalog-first global variant would mislabel the regional model")
 }
 
@@ -392,17 +392,105 @@ func TestResolveFamilyPaths_IndeterminateFallsBackWithoutRepair(t *testing.T) {
 	o := &Orchestrator{}
 	o.SetModelsDir(modelsDir)
 
-	got, usedFallback := o.resolveFamilyPaths(RegistryIDPerchV2, indeterminate, false)
+	res := o.resolveFamilyPaths(RegistryIDPerchV2, indeterminate, false)
 
-	assert.False(t, usedFallback,
+	assert.False(t, res.repairable,
 		"an unreadable path is indeterminate: fall back at runtime but do NOT rewrite config")
-	assert.Equal(t, installedModel, got.model,
+	assert.Equal(t, installedModel, res.resolved.model,
 		"the model still resolves to the installed gallery model so analysis can run")
-	assert.Equal(t, installedLabels, got.labels)
+	assert.Equal(t, installedLabels, res.resolved.labels)
 
-	o.queuePathCorrection(RegistryIDPerchV2, pathResolution{resolved: got, usedFallback: usedFallback})
-	assert.Empty(t, o.pendingPathCorrections,
-		"an indeterminate path must not queue a config repair")
+	// The user IS running a model they did not choose, so the substitution has to
+	// be reported even though the configuration must not be rewritten. Before
+	// these two flags were separated, an indeterminate resolution queued nothing,
+	// so applyPathCorrection was never reached and neither notification fired: the
+	// only trace was a single Debug line, and a user whose model sat on a NAS
+	// mount that started returning EACCES ran a different model indefinitely.
+	assert.True(t, res.substituted,
+		"an unreadable configured path still substitutes a different model, and that must not be silent")
+
+	o.queuePathCorrection(RegistryIDPerchV2, res)
+	assert.Len(t, o.pendingPathCorrections, 1,
+		"the substitution must be queued so the drain can notify, even though it may not repair")
+	assert.False(t, o.pendingPathCorrections[0].repairable,
+		"the queued correction must carry the do-not-rewrite verdict to the drain")
+}
+
+// TestApplyPathCorrection_UnreadableNotifiesWithoutRewriting is the other half of
+// the indeterminate case: the drain must tell the user AND leave config.yaml
+// byte-for-byte as they wrote it. Rewriting here would make a transient
+// permissions or mount failure permanent, and staying silent is the failure that
+// cost a reporter days of lost detections.
+func TestApplyPathCorrection_UnreadableNotifiesWithoutRewriting(t *testing.T) {
+	// Not parallel: mutates the conf global settings, conf.ConfigPath, the
+	// process-level persistence switch and the global notification service.
+	redirectConfigFile(t)
+
+	SetPathCorrectionPersistenceDisabled(false)
+	t.Cleanup(func() { SetPathCorrectionPersistenceDisabled(false) })
+
+	notification.ResetForTest()
+	t.Cleanup(notification.ResetForTest)
+	notification.Initialize(notification.DefaultServiceConfig())
+	svc := notification.GetService()
+	require.NotNil(t, svc)
+	t.Cleanup(svc.Stop)
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+
+	modelsDir := filepath.Join(t.TempDir(), "models")
+	installedModel := writeVariantModelFile(t, modelsDir, &entry, "fp32")
+	installedLabels := writeVariantLabelsFile(t, modelsDir, &entry, "fp32")
+
+	o := &Orchestrator{}
+	o.SetModelsDir(modelsDir)
+
+	// A gallery-managed configured path, so the ONLY thing standing between this
+	// and a rewrite is the repairable verdict. Using a user-owned path instead
+	// would let the pre-existing user-owned veto carry the test and the new guard
+	// could be deleted with the suite still green.
+	staleDir := filepath.Join(t.TempDir(), "models", entry.ID)
+	stale := &conf.Settings{}
+	stale.Perch.ModelPath = filepath.Join(staleDir, filepath.Base(installedModel))
+	stale.Perch.LabelPath = filepath.Join(staleDir, filepath.Base(installedLabels))
+	origSettings := conf.GetSettings()
+	conf.StoreSettings(stale)
+	t.Cleanup(func() { conf.StoreSettings(origSettings) })
+
+	before, err := os.ReadFile(conf.ConfigPath)
+	require.NoError(t, err)
+
+	o.applyPathCorrection(&pendingPathCorrection{
+		registryID: RegistryIDPerchV2,
+		resolved:   modelFileSet{model: installedModel, labels: installedLabels},
+		repairable: false,
+	})
+
+	after, err := os.ReadFile(conf.ConfigPath)
+	require.NoError(t, err)
+	assert.Equal(t, string(before), string(after),
+		"an unreadable configured path must never be persisted over, or a transient failure becomes permanent")
+
+	published := conf.GetSettings()
+	assert.Equal(t, stale.Perch.ModelPath, published.Perch.ModelPath,
+		"the published snapshot must keep the user's configured path too")
+
+	list, err := svc.List(nil)
+	require.NoError(t, err)
+	var unreadable, reconciled bool
+	for _, n := range list {
+		switch n.TitleKey {
+		case notification.MsgModelPathUnreadableTitle:
+			unreadable = true
+		case notification.MsgModelPathReconciledTitle:
+			reconciled = true
+		}
+	}
+	assert.True(t, unreadable,
+		"the user must be told they are running a substitute; telling them it was 'not found' would send them looking in the wrong place")
+	assert.False(t, reconciled,
+		"nothing was repaired, so the reconciled notification must not fire")
 }
 
 // TestQueuePathCorrection_HealthySetQueuesNothing is the negative for
@@ -435,12 +523,12 @@ func TestQueuePathCorrection_HealthySetQueuesNothing(t *testing.T) {
 	// CONFIRMED-missing member, so a healthy set queues nothing down several
 	// different code paths; without this the test cannot tell the healthy-set
 	// early return from a fallback that happened to keep repairable false.
-	got, usedFallback := o.resolveFamilyPaths(RegistryIDPerchV2, configured, false)
-	assert.False(t, usedFallback)
-	assert.Equal(t, configured, got,
+	res := o.resolveFamilyPaths(RegistryIDPerchV2, configured, false)
+	assert.False(t, res.repairable)
+	assert.Equal(t, configured, res.resolved,
 		"a healthy configured set must be returned verbatim, never swapped for the installed gallery variant")
 
-	o.queuePathCorrection(RegistryIDPerchV2, pathResolution{resolved: got, usedFallback: usedFallback})
+	o.queuePathCorrection(RegistryIDPerchV2, res)
 
 	assert.Empty(t, o.pendingPathCorrections,
 		"a healthy, fully-present configured set must not queue a config repair")
@@ -515,18 +603,18 @@ func TestPathCorrection_QueuedThenDrainedRepairsConfig(t *testing.T) {
 	t.Cleanup(func() { conf.StoreSettings(origSettings) })
 
 	// 1. The resolution reports a repairable fallback onto the installed variant.
-	resolved, usedFallback := o.resolveFamilyPaths(RegistryIDPerchV2, configured, false)
-	require.True(t, usedFallback,
+	res := o.resolveFamilyPaths(RegistryIDPerchV2, configured, false)
+	require.True(t, res.repairable,
 		"a confirmed-missing gallery path must be reported as repairable")
-	require.Equal(t, installedModel, resolved.model)
-	require.Equal(t, installedLabels, resolved.labels)
+	require.Equal(t, installedModel, res.resolved.model)
+	require.Equal(t, installedLabels, res.resolved.labels)
 
 	// 2. Queueing records it. A queuePathCorrection that never queues fails here.
-	o.queuePathCorrection(RegistryIDPerchV2, pathResolution{resolved: resolved, usedFallback: usedFallback})
+	o.queuePathCorrection(RegistryIDPerchV2, res)
 	require.Len(t, o.pendingPathCorrections, 1,
 		"a repairable fallback must queue exactly one correction")
 	assert.Equal(t, RegistryIDPerchV2, o.pendingPathCorrections[0].registryID)
-	assert.Equal(t, resolved, o.pendingPathCorrections[0].resolved,
+	assert.Equal(t, res.resolved, o.pendingPathCorrections[0].resolved,
 		"the queued correction must carry the set the model was actually built from")
 
 	// 3. Draining applies it. A runPendingPathCorrections that snapshots and
@@ -619,12 +707,14 @@ func TestRunPendingPathCorrections_DrainsEveryQueuedFamily(t *testing.T) {
 	// Queue Perch first, Bat second. A drain that applies only pending[0] would
 	// repair Perch and leave the whole Bat set stale.
 	o.queuePathCorrection(RegistryIDPerchV2, pathResolution{
-		resolved:     modelFileSet{model: installedPerchModel, labels: installedPerchLabels},
-		usedFallback: true,
+		resolved:    modelFileSet{model: installedPerchModel, labels: installedPerchLabels},
+		substituted: true,
+		repairable:  true,
 	})
 	o.queuePathCorrection(RegistryIDBat, pathResolution{
-		resolved:     modelFileSet{model: batModel, labels: batLabels, embeddings: batEmb},
-		usedFallback: true,
+		resolved:    modelFileSet{model: batModel, labels: batLabels, embeddings: batEmb},
+		substituted: true,
+		repairable:  true,
 	})
 	require.Len(t, o.pendingPathCorrections, 2, "both families must be queued")
 
@@ -761,12 +851,13 @@ func TestPlanPathCorrection(t *testing.T) {
 		current.Perch.ModelPath = stalePath
 		current.Perch.LabelPath = staleLabels
 
-		updated, changed := o.planPathCorrection(current, &pendingPathCorrection{
+		updated, outcome := o.planPathCorrection(current, &pendingPathCorrection{
 			registryID: RegistryIDPerchV2,
 			resolved:   modelFileSet{model: newModel, labels: newLabels},
+			repairable: true,
 		})
 
-		require.True(t, changed)
+		assert.Equal(t, correctionRewrite, outcome)
 		assert.Equal(t, newModel, updated.Perch.ModelPath)
 		assert.Equal(t, newLabels, updated.Perch.LabelPath,
 			"the stale labels path must be repaired too, not only the model path")
@@ -785,12 +876,13 @@ func TestPlanPathCorrection(t *testing.T) {
 		current.Perch.ModelPath = "/srv/my-models/my_own_perch.onnx"
 		current.Perch.LabelPath = "/srv/my-models/my_own_labels.txt"
 
-		_, changed := o.planPathCorrection(current, &pendingPathCorrection{
+		_, outcome := o.planPathCorrection(current, &pendingPathCorrection{
 			registryID: RegistryIDPerchV2,
 			resolved:   modelFileSet{model: newModel, labels: newLabels},
+			repairable: true,
 		})
 
-		assert.False(t, changed,
+		assert.Equal(t, correctionSubstituted, outcome,
 			"a custom model path must never be taken over: it may simply be on a volume that is not mounted yet")
 	})
 
@@ -802,12 +894,13 @@ func TestPlanPathCorrection(t *testing.T) {
 
 		current := &conf.Settings{} // both paths empty: the gallery already owns them
 
-		_, changed := o.planPathCorrection(current, &pendingPathCorrection{
+		_, outcome := o.planPathCorrection(current, &pendingPathCorrection{
 			registryID: RegistryIDPerchV2,
 			resolved:   modelFileSet{model: newModel, labels: newLabels},
+			repairable: true,
 		})
 
-		assert.False(t, changed,
+		assert.Equal(t, correctionNoop, outcome,
 			"an empty path already resolves through the gallery; writing an absolute path back would only go stale again")
 	})
 
@@ -830,16 +923,17 @@ func TestPlanPathCorrection(t *testing.T) {
 		current.Bat.LabelPath = filepath.Join(modelsDir, batEntry.ID, labelsRoleLocalName(t, batEntry.Files))
 		current.Bat.EmbeddingModel = filepath.Join(modelsDir, "shared", embeddingsRoleLocalName(t, batEntry.Files))
 
-		updated, changed := o.planPathCorrection(current, &pendingPathCorrection{
+		updated, outcome := o.planPathCorrection(current, &pendingPathCorrection{
 			registryID: RegistryIDBat,
 			resolved: modelFileSet{
 				model:      "/models/bat/classifier.onnx",
 				labels:     "/models/bat/labels.txt",
 				embeddings: "/models/shared/embeddings.onnx",
 			},
+			repairable: true,
 		})
 
-		require.True(t, changed)
+		assert.Equal(t, correctionRewrite, outcome)
 		assert.Equal(t, "/models/bat/classifier.onnx", updated.Bat.ClassifierModel)
 		assert.Equal(t, "/models/bat/labels.txt", updated.Bat.LabelPath)
 		assert.Equal(t, "/models/shared/embeddings.onnx", updated.Bat.EmbeddingModel,
@@ -863,12 +957,13 @@ func TestPlanPathCorrection(t *testing.T) {
 
 		newV3Model := "/models/birdnet-v3.0/other.onnx"
 		newV3Labels := "/models/birdnet-v3.0/other_labels.txt"
-		updated, changed := o.planPathCorrection(current, &pendingPathCorrection{
+		updated, outcome := o.planPathCorrection(current, &pendingPathCorrection{
 			registryID: RegistryIDBirdNETV3,
 			resolved:   modelFileSet{model: newV3Model, labels: newV3Labels},
+			repairable: true,
 		})
 
-		require.True(t, changed)
+		assert.Equal(t, correctionRewrite, outcome)
 		assert.Equal(t, newV3Model, updated.BirdNETV3.ModelPath)
 		assert.Equal(t, newV3Labels, updated.BirdNETV3.LabelPath)
 	})
@@ -882,12 +977,13 @@ func TestPlanPathCorrection(t *testing.T) {
 		current := &conf.Settings{}
 		current.Perch.ModelPath = "/models/perch-v2/perch_v2.onnx"
 
-		updated, changed := o.planPathCorrection(current, &pendingPathCorrection{
+		updated, outcome := o.planPathCorrection(current, &pendingPathCorrection{
 			registryID: "Not_A_Model",
 			resolved:   modelFileSet{model: newModel, labels: newLabels},
+			repairable: true,
 		})
 
-		assert.False(t, changed)
+		assert.Equal(t, correctionUnknownFamily, outcome)
 		assert.Nil(t, updated,
 			"an unknown registry returns nil, never the live published snapshot")
 	})
@@ -907,12 +1003,13 @@ func TestPlanPathCorrection(t *testing.T) {
 		current.Perch.ModelPath = "/home/birdnet/.config/birdnet-go/models/perch-v2/" + galleryName
 		current.Perch.LabelPath = "/srv/my-models/my_own_labels.txt"
 
-		updated, changed := o.planPathCorrection(current, &pendingPathCorrection{
+		updated, outcome := o.planPathCorrection(current, &pendingPathCorrection{
 			registryID: RegistryIDPerchV2,
 			resolved:   modelFileSet{model: newModel, labels: newLabels},
+			repairable: true,
 		})
 
-		assert.False(t, changed,
+		assert.Equal(t, correctionSubstituted, outcome,
 			"a user-owned field must veto the whole correction, not just its own field")
 		assert.Nil(t, updated,
 			"an abandoned correction returns nil so the gallery-managed model is never written")
@@ -926,7 +1023,7 @@ func TestPlanPathCorrection(t *testing.T) {
 
 		// Gallery-managed paths that ALREADY equal the resolved set. There is nothing
 		// to change: the no-op guard must skip a field whose value already matches,
-		// so the plan reports changed==false rather than "rewriting" a field to the
+		// so the plan reports outcome==correctionNoop rather than "rewriting" a field to the
 		// value it already holds.
 		samePath := "/home/birdnet/.config/birdnet-go/models/perch-v2/" + galleryName
 		sameLabels := "/home/birdnet/.config/birdnet-go/models/perch-v2/" + galleryLabelsName
@@ -934,12 +1031,13 @@ func TestPlanPathCorrection(t *testing.T) {
 		current.Perch.ModelPath = samePath
 		current.Perch.LabelPath = sameLabels
 
-		_, changed := o.planPathCorrection(current, &pendingPathCorrection{
+		_, outcome := o.planPathCorrection(current, &pendingPathCorrection{
 			registryID: RegistryIDPerchV2,
 			resolved:   modelFileSet{model: samePath, labels: sameLabels},
+			repairable: true,
 		})
 
-		assert.False(t, changed,
+		assert.Equal(t, correctionNoop, outcome,
 			"a configured path already equal to the resolved value is not a change")
 	})
 }
@@ -977,6 +1075,7 @@ func TestApplyPathCorrection_PersistsRepairedPaths(t *testing.T) {
 	o.applyPathCorrection(&pendingPathCorrection{
 		registryID: RegistryIDPerchV2,
 		resolved:   modelFileSet{model: newModel, labels: newLabels},
+		repairable: true,
 	})
 
 	// The published snapshot carries the repaired paths.
@@ -998,7 +1097,7 @@ func TestApplyPathCorrection_PersistsRepairedPaths(t *testing.T) {
 // TestApplyPathCorrection_NoWriteWhenNothingChanged pins the redundant-write
 // short-circuit: when planPathCorrection reports no change (the configured paths
 // already equal the resolved set), applyPathCorrection must NOT publish a new
-// snapshot and must NOT persist config.yaml. Without the `if !changed { return }`
+// snapshot and must NOT persist config.yaml. Without the `switch outcome`
 // guard the whole package stays green while a StoreSettings + SaveSettings runs
 // on a plan that changed nothing.
 func TestApplyPathCorrection_NoWriteWhenNothingChanged(t *testing.T) {
@@ -1015,7 +1114,7 @@ func TestApplyPathCorrection_NoWriteWhenNothingChanged(t *testing.T) {
 	o.SetModelsDir(modelsDir)
 
 	// Gallery-managed paths published as current, and the resolved set is the SAME:
-	// there is nothing to repair, so planPathCorrection reports changed==false.
+	// there is nothing to repair, so planPathCorrection reports outcome==correctionNoop.
 	same := &conf.Settings{}
 	same.Perch.ModelPath = filepath.Join(modelsDir, "perch-v2", galleryName)
 	same.Perch.LabelPath = filepath.Join(modelsDir, "perch-v2", galleryLabelsName)
@@ -1030,6 +1129,7 @@ func TestApplyPathCorrection_NoWriteWhenNothingChanged(t *testing.T) {
 	o.applyPathCorrection(&pendingPathCorrection{
 		registryID: RegistryIDPerchV2,
 		resolved:   modelFileSet{model: same.Perch.ModelPath, labels: same.Perch.LabelPath},
+		repairable: true,
 	})
 
 	assert.Same(t, same, conf.GetSettings(),
@@ -1076,14 +1176,14 @@ func TestApplyPathCorrection_PersistenceDisabledSkipsWrite(t *testing.T) {
 
 	// The runtime fallback still resolves the missing path to the installed model,
 	// independent of persistence.
-	resolved, usedFallback := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
+	res := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
 		model:  stale.Perch.ModelPath,
 		labels: stale.Perch.LabelPath,
 	}, false)
-	require.True(t, usedFallback, "a confirmed-missing configured path must still fall back")
-	assert.Equal(t, installedModel, resolved.model,
+	require.True(t, res.repairable, "a confirmed-missing configured path must still fall back")
+	assert.Equal(t, installedModel, res.resolved.model,
 		"the fallback still resolves the model so analysis can run")
-	assert.Equal(t, installedLabels, resolved.labels)
+	assert.Equal(t, installedLabels, res.resolved.labels)
 
 	origSettings := conf.GetSettings()
 	conf.StoreSettings(stale)
@@ -1094,7 +1194,8 @@ func TestApplyPathCorrection_PersistenceDisabledSkipsWrite(t *testing.T) {
 
 	o.applyPathCorrection(&pendingPathCorrection{
 		registryID: RegistryIDPerchV2,
-		resolved:   resolved,
+		resolved:   res.resolved,
+		repairable: true,
 	})
 
 	assert.Same(t, stale, conf.GetSettings(),
@@ -1151,6 +1252,7 @@ func TestApplyPathCorrection_UserOwnedSubstitutionNotifies(t *testing.T) {
 			model:  filepath.Join(modelsDir, "perch-v2", "perch_v2.onnx"),
 			labels: filepath.Join(modelsDir, "perch-v2", "perch_v2_labels.txt"),
 		},
+		repairable: true,
 	})
 
 	list, err := svc.List(nil)
@@ -1213,14 +1315,14 @@ func TestResolveFamilyPaths_KeepsConfiguredVariantWhenOnlyCompanionIsMissing(t *
 	o := &Orchestrator{}
 	o.SetModelsDir(modelsDir)
 
-	got, _ := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
+	res := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
 		model:  configuredModel,
 		labels: filepath.Join(modelsDir, entry.ID, "gone_labels.txt"),
 	}, false)
 
-	assert.Equal(t, configuredModel, got.model,
+	assert.Equal(t, configuredModel, res.resolved.model,
 		"the variant the configuration names must be kept when its own files are recoverable")
-	assert.Equal(t, expectedLabels, got.labels,
+	assert.Equal(t, expectedLabels, res.resolved.labels,
 		"companion files must come from the SAME variant, not from whichever the catalog lists first")
 }
 
@@ -1252,23 +1354,23 @@ func TestResolveFamilyPaths_SafeUnderOrchestratorLock(t *testing.T) {
 		defer o.mu.Unlock()
 
 		// Fallback path: configured file is absent.
-		_, _ = o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
+		_ = o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
 			model:  "/nonexistent/perch_v2.onnx",
 			labels: "/nonexistent/perch_v2_labels.txt",
 		}, false)
 
 		// Sibling-recovery path: configured model present, companion missing.
-		_, _ = o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
+		_ = o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
 			model:  installedModel,
 			labels: filepath.Join(modelsDir, entry.ID, "gone_labels.txt"),
 		}, false)
 
 		// Queueing a correction is also done under the lock.
-		stale, usedFallback := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
+		res := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
 			model:  "/nonexistent/perch_v2.onnx",
 			labels: "/nonexistent/perch_v2_labels.txt",
 		}, false)
-		o.queuePathCorrection(RegistryIDPerchV2, pathResolution{resolved: stale, usedFallback: usedFallback})
+		o.queuePathCorrection(RegistryIDPerchV2, res)
 	}()
 
 	select {

--- a/internal/classifier/onnx_dispatch_test.go
+++ b/internal/classifier/onnx_dispatch_test.go
@@ -30,8 +30,7 @@ func TestUsesONNXBackend(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			bn := &BirdNET{Settings: &conf.Settings{}, ModelInfo: ModelInfo{Backend: tt.backend}}
-			bn.Settings.BirdNET.ModelPath = tt.modelPath
+			bn := birdNETWithModelPath(tt.modelPath, &ModelInfo{Backend: tt.backend})
 			assert.Equal(t, tt.want, bn.usesONNXBackend())
 		})
 	}
@@ -41,14 +40,12 @@ func TestUsesONNXBackend(t *testing.T) {
 // and case-folding are exercised through usesONNXBackend (not parallel: t.Setenv).
 func TestUsesONNXBackend_PathNormalization(t *testing.T) {
 	t.Run("uppercase extension", func(t *testing.T) {
-		bn := &BirdNET{Settings: &conf.Settings{}, ModelInfo: ModelInfo{Backend: BackendTFLite}}
-		bn.Settings.BirdNET.ModelPath = "/models/X.ONNX"
+		bn := birdNETWithModelPath("/models/X.ONNX", &ModelInfo{Backend: BackendTFLite})
 		assert.True(t, bn.usesONNXBackend())
 	})
 	t.Run("env var expansion", func(t *testing.T) {
 		t.Setenv("TEST_MODELS_DIR", "/models")
-		bn := &BirdNET{Settings: &conf.Settings{}, ModelInfo: ModelInfo{Backend: BackendTFLite}}
-		bn.Settings.BirdNET.ModelPath = "$TEST_MODELS_DIR/x.onnx"
+		bn := birdNETWithModelPath("$TEST_MODELS_DIR/x.onnx", &ModelInfo{Backend: BackendTFLite})
 		assert.True(t, bn.usesONNXBackend())
 	})
 }
@@ -74,9 +71,24 @@ func TestONNXModelPath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			bn := &BirdNET{Settings: &conf.Settings{}, ModelInfo: ModelInfo{CustomPath: tt.customPath}}
-			bn.Settings.BirdNET.ModelPath = tt.modelPath
+			bn := birdNETWithModelPath(tt.modelPath, &ModelInfo{CustomPath: tt.customPath})
 			assert.Equal(t, tt.want, bn.onnxModelPath())
 		})
 	}
+}
+
+// birdNETWithModelPath builds a BirdNET the way NewBirdNET does for a caller with
+// no path resolver: the configured setting AND the resolved primary path both
+// carry modelPath.
+//
+// Setting only Settings.BirdNET.ModelPath is not enough. Every load-path consumer
+// reads configuredModelPath(), which returns the RESOLVED path, so a literal that
+// leaves primaryPath at its zero value describes the "configured file was missing
+// and we recovered to the built-in baseline" state rather than the "user
+// configured this file" state these tests mean.
+func birdNETWithModelPath(modelPath string, info *ModelInfo) *BirdNET {
+	bn := &BirdNET{Settings: &conf.Settings{}, ModelInfo: *info}
+	bn.Settings.BirdNET.ModelPath = modelPath
+	bn.primaryPath = pathResolution{resolved: modelFileSet{model: modelPath}}
+	return bn
 }

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -91,7 +91,12 @@ type Orchestrator struct {
 	inferenceMu sync.Mutex   // serializes inference across all models
 	models      map[string]*modelEntry
 	primary     *BirdNET // direct access to the primary model
-	modelsDir   string   // base directory for gallery-installed models
+	// ortAvailable reports whether ONNX Runtime can be loaded from the given
+	// configured path. Nil in production, where inference.CheckORTAvailability is
+	// used. Tests set it so both sides of the primary recovery's backend gate are
+	// reachable without a real ONNX Runtime on the host.
+	ortAvailable func(configuredPath string) bool
+	modelsDir    string // base directory for gallery-installed models
 
 	// Nighttime scheduling for bat model. Stored as atomic.Pointer so
 	// IsModelActive (called on every monitor tick) reads lock-free.
@@ -116,7 +121,8 @@ type Orchestrator struct {
 	pendingWarmups []pendingWarmup
 
 	// pendingPathCorrections queues configuration repairs recorded by model
-	// loaders while they hold o.mu. Drained by runPendingPathCorrections after
+	// loaders while they hold o.mu, and by NewOrchestrator for the primary before o
+	// is published. Drained by runPendingPathCorrections after
 	// o.mu is released, because the drainer itself takes o.mu to snapshot and
 	// clear this queue, and o.mu is not reentrant; applying one also writes
 	// config.yaml (file I/O). (isGalleryManagedPath, reached from the apply step,
@@ -167,9 +173,11 @@ func NewOrchestrator(settings *conf.Settings) (*Orchestrator, error) {
 	// than o.modelsDir is known, so it could only ever see the RAW configured path
 	// and would defeat the stale-path recovery below. NewBirdNET's Tier 2 computes
 	// the identical ModelInfo from the same two settings (and returns the same error
-	// for an unknown version, which this block silently left to Tier 2 anyway), so
-	// passing nil loses nothing and lets the resolution happen once, in the one
-	// place that has the resolved path.
+	// for an unknown version, which this block silently left to Tier 2 anyway). The
+	// two agree on everything except the path, and that difference is the entire
+	// point: Tier 2 sees the RESOLVED path, which is what this block could never
+	// do. Passing nil therefore loses nothing and lets the resolution happen once,
+	// in the one place that has it.
 
 	// Capture host RSS before the primary model allocates its arena. We need o
 	// to exist first (captureRSSBefore records the runtime baseline on first call),
@@ -203,12 +211,32 @@ func NewOrchestrator(settings *conf.Settings) (*Orchestrator, error) {
 
 	rssBefore := o.captureRSSBefore()
 
+	// Install the stale-path recovery ONLY when the primary slot really is the
+	// BirdNET v2.4 family.
+	//
+	// The slot is family-selectable through birdnet.version, but both the recovery
+	// target (resolveInstalledPaths) and the queued correction label are
+	// permanentRegistryID. A v3.0 primary with a stale path would therefore be
+	// "recovered" onto a v2.4 model file: a 32 kHz/5 s identity pinned to a
+	// 48 kHz/3 s model with a different label set, which fails late with a
+	// label-count mismatch or, were the counts ever to agree, would attribute every
+	// detection to the wrong model. That is exactly the cross-variant pairing
+	// hazard resolveFamilyPaths prevents for the secondaries.
+	//
+	// A nil resolver is the pre-recovery behaviour: the configured path is used
+	// verbatim, so any other family is left exactly as it was.
+	//
 	// o.resolvePrimaryModelPath is safe to hand over now: o.modelsDir was assigned
 	// above, and the resolver reads nothing else off o. NewBirdNET calls it once at
 	// construction and keeps it for its hot-reload path, so both resolve the same
 	// way. Passing the bound method rather than a precomputed value is what keeps
 	// the reload from re-deriving the identity off the raw configured string.
-	bn, err := NewBirdNET(settings, nil, o.resolvePrimaryModelPath)
+	var resolvePrimary primaryPathResolver
+	if primaryRegistryID(settings) == permanentRegistryID {
+		resolvePrimary = o.resolvePrimaryModelPath
+	}
+
+	bn, err := NewBirdNET(settings, nil, resolvePrimary)
 	if err != nil {
 		return nil, err
 	}
@@ -225,9 +253,13 @@ func NewOrchestrator(settings *conf.Settings) (*Orchestrator, error) {
 	// Read the resolution NewBirdNET already performed rather than resolving a
 	// second time: a second call would repeat the stat work and, more visibly,
 	// duplicate every recovery log line for a single start.
-	if bn.primaryPath.substituted {
-		o.deferPathCorrection(permanentRegistryID, bn.primaryPath.resolved, bn.primaryPath.repairable)
-	}
+	//
+	// Routed through queuePathCorrection rather than calling deferPathCorrection
+	// directly, so the primary obeys the same queueing rule as the three
+	// secondaries. That rule has already been edited once (it now gates on
+	// substituted rather than repairable); a hand-rolled copy here is the one place
+	// the next such edit would silently miss.
+	o.queuePathCorrection(permanentRegistryID, bn.primaryPath)
 
 	resolver := NewBirdNETLabelResolver(bn.Labels())
 	ofResolver := openfauna.NewResolver()
@@ -270,6 +302,20 @@ func NewOrchestrator(settings *conf.Settings) (*Orchestrator, error) {
 	return o, nil
 }
 
+// primaryRegistryID reports which model family occupies the primary classifier
+// slot. An empty birdnet.version selects the default BirdNET v2.4 family; an
+// unrecognised version returns "" so callers treat it as "not v2.4" rather than
+// guessing (NewBirdNET's Tier 2 reports the unknown version as an error).
+func primaryRegistryID(settings *conf.Settings) string {
+	if settings.BirdNET.Version == "" {
+		return permanentRegistryID
+	}
+	if info, ok := ResolveBirdNETVersion(settings.BirdNET.Version); ok {
+		return info.ID
+	}
+	return ""
+}
+
 // SetModelsDir sets the base directory for gallery-installed models.
 // Called by ModelManager after creation so model loaders can resolve
 // paths from the installed models directory when config paths are empty.
@@ -285,7 +331,8 @@ func (o *Orchestrator) SetModelsDir(dir string) {
 	// makes the field safe. resolveInstalledPaths, resolveSiblingSet and
 	// isGalleryManagedPath all read o.modelsDir with NO lock held: the first two on
 	// the ReloadSecondaryModels path (which releases o.mu before calling the model
-	// builders) and the third on the config-correction drain path. Those reads are
+	// builders) and on the primary's construction and hot-reload path (via
+	// resolvePrimaryModelPath), and the third on the config-correction drain path. Those reads are
 	// safe only because this setter runs at most once, before the pipeline starts.
 	// See resolveSiblingSet for the full rationale and for what making the models
 	// directory dynamic would require.

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -2194,6 +2194,15 @@ func (o *Orchestrator) loadAdditionalModels(threadAlloc map[string]int) error {
 	// so this reads the same as the sibling drain in LoadModel; on the happy path
 	// it still runs exactly where it did, immediately before the return.
 	//
+	// Note what "every exit path" would mean if this function ever gained an error
+	// return: the drain would then also rewrite config.yaml on a startup that goes
+	// on to fail, where the previous placement skipped it. It has exactly one
+	// return today, so that case does not arise, but anyone adding an early error
+	// return here should decide whether a failed startup may still repair the
+	// configuration. The paths written are consistent with what was actually
+	// loaded either way, since a correction is only queued after a successful
+	// build.
+	//
 	// Warm-ups are drained per-iteration INSIDE the loop below, so they still
 	// complete before this does: the config write must not land inside the window
 	// a per-model RSS delta measures (see runPendingWarmups). That ordering is why

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -226,17 +226,14 @@ func NewOrchestrator(settings *conf.Settings) (*Orchestrator, error) {
 	// A nil resolver is the pre-recovery behaviour: the configured path is used
 	// verbatim, so any other family is left exactly as it was.
 	//
-	// o.resolvePrimaryModelPath is safe to hand over now: o.modelsDir was assigned
-	// above, and the resolver reads nothing else off o. NewBirdNET calls it once at
+	// o.resolvePrimaryModelPath is safe to hand over now. It reads o.modelsDir
+	// (assigned above), o.ortAvailable (nil in production) and o.currentSettings(),
+	// which falls back to the o.Settings the struct literal above already set. All
+	// three are populated before this point. NewBirdNET calls it once at
 	// construction and keeps it for its hot-reload path, so both resolve the same
 	// way. Passing the bound method rather than a precomputed value is what keeps
 	// the reload from re-deriving the identity off the raw configured string.
-	var resolvePrimary primaryPathResolver
-	if primaryRegistryID(settings) == permanentRegistryID {
-		resolvePrimary = o.resolvePrimaryModelPath
-	}
-
-	bn, err := NewBirdNET(settings, nil, resolvePrimary)
+	bn, err := NewBirdNET(settings, nil, o.primaryPathResolverFor(settings))
 	if err != nil {
 		return nil, err
 	}
@@ -300,6 +297,19 @@ func NewOrchestrator(settings *conf.Settings) (*Orchestrator, error) {
 	}
 
 	return o, nil
+}
+
+// primaryPathResolverFor returns the stale-path resolver to hand to NewBirdNET,
+// or nil when the primary slot is not the BirdNET v2.4 family.
+//
+// Extracted from NewOrchestrator so the decision is reachable without building a
+// real model: inline, the only way to observe it was to construct an Orchestrator,
+// so removing the family check broke no test.
+func (o *Orchestrator) primaryPathResolverFor(settings *conf.Settings) primaryPathResolver {
+	if primaryRegistryID(settings) != permanentRegistryID {
+		return nil
+	}
+	return o.resolvePrimaryModelPath
 }
 
 // primaryRegistryID reports which model family occupies the primary classifier

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -91,11 +91,16 @@ type Orchestrator struct {
 	inferenceMu sync.Mutex   // serializes inference across all models
 	models      map[string]*modelEntry
 	primary     *BirdNET // direct access to the primary model
-	// ortAvailable reports whether ONNX Runtime can be loaded from the given
-	// configured path. Nil in production, where inference.CheckORTAvailability is
-	// used. Tests set it so both sides of the primary recovery's backend gate are
-	// reachable without a real ONNX Runtime on the host.
+	// ortAvailable and ovLoadable report whether each inference backend can
+	// actually load from the given configured path. Both are nil in production,
+	// where inference.CheckORTAvailability and inference.InitOpenVINO are used.
+	// Tests set them so every side of the primary recovery's backend gate is
+	// reachable regardless of what the host happens to have installed; without an
+	// OpenVINO seam the gate's OpenVINO leg is untestable in the default build
+	// (openvinoBackendAvailable is a compile-time false there) AND its ORT-only
+	// test silently inverts on a machine that does have OpenVINO.
 	ortAvailable func(configuredPath string) bool
+	ovLoadable   func(libraryPath string) bool
 	modelsDir    string // base directory for gallery-installed models
 
 	// Nighttime scheduling for bat model. Stored as atomic.Pointer so

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -161,17 +161,15 @@ func (o *Orchestrator) updateSettings(s *conf.Settings) {
 // and loads any additional models from configuration.
 // This is the primary constructor - callers should use this instead of NewBirdNET.
 func NewOrchestrator(settings *conf.Settings) (*Orchestrator, error) {
-	// Resolve primary model identity from config
-	var primaryInfo *ModelInfo
-	if settings.BirdNET.Version != "" {
-		info, ok := ResolveBirdNETVersion(settings.BirdNET.Version)
-		if ok {
-			if settings.BirdNET.ModelPath != "" {
-				info.CustomPath = settings.BirdNET.ModelPath
-			}
-			primaryInfo = &info
-		}
-	}
+	// The primary model identity is resolved inside NewBirdNET rather than
+	// pre-seeded here. This used to build a *ModelInfo from settings.BirdNET.Version
+	// and settings.BirdNET.ModelPath before o existed, which is strictly earlier
+	// than o.modelsDir is known, so it could only ever see the RAW configured path
+	// and would defeat the stale-path recovery below. NewBirdNET's Tier 2 computes
+	// the identical ModelInfo from the same two settings (and returns the same error
+	// for an unknown version, which this block silently left to Tier 2 anyway), so
+	// passing nil loses nothing and lets the resolution happen once, in the one
+	// place that has the resolved path.
 
 	// Capture host RSS before the primary model allocates its arena. We need o
 	// to exist first (captureRSSBefore records the runtime baseline on first call),
@@ -205,9 +203,30 @@ func NewOrchestrator(settings *conf.Settings) (*Orchestrator, error) {
 
 	rssBefore := o.captureRSSBefore()
 
-	bn, err := NewBirdNET(settings, primaryInfo)
+	// o.resolvePrimaryModelPath is safe to hand over now: o.modelsDir was assigned
+	// above, and the resolver reads nothing else off o. NewBirdNET calls it once at
+	// construction and keeps it for its hot-reload path, so both resolve the same
+	// way. Passing the bound method rather than a precomputed value is what keeps
+	// the reload from re-deriving the identity off the raw configured string.
+	bn, err := NewBirdNET(settings, nil, o.resolvePrimaryModelPath)
 	if err != nil {
 		return nil, err
+	}
+
+	// Queue the primary's configuration repair, if its configured path was
+	// recovered. Queued here rather than inside NewBirdNET because the queue lives
+	// on the orchestrator, and applied by the existing drain at the end of
+	// loadAdditionalModels below, which runs on every path where NewBirdNET
+	// succeeded. Nothing is queued when the path resolved cleanly.
+	//
+	// No lock is taken: o is not published until this constructor returns, so no
+	// other goroutine can observe the queue. deferPathCorrection documents an
+	// o.mu-held precondition for the loader path; here there is nothing to race.
+	// Read the resolution NewBirdNET already performed rather than resolving a
+	// second time: a second call would repeat the stat work and, more visibly,
+	// duplicate every recovery log line for a single start.
+	if bn.primaryPath.substituted {
+		o.deferPathCorrection(permanentRegistryID, bn.primaryPath.resolved, bn.primaryPath.repairable)
 	}
 
 	resolver := NewBirdNETLabelResolver(bn.Labels())
@@ -532,7 +551,11 @@ func (o *Orchestrator) resolveInstalledPaths(registryID string) (modelPath, labe
 			}
 		}
 	}
-	log.Warn("model in models.enabled but not installed on disk",
+	// Worded for BOTH callers. The secondary loaders reach this for a model listed
+	// in models.enabled, but resolvePrimaryModelPath also calls it for the primary
+	// classifier, which is never in that list, so naming models.enabled here would
+	// put a claim in a support dump that is false for the primary.
+	log.Warn("no installed model found on disk for this model family",
 		logger.String("registry_id", registryID),
 		logger.String("models_dir", o.modelsDir))
 	return "", "", ""
@@ -2104,6 +2127,17 @@ func (o *Orchestrator) computeThreadAllocation(settings *conf.Settings, primaryI
 func (o *Orchestrator) loadAdditionalModels(threadAlloc map[string]int) error {
 	log := GetLogger()
 
+	// Drain the queued configuration repairs on every exit path, including a
+	// panic unwinding out of a loader. Deferred rather than called after the loop
+	// so this reads the same as the sibling drain in LoadModel; on the happy path
+	// it still runs exactly where it did, immediately before the return.
+	//
+	// Warm-ups are drained per-iteration INSIDE the loop below, so they still
+	// complete before this does: the config write must not land inside the window
+	// a per-model RSS delta measures (see runPendingWarmups). That ordering is why
+	// LoadModel registers its two drains in the order it does.
+	defer o.runPendingPathCorrections()
+
 	// Read the live published settings snapshot rather than the deprecated
 	// o.Settings pointer, consistent with the per-model loaders (loadPerch/loadBat).
 	settings := o.currentSettings()
@@ -2149,14 +2183,6 @@ func (o *Orchestrator) loadAdditionalModels(threadAlloc map[string]int) error {
 		// before the next model allocates its arena.
 		o.runPendingWarmups()
 	}
-
-	// Drain the queued configuration repairs AFTER the loop. Each pending family
-	// still does its own config.yaml write (there is no coalescing here); draining
-	// outside the loop keeps those writes out of the per-model RSS measurement
-	// window, the same reason the warm-up drain above runs where it does. Unlike
-	// the warm-up drain, the config write has no per-model RSS measurement of its
-	// own to keep accurate, so it does not need to run inside the loop.
-	o.runPendingPathCorrections()
 
 	return nil
 }

--- a/internal/classifier/orchestrator_bat_onnx.go
+++ b/internal/classifier/orchestrator_bat_onnx.go
@@ -23,15 +23,14 @@ import (
 // The returned resolution is meaningful only when err == nil; every error return
 // yields the zero pathResolution{}.
 func (o *Orchestrator) buildBat(settings *conf.Settings, threads int) (*Bat, pathResolution, error) {
-	resolved, usedFallback := o.resolveFamilyPaths(RegistryIDBat, modelFileSet{
+	res := o.resolveFamilyPaths(RegistryIDBat, modelFileSet{
 		model:      settings.Bat.ClassifierModel,
 		labels:     settings.Bat.LabelPath,
 		embeddings: settings.Bat.EmbeddingModel,
 	}, true)
-	res := pathResolution{resolved: resolved, usedFallback: usedFallback}
-	classifierModel := resolved.model
-	labelPath := resolved.labels
-	embeddingModel := resolved.embeddings
+	classifierModel := res.resolved.model
+	labelPath := res.resolved.labels
+	embeddingModel := res.resolved.embeddings
 
 	if classifierModel == "" || labelPath == "" || embeddingModel == "" {
 		return nil, pathResolution{}, errors.Newf("bat model files not installed or configured").

--- a/internal/classifier/orchestrator_birdnet_v3_onnx.go
+++ b/internal/classifier/orchestrator_birdnet_v3_onnx.go
@@ -24,13 +24,12 @@ import (
 // The returned resolution is meaningful only when err == nil; every error return
 // yields the zero pathResolution{}.
 func (o *Orchestrator) buildBirdNETV3(settings *conf.Settings, threads int) (*BirdNETV3, pathResolution, error) {
-	resolved, usedFallback := o.resolveFamilyPaths(RegistryIDBirdNETV3, modelFileSet{
+	res := o.resolveFamilyPaths(RegistryIDBirdNETV3, modelFileSet{
 		model:  settings.BirdNETV3.ModelPath,
 		labels: settings.BirdNETV3.LabelPath,
 	}, false)
-	res := pathResolution{resolved: resolved, usedFallback: usedFallback}
-	modelPath := resolved.model
-	labelPath := resolved.labels
+	modelPath := res.resolved.model
+	labelPath := res.resolved.labels
 
 	if modelPath == "" || labelPath == "" {
 		return nil, pathResolution{}, errors.Newf("BirdNET v3.0 model files not installed or configured").

--- a/internal/classifier/orchestrator_perch_onnx.go
+++ b/internal/classifier/orchestrator_perch_onnx.go
@@ -24,13 +24,12 @@ import (
 // The returned resolution is meaningful only when err == nil; every error return
 // yields the zero pathResolution{}.
 func (o *Orchestrator) buildPerch(settings *conf.Settings, threads int) (*Perch, pathResolution, error) {
-	resolved, usedFallback := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
+	res := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
 		model:  settings.Perch.ModelPath,
 		labels: settings.Perch.LabelPath,
 	}, false)
-	res := pathResolution{resolved: resolved, usedFallback: usedFallback}
-	modelPath := resolved.model
-	labelPath := resolved.labels
+	modelPath := res.resolved.model
+	labelPath := res.resolved.labels
 
 	if modelPath == "" || labelPath == "" {
 		return nil, pathResolution{}, errors.Newf("Perch v2 model files not installed or configured").

--- a/internal/classifier/orchestrator_reload_secondary_test.go
+++ b/internal/classifier/orchestrator_reload_secondary_test.go
@@ -414,3 +414,39 @@ func TestReloadSecondaryModels_PerEntryTripletRebuildsOnlyStale(t *testing.T) {
 	assert.Equal(t, int32(1), stale.closes.Load(), "stale old instance must be closed")
 	assert.Equal(t, currentTriplet, o.models[testSecondaryID2].backend, "stale entry triplet must advance to current")
 }
+
+// TestReloadSecondaryModels_DiscardsPathResolution pins the discard that keeps a
+// hot reload from rewriting the user's configured model paths.
+//
+// The loaders queue a configuration repair after a successful build; the reload
+// path deliberately calls build* directly and throws the resolution away, so a
+// backend or device swap never touches config.yaml. That discard is load-bearing
+// but is expressed as a bare `_`, which any future edit can flip to a
+// queuePathCorrection call without a single test noticing.
+//
+// The builder assertion is what stops this from passing vacuously: without it a
+// reload that skipped every rebuild would leave the queue empty too, and the
+// test would still pass against a broken discard.
+func TestReloadSecondaryModels_DiscardsPathResolution(t *testing.T) {
+	setGlobalBackend(t, "openvino", "gpu", "/opt/ov")
+
+	o := newTestOrchestrator(t, &mockModelInstance{id: permanentRegistryID})
+	o.ModelInfo.ID = permanentRegistryID
+	o.models[testSecondaryID] = &modelEntry{
+		instance: &reloadFakeModel{id: testSecondaryID},
+		backend:  secondaryBackendKey{backend: "onnx"},
+	}
+
+	var built atomic.Int32
+	registerTestSecondaryBuilder(t, testSecondaryID, func(_ *Orchestrator, _ *conf.Settings, _ int) (ModelInstance, error) {
+		built.Add(1)
+		return &reloadFakeModel{id: testSecondaryID}, nil
+	})
+
+	require.NoError(t, o.ReloadSecondaryModels())
+
+	require.Equal(t, int32(1), built.Load(),
+		"the rebuild must actually run, or an empty queue proves nothing")
+	assert.Empty(t, o.pendingPathCorrections,
+		"a hot reload must never queue a config repair: a backend or device swap is not a stale path")
+}

--- a/internal/classifier/orchestrator_reload_secondary_test.go
+++ b/internal/classifier/orchestrator_reload_secondary_test.go
@@ -2,6 +2,7 @@ package classifier
 
 import (
 	"context"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -415,18 +416,18 @@ func TestReloadSecondaryModels_PerEntryTripletRebuildsOnlyStale(t *testing.T) {
 	assert.Equal(t, currentTriplet, o.models[testSecondaryID2].backend, "stale entry triplet must advance to current")
 }
 
-// TestReloadSecondaryModels_DiscardsPathResolution pins the discard that keeps a
-// hot reload from rewriting the user's configured model paths.
+// TestReloadSecondaryModels_DiscardsPathResolution pins that the hot-reload path
+// queues no configuration repair.
 //
-// The loaders queue a configuration repair after a successful build; the reload
-// path deliberately calls build* directly and throws the resolution away, so a
-// backend or device swap never touches config.yaml. That discard is load-bearing
-// but is expressed as a bare `_`, which any future edit can flip to a
-// queuePathCorrection call without a single test noticing.
-//
-// The builder assertion is what stops this from passing vacuously: without it a
-// reload that skipped every rebuild would leave the queue empty too, and the
-// test would still pass against a broken discard.
+// Scope, stated precisely because an earlier version of this test overclaimed:
+// it pins ReloadSecondaryModels ITSELF, not the bare `_` inside the three real
+// closures in openvinoCapableSecondaryBuilders. Those closures discard the
+// resolution on their SUCCESS path, which needs a real ONNX model and a real
+// ONNX Runtime, so no unit test can reach it. The builder-ran assertion closes
+// the "no rebuild happened" vacuity mode; it does not close that one.
+// TestBuildPerch_DoesNotQueuePathCorrection below covers the adjacent half that
+// IS reachable: that resolving is separated from queueing, so only a loader can
+// queue.
 func TestReloadSecondaryModels_DiscardsPathResolution(t *testing.T) {
 	setGlobalBackend(t, "openvino", "gpu", "/opt/ov")
 
@@ -449,4 +450,46 @@ func TestReloadSecondaryModels_DiscardsPathResolution(t *testing.T) {
 		"the rebuild must actually run, or an empty queue proves nothing")
 	assert.Empty(t, o.pendingPathCorrections,
 		"a hot reload must never queue a config repair: a backend or device swap is not a stale path")
+}
+
+// TestBuildPerch_DoesNotQueuePathCorrection pins the separation the reload path
+// depends on: build* RESOLVES but never QUEUES, so only a loader can turn a
+// resolution into a config rewrite. Moving queuePathCorrection into buildPerch
+// (the shape that would make ReloadSecondaryModels start rewriting the user's
+// paths on a backend swap) fails here.
+//
+// The build itself is expected to fail: there is no real ONNX model or runtime
+// here. The resolution runs first, which is the part under test.
+func TestBuildPerch_DoesNotQueuePathCorrection(t *testing.T) {
+	t.Parallel()
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+
+	modelsDir := filepath.Join(t.TempDir(), "models")
+	installedModel := writeVariantModelFile(t, modelsDir, &entry, "fp32")
+	installedLabels := writeVariantLabelsFile(t, modelsDir, &entry, "fp32")
+
+	o := &Orchestrator{}
+	o.SetModelsDir(modelsDir)
+
+	// A stale gallery-shaped configured set: the resolution substitutes and is
+	// repairable, so anything that queued would queue here.
+	staleDir := filepath.Join(t.TempDir(), "models", entry.ID)
+	settings := &conf.Settings{}
+	settings.Perch.ModelPath = filepath.Join(staleDir, filepath.Base(installedModel))
+	settings.Perch.LabelPath = filepath.Join(staleDir, filepath.Base(installedLabels))
+
+	res := o.resolveFamilyPaths(RegistryIDPerchV2, modelFileSet{
+		model:  settings.Perch.ModelPath,
+		labels: settings.Perch.LabelPath,
+	}, false)
+	require.True(t, res.substituted, "fixture must produce a substituting resolution, or the test proves nothing")
+	require.True(t, res.repairable)
+
+	_, _, err := o.buildPerch(settings, 1)
+	require.Error(t, err, "no real ONNX runtime here; the resolution before the failure is the subject")
+
+	assert.Empty(t, o.pendingPathCorrections,
+		"build* must never queue: only a loader may turn a resolution into a config rewrite")
 }

--- a/internal/classifier/primary_model_path_test.go
+++ b/internal/classifier/primary_model_path_test.go
@@ -1,0 +1,419 @@
+package classifier
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/conf/conftest"
+)
+
+// writePrimaryGalleryModel installs a BirdNET v2.4 primary variant's model file
+// into the gallery layout and returns its path. The primary family is
+// model-only: applyConfigForPrimarySwap writes BirdNET.ModelPath and documents
+// that it never touches BirdNET.LabelPath, because the v2.4 label set is
+// embedded and identical across variants.
+func writePrimaryGalleryModel(t *testing.T, modelsDir string) string {
+	t.Helper()
+	entry, ok := primaryCatalogEntry()
+	require.True(t, ok, "the catalog must carry an entry for the primary registry ID")
+	for i := range entry.Variants {
+		v := &entry.Variants[i]
+		for j := range v.Files {
+			if v.Files[j].Role != RoleModel {
+				continue
+			}
+			subdir := filepath.Join(modelsDir, entry.ID)
+			require.NoError(t, os.MkdirAll(subdir, 0o755))
+			p := filepath.Join(subdir, v.Files[j].LocalName)
+			require.NoError(t, os.WriteFile(p, []byte("m"), 0o600))
+			return p
+		}
+	}
+	t.Fatalf("no primary catalog variant declares a model file")
+	return ""
+}
+
+// primaryCatalogEntry returns the catalog entry for the primary classifier.
+func primaryCatalogEntry() (CatalogEntry, bool) {
+	catalog := ActiveCatalog()
+	for i := range catalog {
+		if catalog[i].RegistryID == permanentRegistryID && len(catalog[i].Variants) > 0 {
+			return catalog[i], true
+		}
+	}
+	return CatalogEntry{}, false
+}
+
+// TestResolvePrimaryModelPath covers the primary classifier's stale-path
+// recovery. Before it, BirdNET.ModelPath was the one configured model path with
+// no fallback at all: the Tier-3 branch took the configured string whenever it
+// was non-empty and returned the os.ReadFile error, so under exactly the
+// conditions GitHub #4201 and #4204 describe (a gallery variant switch, or a
+// container HOME change that invalidates a stored absolute path) a user who had
+// selected a DFT primary variant got a hard NewBirdNET failure. That is worse
+// than the secondary case it mirrors: no analysis at all, rather than one
+// missing optional model.
+func TestResolvePrimaryModelPath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("an empty configured path is left alone", func(t *testing.T) {
+		t.Parallel()
+		o := &Orchestrator{}
+		o.SetModelsDir(t.TempDir())
+
+		res := o.resolvePrimaryModelPath("")
+
+		assert.Empty(t, res.resolved.model, "no configured path means the Tier-4 default, not a substitution")
+		assert.False(t, res.substituted, "nothing the user chose was replaced")
+		assert.False(t, res.repairable)
+	})
+
+	t.Run("a present configured path is used verbatim", func(t *testing.T) {
+		t.Parallel()
+		modelsDir := t.TempDir()
+		installed := writePrimaryGalleryModel(t, modelsDir)
+
+		dir := t.TempDir()
+		configured := filepath.Join(dir, "my_own_primary.tflite")
+		require.NoError(t, os.WriteFile(configured, []byte("m"), 0o600))
+
+		o := &Orchestrator{}
+		o.SetModelsDir(modelsDir)
+
+		res := o.resolvePrimaryModelPath(configured)
+
+		assert.Equal(t, configured, res.resolved.model)
+		assert.False(t, res.substituted)
+		assert.NotEqual(t, installed, res.resolved.model,
+			"a healthy custom primary must never be swapped for the installed gallery variant")
+	})
+
+	t.Run("a missing configured path recovers the installed variant", func(t *testing.T) {
+		t.Parallel()
+		modelsDir := t.TempDir()
+		installed := writePrimaryGalleryModel(t, modelsDir)
+
+		o := &Orchestrator{}
+		o.SetModelsDir(modelsDir)
+
+		res := o.resolvePrimaryModelPath(filepath.Join(t.TempDir(), "gone", "primary.onnx"))
+
+		assert.Equal(t, installed, res.resolved.model,
+			"a confirmed-absent primary path must recover the installed variant instead of failing the load")
+		assert.True(t, res.substituted, "the user is running a model they did not configure")
+		assert.True(t, res.repairable, "a CONFIRMED absence may repair config.yaml")
+	})
+
+	t.Run("a missing configured path with nothing installed falls back to the built-in model", func(t *testing.T) {
+		t.Parallel()
+		// A models directory with no primary variant installed at all.
+		o := &Orchestrator{}
+		o.SetModelsDir(t.TempDir())
+
+		res := o.resolvePrimaryModelPath(filepath.Join(t.TempDir(), "gone", "primary.onnx"))
+
+		assert.Empty(t, res.resolved.model,
+			"resolving to empty is what makes Tier 4 fire and the built-in baseline boot; "+
+				"keeping the stale path here is the hard-failure bug this fixes")
+		assert.True(t, res.substituted, "running the baseline instead of the chosen model must not be silent")
+		assert.False(t, res.repairable,
+			"there is no correct path to write, so the user's own setting must survive for the next start")
+	})
+
+	t.Run("an unreadable configured path is kept, not substituted", func(t *testing.T) {
+		t.Parallel()
+		if runtime.GOOS == "windows" {
+			// Same reason as TestResolveFamilyPaths_IndeterminateFallsBackWithoutRepair:
+			// Windows maps the ENOTDIR-via-file-prefix stat to fs.ErrNotExist, which is
+			// a CONFIRMED absence, so the indeterminate branch is unreachable here.
+			t.Skip("ENOTDIR-via-file-prefix is ERROR_PATH_NOT_FOUND on Windows, mapped to fs.ErrNotExist")
+		}
+
+		modelsDir := t.TempDir()
+		installed := writePrimaryGalleryModel(t, modelsDir)
+
+		// A regular file used as a path prefix makes os.Stat return ENOTDIR, which
+		// is indeterminate rather than a confirmed absence.
+		dir := t.TempDir()
+		regular := filepath.Join(dir, "not-a-dir")
+		require.NoError(t, os.WriteFile(regular, []byte("x"), 0o600))
+		configured := filepath.Join(regular, "primary.onnx")
+
+		o := &Orchestrator{}
+		o.SetModelsDir(modelsDir)
+
+		res := o.resolvePrimaryModelPath(configured)
+
+		// This is the ONE place the primary deliberately diverges from the
+		// secondaries, which DO fall back on this signal. A secondary that fails to
+		// load costs one optional overlay for the session; silently swapping the
+		// primary would attribute every detection written while the condition lasted
+		// to the wrong model.
+		assert.Equal(t, configured, res.resolved.model,
+			"the primary must never switch models on an ambiguous stat error")
+		assert.NotEqual(t, installed, res.resolved.model)
+		assert.False(t, res.substituted)
+		assert.False(t, res.repairable)
+	})
+}
+
+// TestResolvePrimaryModelPath_ExpandsBeforeStat is separate from the table above
+// because t.Setenv cannot run under a parallel parent.
+func TestResolvePrimaryModelPath_ExpandsBeforeStat(t *testing.T) {
+	modelsDir := t.TempDir()
+	writePrimaryGalleryModel(t, modelsDir)
+
+	dir := t.TempDir()
+	modelFile := filepath.Join(dir, "primary.tflite")
+	require.NoError(t, os.WriteFile(modelFile, []byte("m"), 0o600))
+	t.Setenv("TEST_PRIMARY_DIR", dir)
+
+	o := &Orchestrator{}
+	o.SetModelsDir(modelsDir)
+
+	res := o.resolvePrimaryModelPath("$TEST_PRIMARY_DIR/primary.tflite")
+
+	// loadModel and initializeONNXModel both expand before opening. Statting the
+	// RAW string here would classify every configured "$VAR/..." path as missing
+	// and substitute a model out from under the user on every single start.
+	assert.Equal(t, "$TEST_PRIMARY_DIR/primary.tflite", res.resolved.model,
+		"the configured form is preserved; only the stat is done on the expanded path")
+	assert.False(t, res.substituted, "an env-var path that resolves to a real file is not stale")
+}
+
+// TestNewBirdNET_NilResolverUsesConfiguredPathVerbatim pins the seam's default.
+// Every construction without an orchestrator (tests, and any future direct
+// caller) must behave exactly as it did before the resolver existed, or the
+// change would silently alter which file those callers load.
+func TestNewBirdNET_NilResolverUsesConfiguredPathVerbatim(t *testing.T) {
+	t.Parallel()
+
+	bn := &BirdNET{Settings: &conf.Settings{}}
+	bn.Settings.BirdNET.ModelPath = "/models/whatever.onnx"
+	bn.primaryPath = resolvePrimaryOrConfigured(nil, bn.Settings.BirdNET.ModelPath)
+
+	assert.Equal(t, "/models/whatever.onnx", bn.configuredModelPath(),
+		"a nil resolver must pass the configured path through untouched")
+}
+
+// TestReloadModelInternal_RecoveredPathDoesNotVetoReload is the regression test
+// for the second-order bug that split this work out of the earlier PR.
+//
+// reloadModelInternal re-derives the model identity from settings on every
+// reload and refuses the reload when the result differs from the live
+// ModelInfo.CustomPath. If startup recovers a stale primary path (making
+// ModelInfo.CustomPath the RECOVERED file) while config.yaml still holds the
+// stale string, then a reload that re-derived from the raw setting would compare
+// recovered against stale, see a mismatch, roll back, and fail with "model
+// identity changed: requires orchestrator restart". A user who hit the original
+// stale-path bug would get a second, louder bug on their very next settings save
+// (a locale change, a threshold edit).
+//
+// No native model is needed: an unreadable TaxonomyPath fails the reload at the
+// first fallible step, which runs AFTER the identity switch. So the error text
+// distinguishes the two outcomes precisely: reaching the taxonomy step proves
+// the identity gate let the reload through, and a veto never gets that far.
+func TestReloadModelInternal_RecoveredPathDoesNotVetoReload(t *testing.T) {
+	newServing := func(t *testing.T, configuredPath, liveCustomPath string, resolve primaryPathResolver) *BirdNET {
+		t.Helper()
+		settings := conftest.GetTestSettings()
+		settings.BirdNET.Version = ""
+		settings.BirdNET.ModelPath = configuredPath
+		conftest.SetTestSettings(settings)
+		t.Cleanup(func() { conftest.SetTestSettings(nil) })
+
+		bn := &BirdNET{
+			classifier:     &rollbackFakeClassifier{},
+			Settings:       settings,
+			ModelInfo:      customBirdNETV24ModelInfo(liveCustomPath),
+			TaxonomyPath:   filepath.Join(t.TempDir(), "does-not-exist-taxonomy.json"),
+			speciesCache:   make(map[string]*speciesCacheEntry),
+			resolvePrimary: resolve,
+		}
+		bn.primaryPath = pathResolution{resolved: modelFileSet{model: liveCustomPath}}
+		bn.settingsAtomic.Store(settings)
+		bn.publishIdentity()
+		return bn
+	}
+
+	t.Run("a recovered path with stale config must not be refused", func(t *testing.T) {
+		stale := "/gone/primary_dft.onnx"
+		recovered := "/config/models/birdnet-v2.4/primary_dft.onnx"
+
+		// The resolver recovers the stale configured path, exactly as it did at
+		// startup. Config still carries the stale string because the correction is
+		// persisted asynchronously, and may have failed to persist at all.
+		bn := newServing(t, stale, recovered, func(configured string) pathResolution {
+			require.Equal(t, stale, configured, "the reload must re-resolve the CONFIGURED path")
+			return pathResolution{
+				resolved:    modelFileSet{model: recovered},
+				substituted: true,
+				repairable:  true,
+			}
+		})
+
+		err := bn.reloadModelInternal(false)
+
+		require.Error(t, err, "the reload still fails at the taxonomy step; that is the probe, not the subject")
+		assert.Contains(t, err.Error(), "taxonomy",
+			"the reload must reach the taxonomy step, which proves the identity gate let it through")
+		assert.NotContains(t, err.Error(), "requires orchestrator restart",
+			"re-resolving the recovered path is what stops a recovered start from failing its next settings save")
+	})
+
+	t.Run("a genuine user edit to a different file is still refused", func(t *testing.T) {
+		// The negative control. Without it the test above would pass just as well
+		// against a gate that had been deleted outright.
+		edited := "/srv/models/a_different_model.tflite"
+		live := "/srv/models/the_old_model.tflite"
+
+		bn := newServing(t, edited, live, func(configured string) pathResolution {
+			return pathResolution{resolved: modelFileSet{model: configured}}
+		})
+
+		err := bn.reloadModelInternal(false)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "requires orchestrator restart",
+			"changing the primary model file is still a model-identity change")
+	})
+}
+
+// TestPlanPathCorrection_PrimaryRepairsModelPathOnly pins the primary family's
+// settings mapping. BirdNET.LabelPath must be left alone: the v2.4 label set is
+// embedded and identical across variants, which is why applyConfigForPrimarySwap
+// writes ModelPath alone and documents that a user-configured custom label path
+// has to survive a variant swap. Repairing LabelPath here would break that
+// contract from the other direction.
+func TestPlanPathCorrection_PrimaryRepairsModelPathOnly(t *testing.T) {
+	t.Parallel()
+
+	entry, ok := primaryCatalogEntry()
+	require.True(t, ok)
+
+	modelsDir := filepath.Join(t.TempDir(), "models")
+	installed := writePrimaryGalleryModel(t, modelsDir)
+
+	o := &Orchestrator{}
+	o.SetModelsDir(modelsDir)
+
+	// The same gallery layout under an OLD root that no longer exists: the
+	// changed-container-HOME case, which is gallery-managed and so repairable.
+	staleModel := filepath.Join(t.TempDir(), "models", entry.ID, filepath.Base(installed))
+	customLabels := "/srv/my-models/my_own_labels.txt"
+
+	current := &conf.Settings{}
+	current.BirdNET.ModelPath = staleModel
+	current.BirdNET.LabelPath = customLabels
+
+	updated, outcome := o.planPathCorrection(current, &pendingPathCorrection{
+		registryID: permanentRegistryID,
+		resolved:   modelFileSet{model: installed},
+		repairable: true,
+	})
+
+	require.Equal(t, correctionRewrite, outcome)
+	assert.Equal(t, installed, updated.BirdNET.ModelPath, "the stale primary model path must be repaired")
+	assert.Equal(t, customLabels, updated.BirdNET.LabelPath,
+		"the primary family is model-only; a user's custom label path must never be rewritten")
+}
+
+// TestIsGalleryManagedPath_RejectsUnexpandedPath covers the guard that keeps the
+// self-heal from flattening a variable out of a configured path. A configured
+// "$HOME/models/<entry>/<file>" matches the gallery layout on base, parent and
+// grandparent, so without the guard the repair would rewrite it to whatever it
+// expands to today, and the path would then stop following HOME on the next
+// container start. That is the exact fragility this self-heal exists to recover
+// from.
+func TestIsGalleryManagedPath_RejectsUnexpandedPath(t *testing.T) {
+	// Not parallel: t.Setenv.
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+
+	modelsDir := filepath.Join(t.TempDir(), "models")
+	installed := writeVariantModelFile(t, modelsDir, &entry, "fp32")
+
+	o := &Orchestrator{}
+	o.SetModelsDir(modelsDir)
+
+	require.True(t, o.isGalleryManagedPath(RegistryIDPerchV2, installed),
+		"the plain installed path is the control: it must qualify, or the cases below prove nothing")
+
+	t.Setenv("TEST_ROOT", filepath.Dir(filepath.Dir(modelsDir)))
+	base := filepath.Base(installed)
+
+	withEnvVar := filepath.Join("$TEST_ROOT", "models", entry.ID, base)
+	assert.False(t, o.isGalleryManagedPath(RegistryIDPerchV2, withEnvVar),
+		"an env-var path must never be taken over, or the repair flattens the variable")
+
+	withTilde := filepath.Join("~", "models", entry.ID, base)
+	assert.False(t, o.isGalleryManagedPath(RegistryIDPerchV2, withTilde),
+		"a ~-prefixed path must never be taken over for the same reason")
+}
+
+// TestNewBirdNET_RecoversStaleConfiguredPath is the construction-level proof
+// that the recovery actually reaches the model load, not just the resolver.
+//
+// It is the unit-level counterpart of the manual reproduction: with a stale
+// birdnet.modelpath, the previous behaviour was a hard NewBirdNET failure, so
+// the pipeline never started and there was no analysis at all. Every consumer on
+// the load path (identity resolution, backend dispatch, the file open itself)
+// has to agree on the RECOVERED file, so a version of this change that resolved
+// the path but left any one consumer reading the raw setting still fails here.
+func TestNewBirdNET_RecoversStaleConfiguredPath(t *testing.T) {
+	t.Parallel()
+
+	// Same reason as TestNewBirdNET_LocaleNormalization: the recovered file is a
+	// TFLite v2.4 model, which a notflite build cannot load. See #1553.
+	if !tfliteBackendAvailable {
+		t.Skip("TFLite backend not linked (notflite build); this test recovers onto a TFLite v2.4 model")
+	}
+
+	stale := filepath.Join(t.TempDir(), "gone", "BirdNET_v2.4_fp32_dfttrunc.onnx")
+
+	settings := conftest.GetTestSettings()
+	settings.BirdNET.Version = ""
+	settings.BirdNET.ModelPath = stale
+	settings.BirdNET.Locale = "en-uk"
+
+	var resolverCalls int
+	bn, err := NewBirdNET(settings, nil, func(configured string) pathResolution {
+		resolverCalls++
+		assert.Equal(t, stale, configured, "the constructor must resolve the CONFIGURED path")
+		return pathResolution{
+			resolved:    modelFileSet{model: testV24TFLiteModelPath},
+			substituted: true,
+			repairable:  true,
+		}
+	})
+	if bn != nil {
+		t.Cleanup(bn.Delete)
+	}
+
+	require.NoError(t, err,
+		"a stale configured primary path must recover, not abort construction; aborting is the total-analysis-loss bug")
+	require.NotNil(t, bn)
+	assert.Equal(t, 1, resolverCalls, "the constructor resolves exactly once, so the log and the stat are not doubled")
+
+	assert.Equal(t, testV24TFLiteModelPath, bn.configuredModelPath(),
+		"every load-path consumer reads this, so it must be the recovered file")
+	assert.Equal(t, testV24TFLiteModelPath, bn.ModelInfo.CustomPath,
+		"the identity must describe the file that was actually loaded, or the next reload vetoes itself")
+	assert.NotEqual(t, stale, bn.ModelInfo.CustomPath)
+
+	// The orchestrator reads these to queue the config repair without resolving a
+	// second time.
+	assert.True(t, bn.primaryPath.substituted)
+	assert.True(t, bn.primaryPath.repairable)
+
+	// The setting itself is never mutated: the repair goes through the correction
+	// queue, which is what keeps a read-only diagnostic command (benchmark,
+	// rangefilter print) from rewriting the user's configuration.
+	assert.Equal(t, stale, settings.BirdNET.ModelPath,
+		"settings.BirdNET.ModelPath must never be mutated in place by the recovery")
+}

--- a/internal/classifier/primary_model_path_test.go
+++ b/internal/classifier/primary_model_path_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/conf/conftest"
+	"github.com/tphakala/birdnet-go/internal/notification"
 )
 
 // writePrimaryGalleryModel installs a BirdNET v2.4 primary variant's model file
@@ -98,7 +99,7 @@ func TestResolvePrimaryModelPath(t *testing.T) {
 		modelsDir := t.TempDir()
 		installed := writePrimaryGalleryModel(t, modelsDir)
 
-		o := &Orchestrator{}
+		o := &Orchestrator{ortAvailable: func(string) bool { return true }}
 		o.SetModelsDir(modelsDir)
 
 		res := o.resolvePrimaryModelPath(filepath.Join(t.TempDir(), "gone", "primary.onnx"))
@@ -107,6 +108,27 @@ func TestResolvePrimaryModelPath(t *testing.T) {
 			"a confirmed-absent primary path must recover the installed variant instead of failing the load")
 		assert.True(t, res.substituted, "the user is running a model they did not configure")
 		assert.True(t, res.repairable, "a CONFIRMED absence may repair config.yaml")
+	})
+
+	t.Run("recovery is refused when the installed variant's backend is unavailable", func(t *testing.T) {
+		t.Parallel()
+		modelsDir := t.TempDir()
+		writePrimaryGalleryModel(t, modelsDir)
+
+		// Every installed primary variant is an ONNX build, so on a host with no
+		// usable ONNX Runtime, recovering onto one converts a recoverable stale path
+		// into a hard startup failure: initializeModel has no TFLite fallback once
+		// usesONNXBackend is true. That is the very outcome this recovery exists to
+		// prevent, so it must fall through to the built-in baseline instead.
+		o := &Orchestrator{ortAvailable: func(string) bool { return false }}
+		o.SetModelsDir(modelsDir)
+
+		res := o.resolvePrimaryModelPath(filepath.Join(t.TempDir(), "gone", "primary.onnx"))
+
+		assert.Empty(t, res.resolved.model,
+			"without ONNX Runtime the installed variant cannot load, so the built-in baseline must be used")
+		assert.True(t, res.substituted, "the user is still not running the model they configured")
+		assert.False(t, res.repairable, "nothing correct to write, so the user's setting must survive")
 	})
 
 	t.Run("a missing configured path with nothing installed falls back to the built-in model", func(t *testing.T) {
@@ -160,6 +182,28 @@ func TestResolvePrimaryModelPath(t *testing.T) {
 		assert.False(t, res.substituted)
 		assert.False(t, res.repairable)
 	})
+}
+
+// TestResolvePrimaryModelPath_EnvVarPathIsRecoveredButNotRepairable is separate
+// from the table above because t.Setenv cannot run under a parallel parent.
+func TestResolvePrimaryModelPath_EnvVarPathIsRecoveredButNotRepairable(t *testing.T) {
+	modelsDir := t.TempDir()
+	installed := writePrimaryGalleryModel(t, modelsDir)
+
+	// A configured "$VAR/..." that is genuinely missing SHOULD still recover at
+	// runtime, but must never be rewritten: flattening the variable into the
+	// absolute path it expands to today makes the path stop following the variable
+	// on the next container start, which is the exact fragility this recovery
+	// exists to undo.
+	t.Setenv("TEST_GONE_DIR", filepath.Join(t.TempDir(), "gone"))
+	o := &Orchestrator{ortAvailable: func(string) bool { return true }}
+	o.SetModelsDir(modelsDir)
+
+	res := o.resolvePrimaryModelPath("$TEST_GONE_DIR/primary.onnx")
+
+	assert.Equal(t, installed, res.resolved.model, "the runtime substitution still happens")
+	assert.True(t, res.substituted)
+	assert.False(t, res.repairable, "rewriting would flatten the variable into an absolute path")
 }
 
 // TestResolvePrimaryModelPath_ExpandsBeforeStat is separate from the table above
@@ -323,48 +367,126 @@ func TestPlanPathCorrection_PrimaryRepairsModelPathOnly(t *testing.T) {
 		"the primary family is model-only; a user's custom label path must never be rewritten")
 }
 
-// TestIsGalleryManagedPath_RejectsUnexpandedPath covers the guard that keeps the
-// self-heal from flattening a variable out of a configured path. A configured
-// "$HOME/models/<entry>/<file>" matches the gallery layout on base, parent and
-// grandparent, so without the guard the repair would rewrite it to whatever it
-// expands to today, and the path would then stop following HOME on the next
-// container start. That is the exact fragility this self-heal exists to recover
-// from.
-func TestIsGalleryManagedPath_RejectsUnexpandedPath(t *testing.T) {
-	// Not parallel: t.Setenv.
-	entry, ok := GetCatalogEntry("perch-v2")
-	require.True(t, ok)
+// TestQueuePathCorrection_PrimaryFamily covers the queueing RULE the primary
+// shares with the three secondaries, for the resolution shapes only the primary
+// can produce (notably the built-in fallback, whose resolved model is empty).
+//
+// Named for what it tests: it calls queuePathCorrection directly and does NOT
+// exercise NewOrchestrator's call site, which needs a real model to reach. The
+// construction path that feeds it is covered by
+// TestNewBirdNET_RecoversStaleConfiguredPath.
+func TestQueuePathCorrection_PrimaryFamily(t *testing.T) {
+	t.Parallel()
 
-	modelsDir := filepath.Join(t.TempDir(), "models")
-	installed := writeVariantModelFile(t, modelsDir, &entry, "fp32")
+	t.Run("a substituted primary resolution is queued under the primary registry ID", func(t *testing.T) {
+		t.Parallel()
+		o := &Orchestrator{}
+		o.queuePathCorrection(permanentRegistryID, pathResolution{
+			resolved:    modelFileSet{model: "/models/birdnet-v2.4/recovered.onnx"},
+			substituted: true,
+			repairable:  true,
+		})
 
-	o := &Orchestrator{}
-	o.SetModelsDir(modelsDir)
+		require.Len(t, o.pendingPathCorrections, 1)
+		assert.Equal(t, permanentRegistryID, o.pendingPathCorrections[0].registryID,
+			"a correction filed under any other ID would be planned against the wrong settings fields")
+		assert.True(t, o.pendingPathCorrections[0].repairable)
+	})
 
-	require.True(t, o.isGalleryManagedPath(RegistryIDPerchV2, installed),
-		"the plain installed path is the control: it must qualify, or the cases below prove nothing")
+	t.Run("a clean primary resolution queues nothing", func(t *testing.T) {
+		t.Parallel()
+		o := &Orchestrator{}
+		o.queuePathCorrection(permanentRegistryID, pathResolution{
+			resolved: modelFileSet{model: "/models/configured.onnx"},
+		})
+		assert.Empty(t, o.pendingPathCorrections,
+			"a healthy configured primary must never queue a repair or a notification")
+	})
 
-	t.Setenv("TEST_ROOT", filepath.Dir(filepath.Dir(modelsDir)))
-	base := filepath.Base(installed)
+	t.Run("a built-in fallback is queued so the user is told, but is not repairable", func(t *testing.T) {
+		t.Parallel()
+		o := &Orchestrator{}
+		o.queuePathCorrection(permanentRegistryID, pathResolution{substituted: true})
 
-	withEnvVar := filepath.Join("$TEST_ROOT", "models", entry.ID, base)
-	assert.False(t, o.isGalleryManagedPath(RegistryIDPerchV2, withEnvVar),
-		"an env-var path must never be taken over, or the repair flattens the variable")
-
-	withTilde := filepath.Join("~", "models", entry.ID, base)
-	assert.False(t, o.isGalleryManagedPath(RegistryIDPerchV2, withTilde),
-		"a ~-prefixed path must never be taken over for the same reason")
+		require.Len(t, o.pendingPathCorrections, 1,
+			"running the built-in model instead of the configured one must not be silent")
+		assert.Empty(t, o.pendingPathCorrections[0].resolved.model)
+		assert.False(t, o.pendingPathCorrections[0].repairable,
+			"there is no correct path to write, so the user's setting must survive")
+	})
 }
 
-// TestNewBirdNET_RecoversStaleConfiguredPath is the construction-level proof
-// that the recovery actually reaches the model load, not just the resolver.
+// TestApplyPathCorrection_NotificationVariants covers the two message variants
+// that had no test: the built-in fallback body, and the developer-facing
+// unknown-family outcome that must NOT produce a user warning. Both were
+// introduced with this change and both are user-visible (or deliberately not).
+func TestApplyPathCorrection_NotificationVariants(t *testing.T) {
+	// Not parallel: mutates conf globals, conf.ConfigPath and the notification
+	// singleton.
+	redirectConfigFile(t)
+	SetPathCorrectionPersistenceDisabled(false)
+	t.Cleanup(func() { SetPathCorrectionPersistenceDisabled(false) })
+
+	notification.ResetForTest()
+	t.Cleanup(notification.ResetForTest)
+	notification.Initialize(notification.DefaultServiceConfig())
+	svc := notification.GetService()
+	require.NotNil(t, svc)
+	t.Cleanup(svc.Stop)
+
+	stale := &conf.Settings{}
+	stale.BirdNET.ModelPath = "/gone/primary_dft.onnx"
+	origSettings := conf.GetSettings()
+	conf.StoreSettings(stale)
+	t.Cleanup(func() { conf.StoreSettings(origSettings) })
+
+	o := &Orchestrator{}
+	o.SetModelsDir(t.TempDir())
+
+	// Built-in fallback: confirmed absent, nothing installed, so resolved is empty.
+	o.applyPathCorrection(&pendingPathCorrection{
+		registryID: permanentRegistryID,
+		resolved:   modelFileSet{},
+		repairable: false,
+	})
+
+	// Unknown family: a self-heal gap, not a user problem.
+	o.applyPathCorrection(&pendingPathCorrection{
+		registryID: "Not_A_Model",
+		resolved:   modelFileSet{model: "/models/whatever.onnx"},
+		repairable: true,
+	})
+
+	list, err := svc.List(nil)
+	require.NoError(t, err)
+	var builtin, other int
+	for _, n := range list {
+		if n.MessageKey == notification.MsgModelPathBuiltinMessage {
+			builtin++
+			continue
+		}
+		other++
+	}
+	assert.Equal(t, 1, builtin,
+		"the built-in fallback must name the built-in model, not an empty installed path")
+	assert.Zero(t, other,
+		"an unknown registry ID is a developer-facing gap and must never warn the user")
+
+	after, err := os.ReadFile(conf.ConfigPath)
+	require.NoError(t, err)
+	assert.NotContains(t, string(after), "/models/whatever.onnx",
+		"an unknown family must never reach the config write")
+}
+
+// TestNewBirdNET_RecoversStaleConfiguredPath is the construction-level proof that
+// the recovery reaches the model load, not just the resolver.
 //
 // It is the unit-level counterpart of the manual reproduction: with a stale
-// birdnet.modelpath, the previous behaviour was a hard NewBirdNET failure, so
-// the pipeline never started and there was no analysis at all. Every consumer on
-// the load path (identity resolution, backend dispatch, the file open itself)
-// has to agree on the RECOVERED file, so a version of this change that resolved
-// the path but left any one consumer reading the raw setting still fails here.
+// birdnet.modelpath, the previous behaviour was a hard NewBirdNET failure, so the
+// pipeline never started and there was no analysis at all. Every consumer on the
+// load path (identity resolution, backend dispatch, the file open itself) has to
+// agree on the RECOVERED file, so a version of this change that resolved the path
+// but left any one consumer reading the raw setting still fails here.
 func TestNewBirdNET_RecoversStaleConfiguredPath(t *testing.T) {
 	t.Parallel()
 
@@ -406,8 +528,6 @@ func TestNewBirdNET_RecoversStaleConfiguredPath(t *testing.T) {
 		"the identity must describe the file that was actually loaded, or the next reload vetoes itself")
 	assert.NotEqual(t, stale, bn.ModelInfo.CustomPath)
 
-	// The orchestrator reads these to queue the config repair without resolving a
-	// second time.
 	assert.True(t, bn.primaryPath.substituted)
 	assert.True(t, bn.primaryPath.repairable)
 
@@ -416,4 +536,75 @@ func TestNewBirdNET_RecoversStaleConfiguredPath(t *testing.T) {
 	// rangefilter print) from rewriting the user's configuration.
 	assert.Equal(t, stale, settings.BirdNET.ModelPath,
 		"settings.BirdNET.ModelPath must never be mutated in place by the recovery")
+}
+
+// TestReloadModelInternal_BuiltinFallbackSteadyStateReloadsCleanly is the
+// regression test for a defect introduced while fixing this changeset's own
+// review findings, and caught by the report-only review of that fix wave.
+//
+// After a successful startup recovery onto the built-in baseline, config keeps
+// the stale path (that recovery is deliberately not repairable), so EVERY
+// subsequent reload re-resolves to the same substituted-and-empty result. A veto
+// keyed on `substituted` alone therefore failed every settings save forever, for
+// exactly the users the recovery exists to rescue. The veto must key on the
+// resolution having CHANGED from a real file to nothing.
+func TestReloadModelInternal_BuiltinFallbackSteadyStateReloadsCleanly(t *testing.T) {
+	settings := conftest.GetTestSettings()
+	settings.BirdNET.Version = ""
+	settings.BirdNET.ModelPath = "/gone/primary_dft.onnx"
+	conftest.SetTestSettings(settings)
+	t.Cleanup(func() { conftest.SetTestSettings(nil) })
+
+	// The steady state: startup already resolved this away to the baseline, so the
+	// live resolution is ALSO empty. Nothing changed between then and now.
+	bn := &BirdNET{
+		classifier:     &rollbackFakeClassifier{},
+		Settings:       settings,
+		ModelInfo:      stockPrimaryModelInfo(),
+		TaxonomyPath:   filepath.Join(t.TempDir(), "does-not-exist-taxonomy.json"),
+		speciesCache:   make(map[string]*speciesCacheEntry),
+		resolvePrimary: func(string) pathResolution { return pathResolution{substituted: true} },
+	}
+	bn.primaryPath = pathResolution{substituted: true}
+	bn.settingsAtomic.Store(settings)
+	bn.publishIdentity()
+
+	err := bn.reloadModelInternal(false)
+
+	require.Error(t, err, "the reload still fails at the taxonomy step; that is the probe, not the subject")
+	assert.Contains(t, err.Error(), "taxonomy",
+		"the reload must reach the taxonomy step, which proves the identity gate let it through")
+	assert.NotContains(t, err.Error(), "requires orchestrator restart",
+		"a steady-state baseline reload must not be refused, or every settings save fails forever")
+}
+
+// TestReloadModelInternal_VanishedRunningModelIsRefused is the positive half:
+// when the file this instance is RUNNING goes away and nothing can replace it,
+// the reload must be refused rather than silently loading the baseline under an
+// identity that still names the vanished file.
+func TestReloadModelInternal_VanishedRunningModelIsRefused(t *testing.T) {
+	settings := conftest.GetTestSettings()
+	settings.BirdNET.Version = ""
+	settings.BirdNET.ModelPath = "/data/custom_v24.tflite"
+	conftest.SetTestSettings(settings)
+	t.Cleanup(func() { conftest.SetTestSettings(nil) })
+
+	bn := &BirdNET{
+		classifier:     &rollbackFakeClassifier{},
+		Settings:       settings,
+		ModelInfo:      customBirdNETV24ModelInfo("/data/custom_v24.tflite"),
+		TaxonomyPath:   filepath.Join(t.TempDir(), "does-not-exist-taxonomy.json"),
+		speciesCache:   make(map[string]*speciesCacheEntry),
+		resolvePrimary: func(string) pathResolution { return pathResolution{substituted: true} },
+	}
+	// Was running a real custom file; the new resolution finds nothing.
+	bn.primaryPath = pathResolution{resolved: modelFileSet{model: "/data/custom_v24.tflite"}}
+	bn.settingsAtomic.Store(settings)
+	bn.publishIdentity()
+
+	err := bn.reloadModelInternal(false)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires orchestrator restart",
+		"loading the baseline under an identity naming the vanished file would misattribute every detection")
 }

--- a/internal/classifier/primary_model_path_test.go
+++ b/internal/classifier/primary_model_path_test.go
@@ -165,9 +165,6 @@ func TestResolvePrimaryModelPath(t *testing.T) {
 		// refused a variant that would have loaded, dropping such a host to the
 		// embedded model while telling the user no installed model was available.
 		//
-		// Only meaningful where OpenVINO is compiled in; in the default build
-		// openVINOPlanFor short-circuits on a compile-time false, so the leg under
-		// test is unreachable and the recovery correctly declines.
 		o := &Orchestrator{
 			ortAvailable: func(string) bool { return false },
 			ovLoadable:   func(string) bool { return true },
@@ -176,9 +173,26 @@ func TestResolvePrimaryModelPath(t *testing.T) {
 
 		res := o.resolvePrimaryModelPath(filepath.Join(t.TempDir(), "gone", "primary.onnx"))
 
-		if !openvinoBackendAvailable {
+		// Branch on whether a plan is actually OBTAINABLE here, not on the build tag.
+		// The tag is necessary but not sufficient: openVINOPlanFor also needs a
+		// usable device, so an openvino build on a plain amd64 runner or an ARMv8.0
+		// core yields no plan. Gating on the tag alone would make this test pass on
+		// this developer's machine and fail on those hosts, which is precisely the
+		// inversion that shipped in the round it replaced.
+		settings := o.currentSettings()
+		if settings == nil {
+			settings = &conf.Settings{}
+		}
+		_, planOK, _ := openVINOPlanFor(
+			settings.BirdNET.Backend,
+			settings.BirdNET.OpenVINODevice,
+			DefaultModelVersion,
+			settings.BirdNET.OpenVINOPath,
+			birdnetLogitsOutputIndex,
+		)
+		if !planOK {
 			assert.Empty(t, res.resolved.model,
-				"without the openvino build tag there is no OpenVINO leg to take")
+				"with no obtainable OpenVINO plan there is no OpenVINO leg to take")
 			return
 		}
 		assert.Equal(t, installed, res.resolved.model,

--- a/internal/classifier/primary_model_path_test.go
+++ b/internal/classifier/primary_model_path_test.go
@@ -115,12 +115,20 @@ func TestResolvePrimaryModelPath(t *testing.T) {
 		modelsDir := t.TempDir()
 		writePrimaryGalleryModel(t, modelsDir)
 
-		// Every installed primary variant is an ONNX build, so on a host with no
-		// usable ONNX Runtime, recovering onto one converts a recoverable stale path
-		// into a hard startup failure: initializeModel has no TFLite fallback once
-		// usesONNXBackend is true. That is the very outcome this recovery exists to
-		// prevent, so it must fall through to the built-in baseline instead.
-		o := &Orchestrator{ortAvailable: func(string) bool { return false }}
+		// Every installed primary variant is an ONNX build, so on a host where
+		// NEITHER backend can load one, recovering onto it converts a recoverable
+		// stale path into a hard startup failure. That is the very outcome this
+		// recovery exists to prevent, so it must fall through to the built-in
+		// baseline instead.
+		//
+		// Both seams are stubbed, not just ORT. Stubbing ORT alone made this test
+		// environment-dependent: it passed on a bare runner and FAILED under
+		// -tags openvino on any host with a plannable OpenVINO device, a build CI
+		// compiles but never runs tests for.
+		o := &Orchestrator{
+			ortAvailable: func(string) bool { return false },
+			ovLoadable:   func(string) bool { return false },
+		}
 		o.SetModelsDir(modelsDir)
 
 		res := o.resolvePrimaryModelPath(filepath.Join(t.TempDir(), "gone", "primary.onnx"))
@@ -145,6 +153,62 @@ func TestResolvePrimaryModelPath(t *testing.T) {
 		assert.True(t, res.substituted, "running the baseline instead of the chosen model must not be silent")
 		assert.False(t, res.repairable,
 			"there is no correct path to write, so the user's own setting must survive for the next start")
+	})
+
+	t.Run("OpenVINO alone is enough to recover, with no ONNX Runtime", func(t *testing.T) {
+		t.Parallel()
+		modelsDir := t.TempDir()
+		installed := writePrimaryGalleryModel(t, modelsDir)
+
+		// An openvino-tagged build on an A76/Pi5 or an Intel iGPU runs these
+		// variants with no ONNX Runtime installed at all. Gating on ORT alone
+		// refused a variant that would have loaded, dropping such a host to the
+		// embedded model while telling the user no installed model was available.
+		//
+		// Only meaningful where OpenVINO is compiled in; in the default build
+		// openVINOPlanFor short-circuits on a compile-time false, so the leg under
+		// test is unreachable and the recovery correctly declines.
+		o := &Orchestrator{
+			ortAvailable: func(string) bool { return false },
+			ovLoadable:   func(string) bool { return true },
+		}
+		o.SetModelsDir(modelsDir)
+
+		res := o.resolvePrimaryModelPath(filepath.Join(t.TempDir(), "gone", "primary.onnx"))
+
+		if !openvinoBackendAvailable {
+			assert.Empty(t, res.resolved.model,
+				"without the openvino build tag there is no OpenVINO leg to take")
+			return
+		}
+		assert.Equal(t, installed, res.resolved.model,
+			"a loadable OpenVINO plan is sufficient; ONNX Runtime is only the fallback")
+		assert.True(t, res.substituted)
+		assert.True(t, res.repairable)
+	})
+
+	t.Run("an eligible but unloadable OpenVINO runtime does not count", func(t *testing.T) {
+		t.Parallel()
+		modelsDir := t.TempDir()
+		writePrimaryGalleryModel(t, modelsDir)
+
+		// initializeModel falls through to ONNX Runtime when OpenVINO is eligible
+		// but fails to LOAD, and openVINOPlanFor's CPU branch answers yes from the
+		// CPU's f16 support without ever opening the library. Accepting on
+		// eligibility would hand a host with a broken OpenVINO library to the ONNX
+		// path it has no runtime for.
+		o := &Orchestrator{
+			ortAvailable: func(string) bool { return false },
+			ovLoadable:   func(string) bool { return false },
+		}
+		o.SetModelsDir(modelsDir)
+
+		res := o.resolvePrimaryModelPath(filepath.Join(t.TempDir(), "gone", "primary.onnx"))
+
+		assert.Empty(t, res.resolved.model,
+			"an OpenVINO plan that cannot load must not count as a usable backend")
+		assert.True(t, res.substituted)
+		assert.False(t, res.repairable)
 	})
 
 	t.Run("an unreadable configured path is kept, not substituted", func(t *testing.T) {
@@ -583,23 +647,34 @@ func TestReloadModelInternal_BuiltinFallbackSteadyStateReloadsCleanly(t *testing
 // the reload must be refused rather than silently loading the baseline under an
 // identity that still names the vanished file.
 func TestReloadModelInternal_VanishedRunningModelIsRefused(t *testing.T) {
-	settings := conftest.GetTestSettings()
-	settings.BirdNET.Version = ""
-	settings.BirdNET.ModelPath = "/data/custom_v24.tflite"
-	conftest.SetTestSettings(settings)
+	const (
+		oldPath = "/data/previous_v24.tflite"
+		newPath = "/data/just_saved_v24.tflite"
+	)
+
+	// The published snapshot is what the reload reads; bn.Settings is the previous
+	// one that rollback restores. They must DIFFER, or the message could be built
+	// from either and the read-after-rollback bug would be invisible.
+	published := conftest.GetTestSettings()
+	published.BirdNET.Version = ""
+	published.BirdNET.ModelPath = newPath
+	conftest.SetTestSettings(published)
 	t.Cleanup(func() { conftest.SetTestSettings(nil) })
+
+	previous := conf.CloneSettings(published)
+	previous.BirdNET.ModelPath = oldPath
 
 	bn := &BirdNET{
 		classifier:     &rollbackFakeClassifier{},
-		Settings:       settings,
-		ModelInfo:      customBirdNETV24ModelInfo("/data/custom_v24.tflite"),
+		Settings:       previous,
+		ModelInfo:      customBirdNETV24ModelInfo(oldPath),
 		TaxonomyPath:   filepath.Join(t.TempDir(), "does-not-exist-taxonomy.json"),
 		speciesCache:   make(map[string]*speciesCacheEntry),
 		resolvePrimary: func(string) pathResolution { return pathResolution{substituted: true} },
 	}
 	// Was running a real custom file; the new resolution finds nothing.
-	bn.primaryPath = pathResolution{resolved: modelFileSet{model: "/data/custom_v24.tflite"}}
-	bn.settingsAtomic.Store(settings)
+	bn.primaryPath = pathResolution{resolved: modelFileSet{model: oldPath}}
+	bn.settingsAtomic.Store(previous)
 	bn.publishIdentity()
 
 	err := bn.reloadModelInternal(false)
@@ -607,6 +682,42 @@ func TestReloadModelInternal_VanishedRunningModelIsRefused(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "requires orchestrator restart",
 		"loading the baseline under an identity naming the vanished file would misattribute every detection")
+	assert.Contains(t, err.Error(), newPath,
+		"the message must name the path being reloaded")
+	assert.NotContains(t, err.Error(), oldPath,
+		"rollback restores the previous settings snapshot, so reading the path after it names the OLD file "+
+			"and tells the user a healthy path is unusable")
+}
+
+// TestReloadModelInternal_UnknownVersionNamesTheRequestedVersion pins the same
+// read-after-rollback hazard at its sibling site. rollback() restores bn.Settings,
+// so a message built afterwards reports the PREVIOUS, valid version as unknown, or
+// an empty string when the user had not set one.
+func TestReloadModelInternal_UnknownVersionNamesTheRequestedVersion(t *testing.T) {
+	published := conftest.GetTestSettings()
+	published.BirdNET.Version = "9.9"
+	conftest.SetTestSettings(published)
+	t.Cleanup(func() { conftest.SetTestSettings(nil) })
+
+	previous := conf.CloneSettings(published)
+	previous.BirdNET.Version = "2.4"
+
+	bn := &BirdNET{
+		classifier:   &rollbackFakeClassifier{},
+		Settings:     previous,
+		ModelInfo:    ModelRegistry[DefaultModelVersion],
+		TaxonomyPath: filepath.Join(t.TempDir(), "does-not-exist-taxonomy.json"),
+		speciesCache: make(map[string]*speciesCacheEntry),
+	}
+	bn.settingsAtomic.Store(previous)
+	bn.publishIdentity()
+
+	err := bn.reloadModelInternal(false)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "9.9", "the message must name the version the user actually typed")
+	assert.NotContains(t, err.Error(), "2.4",
+		"naming the previously valid version tells the user a working setting is unknown")
 }
 
 // TestPrimaryRegistryID covers the family gate that decides whether the recovery

--- a/internal/classifier/primary_model_path_test.go
+++ b/internal/classifier/primary_model_path_test.go
@@ -608,3 +608,93 @@ func TestReloadModelInternal_VanishedRunningModelIsRefused(t *testing.T) {
 	assert.Contains(t, err.Error(), "requires orchestrator restart",
 		"loading the baseline under an identity naming the vanished file would misattribute every detection")
 }
+
+// TestPrimaryRegistryID covers the family gate that decides whether the recovery
+// runs at all. Deleting that gate lets a stale BirdNET v3.0 primary path be
+// "recovered" onto a v2.4 model file: a 32 kHz/5 s identity pinned to a
+// 48 kHz/3 s model with a different label set.
+func TestPrimaryRegistryID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		version string
+		want    string
+		recover bool
+	}{
+		{"empty version is the default v2.4 family", "", permanentRegistryID, true},
+		{"explicit 2.4", "2.4", permanentRegistryID, true},
+		{"3.0 is a different family", "3.0", RegistryIDBirdNETV3, false},
+		{"an unknown version resolves to nothing", "9.9", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			settings := &conf.Settings{}
+			settings.BirdNET.Version = tt.version
+
+			got := primaryRegistryID(settings)
+			assert.Equal(t, tt.want, got)
+
+			// The gate as NewOrchestrator applies it, not just the helper: a nil
+			// resolver is what stops a non-v2.4 primary from being recovered onto a
+			// v2.4 model file, and what keeps the hard-wired permanentRegistryID
+			// correction label from ever being attached to another family.
+			o := &Orchestrator{}
+			resolver := o.primaryPathResolverFor(settings)
+			if tt.recover {
+				assert.NotNil(t, resolver, "the v2.4 family must get the recovery")
+			} else {
+				assert.Nil(t, resolver,
+					"only the v2.4 family may use a recovery whose target and correction label are both hard-wired to it")
+			}
+		})
+	}
+}
+
+// TestEmitPathSubstitutedNotification_UnreadableIsNotDerivedFromRepairable pins
+// the distinction the explicit unreadable flag exists for. Both records below are
+// NOT repairable; only one of them describes a file that is present. Selecting the
+// wording from repairable alone tells the user of an ABSENT file to go and check
+// its permissions.
+func TestEmitPathSubstitutedNotification_UnreadableIsNotDerivedFromRepairable(t *testing.T) {
+	// Not parallel: mutates the global notification service.
+	notification.ResetForTest()
+	t.Cleanup(notification.ResetForTest)
+	notification.Initialize(notification.DefaultServiceConfig())
+	svc := notification.GetService()
+	require.NotNil(t, svc)
+	t.Cleanup(svc.Stop)
+
+	// Present but unreadable: EACCES on a NAS mount.
+	emitPathSubstitutedNotification(&pendingPathCorrection{
+		registryID: RegistryIDPerchV2,
+		resolved:   modelFileSet{model: "/models/perch-v2/perch_v2.onnx"},
+		repairable: false,
+		unreadable: true,
+	})
+
+	// Confirmed ABSENT, and declined for rewriting because the configured path is
+	// written with a variable. Same repairable value, different truth.
+	emitPathSubstitutedNotification(&pendingPathCorrection{
+		registryID: permanentRegistryID,
+		resolved:   modelFileSet{model: "/models/birdnet-v2.4/recovered.onnx"},
+		repairable: false,
+		unreadable: false,
+	})
+
+	list, err := svc.List(nil)
+	require.NoError(t, err)
+	var unreadable, notFound int
+	for _, n := range list {
+		switch n.MessageKey {
+		case notification.MsgModelPathUnreadableMessage:
+			unreadable++
+		case notification.MsgModelPathSubstitutedMessage:
+			notFound++
+		}
+	}
+	assert.Equal(t, 1, unreadable, "only the present-but-unreadable file may say it could not be read")
+	assert.Equal(t, 1, notFound,
+		"an absent file must say it was not found, or the user checks permissions on a file that does not exist")
+}

--- a/internal/notification/message_keys.go
+++ b/internal/notification/message_keys.go
@@ -191,6 +191,23 @@ const (
 	MsgModelPathSubstitutedTitle   = "notifications.content.modelPath.substitutedTitle"
 	MsgModelPathSubstitutedMessage = "notifications.content.modelPath.substitutedMessage"
 
+	// Model path unreadable notifications (a configured model file could not be
+	// read for a reason OTHER than absence: a permissions change, an I/O error, a
+	// half-initialised mount). The installed gallery model is used at runtime, and
+	// the configuration is never rewritten, because a transient failure must not be
+	// made permanent. Worded separately from the substituted pair above: telling a
+	// user their file "was not found" when it is present but unreadable sends them
+	// looking in the wrong place.
+	MsgModelPathUnreadableTitle   = "notifications.content.modelPath.unreadableTitle"
+	MsgModelPathUnreadableMessage = "notifications.content.modelPath.unreadableMessage"
+
+	// Model path built-in fallback notification (a configured model file is
+	// confirmed absent AND no installed model exists to replace it, so the built-in
+	// model is used instead). Shares MsgModelPathSubstitutedTitle, since the title
+	// ("was not found") is accurate for this case too; only the body differs,
+	// because there is no installed model path to name.
+	MsgModelPathBuiltinMessage = "notifications.content.modelPath.builtinMessage"
+
 	// Model registration notifications (a model assigned to an audio source is
 	// not receiving audio, so it produces no detections)
 	MsgModelNotRegisteredTitle   = "notifications.content.modelPath.notRegisteredTitle"


### PR DESCRIPTION
## Summary

The primary BirdNET v2.4 slot (`birdnet.modelpath`) was the one configured model path with no stale-path fallback. Its Tier-3 branch took the configured string whenever it was non-empty and returned the `os.ReadFile` error, so under exactly the conditions #4201 and #4204 describe (a gallery variant switch, or a container HOME change that invalidates a stored absolute path) a user who had selected a DFT-truncated primary variant got a hard `NewBirdNET` failure. That is worse than the secondary-model case it mirrors: no analysis at all, rather than one missing optional model. #4207 gave the three secondary families that fallback; this does the same for the primary.

The configured path is now resolved once, before the identity tier switch, through a resolver injected into `NewBirdNET`. Resolving before the switch is what makes the recovered-to-empty case behave exactly as if no path had ever been configured: Tier 3 stops firing, Tier 4 resolves the default, and `remapV24ToONNXOnARM64` (which returns early on a non-empty `CustomPath`) is free to remap arm64 to the INT8 ONNX build. Every load-path consumer now reads the resolved value, so identity resolution, backend dispatch and the file open cannot disagree about which file is being loaded. `settings.BirdNET.ModelPath` is never mutated; the repair goes through the existing correction queue, and the primary family is model-only because `applyConfigForPrimarySwap` documents that a user-configured `BirdNET.LabelPath` must survive a variant swap.

The recovery is scoped deliberately. It is installed only when the primary slot really is the v2.4 family, because the slot is family-selectable through `birdnet.version` and both the recovery target and the queued correction label are the v2.4 registry ID; a v3.0 primary would otherwise be recovered onto a v2.4 model file, which is the cross-variant pairing hazard the secondary resolver exists to prevent. It also refuses to recover onto an installed variant whose backend cannot run here: every installed primary variant is an ONNX build, so recovering onto one where neither OpenVINO nor ONNX Runtime can load it would turn a recoverable stale path into a hard startup failure, the very outcome this change exists to prevent.

`reloadModelInternal` re-resolves through the same resolver. Without that, a start that successfully recovered a stale path would fail its very next settings reload: the identity gate would compare the recovered path against the still-stale config and refuse with "requires orchestrator restart", so a user who hit the original bug would get a second, louder one on their next save. The reload also now refuses when the file it is actually running has gone away and nothing can replace it, rather than loading the baseline under an identity that still names the vanished file and reporting success.

Separately, an unreadable (not missing) configured path substituted a different model with no user-visible signal at all. `pathResolution` now carries "substituted" and "repairable" independently, so that case is queued and reported while `config.yaml` is still never rewritten, and `planPathCorrection` returns an explicit outcome instead of a nil snapshot that meant two different things. Three notification strings were added, translated into all 16 locales, so a present-but-unreadable file is not described as "not found".

## Related Issues

Relates to #4201
Relates to #4204

## Test Plan

- [x] `golangci-lint run` reports 0 issues
- [x] `go test -race ./internal/classifier/ ./internal/notification/` green
- [x] Suite green under the default, `notflite` and `openvino` tag sets (the openvino job builds and vets but does not run tests, so this was verified locally)
- [x] Frontend `check:all`, i18n key sync and generated-type drift guards green
- [x] 16 new tests; each new guard verified by reverting it and confirming the suite fails
- [x] Manual QA against a built binary, with a stale `birdnet.modelpath`: `main` fails to start; this branch recovers the installed variant when one is present, boots the built-in model when none is, and leaves the user's configuration untouched in both cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automatically recovers usable installed model files when configured paths are missing or outdated.
  - Falls back to the built-in model when no suitable replacement is available.
  - Preserves unreadable paths and provides actionable notifications instead of overwriting configuration.
  - Improves model reload behavior, diagnostics, and backend selection after path changes.

- **Localization**
  - Added translated notifications for model-path recovery, unreadable files, and built-in model fallback across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->