### PR TITLE
fix(processor): drop detections and additional results with a non-finite confidence

### DIFF
--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -1020,6 +1020,19 @@ func shouldApplyRangeFilter(modelID string, settings *conf.Settings) bool {
 	return false
 }
 
+// nonFiniteConfidenceWarned guards the once-per-(model, source) warning for
+// non-finite confidences in shouldFilterDetection. Keyed on both so a second
+// broken backend or source still announces itself.
+//
+//nolint:gochecknoglobals // log-flood guard, see onceByKey
+var nonFiniteConfidenceWarned onceByKey
+
+// isFiniteConfidence reports whether c is a usable score: not NaN and not Inf.
+func isFiniteConfidence(c float32) bool {
+	f := float64(c)
+	return !math.IsNaN(f) && !math.IsInf(f, 0)
+}
+
 // shouldFilterDetection checks if a detection should be filtered out
 func (p *Processor) shouldFilterDetection(settings *conf.Settings, result datastore.Results, commonName, scientificName, speciesLowercase string, baseThreshold float32, source, modelID string) (shouldFilter bool, confidenceThreshold float32) {
 	// Check human detection privacy filter. Match the raw label so Perch v2's
@@ -1053,6 +1066,32 @@ func (p *Processor) shouldFilterDetection(settings *conf.Settings, result datast
 		confidenceThreshold = p.getAdjustedConfidenceThreshold(speciesLowercase, baseThreshold, isCustomThreshold)
 	} else {
 		confidenceThreshold = baseThreshold
+	}
+
+	// A non-finite confidence (NaN or Inf) is a classifier fault, not a score. NaN
+	// compares false against every threshold, so the "<= threshold" gate below
+	// would let it through and it would be saved as a detection, with a "NaNp"
+	// confidence token in the clip name. Drop it here regardless of threshold.
+	// It is logged once per model and source at WARN (the fault repeats every
+	// window while the backend is broken, so a per-hit line would flood the log)
+	// and per hit at DEBUG.
+	if !isFiniteConfidence(result.Confidence) {
+		nonFiniteConfidenceWarned.do(modelID+"|"+source, func() {
+			GetLogger().Warn("Classifier returned a non-finite confidence; dropping such detections",
+				logger.String("species", result.Species),
+				logger.String("source", p.getDisplayNameForSource(source)),
+				logger.String("model_id", modelID),
+				logger.String("operation", "confidence_filter"))
+		})
+		if settings.Debug {
+			GetLogger().Debug("Detection filtered out due to non-finite confidence",
+				logger.String("species", result.Species),
+				logger.Float32("confidence", result.Confidence),
+				logger.String("source", p.getDisplayNameForSource(source)),
+				logger.String("model_id", modelID),
+				logger.String("operation", "confidence_filter"))
+		}
+		return true, confidenceThreshold
 	}
 
 	// Check confidence threshold
@@ -1251,6 +1290,13 @@ func convertToAdditionalResults(results []datastore.Results, primaryScientificNa
 	additional := make([]detection.AdditionalResult, 0, len(results))
 	seen := make(map[string]int, len(results)) // scientificName → index in additional
 	for _, r := range results {
+		// A non-finite confidence never reaches the primary detection (see
+		// shouldFilterDetection) and must not ride along as an additional result
+		// either: it would be persisted as NULL on SQLite and rejected by MySQL,
+		// failing the whole save.
+		if !isFiniteConfidence(r.Confidence) {
+			continue
+		}
 		sp := detection.ParseSpeciesString(r.Species)
 		// Canonicalize the candidate's scientific name so the primary species is
 		// excluded even when this prediction carries it under a legacy/alias name.

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -1035,6 +1035,33 @@ func isFiniteConfidence(c float32) bool {
 
 // shouldFilterDetection checks if a detection should be filtered out
 func (p *Processor) shouldFilterDetection(settings *conf.Settings, result datastore.Results, commonName, scientificName, speciesLowercase string, baseThreshold float32, source, modelID string) (shouldFilter bool, confidenceThreshold float32) {
+	// A non-finite confidence (NaN or Inf) is a classifier fault, not a score. NaN
+	// compares false against every threshold, so the "<= threshold" gate below
+	// would let it through and it would be saved as a detection, with a "NaNp"
+	// confidence token in the clip name. Drop it first, ahead of the privacy and
+	// exclusion filters, so every non-finite value reaches the diagnostic below
+	// no matter which label it landed on. It is logged once per model and source
+	// at WARN (the fault repeats every window while the backend is broken, so a
+	// per-hit line would flood the log) and per hit at DEBUG.
+	if !isFiniteConfidence(result.Confidence) {
+		nonFiniteConfidenceWarned.do(modelID+"|"+source, func() {
+			GetLogger().Warn("Classifier returned a non-finite confidence; dropping such detections",
+				logger.String("species", result.Species),
+				logger.String("source", p.getDisplayNameForSource(source)),
+				logger.String("model_id", modelID),
+				logger.String("operation", "confidence_filter"))
+		})
+		if settings.Debug {
+			GetLogger().Debug("Detection filtered out due to non-finite confidence",
+				logger.String("species", result.Species),
+				logger.Float32("confidence", result.Confidence),
+				logger.String("source", p.getDisplayNameForSource(source)),
+				logger.String("model_id", modelID),
+				logger.String("operation", "confidence_filter"))
+		}
+		return true, 0
+	}
+
 	// Check human detection privacy filter. Match the raw label so Perch v2's
 	// FSD50K human classes are caught too, not just BirdNET's "Human *" classes.
 	if isHumanVocalization(result.Species) && result.Confidence > baseThreshold {
@@ -1066,32 +1093,6 @@ func (p *Processor) shouldFilterDetection(settings *conf.Settings, result datast
 		confidenceThreshold = p.getAdjustedConfidenceThreshold(speciesLowercase, baseThreshold, isCustomThreshold)
 	} else {
 		confidenceThreshold = baseThreshold
-	}
-
-	// A non-finite confidence (NaN or Inf) is a classifier fault, not a score. NaN
-	// compares false against every threshold, so the "<= threshold" gate below
-	// would let it through and it would be saved as a detection, with a "NaNp"
-	// confidence token in the clip name. Drop it here regardless of threshold.
-	// It is logged once per model and source at WARN (the fault repeats every
-	// window while the backend is broken, so a per-hit line would flood the log)
-	// and per hit at DEBUG.
-	if !isFiniteConfidence(result.Confidence) {
-		nonFiniteConfidenceWarned.do(modelID+"|"+source, func() {
-			GetLogger().Warn("Classifier returned a non-finite confidence; dropping such detections",
-				logger.String("species", result.Species),
-				logger.String("source", p.getDisplayNameForSource(source)),
-				logger.String("model_id", modelID),
-				logger.String("operation", "confidence_filter"))
-		})
-		if settings.Debug {
-			GetLogger().Debug("Detection filtered out due to non-finite confidence",
-				logger.String("species", result.Species),
-				logger.Float32("confidence", result.Confidence),
-				logger.String("source", p.getDisplayNameForSource(source)),
-				logger.String("model_id", modelID),
-				logger.String("operation", "confidence_filter"))
-		}
-		return true, confidenceThreshold
 	}
 
 	// Check confidence threshold

--- a/internal/analysis/processor/processor_filter_test.go
+++ b/internal/analysis/processor/processor_filter_test.go
@@ -1,6 +1,7 @@
 package processor
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -141,6 +142,41 @@ func TestShouldFilterDetection_AppliesRangeFilterToPerch(t *testing.T) {
 			)
 
 			assert.Equal(t, tt.expectedFilter, shouldFilter)
+			assert.InDelta(t, 0.7, threshold, 0.001)
+		})
+	}
+}
+
+// TestShouldFilterDetection_DropsNonFiniteConfidence verifies that a NaN or Inf
+// confidence is always filtered. NaN compares false against every threshold, so
+// without an explicit guard "Confidence <= threshold" would promote a poisoned
+// classifier output to a saved detection. Seen in the field with Perch v2 on
+// OpenVINO f16 (all-NaN logits), which filled a disk with unparseable clips.
+func TestShouldFilterDetection_DropsNonFiniteConfidence(t *testing.T) {
+	t.Parallel()
+
+	settings := &conf.Settings{}
+	p := &Processor{}
+
+	tests := []struct {
+		name       string
+		confidence float32
+		wantFilter bool
+	}{
+		{name: "NaN is dropped", confidence: float32(math.NaN()), wantFilter: true},
+		{name: "+Inf is dropped", confidence: float32(math.Inf(1)), wantFilter: true},
+		{name: "-Inf is dropped", confidence: float32(math.Inf(-1)), wantFilter: true},
+		{name: "finite above threshold passes", confidence: 0.95, wantFilter: false},
+		{name: "finite below threshold is dropped", confidence: 0.2, wantFilter: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := datastore.Results{Species: "Turdus migratorius", Confidence: tt.confidence}
+			shouldFilter, threshold := p.shouldFilterDetection(
+				settings, result, "American Robin", "Turdus migratorius", "american robin",
+				0.7, "Backyard", "Perch_V2")
+			assert.Equal(t, tt.wantFilter, shouldFilter)
 			assert.InDelta(t, 0.7, threshold, 0.001)
 		})
 	}

--- a/internal/analysis/processor/processor_filter_test.go
+++ b/internal/analysis/processor/processor_filter_test.go
@@ -158,26 +158,32 @@ func TestShouldFilterDetection_DropsNonFiniteConfidence(t *testing.T) {
 	settings := &conf.Settings{}
 	p := &Processor{}
 
+	// The non-finite gate runs before the privacy and exclusion filters and, like
+	// them, reports no threshold; only a finite score reaches the threshold gate.
 	tests := []struct {
-		name       string
-		confidence float32
-		wantFilter bool
+		name          string
+		species       string
+		confidence    float32
+		wantFilter    bool
+		wantThreshold float32
 	}{
-		{name: "NaN is dropped", confidence: float32(math.NaN()), wantFilter: true},
-		{name: "+Inf is dropped", confidence: float32(math.Inf(1)), wantFilter: true},
-		{name: "-Inf is dropped", confidence: float32(math.Inf(-1)), wantFilter: true},
-		{name: "finite above threshold passes", confidence: 0.95, wantFilter: false},
-		{name: "finite below threshold is dropped", confidence: 0.2, wantFilter: true},
+		{name: "NaN is dropped", species: "Turdus migratorius", confidence: float32(math.NaN()), wantFilter: true},
+		{name: "+Inf is dropped", species: "Turdus migratorius", confidence: float32(math.Inf(1)), wantFilter: true},
+		{name: "-Inf is dropped", species: "Turdus migratorius", confidence: float32(math.Inf(-1)), wantFilter: true},
+		{name: "NaN on a human label is dropped by the non-finite gate", species: "Human vocal", confidence: float32(math.NaN()), wantFilter: true},
+		{name: "+Inf on a human label is dropped by the non-finite gate", species: "Human vocal", confidence: float32(math.Inf(1)), wantFilter: true},
+		{name: "finite above threshold passes", species: "Turdus migratorius", confidence: 0.95, wantFilter: false, wantThreshold: 0.7},
+		{name: "finite below threshold is dropped", species: "Turdus migratorius", confidence: 0.2, wantFilter: true, wantThreshold: 0.7},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			result := datastore.Results{Species: "Turdus migratorius", Confidence: tt.confidence}
+			result := datastore.Results{Species: tt.species, Confidence: tt.confidence}
 			shouldFilter, threshold := p.shouldFilterDetection(
 				settings, result, "American Robin", "Turdus migratorius", "american robin",
 				0.7, "Backyard", "Perch_V2")
 			assert.Equal(t, tt.wantFilter, shouldFilter)
-			assert.InDelta(t, 0.7, threshold, 0.001)
+			assert.InDelta(t, tt.wantThreshold, threshold, 0.001)
 		})
 	}
 }

