### PR TITLE
refactor(classifier,analysis): dedupe enabled-model walk, cover monitor resume

### DIFF
--- a/internal/analysis/buffer_manager.go
+++ b/internal/analysis/buffer_manager.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/audiocore/buffer"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
@@ -40,10 +41,28 @@ type monitorTickState struct {
 	notLoadedWarned bool
 }
 
+// classifierBackend is the analysis package's view of *classifier.Orchestrator:
+// the exact set of methods BufferManager and ProcessData call on it. Declaring
+// the dependency as a consumer-side interface (accept interfaces, return concrete
+// types) lets buffer-manager tests inject a fake to drive the not-loaded ->
+// loaded and active/inactive transitions the monitor resume path depends on; a
+// real Orchestrator only reaches those states with fully loaded models, and its
+// models map and bat scheduler are package-private to internal/classifier.
+// *classifier.Orchestrator satisfies this in production.
+type classifierBackend interface {
+	IsModelLoaded(modelID string) bool
+	IsModelActive(modelID string) bool
+	ModelInfos() []classifier.ModelInfo
+	PrimaryModelInfo() classifier.ModelInfo
+	PredictModel(ctx context.Context, modelID string, sample [][]float32) ([]datastore.Results, error)
+	CurrentSettings() *conf.Settings
+	ModelSpecFor(modelID string) (classifier.ModelSpec, bool)
+}
+
 // BufferManager handles the lifecycle of analysis buffer monitors
 type BufferManager struct {
 	monitors  sync.Map // keyed by monitorKey -> chan struct{}
-	bn        *classifier.Orchestrator
+	bn        classifierBackend
 	bufferMgr *buffer.Manager
 	quitChan  chan struct{}
 	wg        *sync.WaitGroup

--- a/internal/analysis/buffer_manager_test.go
+++ b/internal/analysis/buffer_manager_test.go
@@ -63,6 +63,91 @@ func TestProcessMonitorTick_SkipsWhenModelNotLoaded(t *testing.T) {
 		"the warning is emitted once per monitor, not on every tick")
 }
 
