### PR TITLE
feat(audiocore): native ingest liveness coordination and stream observability

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -54,12 +55,13 @@ The "realtime" command is an alias for backward compatibility.`,
 			engineTransport := settings.Realtime.RTSP.ResolveTransport("")
 
 			audioEngine := engine.New(cmd.Context(), &engine.Config{
-				FFmpegPath:           settings.Realtime.Audio.FfmpegPath,
-				SoxPath:              settings.Realtime.Audio.SoxPath,
-				Transport:            engineTransport,
-				FFmpegParameters:     settings.Realtime.RTSP.FFmpegParameters,
-				Debug:                settings.Debug,
-				CaptureBufferSeconds: settings.Realtime.ExtendedCapture.EffectiveCaptureBufferSeconds(settings.Realtime.Audio.Export.PreCapture),
+				FFmpegPath:               settings.Realtime.Audio.FfmpegPath,
+				SoxPath:                  settings.Realtime.Audio.SoxPath,
+				Transport:                engineTransport,
+				FFmpegParameters:         settings.Realtime.RTSP.FFmpegParameters,
+				Debug:                    settings.Debug,
+				CaptureBufferSeconds:     settings.Realtime.ExtendedCapture.EffectiveCaptureBufferSeconds(settings.Realtime.Audio.Export.PreCapture),
+				LivenessSilenceThreshold: time.Duration(settings.Realtime.Audio.Watchdog.SilenceThreshold) * time.Second,
 			}, nil)
 			defer audioEngine.Stop()
 

--- a/frontend/src/lib/desktop/components/forms/StreamCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamCard.svelte
@@ -175,7 +175,8 @@
   // Derive connection stability status
   let connectionStatus = $derived.by(() => {
     if (!health) return 'Unknown';
-    if (health.process_state === 'circuit_open') return 'Failed';
+    if (health.process_state === 'circuit_open' || health.process_state === 'failed')
+      return 'Failed';
     if (health.process_state === 'backoff' || health.process_state === 'restarting')
       return 'Degraded';
     if (health.is_healthy && health.is_receiving_data) return 'Stable';
@@ -893,7 +894,9 @@
               <span
                 class={cn(
                   'ml-2',
-                  health?.process_state === 'circuit_open' || health?.process_state === 'stopped'
+                  health?.process_state === 'circuit_open' ||
+                    health?.process_state === 'failed' ||
+                    health?.process_state === 'stopped'
                     ? 'text-[var(--color-error)]'
                     : 'text-[var(--color-base-content)]'
                 )}

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -317,6 +317,17 @@ func (p *AudioPipelineService) Start(_ context.Context) error {
 			}
 			return p.quietHoursScheduler.IsStreamSuppressed(sourceID)
 		},
+		// RecoveryState lets the watchdog defer a restart to the native stream
+		// supervisor while it reconnects in place. Sound-card sources and the FFmpeg
+		// producer have no recovery intent, so the lookup miss / RecoveryUnknown both
+		// return the legacy restart path.
+		RecoveryState: func(sourceID string) (audiocore.RecoveryState, time.Time) {
+			h, err := p.engine.StreamManager().StreamHealth(sourceID)
+			if err != nil || h == nil {
+				return audiocore.RecoveryUnknown, time.Time{}
+			}
+			return h.Recovery, h.RecoveryEntered
+		},
 	}
 	p.watchdog = audiocore.NewLivenessWatchdog(
 		buildLivenessConfig(settings.Realtime.Audio.Watchdog),

--- a/internal/api/v2/audio/streams_health.go
+++ b/internal/api/v2/audio/streams_health.go
@@ -66,6 +66,25 @@ type StreamHealthResponse struct {
 	ErrorHistory     []*ErrorContextResponse `json:"error_history,omitempty"`      // Recent errors (last 10)
 	// State history (for debugging state transitions)
 	StateHistory []StateTransitionResponse `json:"state_history,omitempty"` // Recent state transitions
+	// Observability (native ingest). FFmpeg populates Engine and Transport and
+	// leaves the RTP-specific fields zero so they omit from the response.
+	Engine                string    `json:"engine,omitempty"`                   // Ingest producer: "native" or "ffmpeg"
+	Recovery              string    `json:"recovery,omitempty"`                 // Producer recovery intent (native): idle, in_progress, given_up
+	Codec                 string    `json:"codec,omitempty"`                    // Decoded source codec label
+	SourceSampleRate      int       `json:"source_sample_rate,omitempty"`       // Codec native sample rate (Hz) before resampling
+	Transport             string    `json:"transport,omitempty"`                // Negotiated/configured transport (tcp, udp)
+	WireBytesPerSecond    float64   `json:"wire_bytes_per_second,omitempty"`    // Wire data rate (native)
+	PayloadBytesPerSecond float64   `json:"payload_bytes_per_second,omitempty"` // RTP payload data rate (native)
+	Packets               uint64    `json:"packets,omitempty"`                  // Accepted RTP frames this session (native)
+	SeqGaps               uint64    `json:"seq_gaps,omitempty"`                 // Packets lost per sequence tracking (native)
+	Duplicates            uint64    `json:"duplicates,omitempty"`               // Duplicate/reordered packets (native)
+	Malformed             uint64    `json:"malformed,omitempty"`                // Discarded unparseable packets (native)
+	SSRCResets            uint64    `json:"ssrc_resets,omitempty"`              // Mid-stream SSRC changes tolerated (native)
+	LastFrameAt           time.Time `json:"last_frame_at,omitzero"`             // Wall-clock of most recent media frame (native)
+	SenderClockValid      bool      `json:"sender_clock_valid,omitempty"`       // RTCP sender-report clock present (native)
+	SenderClockAgeSeconds float64   `json:"sender_clock_age_seconds,omitempty"` // Age of the RTCP sender report (native)
+	ReconnectAttempt      int       `json:"reconnect_attempt,omitempty"`        // Current reconnect attempt (native)
+	NextRetryInSeconds    float64   `json:"next_retry_in_seconds,omitempty"`    // Backoff before the next reconnect (native)
 }
 
 // ErrorContextResponse represents the API response for FFmpeg error context
@@ -393,6 +412,29 @@ func convertStreamHealthToResponse(rawURL string, health *audiocore.StreamHealth
 		BytesPerSecond:     health.BytesPerSecond,
 		IsReceivingData:    health.IsReceivingData,
 		SourceChannels:     health.SourceChannels,
+
+		Engine:                health.Engine,
+		Codec:                 health.Codec,
+		SourceSampleRate:      health.SourceSampleRate,
+		Transport:             health.Transport,
+		WireBytesPerSecond:    health.WireBytesPerSecond,
+		PayloadBytesPerSecond: health.PayloadBytesPerSecond,
+		Packets:               health.Packets,
+		SeqGaps:               health.SeqGaps,
+		Duplicates:            health.Duplicates,
+		Malformed:             health.Malformed,
+		SSRCResets:            health.SSRCResets,
+		LastFrameAt:           health.LastFrameAt,
+		SenderClockValid:      health.SenderClockValid,
+		SenderClockAgeSeconds: health.SenderClockAge.Seconds(),
+		ReconnectAttempt:      health.ReconnectAttempt,
+		NextRetryInSeconds:    health.NextRetryIn.Seconds(),
+	}
+
+	// Recovery intent is native-only; FFmpeg reports RecoveryUnknown, which stays
+	// absent so the FFmpeg response is unchanged.
+	if health.Recovery != audiocore.RecoveryUnknown {
+		response.Recovery = health.Recovery.String()
 	}
 
 	// Handle LastDataReceived (may be zero time if never received data)

--- a/internal/api/v2/system/diagnostics.go
+++ b/internal/api/v2/system/diagnostics.go
@@ -434,6 +434,18 @@ func (c *Handler) buildStreamHealthProvider() func() []checks.StreamHealthInfo {
 				SSRCResets:         sh.SSRCResets,
 			})
 		}
+		// AllStreamHealth ranges a map, so sort by URL for a stable support-dump
+		// ordering (the diagnostics file sorts its other map-derived outputs too).
+		slices.SortFunc(infos, func(a, b checks.StreamHealthInfo) int {
+			switch {
+			case a.URL < b.URL:
+				return -1
+			case a.URL > b.URL:
+				return 1
+			default:
+				return 0
+			}
+		})
 		return infos
 	}
 }

--- a/internal/api/v2/system/diagnostics.go
+++ b/internal/api/v2/system/diagnostics.go
@@ -419,11 +419,19 @@ func (c *Handler) buildStreamHealthProvider() func() []checks.StreamHealthInfo {
 				errMsg = sh.Error.Error()
 			}
 			infos = append(infos, checks.StreamHealthInfo{
-				URL:          url,
-				IsHealthy:    sh.IsHealthy,
-				State:        sh.State,
-				RestartCount: sh.RestartCount,
-				Error:        errMsg,
+				URL:                url,
+				IsHealthy:          sh.IsHealthy,
+				State:              sh.State,
+				RestartCount:       sh.RestartCount,
+				Error:              errMsg,
+				Engine:             sh.Engine,
+				Codec:              sh.Codec,
+				WireBytesPerSecond: sh.WireBytesPerSecond,
+				Packets:            sh.Packets,
+				SeqGaps:            sh.SeqGaps,
+				Duplicates:         sh.Duplicates,
+				Malformed:          sh.Malformed,
+				SSRCResets:         sh.SSRCResets,
 			})
 		}
 		return infos

--- a/internal/api/v2/system/diagnostics.go
+++ b/internal/api/v2/system/diagnostics.go
@@ -2,6 +2,7 @@
 package system
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"maps"
@@ -406,20 +407,39 @@ func (c *Handler) buildStreamHealthProvider() func() []checks.StreamHealthInfo {
 			return nil
 		}
 		registry := eng.Registry()
-		infos := make([]checks.StreamHealthInfo, 0, len(healthMap))
-		for sourceID, sh := range healthMap {
+		// AllStreamHealth ranges a map, so order deterministically for a stable
+		// support-dump ordering (the diagnostics file sorts its other map-derived
+		// outputs too). Sort by sanitized URL, then by the unique source ID, so two
+		// sources that sanitize to the same URL (credentials stripped) still order
+		// deterministically. Source IDs are precomputed to sanitized URLs so the
+		// comparator does no per-comparison registry lookup.
+		urls := make(map[string]string, len(healthMap))
+		ids := make([]string, 0, len(healthMap))
+		for sourceID := range healthMap {
 			url := sourceID
 			if registry != nil {
 				if connStr, ok := registry.ConnectionStringByID(sourceID); ok {
 					url = privacy.SanitizeStreamUrl(connStr)
 				}
 			}
+			urls[sourceID] = url
+			ids = append(ids, sourceID)
+		}
+		slices.SortFunc(ids, func(a, b string) int {
+			if c := cmp.Compare(urls[a], urls[b]); c != 0 {
+				return c
+			}
+			return cmp.Compare(a, b)
+		})
+		infos := make([]checks.StreamHealthInfo, 0, len(ids))
+		for _, sourceID := range ids {
+			sh := healthMap[sourceID]
 			errMsg := ""
 			if sh.Error != nil {
 				errMsg = sh.Error.Error()
 			}
 			infos = append(infos, checks.StreamHealthInfo{
-				URL:                url,
+				URL:                urls[sourceID],
 				IsHealthy:          sh.IsHealthy,
 				State:              sh.State,
 				RestartCount:       sh.RestartCount,
@@ -434,18 +454,6 @@ func (c *Handler) buildStreamHealthProvider() func() []checks.StreamHealthInfo {
 				SSRCResets:         sh.SSRCResets,
 			})
 		}
-		// AllStreamHealth ranges a map, so sort by URL for a stable support-dump
-		// ordering (the diagnostics file sorts its other map-derived outputs too).
-		slices.SortFunc(infos, func(a, b checks.StreamHealthInfo) int {
-			switch {
-			case a.URL < b.URL:
-				return -1
-			case a.URL > b.URL:
-				return 1
-			default:
-				return 0
-			}
-		})
 		return infos
 	}
 }

--- a/internal/audiocore/engine/engine.go
+++ b/internal/audiocore/engine/engine.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"sync/atomic"
+	"time"
 
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/audiocore/buffer"
@@ -88,6 +89,13 @@ type Config struct {
 	// to support extended capture mode.
 	CaptureBufferSeconds int
 
+	// LivenessSilenceThreshold is the audio watchdog's silence threshold. The
+	// native stream manager tightens its supervisor read-idle window below this so
+	// a stalled transport reconnects in place before the watchdog would alarm.
+	// Zero leaves the native read-idle at its own default. Ignored under the FFmpeg
+	// gate.
+	LivenessSilenceThreshold time.Duration
+
 	// RouterMetrics is optional; nil-safe.
 	// NOTE: Not yet wired to subsystems; metrics plumbing is planned for a future PR.
 	RouterMetrics audiocore.RouterMetrics
@@ -111,6 +119,31 @@ func captureBufferSecs(v int) int {
 		return v
 	}
 	return defaultCaptureBufferSeconds
+}
+
+// nativeReadIdleFloor is the minimum native supervisor read-idle window. A value
+// below this would reconnect on transient network jitter.
+const nativeReadIdleFloor = 5 * time.Second
+
+// deriveNativeReadIdle tightens the native supervisor read-idle window to sit in
+// front of the liveness watchdog silence threshold, so a stalled transport is
+// repaired in place (RecoveryInProgress) before the watchdog would alarm. It
+// returns 0 when the threshold is unknown (<=0), letting the native default
+// apply. The result is min(stream.DefaultReadIdle, two thirds of the threshold),
+// floored at nativeReadIdleFloor only while that floor stays below the silence
+// threshold (so the result is always strictly less than the threshold).
+func deriveNativeReadIdle(silenceThreshold time.Duration) time.Duration {
+	if silenceThreshold <= 0 {
+		return 0
+	}
+	readIdle := min(silenceThreshold*2/3, stream.DefaultReadIdle)
+	// Apply the jitter floor only when it stays below the silence threshold. A
+	// very small threshold must not push readIdle up to or past it, or the
+	// watchdog could alarm before the supervisor's read-idle fires.
+	if readIdle < nativeReadIdleFloor && nativeReadIdleFloor < silenceThreshold {
+		readIdle = nativeReadIdleFloor
+	}
+	return readIdle
 }
 
 // AudioEngine coordinates all audio subsystems: source registry, audio router,
@@ -174,7 +207,11 @@ func New(ctx context.Context, cfg *Config, scheduler *schedule.QuietHoursSchedul
 	dispatch := func(frame audiocore.AudioFrame) { router.Dispatch(frame) }
 	var streamMgr audiocore.StreamManager
 	if conf.NativeStreamIngestEnabled() {
-		streamMgr = stream.NewManager(engineCtx, dispatch, nil, log, bufMgr, &stream.Options{})
+		nativeOpts := &stream.Options{Metrics: cfg.StreamMetrics}
+		if ri := deriveNativeReadIdle(cfg.LivenessSilenceThreshold); ri > 0 {
+			nativeOpts.ReadIdle = ri
+		}
+		streamMgr = stream.NewManager(engineCtx, dispatch, nil, log, bufMgr, nativeOpts)
 		log.Info("network stream ingest using native go-audio-stream path",
 			logger.String("ingest_engine", "native"))
 	} else {
@@ -182,6 +219,7 @@ func New(ctx context.Context, cfg *Config, scheduler *schedule.QuietHoursSchedul
 			FFmpegPath:       cfg.FFmpegPath,
 			FFmpegParameters: cfg.FFmpegParameters,
 			LogLevel:         cfg.LogLevel,
+			Metrics:          cfg.StreamMetrics,
 		})
 	}
 	deviceMgr := audiocore.NewDeviceManager(router, bufMgr, log)

--- a/internal/audiocore/engine/engine_test.go
+++ b/internal/audiocore/engine/engine_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -608,4 +609,55 @@ func TestEngine_StartStream_ZeroBitDepthFallback(t *testing.T) {
 
 	health := eng.StreamManager().AllStreamHealth()
 	assert.Contains(t, health, "test_startstream_bitdepth")
+}
+
+// TestDeriveNativeReadIdle asserts the native supervisor read-idle window sits
+// strictly below the liveness silence threshold for every positive threshold, so
+// the supervisor's read-idle always fires before the watchdog would alarm, while
+// an unknown threshold (<=0) yields 0 (let the native default apply).
+func TestDeriveNativeReadIdle(t *testing.T) {
+	t.Parallel()
+
+	// A non-positive threshold means "unknown": return 0 so the native default applies.
+	assert.Zero(t, deriveNativeReadIdle(0), "threshold 0 must return 0")
+	assert.Zero(t, deriveNativeReadIdle(-5*time.Second), "negative threshold must return 0")
+
+	tests := []struct {
+		name      string
+		threshold time.Duration
+		// want is the exact expected readIdle when non-zero; a zero want means
+		// "assert only the strictly-less-than-threshold invariant".
+		want time.Duration
+	}{
+		// Sub-floor thresholds: the 5s jitter floor is bypassed (it would meet or
+		// exceed the threshold), so readIdle is two thirds of the threshold.
+		{name: "1s sub-floor", threshold: 1 * time.Second, want: 1 * time.Second * 2 / 3},
+		{name: "3s sub-floor", threshold: 3 * time.Second, want: 3 * time.Second * 2 / 3},
+		{name: "5s sub-floor", threshold: 5 * time.Second, want: 5 * time.Second * 2 / 3},
+		// Floor-applied band (5s < threshold < 7.5s): two thirds is below 5s, so the
+		// floor lifts readIdle to 5s while staying below the threshold.
+		{name: "6s floor applied", threshold: 6 * time.Second, want: 5 * time.Second},
+		{name: "7s floor applied", threshold: 7 * time.Second, want: 5 * time.Second},
+		// Two-thirds band (7.5s <= threshold < 30s): floor is below two thirds.
+		{name: "8s two-thirds", threshold: 8 * time.Second, want: 8 * time.Second * 2 / 3},
+		{name: "15s two-thirds", threshold: 15 * time.Second, want: 10 * time.Second},
+		// Capped band (threshold >= 30s): clamped at stream.DefaultReadIdle (20s).
+		{name: "30s capped", threshold: 30 * time.Second, want: 20 * time.Second},
+		{name: "60s capped", threshold: 60 * time.Second, want: 20 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := deriveNativeReadIdle(tt.threshold)
+			// For a positive threshold the read-idle must be positive and STRICTLY
+			// below the threshold, never 0 and never at/past it.
+			require.Positive(t, got, "positive threshold must yield a positive read-idle")
+			assert.Less(t, got, tt.threshold,
+				"read-idle must be strictly less than the silence threshold")
+			if tt.want != 0 {
+				assert.Equal(t, tt.want, got, "read-idle must match the expected value")
+			}
+		})
+	}
 }

--- a/internal/audiocore/ffmpeg/manager.go
+++ b/internal/audiocore/ffmpeg/manager.go
@@ -101,7 +101,7 @@ func NewManager(ctx context.Context, onFrame FrameCallback, onReset func(sourceI
 // starts. NewManager delegates here with a zero Options, so the two constructors
 // behave identically unless a non-zero option is supplied. See Options for the
 // available knobs.
-func NewManagerWithOptions(ctx context.Context, onFrame FrameCallback, onReset func(sourceID string), log logger.Logger, bufMgr *buffer.Manager, opts Options) *Manager {
+func NewManagerWithOptions(ctx context.Context, onFrame FrameCallback, onReset func(sourceID string), log logger.Logger, bufMgr *buffer.Manager, opts Options) *Manager { //nolint:gocritic // hugeParam: Options is a startup config struct passed once per manager; by-value keeps the call sites literal
 	if log == nil {
 		log = audiocore.GetLogger()
 	}
@@ -115,6 +115,7 @@ func NewManagerWithOptions(ctx context.Context, onFrame FrameCallback, onReset f
 		logger:         log,
 		bufMgr:         bufMgr,
 		opts:           opts,
+		metrics:        opts.Metrics,
 		lastForceReset: make(map[string]time.Time),
 	}
 }

--- a/internal/audiocore/ffmpeg/options.go
+++ b/internal/audiocore/ffmpeg/options.go
@@ -1,6 +1,10 @@
 package ffmpeg
 
-import "time"
+import (
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+)
 
 // Options carries manager-level defaults that apply to every stream a Manager
 // starts, as opposed to the per-stream settings on StreamConfig. The zero value
@@ -37,6 +41,10 @@ type Options struct {
 	// LogLevel is the FFmpeg log level (e.g. "error") applied to every stream this
 	// manager starts.
 	LogLevel string
+
+	// Metrics receives stream health and data-rate samples for every stream this
+	// manager starts. Nil-safe: the stream checks for nil before every call.
+	Metrics audiocore.StreamMetrics
 }
 
 // withManagerDefaults returns cfg with manager-level defaults applied where the

--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -1895,6 +1895,8 @@ func (s *Stream) GetHealth() audiocore.StreamHealth {
 	lastError := s.getLastErrorContext()
 
 	return audiocore.StreamHealth{
+		Engine:             audiocore.EngineFFmpeg,
+		Transport:          s.config.Transport,
 		State:              processStateToStreamState(state),
 		StateDetail:        state.String(),
 		StateEntered:       stateEntered,

--- a/internal/audiocore/liveness.go
+++ b/internal/audiocore/liveness.go
@@ -333,10 +333,11 @@ const (
 // whether to restart a silent source now or let the producer's own supervisor
 // finish an in-progress reconnect. A nil callback, an unknown or idle intent, a
 // give-up, or a producer that has been recovering longer than the ceiling all
-// take the legacy restart path. A zero ceiling (coordination disabled) also takes
-// the legacy path because now.Sub(since) is never negative.
+// take the legacy restart path. A nil callback or a non-positive ceiling
+// (coordination disabled) short-circuits to the legacy path without invoking the
+// callback at all.
 func (w *LivenessWatchdog) restartDisposition(sourceID string, now time.Time) restartDisposition {
-	if w.callbacks.RecoveryState == nil {
+	if w.callbacks.RecoveryState == nil || w.cfg.ProducerRecoveryCeiling <= 0 {
 		return restartLegacy
 	}
 	recovery, since := w.callbacks.RecoveryState(sourceID)

--- a/internal/audiocore/liveness.go
+++ b/internal/audiocore/liveness.go
@@ -68,6 +68,14 @@ type LivenessConfig struct {
 	// EscalationTimeout is how long to wait in ESCALATED before transitioning
 	// to FAILED.
 	EscalationTimeout time.Duration
+
+	// ProducerRecoveryCeiling bounds how long the watchdog defers a restart to a
+	// producer that is reconnecting in place (RecoveryInProgress). Past the
+	// ceiling the legacy restart ladder resumes so a genuinely dead source is not
+	// parked forever. Zero disables the coordination (legacy behaviour), which is
+	// the effective state under the FFmpeg gate since FFmpeg reports
+	// RecoveryUnknown.
+	ProducerRecoveryCeiling time.Duration
 }
 
 // DefaultLivenessConfig returns production defaults.
@@ -79,6 +87,10 @@ func DefaultLivenessConfig() LivenessConfig {
 		RetryBackoff:       5 * time.Second,
 		CooldownAfterRecov: 60 * time.Second,
 		EscalationTimeout:  60 * time.Second,
+		// Five minutes matches the native supervisor's default capped-exponential
+		// reconnect budget; past this the source is treated as stuck and the
+		// legacy restart takes over. Not user-configurable yet.
+		ProducerRecoveryCeiling: 5 * time.Minute,
 	}
 }
 
@@ -121,6 +133,13 @@ type LivenessCallbacks struct {
 	// given source. Per-source granularity is required because sound card and
 	// RTSP sources have independent quiet hours schedules.
 	IsQuietHours func(sourceID string) bool
+
+	// RecoveryState reports a producer's recovery intent and when that intent was
+	// last entered, so the watchdog can defer a restart to a producer (the native
+	// stream supervisor) that is reconnecting in place. Optional; when nil the
+	// watchdog always takes the legacy restart path. A lookup miss should return
+	// (RecoveryUnknown, time.Time{}), which also takes the legacy path.
+	RecoveryState func(sourceID string) (RecoveryState, time.Time)
 }
 
 // livenessAction describes a callback to execute outside the mutex.
@@ -296,6 +315,37 @@ func (w *LivenessWatchdog) checkAll() {
 	w.executeActions(actions)
 }
 
+// restartDisposition is the watchdog's decision on whether to tear a source down
+// and restart it, or defer to a producer that is recovering in place.
+type restartDisposition int
+
+const (
+	// restartLegacy takes the pre-native restart ladder. It covers RecoveryUnknown
+	// (FFmpeg, and a nil callback), RecoveryIdle, RecoveryGivenUp, and
+	// RecoveryInProgress once it has run past ProducerRecoveryCeiling.
+	restartLegacy restartDisposition = iota
+	// restartSuppress defers the restart while the producer's supervisor is
+	// reconnecting within the ceiling, so the watchdog does not abort a reconnect.
+	restartSuppress
+)
+
+// restartDisposition consults the optional RecoveryState callback to decide
+// whether to restart a silent source now or let the producer's own supervisor
+// finish an in-progress reconnect. A nil callback, an unknown or idle intent, a
+// give-up, or a producer that has been recovering longer than the ceiling all
+// take the legacy restart path. A zero ceiling (coordination disabled) also takes
+// the legacy path because now.Sub(since) is never negative.
+func (w *LivenessWatchdog) restartDisposition(sourceID string, now time.Time) restartDisposition {
+	if w.callbacks.RecoveryState == nil {
+		return restartLegacy
+	}
+	recovery, since := w.callbacks.RecoveryState(sourceID)
+	if recovery == RecoveryInProgress && !since.IsZero() && now.Sub(since) < w.cfg.ProducerRecoveryCeiling {
+		return restartSuppress
+	}
+	return restartLegacy
+}
+
 // checkSource drives the state machine for a single source. State transitions
 // happen under the mutex; callbacks are collected into actions for deferred
 // execution. The caller must hold w.mu.
@@ -347,11 +397,26 @@ func (w *LivenessWatchdog) checkSource(sourceID string, now time.Time, actions [
 		}
 		h.state = StateRecovering
 		h.stateEntered = now
+		// A native producer whose supervisor is already reconnecting recovers in
+		// place; RestartSource would tear that reconnect down. Defer the restart
+		// while it reports RecoveryInProgress within the ceiling (the alarm has
+		// already fired on the HEALTHY->ALARMED edge, so this still alarms once).
+		// FFmpeg reports RecoveryUnknown, so this is a no-op under the ffmpeg gate.
+		if w.restartDisposition(sourceID, now) == restartSuppress {
+			return actions
+		}
 		actions = w.collectRestart(h, sourceID, now, actions)
 
 	case StateRecovering:
 		if framesFlowing {
 			actions = w.collectRecover(h, sourceID, now, actions)
+			return actions
+		}
+		// Keep waiting while the producer's supervisor reconnects within the
+		// ceiling: no retry is consumed, so the escalation ladder does not advance
+		// on a source the producer is actively recovering. Past the ceiling (or
+		// GivenUp/Idle/Unknown) the legacy ladder below resumes.
+		if w.restartDisposition(sourceID, now) == restartSuppress {
 			return actions
 		}
 		if h.retries >= w.cfg.MaxRetries {

--- a/internal/audiocore/liveness_test.go
+++ b/internal/audiocore/liveness_test.go
@@ -2,6 +2,7 @@ package audiocore
 
 import (
 	"sync"
+	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -376,5 +377,164 @@ func TestLiveness_RecoveryFromFailed(t *testing.T) {
 		require.Len(t, snaps, 1)
 		assert.Equal(t, "HEALTHY", snaps[0].State,
 			"should recover from FAILED when frames resume")
+	})
+}
+
+// TestLiveness_NoRestartDuringSupervisedReconnect is contract case 16: while a
+// producer reports RecoveryInProgress within the ceiling, the watchdog alarms
+// once but never restarts or escalates, so it does not tear down a supervisor
+// that is reconnecting in place.
+func TestLiveness_NoRestartDuringSupervisedReconnect(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const src = "src-1"
+		r := setupRouter(t, src)
+		defer r.Close()
+
+		cfg := fastConfig()
+		cfg.ProducerRecoveryCeiling = 5 * time.Minute
+
+		var restarts, escalations atomic.Int32
+		var mu sync.Mutex
+		alarms := 0
+
+		// recoveryStart is fixed for the whole outage, mirroring the native
+		// producer, which advances RecoveryEntered only when the recovery intent
+		// changes, not on every reconnect attempt.
+		recoveryStart := time.Now()
+
+		w := NewLivenessWatchdog(cfg, r, LivenessCallbacks{
+			RestartSource: func(_ string) error { restarts.Add(1); return nil },
+			Escalate:      func(_ string) { escalations.Add(1) },
+			Notify: func(_ string, state LivenessState, _ string) {
+				if state == StateAlarmed {
+					mu.Lock()
+					alarms++
+					mu.Unlock()
+				}
+			},
+			RecoveryState: func(_ string) (RecoveryState, time.Time) {
+				return RecoveryInProgress, recoveryStart
+			},
+		})
+
+		dispatchFrame(r, src)
+		w.Start()
+		defer w.Stop()
+
+		// Simulate a 60 s outage: the supervisor is reconnecting in place the whole
+		// time, well within the 5 min ceiling.
+		time.Sleep(60 * time.Second)
+
+		assert.Zero(t, restarts.Load(), "watchdog must not restart while the supervisor reconnects within the ceiling")
+		assert.Zero(t, escalations.Load(), "watchdog must not escalate while suppressed")
+
+		snaps := w.Snapshot()
+		require.Len(t, snaps, 1)
+		assert.Equal(t, "RECOVERING", snaps[0].State, "source parks in RECOVERING while the supervisor works")
+
+		mu.Lock()
+		assert.Equal(t, 1, alarms, "silence still alarms exactly once on the HEALTHY->ALARMED edge")
+		mu.Unlock()
+	})
+}
+
+// TestLiveness_RestartWhenSupervisorGivesUp is the other half of contract case
+// 16: once the producer reports RecoveryGivenUp the watchdog restarts exactly
+// once, which (in production) re-adds the source under a fresh dispatch clock.
+func TestLiveness_RestartWhenSupervisorGivesUp(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const src = "src-1"
+		r := setupRouter(t, src)
+		defer r.Close()
+
+		cfg := fastConfig()
+		cfg.ProducerRecoveryCeiling = 5 * time.Minute
+
+		var restarts atomic.Int32
+		w := NewLivenessWatchdog(cfg, r, LivenessCallbacks{
+			RestartSource: func(_ string) error {
+				restarts.Add(1)
+				// A successful restart brings the source back, mirroring the real
+				// RestartSource re-adding the source with a fresh dispatch clock.
+				dispatchFrame(r, src)
+				return nil
+			},
+			RecoveryState: func(_ string) (RecoveryState, time.Time) {
+				return RecoveryGivenUp, time.Time{}
+			},
+		})
+
+		dispatchFrame(r, src)
+		w.Start()
+		defer w.Stop()
+
+		time.Sleep(cfg.SilenceThreshold + 5*cfg.CheckInterval)
+
+		assert.Equal(t, int32(1), restarts.Load(), "a give-up must restart exactly once")
+
+		snaps := w.Snapshot()
+		require.Len(t, snaps, 1)
+		assert.Equal(t, "HEALTHY", snaps[0].State, "source recovers after the single restart")
+	})
+}
+
+// TestLiveness_RestartPastRecoveryCeiling verifies the ceiling backstop: a
+// producer stuck in RecoveryInProgress past ProducerRecoveryCeiling falls back
+// to the legacy restart ladder so a genuinely dead source is not parked forever.
+func TestLiveness_RestartPastRecoveryCeiling(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const src = "src-1"
+		r := setupRouter(t, src)
+		defer r.Close()
+
+		cfg := fastConfig()
+		cfg.ProducerRecoveryCeiling = 200 * time.Millisecond // outage quickly exceeds it
+
+		var restarts atomic.Int32
+		recoveryStart := time.Now()
+		w := NewLivenessWatchdog(cfg, r, LivenessCallbacks{
+			RestartSource: func(_ string) error { restarts.Add(1); return nil },
+			RecoveryState: func(_ string) (RecoveryState, time.Time) {
+				return RecoveryInProgress, recoveryStart
+			},
+		})
+
+		dispatchFrame(r, src)
+		w.Start()
+		defer w.Stop()
+
+		time.Sleep(cfg.SilenceThreshold + 10*cfg.CheckInterval)
+
+		assert.NotZero(t, restarts.Load(), "past the ceiling the legacy restart ladder resumes")
+	})
+}
+
+// TestLiveness_UnknownRecoveryTakesLegacyPath pins FFmpeg parity: a producer
+// reporting RecoveryUnknown (as FFmpeg always does) takes the legacy restart
+// path unchanged, so the coordination is a no-op under the ffmpeg gate.
+func TestLiveness_UnknownRecoveryTakesLegacyPath(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const src = "src-1"
+		r := setupRouter(t, src)
+		defer r.Close()
+
+		cfg := fastConfig()
+		cfg.ProducerRecoveryCeiling = 5 * time.Minute
+
+		var restarts atomic.Int32
+		w := NewLivenessWatchdog(cfg, r, LivenessCallbacks{
+			RestartSource: func(_ string) error { restarts.Add(1); return nil },
+			RecoveryState: func(_ string) (RecoveryState, time.Time) {
+				return RecoveryUnknown, time.Time{}
+			},
+		})
+
+		dispatchFrame(r, src)
+		w.Start()
+		defer w.Stop()
+
+		time.Sleep(cfg.SilenceThreshold + 3*cfg.CheckInterval)
+
+		assert.NotZero(t, restarts.Load(), "RecoveryUnknown (FFmpeg) takes the legacy restart path unchanged")
 	})
 }

--- a/internal/audiocore/liveness_test.go
+++ b/internal/audiocore/liveness_test.go
@@ -438,6 +438,39 @@ func TestLiveness_NoRestartDuringSupervisedReconnect(t *testing.T) {
 	})
 }
 
+// TestLiveness_ZeroCeilingDisablesCoordination verifies that a non-positive
+// ProducerRecoveryCeiling turns the coordination off entirely: the watchdog takes
+// the legacy restart path even while the producer reports RecoveryInProgress, and
+// it never invokes the RecoveryState callback.
+func TestLiveness_ZeroCeilingDisablesCoordination(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const src = "src-1"
+		r := setupRouter(t, src)
+		defer r.Close()
+
+		cfg := fastConfig()
+		cfg.ProducerRecoveryCeiling = 0 // coordination disabled
+
+		var restarts, recoveryCalls atomic.Int32
+		w := NewLivenessWatchdog(cfg, r, LivenessCallbacks{
+			RestartSource: func(_ string) error { restarts.Add(1); return nil },
+			RecoveryState: func(_ string) (RecoveryState, time.Time) {
+				recoveryCalls.Add(1)
+				return RecoveryInProgress, time.Now()
+			},
+		})
+
+		dispatchFrame(r, src)
+		w.Start()
+		defer w.Stop()
+
+		time.Sleep(cfg.SilenceThreshold + 3*cfg.CheckInterval)
+
+		assert.NotZero(t, restarts.Load(), "a zero ceiling must take the legacy restart path despite RecoveryInProgress")
+		assert.Zero(t, recoveryCalls.Load(), "a zero ceiling short-circuits before invoking the RecoveryState callback")
+	})
+}
+
 // TestLiveness_RestartWhenSupervisorGivesUp is the other half of contract case
 // 16: once the producer reports RecoveryGivenUp the watchdog restarts exactly
 // once, which (in production) re-adds the source under a fresh dispatch clock.

--- a/internal/audiocore/metrics.go
+++ b/internal/audiocore/metrics.go
@@ -24,6 +24,14 @@ type StreamMetrics interface {
 
 	// RecordDataRate records the current data rate (bytes per second) for a stream.
 	RecordDataRate(sourceID string, bytesPerSec float64)
+
+	// RecordWireRate records the current wire data rate (bytes per second) for a
+	// stream, distinct from the decoded-PCM RecordDataRate. Native ingest only.
+	RecordWireRate(sourceID string, bytesPerSec float64)
+
+	// SetStreamEngine records which ingest producer ("native"/"ffmpeg") is serving
+	// a stream.
+	SetStreamEngine(sourceID, engine string)
 }
 
 // BufferMetrics tracks buffer pool allocation, usage, and performance metrics.

--- a/internal/audiocore/stream/decode.go
+++ b/internal/audiocore/stream/decode.go
@@ -223,10 +223,27 @@ func float32ToS16LE(dst []byte, src []float32) {
 	}
 }
 
-// codecName is a short label for an unsupported codec, used only in the
-// terminal error message.
+// codecName is a short, stable label for a codec. It feeds the
+// StreamHealth.Codec observability field (e.g. "aac-lc", "opus", "pcmu") and the
+// terminal unsupported-codec error message. An unrecognized codec falls back to
+// its Go type name.
 func codecName(codec audiostream.Codec) string {
-	switch codec.(type) {
+	switch c := codec.(type) {
+	case audiostream.CodecOpus:
+		return "opus"
+	case audiostream.CodecMP3:
+		return "mp3"
+	case audiostream.CodecAAC, audiostream.CodecMP4ALATM:
+		return "aac-lc"
+	case audiostream.CodecG711:
+		if c.Law == audiostream.ALaw {
+			return "pcma"
+		}
+		return "pcmu"
+	case audiostream.CodecG726:
+		return "g726"
+	case audiostream.CodecL16:
+		return "l16"
 	case audiostream.CodecFLAC:
 		return "flac"
 	case audiostream.CodecUnknown:

--- a/internal/audiocore/stream/decode_test.go
+++ b/internal/audiocore/stream/decode_test.go
@@ -1,12 +1,17 @@
 package stream
 
 import (
+	"bytes"
 	"encoding/binary"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	aacpcm "github.com/tphakala/go-aac/pcm"
 	audiostream "github.com/tphakala/go-audio-stream"
+	mp3 "github.com/tphakala/go-mp3"
+	"github.com/tphakala/go-opus/opus"
 )
 
 // ascAACLC48kMono is a valid AAC-LC AudioSpecificConfig: object type 2, sample
@@ -118,6 +123,32 @@ func TestNewFrameDecoder_dispatch(t *testing.T) {
 	}
 }
 
+func TestCodecName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		codec audiostream.Codec
+		want  string
+	}{
+		{"opus", audiostream.CodecOpus{}, "opus"},
+		{"mp3", audiostream.CodecMP3{}, "mp3"},
+		{"aac-lc", audiostream.CodecAAC{}, "aac-lc"},
+		{"mp4a-latm", audiostream.CodecMP4ALATM{}, "aac-lc"},
+		{"g711 mu-law", audiostream.CodecG711{Law: audiostream.MuLaw}, "pcmu"},
+		{"g711 a-law", audiostream.CodecG711{Law: audiostream.ALaw}, "pcma"},
+		{"g726", audiostream.CodecG726{}, "g726"},
+		{"l16", audiostream.CodecL16{}, "l16"},
+		{"flac", audiostream.CodecFLAC{}, "flac"},
+		{"unknown", audiostream.CodecUnknown{}, "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, codecName(tt.codec))
+		})
+	}
+}
+
 func TestPassthroughDecoder_returnsInputAndGeometry(t *testing.T) {
 	d := &passthroughDecoder{sampleRate: 48000, channels: 1}
 	in := []byte{1, 2, 3, 4}
@@ -141,4 +172,166 @@ func TestFloat32ToS16LE_scalesRoundsAndClamps(t *testing.T) {
 	assert.Equal(t, int16(32767), got[1], "full-scale positive")
 	assert.Equal(t, int16(-32767), got[2], "full-scale negative")
 	assert.Equal(t, int16(32767), got[3], "clamps above +1.0")
+}
+
+// TestOpusDecodeRoundTrip encodes a mono 48 kHz tone with go-opus and decodes it
+// back through the stream's opusFrameDecoder, asserting geometry and that the
+// tone survives. Standalone (no MediaMTX); complements the integration-tagged
+// PCMFidelity contract case.
+func TestOpusDecodeRoundTrip(t *testing.T) {
+	t.Parallel()
+	const rate, ch, frame = 48000, 1, 960 // 20 ms at 48 kHz
+
+	enc, err := opus.NewEncoder(opus.EncoderConfig{SampleRate: rate, Channels: ch, Bitrate: 64000})
+	require.NoError(t, err)
+	dec, err := newOpusFrameDecoder()
+	require.NoError(t, err)
+
+	var energy int64
+	var gotRate, gotCh int
+	buf := make([]byte, 4000)
+	for f := range 6 {
+		n, encErr := enc.Encode(toneInt16(frame, rate, 440, f*frame), buf)
+		require.NoError(t, encErr)
+		require.Positive(t, n)
+		out, r, c, decErr := dec.decodeFrame(buf[:n])
+		require.NoError(t, decErr)
+		gotRate, gotCh = r, c
+		assert.Len(t, out, frame*2, "20 ms mono frame decodes to 960 s16le samples")
+		energy += pcmEnergy(out)
+	}
+	assert.Equal(t, rate, gotRate)
+	assert.Equal(t, ch, gotCh)
+	assert.Positive(t, energy, "decoded opus must carry the tone")
+}
+
+// TestMP3DecodeRoundTrip encodes a mono 48 kHz tone with go-mp3 and decodes it
+// back through the stream's mp3FrameDecoder. MP3 carries an encoder/decoder delay,
+// so the tone is asserted over the accumulated output rather than the first frame.
+func TestMP3DecodeRoundTrip(t *testing.T) {
+	t.Parallel()
+	const rate, ch, frame = 48000, 1, 1152 // MPEG-1 samples per frame
+
+	enc, err := mp3.NewEncoder(mp3.EncoderConfig{SampleRate: rate, Channels: ch, Bitrate: 128000})
+	require.NoError(t, err)
+	dec := newMP3FrameDecoder()
+
+	var energy int64
+	var gotRate, gotCh int
+	for f := range 12 {
+		mp3Frame, encErr := enc.EncodeFrame(nil, [][]float32{toneFloat32(frame, rate, 440, f*frame)})
+		require.NoError(t, encErr)
+		if len(mp3Frame) == 0 {
+			continue
+		}
+		out, r, c, decErr := dec.decodeFrame(mp3Frame)
+		require.NoError(t, decErr)
+		if r != 0 {
+			gotRate, gotCh = r, c
+		}
+		energy += pcmEnergy(out)
+	}
+	assert.Equal(t, rate, gotRate)
+	assert.Equal(t, ch, gotCh)
+	assert.Positive(t, energy, "decoded mp3 must carry the tone after priming")
+}
+
+// TestAACDecodeRoundTrip encodes a mono 48 kHz tone to an AAC-LC ADTS stream with
+// go-aac, strips the ADTS headers to raw access units, and decodes them through
+// the stream's aacFrameDecoder built from the matching LC/48k/mono ASC.
+func TestAACDecodeRoundTrip(t *testing.T) {
+	t.Parallel()
+	const rate, ch, samples = 48000, 1, 8192
+
+	var adts bytes.Buffer
+	require.NoError(t, aacpcm.EncodeInterleaved(&adts, aacpcm.Config{
+		SampleRate: rate,
+		BitDepth:   16,
+		Channels:   ch,
+		Bitrate:    128000,
+	}, toneInterleavedS16LE(samples, rate, 440)))
+
+	aus := splitADTS(t, adts.Bytes())
+	require.NotEmpty(t, aus, "encoder should emit at least one ADTS frame")
+
+	dec, err := newAACFrameDecoder(ascAACLC48kMono)
+	require.NoError(t, err)
+
+	var energy int64
+	var gotRate, gotCh int
+	for _, au := range aus {
+		out, r, c, decErr := dec.decodeFrame(au)
+		require.NoError(t, decErr)
+		if r != 0 {
+			gotRate, gotCh = r, c
+		}
+		energy += pcmEnergy(out)
+	}
+	assert.Equal(t, rate, gotRate)
+	assert.Equal(t, ch, gotCh)
+	assert.Positive(t, energy, "decoded aac must carry the tone after priming")
+}
+
+// splitADTS parses an ADTS stream into its raw access units so they can be fed to
+// the raw AAC decoder.
+func splitADTS(t *testing.T, stream []byte) [][]byte {
+	t.Helper()
+	var aus [][]byte
+	for i := 0; i+7 <= len(stream); {
+		require.Equal(t, byte(0xFF), stream[i], "ADTS syncword high")
+		require.Equal(t, byte(0xF0), stream[i+1]&0xF0, "ADTS syncword low")
+		protectionAbsent := stream[i+1]&0x01 == 1
+		frameLen := int(stream[i+3]&0x03)<<11 | int(stream[i+4])<<3 | int(stream[i+5])>>5
+		require.GreaterOrEqual(t, frameLen, 7, "ADTS frame length")
+		require.LessOrEqual(t, i+frameLen, len(stream), "ADTS frame within stream")
+		header := 7
+		if !protectionAbsent {
+			header = 9
+		}
+		aus = append(aus, stream[i+header:i+frameLen])
+		i += frameLen
+	}
+	return aus
+}
+
+// toneInt16 returns n mono int16 samples of a sine at freqHz, phase-continued
+// from the given sample offset.
+func toneInt16(n, rate, freqHz, phase int) []int16 {
+	out := make([]int16, n)
+	for i := range out {
+		out[i] = int16(20000 * math.Sin(2*math.Pi*float64(freqHz)*float64(phase+i)/float64(rate)))
+	}
+	return out
+}
+
+// toneFloat32 returns n mono float32 samples of a sine in [-1, 1].
+func toneFloat32(n, rate, freqHz, phase int) []float32 {
+	out := make([]float32, n)
+	for i := range out {
+		out[i] = float32(0.6 * math.Sin(2*math.Pi*float64(freqHz)*float64(phase+i)/float64(rate)))
+	}
+	return out
+}
+
+// toneInterleavedS16LE returns n mono s16le PCM bytes of a sine at freqHz.
+func toneInterleavedS16LE(n, rate, freqHz int) []byte {
+	out := make([]byte, n*2)
+	for i := range n {
+		v := int16(20000 * math.Sin(2*math.Pi*float64(freqHz)*float64(i)/float64(rate)))
+		binary.LittleEndian.PutUint16(out[i*2:], uint16(v))
+	}
+	return out
+}
+
+// pcmEnergy sums the absolute s16le sample amplitudes, a cheap non-silence check.
+func pcmEnergy(b []byte) int64 {
+	var e int64
+	for i := 0; i+1 < len(b); i += 2 {
+		v := int64(int16(binary.LittleEndian.Uint16(b[i:])))
+		if v < 0 {
+			v = -v
+		}
+		e += v
+	}
+	return e
 }

--- a/internal/audiocore/stream/health.go
+++ b/internal/audiocore/stream/health.go
@@ -46,6 +46,52 @@ const (
 	errTypeStreamError          = "stream_error"
 )
 
+// trackAggregate is the per-session RTP stats summed across the live tracks for
+// the observability snapshot.
+type trackAggregate struct {
+	packets    uint64
+	seqGaps    uint64
+	duplicates uint64
+	malformed  uint64
+	ssrcResets uint64
+	wire       uint64
+	payload    uint64
+
+	lastFrameAt      time.Time
+	senderClockValid bool
+	senderClockAge   time.Duration
+}
+
+// aggregateTrackStats sums the go-audio-stream per-track counters into one
+// per-session view. The newest valid SenderClock across tracks wins; its age is
+// measured against the stats capture time.
+func aggregateTrackStats(stats audiostream.Stats) trackAggregate {
+	var agg trackAggregate
+	var newestSR time.Time
+	for _, t := range stats.Tracks { //nolint:gocritic // rangeValCopy: TrackStats is a map value (no pointer iteration) and tracks per session are few (1-2)
+		agg.packets += t.Packets
+		agg.seqGaps += t.SeqGaps
+		agg.duplicates += t.Duplicates
+		agg.malformed += t.Malformed
+		agg.ssrcResets += t.SSRCResets
+		agg.wire += t.WireBytes
+		agg.payload += t.PayloadBytes
+		if t.LastFrameAt.After(agg.lastFrameAt) {
+			agg.lastFrameAt = t.LastFrameAt
+		}
+		if t.SenderClock.Valid && t.SenderClock.ReceivedAt.After(newestSR) {
+			newestSR = t.SenderClock.ReceivedAt
+			agg.senderClockValid = true
+			if !stats.CapturedAt.IsZero() {
+				if age := stats.CapturedAt.Sub(t.SenderClock.ReceivedAt); age > 0 {
+					agg.senderClockAge = age
+				}
+			}
+		}
+	}
+	return agg
+}
+
 // mapState maps a supervisor lifecycle transition onto the neutral connection
 // model: the StreamState, the legacy process_state detail string, and the
 // RecoveryState the liveness watchdog consults. FFmpeg never reports these

--- a/internal/audiocore/stream/open_rtsp.go
+++ b/internal/audiocore/stream/open_rtsp.go
@@ -38,6 +38,7 @@ func (s *stream) rtspFactory() supervisor.Factory {
 			Transport:     mapTransport(s.spec.Transport),
 			OnFrame:       s.onFrame,
 			OnCodecUpdate: s.onCodecUpdate,
+			Logger:        debugSlog(s.spec.Debug, s.log),
 		}
 		client, err := rtsp.Dial(ctx, cfg)
 		if err != nil {

--- a/internal/audiocore/stream/options.go
+++ b/internal/audiocore/stream/options.go
@@ -16,11 +16,11 @@ import (
 // only; what bounds reconnects is the supervisor plus the liveness watchdog, not
 // the cap value.
 const (
-	// defaultReadIdle is the supervisor read-idle watchdog window: a session
+	// DefaultReadIdle is the supervisor read-idle watchdog window: a session
 	// with no delivered frame within this window ends with ErrReadTimeout and
 	// reconnects. The engine tightens this to sit in front of the liveness
 	// threshold; this is the base before that clamp.
-	defaultReadIdle = 20 * time.Second
+	DefaultReadIdle = 20 * time.Second
 	// defaultChunkBytes is the pooled flush unit for dispatched frames (42.7 ms
 	// at 48 kHz mono). There is no time-based flush; a chunk emits when full or
 	// when the session ends.
@@ -46,7 +46,7 @@ type Options struct {
 	// frame within it ends with a read timeout and reconnects. It defaults below
 	// the liveness watchdog's silence threshold so the supervisor repairs a
 	// transport stall in place before the watchdog would escalate. Zero uses
-	// defaultReadIdle.
+	// DefaultReadIdle.
 	ReadIdle time.Duration
 
 	// Backoff parameterizes the supervisor reconnect schedule. Any zero field is
@@ -73,7 +73,7 @@ type Options struct {
 // the rest of the package reads resolved values.
 func (o *Options) applyDefaults() {
 	if o.ReadIdle <= 0 {
-		o.ReadIdle = defaultReadIdle
+		o.ReadIdle = DefaultReadIdle
 	}
 	if o.ChunkBytes <= 0 {
 		o.ChunkBytes = defaultChunkBytes

--- a/internal/audiocore/stream/pipeline.go
+++ b/internal/audiocore/stream/pipeline.go
@@ -2,6 +2,7 @@ package stream
 
 import (
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	audiostream "github.com/tphakala/go-audio-stream"
@@ -46,6 +47,13 @@ type pipeline struct {
 
 	chunk    []byte // the pooled slice currently being filled, or nil
 	chunkLen int
+
+	// Observability, published for the health snapshot. The reader goroutine is
+	// the sole writer; the snapshot reads them from another goroutine, so they are
+	// atomics rather than mutex-guarded (a lock on the per-frame path is avoided).
+	codecLabel  atomic.Pointer[string]
+	srcRate     atomic.Int32
+	srcChannels atomic.Int32
 }
 
 // newPipeline builds a pipeline for one source. pool may be nil for the unpooled
@@ -84,6 +92,8 @@ func (p *pipeline) setCodec(codec audiostream.Codec, format audiostream.AudioFor
 		return err
 	}
 	p.dec = dec
+	label := codecName(codec)
+	p.codecLabel.Store(&label)
 	if p.resampler != nil {
 		_ = p.resampler.Close()
 		p.resampler = nil
@@ -101,6 +111,9 @@ func (p *pipeline) process(data []byte) error {
 	if err != nil {
 		return err
 	}
+	// Publish the codec's native geometry (before resampling) for observability.
+	p.srcRate.Store(int32(rate))
+	p.srcChannels.Store(int32(channels))
 	if len(pcm) == 0 {
 		return nil
 	}
@@ -219,4 +232,15 @@ func (p *pipeline) dispatch(data, owner []byte) {
 	frame.Ref = audiocore.NewFrameRef(func() { p.pool.Put(owner) })
 	p.onFrame(frame)
 	frame.Ref.Release()
+}
+
+// codecInfo returns the current source codec label and the codec's native sample
+// rate and channel count (before resampling and downmix), for the health
+// snapshot. Values are zero until the first frame resolves the codec. Safe for
+// concurrent use.
+func (p *pipeline) codecInfo() (codec string, sampleRate, channels int) {
+	if lbl := p.codecLabel.Load(); lbl != nil {
+		codec = *lbl
+	}
+	return codec, int(p.srcRate.Load()), int(p.srcChannels.Load())
 }

--- a/internal/audiocore/stream/pipeline.go
+++ b/internal/audiocore/stream/pipeline.go
@@ -84,7 +84,12 @@ func (p *pipeline) setCodec(codec audiostream.Codec, format audiostream.AudioFor
 		// Clear the decoder so a failed (re)resolution does not keep feeding the
 		// new bitstream into the previous decoder: process drops frames while
 		// p.dec is nil until a valid codec is resolved (e.g. via OnCodecUpdate).
+		// Clear the published geometry too, so the health snapshot does not report
+		// a codec and rate that are no longer active.
 		p.dec = nil
+		p.codecLabel.Store(nil)
+		p.srcRate.Store(0)
+		p.srcChannels.Store(0)
 		if p.resampler != nil {
 			_ = p.resampler.Close()
 			p.resampler = nil
@@ -94,6 +99,11 @@ func (p *pipeline) setCodec(codec audiostream.Codec, format audiostream.AudioFor
 	p.dec = dec
 	label := codecName(codec)
 	p.codecLabel.Store(&label)
+	// Reset the geometry until the first decoded frame of the new codec repopulates
+	// it, so a snapshot between the codec change and the first frame does not report
+	// the previous codec's rate.
+	p.srcRate.Store(0)
+	p.srcChannels.Store(0)
 	if p.resampler != nil {
 		_ = p.resampler.Close()
 		p.resampler = nil

--- a/internal/audiocore/stream/pipeline_test.go
+++ b/internal/audiocore/stream/pipeline_test.go
@@ -43,6 +43,26 @@ func pcmL16(rate, ch int) (audiostream.Codec, audiostream.AudioFormat) {
 		audiostream.AudioFormat{Kind: audiostream.KindPCMS16LE, SampleRate: rate, Channels: ch}
 }
 
+func TestPipeline_setCodecClearsMetadataOnError(t *testing.T) {
+	t.Parallel()
+	spec := &audiocore.StreamSpec{SourceID: "s1", SampleRate: 48000, Channels: 1, ChannelMode: channelModeDownmix, BitDepth: 16}
+	p := newPipeline(spec, 8, nil, func(audiocore.AudioFrame) {}, nil)
+
+	// A supported codec publishes its label.
+	codec, format := pcmL16(48000, 1)
+	require.NoError(t, p.setCodec(codec, format))
+	got, _, _ := p.codecInfo()
+	require.Equal(t, "l16", got)
+
+	// A later unsupported codec fails; the stale label and geometry must clear so
+	// the health snapshot does not keep reporting a codec that is no longer active.
+	require.Error(t, p.setCodec(audiostream.CodecFLAC{}, audiostream.AudioFormat{}))
+	got, rate, ch := p.codecInfo()
+	assert.Empty(t, got, "codec label cleared after a failed setCodec")
+	assert.Zero(t, rate, "source rate cleared after a failed setCodec")
+	assert.Zero(t, ch, "source channels cleared after a failed setCodec")
+}
+
 func TestPipeline_chunksAndDispatchesMonoPassthrough(t *testing.T) {
 	pool := &fakeBytePool{size: 8}
 	col := &frameCollector{}

--- a/internal/audiocore/stream/slogbridge.go
+++ b/internal/audiocore/stream/slogbridge.go
@@ -1,0 +1,83 @@
+package stream
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// debugSlog returns an *slog.Logger that bridges go-audio-stream's library
+// logging onto the audiocore logger, or nil when debug is disabled so the library
+// stays quiet. It is the replacement for the Options.Debug field dropped in the
+// Phase 2 merge: without it the native producer ignores StreamSpec.Debug and the
+// library's reconnect and warning records never surface.
+func debugSlog(debug bool, log logger.Logger) *slog.Logger {
+	if !debug || log == nil {
+		return nil
+	}
+	return slog.New(&slogBridge{log: log})
+}
+
+// slogBridge is an slog.Handler that forwards records onto a logger.Logger, so
+// the go-audio-stream library's diagnostics flow through the same structured
+// logger the rest of the stream package uses. It is always enabled: gating
+// happens at construction (debugSlog returns nil when debug is off), so the
+// library never receives a handler unless debug logging was requested.
+type slogBridge struct {
+	log    logger.Logger
+	attrs  []logger.Field
+	prefix string
+}
+
+// Enabled reports handler availability. The bridge is only constructed when debug
+// logging is on, so it accepts every level and lets the audiocore logger apply
+// its own level policy.
+func (b *slogBridge) Enabled(_ context.Context, _ slog.Level) bool { return true }
+
+// Handle forwards one record, mapping the slog level onto the logger's leveled
+// methods and carrying both the accumulated and per-record attributes as fields.
+func (b *slogBridge) Handle(_ context.Context, r slog.Record) error { //nolint:gocritic // hugeParam: slog.Handler.Handle signature is fixed by the interface
+	fields := make([]logger.Field, 0, len(b.attrs)+r.NumAttrs())
+	fields = append(fields, b.attrs...)
+	r.Attrs(func(a slog.Attr) bool {
+		fields = append(fields, b.field(a))
+		return true
+	})
+	switch {
+	case r.Level >= slog.LevelError:
+		b.log.Error(r.Message, fields...)
+	case r.Level >= slog.LevelWarn:
+		b.log.Warn(r.Message, fields...)
+	case r.Level >= slog.LevelInfo:
+		b.log.Info(r.Message, fields...)
+	default:
+		b.log.Debug(r.Message, fields...)
+	}
+	return nil
+}
+
+// WithAttrs returns a handler that prepends attrs to every subsequent record.
+func (b *slogBridge) WithAttrs(attrs []slog.Attr) slog.Handler {
+	nb := &slogBridge{log: b.log, prefix: b.prefix, attrs: slices.Clone(b.attrs)}
+	for i := range attrs {
+		nb.attrs = append(nb.attrs, nb.field(attrs[i]))
+	}
+	return nb
+}
+
+// WithGroup returns a handler that dot-prefixes subsequent attribute keys with
+// the group name.
+func (b *slogBridge) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return b
+	}
+	return &slogBridge{log: b.log, prefix: b.prefix + name + ".", attrs: slices.Clone(b.attrs)}
+}
+
+// field converts one slog attribute into a logger.Field, applying the current
+// group prefix to the key.
+func (b *slogBridge) field(a slog.Attr) logger.Field {
+	return logger.Any(b.prefix+a.Key, a.Value.Any())
+}

--- a/internal/audiocore/stream/stream.go
+++ b/internal/audiocore/stream/stream.go
@@ -370,6 +370,12 @@ const minWireRateInterval = 1 * time.Second
 // session-stats deltas and reports whether it recomputed this call (so the
 // caller can emit the rate to metrics OUTSIDE the lock). The caller holds mu.
 func (s *stream) updateWireRates(capturedAt time.Time, wire, payload uint64) bool {
+	// A zero capture time (no live session yet) carries no usable delta; ignore it
+	// so it never becomes a stale baseline that a later valid sample measures a
+	// negative interval against. Mirrors the guard in aggregateTrackStats.
+	if capturedAt.IsZero() {
+		return false
+	}
 	if s.lastStatsAt.IsZero() {
 		s.lastStatsAt = capturedAt
 		s.lastWire = wire

--- a/internal/audiocore/stream/stream.go
+++ b/internal/audiocore/stream/stream.go
@@ -70,6 +70,7 @@ type stream struct {
 	stateDetail      string
 	stateEntered     time.Time
 	recovery         audiocore.RecoveryState
+	recoveryEntered  time.Time
 	lastData         time.Time
 	totalBytes       int64
 	restartCount     int
@@ -80,6 +81,14 @@ type stream struct {
 	errorHistory     []*audiocore.StreamErrorContext
 	stateHistory     []audiocore.StateTransition
 	audioOnlyStreak  int
+
+	// Wire/payload byte-rate bookkeeping for the observability snapshot, computed
+	// from cumulative session-stats deltas. Guarded by mu.
+	lastStatsAt time.Time
+	lastWire    uint64
+	lastPayload uint64
+	wireRate    float64
+	payloadRate float64
 }
 
 // newStream builds a stream and its supervisor. The supervisor begins connecting
@@ -107,6 +116,7 @@ func newStream(spec *audiocore.StreamSpec, opts *Options, deliver dispatchFunc, 
 		stateDetail:      detailStarting,
 		stateEntered:     time.Now(),
 		recovery:         audiocore.RecoveryInProgress,
+		recoveryEntered:  time.Now(),
 	}
 
 	var pool bytePool
@@ -125,7 +135,11 @@ func newStream(spec *audiocore.StreamSpec, opts *Options, deliver dispatchFunc, 
 		Backoff:   opts.Backoff,
 		OnState:   s.onState,
 		Retryable: s.retryable,
+		Logger:    debugSlog(spec.Debug, log),
 	})
+	if opts.Metrics != nil {
+		opts.Metrics.SetStreamEngine(spec.SourceID, audiocore.EngineNative)
+	}
 	return s
 }
 
@@ -173,6 +187,13 @@ func (s *stream) onState(sc supervisor.StateChange) {
 	s.state = state
 	s.stateDetail = detail
 	s.stateEntered = time.Now()
+	// recoveryEntered advances only when the recovery intent itself changes, not on
+	// every transition: the supervisor cycles Connecting<->Reconnecting (both
+	// RecoveryInProgress) during one outage, and the liveness watchdog measures how
+	// long recovery has been continuously in progress against its ceiling.
+	if s.recovery != recovery {
+		s.recoveryEntered = time.Now()
+	}
 	s.recovery = recovery
 
 	switch sc.State {
@@ -276,19 +297,28 @@ func (s *stream) recordError(err error) {
 // fields against the current time. The returned slices are freshly copied so the
 // caller may read them without holding the lock.
 func (s *stream) snapshot() *audiocore.StreamHealth {
+	// Read the live session stats and codec geometry OUTSIDE s.mu: the supervisor
+	// may invoke onState (which takes s.mu) while holding its own lock, so calling
+	// s.sup.Stats() under s.mu would risk a lock-order inversion.
+	stats := s.sup.Stats()
+	codec, srcRate, _ := s.pl.codecInfo()
+	agg := aggregateTrackStats(stats)
+
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	now := time.Now()
 	receiving := !s.lastData.IsZero() && now.Sub(s.lastData) < receivingDataThreshold
 	healthy := s.state == audiocore.StreamStateConnected &&
 		!s.lastData.IsZero() && now.Sub(s.lastData) < s.healthyThreshold
 
+	recomputed := s.updateWireRates(stats.CapturedAt, agg.wire, agg.payload)
+
 	h := &audiocore.StreamHealth{
 		State:              s.state,
 		StateDetail:        s.stateDetail,
 		StateEntered:       s.stateEntered,
 		Recovery:           s.recovery,
+		RecoveryEntered:    s.recoveryEntered,
 		IsHealthy:          healthy,
 		LastDataReceived:   s.lastData,
 		RestartCount:       s.restartCount,
@@ -298,10 +328,73 @@ func (s *stream) snapshot() *audiocore.StreamHealth {
 		IsReceivingData:    receiving,
 		LastErrorContext:   s.lastErrCtx,
 		SourceChannels:     s.spec.SourceChannels,
+
+		Engine:                audiocore.EngineNative,
+		Codec:                 codec,
+		SourceSampleRate:      srcRate,
+		Transport:             s.spec.Transport,
+		WireBytesPerSecond:    s.wireRate,
+		PayloadBytesPerSecond: s.payloadRate,
+		Packets:               agg.packets,
+		SeqGaps:               agg.seqGaps,
+		Duplicates:            agg.duplicates,
+		Malformed:             agg.malformed,
+		SSRCResets:            agg.ssrcResets,
+		LastFrameAt:           agg.lastFrameAt,
+		SenderClockValid:      agg.senderClockValid,
+		SenderClockAge:        agg.senderClockAge,
+		ReconnectAttempt:      s.reconnectAttempt,
+		NextRetryIn:           s.nextRetryIn,
 	}
 	h.StateHistory = slices.Clone(s.stateHistory)
 	h.ErrorHistory = slices.Clone(s.errorHistory)
+	wireRate := s.wireRate
+	s.mu.Unlock()
+
+	// Emit the wire rate outside s.mu, matching onDeliver's RecordDataRate, so a
+	// metrics implementation that calls back into the stream cannot deadlock.
+	// The wire rate is sampled at health-read cadence (its API/dump consumer);
+	// continuous emission would need a dedicated sampler.
+	if recomputed && s.opts.Metrics != nil {
+		s.opts.Metrics.RecordWireRate(s.spec.SourceID, wireRate)
+	}
 	return h
+}
+
+// minWireRateInterval smooths the wire/payload rate against health-poll cadence:
+// the rate is recomputed only when at least this much has elapsed since the last
+// sample, so back-to-back snapshots do not divide by a tiny interval.
+const minWireRateInterval = 1 * time.Second
+
+// updateWireRates recomputes the wire and payload byte rates from cumulative
+// session-stats deltas and reports whether it recomputed this call (so the
+// caller can emit the rate to metrics OUTSIDE the lock). The caller holds mu.
+func (s *stream) updateWireRates(capturedAt time.Time, wire, payload uint64) bool {
+	if s.lastStatsAt.IsZero() {
+		s.lastStatsAt = capturedAt
+		s.lastWire = wire
+		s.lastPayload = payload
+		return false
+	}
+	dt := capturedAt.Sub(s.lastStatsAt).Seconds()
+	if dt < minWireRateInterval.Seconds() {
+		return false
+	}
+	s.wireRate = deltaRate(wire, s.lastWire, dt)
+	s.payloadRate = deltaRate(payload, s.lastPayload, dt)
+	s.lastStatsAt = capturedAt
+	s.lastWire = wire
+	s.lastPayload = payload
+	return true
+}
+
+// deltaRate returns (cur-prev)/dt, guarding a counter reset (cur<prev) or a
+// non-positive interval as a zero rate.
+func deltaRate(cur, prev uint64, dt float64) float64 {
+	if cur < prev || dt <= 0 {
+		return 0
+	}
+	return float64(cur-prev) / dt
 }
 
 // close stops the supervisor, waits for it to fully stop so no reader goroutine

--- a/internal/audiocore/stream_health.go
+++ b/internal/audiocore/stream_health.go
@@ -295,6 +295,14 @@ func detailOrLegacyName(detail string, s StreamState) string {
 	return s.LegacyProcessName()
 }
 
+// Engine labels for StreamHealth.Engine, naming the ingest producer.
+const (
+	// EngineNative is the pure-Go go-audio-stream producer.
+	EngineNative = "native"
+	// EngineFFmpeg is the FFmpeg subprocess producer.
+	EngineFFmpeg = "ffmpeg"
+)
+
 // StreamHealth is the producer-neutral health snapshot for one network stream,
 // consumed by the health API and the support dump. State plus StateDetail carry
 // the connection state and the producer's sub-state; every other field matches
@@ -310,6 +318,12 @@ type StreamHealth struct {
 	StateEntered time.Time
 	// Recovery is the producer's recovery intent for the liveness watchdog.
 	Recovery RecoveryState
+	// RecoveryEntered is when the current Recovery value was entered. It advances
+	// only when Recovery changes, not on every state transition, so the liveness
+	// watchdog can measure how long a producer has been continuously recovering
+	// (bounded by LivenessConfig.ProducerRecoveryCeiling). Zero when the producer
+	// does not report recovery intent (FFmpeg).
+	RecoveryEntered time.Time
 
 	IsHealthy          bool
 	LastDataReceived   time.Time
@@ -322,6 +336,44 @@ type StreamHealth struct {
 	LastErrorContext   *StreamErrorContext
 	ErrorHistory       []*StreamErrorContext
 	SourceChannels     int
+
+	// Observability fields (additive). The native producer populates them from the
+	// go-audio-stream session stats; the FFmpeg producer leaves the RTP-specific
+	// values zero, so they omit from the API and support dump under the ffmpeg gate.
+
+	// Engine names the ingest producer ("native" or "ffmpeg").
+	Engine string
+	// Codec is the decoded source codec label (e.g. "aac-lc", "opus", "pcmu").
+	Codec string
+	// SourceSampleRate is the codec's native sample rate in Hz before resampling.
+	SourceSampleRate int
+	// Transport is the negotiated (or configured) stream transport (e.g. "tcp").
+	Transport string
+
+	// WireBytesPerSecond and PayloadBytesPerSecond are the wire and RTP-payload
+	// data rates from the session stats, distinct from BytesPerSecond (the decoded
+	// PCM rate).
+	WireBytesPerSecond    float64
+	PayloadBytesPerSecond float64
+
+	// Per-session RTP counters, summed across the tracks of the live session.
+	Packets    uint64
+	SeqGaps    uint64
+	Duplicates uint64
+	Malformed  uint64
+	SSRCResets uint64
+
+	// LastFrameAt is the wall-clock arrival of the most recent media frame.
+	LastFrameAt time.Time
+	// SenderClockValid reports whether an RTCP Sender Report has supplied a valid
+	// RTP-to-wall-clock mapping; SenderClockAge is how old that report is.
+	SenderClockValid bool
+	SenderClockAge   time.Duration
+
+	// ReconnectAttempt is the current reconnect attempt (0 while connected) and
+	// NextRetryIn is the backoff wait before the next attempt.
+	ReconnectAttempt int
+	NextRetryIn      time.Duration
 }
 
 // ProcessStateName returns the legacy process_state string for this snapshot:

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -526,12 +526,23 @@ func lookupComponent(funcName string) string {
 	registryMutex.RLock()
 	defer registryMutex.RUnlock()
 
-	// Check registered patterns, rejecting matches inside hyphenated words
-	// (e.g. "birdnet" must not match the module name "birdnet-go").
+	// Choose the most specific registered pattern that matches, rejecting matches
+	// inside hyphenated words (e.g. "birdnet" must not match the module path
+	// "birdnet-go"). The longest matching pattern wins so a specific registration
+	// (e.g. "audiocore/stream.") beats a broader one ("audiocore"); a string
+	// comparison breaks length ties so the randomized map-iteration order cannot
+	// make the result nondeterministic.
+	best, bestComponent := "", ""
 	for pattern, component := range componentRegistry {
-		if matchesPathSegment(funcName, pattern) {
-			return component
+		if !matchesPathSegment(funcName, pattern) {
+			continue
 		}
+		if len(pattern) > len(best) || (len(pattern) == len(best) && pattern > best) {
+			best, bestComponent = pattern, component
+		}
+	}
+	if best != "" {
+		return bestComponent
 	}
 
 	// Fallback: extract from package path

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -178,6 +178,34 @@ func TestLookupComponentAvoidsMisdetection(t *testing.T) {
 	assert.Equal(t, "birdnet", result, "should match birdnet component via classifier package path")
 }
 
+func TestLookupComponentLongestMatchWins(t *testing.T) {
+	t.Parallel()
+
+	// These package paths each match two registered patterns (a broad one and a
+	// more specific one). lookupComponent must return the most specific
+	// (longest-matching) component. The previous first-match implementation
+	// returned a nondeterministic result because Go map iteration order is
+	// randomized, so each case is checked repeatedly.
+	tests := []struct {
+		name     string
+		funcName string
+		want     string
+	}{
+		{"stream beats audiocore", "github.com/tphakala/birdnet-go/internal/audiocore/stream.newStream", "native-stream"},
+		{"engine beats audiocore", "github.com/tphakala/birdnet-go/internal/audiocore/engine.New", "audiocore.engine"},
+		{"processor beats analysis", "github.com/tphakala/birdnet-go/internal/analysis/processor.Process", "analysis.processor"},
+		{"imports/audio beats imports", "github.com/tphakala/birdnet-go/internal/imports/audio.Import", "imports.audio"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			for range 50 {
+				assert.Equal(t, tt.want, lookupComponent(tt.funcName))
+			}
+		})
+	}
+}
+
 func TestRegexPrecompilation(t *testing.T) {
 	t.Parallel()
 

--- a/internal/health/checks/streams.go
+++ b/internal/health/checks/streams.go
@@ -22,6 +22,18 @@ type StreamHealthInfo struct {
 	RestartCount int
 	// Error holds the most recent error message, if any.
 	Error string
+	// Engine names the ingest producer ("native" or "ffmpeg").
+	Engine string
+	// Codec is the decoded source codec label (native ingest; empty for FFmpeg).
+	Codec string
+	// WireBytesPerSecond is the wire data rate (native ingest; zero for FFmpeg).
+	WireBytesPerSecond float64
+	// Per-session RTP counters (native ingest; zero for FFmpeg).
+	Packets    uint64
+	SeqGaps    uint64
+	Duplicates uint64
+	Malformed  uint64
+	SSRCResets uint64
 }
 
 // StreamConnectivityCheck verifies that all configured RTSP streams are reachable and healthy.
@@ -54,8 +66,8 @@ func (c *StreamConnectivityCheck) Run(_ context.Context) health.Result {
 	}
 
 	unhealthy := 0
-	for _, s := range streams {
-		if !s.IsHealthy {
+	for i := range streams {
+		if !streams[i].IsHealthy {
 			unhealthy++
 		}
 	}
@@ -181,8 +193,8 @@ func (c *FFmpegHealthCheck) Run(_ context.Context) health.Result {
 	stoppedCount := 0
 	notRunningCount := 0
 
-	for _, s := range streams {
-		switch s.State {
+	for i := range streams {
+		switch streams[i].State {
 		case audiocore.StreamStateConnected:
 			// healthy
 		case audiocore.StreamStateStopped:


### PR DESCRIPTION
## Summary

Two related changes advancing the native go-audio-stream ingest path. Both stay behind the `BIRDNET_STREAM_INGEST=native` gate; the FFmpeg default path is unchanged and its audio, detection, and health JSON stay byte-identical apart from additive fields.

Liveness coordination: the liveness watchdog now consults the native producer's recovery intent, so it no longer tears the reconnect supervisor down mid-reconnect. While the supervisor is reconnecting in place within a five minute ceiling the watchdog alarms once but defers the restart; it falls back to the legacy restart ladder on give-up, on idle, or once the ceiling elapses. The FFmpeg producer reports an unknown recovery state, so its watchdog path is byte-identical. The native supervisor read-idle window is derived to sit below the watchdog silence threshold, so a stalled transport reconnects in place before the watchdog would alarm.

Stream observability: `StreamHealth` gains additive, JSON-optional fields for the ingest engine, codec and source sample rate, negotiated transport, wire and payload byte rates, the per-session RTP counters, last-frame time, RTCP sender-clock validity and age, and the reconnect attempt and backoff. The health API, the diagnostics support dump, and the stream card surface the new data; engine stream metrics are wired into both producers nil-safe; and a debug flag bridges the go-audio-stream logger into the structured logger. Because every new field is optional, they omit cleanly on the FFmpeg path.

Error component resolution: `lookupComponent` now selects the longest matching registered pattern (with a lexicographic tie-break) instead of the first match, so a function under overlapping registrations resolves to the same, most-specific component deterministically rather than depending on Go's randomized map iteration.

## Test Plan

- [x] `go test -race` across audiocore, stream, ffmpeg, engine, analysis, errors, and the audio/system API packages
- [x] `golangci-lint run` clean; `npm run check:all` (frontend) clean
- [x] New tests: liveness coordination (suppress / give-up / ceiling / legacy parity), decode round-trips (Opus/MP3/AAC), codec labels, read-idle derivation across threshold bands, longest-match component resolution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed stream health information, including ingest engine, codec, transport, throughput, packet quality, timing, and reconnect status.
  * Diagnostics now display expanded stream metrics and consistently ordered stream results.
  * Added clearer codec identification and improved native stream observability.

* **Bug Fixes**
  * Failed stream processes are now correctly classified and displayed as errors.
  * Liveness monitoring better coordinates with producer recovery, reducing unnecessary restarts during reconnection.
  * Improved handling of codec metadata after unsuccessful decoder setup.

* **Reliability**
  * Improved silence detection, rate tracking, and recovery handling for native audio streams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->