### PR TITLE
fix(audiocore): persist lossy export bitrate default and resample sub-48k clips

### DIFF
--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -1497,9 +1497,12 @@ func (a *SaveAudioAction) planNativeNormalizationGain(ctx context.Context, sampl
 }
 
 // resolveExportParams determines the export sample rate, format, and output
-// path. Bird audio at rates above 48kHz is downsampled. Bat audio keeps the
-// native rate; if the configured format cannot carry it, the format is
-// silently switched to WAV.
+// path. Bird audio above 48kHz is downsampled to 48kHz. Bird audio below 48kHz
+// whose configured lossy native encoder cannot carry the source rate is resampled
+// UP to 48kHz (which every native lossy encoder accepts) so the configured format
+// is kept rather than stranded to WAV, on an install with no FFmpeg to take the
+// source rate directly. Bat audio keeps its native rate and is never resampled; if
+// the configured format cannot carry it, the format is switched to WAV.
 func (a *SaveAudioAction) resolveExportParams(outputPath string) (rate int, format, path string) {
 	rate = a.sourceSampleRate
 	if rate <= 0 {
@@ -1511,30 +1514,21 @@ func (a *SaveAudioAction) resolveExportParams(outputPath string) (rate int, form
 
 	isBat := detection.ResolveModelType(a.modelName, "") == entities.ModelTypeBat
 
-	if needsBatFormatFallback(a.modelName, "", rate, format) {
+	switch {
+	case needsBatFormatFallback(a.modelName, "", rate, format):
 		logBatFormatDowngrade(format, rate)
 		format = ffmpeg.FormatWAV
 		path = replaceExtension(path, ".wav")
-	} else if rate > conf.SampleRate && !isBat {
-		resampled, err := resample.ResampleBytes(a.pcmData, rate, conf.SampleRate)
-		if err != nil {
-			// Guarded per rate pair: resampling a fixed pair either works or it
-			// does not, so an affected source fails on every detection forever.
-			// The target is conf.SampleRate today, but it is keyed rather than
-			// assumed so a future variable target cannot silence the new pair.
-			resampleFailureLogged.do(resampleKey(rate, conf.SampleRate), func() {
-				GetLogger().Warn("Resampling failed, exporting at source rate",
-					logger.String("component", "analysis.processor.actions"),
-					logger.Int("source_rate", rate),
-					logger.Int("target_rate", conf.SampleRate),
-					logger.Error(err),
-					logger.String("operation", "audio_export_resample"))
-			})
-		} else {
-			a.pcmData = resampled
-			a.sourceSampleRate = conf.SampleRate
-			rate = conf.SampleRate
-		}
+	case rate > conf.SampleRate && !isBat:
+		// Bird audio above the analysis rate is downsampled to it.
+		rate = a.resampleExportTo(rate, conf.SampleRate)
+	case rate < conf.SampleRate && !isBat && a.nativeEncoderNeedsUpsample(rate, format):
+		// The configured lossy native encoder cannot carry this sub-48k rate and
+		// there is no FFmpeg to take it. Resample up to conf.SampleRate (accepted by
+		// every native lossy encoder) rather than stranding to WAV; on a resample
+		// failure the rate is unchanged and strandedWithoutEncoder below downgrades
+		// to WAV so the clip survives.
+		rate = a.resampleExportTo(rate, conf.SampleRate)
 	}
 
 	if a.strandedWithoutEncoder(rate, format) {
@@ -1585,6 +1579,66 @@ func (a *SaveAudioAction) strandedWithoutEncoder(rate int, format string) bool {
 		// Every other format either has an unconditional native encoder (WAV,
 		// FLAC) or was already downgraded to WAV by config validation when
 		// FFmpeg went missing (ALAC).
+		return false
+	}
+}
+
+// resampleExportTo converts the captured PCM from srcRate to dstRate for export,
+// updating the action's PCM buffer and source rate on success and returning the
+// rate the clip is now at. On failure it logs once per rate pair and leaves the
+// clip at srcRate for the caller's fallback to handle.
+//
+// The failure log is keyed per rate pair because resampling a fixed pair either
+// works or it does not, so an affected source would otherwise warn on every
+// detection forever; keying by the pair (rather than assuming a fixed target) keeps
+// a future variable target from silencing a new pair.
+func (a *SaveAudioAction) resampleExportTo(srcRate, dstRate int) int {
+	resampled, err := resample.ResampleBytes(a.pcmData, srcRate, dstRate)
+	if err != nil {
+		resampleFailureLogged.do(resampleKey(srcRate, dstRate), func() {
+			GetLogger().Warn("Resampling failed, exporting at source rate",
+				logger.String("component", "analysis.processor.actions"),
+				logger.Int("source_rate", srcRate),
+				logger.Int("target_rate", dstRate),
+				logger.Error(err),
+				logger.String("operation", "audio_export_resample"))
+		})
+		return srcRate
+	}
+	a.pcmData = resampled
+	a.sourceSampleRate = dstRate
+	return dstRate
+}
+
+// nativeEncoderNeedsUpsample reports whether a sub-48k clip must be resampled up to
+// conf.SampleRate to be encodable in its configured lossy format. It is the
+// resample counterpart to strandedWithoutEncoder: the same precondition (no FFmpeg,
+// and the format's active native encoder does not accept the source rate), but the
+// remedy is conversion to 48kHz (accepted by every native lossy encoder) instead of
+// a WAV downgrade.
+//
+// It checks the encoders' Supports directly rather than through nativeXSelected,
+// because a clip about to be resampled is not being skipped and must not emit the
+// "native encoder skipped" log. Opus is always native; AAC and MP3 only once opted
+// in, matching strandedWithoutEncoder. In this pipeline bit depth and channels are
+// fixed (conf.BitDepth, conf.NumChannels), so the only thing Supports rejects here
+// is the sample rate, which 48kHz resolves.
+//
+// REMOVAL: the FfmpegPath guard and the AAC/MP3 gates go away with FFmpeg and the
+// opt-in gates, leaving a plain "resample if the native encoder cannot carry it".
+func (a *SaveAudioAction) nativeEncoderNeedsUpsample(rate int, format string) bool {
+	if a.Settings.Realtime.Audio.FfmpegPath != "" {
+		return false // FFmpeg encodes the source rate directly; no resample needed
+	}
+	switch format {
+	case ffmpeg.FormatAAC:
+		return conf.NativeAACEncoderEnabled() && aac.Supports(rate, conf.BitDepth, conf.NumChannels) != nil
+	case ffmpeg.FormatMP3:
+		return conf.NativeMP3EncoderEnabled() && mp3.Supports(rate, conf.BitDepth, conf.NumChannels) != nil
+	case ffmpeg.FormatOpus:
+		return opus.Supports(rate, conf.BitDepth, conf.NumChannels) != nil
+	default:
+		// WAV and FLAC carry any rate; ALAC is FFmpeg-only. Nothing to resample for.
 		return false
 	}
 }

--- a/internal/analysis/processor/export_logging_test.go
+++ b/internal/analysis/processor/export_logging_test.go
@@ -706,7 +706,7 @@ func TestResolveExportParams_StrandedFallbackIsWarnedOncePerCondition(t *testing
 	// resampled, so this still strands rather than converting to 48kHz.
 	const unsupportedOpusRate = 44100
 	a := newExportLogAction(t, t.TempDir(), "clip.opus", ffmpeg.FormatOpus)
-	a.modelName = "BattyBirdNET"
+	a.modelName = batModelName
 	a.Settings.Realtime.Audio.FfmpegPath = ""
 	a.sourceSampleRate = unsupportedOpusRate
 
@@ -736,7 +736,7 @@ func TestResolveExportParams_StrandedFallbackLogsEachDistinctCondition(t *testin
 	logs := logtest.CaptureBuffer(t)
 
 	a := newExportLogAction(t, t.TempDir(), "clip.opus", ffmpeg.FormatOpus)
-	a.modelName = "BattyBirdNET"
+	a.modelName = batModelName
 	a.Settings.Realtime.Audio.FfmpegPath = ""
 	a.sourceSampleRate = 44100
 	_, _, _ = a.resolveExportParams("/clips/clip.opus")

--- a/internal/analysis/processor/export_logging_test.go
+++ b/internal/analysis/processor/export_logging_test.go
@@ -693,16 +693,20 @@ func TestResolveExportParams_BatDowngradeLogsEachDistinctCondition(t *testing.T)
 // cannot carry the clip either. It means the same thing as the bat downgrade
 // ("you are not getting the format you configured"), so it is logged the same
 // way. It used to be the opposite of its sibling on both counts: WARN on every
-// single clip forever, against Info exactly once.
+// single clip forever, against Info exactly once. A bat clip drives it: bat audio
+// is never resampled (ultrasonic handling is out of scope), so a sub-48k bat clip
+// the encoder cannot carry still strands to WAV instead of being converted.
 func TestResolveExportParams_StrandedFallbackIsWarnedOncePerCondition(t *testing.T) {
 	resetNativeSkipOnce()
 	resetStrandedFormatOnce()
 	logs := logtest.CaptureBuffer(t)
 
 	// 44.1 kHz is a rate Opus does not accept, and with no FFmpeg to fall back
-	// on there is no encoder left for the configured format.
+	// on there is no encoder left for the configured format. A bat clip is not
+	// resampled, so this still strands rather than converting to 48kHz.
 	const unsupportedOpusRate = 44100
 	a := newExportLogAction(t, t.TempDir(), "clip.opus", ffmpeg.FormatOpus)
+	a.modelName = "BattyBirdNET"
 	a.Settings.Realtime.Audio.FfmpegPath = ""
 	a.sourceSampleRate = unsupportedOpusRate
 
@@ -723,7 +727,8 @@ func TestResolveExportParams_StrandedFallbackIsWarnedOncePerCondition(t *testing
 
 // The stranded guard is keyed like its sibling, so a second distinct condition
 // still explains itself. Without this, a bare sync.Once would pass the
-// once-per-condition test above identically.
+// once-per-condition test above identically. Bat clips drive it: they are never
+// resampled, so a sub-48k rate the native encoder cannot carry still strands.
 func TestResolveExportParams_StrandedFallbackLogsEachDistinctCondition(t *testing.T) {
 	t.Setenv(conf.EnvNativeAACEncoder, "native")
 	resetNativeSkipOnce()
@@ -731,6 +736,7 @@ func TestResolveExportParams_StrandedFallbackLogsEachDistinctCondition(t *testin
 	logs := logtest.CaptureBuffer(t)
 
 	a := newExportLogAction(t, t.TempDir(), "clip.opus", ffmpeg.FormatOpus)
+	a.modelName = "BattyBirdNET"
 	a.Settings.Realtime.Audio.FfmpegPath = ""
 	a.sourceSampleRate = 44100
 	_, _, _ = a.resolveExportParams("/clips/clip.opus")

--- a/internal/analysis/processor/native_encoder_gate_test.go
+++ b/internal/analysis/processor/native_encoder_gate_test.go
@@ -392,21 +392,21 @@ func TestResolveExportParams_StrandedClipFallsBackToWAV(t *testing.T) {
 			// cannot carry still strands to WAV rather than being converted. The input
 			// is .opus so the rewrite to .wav is actually exercised, not a no-op.
 			name:      "bat opus at an unsupported sub-48k rate with no ffmpeg strands the clip",
-			modelName: "BattyBirdNET", format: ffmpeg.FormatOpus, inExt: ".opus",
+			modelName: batModelName, format: ffmpeg.FormatOpus, inExt: ".opus",
 			ffmpegPath: "", rate: 44100,
 			wantFormat: "wav", wantExt: ".wav",
 		},
 		{
 			// FFmpeg present: it can still take the clip, so keep the format.
-			name:       "opus at an unsupported rate keeps opus when ffmpeg exists",
-			format:     ffmpeg.FormatOpus, inExt: ".opus",
+			name:   "opus at an unsupported rate keeps opus when ffmpeg exists",
+			format: ffmpeg.FormatOpus, inExt: ".opus",
 			ffmpegPath: "/usr/bin/ffmpeg", rate: 44100,
 			wantFormat: ffmpeg.FormatOpus, wantExt: ".opus",
 		},
 		{
 			// Supported rate: the native encoder carries it, no fallback needed.
-			name:       "opus at a supported rate with no ffmpeg keeps opus",
-			format:     ffmpeg.FormatOpus, inExt: ".opus",
+			name:   "opus at a supported rate with no ffmpeg keeps opus",
+			format: ffmpeg.FormatOpus, inExt: ".opus",
 			ffmpegPath: "", rate: conf.SampleRate,
 			wantFormat: ffmpeg.FormatOpus, wantExt: ".opus",
 		},

--- a/internal/analysis/processor/native_encoder_gate_test.go
+++ b/internal/analysis/processor/native_encoder_gate_test.go
@@ -367,47 +367,46 @@ func TestEncodeClip_UltrasonicRatesWithNormalization(t *testing.T) {
 	}
 }
 
-// A native-encoded format is not downgraded to WAV by config validation when
-// FFmpeg is absent: Opus never is (go-opus is the default), and AAC is not once
-// the operator opts it in. If the native encoder then turns out not to accept the
-// clip's shape, there is no encoder left at all, and without this fallback the
-// export would call FFmpeg with an empty path and lose the recording. The format
-// must resolve to WAV, and the clip path must be corrected with it so the file on
-// disk matches the name recorded in the database.
+// A clip with no encoder left still falls back to WAV so the recording survives.
+// A non-bat sub-48k clip now resamples to 48k instead of stranding (see
+// TestResolveExportParams_SubRateResamplesForNativeEncoder), so the remaining
+// strand cases are a bat clip (never resampled: ultrasonic handling is out of
+// scope) whose format cannot carry its rate. The format must resolve to WAV, and
+// the clip path must be corrected with it so the file on disk matches the name
+// recorded in the database.
 func TestResolveExportParams_StrandedClipFallsBackToWAV(t *testing.T) {
 	// Not parallel: t.Setenv.
 	tests := []struct {
 		name       string
-		envVar     string // AAC gate to set; empty for the ungated Opus cases
+		envVar     string // native gate to set; empty for the ungated Opus cases
+		modelName  string // a bat classifier name opts the clip out of resampling
 		format     string
+		inExt      string // the input clip extension (the configured format's), so the .wav rewrite is genuinely exercised
 		ffmpegPath string
 		rate       int
 		wantFormat string
 		wantExt    string
 	}{
 		{
-			name:       "opus at an unsupported rate with no ffmpeg strands the clip",
-			format:     ffmpeg.FormatOpus,
+			// A bat clip is never resampled, so a sub-48k bat clip the native encoder
+			// cannot carry still strands to WAV rather than being converted. The input
+			// is .opus so the rewrite to .wav is actually exercised, not a no-op.
+			name:      "bat opus at an unsupported sub-48k rate with no ffmpeg strands the clip",
+			modelName: "BattyBirdNET", format: ffmpeg.FormatOpus, inExt: ".opus",
 			ffmpegPath: "", rate: 44100,
-			wantFormat: "wav", wantExt: ".wav",
-		},
-		{
-			name:   "aac at an unsupported rate with no ffmpeg strands the clip",
-			envVar: conf.EnvNativeAACEncoder, format: ffmpeg.FormatAAC,
-			ffmpegPath: "", rate: 22050,
 			wantFormat: "wav", wantExt: ".wav",
 		},
 		{
 			// FFmpeg present: it can still take the clip, so keep the format.
 			name:       "opus at an unsupported rate keeps opus when ffmpeg exists",
-			format:     ffmpeg.FormatOpus,
+			format:     ffmpeg.FormatOpus, inExt: ".opus",
 			ffmpegPath: "/usr/bin/ffmpeg", rate: 44100,
 			wantFormat: ffmpeg.FormatOpus, wantExt: ".opus",
 		},
 		{
 			// Supported rate: the native encoder carries it, no fallback needed.
 			name:       "opus at a supported rate with no ffmpeg keeps opus",
-			format:     ffmpeg.FormatOpus,
+			format:     ffmpeg.FormatOpus, inExt: ".opus",
 			ffmpegPath: "", rate: conf.SampleRate,
 			wantFormat: ffmpeg.FormatOpus, wantExt: ".opus",
 		},
@@ -421,15 +420,136 @@ func TestResolveExportParams_StrandedClipFallsBackToWAV(t *testing.T) {
 			}
 
 			a := newGateTestAction(t, "96k")
+			a.modelName = tt.modelName
 			a.sourceSampleRate = tt.rate
 			a.Settings.Realtime.Audio.Export.Type = tt.format
 			a.Settings.Realtime.Audio.FfmpegPath = tt.ffmpegPath
 
-			rate, format, path := a.resolveExportParams("/clips/2026/07/19/clip" + filepath.Ext("x"+tt.wantExt))
-			_ = rate
+			_, format, path := a.resolveExportParams("/clips/2026/07/19/clip" + tt.inExt)
 			assert.Equal(t, tt.wantFormat, format)
 			assert.Equal(t, tt.wantExt, filepath.Ext(path),
 				"the clip path extension must follow the resolved format")
 		})
 	}
+}
+
+// A non-bat clip whose source rate is below 48kHz and whose lossy native encoder
+// cannot carry that rate is resampled UP to 48kHz (accepted by every native lossy
+// encoder) instead of stranding to WAV, so the configured format is preserved.
+// A rate the encoder already supports is kept as-is (no needless resample), and an
+// install that still has FFmpeg lets FFmpeg take the source rate directly.
+func TestResolveExportParams_SubRateResamplesForNativeEncoder(t *testing.T) {
+	// Not parallel: t.Setenv.
+	tests := []struct {
+		name       string
+		envVar     string // native gate to set; empty for the ungated Opus cases
+		format     string
+		ffmpegPath string
+		rate       int
+		wantRate   int
+		wantFormat string
+	}{
+		// Above 48k (non-bat): downsampled to 48k, format kept (the sibling branch).
+		{"opus 96k downsamples to 48k", "", ffmpeg.FormatOpus, "", 96000, conf.SampleRate, ffmpeg.FormatOpus},
+		// Unsupported sub-48k rate + no FFmpeg: resample up to 48k, keep the format.
+		{"opus 44.1k resamples to 48k", "", ffmpeg.FormatOpus, "", 44100, conf.SampleRate, ffmpeg.FormatOpus},
+		{"aac 22.05k resamples to 48k", conf.EnvNativeAACEncoder, ffmpeg.FormatAAC, "", 22050, conf.SampleRate, ffmpeg.FormatAAC},
+		{"mp3 22.05k resamples to 48k", conf.EnvNativeMP3Encoder, ffmpeg.FormatMP3, "", 22050, conf.SampleRate, ffmpeg.FormatMP3},
+		// Rate the native encoder already supports: encode at the source rate.
+		{"opus 8k stays at source", "", ffmpeg.FormatOpus, "", 8000, 8000, ffmpeg.FormatOpus},
+		{"opus 16k stays at source", "", ffmpeg.FormatOpus, "", 16000, 16000, ffmpeg.FormatOpus},
+		{"aac 44.1k stays at source", conf.EnvNativeAACEncoder, ffmpeg.FormatAAC, "", 44100, 44100, ffmpeg.FormatAAC},
+		{"mp3 32k stays at source", conf.EnvNativeMP3Encoder, ffmpeg.FormatMP3, "", 32000, 32000, ffmpeg.FormatMP3},
+		{"mp3 44.1k stays at source", conf.EnvNativeMP3Encoder, ffmpeg.FormatMP3, "", 44100, 44100, ffmpeg.FormatMP3},
+		// FFmpeg present: it carries the source rate, so nothing is resampled.
+		{"opus 44.1k with ffmpeg stays at source", "", ffmpeg.FormatOpus, "/usr/bin/ffmpeg", 44100, 44100, ffmpeg.FormatOpus},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(conf.EnvNativeAACEncoder, "")
+			t.Setenv(conf.EnvNativeMP3Encoder, "")
+			if tt.envVar != "" {
+				t.Setenv(tt.envVar, "native")
+			}
+			resetNativeSkipOnce()
+
+			a := newGateTestAction(t, "96k")
+			a.sourceSampleRate = tt.rate
+			a.Settings.Realtime.Audio.Export.Type = tt.format
+			a.Settings.Realtime.Audio.FfmpegPath = tt.ffmpegPath
+
+			rate, format, _ := a.resolveExportParams("/clips/2026/07/19/clip")
+			assert.Equal(t, tt.wantRate, rate, "resolved sample rate")
+			assert.Equal(t, tt.wantFormat, format, "the configured lossy format must not be downgraded to WAV")
+		})
+	}
+}
+
+// End to end: a sub-48k clip that resolveExportParams resamples up to 48k must then
+// actually encode in the configured native format and produce a non-empty file, not
+// merely avoid the WAV downgrade.
+func TestResolveExportParams_ResampledSubRateEncodesNatively(t *testing.T) {
+	// Not parallel: t.Setenv.
+	tests := []struct {
+		name    string
+		envVar  string
+		format  string
+		ext     string
+		rate    int
+		wantEnc string
+	}{
+		{"opus 44.1k encodes native opus", "", ffmpeg.FormatOpus, ".opus", 44100, clipenc.NativeOpus},
+		{"aac 22.05k encodes native aac", conf.EnvNativeAACEncoder, ffmpeg.FormatAAC, ".m4a", 22050, clipenc.NativeAAC},
+		{"mp3 22.05k encodes native mp3", conf.EnvNativeMP3Encoder, ffmpeg.FormatMP3, ".mp3", 22050, clipenc.NativeMP3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(conf.EnvNativeAACEncoder, "")
+			t.Setenv(conf.EnvNativeMP3Encoder, "")
+			if tt.envVar != "" {
+				t.Setenv(tt.envVar, "native")
+			}
+			resetNativeSkipOnce()
+
+			a := newGateTestAction(t, "96k")
+			a.sourceSampleRate = tt.rate
+			a.Settings.Realtime.Audio.Export.Type = tt.format
+			a.Settings.Realtime.Audio.FfmpegPath = ""
+
+			out := filepath.Join(t.TempDir(), "clip"+tt.ext)
+			rate, format, path := a.resolveExportParams(out)
+			require.Equal(t, conf.SampleRate, rate, "the sub-48k clip must be resampled to 48k")
+			require.Equal(t, tt.format, format, "the configured format must be kept")
+
+			enc, err := a.encodeClip(t.Context(), rate, format, path)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantEnc, enc.Encoder, "the resampled clip must encode with the native encoder")
+
+			info, statErr := os.Stat(path)
+			require.NoError(t, statErr)
+			assert.Positive(t, info.Size(), "the encoded clip must not be empty")
+		})
+	}
+}
+
+// When resampling a sub-48k clip up to 48k fails, the export must fall through to
+// the WAV safety net so the recording survives rather than being lost. An odd byte
+// count is not whole 16-bit samples, so ResampleBytes rejects it deterministically,
+// exercising the resampleExportTo failure path for the upsample branch.
+func TestResolveExportParams_SubRateResampleFailureStrandsToWAV(t *testing.T) {
+	// Not parallel: touches package-level log guards shared with sibling tests.
+	resetNativeSkipOnce()
+
+	a := newGateTestAction(t, "96k")
+	a.pcmData = []byte{0x01, 0x02, 0x03} // odd length: ResampleBytes returns an error
+	a.sourceSampleRate = 44100           // go-opus cannot carry 44.1k, so an upsample is attempted
+	a.Settings.Realtime.Audio.Export.Type = ffmpeg.FormatOpus
+	a.Settings.Realtime.Audio.FfmpegPath = "" // native only: no FFmpeg to take the source rate
+
+	rate, format, path := a.resolveExportParams("/clips/2026/07/19/clip.opus")
+	assert.Equal(t, 44100, rate, "a failed resample leaves the clip at its source rate")
+	assert.Equal(t, ffmpeg.FormatWAV, format, "a failed resample must strand to WAV, not lose the recording")
+	assert.Equal(t, ".wav", filepath.Ext(path), "the clip path extension must follow the WAV fallback")
 }

--- a/internal/analysis/processor/native_mp3_gate_test.go
+++ b/internal/analysis/processor/native_mp3_gate_test.go
@@ -118,42 +118,44 @@ func TestEncodeClip_MP3GateDoesNotAffectOtherFormats(t *testing.T) {
 	assert.True(t, nativeOpusSelected(conf.SampleRate), "Opus is native by default, unaffected by the MP3 gate")
 }
 
-// On an FFmpeg-less install, opting MP3 into the native encoder must not strand a
-// clip go-mp3 cannot carry: the format is downgraded to WAV so the recording
-// survives, and the clip path extension follows the resolved format.
-func TestResolveExportParams_MP3StrandedClipFallsBackToWAV(t *testing.T) {
+// On an FFmpeg-less install, opting MP3 into the native encoder and feeding it a
+// sub-48k rate go-mp3 cannot carry must now resample the clip up to 48kHz and keep
+// the MP3 format, rather than stranding it to WAV. Supported rates and FFmpeg
+// installs keep MP3 without resampling; the clip path extension follows the format.
+func TestResolveExportParams_MP3SubRateResamplesInsteadOfStranding(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
 		gate       string
 		bitrate    string
 		ffmpegPath string
 		rate       int
+		wantRate   int
 		wantFormat string
 		wantExt    string
 	}{
 		{
-			name: "gate on, unsupported rate, no ffmpeg strands the clip",
+			name: "gate on, unsupported sub-48k rate, no ffmpeg resamples and keeps mp3",
 			gate: "native", bitrate: "128k", ffmpegPath: "", rate: 22050,
-			wantFormat: "wav", wantExt: ".wav",
+			wantRate: conf.SampleRate, wantFormat: ffmpeg.FormatMP3, wantExt: ".mp3",
 		},
 		{
 			// 100k is not an MPEG-1 rate, but the encoder rounds it to 96k rather
 			// than stranding the clip, so the format stays MP3 even without FFmpeg.
 			name: "gate on, non-MPEG-1 bitrate, no ffmpeg keeps mp3 (rounded)",
 			gate: "native", bitrate: "100k", ffmpegPath: "", rate: conf.SampleRate,
-			wantFormat: ffmpeg.FormatMP3, wantExt: ".mp3",
+			wantRate: conf.SampleRate, wantFormat: ffmpeg.FormatMP3, wantExt: ".mp3",
 		},
 		{
-			// FFmpeg present: it can still take the clip, so keep the format.
+			// FFmpeg present: it can still take the clip at its source rate, no resample.
 			name: "gate on, unsupported rate, ffmpeg present keeps mp3",
 			gate: "native", bitrate: "128k", ffmpegPath: "/usr/bin/ffmpeg", rate: 22050,
-			wantFormat: ffmpeg.FormatMP3, wantExt: ".mp3",
+			wantRate: 22050, wantFormat: ffmpeg.FormatMP3, wantExt: ".mp3",
 		},
 		{
-			// Carriable clip: the native encoder takes it, no fallback needed.
+			// Carriable clip: the native encoder takes it at source rate, no fallback.
 			name: "gate on, carriable clip, no ffmpeg keeps mp3",
 			gate: "native", bitrate: "128k", ffmpegPath: "", rate: conf.SampleRate,
-			wantFormat: ffmpeg.FormatMP3, wantExt: ".mp3",
+			wantRate: conf.SampleRate, wantFormat: ffmpeg.FormatMP3, wantExt: ".mp3",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -165,7 +167,8 @@ func TestResolveExportParams_MP3StrandedClipFallsBackToWAV(t *testing.T) {
 			a.Settings.Realtime.Audio.Export.Type = ffmpeg.FormatMP3
 			a.Settings.Realtime.Audio.FfmpegPath = tc.ffmpegPath
 
-			_, format, path := a.resolveExportParams("/clips/2026/07/19/clip.mp3")
+			rate, format, path := a.resolveExportParams("/clips/2026/07/19/clip.mp3")
+			assert.Equal(t, tc.wantRate, rate, "resolved sample rate")
 			assert.Equal(t, tc.wantFormat, format)
 			assert.Equal(t, tc.wantExt, filepath.Ext(path),
 				"the clip path extension must follow the resolved format")

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -47,7 +47,7 @@ type ExportSettings struct {
 	Enabled       bool                  `yaml:"enabled" json:"enabled" mapstructure:"enabled"`                   // export audio clips containing indentified bird calls
 	Path          string                `yaml:"path" json:"path" mapstructure:"path"`                            // path to audio clip export directory
 	Type          string                `yaml:"type" json:"type" mapstructure:"type"`                            // audio file type, wav, mp3 or flac
-	Bitrate       string                `yaml:"bitrate" json:"bitrate" mapstructure:"bitrate"`                   // bitrate for audio export
+	Bitrate       string                `yaml:"bitrate,omitempty" json:"bitrate" mapstructure:"bitrate"`         // bitrate for audio export
 	Retention     RetentionSettings     `yaml:"retention" json:"retention" mapstructure:"retention"`             // retention settings
 	Length        int                   `yaml:"length" json:"length" mapstructure:"length"`                      // audio capture length in seconds
 	PreCapture    int                   `yaml:"precapture" json:"preCapture" mapstructure:"preCapture"`          // pre-capture in seconds

--- a/internal/conf/migrate_export_bitrate_test.go
+++ b/internal/conf/migrate_export_bitrate_test.go
@@ -1,0 +1,184 @@
+package conf
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// loadConfigFromYAML writes cfg to a temp config.yaml, points the loader at it,
+// and returns the loaded settings. It restores the global loader state (ConfigPath,
+// viper, published settings) on cleanup so sequential tests do not leak into each
+// other. Not safe for t.Parallel().
+func loadConfigFromYAML(t *testing.T, cfg string) (settings *Settings, configPath string) {
+	t.Helper()
+	configPath = filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(cfg), 0o600))
+
+	oldPath := ConfigPath
+	oldSettings := CloneSettings(GetSettings())
+	t.Cleanup(func() {
+		ConfigPath = oldPath
+		viper.Reset()
+		StoreSettings(oldSettings)
+	})
+
+	viper.Reset()
+	ConfigPath = configPath
+
+	settings, err := Load()
+	require.NoError(t, err, "a config with a lossy export and no bitrate must load")
+	return settings, configPath
+}
+
+// readPersistedSettings unmarshals the on-disk config.yaml directly (bypassing the
+// load-time normalization), so a test can assert what was actually written to disk
+// rather than what the runtime holds in memory.
+func readPersistedSettings(t *testing.T, configPath string) *Settings {
+	t.Helper()
+	data, err := os.ReadFile(configPath) //nolint:gosec // test-controlled path
+	require.NoError(t, err)
+	var s Settings
+	require.NoError(t, yaml.Unmarshal(data, &s))
+	return &s
+}
+
+// A config that carries an explicit empty bitrate (bitrate: "") for a lossy export
+// unmarshals with an empty bitrate. That is the on-disk shape a disabled-time save
+// or a hand-edit leaves behind. The escalating Sentry warning came from repairing
+// that in memory on every load without ever writing the repair back. The load path
+// must now heal the file once: the in-memory value is the documented default, the
+// file on disk carries it, and a second load does not warn again.
+func TestLoad_EmptyLossyExportBitrate_SelfHealsAndStopsWarning(t *testing.T) {
+	for _, exportType := range []string{AudioExportTypeAAC, AudioExportTypeOPUS, AudioExportTypeMP3} {
+		t.Run(exportType, func(t *testing.T) {
+			cfg := `
+security:
+  sessionsecret: "0123456789abcdef0123456789abcdef"
+realtime:
+  audio:
+    export:
+      enabled: true
+      type: ` + exportType + `
+      path: clips/
+      length: 15
+      bitrate: ""
+`
+			settings, configPath := loadConfigFromYAML(t, cfg)
+
+			assert.Equal(t, DefaultAudioExportBitrate, settings.Realtime.Audio.Export.Bitrate,
+				"the loaded settings must carry the documented default bitrate")
+
+			persisted := readPersistedSettings(t, configPath)
+			assert.Equal(t, DefaultAudioExportBitrate, persisted.Realtime.Audio.Export.Bitrate,
+				"the healed bitrate must be written back to disk so the warning cannot recur")
+
+			// A second load of the healed file must not re-warn about the bitrate.
+			viper.Reset()
+			ConfigPath = configPath
+			reloaded, err := Load()
+			require.NoError(t, err)
+			assert.NotContains(t, warningsText(reloaded), "no bitrate is set",
+				"a healed config must not warn about the bitrate on the next load")
+		})
+	}
+}
+
+// The self-heal write-back runs before the incomplete-feature normalization that
+// disables switched-on-but-unconfigured integrations in memory. Persisting the
+// whole normalized struct would silently flip a user's enabled integration to
+// disabled on disk, which the security rule in validate_incomplete.go forbids. This
+// guards that the bitrate write-back preserves an enabled-but-incomplete
+// integration's on-disk state.
+func TestLoad_EmptyLossyExportBitrate_DoesNotPersistFeatureDisable(t *testing.T) {
+	cfg := `
+security:
+  sessionsecret: "0123456789abcdef0123456789abcdef"
+realtime:
+  birdweather:
+    enabled: true
+    id: ""
+  audio:
+    export:
+      enabled: true
+      type: aac
+      path: clips/
+      length: 15
+      bitrate: ""
+`
+	settings, configPath := loadConfigFromYAML(t, cfg)
+
+	// In memory the incomplete BirdWeather integration is switched off.
+	assert.False(t, settings.Realtime.Birdweather.Enabled,
+		"an incomplete BirdWeather integration is disabled in memory")
+
+	persisted := readPersistedSettings(t, configPath)
+	assert.True(t, persisted.Realtime.Birdweather.Enabled,
+		"the write-back must NOT persist the in-memory integration disable to disk")
+	assert.Equal(t, DefaultAudioExportBitrate, persisted.Realtime.Audio.Export.Bitrate,
+		"the bitrate is still healed on disk")
+}
+
+// The migration contract: fill a blank lossy bitrate (returning true), warn only
+// when the export is enabled, and leave non-lossy or already-set bitrates alone.
+func TestMigrateEmptyLossyExportBitrate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		exportType  string
+		bitrate     string
+		enabled     bool
+		wantChanged bool
+		wantBitrate string
+		wantWarning bool
+	}{
+		{"enabled aac blank fills and warns", AudioExportTypeAAC, "", true, true, DefaultAudioExportBitrate, true},
+		{"disabled opus blank fills without warning", AudioExportTypeOPUS, "", false, true, DefaultAudioExportBitrate, false},
+		{"enabled mp3 blank fills and warns", AudioExportTypeMP3, "", true, true, DefaultAudioExportBitrate, true},
+		{"lossless wav blank is left alone", AudioExportTypeWAV, "", true, false, "", false},
+		{"already-set bitrate is left alone", AudioExportTypeAAC, "128k", true, false, "128k", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := &Settings{}
+			s.Realtime.Audio.Export.Type = tt.exportType
+			s.Realtime.Audio.Export.Bitrate = tt.bitrate
+			s.Realtime.Audio.Export.Enabled = tt.enabled
+
+			changed := s.migrateEmptyLossyExportBitrate()
+
+			assert.Equal(t, tt.wantChanged, changed)
+			assert.Equal(t, tt.wantBitrate, s.Realtime.Audio.Export.Bitrate)
+			if tt.wantWarning {
+				assert.Contains(t, warningsText(s), "no bitrate is set")
+			} else {
+				assert.Empty(t, s.ValidationWarnings)
+			}
+		})
+	}
+}
+
+// omitempty on the Bitrate YAML tag stops a save made while the export is empty
+// from writing bitrate: "" back, which would permanently defeat the viper default
+// on the next load. An omitted key lets the default reapply.
+func TestSaveYAMLConfig_OmitsEmptyLossyBitrate(t *testing.T) {
+	s := &Settings{}
+	s.Realtime.Audio.Export.Type = AudioExportTypeAAC
+	s.Realtime.Audio.Export.Bitrate = ""
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, SaveYAMLConfig(configPath, s))
+
+	data, err := os.ReadFile(configPath) //nolint:gosec // test-controlled path
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), `bitrate: ""`,
+		"an empty bitrate must be omitted, not written as an empty string")
+}

