### PR TITLE
fix(api,frontend): keep concurrent HLS consumers on one shared stream

### DIFF
--- a/frontend/src/lib/utils/session.test.ts
+++ b/frontend/src/lib/utils/session.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { generateSessionId } from './session';
+
+// RFC 4122 v4 UUID: 8-4-4-4-12 hex with version nibble 4 and variant nibble 8..b.
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function fillDeterministic(seed: number): (arr: Uint8Array) => Uint8Array {
+  // Mutate in place like the real crypto.getRandomValues (production reads the
+  // passed-in array, not the return value). set(map(...)) avoids computed-index
+  // writes so it does not trip the object-injection lint rule.
+  return (arr: Uint8Array): Uint8Array => {
+    arr.set(arr.map((_, i) => (i * seed + 11) & 0xff));
+    return arr;
+  };
+}
+
+describe('generateSessionId', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('returns the native crypto.randomUUID value in a secure context', () => {
+    // Pin the native branch: assert it is the one used, not merely that some path
+    // returned a UUID (the env would otherwise decide this silently).
+    const sentinel = '11111111-1111-4111-8111-111111111111';
+    const randomUUID = vi.fn((): string => sentinel);
+    vi.stubGlobal('crypto', { randomUUID });
+
+    const id = generateSessionId();
+    expect(randomUUID).toHaveBeenCalledTimes(1);
+    expect(id).toBe(sentinel);
+    expect(id).toMatch(UUID_V4);
+  });
+
+  it('returns a valid v4 UUID via getRandomValues when randomUUID is unavailable (plain HTTP)', () => {
+    // Simulate a non-secure context: randomUUID missing, getRandomValues present.
+    const getRandomValues = vi.fn(fillDeterministic(37));
+    vi.stubGlobal('crypto', { getRandomValues });
+
+    const id = generateSessionId();
+    // Pin the getRandomValues branch so a fall-through to Math.random (which also
+    // yields a valid UUID) cannot masquerade as this path.
+    expect(getRandomValues).toHaveBeenCalledTimes(1);
+    expect(id).toMatch(UUID_V4);
+  });
+
+  it('returns a valid v4 UUID via Math.random when Web Crypto is entirely absent', () => {
+    vi.stubGlobal('crypto', undefined);
+    const mathRandom = vi.spyOn(Math, 'random');
+
+    const id = generateSessionId();
+    expect(mathRandom).toHaveBeenCalled();
+    expect(id).toMatch(UUID_V4);
+  });
+
+  it('falls back to getRandomValues when randomUUID throws (secure-context guard)', () => {
+    const getRandomValues = vi.fn(fillDeterministic(13));
+    vi.stubGlobal('crypto', {
+      randomUUID: (): string => {
+        throw new Error('not a secure context');
+      },
+      getRandomValues,
+    });
+
+    const id = generateSessionId();
+    expect(getRandomValues).toHaveBeenCalledTimes(1);
+    expect(id).toMatch(UUID_V4);
+  });
+
+  it('produces unique identifiers across calls', () => {
+    const ids = new Set(Array.from({ length: 100 }, () => generateSessionId()));
+    expect(ids.size).toBe(100);
+  });
+});

--- a/frontend/src/lib/utils/session.ts
+++ b/frontend/src/lib/utils/session.ts
@@ -14,6 +14,21 @@
  * valid RFC 4122 v4 UUID. The identifier is a concurrency token, not an
  * authentication secret, so the non-cryptographic last resort is acceptable.
  */
