### PR TITLE
fix(classifier): force FP32 for BirdNET v3.0 on OpenVINO to stop non-finite scores

### DIFF
--- a/internal/classifier/birdnet_v3_onnx.go
+++ b/internal/classifier/birdnet_v3_onnx.go
@@ -27,9 +27,10 @@ type BirdNETV3 struct {
 	// CPU EP. Set once at construction; reported via RuntimeInfo().
 	device string
 	// backend is the live execution backend (BackendOpenVINO on the OV path, else
-	// BackendONNX), and precision is the effective runtime precision (FP16 on the OV
-	// path; the weight precision detected from the model filename on the ORT path).
-	// Both set once at construction; reported via RuntimeInfo().
+	// BackendONNX), and precision is the effective runtime precision (FP32 on the OV
+	// path, forced by openVINOPrecisionFor to avoid the f16 numeric instability in
+	// BIRDNET-GO-2H6; the weight precision detected from the model filename on the ORT
+	// path). Both set once at construction; reported via RuntimeInfo().
 	backend   string
 	precision string
 	// modelPath is the model file this instance actually loaded from (the resolved
@@ -102,12 +103,12 @@ func NewBirdNETV3(cfg *BirdNETV3Config) (*BirdNETV3, error) {
 	// tryBirdNETV3OpenVINO logs and swallows OV errors and returns ok=false. device
 	// records the compute device actually bound to (the OpenVINO device on the OV
 	// path, else the ONNX Runtime CPU EP).
-	classifier, device, ok := tryBirdNETV3OpenVINO(cfg, labels)
-	// The v3.0 OpenVINO path uses the backend default precision (f16 on every
-	// device; openVINOPrecisionFor returns "" for v3.0). The ORT path overrides both
-	// below.
+	classifier, device, precision, ok := tryBirdNETV3OpenVINO(cfg, labels)
+	// The OpenVINO path reports the precision it actually compiled at: FP32 for v3.0,
+	// which openVINOPrecisionFor forces on every device to avoid the f16 numeric
+	// instability (see BIRDNET-GO-2H6). The ORT fallback overrides backend, device,
+	// and precision below.
 	backend := BackendOpenVINO
-	precision := string(QuantizationFP16)
 	if !ok {
 		// Create the ONNX Runtime classifier (the runtime was initialized above).
 		var cerr error
@@ -152,13 +153,14 @@ func NewBirdNETV3(cfg *BirdNETV3Config) (*BirdNETV3, error) {
 }
 
 // tryBirdNETV3OpenVINO attempts to build an OpenVINO classifier for BirdNET v3.0.
-// It returns (classifier, device, true) on success or (nil, "", false) to fall
-// back to ORT, where device is the concrete OpenVINO device the classifier bound
-// to (inference.OVDeviceCPU/OVDeviceGPU). Any failure (gate denied,
-// init/compile/validation error) is logged and swallowed: OpenVINO must never make
-// BirdNET v3.0 fail to load. Unlike Perch there is no model-variant filename gate:
-// the v3.0 GPU-native model has no STFT op, so it compiles on OpenVINO directly.
-func tryBirdNETV3OpenVINO(cfg *BirdNETV3Config, labels []string) (inference.Classifier, string, bool) {
+// It returns (classifier, device, precision, true) on success or
+// (nil, "", "", false) to fall back to ORT, where device is the concrete OpenVINO
+// device the classifier bound to (inference.OVDeviceCPU/OVDeviceGPU) and precision is
+// the effective runtime precision label (FP16/FP32) for the compiled hint. Any failure
+// (gate denied, init/compile/validation error) is logged and swallowed: OpenVINO must
+// never make BirdNET v3.0 fail to load. Unlike Perch there is no model-variant filename
+// gate: the v3.0 GPU-native model has no STFT op, so it compiles on OpenVINO directly.
+func tryBirdNETV3OpenVINO(cfg *BirdNETV3Config, labels []string) (classifier inference.Classifier, device, precision string, ok bool) {
 	// openVINOPlanFor gates on the build tag, backend preference, and device
 	// availability without needing the output port, so run it first; only read the
 	// model metadata to resolve the predictions port once OpenVINO is actually in
@@ -167,7 +169,7 @@ func tryBirdNETV3OpenVINO(cfg *BirdNETV3Config, labels []string) (inference.Clas
 	plan, ok, reason := openVINOPlanFor(cfg.Backend, cfg.OpenVINODevice, RegistryIDBirdNETV3, cfg.OpenVINOPath, 0)
 	if !ok {
 		logOpenVINODeclined(RegistryIDBirdNETV3, cfg.Backend, reason)
-		return nil, "", false
+		return nil, "", "", false
 	}
 
 	log := GetLogger()
@@ -182,7 +184,7 @@ func tryBirdNETV3OpenVINO(cfg *BirdNETV3Config, labels []string) (inference.Clas
 		log.Warn("BirdNET v3.0 OpenVINO predictions-output detection failed; using ONNX Runtime",
 			logger.String("model_path", cfg.ModelPath),
 			logger.Error(err))
-		return nil, "", false
+		return nil, "", "", false
 	}
 	plan.outputIndex = outIdx
 
@@ -191,22 +193,22 @@ func tryBirdNETV3OpenVINO(cfg *BirdNETV3Config, labels []string) (inference.Clas
 	// here to cover it. A load failure means no usable OpenVINO; fall back to ORT.
 	if err := inference.InitOpenVINO(cfg.OpenVINOPath); err != nil {
 		log.Warn("BirdNET v3.0 OpenVINO init failed; using ONNX Runtime", logger.Error(err))
-		return nil, "", false
+		return nil, "", "", false
 	}
 
 	start := time.Now()
-	classifier, err := inference.NewOpenVINOClassifier(cfg.ModelPath, inference.OpenVINOClassifierOptions{
+	classifier, err = inference.NewOpenVINOClassifier(cfg.ModelPath, inference.OpenVINOClassifierOptions{
 		Labels:        labels,
 		Threads:       cfg.Threads,
 		Device:        plan.device,
 		OutputIndex:   plan.outputIndex,
-		PrecisionHint: plan.precision, // "" => f16 default; v3.0 f16 validated OK
+		PrecisionHint: plan.precision, // openVINOPrecisionFor forces f32 for v3.0 (f16 is numerically broken; see BIRDNET-GO-2H6)
 	})
 	if err != nil {
 		log.Warn("BirdNET v3.0 OpenVINO classifier init failed; using ONNX Runtime",
 			logger.String("device", plan.device),
 			logger.Error(err))
-		return nil, "", false
+		return nil, "", "", false
 	}
 
 	log.Info("BirdNET v3.0 model using OpenVINO backend",
@@ -214,7 +216,7 @@ func tryBirdNETV3OpenVINO(cfg *BirdNETV3Config, labels []string) (inference.Clas
 		logger.String("precision", openVINOPrecisionLabel(plan.precision)),
 		logger.Int("species", classifier.NumSpecies()),
 		logger.String("init_time", time.Since(start).String()))
-	return classifier, plan.device, true
+	return classifier, plan.device, openVINOEffectivePrecision(plan.precision), true
 }
 
 // Predict runs inference on the given audio samples.
@@ -306,9 +308,10 @@ func (b *BirdNETV3) Labels() []string {
 
 // RuntimeInfo returns the device, backend, and effective precision the BirdNET
 // v3.0 classifier bound to at construction: the OpenVINO device on the OV path
-// (else "CPU"); BackendOpenVINO on the OV path (else BackendONNX); FP16 on the OV
-// path or the weight precision detected from the model filename on the ORT path.
-// All three are set once and never mutated, so no lock is needed. Implements
+// (else "CPU"); BackendOpenVINO on the OV path (else BackendONNX); FP32 on the OV
+// path (forced by openVINOPrecisionFor to avoid the f16 numeric instability in
+// BIRDNET-GO-2H6) or the weight precision detected from the model filename on the ORT
+// path. All three are set once and never mutated, so no lock is needed. Implements
 // ModelInstance.
 func (b *BirdNETV3) RuntimeInfo() (device, backend, precision string) {
 	return b.device, b.backend, b.precision

--- a/internal/classifier/birdnet_v3_openvino_functional_test.go
+++ b/internal/classifier/birdnet_v3_openvino_functional_test.go
@@ -53,7 +53,14 @@ func TestBirdNETV3OpenVINO_ForcesF32AndStaysFinite(t *testing.T) {
 	device, backend, precision := model.RuntimeInfo()
 	t.Logf("backend=%s device=%s precision=%s species=%d", backend, device, precision, model.NumSpecies())
 	if backend != BackendOpenVINO {
-		t.Skipf("OpenVINO backend not active on this host (backend=%s); cannot exercise the f16->f32 fix", backend)
+		// A fallback to ORT is legitimate when no usable OpenVINO device was requested
+		// or available (amd64 "auto" with no Intel GPU, or a non-A76 ARM CPU), so skip
+		// there. But when OV_V3_DEVICE explicitly named a device, OpenVINO was expected,
+		// so an ORT fallback is a regression in the OV path rather than a silent skip.
+		if dev := os.Getenv("OV_V3_DEVICE"); dev != "" {
+			t.Fatalf("OV_V3_DEVICE=%s requested but BirdNET v3.0 fell back to %s; the OpenVINO path regressed", dev, backend)
+		}
+		t.Skipf("OpenVINO backend not active on this host (backend=%s); set OV_V3_DEVICE to require it", backend)
 	}
 
 	// The fix: v3.0 on OpenVINO must compile at FP32 on every device, so the f16

--- a/internal/classifier/birdnet_v3_openvino_functional_test.go
+++ b/internal/classifier/birdnet_v3_openvino_functional_test.go
@@ -1,0 +1,102 @@
+//go:build openvino
+
+package classifier
+
+import (
+	"encoding/binary"
+	"math"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// TestBirdNETV3OpenVINO_ForcesF32AndStaysFinite drives the real NewBirdNETV3
+// dispatch on the OpenVINO backend and asserts the BIRDNET-GO-2H6 fix end to end:
+// the classifier compiles at FP32 (openVINOPrecisionFor forces it for v3.0 on every
+// device, so RuntimeInfo reports FP32, not the f16 default) and Predict returns only
+// finite, in-range scores. Before the fix the OV path ran at f16, which overflows to
+// NaN on fp16-weight regional tiles and inflates scores ~25-30x on fp32-weight tiles.
+//
+// Hardware/lib/model-gated so normal CI stays green (CI never builds the openvino
+// tag). Skipped unless OV_V3_MODEL and OV_V3_LABELS are set. Env knobs:
+//
+//   - OV_V3_MODEL:   path to a BirdNET v3.0 ONNX tile (fp16 or fp32 weights).
+//   - OV_V3_LABELS:  matching labels file, one "Scientific_Common" per line.
+//   - OV_V3_AUDIO:   optional raw little-endian float32 PCM (32 kHz mono, 5 s =
+//     160000 samples). Zeros if unset, but a real clip exercises realistic activations.
+//   - OV_V3_DEVICE:  "", "cpu", or "gpu" (BirdNET.OpenVINODevice; "" = auto).
+//   - OV_V3_LIB / OV_V3_ORT_LIB: optional libopenvino_c / libonnxruntime paths.
+func TestBirdNETV3OpenVINO_ForcesF32AndStaysFinite(t *testing.T) {
+	modelPath := os.Getenv("OV_V3_MODEL")
+	labelPath := os.Getenv("OV_V3_LABELS")
+	if modelPath == "" || labelPath == "" {
+		t.Skip("set OV_V3_MODEL and OV_V3_LABELS to run the BirdNET v3.0 OpenVINO functional test")
+	}
+
+	cfg := BirdNETV3Config{
+		ModelPath:       modelPath,
+		LabelPath:       labelPath,
+		ONNXRuntimePath: os.Getenv("OV_V3_ORT_LIB"),
+		Threads:         1,
+		Backend:         conf.BackendPrefOpenVINO,
+		OpenVINOPath:    os.Getenv("OV_V3_LIB"),
+		OpenVINODevice:  os.Getenv("OV_V3_DEVICE"),
+	}
+
+	model, err := NewBirdNETV3(&cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, model.Close()) })
+
+	device, backend, precision := model.RuntimeInfo()
+	t.Logf("backend=%s device=%s precision=%s species=%d", backend, device, precision, model.NumSpecies())
+	if backend != BackendOpenVINO {
+		t.Skipf("OpenVINO backend not active on this host (backend=%s); cannot exercise the f16->f32 fix", backend)
+	}
+
+	// The fix: v3.0 on OpenVINO must compile at FP32 on every device, so the f16
+	// overflow/inflation cannot occur. A regression that reverted the forcing would
+	// report FP16 here.
+	require.Equal(t, string(QuantizationFP32), precision,
+		"BirdNET v3.0 on OpenVINO must run at FP32 (openVINOPrecisionFor), not the f16 default; see BIRDNET-GO-2H6")
+
+	samples := readV3AudioOrZeros(t, os.Getenv("OV_V3_AUDIO"))
+	results, err := model.Predict(t.Context(), [][]float32{samples})
+	// Predict itself rejects non-finite scores (firstNonFinite) and the in-graph
+	// sigmoid bounds finite scores to [0,1], so require.NoError here IS the finiteness
+	// guard: at FP32 the window must not fault the way f16 does (BIRDNET-GO-2H6).
+	require.NoError(t, err, "Predict must not return a non-finite-score error at FP32")
+	require.NotEmpty(t, results)
+
+	// Assert the aggregate is a real, non-degenerate probability, so an all-zero or
+	// collapsed output would still fail here rather than pass silently.
+	var maxConf float32
+	for i := range results {
+		if c := results[i].Confidence; c > maxConf {
+			maxConf = c
+		}
+	}
+	require.Positive(t, maxConf, "top confidence must be > 0 (non-degenerate output)")
+	require.LessOrEqual(t, maxConf, float32(1), "post-sigmoid confidence must be <= 1")
+	t.Logf("top confidence=%.4f across %d results", maxConf, len(results))
+}
+
+// readV3AudioOrZeros reads a raw little-endian float32 PCM file, or returns a silent
+// BirdNET-v3.0-sized buffer (32 kHz * 5 s) when no path is given.
+func readV3AudioOrZeros(t *testing.T, path string) []float32 {
+	t.Helper()
+	const birdnetV3Samples = 160000 // 32 kHz * 5 s
+	if path == "" {
+		return make([]float32, birdnetV3Samples)
+	}
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Zero(t, len(data)%4, "audio file must be whole float32 samples")
+	out := make([]float32, len(data)/4)
+	for i := range out {
+		out[i] = math.Float32frombits(binary.LittleEndian.Uint32(data[i*4:]))
+	}
+	return out
+}

--- a/internal/classifier/model_catalog_test.go
+++ b/internal/classifier/model_catalog_test.go
@@ -243,6 +243,25 @@ func TestEmbeddedCatalog_HasFilesWithModelRole(t *testing.T) {
 	}
 }
 
+// TestEmbeddedCatalog_AllEntriesDeclareFiles guards against the class of bug in
+// BIRDNET-GO-2G2, where a released build shipped a birdnet-v3.0 catalog entry that
+// declared neither top-level Files nor Variants, so validateCatalogEntryFiles
+// rejected it and the whole catalog load failed on a user's machine. Every embedded
+// entry must pass the same validation the loader (catalog_loader.go) applies, so a
+// future entry that declares no files/variants, both, or a malformed variant fails
+// here at build time rather than in the field.
+func TestEmbeddedCatalog_AllEntriesDeclareFiles(t *testing.T) {
+	t.Parallel()
+	for i := range EmbeddedCatalog {
+		entry := EmbeddedCatalog[i]
+		t.Run(entry.ID, func(t *testing.T) {
+			t.Parallel()
+			require.NoError(t, validateCatalogEntryFiles(&entry),
+				"embedded catalog entry %q must pass validateCatalogEntryFiles (see BIRDNET-GO-2G2)", entry.ID)
+		})
+	}
+}
+
 func TestEmbeddedCatalog_ValidCategories(t *testing.T) {
 	t.Parallel()
 

--- a/internal/classifier/model_openvino.go
+++ b/internal/classifier/model_openvino.go
@@ -115,13 +115,28 @@ func openVINOPlanFor(backendPref, devicePref, modelID, libraryPath string, outpu
 // on adapters where f16 worked, but stays well within real time. Do NOT relax it
 // to f16 without validating on a discrete Arc part.
 //
-// The bat embedding model is the exception that is forced to f32 on EVERY device:
+// The bat embedding model is forced to f32 on EVERY device:
 // its embedding head overflows at f16 on genuine f16 hardware (the A76 CPU's f16 NEON
 // and the Intel iGPU), corrupting the raw embedding the bat classifier consumes and
 // flipping detections. Unlike BirdNET v2.4 this is not GPU-only. Do NOT relax it to
 // f16 without re-running the bat embedding parity check.
+//
+// BirdNET v3.0 is likewise forced to f32 on EVERY device. Its EfficientNetV2-S
+// backbone is numerically unstable at f16 wherever genuine f16 kernels run (the Intel
+// GPU always, and the A76 CPU's native f16), independent of the model file's weight
+// precision. On fp16-weight regional tiles, f16 execution overflows to NaN (Sentry
+// BIRDNET-GO-2H6: the 800-class north-america-east tile, "non-finite score (index 0
+// of 800)", backend=OpenVINO precision=FP16); the in-graph sigmoid cannot rescue a
+// NaN, so every window is dropped. On fp32-weight tiles f16 stays finite but silently
+// inflates the scores: measured against an f32 reference on identical input, the max
+// post-sigmoid confidence error was ~0.28 on the A76 CPU and ~0.29 on an Iris Xe iGPU
+// (both far past the 0.15 divergence tolerance), with index 0 the worst (~25-30x). f32
+// restores parity (~1e-4). Forced on the CPU too, not GPU-only, because the A76
+// native-f16 path is affected as well. Do NOT relax it to f16 without re-running
+// inference/openvino_parity_functional_test.go on a genuine f16 device (the Intel GPU
+// and the A76 CPU) with an fp16-weight regional tile.
 func openVINOPrecisionFor(modelID, device string) string {
-	if modelID == RegistryIDBat {
+	if modelID == RegistryIDBat || modelID == RegistryIDBirdNETV3 {
 		return inference.OVPrecisionF32
 	}
 	if device == inference.OVDeviceGPU && (modelID == DefaultModelVersion || modelID == RegistryIDPerchV2) {
@@ -261,7 +276,7 @@ func openVINOPrecisionLabel(precision string) string {
 // shared Quantization vocabulary ("FP16"/"FP32"). An empty hint means the backend
 // default, which is f16 (see openVINOPrecisionFor), so it maps to FP16; the
 // explicit override OVPrecisionF32 (BirdNET v2.4 and Perch v2 on the GPU, the bat
-// embedding model on every device) maps to FP32.
+// embedding model and BirdNET v3.0 on every device) maps to FP32.
 func openVINOEffectivePrecision(precisionHint string) string {
 	if precisionHint == inference.OVPrecisionF32 {
 		return string(QuantizationFP32)

--- a/internal/classifier/openvino_precision_test.go
+++ b/internal/classifier/openvino_precision_test.go
@@ -65,6 +65,23 @@ func TestOpenVINOPrecisionFor(t *testing.T) {
 			device:  inference.OVDeviceCPU,
 			want:    inference.OVPrecisionF32,
 		},
+		// BirdNET v3.0 (EfficientNetV2-S) is numerically unstable at f16 wherever
+		// genuine f16 kernels run (the Intel GPU, and the A76 CPU's native f16):
+		// fp16-weight regional tiles overflow to NaN and fp32-weight tiles silently
+		// inflate the scores. Like bat, it must be f32 on BOTH devices, not GPU-only.
+		// See BIRDNET-GO-2H6.
+		{
+			name:    "birdnet v3.0 on GPU is forced to f32",
+			modelID: RegistryIDBirdNETV3,
+			device:  inference.OVDeviceGPU,
+			want:    inference.OVPrecisionF32,
+		},
+		{
+			name:    "birdnet v3.0 on CPU is forced to f32 (A76 native f16 corrupts scores)",
+			modelID: RegistryIDBirdNETV3,
+			device:  inference.OVDeviceCPU,
+			want:    inference.OVPrecisionF32,
+		},
 	}
 
 	for _, tt := range tests {
@@ -78,13 +95,13 @@ func TestOpenVINOPrecisionFor(t *testing.T) {
 // TestOpenVINOEffectivePrecision verifies the mapping from an OpenVINO
 // INFERENCE_PRECISION_HINT to the display precision shown on the inference status
 // card. The empty default hint (f16) maps to FP16, and the explicit override
-// (OVPrecisionF32: BirdNET v2.4 and Perch v2 on the GPU, bat everywhere) maps to
-// FP32. Tag-agnostic
+// (OVPrecisionF32: BirdNET v2.4 and Perch v2 on the GPU, bat and BirdNET v3.0 on
+// every device) maps to FP32. Tag-agnostic
 // like openVINOEffectivePrecision itself, so it runs in the default suite.
 func TestOpenVINOEffectivePrecision(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, string(QuantizationFP16), openVINOEffectivePrecision(""),
 		"empty hint is the backend f16 default, shown as FP16")
 	assert.Equal(t, string(QuantizationFP32), openVINOEffectivePrecision(inference.OVPrecisionF32),
-		"the f32 hint (BirdNET v2.4 and Perch v2 on the GPU) is shown as FP32")
+		"the f32 hint (BirdNET v2.4 and Perch v2 on the GPU, bat and BirdNET v3.0 on every device) is shown as FP32")
 }


### PR DESCRIPTION
## Summary

BirdNET v3.0 ran on the OpenVINO backend at the f16 default precision hint, which is numerically unstable for the v3.0 EfficientNetV2-S model wherever genuine f16 kernels execute (the Intel GPU always, and the Raspberry Pi 5 A76 CPU's native f16). On fp16-weight regional tiles, f16 execution overflows to NaN (Sentry BIRDNET-GO-2H6, "non-finite score (index 0 of 800)"), and the model's in-graph sigmoid cannot rescue a NaN, so every window is dropped and v3.0 produces no detections. On fp32-weight tiles f16 stays finite but silently inflates the scores roughly 25-30x at index 0. The affected model is a developer preview, so the blast radius is preview opt-in users only.

`openVINOPrecisionFor` now forces f32 for v3.0 on every device, matching the existing Bat policy (BirdNET v2.4 and Perch v2 are forced to f32 on the GPU only, but for v3.0 the A76 native-f16 CPU path is affected as well). `tryBirdNETV3OpenVINO` now threads the effective precision out so `RuntimeInfo`, the inference-status card, and Sentry report FP32 instead of the previously hardcoded FP16.

## Validation

Measured with OpenVINO 2026.2.1 on the 800-class North America East tile: f16 vs f32 max post-sigmoid confidence error was 0.29 on an Iris Xe iGPU and 0.28 on a Raspberry Pi 5 A76 CPU, both past the project's 0.15 divergence tolerance, with index 0 the worst (roughly 25-30x); f32 restores parity (about 1e-4). Validated end to end through the real `NewBirdNETV3` dispatch on amd64 and cross-compiled arm64 on the A76: both report precision=FP32 and correct scores.

## Tests

- `TestOpenVINOPrecisionFor`: v3.0 forced to f32 on both CPU and GPU (tag-agnostic, runs in CI).
- `TestEmbeddedCatalog_AllEntriesDeclareFiles`: every embedded catalog entry passes `validateCatalogEntryFiles`, guarding the "declares no files" catalog-load failure class.
- `TestBirdNETV3OpenVINO_ForcesF32AndStaysFinite`: hardware-gated OpenVINO functional test that drives the real dispatch and asserts precision=FP32 and finite scores.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - BirdNET v3 models now use FP32 precision with OpenVINO across supported devices for improved consistency and stability.
  - Runtime information accurately reports effective FP32 precision after successful OpenVINO initialization.
  - OpenVINO initialization failures continue to fall back to ONNX Runtime, preserving classification availability.

- **Reliability**
  - Expanded validation helps ensure bundled model files are complete and compatible.
  - Added coverage to verify stable, finite confidence scores during BirdNET v3 OpenVINO predictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->