### PR TITLE
fix(classifier): reject non-finite scores from every model before they become detections

### DIFF
--- a/internal/classifier/analyze.go
+++ b/internal/classifier/analyze.go
@@ -87,8 +87,8 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 		m.RecordModelInvoke(modelID, invokeDuration.Seconds())
 	}
 
-	if idx := firstNonFinite(predictions); idx >= 0 {
-		err = newNonFiniteScoreError(modelID, idx, len(predictions), bn.RuntimeInfo)
+	if idx := firstNonFinite(predictions); idx != noNonFiniteScore {
+		err = newNonFiniteScoreError(nonFiniteScore{modelID: modelID, index: idx, count: len(predictions)}, bn.RuntimeInfo)
 		recordPredictionFailure(span, modelID, errTypeNonFiniteLogits, start, err)
 		return nil, err
 	}
@@ -136,15 +136,25 @@ func sortResults(results []datastore.Results) {
 	})
 }
 
+// noNonFiniteScore is the index firstNonFinite returns when every score is finite.
+const noNonFiniteScore = -1
+
 // firstNonFinite returns the index of the first NaN or infinite value in
-// scores, or -1 when every value is finite.
+// scores, or noNonFiniteScore when every value is finite.
 func firstNonFinite(scores []float32) int {
 	for i, v := range scores {
 		if f := float64(v); math.IsNaN(f) || math.IsInf(f, 0) {
 			return i
 		}
 	}
-	return -1
+	return noNonFiniteScore
+}
+
+// nonFiniteScore locates the offending value for newNonFiniteScoreError.
+type nonFiniteScore struct {
+	modelID string // registry ID of the classifier that produced the score
+	index   int    // position of the first non-finite value in the backend output
+	count   int    // number of scores the backend returned
 }
 
 // newNonFiniteScoreError builds the error every ModelInstance.Predict returns
@@ -154,11 +164,11 @@ func firstNonFinite(scores []float32) int {
 // the model's RuntimeInfo method, so the error names the backend, device and
 // precision that produced the value (the OpenVINO f16 GPU path is the known
 // offender).
-func newNonFiniteScoreError(modelID string, idx, n int, runtimeInfo func() (device, backend, precision string)) error {
+func newNonFiniteScoreError(score nonFiniteScore, runtimeInfo func() (device, backend, precision string)) error {
 	device, backend, precision := runtimeInfo()
-	return errors.Newf("%s classifier returned a non-finite score (index %d of %d)", modelID, idx, n).
+	return errors.Newf("%s classifier returned a non-finite score (index %d of %d)", score.modelID, score.index, score.count).
 		Category(errors.CategoryAudioAnalysis).
-		Context("model", modelID).
+		Context("model", score.modelID).
 		Context("backend", backend).
 		Context("device", device).
 		Context("precision", precision).

--- a/internal/classifier/analyze.go
+++ b/internal/classifier/analyze.go
@@ -87,6 +87,12 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 		m.RecordModelInvoke(modelID, invokeDuration.Seconds())
 	}
 
+	if idx := firstNonFinite(predictions); idx >= 0 {
+		err = newNonFiniteScoreError(modelID, idx, len(predictions), bn.RuntimeInfo)
+		recordPredictionFailure(span, modelID, errTypeNonFiniteLogits, start, err)
+		return nil, err
+	}
+
 	// Use optimized sigmoid function with buffer reuse
 	confidence := applySigmoidToPredictionsReuse(predictions, settings.BirdNET.Sensitivity, bn.confidenceBuffer)
 
@@ -128,6 +134,35 @@ func sortResults(results []datastore.Results) {
 	sort.Slice(results, func(i, j int) bool {
 		return results[i].Confidence > results[j].Confidence
 	})
+}
+
+// firstNonFinite returns the index of the first NaN or infinite value in
+// scores, or -1 when every value is finite.
+func firstNonFinite(scores []float32) int {
+	for i, v := range scores {
+		if f := float64(v); math.IsNaN(f) || math.IsInf(f, 0) {
+			return i
+		}
+	}
+	return -1
+}
+
+// newNonFiniteScoreError builds the error every ModelInstance.Predict returns
+// when its backend produced a NaN or Inf score. A non-finite score is a backend
+// fault, not a prediction: it compares false against every threshold, so left
+// alone it is promoted to a detection instead of being dropped. runtimeInfo is
+// the model's RuntimeInfo method, so the error names the backend, device and
+// precision that produced the value (the OpenVINO f16 GPU path is the known
+// offender).
+func newNonFiniteScoreError(modelID string, idx, n int, runtimeInfo func() (device, backend, precision string)) error {
+	device, backend, precision := runtimeInfo()
+	return errors.Newf("%s classifier returned a non-finite score (index %d of %d)", modelID, idx, n).
+		Category(errors.CategoryAudioAnalysis).
+		Context("model", modelID).
+		Context("backend", backend).
+		Context("device", device).
+		Context("precision", precision).
+		Build()
 }
 
 // pairLabelsAndConfidence pairs labels with their corresponding confidence values.

--- a/internal/classifier/analyze_test.go
+++ b/internal/classifier/analyze_test.go
@@ -851,3 +851,26 @@ func generateLargeTestResults(count int) []datastore.Results {
 	}
 	return results
 }
+
+// TestFirstNonFinite pins the scanner every ModelInstance.Predict uses to reject
+// a backend that produced NaN or Inf scores.
+func TestFirstNonFinite(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		scores []float32
+		want   int
+	}{
+		{name: "empty", scores: nil, want: -1},
+		{name: "all finite", scores: []float32{0.2, 0.1, 0.0, -3.5}, want: -1},
+		{name: "NaN", scores: []float32{0.2, float32(math.NaN()), 0.1}, want: 1},
+		{name: "+Inf first", scores: []float32{float32(math.Inf(1)), 0.2}, want: 0},
+		{name: "-Inf last", scores: []float32{0.2, 0.1, float32(math.Inf(-1))}, want: 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, firstNonFinite(tt.scores))
+		})
+	}
+}