--- a/internal/analysis/processor/processor_test.go
+++ b/internal/analysis/processor/processor_test.go
@@ -1,6 +1,7 @@
 package processor
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -309,4 +310,24 @@ func TestConvertToAdditionalResults_SetsRawLabelFromSpecies(t *testing.T) {
 	require.Len(t, result, 2)
 	assert.Equal(t, "male_speech_and_man_speaking", result[0].RawLabel, "raw label must equal the original r.Species string")
 	assert.Equal(t, "Turdus merula_Common Blackbird", result[1].RawLabel, "raw label must equal the original r.Species string")
+}
+
+// TestConvertToAdditionalResults_SkipsNonFiniteConfidence verifies that a
+// top-K entry carrying a NaN or Inf confidence is dropped from the additional
+// results rather than persisted (NULL on SQLite, a rejected insert on MySQL).
+func TestConvertToAdditionalResults_SkipsNonFiniteConfidence(t *testing.T) {
+	t.Parallel()
+
+	input := []datastore.Results{
+		{Species: "Periparus ater_Coal Tit", Confidence: 0.80},
+		{Species: "Parus major_Great Tit", Confidence: float32(math.NaN())},
+		{Species: "Corvus corax_Common Raven", Confidence: float32(math.Inf(1))},
+		{Species: "Turdus merula_Common Blackbird", Confidence: 0.40},
+	}
+
+	result := convertToAdditionalResults(input, "")
+
+	require.Len(t, result, 2, "non-finite entries must be skipped")
+	assert.Equal(t, "Periparus ater", result[0].Species.ScientificName)
+	assert.Equal(t, "Turdus merula", result[1].Species.ScientificName)
 }


