### PR TITLE
fix(inference): probe OpenVINO devices in a child process so a driver-stack crash falls back to ORT

### DIFF
--- a/cmd/support/openvino_probe.go
+++ b/cmd/support/openvino_probe.go
@@ -1,0 +1,39 @@
+package support
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/inference"
+)
+
+// OpenVINOProbeCommand creates the hidden `support openvino-probe` subcommand.
+// It is the child half of the out-of-process OpenVINO device probe
+// (inference.OpenVINOProbeDevices): it loads the OpenVINO core in this
+// process, enumerates the available devices, and reports them on stdout as
+// marker-prefixed lines the parent parses. A crash anywhere in the vendor
+// driver stack during enumeration then kills only this child, and the parent
+// falls back to ONNX Runtime instead of crash-looping (issue #4236). The
+// command is hidden because it is an internal protocol, not a user surface.
+func OpenVINOProbeCommand(settings *conf.Settings) *cobra.Command {
+	var libraryPath string
+	cmd := &cobra.Command{
+		Use:    "openvino-probe",
+		Short:  "Internal: enumerate OpenVINO devices in an isolated process",
+		Hidden: true,
+		// Errors exit non-zero; the parent treats that (and any signal) as
+		// "no OpenVINO devices". Usage help on failure would only pollute the
+		// parsed stdout stream.
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			path := libraryPath
+			if path == "" && settings != nil {
+				path = settings.BirdNET.OpenVINOPath
+			}
+			return inference.RunOVProbeChild(path, cmd.OutOrStdout())
+		},
+	}
+	cmd.Flags().StringVar(&libraryPath, "library-path", "",
+		"Path to libopenvino_c (defaults to birdnet.openvinopath from the config)")
+	return cmd
+}

--- a/cmd/support/support.go
+++ b/cmd/support/support.go
@@ -14,6 +14,7 @@ func Command(settings *conf.Settings) *cobra.Command {
 
 	// Add subcommands here
 	supportCmd.AddCommand(CollectCommand())
+	supportCmd.AddCommand(OpenVINOProbeCommand(settings))
 
 	return supportCmd
 }

--- a/internal/classifier/model_openvino.go
+++ b/internal/classifier/model_openvino.go
@@ -3,6 +3,7 @@ package classifier
 import (
 	"os"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 
@@ -155,7 +156,20 @@ func openVINOGPUAvailable(libraryPath string) bool {
 		}
 		return false
 	}
-	return inference.OpenVINOHasDevice(inference.OVDeviceGPU)
+	// Enumerate devices in a short-lived child process rather than in-process:
+	// ov_core_get_available_devices walks the vendor driver stack, and a fault
+	// there aborts the process before Go can recover (glibc heap-corruption
+	// SIGABRT during cgo, issue #4236 - a systemd crash-loop on the first GPU
+	// enablement). A crashing probe child degrades to the ordinary ORT
+	// fallback instead. The probe result is cached per process, so this costs
+	// one child run per library path.
+	devices, err := inference.OpenVINOProbeDevices(libraryPath)
+	if err != nil {
+		GetLogger().Warn("OpenVINO device probe failed; treating GPU as unavailable",
+			logger.Error(err))
+		return false
+	}
+	return slices.Contains(devices, inference.OVDeviceGPU)
 }
 
 // isLibraryAbsent reports whether err indicates the OpenVINO shared library is

