### PR TITLE
feat(audiocore): log FFmpeg stderr tail when a stream process exits

### DIFF
--- a/internal/audiocore/ffmpeg/bounded_buffer_test.go
+++ b/internal/audiocore/ffmpeg/bounded_buffer_test.go
@@ -292,6 +292,14 @@ func TestStderrLogTail(t *testing.T) {
 			want:     "cccc\ndddd",
 		},
 		{
+			// The cut lands exactly on a newline, so the first retained line is
+			// complete and must be kept rather than dropped.
+			name:     "cut on line boundary keeps complete first line",
+			input:    "aaaa\nbbbb\ncccc\n",
+			maxBytes: 10, // last 10 bytes = "bbbb\ncccc\n"; cut sits right after a newline
+			want:     "bbbb\ncccc",
+		},
+		{
 			name:     "single long line over cap keeps trailing bytes",
 			input:    "0123456789abcdef",
 			maxBytes: 6,
@@ -367,6 +375,30 @@ func TestStream_stderrTailForLog(t *testing.T) {
 		// host and path may remain for debugging.
 		assert.NotContains(t, got, "secret", "URL password must be redacted")
 		assert.NotContains(t, got, "user:", "URL username must be redacted")
+	})
+
+	t.Run("redacts credentials that straddle the tail boundary", func(t *testing.T) {
+		t.Parallel()
+		s := &Stream{}
+		// One long line with no newlines (so the partial-line drop cannot remove
+		// the fragment), sized so the last stderrLogTailMaxBytes bytes begin right
+		// after the URL scheme. If the tail were taken before sanitizing, only
+		// "user:secret@..." would remain and evade URL redaction. Sanitizing the
+		// whole capture first strips the credential regardless of the cut point.
+		url := "rtsp://user:secret@cam.example.com/stream"
+		// tail length 2014 makes the cut land at urlStart+7 (just past "rtsp://").
+		full := strings.Repeat("x", 50) + url + strings.Repeat("y", stderrLogTailMaxBytes-34)
+		_, err := s.stderr.Write([]byte(full))
+		require.NoError(t, err)
+		require.Greater(t, len(full), stderrLogTailMaxBytes, "input must exceed the cap to force truncation")
+
+		got := s.stderrTailForLog()
+		assert.NotContains(t, got, "secret", "credential must be redacted even when the URL straddles the tail cut")
+		assert.NotContains(t, got, "user:", "credential username must be redacted across the boundary")
+		// The host survives redaction and lies in the retained window, proving the
+		// URL region was kept and sanitized rather than simply truncated away.
+		assert.Contains(t, got, "cam.example.com", "host should remain after credential redaction")
+		assert.LessOrEqual(t, len(got), stderrLogTailMaxBytes)
 	})
 
 	t.Run("bounds snippet to the log tail cap", func(t *testing.T) {

--- a/internal/audiocore/ffmpeg/bounded_buffer_test.go
+++ b/internal/audiocore/ffmpeg/bounded_buffer_test.go
@@ -264,3 +264,128 @@ func TestThreadSafeWriter_ConcurrentBounded(t *testing.T) {
 	assert.LessOrEqual(t, len(buf.buf), 1024,
 		"retained bytes must stay within the cap under concurrent writes")
 }
+
+// TestStderrLogTail verifies the pure tail-extraction used for the
+// stderr-on-exit log field: trailing-byte capping, leading-partial-line drop,
+// whitespace trimming, and the maxBytes <= 0 passthrough.
+func TestStderrLogTail(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		maxBytes int
+		want     string
+	}{
+		{name: "empty", input: "", maxBytes: 16, want: ""},
+		{name: "whitespace only", input: "  \n\t\n ", maxBytes: 16, want: ""},
+		{
+			name:     "under cap returned trimmed",
+			input:    "line one\nline two\n",
+			maxBytes: 64,
+			want:     "line one\nline two",
+		},
+		{
+			name:     "over cap keeps trailing window on line boundary",
+			input:    "aaaa\nbbbb\ncccc\ndddd\n",
+			maxBytes: 12, // last 12 bytes = "b\ncccc\ndddd\n"; partial "b" line dropped
+			want:     "cccc\ndddd",
+		},
+		{
+			name:     "single long line over cap keeps trailing bytes",
+			input:    "0123456789abcdef",
+			maxBytes: 6,
+			want:     "abcdef",
+		},
+		{
+			// The window's only newline is its last byte, so the partial-line
+			// drop is skipped (nl+1 < len(s) is false) and TrimSpace removes the
+			// trailing newline rather than collapsing to "".
+			name:     "trailing newline is last byte in window",
+			input:    "xxabc\n",
+			maxBytes: 4,
+			want:     "abc",
+		},
+		{
+			name:     "non-positive maxBytes returns whole trimmed input",
+			input:    "  keep everything  ",
+			maxBytes: 0,
+			want:     "keep everything",
+		},
+		{
+			name:     "negative maxBytes returns whole trimmed input",
+			input:    "\nkeep\n",
+			maxBytes: -1,
+			want:     "keep",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := stderrLogTail(tt.input, tt.maxBytes)
+			assert.Equal(t, tt.want, got)
+			if tt.maxBytes > 0 {
+				assert.LessOrEqual(t, len(got), tt.maxBytes,
+					"result must not exceed the cap")
+			}
+		})
+	}
+}
+
+// TestStream_stderrTailForLog verifies the Stream method reads the captured
+// stderr under its mutex, sanitizes FFmpeg memory-address prefixes, returns ""
+// when nothing was captured, and bounds the snippet to stderrLogTailMaxBytes.
+func TestStream_stderrTailForLog(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty buffer returns empty", func(t *testing.T) {
+		t.Parallel()
+		s := &Stream{}
+		assert.Empty(t, s.stderrTailForLog())
+	})
+
+	t.Run("strips ffmpeg memory-address prefix", func(t *testing.T) {
+		t.Parallel()
+		s := &Stream{}
+		_, err := s.stderr.Write([]byte("[rtsp @ 0x55d4a4808980] method DESCRIBE failed: 404 Not Found\n"))
+		require.NoError(t, err)
+
+		got := s.stderrTailForLog()
+		assert.NotContains(t, got, "0x55d4a4808980", "memory address must be sanitized")
+		assert.Contains(t, got, "404 Not Found", "diagnostic message must be preserved")
+	})
+
+	t.Run("redacts URL credentials", func(t *testing.T) {
+		t.Parallel()
+		s := &Stream{}
+		_, err := s.stderr.Write([]byte("Error opening input file rtsp://user:secret@cam.example.com:554/stream.\n"))
+		require.NoError(t, err)
+
+		got := s.stderrTailForLog()
+		// Credentials embedded in a stream URL must never reach the log; the
+		// host and path may remain for debugging.
+		assert.NotContains(t, got, "secret", "URL password must be redacted")
+		assert.NotContains(t, got, "user:", "URL username must be redacted")
+	})
+
+	t.Run("bounds snippet to the log tail cap", func(t *testing.T) {
+		t.Parallel()
+		s := &Stream{}
+		// Write far more than the log tail cap as distinct newline-terminated lines.
+		var written strings.Builder
+		for i := range 4000 {
+			line := "ffmpeg diagnostic line number " + strings.Repeat("x", i%5) + "\n"
+			written.WriteString(line)
+			_, err := s.stderr.Write([]byte(line))
+			require.NoError(t, err)
+		}
+		got := s.stderrTailForLog()
+		assert.NotEmpty(t, got)
+		assert.LessOrEqual(t, len(got), stderrLogTailMaxBytes,
+			"logged tail must not exceed the log tail cap")
+		// The tail must be a suffix of the full written stream (all ASCII).
+		assert.True(t, strings.HasSuffix(strings.TrimSpace(written.String()), got),
+			"logged tail must be the trailing portion of the captured stderr")
+	})
+}

