### PR TITLE
feat(audiocore): native RTSP stream ingest behind BIRDNET_STREAM_INGEST=native

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,8 +38,9 @@ require (
 	github.com/stretchr/testify v1.12.1
 	github.com/testcontainers/testcontainers-go v0.44.0
 	github.com/testcontainers/testcontainers-go/modules/mysql v0.44.0
-	github.com/tphakala/go-aac v0.6.1
+	github.com/tphakala/go-aac v0.7.0
 	github.com/tphakala/go-audio-resampler v1.7.0
+	github.com/tphakala/go-audio-stream v0.4.0
 	github.com/tphakala/go-flac v1.1.0
 	github.com/tphakala/go-hls v0.1.0
 	github.com/tphakala/go-m4a v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -282,10 +282,12 @@ github.com/tklauser/go-sysconf v0.4.0 h1:7H0uAN+7RkwWRaxhYXDLqa5V3LPrJeV8wmD9dRU
 github.com/tklauser/go-sysconf v0.4.0/go.mod h1:8mTNWyog7H+MpKijp4VmKJAd2bbYQ2zuUwkYRbUArPI=
 github.com/tklauser/numcpus v0.12.0 h1:NR85qdvHA9pFse3x3weVZ0r0ST8R6l5RHbZrlRaqob4=
 github.com/tklauser/numcpus v0.12.0/go.mod h1:ABHeXzJnr/qqwguhClkZKT1/8VABcYrsyUiUGobwWJg=
-github.com/tphakala/go-aac v0.6.1 h1:X9BFJT2SnkiLm9xNij4XrL1baM1gkpKWJrSplccxFCA=
-github.com/tphakala/go-aac v0.6.1/go.mod h1:zbnhFT1TNtHgFjbtJnW32vCi9yyaSC9tdhqyjAiti1c=
+github.com/tphakala/go-aac v0.7.0 h1:QuwkvhNXNaAS0CaGgpkrErXV8rmekGTi+nPIFNQZQ5s=
+github.com/tphakala/go-aac v0.7.0/go.mod h1:zbnhFT1TNtHgFjbtJnW32vCi9yyaSC9tdhqyjAiti1c=
 github.com/tphakala/go-audio-resampler v1.7.0 h1:Nqr1zNRlow28EjlQKS/SSmhqSa6qHRZRydrPXNkiKTo=
 github.com/tphakala/go-audio-resampler v1.7.0/go.mod h1:h/j0tsie+Jv7qVEytRZ4KrxfO//zxO3RAbesX+1ZEo4=
+github.com/tphakala/go-audio-stream v0.4.0 h1:ojcJAwB+r8BQOGpQtQYTqgHcQpgGhosQFmiCv2gtvuI=
+github.com/tphakala/go-audio-stream v0.4.0/go.mod h1:W9be1o1XSqEkSAG81yHOV6+G9odYbpWJlmL5DBEhfgM=
 github.com/tphakala/go-flac v1.1.0 h1:dyVNPFW+MVLzPvw1n3dEvBHPtKUMbQ5PHWvW/pxQMv0=
 github.com/tphakala/go-flac v1.1.0/go.mod h1:9MM9hnsIryw1BbD/e3iZgKMx3s34VCMlxzhSIP8gpEA=
 github.com/tphakala/go-hls v0.1.0 h1:bLJMJYV1b4FGXsjkQXdtsU9CWHEjdaON5dGLZeqWebc=

--- a/internal/audiocore/engine/engine.go
+++ b/internal/audiocore/engine/engine.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/audiocore/buffer"
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/audiocore/schedule"
+	"github.com/tphakala/birdnet-go/internal/audiocore/stream"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -165,16 +166,26 @@ func New(ctx context.Context, cfg *Config, scheduler *schedule.QuietHoursSchedul
 	// allocating per-frame. The router Retain/Release path keeps pooled
 	// buffers alive across fan-out subscribers.
 	// The engine drives its network stream producer through the
-	// audiocore.StreamManager seam. The manager-level FFmpeg settings (binary
-	// path, extra parameters, log level) are handed to the manager once here
-	// rather than repeated on every StreamSpec.
-	var streamMgr audiocore.StreamManager = ffmpeg.NewManagerWithOptions(engineCtx, func(frame audiocore.AudioFrame) {
-		router.Dispatch(frame)
-	}, nil, log, bufMgr, ffmpeg.Options{
-		FFmpegPath:       cfg.FFmpegPath,
-		FFmpegParameters: cfg.FFmpegParameters,
-		LogLevel:         cfg.LogLevel,
-	})
+	// audiocore.StreamManager seam, selected at construction by the
+	// BIRDNET_STREAM_INGEST gate. FFmpeg is the default; the value "native"
+	// switches to the pure-Go go-audio-stream producer. Manager-level settings
+	// are handed to the chosen manager once here rather than repeated on every
+	// StreamSpec.
+	dispatch := func(frame audiocore.AudioFrame) { router.Dispatch(frame) }
+	var streamMgr audiocore.StreamManager
+	if conf.NativeStreamIngestEnabled() {
+		streamMgr = stream.NewManager(engineCtx, dispatch, nil, log, bufMgr, &stream.Options{
+			Debug: cfg.Debug,
+		})
+		log.Info("network stream ingest using native go-audio-stream path",
+			logger.String("ingest_engine", "native"))
+	} else {
+		streamMgr = ffmpeg.NewManagerWithOptions(engineCtx, dispatch, nil, log, bufMgr, ffmpeg.Options{
+			FFmpegPath:       cfg.FFmpegPath,
+			FFmpegParameters: cfg.FFmpegParameters,
+			LogLevel:         cfg.LogLevel,
+		})
+	}
 	deviceMgr := audiocore.NewDeviceManager(router, bufMgr, log)
 
 	// Probe all device capabilities at startup, before any capture begins.

--- a/internal/audiocore/engine/engine.go
+++ b/internal/audiocore/engine/engine.go
@@ -174,9 +174,7 @@ func New(ctx context.Context, cfg *Config, scheduler *schedule.QuietHoursSchedul
 	dispatch := func(frame audiocore.AudioFrame) { router.Dispatch(frame) }
 	var streamMgr audiocore.StreamManager
 	if conf.NativeStreamIngestEnabled() {
-		streamMgr = stream.NewManager(engineCtx, dispatch, nil, log, bufMgr, &stream.Options{
-			Debug: cfg.Debug,
-		})
+		streamMgr = stream.NewManager(engineCtx, dispatch, nil, log, bufMgr, &stream.Options{})
 		log.Info("network stream ingest using native go-audio-stream path",
 			logger.String("ingest_engine", "native"))
 	} else {

--- a/internal/audiocore/stream/decode.go
+++ b/internal/audiocore/stream/decode.go
@@ -1,0 +1,237 @@
+package stream
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+
+	aacpcm "github.com/tphakala/go-aac/pcm"
+	audiostream "github.com/tphakala/go-audio-stream"
+	mp3 "github.com/tphakala/go-mp3"
+	"github.com/tphakala/go-opus/opus"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+)
+
+// errCodecConfigPending signals that a track's codec configuration is not yet
+// resolved: an in-band MP4A-LATM stream (cpresent=1) carries its
+// AudioSpecificConfig in the first packets, not in the SDP, so there is nothing
+// to decode until OnCodecUpdate delivers it. It is deliberately NOT terminal
+// (unlike ErrUnsupportedCodec): the caller proceeds to SETUP/PLAY and lets the
+// in-band update install the decoder, and the pipeline drops frames while the
+// decoder is nil.
+var errCodecConfigPending = errors.Newf("codec configuration not yet resolved").
+	Component("native-stream").Category(errors.CategoryAudioSource).Build()
+
+// Decoder scratch sizing. Each bounds one decoded frame so the reused output
+// buffers never reallocate on the steady-state path.
+const (
+	// opusMaxSamples is the largest Opus frame at 48 kHz: 120 ms, mono.
+	opusMaxSamples = 5760
+	// mp3MaxInterleaved is the largest MPEG Layer III frame interleaved: 1152
+	// samples per channel, stereo.
+	mp3MaxInterleaved = 1152 * 2
+	// aacMaxBytes is one AAC-LC access unit as s16 PCM: 1024 samples, stereo.
+	aacMaxBytes = 1024 * 2 * 2
+
+	// opusOutputRate and opusOutputChannels are the geometry the native path
+	// decodes Opus straight into, skipping the downmix and resample stages.
+	opusOutputRate     = 48000
+	opusOutputChannels = 1
+
+	// s16FullScale scales a normalized [-1, 1] float to the 16-bit range.
+	s16FullScale = 32767
+)
+
+// frameDecoder converts one depacketized frame into interleaved little-endian
+// s16 PCM. Implementations own reusable scratch buffers, so decodeFrame is not
+// safe for concurrent use and must be called only from the supervisor's reader
+// goroutine. Geometry is reported per frame because a compressed codec's true
+// sample rate and channel count come from its bitstream, not the transport.
+type frameDecoder interface {
+	// decodeFrame decodes in into interleaved s16le PCM and reports the PCM
+	// geometry. The returned slice is owned by the decoder and is valid only
+	// until the next decodeFrame call; the caller must consume or copy it before
+	// decoding the next frame.
+	decodeFrame(in []byte) (pcm []byte, sampleRate, channels int, err error)
+	// reset clears codec state at a session boundary (a supervisor reconnect).
+	reset() error
+}
+
+// newFrameDecoder builds the decoder for a track's codec. PCM kinds (G.711,
+// G.726, L16) the library already expanded to s16le pass through with the
+// geometry from format; compressed kinds decode through the codec library. An
+// unsupported codec (FLAC, HE-AAC/SBR, opaque, or an unresolved LATM config) is
+// a terminal ErrUnsupportedCodec.
+func newFrameDecoder(codec audiostream.Codec, format audiostream.AudioFormat) (frameDecoder, error) {
+	switch c := codec.(type) {
+	case audiostream.CodecG711, audiostream.CodecG726, audiostream.CodecL16:
+		return &passthroughDecoder{sampleRate: format.SampleRate, channels: format.Channels}, nil
+	case audiostream.CodecOpus:
+		return newOpusFrameDecoder()
+	case audiostream.CodecMP3:
+		return newMP3FrameDecoder(), nil
+	case audiostream.CodecAAC:
+		return newAACFrameDecoder(c.AudioSpecificConfig)
+	case audiostream.CodecMP4ALATM:
+		if len(c.AudioSpecificConfig) == 0 {
+			// The ASC has not been learned yet (in-band cpresent=1). This is not
+			// terminal: the stream proceeds and OnCodecUpdate installs the
+			// decoder once the config arrives in-band.
+			return nil, errCodecConfigPending
+		}
+		return newAACFrameDecoder(c.AudioSpecificConfig)
+	default:
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedCodec, codecName(codec))
+	}
+}
+
+// passthroughDecoder returns the library-expanded PCM unchanged. The library
+// delivers G.711, G.726, and L16 as interleaved s16le PCM, so decode is a no-op
+// and the geometry comes from the reported AudioFormat.
+type passthroughDecoder struct {
+	sampleRate, channels int
+}
+
+func (d *passthroughDecoder) decodeFrame(in []byte) (pcm []byte, sampleRate, channels int, err error) {
+	return in, d.sampleRate, d.channels, nil
+}
+
+func (d *passthroughDecoder) reset() error { return nil }
+
+// opusFrameDecoder decodes one Opus packet per frame straight to 48 kHz mono.
+// Downmix is always skipped (the output is already mono); resample is skipped
+// too whenever the analysis target rate is 48 kHz, the common case.
+type opusFrameDecoder struct {
+	dec *opus.Decoder
+	i16 []int16
+	out []byte
+}
+
+func newOpusFrameDecoder() (*opusFrameDecoder, error) {
+	dec, err := opus.NewDecoder(opusOutputRate, opusOutputChannels)
+	if err != nil {
+		return nil, fmt.Errorf("native opus decoder: %w", err)
+	}
+	return &opusFrameDecoder{
+		dec: dec,
+		i16: make([]int16, opusMaxSamples),
+		out: make([]byte, opusMaxSamples*2),
+	}, nil
+}
+
+func (d *opusFrameDecoder) decodeFrame(in []byte) (pcm []byte, sampleRate, channels int, err error) {
+	n, err := d.dec.Decode(in, d.i16)
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("opus decode: %w", err)
+	}
+	// Slice both to n so the compiler can eliminate the per-sample bounds checks
+	// in this tight loop.
+	samples := d.i16[:n]
+	out := d.out[:n*2]
+	for i := range samples {
+		binary.LittleEndian.PutUint16(out[i*2:], uint16(samples[i]))
+	}
+	return out, opusOutputRate, opusOutputChannels, nil
+}
+
+func (d *opusFrameDecoder) reset() error {
+	d.dec.Reset()
+	return nil
+}
+
+// mp3FrameDecoder decodes one MPEG frame per call. Each frame's header names its
+// own geometry, so sample rate and channel count are reported per frame.
+type mp3FrameDecoder struct {
+	dec *mp3.Decoder
+	f32 []float32
+	out []byte
+}
+
+func newMP3FrameDecoder() *mp3FrameDecoder {
+	return &mp3FrameDecoder{
+		dec: mp3.NewDecoder(),
+		f32: make([]float32, mp3MaxInterleaved),
+		out: make([]byte, mp3MaxInterleaved*2),
+	}
+}
+
+func (d *mp3FrameDecoder) decodeFrame(in []byte) (pcm []byte, sampleRate, channels int, err error) {
+	n, info, err := d.dec.DecodeFrame(in, d.f32)
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("mp3 decode: %w", err)
+	}
+	if n == 0 {
+		return d.out[:0], info.SampleRate, info.Channels, nil
+	}
+	out := d.out[:n*2]
+	float32ToS16LE(out, d.f32[:n])
+	return out, info.SampleRate, info.Channels, nil
+}
+
+func (d *mp3FrameDecoder) reset() error {
+	d.dec.Reset()
+	return nil
+}
+
+// aacFrameDecoder decodes AAC-LC access units through go-aac's push-style frame
+// decoder, built from the out-of-band AudioSpecificConfig. NewRawDecoder parses
+// the ASC up front and rejects a non-LC, multichannel, or HE-AAC config, so an
+// unsupported stream fails at construction rather than at the first frame.
+type aacFrameDecoder struct {
+	dec *aacpcm.FrameDecoder
+	out []byte
+}
+
+func newAACFrameDecoder(asc []byte) (*aacFrameDecoder, error) {
+	dec, err := aacpcm.NewRawDecoder(asc)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrUnsupportedCodec, err)
+	}
+	return &aacFrameDecoder{dec: dec, out: make([]byte, 0, aacMaxBytes)}, nil
+}
+
+func (d *aacFrameDecoder) decodeFrame(in []byte) (pcm []byte, sampleRate, channels int, err error) {
+	out, _, err := d.dec.DecodeFrame(d.out[:0], in)
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("aac decode: %w", err)
+	}
+	d.out = out
+	return out, d.dec.SampleRate(), d.dec.Channels(), nil
+}
+
+func (d *aacFrameDecoder) reset() error {
+	return d.dec.Reset()
+}
+
+// float32ToS16LE writes len(src) normalized float samples into dst as
+// interleaved little-endian s16, rounding to nearest. dst must have room for
+// len(src)*2 bytes. The float is clamped to [-1, 1] BEFORE the integer cast, so
+// an out-of-range input can never overflow the cast and bypass the clamp; the
+// reslice is also a bounds-check hint for this per-sample loop.
+func float32ToS16LE(dst []byte, src []float32) {
+	dst = dst[:len(src)*2]
+	for i, s := range src {
+		switch {
+		case s > 1:
+			s = 1
+		case s < -1:
+			s = -1
+		}
+		v := int16(math.Round(float64(s) * s16FullScale))
+		binary.LittleEndian.PutUint16(dst[i*2:], uint16(v))
+	}
+}
+
+// codecName is a short label for an unsupported codec, used only in the
+// terminal error message.
+func codecName(codec audiostream.Codec) string {
+	switch codec.(type) {
+	case audiostream.CodecFLAC:
+		return "flac"
+	case audiostream.CodecUnknown:
+		return "unknown"
+	default:
+		return fmt.Sprintf("%T", codec)
+	}
+}

--- a/internal/audiocore/stream/decode_test.go
+++ b/internal/audiocore/stream/decode_test.go
@@ -1,0 +1,144 @@
+package stream
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	audiostream "github.com/tphakala/go-audio-stream"
+)
+
+// ascAACLC48kMono is a valid AAC-LC AudioSpecificConfig: object type 2, sample
+// rate index 3 (48000 Hz), channel config 1 (mono).
+var ascAACLC48kMono = []byte{0x11, 0x88}
+
+// ascAACMain48kMono is object type 1 (Main), which the LC-only decoder rejects.
+var ascAACMain48kMono = []byte{0x09, 0x88}
+
+func TestNewFrameDecoder_dispatch(t *testing.T) {
+	pcmFormat := func(rate, ch int) audiostream.AudioFormat {
+		return audiostream.AudioFormat{Kind: audiostream.KindPCMS16LE, SampleRate: rate, Channels: ch}
+	}
+	tests := []struct {
+		name    string
+		codec   audiostream.Codec
+		format  audiostream.AudioFormat
+		wantErr error
+		verify  func(t *testing.T, d frameDecoder)
+	}{
+		{
+			name:   "g711 mu-law passthrough",
+			codec:  audiostream.CodecG711{Law: audiostream.MuLaw},
+			format: pcmFormat(8000, 1),
+			verify: func(t *testing.T, d frameDecoder) {
+				t.Helper()
+				pt, ok := d.(*passthroughDecoder)
+				require.True(t, ok, "want passthroughDecoder")
+				assert.Equal(t, 8000, pt.sampleRate)
+				assert.Equal(t, 1, pt.channels)
+			},
+		},
+		{
+			name:   "l16 stereo passthrough",
+			codec:  audiostream.CodecL16{ClockRate: 48000, Channels: 2},
+			format: pcmFormat(48000, 2),
+			verify: func(t *testing.T, d frameDecoder) {
+				t.Helper()
+				pt, ok := d.(*passthroughDecoder)
+				require.True(t, ok, "want passthroughDecoder")
+				assert.Equal(t, 48000, pt.sampleRate)
+				assert.Equal(t, 2, pt.channels)
+			},
+		},
+		{
+			name:  "opus decoder",
+			codec: audiostream.CodecOpus{},
+			verify: func(t *testing.T, d frameDecoder) {
+				t.Helper()
+				_, ok := d.(*opusFrameDecoder)
+				assert.True(t, ok, "want opusFrameDecoder")
+			},
+		},
+		{
+			name:  "mp3 decoder",
+			codec: audiostream.CodecMP3{},
+			verify: func(t *testing.T, d frameDecoder) {
+				t.Helper()
+				_, ok := d.(*mp3FrameDecoder)
+				assert.True(t, ok, "want mp3FrameDecoder")
+			},
+		},
+		{
+			name:  "aac-lc decoder learns geometry from asc",
+			codec: audiostream.CodecAAC{AudioSpecificConfig: ascAACLC48kMono},
+			verify: func(t *testing.T, d frameDecoder) {
+				t.Helper()
+				ad, ok := d.(*aacFrameDecoder)
+				require.True(t, ok, "want aacFrameDecoder")
+				assert.Equal(t, 48000, ad.dec.SampleRate())
+				assert.Equal(t, 1, ad.dec.Channels())
+			},
+		},
+		{
+			name:    "aac main profile is unsupported",
+			codec:   audiostream.CodecAAC{AudioSpecificConfig: ascAACMain48kMono},
+			wantErr: ErrUnsupportedCodec,
+		},
+		{
+			name:    "flac is unsupported",
+			codec:   audiostream.CodecFLAC{},
+			wantErr: ErrUnsupportedCodec,
+		},
+		{
+			name:    "unknown codec is unsupported",
+			codec:   audiostream.CodecUnknown{},
+			wantErr: ErrUnsupportedCodec,
+		},
+		{
+			name:    "latm without resolved config is pending, not terminal",
+			codec:   audiostream.CodecMP4ALATM{},
+			wantErr: errCodecConfigPending,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, err := newFrameDecoder(tt.codec, tt.format)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, d)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, d)
+			if tt.verify != nil {
+				tt.verify(t, d)
+			}
+		})
+	}
+}
+
+func TestPassthroughDecoder_returnsInputAndGeometry(t *testing.T) {
+	d := &passthroughDecoder{sampleRate: 48000, channels: 1}
+	in := []byte{1, 2, 3, 4}
+	pcm, rate, ch, err := d.decodeFrame(in)
+	require.NoError(t, err)
+	assert.Equal(t, in, pcm)
+	assert.Equal(t, 48000, rate)
+	assert.Equal(t, 1, ch)
+}
+
+func TestFloat32ToS16LE_scalesRoundsAndClamps(t *testing.T) {
+	dst := make([]byte, 4*2)
+	float32ToS16LE(dst, []float32{0, 1.0, -1.0, 2.0})
+	got := []int16{
+		int16(binary.LittleEndian.Uint16(dst[0:])),
+		int16(binary.LittleEndian.Uint16(dst[2:])),
+		int16(binary.LittleEndian.Uint16(dst[4:])),
+		int16(binary.LittleEndian.Uint16(dst[6:])),
+	}
+	assert.Equal(t, int16(0), got[0], "silence")
+	assert.Equal(t, int16(32767), got[1], "full-scale positive")
+	assert.Equal(t, int16(-32767), got[2], "full-scale negative")
+	assert.Equal(t, int16(32767), got[3], "clamps above +1.0")
+}

--- a/internal/audiocore/stream/doc.go
+++ b/internal/audiocore/stream/doc.go
@@ -1,0 +1,37 @@
+// Package stream is the pure-Go network stream ingest producer. It
+// implements audiocore.StreamManager on top of github.com/tphakala/go-audio-stream,
+// so the audio engine drives it through the same seam as the FFmpeg producer,
+// selected at construction by the BIRDNET_STREAM_INGEST=native gate
+// (conf.NativeStreamIngestEnabled). Phase 2 handles RTSP only; other source
+// types hard-fail with ErrUnsupportedType.
+//
+// # Responsibilities
+//
+// The library owns transport, depacketization, reconnect, and backoff. This
+// package owns policy: which track to set up, the audio-only fallback, decoding
+// each depacketized frame (AAC via go-aac, Opus via go-opus, MP3 via go-mp3,
+// PCM kinds passed through), downmixing to mono, resampling to the analysis
+// sample rate, chunking, and dispatching audiocore.AudioFrames into the router.
+// It also maps the supervisor's connection lifecycle onto the neutral
+// audiocore.StreamHealth model and coordinates with the liveness watchdog so an
+// ordinary supervised reconnect never triggers a full source teardown.
+//
+// # Goroutine model
+//
+// Each source wraps one github.com/tphakala/go-audio-stream/supervisor.Supervisor,
+// which runs a single supervising goroutine that connects, delivers, and
+// reconnects. Frame delivery, decode, shape, and dispatch all run inline on the
+// supervisor's reader goroutine inside the OnFrame callback; that callback must
+// not block, and router.Dispatch never does. State transitions arrive on the
+// same supervisor goroutine through OnState. The Manager owns a map of sourceID
+// to *stream guarded by a mutex; Shutdown closes every supervisor and waits.
+//
+// # Buffer contract
+//
+// The audiostream.Frame handed to OnFrame owns its Data only for the duration of
+// the call, so retained audio is copied. Each dispatched audiocore.AudioFrame
+// owns its own pooled slice drawn from the buffer.Manager byte pool, carried by
+// a FrameRef whose release returns the slice to the pool; a dispatched chunk is
+// never a sub-slice of a shared buffer. The producer releases its own reference
+// after onFrame returns, mirroring the FFmpeg producer.
+package stream

--- a/internal/audiocore/stream/doc.go
+++ b/internal/audiocore/stream/doc.go
@@ -13,8 +13,10 @@
 // PCM kinds passed through), downmixing to mono, resampling to the analysis
 // sample rate, chunking, and dispatching audiocore.AudioFrames into the router.
 // It also maps the supervisor's connection lifecycle onto the neutral
-// audiocore.StreamHealth model and coordinates with the liveness watchdog so an
-// ordinary supervised reconnect never triggers a full source teardown.
+// audiocore.StreamHealth model, including a RecoveryState that a liveness
+// watchdog can consult. The watchdog-side coordination that lets an ordinary
+// supervised reconnect avoid a full source teardown is a planned follow-up; it
+// is not wired yet.
 //
 // # Goroutine model
 //

--- a/internal/audiocore/stream/errors.go
+++ b/internal/audiocore/stream/errors.go
@@ -4,8 +4,9 @@ import "github.com/tphakala/birdnet-go/internal/errors"
 
 // Sentinel errors for the native ingest path. They are terminal (non-retryable)
 // causes: the Retryable policy in stream.go marks them so the supervisor stops
-// rather than reconnecting into the same failure, and the liveness watchdog sees
-// RecoveryGivenUp and escalates once.
+// rather than reconnecting into the same failure, and the health snapshot then
+// reports RecoveryGivenUp (which a liveness watchdog can consult once the
+// watchdog-side coordination lands; it is not wired yet).
 
 // ErrNoAudioTrack is returned when a negotiated session exposes no decodable
 // audio track. A fresh connection will not grow one, so it is terminal. It maps

--- a/internal/audiocore/stream/errors.go
+++ b/internal/audiocore/stream/errors.go
@@ -1,0 +1,32 @@
+package stream
+
+import "github.com/tphakala/birdnet-go/internal/errors"
+
+// Sentinel errors for the native ingest path. They are terminal (non-retryable)
+// causes: the Retryable policy in stream.go marks them so the supervisor stops
+// rather than reconnecting into the same failure, and the liveness watchdog sees
+// RecoveryGivenUp and escalates once.
+
+// ErrNoAudioTrack is returned when a negotiated session exposes no decodable
+// audio track. A fresh connection will not grow one, so it is terminal. It maps
+// to the "no_audio_stream" error type and replaces FFmpeg's silent stall.
+var ErrNoAudioTrack = errors.Newf("stream has no supported audio track").
+	Component("native-stream").Category(errors.CategoryAudioSource).Build()
+
+// ErrUnsupportedCodec is returned when a track's codec cannot be decoded by the
+// native path (FLAC over RTP, HE-AAC/SBR/PS, or an opaque payload). It maps to
+// "unsupported_codec" with the codec named, and is terminal.
+var ErrUnsupportedCodec = errors.Newf("stream codec is not supported by native ingest").
+	Component("native-stream").Category(errors.CategoryAudioSource).Build()
+
+// ErrUnsupportedType is returned by StartStream for a SourceType the native
+// manager does not implement in this phase. RTSP is the only type native ingest
+// handles in Phase 2; hls, http, udp, and rtmp hard-fail here.
+var ErrUnsupportedType = errors.Newf("source type is not supported by native ingest").
+	Component("native-stream").Category(errors.CategoryValidation).Build()
+
+// ErrUDPCodecUnspecified is returned when a udp:// or rtp:// source carries a
+// dynamic RTP payload type with no codec description to interpret it. UDP ingest
+// arrives in Phase 3; this sentinel reserves the failure mode.
+var ErrUDPCodecUnspecified = errors.Newf("udp stream needs an explicit codec description").
+	Component("native-stream").Category(errors.CategoryConfiguration).Build()

--- a/internal/audiocore/stream/health.go
+++ b/internal/audiocore/stream/health.go
@@ -1,0 +1,157 @@
+package stream
+
+import (
+	"crypto/x509"
+	"fmt"
+	"net"
+	"time"
+
+	audiostream "github.com/tphakala/go-audio-stream"
+	"github.com/tphakala/go-audio-stream/rtsp"
+	"github.com/tphakala/go-audio-stream/supervisor"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+	"github.com/tphakala/birdnet-go/internal/errors"
+)
+
+// Legacy process_state sub-state names carried in StreamHealth.StateDetail so the
+// health API and frontend keep switching on the same strings the FFmpeg producer
+// emitted. The frontend already styles each of these.
+const (
+	detailStarting   = "starting"
+	detailRunning    = "running"
+	detailRestarting = "restarting"
+	detailBackoff    = "backoff"
+	detailStopped    = "stopped"
+	detailFailed     = "failed"
+)
+
+// Error type tags mirror the FFmpeg stderr classifier so the health API and any
+// error-type searches keep working across the producer switch. The tags that
+// have a shared audiocore.ErrType* constant reference it directly, so the two
+// producers cannot drift on those values; the rest are native-specific vocabulary
+// with no FFmpeg equivalent.
+const (
+	errTypeNoAudioStream        = "no_audio_stream"
+	errTypeUnsupportedCodec     = "unsupported_codec"
+	errTypeAuthFailed           = audiocore.ErrTypeAuthFailed
+	errTypeReadTimeout          = "read_timeout"
+	errTypeConnectionTimeout    = audiocore.ErrTypeConnectionTimeout
+	errTypeConnectionReset      = "connection_reset"
+	errTypeConnectionRefused    = audiocore.ErrTypeConnectionRefused
+	errTypeRedirect             = "redirect"
+	errTypeTLSVerifyFailed      = "tls_verify_failed"
+	errTypeUDPTransportRejected = "udp_transport_rejected"
+	errTypeInvalidURL           = "invalid_url"
+	errTypeStreamError          = "stream_error"
+)
+
+// mapState maps a supervisor lifecycle transition onto the neutral connection
+// model: the StreamState, the legacy process_state detail string, and the
+// RecoveryState the liveness watchdog consults. FFmpeg never reports these
+// values, so under the ffmpeg gate the watchdog keeps its legacy behaviour.
+func mapState(sc supervisor.StateChange) (state audiocore.StreamState, detail string, recovery audiocore.RecoveryState) {
+	switch sc.State {
+	case supervisor.StateConnecting:
+		if sc.Attempt > 0 {
+			return audiocore.StreamStateReconnecting, detailRestarting, audiocore.RecoveryInProgress
+		}
+		return audiocore.StreamStateStarting, detailStarting, audiocore.RecoveryInProgress
+	case supervisor.StateConnected:
+		return audiocore.StreamStateConnected, detailRunning, audiocore.RecoveryIdle
+	case supervisor.StateReconnecting:
+		return audiocore.StreamStateReconnecting, detailBackoff, audiocore.RecoveryInProgress
+	case supervisor.StateClosed:
+		return audiocore.StreamStateStopped, detailStopped, audiocore.RecoveryUnknown
+	case supervisor.StateFailed:
+		return audiocore.StreamStateFailed, detailFailed, audiocore.RecoveryGivenUp
+	default:
+		return audiocore.StreamStateStarting, detailStarting, audiocore.RecoveryUnknown
+	}
+}
+
+// classifyError maps a typed session-ending error to a producer-neutral
+// StreamErrorContext, the native counterpart of the FFmpeg stderr classifier. It
+// returns nil for a nil error. host and port are the parsed target with any
+// userinfo already stripped by the caller.
+func classifyError(err error, host string, port int) *audiocore.StreamErrorContext {
+	if err == nil {
+		return nil
+	}
+	ctx := &audiocore.StreamErrorContext{
+		PrimaryMessage: err.Error(),
+		TargetHost:     host,
+		TargetPort:     port,
+		Timestamp:      time.Now(),
+	}
+	classifyInto(ctx, err)
+	if ctx.UserFacingMsg == "" {
+		ctx.UserFacingMsg = "The audio stream connection failed."
+	}
+	return ctx
+}
+
+// classifyInto fills ErrorType, HTTPStatus, and the user-facing text on ctx from
+// the concrete error. The order matters: the most specific typed errors are
+// tested before the broad sentinels.
+func classifyInto(ctx *audiocore.StreamErrorContext, err error) {
+	var respErr *rtsp.ResponseError
+	var unauthErr *rtsp.UnauthorizedError
+	var redirectErr *audiostream.RedirectError
+	var certErr *x509.CertificateInvalidError
+	var authorityErr x509.UnknownAuthorityError
+	var netErr net.Error
+	isNetTimeout := errors.As(err, &netErr) && netErr.Timeout()
+
+	switch {
+	case errors.Is(err, ErrNoAudioTrack):
+		ctx.ErrorType = errTypeNoAudioStream
+		ctx.UserFacingMsg = "The stream has no supported audio track."
+		ctx.TroubleShooting = []string{"Confirm the camera or restreamer publishes an audio track.", "Check that the audio codec is AAC-LC, Opus, G.711, or L16."}
+	case errors.Is(err, ErrUnsupportedCodec):
+		ctx.ErrorType = errTypeUnsupportedCodec
+		ctx.UserFacingMsg = "The stream uses an audio codec native ingest cannot decode."
+		ctx.TroubleShooting = []string{"Reconfigure the source to AAC-LC, Opus, G.711, or L16.", "Or unset BIRDNET_STREAM_INGEST to fall back to FFmpeg."}
+	case errors.Is(err, rtsp.ErrAuthFailed), errors.Is(err, rtsp.ErrUnauthorized), errors.As(err, &unauthErr):
+		ctx.ErrorType = errTypeAuthFailed
+		ctx.UserFacingMsg = "Authentication with the stream failed."
+		ctx.TroubleShooting = []string{"Check the username and password in the stream URL."}
+	case errors.As(err, &respErr):
+		ctx.ErrorType = fmt.Sprintf("rtsp_%d", respErr.Code)
+		ctx.HTTPStatus = respErr.Code
+		ctx.UserFacingMsg = fmt.Sprintf("The stream server returned %d %s.", respErr.Code, respErr.Reason)
+	case errors.As(err, &redirectErr):
+		ctx.ErrorType = errTypeRedirect
+		ctx.UserFacingMsg = "The stream server issued a redirect."
+	case errors.Is(err, rtsp.ErrUDPSetupRejected):
+		ctx.ErrorType = errTypeUDPTransportRejected
+		ctx.UserFacingMsg = "The server rejected the UDP transport."
+	case errors.Is(err, audiostream.ErrReadTimeout):
+		ctx.ErrorType = errTypeReadTimeout
+		ctx.UserFacingMsg = "The stream stopped sending data."
+	case errors.Is(err, rtsp.ErrRequestTimeout), isNetTimeout:
+		ctx.ErrorType = errTypeConnectionTimeout
+		ctx.UserFacingMsg = "The connection to the stream timed out."
+	case errors.As(err, &certErr), errors.As(err, &authorityErr):
+		ctx.ErrorType = errTypeTLSVerifyFailed
+		ctx.UserFacingMsg = "The stream's TLS certificate could not be verified."
+	case errors.Is(err, rtsp.ErrServerTeardown), errors.Is(err, rtsp.ErrConnectionClosed):
+		ctx.ErrorType = classifyConnClosed(err)
+		ctx.UserFacingMsg = "The stream connection was closed."
+	case errors.Is(err, rtsp.ErrInvalidURL):
+		ctx.ErrorType = errTypeInvalidURL
+		ctx.UserFacingMsg = "The stream URL is not valid."
+	default:
+		ctx.ErrorType = errTypeStreamError
+	}
+}
+
+// classifyConnClosed distinguishes a refused connection from a reset one by the
+// wrapped syscall, defaulting to reset.
+func classifyConnClosed(err error) string {
+	var opErr *net.OpError
+	if errors.As(err, &opErr) && opErr.Op == "dial" {
+		return errTypeConnectionRefused
+	}
+	return errTypeConnectionReset
+}

--- a/internal/audiocore/stream/health_test.go
+++ b/internal/audiocore/stream/health_test.go
@@ -1,0 +1,131 @@
+package stream
+
+import (
+	"crypto/x509"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	audiostream "github.com/tphakala/go-audio-stream"
+	"github.com/tphakala/go-audio-stream/rtsp"
+	"github.com/tphakala/go-audio-stream/supervisor"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+)
+
+func TestMapState(t *testing.T) {
+	tests := []struct {
+		name         string
+		sc           supervisor.StateChange
+		wantState    audiocore.StreamState
+		wantDetail   string
+		wantRecovery audiocore.RecoveryState
+	}{
+		{
+			name:         "first connect is starting",
+			sc:           supervisor.StateChange{State: supervisor.StateConnecting, Attempt: 0},
+			wantState:    audiocore.StreamStateStarting,
+			wantDetail:   detailStarting,
+			wantRecovery: audiocore.RecoveryInProgress,
+		},
+		{
+			name:         "reconnect attempt is restarting",
+			sc:           supervisor.StateChange{State: supervisor.StateConnecting, Attempt: 2},
+			wantState:    audiocore.StreamStateReconnecting,
+			wantDetail:   detailRestarting,
+			wantRecovery: audiocore.RecoveryInProgress,
+		},
+		{
+			name:         "connected is running and idle",
+			sc:           supervisor.StateChange{State: supervisor.StateConnected},
+			wantState:    audiocore.StreamStateConnected,
+			wantDetail:   detailRunning,
+			wantRecovery: audiocore.RecoveryIdle,
+		},
+		{
+			name:         "reconnecting is backoff and in-progress",
+			sc:           supervisor.StateChange{State: supervisor.StateReconnecting, Attempt: 1},
+			wantState:    audiocore.StreamStateReconnecting,
+			wantDetail:   detailBackoff,
+			wantRecovery: audiocore.RecoveryInProgress,
+		},
+		{
+			name:         "closed is stopped and unknown",
+			sc:           supervisor.StateChange{State: supervisor.StateClosed},
+			wantState:    audiocore.StreamStateStopped,
+			wantDetail:   detailStopped,
+			wantRecovery: audiocore.RecoveryUnknown,
+		},
+		{
+			name:         "failed is failed and given-up",
+			sc:           supervisor.StateChange{State: supervisor.StateFailed},
+			wantState:    audiocore.StreamStateFailed,
+			wantDetail:   detailFailed,
+			wantRecovery: audiocore.RecoveryGivenUp,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state, detail, recovery := mapState(tt.sc)
+			assert.Equal(t, tt.wantState, state, "state")
+			assert.Equal(t, tt.wantDetail, detail, "detail")
+			assert.Equal(t, tt.wantRecovery, recovery, "recovery")
+		})
+	}
+}
+
+func TestClassifyError(t *testing.T) {
+	const host, port = "cam.local", 554
+
+	t.Run("nil error yields nil context", func(t *testing.T) {
+		assert.Nil(t, classifyError(nil, host, port))
+	})
+
+	tests := []struct {
+		name     string
+		err      error
+		wantType string
+		wantHTTP int
+	}{
+		{name: "no audio track", err: fmt.Errorf("setup: %w", ErrNoAudioTrack), wantType: errTypeNoAudioStream},
+		{name: "unsupported codec", err: fmt.Errorf("decode: %w", ErrUnsupportedCodec), wantType: errTypeUnsupportedCodec},
+		{name: "rtsp auth", err: fmt.Errorf("describe: %w", rtsp.ErrAuthFailed), wantType: errTypeAuthFailed},
+		{name: "read timeout", err: fmt.Errorf("wait: %w", audiostream.ErrReadTimeout), wantType: errTypeReadTimeout},
+		{name: "udp rejected", err: fmt.Errorf("setup: %w", rtsp.ErrUDPSetupRejected), wantType: errTypeUDPTransportRejected},
+		{name: "rtsp 404 response", err: fmt.Errorf("describe: %w", &rtsp.ResponseError{Code: 404, Reason: "Not Found"}), wantType: "rtsp_404", wantHTTP: 404},
+		{name: "redirect", err: fmt.Errorf("describe: %w", &audiostream.RedirectError{Location: "rtsp://other.host/s"}), wantType: errTypeRedirect},
+		{name: "request timeout", err: fmt.Errorf("dial: %w", rtsp.ErrRequestTimeout), wantType: errTypeConnectionTimeout},
+		{name: "tls verify failed", err: fmt.Errorf("tls: %w", x509.UnknownAuthorityError{}), wantType: errTypeTLSVerifyFailed},
+		{name: "invalid url", err: fmt.Errorf("dial: %w", rtsp.ErrInvalidURL), wantType: errTypeInvalidURL},
+		{name: "connection closed maps to reset", err: fmt.Errorf("wait: %w", rtsp.ErrConnectionClosed), wantType: errTypeConnectionReset},
+		{name: "server teardown maps to reset", err: fmt.Errorf("wait: %w", rtsp.ErrServerTeardown), wantType: errTypeConnectionReset},
+		{name: "generic error", err: fmt.Errorf("something broke"), wantType: errTypeStreamError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := classifyError(tt.err, host, port)
+			require.NotNil(t, ctx)
+			assert.Equal(t, tt.wantType, ctx.ErrorType)
+			assert.Equal(t, host, ctx.TargetHost)
+			assert.Equal(t, port, ctx.TargetPort)
+			assert.NotEmpty(t, ctx.UserFacingMsg)
+			assert.False(t, ctx.Timestamp.IsZero())
+			if tt.wantHTTP != 0 {
+				assert.Equal(t, tt.wantHTTP, ctx.HTTPStatus)
+			}
+		})
+	}
+}
+
+func TestClassifyConnClosed(t *testing.T) {
+	// A dial-phase net.OpError means the peer refused the connection.
+	dialErr := &net.OpError{Op: "dial", Err: fmt.Errorf("connection refused")}
+	assert.Equal(t, errTypeConnectionRefused, classifyConnClosed(dialErr), "dial OpError is a refusal")
+
+	// A read/teardown with no dial OpError is a reset.
+	assert.Equal(t, errTypeConnectionReset, classifyConnClosed(fmt.Errorf("peer went away")), "non-dial close is a reset")
+	readErr := &net.OpError{Op: "read", Err: fmt.Errorf("reset by peer")}
+	assert.Equal(t, errTypeConnectionReset, classifyConnClosed(readErr), "read OpError is a reset")
+}

--- a/internal/audiocore/stream/manager.go
+++ b/internal/audiocore/stream/manager.go
@@ -1,0 +1,226 @@
+package stream
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+	"github.com/tphakala/birdnet-go/internal/audiocore/buffer"
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// shutdownTimeout bounds the default Shutdown of every stream.
+const shutdownTimeout = 10 * time.Second
+
+// errManagerShutDown is the cause recorded when the manager context is cancelled.
+var errManagerShutDown = errors.Newf("native stream manager shut down").
+	Component("native-stream").Category(errors.CategoryState).Build()
+
+// Manager is the pure-Go network stream producer. It implements
+// audiocore.StreamManager on top of go-audio-stream supervisors, so the engine
+// drives it through the same seam as ffmpeg.Manager. Phase 2 handles RTSP only;
+// every other source type hard-fails from StartStream.
+type Manager struct {
+	ctx    context.Context
+	cancel context.CancelCauseFunc
+
+	deliver dispatchFunc
+	log     logger.Logger
+	bufMgr  *buffer.Manager
+	opts    Options
+
+	onResetMu sync.RWMutex
+	onReset   func(sourceID string)
+
+	mu      sync.RWMutex
+	streams map[string]*stream
+
+	closeOnce sync.Once
+}
+
+// Manager implements the producer-neutral seam.
+var _ audiocore.StreamManager = (*Manager)(nil)
+
+// NewManager creates a native stream Manager. onFrame receives every dispatched
+// AudioFrame (the engine forwards it to the router); onReset fires once when a
+// stream is (re)started; bufMgr, when non-nil, pools dispatched chunks. opts may be nil
+// for all defaults; it is copied and defaulted, so the caller's value is not
+// mutated. The manager starts no work until StartStream is called.
+func NewManager(ctx context.Context, onFrame dispatchFunc, onReset func(sourceID string), log logger.Logger, bufMgr *buffer.Manager, opts *Options) *Manager {
+	if log == nil {
+		log = audiocore.GetLogger()
+	}
+	if onFrame == nil {
+		// Defense-in-depth for external callers: the engine always supplies a
+		// delivery callback, but a nil one would panic on the first frame.
+		onFrame = func(audiocore.AudioFrame) {}
+	}
+	resolved := Options{}
+	if opts != nil {
+		resolved = *opts
+	}
+	resolved.applyDefaults()
+
+	mgrCtx, cancel := context.WithCancelCause(ctx)
+	return &Manager{
+		ctx:     mgrCtx,
+		cancel:  cancel,
+		deliver: onFrame,
+		onReset: onReset,
+		log:     log.With(logger.String("component", "native-stream")),
+		bufMgr:  bufMgr,
+		opts:    resolved,
+		streams: make(map[string]*stream),
+	}
+}
+
+// StartStream begins capturing spec.SourceID. RTSP is the only supported type in
+// this phase; any other returns ErrUnsupportedType. A duplicate ID errors.
+func (m *Manager) StartStream(spec *audiocore.StreamSpec) error {
+	if spec == nil {
+		return errors.Newf("nil stream spec").Component("native-stream").Category(errors.CategoryValidation).Build()
+	}
+	if spec.SourceID == "" {
+		return errors.Newf("stream spec has an empty source ID").
+			Component("native-stream").Category(errors.CategoryValidation).Build()
+	}
+	if spec.Type != audiocore.SourceTypeRTSP {
+		return fmt.Errorf("%w: %s", ErrUnsupportedType, spec.Type)
+	}
+
+	m.mu.Lock()
+	if err := context.Cause(m.ctx); err != nil {
+		m.mu.Unlock()
+		return fmt.Errorf("start stream %s: %w", spec.SourceID, err)
+	}
+	if _, exists := m.streams[spec.SourceID]; exists {
+		m.mu.Unlock()
+		return errors.Newf("stream %s is already running", spec.SourceID).
+			Component("native-stream").Category(errors.CategoryConflict).Build()
+	}
+	s := newStream(spec, &m.opts, m.deliver, m.bufMgr, m.log)
+	m.streams[spec.SourceID] = s
+	m.mu.Unlock()
+
+	// Fire onReset once at (re)start, matching the FFmpeg producer and the shared
+	// contract's caseOnResetFires. Fire outside the lock so the callback cannot
+	// deadlock against a manager method.
+	m.fireReset(spec.SourceID)
+	m.log.Info("started native stream",
+		logger.String("source_id", spec.SourceID),
+		logger.String("ingest_engine", "native"),
+		logger.String("operation", "start_stream"))
+	return nil
+}
+
+// StopStream stops capture for sourceID and forgets it. An unknown ID errors and
+// reports the active count.
+func (m *Manager) StopStream(sourceID string) error {
+	m.mu.Lock()
+	s, ok := m.streams[sourceID]
+	if !ok {
+		active := len(m.streams)
+		m.mu.Unlock()
+		return errors.Newf("stream %s not found (%d active)", sourceID, active).
+			Component("native-stream").Category(errors.CategoryNotFound).Build()
+	}
+	delete(m.streams, sourceID)
+	m.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+	s.close(ctx)
+	m.log.Info("stopped native stream",
+		logger.String("source_id", sourceID),
+		logger.String("ingest_engine", "native"),
+		logger.String("operation", "stop_stream"))
+	return nil
+}
+
+// StreamHealth returns a point-in-time snapshot for one stream.
+func (m *Manager) StreamHealth(sourceID string) (*audiocore.StreamHealth, error) {
+	m.mu.RLock()
+	s, ok := m.streams[sourceID]
+	m.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("native stream health: %w: %s", audiocore.ErrSourceNotFound, sourceID)
+	}
+	return s.snapshot(), nil
+}
+
+// AllStreamHealth returns snapshots for every tracked stream, keyed by ID.
+func (m *Manager) AllStreamHealth() map[string]*audiocore.StreamHealth {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make(map[string]*audiocore.StreamHealth, len(m.streams))
+	for id, s := range m.streams {
+		out[id] = s.snapshot()
+	}
+	return out
+}
+
+// GetActiveStreamIDs lists the currently tracked source IDs.
+func (m *Manager) GetActiveStreamIDs() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return slices.Collect(maps.Keys(m.streams))
+}
+
+// SetOnStreamReset registers the callback invoked after a stream starts or is
+// fully reset. It applies to existing streams too, which invoke it indirectly
+// through fireReset.
+func (m *Manager) SetOnStreamReset(fn func(sourceID string)) {
+	m.onResetMu.Lock()
+	m.onReset = fn
+	m.onResetMu.Unlock()
+}
+
+// Shutdown stops every stream with the manager's default timeout.
+func (m *Manager) Shutdown() error {
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+	return m.ShutdownWithContext(ctx)
+}
+
+// ShutdownWithContext stops every stream honouring ctx.
+func (m *Manager) ShutdownWithContext(ctx context.Context) error {
+	m.closeOnce.Do(func() {
+		m.mu.Lock()
+		// Cancel under the lock BEFORE releasing it, so a StartStream that races
+		// this shutdown either ran fully before the swap (and its stream is in
+		// the captured set) or observes the cancelled context and is refused.
+		// Cancelling after wg.Wait() would let such a StartStream store a stream
+		// into the fresh map that shutdown never closes, leaking its goroutines.
+		m.cancel(errManagerShutDown)
+		streams := m.streams
+		m.streams = make(map[string]*stream)
+		m.mu.Unlock()
+
+		var wg sync.WaitGroup
+		for _, s := range streams {
+			wg.Add(1)
+			go func(s *stream) {
+				defer wg.Done()
+				s.close(ctx)
+			}(s)
+		}
+		wg.Wait()
+	})
+	return nil
+}
+
+// fireReset invokes the current reset callback, read under lock so
+// SetOnStreamReset reaches streams started earlier.
+func (m *Manager) fireReset(sourceID string) {
+	m.onResetMu.RLock()
+	fn := m.onReset
+	m.onResetMu.RUnlock()
+	if fn != nil {
+		fn(sourceID)
+	}
+}

