### PR TITLE
feat(detections): filter the detections list by audio source

### DIFF
--- a/frontend/src/lib/utils/searchParser.test.ts
+++ b/frontend/src/lib/utils/searchParser.test.ts
@@ -166,9 +166,8 @@ describe('formatFiltersForAPI', () => {
     expect(result).toEqual({ timeOfDay: 'dawn' });
   });
 
-  // location and source are aliases for the same backend dimension (source_node),
-  // exposed by GET /api/v2/detections as the single `location` query param.
-  it('should map source filter to the location API param (shared source_node dimension)', () => {
+  // source: maps to the `source` query param; location: to `location` (node name).
+  it('should map source filter to the source API param', () => {
     const filters = [
       {
         type: 'source' as const,
@@ -179,7 +178,7 @@ describe('formatFiltersForAPI', () => {
     ];
 
     const result = formatFiltersForAPI(filters);
-    expect(result).toEqual({ location: 'rtsp_87b89761' });
+    expect(result).toEqual({ source: 'rtsp_87b89761' });
   });
 
   it('should map location filter to the location API param', () => {

--- a/frontend/src/lib/utils/searchParser.ts
+++ b/frontend/src/lib/utils/searchParser.ts
@@ -601,15 +601,16 @@ export function formatFiltersForAPI(filters: SearchFilter[]): Record<string, str
         params.species = filter.value.toString();
         break;
 
-      // location and source are aliases for the same backend dimension: both map
-      // to the notes.source_node column (datastore AdvancedSearchFilters.Location),
-      // which the GET /api/v2/detections endpoint reads from the `location` query
-      // param. There is no separate `source` param on that endpoint, so source:
-      // intentionally serializes to params.location too. A query that sets both
-      // keys collides on this single param (last one wins) by design.
+      // location: filters by node name (the `location` query param, notes.source_node).
       case 'location':
-      case 'source':
         params.location = filter.value.toString();
+        break;
+
+      // source: filters by audio source (the `source` query param), which the server
+      // resolves by numeric id, display name, node name or source URI. When both are
+      // given the server intersects them.
+      case 'source':
+        params.source = filter.value.toString();
         break;
 
       case 'locked':

--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -135,7 +135,7 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 
 | Method | Route                         | Handler                 | Auth | Description                                |
 | ------ | ----------------------------- | ----------------------- | ---- | ------------------------------------------ |
-| GET    | `/detections`                 | `GetDetections`         | ❌   | List bird detections                       |
+| GET    | `/detections`                 | `GetDetections`         | ❌   | List bird detections; `source` (id from `/analytics/sources`, display name, node name or URI) restricts to an audio source |
 | GET    | `/detections/:id`             | `GetDetection`          | ❌   | Get specific detection                     |
 | GET    | `/detections/recent`          | `GetRecentDetections`   | ❌   | Recent detections                          |
 | GET    | `/detections/:id/time-of-day` | `GetDetectionTimeOfDay` | ❌   | Detection time context                     |

--- a/internal/api/v2/detections/detection_routing_test.go
+++ b/internal/api/v2/detections/detection_routing_test.go
@@ -58,6 +58,11 @@ func TestNeedsAdvancedRouting(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "source triggers advanced",
+			params:   detectionQueryParams{Source: "north"},
+			expected: true,
+		},
+		{
 			name:     "locked triggers advanced",
 			params:   detectionQueryParams{Locked: "true"},
 			expected: true,

--- a/internal/api/v2/detections/detection_routing_test.go
+++ b/internal/api/v2/detections/detection_routing_test.go
@@ -199,3 +199,17 @@ func TestNeedsAdvancedRouting(t *testing.T) {
 		})
 	}
 }
+
+// TestAdvancedSearchCacheKey_NoDelimiterCollision pins that free-text filter values containing
+// the key's own delimiter cannot make two different requests share a cache entry.
+func TestAdvancedSearchCacheKey_NoDelimiterCollision(t *testing.T) {
+	t.Parallel()
+	a := detectionQueryParams{QueryType: queryTypeSearch, Location: "node", Source: "rtsp://camera", Locked: "true"}
+	b := detectionQueryParams{QueryType: queryTypeSearch, Location: "node:rtsp", Source: "//camera", Locked: "true"}
+	assert.NotEqual(t, a.advancedSearchCacheKey(), b.advancedSearchCacheKey())
+
+	same := a
+	assert.Equal(t, a.advancedSearchCacheKey(), same.advancedSearchCacheKey())
+	same.Source = "rtsp://camera2"
+	assert.NotEqual(t, a.advancedSearchCacheKey(), same.advancedSearchCacheKey(), "source must be part of the key")
+}

--- a/internal/api/v2/detections/detections.go
+++ b/internal/api/v2/detections/detections.go
@@ -240,6 +240,7 @@ type detectionQueryParams struct {
 	HourRange  string
 	Verified   string
 	Location   string
+	Source     string
 	Locked     string
 	// Sorting
 	SortBy string
@@ -250,10 +251,10 @@ type detectionQueryParams struct {
 // advancedSearchCacheKey generates a deterministic cache key for advanced search queries.
 // Includes all filter parameters to avoid cache collisions.
 func (p *detectionQueryParams) advancedSearchCacheKey() string {
-	return fmt.Sprintf("adv_search:%s:%s:%d:%d:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%d",
+	return fmt.Sprintf("adv_search:%s:%s:%d:%d:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%d",
 		p.Search, strings.Join(p.SearchScientific, "\x00"), p.NumResults, p.Offset,
 		p.Confidence, p.TimeOfDay, p.HourRange,
-		p.Verified, p.Location, p.Locked,
+		p.Verified, p.Location, p.Source, p.Locked,
 		p.Species, p.Date, p.StartDate+":"+p.EndDate,
 		p.SortBy, p.QueryType, p.Hour, p.Duration)
 }
@@ -274,6 +275,7 @@ func (c *Handler) parseDetectionQueryParams(ctx echo.Context) (*detectionQueryPa
 		HourRange:  ctx.QueryParam("hourRange"),
 		Verified:   ctx.QueryParam("verified"),
 		Location:   ctx.QueryParam("location"),
+		Source:     ctx.QueryParam("source"),
 		Locked:     ctx.QueryParam("locked"),
 		// Sorting
 		SortBy: ctx.QueryParam("sortBy"),
@@ -589,7 +591,7 @@ func (c *Handler) GetDetections(ctx echo.Context) error {
 func (p *detectionQueryParams) needsAdvancedRouting() bool {
 	if p.Confidence != "" || p.TimeOfDay != "" ||
 		p.HourRange != "" || p.Verified != "" ||
-		p.Location != "" || p.Locked != "" ||
+		p.Location != "" || p.Source != "" || p.Locked != "" ||
 		p.StartDate != "" || p.EndDate != "" {
 		return true
 	}
@@ -1108,6 +1110,9 @@ func (c *Handler) buildAdvancedSearchFilters(params *detectionQueryParams) datas
 	}
 	if params.Location != "" {
 		filters.Location = []string{params.Location}
+	}
+	if params.Source != "" {
+		filters.Source = []string{params.Source}
 	}
 
 	// Apply boolean filters

--- a/internal/api/v2/detections/detections.go
+++ b/internal/api/v2/detections/detections.go
@@ -23,6 +23,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/notification"
+	"github.com/tphakala/birdnet-go/internal/privacy"
 	"github.com/tphakala/birdnet-go/internal/suncalc"
 )
 
@@ -249,13 +250,15 @@ type detectionQueryParams struct {
 }
 
 // advancedSearchCacheKey generates a deterministic cache key for advanced search queries.
-// Includes all filter parameters to avoid cache collisions.
+// Includes all filter parameters to avoid cache collisions. Free-text values (search text,
+// species, location, source, which may be URIs) are quoted so a delimiter inside a value
+// cannot make two different requests share a key.
 func (p *detectionQueryParams) advancedSearchCacheKey() string {
-	return fmt.Sprintf("adv_search:%s:%s:%d:%d:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%d",
+	return fmt.Sprintf("adv_search:%q:%q:%d:%d:%q:%q:%q:%q:%q:%q:%q:%q:%q:%q:%q:%q:%q:%q:%d",
 		p.Search, strings.Join(p.SearchScientific, "\x00"), p.NumResults, p.Offset,
 		p.Confidence, p.TimeOfDay, p.HourRange,
 		p.Verified, p.Location, p.Source, p.Locked,
-		p.Species, p.Date, p.StartDate+":"+p.EndDate,
+		p.Species, p.Date, p.StartDate, p.EndDate,
 		p.SortBy, p.QueryType, p.Hour, p.Duration)
 }
 
@@ -1042,8 +1045,9 @@ func (c *Handler) getSearchDetectionsAdvanced(params *detectionQueryParams) ([]d
 
 	notes, totalCount, err := c.DS.SearchNotesAdvanced(&filters)
 	if err != nil {
+		// Filters carry request text, and a source value may be a URI with credentials.
 		c.LogErrorIfEnabled("Failed to perform advanced search",
-			logger.String("filters", fmt.Sprintf("%+v", filters)),
+			logger.String("filters", privacy.ScrubMessage(fmt.Sprintf("%+v", filters))),
 			logger.Error(err),
 		)
 		return nil, 0, err

--- a/internal/datastore/search_advanced.go
+++ b/internal/datastore/search_advanced.go
@@ -29,11 +29,16 @@ type AdvancedSearchFilters struct {
 	Verified          *bool
 	Species           []string
 	Location          []string // Maps to source_node column
-	Locked            *bool
-	SortAscending     bool
-	SortBy            string // "date_desc", "date_asc", "species_asc", "species_desc", "confidence_asc", "confidence_desc", "status", or SortBySearchDefault
-	Limit             int
-	Offset            int
+	// Source restricts results to audio sources, each given as the source's numeric ID (as listed
+	// by /analytics/sources), its display name, node name, or source URI. The v2 store resolves it
+	// against the audio_sources table; the legacy store, which records only the node name per
+	// note, matches it against source_node, so only node-name values select rows there.
+	Source        []string
+	Locked        *bool
+	SortAscending bool
+	SortBy        string // "date_desc", "date_asc", "species_asc", "species_desc", "confidence_asc", "confidence_desc", "status", or SortBySearchDefault
+	Limit         int
+	Offset        int
 	// MinID filters to records with ID > MinID (cursor-based pagination for migration)
 	MinID uint
 	// CursorPagination indicates this query uses cursor-based pagination and must
@@ -107,6 +112,11 @@ func (ds *DataStore) SearchNotesAdvanced(filters *AdvancedSearchFilters) ([]Note
 	// Apply location/source filter (source_node column in notes table)
 	if len(filters.Location) > 0 {
 		query = query.Where("source_node IN ?", filters.Location)
+	}
+	// The legacy schema records only the node per note, so a source filter can select rows only
+	// by node name; any other spelling matches nothing rather than everything.
+	if len(filters.Source) > 0 {
+		query = query.Where("source_node IN ?", filters.Source)
 	}
 
 	// Apply verified filter

--- a/internal/datastore/search_advanced.go
+++ b/internal/datastore/search_advanced.go
@@ -16,6 +16,10 @@ import (
 const SortBySearchDefault = "search_default"
 
 // AdvancedSearchFilters represents all possible search filters from the frontend
+// sourceNodeInPredicate selects notes by the node that recorded them; both the location and
+// source filters resolve to it on the legacy schema.
+const sourceNodeInPredicate = "source_node IN ?"
+
 type AdvancedSearchFilters struct {
 	TextQuery string
 	// SpeciesScientific contains exact scientific names that are OR-ed with
@@ -111,12 +115,12 @@ func (ds *DataStore) SearchNotesAdvanced(filters *AdvancedSearchFilters) ([]Note
 
 	// Apply location/source filter (source_node column in notes table)
 	if len(filters.Location) > 0 {
-		query = query.Where("source_node IN ?", filters.Location)
+		query = query.Where(sourceNodeInPredicate, filters.Location)
 	}
 	// The legacy schema records only the node per note, so a source filter can select rows only
 	// by node name; any other spelling matches nothing rather than everything.
 	if len(filters.Source) > 0 {
-		query = query.Where("source_node IN ?", filters.Source)
+		query = query.Where(sourceNodeInPredicate, filters.Source)
 	}
 
 	// Apply verified filter

--- a/internal/datastore/v2/repository/filter_conversion.go
+++ b/internal/datastore/v2/repository/filter_conversion.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"maps"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -342,6 +343,79 @@ func ResolveSpeciesToLabelIDs(ctx context.Context, deps *FilterLookupDeps, speci
 	}
 
 	return labelIDs, nil
+}
+
+// ResolveSourcesToSourceIDs maps the public source filter values to audio source IDs. Each value
+// is the source's numeric ID (as /analytics/sources lists it) or a name, which goes through the
+// same matching as the search endpoint's device filter (ResolveDeviceToSourceIDs: node name,
+// display name or source URI, case-insensitively, exact before substring). Returns nil for an
+// empty filter and sentinelNoMatchIDs when nothing matches, so an unknown source yields no rows
+// rather than every row.
+func ResolveSourcesToSourceIDs(ctx context.Context, deps *FilterLookupDeps, sources []string) ([]uint, error) {
+	if len(sources) == 0 {
+		return nil, nil
+	}
+	if deps == nil || deps.SourceRepo == nil {
+		return nil, nil
+	}
+	var groups [][]uint
+	for _, want := range sources {
+		want = strings.TrimSpace(want)
+		if want == "" {
+			continue
+		}
+		if id, ok := parseSourceID(want); ok {
+			groups = append(groups, []uint{id})
+			continue
+		}
+		ids, err := ResolveDeviceToSourceIDs(ctx, deps, want)
+		if err != nil {
+			return nil, err
+		}
+		if len(ids) > 0 && ids[0] != sentinelNoMatchIDs[0] {
+			groups = append(groups, ids)
+		}
+	}
+	merged := mergeUniqueIDs(groups...)
+	if len(merged) == 0 {
+		return sentinelNoMatchIDs, nil
+	}
+	return merged, nil
+}
+
+// parseSourceID reports whether s is a positive decimal integer and returns it.
+func parseSourceID(s string) (id uint, ok bool) {
+	n, err := strconv.ParseUint(s, 10, 32)
+	if err != nil || n == 0 {
+		return 0, false
+	}
+	return uint(n), true
+}
+
+// intersectSourceIDs combines the location and source filters: nil means "no filter" on either
+// side, so the other side wins; when both are set only sources in both survive, and an empty
+// intersection becomes the no-match sentinel.
+func intersectSourceIDs(a, b []uint) []uint {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	inB := make(map[uint]struct{}, len(b))
+	for _, id := range b {
+		inB[id] = struct{}{}
+	}
+	out := make([]uint, 0, len(a))
+	for _, id := range a {
+		if _, ok := inB[id]; ok {
+			out = append(out, id)
+		}
+	}
+	if len(out) == 0 {
+		return sentinelNoMatchIDs
+	}
+	return out
 }
 
 // ResolveLocationsToSourceIDs converts location/node names to audio source IDs.
@@ -848,6 +922,11 @@ func ConvertAdvancedFilters(
 		if err != nil {
 			return nil, err
 		}
+		sourceIDs, err := ResolveSourcesToSourceIDs(ctx, deps, filters.Source)
+		if err != nil {
+			return nil, err
+		}
+		sf.AudioSourceIDs = intersectSourceIDs(sf.AudioSourceIDs, sourceIDs)
 	}
 
 	return sf, nil

--- a/internal/datastore/v2/repository/filter_conversion.go
+++ b/internal/datastore/v2/repository/filter_conversion.go
@@ -350,14 +350,15 @@ func ResolveSpeciesToLabelIDs(ctx context.Context, deps *FilterLookupDeps, speci
 // same matching as the search endpoint's device filter (ResolveDeviceToSourceIDs: node name,
 // display name or source URI, case-insensitively, exact before substring). Returns nil for an
 // empty filter and sentinelNoMatchIDs when nothing matches, so an unknown source yields no rows
-// rather than every row.
+// rather than every row. Without a source repository only numeric IDs can match.
 func ResolveSourcesToSourceIDs(ctx context.Context, deps *FilterLookupDeps, sources []string) ([]uint, error) {
 	if len(sources) == 0 {
 		return nil, nil
 	}
-	if deps == nil || deps.SourceRepo == nil {
-		return nil, nil
-	}
+	// Numeric IDs need no lookup, so a filter is still applied when no source repository is
+	// wired; names then match nothing rather than being dropped, so the response is never
+	// silently unfiltered.
+	haveRepo := deps != nil && deps.SourceRepo != nil
 	var groups [][]uint
 	for _, want := range sources {
 		want = strings.TrimSpace(want)
@@ -366,6 +367,9 @@ func ResolveSourcesToSourceIDs(ctx context.Context, deps *FilterLookupDeps, sour
 		}
 		if id, ok := parseSourceID(want); ok {
 			groups = append(groups, []uint{id})
+			continue
+		}
+		if !haveRepo {
 			continue
 		}
 		ids, err := ResolveDeviceToSourceIDs(ctx, deps, want)

--- a/internal/datastore/v2/repository/filter_conversion_test.go
+++ b/internal/datastore/v2/repository/filter_conversion_test.go
@@ -1423,3 +1423,78 @@ func TestResolveDeviceToSourceIDs(t *testing.T) {
 		assert.Equal(t, []uint{0}, result)
 	})
 }
+
+// mockAllSourceRepository serves GetAll from a fixed list, for the source filter resolver.
+type mockAllSourceRepository struct {
+	mockAudioSourceRepository
+	all []*entities.AudioSource
+}
+
+func (m *mockAllSourceRepository) GetAll(_ context.Context) ([]*entities.AudioSource, error) {
+	return m.all, nil
+}
+
+// TestResolveSourcesToSourceIDs pins the public source filter: a value matches a source by its
+// numeric ID, display name or node name (names case-insensitively); nothing matching yields the
+// no-match sentinel rather than no filter.
+func TestResolveSourcesToSourceIDs(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	deps := &FilterLookupDeps{SourceRepo: &mockAllSourceRepository{all: []*entities.AudioSource{
+		{ID: 1, NodeName: "station", DisplayName: new("back")},
+		{ID: 2, NodeName: "station", DisplayName: new("north")},
+		{ID: 3, NodeName: "garage-pi", DisplayName: nil},
+	}}}
+
+	tests := []struct {
+		name    string
+		sources []string
+		want    []uint
+	}{
+		{name: "empty is no filter", sources: nil, want: nil},
+		{name: "numeric id", sources: []string{"2"}, want: []uint{2}},
+		{name: "display name, any case", sources: []string{"NORTH"}, want: []uint{2}},
+		{name: "node name matches every source on the node", sources: []string{"station"}, want: []uint{1, 2}},
+		{name: "node name without display name", sources: []string{"garage-pi"}, want: []uint{3}},
+		{name: "several values union", sources: []string{"back", "3"}, want: []uint{1, 3}},
+		{name: "unknown yields no match", sources: []string{"doorbell"}, want: sentinelNoMatchIDs},
+		{name: "zero is not an id", sources: []string{"0"}, want: sentinelNoMatchIDs},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ResolveSourcesToSourceIDs(ctx, deps, tt.sources)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	t.Run("nil deps is no filter", func(t *testing.T) {
+		t.Parallel()
+		got, err := ResolveSourcesToSourceIDs(ctx, nil, []string{"north"})
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+}
+
+// TestIntersectSourceIDs pins how the location (node) and source filters combine.
+func TestIntersectSourceIDs(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		a, b []uint
+		want []uint
+	}{
+		{name: "both unset", a: nil, b: nil, want: nil},
+		{name: "only source set", a: nil, b: []uint{2}, want: []uint{2}},
+		{name: "only location set", a: []uint{1, 2}, b: nil, want: []uint{1, 2}},
+		{name: "overlap", a: []uint{1, 2}, b: []uint{2, 3}, want: []uint{2}},
+		{name: "disjoint is no match", a: []uint{1}, b: []uint{2}, want: sentinelNoMatchIDs},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, intersectSourceIDs(tt.a, tt.b))
+		})
+	}
+}

--- a/internal/datastore/v2/repository/filter_conversion_test.go
+++ b/internal/datastore/v2/repository/filter_conversion_test.go
@@ -1469,11 +1469,14 @@ func TestResolveSourcesToSourceIDs(t *testing.T) {
 		})
 	}
 
-	t.Run("nil deps is no filter", func(t *testing.T) {
+	t.Run("nil deps: names match nothing, ids still apply", func(t *testing.T) {
 		t.Parallel()
 		got, err := ResolveSourcesToSourceIDs(ctx, nil, []string{"north"})
 		require.NoError(t, err)
-		assert.Nil(t, got)
+		assert.Equal(t, sentinelNoMatchIDs, got, "a name cannot be resolved without a repository, so it must not drop the filter")
+		got, err = ResolveSourcesToSourceIDs(ctx, nil, []string{"north", "2"})
+		require.NoError(t, err)
+		assert.Equal(t, []uint{2}, got)
 	})
 }
 


### PR DESCRIPTION
## Description

`GET /api/v2/detections` had no way to ask for one audio source. Its only source-related filter, `location`, matches the station's node name, so a station listening on several RTSP sources (three here) could not list detections from one of them, even though the v2 store keys every detection by source and `POST /detections/search` already resolves a device name.

This PR adds a `source` query parameter taking the source's numeric ID (as `/analytics/sources` lists it), its display name, node name, or source URI. Names go through the same `ResolveDeviceToSourceIDs` matching the search endpoint uses (case-insensitive, exact before substring), so the two entry points agree; an unknown source yields no rows rather than every row, and when `location` is also given the two intersect. The legacy store, which records only the node name per note, applies the value to `source_node`, so node names work there and other spellings match nothing. The parameter is part of the advanced-search cache key (the first review caught that it was not, which made responses stick to the first source asked for). The frontend's `source:` search token now serializes to this parameter instead of aliasing `location`.

Verified on the station: `source=north`, `source=2` and `source=doorbell` return only that source's detections; `source=nosuch` returns none.

## Related issue

None open. Companion PRs from the same review: species label resolution across models (#4258), daily summary `first_heard` (#4259), `count_in_period` (#4260), dawn-chorus window parameters (#4262).

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/tphakala/birdnet-go/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`go test -race ./...` and/or `npm test`)
- [x] Linters are clean (`golangci-lint run` and/or `npm run check:all`)
- [x] New exports and user-facing changes are documented

## Preflight Status

- [x] Single concern: one feature, end to end (API, both stores, cache key, frontend token, README)
- [x] Preflight passed: findings resolved (cache key includes `source`; resolver reuses `ResolveDeviceToSourceIDs`; legacy store honours node names instead of ignoring the filter; dead error check removed; misplaced doc comment restored; frontend `searchParser` updated with its tests)
- [x] Linters clean: `golangci-lint run` zero issues; `eslint` and `prettier --check` clean on the two frontend files
- [x] Tests pass: `go test -race` on `internal/datastore/v2/repository`, `internal/api/v2/detections`; `vitest` on `searchParser.test.ts` (35 passed)
- [x] No unrelated changes
- [x] Scope complete; no TODO/FIXME
- [x] No regression/backward-compat break: additive parameter; `location` unchanged; the frontend `source:` token changes meaning from node name to source (it now also matches display names, which is what the token name says)
- [x] Breaking changes documented: above
- [x] Maintainer-confirm items: none
- [x] i18n complete: no user-facing strings added
- [x] No secrets or PII
- Secondary-model cross-validation: **not run**; three single-model review passes.

## Licensing

- [x] My contribution is licensed under **CC BY-NC-SA 4.0**, and I grant the maintainer the right to relicense it under any **OSI-approved open source license**, as described in the [Relicensing Grant](https://github.com/tphakala/birdnet-go/blob/main/CONTRIBUTING.md#relicensing-grant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBXUYwsiTWinmcQbW8Noo7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `source` filter for detection searches.
  - Sources can be matched by ID, display name, node name, or URI.
  - Source and location filters can be combined to narrow results.
  - Multiple source values are supported.

- **Bug Fixes**
  - Corrected filtering when both source and location criteria are provided.
  - Improved detection search reliability for source-based queries.
  - Sensitive source details are protected in advanced-search error logs.

- **Documentation**
  - Documented the optional `source` query parameter for detection searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->