### PR TITLE
fix(audiocore): native ingest QA follow-ups for RTSP monitor log and streamtest leak

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -41,6 +41,13 @@ const hlsCleanupTimeout = 2 * time.Second
 // policyNone is the sentinel value indicating no retention/provider policy is configured.
 const policyNone = "none"
 
+// Stream-manager display labels for the RTSP monitoring startup log. They name
+// whichever manager the BIRDNET_STREAM_INGEST gate selected.
+const (
+	streamManagerFFmpeg = "FFmpeg manager"
+	streamManagerNative = "native stream manager"
+)
+
 // AudioPipelineService manages the audio capture pipeline, buffer management,
 // and control monitor as an app.Service. It coordinates HLS cleanup, audio source
 // initialization, sound level monitoring, quiet hours scheduling, clip cleanup,
@@ -356,9 +363,9 @@ func (p *AudioPipelineService) Start(_ context.Context) error {
 	// BIRDNET_STREAM_INGEST gate selected: the native stream manager when
 	// native ingest is enabled, otherwise the FFmpeg manager.
 	if len(settings.Realtime.RTSP.Streams) > 0 {
-		streamManagerName := "FFmpeg manager"
+		streamManagerName := streamManagerFFmpeg
 		if conf.NativeStreamIngestEnabled() {
-			streamManagerName = "native stream manager"
+			streamManagerName = streamManagerNative
 		}
 		audiocore.GetLogger().Info("RTSP streams will be monitored",
 			logger.Int("stream_count", len(settings.Realtime.RTSP.Streams)),

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -352,10 +352,17 @@ func (p *AudioPipelineService) Start(_ context.Context) error {
 		Properties: map[string]any{},
 	})
 
-	// RTSP health monitoring is built into the FFmpeg manager.
+	// RTSP health monitoring is built into whichever stream manager the
+	// BIRDNET_STREAM_INGEST gate selected: the native stream manager when
+	// native ingest is enabled, otherwise the FFmpeg manager.
 	if len(settings.Realtime.RTSP.Streams) > 0 {
-		audiocore.GetLogger().Info("RTSP streams will be monitored by FFmpeg manager",
+		streamManagerName := "FFmpeg manager"
+		if conf.NativeStreamIngestEnabled() {
+			streamManagerName = "native stream manager"
+		}
+		audiocore.GetLogger().Info("RTSP streams will be monitored",
 			logger.Int("stream_count", len(settings.Realtime.RTSP.Streams)),
+			logger.String("stream_manager", streamManagerName),
 			logger.String("operation", "rtsp_monitoring_setup"))
 	}
 

--- a/internal/analysis/control_monitor_telemetry_test.go
+++ b/internal/analysis/control_monitor_telemetry_test.go
@@ -50,7 +50,7 @@ func freeLoopbackAddr(t *testing.T) string {
 func TestControlMonitor_InitializeTelemetryStartsEndpoint(t *testing.T) {
 	// Not parallel: conftest.SetTestSettings mutates package-global settings and
 	// initializeTelemetryIfEnabled reads them via conf.Setting().
-	prev := conf.GetSettings()
+	prev := conf.CloneSettings(conf.GetSettings())
 	t.Cleanup(func() { conftest.SetTestSettings(prev) })
 
 	metrics, err := observability.NewMetrics()
@@ -94,7 +94,7 @@ func TestControlMonitor_InitializeTelemetryStartsEndpoint(t *testing.T) {
 // is not started when telemetry is disabled, so the loopback listener is never
 // bound. This pins the enabled-gate behavior alongside the enabled case above.
 func TestControlMonitor_InitializeTelemetryDisabledNoEndpoint(t *testing.T) {
-	prev := conf.GetSettings()
+	prev := conf.CloneSettings(conf.GetSettings())
 	t.Cleanup(func() { conftest.SetTestSettings(prev) })
 
 	metrics, err := observability.NewMetrics()
@@ -117,7 +117,7 @@ func TestControlMonitor_InitializeTelemetryDisabledNoEndpoint(t *testing.T) {
 // hand a nil *observability.Metrics to NewEndpoint. This pins the "drops the
 // metrics argument" regression the package comment names.
 func TestControlMonitor_InitializeTelemetryNilMetricsNoEndpoint(t *testing.T) {
-	prev := conf.GetSettings()
+	prev := conf.CloneSettings(conf.GetSettings())
 	t.Cleanup(func() { conftest.SetTestSettings(prev) })
 
 	settings := &conf.Settings{}

--- a/internal/analysis/control_monitor_telemetry_test.go
+++ b/internal/analysis/control_monitor_telemetry_test.go
@@ -1,0 +1,132 @@
+// control_monitor_telemetry_test.go guards the Prometheus telemetry endpoint's
+// bind-and-serve behavior. In production the realtime telemetry endpoint
+// (observability.NewEndpoint) is started from ControlMonitor.Start via
+// initializeTelemetryIfEnabled, which AudioPipelineService.Start invokes with a
+// non-nil *observability.Metrics; a QA defect reported the endpoint as never
+// starting even though this wiring is present.
+//
+// These tests pin the leaf that does the work, initializeTelemetryIfEnabled:
+// given telemetry enabled and non-nil metrics it must construct the endpoint
+// and actually bind and serve /metrics; given telemetry disabled, or metrics
+// nil, it must not start an endpoint. They exercise initializeTelemetryIfEnabled
+// directly rather than the full AudioPipelineService.Start -> NewControlMonitor
+// -> Start chain, so they do not by themselves pin that Start still calls the
+// initializer (that call is a single line, verified structurally) nor that
+// AudioPipelineService passes non-nil metrics; the end-to-end path is covered
+// empirically by running the server.
+package analysis
+
+import (
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/conf/conftest"
+	"github.com/tphakala/birdnet-go/internal/observability"
+)
+
+// freeLoopbackAddr returns a currently-free 127.0.0.1 host:port. It binds an
+// ephemeral port, records the address, and releases it so the telemetry
+// endpoint can claim it. The small reuse window is acceptable for a test.
+func freeLoopbackAddr(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err, "reserve a free loopback port")
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close())
+	return addr
+}
+
+// TestControlMonitor_InitializeTelemetryStartsEndpoint verifies that, with
+// realtime telemetry enabled and non-nil metrics, ControlMonitor initializes
+// and starts the Prometheus endpoint so /metrics is reachable. This is the wire
+// path AudioPipelineService.Start drives via NewControlMonitor(..., metrics,
+// ...) then ctrlMonitor.Start().
+func TestControlMonitor_InitializeTelemetryStartsEndpoint(t *testing.T) {
+	// Not parallel: conftest.SetTestSettings mutates package-global settings and
+	// initializeTelemetryIfEnabled reads them via conf.Setting().
+	prev := conf.GetSettings()
+	t.Cleanup(func() { conftest.SetTestSettings(prev) })
+
+	metrics, err := observability.NewMetrics()
+	require.NoError(t, err, "metrics must initialize")
+
+	addr := freeLoopbackAddr(t)
+	settings := &conf.Settings{}
+	settings.Realtime.Telemetry.Enabled = true
+	settings.Realtime.Telemetry.Listen = addr
+	conftest.SetTestSettings(settings)
+
+	cm := &ControlMonitor{metrics: metrics}
+	cm.initializeTelemetryIfEnabled()
+
+	// The endpoint must have been constructed and started.
+	require.NotNil(t, cm.telemetryEndpoint, "telemetry endpoint should be initialized when enabled")
+
+	// Ensure the endpoint goroutine is torn down even if an assertion below
+	// fails. ControlMonitor.Stop closes the quit channel and waits on the
+	// endpoint WaitGroup under telemetryEndpointMutex, and is a no-op for the
+	// components this test never started. Registered after Start so it runs
+	// before the settings restore above (t.Cleanup is LIFO).
+	t.Cleanup(cm.Stop)
+
+	// The server binds asynchronously, so poll /metrics until it answers. A
+	// successful scrape proves the endpoint is actually listening, not merely
+	// constructed.
+	url := "http://" + addr + "/metrics"
+	client := &http.Client{Timeout: time.Second}
+	require.Eventually(t, func() bool {
+		resp, getErr := client.Get(url)
+		if getErr != nil {
+			return false
+		}
+		defer func() { assert.NoError(t, resp.Body.Close()) }()
+		return resp.StatusCode == http.StatusOK
+	}, 5*time.Second, 20*time.Millisecond, "telemetry /metrics endpoint should serve requests")
+}
+
+// TestControlMonitor_InitializeTelemetryDisabledNoEndpoint verifies the endpoint
+// is not started when telemetry is disabled, so the loopback listener is never
+// bound. This pins the enabled-gate behavior alongside the enabled case above.
+func TestControlMonitor_InitializeTelemetryDisabledNoEndpoint(t *testing.T) {
+	prev := conf.GetSettings()
+	t.Cleanup(func() { conftest.SetTestSettings(prev) })
+
+	metrics, err := observability.NewMetrics()
+	require.NoError(t, err, "metrics must initialize")
+
+	settings := &conf.Settings{}
+	settings.Realtime.Telemetry.Enabled = false
+	settings.Realtime.Telemetry.Listen = freeLoopbackAddr(t)
+	conftest.SetTestSettings(settings)
+
+	cm := &ControlMonitor{metrics: metrics}
+	cm.initializeTelemetryIfEnabled()
+
+	assert.Nil(t, cm.telemetryEndpoint, "telemetry endpoint must not start when disabled")
+}
+
+// TestControlMonitor_InitializeTelemetryNilMetricsNoEndpoint verifies that, even
+// with telemetry enabled, no endpoint is started when metrics is nil:
+// initializeTelemetryIfEnabled must take its metrics-nil early return rather than
+// hand a nil *observability.Metrics to NewEndpoint. This pins the "drops the
+// metrics argument" regression the package comment names.
+func TestControlMonitor_InitializeTelemetryNilMetricsNoEndpoint(t *testing.T) {
+	prev := conf.GetSettings()
+	t.Cleanup(func() { conftest.SetTestSettings(prev) })
+
+	settings := &conf.Settings{}
+	settings.Realtime.Telemetry.Enabled = true
+	settings.Realtime.Telemetry.Listen = freeLoopbackAddr(t)
+	conftest.SetTestSettings(settings)
+
+	cm := &ControlMonitor{metrics: nil}
+	cm.initializeTelemetryIfEnabled()
+
+	assert.Nil(t, cm.telemetryEndpoint, "telemetry endpoint must not start when metrics is nil")
+}

--- a/internal/audiocore/streamtest/contract_cases.go
+++ b/internal/audiocore/streamtest/contract_cases.go
@@ -186,6 +186,15 @@ func caseLifecycle(t *testing.T, cfg *ContractConfig) {
 	defer cancel()
 	require.NoError(t, mgr.ShutdownWithContext(ctx), "shutdown should return within the timeout")
 
+	// Stop the MediaMTX publisher before the leak check. pub.Stop is also
+	// registered via t.Cleanup as a safety net, but t.Cleanup runs only after
+	// this function body returns, i.e. after goleak.VerifyNone below. Without
+	// this explicit stop, the publisher's still-running cmd.Wait() goroutine
+	// (containers.startPublisher.func1) is caught as a false goroutine leak.
+	// mediaPublication.Stop is idempotent, so the deferred cleanup call is a
+	// no-op once this has run.
+	pub.Stop(t)
+
 	// os/exec.(*Cmd).watchCtx is the Go stdlib goroutine that watches a child
 	// process's context; it is reaped by the runtime shortly after the child
 	// exits and is not a producer goroutine, so it is ignored here. Any other


### PR DESCRIPTION
## Summary

Three follow-ups from native RTSP ingest QA. Native ingest is gated behind `BIRDNET_STREAM_INGEST=native` and FFmpeg remains the default, so the default path is unaffected.

- **Accurate RTSP monitoring log.** At startup `AudioPipelineService` logged "RTSP streams will be monitored by FFmpeg manager" unconditionally, which is misleading when native ingest is active. It now names whichever stream manager the `BIRDNET_STREAM_INGEST` gate selected (native or FFmpeg) via `conf.NativeStreamIngestEnabled()` (the same gate the engine uses to build the manager), and moves the manager name into a structured `stream_manager` log field. This is a log-only change; the stable `operation="rtsp_monitoring_setup"` key is unchanged.

- **Stabilized streamtest lifecycle leak check.** `caseLifecycle` in the stream-manager contract suite ran `goleak.VerifyNone` before its `t.Cleanup`-registered publisher stop, so the MediaMTX publisher's still-running `cmd.Wait()` goroutine was caught as a false goroutine leak. The publisher is now stopped explicitly before the leak check; the deferred cleanup stays as an idempotent safety net. Verified: the Lifecycle contract test fails without this change (flagging `containers.startPublisher.func1`) and passes with it.

- **Telemetry endpoint regression test.** Added tests proving the Prometheus telemetry endpoint is initialized and actually serves `/metrics` through `ControlMonitor.initializeTelemetryIfEnabled` when `realtime.telemetry.enabled` is set, and stays down when telemetry is disabled or metrics is nil. This guards the observability wiring that a QA report suspected was broken; the endpoint in fact starts correctly under the `AudioPipelineService` path (verified by running the server), so this adds durable coverage rather than a behavior change.

## Testing

- `go test -race ./internal/analysis/ -run TestControlMonitor_InitializeTelemetry` (three new tests pass; the enabled case actually scrapes `/metrics`).
- `go test -tags integration ./internal/audiocore/stream/ -run TestNativeManagerContract/Lifecycle` passes with the fix and fails without it.
- `golangci-lint run` clean on the changed packages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * RTSP startup logs now accurately identify whether monitoring is handled by the native stream manager or FFmpeg manager based on configuration.

* **Tests**
  * Added coverage for telemetry endpoint initialization when telemetry is enabled, disabled, or missing metrics.
  * Improved stream lifecycle test cleanup to stop publishing before checking for goroutine leaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->