--- a/internal/conf/migrations.go
+++ b/internal/conf/migrations.go
@@ -26,6 +26,35 @@ func persistMigration(settings *Settings, label string) {
 	}
 }
 
+// migrateEmptyLossyExportBitrate fills the documented default into a lossy export
+// whose bitrate was left blank on disk (an explicit `bitrate: ""` from a save made
+// while export was disabled, or a hand-edit), returning whether it changed anything.
+//
+// viper reads the blank as "", so without a persisted repair the default would be
+// re-applied only in memory on every load, re-emitting the same telemetry warning on
+// every restart because nothing writes it back. Healing it here, before the file is
+// saved, writes the default to disk once. The warning is recorded here (once, on the
+// healing load, when the export is enabled); the persisted default then stops it
+// firing on later loads.
+//
+// It runs from Load before normalizeIncompleteFeatures on purpose: a persistMigration
+// of the returned change writes the file with every feature's on-disk enabled state
+// intact. The incomplete-feature pass disables switched-on-but-unconfigured
+// integrations only in memory, and those disables must never reach disk.
+func (s *Settings) migrateEmptyLossyExportBitrate() bool {
+	export := &s.Realtime.Audio.Export
+	if !isLossyExportFormat(export.Type) || export.Bitrate != "" {
+		return false
+	}
+	export.Bitrate = DefaultAudioExportBitrate
+	if export.Enabled {
+		s.recordValidationWarning(warnComponentAudio,
+			"audio export is enabled with the lossy format %s but no bitrate is set; using the default %s",
+			export.Type, DefaultAudioExportBitrate)
+	}
+	return true
+}
+
 // migrateStreamEnabledDefaults materializes missing enabled fields for legacy
 // RTSP stream configs before viper unmarshals them into the strongly typed
 // settings struct.

