### PR TITLE
fix(spectrogram): render the live waterfall on Safari/WebKit

### DIFF
--- a/frontend/src/lib/desktop/components/media/SpectrogramCanvas.svelte
+++ b/frontend/src/lib/desktop/components/media/SpectrogramCanvas.svelte
@@ -31,6 +31,12 @@
     analyser: AnalyserNode | null;
     /** Pre-allocated frequency data buffer */
     frequencyData: Uint8Array<ArrayBuffer>;
+    /**
+     * Render `frequencyData` as supplied instead of polling the analyser.
+     * Set when the bins come from the server because the browser's
+     * AnalyserNode cannot read HLS-backed media (Safari/WebKit).
+     */
+    externalFrequencyData?: boolean;
     /** Sample rate for bin-to-frequency mapping */
     sampleRate: number;
     /** FFT size for bin count calculation */
@@ -64,6 +70,7 @@
   let {
     analyser,
     frequencyData,
+    externalFrequencyData = false,
     sampleRate,
     fftSize,
     frequencyRange = [0, 15000],
@@ -203,7 +210,7 @@
 
   // Main animation loop
   $effect(() => {
-    if (!analyser || !isActive || !canvasEl) return;
+    if ((!analyser && !externalFrequencyData) || !isActive || !canvasEl) return;
 
     const ctx = canvasEl.getContext('2d');
     if (!ctx) return;
@@ -266,8 +273,11 @@
       const deltaTime = (now - lastFrameTime) / 1000;
       lastFrameTime = now;
 
-      // Read frequency data from analyser
-      analyser.getByteFrequencyData(frequencyData);
+      // Read frequency data from the analyser, unless the caller is filling
+      // frequencyData itself from the server.
+      if (!externalFrequencyData) {
+        analyser?.getByteFrequencyData(frequencyData);
+      }
 
       // Compute device pixels to scroll; cap deltaTime to prevent OOM after tab resume
       const clampedDelta = Math.min(deltaTime, MAX_FRAME_DELTA_SEC);

--- a/frontend/src/lib/desktop/features/dashboard/components/MiniSpectrogram.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/MiniSpectrogram.svelte
@@ -97,7 +97,11 @@
   const MAX_OVERLAY_SLOTS = 4;
 
   // Initialize composable during component init (must be at top level for $effect cleanup)
-  const spectro = useSpectrogramAnalyser({ fftSize: FFT_SIZE, audioOutput: false });
+  const spectro = useSpectrogramAnalyser({
+    fftSize: FFT_SIZE,
+    audioOutput: false,
+    getPlayingDate: () => hls?.playingDate ?? null,
+  });
 
   function shouldAutoStart(): boolean {
     if (appState.liveSpectrogram) return true;
@@ -244,7 +248,7 @@
           persistToggleState(true);
 
           if (audioElement) {
-            await spectro.connect(audioElement);
+            await spectro.connect(audioElement, sourceId);
           }
           if (signal.aborted) {
             spectro.disconnect();
@@ -277,7 +281,7 @@
         isConnecting = false;
         persistToggleState(true);
 
-        await spectro.connect(audioElement);
+        await spectro.connect(audioElement, sourceId);
         if (signal.aborted) {
           spectro.disconnect();
         }
@@ -532,8 +536,9 @@
       <SpectrogramCanvas
         analyser={spectro.analyser}
         frequencyData={spectro.frequencyData}
+        externalFrequencyData={spectro.usingServerSpectrum}
         sampleRate={spectro.sampleRate}
-        fftSize={FFT_SIZE}
+        fftSize={spectro.fftSize}
         {frequencyRange}
         {colorMap}
         isActive={spectro.isActive}

--- a/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
+++ b/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
@@ -97,7 +97,11 @@
   let activeSourceId: string | null = null;
 
   // Initialize composable during component init (registers cleanup $effect)
-  const spectro = useSpectrogramAnalyser({ fftSize: FFT_SIZE, audioOutput: true });
+  const spectro = useSpectrogramAnalyser({
+    fftSize: FFT_SIZE,
+    audioOutput: true,
+    getPlayingDate: () => hls?.playingDate ?? null,
+  });
 
   // Source discovery via SSE
   function connectSSE() {
@@ -330,7 +334,7 @@
           if (signal.aborted) return;
           // Connect the spectrogram analyser once manifest is ready
           if (audioElement) {
-            await spectro.connect(audioElement);
+            await spectro.connect(audioElement, activeSourceId);
           }
           if (signal.aborted) {
             spectro.disconnect();
@@ -401,7 +405,7 @@
           }
         }
         if (signal.aborted || !audioElement) return;
-        await spectro.connect(audioElement);
+        await spectro.connect(audioElement, activeSourceId);
         if (signal.aborted) {
           spectro.disconnect();
           return;
@@ -850,6 +854,7 @@
         <SpectrogramCanvas
           analyser={spectro.analyser}
           frequencyData={spectro.frequencyData}
+          externalFrequencyData={spectro.usingServerSpectrum}
           sampleRate={spectro.sampleRate}
           fftSize={spectro.fftSize}
           {frequencyRange}

--- a/frontend/src/lib/utils/serverSpectrum.test.ts
+++ b/frontend/src/lib/utils/serverSpectrum.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  decodeSpectrumColumn,
+  hasSpectrumEnergy,
+  nextSpectrumRender,
+  selectSpectrumColumn,
+  trimSpectrumQueue,
+  type SpectrumColumn,
+  type SpectrumRenderState,
+} from './serverSpectrum';
+
+function column(time: number, first = 0): SpectrumColumn {
+  const bins = new Uint8Array(4);
+  bins[0] = first;
+  return { time, bins };
+}
+
+function encode(bytes: number[]): string {
+  return globalThis.btoa(String.fromCharCode(...bytes));
+}
+
+describe('decodeSpectrumColumn', () => {
+  it('decodes base64 into the original bytes', () => {
+    const bytes = [0, 1, 127, 128, 255];
+    const decoded = decodeSpectrumColumn(encode(bytes));
+    expect(decoded).not.toBeNull();
+    expect(Array.from(decoded ?? [])).toEqual(bytes);
+  });
+
+  it('round-trips a full 512-bin column', () => {
+    const bytes = Array.from({ length: 512 }, (_, i) => i % 256);
+    const decoded = decodeSpectrumColumn(encode(bytes));
+    expect(decoded).toHaveLength(512);
+    expect(Array.from(decoded ?? [])).toEqual(bytes);
+  });
+
+  it('returns null for an empty payload', () => {
+    expect(decodeSpectrumColumn('')).toBeNull();
+  });
+
+  it('returns null for a malformed payload instead of throwing', () => {
+    expect(decodeSpectrumColumn('not base64!!')).toBeNull();
+  });
+});
+
+describe('hasSpectrumEnergy', () => {
+  it('is false for digital silence', () => {
+    expect(hasSpectrumEnergy(new Uint8Array(512), 8)).toBe(false);
+  });
+
+  it('is false when every bin sits at or below the threshold', () => {
+    expect(hasSpectrumEnergy(Uint8Array.from([1, 5, 8, 8]), 8)).toBe(false);
+  });
+
+  it('is true as soon as one bin exceeds the threshold', () => {
+    expect(hasSpectrumEnergy(Uint8Array.from([0, 0, 9, 0]), 8)).toBe(true);
+  });
+});
+
+describe('trimSpectrumQueue', () => {
+  it('leaves a queue inside the window untouched', () => {
+    const queue = [column(100), column(105), column(110)];
+    expect(trimSpectrumQueue(queue, 30, 800)).toBe(queue);
+  });
+
+  it('drops columns older than the window', () => {
+    const queue = [column(10), column(60), column(95), column(100)];
+    expect(trimSpectrumQueue(queue, 30, 800).map(c => c.time)).toEqual([95, 100]);
+  });
+
+  it('always keeps the newest column, however old the queue is', () => {
+    const queue = [column(10), column(20)];
+    expect(trimSpectrumQueue(queue, 1, 800).map(c => c.time)).toEqual([20]);
+  });
+
+  it('handles an empty or single-entry queue', () => {
+    expect(trimSpectrumQueue([], 30, 800)).toEqual([]);
+    expect(trimSpectrumQueue([column(1)], 30, 800).map(c => c.time)).toEqual([1]);
+  });
+});
+
+describe('selectSpectrumColumn', () => {
+  const queue = [column(100, 1), column(101, 2), column(102, 3)];
+
+  it('returns -1 for an empty queue', () => {
+    expect(selectSpectrumColumn([], 100)).toBe(-1);
+  });
+
+  it('uses the newest column when the playhead is unknown', () => {
+    expect(selectSpectrumColumn(queue, 0)).toBe(2);
+  });
+
+  it('picks the newest column at or before the playhead', () => {
+    expect(selectSpectrumColumn(queue, 101.5)).toBe(1);
+    expect(selectSpectrumColumn(queue, 101)).toBe(1);
+  });
+
+  it('holds the whole queue back when the playhead is behind all of it', () => {
+    expect(selectSpectrumColumn(queue, 99)).toBe(-1);
+  });
+
+  it('does not run ahead of the playhead once it catches up to live', () => {
+    expect(selectSpectrumColumn(queue, 500)).toBe(2);
+  });
+
+  it('walks forward one column at a time as the playhead advances', () => {
+    expect(queue.map(c => selectSpectrumColumn(queue, c.time))).toEqual([0, 1, 2]);
+  });
+});
+
+describe('nextSpectrumRender', () => {
+  const STALL = 1500;
+  const fresh: SpectrumRenderState = { renderedTime: 0, advancedAt: 1000, unaligned: false };
+
+  it('renders the column the playhead has reached', () => {
+    const queue = [column(100), column(101), column(102)];
+    const step = nextSpectrumRender(queue, 101, fresh, 1000, STALL);
+    expect(step).toMatchObject({ index: 1, blank: false });
+    expect(step.state).toMatchObject({ renderedTime: 101, advancedAt: 1000, unaligned: false });
+  });
+
+  it('holds without re-rendering while the playhead sits on the same column', () => {
+    const queue = [column(100), column(101)];
+    const shown: SpectrumRenderState = { renderedTime: 101, advancedAt: 1000, unaligned: false };
+    expect(nextSpectrumRender(queue, 101.2, shown, 1400, STALL)).toMatchObject({
+      index: -1,
+      blank: false,
+      state: shown,
+    });
+  });
+
+  it('blanks the waterfall when no new column arrives before the stall timeout', () => {
+    const queue = [column(100), column(101)];
+    const shown: SpectrumRenderState = { renderedTime: 101, advancedAt: 1000, unaligned: false };
+    const step = nextSpectrumRender(queue, 101.2, shown, 1000 + STALL + 1, STALL);
+    expect(step).toMatchObject({ index: -1, blank: true });
+    expect(step.state.renderedTime).toBe(0);
+  });
+
+  it('blanks only once, not on every tick after the stall', () => {
+    const queue = [column(100)];
+    const blanked: SpectrumRenderState = { renderedTime: 0, advancedAt: 1000, unaligned: false };
+    expect(nextSpectrumRender(queue, 100.5, blanked, 9000, STALL).blank).toBe(false);
+  });
+
+  it('recovers as soon as a newer column becomes due', () => {
+    const queue = [column(100), column(105)];
+    const blanked: SpectrumRenderState = { renderedTime: 0, advancedAt: 1000, unaligned: false };
+    expect(nextSpectrumRender(queue, 105, blanked, 9000, STALL)).toMatchObject({
+      index: 1,
+      blank: false,
+    });
+  });
+
+  it('blanks when the stream stops delivering columns entirely', () => {
+    const shown: SpectrumRenderState = { renderedTime: 101, advancedAt: 1000, unaligned: false };
+    expect(nextSpectrumRender([], 200, shown, 1000 + STALL + 1, STALL)).toMatchObject({
+      index: -1,
+      blank: true,
+    });
+  });
+
+  it('waits, then abandons alignment when the playhead never reaches the queue', () => {
+    // Browser clock behind the server: every queued column looks like the future.
+    const queue = [column(500), column(501)];
+    expect(nextSpectrumRender(queue, 100, fresh, 1200, STALL)).toMatchObject({
+      index: -1,
+      blank: false,
+      state: { unaligned: false },
+    });
+
+    const step = nextSpectrumRender(queue, 100, fresh, 1000 + STALL + 1, STALL);
+    expect(step).toMatchObject({ index: 1, blank: false });
+    expect(step.state.unaligned).toBe(true);
+  });
+
+  it('keeps rendering the newest column once alignment is abandoned', () => {
+    const queue = [column(500), column(501), column(502)];
+    const unaligned: SpectrumRenderState = { renderedTime: 501, advancedAt: 1000, unaligned: true };
+    expect(nextSpectrumRender(queue, 0, unaligned, 1000, STALL)).toMatchObject({ index: 2 });
+  });
+
+  it('replays history when the playhead jumps backwards', () => {
+    const queue = [column(100), column(101), column(102)];
+    const shown: SpectrumRenderState = { renderedTime: 102, advancedAt: 1000, unaligned: false };
+    expect(nextSpectrumRender(queue, 100, shown, 1000, STALL)).toMatchObject({ index: 0 });
+  });
+
+  it('advances one column per tick as the playhead runs forward', () => {
+    const queue = [column(100), column(101), column(102)];
+    let state = fresh;
+    const seen: number[] = [];
+    for (const playhead of [100, 101, 102]) {
+      const step = nextSpectrumRender(queue, playhead, state, 1000, STALL);
+      state = step.state;
+      seen.push(step.index);
+    }
+    expect(seen).toEqual([0, 1, 2]);
+  });
+});

--- a/frontend/src/lib/utils/serverSpectrum.ts
+++ b/frontend/src/lib/utils/serverSpectrum.ts
@@ -1,0 +1,155 @@
+/**
+ * Server-computed spectrum column helpers.
+ *
+ * WebKit cannot route an HLS-backed media element into the Web Audio graph
+ * (https://bugs.webkit.org/show_bug.cgi?id=180696), so on Safari the live
+ * spectrogram's AnalyserNode reports nothing and the waterfall stays blank.
+ * `useSpectrogramAnalyser` falls back to magnitude columns computed on the
+ * server and delivered over the audio-level SSE stream; the decoding and
+ * queueing decisions live here so they stay pure and unit testable.
+ */
+
+/** One magnitude column: capture time (Unix seconds) and 0-255 bin values. */
+export interface SpectrumColumn {
+  time: number;
+  bins: Uint8Array<ArrayBuffer>;
+}
+
+/** Decode a base64 spectrum column into bytes, or null if it is unusable. */
+export function decodeSpectrumColumn(encoded: string): Uint8Array<ArrayBuffer> | null {
+  try {
+    const binary = globalThis.atob(encoded);
+    if (binary.length === 0) return null;
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      // eslint-disable-next-line security/detect-object-injection -- i is a loop counter bounded by the decoded length
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  } catch {
+    return null;
+  }
+}
+
+/** True when any bin is loud enough to count as audio rather than silence. */
+export function hasSpectrumEnergy(bins: Uint8Array, threshold: number): boolean {
+  return bins.some(v => v > threshold);
+}
+
+/**
+ * Drop columns older than `windowSeconds` before the newest one.
+ *
+ * The queue only has to span the gap between live capture and buffered
+ * playback, plus enough history to survive a small backward correction of the
+ * playhead; holding more would grow memory to redraw audio nobody is listening
+ * to. The newest column is always kept, so the queue never empties.
+ *
+ * `maxColumns` is a backstop for a server clock that jumps backwards, which
+ * would otherwise make the newest timestamp a useless cutoff reference.
+ */
+export function trimSpectrumQueue(
+  queue: SpectrumColumn[],
+  windowSeconds: number,
+  maxColumns: number
+): SpectrumColumn[] {
+  if (queue.length < 2) return queue;
+  const cutoff = queue[queue.length - 1].time - windowSeconds;
+  let drop = 0;
+  // eslint-disable-next-line security/detect-object-injection -- drop is a loop counter bounded by the queue length
+  while (drop < queue.length - 1 && queue[drop].time < cutoff) drop++;
+  drop = Math.max(drop, queue.length - maxColumns);
+  return drop > 0 ? queue.slice(drop) : queue;
+}
+
+/**
+ * Pick the column to render for a given playhead wall-clock time.
+ *
+ * Columns are stamped with capture time, but HLS playback runs several seconds
+ * behind live. Rendering each column on arrival would put the waterfall ahead
+ * of the audio, and ahead of the detection labels overlaid on it, which are
+ * already aligned to the playhead. So take the newest column at or before the
+ * playhead.
+ *
+ * @returns the index to render, or -1 when nothing is due yet. A playhead of 0
+ *   means "unknown" (no program date, nothing seekable), in which case the
+ *   newest column is used — a slightly early waterfall beats a blank one.
+ */
+export function selectSpectrumColumn(queue: SpectrumColumn[], playhead: number): number {
+  if (queue.length === 0) return -1;
+  if (playhead <= 0) return queue.length - 1;
+  for (let i = queue.length - 1; i >= 0; i--) {
+    // eslint-disable-next-line security/detect-object-injection -- i is a loop counter bounded by the queue length
+    if (queue[i].time <= playhead) return i;
+  }
+  return -1;
+}
+
+/** What the render loop should do with the queue on this tick. */
+export interface SpectrumRenderState {
+  /** Capture time of the column currently in the render buffer; 0 when blank. */
+  renderedTime: number;
+  /** Clock reading (ms) when the rendered column last advanced. */
+  advancedAt: number;
+  /** True once playhead alignment has been abandoned as unusable. */
+  unaligned: boolean;
+}
+
+export interface SpectrumRenderStep {
+  /** Queue index to copy into the render buffer, or -1 to leave it alone. */
+  index: number;
+  /** Clear the render buffer: nothing new has arrived for too long. */
+  blank: boolean;
+  state: SpectrumRenderState;
+}
+
+/**
+ * Decide what the fallback waterfall shows on one tick.
+ *
+ * Three things have to hold at once, which is why this is a single reducer
+ * rather than three checks scattered through the render loop:
+ *
+ * - a column is shown only when the playhead has reached it, so the waterfall
+ *   matches the buffered audio and the detection labels drawn over it;
+ * - the buffer is blanked when no *new* column has been shown for
+ *   `stallTimeoutMs`, so a dropped stream reads as silence instead of smearing
+ *   one frozen column across the canvas;
+ * - if the playhead never reaches the queue at all — a browser and server whose
+ *   clocks disagree, which the seekable-range playhead estimate cannot detect —
+ *   alignment is abandoned rather than leaving the user with a blank waterfall
+ *   forever. That is the pre-alignment behaviour, and it is still far better
+ *   than the blank canvas this whole fallback exists to fix.
+ */
+export function nextSpectrumRender(
+  queue: SpectrumColumn[],
+  playhead: number,
+  state: SpectrumRenderState,
+  now: number,
+  stallTimeoutMs: number
+): SpectrumRenderStep {
+  const stalled = now - state.advancedAt > stallTimeoutMs;
+  const hold = (): SpectrumRenderStep =>
+    stalled && state.renderedTime !== 0
+      ? { index: -1, blank: true, state: { ...state, renderedTime: 0 } }
+      : { index: -1, blank: false, state };
+
+  if (queue.length === 0) return hold();
+
+  const index = selectSpectrumColumn(queue, state.unaligned ? 0 : playhead);
+
+  if (index < 0) {
+    if (!stalled) return { index: -1, blank: false, state };
+    const newest = queue.length - 1;
+    return {
+      index: newest,
+      blank: false,
+      // eslint-disable-next-line security/detect-object-injection -- newest is the queue's last index
+      state: { renderedTime: queue[newest].time, advancedAt: now, unaligned: true },
+    };
+  }
+
+  // eslint-disable-next-line security/detect-object-injection -- index comes from selectSpectrumColumn, bounded by the queue
+  const time = queue[index].time;
+  if (time === state.renderedTime) return hold();
+
+  return { index, blank: false, state: { ...state, renderedTime: time, advancedAt: now } };
+}

--- a/frontend/src/lib/utils/serverSpectrumFallback.ts
+++ b/frontend/src/lib/utils/serverSpectrumFallback.ts
@@ -1,0 +1,264 @@
+/**
+ * Server-spectrum fallback controller for the live spectrogram.
+ *
+ * WebKit cannot route an HLS-backed media element into the Web Audio graph
+ * (https://bugs.webkit.org/show_bug.cgi?id=180696), so on Safari the live
+ * spectrogram's AnalyserNode reports nothing and the waterfall stays blank.
+ * This owns the whole workaround: watch the local analyser, and if it turns out
+ * to be blind, subscribe to magnitude columns computed on the server and
+ * delivered over the audio-level SSE stream.
+ *
+ * It is deliberately free of Svelte runes and of any Web Audio state, so it can
+ * be unit tested with plain fakes and so `useSpectrogramAnalyser` keeps only a
+ * handful of lines of wiring. Everything it needs from the host arrives through
+ * `ServerSpectrumHooks`; everything it produces leaves through `onColumn` and
+ * `onAdopt`.
+ */
+
+import { buildAppUrl } from './urlHelpers';
+import { loggers } from './logger';
+import { ReconnectingEventSource } from './ReconnectingEventSource';
+import {
+  decodeSpectrumColumn,
+  hasSpectrumEnergy,
+  nextSpectrumRender,
+  trimSpectrumQueue,
+  type SpectrumColumn,
+  type SpectrumRenderState,
+} from './serverSpectrum';
+
+const logger = loggers.audio;
+
+/** How often the local analyser is checked (ms) */
+const PROBE_INTERVAL = 250;
+/** Consecutive silent analyser reads, while playing, before asking the server */
+const PROBE_THRESHOLD = 4;
+/** Bin value above which a server column counts as carrying energy (0-255) */
+const ENERGY_THRESHOLD = 8;
+/** How often a queued column is promoted to the render buffer (ms) */
+const PUBLISH_INTERVAL = 50;
+/**
+ * Longest playback lag the column queue can cover (seconds). HLS live latency
+ * is a few seconds; holding more would only grow memory to redraw audio nobody
+ * is listening to.
+ */
+const QUEUE_SECONDS = 30;
+/** Hard cap on queued columns, in case a server clock jumps backwards */
+const QUEUE_MAX_COLUMNS = 800;
+/** Blank the waterfall when no new column has been published for this long (ms) */
+const STALL_TIMEOUT = 1500;
+
+/**
+ * What the host's analyser looks like right now.
+ *
+ * - `working` — it produced data, so this browser needs no fallback at all.
+ * - `silent`  — audio is playing through a running context but every bin is 0.
+ * - `absent`  — no analyser could be built; there is nothing to compare against.
+ * - `idle`    — paused, suspended, or not started: proves nothing either way.
+ */
+export type AnalyserProbe = 'working' | 'silent' | 'absent' | 'idle';
+
+export interface ServerSpectrumHooks {
+  /** Inspect the local analyser. Called every PROBE_INTERVAL until decided. */
+  probeAnalyser: () => AnalyserProbe;
+  /**
+   * Wall-clock time (Unix seconds) of the audio currently being heard, or 0 if
+   * unknown. Columns are held back until the playhead reaches them so the
+   * waterfall matches the buffered audio rather than live capture.
+   */
+  playheadWallClock: () => number;
+  /** Render these bins. Called with an all-zero column to blank the waterfall. */
+  onColumn: (bins: Uint8Array<ArrayBuffer>) => void;
+  /** The fallback has taken over; the host should stop polling its analyser. */
+  onAdopt: (info: { sampleRate: number; binCount: number; hadAnalyser: boolean }) => void;
+}
+
+export interface ServerSpectrumFallback {
+  /** Begin watching the analyser for this audio source. */
+  start: (sourceID: string) => void;
+  /** Close the stream, clear the timers, and forget everything. */
+  stop: () => void;
+}
+
+interface SpectrumEntry {
+  spectrum?: string;
+  spectrumSampleRate?: number;
+  spectrumTime?: number;
+}
+
+export function createServerSpectrumFallback(hooks: ServerSpectrumHooks): ServerSpectrumFallback {
+  let sourceID: string | null = null;
+  let stream: ReconnectingEventSource | null = null;
+  let probeTimer: ReturnType<typeof globalThis.setInterval> | null = null;
+  let publishTimer: ReturnType<typeof globalThis.setInterval> | null = null;
+  let columns: SpectrumColumn[] = [];
+  let render: SpectrumRenderState = { renderedTime: 0, advancedAt: 0, unaligned: false };
+  let sampleRate = 0;
+  let binCount = 0;
+  let silentProbes = 0;
+  let adopted = false;
+  let hadAnalyser = true;
+  /**
+   * Bumped by every start/stop. Timers and SSE callbacks check it, so a frame
+   * already queued when the stream was replaced cannot resurrect a fallback for
+   * a source nobody is listening to.
+   */
+  let epoch = 0;
+
+  function start(id: string): void {
+    stop();
+    sourceID = id;
+    const mine = epoch;
+    probeTimer = globalThis.setInterval(() => probe(mine), PROBE_INTERVAL);
+  }
+
+  function stop(): void {
+    epoch++;
+    clearTimer('probe');
+    clearTimer('publish');
+    stream?.close();
+    stream = null;
+    columns = [];
+    render = { renderedTime: 0, advancedAt: 0, unaligned: false };
+    sourceID = null;
+    sampleRate = 0;
+    binCount = 0;
+    silentProbes = 0;
+    adopted = false;
+    hadAnalyser = true;
+  }
+
+  function clearTimer(which: 'probe' | 'publish'): void {
+    const timer = which === 'probe' ? probeTimer : publishTimer;
+    if (timer === null) return;
+    globalThis.clearInterval(timer);
+    if (which === 'probe') probeTimer = null;
+    else publishTimer = null;
+  }
+
+  /**
+   * Decide whether the local analyser can see this stream.
+   *
+   * All-zero bins alone prove nothing — silence, a paused element and a
+   * suspended context look identical. So this waits for the analyser to stay
+   * empty while audio is playing, and only then opens the server stream to ask
+   * whether there was anything to see. One non-empty read ends the whole thing:
+   * that browser is fine, and never pays for the extra connection.
+   */
+  function probe(mine: number): void {
+    if (mine !== epoch || adopted) return;
+
+    switch (hooks.probeAnalyser()) {
+      case 'working':
+        stop();
+        return;
+      case 'absent':
+        hadAnalyser = false;
+        openStream(mine);
+        return;
+      case 'silent':
+        if (++silentProbes >= PROBE_THRESHOLD) openStream(mine);
+        return;
+      case 'idle':
+        return;
+    }
+  }
+
+  /** Subscribe to server-computed columns for this source. No-op if already open. */
+  function openStream(mine: number): void {
+    const id = sourceID;
+    if (stream || !id) return;
+
+    const url = buildAppUrl(`/api/v2/streams/audio-level?spectrum=${encodeURIComponent(id)}`);
+    const sse = new ReconnectingEventSource(url, { max_retry_time: 30000, withCredentials: false });
+    stream = sse;
+
+    sse.onmessage = (event: globalThis.MessageEvent) => {
+      if (mine !== epoch || stream !== sse) return;
+
+      try {
+        const data = JSON.parse(event.data) as {
+          type?: string;
+          levels?: Record<string, SpectrumEntry>;
+        };
+        if (data.type !== 'audio-level') return;
+        // eslint-disable-next-line security/detect-object-injection -- id is this controller's own audio source
+        const entry = data.levels?.[id];
+        if (!entry?.spectrum) return;
+
+        const bins = decodeSpectrumColumn(entry.spectrum);
+        if (!bins) return;
+
+        if (entry.spectrumSampleRate) sampleRate = entry.spectrumSampleRate;
+        columns.push({ bins, time: entry.spectrumTime ?? 0 });
+        columns = trimSpectrumQueue(columns, QUEUE_SECONDS, QUEUE_MAX_COLUMNS);
+
+        // Either there is no analyser to compare against, or the server can see
+        // energy on this source that the analyser cannot: the local Web Audio
+        // path is confirmed dead.
+        if (!adopted && (!hadAnalyser || hasSpectrumEnergy(bins, ENERGY_THRESHOLD))) {
+          adopt(mine);
+        }
+      } catch {
+        /* ignore malformed frames; the next one is 50ms away */
+      }
+    };
+
+    sse.onerror = () => {
+      /* ReconnectingEventSource handles reconnection */
+    };
+
+    logger.debug('Live spectrogram opened server spectrum stream', { sourceID: id });
+  }
+
+  /** Hand rendering over to the server columns for the rest of this session. */
+  function adopt(mine: number): void {
+    adopted = true;
+    binCount = columns.at(-1)?.bins.length ?? 0;
+    render = { renderedTime: 0, advancedAt: Date.now(), unaligned: false };
+
+    clearTimer('probe');
+    publishTimer = globalThis.setInterval(() => pump(mine), PUBLISH_INTERVAL);
+
+    logger.info('Live spectrogram falling back to server-computed bins', {
+      reason: hadAnalyser ? 'analyser returned no data' : 'analyser unavailable',
+      sampleRate,
+      bins: binCount,
+    });
+
+    hooks.onAdopt({ sampleRate, binCount, hadAnalyser });
+    pump(mine);
+  }
+
+  /** Apply one render decision. All the timing logic lives in nextSpectrumRender. */
+  function pump(mine: number): void {
+    if (mine !== epoch || !adopted) return;
+
+    const wasAligned = !render.unaligned;
+    const step = nextSpectrumRender(
+      columns,
+      hooks.playheadWallClock(),
+      render,
+      Date.now(),
+      STALL_TIMEOUT
+    );
+    render = step.state;
+
+    if (wasAligned && render.unaligned) {
+      logger.warn(
+        'Live spectrogram could not align server columns to the playhead; rendering live columns instead',
+        { hint: 'check that the browser and server clocks agree' }
+      );
+    }
+
+    if (step.blank) {
+      hooks.onColumn(new Uint8Array(binCount));
+      return;
+    }
+    if (step.index < 0) return;
+
+    hooks.onColumn(columns[step.index].bins);
+  }
+
+  return { start, stop };
+}

--- a/frontend/src/lib/utils/useSpectrogramAnalyser.svelte.ts
+++ b/frontend/src/lib/utils/useSpectrogramAnalyser.svelte.ts
@@ -15,6 +15,8 @@
  * - createMediaElementSource() can only be called once per element (guarded by WeakMap)
  * - Uses the shared audioContextManager singleton
  * - Does NOT use onMount — exposes connect()/disconnect() for parent control
+ * - On browsers whose AnalyserNode cannot read HLS-backed media (Safari/WebKit)
+ *   the bins come from the server instead; see ./serverSpectrumFallback
  */
 
 import {
@@ -24,6 +26,8 @@ import {
 } from './audioContextManager';
 import { dbToGain } from './audio';
 import { loggers } from './logger';
+import { computeWallClockAtPlayhead } from './detectionOverlay';
+import { createServerSpectrumFallback, type AnalyserProbe } from './serverSpectrumFallback';
 
 const logger = loggers.audio;
 
@@ -44,6 +48,13 @@ export interface SpectrogramAnalyserOptions {
   audioOutput?: boolean;
   /** Gain in dB (default: 0) */
   gainDb?: number;
+  /**
+   * Current HLS program date at the playhead, if the player exposes one
+   * (hls.js `playingDate`). Lets the server-spectrum fallback line its columns
+   * up with the buffered audio; without it the seekable-range estimate is used,
+   * as elsewhere in the live UI.
+   */
+  getPlayingDate?: () => Date | null;
 }
 
 const DEFAULT_FFT_SIZE = 1024;
@@ -56,16 +67,18 @@ const OUTPUT_GAIN_MUTED = 0;
 const GAIN_RAMP_DURATION = 0.01;
 
 export function useSpectrogramAnalyser(options?: SpectrogramAnalyserOptions) {
-  const fftSize = options?.fftSize ?? DEFAULT_FFT_SIZE;
-  const binCount = fftSize / 2;
+  const analyserFftSize = options?.fftSize ?? DEFAULT_FFT_SIZE;
+  const binCount = analyserFftSize / 2;
 
   // Reactive state (exposed to consumers)
   let analyser = $state<AnalyserNode | null>(null);
   let frequencyData = $state<Uint8Array<ArrayBuffer>>(new Uint8Array(binCount));
   let isActive = $state(false);
   let sampleRate = $state(48000);
+  let fftSize = $state(analyserFftSize);
   let audioOutput = $state(options?.audioOutput ?? false);
   let gainDb = $state(options?.gainDb ?? 0);
+  let usingServerSpectrum = $state(false);
 
   // Non-reactive internal nodes
   let audioContext: AudioContext | null = null;
@@ -74,11 +87,66 @@ export function useSpectrogramAnalyser(options?: SpectrogramAnalyserOptions) {
   let outputGainNode: GainNode | null = null;
   let highPassNode: BiquadFilterNode | null = null;
   let analyserNode: AnalyserNode | null = null;
+  let mediaEl: HTMLMediaElement | null = null;
+  let probeBuffer: Uint8Array<ArrayBuffer> | null = null;
+  /**
+   * Bumped by every disconnect. connect() checks it after its await, so a stop
+   * or a source switch mid-flight cannot be undone by the call it replaced.
+   */
+  let generation = 0;
 
-  /** Connect to a media element and set up the Web Audio graph */
-  async function connect(mediaElement: HTMLMediaElement): Promise<void> {
-    // Disconnect any existing graph first
+  const fallback = createServerSpectrumFallback({
+    probeAnalyser,
+    playheadWallClock: () =>
+      mediaEl
+        ? computeWallClockAtPlayhead(
+            mediaEl as HTMLAudioElement,
+            options?.getPlayingDate?.() ?? null,
+            Date.now() / 1000
+          )
+        : 0,
+    onColumn: bins => {
+      if (frequencyData.length !== bins.length) {
+        frequencyData = new Uint8Array(bins.length);
+        fftSize = bins.length * 2;
+      }
+      frequencyData.set(bins);
+    },
+    onAdopt: info => {
+      usingServerSpectrum = true;
+      if (info.sampleRate > 0) sampleRate = info.sampleRate;
+      // The canvas is gated on isActive, and the graph may never have come up.
+      isActive = true;
+    },
+  });
+
+  /** Report what the local analyser can see; see AnalyserProbe for the values. */
+  function probeAnalyser(): AnalyserProbe {
+    if (!mediaEl || mediaEl.paused) return 'idle';
+    if (!analyserNode || !audioContext) return 'absent';
+    if (audioContext.state !== 'running') return 'idle';
+
+    if (probeBuffer?.length !== analyserNode.frequencyBinCount) {
+      probeBuffer = new Uint8Array(analyserNode.frequencyBinCount);
+    }
+    analyserNode.getByteFrequencyData(probeBuffer);
+    return probeBuffer.some(v => v > 0) ? 'working' : 'silent';
+  }
+
+  /**
+   * Connect to a media element and set up the Web Audio graph.
+   *
+   * @param mediaElement - element to analyse
+   * @param sourceID - audio source to request server-computed bins for. Pass it
+   *   whenever one is known: it is what lets the spectrogram survive a browser
+   *   whose AnalyserNode cannot read HLS-backed media (Safari/WebKit).
+   */
+  async function connect(mediaElement: HTMLMediaElement, sourceID?: string | null): Promise<void> {
+    // Disconnect any existing graph first (this bumps the generation)
     disconnect();
+
+    const mine = generation;
+    mediaEl = mediaElement;
 
     if (!isAudioContextSupported()) {
       logger.error('AudioContext not supported');
@@ -86,7 +154,11 @@ export function useSpectrogramAnalyser(options?: SpectrogramAnalyserOptions) {
     }
 
     try {
-      audioContext = await getAudioContext();
+      const ctx = await getAudioContext();
+      // A stop or a source switch while getAudioContext() was pending owns the
+      // composable now; installing this graph would clobber theirs.
+      if (mine !== generation) return;
+      audioContext = ctx;
       sampleRate = audioContext.sampleRate;
 
       // Guard: reuse existing source node for this element + context combination
@@ -113,7 +185,7 @@ export function useSpectrogramAnalyser(options?: SpectrogramAnalyserOptions) {
       gainNode.gain.value = dbToGain(gainDb);
 
       analyserNode = audioContext.createAnalyser();
-      analyserNode.fftSize = fftSize;
+      analyserNode.fftSize = analyserFftSize;
       analyserNode.smoothingTimeConstant = ANALYSER_SMOOTHING;
 
       // Output gain node controls audio to speakers (mute sets to 0)
@@ -133,19 +205,35 @@ export function useSpectrogramAnalyser(options?: SpectrogramAnalyserOptions) {
       isActive = true;
 
       logger.debug('Spectrogram analyser connected', {
-        fftSize,
+        fftSize: analyserFftSize,
         sampleRate: audioContext.sampleRate,
         audioOutput,
       });
     } catch (error) {
+      if (mine !== generation) return;
       logger.error('Failed to connect spectrogram analyser', error);
-      // Clean up any partially built graph
+      // Clean up any partially built graph. disconnect() bumps the generation,
+      // so re-adopt it: this call is still the current owner.
       disconnect();
+      generation = mine;
+      mediaEl = mediaElement;
     }
+
+    // Started last, and outside the try, so it also covers the case where the
+    // graph above failed outright and there is no analyser to compare against.
+    if (sourceID && mine === generation) fallback.start(sourceID);
   }
 
-  /** Disconnect the audio graph */
+  /** Disconnect the audio graph and the server-spectrum fallback */
   function disconnect(): void {
+    // Invalidate every in-flight await before releasing any state it may touch.
+    generation++;
+    fallback.stop();
+    usingServerSpectrum = false;
+    fftSize = analyserFftSize;
+    mediaEl = null;
+    probeBuffer = null;
+
     try {
       if (outputGainNode) outputGainNode.disconnect();
       if (analyserNode) analyserNode.disconnect();
@@ -202,6 +290,14 @@ export function useSpectrogramAnalyser(options?: SpectrogramAnalyserOptions) {
   return {
     get analyser() {
       return analyser;
+    },
+    /**
+     * True when `frequencyData` is fed by the server instead of the analyser.
+     * Renderers must stop calling `analyser.getByteFrequencyData()` while this
+     * is set, or they will overwrite the server column with zeros.
+     */
+    get usingServerSpectrum() {
+      return usingServerSpectrum;
     },
     get frequencyData() {
       return frequencyData;

--- a/internal/analysis/audio_level_consumer.go
+++ b/internal/analysis/audio_level_consumer.go
@@ -3,6 +3,7 @@ package analysis
 import (
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/errors"
@@ -22,6 +23,7 @@ type AudioLevelConsumer struct {
 	depth     int
 	channels  int
 	outCh     chan AudioLevelData
+	spectrum  *spectrumAnalyzer
 	closed    atomic.Bool
 	closeOnce sync.Once
 	outDrops  atomic.Int64
@@ -42,6 +44,7 @@ func NewAudioLevelConsumer(id string, sampleRate, bitDepth, channels int) (consu
 		depth:    bitDepth,
 		channels: channels,
 		outCh:    ch,
+		spectrum: newSpectrumAnalyzer(),
 	}, ch
 }
 
@@ -68,6 +71,16 @@ func (c *AudioLevelConsumer) Write(frame audiocore.AudioFrame) error { //nolint:
 	}
 
 	level := calculateAudioLevel(frame.Data, frame.SourceID, frame.SourceName)
+
+	// Attach a magnitude column for browsers whose AnalyserNode cannot see
+	// HLS-backed audio (WebKit bug 180696). The analyzer rate-limits itself, so
+	// most frames add nothing beyond the rolling-window copy.
+	now := time.Now()
+	if bins := c.spectrum.process(frame.Data, now); bins != nil {
+		level.Spectrum = bins
+		level.SpectrumSampleRate = c.rate
+		level.SpectrumTime = float64(now.UnixNano()) / float64(time.Second)
+	}
 
 	select {
 	case c.outCh <- level:

--- a/internal/analysis/audio_level_spectrum.go
+++ b/internal/analysis/audio_level_spectrum.go
@@ -1,0 +1,197 @@
+// audio_level_spectrum.go - Server-side magnitude spectrum for the live spectrogram.
+//
+// Safari/WebKit cannot feed an HLS-backed <audio> element into the Web Audio
+// graph (WebKit bug 180696, open since 2017), so AnalyserNode.getByteFrequencyData()
+// returns all zeros there and the live spectrogram waterfall stays blank. This
+// computes the same magnitude data server-side from the PCM the audio-level
+// consumer already receives, so browsers whose AnalyserNode is dead can render
+// the waterfall from the audio-level SSE stream instead.
+package analysis
+
+import (
+	"encoding/binary"
+	"math"
+	"math/cmplx"
+	"time"
+)
+
+const (
+	// spectrumFFTSize is the analysis window in samples. It matches the
+	// browser-side AnalyserNode fftSize so the fallback bins line up with the
+	// bins SpectrogramCanvas already expects.
+	spectrumFFTSize = 1024
+
+	// spectrumBinCount is the number of magnitude bins published per column,
+	// i.e. the usable half of the FFT.
+	spectrumBinCount = spectrumFFTSize / 2
+
+	// spectrumInterval caps how often a column is produced per source. It
+	// matches the audio-level SSE rate limit, so no column is computed that
+	// the stream would drop anyway.
+	spectrumInterval = 50 * time.Millisecond
+
+	// spectrumDBFloor and spectrumDBCeiling mirror the AnalyserNode defaults
+	// (minDecibels/maxDecibels), so a column lands in roughly the same part of
+	// the colour map as an analyser-driven one. The match is close, not exact:
+	// Web Audio uses a Blackman window and 0.8 temporal smoothing, this uses a
+	// Hann window and none.
+	spectrumDBFloor   = -100.0
+	spectrumDBCeiling = -30.0
+
+	// spectrumMagnitudeEpsilon avoids log10(0) for digital silence.
+	spectrumMagnitudeEpsilon = 1e-12
+)
+
+// spectrumAnalyzer turns a stream of 16-bit PCM frames into fixed-size
+// magnitude columns. It keeps a rolling window so columns have a constant
+// resolution regardless of how many samples an individual frame carries.
+//
+// Columns are produced unconditionally rather than on subscriber demand:
+// BenchmarkSpectrumAnalyzer measures ~42us per column on an Intel N150, so at
+// 20 columns/s a source costs well under 0.1% of a core there, and still a
+// fraction of a percent on a Raspberry Pi. Demand tracking would cost more
+// plumbing than it saves.
+//
+// Not safe for concurrent use: one analyzer belongs to one AudioLevelConsumer,
+// whose Write is called by that route's single drain goroutine.
+type spectrumAnalyzer struct {
+	ring     []float64    // newest spectrumFFTSize samples, oldest first
+	filled   int          // samples written into ring so far, capped at len(ring)
+	window   []float64    // Hann window
+	scale    float64      // window-coherent-gain correction for magnitudes
+	scratch  []complex128 // reused FFT working buffer
+	lastEmit time.Time
+}
+
+func newSpectrumAnalyzer() *spectrumAnalyzer {
+	window := make([]float64, spectrumFFTSize)
+	var sum float64
+	for i := range window {
+		window[i] = 0.5 * (1 - math.Cos(2*math.Pi*float64(i)/float64(spectrumFFTSize-1)))
+		sum += window[i]
+	}
+	return &spectrumAnalyzer{
+		ring:    make([]float64, spectrumFFTSize),
+		window:  window,
+		scale:   2.0 / sum,
+		scratch: make([]complex128, spectrumFFTSize),
+	}
+}
+
+// process appends a PCM frame to the rolling window and returns a new
+// magnitude column, or nil when the window is not full yet or the previous
+// column is younger than spectrumInterval.
+func (s *spectrumAnalyzer) process(pcm []byte, now time.Time) []byte {
+	s.push(pcm)
+	if s.filled < spectrumFFTSize {
+		return nil
+	}
+	if !s.lastEmit.IsZero() && now.Sub(s.lastEmit) < spectrumInterval {
+		return nil
+	}
+	s.lastEmit = now
+	return s.column()
+}
+
+// push copies the newest samples of pcm into the rolling window, discarding
+// the same number of oldest samples.
+func (s *spectrumAnalyzer) push(pcm []byte) {
+	// Drop a trailing odd byte: it cannot form a 16-bit sample.
+	if len(pcm)%2 != 0 {
+		pcm = pcm[:len(pcm)-1]
+	}
+	count := len(pcm) / 2
+	if count == 0 {
+		return
+	}
+
+	// A frame longer than the window replaces it outright; only its newest
+	// spectrumFFTSize samples matter.
+	if count >= spectrumFFTSize {
+		pcm = pcm[(count-spectrumFFTSize)*2:]
+		count = spectrumFFTSize
+	} else {
+		copy(s.ring, s.ring[count:])
+	}
+
+	base := spectrumFFTSize - count
+	for i := range count {
+		sample := int16(binary.LittleEndian.Uint16(pcm[i*2 : i*2+2])) //nolint:gosec // G115: intentional uint16→int16 bit reinterpretation for PCM audio
+		s.ring[base+i] = float64(sample) / pcm16Max
+	}
+
+	if s.filled += count; s.filled > spectrumFFTSize {
+		s.filled = spectrumFFTSize
+	}
+}
+
+// column runs the FFT over the current window and scales each magnitude to a
+// 0-255 byte over [spectrumDBFloor, spectrumDBCeiling].
+func (s *spectrumAnalyzer) column() []byte {
+	for i := range spectrumFFTSize {
+		s.scratch[i] = complex(s.ring[i]*s.window[i], 0)
+	}
+	fftInPlace(s.scratch)
+
+	const dbRange = spectrumDBCeiling - spectrumDBFloor
+	// A fresh slice per column: it is published on a channel and read by SSE
+	// goroutines, so it cannot be reused.
+	out := make([]byte, spectrumBinCount)
+	for i := range spectrumBinCount {
+		db := 20 * math.Log10(cmplx.Abs(s.scratch[i])*s.scale+spectrumMagnitudeEpsilon)
+		scaled := (db - spectrumDBFloor) * (255.0 / dbRange)
+		switch {
+		case scaled <= 0:
+			out[i] = 0
+		case scaled >= 255:
+			out[i] = 255
+		default:
+			out[i] = byte(scaled)
+		}
+	}
+	return out
+}
+
+// fftInPlace performs an in-place iterative Cooley-Tukey FFT on data, whose
+// length must be a power of two.
+//
+// This is deliberately a small package-local copy rather than a shared helper:
+// the only other FFT in the tree is private to internal/audiocore/ultrasonic,
+// a bat-detection package the live audio-level path should not depend on.
+// Extracting a common DSP package is a separate cleanup.
+func fftInPlace(data []complex128) {
+	n := len(data)
+	if n <= 1 {
+		return
+	}
+
+	// Bit-reversal permutation.
+	j := 0
+	for i := 1; i < n; i++ {
+		bit := n >> 1
+		for j&bit != 0 {
+			j ^= bit
+			bit >>= 1
+		}
+		j ^= bit
+		if i < j {
+			data[i], data[j] = data[j], data[i]
+		}
+	}
+
+	// Butterfly stages.
+	for size := 2; size <= n; size <<= 1 {
+		half := size >> 1
+		wn := cmplx.Rect(1, -2.0*math.Pi/float64(size))
+		for start := 0; start < n; start += size {
+			w := complex(1, 0)
+			for k := range half {
+				u := data[start+k]
+				v := w * data[start+k+half]
+				data[start+k] = u + v
+				data[start+k+half] = u - v
+				w *= wn
+			}
+		}
+	}
+}

--- a/internal/analysis/audio_level_spectrum_test.go
+++ b/internal/analysis/audio_level_spectrum_test.go
@@ -1,0 +1,128 @@
+package analysis
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sinePCM returns count 16-bit LE samples of a full-scale sine at freqHz.
+func sinePCM(count, freqHz, sampleRate int) []byte {
+	pcm := make([]byte, count*2)
+	for i := range count {
+		v := math.Sin(2 * math.Pi * float64(freqHz) * float64(i) / float64(sampleRate))
+		binary.LittleEndian.PutUint16(pcm[i*2:], uint16(int16(v*(pcm16Max-1)))) //nolint:gosec // G115: intentional int16→uint16 bit reinterpretation for PCM audio
+	}
+	return pcm
+}
+
+func TestSpectrumAnalyzerPeaksAtToneFrequency(t *testing.T) {
+	t.Parallel()
+
+	const sampleRate = 48000
+	const toneHz = 3000
+	a := newSpectrumAnalyzer()
+
+	bins := a.process(sinePCM(spectrumFFTSize, toneHz, sampleRate), time.Now())
+	require.NotNil(t, bins, "a full window should produce a column")
+	require.Len(t, bins, spectrumBinCount)
+
+	peak := 0
+	for i, v := range bins {
+		if v > bins[peak] {
+			peak = i
+		}
+	}
+
+	expected := int(math.Round(float64(toneHz) * spectrumFFTSize / sampleRate))
+	assert.InDelta(t, expected, peak, 1, "peak bin should match the tone frequency")
+	assert.Greater(t, int(bins[peak]), 200, "a full-scale tone should be near the top of the dB range")
+}
+
+func TestSpectrumAnalyzerSilenceIsZero(t *testing.T) {
+	t.Parallel()
+
+	a := newSpectrumAnalyzer()
+	bins := a.process(make([]byte, spectrumFFTSize*2), time.Now())
+	require.NotNil(t, bins)
+
+	for i, v := range bins {
+		require.Zerof(t, v, "bin %d should be zero for digital silence", i)
+	}
+}
+
+func TestSpectrumAnalyzerNeedsFullWindow(t *testing.T) {
+	t.Parallel()
+
+	const chunk = 256
+	a := newSpectrumAnalyzer()
+	now := time.Now()
+
+	for range spectrumFFTSize/chunk - 1 {
+		assert.Nil(t, a.process(sinePCM(chunk, 3000, 48000), now), "partial window must not emit")
+	}
+	assert.NotNil(t, a.process(sinePCM(chunk, 3000, 48000), now), "window completion should emit")
+}
+
+func TestSpectrumAnalyzerRateLimits(t *testing.T) {
+	t.Parallel()
+
+	a := newSpectrumAnalyzer()
+	start := time.Now()
+	pcm := sinePCM(spectrumFFTSize, 3000, 48000)
+
+	require.NotNil(t, a.process(pcm, start))
+	assert.Nil(t, a.process(pcm, start.Add(spectrumInterval/2)), "columns inside the interval are suppressed")
+	assert.NotNil(t, a.process(pcm, start.Add(spectrumInterval)), "columns after the interval resume")
+}
+
+func TestSpectrumAnalyzerToleratesOddByteCount(t *testing.T) {
+	t.Parallel()
+
+	a := newSpectrumAnalyzer()
+	pcm := sinePCM(spectrumFFTSize, 3000, 48000)
+
+	assert.NotPanics(t, func() {
+		a.process(append(pcm, 0x7f), time.Now())
+	})
+}
+
+func TestSpectrumAnalyzerKeepsNewestSamplesOfLongFrame(t *testing.T) {
+	t.Parallel()
+
+	const sampleRate = 48000
+	a := newSpectrumAnalyzer()
+
+	// A frame four windows long: only its newest window should shape the column.
+	// Prefix it with silence and end with a tone; the tone must still be found.
+	pcm := append(make([]byte, spectrumFFTSize*3*2), sinePCM(spectrumFFTSize, 6000, sampleRate)...)
+	bins := a.process(pcm, time.Now())
+	require.NotNil(t, bins)
+
+	peak := 0
+	for i, v := range bins {
+		if v > bins[peak] {
+			peak = i
+		}
+	}
+	expected := int(math.Round(6000 * float64(spectrumFFTSize) / sampleRate))
+	assert.InDelta(t, expected, peak, 1)
+}
+
+// BenchmarkSpectrumAnalyzer measures the per-column cost, which every source
+// pays continuously whether or not a client asked for spectrum data. Frames are
+// sized like a typical router frame so the rolling-window copy is included.
+func BenchmarkSpectrumAnalyzer(b *testing.B) {
+	a := newSpectrumAnalyzer()
+	pcm := sinePCM(2400, 3000, 48000) // 50ms at 48kHz
+	now := time.Now()
+
+	for b.Loop() {
+		now = now.Add(spectrumInterval)
+		a.process(pcm, now)
+	}
+}

--- a/internal/analysis/buffer_consumer.go
+++ b/internal/analysis/buffer_consumer.go
@@ -245,6 +245,12 @@ type AudioLevelData struct {
 	Clipping bool   `json:"clipping"` // true if clipping is detected
 	Source   string `json:"source"`   // Source identifier
 	Name     string `json:"name"`     // Human-readable name of the source
+	// Optional magnitude spectrum for the live spectrogram fallback, computed
+	// from the same PCM as Level. See analysis.spectrumAnalyzer for how the bins
+	// are produced and audio.filterSpectrum for when they reach a client.
+	Spectrum           []byte  `json:"spectrum,omitempty"`           // 0-255 bins, log scale
+	SpectrumSampleRate int     `json:"spectrumSampleRate,omitempty"` // source rate, not the browser's
+	SpectrumTime       float64 `json:"spectrumTime,omitempty"`       // capture time, Unix seconds
 }
 
 // Audio level scaling constants.

--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -302,6 +302,8 @@ Both verbs report identically under the `skippedFields` response key: it lists o
 **Features:**
 
 - Real-time audio level data for UI audio indicators (0-100 with clipping detection)
+- Optional server-computed spectrum bins for the live spectrogram, opted into
+  with `?spectrum=1` or `?spectrum=<sourceID>`; see `audio_level_spectrum.go`
 - Automatic source anonymization for unauthenticated clients
 - Connection limiting: up to 5 concurrent connections per client IP (allows multiple browser tabs)
 - Maximum connection duration: 30 minutes

--- a/internal/api/v2/audio/audio_level.go
+++ b/internal/api/v2/audio/audio_level.go
@@ -140,7 +140,7 @@ func runAudioLevelBroadcaster(ctx context.Context, sourceChan chan audiocore.Aud
 
 			// Track latest level per source for health checks
 			audioLevelMgr.latestLevelsMu.Lock()
-			audioLevelMgr.latestLevels[data.Source] = data
+			audioLevelMgr.latestLevels[data.Source] = withoutSpectrum(data)
 			audioLevelMgr.latestLevelsMu.Unlock()
 
 			// Fan out to all subscribers (non-blocking send)
@@ -319,6 +319,7 @@ func (c *Handler) StreamAudioLevel(ctx echo.Context) error {
 
 	// Check authentication status for data anonymization
 	isAuthenticated := c.isClientAuthenticated(ctx)
+	spectrumParam := ctx.QueryParam(spectrumQueryParam)
 
 	// Initialize level tracking data
 	levels := c.initializeAudioLevels(isAuthenticated)
@@ -368,8 +369,10 @@ func (c *Handler) StreamAudioLevel(ctx echo.Context) error {
 				return nil
 			}
 
+			filterSpectrum(&audioData, spectrumParam)
+
 			// Update audio levels with proper name handling
-			c.updateAudioLevel(audioData, levels, lastUpdateTime, lastNonZeroTime, isAuthenticated)
+			c.updateAudioLevel(&audioData, levels, lastUpdateTime, lastNonZeroTime, isAuthenticated)
 
 			// Rate limit updates
 			if time.Since(lastSentTime) >= audioLevelRateLimitUpdate {
@@ -478,9 +481,11 @@ func (c *Handler) addStreamSourcesToLevels(registry *audiocore.SourceRegistry, l
 	}
 }
 
-// updateAudioLevel processes incoming audio data and updates the levels map
+// updateAudioLevel processes incoming audio data and updates the levels map.
+// audioData is taken by pointer to avoid copying the struct (which carries an
+// optional spectrum column) on every update; the callee may rewrite its Name.
 func (c *Handler) updateAudioLevel(
-	audioData audiocore.AudioLevelData,
+	audioData *audiocore.AudioLevelData,
 	levels map[string]audiocore.AudioLevelData,
 	lastUpdateTime, lastNonZeroTime map[string]time.Time,
 	isAuthenticated bool,
@@ -513,12 +518,10 @@ func (c *Handler) updateAudioLevel(
 	}
 
 	// Update level unless source is inactive
-	if !c.isSourceInactive(audioData.Source, now, lastUpdateTime, lastNonZeroTime) {
-		levels[audioData.Source] = audioData
-	} else {
+	if c.isSourceInactive(audioData.Source, now, lastUpdateTime, lastNonZeroTime) {
 		audioData.Level = 0
-		levels[audioData.Source] = audioData
 	}
+	levels[audioData.Source] = *audioData
 }
 
 // getAnonymizedSourceName returns an anonymized name for a source
@@ -630,9 +633,10 @@ func (c *Handler) checkSourceActivity(
 	updated := false
 
 	for source, data := range levels {
-		if c.isSourceInactive(source, now, lastUpdateTime, lastNonZeroTime) && data.Level != 0 {
+		if c.isSourceInactive(source, now, lastUpdateTime, lastNonZeroTime) &&
+			(data.Level != 0 || data.Spectrum != nil) {
 			data.Level = 0
-			levels[source] = data
+			levels[source] = withoutSpectrum(data)
 			updated = true
 		}
 	}

--- a/internal/api/v2/audio/audio_level_spectrum.go
+++ b/internal/api/v2/audio/audio_level_spectrum.go
@@ -1,0 +1,49 @@
+// audio_level_spectrum.go - Opt-in spectrum data on the audio level SSE stream.
+//
+// Browsers whose AnalyserNode cannot read HLS-backed media (Safari/WebKit,
+// https://bugs.webkit.org/show_bug.cgi?id=180696) render the live spectrogram
+// waterfall from server-computed magnitude bins instead of their own Web Audio
+// graph. Those bins ride this existing stream rather than a dedicated endpoint,
+// so they are stripped by default: a column is ~700 bytes per source per
+// update, which the level-meter clients that make up most of this endpoint's
+// traffic have no use for.
+package audio
+
+import "github.com/tphakala/birdnet-go/internal/audiocore"
+
+// spectrumQueryParam is the query parameter a client uses to opt in.
+const spectrumQueryParam = "spectrum"
+
+// spectrumRequested reports whether a client asked for magnitude bins for a
+// source. An absent parameter (the default) means no spectrum at all;
+// "1"/"true" means every source; any other value is read as a source ID and
+// selects just that source, which keeps the payload flat on multi-source
+// installs where a spectrogram only ever renders one of them.
+func spectrumRequested(param, sourceID string) bool {
+	switch param {
+	case "":
+		return false
+	case "1", "true":
+		return true
+	default:
+		return param == sourceID
+	}
+}
+
+// filterSpectrum drops the spectrum fields in place unless this client asked
+// for that source.
+func filterSpectrum(data *audiocore.AudioLevelData, param string) {
+	if !spectrumRequested(param, data.Source) {
+		*data = withoutSpectrum(*data)
+	}
+}
+
+// withoutSpectrum returns a copy carrying no spectrum. Used both to strip
+// non-requested data and to keep the column out of long-lived copies, where it
+// would pin a buffer per source and risk reaching a client that never opted in.
+func withoutSpectrum(data audiocore.AudioLevelData) audiocore.AudioLevelData { //nolint:gocritic // hugeParam: value semantics keep call sites a single expression
+	data.Spectrum = nil
+	data.SpectrumSampleRate = 0
+	data.SpectrumTime = 0
+	return data
+}

--- a/internal/api/v2/audio/audio_level_spectrum_test.go
+++ b/internal/api/v2/audio/audio_level_spectrum_test.go
@@ -1,0 +1,136 @@
+package audio
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+)
+
+func TestSpectrumRequested(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		param    string
+		sourceID string
+		want     bool
+	}{
+		{"absent means opted out", "", "src-1", false},
+		{"1 selects every source", "1", "src-1", true},
+		{"true selects every source", "true", "src-2", true},
+		{"source id selects that source", "src-1", "src-1", true},
+		{"source id excludes other sources", "src-1", "src-2", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, spectrumRequested(tt.param, tt.sourceID))
+		})
+	}
+}
+
+func TestFilterSpectrum(t *testing.T) {
+	t.Parallel()
+
+	sample := func() audiocore.AudioLevelData {
+		return audiocore.AudioLevelData{
+			Level:              42,
+			Source:             "src-1",
+			Spectrum:           []byte{1, 2, 3},
+			SpectrumSampleRate: 48000,
+			SpectrumTime:       1750000000,
+		}
+	}
+
+	t.Run("strips every spectrum field when the client did not opt in", func(t *testing.T) {
+		t.Parallel()
+		data := sample()
+		filterSpectrum(&data, "")
+		assert.Nil(t, data.Spectrum)
+		assert.Zero(t, data.SpectrumSampleRate)
+		assert.Zero(t, data.SpectrumTime)
+		assert.Equal(t, 42, data.Level, "the level itself must survive")
+	})
+
+	t.Run("keeps the spectrum for the requested source", func(t *testing.T) {
+		t.Parallel()
+		data := sample()
+		filterSpectrum(&data, "src-1")
+		assert.Equal(t, []byte{1, 2, 3}, data.Spectrum)
+		assert.Equal(t, 48000, data.SpectrumSampleRate)
+	})
+
+	t.Run("strips the spectrum for a source the client did not select", func(t *testing.T) {
+		t.Parallel()
+		data := sample()
+		filterSpectrum(&data, "src-2")
+		assert.Nil(t, data.Spectrum)
+	})
+}
+
+func TestWithoutSpectrumDoesNotMutateItsArgument(t *testing.T) {
+	t.Parallel()
+
+	original := audiocore.AudioLevelData{
+		Source:             "src-1",
+		Spectrum:           []byte{1, 2, 3},
+		SpectrumSampleRate: 48000,
+		SpectrumTime:       1750000000,
+	}
+
+	stripped := withoutSpectrum(original)
+
+	assert.Nil(t, stripped.Spectrum)
+	assert.Equal(t, []byte{1, 2, 3}, original.Spectrum, "the caller's copy must be untouched")
+	assert.Equal(t, 48000, original.SpectrumSampleRate)
+}
+
+// TestAudioLevelSSEDataSpectrumWireFormat pins the JSON the browser fallback
+// parses: the spectrum fields appear only when the handler kept them, so a
+// client that did not opt in sees exactly the payload it saw before.
+func TestAudioLevelSSEDataSpectrumWireFormat(t *testing.T) {
+	t.Parallel()
+
+	t.Run("omitted when the client did not opt in", func(t *testing.T) {
+		t.Parallel()
+		payload, err := json.Marshal(AudioLevelSSEData{
+			Type:   "audio-level",
+			Levels: map[string]audiocore.AudioLevelData{"src-1": {Level: 42, Source: "src-1"}},
+		})
+		require.NoError(t, err)
+		assert.NotContains(t, string(payload), "spectrum")
+	})
+
+	t.Run("carried as base64 with its sample rate and capture time", func(t *testing.T) {
+		t.Parallel()
+		payload, err := json.Marshal(AudioLevelSSEData{
+			Type: "audio-level",
+			Levels: map[string]audiocore.AudioLevelData{"src-1": {
+				Level:              42,
+				Source:             "src-1",
+				Spectrum:           []byte{0, 128, 255},
+				SpectrumSampleRate: 48000,
+				SpectrumTime:       1750000000.5,
+			}},
+		})
+		require.NoError(t, err)
+
+		var decoded struct {
+			Levels map[string]struct {
+				Spectrum           []byte  `json:"spectrum"`
+				SpectrumSampleRate int     `json:"spectrumSampleRate"`
+				SpectrumTime       float64 `json:"spectrumTime"`
+			} `json:"levels"`
+		}
+		require.NoError(t, json.Unmarshal(payload, &decoded))
+
+		entry := decoded.Levels["src-1"]
+		assert.Equal(t, []byte{0, 128, 255}, entry.Spectrum)
+		assert.Equal(t, 48000, entry.SpectrumSampleRate)
+		assert.InDelta(t, 1750000000.5, entry.SpectrumTime, 0.001)
+	})
+}

--- a/internal/audiocore/audio_level.go
+++ b/internal/audiocore/audio_level.go
@@ -8,4 +8,10 @@ type AudioLevelData struct {
 	Clipping bool   `json:"clipping"` // true if clipping is detected
 	Source   string `json:"source"`   // Source identifier
 	Name     string `json:"name"`     // Human-readable name
+	// Optional magnitude spectrum for the live spectrogram fallback, computed
+	// from the same PCM as Level. See analysis.spectrumAnalyzer for how the bins
+	// are produced and audio.filterSpectrum for when they reach a client.
+	Spectrum           []byte  `json:"spectrum,omitempty"`           // 0-255 bins, log scale
+	SpectrumSampleRate int     `json:"spectrumSampleRate,omitempty"` // source rate, not the browser's
+	SpectrumTime       float64 `json:"spectrumTime,omitempty"`       // capture time, Unix seconds
 }


### PR DESCRIPTION
## Summary

The live spectrogram waterfall is blank on Safari/WebKit (macOS and iOS) while audio playback works — reported in #2702.

Root cause is [WebKit bug 180696](https://bugs.webkit.org/show_bug.cgi?id=180696), open since 2017: `createMediaElementSource()` on an HLS-backed `<audio>` element yields silence, so `AnalyserNode.getByteFrequencyData()` returns all zeros. There is no client-side workaround — the samples never reach the Web Audio graph.

So the bins have to come from the server. Rather than add a dedicated spectrogram endpoint, this rides three things that already exist: the PCM consumer that already computes audio levels, the SSE stream the spectrogram pages already open, and `SpectrogramCanvas`'s existing `frequencyData` buffer. No new endpoint, no new lifecycle manager, no config surface.

**Browsers with a working `AnalyserNode` are untouched** — they never open the extra connection and never receive spectrum data.

## Changes

**Server — magnitude columns beside the existing audio level**

- `internal/analysis/audio_level_spectrum.go` (new): a rolling 1024-sample Hann window and a package-local radix-2 FFT producing 512 bins, scaled over the `AnalyserNode` defaults (−100/−30 dB), rate-limited to one column per 50 ms per source — the same rate the SSE stream already enforces, so no column is computed that would be dropped.
- `AudioLevelConsumer.Write` attaches the column to the value it already publishes. `AudioLevelData` gains `Spectrum`, `SpectrumSampleRate` and `SpectrumTime`.
- Columns are computed unconditionally rather than on subscriber demand. `BenchmarkSpectrumAnalyzer` (included) measures **~42 µs/column on an Intel N150** — under 0.1% of a core per source at 20 columns/s, and a fraction of a percent on a Pi. Demand plumbing across the analysis/API boundary would cost more than it saves.

**API — opt-in, off by default**

- `internal/api/v2/audio/audio_level_spectrum.go` (new): `?spectrum=1` for every source, or `?spectrum=<sourceID>` for one. Absent by default, so level-meter clients (the bulk of this endpoint's traffic) get a byte-identical payload. A column is ~700 bytes per source per update, which is exactly why it is not unconditional.
- The spectrum is also stripped from the long-lived `latestLevels` health-check copy, so it cannot reach a client that never asked.

**Frontend — adopt the server bins only when the local analyser is proven blind**

- `frontend/src/lib/utils/serverSpectrumFallback.ts` (new) owns the whole workaround. It probes the analyser every 250 ms; only after four consecutive all-zero reads **while audio is playing through a running context** does it open the spectrum stream, and it adopts the server bins only once a column shows energy the analyser cannot see. A single non-zero analyser read tears the fallback down permanently. No UA sniffing — the decision is made from observed behaviour.
- Columns carry their capture time, are queued, and are rendered against the playhead wall clock via the existing `computeWallClockAtPlayhead()` — the same helper and clock the detection-label promotion already uses. Without this the waterfall would run seconds ahead of the buffered audio, and ahead of the labels drawn over it.
- If the stream drops, the waterfall blanks after 1.5 s rather than smearing one frozen column across the canvas. If the playhead never reaches the queue (a browser and server whose clocks disagree, which the seekable-range estimate cannot detect), alignment is abandoned with a warning rather than leaving the user blank.
- `SpectrogramCanvas` gains one boolean prop, `externalFrequencyData`; the render path is otherwise unchanged. The server bins match the browser analyser's shape (1024-point FFT, 512 bins, same dB range), so `pixelToBinMap` works as-is.

## Testing

- [x] Go tests pass — 675 across `internal/analysis`, `internal/api/v2/audio`, `internal/audiocore`, including 16 new ones (`-race` on the new suites)
- [x] Frontend tests pass — 2910/2910, including 27 new unit tests for the decode, queue-trim, column-selection and render-decision logic
- [x] Linting passes — `golangci-lint run` clean on the changed packages; frontend `format:check`, `lint`, `lint:css`, `typecheck` (0 errors), `ast:all`, `analyze:circular` and `build` all clean
- [x] Benchmark included for the per-column FFT cost
- [ ] Manual testing on a real Safari/iOS device — **not yet done, see below**

### What I could not verify

I do not have a WebKit device in this environment, so two things are reasoned about rather than observed, and I would value a second pair of eyes (or hands) on them:

1. **That Safari actually latches the fallback.** The probe logic follows from the bug report's description (analyser returns zeros while playback works), but I have not watched it happen.
2. **Clock agreement on native iOS HLS.** With hls.js, alignment uses `playingDate` (stream time) and is exact. Native HLS has no `playingDate`, so the playhead is derived from the browser clock while columns carry the server clock. Badly disagreeing clocks degrade to unaligned rendering — handled deliberately, but unconfirmed in the field.

## Notes for review

Scoped deliberately to this one bug, after the feedback on #2745. No axis labels, no colormap persistence, no unrelated refactors. Most of the code is in five new files; existing files are touched in ~155 lines across 25 hunks, mostly single lines.

`internal/api/v2/audio/audio_level.go` has one change beyond the opt-in wiring: `updateAudioLevel` now takes `*audiocore.AudioLevelData`. The three new fields pushed the struct past gocritic's 80-byte `hugeParam` threshold, and copying it per update per client was pointless anyway.

The FFT is a small package-local copy rather than a shared helper. The only other FFT in the tree is private to `internal/audiocore/ultrasonic`, and I did not want the live audio-level path depending on a bat-detection package. Extracting a common DSP helper felt like a separate cleanup rather than something to smuggle into this PR — happy to do it either way.

## Related Issues

Refs #2702


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live spectrograms now remain available for HLS playback in browsers where local audio analysis is unavailable.
  * Spectrogram data can be requested through the audio-level stream for all sources or a specific source.
  * Server-provided spectrum data stays synchronized with playback timing and handles stalls and recovery gracefully.

* **Documentation**
  * Added audio-level stream documentation for requesting spectrum data.

* **Tests**
  * Expanded coverage for spectrum generation, streaming, rendering, alignment, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->