### PR TITLE
refactor(audiocore): neutralize producer-facing naming ahead of native ingest

### DIFF
--- a/internal/audiocore/engine/engine.go
+++ b/internal/audiocore/engine/engine.go
@@ -221,26 +221,16 @@ func (e *AudioEngine) StreamManager() audiocore.StreamManager {
 	return e.streamMgr
 }
 
-// buildStreamSpec assembles the protocol-neutral audiocore.StreamSpec the stream
-// manager consumes from a source's resolved parameters. The manager-level FFmpeg
-// settings (binary path, extra parameters, log level) are not part of the spec;
-// the manager already holds them from its Options.
-func (e *AudioEngine) buildStreamSpec(sourceID, displayName, url string, typ audiocore.SourceType, sampleRate, sourceSampleRate, bitDepth, channels, sourceChannels int, channelMode, mediaMode, transport string) *audiocore.StreamSpec {
-	return &audiocore.StreamSpec{
-		SourceID:         sourceID,
-		SourceName:       displayName,
-		URL:              url,
-		Type:             typ,
-		SampleRate:       sampleRate,
-		SourceSampleRate: sourceSampleRate,
-		BitDepth:         bitDepth,
-		Channels:         channels,
-		SourceChannels:   sourceChannels,
-		ChannelMode:      channelMode,
-		MediaMode:        mediaMode,
-		Transport:        transport,
-		Debug:            e.debug,
-	}
+// buildStreamSpec stamps the engine-owned fields onto a caller-assembled
+// audiocore.StreamSpec and returns it. Call sites pass a keyed literal holding
+// the resolved per-source fields, so the many string and int fields cannot be
+// transposed; Debug is engine state, so it is injected here rather than repeated
+// at every call site. Manager-level FFmpeg settings (binary path, extra
+// parameters, log level) are not part of the spec; the manager holds them from
+// its Options.
+func (e *AudioEngine) buildStreamSpec(spec *audiocore.StreamSpec) *audiocore.StreamSpec {
+	spec.Debug = e.debug
+	return spec
 }
 
 // DeviceManager returns the device manager.
@@ -323,7 +313,20 @@ func (e *AudioEngine) StartStream(sourceID, url, transport string) error {
 	if bitDepth <= 0 {
 		bitDepth = defaultBitDepth
 	}
-	spec := e.buildStreamSpec(sourceID, src.DisplayName, url, src.Type, sampleRate, src.SourceSampleRate, bitDepth, channels, src.SourceChannels, src.ChannelMode, src.MediaMode, transport)
+	spec := e.buildStreamSpec(&audiocore.StreamSpec{
+		SourceID:         sourceID,
+		SourceName:       src.DisplayName,
+		URL:              url,
+		Type:             src.Type,
+		SampleRate:       sampleRate,
+		SourceSampleRate: src.SourceSampleRate,
+		BitDepth:         bitDepth,
+		Channels:         channels,
+		SourceChannels:   src.SourceChannels,
+		ChannelMode:      src.ChannelMode,
+		MediaMode:        src.MediaMode,
+		Transport:        transport,
+	})
 	if err := e.streamMgr.StartStream(spec); err != nil {
 		_ = e.registry.UpdateState(sourceID, audiocore.SourceError)
 		return err
@@ -450,7 +453,20 @@ func (e *AudioEngine) AddSource(cfg *audiocore.SourceConfig) error {
 
 	// 5. Start capture based on source type.
 	if isStreamType(cfg.Type) {
-		spec := e.buildStreamSpec(sourceID, src.DisplayName, cfg.ConnectionString, cfg.Type, sampleRate, cfg.SourceSampleRate, bitDepth, channels, cfg.SourceChannels, cfg.ChannelMode, cfg.MediaMode, e.resolveTransport(cfg.Transport))
+		spec := e.buildStreamSpec(&audiocore.StreamSpec{
+			SourceID:         sourceID,
+			SourceName:       src.DisplayName,
+			URL:              cfg.ConnectionString,
+			Type:             cfg.Type,
+			SampleRate:       sampleRate,
+			SourceSampleRate: cfg.SourceSampleRate,
+			BitDepth:         bitDepth,
+			Channels:         channels,
+			SourceChannels:   cfg.SourceChannels,
+			ChannelMode:      cfg.ChannelMode,
+			MediaMode:        cfg.MediaMode,
+			Transport:        e.resolveTransport(cfg.Transport),
+		})
 		if err := e.streamMgr.StartStream(spec); err != nil {
 			e.bufferMgr.DeallocateSource(sourceID)
 			_ = e.registry.Unregister(sourceID)
@@ -639,7 +655,20 @@ func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.Sourc
 	}
 
 	if isStreamType(newType) {
-		spec := e.buildStreamSpec(sourceID, src.DisplayName, newCfg.ConnectionString, newType, sampleRate, newCfg.SourceSampleRate, bitDepth, channels, newCfg.SourceChannels, newCfg.ChannelMode, newCfg.MediaMode, e.resolveTransport(newCfg.Transport))
+		spec := e.buildStreamSpec(&audiocore.StreamSpec{
+			SourceID:         sourceID,
+			SourceName:       src.DisplayName,
+			URL:              newCfg.ConnectionString,
+			Type:             newType,
+			SampleRate:       sampleRate,
+			SourceSampleRate: newCfg.SourceSampleRate,
+			BitDepth:         bitDepth,
+			Channels:         channels,
+			SourceChannels:   newCfg.SourceChannels,
+			ChannelMode:      newCfg.ChannelMode,
+			MediaMode:        newCfg.MediaMode,
+			Transport:        e.resolveTransport(newCfg.Transport),
+		})
 		if err := e.streamMgr.StartStream(spec); err != nil {
 			e.bufferMgr.DeallocateSource(sourceID)
 			_ = e.registry.UpdateState(sourceID, audiocore.SourceError)

--- a/internal/audiocore/engine/stream_spec_test.go
+++ b/internal/audiocore/engine/stream_spec_test.go
@@ -65,9 +65,11 @@ func TestBuildStreamSpec(t *testing.T) {
 			t.Parallel()
 			e := &AudioEngine{debug: tt.debug}
 			// The call site assembles every field except Debug, which the engine
-			// owns; buildStreamSpec must stamp it and leave the rest untouched.
+			// owns. Start Debug at the opposite of the wanted value so the
+			// assertion proves buildStreamSpec actively stamps it, not that it
+			// happened to match.
 			in := tt.want
-			in.Debug = false
+			in.Debug = !tt.debug
 			got := e.buildStreamSpec(&in)
 			assert.Equal(t, &tt.want, got)
 		})

--- a/internal/audiocore/engine/stream_spec_test.go
+++ b/internal/audiocore/engine/stream_spec_test.go
@@ -8,11 +8,10 @@ import (
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 )
 
-// TestBuildStreamSpec verifies that buildStreamSpec maps its parameters onto the
-// StreamSpec field-for-field, reproducing the three former ffmpeg.StreamConfig
-// literals in AddSource, the reconfigure path, and the quiet-hours restart path.
-// Every column uses a distinct value so a transposed positional argument in the
-// twelve-parameter helper is caught. Debug is read from the engine, not passed.
+// TestBuildStreamSpec verifies that buildStreamSpec stamps the engine-owned
+// Debug field onto a caller-assembled StreamSpec and otherwise returns it
+// unchanged, covering both debug settings. Every column uses a distinct value so
+// a field the helper accidentally overwrote would be caught.
 func TestBuildStreamSpec(t *testing.T) {
 	t.Parallel()
 
@@ -65,20 +64,11 @@ func TestBuildStreamSpec(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			e := &AudioEngine{debug: tt.debug}
-			got := e.buildStreamSpec(
-				tt.want.SourceID,
-				tt.want.SourceName,
-				tt.want.URL,
-				tt.want.Type,
-				tt.want.SampleRate,
-				tt.want.SourceSampleRate,
-				tt.want.BitDepth,
-				tt.want.Channels,
-				tt.want.SourceChannels,
-				tt.want.ChannelMode,
-				tt.want.MediaMode,
-				tt.want.Transport,
-			)
+			// The call site assembles every field except Debug, which the engine
+			// owns; buildStreamSpec must stamp it and leave the rest untouched.
+			in := tt.want
+			in.Debug = false
+			got := e.buildStreamSpec(&in)
 			assert.Equal(t, &tt.want, got)
 		})
 	}

--- a/internal/audiocore/ffmpeg/error_context.go
+++ b/internal/audiocore/ffmpeg/error_context.go
@@ -110,8 +110,8 @@ func ExtractErrorContext(stderrOutput string) *audiocore.StreamErrorContext {
 	sanitizedOutput := privacy.SanitizeFFmpegError(stderrOutput)
 
 	ctx := &audiocore.StreamErrorContext{
-		RawFFmpegOutput: sanitizedOutput,
-		Timestamp:       time.Now(),
+		RawProducerOutput: sanitizedOutput,
+		Timestamp:         time.Now(),
 	}
 
 	// Connection timeout - very common with unreachable hosts.

--- a/internal/audiocore/ffmpeg/error_context_test.go
+++ b/internal/audiocore/ffmpeg/error_context_test.go
@@ -483,14 +483,14 @@ Error opening input file rtsp://user:p@ssw0rd!@host.local:8554/live`,
 			require.NotNil(t, ctx, "Expected error context, got nil")
 			assert.Equal(t, tt.expectedType, ctx.ErrorType)
 
-			// Check that RawFFmpegOutput is sanitized.
-			assert.NotContains(t, ctx.RawFFmpegOutput, "password", "RawFFmpegOutput contains unsanitized 'password'")
-			assert.NotContains(t, ctx.RawFFmpegOutput, "secret", "RawFFmpegOutput contains unsanitized 'secret'")
-			assert.NotContains(t, ctx.RawFFmpegOutput, "p@ssw0rd", "RawFFmpegOutput contains unsanitized 'p@ssw0rd'")
+			// Check that RawProducerOutput is sanitized.
+			assert.NotContains(t, ctx.RawProducerOutput, "password", "RawProducerOutput contains unsanitized 'password'")
+			assert.NotContains(t, ctx.RawProducerOutput, "secret", "RawProducerOutput contains unsanitized 'secret'")
+			assert.NotContains(t, ctx.RawProducerOutput, "p@ssw0rd", "RawProducerOutput contains unsanitized 'p@ssw0rd'")
 
 			// Check that credentials should be replaced with ***.
-			if !strings.Contains(ctx.RawFFmpegOutput, "***") {
-				t.Log("Note: RawFFmpegOutput should contain *** placeholders for credentials")
+			if !strings.Contains(ctx.RawProducerOutput, "***") {
+				t.Log("Note: RawProducerOutput should contain *** placeholders for credentials")
 			}
 
 			// Check TargetHost is clean.

--- a/internal/audiocore/ffmpeg/error_context_test.go
+++ b/internal/audiocore/ffmpeg/error_context_test.go
@@ -488,10 +488,12 @@ Error opening input file rtsp://user:p@ssw0rd!@host.local:8554/live`,
 			assert.NotContains(t, ctx.RawProducerOutput, "secret", "RawProducerOutput contains unsanitized 'secret'")
 			assert.NotContains(t, ctx.RawProducerOutput, "p@ssw0rd", "RawProducerOutput contains unsanitized 'p@ssw0rd'")
 
-			// Check that credentials should be replaced with ***.
-			if !strings.Contains(ctx.RawProducerOutput, "***") {
-				t.Log("Note: RawProducerOutput should contain *** placeholders for credentials")
-			}
+			// SanitizeFFmpegError strips the user:pass@ credentials from the URL
+			// rather than masking them, so the sanitized output keeps the scheme
+			// and host but not the secret. Assert the URL line survived as a
+			// non-vacuous positive control for the credential-absence checks above.
+			assert.Contains(t, ctx.RawProducerOutput, "rtsp://",
+				"sanitized output should retain the stream URL, not be emptied")
 
 			// Check TargetHost is clean.
 			if tt.checkHost {

--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -2312,13 +2312,13 @@ func (s *Stream) recordErrorContext(ctx *audiocore.StreamErrorContext) {
 			logger.String("component", "ffmpeg-stream"),
 			logger.String("operation", "error_troubleshooting"))
 	}
-	if ctx.RawFFmpegOutput != "" {
+	if ctx.RawProducerOutput != "" {
 		log.Debug("FFmpeg raw error output",
 			logger.String("source_id", s.config.SourceID),
 			logger.String("error_type", ctx.ErrorType),
 			logger.String("target_host", targetHost),
 			logger.Int("target_port", ctx.TargetPort),
-			logger.String("ffmpeg_output", ctx.RawFFmpegOutput),
+			logger.String("ffmpeg_output", ctx.RawProducerOutput),
 			logger.String("component", "ffmpeg-stream"),
 			logger.String("operation", "error_raw_output"))
 	}

--- a/internal/audiocore/stream_health.go
+++ b/internal/audiocore/stream_health.go
@@ -192,14 +192,14 @@ type StreamErrorContext struct {
 	TimeoutDuration time.Duration // Extracted timeout (if applicable)
 	HTTPStatus      int           // HTTP/RTSP status code (if applicable)
 	RTSPMethod      string        // RTSP method that failed (if applicable)
-	// RawFFmpegOutput stores the sanitized producer stderr/log output for
+	// RawProducerOutput stores the sanitized producer stderr/log output for
 	// debugging. SECURITY: this field is sanitized by the producer (for FFmpeg,
 	// privacy.SanitizeFFmpegError) to remove credentials from stream URLs. The
 	// json:"-" tag prevents accidental credential leakage via JSON marshaling.
-	RawFFmpegOutput string    `json:"-"` // Full producer output for debugging (sanitized)
-	UserFacingMsg   string    // Friendly message for user
-	TroubleShooting []string  // List of troubleshooting steps
-	Timestamp       time.Time // When this error was detected
+	RawProducerOutput string    `json:"-"` // Full producer output for debugging (sanitized)
+	UserFacingMsg     string    // Friendly message for user
+	TroubleShooting   []string  // List of troubleshooting steps
+	Timestamp         time.Time // When this error was detected
 }
 
 // FormatForConsole renders the user-facing message plus troubleshooting steps


### PR DESCRIPTION
## Summary

Phase-2 preparation for native (non-FFmpeg) stream ingest. Two producer-neutral cleanups to the audiocore stream seam, with no behavior change.

Rename the internal `StreamErrorContext.RawFFmpegOutput` field to `RawProducerOutput` so the neutral seam is not FFmpeg-specific ahead of a second producer that will populate the same field. The field is tagged `json:"-"` and the struct lives in an internal package, so the rename has no wire, config, persistence, or API impact. The FFmpeg producer's `"ffmpeg_output"` log key is deliberately kept, since at that call site the value is genuinely FFmpeg output.

Replace `buildStreamSpec`'s twelve positional parameters with a caller-built keyed `audiocore.StreamSpec{}` literal; `buildStreamSpec` now stamps the engine-owned `Debug` field onto the passed spec. This removes the argument-transposition footgun of the long positional signature without introducing a parallel params struct, and keeps the single place where the engine injects its own fields.

## Test Plan

- [x] `go build ./...`
- [x] `golangci-lint run` clean across all 8 build-tag combinations
- [x] `go test -race` green for `internal/audiocore/...` and `internal/api/v2/audio/...` (including the `TestConvertStreamHealthToResponse_Golden` drift guard)
- [x] `gofmt` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stream error diagnostics by consistently capturing and displaying sanitized producer output.
  - Continued masking sensitive credentials in error details to help prevent accidental exposure.
  - Preserved existing timestamps and other stream health information during error reporting.
  - Ensured stream debug settings are applied consistently while preserving other stream configuration details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->