### PR TITLE
feat(insights): let callers size the dawn-chorus window

### DIFF
--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -541,6 +541,7 @@ Requires enhanced (v2) database. Returns 409 Conflict if not available.
 **Query Parameters:**
 
 - All insights endpoints accept optional `model_id` query parameter to filter by BirdNET model
+- `/insights/dawn-chorus` also accepts `period_days` (default 30, 1 to 365) and `min_days` (default 3, clamped to `period_days`); the response echoes both as `period_days` and `min_days`
 
 ### Models (`models/models.go`)
 

--- a/internal/api/v2/analytics/insights.go
+++ b/internal/api/v2/analytics/insights.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -35,6 +36,7 @@ const (
 	dawnChorusStartHour         = 4
 	dawnChorusEndHour           = 10
 	dawnChorusMinDaysObserved   = 3
+	dawnChorusMaxPeriodDays     = 365
 	migrationRecentDays         = 14
 	migrationMinTotalDetections = 5
 	expectedTodayWindowDays     = 3  // +/- days around today's DOY
@@ -95,6 +97,7 @@ type PhantomSpeciesItem struct {
 type DawnChorusResponse struct {
 	Species    []DawnChorusItem `json:"species"`
 	PeriodDays int              `json:"period_days"`
+	MinDays    int              `json:"min_days"`
 	StartHour  int              `json:"start_hour"`
 	EndHour    int              `json:"end_hour"`
 }
@@ -466,8 +469,34 @@ func (c *Handler) GetDawnChorus(ctx echo.Context) error {
 	return c.getDawnChorusImpl(ctx)
 }
 
+// parseBoundedDays parses a day-count query value. Absent falls back to def; a value that is not
+// a positive integer is an error, like the package's other integer parameters; the result is
+// clamped to maxDays (the default too, so min_days never exceeds period_days).
+func parseBoundedDays(raw string, def, maxDays int) (int, error) {
+	n := def
+	if raw != "" {
+		v, err := strconv.Atoi(raw)
+		if err != nil || v < 1 {
+			return 0, fmt.Errorf("must be a positive integer")
+		}
+		n = v
+	}
+	if n > maxDays {
+		n = maxDays
+	}
+	return n, nil
+}
+
 func (c *Handler) getDawnChorusImpl(ctx echo.Context) error {
-	since := time.Now().AddDate(0, 0, -dawnChorusPeriodDays).Unix()
+	periodDays, err := parseBoundedDays(ctx.QueryParam("period_days"), dawnChorusPeriodDays, dawnChorusMaxPeriodDays)
+	if err != nil {
+		return c.HandleError(ctx, err, "period_days must be a positive integer", http.StatusBadRequest)
+	}
+	minDays, err := parseBoundedDays(ctx.QueryParam("min_days"), dawnChorusMinDaysObserved, periodDays)
+	if err != nil {
+		return c.HandleError(ctx, err, "min_days must be a positive integer", http.StatusBadRequest)
+	}
+	since := time.Now().AddDate(0, 0, -periodDays).Unix()
 
 	reqCtx, cancel := context.WithTimeout(ctx.Request().Context(), insightsQueryTimeout)
 	defer cancel()
@@ -511,7 +540,7 @@ func (c *Handler) getDawnChorusImpl(ctx echo.Context) error {
 
 	items := make([]DawnChorusItem, 0, len(speciesMap))
 	for _, sd := range speciesMap {
-		if sd.daysObserved < dawnChorusMinDaysObserved {
+		if sd.daysObserved < minDays {
 			continue
 		}
 		avgSeconds := sd.secondsSum / sd.daysObserved
@@ -531,7 +560,8 @@ func (c *Handler) getDawnChorusImpl(ctx echo.Context) error {
 
 	return ctx.JSON(http.StatusOK, DawnChorusResponse{
 		Species:    items,
-		PeriodDays: dawnChorusPeriodDays,
+		PeriodDays: periodDays,
+		MinDays:    minDays,
 		StartHour:  dawnChorusStartHour,
 		EndHour:    dawnChorusEndHour,
 	})

--- a/internal/api/v2/analytics/insights_test.go
+++ b/internal/api/v2/analytics/insights_test.go
@@ -391,3 +391,72 @@ func TestSecondsToTimeString(t *testing.T) {
 	assert.Equal(t, "00:00", secondsToTimeString(0))
 	assert.Equal(t, "23:59", secondsToTimeString(23*3600+59*60))
 }
+
+// TestGetDawnChorus_PeriodAndMinDays pins the period_days and min_days query parameters: the
+// window and the days-observed threshold follow the request (bounded), and the response echoes
+// both so a caller can see what it got. A two-day-old station asking for min_days=1 sees its
+// chorus instead of an empty list.
+func TestGetDawnChorus_PeriodAndMinDays(t *testing.T) {
+	t.Parallel()
+	loc := time.Local
+	day := func(d, h int) int64 { return time.Date(2026, 3, d, h, 0, 0, 0, loc).Unix() }
+	mockRepo := &mockInsightsRepo{
+		dawnChorusRaw: []repository.DawnChorusRawEntry{
+			{ScientificName: "Parus major", Date: "2026-03-01", EarliestAt: day(1, 5)},
+			{ScientificName: "Parus major", Date: "2026-03-02", EarliestAt: day(2, 5)},
+			{ScientificName: "Turdus merula", Date: "2026-03-02", EarliestAt: day(2, 6)},
+		},
+	}
+	e, controller := setupInsightsTestController(t, mockRepo)
+
+	tests := []struct {
+		name        string
+		query       string
+		wantPeriod  int
+		wantMinDays int
+		wantSpecies []string
+	}{
+		{name: "defaults", query: "", wantPeriod: dawnChorusPeriodDays, wantMinDays: dawnChorusMinDaysObserved, wantSpecies: []string{}},
+		{name: "young station", query: "?period_days=7&min_days=1", wantPeriod: 7, wantMinDays: 1, wantSpecies: []string{"Parus major", "Turdus merula"}},
+		{name: "two days observed", query: "?period_days=7&min_days=2", wantPeriod: 7, wantMinDays: 2, wantSpecies: []string{"Parus major"}},
+		{name: "period is bounded", query: "?period_days=9999", wantPeriod: dawnChorusMaxPeriodDays, wantMinDays: dawnChorusMinDaysObserved, wantSpecies: []string{}},
+		{name: "min days cannot exceed period", query: "?period_days=2&min_days=5", wantPeriod: 2, wantMinDays: 2, wantSpecies: []string{"Parus major"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(http.MethodGet, "/api/v2/insights/dawn-chorus"+tt.query, http.NoBody)
+			rec := httptest.NewRecorder()
+			ctx := e.NewContext(req, rec)
+			require.NoError(t, controller.getDawnChorusImpl(ctx))
+			assert.Equal(t, http.StatusOK, rec.Code)
+
+			var resp DawnChorusResponse
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			assert.Equal(t, tt.wantPeriod, resp.PeriodDays)
+			assert.Equal(t, tt.wantMinDays, resp.MinDays)
+			got := make([]string, 0, len(resp.Species))
+			for _, s := range resp.Species {
+				got = append(got, s.ScientificName)
+			}
+			assert.ElementsMatch(t, tt.wantSpecies, got)
+		})
+	}
+}
+
+// TestGetDawnChorus_RejectsMalformedDays pins the package convention that a malformed integer
+// parameter is a 400, not a silent fallback.
+func TestGetDawnChorus_RejectsMalformedDays(t *testing.T) {
+	t.Parallel()
+	e, controller := setupInsightsTestController(t, &mockInsightsRepo{})
+	for _, q := range []string{"?period_days=abc", "?period_days=0", "?min_days=-2", "?min_days=x"} {
+		t.Run(q, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(http.MethodGet, "/api/v2/insights/dawn-chorus"+q, http.NoBody)
+			rec := httptest.NewRecorder()
+			ctx := e.NewContext(req, rec)
+			_ = controller.getDawnChorusImpl(ctx)
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+		})
+	}
+}


### PR DESCRIPTION
## Description

`/insights/dawn-chorus` always looked back 30 days and required three observed days per species, with no way for a caller to change either. A station a day or two old therefore got an empty list, and a caller could not ask for a shorter or longer view than the fixed month.

This PR accepts `period_days` (default 30, clamped to 365) and `min_days` (default 3, clamped to `period_days`), rejects malformed values with 400 like the package's other integer parameters, and echoes both in the response as `period_days` and `min_days` so the caller sees what was applied. Defaults are unchanged, so a request with no parameters returns exactly what it did. Verified on a two-day-old station: `?period_days=7&min_days=1` lists the owls and the dawn singers, the default still returns an empty list until three days are observed.

## Related issue

None open. Companion PRs from the same review: species label resolution across models (#4258), daily summary `first_heard` (#4259), `count_in_period` (#4260), detections `source` filter (#4261).

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/tphakala/birdnet-go/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`go test -race ./...` and/or `npm test`)
- [x] Linters are clean (`golangci-lint run` and/or `npm run check:all`)
- [x] New exports and user-facing changes are documented

## Preflight Status

- [x] Single concern: one small feature
- [x] Preflight passed: findings resolved (malformed values now 400 instead of a silent fallback, matching `parseNonNegativeInt`; README insights section lists the parameters)
- [x] Linters clean: `golangci-lint run`, zero issues
- [x] Tests pass: `go test -race` on `internal/api/v2/analytics`
- [x] No unrelated changes
- [x] Scope complete; no TODO/FIXME
- [x] No regression/backward-compat break: additive parameters and one additive response field; defaults unchanged; no frontend consumer of this route
- [x] Breaking changes documented: none
- [x] Maintainer-confirm items: none
- [x] i18n complete: no user-facing strings
- [x] No secrets or PII
- Secondary-model cross-validation: **not run**; three single-model review passes.

## Licensing

- [x] My contribution is licensed under **CC BY-NC-SA 4.0**, and I grant the maintainer the right to relicense it under any **OSI-approved open source license**, as described in the [Relicensing Grant](https://github.com/tphakala/birdnet-go/blob/main/CONTRIBUTING.md#relicensing-grant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBXUYwsiTWinmcQbW8Noo7
