### PR TITLE
feat(audiocore): adopt go-audio-stream v0.5.0 and surface SourceFiltered

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/mysql v0.44.0
 	github.com/tphakala/go-aac v0.7.0
 	github.com/tphakala/go-audio-resampler v1.7.0
-	github.com/tphakala/go-audio-stream v0.4.0
+	github.com/tphakala/go-audio-stream v0.5.0
 	github.com/tphakala/go-flac v1.1.0
 	github.com/tphakala/go-hls v0.1.0
 	github.com/tphakala/go-m4a v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -286,8 +286,8 @@ github.com/tphakala/go-aac v0.7.0 h1:QuwkvhNXNaAS0CaGgpkrErXV8rmekGTi+nPIFNQZQ5s
 github.com/tphakala/go-aac v0.7.0/go.mod h1:zbnhFT1TNtHgFjbtJnW32vCi9yyaSC9tdhqyjAiti1c=
 github.com/tphakala/go-audio-resampler v1.7.0 h1:Nqr1zNRlow28EjlQKS/SSmhqSa6qHRZRydrPXNkiKTo=
 github.com/tphakala/go-audio-resampler v1.7.0/go.mod h1:h/j0tsie+Jv7qVEytRZ4KrxfO//zxO3RAbesX+1ZEo4=
-github.com/tphakala/go-audio-stream v0.4.0 h1:ojcJAwB+r8BQOGpQtQYTqgHcQpgGhosQFmiCv2gtvuI=
-github.com/tphakala/go-audio-stream v0.4.0/go.mod h1:W9be1o1XSqEkSAG81yHOV6+G9odYbpWJlmL5DBEhfgM=
+github.com/tphakala/go-audio-stream v0.5.0 h1:YGOKF/2A445Z+Zmzg67Er8/IhrGefjelDB1z1BCUmgc=
+github.com/tphakala/go-audio-stream v0.5.0/go.mod h1:W9be1o1XSqEkSAG81yHOV6+G9odYbpWJlmL5DBEhfgM=
 github.com/tphakala/go-flac v1.1.0 h1:dyVNPFW+MVLzPvw1n3dEvBHPtKUMbQ5PHWvW/pxQMv0=
 github.com/tphakala/go-flac v1.1.0/go.mod h1:9MM9hnsIryw1BbD/e3iZgKMx3s34VCMlxzhSIP8gpEA=
 github.com/tphakala/go-hls v0.1.0 h1:bLJMJYV1b4FGXsjkQXdtsU9CWHEjdaON5dGLZeqWebc=