--- a/internal/inference/openvino.go
+++ b/internal/inference/openvino.go
@@ -90,16 +90,21 @@ func NewOpenVINOClassifier(modelPath string, opts OpenVINOClassifierOptions) (Cl
 // When the out-of-process probe has completed (the device planner runs it before
 // any classifier is built), its cached result answers without touching the
 // in-process driver stack, so a status or capability query can never trip the
-// enumeration crash the probe exists to contain (issue #4236). Before any probe
-// has run it falls back to the in-process query, preserving prior behavior.
+// enumeration crash the probe exists to contain (issue #4236). While a probe is
+// still in flight it answers false rather than enumerating in-process behind
+// the child's back. Before any probe has run it falls back to the in-process
+// query, preserving prior behavior.
 func OpenVINOHasDevice(name string) bool {
-	if devs, probed, err := cachedOVProbeDevices(); probed {
-		if err != nil {
-			return false
-		}
-		return slices.Contains(devs, name)
+	devs, status, err := cachedOVProbeDevices()
+	switch status {
+	case ovProbeCached:
+		return err == nil && slices.Contains(devs, name)
+	case ovProbeInFlight:
+		return false
+	case ovProbeNotRun:
+		// fall through to the in-process query below
 	}
-	devs, err := ov.AvailableDevices()
+	devs, err = ov.AvailableDevices()
 	if err != nil {
 		return false
 	}

--- a/internal/inference/openvino.go
+++ b/internal/inference/openvino.go
@@ -86,7 +86,19 @@ func NewOpenVINOClassifier(modelPath string, opts OpenVINOClassifierOptions) (Cl
 // OpenVINOHasDevice reports whether the named OpenVINO device (e.g. ov.DeviceGPU)
 // is available. It returns false on any error (backend not compiled in, core not
 // initialized, or query failure), so callers can use it as a plain gate.
+//
+// When the out-of-process probe has completed (the device planner runs it before
+// any classifier is built), its cached result answers without touching the
+// in-process driver stack, so a status or capability query can never trip the
+// enumeration crash the probe exists to contain (issue #4236). Before any probe
+// has run it falls back to the in-process query, preserving prior behavior.
 func OpenVINOHasDevice(name string) bool {
+	if devs, probed, err := cachedOVProbeDevices(); probed {
+		if err != nil {
+			return false
+		}
+		return slices.Contains(devs, name)
+	}
 	devs, err := ov.AvailableDevices()
 	if err != nil {
 		return false

--- a/internal/inference/openvino_parity_functional_test.go
+++ b/internal/inference/openvino_parity_functional_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"math"
 	"os"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -140,7 +141,7 @@ func medianPredict(t *testing.T, c Classifier, samples []float32, n int) time.Du
 		require.NoError(t, err)
 		ds[i] = time.Since(start)
 	}
-	sort.Slice(ds, func(a, b int) bool { return ds[a] < ds[b] })
+	slices.Sort(ds)
 	return ds[n/2]
 }
 

--- a/internal/inference/openvino_probe.go
+++ b/internal/inference/openvino_probe.go
@@ -59,16 +59,51 @@ const (
 // the context. Variable rather than constant so tests can shorten it.
 var ovProbeTimeout = 60 * time.Second
 
-// ovProbeState caches the single per-process probe outcome.
-type ovProbeState struct {
-	mu          sync.Mutex
-	done        bool
-	libraryPath string
-	devices     []string
-	err         error
+// ovProbeResult is one cached probe verdict.
+type ovProbeResult struct {
+	devices []string
+	err     error
 }
 
-var ovProbe ovProbeState
+// ovProbeState caches probe outcomes per library path and tracks probes in
+// flight. The mutex guards only the maps; it is never held while a child
+// runs, so status/API readers of the cache do not stall behind a slow or
+// hanging driver stack.
+type ovProbeState struct {
+	mu sync.Mutex
+	// results holds the cached verdict per library path. Keyed by path so
+	// switching openvinopath A -> B -> A does not re-run a probe (and a known
+	// crashing driver stack) for a path already decided.
+	results map[string]ovProbeResult
+	// inFlight holds a channel per library path whose probe child is running;
+	// it is closed when the child finishes, so concurrent callers for the same
+	// path wait for that result instead of launching a second child.
+	inFlight map[string]chan struct{}
+	// lastPath is the library path most recently requested through
+	// OpenVINOProbeDevices; it is the path cache readers without a path of
+	// their own (OpenVINOHasDevice) are answered for.
+	lastPath string
+}
+
+var ovProbe = ovProbeState{
+	results:  map[string]ovProbeResult{},
+	inFlight: map[string]chan struct{}{},
+}
+
+// ovProbeCacheStatus describes what the probe cache can say right now.
+type ovProbeCacheStatus int
+
+const (
+	// ovProbeNotRun means no probe has been attempted (or a transient failure
+	// left nothing cached); callers may use their pre-probe behavior.
+	ovProbeNotRun ovProbeCacheStatus = iota
+	// ovProbeInFlight means a probe child is currently running; callers should
+	// not touch the in-process driver stack until it reports.
+	ovProbeInFlight
+	// ovProbeCached means a definitive result (success or child failure) is
+	// available.
+	ovProbeCached
+)
 
 // Test seams: how the probe locates and launches its child process.
 var (
@@ -85,45 +120,72 @@ func newOVProbeCommand(ctx context.Context, exe, libraryPath string) *exec.Cmd {
 
 // OpenVINOProbeDevices reports the OpenVINO device names visible on this host
 // (e.g. "CPU", "GPU"), determined by running the enumeration in a short-lived
-// child process so a driver-stack crash cannot abort the caller. The result
-// (success or failure) is cached for the life of the process per library
-// path; only a changed libraryPath re-runs the probe. Callers treat any error
-// as "no OpenVINO devices" and fall back to ONNX Runtime.
+// child process so a driver-stack crash cannot abort the caller. Callers treat
+// any error as "no OpenVINO devices" and fall back to ONNX Runtime.
+//
+// Caching: a successful result, and any failure produced by the child itself
+// (signaled, non-zero exit, no completion marker), is cached for the life of
+// the process per library path, so a crashing driver stack is not re-executed
+// on every hot reload; only a changed libraryPath re-probes. Failures that
+// never reached a child verdict (executable lookup, pipe or start errors, the
+// probe timeout) are transient and are NOT cached, so the next planning pass
+// retries. Concurrent callers for the same path share one child.
 func OpenVINOProbeDevices(libraryPath string) ([]string, error) {
 	if !ov.Supported {
 		return nil, ov.ErrOpenVINOUnavailable
 	}
 
-	ovProbe.mu.Lock()
-	defer ovProbe.mu.Unlock()
-	if ovProbe.done && ovProbe.libraryPath == libraryPath {
-		return slices.Clone(ovProbe.devices), ovProbe.err
-	}
+	for {
+		ovProbe.mu.Lock()
+		ovProbe.lastPath = libraryPath
+		if res, ok := ovProbe.results[libraryPath]; ok {
+			ovProbe.mu.Unlock()
+			return slices.Clone(res.devices), res.err
+		}
+		if wait, running := ovProbe.inFlight[libraryPath]; running {
+			ovProbe.mu.Unlock()
+			<-wait
+			continue // re-read the cache the finished probe populated (or retry)
+		}
+		inFlight := make(chan struct{})
+		ovProbe.inFlight[libraryPath] = inFlight
+		ovProbe.mu.Unlock()
 
-	devices, err := runOVProbe(libraryPath)
-	ovProbe.done = true
-	ovProbe.libraryPath = libraryPath
-	ovProbe.devices = devices
-	ovProbe.err = err
-	return slices.Clone(devices), err
+		devices, cacheable, err := runOVProbe(libraryPath)
+
+		ovProbe.mu.Lock()
+		if err == nil || cacheable {
+			ovProbe.results[libraryPath] = ovProbeResult{devices: devices, err: err}
+		}
+		delete(ovProbe.inFlight, libraryPath)
+		close(inFlight)
+		ovProbe.mu.Unlock()
+		return slices.Clone(devices), err
+	}
 }
 
-// cachedOVProbeDevices returns the cached probe result, reporting ok=false
-// when no probe has completed in this process.
-func cachedOVProbeDevices() (devices []string, probed bool, err error) {
+// cachedOVProbeDevices returns the cached probe result for the most recently
+// requested library path, together with the cache status. It never blocks on
+// a running probe.
+func cachedOVProbeDevices() (devices []string, status ovProbeCacheStatus, err error) {
 	ovProbe.mu.Lock()
 	defer ovProbe.mu.Unlock()
-	if !ovProbe.done {
-		return nil, false, nil
+	if res, ok := ovProbe.results[ovProbe.lastPath]; ok {
+		return slices.Clone(res.devices), ovProbeCached, res.err
 	}
-	return slices.Clone(ovProbe.devices), true, ovProbe.err
+	if _, running := ovProbe.inFlight[ovProbe.lastPath]; running {
+		return nil, ovProbeInFlight, nil
+	}
+	return nil, ovProbeNotRun, nil
 }
 
-// runOVProbe launches the probe child and parses its marker output.
-func runOVProbe(libraryPath string) ([]string, error) {
+// runOVProbe launches the probe child and parses its marker output. cacheable
+// reports whether a returned error is a child verdict worth remembering (see
+// OpenVINOProbeDevices) as opposed to a transient launch or timeout failure.
+func runOVProbe(libraryPath string) (devices []string, cacheable bool, err error) {
 	exe, err := ovProbeExecutable()
 	if err != nil {
-		return nil, errors.Newf("openvino probe: cannot resolve own executable: %v", err).
+		return nil, false, errors.Newf("openvino probe: cannot resolve own executable: %v", err).
 			Category(errors.CategorySystem).Build()
 	}
 
@@ -135,35 +197,51 @@ func runOVProbe(libraryPath string) ([]string, error) {
 	cmd.Stderr = &stderr
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, errors.Newf("openvino probe: stdout pipe: %v", err).
+		return nil, false, errors.Newf("openvino probe: stdout pipe: %v", err).
 			Category(errors.CategorySystem).Build()
 	}
 	if err := cmd.Start(); err != nil {
-		return nil, errors.Newf("openvino probe: start: %v", err).
+		return nil, false, errors.Newf("openvino probe: start: %v", err).
 			Category(errors.CategorySystem).Build()
 	}
 
-	devices, sawOK := parseOVProbeOutput(stdout)
+	devices, sawOK, scanErr := parseOVProbeOutput(stdout)
+	waitErr := cmd.Wait()
 
-	if err := cmd.Wait(); err != nil {
+	if ctx.Err() != nil {
+		// The context killed the child: a timeout, not a verdict. Do not cache,
+		// so a transiently slow driver init gets another chance next time.
+		return nil, false, errors.Newf("openvino probe: child timed out after %s", ovProbeTimeout).
+			Category(errors.CategorySystem).Build()
+	}
+	if waitErr != nil {
 		// A signaled child (the crash this probe exists for) surfaces here as
-		// e.g. "signal: aborted"; include trailing stderr for the journal.
-		return nil, errors.Newf("openvino probe: child failed: %v (stderr: %s)",
-			err, lastOVProbeStderr(stderr.String())).
+		// e.g. "signal: aborted"; include a stderr excerpt for the journal.
+		return nil, true, errors.Newf("openvino probe: child failed: %v (stderr: %s)",
+			waitErr, lastOVProbeStderr(stderr.String())).
+			Category(errors.CategorySystem).Build()
+	}
+	if scanErr != nil {
+		return nil, false, errors.Newf("openvino probe: reading child output: %v", scanErr).
 			Category(errors.CategorySystem).Build()
 	}
 	if !sawOK {
-		return nil, errors.Newf("openvino probe: child exited without completion marker").
+		return nil, true, errors.Newf("openvino probe: child exited without completion marker").
 			Category(errors.CategorySystem).Build()
 	}
-	return devices, nil
+	return devices, false, nil
 }
 
+// ovProbeMaxLineBytes bounds a single stdout line from the child. Marker lines
+// are tiny; the headroom is for bootstrap log lines sharing the stream.
+const ovProbeMaxLineBytes = 1 << 20
+
 // parseOVProbeOutput scans probe stdout for marker lines, returning the device
-// names and whether the completion marker was seen. Non-marker lines (logging
-// from the CLI bootstrap) are ignored.
-func parseOVProbeOutput(r io.Reader) (devices []string, sawOK bool) {
+// names, whether the completion marker was seen, and any read error.
+// Non-marker lines (logging from the CLI bootstrap) are ignored.
+func parseOVProbeOutput(r io.Reader) (devices []string, sawOK bool, err error) {
 	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), ovProbeMaxLineBytes)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		switch {
@@ -175,7 +253,7 @@ func parseOVProbeOutput(r io.Reader) (devices []string, sawOK bool) {
 			}
 		}
 	}
-	return devices, sawOK
+	return devices, sawOK, scanner.Err()
 }
 
 // ovProbeStderrExcerpt bounds each half of the child stderr excerpt echoed

--- a/internal/inference/openvino_probe.go
+++ b/internal/inference/openvino_probe.go
@@ -1,0 +1,221 @@
+package inference
+
+// This file implements an out-of-process probe for OpenVINO device
+// availability. Enumerating devices walks the vendor driver stack (NEO, IGC,
+// Level Zero) inside ov_core_get_available_devices, and a fault anywhere in
+// that stack aborts the process before Go can recover: glibc heap-corruption
+// detection raises SIGABRT during cgo execution, which took down the whole
+// analyzer in a systemd crash-loop (issue #4236). Running the first
+// enumeration in a short-lived child process turns that worst case into an
+// ordinary "OpenVINO unavailable" fallback to ONNX Runtime, matching the
+// backend's stated philosophy that any OpenVINO failure degrades to ORT.
+//
+// The child is this same executable invoked as `support openvino-probe`,
+// which loads the core, enumerates devices, and reports them on stdout using
+// marker-prefixed lines (config loading may log to stdout, so bare lines are
+// not trusted). The probe result is cached per (process, library path):
+// device topology does not change under a running service, and a cached
+// failure prevents a crashing driver stack from being re-executed on every
+// hot reload.
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+	ov "github.com/tphakala/birdnet-go/internal/inference/openvino"
+)
+
+const (
+	// ovProbeDeviceMarker prefixes one probe stdout line per available device
+	// (e.g. "OVPROBE_DEVICE=GPU"). A marker prefix is required because the
+	// child shares the normal CLI bootstrap, whose logging can interleave
+	// arbitrary lines on stdout.
+	ovProbeDeviceMarker = "OVPROBE_DEVICE="
+	// ovProbeOKMarker is the final probe stdout line, printed only after the
+	// enumeration completed and every device line was written. Requiring it
+	// means truncated output from a child that died mid-write is never
+	// mistaken for a successful empty result.
+	ovProbeOKMarker = "OVPROBE_OK"
+	// ovProbeSubcommand is the hidden CLI path the probe child runs.
+	ovProbeSubcommand = "openvino-probe"
+	// ovProbeParentCommand is the CLI command group hosting the probe.
+	ovProbeParentCommand = "support"
+	// ovProbeLibraryPathFlag names the probe child's library path flag.
+	ovProbeLibraryPathFlag = "--library-path"
+)
+
+// ovProbeTimeout bounds one probe child run. First-ever enumeration includes
+// vendor driver initialization (cold NEO caches take seconds, not minutes);
+// a child still running after this long is treated as failed and killed by
+// the context. Variable rather than constant so tests can shorten it.
+var ovProbeTimeout = 60 * time.Second
+
+// ovProbeState caches the single per-process probe outcome.
+type ovProbeState struct {
+	mu          sync.Mutex
+	done        bool
+	libraryPath string
+	devices     []string
+	err         error
+}
+
+var ovProbe ovProbeState
+
+// Test seams: how the probe locates and launches its child process.
+var (
+	ovProbeExecutable = os.Executable
+	ovProbeNewCommand = newOVProbeCommand
+)
+
+// newOVProbeCommand builds the probe child invocation: this executable run as
+// `support openvino-probe --library-path <path>`.
+func newOVProbeCommand(ctx context.Context, exe, libraryPath string) *exec.Cmd {
+	return exec.CommandContext(ctx, exe,
+		ovProbeParentCommand, ovProbeSubcommand, ovProbeLibraryPathFlag, libraryPath)
+}
+
+// OpenVINOProbeDevices reports the OpenVINO device names visible on this host
+// (e.g. "CPU", "GPU"), determined by running the enumeration in a short-lived
+// child process so a driver-stack crash cannot abort the caller. The result
+// (success or failure) is cached for the life of the process per library
+// path; only a changed libraryPath re-runs the probe. Callers treat any error
+// as "no OpenVINO devices" and fall back to ONNX Runtime.
+func OpenVINOProbeDevices(libraryPath string) ([]string, error) {
+	if !ov.Supported {
+		return nil, ov.ErrOpenVINOUnavailable
+	}
+
+	ovProbe.mu.Lock()
+	defer ovProbe.mu.Unlock()
+	if ovProbe.done && ovProbe.libraryPath == libraryPath {
+		return slices.Clone(ovProbe.devices), ovProbe.err
+	}
+
+	devices, err := runOVProbe(libraryPath)
+	ovProbe.done = true
+	ovProbe.libraryPath = libraryPath
+	ovProbe.devices = devices
+	ovProbe.err = err
+	return slices.Clone(devices), err
+}
+
+// cachedOVProbeDevices returns the cached probe result, reporting ok=false
+// when no probe has completed in this process.
+func cachedOVProbeDevices() (devices []string, probed bool, err error) {
+	ovProbe.mu.Lock()
+	defer ovProbe.mu.Unlock()
+	if !ovProbe.done {
+		return nil, false, nil
+	}
+	return slices.Clone(ovProbe.devices), true, ovProbe.err
+}
+
+// runOVProbe launches the probe child and parses its marker output.
+func runOVProbe(libraryPath string) ([]string, error) {
+	exe, err := ovProbeExecutable()
+	if err != nil {
+		return nil, errors.Newf("openvino probe: cannot resolve own executable: %v", err).
+			Category(errors.CategorySystem).Build()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), ovProbeTimeout)
+	defer cancel()
+
+	cmd := ovProbeNewCommand(ctx, exe, libraryPath)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, errors.Newf("openvino probe: stdout pipe: %v", err).
+			Category(errors.CategorySystem).Build()
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, errors.Newf("openvino probe: start: %v", err).
+			Category(errors.CategorySystem).Build()
+	}
+
+	devices, sawOK := parseOVProbeOutput(stdout)
+
+	if err := cmd.Wait(); err != nil {
+		// A signaled child (the crash this probe exists for) surfaces here as
+		// e.g. "signal: aborted"; include trailing stderr for the journal.
+		return nil, errors.Newf("openvino probe: child failed: %v (stderr: %s)",
+			err, lastOVProbeStderr(stderr.String())).
+			Category(errors.CategorySystem).Build()
+	}
+	if !sawOK {
+		return nil, errors.Newf("openvino probe: child exited without completion marker").
+			Category(errors.CategorySystem).Build()
+	}
+	return devices, nil
+}
+
+// parseOVProbeOutput scans probe stdout for marker lines, returning the device
+// names and whether the completion marker was seen. Non-marker lines (logging
+// from the CLI bootstrap) are ignored.
+func parseOVProbeOutput(r io.Reader) (devices []string, sawOK bool) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		switch {
+		case line == ovProbeOKMarker:
+			sawOK = true
+		case strings.HasPrefix(line, ovProbeDeviceMarker):
+			if name := strings.TrimPrefix(line, ovProbeDeviceMarker); name != "" {
+				devices = append(devices, name)
+			}
+		}
+	}
+	return devices, sawOK
+}
+
+// ovProbeStderrExcerpt bounds each half of the child stderr excerpt echoed
+// into a probe error.
+const ovProbeStderrExcerpt = 300
+
+// lastOVProbeStderr trims child stderr to a head+tail excerpt so a probe
+// error stays journal-sized. The head carries the cause (glibc prints
+// "free(): invalid next size" and Go prints "SIGABRT: abort" before the
+// goroutine and register dump), the tail the final state.
+func lastOVProbeStderr(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= 2*ovProbeStderrExcerpt {
+		return s
+	}
+	return s[:ovProbeStderrExcerpt] + " ... " + s[len(s)-ovProbeStderrExcerpt:]
+}
+
+// RunOVProbeChild is the child-side body of `support openvino-probe`: it
+// loads the OpenVINO core in THIS process, enumerates devices, and writes the
+// marker lines the parent parses to w. It is the only intended in-process
+// caller of the enumeration on the planning path; everything else consults
+// the cached probe result.
+func RunOVProbeChild(libraryPath string, w io.Writer) error {
+	if err := InitOpenVINO(libraryPath); err != nil {
+		return err
+	}
+	devices, err := ov.AvailableDevices()
+	if err != nil {
+		return err
+	}
+	for _, d := range devices {
+		if _, err := fmt.Fprintf(w, "%s%s\n", ovProbeDeviceMarker, d); err != nil {
+			return errors.Newf("openvino probe: write device line: %v", err).
+				Category(errors.CategorySystem).Build()
+		}
+	}
+	if _, err := fmt.Fprintln(w, ovProbeOKMarker); err != nil {
+		return errors.Newf("openvino probe: write completion marker: %v", err).
+			Category(errors.CategorySystem).Build()
+	}
+	return nil
+}

--- a/internal/inference/openvino_probe.go
+++ b/internal/inference/openvino_probe.go
@@ -151,17 +151,30 @@ func OpenVINOProbeDevices(libraryPath string) ([]string, error) {
 		ovProbe.inFlight[libraryPath] = inFlight
 		ovProbe.mu.Unlock()
 
-		devices, cacheable, err := runOVProbe(libraryPath)
+		return probeAndPublish(libraryPath, inFlight)
+	}
+}
 
+// probeAndPublish runs the probe child for libraryPath, records a cacheable
+// verdict, and always releases the in-flight registration. The release is
+// deferred so that a panic inside the exec plumbing cannot leave the path
+// marked in flight forever, which would block every later caller on <-wait.
+func probeAndPublish(libraryPath string, inFlight chan struct{}) (devices []string, err error) {
+	defer func() {
 		ovProbe.mu.Lock()
-		if err == nil || cacheable {
-			ovProbe.results[libraryPath] = ovProbeResult{devices: devices, err: err}
-		}
 		delete(ovProbe.inFlight, libraryPath)
 		close(inFlight)
 		ovProbe.mu.Unlock()
-		return slices.Clone(devices), err
+	}()
+
+	devices, cacheable, err := runOVProbe(libraryPath)
+
+	ovProbe.mu.Lock()
+	if err == nil || cacheable {
+		ovProbe.results[libraryPath] = ovProbeResult{devices: devices, err: err}
 	}
+	ovProbe.mu.Unlock()
+	return slices.Clone(devices), err
 }
 
 // cachedOVProbeDevices returns the cached probe result for the most recently

--- a/internal/inference/openvino_probe_test.go
+++ b/internal/inference/openvino_probe_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -55,15 +56,16 @@ func TestOVProbeHelperProcess(t *testing.T) {
 }
 
 // fakeOVProbeChild points the probe's command seam at this test binary running
-// TestOVProbeHelperProcess in the given mode, and returns a call counter.
-func fakeOVProbeChild(t *testing.T, mode string) *int {
+// TestOVProbeHelperProcess in the given mode, and returns a call counter. The
+// counter is guarded because concurrent callers may launch children.
+func fakeOVProbeChild(t *testing.T, mode string) *ovProbeCallCounter {
 	t.Helper()
-	calls := new(int)
+	calls := &ovProbeCallCounter{}
 	origNew := ovProbeNewCommand
 	origExe := ovProbeExecutable
 	ovProbeExecutable = os.Executable
 	ovProbeNewCommand = func(ctx context.Context, exe, _ string) *exec.Cmd {
-		*calls++
+		calls.inc()
 		cmd := exec.CommandContext(ctx, exe, "-test.run=TestOVProbeHelperProcess", "-test.v=false")
 		cmd.Env = append(os.Environ(), ovProbeHelperEnv+"="+mode)
 		return cmd
@@ -77,14 +79,39 @@ func fakeOVProbeChild(t *testing.T, mode string) *int {
 	return calls
 }
 
+// ovProbeCallCounter counts fake child launches across goroutines.
+type ovProbeCallCounter struct {
+	mu sync.Mutex
+	n  int
+}
+
+func (c *ovProbeCallCounter) inc() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.n++
+}
+
+func (c *ovProbeCallCounter) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.n
+}
+
 // resetOVProbeForTest clears the per-process probe cache between tests.
 func resetOVProbeForTest() {
 	ovProbe.mu.Lock()
 	defer ovProbe.mu.Unlock()
-	ovProbe.done = false
-	ovProbe.libraryPath = ""
-	ovProbe.devices = nil
-	ovProbe.err = nil
+	ovProbe.results = map[string]ovProbeResult{}
+	ovProbe.inFlight = map[string]chan struct{}{}
+	ovProbe.lastPath = ""
+}
+
+// shortenOVProbeTimeout lowers the probe timeout for the test's lifetime.
+func shortenOVProbeTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	orig := ovProbeTimeout
+	ovProbeTimeout = d
+	t.Cleanup(func() { ovProbeTimeout = orig })
 }
 
 func TestParseOVProbeOutput(t *testing.T) {
@@ -123,42 +150,56 @@ func TestParseOVProbeOutput(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			devices, sawOK := parseOVProbeOutput(strings.NewReader(tt.input))
+			devices, sawOK, err := parseOVProbeOutput(strings.NewReader(tt.input))
+			require.NoError(t, err)
 			assert.Equal(t, tt.wantDevices, devices)
 			assert.Equal(t, tt.wantOK, sawOK)
 		})
 	}
 }
 
+func TestParseOVProbeOutputSurfacesReadErrors(t *testing.T) {
+	t.Parallel()
+	// A single line longer than the scanner's maximum must be reported, not
+	// silently mistaken for a probe that never printed its completion marker.
+	huge := strings.Repeat("x", ovProbeMaxLineBytes+1) + "\nOVPROBE_OK\n"
+	_, sawOK, err := parseOVProbeOutput(strings.NewReader(huge))
+	require.Error(t, err)
+	assert.False(t, sawOK)
+}
+
 func TestRunOVProbeSuccess(t *testing.T) {
 	fakeOVProbeChild(t, "ok")
-	devices, err := runOVProbe("libopenvino_c.so")
+	devices, cacheable, err := runOVProbe("libopenvino_c.so")
 	require.NoError(t, err)
+	assert.False(t, cacheable)
 	assert.Equal(t, []string{"CPU", "GPU"}, devices)
 }
 
-func TestRunOVProbeChildCrash(t *testing.T) {
+func TestRunOVProbeChildCrashIsCacheable(t *testing.T) {
 	fakeOVProbeChild(t, "crash")
-	_, err := runOVProbe("libopenvino_c.so")
+	_, cacheable, err := runOVProbe("libopenvino_c.so")
 	require.Error(t, err)
+	assert.True(t, cacheable, "a child verdict must be remembered")
 	assert.Contains(t, err.Error(), "child failed")
 	assert.Contains(t, err.Error(), "invalid next size")
 }
 
-func TestRunOVProbeMissingCompletionMarker(t *testing.T) {
+func TestRunOVProbeMissingCompletionMarkerIsCacheable(t *testing.T) {
 	fakeOVProbeChild(t, "no-marker")
-	_, err := runOVProbe("libopenvino_c.so")
+	_, cacheable, err := runOVProbe("libopenvino_c.so")
 	require.Error(t, err)
+	assert.True(t, cacheable)
 	assert.Contains(t, err.Error(), "completion marker")
 }
 
-func TestRunOVProbeTimeout(t *testing.T) {
+func TestRunOVProbeTimeoutIsTransient(t *testing.T) {
 	fakeOVProbeChild(t, "hang")
-	origTimeout := ovProbeTimeout
-	ovProbeTimeout = 500 * time.Millisecond
-	t.Cleanup(func() { ovProbeTimeout = origTimeout })
-	_, err := runOVProbe("libopenvino_c.so")
+	shortenOVProbeTimeout(t, 500*time.Millisecond)
+	_, cacheable, err := runOVProbe("libopenvino_c.so")
 	require.Error(t, err)
+	assert.False(t, cacheable, "a timeout is not a child verdict and must not be cached")
+	assert.Contains(t, err.Error(), "timed out")
 }
 
 func TestOpenVINOProbeDevicesCachesResult(t *testing.T) {
@@ -172,21 +213,21 @@ func TestOpenVINOProbeDevicesCachesResult(t *testing.T) {
 		// child runs; the seam proves that.
 		require.Error(t, err1)
 		require.Error(t, err2)
-		assert.Equal(t, 0, *calls)
+		assert.Equal(t, 0, calls.count())
 		return
 	}
 	require.NoError(t, err1)
 	require.NoError(t, err2)
 	assert.Equal(t, first, second)
-	assert.Equal(t, 1, *calls, "second call must be served from the cache")
+	assert.Equal(t, 1, calls.count(), "second call must be served from the cache")
 
 	// A cached result also answers OpenVINOHasDevice without new children.
 	assert.True(t, OpenVINOHasDevice("GPU"))
 	assert.False(t, OpenVINOHasDevice("NPU"))
-	assert.Equal(t, 1, *calls)
+	assert.Equal(t, 1, calls.count())
 }
 
-func TestOpenVINOProbeDevicesCachesFailure(t *testing.T) {
+func TestOpenVINOProbeDevicesCachesChildFailure(t *testing.T) {
 	calls := fakeOVProbeChild(t, "crash")
 
 	_, err1 := OpenVINOProbeDevices("libopenvino_c.so")
@@ -195,26 +236,76 @@ func TestOpenVINOProbeDevicesCachesFailure(t *testing.T) {
 	require.Error(t, err1)
 	require.Error(t, err2)
 	if !ov.Supported {
-		assert.Equal(t, 0, *calls)
+		assert.Equal(t, 0, calls.count())
 		return
 	}
-	assert.Equal(t, 1, *calls, "a crashing probe child must not be re-executed")
+	assert.Equal(t, 1, calls.count(), "a crashing probe child must not be re-executed")
 	// A cached failure gates OpenVINOHasDevice closed.
 	assert.False(t, OpenVINOHasDevice("GPU"))
 }
 
-func TestOpenVINOProbeDevicesReprobesOnLibraryPathChange(t *testing.T) {
-	calls := fakeOVProbeChild(t, "ok")
+func TestOpenVINOProbeDevicesDoesNotCacheTimeout(t *testing.T) {
+	calls := fakeOVProbeChild(t, "hang")
+	shortenOVProbeTimeout(t, 300*time.Millisecond)
 
 	_, err1 := OpenVINOProbeDevices("libopenvino_c.so")
-	_, err2 := OpenVINOProbeDevices("/opt/custom/libopenvino_c.so")
+	_, err2 := OpenVINOProbeDevices("libopenvino_c.so")
 
+	require.Error(t, err1)
+	require.Error(t, err2)
 	if !ov.Supported {
-		require.Error(t, err1)
-		require.Error(t, err2)
+		assert.Equal(t, 0, calls.count())
 		return
 	}
-	require.NoError(t, err1)
-	require.NoError(t, err2)
-	assert.Equal(t, 2, *calls, "a changed library path must re-run the probe")
+	assert.Equal(t, 2, calls.count(), "a transient timeout must be retried on the next call")
+	// Nothing cached, so readers see the pre-probe state rather than a verdict.
+	_, status, _ := cachedOVProbeDevices()
+	assert.Equal(t, ovProbeNotRun, status)
+}
+
+func TestOpenVINOProbeDevicesCachesPerLibraryPath(t *testing.T) {
+	calls := fakeOVProbeChild(t, "ok")
+
+	_, errA := OpenVINOProbeDevices("libopenvino_c.so")
+	_, errB := OpenVINOProbeDevices("/opt/custom/libopenvino_c.so")
+	_, errA2 := OpenVINOProbeDevices("libopenvino_c.so")
+
+	if !ov.Supported {
+		require.Error(t, errA)
+		require.Error(t, errB)
+		require.Error(t, errA2)
+		return
+	}
+	require.NoError(t, errA)
+	require.NoError(t, errB)
+	require.NoError(t, errA2)
+	assert.Equal(t, 2, calls.count(), "A -> B -> A must probe each path once")
+}
+
+func TestOpenVINOHasDeviceDoesNotBlockOnInFlightProbe(t *testing.T) {
+	if !ov.Supported {
+		t.Skip("probe short-circuits without the openvino build tag")
+	}
+	calls := fakeOVProbeChild(t, "hang")
+	shortenOVProbeTimeout(t, 2*time.Second)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = OpenVINOProbeDevices("libopenvino_c.so")
+	}()
+	// Wait for the goroutine to register its in-flight probe.
+	require.Eventually(t, func() bool {
+		_, status, _ := cachedOVProbeDevices()
+		return status == ovProbeInFlight
+	}, time.Second, 10*time.Millisecond)
+
+	// A status reader must answer immediately, and answer false, while the
+	// probe child is still running.
+	begin := time.Now()
+	assert.False(t, OpenVINOHasDevice("GPU"))
+	assert.Less(t, time.Since(begin), 500*time.Millisecond, "reader blocked behind the probe child")
+
+	<-done
+	assert.Equal(t, 1, calls.count())
 }

--- a/internal/inference/openvino_probe_test.go
+++ b/internal/inference/openvino_probe_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 
 	ov "github.com/tphakala/birdnet-go/internal/inference/openvino"
 )
@@ -288,6 +289,10 @@ func TestOpenVINOHasDeviceDoesNotBlockOnInFlightProbe(t *testing.T) {
 	}
 	calls := fakeOVProbeChild(t, "hang")
 	shortenOVProbeTimeout(t, 2*time.Second)
+
+	// If an assertion below fails before <-done, the probe goroutine (and its
+	// child) would outlive the test; make that a reported leak, not a silent one.
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
 	done := make(chan struct{})
 	go func() {

--- a/internal/inference/openvino_probe_test.go
+++ b/internal/inference/openvino_probe_test.go
@@ -1,0 +1,220 @@
+package inference
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ov "github.com/tphakala/birdnet-go/internal/inference/openvino"
+)
+
+// ovProbeHelperEnv marks a test-binary re-invocation as the probe child
+// helper; its value selects the helper's behavior.
+const ovProbeHelperEnv = "GO_OVPROBE_HELPER_MODE"
+
+// TestOVProbeHelperProcess is not a real test: it is the body of the fake
+// probe child. The probe tests re-invoke the test binary with
+// ovProbeHelperEnv set, and this "test" then plays the requested child role.
+func TestOVProbeHelperProcess(t *testing.T) {
+	mode := os.Getenv(ovProbeHelperEnv)
+	if mode == "" {
+		t.Skip("not a helper invocation")
+	}
+	switch mode {
+	case "ok":
+		fmt.Println("INFO some interleaved log line")
+		fmt.Println("OVPROBE_DEVICE=CPU")
+		fmt.Println("OVPROBE_DEVICE=GPU")
+		fmt.Println("OVPROBE_OK")
+		os.Exit(0)
+	case "crash":
+		// Stands in for the driver-stack abort: marker lines already written,
+		// then the child dies without the completion marker.
+		fmt.Println("OVPROBE_DEVICE=CPU")
+		fmt.Fprintln(os.Stderr, "free(): invalid next size (fast)")
+		os.Exit(2)
+	case "no-marker":
+		// Exits cleanly but never prints the completion marker (e.g. killed
+		// stdout, or an unexpected code path).
+		fmt.Println("something unrelated")
+		os.Exit(0)
+	case "hang":
+		time.Sleep(10 * time.Second)
+		os.Exit(0)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown helper mode %q\n", mode)
+		os.Exit(3)
+	}
+}
+
+// fakeOVProbeChild points the probe's command seam at this test binary running
+// TestOVProbeHelperProcess in the given mode, and returns a call counter.
+func fakeOVProbeChild(t *testing.T, mode string) *int {
+	t.Helper()
+	calls := new(int)
+	origNew := ovProbeNewCommand
+	origExe := ovProbeExecutable
+	ovProbeExecutable = os.Executable
+	ovProbeNewCommand = func(ctx context.Context, exe, _ string) *exec.Cmd {
+		*calls++
+		cmd := exec.CommandContext(ctx, exe, "-test.run=TestOVProbeHelperProcess", "-test.v=false")
+		cmd.Env = append(os.Environ(), ovProbeHelperEnv+"="+mode)
+		return cmd
+	}
+	t.Cleanup(func() {
+		ovProbeNewCommand = origNew
+		ovProbeExecutable = origExe
+		resetOVProbeForTest()
+	})
+	resetOVProbeForTest()
+	return calls
+}
+
+// resetOVProbeForTest clears the per-process probe cache between tests.
+func resetOVProbeForTest() {
+	ovProbe.mu.Lock()
+	defer ovProbe.mu.Unlock()
+	ovProbe.done = false
+	ovProbe.libraryPath = ""
+	ovProbe.devices = nil
+	ovProbe.err = nil
+}
+
+func TestParseOVProbeOutput(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		input       string
+		wantDevices []string
+		wantOK      bool
+	}{
+		{
+			name:        "devices with interleaved logging",
+			input:       "INFO starting up\nOVPROBE_DEVICE=CPU\nnoise\nOVPROBE_DEVICE=GPU\nOVPROBE_OK\n",
+			wantDevices: []string{"CPU", "GPU"},
+			wantOK:      true,
+		},
+		{
+			name:        "no devices but completed",
+			input:       "OVPROBE_OK\n",
+			wantDevices: nil,
+			wantOK:      true,
+		},
+		{
+			name:        "truncated output without completion marker",
+			input:       "OVPROBE_DEVICE=CPU\n",
+			wantDevices: []string{"CPU"},
+			wantOK:      false,
+		},
+		{
+			name:        "empty device name ignored",
+			input:       "OVPROBE_DEVICE=\nOVPROBE_OK\n",
+			wantDevices: nil,
+			wantOK:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			devices, sawOK := parseOVProbeOutput(strings.NewReader(tt.input))
+			assert.Equal(t, tt.wantDevices, devices)
+			assert.Equal(t, tt.wantOK, sawOK)
+		})
+	}
+}
+
+func TestRunOVProbeSuccess(t *testing.T) {
+	fakeOVProbeChild(t, "ok")
+	devices, err := runOVProbe("libopenvino_c.so")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"CPU", "GPU"}, devices)
+}
+
+func TestRunOVProbeChildCrash(t *testing.T) {
+	fakeOVProbeChild(t, "crash")
+	_, err := runOVProbe("libopenvino_c.so")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "child failed")
+	assert.Contains(t, err.Error(), "invalid next size")
+}
+
+func TestRunOVProbeMissingCompletionMarker(t *testing.T) {
+	fakeOVProbeChild(t, "no-marker")
+	_, err := runOVProbe("libopenvino_c.so")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "completion marker")
+}
+
+func TestRunOVProbeTimeout(t *testing.T) {
+	fakeOVProbeChild(t, "hang")
+	origTimeout := ovProbeTimeout
+	ovProbeTimeout = 500 * time.Millisecond
+	t.Cleanup(func() { ovProbeTimeout = origTimeout })
+	_, err := runOVProbe("libopenvino_c.so")
+	require.Error(t, err)
+}
+
+func TestOpenVINOProbeDevicesCachesResult(t *testing.T) {
+	calls := fakeOVProbeChild(t, "ok")
+
+	first, err1 := OpenVINOProbeDevices("libopenvino_c.so")
+	second, err2 := OpenVINOProbeDevices("libopenvino_c.so")
+
+	if !ov.Supported {
+		// Without the openvino build tag the probe short-circuits before any
+		// child runs; the seam proves that.
+		require.Error(t, err1)
+		require.Error(t, err2)
+		assert.Equal(t, 0, *calls)
+		return
+	}
+	require.NoError(t, err1)
+	require.NoError(t, err2)
+	assert.Equal(t, first, second)
+	assert.Equal(t, 1, *calls, "second call must be served from the cache")
+
+	// A cached result also answers OpenVINOHasDevice without new children.
+	assert.True(t, OpenVINOHasDevice("GPU"))
+	assert.False(t, OpenVINOHasDevice("NPU"))
+	assert.Equal(t, 1, *calls)
+}
+
+func TestOpenVINOProbeDevicesCachesFailure(t *testing.T) {
+	calls := fakeOVProbeChild(t, "crash")
+
+	_, err1 := OpenVINOProbeDevices("libopenvino_c.so")
+	_, err2 := OpenVINOProbeDevices("libopenvino_c.so")
+
+	require.Error(t, err1)
+	require.Error(t, err2)
+	if !ov.Supported {
+		assert.Equal(t, 0, *calls)
+		return
+	}
+	assert.Equal(t, 1, *calls, "a crashing probe child must not be re-executed")
+	// A cached failure gates OpenVINOHasDevice closed.
+	assert.False(t, OpenVINOHasDevice("GPU"))
+}
+
+func TestOpenVINOProbeDevicesReprobesOnLibraryPathChange(t *testing.T) {
+	calls := fakeOVProbeChild(t, "ok")
+
+	_, err1 := OpenVINOProbeDevices("libopenvino_c.so")
+	_, err2 := OpenVINOProbeDevices("/opt/custom/libopenvino_c.so")
+
+	if !ov.Supported {
+		require.Error(t, err1)
+		require.Error(t, err2)
+		return
+	}
+	require.NoError(t, err1)
+	require.NoError(t, err2)
+	assert.Equal(t, 2, *calls, "a changed library path must re-run the probe")
+}


