### PR TITLE
docs(wiki): add install.sh troubleshooting and correct manual binary deps

### DIFF
--- a/doc/wiki/faq.md
+++ b/doc/wiki/faq.md
@@ -28,6 +28,12 @@ The app opened a fresh, empty database instead of your real one. Your old detect
 
 No. `install.sh` supports Debian, Ubuntu, and Raspberry Pi OS only. Use a manual binary install on macOS (see the [Installation Guide](installation.md)).
 
+### install.sh fails on WSL ("requires systemd" or "Docker cannot be accessed")
+
+Two things trip people up under WSL. First, the installer manages BirdNET-Go as a systemd service, so systemd has to be the init system (PID 1). Enable it by adding a `[boot]` section with `systemd=true` to `/etc/wsl.conf`, then run `wsl --shutdown` from Windows and reopen the distro. Second, "Docker cannot be accessed by user" means the `docker info` check failed, usually because your user isn't in the `docker` group yet (group changes need a fresh login, and on WSL that means another `wsl --shutdown`) or the Docker service isn't running (`sudo systemctl enable --now docker`). The full step-by-step is in [Troubleshooting install.sh](installation.md#troubleshooting-installsh).
+
+Worth knowing: BirdNET-Go also runs natively on Windows with no Docker and no WSL, so if WSL is more hassle than it's worth, just download the Windows archive from the [releases page](https://github.com/tphakala/birdnet-go/releases) and run `birdnet-go.exe`.
+
 ### I installed as root. How do I move to a normal user without losing data?
 
 Run `install.sh` as your normal user; it detects the root install and offers to migrate it automatically. After migrating, the old `/root/birdnet-go-app` is left in place so you can verify, which makes the installer keep re-offering migration. Once you have confirmed everything works, remove it:

--- a/doc/wiki/index.md
+++ b/doc/wiki/index.md
@@ -52,6 +52,7 @@ Welcome to the BirdNET-Go documentation. This index will help you navigate throu
 ## Troubleshooting & Support
 
 - [Frequently Asked Questions](faq.md) - Common questions, problems, and quick fixes
+- [install.sh Troubleshooting](installation.md#troubleshooting-installsh) - Fixing installer failures (systemd, Docker access, WSL)
 - [RTSP Troubleshooting](rtsp-troubleshooting.md) - Comprehensive guide for RTSP camera issues and configuration
 - [Docker Troubleshooting](guide.md#docker-installation-troubleshooting) - Resolving common Docker issues
 - [Support Script](guide.md#support-script) - Generating diagnostic information

--- a/doc/wiki/installation.md
+++ b/doc/wiki/installation.md
@@ -7,7 +7,7 @@ There are four main ways to install BirdNET-Go:
 1.  **Using `install.sh` (Recommended for Linux):** This script automates the setup of BirdNET-Go within a Docker container, including dependencies, configuration prompts, performance optimization, and systemd service creation. This is the easiest and recommended method for supported Linux distributions (Debian 11+, Ubuntu 20.04+, Raspberry Pi OS Bullseye+).
 2.  **Using Docker Compose (Linux only):** Set up BirdNET-Go using Docker Compose for a more flexible containerized approach. This offers better configurability and easier management than manual Docker installation. See the [Docker Compose Guide](docker_compose_guide.md) for detailed instructions.
 3.  **Manual Docker Installation (Advanced, Linux only):** Manually run the BirdNET-Go Docker container. This offers more control but requires managing the container lifecycle yourself.
-4.  **Manual Binary Installation (All platforms):** Download pre-compiled binaries. This is currently the only supported method for Windows and macOS users. This approach avoids Docker but requires manually installing dependencies (TensorFlow Lite C library, FFmpeg, SoX) and managing the application process.
+4.  **Manual Binary Installation (All platforms):** Download pre-compiled binaries. This is currently the only supported method for Windows and macOS users. This approach avoids Docker; the release archive bundles the machine learning libraries (TensorFlow Lite C and ONNX Runtime), and you only install FFmpeg and SoX separately if you need the features that use them (see [Manual Binary Installation](#manual-binary-installation-all-platforms)). You manage the application process yourself.
 
 ## Container Registry Options
 
@@ -90,6 +90,69 @@ If you installed BirdNET-Go using the `install.sh` script, updating is straightf
     - Restart the BirdNET-Go service with the new image.
     - Your existing configuration and data in `~/birdnet-go-app/` will be preserved.
 
+## Troubleshooting `install.sh`
+
+The installer runs a series of preflight checks and stops with a clear message if one fails. The most common failures, and how to fix them, are below. Every step is also written to the install log (the path is printed at the start of the run), so check the log if you need more detail.
+
+### `This script requires systemd as the init system`
+
+`install.sh` installs BirdNET-Go as a systemd service and starts the Docker service through systemd, so systemd must be the init system (PID 1). You will hit this on minimal container images, some VPS templates, and **WSL running the default init**.
+
+On WSL, enable systemd once and restart the distribution:
+
+1.  Edit (or create) `/etc/wsl.conf` inside your WSL distribution:
+
+    ```bash
+    sudo tee /etc/wsl.conf > /dev/null <<'EOF'
+    [boot]
+    systemd=true
+    EOF
+    ```
+
+2.  From a **Windows** PowerShell or Command Prompt, fully restart WSL:
+
+    ```powershell
+    wsl --shutdown
+    ```
+
+3.  Reopen your distribution and re-run `bash ./install.sh`. Confirm it worked with `ps -p 1 -o comm=`, which should now print `systemd`.
+
+Enabling systemd in WSL needs a reasonably recent WSL release (0.67.6 or newer, which ships with current Windows 10 and 11). If you would rather not deal with systemd at all, BirdNET-Go also runs **natively on Windows** with no Docker and no WSL; see [Manual Binary Installation](#manual-binary-installation-all-platforms).
+
+### `Docker cannot be accessed by user ...`
+
+This means the installer's `docker info` check failed. There are three common causes; work through them in order:
+
+```bash
+# 1. Is your user in the docker group?
+groups "$USER"
+
+# 2. Is the Docker service running?
+sudo systemctl status docker --no-pager
+
+# 3. Can Docker be reached at all?
+docker info
+```
+
+- **Your user is not in the `docker` group.** The installer adds it for you with `sudo usermod -aG docker "$USER"`, but group membership only takes effect in a **new login session**. Log out and back in, then re-run the installer. On WSL, closing the terminal is not enough; run `wsl --shutdown` from Windows and reopen the distribution. To apply the group in your current shell without logging out, run `newgrp docker`.
+- **The Docker service is not running.** Start it and enable it on boot:
+
+  ```bash
+  sudo systemctl enable --now docker
+  ```
+
+  If `/var/run/docker.sock` does not exist, the daemon is not running; start the service and retry `docker info`.
+
+- **The socket is not accessible.** Check that the daemon is up and the socket has group access with `ls -l /var/run/docker.sock` (it should be owned by `root:docker`).
+
+On WSL specifically, use the Docker packages the installer sets up (or `sudo apt install docker.io`) together with systemd, as described above. Docker Desktop's WSL integration gives you a working `docker` command but does not run as a systemd service, so `install.sh` cannot manage it.
+
+### The installer says to log out and log back in
+
+When the script installs Docker or adds you to the `docker`/`audio` groups, it exits and asks you to log out and back in before re-running it. This is expected: Linux only applies new group membership to new login sessions. Start a fresh session (log out and in, or on WSL run `wsl --shutdown` from Windows and reopen the distribution), then run `bash ./install.sh` again to continue.
+
+For runtime problems after a successful install (no sound, web UI unreachable, container restarts), see [Docker Installation Troubleshooting](guide.md#docker-installation-troubleshooting) and the [FAQ](faq.md).
+
 ## Using Docker Compose (Linux only)
 
 For a more flexible containerized approach than the manual Docker installation, you can use Docker Compose which offers better configurability and easier management.
@@ -164,17 +227,22 @@ docker run -ti --rm \\
 
 This method does not use Docker but requires manual dependency installation.
 
-1.  **Download Binary:** Go to the [BirdNET-Go Releases page](https://github.com/tphakala/birdnet-go/releases) and download the pre-compiled binary suitable for your operating system (Linux, macOS, Windows) and architecture.
-2.  **Download TFLite Library:** Download the corresponding TensorFlow Lite C library from [tphakala/tflite_c Releases](https://github.com/tphakala/tflite_c/releases). Follow the installation instructions there (copying the `.so`, `.dylib`, or `.dll` file to the correct system path or the BirdNET-Go executable directory). Version `v2.17.1` or newer is recommended for best performance (XNNPACK support).
-3.  **(Optional) Install ONNX Runtime:** Required for BirdNET v3.0 models (currently in development preview). The release tarballs bundle the library. See the [ONNX Runtime Installation Guide](onnx-runtime-installation.md) for platform-specific instructions.
-4.  **Install Dependencies:**
-    - **FFmpeg:** Required for RTSP stream capture and on-demand clip transcoding in the web interface. WAV, FLAC and Opus are encoded natively and do not need FFmpeg. AAC and MP3 export use FFmpeg by default, but each has a native encoder available as an opt-in preview via the `BIRDNET_AAC_ENCODER=native` and `BIRDNET_MP3_ENCODER=native` environment variables. The [Live Audio Streaming](guide.md#live-audio-streaming) feature is now encoded natively and no longer uses FFmpeg at all. Loudness normalization of saved clips is done natively for every format and no longer needs FFmpeg. Install using your system's package manager (e.g., `sudo apt install ffmpeg` on Debian/Ubuntu, `brew install ffmpeg` on macOS).
-    - **SoX:** Required for rendering spectrograms in the web interface. Install using your system's package manager (e.g., `sudo apt install sox` on Debian/Ubuntu, `brew install sox` on macOS).
+1.  **Download Binary:** Go to the [BirdNET-Go Releases page](https://github.com/tphakala/birdnet-go/releases) and download the pre-compiled archive for your operating system (Linux, macOS, Windows) and architecture.
+2.  **Machine learning libraries are bundled:** The release archive already includes the TensorFlow Lite C library and the ONNX Runtime library next to the executable (`tensorflowlite_c.dll` and `onnxruntime.dll` on Windows, `libtensorflowlite_c.so`/`libonnxruntime.so` on Linux, `libtensorflowlite_c.dylib`/`libonnxruntime.dylib` on macOS). Each archive contains a `README.md` with the exact per-platform steps; in short:
+    - **Windows:** Keep the `.dll` files in the same folder as `birdnet-go.exe`. Windows loads them from the application directory automatically, so no further setup is needed.
+    - **Linux:** Copy the `.so` files to a directory on the library search path and refresh the linker cache (`sudo cp libtensorflowlite_c.so libonnxruntime.so /usr/local/lib/ && sudo ldconfig`), or, without root, run the binary from the extracted folder with `LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH"`.
+    - **macOS:** Copy the `.dylib` files to `/usr/local/lib/` (the dynamic linker searches it by default), and clear the Gatekeeper quarantine attribute with `xattr -d com.apple.quarantine` on the binary and the libraries.
+
+    You only need to download the library separately (from [tphakala/tflite_c Releases](https://github.com/tphakala/tflite_c/releases), `v2.17.1` or newer for XNNPACK support) if you build BirdNET-Go from source rather than using a release archive. See the [ONNX Runtime Installation Guide](onnx-runtime-installation.md) if you need to install ONNX Runtime manually.
+
+3.  **Install Optional Dependencies:** These external tools are not bundled. Install the ones you need for the features you use:
+    - **FFmpeg:** Required for RTSP stream capture and on-demand clip transcoding in the web interface. WAV, FLAC and Opus are encoded natively and do not need FFmpeg. AAC and MP3 export use FFmpeg by default, but each has a native encoder available as an opt-in preview via the `BIRDNET_AAC_ENCODER=native` and `BIRDNET_MP3_ENCODER=native` environment variables. The [Live Audio Streaming](guide.md#live-audio-streaming) feature is now encoded natively and no longer uses FFmpeg at all. Loudness normalization of saved clips is done natively for every format and no longer needs FFmpeg. Install using your system's package manager (e.g., `sudo apt install ffmpeg` on Debian/Ubuntu, `brew install ffmpeg` on macOS, or download a build from [ffmpeg.org](https://ffmpeg.org/download.html) on Windows).
+    - **SoX:** Required for rendering spectrograms in the web interface. Install using your system's package manager (e.g., `sudo apt install sox` on Debian/Ubuntu, `brew install sox` on macOS, or download from the [SoX project](https://sourceforge.net/projects/sox/) on Windows).
     - **libasound2 (Linux only):** Required for microphone audio capture. Install with `sudo apt install libasound2-dev` on Debian/Ubuntu.
-5.  **Place Executable:** Extract the downloaded BirdNET-Go binary and place it in your desired directory.
-6.  **Run BirdNET-Go:** Open a terminal or command prompt, navigate to the directory containing the `birdnet-go` executable, and run it (e.g., `./birdnet-go`).
-7.  **Configuration:** On the first run, BirdNET-Go will create a default `config.yaml` file. Edit this file according to your needs. See the [Configuration](guide.md#configuration) section in the Wiki for details and default file locations per OS.
-8.  **Process Management:** You are responsible for managing the BirdNET-Go process (running it in the background, ensuring it restarts on boot, etc.) using tools like `systemd`, `supervisor`, `screen`, or Task Scheduler (Windows).
+4.  **Place Executable:** Put the `birdnet-go` binary wherever you want to run it. If you did not install the libraries to a system path in step 2, keep the bundled libraries in the same folder as the binary (this is the required setup on Windows).
+5.  **Run BirdNET-Go:** Open a terminal or command prompt, navigate to the directory containing the `birdnet-go` executable, and run it (e.g., `./birdnet-go` on Linux/macOS, or double-click `birdnet-go.exe` on Windows).
+6.  **Configuration:** On the first run, BirdNET-Go will create a default `config.yaml` file. Edit this file according to your needs. See the [Configuration](guide.md#configuration) section in the Wiki for details and default file locations per OS.
+7.  **Process Management:** You are responsible for managing the BirdNET-Go process (running it in the background, ensuring it restarts on boot, etc.) using tools like `systemd`, `supervisor`, `screen`, or Task Scheduler (Windows).
 
 ## Systemd Service Details (`install.sh` Method)
 

--- a/doc/wiki/installation.md
+++ b/doc/wiki/installation.md
@@ -92,7 +92,7 @@ If you installed BirdNET-Go using the `install.sh` script, updating is straightf
 
 ## Troubleshooting `install.sh`
 
-The installer runs a series of preflight checks and stops with a clear message if one fails. The most common failures, and how to fix them, are below. Every step is also written to the install log (the path is printed at the start of the run), so check the log if you need more detail.
+The installer runs a series of preflight checks and stops with a clear message if one fails. The most common failures, and how to fix them, are below. Every step is also written to a timestamped install log at `~/birdnet-go-app/data/logs/install-<timestamp>.log`, so open the newest file there if you need more detail.
 
 ### `This script requires systemd as the init system`
 
@@ -100,14 +100,14 @@ The installer runs a series of preflight checks and stops with a clear message i
 
 On WSL, enable systemd once and restart the distribution:
 
-1.  Edit (or create) `/etc/wsl.conf` inside your WSL distribution:
+1.  Edit `/etc/wsl.conf` inside your WSL distribution (create it if it does not exist), for example with `sudo nano /etc/wsl.conf`. Make sure it contains:
 
-    ```bash
-    sudo tee /etc/wsl.conf > /dev/null <<'EOF'
+    ```ini
     [boot]
     systemd=true
-    EOF
     ```
+
+    If the file already has content, do not overwrite it: keep the existing sections and just add the `[boot]` section, or add `systemd=true` under an existing `[boot]` section.
 
 2.  From a **Windows** PowerShell or Command Prompt, fully restart WSL:
 
@@ -225,13 +225,19 @@ docker run -ti --rm \\
 
 ## Manual Binary Installation (All platforms)
 
-This method does not use Docker but requires manual dependency installation.
+This method does not use Docker. The release archive bundles the machine learning libraries, so a minimal run needs no extra downloads; you only install the optional tools (FFmpeg, SoX, `libasound2`) for the features that use them, and you manage the process yourself.
 
 1.  **Download Binary:** Go to the [BirdNET-Go Releases page](https://github.com/tphakala/birdnet-go/releases) and download the pre-compiled archive for your operating system (Linux, macOS, Windows) and architecture.
 2.  **Machine learning libraries are bundled:** The release archive already includes the TensorFlow Lite C library and the ONNX Runtime library next to the executable (`tensorflowlite_c.dll` and `onnxruntime.dll` on Windows, `libtensorflowlite_c.so`/`libonnxruntime.so` on Linux, `libtensorflowlite_c.dylib`/`libonnxruntime.dylib` on macOS). Each archive contains a `README.md` with the exact per-platform steps; in short:
     - **Windows:** Keep the `.dll` files in the same folder as `birdnet-go.exe`. Windows loads them from the application directory automatically, so no further setup is needed.
     - **Linux:** Copy the `.so` files to a directory on the library search path and refresh the linker cache (`sudo cp libtensorflowlite_c.so libonnxruntime.so /usr/local/lib/ && sudo ldconfig`), or, without root, run the binary from the extracted folder with `LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH"`.
-    - **macOS:** Copy the `.dylib` files to `/usr/local/lib/` (the dynamic linker searches it by default), and clear the Gatekeeper quarantine attribute with `xattr -d com.apple.quarantine` on the binary and the libraries.
+    - **macOS:** Copy the `.dylib` files to `/usr/local/lib/` (the dynamic linker searches it by default), then clear the Gatekeeper quarantine attribute from the binary and both libraries, naming each path explicitly:
+
+      ```bash
+      xattr -d com.apple.quarantine birdnet-go
+      xattr -d com.apple.quarantine /usr/local/lib/libtensorflowlite_c.dylib
+      xattr -d com.apple.quarantine /usr/local/lib/libonnxruntime.dylib
+      ```
 
     You only need to download the library separately (from [tphakala/tflite_c Releases](https://github.com/tphakala/tflite_c/releases), `v2.17.1` or newer for XNNPACK support) if you build BirdNET-Go from source rather than using a release archive. See the [ONNX Runtime Installation Guide](onnx-runtime-installation.md) if you need to install ONNX Runtime manually.
 
@@ -239,7 +245,7 @@ This method does not use Docker but requires manual dependency installation.
     - **FFmpeg:** Required for RTSP stream capture and on-demand clip transcoding in the web interface. WAV, FLAC and Opus are encoded natively and do not need FFmpeg. AAC and MP3 export use FFmpeg by default, but each has a native encoder available as an opt-in preview via the `BIRDNET_AAC_ENCODER=native` and `BIRDNET_MP3_ENCODER=native` environment variables. The [Live Audio Streaming](guide.md#live-audio-streaming) feature is now encoded natively and no longer uses FFmpeg at all. Loudness normalization of saved clips is done natively for every format and no longer needs FFmpeg. Install using your system's package manager (e.g., `sudo apt install ffmpeg` on Debian/Ubuntu, `brew install ffmpeg` on macOS, or download a build from [ffmpeg.org](https://ffmpeg.org/download.html) on Windows).
     - **SoX:** Required for rendering spectrograms in the web interface. Install using your system's package manager (e.g., `sudo apt install sox` on Debian/Ubuntu, `brew install sox` on macOS, or download from the [SoX project](https://sourceforge.net/projects/sox/) on Windows).
     - **libasound2 (Linux only):** Required for microphone audio capture. Install with `sudo apt install libasound2-dev` on Debian/Ubuntu.
-4.  **Place Executable:** Put the `birdnet-go` binary wherever you want to run it. If you did not install the libraries to a system path in step 2, keep the bundled libraries in the same folder as the binary (this is the required setup on Windows).
+4.  **Place Executable:** Put the `birdnet-go` binary wherever you want to run it. On **Windows**, keep the bundled `.dll` files in that same folder (Windows loads them from the application directory). On **Linux** and **macOS**, placing the libraries next to the binary is not enough on its own, because the dynamic linker does not search the application directory by default; make them findable using the system-path or `LD_LIBRARY_PATH` approach from step 2.
 5.  **Run BirdNET-Go:** Open a terminal or command prompt, navigate to the directory containing the `birdnet-go` executable, and run it (e.g., `./birdnet-go` on Linux/macOS, or double-click `birdnet-go.exe` on Windows).
 6.  **Configuration:** On the first run, BirdNET-Go will create a default `config.yaml` file. Edit this file according to your needs. See the [Configuration](guide.md#configuration) section in the Wiki for details and default file locations per OS.
 7.  **Process Management:** You are responsible for managing the BirdNET-Go process (running it in the background, ensuring it restarts on boot, etc.) using tools like `systemd`, `supervisor`, `screen`, or Task Scheduler (Windows).


### PR DESCRIPTION
## Summary

Inspired by [discussion #4276](https://github.com/tphakala/birdnet-go/discussions/4276), where a user hit `install.sh` failures running under WSL and suggested a troubleshooting section for the wiki.

Adds a **Troubleshooting `install.sh`** section to the installation guide covering the two preflight failures that stop the installer for WSL and minimal-init users, both verified against `install.sh`:

- **`This script requires systemd as the init system`** (`check_systemd()` in `install.sh`): the installer manages BirdNET-Go as a systemd service and starts Docker through systemd, so PID 1 must be systemd. Documents enabling systemd on WSL via `/etc/wsl.conf` (`[boot]` / `systemd=true`) and `wsl --shutdown`.
- **`Docker cannot be accessed by user ...`** (the `docker info` preflight): documents the three causes the script itself reports (user not in the `docker` group and needing a fresh login, Docker service not running, socket permissions) with the fix for each, including the WSL-specific steps.

Also corrects the **Manual Binary Installation** section, which is the discussion's secondary theme (the native install looking more technical than it is). The release archive already bundles the TensorFlow Lite C and ONNX Runtime libraries next to the binary for every platform (verified in `.github/actions/build-birdnet-binary/action.yml`), so a separate library download is only needed when building from source. Added per-platform library-placement steps that match the `README.md` shipped inside each archive (Windows application folder, Linux `ldconfig` or `LD_LIBRARY_PATH`, macOS `/usr/local/lib` plus quarantine clearing).

The SoX and FFmpeg dependency notes were left unchanged: they are already accurate (SoX is still the spectrogram renderer, FFmpeg is still used for RTSP ingest, on-demand transcode, and default AAC/MP3 export), so the discussion bot's "SoX is no longer used" claim was not adopted.

Adds a matching FAQ entry and a Troubleshooting & Support index link. On merge, the wiki-sync workflow publishes these pages to the GitHub wiki.

## Changes

- `doc/wiki/installation.md`: new `## Troubleshooting install.sh` section; reworked Manual Binary Installation steps for bundled libraries and per-platform placement.
- `doc/wiki/faq.md`: new "install.sh fails on WSL" entry under Installation and updates.
- `doc/wiki/index.md`: link to the new troubleshooting section.

## Test Plan

- [x] `go run ./cmd/wiki-export doc/wiki <staging>` succeeds; cross-page links rewrite to correct wiki slugs (`installation#troubleshooting-installsh`, `BirdNET-Go-Guide#docker-installation-troubleshooting`, `FAQ`) and same-page anchors are preserved.
- [x] `go test ./cmd/wiki-export/` passes.
- [x] `prettier --check` clean on all three files.
- [x] Technical claims verified against `install.sh`, the release build action, and the bundled platform READMEs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added troubleshooting guidance for WSL, including systemd, Docker access, permissions, service startup, and required restarts.
  - Added guidance for preserving existing WSL configuration when enabling systemd.
  - Documented the native Windows installation alternative.
  - Updated macOS quarantine-removal commands for executables and library files.
  - Updated manual installation instructions for release archives and platform-specific library placement.
  - Clarified optional FFmpeg and SoX dependencies.
  - Added troubleshooting links, including install script guidance, to the documentation index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->