### PR TITLE
fix(processor): stop sub-trigger detections from sustaining lowered dynamic thresholds (#4194)

### DIFF
--- a/internal/analysis/processor/dynamic_threshold.go
+++ b/internal/analysis/processor/dynamic_threshold.go
@@ -291,28 +291,6 @@ func (p *Processor) LearnFromApprovedDetection(speciesLowercase, scientificName 
 	}
 }
 
-// updateDynamicThreshold updates the dynamic threshold for a given species if enabled.
-func (p *Processor) updateDynamicThreshold(modelID, commonName string, confidence float64) {
-	settings := p.currentSettings()
-	if settings.Realtime.DynamicThreshold.Enabled {
-		// Lock the mutex to ensure thread-safe access to the DynamicThresholds map
-		p.thresholdsMutex.Lock()
-		defer p.thresholdsMutex.Unlock()
-
-		// Check if the species already has a dynamic threshold. The entry is keyed
-		// per species; modelID still selects the model-specific base to compare the
-		// detection confidence against before extending the timer.
-		// Note: scientific name not available in this context, but common name lookup is sufficient.
-		// Lowercase the key to match how entries are stored (addSpeciesToDynamicThresholds);
-		// otherwise a title-cased common name misses and the timer is never extended.
-		if dt, exists := p.DynamicThresholds[strings.ToLower(commonName)]; exists && confidence > float64(p.getBaseConfidenceThreshold(settings, commonName, "", modelID)) {
-			// Update the timer to extend the threshold's validity
-			// Note: dt is a pointer, so this directly mutates the struct in the map
-			dt.Timer = time.Now().Add(time.Duration(dt.ValidHours) * time.Hour)
-		}
-	}
-}
-
 // cleanUpDynamicThresholds removes stale dynamic thresholds for species that haven't been detected for a long time.
 // This cleans up both the in-memory map and the database.
 func (p *Processor) cleanUpDynamicThresholds() {

--- a/internal/analysis/processor/dynamic_threshold_test.go
+++ b/internal/analysis/processor/dynamic_threshold_test.go
@@ -499,8 +499,11 @@ func TestLearnFromApprovedDetectionSubTriggerDoesNotRenewLatchedTimer(t *testing
 
 	dt := p.DynamicThresholds["test species"]
 	require.NotNil(t, dt, "threshold entry must still exist after a sub-trigger detection")
-	assert.True(t, dt.Timer.Before(before.Add(2*time.Hour)),
-		"Sub-trigger detection must not renew the timer (expected ~1h out, got %v out)", time.Until(dt.Timer))
+	// Assert the timer is unchanged (exactly soonToExpire), not merely "still soon":
+	// the intended behavior is no renewal at all, so any partial or unexpected timer
+	// mutation must fail. Exact equality also keeps the assertion time-independent.
+	assert.Equal(t, soonToExpire, dt.Timer,
+		"Sub-trigger detection must not renew the timer; it must stay exactly at soonToExpire")
 	// HighConfCount is the discriminating field: Level is already saturated at 3,
 	// so a spurious learn would surface as the count advancing to 4.
 	assert.Equal(t, 3, dt.HighConfCount, "Sub-trigger detection must not count as a learning event")

--- a/internal/analysis/processor/dynamic_threshold_test.go
+++ b/internal/analysis/processor/dynamic_threshold_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
@@ -451,4 +452,56 @@ func TestEffectiveDynamicThreshold(t *testing.T) {
 			assert.InDelta(t, tt.expected, effectiveDynamicThreshold(tt.base, tt.level, tt.min), 0.001)
 		})
 	}