+
+// RFC 4122 v4 UUID layout constants (kept named so the bit handling is auditable).
+const UUID_BYTE_LENGTH = 16;
+const UUID_VERSION_BYTE_INDEX = 6; // byte carrying the 4-bit version field
+const UUID_VARIANT_BYTE_INDEX = 8; // byte carrying the 2-bit variant field
+const UUID_VERSION_NIBBLE_MASK = 0x0f; // clears the high nibble before setting the version
+const UUID_VERSION_4_BITS = 0x40; // version 4 (0100) in the high nibble
+const UUID_VARIANT_BITS_MASK = 0x3f; // clears the top two bits before setting the variant
+const UUID_VARIANT_RFC4122_BITS = 0x80; // variant 10xx
+const UUID_GROUP_LENGTHS = [8, 4, 4, 4, 12] as const; // canonical 8-4-4-4-12 hex grouping
+
+const HEX_RADIX = 16;
+const HEX_BYTE_WIDTH = 2; // hex digits per byte
+const BYTE_VALUE_COUNT = 256; // number of distinct byte values [0, 255]
+
 export function generateSessionId(): string {
   return uuidv4();
 }
@@ -24,18 +39,24 @@ function uuidv4(): string {
     return native;
   }
 
-  const bytes = randomBytes(16);
+  const bytes = randomBytes(UUID_BYTE_LENGTH);
   const hex = Array.from(bytes, (byte, index) => {
     let value = byte;
-    if (index === 6) {
-      value = (value & 0x0f) | 0x40; // version 4
-    } else if (index === 8) {
-      value = (value & 0x3f) | 0x80; // variant 10xx
+    if (index === UUID_VERSION_BYTE_INDEX) {
+      value = (value & UUID_VERSION_NIBBLE_MASK) | UUID_VERSION_4_BITS;
+    } else if (index === UUID_VARIANT_BYTE_INDEX) {
+      value = (value & UUID_VARIANT_BITS_MASK) | UUID_VARIANT_RFC4122_BITS;
     }
-    return value.toString(16).padStart(2, '0');
+    return value.toString(HEX_RADIX).padStart(HEX_BYTE_WIDTH, '0');
   }).join('');
 
-  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+  const groups: string[] = [];
+  let offset = 0;
+  for (const length of UUID_GROUP_LENGTHS) {
+    groups.push(hex.slice(offset, offset + length));
+    offset += length;
+  }
+  return groups.join('-');
 }
 
 function tryNativeUUID(): string | null {
@@ -59,5 +80,5 @@ function randomBytes(length: number): Uint8Array {
   } catch {
     // getRandomValues threw (extremely rare); fall back to Math.random below.
   }
-  return bytes.map(() => Math.floor(Math.random() * 256));
+  return bytes.map(() => Math.floor(Math.random() * BYTE_VALUE_COUNT));
 }

--- a/frontend/src/lib/utils/session.ts
+++ b/frontend/src/lib/utils/session.ts
@@ -27,6 +27,8 @@ const UUID_GROUP_LENGTHS = [8, 4, 4, 4, 12] as const; // canonical 8-4-4-4-12 he
 
 const HEX_RADIX = 16;
 const HEX_BYTE_WIDTH = 2; // hex digits per byte
+const HEX_PADDING_CHARACTER = '0'; // left-pad for a single-digit hex byte
+const UUID_GROUP_SEPARATOR = '-'; // separator between the 8-4-4-4-12 groups
 const BYTE_VALUE_COUNT = 256; // number of distinct byte values [0, 255]
 
 export function generateSessionId(): string {
@@ -47,7 +49,7 @@ function uuidv4(): string {
     } else if (index === UUID_VARIANT_BYTE_INDEX) {
       value = (value & UUID_VARIANT_BITS_MASK) | UUID_VARIANT_RFC4122_BITS;
     }
-    return value.toString(HEX_RADIX).padStart(HEX_BYTE_WIDTH, '0');
+    return value.toString(HEX_RADIX).padStart(HEX_BYTE_WIDTH, HEX_PADDING_CHARACTER);
   }).join('');
 
   const groups: string[] = [];
@@ -56,7 +58,7 @@ function uuidv4(): string {
     groups.push(hex.slice(offset, offset + length));
     offset += length;
   }
