### PR TITLE
fix(lint): resolve Go 1.27 / golangci-lint v2.13.2 follow-ups

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -19,6 +19,17 @@ linters:
         text: "dupSubExpr"
         linters:
           - gocritic
+      # The notflite stub build of NewTFLiteClassifier / NewTFLiteRangeFilter
+      # always returns a non-nil error, so staticcheck's SA4023 flags the
+      # `if err != nil` guards (and their related-information notes) as "always
+      # true" under -tags notflite. Those guards are real runtime checks in the
+      # default tflite build; suppress the stub-only false positive for this
+      # file. CI never lints the notflite tag (it is a compile check only), so
+      # this only affects the notflite lint lane.
+      - path: internal/classifier/birdnet.go
+        text: "SA4023"
+        linters:
+          - staticcheck
       # goconst v1.9.0+ started walking
       # composite-literal nodes (map keys, slice elements, struct-init values),
       # which surfaced hundreds of "make it a constant" nits for inline
@@ -59,7 +70,7 @@ linters:
     - thelper
     - testifylint
     - gocyclo
-    # - modernize  # Disabled: enabling surfaces many modernization suggestions (e.g. embedlit) across the codebase; deferred to a dedicated cleanup pass rather than the toolchain bump
+    - modernize  # Re-enabled under golangci-lint v2.13.2 + Go 1.27: the earlier Go 1.26 atomic-types panic no longer reproduces, and the codebase was modernized in the same change
     - forbidigo  # Sensitive field name detection
     # Performance linters
     - prealloc