+}
+
+// =============================================================================
+// Regression coverage for #4194 (dynamic-threshold timer renewal)
+// =============================================================================
+//
+// The #4194 bug lived in updateDynamicThreshold, which renewed the expiry timer
+// from the PENDING detection path on any detection above the model base, letting
+// sub-trigger noise (or a lower-base model's normal output on the shared
+// per-species timer) pin a species at its lowered gate indefinitely. That method
+// was removed; LearnFromApprovedDetection is now the only runtime path that
+// renews the timer (creation-time init and DB hydration also assign it), and it
+// is Trigger-gated.
+//
+// The test below guards that surviving renewal path: a sub-trigger detection must
+// neither renew the timer nor count as a learning event on an already-latched
+// species. It does not drive the removed pending path (processDetections) end to
+// end, so it does not by itself reproduce the original bug; the above-Trigger
+// renewal direction is covered by TestLearnFromApprovedDetectionExtendsTimer.
+
+// TestLearnFromApprovedDetectionSubTriggerDoesNotRenewLatchedTimer verifies the
+// sole runtime renewal path stays Trigger-gated: a species latched at its maximum
+// reduction must not have its expiry timer renewed, nor its learning count
+// advanced, by a sub-trigger detection, so the lowered gate decays once
+// above-Trigger activity stops.
+func TestLearnFromApprovedDetectionSubTriggerDoesNotRenewLatchedTimer(t *testing.T) {
+	p := newTestProcessor()
+
+	// Species latched at Level 3 with a timer about to expire.
+	before := time.Now()
+	soonToExpire := before.Add(1 * time.Hour)
+	p.DynamicThresholds["test species"] = &DynamicThreshold{
+		Level:          3,
+		BaseThreshold:  0.80,
+		Timer:          soonToExpire,
+		HighConfCount:  3,
+		ValidHours:     24,
+		LastLearnedAt:  before.Add(-1 * time.Hour),
+		ScientificName: "Testus speciesus",
+	}
+
+	// 0.85 is above base (0.80) but below Trigger (0.90): a sub-trigger detection.
+	// It must not renew the timer, so the latched state is allowed to expire.
+	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.85, 0.80)
+
+	dt := p.DynamicThresholds["test species"]
+	require.NotNil(t, dt, "threshold entry must still exist after a sub-trigger detection")
+	assert.True(t, dt.Timer.Before(before.Add(2*time.Hour)),
+		"Sub-trigger detection must not renew the timer (expected ~1h out, got %v out)", time.Until(dt.Timer))
+	// HighConfCount is the discriminating field: Level is already saturated at 3,
+	// so a spurious learn would surface as the count advancing to 4.
+	assert.Equal(t, 3, dt.HighConfCount, "Sub-trigger detection must not count as a learning event")
 }

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -799,8 +799,11 @@ func (p *Processor) processDetections(item classifier.Results) {
 			p.applyExtendedCapture(mapKey, now, detectionWindow)
 		}
 
-		// Update the dynamic threshold for this species if enabled
-		p.updateDynamicThreshold(item.ModelID, commonName, confidence)
+		// Note: the dynamic-threshold expiry timer is renewed only from approved,
+		// filter-passing detections above Trigger in LearnFromApprovedDetection
+		// (via processApprovedDetection). Renewing it here from pending detections
+		// above the model base let sub-trigger noise sustain a lowered gate
+		// indefinitely (#4194), so no renewal happens on the pending path.
 
 		// Unlock the mutex to allow other goroutines to access shared resources
 		p.pendingMutex.Unlock()


### PR DESCRIPTION
## Summary

Entering or advancing a lowered dynamic threshold requires a detection above the configured `trigger`, but the expiry timer was renewed by `updateDynamicThreshold` on any pending detection above the model's base threshold. That asymmetry let a persistent source scoring between base and `trigger` renew the 24h timer forever, pinning a species at its maximum reduction and saving thousands of detections that never cleared `trigger`. Because the threshold state is shared per species across models, a lower-base model (Perch v2 at 0.70) also sustained the lowered gate for a higher-base model (BirdNET v3.0 at 0.90).

`updateDynamicThreshold` also ran during the pending phase, before the flush-time discard filters, so even a `trigger`-gated renewal there could be kept alive by a detection that is later discarded. This removes the pending-path renewal entirely and lets `LearnFromApprovedDetection` be the sole timer extender: it already renews the timer only for approved, filter-passing detections above `trigger`, making entry and persistence symmetric. It also drops a mutex acquisition from the hot detection path.

## Behavior change (release note)

A latched lowered gate now decays `validhours` after the last above-`trigger` approved detection, instead of after the last above-base pending detection. Species that keep producing above-`trigger` detections still renew normally; only species that stop producing above-`trigger` detections decay back to base, which is the intended fix. As a minor consequence of moving renewal to approval time, a species whose timer is within one detection window (~15s) of expiry when a fresh above-`trigger` detection arrives may decay and re-earn from level 1 rather than continuing at its current level. This is the safe direction (a higher, more conservative gate) and self-heals as detections continue.

## Related Issues

Fixes #4194

## Test Plan

- [x] `go test -race ./internal/analysis/processor/` passes
- [x] `go vet` and `golangci-lint run` are clean on the package
- [x] Added `TestLearnFromApprovedDetectionSubTriggerDoesNotRenewLatchedTimer`: a sub-trigger detection does not renew a latched species' timer or advance its learning count
- [x] Existing `TestLearnFromApprovedDetectionExtendsTimer` still covers the above-`trigger` renewal direction


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dynamic thresholds now renew only after approved detections pass filtering.
  * Below-trigger or sub-trigger detections no longer prolong lowered thresholds or increase learning counts.
  * Threshold timers now preserve their original expiry when detections do not meet approval criteria.
  * Added regression coverage to verify correct timer renewal and learning behavior across repeated detections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->