### PR TITLE
fix(analytics): report the real first-heard time in the daily species summary

### DIFF
--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -92,7 +92,7 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 
 | Method | Route                                 | Handler                    | Auth | Description                        |
 | ------ | ------------------------------------- | -------------------------- | ---- | ---------------------------------- |
-| GET    | `/analytics/species/daily`            | `GetDailySpeciesSummary`   | ❌   | Daily species detection summary    |
+| GET    | `/analytics/species/daily`            | `GetDailySpeciesSummary`   | ❌   | Daily species detection summary (`first_heard` earliest, `latest_heard` latest call of the day) |
 | GET    | `/analytics/species/summary`          | `GetSpeciesSummary`        | ❌   | Overall species statistics         |
 | GET    | `/analytics/species/detections/new`   | `GetNewSpeciesDetections`  | ❌   | Recently detected new species      |
 | GET    | `/analytics/species/thumbnails`       | `GetSpeciesThumbnails`     | ❌   | Species thumbnail images           |

--- a/internal/api/v2/analytics/analytics.go
+++ b/internal/api/v2/analytics/analytics.go
@@ -465,6 +465,16 @@ func (c *Handler) aggregateDailySpeciesData(ctx context.Context, notes []datasto
 	return aggregatedData, nil
 }
 
+// noteFirstTime returns the earliest detection time a per-species summary note carries. The
+// summary queries return one note per species with Time set to the latest detection and
+// FirstTime to the earliest; a note without FirstTime (any other read path) has one time.
+func noteFirstTime(note *datastore.Note) string {
+	if note.FirstTime != "" {
+		return note.FirstTime
+	}
+	return note.Time
+}
+
 // updateAggregatedData updates the aggregated map with note data
 func (c *Handler) updateAggregatedData(aggregatedData map[string]aggregatedBirdInfo, note *datastore.Note, hourlyCounts *[24]int) {
 	birdKey := note.ScientificName
@@ -480,7 +490,7 @@ func (c *Handler) updateAggregatedData(aggregatedData map[string]aggregatedBirdI
 			CommonName:     note.CommonName,
 			ScientificName: note.ScientificName,
 			SpeciesCode:    note.SpeciesCode,
-			First:          note.Time,
+			First:          noteFirstTime(note),
 			Latest:         note.Time,
 		}
 	}
@@ -492,8 +502,8 @@ func (c *Handler) updateAggregatedData(aggregatedData map[string]aggregatedBirdI
 	// across notes defensively in case multiple notes for a species are aggregated.
 	data.MaxConfidence = max(data.MaxConfidence, note.Confidence)
 
-	if note.Time < data.First {
-		data.First = note.Time
+	if first := noteFirstTime(note); first < data.First {
+		data.First = first
 	}
 	if note.Time > data.Latest {
 		data.Latest = note.Time

--- a/internal/api/v2/analytics/daily_summary_first_heard_test.go
+++ b/internal/api/v2/analytics/daily_summary_first_heard_test.go
@@ -1,0 +1,48 @@
+package analytics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+)
+
+// TestUpdateAggregatedData_FirstHeard pins the daily summary's first_heard to the note's
+// FirstTime when the datastore supplies one, and to Time otherwise. The summary queries return
+// one note per species with Time = latest detection, so seeding first_heard from Time made the
+// daily summary report the last call of the day as the first.
+func TestUpdateAggregatedData_FirstHeard(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		note      datastore.Note
+		wantFirst string
+		wantLast  string
+	}{
+		{
+			name:      "summary note carries both times",
+			note:      datastore.Note{ScientificName: "Megascops asio", Time: "07:30:00", FirstTime: "05:00:00"},
+			wantFirst: "05:00:00",
+			wantLast:  "07:30:00",
+		},
+		{
+			name:      "plain note has one time",
+			note:      datastore.Note{ScientificName: "Megascops asio", Time: "07:30:00"},
+			wantFirst: "07:30:00",
+			wantLast:  "07:30:00",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			agg := map[string]aggregatedBirdInfo{}
+			counts := [24]int{5: 1, 7: 2}
+			(&Handler{}).updateAggregatedData(agg, &tt.note, &counts)
+			got := agg[tt.note.ScientificName]
+			assert.Equal(t, tt.wantFirst, got.First)
+			assert.Equal(t, tt.wantLast, got.Latest)
+			assert.Equal(t, 3, got.Count)
+		})
+	}
+}

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -695,6 +695,7 @@ func (ds *DataStore) GetTopBirdsData(ctx context.Context, selectedDate string, m
 		Confidence     float64
 		Date           string
 		Time           string
+		FirstTime      string
 	}
 
 	var results []SpeciesCount