--- a/internal/audiocore/stream/manager_contract_test.go
+++ b/internal/audiocore/stream/manager_contract_test.go
@@ -1,0 +1,150 @@
+//go:build integration
+
+package stream_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+	"github.com/tphakala/birdnet-go/internal/audiocore/stream"
+	"github.com/tphakala/birdnet-go/internal/audiocore/streamtest"
+	"github.com/tphakala/birdnet-go/internal/testutil/containers"
+)
+
+// nativeManagerAdapter adapts *stream.Manager to the producer-agnostic
+// streamtest.Manager contract, so the same Phase-0 characterization suite that
+// pins the FFmpeg producer's behaviour also runs against the native producer.
+type nativeManagerAdapter struct{ mgr *stream.Manager }
+
+func (a *nativeManagerAdapter) StartStream(spec *streamtest.StreamSpec) error {
+	return a.mgr.StartStream(&audiocore.StreamSpec{
+		URL:                  spec.URL,
+		SourceID:             spec.SourceID,
+		SourceName:           spec.SourceName,
+		Type:                 audiocore.SourceType(spec.Type),
+		SampleRate:           spec.SampleRate,
+		SourceSampleRate:     spec.SourceSampleRate,
+		BitDepth:             spec.BitDepth,
+		Channels:             spec.Channels,
+		SourceChannels:       spec.SourceChannels,
+		ChannelMode:          spec.ChannelMode,
+		MediaMode:            spec.MediaMode,
+		Transport:            spec.Transport,
+		HealthyDataThreshold: spec.HealthyDataThreshold,
+		Debug:                spec.Debug,
+	})
+}
+
+func (a *nativeManagerAdapter) StopStream(sourceID string) error { return a.mgr.StopStream(sourceID) }
+
+func (a *nativeManagerAdapter) StreamHealth(sourceID string) (streamtest.Health, error) {
+	h, err := a.mgr.StreamHealth(sourceID)
+	if err != nil {
+		return nil, err
+	}
+	return nativeHealth{h: h}, nil
+}
+
+func (a *nativeManagerAdapter) AllStreamHealth() map[string]streamtest.Health {
+	src := a.mgr.AllStreamHealth()
+	out := make(map[string]streamtest.Health, len(src))
+	for id, h := range src {
+		out[id] = nativeHealth{h: h}
+	}
+	return out
+}
+
+func (a *nativeManagerAdapter) GetActiveStreamIDs() []string { return a.mgr.GetActiveStreamIDs() }
+
+func (a *nativeManagerAdapter) SetOnStreamReset(fn func(sourceID string)) {
+	a.mgr.SetOnStreamReset(fn)
+}
+
+func (a *nativeManagerAdapter) Shutdown() error { return a.mgr.Shutdown() }
+
+func (a *nativeManagerAdapter) ShutdownWithContext(ctx context.Context) error {
+	return a.mgr.ShutdownWithContext(ctx)
+}
+
+// nativeHealth adapts *audiocore.StreamHealth to streamtest.Health.
+type nativeHealth struct{ h *audiocore.StreamHealth }
+
+func (f nativeHealth) IsHealthy() bool           { return f.h.IsHealthy }
+func (f nativeHealth) IsReceivingData() bool     { return f.h.IsReceivingData }
+func (f nativeHealth) RestartCount() int         { return f.h.RestartCount }
+func (f nativeHealth) TotalBytesReceived() int64 { return f.h.TotalBytesReceived }
+func (f nativeHealth) BytesPerSecond() float64   { return f.h.BytesPerSecond }
+func (f nativeHealth) LastDataReceived() time.Time {
+	return f.h.LastDataReceived
+}
+func (f nativeHealth) SourceChannels() int  { return f.h.SourceChannels }
+func (f nativeHealth) ProcessState() string { return f.h.ProcessStateName() }
+func (f nativeHealth) StateHistoryLen() int { return len(f.h.StateHistory) }
+
+func (f nativeHealth) ErrorType() string {
+	if f.h.LastErrorContext != nil {
+		return f.h.LastErrorContext.ErrorType
+	}
+	return ""
+}
+
+// nativeProcessStates are the legacy process_state strings the native producer
+// can report (a subset of the FFmpeg set: it has no idle/circuit_open because it
+// runs no subprocess and no circuit breaker). The frontend must render each.
+var nativeProcessStates = []string{
+	"starting", "running", "restarting", "backoff", "stopped", "failed",
+}
+
+// TestNativeManagerContract runs the Phase-0 characterization suite against the
+// native go-audio-stream ingest path, using a MediaMTX container as the media
+// server, proving the native producer matches the FFmpeg baseline at the manager
+// seam (frame shape, PCM fidelity across codecs, data rate, lifecycle, health
+// transitions, silence restart, reconnect, media modes, multi-stream, error
+// clarity, time to first frame).
+func TestNativeManagerContract(t *testing.T) {
+	containers.SkipIfContainerRuntimeUnavailable(t)
+
+	server, err := containers.NewMediaMTXContainer(t.Context(), nil)
+	require.NoError(t, err, "MediaMTX container should start")
+	t.Cleanup(func() {
+		//nolint:gocritic // t.Context() is already cancelled when Cleanup runs; Terminate needs a live context
+		assert.NoError(t, server.Terminate(context.Background()), "MediaMTX container should terminate cleanly")
+	})
+
+	fixture := streamtest.NewMediaMTXFixture(t, server)
+
+	factory := func(t *testing.T, fc streamtest.FactoryConfig) streamtest.Manager {
+		t.Helper()
+		opts := &stream.Options{}
+		if fc.SilenceTimeout > 0 {
+			// The suite drives the silence watchdog through SilenceTimeout; on the
+			// native path the supervisor's read-idle window is the equivalent knob.
+			opts.ReadIdle = fc.SilenceTimeout
+		}
+		mgr := stream.NewManager(t.Context(), fc.OnFrame, fc.OnReset, nil, fc.BufferManager, opts)
+		return &nativeManagerAdapter{mgr: mgr}
+	}
+
+	streamtest.RunManagerContract(t, &streamtest.ContractConfig{
+		Factory: factory,
+		Fixture: fixture,
+		Codecs: []streamtest.Codec{
+			streamtest.CodecPCMU,
+			streamtest.CodecPCMA,
+			streamtest.CodecAAC,
+			streamtest.CodecOpus,
+			streamtest.CodecL16,
+		},
+		ValidProcessStates: nativeProcessStates,
+		TargetSampleRate:   48000,
+		ProducerName:       "native",
+	})
+}
+
+// compile-time guard: the adapter satisfies the contract manager interface.
+var _ streamtest.Manager = (*nativeManagerAdapter)(nil)

--- a/internal/audiocore/stream/manager_test.go
+++ b/internal/audiocore/stream/manager_test.go
@@ -1,0 +1,103 @@
+package stream
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+)
+
+// unreachableRTSP points at a closed local port so the supervisor fails to
+// connect and backs off, exercising the lifecycle without a live server.
+const unreachableRTSP = "rtsp://127.0.0.1:1/none"
+
+func rtspSpec(id string) *audiocore.StreamSpec {
+	return &audiocore.StreamSpec{
+		SourceID:   id,
+		SourceName: id,
+		URL:        unreachableRTSP,
+		Type:       audiocore.SourceTypeRTSP,
+		SampleRate: 48000,
+		Channels:   1,
+		BitDepth:   16,
+	}
+}
+
+func newTestManager(t *testing.T) *Manager {
+	t.Helper()
+	m := NewManager(t.Context(), func(audiocore.AudioFrame) {}, nil, nil, nil, nil)
+	t.Cleanup(func() { assert.NoError(t, m.Shutdown()) })
+	return m
+}
+
+func TestManager_StartStream_rejectsNonRTSP(t *testing.T) {
+	m := newTestManager(t)
+	err := m.StartStream(&audiocore.StreamSpec{SourceID: "h1", URL: "http://host/stream", Type: audiocore.SourceTypeHTTP})
+	require.ErrorIs(t, err, ErrUnsupportedType)
+	assert.Empty(t, m.GetActiveStreamIDs(), "a rejected stream is not tracked")
+}
+
+func TestManager_StartStream_rejectsDuplicate(t *testing.T) {
+	m := newTestManager(t)
+	require.NoError(t, m.StartStream(rtspSpec("s1")))
+	err := m.StartStream(rtspSpec("s1"))
+	require.Error(t, err, "a duplicate source ID is rejected")
+	assert.Equal(t, []string{"s1"}, m.GetActiveStreamIDs())
+}
+
+func TestManager_StopStream_unknownReportsActiveCount(t *testing.T) {
+	m := newTestManager(t)
+	require.NoError(t, m.StartStream(rtspSpec("s1")))
+	err := m.StopStream("missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "1 active")
+}
+
+func TestManager_StreamHealth_unknownErrors(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.StreamHealth("missing")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, audiocore.ErrSourceNotFound)
+}
+
+func TestManager_lifecycle_tracksHealthAndShutsDownCleanly(t *testing.T) {
+	defer goleak.VerifyNone(t,
+		goleak.IgnoreTopFunction("testing.(*T).Run"),
+		goleak.IgnoreTopFunction("runtime.gopark"),
+	)
+	m := NewManager(t.Context(), func(audiocore.AudioFrame) {}, nil, nil, nil, nil)
+
+	require.NoError(t, m.StartStream(rtspSpec("s1")))
+	require.NoError(t, m.StartStream(rtspSpec("s2")))
+	assert.ElementsMatch(t, []string{"s1", "s2"}, m.GetActiveStreamIDs())
+
+	h, err := m.StreamHealth("s1")
+	require.NoError(t, err)
+	require.NotNil(t, h)
+	assert.Contains(t, []audiocore.StreamState{audiocore.StreamStateStarting, audiocore.StreamStateReconnecting}, h.State)
+
+	all := m.AllStreamHealth()
+	assert.Len(t, all, 2)
+
+	require.NoError(t, m.StopStream("s1"))
+	assert.Equal(t, []string{"s2"}, m.GetActiveStreamIDs())
+
+	require.NoError(t, m.Shutdown())
+	assert.Empty(t, m.GetActiveStreamIDs())
+	// Shutdown is idempotent.
+	require.NoError(t, m.Shutdown())
+}
+
+func TestManager_SetOnStreamReset_firesOnStart(t *testing.T) {
+	m := newTestManager(t)
+	// A callback set after construction must reach a later StartStream, and the
+	// reset must fire once with the started source's ID (synchronously, matching
+	// the FFmpeg producer and the shared contract's caseOnResetFires).
+	var gotID string
+	m.SetOnStreamReset(func(id string) { gotID = id })
+	require.NoError(t, m.StartStream(rtspSpec("s1")))
+	assert.Equal(t, "s1", gotID)
+}

