### PR TITLE
fix(classifier): force f32 for Perch v2 on the OpenVINO GPU device

### DIFF
--- a/doc/wiki/openvino-acceleration.md
+++ b/doc/wiki/openvino-acceleration.md
@@ -24,7 +24,7 @@ OpenVINO is applied per model, only where it is known to be correct and faster. 
 | Model                                         | OpenVINO eligible | GPU precision | Notes                                                                                                                                   |
 | --------------------------------------------- | :---------------: | :-----------: | --------------------------------------------------------------------------------------------------------------------------------------- |
 | BirdNET v2.4 (stock classifier)               |        Yes        |      f32      | The GPU f16 kernel miscompiles this model, so it is forced to f32 on the iGPU (still faster than ORT CPU). f16 on the ARM A76 CPU path. |
-| Perch v2 (`no_dft` variant)                   |        Yes        |      f16      | Runs its own OpenVINO path. The stock `perch_v2.onnx` (with the DFT layer) is **not** OpenVINO-eligible; the `no_dft` variant is.       |
+| Perch v2 (`no_dft` variant)                   |        Yes        |      f32      | Forced to f32 on the GPU: the GPU f16 kernel returns NaN logits on Intel Arc. f16 on the ARM A76 CPU path. The stock `perch_v2.onnx` (with the DFT layer) is **not** OpenVINO-eligible; the `no_dft` variant is. |
 | BattyBirdNET (bat embedding)                  |        Yes        |      f32      | Forced to f32 on every device (its embedding head overflows at f16).                                                                    |
 | INT8 models (e.g. the arm64 INT8-ARM default) |        No         |       -       | INT8 stays on ONNX Runtime CPU.                                                                                                         |
 | Custom / other models                         |        No         |       -       | Fall back to ONNX Runtime.                                                                                                              |