@@ -709,7 +710,7 @@ func (ds *DataStore) GetTopBirdsData(ctx context.Context, selectedDate string, m
 	// Exclude detections marked as false_positive
 	query := ds.DB.WithContext(ctx).Table("notes").
 		Joins("LEFT JOIN note_reviews ON notes.id = note_reviews.note_id").
-		Select("notes.common_name, notes.scientific_name, notes.species_code, COUNT(*) as count, MAX(notes.confidence) as confidence, notes.date, MAX(notes.time) as time").
+		Select("notes.common_name, notes.scientific_name, notes.species_code, COUNT(*) as count, MAX(notes.confidence) as confidence, notes.date, MAX(notes.time) as time, MIN(notes.time) as first_time").
 		Where("notes.date = ? AND notes.confidence >= ?", selectedDate, minConfidenceNormalized).
 		Where("(note_reviews.verified IS NULL OR note_reviews.verified != ?)", string(entities.VerificationFalsePositive)).
 		Group("notes.common_name, notes.scientific_name, notes.species_code, notes.date").
@@ -737,6 +738,7 @@ func (ds *DataStore) GetTopBirdsData(ctx context.Context, selectedDate string, m
 			Confidence:     result.Confidence,
 			Date:           result.Date,
 			Time:           result.Time,
+			FirstTime:      result.FirstTime,
 		}
 
 		// Add this note to our results

--- a/internal/datastore/model.go
+++ b/internal/datastore/model.go
@@ -28,7 +28,12 @@ type Note struct {
 	// internal/datastore/v2/entities). On the legacy v1 datastore the field is
 	// never rehydrated on read, so the detections API returns a nil Source for
 	// historical detections saved through that path.
-	Source      AudioSource         `gorm:"-"`
+	Source AudioSource `gorm:"-"`
+	// FirstTime is runtime-only: the per-species summary queries (GetTopBirdsData) collapse a
+	// day's detections into one Note per species whose Time is the latest detection, and carry
+	// the earliest one here so the daily summary can report first heard and last heard apart.
+	// Empty on every other read path.
+	FirstTime   string              `gorm:"-" json:"-"`
 	Model       detection.ModelInfo `gorm:"-"` // Runtime only: model that produced this detection
 	BeginTime   time.Time
 	EndTime     time.Time

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -1239,6 +1239,7 @@ func (ds *Datastore) GetTopBirdsData(ctx context.Context, selectedDate string, m
 		Count          int     `gorm:"column:count"`
 		MaxConfidence  float64 `gorm:"column:max_confidence"`
 		LatestTime     int64   `gorm:"column:latest_time"`
+		FirstTime      int64   `gorm:"column:first_time"`
 	}
 
 	var results []speciesAggregate
@@ -1255,7 +1256,8 @@ func (ds *Datastore) GetTopBirdsData(ctx context.Context, selectedDate string, m
 			l.scientific_name,
 			COUNT(d.id) as count,
 			MAX(d.confidence) as max_confidence,
-			MAX(d.detected_at) as latest_time
+			MAX(d.detected_at) as latest_time,
+			MIN(d.detected_at) as first_time
 		`).
 		Joins(fmt.Sprintf("JOIN %slabels l ON d.label_id = l.id", prefix)).
 		Joins(fmt.Sprintf("LEFT JOIN %sdetection_reviews dr ON d.id = dr.detection_id", prefix)).
@@ -1276,6 +1278,7 @@ func (ds *Datastore) GetTopBirdsData(ctx context.Context, selectedDate string, m
 	for _, r := range results {
 		// Format the latest time as HH:MM:SS
 		latestTime := time.Unix(r.LatestTime, 0).In(ds.timezone)
+		firstTime := time.Unix(r.FirstTime, 0).In(ds.timezone)
 
 		// Labels may contain legacy concatenated "ScientificName_CommonName" format,
 		// so extract only the scientific name portion.
@@ -1291,6 +1294,7 @@ func (ds *Datastore) GetTopBirdsData(ctx context.Context, selectedDate string, m
 			Confidence:     r.MaxConfidence,
 			Date:           selectedDate,
 			Time:           latestTime.Format(time.TimeOnly),
+			FirstTime:      firstTime.Format(time.TimeOnly),
 		}
 		notes = append(notes, note)
 	}

--- a/internal/datastore/v2only/top_birds_first_time_test.go
+++ b/internal/datastore/v2only/top_birds_first_time_test.go
@@ -1,0 +1,39 @@
+package v2only
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
+)
+
+// TestV2OnlyDatastore_GetTopBirdsData_FirstTime pins the per-species summary note to carry the
+// day's earliest detection as FirstTime alongside the latest one as Time. The daily species
+// summary reported "first heard" from Time, so first and last heard were always the same clock
+// time, the latest one.
+func TestV2OnlyDatastore_GetTopBirdsData_FirstTime(t *testing.T) {
+	t.Parallel()
+	ds, cleanup := setupTestDatastore(t)
+	t.Cleanup(cleanup)
+	ds.timezone = time.UTC
+	ctx := t.Context()
+
+	label, err := ds.label.GetOrCreate(ctx, "Megascops asio", ds.defaultModelID, ds.speciesLabelTypeID, ds.avesClassID)
+	require.NoError(t, err)
+	for _, hm := range [][2]int{{7, 30}, {5, 0}, {6, 15}} {
+		require.NoError(t, ds.detection.Save(ctx, &entities.Detection{
+			ModelID:    ds.defaultModelID,
+			LabelID:    label.ID,
+			DetectedAt: time.Date(2026, 3, 1, hm[0], hm[1], 0, 0, time.UTC).Unix(),
+			Confidence: 0.9,
+		}))
+	}
+
+	notes, err := ds.GetTopBirdsData(ctx, "2026-03-01", 0, 10)
+	require.NoError(t, err)
+	require.Len(t, notes, 1)
+	assert.Equal(t, "07:30:00", notes[0].Time, "Time stays the latest detection")
+	assert.Equal(t, "05:00:00", notes[0].FirstTime, "FirstTime is the earliest detection")
+}


### PR DESCRIPTION
## Description

`/analytics/species/daily` reported `first_heard` equal to `latest_heard` for every species. The handler aggregates from `GetTopBirdsData`, which returns one note per species whose time is `MAX(time)` for the day, and seeded both fields from that single time, so "first heard" was always the last call of the day (an owl with 144 calls in the midnight hour showed `first_heard: 06:40`).

This PR has both stores' per-species summary query also select the earliest time (`MIN(notes.time)` on the legacy store, `MIN(d.detected_at)` on v2) and carry it on the summary note as a runtime-only `Note.FirstTime` (`gorm:"-" json:"-"`, like the existing `Source` and `Model` fields, so no schema or wire change). The handler seeds `first_heard` from it when present and from `Time` otherwise, so every other read path is unchanged.

The dashboard never read `first_heard` from this route (it sorts on `latest_heard`), so no consumer assumed the two were equal. The README row for the route now names the two fields.

## Related issue

None open. Companion PRs from the same review: species label resolution across models (#4258), `count_in_period` (#4260), detections `source` filter (#4261), dawn-chorus window parameters (#4262).

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/tphakala/birdnet-go/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`go test -race ./...` and/or `npm test`)
- [x] Linters are clean (`golangci-lint run` and/or `npm run check:all`)
- [x] New exports and user-facing changes are documented

## Preflight Status

- [x] Single concern: one fix
- [x] Preflight passed: no findings on this concern
- [x] Linters clean: `golangci-lint run`, zero issues
- [x] Tests pass: `go test -race` on `internal/datastore`, `internal/datastore/v2only`, `internal/api/v2/analytics` (two `internal/datastore` tests fail only when run as root, on main as well)
- [x] No unrelated changes
- [x] Scope complete; no TODO/FIXME
- [x] No regression/backward-compat break: no schema change (`gorm:"-"`), no JSON change (`json:"-"`); `MIN` over the same rows `MAX` already scans
- [x] Breaking changes documented: none
- [x] Maintainer-confirm items: none
- [x] i18n complete: no user-facing strings
- [x] No secrets or PII
- Secondary-model cross-validation: **not run**; three single-model review passes.

## Licensing

- [x] My contribution is licensed under **CC BY-NC-SA 4.0**, and I grant the maintainer the right to relicense it under any **OSI-approved open source license**, as described in the [Relicensing Grant](https://github.com/tphakala/birdnet-go/blob/main/CONTRIBUTING.md#relicensing-grant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBXUYwsiTWinmcQbW8Noo7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Daily species summaries now report the earliest detection as “first heard” and the latest detection as “latest heard.”
  - Earliest detection times are consistently preserved in species summary data.

- **Documentation**
  - Clarified the analytics endpoint description to explain that `first_heard` represents the day’s earliest call, while `latest_heard` represents the latest call.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->