### PR DESCRIPTION
## Description

`shouldFilterDetection` gates on `Confidence <= threshold`. NaN compares false against every value, so a NaN confidence from a faulty classifier backend passes the gate and is saved as a detection, complete with an audio clip whose filename carries a `NaNp` confidence token that the disk manager cannot parse or delete. On one host (Perch v2 on OpenVINO f16, Intel Arc) this produced four bogus detections per 5 s window and filled a 32 GB volume in 11 hours. Sentry `BIRDNET-GO-2EN` (NULL confidence aggregates, patched at the query level in #4170) is the same rows reaching SQLite, which stores NaN as NULL.

This PR treats NaN and Inf as "no usable score":
- `shouldFilterDetection` drops them explicitly, independent of the configured threshold, announcing the drop once per model and source at WARN and per hit at DEBUG.
- `convertToAdditionalResults` skips them, so a non-finite secondary score can no longer be persisted alongside a valid primary detection (NULL on SQLite, a rejected insert on MySQL).

The human/dog privacy checks and the "last heard" feed already use `>` comparisons, which are false for NaN, so their behavior is unchanged. This is defence in depth for the classifier-side guard in the companion PR: it catches any model, present or future, whose backend emits a non-finite score.

## Related issue

Related: #4206, #4170 (NULL confidence in species summary). Companion PRs: #4251 (f32 for Perch on the OpenVINO GPU), #4252 (non-finite score guard in the classifiers), #4254 (disk manager tolerance for `NaNp` clip names).

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/tphakala/birdnet-go/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`go test -race ./...` and/or `npm test`)
- [x] Linters are clean (`golangci-lint run` and/or `npm run check:all`)
- [x] New exports and user-facing changes are documented

