### PR TITLE
fix(diskmanager): keep clips with a non-finite confidence token eligible for cleanup

### DIFF
--- a/internal/diskmanager/file_utils.go
+++ b/internal/diskmanager/file_utils.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/csv"
 	"fmt"
-	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -40,11 +39,18 @@ const nonFiniteConfidence = 0
 var lastParseErrorCount atomic.Int64
 
 // isNonFiniteConfidenceToken reports whether a clip-name confidence token is one
-// of the non-finite spellings Go's %f verbs produce ("NaN", "+Inf", "-Inf", with
-// the trailing "p"), which is what the exporter writes for a non-finite score.
+// of the exact non-finite spellings Go's %f verbs produce ("NaN", "+Inf", "-Inf",
+// with the trailing "p"), which is what the exporter writes for a non-finite
+// score. It deliberately does not use strconv.ParseFloat, which would also accept
+// "nan", "inf", "infinity" and other spellings the exporter never emits, so a
+// foreign file with such a token keeps being rejected rather than swept up.
 func isNonFiniteConfidenceToken(token string) bool {
-	f, err := strconv.ParseFloat(strings.TrimSuffix(token, "p"), 64)
-	return err == nil && (math.IsNaN(f) || math.IsInf(f, 0))
+	switch strings.TrimSuffix(token, "p") {
+	case "NaN", "+Inf", "-Inf":
+		return true
+	default:
+		return false
+	}
 }
 
 // errUnrecognizedFilename is returned when a file's name does not match the

