### PR TITLE
fix(datastore): span every model's label when filtering time analytics by species

### DIFF
--- a/internal/datastore/v2/repository/detection.go
+++ b/internal/datastore/v2/repository/detection.go
@@ -239,14 +239,17 @@ type DetectionRepository interface {
 
 	// GetHourlyDistribution returns detection counts by hour. tzOffsetSeconds is the
 	// configured timezone's UTC offset, applied so detections bucket by wall-clock hour in
-	// that zone rather than the database/OS-local zone. labelID and modelID are optional filters.
-	GetHourlyDistribution(ctx context.Context, start, end int64, tzOffsetSeconds int, labelID, modelID *uint) ([]HourlyDistributionData, error)
+	// that zone rather than the database/OS-local zone. labelIDs (every label of one species across
+	// models) and modelID are optional filters: nil or empty labelIDs means no label filter, so a
+	// caller that resolved a species to no labels must return its own empty result (or pass the
+	// no-match sentinel) rather than forward the empty slice.
+	GetHourlyDistribution(ctx context.Context, start, end int64, tzOffsetSeconds int, labelIDs []uint, modelID *uint) ([]HourlyDistributionData, error)
 
 	// GetDetectionTimestamps returns the raw detected_at epochs (seconds) for the half-open
-	// range [start, end), excluding false positives, in no particular order. labelID is an
-	// optional species filter. Callers bucket the timestamps in Go (e.g. the seasonal heatmap),
+	// range [start, end), excluding false positives, in no particular order. labelIDs is an
+	// optional species filter (every label of the species; nil or empty for none). Callers bucket the timestamps in Go (e.g. the seasonal heatmap),
 	// which keeps the slot/date math out of dialect SQL and correct across DST.
-	GetDetectionTimestamps(ctx context.Context, start, end int64, labelID *uint) ([]int64, error)
+	GetDetectionTimestamps(ctx context.Context, start, end int64, labelIDs []uint) ([]int64, error)
 
 	// GetBatchConfidences returns the per-label-ID detection confidences for the given label IDs over
 	// the half-open range [start, end), false positives excluded and filtered by minConfidence. Results
@@ -258,8 +261,9 @@ type DetectionRepository interface {
 	// GetDailyAnalytics returns daily statistics.
 	// tzOffsetSeconds is the configured timezone's UTC offset, applied so detections bucket by
 	// wall-clock date in that zone rather than the database/OS-local zone.
-	// labelID and modelID are optional filters.
-	GetDailyAnalytics(ctx context.Context, start, end int64, tzOffsetSeconds int, labelID, modelID *uint) ([]DailyAnalyticsData, error)
+	// labelIDs (every label of one species across models) and modelID are optional filters; nil or
+	// empty labelIDs means no label filter (see GetHourlyDistribution).
+	GetDailyAnalytics(ctx context.Context, start, end int64, tzOffsetSeconds int, labelIDs []uint, modelID *uint) ([]DailyAnalyticsData, error)
 
 	// GetDetectionTrends returns detection trends over time.
 	// period is "day", "week", or "month".

--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -1623,7 +1623,7 @@ func (r *detectionRepository) GetSpeciesSummary(ctx context.Context, start, end 
 
 // buildAnalyticsBaseQuery creates a base query with JOIN and WHERE clauses for analytics.
 // This helper reduces duplication between analytics query methods.
-func (r *detectionRepository) buildAnalyticsBaseQuery(ctx context.Context, start, end int64, labelID, modelID *uint) *gorm.DB {
+func (r *detectionRepository) buildAnalyticsBaseQuery(ctx context.Context, start, end int64, labelIDs []uint, modelID *uint) *gorm.DB {
 	detTable := r.tableName()
 	revTable := r.reviewsTable()
 	query := r.db.WithContext(ctx).Table(fmt.Sprintf("%s d", detTable)).
@@ -1631,8 +1631,10 @@ func (r *detectionRepository) buildAnalyticsBaseQuery(ctx context.Context, start
 		Where("d.detected_at >= ? AND d.detected_at < ?", start, end).
 		Where("(dr.verified IS NULL OR dr.verified != ?)", string(entities.VerificationFalsePositive))
 
-	if labelID != nil {
-		query = query.Where("d.label_id = ?", *labelID)
+	// A species has one label per model, so a species filter is a set of label IDs, not one:
+	// filtering on a single label silently dropped every detection made by the other models.
+	if len(labelIDs) > 0 {
+		query = query.Where("d.label_id IN ?", labelIDs)
 	}
 	if modelID != nil {
 		query = query.Where("d.model_id = ?", *modelID)
@@ -1642,13 +1644,13 @@ func (r *detectionRepository) buildAnalyticsBaseQuery(ctx context.Context, start
 }
 
 // GetHourlyDistribution returns detection counts by hour.
-func (r *detectionRepository) GetHourlyDistribution(ctx context.Context, start, end int64, tzOffsetSeconds int, labelID, modelID *uint) ([]HourlyDistributionData, error) {
+func (r *detectionRepository) GetHourlyDistribution(ctx context.Context, start, end int64, tzOffsetSeconds int, labelIDs []uint, modelID *uint) ([]HourlyDistributionData, error) {
 	var results []HourlyDistributionData
 
 	// Bucket by wall-clock hour in the configured timezone via hourFromUnixExpr.
 	// Exclude detections marked as false_positive
 	hourExpr := r.hourFromUnixExpr("d.detected_at", tzOffsetSeconds)
-	query := r.buildAnalyticsBaseQuery(ctx, start, end, labelID, modelID).
+	query := r.buildAnalyticsBaseQuery(ctx, start, end, labelIDs, modelID).
 		Select(fmt.Sprintf("%s as hour, COUNT(*) as count", hourExpr)).
 		Group("hour").
 		Order("hour ASC")
@@ -1660,23 +1662,23 @@ func (r *detectionRepository) GetHourlyDistribution(ctx context.Context, start, 
 // GetDetectionTimestamps returns raw detected_at epochs for [start, end), false positives
 // excluded, in no particular order. See the interface doc for why bucketing happens in Go,
 // not SQL.
-func (r *detectionRepository) GetDetectionTimestamps(ctx context.Context, start, end int64, labelID *uint) ([]int64, error) {
+func (r *detectionRepository) GetDetectionTimestamps(ctx context.Context, start, end int64, labelIDs []uint) ([]int64, error) {
 	var timestamps []int64
 	// No ORDER BY: the caller buckets timestamps into a map and sorts the resulting cells
 	// itself, so ordering (potentially millions of) rows in SQL would be wasted work.
-	err := r.buildAnalyticsBaseQuery(ctx, start, end, labelID, nil).
+	err := r.buildAnalyticsBaseQuery(ctx, start, end, labelIDs, nil).
 		Pluck("d.detected_at", &timestamps).Error
 	return timestamps, err
 }
 
 // GetDailyAnalytics returns daily statistics.
-func (r *detectionRepository) GetDailyAnalytics(ctx context.Context, start, end int64, tzOffsetSeconds int, labelID, modelID *uint) ([]DailyAnalyticsData, error) {
+func (r *detectionRepository) GetDailyAnalytics(ctx context.Context, start, end int64, tzOffsetSeconds int, labelIDs []uint, modelID *uint) ([]DailyAnalyticsData, error) {
 	var results []DailyAnalyticsData
 
 	// Group by wall-clock date in the configured timezone (offset-adjusted).
 	// Exclude detections marked as false_positive
 	dateExpr := r.dateFromUnixExpr("d.detected_at", tzOffsetSeconds)
-	query := r.buildAnalyticsBaseQuery(ctx, start, end, labelID, modelID).
+	query := r.buildAnalyticsBaseQuery(ctx, start, end, labelIDs, modelID).
 		Select(fmt.Sprintf(`
 			%s as date,
 			COUNT(*) as total_detections,

--- a/internal/datastore/v2/repository/detection_timestamps_test.go
+++ b/internal/datastore/v2/repository/detection_timestamps_test.go
@@ -31,7 +31,7 @@ func TestGetDetectionTimestamps(t *testing.T) {
 	})
 
 	t.Run("species filter", func(t *testing.T) {
-		got, err := repo.GetDetectionTimestamps(ctx, 500, 5000, &labelA)
+		got, err := repo.GetDetectionTimestamps(ctx, 500, 5000, []uint{labelA})
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []int64{1000, 2000}, got)
 	})

--- a/internal/datastore/v2only/aggregate_species_filter_test.go
+++ b/internal/datastore/v2only/aggregate_species_filter_test.go
@@ -234,3 +234,97 @@ func TestV2OnlyDatastore_HourlyChartsSpeciesFilter(t *testing.T) {
 		assert.Equal(t, "Troglodytes troglodytes", got[1].ScientificName)
 	})
 }
+
+// TestV2OnlyDatastore_SpeciesFilterSpansModels pins the species filter of the single-species
+// time analytics (daily counts, hourly counts, activity heatmap, dawn-chorus onset) to every
+// label of the species, not just the first one.
+//
+// A species has one label per AI model, and each detection references the label of the model
+// that made it. On a multi-model station the first label for a name typically belongs to the
+// permanently installed primary model, which may have no streams assigned; resolving the filter
+// to that single label returned empty results for every species even while the other models
+// were detecting it all day.
+func TestV2OnlyDatastore_SpeciesFilterSpansModels(t *testing.T) {
+	t.Parallel()
+	ds, cleanup := setupTestDatastore(t)
+	t.Cleanup(cleanup)
+	ds.timezone = time.UTC
+	ctx := t.Context()
+
+	const (
+		species   = "Megascops asio"
+		startDate = "2026-03-01"
+		endDate   = "2026-03-02"
+	)
+
+	// The default (primary) model gets the label first, and never detects the species.
+	_, err := ds.label.GetOrCreate(ctx, species, ds.defaultModelID, ds.speciesLabelTypeID, ds.avesClassID)
+	require.NoError(t, err)
+
+	// A second model, the one actually listening, owns every detection.
+	otherModel, err := ds.model.GetOrCreate(ctx, "Perch", "1.0", "default", entities.ModelTypeBird, nil)
+	require.NoError(t, err)
+	otherLabel, err := ds.label.GetOrCreate(ctx, species, otherModel.ID, ds.speciesLabelTypeID, ds.avesClassID)
+	require.NoError(t, err)
+	const calls = 4
+	for i := range calls {
+		require.NoError(t, ds.detection.Save(ctx, &entities.Detection{
+			ModelID:    otherModel.ID,
+			LabelID:    otherLabel.ID,
+			DetectedAt: time.Date(2026, 3, 1, 5, 10*i, 0, 0, time.UTC).Unix(),
+			Confidence: 0.9,
+		}))
+	}
+
+	t.Run("daily counts", func(t *testing.T) {
+		t.Parallel()
+		got, err := ds.GetDailyAnalyticsData(ctx, startDate, endDate, species)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, calls, got[0].Count)
+	})
+
+	t.Run("hourly counts", func(t *testing.T) {
+		t.Parallel()
+		got, err := ds.GetHourlyAnalyticsData(ctx, startDate, species)
+		require.NoError(t, err)
+		total := 0
+		for _, h := range got {
+			total += h.Count
+		}
+		assert.Equal(t, calls, total)
+	})
+
+	t.Run("hourly distribution", func(t *testing.T) {
+		t.Parallel()
+		got, err := ds.GetHourlyDistribution(ctx, startDate, endDate, species)
+		require.NoError(t, err)
+		total := 0
+		for _, h := range got {
+			total += h.Count
+		}
+		assert.Equal(t, calls, total)
+	})
+
+	t.Run("activity heatmap", func(t *testing.T) {
+		t.Parallel()
+		got, err := ds.GetActivityHeatmap(ctx, startDate, endDate, species)
+		require.NoError(t, err)
+		total := 0
+		for _, c := range got.CellCount {
+			total += c
+		}
+		assert.Equal(t, calls, total)
+	})
+
+	t.Run("dawn chorus onset", func(t *testing.T) {
+		t.Parallel()
+		got, err := ds.GetDailyActivityOnset(ctx, startDate, endDate, species)
+		require.NoError(t, err)
+		counted := 0
+		for _, d := range got {
+			counted += d.DetectionCount
+		}
+		assert.Equal(t, calls, counted)
+	})
+}

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -2727,7 +2727,7 @@ func (ds *Datastore) GetHourlyAnalyticsData(ctx context.Context, date, species s
 		return nil, err
 	}
 
-	labelID, err := ds.resolveLabelID(ctx, species)
+	labelIDs, err := ds.resolveLabelIDs(ctx, species)
 	if err != nil {
 		if errors.Is(err, errNotFound) {
 			return []datastore.HourlyAnalyticsData{}, nil
@@ -2735,7 +2735,7 @@ func (ds *Datastore) GetHourlyAnalyticsData(ctx context.Context, date, species s
 		return nil, err
 	}
 
-	v2Data, err := ds.detection.GetHourlyDistribution(ctx, start, end, ds.zoneOffsetSeconds(start), labelID, nil)
+	v2Data, err := ds.detection.GetHourlyDistribution(ctx, start, end, ds.zoneOffsetSeconds(start), labelIDs, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2750,16 +2750,20 @@ func (ds *Datastore) GetHourlyAnalyticsData(ctx context.Context, date, species s
 	return result, nil
 }
 
-// resolveLabelID looks up a label ID for a species name.
-// Returns (nil, nil) if species is empty (no filter).
-// Returns (nil, errNotFound) if species not found.
-// Returns (&id, nil) if found.
-// Returns (nil, err) for other errors.
+
+// errNotFound is returned by resolveLabelIDs when no label carries the species name.
 var errNotFound = errors.NewStd("species not found")
 
-func (ds *Datastore) resolveLabelID(ctx context.Context, species string) (*uint, error) {
+// resolveLabelIDs returns every label ID carrying the species' scientific name. A species has one
+// label per AI model, and detections reference the label of the model that made them, so a species
+// filter must span all of its labels: picking one (the first, which on a multi-model station is
+// typically the permanently installed primary model's) silently excluded every detection from the
+// models actually assigned to the audio streams.
+//
+// Returns (nil, nil) for an empty species (no filter), (nil, errNotFound) when no label matches.
+func (ds *Datastore) resolveLabelIDs(ctx context.Context, species string) ([]uint, error) {
 	if species == "" {
-		return nil, nil //nolint:nilnil // nil means no filter, which is valid
+		return nil, nil
 	}
 	labelIDs, err := ds.label.GetLabelIDsByScientificName(ctx, species)
 	if err != nil {
@@ -2768,7 +2772,7 @@ func (ds *Datastore) resolveLabelID(ctx context.Context, species string) (*uint,
 	if len(labelIDs) == 0 {
 		return nil, errNotFound
 	}
-	return &labelIDs[0], nil
+	return labelIDs, nil
 }
 
 // GetDailyAnalyticsData retrieves daily analytics data.
@@ -2778,7 +2782,7 @@ func (ds *Datastore) GetDailyAnalyticsData(ctx context.Context, startDate, endDa
 		return nil, err
 	}
 
-	labelID, err := ds.resolveLabelID(ctx, species)
+	labelIDs, err := ds.resolveLabelIDs(ctx, species)
 	if err != nil {
 		if errors.Is(err, errNotFound) {
 			return []datastore.DailyAnalyticsData{}, nil
@@ -2788,7 +2792,7 @@ func (ds *Datastore) GetDailyAnalyticsData(ctx context.Context, startDate, endDa
 
 	// Bucket dates by the configured timezone, anchored to a query boundary (start, or end for a
 	// left-open range) so an end-only historical query buckets stably regardless of run time.
-	v2Data, err := ds.detection.GetDailyAnalytics(ctx, start, end, ds.zoneOffsetSeconds(dateRangeOffsetAnchor(start, end)), labelID, nil)
+	v2Data, err := ds.detection.GetDailyAnalytics(ctx, start, end, ds.zoneOffsetSeconds(dateRangeOffsetAnchor(start, end)), labelIDs, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2828,7 +2832,7 @@ func (ds *Datastore) GetHourlyDistribution(ctx context.Context, startDate, endDa
 		return nil, err
 	}
 
-	labelID, err := ds.resolveLabelID(ctx, species)
+	labelIDs, err := ds.resolveLabelIDs(ctx, species)
 	if err != nil {
 		if errors.Is(err, errNotFound) {
 			return []datastore.HourlyDistributionData{}, nil
@@ -2836,7 +2840,7 @@ func (ds *Datastore) GetHourlyDistribution(ctx context.Context, startDate, endDa
 		return nil, err
 	}
 
-	v2Data, err := ds.detection.GetHourlyDistribution(ctx, start, end, ds.zoneOffsetSeconds(start), labelID, nil)
+	v2Data, err := ds.detection.GetHourlyDistribution(ctx, start, end, ds.zoneOffsetSeconds(start), labelIDs, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -3139,7 +3143,7 @@ func (ds *Datastore) GetActivityHeatmap(ctx context.Context, startDate, endDate,
 		return datastore.ActivityHeatmapData{}, err
 	}
 
-	labelID, err := ds.resolveLabelID(ctx, species)
+	labelIDs, err := ds.resolveLabelIDs(ctx, species)
 	if err != nil {
 		if errors.Is(err, errNotFound) {
 			return buildActivityHeatmap(nil, ds.timezone, startDate, endDate)
@@ -3147,7 +3151,7 @@ func (ds *Datastore) GetActivityHeatmap(ctx context.Context, startDate, endDate,
 		return datastore.ActivityHeatmapData{}, err
 	}
 
-	timestamps, err := ds.detection.GetDetectionTimestamps(ctx, start, end, labelID)
+	timestamps, err := ds.detection.GetDetectionTimestamps(ctx, start, end, labelIDs)
 	if err != nil {
 		return datastore.ActivityHeatmapData{}, err
 	}
@@ -3272,7 +3276,7 @@ func (ds *Datastore) GetDailyActivityOnset(ctx context.Context, startDate, endDa
 
 	dawn := ds.civilDawnMinuteLookup()
 
-	labelID, err := ds.resolveLabelID(ctx, species)
+	labelIDs, err := ds.resolveLabelIDs(ctx, species)
 	if err != nil {
 		if errors.Is(err, errNotFound) {
 			return buildDailyActivityOnset(nil, ds.timezone, startDate, endDate, onsetDetectionRank, minOnsetDetections, dawn)
@@ -3280,7 +3284,7 @@ func (ds *Datastore) GetDailyActivityOnset(ctx context.Context, startDate, endDa
 		return nil, err
 	}
 
-	timestamps, err := ds.detection.GetDetectionTimestamps(ctx, start, end, labelID)
+	timestamps, err := ds.detection.GetDetectionTimestamps(ctx, start, end, labelIDs)
 	if err != nil {
 		return nil, errors.New(err).
 			Component("datastore").


### PR DESCRIPTION
## Description

On the v2-only datastore, every species-filtered time analytics route answered empty on a multi-model station: `/analytics/time/daily`, `/analytics/time/daily/batch`, `/analytics/time/heatmap`, `/analytics/time/dawn-onset`, and `/analytics/time/distribution/hourly` with `species=`, while `/analytics/species/summary` and the top-species routes showed the birds plainly.

The cause is in `resolveLabelID`: a species has one label per AI model, each detection references the label of the model that produced it, and the filter was resolved to `labelIDs[0]`, the first label carrying the scientific name. BirdNET v2.4 is always installed and typically owns that first label; when the audio streams are assigned to BirdNET v3.0 and Perch v2 instead, that label has no detections, so the filter matched nothing. On the reporting station (3 RTSP sources, streams on v3.0 + Perch v2) the Eastern Screech-Owl had 1,394 detections in the range and every one of these routes returned zero, which is also why the Activity, Trends and Nocturnal charts in the dashboard spin or show "no data" there.

This PR resolves the filter to all of the species' label IDs and matches with `label_id IN (...)`. The repository's analytics base query and the three methods built on it (`GetHourlyDistribution`, `GetDetectionTimestamps`, `GetDailyAnalytics`) take a label ID slice; nil or empty keeps meaning "no filter", which the interface docs now state so a caller never forwards an empty resolution. No double counting results: the processor stores one detection per audio window regardless of how many models contributed, and the summary routes already grouped by scientific name across labels, so these routes now report the same population.

Verified on the station: the five routes return the same totals the summary reports, and the test fails on the old code (first label on an idle default model, detections on a second model).

## Related issue

Related to the multi-model support work; companion PRs from the same review: daily summary `first_heard` (#4259), `count_in_period` (#4260), detections `source` filter (#4261), dawn-chorus window parameters (#4262).

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/tphakala/birdnet-go/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`go test -race ./...` and/or `npm test`)
- [x] Linters are clean (`golangci-lint run` and/or `npm run check:all`)
- [x] New exports and user-facing changes are documented

## Preflight Status

- [x] Single concern: one fix
- [x] Preflight passed: findings resolved (interface docs state nil-or-empty semantics; stale comment on the old helper removed; the three v2only sites that already spanned labels were confirmed consistent)
- [x] Linters clean: `golangci-lint run`, zero issues
- [x] Tests pass: `go test -race` on `internal/datastore/v2only`, `internal/datastore/v2/repository`, `internal/api/v2/analytics`
- [x] No unrelated changes
- [x] Scope complete; no TODO/FIXME
- [x] No regression/backward-compat break: the `DetectionRepository` interface signature changes for three methods (`*uint` to `[]uint`); the only implementer is in-tree and no generated mock covers it. API shapes unchanged; behaviour changes from empty to correct on multi-model stations
- [x] Breaking changes documented: above
- [x] Maintainer-confirm items: none
- [x] i18n complete: no user-facing strings
- [x] No secrets or PII
- Secondary-model cross-validation: **not run** (no second model authenticated); three single-model review passes.

## Licensing

- [x] My contribution is licensed under **CC BY-NC-SA 4.0**, and I grant the maintainer the right to relicense it under any **OSI-approved open source license**, as described in the [Relicensing Grant](https://github.com/tphakala/birdnet-go/blob/main/CONTRIBUTING.md#relicensing-grant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBXUYwsiTWinmcQbW8Noo7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Species-filtered analytics now include detections across all AI models associated with that species.
  * Improved accuracy for daily and hourly counts, distributions, activity heatmaps, and dawn-chorus onset analytics.

* **Tests**
  * Added coverage confirming species filters return detections from multiple AI models.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->