### PR DESCRIPTION
## Summary

Fixes #4236.

`ov_core_get_available_devices` walks the vendor driver stack (NEO, IGC, Level Zero), and a fault anywhere in that stack aborts the process before Go can recover: glibc heap-corruption detection raises SIGABRT during cgo execution, which crash-looped the whole analyzer under systemd on first GPU enablement of the native binary. This PR runs the first device enumeration in a short-lived child process, so that worst case degrades to the ordinary "OpenVINO unavailable, using ONNX Runtime" fallback the backend already promises for every other failure mode.

## Design

- New hidden subcommand `support openvino-probe`: loads the OpenVINO core in its own process, enumerates devices, and reports them on stdout as marker-prefixed lines (`OVPROBE_DEVICE=GPU`, terminated by `OVPROBE_OK`). Markers are required because the CLI bootstrap can interleave log lines on stdout; the completion marker means truncated output from a dying child is never mistaken for a successful empty result.
- `inference.OpenVINOProbeDevices(libraryPath)` launches this same executable as that subcommand (60s timeout), parses the markers, and caches the outcome per (process, library path). A cached failure means a crashing driver stack is not re-executed on every hot reload; a changed `openvinopath` re-probes.
- `classifier.openVINOGPUAvailable` now gates the GPU decision on the probe instead of the in-process enumeration. The in-process `InitOpenVINO` stays where it is: dlopen/core-create was not the crashing step, and it preserves the existing absent-vs-broken library log classification.
- `inference.OpenVINOHasDevice` (status/capability surfaces: system inference status, models API, hwprofile) serves from the cached probe result once the planner has probed, and keeps its previous in-process behavior before any probe has run. Note the pre-probe in-process fallback only ever enumerates when the core is already initialized, same as before this change.

