### PR TITLE
fix(test): make notflite and integration tagged builds green on main

### DIFF
--- a/internal/api/v2/system/inference_status_test.go
+++ b/internal/api/v2/system/inference_status_test.go
@@ -209,9 +209,10 @@ func TestApplyRuntimeBackend(t *testing.T) {
 }
 
 // TestGetInferenceStatus_HTTP200 verifies that GetInferenceStatus returns HTTP
-// 200 and a valid InferenceStatusResponse with TFLite marked available. It uses
-// an apitest.NewCore-backed Handler over httptest to exercise the handler
-// without starting any background goroutines.
+// 200 and a valid InferenceStatusResponse whose TFLite backend availability
+// tracks the compiled-in state (true by default, false under the notflite build
+// tag). It uses an apitest.NewCore-backed Handler over httptest to exercise the
+// handler without starting any background goroutines.
 func TestGetInferenceStatus_HTTP200(t *testing.T) {
 	// NOT parallel: apitest.NewCore publishes settings to the process-global snapshot.
 	e := echo.New()
@@ -226,7 +227,7 @@ func TestGetInferenceStatus_HTTP200(t *testing.T) {
 
 	var resp InferenceStatusResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp), "response body must unmarshal to InferenceStatusResponse")
-	assert.True(t, resp.Backends.TFLite.Available, "TFLite backend must always report Available=true")
+	assert.Equal(t, hwprofile.TFLiteLinked(), resp.Backends.TFLite.Available, "TFLite backend availability must match the compiled-in state (false under the notflite build tag)")
 	assert.NotZero(t, resp.SnapshotAtUnix, "SnapshotAtUnix must be a non-zero Unix timestamp")
 }
 

--- a/internal/hwprofile/tflite_available_test.go
+++ b/internal/hwprofile/tflite_available_test.go
@@ -1,0 +1,17 @@
+//go:build !notflite
+
+package hwprofile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTFLiteLinked_DefaultBuild pins the compile-time guarantee that a normal
+// build links the TFLite backend. It is the counterpart to the notflite-tagged
+// test and keeps the API-level equality assertions from silently passing if a
+// regression ever dropped TFLite from the default build.
+func TestTFLiteLinked_DefaultBuild(t *testing.T) {
+	require.True(t, TFLiteLinked(), "TFLiteLinked() must be true on a default (non-notflite) build")
+}

--- a/internal/hwprofile/tflite_unavailable_test.go
+++ b/internal/hwprofile/tflite_unavailable_test.go
@@ -1,0 +1,17 @@
+//go:build notflite
+
+package hwprofile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTFLiteLinked_NotfliteBuild pins the compile-time guarantee that the
+// notflite build tag produces a strictly-ONNX build reporting TFLite as not
+// linked, so the tflite capability token is never emitted for a binary with no
+// TFLite runtime.
+func TestTFLiteLinked_NotfliteBuild(t *testing.T) {
+	require.False(t, TFLiteLinked(), "TFLiteLinked() must be false under the notflite build tag")
+}