--- a/internal/classifier/analyze_test.go
+++ b/internal/classifier/analyze_test.go
@@ -861,8 +861,8 @@ func TestFirstNonFinite(t *testing.T) {
 		scores []float32
 		want   int
 	}{
-		{name: "empty", scores: nil, want: -1},
-		{name: "all finite", scores: []float32{0.2, 0.1, 0.0, -3.5}, want: -1},
+		{name: "empty", scores: nil, want: noNonFiniteScore},
+		{name: "all finite", scores: []float32{0.2, 0.1, 0.0, -3.5}, want: noNonFiniteScore},
 		{name: "NaN", scores: []float32{0.2, float32(math.NaN()), 0.1}, want: 1},
 		{name: "+Inf first", scores: []float32{float32(math.Inf(1)), 0.2}, want: 0},
 		{name: "-Inf last", scores: []float32{0.2, 0.1, float32(math.Inf(-1))}, want: 2},

--- a/internal/classifier/bat_onnx.go
+++ b/internal/classifier/bat_onnx.go
@@ -304,6 +304,12 @@ func (b *Bat) Predict(ctx context.Context, samples [][]float32) ([]datastore.Res
 		logger.Int("score_count", len(scores)),
 		logger.Duration("duration", classDuration))
 
+	if idx := firstNonFinite(scores); idx >= 0 {
+		err = newNonFiniteScoreError(RegistryIDBat, idx, len(scores), b.RuntimeInfo)
+		recordPredictionFailure(span, RegistryIDBat, errTypeNonFiniteLogits, start, err)
+		return nil, err
+	}
+
 	results, err := pairLabelsAndConfidence(b.batClassifier.Labels(), scores)
 	if err != nil {
 		recordPredictionFailure(span, RegistryIDBat, errTypeLabelMismatch, start, err)

--- a/internal/classifier/bat_onnx.go
+++ b/internal/classifier/bat_onnx.go
@@ -304,8 +304,8 @@ func (b *Bat) Predict(ctx context.Context, samples [][]float32) ([]datastore.Res
 		logger.Int("score_count", len(scores)),
 		logger.Duration("duration", classDuration))
 
-	if idx := firstNonFinite(scores); idx >= 0 {
-		err = newNonFiniteScoreError(RegistryIDBat, idx, len(scores), b.RuntimeInfo)
+	if idx := firstNonFinite(scores); idx != noNonFiniteScore {
+		err = newNonFiniteScoreError(nonFiniteScore{modelID: RegistryIDBat, index: idx, count: len(scores)}, b.RuntimeInfo)
 		recordPredictionFailure(span, RegistryIDBat, errTypeNonFiniteLogits, start, err)
 		return nil, err
 	}

--- a/internal/classifier/birdnet_v3_onnx.go
+++ b/internal/classifier/birdnet_v3_onnx.go
@@ -262,8 +262,8 @@ func (b *BirdNETV3) Predict(ctx context.Context, samples [][]float32) ([]datasto
 	// The in-graph sigmoid bounds every finite score to [0,1]; a NaN or Inf here
 	// is a backend fault (see newNonFiniteScoreError) and must not become a
 	// detection.
-	if idx := firstNonFinite(scores); idx >= 0 {
-		err = newNonFiniteScoreError(RegistryIDBirdNETV3, idx, len(scores), b.RuntimeInfo)
+	if idx := firstNonFinite(scores); idx != noNonFiniteScore {
+		err = newNonFiniteScoreError(nonFiniteScore{modelID: RegistryIDBirdNETV3, index: idx, count: len(scores)}, b.RuntimeInfo)
 		recordPredictionFailure(span, RegistryIDBirdNETV3, errTypeNonFiniteLogits, start, err)
 		return nil, err
 	}

--- a/internal/classifier/birdnet_v3_onnx.go
+++ b/internal/classifier/birdnet_v3_onnx.go
@@ -259,6 +259,15 @@ func (b *BirdNETV3) Predict(ctx context.Context, samples [][]float32) ([]datasto
 		return nil, err
 	}
 
+	// The in-graph sigmoid bounds every finite score to [0,1]; a NaN or Inf here
+	// is a backend fault (see newNonFiniteScoreError) and must not become a
+	// detection.
+	if idx := firstNonFinite(scores); idx >= 0 {
+		err = newNonFiniteScoreError(RegistryIDBirdNETV3, idx, len(scores), b.RuntimeInfo)
+		recordPredictionFailure(span, RegistryIDBirdNETV3, errTypeNonFiniteLogits, start, err)
+		return nil, err
+	}
+
 	// Pair labels with predictions
 	results, err := pairLabelsAndConfidence(b.labels, scores)
 	if err != nil {

--- a/internal/classifier/birdnet_v3_onnx_test.go
+++ b/internal/classifier/birdnet_v3_onnx_test.go
@@ -203,3 +203,26 @@ func TestBirdNETV3_Close(t *testing.T) {
 	_, err := b.Predict(t.Context(), [][]float32{{0.1}})
 	require.Error(t, err, "Predict after Close must fail via the nil-classifier guard")
 }
+
+// TestBirdNETV3Predict_RejectsNonFiniteScores verifies that a backend returning a
+// NaN or Inf score fails the window instead of handing a non-finite confidence to
+// the processor, where it would bypass the threshold filter. BirdNET v3.0 runs
+// the OpenVINO f16 GPU path that produced all-NaN Perch logits on Intel Arc, so
+// it needs the same guard.
+func TestBirdNETV3Predict_RejectsNonFiniteScores(t *testing.T) {
+	t.Parallel()
+	labels := []string{"Aaa aaa_Alpha", "Bbb bbb_Beta", "Ccc ccc_Gamma"}
+	for name, scores := range map[string][]float32{
+		"NaN":  {0.9, float32(math.NaN()), 0.1},
+		"+Inf": {float32(math.Inf(1)), 0.2, 0.1},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			b := newTestBirdNETV3(&predTelemetryClassifier{logits: scores}, labels)
+			results, err := b.Predict(t.Context(), [][]float32{{0.1, 0.2, 0.3}})
+			require.Error(t, err)
+			assert.Nil(t, results)
+			assert.Contains(t, err.Error(), "non-finite score")
+		})
+	}
+}

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -625,6 +625,31 @@ func (o *Orchestrator) resolveInstalledPaths(registryID string) (modelPath, labe
 
 // Predict runs inference using the primary model.
 // Delegates to PredictModel for uniform locking and telemetry.
+// inferenceFailureLogEvery is the interval, in consecutive failures of one
+// model, at which PredictModel repeats its ERROR log after the first failure.
+const inferenceFailureLogEvery = 100
+
+// inferenceFailureStreaks tracks consecutive PredictModel failures per model ID
+// (value: *atomic.Int64) for the log rate limiting in PredictModel.
+//
+//nolint:gochecknoglobals // log-flood guard shared with globalInferenceCounters
+var inferenceFailureStreaks sync.Map
+
+// inferenceFailureStreak increments and returns the consecutive failure count
+// for modelID.
+func (o *Orchestrator) inferenceFailureStreak(modelID string) int64 {
+	v, _ := inferenceFailureStreaks.LoadOrStore(modelID, new(atomic.Int64))
+	return v.(*atomic.Int64).Add(1) //nolint:errcheck // stored type is fixed above
+}
+
+// resetInferenceFailureStreak clears the consecutive failure count for modelID
+// after a successful inference so the next fault is logged at ERROR again.
+func (o *Orchestrator) resetInferenceFailureStreak(modelID string) {
+	if v, ok := inferenceFailureStreaks.Load(modelID); ok {
+		v.(*atomic.Int64).Store(0) //nolint:errcheck // stored type is fixed above
+	}
+}
+
 func (o *Orchestrator) Predict(ctx context.Context, sample [][]float32) ([]datastore.Results, error) {
 	o.mu.RLock()
 	id := o.ModelInfo.ID
@@ -683,11 +708,22 @@ func (o *Orchestrator) PredictModel(ctx context.Context, modelID string, sample 
 
 	if err != nil {
 		globalInferenceCounters.RecordError(modelID)
-		log.Error("PredictModel inference failed",
+		// A broken backend fails every window (one per few seconds per source), so
+		// after the first failure only every inferenceFailureLogEvery-th repeat is
+		// logged at ERROR; the rest go to DEBUG. The metrics counter above still
+		// records each one.
+		streak := o.inferenceFailureStreak(modelID)
+		emit := log.Debug
+		if streak == 1 || streak%inferenceFailureLogEvery == 0 {
+			emit = log.Error
+		}
+		emit("PredictModel inference failed",
 			logger.String("model_id", modelID),
 			logger.Error(err),
+			logger.Int64("consecutive_failures", streak),
 			logger.Duration("duration", duration))
 	} else {
+		o.resetInferenceFailureStreak(modelID)
 		globalInferenceCounters.RecordInvoke(modelID, duration.Microseconds())
 		log.Debug("PredictModel complete",
 			logger.String("model_id", modelID),

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -650,6 +650,20 @@ func (o *Orchestrator) resetInferenceFailureStreak(modelID string) {
 	}
 }
 
+// dropInferenceFailureStreak removes modelID's streak entry when its instance is
+// torn down or replaced, so a later instance under the same ID starts fresh (its
+// first failure is logged at ERROR) and stale IDs do not accumulate across reloads.
+func dropInferenceFailureStreak(modelID string) {
+	inferenceFailureStreaks.Delete(modelID)
+}
+
+// inferenceFailureLogsAtError reports whether the streak-th consecutive failure
+// of one model is logged at ERROR (the first, then every
+// inferenceFailureLogEvery-th) rather than DEBUG.
+func inferenceFailureLogsAtError(streak int64) bool {
+	return streak == 1 || streak%inferenceFailureLogEvery == 0
+}
+
 func (o *Orchestrator) Predict(ctx context.Context, sample [][]float32) ([]datastore.Results, error) {
 	o.mu.RLock()
 	id := o.ModelInfo.ID
@@ -714,7 +728,7 @@ func (o *Orchestrator) PredictModel(ctx context.Context, modelID string, sample 
 		// records each one.
 		streak := o.inferenceFailureStreak(modelID)
 		emit := log.Debug
-		if streak == 1 || streak%inferenceFailureLogEvery == 0 {
+		if inferenceFailureLogsAtError(streak) {
 			emit = log.Error
 		}
 		emit("PredictModel inference failed",
@@ -1476,6 +1490,10 @@ func (o *Orchestrator) reloadPrimaryModel(reload func(primary *BirdNET) error) e
 	}
 
 	info, taxMap, taxPath, sciIndex := o.primary.ReloadSnapshot()
+	// The reloaded primary is a fresh instance: drop its streak, and the previous
+	// ID's when the reload changed it, so neither lingers.
+	dropInferenceFailureStreak(o.ModelInfo.ID)
+	dropInferenceFailureStreak(info.ID)
 	o.ModelInfo = info
 	o.TaxonomyMap = taxMap
 	o.TaxonomyPath = taxPath
@@ -1698,6 +1716,7 @@ func (o *Orchestrator) ReloadSecondaryModels() error {
 		}
 		ref.entry.instance = newInst
 		ref.entry.backend = triplet
+		dropInferenceFailureStreak(ref.id) // fresh instance, fresh streak
 		ref.entry.mu.Unlock()
 
 		// Close the old instance after releasing entry.mu: native teardown can be
@@ -1760,6 +1779,7 @@ func (o *Orchestrator) Delete() {
 		// re-creating the entry after deletion, and stops a teardown-then-recreate
 		// cycle from leaking counter entries.
 		globalInferenceCounters.Delete(id)
+		dropInferenceFailureStreak(id)
 		entry.mu.Unlock()
 	}
 
@@ -2017,6 +2037,7 @@ func (o *Orchestrator) UnloadModel(registryID string) error {
 	defer entry.mu.Unlock()
 
 	globalInferenceCounters.Delete(registryID)
+	dropInferenceFailureStreak(registryID)
 
 	o.rssMu.Lock()
 	delete(o.modelRSS, registryID)

--- a/internal/classifier/orchestrator_test.go
+++ b/internal/classifier/orchestrator_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -537,6 +538,93 @@ func TestOrchestrator_PredictModel_ErrorIncrementsInvokeErrors(t *testing.T) {
 	// The success counter must not have been touched.
 	assert.Equal(t, int64(0), GetInferenceCounters().PeekAll()[modelID].InvokeCount,
 		"InvokeCount must remain zero after a failed predict")
+}
+
+// TestInferenceFailureLogsAtError pins the PredictModel failure-log throttle:
+// the first consecutive failure and every inferenceFailureLogEvery-th one are
+// logged at ERROR, everything in between at DEBUG.
+func TestInferenceFailureLogsAtError(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		streak int64
+		want   bool
+	}{
+		{streak: 1, want: true},
+		{streak: 2, want: false},
+		{streak: inferenceFailureLogEvery - 1, want: false},
+		{streak: inferenceFailureLogEvery, want: true},
+		{streak: inferenceFailureLogEvery + 1, want: false},
+		{streak: 2 * inferenceFailureLogEvery, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("streak_%d", tt.streak), func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, inferenceFailureLogsAtError(tt.streak))
+		})
+	}
+}
+
+// TestOrchestrator_PredictModel_FailureStreak verifies the per-model consecutive
+// failure count that drives the failure-log throttle: it grows across failed
+// Predict calls, a success resets it so the next failure is logged at ERROR
+// again, and unloading the model drops the entry so a later instance under the
+// same ID starts fresh.
+func TestOrchestrator_PredictModel_FailureStreak(t *testing.T) {
+	// Not parallel: exercises the package-global inferenceFailureStreaks map.
+	const modelID = "streak-model"
+	predictErr := errors.New("injected predict failure")
+
+	var fail bool
+	mock := &mockModelInstance{
+		id:   modelID,
+		spec: ModelSpec{SampleRate: 48000, ClipLength: 3 * time.Second},
+		predict: func(_ context.Context, _ [][]float32) ([]datastore.Results, error) {
+			if fail {
+				return nil, predictErr
+			}
+			return []datastore.Results{{Species: "Turdus merula", Confidence: 0.95}}, nil
+		},
+	}
+	o := newTestOrchestrator(t, mock)
+	dropInferenceFailureStreak(modelID)
+	t.Cleanup(func() { dropInferenceFailureStreak(modelID) })
+
+	streak := func() (int64, bool) {
+		v, ok := inferenceFailureStreaks.Load(modelID)
+		if !ok {
+			return 0, false
+		}
+		return v.(*atomic.Int64).Load(), true
+	}
+	sample := [][]float32{{0.1}}
+
+	fail = true
+	for want := int64(1); want <= 3; want++ {
+		_, err := o.PredictModel(t.Context(), modelID, sample)
+		require.ErrorIs(t, err, predictErr)
+		got, ok := streak()
+		require.True(t, ok, "streak entry must exist after a failure")
+		assert.Equal(t, want, got, "each consecutive failure increments the streak")
+		assert.Equal(t, want == 1, inferenceFailureLogsAtError(got))
+	}
+
+	fail = false
+	_, err := o.PredictModel(t.Context(), modelID, sample)
+	require.NoError(t, err)
+	got, ok := streak()
+	require.True(t, ok)
+	assert.Zero(t, got, "a successful inference resets the streak")
+
+	fail = true
+	_, err = o.PredictModel(t.Context(), modelID, sample)
+	require.ErrorIs(t, err, predictErr)
+	got, _ = streak()
+	assert.Equal(t, int64(1), got, "the first failure after a success starts a new streak")
+	assert.True(t, inferenceFailureLogsAtError(got), "and is logged at ERROR again")
+
+	require.NoError(t, o.UnloadModel(modelID))
+	_, ok = streak()
+	assert.False(t, ok, "unloading the model must drop its streak entry")
 }
 
 // testRegistryIDForLoadFailure is a synthetic registry ID used only in tests

--- a/internal/classifier/perch_onnx.go
+++ b/internal/classifier/perch_onnx.go
@@ -255,6 +255,18 @@ func (p *Perch) Predict(ctx context.Context, samples [][]float32) ([]datastore.R
 		return nil, err
 	}
 
+	// Reject non-finite logits before softmax: a single NaN or +Inf poisons every
+	// score (the running max and the normalising sum both turn NaN), and a NaN
+	// confidence compares false against every threshold downstream, so instead of
+	// being dropped it would be promoted to a detection for whichever labels
+	// happen to sort first. Fail the window so the backend fault is counted and
+	// logged rather than turned into bogus detections.
+	if idx := firstNonFinite(rawLogits); idx >= 0 {
+		err = newNonFiniteScoreError(RegistryIDPerchV2, idx, len(rawLogits), p.RuntimeInfo)
+		recordPredictionFailure(span, RegistryIDPerchV2, errTypeNonFiniteLogits, start, err)
+		return nil, err
+	}
+
 	// Apply softmax to normalize raw logits into probabilities (0.0-1.0).
 	// The inference.Classifier interface returns pre-activation logits;
 	// BirdNET applies sigmoid in its own Predict path, Perch needs softmax.

--- a/internal/classifier/perch_onnx.go
+++ b/internal/classifier/perch_onnx.go
@@ -261,8 +261,8 @@ func (p *Perch) Predict(ctx context.Context, samples [][]float32) ([]datastore.R
 	// being dropped it would be promoted to a detection for whichever labels
 	// happen to sort first. Fail the window so the backend fault is counted and
 	// logged rather than turned into bogus detections.
-	if idx := firstNonFinite(rawLogits); idx >= 0 {
-		err = newNonFiniteScoreError(RegistryIDPerchV2, idx, len(rawLogits), p.RuntimeInfo)
+	if idx := firstNonFinite(rawLogits); idx != noNonFiniteScore {
+		err = newNonFiniteScoreError(nonFiniteScore{modelID: RegistryIDPerchV2, index: idx, count: len(rawLogits)}, p.RuntimeInfo)
 		recordPredictionFailure(span, RegistryIDPerchV2, errTypeNonFiniteLogits, start, err)
 		return nil, err
 	}

--- a/internal/classifier/perch_onnx_test.go
+++ b/internal/classifier/perch_onnx_test.go
@@ -1,4 +1,56 @@
 package classifier
 
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
 // Compile-time check that Perch implements ModelInstance.
 var _ ModelInstance = (*Perch)(nil)
+
+// TestPerchPredict_RejectsNonFiniteLogits verifies that a backend returning NaN or
+// Inf logits fails the window instead of feeding softmax, which would otherwise
+// turn every score into NaN and let the results bypass the confidence threshold
+// (NaN compares false against any threshold). Regression for the OpenVINO f16
+// Perch path on Intel Arc GPUs, which returns all-NaN logits.
+func TestPerchPredict_RejectsNonFiniteLogits(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		logits []float32
+	}{
+		{name: "NaN", logits: []float32{0.2, float32(math.NaN()), 0.1}},
+		{name: "+Inf", logits: []float32{float32(math.Inf(1)), 0.2, 0.1}},
+		{name: "-Inf", logits: []float32{0.2, 0.1, float32(math.Inf(-1))}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := &Perch{
+				classifier: &predTelemetryClassifier{logits: tt.logits},
+				labels:     []string{"A", "B", "C"},
+				backend:    BackendOpenVINO,
+				device:     "GPU",
+			}
+			results, err := p.Predict(t.Context(), [][]float32{{0.1, 0.2, 0.3}})
+			require.Error(t, err, "non-finite logits must fail the prediction")
+			assert.Nil(t, results, "no results may be returned for a poisoned window")
+			assert.Contains(t, err.Error(), "non-finite score")
+		})
+	}
+}
+
+// TestPerchSoftmax_NonFinitePoisonsAllScores documents why the guard in
+// Perch.Predict sits before softmax: a single NaN logit poisons every output
+// score.
+func TestPerchSoftmax_NonFinitePoisonsAllScores(t *testing.T) {
+	t.Parallel()
+	out := perchSoftmax([]float32{0.2, float32(math.NaN()), 0.1})
+	for i, v := range out {
+		assert.True(t, math.IsNaN(float64(v)), "score %d must be NaN once any logit is NaN", i)
+	}
+}

--- a/internal/classifier/tracing.go
+++ b/internal/classifier/tracing.go
@@ -52,6 +52,7 @@ const (
 	errTypeClassifierNil       = "classifier_nil"
 	errTypeInvokeFailed        = "invoke_failed"
 	errTypeLabelMismatch       = "label_mismatch"
+	errTypeNonFiniteLogits     = "non_finite_logits"
 	errTypeEmbeddingExtraction = "embedding_extraction"
 	errTypeNilEmbeddings       = "nil_embeddings"
 	errTypeBatClassification   = "bat_classification"


### PR DESCRIPTION
## Description

A classifier backend that returns a NaN or Inf score hands the processor a confidence that compares false against every threshold, so instead of being dropped it is promoted to a detection for whichever labels happen to sort first, and the clip is written with a `NaNp` confidence token that retention cannot parse. For Perch a single non-finite logit poisons every score, because the running max and the normalising sum in `perchSoftmax` both turn NaN. This is what the OpenVINO f16 Perch path does on an Intel Arc GPU (see the companion f32 PR), and BirdNET v3.0 runs the same f16 GPU path.

This PR adds a shared `firstNonFinite` scan and `newNonFiniteScoreError` in `analyze.go` and applies them in the Perch, BirdNET v3.0, BirdNET v2.4 and bat `Predict` paths. A window with a non-finite score now fails with an `audio-analysis` error that names the backend, device and precision, recorded under a new `non_finite_logits` prediction failure type, so the fault shows up in metrics rather than as bogus detections.

Because such a fault repeats every window until the backend is fixed, the orchestrator now logs the first failure of a model at ERROR and then only every 100th consecutive repeat, with the rest at DEBUG. The per-failure metrics counter is unchanged. (The second ERROR line per failure in `buffer_manager.go` is pre-existing and left alone.)

Tests: NaN/+Inf/-Inf rejection for Perch and BirdNET v3.0 via the existing fake classifier, a `firstNonFinite` table, and a test documenting why the guard must sit before softmax. All fail on the previous code.

## Related issue

Related: #4206. Companion PRs: #4251 (f32 for Perch on the OpenVINO GPU), #4253 (non-finite confidence filter in the processor), #4254 (disk manager tolerance for `NaNp` clip names).

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/tphakala/birdnet-go/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`go test -race ./...` and/or `npm test`)
- [x] Linters are clean (`golangci-lint run` and/or `npm run check:all`)
- [x] New exports and user-facing changes are documented

## Preflight Status

- [x] Single concern: one fix (non-finite score guard at the model boundary; the log rate limit exists only because the guard makes a persistent backend fault visible every window)
- [x] Preflight passed: findings resolved (guard extended from Perch to every model per the multi-site check; error category `audio-analysis`; helper shared in `analyze.go`; repeated-failure log rate-limited)
- [x] Linters clean: `golangci-lint run`, zero issues
- [x] Tests pass: `go test -race` on `internal/classifier` and the whole tree
- [x] No unrelated changes
- [x] Scope complete; no TODO/FIXME
- [x] No regression/backward-compat break: no config, API or DB surface touched; no legitimate path produced Inf logits
- [x] Breaking changes documented: n/a
- [x] Maintainer-confirm items: none
- [x] i18n complete: no user-facing strings added
- [x] No secrets or PII
- Secondary-model cross-validation: **not run**; single-model review passes.

## Licensing

- [x] My contribution is licensed under **CC BY-NC-SA 4.0**, and I grant the maintainer the right to relicense it under any **OSI-approved open source license**, as described in the [Relicensing Grant](https://github.com/tphakala/birdnet-go/blob/main/CONTRIBUTING.md#relicensing-grant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBXUYwsiTWinmcQbW8Noo7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Classifier predictions now reject invalid NaN or infinite scores instead of producing unreliable detections.
  * Failed predictions include clearer diagnostic context for troubleshooting.
  * Repeated inference failures are logged less noisily while preserving visibility of initial and recurring issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->