## Testing

- `go test -race` (probe unit tests, tagged and untagged): child crash, missing completion marker, timeout, success/failure caching, re-probe on library path change, interleaved-log parsing. Fake children via test-binary re-invocation seams.
- `golangci-lint run --build-tags openvino` on the touched packages: 0 issues (the second commit fixes the one pre-existing `modernize` finding this surfaces in `openvino_parity_functional_test.go`, which CI does not lint because it does not use the tag).
- Happy path on the hardware from #4236 (i5-12500T Gen12 iGPU, unprivileged Proxmox LXC, Debian 13, OpenVINO 2026.2, NEO 26.22): probe child reports `CPU`,`GPU`; `BirdNET v2.4 fp32-dfttrunc` initializes on GPU (f32) and `Perch v2 no-dft` on GPU (f16), identical to the pre-patch behavior.
- Fault injection: with `abort()` compiled into the enumeration shim (local test build), the probe child dies with the same SIGABRT signature as #4236 and the service logs `OpenVINO device probe failed; treating GPU as unavailable`, initializes both models on ONNX Runtime, and keeps running - previously this configuration was a systemd crash-loop.

## Notes

- The probe warning is logged once per model plan that consults it (the underlying child runs once); happy to dedupe if preferred.
- Cost is one extra process execution per library path per service lifetime; on the test hardware the child completes in well under 2s warm, ~2.5s with a cold NEO cache.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a support command for safely inspecting available OpenVINO devices.
- **Bug Fixes**
  - Improved hardware detection by isolating OpenVINO probing, preventing driver failures from terminating the application.
  - Automatically falls back to ONNX Runtime when OpenVINO is unavailable or probing fails.
- **Reliability**
  - Added probe result caching and safeguards for crashes, incomplete responses, and timeouts.
  - Improved handling of concurrent device checks and retryable probe failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->