### PR TITLE
test(audiocore): pin FFmpeg stream ingest with a producer-agnostic contract suite

### DIFF
--- a/internal/audiocore/engine/engine_contract_test.go
+++ b/internal/audiocore/engine/engine_contract_test.go
@@ -1,0 +1,234 @@
+//go:build integration
+
+package engine
+
+import (
+	"context"
+	"os/exec"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+	"github.com/tphakala/birdnet-go/internal/audiocore/buffer"
+	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
+	"github.com/tphakala/birdnet-go/internal/audiocore/streamtest"
+	"github.com/tphakala/birdnet-go/internal/testutil/containers"
+)
+
+// Engine-level contract timing (integration; real container and FFmpeg children).
+const (
+	engineHealthyBudget = 25 * time.Second
+	enginePollInterval  = 250 * time.Millisecond
+	engineSampleRate    = 48000
+	engineBitDepth      = 16
+	engineChannels      = 1
+
+	// Shortened liveness thresholds so the chain runs in seconds.
+	livenessCheckInterval = 1 * time.Second
+	livenessSilence       = 3 * time.Second
+	livenessMaxRetries    = 20
+	livenessRetryBackoff  = 2 * time.Second
+	livenessCooldown      = 2 * time.Second
+	livenessEscalation    = 90 * time.Second
+	livenessRestartBudget = 30 * time.Second
+	livenessRecoverBudget = 60 * time.Second
+
+	// managerShutdownCleanupTimeout bounds the manager shutdown in test cleanup.
+	managerShutdownCleanupTimeout = 15 * time.Second
+)
+
+// TestEngineIngestContract runs the Phase 0 engine-level characterization cases
+// (spec cases 12 and 13) against the live FFmpeg ingest path with a MediaMTX
+// container. They pin behaviour the manager-seam contract cannot: engine
+// reconfigure/stop/start round-trips, and the router + LivenessWatchdog + manager
+// recovery chain.
+func TestEngineIngestContract(t *testing.T) {
+	containers.SkipIfContainerRuntimeUnavailable(t)
+
+	ffmpegPath, err := exec.LookPath("ffmpeg")
+	require.NoError(t, err, "ffmpeg must be on PATH")
+
+	server, err := containers.NewMediaMTXContainer(t.Context(), nil)
+	require.NoError(t, err, "MediaMTX container should start")
+	t.Cleanup(func() {
+		//nolint:gocritic // t.Context() is already cancelled when Cleanup runs; Terminate needs a live context
+		assert.NoError(t, server.Terminate(context.Background()), "MediaMTX container should terminate cleanly")
+	})
+
+	fixture := streamtest.NewMediaMTXFixture(t, server)
+
+	t.Run("EngineReconfigure", func(t *testing.T) {
+		engineReconfigureCase(t, ffmpegPath, fixture)
+	})
+	t.Run("LivenessChain", func(t *testing.T) {
+		livenessChainCase(t, ffmpegPath, fixture)
+	})
+}
+
+// engineStreamHealthy reports whether the engine's FFmpeg stream for sourceID is
+// healthy right now.
+func engineStreamHealthy(eng *AudioEngine, sourceID string) bool {
+	h, err := eng.FFmpegManager().StreamHealth(sourceID)
+	return err == nil && h != nil && h.IsHealthy
+}
+
+// engineReconfigureCase (contract case 12): a reconfigure restarts the stream and
+// frames keep flowing, and a stop/start round-trip (the quiet-hours path) works.
+func engineReconfigureCase(t *testing.T, ffmpegPath string, fixture streamtest.Fixture) {
+	t.Helper()
+	pub := fixture.Publish(t, streamtest.PublishOptions{Codec: streamtest.CodecOpus, SampleRate: engineSampleRate, Channels: engineChannels})
+	t.Cleanup(func() { pub.Stop(t) })
+
+	eng := New(t.Context(), &Config{
+		Logger:     audiocore.GetLogger(),
+		FFmpegPath: ffmpegPath,
+		Transport:  "tcp",
+		LogLevel:   "error",
+	}, nil)
+	t.Cleanup(eng.Stop)
+	eng.SetPrimaryModel(testModelID, testClipBytes, testOverlapBytes, testReadSize)
+
+	const sourceID = "engine-reconf"
+	baseCfg := func(mediaMode string) *audiocore.SourceConfig {
+		return &audiocore.SourceConfig{
+			ID:               sourceID,
+			DisplayName:      "Engine Reconfigure",
+			Type:             audiocore.SourceTypeRTSP,
+			ConnectionString: pub.URL(),
+			SampleRate:       engineSampleRate,
+			BitDepth:         engineBitDepth,
+			Channels:         engineChannels,
+			Transport:        "tcp",
+			MediaMode:        mediaMode,
+		}
+	}
+
+	require.NoError(t, eng.AddSource(baseCfg("auto")))
+	require.Eventually(t, func() bool { return engineStreamHealthy(eng, sourceID) },
+		engineHealthyBudget, enginePollInterval, "stream should become healthy after AddSource")
+
+	// Reconfigure with a changed field (MediaMode) keeping TCP transport, which
+	// the TCP-only test server supports; the stream restarts and frames resume.
+	require.NoError(t, eng.ReconfigureSource(sourceID, baseCfg("full-stream")))
+	require.Eventually(t, func() bool { return engineStreamHealthy(eng, sourceID) },
+		engineHealthyBudget, enginePollInterval, "stream should recover after reconfigure")
+
+	// Quiet-hours round-trip: stop then start the same source.
+	require.NoError(t, eng.StopStream(sourceID))
+	require.Eventually(t, func() bool {
+		_, err := eng.FFmpegManager().StreamHealth(sourceID)
+		return err != nil
+	}, engineHealthyBudget, enginePollInterval, "stream should be gone from the manager after StopStream")
+
+	require.NoError(t, eng.StartStream(sourceID, pub.URL(), "tcp"))
+	require.Eventually(t, func() bool { return engineStreamHealthy(eng, sourceID) },
+		engineHealthyBudget, enginePollInterval, "stream should become healthy after StartStream")
+}
+
+// countingConsumer is a minimal AudioConsumer that registers a route so the
+// LivenessWatchdog treats the source as active, and counts dispatched frames.
+type countingConsumer struct {
+	id string
+	n  atomic.Int64
+}
+
+func (c *countingConsumer) ID() string      { return c.id }
+func (c *countingConsumer) SampleRate() int { return engineSampleRate }
+func (c *countingConsumer) BitDepth() int   { return engineBitDepth }
+func (c *countingConsumer) Channels() int   { return engineChannels }
+func (c *countingConsumer) Close() error    { return nil }
+func (c *countingConsumer) Write(_ audiocore.AudioFrame) error { //nolint:gocritic // hugeParam: matches AudioConsumer.Write contract
+	c.n.Add(1)
+	return nil
+}
+
+// watchdogState returns the current liveness state string for sourceID, or "".
+func watchdogState(w *audiocore.LivenessWatchdog, sourceID string) string {
+	for _, s := range w.Snapshot() {
+		if s.SourceID == sourceID {
+			return s.State
+		}
+	}
+	return ""
+}
+
+// livenessChainCase (contract case 13): router + LivenessWatchdog + manager;
+// stopping the publisher drives the chain to invoke RestartSource, and the source
+// returns to HEALTHY once the publisher comes back.
+func livenessChainCase(t *testing.T, ffmpegPath string, fixture streamtest.Fixture) {
+	t.Helper()
+	pub := fixture.Publish(t, streamtest.PublishOptions{Codec: streamtest.CodecOpus, SampleRate: engineSampleRate, Channels: engineChannels})
+	t.Cleanup(func() { pub.Stop(t) })
+
+	log := audiocore.GetLogger()
+	bufMgr := buffer.NewManager(log)
+	router := audiocore.NewAudioRouter(log, bufMgr)
+
+	const sourceID = "liveness-chain"
+	consumer := &countingConsumer{id: "liveness-consumer"}
+	require.NoError(t, router.AddRoute(sourceID, consumer, engineSampleRate, 0, nil))
+
+	mgr := ffmpeg.NewManager(t.Context(), func(f audiocore.AudioFrame) { router.Dispatch(f) }, nil, log, bufMgr)
+	t.Cleanup(func() {
+		//nolint:gocritic // t.Context() is already cancelled when Cleanup runs; shutdown needs a live context
+		ctx, cancel := context.WithTimeout(context.Background(), managerShutdownCleanupTimeout)
+		defer cancel()
+		assert.NoError(t, mgr.ShutdownWithContext(ctx), "manager should shut down cleanly")
+	})
+
+	streamCfg := &ffmpeg.StreamConfig{
+		SourceID:   sourceID,
+		SourceName: "Liveness Chain",
+		URL:        pub.URL(),
+		Type:       "rtsp",
+		SampleRate: engineSampleRate,
+		BitDepth:   engineBitDepth,
+		Channels:   engineChannels,
+		Transport:  "tcp",
+		FFmpegPath: ffmpegPath,
+		LogLevel:   "error",
+	}
+
+	var restartCalls atomic.Int64
+	watchdog := audiocore.NewLivenessWatchdog(audiocore.LivenessConfig{
+		CheckInterval:      livenessCheckInterval,
+		SilenceThreshold:   livenessSilence,
+		MaxRetries:         livenessMaxRetries,
+		RetryBackoff:       livenessRetryBackoff,
+		CooldownAfterRecov: livenessCooldown,
+		EscalationTimeout:  livenessEscalation,
+	}, router, audiocore.LivenessCallbacks{
+		RestartSource: func(id string) error {
+			restartCalls.Add(1)
+			// Mirror the production restart shape (fresh stop then start) so a
+			// recovered publisher can be picked up without waiting out the
+			// producer's own backoff.
+			_ = mgr.StopStream(id)
+			return mgr.StartStream(streamCfg)
+		},
+	})
+
+	require.NoError(t, mgr.StartStream(streamCfg))
+	watchdog.Start()
+	t.Cleanup(watchdog.Stop)
+
+	// Establish healthy flow.
+	require.Eventually(t, func() bool { return consumer.n.Load() > 0 },
+		engineHealthyBudget, enginePollInterval, "frames should flow before the outage")
+	require.Eventually(t, func() bool { return watchdogState(watchdog, sourceID) == audiocore.StateHealthy.String() },
+		engineHealthyBudget, enginePollInterval, "watchdog should report HEALTHY while data flows")
+
+	// Silence: the chain must reach a recovery state and invoke RestartSource.
+	pub.Stop(t)
+	require.Eventually(t, func() bool { return restartCalls.Load() > 0 },
+		livenessRestartBudget, enginePollInterval, "silence should invoke RestartSource")
+
+	// The publisher returns; the watchdog should drive the source back to HEALTHY.
+	pub.Restart(t)
+	require.Eventually(t, func() bool { return watchdogState(watchdog, sourceID) == audiocore.StateHealthy.String() },
+		livenessRecoverBudget, enginePollInterval, "watchdog should return to HEALTHY after recovery")
+}

--- a/internal/audiocore/ffmpeg/manager.go
+++ b/internal/audiocore/ffmpeg/manager.go
@@ -36,8 +36,6 @@ const (
 	managerShutdownTimeout = 30 * time.Second
 )
 
-// FrameCallback is invoked for each chunk of audio data received from a stream.
-// sourceID identifies the stream and data contains the raw audio bytes.
 // FrameCallback is invoked by a Stream for every chunk of audio data received.
 // The AudioFrame is fully populated with source metadata (ID, name, sample rate,
 // bit depth, channels, timestamp).
