### PR TITLE
fix(audiocore): carry per-stream RTSP transport through the pipeline (#4240)

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -46,10 +46,17 @@ The "realtime" command is an alias for backward compatibility.`,
 			// depends on SunCalc and ControlChan that are only available
 			// after APIServerService.Start(), so it is set later via
 			// AudioEngine.SetScheduler().
+			// Resolve the engine-wide default transport. A migrated config can
+			// persist an empty global transport, which would otherwise reach
+			// FFmpeg as -rtsp_transport "" and fail every stream that does not
+			// carry its own per-stream transport. ResolveTransport("") falls back
+			// to the global, then to conf.DefaultTransport.
+			engineTransport := settings.Realtime.RTSP.ResolveTransport("")
+
 			audioEngine := engine.New(cmd.Context(), &engine.Config{
 				FFmpegPath:           settings.Realtime.Audio.FfmpegPath,
 				SoxPath:              settings.Realtime.Audio.SoxPath,
-				Transport:            settings.Realtime.RTSP.Transport,
+				Transport:            engineTransport,
 				FFmpegParameters:     settings.Realtime.RTSP.FFmpegParameters,
 				Debug:                settings.Debug,
 				CaptureBufferSeconds: settings.Realtime.ExtendedCapture.EffectiveCaptureBufferSeconds(settings.Realtime.Audio.Export.PreCapture),
@@ -97,11 +104,12 @@ func setupFlags(cmd *cobra.Command, settings *conf.Settings) error {
 	// Every flag default comes from the loaded settings rather than from viper, for
 	// the same reason as --locale in cmd/root.go: cobra assigns the default into the
 	// bound variable at registration time, so passing the raw viper value writes it
-	// straight back over whatever load produced. For --source, --rtsp and
-	// --rtsptransport that would resurrect the legacy keys MigrateAudioSourceConfig
-	// and MigrateRTSPConfig deliberately cleared, and the next save would write them
-	// back into config.yaml. For --listen it would undo the normalized telemetry
-	// address, leaving the endpoint with nothing to bind.
+	// straight back over whatever load produced. For --source and --rtsp that would
+	// resurrect the legacy keys MigrateAudioSourceConfig and MigrateRTSPConfig
+	// deliberately cleared, and the next save would write them back into config.yaml.
+	// (MigrateRTSPConfig no longer clears the global rtsp.transport, so --rtsptransport
+	// simply re-defaults from the preserved value.) For --listen it would undo the
+	// normalized telemetry address, leaving the endpoint with nothing to bind.
 	//
 	// The remaining flags are read from settings too, even though nothing rewrites
 	// their keys today. Since the bound field already holds the loaded value, each

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -1106,13 +1106,33 @@ func sourceNeedsReconfigure(running *audiocore.AudioSource, desired *audiocore.S
 	// running FFmpeg, silently breaking hot-reload.
 	mediaModeChanged := conf.MediaMode(running.MediaMode).Canonical() !=
 		conf.MediaMode(desired.MediaMode).Canonical()
+	// Both sides carry the resolved concrete transport (buildSourceConfigsWithModels
+	// resolves it via RTSPSettings.ResolveTransport, and the registry stores that
+	// same value), so a direct compare is correct. It must NOT canonicalize an
+	// empty value to conf.DefaultTransport here: the true default is the engine
+	// global, which can be "udp", and hardcoding "tcp" would mask a real
+	// udp->tcp change (issue #4240 hot-reload path).
+	transportChanged := running.Transport != desired.Transport
 	return running.SampleRate != desired.SampleRate ||
 		sourceSampleRateChanged ||
 		running.BitDepth != desired.BitDepth ||
 		running.Channels != desired.Channels ||
 		channelModeChanged ||
 		mediaModeChanged ||
+		transportChanged ||
 		sourceChannelsChanged
+}
+
+// rtspStreamTransport resolves the concrete transport for an rtsp.streams entry:
+// the per-stream value if set, else the global default (via ResolveTransport),
+// and only for RTSP/RTMP types where transport applies. Resolving here keeps the
+// built SourceConfig, the registry entry, and the engine's FFmpeg args all in
+// agreement on one concrete value, so change detection compares like with like.
+func rtspStreamTransport(stream *conf.StreamConfig, rtsp *conf.RTSPSettings) string {
+	if stream.Type != conf.StreamTypeRTSP && stream.Type != conf.StreamTypeRTMP {
+		return ""
+	}
+	return rtsp.ResolveTransport(stream.Transport)
 }
 
 // resolveDesiredModelSet resolves config-level model IDs to registry IDs,
@@ -1442,6 +1462,7 @@ func (p *AudioPipelineService) buildSourceConfigsWithModels() []sourceConfigWith
 				SourceChannels:   probe.channels,
 				ChannelMode:      string(stream.ChannelMode),
 				MediaMode:        string(stream.MediaMode),
+				Transport:        rtspStreamTransport(stream, &settings.Realtime.RTSP),
 				Gain:             stream.Gain,
 			},
 			modelIDs: stream.Models,
@@ -1481,6 +1502,10 @@ func (p *AudioPipelineService) buildSourceConfigsWithModels() []sourceConfigWith
 		// stream URL from being opened as an ALSA device (which fails and
 		// breaks live audio) even before the config migration relocates it.
 		sourceType := audiocore.SourceTypeAudioCard
+		// transport stays empty for ALSA cards; a misplaced RTSP/RTMP stream URL
+		// resolves to the global default so the built config carries the same
+		// concrete value the engine will use (audio.sources has no per-stream field).
+		transport := ""
 		if streamType, isStream := audiocore.StreamSourceType(device); isStream {
 			if _, dup := streamConns[device]; dup {
 				// Already produced from rtsp.streams; skip the duplicate so the
@@ -1488,6 +1513,9 @@ func (p *AudioPipelineService) buildSourceConfigsWithModels() []sourceConfigWith
 				continue
 			}
 			sourceType = streamType
+			if streamType == audiocore.SourceTypeRTSP || streamType == audiocore.SourceTypeRTMP {
+				transport = settings.Realtime.RTSP.ResolveTransport("")
+			}
 		}
 
 		result = append(result, sourceConfigWithModels{
@@ -1498,6 +1526,7 @@ func (p *AudioPipelineService) buildSourceConfigsWithModels() []sourceConfigWith
 				SampleRate:       sampleRate,
 				BitDepth:         conf.BitDepth,
 				Channels:         1,
+				Transport:        transport,
 				Gain:             src.Gain,
 			},
 			modelIDs: src.Models,

--- a/internal/analysis/audio_pipeline_source_typing_test.go
+++ b/internal/analysis/audio_pipeline_source_typing_test.go
@@ -50,6 +50,67 @@ func TestBuildSourceConfigsWithModels_RTSPStreamCarriesGain(t *testing.T) {
 	assert.InDelta(t, 7.5, cfg.Gain, 1e-9, "per-stream gain should flow to the pipeline")
 }
 
+// TestBuildSourceConfigsWithModels_RTSPStreamCarriesTransport verifies the
+// per-stream transport flows from the config into the built RTSP SourceConfig,
+// so the initial stream start honors it rather than only the engine-wide
+// default (issue #4240).
+func TestBuildSourceConfigsWithModels_RTSPStreamCarriesTransport(t *testing.T) {
+	prev := conf.CloneSettings(conf.GetSettings())
+	t.Cleanup(func() { conftest.SetTestSettings(prev) })
+
+	settings := &conf.Settings{}
+	settings.Realtime.RTSP.Streams = []conf.StreamConfig{
+		{
+			Name:      "udp-stream",
+			URL:       "rtsp://cam-udp",
+			Enabled:   true,
+			Type:      conf.StreamTypeRTSP,
+			Transport: "udp",
+			Models:    []string{"birdnet"},
+		},
+	}
+	conftest.SetTestSettings(settings)
+
+	p := &AudioPipelineService{}
+	configs := p.buildSourceConfigsWithModels()
+
+	require.Len(t, configs, 1)
+	cfg := findConfigByConnection(configs, "rtsp://cam-udp")
+	require.NotNil(t, cfg, "rtsp stream config should be present")
+	assert.Equal(t, "udp", cfg.Transport, "per-stream transport should flow to the pipeline")
+}
+
+// TestBuildSourceConfigsWithModels_RTSPStreamResolvesGlobalTransport verifies a
+// stream with no per-stream transport resolves to the global default in the built
+// config, so the pipeline diff and the engine agree on one concrete value even
+// when the global is not the built-in "tcp" default (issue #4240).
+func TestBuildSourceConfigsWithModels_RTSPStreamResolvesGlobalTransport(t *testing.T) {
+	prev := conf.CloneSettings(conf.GetSettings())
+	t.Cleanup(func() { conftest.SetTestSettings(prev) })
+
+	settings := &conf.Settings{}
+	settings.Realtime.RTSP.Transport = "udp" // global default
+	settings.Realtime.RTSP.Streams = []conf.StreamConfig{
+		{
+			Name:    "no-transport-stream",
+			URL:     "rtsp://cam-global",
+			Enabled: true,
+			Type:    conf.StreamTypeRTSP,
+			// Transport intentionally empty: must resolve to the global "udp".
+			Models: []string{"birdnet"},
+		},
+	}
+	conftest.SetTestSettings(settings)
+
+	p := &AudioPipelineService{}
+	configs := p.buildSourceConfigsWithModels()
+
+	require.Len(t, configs, 1)
+	cfg := findConfigByConnection(configs, "rtsp://cam-global")
+	require.NotNil(t, cfg, "rtsp stream config should be present")
+	assert.Equal(t, "udp", cfg.Transport, "unset per-stream transport must resolve to the global default")
+}
+
 // TestBuildSourceConfigsWithModels_StreamURLInAudioSources verifies that a
 // stream URL misplaced under audio.sources is emitted as a stream-typed
 // SourceConfig (not an ALSA audio card) with its gain carried.

--- a/internal/analysis/audio_pipeline_source_typing_test.go
+++ b/internal/analysis/audio_pipeline_source_typing_test.go
@@ -65,7 +65,7 @@ func TestBuildSourceConfigsWithModels_RTSPStreamCarriesTransport(t *testing.T) {
 			URL:       "rtsp://cam-udp",
 			Enabled:   true,
 			Type:      conf.StreamTypeRTSP,
-			Transport: "udp",
+			Transport: transportUDP,
 			Models:    []string{"birdnet"},
 		},
 	}
@@ -77,7 +77,7 @@ func TestBuildSourceConfigsWithModels_RTSPStreamCarriesTransport(t *testing.T) {
 	require.Len(t, configs, 1)
 	cfg := findConfigByConnection(configs, "rtsp://cam-udp")
 	require.NotNil(t, cfg, "rtsp stream config should be present")
-	assert.Equal(t, "udp", cfg.Transport, "per-stream transport should flow to the pipeline")
+	assert.Equal(t, transportUDP, cfg.Transport, "per-stream transport should flow to the pipeline")
 }
 
 // TestBuildSourceConfigsWithModels_RTSPStreamResolvesGlobalTransport verifies a
@@ -89,7 +89,7 @@ func TestBuildSourceConfigsWithModels_RTSPStreamResolvesGlobalTransport(t *testi
 	t.Cleanup(func() { conftest.SetTestSettings(prev) })
 
 	settings := &conf.Settings{}
-	settings.Realtime.RTSP.Transport = "udp" // global default
+	settings.Realtime.RTSP.Transport = transportUDP // global default
 	settings.Realtime.RTSP.Streams = []conf.StreamConfig{
 		{
 			Name:    "no-transport-stream",
@@ -108,7 +108,7 @@ func TestBuildSourceConfigsWithModels_RTSPStreamResolvesGlobalTransport(t *testi
 	require.Len(t, configs, 1)
 	cfg := findConfigByConnection(configs, "rtsp://cam-global")
 	require.NotNil(t, cfg, "rtsp stream config should be present")
-	assert.Equal(t, "udp", cfg.Transport, "unset per-stream transport must resolve to the global default")
+	assert.Equal(t, transportUDP, cfg.Transport, "unset per-stream transport must resolve to the global default")
 }
 
 // TestBuildSourceConfigsWithModels_StreamURLInAudioSources verifies that a

--- a/internal/analysis/source_config_diff_test.go
+++ b/internal/analysis/source_config_diff_test.go
@@ -142,6 +142,44 @@ func TestSourceNeedsReconfigure(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			// Both sides carry the resolved concrete transport, so equal values
+			// are a no-op. This is the common case after buildSourceConfigsWithModels
+			// resolves the transport.
+			name: "transport unchanged is a no-op",
+			running: &audiocore.AudioSource{
+				SampleRate: 48000, BitDepth: 16, Channels: 1, Transport: "tcp",
+			},
+			desired: &audiocore.SourceConfig{
+				SampleRate: 48000, BitDepth: 16, Channels: 1, Transport: "tcp",
+			},
+			expected: false,
+		},
+		{
+			// Non-RTSP sources carry no transport on either side; empty vs empty
+			// must not be seen as a change.
+			name: "empty transport both sides is a no-op",
+			running: &audiocore.AudioSource{
+				SampleRate: 48000, BitDepth: 16, Channels: 1, Transport: "",
+			},
+			desired: &audiocore.SourceConfig{
+				SampleRate: 48000, BitDepth: 16, Channels: 1, Transport: "",
+			},
+			expected: false,
+		},
+		{
+			// The issue #4240 hot-reload path: a stream running on the global "udp"
+			// (resolved to a concrete "udp" on both sides) edited to explicit "tcp"
+			// MUST restart. A hardcoded empty->tcp canonicalization would mask this.
+			name: "transport udp to tcp changes",
+			running: &audiocore.AudioSource{
+				SampleRate: 48000, BitDepth: 16, Channels: 1, Transport: "udp",
+			},
+			desired: &audiocore.SourceConfig{
+				SampleRate: 48000, BitDepth: 16, Channels: 1, Transport: "tcp",
+			},
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/analysis/source_config_diff_test.go
+++ b/internal/analysis/source_config_diff_test.go
@@ -13,6 +13,13 @@ import (
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
+// Named RTSP transport values for tests, so the diff/resolution cases avoid raw
+// magic strings.
+const (
+	transportTCP = "tcp"
+	transportUDP = "udp"
+)
+
 func TestSourceNeedsReconfigure(t *testing.T) {
 	t.Parallel()
 
@@ -148,10 +155,10 @@ func TestSourceNeedsReconfigure(t *testing.T) {
 			// resolves the transport.
 			name: "transport unchanged is a no-op",
 			running: &audiocore.AudioSource{
-				SampleRate: 48000, BitDepth: 16, Channels: 1, Transport: "tcp",
+				SampleRate: 48000, BitDepth: 16, Channels: 1, Transport: transportTCP,
 			},
 			desired: &audiocore.SourceConfig{
-				SampleRate: 48000, BitDepth: 16, Channels: 1, Transport: "tcp",
+				SampleRate: 48000, BitDepth: 16, Channels: 1, Transport: transportTCP,
 			},
 			expected: false,
 		},
@@ -173,10 +180,10 @@ func TestSourceNeedsReconfigure(t *testing.T) {
 			// MUST restart. A hardcoded empty->tcp canonicalization would mask this.
 			name: "transport udp to tcp changes",
 			running: &audiocore.AudioSource{
-				SampleRate: 48000, BitDepth: 16, Channels: 1, Transport: "udp",
+				SampleRate: 48000, BitDepth: 16, Channels: 1, Transport: transportUDP,
 			},
 			desired: &audiocore.SourceConfig{
-				SampleRate: 48000, BitDepth: 16, Channels: 1, Transport: "tcp",
+				SampleRate: 48000, BitDepth: 16, Channels: 1, Transport: transportTCP,
 			},
 			expected: true,
 		},

--- a/internal/audiocore/engine/engine.go
+++ b/internal/audiocore/engine/engine.go
@@ -268,6 +268,19 @@ func (e *AudioEngine) StopStream(sourceID string) error {
 	return nil
 }
 
+// resolveTransport selects the RTSP transport for a stream: the per-stream
+// value when set, otherwise the engine-wide default. The per-stream value is
+// the source of truth in the new streams format, so it wins; the engine
+// default covers streams that leave it unset. A final empty-string guard in
+// the ffmpeg package still applies conf.DefaultTransport if both are empty, so
+// FFmpeg never receives an empty -rtsp_transport value.
+func (e *AudioEngine) resolveTransport(streamTransport string) string {
+	if streamTransport != "" {
+		return streamTransport
+	}
+	return e.transport
+}
+
 // StartStream restarts a quiet-hours-suppressed FFmpeg stream under its
 // existing runtime sourceID.
 func (e *AudioEngine) StartStream(sourceID, url, transport string) error {
@@ -275,9 +288,7 @@ func (e *AudioEngine) StartStream(sourceID, url, transport string) error {
 	if !ok {
 		return fmt.Errorf("restart stream: %w: %s", audiocore.ErrSourceNotFound, sourceID)
 	}
-	if transport == "" {
-		transport = e.transport
-	}
+	transport = e.resolveTransport(transport)
 	sampleRate := src.SampleRate
 	if sampleRate <= 0 {
 		sampleRate = defaultSampleRate
@@ -441,7 +452,7 @@ func (e *AudioEngine) AddSource(cfg *audiocore.SourceConfig) error {
 			ChannelMode:      cfg.ChannelMode,
 			MediaMode:        cfg.MediaMode,
 			FFmpegPath:       e.ffmpegPath,
-			Transport:        e.transport,
+			Transport:        e.resolveTransport(cfg.Transport),
 			FFmpegParameters: e.ffmpegParameters,
 			LogLevel:         e.logLevel,
 			Debug:            e.debug,
@@ -647,7 +658,7 @@ func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.Sourc
 			ChannelMode:      newCfg.ChannelMode,
 			MediaMode:        newCfg.MediaMode,
 			FFmpegPath:       e.ffmpegPath,
-			Transport:        e.transport,
+			Transport:        e.resolveTransport(newCfg.Transport),
 			FFmpegParameters: e.ffmpegParameters,
 			LogLevel:         e.logLevel,
 			Debug:            e.debug,
@@ -686,7 +697,7 @@ func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.Sourc
 	// snapshots and emits the SourceReconfigured event with the fully updated entry.
 	// Without the sync, a channel/media-mode-only change re-triggers on every later
 	// reconfigure and restarts the stream indefinitely.
-	syncedModes := e.registry.SyncReconfiguredParams(sourceID, newCfg.ChannelMode, newCfg.MediaMode, newCfg.SourceSampleRate, newCfg.SourceChannels)
+	syncedModes := e.registry.SyncReconfiguredParams(sourceID, newCfg.ChannelMode, newCfg.MediaMode, newCfg.Transport, newCfg.SourceSampleRate, newCfg.SourceChannels)
 	syncedParams := e.registry.UpdateAudioParams(sourceID, sampleRate, bitDepth, channels)
 	if !syncedModes || !syncedParams {
 		// The source was fetched at the top of this function and the reconfigure

--- a/internal/audiocore/engine/engine_test.go
+++ b/internal/audiocore/engine/engine_test.go
@@ -17,6 +17,12 @@ import (
 // testModelID is used by tests to verify analysis buffer allocation.
 const testModelID = "BirdNET_V2.4"
 
+// Named RTSP transport values for tests.
+const (
+	transportTCP = "tcp"
+	transportUDP = "udp"
+)
+
 // BirdNET v2.4 analysis buffer dimensions: 3s of 16-bit 48kHz mono audio.
 const (
 	testClipBytes    = 288000 // 48000 * 3 * 1 * 2
@@ -77,9 +83,9 @@ func TestEngine_resolveTransport(t *testing.T) {
 		streamTransport string
 		want            string
 	}{
-		{name: "per-stream wins over default", engineDefault: "tcp", streamTransport: "udp", want: "udp"},
-		{name: "empty per-stream falls back to default", engineDefault: "tcp", streamTransport: "", want: "tcp"},
-		{name: "per-stream used when default empty", engineDefault: "", streamTransport: "udp", want: "udp"},
+		{name: "per-stream wins over default", engineDefault: transportTCP, streamTransport: transportUDP, want: transportUDP},
+		{name: "empty per-stream falls back to default", engineDefault: transportTCP, streamTransport: "", want: transportTCP},
+		{name: "per-stream used when default empty", engineDefault: "", streamTransport: transportUDP, want: transportUDP},
 		{name: "both empty stays empty (ffmpeg guard applies later)", engineDefault: "", streamTransport: "", want: ""},
 	}
 
@@ -380,7 +386,7 @@ func TestEngine_ReconfigureSource(t *testing.T) {
 func TestEngine_ReconfigureSource_NonRTSPTransportStaysEmpty(t *testing.T) {
 	t.Parallel()
 	// Engine default is a concrete transport; the non-RTSP source must not pick it up.
-	eng := New(t.Context(), &Config{Logger: audiocore.GetLogger(), Transport: "tcp"}, nil)
+	eng := New(t.Context(), &Config{Logger: audiocore.GetLogger(), Transport: transportTCP}, nil)
 	eng.SetPrimaryModel(testModelID, testClipBytes, testOverlapBytes, testReadSize)
 	t.Cleanup(eng.Stop)
 

--- a/internal/audiocore/engine/engine_test.go
+++ b/internal/audiocore/engine/engine_test.go
@@ -65,6 +65,34 @@ func TestEngine_Accessors(t *testing.T) {
 	assert.Nil(t, eng.Scheduler(), "Scheduler() should be nil when no scheduler provided")
 }
 
+// TestEngine_resolveTransport verifies that a per-stream transport wins over
+// the engine-wide default, and that an unset per-stream value falls back to
+// the engine default (issue #4240).
+func TestEngine_resolveTransport(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		engineDefault   string
+		streamTransport string
+		want            string
+	}{
+		{name: "per-stream wins over default", engineDefault: "tcp", streamTransport: "udp", want: "udp"},
+		{name: "empty per-stream falls back to default", engineDefault: "tcp", streamTransport: "", want: "tcp"},
+		{name: "per-stream used when default empty", engineDefault: "", streamTransport: "udp", want: "udp"},
+		{name: "both empty stays empty (ffmpeg guard applies later)", engineDefault: "", streamTransport: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			eng := New(t.Context(), &Config{Logger: audiocore.GetLogger(), Transport: tt.engineDefault}, nil)
+			t.Cleanup(eng.Stop)
+			assert.Equal(t, tt.want, eng.resolveTransport(tt.streamTransport))
+		})
+	}
+}
+
 // TestEngine_AddSource_Stream adds an RTSP source and verifies that it is
 // registered in the source registry and that buffers are allocated.
 func TestEngine_AddSource_Stream(t *testing.T) {
@@ -340,6 +368,51 @@ func TestEngine_ReconfigureSource(t *testing.T) {
 	// Verify the FFmpeg stream was restarted.
 	health := eng.FFmpegManager().AllStreamHealth()
 	assert.Contains(t, health, "test_reconfig_001", "stream should be restarted after reconfigure")
+}
+
+// TestEngine_ReconfigureSource_NonRTSPTransportStaysEmpty guards against the
+// hot-reload restart loop for non-RTSP stream types (issue #4240). A non-RTSP
+// source (HLS/HTTP/UDP) carries an empty Transport in its desired config, so the
+// reconfigure write-back must store that empty value verbatim, NOT re-resolve it
+// to the engine default. If it stored a concrete default, the registry entry
+// ("tcp") would never equal the empty desired value and every later reload would
+// restart the stream forever.
+func TestEngine_ReconfigureSource_NonRTSPTransportStaysEmpty(t *testing.T) {
+	t.Parallel()
+	// Engine default is a concrete transport; the non-RTSP source must not pick it up.
+	eng := New(t.Context(), &Config{Logger: audiocore.GetLogger(), Transport: "tcp"}, nil)
+	eng.SetPrimaryModel(testModelID, testClipBytes, testOverlapBytes, testReadSize)
+	t.Cleanup(eng.Stop)
+
+	cfg := &audiocore.SourceConfig{
+		ID:               "test_hls_transport",
+		DisplayName:      "HLS Source",
+		Type:             audiocore.SourceTypeHLS,
+		ConnectionString: "https://example.com/live/playlist.m3u8",
+		SampleRate:       48000,
+		BitDepth:         16,
+		Channels:         1,
+		// Transport intentionally empty: HLS does not use -rtsp_transport.
+	}
+	require.NoError(t, eng.AddSource(cfg))
+
+	src, ok := eng.Registry().Get("test_hls_transport")
+	require.True(t, ok)
+	assert.Empty(t, src.Transport, "non-RTSP source must be registered with an empty transport")
+
+	// Reconfigure an unrelated field; desired transport is still empty.
+	newCfg := &audiocore.SourceConfig{
+		ConnectionString: "https://example.com/live/playlist.m3u8",
+		SampleRate:       32000,
+		BitDepth:         16,
+		Channels:         1,
+	}
+	require.NoError(t, eng.ReconfigureSource("test_hls_transport", newCfg))
+
+	src, ok = eng.Registry().Get("test_hls_transport")
+	require.True(t, ok)
+	assert.Empty(t, src.Transport,
+		"reconfigure must not re-resolve a non-RTSP transport to the engine default")
 }
 
 // TestEngine_ReconfigureSource_NotFound verifies that reconfiguring a

--- a/internal/audiocore/ffmpeg/process.go
+++ b/internal/audiocore/ffmpeg/process.go
@@ -61,6 +61,13 @@ func isRTSPURL(url string) bool {
 // fallen back to requesting the full stream (issue #3902); video is still
 // dropped after decode via -vn, so the fallback only affects the RTSP handshake.
 func appendRTSPMediaArgs(args []string, transport string, audioOnly bool) []string {
+	// Final safety net: never emit an empty -rtsp_transport. A blank value makes
+	// FFmpeg fail to parse the option ("Error setting option rtsp_transport to
+	// value") and the stream never opens. Callers should resolve the transport
+	// upstream, but a missing or misconfigured value falls back to the default.
+	if transport == "" {
+		transport = conf.DefaultTransport
+	}
 	args = append(args, "-rtsp_transport", transport)
 	if audioOnly {
 		args = append(args, ffmpegAllowedMediaTypesFlag, ffmpegAllowedMediaTypesAudio)

--- a/internal/audiocore/ffmpeg/process_test.go
+++ b/internal/audiocore/ffmpeg/process_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
+	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
 // TestBuildFFmpegArgs_RTSP verifies that BuildFFmpegArgs produces the correct
@@ -62,6 +63,35 @@ func TestBuildFFmpegArgs_RTSP(t *testing.T) {
 	assert.Contains(t, args, "-ac")
 	assert.Contains(t, args, "-f")
 	assert.Contains(t, args, "-vn")
+}
+
+// TestBuildFFmpegArgs_RTSPEmptyTransportFallsBackToDefault guards issue #4240:
+// an RTSP stream whose Transport is empty (e.g. a migrated config that cleared
+// the global transport) must never emit -rtsp_transport "". FFmpeg cannot parse
+// an empty value and the stream fails to open. The builder falls back to the
+// default transport instead.
+func TestBuildFFmpegArgs_RTSPEmptyTransportFallsBackToDefault(t *testing.T) {
+	t.Parallel()
+
+	cfg := &StreamConfig{
+		URL:        "rtsp://camera.example.com/live",
+		Type:       "rtsp",
+		SampleRate: 48000,
+		BitDepth:   16,
+		Channels:   1,
+		Transport:  "", // empty: migration cleared it, engine default was also empty
+		LogLevel:   "error",
+		MediaMode:  "auto",
+	}
+
+	args := BuildFFmpegArgs(cfg, nil)
+
+	rtspIdx := slices.Index(args, "-rtsp_transport")
+	require.NotEqual(t, -1, rtspIdx, "expected -rtsp_transport flag")
+	require.Less(t, rtspIdx+1, len(args), "-rtsp_transport must have a value")
+	assert.Equal(t, conf.DefaultTransport, args[rtspIdx+1],
+		"empty transport must fall back to the default, never an empty string")
+	assert.NotEmpty(t, args[rtspIdx+1], "-rtsp_transport value must not be empty")
 }
 
 // TestBuildFFmpegArgs_MediaModes verifies the audio-only request tracks the

--- a/internal/audiocore/source.go
+++ b/internal/audiocore/source.go
@@ -125,6 +125,10 @@ type AudioSource struct {
 	// Values: "auto", "audio-only", "full-stream" (empty = full-stream).
 	MediaMode string `json:"mediaMode,omitempty"`
 
+	// Transport is the per-stream RTSP transport protocol ("tcp" or "udp").
+	// Empty means fall back to the engine-wide default. Only applied to RTSP/RTMP sources.
+	Transport string `json:"transport,omitempty"`
+
 	// Gain is the configured input gain in dB. 0 means no adjustment.
 	Gain float64 `json:"gain"`
 
@@ -244,6 +248,11 @@ type SourceConfig struct {
 	// MediaMode controls which RTSP media is requested from the camera.
 	// Values: "auto", "audio-only", "full-stream" (empty = full-stream).
 	MediaMode string
+
+	// Transport is the per-stream RTSP transport protocol ("tcp" or "udp").
+	// Empty means fall back to the engine-wide default. Only applied to
+	// RTSP/RTMP sources; ignored for local audio cards and HTTP sources.
+	Transport string
 
 	// Gain is the input gain adjustment in dB. 0 means no adjustment.
 	// Positive values amplify, negative values attenuate.

--- a/internal/audiocore/source_registry.go
+++ b/internal/audiocore/source_registry.go
@@ -140,6 +140,7 @@ func (r *SourceRegistry) Register(cfg *SourceConfig) (*AudioSource, error) {
 		SourceChannels:   cfg.SourceChannels,
 		ChannelMode:      cfg.ChannelMode,
 		MediaMode:        cfg.MediaMode,
+		Transport:        cfg.Transport,
 		Gain:             cfg.Gain,
 		State:            SourceInactive,
 		RegisteredAt:     time.Now(),
@@ -315,19 +316,24 @@ func (r *SourceRegistry) UpdateAudioParams(sourceID string, sampleRate, bitDepth
 	return true
 }
 
-// SyncReconfiguredParams updates the registry entry's mode and probed source-shape
-// fields after an in-place reconfigure. Register writes these once at add time and
-// ReconfigureSource does not re-register, so without this the registry keeps the
-// values captured when the source was first added. Because sourceNeedsReconfigure
-// diffs the desired config against the registry entry, a stale entry makes a
-// change to only these fields re-trigger on every subsequent reconfigure and
-// restart the stream indefinitely; quiet-hours resume (which rebuilds the stream
-// config from the registry) would also use the old values. Source-shape fields are
-// only overwritten when the new value is known (non-zero), matching the "desired
-// != 0" guard in sourceNeedsReconfigure. It does not notify; the caller's
-// following UpdateAudioParams emits the SourceReconfigured event with the fully
-// updated snapshot.
-func (r *SourceRegistry) SyncReconfiguredParams(sourceID, channelMode, mediaMode string, sourceSampleRate, sourceChannels int) bool {
+// SyncReconfiguredParams updates the registry entry's mode, transport, and probed
+// source-shape fields after an in-place reconfigure. Register writes these once at
+// add time and ReconfigureSource does not re-register, so without this the registry
+// keeps the values captured when the source was first added. Because
+// sourceNeedsReconfigure diffs the desired config against the registry entry, a
+// stale entry makes a change to only these fields re-trigger on every subsequent
+// reconfigure and restart the stream indefinitely; quiet-hours resume (which
+// rebuilds the stream config from the registry) would also use the old values.
+// transport is stored EXACTLY as the caller passes it (the pipeline's desired
+// value, matching what Register stores), NOT re-resolved to the engine default:
+// buildSourceConfigsWithModels leaves it empty for non-RTSP stream types, so
+// re-resolving here would store a concrete default that never equals the empty
+// desired value and would re-trigger a restart on every later reload. Source-shape
+// fields are only overwritten when the new value is known (non-zero), matching the
+// "desired != 0" guard in sourceNeedsReconfigure. It does not notify; the caller's following
+// UpdateAudioParams emits the SourceReconfigured event with the fully updated
+// snapshot.
+func (r *SourceRegistry) SyncReconfiguredParams(sourceID, channelMode, mediaMode, transport string, sourceSampleRate, sourceChannels int) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	src, ok := r.sources[sourceID]
@@ -336,6 +342,7 @@ func (r *SourceRegistry) SyncReconfiguredParams(sourceID, channelMode, mediaMode
 	}
 	src.ChannelMode = channelMode
 	src.MediaMode = mediaMode
+	src.Transport = transport
 	if sourceSampleRate != 0 {
 		src.SourceSampleRate = sourceSampleRate
 	}

--- a/internal/audiocore/source_registry_test.go
+++ b/internal/audiocore/source_registry_test.go
@@ -466,31 +466,34 @@ func TestSourceRegistry_SyncReconfiguredParams(t *testing.T) {
 		ConnectionString: "rtsp://sync.example.com/stream",
 		ChannelMode:      "downmix",
 		MediaMode:        "auto",
+		Transport:        "tcp",
 		SourceSampleRate: 48000,
 		SourceChannels:   2,
 	})
 	require.NoError(t, err)
 
-	// New mode plus non-zero shape overwrites all four fields.
-	ok := r.SyncReconfiguredParams(src.ID, "left", "full-stream", 44100, 1)
+	// New mode/transport plus non-zero shape overwrites all fields.
+	ok := r.SyncReconfiguredParams(src.ID, "left", "full-stream", "udp", 44100, 1)
 	require.True(t, ok)
 
 	got, ok := r.Get(src.ID)
 	require.True(t, ok)
 	assert.Equal(t, "left", got.ChannelMode, "channel mode must be written back")
 	assert.Equal(t, "full-stream", got.MediaMode, "media mode must be written back")
+	assert.Equal(t, "udp", got.Transport, "transport must be written back so a later reload does not re-trigger reconfigure")
 	assert.Equal(t, 44100, got.SourceSampleRate, "non-zero source sample rate must be written back")
 	assert.Equal(t, 1, got.SourceChannels, "non-zero source channels must be written back")
 
 	// Zero-valued shape must NOT clobber the known values (mirrors the
-	// "desired != 0" guard in sourceNeedsReconfigure); modes are always written.
-	ok = r.SyncReconfiguredParams(src.ID, "right", "audio-only", 0, 0)
+	// "desired != 0" guard in sourceNeedsReconfigure); modes/transport are always written.
+	ok = r.SyncReconfiguredParams(src.ID, "right", "audio-only", "tcp", 0, 0)
 	require.True(t, ok)
 
 	got, ok = r.Get(src.ID)
 	require.True(t, ok)
 	assert.Equal(t, "right", got.ChannelMode)
 	assert.Equal(t, "audio-only", got.MediaMode)
+	assert.Equal(t, "tcp", got.Transport)
 	assert.Equal(t, 44100, got.SourceSampleRate, "zero source sample rate must not clobber the known value")
 	assert.Equal(t, 1, got.SourceChannels, "zero source channels must not clobber the known value")
 }
@@ -501,5 +504,5 @@ func TestSourceRegistry_SyncReconfiguredParams_NotFound(t *testing.T) {
 	t.Parallel()
 	r := newTestRegistry(t)
 
-	assert.False(t, r.SyncReconfiguredParams("nonexistent-id", "left", "full-stream", 48000, 1))
+	assert.False(t, r.SyncReconfiguredParams("nonexistent-id", "left", "full-stream", "tcp", 48000, 1))
 }

--- a/internal/audiocore/source_registry_test.go
+++ b/internal/audiocore/source_registry_test.go
@@ -10,6 +10,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Named RTSP transport values for tests.
+const (
+	transportTCP = "tcp"
+	transportUDP = "udp"
+)
+
 // newTestRegistry creates a SourceRegistry with the package logger for tests.
 func newTestRegistry(t *testing.T) *SourceRegistry {
 	t.Helper()
@@ -466,34 +472,34 @@ func TestSourceRegistry_SyncReconfiguredParams(t *testing.T) {
 		ConnectionString: "rtsp://sync.example.com/stream",
 		ChannelMode:      "downmix",
 		MediaMode:        "auto",
-		Transport:        "tcp",
+		Transport:        transportTCP,
 		SourceSampleRate: 48000,
 		SourceChannels:   2,
 	})
 	require.NoError(t, err)
 
 	// New mode/transport plus non-zero shape overwrites all fields.
-	ok := r.SyncReconfiguredParams(src.ID, "left", "full-stream", "udp", 44100, 1)
+	ok := r.SyncReconfiguredParams(src.ID, "left", "full-stream", transportUDP, 44100, 1)
 	require.True(t, ok)
 
 	got, ok := r.Get(src.ID)
 	require.True(t, ok)
 	assert.Equal(t, "left", got.ChannelMode, "channel mode must be written back")
 	assert.Equal(t, "full-stream", got.MediaMode, "media mode must be written back")
-	assert.Equal(t, "udp", got.Transport, "transport must be written back so a later reload does not re-trigger reconfigure")
+	assert.Equal(t, transportUDP, got.Transport, "transport must be written back so a later reload does not re-trigger reconfigure")
 	assert.Equal(t, 44100, got.SourceSampleRate, "non-zero source sample rate must be written back")
 	assert.Equal(t, 1, got.SourceChannels, "non-zero source channels must be written back")
 
 	// Zero-valued shape must NOT clobber the known values (mirrors the
 	// "desired != 0" guard in sourceNeedsReconfigure); modes/transport are always written.
-	ok = r.SyncReconfiguredParams(src.ID, "right", "audio-only", "tcp", 0, 0)
+	ok = r.SyncReconfiguredParams(src.ID, "right", "audio-only", transportTCP, 0, 0)
 	require.True(t, ok)
 
 	got, ok = r.Get(src.ID)
 	require.True(t, ok)
 	assert.Equal(t, "right", got.ChannelMode)
 	assert.Equal(t, "audio-only", got.MediaMode)
-	assert.Equal(t, "tcp", got.Transport)
+	assert.Equal(t, transportTCP, got.Transport)
 	assert.Equal(t, 44100, got.SourceSampleRate, "zero source sample rate must not clobber the known value")
 	assert.Equal(t, 1, got.SourceChannels, "zero source channels must not clobber the known value")
 }
@@ -504,5 +510,5 @@ func TestSourceRegistry_SyncReconfiguredParams_NotFound(t *testing.T) {
 	t.Parallel()
 	r := newTestRegistry(t)
 
-	assert.False(t, r.SyncReconfiguredParams("nonexistent-id", "left", "full-stream", "tcp", 48000, 1))
+	assert.False(t, r.SyncReconfiguredParams("nonexistent-id", "left", "full-stream", transportTCP, 48000, 1))
 }

--- a/internal/conf/migrations.go
+++ b/internal/conf/migrations.go
@@ -220,12 +220,14 @@ func inferStreamType(url string) string {
 
 // MigrateRTSPConfig migrates legacy URLs []string to Streams []StreamConfig.
 // This migration:
-// - Skips if Streams already has entries (already migrated)
-// - Only migrates if URLs has data
-// - Trims whitespace and skips empty URLs
-// - Infers stream type from URL scheme
-// - Preserves the global Transport setting for RTSP/RTMP streams
-// - Returns true if migration occurred, false if skipped
+//   - Skips if Streams already has entries (already migrated)
+//   - Only migrates if URLs has data
+//   - Trims whitespace and skips empty URLs
+//   - Infers stream type from URL scheme
+//   - Copies the global Transport into each RTSP/RTMP stream entry AND keeps the
+//     global Transport in place, because the startup path reads the global value
+//     as the engine-wide default
+//   - Returns true if migration occurred, false if skipped
 func (s *Settings) MigrateRTSPConfig() bool {
 	rtsp := &s.Realtime.RTSP
 
@@ -289,9 +291,13 @@ func (s *Settings) MigrateRTSPConfig() bool {
 		return false
 	}
 
-	// Clear legacy fields
+	// Clear the legacy URLs list now that it has been migrated to Streams.
+	// Keep rtsp.Transport: it is copied into each per-stream entry above, but
+	// the startup path (cmd/serve/serve.go) still reads the global value as the
+	// engine-wide default transport. Clearing it made FFmpeg receive an empty
+	// -rtsp_transport and fail to open the stream on the next start (the value
+	// is present-but-empty, so the Viper default no longer applies).
 	rtsp.URLs = nil
-	rtsp.Transport = ""
 
 	GetLogger().Info("Migrated RTSP configuration to new streams format",
 		logger.Int("stream_count", len(rtsp.Streams)))

--- a/internal/conf/stream_migration_test.go
+++ b/internal/conf/stream_migration_test.go
@@ -17,6 +17,10 @@ func TestSettings_MigrateRTSPConfig(t *testing.T) {
 		expectMigrated bool
 		expectedCount  int
 		expectedNames  []string
+		// expectedTransport is the global rtsp.transport value expected AFTER
+		// migration. The migration keeps the global (the startup path reads it
+		// as the engine-wide default), so it must equal the input value.
+		expectedTransport string
 	}{
 		{
 			name: "migrate legacy URLs to streams",
@@ -28,9 +32,10 @@ func TestSettings_MigrateRTSPConfig(t *testing.T) {
 					},
 				},
 			},
-			expectMigrated: true,
-			expectedCount:  2,
-			expectedNames:  []string{"Stream 1", "Stream 2"},
+			expectMigrated:    true,
+			expectedCount:     2,
+			expectedNames:     []string{"Stream 1", "Stream 2"},
+			expectedTransport: "tcp",
 		},
 		{
 			name: "skip migration if streams already exist",
@@ -72,6 +77,9 @@ func TestSettings_MigrateRTSPConfig(t *testing.T) {
 			},
 			expectMigrated: true,
 			expectedCount:  1,
+			// Input global was empty; migration does not backfill the global
+			// (only per-stream entries get the default), so it stays empty.
+			expectedTransport: "",
 		},
 		{
 			name: "preserve udp transport from legacy",
@@ -83,8 +91,9 @@ func TestSettings_MigrateRTSPConfig(t *testing.T) {
 					},
 				},
 			},
-			expectMigrated: true,
-			expectedCount:  1,
+			expectMigrated:    true,
+			expectedCount:     1,
+			expectedTransport: "udp",
 		},
 	}
 
@@ -97,9 +106,12 @@ func TestSettings_MigrateRTSPConfig(t *testing.T) {
 			assert.Len(t, tt.settings.Realtime.RTSP.Streams, tt.expectedCount)
 
 			if tt.expectMigrated {
-				// Verify legacy fields are cleared
+				// Verify the legacy URLs list is cleared.
 				assert.Empty(t, tt.settings.Realtime.RTSP.URLs)
-				assert.Empty(t, tt.settings.Realtime.RTSP.Transport)
+				// The global transport is preserved, not cleared: the startup
+				// path reads it as the engine-wide default. Clearing it made
+				// FFmpeg receive an empty -rtsp_transport and fail (issue #4240).
+				assert.Equal(t, tt.expectedTransport, tt.settings.Realtime.RTSP.Transport)
 			}
 
 			// Verify names if expected

--- a/internal/conf/stream_persistence_test.go
+++ b/internal/conf/stream_persistence_test.go
@@ -537,9 +537,10 @@ transport: "tcp"
 	assert.Equal(t, StreamTypeHLS, settings.Realtime.RTSP.Streams[2].Type)
 	assert.Empty(t, settings.Realtime.RTSP.Streams[2].Transport, "HLS streams should not have transport")
 
-	// Legacy fields should be cleared
+	// The legacy URLs list is cleared, but the global transport is preserved:
+	// the startup path reads it as the engine-wide default (issue #4240).
 	assert.Empty(t, settings.Realtime.RTSP.URLs)
-	assert.Empty(t, settings.Realtime.RTSP.Transport)
+	assert.Equal(t, "tcp", settings.Realtime.RTSP.Transport)
 
 	// Now save the migrated config and verify it can be reloaded
 	migratedData, err := yaml.Marshal(&settings.Realtime.RTSP)

--- a/internal/conf/stream_validation_test.go
+++ b/internal/conf/stream_validation_test.go
@@ -513,6 +513,32 @@ func TestApplyStreamDefaults(t *testing.T) {
 	}
 }
 
+// TestRTSPSettings_ResolveTransport verifies the single owner of the
+// "per-stream else global else default" transport rule (issue #4240).
+func TestRTSPSettings_ResolveTransport(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		globalT    string
+		perStreamT string
+		want       string
+	}{
+		{name: "per-stream wins over global", globalT: "tcp", perStreamT: "udp", want: "udp"},
+		{name: "empty per-stream uses global", globalT: "udp", perStreamT: "", want: "udp"},
+		{name: "empty per-stream and empty global uses default", globalT: "", perStreamT: "", want: DefaultTransport},
+		{name: "per-stream used when global empty", globalT: "", perStreamT: "tcp", want: "tcp"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			r := &RTSPSettings{Transport: tt.globalT}
+			assert.Equal(t, tt.want, r.ResolveTransport(tt.perStreamT))
+		})
+	}
+}
+
 // streamModeCase is one enum-mode validation case: the raw value to set and
 // whether StreamConfig.Validate must reject it.
 type streamModeCase struct {

--- a/internal/conf/validate_audio.go
+++ b/internal/conf/validate_audio.go
@@ -258,6 +258,22 @@ func (s *StreamConfig) validateURLScheme() error {
 	return nil
 }
 
+// ResolveTransport returns the concrete RTSP transport to use for a stream given
+// its per-stream value: the per-stream value when set, otherwise the global
+// RTSPSettings.Transport, otherwise DefaultTransport. This is the single owner of
+// the "per-stream else global else default" rule, so the migration, the startup
+// engine default, and the audio pipeline all resolve transport the same way and
+// never disagree about what an unset value means.
+func (r *RTSPSettings) ResolveTransport(perStreamTransport string) string {
+	if perStreamTransport != "" {
+		return perStreamTransport
+	}
+	if r.Transport != "" {
+		return r.Transport
+	}
+	return DefaultTransport
+}
+
 // ApplyStreamDefaults sets default transport for RTSP/RTMP streams that have an empty
 // transport field. This handles the case where users write the new streams: YAML format
 // directly without specifying per-stream transport; the global RTSPSettings.Transport


### PR DESCRIPTION
## Summary

Following the wiki's legacy RTSP config (`urls:` plus a global `transport:`) produced a config that failed on the first start with an empty `-rtsp_transport` argument, so FFmpeg refused to open the stream. `MigrateRTSPConfig` copied the global transport into each stream and then cleared the global, but the startup path read only the global, so FFmpeg received `-rtsp_transport ""`. The per-stream value the migration wrote was dropped because `audiocore.SourceConfig` had no transport field, and only the quiet-hours restart path read it, so the initial start and the restart disagreed about the transport.

This fixes the transport handling end to end:

- `MigrateRTSPConfig` keeps the global transport instead of clearing it. The startup path reads it as the engine-wide default.
- `audiocore.SourceConfig` and `audiocore.AudioSource` gain a `Transport` field, carried from the per-stream config through the registry into the FFmpeg `StreamConfig`, so the per-stream transport is honored at initial start (previously only the quiet-hours restart read it).
- `buildSourceConfigsWithModels` resolves the transport to a concrete value via a new `RTSPSettings.ResolveTransport` (per-stream else global else default), so change detection compares like with like and a non-tcp global is not masked.
- `sourceNeedsReconfigure` diffs the transport so a per-stream transport edit hot-reloads, and `SyncReconfiguredParams` writes the transport back to the registry so the change does not re-fire on every later reload. The write-back stores the raw pipeline value (empty for non-RTSP stream types) so non-RTSP streams do not enter a restart loop.
- `appendRTSPMediaArgs` falls back to the default transport when empty, so FFmpeg never receives an empty `-rtsp_transport`.
- `serve.go` resolves the engine-wide default the same way.

The wiki docs (guide RTSP example, configuration reference, RTSP troubleshooting) are updated separately since they live outside the repository.

## Testing

- `go test -race` across `internal/conf`, `internal/audiocore`, `internal/audiocore/engine`, `internal/audiocore/ffmpeg`, `internal/analysis` (all pass)
- `golangci-lint run` clean
- New tests: `RTSPSettings.ResolveTransport` truth table; migration preserves the global; empty transport falls back to the default at the FFmpeg arg layer; per-stream transport flows into `SourceConfig` (explicit and global-resolved); transport change triggers reconfigure while an unchanged transport does not; registry write-back syncs transport; a non-RTSP source stays empty through reconfigure (no restart loop)

## Related Issues

Fixes #4240


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-stream RTSP/RTMP transport selection, with stream-specific settings taking precedence over global and default values.
  * Preserved the global transport setting during configuration migration for use as the engine-wide default.

* **Bug Fixes**
  * Prevented empty RTSP transport values from being passed to media processing.
  * Transport changes now correctly trigger stream reconfiguration, while unchanged settings avoid unnecessary restarts.
  * Non-network audio sources remain unaffected by network transport defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->