@@ -213,7 +213,7 @@ With Perch v2 or BirdNET v2.4 on the iGPU you will see the **Render/3D** (or **C
 
 ## Performance Expectations
 
-- **amd64 + Intel iGPU:** offloading FP32 models to the iGPU is faster than CPU inference and, more importantly, moves the load off the CPU. On a 12th-gen Core with an Iris Xe iGPU, Perch v2 runs around 45 ms on the iGPU versus about 67 ms on four CPU threads, while leaving those CPU cores free for other streams.
+- **amd64 + Intel iGPU:** offloading FP32 models to the iGPU is faster than CPU inference and, more importantly, moves the load off the CPU. On a 12th-gen Core with an Iris Xe iGPU, Perch v2 ran around 45 ms on the iGPU (measured at f16, before the f32 override; expect somewhat more at f32) versus about 67 ms on four CPU threads, while leaving those CPU cores free for other streams. On an Intel Arc A380, Perch v2 at f32 runs around 19 ms.
 - **Raspberry Pi 5 (A76):** the OpenVINO f16 CPU path can beat ONNX Runtime for FP32 models. Results vary by model.
 - **Raspberry Pi 4 and older ARM (no native f16):** OpenVINO is slower, uses more memory, and loads more slowly than ONNX Runtime. Do not enable it; keep the default `onnx`/INT8-ARM path.
 

--- a/internal/classifier/model_openvino.go
+++ b/internal/classifier/model_openvino.go
@@ -103,9 +103,17 @@ func openVINOPlanFor(backendPref, devicePref, modelID, libraryPath string, outpu
 // (2026-06-18), f16 collapses on realistic low-SNR audio (max confidence error
 // ~0.8, wrong top-1, confidences fall to ~0) while a loud single-species clip
 // survives by luck; f32 is bit-exact with ORT (~6e-6) and still ~4.6x faster than
-// ORT CPU. CPU f16 (incl. ARM A76) and Perch v2 f16-GPU are unaffected, so the
-// BirdNET-v2.4 override is scoped to its GPU path. Do NOT widen it to f16 without
-// re-running the inference/openvino_parity_functional_test.go soundscape parity check.
+// ORT CPU. CPU f16 (incl. ARM A76) is unaffected, so the override is scoped to
+// the GPU path. Do NOT widen it to f16 without re-running the
+// inference/openvino_parity_functional_test.go soundscape parity check.
+//
+// Perch v2 is likewise forced to f32 on the GPU. Its f16-GPU path was validated
+// on an Iris Xe iGPU, but on an Intel Arc A380 (dGPU) the f16 kernel returns
+// all-NaN logits for every window, which the pipeline then promoted to bogus
+// detections. The plan carries only the device class ("GPU"), not the adapter,
+// so the override necessarily covers every Intel GPU; f32 costs some throughput
+// on adapters where f16 worked, but stays well within real time. Do NOT relax it
+// to f16 without validating on a discrete Arc part.
 //
 // The bat embedding model is the exception that is forced to f32 on EVERY device:
 // its embedding head overflows at f16 on genuine f16 hardware (the A76 CPU's f16 NEON
@@ -116,7 +124,7 @@ func openVINOPrecisionFor(modelID, device string) string {
 	if modelID == RegistryIDBat {
 		return inference.OVPrecisionF32
 	}
-	if device == inference.OVDeviceGPU && modelID == DefaultModelVersion {
+	if device == inference.OVDeviceGPU && (modelID == DefaultModelVersion || modelID == RegistryIDPerchV2) {
 		return inference.OVPrecisionF32
 	}
 	return ""
@@ -251,9 +259,9 @@ func openVINOPrecisionLabel(precision string) string {
 // openVINOEffectivePrecision maps an OpenVINO INFERENCE_PRECISION_HINT to the
 // effective runtime precision label shown on the inference status card, using the
 // shared Quantization vocabulary ("FP16"/"FP32"). An empty hint means the backend
-// default, which is f16 (see openVINOPrecisionFor), so it maps to FP16; the only
-// explicit override currently emitted is OVPrecisionF32 (BirdNET v2.4 on the GPU),
-// which maps to FP32.
+// default, which is f16 (see openVINOPrecisionFor), so it maps to FP16; the
+// explicit override OVPrecisionF32 (BirdNET v2.4 and Perch v2 on the GPU, the bat
+// embedding model on every device) maps to FP32.
 func openVINOEffectivePrecision(precisionHint string) string {
 	if precisionHint == inference.OVPrecisionF32 {
 		return string(QuantizationFP32)

--- a/internal/classifier/openvino_precision_test.go
+++ b/internal/classifier/openvino_precision_test.go
@@ -19,20 +19,60 @@ import (
 // hardware dependency and runs in the default test suite.
 func TestOpenVINOPrecisionFor(t *testing.T) {
 	t.Parallel()
-	assert.Equal(t, inference.OVPrecisionF32, openVINOPrecisionFor(DefaultModelVersion, inference.OVDeviceGPU),
-		"BirdNET v2.4 on the GPU must be forced to f32")
-	assert.Empty(t, openVINOPrecisionFor(DefaultModelVersion, inference.OVDeviceCPU),
-		"BirdNET v2.4 on CPU keeps the f16 default")
-	assert.Equal(t, inference.OVPrecisionF32, openVINOPrecisionFor(RegistryIDPerchV2, inference.OVDeviceGPU),
-		"Perch on the GPU must be forced to f32 (f16 returns all-NaN logits on Intel Arc A380)")
-	assert.Empty(t, openVINOPrecisionFor(RegistryIDPerchV2, inference.OVDeviceCPU),
-		"Perch on CPU keeps the f16 default")
-	// The bat embedding model overflows at f16 on every device, so it must be forced
-	// to f32 on BOTH GPU and CPU (unlike BirdNET v2.4, which is f32 on GPU only).
-	assert.Equal(t, inference.OVPrecisionF32, openVINOPrecisionFor(RegistryIDBat, inference.OVDeviceGPU),
-		"bat embedding model on the GPU must be forced to f32")
-	assert.Equal(t, inference.OVPrecisionF32, openVINOPrecisionFor(RegistryIDBat, inference.OVDeviceCPU),
-		"bat embedding model on CPU must be forced to f32 (f16 overflows the embedding head)")
+
+	tests := []struct {
+		name    string
+		modelID string
+		device  string
+		want    string
+	}{
+		{
+			name:    "birdnet v2.4 on GPU is forced to f32",
+			modelID: DefaultModelVersion,
+			device:  inference.OVDeviceGPU,
+			want:    inference.OVPrecisionF32,
+		},
+		{
+			name:    "birdnet v2.4 on CPU keeps the f16 default",
+			modelID: DefaultModelVersion,
+			device:  inference.OVDeviceCPU,
+			want:    "",
+		},
+		{
+			name:    "perch v2 on GPU is forced to f32 (f16 returns all-NaN logits on Intel Arc A380)",
+			modelID: RegistryIDPerchV2,
+			device:  inference.OVDeviceGPU,
+			want:    inference.OVPrecisionF32,
+		},
+		{
+			name:    "perch v2 on CPU keeps the f16 default",
+			modelID: RegistryIDPerchV2,
+			device:  inference.OVDeviceCPU,
+			want:    "",
+		},
+		// The bat embedding model overflows at f16 on every device, so it must be
+		// forced to f32 on BOTH GPU and CPU (unlike BirdNET v2.4, which is f32 on
+		// GPU only).
+		{
+			name:    "bat on GPU is forced to f32",
+			modelID: RegistryIDBat,
+			device:  inference.OVDeviceGPU,
+			want:    inference.OVPrecisionF32,
+		},
+		{
+			name:    "bat on CPU is forced to f32 (f16 overflows the embedding head)",
+			modelID: RegistryIDBat,
+			device:  inference.OVDeviceCPU,
+			want:    inference.OVPrecisionF32,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, openVINOPrecisionFor(tt.modelID, tt.device))
+		})
+	}
 }
 
 // TestOpenVINOEffectivePrecision verifies the mapping from an OpenVINO

--- a/internal/classifier/openvino_precision_test.go
+++ b/internal/classifier/openvino_precision_test.go
@@ -8,8 +8,9 @@ import (
 )
 
 // TestOpenVINOPrecisionFor verifies the per-(model, device) precision policy:
-// BirdNET v2.4 is forced to f32 on the GPU (its GPU f16 kernel miscompiles this
-// model; validated on Iris Xe), while CPU and Perch keep the f16 default.
+// BirdNET v2.4 and Perch v2 are forced to f32 on the GPU (the GPU f16 kernel
+// miscompiles BirdNET v2.4 on Iris Xe and returns all-NaN Perch logits on an Arc
+// A380), while the CPU paths keep the f16 default.
 //
 // This is intentionally NOT behind the openvino build tag: openVINOPrecisionFor
 // lives in a tag-agnostic file and compiles into every build, but CI never builds
@@ -22,8 +23,8 @@ func TestOpenVINOPrecisionFor(t *testing.T) {
 		"BirdNET v2.4 on the GPU must be forced to f32")
 	assert.Empty(t, openVINOPrecisionFor(DefaultModelVersion, inference.OVDeviceCPU),
 		"BirdNET v2.4 on CPU keeps the f16 default")
-	assert.Empty(t, openVINOPrecisionFor(RegistryIDPerchV2, inference.OVDeviceGPU),
-		"Perch on the GPU keeps f16 (validated parity with f32)")
+	assert.Equal(t, inference.OVPrecisionF32, openVINOPrecisionFor(RegistryIDPerchV2, inference.OVDeviceGPU),
+		"Perch on the GPU must be forced to f32 (f16 returns all-NaN logits on Intel Arc A380)")
 	assert.Empty(t, openVINOPrecisionFor(RegistryIDPerchV2, inference.OVDeviceCPU),
 		"Perch on CPU keeps the f16 default")
 	// The bat embedding model overflows at f16 on every device, so it must be forced
@@ -36,13 +37,14 @@ func TestOpenVINOPrecisionFor(t *testing.T) {
 
 // TestOpenVINOEffectivePrecision verifies the mapping from an OpenVINO
 // INFERENCE_PRECISION_HINT to the display precision shown on the inference status
-// card. The empty default hint (f16) maps to FP16, and the only explicit override
-// emitted (OVPrecisionF32, the BirdNET v2.4 GPU path) maps to FP32. Tag-agnostic
+// card. The empty default hint (f16) maps to FP16, and the explicit override
+// (OVPrecisionF32: BirdNET v2.4 and Perch v2 on the GPU, bat everywhere) maps to
+// FP32. Tag-agnostic
 // like openVINOEffectivePrecision itself, so it runs in the default suite.
 func TestOpenVINOEffectivePrecision(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, string(QuantizationFP16), openVINOEffectivePrecision(""),
 		"empty hint is the backend f16 default, shown as FP16")
 	assert.Equal(t, string(QuantizationFP32), openVINOEffectivePrecision(inference.OVPrecisionF32),
-		"the f32 hint (BirdNET v2.4 GPU) is shown as FP32")
+		"the f32 hint (BirdNET v2.4 and Perch v2 on the GPU) is shown as FP32")
 }

--- a/internal/classifier/perch_onnx.go
+++ b/internal/classifier/perch_onnx.go
@@ -39,10 +39,11 @@ type Perch struct {
 	// Runtime CPU EP. Set once at construction; reported via RuntimeInfo().
 	device string
 	// backend is the live execution backend (BackendOpenVINO on the OV path, else
-	// BackendONNX), and precision is the effective runtime precision (FP16 on the
-	// OV path; the weight precision detected from the model filename on the ORT
-	// path, e.g. INT8 for perch_v2_int8_arm.onnx). Both set once at construction;
-	// reported via RuntimeInfo().
+	// BackendONNX), and precision is the effective runtime precision (on the OV
+	// path the compiled INFERENCE_PRECISION_HINT per openVINOPrecisionFor: FP32 on
+	// the GPU, FP16 on the CPU; on the ORT path the weight precision detected from
+	// the model filename, e.g. INT8 for perch_v2_int8_arm.onnx). Both set once at
+	// construction; reported via RuntimeInfo().
 	backend   string
 	precision string
 	// modelPath is the model file this instance actually loaded from (the resolved
@@ -99,12 +100,12 @@ func NewPerch(cfg *PerchConfig) (*Perch, error) {
 	// load, so tryPerchOpenVINO logs and swallows OV errors and returns ok=false.
 	// device records the compute device actually bound to (the OpenVINO device on
 	// the OV path, else the ONNX Runtime CPU EP).
-	classifier, device, ok := tryPerchOpenVINO(cfg, labels)
-	// Perch always compiles OpenVINO at the f16 default (openVINOPrecisionFor
-	// returns "" for Perch, never f32), so the effective OV runtime precision is
-	// FP16. The ORT path overrides both below.
+	classifier, device, precisionHint, ok := tryPerchOpenVINO(cfg, labels)
+	// On the OV path the effective runtime precision follows the compiled
+	// INFERENCE_PRECISION_HINT (f32 on the GPU per openVINOPrecisionFor, else the
+	// f16 default). The ORT path overrides both below.
 	backend := BackendOpenVINO
-	precision := string(QuantizationFP16)
+	precision := openVINOEffectivePrecision(precisionHint)
 	if !ok {
 		// Initialize ONNX Runtime
 		if err := inference.InitONNXRuntime(cfg.ONNXRuntimePath); err != nil {
@@ -159,22 +160,24 @@ func NewPerch(cfg *PerchConfig) (*Perch, error) {
 }
 
 // tryPerchOpenVINO attempts to build an OpenVINO classifier for Perch v2. It
-// returns (classifier, device, true) on success or (nil, "", false) to fall back
-// to ORT, where device is the concrete OpenVINO device the classifier bound to
-// (inference.OVDeviceCPU/OVDeviceGPU). Any failure (ineligible model, gate
+// returns (classifier, device, precisionHint, true) on success or
+// (nil, "", "", false) to fall back to ORT, where device is the concrete OpenVINO
+// device the classifier bound to (inference.OVDeviceCPU/OVDeviceGPU) and
+// precisionHint is the INFERENCE_PRECISION_HINT the model was compiled with
+// ("" = backend f16 default). Any failure (ineligible model, gate
 // denied, init/compile/validation error) is logged and swallowed: OpenVINO must
 // never make Perch fail to load. OV is only attempted for the no_dft model
 // variant, since the stock perch_v2.onnx cannot compile on OpenVINO (a
 // dynamic-rank DFT op).
-func tryPerchOpenVINO(cfg *PerchConfig, labels []string) (inference.Classifier, string, bool) {
+func tryPerchOpenVINO(cfg *PerchConfig, labels []string) (classifier inference.Classifier, device, precisionHint string, ok bool) {
 	if !isPerchNoDFT(cfg.ModelPath) {
 		logOpenVINODeclined(RegistryIDPerchV2, cfg.Backend, ovReasonNotPerchNoDFT)
-		return nil, "", false
+		return nil, "", "", false
 	}
 	plan, ok, reason := openVINOPlanFor(cfg.Backend, cfg.OpenVINODevice, RegistryIDPerchV2, cfg.OpenVINOPath, perchLogitsOutputIndex)
 	if !ok {
 		logOpenVINODeclined(RegistryIDPerchV2, cfg.Backend, reason)
-		return nil, "", false
+		return nil, "", "", false
 	}
 
 	log := GetLogger()
@@ -183,7 +186,7 @@ func tryPerchOpenVINO(cfg *PerchConfig, labels []string) (inference.Classifier, 
 	// here to cover it. A load failure means no usable OpenVINO; fall back to ORT.
 	if err := inference.InitOpenVINO(cfg.OpenVINOPath); err != nil {
 		log.Warn("Perch OpenVINO init failed; using ONNX Runtime", logger.Error(err))
-		return nil, "", false
+		return nil, "", "", false
 	}
 
 	start := time.Now()
@@ -192,13 +195,13 @@ func tryPerchOpenVINO(cfg *PerchConfig, labels []string) (inference.Classifier, 
 		Threads:       cfg.Threads,
 		Device:        plan.device,
 		OutputIndex:   plan.outputIndex,
-		PrecisionHint: plan.precision, // "" => f16 default; Perch f16-GPU validated OK
+		PrecisionHint: plan.precision, // f32 on the GPU (f16 returns NaN on Intel Arc), else the f16 default
 	})
 	if err != nil {
 		log.Warn("Perch OpenVINO classifier init failed; using ONNX Runtime",
 			logger.String("device", plan.device),
 			logger.Error(err))
-		return nil, "", false
+		return nil, "", "", false
 	}
 
 	log.Info("Perch v2 model using OpenVINO backend",
@@ -206,7 +209,7 @@ func tryPerchOpenVINO(cfg *PerchConfig, labels []string) (inference.Classifier, 
 		logger.String("precision", openVINOPrecisionLabel(plan.precision)),
 		logger.Int("species", classifier.NumSpecies()),
 		logger.String("init_time", time.Since(start).String()))
-	return classifier, plan.device, true
+	return classifier, plan.device, plan.precision, true
 }
 
 // isPerchNoDFT reports whether the model file is the OpenVINO-compatible Perch
@@ -298,10 +301,11 @@ func (p *Perch) Labels() []string {
 
 // RuntimeInfo returns the device, backend, and effective precision the Perch
 // classifier bound to at construction: the OpenVINO device on the OV path (else
-// "CPU"); BackendOpenVINO on the OV path (else BackendONNX); FP16 on the OV path
-// or the weight precision detected from the model filename on the ORT path (e.g.
-// INT8 for perch_v2_int8_arm.onnx, empty when no token). All three are set once
-// and never mutated, so no lock is needed. Implements ModelInstance.
+// "CPU"); BackendOpenVINO on the OV path (else BackendONNX); the compiled
+// OpenVINO precision on the OV path (FP32 on the GPU, FP16 on the CPU) or the
+// weight precision detected from the model filename on the ORT path (e.g. INT8
+// for perch_v2_int8_arm.onnx, empty when no token). All three are set once and
+// never mutated, so no lock is needed. Implements ModelInstance.
 func (p *Perch) RuntimeInfo() (device, backend, precision string) {
 	return p.device, p.backend, p.precision
 }

--- a/internal/classifier/perch_openvino_functional_test.go
+++ b/internal/classifier/perch_openvino_functional_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/inference"
@@ -51,9 +52,13 @@ func TestPerchOpenVINO_Functional(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = inference.DestroyOpenVINO() })
 
-	c, _, ok := tryPerchOpenVINO(&cfg, labels)
+	c, boundDevice, precisionHint, ok := tryPerchOpenVINO(&cfg, labels)
 	require.True(t, ok, "Perch OpenVINO classifier must be created for the no_dft model")
 	require.NotNil(t, c)
+	if boundDevice == inference.OVDeviceGPU {
+		assert.Equal(t, inference.OVPrecisionF32, precisionHint,
+			"Perch on the GPU must compile at f32 (f16 returns NaN logits on Intel Arc)")
+	}
 	t.Cleanup(func() { c.Close() })
 
 	// #1112: NumSpecies must reflect the real model output dimension (== label

--- a/internal/classifier/perch_openvino_test.go
+++ b/internal/classifier/perch_openvino_test.go
@@ -35,7 +35,7 @@ func TestIsPerchNoDFT(t *testing.T) {
 // this is deterministic everywhere (no libopenvino_c required).
 func TestTryPerchOpenVINO_StockModelFallsBack(t *testing.T) {
 	t.Parallel()
-	c, device, ok := tryPerchOpenVINO(&PerchConfig{
+	c, device, precisionHint, ok := tryPerchOpenVINO(&PerchConfig{
 		ModelPath:      "/models/perch_v2.onnx",
 		Backend:        conf.BackendPrefOpenVINO,
 		OpenVINODevice: conf.OVDeviceAuto,
@@ -43,4 +43,5 @@ func TestTryPerchOpenVINO_StockModelFallsBack(t *testing.T) {
 	assert.False(t, ok, "stock perch_v2 must not use OpenVINO")
 	assert.Nil(t, c)
 	assert.Empty(t, device, "fallback path must not report an OpenVINO device")
+	assert.Empty(t, precisionHint, "fallback path must not report an OpenVINO precision hint")
 }

--- a/internal/inference/openvino_parity_functional_test.go
+++ b/internal/inference/openvino_parity_functional_test.go
@@ -155,7 +155,8 @@ func medianPredict(t *testing.T, c Classifier, samples []float32, n int) time.Du
 // env: OV_TEST_DIVERGE_AUDIO (raw f32 input), OV_TEST_DIVERGE_OUTPUT_INDEX,
 // OV_TEST_DEVICE (default "gpu"), OV_TEST_LIB, OV_TEST_DIVERGE_MAX_CONF_ERR
 // (default 0.15: cross-precision drift is inherently larger than ORT-vs-f32, e.g.
-// Perch v2 f16-GPU is ~0.08 while a broken model like BirdNET v2.4 f16-GPU is
+// Perch v2 f16 on an Iris Xe GPU is ~0.08 (NaN on an Arc A380, hence its f32
+// override) while a broken model like BirdNET v2.4 f16-GPU is
 // ~0.8; the top-1 match assertion is the primary catch for a catastrophic
 // divergence). The divergence knob is named distinctly from the parity test's
 // OV_TEST_MAX_CONF_ERR so the two tolerances cannot be conflated.


### PR DESCRIPTION
## Description

Perch v2 compiled at the OpenVINO f16 default returns **all-NaN logits on an Intel Arc A380** (dGPU `8086:56a5`, OpenVINO 2026.2). Every NaN score then passes the `confidence <= threshold` filter, so each 5 s window emits detections for the first few labels of the label set and writes a clip named with a `NaNp` confidence token that the disk manager can never parse or delete. On the reporting host this filled a 32 GB volume in about 11 hours.

The Perch f16-GPU path was only ever validated on an Iris Xe iGPU. BirdNET v2.4 is already forced to f32 on the GPU for a similar f16 miscompile (#3551), so this extends the same guard to Perch in `openVINOPrecisionFor`.

Verified on the Arc A380 with the `north-america-east` `no_dft` fp32 regional model:

| Backend / precision | Result |
|---|---|
| OpenVINO GPU f16 (before) | every logit NaN, 0 real detections, 4 bogus `NaNp` clips per window |
| OpenVINO CPU (f32 internally on this Xeon) | correct detections |
| ONNX Runtime CPU (same file, x86) | correct on silence, DC, clipping, real clips |
| **OpenVINO GPU f32 (this PR)** | correct detections, ~19 ms per inference |

Also:
- Perch's reported runtime precision is now derived from the compiled `INFERENCE_PRECISION_HINT` via `openVINOEffectivePrecision` instead of a hard-coded FP16, so the inference status card shows FP32 on the GPU.
- Precision policy comments, the OpenVINO wiki table, and the hardware-gated Perch functional test updated to match.

**Behavioral note for the maintainer:** the plan carries only the device class (`GPU`), so the override also applies to iGPUs where f16 worked (Iris Xe, ~45 ms at f16 per the wiki). There is no config knob for the precision hint. Correctness was preferred over the f16 throughput there; scoping to discrete Arc parts would need adapter-name probing that does not exist today. Issue #4206 reports the same class of failure (wrong species from the regional `no_dft` model) on a Raspberry Pi 5, which is the OpenVINO **CPU** f16 path; this PR deliberately does not change the CPU path, since I could not validate ARM, but it is very likely the same root cause.

## Related issue

Related: #4206 (Perch `no_dft` on OpenVINO f16, Pi 5 CPU path). Companion PRs: #4252 (non-finite score guard in the classifiers), #4253 (non-finite confidence filter in the processor), #4254 (disk manager tolerance for `NaNp` clip names).

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/tphakala/birdnet-go/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`go test -race ./...` and/or `npm test`)
- [x] Linters are clean (`golangci-lint run` and/or `npm run check:all`)
- [x] New exports and user-facing changes are documented

## Preflight Status

- [x] Single concern: PR contains exactly ONE fix
- [x] Preflight passed: all Phase 1-3 findings resolved (stale precision docs/comments/wiki updated; functional test asserts the f32 hint on GPU)
- [x] Linters clean: `golangci-lint run` on the changed packages and the whole tree, zero issues
- [x] Tests pass: `go test -race` on `internal/classifier` and the whole tree
- [x] No unrelated changes
- [x] Scope complete; no TODO/FIXME
- [x] No regression/backward-compat break: no config keys, API fields, or migrations touched. Behavioral change: Perch on any Intel GPU now runs f32 (see note above); the status card's `quantization` value for Perch on GPU changes FP16 → FP32 (reporting only).
- [x] Breaking changes documented: wiki table and perf note updated
- [ ] Maintainer-confirm item: scope of the f32 override (all Intel GPUs vs. Arc only) — see note above
- [x] i18n complete: no user-facing strings added
- [x] No secrets or PII
- Secondary-model cross-validation: **not run** (no second model available in the review environment); all review passes were single-model.

## Licensing

- [x] My contribution is licensed under **CC BY-NC-SA 4.0**, and I grant the maintainer the right to relicense it under any **OSI-approved open source license**, as described in the [Relicensing Grant](https://github.com/tphakala/birdnet-go/blob/main/CONTRIBUTING.md#relicensing-grant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBXUYwsiTWinmcQbW8Noo7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed NaN inference results for Perch v2 when running on Intel Arc GPUs by using 32-bit precision.
  * Runtime precision reporting now reflects the precision actually used by the accelerator.

* **Documentation**
  * Updated OpenVINO performance guidance with revised Iris Xe details and Intel Arc A380 timing information.

* **Tests**
  * Added coverage confirming GPU precision selection and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->