@@ -64,6 +62,11 @@ type Manager struct {
 	// pool their read buffers via FrameRef. May be nil (legacy allocation).
 	bufMgr *buffer.Manager
 
+	// opts carries manager-level defaults applied to every stream this manager
+	// starts (see withManagerDefaults). The zero value reproduces the historic
+	// behaviour, so NewManager callers are unaffected.
+	opts Options
+
 	// Watchdog state: tracks when each stream was last force-reset.
 	lastForceReset   map[string]time.Time
 	lastForceResetMu sync.Mutex
@@ -86,6 +89,15 @@ type Manager struct {
 // attach a FrameRef whose release closure returns the slice. When nil, streams
 // fall back to per-iteration allocation.
 func NewManager(ctx context.Context, onFrame FrameCallback, onReset func(sourceID string), log logger.Logger, bufMgr *buffer.Manager) *Manager {
+	return NewManagerWithOptions(ctx, onFrame, onReset, log, bufMgr, Options{})
+}
+
+// NewManagerWithOptions is NewManager with manager-level defaults. The extra
+// Options argument carries settings that apply to every stream the manager
+// starts. NewManager delegates here with a zero Options, so the two constructors
+// behave identically unless a non-zero option is supplied. See Options for the
+// available knobs.
+func NewManagerWithOptions(ctx context.Context, onFrame FrameCallback, onReset func(sourceID string), log logger.Logger, bufMgr *buffer.Manager, opts Options) *Manager {
 	if log == nil {
 		log = audiocore.GetLogger()
 	}
@@ -98,12 +110,13 @@ func NewManager(ctx context.Context, onFrame FrameCallback, onReset func(sourceI
 		onReset:        onReset,
 		logger:         log,
 		bufMgr:         bufMgr,
+		opts:           opts,
 		lastForceReset: make(map[string]time.Time),
 	}
 }
 
 // SetOnFrame registers a callback invoked for each chunk of audio data
-// received from any managed stream. Thread-safe — can be called while the
+// received from any managed stream. Thread-safe; can be called while the
 // manager is running.
 func (m *Manager) SetOnFrame(fn FrameCallback) {
 	m.onFrameMu.Lock()
@@ -113,7 +126,7 @@ func (m *Manager) SetOnFrame(fn FrameCallback) {
 
 // SetOnStreamReset registers a callback invoked after a stream starts or is
 // force-reset by the watchdog. The callback receives the sourceID of the
-// newly-started stream. Thread-safe — can be called while the manager is running.
+// newly-started stream. Thread-safe; can be called while the manager is running.
 func (m *Manager) SetOnStreamReset(fn func(sourceID string)) {
 	m.onResetMu.Lock()
 	defer m.onResetMu.Unlock()
@@ -139,6 +152,10 @@ func (m *Manager) StartStream(cfg *StreamConfig) error {
 			Context("operation", "start_stream").
 			Build()
 	}
+
+	// Apply manager-level defaults (e.g. a shortened silence timeout for tests)
+	// before constructing the stream, without mutating the caller's config.
+	cfg = m.withManagerDefaults(cfg)
 
 	// Hold the lock only for the map check and insertion.
 	stream := NewStream(cfg, m.dispatchFrame, m.notifyReset, m.metrics, m.bufMgr)
@@ -220,7 +237,7 @@ func (m *Manager) StopStream(sourceID string) error {
 	delete(m.streams, sourceID)
 	m.mu.Unlock()
 
-	// Stop the stream outside the lock — Stop() can block.
+	// Stop the stream outside the lock; Stop() can block.
 	stream.Stop()
 
 	// Clean up watchdog tracking.
@@ -378,7 +395,7 @@ func (m *Manager) ShutdownWithContext(ctx context.Context) error {
 
 	for i, id := range sourceIDs {
 		if ctx.Err() != nil {
-			m.logger.Warn("skipping remaining stream stops — context expired",
+			m.logger.Warn("skipping remaining stream stops; context expired",
 				logger.Int("remaining", len(sourceIDs)-i),
 				logger.String("component", "ffmpeg-manager"),
 				logger.String("operation", "shutdown"))

--- a/internal/audiocore/ffmpeg/manager_contract_test.go
+++ b/internal/audiocore/ffmpeg/manager_contract_test.go
@@ -1,0 +1,158 @@
+//go:build integration
+
+package ffmpeg_test
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
+	"github.com/tphakala/birdnet-go/internal/audiocore/streamtest"
+	"github.com/tphakala/birdnet-go/internal/testutil/containers"
+)
+
+// ffmpegManagerAdapter adapts *ffmpeg.Manager to the producer-agnostic
+// streamtest.Manager contract, translating the neutral StreamSpec into an
+// ffmpeg.StreamConfig and the ffmpeg health snapshot into streamtest.Health.
+type ffmpegManagerAdapter struct {
+	mgr        *ffmpeg.Manager
+	ffmpegPath string
+}
+
+func (a *ffmpegManagerAdapter) StartStream(spec *streamtest.StreamSpec) error {
+	return a.mgr.StartStream(&ffmpeg.StreamConfig{
+		URL:                  spec.URL,
+		SourceID:             spec.SourceID,
+		SourceName:           spec.SourceName,
+		Type:                 spec.Type,
+		SampleRate:           spec.SampleRate,
+		SourceSampleRate:     spec.SourceSampleRate,
+		BitDepth:             spec.BitDepth,
+		Channels:             spec.Channels,
+		SourceChannels:       spec.SourceChannels,
+		ChannelMode:          spec.ChannelMode,
+		MediaMode:            spec.MediaMode,
+		Transport:            spec.Transport,
+		HealthyDataThreshold: spec.HealthyDataThreshold,
+		Debug:                spec.Debug,
+		FFmpegPath:           a.ffmpegPath,
+		LogLevel:             "error",
+	})
+}
+
+func (a *ffmpegManagerAdapter) StopStream(sourceID string) error { return a.mgr.StopStream(sourceID) }
+
+func (a *ffmpegManagerAdapter) StreamHealth(sourceID string) (streamtest.Health, error) {
+	h, err := a.mgr.StreamHealth(sourceID)
+	if err != nil {
+		return nil, err
+	}
+	return ffmpegHealth{h: h}, nil
+}
+
+func (a *ffmpegManagerAdapter) AllStreamHealth() map[string]streamtest.Health {
+	src := a.mgr.AllStreamHealth()
+	out := make(map[string]streamtest.Health, len(src))
+	for id, h := range src {
+		out[id] = ffmpegHealth{h: h}
+	}
+	return out
+}
+
+func (a *ffmpegManagerAdapter) GetActiveStreamIDs() []string { return a.mgr.GetActiveStreamIDs() }
+
+func (a *ffmpegManagerAdapter) SetOnStreamReset(fn func(sourceID string)) { a.mgr.SetOnStreamReset(fn) }
+
+func (a *ffmpegManagerAdapter) Shutdown() error { return a.mgr.Shutdown() }
+
+func (a *ffmpegManagerAdapter) ShutdownWithContext(ctx context.Context) error {
+	return a.mgr.ShutdownWithContext(ctx)
+}
+
+// ffmpegHealth adapts *ffmpeg.StreamHealth to streamtest.Health.
+type ffmpegHealth struct{ h *ffmpeg.StreamHealth }
+
+func (f ffmpegHealth) IsHealthy() bool             { return f.h.IsHealthy }
+func (f ffmpegHealth) IsReceivingData() bool       { return f.h.IsReceivingData }
+func (f ffmpegHealth) RestartCount() int           { return f.h.RestartCount }
+func (f ffmpegHealth) TotalBytesReceived() int64   { return f.h.TotalBytesReceived }
+func (f ffmpegHealth) BytesPerSecond() float64     { return f.h.BytesPerSecond }
+func (f ffmpegHealth) LastDataReceived() time.Time { return f.h.LastDataReceived }
+func (f ffmpegHealth) SourceChannels() int         { return f.h.SourceChannels }
+func (f ffmpegHealth) ProcessState() string        { return f.h.ProcessState.String() }
+func (f ffmpegHealth) StateHistoryLen() int        { return len(f.h.StateHistory) }
+
+func (f ffmpegHealth) ErrorType() string {
+	if f.h.LastErrorContext != nil {
+		return f.h.LastErrorContext.ErrorType
+	}
+	return ""
+}
+
+// ffmpegProcessStates are the legacy process_state strings the FFmpeg producer
+// can report; the frontend and health API must be able to render each.
+var ffmpegProcessStates = []string{
+	ffmpeg.ProcessStateIdle,
+	ffmpeg.ProcessStateStarting,
+	ffmpeg.ProcessStateRunning,
+	ffmpeg.ProcessStateRestarting,
+	ffmpeg.ProcessStateBackoff,
+	ffmpeg.ProcessStateCircuitOpen,
+	ffmpeg.ProcessStateStopped,
+}
+
+// TestFFmpegManagerContract runs the Phase 0 characterization suite against the
+// live FFmpeg ingest path, using a MediaMTX container as the media server. It
+// records the FFmpeg baseline numbers (grep BASELINE in the output) that the
+// native producer must match or beat in later phases.
+func TestFFmpegManagerContract(t *testing.T) {
+	containers.SkipIfContainerRuntimeUnavailable(t)
+
+	ffmpegPath, err := exec.LookPath("ffmpeg")
+	require.NoError(t, err, "ffmpeg must be on PATH for the ingest contract")
+
+	server, err := containers.NewMediaMTXContainer(t.Context(), nil)
+	require.NoError(t, err, "MediaMTX container should start")
+	t.Cleanup(func() {
+		//nolint:gocritic // t.Context() is already cancelled when Cleanup runs; Terminate needs a live context
+		assert.NoError(t, server.Terminate(context.Background()), "MediaMTX container should terminate cleanly")
+	})
+
+	fixture := streamtest.NewMediaMTXFixture(t, server)
+
+	factory := func(t *testing.T, fc streamtest.FactoryConfig) streamtest.Manager {
+		t.Helper()
+		mgr := ffmpeg.NewManagerWithOptions(
+			t.Context(),
+			fc.OnFrame,
+			fc.OnReset,
+			nil,
+			fc.BufferManager,
+			ffmpeg.Options{SilenceTimeout: fc.SilenceTimeout},
+		)
+		return &ffmpegManagerAdapter{mgr: mgr, ffmpegPath: ffmpegPath}
+	}
+
+	streamtest.RunManagerContract(t, &streamtest.ContractConfig{
+		Factory: factory,
+		Fixture: fixture,
+		Codecs: []streamtest.Codec{
+			streamtest.CodecPCMU,
+			streamtest.CodecPCMA,
+			streamtest.CodecAAC,
+			streamtest.CodecOpus,
+			streamtest.CodecL16,
+		},
+		ValidProcessStates: ffmpegProcessStates,
+		TargetSampleRate:   48000,
+		ProducerName:       "ffmpeg",
+	})
+}
+
+// compile-time guard: the adapter satisfies the contract manager interface.
+var _ streamtest.Manager = (*ffmpegManagerAdapter)(nil)

--- a/internal/audiocore/ffmpeg/options.go
+++ b/internal/audiocore/ffmpeg/options.go
@@ -1,0 +1,43 @@
+package ffmpeg
+
+import "time"
+
+// Options carries manager-level defaults that apply to every stream a Manager
+// starts, as opposed to the per-stream settings on StreamConfig. The zero value
+// reproduces the manager's historic behaviour, so the plain NewManager
+// constructor (which passes a zero Options) is unaffected.
+//
+// The only knob today is SilenceTimeout, which exists so characterization tests
+// can drive the silence watchdog in seconds instead of the production 90 s
+// without mutating the package-level silenceTimeout constant. Later phases fold
+// the remaining per-manager settings (FFmpeg binary path, extra FFmpeg
+// parameters, log level) into this struct as well.
+type Options struct {
+	// SilenceTimeout overrides the per-stream silence watchdog timeout for every
+	// stream started through this manager, unless a stream's own
+	// StreamConfig.SilenceTimeout is already set. Zero keeps the production
+	// default (silenceTimeout, 90 s).
+	//
+	// NOTE: the silence-restart error message embeds this value ("stream stopped
+	// producing data for N seconds"), and internal/errors/telemetry_integration.go
+	// suppresses that error from Sentry by matching the literal 90-second text. A
+	// future phase that wires a non-90s value into a PRODUCTION path must update
+	// that suppression signature to a prefix match or keep the two in sync.
+	SilenceTimeout time.Duration
+}
+
+// withManagerDefaults returns cfg with manager-level defaults applied where the
+// per-stream config leaves them unset. It never mutates the caller's config:
+// when a default has to be applied it returns a shallow copy, otherwise it
+// returns cfg unchanged.
+func (m *Manager) withManagerDefaults(cfg *StreamConfig) *StreamConfig {
+	// Treat any non-positive per-stream value as "unset", matching
+	// effectiveSilenceTimeout, so a negative config value cannot both suppress
+	// the manager option here and fall back to the default there.
+	if cfg.SilenceTimeout <= 0 && m.opts.SilenceTimeout > 0 {
+		c := *cfg
+		c.SilenceTimeout = m.opts.SilenceTimeout
+		return &c
+	}
+	return cfg
+}

--- a/internal/audiocore/ffmpeg/options_test.go
+++ b/internal/audiocore/ffmpeg/options_test.go
@@ -1,0 +1,135 @@
+package ffmpeg
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStreamConfig_effectiveSilenceTimeout pins the accessor that lets the
+// silence watchdog run in seconds under test without mutating the package-level
+// silenceTimeout constant: an unset field falls back to the production default,
+// a set field is honoured verbatim.
+func TestStreamConfig_effectiveSilenceTimeout(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		set  time.Duration
+		want time.Duration
+	}{
+		{name: "zero falls back to default", set: 0, want: silenceTimeout},
+		{name: "explicit value honoured", set: 5 * time.Second, want: 5 * time.Second},
+		{name: "negative falls back to default", set: -1, want: silenceTimeout},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := &StreamConfig{SilenceTimeout: tt.set}
+			assert.Equal(t, tt.want, cfg.effectiveSilenceTimeout())
+		})
+	}
+}
+
+// TestManager_withManagerDefaults verifies that the manager-level SilenceTimeout
+// option is applied to a per-stream config only when the config leaves it unset,
+// and that the caller's config is never mutated in the process.
+func TestManager_withManagerDefaults(t *testing.T) {
+	t.Parallel()
+
+	t.Run("applies option when config leaves it unset", func(t *testing.T) {
+		t.Parallel()
+		mgr := NewManagerWithOptions(t.Context(), nil, nil, nil, nil, Options{SilenceTimeout: 5 * time.Second})
+		in := &StreamConfig{SourceID: "s1"}
+		out := mgr.withManagerDefaults(in)
+		assert.Equal(t, 5*time.Second, out.SilenceTimeout)
+		assert.Zero(t, in.SilenceTimeout, "caller config must not be mutated")
+	})
+
+	t.Run("per-stream value wins over manager option", func(t *testing.T) {
+		t.Parallel()
+		mgr := NewManagerWithOptions(t.Context(), nil, nil, nil, nil, Options{SilenceTimeout: 5 * time.Second})
+		in := &StreamConfig{SourceID: "s1", SilenceTimeout: 42 * time.Second}
+		out := mgr.withManagerDefaults(in)
+		assert.Equal(t, 42*time.Second, out.SilenceTimeout)
+	})
+
+	t.Run("no option leaves config untouched", func(t *testing.T) {
+		t.Parallel()
+		mgr := NewManagerWithOptions(t.Context(), nil, nil, nil, nil, Options{})
+		in := &StreamConfig{SourceID: "s1"}
+		out := mgr.withManagerDefaults(in)
+		assert.Zero(t, out.SilenceTimeout)
+	})
+
+	t.Run("NewManager delegates with zero options", func(t *testing.T) {
+		t.Parallel()
+		mgr := NewManager(t.Context(), nil, nil, nil, nil)
+		require.NotNil(t, mgr)
+		in := &StreamConfig{SourceID: "s1"}
+		out := mgr.withManagerDefaults(in)
+		assert.Zero(t, out.SilenceTimeout, "NewManager must not inject a silence timeout")
+	})
+
+	t.Run("negative config value is treated as unset", func(t *testing.T) {
+		t.Parallel()
+		mgr := NewManagerWithOptions(t.Context(), nil, nil, nil, nil, Options{SilenceTimeout: 5 * time.Second})
+		in := &StreamConfig{SourceID: "s1", SilenceTimeout: -1}
+		out := mgr.withManagerDefaults(in)
+		assert.Equal(t, 5*time.Second, out.SilenceTimeout, "a non-positive config value is unset, so the manager option applies")
+	})
+}
+
+// TestStream_handleSilenceTimeout pins the seam's point of use: the silence
+// watchdog must restart at the configured SilenceTimeout, and a zero value must
+// keep the 90 s default. This is the one production behaviour the integration
+// SilenceRestart case cannot isolate, because a stopped publisher makes MediaMTX
+// tear the reader session down (an EOF-driven restart) before the silence
+// watchdog would fire.
+func TestStream_handleSilenceTimeout(t *testing.T) {
+	t.Parallel()
+
+	const (
+		shortTimeout = 5 * time.Second
+		beyondShort  = 30 * time.Second // older than shortTimeout, younger than 90 s
+		withinShort  = 1 * time.Second
+	)
+
+	tests := []struct {
+		name           string
+		silenceTimeout time.Duration
+		lastDataAge    time.Duration
+		wantRestart    bool
+		wantMsgSeconds string
+	}{
+		{name: "fires at the shortened timeout", silenceTimeout: shortTimeout, lastDataAge: beyondShort, wantRestart: true, wantMsgSeconds: "5 seconds"},
+		{name: "quiet within the shortened timeout does not fire", silenceTimeout: shortTimeout, lastDataAge: withinShort, wantRestart: false},
+		{name: "zero keeps the 90s default so 30s of silence does not fire", silenceTimeout: 0, lastDataAge: beyondShort, wantRestart: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := NewStream(&StreamConfig{
+				SourceID:       "silence-unit",
+				URL:            "rtsp://example.test/stream",
+				SilenceTimeout: tt.silenceTimeout,
+			}, nil, nil, nil, nil)
+
+			s.lastDataMu.Lock()
+			s.lastDataTime = time.Now().Add(-tt.lastDataAge)
+			s.lastDataMu.Unlock()
+
+			err := s.handleSilenceTimeout(time.Now())
+			if tt.wantRestart {
+				require.Error(t, err, "silence past the effective timeout should trigger a restart")
+				assert.Contains(t, err.Error(), tt.wantMsgSeconds, "restart error should name the effective timeout")
+			} else {
+				assert.NoError(t, err, "silence within the effective timeout should not restart")
+			}
+		})
+	}
+}

--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -259,6 +259,13 @@ type StreamConfig struct {
 	// Zero uses defaultHealthyDataThreshold.
 	HealthyDataThreshold time.Duration
 
+	// SilenceTimeout is how long without any received data before the stream
+	// forces a restart. Zero uses the package default (silenceTimeout, 90 s).
+	// Exposed so characterization tests can drive the silence watchdog in
+	// seconds without mutating the package-level constant; production callers
+	// leave it zero.
+	SilenceTimeout time.Duration
+
 	// Debug enables verbose debug logging.
 	Debug bool
 }
@@ -309,6 +316,15 @@ func (c *StreamConfig) healthyThreshold() time.Duration {
 		return c.HealthyDataThreshold
 	}
 	return defaultHealthyDataThreshold
+}
+
+// effectiveSilenceTimeout returns the configured silence timeout or the package
+// default (silenceTimeout) when it is unset or non-positive.
+func (c *StreamConfig) effectiveSilenceTimeout() time.Duration {
+	if c.SilenceTimeout > 0 {
+		return c.SilenceTimeout
+	}
+	return silenceTimeout
 }
 
 // StreamHealth represents the health status of an FFmpeg stream.
@@ -1127,7 +1143,7 @@ func (s *Stream) processAudio() error {
 	s.cmdMu.Unlock()
 
 	if stdout == nil {
-		// During intentional stop, cleanupProcess clears stdout before Run checks —
+		// During intentional stop, cleanupProcess clears stdout before Run checks;
 		// this is expected, not a warning condition.
 		s.stoppedMu.RLock()
 		stopped := s.stopped
@@ -1464,24 +1480,25 @@ func (s *Stream) handleSilenceTimeout(startTime time.Time) error {
 		return time.Since(lastData)
 	}()
 
-	if effectiveAge > 0 && effectiveAge > silenceTimeout {
+	timeout := s.config.effectiveSilenceTimeout()
+	if effectiveAge > 0 && effectiveAge > timeout {
 		lastDataDesc := formatLastDataDescription(lastData)
 
 		getStreamLogger().Warn("no data received from stream source, triggering restart",
 			logger.String("url", s.config.safeURL()),
-			logger.Float64("timeout_seconds", silenceTimeout.Seconds()),
+			logger.Float64("timeout_seconds", timeout.Seconds()),
 			logger.String("last_data", lastDataDesc),
 			logger.Float64("effective_age_seconds", effectiveAge.Seconds()),
 			logger.Float64("process_runtime_seconds", time.Since(startTime).Seconds()),
 			logger.String("component", "ffmpeg-stream"),
 			logger.String("operation", "silence_detected"))
 		s.cleanupProcess()
-		return errors.Newf("stream stopped producing data for %v seconds", silenceTimeout.Seconds()).
+		return errors.Newf("stream stopped producing data for %v seconds", timeout.Seconds()).
 			Category(errors.CategoryRTSP).
 			Component("ffmpeg-stream").
 			Context("operation", "silence_timeout").
 			Context("url", s.config.safeURL()).
-			Context("timeout_seconds", silenceTimeout.Seconds()).
+			Context("timeout_seconds", timeout.Seconds()).
 			Context("last_data", lastDataDesc).
 			Build()
 	}
@@ -1590,7 +1607,7 @@ func (s *Stream) handleQuickExitError(startTime time.Time) error {
 				processState = s.exitProcessState
 				s.exitInfoMu.Unlock()
 			case <-time.After(stderrDrainTimeout):
-				// cmd.Wait() still pending — proceed with partial stderr.
+				// cmd.Wait() still pending; proceed with partial stderr.
 			}
 		}
 	}
@@ -1912,7 +1929,7 @@ func (s *Stream) GetHealth() StreamHealth {
 	var isHealthy, isReceivingData bool
 	switch {
 	case state != StateRunning:
-		// Stream is not actively processing audio — always unhealthy.
+		// Stream is not actively processing audio; always unhealthy.
 		// Covers StateIdle, StateStarting, StateRestarting, StateBackoff,
 		// StateCircuitOpen, and StateStopped.
 		isHealthy = false

--- a/internal/audiocore/streamtest/assert.go
+++ b/internal/audiocore/streamtest/assert.go
@@ -1,0 +1,108 @@
+package streamtest
+
+import (
+	"math"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore/convert"
+)
+
+// Signal-analysis constants for the tone assertions.
+const (
+	// silenceFloorDBFS is returned by RMSDBFS for input with no measurable
+	// energy, so callers get a finite, deeply negative value instead of -Inf.
+	silenceFloorDBFS = -200.0
+
+	// coarseScanStepHz and fineScanStepHz control the two-pass Goertzel sweep in
+	// DominantFrequency: a coarse sweep finds the rough peak, a fine sweep around
+	// it pins the frequency to within the 1% tolerance the tone checks need.
+	coarseScanStepHz = 5.0
+	fineScanStepHz   = 0.5
+
+	// scanLowHz and scanHighHz bound the search. They comfortably contain the
+	// 1 kHz reference tone and its low harmonics while excluding DC drift and
+	// codec artefacts near Nyquist.
+	scanLowHz  = 50.0
+	scanHighHz = 8000.0
+
+	// fineScanHalfWindowHz is the half-width of the fine sweep around the coarse
+	// peak.
+	fineScanHalfWindowHz = 2 * coarseScanStepHz
+
+	// minScanFreqHz is the lowest frequency the fine sweep will probe, keeping the
+	// scan above DC even when the coarse peak sits near the low bound.
+	minScanFreqHz = 1.0
+)
+
+// samplesFromS16LE decodes mono s16le PCM into float64 samples in [-1, 1) using
+// the same convention the production pipeline uses (convert.BytesToFloat64PCM16),
+// so the characterization measurement never drifts from the real decode.
+func samplesFromS16LE(pcm []byte) []float64 {
+	return convert.BytesToFloat64PCM16(pcm)
+}
+
+// goertzelPower returns the (unnormalised) power of frequency freq in samples
+// taken at sampleRate, via the Goertzel algorithm.
+func goertzelPower(samples []float64, freq float64, sampleRate int) float64 {
+	if len(samples) == 0 || sampleRate <= 0 {
+		return 0
+	}
+	omega := 2 * math.Pi * freq / float64(sampleRate)
+	coeff := 2 * math.Cos(omega)
+	var s0, s1, s2 float64
+	for _, x := range samples {
+		s0 = x + coeff*s1 - s2
+		s2 = s1
+		s1 = s0
+	}
+	return s1*s1 + s2*s2 - coeff*s1*s2
+}
+
+// scanPeak returns the frequency in [low, high] (stepping by step) whose
+// Goertzel power is greatest, clamping high to just under Nyquist.
+func scanPeak(samples []float64, sampleRate int, low, high, step float64) float64 {
+	nyquist := float64(sampleRate) / 2
+	if high > nyquist {
+		high = nyquist - step
+	}
+	bestFreq := low
+	bestPower := math.Inf(-1)
+	for f := low; f <= high; f += step {
+		if p := goertzelPower(samples, f, sampleRate); p > bestPower {
+			bestPower = p
+			bestFreq = f
+		}
+	}
+	return bestFreq
+}
+
+// DominantFrequency returns the frequency in Hz carrying the most energy in
+// mono s16le PCM sampled at sampleRate. It runs a coarse Goertzel sweep across
+// the audible band followed by a fine sweep around the peak, which is accurate
+// enough to confirm a published test tone survives the ingest pipeline. It
+// returns 0 when there is less than one full sample.
+func DominantFrequency(pcm []byte, sampleRate int) float64 {
+	samples := samplesFromS16LE(pcm)
+	if len(samples) == 0 || sampleRate <= 0 {
+		return 0
+	}
+	coarse := scanPeak(samples, sampleRate, scanLowHz, scanHighHz, coarseScanStepHz)
+	low := math.Max(coarse-fineScanHalfWindowHz, minScanFreqHz)
+	high := coarse + fineScanHalfWindowHz
+	return scanPeak(samples, sampleRate, low, high, fineScanStepHz)
+}
+
+// RMSDBFS returns the RMS level of mono s16le PCM in dBFS, where 0 dBFS is a
+// full-scale int16. Silence and empty input return silenceFloorDBFS rather than
+// negative infinity.
+func RMSDBFS(pcm []byte) float64 {
+	samples := samplesFromS16LE(pcm)
+	if len(samples) == 0 {
+		return silenceFloorDBFS
+	}
+	rms := math.Sqrt(convert.SumOfSquaresFloat64(samples) / float64(len(samples)))
+	if rms <= 0 {
+		return silenceFloorDBFS
+	}
+	db := 20 * math.Log10(rms)
+	return math.Max(db, silenceFloorDBFS)
+}

--- a/internal/audiocore/streamtest/assert_test.go
+++ b/internal/audiocore/streamtest/assert_test.go
@@ -1,0 +1,83 @@
+package streamtest
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// synthToneS16LE builds mono s16le PCM of a sine wave, for exercising the
+// signal-analysis helpers without any audio pipeline.
+func synthToneS16LE(freq float64, sampleRate, samples int, amplitude float64) []byte {
+	buf := make([]byte, samples*2)
+	for i := range samples {
+		v := amplitude * math.Sin(2*math.Pi*freq*float64(i)/float64(sampleRate))
+		s := int16(math.Round(v * math.MaxInt16))
+		binary.LittleEndian.PutUint16(buf[i*2:], uint16(s))
+	}
+	return buf
+}
+
+func TestDominantFrequency(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		freq       float64
+		sampleRate int
+	}{
+		{name: "1kHz at 48k", freq: 1000, sampleRate: 48000},
+		{name: "440Hz at 48k", freq: 440, sampleRate: 48000},
+		{name: "2kHz at 96k", freq: 2000, sampleRate: 96000},
+		{name: "1kHz at 16k", freq: 1000, sampleRate: 16000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			// 0.5 s of tone is plenty of resolution for a coarse+fine scan.
+			pcm := synthToneS16LE(tt.freq, tt.sampleRate, tt.sampleRate/2, 0.5)
+			got := DominantFrequency(pcm, tt.sampleRate)
+			// Within 1% of the true tone.
+			assert.InEpsilon(t, tt.freq, got, 0.01)
+		})
+	}
+}
+
+func TestRMSDBFS(t *testing.T) {
+	t.Parallel()
+
+	t.Run("full-scale sine is about -3 dBFS", func(t *testing.T) {
+		t.Parallel()
+		pcm := synthToneS16LE(1000, 48000, 48000, 1.0)
+		// A full-scale sine has RMS = 1/sqrt(2) => 20*log10(0.707) = -3.01 dBFS.
+		assert.InDelta(t, -3.01, RMSDBFS(pcm), 0.2)
+	})
+
+	t.Run("half-scale sine is about -9 dBFS", func(t *testing.T) {
+		t.Parallel()
+		pcm := synthToneS16LE(1000, 48000, 48000, 0.5)
+		assert.InDelta(t, -9.03, RMSDBFS(pcm), 0.2)
+	})
+
+	t.Run("silence is deeply negative", func(t *testing.T) {
+		t.Parallel()
+		pcm := make([]byte, 48000*2)
+		assert.Less(t, RMSDBFS(pcm), -100.0)
+	})
+
+	t.Run("empty input is deeply negative", func(t *testing.T) {
+		t.Parallel()
+		assert.Less(t, RMSDBFS(nil), -100.0)
+	})
+}
+
+func TestDominantFrequencyRejectsShortInput(t *testing.T) {
+	t.Parallel()
+	// Fewer than one full sample pair should not panic; it returns 0.
+	got := DominantFrequency([]byte{0x01}, 48000)
+	require.Zero(t, got)
+}

--- a/internal/audiocore/streamtest/contract.go
+++ b/internal/audiocore/streamtest/contract.go
@@ -1,0 +1,421 @@
+package streamtest
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+	"github.com/tphakala/birdnet-go/internal/audiocore/buffer"
+)
+
+// Contract timing and shape constants. Timeouts are generous so the suite stays
+// green on slow CI while still bounding each behaviour; the cases that record a
+// baseline log the value they actually measured (grep BASELINE in test output).
+const (
+	// defaultTargetSampleRate is the analysis rate BirdNET-Go feeds its model.
+	defaultTargetSampleRate = 48000
+
+	// highSampleRate is the bat-path rate exercised by HighRatePassthrough.
+	highSampleRate = 96000
+
+	// s16BytesPerSample and monoChannels describe the dispatched PCM geometry.
+	s16BytesPerSample = 2
+	monoChannels      = 1
+	targetBitDepth    = 16
+
+	// maxFrameBytes is the largest frame the FFmpeg reader emits (its 32 KiB
+	// stdout buffer); every producer must stay at or below it.
+	maxFrameBytes = 32768
+
+	// defaultHealthyThreshold keeps the healthy/unhealthy transition fast under
+	// test instead of the 60 s production default.
+	defaultHealthyThreshold = 8 * time.Second
+
+	// silenceTimeoutUnderTest shortens the producer silence watchdog so
+	// SilenceRestart completes in seconds.
+	silenceTimeoutUnderTest = 5 * time.Second
+
+	// Timing budgets for the individual cases.
+	healthyWithinBudget    = 20 * time.Second
+	firstFrameBudget       = 20 * time.Second
+	fidelityCollectWindow  = 2 * time.Second
+	dataRateWindow         = 10 * time.Second
+	silenceRestartBudget   = 25 * time.Second
+	serverGoneStopFor      = 20 * time.Second
+	serverReconnectBudget  = 75 * time.Second
+	errorClarityBudget     = 35 * time.Second
+	receivingFalseBudget   = 12 * time.Second
+	shutdownTimeout        = 15 * time.Second
+	pollInterval           = 250 * time.Millisecond
+	streamStartSettle      = 500 * time.Millisecond
+	dominantFreqToleranceR = 0.02 // dominant frequency must be within 2% of the tone
+	toneFrequencyHz        = 1000.0
+	nonSilentFloorDBFS     = -40.0           // dispatched audio must be clearly above this
+	dataRateTolerance      = 0.10            // dispatched byte rate within 10% of nominal
+	healthRateTolerance    = 0.15            // health BytesPerSecond vs nominal (looser: sampled)
+	g711SampleRate         = 8000            // G.711 is defined at 8 kHz mono
+	healthyObserveWindow   = 3 * time.Second // steady-state observation window
+)
+
+// StreamSpec is the protocol-neutral per-stream configuration the contract suite
+// hands to a producer's StartStream. It mirrors the fields the engine already
+// builds for the FFmpeg producer today; Phase 1 promotes an equivalent type into
+// the audiocore package. Producer-specific settings (FFmpeg binary path, log
+// level) are the factory's concern, not this struct's.
+type StreamSpec struct {
+	SourceID             string
+	SourceName           string
+	URL                  string
+	Type                 string // "rtsp", "http", "hls", "udp"
+	SampleRate           int    // target output rate (48000, or the bat rate)
+	SourceSampleRate     int    // probed source rate, 0 when unknown
+	BitDepth             int    // 16
+	Channels             int    // target channels (1)
+	SourceChannels       int    // probed source channels, 0 when unknown
+	ChannelMode          string // downmix, left, right
+	MediaMode            string // auto, audio-only, full-stream
+	Transport            string // tcp, udp (RTSP only)
+	HealthyDataThreshold time.Duration
+	Debug                bool
+}
+
+// Codec identifies the wire codec a Fixture should publish. The values are the
+// FFmpeg encoder names so a MediaMTX-backed fixture can pass them straight
+// through; a producer's contract run lists the subset it supports.
+type Codec string
+
+const (
+	CodecOpus Codec = "opus"      // libopus, 48 kHz
+	CodecPCMU Codec = "pcm_mulaw" // G.711 mu-law, 8 kHz
+	CodecPCMA Codec = "pcm_alaw"  // G.711 A-law, 8 kHz
+	CodecAAC  Codec = "aac"       // AAC-LC
+	CodecL16  Codec = "pcm_s16be" // L16 big-endian PCM
+)
+
+// Health is a read-only view of a producer's per-stream health snapshot. Both
+// producers adapt their concrete health type to it so the suite reads the same
+// fields regardless of implementation.
+type Health interface {
+	IsHealthy() bool
+	IsReceivingData() bool
+	RestartCount() int
+	TotalBytesReceived() int64
+	BytesPerSecond() float64
+	LastDataReceived() time.Time
+	SourceChannels() int
+	// ProcessState is the legacy process_state string the health API and
+	// frontend switch on; it must always be one of ContractConfig.ValidProcessStates.
+	ProcessState() string
+	// ErrorType is LastErrorContext.ErrorType, or "" when no error is recorded.
+	ErrorType() string
+	// StateHistoryLen reports how many lifecycle transitions the producer has
+	// retained, so the suite can confirm transitions were recorded.
+	StateHistoryLen() int
+}
+
+// Manager is the minimal producer contract the characterization suite drives. It
+// is the de facto surface the engine calls on ffmpeg.Manager today (spec section
+// 2.2), narrowed to what the suite needs. Producers satisfy it through a thin
+// adapter so the SAME suite runs unchanged against nativestream.Manager later.
+type Manager interface {
+	// StartStream begins capturing spec.SourceID and dispatching its frames.
+	StartStream(spec *StreamSpec) error
+	// StopStream stops capture for sourceID and forgets it.
+	StopStream(sourceID string) error
+	// StreamHealth returns a point-in-time health snapshot for one stream.
+	StreamHealth(sourceID string) (Health, error)
+	// AllStreamHealth returns snapshots for every tracked stream, keyed by source ID.
+	AllStreamHealth() map[string]Health
+	// GetActiveStreamIDs lists the currently tracked source IDs.
+	GetActiveStreamIDs() []string
+	// SetOnStreamReset registers the callback invoked when a stream is (re)started.
+	SetOnStreamReset(fn func(sourceID string))
+	// Shutdown stops every stream with the producer's default timeout.
+	Shutdown() error
+	// ShutdownWithContext stops every stream, honouring ctx's deadline.
+	ShutdownWithContext(ctx context.Context) error
+}
+
+// FactoryConfig carries the wiring a producer needs to build a Manager that
+// dispatches into the suite's frame collector.
+type FactoryConfig struct {
+	// OnFrame receives every dispatched frame; the suite passes its collector.
+	OnFrame func(frame audiocore.AudioFrame)
+	// OnReset receives every stream reset notification; may be nil.
+	OnReset func(sourceID string)
+	// BufferManager, when non-nil, must make the producer attach a pooled
+	// FrameRef to each frame; when nil, frames carry a nil Ref.
+	BufferManager *buffer.Manager
+	// SilenceTimeout overrides the producer silence watchdog; 0 keeps its default.
+	SilenceTimeout time.Duration
+}
+
+// ManagerFactory builds a Manager from a FactoryConfig. Supplying a different
+// factory is the only change needed to run the suite against another producer.
+type ManagerFactory func(t *testing.T, cfg FactoryConfig) Manager
+
+// PublishOptions describe a stream a Fixture should start publishing.
+type PublishOptions struct {
+	Path       string // stream path; empty means the fixture picks a unique one
+	Codec      Codec
+	SampleRate int
+	Channels   int
+	WithVideo  bool
+}
+
+// Publication is a live publisher the suite reads from. Stop halts just this
+// publisher while the server stays up; Restart brings it back.
+type Publication interface {
+	URL() string
+	Stop(t *testing.T)
+	Restart(t *testing.T)
+}
+
+// Fixture provides live streams and server control for the contract suite. The
+// MediaMTX-backed implementation lives alongside the suite behind the
+// integration build tag; a fake-server implementation can back it later.
+type Fixture interface {
+	// Publish starts a publisher and returns once the stream is live.
+	Publish(t *testing.T, opts PublishOptions) Publication
+	// URLForPath returns a read URL for an arbitrary (possibly unpublished) path,
+	// used to characterize the "path not found" error.
+	URLForPath(path string) string
+	// UnreachableHostURL returns a URL whose host is routable-but-dead so the
+	// connect times out.
+	UnreachableHostURL() string
+	// RefusedPortURL returns a URL on a live host with a closed port so the
+	// connection is refused.
+	RefusedPortURL() string
+	// BadAuthURL returns a URL with wrong credentials for an auth-protected path,
+	// or "" when the fixture does not enforce authentication.
+	BadAuthURL(t *testing.T) string
+	// StopServer and StartServer stop and restart the whole media server.
+	StopServer(t *testing.T)
+	StartServer(t *testing.T)
+	// SupportsVideo reports whether Publish can add a video track (for MediaModes).
+	SupportsVideo() bool
+}
+
+// ContractConfig bundles everything RunManagerContract needs.
+type ContractConfig struct {
+	// Factory builds the producer under test.
+	Factory ManagerFactory
+	// Fixture supplies live streams and server control.
+	Fixture Fixture
+	// Codecs is the PCMFidelity matrix the producer supports.
+	Codecs []Codec
+	// ValidProcessStates is the set of legacy process_state strings the producer
+	// may report; the frontend must be able to render each.
+	ValidProcessStates []string
+	// TargetSampleRate is the analysis rate (defaults to 48000).
+	TargetSampleRate int
+	// ProducerName labels baseline log lines (e.g. "ffmpeg").
+	ProducerName string
+}
+
+func (c *ContractConfig) applyDefaults() {
+	if c.TargetSampleRate == 0 {
+		c.TargetSampleRate = defaultTargetSampleRate
+	}
+	if c.ProducerName == "" {
+		c.ProducerName = "producer"
+	}
+	if len(c.Codecs) == 0 {
+		c.Codecs = []Codec{CodecOpus}
+	}
+}
+
+// RunManagerContract runs the full characterization suite against the producer
+// built by cfg.Factory, using cfg.Fixture for live streams. Each behaviour is a
+// named subtest so later phases can report them individually. The subtests run
+// sequentially because they share the fixture and some manipulate server state.
+func RunManagerContract(t *testing.T, cfg *ContractConfig) {
+	t.Helper()
+	require.NotNil(t, cfg, "ContractConfig is required")
+	require.NotNil(t, cfg.Factory, "ContractConfig.Factory is required")
+	require.NotNil(t, cfg.Fixture, "ContractConfig.Fixture is required")
+	cfg.applyDefaults()
+
+	t.Run("FrameShape", func(t *testing.T) { caseFrameShape(t, cfg) })
+	t.Run("PCMFidelity", func(t *testing.T) { casePCMFidelity(t, cfg) })
+	t.Run("DataRate", func(t *testing.T) { caseDataRate(t, cfg) })
+	t.Run("Lifecycle", func(t *testing.T) { caseLifecycle(t, cfg) })
+	t.Run("OnResetFires", func(t *testing.T) { caseOnResetFires(t, cfg) })
+	t.Run("HealthTransitions", func(t *testing.T) { caseHealthTransitions(t, cfg) })
+	t.Run("SilenceRestart", func(t *testing.T) { caseSilenceRestart(t, cfg) })
+	t.Run("ServerGoneReconnect", func(t *testing.T) { caseServerGoneReconnect(t, cfg) })
+	t.Run("MediaModes", func(t *testing.T) { caseMediaModes(t, cfg) })
+	t.Run("MultiStream", func(t *testing.T) { caseMultiStream(t, cfg) })
+	t.Run("HighRatePassthrough", func(t *testing.T) { caseHighRatePassthrough(t, cfg) })
+	t.Run("ErrorClarity", func(t *testing.T) { caseErrorClarity(t, cfg) })
+	t.Run("TimeToFirstFrame", func(t *testing.T) { caseTimeToFirstFrame(t, cfg) })
+	// Cases 12 (EngineReconfigure) and 13 (LivenessChain) are engine-level and
+	// live in internal/audiocore/engine/engine_contract_test.go, so the case
+	// numbers in contract_cases.go jump from 11 to 14.
+}
+
+// capturedFrame is a copy of a dispatched frame's observable properties. Data is
+// copied because a producer may recycle the underlying pooled slice as soon as
+// the callback returns.
+type capturedFrame struct {
+	SourceID   string
+	SourceName string
+	Data       []byte
+	SampleRate int
+	BitDepth   int
+	Channels   int
+	Timestamp  time.Time
+	HadRef     bool
+	ReceivedAt time.Time
+}
+
+// frameCollector records dispatched frames and reset notifications from producer
+// goroutines. It never calls t assertions itself (see TESTING.md): the test
+// goroutine reads snapshots and asserts.
+type frameCollector struct {
+	mu     sync.Mutex
+	frames []capturedFrame
+	resets []string
+}
+
+func (c *frameCollector) onFrame(f audiocore.AudioFrame) { //nolint:gocritic // hugeParam: matches FrameCallback/AudioConsumer contract
+	data := make([]byte, len(f.Data))
+	copy(data, f.Data)
+	c.mu.Lock()
+	c.frames = append(c.frames, capturedFrame{
+		SourceID:   f.SourceID,
+		SourceName: f.SourceName,
+		Data:       data,
+		SampleRate: f.SampleRate,
+		BitDepth:   f.BitDepth,
+		Channels:   f.Channels,
+		Timestamp:  f.Timestamp,
+		HadRef:     f.Ref != nil,
+		ReceivedAt: time.Now(),
+	})
+	c.mu.Unlock()
+}
+
+func (c *frameCollector) onReset(sourceID string) {
+	c.mu.Lock()
+	c.resets = append(c.resets, sourceID)
+	c.mu.Unlock()
+}
+
+func (c *frameCollector) snapshot() []capturedFrame {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]capturedFrame, len(c.frames))
+	copy(out, c.frames)
+	return out
+}
+
+func (c *frameCollector) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.frames)
+}
+
+func (c *frameCollector) resetCount(sourceID string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	n := 0
+	for _, id := range c.resets {
+		if id == sourceID {
+			n++
+		}
+	}
+	return n
+}
+
+// reset clears recorded frames and resets so a case can measure a fresh window.
+func (c *frameCollector) reset() {
+	c.mu.Lock()
+	c.frames = c.frames[:0]
+	c.resets = c.resets[:0]
+	c.mu.Unlock()
+}
+
+// concatData returns all dispatched PCM bytes in receipt order.
+func (c *frameCollector) concatData() []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var total int
+	for i := range c.frames {
+		total += len(c.frames[i].Data)
+	}
+	out := make([]byte, 0, total)
+	//nolint:gocritic // ruleguard false positive: appends distinct per-frame PCM, not a repetition of one slice
+	for i := range c.frames {
+		out = append(out, c.frames[i].Data...)
+	}
+	return out
+}
+
+// rtspSpec builds a standard RTSP StreamSpec for the given source ID and URL.
+func (c *ContractConfig) rtspSpec(sourceID, url string) *StreamSpec {
+	return &StreamSpec{
+		SourceID:             sourceID,
+		SourceName:           sourceID + " display",
+		URL:                  url,
+		Type:                 "rtsp",
+		SampleRate:           c.TargetSampleRate,
+		BitDepth:             targetBitDepth,
+		Channels:             monoChannels,
+		ChannelMode:          "downmix",
+		MediaMode:            "auto",
+		Transport:            "tcp",
+		HealthyDataThreshold: defaultHealthyThreshold,
+	}
+}
+
+// harness bundles a manager with the collector feeding it, plus cleanup.
+type harness struct {
+	mgr       Manager
+	collector *frameCollector
+}
+
+// newHarness builds a manager wired to a fresh collector and registers Shutdown
+// as test cleanup.
+func newHarness(t *testing.T, cfg *ContractConfig, bufMgr *buffer.Manager, silence time.Duration) *harness {
+	t.Helper()
+	coll := &frameCollector{}
+	mgr := cfg.Factory(t, FactoryConfig{
+		OnFrame:        coll.onFrame,
+		OnReset:        coll.onReset,
+		BufferManager:  bufMgr,
+		SilenceTimeout: silence,
+	})
+	require.NotNil(t, mgr, "factory must return a manager")
+	t.Cleanup(func() {
+		//nolint:gocritic // t.Context() is already cancelled when Cleanup runs; shutdown needs a live context
+		ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		assert.NoError(t, mgr.ShutdownWithContext(ctx), "manager should shut down cleanly")
+	})
+	return &harness{mgr: mgr, collector: coll}
+}
+
+// bufferManagerFor builds a real buffer.Manager for cases that assert pooled Ref.
+func bufferManagerFor(t *testing.T) *buffer.Manager {
+	t.Helper()
+	return buffer.NewManager(nil)
+}
+
+// waitForFrames blocks until at least n frames have been collected or the budget
+// elapses, returning whether the target was reached.
+func waitForFrames(coll *frameCollector, n int, budget time.Duration) bool {
+	deadline := time.Now().Add(budget)
+	for time.Now().Before(deadline) {
+		if coll.count() >= n {
+			return true
+		}
+		time.Sleep(pollInterval)
+	}
+	return coll.count() >= n
+}