--- a/internal/api/v2/audio/streams_health.go
+++ b/internal/api/v2/audio/streams_health.go
@@ -80,6 +80,7 @@ type StreamHealthResponse struct {
 	Duplicates            uint64    `json:"duplicates,omitempty"`               // Duplicate/reordered packets (native)
 	Malformed             uint64    `json:"malformed,omitempty"`                // Discarded unparseable packets (native)
 	SSRCResets            uint64    `json:"ssrc_resets,omitempty"`              // Mid-stream SSRC changes tolerated (native)
+	SourceFiltered        uint64    `json:"source_filtered,omitempty"`          // Datagrams dropped: source != peer/allowlist (native, UDP only)
 	LastFrameAt           time.Time `json:"last_frame_at,omitzero"`             // Wall-clock of most recent media frame (native)
 	SenderClockValid      bool      `json:"sender_clock_valid,omitempty"`       // RTCP sender-report clock present (native)
 	SenderClockAgeSeconds float64   `json:"sender_clock_age_seconds,omitempty"` // Age of the RTCP sender report (native)
@@ -424,6 +425,7 @@ func convertStreamHealthToResponse(rawURL string, health *audiocore.StreamHealth
 		Duplicates:            health.Duplicates,
 		Malformed:             health.Malformed,
 		SSRCResets:            health.SSRCResets,
+		SourceFiltered:        health.SourceFiltered,
 		LastFrameAt:           health.LastFrameAt,
 		SenderClockValid:      health.SenderClockValid,
 		SenderClockAgeSeconds: health.SenderClockAge.Seconds(),

--- a/internal/api/v2/audio/streams_health_golden_test.go
+++ b/internal/api/v2/audio/streams_health_golden_test.go
@@ -132,6 +132,35 @@ func TestConvertStreamHealthToResponse_RealFFmpegGetHealth(t *testing.T) {
 	assert.Equal(t, baseMap, realMap, "engine and transport must be the only additions vs the pre-seam JSON")
 }
 
+// TestConvertStreamHealthToResponse_NativeCounters verifies the native RTP
+// observability counters, including SourceFiltered (added with the go-audio-stream
+// v0.5.0 bump), surface through the health response. They are omitempty, so only
+// the nonzero ones serialize and a clean stream adds no key.
+func TestConvertStreamHealthToResponse_NativeCounters(t *testing.T) {
+	t.Parallel()
+
+	const url = "rtsp://camera.local:554/stream"
+
+	health := &audiocore.StreamHealth{
+		State:          audiocore.StreamStateConnected,
+		Engine:         audiocore.EngineNative,
+		Packets:        1000,
+		SeqGaps:        3,
+		Malformed:      2,
+		SSRCResets:     1,
+		SourceFiltered: 42,
+	}
+	response := convertStreamHealthToResponse(url, health)
+	assert.Equal(t, uint64(42), response.SourceFiltered, "source-filtered count must map onto the response")
+
+	m := toJSONMap(t, response)
+	assert.EqualValues(t, 42, m["source_filtered"], "source_filtered must serialize when nonzero")
+
+	// Zero stays omitted (omitempty), so a stream with no filtered datagrams adds no key.
+	zero := &audiocore.StreamHealth{State: audiocore.StreamStateConnected, Engine: audiocore.EngineNative}
+	assert.NotContains(t, toJSONMap(t, convertStreamHealthToResponse(url, zero)), "source_filtered", "source_filtered omitted when zero")
+}
+
 // toJSONMap marshals v and unmarshals it into a generic map so two responses can
 // be diffed by key set.
 func toJSONMap(t *testing.T, v any) map[string]any {

--- a/internal/api/v2/audio/streams_health_golden_test.go
+++ b/internal/api/v2/audio/streams_health_golden_test.go
@@ -139,22 +139,29 @@ func TestConvertStreamHealthToResponse_RealFFmpegGetHealth(t *testing.T) {
 func TestConvertStreamHealthToResponse_NativeCounters(t *testing.T) {
 	t.Parallel()
 
-	const url = "rtsp://camera.local:554/stream"
+	const (
+		url                       = "rtsp://camera.local:554/stream"
+		wantPackets        uint64 = 1000
+		wantSeqGaps        uint64 = 3
+		wantMalformed      uint64 = 2
+		wantSSRCResets     uint64 = 1
+		wantSourceFiltered uint64 = 42
+	)
 
 	health := &audiocore.StreamHealth{
 		State:          audiocore.StreamStateConnected,
 		Engine:         audiocore.EngineNative,
-		Packets:        1000,
-		SeqGaps:        3,
-		Malformed:      2,
-		SSRCResets:     1,
-		SourceFiltered: 42,
+		Packets:        wantPackets,
+		SeqGaps:        wantSeqGaps,
+		Malformed:      wantMalformed,
+		SSRCResets:     wantSSRCResets,
+		SourceFiltered: wantSourceFiltered,
 	}
 	response := convertStreamHealthToResponse(url, health)
-	assert.Equal(t, uint64(42), response.SourceFiltered, "source-filtered count must map onto the response")
+	assert.Equal(t, wantSourceFiltered, response.SourceFiltered, "source-filtered count must map onto the response")
 
 	m := toJSONMap(t, response)
-	assert.EqualValues(t, 42, m["source_filtered"], "source_filtered must serialize when nonzero")
+	assert.EqualValues(t, wantSourceFiltered, m["source_filtered"], "source_filtered must serialize when nonzero")
 
 	// Zero stays omitted (omitempty), so a stream with no filtered datagrams adds no key.
 	zero := &audiocore.StreamHealth{State: audiocore.StreamStateConnected, Engine: audiocore.EngineNative}

--- a/internal/api/v2/system/diagnostics.go
+++ b/internal/api/v2/system/diagnostics.go
@@ -452,6 +452,7 @@ func (c *Handler) buildStreamHealthProvider() func() []checks.StreamHealthInfo {
 				Duplicates:         sh.Duplicates,
 				Malformed:          sh.Malformed,
 				SSRCResets:         sh.SSRCResets,
+				SourceFiltered:     sh.SourceFiltered,
 			})
 		}
 		return infos

--- a/internal/audiocore/ffmpeg/analyze.go
+++ b/internal/audiocore/ffmpeg/analyze.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/privacy"
 )
@@ -135,7 +136,7 @@ func buildAnalysisArgs(url string, ffmpegMajor int, audioOnly bool) []string {
 		// Restrict the RTSP handshake to audio tracks; -vn below only drops video
 		// after decode, so without this the camera's video track is still SETUP
 		// (issue #3798). audioOnly is false on the full-stream fallback (#3902).
-		args = appendRTSPMediaArgs(args, "tcp", audioOnly)
+		args = appendRTSPMediaArgs(args, conf.DefaultTransport, audioOnly)
 		timeoutFlag = rtspTimeoutParamForMajor(ffmpegMajor)
 	}
 

--- a/internal/audiocore/ffmpeg/probe.go
+++ b/internal/audiocore/ffmpeg/probe.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/privacy"
 )
@@ -163,7 +164,7 @@ func buildProbeArgs(url string, audioOnly bool) []string {
 	// handshake to audio tracks so ffprobe never SETUPs the camera's video track
 	// (issue #3798); -select_streams below only filters ffprobe's output.
 	if isRTSPURL(url) {
-		args = appendRTSPMediaArgs(args, "tcp", audioOnly)
+		args = appendRTSPMediaArgs(args, conf.DefaultTransport, audioOnly)
 	}
 
 	args = append(args,

--- a/internal/audiocore/stream/health.go
+++ b/internal/audiocore/stream/health.go
@@ -84,11 +84,17 @@ func aggregateTrackStats(stats audiostream.Stats) trackAggregate {
 		if t.SenderClock.Valid && t.SenderClock.ReceivedAt.After(newestSR) {
 			newestSR = t.SenderClock.ReceivedAt
 			agg.senderClockValid = true
-			if !stats.CapturedAt.IsZero() {
-				if age := stats.CapturedAt.Sub(t.SenderClock.ReceivedAt); age > 0 {
-					agg.senderClockAge = age
-				}
-			}
+		}
+	}
+	// Measure the age of the selected (newest valid) report once, after the loop,
+	// so it always tracks the winning report. Computing it per-candidate could
+	// leave a stale age from an earlier report when a newer one is selected but
+	// its age is not computable. A zero capture time carries no usable delta, and
+	// a report timestamped after the capture (clock skew) yields no positive age;
+	// both leave senderClockAge at zero.
+	if agg.senderClockValid && !stats.CapturedAt.IsZero() {
+		if age := stats.CapturedAt.Sub(newestSR); age > 0 {
+			agg.senderClockAge = age
 		}
 	}
 	return agg

--- a/internal/audiocore/stream/health.go
+++ b/internal/audiocore/stream/health.go
@@ -49,13 +49,14 @@ const (
 // trackAggregate is the per-session RTP stats summed across the live tracks for
 // the observability snapshot.
 type trackAggregate struct {
-	packets    uint64
-	seqGaps    uint64
-	duplicates uint64
-	malformed  uint64
-	ssrcResets uint64
-	wire       uint64
-	payload    uint64
+	packets        uint64
+	seqGaps        uint64
+	duplicates     uint64
+	malformed      uint64
+	ssrcResets     uint64
+	sourceFiltered uint64
+	wire           uint64
+	payload        uint64
 
 	lastFrameAt      time.Time
 	senderClockValid bool
@@ -74,6 +75,7 @@ func aggregateTrackStats(stats audiostream.Stats) trackAggregate {
 		agg.duplicates += t.Duplicates
 		agg.malformed += t.Malformed
 		agg.ssrcResets += t.SSRCResets
+		agg.sourceFiltered += t.SourceFiltered
 		agg.wire += t.WireBytes
 		agg.payload += t.PayloadBytes
 		if t.LastFrameAt.After(agg.lastFrameAt) {

--- a/internal/audiocore/stream/health_test.go
+++ b/internal/audiocore/stream/health_test.go
@@ -190,58 +190,63 @@ func TestAggregateTrackStats(t *testing.T) {
 	assert.Equal(t, 4*time.Second, agg.senderClockAge, "sender clock age measured from the newest report against CapturedAt")
 }
 
-// TestAggregateTrackStats_SenderClockGuards exercises the two reject branches of
-// the sender-clock age calculation: a report newer than the capture time (the
-// age>0 guard) and a zero capture time (the !CapturedAt.IsZero() guard). Both must
-// mark the clock valid yet leave the age at zero rather than producing a negative
-// or nonsensical value.
+// TestAggregateTrackStats_SenderClockGuards exercises the guard branches of the
+// sender-clock age calculation: a report newer than the capture time (the age>0
+// guard), a zero capture time (the !CapturedAt.IsZero() guard), and a newer valid
+// report that wins the clock while carrying a non-positive age (which must not
+// retain an earlier report's age). Every case must mark the clock valid yet leave
+// the age at zero rather than producing a negative or stale value.
 func TestAggregateTrackStats_SenderClockGuards(t *testing.T) {
 	t.Parallel()
 
 	base := time.Now()
+	const (
+		shortOffset   = 2 * time.Second
+		captureOffset = 10 * time.Second
+		// newerOffset lands after the capture (derived from it), so its report is the
+		// newest yet carries a non-positive age against the capture time.
+		newerOffset = captureOffset + shortOffset
+	)
 
-	t.Run("report newer than capture yields no age", func(t *testing.T) {
-		t.Parallel()
-		stats := audiostream.Stats{
-			CapturedAt: base,
-			Tracks: map[int]audiostream.TrackStats{
-				0: {SenderClock: audiostream.SenderClock{Valid: true, ReceivedAt: base.Add(2 * time.Second)}},
+	tests := []struct {
+		name       string
+		capturedAt time.Time
+		tracks     map[int]audiostream.TrackStats
+	}{
+		{
+			name:       "report newer than capture yields no age",
+			capturedAt: base,
+			tracks: map[int]audiostream.TrackStats{
+				0: {SenderClock: audiostream.SenderClock{Valid: true, ReceivedAt: base.Add(shortOffset)}},
 			},
-		}
-		agg := aggregateTrackStats(stats)
-		assert.True(t, agg.senderClockValid, "a valid report still marks the clock valid")
-		assert.Zero(t, agg.senderClockAge, "a report newer than the capture time yields no positive age")
-	})
-
-	t.Run("zero capture time yields no age", func(t *testing.T) {
-		t.Parallel()
-		stats := audiostream.Stats{
-			Tracks: map[int]audiostream.TrackStats{
+		},
+		{
+			name:       "zero capture time yields no age",
+			capturedAt: time.Time{},
+			tracks: map[int]audiostream.TrackStats{
 				0: {SenderClock: audiostream.SenderClock{Valid: true, ReceivedAt: base}},
 			},
-		}
-		agg := aggregateTrackStats(stats)
-		assert.True(t, agg.senderClockValid, "a valid report still marks the clock valid")
-		assert.Zero(t, agg.senderClockAge, "a zero capture time yields no measurable age")
-	})
-
-	t.Run("newer selected report with no positive age does not retain an older age", func(t *testing.T) {
-		t.Parallel()
-		// An older valid report (2s before capture, age 8s) precedes a NEWER valid
-		// report received after capture (clock skew). The newest report wins the
-		// clock, but its age is not positive, so the aggregate age must be zero
-		// rather than falling back to the older report's 8s. This is order-independent
-		// only because the age is computed once, against the winning report, after
-		// the loop.
-		stats := audiostream.Stats{
-			CapturedAt: base.Add(10 * time.Second),
-			Tracks: map[int]audiostream.TrackStats{
-				0: {SenderClock: audiostream.SenderClock{Valid: true, ReceivedAt: base.Add(2 * time.Second)}},
-				1: {SenderClock: audiostream.SenderClock{Valid: true, ReceivedAt: base.Add(12 * time.Second)}},
+		},
+		{
+			// The older valid report (before capture) is selected first; the newer
+			// valid report then wins newestSR but sits after the capture. Computing the
+			// age once after the loop keeps it at zero rather than the older report's
+			// positive age, so the result does not depend on map iteration order.
+			name:       "newer selected report with no positive age does not retain an older age",
+			capturedAt: base.Add(captureOffset),
+			tracks: map[int]audiostream.TrackStats{
+				0: {SenderClock: audiostream.SenderClock{Valid: true, ReceivedAt: base.Add(shortOffset)}},
+				1: {SenderClock: audiostream.SenderClock{Valid: true, ReceivedAt: base.Add(newerOffset)}},
 			},
-		}
-		agg := aggregateTrackStats(stats)
-		assert.True(t, agg.senderClockValid, "a valid report still marks the clock valid")
-		assert.Zero(t, agg.senderClockAge, "the newest report's non-positive age must not fall back to an older report's age")
-	})
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			agg := aggregateTrackStats(audiostream.Stats{CapturedAt: tt.capturedAt, Tracks: tt.tracks})
+			assert.True(t, agg.senderClockValid, "a valid report still marks the clock valid")
+			assert.Zero(t, agg.senderClockAge, "a guard case must leave the age at zero, not stale or negative")
+		})
+	}
 }

--- a/internal/audiocore/stream/health_test.go
+++ b/internal/audiocore/stream/health_test.go
@@ -224,4 +224,24 @@ func TestAggregateTrackStats_SenderClockGuards(t *testing.T) {
 		assert.True(t, agg.senderClockValid, "a valid report still marks the clock valid")
 		assert.Zero(t, agg.senderClockAge, "a zero capture time yields no measurable age")
 	})
+
+	t.Run("newer selected report with no positive age does not retain an older age", func(t *testing.T) {
+		t.Parallel()
+		// An older valid report (2s before capture, age 8s) precedes a NEWER valid
+		// report received after capture (clock skew). The newest report wins the
+		// clock, but its age is not positive, so the aggregate age must be zero
+		// rather than falling back to the older report's 8s. This is order-independent
+		// only because the age is computed once, against the winning report, after
+		// the loop.
+		stats := audiostream.Stats{
+			CapturedAt: base.Add(10 * time.Second),
+			Tracks: map[int]audiostream.TrackStats{
+				0: {SenderClock: audiostream.SenderClock{Valid: true, ReceivedAt: base.Add(2 * time.Second)}},
+				1: {SenderClock: audiostream.SenderClock{Valid: true, ReceivedAt: base.Add(12 * time.Second)}},
+			},
+		}
+		agg := aggregateTrackStats(stats)
+		assert.True(t, agg.senderClockValid, "a valid report still marks the clock valid")
+		assert.Zero(t, agg.senderClockAge, "the newest report's non-positive age must not fall back to an older report's age")
+	})
 }

--- a/internal/audiocore/stream/health_test.go
+++ b/internal/audiocore/stream/health_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -128,4 +129,99 @@ func TestClassifyConnClosed(t *testing.T) {
 	assert.Equal(t, errTypeConnectionReset, classifyConnClosed(fmt.Errorf("peer went away")), "non-dial close is a reset")
 	readErr := &net.OpError{Op: "read", Err: fmt.Errorf("reset by peer")}
 	assert.Equal(t, errTypeConnectionReset, classifyConnClosed(readErr), "read OpError is a reset")
+}
+
+// TestAggregateTrackStats verifies that the per-track go-audio-stream counters
+// are summed across the live tracks, that SourceFiltered (added with the v0.5.0
+// bump) is aggregated like its siblings, and that the newest valid RTCP Sender
+// Report wins for the SenderClock age.
+func TestAggregateTrackStats(t *testing.T) {
+	t.Parallel()
+
+	base := time.Now()
+	stats := audiostream.Stats{
+		CapturedAt: base.Add(10 * time.Second),
+		Tracks: map[int]audiostream.TrackStats{
+			0: {
+				Packets:        100,
+				PayloadBytes:   4000,
+				WireBytes:      5000,
+				SeqGaps:        2,
+				Duplicates:     1,
+				Malformed:      3,
+				SSRCResets:     1,
+				SourceFiltered: 7,
+				LastFrameAt:    base.Add(5 * time.Second),
+				SenderClock:    audiostream.SenderClock{Valid: true, ReceivedAt: base.Add(2 * time.Second)},
+			},
+			1: {
+				Packets:        50,
+				PayloadBytes:   2000,
+				WireBytes:      2500,
+				SeqGaps:        4,
+				Duplicates:     0,
+				Malformed:      1,
+				SSRCResets:     2,
+				SourceFiltered: 11,
+				LastFrameAt:    base.Add(8 * time.Second),
+				SenderClock:    audiostream.SenderClock{Valid: true, ReceivedAt: base.Add(6 * time.Second)},
+			},
+			2: {
+				// A newer but INVALID sender report must not win: the .Valid guard
+				// keeps the newest VALID report (track 1) as the clock source, so
+				// senderClockAge stays 4s rather than following this 9s report.
+				SenderClock: audiostream.SenderClock{Valid: false, ReceivedAt: base.Add(9 * time.Second)},
+			},
+		},
+	}
+
+	agg := aggregateTrackStats(stats)
+
+	assert.Equal(t, uint64(150), agg.packets, "packets summed across tracks")
+	assert.Equal(t, uint64(6000), agg.payload, "payload bytes summed across tracks")
+	assert.Equal(t, uint64(7500), agg.wire, "wire bytes summed across tracks")
+	assert.Equal(t, uint64(6), agg.seqGaps, "seq gaps summed across tracks")
+	assert.Equal(t, uint64(1), agg.duplicates, "duplicates summed across tracks")
+	assert.Equal(t, uint64(4), agg.malformed, "malformed summed across tracks")
+	assert.Equal(t, uint64(3), agg.ssrcResets, "ssrc resets summed across tracks")
+	assert.Equal(t, uint64(18), agg.sourceFiltered, "source-filtered datagrams summed across tracks")
+	assert.WithinDuration(t, base.Add(8*time.Second), agg.lastFrameAt, time.Millisecond, "newest frame time wins")
+	assert.True(t, agg.senderClockValid, "sender clock is valid when any track reports one")
+	assert.Equal(t, 4*time.Second, agg.senderClockAge, "sender clock age measured from the newest report against CapturedAt")
+}
+
+// TestAggregateTrackStats_SenderClockGuards exercises the two reject branches of
+// the sender-clock age calculation: a report newer than the capture time (the
+// age>0 guard) and a zero capture time (the !CapturedAt.IsZero() guard). Both must
+// mark the clock valid yet leave the age at zero rather than producing a negative
+// or nonsensical value.
+func TestAggregateTrackStats_SenderClockGuards(t *testing.T) {
+	t.Parallel()
+
+	base := time.Now()
+
+	t.Run("report newer than capture yields no age", func(t *testing.T) {
+		t.Parallel()
+		stats := audiostream.Stats{
+			CapturedAt: base,
+			Tracks: map[int]audiostream.TrackStats{
+				0: {SenderClock: audiostream.SenderClock{Valid: true, ReceivedAt: base.Add(2 * time.Second)}},
+			},
+		}
+		agg := aggregateTrackStats(stats)
+		assert.True(t, agg.senderClockValid, "a valid report still marks the clock valid")
+		assert.Zero(t, agg.senderClockAge, "a report newer than the capture time yields no positive age")
+	})
+
+	t.Run("zero capture time yields no age", func(t *testing.T) {
+		t.Parallel()
+		stats := audiostream.Stats{
+			Tracks: map[int]audiostream.TrackStats{
+				0: {SenderClock: audiostream.SenderClock{Valid: true, ReceivedAt: base}},
+			},
+		}
+		agg := aggregateTrackStats(stats)
+		assert.True(t, agg.senderClockValid, "a valid report still marks the clock valid")
+		assert.Zero(t, agg.senderClockAge, "a zero capture time yields no measurable age")
+	})
 }

--- a/internal/audiocore/stream/open_rtsp.go
+++ b/internal/audiocore/stream/open_rtsp.go
@@ -179,7 +179,7 @@ func supportedCodec(c audiostream.Codec) bool {
 // mapTransport maps the spec transport onto the library preference: udp prefers
 // UDP with TCP fallback, everything else uses TCP interleaved.
 func mapTransport(t string) rtsp.TransportPreference {
-	if strings.EqualFold(strings.TrimSpace(t), "udp") {
+	if strings.EqualFold(strings.TrimSpace(t), conf.TransportUDP) {
 		return rtsp.PreferUDPThenTCP
 	}
 	return rtsp.PreferTCP

--- a/internal/audiocore/stream/stream.go
+++ b/internal/audiocore/stream/stream.go
@@ -351,6 +351,7 @@ func (s *stream) snapshot() *audiocore.StreamHealth {
 		Duplicates:            agg.duplicates,
 		Malformed:             agg.malformed,
 		SSRCResets:            agg.ssrcResets,
+		SourceFiltered:        agg.sourceFiltered,
 		LastFrameAt:           agg.lastFrameAt,
 		SenderClockValid:      agg.senderClockValid,
 		SenderClockAge:        agg.senderClockAge,

--- a/internal/audiocore/stream_health.go
+++ b/internal/audiocore/stream_health.go
@@ -362,6 +362,11 @@ type StreamHealth struct {
 	Duplicates uint64
 	Malformed  uint64
 	SSRCResets uint64
+	// SourceFiltered counts datagrams dropped because their source address did
+	// not match the negotiated media peer (RTSP over UDP) or the configured
+	// SourceIP allowlist (udpsource). It stays zero on TCP-interleaved transport
+	// and for the FFmpeg producer.
+	SourceFiltered uint64
 
 	// LastFrameAt is the wall-clock arrival of the most recent media frame.
 	LastFrameAt time.Time

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -567,8 +567,16 @@ const (
 	StreamTypeUDP  = "udp"  // UDP/RTP - Low-latency LAN
 )
 
+// Transport protocol identifiers for RTSP/RTMP streams.
+const (
+	// TransportTCP is the TCP interleaved RTP transport.
+	TransportTCP = "tcp"
+	// TransportUDP is the UDP RTP transport.
+	TransportUDP = "udp"
+)
+
 // DefaultTransport is the default RTSP/RTMP transport protocol
-const DefaultTransport = "tcp"
+const DefaultTransport = TransportTCP
 
 // ChannelMode controls how multi-channel audio is handled before analysis.
 type ChannelMode string

--- a/internal/conf/migrations.go
+++ b/internal/conf/migrations.go
@@ -270,11 +270,8 @@ func (s *Settings) MigrateRTSPConfig() bool {
 		return false
 	}
 
-	// Get global transport, default to tcp
-	globalTransport := rtsp.Transport
-	if globalTransport == "" {
-		globalTransport = DefaultTransport
-	}
+	// Get global transport via the single resolution owner (global else default).
+	globalTransport := rtsp.ResolveTransport("")
 
 	// Preallocate streams slice with capacity and track seen URLs for deduplication
 	rtsp.Streams = make([]StreamConfig, 0, len(rtsp.URLs))

--- a/internal/conf/validate_audio.go
+++ b/internal/conf/validate_audio.go
@@ -154,7 +154,7 @@ func (s *StreamConfig) Validate() error {
 	}
 
 	// Validate transport (only tcp/udp allowed, empty defaults to tcp)
-	if s.Transport != "" && s.Transport != "tcp" && s.Transport != "udp" {
+	if s.Transport != "" && s.Transport != TransportTCP && s.Transport != TransportUDP {
 		return fmt.Errorf("invalid transport '%s' for '%s': must be tcp or udp", s.Transport, s.Name)
 	}
 
@@ -292,10 +292,10 @@ func (r *RTSPSettings) ResolveTransport(perStreamTransport string) string {
 // directly without specifying per-stream transport; the global RTSPSettings.Transport
 // (defaulting to "tcp") is propagated to each applicable stream.
 func (r *RTSPSettings) ApplyStreamDefaults() {
-	globalTransport := r.Transport
-	if globalTransport == "" {
-		globalTransport = DefaultTransport
-	}
+	// ResolveTransport("") yields the global transport when set, else the default.
+	// Resolve once (it is loop-invariant) and propagate to each per-stream empty,
+	// matching MigrateRTSPConfig and the single owner of the rule.
+	globalTransport := r.ResolveTransport("")
 	for _, stream := range r.AllStreams() {
 		if stream.Transport == "" && (stream.Type == StreamTypeRTSP || stream.Type == StreamTypeRTMP) {
 			stream.Transport = globalTransport

--- a/internal/health/checks/streams.go
+++ b/internal/health/checks/streams.go
@@ -34,6 +34,10 @@ type StreamHealthInfo struct {
 	Duplicates uint64
 	Malformed  uint64
 	SSRCResets uint64
+	// SourceFiltered counts datagrams dropped because their source did not match
+	// the negotiated media peer or configured allowlist (native UDP only; zero
+	// on TCP-interleaved transport and for FFmpeg).
+	SourceFiltered uint64
 }
 
 // StreamConnectivityCheck verifies that all configured RTSP streams are reachable and healthy.


### PR DESCRIPTION
## Summary

Adopts go-audio-stream v0.5.0 and closes a few native-ingest gaps in one pass.

The v0.5.0 bump adds MP3/MPA over RTSP/RTP (RFC 2250) SDP mapping upstream. The native stream adapter already carries a full MP3 decode path (go-mp3), so an RTSP stream that advertises an MP3 audio track now negotiates as CodecMP3 and decodes natively instead of being rejected as an unsupported codec. Native ingest stays opt-in behind `BIRDNET_STREAM_INGEST=native`; FFmpeg remains the default.

The release also adds a `TrackStats.SourceFiltered` counter: datagrams dropped because their source did not match the negotiated media peer, or a configured SourceIP allowlist. This wires that counter through the same additive, native-only path as the existing Packets/SeqGaps/Duplicates/Malformed/SSRCResets counters. It is summed in `aggregateTrackStats`, carried on `StreamHealth`, and exposed on the v2 health API (`source_filtered`, omitempty) and the diagnostics stream-health info. It stays zero on TCP-interleaved transport and for the FFmpeg producer, so the default health JSON is byte-identical and the golden byte-identity test is unchanged.

Finally, some tech-debt cleanup around RTSP transport strings: new `conf.TransportTCP` and `conf.TransportUDP` constants replace the scattered `"tcp"`/`"udp"` literals, and the duplicated empty-to-default idiom in `ApplyStreamDefaults` and `MigrateRTSPConfig` now routes through the single owner, `RTSPSettings.ResolveTransport`. No behavior change; the constants hold the same values.

## Behavior note

On the opt-in native engine, a camera that advertises multiple audio tracks with an MP3 track listed before an AAC/Opus track will now select the MP3 track (previously the MP3 track was unsupported and skipped, so a later AAC/Opus track was chosen). Both tracks carry the same acoustic content, so detection is unaffected, and the single-audio-track case is a pure fix. Track selection remains first-supported-wins; a codec preference order could be a follow-up if desired.

## Testing

- `go build ./...`, `golangci-lint run` (0 issues), `go test -race` on the touched packages.
- New tests: SourceFiltered aggregation and health-API serialization (including the omitempty zero case), plus the sender-clock aggregation guards.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stream health reporting now includes datagrams rejected due to source or allowlist mismatches.
  * The counter is available in stream health API responses and diagnostics for native UDP streams.

* **Improvements**
  * RTSP analysis and probing now honor the configured default transport.
  * Transport handling is more consistent across stream and RTSP configuration.
  * Sender-clock age reporting is more accurate when newer reports are received.

* **Tests**
  * Added coverage for source-filtered packet counts and stream health aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->