--- a/internal/conf/storage.go
+++ b/internal/conf/storage.go
@@ -156,6 +156,15 @@ func Load() (*Settings, error) {
 		persistMigration(settings, "LocationConfigured flag")
 	}
 
+	// Heal a lossy export left with a blank bitrate by writing the documented
+	// default back once. Runs before normalizeIncompleteFeatures so persistMigration
+	// saves the file with every feature's on-disk enabled state intact; that pass
+	// disables switched-on-but-unconfigured integrations in memory only, and those
+	// disables must never be written to disk.
+	if settings.migrateEmptyLossyExportBitrate() {
+		persistMigration(settings, "empty lossy export bitrate")
+	}
+
 	// Auto-generate SessionSecret if not set (for backward compatibility)
 	if err := ensureSessionSecret(settings); err != nil {
 		return nil, err

--- a/internal/conf/validate_audio.go
+++ b/internal/conf/validate_audio.go
@@ -38,6 +38,19 @@ const (
 	AudioExportTypeOPUS = "opus" // Lossy compressed audio
 )
 
+// isLossyExportFormat reports whether an export format is a lossy codec that needs
+// a bitrate. AAC, Opus and MP3 are lossy; WAV and FLAC are lossless and ignore the
+// bitrate. Callers gate bitrate defaulting and validation on this instead of
+// repeating the AAC/OPUS/MP3 set.
+func isLossyExportFormat(format string) bool {
+	switch format {
+	case AudioExportTypeAAC, AudioExportTypeOPUS, AudioExportTypeMP3:
+		return true
+	default:
+		return false
+	}
+}
+
 // EBU R128 normalization limits
 const (
 	MinTargetLUFS    = -40.0 // Minimum target loudness in LUFS
@@ -575,12 +588,9 @@ func validateAudioSettings(settings *AudioSettings) error {
 	settings.applyFfmpegFormatFallback()
 
 	// Bitrate only matters for lossy formats and only when export is enabled.
-	switch settings.Export.Type {
-	case AudioExportTypeAAC, AudioExportTypeOPUS, AudioExportTypeMP3:
-		if settings.Export.Enabled {
-			if err := validateExportBitrate(settings.Export.Type, settings.Export.Bitrate); err != nil {
-				return err
-			}
+	if settings.Export.Enabled && isLossyExportFormat(settings.Export.Type) {
+		if err := validateExportBitrate(settings.Export.Type, settings.Export.Bitrate); err != nil {
+			return err
 		}
 	}
 

--- a/internal/conf/validate_incomplete.go
+++ b/internal/conf/validate_incomplete.go
@@ -416,6 +416,10 @@ func (s *Settings) normalizeIntegrations() {
 // and viper drops a nested default whenever the parent key is present but the child
 // is not, so an unfinished edit here is the likeliest way to meet this whole class
 // of failure.
+//
+// A blank lossy bitrate is not repaired here: it is healed and persisted by
+// migrateEmptyLossyExportBitrate in Load (before this pass), so the fix reaches
+// disk and the warning fires at most once instead of on every load.
 func (s *Settings) normalizeAudioExport() {
 	export := &s.Realtime.Audio.Export
 	if !export.Enabled {
@@ -427,16 +431,6 @@ func (s *Settings) normalizeAudioExport() {
 		s.recordValidationWarning(warnComponentAudio,
 			"audio export is enabled but no clip length is set; using the default %d seconds",
 			DefaultAudioExportLength)
-	}
-
-	switch export.Type {
-	case AudioExportTypeAAC, AudioExportTypeOPUS, AudioExportTypeMP3:
-		if export.Bitrate == "" {
-			export.Bitrate = DefaultAudioExportBitrate
-			s.recordValidationWarning(warnComponentAudio,
-				"audio export is enabled with the lossy format %s but no bitrate is set; using the default %s",
-				export.Type, DefaultAudioExportBitrate)
-		}
 	}
 
 	// Only targetLufs needs this: zero is outside its supported range, while zero

--- a/internal/conf/validate_incomplete_test.go
+++ b/internal/conf/validate_incomplete_test.go
@@ -972,7 +972,10 @@ func TestNormalizeSpeciesTracking_DefaultsResetDayIndependently(t *testing.T) {
 }
 
 // TestNormalizeAudioExport_AppliesDefaults covers the section users hand-edit most,
-// where viper drops a nested default whenever the parent key is present.
+// where viper drops a nested default whenever the parent key is present. The blank
+// lossy bitrate is not filled here (it is healed and persisted by the Load-time
+// migrateEmptyLossyExportBitrate; see TestLoad_EmptyLossyExportBitrate_*), so this
+// input carries a valid bitrate and asserts only the fields normalize still owns.
 func TestNormalizeAudioExport_AppliesDefaults(t *testing.T) {
 	t.Parallel()
 
@@ -980,6 +983,7 @@ func TestNormalizeAudioExport_AppliesDefaults(t *testing.T) {
 	s.Realtime.Audio.Export = ExportSettings{
 		Enabled:       true,
 		Type:          AudioExportTypeOPUS,
+		Bitrate:       DefaultAudioExportBitrate,
 		Normalization: NormalizationSettings{Enabled: true},
 	}
 	s.Realtime.Audio.Export.Retention = RetentionSettings{Policy: RetentionPolicyAge}
@@ -988,7 +992,6 @@ func TestNormalizeAudioExport_AppliesDefaults(t *testing.T) {
 
 	export := s.Realtime.Audio.Export
 	assert.Equal(t, DefaultAudioExportLength, export.Length)
-	assert.Equal(t, DefaultAudioExportBitrate, export.Bitrate)
 	assert.InDelta(t, DefaultNormalizationTargetLUFS, export.Normalization.TargetLUFS, 0.0001)
 	assert.Equal(t, DefaultRetentionMaxAge, export.Retention.MaxAge)
 	require.NoError(t, ValidateSettings(s))


### PR DESCRIPTION
## Summary

An enabled lossy audio export (aac/opus/mp3) with a blank bitrate on disk (`bitrate: ""`) was repaired in memory on every load but never written back, so the "audio export is enabled with the lossy format ... but no bitrate is set; using the default 96k" warning re-emitted on every restart. This heals it once: a load-time migration fills the documented default and persists it, running before the incomplete-feature normalization so a switched-on-but-unconfigured integration's `enabled: true` is never flipped to `false` on disk. `omitempty` is added to the `Bitrate` YAML tag so a blank is never written back to defeat the viper default on reload; the JSON tag is unchanged, so the settings API still always emits the field.

It also stops stranding sub-48kHz clips to WAV on the native encoders: when the configured lossy native encoder cannot carry the source rate and no FFmpeg is present, the clip is resampled up to 48kHz (accepted by every native encoder) instead of silently downgrading the format to WAV. This is native-path only; FFmpeg-present installs and bat clips are unchanged, and a resample failure still falls back to WAV so the recording always survives. The existing downsample path and the new upsample path now share one `resampleExportTo` helper.

## Test Plan

- conf round-trip per format (aac/opus/mp3): a config carrying an empty lossy bitrate self-heals on load, persists `96k` to disk, and does not re-warn on the next load
- a save made while export is disabled no longer writes `bitrate: ""` (omitempty), and the load-time write-back never persists an incomplete integration's disable
- `resolveExportParams` resamples sub-48k native clips to 48k instead of stranding, keeps encoder-supported rates at their source rate, still strands bat clips to WAV, and falls back to WAV on a resample failure
- `go test -race ./internal/conf/ ./internal/analysis/processor/` and `golangci-lint run` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bird audio exports below 48 kHz can be resampled to 48 kHz when required, preserving the selected lossy format instead of falling back to WAV.
  * Empty AAC, Opus, and MP3 bitrate settings are automatically repaired with documented defaults and saved for future use.

* **Bug Fixes**
  * Improved handling of unsupported sample rates and native encoding scenarios.
  * Prevented temporary configuration repairs from unintentionally disabling incomplete audio exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->