--- a/internal/diskmanager/file_utils.go
+++ b/internal/diskmanager/file_utils.go
@@ -5,12 +5,14 @@ import (
 	"context"
 	"encoding/csv"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
 	"slices"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/errors"
@@ -21,6 +23,29 @@ import (
 // Audio files are written with this suffix during recording and renamed upon
 // completion to ensure atomic file operations.
 const tempFileExt = ".temp"
+
+// nonFiniteConfidence is the confidence assigned to a clip whose filename
+// confidence token is a non-finite float ("NaNp", "+Infp", "-Infp"), which the
+// exporter writes when a classifier returns a NaN or Inf score. Such a clip
+// carries no usable score, so it gets the lowest value and becomes the first
+// candidate among equally-aged clips under both the age and usage policies,
+// where confidence is the final tie-breaker.
+const nonFiniteConfidence = 0
+
+// lastParseErrorCount remembers the unparseable-file count from the previous
+// scan so the summary warning fires when the situation changes rather than on
+// every check interval.
+//
+//nolint:gochecknoglobals // scan-to-scan log dedup state, see GetAudioFilesContext
+var lastParseErrorCount atomic.Int64
+
+// isNonFiniteConfidenceToken reports whether a clip-name confidence token is one
+// of the non-finite spellings Go's %f verbs produce ("NaN", "+Inf", "-Inf", with
+// the trailing "p"), which is what the exporter writes for a non-finite score.
+func isNonFiniteConfidenceToken(token string) bool {
+	f, err := strconv.ParseFloat(strings.TrimSuffix(token, "p"), 64)
+	return err == nil && (math.IsNaN(f) || math.IsInf(f, 0))
+}
 
 // errUnrecognizedFilename is returned when a file's name does not match the
 // expected BirdNET naming pattern (species_confidence_timestamp). Such files
@@ -296,11 +321,19 @@ func GetAudioFilesContext(ctx context.Context, baseDir string, allowedExts []str
 		return nil, descriptiveErr
 	}
 
-	// If we encountered parse errors but still have some valid files, log a summary but continue
+	// Files that failed to parse are excluded from every retention policy, so an
+	// operator whose disk keeps filling needs to see this at the default log
+	// level, not only with diskmanager debug logging enabled. The scan repeats
+	// every check interval and a foreign file never goes away by itself, so warn
+	// only when the count changes and demote the steady-state repeats to debug.
 	if state.parseErrorCount > 0 {
-		log.Debug("Encountered file parsing errors during cleanup",
-			logger.Int("error_count", state.parseErrorCount),
-			logger.Int("max_logged", maxParseErrors))
+		summary := log.Debug
+		if lastParseErrorCount.Swap(int64(state.parseErrorCount)) != int64(state.parseErrorCount) {
+			summary = log.Warn
+		}
+		summary("Skipped audio files with unparseable names during cleanup; they will not be deleted by any retention policy",
+			logger.Int("skipped_count", state.parseErrorCount),
+			logger.Error(state.firstParseError))
 		// If we have no valid files at all, return an error
 		if len(state.files) == 0 && state.firstParseError != nil {
 			descriptiveErr := errors.Newf("diskmanager: failed to parse any audio files: %w", state.firstParseError).
@@ -311,6 +344,10 @@ func GetAudioFilesContext(ctx context.Context, baseDir string, allowedExts []str
 				Build()
 			return nil, descriptiveErr
 		}
+	}
+
+	if state.parseErrorCount == 0 {
+		lastParseErrorCount.Store(0)
 	}
 
 	// Update the pooled slice with the final data while preserving the backing array
@@ -362,16 +399,23 @@ func parseFileInfo(path string, info os.FileInfo, allowedExts []string) (FileInf
 
 	confidence, err := strconv.Atoi(strings.TrimSuffix(confidenceStr, "p"))
 	if err != nil {
-		// Lightweight error for confidence parsing
-		descriptiveErr := errors.Newf("diskmanager: invalid confidence value").
-			Component("diskmanager").
-			Category(errors.CategoryValidation).
-			Context("confidence_string", confidenceStr).
-			Context("filename", name).
-			Context("parsed_species", species).
-			Context("parsed_timestamp_str", timestampStr).
-			Build()
-		return FileInfo{}, descriptiveErr
+		// A clip that retention cannot parse is never deleted by any policy, so an
+		// exporter-written non-finite token would otherwise accumulate without
+		// bound. Tolerate exactly those spellings (see nonFiniteConfidence) and
+		// keep rejecting every other token, so foreign files that merely share the
+		// name shape do not become deletion candidates.
+		if !isNonFiniteConfidenceToken(confidenceStr) {
+			descriptiveErr := errors.Newf("diskmanager: invalid confidence value").
+				Component("diskmanager").
+				Category(errors.CategoryValidation).
+				Context("confidence_string", confidenceStr).
+				Context("filename", name).
+				Context("parsed_species", species).
+				Context("parsed_timestamp_str", timestampStr).
+				Build()
+			return FileInfo{}, descriptiveErr
+		}
+		confidence = nonFiniteConfidence
 	}
 
 	// IMPORTANT: Despite the Z suffix in the filename (which normally indicates UTC),

--- a/internal/diskmanager/file_utils_test.go
+++ b/internal/diskmanager/file_utils_test.go
@@ -24,11 +24,13 @@ func TestInvalidFileNameErrorMessages(t *testing.T) {
 		// This actually gets parsed as species="bubo", confidence="bubo", which fails at the confidence parsing step
 		{"bubo_bubo_80p.wav", "diskmanager: invalid confidence value"},
 
-		// Invalid confidence value
-		{"bubo_bubo_XXp_20210102T150405Z.wav", "diskmanager: invalid confidence value"},
-
 		// Invalid timestamp format
 		{"bubo_bubo_80p_invalid.wav", "diskmanager: invalid timestamp format"},
+
+		// Non-numeric confidence token that is not one of the non-finite float
+		// spellings the exporter can produce: still rejected so foreign files that
+		// merely share the name shape never become deletion candidates.
+		{"bubo_bubo_XXp_20210102T150405Z.wav", "diskmanager: invalid confidence value"},
 	}
 
 	for _, tc := range testCases {
@@ -270,6 +272,7 @@ func TestGetAudioFilesWithMixedFiles(t *testing.T) {
 		filepath.Join(tempDir, "erithacus_rubecula_60p_20210104T150405Z.flac"),
 		filepath.Join(tempDir, "turdus_migratorius_94p_20210105T150405Z_86s.m4a"),  // with duration suffix
 		filepath.Join(tempDir, "cyanocitta_cristata_89p_20210106T150405Z_38s.wav"), // with duration suffix
+		filepath.Join(tempDir, "acris_crepitans_NaNp_20210102T150405Z_105s.wav"),   // non-finite confidence: tolerated, lowest confidence
 	}
 
 	invalidFiles := []string{
@@ -548,4 +551,52 @@ func TestDotDirectorySkipping(t *testing.T) {
 	// Hidden dir's file should be skipped, normal file should be found
 	assert.Contains(t, visited, normalWAV)
 	assert.NotContains(t, visited, hiddenWAV)
+}
+
+// TestParseFileInfo_NonFiniteConfidenceStaysEligible verifies that a clip whose
+// confidence token is a non-finite float is still returned as a cleanup candidate
+// with the lowest confidence, instead of being skipped. The exporter writes "NaNp"
+// (or "+Infp"/"-Infp") when a classifier returns a non-finite score; such clips
+// previously never entered the deletion candidate set and accumulated until the
+// disk was full. Any other unparseable token keeps being rejected (see
+// TestInvalidFileNameErrorMessages) so foreign files are not swept up.
+func TestParseFileInfo_NonFiniteConfidenceStaysEligible(t *testing.T) {
+	t.Parallel()
+
+	for _, filename := range []string{
+		"acris_crepitans_NaNp_20260901T230412Z_105s.wav",
+		"bubo_bubo_+Infp_20210102T150405Z.wav",
+		"bubo_bubo_-Infp_20210102T150405Z.wav",
+	} {
+		t.Run(filename, func(t *testing.T) {
+			t.Parallel()
+			mockInfo := &MockFileInfo{
+				FileName:    filename,
+				FileSize:    1024,
+				FileMode:    0o644,
+				FileModTime: parseTime("20210102T150405Z"),
+				FileIsDir:   false,
+			}
+
+			info, err := parseFileInfo("/test/"+filename, mockInfo, allowedFileTypes)
+			require.NoError(t, err, "a non-finite confidence token must not reject the file")
+			assert.Equal(t, nonFiniteConfidence, info.Confidence, "non-finite confidence must be the lowest value")
+			assert.False(t, info.Timestamp.IsZero(), "timestamp must still be parsed")
+		})
+	}
+}
+
+// TestIsNonFiniteConfidenceToken pins the accepted spellings to exactly what
+// fmt's %f verbs emit for NaN and Inf, with or without the "p" suffix.
+func TestIsNonFiniteConfidenceToken(t *testing.T) {
+	t.Parallel()
+	for token, want := range map[string]bool{
+		"NaNp": true, "+Infp": true, "-Infp": true, "NaN": true, "Infp": true,
+		"80p": false, "XXp": false, "": false, "p": false,
+		// An out-of-range literal parses to Inf with a range error; fmt never
+		// emits it for a float32 score, so it is not one of ours.
+		"1e999p": false,
+	} {
+		assert.Equal(t, want, isNonFiniteConfidenceToken(token), "token %q", token)
+	}
 }

--- a/internal/diskmanager/file_utils_test.go
+++ b/internal/diskmanager/file_utils_test.go
@@ -2,6 +2,7 @@ package diskmanager
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -587,16 +588,38 @@ func TestParseFileInfo_NonFiniteConfidenceStaysEligible(t *testing.T) {
 }
 
 // TestIsNonFiniteConfidenceToken pins the accepted spellings to exactly what
-// fmt's %f verbs emit for NaN and Inf, with or without the "p" suffix.
+// fmt's %f verbs emit for NaN and Inf, with or without the "p" suffix. Every
+// other spelling strconv.ParseFloat would accept (unsigned or lower-case Inf,
+// "infinity", lower-case NaN) is rejected: the exporter never writes them, so a
+// file carrying one is foreign and must not become a cleanup candidate.
 func TestIsNonFiniteConfidenceToken(t *testing.T) {
 	t.Parallel()
-	for token, want := range map[string]bool{
-		"NaNp": true, "+Infp": true, "-Infp": true, "NaN": true, "Infp": true,
-		"80p": false, "XXp": false, "": false, "p": false,
-		// An out-of-range literal parses to Inf with a range error; fmt never
-		// emits it for a float32 score, so it is not one of ours.
-		"1e999p": false,
-	} {
-		assert.Equal(t, want, isNonFiniteConfidenceToken(token), "token %q", token)
+	tests := []struct {
+		token string
+		want  bool
+	}{
+		{token: "NaNp", want: true},
+		{token: "+Infp", want: true},
+		{token: "-Infp", want: true},
+		{token: "NaN", want: true},
+		{token: "+Inf", want: true},
+		{token: "Infp", want: false},
+		{token: "infp", want: false},
+		{token: "+infp", want: false},
+		{token: "nanp", want: false},
+		{token: "NANp", want: false},
+		{token: "infinityp", want: false},
+		{token: "+Infinityp", want: false},
+		{token: "1e999p", want: false},
+		{token: "80p", want: false},
+		{token: "XXp", want: false},
+		{token: "", want: false},
+		{token: "p", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("token=%q", tt.token), func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isNonFiniteConfidenceToken(tt.token))
+		})
 	}
 }


### PR DESCRIPTION
## Description

`parseFileInfo` rejected any clip whose confidence token failed `strconv.Atoi`, and `processFile` then dropped the file from the candidate set. Such files never entered either retention policy, so they accumulated without bound regardless of the configured limits, and the only trace was a debug-level log line. The exporter itself produces such names: a NaN confidence renders as `NaNp` (Inf as `+Infp`/`-Infp`) via `buildClipPath`'s `%.0fp`. On one host 2,675 `NaNp` clips filled a 32 GB volume in 11 hours while every parseable species was pruned correctly to the `minclips` floor. Older reports of clips that never get deleted show the same "parse error, then nothing eligible" pattern (#502's log, and possibly #4059 / #3892).

This PR:
- Tolerates exactly the non-finite float spellings, assigning them the lowest confidence so they are the first tie-break candidates under both policies. Every other unparseable token is still rejected, so foreign files that merely share the `species_NNp_timestamp` shape do not become deletion candidates (the review flagged this, so the tolerance was narrowed from "any token" to these spellings).
- Raises the end-of-scan parse-failure summary from DEBUG to WARN with the first error attached, emitted when the count changes rather than on every check interval, so an operator whose disk keeps filling can see why without enabling module debug logging.

Locked clips, the extension allowlist, the timestamp parse, the age cutoff / usage threshold and `minclips` per species all still gate deletion; confidence remains only the final tie-breaker.

## Related issue

Related: #502, #4059, #3892 (clips not deleted). Companion PRs: #4251 (f32 for Perch on the OpenVINO GPU), #4252 (non-finite score guard in the classifiers), #4253 (non-finite confidence filter in the processor).

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/tphakala/birdnet-go/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`go test -race ./...` and/or `npm test`)
- [x] Linters are clean (`golangci-lint run` and/or `npm run check:all`)
- [x] New exports and user-facing changes are documented

## Preflight Status

- [x] Single concern: one fix
- [x] Preflight passed: findings resolved (tolerance narrowed to non-finite spellings; per-file debug log removed; WARN deduplicated across scans; const doc corrected)
- [x] Linters clean: `golangci-lint run`, zero issues
- [x] Tests pass: `go test -race` on `internal/diskmanager` and the whole tree
- [x] No unrelated changes
- [x] Scope complete; no TODO/FIXME
- [x] No regression/backward-compat break: no config, API or DB surface touched. Behavioral change: exporter-written `NaNp`/`±Infp` clips become deletable (they were never meant to be immune); a WARN now appears when unparseable audio files are present in the clips tree
- [x] Breaking changes documented: above
- [x] Maintainer-confirm items: none after narrowing
- [x] i18n complete: no user-facing strings added
- [x] No secrets or PII
- Secondary-model cross-validation: **not run**; single-model review passes.

## Licensing

- [x] My contribution is licensed under **CC BY-NC-SA 4.0**, and I grant the maintainer the right to relicense it under any **OSI-approved open source license**, as described in the [Relicensing Grant](https://github.com/tphakala/birdnet-go/blob/main/CONTRIBUTING.md#relicensing-grant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBXUYwsiTWinmcQbW8Noo7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clips with non-finite classifier scores are now recognized and remain eligible for cleanup.
  * Invalid confidence values continue to be rejected.
  * Repeated file-parse warnings are now reduced when the number of affected files remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->