--- a/internal/notification/ntfy_auth_integration_test.go
+++ b/internal/notification/ntfy_auth_integration_test.go
@@ -19,6 +19,7 @@ import (
 // and registers cleanup.
 func setupNtfyAuthContainer(t *testing.T, username, password string) *containers.NtfyContainer {
 	t.Helper()
+	containers.SkipIfContainerRuntimeUnavailable(t)
 	ctx := t.Context()
 	cfg := containers.DefaultNtfyConfig()
 	cfg.EnableAuth = true

--- a/internal/notification/ntfy_integration_test.go
+++ b/internal/notification/ntfy_integration_test.go
@@ -19,6 +19,7 @@ import (
 // setupNtfyContainer creates a no-auth ntfy container and registers cleanup.
 func setupNtfyContainer(t *testing.T) *containers.NtfyContainer {
 	t.Helper()
+	containers.SkipIfContainerRuntimeUnavailable(t)
 	ctx := t.Context()
 	c, err := containers.NewNtfyContainer(ctx, nil)
 	require.NoError(t, err, "failed to start ntfy container")

--- a/internal/testutil/containers/helpers.go
+++ b/internal/testutil/containers/helpers.go
@@ -7,8 +7,12 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"strconv"
+	"testing"
 	"time"
+
+	"github.com/testcontainers/testcontainers-go"
 )
 
 // WaitForHTTP waits for an HTTP endpoint to respond with a 200 status code.
@@ -135,4 +139,53 @@ func GetFreePort() (int, error) {
 		return 0, fmt.Errorf("listener address is not TCP: %T", listener.Addr())
 	}
 	return addr.Port, nil
+}
+
+// containerRuntimeHealthTimeout bounds the daemon health probe in
+// containerRuntimeError so an unresponsive runtime fails fast.
+const containerRuntimeHealthTimeout = 10 * time.Second
+
+// containerRuntimeError returns nil when a Docker-compatible container runtime
+// is reachable, or the reason it is not. It bounds the daemon health probe so an
+// unresponsive runtime (socket present but not answering) fails fast instead of
+// hanging. NewDockerProvider builds the client; Health pings the daemon and
+// closes that client via an internal defer, so there is nothing to clean up here
+// on either path.
+func containerRuntimeError() error {
+	provider, err := testcontainers.NewDockerProvider()
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), containerRuntimeHealthTimeout)
+	defer cancel()
+	return provider.Health(ctx)
+}
+
+// SkipIfContainerRuntimeUnavailable keeps container-backed tests usable on a host
+// with no Docker-compatible runtime. Call it before creating any container.
+//
+// The integration build tag compiles these tests, but a developer host without
+// Docker (for example a rootless Podman setup with no DOCKER_HOST) has no
+// provider to start containers with, so testcontainers fails when it tries. There
+// it skips, so the tests that call it stay green locally while still running
+// wherever a runtime is present.
+//
+// On CI a runtime is promised, so its absence is a real breakage rather than an
+// expected environment: when the CI environment variable is set, a missing or
+// unhealthy runtime fails loudly instead of skipping green and masking the
+// outage. This helper only covers the call sites that invoke it; sibling
+// container suites in other packages are not yet guarded, so it does not by
+// itself make the whole integration-tagged build green.
+func SkipIfContainerRuntimeUnavailable(tb testing.TB) {
+	tb.Helper()
+	err := containerRuntimeError()
+	if err == nil {
+		return
+	}
+	// GitHub Actions and most CI systems set CI; there a container runtime is
+	// expected, so surface its absence as a failure rather than a silent skip.
+	if os.Getenv("CI") != "" {
+		tb.Fatalf("container runtime required on CI but unavailable: %v", err)
+	}
+	tb.Skipf("skipping: container runtime unavailable (%v)", err)
 }

--- a/internal/testutil/containers/helpers.go
+++ b/internal/testutil/containers/helpers.go
@@ -151,12 +151,12 @@ const containerRuntimeHealthTimeout = 10 * time.Second
 // hanging. NewDockerProvider builds the client; Health pings the daemon and
 // closes that client via an internal defer, so there is nothing to clean up here
 // on either path.
-func containerRuntimeError() error {
+func containerRuntimeError(ctx context.Context) error {
 	provider, err := testcontainers.NewDockerProvider()
 	if err != nil {
 		return err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), containerRuntimeHealthTimeout)
+	ctx, cancel := context.WithTimeout(ctx, containerRuntimeHealthTimeout)
 	defer cancel()
 	return provider.Health(ctx)
 }
