### PR TITLE
refactor(audiocore): extract producer-neutral StreamManager seam

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -250,7 +250,7 @@ func (p *AudioPipelineService) Start(_ context.Context) error {
 
 	// Register watchdog reset callback so analysis monitors are recreated
 	// when the watchdog force-resets a stuck stream.
-	p.engine.FFmpegManager().SetOnStreamReset(func(newSourceID string) {
+	p.engine.StreamManager().SetOnStreamReset(func(newSourceID string) {
 		if err := p.bufferMgr.AddMonitor(newSourceID); err != nil {
 			audiocore.GetLogger().Warn("failed to add monitor after watchdog stream reset",
 				logger.String("source_id", newSourceID),

--- a/internal/api/v2/audio/streams_health.go
+++ b/internal/api/v2/audio/streams_health.go
@@ -12,7 +12,6 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
-	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/privacy"
 	"golang.org/x/time/rate"
@@ -30,6 +29,12 @@ const (
 	// Rate limiting for stream health SSE endpoint
 	streamHealthRateLimitRequests = 5               // Requests per window
 	streamHealthRateLimitWindow   = 1 * time.Minute // Rate limit window
+
+	// removedStreamProcessState is the legacy process_state reported for a stream
+	// that has been removed. Historically the removed-stream SSE event carried an
+	// empty ffmpeg.StreamHealth, whose zero-valued ProcessState serialized as
+	// "idle"; preserving that keeps the JSON byte-identical.
+	removedStreamProcessState = "idle"
 )
 
 // SSEStreamHealthData represents stream health data sent via SSE
@@ -44,7 +49,8 @@ type StreamHealthResponse struct {
 	Type             string     `json:"type,omitempty"`                    // Stream type from config (empty if not found)
 	URL              string     `json:"url"`                               // Sanitized RTSP URL
 	IsHealthy        bool       `json:"is_healthy"`                        // Overall health status
-	ProcessState     string     `json:"process_state"`                     // Current process state (idle, starting, running, etc.)
+	ProcessState     string     `json:"process_state"`                     // Legacy per-producer sub-state string the frontend switches on (idle, starting, running, restarting, backoff, circuit_open, stopped, failed)
+	State            string     `json:"state"`                             // Producer-neutral connection state (starting, connected, reconnecting, stopped, failed); additive, for frontend migration
 	LastDataReceived *time.Time `json:"last_data_received"`                // When data was last received (null if never)
 	TimeSinceData    *float64   `json:"time_since_data_seconds,omitempty"` // Seconds since last data (omitempty for never)
 	RestartCount     int        `json:"restart_count"`                     // Number of times stream has been restarted
@@ -210,7 +216,7 @@ func (c *Handler) GetAllStreamsHealth(ctx echo.Context) error {
 		return c.HandleError(ctx, nil, "Audio engine not initialized", http.StatusServiceUnavailable)
 	}
 	// Get health data from the FFmpeg manager (keyed by sourceID)
-	healthData := eng.FFmpegManager().AllStreamHealth()
+	healthData := eng.StreamManager().AllStreamHealth()
 
 	// Look up the connection URL from the registry for each source
 	registry := eng.Registry()
@@ -269,10 +275,10 @@ func (c *Handler) GetStreamHealth(ctx echo.Context) error {
 	}
 	// Try to find stream by sourceID first, then by connection URL
 	registry := eng.Registry()
-	ffmpegMgr := eng.FFmpegManager()
+	streamMgr := eng.StreamManager()
 
 	// First: try direct sourceID lookup
-	fh, lookupErr := ffmpegMgr.StreamHealth(decodedURL)
+	fh, lookupErr := streamMgr.StreamHealth(decodedURL)
 	var rawURL string
 
 	if lookupErr == nil {
@@ -284,13 +290,13 @@ func (c *Handler) GetStreamHealth(ctx echo.Context) error {
 	} else {
 		// Second: try to find sourceID by connection URL
 		if src, found := registry.GetByConnection(decodedURL); found {
-			fh, lookupErr = ffmpegMgr.StreamHealth(src.ID)
+			fh, lookupErr = streamMgr.StreamHealth(src.ID)
 			rawURL = decodedURL
 		}
 	}
 
 	if lookupErr != nil {
-		healthData := ffmpegMgr.AllStreamHealth()
+		healthData := streamMgr.AllStreamHealth()
 		c.LogAPIRequest(ctx, logger.LogLevelWarn, "Stream not found",
 			logger.String("requested_url", privacy.SanitizeStreamUrl(decodedURL)),
 			logger.Int("active_streams", len(healthData)))
@@ -325,7 +331,7 @@ func (c *Handler) GetStreamsStatusSummary(ctx echo.Context) error {
 		return c.HandleError(ctx, nil, "Audio engine not initialized", http.StatusServiceUnavailable)
 	}
 	// Get health data from the FFmpeg manager (keyed by sourceID)
-	healthData := eng.FFmpegManager().AllStreamHealth()
+	healthData := eng.StreamManager().AllStreamHealth()
 	registry := eng.Registry()
 
 	// Build summary
@@ -355,7 +361,7 @@ func (c *Handler) GetStreamsStatusSummary(ctx echo.Context) error {
 			Type:         info.Type,
 			URL:          privacy.SanitizeStreamUrl(rawURL),
 			IsHealthy:    fh.IsHealthy,
-			ProcessState: fh.ProcessState.String(),
+			ProcessState: fh.ProcessStateName(),
 		}
 
 		// Add time since data if available
@@ -376,11 +382,12 @@ func (c *Handler) GetStreamsStatusSummary(ctx echo.Context) error {
 }
 
 // convertStreamHealthToResponse converts internal StreamHealth to API response format.
-func convertStreamHealthToResponse(rawURL string, health *ffmpeg.StreamHealth) StreamHealthResponse {
+func convertStreamHealthToResponse(rawURL string, health *audiocore.StreamHealth) StreamHealthResponse {
 	response := StreamHealthResponse{
 		URL:                privacy.SanitizeStreamUrl(rawURL),
 		IsHealthy:          health.IsHealthy,
-		ProcessState:       health.ProcessState.String(),
+		ProcessState:       health.ProcessStateName(),
+		State:              health.State.String(),
 		RestartCount:       health.RestartCount,
 		TotalBytesReceived: health.TotalBytesReceived,
 		BytesPerSecond:     health.BytesPerSecond,
@@ -422,8 +429,8 @@ func convertStreamHealthToResponse(rawURL string, health *ffmpeg.StreamHealth) S
 		response.StateHistory = make([]StateTransitionResponse, 0, len(health.StateHistory))
 		for _, st := range health.StateHistory {
 			response.StateHistory = append(response.StateHistory, StateTransitionResponse{
-				FromState: st.From.String(),
-				ToState:   st.To.String(),
+				FromState: st.FromName(),
+				ToState:   st.ToName(),
 				Timestamp: st.Timestamp,
 				Reason:    st.Reason,
 			})
@@ -434,7 +441,7 @@ func convertStreamHealthToResponse(rawURL string, health *ffmpeg.StreamHealth) S
 }
 
 // convertErrorContextToResponse converts internal ErrorContext to API response format.
-func convertErrorContextToResponse(errCtx *ffmpeg.ErrorContext) *ErrorContextResponse {
+func convertErrorContextToResponse(errCtx *audiocore.StreamErrorContext) *ErrorContextResponse {
 	if errCtx == nil {
 		return nil
 	}
@@ -493,7 +500,7 @@ func (c *Handler) handleStreamHealthPoll(ctx echo.Context, clientID string, prev
 	if eng == nil {
 		return nil
 	}
-	healthData := eng.FFmpegManager().AllStreamHealth()
+	healthData := eng.StreamManager().AllStreamHealth()
 	registry := eng.Registry()
 
 	if err := c.processStreamHealthUpdates(ctx, clientID, healthData, registry, previousState); err != nil {
@@ -510,7 +517,7 @@ func (c *Handler) handleStreamStatsUpdate(ctx echo.Context, clientID string) err
 	if eng == nil {
 		return nil
 	}
-	healthData := eng.FFmpegManager().AllStreamHealth()
+	healthData := eng.StreamManager().AllStreamHealth()
 	registry := eng.Registry()
 
 	for sourceID, fh := range healthData {
@@ -560,7 +567,7 @@ func (c *Handler) StreamHealthUpdates(ctx echo.Context) error {
 	}
 
 	// Pre-allocate state tracking based on initial stream count
-	previousState := make(map[string]streamHealthSnapshot, len(eng.FFmpegManager().AllStreamHealth()))
+	previousState := make(map[string]streamHealthSnapshot, len(eng.StreamManager().AllStreamHealth()))
 
 	ticker := time.NewTicker(streamHealthPollInterval)
 	defer ticker.Stop()
@@ -609,11 +616,11 @@ type streamHealthSnapshot struct {
 }
 
 // createHealthSnapshot creates a snapshot of stream health for comparison.
-func createHealthSnapshot(rawURL string, health *ffmpeg.StreamHealth) streamHealthSnapshot {
+func createHealthSnapshot(rawURL string, health *audiocore.StreamHealth) streamHealthSnapshot {
 	snapshot := streamHealthSnapshot{
 		RawURL:             rawURL,
 		IsHealthy:          health.IsHealthy,
-		ProcessState:       health.ProcessState.String(),
+		ProcessState:       health.ProcessStateName(),
 		RestartCount:       health.RestartCount,
 		IsReceivingData:    health.IsReceivingData,
 		TotalBytesReceived: health.TotalBytesReceived,
@@ -663,7 +670,7 @@ func determineEventType(prev, current *streamHealthSnapshot) string {
 }
 
 // processStreamHealthUpdates processes health updates for all active streams.
-func (c *Handler) processStreamHealthUpdates(ctx echo.Context, clientID string, healthData map[string]*ffmpeg.StreamHealth, registry *audiocore.SourceRegistry, previousState map[string]streamHealthSnapshot) error {
+func (c *Handler) processStreamHealthUpdates(ctx echo.Context, clientID string, healthData map[string]*audiocore.StreamHealth, registry *audiocore.SourceRegistry, previousState map[string]streamHealthSnapshot) error {
 
 	for sourceID, health := range healthData {
 		// Resolve the connection URL for SSE events (sourceID is an internal key, not a URL)
@@ -703,8 +710,20 @@ func (c *Handler) processStreamHealthUpdates(ctx echo.Context, clientID string, 
 	return nil
 }
 
+// removedStreamHealth is the synthetic health snapshot sent in a stream_removed
+// SSE event. StateDetail pins the legacy process_state to "idle" (byte-identical
+// with the pre-seam behaviour, where an empty ffmpeg.StreamHealth defaulted to
+// the idle process state); State reports the neutral connection state Stopped so
+// the additive state field reads correctly for a stream that is gone.
+func removedStreamHealth() audiocore.StreamHealth {
+	return audiocore.StreamHealth{
+		State:       audiocore.StreamStateStopped,
+		StateDetail: removedStreamProcessState,
+	}
+}
+
 // processRemovedStreams checks for and processes streams that have been removed
-func (c *Handler) processRemovedStreams(ctx echo.Context, clientID string, healthData map[string]*ffmpeg.StreamHealth, previousState map[string]streamHealthSnapshot) error {
+func (c *Handler) processRemovedStreams(ctx echo.Context, clientID string, healthData map[string]*audiocore.StreamHealth, previousState map[string]streamHealthSnapshot) error {
 	for prevSourceID, prevSnapshot := range previousState {
 		if _, exists := healthData[prevSourceID]; exists {
 			continue
@@ -714,7 +733,7 @@ func (c *Handler) processRemovedStreams(ctx echo.Context, clientID string, healt
 		// source has already been unregistered from the registry.
 		rawURL := prevSnapshot.RawURL
 		sanitizedURL := privacy.SanitizeStreamUrl(rawURL)
-		emptyHealth := ffmpeg.StreamHealth{}
+		emptyHealth := removedStreamHealth()
 		response := convertStreamHealthToResponse(rawURL, &emptyHealth)
 
 		// Add stream name and type from config (may be empty if stream was removed from config)
@@ -742,7 +761,7 @@ func (c *Handler) processRemovedStreams(ctx echo.Context, clientID string, healt
 }
 
 // sendStreamHealthUpdate sends a stream health update via SSE.
-func (c *Handler) sendStreamHealthUpdate(ctx echo.Context, rawURL string, health *ffmpeg.StreamHealth, eventType string) error {
+func (c *Handler) sendStreamHealthUpdate(ctx echo.Context, rawURL string, health *audiocore.StreamHealth, eventType string) error {
 	response := convertStreamHealthToResponse(rawURL, health)
 
 	// Add stream name and type from config
@@ -763,7 +782,7 @@ func (c *Handler) sendStreamHealthUpdate(ctx echo.Context, rawURL string, health
 		logger.String("url", privacy.SanitizeStreamUrl(rawURL)),
 		logger.String("event_type", eventType),
 		logger.Bool("is_healthy", health.IsHealthy),
-		logger.String("state", health.ProcessState.String()))
+		logger.String("state", health.ProcessStateName()))
 
 	return nil
 }
@@ -771,7 +790,7 @@ func (c *Handler) sendStreamHealthUpdate(ctx echo.Context, rawURL string, health
 // sendStreamStatsUpdate sends a lightweight stats-only update via SSE.
 // This excludes history arrays (ErrorHistory, StateHistory) to reduce bandwidth
 // for frequent periodic updates.
-func (c *Handler) sendStreamStatsUpdate(ctx echo.Context, rawURL string, health *ffmpeg.StreamHealth) error {
+func (c *Handler) sendStreamStatsUpdate(ctx echo.Context, rawURL string, health *audiocore.StreamHealth) error {
 	// Build lightweight response with only essential stats fields
 	var timeSinceData *float64
 	if !health.LastDataReceived.IsZero() {
@@ -787,7 +806,8 @@ func (c *Handler) sendStreamStatsUpdate(ctx echo.Context, rawURL string, health 
 		Type:               info.Type,
 		URL:                privacy.SanitizeStreamUrl(rawURL),
 		IsHealthy:          health.IsHealthy,
-		ProcessState:       health.ProcessState.String(),
+		ProcessState:       health.ProcessStateName(),
+		State:              health.State.String(),
 		RestartCount:       health.RestartCount,
 		TotalBytesReceived: health.TotalBytesReceived,
 		BytesPerSecond:     health.BytesPerSecond,

--- a/internal/api/v2/audio/streams_health_golden_test.go
+++ b/internal/api/v2/audio/streams_health_golden_test.go
@@ -59,8 +59,8 @@ func TestConvertStreamHealthToResponse_Golden(t *testing.T) {
 			require.NoError(t, err)
 			want := fmt.Sprintf(goldenTemplate, tt.wantProcess, tt.wantState)
 			// Compare the exact marshaled bytes, not a semantic JSON match, so a
-			// reordered or renamed field (which assert.JSONEq would tolerate) fails
-			// the byte-identity contract this test exists to lock.
+			// reordered field or changed whitespace (which assert.JSONEq tolerates)
+			// also fails the byte-identity contract this test exists to lock.
 			assert.Equal(t, want, string(got))
 		})
 	}

--- a/internal/api/v2/audio/streams_health_golden_test.go
+++ b/internal/api/v2/audio/streams_health_golden_test.go
@@ -58,7 +58,10 @@ func TestConvertStreamHealthToResponse_Golden(t *testing.T) {
 			got, err := json.Marshal(response)
 			require.NoError(t, err)
 			want := fmt.Sprintf(goldenTemplate, tt.wantProcess, tt.wantState)
-			assert.JSONEq(t, want, string(got))
+			// Compare the exact marshaled bytes, not a semantic JSON match, so a
+			// reordered or renamed field (which assert.JSONEq would tolerate) fails
+			// the byte-identity contract this test exists to lock.
+			assert.Equal(t, want, string(got))
 		})
 	}
 }

--- a/internal/api/v2/audio/streams_health_golden_test.go
+++ b/internal/api/v2/audio/streams_health_golden_test.go
@@ -1,0 +1,81 @@
+// internal/api/v2/audio/streams_health_golden_test.go
+package audio
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+)
+
+// TestConvertStreamHealthToResponse_Golden locks the health API JSON for every
+// FFmpeg process state. The legacy process_state string the frontend switches on
+// must stay byte-identical to the pre-seam output (the ffmpeg producer records
+// its process name in StateDetail); the additive neutral state field carries the
+// connection vocabulary. Building each health the way GetHealth does (mapped
+// State plus StateDetail) exercises the exact production path.
+func TestConvertStreamHealthToResponse_Golden(t *testing.T) {
+	t.Parallel()
+
+	const goldenURL = "rtsp://camera.local:554/stream"
+
+	// goldenTemplate is the full serialized StreamHealthResponse for a stream
+	// with no data, error, or history yet. Only process_state and state vary per
+	// FFmpeg process state, so a change to any other field, its omitempty, or the
+	// field order fails every row.
+	goldenTemplate := `{"url":"` + goldenURL + `","is_healthy":false,"process_state":%q,"state":%q,"last_data_received":null,"restart_count":0,"total_bytes_received":0,"bytes_per_second":0,"is_receiving_data":false}`
+
+	tests := []struct {
+		name        string
+		state       audiocore.StreamState
+		detail      string // legacy process_state name the ffmpeg producer records
+		wantProcess string
+		wantState   string
+	}{
+		{"idle", audiocore.StreamStateStarting, "idle", "idle", "starting"},
+		{"starting", audiocore.StreamStateStarting, "starting", "starting", "starting"},
+		{"running", audiocore.StreamStateConnected, "running", "running", "connected"},
+		{"restarting", audiocore.StreamStateReconnecting, "restarting", "restarting", "reconnecting"},
+		{"backoff", audiocore.StreamStateReconnecting, "backoff", "backoff", "reconnecting"},
+		{"circuit_open", audiocore.StreamStateReconnecting, "circuit_open", "circuit_open", "reconnecting"},
+		{"stopped", audiocore.StreamStateStopped, "stopped", "stopped", "stopped"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			health := &audiocore.StreamHealth{State: tt.state, StateDetail: tt.detail}
+			response := convertStreamHealthToResponse(goldenURL, health)
+
+			// Field-level guards make a failure legible before the byte compare.
+			assert.Equal(t, tt.wantProcess, response.ProcessState, "legacy process_state must be byte-identical")
+			assert.Equal(t, tt.wantState, response.State, "neutral state field")
+
+			got, err := json.Marshal(response)
+			require.NoError(t, err)
+			want := fmt.Sprintf(goldenTemplate, tt.wantProcess, tt.wantState)
+			assert.JSONEq(t, want, string(got))
+		})
+	}
+}
+
+// TestRemovedStreamHealth_ByteIdentity pins the synthetic health the
+// stream_removed SSE event carries. The legacy process_state must stay "idle"
+// byte-identically (the pre-seam empty ffmpeg.StreamHealth defaulted to the idle
+// process state), while the additive neutral state field reports "stopped" for a
+// stream that is gone. The literals are asserted directly (not via the source
+// constant) so a regression that drops StateDetail or changes the constant is
+// caught here rather than silently passing.
+func TestRemovedStreamHealth_ByteIdentity(t *testing.T) {
+	t.Parallel()
+
+	health := removedStreamHealth()
+	response := convertStreamHealthToResponse("rtsp://camera.local:554/stream", &health)
+
+	assert.Equal(t, "idle", response.ProcessState, "removed-stream process_state must stay byte-identical")
+	assert.Equal(t, "stopped", response.State, "removed-stream neutral state should read stopped")
+}

--- a/internal/api/v2/audio/streams_health_test.go
+++ b/internal/api/v2/audio/streams_health_test.go
@@ -7,18 +7,29 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/audiocore"
 )
 
 // Test error type constant for connection timeout scenarios
 const testErrorTypeTimeout = "connection_timeout"
 
+// Legacy process_state detail strings the FFmpeg producer records in
+// StreamHealth.StateDetail; the API must echo them byte-identically.
+const (
+	testProcStateRunning     = "running"
+	testProcStateStarting    = "starting"
+	testProcStateBackoff     = "backoff"
+	testProcStateCircuitOpen = "circuit_open"
+)
+
 // TestCreateHealthSnapshot tests the createHealthSnapshot function
 func TestCreateHealthSnapshot(t *testing.T) {
 	t.Run("healthy stream with all fields populated", func(t *testing.T) {
-		health := &ffmpeg.StreamHealth{
+		health := &audiocore.StreamHealth{
 			IsHealthy:          true,
-			ProcessState:       ffmpeg.StateRunning,
+			State:              audiocore.StreamStateConnected,
+			StateDetail:        testProcStateRunning,
 			RestartCount:       0,
 			IsReceivingData:    true,
 			TotalBytesReceived: 1024,
@@ -37,13 +48,14 @@ func TestCreateHealthSnapshot(t *testing.T) {
 	})
 
 	t.Run("unhealthy stream with error context", func(t *testing.T) {
-		health := &ffmpeg.StreamHealth{
+		health := &audiocore.StreamHealth{
 			IsHealthy:          false,
-			ProcessState:       ffmpeg.StateCircuitOpen,
+			State:              audiocore.StreamStateReconnecting,
+			StateDetail:        testProcStateCircuitOpen,
 			RestartCount:       5,
 			IsReceivingData:    false,
 			TotalBytesReceived: 0,
-			LastErrorContext: &ffmpeg.ErrorContext{
+			LastErrorContext: &audiocore.StreamErrorContext{
 				ErrorType:      "rtsp_404",
 				PrimaryMessage: "method DESCRIBE failed: 404 Not Found",
 			},
@@ -61,9 +73,10 @@ func TestCreateHealthSnapshot(t *testing.T) {
 	})
 
 	t.Run("stream with nil error context", func(t *testing.T) {
-		health := &ffmpeg.StreamHealth{
+		health := &audiocore.StreamHealth{
 			IsHealthy:          true,
-			ProcessState:       ffmpeg.StateRunning,
+			State:              audiocore.StreamStateConnected,
+			StateDetail:        testProcStateRunning,
 			RestartCount:       0,
 			IsReceivingData:    true,
 			TotalBytesReceived: 2048,
@@ -77,13 +90,14 @@ func TestCreateHealthSnapshot(t *testing.T) {
 	})
 
 	t.Run("stream in backoff state", func(t *testing.T) {
-		health := &ffmpeg.StreamHealth{
+		health := &audiocore.StreamHealth{
 			IsHealthy:          false,
-			ProcessState:       ffmpeg.StateBackoff,
+			State:              audiocore.StreamStateReconnecting,
+			StateDetail:        testProcStateBackoff,
 			RestartCount:       3,
 			IsReceivingData:    false,
 			TotalBytesReceived: 512,
-			LastErrorContext: &ffmpeg.ErrorContext{
+			LastErrorContext: &audiocore.StreamErrorContext{
 				ErrorType: testErrorTypeTimeout,
 			},
 		}
@@ -376,9 +390,10 @@ func TestDetermineEventType(t *testing.T) {
 func TestConvertStreamHealthToResponse(t *testing.T) {
 	t.Run("complete health data conversion", func(t *testing.T) {
 		now := time.Now()
-		health := &ffmpeg.StreamHealth{
+		health := &audiocore.StreamHealth{
 			IsHealthy:          true,
-			ProcessState:       ffmpeg.StateRunning,
+			State:              audiocore.StreamStateConnected,
+			StateDetail:        testProcStateRunning,
 			LastDataReceived:   now,
 			RestartCount:       0,
 			Error:              nil,
@@ -386,8 +401,8 @@ func TestConvertStreamHealthToResponse(t *testing.T) {
 			BytesPerSecond:     128000.5,
 			IsReceivingData:    true,
 			LastErrorContext:   nil,
-			ErrorHistory:       []*ffmpeg.ErrorContext{},
-			StateHistory:       []ffmpeg.StateTransition{},
+			ErrorHistory:       []*audiocore.StreamErrorContext{},
+			StateHistory:       []audiocore.StateTransition{},
 		}
 
 		response := convertStreamHealthToResponse("rtsp://user:pass@camera.local:554/stream", health)
@@ -408,9 +423,10 @@ func TestConvertStreamHealthToResponse(t *testing.T) {
 	})
 
 	t.Run("handle nil LastDataReceived", func(t *testing.T) {
-		health := &ffmpeg.StreamHealth{
+		health := &audiocore.StreamHealth{
 			IsHealthy:          false,
-			ProcessState:       ffmpeg.StateStarting,
+			State:              audiocore.StreamStateStarting,
+			StateDetail:        testProcStateStarting,
 			LastDataReceived:   time.Time{}, // Zero time
 			RestartCount:       0,
 			TotalBytesReceived: 0,
@@ -426,9 +442,10 @@ func TestConvertStreamHealthToResponse(t *testing.T) {
 
 	t.Run("handle error present", func(t *testing.T) {
 		testError := errors.New("connection timeout")
-		health := &ffmpeg.StreamHealth{
+		health := &audiocore.StreamHealth{
 			IsHealthy:          false,
-			ProcessState:       ffmpeg.StateBackoff,
+			State:              audiocore.StreamStateReconnecting,
+			StateDetail:        testProcStateBackoff,
 			LastDataReceived:   time.Time{},
 			RestartCount:       2,
 			Error:              testError,
@@ -444,7 +461,7 @@ func TestConvertStreamHealthToResponse(t *testing.T) {
 
 	t.Run("handle error context and history", func(t *testing.T) {
 		now := time.Now()
-		errorCtx := &ffmpeg.ErrorContext{
+		errorCtx := &audiocore.StreamErrorContext{
 			ErrorType:      "rtsp_404",
 			PrimaryMessage: "method DESCRIBE failed: 404 Not Found",
 			UserFacingMsg:  "RTSP stream not found (404)",
@@ -459,16 +476,17 @@ func TestConvertStreamHealthToResponse(t *testing.T) {
 			RTSPMethod: "describe",
 		}
 
-		health := &ffmpeg.StreamHealth{
+		health := &audiocore.StreamHealth{
 			IsHealthy:          false,
-			ProcessState:       ffmpeg.StateCircuitOpen,
+			State:              audiocore.StreamStateReconnecting,
+			StateDetail:        testProcStateCircuitOpen,
 			LastDataReceived:   time.Time{},
 			RestartCount:       3,
 			TotalBytesReceived: 0,
 			BytesPerSecond:     0,
 			IsReceivingData:    false,
 			LastErrorContext:   errorCtx,
-			ErrorHistory:       []*ffmpeg.ErrorContext{errorCtx},
+			ErrorHistory:       []*audiocore.StreamErrorContext{errorCtx},
 		}
 
 		response := convertStreamHealthToResponse("rtsp://camera.local:554/stream", health)
@@ -481,18 +499,21 @@ func TestConvertStreamHealthToResponse(t *testing.T) {
 
 	t.Run("handle state history", func(t *testing.T) {
 		now := time.Now()
-		stateHistory := []ffmpeg.StateTransition{
+		stateHistory := []audiocore.StateTransition{
 			{
-				From:      ffmpeg.StateStarting,
-				To:        ffmpeg.StateCircuitOpen,
-				Timestamp: now,
-				Reason:    "permanent failure detected",
+				From:       audiocore.StreamStateStarting,
+				To:         audiocore.StreamStateReconnecting,
+				FromDetail: testProcStateStarting,
+				ToDetail:   testProcStateCircuitOpen,
+				Timestamp:  now,
+				Reason:     "permanent failure detected",
 			},
 		}
 
-		health := &ffmpeg.StreamHealth{
+		health := &audiocore.StreamHealth{
 			IsHealthy:          false,
-			ProcessState:       ffmpeg.StateCircuitOpen,
+			State:              audiocore.StreamStateReconnecting,
+			StateDetail:        testProcStateCircuitOpen,
 			LastDataReceived:   time.Time{},
 			RestartCount:       1,
 			TotalBytesReceived: 0,
@@ -503,16 +524,17 @@ func TestConvertStreamHealthToResponse(t *testing.T) {
 
 		response := convertStreamHealthToResponse("rtsp://camera.local:554/stream", health)
 
-		assert.Len(t, response.StateHistory, 1)
+		require.Len(t, response.StateHistory, 1)
 		assert.Equal(t, "starting", response.StateHistory[0].FromState)
 		assert.Equal(t, "circuit_open", response.StateHistory[0].ToState)
 		assert.Equal(t, "permanent failure detected", response.StateHistory[0].Reason)
 	})
 
 	t.Run("URL sanitization", func(t *testing.T) {
-		health := &ffmpeg.StreamHealth{
+		health := &audiocore.StreamHealth{
 			IsHealthy:          true,
-			ProcessState:       ffmpeg.StateRunning,
+			State:              audiocore.StreamStateConnected,
+			StateDetail:        testProcStateRunning,
 			RestartCount:       0,
 			TotalBytesReceived: 1024,
 			BytesPerSecond:     128,
@@ -530,18 +552,20 @@ func TestConvertStreamHealthToResponse(t *testing.T) {
 	t.Run("multiple URLs with different credentials sanitize to different entries", func(t *testing.T) {
 		// This test verifies that URLs differing only by credentials are preserved
 		// as separate entries when using array response format (not map)
-		health1 := &ffmpeg.StreamHealth{
+		health1 := &audiocore.StreamHealth{
 			IsHealthy:          true,
-			ProcessState:       ffmpeg.StateRunning,
+			State:              audiocore.StreamStateConnected,
+			StateDetail:        testProcStateRunning,
 			RestartCount:       0,
 			TotalBytesReceived: 1024,
 			BytesPerSecond:     128,
 			IsReceivingData:    true,
 		}
 
-		health2 := &ffmpeg.StreamHealth{
+		health2 := &audiocore.StreamHealth{
 			IsHealthy:          true,
-			ProcessState:       ffmpeg.StateRunning,
+			State:              audiocore.StreamStateConnected,
+			StateDetail:        testProcStateRunning,
 			RestartCount:       0,
 			TotalBytesReceived: 2048,
 			BytesPerSecond:     256,
@@ -572,7 +596,7 @@ func TestConvertErrorContextToResponse(t *testing.T) {
 	t.Run("complete error context conversion", func(t *testing.T) {
 		now := time.Now()
 		timeout := 10 * time.Second
-		errCtx := &ffmpeg.ErrorContext{
+		errCtx := &audiocore.StreamErrorContext{
 			ErrorType:       testErrorTypeTimeout,
 			PrimaryMessage:  "Connection timed out after 10s",
 			UserFacingMsg:   "Connection timeout",
@@ -605,7 +629,7 @@ func TestConvertErrorContextToResponse(t *testing.T) {
 
 	t.Run("permanent failure context", func(t *testing.T) {
 		now := time.Now()
-		errCtx := &ffmpeg.ErrorContext{
+		errCtx := &audiocore.StreamErrorContext{
 			ErrorType:       "rtsp_404",
 			PrimaryMessage:  "method DESCRIBE failed: 404 Not Found",
 			UserFacingMsg:   "RTSP stream not found (404)",
@@ -627,7 +651,7 @@ func TestConvertErrorContextToResponse(t *testing.T) {
 
 	t.Run("RTSP method uppercase conversion", func(t *testing.T) {
 		now := time.Now()
-		errCtx := &ffmpeg.ErrorContext{
+		errCtx := &audiocore.StreamErrorContext{
 			ErrorType:      "rtsp_404",
 			PrimaryMessage: "method SETUP failed",
 			Timestamp:      now,
@@ -641,7 +665,7 @@ func TestConvertErrorContextToResponse(t *testing.T) {
 
 	t.Run("optional fields omitted when not set", func(t *testing.T) {
 		now := time.Now()
-		errCtx := &ffmpeg.ErrorContext{
+		errCtx := &audiocore.StreamErrorContext{
 			ErrorType:      "generic_error",
 			PrimaryMessage: "Something went wrong",
 			Timestamp:      now,

--- a/internal/api/v2/system/diagnostics.go
+++ b/internal/api/v2/system/diagnostics.go
@@ -388,8 +388,8 @@ func mapInferenceSnapshots(snapshots map[string]inferencestats.PeekSnapshot, inf
 	return result
 }
 
-// buildStreamHealthProvider returns a closure that bridges the FFmpegManager's
-// stream health data to the checks.StreamHealthInfo format. The closure
+// buildStreamHealthProvider returns a closure that bridges the stream manager's
+// health data to the checks.StreamHealthInfo format. The closure
 // atomically loads c.Engine at call time because it is set after Controller init.
 func (c *Handler) buildStreamHealthProvider() func() []checks.StreamHealthInfo {
 	return func() []checks.StreamHealthInfo {
@@ -397,7 +397,7 @@ func (c *Handler) buildStreamHealthProvider() func() []checks.StreamHealthInfo {
 		if eng == nil {
 			return nil
 		}
-		mgr := eng.FFmpegManager()
+		mgr := eng.StreamManager()
 		if mgr == nil {
 			return nil
 		}
@@ -421,7 +421,7 @@ func (c *Handler) buildStreamHealthProvider() func() []checks.StreamHealthInfo {
 			infos = append(infos, checks.StreamHealthInfo{
 				URL:          url,
 				IsHealthy:    sh.IsHealthy,
-				ProcessState: sh.ProcessState.String(),
+				State:        sh.State,
 				RestartCount: sh.RestartCount,
 				Error:        errMsg,
 			})
@@ -479,7 +479,7 @@ func (c *Handler) buildStreamHealthSnapshotProvider() func() []observability.Str
 		if eng == nil {
 			return nil
 		}
-		mgr := eng.FFmpegManager()
+		mgr := eng.StreamManager()
 		if mgr == nil {
 			return nil
 		}

--- a/internal/audiocore/engine/engine.go
+++ b/internal/audiocore/engine/engine.go
@@ -263,7 +263,7 @@ func (e *AudioEngine) SetScheduler(s *schedule.QuietHoursScheduler) {
 	}
 }
 
-// GetActiveStreamIDs returns the runtime source IDs currently tracked by FFmpeg.
+// GetActiveStreamIDs returns the runtime source IDs currently tracked by the stream manager.
 func (e *AudioEngine) GetActiveStreamIDs() []string {
 	return e.streamMgr.GetActiveStreamIDs()
 }

--- a/internal/audiocore/engine/engine.go
+++ b/internal/audiocore/engine/engine.go
@@ -61,7 +61,7 @@ type Config struct {
 	Logger logger.Logger
 
 	// FFmpegPath is the absolute path to the FFmpeg binary.
-	// It is passed to StreamConfig when starting stream-type sources.
+	// It is handed to the FFmpeg stream manager as a manager-level option.
 	FFmpegPath string
 
 	// SoxPath is the absolute path to the SoX binary.
@@ -119,7 +119,7 @@ func captureBufferSecs(v int) int {
 type AudioEngine struct {
 	registry  *audiocore.SourceRegistry
 	router    *audiocore.AudioRouter
-	ffmpegMgr *ffmpeg.Manager
+	streamMgr audiocore.StreamManager
 	deviceMgr *audiocore.DeviceManager
 	bufferMgr *buffer.Manager
 	scheduler atomic.Pointer[schedule.QuietHoursScheduler]
@@ -136,16 +136,10 @@ type AudioEngine struct {
 	primaryClipBytes    int
 	primaryOverlapBytes int
 	primaryReadSize     int
-	// ffmpegPath is the absolute path to the FFmpeg binary.
-	ffmpegPath string
 	// soxPath is the absolute path to the SoX binary.
 	soxPath string
 	// transport is the default RTSP transport protocol.
 	transport string
-	// ffmpegParameters are additional FFmpeg command-line parameters.
-	ffmpegParameters []string
-	// logLevel is the FFmpeg log level.
-	logLevel string
 	// debug enables verbose debug logging for stream capture.
 	debug bool
 	// captureBufferSeconds is the ring buffer capacity for audio history.
@@ -170,9 +164,17 @@ func New(ctx context.Context, cfg *Config, scheduler *schedule.QuietHoursSchedul
 	// convert-on-capture (malgo) go through pooled byte slices instead of
 	// allocating per-frame. The router Retain/Release path keeps pooled
 	// buffers alive across fan-out subscribers.
-	ffmpegMgr := ffmpeg.NewManager(engineCtx, func(frame audiocore.AudioFrame) {
+	// The engine drives its network stream producer through the
+	// audiocore.StreamManager seam. The manager-level FFmpeg settings (binary
+	// path, extra parameters, log level) are handed to the manager once here
+	// rather than repeated on every StreamSpec.
+	var streamMgr audiocore.StreamManager = ffmpeg.NewManagerWithOptions(engineCtx, func(frame audiocore.AudioFrame) {
 		router.Dispatch(frame)
-	}, nil, log, bufMgr)
+	}, nil, log, bufMgr, ffmpeg.Options{
+		FFmpegPath:       cfg.FFmpegPath,
+		FFmpegParameters: cfg.FFmpegParameters,
+		LogLevel:         cfg.LogLevel,
+	})
 	deviceMgr := audiocore.NewDeviceManager(router, bufMgr, log)
 
 	// Probe all device capabilities at startup, before any capture begins.
@@ -183,17 +185,14 @@ func New(ctx context.Context, cfg *Config, scheduler *schedule.QuietHoursSchedul
 	e := &AudioEngine{
 		registry:             audiocore.NewSourceRegistry(log),
 		router:               router,
-		ffmpegMgr:            ffmpegMgr,
+		streamMgr:            streamMgr,
 		deviceMgr:            deviceMgr,
 		bufferMgr:            bufMgr,
 		logger:               log.With(logger.String("component", "audio_engine")),
 		ctx:                  engineCtx,
 		cancel:               cancel,
-		ffmpegPath:           cfg.FFmpegPath,
 		soxPath:              cfg.SoxPath,
 		transport:            cfg.Transport,
-		ffmpegParameters:     cfg.FFmpegParameters,
-		logLevel:             cfg.LogLevel,
 		debug:                cfg.Debug,
 		captureBufferSeconds: captureBufferSecs(cfg.CaptureBufferSeconds),
 	}
@@ -216,9 +215,32 @@ func (e *AudioEngine) BufferManager() *buffer.Manager {
 	return e.bufferMgr
 }
 
-// FFmpegManager returns the FFmpeg stream manager.
-func (e *AudioEngine) FFmpegManager() *ffmpeg.Manager {
-	return e.ffmpegMgr
+// StreamManager returns the network stream manager the engine drives through
+// the producer-neutral audiocore.StreamManager seam.
+func (e *AudioEngine) StreamManager() audiocore.StreamManager {
+	return e.streamMgr
+}
+
+// buildStreamSpec assembles the protocol-neutral audiocore.StreamSpec the stream
+// manager consumes from a source's resolved parameters. The manager-level FFmpeg
+// settings (binary path, extra parameters, log level) are not part of the spec;
+// the manager already holds them from its Options.
+func (e *AudioEngine) buildStreamSpec(sourceID, displayName, url string, typ audiocore.SourceType, sampleRate, sourceSampleRate, bitDepth, channels, sourceChannels int, channelMode, mediaMode, transport string) *audiocore.StreamSpec {
+	return &audiocore.StreamSpec{
+		SourceID:         sourceID,
+		SourceName:       displayName,
+		URL:              url,
+		Type:             typ,
+		SampleRate:       sampleRate,
+		SourceSampleRate: sourceSampleRate,
+		BitDepth:         bitDepth,
+		Channels:         channels,
+		SourceChannels:   sourceChannels,
+		ChannelMode:      channelMode,
+		MediaMode:        mediaMode,
+		Transport:        transport,
+		Debug:            e.debug,
+	}
 }
 
 // DeviceManager returns the device manager.
@@ -243,12 +265,12 @@ func (e *AudioEngine) SetScheduler(s *schedule.QuietHoursScheduler) {
 
 // GetActiveStreamIDs returns the runtime source IDs currently tracked by FFmpeg.
 func (e *AudioEngine) GetActiveStreamIDs() []string {
-	return e.ffmpegMgr.GetActiveStreamIDs()
+	return e.streamMgr.GetActiveStreamIDs()
 }
 
 // GetActiveStreamURLs returns active runtime sourceID -> raw stream URL.
 func (e *AudioEngine) GetActiveStreamURLs() map[string]string {
-	ids := e.ffmpegMgr.GetActiveStreamIDs()
+	ids := e.streamMgr.GetActiveStreamIDs()
 	urls := make(map[string]string, len(ids))
 	for _, sourceID := range ids {
 		if url, ok := e.registry.ConnectionStringByID(sourceID); ok {
@@ -261,7 +283,7 @@ func (e *AudioEngine) GetActiveStreamURLs() map[string]string {
 // StopStream stops the FFmpeg stream for sourceID while keeping the registered
 // source, routes, and buffers available for a later quiet-hours restart.
 func (e *AudioEngine) StopStream(sourceID string) error {
-	if err := e.ffmpegMgr.StopStream(sourceID); err != nil {
+	if err := e.streamMgr.StopStream(sourceID); err != nil {
 		return err
 	}
 	_ = e.registry.UpdateState(sourceID, audiocore.SourceStopped)
@@ -301,25 +323,8 @@ func (e *AudioEngine) StartStream(sourceID, url, transport string) error {
 	if bitDepth <= 0 {
 		bitDepth = defaultBitDepth
 	}
-	streamCfg := &ffmpeg.StreamConfig{
-		SourceID:         sourceID,
-		SourceName:       src.DisplayName,
-		URL:              url,
-		Type:             string(src.Type),
-		SampleRate:       sampleRate,
-		SourceSampleRate: src.SourceSampleRate,
-		BitDepth:         bitDepth,
-		Channels:         channels,
-		SourceChannels:   src.SourceChannels,
-		ChannelMode:      src.ChannelMode,
-		MediaMode:        src.MediaMode,
-		FFmpegPath:       e.ffmpegPath,
-		Transport:        transport,
-		FFmpegParameters: e.ffmpegParameters,
-		LogLevel:         e.logLevel,
-		Debug:            e.debug,
-	}
-	if err := e.ffmpegMgr.StartStream(streamCfg); err != nil {
+	spec := e.buildStreamSpec(sourceID, src.DisplayName, url, src.Type, sampleRate, src.SourceSampleRate, bitDepth, channels, src.SourceChannels, src.ChannelMode, src.MediaMode, transport)
+	if err := e.streamMgr.StartStream(spec); err != nil {
 		_ = e.registry.UpdateState(sourceID, audiocore.SourceError)
 		return err
 	}
@@ -445,25 +450,8 @@ func (e *AudioEngine) AddSource(cfg *audiocore.SourceConfig) error {
 
 	// 5. Start capture based on source type.
 	if isStreamType(cfg.Type) {
-		streamCfg := &ffmpeg.StreamConfig{
-			SourceID:         sourceID,
-			SourceName:       src.DisplayName,
-			URL:              cfg.ConnectionString,
-			Type:             string(cfg.Type),
-			SampleRate:       sampleRate,
-			SourceSampleRate: cfg.SourceSampleRate,
-			BitDepth:         bitDepth,
-			Channels:         channels,
-			SourceChannels:   cfg.SourceChannels,
-			ChannelMode:      cfg.ChannelMode,
-			MediaMode:        cfg.MediaMode,
-			FFmpegPath:       e.ffmpegPath,
-			Transport:        e.resolveTransport(cfg.Transport),
-			FFmpegParameters: e.ffmpegParameters,
-			LogLevel:         e.logLevel,
-			Debug:            e.debug,
-		}
-		if err := e.ffmpegMgr.StartStream(streamCfg); err != nil {
+		spec := e.buildStreamSpec(sourceID, src.DisplayName, cfg.ConnectionString, cfg.Type, sampleRate, cfg.SourceSampleRate, bitDepth, channels, cfg.SourceChannels, cfg.ChannelMode, cfg.MediaMode, e.resolveTransport(cfg.Transport))
+		if err := e.streamMgr.StartStream(spec); err != nil {
 			e.bufferMgr.DeallocateSource(sourceID)
 			_ = e.registry.Unregister(sourceID)
 			return errors.New(err).
@@ -527,7 +515,7 @@ func (e *AudioEngine) RemoveSource(sourceID string) error {
 
 	// 1. Stop capture.
 	if isStreamType(src.Type) {
-		if err := e.ffmpegMgr.StopStream(sourceID); err != nil {
+		if err := e.streamMgr.StopStream(sourceID); err != nil {
 			e.logger.Warn("failed to stop stream during removal",
 				logger.String("source_id", sourceID),
 				logger.Error(err))
@@ -582,7 +570,7 @@ func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.Sourc
 
 	// 1. Stop existing capture.
 	if isStreamType(src.Type) {
-		_ = e.ffmpegMgr.StopStream(sourceID)
+		_ = e.streamMgr.StopStream(sourceID)
 	} else if src.Type == audiocore.SourceTypeAudioCard {
 		_ = e.deviceMgr.StopCapture(sourceID)
 	}
@@ -651,25 +639,8 @@ func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.Sourc
 	}
 
 	if isStreamType(newType) {
-		streamCfg := &ffmpeg.StreamConfig{
-			SourceID:         sourceID,
-			SourceName:       src.DisplayName,
-			URL:              newCfg.ConnectionString,
-			Type:             string(newType),
-			SampleRate:       sampleRate,
-			SourceSampleRate: newCfg.SourceSampleRate,
-			BitDepth:         bitDepth,
-			Channels:         channels,
-			SourceChannels:   newCfg.SourceChannels,
-			ChannelMode:      newCfg.ChannelMode,
-			MediaMode:        newCfg.MediaMode,
-			FFmpegPath:       e.ffmpegPath,
-			Transport:        e.resolveTransport(newCfg.Transport),
-			FFmpegParameters: e.ffmpegParameters,
-			LogLevel:         e.logLevel,
-			Debug:            e.debug,
-		}
-		if err := e.ffmpegMgr.StartStream(streamCfg); err != nil {
+		spec := e.buildStreamSpec(sourceID, src.DisplayName, newCfg.ConnectionString, newType, sampleRate, newCfg.SourceSampleRate, bitDepth, channels, newCfg.SourceChannels, newCfg.ChannelMode, newCfg.MediaMode, e.resolveTransport(newCfg.Transport))
+		if err := e.streamMgr.StartStream(spec); err != nil {
 			e.bufferMgr.DeallocateSource(sourceID)
 			_ = e.registry.UpdateState(sourceID, audiocore.SourceError)
 			return errors.New(err).
@@ -732,7 +703,7 @@ func (e *AudioEngine) Stop() {
 	e.cancel(ErrEngineStopped)
 
 	// Shut down FFmpeg streams.
-	if err := e.ffmpegMgr.Shutdown(); err != nil {
+	if err := e.streamMgr.Shutdown(); err != nil {
 		e.logger.Warn("ffmpeg manager shutdown error", logger.Error(err))
 	}
 

--- a/internal/audiocore/engine/engine_contract_test.go
+++ b/internal/audiocore/engine/engine_contract_test.go
@@ -72,7 +72,7 @@ func TestEngineIngestContract(t *testing.T) {
 // engineStreamHealthy reports whether the engine's FFmpeg stream for sourceID is
 // healthy right now.
 func engineStreamHealthy(eng *AudioEngine, sourceID string) bool {
-	h, err := eng.FFmpegManager().StreamHealth(sourceID)
+	h, err := eng.StreamManager().StreamHealth(sourceID)
 	return err == nil && h != nil && h.IsHealthy
 }
 
@@ -120,7 +120,7 @@ func engineReconfigureCase(t *testing.T, ffmpegPath string, fixture streamtest.F
 	// Quiet-hours round-trip: stop then start the same source.
 	require.NoError(t, eng.StopStream(sourceID))
 	require.Eventually(t, func() bool {
-		_, err := eng.FFmpegManager().StreamHealth(sourceID)
+		_, err := eng.StreamManager().StreamHealth(sourceID)
 		return err != nil
 	}, engineHealthyBudget, enginePollInterval, "stream should be gone from the manager after StopStream")
 
@@ -172,7 +172,7 @@ func livenessChainCase(t *testing.T, ffmpegPath string, fixture streamtest.Fixtu
 	consumer := &countingConsumer{id: "liveness-consumer"}
 	require.NoError(t, router.AddRoute(sourceID, consumer, engineSampleRate, 0, nil))
 
-	mgr := ffmpeg.NewManager(t.Context(), func(f audiocore.AudioFrame) { router.Dispatch(f) }, nil, log, bufMgr)
+	mgr := ffmpeg.NewManagerWithOptions(t.Context(), func(f audiocore.AudioFrame) { router.Dispatch(f) }, nil, log, bufMgr, ffmpeg.Options{FFmpegPath: ffmpegPath, LogLevel: "error"})
 	t.Cleanup(func() {
 		//nolint:gocritic // t.Context() is already cancelled when Cleanup runs; shutdown needs a live context
 		ctx, cancel := context.WithTimeout(context.Background(), managerShutdownCleanupTimeout)
@@ -180,17 +180,15 @@ func livenessChainCase(t *testing.T, ffmpegPath string, fixture streamtest.Fixtu
 		assert.NoError(t, mgr.ShutdownWithContext(ctx), "manager should shut down cleanly")
 	})
 
-	streamCfg := &ffmpeg.StreamConfig{
+	streamCfg := &audiocore.StreamSpec{
 		SourceID:   sourceID,
 		SourceName: "Liveness Chain",
 		URL:        pub.URL(),
-		Type:       "rtsp",
+		Type:       audiocore.SourceTypeRTSP,
 		SampleRate: engineSampleRate,
 		BitDepth:   engineBitDepth,
 		Channels:   engineChannels,
 		Transport:  "tcp",
-		FFmpegPath: ffmpegPath,
-		LogLevel:   "error",
 	}
 
 	var restartCalls atomic.Int64

--- a/internal/audiocore/engine/engine_test.go
+++ b/internal/audiocore/engine/engine_test.go
@@ -48,7 +48,7 @@ func TestEngine_NewAndStop(t *testing.T) {
 	// All subsystems should be non-nil after construction.
 	assert.NotNil(t, eng.registry)
 	assert.NotNil(t, eng.router)
-	assert.NotNil(t, eng.ffmpegMgr)
+	assert.NotNil(t, eng.streamMgr)
 	assert.NotNil(t, eng.deviceMgr)
 	assert.NotNil(t, eng.bufferMgr)
 	assert.NotNil(t, eng.logger)
@@ -66,7 +66,7 @@ func TestEngine_Accessors(t *testing.T) {
 	assert.NotNil(t, eng.Registry(), "Registry() should return non-nil")
 	assert.NotNil(t, eng.Router(), "Router() should return non-nil")
 	assert.NotNil(t, eng.BufferManager(), "BufferManager() should return non-nil")
-	assert.NotNil(t, eng.FFmpegManager(), "FFmpegManager() should return non-nil")
+	assert.NotNil(t, eng.StreamManager(), "StreamManager() should return non-nil")
 	assert.NotNil(t, eng.DeviceManager(), "DeviceManager() should return non-nil")
 	assert.Nil(t, eng.Scheduler(), "Scheduler() should be nil when no scheduler provided")
 }
@@ -136,7 +136,7 @@ func TestEngine_AddSource_Stream(t *testing.T) {
 	assert.NotNil(t, cb, "capture buffer should be allocated")
 
 	// Verify FFmpeg stream was started (it appears in AllStreamHealth).
-	health := eng.FFmpegManager().AllStreamHealth()
+	health := eng.StreamManager().AllStreamHealth()
 	assert.Contains(t, health, "test_rtsp_001", "stream should appear in FFmpeg manager")
 }
 
@@ -304,7 +304,7 @@ func TestEngine_RemoveSource(t *testing.T) {
 	require.Error(t, cbErr, "capture buffer should be deallocated")
 
 	// Verify stream is gone from FFmpeg manager.
-	health := eng.FFmpegManager().AllStreamHealth()
+	health := eng.StreamManager().AllStreamHealth()
 	assert.NotContains(t, health, "test_remove_001", "stream should be removed from FFmpeg manager")
 }
 
@@ -372,7 +372,7 @@ func TestEngine_ReconfigureSource(t *testing.T) {
 	assert.NotNil(t, cb2, "new capture buffer should be allocated after reconfigure")
 
 	// Verify the FFmpeg stream was restarted.
-	health := eng.FFmpegManager().AllStreamHealth()
+	health := eng.StreamManager().AllStreamHealth()
 	assert.Contains(t, health, "test_reconfig_001", "stream should be restarted after reconfigure")
 }
 
@@ -597,7 +597,7 @@ func TestEngine_StartStream_ZeroBitDepthFallback(t *testing.T) {
 	require.NoError(t, eng.AddSource(cfg))
 
 	// Stop the stream started by AddSource so we can restart it.
-	require.NoError(t, eng.FFmpegManager().StopStream("test_startstream_bitdepth"))
+	require.NoError(t, eng.StreamManager().StopStream("test_startstream_bitdepth"))
 
 	// Manually zero out BitDepth in the registry to simulate an edge case.
 	eng.Registry().UpdateAudioParams("test_startstream_bitdepth", 48000, 0, 1)
@@ -606,6 +606,6 @@ func TestEngine_StartStream_ZeroBitDepthFallback(t *testing.T) {
 	err := eng.StartStream("test_startstream_bitdepth", "rtsp://192.168.1.100/stream2", "")
 	require.NoError(t, err)
 
-	health := eng.FFmpegManager().AllStreamHealth()
+	health := eng.StreamManager().AllStreamHealth()
 	assert.Contains(t, health, "test_startstream_bitdepth")
 }

--- a/internal/audiocore/engine/stream_spec_test.go
+++ b/internal/audiocore/engine/stream_spec_test.go
@@ -1,0 +1,85 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+)
+
+// TestBuildStreamSpec verifies that buildStreamSpec maps its parameters onto the
+// StreamSpec field-for-field, reproducing the three former ffmpeg.StreamConfig
+// literals in AddSource, the reconfigure path, and the quiet-hours restart path.
+// Every column uses a distinct value so a transposed positional argument in the
+// twelve-parameter helper is caught. Debug is read from the engine, not passed.
+func TestBuildStreamSpec(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		debug bool
+		want  audiocore.StreamSpec
+	}{
+		{
+			name:  "rtsp downmix auto tcp, debug on",
+			debug: true,
+			want: audiocore.StreamSpec{
+				SourceID:         "src-a",
+				SourceName:       "Camera A",
+				URL:              "rtsp://a.example/stream",
+				Type:             audiocore.SourceTypeRTSP,
+				SampleRate:       48000,
+				SourceSampleRate: 44100,
+				BitDepth:         16,
+				Channels:         1,
+				SourceChannels:   2,
+				ChannelMode:      "downmix",
+				MediaMode:        "auto",
+				Transport:        "tcp",
+				Debug:            true,
+			},
+		},
+		{
+			name:  "http left audio-only udp, debug off",
+			debug: false,
+			want: audiocore.StreamSpec{
+				SourceID:         "src-b",
+				SourceName:       "Restreamer B",
+				URL:              "http://b.example/stream.mp3",
+				Type:             audiocore.SourceTypeHTTP,
+				SampleRate:       96000,
+				SourceSampleRate: 0,
+				BitDepth:         24,
+				Channels:         1,
+				SourceChannels:   0,
+				ChannelMode:      "left",
+				MediaMode:        "audio-only",
+				Transport:        "udp",
+				Debug:            false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			e := &AudioEngine{debug: tt.debug}
+			got := e.buildStreamSpec(
+				tt.want.SourceID,
+				tt.want.SourceName,
+				tt.want.URL,
+				tt.want.Type,
+				tt.want.SampleRate,
+				tt.want.SourceSampleRate,
+				tt.want.BitDepth,
+				tt.want.Channels,
+				tt.want.SourceChannels,
+				tt.want.ChannelMode,
+				tt.want.MediaMode,
+				tt.want.Transport,
+			)
+			assert.Equal(t, &tt.want, got)
+		})
+	}
+}

--- a/internal/audiocore/ffmpeg/error_context.go
+++ b/internal/audiocore/ffmpeg/error_context.go
@@ -8,48 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/privacy"
-)
-
-// FFmpeg error type constants for categorizing error conditions.
-//
-// Error classification for retry and circuit breaker decisions:
-//
-// Transient errors (may recover on retry):
-//   - ErrTypeConnectionTimeout — host unreachable or slow network
-//   - ErrTypeNetworkUnreachable — network transition, interface coming up
-//   - ErrTypeRTSP503 — server overloaded, may recover
-//   - ErrTypeInvalidData — stream corruption, may be temporary
-//   - ErrTypeEOF — stream ended unexpectedly, may restart
-//
-// Permanent errors (require configuration fix, no retry):
-//   - ErrTypeRTSP404 — stream path does not exist
-//   - ErrTypeConnectionRefused — no server listening on port
-//   - ErrTypeAuthFailed — invalid credentials (401)
-//   - ErrTypeAuthForbidden — insufficient permissions (403)
-//   - ErrTypeNoRoute — routing table problem for specific host
-//   - ErrTypeOperationNotPermit — firewall/SELinux blocking
-//   - ErrTypeSSLError — certificate or TLS configuration issue
-//   - ErrTypeDNSResolutionFailed — hostname does not resolve
-//   - ErrTypeProtocolError — unsupported protocol in URL
-//
-// See ShouldOpenCircuit() and ShouldRestart() for how these classifications
-// drive circuit breaker and restart behaviour.
-const (
-	ErrTypeConnectionTimeout   = "connection_timeout"
-	ErrTypeNetworkUnreachable  = "network_unreachable"
-	ErrTypeRTSP503             = "rtsp_503"
-	ErrTypeInvalidData         = "invalid_data"
-	ErrTypeEOF                 = "eof"
-	ErrTypeRTSP404             = "rtsp_404"
-	ErrTypeConnectionRefused   = "connection_refused"
-	ErrTypeAuthFailed          = "auth_failed"
-	ErrTypeAuthForbidden       = "auth_forbidden"
-	ErrTypeNoRoute             = "no_route"
-	ErrTypeOperationNotPermit  = "operation_not_permitted"
-	ErrTypeSSLError            = "ssl_error"
-	ErrTypeDNSResolutionFailed = "dns_resolution_failed"
-	ErrTypeProtocolError       = "protocol_error"
 )
 
 // Pre-compiled regular expressions for FFmpeg error parsing.
@@ -66,26 +26,6 @@ var (
 	reConnectionToTCP = regexp.MustCompile(`Connection to (tcp://\S+)`)
 	reSSLError        = regexp.MustCompile(`SSL.*error|TLS.*error|certificate.*error`)
 )
-
-// ErrorContext contains rich information extracted from FFmpeg output.
-// It provides detailed diagnostics for user-facing error messages and troubleshooting.
-type ErrorContext struct {
-	ErrorType       string        // "connection_timeout", "rtsp_404", "auth_failed", etc.
-	PrimaryMessage  string        // Main error message
-	TargetHost      string        // Extracted host/IP (sanitized - no credentials)
-	TargetPort      int           // Extracted port
-	TimeoutDuration time.Duration // Extracted timeout (if applicable)
-	HTTPStatus      int           // HTTP/RTSP status code (if applicable)
-	RTSPMethod      string        // RTSP method that failed (if applicable)
-	// RawFFmpegOutput stores the sanitized FFmpeg stderr output for debugging.
-	// SECURITY: This field is sanitized using privacy.SanitizeFFmpegError() to remove
-	// credentials from RTSP URLs (e.g., rtsp://user:pass@host → rtsp://***:***@host).
-	// The json:"-" tag prevents accidental credential leakage via JSON marshaling.
-	RawFFmpegOutput string    `json:"-"` // Full FFmpeg output for debugging (sanitized)
-	UserFacingMsg   string    // Friendly message for user
-	TroubleShooting []string  // List of troubleshooting steps
-	Timestamp       time.Time // When this error was detected
-}
 
 // extractHostWithoutCredentials safely extracts hostname from a URL string,
 // stripping any userinfo (username:password) to prevent credential leakage.
@@ -153,14 +93,14 @@ func extractHostAndPortFromConnectionURL(connectionURL string) (hostname string,
 // It returns nil if no recognizable error pattern is found.
 //
 // Error patterns are checked in order of specificity and diagnostic value:
-//  1. Socket-level errors (connection refused, timeout) — most specific about network failure
-//  2. RTSP protocol errors (404, 401, 403, 503) — application-layer specific issues
-//  3. Network-layer errors (no route, network unreachable) — broader network configuration
-//  4. DNS errors — name resolution layer
-//  5. Security/permission errors (SSL, operation not permitted) — system policy layer
-//  6. Data errors (invalid data, EOF) — stream content issues
-//  7. Generic errors (protocol not found) — catch-all patterns
-func ExtractErrorContext(stderrOutput string) *ErrorContext {
+//  1. Socket-level errors (connection refused, timeout) - most specific about network failure
+//  2. RTSP protocol errors (404, 401, 403, 503) - application-layer specific issues
+//  3. Network-layer errors (no route, network unreachable) - broader network configuration
+//  4. DNS errors - name resolution layer
+//  5. Security/permission errors (SSL, operation not permitted) - system policy layer
+//  6. Data errors (invalid data, EOF) - stream content issues
+//  7. Generic errors (protocol not found) - catch-all patterns
+func ExtractErrorContext(stderrOutput string) *audiocore.StreamErrorContext {
 	if stderrOutput == "" {
 		return nil
 	}
@@ -169,136 +109,136 @@ func ExtractErrorContext(stderrOutput string) *ErrorContext {
 	// before storing. This prevents credential leakage via logs, health APIs, etc.
 	sanitizedOutput := privacy.SanitizeFFmpegError(stderrOutput)
 
-	ctx := &ErrorContext{
+	ctx := &audiocore.StreamErrorContext{
 		RawFFmpegOutput: sanitizedOutput,
 		Timestamp:       time.Now(),
 	}
 
-	// Connection timeout — very common with unreachable hosts.
+	// Connection timeout - very common with unreachable hosts.
 	if strings.Contains(stderrOutput, "Connection timed out") {
-		ctx.ErrorType = ErrTypeConnectionTimeout
-		ctx.extractConnectionTimeout(stderrOutput)
-		ctx.buildConnectionTimeoutMessage()
+		ctx.ErrorType = audiocore.ErrTypeConnectionTimeout
+		extractConnectionTimeout(ctx, stderrOutput)
+		buildConnectionTimeoutMessage(ctx)
 
 		return ctx
 	}
 
-	// RTSP 404 — stream path doesn't exist.
+	// RTSP 404 - stream path doesn't exist.
 	if strings.Contains(stderrOutput, "404 Not Found") {
-		ctx.ErrorType = ErrTypeRTSP404
-		ctx.extractRTSP404(stderrOutput)
-		ctx.buildRTSP404Message()
+		ctx.ErrorType = audiocore.ErrTypeRTSP404
+		extractRTSP404(ctx, stderrOutput)
+		buildRTSP404Message(ctx)
 
 		return ctx
 	}
 
-	// Connection refused — server not listening.
+	// Connection refused - server not listening.
 	if strings.Contains(stderrOutput, "Connection refused") {
-		ctx.ErrorType = ErrTypeConnectionRefused
-		ctx.extractConnectionRefused(stderrOutput)
-		ctx.buildConnectionRefusedMessage()
+		ctx.ErrorType = audiocore.ErrTypeConnectionRefused
+		extractConnectionRefused(ctx, stderrOutput)
+		buildConnectionRefusedMessage(ctx)
 
 		return ctx
 	}
 
 	// Authentication failure.
 	if strings.Contains(stderrOutput, "401 Unauthorized") {
-		ctx.ErrorType = ErrTypeAuthFailed
-		ctx.extractAuthFailure(stderrOutput)
-		ctx.buildAuthFailureMessage()
+		ctx.ErrorType = audiocore.ErrTypeAuthFailed
+		extractAuthFailure(ctx, stderrOutput)
+		buildAuthFailureMessage(ctx)
 
 		return ctx
 	}
 
 	// 403 Forbidden.
 	if strings.Contains(stderrOutput, "403 Forbidden") {
-		ctx.ErrorType = ErrTypeAuthForbidden
-		ctx.extractAuthForbidden(stderrOutput)
-		ctx.buildAuthForbiddenMessage()
+		ctx.ErrorType = audiocore.ErrTypeAuthForbidden
+		extractAuthForbidden(ctx, stderrOutput)
+		buildAuthForbiddenMessage(ctx)
 
 		return ctx
 	}
 
 	// No route to host.
 	if strings.Contains(stderrOutput, "No route to host") {
-		ctx.ErrorType = ErrTypeNoRoute
-		ctx.extractNoRoute(stderrOutput)
-		ctx.buildNoRouteMessage()
+		ctx.ErrorType = audiocore.ErrTypeNoRoute
+		extractNoRoute(ctx, stderrOutput)
+		buildNoRouteMessage(ctx)
 
 		return ctx
 	}
 
-	// Network unreachable — different from no route.
+	// Network unreachable - different from no route.
 	if strings.Contains(stderrOutput, "Network unreachable") {
-		ctx.ErrorType = ErrTypeNetworkUnreachable
-		ctx.extractNetworkUnreachable(stderrOutput)
-		ctx.buildNetworkUnreachableMessage()
+		ctx.ErrorType = audiocore.ErrTypeNetworkUnreachable
+		extractNetworkUnreachable(ctx, stderrOutput)
+		buildNetworkUnreachableMessage(ctx)
 
 		return ctx
 	}
 
-	// Operation not permitted — firewall/SELinux.
+	// Operation not permitted - firewall/SELinux.
 	if strings.Contains(stderrOutput, "Operation not permitted") {
-		ctx.ErrorType = ErrTypeOperationNotPermit
-		ctx.extractOperationNotPermitted(stderrOutput)
-		ctx.buildOperationNotPermittedMessage()
+		ctx.ErrorType = audiocore.ErrTypeOperationNotPermit
+		extractOperationNotPermitted(ctx, stderrOutput)
+		buildOperationNotPermittedMessage(ctx)
 
 		return ctx
 	}
 
 	// SSL/TLS errors for rtsps://.
 	if reSSLError.MatchString(stderrOutput) {
-		ctx.ErrorType = ErrTypeSSLError
-		ctx.extractSSLError(stderrOutput)
-		ctx.buildSSLErrorMessage()
+		ctx.ErrorType = audiocore.ErrTypeSSLError
+		extractSSLError(ctx, stderrOutput)
+		buildSSLErrorMessage(ctx)
 
 		return ctx
 	}
 
-	// RTSP 503 Service Unavailable — server overload.
+	// RTSP 503 Service Unavailable - server overload.
 	if strings.Contains(stderrOutput, "503 Service Unavailable") {
-		ctx.ErrorType = ErrTypeRTSP503
-		ctx.extractRTSP503(stderrOutput)
-		ctx.buildRTSP503Message()
+		ctx.ErrorType = audiocore.ErrTypeRTSP503
+		extractRTSP503(ctx, stderrOutput)
+		buildRTSP503Message(ctx)
 
 		return ctx
 	}
 
-	// DNS resolution failures — common with typos in hostnames.
+	// DNS resolution failures - common with typos in hostnames.
 	if strings.Contains(stderrOutput, "Name or service not known") ||
 		strings.Contains(stderrOutput, "nodename nor servname provided") ||
 		strings.Contains(stderrOutput, "Temporary failure in name resolution") ||
 		strings.Contains(stderrOutput, "Could not resolve hostname") {
-		ctx.ErrorType = ErrTypeDNSResolutionFailed
-		ctx.extractDNSError(stderrOutput)
-		ctx.buildDNSErrorMessage()
+		ctx.ErrorType = audiocore.ErrTypeDNSResolutionFailed
+		extractDNSError(ctx, stderrOutput)
+		buildDNSErrorMessage(ctx)
 
 		return ctx
 	}
 
-	// Invalid data — stream corruption.
+	// Invalid data - stream corruption.
 	if strings.Contains(stderrOutput, "Invalid data found") {
-		ctx.ErrorType = ErrTypeInvalidData
-		ctx.extractInvalidData(stderrOutput)
-		ctx.buildInvalidDataMessage()
+		ctx.ErrorType = audiocore.ErrTypeInvalidData
+		extractInvalidData(ctx, stderrOutput)
+		buildInvalidDataMessage(ctx)
 
 		return ctx
 	}
 
-	// End of file — stream ended unexpectedly.
+	// End of file - stream ended unexpectedly.
 	if strings.Contains(stderrOutput, "End of file") {
-		ctx.ErrorType = ErrTypeEOF
+		ctx.ErrorType = audiocore.ErrTypeEOF
 		ctx.PrimaryMessage = "Stream ended unexpectedly"
-		ctx.buildEOFMessage()
+		buildEOFMessage(ctx)
 
 		return ctx
 	}
 
 	// Protocol not found.
 	if strings.Contains(stderrOutput, "Protocol not found") {
-		ctx.ErrorType = ErrTypeProtocolError
+		ctx.ErrorType = audiocore.ErrTypeProtocolError
 		ctx.PrimaryMessage = "Unsupported protocol"
-		ctx.buildProtocolErrorMessage()
+		buildProtocolErrorMessage(ctx)
 
 		return ctx
 	}
@@ -308,7 +248,7 @@ func ExtractErrorContext(stderrOutput string) *ErrorContext {
 }
 
 // extractConnectionTimeout parses connection timeout details from FFmpeg output.
-func (ctx *ErrorContext) extractConnectionTimeout(output string) {
+func extractConnectionTimeout(ctx *audiocore.StreamErrorContext, output string) {
 	// Extract target host and port.
 	// Pattern: "Connection attempt to 192.168.44.3 port 8554 failed"
 	if matches := reConnectionAttempt.FindStringSubmatch(output); len(matches) == 3 {
@@ -329,7 +269,7 @@ func (ctx *ErrorContext) extractConnectionTimeout(output string) {
 	ctx.PrimaryMessage = "Connection timed out"
 }
 
-func (ctx *ErrorContext) buildConnectionTimeoutMessage() {
+func buildConnectionTimeoutMessage(ctx *audiocore.StreamErrorContext) {
 	// Handle timeout duration display:
 	//   Positive duration: show explicit timeout value (e.g., "10s").
 	//   Zero duration: indicates infinite timeout (no timeout was set, but connection still failed).
@@ -359,7 +299,7 @@ func (ctx *ErrorContext) buildConnectionTimeoutMessage() {
 }
 
 // extractRTSP404 parses RTSP 404 error details from FFmpeg output.
-func (ctx *ErrorContext) extractRTSP404(output string) {
+func extractRTSP404(ctx *audiocore.StreamErrorContext, output string) {
 	ctx.HTTPStatus = 404
 
 	// Extract RTSP method.
@@ -377,7 +317,7 @@ func (ctx *ErrorContext) extractRTSP404(output string) {
 	ctx.PrimaryMessage = "RTSP stream not found"
 }
 
-func (ctx *ErrorContext) buildRTSP404Message() {
+func buildRTSP404Message(ctx *audiocore.StreamErrorContext) {
 	method := ctx.RTSPMethod
 	if method == "" {
 		method = "DESCRIBE"
@@ -400,7 +340,7 @@ func (ctx *ErrorContext) buildRTSP404Message() {
 }
 
 // extractConnectionRefused parses connection refused details from FFmpeg output.
-func (ctx *ErrorContext) extractConnectionRefused(output string) {
+func extractConnectionRefused(ctx *audiocore.StreamErrorContext, output string) {
 	// Pattern: "Connection to tcp://localhost:8553?timeout=0 failed"
 	// Use URL parsing to handle IPv6, credentials, and query parameters correctly.
 	if matches := reConnectionToTCP.FindStringSubmatch(output); len(matches) == 2 {
@@ -413,7 +353,7 @@ func (ctx *ErrorContext) extractConnectionRefused(output string) {
 	ctx.PrimaryMessage = "Connection refused"
 }
 
-func (ctx *ErrorContext) buildConnectionRefusedMessage() {
+func buildConnectionRefusedMessage(ctx *audiocore.StreamErrorContext) {
 	ctx.UserFacingMsg = fmt.Sprintf(
 		"🚫 Connection refused: %s:%d\n"+
 			"   The connection was actively refused by the target.\n"+
@@ -431,7 +371,7 @@ func (ctx *ErrorContext) buildConnectionRefusedMessage() {
 }
 
 // extractAuthFailure parses authentication failure details from FFmpeg output.
-func (ctx *ErrorContext) extractAuthFailure(output string) {
+func extractAuthFailure(ctx *audiocore.StreamErrorContext, output string) {
 	ctx.HTTPStatus = 401
 	ctx.PrimaryMessage = "Authentication required"
 
@@ -441,7 +381,7 @@ func (ctx *ErrorContext) extractAuthFailure(output string) {
 	}
 }
 
-func (ctx *ErrorContext) buildAuthFailureMessage() {
+func buildAuthFailureMessage(ctx *audiocore.StreamErrorContext) {
 	ctx.UserFacingMsg = "🔐 Authentication required (401 Unauthorized)\n" +
 		"   The RTSP server requires username and password.\n" +
 		"   Credentials were not provided or are incorrect."
@@ -456,12 +396,12 @@ func (ctx *ErrorContext) buildAuthFailureMessage() {
 }
 
 // extractAuthForbidden parses forbidden access details from FFmpeg output.
-func (ctx *ErrorContext) extractAuthForbidden(_ string) {
+func extractAuthForbidden(ctx *audiocore.StreamErrorContext, _ string) {
 	ctx.HTTPStatus = 403
 	ctx.PrimaryMessage = "Access forbidden"
 }
 
-func (ctx *ErrorContext) buildAuthForbiddenMessage() {
+func buildAuthForbiddenMessage(ctx *audiocore.StreamErrorContext) {
 	ctx.UserFacingMsg = "⛔ Access forbidden (403)\n" +
 		"   The RTSP server understood the request but refuses to authorize it.\n" +
 		"   The credentials may be valid but lack permissions."
@@ -475,7 +415,7 @@ func (ctx *ErrorContext) buildAuthForbiddenMessage() {
 }
 
 // extractNoRoute parses no route to host details from FFmpeg output.
-func (ctx *ErrorContext) extractNoRoute(output string) {
+func extractNoRoute(ctx *audiocore.StreamErrorContext, output string) {
 	// Use URL parsing to handle IPv6, credentials, and query parameters correctly.
 	if matches := reConnectionToTCP.FindStringSubmatch(output); len(matches) == 2 {
 		if host, port, ok := extractHostAndPortFromConnectionURL(matches[1]); ok {
@@ -487,7 +427,7 @@ func (ctx *ErrorContext) extractNoRoute(output string) {
 	ctx.PrimaryMessage = "No route to host"
 }
 
-func (ctx *ErrorContext) buildNoRouteMessage() {
+func buildNoRouteMessage(ctx *audiocore.StreamErrorContext) {
 	ctx.UserFacingMsg = fmt.Sprintf(
 		"🗺️  No route to host: %s\n"+
 			"   The network cannot find a route to reach the target host.\n"+
@@ -505,7 +445,7 @@ func (ctx *ErrorContext) buildNoRouteMessage() {
 }
 
 // extractNetworkUnreachable parses network unreachable details from FFmpeg output.
-func (ctx *ErrorContext) extractNetworkUnreachable(output string) {
+func extractNetworkUnreachable(ctx *audiocore.StreamErrorContext, output string) {
 	// Use URL parsing to handle IPv6, credentials, and query parameters correctly.
 	if matches := reConnectionToTCP.FindStringSubmatch(output); len(matches) == 2 {
 		if host, port, ok := extractHostAndPortFromConnectionURL(matches[1]); ok {
@@ -517,7 +457,7 @@ func (ctx *ErrorContext) extractNetworkUnreachable(output string) {
 	ctx.PrimaryMessage = "Network unreachable"
 }
 
-func (ctx *ErrorContext) buildNetworkUnreachableMessage() {
+func buildNetworkUnreachableMessage(ctx *audiocore.StreamErrorContext) {
 	ctx.UserFacingMsg = fmt.Sprintf(
 		"🌐 Network unreachable: %s\n"+
 			"   The network is unreachable from this host.\n"+
@@ -536,7 +476,7 @@ func (ctx *ErrorContext) buildNetworkUnreachableMessage() {
 }
 
 // extractOperationNotPermitted parses operation not permitted details from FFmpeg output.
-func (ctx *ErrorContext) extractOperationNotPermitted(output string) {
+func extractOperationNotPermitted(ctx *audiocore.StreamErrorContext, output string) {
 	// Use URL parsing to handle IPv6, credentials, and query parameters correctly.
 	if matches := reConnectionToTCP.FindStringSubmatch(output); len(matches) == 2 {
 		if host, port, ok := extractHostAndPortFromConnectionURL(matches[1]); ok {
@@ -548,7 +488,7 @@ func (ctx *ErrorContext) extractOperationNotPermitted(output string) {
 	ctx.PrimaryMessage = "Operation not permitted"
 }
 
-func (ctx *ErrorContext) buildOperationNotPermittedMessage() {
+func buildOperationNotPermittedMessage(ctx *audiocore.StreamErrorContext) {
 	ctx.UserFacingMsg = "🔒 Operation not permitted\n" +
 		"   The system denied the network operation.\n" +
 		"   This is typically caused by firewall rules or security policies (SELinux/AppArmor)."
@@ -564,7 +504,7 @@ func (ctx *ErrorContext) buildOperationNotPermittedMessage() {
 }
 
 // extractSSLError parses SSL/TLS error details from FFmpeg output.
-func (ctx *ErrorContext) extractSSLError(output string) {
+func extractSSLError(ctx *audiocore.StreamErrorContext, output string) {
 	// Try to extract URL to get host info.
 	// SECURITY: Use safe extraction to prevent credential leakage.
 	if matches := reErrorOpeningInput.FindStringSubmatch(output); len(matches) == 2 {
@@ -574,7 +514,7 @@ func (ctx *ErrorContext) extractSSLError(output string) {
 	ctx.PrimaryMessage = "SSL/TLS error"
 }
 
-func (ctx *ErrorContext) buildSSLErrorMessage() {
+func buildSSLErrorMessage(ctx *audiocore.StreamErrorContext) {
 	ctx.UserFacingMsg = "🔐 SSL/TLS connection error\n" +
 		"   Failed to establish a secure connection to the RTSP server.\n" +
 		"   This could be due to certificate issues or TLS configuration problems."
@@ -590,7 +530,7 @@ func (ctx *ErrorContext) buildSSLErrorMessage() {
 }
 
 // extractRTSP503 parses RTSP 503 error details from FFmpeg output.
-func (ctx *ErrorContext) extractRTSP503(output string) {
+func extractRTSP503(ctx *audiocore.StreamErrorContext, output string) {
 	ctx.HTTPStatus = 503
 
 	// Extract RTSP method if available.
@@ -607,7 +547,7 @@ func (ctx *ErrorContext) extractRTSP503(output string) {
 	ctx.PrimaryMessage = "RTSP service unavailable"
 }
 
-func (ctx *ErrorContext) buildRTSP503Message() {
+func buildRTSP503Message(ctx *audiocore.StreamErrorContext) {
 	ctx.UserFacingMsg = "⏳ RTSP service unavailable (503)\n" +
 		"   The RTSP server is temporarily unable to handle the request.\n" +
 		"   This typically indicates server overload or maintenance."
@@ -623,7 +563,7 @@ func (ctx *ErrorContext) buildRTSP503Message() {
 }
 
 // extractDNSError parses DNS resolution error details from FFmpeg output.
-func (ctx *ErrorContext) extractDNSError(output string) {
+func extractDNSError(ctx *audiocore.StreamErrorContext, output string) {
 	// Try to extract hostname from URL.
 	// SECURITY: Use safe extraction to prevent credential leakage.
 	if matches := reErrorOpeningInput.FindStringSubmatch(output); len(matches) == 2 {
@@ -649,7 +589,7 @@ func (ctx *ErrorContext) extractDNSError(output string) {
 	ctx.PrimaryMessage = "DNS resolution failed"
 }
 
-func (ctx *ErrorContext) buildDNSErrorMessage() {
+func buildDNSErrorMessage(ctx *audiocore.StreamErrorContext) {
 	hostInfo := "the hostname"
 	if ctx.TargetHost != "" {
 		hostInfo = fmt.Sprintf("'%s'", ctx.TargetHost)
@@ -685,11 +625,11 @@ func (ctx *ErrorContext) buildDNSErrorMessage() {
 }
 
 // extractInvalidData parses invalid data details from FFmpeg output.
-func (ctx *ErrorContext) extractInvalidData(_ string) {
+func extractInvalidData(ctx *audiocore.StreamErrorContext, _ string) {
 	ctx.PrimaryMessage = "Invalid or corrupted stream data"
 }
 
-func (ctx *ErrorContext) buildInvalidDataMessage() {
+func buildInvalidDataMessage(ctx *audiocore.StreamErrorContext) {
 	ctx.UserFacingMsg = "📺 Invalid or corrupted stream data\n" +
 		"   FFmpeg detected invalid data when processing the stream.\n" +
 		"   The stream may be corrupted or using an unsupported format."
@@ -704,7 +644,7 @@ func (ctx *ErrorContext) buildInvalidDataMessage() {
 }
 
 // buildEOFMessage builds the user-facing message for unexpected stream end.
-func (ctx *ErrorContext) buildEOFMessage() {
+func buildEOFMessage(ctx *audiocore.StreamErrorContext) {
 	ctx.UserFacingMsg = "📡 Stream ended unexpectedly\n" +
 		"   The RTSP stream terminated without proper closure."
 
@@ -717,7 +657,7 @@ func (ctx *ErrorContext) buildEOFMessage() {
 }
 
 // buildProtocolErrorMessage builds the user-facing message for unsupported protocols.
-func (ctx *ErrorContext) buildProtocolErrorMessage() {
+func buildProtocolErrorMessage(ctx *audiocore.StreamErrorContext) {
 	ctx.UserFacingMsg = "🔌 Unsupported protocol\n" +
 		"   FFmpeg does not support the requested protocol.\n" +
 		"   This usually indicates an incorrect URL format."
@@ -727,64 +667,5 @@ func (ctx *ErrorContext) buildProtocolErrorMessage() {
 		"Check if the URL format is correct",
 		"Ensure FFmpeg was compiled with RTSP support",
 		"Try a different transport method (TCP vs UDP)",
-	}
-}
-
-// FormatForConsole returns a formatted string for console output.
-func (ctx *ErrorContext) FormatForConsole() string {
-	var sb strings.Builder
-
-	// User-facing message.
-	sb.WriteString(ctx.UserFacingMsg)
-	sb.WriteString("\n")
-
-	// Troubleshooting steps.
-	if len(ctx.TroubleShooting) > 0 {
-		sb.WriteString("\n   Troubleshooting steps:\n")
-		for _, step := range ctx.TroubleShooting {
-			fmt.Fprintf(&sb, "   • %s\n", step)
-		}
-	}
-
-	return sb.String()
-}
-
-// ShouldOpenCircuit determines if this error should immediately open the circuit breaker.
-// Returns true for permanent failures (404, auth, connection refused, DNS errors, etc.)
-//
-// Network unreachable handling:
-// ENETUNREACH is treated as transient because it often occurs during network transitions
-// (interface coming up, gateway being configured, switching networks). Unlike EHOSTUNREACH
-// (no_route), which indicates a specific routing table problem, ENETUNREACH suggests
-// the entire network is currently unavailable but may recover. We allow retry with
-// exponential backoff via the existing circuit breaker graduated failure thresholds,
-// which will eventually open the circuit if the network remains unreachable.
-func (ctx *ErrorContext) ShouldOpenCircuit() bool {
-	switch ctx.ErrorType {
-	case ErrTypeRTSP404, ErrTypeAuthFailed, ErrTypeAuthForbidden, ErrTypeConnectionRefused,
-		ErrTypeNoRoute, ErrTypeProtocolError, ErrTypeDNSResolutionFailed,
-		ErrTypeOperationNotPermit, ErrTypeSSLError:
-		return true // Permanent failures — require configuration fix.
-	case ErrTypeConnectionTimeout, ErrTypeInvalidData, ErrTypeEOF, ErrTypeNetworkUnreachable, ErrTypeRTSP503:
-		return false // Transient failures — allow retry with backoff.
-	default:
-		return false
-	}
-}
-
-// ShouldRestart determines if this error should trigger an automatic restart.
-// Returns true for transient failures that might recover on retry.
-//
-// Network unreachable is treated as transient with bounded retry:
-//   - Allows restart (returns true) to handle network transitions.
-//   - Circuit breaker's graduated failure thresholds provide bounded retry.
-//   - After circuitBreakerRapidThreshold (5) failures in < 5 seconds, circuit opens.
-//   - This prevents infinite restarts while allowing recovery from brief network issues.
-func (ctx *ErrorContext) ShouldRestart() bool {
-	switch ctx.ErrorType {
-	case ErrTypeConnectionTimeout, ErrTypeInvalidData, ErrTypeEOF, ErrTypeNetworkUnreachable, ErrTypeRTSP503:
-		return true // Transient failures — might recover with bounded retry.
-	default:
-		return false
 	}
 }

--- a/internal/audiocore/ffmpeg/error_context_test.go
+++ b/internal/audiocore/ffmpeg/error_context_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore"
 )
 
 func TestExtractErrorContext_ConnectionTimeout(t *testing.T) {
@@ -96,7 +98,7 @@ func TestExtractErrorContext_EmptyString(t *testing.T) {
 }
 
 func TestFormatForConsole(t *testing.T) {
-	ctx := &ErrorContext{
+	ctx := &audiocore.StreamErrorContext{
 		ErrorType:      "connection_timeout",
 		PrimaryMessage: "Connection timed out",
 		TargetHost:     "192.168.1.1",
@@ -149,7 +151,7 @@ func TestFormatForConsole(t *testing.T) {
 
 // TestFormatForConsole_NoTroubleshooting tests formatting when no troubleshooting steps are provided.
 func TestFormatForConsole_NoTroubleshooting(t *testing.T) {
-	ctx := &ErrorContext{
+	ctx := &audiocore.StreamErrorContext{
 		ErrorType:       "unknown",
 		PrimaryMessage:  "Unknown error",
 		UserFacingMsg:   "An unknown error occurred",
@@ -193,7 +195,7 @@ func TestErrorContext_ShouldOpenCircuit(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			ctx := &ErrorContext{ErrorType: tt.errorType}
+			ctx := &audiocore.StreamErrorContext{ErrorType: tt.errorType}
 			assert.Equal(t, tt.shouldOpen, ctx.ShouldOpenCircuit(), tt.description)
 		})
 	}
@@ -221,7 +223,7 @@ func TestErrorContext_ShouldRestart(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			ctx := &ErrorContext{ErrorType: tt.errorType}
+			ctx := &audiocore.StreamErrorContext{ErrorType: tt.errorType}
 			assert.Equal(t, tt.shouldRestart, ctx.ShouldRestart(), tt.description)
 		})
 	}

--- a/internal/audiocore/ffmpeg/manager.go
+++ b/internal/audiocore/ffmpeg/manager.go
@@ -72,6 +72,10 @@ type Manager struct {
 	lastForceResetMu sync.Mutex
 }
 
+// Manager implements the producer-neutral audiocore.StreamManager seam so the
+// engine can drive it through the interface.
+var _ audiocore.StreamManager = (*Manager)(nil)
+
 // NewManager creates a new Manager.
 //
 // onFrame is invoked for each chunk of audio data received from any managed
@@ -133,19 +137,45 @@ func (m *Manager) SetOnStreamReset(fn func(sourceID string)) {
 	m.onReset = fn
 }
 
-// StartStream starts a new FFmpeg stream using the given config.
-// cfg.SourceID is used as the map key; it must be non-empty and unique.
-// The per-stream onFrame callback is taken from the manager's onFrame field,
-// which is set via the constructor or SetOnFrame.
-func (m *Manager) StartStream(cfg *StreamConfig) error {
-	if cfg == nil {
-		return errors.Newf("StreamConfig must not be nil").
+// streamConfigFromSpec builds the internal StreamConfig for a stream from the
+// protocol-neutral StreamSpec plus the manager-level FFmpeg options (binary
+// path, extra parameters, log level). SilenceTimeout is left unset here and
+// applied by withManagerDefaults.
+func (m *Manager) streamConfigFromSpec(spec *audiocore.StreamSpec) *StreamConfig {
+	return &StreamConfig{
+		URL:                  spec.URL,
+		SourceID:             spec.SourceID,
+		SourceName:           spec.SourceName,
+		Type:                 string(spec.Type),
+		SampleRate:           spec.SampleRate,
+		SourceSampleRate:     spec.SourceSampleRate,
+		BitDepth:             spec.BitDepth,
+		Channels:             spec.Channels,
+		SourceChannels:       spec.SourceChannels,
+		ChannelMode:          spec.ChannelMode,
+		MediaMode:            spec.MediaMode,
+		Transport:            spec.Transport,
+		HealthyDataThreshold: spec.HealthyDataThreshold,
+		Debug:                spec.Debug,
+		FFmpegPath:           m.opts.FFmpegPath,
+		FFmpegParameters:     m.opts.FFmpegParameters,
+		LogLevel:             m.opts.LogLevel,
+	}
+}
+
+// StartStream starts a new FFmpeg stream from the given protocol-neutral spec.
+// spec.SourceID is used as the map key; it must be non-empty and unique. The
+// per-stream onFrame callback is taken from the manager's onFrame field, which
+// is set via the constructor or SetOnFrame.
+func (m *Manager) StartStream(spec *audiocore.StreamSpec) error {
+	if spec == nil {
+		return errors.Newf("StreamSpec must not be nil").
 			Category(errors.CategoryValidation).
 			Component("ffmpeg-manager").
 			Context("operation", "start_stream").
 			Build()
 	}
-	if cfg.SourceID == "" {
+	if spec.SourceID == "" {
 		return errors.Newf("sourceID must not be empty").
 			Category(errors.CategoryValidation).
 			Component("ffmpeg-manager").
@@ -153,6 +183,15 @@ func (m *Manager) StartStream(cfg *StreamConfig) error {
 			Build()
 	}
 
+	// Build the internal StreamConfig from the protocol-neutral spec plus the
+	// manager-level FFmpeg options, then start it.
+	return m.startStreamWithConfig(m.streamConfigFromSpec(spec))
+}
+
+// startStreamWithConfig starts a stream from a fully-built internal StreamConfig.
+// StartStream builds the config from a StreamSpec; the manager's own restart and
+// reconfigure paths reuse an existing stream's config directly.
+func (m *Manager) startStreamWithConfig(cfg *StreamConfig) error {
 	// Apply manager-level defaults (e.g. a shortened silence timeout for tests)
 	// before constructing the stream, without mutating the caller's config.
 	cfg = m.withManagerDefaults(cfg)
@@ -307,7 +346,7 @@ func (m *Manager) ReconfigureStream(sourceID string, cfg *StreamConfig) error {
 			Build()
 	}
 
-	if err := m.StartStream(cfg); err != nil {
+	if err := m.startStreamWithConfig(cfg); err != nil {
 		return errors.New(err).
 			Component("ffmpeg-manager").
 			Context("operation", "reconfigure_stream_start").
@@ -325,7 +364,7 @@ func (m *Manager) ReconfigureStream(sourceID string, cfg *StreamConfig) error {
 }
 
 // StreamHealth returns health information for the stream identified by sourceID.
-func (m *Manager) StreamHealth(sourceID string) (*StreamHealth, error) {
+func (m *Manager) StreamHealth(sourceID string) (*audiocore.StreamHealth, error) {
 	m.mu.RLock()
 	stream, exists := m.streams[sourceID]
 	m.mu.RUnlock()
@@ -344,11 +383,11 @@ func (m *Manager) StreamHealth(sourceID string) (*StreamHealth, error) {
 }
 
 // AllStreamHealth returns health information for all active streams.
-func (m *Manager) AllStreamHealth() map[string]*StreamHealth {
+func (m *Manager) AllStreamHealth() map[string]*audiocore.StreamHealth {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	result := make(map[string]*StreamHealth, len(m.streams))
+	result := make(map[string]*audiocore.StreamHealth, len(m.streams))
 	for id, stream := range m.streams {
 		h := stream.GetHealth()
 		result[id] = &h
@@ -527,7 +566,7 @@ func (m *Manager) checkForStuckStreams() {
 			logger.String("url", privacy.SanitizeStreamUrl(cfgCopy.URL)),
 			logger.Float64("unhealthy_seconds", unhealthyFor.Seconds()),
 			logger.Int("restart_count", h.RestartCount),
-			logger.String("process_state", h.ProcessState.String()),
+			logger.String("process_state", h.ProcessStateName()),
 			logger.String("component", "ffmpeg-manager"),
 			logger.String("operation", "watchdog_force_reset"))
 
@@ -558,7 +597,7 @@ func (m *Manager) checkForStuckStreams() {
 			return
 		}
 
-		if err := m.StartStream(&cfgCopy); err != nil {
+		if err := m.startStreamWithConfig(&cfgCopy); err != nil {
 			m.logger.Error("watchdog: failed to restart stuck stream",
 				logger.String("source_id", id),
 				logger.String("url", privacy.SanitizeStreamUrl(cfgCopy.URL)),

--- a/internal/audiocore/ffmpeg/manager_contract_test.go
+++ b/internal/audiocore/ffmpeg/manager_contract_test.go
@@ -11,25 +11,27 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/audiocore/streamtest"
 	"github.com/tphakala/birdnet-go/internal/testutil/containers"
 )
 
 // ffmpegManagerAdapter adapts *ffmpeg.Manager to the producer-agnostic
-// streamtest.Manager contract, translating the neutral StreamSpec into an
-// ffmpeg.StreamConfig and the ffmpeg health snapshot into streamtest.Health.
+// streamtest.Manager contract, translating the neutral streamtest.StreamSpec
+// into an audiocore.StreamSpec and the neutral health snapshot into
+// streamtest.Health. The FFmpeg binary path and log level are manager-level
+// options passed to NewManagerWithOptions, not per-stream spec fields.
 type ffmpegManagerAdapter struct {
-	mgr        *ffmpeg.Manager
-	ffmpegPath string
+	mgr *ffmpeg.Manager
 }
 
 func (a *ffmpegManagerAdapter) StartStream(spec *streamtest.StreamSpec) error {
-	return a.mgr.StartStream(&ffmpeg.StreamConfig{
+	return a.mgr.StartStream(&audiocore.StreamSpec{
 		URL:                  spec.URL,
 		SourceID:             spec.SourceID,
 		SourceName:           spec.SourceName,
-		Type:                 spec.Type,
+		Type:                 audiocore.SourceType(spec.Type),
 		SampleRate:           spec.SampleRate,
 		SourceSampleRate:     spec.SourceSampleRate,
 		BitDepth:             spec.BitDepth,
@@ -40,8 +42,6 @@ func (a *ffmpegManagerAdapter) StartStream(spec *streamtest.StreamSpec) error {
 		Transport:            spec.Transport,
 		HealthyDataThreshold: spec.HealthyDataThreshold,
 		Debug:                spec.Debug,
-		FFmpegPath:           a.ffmpegPath,
-		LogLevel:             "error",
 	})
 }
 
@@ -74,8 +74,8 @@ func (a *ffmpegManagerAdapter) ShutdownWithContext(ctx context.Context) error {
 	return a.mgr.ShutdownWithContext(ctx)
 }
 
-// ffmpegHealth adapts *ffmpeg.StreamHealth to streamtest.Health.
-type ffmpegHealth struct{ h *ffmpeg.StreamHealth }
+// ffmpegHealth adapts *audiocore.StreamHealth to streamtest.Health.
+type ffmpegHealth struct{ h *audiocore.StreamHealth }
 
 func (f ffmpegHealth) IsHealthy() bool             { return f.h.IsHealthy }
 func (f ffmpegHealth) IsReceivingData() bool       { return f.h.IsReceivingData }
@@ -84,7 +84,7 @@ func (f ffmpegHealth) TotalBytesReceived() int64   { return f.h.TotalBytesReceiv
 func (f ffmpegHealth) BytesPerSecond() float64     { return f.h.BytesPerSecond }
 func (f ffmpegHealth) LastDataReceived() time.Time { return f.h.LastDataReceived }
 func (f ffmpegHealth) SourceChannels() int         { return f.h.SourceChannels }
-func (f ffmpegHealth) ProcessState() string        { return f.h.ProcessState.String() }
+func (f ffmpegHealth) ProcessState() string        { return f.h.ProcessStateName() }
 func (f ffmpegHealth) StateHistoryLen() int        { return len(f.h.StateHistory) }
 
 func (f ffmpegHealth) ErrorType() string {
@@ -133,9 +133,9 @@ func TestFFmpegManagerContract(t *testing.T) {
 			fc.OnReset,
 			nil,
 			fc.BufferManager,
-			ffmpeg.Options{SilenceTimeout: fc.SilenceTimeout},
+			ffmpeg.Options{SilenceTimeout: fc.SilenceTimeout, FFmpegPath: ffmpegPath, LogLevel: "error"},
 		)
-		return &ffmpegManagerAdapter{mgr: mgr, ffmpegPath: ffmpegPath}
+		return &ffmpegManagerAdapter{mgr: mgr}
 	}
 
 	streamtest.RunManagerContract(t, &streamtest.ContractConfig{

--- a/internal/audiocore/ffmpeg/manager_test.go
+++ b/internal/audiocore/ffmpeg/manager_test.go
@@ -9,22 +9,24 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore"
 )
 
-// newTestManagerConfig returns a minimal StreamConfig suitable for manager unit tests.
-// It uses a fake sourceID and URL; no real FFmpeg process is spawned during these tests.
-func newTestManagerConfig(sourceID, url string) *StreamConfig {
-	return &StreamConfig{
+// newTestManagerSpec returns a minimal StreamSpec suitable for manager unit
+// tests. It uses a fake sourceID and URL; no real FFmpeg process is spawned
+// during these tests. The FFmpeg binary path and log level are manager-level
+// Options, not spec fields, and are irrelevant here because no process starts.
+func newTestManagerSpec(sourceID, url string) *audiocore.StreamSpec {
+	return &audiocore.StreamSpec{
 		SourceID:   sourceID,
 		SourceName: "Test Stream " + sourceID,
 		URL:        url,
-		Type:       "rtsp",
+		Type:       audiocore.SourceTypeRTSP,
 		SampleRate: 48000,
 		BitDepth:   16,
 		Channels:   1,
-		FFmpegPath: "/usr/bin/ffmpeg",
 		Transport:  "tcp",
-		LogLevel:   "error",
 	}
 }
 
@@ -42,7 +44,7 @@ func TestManager_StartStopStream(t *testing.T) {
 	mgr := newTestManager(t)
 	t.Cleanup(func() { _ = mgr.Shutdown() })
 
-	cfg := newTestManagerConfig("src-1", "rtsp://test.example.com/stream")
+	cfg := newTestManagerSpec("src-1", "rtsp://test.example.com/stream")
 
 	// Start the stream.
 	require.NoError(t, mgr.StartStream(cfg))
@@ -78,8 +80,8 @@ func TestManager_ReconfigureStream(t *testing.T) {
 	t.Cleanup(func() { _ = mgr.Shutdown() })
 
 	const sourceID = "src-reconfig"
-	originalCfg := newTestManagerConfig(sourceID, "rtsp://original.example.com/stream")
-	updatedCfg := newTestManagerConfig(sourceID, "rtsp://updated.example.com/stream")
+	originalCfg := newTestManagerSpec(sourceID, "rtsp://original.example.com/stream")
+	updatedCfg := newTestManagerSpec(sourceID, "rtsp://updated.example.com/stream")
 	updatedCfg.Transport = "udp"
 
 	// Start with the original config.
@@ -90,7 +92,7 @@ func TestManager_ReconfigureStream(t *testing.T) {
 	require.Contains(t, ids, sourceID)
 
 	// Reconfigure to the new config.
-	require.NoError(t, mgr.ReconfigureStream(sourceID, updatedCfg))
+	require.NoError(t, mgr.ReconfigureStream(sourceID, mgr.streamConfigFromSpec(updatedCfg)))
 
 	// Stream must still be tracked under the same sourceID.
 	ids = mgr.GetActiveStreamIDs()
@@ -123,7 +125,7 @@ func TestManager_AllStreamHealth(t *testing.T) {
 	}
 
 	for _, s := range sources {
-		require.NoError(t, mgr.StartStream(newTestManagerConfig(s.id, s.url)))
+		require.NoError(t, mgr.StartStream(newTestManagerSpec(s.id, s.url)))
 	}
 
 	health := mgr.AllStreamHealth()
@@ -156,7 +158,7 @@ func TestManager_Shutdown(t *testing.T) {
 	sources := []string{"shutdown-1", "shutdown-2", "shutdown-3"}
 	for _, id := range sources {
 		require.NoError(t, mgr.StartStream(
-			newTestManagerConfig(id, "rtsp://"+id+".example.com/stream")))
+			newTestManagerSpec(id, "rtsp://"+id+".example.com/stream")))
 	}
 
 	// All streams should be tracked before shutdown.
@@ -181,7 +183,7 @@ func TestManager_ShutdownWithContext(t *testing.T) {
 	t.Run("completes within deadline", func(t *testing.T) {
 		mgr := newTestManager(t)
 		require.NoError(t, mgr.StartStream(
-			newTestManagerConfig("ctx-1", "rtsp://ctx.example.com/stream")))
+			newTestManagerSpec("ctx-1", "rtsp://ctx.example.com/stream")))
 
 		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
@@ -219,7 +221,7 @@ func TestManager_SetOnStreamReset(t *testing.T) {
 	})
 
 	require.NoError(t, mgr.StartStream(
-		newTestManagerConfig("reset-src", "rtsp://reset.example.com/stream")))
+		newTestManagerSpec("reset-src", "rtsp://reset.example.com/stream")))
 
 	// The callback must have been invoked with the correct sourceID.
 	stored := calledWith.Load()
@@ -239,8 +241,8 @@ func TestManager_ReconfigureStream_SourceIDMismatch(t *testing.T) {
 	mgr := newTestManager(t)
 	t.Cleanup(func() { _ = mgr.Shutdown() })
 
-	cfg := newTestManagerConfig("id-A", "rtsp://a.example.com/stream")
-	err := mgr.ReconfigureStream("id-B", cfg)
+	cfg := newTestManagerSpec("id-A", "rtsp://a.example.com/stream")
+	err := mgr.ReconfigureStream("id-B", mgr.streamConfigFromSpec(cfg))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "sourceID mismatch")
 }
@@ -264,7 +266,7 @@ func TestManager_WatchdogForceReset(t *testing.T) {
 
 		const sourceID = "stuck-stream"
 		require.NoError(t, mgr.StartStream(
-			newTestManagerConfig(sourceID, "rtsp://stuck.example.com/stream")))
+			newTestManagerSpec(sourceID, "rtsp://stuck.example.com/stream")))
 
 		// Advance the stream creation time so the watchdog considers it stuck.
 		mgr.mu.Lock()
@@ -307,7 +309,7 @@ func TestManager_StartStream_EmptySourceID(t *testing.T) {
 	mgr := newTestManager(t)
 	t.Cleanup(func() { _ = mgr.Shutdown() })
 
-	cfg := newTestManagerConfig("", "rtsp://empty.example.com/stream")
+	cfg := newTestManagerSpec("", "rtsp://empty.example.com/stream")
 	err := mgr.StartStream(cfg)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "sourceID must not be empty")
@@ -332,7 +334,7 @@ func TestManager_RestartStreamResetsBackoff(t *testing.T) {
 	// Stream.Restart(true) resets the backoff counters) and makes it
 	// deterministic on every platform. Shutdown still stops the stream safely.
 	stream := NewStream(
-		newTestManagerConfig(sourceID, "rtsp://restart.example.com/stream"),
+		mgr.streamConfigFromSpec(newTestManagerSpec(sourceID, "rtsp://restart.example.com/stream")),
 		nil, nil, nil, nil)
 	mgr.mu.Lock()
 	mgr.streams[sourceID] = stream

--- a/internal/audiocore/ffmpeg/options.go
+++ b/internal/audiocore/ffmpeg/options.go
@@ -7,11 +7,12 @@ import "time"
 // reproduces the manager's historic behaviour, so the plain NewManager
 // constructor (which passes a zero Options) is unaffected.
 //
-// The only knob today is SilenceTimeout, which exists so characterization tests
-// can drive the silence watchdog in seconds instead of the production 90 s
-// without mutating the package-level silenceTimeout constant. Later phases fold
-// the remaining per-manager settings (FFmpeg binary path, extra FFmpeg
-// parameters, log level) into this struct as well.
+// SilenceTimeout exists so characterization tests can drive the silence
+// watchdog in seconds instead of the production 90 s without mutating the
+// package-level silenceTimeout constant. FFmpegPath, FFmpegParameters, and
+// LogLevel are the manager-level FFmpeg settings the engine used to set on every
+// StreamConfig; folding them here lets the engine hand StartStream a
+// protocol-neutral audiocore.StreamSpec that carries none of them.
 type Options struct {
 	// SilenceTimeout overrides the per-stream silence watchdog timeout for every
 	// stream started through this manager, unless a stream's own
@@ -24,6 +25,18 @@ type Options struct {
 	// future phase that wires a non-90s value into a PRODUCTION path must update
 	// that suppression signature to a prefix match or keep the two in sync.
 	SilenceTimeout time.Duration
+
+	// FFmpegPath is the absolute path to the FFmpeg binary applied to every stream
+	// this manager starts.
+	FFmpegPath string
+
+	// FFmpegParameters are additional FFmpeg command-line parameters applied to
+	// every stream this manager starts.
+	FFmpegParameters []string
+
+	// LogLevel is the FFmpeg log level (e.g. "error") applied to every stream this
+	// manager starts.
+	LogLevel string
 }
 
 // withManagerDefaults returns cfg with manager-level defaults applied where the

--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -36,10 +36,6 @@ const (
 	silenceTimeout       = 90 * time.Second
 	silenceCheckInterval = 10 * time.Second
 
-	// Data rate calculation settings.
-	dataRateWindowSize = 10 * time.Second
-	dataRateMaxSamples = 100
-
 	// Process management timeouts.
 	processCleanupTimeout = 5 * time.Second
 	processQuickExitTime  = 5 * time.Second
@@ -107,6 +103,9 @@ const (
 
 	// Maximum number of state transitions to keep in history.
 	maxStateHistory = 100
+	// maxStateHistoryExposed caps how many recent state transitions the health
+	// snapshot surfaces to the API.
+	maxStateHistoryExposed = 10
 )
 
 // getStreamLogger returns the logger for FFmpeg stream operations.
@@ -168,8 +167,11 @@ func (s ProcessState) String() string {
 	}
 }
 
-// StateTransition records a transition between process states for debugging.
-type StateTransition struct {
+// ProcessStateTransition records a transition between FFmpeg process states for
+// the stream's internal state machine and debug history. It is distinct from
+// audiocore.StateTransition, the producer-neutral transition the health snapshot
+// exposes; GetHealth maps each of these onto that neutral type.
+type ProcessStateTransition struct {
 	From      ProcessState
 	To        ProcessState
 	Timestamp time.Time
@@ -325,102 +327,6 @@ func (c *StreamConfig) effectiveSilenceTimeout() time.Duration {
 		return c.SilenceTimeout
 	}
 	return silenceTimeout
-}
-
-// StreamHealth represents the health status of an FFmpeg stream.
-type StreamHealth struct {
-	IsHealthy          bool
-	LastDataReceived   time.Time
-	RestartCount       int
-	Error              error
-	TotalBytesReceived int64
-	BytesPerSecond     float64
-	IsReceivingData    bool
-	ProcessState       ProcessState
-	StateHistory       []StateTransition
-	LastErrorContext   *ErrorContext
-	ErrorHistory       []*ErrorContext
-	SourceChannels     int
-}
-
-// dataRateCalculator tracks data rate over a sliding window.
-type dataRateCalculator struct {
-	samples    []dataSample
-	samplesMu  sync.RWMutex
-	windowSize time.Duration
-	maxSamples int
-}
-
-type dataSample struct {
-	timestamp time.Time
-	bytes     int64
-}
-
-// newDataRateCalculator creates a new data rate calculator.
-func newDataRateCalculator(windowSize time.Duration) *dataRateCalculator {
-	return &dataRateCalculator{
-		samples:    make([]dataSample, 0, dataRateMaxSamples),
-		windowSize: windowSize,
-		maxSamples: dataRateMaxSamples,
-	}
-}
-
-// addSample adds a new data sample.
-func (d *dataRateCalculator) addSample(numBytes int64) {
-	d.samplesMu.Lock()
-	defer d.samplesMu.Unlock()
-
-	now := time.Now()
-	d.samples = append(d.samples, dataSample{
-		timestamp: now,
-		bytes:     numBytes,
-	})
-
-	// Remove old samples outside the window.
-	cutoff := now.Add(-d.windowSize)
-	i := 0
-	for i < len(d.samples) && d.samples[i].timestamp.Before(cutoff) {
-		i++
-	}
-	if i > 0 {
-		d.samples = d.samples[i:]
-	}
-
-	// Limit max samples.
-	if len(d.samples) > d.maxSamples {
-		d.samples = d.samples[len(d.samples)-d.maxSamples:]
-	}
-}
-
-// getRate returns the current data rate in bytes per second.
-func (d *dataRateCalculator) getRate() float64 {
-	d.samplesMu.RLock()
-	defer d.samplesMu.RUnlock()
-
-	if len(d.samples) == 0 {
-		return 0
-	}
-
-	if len(d.samples) == 1 {
-		sample := d.samples[0]
-		timeSinceSample := time.Since(sample.timestamp)
-		if timeSinceSample < 5*time.Second {
-			return float64(sample.bytes)
-		}
-		return 0
-	}
-
-	totalBytes := int64(0)
-	for _, s := range d.samples {
-		totalBytes += s.bytes
-	}
-
-	duration := d.samples[len(d.samples)-1].timestamp.Sub(d.samples[0].timestamp).Seconds()
-	if duration <= 0 {
-		return 0
-	}
-
-	return float64(totalBytes) / duration
 }
 
 // secondsSinceOrZero returns seconds since t, or 0 if t is zero.
@@ -628,7 +534,7 @@ type Stream struct {
 	// Data tracking.
 	totalBytesReceived int64
 	bytesReceivedMu    sync.RWMutex
-	dataRateCalc       *dataRateCalculator
+	dataRateCalc       *audiocore.DataRateMeter
 
 	// Process timing.
 	processStartTime time.Time
@@ -671,11 +577,11 @@ type Stream struct {
 	// Process state tracking.
 	processState     ProcessState
 	processStateMu   sync.RWMutex
-	stateTransitions []StateTransition
+	stateTransitions []ProcessStateTransition
 	transitionsMu    sync.Mutex
 
 	// FFmpeg error tracking for diagnostics.
-	errorContexts   []*ErrorContext
+	errorContexts   []*audiocore.StreamErrorContext
 	errorContextsMu sync.RWMutex
 	maxErrorHistory int
 
@@ -707,12 +613,12 @@ func NewStream(cfg *StreamConfig, onFrame func(frame audiocore.AudioFrame), onRe
 		backoffDuration:  defaultBackoffDuration,
 		maxBackoff:       maxBackoffDuration,
 		lastDataTime:     time.Time{},
-		dataRateCalc:     newDataRateCalculator(dataRateWindowSize),
+		dataRateCalc:     audiocore.NewDataRateMeter(audiocore.DataRateWindowSize),
 		lastDropLogTime:  time.Now(),
 		streamCreatedAt:  time.Now(),
 		processState:     StateIdle,
-		stateTransitions: make([]StateTransition, 0, maxStateHistory),
-		errorContexts:    make([]*ErrorContext, 0, maxErrorHistorySize),
+		stateTransitions: make([]ProcessStateTransition, 0, maxStateHistory),
+		errorContexts:    make([]*audiocore.StreamErrorContext, 0, maxErrorHistorySize),
 		maxErrorHistory:  maxErrorHistorySize,
 		bufMgr:           bufMgr,
 	}
@@ -767,7 +673,7 @@ func (s *Stream) transitionState(to ProcessState, reason string) {
 	s.processState = to
 	s.processStateMu.Unlock()
 
-	transition := StateTransition{
+	transition := ProcessStateTransition{
 		From:      from,
 		To:        to,
 		Timestamp: time.Now(),
@@ -799,7 +705,7 @@ func (s *Stream) GetProcessState() ProcessState {
 }
 
 // GetStateHistory returns recent state transitions for debugging (thread-safe).
-func (s *Stream) GetStateHistory() []StateTransition {
+func (s *Stream) GetStateHistory() []ProcessStateTransition {
 	s.transitionsMu.Lock()
 	defer s.transitionsMu.Unlock()
 	return slices.Clone(s.stateTransitions)
@@ -1433,7 +1339,7 @@ func (s *Stream) dispatchAudioData(data []byte, ref *audiocore.FrameRef) {
 	totalReceived := s.totalBytesReceived
 	s.bytesReceivedMu.Unlock()
 
-	s.dataRateCalc.addSample(int64(n))
+	s.dataRateCalc.AddSample(int64(n))
 
 	s.conditionalFailureReset(totalReceived)
 
@@ -1457,7 +1363,7 @@ func (s *Stream) dispatchAudioData(data []byte, ref *audiocore.FrameRef) {
 
 	// Update metrics if available.
 	if s.metrics != nil {
-		s.metrics.RecordDataRate(s.config.SourceID, s.dataRateCalc.getRate())
+		s.metrics.RecordDataRate(s.config.SourceID, s.dataRateCalc.Rate())
 	}
 }
 
@@ -1903,7 +1809,7 @@ func (s *Stream) GetProcessStartTime() time.Time {
 }
 
 // GetHealth returns the current health status of the stream.
-func (s *Stream) GetHealth() StreamHealth {
+func (s *Stream) GetHealth() audiocore.StreamHealth {
 	s.lastDataMu.RLock()
 	lastData := s.lastDataTime
 	s.lastDataMu.RUnlock()
@@ -1916,7 +1822,7 @@ func (s *Stream) GetHealth() StreamHealth {
 	totalBytes := s.totalBytesReceived
 	s.bytesReceivedMu.RUnlock()
 
-	dataRate := s.dataRateCalc.getRate()
+	dataRate := s.dataRateCalc.Rate()
 
 	healthyDataThreshold := s.config.healthyThreshold()
 	const maxHealthyDataThreshold = 30 * time.Minute
@@ -1950,15 +1856,36 @@ func (s *Stream) GetHealth() StreamHealth {
 	}
 
 	allHistory := s.GetStateHistory()
-	var recentHistory []StateTransition
-	if len(allHistory) > 10 {
-		recentHistory = allHistory[len(allHistory)-10:]
+	var recentHistory []ProcessStateTransition
+	if len(allHistory) > maxStateHistoryExposed {
+		recentHistory = allHistory[len(allHistory)-maxStateHistoryExposed:]
 	} else {
 		recentHistory = allHistory
 	}
+	// Map the FFmpeg process transitions onto the neutral health type, carrying
+	// each process-state name in FromDetail/ToDetail so the legacy process_state
+	// history stays byte-identical.
+	stateHistory := make([]audiocore.StateTransition, 0, len(recentHistory))
+	for _, t := range recentHistory {
+		stateHistory = append(stateHistory, audiocore.StateTransition{
+			From:       processStateToStreamState(t.From),
+			To:         processStateToStreamState(t.To),
+			FromDetail: t.From.String(),
+			ToDetail:   t.To.String(),
+			Timestamp:  t.Timestamp,
+			Reason:     t.Reason,
+		})
+	}
+
+	// StateEntered is the timestamp of the most recent transition into the
+	// current state; it stays zero until the first transition is recorded.
+	var stateEntered time.Time
+	if n := len(allHistory); n > 0 {
+		stateEntered = allHistory[n-1].Timestamp
+	}
 
 	allErrors := s.getErrorContexts()
-	var recentErrors []*ErrorContext
+	var recentErrors []*audiocore.StreamErrorContext
 	if len(allErrors) > maxErrorHistoryExposed {
 		recentErrors = allErrors[len(allErrors)-maxErrorHistoryExposed:]
 	} else {
@@ -1967,18 +1894,41 @@ func (s *Stream) GetHealth() StreamHealth {
 
 	lastError := s.getLastErrorContext()
 
-	return StreamHealth{
+	return audiocore.StreamHealth{
+		State:              processStateToStreamState(state),
+		StateDetail:        state.String(),
+		StateEntered:       stateEntered,
+		Recovery:           audiocore.RecoveryUnknown,
 		IsHealthy:          isHealthy,
 		LastDataReceived:   lastData,
 		RestartCount:       restarts,
 		TotalBytesReceived: totalBytes,
 		BytesPerSecond:     dataRate,
 		IsReceivingData:    isReceivingData,
-		ProcessState:       state,
-		StateHistory:       recentHistory,
+		StateHistory:       stateHistory,
 		LastErrorContext:   lastError,
 		ErrorHistory:       recentErrors,
 		SourceChannels:     s.config.SourceChannels,
+	}
+}
+
+// processStateToStreamState maps an FFmpeg process state onto the neutral
+// audiocore.StreamState. The FFmpeg process name is carried separately in
+// StreamHealth.StateDetail (and in StateTransition detail fields) so the legacy
+// process_state API strings remain byte-identical. FFmpeg never reports a
+// terminal failure state, so StreamStateFailed is unmapped here.
+func processStateToStreamState(state ProcessState) audiocore.StreamState {
+	switch state {
+	case StateIdle, StateStarting:
+		return audiocore.StreamStateStarting
+	case StateRunning:
+		return audiocore.StreamStateConnected
+	case StateRestarting, StateBackoff, StateCircuitOpen:
+		return audiocore.StreamStateReconnecting
+	case StateStopped:
+		return audiocore.StreamStateStopped
+	default:
+		return audiocore.StreamStateStarting
 	}
 }
 
@@ -2315,7 +2265,7 @@ func detectUserTimeout(params []string) (found bool, value string) {
 }
 
 // recordErrorContext stores an error context in the history buffer.
-func (s *Stream) recordErrorContext(ctx *ErrorContext) {
+func (s *Stream) recordErrorContext(ctx *audiocore.StreamErrorContext) {
 	if ctx == nil {
 		return
 	}
@@ -2375,17 +2325,17 @@ func (s *Stream) recordErrorContext(ctx *ErrorContext) {
 }
 
 // getErrorContexts returns a copy of the error history.
-func (s *Stream) getErrorContexts() []*ErrorContext {
+func (s *Stream) getErrorContexts() []*audiocore.StreamErrorContext {
 	s.errorContextsMu.RLock()
 	defer s.errorContextsMu.RUnlock()
 
-	result := make([]*ErrorContext, len(s.errorContexts))
+	result := make([]*audiocore.StreamErrorContext, len(s.errorContexts))
 	copy(result, s.errorContexts)
 	return result
 }
 
 // getLastErrorContext returns the most recent error context, or nil if no errors.
-func (s *Stream) getLastErrorContext() *ErrorContext {
+func (s *Stream) getLastErrorContext() *audiocore.StreamErrorContext {
 	s.errorContextsMu.RLock()
 	defer s.errorContextsMu.RUnlock()
 
@@ -2396,7 +2346,7 @@ func (s *Stream) getLastErrorContext() *ErrorContext {
 }
 
 // checkEarlyErrors checks FFmpeg stderr for errors during the early detection window.
-func (s *Stream) checkEarlyErrors() *ErrorContext {
+func (s *Stream) checkEarlyErrors() *audiocore.StreamErrorContext {
 	s.stderrMu.RLock()
 	stderrOutput := s.stderr.String()
 	s.stderrMu.RUnlock()

--- a/internal/audiocore/ffmpeg/stream_manager_test.go
+++ b/internal/audiocore/ffmpeg/stream_manager_test.go
@@ -1,0 +1,57 @@
+package ffmpeg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+)
+
+// TestStreamManager_FFmpegConformance asserts that *Manager satisfies the
+// producer-neutral audiocore.StreamManager seam the engine drives it through.
+// The compile-time guard lives in manager.go; this exercises the assignment at
+// runtime so the conformance is covered by the test suite too.
+func TestStreamManager_FFmpegConformance(t *testing.T) {
+	var mgr audiocore.StreamManager = NewManager(t.Context(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = mgr.Shutdown() })
+	require.NotNil(t, mgr)
+	assert.Empty(t, mgr.GetActiveStreamIDs())
+}
+
+// TestProcessStateToStreamState verifies that every FFmpeg process state maps to
+// the intended neutral StreamState and that the process name round-trips through
+// StateDetail so the legacy process_state string stays byte-identical.
+func TestProcessStateToStreamState(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		ps          ProcessState
+		wantState   audiocore.StreamState
+		wantProcess string // legacy process_state string carried in StateDetail
+	}{
+		{"idle", StateIdle, audiocore.StreamStateStarting, ProcessStateIdle},
+		{"starting", StateStarting, audiocore.StreamStateStarting, ProcessStateStarting},
+		{"running", StateRunning, audiocore.StreamStateConnected, ProcessStateRunning},
+		{"restarting", StateRestarting, audiocore.StreamStateReconnecting, ProcessStateRestarting},
+		{"backoff", StateBackoff, audiocore.StreamStateReconnecting, ProcessStateBackoff},
+		{"circuit_open", StateCircuitOpen, audiocore.StreamStateReconnecting, ProcessStateCircuitOpen},
+		{"stopped", StateStopped, audiocore.StreamStateStopped, ProcessStateStopped},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.wantState, processStateToStreamState(tt.ps), "neutral state mapping")
+			assert.Equal(t, tt.wantProcess, tt.ps.String(), "process name is preserved")
+
+			// A health snapshot built the way GetHealth builds it must report the
+			// original process name through the legacy process_state field.
+			h := audiocore.StreamHealth{
+				State:       processStateToStreamState(tt.ps),
+				StateDetail: tt.ps.String(),
+			}
+			assert.Equal(t, tt.wantProcess, h.ProcessStateName(), "legacy process_state round-trip")
+		})
+	}
+}

--- a/internal/audiocore/ffmpeg/stream_test.go
+++ b/internal/audiocore/ffmpeg/stream_test.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
-	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -464,44 +463,6 @@ func TestStream_CircuitBreakerCooldown(t *testing.T) {
 
 	// Failures should be reset.
 	assert.Equal(t, 0, stream.getConsecutiveFailures())
-}
-
-func TestStream_DataRateCalculation(t *testing.T) {
-	// getRate divides total bytes by the time span between the first and last
-	// sample, returning 0 when that span is zero (div-by-zero guard). On
-	// coarse-timer platforms (Windows, ~15ms resolution) three back-to-back
-	// addSample calls can share a timestamp, making the span zero and the rate
-	// zero. Use synctest's fake clock advanced by time.Sleep so the samples get
-	// distinct timestamps deterministically on every platform.
-	synctest.Test(t, func(t *testing.T) {
-		calc := newDataRateCalculator(dataRateWindowSize)
-
-		calc.addSample(1024)
-		time.Sleep(time.Millisecond)
-		calc.addSample(2048)
-		time.Sleep(time.Millisecond)
-		calc.addSample(1536)
-
-		rate := calc.getRate()
-		assert.Greater(t, rate, 0.0)
-	})
-}
-
-func TestStream_DataRateCalculator_EmptyRate(t *testing.T) {
-	t.Parallel()
-
-	calc := newDataRateCalculator(dataRateWindowSize)
-	assert.InDelta(t, 0.0, calc.getRate(), 0.001)
-}
-
-func TestStream_DataRateCalculator_SingleSampleRate(t *testing.T) {
-	t.Parallel()
-
-	calc := newDataRateCalculator(dataRateWindowSize)
-	calc.addSample(1024)
-
-	rate := calc.getRate()
-	assert.InDelta(t, 1024.0, rate, 0.01, "Single recent sample should return instantaneous rate")
 }
 
 func TestStream_HealthTracking(t *testing.T) {
@@ -1239,8 +1200,8 @@ func TestStream_ErrorContextTracking(t *testing.T) {
 	assert.Nil(t, stream.getLastErrorContext())
 	assert.Empty(t, stream.getErrorContexts())
 
-	ctx1 := &ErrorContext{ErrorType: ErrTypeConnectionTimeout, PrimaryMessage: "test1"}
-	ctx2 := &ErrorContext{ErrorType: ErrTypeConnectionRefused, PrimaryMessage: "test2"}
+	ctx1 := &audiocore.StreamErrorContext{ErrorType: audiocore.ErrTypeConnectionTimeout, PrimaryMessage: "test1"}
+	ctx2 := &audiocore.StreamErrorContext{ErrorType: audiocore.ErrTypeConnectionRefused, PrimaryMessage: "test2"}
 
 	stream.recordErrorContext(ctx1)
 	assert.Equal(t, ctx1, stream.getLastErrorContext())

--- a/internal/audiocore/stream_health.go
+++ b/internal/audiocore/stream_health.go
@@ -1,0 +1,431 @@
+package audiocore
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+// StreamState is the connection-oriented lifecycle of a network stream,
+// independent of how the producer implements it. It replaces the FFmpeg
+// process vocabulary (idle, starting, running, restarting, backoff,
+// circuit_open, stopped) at the neutral seam: a producer maps its own
+// sub-states onto these and carries the sub-state name in
+// StreamHealth.StateDetail for the legacy process_state API field.
+type StreamState int
+
+const (
+	// StreamStateStarting means the first connect is in flight.
+	StreamStateStarting StreamState = iota
+	// StreamStateConnected means a session is live and may deliver audio.
+	StreamStateConnected
+	// StreamStateReconnecting means a session ended and the producer is retrying
+	// or waiting out backoff.
+	StreamStateReconnecting
+	// StreamStateStopped means the stream was stopped on request (StopStream,
+	// quiet hours, shutdown).
+	StreamStateStopped
+	// StreamStateFailed means the producer gave up on a terminal, non-retryable
+	// cause.
+	StreamStateFailed
+)
+
+// Neutral StreamState names. Distinct from the legacy process_state strings
+// (see LegacyProcessName): "connected" and "reconnecting" have no legacy
+// equivalent because the legacy vocabulary was process-oriented.
+const (
+	streamStateNameStarting     = "starting"
+	streamStateNameConnected    = "connected"
+	streamStateNameReconnecting = "reconnecting"
+	streamStateNameStopped      = "stopped"
+	streamStateNameFailed       = "failed"
+)
+
+// String returns the neutral connection-state name.
+func (s StreamState) String() string {
+	switch s {
+	case StreamStateStarting:
+		return streamStateNameStarting
+	case StreamStateConnected:
+		return streamStateNameConnected
+	case StreamStateReconnecting:
+		return streamStateNameReconnecting
+	case StreamStateStopped:
+		return streamStateNameStopped
+	case StreamStateFailed:
+		return streamStateNameFailed
+	default:
+		return fmt.Sprintf("unknown(%d)", int(s))
+	}
+}
+
+// Legacy process_state strings the health API emits so the existing frontend,
+// which switches on these literals, keeps working. A producer that does not
+// set StreamHealth.StateDetail falls back to this fixed mapping.
+const (
+	legacyProcessStateStarting   = "starting"
+	legacyProcessStateRunning    = "running"
+	legacyProcessStateRestarting = "restarting"
+	legacyProcessStateStopped    = "stopped"
+	legacyProcessStateFailed     = "failed"
+)
+
+// LegacyProcessName returns the legacy process_state string this state maps to
+// when a producer supplies no finer-grained StateDetail. Connected maps to the
+// historical "running" and Reconnecting to "restarting"; the FFmpeg producer
+// always sets StateDetail, so this fallback only serves producers that report
+// the neutral state alone.
+func (s StreamState) LegacyProcessName() string {
+	switch s {
+	case StreamStateStarting:
+		return legacyProcessStateStarting
+	case StreamStateConnected:
+		return legacyProcessStateRunning
+	case StreamStateReconnecting:
+		return legacyProcessStateRestarting
+	case StreamStateStopped:
+		return legacyProcessStateStopped
+	case StreamStateFailed:
+		return legacyProcessStateFailed
+	default:
+		return s.String()
+	}
+}
+
+// RecoveryState is what the liveness watchdog asks a producer before it decides
+// to tear a silent source down. Phase 1 producers report RecoveryUnknown; the
+// watchdog coordination that consumes the other values arrives in Phase 2.
+type RecoveryState int
+
+const (
+	// RecoveryUnknown means the producer does not report recovery intent, so the
+	// legacy watchdog behaviour applies.
+	RecoveryUnknown RecoveryState = iota
+	// RecoveryIdle means the stream is connected and any silence is a media stall
+	// the watchdog owns.
+	RecoveryIdle
+	// RecoveryInProgress means the producer is reconnecting and the watchdog
+	// should defer.
+	RecoveryInProgress
+	// RecoveryGivenUp means the producer failed terminally and the watchdog should
+	// escalate now.
+	RecoveryGivenUp
+)
+
+// Recovery state names for logs and diagnostics.
+const (
+	recoveryNameUnknown    = "unknown"
+	recoveryNameIdle       = "idle"
+	recoveryNameInProgress = "in_progress"
+	recoveryNameGivenUp    = "given_up"
+)
+
+// String returns a human-readable name for the recovery state.
+func (r RecoveryState) String() string {
+	switch r {
+	case RecoveryUnknown:
+		return recoveryNameUnknown
+	case RecoveryIdle:
+		return recoveryNameIdle
+	case RecoveryInProgress:
+		return recoveryNameInProgress
+	case RecoveryGivenUp:
+		return recoveryNameGivenUp
+	default:
+		return fmt.Sprintf("unknown(%d)", int(r))
+	}
+}
+
+// Stream error type constants categorise a failure for retry and circuit
+// breaker decisions and for the user-facing health API. They are the neutral
+// vocabulary both the FFmpeg stderr classifier and the future native typed-error
+// mapper populate.
+//
+// Transient errors (may recover on retry):
+//   - ErrTypeConnectionTimeout - host unreachable or slow network
+//   - ErrTypeNetworkUnreachable - network transition, interface coming up
+//   - ErrTypeRTSP503 - server overloaded, may recover
+//   - ErrTypeInvalidData - stream corruption, may be temporary
+//   - ErrTypeEOF - stream ended unexpectedly, may restart
+//
+// Permanent errors (require configuration fix, no retry):
+//   - ErrTypeRTSP404 - stream path does not exist
+//   - ErrTypeConnectionRefused - no server listening on port
+//   - ErrTypeAuthFailed - invalid credentials (401)
+//   - ErrTypeAuthForbidden - insufficient permissions (403)
+//   - ErrTypeNoRoute - routing table problem for specific host
+//   - ErrTypeOperationNotPermit - firewall/SELinux blocking
+//   - ErrTypeSSLError - certificate or TLS configuration issue
+//   - ErrTypeDNSResolutionFailed - hostname does not resolve
+//   - ErrTypeProtocolError - unsupported protocol in URL
+//
+// See ShouldOpenCircuit and ShouldRestart for how these drive circuit breaker
+// and restart behaviour.
+const (
+	ErrTypeConnectionTimeout   = "connection_timeout"
+	ErrTypeNetworkUnreachable  = "network_unreachable"
+	ErrTypeRTSP503             = "rtsp_503"
+	ErrTypeInvalidData         = "invalid_data"
+	ErrTypeEOF                 = "eof"
+	ErrTypeRTSP404             = "rtsp_404"
+	ErrTypeConnectionRefused   = "connection_refused"
+	ErrTypeAuthFailed          = "auth_failed"
+	ErrTypeAuthForbidden       = "auth_forbidden"
+	ErrTypeNoRoute             = "no_route"
+	ErrTypeOperationNotPermit  = "operation_not_permitted"
+	ErrTypeSSLError            = "ssl_error"
+	ErrTypeDNSResolutionFailed = "dns_resolution_failed"
+	ErrTypeProtocolError       = "protocol_error"
+)
+
+// StreamErrorContext contains rich, producer-neutral diagnostics extracted from
+// a failed stream connection. The FFmpeg stderr classifier and the native
+// typed-error mapper both populate it; the health API renders it. Field set is
+// unchanged from the historical ffmpeg.ErrorContext (the classifier moved with
+// the struct).
+type StreamErrorContext struct {
+	ErrorType       string        // "connection_timeout", "rtsp_404", "auth_failed", etc.
+	PrimaryMessage  string        // Main error message
+	TargetHost      string        // Extracted host/IP (sanitized - no credentials)
+	TargetPort      int           // Extracted port
+	TimeoutDuration time.Duration // Extracted timeout (if applicable)
+	HTTPStatus      int           // HTTP/RTSP status code (if applicable)
+	RTSPMethod      string        // RTSP method that failed (if applicable)
+	// RawFFmpegOutput stores the sanitized producer stderr/log output for
+	// debugging. SECURITY: this field is sanitized by the producer (for FFmpeg,
+	// privacy.SanitizeFFmpegError) to remove credentials from stream URLs. The
+	// json:"-" tag prevents accidental credential leakage via JSON marshaling.
+	RawFFmpegOutput string    `json:"-"` // Full producer output for debugging (sanitized)
+	UserFacingMsg   string    // Friendly message for user
+	TroubleShooting []string  // List of troubleshooting steps
+	Timestamp       time.Time // When this error was detected
+}
+
+// FormatForConsole renders the user-facing message plus troubleshooting steps
+// for console/log output.
+func (ctx *StreamErrorContext) FormatForConsole() string {
+	var sb strings.Builder
+
+	// User-facing message.
+	sb.WriteString(ctx.UserFacingMsg)
+	sb.WriteString("\n")
+
+	// Troubleshooting steps.
+	if len(ctx.TroubleShooting) > 0 {
+		sb.WriteString("\n   Troubleshooting steps:\n")
+		for _, step := range ctx.TroubleShooting {
+			fmt.Fprintf(&sb, "   • %s\n", step)
+		}
+	}
+
+	return sb.String()
+}
+
+// ShouldOpenCircuit determines if this error should immediately open the circuit breaker.
+// Returns true for permanent failures (404, auth, connection refused, DNS errors, etc.)
+//
+// Network unreachable handling:
+// ENETUNREACH is treated as transient because it often occurs during network transitions
+// (interface coming up, gateway being configured, switching networks). Unlike EHOSTUNREACH
+// (no_route), which indicates a specific routing table problem, ENETUNREACH suggests
+// the entire network is currently unavailable but may recover. We allow retry with
+// exponential backoff via the existing circuit breaker graduated failure thresholds,
+// which will eventually open the circuit if the network remains unreachable.
+func (ctx *StreamErrorContext) ShouldOpenCircuit() bool {
+	switch ctx.ErrorType {
+	case ErrTypeRTSP404, ErrTypeAuthFailed, ErrTypeAuthForbidden, ErrTypeConnectionRefused,
+		ErrTypeNoRoute, ErrTypeProtocolError, ErrTypeDNSResolutionFailed,
+		ErrTypeOperationNotPermit, ErrTypeSSLError:
+		return true // Permanent failures - require configuration fix.
+	case ErrTypeConnectionTimeout, ErrTypeInvalidData, ErrTypeEOF, ErrTypeNetworkUnreachable, ErrTypeRTSP503:
+		return false // Transient failures - allow retry with backoff.
+	default:
+		return false
+	}
+}
+
+// ShouldRestart determines if this error should trigger an automatic restart.
+// Returns true for transient failures that might recover on retry.
+//
+// Network unreachable is treated as transient with bounded retry:
+//   - Allows restart (returns true) to handle network transitions.
+//   - Circuit breaker's graduated failure thresholds provide bounded retry.
+//   - After circuitBreakerRapidThreshold (5) failures in < 5 seconds, circuit opens.
+//   - This prevents infinite restarts while allowing recovery from brief network issues.
+func (ctx *StreamErrorContext) ShouldRestart() bool {
+	switch ctx.ErrorType {
+	case ErrTypeConnectionTimeout, ErrTypeInvalidData, ErrTypeEOF, ErrTypeNetworkUnreachable, ErrTypeRTSP503:
+		return true // Transient failures - might recover with bounded retry.
+	default:
+		return false
+	}
+}
+
+// StateTransition records a lifecycle transition for the health snapshot's
+// StateHistory. From and To are the neutral connection states; FromDetail and
+// ToDetail carry the producer's sub-state names (for FFmpeg: idle, backoff,
+// circuit_open, etc.) so the legacy process_state history stays byte-identical.
+type StateTransition struct {
+	From       StreamState
+	To         StreamState
+	FromDetail string
+	ToDetail   string
+	Timestamp  time.Time
+	Reason     string
+}
+
+// FromName returns the legacy process_state name for the From state: the
+// producer detail when set, otherwise the fixed StreamState mapping.
+func (t *StateTransition) FromName() string {
+	return detailOrLegacyName(t.FromDetail, t.From)
+}
+
+// ToName returns the legacy process_state name for the To state: the producer
+// detail when set, otherwise the fixed StreamState mapping.
+func (t *StateTransition) ToName() string {
+	return detailOrLegacyName(t.ToDetail, t.To)
+}
+
+// detailOrLegacyName returns detail when non-empty, else the state's legacy name.
+func detailOrLegacyName(detail string, s StreamState) string {
+	if detail != "" {
+		return detail
+	}
+	return s.LegacyProcessName()
+}
+
+// StreamHealth is the producer-neutral health snapshot for one network stream,
+// consumed by the health API and the support dump. State plus StateDetail carry
+// the connection state and the producer's sub-state; every other field matches
+// the historical ffmpeg.StreamHealth so the API stays unchanged.
+type StreamHealth struct {
+	// State is the neutral connection lifecycle state.
+	State StreamState
+	// StateDetail is the producer-specific sub-state name for the legacy
+	// process_state API field (FFmpeg: idle, backoff, circuit_open, restarting).
+	// Empty means the API falls back to State.LegacyProcessName().
+	StateDetail string
+	// StateEntered is when the current state was entered.
+	StateEntered time.Time
+	// Recovery is the producer's recovery intent for the liveness watchdog.
+	Recovery RecoveryState
+
+	IsHealthy          bool
+	LastDataReceived   time.Time
+	RestartCount       int
+	Error              error
+	TotalBytesReceived int64
+	BytesPerSecond     float64
+	IsReceivingData    bool
+	StateHistory       []StateTransition
+	LastErrorContext   *StreamErrorContext
+	ErrorHistory       []*StreamErrorContext
+	SourceChannels     int
+}
+
+// ProcessStateName returns the legacy process_state string for this snapshot:
+// StateDetail when the producer set it, otherwise the fixed State mapping. This
+// is the single source of the process_state value the health API and the
+// support dump emit, so the FFmpeg-era JSON stays byte-identical.
+func (h *StreamHealth) ProcessStateName() string {
+	if h.StateDetail != "" {
+		return h.StateDetail
+	}
+	return h.State.LegacyProcessName()
+}
+
+// Data rate sliding-window parameters.
+const (
+	// DataRateWindowSize is the default sliding window over which a DataRateMeter
+	// averages the delivered byte rate.
+	DataRateWindowSize = 10 * time.Second
+	// dataRateMaxSamples caps the number of retained rate samples.
+	dataRateMaxSamples = 100
+	// dataRateSingleSampleWindow is how recent a lone sample must be for the meter
+	// to report its instantaneous byte count rather than zero.
+	dataRateSingleSampleWindow = 5 * time.Second
+)
+
+// DataRateMeter tracks a delivered-byte rate over a sliding time window so every
+// producer reports StreamHealth.BytesPerSecond identically. It is safe for
+// concurrent use.
+type DataRateMeter struct {
+	samples    []dataRateSample
+	samplesMu  sync.RWMutex
+	windowSize time.Duration
+	maxSamples int
+}
+
+type dataRateSample struct {
+	timestamp time.Time
+	bytes     int64
+}
+
+// NewDataRateMeter creates a DataRateMeter that averages over windowSize.
+func NewDataRateMeter(windowSize time.Duration) *DataRateMeter {
+	return &DataRateMeter{
+		samples:    make([]dataRateSample, 0, dataRateMaxSamples),
+		windowSize: windowSize,
+		maxSamples: dataRateMaxSamples,
+	}
+}
+
+// AddSample records numBytes delivered at the current time and evicts samples
+// older than the window.
+func (d *DataRateMeter) AddSample(numBytes int64) {
+	d.samplesMu.Lock()
+	defer d.samplesMu.Unlock()
+
+	now := time.Now()
+	d.samples = append(d.samples, dataRateSample{
+		timestamp: now,
+		bytes:     numBytes,
+	})
+
+	// Remove old samples outside the window.
+	cutoff := now.Add(-d.windowSize)
+	i := 0
+	for i < len(d.samples) && d.samples[i].timestamp.Before(cutoff) {
+		i++
+	}
+	if i > 0 {
+		d.samples = d.samples[i:]
+	}
+
+	// Limit max samples.
+	if len(d.samples) > d.maxSamples {
+		d.samples = d.samples[len(d.samples)-d.maxSamples:]
+	}
+}
+
+// Rate returns the current data rate in bytes per second.
+func (d *DataRateMeter) Rate() float64 {
+	d.samplesMu.RLock()
+	defer d.samplesMu.RUnlock()
+
+	if len(d.samples) == 0 {
+		return 0
+	}
+
+	if len(d.samples) == 1 {
+		sample := d.samples[0]
+		timeSinceSample := time.Since(sample.timestamp)
+		if timeSinceSample < dataRateSingleSampleWindow {
+			return float64(sample.bytes)
+		}
+		return 0
+	}
+
+	totalBytes := int64(0)
+	for _, s := range d.samples {
+		totalBytes += s.bytes
+	}
+
+	duration := d.samples[len(d.samples)-1].timestamp.Sub(d.samples[0].timestamp).Seconds()
+	if duration <= 0 {
+		return 0
+	}
+
+	return float64(totalBytes) / duration
+}

--- a/internal/audiocore/stream_health_test.go
+++ b/internal/audiocore/stream_health_test.go
@@ -1,0 +1,148 @@
+package audiocore
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStreamState_String(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		state StreamState
+		want  string
+	}{
+		{StreamStateStarting, "starting"},
+		{StreamStateConnected, "connected"},
+		{StreamStateReconnecting, "reconnecting"},
+		{StreamStateStopped, "stopped"},
+		{StreamStateFailed, "failed"},
+		{StreamState(99), "unknown(99)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.state.String())
+		})
+	}
+}
+
+func TestStreamState_LegacyProcessName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		state StreamState
+		want  string
+	}{
+		{StreamStateStarting, "starting"},
+		{StreamStateConnected, "running"},
+		{StreamStateReconnecting, "restarting"},
+		{StreamStateStopped, "stopped"},
+		{StreamStateFailed, "failed"},
+		// An out-of-range value falls back to the neutral String() form.
+		{StreamState(99), "unknown(99)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.state.LegacyProcessName())
+		})
+	}
+}
+
+func TestRecoveryState_String(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		state RecoveryState
+		want  string
+	}{
+		{RecoveryUnknown, "unknown"},
+		{RecoveryIdle, "idle"},
+		{RecoveryInProgress, "in_progress"},
+		{RecoveryGivenUp, "given_up"},
+		{RecoveryState(99), "unknown(99)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.state.String())
+		})
+	}
+}
+
+func TestStreamHealth_ProcessStateName(t *testing.T) {
+	t.Parallel()
+
+	t.Run("StateDetail overrides the state mapping", func(t *testing.T) {
+		t.Parallel()
+		// circuit_open has no neutral StreamState; only StateDetail preserves it.
+		h := StreamHealth{State: StreamStateReconnecting, StateDetail: "circuit_open"}
+		assert.Equal(t, "circuit_open", h.ProcessStateName())
+	})
+
+	t.Run("falls back to the legacy state mapping when detail is empty", func(t *testing.T) {
+		t.Parallel()
+		h := StreamHealth{State: StreamStateConnected}
+		assert.Equal(t, "running", h.ProcessStateName())
+	})
+}
+
+func TestStateTransition_Names(t *testing.T) {
+	t.Parallel()
+
+	t.Run("details override the state mapping", func(t *testing.T) {
+		t.Parallel()
+		tr := StateTransition{
+			From:       StreamStateStarting,
+			To:         StreamStateReconnecting,
+			FromDetail: "starting",
+			ToDetail:   "circuit_open",
+		}
+		assert.Equal(t, "starting", tr.FromName())
+		assert.Equal(t, "circuit_open", tr.ToName())
+	})
+
+	t.Run("falls back to the legacy state mapping when details are empty", func(t *testing.T) {
+		t.Parallel()
+		tr := StateTransition{From: StreamStateConnected, To: StreamStateReconnecting}
+		assert.Equal(t, "running", tr.FromName())
+		assert.Equal(t, "restarting", tr.ToName())
+	})
+}
+
+func TestDataRateMeter_Calculation(t *testing.T) {
+	// Rate divides total bytes by the time span between the first and last
+	// sample, returning 0 when that span is zero (div-by-zero guard). On
+	// coarse-timer platforms (Windows, ~15ms resolution) three back-to-back
+	// AddSample calls can share a timestamp, making the span zero and the rate
+	// zero. Use synctest's fake clock advanced by time.Sleep so the samples get
+	// distinct timestamps deterministically on every platform.
+	synctest.Test(t, func(t *testing.T) {
+		meter := NewDataRateMeter(DataRateWindowSize)
+
+		meter.AddSample(1024)
+		time.Sleep(time.Millisecond)
+		meter.AddSample(2048)
+		time.Sleep(time.Millisecond)
+		meter.AddSample(1536)
+
+		assert.Greater(t, meter.Rate(), 0.0)
+	})
+}
+
+func TestDataRateMeter_EmptyRate(t *testing.T) {
+	t.Parallel()
+
+	meter := NewDataRateMeter(DataRateWindowSize)
+	assert.InDelta(t, 0.0, meter.Rate(), 0.001)
+}
+
+func TestDataRateMeter_SingleSampleRate(t *testing.T) {
+	t.Parallel()
+
+	meter := NewDataRateMeter(DataRateWindowSize)
+	meter.AddSample(1024)
+
+	assert.InDelta(t, 1024.0, meter.Rate(), 0.01, "single recent sample should return its instantaneous rate")
+}

--- a/internal/audiocore/stream_manager.go
+++ b/internal/audiocore/stream_manager.go
@@ -1,0 +1,71 @@
+package audiocore
+
+import (
+	"context"
+	"time"
+)
+
+// StreamManager is the contract the engine drives network stream producers
+// through. It is implemented by ffmpeg.Manager today and by nativestream.Manager
+// later, so both producers satisfy the same surface without importing the
+// engine. It is distinct from schedule.StreamManager, which is the engine-level
+// stop/start surface the quiet-hours scheduler uses.
+type StreamManager interface {
+	// StartStream starts capture for spec.SourceID and begins dispatching
+	// AudioFrames through the manager's frame callback. It returns an error when
+	// the ID is already running or spec is invalid; connection failures are
+	// asynchronous and surface through StreamHealth.
+	StartStream(spec *StreamSpec) error
+	// StopStream stops capture for sourceID and forgets it.
+	StopStream(sourceID string) error
+	// StreamHealth returns a point-in-time snapshot for one stream.
+	StreamHealth(sourceID string) (*StreamHealth, error)
+	// AllStreamHealth returns snapshots for every tracked stream, keyed by source ID.
+	AllStreamHealth() map[string]*StreamHealth
+	// GetActiveStreamIDs lists the currently tracked source IDs.
+	GetActiveStreamIDs() []string
+	// SetOnStreamReset registers the callback invoked after a stream starts or is
+	// fully reset under the same sourceID.
+	SetOnStreamReset(fn func(sourceID string))
+	// Shutdown stops every stream with the manager's default timeout.
+	Shutdown() error
+	// ShutdownWithContext stops every stream honouring ctx.
+	ShutdownWithContext(ctx context.Context) error
+}
+
+// StreamSpec is the protocol-neutral per-stream configuration handed to
+// StreamManager.StartStream. Producer-specific options (the FFmpeg binary path,
+// extra FFmpeg parameters, log level) belong to the producer's constructor
+// options, not here.
+type StreamSpec struct {
+	// SourceID is the unique identifier for this source.
+	SourceID string
+	// SourceName is the human-readable display name.
+	SourceName string
+	// URL is the stream URL (e.g. rtsp://host/stream).
+	URL string
+	// Type is the source type (rtsp, http, hls, udp, ...).
+	Type SourceType
+	// SampleRate is the desired output rate in Hz (48000, or the bat rate).
+	SampleRate int
+	// SourceSampleRate is the probed source rate; 0 when unknown.
+	SourceSampleRate int
+	// BitDepth is the output bit depth in bits (16).
+	BitDepth int
+	// Channels is the target channel count (1).
+	Channels int
+	// SourceChannels is the probed source channel count; 0 when unknown.
+	SourceChannels int
+	// ChannelMode controls multi-channel handling (downmix, left, right).
+	ChannelMode string
+	// MediaMode controls which RTSP media is requested (auto, audio-only,
+	// full-stream). Applied for RTSP sources only.
+	MediaMode string
+	// Transport is the RTSP transport protocol (tcp, udp).
+	Transport string
+	// HealthyDataThreshold is how long without data before marking unhealthy.
+	// Zero uses the producer default.
+	HealthyDataThreshold time.Duration
+	// Debug enables verbose debug logging for this stream.
+	Debug bool
+}

--- a/internal/health/checks/streams.go
+++ b/internal/health/checks/streams.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
+	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/health"
 	"github.com/tphakala/birdnet-go/internal/observability"
 )
@@ -16,8 +16,8 @@ type StreamHealthInfo struct {
 	URL string
 	// IsHealthy indicates whether the stream is considered healthy.
 	IsHealthy bool
-	// ProcessState is the current state of the underlying FFmpeg process (e.g. "running", "stopped").
-	ProcessState string
+	// State is the producer-neutral connection state of the underlying stream.
+	State audiocore.StreamState
 	// RestartCount is the number of times this stream has been restarted.
 	RestartCount int
 	// Error holds the most recent error message, if any.
@@ -182,10 +182,10 @@ func (c *FFmpegHealthCheck) Run(_ context.Context) health.Result {
 	notRunningCount := 0
 
 	for _, s := range streams {
-		switch s.ProcessState {
-		case ffmpeg.ProcessStateRunning:
+		switch s.State {
+		case audiocore.StreamStateConnected:
 			// healthy
-		case ffmpeg.ProcessStateStopped:
+		case audiocore.StreamStateStopped:
 			stoppedCount++
 		default:
 			notRunningCount++

--- a/internal/health/checks/streams_test.go
+++ b/internal/health/checks/streams_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/health"
 )
 
@@ -31,8 +32,8 @@ func TestFFmpegHealthCheck_NoStreams(t *testing.T) {
 func TestFFmpegHealthCheck_AllRunning(t *testing.T) {
 	t.Parallel()
 	streams := []StreamHealthInfo{
-		{URL: "rtsp://a", ProcessState: "running"},
-		{URL: "rtsp://b", ProcessState: "running"},
+		{URL: "rtsp://a", State: audiocore.StreamStateConnected},
+		{URL: "rtsp://b", State: audiocore.StreamStateConnected},
 	}
 	check := NewFFmpegHealthCheck(streamProvider(streams))
 	result := check.Run(t.Context())
@@ -45,13 +46,12 @@ func TestFFmpegHealthCheck_AllRunning(t *testing.T) {
 }
 
 // TestFFmpegHealthCheck_StoppedOnly covers a permanently stopped (terminal)
-// process, the most severe state. "stopped" is the string ProcessState.String()
-// actually returns for StateStopped.
+// stream, the most severe state, reported as audiocore.StreamStateStopped.
 func TestFFmpegHealthCheck_StoppedOnly(t *testing.T) {
 	t.Parallel()
 	streams := []StreamHealthInfo{
-		{URL: "rtsp://a", ProcessState: "stopped"},
-		{URL: "rtsp://b", ProcessState: "running"},
+		{URL: "rtsp://a", State: audiocore.StreamStateStopped},
+		{URL: "rtsp://b", State: audiocore.StreamStateConnected},
 	}
 	check := NewFFmpegHealthCheck(streamProvider(streams))
 	result := check.Run(t.Context())
@@ -69,8 +69,8 @@ func TestFFmpegHealthCheck_StoppedOnly(t *testing.T) {
 func TestFFmpegHealthCheck_NotRunningOnly(t *testing.T) {
 	t.Parallel()
 	streams := []StreamHealthInfo{
-		{URL: "rtsp://a", ProcessState: "starting"},
-		{URL: "rtsp://b", ProcessState: "running"},
+		{URL: "rtsp://a", State: audiocore.StreamStateStarting},
+		{URL: "rtsp://b", State: audiocore.StreamStateConnected},
 	}
 	check := NewFFmpegHealthCheck(streamProvider(streams))
 	result := check.Run(t.Context())
@@ -87,10 +87,10 @@ func TestFFmpegHealthCheck_NotRunningOnly(t *testing.T) {
 func TestFFmpegHealthCheck_StoppedAndNotRunning(t *testing.T) {
 	t.Parallel()
 	streams := []StreamHealthInfo{
-		{URL: "rtsp://a", ProcessState: "stopped"},
-		{URL: "rtsp://b", ProcessState: "stopped"},
-		{URL: "rtsp://c", ProcessState: "starting"},
-		{URL: "rtsp://d", ProcessState: "running"},
+		{URL: "rtsp://a", State: audiocore.StreamStateStopped},
+		{URL: "rtsp://b", State: audiocore.StreamStateStopped},
+		{URL: "rtsp://c", State: audiocore.StreamStateStarting},
+		{URL: "rtsp://d", State: audiocore.StreamStateConnected},
 	}
 	check := NewFFmpegHealthCheck(streamProvider(streams))
 	result := check.Run(t.Context())


### PR DESCRIPTION
## Summary

Extract a producer-neutral seam for network stream ingest so a second, non-FFmpeg producer can be added later without touching the engine or its clients. This is the first phase of that work and a pure refactor: no behaviour change, and no change to the existing health API JSON fields. It adds one additive `state` field (described below); every field a client reads today is byte-identical.

A new `audiocore.StreamManager` interface (the eight methods the engine already drives) and a protocol-neutral `audiocore.StreamSpec` replace the engine's direct dependency on the concrete `*ffmpeg.Manager` and `ffmpeg.StreamConfig`. The stream health data types move out of the `ffmpeg` package into `audiocore` so they outlive it: `StreamHealth`, `StateTransition`, the error-context struct (now `StreamErrorContext`, with its `ErrType` constants and the `ShouldOpenCircuit`, `ShouldRestart`, and `FormatForConsole` helpers), and the sliding-window rate calculator (now `DataRateMeter`). Two new connection-domain enums, `StreamState` and `RecoveryState`, model a stream as a connection rather than a child process; `ffmpeg.ProcessState` stays private to the ffmpeg package and maps onto `StreamState`, carrying its old process name in a new `StateDetail` field.

`ffmpeg.Manager` now implements `audiocore.StreamManager`: `StartStream` takes a `*audiocore.StreamSpec`, the health accessors return `*audiocore.StreamHealth`, and the FFmpeg binary path, extra parameters, and log level fold into the manager's `Options` (set once at construction) instead of being repeated on every stream config. The FFmpeg stderr classifier stays in the ffmpeg package; only the error-context struct it fills moved.

The engine's field becomes `streamMgr audiocore.StreamManager`, `FFmpegManager()` becomes `StreamManager()`, and the three duplicated `ffmpeg.StreamConfig` literals collapse into one `buildStreamSpec` helper. Every client (the analysis pipeline, the stream-health API, the system diagnostics provider, and the stream health check) switches to the interface and the neutral types.

The health API JSON is byte-identical for the same FFmpeg state. The `process_state` field the frontend switches on is filled from `StateDetail` (the old process name for FFmpeg), and `state_history` preserves the same per-transition names. A new additive `state` field carries the neutral connection vocabulary for a future frontend migration.

## Test Plan

- [x] `go build ./...`, `go vet ./...`, and `golangci-lint run` (including the integration build tags) are clean.
- [x] Unit tests pass with `-race` across the audiocore, ffmpeg, engine, api/v2/audio, and health/checks packages.
- [x] New tests: a compile-time and runtime conformance assertion that `*ffmpeg.Manager` satisfies `audiocore.StreamManager`; a table test that every `ffmpeg.ProcessState` maps to the intended `StreamState` and round-trips its legacy name; a `buildStreamSpec` table test with distinct per-field values to catch a transposed argument; and a golden-JSON test on the health response covering every process state plus the removed-stream event.
- [x] The FFmpeg characterization contract suite introduced in #4269 passes unchanged against the refactored manager, proving the refactor is behaviour-preserving.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stream health now reports producer-neutral lifecycle states, including starting, connected, reconnecting, stopped, and failed.
  * Health responses include neutral state information alongside legacy process-state values.
  * Added richer health details, including state history, recovery information, error diagnostics, and data-rate tracking.

* **Bug Fixes**
  * Improved stream reset handling and health diagnostics.
  * Removed-stream notifications now report a stopped state while preserving legacy compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->