--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -529,18 +529,24 @@ func (b *boundedBuffer) Reset() {
 const stderrLogTailMaxBytes = 2 << 10 // 2 KiB
 
 // stderrLogTail returns the trailing snippet of s used for a stderr-on-exit log
-// field: at most maxBytes trailing bytes, with a leading partial line dropped so
-// the snippet starts on a line boundary, and surrounding whitespace trimmed. It
-// performs no locking or sanitization; callers do both. A maxBytes <= 0 returns
-// the whole trimmed input.
+// field: at most maxBytes trailing bytes, with surrounding whitespace trimmed. A
+// leading partial line is dropped so the snippet starts on a line boundary, but
+// only when the cut bisects a line; if the retained suffix already begins right
+// after a newline its first line is kept whole. It performs no locking or
+// sanitization; callers do both. A maxBytes <= 0 returns the whole trimmed input.
 func stderrLogTail(s string, maxBytes int) string {
 	if maxBytes > 0 && len(s) > maxBytes {
-		s = s[len(s)-maxBytes:]
-		// Drop a leading partial line so the snippet starts on a line boundary,
-		// but only when there is still content after the break.
-		if nl := strings.IndexByte(s, '\n'); nl >= 0 && nl+1 < len(s) {
-			s = s[nl+1:]
+		start := len(s) - maxBytes
+		// When the cut bisects a line (the byte before the retained suffix is not
+		// a newline), drop the leading partial line so the snippet starts on a
+		// line boundary, but only when content remains after the break. When the
+		// cut already lands on a boundary, keep the complete first line.
+		if s[start-1] != '\n' {
+			if nl := strings.IndexByte(s[start:], '\n'); nl >= 0 && start+nl+1 < len(s) {
+				start += nl + 1
+			}
 		}
+		s = s[start:]
 	}
 	return strings.TrimSpace(s)
 }
@@ -870,7 +876,8 @@ func (s *Stream) Run(parentCtx context.Context) {
 			runtime := time.Since(processStartTime)
 
 			fallbackEngaged := false
-			if err != nil && !errors.Is(err, context.Canceled) {
+			abnormalExit := err != nil && !errors.Is(err, context.Canceled)
+			if abnormalExit {
 				s.recordFailure(runtime)
 				// Latch to the full-stream request if repeated RTSP failures with
 				// no audio point at an audio-only handshake the camera cannot
@@ -907,12 +914,6 @@ func (s *Stream) Run(parentCtx context.Context) {
 					logger.String("component", "ffmpeg-stream"),
 					logger.String("operation", "process_ended"))
 
-				// Surface the tail of FFmpeg's own stderr so operators can see why
-				// it stopped. It is captured but otherwise only read during the
-				// early-detection and quick-exit windows, so a steady-state failure
-				// would leave it unlogged. WARN for an abnormal exit.
-				s.logStderrTailOnExit(true)
-
 				if isSilenceTimeout {
 					func() {
 						s.restartCountMu.Lock()
@@ -933,14 +934,18 @@ func (s *Stream) Run(parentCtx context.Context) {
 					logger.Float64("runtime_seconds", runtime.Seconds()),
 					logger.String("component", "ffmpeg-stream"),
 					logger.String("operation", "process_ended"))
-
-				// A normal exit rarely leaves meaningful stderr at loglevel error,
-				// so surface any tail only at debug to keep steady-state logs quiet.
-				s.logStderrTailOnExit(false)
 				s.resetFailures()
 			}
 
 			s.cleanupProcess()
+
+			// Surface the tail of FFmpeg's own stderr so operators can see why it
+			// stopped. It is otherwise only read during the early-detection and
+			// quick-exit windows, so a steady-state exit would leave it unlogged.
+			// Logged after cleanupProcess so cmd.Wait has flushed the final stderr:
+			// WARN for an abnormal exit, DEBUG for a normal one, and only when
+			// non-empty.
+			s.logStderrTailOnExit(abnormalExit)
 
 			// Notify consumers of stream restart.
 			if s.onReset != nil {
@@ -2386,21 +2391,19 @@ func (s *Stream) checkEarlyErrors() *ErrorContext {
 // captured FFmpeg stderr for a log field, or "" if nothing was captured. The
 // process-ended paths use it to surface why FFmpeg stopped without requiring a
 // live debugger, since the capture is otherwise only inspected during the early
-// detection and quick-exit windows. It is called after the stdout read loop has
-// reached EOF (FFmpeg has exited and closed its pipes), so the captured stderr
-// is effectively complete; the read is guarded by stderrMu, which serializes it
-// against the stderr copy goroutine regardless of whether cmd.Wait (which may
-// run slightly later in cleanupProcess for steady-state exits) has returned.
+// detection and quick-exit windows. It is called after cleanupProcess has run
+// cmd.Wait, so the os/exec stderr copy is fully flushed and the capture is
+// complete; the read is also guarded by stderrMu.
 func (s *Stream) stderrTailForLog() string {
 	s.stderrMu.RLock()
 	full := s.stderr.String()
 	s.stderrMu.RUnlock()
 
-	tail := stderrLogTail(full, stderrLogTailMaxBytes)
-	if tail == "" {
-		return ""
-	}
-	return privacy.SanitizeFFmpegError(tail)
+	// Sanitize the whole capture BEFORE trimming to the tail. Truncating first
+	// could cut a credential-bearing stream URL at the tail boundary and leave a
+	// fragment the URL sanitizer can no longer recognize, leaking the credential
+	// into the log. stderrLogTail returns "" for empty or whitespace-only input.
+	return stderrLogTail(privacy.SanitizeFFmpegError(full), stderrLogTailMaxBytes)
 }
 
 // logStderrTailOnExit logs the tail of this process's captured FFmpeg stderr, if

--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -521,6 +521,30 @@ func (b *boundedBuffer) Reset() {
 	b.buf = b.buf[:0]
 }
 
+// stderrLogTailMaxBytes caps how much of the captured FFmpeg stderr is attached
+// to the process-ended log lines. The capture itself is bounded to
+// stderrTailMaxBytes; this keeps the log field small and readable while still
+// showing the last handful of FFmpeg messages that explain why the process
+// stopped.
+const stderrLogTailMaxBytes = 2 << 10 // 2 KiB
+
+// stderrLogTail returns the trailing snippet of s used for a stderr-on-exit log
+// field: at most maxBytes trailing bytes, with a leading partial line dropped so
+// the snippet starts on a line boundary, and surrounding whitespace trimmed. It
+// performs no locking or sanitization; callers do both. A maxBytes <= 0 returns
+// the whole trimmed input.
+func stderrLogTail(s string, maxBytes int) string {
+	if maxBytes > 0 && len(s) > maxBytes {
+		s = s[len(s)-maxBytes:]
+		// Drop a leading partial line so the snippet starts on a line boundary,
+		// but only when there is still content after the break.
+		if nl := strings.IndexByte(s, '\n'); nl >= 0 && nl+1 < len(s) {
+			s = s[nl+1:]
+		}
+	}
+	return strings.TrimSpace(s)
+}
+
 // threadSafeWriter wraps a boundedBuffer with mutex protection for concurrent access.
 type threadSafeWriter struct {
 	buf *boundedBuffer
@@ -883,6 +907,12 @@ func (s *Stream) Run(parentCtx context.Context) {
 					logger.String("component", "ffmpeg-stream"),
 					logger.String("operation", "process_ended"))
 
+				// Surface the tail of FFmpeg's own stderr so operators can see why
+				// it stopped. It is captured but otherwise only read during the
+				// early-detection and quick-exit windows, so a steady-state failure
+				// would leave it unlogged. WARN for an abnormal exit.
+				s.logStderrTailOnExit(true)
+
 				if isSilenceTimeout {
 					func() {
 						s.restartCountMu.Lock()
@@ -903,6 +933,10 @@ func (s *Stream) Run(parentCtx context.Context) {
 					logger.Float64("runtime_seconds", runtime.Seconds()),
 					logger.String("component", "ffmpeg-stream"),
 					logger.String("operation", "process_ended"))
+
+				// A normal exit rarely leaves meaningful stderr at loglevel error,
+				// so surface any tail only at debug to keep steady-state logs quiet.
+				s.logStderrTailOnExit(false)
 				s.resetFailures()
 			}
 
@@ -2346,4 +2380,48 @@ func (s *Stream) checkEarlyErrors() *ErrorContext {
 	s.stderrMu.RUnlock()
 
 	return ExtractErrorContext(stderrOutput)
+}
+
+// stderrTailForLog returns a sanitized, trailing snippet of this process's
+// captured FFmpeg stderr for a log field, or "" if nothing was captured. The
+// process-ended paths use it to surface why FFmpeg stopped without requiring a
+// live debugger, since the capture is otherwise only inspected during the early
+// detection and quick-exit windows. It is called after the stdout read loop has
+// reached EOF (FFmpeg has exited and closed its pipes), so the captured stderr
+// is effectively complete; the read is guarded by stderrMu, which serializes it
+// against the stderr copy goroutine regardless of whether cmd.Wait (which may
+// run slightly later in cleanupProcess for steady-state exits) has returned.
+func (s *Stream) stderrTailForLog() string {
+	s.stderrMu.RLock()
+	full := s.stderr.String()
+	s.stderrMu.RUnlock()
+
+	tail := stderrLogTail(full, stderrLogTailMaxBytes)
+	if tail == "" {
+		return ""
+	}
+	return privacy.SanitizeFFmpegError(tail)
+}
+
+// logStderrTailOnExit logs the tail of this process's captured FFmpeg stderr, if
+// any, with the process-ended context. abnormal true logs at WARN (the process
+// failed); abnormal false logs at DEBUG (a normal exit rarely carries useful
+// stderr at loglevel error, so keep steady-state logs quiet). Nothing is logged
+// when no stderr was captured.
+func (s *Stream) logStderrTailOnExit(abnormal bool) {
+	tail := s.stderrTailForLog()
+	if tail == "" {
+		return
+	}
+	fields := []logger.Field{
+		logger.String("url", s.config.safeURL()),
+		logger.String("stderr_tail", tail),
+		logger.String("component", "ffmpeg-stream"),
+		logger.String("operation", "process_ended_stderr"),
+	}
+	if abnormal {
+		getStreamLogger().Warn("FFmpeg stderr on exit", fields...)
+		return
+	}
+	getStreamLogger().Debug("FFmpeg stderr on exit", fields...)
 }


### PR DESCRIPTION
## Summary

The FFmpeg stderr capture in the audiocore streaming path is only inspected during the early-detection and quick-exit windows (`checkEarlyErrors` and the quick-exit handler). On a normal or steady-state exit nothing logged its contents, so the diagnostics that explain why FFmpeg stopped were captured but never surfaced anywhere useful. This is the follow-up noted in issue #4257 after PR #4263 bounded the capture to a trailing 64 KiB.

This adds `stderrTailForLog`, which reads the captured stderr under `stderrMu`, keeps only a trailing 2 KiB snippet starting on a line boundary (`stderrLogTail`), and sanitizes it through `privacy.SanitizeFFmpegError` so URL credentials and FFmpeg memory-address prefixes do not reach the log. `logStderrTailOnExit` emits it, only when non-empty, from the two process-ended paths: WARN for an abnormal exit (alongside the existing "FFmpeg process ended" line) and DEBUG for a normal exit, since a clean exit rarely carries useful stderr at loglevel `error` and would otherwise add steady-state noise.

The tail read is safe: it runs after the stdout loop reached EOF (FFmpeg has exited and closed its pipes) and is serialized against the stderr copy goroutine by `stderrMu`, and the buffer is only reset on the next process start, so it still holds this process's output.

## Related Issues

Follow-up to #4257 (the primary unbounded-buffer fix landed in #4263).

## Test Plan

- [x] `go build ./...` passes
- [x] `go test -race ./internal/audiocore/ffmpeg/` passes, including new tests for `stderrLogTail` (trailing-window capping, leading-partial-line drop on a line boundary, the trailing-newline-as-last-byte guard, whitespace trimming, non-positive `maxBytes` passthrough) and `stderrTailForLog` (empty buffer, memory-address prefix stripping, URL credential redaction, bounding to the log tail cap)
- [x] `golangci-lint run` reports 0 issues
- [x] Verified with the built binary against a bad RTSP URL: the new WARN line "FFmpeg stderr on exit" now carries the sanitized stderr tail (`method DESCRIBE failed: 404 Not Found ... Server returned 404 Not Found`), so an operator can see why FFmpeg stopped without attaching a debugger


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FFmpeg failure logging by reliably capturing the final bounded portion of diagnostic output, including output produced during process cleanup.
  * Preserved complete log lines when truncating FFmpeg diagnostics at a byte limit.
  * Ensured credentials remain redacted even when truncation occurs within sensitive URL content.
  * Normal process completions continue to record trailing diagnostic output at a lower verbosity level, reducing unnecessary warning noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->