### PR TITLE
fix(classifier): report the running model after a stale-path recovery, and close two reload/presence gaps

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -1771,7 +1771,11 @@ func modelIsDownloading(mm *classifier.ModelManager, modelID string) bool {
 	}
 	catalog := classifier.ActiveCatalog()
 	for i := range catalog {
-		if catalog[i].RegistryID == registryID && mm.GetDownloadState(catalog[i].ID) != nil {
+		// Suppress the not-analyzing alarm only while a download is genuinely in
+		// progress. A FAILED state lingers for failedStateRetention so SSE pollers
+		// can see it, but the model is NOT analyzing during that window, so a
+		// non-nil-but-failed state must not be read as "still downloading".
+		if catalog[i].RegistryID == registryID && mm.GetDownloadState(catalog[i].ID).IsActive() {
 			return true
 		}
 	}

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -978,8 +978,12 @@ func (p *Processor) parseAndValidateSpecies(settings *conf.Settings, result data
 		commonName = scientificName
 	}
 
-	// Log placeholder taxonomy codes if using custom model
-	if settings.BirdNET.ModelPath != "" && settings.Debug && speciesCode != "" {
+	// Log placeholder taxonomy codes if a custom model is actually running. Read the
+	// RESOLVED primary path, not settings.BirdNET.ModelPath: after a stale-path
+	// recovery the configured value can name a file the instance is not running (or
+	// the built-in baseline is running while config still points at a custom path),
+	// so the raw setting would misclassify which model produced the code.
+	if p.Bn.PrimaryResolvedModelPath() != "" && settings.Debug && speciesCode != "" {
 		if len(speciesCode) == 8 && (speciesCode[:2] == "XX" || (speciesCode[0] >= 'A' && speciesCode[0] <= 'Z' && speciesCode[1] >= 'A' && speciesCode[1] <= 'Z')) {
 			GetLogger().Debug("using placeholder taxonomy code",
 				logger.String("taxonomy_code", speciesCode),

--- a/internal/classifier/analyze.go
+++ b/internal/classifier/analyze.go
@@ -32,14 +32,14 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 	settings := bn.currentSettings()
 	start := time.Now()
 
-	// The decoration below reports the CONFIGURED path
-	// (settings.BirdNET.ModelPath), not bn.configuredModelPath(), and that is
-	// deliberate: this runs BEFORE bn.mu is taken, and bn.primaryPath is written
-	// under bn.mu by reloadModelInternal, so reading the resolved value here would
-	// be a data race. Reporting the resolved path on THIS path needs a lock-free
-	// published copy alongside bn.identity. The two decorations after the lock do
-	// report the resolved path, since after a stale-path recovery the configured
-	// one names a file the instance is not running.
+	// This decoration runs BEFORE bn.mu is taken, so it must not read
+	// bn.primaryPath (written under bn.mu by reloadModelInternal). It reads the
+	// RESOLVED path lock-free from the published identity snapshot via
+	// bn.resolvedModelPath(), so after a stale-path recovery it names the file the
+	// instance is actually running rather than settings.BirdNET.ModelPath, which
+	// would name a file this instance is not loaded from. The two decorations after
+	// the lock report the same resolved path via bn.configuredModelPath(), so all
+	// three now agree.
 	//
 	// Guard against empty sample slice. Pre-inference rejections are tagged but
 	// not counted as predictions.
@@ -47,7 +47,7 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 		span.markErrored(errTypeEmptySample)
 		return nil, errors.Newf("empty audio sample").
 			Category(errors.CategoryValidation).
-			ModelContext(settings.BirdNET.ModelPath, modelID).
+			ModelContext(bn.resolvedModelPath(), modelID).
 			Build()
 	}
 

--- a/internal/classifier/bat_onnx.go
+++ b/internal/classifier/bat_onnx.go
@@ -35,6 +35,11 @@ type Bat struct {
 	// construction; reported via RuntimeInfo().
 	backend   string
 	precision string
+	// modelPath is the classifier model file this instance actually loaded from
+	// (the resolved path the loader built with, which after a stale-path recovery
+	// differs from the configured Bat.ClassifierModel). Set once at construction;
+	// reported via ResolvedModelPath().
+	modelPath string
 }
 
 // BatModelConfig holds configuration for creating a Bat model instance.
@@ -143,6 +148,7 @@ func NewBat(cfg *BatModelConfig) (*Bat, error) {
 		device:             device,
 		backend:            backend,
 		precision:          precision,
+		modelPath:          cfg.ClassifierModelPath,
 	}, nil
 }
 
@@ -384,6 +390,10 @@ func (b *Bat) Labels() []string {
 func (b *Bat) RuntimeInfo() (device, backend, precision string) {
 	return b.device, b.backend, b.precision
 }
+
+// ResolvedModelPath returns the classifier model file this bat instance loaded
+// from. Fixed at construction, so the read needs no lock. Implements ModelInstance.
+func (b *Bat) ResolvedModelPath() string { return b.modelPath }
 
 // Close releases resources held by the bat model.
 func (b *Bat) Close() error {

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -65,6 +65,14 @@ type modelIdentity struct {
 	name    string
 	version string
 	spec    ModelSpec
+	// resolvedPath is the primary classifier model file this instance actually
+	// loaded from (bn.primaryPath.resolved.model), published alongside the identity
+	// so observers on and off the hot path can read the RUNNING file lock-free
+	// rather than settings.BirdNET.ModelPath, which after a stale-path recovery names
+	// a file the instance is not running. Empty means the built-in baseline is
+	// running (no configured path, or a confirmed-absent path with no usable
+	// installed variant).
+	resolvedPath string
 }
 
 // BirdNET struct represents the BirdNET model with interpreters and configuration.
@@ -167,6 +175,34 @@ func (bn *BirdNET) updateSettings(s *conf.Settings) {
 // the settings API's change detection is one such caller.
 func (bn *BirdNET) configuredModelPath() string {
 	return bn.primaryPath.resolved.model
+}
+
+// resolvedModelPath returns the primary classifier model file this instance is
+// running, read LOCK-FREE from the published identity snapshot. Unlike
+// configuredModelPath (which reads bn.primaryPath under bn.mu or before the
+// instance is shared), this is safe to call off bn.mu: it is what the pre-lock
+// inference decoration and the cross-package accessors below use so they report
+// the file the instance is actually running, never the stale configured path,
+// without taking bn.mu (held by inference for the full native call, issue #3336).
+//
+// Before the first publishIdentity (a struct-literal instance in tests that
+// bypassed NewBirdNET, never concurrently reloaded) the pointer is nil and it
+// falls back to reading bn.primaryPath directly, which is race-free in that case,
+// mirroring the ModelID/ModelName/ModelVersion getters.
+func (bn *BirdNET) resolvedModelPath() string {
+	if id := bn.identity.Load(); id != nil {
+		return id.resolvedPath
+	}
+	return bn.primaryPath.resolved.model
+}
+
+// ResolvedModelPath returns the primary classifier model file this instance is
+// running (empty means the built-in baseline). It is the lock-free, RUNNING-file
+// answer that cross-package consumers must prefer over settings.BirdNET.ModelPath,
+// which after a stale-path recovery names a file that is not loaded. Implements
+// ModelInstance.
+func (bn *BirdNET) ResolvedModelPath() string {
+	return bn.resolvedModelPath()
 }
 
 // resolvePrimaryOrConfigured applies a primaryPathResolver, treating a nil
@@ -1542,21 +1578,32 @@ func (bn *BirdNET) reloadModelInternal(allowPathChange bool) error {
 				Build()
 		}
 		bn.ModelInfo = newInfo
-	case !allowPathChange && bn.primaryPath.substituted &&
+	case !allowPathChange &&
 		oldPrimaryPath.resolved.model != "" && bn.primaryPath.resolved.model == "":
-		// The file this instance is RUNNING has gone away: the previous resolution
-		// named a real file, this one resolves to nothing (confirmed absent with no
-		// usable installed variant). A substitution onto a real file has a non-empty
-		// configuredModelPath and is handled by the case above.
+		// The file this instance is RUNNING is gone from the configuration: the
+		// previous resolution named a real file, this one resolves to nothing. Two
+		// ways in, both a model-identity change that the settings-reload path must
+		// refuse (the caller restarts the orchestrator instead):
+		//   - the configured file was CONFIRMED absent with no usable installed
+		//     variant, so resolvePrimaryModelPath substituted onto the empty
+		//     built-in (substituted=true, resolved.model=""); or
+		//   - the user CLEARED birdnet.modelpath while a custom model was running, so
+		//     resolvePrimaryModelPath("") returns the empty result verbatim
+		//     (substituted=false, resolved.model="").
+		// A substitution onto a REAL file has a non-empty configuredModelPath and is
+		// handled by the case above.
 		//
 		// The old-vs-new comparison is what makes this precise, and it is load
-		// bearing. Testing bn.primaryPath.substituted alone would also fire in the
-		// STEADY STATE after a successful startup recovery onto the built-in
-		// baseline: config keeps the stale path (the recovery is deliberately not
-		// repairable there), so every reload re-resolves to the same empty result,
-		// and every settings save would fail forever. That is precisely the
-		// second-order bug the re-resolution above exists to prevent, and it would
-		// hit exactly the users this whole recovery is for.
+		// bearing: it is what excludes the STEADY STATE after a successful startup
+		// recovery onto the built-in baseline. There config keeps the stale path (the
+		// recovery is deliberately not repairable), so every reload re-resolves to
+		// the same empty result, but the PREVIOUS resolution was already empty too
+		// (oldPrimaryPath.resolved.model == ""), so this case does not fire and
+		// settings saves keep succeeding. The guard deliberately does NOT test
+		// bn.primaryPath.substituted: gating on it would leave the cleared-path case
+		// (substituted=false) falling through, which is the silent-corruption bug
+		// below, while adding nothing to the steady-state exclusion the old!="" arm
+		// already provides.
 		//
 		// Falling through would instead be silent corruption: no case matches,
 		// bn.ModelInfo keeps naming the vanished file, initializeModel loads the
@@ -1763,10 +1810,11 @@ func (bn *BirdNET) GetSpeciesOccurrenceAtTime(species string, detectionTime time
 // consistent.
 func (bn *BirdNET) publishIdentity() {
 	bn.identity.Store(&modelIdentity{
-		id:      bn.ModelInfo.ID,
-		name:    bn.ModelInfo.Name,
-		version: bn.modelVersion,
-		spec:    bn.ModelInfo.Spec,
+		id:           bn.ModelInfo.ID,
+		name:         bn.ModelInfo.Name,
+		version:      bn.modelVersion,
+		spec:         bn.ModelInfo.Spec,
+		resolvedPath: bn.primaryPath.resolved.model,
 	})
 }
 

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -2017,7 +2017,7 @@ func (bn *BirdNET) PrimaryRangeFilterCoverage() (geomodel *GeomodelStatus, prima
 	bn.mu.Unlock()
 
 	if rf.Model == "v3" && modelsDir != "" {
-		sharedDir := filepath.Join(modelsDir, "shared")
+		sharedDir := filepath.Join(modelsDir, sharedDirName)
 		expectedONNX := filepath.Join(sharedDir, conf.GeomodelONNXLocalName)
 		expectedLabels := filepath.Join(sharedDir, conf.GeomodelLabelsLocalName)
 		autoSelected = rf.ModelPath == expectedONNX && rf.LabelsPath == expectedLabels
@@ -2066,7 +2066,7 @@ func shouldAutoSelectV3Geomodel(modelID, modelsDir string) bool {
 	default:
 		return false
 	}
-	sharedDir := filepath.Join(modelsDir, "shared")
+	sharedDir := filepath.Join(modelsDir, sharedDirName)
 	onnxPath := filepath.Join(sharedDir, conf.GeomodelONNXLocalName)
 	labelsPath := filepath.Join(sharedDir, conf.GeomodelLabelsLocalName)
 	if _, err := os.Stat(onnxPath); err != nil {
@@ -2116,7 +2116,7 @@ func applyAutoSelectedGeomodelPaths(settings *conf.Settings, modelsDir string) {
 		}
 	}
 
-	sharedDir := filepath.Join(modelsDir, "shared")
+	sharedDir := filepath.Join(modelsDir, sharedDirName)
 	rf.Model = "v3"
 	rf.ModelPath = filepath.Join(sharedDir, conf.GeomodelONNXLocalName)
 	rf.LabelsPath = filepath.Join(sharedDir, conf.GeomodelLabelsLocalName)

--- a/internal/classifier/birdnet_test.go
+++ b/internal/classifier/birdnet_test.go
@@ -17,9 +17,10 @@ import (
 // fakeModelInstance is a minimal ModelInstance for testing orchestrator logic
 // without loading real models.
 type fakeModelInstance struct {
-	id     string
-	name   string
-	labels []string
+	id           string
+	name         string
+	labels       []string
+	resolvedPath string
 }
 
 func (f *fakeModelInstance) Predict(_ context.Context, _ [][]float32) ([]datastore.Results, error) {
@@ -35,6 +36,7 @@ func (f *fakeModelInstance) Close() error         { return nil }
 func (f *fakeModelInstance) RuntimeInfo() (device, backend, precision string) {
 	return deviceCPU, BackendONNX, ""
 }
+func (f *fakeModelInstance) ResolvedModelPath() string { return f.resolvedPath }
 
 func TestShouldAutoSelectV3Geomodel(t *testing.T) {
 	t.Parallel()

--- a/internal/classifier/birdnet_v3_onnx.go
+++ b/internal/classifier/birdnet_v3_onnx.go
@@ -32,6 +32,11 @@ type BirdNETV3 struct {
 	// Both set once at construction; reported via RuntimeInfo().
 	backend   string
 	precision string
+	// modelPath is the model file this instance actually loaded from (the resolved
+	// path the loader built with, which after a stale-path recovery differs from the
+	// configured BirdNETV3.ModelPath). Set once at construction; reported via
+	// ResolvedModelPath().
+	modelPath string
 }
 
 // BirdNETV3Config holds configuration for creating a BirdNET v3.0 model instance.
@@ -142,6 +147,7 @@ func NewBirdNETV3(cfg *BirdNETV3Config) (*BirdNETV3, error) {
 		device:     device,
 		backend:    backend,
 		precision:  precision,
+		modelPath:  cfg.ModelPath,
 	}, nil
 }
 
@@ -298,6 +304,10 @@ func (b *BirdNETV3) Labels() []string {
 func (b *BirdNETV3) RuntimeInfo() (device, backend, precision string) {
 	return b.device, b.backend, b.precision
 }
+
+// ResolvedModelPath returns the model file this BirdNET v3.0 instance loaded from.
+// Fixed at construction, so the read needs no lock. Implements ModelInstance.
+func (b *BirdNETV3) ResolvedModelPath() string { return b.modelPath }
 
 // Close releases resources held by the BirdNET v3.0 model.
 func (b *BirdNETV3) Close() error {

--- a/internal/classifier/model.go
+++ b/internal/classifier/model.go
@@ -109,6 +109,16 @@ type ModelInstance interface {
 	// metadata.
 	RuntimeInfo() (device, backend, precision string)
 
+	// ResolvedModelPath returns the model file this instance is actually running,
+	// which after a stale-path recovery differs from the path configured in
+	// settings. Empty means the model's built-in/default source is running rather
+	// than a file the user named. The value is fixed at construction (secondaries)
+	// or published lock-free alongside the identity snapshot (the primary), so the
+	// read takes no lock. Consumers that need "which variant is loaded" (the model
+	// gallery scan, telemetry) must read this rather than the settings field, which
+	// can name a file that is not loaded.
+	ResolvedModelPath() string
+
 	// Close releases resources held by the model.
 	Close() error
 }

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -129,6 +129,24 @@ type DownloadState struct {
 	Error           string `json:"error,omitempty"`
 }
 
+// IsActive reports whether this download state means the model is genuinely
+// mid-acquisition (downloading, verifying, or loading). A FAILED state is retained
+// for failedStateRetention so SSE pollers can still observe the failure, but during
+// that window the model is NOT analyzing, so callers deciding whether to suppress a
+// "not analyzing" alarm must treat failed (and the terminal complete/removed) as
+// inactive rather than as an in-progress download.
+func (s *DownloadState) IsActive() bool {
+	if s == nil {
+		return false
+	}
+	switch s.Status {
+	case StatusDownloading, StatusVerifying, StatusLoading:
+		return true
+	default:
+		return false
+	}
+}
+
 // NewModelManager creates a ModelManager that manages downloadable models
 // stored under modelsDir. The orchestrator is used for coordinating with
 // running model instances during install/uninstall operations. The settings
@@ -193,6 +211,17 @@ func (mm *ModelManager) ScanInstalled() {
 	// recorded model path points at). GetSettings returns an atomic snapshot.
 	settings := conf.GetSettings()
 
+	// Snapshot the resolved path each loaded instance is actually running, BEFORE
+	// taking mm.mu. installedModelBasenameHint prefers this over the configured path
+	// so the scan reports the RUNNING variant after a stale-path recovery, not the
+	// stale configured one. Snapshotting here keeps o.mu (taken
+	// briefly by LoadedModelPaths) from ever nesting under mm.mu. Nil when no
+	// orchestrator is wired (tests), which leaves the hint on its settings fallback.
+	var loadedPaths map[string]string
+	if mm.orchestrator != nil {
+		loadedPaths = mm.orchestrator.LoadedModelPaths()
+	}
+
 	// Phase 1: scan the filesystem under mm.mu.
 	mm.mu.Lock()
 	// Preserve in-flight installs/switches: replaceVariant swaps mm.installed and
@@ -225,7 +254,7 @@ func (mm *ModelManager) ScanInstalled() {
 		// file, so a variant entry is never shared-only and never needs the
 		// shared-only fall-through below.
 		if len(entry.Variants) > 0 {
-			if im, ok := scanVariantEntry(entry, subdir, installedModelBasenameHint(settings, entry.RegistryID)); ok {
+			if im, ok := scanVariantEntry(entry, subdir, installedModelBasenameHint(settings, entry.RegistryID, loadedPaths)); ok {
 				mm.installed[entry.ID] = im
 				log.Debug("Found installed model variant",
 					logger.String("catalog_id", entry.ID),
@@ -436,7 +465,24 @@ func variantByModelHint(entry *CatalogEntry, subdir, modelBasenameHint string) (
 // settings for the given registry ID, or "" when settings are absent or the
 // family carries no path. It is the tie-break scanVariantEntry uses to resolve an
 // ambiguous multi-variant on-disk state to the variant the loader actually opens.
-func installedModelBasenameHint(settings *conf.Settings, registryID string) string {
+func installedModelBasenameHint(settings *conf.Settings, registryID string, loadedPaths map[string]string) string {
+	// Prefer the file the LOADED instance is actually running. After a stale-path
+	// recovery the settings field still names the pre-recovery file, so keying the
+	// gallery scan off it would report a variant that is not loaded and offer to
+	// "optimize" a build the process is already running. A family
+	// PRESENT in loadedPaths is authoritative even when its value is empty: empty
+	// means the built-in/default source is running, so returning "" (which
+	// scanVariantEntry maps to the BuiltIn record) is the correct answer, not a
+	// reason to fall back to config. Fall back to the configured field only when no
+	// instance is loaded for the family: the startup scan before models load, or a
+	// nil orchestrator in tests, both leave the family absent from loadedPaths.
+	if p, loaded := loadedPaths[registryID]; loaded {
+		if p == "" {
+			return ""
+		}
+		return filepath.Base(p)
+	}
+
 	if settings == nil {
 		return ""
 	}

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -29,6 +29,12 @@ import (
 // that cannot be uninstalled.
 const permanentRegistryID = "BirdNET_V2.4"
 
+// sharedDirName is the gallery subdirectory that holds files shared across a
+// family's variants (the bat embedding extractor, the geomodel range filter).
+// Named once so the layout is not spelled out as a literal at every join and
+// parent-directory check.
+const sharedDirName = "shared"
+
 // Download status constants used in DownloadState.Status and SSE progress events.
 const (
 	StatusDownloading = "downloading"
@@ -465,6 +471,35 @@ func variantByModelHint(entry *CatalogEntry, subdir, modelBasenameHint string) (
 // settings for the given registry ID, or "" when settings are absent or the
 // family carries no path. It is the tie-break scanVariantEntry uses to resolve an
 // ambiguous multi-variant on-disk state to the variant the loader actually opens.
+// familyPathFields returns pointers to the model, labels, and embeddings path
+// fields in s for registryID, so the family-to-settings-field mapping lives in ONE
+// place instead of the copies that had drifted apart (the newest omitted BSG). A
+// nil labels or embeddings pointer means the family has no such field and it must
+// NOT be written: the primary is model-only (its label set is embedded and
+// identical across variants, so applyConfigForPrimarySwap writes BirdNET.ModelPath
+// alone and a user-configured BirdNET.LabelPath must survive a variant swap), and
+// every family but bat carries no embeddings path. ok is false for an unknown
+// registry ID or a nil settings pointer.
+func familyPathFields(s *conf.Settings, registryID string) (model, labels, embeddings *string, ok bool) {
+	if s == nil {
+		return nil, nil, nil, false
+	}
+	switch registryID {
+	case permanentRegistryID:
+		return &s.BirdNET.ModelPath, nil, nil, true
+	case RegistryIDPerchV2:
+		return &s.Perch.ModelPath, &s.Perch.LabelPath, nil, true
+	case RegistryIDBirdNETV3:
+		return &s.BirdNETV3.ModelPath, &s.BirdNETV3.LabelPath, nil, true
+	case RegistryIDBSG:
+		return &s.BSG.ModelPath, &s.BSG.LabelPath, nil, true
+	case RegistryIDBat:
+		return &s.Bat.ClassifierModel, &s.Bat.LabelPath, &s.Bat.EmbeddingModel, true
+	default:
+		return nil, nil, nil, false
+	}
+}
+
 func installedModelBasenameHint(settings *conf.Settings, registryID string, loadedPaths map[string]string) string {
 	// Prefer the file the LOADED instance is actually running. After a stale-path
 	// recovery the settings field still names the pre-recovery file, so keying the
@@ -483,29 +518,15 @@ func installedModelBasenameHint(settings *conf.Settings, registryID string, load
 		return filepath.Base(p)
 	}
 
-	if settings == nil {
+	// No loaded instance for this family: fall back to the configured model path.
+	// The permanent BirdNET v2.4 slot records its selected DFT-truncated file in
+	// BirdNET.ModelPath (empty means the embedded BuiltIn baseline); each secondary
+	// records its own. familyPathFields is the single source of that mapping.
+	model, _, _, ok := familyPathFields(settings, registryID)
+	if !ok || *model == "" {
 		return ""
 	}
-	var p string
-	switch registryID {
-	case permanentRegistryID:
-		// The permanent BirdNET v2.4 classifier: its selected DFT-truncated file
-		// (if any) is recorded in BirdNET.ModelPath. An empty path means the
-		// embedded BuiltIn baseline is active.
-		p = settings.BirdNET.ModelPath
-	case RegistryIDBirdNETV3:
-		p = settings.BirdNETV3.ModelPath
-	case RegistryIDPerchV2:
-		p = settings.Perch.ModelPath
-	case RegistryIDBSG:
-		p = settings.BSG.ModelPath
-	case RegistryIDBat:
-		p = settings.Bat.ClassifierModel
-	}
-	if p == "" {
-		return ""
-	}
-	return filepath.Base(p)
+	return filepath.Base(*model)
 }
 
 // installedFromVariant builds the InstalledModel for a specific variant if its
@@ -602,7 +623,7 @@ func (mm *ModelManager) ensureGeomodelConfig(log logger.Logger, installedIDs []s
 			if !isGeomodelRole(f.Role) {
 				continue
 			}
-			path := filepath.Join(mm.modelsDir, "shared", f.LocalName)
+			path := filepath.Join(mm.modelsDir, sharedDirName, f.LocalName)
 			if _, err := os.Stat(path); err != nil {
 				allPresent = false
 				break
@@ -633,9 +654,9 @@ func (mm *ModelManager) applyInstalledGeomodelConfig(log logger.Logger, entry *C
 	for _, f := range entry.Files {
 		switch f.Role {
 		case RoleGeomodelModel:
-			expectedModelPath = filepath.Join(mm.modelsDir, "shared", f.LocalName)
+			expectedModelPath = filepath.Join(mm.modelsDir, sharedDirName, f.LocalName)
 		case RoleGeomodelLabels:
-			expectedLabelsPath = filepath.Join(mm.modelsDir, "shared", f.LocalName)
+			expectedLabelsPath = filepath.Join(mm.modelsDir, sharedDirName, f.LocalName)
 		}
 	}
 
@@ -692,8 +713,8 @@ func (mm *ModelManager) applyInstalledGeomodelConfig(log logger.Logger, entry *C
 // orchestrator and to cover cases where the config migration did not persist
 // (e.g. no config file on disk).
 func (mm *ModelManager) healOrphanGeomodelConfig(log logger.Logger) {
-	expectedModelPath := filepath.Join(mm.modelsDir, "shared", conf.GeomodelONNXLocalName)
-	expectedLabelsPath := filepath.Join(mm.modelsDir, "shared", conf.GeomodelLabelsLocalName)
+	expectedModelPath := filepath.Join(mm.modelsDir, sharedDirName, conf.GeomodelONNXLocalName)
+	expectedLabelsPath := filepath.Join(mm.modelsDir, sharedDirName, conf.GeomodelLabelsLocalName)
 
 	filesPresent := true
 	for _, path := range []string{expectedModelPath, expectedLabelsPath} {
@@ -813,7 +834,7 @@ func (mm *ModelManager) scanSharedOnlyEntry(log logger.Logger, entry *CatalogEnt
 	if !IsSharedOnly(entry) {
 		return false
 	}
-	sharedDir := filepath.Join(mm.modelsDir, "shared")
+	sharedDir := filepath.Join(mm.modelsDir, sharedDirName)
 	var modelPath, labelsPath string
 	for _, f := range entry.Files {
 		p := filepath.Join(sharedDir, f.LocalName)
@@ -1086,7 +1107,7 @@ func (mm *ModelManager) cleanupSharedFiles(log logger.Logger, catalogID string, 
 	}
 	for _, f := range entry.Files {
 		if matchRole(f.Role) {
-			path := filepath.Join(mm.modelsDir, "shared", f.LocalName)
+			path := filepath.Join(mm.modelsDir, sharedDirName, f.LocalName)
 			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 				log.Warn("Failed to remove "+label+" file",
 					logger.String("path", path),
@@ -1458,7 +1479,7 @@ func (mm *ModelManager) rollbackVariantSwitch(log logger.Logger, entry *CatalogE
 	if oldFiles, ok := variantFilesByID(entry, old.VariantID); ok {
 		for _, f := range oldFiles {
 			if f.Role == RoleEmbeddings {
-				oldEmbeddings = filepath.Join(mm.modelsDir, "shared", f.LocalName)
+				oldEmbeddings = filepath.Join(mm.modelsDir, sharedDirName, f.LocalName)
 				break
 			}
 		}
@@ -1766,7 +1787,7 @@ func (mm *ModelManager) downloadVariantFiles(ctx context.Context, entry *Catalog
 	// Shared files (embeddings, geomodel, taxonomy) are stored in a common directory.
 	fileDestPath := func(f CatalogFile) string {
 		if isSharedRole(f.Role) {
-			return filepath.Join(mm.modelsDir, "shared", f.LocalName)
+			return filepath.Join(mm.modelsDir, sharedDirName, f.LocalName)
 		}
 		return filepath.Join(subdir, f.LocalName)
 	}
@@ -1897,7 +1918,7 @@ func (mm *ModelManager) downloadVariantFiles(ctx context.Context, entry *Catalog
 	// Find embeddings path for bat models.
 	for _, f := range files {
 		if f.Role == RoleEmbeddings {
-			embeddingsPath = filepath.Join(mm.modelsDir, "shared", f.LocalName)
+			embeddingsPath = filepath.Join(mm.modelsDir, sharedDirName, f.LocalName)
 			break
 		}
 	}
@@ -2059,37 +2080,19 @@ func (mm *ModelManager) applyConfigForInstall(entry *CatalogEntry, modelPath, la
 
 	updated := conf.CloneSettings(conf.GetSettings())
 
-	switch entry.RegistryID {
-	case RegistryIDBirdNETV3:
+	// Set only the non-empty paths, and only fields the family actually carries
+	// (familyPathFields returns nil for a family's absent labels/embeddings). The
+	// primary is not gallery-installed through this path, so a permanent registry ID
+	// never reaches here; if it did, familyPathFields would expose model only.
+	if model, labels, embeddings, ok := familyPathFields(updated, entry.RegistryID); ok {
 		if modelPath != "" {
-			updated.BirdNETV3.ModelPath = modelPath
+			*model = modelPath
 		}
-		if labelsPath != "" {
-			updated.BirdNETV3.LabelPath = labelsPath
+		if labels != nil && labelsPath != "" {
+			*labels = labelsPath
 		}
-	case RegistryIDPerchV2:
-		if modelPath != "" {
-			updated.Perch.ModelPath = modelPath
-		}
-		if labelsPath != "" {
-			updated.Perch.LabelPath = labelsPath
-		}
-	case RegistryIDBSG:
-		if modelPath != "" {
-			updated.BSG.ModelPath = modelPath
-		}
-		if labelsPath != "" {
-			updated.BSG.LabelPath = labelsPath
-		}
-	case RegistryIDBat:
-		if modelPath != "" {
-			updated.Bat.ClassifierModel = modelPath
-		}
-		if labelsPath != "" {
-			updated.Bat.LabelPath = labelsPath
-		}
-		if embeddingsPath != "" {
-			updated.Bat.EmbeddingModel = embeddingsPath
+		if embeddings != nil && embeddingsPath != "" {
+			*embeddings = embeddingsPath
 		}
 	}
 
@@ -2099,9 +2102,9 @@ func (mm *ModelManager) applyConfigForInstall(entry *CatalogEntry, modelPath, la
 		for _, f := range entry.Files {
 			switch f.Role {
 			case RoleGeomodelModel:
-				updated.BirdNET.RangeFilter.ModelPath = filepath.Join(mm.modelsDir, "shared", f.LocalName)
+				updated.BirdNET.RangeFilter.ModelPath = filepath.Join(mm.modelsDir, sharedDirName, f.LocalName)
 			case RoleGeomodelLabels:
-				updated.BirdNET.RangeFilter.LabelsPath = filepath.Join(mm.modelsDir, "shared", f.LocalName)
+				updated.BirdNET.RangeFilter.LabelsPath = filepath.Join(mm.modelsDir, sharedDirName, f.LocalName)
 			}
 		}
 	}
@@ -2142,15 +2145,6 @@ func (mm *ModelManager) applyConfigForUninstall(entry *CatalogEntry) {
 	retainAlias := false
 
 	switch entry.RegistryID {
-	case RegistryIDBirdNETV3:
-		updated.BirdNETV3.ModelPath = ""
-		updated.BirdNETV3.LabelPath = ""
-	case RegistryIDPerchV2:
-		updated.Perch.ModelPath = ""
-		updated.Perch.LabelPath = ""
-	case RegistryIDBSG:
-		updated.BSG.ModelPath = ""
-		updated.BSG.LabelPath = ""
 	case RegistryIDBat:
 		// Find another installed bat model to re-point config to.
 		var replacement *InstalledModel
@@ -2174,9 +2168,20 @@ func (mm *ModelManager) applyConfigForUninstall(entry *CatalogEntry) {
 			updated.Bat.EmbeddingModel = ""
 			for _, f := range replacementEntry.Files {
 				if f.Role == RoleEmbeddings {
-					updated.Bat.EmbeddingModel = filepath.Join(mm.modelsDir, "shared", f.LocalName)
+					updated.Bat.EmbeddingModel = filepath.Join(mm.modelsDir, sharedDirName, f.LocalName)
 					break
 				}
+			}
+		}
+	default:
+		// The single-model families (Perch, BirdNET v3.0, BSG) just clear their
+		// paths; familyPathFields is the single source of that mapping. The primary
+		// is never uninstalled (Uninstall refuses permanentRegistryID) and an unknown
+		// registry ID yields ok=false, so both are safely no-ops here.
+		if model, labels, _, ok := familyPathFields(updated, entry.RegistryID); ok {
+			*model = ""
+			if labels != nil {
+				*labels = ""
 			}
 		}
 	}

--- a/internal/classifier/model_manager_downloadstate_test.go
+++ b/internal/classifier/model_manager_downloadstate_test.go
@@ -1,0 +1,41 @@
+package classifier
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestDownloadStateIsActive pins the failed-download follow-up: only a genuinely
+// in-progress
+// download suppresses the not-analyzing alarm. A FAILED state is retained for
+// failedStateRetention so SSE pollers can observe it, but the model is NOT
+// analyzing during that window, so IsActive must report false for it (and for the
+// terminal complete/removed states, and a nil receiver).
+func TestDownloadStateIsActive(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		status string
+		want   bool
+	}{
+		{StatusDownloading, true},
+		{StatusVerifying, true},
+		{StatusLoading, true},
+		{StatusFailed, false},
+		{StatusComplete, false},
+		{StatusRemoved, false},
+		{"", false},
+		{"bogus", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			t.Parallel()
+			s := &DownloadState{Status: tt.status}
+			assert.Equal(t, tt.want, s.IsActive())
+		})
+	}
+
+	var nilState *DownloadState
+	assert.False(t, nilState.IsActive(), "a nil download state is not active")
+}

--- a/internal/classifier/model_manager_family_fields_test.go
+++ b/internal/classifier/model_manager_family_fields_test.go
@@ -1,0 +1,73 @@
+package classifier
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// TestFamilyPathFields pins the single family-to-settings-field mapping, including
+// the primary's model-only contract (nil labels/embeddings so planPathCorrection
+// can never rewrite BirdNET.LabelPath) and BSG, which an earlier copy of this
+// switch omitted.
+func TestFamilyPathFields(t *testing.T) {
+	t.Parallel()
+
+	s := &conf.Settings{}
+	s.BirdNET.ModelPath = "primary.tflite"
+	s.BirdNET.LabelPath = "user-labels.txt"
+	s.Perch.ModelPath = "perch.onnx"
+	s.Perch.LabelPath = "perch-labels.txt"
+	s.BirdNETV3.ModelPath = "v3.onnx"
+	s.BirdNETV3.LabelPath = "v3-labels.txt"
+	s.BSG.ModelPath = "bsg.onnx"
+	s.BSG.LabelPath = "bsg-labels.txt"
+	s.Bat.ClassifierModel = "bat.onnx"
+	s.Bat.LabelPath = "bat-labels.txt"
+	s.Bat.EmbeddingModel = "bat-emb.onnx"
+
+	t.Run("primary is model-only", func(t *testing.T) {
+		t.Parallel()
+		model, labels, emb, ok := familyPathFields(s, permanentRegistryID)
+		assert.True(t, ok)
+		assert.Same(t, &s.BirdNET.ModelPath, model)
+		assert.Nil(t, labels, "the primary's label set is embedded; LabelPath must never be rewritten")
+		assert.Nil(t, emb)
+	})
+
+	t.Run("perch has model+labels, no embeddings", func(t *testing.T) {
+		t.Parallel()
+		model, labels, emb, ok := familyPathFields(s, RegistryIDPerchV2)
+		assert.True(t, ok)
+		assert.Same(t, &s.Perch.ModelPath, model)
+		assert.Same(t, &s.Perch.LabelPath, labels)
+		assert.Nil(t, emb)
+	})
+
+	t.Run("bsg is mapped (the field an earlier switch omitted)", func(t *testing.T) {
+		t.Parallel()
+		model, labels, emb, ok := familyPathFields(s, RegistryIDBSG)
+		assert.True(t, ok)
+		assert.Same(t, &s.BSG.ModelPath, model)
+		assert.Same(t, &s.BSG.LabelPath, labels)
+		assert.Nil(t, emb)
+	})
+
+	t.Run("bat carries all three", func(t *testing.T) {
+		t.Parallel()
+		model, labels, emb, ok := familyPathFields(s, RegistryIDBat)
+		assert.True(t, ok)
+		assert.Same(t, &s.Bat.ClassifierModel, model)
+		assert.Same(t, &s.Bat.LabelPath, labels)
+		assert.Same(t, &s.Bat.EmbeddingModel, emb)
+	})
+
+	t.Run("unknown registry and nil settings are not ok", func(t *testing.T) {
+		t.Parallel()
+		_, _, _, ok := familyPathFields(s, "NoSuchModel")
+		assert.False(t, ok)
+		_, _, _, okNil := familyPathFields(nil, RegistryIDPerchV2)
+		assert.False(t, okNil)
+	})
+}

--- a/internal/classifier/model_manager_family_fields_test.go
+++ b/internal/classifier/model_manager_family_fields_test.go
@@ -10,7 +10,8 @@ import (
 // TestFamilyPathFields pins the single family-to-settings-field mapping, including
 // the primary's model-only contract (nil labels/embeddings so planPathCorrection
 // can never rewrite BirdNET.LabelPath) and BSG, which an earlier copy of this
-// switch omitted.
+// switch omitted. Table-driven so a new family mapping is a single row and cannot
+// silently omit an assertion.
 func TestFamilyPathFields(t *testing.T) {
 	t.Parallel()
 
@@ -27,47 +28,88 @@ func TestFamilyPathFields(t *testing.T) {
 	s.Bat.LabelPath = "bat-labels.txt"
 	s.Bat.EmbeddingModel = "bat-emb.onnx"
 
-	t.Run("primary is model-only", func(t *testing.T) {
-		t.Parallel()
-		model, labels, emb, ok := familyPathFields(s, permanentRegistryID)
-		assert.True(t, ok)
-		assert.Same(t, &s.BirdNET.ModelPath, model)
-		assert.Nil(t, labels, "the primary's label set is embedded; LabelPath must never be rewritten")
-		assert.Nil(t, emb)
-	})
+	// wantModel/wantLabels/wantEmbeddings are the exact field addresses the accessor
+	// must return (nil = the family has no such field and it must never be written).
+	tests := []struct {
+		name           string
+		registryID     string
+		wantModel      *string
+		wantLabels     *string
+		wantEmbeddings *string
+		wantOK         bool
+	}{
+		{
+			name:       "primary is model-only (nil labels protects the embedded label set)",
+			registryID: permanentRegistryID,
+			wantModel:  &s.BirdNET.ModelPath,
+			wantOK:     true,
+		},
+		{
+			name:       "perch has model+labels, no embeddings",
+			registryID: RegistryIDPerchV2,
+			wantModel:  &s.Perch.ModelPath,
+			wantLabels: &s.Perch.LabelPath,
+			wantOK:     true,
+		},
+		{
+			name:       "birdnet v3 has model+labels, no embeddings",
+			registryID: RegistryIDBirdNETV3,
+			wantModel:  &s.BirdNETV3.ModelPath,
+			wantLabels: &s.BirdNETV3.LabelPath,
+			wantOK:     true,
+		},
+		{
+			name:       "bsg is mapped (the field an earlier switch omitted)",
+			registryID: RegistryIDBSG,
+			wantModel:  &s.BSG.ModelPath,
+			wantLabels: &s.BSG.LabelPath,
+			wantOK:     true,
+		},
+		{
+			name:           "bat carries all three",
+			registryID:     RegistryIDBat,
+			wantModel:      &s.Bat.ClassifierModel,
+			wantLabels:     &s.Bat.LabelPath,
+			wantEmbeddings: &s.Bat.EmbeddingModel,
+			wantOK:         true,
+		},
+		{
+			name:       "unknown registry yields no fields",
+			registryID: "NoSuchModel",
+			wantOK:     false,
+		},
+	}
 
-	t.Run("perch has model+labels, no embeddings", func(t *testing.T) {
-		t.Parallel()
-		model, labels, emb, ok := familyPathFields(s, RegistryIDPerchV2)
-		assert.True(t, ok)
-		assert.Same(t, &s.Perch.ModelPath, model)
-		assert.Same(t, &s.Perch.LabelPath, labels)
-		assert.Nil(t, emb)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			// s is only read (familyPathFields returns pointers into it, never
+			// mutates), so sharing it across parallel subtests is safe.
+			model, labels, embeddings, ok := familyPathFields(s, tt.registryID)
+			assert.Equal(t, tt.wantOK, ok)
+			assertSameOrNil(t, tt.wantModel, model, "model")
+			assertSameOrNil(t, tt.wantLabels, labels, "labels")
+			assertSameOrNil(t, tt.wantEmbeddings, embeddings, "embeddings")
+		})
+	}
 
-	t.Run("bsg is mapped (the field an earlier switch omitted)", func(t *testing.T) {
+	t.Run("nil settings is not ok", func(t *testing.T) {
 		t.Parallel()
-		model, labels, emb, ok := familyPathFields(s, RegistryIDBSG)
-		assert.True(t, ok)
-		assert.Same(t, &s.BSG.ModelPath, model)
-		assert.Same(t, &s.BSG.LabelPath, labels)
-		assert.Nil(t, emb)
-	})
-
-	t.Run("bat carries all three", func(t *testing.T) {
-		t.Parallel()
-		model, labels, emb, ok := familyPathFields(s, RegistryIDBat)
-		assert.True(t, ok)
-		assert.Same(t, &s.Bat.ClassifierModel, model)
-		assert.Same(t, &s.Bat.LabelPath, labels)
-		assert.Same(t, &s.Bat.EmbeddingModel, emb)
-	})
-
-	t.Run("unknown registry and nil settings are not ok", func(t *testing.T) {
-		t.Parallel()
-		_, _, _, ok := familyPathFields(s, "NoSuchModel")
+		model, labels, embeddings, ok := familyPathFields(nil, RegistryIDPerchV2)
 		assert.False(t, ok)
-		_, _, _, okNil := familyPathFields(nil, RegistryIDPerchV2)
-		assert.False(t, okNil)
+		assert.Nil(t, model)
+		assert.Nil(t, labels)
+		assert.Nil(t, embeddings)
 	})
+}
+
+// assertSameOrNil asserts got is exactly the expected field address, or nil when
+// the family has no such field.
+func assertSameOrNil(t *testing.T, want, got *string, field string) {
+	t.Helper()
+	if want == nil {
+		assert.Nil(t, got, "%s pointer must be nil for a family without that field", field)
+		return
+	}
+	assert.Same(t, want, got, "%s pointer must be the settings field's own address", field)
 }

--- a/internal/classifier/model_manager_replace_test.go
+++ b/internal/classifier/model_manager_replace_test.go
@@ -372,7 +372,37 @@ func TestInstalledModelBasenameHint(t *testing.T) {
 
 	s := &conf.Settings{}
 	s.Perch.ModelPath = "/models/perch-v2/perch_v2_int8_arm.onnx"
-	assert.Equal(t, "perch_v2_int8_arm.onnx", installedModelBasenameHint(s, RegistryIDPerchV2))
-	assert.Empty(t, installedModelBasenameHint(s, RegistryIDBirdNETV3), "a family with no recorded path yields no hint")
-	assert.Empty(t, installedModelBasenameHint(nil, RegistryIDPerchV2), "nil settings yields no hint")
+	assert.Equal(t, "perch_v2_int8_arm.onnx", installedModelBasenameHint(s, RegistryIDPerchV2, nil))
+	assert.Empty(t, installedModelBasenameHint(s, RegistryIDBirdNETV3, nil), "a family with no recorded path yields no hint")
+	assert.Empty(t, installedModelBasenameHint(nil, RegistryIDPerchV2, nil), "nil settings yields no hint")
+}
+
+// TestInstalledModelBasenameHint_PrefersLoadedPath pins the stale-variant
+// follow-up: after a
+// stale-path recovery the settings field still names the pre-recovery variant, so
+// the gallery scan must key off the file the LOADED instance is actually running,
+// not config.
+func TestInstalledModelBasenameHint_PrefersLoadedPath(t *testing.T) {
+	t.Parallel()
+
+	s := &conf.Settings{}
+	// Config still points at the stale, pre-recovery variant.
+	s.Perch.ModelPath = "/stale/perch_v2_fp32.onnx"
+
+	// A loaded instance whose resolved path is the RECOVERED variant wins over the
+	// stale config: the scan must report the running variant.
+	loaded := map[string]string{RegistryIDPerchV2: "/models/perch-v2/perch_v2_int8_arm.onnx"}
+	assert.Equal(t, "perch_v2_int8_arm.onnx", installedModelBasenameHint(s, RegistryIDPerchV2, loaded),
+		"the loaded instance's resolved path wins over the stale configured path")
+
+	// A loaded instance running the built-in (empty resolved path) yields no hint
+	// even though config still names a file: present-but-empty is authoritative.
+	builtin := map[string]string{RegistryIDPerchV2: ""}
+	assert.Empty(t, installedModelBasenameHint(s, RegistryIDPerchV2, builtin),
+		"a loaded instance running the built-in yields no hint, not a fallback to the stale config")
+
+	// A family ABSENT from the loaded map (no instance loaded: startup scan, or a
+	// family the user disabled) falls back to the configured value.
+	assert.Equal(t, "perch_v2_fp32.onnx", installedModelBasenameHint(s, RegistryIDPerchV2, map[string]string{}),
+		"with no loaded instance the hint falls back to the configured field")
 }

--- a/internal/classifier/model_path_reconcile.go
+++ b/internal/classifier/model_path_reconcile.go
@@ -133,16 +133,33 @@ func (o *Orchestrator) runPendingPathCorrections() {
 	o.pendingPathCorrections = nil
 	o.mu.Unlock()
 
-	for i := range pending {
-		o.applyPathCorrection(&pending[i])
-	}
+	o.applyPathCorrections(pending)
 }
 
 // applyPathCorrection rewrites one family's stale gallery paths in settings and
-// persists them, using the clone-mutate-publish protocol every other settings
-// writer follows. It serializes against ModelManager's install/uninstall config
-// writers through the package-level settingsWriteMu.
+// persists them. It is a thin single-family wrapper over applyPathCorrections so
+// the drain and the tests share one code path.
 func (o *Orchestrator) applyPathCorrection(pc *pendingPathCorrection) {
+	o.applyPathCorrections([]pendingPathCorrection{*pc})
+}
+
+// applyPathCorrections drains a batch of queued corrections under ONE settings
+// clone/store/save, using the clone-mutate-publish protocol every other settings
+// writer follows and serializing against ModelManager's install/uninstall config
+// writers through the package-level settingsWriteMu.
+//
+// Coalescing the batch is deliberate. Rewriting per family (one StoreSettings +
+// SaveSettings each) republished config.yaml once per stale family, so a start
+// that had, say, the primary and two secondaries stale would publish a sequence of
+// snapshots in which some families were repaired and others still stale, and a
+// concurrent reader could observe a half-repaired configuration. One clone threaded
+// across every rewriting family, then a single store+save, publishes the repaired
+// configuration atomically. Notifications are emitted per family after the write.
+func (o *Orchestrator) applyPathCorrections(pending []pendingPathCorrection) {
+	if len(pending) == 0 {
+		return
+	}
+
 	settingsWriteMu.Lock()
 	defer settingsWriteMu.Unlock()
 
@@ -157,72 +174,91 @@ func (o *Orchestrator) applyPathCorrection(pc *pendingPathCorrection) {
 
 	if pathCorrectionPersistenceDisabled.Load() {
 		// A read-only diagnostic command (benchmark, rangefilter print) is running.
-		// The model already loaded from the runtime fallback, so analysis works; we
+		// The models already loaded from the runtime fallback, so analysis works; we
 		// only skip rewriting config.yaml and any user-facing notification, so the
 		// command leaves no side effect on the user's configuration.
-		GetLogger().Info("stale model path resolved via fallback; persistence disabled, leaving config.yaml untouched",
-			logger.String("registry_id", pc.registryID),
-			logger.String("resolved_model_path", pc.resolved.model))
+		for i := range pending {
+			GetLogger().Info("stale model path resolved via fallback; persistence disabled, leaving config.yaml untouched",
+				logger.String("registry_id", pending[i].registryID),
+				logger.String("resolved_model_path", pending[i].resolved.model))
+		}
 		return
 	}
 
-	updated, outcome := o.planPathCorrection(current, pc)
+	// Thread ONE snapshot through every rewriting family. planPathCorrection clones
+	// the snapshot it is given and returns the clone; feeding the previous rewrite
+	// forward accumulates every family's repair into a single snapshot, since the
+	// families touch disjoint settings fields. rolling ends as current when nothing
+	// rewrote, so no store happens.
+	rolling := current
+	var rewritten, substituted []*pendingPathCorrection
+	for i := range pending {
+		pc := &pending[i]
+		updated, outcome := o.planPathCorrection(rolling, pc)
+		switch outcome {
+		case correctionNoop:
+			// The configured paths already match what the model was built from.
+		case correctionRewrite:
+			if updated == nil {
+				// Defensive: correctionRewrite always carries a snapshot. Skipping keeps
+				// a nil out of StoreSettings, which would publish a nil process-wide.
+				GetLogger().Warn("path-correction rewrite produced no settings snapshot; skipping family",
+					logger.String("registry_id", pc.registryID))
+				continue
+			}
+			rolling = updated
+			rewritten = append(rewritten, pc)
+		case correctionSubstituted:
+			// The model is running a DIFFERENT (installed) model than the user
+			// configured, and the configuration was deliberately left alone: either the
+			// configured path is user-owned, or the failure to read it was not a
+			// confirmed absence and must not be persisted. This would otherwise be
+			// entirely silent, since the reconciled notification fires only when config
+			// was rewritten. Tell the user, after the batch write below.
+			substituted = append(substituted, pc)
+		case correctionUnknownFamily:
+			// No settings mapping for this registry ID. Distinct from
+			// correctionSubstituted on purpose: a substitution did happen, but the thing
+			// at fault is the SELF-HEAL (no settings mapping for this family), not the
+			// user's configuration, so this is developer-facing and never a user warning.
+			GetLogger().Warn("no settings mapping for model family; skipping path correction",
+				logger.String("registry_id", pc.registryID))
+		default:
+			// Not reachable today. Guarded anyway because the write below is the only
+			// destructive action in this file: an outcome nobody enumerated must never
+			// reach it by falling out of the switch.
+			GetLogger().Warn("unrecognised path-correction outcome; not writing configuration",
+				logger.String("registry_id", pc.registryID),
+				logger.Int("outcome", int(outcome)))
+		}
+	}
 
-	switch outcome {
-	case correctionNoop:
-		// The configured paths already match what the model was built from. Nothing
-		// to write and nothing to say.
-		return
-	case correctionSubstituted:
-		// The model is running a DIFFERENT (installed) model than the user
-		// configured, and the configuration was deliberately left alone: either the
-		// configured path is user-owned, or the failure to read it was not a
-		// confirmed absence and must not be persisted. Either way this would
-		// otherwise be entirely silent, since emitPathReconciledNotification fires
-		// only when config was rewritten. Tell the user instead.
+	saved := false
+	if len(rewritten) > 0 {
+		conf.StoreSettings(rolling)
+		if err := conf.SaveSettings(); err != nil {
+			// The in-memory snapshot still carries the corrected paths, so the running
+			// process is consistent; only the repair's persistence is lost, and the
+			// next start repeats the fallback and tries again. Withhold the reconciled
+			// notifications, since config was not actually saved.
+			GetLogger().Warn("failed to persist repaired model paths",
+				logger.Error(err))
+		} else {
+			saved = true
+		}
+	}
+
+	if saved {
+		for _, pc := range rewritten {
+			emitPathReconciledNotification(pc.registryID, pc.resolved.model)
+		}
+	}
+	// Substituted families are independent of the rewrite save: their configuration
+	// was never going to be written, so they are told regardless of whether another
+	// family's save succeeded.
+	for _, pc := range substituted {
 		emitPathSubstitutedNotification(pc)
-		return
-	case correctionUnknownFamily:
-		// No settings mapping for this registry ID, so there is nothing to plan.
-		// Distinct from correctionSubstituted on purpose: a substitution did happen,
-		// but the thing at fault is the SELF-HEAL (no settings mapping for this
-		// family), not the user's configuration, so this is a developer-facing log
-		// and never a user-facing warning.
-		GetLogger().Warn("no settings mapping for model family; skipping path correction",
-			logger.String("registry_id", pc.registryID))
-		return
-	case correctionRewrite:
-		// Fall through to the write below.
-	default:
-		// Not reachable today. Guarded anyway because the write below is the only
-		// destructive action in this file: an outcome nobody enumerated must never
-		// reach it by falling out of the switch.
-		GetLogger().Warn("unrecognised path-correction outcome; not writing configuration",
-			logger.String("registry_id", pc.registryID),
-			logger.Int("outcome", int(outcome)))
-		return
 	}
-
-	if updated == nil {
-		// Defensive: correctionRewrite always carries a snapshot. StoreSettings(nil)
-		// would publish a nil settings pointer process-wide.
-		GetLogger().Warn("path-correction rewrite produced no settings snapshot; skipping write",
-			logger.String("registry_id", pc.registryID))
-		return
-	}
-
-	conf.StoreSettings(updated)
-	if err := conf.SaveSettings(); err != nil {
-		// The in-memory snapshot still carries the corrected paths, so the running
-		// process is consistent; only the repair's persistence is lost, and the
-		// next start repeats the fallback and tries again.
-		GetLogger().Warn("failed to persist repaired model paths",
-			logger.String("registry_id", pc.registryID),
-			logger.Error(err))
-		return
-	}
-
-	emitPathReconciledNotification(pc.registryID, pc.resolved.model)
 }
 
 // correctionOutcome is what applyPathCorrection should DO with a planned
@@ -274,40 +310,25 @@ func (o *Orchestrator) planPathCorrection(current *conf.Settings, pc *pendingPat
 		resolved string
 	}
 
-	var fields []fieldCorrection
-	switch pc.registryID {
-	case permanentRegistryID:
-		// The primary BirdNET v2.4 slot carries ONE gallery-managed path. Its label
-		// set is embedded and identical across variants, which is why
-		// applyConfigForPrimarySwap sets BirdNET.ModelPath alone and documents that
-		// it never touches BirdNET.LabelPath: a user-configured custom label path
-		// must survive a variant swap. Repairing LabelPath here would break that
-		// contract, so the primary family is deliberately model-only.
-		fields = []fieldCorrection{
-			{&updated.BirdNET.ModelPath, pc.resolved.model},
-		}
-	case RegistryIDPerchV2:
-		fields = []fieldCorrection{
-			{&updated.Perch.ModelPath, pc.resolved.model},
-			{&updated.Perch.LabelPath, pc.resolved.labels},
-		}
-	case RegistryIDBirdNETV3:
-		fields = []fieldCorrection{
-			{&updated.BirdNETV3.ModelPath, pc.resolved.model},
-			{&updated.BirdNETV3.LabelPath, pc.resolved.labels},
-		}
-	case RegistryIDBat:
-		// The bat family carries three paths; the shared embedding extractor is
-		// part of the set and goes stale with the rest.
-		fields = []fieldCorrection{
-			{&updated.Bat.ClassifierModel, pc.resolved.model},
-			{&updated.Bat.LabelPath, pc.resolved.labels},
-			{&updated.Bat.EmbeddingModel, pc.resolved.embeddings},
-		}
-	default:
+	// familyPathFields is the single source of truth for the family-to-settings-field
+	// mapping. A nil labels/embeddings pointer means the family has no such field and
+	// it must NOT be written: the primary is deliberately model-only (its label set
+	// is embedded and identical across variants, which is why applyConfigForPrimarySwap
+	// writes BirdNET.ModelPath alone and a user-configured BirdNET.LabelPath must
+	// survive a variant swap), and every family but bat carries no embeddings path.
+	model, labels, embeddings, ok := familyPathFields(updated, pc.registryID)
+	if !ok {
 		// Unknown registry: nothing to plan. Return nil rather than current so no
 		// caller can mutate the live published snapshot through the result.
 		return nil, correctionUnknownFamily
+	}
+	fields := make([]fieldCorrection, 0, 3)
+	fields = append(fields, fieldCorrection{model, pc.resolved.model})
+	if labels != nil {
+		fields = append(fields, fieldCorrection{labels, pc.resolved.labels})
+	}
+	if embeddings != nil {
+		fields = append(fields, fieldCorrection{embeddings, pc.resolved.embeddings})
 	}
 
 	// A substitution that is not repairable must never reach the field loop: the

--- a/internal/classifier/model_path_resolution.go
+++ b/internal/classifier/model_path_resolution.go
@@ -348,7 +348,7 @@ func (o *Orchestrator) resolveSiblingSet(registryID, modelPath string) (set mode
 					candidate.labels = filepath.Join(dir, f.LocalName)
 				case RoleEmbeddings:
 					if modelsDir != "" {
-						candidate.embeddings = filepath.Join(modelsDir, "shared", f.LocalName)
+						candidate.embeddings = filepath.Join(modelsDir, sharedDirName, f.LocalName)
 					}
 				}
 			}
@@ -449,7 +449,7 @@ func (o *Orchestrator) isGalleryManagedPath(registryID, path string) bool {
 				}
 				expectedParent := entry.ID
 				if isSharedRole(f.Role) {
-					expectedParent = "shared"
+					expectedParent = sharedDirName
 				}
 				if parent == expectedParent {
 					return true

--- a/internal/classifier/model_path_resolution.go
+++ b/internal/classifier/model_path_resolution.go
@@ -48,32 +48,40 @@ func (s modelFileSet) allPresentOnDisk(needEmbeddings bool) bool {
 	return true
 }
 
-// diskPresence classifies the on-disk state of a required member set. It
-// separates a member that is confirmed absent (fs.ErrNotExist), which marks the
-// configured set stale and worth repairing, from a member that could not be
-// stat'd for another reason (EACCES, EIO, a stale NFS handle, a half-initialised
-// mount that reports EIO). The latter must not trigger a permanent config
-// rewrite, because the file may well reappear.
+// presenceResult classifies the on-disk state of a required member set as two
+// INDEPENDENT facts rather than one ranked enum, because a set can be both at once
+// (one member confirmed gone, another merely unreadable) and the two facts drive
+// two different decisions that must not be collapsed:
+//
+//   - missing is true when at least one non-empty required member is CONFIRMED
+//     absent (fs.ErrNotExist). This is what makes the configured set stale and, on
+//     its own, worth repairing.
+//   - unreadable is true when at least one non-empty required member could not be
+//     stat'd for a reason OTHER than absence (EACCES, EIO, a stale NFS handle, a
+//     half-initialised mount). The file may well reappear, so it must never trigger
+//     a permanent config rewrite.
+//
+// PERSISTENCE keys on unreadable: while any member is merely unreadable the repair
+// is withheld (repairable = missing && !unreadable), so a slow-to-mount volume is
+// never persisted as a stale path. WORDING keys on missing: a set with a
+// confirmed-absent member is "not found", never "exists but could not be read",
+// even when another member is also unreadable (the unreadable notification flag is
+// unreadable && !missing). Keeping the two facts separate is what lets a set that
+// is BOTH be reported honestly: withhold the rewrite AND tell the
+// user a file is missing.
 //
 // Note the boundary: a FULLY unmounted path reports ErrNotExist, not one of the
-// above, so it classifies as presenceMissing (repairable), NOT indeterminate.
-// The guard against that rewriting a user's own path is the gallery-layout
-// requirement in isGalleryManagedPath, not this classification.
-type diskPresence int
+// above, so it classifies as missing (repairable), NOT unreadable. The guard
+// against that rewriting a user's own path is the gallery-layout requirement in
+// isGalleryManagedPath, not this classification.
+type presenceResult struct {
+	missing    bool
+	unreadable bool
+}
 
-const (
-	// presenceComplete means every non-empty required member exists on disk.
-	presenceComplete diskPresence = iota
-	// presenceMissing means at least one non-empty required member is confirmed
-	// absent (fs.ErrNotExist) and no member was indeterminate.
-	presenceMissing
-	// presenceIndeterminate means at least one non-empty required member could
-	// not be stat'd for a reason OTHER than absence (a permissions failure, an I/O
-	// error, a half-initialised mount reporting EIO). It dominates presenceMissing
-	// so a transient error is never mistaken for a stale path. A fully unmounted
-	// path reports ErrNotExist and is therefore presenceMissing, not this.
-	presenceIndeterminate
-)
+// complete reports that every non-empty required member exists on disk (neither
+// missing nor unreadable).
+func (p presenceResult) complete() bool { return !p.missing && !p.unreadable }
 
 // pathResolution carries resolveFamilyPaths' outcome out of a model builder so
 // the loader can act on it without resolving a second time.
@@ -100,7 +108,7 @@ type pathResolution struct {
 	// repairable reports that the substitution came from a CONFIRMED absence
 	// (ErrNotExist), so the stale configuration MAY be rewritten. It is never true
 	// unless substituted is also true. A member that is unreadable for some OTHER
-	// reason (presenceIndeterminate: a permissions failure, an I/O error, a
+	// reason (unreadable: a permissions failure, an I/O error, a
 	// half-initialised mount) is substituted but NOT repairable, so a transient
 	// failure never rewrites config.yaml permanently.
 	repairable bool
@@ -121,32 +129,30 @@ type pathResolution struct {
 // configured path (fill it from the gallery, keep the rest) from a stale one (a
 // non-empty path that has gone missing, which makes the whole set stale).
 //
-// A member that is unreadable for a reason other than absence yields
-// presenceIndeterminate, which dominates: a single unreadable member classifies
-// the whole set as indeterminate so a slow-to-mount volume is never mistaken for
-// a stale configuration.
-func (s modelFileSet) nonEmptyMembersPresence(needEmbeddings bool) diskPresence {
+// Every member is stat'd and BOTH facts are recorded: the scan does not stop at the
+// first unreadable member, because a later member may be confirmed absent, and a
+// set with a confirmed-absent member must be reported as missing (for the wording)
+// even while its unreadable member withholds the config rewrite (for persistence).
+// See presenceResult for why the two are kept separate rather than ranked.
+func (s modelFileSet) nonEmptyMembersPresence(needEmbeddings bool) presenceResult {
 	paths := []string{s.model, s.labels}
 	if needEmbeddings {
 		paths = append(paths, s.embeddings)
 	}
-	sawMissing := false
+	var res presenceResult
 	for _, p := range paths {
 		if p == "" {
 			continue
 		}
 		if _, err := os.Stat(p); err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
-				sawMissing = true
+				res.missing = true
 				continue
 			}
-			return presenceIndeterminate
+			res.unreadable = true
 		}
 	}
-	if sawMissing {
-		return presenceMissing
-	}
-	return presenceComplete
+	return res
 }
 
 // resolveFamilyPaths decides which file set a secondary model family should be
@@ -184,7 +190,7 @@ func (o *Orchestrator) resolveFamilyPaths(registryID string, configured modelFil
 	// empty members from the gallery (main's behaviour). Neither flag is set:
 	// nothing configured went stale, so there is nothing to repair and nothing the
 	// user chose was replaced.
-	if presence == presenceComplete {
+	if presence.complete() {
 		if configured.complete(needEmbeddings) {
 			return pathResolution{resolved: configured}
 		}
@@ -220,17 +226,20 @@ func (o *Orchestrator) resolveFamilyPaths(registryID string, configured modelFil
 		return pathResolution{resolved: filled}
 	}
 
-	// A non-empty configured path is missing or unreadable. Only a CONFIRMED
-	// absence (presenceMissing) marks the set stale and may rewrite config; a
-	// member that is unreadable for a reason OTHER than absence
-	// (presenceIndeterminate: a permissions failure, an I/O error, a
-	// half-initialised mount reporting EIO) still falls back at runtime so
-	// analysis can run, but must NOT persist a repair, or a transient error
-	// rewrites config.yaml permanently. repairable carries that distinction to
-	// both fallback returns below. (A fully unmounted path reports ErrNotExist, so
-	// it is presenceMissing here; isGalleryManagedPath is what stops that rewrite
-	// from taking over a user's own path.)
-	repairable := presence == presenceMissing
+	// A non-empty configured path is missing or unreadable. The repair may rewrite
+	// config only for a CONFIRMED absence with NO member merely unreadable: a member
+	// that could not be read for a reason OTHER than absence (a permissions failure,
+	// an I/O error, a half-initialised mount reporting EIO) may still reappear, so a
+	// set that has ANY such member still falls back at runtime so analysis can run
+	// but must NOT persist a repair, or a transient error rewrites config.yaml
+	// permanently. repairable carries that distinction to both fallback returns
+	// below; the unreadable-for-wording flag (unreadable && !missing) is set only
+	// when NOTHING is confirmed absent, so a set with a missing member is reported
+	// "not found" rather than "could not be read". (A fully unmounted path reports
+	// ErrNotExist, so it is missing here; isGalleryManagedPath is what stops that
+	// rewrite from taking over a user's own path.)
+	repairable := presence.missing && !presence.unreadable
+	unreadableWording := presence.unreadable && !presence.missing
 
 	// Before the generic gallery probe, try to keep the variant the configured
 	// model file names. When only a companion file went missing (a partial
@@ -244,7 +253,7 @@ func (o *Orchestrator) resolveFamilyPaths(registryID string, configured modelFil
 		GetLogger().Debug("recovered the configured variant's companion files",
 			logger.String("registry_id", registryID),
 			logger.String("model_path", sameVariant.model))
-		return pathResolution{resolved: sameVariant, substituted: true, repairable: repairable, unreadable: presence == presenceIndeterminate}
+		return pathResolution{resolved: sameVariant, substituted: true, repairable: repairable, unreadable: unreadableWording}
 	}
 
 	m, l, e := o.resolveInstalledPaths(registryID)
@@ -267,7 +276,7 @@ func (o *Orchestrator) resolveFamilyPaths(registryID string, configured modelFil
 		logger.String("configured_model_path", configured.model),
 		logger.String("resolved_model_path", fallback.model))
 
-	return pathResolution{resolved: fallback, substituted: true, repairable: repairable, unreadable: presence == presenceIndeterminate}
+	return pathResolution{resolved: fallback, substituted: true, repairable: repairable, unreadable: unreadableWording}
 }
 
 // resolveSiblingSet rebuilds a family's complete file set from the variant that
@@ -291,7 +300,7 @@ func (o *Orchestrator) resolveSiblingSet(registryID, modelPath string) (set mode
 		// error (an unreadable volume) is treated the same as absence here, so a
 		// half-mounted volume never yields a spurious sibling set. Suppressing the
 		// config repair for the merely-unreadable case is the caller's job, via the
-		// presenceIndeterminate classification from nonEmptyMembersPresence.
+		// unreadable classification from nonEmptyMembersPresence.
 		return modelFileSet{}, false
 	}
 
@@ -404,7 +413,7 @@ func (o *Orchestrator) isGalleryManagedPath(registryID, path string) bool {
 	// name, normally "models"). Matching only base + parent would qualify any path
 	// that merely MIRRORS the gallery layout, e.g. /mnt/nas/perch-v2/perch_v2.onnx:
 	// a NAS or USB mount that is late at boot yields ENOENT (the mountpoint exists
-	// but is empty), which classifies as presenceMissing with repairable=true, so a
+	// but is empty), which classifies as missing with repairable=true, so a
 	// user who moved their models to a NAS but left a local gallery copy would have
 	// the NAS path permanently rewritten. Dropping only the models-directory PREFIX
 	// (not its base name) still handles the changed-container-HOME case the issues

--- a/internal/classifier/model_path_resolution_test.go
+++ b/internal/classifier/model_path_resolution_test.go
@@ -426,6 +426,52 @@ func TestResolveFamilyPaths_IndeterminateFallsBackWithoutRepair(t *testing.T) {
 		"the queued correction must carry the do-not-rewrite verdict to the drain")
 }
 
+// TestResolveFamilyPaths_MissingAndUnreadableReportsNotFound pins the
+// missing-and-unreadable follow-up: a set with one member CONFIRMED absent and another merely unreadable
+// must withhold the config rewrite (unreadable dominates persistence) AND report
+// "not found" rather than "could not be read" (missing dominates the wording).
+// Before the two facts were separated, nonEmptyMembersPresence returned
+// indeterminate on the first non-ENOENT error regardless of the earlier confirmed
+// absence, so the user was told a file that is actually gone "exists but could not
+// be read".
+func TestResolveFamilyPaths_MissingAndUnreadableReportsNotFound(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("ENOTDIR-via-file-prefix is ERROR_PATH_NOT_FOUND on Windows, mapped to fs.ErrNotExist")
+	}
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+
+	modelsDir := t.TempDir()
+	installedModel := writeVariantModelFile(t, modelsDir, &entry, "fp32")
+	writeVariantLabelsFile(t, modelsDir, &entry, "fp32")
+
+	// A regular file used as a path prefix makes os.Stat return ENOTDIR (unreadable,
+	// not a confirmed absence). The model member sits under a real directory but is
+	// absent -> ENOENT (missing). The set is therefore BOTH missing and unreadable.
+	dir := t.TempDir()
+	regular := filepath.Join(dir, "not-a-dir")
+	require.NoError(t, os.WriteFile(regular, []byte("x"), 0o600))
+	mixed := modelFileSet{
+		model:  filepath.Join(dir, "perch_v2.onnx"),           // ENOENT -> missing
+		labels: filepath.Join(regular, "perch_v2_labels.txt"), // ENOTDIR -> unreadable
+	}
+
+	o := &Orchestrator{}
+	o.SetModelsDir(modelsDir)
+
+	res := o.resolveFamilyPaths(RegistryIDPerchV2, mixed, false)
+
+	assert.True(t, res.substituted, "the set fell back, so the substitution must be reported")
+	assert.Equal(t, installedModel, res.resolved.model, "analysis still runs from the installed model")
+	assert.False(t, res.repairable,
+		"an unreadable member withholds the config rewrite even though another member is confirmed absent")
+	assert.False(t, res.unreadable,
+		"a confirmed-absent member makes the wording 'not found', never 'could not be read'")
+}
+
 // TestApplyPathCorrection_UnreadableNotifiesWithoutRewriting is the other half of
 // the indeterminate case: the drain must tell the user AND leave config.yaml
 // byte-for-byte as they wrote it. Rewriting here would make a transient

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -762,6 +762,42 @@ func scientificNamesFromLabels(labels []string) []string {
 	return out
 }
 
+// PrimaryResolvedModelPath returns the model file the primary classifier is
+// actually running (empty when the built-in baseline runs, or when no primary is
+// loaded). Cross-package consumers must prefer it over settings.BirdNET.ModelPath,
+// which after a stale-path recovery names a file the instance is not running. The
+// o.primary read is guarded by o.mu; the resolved-path read itself is lock-free.
+func (o *Orchestrator) PrimaryResolvedModelPath() string {
+	o.mu.RLock()
+	primary := o.primary
+	o.mu.RUnlock()
+	if primary == nil {
+		return ""
+	}
+	return primary.ResolvedModelPath()
+}
+
+// LoadedModelPaths returns, for each currently-loaded model family (keyed by its
+// registry ID, which is also the o.models key), the model file that instance is
+// actually running. A family PRESENT in the map with an EMPTY value is loaded and
+// running its built-in/default source; a family ABSENT from the map has no loaded
+// instance. That distinction lets the model-gallery scan tell "loaded, running the
+// built-in" from "not loaded", so it consults configuration only for the latter.
+// Snapshotted under a single o.mu.RLock so a caller already
+// holding another lock (ModelManager.mu, taken by ScanInstalled) never nests o.mu
+// under it.
+func (o *Orchestrator) LoadedModelPaths() map[string]string {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	out := make(map[string]string, len(o.models))
+	for id, entry := range o.models {
+		if entry != nil && entry.instance != nil {
+			out[id] = entry.instance.ResolvedModelPath()
+		}
+	}
+	return out
+}
+
 // GetProbableSpecies returns species scores from the range filter.
 func (o *Orchestrator) GetProbableSpecies(date time.Time, week float32) ([]SpeciesScore, error) {
 	o.mu.RLock()

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -787,12 +787,39 @@ func (o *Orchestrator) PrimaryResolvedModelPath() string {
 // holding another lock (ModelManager.mu, taken by ScanInstalled) never nests o.mu
 // under it.
 func (o *Orchestrator) LoadedModelPaths() map[string]string {
+	// entry.instance is guarded by entry.mu, NOT o.mu: ReloadSecondaryModels,
+	// UnloadModel and Delete all swap it under entry.mu (see the "PredictModel reads
+	// entry.instance under entry.mu" contract at the reload swap), while o.mu guards
+	// only the o.models map itself. So snapshot the entries under o.mu, release it,
+	// then read each instance under its own entry.mu. This mirrors
+	// ReloadSecondaryModels (snapshot refs under o.mu, release, then per-entry
+	// entry.mu), and crucially never holds o.mu while acquiring entry.mu, so it adds
+	// no new lock-ordering edge.
+	type entryRef struct {
+		id    string
+		entry *modelEntry
+	}
 	o.mu.RLock()
-	defer o.mu.RUnlock()
-	out := make(map[string]string, len(o.models))
+	refs := make([]entryRef, 0, len(o.models))
 	for id, entry := range o.models {
-		if entry != nil && entry.instance != nil {
-			out[id] = entry.instance.ResolvedModelPath()
+		if entry != nil {
+			refs = append(refs, entryRef{id: id, entry: entry})
+		}
+	}
+	o.mu.RUnlock()
+
+	out := make(map[string]string, len(refs))
+	for _, r := range refs {
+		// Capture the instance under entry.mu, then call the lock-free
+		// ResolvedModelPath() on the captured value after releasing the lock: the
+		// resolved path is fixed at construction (secondaries) or published lock-free
+		// (the primary) and is not touched by Close(), so reading it off-lock on a
+		// captured instance is safe even if the entry is torn down concurrently.
+		r.entry.mu.Lock()
+		inst := r.entry.instance
+		r.entry.mu.Unlock()
+		if inst != nil {
+			out[r.id] = inst.ResolvedModelPath()
 		}
 	}
 	return out

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -393,7 +393,7 @@ func (o *Orchestrator) registerTaxonomyResolver(modelsDir string) {
 	}
 
 	log := GetLogger()
-	taxonomyPath := filepath.Join(modelsDir, "shared", "taxonomy.csv")
+	taxonomyPath := filepath.Join(modelsDir, sharedDirName, "taxonomy.csv")
 
 	locale := settings.BirdNET.Locale
 	// Load the resolver outside the lock; NewTaxonomyResolver does file I/O.
@@ -600,7 +600,7 @@ func (o *Orchestrator) resolveInstalledPaths(registryID string) (modelPath, labe
 				case RoleLabels:
 					lp = filepath.Join(subdir, f.LocalName)
 				case RoleEmbeddings:
-					ep = filepath.Join(o.modelsDir, "shared", f.LocalName)
+					ep = filepath.Join(o.modelsDir, sharedDirName, f.LocalName)
 				}
 			}
 			if mp != "" {

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -783,9 +783,11 @@ func (o *Orchestrator) PrimaryResolvedModelPath() string {
 // running its built-in/default source; a family ABSENT from the map has no loaded
 // instance. That distinction lets the model-gallery scan tell "loaded, running the
 // built-in" from "not loaded", so it consults configuration only for the latter.
-// Snapshotted under a single o.mu.RLock so a caller already
-// holding another lock (ModelManager.mu, taken by ScanInstalled) never nests o.mu
-// under it.
+// The model set is snapshotted under o.mu, which is then RELEASED before each
+// instance is read under its own entry.mu (see the body for why entry.instance
+// needs entry.mu). Because o.mu is never held while entry.mu is acquired, a caller
+// already holding another lock (ModelManager.mu, taken by ScanInstalled) never
+// causes o.mu to nest under it.
 func (o *Orchestrator) LoadedModelPaths() map[string]string {
 	// entry.instance is guarded by entry.mu, NOT o.mu: ReloadSecondaryModels,
 	// UnloadModel and Delete all swap it under entry.mu (see the "PredictModel reads

--- a/internal/classifier/orchestrator_memory_test.go
+++ b/internal/classifier/orchestrator_memory_test.go
@@ -14,11 +14,12 @@ import (
 
 // fakeInstance is a minimal ModelInstance for warm-up/RSS tests.
 type fakeInstance struct {
-	id         string
-	sampleRate int
-	clip       time.Duration
-	predictedN int
-	predictErr error
+	id           string
+	sampleRate   int
+	clip         time.Duration
+	predictedN   int
+	predictErr   error
+	resolvedPath string
 }
 
 func (f *fakeInstance) Predict(_ context.Context, samples [][]float32) ([]datastore.Results, error) {
@@ -39,6 +40,7 @@ func (f *fakeInstance) Close() error         { return nil }
 func (f *fakeInstance) RuntimeInfo() (device, backend, precision string) {
 	return deviceCPU, BackendONNX, ""
 }
+func (f *fakeInstance) ResolvedModelPath() string { return f.resolvedPath }
 
 func TestWarmupAndRecordRSS_RecordsNonNegativeDelta(t *testing.T) {
 	t.Parallel()

--- a/internal/classifier/orchestrator_reload_secondary_test.go
+++ b/internal/classifier/orchestrator_reload_secondary_test.go
@@ -30,9 +30,10 @@ const fakeModelVersion = "1.0"
 // reloadFakeModel is a ModelInstance that records Close calls so tests can assert
 // the old instance is torn down after a swap.
 type reloadFakeModel struct {
-	id      string
-	closes  atomic.Int32
-	onClose func()
+	id           string
+	closes       atomic.Int32
+	onClose      func()
+	resolvedPath string
 }
 
 func (m *reloadFakeModel) Predict(_ context.Context, _ [][]float32) ([]datastore.Results, error) {
@@ -54,6 +55,7 @@ func (m *reloadFakeModel) Close() error {
 func (m *reloadFakeModel) RuntimeInfo() (device, backend, precision string) {
 	return deviceCPU, BackendONNX, ""
 }
+func (m *reloadFakeModel) ResolvedModelPath() string { return m.resolvedPath }
 
 // registerTestSecondaryBuilder adds a builder under id for the duration of the
 // test, restoring the global map on cleanup. The map is a package global, so the

--- a/internal/classifier/orchestrator_test.go
+++ b/internal/classifier/orchestrator_test.go
@@ -17,14 +17,15 @@ import (
 
 // mockModelInstance implements ModelInstance for testing.
 type mockModelInstance struct {
-	id         string
-	spec       ModelSpec
-	labels     []string // optional; when nil a single default label is returned
-	device     string   // optional; when empty RuntimeInfo reports "CPU"
-	backend    string   // optional; reported verbatim by RuntimeInfo
-	precision  string   // optional; reported verbatim by RuntimeInfo
-	numSpecies int      // optional; when 0 NumSpecies reports a single default species
-	predict    func(ctx context.Context, samples [][]float32) ([]datastore.Results, error)
+	id           string
+	spec         ModelSpec
+	labels       []string // optional; when nil a single default label is returned
+	device       string   // optional; when empty RuntimeInfo reports "CPU"
+	backend      string   // optional; reported verbatim by RuntimeInfo
+	precision    string   // optional; reported verbatim by RuntimeInfo
+	resolvedPath string
+	numSpecies   int // optional; when 0 NumSpecies reports a single default species
+	predict      func(ctx context.Context, samples [][]float32) ([]datastore.Results, error)
 }
 
 func (m *mockModelInstance) Predict(ctx context.Context, samples [][]float32) ([]datastore.Results, error) {
@@ -60,6 +61,7 @@ func (m *mockModelInstance) RuntimeInfo() (device, backend, precision string) {
 	}
 	return device, m.backend, m.precision
 }
+func (m *mockModelInstance) ResolvedModelPath() string { return m.resolvedPath }
 
 // newTestOrchestrator creates an Orchestrator with mock models for unit testing.
 // It does not require real model files.

--- a/internal/classifier/perch_onnx.go
+++ b/internal/classifier/perch_onnx.go
@@ -45,6 +45,11 @@ type Perch struct {
 	// reported via RuntimeInfo().
 	backend   string
 	precision string
+	// modelPath is the model file this instance actually loaded from (the resolved
+	// path the loader built with, which after a stale-path recovery differs from the
+	// configured Perch.ModelPath). Set once at construction; reported via
+	// ResolvedModelPath().
+	modelPath string
 }
 
 // PerchConfig holds configuration for creating a Perch model instance.
@@ -149,6 +154,7 @@ func NewPerch(cfg *PerchConfig) (*Perch, error) {
 		device:     device,
 		backend:    backend,
 		precision:  precision,
+		modelPath:  cfg.ModelPath,
 	}, nil
 }
 
@@ -299,6 +305,10 @@ func (p *Perch) Labels() []string {
 func (p *Perch) RuntimeInfo() (device, backend, precision string) {
 	return p.device, p.backend, p.precision
 }
+
+// ResolvedModelPath returns the model file this Perch instance loaded from. Fixed
+// at construction, so the read needs no lock. Implements ModelInstance.
+func (p *Perch) ResolvedModelPath() string { return p.modelPath }
 
 // Close releases resources held by the Perch model.
 func (p *Perch) Close() error {

--- a/internal/classifier/primary_model_path_test.go
+++ b/internal/classifier/primary_model_path_test.go
@@ -406,6 +406,56 @@ func TestReloadModelInternal_RecoveredPathDoesNotVetoReload(t *testing.T) {
 	})
 }
 
+// TestReloadModelInternal_ClearingPathWhileCustomRunningIsRefused pins the
+// cleared-path follow-up (the MAJOR-3 silent-corruption path). When the user CLEARS
+// birdnet.modelpath while a custom primary model is running, the settings-reload
+// path must REFUSE and require an orchestrator restart, exactly as it does when a
+// custom file is swapped for another. Before the reload guard dropped its
+// substituted conjunct, this case fell through the identity switch: no case
+// matched, initializeModel loaded the built-in baseline underneath a ModelInfo
+// still naming the custom file, and the reload reported success while every
+// detection was attributed to a model that was not running.
+//
+// The discriminator, as in the recovered-path test above, is an unreadable
+// TaxonomyPath that fails the reload at the first fallible step AFTER the identity
+// switch: reaching "taxonomy" would prove the guard let the fall-through through
+// (the bug), while "requires orchestrator restart" proves it refused (the fix).
+func TestReloadModelInternal_ClearingPathWhileCustomRunningIsRefused(t *testing.T) {
+	liveCustom := "/srv/models/my_custom_primary.tflite"
+
+	settings := conftest.GetTestSettings()
+	settings.BirdNET.Version = ""
+	settings.BirdNET.ModelPath = "" // the user just cleared the configured path
+	conftest.SetTestSettings(settings)
+	t.Cleanup(func() { conftest.SetTestSettings(nil) })
+
+	bn := &BirdNET{
+		classifier:   &rollbackFakeClassifier{},
+		Settings:     settings,
+		ModelInfo:    customBirdNETV24ModelInfo(liveCustom), // a custom model is live
+		TaxonomyPath: filepath.Join(t.TempDir(), "does-not-exist-taxonomy.json"),
+		speciesCache: make(map[string]*speciesCacheEntry),
+		// The resolver mirrors production: a cleared configured path resolves to the
+		// empty result (substituted=false), which is exactly the case the dropped
+		// conjunct used to let fall through.
+		resolvePrimary: func(configured string) pathResolution {
+			require.Empty(t, configured, "the reload must re-resolve the CLEARED configured path")
+			return pathResolution{}
+		},
+	}
+	bn.primaryPath = pathResolution{resolved: modelFileSet{model: liveCustom}}
+	bn.settingsAtomic.Store(settings)
+	bn.publishIdentity()
+
+	err := bn.reloadModelInternal(false)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires orchestrator restart",
+		"clearing the model path while a custom model runs is a model-identity change and must be refused")
+	assert.NotContains(t, err.Error(), "taxonomy",
+		"the reload must refuse in the identity switch, never fall through to load the baseline under the custom identity")
+}
+
 // TestPlanPathCorrection_PrimaryRepairsModelPathOnly pins the primary family's
 // settings mapping. BirdNET.LabelPath must be left alone: the v2.4 label set is
 // embedded and identical across variants, which is why applyConfigForPrimarySwap

--- a/internal/classifier/region_staleness_test.go
+++ b/internal/classifier/region_staleness_test.go
@@ -293,8 +293,9 @@ func TestNotifyRegionStaleness_EmitsPerChange(t *testing.T) {
 	notification.Initialize(notification.DefaultServiceConfig())
 	svc := notification.GetService()
 	require.NotNil(t, svc)
-	// Stop the service's cleanup goroutine so the package goleak check stays clean;
-	// this test is the only one that starts the process-global notification service.
+	// Stop the service's cleanup goroutine so the package goleak check stays clean.
+	// Several tests in this package start the process-global notification service;
+	// each is responsible for stopping the instance it starts.
 	t.Cleanup(svc.Stop)
 
 	NotifyRegionStaleness([]RegionStalenessChange{


### PR DESCRIPTION
## Summary

Follow-up hardening for the primary/secondary model-path stale-path recovery arc (#4207, #4214, #4215). After a stale-path recovery the configured `settings.BirdNET.ModelPath` names a file the instance is not running, so several observers reported the wrong model; two narrower defects in the reload and presence-classification logic were also reachable. This PR fixes those and pays down the mechanical debt the recovery work left behind.

Correctness:

- Publish the resolved primary model path lock-free. `modelIdentity` gains a `resolvedPath` field populated by `publishIdentity` (written under `bn.mu` at construction and on every reload, rolled back with the rest of the identity), read lock-free via `bn.resolvedModelPath()` / `ResolvedModelPath()`. The pre-lock inference decoration in `Predict` and the placeholder-taxonomy debug gate in the processor now report the file the instance is actually running instead of the configured path, so all three inference-error decorations agree.
- Report the running variant in the model gallery scan. `ModelInstance` gains `ResolvedModelPath()` (implemented by the primary and by Perch/BirdNETV3/Bat, which now retain their resolved model path). `ScanInstalled` snapshots each loaded instance's resolved path before taking `mm.mu` and `installedModelBasenameHint` prefers it, so the gallery reports the variant that is loaded rather than a stale one it would offer to re-optimize. A loaded instance running the built-in (empty resolved path) is authoritative and maps to the BuiltIn record.
- Close a reload fall-through. When the user clears `birdnet.modelpath` while a custom model is running, the reload identity switch fell through and loaded the baseline under an identity still naming the custom file while reporting success (detections then misattributed). The switch now refuses and requires an orchestrator restart, matching how it already treats swapping one custom file for another. The `old != "" && new == ""` guard still excludes the steady-state-after-recovery case, so this does not reintroduce a perpetual settings-save failure.
- Separate the two on-disk presence facts. A required file set that has one confirmed-absent member and one merely-unreadable member now withholds the config rewrite (persistence keys on the unreadable member, which may reappear) while telling the user the file is "not found" rather than "could not be read" (wording keys on the confirmed-absent member).
- Stop suppressing the not-analyzing alarm on a failed download. A failed download state lingers for 30s so SSE pollers can observe it, but the model is not analyzing during that window; `DownloadState.IsActive()` reports true only for downloading/verifying/loading, so a lingering failure no longer reads as an in-progress download.

Mechanical debt:

- Coalesce the path-correction drain into one settings clone plus a single store and save, instead of one write per stale family, so a start with several stale families no longer publishes a sequence of half-repaired snapshots a concurrent reader could observe. Single-family behaviour is unchanged.
- Consolidate the registry-ID-to-settings-field mapping into one `familyPathFields` accessor used by the gallery hint, install, uninstall, and the correction planner, replacing four hand-rolled switches that had drifted. The planner gains the previously-omitted BSG case, and the accessor returns nil label/embedding pointers for the primary so its model-only contract cannot be violated by accident.
- Name the shared gallery subdirectory once as a constant, and correct a stale test comment.

## Test Plan

- [x] `go test -race ./internal/classifier/ ./internal/analysis/...`
- [x] `go build` and `go vet` with default, `tflite`, and `openvino` build tags
- [x] `golangci-lint run` clean (zero issues)
- [x] New regression tests: the cleared-path reload refuse (verified to fall through without the guard change), the missing-and-unreadable wording, the gallery hint preferring the loaded path, the failed-download active check, and the `familyPathFields` mapping including the primary's nil-pointer contract and BSG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved model download reliability with endpoint failover and better timeout handling.
  - Added smarter recovery when configured model files are missing, stale, or unavailable.
  - Model switching and rollback now preserve settings more consistently.

- **Bug Fixes**
  - Prevented failed or completed downloads from being treated as active.
  - Improved model status, error messages, and taxonomy diagnostics.
  - Prevented unsafe reloads when a running custom model path is cleared.
  - Corrected notifications and configuration repairs for mixed missing or unreadable files.

- **Tests**
  - Added coverage for download states, model recovery, family mappings, and reload safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->