### PR TITLE
feat(audiocore): stream metrics collector and ffmpeg silence-timeout fix

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -62,6 +62,10 @@ The "realtime" command is an alias for backward compatibility.`,
 				Debug:                    settings.Debug,
 				CaptureBufferSeconds:     settings.Realtime.ExtendedCapture.EffectiveCaptureBufferSeconds(settings.Realtime.Audio.Export.PreCapture),
 				LivenessSilenceThreshold: time.Duration(settings.Realtime.Audio.Watchdog.SilenceThreshold) * time.Second,
+				// StreamMetrics is the concrete Prometheus collector for both the
+				// FFmpeg and native stream producers. The engine forwards it to
+				// whichever manager the BIRDNET_STREAM_INGEST gate selects.
+				StreamMetrics: metrics.AudioStream,
 			}, nil)
 			defer audioEngine.Stop()
 

--- a/internal/api/v2/audio/streams_health_golden_test.go
+++ b/internal/api/v2/audio/streams_health_golden_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tphakala/birdnet-go/internal/audiocore"
+	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 )
 
 // TestConvertStreamHealthToResponse_Golden locks the health API JSON for every
@@ -81,4 +82,63 @@ func TestRemovedStreamHealth_ByteIdentity(t *testing.T) {
 
 	assert.Equal(t, "idle", response.ProcessState, "removed-stream process_state must stay byte-identical")
 	assert.Equal(t, "stopped", response.State, "removed-stream neutral state should read stopped")
+}
+
+// TestConvertStreamHealthToResponse_RealFFmpegGetHealth guards the FFmpeg
+// producer's actually-emitted JSON. The golden cases above hand-build
+// StreamHealth with empty Engine/Transport, so they cannot catch a change to the
+// additive keys the real ffmpeg.GetHealth emits (engine, transport). This runs a
+// real ffmpeg.Stream's GetHealth through the converter and asserts engine and
+// transport are the ONLY additions over the same health with those two fields
+// cleared (Forgejo #1648).
+func TestConvertStreamHealthToResponse_RealFFmpegGetHealth(t *testing.T) {
+	t.Parallel()
+
+	const (
+		url       = "rtsp://camera.local:554/stream"
+		transport = "tcp"
+	)
+
+	// A freshly constructed stream is never Run, so it starts no FFmpeg process
+	// and no goroutines; GetHealth only reads struct state, so this is goleak-safe.
+	st := ffmpeg.NewStream(&ffmpeg.StreamConfig{
+		URL:       url,
+		SourceID:  "golden-source",
+		Transport: transport,
+	}, nil, nil, nil, nil)
+
+	health := st.GetHealth()
+	require.Equal(t, audiocore.EngineFFmpeg, health.Engine, "ffmpeg GetHealth must stamp the engine")
+	require.Equal(t, transport, health.Transport, "ffmpeg GetHealth must carry the configured transport")
+
+	realMap := toJSONMap(t, convertStreamHealthToResponse(url, &health))
+
+	// Baseline: the same health with the additive fields cleared, so any key
+	// difference isolates exactly what the ffmpeg producer adds.
+	baseHealth := health
+	baseHealth.Engine = ""
+	baseHealth.Transport = ""
+	baseMap := toJSONMap(t, convertStreamHealthToResponse(url, &baseHealth))
+
+	assert.Equal(t, audiocore.EngineFFmpeg, realMap["engine"], "engine key must carry the ffmpeg producer name")
+	assert.Equal(t, transport, realMap["transport"], "transport key must carry the configured transport")
+	assert.NotContains(t, baseMap, "engine", "baseline (cleared) health must omit engine")
+	assert.NotContains(t, baseMap, "transport", "baseline (cleared) health must omit transport")
+
+	// After removing the two additive keys, every other key must match the
+	// baseline exactly: engine and transport are the only additions.
+	delete(realMap, "engine")
+	delete(realMap, "transport")
+	assert.Equal(t, baseMap, realMap, "engine and transport must be the only additions vs the pre-seam JSON")
+}
+
+// toJSONMap marshals v and unmarshals it into a generic map so two responses can
+// be diffed by key set.
+func toJSONMap(t *testing.T, v any) map[string]any {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(b, &m))
+	return m
 }

--- a/internal/audiocore/engine/engine.go
+++ b/internal/audiocore/engine/engine.go
@@ -100,8 +100,9 @@ type Config struct {
 	// NOTE: Not yet wired to subsystems; metrics plumbing is planned for a future PR.
 	RouterMetrics audiocore.RouterMetrics
 
-	// StreamMetrics is optional; nil-safe.
-	// NOTE: Not yet wired to subsystems; metrics plumbing is planned for a future PR.
+	// StreamMetrics is optional; nil-safe. Forwarded to whichever stream manager
+	// the BIRDNET_STREAM_INGEST gate selects (FFmpeg or native), which emits
+	// per-source health, error, and data-rate metrics.
 	StreamMetrics audiocore.StreamMetrics
 
 	// BufferMetrics is optional; nil-safe.

--- a/internal/audiocore/ffmpeg/manager.go
+++ b/internal/audiocore/ffmpeg/manager.go
@@ -280,6 +280,12 @@ func (m *Manager) StopStream(sourceID string) error {
 	// Stop the stream outside the lock; Stop() can block.
 	stream.Stop()
 
+	// Remove the stream's metric series once it is stopped, so a stopped source
+	// stops being exported instead of lingering (e.g. reading healthy forever).
+	if m.metrics != nil {
+		m.metrics.DeleteStream(sourceID)
+	}
+
 	// Clean up watchdog tracking.
 	m.lastForceResetMu.Lock()
 	delete(m.lastForceReset, sourceID)

--- a/internal/audiocore/ffmpeg/newstream_metrics_test.go
+++ b/internal/audiocore/ffmpeg/newstream_metrics_test.go
@@ -1,0 +1,52 @@
+package ffmpeg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+)
+
+// engineRecorder is a StreamMetrics stub that records the SetStreamEngine call so
+// a test can assert the FFmpeg producer stamps its ingest engine at construction.
+type engineRecorder struct {
+	sourceID string
+	engine   string
+	called   bool
+}
+
+func (e *engineRecorder) IncStreamErrors(string)         {}
+func (e *engineRecorder) SetStreamHealth(string, bool)   {}
+func (e *engineRecorder) RecordDataRate(string, float64) {}
+func (e *engineRecorder) RecordWireRate(string, float64) {}
+func (e *engineRecorder) SetStreamEngine(sourceID, engine string) {
+	e.sourceID, e.engine, e.called = sourceID, engine, true
+}
+func (e *engineRecorder) DeleteStream(string) {}
+
+// TestNewStream_RecordsFFmpegEngine locks that the FFmpeg producer records its
+// ingest engine to the metrics collector at construction, so the
+// audio_stream_engine gauge is populated for the default FFmpeg path (Forgejo
+// #1646). The native producer emits EngineNative in its own constructor; this
+// closes the sibling gap where FFmpeg previously never called SetStreamEngine.
+func TestNewStream_RecordsFFmpegEngine(t *testing.T) {
+	t.Parallel()
+
+	rec := &engineRecorder{}
+	_ = NewStream(&StreamConfig{URL: "rtsp://camera.local:554/stream", SourceID: "src-1"}, nil, nil, rec, nil)
+
+	assert.True(t, rec.called, "NewStream must record the ingest engine")
+	assert.Equal(t, "src-1", rec.sourceID)
+	assert.Equal(t, audiocore.EngineFFmpeg, rec.engine)
+}
+
+// TestNewStream_NilMetricsSafe ensures construction with a nil metrics collector
+// does not panic (the engine emission is nil-guarded).
+func TestNewStream_NilMetricsSafe(t *testing.T) {
+	t.Parallel()
+
+	assert.NotPanics(t, func() {
+		_ = NewStream(&StreamConfig{URL: "rtsp://camera.local:554/stream", SourceID: "src-2"}, nil, nil, nil, nil)
+	})
+}

--- a/internal/audiocore/ffmpeg/silence_classify_test.go
+++ b/internal/audiocore/ffmpeg/silence_classify_test.go
@@ -43,6 +43,17 @@ func TestIsSilenceTimeoutError(t *testing.T) {
 			want: true,
 		},
 		{
+			// The silence error nested inside ANOTHER EnhancedError whose own
+			// operation differs: a single errors.As would stop at the outer one and
+			// miss it, so this proves the chain is walked.
+			name: "silence error wrapped in a different enhanced error is still classified",
+			err: errors.New(silenceErr).
+				Component("ffmpeg-stream").
+				Context("operation", "process_ended").
+				Build(),
+			want: true,
+		},
+		{
 			name: "different operation is not a silence timeout",
 			err: errors.Newf("error reading from FFmpeg").
 				Component("ffmpeg-stream").

--- a/internal/audiocore/ffmpeg/silence_classify_test.go
+++ b/internal/audiocore/ffmpeg/silence_classify_test.go
@@ -1,0 +1,78 @@
+package ffmpeg
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+)
+
+// TestIsSilenceTimeoutError locks the silence-restart classification contract:
+// the run loop identifies a silence-watchdog restart by the structured
+// operation=silence_timeout context stamped by handleSilenceTimeout, not by a
+// substring of the (dynamic) error message. The old substring check
+// (strings.Contains(msg, "silence timeout")) never matched because the message
+// is "stream stopped producing data for N seconds" (Forgejo #1641).
+func TestIsSilenceTimeoutError(t *testing.T) {
+	t.Parallel()
+
+	// silenceErr is shaped exactly like the error handleSilenceTimeout builds:
+	// the message never contains the words "silence timeout", so only the
+	// operation context can classify it.
+	silenceErr := errors.Newf("stream stopped producing data for %v seconds", 90.0).
+		Category(errors.CategoryRTSP).
+		Component("ffmpeg-stream").
+		Context("operation", opSilenceTimeout).
+		Build()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "real silence-timeout error is classified",
+			err:  silenceErr,
+			want: true,
+		},
+		{
+			name: "wrapped silence-timeout error still classified",
+			err:  fmt.Errorf("outer wrapper: %w", silenceErr),
+			want: true,
+		},
+		{
+			name: "different operation is not a silence timeout",
+			err: errors.Newf("error reading from FFmpeg").
+				Component("ffmpeg-stream").
+				Context("operation", "read").
+				Build(),
+			want: false,
+		},
+		{
+			name: "enhanced error without an operation context",
+			err: errors.Newf("some other failure").
+				Component("ffmpeg-stream").
+				Build(),
+			want: false,
+		},
+		{
+			name: "plain error is not a silence timeout",
+			err:  fmt.Errorf("plain error without structured context"),
+			want: false,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isSilenceTimeoutError(tt.err))
+		})
+	}
+}

--- a/internal/audiocore/ffmpeg/silence_reset_test.go
+++ b/internal/audiocore/ffmpeg/silence_reset_test.go
@@ -1,0 +1,45 @@
+package ffmpeg
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResetForSilenceTimeout_ClearsCircuitBreaker is a regression test for a
+// silence-watchdog restart leaving the circuit breaker open. recordFailure sets
+// circuitOpenTime once the consecutive-failure count crosses a threshold, and
+// isCircuitOpen keys off circuitOpenTime (not the count), so a silence restart
+// that tipped the count over the threshold must not leave the breaker open: a
+// silent-but-connected source is recoverable and should keep retrying. The prior
+// failure count is nonzero, per the review scenario.
+func TestResetForSilenceTimeout_ClearsCircuitBreaker(t *testing.T) {
+	t.Parallel()
+
+	s := &Stream{}
+	// Simulate a prior run of failures that opened the circuit breaker.
+	s.consecutiveFailures = circuitBreakerThreshold
+	s.circuitOpenTime = time.Now()
+	s.restartCount = 5
+	require.True(t, s.isCircuitOpen(), "precondition: the breaker is open")
+
+	s.resetForSilenceTimeout()
+
+	assert.False(t, s.isCircuitOpen(), "a silence timeout must not leave the circuit open")
+	assert.Equal(t, circuitBreakerThreshold-1, s.consecutiveFailures, "only this event's failure increment is undone")
+	assert.Zero(t, s.restartCount, "restart count is reset")
+}
+
+// TestResetForSilenceTimeout_FloorsAtZero ensures the consecutive-failure
+// decrement does not underflow when there was no prior failure recorded.
+func TestResetForSilenceTimeout_FloorsAtZero(t *testing.T) {
+	t.Parallel()
+
+	s := &Stream{}
+	s.resetForSilenceTimeout()
+
+	assert.Zero(t, s.consecutiveFailures)
+	assert.False(t, s.isCircuitOpen())
+}

--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -603,7 +603,7 @@ type Stream struct {
 // bufMgr is an optional buffer manager used to pool stdout read buffers via
 // FrameRef; when nil, readStdout falls back to a fresh per-iteration allocation.
 func NewStream(cfg *StreamConfig, onFrame func(frame audiocore.AudioFrame), onReset func(sourceID string), metrics audiocore.StreamMetrics, bufMgr *buffer.Manager) *Stream {
-	return &Stream{
+	s := &Stream{
 		config:           *cfg,
 		onFrame:          onFrame,
 		onReset:          onReset,
@@ -622,6 +622,13 @@ func NewStream(cfg *StreamConfig, onFrame func(frame audiocore.AudioFrame), onRe
 		maxErrorHistory:  maxErrorHistorySize,
 		bufMgr:           bufMgr,
 	}
+	// Record the ingest engine once at construction, matching the native producer,
+	// so the audio_stream_engine metric is populated for the default FFmpeg path
+	// too (native emits EngineNative in its own constructor).
+	if metrics != nil {
+		metrics.SetStreamEngine(cfg.SourceID, audiocore.EngineFFmpeg)
+	}
+	return s
 }
 
 // transitionState safely transitions the process state and logs the change.
@@ -1373,17 +1380,24 @@ func (s *Stream) dispatchAudioData(data []byte, ref *audiocore.FrameRef) {
 // depend on the human-readable (and dynamic) error message.
 const opSilenceTimeout = "silence_timeout"
 
-// isSilenceTimeoutError reports whether err is the silence-watchdog restart error
-// produced by handleSilenceTimeout, identified by its operation=silence_timeout
-// context rather than a substring of its message. processAudio returns that error
-// directly, so a single errors.As locates it.
+// isSilenceTimeoutError reports whether err (or any error it wraps) is the
+// silence-watchdog restart error produced by handleSilenceTimeout, identified by
+// its operation=silence_timeout context rather than a substring of its message.
+// It walks the whole chain of EnhancedError values so classification still holds
+// if the silence error is ever wrapped inside another EnhancedError with a
+// different operation (errors.As alone would stop at the outer one).
 func isSilenceTimeoutError(err error) bool {
-	var ee *errors.EnhancedError
-	if !errors.As(err, &ee) {
-		return false
+	for err != nil {
+		var ee *errors.EnhancedError
+		if !errors.As(err, &ee) {
+			return false
+		}
+		if op, _ := ee.GetContext()["operation"].(string); op == opSilenceTimeout {
+			return true
+		}
+		err = ee.Unwrap()
 	}
-	op, _ := ee.GetContext()["operation"].(string)
-	return op == opSilenceTimeout
+	return false
 }
 
 // handleSilenceTimeout checks if stream has stopped producing data and triggers restart.

--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -844,18 +844,7 @@ func (s *Stream) Run(parentCtx context.Context) {
 					logger.String("operation", "process_ended"))
 
 				if isSilenceTimeout {
-					func() {
-						s.restartCountMu.Lock()
-						defer s.restartCountMu.Unlock()
-						s.restartCount = 0
-					}()
-					func() {
-						s.circuitMu.Lock()
-						defer s.circuitMu.Unlock()
-						if s.consecutiveFailures > 0 {
-							s.consecutiveFailures--
-						}
-					}()
+					s.resetForSilenceTimeout()
 				}
 			} else {
 				getStreamLogger().Info("FFmpeg process ended normally",
@@ -2071,6 +2060,30 @@ func (s *Stream) isCircuitOpen() bool {
 
 // recordFailure records a failure for the circuit breaker with runtime consideration.
 // Graduated threshold system opens the circuit breaker earlier for rapid failures.
+// resetForSilenceTimeout undoes this iteration's failure bookkeeping for a
+// silence-watchdog restart. A silent-but-connected source (a session opened but
+// no audio flowed) is a recoverable condition, not a hard failure, so it must not
+// accumulate restarts or leave the circuit breaker open. It clears restartCount,
+// decrements the consecutive-failure count that recordFailure incremented for
+// this event, and clears circuitOpenTime: recordFailure may have just opened the
+// breaker (isCircuitOpen keys off circuitOpenTime, not the failure count), and
+// leaving it set would suppress ingest for the whole cooldown after a merely
+// silent restart. Before the silence classifier was fixed this path was dead, so
+// this completes the reset it now performs.
+func (s *Stream) resetForSilenceTimeout() {
+	func() {
+		s.restartCountMu.Lock()
+		defer s.restartCountMu.Unlock()
+		s.restartCount = 0
+	}()
+	s.circuitMu.Lock()
+	defer s.circuitMu.Unlock()
+	if s.consecutiveFailures > 0 {
+		s.consecutiveFailures--
+	}
+	s.circuitOpenTime = time.Time{}
+}
+
 func (s *Stream) recordFailure(runtime time.Duration) {
 	s.circuitMu.Lock()
 	defer s.circuitMu.Unlock()

--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -2058,8 +2058,6 @@ func (s *Stream) isCircuitOpen() bool {
 	return false
 }
 
-// recordFailure records a failure for the circuit breaker with runtime consideration.
-// Graduated threshold system opens the circuit breaker earlier for rapid failures.
 // resetForSilenceTimeout undoes this iteration's failure bookkeeping for a
 // silence-watchdog restart. A silent-but-connected source (a session opened but
 // no audio flowed) is a recoverable condition, not a hard failure, so it must not
@@ -2084,6 +2082,8 @@ func (s *Stream) resetForSilenceTimeout() {
 	s.circuitOpenTime = time.Time{}
 }
 
+// recordFailure records a failure for the circuit breaker with runtime consideration.
+// Graduated threshold system opens the circuit breaker earlier for rapid failures.
 func (s *Stream) recordFailure(runtime time.Duration) {
 	s.circuitMu.Lock()
 	defer s.circuitMu.Unlock()

--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -808,7 +808,7 @@ func (s *Stream) Run(parentCtx context.Context) {
 				fallbackEngaged = s.maybeEngageAudioOnlyFallback()
 				errorMsg := err.Error()
 				sanitizedError := privacy.SanitizeFFmpegError(errorMsg)
-				isSilenceTimeout := strings.Contains(errorMsg, "silence timeout")
+				isSilenceTimeout := isSilenceTimeoutError(err)
 
 				// Publish stream event for alerting rules.
 				// A normal EOF (audio already seen) or a canceled context returns
@@ -1367,6 +1367,25 @@ func (s *Stream) dispatchAudioData(data []byte, ref *audiocore.FrameRef) {
 	}
 }
 
+// opSilenceTimeout is the structured error operation context stamped on the
+// silence-watchdog restart error built by handleSilenceTimeout. The run loop
+// reads it back to classify a silence restart, so the classification does not
+// depend on the human-readable (and dynamic) error message.
+const opSilenceTimeout = "silence_timeout"
+
+// isSilenceTimeoutError reports whether err is the silence-watchdog restart error
+// produced by handleSilenceTimeout, identified by its operation=silence_timeout
+// context rather than a substring of its message. processAudio returns that error
+// directly, so a single errors.As locates it.
+func isSilenceTimeoutError(err error) bool {
+	var ee *errors.EnhancedError
+	if !errors.As(err, &ee) {
+		return false
+	}
+	op, _ := ee.GetContext()["operation"].(string)
+	return op == opSilenceTimeout
+}
+
 // handleSilenceTimeout checks if stream has stopped producing data and triggers restart.
 func (s *Stream) handleSilenceTimeout(startTime time.Time) error {
 	s.lastDataMu.RLock()
@@ -1402,7 +1421,7 @@ func (s *Stream) handleSilenceTimeout(startTime time.Time) error {
 		return errors.Newf("stream stopped producing data for %v seconds", timeout.Seconds()).
 			Category(errors.CategoryRTSP).
 			Component("ffmpeg-stream").
-			Context("operation", "silence_timeout").
+			Context("operation", opSilenceTimeout).
 			Context("url", s.config.safeURL()).
 			Context("timeout_seconds", timeout.Seconds()).
 			Context("last_data", lastDataDesc).

--- a/internal/audiocore/metrics.go
+++ b/internal/audiocore/metrics.go
@@ -13,7 +13,8 @@ type RouterMetrics interface {
 	IncRouteErrors(sourceID, consumerID string)
 }
 
-// StreamMetrics tracks FFmpeg stream health and performance metrics.
+// StreamMetrics tracks network audio stream ingest health and performance
+// metrics for either the FFmpeg or the native go-audio-stream producer.
 // Callers must check for nil before calling methods on this interface.
 type StreamMetrics interface {
 	// IncStreamErrors increments the error count for a stream.

--- a/internal/audiocore/metrics.go
+++ b/internal/audiocore/metrics.go
@@ -33,6 +33,12 @@ type StreamMetrics interface {
 	// SetStreamEngine records which ingest producer ("native"/"ffmpeg") is serving
 	// a stream.
 	SetStreamEngine(sourceID, engine string)
+
+	// DeleteStream removes every metric series for a stream. It is called when a
+	// source is stopped or removed so a dead stream stops being exported (no stale
+	// health/rate series reading as if it were live) and series do not accumulate
+	// without bound across repeated add/remove churn.
+	DeleteStream(sourceID string)
 }
 
 // BufferMetrics tracks buffer pool allocation, usage, and performance metrics.

--- a/internal/audiocore/stream/manager.go
+++ b/internal/audiocore/stream/manager.go
@@ -212,6 +212,12 @@ func (m *Manager) ShutdownWithContext(ctx context.Context) error {
 			go func(s *stream) {
 				defer wg.Done()
 				s.close(ctx)
+				// Remove metric series on shutdown too, matching StopStream, so a
+				// manager stopped while the process/registry outlives it (engine
+				// restart, tests) does not leak stale series.
+				if m.opts.Metrics != nil {
+					m.opts.Metrics.DeleteStream(s.spec.SourceID)
+				}
 			}(s)
 		}
 		wg.Wait()

--- a/internal/audiocore/stream/manager.go
+++ b/internal/audiocore/stream/manager.go
@@ -135,6 +135,11 @@ func (m *Manager) StopStream(sourceID string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
 	s.close(ctx)
+	// Remove the stream's metric series after it is fully closed, so a stopped
+	// source stops being exported instead of lingering as stale series.
+	if m.opts.Metrics != nil {
+		m.opts.Metrics.DeleteStream(sourceID)
+	}
 	m.log.Info("stopped native stream",
 		logger.String("source_id", sourceID),
 		logger.String("ingest_engine", "native"),

--- a/internal/audiocore/stream/metrics_lock_test.go
+++ b/internal/audiocore/stream/metrics_lock_test.go
@@ -47,6 +47,7 @@ func (m *reentrantMetrics) SetStreamHealth(_ string, healthy bool) {
 func (m *reentrantMetrics) RecordDataRate(string, float64) {}
 func (m *reentrantMetrics) RecordWireRate(string, float64) {}
 func (m *reentrantMetrics) SetStreamEngine(string, string) {}
+func (m *reentrantMetrics) DeleteStream(string)            {}
 
 // TestOnState_EmitsMetricsOutsideLock is a regression test for the AB-BA hazard
 // fixed in Forgejo #1646: onState must release s.mu before emitting stream

--- a/internal/audiocore/stream/metrics_lock_test.go
+++ b/internal/audiocore/stream/metrics_lock_test.go
@@ -1,0 +1,96 @@
+package stream
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/go-audio-stream/supervisor"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+)
+
+// reentrantMetrics is a StreamMetrics stub that probes, from inside each emission
+// callback, whether the stream's own mutex is free (via TryLock). onState and
+// recordError must release s.mu before emitting metrics (Forgejo #1646); if they
+// did not, TryLock here would fail because a sync.Mutex is not reentrant. TryLock
+// is used rather than a blocking Lock so a regression fails the assertion instead
+// of deadlocking the test.
+type reentrantMetrics struct {
+	s           *stream
+	healthCalls atomic.Int32
+	errorCalls  atomic.Int32
+	lockWasFree atomic.Bool
+	lastHealthy atomic.Bool
+}
+
+func (m *reentrantMetrics) probeLockFree() {
+	if m.s.mu.TryLock() {
+		m.lockWasFree.Store(true)
+		m.s.mu.Unlock()
+	}
+}
+
+func (m *reentrantMetrics) IncStreamErrors(string) {
+	m.probeLockFree()
+	m.errorCalls.Add(1)
+}
+
+func (m *reentrantMetrics) SetStreamHealth(_ string, healthy bool) {
+	m.probeLockFree()
+	m.lastHealthy.Store(healthy)
+	m.healthCalls.Add(1)
+}
+
+func (m *reentrantMetrics) RecordDataRate(string, float64) {}
+func (m *reentrantMetrics) RecordWireRate(string, float64) {}
+func (m *reentrantMetrics) SetStreamEngine(string, string) {}
+
+// TestOnState_EmitsMetricsOutsideLock is a regression test for the AB-BA hazard
+// fixed in Forgejo #1646: onState must release s.mu before emitting stream
+// metrics, matching onDeliver and snapshot. A metrics implementation that reads
+// stream health back while holding its own lock would otherwise risk a deadlock.
+// StateConnected is used because that transition drives onState without touching
+// the pipeline or supervisor.
+func TestOnState_EmitsMetricsOutsideLock(t *testing.T) {
+	t.Parallel()
+
+	s := &stream{
+		spec: &audiocore.StreamSpec{SourceID: "src1"},
+		opts: &Options{},
+	}
+	m := &reentrantMetrics{s: s}
+	s.opts.Metrics = m
+
+	s.onState(supervisor.StateChange{State: supervisor.StateConnected})
+
+	assert.Equal(t, int32(1), m.healthCalls.Load(), "SetStreamHealth should be emitted once")
+	assert.True(t, m.lockWasFree.Load(), "s.mu must be released before metrics are emitted (AB-BA guard)")
+	assert.True(t, m.lastHealthy.Load(), "connected stream should report healthy=true")
+}
+
+// TestRecordError_ReportsRecorded locks the recordError contract used by onState
+// to decide whether to emit IncStreamErrors after unlocking: it returns false for
+// a nil error and true (appending one history entry) when it records a classified
+// error.
+func TestRecordError_ReportsRecorded(t *testing.T) {
+	t.Parallel()
+
+	s := &stream{
+		spec:       &audiocore.StreamSpec{SourceID: "src1"},
+		opts:       &Options{},
+		targetHost: "cam.local",
+		targetPort: 554,
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	assert.False(t, s.recordError(nil), "nil error records nothing")
+	assert.Empty(t, s.errorHistory, "nil error must not append history")
+
+	require.True(t, s.recordError(fmt.Errorf("something broke")), "a classified error is recorded")
+	assert.Len(t, s.errorHistory, 1, "a recorded error appends exactly one history entry")
+}

--- a/internal/audiocore/stream/stream.go
+++ b/internal/audiocore/stream/stream.go
@@ -179,7 +179,6 @@ func (s *stream) onState(sc supervisor.StateChange) {
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	if s.state != state || s.stateDetail != detail {
 		s.appendHistory(state, detail, causeString(sc.Err))
@@ -196,14 +195,15 @@ func (s *stream) onState(sc supervisor.StateChange) {
 	}
 	s.recovery = recovery
 
+	errored := false
 	switch sc.State {
 	case supervisor.StateReconnecting:
 		s.restartCount++
 		s.reconnectAttempt = sc.Attempt
 		s.nextRetryIn = sc.Backoff
-		s.recordError(sc.Err)
+		errored = s.recordError(sc.Err)
 	case supervisor.StateFailed:
-		s.recordError(sc.Err)
+		errored = s.recordError(sc.Err)
 	case supervisor.StateConnected:
 		s.reconnectAttempt = 0
 		s.nextRetryIn = 0
@@ -211,7 +211,17 @@ func (s *stream) onState(sc supervisor.StateChange) {
 		// no counter changes
 	}
 
+	s.mu.Unlock()
+
+	// Emit metrics outside s.mu, matching onDeliver and snapshot, so a metrics
+	// implementation that reads stream health back cannot deadlock (AB-BA). The
+	// error count is emitted before the health gauge to preserve the previous
+	// under-lock ordering. state is a local and s.spec.SourceID is immutable, so
+	// both are safe to read after the unlock.
 	if s.opts.Metrics != nil {
+		if errored {
+			s.opts.Metrics.IncStreamErrors(s.spec.SourceID)
+		}
 		s.opts.Metrics.SetStreamHealth(s.spec.SourceID, state == audiocore.StreamStateConnected)
 	}
 }
@@ -274,23 +284,24 @@ func (s *stream) appendHistory(to audiocore.StreamState, toDetail, reason string
 }
 
 // recordError classifies err and stores it as the last error plus history entry.
-// Caller holds mu.
-func (s *stream) recordError(err error) {
+// It returns true when an error context was recorded, so the caller can emit the
+// IncStreamErrors metric after releasing the lock (the metric must not be emitted
+// under s.mu; see onState). Caller holds mu.
+func (s *stream) recordError(err error) bool {
 	if err == nil {
-		return
+		return false
 	}
 	s.lastErr = err
 	ctx := classifyError(err, s.targetHost, s.targetPort)
 	s.lastErrCtx = ctx
-	if ctx != nil {
-		s.errorHistory = append(s.errorHistory, ctx)
-		if len(s.errorHistory) > errorHistoryLen {
-			s.errorHistory = s.errorHistory[len(s.errorHistory)-errorHistoryLen:]
-		}
-		if s.opts.Metrics != nil {
-			s.opts.Metrics.IncStreamErrors(s.spec.SourceID)
-		}
+	if ctx == nil {
+		return false
 	}
+	s.errorHistory = append(s.errorHistory, ctx)
+	if len(s.errorHistory) > errorHistoryLen {
+		s.errorHistory = s.errorHistory[len(s.errorHistory)-errorHistoryLen:]
+	}
+	return true
 }
 
 // snapshot returns a copy of the current health, computing the derived liveness

--- a/internal/audiocore/streamtest/fixture_mediamtx.go
+++ b/internal/audiocore/streamtest/fixture_mediamtx.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"net"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -147,4 +148,21 @@ func (p *mediaPublication) Restart(t *testing.T) {
 	p.pub = pub
 	p.mu.Unlock()
 	time.Sleep(publishSettle)
+	requirePublisherAlive(t, pub)
+}
+
+// requirePublisherAlive fails fast, with the publisher's captured stderr, when
+// the FFmpeg tone publisher has already exited (bad args, an unsupported codec).
+// Without it a dead publisher surfaces only later as a confusing "frames should
+// flow" waitForFrames timeout instead of a clear "publisher died: <stderr>".
+func requirePublisherAlive(t *testing.T, pub *containers.StreamPublisher) {
+	t.Helper()
+	if pub.IsRunning() {
+		return
+	}
+	stderr := strings.TrimSpace(pub.Stderr())
+	if exitErr, ok := pub.ExitError(); ok && exitErr != nil {
+		t.Fatalf("FFmpeg publisher exited shortly after start: %v\nstderr:\n%s", exitErr, stderr)
+	}
+	t.Fatalf("FFmpeg publisher exited shortly after start\nstderr:\n%s", stderr)
 }

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -29,6 +29,7 @@ type Metrics struct {
 	HTTP          *metrics.HTTPMetrics
 	Notification  *metrics.NotificationMetrics
 	PrivacyFilter *metrics.PrivacyFilterMetrics
+	AudioStream   *metrics.AudioStreamMetrics
 }
 
 // NewMetrics creates a new instance of Metrics, initializing all metric collectors.
@@ -96,6 +97,11 @@ func NewMetrics() (*Metrics, error) {
 		return nil, fmt.Errorf("failed to create PrivacyFilter metrics: %w", err)
 	}
 
+	audioStreamMetrics, err := metrics.NewAudioStreamMetrics(registry)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AudioStream metrics: %w", err)
+	}
+
 	m := &Metrics{
 		registry:      registry,
 		MQTT:          mqttMetrics,
@@ -110,6 +116,7 @@ func NewMetrics() (*Metrics, error) {
 		HTTP:          httpMetrics,
 		Notification:  notificationMetrics,
 		PrivacyFilter: privacyFilterMetrics,
+		AudioStream:   audioStreamMetrics,
 	}
 
 	// Initialize tracing with metrics

--- a/internal/observability/metrics/audiostream.go
+++ b/internal/observability/metrics/audiostream.go
@@ -95,6 +95,19 @@ func (m *AudioStreamMetrics) SetStreamEngine(sourceID, engine string) {
 	m.StreamEngine.WithLabelValues(sourceID, engine).Set(1)
 }
 
+// DeleteStream removes every series for sourceID across all vecs, so a stopped or
+// removed stream stops being exported. It is safe to call for a source that has
+// no series yet (the deletes are no-ops).
+func (m *AudioStreamMetrics) DeleteStream(sourceID string) {
+	m.StreamErrors.DeleteLabelValues(sourceID)
+	m.StreamHealthy.DeleteLabelValues(sourceID)
+	m.DataRate.DeleteLabelValues(sourceID)
+	m.WireRate.DeleteLabelValues(sourceID)
+	// StreamEngine carries a second (engine) label, so delete every series whose
+	// source_id matches regardless of the engine value.
+	m.StreamEngine.DeletePartialMatch(prometheus.Labels{"source_id": sourceID})
+}
+
 // Collect implements the prometheus.Collector interface.
 func (m *AudioStreamMetrics) Collect(ch chan<- prometheus.Metric) {
 	m.StreamErrors.Collect(ch)

--- a/internal/observability/metrics/audiostream.go
+++ b/internal/observability/metrics/audiostream.go
@@ -1,0 +1,122 @@
+package metrics
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// AudioStreamMetrics contains Prometheus metrics for network audio stream ingest
+// (both the FFmpeg and native go-audio-stream producers). It is the concrete
+// implementation of the audiocore.StreamMetrics interface; because that interface
+// uses only primitive argument types, this package does not import audiocore and
+// no import cycle is introduced. The interface contract is asserted in the tests.
+//
+// All series are keyed by the stable internal source ID (not the raw URL) to
+// avoid leaking stream credentials into metric labels and to stay stable across
+// URL changes.
+type AudioStreamMetrics struct {
+	StreamErrors  *prometheus.CounterVec
+	StreamHealthy *prometheus.GaugeVec
+	DataRate      *prometheus.GaugeVec
+	WireRate      *prometheus.GaugeVec
+	StreamEngine  *prometheus.GaugeVec
+	registry      *prometheus.Registry
+}
+
+// NewAudioStreamMetrics creates a new AudioStreamMetrics and registers it with
+// the provided Prometheus registry. It returns an error if registration fails.
+func NewAudioStreamMetrics(registry *prometheus.Registry) (*AudioStreamMetrics, error) {
+	m := &AudioStreamMetrics{registry: registry}
+	if err := m.initMetrics(); err != nil {
+		return nil, fmt.Errorf("failed to initialize audio stream metrics: %w", err)
+	}
+	if err := registry.Register(m); err != nil {
+		return nil, fmt.Errorf("failed to register audio stream metrics: %w", err)
+	}
+	return m, nil
+}
+
+// initMetrics initializes all metrics for AudioStreamMetrics.
+func (m *AudioStreamMetrics) initMetrics() error {
+	m.StreamErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "audio_stream_errors_total",
+		Help: "Total number of network audio stream ingest errors per source",
+	}, []string{"source_id"})
+
+	m.StreamHealthy = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "audio_stream_healthy",
+		Help: "Network audio stream health per source (1 when connected, 0 otherwise)",
+	}, []string{"source_id"})
+
+	m.DataRate = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "audio_stream_data_rate_bytes_per_second",
+		Help: "Decoded PCM data rate in bytes per second per source",
+	}, []string{"source_id"})
+
+	m.WireRate = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "audio_stream_wire_rate_bytes_per_second",
+		Help: "Wire (pre-decode) data rate in bytes per second per source; native ingest only",
+	}, []string{"source_id"})
+
+	m.StreamEngine = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "audio_stream_engine",
+		Help: "Active ingest engine per source, exported as a constant 1 labeled by engine (native or ffmpeg)",
+	}, []string{"source_id", "engine"})
+
+	return nil
+}
+
+// IncStreamErrors increments the error count for a stream.
+func (m *AudioStreamMetrics) IncStreamErrors(sourceID string) {
+	m.StreamErrors.WithLabelValues(sourceID).Inc()
+}
+
+// SetStreamHealth updates the health status of a stream (1 healthy, 0 unhealthy).
+func (m *AudioStreamMetrics) SetStreamHealth(sourceID string, healthy bool) {
+	m.StreamHealthy.WithLabelValues(sourceID).Set(boolToFloat(healthy))
+}
+
+// RecordDataRate records the current decoded-PCM data rate (bytes per second).
+func (m *AudioStreamMetrics) RecordDataRate(sourceID string, bytesPerSec float64) {
+	m.DataRate.WithLabelValues(sourceID).Set(bytesPerSec)
+}
+
+// RecordWireRate records the current wire data rate (bytes per second), distinct
+// from the decoded-PCM RecordDataRate. Native ingest only.
+func (m *AudioStreamMetrics) RecordWireRate(sourceID string, bytesPerSec float64) {
+	m.WireRate.WithLabelValues(sourceID).Set(bytesPerSec)
+}
+
+// SetStreamEngine records which ingest producer ("native"/"ffmpeg") serves a
+// stream. The engine per source is fixed for the life of a run, so this yields a
+// single series per source.
+func (m *AudioStreamMetrics) SetStreamEngine(sourceID, engine string) {
+	m.StreamEngine.WithLabelValues(sourceID, engine).Set(1)
+}
+
+// Collect implements the prometheus.Collector interface.
+func (m *AudioStreamMetrics) Collect(ch chan<- prometheus.Metric) {
+	m.StreamErrors.Collect(ch)
+	m.StreamHealthy.Collect(ch)
+	m.DataRate.Collect(ch)
+	m.WireRate.Collect(ch)
+	m.StreamEngine.Collect(ch)
+}
+
+// Describe implements the prometheus.Collector interface.
+func (m *AudioStreamMetrics) Describe(ch chan<- *prometheus.Desc) {
+	m.StreamErrors.Describe(ch)
+	m.StreamHealthy.Describe(ch)
+	m.DataRate.Describe(ch)
+	m.WireRate.Describe(ch)
+	m.StreamEngine.Describe(ch)
+}
+
+// boolToFloat maps a health boolean onto the gauge value space (1 or 0).
+func boolToFloat(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/internal/observability/metrics/audiostream_test.go
+++ b/internal/observability/metrics/audiostream_test.go
@@ -32,15 +32,25 @@ func TestAudioStreamMetrics(t *testing.T) {
 	m.SetStreamHealth(src, true)
 	m.RecordDataRate(src, 1234.5)
 	m.RecordWireRate(src, 678.0)
-	m.SetStreamEngine(src, "native")
+	m.SetStreamEngine(src, audiocore.EngineNative)
+
+	// The aggregate Collect must export exactly one series per vec (5). ToFloat64
+	// below only exercises each vec in isolation, so this guards against a vec
+	// being dropped from Collect.
+	assert.Equal(t, 5, testutil.CollectAndCount(m), "Collect must export one series per vec")
 
 	assert.InDelta(t, 2.0, testutil.ToFloat64(m.StreamErrors.WithLabelValues(src)), delta)
 	assert.InDelta(t, 1.0, testutil.ToFloat64(m.StreamHealthy.WithLabelValues(src)), delta)
 	assert.InDelta(t, 1234.5, testutil.ToFloat64(m.DataRate.WithLabelValues(src)), delta)
 	assert.InDelta(t, 678.0, testutil.ToFloat64(m.WireRate.WithLabelValues(src)), delta)
-	assert.InDelta(t, 1.0, testutil.ToFloat64(m.StreamEngine.WithLabelValues(src, "native")), delta)
+	assert.InDelta(t, 1.0, testutil.ToFloat64(m.StreamEngine.WithLabelValues(src, audiocore.EngineNative)), delta)
 
-	// An unhealthy transition flips the health gauge to 0.
+	// An unhealthy transition flips the health gauge to 0 (still a live series).
 	m.SetStreamHealth(src, false)
 	assert.InDelta(t, 0.0, testutil.ToFloat64(m.StreamHealthy.WithLabelValues(src)), delta)
+
+	// DeleteStream removes every series for the source, so a stopped stream stops
+	// being exported.
+	m.DeleteStream(src)
+	assert.Equal(t, 0, testutil.CollectAndCount(m), "DeleteStream must remove all series for the source")
 }

--- a/internal/observability/metrics/audiostream_test.go
+++ b/internal/observability/metrics/audiostream_test.go
@@ -1,0 +1,46 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+)
+
+// AudioStreamMetrics must satisfy audiocore.StreamMetrics so it can be assigned
+// to engine.Config.StreamMetrics and forwarded to both stream producers.
+var _ audiocore.StreamMetrics = (*AudioStreamMetrics)(nil)
+
+func TestAudioStreamMetrics(t *testing.T) {
+	t.Parallel()
+
+	reg := prometheus.NewRegistry()
+	m, err := NewAudioStreamMetrics(reg)
+	require.NoError(t, err)
+
+	const (
+		src   = "source-1"
+		delta = 1e-9
+	)
+
+	m.IncStreamErrors(src)
+	m.IncStreamErrors(src)
+	m.SetStreamHealth(src, true)
+	m.RecordDataRate(src, 1234.5)
+	m.RecordWireRate(src, 678.0)
+	m.SetStreamEngine(src, "native")
+
+	assert.InDelta(t, 2.0, testutil.ToFloat64(m.StreamErrors.WithLabelValues(src)), delta)
+	assert.InDelta(t, 1.0, testutil.ToFloat64(m.StreamHealthy.WithLabelValues(src)), delta)
+	assert.InDelta(t, 1234.5, testutil.ToFloat64(m.DataRate.WithLabelValues(src)), delta)
+	assert.InDelta(t, 678.0, testutil.ToFloat64(m.WireRate.WithLabelValues(src)), delta)
+	assert.InDelta(t, 1.0, testutil.ToFloat64(m.StreamEngine.WithLabelValues(src, "native")), delta)
+
+	// An unhealthy transition flips the health gauge to 0.
+	m.SetStreamHealth(src, false)
+	assert.InDelta(t, 0.0, testutil.ToFloat64(m.StreamHealthy.WithLabelValues(src)), delta)
+}

--- a/internal/testutil/containers/mediamtx_publisher.go
+++ b/internal/testutil/containers/mediamtx_publisher.go
@@ -3,17 +3,63 @@
 package containers
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os/exec"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"time"
 )
+
+// publisherStderrCap bounds the captured publisher stderr so a chatty or
+// long-running publisher cannot grow the buffer without limit. The publishers run
+// with -loglevel error, so this is generous headroom for a diagnostic tail.
+const publisherStderrCap = 64 * 1024
+
+// cappedBuffer is a concurrency-safe io.Writer that retains up to cap bytes of
+// what is written to it and discards the rest, so it can serve as an exec.Cmd
+// stderr sink read from another goroutine. It always reports a full write so the
+// os/exec stderr copier keeps draining the pipe.
+type cappedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+	cap int
+}
+
+func (b *cappedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if remaining := b.cap - b.buf.Len(); remaining > 0 {
+		if len(p) > remaining {
+			b.buf.Write(p[:remaining])
+		} else {
+			b.buf.Write(p)
+		}
+	}
+	return len(p), nil
+}
+
+func (b *cappedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
 
 // StreamPublisher manages an FFmpeg process that publishes audio to MediaMTX.
 type StreamPublisher struct {
 	cmd    *exec.Cmd
 	cancel context.CancelFunc
+	stderr *cappedBuffer
+	// exited is flipped once the single background Wait completes; IsRunning reads
+	// it (cmd.ProcessState stays nil until Wait returns, so it is not a reliable
+	// liveness signal on its own).
+	exited atomic.Bool
+	// waitErr is the process exit error, written once before done is closed and
+	// safe to read after receiving from done.
+	waitErr error
+	done    chan struct{}
 }
 
 // Publisher defaults for the tone generator.
@@ -99,11 +145,11 @@ func PublishToneToMediaMTX(ctx context.Context, rtspURL string, opts ToneOptions
 
 	//nolint:gosec // G204: args are built from test infrastructure, not user input
 	cmd := exec.CommandContext(pubCtx, "ffmpeg", buildToneArgs(rtspURL, opts)...)
-	if err := cmd.Start(); err != nil {
-		cancel()
+	p, err := startPublisher(cmd, cancel)
+	if err != nil {
 		return nil, fmt.Errorf("failed to start FFmpeg tone publisher: %w", err)
 	}
-	return &StreamPublisher{cmd: cmd, cancel: cancel}, nil
+	return p, nil
 }
 
 // PublishWAVToMediaMTX starts FFmpeg to publish a WAV file to MediaMTX via RTSP.
@@ -128,42 +174,83 @@ func PublishWAVToMediaMTX(ctx context.Context, wavPath, rtspURL string) (*Stream
 		rtspURL, // Destination
 	)
 
-	if err := cmd.Start(); err != nil {
-		cancel()
+	p, err := startPublisher(cmd, cancel)
+	if err != nil {
 		return nil, fmt.Errorf("failed to start FFmpeg publisher: %w", err)
 	}
-
-	return &StreamPublisher{cmd: cmd, cancel: cancel}, nil
+	return p, nil
 }
 
-// Stop terminates the FFmpeg publisher process.
+// startPublisher captures the process stderr, starts it, and owns the single
+// cmd.Wait() call in a background goroutine. Concentrating Wait() here is what
+// makes IsRunning reliable (it flips exited when the process actually ends) and
+// lets Stop wait on done without a second, illegal Wait() call.
+func startPublisher(cmd *exec.Cmd, cancel context.CancelFunc) (*StreamPublisher, error) {
+	sb := &cappedBuffer{cap: publisherStderrCap}
+	cmd.Stderr = sb
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, err
+	}
+	p := &StreamPublisher{cmd: cmd, cancel: cancel, stderr: sb, done: make(chan struct{})}
+	go func() {
+		p.waitErr = p.cmd.Wait()
+		p.exited.Store(true)
+		close(p.done)
+	}()
+	return p, nil
+}
+
+// Stop terminates the FFmpeg publisher process. It cancels the context and waits
+// for the background Wait() to finish, force-killing after a timeout. It never
+// calls cmd.Wait() itself: that goroutine already owns the single Wait().
 func (p *StreamPublisher) Stop() {
 	if p.cancel != nil {
 		p.cancel()
 	}
-	if p.cmd != nil && p.cmd.Process != nil {
-		// Wait with a timeout to avoid hanging
-		done := make(chan error, 1)
-		go func() {
-			done <- p.cmd.Wait()
-		}()
-
-		select {
-		case <-done:
-			// Process exited
-		case <-time.After(5 * time.Second):
-			// Force kill if it hasn't stopped
+	if p.done == nil {
+		return
+	}
+	select {
+	case <-p.done:
+		// Process exited.
+	case <-time.After(5 * time.Second):
+		// Force kill if it hasn't stopped, then wait for the background Wait().
+		if p.cmd != nil && p.cmd.Process != nil {
 			_ = p.cmd.Process.Kill()
-			<-done
 		}
+		<-p.done
 	}
 }
 
-// IsRunning checks if the publisher process is still running.
+// IsRunning reports whether the publisher process is still running. It relies on
+// the background Wait() flipping exited, because cmd.ProcessState stays nil until
+// Wait() returns and so cannot detect a process that has already died.
 func (p *StreamPublisher) IsRunning() bool {
-	if p.cmd == nil || p.cmd.Process == nil {
-		return false
+	return p.done != nil && !p.exited.Load()
+}
+
+// Stderr returns whatever the publisher subprocess has written to stderr so far
+// (bounded by publisherStderrCap). It is safe to call while the process runs and
+// after it has exited, and is meant to explain a publisher that died on bad args
+// or an unsupported codec.
+func (p *StreamPublisher) Stderr() string {
+	if p.stderr == nil {
+		return ""
 	}
-	// ProcessState is nil while process is running
-	return p.cmd.ProcessState == nil
+	return p.stderr.String()
+}
+
+// ExitError returns the process exit error once the publisher has exited. The
+// boolean is false while it is still running (the error is not yet known).
+func (p *StreamPublisher) ExitError() (error, bool) {
+	if p.done == nil {
+		return nil, false
+	}
+	select {
+	case <-p.done:
+		return p.waitErr, true
+	default:
+		return nil, false
+	}
 }

--- a/internal/testutil/containers/mediamtx_publisher.go
+++ b/internal/testutil/containers/mediamtx_publisher.go
@@ -14,8 +14,10 @@ import (
 )
 
 // publisherStderrCap bounds the captured publisher stderr so a chatty or
-// long-running publisher cannot grow the buffer without limit. The publishers run
-// with -loglevel error, so this is generous headroom for a diagnostic tail.
+// long-running publisher cannot grow the buffer without limit. cappedBuffer keeps
+// the first N bytes (where FFmpeg prints its arg/codec startup errors) and
+// discards the rest; with -loglevel error this is generous headroom for that
+// diagnostic prefix.
 const publisherStderrCap = 64 * 1024
 
 // cappedBuffer is a concurrency-safe io.Writer that retains up to cap bytes of


### PR DESCRIPTION
## Description

Four folded audiocore/observability follow-ups from the native stream ingest work, kept as separate self-contained commits. The FFmpeg default ingest path stays behaviorally identical except for the silence-timeout classification fix noted below.

- Fix the FFmpeg silence-timeout classifier. The run loop classified a silence-watchdog restart with a substring check on the error message, but the silence error reads "stream stopped producing data for N seconds" and never contained the matched phrase, so the check was always false. Classification now keys on the error's structured `operation=silence_timeout` context (walking the wrapped-error chain), so a silence restart is correctly published as a disconnect, the intended failure-count reset runs, and the circuit breaker is fully reset instead of being left open.
- Add a concrete Prometheus collector for network audio stream ingest and wire it into the audio engine. The `audiocore.StreamMetrics` interface was forward-plumbed through both stream managers but had no implementer, so the engine/health/rate metrics were no-ops. The new collector exports per-source stream errors, health, decoded-PCM data rate, wire rate, and active ingest engine (native or ffmpeg), for both producers. Series are removed when a stream stops or the manager shuts down, so a stopped source stops being exported rather than lingering as stale series.
- Move the native producer's metric emissions outside the stream mutex, matching the existing dispatch and snapshot paths, to remove a latent lock-ordering hazard.
- Test hardening: the stream-health golden test now exercises the real FFmpeg `GetHealth` output (guarding the additive engine/transport JSON keys), and the MediaMTX test publisher captures its subprocess stderr and reports liveness reliably so a publisher that dies on startup fails fast with a clear message.

## Release Notes

- New Prometheus metrics for network audio stream ingest (`audio_stream_errors_total`, `audio_stream_healthy`, `audio_stream_data_rate_bytes_per_second`, `audio_stream_wire_rate_bytes_per_second`, `audio_stream_engine`), labeled per source and populated for both the FFmpeg and native ingest producers. Series for a stopped source are removed automatically.
- Behavior change for streams that connect but deliver no audio (for example a video-only track or an undecodable audio codec): these are now correctly reported as "Stream Disconnected" rather than a generic "Stream Error", and the stream keeps retrying instead of tripping the circuit breaker. Previously the silence-timeout classification never matched, so the disconnect alert, the failure-count reset, and the circuit-breaker reset never fired. No configuration or migration changes.

## Related issue

None (internal follow-up work).

## Test Plan

- `go build ./...` and `golangci-lint run` clean (0 issues, across the repo's build-tag matrix).
- `go test -race` green for `internal/audiocore/ffmpeg`, `internal/audiocore/stream`, `internal/observability/metrics`, and `internal/api/v2/audio`.
- New collector unit test asserts per-source values, the aggregate `Collect`, and `DeleteStream` removing all series.
- Silence classifier unit tests cover the context match, wrapped-error chain, and negatives; a regression test asserts the native producer emits metrics outside `s.mu`; another asserts a silence timeout fully clears the circuit breaker with a nonzero prior failure count.
- The stream-health golden test now runs a real `ffmpeg.GetHealth` and locks the additive `engine`/`transport` keys.
- Integration (`-tags integration`) streamtest contract suite exercises the publisher stderr/liveness changes against MediaMTX in CI/QA.

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/tphakala/birdnet-go/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`go test -race ./...` and/or `npm test`)
- [x] Linters are clean (`golangci-lint run` and/or `npm run check:all`)
- [x] New exports and user-facing changes are documented

## Licensing

- [x] My contribution is licensed under **CC BY-NC-SA 4.0**, and I grant the maintainer the right to relicense it under any **OSI-approved open source license**, as described in the [Relicensing Grant](https://github.com/tphakala/birdnet-go/blob/main/CONTRIBUTING.md#relicensing-grant).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added audio stream monitoring metrics for health, errors, data rates, wire rates, and ingest engine.
  - Metrics now support both FFmpeg and native audio stream implementations.

- **Bug Fixes**
  - Removed metrics for stopped or removed streams to prevent stale monitoring data.
  - Improved silence-timeout handling by resetting restart and circuit-breaker state.
  - Improved stream startup diagnostics by reporting publisher failures and captured error details promptly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->