### PR TITLE
fix(api,classifier,analysis): gate hardware-incompatible model installs; quieter OpenVINO-absent log; aggregate daylight-filter discards

### DIFF
--- a/internal/analysis/processor/daylight_filter.go
+++ b/internal/analysis/processor/daylight_filter.go
@@ -9,6 +9,12 @@ import (
 	"github.com/tphakala/birdnet-go/internal/suncalc"
 )
 
+// reasonDaylightFilter is the discard reason returned by shouldDiscardDetection
+// when a detection is dropped by the daylight filter. Shared with the flush path
+// so it can single out daylight discards for aggregate reporting instead of
+// matching a bare string literal.
+const reasonDaylightFilter = "daylight filter"
+
 // SetSunCalc injects the sun calculator into the processor and initializes
 // the daylight filter species list. This is called after processor creation
 // when the suncalc instance becomes available.

--- a/internal/analysis/processor/pipeline_stats.go
+++ b/internal/analysis/processor/pipeline_stats.go
@@ -74,9 +74,13 @@ func (ps *PipelineStats) RecordInference(sourceID, modelID string, rawResults, p
 }
 
 // RecordDaylightDiscard records one detection dropped by the daylight filter for
-// the given source and model. It accumulates into the same per-source/model
-// window as RecordInference so the periodic summary can surface how many
-// detections a filter is silently eating.
+// the given source and model so the periodic summary can surface how many
+// detections a filter is silently eating. The model id is the detection's best
+// (winning) model: in a multi-model consensus config that can differ from a
+// per-inference model id, so a discard may land on a different summary row than
+// some of that detection's inferences. That attribution is intentional (the
+// discard belongs to the model that produced the detection), and on the common
+// single-model config it shares the row with the matching inferences.
 func (ps *PipelineStats) RecordDaylightDiscard(sourceID, modelID string) {
 	ps.mu.Lock()
 	defer ps.mu.Unlock()

--- a/internal/analysis/processor/pipeline_stats.go
+++ b/internal/analysis/processor/pipeline_stats.go
@@ -24,6 +24,11 @@ type inferenceStats struct {
 	passedFilter  int
 	maxConfidence float32
 	threshold     float32
+	// daylightDiscards counts detections dropped by the daylight filter in the
+	// current window. Tracked here so a user who sees zero saved detections has an
+	// aggregate signal that a filter is discarding them, instead of only a
+	// per-detection Debug line they have to know to grep for.
+	daylightDiscards int
 }
 
 // PipelineStats accumulates per-source, per-model inference statistics
@@ -68,6 +73,24 @@ func (ps *PipelineStats) RecordInference(sourceID, modelID string, rawResults, p
 	s.threshold = threshold
 }
 
+// RecordDaylightDiscard records one detection dropped by the daylight filter for
+// the given source and model. It accumulates into the same per-source/model
+// window as RecordInference so the periodic summary can surface how many
+// detections a filter is silently eating.
+func (ps *PipelineStats) RecordDaylightDiscard(sourceID, modelID string) {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+
+	key := sourceModelKey{sourceID: sourceID, modelID: modelID}
+	s := ps.stats[key]
+	if s == nil {
+		s = &inferenceStats{}
+		ps.stats[key] = s
+	}
+
+	s.daylightDiscards++
+}
+
 // Start launches the periodic logging goroutine. Safe to call multiple times.
 func (ps *PipelineStats) Start() {
 	ps.startOnce.Do(func() {
@@ -107,7 +130,14 @@ func (ps *PipelineStats) logAndReset(log logger.Logger) {
 	ps.mu.Unlock()
 
 	for key, s := range snapshot {
-		if s.inferences == 0 {
+		// Emit when the window saw any activity worth reporting: inferences, or
+		// daylight-filter discards on their own. Discards usually share a window with
+		// the inferences that produced them (RecordInference runs before filtering),
+		// but a detection inferred at the tail of one window can be flushed and
+		// discarded in the next, leaving a window with only discards; surfacing that
+		// window is exactly the zero-detections-saved signal a user needs, so it must
+		// not be suppressed here.
+		if s.inferences == 0 && s.daylightDiscards == 0 {
 			continue
 		}
 
@@ -124,6 +154,7 @@ func (ps *PipelineStats) logAndReset(log logger.Logger) {
 			logger.Int("inferences", s.inferences),
 			logger.Int("raw_results", s.rawResults),
 			logger.Int("passed_filter", s.passedFilter),
+			logger.Int("daylight_discards", s.daylightDiscards),
 			logger.Float64("max_confidence", roundTo2(float64(s.maxConfidence))),
 			logger.Float64("threshold", roundTo2(float64(s.threshold))),
 			logger.Duration("period", pipelineStatsInterval),

--- a/internal/analysis/processor/pipeline_stats_test.go
+++ b/internal/analysis/processor/pipeline_stats_test.go
@@ -82,22 +82,32 @@ func TestPipelineStats_ZeroActivitySuppressed(t *testing.T) {
 // saved detections needs surfaced, so it must not be suppressed. Not parallel:
 // logtest swaps the process-global logger.
 func TestPipelineStats_RecordDaylightDiscard(t *testing.T) {
-	buf := logtest.CaptureBuffer(t)
-	ps := NewPipelineStats(nil)
+	// Each subtest builds isolated logger capture and PipelineStats state. Not
+	// parallel: logtest swaps the process-global logger.
+	t.Run("discard-only window is reported", func(t *testing.T) {
+		buf := logtest.CaptureBuffer(t)
+		ps := NewPipelineStats(nil)
 
-	ps.RecordDaylightDiscard("src-1", "BirdNET_v2.4")
-	ps.RecordDaylightDiscard("src-1", "BirdNET_v2.4")
-	ps.logAndReset(GetLogger())
+		ps.RecordDaylightDiscard("src-1", "BirdNET_v2.4")
+		ps.RecordDaylightDiscard("src-1", "BirdNET_v2.4")
+		ps.logAndReset(GetLogger())
 
-	out := buf.String()
-	require.Contains(t, out, "pipeline stats", "a discard-only window must still emit a summary")
-	assert.Contains(t, out, "daylight_discards=2")
-	assert.Contains(t, out, "inferences=0")
+		out := buf.String()
+		require.Contains(t, out, "pipeline stats", "a discard-only window must still emit a summary")
+		assert.Contains(t, out, "daylight_discards=2")
+		assert.Contains(t, out, "inferences=0")
+	})
 
-	// The window was swapped out by logAndReset; an idle window logs nothing.
-	buf.Reset()
-	ps.logAndReset(GetLogger())
-	assert.NotContains(t, buf.String(), "pipeline stats", "an idle window must be suppressed")
+	t.Run("window is suppressed after its discards were reported", func(t *testing.T) {
+		buf := logtest.CaptureBuffer(t)
+		ps := NewPipelineStats(nil)
+
+		ps.RecordDaylightDiscard("src-1", "BirdNET_v2.4")
+		ps.logAndReset(GetLogger()) // consumes and resets the window
+		buf.Reset()
+		ps.logAndReset(GetLogger()) // now idle
+		assert.NotContains(t, buf.String(), "pipeline stats", "an idle window after reset must be suppressed")
+	})
 }
 
 // TestPipelineStats_InferencesAndDiscards verifies a window carrying both

--- a/internal/analysis/processor/pipeline_stats_test.go
+++ b/internal/analysis/processor/pipeline_stats_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/logger/logtest"
 )
 
 func TestPipelineStats_RecordAndReset(t *testing.T) {
@@ -72,4 +73,45 @@ func TestPipelineStats_ZeroActivitySuppressed(t *testing.T) {
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 	assert.Empty(t, ps.stats)
+}
+
+// TestPipelineStats_RecordDaylightDiscard verifies that daylight-filter discards
+// are aggregated into the periodic pipeline-stats summary, and in particular that
+// a window whose every detection was filtered (zero inferences, non-zero
+// discards) is still reported. That is exactly the case a user who sees zero
+// saved detections needs surfaced, so it must not be suppressed. Not parallel:
+// logtest swaps the process-global logger.
+func TestPipelineStats_RecordDaylightDiscard(t *testing.T) {
+	buf := logtest.CaptureBuffer(t)
+	ps := NewPipelineStats(nil)
+
+	ps.RecordDaylightDiscard("src-1", "BirdNET_v2.4")
+	ps.RecordDaylightDiscard("src-1", "BirdNET_v2.4")
+	ps.logAndReset(GetLogger())
+
+	out := buf.String()
+	require.Contains(t, out, "pipeline stats", "a discard-only window must still emit a summary")
+	assert.Contains(t, out, "daylight_discards=2")
+	assert.Contains(t, out, "inferences=0")
+
+	// The window was swapped out by logAndReset; an idle window logs nothing.
+	buf.Reset()
+	ps.logAndReset(GetLogger())
+	assert.NotContains(t, buf.String(), "pipeline stats", "an idle window must be suppressed")
+}
+
+// TestPipelineStats_InferencesAndDiscards verifies a window carrying both
+// inferences and daylight discards reports both counts on one line.
+func TestPipelineStats_InferencesAndDiscards(t *testing.T) {
+	buf := logtest.CaptureBuffer(t)
+	ps := NewPipelineStats(nil)
+
+	ps.RecordInference("src-2", "perch_v2", 5, 1, 0.8, 0.5)
+	ps.RecordDaylightDiscard("src-2", "perch_v2")
+	ps.logAndReset(GetLogger())
+
+	out := buf.String()
+	require.Contains(t, out, "pipeline stats")
+	assert.Contains(t, out, "inferences=1")
+	assert.Contains(t, out, "daylight_discards=1")
 }

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -1584,7 +1584,7 @@ func (p *Processor) shouldDiscardDetection(item *PendingDetection, settings *con
 				logger.Time("detection_time", item.FirstDetected),
 				logger.String("source", p.getDisplayNameForSource(item.Source)),
 				logger.String("operation", "daylight_filter"))
-			return true, "daylight filter"
+			return true, reasonDaylightFilter
 		}
 	}
 
@@ -1785,6 +1785,16 @@ func (p *Processor) flushPendingDetections() (pendingCount, flushedCount int) {
 		itemMinDetections := calculateMinDetectionsForModel(settings, item.BestModelID)
 
 		if shouldDiscard, reason := p.shouldDiscardDetection(&item, settings, itemMinDetections); shouldDiscard {
+			// Aggregate daylight-filter discards into the periodic pipeline-stats
+			// summary so a user who sees zero saved detections has an at-a-glance
+			// signal that a filter is eating them. The per-detection log stays at
+			// Info: it carries the discard_detection operation the
+			// /system/events/detections API aggregates into per-species discard
+			// counts (DiscardReasons / TopDiscarded), so demoting it would silently
+			// drop daylight-filtered species from that endpoint on a default config.
+			if reason == reasonDaylightFilter && p.pipelineStats != nil {
+				p.pipelineStats.RecordDaylightDiscard(item.Source, item.BestModelID)
+			}
 			GetLogger().Info("discarding detection",
 				logger.String("species", speciesName),
 				logger.String("source", p.getDisplayNameForSource(item.Source)),

--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -551,7 +551,7 @@ Requires enhanced (v2) database. Returns 409 Conflict if not available.
 | GET    | `/models/regions`              | `GetModelRegions`       | ✅   | Region selector data: selectable regions, the auto-resolved region for the configured coordinates, and per-family resolution (auth-gated; never echoes raw coordinates) |
 | GET    | `/models/regions/:slug/map`    | `GetRegionCoverageMap`  | ❌   | Embedded SVG coverage map for a region slug (public static asset; strong ETag, honors If-None-Match; 404 when no map exists for the slug) |
 | GET    | `/models/installed`            | `GetInstalledModels`    | ❌   | List downloaded models                                |
-| POST   | `/models/install/:id`          | `InstallModel`          | ✅   | Download and install a catalog model                  |
+| POST   | `/models/install/:id`          | `InstallModel`          | ✅   | Download and install a catalog variant; body `{variantId?, allowIncompatible?}`. A variant incompatible with the detected hardware is rejected with 409 unless `allowIncompatible:true` |
 | POST   | `/models/reinstall/:id`        | `ReinstallModel`        | ✅   | Re-download missing/corrupt files for installed model |
 | DELETE | `/models/installed/:id`        | `UninstallModel`        | ✅   | Remove an installed model from disk                   |
 | GET    | `/models/install/:id/progress` | `StreamInstallProgress` | ❌   | SSE stream for install/reinstall progress             |

--- a/internal/api/v2/models/models.go
+++ b/internal/api/v2/models/models.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -179,6 +180,12 @@ type VariantReasonResponse struct {
 // absent body or empty variantId installs (or switches to) the default variant.
 type installModelRequest struct {
 	VariantID string `json:"variantId"`
+	// AllowIncompatible overrides the hardware-compatibility gate. When false (the
+	// default), installing a variant the catalog marks incompatible with the
+	// detected hardware is rejected with 409. When true, an advanced user can force
+	// the install; it still proceeds but a WARN is logged so the choice is visible
+	// in logs and support dumps.
+	AllowIncompatible bool `json:"allowIncompatible"`
 }
 
 // ListModels returns classifier models that are enabled in the configuration.
@@ -594,6 +601,74 @@ func (c *Handler) rankCatalog(entries []classifier.CatalogEntry, ort inference.O
 	return byVariant, recommended, hostArch
 }
 
+// requestedVariantCompatibility reports the hardware compatibility of the
+// requested variant of entry, reusing the same recommender and host profile
+// GetModelCatalog uses so the install gate and the gallery's compatible flag stay
+// in agreement. gated is false for an entry the recommender does not rank (a flat
+// entry with no variants, or a variant it produced no verdict for), for which
+// there is nothing to gate; callers must treat gated==false as "allow". An empty
+// variantID resolves to the entry's default variant, matching install semantics.
+func (c *Handler) requestedVariantCompatibility(entry *classifier.CatalogEntry, variantID string, ort inference.ORTStatus) (compatible, gated bool, blockers []recommend.Reason, hostArch string) {
+	if entry == nil || len(entry.Variants) == 0 {
+		return true, false, nil, ""
+	}
+	resolvedID := variantID
+	if resolvedID == "" {
+		resolvedID = classifier.DefaultVariantID(entry)
+	}
+	byVariant, _, hostArch := c.rankCatalog([]classifier.CatalogEntry{*entry}, ort)
+	rec, ok := byVariant[entry.ID][resolvedID]
+	if !ok {
+		// The recommender produced no verdict for this variant (profiling seam
+		// returned nothing, or a variant the ranker skipped). Do not block on a
+		// missing verdict; offering the model is safer than a spurious rejection.
+		return true, false, nil, hostArch
+	}
+	return rec.Compatible, true, rec.Blockers, hostArch
+}
+
+// variantOrDefault renders a variant id for messages and logs, mapping the empty
+// (default) selection to a readable token instead of an empty string.
+func variantOrDefault(variantID string) string {
+	if variantID == "" {
+		return "(default)"
+	}
+	return variantID
+}
+
+// hostArchOrUnknown renders a host architecture for messages, mapping an empty
+// (unresolved) arch to a readable token.
+func hostArchOrUnknown(arch string) string {
+	if arch == "" {
+		return "unknown"
+	}
+	return arch
+}
+
+// formatBlockers renders recommender blocker reasons as a compact, deterministic
+// string for an error message or log field (e.g. "arch.unsupported[required=aarch64]").
+// Args are sorted so the output is stable across the map's iteration order.
+func formatBlockers(blockers []recommend.Reason) string {
+	if len(blockers) == 0 {
+		return "incompatible with this host"
+	}
+	parts := make([]string, 0, len(blockers))
+	for i := range blockers {
+		b := &blockers[i]
+		if len(b.Args) == 0 {
+			parts = append(parts, b.Code)
+			continue
+		}
+		args := make([]string, 0, len(b.Args))
+		for k, v := range b.Args {
+			args = append(args, k+"="+v)
+		}
+		slices.Sort(args)
+		parts = append(parts, b.Code+"["+strings.Join(args, ",")+"]")
+	}
+	return strings.Join(parts, "; ")
+}
+
 // defaultHardwareProfile resolves the live host profile from the already-probed
 // ONNX Runtime status plus a per-request OpenVINO device probe, mirroring the
 // inference-status endpoint (internal/api/v2/system/inference_status.go). The ORT
@@ -680,6 +755,11 @@ func (c *Handler) InstallModel(ctx echo.Context) error {
 		return c.HandleError(ctx, nil, "unknown variant "+req.VariantID+" for model "+catalogID, http.StatusBadRequest)
 	}
 
+	// Probe ORT once: it gates ONNX-only variants below and also feeds the hardware
+	// profile the compatibility gate consults, mirroring how GetModelCatalog probes
+	// it a single time per request.
+	ortStatus := inference.CheckORTAvailability(c.CurrentSettings().BirdNET.ONNXRuntimePath)
+
 	// Reject installation of ONNX-dependent models when ORT is unavailable. The gate
 	// is variant-scoped: an entry may be ORT-free overall (e.g. BirdNET v2.4, whose
 	// BuiltIn baseline runs on the embedded TFLite model) yet expose ONNX-only
@@ -687,12 +767,35 @@ func (c *Handler) InstallModel(ctx echo.Context) error {
 	// flag so swapping to the embedded baseline is never blocked, while selecting an
 	// ONNX build still requires the runtime.
 	if entry.RequiresONNX || classifier.VariantNeedsONNX(&entry, req.VariantID) {
-		ortStatus := inference.CheckORTAvailability(c.CurrentSettings().BirdNET.ONNXRuntimePath)
 		if !ortStatus.Available {
 			return c.HandleError(ctx, nil,
 				"model requires ONNX Runtime "+inference.ORTRequiredVersion()+": "+ortStatus.Error,
 				http.StatusConflict)
 		}
+	}
+
+	// Hardware-compatibility gate. A variant the catalog marks incompatible with the
+	// detected hardware (an ARM-only int8 build on an x86 host, a variant needing
+	// more RAM than the host has) is rejected with 409 unless the request explicitly
+	// opts in via allowIncompatible. Reusing the same recommender GetModelCatalog
+	// uses keeps this gate and the gallery's compatible flag in agreement, and closes
+	// the hole where a direct API call could install an incompatible variant and, on
+	// switch, delete the working compatible one with no warning anywhere. An explicit
+	// override still installs, but logs a WARN so the choice is visible in support dumps.
+	compatible, gated, blockers, hostArch := c.requestedVariantCompatibility(&entry, req.VariantID, ortStatus)
+	if gated && !compatible {
+		if !req.AllowIncompatible {
+			return c.HandleError(ctx, nil,
+				fmt.Sprintf("variant %s of model %s is not compatible with the detected hardware (%s): %s; pass allowIncompatible to override",
+					variantOrDefault(req.VariantID), catalogID, hostArchOrUnknown(hostArch), formatBlockers(blockers)),
+				http.StatusConflict)
+		}
+		c.LogWarnIfEnabled("Installing model variant incompatible with detected hardware",
+			logger.String("catalog_id", catalogID),
+			logger.String("variant_id", variantOrDefault(req.VariantID)),
+			logger.String("host_arch", hostArchOrUnknown(hostArch)),
+			logger.String("blockers", formatBlockers(blockers)),
+			logger.String("operation", "model_install_incompatible_override"))
 	}
 
 	// Start async install in a background goroutine.

--- a/internal/api/v2/models/models_install_compat_test.go
+++ b/internal/api/v2/models/models_install_compat_test.go
@@ -1,0 +1,140 @@
+package models
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
+	"github.com/tphakala/birdnet-go/internal/classifier"
+	"github.com/tphakala/birdnet-go/internal/hwprofile"
+	"github.com/tphakala/birdnet-go/internal/inference"
+	"github.com/tphakala/birdnet-go/internal/logger/logtest"
+)
+
+// TestRequestedVariantCompatibility verifies the install gate's compatibility
+// computation reuses the recommender correctly across the cases the handler
+// depends on: an incompatible variant (int8-arm on amd64), a compatible one,
+// the empty-variant default resolution, and a flat entry that is never gated.
+// amd64ONNXProfile lives in models_recommend_test.go (same package).
+func TestRequestedVariantCompatibility(t *testing.T) {
+	core := apitest.NewCore(t)
+	h := New(core, nil)
+	h.hardwareProfile = func(inference.ORTStatus) hwprofile.Profile { return amd64ONNXProfile() }
+
+	entry, ok := classifier.GetCatalogEntry("perch-v2")
+	require.True(t, ok, "perch-v2 must exist in the embedded catalog")
+
+	ort := inference.ORTStatus{Available: true}
+
+	// int8-arm requires aarch64; on an amd64 host it is gated and incompatible,
+	// with an arch blocker naming the requirement.
+	compatible, gated, blockers, arch := h.requestedVariantCompatibility(&entry, "int8-arm", ort)
+	assert.True(t, gated, "a variant-bearing entry is gated")
+	assert.False(t, compatible, "int8-arm is incompatible on amd64")
+	require.NotEmpty(t, blockers, "an incompatible variant must carry blockers")
+	assert.Equal(t, "amd64", arch)
+
+	// fp32 (the default) runs on amd64 with ONNX available.
+	compatible, gated, _, _ = h.requestedVariantCompatibility(&entry, "fp32", ort)
+	assert.True(t, gated)
+	assert.True(t, compatible, "fp32 is compatible on amd64 ONNX")
+
+	// An empty variant id resolves to the default variant (fp32), which is compatible.
+	compatible, gated, _, _ = h.requestedVariantCompatibility(&entry, "", ort)
+	assert.True(t, gated)
+	assert.True(t, compatible, "the default variant resolves and is compatible")
+
+	// A flat entry (no variants) is never gated: there is nothing to select.
+	flat := classifier.CatalogEntry{ID: "flat-test"}
+	_, gated, _, _ = h.requestedVariantCompatibility(&flat, "", ort)
+	assert.False(t, gated, "a flat entry with no variants is not gated")
+}
+
+// TestInstallModel_RejectsIncompatibleVariant verifies the install handler
+// rejects a hardware-incompatible variant with 409 by default, synchronously and
+// before any download, naming the variant, the hardware, and the override flag.
+func TestInstallModel_RejectsIncompatibleVariant(t *testing.T) {
+	core := apitest.NewCore(t)
+	core.ModelManager = classifier.NewModelManager(t.TempDir(), nil, nil)
+	h := New(core, nil)
+	h.hardwareProfile = func(inference.ORTStatus) hwprofile.Profile { return amd64ONNXProfile() }
+	e := echo.New()
+
+	body := strings.NewReader(`{"variantId":"int8-arm"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/models/install/perch-v2", body)
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("id")
+	ctx.SetParamValues("perch-v2")
+
+	require.NoError(t, h.InstallModel(ctx))
+	assert.Equal(t, http.StatusConflict, rec.Code)
+	body409 := rec.Body.String()
+	assert.Contains(t, body409, "not compatible")
+	assert.Contains(t, body409, "int8-arm")
+	assert.Contains(t, body409, "allowIncompatible")
+}
+
+// TestInstallModel_AllowIncompatibleOverride verifies the explicit override flag
+// bypasses the compatibility gate, accepts the install (202), AND emits the WARN
+// whose whole purpose is to make the forced choice visible in logs and support
+// dumps. Asserting the WARN (not just the 202) is what isolates the override
+// branch: a gate that ignored allowIncompatible would also reach 202 on this
+// input, but only the override branch logs the operation code. The buffer is
+// swapped in before apitest.NewCore so the Core's APILogger (built from
+// logger.Global() at construction) writes into it. The async download is
+// cancelled by the apitest core cleanup (Cancel/Wait). Not parallel: logtest
+// swaps the process-global logger.
+func TestInstallModel_AllowIncompatibleOverride(t *testing.T) {
+	buf := logtest.CaptureBuffer(t)
+	core := apitest.NewCore(t)
+	core.ModelManager = classifier.NewModelManager(t.TempDir(), nil, nil)
+	h := New(core, nil)
+	h.hardwareProfile = func(inference.ORTStatus) hwprofile.Profile { return amd64ONNXProfile() }
+	e := echo.New()
+
+	body := strings.NewReader(`{"variantId":"int8-arm","allowIncompatible":true}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/models/install/perch-v2", body)
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("id")
+	ctx.SetParamValues("perch-v2")
+
+	require.NoError(t, h.InstallModel(ctx))
+	assert.Equal(t, http.StatusAccepted, rec.Code, "an explicit override must accept the install")
+	assert.Contains(t, buf.String(), "model_install_incompatible_override",
+		"the override branch must log a WARN so the forced choice is visible in support dumps")
+}
+
+// TestInstallModel_AcceptsCompatibleVariant verifies the gate does NOT block a
+// variant that is compatible with the detected hardware: a normal fp32 install on
+// an amd64 ONNX host proceeds to 202 with no override flag. This pins the
+// happy-path wiring (compatible => skip the gate => 202); without it a mutation
+// that rejected compatible variants would leave the reject/override tests green
+// while breaking every normal install. The async download is cancelled by the
+// apitest core cleanup.
+func TestInstallModel_AcceptsCompatibleVariant(t *testing.T) {
+	core := apitest.NewCore(t)
+	core.ModelManager = classifier.NewModelManager(t.TempDir(), nil, nil)
+	h := New(core, nil)
+	h.hardwareProfile = func(inference.ORTStatus) hwprofile.Profile { return amd64ONNXProfile() }
+	e := echo.New()
+
+	body := strings.NewReader(`{"variantId":"fp32"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/models/install/perch-v2", body)
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("id")
+	ctx.SetParamValues("perch-v2")
+
+	require.NoError(t, h.InstallModel(ctx))
+	assert.Equal(t, http.StatusAccepted, rec.Code, "a compatible variant must not be gated")
+}

--- a/internal/api/v2/models/models_install_compat_test.go
+++ b/internal/api/v2/models/models_install_compat_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/classifier"
+	"github.com/tphakala/birdnet-go/internal/classifier/recommend"
 	"github.com/tphakala/birdnet-go/internal/hwprofile"
 	"github.com/tphakala/birdnet-go/internal/inference"
 	"github.com/tphakala/birdnet-go/internal/logger/logtest"
@@ -37,31 +38,36 @@ func TestRequestedVariantCompatibility(t *testing.T) {
 		variantID      string
 		wantGated      bool
 		wantCompatible bool
-		wantBlockers   bool
+		wantBlocker    string // expected blocker code, "" when none is expected
 		wantArch       string
 	}{
 		// int8-arm requires aarch64; on an amd64 host it is gated and incompatible,
-		// carrying an arch blocker.
-		{"int8-arm incompatible on amd64", &perch, "int8-arm", true, false, true, "amd64"},
+		// carrying the deterministic arch-unsupported blocker.
+		{"int8-arm incompatible on amd64", &perch, "int8-arm", true, false, recommend.BlockerArchUnsupported, "amd64"},
 		// fp32 (the default) runs on amd64 with ONNX available.
-		{"fp32 compatible on amd64 ONNX", &perch, "fp32", true, true, false, "amd64"},
+		{"fp32 compatible on amd64 ONNX", &perch, "fp32", true, true, "", "amd64"},
 		// An empty variant id resolves to the default variant (fp32), compatible.
-		{"empty resolves to the compatible default", &perch, "", true, true, false, "amd64"},
-		// A flat entry (no variants) is never gated: there is nothing to select.
-		{"flat entry is not gated", &flat, "", false, false, false, ""},
+		{"empty resolves to the compatible default", &perch, "", true, true, "", "amd64"},
+		// A flat entry (no variants) is never gated: the contract returns
+		// compatible=true, gated=false, no blockers, and no host arch.
+		{"flat entry is not gated", &flat, "", false, true, "", ""},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			compatible, gated, blockers, arch := h.requestedVariantCompatibility(tt.entry, tt.variantID, ort)
-			assert.Equal(t, tt.wantGated, gated)
-			if !tt.wantGated {
-				// Nothing else is meaningful for an entry the recommender does not gate.
+			assert.Equal(t, tt.wantGated, gated, "gated")
+			assert.Equal(t, tt.wantCompatible, compatible, "compatible")
+			assert.Equal(t, tt.wantArch, arch, "host arch")
+			if tt.wantBlocker == "" {
+				assert.Empty(t, blockers, "no blocker expected")
 				return
 			}
-			assert.Equal(t, tt.wantCompatible, compatible)
-			assert.Equal(t, tt.wantBlockers, len(blockers) > 0, "blocker presence")
-			assert.Equal(t, tt.wantArch, arch)
+			codes := make([]string, len(blockers))
+			for i := range blockers {
+				codes[i] = blockers[i].Code
+			}
+			assert.Contains(t, codes, tt.wantBlocker, "expected blocker code")
 		})
 	}
 }

--- a/internal/api/v2/models/models_install_compat_test.go
+++ b/internal/api/v2/models/models_install_compat_test.go
@@ -26,33 +26,44 @@ func TestRequestedVariantCompatibility(t *testing.T) {
 	h := New(core, nil)
 	h.hardwareProfile = func(inference.ORTStatus) hwprofile.Profile { return amd64ONNXProfile() }
 
-	entry, ok := classifier.GetCatalogEntry("perch-v2")
+	perch, ok := classifier.GetCatalogEntry("perch-v2")
 	require.True(t, ok, "perch-v2 must exist in the embedded catalog")
-
+	flat := classifier.CatalogEntry{ID: "flat-test"}
 	ort := inference.ORTStatus{Available: true}
 
-	// int8-arm requires aarch64; on an amd64 host it is gated and incompatible,
-	// with an arch blocker naming the requirement.
-	compatible, gated, blockers, arch := h.requestedVariantCompatibility(&entry, "int8-arm", ort)
-	assert.True(t, gated, "a variant-bearing entry is gated")
-	assert.False(t, compatible, "int8-arm is incompatible on amd64")
-	require.NotEmpty(t, blockers, "an incompatible variant must carry blockers")
-	assert.Equal(t, "amd64", arch)
+	tests := []struct {
+		name           string
+		entry          *classifier.CatalogEntry
+		variantID      string
+		wantGated      bool
+		wantCompatible bool
+		wantBlockers   bool
+		wantArch       string
+	}{
+		// int8-arm requires aarch64; on an amd64 host it is gated and incompatible,
+		// carrying an arch blocker.
+		{"int8-arm incompatible on amd64", &perch, "int8-arm", true, false, true, "amd64"},
+		// fp32 (the default) runs on amd64 with ONNX available.
+		{"fp32 compatible on amd64 ONNX", &perch, "fp32", true, true, false, "amd64"},
+		// An empty variant id resolves to the default variant (fp32), compatible.
+		{"empty resolves to the compatible default", &perch, "", true, true, false, "amd64"},
+		// A flat entry (no variants) is never gated: there is nothing to select.
+		{"flat entry is not gated", &flat, "", false, false, false, ""},
+	}
 
-	// fp32 (the default) runs on amd64 with ONNX available.
-	compatible, gated, _, _ = h.requestedVariantCompatibility(&entry, "fp32", ort)
-	assert.True(t, gated)
-	assert.True(t, compatible, "fp32 is compatible on amd64 ONNX")
-
-	// An empty variant id resolves to the default variant (fp32), which is compatible.
-	compatible, gated, _, _ = h.requestedVariantCompatibility(&entry, "", ort)
-	assert.True(t, gated)
-	assert.True(t, compatible, "the default variant resolves and is compatible")
-
-	// A flat entry (no variants) is never gated: there is nothing to select.
-	flat := classifier.CatalogEntry{ID: "flat-test"}
-	_, gated, _, _ = h.requestedVariantCompatibility(&flat, "", ort)
-	assert.False(t, gated, "a flat entry with no variants is not gated")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			compatible, gated, blockers, arch := h.requestedVariantCompatibility(tt.entry, tt.variantID, ort)
+			assert.Equal(t, tt.wantGated, gated)
+			if !tt.wantGated {
+				// Nothing else is meaningful for an entry the recommender does not gate.
+				return
+			}
+			assert.Equal(t, tt.wantCompatible, compatible)
+			assert.Equal(t, tt.wantBlockers, len(blockers) > 0, "blocker presence")
+			assert.Equal(t, tt.wantArch, arch)
+		})
+	}
 }
 
 // TestInstallModel_RejectsIncompatibleVariant verifies the install handler

--- a/internal/classifier/model_catalog.go
+++ b/internal/classifier/model_catalog.go
@@ -735,6 +735,20 @@ func defaultVariant(entry *CatalogEntry) *CatalogVariant {
 	return &entry.Variants[0]
 }
 
+// DefaultVariantID returns the ID of the variant that an empty variant selection
+// resolves to (the one flagged Default, else the first), or "" for a flat entry
+// with no variants. It is the exported form used by the API layer to map an empty
+// install request to the concrete variant ID the recommender keys its verdict by.
+func DefaultVariantID(entry *CatalogEntry) string {
+	if entry == nil {
+		return ""
+	}
+	if v := defaultVariant(entry); v != nil {
+		return v.ID
+	}
+	return ""
+}
+
 // variantFilesByID returns the file list for the given variant of an entry. An
 // empty variantID yields the entry's resolved (default) Files, preserving the
 // pre-variant behaviour. A non-empty variantID selects the matching variant's

--- a/internal/classifier/model_openvino.go
+++ b/internal/classifier/model_openvino.go
@@ -3,6 +3,7 @@ package classifier
 import (
 	"os"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/conf"
@@ -137,14 +138,59 @@ func openVINOCPUAllowed(devicePref string) bool {
 // is idempotent and fast on repeat); a load failure means no usable OV at all.
 func openVINOGPUAvailable(libraryPath string) bool {
 	if err := inference.InitOpenVINO(libraryPath); err != nil {
-		// Surface the load failure: without this, an explicit openvino/gpu opt-in
-		// with a bad OpenVINOPath would silently fall back to ORT carrying only a
-		// generic "not eligible" message, hiding the real library-load cause.
-		GetLogger().Warn("OpenVINO library load failed during device planning; treating GPU as unavailable",
-			logger.Error(err))
+		// A merely-absent OpenVINO library is the expected CPU-only case, not a
+		// fault: device planning falls back to ONNX Runtime and logs that fallback
+		// at INFO (logOpenVINODeclined). Log the absent case at Debug so a recurring
+		// line does not read as a problem in a support dump, and reserve Warn for a
+		// present-but-broken library (wrong version, missing symbol) whose load
+		// failure a user would actually want surfaced. This still surfaces the real
+		// cause of a broken explicit openvino/gpu opt-in, while staying quiet on a
+		// host that simply never installed OpenVINO.
+		if isLibraryAbsent(err) {
+			GetLogger().Debug("OpenVINO library not installed; treating GPU as unavailable",
+				logger.Error(err))
+		} else {
+			GetLogger().Warn("OpenVINO library load failed during device planning; treating GPU as unavailable",
+				logger.Error(err))
+		}
 		return false
 	}
 	return inference.OpenVINOHasDevice(inference.OVDeviceGPU)
+}
+
+// isLibraryAbsent reports whether err indicates the OpenVINO shared library is
+// simply not installed (the dynamic loader could not find the file), as opposed
+// to present but broken. The loader reports a missing library only through its
+// error text across the cgo boundary, so the message is the signal, matched
+// case-insensitively for Linux dlopen ("cannot open shared object file"), macOS
+// dyld ("image not found") and Windows LoadLibrary ("the specified module could
+// not be found"), plus os.ErrNotExist for any path stat'd before the load.
+//
+// It is best-effort and deliberately conservative about staying quiet. A
+// "permission denied" load failure is a present-but-broken case, not an absent
+// one, so it is excluded and stays a Warn. Two residual imperfections are
+// accepted because the only consequence is the Warn-vs-Debug log level (device
+// planning falls back to ONNX Runtime either way, and logOpenVINODeclined still
+// records the fallback at Info): a missing transitive dependency yields the same
+// "cannot open shared object file" text as an absent primary and is treated as
+// absent, and a non-English loader locale may not match the English text and so
+// falls through to Warn.
+func isLibraryAbsent(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	// A present-but-inaccessible library is broken, not absent; keep it a Warn.
+	if strings.Contains(msg, "permission denied") {
+		return false
+	}
+	return strings.Contains(msg, "cannot open shared object file") || // Linux dlopen
+		strings.Contains(msg, "no such file or directory") ||
+		strings.Contains(msg, "image not found") || // macOS dyld
+		strings.Contains(msg, "the specified module could not be found") // Windows LoadLibrary
 }
 
 // openVINOPlan returns the OpenVINO plan for the primary BirdNET classifier, or

--- a/internal/classifier/model_openvino_absent_test.go
+++ b/internal/classifier/model_openvino_absent_test.go
@@ -1,0 +1,76 @@
+package classifier
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIsLibraryAbsent verifies the discrimination between a merely-absent
+// OpenVINO shared library (which should be logged at Debug during device
+// planning) and a present-but-broken one (which stays a Warn). The dynamic
+// loader reports a missing library only through its error text across the cgo
+// boundary, so the message is the signal; os.ErrNotExist is honored too.
+func TestIsLibraryAbsent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error is not absent", nil, false},
+		{
+			"linux dlopen missing file",
+			fmt.Errorf("libopenvino_c.so: cannot open shared object file: No such file or directory"),
+			true,
+		},
+		{
+			"bare no such file or directory",
+			fmt.Errorf("open /opt/openvino/libopenvino_c.so: no such file or directory"),
+			true,
+		},
+		{
+			"macos dyld image not found",
+			fmt.Errorf("dlopen(libopenvino_c.dylib): image not found"),
+			true,
+		},
+		{
+			"windows loadlibrary missing dll",
+			fmt.Errorf("openvino_c.dll: The specified module could not be found."),
+			true,
+		},
+		{
+			"wrapped os.ErrNotExist",
+			fmt.Errorf("stat libopenvino_c.so: %w", os.ErrNotExist),
+			true,
+		},
+		{
+			"present but broken: missing symbol",
+			fmt.Errorf("libopenvino_c.so: undefined symbol: ov_core_create"),
+			false,
+		},
+		{
+			"present but broken: wrong ELF class",
+			fmt.Errorf("libopenvino_c.so: wrong ELF class: ELFCLASS32"),
+			false,
+		},
+		{
+			// A present-but-inaccessible library carries the "cannot open shared
+			// object file" text too, but "permission denied" marks it broken, not
+			// absent, so it must stay a Warn.
+			"present but broken: permission denied",
+			fmt.Errorf("libopenvino_c.so: cannot open shared object file: Permission denied"),
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isLibraryAbsent(tt.err))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Three fixes surfaced by the model-gallery QA campaign, folded into one PR.

**Install compatibility gate.** `POST /api/v2/models/install/:id` gated only on variant existence and ONNX-runtime availability, never the catalog compatibility verdict, so a direct API call (or any UI regression) could install a variant the detected hardware cannot run (an ARM-only int8 build on an x86 host), load it, switch the active model, produce detections, and delete the previously installed compatible file with no warning anywhere. `InstallModel` now reuses the same recommender the gallery uses to compute compatibility (`requestedVariantCompatibility` over `rankCatalog`) and returns 409 for a variant incompatible with the detected hardware, unless the request body sets `allowIncompatible: true`, in which case the install proceeds but logs a WARN so the forced choice is visible in logs and support dumps. `ReinstallModel` is left unchanged: it repairs the currently installed variant and selects no new one, so it cannot introduce an incompatible switch. A new exported `classifier.DefaultVariantID` resolves an empty variant selection to the concrete default the recommender keys its verdict on.

**OpenVINO device-planning log.** `openVINOGPUAvailable` logged a merely-absent OpenVINO library (the expected CPU-only case) at WARN, which reads as a fault in a support dump. It now logs the absent case at Debug and reserves WARN for a present-but-broken library. The absent-vs-broken split is best-effort over the loader's error text: a permission-denied failure stays WARN, while a missing transitive dependency or a non-English loader locale is documented as an accepted imperfection, because the only consequence is the log level (device planning falls back to ONNX Runtime either way, and the decline is already logged at Info).

**Daylight-filter observability.** With the daylight filter enabled (its default when a location is configured), every off-hours detection is dropped one by one and a user who sees zero saved detections has no aggregate signal that a filter is eating them. Daylight discards are now accumulated into the periodic pipeline-stats summary (a `daylight_discards` count per source/model, and a window carrying only discards is no longer suppressed). The per-detection discard log deliberately stays at Info because it carries the `discard_detection` operation that `GET /system/events/detections` aggregates into per-species discard counts; demoting it would have silently dropped daylight-filtered species from that endpoint on a default config.

## Test Plan

- [x] `go build ./internal/...`
- [x] `go test -race` on `internal/api/v2/models`, `internal/classifier`, `internal/analysis/processor`
- [x] `golangci-lint run` clean (full project, pinned toolchain)
- [x] New unit tests: the 409 reject, the `allowIncompatible` override and its WARN, a compatible install reaching 202, the absent-vs-broken OpenVINO discrimination (including permission-denied), and the daylight-discard aggregation including the discard-only window
- [x] End-to-end on a live container: authenticated catalog correctly flags `int8-arm` as arch-incompatible on an amd64 host; install endpoint returns 409; settings round-trip E2E suite (19 tests) passes with no regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model installation now checks hardware compatibility for selected variants.
  * Incompatible variants return a clear `409 Conflict` response unless explicitly overridden with `allowIncompatible`.
  * Installation requests can select a specific model variant or use the default.
  * Pipeline reports now include detections discarded by daylight filtering, including discard-only reporting windows.
  * Improved logging distinguishes unavailable hardware libraries from other loading failures.

* **Documentation**
  * Updated model installation API documentation with variant selection and compatibility override options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->