@@ -178,7 +178,7 @@ func containerRuntimeError() error {
 // itself make the whole integration-tagged build green.
 func SkipIfContainerRuntimeUnavailable(tb testing.TB) {
 	tb.Helper()
-	err := containerRuntimeError()
+	err := containerRuntimeError(tb.Context())
 	if err == nil {
 		return
 	}

--- a/internal/testutil/containers/mosquitto_test.go
+++ b/internal/testutil/containers/mosquitto_test.go
@@ -17,6 +17,7 @@ import (
 // TestMosquittoContainer_ClearRetainedMessages tests the ClearRetainedMessages function
 // to ensure it properly clears retained messages without flakiness.
 func TestMosquittoContainer_ClearRetainedMessages(t *testing.T) {
+	SkipIfContainerRuntimeUnavailable(t)
 	ctx := t.Context()
 
 	// Create Mosquitto container
@@ -124,6 +125,7 @@ func TestMosquittoContainer_ClearRetainedMessages(t *testing.T) {
 // TestMosquittoContainer_ClearRetainedMessages_ContextCancellation tests that
 // ClearRetainedMessages respects context cancellation.
 func TestMosquittoContainer_ClearRetainedMessages_ContextCancellation(t *testing.T) {
+	SkipIfContainerRuntimeUnavailable(t)
 	ctx := t.Context()
 
 	// Create Mosquitto container

--- a/internal/testutil/containers/pebble_test.go
+++ b/internal/testutil/containers/pebble_test.go
@@ -20,6 +20,7 @@ import (
 // lives in internal/api behind the pebble_e2e build tag because it needs the api
 // package's unexported server path.
 func TestPebbleContainer_DirectoryAndRoots(t *testing.T) {
+	SkipIfContainerRuntimeUnavailable(t)
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	t.Cleanup(cancel)
 


### PR DESCRIPTION
## Summary

Two test suites failed under build-tag combinations that the normal PR checks never run, so the drift stayed invisible on pull requests. Both were found while running the full tag matrix and both reproduce on a clean `main` checkout, so neither is a new regression.

`internal/api/v2/system` under `-tags noembed,skipfrontend,notflite`: `TestGetInferenceStatus_HTTP200` hardcoded `assert.True` on `resp.Backends.TFLite.Available`, but that field is set from `hwprofile.TFLiteLinked()`, which is a compile-time fact that is false in an ONNX-only `notflite` build. The assertion now checks equality against `hwprofile.TFLiteLinked()` so it tracks the compiled-in state under every tag (identical to `assert.True` on the default build, correct under `notflite`). To keep the equality check from silently passing if a real regression ever dropped TFLite from the default build, two small build-tagged tests in `internal/hwprofile` pin `TFLiteLinked()` to true by default and false under `notflite`. They are exact tag complements, so exactly one runs in any build and the contract is never left untested.

`internal/notification` under `-tags integration`: the ntfy testcontainers tests hard-failed on a host with no Docker-compatible runtime (for example a rootless Podman setup with no `DOCKER_HOST`) because they call `require.NoError` on container startup. A new `SkipIfContainerRuntimeUnavailable` helper in `internal/testutil/containers` probes the runtime (bounded health check) and skips in local dev, but fails loudly when the `CI` environment variable is set (a runtime is promised there) so a broken daemon on CI cannot skip green and mask an outage. The `mosquitto` and `pebble` tests in the same package adopt the same guard, since they had the identical failure mode.

## Scope and follow-ups

This fixes the two suites named above plus the container tests in the same `internal/testutil/containers` package. Integration container tests in other packages (`internal/api/v2/notifications`, `internal/api` AutoTLS/pebble, and the `datastore` MySQL suites) have the same runtime-less hard-fail and are not touched here; the `TestMain`-based ones need a companion helper that does not take `*testing.T`. I will file a follow-up to adopt the guard repo-wide. Separately, these tag combinations are still not part of any CI `go test` job (CI only compiles the `notflite` tree and runs the container suites where Docker is present), which is the periodic-run gap the issue itself raised; wiring a periodic tag-matrix run is a CI-workflow change best done on its own.

## Test Plan

- [x] `go test -tags "noembed,skipfrontend,notflite" ./internal/api/v2/system/...` passes
- [x] `go test -tags integration ./internal/notification/...` passes (ntfy tests skip locally with no runtime)
- [x] `go test -tags notflite ./internal/hwprofile/...` and default build both pass the new TFLite tests
- [x] Container suites in `internal/testutil/containers` skip locally, and fail loudly under `CI=true` when no runtime is present
- [x] Default `-race` run of all affected packages is green
- [x] `golangci-lint` clean on the changed packages under default, `notflite`, and `integration` tag sets

## Related Issues

Fixes #4211

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved coverage for TFLite availability in builds with and without TFLite support.
  - Integration tests now detect unavailable container runtimes before setup.
  - Tests skip gracefully when containers are unavailable locally while still failing appropriately in CI.
  - Updated notification, messaging, and containerized service integration test coverage.
  - Expanded inference-status validation to reflect the capabilities of each build configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->