### PR TITLE
fix(audiocore): round native MP3 bitrate to nearest MPEG-1 rate

### DIFF
--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -812,11 +812,9 @@ func (a *SaveAudioAction) logExportFailure(enc *clipEncoding, exportFormat strin
 // fallback for a clip go-opus cannot carry. AAC and MP3 each have a native
 // encoder too, but both are opt-in while they earn field confidence, so AAC
 // reaches go-aac/go-m4a and MP3 reaches go-mp3 only when the matching gate in
-// internal/conf is set and the encoder accepts the clip's shape (for MP3 that
-// includes the bitrate, since go-mp3 codes only the fixed MPEG-1 rates).
-// Everything else, a non-gated AAC or MP3 clip, and an Opus clip go-opus cannot
-// carry go to FFmpeg.
-func selectEncoder(exportFormat string, exportRate, bitrateKbps int) string {
+// internal/conf is set and the encoder accepts the clip's shape. Everything else,
+// a non-gated AAC or MP3 clip, and an Opus clip go-opus cannot carry go to FFmpeg.
+func selectEncoder(exportFormat string, exportRate int) string {
 	switch exportFormat {
 	case ffmpeg.FormatWAV:
 		return clipenc.NativeWAV
@@ -837,7 +835,7 @@ func selectEncoder(exportFormat string, exportRate, bitrateKbps int) string {
 		return clipenc.FFmpeg
 	case ffmpeg.FormatMP3:
 		// Opt-in; see internal/conf/native_encoders.go for the gate and its removal.
-		if nativeMP3Selected(exportRate, bitrateKbps) {
+		if nativeMP3Selected(exportRate) {
 			return clipenc.NativeMP3
 		}
 		return clipenc.FFmpeg
@@ -877,8 +875,16 @@ func lossyBitrateKbps(exportFormat, bitrate string) int {
 // gain that was going to be applied.
 func (a *SaveAudioAction) encodeClip(ctx context.Context, exportRate int, exportFormat, outputPath string) (clipEncoding, error) {
 	bitrateKbps := lossyBitrateKbps(exportFormat, a.Settings.Realtime.Audio.Export.Bitrate)
+	encoder := selectEncoder(exportFormat, exportRate)
+	if encoder == clipenc.NativeMP3 {
+		// go-mp3 codes only the 14 fixed MPEG-1 rates and the wrapper rounds the
+		// requested bitrate to the nearest, so report that rounded value here to keep
+		// the encoding log and the file on disk in agreement. The FFmpeg MP3 path
+		// keeps the clamped EffectiveBitrateKbps, which is what FFmpeg is handed.
+		bitrateKbps = mp3.RoundBitrateKbps(bitrateKbps)
+	}
 	enc := clipEncoding{
-		Encoder:     selectEncoder(exportFormat, exportRate, bitrateKbps),
+		Encoder:     encoder,
 		BitrateKbps: bitrateKbps,
 	}
 
@@ -1058,21 +1064,17 @@ func nativeOpusSelected(exportRate int) bool {
 }
 
 // nativeMP3Selected reports whether this clip should take the native MP3 path:
-// the operator opted in AND go-mp3 accepts the clip's rate, depth, channel count
-// and bitrate. MP3 differs from AAC and Opus in that last check: it codes only
-// the 14 fixed MPEG-1 Layer III bitrates, so a configured rate outside that set
-// (BirdNET-Go validation allows any value in 32-320k) falls back to FFmpeg with a
-// warning rather than failing the export. Like the AAC gate, this whole check
-// goes away when the native encoder becomes the default.
-func nativeMP3Selected(exportRate, bitrateKbps int) bool {
+// the operator opted in AND go-mp3 accepts the clip's rate, depth and channel
+// count. Bitrate is not part of the check: go-mp3 codes only the 14 fixed MPEG-1
+// Layer III rates, but the encoder rounds any configured value (BirdNET-Go allows
+// any 32-320k) to the nearest of them, so a bitrate is never a reason to fall back.
+// This mirrors nativeAACSelected and goes away when the native encoder becomes the
+// default.
+func nativeMP3Selected(exportRate int) bool {
 	if !conf.NativeMP3EncoderEnabled() {
 		return false
 	}
 	if err := mp3.Supports(exportRate, conf.BitDepth, conf.NumChannels); err != nil {
-		logNativeEncoderSkipped(ffmpeg.FormatMP3, exportRate, err)
-		return false
-	}
-	if err := mp3.SupportsBitrate(bitrateKbps); err != nil {
 		logNativeEncoderSkipped(ffmpeg.FormatMP3, exportRate, err)
 		return false
 	}
@@ -1568,12 +1570,12 @@ func (a *SaveAudioAction) strandedWithoutEncoder(rate int, format string) bool {
 	case ffmpeg.FormatAAC:
 		return conf.NativeAACEncoderEnabled() && !nativeAACSelected(rate)
 	case ffmpeg.FormatMP3:
-		// Like AAC: opting MP3 into its native encoder stops config validation
-		// from downgrading it to WAV, so a clip go-mp3 cannot carry (an
-		// unsupported rate or a non-MPEG-1 bitrate) is stranded without FFmpeg
-		// and must be downgraded here.
-		bitrateKbps := lossyBitrateKbps(format, a.Settings.Realtime.Audio.Export.Bitrate)
-		return conf.NativeMP3EncoderEnabled() && !nativeMP3Selected(rate, bitrateKbps)
+		// Like AAC: opting MP3 into its native encoder stops config validation from
+		// downgrading it to WAV, so a clip go-mp3 cannot carry is stranded without
+		// FFmpeg and must be downgraded here. Bitrate is no longer a reason (the
+		// encoder rounds any configured value to a valid MPEG-1 rate); only an
+		// unsupported sample rate can strand an MP3 clip now.
+		return conf.NativeMP3EncoderEnabled() && !nativeMP3Selected(rate)
 	case ffmpeg.FormatOpus:
 		// go-opus is the default, so config validation never downgrades .opus to
 		// WAV: if go-opus cannot carry this clip and there is no FFmpeg, it is

--- a/internal/analysis/processor/export_logging_test.go
+++ b/internal/analysis/processor/export_logging_test.go
@@ -791,7 +791,7 @@ func TestSelectEncoder_RoutingTable(t *testing.T) {
 			t.Setenv(conf.EnvNativeMP3Encoder, "")
 			resetNativeSkipOnce()
 
-			assert.Equal(t, tc.wantEncode, selectEncoder(tc.format, tc.rate, 128))
+			assert.Equal(t, tc.wantEncode, selectEncoder(tc.format, tc.rate))
 		})
 	}
 }

--- a/internal/analysis/processor/native_mp3_gate_test.go
+++ b/internal/analysis/processor/native_mp3_gate_test.go
@@ -18,7 +18,7 @@ import (
 // the native MP3 encoder is still proving itself.
 func TestNativeMP3Selected_GateUnsetKeepsFFmpeg(t *testing.T) {
 	t.Setenv(conf.EnvNativeMP3Encoder, "")
-	assert.False(t, nativeMP3Selected(conf.SampleRate, 128), "MP3 must stay on FFmpeg without its gate")
+	assert.False(t, nativeMP3Selected(conf.SampleRate), "MP3 must stay on FFmpeg without its gate")
 }
 
 // With the gate set and a shape go-mp3 accepts, the clip is encoded natively and
@@ -27,7 +27,7 @@ func TestEncodeClip_GateSelectsNativeMP3(t *testing.T) {
 	t.Setenv(conf.EnvNativeMP3Encoder, "native")
 
 	a := newGateTestAction(t, "96k")
-	require.True(t, nativeMP3Selected(conf.SampleRate, 96))
+	require.True(t, nativeMP3Selected(conf.SampleRate))
 
 	out := filepath.Join(t.TempDir(), "clip.mp3")
 	encoder, err := a.encodeClip(t.Context(), conf.SampleRate, ffmpeg.FormatMP3, out)
@@ -42,42 +42,69 @@ func TestEncodeClip_GateSelectsNativeMP3(t *testing.T) {
 	assert.Equal(t, byte(0xE0), b[1]&0xE0, "second byte must carry the 11-bit frame sync")
 }
 
-// A clip go-mp3 cannot carry falls back to FFmpeg rather than failing. MP3 has
-// two ways to be unable to carry a clip the other codecs do not: an unsupported
-// capture rate, and a bitrate outside the 14 MPEG-1 Layer III rates, which
-// BirdNET-Go config otherwise allows anywhere in 32-320k.
+// A native MP3 clip encoded at a non-MPEG-1 configured bitrate records the rounded
+// bitrate that was actually used, so the encoding log matches the file on disk.
+func TestEncodeClip_NativeMP3RoundsBitrate(t *testing.T) {
+	t.Setenv(conf.EnvNativeMP3Encoder, "native")
+
+	a := newGateTestAction(t, "100k")
+	out := filepath.Join(t.TempDir(), "clip.mp3")
+	encoder, err := a.encodeClip(t.Context(), conf.SampleRate, ffmpeg.FormatMP3, out)
+	require.NoError(t, err)
+	assert.Equal(t, clipenc.NativeMP3, encoder.Encoder, "100k is rounded, so the clip stays native MP3")
+	assert.Equal(t, 96, encoder.BitrateKbps, "100k rounds to the nearest MPEG-1 rate, 96k")
+}
+
+// The rounding is deliberately native-only: a clip that routes to FFmpeg must keep
+// the unrounded configured bitrate, because FFmpeg accepts arbitrary rates and the
+// log must report what FFmpeg was actually handed. This pins the else-arm of the
+// conditional round in encodeClip so removing the "native only" guard is caught.
+func TestEncodeClip_FFmpegMP3KeepsUnroundedBitrate(t *testing.T) {
+	t.Setenv(conf.EnvNativeMP3Encoder, "") // gate off routes MP3 to FFmpeg
+
+	a := newGateTestAction(t, "100k")
+	out := filepath.Join(t.TempDir(), "clip.mp3")
+	// The FFmpeg encode itself may fail when no ffmpeg binary is present; the
+	// returned clipEncoding is populated before the encoder runs, and its
+	// BitrateKbps is what this test asserts, so the encode error is irrelevant here.
+	encoder, _ := a.encodeClip(t.Context(), conf.SampleRate, ffmpeg.FormatMP3, out)
+	assert.Equal(t, clipenc.FFmpeg, encoder.Encoder, "gate off routes MP3 to FFmpeg")
+	assert.Equal(t, 100, encoder.BitrateKbps, "the FFmpeg path keeps the unrounded configured bitrate")
+}
+
+// A clip go-mp3 cannot carry falls back to FFmpeg rather than failing. After the
+// bitrate is rounded to a valid MPEG-1 rate, the only remaining reason MP3 cannot
+// be carried natively is an unsupported capture rate.
 func TestNativeMP3Selected_FallsBackToFFmpeg(t *testing.T) {
 	t.Setenv(conf.EnvNativeMP3Encoder, "native")
 
-	// 22.05 kHz is not an MPEG-1 Layer III rate.
-	assert.False(t, nativeMP3Selected(22050, 128), "22.05 kHz must fall back to FFmpeg")
-	// The bitrate half: 128 kbps is a valid MPEG-1 rate, 100 kbps is in the
-	// configurable range but not one go-mp3 codes.
-	assert.True(t, nativeMP3Selected(conf.SampleRate, 128), "128 kbps is a valid MPEG-1 rate")
-	assert.False(t, nativeMP3Selected(conf.SampleRate, 100), "100 kbps must fall back to FFmpeg")
+	// 22.05 kHz is not an MPEG-1 Layer III rate, so it still falls back.
+	assert.False(t, nativeMP3Selected(22050), "22.05 kHz must fall back to FFmpeg")
+	// A supported capture rate is carried natively regardless of the configured
+	// bitrate, which the encoder rounds to a valid MPEG-1 rate.
+	assert.True(t, nativeMP3Selected(conf.SampleRate), "a supported rate is carried natively")
 }
 
 // selectEncoder routes MP3 to the native encoder only with the gate on and a
-// carriable clip, and to FFmpeg otherwise. This pins the bitrate-driven fork the
-// other lossy formats do not have.
+// carriable clip, and to FFmpeg otherwise. The bitrate no longer forks the
+// decision: any configured value is rounded to a valid MPEG-1 rate, so only the
+// gate and the capture rate matter.
 func TestSelectEncoder_MP3Routing(t *testing.T) {
 	for _, tc := range []struct {
-		name    string
-		gate    string
-		rate    int
-		bitrate int
-		want    string
+		name string
+		gate string
+		rate int
+		want string
 	}{
-		{"gate off routes to ffmpeg", "", conf.SampleRate, 128, clipenc.FFmpeg},
-		{"gate on with a carriable clip goes native", "native", conf.SampleRate, 128, clipenc.NativeMP3},
-		{"gate on with an unsupported rate falls back", "native", 22050, 128, clipenc.FFmpeg},
-		{"gate on with a non-MPEG-1 bitrate falls back", "native", conf.SampleRate, 100, clipenc.FFmpeg},
+		{"gate off routes to ffmpeg", "", conf.SampleRate, clipenc.FFmpeg},
+		{"gate on with a carriable clip goes native", "native", conf.SampleRate, clipenc.NativeMP3},
+		{"gate on with an unsupported rate falls back", "native", 22050, clipenc.FFmpeg},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			// Not parallel: t.Setenv, and the skip warning uses a package-level Once.
 			t.Setenv(conf.EnvNativeMP3Encoder, tc.gate)
 			resetNativeSkipOnce()
-			assert.Equal(t, tc.want, selectEncoder(ffmpeg.FormatMP3, tc.rate, tc.bitrate))
+			assert.Equal(t, tc.want, selectEncoder(ffmpeg.FormatMP3, tc.rate))
 		})
 	}
 }
@@ -110,9 +137,11 @@ func TestResolveExportParams_MP3StrandedClipFallsBackToWAV(t *testing.T) {
 			wantFormat: "wav", wantExt: ".wav",
 		},
 		{
-			name: "gate on, non-MPEG-1 bitrate, no ffmpeg strands the clip",
+			// 100k is not an MPEG-1 rate, but the encoder rounds it to 96k rather
+			// than stranding the clip, so the format stays MP3 even without FFmpeg.
+			name: "gate on, non-MPEG-1 bitrate, no ffmpeg keeps mp3 (rounded)",
 			gate: "native", bitrate: "100k", ffmpegPath: "", rate: conf.SampleRate,
-			wantFormat: "wav", wantExt: ".wav",
+			wantFormat: ffmpeg.FormatMP3, wantExt: ".mp3",
 		},
 		{
 			// FFmpeg present: it can still take the clip, so keep the format.

--- a/internal/audiocore/mp3/encode.go
+++ b/internal/audiocore/mp3/encode.go
@@ -45,13 +45,14 @@ const (
 var supportedSampleRates = [...]int{32000, 44100, 48000}
 
 // supportedBitratesKbps is the fixed set of MPEG-1 Layer III CBR bitrates go-mp3
-// accepts. Unlike AAC and Opus, MP3 has no continuous bitrate range: a value
-// outside this set (a BirdNET-Go config as ordinary as 100k, which validation
-// allows anywhere in 32-320k) is rejected by go-mp3 rather than snapped, so the
-// encoder selection uses SupportsBitrate to fall back to FFmpeg rather than
-// failing the export. The set is duplicated here rather than imported because
-// go-mp3 keeps its validator (enc.ValidBitrateKbps) internal, the same way the
-// sibling codecs duplicate small constants across module boundaries.
+// accepts, in ascending order. Unlike AAC and Opus, MP3 has no continuous bitrate
+// range: a value outside this set (a BirdNET-Go config as ordinary as 100k, which
+// validation allows anywhere in 32-320k) is rejected by go-mp3 rather than snapped.
+// RoundBitrateKbps snaps any requested rate to the nearest entry here so the native
+// path always encodes MP3 rather than falling back. The set is duplicated here
+// rather than imported because go-mp3 keeps its validator (enc.ValidBitrateKbps)
+// internal, the same way the sibling codecs duplicate small constants across module
+// boundaries.
 var supportedBitratesKbps = [...]int{32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320}
 
 // Options configures a native MP3 export of an in-memory PCM buffer.
@@ -67,9 +68,9 @@ type Options struct {
 	Channels int
 	// BitDepth is the PCM bit depth; only 16 is supported.
 	BitDepth int
-	// BitrateKbps is the target CBR bitrate in kbit/s. It must be one of the 14
-	// MPEG-1 Layer III rates (see SupportsBitrate); zero selects go-mp3's default
-	// (128 kbps).
+	// BitrateKbps is the target CBR bitrate in kbit/s. Any non-negative value is
+	// accepted: EncodePCM rounds it to the nearest of the 14 MPEG-1 Layer III rates
+	// (see RoundBitrateKbps). Zero selects go-mp3's default (128 kbps).
 	BitrateKbps int
 	// GainDB is the volume adjustment in dB (0 = no change).
 	GainDB float64
@@ -77,9 +78,9 @@ type Options struct {
 
 // Supports reports whether the native encoder can carry a clip of this shape,
 // returning a descriptive error naming the offending value when it cannot. It
-// covers rate, depth and channel count; bitrate is checked separately by
-// SupportsBitrate because MP3, unlike the other lossy formats, constrains it to
-// a fixed set rather than a range.
+// covers rate, depth and channel count. Bitrate is not a carriability constraint:
+// EncodePCM rounds any requested bitrate to a rate go-mp3 accepts (see
+// RoundBitrateKbps), so it is never a reason to fall back.
 func Supports(sampleRate, bitDepth, channels int) error {
 	if !slices.Contains(supportedSampleRates[:], sampleRate) {
 		return errors.Newf("mp3: unsupported sample rate %d (supported: %v)", sampleRate, supportedSampleRates).
@@ -108,21 +109,30 @@ func Supports(sampleRate, bitDepth, channels int) error {
 	return nil
 }
 
-// SupportsBitrate reports whether go-mp3 can encode at bitrateKbps, returning a
-// descriptive error when it cannot. Zero is accepted and maps to go-mp3's
-// default rate. MP3 only codes the 14 fixed MPEG-1 Layer III rates, so a
-// configured bitrate outside that set is the reason a clip falls back to FFmpeg
-// rather than being encoded natively.
-func SupportsBitrate(bitrateKbps int) error {
-	if bitrateKbps == 0 || slices.Contains(supportedBitratesKbps[:], bitrateKbps) {
-		return nil
+// RoundBitrateKbps maps a requested CBR bitrate to the nearest rate go-mp3 can
+// code. MP3, unlike AAC and Opus, has no continuous bitrate range: it codes only
+// the 14 fixed MPEG-1 Layer III rates. BirdNET-Go config allows any value in
+// 32-320k, so a setting like 100k that is not one of those rates is snapped to the
+// closest one (96k) instead of being rejected, so the native path always encodes
+// MP3 rather than downgrading the clip to FFmpeg or WAV. Zero (and any non-positive
+// value) maps to 0, which selects go-mp3's default (128 kbps). A value below 32k
+// snaps up to 32k and one above 320k snaps down to 320k; on an exact tie the higher
+// rate wins, favouring quality and keeping the result deterministic.
+func RoundBitrateKbps(kbps int) int {
+	if kbps <= 0 {
+		return 0
 	}
-	return errors.Newf("mp3: unsupported bitrate %d kbps (supported: %v)", bitrateKbps, supportedBitratesKbps).
-		Component(component).
-		Category(errors.CategoryValidation).
-		Context("operation", "mp3_supports_bitrate").
-		Context("bitrate_kbps", bitrateKbps).
-		Build()
+	// The list is ascending, so keeping the last rate whose distance ties or beats
+	// the current best makes an exact tie resolve to the higher rate. max(d, -d) is
+	// the integer absolute distance (the standard library has no int abs).
+	nearest := supportedBitratesKbps[0]
+	bestDelta := max(kbps-nearest, nearest-kbps)
+	for _, rate := range supportedBitratesKbps[1:] {
+		if delta := max(kbps-rate, rate-kbps); delta <= bestDelta {
+			nearest, bestDelta = rate, delta
+		}
+	}
+	return nearest
 }
 
 // EncodePCM encodes opts.PCMData to a CBR MP3 file at opts.OutputPath. The write
@@ -144,10 +154,13 @@ func EncodePCM(ctx context.Context, opts *Options) error {
 		return err
 	}
 
+	// go-mp3 codes only the 14 fixed MPEG-1 Layer III rates, so round the requested
+	// bitrate to the nearest before handing it over; this is what lets the native
+	// path carry any configured 32-320k value instead of falling back to FFmpeg.
 	cfg := mp3pcm.Config{
 		SampleRate: opts.SampleRate,
 		Channels:   opts.Channels,
-		Bitrate:    opts.BitrateKbps * bitsPerKilobit,
+		Bitrate:    RoundBitrateKbps(opts.BitrateKbps) * bitsPerKilobit,
 	}
 
 	// Gain is applied up front because the library entry point takes the whole
@@ -203,9 +216,6 @@ func validateEncodeInput(opts *Options) error {
 			Context("operation", "mp3_encode_validate").
 			Context("bitrate_kbps", opts.BitrateKbps).
 			Build()
-	}
-	if err := SupportsBitrate(opts.BitrateKbps); err != nil {
-		return err
 	}
 	// Reject a partial trailing sample early rather than letting it surface as an
 	// opaque length error inside go-mp3.

--- a/internal/audiocore/mp3/encode_test.go
+++ b/internal/audiocore/mp3/encode_test.go
@@ -280,7 +280,6 @@ func TestEncodePCM_RejectsInvalidOptions(t *testing.T) {
 		{name: "unsupported bit depth 32", mutate: func(o *Options) { o.BitDepth = 32 }},
 		{name: "unsupported channel count", mutate: func(o *Options) { o.Channels = 3 }},
 		{name: "negative bitrate", mutate: func(o *Options) { o.BitrateKbps = -1 }},
-		{name: "non-MPEG-1 bitrate", mutate: func(o *Options) { o.BitrateKbps = 100 }},
 		{name: "partial trailing sample", mutate: func(o *Options) { o.PCMData = append(o.PCMData, 0) }},
 	}
 	for _, tt := range tests {
@@ -344,19 +343,53 @@ func TestSupports_BitDepthAndChannels(t *testing.T) {
 	require.Error(t, Supports(48000, 16, 3))
 }
 
-func TestSupportsBitrate(t *testing.T) {
+func TestRoundBitrateKbps(t *testing.T) {
 	t.Parallel()
-	// Zero maps to go-mp3's default and is accepted.
-	require.NoError(t, SupportsBitrate(0))
-	// The 14 valid MPEG-1 Layer III CBR rates.
+	// Zero (and any non-positive value) maps to go-mp3's default.
+	assert.Equal(t, 0, RoundBitrateKbps(0))
+	assert.Equal(t, 0, RoundBitrateKbps(-1))
+	// Each of the 14 valid MPEG-1 Layer III rates maps to itself.
 	for _, kbps := range []int{32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320} {
-		require.NoError(t, SupportsBitrate(kbps), "%d kbps is a valid MPEG-1 rate", kbps)
+		assert.Equal(t, kbps, RoundBitrateKbps(kbps), "%d kbps is already a valid rate", kbps)
 	}
-	// In-range but not an MPEG-1 rate: allowed by BirdNET-Go config, rejected here.
-	require.Error(t, SupportsBitrate(100))
-	require.Error(t, SupportsBitrate(200))
-	require.Error(t, SupportsBitrate(-1))
-	require.Error(t, SupportsBitrate(321))
+	// In-range non-MPEG-1 values snap to the nearest rate instead of being rejected.
+	assert.Equal(t, 96, RoundBitrateKbps(100), "100 -> nearest is 96")
+	assert.Equal(t, 192, RoundBitrateKbps(200), "200 -> nearest is 192")
+	assert.Equal(t, 224, RoundBitrateKbps(210), "210 -> nearest is 224")
+	// Below the lowest rate snaps up; above the highest snaps down.
+	assert.Equal(t, 32, RoundBitrateKbps(10))
+	assert.Equal(t, 320, RoundBitrateKbps(500))
+	assert.Equal(t, 320, RoundBitrateKbps(321))
+	// An exact midpoint resolves to the higher rate.
+	assert.Equal(t, 160, RoundBitrateKbps(144), "144 is midway between 128 and 160; ties round up")
+	assert.Equal(t, 40, RoundBitrateKbps(36), "36 is midway between 32 and 40; ties round up")
+}
+
+func TestEncodePCM_RoundsNonStandardBitrate(t *testing.T) {
+	t.Parallel()
+	// 100 kbps is in BirdNET-Go's configurable range but not an MPEG-1 rate. It must
+	// encode natively (rounded to 96k) rather than error, so a clip is never lost to
+	// a bitrate the config allowed.
+	out := filepath.Join(t.TempDir(), "clip.mp3")
+	err := EncodePCM(t.Context(), &Options{
+		PCMData:     tonePCM(t, testSampleRate, 0.1, testToneHz),
+		OutputPath:  out,
+		SampleRate:  testSampleRate,
+		Channels:    1,
+		BitDepth:    16,
+		BitrateKbps: 100,
+	})
+	require.NoError(t, err)
+	b, err := os.ReadFile(out) //nolint:gosec // test-controlled path
+	require.NoError(t, err)
+	require.Greater(t, len(b), 4, "MP3 stream truncated")
+	assert.Equal(t, byte(0xFF), b[0], "output must start with a frame sync byte")
+	assert.Equal(t, byte(0xE0), b[1]&0xE0, "second byte must carry the 11-bit frame sync")
+	// Prove the rounded rate actually reached the stream, not just that encoding
+	// succeeded: byte 2's top nibble is the MPEG-1 Layer III bitrate index, and
+	// 96 kbps is index 7 (0b0111). This fails if the wrapper ever passed 0 and let
+	// go-mp3 default to 128 kbps (index 9) instead of rounding 100 to 96.
+	assert.Equal(t, byte(0x70), b[2]&0xF0, "third byte must carry the 96 kbps bitrate index")
 }
 
 // Cross-validate the stream against an external decoder when ffprobe is present.

--- a/internal/audiocore/mp3/encode_test.go
+++ b/internal/audiocore/mp3/encode_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -345,24 +346,40 @@ func TestSupports_BitDepthAndChannels(t *testing.T) {
 
 func TestRoundBitrateKbps(t *testing.T) {
 	t.Parallel()
-	// Zero (and any non-positive value) maps to go-mp3's default.
-	assert.Equal(t, 0, RoundBitrateKbps(0))
-	assert.Equal(t, 0, RoundBitrateKbps(-1))
-	// Each of the 14 valid MPEG-1 Layer III rates maps to itself.
-	for _, kbps := range []int{32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320} {
-		assert.Equal(t, kbps, RoundBitrateKbps(kbps), "%d kbps is already a valid rate", kbps)
+	type roundCase struct {
+		name string
+		in   int
+		want int
 	}
-	// In-range non-MPEG-1 values snap to the nearest rate instead of being rejected.
-	assert.Equal(t, 96, RoundBitrateKbps(100), "100 -> nearest is 96")
-	assert.Equal(t, 192, RoundBitrateKbps(200), "200 -> nearest is 192")
-	assert.Equal(t, 224, RoundBitrateKbps(210), "210 -> nearest is 224")
-	// Below the lowest rate snaps up; above the highest snaps down.
-	assert.Equal(t, 32, RoundBitrateKbps(10))
-	assert.Equal(t, 320, RoundBitrateKbps(500))
-	assert.Equal(t, 320, RoundBitrateKbps(321))
-	// An exact midpoint resolves to the higher rate.
-	assert.Equal(t, 160, RoundBitrateKbps(144), "144 is midway between 128 and 160; ties round up")
-	assert.Equal(t, 40, RoundBitrateKbps(36), "36 is midway between 32 and 40; ties round up")
+	specials := []roundCase{
+		// Zero and any non-positive value map to go-mp3's default (0).
+		{"zero maps to the go-mp3 default", 0, 0},
+		{"negative maps to the go-mp3 default", -1, 0},
+		// In-range non-MPEG-1 values snap to the nearest rate instead of being rejected.
+		{"in-range rounds down to 96", 100, 96},
+		{"in-range rounds down to 192", 200, 192},
+		{"in-range rounds up to 224", 210, 224},
+		// Below the lowest rate snaps up; above the highest snaps down.
+		{"below the lowest rate snaps up to 32", 10, 32},
+		{"above the highest rate snaps down to 320", 500, 320},
+		{"just above 320 snaps to 320", 321, 320},
+		// An exact midpoint resolves to the higher rate.
+		{"exact midpoint rounds up (128 vs 160)", 144, 160},
+		{"exact midpoint rounds up (32 vs 40)", 36, 40},
+	}
+	validRates := []int{32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320}
+	cases := make([]roundCase, 0, len(specials)+len(validRates))
+	cases = append(cases, specials...)
+	// Every valid MPEG-1 Layer III rate maps to itself.
+	for _, kbps := range validRates {
+		cases = append(cases, roundCase{strconv.Itoa(kbps) + "k maps to itself", kbps, kbps})
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, RoundBitrateKbps(tc.in))
+		})
+	}
 }
 
 func TestEncodePCM_RoundsNonStandardBitrate(t *testing.T) {


### PR DESCRIPTION
## Summary

The native go-mp3 clip encoder (opt-in via `BIRDNET_MP3_ENCODER=native`) codes only the 14 fixed MPEG-1 Layer III CBR bitrates, but the export bitrate setting accepts any value in the 32-320k range. A non-standard value such as 100k was rejected by the encoder wrapper, which pushed the clip onto FFmpeg and, on an FFmpeg-less install, silently downgraded it to a lossless WAV. Swapping the user's chosen lossy MP3 for a WAV is surprising and defeats the point of selecting MP3.

This rounds the requested bitrate to the nearest of the 14 valid rates inside the mp3 wrapper (`RoundBitrateKbps`), so the native path always encodes MP3. With rounding in place, the bitrate check drops out of encoder selection and the stranded-clip fallback, leaving only the sample rate (32/44.1/48 kHz) as a reason to fall back. The rounded bitrate is reported through `clipEncoding.BitrateKbps` so the export log and the file on disk agree. The FFmpeg MP3 path is unchanged and keeps the unrounded configured bitrate, which is what FFmpeg is handed.

The default FFmpeg path (gate off) is byte-for-byte unchanged; this only affects installs that opted into the native MP3 encoder.

## Test Plan

- [x] `go test -race ./internal/audiocore/mp3/... ./internal/analysis/processor/...`
- [x] `golangci-lint run` (0 issues)
- [x] `TestRoundBitrateKbps`: nearest-rate mapping, clamping below 32k / above 320k, ties round up
- [x] `TestEncodePCM_RoundsNonStandardBitrate`: encoding 100k succeeds and the frame header carries the rounded 96 kbps bitrate index
- [x] `TestEncodeClip_NativeMP3RoundsBitrate`: the native path records the rounded bitrate in the export log
- [x] `TestEncodeClip_FFmpegMP3KeepsUnroundedBitrate`: the FFmpeg path keeps the unrounded configured bitrate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MP3 exports now round unsupported configured bitrates to the nearest compatible native-encoding rate.
  * Settings such as 100 kbps can remain MP3 exports instead of being converted to WAV.
  * Native MP3 encoding continues to validate audio format requirements, including sample rate, bit depth, and channel count.

* **Bug Fixes**
  * MP3 export routing no longer falls back solely because of the selected bitrate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->