--- a/internal/audiocore/streamtest/contract_cases.go
+++ b/internal/audiocore/streamtest/contract_cases.go
@@ -1,0 +1,467 @@
+package streamtest
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+// pathSeq gives each published stream a unique MediaMTX path within a run.
+var pathSeq atomic.Uint64
+
+func uniquePath(prefix string) string {
+	return fmt.Sprintf("%s-%d", prefix, pathSeq.Add(1))
+}
+
+// pollHealth returns the health snapshot for sourceID, failing the test if the
+// stream is unknown.
+func pollHealth(t *testing.T, mgr Manager, sourceID string) Health {
+	t.Helper()
+	h, err := mgr.StreamHealth(sourceID)
+	require.NoError(t, err, "StreamHealth(%s)", sourceID)
+	require.NotNil(t, h)
+	return h
+}
+
+// requireHealthy waits until the stream reports healthy or the budget elapses.
+func requireHealthy(t *testing.T, mgr Manager, sourceID string, budget time.Duration) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		h, err := mgr.StreamHealth(sourceID)
+		return err == nil && h != nil && h.IsHealthy()
+	}, budget, pollInterval, "stream %s should become healthy", sourceID)
+}
+
+// caseFrameShape (contract case 1): every dispatched frame carries the spec's
+// identity and the expected PCM geometry, a pooled Ref when a buffer manager is
+// wired and a nil Ref when it is not.
+func caseFrameShape(t *testing.T, cfg *ContractConfig) {
+	t.Helper()
+	pub := cfg.Fixture.Publish(t, PublishOptions{Codec: CodecOpus, SampleRate: cfg.TargetSampleRate, Channels: monoChannels})
+	t.Cleanup(func() { pub.Stop(t) })
+
+	t.Run("pooled Ref when buffer manager wired", func(t *testing.T) {
+		h := newHarness(t, cfg, bufferManagerFor(t), 0)
+		spec := cfg.rtspSpec(uniquePath("frameshape"), pub.URL())
+		require.NoError(t, h.mgr.StartStream(spec))
+		require.True(t, waitForFrames(h.collector, 3, firstFrameBudget), "frames should flow")
+
+		frames := h.collector.snapshot()
+		for i := range frames {
+			f := &frames[i]
+			assert.Equal(t, spec.SourceID, f.SourceID)
+			assert.Equal(t, spec.SourceName, f.SourceName)
+			assert.Equal(t, spec.SampleRate, f.SampleRate)
+			assert.Equal(t, targetBitDepth, f.BitDepth)
+			assert.Equal(t, monoChannels, f.Channels)
+			assert.NotEmpty(t, f.Data)
+			assert.Zero(t, len(f.Data)%s16BytesPerSample, "PCM length must be sample-aligned")
+			assert.LessOrEqual(t, len(f.Data), maxFrameBytes)
+			assert.True(t, f.HadRef, "frame should carry a pooled Ref when bufMgr is wired")
+			assert.WithinDuration(t, f.ReceivedAt, f.Timestamp, time.Second)
+		}
+	})
+
+	t.Run("nil Ref when no buffer manager", func(t *testing.T) {
+		h := newHarness(t, cfg, nil, 0)
+		spec := cfg.rtspSpec(uniquePath("frameshape-noref"), pub.URL())
+		require.NoError(t, h.mgr.StartStream(spec))
+		require.True(t, waitForFrames(h.collector, 3, firstFrameBudget), "frames should flow")
+		frames := h.collector.snapshot()
+		for i := range frames {
+			assert.False(t, frames[i].HadRef, "frame should have a nil Ref when no bufMgr is wired")
+		}
+	})
+}
+
+// casePCMFidelity (contract case 2): the published 1 kHz tone survives ingest for
+// every codec in the matrix, staying near 1000 Hz and clearly non-silent.
+func casePCMFidelity(t *testing.T, cfg *ContractConfig) {
+	t.Helper()
+	for _, codec := range cfg.Codecs {
+		t.Run(string(codec), func(t *testing.T) {
+			rate := cfg.TargetSampleRate
+			channels := monoChannels
+			// G.711 is defined at 8 kHz mono; publish it that way and let the
+			// producer resample to the analysis rate.
+			if codec == CodecPCMU || codec == CodecPCMA {
+				rate = g711SampleRate
+			}
+			pub := cfg.Fixture.Publish(t, PublishOptions{Codec: codec, SampleRate: rate, Channels: channels})
+			t.Cleanup(func() { pub.Stop(t) })
+
+			h := newHarness(t, cfg, bufferManagerFor(t), 0)
+			spec := cfg.rtspSpec(uniquePath("fidelity-"+string(codec)), pub.URL())
+			require.NoError(t, h.mgr.StartStream(spec))
+			require.True(t, waitForFrames(h.collector, 1, firstFrameBudget), "frames should flow")
+
+			// Collect a fidelity window of audio.
+			h.collector.reset()
+			time.Sleep(fidelityCollectWindow)
+			pcm := h.collector.concatData()
+			require.NotEmpty(t, pcm, "should have collected PCM")
+
+			dominant := DominantFrequency(pcm, cfg.TargetSampleRate)
+			rms := RMSDBFS(pcm)
+			t.Logf("BASELINE %s PCMFidelity codec=%s dominantHz=%.1f rmsDBFS=%.2f", cfg.ProducerName, codec, dominant, rms)
+			assert.InEpsilon(t, toneFrequencyHz, dominant, dominantFreqToleranceR,
+				"dominant frequency should be ~1000 Hz for codec %s", codec)
+			assert.Greater(t, rms, nonSilentFloorDBFS, "dispatched audio should be clearly non-silent for codec %s", codec)
+		})
+	}
+}
+
+// caseDataRate (contract case 3): the dispatched byte rate matches the analysis
+// geometry and the health snapshot agrees.
+func caseDataRate(t *testing.T, cfg *ContractConfig) {
+	t.Helper()
+	pub := cfg.Fixture.Publish(t, PublishOptions{Codec: CodecOpus, SampleRate: cfg.TargetSampleRate, Channels: monoChannels})
+	t.Cleanup(func() { pub.Stop(t) })
+
+	h := newHarness(t, cfg, bufferManagerFor(t), 0)
+	spec := cfg.rtspSpec(uniquePath("datarate"), pub.URL())
+	require.NoError(t, h.mgr.StartStream(spec))
+	requireHealthy(t, h.mgr, spec.SourceID, healthyWithinBudget)
+
+	h.collector.reset()
+	start := time.Now()
+	time.Sleep(dataRateWindow)
+	elapsed := time.Since(start)
+	bytesGot := len(h.collector.concatData())
+
+	nominal := float64(cfg.TargetSampleRate * s16BytesPerSample)
+	measured := float64(bytesGot) / elapsed.Seconds()
+	health := pollHealth(t, h.mgr, spec.SourceID)
+	t.Logf("BASELINE %s DataRate nominalBps=%.0f dispatchedBps=%.0f healthBps=%.0f",
+		cfg.ProducerName, nominal, measured, health.BytesPerSecond())
+
+	assert.InEpsilon(t, nominal, measured, dataRateTolerance, "dispatched byte rate should match analysis geometry")
+	assert.InEpsilon(t, nominal, health.BytesPerSecond(), healthRateTolerance, "health BytesPerSecond should agree with dispatched rate")
+}
+
+// caseLifecycle (contract case 4): duplicate starts and unknown stops error,
+// active tracking is accurate, and Shutdown is clean with no leaked goroutines.
+func caseLifecycle(t *testing.T, cfg *ContractConfig) {
+	t.Helper()
+	leakOpt := goleak.IgnoreCurrent()
+
+	pub := cfg.Fixture.Publish(t, PublishOptions{Codec: CodecOpus, SampleRate: cfg.TargetSampleRate, Channels: monoChannels})
+	t.Cleanup(func() { pub.Stop(t) })
+
+	coll := &frameCollector{}
+	mgr := cfg.Factory(t, FactoryConfig{OnFrame: coll.onFrame, OnReset: coll.onReset, BufferManager: bufferManagerFor(t)})
+	require.NotNil(t, mgr)
+
+	spec := cfg.rtspSpec(uniquePath("lifecycle"), pub.URL())
+	require.NoError(t, mgr.StartStream(spec), "first start should succeed")
+	require.Error(t, mgr.StartStream(spec), "duplicate start should error")
+	require.Error(t, mgr.StopStream("does-not-exist"), "stopping an unknown stream should error")
+
+	assert.Contains(t, mgr.GetActiveStreamIDs(), spec.SourceID)
+	assert.Contains(t, mgr.AllStreamHealth(), spec.SourceID)
+
+	require.True(t, waitForFrames(coll, 1, firstFrameBudget), "frames should flow before stop")
+	require.NoError(t, mgr.StopStream(spec.SourceID))
+	assert.NotContains(t, mgr.GetActiveStreamIDs(), spec.SourceID)
+	assert.NotContains(t, mgr.AllStreamHealth(), spec.SourceID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+	require.NoError(t, mgr.ShutdownWithContext(ctx), "shutdown should return within the timeout")
+
+	// os/exec.(*Cmd).watchCtx is the Go stdlib goroutine that watches a child
+	// process's context; it is reaped by the runtime shortly after the child
+	// exits and is not a producer goroutine, so it is ignored here. Any other
+	// lingering goroutine is a real leak the producer must not have.
+	goleak.VerifyNone(t, leakOpt, goleak.IgnoreAnyFunction("os/exec.(*Cmd).watchCtx"))
+}
+
+// caseOnResetFires (contract case 5): the reset callback fires exactly once for a
+// fresh StartStream and stays stable while the stream runs healthy.
+func caseOnResetFires(t *testing.T, cfg *ContractConfig) {
+	t.Helper()
+	pub := cfg.Fixture.Publish(t, PublishOptions{Codec: CodecOpus, SampleRate: cfg.TargetSampleRate, Channels: monoChannels})
+	t.Cleanup(func() { pub.Stop(t) })
+
+	h := newHarness(t, cfg, bufferManagerFor(t), 0)
+	spec := cfg.rtspSpec(uniquePath("onreset"), pub.URL())
+	require.NoError(t, h.mgr.StartStream(spec))
+	require.Equal(t, 1, h.collector.resetCount(spec.SourceID), "reset should fire once on StartStream")
+
+	requireHealthy(t, h.mgr, spec.SourceID, healthyWithinBudget)
+	// While the stream stays healthy there must be no further resets.
+	time.Sleep(healthyObserveWindow)
+	assert.Equal(t, 1, h.collector.resetCount(spec.SourceID), "no extra resets while healthy")
+}
+
+// caseHealthTransitions (contract case 6): health flags track a stream going
+// silent and recovering, and the legacy process_state string is always valid.
+func caseHealthTransitions(t *testing.T, cfg *ContractConfig) {
+	t.Helper()
+	pub := cfg.Fixture.Publish(t, PublishOptions{Codec: CodecOpus, SampleRate: cfg.TargetSampleRate, Channels: monoChannels})
+	t.Cleanup(func() { pub.Stop(t) })
+
+	h := newHarness(t, cfg, bufferManagerFor(t), 0)
+	spec := cfg.rtspSpec(uniquePath("health"), pub.URL())
+	require.NoError(t, h.mgr.StartStream(spec))
+	requireHealthy(t, h.mgr, spec.SourceID, healthyWithinBudget)
+
+	assertProcessStateValid(t, cfg, pollHealth(t, h.mgr, spec.SourceID))
+
+	// LastDataReceived advances while data flows.
+	first := pollHealth(t, h.mgr, spec.SourceID).LastDataReceived()
+	require.Eventually(t, func() bool {
+		return pollHealth(t, h.mgr, spec.SourceID).LastDataReceived().After(first)
+	}, healthyWithinBudget, pollInterval, "LastDataReceived should advance")
+
+	// Stop the publisher (server stays up): receiving goes false quickly, healthy
+	// goes false within the healthy threshold.
+	pub.Stop(t)
+	require.Eventually(t, func() bool {
+		return !pollHealth(t, h.mgr, spec.SourceID).IsReceivingData()
+	}, receivingFalseBudget, pollInterval, "IsReceivingData should go false after publisher stops")
+	require.Eventually(t, func() bool {
+		return !pollHealth(t, h.mgr, spec.SourceID).IsHealthy()
+	}, defaultHealthyThreshold+healthyWithinBudget, pollInterval, "IsHealthy should go false after silence")
+
+	// Recover.
+	pub.Restart(t)
+	requireHealthy(t, h.mgr, spec.SourceID, healthyWithinBudget)
+	assertProcessStateValid(t, cfg, pollHealth(t, h.mgr, spec.SourceID))
+}
+
+func assertProcessStateValid(t *testing.T, cfg *ContractConfig, h Health) {
+	t.Helper()
+	state := h.ProcessState()
+	assert.NotEmpty(t, state, "process_state must not be empty")
+	if len(cfg.ValidProcessStates) > 0 {
+		assert.Contains(t, cfg.ValidProcessStates, state, "process_state must be a value the frontend renders")
+	}
+}
+
+// caseSilenceRestart (contract case 7): with a shortened silence timeout, a
+// publisher that goes quiet while the server stays up triggers a restart, and the
+// stream recovers when the publisher returns.
+func caseSilenceRestart(t *testing.T, cfg *ContractConfig) {
+	t.Helper()
+	pub := cfg.Fixture.Publish(t, PublishOptions{Codec: CodecOpus, SampleRate: cfg.TargetSampleRate, Channels: monoChannels})
+	t.Cleanup(func() { pub.Stop(t) })
+
+	h := newHarness(t, cfg, bufferManagerFor(t), silenceTimeoutUnderTest)
+	spec := cfg.rtspSpec(uniquePath("silence"), pub.URL())
+	require.NoError(t, h.mgr.StartStream(spec))
+	requireHealthy(t, h.mgr, spec.SourceID, healthyWithinBudget)
+
+	before := pollHealth(t, h.mgr, spec.SourceID).RestartCount()
+	pub.Stop(t)
+	require.Eventually(t, func() bool {
+		return pollHealth(t, h.mgr, spec.SourceID).RestartCount() > before
+	}, silenceRestartBudget, pollInterval, "silence should trigger a restart")
+
+	pub.Restart(t)
+	requireHealthy(t, h.mgr, spec.SourceID, serverReconnectBudget)
+}
+
+// caseServerGoneReconnect (contract case 8): the whole server disappearing and
+// returning is recovered from, with the restart counted and transitions recorded.
+func caseServerGoneReconnect(t *testing.T, cfg *ContractConfig) {
+	t.Helper()
+	pub := cfg.Fixture.Publish(t, PublishOptions{Codec: CodecOpus, SampleRate: cfg.TargetSampleRate, Channels: monoChannels})
+	t.Cleanup(func() { pub.Stop(t) })
+
+	h := newHarness(t, cfg, bufferManagerFor(t), 0)
+	spec := cfg.rtspSpec(uniquePath("servergone"), pub.URL())
+	require.NoError(t, h.mgr.StartStream(spec))
+	requireHealthy(t, h.mgr, spec.SourceID, healthyWithinBudget)
+
+	restartsBefore := pollHealth(t, h.mgr, spec.SourceID).RestartCount()
+
+	cfg.Fixture.StopServer(t)
+	time.Sleep(serverGoneStopFor)
+	cfg.Fixture.StartServer(t)
+	pub.Restart(t)
+
+	h.collector.reset()
+	serverBack := time.Now()
+	require.True(t, waitForFrames(h.collector, 1, serverReconnectBudget), "frames should resume after the server returns")
+	reconnectTook := time.Since(serverBack)
+	t.Logf("BASELINE %s ServerGoneReconnect reconnectSeconds=%.1f", cfg.ProducerName, reconnectTook.Seconds())
+
+	after := pollHealth(t, h.mgr, spec.SourceID)
+	assert.Greater(t, after.RestartCount(), restartsBefore, "the outage should have counted a restart")
+	// StateHistory saturates at a small cap, so a count comparison is not
+	// meaningful; assert only that lifecycle transitions are recorded at all,
+	// which a producer that tracked none would fail.
+	assert.Positive(t, after.StateHistoryLen(), "the producer should record lifecycle transitions")
+}
+
+// caseMediaModes (contract case 9): every RTSP media mode delivers audio from a
+// video+audio publish.
+func caseMediaModes(t *testing.T, cfg *ContractConfig) {
+	t.Helper()
+	if !cfg.Fixture.SupportsVideo() {
+		t.Skip("fixture cannot publish video; media-mode selection not exercised")
+	}
+	pub := cfg.Fixture.Publish(t, PublishOptions{
+		Codec: CodecOpus, SampleRate: cfg.TargetSampleRate, Channels: monoChannels, WithVideo: true,
+	})
+	t.Cleanup(func() { pub.Stop(t) })
+
+	for _, mode := range []string{"auto", "audio-only", "full-stream"} {
+		t.Run(mode, func(t *testing.T) {
+			h := newHarness(t, cfg, bufferManagerFor(t), 0)
+			spec := cfg.rtspSpec(uniquePath("mediamode-"+mode), pub.URL())
+			spec.MediaMode = mode
+			require.NoError(t, h.mgr.StartStream(spec))
+			require.True(t, waitForFrames(h.collector, 3, firstFrameBudget), "audio should flow in %s mode", mode)
+		})
+	}
+}
+
+// caseMultiStream (contract case 10): independent streams start, run, and stop
+// without interfering with one another.
+func caseMultiStream(t *testing.T, cfg *ContractConfig) {
+	t.Helper()
+	const streamCount = 3
+	pubs := make([]Publication, streamCount)
+	specs := make([]*StreamSpec, streamCount)
+
+	h := newHarness(t, cfg, bufferManagerFor(t), 0)
+	for i := range streamCount {
+		pub := cfg.Fixture.Publish(t, PublishOptions{Codec: CodecOpus, SampleRate: cfg.TargetSampleRate, Channels: monoChannels})
+		t.Cleanup(func() { pub.Stop(t) })
+		pubs[i] = pub
+		specs[i] = cfg.rtspSpec(uniquePath(fmt.Sprintf("multi%d", i)), pub.URL())
+		require.NoError(t, h.mgr.StartStream(specs[i]))
+	}
+
+	for i := range streamCount {
+		requireHealthy(t, h.mgr, specs[i].SourceID, healthyWithinBudget)
+	}
+
+	// Stop one stream; the others must keep delivering.
+	require.NoError(t, h.mgr.StopStream(specs[0].SourceID))
+	for i := 1; i < streamCount; i++ {
+		before := pollHealth(t, h.mgr, specs[i].SourceID).TotalBytesReceived()
+		require.Eventually(t, func() bool {
+			return pollHealth(t, h.mgr, specs[i].SourceID).TotalBytesReceived() > before
+		}, healthyWithinBudget, pollInterval, "surviving stream %d should keep delivering", i)
+	}
+	assert.NotContains(t, h.mgr.GetActiveStreamIDs(), specs[0].SourceID)
+}
+
+// caseHighRatePassthrough (contract case 11): a 96 kHz L16 source is dispatched at
+// 96 kHz (the bat path) and the tone survives.
+func caseHighRatePassthrough(t *testing.T, cfg *ContractConfig) {
+	t.Helper()
+	pub := cfg.Fixture.Publish(t, PublishOptions{Codec: CodecL16, SampleRate: highSampleRate, Channels: monoChannels})
+	t.Cleanup(func() { pub.Stop(t) })
+
+	h := newHarness(t, cfg, bufferManagerFor(t), 0)
+	spec := cfg.rtspSpec(uniquePath("highrate"), pub.URL())
+	spec.SampleRate = highSampleRate
+	spec.SourceSampleRate = highSampleRate
+	require.NoError(t, h.mgr.StartStream(spec))
+	require.True(t, waitForFrames(h.collector, 1, firstFrameBudget), "frames should flow")
+
+	h.collector.reset()
+	time.Sleep(fidelityCollectWindow)
+	frames := h.collector.snapshot()
+	require.NotEmpty(t, frames)
+	for i := range frames {
+		assert.Equal(t, highSampleRate, frames[i].SampleRate, "frames should be dispatched at the high rate")
+	}
+	dominant := DominantFrequency(h.collector.concatData(), highSampleRate)
+	t.Logf("BASELINE %s HighRatePassthrough dominantHz=%.1f", cfg.ProducerName, dominant)
+	assert.InEpsilon(t, toneFrequencyHz, dominant, dominantFreqToleranceR, "tone should survive the high-rate path")
+}
+
+// caseErrorClarity (contract case 14): connection failures surface a specific
+// error type where the producer classifies them; the measured types are recorded
+// as the baseline. Fast failures (path not found, connection refused) are
+// asserted to classify; the slow connect timeout is recorded only, because the
+// FFmpeg producer's stderr classifier windows are shorter than its 10 s connect
+// timeout so a timeout leaves the health error context empty (a documented gap
+// the native producer is expected to close with typed errors).
+func caseErrorClarity(t *testing.T, cfg *ContractConfig) {
+	t.Helper()
+	type errCase struct {
+		name            string
+		url             string
+		wantSubstr      string // substring the classification should contain when present
+		requireNonEmpty bool   // whether a classification must appear within the budget
+	}
+	cases := []errCase{
+		{name: "path_not_found", url: cfg.Fixture.URLForPath(uniquePath("nopath")), wantSubstr: "404", requireNonEmpty: true},
+		{name: "connection_refused", url: cfg.Fixture.RefusedPortURL(), wantSubstr: "refused", requireNonEmpty: true},
+		{name: "unreachable_host", url: cfg.Fixture.UnreachableHostURL()},
+	}
+	if authURL := cfg.Fixture.BadAuthURL(t); authURL != "" {
+		cases = append(cases, errCase{name: "auth_failed", url: authURL, wantSubstr: "auth", requireNonEmpty: true})
+	}
+
+	for _, ec := range cases {
+		t.Run(ec.name, func(t *testing.T) {
+			h := newHarness(t, cfg, bufferManagerFor(t), 0)
+			spec := cfg.rtspSpec(uniquePath("err-"+ec.name), ec.url)
+			require.NoError(t, h.mgr.StartStream(spec), "start returns nil; failures are async")
+
+			var got string
+			classified := waitForCondition(errorClarityBudget, func() bool {
+				got = pollHealth(t, h.mgr, spec.SourceID).ErrorType()
+				return got != ""
+			})
+			t.Logf("BASELINE %s ErrorClarity case=%s errorType=%q classified=%t", cfg.ProducerName, ec.name, got, classified)
+
+			if ec.requireNonEmpty {
+				require.True(t, classified, "an error type should be classified for %s", ec.name)
+				assert.Contains(t, strings.ToLower(got), ec.wantSubstr, "error type should identify the failure")
+			}
+		})
+	}
+}
+
+// waitForCondition polls fn until it returns true or the budget elapses. Unlike
+// require.Eventually it does not fail the test, so a case can record whether a
+// condition held without asserting it.
+func waitForCondition(budget time.Duration, fn func() bool) bool {
+	deadline := time.Now().Add(budget)
+	for time.Now().Before(deadline) {
+		if fn() {
+			return true
+		}
+		time.Sleep(pollInterval)
+	}
+	return fn()
+}
+
+// caseTimeToFirstFrame (contract case 15): the first frame arrives promptly from
+// an already-publishing source; the measured latency is recorded as the baseline.
+func caseTimeToFirstFrame(t *testing.T, cfg *ContractConfig) {
+	t.Helper()
+	pub := cfg.Fixture.Publish(t, PublishOptions{Codec: CodecOpus, SampleRate: cfg.TargetSampleRate, Channels: monoChannels})
+	t.Cleanup(func() { pub.Stop(t) })
+	// Let the publisher settle so the source is already live before we start.
+	time.Sleep(streamStartSettle)
+
+	h := newHarness(t, cfg, bufferManagerFor(t), 0)
+	spec := cfg.rtspSpec(uniquePath("ttff"), pub.URL())
+	start := time.Now()
+	require.NoError(t, h.mgr.StartStream(spec))
+	require.True(t, waitForFrames(h.collector, 1, firstFrameBudget), "a first frame should arrive")
+
+	frames := h.collector.snapshot()
+	require.NotEmpty(t, frames)
+	// The require.True(waitForFrames(..., firstFrameBudget)) above already bounds
+	// the latency; the value is captured here as the baseline the native producer
+	// must match or beat in a later phase.
+	ttff := frames[0].ReceivedAt.Sub(start)
+	t.Logf("BASELINE %s TimeToFirstFrame seconds=%.2f", cfg.ProducerName, ttff.Seconds())
+}

--- a/internal/audiocore/streamtest/contract_cases.go
+++ b/internal/audiocore/streamtest/contract_cases.go
@@ -158,6 +158,16 @@ func caseLifecycle(t *testing.T, cfg *ContractConfig) {
 	coll := &frameCollector{}
 	mgr := cfg.Factory(t, FactoryConfig{OnFrame: coll.onFrame, OnReset: coll.onReset, BufferManager: bufferManagerFor(t)})
 	require.NotNil(t, mgr)
+	// Safety net so a require failure before the explicit shutdown below cannot
+	// leak the manager (and its FFmpeg child) into the sibling subtests that
+	// share the fixture. The explicit ShutdownWithContext below still owns the
+	// assertion; this best-effort call is a no-op once that has run.
+	t.Cleanup(func() {
+		//nolint:gocritic // t.Context() is already cancelled when Cleanup runs; shutdown needs a live context
+		ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		_ = mgr.ShutdownWithContext(ctx)
+	})
 
 	spec := cfg.rtspSpec(uniquePath("lifecycle"), pub.URL())
 	require.NoError(t, mgr.StartStream(spec), "first start should succeed")

--- a/internal/audiocore/streamtest/doc.go
+++ b/internal/audiocore/streamtest/doc.go
@@ -1,0 +1,19 @@
+// Package streamtest is an importable test-support package that characterizes
+// BirdNET-Go's network stream ingest at the manager seam.
+//
+// It exists so the observable behaviour of the current FFmpeg ingest path can be
+// pinned by a single suite before the native go-audio-stream producer is built,
+// and so that same suite can then be run unchanged against the native producer
+// to prove parity. Production code never imports this package.
+//
+// The suite is producer-agnostic. RunManagerContract drives any producer through
+// the narrow Manager interface, reading health through the Health interface and
+// obtaining live streams and server control through the Fixture interface. A
+// producer participates by supplying a ManagerFactory that adapts its concrete
+// manager to Manager, plus a Fixture; the FFmpeg producer's adapter and a
+// MediaMTX-backed Fixture live in the integration-tagged tests.
+//
+// The signal-analysis helpers (DominantFrequency, RMSDBFS) are pure and unit
+// tested; the MediaMTX-backed Fixture (fixture_mediamtx.go) is behind the
+// integration build tag because it needs a container runtime.
+package streamtest

--- a/internal/audiocore/streamtest/fixture_mediamtx.go
+++ b/internal/audiocore/streamtest/fixture_mediamtx.go
@@ -1,0 +1,146 @@
+//go:build integration
+
+package streamtest
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/testutil/containers"
+)
+
+// Fixture tuning for the MediaMTX-backed implementation.
+const (
+	// publishSettle is how long to wait after (re)starting a publisher before the
+	// stream is reliably registered on the server.
+	publishSettle = 3 * time.Second
+
+	// serverStopTimeout bounds the graceful container stop.
+	serverStopTimeout = 10 * time.Second
+
+	// unreachableHostURL points at TEST-NET-1 (RFC 5737), which is guaranteed not
+	// to be routable, so a connect attempt times out.
+	unreachableHostURL = "rtsp://192.0.2.1:554/dead"
+)
+
+// MediaMTXFixture is a Fixture backed by a MediaMTX container. It publishes
+// synthesized tones with FFmpeg and can stop and restart the whole server.
+type MediaMTXFixture struct {
+	server *containers.MediaMTXContainer
+}
+
+// NewMediaMTXFixture wraps a running MediaMTX container as a contract Fixture.
+func NewMediaMTXFixture(t *testing.T, server *containers.MediaMTXContainer) *MediaMTXFixture {
+	t.Helper()
+	require.NotNil(t, server, "MediaMTX container is required")
+	return &MediaMTXFixture{server: server}
+}
+
+// toneOptions maps the neutral PublishOptions to the FFmpeg encoder names the
+// publisher expects.
+func toneOptions(o PublishOptions) containers.ToneOptions {
+	codec := string(o.Codec)
+	if o.Codec == CodecOpus {
+		codec = "libopus"
+	}
+	return containers.ToneOptions{
+		Codec:      codec,
+		SampleRate: o.SampleRate,
+		Channels:   o.Channels,
+		WithVideo:  o.WithVideo,
+	}
+}
+
+// Publish starts a publisher for the given options and returns once it has had
+// time to register on the server.
+func (f *MediaMTXFixture) Publish(t *testing.T, opts PublishOptions) Publication {
+	t.Helper()
+	if opts.Path == "" {
+		opts.Path = uniquePath("pub")
+	}
+	p := &mediaPublication{
+		opts: opts,
+		url:  f.server.GetRTSPURL(opts.Path),
+	}
+	p.Restart(t)
+	return p
+}
+
+// URLForPath returns a read URL for an arbitrary path.
+func (f *MediaMTXFixture) URLForPath(path string) string {
+	return f.server.GetRTSPURL(path)
+}
+
+// UnreachableHostURL returns a URL whose host cannot be routed.
+func (f *MediaMTXFixture) UnreachableHostURL() string {
+	return unreachableHostURL
+}
+
+// RefusedPortURL returns a URL on the live server host but a closed port.
+func (f *MediaMTXFixture) RefusedPortURL() string {
+	port := 1 // a port almost never open, used if a free port cannot be found
+	if free, err := containers.GetFreePort(); err == nil {
+		port = free
+	}
+	return "rtsp://" + net.JoinHostPort(f.server.GetHost(), strconv.Itoa(port)) + "/closed"
+}
+
+// BadAuthURL returns "" because the default MediaMTX container enforces no
+// authentication, so the auth_failed classification is not exercised here.
+func (f *MediaMTXFixture) BadAuthURL(t *testing.T) string {
+	t.Helper()
+	return ""
+}
+
+// StopServer stops the whole media server.
+func (f *MediaMTXFixture) StopServer(t *testing.T) {
+	t.Helper()
+	require.NoError(t, f.server.Stop(context.Background(), serverStopTimeout))
+}
+
+// StartServer restarts the media server and waits for it to accept connections.
+func (f *MediaMTXFixture) StartServer(t *testing.T) {
+	t.Helper()
+	require.NoError(t, f.server.Start(context.Background()))
+}
+
+// SupportsVideo reports that MediaMTX can carry a video track.
+func (f *MediaMTXFixture) SupportsVideo() bool { return true }
+
+// mediaPublication is a single supervised FFmpeg publisher.
+type mediaPublication struct {
+	opts PublishOptions
+	url  string
+	mu   sync.Mutex
+	pub  *containers.StreamPublisher
+}
+
+func (p *mediaPublication) URL() string { return p.url }
+
+func (p *mediaPublication) Stop(t *testing.T) {
+	t.Helper()
+	p.mu.Lock()
+	pub := p.pub
+	p.pub = nil
+	p.mu.Unlock()
+	if pub != nil {
+		pub.Stop()
+	}
+}
+
+func (p *mediaPublication) Restart(t *testing.T) {
+	t.Helper()
+	p.Stop(t)
+	pub, err := containers.PublishToneToMediaMTX(context.Background(), p.url, toneOptions(p.opts))
+	require.NoError(t, err, "publisher should start")
+	p.mu.Lock()
+	p.pub = pub
+	p.mu.Unlock()
+	time.Sleep(publishSettle)
+}

--- a/internal/audiocore/streamtest/fixture_mediamtx.go
+++ b/internal/audiocore/streamtest/fixture_mediamtx.go
@@ -27,6 +27,10 @@ const (
 	// unreachableHostURL points at TEST-NET-1 (RFC 5737), which is guaranteed not
 	// to be routable, so a connect attempt times out.
 	unreachableHostURL = "rtsp://192.0.2.1:554/dead"
+
+	// fallbackRefusedPort is a port that is almost never listening, used by
+	// RefusedPortURL only when a free port cannot be obtained.
+	fallbackRefusedPort = 1
 )
 
 // MediaMTXFixture is a Fixture backed by a MediaMTX container. It publishes
@@ -84,7 +88,7 @@ func (f *MediaMTXFixture) UnreachableHostURL() string {
 
 // RefusedPortURL returns a URL on the live server host but a closed port.
 func (f *MediaMTXFixture) RefusedPortURL() string {
-	port := 1 // a port almost never open, used if a free port cannot be found
+	port := fallbackRefusedPort
 	if free, err := containers.GetFreePort(); err == nil {
 		port = free
 	}

--- a/internal/testutil/containers/mediamtx.go
+++ b/internal/testutil/containers/mediamtx.go
@@ -26,7 +26,7 @@ type MediaMTXContainer struct {
 
 // MediaMTXConfig holds configuration for MediaMTX container creation.
 type MediaMTXConfig struct {
-	// ImageTag for bluenviron/mediamtx (default: "latest")
+	// ImageTag for bluenviron/mediamtx (default: "1.16.1" via DefaultMediaMTXConfig)
 	ImageTag string
 }
 
@@ -159,6 +159,31 @@ func (c *MediaMTXContainer) GetRTSPPort() int {
 // GetRTSPAddress returns the host:port for RTSP connections.
 func (c *MediaMTXContainer) GetRTSPAddress() string {
 	return net.JoinHostPort(c.host, strconv.Itoa(c.rtspPort))
+}
+
+// Stop stops the running MediaMTX container without removing it, so it can be
+// started again with the same port mappings. It is used to characterize how a
+// consumer recovers when the media server disappears and returns.
+func (c *MediaMTXContainer) Stop(ctx context.Context, timeout time.Duration) error {
+	if c.container == nil {
+		return nil
+	}
+	return c.container.Stop(ctx, &timeout)
+}
+
+// Start restarts a container previously stopped with Stop and waits until the
+// RTSP port accepts connections again.
+func (c *MediaMTXContainer) Start(ctx context.Context) error {
+	if c.container == nil {
+		return nil
+	}
+	if err := c.container.Start(ctx); err != nil {
+		return fmt.Errorf("failed to restart MediaMTX container: %w", err)
+	}
+	if err := WaitForTCP(c.host, c.rtspPort, 30*time.Second); err != nil {
+		return fmt.Errorf("RTSP port did not come back after restart: %w", err)
+	}
+	return nil
 }
 
 // Terminate stops and removes the MediaMTX container.

--- a/internal/testutil/containers/mediamtx_publisher.go
+++ b/internal/testutil/containers/mediamtx_publisher.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"strconv"
 	"time"
 )
 
@@ -13,6 +14,96 @@ import (
 type StreamPublisher struct {
 	cmd    *exec.Cmd
 	cancel context.CancelFunc
+}
+
+// Publisher defaults for the tone generator.
+const (
+	defaultToneFrequencyHz = 1000.0
+	defaultToneSampleRate  = 48000
+	defaultToneChannels    = 1
+	defaultToneLevelDBFS   = -12.0
+	opusPublishBitrate     = "64k"
+	aacPublishBitrate      = "96k"
+)
+
+// ToneOptions configures PublishToneToMediaMTX. Codec is the FFmpeg encoder name
+// (for example "libopus", "pcm_mulaw", "pcm_alaw", "aac", "pcm_s16be"), which
+// lets a caller cover the RTSP codec matrix from one helper. Zero fields fall
+// back to a 1 kHz mono 48 kHz tone at -12 dBFS.
+type ToneOptions struct {
+	Codec       string
+	SampleRate  int
+	Channels    int
+	FrequencyHz float64
+	LevelDBFS   float64
+	WithVideo   bool
+}
+
+func (o *ToneOptions) applyDefaults() {
+	if o.FrequencyHz == 0 {
+		o.FrequencyHz = defaultToneFrequencyHz
+	}
+	if o.SampleRate == 0 {
+		o.SampleRate = defaultToneSampleRate
+	}
+	if o.Channels == 0 {
+		o.Channels = defaultToneChannels
+	}
+	if o.LevelDBFS == 0 {
+		o.LevelDBFS = defaultToneLevelDBFS
+	}
+	if o.Codec == "" {
+		o.Codec = "libopus"
+	}
+}
+
+// buildToneArgs assembles the FFmpeg argument list that publishes a synthesized
+// tone (and optionally a test video track) to an RTSP URL.
+func buildToneArgs(rtspURL string, o ToneOptions) []string {
+	args := []string{"-hide_banner", "-loglevel", "error"}
+
+	// Audio input: a synthesized sine, read in real time.
+	sine := fmt.Sprintf("sine=frequency=%.0f:sample_rate=%d", o.FrequencyHz, o.SampleRate)
+	args = append(args, "-re", "-f", "lavfi", "-i", sine)
+
+	if o.WithVideo {
+		args = append(args, "-re", "-f", "lavfi", "-i", "testsrc2=size=320x240:rate=15", "-map", "1:v", "-map", "0:a")
+	}
+
+	// Attenuate to the requested level so the tone is not full-scale.
+	args = append(args, "-filter:a", fmt.Sprintf("volume=%gdB", o.LevelDBFS), "-c:a", o.Codec)
+	switch o.Codec {
+	case "libopus":
+		args = append(args, "-b:a", opusPublishBitrate)
+	case "aac":
+		args = append(args, "-b:a", aacPublishBitrate)
+	}
+	args = append(args, "-ar", strconv.Itoa(o.SampleRate), "-ac", strconv.Itoa(o.Channels))
+
+	if o.WithVideo {
+		args = append(args, "-c:v", "libx264", "-preset", "ultrafast", "-tune", "zerolatency", "-pix_fmt", "yuv420p", "-g", "30")
+	}
+
+	args = append(args, "-f", "rtsp", "-rtsp_transport", "tcp", rtspURL)
+	return args
+}
+
+// PublishToneToMediaMTX starts FFmpeg publishing a synthesized tone to MediaMTX
+// via RTSP in the requested codec, looping until Stop is called. The caller
+// should wait a couple of seconds for the stream to register on the server. It
+// generalizes PublishWAVToMediaMTX across the RTSP codec matrix (Opus, G.711
+// mu/A-law, AAC, L16) plus an optional video track for media-mode tests.
+func PublishToneToMediaMTX(ctx context.Context, rtspURL string, opts ToneOptions) (*StreamPublisher, error) {
+	opts.applyDefaults()
+	pubCtx, cancel := context.WithCancel(ctx)
+
+	//nolint:gosec // G204: args are built from test infrastructure, not user input
+	cmd := exec.CommandContext(pubCtx, "ffmpeg", buildToneArgs(rtspURL, opts)...)
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, fmt.Errorf("failed to start FFmpeg tone publisher: %w", err)
+	}
+	return &StreamPublisher{cmd: cmd, cancel: cancel}, nil
 }
 
 // PublishWAVToMediaMTX starts FFmpeg to publish a WAV file to MediaMTX via RTSP.


### PR DESCRIPTION
## Summary

BirdNET-Go is going to replace the per-stream FFmpeg ingest subprocess with a pure-Go network stream path. Before any of that refactoring starts, this PR pins the current FFmpeg ingest behaviour with characterization tests, so the later work can be proven to preserve it 1:1. Tests come before the refactor, on purpose.

The tests are producer-agnostic. A new importable test-support package `internal/audiocore/streamtest` defines a single contract suite, `RunManagerContract`, that drives any stream producer through a narrow manager interface and reads its health through a small health interface. It is parametrized over a manager factory and a stream fixture, so the exact same cases will run unchanged against the native producer later. Today it runs against `ffmpeg.NewManager` via a thin adapter and a MediaMTX container. Production code never imports `streamtest`.

## What's here

- `internal/audiocore/streamtest/`: the contract suite (13 manager-seam cases: frame shape, PCM fidelity across the codec matrix, data rate, lifecycle, reset callback, health transitions, silence restart, server-gone reconnect, media modes, multistream, high-rate passthrough, error clarity, time-to-first-frame) plus pure Goertzel dominant-frequency and RMS helpers (unit tested, reusing `internal/audiocore/convert` for the PCM decode), and a MediaMTX-backed fixture behind the `integration` build tag.
- `internal/audiocore/ffmpeg/manager_contract_test.go` (`integration`): runs the contract against `ffmpeg.NewManager` over a MediaMTX container across the RTSP codec matrix (G.711 mu/A-law, AAC-LC, Opus, L16 at 48k and 96k).
- `internal/audiocore/engine/engine_contract_test.go` (`integration`): engine reconfigure and stop/start round-trips, plus the router + liveness-watchdog + manager recovery chain.
- The one production change: a new `ffmpeg.NewManagerWithOptions` constructor taking `ffmpeg.Options{SilenceTimeout}`, so the silence-restart path can be driven in seconds instead of the 90s production default. `NewManager` delegates with a zero `Options` (behaviour unchanged), and the timeout is read per stream via a new `StreamConfig.SilenceTimeout` field that falls back to the existing 90s constant. It is unit-tested directly (`handleSilenceTimeout`) and never mutates the caller's config.
- `internal/testutil/containers`: the MediaMTX publisher now covers the codec matrix (`PublishToneToMediaMTX`), and the container gained `Stop`/`Start` for the server-outage case.

Integration tests skip cleanly when no container runtime is present, so they do not affect the normal unit-test run.

## Characterization findings recorded as the baseline

Two current FFmpeg behaviours are documented (not treated as bugs to fix here):

- Health error classification only runs during the stream's early-detection and quick-exit windows (both about 5s), so fast failures classify (`rtsp_404`, `connection_refused`) but a slow connect timeout (10s, unreachable host) leaves the health error context empty. The error-clarity case asserts the fast failures and records the timeout as an accepted gap the native path is expected to close.
- After manager shutdown the only lingering goroutine is the Go stdlib `os/exec.(*Cmd).watchCtx` for the just-killed child, which the runtime reaps; the lifecycle goleak check ignores that function.

## Test Plan

- [x] `go build ./...`, `go vet ./...`, and `golangci-lint run` (default and `--build-tags=integration`) are clean.
- [x] Unit tests: `go test -race ./internal/audiocore/...`.
- [x] Integration (local, podman + FFmpeg 7.1.1): all 13 manager-seam cases and both engine-level cases pass; baselines captured and reproduced across runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable silence timeouts for audio streams, with manager-level defaults and per-stream overrides.
  - Improved stream recovery after interruptions, reconnects, and server restarts.

- **Bug Fixes**
  - Improved detection and reporting of silent or unhealthy audio streams.

- **Tests**
  - Expanded coverage for audio fidelity, stream health, lifecycle behavior, codec compatibility, and recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->