--- a/internal/audiocore/stream/manager_test.go
+++ b/internal/audiocore/stream/manager_test.go
@@ -64,10 +64,11 @@ func TestManager_StreamHealth_unknownErrors(t *testing.T) {
 }
 
 func TestManager_lifecycle_tracksHealthAndShutsDownCleanly(t *testing.T) {
-	defer goleak.VerifyNone(t,
-		goleak.IgnoreTopFunction("testing.(*T).Run"),
-		goleak.IgnoreTopFunction("runtime.gopark"),
-	)
+	// Snapshot the goroutines that exist before the test (deferred args evaluate
+	// now, at the defer statement), so the check flags only NEW goroutines such
+	// as a leaked supervisor or reader, rather than filtering by top-of-stack
+	// function, which can hide a parked leaked goroutine.
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 	m := NewManager(t.Context(), func(audiocore.AudioFrame) {}, nil, nil, nil, nil)
 
 	require.NoError(t, m.StartStream(rtspSpec("s1")))

--- a/internal/audiocore/stream/open_rtsp.go
+++ b/internal/audiocore/stream/open_rtsp.go
@@ -1,0 +1,185 @@
+package stream
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	audiostream "github.com/tphakala/go-audio-stream"
+	"github.com/tphakala/go-audio-stream/rtsp"
+	"github.com/tphakala/go-audio-stream/supervisor"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// rtspDialTimeout bounds the dial and each request round-trip, matching the
+// FFmpeg path's 10 s stimeout.
+const rtspDialTimeout = 10 * time.Second
+
+// rtspFactory returns the supervisor factory for an RTSP source. It dials,
+// discovers and negotiates the audio track (and the video tracks in full-stream
+// mode), resolves the decoder before SETUP begins routing frames, and plays,
+// returning a delivering Client the supervisor drives.
+func (s *stream) rtspFactory() supervisor.Factory {
+	return func(ctx context.Context) (audiostream.Source, error) {
+		// New session: clear the delivered flag before any frame can arrive, so
+		// the audio-only fallback counts only sessions that truly produced no
+		// audio. Doing it here (before SETUP begins routing) rather than on the
+		// StateConnected transition avoids erasing a frame that arrived first.
+		s.deliveredSession.Store(false)
+
+		cfg := rtsp.Config{
+			URL:           s.spec.URL,
+			Timeout:       rtspDialTimeout,
+			ReadIdle:      s.opts.ReadIdle,
+			InsecureTLS:   s.opts.insecureTLS(),
+			Transport:     mapTransport(s.spec.Transport),
+			OnFrame:       s.onFrame,
+			OnCodecUpdate: s.onCodecUpdate,
+		}
+		client, err := rtsp.Dial(ctx, cfg)
+		if err != nil {
+			return nil, err
+		}
+		if negErr := s.negotiate(ctx, client); negErr != nil {
+			// Close signals shutdown but does not drain the reader goroutine;
+			// Wait does. SETUP may already have started routing frames into the
+			// lock-free pipeline, so block until the reader has stopped before
+			// returning, or onFrame could race the supervisor's flush on the
+			// error transition.
+			_ = client.Close()
+			_ = client.Wait(ctx)
+			return nil, negErr
+		}
+		return client, nil
+	}
+}
+
+// negotiate discovers the tracks, resolves the decoder from the audio track's
+// codec BEFORE the first SETUP (routing, and therefore OnFrame, begins at the
+// first successful SETUP), sets the tracks up, and plays.
+func (s *stream) negotiate(ctx context.Context, client *rtsp.Client) error {
+	tracks, err := client.Describe(ctx)
+	if err != nil {
+		return err
+	}
+	audioTrack, ok := selectAudioTrack(tracks)
+	if !ok {
+		return ErrNoAudioTrack
+	}
+	// Build the decoder before SETUP so it is ready before any frame is routed.
+	// A terminal ErrUnsupportedCodec here stops the supervisor via retryable; a
+	// pending in-band config (MP4A-LATM cpresent=1) is not terminal, so proceed
+	// and let OnCodecUpdate install the decoder after PLAY.
+	if setErr := s.pl.setCodec(audioTrack.Codec, audioTrack.Format()); setErr != nil {
+		if !errors.Is(setErr, errCodecConfigPending) {
+			return setErr
+		}
+		s.log.Debug("audio codec config pending in-band resolution",
+			logger.String("source_id", s.spec.SourceID))
+	}
+	if setupErr := client.Setup(ctx, audioTrack, rtsp.SetupOptions{}); setupErr != nil {
+		return setupErr
+	}
+	if s.wantFullStream() {
+		for _, vt := range videoTracks(tracks) {
+			if vErr := client.Setup(ctx, vt, rtsp.SetupOptions{Discard: true}); vErr != nil {
+				s.log.Warn("video SETUP failed in full-stream mode",
+					logger.String("source_id", s.spec.SourceID),
+					logger.Error(vErr))
+			}
+		}
+	}
+	return client.Play(ctx)
+}
+
+// onFrame decodes and dispatches one delivered frame. It runs on the reader
+// goroutine and must not block. A per-frame decode error drops that frame; a
+// codec that cannot be decoded at all was already rejected in negotiate.
+func (s *stream) onFrame(f audiostream.Frame) { //nolint:gocritic // hugeParam: the by-value Frame signature is mandated by rtsp.Config.OnFrame
+	if err := s.pl.process(f.Data); err != nil {
+		s.log.Debug("native ingest dropped a frame",
+			logger.String("source_id", s.spec.SourceID),
+			logger.Error(err))
+	}
+}
+
+// onCodecUpdate rebuilds the decoder when a track's codec configuration is
+// resolved in-band (MP4A-LATM cpresent=1). It runs on the reader goroutine,
+// before the first frame under the new config, so it is serialized with onFrame.
+func (s *stream) onCodecUpdate(u audiostream.CodecUpdate) {
+	format := audiostream.AudioFormat{Codec: u.Codec, Kind: audiostream.PayloadKindFor(u.Codec)}
+	if err := s.pl.setCodec(u.Codec, format); err != nil {
+		s.log.Warn("in-band codec update produced an unsupported decoder",
+			logger.String("source_id", s.spec.SourceID),
+			logger.Error(err))
+	}
+}
+
+// wantFullStream reports whether the video tracks should be set up: either the
+// canonical media mode is full-stream (which an unset mode resolves to, matching
+// the FFmpeg path via conf.MediaMode.Canonical), or the audio-only fallback has
+// latched.
+func (s *stream) wantFullStream() bool {
+	mode := conf.MediaMode(s.spec.MediaMode).Canonical()
+	return mode == conf.MediaModeFullStream || s.fullStreamLatched.Load()
+}
+
+// selectAudioTrack picks the first supported audio track. If audio tracks exist
+// but none is decodable it returns the first one so negotiate surfaces a clear
+// terminal ErrUnsupportedCodec rather than a generic no-audio error.
+func selectAudioTrack(tracks []rtsp.Track) (rtsp.Track, bool) {
+	var firstAudio *rtsp.Track
+	for i := range tracks {
+		if tracks[i].Media != audiostream.MediaAudio {
+			continue
+		}
+		if firstAudio == nil {
+			firstAudio = &tracks[i]
+		}
+		if supportedCodec(tracks[i].Codec) {
+			return tracks[i], true
+		}
+	}
+	if firstAudio != nil {
+		return *firstAudio, true
+	}
+	return rtsp.Track{}, false
+}
+
+// videoTracks returns the video tracks, set up with Discard in full-stream mode.
+func videoTracks(tracks []rtsp.Track) []rtsp.Track {
+	var out []rtsp.Track
+	for i := range tracks {
+		if tracks[i].Media == audiostream.MediaVideo {
+			out = append(out, tracks[i])
+		}
+	}
+	return out
+}
+
+// supportedCodec reports whether the native decode path can handle a codec.
+// MP4A-LATM is included even when its AudioSpecificConfig is not yet known: an
+// in-band (cpresent=1) config resolves after PLAY via OnCodecUpdate, so the
+// track is selectable and the pipeline drops frames until the config arrives.
+func supportedCodec(c audiostream.Codec) bool {
+	switch c.(type) {
+	case audiostream.CodecG711, audiostream.CodecG726, audiostream.CodecL16,
+		audiostream.CodecOpus, audiostream.CodecMP3, audiostream.CodecAAC,
+		audiostream.CodecMP4ALATM:
+		return true
+	default:
+		return false
+	}
+}
+
+// mapTransport maps the spec transport onto the library preference: udp prefers
+// UDP with TCP fallback, everything else uses TCP interleaved.
+func mapTransport(t string) rtsp.TransportPreference {
+	if strings.EqualFold(strings.TrimSpace(t), "udp") {
+		return rtsp.PreferUDPThenTCP
+	}
+	return rtsp.PreferTCP
+}

--- a/internal/audiocore/stream/options.go
+++ b/internal/audiocore/stream/options.go
@@ -37,9 +37,6 @@ const (
 // zero Options passed to NewManager is filled by applyDefaults. Producer-neutral
 // per-stream settings live on audiocore.StreamSpec, not here.
 type Options struct {
-	// Debug enables verbose debug logging for stream capture.
-	Debug bool
-
 	// AllowInsecureAuth permits plaintext-credential auth on http and hls
 	// sources. It has no effect on RTSP (challenge-response auth) and is unused
 	// until Phase 3 adds those source types.

--- a/internal/audiocore/stream/options.go
+++ b/internal/audiocore/stream/options.go
@@ -1,0 +1,110 @@
+package stream
+
+import (
+	"time"
+
+	"github.com/tphakala/go-audio-stream/supervisor"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+)
+
+// Native ingest defaults. The backoff schedule overrides the go-audio-stream
+// library defaults (500 ms / 30 s / 2.0 / 0.2) so the ceiling matches FFmpeg's
+// 2 min cap: a camera down for hours is polled every two minutes rather than
+// every thirty seconds. The 1 s base is the native starting point (FFmpeg starts
+// at 5 s); only the ceiling is held to parity. The cap is a politeness setting
+// only; what bounds reconnects is the supervisor plus the liveness watchdog, not
+// the cap value.
+const (
+	// defaultReadIdle is the supervisor read-idle watchdog window: a session
+	// with no delivered frame within this window ends with ErrReadTimeout and
+	// reconnects. The engine tightens this to sit in front of the liveness
+	// threshold; this is the base before that clamp.
+	defaultReadIdle = 20 * time.Second
+	// defaultChunkBytes is the pooled flush unit for dispatched frames (42.7 ms
+	// at 48 kHz mono). There is no time-based flush; a chunk emits when full or
+	// when the session ends.
+	defaultChunkBytes = 4096
+
+	defaultBackoffBase   = 1 * time.Second
+	defaultBackoffMax    = 2 * time.Minute
+	defaultBackoffFactor = 2.0
+	defaultBackoffJitter = 0.2
+)
+
+// Options carries manager-level defaults applied to every stream the native
+// Manager starts, mirroring ffmpeg.Options. The zero value is valid: a nil or
+// zero Options passed to NewManager is filled by applyDefaults. Producer-neutral
+// per-stream settings live on audiocore.StreamSpec, not here.
+type Options struct {
+	// Debug enables verbose debug logging for stream capture.
+	Debug bool
+
+	// AllowInsecureAuth permits plaintext-credential auth on http and hls
+	// sources. It has no effect on RTSP (challenge-response auth) and is unused
+	// until Phase 3 adds those source types.
+	AllowInsecureAuth bool
+
+	// ReadIdle is the supervisor read-idle window: a session that delivers no
+	// frame within it ends with a read timeout and reconnects. It defaults below
+	// the liveness watchdog's silence threshold so the supervisor repairs a
+	// transport stall in place before the watchdog would escalate. Zero uses
+	// defaultReadIdle.
+	ReadIdle time.Duration
+
+	// Backoff parameterizes the supervisor reconnect schedule. Any zero field is
+	// filled with the native override defaults above (not the library defaults).
+	Backoff supervisor.BackoffConfig
+
+	// ChunkBytes is the pooled flush unit for dispatched AudioFrames. Zero uses
+	// defaultChunkBytes.
+	ChunkBytes int
+
+	// InsecureTLS opts into skipping certificate verification for rtsps sources
+	// (self-signed cameras). A nil pointer defaults to true for parity with the
+	// FFmpeg path, which never verified; set a pointer to false to require
+	// verification. It is a pointer because the parity default is true and a Go
+	// bool cannot distinguish "unset" from "explicitly false".
+	InsecureTLS *bool
+
+	// Metrics receives stream health and data-rate samples. Nil-safe: the
+	// manager checks for nil before every call.
+	Metrics audiocore.StreamMetrics
+}
+
+// applyDefaults fills every unset field in place. NewManager applies it once, so
+// the rest of the package reads resolved values.
+func (o *Options) applyDefaults() {
+	if o.ReadIdle <= 0 {
+		o.ReadIdle = defaultReadIdle
+	}
+	if o.ChunkBytes <= 0 {
+		o.ChunkBytes = defaultChunkBytes
+	} else if o.ChunkBytes%2 != 0 {
+		// s16 samples are 2 bytes, so an odd chunk size would split a sample
+		// across a chunk boundary and byte-misalign every subsequent chunk.
+		o.ChunkBytes++
+	}
+	if o.Backoff.Base <= 0 {
+		o.Backoff.Base = defaultBackoffBase
+	}
+	if o.Backoff.Max <= 0 {
+		o.Backoff.Max = defaultBackoffMax
+	}
+	if o.Backoff.Factor <= 1.0 {
+		o.Backoff.Factor = defaultBackoffFactor
+	}
+	if o.Backoff.Jitter <= 0 {
+		o.Backoff.Jitter = defaultBackoffJitter
+	}
+	if o.InsecureTLS == nil {
+		t := true
+		o.InsecureTLS = &t
+	}
+}
+
+// insecureTLS reports the effective TLS-verification-skipping setting, treating a
+// nil InsecureTLS as the parity default of true.
+func (o *Options) insecureTLS() bool {
+	return o.InsecureTLS == nil || *o.InsecureTLS
+}

--- a/internal/audiocore/stream/options_test.go
+++ b/internal/audiocore/stream/options_test.go
@@ -1,0 +1,51 @@
+package stream
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOptions_applyDefaults_fillsZeroFields(t *testing.T) {
+	got := Options{}
+	got.applyDefaults()
+
+	assert.Equal(t, 20*time.Second, got.ReadIdle, "ReadIdle default")
+	assert.Equal(t, 4096, got.ChunkBytes, "ChunkBytes default")
+	assert.Equal(t, 1*time.Second, got.Backoff.Base, "Backoff.Base native override")
+	assert.Equal(t, 2*time.Minute, got.Backoff.Max, "Backoff.Max native override")
+	assert.InEpsilon(t, 2.0, got.Backoff.Factor, 1e-9, "Backoff.Factor native override")
+	assert.InEpsilon(t, 0.2, got.Backoff.Jitter, 1e-9, "Backoff.Jitter native override")
+
+	require.NotNil(t, got.InsecureTLS, "InsecureTLS defaults to a concrete value")
+	assert.True(t, *got.InsecureTLS, "InsecureTLS defaults to true for FFmpeg parity")
+	assert.True(t, got.insecureTLS(), "insecureTLS() reads the effective value")
+}
+
+func TestOptions_applyDefaults_preservesExplicitValues(t *testing.T) {
+	strict := false
+	in := Options{
+		Debug:       true,
+		ReadIdle:    5 * time.Second,
+		ChunkBytes:  8192,
+		InsecureTLS: &strict,
+	}
+	in.Backoff.Base = 250 * time.Millisecond
+	in.applyDefaults()
+
+	assert.True(t, in.Debug, "Debug preserved")
+	assert.Equal(t, 5*time.Second, in.ReadIdle, "explicit ReadIdle preserved")
+	assert.Equal(t, 8192, in.ChunkBytes, "explicit ChunkBytes preserved")
+	assert.Equal(t, 250*time.Millisecond, in.Backoff.Base, "explicit Backoff.Base preserved")
+	assert.Equal(t, 2*time.Minute, in.Backoff.Max, "unset Backoff.Max still defaulted")
+	require.NotNil(t, in.InsecureTLS)
+	assert.False(t, *in.InsecureTLS, "explicit InsecureTLS=false preserved")
+	assert.False(t, in.insecureTLS(), "insecureTLS() honours an explicit false")
+}
+
+func TestOptions_insecureTLS_nilDefaultsTrue(t *testing.T) {
+	o := Options{}
+	assert.True(t, o.insecureTLS(), "nil InsecureTLS reads as true")
+}

--- a/internal/audiocore/stream/options_test.go
+++ b/internal/audiocore/stream/options_test.go
@@ -27,7 +27,6 @@ func TestOptions_applyDefaults_fillsZeroFields(t *testing.T) {
 func TestOptions_applyDefaults_preservesExplicitValues(t *testing.T) {
 	strict := false
 	in := Options{
-		Debug:       true,
 		ReadIdle:    5 * time.Second,
 		ChunkBytes:  8192,
 		InsecureTLS: &strict,
@@ -35,7 +34,6 @@ func TestOptions_applyDefaults_preservesExplicitValues(t *testing.T) {
 	in.Backoff.Base = 250 * time.Millisecond
 	in.applyDefaults()
 
-	assert.True(t, in.Debug, "Debug preserved")
 	assert.Equal(t, 5*time.Second, in.ReadIdle, "explicit ReadIdle preserved")
 	assert.Equal(t, 8192, in.ChunkBytes, "explicit ChunkBytes preserved")
 	assert.Equal(t, 250*time.Millisecond, in.Backoff.Base, "explicit Backoff.Base preserved")

--- a/internal/audiocore/stream/pipeline.go
+++ b/internal/audiocore/stream/pipeline.go
@@ -1,0 +1,222 @@
+package stream
+
+import (
+	"fmt"
+	"time"
+
+	audiostream "github.com/tphakala/go-audio-stream"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+	"github.com/tphakala/birdnet-go/internal/audiocore/resample"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// bytePool is the pooled-slice source the pipeline draws dispatched chunks from.
+// buffer.BytePool satisfies it; a nil pool means unpooled (plain allocation and
+// a nil FrameRef), matching the FFmpeg producer without a wired buffer manager.
+type bytePool interface {
+	Get() []byte
+	Put(buf []byte)
+}
+
+// dispatchFunc receives each assembled AudioFrame; it is the manager's frame
+// callback, which forwards into the audio router.
+type dispatchFunc func(audiocore.AudioFrame)
+
+// pipeline is the per-source decode, shape, resample, chunk, and dispatch hot
+// path. It runs entirely on the supervisor's reader goroutine inside OnFrame,
+// so it is not safe for concurrent use and owns reusable scratch buffers so the
+// decode and shape stages are allocation-free. The dispatched chunk's byte slice
+// is drawn from a pool and reused, but each dispatch still allocates its FrameRef
+// and release closure; driving that to zero would need a FrameRef free-list and
+// is left as a follow-up.
+type pipeline struct {
+	sourceID    string
+	sourceName  string
+	targetRate  int
+	channelMode string
+	chunkBytes  int
+	pool        bytePool // nil => unpooled
+	onFrame     dispatchFunc
+	log         logger.Logger
+
+	dec       frameDecoder
+	resampler *resample.Resampler
+	monoBuf   []byte // reused mono s16le scratch for the downmix stage
+
+	chunk    []byte // the pooled slice currently being filled, or nil
+	chunkLen int
+}
+
+// newPipeline builds a pipeline for one source. pool may be nil for the unpooled
+// path. log may be nil, in which case the package logger is used.
+func newPipeline(spec *audiocore.StreamSpec, chunkBytes int, pool bytePool, onFrame dispatchFunc, log logger.Logger) *pipeline {
+	if log == nil {
+		log = audiocore.GetLogger()
+	}
+	return &pipeline{
+		sourceID:    spec.SourceID,
+		sourceName:  spec.SourceName,
+		targetRate:  spec.SampleRate,
+		channelMode: spec.ChannelMode,
+		chunkBytes:  chunkBytes,
+		pool:        pool,
+		onFrame:     onFrame,
+		log:         log,
+	}
+}
+
+// setCodec builds the frame decoder for a track's codec and discards any prior
+// resampler so the next frame rebuilds it for the new geometry. It is called at
+// session start and on an OnCodecUpdate. An unsupported codec returns a terminal
+// error the caller maps to stream health.
+func (p *pipeline) setCodec(codec audiostream.Codec, format audiostream.AudioFormat) error {
+	dec, err := newFrameDecoder(codec, format)
+	if err != nil {
+		// Clear the decoder so a failed (re)resolution does not keep feeding the
+		// new bitstream into the previous decoder: process drops frames while
+		// p.dec is nil until a valid codec is resolved (e.g. via OnCodecUpdate).
+		p.dec = nil
+		if p.resampler != nil {
+			_ = p.resampler.Close()
+			p.resampler = nil
+		}
+		return err
+	}
+	p.dec = dec
+	if p.resampler != nil {
+		_ = p.resampler.Close()
+		p.resampler = nil
+	}
+	return nil
+}
+
+// process decodes one depacketized frame and dispatches the resulting audio as
+// pooled chunks. A frame that arrives before the codec is resolved is dropped.
+func (p *pipeline) process(data []byte) error {
+	if p.dec == nil {
+		return nil
+	}
+	pcm, rate, channels, err := p.dec.decodeFrame(data)
+	if err != nil {
+		return err
+	}
+	if len(pcm) == 0 {
+		return nil
+	}
+
+	var mono []byte
+	if channels <= 1 {
+		mono = pcm
+	} else {
+		p.monoBuf = shapeToMono(p.monoBuf, pcm, channels, p.channelMode)
+		mono = p.monoBuf
+	}
+
+	out, err := p.resampleTo(mono, rate)
+	if err != nil {
+		return err
+	}
+	p.chunkAndDispatch(out)
+	return nil
+}
+
+// resampleTo resamples mono s16le from rate to the target rate, rebuilding the
+// resampler if the input rate changed. When the rates already match it returns
+// the input unchanged so the common case does no work.
+func (p *pipeline) resampleTo(mono []byte, rate int) ([]byte, error) {
+	if rate == p.targetRate {
+		return mono, nil
+	}
+	if p.resampler == nil || p.resampler.FromRate() != rate {
+		if p.resampler != nil {
+			_ = p.resampler.Close()
+		}
+		r, err := resample.NewResampler(rate, p.targetRate)
+		if err != nil {
+			return nil, fmt.Errorf("build resampler %d->%d: %w", rate, p.targetRate, err)
+		}
+		p.resampler = r
+	}
+	out, err := p.resampler.ResampleInto(mono)
+	if err != nil {
+		return nil, fmt.Errorf("resample %d->%d: %w", rate, p.targetRate, err)
+	}
+	return out, nil
+}
+
+// chunkAndDispatch copies mono s16le PCM into pooled chunkBytes slices, emitting
+// each slice as it fills. Because chunkBytes and every PCM length are even, a
+// sample is never split across a chunk boundary.
+func (p *pipeline) chunkAndDispatch(pcm []byte) {
+	for len(pcm) > 0 {
+		if p.chunk == nil {
+			p.chunk = p.newChunk()
+			p.chunkLen = 0
+		}
+		n := copy(p.chunk[p.chunkLen:p.chunkBytes], pcm)
+		p.chunkLen += n
+		pcm = pcm[n:]
+		if p.chunkLen == p.chunkBytes {
+			p.dispatch(p.chunk[:p.chunkLen], p.chunk)
+			p.chunk = nil
+			p.chunkLen = 0
+		}
+	}
+}
+
+// flush dispatches the partial chunk (if any) so nothing stays buffered when a
+// session ends or the stream stops. It is a no-op when no chunk is in flight.
+func (p *pipeline) flush() {
+	switch {
+	case p.chunkLen > 0:
+		p.dispatch(p.chunk[:p.chunkLen], p.chunk)
+	case p.chunk != nil && p.pool != nil:
+		p.pool.Put(p.chunk)
+	}
+	p.chunk = nil
+	p.chunkLen = 0
+}
+
+// close flushes any buffered audio and releases the resampler. It is called at
+// stream stop and manager shutdown.
+func (p *pipeline) close() {
+	p.flush()
+	if p.resampler != nil {
+		_ = p.resampler.Close()
+		p.resampler = nil
+	}
+}
+
+// newChunk returns a fresh chunk slice: a pooled one when a pool is wired, or a
+// plain allocation otherwise (the unpooled path never reuses a slice because the
+// consumer's lifetime is GC-governed with a nil FrameRef).
+func (p *pipeline) newChunk() []byte {
+	if p.pool != nil {
+		return p.pool.Get()
+	}
+	return make([]byte, p.chunkBytes)
+}
+
+// dispatch builds the AudioFrame for one chunk and hands it to onFrame. When the
+// chunk is pooled it carries a FrameRef whose release returns owner to the pool;
+// the producer releases its own reference after onFrame returns, so the slice is
+// reclaimed once every retaining consumer has released too.
+func (p *pipeline) dispatch(data, owner []byte) {
+	frame := audiocore.AudioFrame{
+		SourceID:   p.sourceID,
+		SourceName: p.sourceName,
+		Data:       data,
+		SampleRate: p.targetRate,
+		BitDepth:   16,
+		Channels:   1,
+		Timestamp:  time.Now(),
+	}
+	if p.pool == nil {
+		p.onFrame(frame)
+		return
+	}
+	frame.Ref = audiocore.NewFrameRef(func() { p.pool.Put(owner) })
+	p.onFrame(frame)
+	frame.Ref.Release()
+}

--- a/internal/audiocore/stream/pipeline_test.go
+++ b/internal/audiocore/stream/pipeline_test.go
@@ -1,0 +1,177 @@
+package stream
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	audiostream "github.com/tphakala/go-audio-stream"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+	"github.com/tphakala/birdnet-go/internal/audiocore/buffer"
+)
+
+// fakeBytePool is a deterministic bytePool for asserting FrameRef accounting.
+type fakeBytePool struct {
+	size       int
+	gets, puts int
+}
+
+func (p *fakeBytePool) Get() []byte    { p.gets++; return make([]byte, p.size) }
+func (p *fakeBytePool) Put(buf []byte) { p.puts++ }
+
+// frameCollector records dispatched frames, optionally retaining their FrameRef
+// to model a router route that holds the frame past the OnFrame return.
+type frameCollector struct {
+	retain bool
+	frames []audiocore.AudioFrame
+	data   [][]byte
+}
+
+func (c *frameCollector) onFrame(f audiocore.AudioFrame) { //nolint:gocritic // hugeParam: must match dispatchFunc's by-value signature
+	if c.retain {
+		f.Ref.Retain()
+	}
+	d := make([]byte, len(f.Data))
+	copy(d, f.Data)
+	c.data = append(c.data, d)
+	c.frames = append(c.frames, f)
+}
+
+func pcmL16(rate, ch int) (audiostream.Codec, audiostream.AudioFormat) {
+	return audiostream.CodecL16{ClockRate: rate, Channels: ch},
+		audiostream.AudioFormat{Kind: audiostream.KindPCMS16LE, SampleRate: rate, Channels: ch}
+}
+
+func TestPipeline_chunksAndDispatchesMonoPassthrough(t *testing.T) {
+	pool := &fakeBytePool{size: 8}
+	col := &frameCollector{}
+	spec := &audiocore.StreamSpec{SourceID: "s1", SourceName: "Feeder", SampleRate: 48000, Channels: 1, ChannelMode: channelModeDownmix, BitDepth: 16}
+	p := newPipeline(spec, 8, pool, col.onFrame, nil)
+	codec, format := pcmL16(48000, 1)
+	require.NoError(t, p.setCodec(codec, format))
+
+	in := make([]byte, 20)
+	for i := range in {
+		in[i] = byte(i)
+	}
+	require.NoError(t, p.process(in))
+
+	require.Len(t, col.frames, 2, "two full 8-byte chunks emit while filling")
+	for _, f := range col.frames {
+		assert.Len(t, f.Data, 8, "full chunk is exactly chunkBytes")
+		assert.Equal(t, "s1", f.SourceID)
+		assert.Equal(t, "Feeder", f.SourceName)
+		assert.Equal(t, 48000, f.SampleRate)
+		assert.Equal(t, 16, f.BitDepth)
+		assert.Equal(t, 1, f.Channels)
+		assert.NotNil(t, f.Ref, "pooled chunk carries a FrameRef")
+		assert.False(t, f.Timestamp.IsZero())
+	}
+
+	p.flush()
+	require.Len(t, col.frames, 3, "flush emits the buffered remainder")
+	assert.Len(t, col.data[2], 4, "remainder is the trailing 4 bytes")
+
+	var got []byte
+	for _, d := range col.data {
+		got = append(got, d...)
+	}
+	assert.Equal(t, in, got, "content is preserved across chunk boundaries")
+}
+
+func TestPipeline_frameRefReturnsChunkOnRouterDrop(t *testing.T) {
+	pool := &fakeBytePool{size: 8}
+	col := &frameCollector{retain: false} // router enqueued nothing (all dropped)
+	spec := &audiocore.StreamSpec{SourceID: "s1", SampleRate: 48000, Channels: 1, BitDepth: 16}
+	p := newPipeline(spec, 8, pool, col.onFrame, nil)
+	codec, format := pcmL16(48000, 1)
+	require.NoError(t, p.setCodec(codec, format))
+
+	require.NoError(t, p.process(make([]byte, 8)))
+	require.Len(t, col.frames, 1)
+	assert.Equal(t, 1, pool.puts, "a dropped frame returns its pooled chunk exactly once")
+}
+
+func TestPipeline_frameRefHeldUntilConsumerReleases(t *testing.T) {
+	pool := &fakeBytePool{size: 8}
+	col := &frameCollector{retain: true} // one route holds the frame
+	spec := &audiocore.StreamSpec{SourceID: "s1", SampleRate: 48000, Channels: 1, BitDepth: 16}
+	p := newPipeline(spec, 8, pool, col.onFrame, nil)
+	codec, format := pcmL16(48000, 1)
+	require.NoError(t, p.setCodec(codec, format))
+
+	require.NoError(t, p.process(make([]byte, 8)))
+	require.Len(t, col.frames, 1)
+	assert.Equal(t, 0, pool.puts, "chunk is not returned while a consumer holds the ref")
+
+	col.frames[0].Ref.Release()
+	assert.Equal(t, 1, pool.puts, "chunk returns once the consumer releases")
+}
+
+func TestPipeline_unpooledLeavesRefNil(t *testing.T) {
+	col := &frameCollector{}
+	spec := &audiocore.StreamSpec{SourceID: "s1", SampleRate: 48000, Channels: 1, BitDepth: 16}
+	p := newPipeline(spec, 8, nil, col.onFrame, nil)
+	codec, format := pcmL16(48000, 1)
+	require.NoError(t, p.setCodec(codec, format))
+
+	require.NoError(t, p.process(make([]byte, 8)))
+	require.Len(t, col.frames, 1)
+	assert.Nil(t, col.frames[0].Ref, "unpooled dispatch leaves Ref nil")
+}
+
+func TestPipeline_resamplesToTargetRate(t *testing.T) {
+	pool := &fakeBytePool{size: 4096}
+	col := &frameCollector{}
+	spec := &audiocore.StreamSpec{SourceID: "s1", SampleRate: 48000, Channels: 1, BitDepth: 16}
+	p := newPipeline(spec, 4096, pool, col.onFrame, nil)
+	codec, format := pcmL16(24000, 1)
+	require.NoError(t, p.setCodec(codec, format))
+
+	in := make([]byte, 4800) // 2400 samples at 24 kHz mono
+	require.NoError(t, p.process(in))
+	p.flush()
+
+	require.NotNil(t, p.resampler, "a rate mismatch builds a resampler")
+	assert.Equal(t, 24000, p.resampler.FromRate())
+	assert.Equal(t, 48000, p.resampler.ToRate())
+
+	var total int
+	for _, f := range col.frames {
+		total += len(f.Data)
+		assert.Equal(t, 48000, f.SampleRate, "dispatched frames carry the target rate")
+	}
+	assert.Greater(t, total, len(in), "upsampling 24k to 48k yields more bytes")
+}
+
+// BenchmarkPipelineProcess measures the steady-state per-frame allocations of
+// the decode->shape->chunk->dispatch hot path on the zero-copy PCM passthrough
+// path, for both the pooled and unpooled dispatch. It locks the allocation
+// budget so a regression (a mis-sized scratch buffer, an added per-frame
+// allocation) is visible in b.ReportAllocs output.
+func BenchmarkPipelineProcess(b *testing.B) {
+	run := func(b *testing.B, pool bytePool) {
+		b.Helper()
+		spec := &audiocore.StreamSpec{SourceID: "s1", SampleRate: 48000, Channels: 1, BitDepth: 16}
+		// onFrame models a router with no live route: it drops the frame, so the
+		// producer's own FrameRef release returns the pooled chunk each iteration.
+		p := newPipeline(spec, 4096, pool, func(audiocore.AudioFrame) {}, nil)
+		codec, format := pcmL16(48000, 1)
+		require.NoError(b, p.setCodec(codec, format))
+
+		frame := make([]byte, 4096) // one full chunk of mono s16le
+		b.ReportAllocs()
+		for b.Loop() {
+			if err := p.process(frame); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+
+	b.Run("pooled", func(b *testing.B) {
+		bufMgr := buffer.NewManager(audiocore.GetLogger())
+		run(b, bufMgr.BytePoolFor(4096))
+	})
+	b.Run("unpooled", func(b *testing.B) { run(b, nil) })
+}

--- a/internal/audiocore/stream/shape.go
+++ b/internal/audiocore/stream/shape.go
@@ -1,0 +1,64 @@
+package stream
+
+import (
+	"encoding/binary"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// Channel mode names, sourced from conf so the native path cannot drift from the
+// canonical config vocabulary. Downmix is the default: an empty or unrecognized
+// mode averages every channel.
+const (
+	channelModeDownmix = string(conf.ChannelModeDownmix)
+	channelModeLeft    = string(conf.ChannelModeLeft)
+	channelModeRight   = string(conf.ChannelModeRight)
+
+	bytesPerSample = 2 // interleaved s16le
+)
+
+// shapeToMono reduces interleaved little-endian s16 PCM with srcChannels to mono
+// s16le, written into dst[:0] and returned (so dst's backing array is reused
+// across calls). channelModeLeft and channelModeRight select one channel;
+// anything else averages all channels. A mono or channel-less input is returned
+// unchanged, so no work is done on the common single-channel path.
+func shapeToMono(dst, src []byte, srcChannels int, mode string) []byte {
+	if srcChannels <= 1 {
+		return src
+	}
+	frameBytes := srcChannels * bytesPerSample
+	nFrames := len(src) / frameBytes
+	dst = dst[:0]
+
+	sampleAt := func(frame, ch int) int16 {
+		off := frame*frameBytes + ch*bytesPerSample
+		return int16(binary.LittleEndian.Uint16(src[off:]))
+	}
+	appendSample := func(v int16) {
+		dst = binary.LittleEndian.AppendUint16(dst, uint16(v))
+	}
+
+	switch mode {
+	case channelModeLeft:
+		for f := range nFrames {
+			appendSample(sampleAt(f, 0))
+		}
+	case channelModeRight:
+		ch := 1
+		if ch >= srcChannels {
+			ch = srcChannels - 1
+		}
+		for f := range nFrames {
+			appendSample(sampleAt(f, ch))
+		}
+	default: // downmix
+		for f := range nFrames {
+			var sum int32
+			for c := range srcChannels {
+				sum += int32(sampleAt(f, c))
+			}
+			appendSample(int16(sum / int32(srcChannels)))
+		}
+	}
+	return dst
+}

--- a/internal/audiocore/stream/shape_test.go
+++ b/internal/audiocore/stream/shape_test.go
@@ -1,0 +1,102 @@
+package stream
+
+import (
+	"encoding/binary"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// s16le builds an interleaved little-endian s16 buffer from sample values.
+func s16le(samples ...int16) []byte {
+	b := make([]byte, len(samples)*2)
+	for i, s := range samples {
+		binary.LittleEndian.PutUint16(b[i*2:], uint16(s))
+	}
+	return b
+}
+
+// monoSamples decodes an s16le buffer back to int16 values.
+func monoSamples(b []byte) []int16 {
+	out := make([]int16, len(b)/2)
+	for i := range out {
+		out[i] = int16(binary.LittleEndian.Uint16(b[i*2:]))
+	}
+	return out
+}
+
+func TestShapeToMono(t *testing.T) {
+	tests := []struct {
+		name        string
+		src         []byte
+		srcChannels int
+		mode        string
+		want        []int16
+	}{
+		{
+			name:        "mono passthrough",
+			src:         s16le(10, 20, 30),
+			srcChannels: 1,
+			mode:        channelModeDownmix,
+			want:        []int16{10, 20, 30},
+		},
+		{
+			name:        "stereo downmix averages channels",
+			src:         s16le(100, 200, -100, 100), // (L,R),(L,R)
+			srcChannels: 2,
+			mode:        channelModeDownmix,
+			want:        []int16{150, 0},
+		},
+		{
+			name:        "empty mode defaults to downmix",
+			src:         s16le(100, 200),
+			srcChannels: 2,
+			mode:        "",
+			want:        []int16{150},
+		},
+		{
+			name:        "stereo left picks channel 0",
+			src:         s16le(100, 200, 300, 400),
+			srcChannels: 2,
+			mode:        channelModeLeft,
+			want:        []int16{100, 300},
+		},
+		{
+			name:        "stereo right picks channel 1",
+			src:         s16le(100, 200, 300, 400),
+			srcChannels: 2,
+			mode:        channelModeRight,
+			want:        []int16{200, 400},
+		},
+		{
+			name:        "four channel downmix averages all",
+			src:         s16le(100, 200, 300, 400),
+			srcChannels: 4,
+			mode:        channelModeDownmix,
+			want:        []int16{250},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shapeToMono(nil, tt.src, tt.srcChannels, tt.mode)
+			assert.Equal(t, tt.want, monoSamples(got))
+		})
+	}
+}
+
+func TestShapeToMono_reusesDstCapacity(t *testing.T) {
+	dst := make([]byte, 0, 64)
+	got := shapeToMono(dst, s16le(100, 200), 2, channelModeDownmix)
+	require.Equal(t, []int16{150}, monoSamples(got))
+	require.NotEmpty(t, got)
+	// The result must be written into dst's backing array, not a fresh
+	// allocation. Compare the backing pointers as addresses: comparing *byte
+	// with assert.Equal routes through reflect.DeepEqual, which compares the
+	// pointed-to values (both 150 here) and would pass even for a fresh buffer.
+	assert.Equal(t,
+		uintptr(unsafe.Pointer(unsafe.SliceData(dst[:1]))),
+		uintptr(unsafe.Pointer(unsafe.SliceData(got))),
+		"shapeToMono should reuse dst's backing array")
+}

--- a/internal/audiocore/stream/stream.go
+++ b/internal/audiocore/stream/stream.go
@@ -53,6 +53,10 @@ type stream struct {
 
 	targetHost string
 	targetPort int
+	// healthyThreshold is the resolved per-source "no data before unhealthy"
+	// window: spec.HealthyDataThreshold when set, else healthyDataThreshold,
+	// mirroring the FFmpeg producer's StreamConfig.healthyThreshold().
+	healthyThreshold time.Duration
 
 	// deliveredSession is set by the reader goroutine when a frame is dispatched
 	// and cleared in the RTSP factory at each session start (before routing
@@ -87,17 +91,22 @@ func newStream(spec *audiocore.StreamSpec, opts *Options, deliver dispatchFunc, 
 		log = audiocore.GetLogger()
 	}
 	host, port := parseHostPort(spec.URL)
+	healthyThreshold := spec.HealthyDataThreshold
+	if healthyThreshold <= 0 {
+		healthyThreshold = healthyDataThreshold
+	}
 	s := &stream{
-		spec:         spec,
-		opts:         opts,
-		log:          log,
-		rateMeter:    audiocore.NewDataRateMeter(dataRateWindow),
-		targetHost:   host,
-		targetPort:   port,
-		state:        audiocore.StreamStateStarting,
-		stateDetail:  detailStarting,
-		stateEntered: time.Now(),
-		recovery:     audiocore.RecoveryInProgress,
+		spec:             spec,
+		opts:             opts,
+		log:              log,
+		rateMeter:        audiocore.NewDataRateMeter(dataRateWindow),
+		targetHost:       host,
+		targetPort:       port,
+		healthyThreshold: healthyThreshold,
+		state:            audiocore.StreamStateStarting,
+		stateDetail:      detailStarting,
+		stateEntered:     time.Now(),
+		recovery:         audiocore.RecoveryInProgress,
 	}
 
 	var pool bytePool
@@ -273,7 +282,7 @@ func (s *stream) snapshot() *audiocore.StreamHealth {
 	now := time.Now()
 	receiving := !s.lastData.IsZero() && now.Sub(s.lastData) < receivingDataThreshold
 	healthy := s.state == audiocore.StreamStateConnected &&
-		!s.lastData.IsZero() && now.Sub(s.lastData) < healthyDataThreshold
+		!s.lastData.IsZero() && now.Sub(s.lastData) < s.healthyThreshold
 
 	h := &audiocore.StreamHealth{
 		State:              s.state,

--- a/internal/audiocore/stream/stream.go
+++ b/internal/audiocore/stream/stream.go
@@ -1,0 +1,341 @@
+package stream
+
+import (
+	"context"
+	"net/url"
+	"slices"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/tphakala/go-audio-stream/supervisor"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+	"github.com/tphakala/birdnet-go/internal/audiocore/buffer"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+const (
+	// dataRateWindow is the sliding window for the delivered-PCM rate meter.
+	dataRateWindow = 5 * time.Second
+	// receivingDataThreshold and healthyDataThreshold match the FFmpeg producer's
+	// defaultReceivingDataThreshold and defaultHealthyDataThreshold so
+	// IsReceivingData and IsHealthy compute identically.
+	receivingDataThreshold = 5 * time.Second
+	healthyDataThreshold   = 60 * time.Second
+	// stateHistoryLen bounds the retained transition history, matching the FFmpeg
+	// producer's maxStateHistoryExposed.
+	stateHistoryLen = 10
+	// errorHistoryLen bounds the retained error context history.
+	errorHistoryLen = 10
+	// audioOnlyFallbackStreak is how many consecutive audio-only sessions may
+	// end without a frame before the stream latches to full-stream SETUP.
+	audioOnlyFallbackStreak = 2
+)
+
+// stream owns one supervised source: its pipeline, its go-audio-stream
+// supervisor, and its neutral health state. Health mutations happen on the
+// supervisor goroutine (onState) and the reader goroutine (onDeliver); they do
+// not overlap within a session because a session's delivery has stopped before
+// its terminal transition fires, but both are guarded so a concurrent snapshot
+// read is race-free.
+type stream struct {
+	spec *audiocore.StreamSpec
+	opts *Options
+	log  logger.Logger
+
+	pl        *pipeline
+	sup       *supervisor.Supervisor
+	rateMeter *audiocore.DataRateMeter
+
+	targetHost string
+	targetPort int
+
+	// deliveredSession is set by the reader goroutine when a frame is dispatched
+	// and cleared in the RTSP factory at each session start (before routing
+	// begins), so the audio-only fallback can tell whether a session ever
+	// produced audio.
+	deliveredSession  atomic.Bool
+	fullStreamLatched atomic.Bool
+
+	mu               sync.Mutex
+	state            audiocore.StreamState
+	stateDetail      string
+	stateEntered     time.Time
+	recovery         audiocore.RecoveryState
+	lastData         time.Time
+	totalBytes       int64
+	restartCount     int
+	reconnectAttempt int
+	nextRetryIn      time.Duration
+	lastErr          error
+	lastErrCtx       *audiocore.StreamErrorContext
+	errorHistory     []*audiocore.StreamErrorContext
+	stateHistory     []audiocore.StateTransition
+	audioOnlyStreak  int
+}
+
+// newStream builds a stream and its supervisor. The supervisor begins connecting
+// immediately on a background goroutine, so onDeliver can fire before the first
+// health read. deliver forwards dispatched frames into the manager's router
+// callback.
+func newStream(spec *audiocore.StreamSpec, opts *Options, deliver dispatchFunc, bufMgr *buffer.Manager, log logger.Logger) *stream {
+	if log == nil {
+		log = audiocore.GetLogger()
+	}
+	host, port := parseHostPort(spec.URL)
+	s := &stream{
+		spec:         spec,
+		opts:         opts,
+		log:          log,
+		rateMeter:    audiocore.NewDataRateMeter(dataRateWindow),
+		targetHost:   host,
+		targetPort:   port,
+		state:        audiocore.StreamStateStarting,
+		stateDetail:  detailStarting,
+		stateEntered: time.Now(),
+		recovery:     audiocore.RecoveryInProgress,
+	}
+
+	var pool bytePool
+	if bufMgr != nil {
+		pool = bufMgr.BytePoolFor(opts.ChunkBytes)
+	}
+	// The pipeline dispatches through onDeliver, which records liveness before
+	// forwarding to the router.
+	s.pl = newPipeline(spec, opts.ChunkBytes, pool, func(f audiocore.AudioFrame) {
+		s.onDeliver(len(f.Data), f.Timestamp)
+		deliver(f)
+	}, log)
+
+	s.sup = supervisor.New(supervisor.Config{
+		Factory:   s.rtspFactory(),
+		Backoff:   opts.Backoff,
+		OnState:   s.onState,
+		Retryable: s.retryable,
+	})
+	return s
+}
+
+// onDeliver records the liveness and byte counters for a dispatched frame of
+// dataLen bytes at ts. It runs on the reader goroutine.
+func (s *stream) onDeliver(dataLen int, ts time.Time) {
+	s.deliveredSession.Store(true)
+	n := int64(dataLen)
+	s.mu.Lock()
+	s.lastData = ts
+	s.totalBytes += n
+	s.mu.Unlock()
+	s.rateMeter.AddSample(n)
+	if s.opts.Metrics != nil {
+		s.opts.Metrics.RecordDataRate(s.spec.SourceID, s.rateMeter.Rate())
+	}
+}
+
+// onState maps a supervisor transition onto the neutral health model. It runs on
+// the supervisor goroutine, serialized with the reader goroutine by the session
+// boundary (a terminated session's delivery has stopped before its terminal
+// transition fires).
+func (s *stream) onState(sc supervisor.StateChange) {
+	state, detail, recovery := mapState(sc)
+
+	switch sc.State {
+	case supervisor.StateReconnecting:
+		s.pl.flush()
+		s.noteSessionEndedWithoutAudio()
+	case supervisor.StateClosed, supervisor.StateFailed:
+		s.pl.flush()
+	case supervisor.StateConnecting, supervisor.StateConnected:
+		// StateConnecting adds nothing beyond the health update below.
+		// StateConnected: onReset fires once at StartStream (parity with the
+		// FFmpeg producer and the shared contract), not per reconnect; the
+		// delivered flag is cleared in the factory before routing begins.
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.state != state || s.stateDetail != detail {
+		s.appendHistory(state, detail, causeString(sc.Err))
+	}
+	s.state = state
+	s.stateDetail = detail
+	s.stateEntered = time.Now()
+	s.recovery = recovery
+
+	switch sc.State {
+	case supervisor.StateReconnecting:
+		s.restartCount++
+		s.reconnectAttempt = sc.Attempt
+		s.nextRetryIn = sc.Backoff
+		s.recordError(sc.Err)
+	case supervisor.StateFailed:
+		s.recordError(sc.Err)
+	case supervisor.StateConnected:
+		s.reconnectAttempt = 0
+		s.nextRetryIn = 0
+	case supervisor.StateConnecting, supervisor.StateClosed:
+		// no counter changes
+	}
+
+	if s.opts.Metrics != nil {
+		s.opts.Metrics.SetStreamHealth(s.spec.SourceID, state == audiocore.StreamStateConnected)
+	}
+}
+
+// noteSessionEndedWithoutAudio advances the audio-only fallback latch. Only the
+// "auto" media mode falls back (matching the FFmpeg path's usesAudioOnlyFallback):
+// audio-only never falls back and full-stream already requests video. A session
+// that produced audio resets the consecutive streak; a session that produced
+// none advances it, and once it reaches the threshold the stream latches to
+// full-stream SETUP for its remaining life.
+func (s *stream) noteSessionEndedWithoutAudio() {
+	if s.fullStreamLatched.Load() {
+		return
+	}
+	if conf.MediaMode(s.spec.MediaMode).Canonical() != conf.MediaModeAuto {
+		return
+	}
+	if s.deliveredSession.Load() {
+		s.mu.Lock()
+		s.audioOnlyStreak = 0
+		s.mu.Unlock()
+		return
+	}
+	s.mu.Lock()
+	s.audioOnlyStreak++
+	streak := s.audioOnlyStreak
+	s.mu.Unlock()
+	if streak >= audioOnlyFallbackStreak {
+		s.fullStreamLatched.Store(true)
+		s.log.Info("latching stream to full-stream SETUP after audio-only sessions produced no audio",
+			logger.String("source_id", s.spec.SourceID),
+			logger.String("operation", "audio_only_fallback"))
+	}
+}
+
+// retryable wraps the library default, marking the terminal native causes so the
+// supervisor stops rather than reconnecting into the same failure. A nil error
+// (a clean session end) is not terminal, so it falls through to the default.
+func (s *stream) retryable(err error) bool {
+	if isTerminalCause(err) {
+		return false
+	}
+	return supervisor.DefaultRetryable(err)
+}
+
+// appendHistory records a transition, trimming to the retained window. Caller
+// holds mu.
+func (s *stream) appendHistory(to audiocore.StreamState, toDetail, reason string) {
+	s.stateHistory = append(s.stateHistory, audiocore.StateTransition{
+		From:       s.state,
+		To:         to,
+		FromDetail: s.stateDetail,
+		ToDetail:   toDetail,
+		Timestamp:  time.Now(),
+		Reason:     reason,
+	})
+	if len(s.stateHistory) > stateHistoryLen {
+		s.stateHistory = s.stateHistory[len(s.stateHistory)-stateHistoryLen:]
+	}
+}
+
+// recordError classifies err and stores it as the last error plus history entry.
+// Caller holds mu.
+func (s *stream) recordError(err error) {
+	if err == nil {
+		return
+	}
+	s.lastErr = err
+	ctx := classifyError(err, s.targetHost, s.targetPort)
+	s.lastErrCtx = ctx
+	if ctx != nil {
+		s.errorHistory = append(s.errorHistory, ctx)
+		if len(s.errorHistory) > errorHistoryLen {
+			s.errorHistory = s.errorHistory[len(s.errorHistory)-errorHistoryLen:]
+		}
+		if s.opts.Metrics != nil {
+			s.opts.Metrics.IncStreamErrors(s.spec.SourceID)
+		}
+	}
+}
+
+// snapshot returns a copy of the current health, computing the derived liveness
+// fields against the current time. The returned slices are freshly copied so the
+// caller may read them without holding the lock.
+func (s *stream) snapshot() *audiocore.StreamHealth {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+	receiving := !s.lastData.IsZero() && now.Sub(s.lastData) < receivingDataThreshold
+	healthy := s.state == audiocore.StreamStateConnected &&
+		!s.lastData.IsZero() && now.Sub(s.lastData) < healthyDataThreshold
+
+	h := &audiocore.StreamHealth{
+		State:              s.state,
+		StateDetail:        s.stateDetail,
+		StateEntered:       s.stateEntered,
+		Recovery:           s.recovery,
+		IsHealthy:          healthy,
+		LastDataReceived:   s.lastData,
+		RestartCount:       s.restartCount,
+		Error:              s.lastErr,
+		TotalBytesReceived: s.totalBytes,
+		BytesPerSecond:     s.rateMeter.Rate(),
+		IsReceivingData:    receiving,
+		LastErrorContext:   s.lastErrCtx,
+		SourceChannels:     s.spec.SourceChannels,
+	}
+	h.StateHistory = slices.Clone(s.stateHistory)
+	h.ErrorHistory = slices.Clone(s.errorHistory)
+	return h
+}
+
+// close stops the supervisor, waits for it to fully stop so no reader goroutine
+// is in flight, then flushes the pipeline's final partial chunk.
+func (s *stream) close(ctx context.Context) {
+	_ = s.sup.Close()
+	// Wait always blocks until the supervisor's reader goroutine has fully
+	// stopped (it drains the done channel even when ctx cancels), so pl.close
+	// below never races a live reader. ctx bounds only how long Close's own
+	// cancellation is given to propagate, so the StopStream/Shutdown timeout is
+	// best-effort: a reader wedged in a syscall that ignores cancellation can
+	// still exceed it.
+	_ = s.sup.Wait(ctx)
+	s.pl.close()
+}
+
+// parseHostPort extracts the sanitized host and port from a stream URL for the
+// error context. Credentials in the userinfo are never returned.
+func parseHostPort(raw string) (host string, port int) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", 0
+	}
+	host = u.Hostname()
+	if p := u.Port(); p != "" {
+		if n, convErr := strconv.Atoi(p); convErr == nil {
+			port = n
+		}
+	}
+	return host, port
+}
+
+// causeString renders an error for the transition reason, "" for nil.
+func causeString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+// isTerminalCause reports whether err is a native failure that a reconnect
+// cannot resolve: no audio track, or an undecodable codec. Auth failures stay
+// retryable so a rotated password recovers on the next poll.
+func isTerminalCause(err error) bool {
+	return errors.Is(err, ErrNoAudioTrack) || errors.Is(err, ErrUnsupportedCodec)
+}

--- a/internal/audiocore/stream_manager.go
+++ b/internal/audiocore/stream_manager.go
@@ -6,7 +6,7 @@ import (
 )
 
 // StreamManager is the contract the engine drives network stream producers
-// through. It is implemented by ffmpeg.Manager today and by nativestream.Manager
+// through. It is implemented by ffmpeg.Manager today and by stream.Manager
 // later, so both producers satisfy the same surface without importing the
 // engine. It is distinct from schedule.StreamManager, which is the engine-level
 // stop/start surface the quiet-hours scheduler uses.

--- a/internal/audiocore/streamtest/contract.go
+++ b/internal/audiocore/streamtest/contract.go
@@ -121,7 +121,7 @@ type Health interface {
 // Manager is the minimal producer contract the characterization suite drives. It
 // is the de facto surface the engine calls on ffmpeg.Manager today (spec section
 // 2.2), narrowed to what the suite needs. Producers satisfy it through a thin
-// adapter so the SAME suite runs unchanged against nativestream.Manager later.
+// adapter so the SAME suite runs unchanged against stream.Manager later.
 type Manager interface {
 	// StartStream begins capturing spec.SourceID and dispatching its frames.
 	StartStream(spec *StreamSpec) error

--- a/internal/conf/native_encoders.go
+++ b/internal/conf/native_encoders.go
@@ -1,10 +1,5 @@
 package conf
 
-import (
-	"os"
-	"strings"
-)
-
 // Temporary runtime opt-in for the native Go AAC and MP3 encoders.
 //
 // AAC and MP3 clip export still run through FFmpeg by default. Setting
@@ -41,29 +36,12 @@ const (
 
 	// EnvNativeMP3Encoder selects the native MP3 encoder for .mp3 clip export.
 	EnvNativeMP3Encoder = "BIRDNET_MP3_ENCODER"
-
-	// nativeEncoderValue is the only value that enables a native encoder.
-	// Anything else, including an unset variable, keeps the FFmpeg path.
-	nativeEncoderValue = "native"
 )
 
 // NativeAACEncoderEnabled reports whether AAC clip export should use the native
 // encoder.
-func NativeAACEncoderEnabled() bool { return nativeEncoderSelected(EnvNativeAACEncoder) }
+func NativeAACEncoderEnabled() bool { return nativeSelected(EnvNativeAACEncoder) }
 
 // NativeMP3EncoderEnabled reports whether MP3 clip export should use the native
 // encoder.
-func NativeMP3EncoderEnabled() bool { return nativeEncoderSelected(EnvNativeMP3Encoder) }
-
-// nativeEncoderSelected reads env and reports whether it opts into the native
-// encoder. Matching is case-insensitive and tolerates surrounding whitespace,
-// because these are hand-edited in compose files and systemd unit drop-ins where
-// a stray space is easy to introduce and hard to spot.
-//
-// The value is read per call rather than cached at startup. A clip export
-// happens once per detection, so the lookup cost is irrelevant, and reading it
-// live keeps the gate consistent with the rest of BirdNET-Go's settings, which
-// take effect without a restart.
-func nativeEncoderSelected(env string) bool {
-	return strings.EqualFold(strings.TrimSpace(os.Getenv(env)), nativeEncoderValue)
-}
+func NativeMP3EncoderEnabled() bool { return nativeSelected(EnvNativeMP3Encoder) }

--- a/internal/conf/native_encoders_test.go
+++ b/internal/conf/native_encoders_test.go
@@ -1,32 +1,9 @@
 package conf
 
-import (
-	"testing"
-
-	"github.com/stretchr/testify/assert"
-)
+import "testing"
 
 func TestNativeAACEncoderEnabled(t *testing.T) {
-	tests := []struct {
-		name  string
-		value string
-		want  bool
-	}{
-		{name: "unset keeps ffmpeg", value: "", want: false},
-		{name: "native opts in", value: "native", want: true},
-		{name: "uppercase opts in", value: "NATIVE", want: true},
-		{name: "mixed case opts in", value: "Native", want: true},
-		{name: "surrounding whitespace opts in", value: "  native ", want: true},
-		{name: "ffmpeg stays ffmpeg", value: "ffmpeg", want: false},
-		{name: "truthy value is not enough", value: "1", want: false},
-		{name: "typo stays ffmpeg", value: "nativ", want: false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv(EnvNativeAACEncoder, tt.value)
-			assert.Equal(t, tt.want, NativeAACEncoderEnabled())
-		})
-	}
+	assertNativeGate(t, EnvNativeAACEncoder, NativeAACEncoderEnabled)
 }
 
 // AAC is now the only gated native encoder: go-opus (Opus) and go-hls (HLS) are

--- a/internal/conf/native_ingest.go
+++ b/internal/conf/native_ingest.go
@@ -1,0 +1,48 @@
+package conf
+
+import (
+	"os"
+	"strings"
+)
+
+// Runtime opt-in for the native Go network stream ingest path.
+//
+// Network stream ingest (RTSP today; HLS, HTTP, and UDP in later phases) runs
+// through an FFmpeg subprocess by default. Setting BIRDNET_STREAM_INGEST=native
+// switches it to the pure-Go go-audio-stream path (depacketize, then decode via
+// go-aac, go-opus, or go-mp3, resample, and dispatch), exercised in the field
+// behind this gate before it becomes the default.
+//
+// The gate is read live per call, matching the encoder gates in
+// native_encoders.go. An environment variable cannot change inside a running
+// process, so a flip takes effect at the next service start (Docker --env,
+// systemd drop-in) or the next pipeline restart that rebuilds the audio engine.
+//
+// REMOVAL: at promotion this inverts to an FFmpegStreamIngestForced() reading
+// the value "ffmpeg", native becomes the default, and this doc gets the same
+// removal note the encoder gates carry.
+const EnvNativeStreamIngest = "BIRDNET_STREAM_INGEST"
+
+// nativeSelectValue is the only value that opts into a native code path. It is
+// shared by the ingest gate here and the encoder gates in native_encoders.go.
+// Anything else, including an unset variable, keeps the FFmpeg path.
+const nativeSelectValue = "native"
+
+// NativeStreamIngestEnabled reports whether network stream ingest should use the
+// pure-Go go-audio-stream path instead of the FFmpeg subprocess. Only the value
+// "native" (case-insensitive, whitespace trimmed) enables it; unset or any other
+// value keeps FFmpeg. Read live per call.
+func NativeStreamIngestEnabled() bool { return nativeSelected(EnvNativeStreamIngest) }
+
+// nativeSelected reads env and reports whether it opts into the native path.
+// Matching is case-insensitive and tolerates surrounding whitespace, because
+// these are hand-edited in compose files and systemd unit drop-ins where a stray
+// space is easy to introduce and hard to spot.
+//
+// The value is read per call rather than cached at startup, so the gate stays
+// consistent with the rest of BirdNET-Go's settings, which take effect without a
+// restart. It lives here rather than in native_encoders.go so the encoder
+// scaffolding stays independently deletable while this shared matcher survives.
+func nativeSelected(env string) bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv(env)), nativeSelectValue)
+}

--- a/internal/conf/native_ingest_test.go
+++ b/internal/conf/native_ingest_test.go
@@ -1,0 +1,38 @@
+package conf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// assertNativeGate runs the shared case matrix every "native" opt-in gate obeys:
+// only the value "native" (case-insensitive, whitespace trimmed) enables it;
+// unset or anything else keeps the FFmpeg path.
+func assertNativeGate(t *testing.T, env string, enabled func() bool) {
+	t.Helper()
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "unset keeps ffmpeg", value: "", want: false},
+		{name: "native opts in", value: "native", want: true},
+		{name: "uppercase opts in", value: "NATIVE", want: true},
+		{name: "mixed case opts in", value: "Native", want: true},
+		{name: "surrounding whitespace opts in", value: "  native ", want: true},
+		{name: "ffmpeg stays ffmpeg", value: "ffmpeg", want: false},
+		{name: "truthy value is not enough", value: "1", want: false},
+		{name: "typo stays ffmpeg", value: "nativ", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(env, tt.value)
+			assert.Equal(t, tt.want, enabled())
+		})
+	}
+}
+
+func TestNativeStreamIngestEnabled(t *testing.T) {
+	assertNativeGate(t, EnvNativeStreamIngest, NativeStreamIngestEnabled)
+}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -396,6 +396,7 @@ func init() {
 	RegisterComponent("myaudio", "myaudio")
 	RegisterComponent("ffmpeg-manager", "ffmpeg-manager")
 	RegisterComponent("ffmpeg-stream", "ffmpeg-stream")
+	RegisterComponent("audiocore/stream.", "native-stream")
 	RegisterComponent("datastore", "datastore")
 	RegisterComponent("imageprovider", "imageprovider")
 	RegisterComponent("diskmanager", "diskmanager")

--- a/internal/support/collector.go
+++ b/internal/support/collector.go
@@ -785,7 +785,7 @@ func (c *Collector) CreateArchive(ctx context.Context, dump *SupportDump, opts C
 // map is nil-and-omitted on the overwhelmingly common install where no gate is
 // set, instead of adding a block of empty strings to every dump. os.Getenv
 // cannot tell those two states apart, and for these gates nothing does: an
-// empty value fails nativeEncoderSelected exactly as an unset one does, so a
+// empty value fails nativeSelected exactly as an unset one does, so a
 // dump loses no triage signal by collapsing them.
 //
 // Values are redacted by key even though the allowlist is supposed to make that


### PR DESCRIPTION
## Summary

Adds an opt-in pure-Go network stream ingest producer as an alternative to the FFmpeg subprocess path, selected at engine construction by a new `BIRDNET_STREAM_INGEST=native` environment gate. The default is unchanged (`ffmpeg`), so existing users are unaffected until they opt in, and the FFmpeg branch of `engine.New` is byte-equivalent to before.

The new `internal/audiocore/stream` package implements the producer-neutral `audiocore.StreamManager` seam on top of `github.com/tphakala/go-audio-stream`. Per source it wraps a reconnecting supervisor that dials RTSP, selects the audio track, and decodes AAC-LC (go-aac `pcm.FrameDecoder`), Opus (go-opus), MP3 (go-mp3), and library-expanded PCM (G.711/G.726/L16), then downmixes to mono, resamples to the analysis sample rate, accumulates pooled chunks, and dispatches `AudioFrame`s into the audio router. Health snapshots, reconnect backoff, typed-error classification, and the `auto` media-mode audio-only-to-full-stream fallback mirror the FFmpeg producer, so the health API, support dump, and frontend keep working unchanged. In-band MP4A-LATM configurations (cpresent=1) resolve after PLAY via `OnCodecUpdate`.

Dependencies: bumps `go-aac` to v0.7.0 (its exported access-unit frame decoder and `ParseASC`) and adds `go-audio-stream` v0.4.0; both are cgo-free. The shared "native" env-gate matcher moves to `native_ingest.go` and the existing encoder gates reference it, so their behaviour is unchanged.

Follow-ups (not in this PR): liveness-watchdog coordination so a supervised reconnect never triggers a full source teardown, the additive `StreamHealth` observability fields plus their health-API/diagnostics/frontend surface, and the container-verified contract acceptance run on the QA hardware.

## Related Issues

Part of the ongoing migration of network stream ingest from an FFmpeg subprocess to a native pure-Go path. No user-facing behaviour changes while the gate is unset.

## Test Plan

- [x] `golangci-lint` clean across all build-tag combinations, and again with `-tags=integration`
- [x] `go test -race ./internal/audiocore/stream/ ./internal/conf/` green; package unit tests cover the codec-decode dispatch, channel shaping, the chunk/dispatch pipeline with FrameRef pool-return accounting, health/error mapping, and the manager lifecycle with `goleak`
- [x] `BenchmarkPipelineProcess` locks the per-frame allocation budget
- [x] Integration-tagged `TestNativeManagerContract` runs the shared producer-agnostic characterization suite (frame shape, PCM fidelity across codecs, data rate, lifecycle, health transitions, reconnect, media modes, multi-stream, error clarity, time to first frame) against the native manager using a MediaMTX container
- [x] Engine tests confirm the default FFmpeg path is unaffected
- [ ] Field validation with `BIRDNET_STREAM_INGEST=native` against a real RTSP camera on the QA hosts

## Release notes
- audience: user
- summary: New optional pure-Go native RTSP audio ingest, enabled with BIRDNET_STREAM_INGEST=native; the default stays FFmpeg, so nothing changes unless you opt in. Experimental in this release.
- feature: Native network stream ingest
- breaking: none
- config: none (opt-in via the BIRDNET_STREAM_INGEST environment variable; default ffmpeg)
- schema: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional native Go audio-streaming engine for RTSP sources.
  - Supports PCM, Opus, MP3, AAC, and MP4A-LATM audio decoding.
  - Added automatic downmixing, resampling, and consistent audio chunk delivery.
  - Added stream lifecycle monitoring with connection health, error details, and recovery status.
  - Added configurable timeouts, reconnect behavior, TLS handling, authentication, and diagnostics.
  - Native ingest can be enabled with `BIRDNET_STREAM_INGEST=native`; FFmpeg remains the default.

- **Documentation**
  - Added guidance covering native stream support, limitations, lifecycle behavior, and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->