### PR TITLE
fix(classifier): stop the model-unload predict storm and BirdNET v3.0 preview follow-ups

### DIFF
--- a/internal/analysis/buffer_manager.go
+++ b/internal/analysis/buffer_manager.go
@@ -30,6 +30,16 @@ type monitorConfig struct {
 	overlapSize int // bytes, scaled from user config, PCM-aligned
 }
 
+// monitorTickState is the per-monitor state threaded across processMonitorTick
+// calls by analysisBufferMonitor. hasReadBuffer flips the "buffer removed" log
+// level once the buffer has been seen at least once; notLoadedWarned is the
+// warn-once latch for the model-not-loaded skip, so a monitor that outlives its
+// model during a reconfigure logs one warning rather than one per window.
+type monitorTickState struct {
+	hasReadBuffer   bool
+	notLoadedWarned bool
+}
+
 // BufferManager handles the lifecycle of analysis buffer monitors
 type BufferManager struct {
 	monitors  sync.Map // keyed by monitorKey -> chan struct{}
@@ -392,7 +402,7 @@ func (m *BufferManager) analysisBufferMonitor(quitChan chan struct{}, cfg *monit
 	const pollInterval = 100 * time.Millisecond
 
 	analysisWindowBytes := cfg.readSize
-	hasReadBuffer := false
+	var state monitorTickState
 	var tickCount int64
 
 	ticker := time.NewTicker(pollInterval)
@@ -404,9 +414,7 @@ func (m *BufferManager) analysisBufferMonitor(quitChan chan struct{}, cfg *monit
 			return
 		case <-ticker.C:
 			tickCount++
-			keepRunning, newHasReadBuffer := m.processMonitorTick(quitChan, cfg, analysisWindowBytes, detectionOffset, hasReadBuffer, tickCount)
-			hasReadBuffer = newHasReadBuffer
-			if !keepRunning {
+			if !m.processMonitorTick(quitChan, cfg, analysisWindowBytes, detectionOffset, &state, tickCount) {
 				return
 			}
 		}
@@ -418,9 +426,10 @@ func (m *BufferManager) analysisBufferMonitor(quitChan chan struct{}, cfg *monit
 // and dispatches it to ProcessData when a full readSize window is present.
 //
 // Returns keepRunning=false when the buffer was not found OR the goroutine was
-// asked to shut down during a backoff. The updated hasReadBuffer flag is
-// propagated back so the caller can toggle its "once seen, log on later loss"
-// log-level preference across ticks.
+// asked to shut down during a backoff. The per-monitor state (see
+// monitorTickState) is updated in place across ticks so the caller can toggle its
+// "once seen, log on later loss" log-level preference and hold the model-not-loaded
+// warn-once latch.
 //
 // The window's backing slice is always returned to its pool via a
 // "defer release()" immediately after Read, so every exit path including the
@@ -430,12 +439,12 @@ func (m *BufferManager) processMonitorTick(
 	cfg *monitorConfig,
 	analysisWindowBytes int,
 	detectionOffset time.Duration,
-	hasReadBuffer bool,
+	state *monitorTickState,
 	tickCount int64,
-) (keepRunning, updatedHasReadBuffer bool) {
+) (keepRunning bool) {
 	ab, err := m.bufferMgr.AnalysisBuffer(cfg.sourceID, cfg.modelID)
 	if err != nil {
-		if hasReadBuffer {
+		if state.hasReadBuffer {
 			m.logger.Info("analysis buffer removed, stopping monitor",
 				logger.String("source_id", cfg.sourceID),
 				logger.String("model_id", cfg.modelID))
@@ -444,9 +453,9 @@ func (m *BufferManager) processMonitorTick(
 				logger.String("source_id", cfg.sourceID),
 				logger.String("model_id", cfg.modelID))
 		}
-		return false, hasReadBuffer
+		return false
 	}
-	hasReadBuffer = true
+	state.hasReadBuffer = true
 
 	data, release, readErr := ab.Read()
 	defer release()
@@ -457,9 +466,9 @@ func (m *BufferManager) processMonitorTick(
 			logger.Error(readErr))
 		select {
 		case <-time.After(1 * time.Second):
-			return true, hasReadBuffer
+			return true
 		case <-quitChan:
-			return false, hasReadBuffer
+			return false
 		}
 	}
 
@@ -471,14 +480,48 @@ func (m *BufferManager) processMonitorTick(
 				logger.Int("data_len", len(data)),
 				logger.Int("expected", analysisWindowBytes))
 		}
-		return true, hasReadBuffer
+		return true
+	}
+
+	// Skip inference when the model is not loaded in the orchestrator. A monitor
+	// can briefly outlive its model's registration: UnloadModel (uninstall,
+	// reinstall, variant switch) removes the model immediately, but monitor
+	// teardown is asynchronous (the topology-reconfigure debounce). Dispatching in
+	// that window would hand the orchestrator a model it no longer has, producing a
+	// stream of "model not loaded" errors (Sentry BIRDNET-GO-2G6 / 1S1). Skip
+	// quietly instead, warning once per monitor so a genuinely stuck reconfigure is
+	// still visible; the window was already read and is released by the defer above.
+	// The monitor keeps running rather than stopping, so a reinstall or variant
+	// switch that re-registers the same registry ID resumes inference immediately,
+	// while UpdateMonitors still removes it if the model is gone for good.
+	if !m.bn.IsModelLoaded(cfg.modelID) {
+		switch {
+		case !state.notLoadedWarned:
+			m.logger.Warn("model not loaded, skipping inference window (a model reconfigure or reinstall may be in progress)",
+				logger.String("source_id", cfg.sourceID),
+				logger.String("model_id", cfg.modelID))
+			state.notLoadedWarned = true
+		case tickCount%bufferMonitorDebugEveryTicks == 0:
+			m.logger.Debug("model still not loaded, skipping inference window",
+				logger.String("source_id", cfg.sourceID),
+				logger.String("model_id", cfg.modelID))
+		}
+		return true
+	}
+	if state.notLoadedWarned {
+		// The model came back (a reinstall or variant switch re-registered the same
+		// registry ID). Resume inference and reset the warn-once latch.
+		m.logger.Info("model loaded again, resuming inference",
+			logger.String("source_id", cfg.sourceID),
+			logger.String("model_id", cfg.modelID))
+		state.notLoadedWarned = false
 	}
 
 	// Skip inference for models that are currently inactive (e.g., bat model
 	// during daytime when nighttime-only scheduling is enabled). The buffered
 	// audio data is released by the existing defer release().
 	if !m.bn.IsModelActive(cfg.modelID) {
-		return true, hasReadBuffer
+		return true
 	}
 
 	m.logger.Debug("buffer monitor dispatching to ProcessData",
@@ -496,7 +539,7 @@ func (m *BufferManager) processMonitorTick(
 			logger.String("model_id", cfg.modelID),
 			logger.Error(processErr))
 	}
-	return true, hasReadBuffer
+	return true
 }
 
 // buildMonitorConfig builds a monitorConfig from a ModelInfo.

--- a/internal/analysis/buffer_manager_test.go
+++ b/internal/analysis/buffer_manager_test.go
@@ -1,14 +1,67 @@
 package analysis
 
 import (
+	"bytes"
+	"io"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/audiocore/buffer"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/logger"
 )
+
+// TestProcessMonitorTick_SkipsWhenModelNotLoaded verifies the monitor-layer guard
+// that stops the "model not loaded" error storm (Sentry BIRDNET-GO-2G6 / 1S1). A
+// monitor whose model was unloaded (or never registered) must skip the inference
+// window with a single warning instead of dispatching to ProcessData, which would
+// log "error processing data" on every window during the reconfigure gap.
+func TestProcessMonitorTick_SkipsWhenModelNotLoaded(t *testing.T) {
+	t.Parallel()
+
+	const (
+		sourceID = "src"
+		modelID  = "Perch_V2"
+		readSize = 480
+	)
+
+	mgr := buffer.NewManager(logger.NewSlogLogger(io.Discard, logger.LogLevelError, time.UTC))
+	require.NoError(t, mgr.AllocateAnalysis(sourceID, modelID, readSize*2, 0, readSize))
+	ab, err := mgr.AnalysisBuffer(sourceID, modelID)
+	require.NoError(t, err)
+	require.NoError(t, ab.Write(make([]byte, readSize)))
+
+	var logBuf bytes.Buffer
+	bm := &BufferManager{
+		bn:        &classifier.Orchestrator{}, // no models loaded, so IsModelLoaded is false
+		bufferMgr: mgr,
+		logger:    logger.NewSlogLogger(&logBuf, logger.LogLevelDebug, time.UTC),
+	}
+
+	cfg := &monitorConfig{sourceID: sourceID, modelID: modelID, readSize: readSize}
+	quit := make(chan struct{})
+	state := &monitorTickState{}
+
+	keepRunning := bm.processMonitorTick(quit, cfg, readSize, 0, state, 1)
+	require.True(t, keepRunning, "the monitor keeps running so a reinstall can resume it")
+	assert.Contains(t, logBuf.String(), "model not loaded, skipping inference window")
+	assert.NotContains(t, logBuf.String(), "error processing data",
+		"a not-loaded model must not reach ProcessData")
+	assert.True(t, state.notLoadedWarned, "the warn-once latch is set after the first skip")
+
+	// A second full window on the next tick must not repeat the warning and must
+	// still never dispatch to ProcessData.
+	require.NoError(t, ab.Write(make([]byte, readSize)))
+	logBuf.Reset()
+	keepRunning = bm.processMonitorTick(quit, cfg, readSize, 0, state, 2)
+	require.True(t, keepRunning)
+	assert.NotContains(t, logBuf.String(), "error processing data")
+	assert.NotContains(t, logBuf.String(), "model not loaded, skipping inference window",
+		"the warning is emitted once per monitor, not on every tick")
+}
 
 func TestMonitorConfig_ReadSize(t *testing.T) {
 	t.Parallel()

--- a/internal/classifier/bat_onnx.go
+++ b/internal/classifier/bat_onnx.go
@@ -92,11 +92,12 @@ func NewBat(cfg *BatModelConfig) (*Bat, error) {
 	// OpenVINO must never make the bat model fail to load, so tryBatOpenVINO logs and
 	// swallows OV errors and returns ok=false. device records the compute device the
 	// extractor actually bound to (the OpenVINO device on the OV path).
-	embExtractor, device, ok := tryBatOpenVINO(cfg, batCC.InputDim())
-	// The bat embedding model is forced to f32 on every OpenVINO device, so the
-	// effective OV runtime precision is FP32. The ORT path overrides all three below.
+	embExtractor, device, precision, ok := tryBatOpenVINO(cfg, batCC.InputDim())
+	// The OpenVINO path reports the precision it actually compiled at:
+	// openVINOPrecisionFor forces f32 for the bat embedding model on every device
+	// (its embedding head overflows at f16), matching the BirdNET v3.0 policy. The
+	// ORT fallback overrides backend, device, and precision below.
 	backend := BackendOpenVINO
-	precision := string(QuantizationFP32)
 	if !ok {
 		embClassifier, cerr := inference.NewONNXClassifier(cfg.EmbeddingModelPath, inference.ONNXClassifierOptions{
 			Labels:              cfg.EmbeddingLabels,
@@ -153,16 +154,18 @@ func NewBat(cfg *BatModelConfig) (*Bat, error) {
 }
 
 // tryBatOpenVINO attempts to build an OpenVINO embedding extractor for the bat
-// pipeline's heavy embedding model. It returns (extractor, device, true) on success
-// or (nil, "", false) to fall back to ORT, where device is the concrete OpenVINO
-// device the extractor bound to (inference.OVDeviceCPU/OVDeviceGPU). Any failure
+// pipeline's heavy embedding model. It returns (extractor, device, precision, true)
+// on success or (nil, "", "", false) to fall back to ORT, where device is the
+// concrete OpenVINO device the extractor bound to (inference.OVDeviceCPU/OVDeviceGPU)
+// and precision is the effective runtime precision label (FP32 for the bat model on
+// every device). Any failure
 // (gate denied, init/compile/validation error) is logged and swallowed: OpenVINO
 // must never make the bat model fail to load. The device gate matches BirdNET v2.4;
 // the bat embedding model is forced to f32 on every device by
 // openVINOPrecisionFor(RegistryIDBat, ...) because its embedding head overflows at
 // f16. expectedDim is the bat classifier's input dimension, used to reject a wrong
 // output port before any inference.
-func tryBatOpenVINO(cfg *BatModelConfig, expectedDim int) (inference.EmbeddingExtractor, string, bool) {
+func tryBatOpenVINO(cfg *BatModelConfig, expectedDim int) (extractor inference.EmbeddingExtractor, device, precision string, ok bool) {
 	log := GetLogger()
 
 	// openVINOPlanFor gates on the build tag, backend preference, and device
@@ -174,7 +177,7 @@ func tryBatOpenVINO(cfg *BatModelConfig, expectedDim int) (inference.EmbeddingEx
 	plan, ok, reason := openVINOPlanFor(cfg.Backend, cfg.OpenVINODevice, RegistryIDBat, cfg.OpenVINOPath, 0)
 	if !ok {
 		logOpenVINODeclined(RegistryIDBat, cfg.Backend, reason)
-		return nil, "", false
+		return nil, "", "", false
 	}
 
 	// Resolve which output port carries the [1024] embedding: index 1 for the 2-output
@@ -187,7 +190,7 @@ func tryBatOpenVINO(cfg *BatModelConfig, expectedDim int) (inference.EmbeddingEx
 		log.Warn("Bat OpenVINO embedding-output detection failed; using ONNX Runtime",
 			logger.String("embedding_model", cfg.EmbeddingModelPath),
 			logger.Error(err))
-		return nil, "", false
+		return nil, "", "", false
 	}
 	plan.outputIndex = embIndex
 
@@ -196,11 +199,11 @@ func tryBatOpenVINO(cfg *BatModelConfig, expectedDim int) (inference.EmbeddingEx
 	// to cover it. A load failure means no usable OpenVINO; fall back to ORT.
 	if err := inference.InitOpenVINO(cfg.OpenVINOPath); err != nil {
 		log.Warn("Bat OpenVINO init failed; using ONNX Runtime", logger.Error(err))
-		return nil, "", false
+		return nil, "", "", false
 	}
 
 	start := time.Now()
-	extractor, err := inference.NewOpenVINOEmbeddingExtractor(cfg.EmbeddingModelPath, inference.OpenVINOEmbeddingExtractorOptions{
+	extractor, err = inference.NewOpenVINOEmbeddingExtractor(cfg.EmbeddingModelPath, inference.OpenVINOEmbeddingExtractorOptions{
 		Threads:       cfg.Threads,
 		Device:        plan.device,
 		OutputIndex:   plan.outputIndex,
@@ -211,7 +214,7 @@ func tryBatOpenVINO(cfg *BatModelConfig, expectedDim int) (inference.EmbeddingEx
 		log.Warn("Bat OpenVINO embedding extractor init failed; using ONNX Runtime",
 			logger.String("device", plan.device),
 			logger.Error(err))
-		return nil, "", false
+		return nil, "", "", false
 	}
 
 	log.Info("Bat embedding extractor using OpenVINO backend",
@@ -219,7 +222,7 @@ func tryBatOpenVINO(cfg *BatModelConfig, expectedDim int) (inference.EmbeddingEx
 		logger.String("precision", openVINOPrecisionLabel(plan.precision)),
 		logger.Int("embedding_dim", extractor.NumSpecies()),
 		logger.String("init_time", time.Since(start).String()))
-	return extractor, plan.device, true
+	return extractor, plan.device, openVINOEffectivePrecision(plan.precision), true
 }
 
 // Predict runs the two-stage bat detection pipeline: embedding extraction then bat classification.

--- a/internal/classifier/model_catalog.go
+++ b/internal/classifier/model_catalog.go
@@ -209,7 +209,11 @@ var EmbeddedCatalog = []CatalogEntry{
 				SpeciesCount: 11560,
 				Default:      true,
 				// RAM floor and benchmarks sourced from the acoustic-models
-				// BirdNET-v3.0-Models.models.json manifest.
+				// BirdNET-v3.0-Models.models.json manifest, measured under f16
+				// compilation. Post-#4289 v3.0 runs f32 on OpenVINO (openVINOPrecisionFor
+				// forces it; see BIRDNET-GO-2H6), which raises the real activation
+				// footprint, but the f32-on-OpenVINO RSS is unmeasured, so this floor is
+				// left as sourced. See the fp16 variant's note before changing either.
 				Requirements: VariantRequirements{MinRAMMB: 800},
 				Backends: map[string]BackendSupport{
 					"onnxruntime-cpu": {Supported: true, Recommended: true},
@@ -234,7 +238,13 @@ var EmbeddedCatalog = []CatalogEntry{
 				Precision:    "fp16",
 				SpeciesCount: 11560,
 				// RAM floor, exclude token and benchmarks sourced from the
-				// acoustic-models BirdNET-v3.0-Models.models.json manifest.
+				// acoustic-models BirdNET-v3.0-Models.models.json manifest, measured
+				// under f16 compilation. Post-#4289 both v3.0 variants run f32 on
+				// OpenVINO (openVINOPrecisionFor forces it; see BIRDNET-GO-2H6), which
+				// raises the real activation footprint, but no f32-on-OpenVINO RSS has
+				// been measured for either variant, so neither floor is changed without
+				// one. 1100 already carries headroom over the worst measured RSS (929 on
+				// the A72 ONNX Runtime path) and is 300 above the fp32 variant's floor.
 				Requirements: VariantRequirements{MinRAMMB: 1100, Excludes: []string{"openvino-gpu-intel-gen12"}},
 				Backends: map[string]BackendSupport{
 					"openvino-gpu":    {Supported: true, Recommended: true},

--- a/internal/classifier/model_openvino.go
+++ b/internal/classifier/model_openvino.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/cpuspec"
 	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/hwprofile"
 	"github.com/tphakala/birdnet-go/internal/inference"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
@@ -143,6 +144,43 @@ func openVINOPrecisionFor(modelID, device string) string {
 		return inference.OVPrecisionF32
 	}
 	return ""
+}
+
+// openVINODeviceForBackend maps a hwprofile backend capability token to the
+// concrete inference OpenVINO device it denotes, reporting ok=false for any
+// token that is not an OpenVINO backend. Only OpenVINO carries an
+// INFERENCE_PRECISION_HINT, so a non-OpenVINO backend can never override a
+// model's declared file precision.
+func openVINODeviceForBackend(backendToken string) (device string, ok bool) {
+	switch backendToken {
+	case hwprofile.CapOpenVINOCPU:
+		return inference.OVDeviceCPU, true
+	case hwprofile.CapOpenVINOGPU:
+		return inference.OVDeviceGPU, true
+	default:
+		return "", false
+	}
+}
+
+// BackendForcesFP32 reports whether running the given model on the given host
+// backend forces FP32 execution, overriding whatever precision the model file
+// declares. Only the OpenVINO backends carry an INFERENCE_PRECISION_HINT that
+// can override the file precision (see openVINOPrecisionFor); every other
+// backend (ONNX Runtime, and the CUDA/TensorRT compute backends) runs the file
+// as stored, so this returns false for them.
+//
+// It is exported for the model-gallery recommender (internal/classifier/recommend),
+// which uses it to avoid rewarding an fp16 variant's native-f16 speed on a
+// backend that will not actually run that variant at f16. backendToken is a
+// hwprofile capability token (hwprofile.CapOpenVINOCPU and friends). Keeping the
+// policy here means the recommender never has to name a model ID, so any future
+// change to the per-model precision policy propagates automatically.
+func BackendForcesFP32(registryID, backendToken string) bool {
+	device, ok := openVINODeviceForBackend(backendToken)
+	if !ok {
+		return false
+	}
+	return openVINOPrecisionFor(registryID, device) == inference.OVPrecisionF32
 }
 
 // openVINOCPUAllowed reports whether the OpenVINO CPU device may be used. The f16

--- a/internal/classifier/openvino_dispatch_test.go
+++ b/internal/classifier/openvino_dispatch_test.go
@@ -110,10 +110,11 @@ func TestTryBatOpenVINO_FallsBackWithoutTag(t *testing.T) {
 		Backend:        conf.BackendPrefOpenVINO,
 		OpenVINODevice: conf.OVDeviceGPU,
 	}
-	ext, device, ok := tryBatOpenVINO(cfg, 1024)
+	ext, device, precision, ok := tryBatOpenVINO(cfg, 1024)
 	assert.False(t, ok, "without the openvino tag, the bat OV path must decline")
 	assert.Nil(t, ext, "a declined OV path must return a nil extractor (no typed-nil trap)")
 	assert.Empty(t, device)
+	assert.Empty(t, precision, "a declined OV path reports no precision; NewBat's ORT branch sets it")
 }
 
 // TestOpenVINOPlanForBat_NotBuilt verifies that in the default (no-tag) build the

--- a/internal/classifier/openvino_precision_test.go
+++ b/internal/classifier/openvino_precision_test.go
@@ -120,6 +120,11 @@ func TestOpenVINOEffectivePrecision(t *testing.T) {
 func TestBackendForcesFP32(t *testing.T) {
 	t.Parallel()
 
+	// cudaBackendToken is a representative non-OpenVINO compute backend: only the
+	// OpenVINO backends carry a precision hint, so a CUDA host runs the file as
+	// stored and never forces f32.
+	const cudaBackendToken = "cuda"
+
 	tests := []struct {
 		name         string
 		registryID   string
@@ -147,7 +152,7 @@ func TestBackendForcesFP32(t *testing.T) {
 		{
 			name:         "birdnet v3.0 on a non-openvino gpu backend runs the file as stored",
 			registryID:   RegistryIDBirdNETV3,
-			backendToken: "cuda",
+			backendToken: cudaBackendToken,
 			want:         false,
 		},
 		{

--- a/internal/classifier/openvino_precision_test.go
+++ b/internal/classifier/openvino_precision_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/hwprofile"
 	"github.com/tphakala/birdnet-go/internal/inference"
 )
 
@@ -104,4 +105,93 @@ func TestOpenVINOEffectivePrecision(t *testing.T) {
 		"empty hint is the backend f16 default, shown as FP16")
 	assert.Equal(t, string(QuantizationFP32), openVINOEffectivePrecision(inference.OVPrecisionF32),
 		"the f32 hint (BirdNET v2.4 and Perch v2 on the GPU, bat and BirdNET v3.0 on every device) is shown as FP32")
+}
+
+// TestBackendForcesFP32 verifies the backend-token predicate the model-gallery
+// recommender uses to decide whether a variant's declared file precision (for
+// example an fp16 model) will actually run at f16 on a given host backend, or be
+// overridden to f32. Only the OpenVINO backends carry an INFERENCE_PRECISION_HINT
+// that can override the file precision; ONNX Runtime and the CUDA/TensorRT
+// compute backends run the file as stored. The truth table mirrors
+// openVINOPrecisionFor: bat and BirdNET v3.0 are f32 on every OpenVINO device,
+// BirdNET v2.4 and Perch v2 only on the OpenVINO GPU.
+//
+// Tag-agnostic like BackendForcesFP32 itself, so it runs in the default suite.
+func TestBackendForcesFP32(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		registryID   string
+		backendToken string
+		want         bool
+	}{
+		{
+			name:         "birdnet v3.0 on openvino cpu is forced to f32",
+			registryID:   RegistryIDBirdNETV3,
+			backendToken: hwprofile.CapOpenVINOCPU,
+			want:         true,
+		},
+		{
+			name:         "birdnet v3.0 on openvino gpu is forced to f32",
+			registryID:   RegistryIDBirdNETV3,
+			backendToken: hwprofile.CapOpenVINOGPU,
+			want:         true,
+		},
+		{
+			name:         "birdnet v3.0 on onnx runtime cpu runs the file as stored",
+			registryID:   RegistryIDBirdNETV3,
+			backendToken: hwprofile.CapONNXRuntimeCPU,
+			want:         false,
+		},
+		{
+			name:         "birdnet v3.0 on a non-openvino gpu backend runs the file as stored",
+			registryID:   RegistryIDBirdNETV3,
+			backendToken: "cuda",
+			want:         false,
+		},
+		{
+			name:         "bat on openvino cpu is forced to f32",
+			registryID:   RegistryIDBat,
+			backendToken: hwprofile.CapOpenVINOCPU,
+			want:         true,
+		},
+		{
+			name:         "birdnet v2.4 on openvino cpu keeps the f16 default",
+			registryID:   DefaultModelVersion,
+			backendToken: hwprofile.CapOpenVINOCPU,
+			want:         false,
+		},
+		{
+			name:         "birdnet v2.4 on openvino gpu is forced to f32",
+			registryID:   DefaultModelVersion,
+			backendToken: hwprofile.CapOpenVINOGPU,
+			want:         true,
+		},
+		{
+			name:         "perch v2 on openvino cpu keeps the f16 default",
+			registryID:   RegistryIDPerchV2,
+			backendToken: hwprofile.CapOpenVINOCPU,
+			want:         false,
+		},
+		{
+			name:         "unknown model on openvino cpu forces nothing",
+			registryID:   "",
+			backendToken: hwprofile.CapOpenVINOCPU,
+			want:         false,
+		},
+		{
+			name:         "empty backend token is not an openvino backend",
+			registryID:   RegistryIDBirdNETV3,
+			backendToken: "",
+			want:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, BackendForcesFP32(tt.registryID, tt.backendToken))
+		})
+	}
 }

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -4,6 +4,7 @@ package classifier
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -127,6 +128,19 @@ type Orchestrator struct {
 	// ID. Uses sync.Map to avoid holding o.mu for reads (see LoadFailures).
 	// Values are *atomic.Int64.
 	modelLoadFailures sync.Map
+
+	// modelLoadErrors records the last load error string per registry ID
+	// (registryID -> string), set alongside modelLoadFailures by recordLoadFailure
+	// so modelNotLoadedReason can explain why a model is missing. Lock-free.
+	modelLoadErrors sync.Map
+
+	// modelUnloaded is a tombstone set (registryID -> struct{}{}) marking models
+	// removed by UnloadModel and not yet reloaded. The unloaded case is the benign
+	// cause of the transient not-loaded predict during the topology-reconfigure
+	// debounce window (Sentry BIRDNET-GO-2G6 / 1S1): the tombstone lets
+	// modelNotLoadedReason report "unloaded, reconfigure in progress" instead of
+	// conflating it with a model that never loaded. Lock-free.
+	modelUnloaded sync.Map
 
 	// pendingWarmups queues deferred warm-ups recorded by model loaders while
 	// they hold o.mu (write lock). Drained by runPendingWarmups after o.mu is
@@ -695,9 +709,11 @@ func (o *Orchestrator) PredictModel(ctx context.Context, modelID string, sample 
 	o.mu.RUnlock()
 
 	if !ok {
-		log.Error("PredictModel unknown model",
-			logger.String("model_id", modelID))
-		return nil, errors.Newf("unknown model: %s", modelID).
+		reason := o.modelNotLoadedReason(modelID)
+		log.Error("PredictModel model not loaded",
+			logger.String("model_id", modelID),
+			logger.String("reason", reason))
+		return nil, errors.Newf("%w: %s (%s)", ErrModelNotLoaded, modelID, reason).
 			Component("classifier.orchestrator").
 			Category(errors.CategoryValidation).
 			Context("model_id", modelID).
@@ -1951,9 +1967,15 @@ func (o *Orchestrator) LoadModel(registryID string) error {
 			logger.Int("threads", dynamicThreads))
 
 		if err := loader(o, dynamicThreads); err != nil {
-			o.incLoadFailure(registryID)
+			o.recordLoadFailure(registryID, err)
 			return err
 		}
+		// The model registered successfully; clear any stale unload tombstone and the
+		// stored load error so a later not-loaded diagnosis reports the model's actual
+		// current state rather than a now-superseded unload or failure. The cumulative
+		// modelLoadFailures count is intentionally kept for the LoadFailures metric.
+		o.modelUnloaded.Delete(registryID)
+		o.modelLoadErrors.Delete(registryID)
 
 		log.Info("Model loaded dynamically",
 			logger.String("registry_id", registryID))
@@ -1978,11 +2000,16 @@ func (o *Orchestrator) LoadModel(registryID string) error {
 	return nil
 }
 
-// incLoadFailure atomically increments the load-failure counter for registryID.
-// Safe to call concurrently; does not require o.mu.
-func (o *Orchestrator) incLoadFailure(registryID string) {
+// recordLoadFailure atomically increments the load-failure counter for registryID
+// and records the last error text, so a later "model not loaded" diagnosis
+// (modelNotLoadedReason) can explain why the model is missing. Safe to call
+// concurrently; does not require o.mu.
+func (o *Orchestrator) recordLoadFailure(registryID string, err error) {
 	v, _ := o.modelLoadFailures.LoadOrStore(registryID, new(atomic.Int64))
 	v.(*atomic.Int64).Add(1)
+	if err != nil {
+		o.modelLoadErrors.Store(registryID, err.Error())
+	}
 }
 
 // LoadFailures returns a snapshot of the per-model load-failure counts accumulated
@@ -1995,6 +2022,80 @@ func (o *Orchestrator) LoadFailures() map[string]int64 {
 		return true
 	})
 	return result
+}
+
+// ErrModelNotLoaded is returned by PredictModel when the requested model is not
+// in the loaded set. It wraps a per-call reason (see modelNotLoadedReason);
+// callers match it with errors.Is. Plain sentinel: no telemetry registered at
+// package init.
+var ErrModelNotLoaded = errors.NewStd("model not loaded")
+
+// Reasons a model can be absent from o.models when PredictModel is called.
+// modelNotLoadedReason returns the most specific, most actionable one so a
+// transient not-loaded predict (Sentry BIRDNET-GO-2G6 / 1S1, the monitor that
+// outlives an unload during the topology-reconfigure debounce) is legible rather
+// than a bare "unknown model".
+const (
+	notLoadedReasonDeleted         = "the orchestrator has been shut down"
+	notLoadedReasonUnknownRegistry = "no model with this ID is registered"
+	notLoadedReasonNotEnabled      = "the model is not enabled in settings"
+	notLoadedReasonUnloaded        = "the model was unloaded (a model reconfigure or reinstall is in progress)"
+	notLoadedReasonNeverLoaded     = "the model has not finished loading"
+	// notLoadedReasonFailedFormat renders the load-failure count and last error.
+	notLoadedReasonFailedFormat = "the model failed to load %d time(s), last error: %s"
+)
+
+// modelNotLoadedReason explains why modelID is absent from o.models, turning the
+// bare "unknown model" into an actionable diagnosis. Safe to call without holding
+// o.mu: it takes its own read lock only for the map-nil check (PredictModel has
+// already released the lock at this point) and otherwise reads lock-free
+// sync.Maps and the published settings snapshot. The most specific, most
+// actionable cause wins.
+func (o *Orchestrator) modelNotLoadedReason(modelID string) string {
+	o.mu.RLock()
+	deleted := o.models == nil
+	o.mu.RUnlock()
+	if deleted {
+		return notLoadedReasonDeleted
+	}
+	if _, registered := ModelRegistry[modelID]; !registered {
+		return notLoadedReasonUnknownRegistry
+	}
+	// A stored error means the model's most recent load attempt failed and has not
+	// since succeeded: a successful load clears the error (see LoadModel /
+	// loadAdditionalModels), so gate on the error's PRESENCE rather than the
+	// modelLoadFailures count, which is a cumulative lifetime counter (kept for the
+	// LoadFailures metric) that survives a later success. Without this gate, a model
+	// that failed once, recovered, then was cleanly unloaded would be misreported as
+	// "failed to load" with a stale error instead of "unloaded".
+	if e, ok := o.modelLoadErrors.Load(modelID); ok {
+		lastErr, _ := e.(string)
+		count := int64(0)
+		if v, ok := o.modelLoadFailures.Load(modelID); ok {
+			count = v.(*atomic.Int64).Load()
+		}
+		return fmt.Sprintf(notLoadedReasonFailedFormat, count, lastErr)
+	}
+	if _, unloaded := o.modelUnloaded.Load(modelID); unloaded {
+		return notLoadedReasonUnloaded
+	}
+	if !o.modelIDEnabled(modelID) {
+		return notLoadedReasonNotEnabled
+	}
+	return notLoadedReasonNeverLoaded
+}
+
+// modelIDEnabled reports whether registryID corresponds to a model the user has
+// enabled: an entry in settings.Models.Enabled once its config alias is resolved
+// to a registry ID. Mirrors loadAdditionalModels' own resolution so the two agree
+// on what "enabled" means.
+func (o *Orchestrator) modelIDEnabled(registryID string) bool {
+	for _, configID := range o.currentSettings().Models.Enabled {
+		if resolved, known := ResolveConfigModelID(configID); known && resolved == registryID {
+			return true
+		}
+	}
+	return false
 }
 
 // UnloadModel removes a model from the Orchestrator and releases its resources.
@@ -2038,6 +2139,10 @@ func (o *Orchestrator) UnloadModel(registryID string) error {
 	// Remove from map while holding the write lock so no new PredictModel
 	// calls can obtain this entry.
 	delete(o.models, registryID)
+	// Tombstone the model so a predict that races the asynchronous monitor
+	// teardown (the topology-reconfigure debounce window) is diagnosed as
+	// "unloaded" rather than a bare unknown model. Cleared on the next load.
+	o.modelUnloaded.Store(registryID, struct{}{})
 	if registryID == RegistryIDBat {
 		if s := o.scheduler.Load(); s != nil {
 			s.stop()
@@ -2388,9 +2493,19 @@ func (o *Orchestrator) loadAdditionalModels(threadAlloc map[string]int) error {
 
 			// Hold the lock through the loader call because loaders write
 			// directly to o.models (e.g., loadPerch, loadBat).
-			return loader(o, threadAlloc[registryID])
+			if err := loader(o, threadAlloc[registryID]); err != nil {
+				return err
+			}
+			// The model registered; clear any stale unload tombstone and stored load
+			// error (the cumulative failure count is kept for the LoadFailures metric).
+			o.modelUnloaded.Delete(registryID)
+			o.modelLoadErrors.Delete(registryID)
+			return nil
 		}()
 		if loadErr != nil {
+			// Record the failure (not just log it) so a later not-loaded predict on
+			// this model can report why it is missing instead of a bare unknown model.
+			o.recordLoadFailure(registryID, loadErr)
 			log.Warn("optional model failed to load, will retry after gallery scan",
 				logger.String("registry_id", registryID),
 				logger.Error(loadErr))

--- a/internal/classifier/orchestrator_test.go
+++ b/internal/classifier/orchestrator_test.go
@@ -174,17 +174,106 @@ func TestOrchestrator_PredictModel_Success(t *testing.T) {
 	assert.InDelta(t, 0.88, float64(results[0].Confidence), 0.001)
 }
 
-func TestOrchestrator_PredictModel_UnknownModel(t *testing.T) {
-	t.Parallel()
+// testRegistryIDNotLoaded is a synthetic registry ID registered by the
+// not-loaded reason tests so the unknown-registry branch is not taken for the
+// cases that exercise the other reasons.
+const testRegistryIDNotLoaded = "__test_not_loaded__"
 
-	o := newTestOrchestrator(t) // no models registered
+// TestOrchestrator_PredictModel_NotLoaded verifies that a predict on a model that
+// is not in o.models fails with the ErrModelNotLoaded sentinel and an actionable
+// reason, rather than the bare "unknown model" it used to return. The reason
+// distinguishes the causes that Sentry BIRDNET-GO-2G6 / 1S1 could not tell apart:
+// a shut-down orchestrator, an unregistered ID, a model disabled in settings, a
+// model whose load failed, and a model that was unloaded (the reconfigure race).
+func TestOrchestrator_PredictModel_NotLoaded(t *testing.T) {
+	// Not parallel: mutates package-level ModelRegistry/modelLoaders and the
+	// global settings snapshot.
 
-	results, err := o.PredictModel(t.Context(), "nonexistent", [][]float32{{0.1}})
+	ModelRegistry[testRegistryIDNotLoaded] = ModelInfo{ID: testRegistryIDNotLoaded}
+	t.Cleanup(func() { delete(ModelRegistry, testRegistryIDNotLoaded) })
 
-	require.Error(t, err)
-	assert.Nil(t, results)
-	assert.Contains(t, err.Error(), "unknown model")
-	assert.Contains(t, err.Error(), "nonexistent")
+	sample := [][]float32{{0.1}}
+
+	t.Run("unknown registry id", func(t *testing.T) {
+		o := newTestOrchestrator(t) // empty models map (not nil)
+		results, err := o.PredictModel(t.Context(), "nonexistent", sample)
+		require.Error(t, err)
+		assert.Nil(t, results)
+		require.ErrorIs(t, err, ErrModelNotLoaded)
+		assert.Contains(t, err.Error(), "nonexistent")
+		assert.Contains(t, err.Error(), notLoadedReasonUnknownRegistry)
+	})
+
+	t.Run("registered but not enabled", func(t *testing.T) {
+		conftest.SetTestSettings(conftest.GetTestSettings()) // Models.Enabled is empty
+		t.Cleanup(func() { conftest.SetTestSettings(nil) })
+		o := &Orchestrator{models: map[string]*modelEntry{}, modelRSS: make(map[string]int64), Settings: conftest.GetTestSettings()}
+		results, err := o.PredictModel(t.Context(), testRegistryIDNotLoaded, sample)
+		require.Error(t, err)
+		assert.Nil(t, results)
+		require.ErrorIs(t, err, ErrModelNotLoaded)
+		assert.Contains(t, err.Error(), testRegistryIDNotLoaded)
+		assert.Contains(t, err.Error(), notLoadedReasonNotEnabled)
+	})
+
+	t.Run("enabled but loader failed", func(t *testing.T) {
+		loaderErr := fmt.Errorf("injected loader failure")
+		modelLoaders[testRegistryIDNotLoaded] = func(_ *Orchestrator, _ int) error { return loaderErr }
+		t.Cleanup(func() { delete(modelLoaders, testRegistryIDNotLoaded) })
+		o := &Orchestrator{models: map[string]*modelEntry{}, modelRSS: make(map[string]int64), Settings: conftest.GetTestSettings()}
+		require.Error(t, o.LoadModel(testRegistryIDNotLoaded))
+		results, err := o.PredictModel(t.Context(), testRegistryIDNotLoaded, sample)
+		require.Error(t, err)
+		assert.Nil(t, results)
+		require.ErrorIs(t, err, ErrModelNotLoaded)
+		assert.Contains(t, err.Error(), "failed to load")
+		assert.Contains(t, err.Error(), loaderErr.Error())
+	})
+
+	t.Run("unloaded", func(t *testing.T) {
+		mock := &mockModelInstance{id: testRegistryIDNotLoaded}
+		o := newTestOrchestrator(t, mock)
+		require.NoError(t, o.UnloadModel(testRegistryIDNotLoaded))
+		results, err := o.PredictModel(t.Context(), testRegistryIDNotLoaded, sample)
+		require.Error(t, err)
+		assert.Nil(t, results)
+		require.ErrorIs(t, err, ErrModelNotLoaded)
+		assert.Contains(t, err.Error(), notLoadedReasonUnloaded)
+	})
+
+	t.Run("deleted orchestrator", func(t *testing.T) {
+		mock := &mockModelInstance{id: testRegistryIDNotLoaded}
+		o := newTestOrchestrator(t, mock)
+		o.Delete()
+		results, err := o.PredictModel(t.Context(), testRegistryIDNotLoaded, sample)
+		require.Error(t, err)
+		assert.Nil(t, results)
+		require.ErrorIs(t, err, ErrModelNotLoaded)
+		assert.Contains(t, err.Error(), notLoadedReasonDeleted)
+	})
+
+	t.Run("registered and enabled but not yet loaded", func(t *testing.T) {
+		// Registered in ModelRegistry, resolved-enabled in settings, no failure and
+		// no tombstone: the model is simply still loading. This also exercises
+		// modelIDEnabled's positive (resolves-to-enabled) branch.
+		const (
+			regID = "__test_never_loaded__"
+			alias = "__test_never_alias__"
+		)
+		ModelRegistry[regID] = ModelInfo{ID: regID, ConfigAliases: []string{alias}}
+		t.Cleanup(func() { delete(ModelRegistry, regID) })
+		settings := conftest.GetTestSettings()
+		settings.Models.Enabled = []string{alias}
+		conftest.SetTestSettings(settings)
+		t.Cleanup(func() { conftest.SetTestSettings(nil) })
+
+		o := &Orchestrator{models: map[string]*modelEntry{}, modelRSS: make(map[string]int64), Settings: settings}
+		results, err := o.PredictModel(t.Context(), regID, sample)
+		require.Error(t, err)
+		assert.Nil(t, results)
+		require.ErrorIs(t, err, ErrModelNotLoaded)
+		assert.Contains(t, err.Error(), notLoadedReasonNeverLoaded)
+	})
 }
 
 func TestOrchestrator_PredictModel_SerializedInference(t *testing.T) {
@@ -674,4 +763,91 @@ func TestOrchestrator_LoadModel_FailureIncrementsLoadFailures(t *testing.T) {
 	failures = o.LoadFailures()
 	assert.Equal(t, int64(2), failures[testRegistryIDForLoadFailure],
 		"LoadFailures must be 2 after two failed LoadModel calls")
+}
+
+// TestOrchestrator_LoadAdditionalModels_RecordsLoadFailure verifies that a
+// startup (optional-model) loader failure is recorded in LoadFailures, so a later
+// "model not loaded" diagnosis can explain why the model is missing instead of
+// reporting a bare unknown-model error. Previously loadAdditionalModels only
+// logged the failure, leaving LoadFailures empty for a startup-failed model.
+func TestOrchestrator_LoadAdditionalModels_RecordsLoadFailure(t *testing.T) {
+	// Not parallel: mutates package-level ModelRegistry/modelLoaders and the
+	// global settings snapshot.
+	const alias = "__test_addl_alias__"
+	loaderErr := fmt.Errorf("injected additional-model loader failure")
+
+	ModelRegistry[testRegistryIDNotLoaded] = ModelInfo{ID: testRegistryIDNotLoaded, ConfigAliases: []string{alias}}
+	modelLoaders[testRegistryIDNotLoaded] = func(_ *Orchestrator, _ int) error { return loaderErr }
+	t.Cleanup(func() {
+		delete(ModelRegistry, testRegistryIDNotLoaded)
+		delete(modelLoaders, testRegistryIDNotLoaded)
+	})
+
+	settings := conftest.GetTestSettings()
+	settings.Models.Enabled = []string{alias}
+	conftest.SetTestSettings(settings)
+	t.Cleanup(func() { conftest.SetTestSettings(nil) })
+
+	o := &Orchestrator{Settings: settings, models: map[string]*modelEntry{}, modelRSS: make(map[string]int64)}
+	require.NoError(t, o.loadAdditionalModels(map[string]int{}))
+
+	assert.Equal(t, int64(1), o.LoadFailures()[testRegistryIDNotLoaded],
+		"a startup loader failure must be recorded so a later not-loaded diagnosis can explain it")
+
+	// The recorded failure now explains a subsequent predict on the missing model.
+	results, err := o.PredictModel(t.Context(), testRegistryIDNotLoaded, [][]float32{{0.1}})
+	require.Error(t, err)
+	assert.Nil(t, results)
+	require.ErrorIs(t, err, ErrModelNotLoaded)
+	assert.Contains(t, err.Error(), loaderErr.Error())
+}
+
+// TestOrchestrator_SuccessfulReload_ClearsStaleFailureError verifies that a
+// successful load clears the stored load error, so a model that failed to load
+// once, recovered, then was cleanly unloaded is diagnosed as "unloaded" rather
+// than mislabeled with the stale earlier failure. The cumulative LoadFailures
+// count must survive the successful load (it feeds the inference-status metric).
+func TestOrchestrator_SuccessfulReload_ClearsStaleFailureError(t *testing.T) {
+	// Not parallel: mutates package-level ModelRegistry/modelLoaders and the
+	// global settings snapshot.
+	const (
+		regID = "__test_recover__"
+		alias = "__test_recover_alias__"
+	)
+	ModelRegistry[regID] = ModelInfo{ID: regID, ConfigAliases: []string{alias}}
+	t.Cleanup(func() {
+		delete(ModelRegistry, regID)
+		delete(modelLoaders, regID)
+	})
+	settings := conftest.GetTestSettings()
+	settings.Models.Enabled = []string{alias}
+	conftest.SetTestSettings(settings)
+	t.Cleanup(func() { conftest.SetTestSettings(nil) })
+
+	o := &Orchestrator{Settings: settings, models: map[string]*modelEntry{}, modelRSS: make(map[string]int64)}
+
+	// 1. First load attempt fails: records a cumulative failure and a stored error.
+	loadErr := fmt.Errorf("transient startup failure")
+	modelLoaders[regID] = func(_ *Orchestrator, _ int) error { return loadErr }
+	require.NoError(t, o.loadAdditionalModels(map[string]int{}))
+	require.Equal(t, int64(1), o.LoadFailures()[regID])
+
+	// 2. Second attempt succeeds: the loader registers the model, which must clear
+	//    the stored error while the cumulative failure count survives.
+	modelLoaders[regID] = func(orc *Orchestrator, _ int) error {
+		orc.models[regID] = &modelEntry{instance: &mockModelInstance{id: regID}}
+		return nil
+	}
+	require.NoError(t, o.loadAdditionalModels(map[string]int{}))
+	require.True(t, o.IsModelLoaded(regID))
+	assert.Equal(t, int64(1), o.LoadFailures()[regID],
+		"the cumulative failure count survives a successful load")
+
+	// 3. Clean unload, then a race predict must report unloaded, not the stale failure.
+	require.NoError(t, o.UnloadModel(regID))
+	_, err := o.PredictModel(t.Context(), regID, [][]float32{{0.1}})
+	require.ErrorIs(t, err, ErrModelNotLoaded)
+	assert.Contains(t, err.Error(), notLoadedReasonUnloaded)
+	assert.NotContains(t, err.Error(), "failed to load",
+		"a model that recovered from an earlier failure and was then unloaded must report unloaded, not the stale failure")
 }

--- a/internal/classifier/recommend/recommend.go
+++ b/internal/classifier/recommend/recommend.go
@@ -46,7 +46,10 @@ const (
 	// that case does not arise in shipped catalog data.)
 	scoreRegionGlobalFallback = 50
 	// scoreFP16Native rewards an fp16 variant on a host with native
-	// half-precision SIMD.
+	// half-precision SIMD, but only when the variant's selected backend actually
+	// runs the fp16 file at f16. It is suppressed when the chosen backend forces
+	// f32 (see classifier.BackendForcesFP32), for example BirdNET v3.0 on any
+	// OpenVINO device, where the native-f16 speed rationale does not hold.
 	scoreFP16Native = 15
 	// scoreFP16GPUPreferredHeadroom is the margin above benchmarkMaxScore that
 	// keeps fp16 winning outright rather than on the backend-rank tie-break.
@@ -297,7 +300,7 @@ func rankEntry(entry *classifier.CatalogEntry, in *Input) []Recommendation {
 	scoredVariants := make([]scoredVariant, 0, len(entry.Variants))
 	for j := range entry.Variants {
 		v := &entry.Variants[j]
-		scoredVariants = append(scoredVariants, evaluateVariant(entry.ID, v, in, bench[v.ID], hasMatchingRegion))
+		scoredVariants = append(scoredVariants, evaluateVariant(entry, v, in, bench[v.ID], hasMatchingRegion))
 	}
 
 	sortScored(scoredVariants)
@@ -335,7 +338,7 @@ type scoredVariant struct {
 // hasMatchingRegion reports whether the variant's entry ships a slice matching
 // the host's resolved region, which decides whether a global variant earns the
 // region fallback bonus (see rankEntry).
-func evaluateVariant(catalogID string, v *classifier.CatalogVariant, in *Input, bench benchmarkResult, hasMatchingRegion bool) scoredVariant {
+func evaluateVariant(entry *classifier.CatalogEntry, v *classifier.CatalogVariant, in *Input, bench benchmarkResult, hasMatchingRegion bool) scoredVariant {
 	var reasons, blockers []Reason
 	score := 0
 
@@ -374,6 +377,12 @@ func evaluateVariant(catalogID string, v *classifier.CatalogVariant, in *Input, 
 	// gpuRecommended is set when the variant's Recommended backend on this host
 	// runs on a GPU, gating the fp16 size-lever modifier below.
 	gpuRecommended := false
+	// fp16ForcedOff is set when the variant's selected backend force-runs it at
+	// f32 (see classifier.BackendForcesFP32), which suppresses the fp16 native-f16
+	// reward below because the variant will not actually execute at f16 on that
+	// backend. It stays false when no backend term applies, preserving the
+	// empty-Backends-map behaviour a user-edited catalog can carry.
+	fp16ForcedOff := false
 	if term, missing := backendTerm(v, in.Capabilities); missing {
 		if !backendMissing {
 			blockers = append(blockers, Reason{Code: BlockerBackendMissing, Args: joinArg("required", backendKeys(v.Backends))})
@@ -383,6 +392,7 @@ func evaluateVariant(catalogID string, v *classifier.CatalogVariant, in *Input, 
 		reasons = append(reasons, Reason{Code: term.code, Args: map[string]string{ReasonArgBackend: term.backend}})
 		backendRank = preferenceRank(term.backend)
 		gpuRecommended = term.code == ReasonBackendRecommended && isGPUBackend(term.backend)
+		fp16ForcedOff = classifier.BackendForcesFP32(entry.RegistryID, term.backend)
 	}
 
 	// Region term. A regional slice matching the host's resolved region is the
@@ -401,7 +411,7 @@ func evaluateVariant(catalogID string, v *classifier.CatalogVariant, in *Input, 
 	}
 
 	// Modifiers.
-	if slices.Contains(in.Capabilities, hwprofile.CapFP16Native) && v.Precision == precisionFP16 {
+	if slices.Contains(in.Capabilities, hwprofile.CapFP16Native) && v.Precision == precisionFP16 && !fp16ForcedOff {
 		score += scoreFP16Native
 		reasons = append(reasons, Reason{Code: ReasonPrecisionFP16Native})
 	}
@@ -435,7 +445,7 @@ func evaluateVariant(catalogID string, v *classifier.CatalogVariant, in *Input, 
 
 	return scoredVariant{
 		rec: Recommendation{
-			CatalogID:  catalogID,
+			CatalogID:  entry.ID,
 			VariantID:  v.ID,
 			Score:      score,
 			Compatible: len(blockers) == 0,

--- a/internal/classifier/recommend/recommend_test.go
+++ b/internal/classifier/recommend/recommend_test.go
@@ -751,6 +751,97 @@ func TestRank_FP16NativeBonus(t *testing.T) {
 	assert.True(t, hasReason(&fp16, ReasonPrecisionFP16Native), "fp16 variant on an fp16-native host gets the precision bonus (reasons: %+v)", fp16.Reasons)
 }
 
+// TestRank_FP16NativeBonus_BackendAware pins that the fp16 native-speed reward is
+// awarded only when the variant's selected backend actually runs the fp16 file at
+// f16. After #4289 BirdNET v3.0 is force-run at f32 on every OpenVINO device, so
+// the reward must not be given on an OpenVINO backend for v3.0, while it must
+// still be given on the ONNX Runtime path (which executes the fp16 file as
+// stored) and for a model whose OpenVINO path does keep f16.
+func TestRank_FP16NativeBonus_BackendAware(t *testing.T) {
+	t.Parallel()
+
+	t.Run("onnx runtime host keeps the reward", func(t *testing.T) {
+		t.Parallel()
+		v3 := realEntry(t, "birdnet-v3.0")
+		recs := Rank(&Input{
+			Capabilities: []string{hwprofile.CapAArch64, hwprofile.CapAArch64A76, hwprofile.CapONNXRuntimeCPU, hwprofile.CapFP16Native},
+			DeviceClass:  deviceClassRPi5,
+			Entries:      []classifier.CatalogEntry{v3},
+		})
+		fp16, ok := variantRec(recs, "birdnet-v3.0", "fp16")
+		require.True(t, ok)
+		assert.True(t, hasReason(&fp16, ReasonPrecisionFP16Native),
+			"fp16 runs at f16 on the ONNX Runtime path, so the native-f16 reward applies (reasons: %+v)", fp16.Reasons)
+	})
+
+	t.Run("openvino cpu host drops the reward for v3.0", func(t *testing.T) {
+		t.Parallel()
+		v3 := realEntry(t, "birdnet-v3.0")
+		recs := Rank(&Input{
+			Capabilities: []string{hwprofile.CapAArch64, hwprofile.CapAArch64A76, hwprofile.CapONNXRuntimeCPU, hwprofile.CapOpenVINOCPU, hwprofile.CapFP16Native},
+			DeviceClass:  deviceClassRPi5,
+			Entries:      []classifier.CatalogEntry{v3},
+		})
+		fp16, ok := variantRec(recs, "birdnet-v3.0", "fp16")
+		require.True(t, ok)
+		assert.False(t, hasReason(&fp16, ReasonPrecisionFP16Native),
+			"v3.0 is forced to f32 on OpenVINO, so the native-f16 reward must be suppressed (reasons: %+v)", fp16.Reasons)
+		assert.Equal(t, hwprofile.CapOpenVINOCPU, reasonArg(&fp16, ReasonBackendSupported, ReasonArgBackend),
+			"the suppression is driven by the openvino-cpu backend the recommender selected")
+		assert.Equal(t, "fp32", recommendedVariant(recs, "birdnet-v3.0"),
+			"dropping the reward does not flip the recommended pick away from fp32")
+	})
+
+	t.Run("openvino gpu host drops the reward but keeps the gpu size lever", func(t *testing.T) {
+		t.Parallel()
+		v3 := realEntry(t, "birdnet-v3.0")
+		// A real x86 iGPU never carries fp16-native (that token is arm64-only); the
+		// synthetic token here forces the fp16 modifier to be evaluated so the test
+		// pins the OpenVINO-GPU suppression branch specifically.
+		recs := Rank(&Input{
+			Capabilities: []string{hwprofile.CapX86_64, hwprofile.CapONNXRuntimeCPU, hwprofile.CapOpenVINOCPU, hwprofile.CapOpenVINOGPU, hwprofile.CapFP16Native},
+			DeviceClass:  deviceClassX86,
+			Entries:      []classifier.CatalogEntry{v3},
+		})
+		fp16, ok := variantRec(recs, "birdnet-v3.0", "fp16")
+		require.True(t, ok)
+		assert.False(t, hasReason(&fp16, ReasonPrecisionFP16Native),
+			"v3.0 is forced to f32 on the OpenVINO GPU, so the native-f16 reward must be suppressed (reasons: %+v)", fp16.Reasons)
+		assert.True(t, hasReason(&fp16, ReasonPrecisionFP16GPUPreferred),
+			"the GPU size lever is unrelated to precision forcing and must still apply")
+		assert.Equal(t, "fp16", recommendedVariant(recs, "birdnet-v3.0"),
+			"fp16 stays the recommended build on the iGPU host")
+	})
+
+	t.Run("reward is policy-driven not blanket openvino", func(t *testing.T) {
+		t.Parallel()
+		// A model whose OpenVINO CPU path keeps f16 (registry ID BirdNET v2.4) must
+		// still earn the reward on an OpenVINO CPU host: the suppression follows the
+		// per-model precision policy, it is not "OpenVINO means no reward".
+		synthetic := classifier.CatalogEntry{
+			ID:         "synthetic-v24",
+			RegistryID: classifier.DefaultModelVersion,
+			Variants: []classifier.CatalogVariant{
+				{
+					ID:        "fp16",
+					Precision: precisionFP16,
+					Backends:  map[string]classifier.BackendSupport{hwprofile.CapOpenVINOCPU: {Supported: true, Recommended: true}},
+					Files:     []classifier.CatalogFile{{SizeBytes: 100}},
+				},
+			},
+		}
+		recs := Rank(&Input{
+			Capabilities: []string{hwprofile.CapAArch64, hwprofile.CapAArch64A76, hwprofile.CapOpenVINOCPU, hwprofile.CapFP16Native},
+			DeviceClass:  deviceClassRPi5,
+			Entries:      []classifier.CatalogEntry{synthetic},
+		})
+		fp16, ok := variantRec(recs, "synthetic-v24", "fp16")
+		require.True(t, ok)
+		assert.True(t, hasReason(&fp16, ReasonPrecisionFP16Native),
+			"v2.4 keeps f16 on the OpenVINO CPU path, so its fp16 variant still earns the reward (reasons: %+v)", fp16.Reasons)
+	})
+}
+
 func TestRank_LowRAMInt8Bonus(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Follow-ups for the BirdNET v3.0 developer preview, plus a general fix for a model-unload predict storm that affects every secondary model, not just v3.0.

**Stop the model-unload predict storm (Sentry BIRDNET-GO-2G6, BIRDNET-GO-1S1).** When a model is unloaded (uninstall, reinstall, or variant switch) the orchestrator drops it from its loaded set immediately, but the analysis monitor for that source is torn down asynchronously, after the topology-reconfigure debounce. During that window the monitor kept dispatching audio windows to a model the orchestrator no longer had, logging an "unknown model" error on every window: 2G6 fired for BirdNET v3.0 and 1S1 for Perch v2 (285 events). The monitor now skips inference for a model that is not loaded, warning once and resuming automatically when the same model is re-registered, so a reconfigure no longer spams the log or Sentry. The monitor keeps running rather than stopping, so a reinstall or variant switch resumes immediately while the reconcile still tears it down when the model is gone for good. The predict path also turns the bare "unknown model" into an ErrModelNotLoaded carrying an actionable reason (shut down, unknown registry, not enabled, failed to load with the last error, unloaded, or still loading), and startup optional-model load failures are now recorded so a later not-loaded predict can explain itself.

**Make the fp16-native recommender reward backend-aware.** The model-gallery recommender gave an fp16 variant a native-f16 speed bonus on any host with native half-precision SIMD. After BirdNET v3.0 was forced to FP32 on every OpenVINO device (PR #4289, Sentry BIRDNET-GO-2H6), that bonus is wrong on the OpenVINO path, where the fp16 file runs at f32. The reward is now suppressed when the variant's selected backend forces f32, via a predicate that wraps the existing per-model precision policy rather than hardcoding a model ID in the recommender. It still applies on the ONNX Runtime path and for a model whose OpenVINO path keeps f16. The rule only ever removes a reward, and the measured scores show no shipped recommendation flips.

**Derive Bat OpenVINO precision from the compiled plan.** NewBat hardcoded FP32 rather than reading the precision the OpenVINO plan compiled at, the way the v3.0 path does. It is correct only because the bat embedding model is forced to f32 on every device today; deriving it from the plan removes the latent silent-lie if that policy ever changes.

**Document the v3.0 RAM floors.** Both v3.0 RAM floors were sourced from the upstream manifest under f16 compilation. Forcing f32 on OpenVINO raises the real footprint, but no f32-on-OpenVINO RSS has been measured for either variant, so the floors are left as sourced with a comment recording why.

## Related Issues

Follows up PR #4289 (the BirdNET v3.0 OpenVINO FP32 fix). No public issue is linked.

## Test Plan

- [x] `go build ./...`, `go vet` (default, `notflite`, `noembed` tags)
- [x] `golangci-lint run` clean on the changed packages
- [x] `go test -race ./internal/classifier/... ./internal/analysis/... ./internal/api/v2/models/... ./internal/api/v2/system/...`
- [x] New tests: monitor skips a not-loaded model without dispatching; the not-loaded reason distinguishes each cause and survives a fail-recover-unload sequence; the fp16 reward is suppressed on OpenVINO for v3.0 but kept on ONNX Runtime and for a model whose OpenVINO path keeps f16; the Bat OpenVINO decline path reports no precision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer model availability diagnostics, including specific reasons when a model cannot be used.
  * Added tracking for model loading failures and successful reloads.
  * Added backend-aware precision handling for OpenVINO and ONNX Runtime configurations.

* **Bug Fixes**
  * Monitoring now continues safely when a configured model is unavailable and resumes inference once it returns.
  * Prevented repeated warnings during consecutive monitoring cycles.
  * Improved model recommendations based on backend-specific precision capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->