--- a/internal/analysis/jobqueue/queue_test.go
+++ b/internal/analysis/jobqueue/queue_test.go
@@ -1586,34 +1586,28 @@ func TestJobTypeStatistics(t *testing.T) {
 
 	// Configure actions with descriptions
 	successAction := &SuccessActionType{
-		MockAction: MockAction{
-			Description: "Success Action",
-		},
+		Description: "Success Action",
 	}
 
 	failAction := &FailActionType{
-		MockAction: MockAction{
-			Description: "Fail Action",
-			ExecuteFunc: func(data any) error {
-				return errors.New("simulated failure")
-			},
+		Description: "Fail Action",
+		ExecuteFunc: func(data any) error {
+			return errors.New("simulated failure")
 		},
 	}
 
 	// Create a counter for retry attempts
 	retryCounter := 0
 	retryAction := &RetryActionType{
-		MockAction: MockAction{
-			Description: "Retry Action",
-			ExecuteFunc: func(data any) error {
-				// Increment counter and check
-				retryCounter++
-				// Fail on first attempt, succeed on retry
-				if retryCounter == 1 {
-					return errors.New("simulated failure for retry")
-				}
-				return nil
-			},
+		Description: "Retry Action",
+		ExecuteFunc: func(data any) error {
+			// Increment counter and check
+			retryCounter++
+			// Fail on first attempt, succeed on retry
+			if retryCounter == 1 {
+				return errors.New("simulated failure for retry")
+			}
+			return nil
 		},
 	}
 

--- a/internal/analysis/processor/save_audio_action_test.go
+++ b/internal/analysis/processor/save_audio_action_test.go
@@ -196,10 +196,7 @@ func TestSaveAudioDeferredMaxRetries_ScalesWithDuration(t *testing.T) {
 			delay := saveAudioDeferredInitialDelay
 			for range retries {
 				total += delay
-				delay = time.Duration(float64(delay) * saveAudioDeferredMultiplier)
-				if delay > saveAudioDeferredMaxDelay {
-					delay = saveAudioDeferredMaxDelay
-				}
+				delay = min(time.Duration(float64(delay)*saveAudioDeferredMultiplier), saveAudioDeferredMaxDelay)
 			}
 			assert.GreaterOrEqual(t, total, tt.minTotal,
 				"retry schedule must cover capture duration + margin for %s", tt.name)

--- a/internal/analysis/species/species_tracker_race_condition_test.go
+++ b/internal/analysis/species/species_tracker_race_condition_test.go
@@ -234,8 +234,8 @@ func TestHighContentionScenario(t *testing.T) {
 	)
 
 	species := "Maximum_Contention_Species"
-	var negativeCount int64
-	var totalCount int64
+	var negativeCount atomic.Int64
+	var totalCount atomic.Int64
 	var wg sync.WaitGroup
 
 	baseTime := time.Now()
@@ -251,9 +251,9 @@ func TestHighContentionScenario(t *testing.T) {
 
 				isNew, days := tracker.CheckAndUpdateSpecies(species, detectionTime)
 
-				atomic.AddInt64(&totalCount, 1)
+				totalCount.Add(1)
 				if days < 0 {
-					atomic.AddInt64(&negativeCount, 1)
+					negativeCount.Add(1)
 				}
 
 				_ = isNew // Use the result to prevent optimization
@@ -265,11 +265,11 @@ func TestHighContentionScenario(t *testing.T) {
 
 	t.Logf("High contention test results:")
 	t.Logf("  Single species: %s", species)
-	t.Logf("  Total operations: %d", atomic.LoadInt64(&totalCount))
-	t.Logf("  Negative day results: %d", atomic.LoadInt64(&negativeCount))
+	t.Logf("  Total operations: %d", totalCount.Load())
+	t.Logf("  Negative day results: %d", negativeCount.Load())
 
-	if atomic.LoadInt64(&negativeCount) > 0 {
-		errorRate := float64(atomic.LoadInt64(&negativeCount)) / float64(atomic.LoadInt64(&totalCount)) * 100
+	if negativeCount.Load() > 0 {
+		errorRate := float64(negativeCount.Load()) / float64(totalCount.Load()) * 100
 		t.Logf("  🔥 Race condition rate: %.2f%%", errorRate)
 		t.Logf("  📊 This demonstrates the race condition under maximum contention")
 	} else {

--- a/internal/api/v2/analytics/heatmap.go
+++ b/internal/api/v2/analytics/heatmap.go
@@ -339,10 +339,7 @@ func (c *Handler) computeHeatmapGrid(birdnet *classifier.Orchestrator, params *h
 
 		// Process in chunks of heatmapBatchSize to release the lock between calls
 		for chunkStart := 0; chunkStart < totalCells; chunkStart += heatmapBatchSize {
-			chunkEnd := chunkStart + heatmapBatchSize
-			if chunkEnd > totalCells {
-				chunkEnd = totalCells
-			}
+			chunkEnd := min(chunkStart+heatmapBatchSize, totalCells)
 			chunkSize := chunkEnd - chunkStart
 
 			chunkInputs := inputs[chunkStart*3 : chunkEnd*3]

--- a/internal/api/v2/audio/audio_level.go
+++ b/internal/api/v2/audio/audio_level.go
@@ -58,7 +58,7 @@ type audioLevelManager struct {
 	// Mutex for connection count operations
 	connectionMu sync.Mutex
 	// Total connection counter for monitoring
-	totalConnections int64
+	totalConnections atomic.Int64
 	// Stream anonymization map for non-authenticated users (bounded to maxStreamSources)
 	streamAnonymMap map[string]string
 	streamAnonymMu  sync.RWMutex
@@ -280,11 +280,11 @@ func (c *Handler) StreamAudioLevel(ctx echo.Context) error {
 			}
 		}
 		audioLevelMgr.connectionMu.Unlock()
-		atomic.AddInt64(&audioLevelMgr.totalConnections, -1)
+		audioLevelMgr.totalConnections.Add(-1)
 	}()
 
 	// Track connection
-	atomic.AddInt64(&audioLevelMgr.totalConnections, 1)
+	audioLevelMgr.totalConnections.Add(1)
 
 	// Track metrics if available
 	if c.Metrics != nil && c.Metrics.HTTP != nil {
@@ -333,7 +333,7 @@ func (c *Handler) StreamAudioLevel(ctx echo.Context) error {
 	// Log connection
 	c.LogAPIRequest(ctx, logger.LogLevelInfo, "Audio level SSE client connected",
 		logger.Bool("authenticated", isAuthenticated),
-		logger.Int64("total_connections", atomic.LoadInt64(&audioLevelMgr.totalConnections)))
+		logger.Int64("total_connections", audioLevelMgr.totalConnections.Load()))
 
 	// Send initial empty update to establish connection
 	if err := c.sendAudioLevelUpdate(ctx, levels); err != nil {

--- a/internal/api/v2/sse/sse_connection_test.go
+++ b/internal/api/v2/sse/sse_connection_test.go
@@ -266,19 +266,19 @@ func testSingleConnectionContextCancellation(t *testing.T, server *httptest.Serv
 func testMultipleConcurrentConnections(t *testing.T, server *httptest.Server, config SSETestConfig) {
 	t.Helper()
 	var wg sync.WaitGroup
-	var connectionsEstablished int32
+	var connectionsEstablished atomic.Int32
 
 	for i := range config.maxConnections {
 		connID := i
 		wg.Go(func() {
 			if attemptSSEConnection(t, server.URL, config.endpoint, connID, config.testTimeout) {
-				atomic.AddInt32(&connectionsEstablished, 1)
+				connectionsEstablished.Add(1)
 			}
 		})
 	}
 
 	wg.Wait()
-	require.Positive(t, int(atomic.LoadInt32(&connectionsEstablished)),
+	require.Positive(t, int(connectionsEstablished.Load()),
 		"At least one connection should have been established")
 }
 

--- a/internal/audiocore/equalizer/builder.go
+++ b/internal/audiocore/equalizer/builder.go
@@ -28,10 +28,7 @@ func BuildFilterChain(settings conf.EqualizerSettings, sampleRate int) *FilterCh
 
 	for i := range settings.Filters {
 		f := &settings.Filters[i]
-		passes := f.Passes
-		if passes < 1 {
-			passes = 1
-		}
+		passes := max(f.Passes, 1)
 
 		filter, err := buildFilter(f, sr, passes)
 		if err != nil {

--- a/internal/audiocore/liveness.go
+++ b/internal/audiocore/liveness.go
@@ -98,9 +98,9 @@ type SourceHealthSnapshot struct {
 	SourceID     string        `json:"source_id"`
 	State        string        `json:"state"`
 	Retries      int           `json:"retries"`
-	LastRestart  time.Time     `json:"last_restart,omitempty"`
+	LastRestart  time.Time     `json:"last_restart,omitzero"`
 	StateEntered time.Time     `json:"state_entered"`
-	LastDispatch time.Time     `json:"last_dispatch,omitempty"`
+	LastDispatch time.Time     `json:"last_dispatch,omitzero"`
 	RawState     LivenessState `json:"-"`
 }
 

--- a/internal/audiocore/normbench/corpus_test.go
+++ b/internal/audiocore/normbench/corpus_test.go
@@ -178,10 +178,7 @@ func transientOverQuietBed(clip []byte) []byte {
 	// dominate the gated integrated loudness, short enough to leave the bed as
 	// the clip's character.
 	burstStart := (len(out) / 3) &^ 1 // keep the offset sample-aligned
-	burstEnd := burstStart + bytesPerSecond
-	if burstEnd > len(out) {
-		burstEnd = len(out)
-	}
+	burstEnd := min(burstStart+bytesPerSecond, len(out))
 	copy(out[burstStart:burstEnd], clip[burstStart:burstEnd])
 	return out
 }

--- a/internal/audiocore/router_pcm_align_test.go
+++ b/internal/audiocore/router_pcm_align_test.go
@@ -26,12 +26,10 @@ type collectingConsumer struct {
 
 func newCollectingConsumer(sampleRate int) *collectingConsumer {
 	return &collectingConsumer{
-		mockConsumer: mockConsumer{
-			id:         "align-consumer",
-			sampleRate: sampleRate,
-			bitDepth:   16,
-			channels:   1,
-		},
+		id:         "align-consumer",
+		sampleRate: sampleRate,
+		bitDepth:   16,
+		channels:   1,
 	}
 }
 

--- a/internal/audiocore/router_test.go
+++ b/internal/audiocore/router_test.go
@@ -1050,14 +1050,12 @@ type slowConsumer struct {
 
 func newSlowConsumer(id string, delay time.Duration) *slowConsumer {
 	return &slowConsumer{
-		mockConsumer: mockConsumer{
-			id:         id,
-			sampleRate: 48000,
-			bitDepth:   16,
-			channels:   1,
-			frames:     make(chan AudioFrame, 256),
-		},
-		delay: delay,
+		id:         id,
+		sampleRate: 48000,
+		bitDepth:   16,
+		channels:   1,
+		frames:     make(chan AudioFrame, 256),
+		delay:      delay,
 	}
 }
 

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -307,9 +307,7 @@ func (m *Manager) RunBackup(ctx context.Context) error {
 	sourcesLen := len(m.sources)
 	targetsLen := len(m.targets)
 	sources := make(map[string]Source, sourcesLen)
-	for k, v := range m.sources {
-		sources[k] = v
-	}
+	maps.Copy(sources, m.sources)
 	m.mu.RUnlock()
 
 	// Early-return when neither sources nor targets have been registered.

--- a/internal/backup/targets/gdrive.go
+++ b/internal/backup/targets/gdrive.go
@@ -689,12 +689,10 @@ func (t *GDriveTarget) List(ctx context.Context) ([]backup.BackupInfo, error) {
 				}
 
 				backups = append(backups, backup.BackupInfo{
-					Target: file.Name,
-					Metadata: backup.Metadata{
-						ID:        file.Id,
-						Timestamp: createdTime,
-						Size:      file.Size,
-					},
+					Target:    file.Name,
+					ID:        file.Id,
+					Timestamp: createdTime,
+					Size:      file.Size,
 				})
 			}
 

--- a/internal/backup/targets/rsync.go
+++ b/internal/backup/targets/rsync.go
@@ -617,17 +617,15 @@ func (t *RsyncTarget) List(ctx context.Context) ([]backup.BackupInfo, error) {
 		}
 
 		backupInfo := backup.BackupInfo{
-			Metadata: backup.Metadata{
-				Version:    metadata.Version,
-				Timestamp:  metadata.Timestamp,
-				Size:       metadata.Size,
-				Type:       metadata.Type,
-				Source:     metadata.Source,
-				IsDaily:    metadata.IsDaily,
-				ConfigHash: metadata.ConfigHash,
-				AppVersion: metadata.AppVersion,
-			},
-			Target: t.Name(),
+			Version:    metadata.Version,
+			Timestamp:  metadata.Timestamp,
+			Size:       metadata.Size,
+			Type:       metadata.Type,
+			Source:     metadata.Source,
+			IsDaily:    metadata.IsDaily,
+			ConfigHash: metadata.ConfigHash,
+			AppVersion: metadata.AppVersion,
+			Target:     t.Name(),
 		}
 		backups = append(backups, backupInfo)
 	}

--- a/internal/backup/targets/sftp.go
+++ b/internal/backup/targets/sftp.go
@@ -607,11 +607,9 @@ func (t *SFTPTarget) List(ctx context.Context) ([]backup.BackupInfo, error) {
 				}
 
 				backups = append(backups, backup.BackupInfo{
-					Target: entry.Name(),
-					Metadata: backup.Metadata{
-						Timestamp: entry.ModTime(),
-						Size:      entry.Size(),
-					},
+					Target:    entry.Name(),
+					Timestamp: entry.ModTime(),
+					Size:      entry.Size(),
 				})
 			}
 

--- a/internal/classifier/orchestrator_memory.go
+++ b/internal/classifier/orchestrator_memory.go
@@ -2,6 +2,7 @@ package classifier
 
 import (
 	"context"
+	"maps"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -51,10 +52,7 @@ func (o *Orchestrator) warmupAndRecordRSS(modelID string, before uint64, instanc
 	if err != nil || before == 0 {
 		return // RSS unavailable: leave the model out of modelRSS (endpoint shows n/a)
 	}
-	delta := int64(after) - int64(before)
-	if delta < 0 {
-		delta = 0
-	}
+	delta := max(int64(after)-int64(before), 0)
 	o.rssMu.Lock()
 	o.modelRSS[modelID] = delta
 	o.rssMu.Unlock()
@@ -140,8 +138,6 @@ func (o *Orchestrator) ModelRSS() (perModel map[string]int64, runtimeBaseline in
 	o.rssMu.Lock()
 	defer o.rssMu.Unlock()
 	out := make(map[string]int64, len(o.modelRSS))
-	for k, v := range o.modelRSS {
-		out[k] = v
-	}
+	maps.Copy(out, o.modelRSS)
 	return out, o.runtimeBaseline
 }

--- a/internal/conf/migrations.go
+++ b/internal/conf/migrations.go
@@ -2,6 +2,7 @@ package conf
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"reflect"
 	"strings"
@@ -384,9 +385,7 @@ func normalizeRTSPStreamEnabledDefaults(rawStreams any) ([]any, bool) {
 		}
 
 		copied := make(map[string]any, len(streamMap)+1)
-		for key, value := range streamMap {
-			copied[key] = value
-		}
+		maps.Copy(copied, streamMap)
 		copied["enabled"] = true
 		normalized[i] = copied
 		migrated = true
@@ -839,6 +838,11 @@ func (s *Settings) mergeSourceIntoStream(src *AudioSourceConfig, stream *StreamC
 // ever gains a non-comparable field this returns false so the merge is skipped
 // rather than risking a runtime panic.
 func quietHoursComparable() bool {
+	// Keep reflect.TypeOf here, not reflect.TypeFor[QuietHoursConfig](): the
+	// generic form trips a Go linker bug (R_USEIFACE ... references type:.eqfunc
+	// which is not a type or itab) during deadcode elimination for this
+	// comparable-struct check.
+	//nolint:modernize // reflect.TypeOf is intentional; reflect.TypeFor breaks the linker here (see above)
 	return reflect.TypeOf(QuietHoursConfig{}).Comparable()
 }
 

--- a/internal/datastore/db_close_test.go
+++ b/internal/datastore/db_close_test.go
@@ -85,7 +85,7 @@ func newTestSQLiteStore(t *testing.T) *SQLiteStore {
 	settings.Output.SQLite.Path = "test.db"
 
 	return &SQLiteStore{
-		Settings:  settings,
-		DataStore: DataStore{DB: db},
+		Settings: settings,
+		DB:       db,
 	}
 }

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -356,24 +356,18 @@ func New(settings *conf.Settings) Interface {
 	case settings.Output.SQLite.Enabled:
 		return &SQLiteStore{
 			Settings: settings,
-			DataStore: DataStore{
-				SunCalc: sunCalc,
-			},
+			SunCalc:  sunCalc,
 		}
 	case settings.Output.MySQL.Enabled:
 		return &MySQLStore{
 			Settings: settings,
-			DataStore: DataStore{
-				SunCalc: sunCalc,
-			},
+			SunCalc:  sunCalc,
 		}
 	default:
 		// No database explicitly enabled — default to SQLite
 		return &SQLiteStore{
 			Settings: settings,
-			DataStore: DataStore{
-				SunCalc: sunCalc,
-			},
+			SunCalc:  sunCalc,
 		}
 	}
 }

--- a/internal/datastore/sqlite_integrity_test.go
+++ b/internal/datastore/sqlite_integrity_test.go
@@ -30,7 +30,7 @@ func newIntegrityTestStore(t *testing.T) *SQLiteStore {
 	})
 
 	return &SQLiteStore{
-		DataStore: DataStore{DB: db},
+		DB: db,
 	}
 }
 
@@ -175,7 +175,7 @@ func TestPerformStartupIntegrityCheck_CorruptedDatabase(t *testing.T) {
 	})
 
 	store := &SQLiteStore{
-		DataStore: DataStore{DB: db2},
+		DB: db2,
 	}
 
 	store.performStartupIntegrityCheck()

--- a/internal/datastore/v2/repository/detection_impl_test.go
+++ b/internal/datastore/v2/repository/detection_impl_test.go
@@ -744,7 +744,7 @@ func TestGetByHour_PaginationHonored(t *testing.T) {
 	repo := &detectionRepository{db: db}
 
 	const hourStart = int64(1_700_000_000)
-	for i := int64(0); i < 5; i++ {
+	for i := range int64(5) {
 		createTestDetection(t, db, hourStart+i*60)
 	}
 

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -164,7 +164,7 @@ type Datastore struct {
 
 	// dbstatAvailable caches whether the dbstat virtual table exists.
 	// 0 = unchecked, 1 = available, -1 = not available.
-	dbstatAvailable int32
+	dbstatAvailable atomic.Int32
 
 	// dbCounters tracks atomic query latency counters for metrics collection.
 	dbCounters *dbstats.Counters

--- a/internal/datastore/v2only/inspector.go
+++ b/internal/datastore/v2only/inspector.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"sync/atomic"
 
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"gorm.io/gorm"
@@ -145,7 +144,7 @@ func (ds *Datastore) GetTableStats() ([]datastore.TableStats, error) {
 // to row-count proportional estimation. Caches dbstat availability to avoid
 // repeated WARN logs when the virtual table is not compiled in.
 func (ds *Datastore) getSQLiteTableStats() ([]datastore.TableStats, error) {
-	cached := atomic.LoadInt32(&ds.dbstatAvailable)
+	cached := ds.dbstatAvailable.Load()
 	if cached == -1 {
 		// Already known to be unavailable — skip directly to estimation
 		return ds.getSQLiteTableStatsEstimated()
@@ -153,12 +152,12 @@ func (ds *Datastore) getSQLiteTableStats() ([]datastore.TableStats, error) {
 
 	stats, err := ds.getSQLiteTableStatsViaDBStat()
 	if err == nil {
-		atomic.StoreInt32(&ds.dbstatAvailable, 1)
+		ds.dbstatAvailable.Store(1)
 		return stats, nil
 	}
 
 	// Mark as unavailable so we don't retry on every refresh
-	atomic.StoreInt32(&ds.dbstatAvailable, -1)
+	ds.dbstatAvailable.Store(-1)
 	return ds.getSQLiteTableStatsEstimated()
 }
 

--- a/internal/imageprovider/cache_resilience_test.go
+++ b/internal/imageprovider/cache_resilience_test.go
@@ -85,9 +85,7 @@ type mockCorruptStore struct {
 
 func newMockCorruptStore() *mockCorruptStore {
 	return &mockCorruptStore{
-		mockStore: mockStore{
-			images: make(map[string]*datastore.ImageCache),
-		},
+		images: make(map[string]*datastore.ImageCache),
 	}
 }
 

--- a/internal/imageprovider/cache_validation_test.go
+++ b/internal/imageprovider/cache_validation_test.go
@@ -20,9 +20,7 @@ func setupTestCache(t *testing.T) (*mockProviderWithAPICounter, *imageprovider.B
 	t.Helper()
 
 	mockProvider := &mockProviderWithAPICounter{
-		mockImageProvider: mockImageProvider{
-			fetchDelay: 10 * time.Millisecond,
-		},
+		fetchDelay: 10 * time.Millisecond,
 	}
 
 	mockStore := newMockStore()
@@ -44,9 +42,7 @@ func setupTestCacheWithSharedStore(t *testing.T) (*mockProviderWithAPICounter, *
 	t.Helper()
 
 	mockProvider := &mockProviderWithAPICounter{
-		mockImageProvider: mockImageProvider{
-			fetchDelay: 10 * time.Millisecond,
-		},
+		fetchDelay: 10 * time.Millisecond,
 	}
 
 	mockStore := newMockStore()
@@ -190,10 +186,8 @@ func TestBackgroundRefreshIsolation(t *testing.T) {
 	)
 
 	mockProvider := &mockProviderWithContextTracking{
-		mockProviderWithAPICounter: mockProviderWithAPICounter{
-			mockImageProvider: mockImageProvider{
-				fetchDelay: providerFetchDelay, // Simulate slow API
-			},
+		mockImageProvider: mockImageProvider{
+			fetchDelay: providerFetchDelay, // Simulate slow API
 		},
 	}
 
@@ -294,13 +288,13 @@ func TestCacheMetrics(t *testing.T) {
 // mockProviderWithAPICounter tracks API calls
 type mockProviderWithAPICounter struct {
 	mockImageProvider
-	apiCallCount    int64
+	apiCallCount    atomic.Int64
 	notFoundSpecies map[string]bool
 	mu2             sync.RWMutex
 }
 
 func (m *mockProviderWithAPICounter) Fetch(scientificName string) (imageprovider.BirdImage, error) {
-	atomic.AddInt64(&m.apiCallCount, 1)
+	m.apiCallCount.Add(1)
 
 	m.mu2.RLock()
 	if m.notFoundSpecies != nil && m.notFoundSpecies[scientificName] {
@@ -313,11 +307,11 @@ func (m *mockProviderWithAPICounter) Fetch(scientificName string) (imageprovider
 }
 
 func (m *mockProviderWithAPICounter) getAPICallCount() int64 {
-	return atomic.LoadInt64(&m.apiCallCount)
+	return m.apiCallCount.Load()
 }
 
 func (m *mockProviderWithAPICounter) resetCounters() {
-	atomic.StoreInt64(&m.apiCallCount, 0)
+	m.apiCallCount.Store(0)
 }
 
 func (m *mockProviderWithAPICounter) setNotFoundSpecies(species string) {
@@ -332,25 +326,25 @@ func (m *mockProviderWithAPICounter) setNotFoundSpecies(species string) {
 // mockProviderWithContextTracking tracks background vs user fetches
 type mockProviderWithContextTracking struct {
 	mockProviderWithAPICounter
-	backgroundFetches int64
-	userFetches       int64
+	backgroundFetches atomic.Int64
+	userFetches       atomic.Int64
 }
 
 func (m *mockProviderWithContextTracking) FetchWithContext(ctx context.Context, scientificName string) (imageprovider.BirdImage, error) {
 	// Track whether this is a background fetch
 	if imageprovider.IsBackgroundContext(ctx) {
-		atomic.AddInt64(&m.backgroundFetches, 1)
+		m.backgroundFetches.Add(1)
 	} else {
-		atomic.AddInt64(&m.userFetches, 1)
+		m.userFetches.Add(1)
 	}
 
 	return m.Fetch(scientificName)
 }
 
 func (m *mockProviderWithContextTracking) getBackgroundFetchCount() int64 {
-	return atomic.LoadInt64(&m.backgroundFetches)
+	return m.backgroundFetches.Load()
 }
 
 func (m *mockProviderWithContextTracking) getUserFetchCount() int64 {
-	return atomic.LoadInt64(&m.userFetches)
+	return m.userFetches.Load()
 }

--- a/internal/imageprovider/error_handling_test.go
+++ b/internal/imageprovider/error_handling_test.go
@@ -38,9 +38,7 @@ func createDatabaseErrorTestFunc(t *testing.T) func() error {
 	t.Helper()
 	return func() error {
 		failingStore := &mockFailingStore{
-			mockStore: mockStore{
-				images: make(map[string]*datastore.ImageCache),
-			},
+			images:       make(map[string]*datastore.ImageCache),
 			failGetCache: true,
 		}
 		metrics, err := observability.NewMetrics()

--- a/internal/imageprovider/imageprovider_test.go
+++ b/internal/imageprovider/imageprovider_test.go
@@ -437,9 +437,7 @@ type mockFailingStore struct {
 
 func newMockFailingStore() *mockFailingStore {
 	return &mockFailingStore{
-		mockStore: mockStore{
-			images: make(map[string]*datastore.ImageCache),
-		},
+		images: make(map[string]*datastore.ImageCache),
 	}
 }
 
@@ -1078,8 +1076,8 @@ func TestBackgroundRequestsRateLimited(t *testing.T) {
 
 	fetchAttempts := make(chan time.Time, 2*numStaleEntries)
 	mockProvider := &mockProviderWithContext{
-		mockImageProvider: mockImageProvider{fetchDelay: 5 * time.Millisecond},
-		fetchChannel:      fetchAttempts,
+		fetchDelay:   5 * time.Millisecond,
+		fetchChannel: fetchAttempts,
 	}
 
 	store := newMockStore()

--- a/internal/imageprovider/negative_cache_test.go
+++ b/internal/imageprovider/negative_cache_test.go
@@ -191,13 +191,13 @@ func TestNegativeCachePersistence(t *testing.T) {
 
 // mockProviderWithNotFound returns not found for specific species
 type mockProviderWithNotFound struct {
-	apiCallCount    int64
+	apiCallCount    atomic.Int64
 	notFoundSpecies map[string]bool
 	mu              sync.RWMutex
 }
 
 func (m *mockProviderWithNotFound) Fetch(scientificName string) (imageprovider.BirdImage, error) {
-	atomic.AddInt64(&m.apiCallCount, 1)
+	m.apiCallCount.Add(1)
 
 	m.mu.RLock()
 	isNotFound := m.notFoundSpecies[scientificName]
@@ -218,21 +218,21 @@ func (m *mockProviderWithNotFound) Fetch(scientificName string) (imageprovider.B
 }
 
 func (m *mockProviderWithNotFound) getAPICallCount() int64 {
-	return atomic.LoadInt64(&m.apiCallCount)
+	return m.apiCallCount.Load()
 }
 
 func (m *mockProviderWithNotFound) resetCounters() {
-	atomic.StoreInt64(&m.apiCallCount, 0)
+	m.apiCallCount.Store(0)
 }
 
 // mockProviderWithTransientError simulates transient errors
 type mockProviderWithTransientError struct {
-	apiCallCount int64
+	apiCallCount atomic.Int64
 	errorMessage string
 }
 
 func (m *mockProviderWithTransientError) Fetch(scientificName string) (imageprovider.BirdImage, error) {
-	atomic.AddInt64(&m.apiCallCount, 1)
+	m.apiCallCount.Add(1)
 	// Return a network error (not ErrImageNotFound) to simulate transient error
 	return imageprovider.BirdImage{}, errors.New(errors.NewStd(m.errorMessage)).
 		Component("imageprovider").
@@ -242,7 +242,7 @@ func (m *mockProviderWithTransientError) Fetch(scientificName string) (imageprov
 }
 
 func (m *mockProviderWithTransientError) getAPICallCount() int64 {
-	return atomic.LoadInt64(&m.apiCallCount)
+	return m.apiCallCount.Load()
 }
 
 // TestNegativeCacheTTLValue pins the negative-cache TTL.

--- a/internal/inference/openvino/backend_openvino.go
+++ b/internal/inference/openvino/backend_openvino.go
@@ -821,7 +821,7 @@ func AvailableDevices() ([]string, error) {
 
 	n := int(C.ovbind_devices_count(&list))
 	devices := make([]string, 0, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		cName := C.ovbind_devices_at(&list, C.size_t(i))
 		if cName == nil {
 			continue

--- a/internal/inference/ort_status.go
+++ b/internal/inference/ort_status.go
@@ -126,13 +126,13 @@ func inferVersionFromPath(libPath string) string {
 	base := filepath.Base(resolved)
 
 	// Linux convention: "libonnxruntime.so.1.25.1" -> "1.25.1"
-	if idx := strings.Index(base, ".so."); idx >= 0 {
-		return base[idx+len(".so."):]
+	if _, after, ok := strings.Cut(base, ".so."); ok {
+		return after
 	}
 
 	// macOS convention: "libonnxruntime.1.25.1.dylib" -> "1.25.1"
-	if strings.HasSuffix(base, ".dylib") {
-		name := strings.TrimSuffix(base, ".dylib")
+	if before, ok := strings.CutSuffix(base, ".dylib"); ok {
+		name := before
 		for i := range len(name) {
 			if name[i] == '.' && i+1 < len(name) && name[i+1] >= '0' && name[i+1] <= '9' {
 				return name[i+1:]

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -952,7 +952,7 @@ func TestSanitizeAny_NonFiniteBehindInterfaces(t *testing.T) {
 		{"nested Stringer with NaN", map[string]any{"src": stringerWithFloat{Gain: math.NaN()}, "trigger": math.Inf(1)}},
 		{"top-level error with Inf", floatFieldError{Gain: math.Inf(1)}},
 		{"nested error with NaN", map[string]any{"err": floatFieldError{Gain: math.NaN()}, "trigger": math.Inf(1)}},
-		{"unexported embedded struct with NaN", outerEmbed{innerFloat: innerFloat{Y: math.NaN()}, Name: "x"}},
+		{"unexported embedded struct with NaN", outerEmbed{Y: math.NaN(), Name: "x"}},
 		{"pointer to Stringer with NaN", &stringerWithFloat{Gain: math.NaN()}},
 	}
 	for _, tt := range tests {
@@ -980,7 +980,7 @@ func TestSanitizeAny_MatchesEncodingJSONForCleanValues(t *testing.T) {
 		Score float64 `json:"score"`
 	}
 	cases := []any{
-		Outer{Inner: Inner{A: 1}, Name: "x", Score: 2.5},
+		Outer{A: 1, Name: "x", Score: 2.5},
 		[]any{1, "two", 3.5, true},
 		map[string]any{"a": 1, "b": []int{1, 2}},
 		Inner{A: 7, B: "z"},
@@ -1012,7 +1012,7 @@ func FuzzSanitizeAny(f *testing.F) {
 			fuzzStruct{V: x, S: string(b)},
 			stringerWithFloat{Gain: x},
 			floatFieldError{Gain: x},
-			outerEmbed{innerFloat: innerFloat{Y: x}, Name: string(b)},
+			outerEmbed{Y: x, Name: string(b)},
 			&fuzzStruct{V: x, S: string(b)},
 			[]float64{x, float64(n)},
 		}

--- a/internal/notification/error_suppressor.go
+++ b/internal/notification/error_suppressor.go
@@ -158,10 +158,7 @@ func nextReminderInterval(reportCount int) time.Duration {
 	// maxSuppressionReminderInterval to avoid any chance of signed-int
 	// overflow if reportCount grows unbounded during a very long outage.
 	const maxShift = 20
-	shift := reportCount - 1
-	if shift > maxShift {
-		shift = maxShift
-	}
+	shift := min(reportCount-1, maxShift)
 
 	multiplier := int64(1) << shift
 	interval := time.Duration(multiplier) * suppressionReminderInterval

--- a/internal/observability/health_metrics_store.go
+++ b/internal/observability/health_metrics_store.go
@@ -132,10 +132,7 @@ func (r *hourlyRing) recentBuckets(n int) []HourlyBucket {
 	if r.size == 0 || n <= 0 {
 		return nil
 	}
-	count := n
-	if count > r.size {
-		count = r.size
-	}
+	count := min(n, r.size)
 	result := make([]HourlyBucket, count)
 	for i := range count {
 		idx := (r.head - count + 1 + i + len(r.buckets)) % len(r.buckets)

--- a/internal/telemetry/eventbus_integration.go
+++ b/internal/telemetry/eventbus_integration.go
@@ -3,7 +3,6 @@ package telemetry
 import (
 	"fmt"
 	"sync"
-	"sync/atomic"
 
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/events"
@@ -24,7 +23,7 @@ func InitializeEventBusIntegration() error {
 	log := GetLogger()
 
 	// Check if Sentry is enabled (skip check in test mode)
-	if atomic.LoadInt32(&testMode) == 0 {
+	if testMode.Load() == 0 {
 		settings := conf.GetSettings()
 		if settings == nil || !settings.Sentry.Enabled {
 			log.Info("Sentry telemetry disabled, skipping event bus integration")

--- a/internal/telemetry/eventbus_integration.go
+++ b/internal/telemetry/eventbus_integration.go
@@ -23,7 +23,7 @@ func InitializeEventBusIntegration() error {
 	log := GetLogger()
 
 	// Check if Sentry is enabled (skip check in test mode)
-	if testMode.Load() == 0 {
+	if testMode.Load() == testModeDisabled {
 		settings := conf.GetSettings()
 		if settings == nil || !settings.Sentry.Enabled {
 			log.Info("Sentry telemetry disabled, skipping event bus integration")

--- a/internal/telemetry/optimized_capture.go
+++ b/internal/telemetry/optimized_capture.go
@@ -13,7 +13,7 @@ var telemetryEnabled atomic.Bool
 // UpdateTelemetryEnabled updates the cached telemetry enabled state
 func UpdateTelemetryEnabled() {
 	// In test mode, telemetry is always enabled
-	if atomic.LoadInt32(&testMode) == 1 {
+	if testMode.Load() == 1 {
 		telemetryEnabled.Store(true)
 		return
 	}
@@ -35,13 +35,13 @@ func IsTelemetryEnabled() bool {
 // EnableTestMode enables test mode and updates the telemetry enabled state
 // This is useful for tests that need to enable telemetry without real settings
 func EnableTestMode() {
-	atomic.StoreInt32(&testMode, 1)
+	testMode.Store(1)
 	UpdateTelemetryEnabled()
 }
 
 // DisableTestMode disables test mode and updates the telemetry enabled state
 func DisableTestMode() {
-	atomic.StoreInt32(&testMode, 0)
+	testMode.Store(0)
 	UpdateTelemetryEnabled()
 }
 

--- a/internal/telemetry/optimized_capture.go
+++ b/internal/telemetry/optimized_capture.go
@@ -13,7 +13,7 @@ var telemetryEnabled atomic.Bool
 // UpdateTelemetryEnabled updates the cached telemetry enabled state
 func UpdateTelemetryEnabled() {
 	// In test mode, telemetry is always enabled
-	if testMode.Load() == 1 {
+	if testMode.Load() == testModeEnabled {
 		telemetryEnabled.Store(true)
 		return
 	}
@@ -35,13 +35,13 @@ func IsTelemetryEnabled() bool {
 // EnableTestMode enables test mode and updates the telemetry enabled state
 // This is useful for tests that need to enable telemetry without real settings
 func EnableTestMode() {
-	testMode.Store(1)
+	testMode.Store(testModeEnabled)
 	UpdateTelemetryEnabled()
 }
 
 // DisableTestMode disables test mode and updates the telemetry enabled state
 func DisableTestMode() {
-	testMode.Store(0)
+	testMode.Store(testModeDisabled)
 	UpdateTelemetryEnabled()
 }
 

--- a/internal/telemetry/sentry.go
+++ b/internal/telemetry/sentry.go
@@ -175,13 +175,19 @@ type DeferredMessage struct {
 const maxDeferredMessages = 100
 
 // sentryInitialized tracks whether Sentry has been initialized
+// testMode state values. testMode lets tests bypass settings checks.
+const (
+	testModeDisabled int32 = 0
+	testModeEnabled  int32 = 1
+)
+
 var (
 	sentryInitialized      bool
 	deferredMessages       []DeferredMessage
 	deferredMutex          sync.Mutex
 	deferredOverflowLogged bool
 	attachmentUploader     *AttachmentUploader
-	testMode               atomic.Int32 // testMode allows tests to bypass settings checks (0=false, 1=true)
+	testMode               atomic.Int32 // testMode allows tests to bypass settings checks
 )
 
 // shouldSkipTelemetry returns true if telemetry should be skipped.
@@ -190,7 +196,7 @@ var (
 // This helper reduces code duplication across telemetry functions.
 func shouldSkipTelemetry() bool {
 	// In test mode, never skip (telemetry is always "enabled" for testing)
-	if testMode.Load() == 1 {
+	if testMode.Load() == testModeEnabled {
 		return false
 	}
 	settings := conf.GetSettings()

--- a/internal/telemetry/sentry.go
+++ b/internal/telemetry/sentry.go
@@ -181,7 +181,7 @@ var (
 	deferredMutex          sync.Mutex
 	deferredOverflowLogged bool
 	attachmentUploader     *AttachmentUploader
-	testMode               int32 // testMode allows tests to bypass settings checks (0=false, 1=true)
+	testMode               atomic.Int32 // testMode allows tests to bypass settings checks (0=false, 1=true)
 )
 
 // shouldSkipTelemetry returns true if telemetry should be skipped.
@@ -190,7 +190,7 @@ var (
 // This helper reduces code duplication across telemetry functions.
 func shouldSkipTelemetry() bool {
 	// In test mode, never skip (telemetry is always "enabled" for testing)
-	if atomic.LoadInt32(&testMode) == 1 {
+	if testMode.Load() == 1 {
 		return false
 	}
 	settings := conf.GetSettings()

--- a/internal/telemetry/test_helpers_test.go
+++ b/internal/telemetry/test_helpers_test.go
@@ -2,7 +2,6 @@ package telemetry
 
 import (
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -67,7 +66,7 @@ func InitForTesting(t TestingTB) (config *TestConfig, cleanup func()) {
 
 	// Mark as initialized and enable test mode
 	sentryInitialized = true
-	atomic.StoreInt32(&testMode, 1)
+	testMode.Store(1)
 
 	// Update telemetry enabled state for test mode
 	UpdateTelemetryEnabled()
@@ -121,7 +120,7 @@ func InitForTesting(t TestingTB) (config *TestConfig, cleanup func()) {
 
 		// Reset initialization state
 		sentryInitialized = false
-		atomic.StoreInt32(&testMode, 0)
+		testMode.Store(0)
 
 		// Clear deferred messages
 		deferredMutex.Lock()

--- a/internal/telemetry/test_helpers_test.go
+++ b/internal/telemetry/test_helpers_test.go
@@ -66,7 +66,7 @@ func InitForTesting(t TestingTB) (config *TestConfig, cleanup func()) {
 
 	// Mark as initialized and enable test mode
 	sentryInitialized = true
-	testMode.Store(1)
+	testMode.Store(testModeEnabled)
 
 	// Update telemetry enabled state for test mode
 	UpdateTelemetryEnabled()
@@ -120,7 +120,7 @@ func InitForTesting(t TestingTB) (config *TestConfig, cleanup func()) {
 
 		// Reset initialization state
 		sentryInitialized = false
-		testMode.Store(0)
+		testMode.Store(testModeDisabled)
 
 		// Clear deferred messages
 		deferredMutex.Lock()

--- a/rules/birdnet-go.go
+++ b/rules/birdnet-go.go
@@ -37,6 +37,10 @@ func ErrorsNewf(m dsl.Matcher) {
 	m.Match(
 		`errors.New(fmt.Errorf($format, $*args))`,
 	).
-		Report("use errors.Newf($format, $args) instead of errors.New(fmt.Errorf(...))").
-		Suggest("errors.Newf($format, $args)")
+		// Do not interpolate $args (a $* NodeSlice) into Report OR Suggest: go-ruleguard
+		// renders both templates through the same nodeText path, which falls back to
+		// go/printer and panics on *gogrep.NodeSlice ("unsupported node type"), crashing
+		// gocritic on any file that matches (e.g. the openvino backend). That is why this
+		// rule reports a static message and provides no Suggest quickfix.
+		Report("use errors.Newf($format, ...) instead of errors.New(fmt.Errorf(...))")
 }

--- a/rules/builtins.go
+++ b/rules/builtins.go
@@ -148,8 +148,10 @@ func RangeOverInteger(m dsl.Matcher) {
 			!m["n"].Text.Matches(`.*\.N$`) &&
 				!m["n"].Text.Matches(`\.(NumField|NumMethod|NumIn|NumOut)\(\)$`),
 		).
-		Report("use for $i := range $n instead of for $i := 0; $i < $n; $i++ (Go 1.22+)").
-		Suggest("for $i := range $n { $body }")
+		// No Suggest: the loop body is captured as $*body (a NodeSlice), and
+		// go-ruleguard renders Suggest via go/printer, which panics on the
+		// NodeSlice and crashes gocritic on any matching file.
+		Report("use for $i := range $n instead of for $i := 0; $i < $n; $i++ (Go 1.22+)")
 }
 
 // AppendWithoutValues detects append calls with no values which have no effect.

--- a/rules/sync.go
+++ b/rules/sync.go
@@ -27,6 +27,13 @@ import "github.com/quasilyte/go-ruleguard/dsl"
 //   - Automatic panic handling
 //
 // See: https://pkg.go.dev/sync#WaitGroup.Go
+//
+// NOTE: the goroutine body is captured as $*body (a NodeSlice). Do NOT interpolate
+// it into Report or Suggest: go-ruleguard renders both templates via go/printer,
+// which panics on *gogrep.NodeSlice ("unsupported node type") and crashes gocritic
+// on any file that matches (e.g. the openvino backend). That is why these rules
+// interpolate only the single-node $wg (never the $*body NodeSlice) and provide no
+// Suggest quickfix.
 func WaitGroupGo(m dsl.Matcher) {
 	// Pattern 1: wg.Add(1) followed by go func() with defer wg.Done()
 	// This matches when the defer is the first statement
@@ -34,16 +41,14 @@ func WaitGroupGo(m dsl.Matcher) {
 		`$wg.Add(1); go func() { defer $wg.Done(); $*body }()`,
 	).
 		Where(m["wg"].Type.Is("*sync.WaitGroup") || m["wg"].Type.Is("sync.WaitGroup")).
-		Report("use $wg.Go(func() { $body }) instead of manual Add/Done pattern (Go 1.25+)").
-		Suggest("$wg.Go(func() { $body })")
+		Report("use $wg.Go(func() { ... }) instead of the manual Add/Done goroutine pattern (Go 1.25+)")
 
 	// Pattern 2: Same but with pointer receiver explicitly
 	m.Match(
 		`$wg.Add(1); go func() { defer $wg.Done(); $*body }()`,
 	).
 		Where(m["wg"].Type.Underlying().Is("sync.WaitGroup")).
-		Report("use $wg.Go(func() { $body }) instead of manual Add/Done pattern (Go 1.25+)").
-		Suggest("$wg.Go(func() { $body })")
+		Report("use $wg.Go(func() { ... }) instead of the manual Add/Done goroutine pattern (Go 1.25+)")
 
 	// Pattern 3: When wg is passed by reference to the closure
 	m.Match(
@@ -51,5 +56,5 @@ func WaitGroupGo(m dsl.Matcher) {
 		`$wg.Add(1); go func($param $typ) { defer $param.Done(); $*body }(&$wg)`,
 	).
 		Where(m["wg"].Type.Is("*sync.WaitGroup") || m["wg"].Type.Is("sync.WaitGroup")).
-		Report("use $wg.Go(func() { $body }) instead of manual Add/Done pattern (Go 1.25+)")
+		Report("use $wg.Go(func() { ... }) instead of the manual Add/Done goroutine pattern (Go 1.25+)")
 }

--- a/rules/testing.go
+++ b/rules/testing.go
@@ -50,8 +50,9 @@ func BenchmarkLoop(m dsl.Matcher) {
 		`for range $b.N { $*body }`,
 	).
 		Where(m["b"].Type.Is("*testing.B")).
-		Report("use for $b.Loop() { ... } instead of for range $b.N (Go 1.24+)").
-		Suggest("for $b.Loop() { $body }")
+		// No Suggest: $*body is a NodeSlice that go-ruleguard cannot render
+		// (go/printer panics), which crashes gocritic on any matching file.
+		Report("use for $b.Loop() { ... } instead of for range $b.N (Go 1.24+)")
 }
 
 // TestingContext detects context.Background() or context.TODO() in test functions


### PR DESCRIPTION
## Summary

Three lint follow-ups surfaced by the Go 1.27 + golangci-lint v2.13.2 toolchain bump.

**1. Fix the gocritic/go-ruleguard crash on the openvino backend.** Running golangci-lint with the `openvino` build tag crashed inside go-ruleguard instead of linting: several custom rules in `rules/*.go` interpolated a `$*` NodeSlice capture (`$body`, `$args`) into their `Report`/`Suggest` templates, and go-ruleguard renders both templates through the same path, which falls back to `go/printer` and panics on `*gogrep.NodeSlice`. The openvino backend matched the for-loop-to-range rule, so gocritic crashed and dropped all coverage for that file. Removed the NodeSlice interpolation from every affected rule (`WaitGroupGo`, `RangeOverInteger`, `BenchmarkLoop`, `ErrorsNewf`); the rules still detect the pattern via a static `Report` message but no longer provide an autofix quickfix. Also modernized the one flagged for-loop in the openvino backend. gocritic now lints the openvino backend cleanly.

**2. Silence a notflite-stub SA4023 false positive.** Under the `notflite` stub build, `NewTFLiteClassifier` and `NewTFLiteRangeFilter` always return a non-nil error, so staticcheck flags the `if err != nil` guards as always-true. Those guards are real runtime checks in the tflite build, so this adds a scoped `.golangci.yaml` exclusion for SA4023 on that one file rather than touching production error handling. The `notflite` tag is a compile check in CI, never linted, so this only affects a local notflite lint.

**3. Re-enable the modernize linter.** The Go 1.26 atomic-types panic that forced it off no longer reproduces under v2.13.2 + Go 1.27, so the codebase is modernized in the same change and the linter re-enabled. Most fixes are mechanical (embedlit, min/max builtins, maps.Copy, range-over-int, strings.Cut). Three atomic globals move to typed atomics (`atomic.Int32`/`atomic.Int64`): telemetry `testMode`, v2only `dbstatAvailable`, audio `totalConnections`.

`reflect.TypeOf(QuietHoursConfig{})` is deliberately NOT converted to `reflect.TypeFor`: the generic form trips a Go linker panic (`R_USEIFACE ... references type:.eqfunc which is not a type or itab`) during deadcode elimination. A scoped `//nolint:modernize` documents why.

## Minor API refinement

`SourceHealthSnapshot.LastRestart` / `LastDispatch` move from an ineffective `omitempty` (a no-op on `time.Time`) to `omitzero`. Today a source that never restarted serializes these as the sentinel `0001-01-01T00:00:00Z` on the auth-gated `GET /api/v2/health/audio` diagnostic endpoint; with `omitzero` the zero timestamp is omitted instead. No frontend or internal consumer reads these fields (the internal liveness check builds its own struct with explicit `IsZero()` handling), so this only cleans up the diagnostic JSON.

## Test Plan

- [x] `golangci-lint` v2.13.2 reports 0 issues across default, CI, notflite, and openvino tag sets
- [x] gocritic lints the openvino backend without crashing (0 issues)
- [x] `go build` passes for the default, notflite, and openvino tags (full main-binary link clean)
- [x] `go test -race` passes for all affected packages, no data races

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Backup listings now consistently display target, identifier, timestamp, and file size across supported destinations.
  - Health information more accurately omits unset restart and dispatch timestamps.

- **Reliability**
  - Improved safety for concurrent connection, telemetry, audio, caching, and database status tracking.

- **Maintenance**
  - Simplified internal processing and improved static analysis coverage.
  - Safer code-quality checks prevent problematic automatic fixes while retaining useful diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->