+// scriptedModelState is a classifierBackend fake that drives processMonitorTick
+// through the not-loaded -> loaded resume transition a real Orchestrator only
+// reaches with fully loaded models (its models map and bat scheduler are
+// package-private to internal/classifier). The embedded interface is nil: only
+// IsModelLoaded and IsModelActive are exercised by this test; the remaining
+// classifierBackend methods would panic if called, which they never are because
+// the model is kept inactive so ProcessData is not reached.
+type scriptedModelState struct {
+	classifierBackend
+	loaded     []bool // IsModelLoaded return per call; the final entry repeats
+	loadedCall int
+	active     bool // IsModelActive return
+}
+
+func (s *scriptedModelState) IsModelLoaded(string) bool {
+	if len(s.loaded) == 0 {
+		return false
+	}
+	i := s.loadedCall
+	if i >= len(s.loaded) {
+		i = len(s.loaded) - 1
+	}
+	s.loadedCall++
+	return s.loaded[i]
+}
+
+func (s *scriptedModelState) IsModelActive(string) bool { return s.active }
+
+// TestProcessMonitorTick_ResumesWhenModelReloads covers the resume/recovery path:
+// once a monitor has warned that its model is not loaded, a later tick that finds
+// the model loaded again must log the resume line exactly once and clear the
+// warn-once latch. IsModelActive is false so the tick returns before ProcessData,
+// exercising the resume block without driving the full inference pipeline.
+func TestProcessMonitorTick_ResumesWhenModelReloads(t *testing.T) {
+	t.Parallel()
+
+	const (
+		sourceID = "src"
+		modelID  = "Perch_V2"
+		readSize = 480
+	)
+
+	mgr := buffer.NewManager(logger.NewSlogLogger(io.Discard, logger.LogLevelError, time.UTC))
+	require.NoError(t, mgr.AllocateAnalysis(sourceID, modelID, readSize*2, 0, readSize))
+	ab, err := mgr.AnalysisBuffer(sourceID, modelID)
+	require.NoError(t, err)
+
+	var logBuf bytes.Buffer
+	// loaded=false on tick 1 (model unloaded), true afterwards. active=false so the
+	// resume block is reached but ProcessData is never dispatched.
+	state := &scriptedModelState{loaded: []bool{false, true}, active: false}
+	bm := &BufferManager{
+		bn:        state,
+		bufferMgr: mgr,
+		logger:    logger.NewSlogLogger(&logBuf, logger.LogLevelDebug, time.UTC),
+	}
+
+	cfg := &monitorConfig{sourceID: sourceID, modelID: modelID, readSize: readSize}
+	quit := make(chan struct{})
+	tickState := &monitorTickState{}
+
+	// Tick 1: model not loaded -> warn once, latch set, no dispatch.
+	require.NoError(t, ab.Write(make([]byte, readSize)))
+	require.True(t, bm.processMonitorTick(quit, cfg, readSize, 0, tickState, 1))
+	assert.Contains(t, logBuf.String(), "model not loaded, skipping inference window")
+	assert.True(t, tickState.notLoadedWarned, "the warn-once latch is set after the first skip")
+
+	// Tick 2: model came back -> resume log fires once and the latch resets.
+	logBuf.Reset()
+	require.NoError(t, ab.Write(make([]byte, readSize)))
+	require.True(t, bm.processMonitorTick(quit, cfg, readSize, 0, tickState, 2))
+	assert.Contains(t, logBuf.String(), "model loaded again, resuming inference",
+		"the resume log fires when the model reloads")
+	assert.False(t, tickState.notLoadedWarned, "the warn-once latch resets on resume")
+	assert.NotContains(t, logBuf.String(), "buffer monitor dispatching to ProcessData",
+		"an inactive model must not dispatch to ProcessData")
+
+	// Tick 3: still loaded and inactive, latch already clear -> no repeated resume log.
+	logBuf.Reset()
+	require.NoError(t, ab.Write(make([]byte, readSize)))
+	require.True(t, bm.processMonitorTick(quit, cfg, readSize, 0, tickState, 3))
+	assert.NotContains(t, logBuf.String(), "model loaded again, resuming inference",
+		"the resume log fires once, not on every subsequent tick")
+}
+
 func TestMonitorConfig_ReadSize(t *testing.T) {
 	t.Parallel()
 

--- a/internal/analysis/process.go
+++ b/internal/analysis/process.go
@@ -250,7 +250,7 @@ func SetProcessMetrics(myAudioMetrics *metrics.MyAudioMetrics) {
 // bufMgr is the audiocore buffer manager owning the Float32Pool that the
 // 16-bit conversion hot path draws from. Must be non-nil; callers that reach
 // ProcessData without a manager have a plumbing bug.
-func ProcessData(ctx context.Context, bn *classifier.Orchestrator, bufMgr *buffer.Manager, data []byte, startTime, audioCapturedAt time.Time, source, modelID string) error {
+func ProcessData(ctx context.Context, bn classifierBackend, bufMgr *buffer.Manager, data []byte, startTime, audioCapturedAt time.Time, source, modelID string) error {
 	if bufMgr == nil {
 		return errors.Newf("buffer manager must not be nil").
 			Component("analysis").

--- a/internal/classifier/openvino_dispatch_test.go
+++ b/internal/classifier/openvino_dispatch_test.go
@@ -31,7 +31,7 @@ func newCaptureLogger(t *testing.T) *bytes.Buffer {
 		capture,
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = cl.Close() })
+	t.Cleanup(func() { assert.NoError(t, cl.Close()) })
 	prev := logger.Global()
 	logger.SetGlobal(cl)
 	t.Cleanup(func() { logger.SetGlobal(prev) })

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -5,6 +5,7 @@ package classifier
 import (
 	"context"
 	"fmt"
+	"iter"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -1819,6 +1820,15 @@ func (o *Orchestrator) Delete() {
 
 // IsModelLoaded returns true if a model with the given registry ID is
 // currently loaded in the orchestrator.
+//
+// This takes o.mu.RLock, unlike its sibling IsModelActive which is deliberately
+// lock-free: IsModelActive reads only the scheduler atomic.Pointer, while the
+// models map read here is mutable state guarded by o.mu (ReloadModel, Delete, and
+// the loaders all mutate it under the write lock). The asymmetry is intentional.
+// On the monitor tick the RLock is reached only once a full analysis window is
+// present and sits directly before a millisecond-scale inference, so it was
+// measured as negligible; a lock-free models map is not worth the copy-on-write
+// machinery it would require.
 func (o *Orchestrator) IsModelLoaded(registryID string) bool {
 	o.mu.RLock()
 	defer o.mu.RUnlock()
@@ -2087,11 +2097,11 @@ func (o *Orchestrator) modelNotLoadedReason(modelID string) string {
 
 // modelIDEnabled reports whether registryID corresponds to a model the user has
 // enabled: an entry in settings.Models.Enabled once its config alias is resolved
-// to a registry ID. Mirrors loadAdditionalModels' own resolution so the two agree
-// on what "enabled" means.
+// to a registry ID. Uses the shared enabledModels walk, so it agrees with
+// computeThreadAllocation and loadAdditionalModels on what "enabled" means.
 func (o *Orchestrator) modelIDEnabled(registryID string) bool {
-	for _, configID := range o.currentSettings().Models.Enabled {
-		if resolved, known := ResolveConfigModelID(configID); known && resolved == registryID {
+	for m := range enabledModels(o.currentSettings()) {
+		if m.known && m.registryID == registryID {
 			return true
 		}
 	}
@@ -2395,6 +2405,33 @@ func (o *Orchestrator) ModelInfos() []ModelInfo {
 	return infos
 }
 
+// enabledModel is one entry of settings.Models.Enabled resolved against the
+// model registry.
+type enabledModel struct {
+	configID   string // the raw ID as written in models.enabled
+	registryID string // the resolved registry ID (empty when known is false)
+	known      bool   // whether configID resolved to a registry model
+}
+
+// enabledModels yields each settings.Models.Enabled entry in config order,
+// resolved to its registry ID. It centralizes the settings.Models.Enabled ->
+// ResolveConfigModelID walk shared by modelIDEnabled, computeThreadAllocation,
+// and loadAdditionalModels so the three stay in step. Unknown config IDs are
+// yielded with known=false so each caller decides whether to warn or skip;
+// deduplication is left to the callers that need it (computeThreadAllocation
+// tracks a seen-set, loadAdditionalModels relies on the models-map existence
+// check), so the helper preserves each caller's existing behavior.
+func enabledModels(settings *conf.Settings) iter.Seq[enabledModel] {
+	return func(yield func(enabledModel) bool) {
+		for _, configID := range settings.Models.Enabled {
+			registryID, known := ResolveConfigModelID(configID)
+			if !yield(enabledModel{configID: configID, registryID: registryID, known: known}) {
+				return
+			}
+		}
+	}
+}
+
 // computeThreadAllocation pre-computes thread distribution for all models
 // that will be loaded. Inference is serialized by inferenceMu, so each model
 // gets the full thread budget (they never run simultaneously).
@@ -2403,13 +2440,12 @@ func (o *Orchestrator) computeThreadAllocation(settings *conf.Settings, primaryI
 	// case variants like ["perch_v2", "PERCH_V2"] that resolve to the same ID.
 	seen := map[string]bool{primaryID: true}
 	modelIDs := []string{primaryID}
-	for _, configID := range settings.Models.Enabled {
-		registryID, known := ResolveConfigModelID(configID)
-		if !known || seen[registryID] {
+	for m := range enabledModels(settings) {
+		if !m.known || seen[m.registryID] {
 			continue
 		}
-		seen[registryID] = true
-		modelIDs = append(modelIDs, registryID)
+		seen[m.registryID] = true
+		modelIDs = append(modelIDs, m.registryID)
 	}
 
 	total := settings.BirdNET.Threads
@@ -2466,13 +2502,13 @@ func (o *Orchestrator) loadAdditionalModels(threadAlloc map[string]int) error {
 	// o.Settings pointer, consistent with the per-model loaders (loadPerch/loadBat).
 	settings := o.currentSettings()
 
-	for _, configID := range settings.Models.Enabled {
-		registryID, known := ResolveConfigModelID(configID)
-		if !known {
+	for m := range enabledModels(settings) {
+		if !m.known {
 			log.Warn("skipping unknown model ID in models.enabled",
-				logger.String("model_id", configID))
+				logger.String("model_id", m.configID))
 			continue
 		}
+		registryID := m.registryID
 
 		// Closure with defer ensures the mutex is released even if a
 		// loader panics during model initialization.

--- a/internal/classifier/orchestrator_test.go
+++ b/internal/classifier/orchestrator_test.go
@@ -376,6 +376,68 @@ func TestOrchestrator_LoadAdditionalModels_UnknownModelSkipped(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestEnabledModels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		enabled []string
+		want    []enabledModel
+	}{
+		{
+			name:    "empty yields nothing",
+			enabled: nil,
+			want:    nil,
+		},
+		{
+			name:    "known IDs resolve in config order",
+			enabled: []string{conf.ModelIDPerchV2, conf.ModelIDBirdNET},
+			want: []enabledModel{
+				{configID: conf.ModelIDPerchV2, registryID: RegistryIDPerchV2, known: true},
+				{configID: conf.ModelIDBirdNET, registryID: BirdNET_V2_4, known: true},
+			},
+		},
+		{
+			name:    "unknown ID is yielded with known=false",
+			enabled: []string{"nope"},
+			want: []enabledModel{
+				{configID: "nope", registryID: "", known: false},
+			},
+		},
+		{
+			name:    "case variants are yielded without deduplication",
+			enabled: []string{conf.ModelIDPerchV2, "PERCH_V2"},
+			want: []enabledModel{
+				{configID: conf.ModelIDPerchV2, registryID: RegistryIDPerchV2, known: true},
+				{configID: "PERCH_V2", registryID: RegistryIDPerchV2, known: true},
+			},
+		},
+		{
+			name:    "mixed known and unknown preserves order across the boundary",
+			enabled: []string{conf.ModelIDBirdNET, "nope", conf.ModelIDPerchV2},
+			want: []enabledModel{
+				{configID: conf.ModelIDBirdNET, registryID: BirdNET_V2_4, known: true},
+				{configID: "nope", registryID: "", known: false},
+				{configID: conf.ModelIDPerchV2, registryID: RegistryIDPerchV2, known: true},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			settings := &conf.Settings{}
+			settings.Models.Enabled = tt.enabled
+
+			var got []enabledModel
+			for m := range enabledModels(settings) {
+				got = append(got, m)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestOrchestrator_ModelSpecFor(t *testing.T) {
 	t.Parallel()
 

--- a/internal/classifier/orchestrator_test.go
+++ b/internal/classifier/orchestrator_test.go
@@ -379,6 +379,11 @@ func TestOrchestrator_LoadAdditionalModels_UnknownModelSkipped(t *testing.T) {
 func TestEnabledModels(t *testing.T) {
 	t.Parallel()
 
+	const (
+		unknownModelID      = "nope"     // an ID that resolves to no registry model
+		upperPerchV2ModelID = "PERCH_V2" // a case variant of conf.ModelIDPerchV2
+	)
+
 	tests := []struct {
 		name    string
 		enabled []string
@@ -399,25 +404,25 @@ func TestEnabledModels(t *testing.T) {
 		},
 		{
 			name:    "unknown ID is yielded with known=false",
-			enabled: []string{"nope"},
+			enabled: []string{unknownModelID},
 			want: []enabledModel{
-				{configID: "nope", registryID: "", known: false},
+				{configID: unknownModelID, registryID: "", known: false},
 			},
 		},
 		{
 			name:    "case variants are yielded without deduplication",
-			enabled: []string{conf.ModelIDPerchV2, "PERCH_V2"},
+			enabled: []string{conf.ModelIDPerchV2, upperPerchV2ModelID},
 			want: []enabledModel{
 				{configID: conf.ModelIDPerchV2, registryID: RegistryIDPerchV2, known: true},
-				{configID: "PERCH_V2", registryID: RegistryIDPerchV2, known: true},
+				{configID: upperPerchV2ModelID, registryID: RegistryIDPerchV2, known: true},
 			},
 		},
 		{
 			name:    "mixed known and unknown preserves order across the boundary",
-			enabled: []string{conf.ModelIDBirdNET, "nope", conf.ModelIDPerchV2},
+			enabled: []string{conf.ModelIDBirdNET, unknownModelID, conf.ModelIDPerchV2},
 			want: []enabledModel{
 				{configID: conf.ModelIDBirdNET, registryID: BirdNET_V2_4, known: true},
-				{configID: "nope", registryID: "", known: false},
+				{configID: unknownModelID, registryID: "", known: false},
 				{configID: conf.ModelIDPerchV2, registryID: RegistryIDPerchV2, known: true},
 			},
 		},


### PR DESCRIPTION
## Summary

Batched low-severity follow-ups from the #4290 gate, split across two areas. No behavior change.

classifier: the `settings.Models.Enabled -> ResolveConfigModelID` walk was duplicated at three call sites (`modelIDEnabled`, `computeThreadAllocation`, `loadAdditionalModels`). They now share a single `enabledModels` iterator so the three stay in step. It inlines at every call site with no closure escape, and deduplication is left to the callers that need it, so behavior is preserved. Added `TestEnabledModels`.

analysis: extracted a consumer-side `classifierBackend` interface for `BufferManager.bn` and `ProcessData`, so the monitor resume/recovery path in `processMonitorTick` (the "model loaded again, resuming inference" log and the warn-once latch reset) can be unit-tested. A real `Orchestrator` only reaches the not-loaded to loaded transition with fully loaded models, and its models map and bat scheduler are package-private to `internal/classifier`. Added `TestProcessMonitorTick_ResumesWhenModelReloads`.

classifier: documented why `IsModelLoaded` takes the models-map RLock while its sibling `IsModelActive` is deliberately lock-free, and switched the OpenVINO dispatch test cleanup to assert `cl.Close()` instead of discarding the error.

## Test Plan

- [x] `go test -race` on `internal/analysis` and `internal/classifier`, across every build-tag combo, via the pre-push gate
- [x] `golangci-lint` clean on both packages (all 8 tag variants)
- [x] New tests cover the monitor resume/recovery path and the shared `enabledModels` iterator (including a mixed known/unknown case)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Reliability**
  - Improved monitoring recovery after a model reload, including clearer resume behavior and preventing processing while the model is inactive.
  - Preserved existing inference, buffering, metrics, and queue-handling behavior.

- **Model Configuration**
  - Improved handling of configured model IDs, including ordering, duplicate management, case variations, and unknown-model warnings.

- **Maintenance**
  - Improved validation of classifier shutdown operations and expanded automated coverage for model and monitoring behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->