## Preflight Status

- [x] Single concern: one fix
- [x] Preflight passed: findings resolved (additional-results path guarded; once-per-(model, source) WARN via the existing `onceByKey` guard; comment corrected)
- [x] Linters clean: `golangci-lint run`, zero issues
- [x] Tests pass: `go test -race` on `internal/analysis/processor` and the whole tree
- [x] No unrelated changes
- [x] Scope complete; no TODO/FIXME
- [x] No regression/backward-compat break: no config, API or DB surface touched; only non-finite confidences change outcome
- [x] Breaking changes documented: n/a
- [x] Maintainer-confirm items: none
- [x] i18n complete: no user-facing strings added
- [x] No secrets or PII
- Secondary-model cross-validation: **not run**; single-model review passes.

## Licensing

- [x] My contribution is licensed under **CC BY-NC-SA 4.0**, and I grant the maintainer the right to relicense it under any **OSI-approved open source license**, as described in the [Relicensing Grant](https://github.com/tphakala/birdnet-go/blob/main/CONTRIBUTING.md#relicensing-grant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBXUYwsiTWinmcQbW8Noo7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid confidence values from classifiers are now excluded from saved detections and additional results.
  * Prevents malformed detection data and invalid clip identifiers caused by `NaN` or infinite confidence values.
  * Adds warning and debug logging to improve visibility when invalid confidence values are encountered.

* **Tests**
  * Added coverage for filtering and conversion behavior with `NaN`, positive infinity, and negative infinity confidence values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->