-  return groups.join('-');
+  return groups.join(UUID_GROUP_SEPARATOR);
 }
 
 function tryNativeUUID(): string | null {

--- a/frontend/src/lib/utils/session.ts
+++ b/frontend/src/lib/utils/session.ts
@@ -1,7 +1,63 @@
+/**
+ * Generate a session identifier used to distinguish concurrent live-audio
+ * consumers (the HLS audio player and the dashboard spectrogram) running on the
+ * same host. The backend keys its per-client reference count on this value, so it
+ * MUST be unique per component and in a format the backend accepts (a canonical
+ * UUID or another safe token). If two components send the same identifier the
+ * backend collapses them into one client, and the first to stop tears the shared
+ * stream down for the other.
+ *
+ * `crypto.randomUUID()` is only defined in a secure context, and BirdNET-Go is
+ * commonly served over plain HTTP on home networks, so we must not rely on it.
+ * We fall back to `crypto.getRandomValues()` (available on plain HTTP) and, if the
+ * Web Crypto API is absent or throws, to `Math.random()`. All three paths return a
+ * valid RFC 4122 v4 UUID. The identifier is a concurrency token, not an
+ * authentication secret, so the non-cryptographic last resort is acceptable.
+ */
 export function generateSessionId(): string {
-  try {
-    return crypto.randomUUID();
-  } catch {
-    return `fallback-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  return uuidv4();
+}
+
+function uuidv4(): string {
+  const native = tryNativeUUID();
+  if (native !== null) {
+    return native;
   }
+
+  const bytes = randomBytes(16);
+  const hex = Array.from(bytes, (byte, index) => {
+    let value = byte;
+    if (index === 6) {
+      value = (value & 0x0f) | 0x40; // version 4
+    } else if (index === 8) {
+      value = (value & 0x3f) | 0x80; // variant 10xx
+    }
+    return value.toString(16).padStart(2, '0');
+  }).join('');
+
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+function tryNativeUUID(): string | null {
+  try {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+  } catch {
+    // Secure-context guard threw; fall back to manual generation.
+  }
+  return null;
+}
+
+function randomBytes(length: number): Uint8Array {
+  const bytes = new Uint8Array(length);
+  try {
+    if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+      crypto.getRandomValues(bytes);
+      return bytes;
+    }
+  } catch {
+    // getRandomValues threw (extremely rare); fall back to Math.random below.
+  }
+  return bytes.map(() => Math.floor(Math.random() * 256));
 }

--- a/internal/api/v2/audio/audio_hls.go
+++ b/internal/api/v2/audio/audio_hls.go
@@ -691,16 +691,60 @@ func (c *Handler) generateClientID(ctx echo.Context) string {
 	return clientIP + "-" + clientType
 }
 
-// resolveClientID returns a client identifier, preferring session-based ID when available.
-// Session ID is validated as a UUID and prefixed with IP to prevent spoofing.
-// Invalid or missing session IDs fall back to IP+UA-based identification.
-func (c *Handler) resolveClientID(ctx echo.Context, sessionID string) string {
-	if sessionID != "" {
-		if _, err := uuid.Parse(sessionID); err == nil {
-			return c.extractRemoteAddr(ctx) + "-" + sessionID
+// hlsSessionIDMinLen and hlsSessionIDMaxLen bound the length of a client-supplied
+// HLS session identifier that resolveClientID will accept. The lower bound keeps
+// trivially short tokens out; the upper bound caps how much client-controlled data
+// can enter the client-tracking map.
+const (
+	hlsSessionIDMinLen = 8
+	hlsSessionIDMaxLen = 128
+)
+
+// hlsSessionClientPrefix namespaces client IDs derived from a client-supplied
+// session ID. Without it a crafted session ID could equal the User-Agent type
+// segment that generateClientID appends (for example "HLSPlayer"), letting a
+// session-based client collide with a fallback client on the same IP. The prefix
+// keeps the two identity spaces disjoint regardless of the fallback type strings.
+const hlsSessionClientPrefix = "sid"
+
+// isSafeSessionID reports whether a client-supplied session identifier is safe to
+// embed in a client ID. It accepts bounded-length tokens containing only
+// URL/filename-safe characters ([A-Za-z0-9._-]). This admits canonical UUIDs as
+// well as other unique tokens a client may send (an alternate or older client may
+// use a non-canonical but still unique token), while rejecting empty, oversized,
+// or structurally unexpected input.
+func isSafeSessionID(sessionID string) bool {
+	if len(sessionID) < hlsSessionIDMinLen || len(sessionID) > hlsSessionIDMaxLen {
+		return false
+	}
+	for _, ch := range sessionID {
+		switch {
+		case ch >= 'a' && ch <= 'z',
+			ch >= 'A' && ch <= 'Z',
+			ch >= '0' && ch <= '9',
+			ch == '.', ch == '_', ch == '-':
+			// allowed character
+		default:
+			return false
 		}
 	}
-	// Fallback for non-browser clients (VLC, FFmpeg, etc.) or invalid session IDs
+	return true
+}
+
+// resolveClientID returns a client identifier, preferring a client-supplied
+// session ID when it is present and safe. The session ID is prefixed with the
+// remote IP so a client can never impersonate another IP's clients, and it lets
+// multiple live-audio consumers on the same host (for example the HLS player and
+// the dashboard spectrogram) be tracked as distinct clients instead of collapsing
+// onto a single IP+UA identity. Missing or unsafe session IDs fall back to
+// IP+UA-based identification (used by non-browser clients such as VLC and FFmpeg).
+func (c *Handler) resolveClientID(ctx echo.Context, sessionID string) string {
+	if isSafeSessionID(sessionID) {
+		// Namespace session-derived IDs so a crafted session ID can never collide
+		// with a generateClientID fallback (see hlsSessionClientPrefix).
+		return c.extractRemoteAddr(ctx) + "-" + hlsSessionClientPrefix + "-" + sessionID
+	}
+	// Fallback for non-browser clients (VLC, FFmpeg, etc.) or unsafe session IDs
 	return c.generateClientID(ctx)
 }
 

--- a/internal/api/v2/audio/audio_hls_test.go
+++ b/internal/api/v2/audio/audio_hls_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -507,9 +508,11 @@ func TestGetOrCreateStreamTokenConcurrency(t *testing.T) {
 
 // TestResolveClientID tests the resolveClientID method
 func TestResolveClientID(t *testing.T) {
+	t.Parallel()
 	const testRemoteAddr = "192.168.1.100:12345"
 
 	t.Run("prefers session ID when provided", func(t *testing.T) {
+		t.Parallel()
 		c := &Handler{Core: &apicore.Core{}}
 		c.Settings.Store(apitest.NewValidTestSettings())
 		e := echo.New()
@@ -524,6 +527,7 @@ func TestResolveClientID(t *testing.T) {
 	})
 
 	t.Run("falls back to generateClientID when no session", func(t *testing.T) {
+		t.Parallel()
 		c := &Handler{Core: &apicore.Core{}}
 		c.Settings.Store(apitest.NewValidTestSettings())
 		e := echo.New()
@@ -539,6 +543,7 @@ func TestResolveClientID(t *testing.T) {
 	})
 
 	t.Run("different sessions from same IP get different IDs", func(t *testing.T) {
+		t.Parallel()
 		c := &Handler{Core: &apicore.Core{}}
 		c.Settings.Store(apitest.NewValidTestSettings())
 		e := echo.New()
@@ -556,7 +561,8 @@ func TestResolveClientID(t *testing.T) {
 		assert.NotEqual(t, id1, id2)
 	})
 
-	t.Run("rejects invalid session ID format", func(t *testing.T) {
+	t.Run("accepts safe non-UUID session ID", func(t *testing.T) {
+		t.Parallel()
 		c := &Handler{Core: &apicore.Core{}}
 		c.Settings.Store(apitest.NewValidTestSettings())
 		e := echo.New()
@@ -565,12 +571,99 @@ func TestResolveClientID(t *testing.T) {
 		req.Header.Set("User-Agent", "Mozilla/5.0")
 		ctx := e.NewContext(req, httptest.NewRecorder())
 
-		// Non-UUID session ID should be rejected
-		clientID := c.resolveClientID(ctx, "not-a-valid-uuid")
-		// Should fall back to IP+UA-based ID
-		assert.Contains(t, clientID, "Browser")
-		assert.NotContains(t, clientID, "not-a-valid-uuid")
+		// A safe but non-canonical token (an alternate or older client may send one)
+		// must still identify a distinct client; otherwise concurrent consumers on
+		// the same host collapse to one client ID and tear down each other's shared
+		// stream.
+		safeSession := "client-1712345678901-abc123xyz"
+		clientID := c.resolveClientID(ctx, safeSession)
+		assert.Contains(t, clientID, "192.168.1.100")
+		assert.Contains(t, clientID, safeSession)
+		assert.NotContains(t, clientID, "Browser")
 	})
+
+	t.Run("session ID matching a fallback client type does not collide", func(t *testing.T) {
+		t.Parallel()
+		// A crafted session ID equal to generateClientID's fallback type string
+		// (e.g. "HLSPlayer", which is itself a safe token) must not resolve to the
+		// same client ID as an unrecognized-UA client with no session on the same
+		// IP. The session namespace prefix keeps the two identity spaces disjoint.
+		c := &Handler{Core: &apicore.Core{}}
+		c.Settings.Store(apitest.NewValidTestSettings())
+		e := echo.New()
+
+		reqSession := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+		reqSession.RemoteAddr = testRemoteAddr
+		reqSession.Header.Set("User-Agent", "curl/8.0") // unrecognized UA
+		ctxSession := e.NewContext(reqSession, httptest.NewRecorder())
+
+		reqFallback := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+		reqFallback.RemoteAddr = testRemoteAddr          // same IP
+		reqFallback.Header.Set("User-Agent", "curl/8.0") // same unrecognized UA -> "HLSPlayer" type
+		ctxFallback := e.NewContext(reqFallback, httptest.NewRecorder())
+
+		sessionID := c.resolveClientID(ctxSession, "HLSPlayer")
+		fallbackID := c.resolveClientID(ctxFallback, "")
+		assert.NotEqual(t, sessionID, fallbackID)
+	})
+
+	t.Run("rejects unsafe or malformed session ID", func(t *testing.T) {
+		t.Parallel()
+		c := &Handler{Core: &apicore.Core{}}
+		c.Settings.Store(apitest.NewValidTestSettings())
+		e := echo.New()
+
+		for _, unsafe := range []string{
+			"short",                // below minimum length
+			"has spaces here",      // whitespace not allowed
+			"path/../traversal",    // slashes not allowed
+			"semi;colon;injection", // punctuation not allowed
+			strings.Repeat("a", hlsSessionIDMaxLen+1), // above maximum length
+		} {
+			req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+			req.RemoteAddr = testRemoteAddr
+			req.Header.Set("User-Agent", "Mozilla/5.0")
+			ctx := e.NewContext(req, httptest.NewRecorder())
+
+			clientID := c.resolveClientID(ctx, unsafe)
+			// Should fall back to IP+UA-based ID and never echo the unsafe token.
+			assert.Contains(t, clientID, "Browser", "input %q should fall back", unsafe)
+			assert.NotContains(t, clientID, unsafe)
+		}
+	})
+}
+
+// TestIsSafeSessionID tests the isSafeSessionID validation helper directly.
+func TestIsSafeSessionID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		sessionID string
+		want      bool
+	}{
+		{name: "canonical uuid", sessionID: "550e8400-e29b-41d4-a716-446655440000", want: true},
+		{name: "fallback token", sessionID: "fallback-1712345678901-abc123xyz", want: true},
+		{name: "alphanumeric with dot and underscore", sessionID: "a.b_c-1234", want: true},
+		{name: "uppercase and mixed case", sessionID: "ABCdef-1234", want: true},
+		{name: "minimum length", sessionID: strings.Repeat("a", hlsSessionIDMinLen), want: true},
+		{name: "maximum length", sessionID: strings.Repeat("a", hlsSessionIDMaxLen), want: true},
+		{name: "empty", sessionID: "", want: false},
+		{name: "one below minimum length", sessionID: strings.Repeat("a", hlsSessionIDMinLen-1), want: false},
+		{name: "one above maximum length", sessionID: strings.Repeat("a", hlsSessionIDMaxLen+1), want: false},
+		{name: "space", sessionID: "abc def ghi", want: false},
+		{name: "slash", sessionID: "abc/def/ghi", want: false},
+		{name: "semicolon", sessionID: "abc;def;ghi", want: false},
+		{name: "plus and at signs", sessionID: "abc+def@ghi", want: false},
+		{name: "non-ascii", sessionID: "abcdéfghij", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isSafeSessionID(tt.sessionID))
+		})
+	}
 }
 
 // TestHLSConsumer_WriteDoesNotRetainFrameData verifies that hlsConsumer.Write


### PR DESCRIPTION
## Summary

Opening the dashboard live spectrogram while the HLS audio player was already streaming tore both down with repeated 404 "Stream not found" on the playlist. The dashboard runs two independent HLS consumers (the audio player and the mini spectrogram) that share one backend stream and one token per source, kept alive by a per-client reference count.

Client identity came from the frontend `session_id`, but the backend only honored it when it parsed as a UUID. On plain HTTP (a non-secure context) `crypto.randomUUID()` is undefined, so the frontend fell back to a non-UUID token that the backend rejected, collapsing both consumers to a single IP+User-Agent client id. The first consumer to stop then dropped the only reference and tore down the shared stream for the other. On HTTPS the UUIDs were valid, so the bug only reproduced on plain-HTTP deployments (the common home-network case).

## Changes

Frontend (`session.ts`): `generateSessionId()` now always returns a valid RFC 4122 v4 UUID, using `crypto.getRandomValues()` and finally `Math.random()` when `crypto.randomUUID()` is unavailable, so distinct consumers always send distinct, valid identifiers even on plain HTTP.

Backend (`resolveClientID`): accepts any safe session id (bounded length, `[A-Za-z0-9._-]`) instead of requiring a canonical UUID, so a unique-but-non-canonical token from any client still identifies a distinct client. Session-derived client ids are namespaced so a crafted session id cannot collide with the IP+User-Agent fallback (for example `HLSPlayer`). The remote IP prefix is retained as the anti-spoofing mechanism.

## Test Plan

- [x] `go test -race ./internal/api/v2/audio/` (new `TestIsSafeSessionID`, expanded `TestResolveClientID` incl. a fallback-collision case)
- [x] Frontend `vitest run src/lib/utils/session.test.ts` (native / getRandomValues / Math.random / throwing-randomUUID branches all pinned)
- [x] `golangci-lint run` clean, `go vet` clean, frontend `npm run check:all` clean
- [ ] Manual: open the live spectrogram and the audio player together over plain HTTP; both keep streaming, and stopping one leaves the other running

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Session identifiers are now generated as standards-compliant UUIDs with reliable fallback options across supported browser environments.
  * HLS playback accepts a broader range of safe session identifiers, including valid non-UUID values.
  * Unsafe, malformed, or missing identifiers continue to receive safe fallback handling, helping maintain reliable playback sessions.

* **Tests**
  * Expanded coverage for session ID generation, validation, formatting, fallback behavior, and collision prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->