### PR TITLE
fix(api): stop echo.Context use-after-recycle in SSE/streaming goroutines (#4292)

### DIFF
--- a/.github/workflows/automated-test-engineer.yml
+++ b/.github/workflows/automated-test-engineer.yml
@@ -166,7 +166,6 @@ jobs:
                   "internal/birdweather"*) PACKAGE_LABELS+=",pkg:birdweather" ;;
                   "internal/security"*) PACKAGE_LABELS+=",pkg:security" ;;
                   "internal/conf"*) PACKAGE_LABELS+=",pkg:conf" ;;
-                  "internal/httpcontroller"*) PACKAGE_LABELS+=",pkg:httpcontroller" ;;
                   "internal/errors"*) PACKAGE_LABELS+=",pkg:errors" ;;
                   "internal/logging"*) PACKAGE_LABELS+=",pkg:logging" ;;
                   "internal/testing"*) PACKAGE_LABELS+=",pkg:testing" ;;

--- a/internal/api/v2/apicore/sse.go
+++ b/internal/api/v2/apicore/sse.go
@@ -2,7 +2,6 @@ package apicore
 
 import (
 	"fmt"
-	"net/http"
 	"path/filepath"
 	"sync"
 	"sync/atomic"
@@ -173,9 +172,7 @@ type SSEClient struct {
 	ID             string
 	Channel        chan SSEDetectionData
 	SoundLevelChan chan SSESoundLevelData
-	PendingChan    chan any // Channel for pending detection snapshots ([]SSEPendingDetection from processor)
-	Request        *http.Request
-	Response       http.ResponseWriter
+	PendingChan    chan any      // Channel for pending detection snapshots ([]SSEPendingDetection from processor)
 	Done           chan struct{} // Signal-only buffered channel to prevent blocking
 	StreamType     string        // StreamTypeDetections, StreamTypeSoundLevels, or StreamTypeAll
 

--- a/internal/api/v2/integrations/integrations.go
+++ b/internal/api/v2/integrations/integrations.go
@@ -292,8 +292,19 @@ func runStreamingIntegrationTest[T any](
 		select {
 		case <-httpCtx.Done():
 			c.Debug("HTTP client disconnected during %s test", integrationName)
+			// Signal shutdown under writeMu, mirroring the encode-error path
+			// above. Acquiring the lock blocks until any in-progress worker
+			// final write finishes (so ctx is not recycled mid-write), and it
+			// establishes the happens-before that makes a worker later blocked
+			// on writeMu.Lock() observe the closed doneChan and skip its write.
+			// Signalling after the unlock instead would leave a window where the
+			// worker touches the recycled ctx after this handler returns, since
+			// testCtx cancellation propagates from httpCtx only after httpCtx's
+			// own Done channel is already closed (issue #4292 bug class).
+			writeMu.Lock()
 			safeDoneClose()
 			cancel()
+			writeMu.Unlock()
 			drainResultChan()
 			return nil
 		default:

--- a/internal/api/v2/integrations/integrations.go
+++ b/internal/api/v2/integrations/integrations.go
@@ -221,6 +221,23 @@ func runStreamingIntegrationTest[T any](
 			writeMu.Lock()
 			defer writeMu.Unlock()
 
+			// Re-check under the lock before touching ctx. The handler may have
+			// returned (encode error or client disconnect) while we were blocked
+			// acquiring writeMu; on those paths it closes doneChan / cancels
+			// testCtx before releasing the lock, so observing either here means
+			// the handler has gone. Writing to ctx after the handler returns
+			// touches a recycled echo.Context/Response and races with the next
+			// request that reuses it (issue #4292 bug class).
+			select {
+			case <-doneChan:
+				c.Debug("HTTP client disconnected, skipping final result")
+				return
+			case <-testCtx.Done():
+				c.Debug("Test context cancelled: %v", testCtx.Err())
+				return
+			default:
+			}
+
 			finalResult := map[string]any{
 				"elapsed_time_ms": elapsedTime,
 				"state":           "completed",
@@ -257,9 +274,14 @@ func runStreamingIntegrationTest[T any](
 				logger.String("integration", integrationName),
 				logger.Error(err),
 			)
-			writeMu.Unlock()
+			// Signal shutdown BEFORE releasing writeMu so a worker goroutine
+			// blocked on writeMu.Lock() observes the closed doneChan (and the
+			// cancelled testCtx) once it acquires the lock, and skips its final
+			// write instead of touching the recycled ctx after this handler
+			// returns (issue #4292 bug class).
 			safeDoneClose()
 			cancel()
+			writeMu.Unlock()
 			drainResultChan()
 			return nil
 		}

--- a/internal/api/v2/notifications/notifications.go
+++ b/internal/api/v2/notifications/notifications.go
@@ -147,8 +147,6 @@ type UnifiedSSEEvent struct {
 type NotificationClient struct {
 	ID           string
 	Channel      chan *notification.Notification
-	Request      *http.Request
-	Response     http.ResponseWriter
 	Done         chan struct{} // Signal-only channel for shutdown notification
 	SubscriberCh <-chan *notification.Notification
 	Context      context.Context
@@ -516,8 +514,6 @@ func (c *Handler) setupNotificationSSEClient(ctx echo.Context) (*NotificationCli
 	client := &NotificationClient{
 		ID:           clientID,
 		Channel:      make(chan *notification.Notification, notificationChannelBuffer),
-		Request:      ctx.Request(),
-		Response:     ctx.Response(),
 		Done:         make(chan struct{}, 1), // Buffered signal channel to prevent deadlock during disconnect
 		SubscriberCh: notificationCh,
 		Context:      notificationCtx,
@@ -545,9 +541,18 @@ func (c *Handler) setupNotificationSSEClient(ctx echo.Context) (*NotificationCli
 
 // setupNotificationDisconnectHandler sets up client disconnect handling with timeout
 func (c *Handler) setupNotificationDisconnectHandler(ctx echo.Context, client *NotificationClient) {
+	// Capture request-scoped values on the request goroutine, before spawning the
+	// watcher. Echo pools and recycles the echo.Context (and rebinds its
+	// *http.Request) once the handler returns, so touching ctx from a goroutine
+	// that outlives the handler reads a recycled Request whose header map a new
+	// in-flight request is concurrently writing. That is a fatal
+	// "concurrent map read and map write" (issue #4292): ctx.RealIP() reads
+	// req.Header, so it must be evaluated here, not inside the goroutine.
+	reqCtx := ctx.Request().Context()
+	clientIP := ctx.RealIP()
 	go func() {
 		// Wait for client disconnect or timeout
-		<-ctx.Request().Context().Done()
+		<-reqCtx.Done()
 
 		// Client disconnected or timeout reached
 		select {
@@ -556,7 +561,7 @@ func (c *Handler) setupNotificationDisconnectHandler(ctx echo.Context, client *N
 		case <-time.After(eventLoopCheckInterval):
 			// Done channel might be blocked, continue
 		}
-		c.logNotificationConnection(client.ID, ctx.RealIP(), "", false)
+		c.logNotificationConnection(client.ID, clientIP, "", false)
 	}()
 }
 

--- a/internal/api/v2/notifications/notifications_disconnect_test.go
+++ b/internal/api/v2/notifications/notifications_disconnect_test.go
@@ -1,0 +1,92 @@
+package notifications
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+// requestWithCancelCtx builds an *http.Request whose context can be cancelled to
+// simulate an SSE client disconnect, with the given RemoteAddr for RealIP.
+func requestWithCancelCtx(t *testing.T, remoteAddr string) (*http.Request, context.CancelFunc) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/notifications/stream", http.NoBody)
+	req.RemoteAddr = remoteAddr
+	baseCtx, cancel := context.WithCancel(t.Context())
+	return req.WithContext(baseCtx), cancel
+}
+
+// TestSetupNotificationDisconnectHandler_NoContextRaceAfterHandlerReturn is a
+// regression test for issue #4292 ("fatal error: concurrent map read and map
+// write"). The disconnect watcher goroutine outlives the SSE handler, and Echo
+// pools and recycles the echo.Context once the handler returns, rebinding its
+// *http.Request to the next in-flight request. Reading ctx (ctx.Request(),
+// ctx.RealIP()) from the watcher therefore races with the request the pooled
+// context is next bound to.
+//
+// This test simulates that recycle by swapping the context's request (and
+// writing its header map) from another goroutine while the watcher runs. Under
+// -race it fails if the watcher touches ctx after setup; it passes because the
+// watcher captures the request context and client IP up front and never reads
+// ctx afterwards.
+func TestSetupNotificationDisconnectHandler_NoContextRaceAfterHandlerReturn(t *testing.T) {
+	t.Parallel()
+
+	c := mockHandler()
+
+	e := echo.New()
+	req, cancel := requestWithCancelCtx(t, "1.1.1.1:1111")
+	defer cancel()
+	ctx := e.NewContext(req, httptest.NewRecorder())
+
+	client := &NotificationClient{
+		ID:   "race-client",
+		Done: make(chan struct{}, 1),
+	}
+
+	c.setupNotificationDisconnectHandler(ctx, client)
+
+	// Simulate Echo recycling the pooled context onto new in-flight requests
+	// while the watcher goroutine is running. Only this goroutine touches ctx;
+	// a correctly-fixed watcher never does, so there is no race. A regressed
+	// watcher reading ctx here trips the race detector.
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			next := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+			next.Header.Set(echo.HeaderXForwardedFor, "2.2.2.2")
+			next.RemoteAddr = "2.2.2.2:2222"
+			ctx.SetRequest(next)
+		}
+	})
+
+	// Unblock the watcher (client disconnect) so its post-disconnect logging
+	// (the ctx access in the pre-fix code) overlaps with the swapping goroutine.
+	cancel()
+
+	select {
+	case <-client.Done:
+		// Watcher observed the disconnect and is about to log.
+	case <-time.After(2 * time.Second):
+		close(stop)
+		wg.Wait()
+		t.Fatal("disconnect watcher did not signal client.Done")
+	}
+
+	// Keep swapping briefly so the watcher's logging step overlaps the swaps,
+	// widening the window the race detector can observe if the bug regresses.
+	time.Sleep(10 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}

--- a/internal/api/v2/sse/sse.go
+++ b/internal/api/v2/sse/sse.go
@@ -101,11 +101,9 @@ func (c *Handler) RegisterRoutes(g *echo.Group) {
 }
 
 // createSSEClient creates a new SSE client with common settings
-func createSSEClient(clientID string, ctx echo.Context, streamType string) *apicore.SSEClient {
+func createSSEClient(clientID, streamType string) *apicore.SSEClient {
 	return &apicore.SSEClient{
 		ID:         clientID,
-		Request:    ctx.Request(),
-		Response:   ctx.Response(),
 		Done:       make(chan struct{}, sseDoneChannelBuffer), // Signal-only buffered channel to prevent blocking on cleanup
 		StreamType: streamType,
 	}
@@ -152,7 +150,7 @@ func (c *Handler) handleSSEStream(ctx echo.Context, streamType, message, logPref
 
 	// Generate client ID and create client
 	clientID := apicore.GenerateCorrelationID()
-	client := createSSEClient(clientID, ctx, streamType)
+	client := createSSEClient(clientID, streamType)
 
 	// Allow custom setup
 	if setupFunc != nil {

--- a/internal/errors/README.md
+++ b/internal/errors/README.md
@@ -238,7 +238,7 @@ Components should match your package structure:
 - `suncalc`: Astronomical calculations
 - `birdnet`: AI model operations
 - `myaudio`: Audio processing
-- `http-controller`: HTTP API operations
+- `api`: HTTP API operations
 - `birdweather`: BirdWeather integration
 - `diskmanager`: Disk space management
 - `mqtt`: MQTT messaging

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -663,8 +663,6 @@ func detectCategory(err error, component string) ErrorCategory {
 		return CategoryAudio
 	case "datastore":
 		return CategoryDatabase
-	case "http-controller":
-		return CategoryHTTP
 	case "imageprovider":
 		if strings.Contains(errorMsg, "cache") {
 			return CategoryImageCache

--- a/internal/telemetry/sentry_title_test.go
+++ b/internal/telemetry/sentry_title_test.go
@@ -111,8 +111,8 @@ func TestTitleCaseComponent(t *testing.T) {
 	}{
 		{
 			name:      "http prefix",
-			component: "httpcontroller",
-			expected:  "HTTP Controller",
+			component: "httphandler",
+			expected:  "HTTP Handler",
 		},
 		{
 			name:      "rtsp prefix",
@@ -186,8 +186,8 @@ func TestGenerateErrorTitle(t *testing.T) {
 		{
 			name:      "index out of range with http component",
 			err:       errors.New("runtime error: index out of range [5] with length 3"),
-			component: "httpcontroller",
-			expected:  "HTTP Controller: Index Out of Range",
+			component: "httphandler",
+			expected:  "HTTP Handler: Index Out of Range",
 		},
 		{
 			name:      "concurrent map write with api component",
@@ -240,8 +240,8 @@ func TestGenerateErrorTitleRealWorldExamples(t *testing.T) {
 		{
 			name:      "http handler panic",
 			err:       errors.New("panic: Handler.ServeHTTP panic"),
-			component: "httpcontroller",
-			expected:  "HTTP Controller: Panic: Handler.ServeHTTP panic",
+			component: "httphandler",
+			expected:  "HTTP Handler: Panic: Handler.ServeHTTP panic",
 		},
 		{
 			name:      "database connection error",


### PR DESCRIPTION
## Summary

Fixes a `fatal error: concurrent map read and map write` crash reported in the notification SSE stream, plus a sibling instance of the same bug class in the streaming integration-test handler.

The notification SSE disconnect watcher spawned a goroutine that outlived the handler and then called `ctx.RealIP()`, which reads `req.Header`. Echo pools and recycles its `Context` via `sync.Pool` once the handler returns, rebinding the `Context` to the next in-flight request, so that read raced with `net/http` populating the new request's header map. The watcher now captures the request context and the client IP on the request goroutine before it spawns, and never touches the pooled `Context` afterwards.

The streaming integration-test handler (`runStreamingIntegrationTest`, used by the MQTT and BirdWeather "test connection" endpoints) had the same hazard on its shutdown paths: a worker goroutine could enter its final-write branch, block on the write mutex, and only acquire it after the handler had returned, then write to a recycled `Context` (a data race plus cross-request response corruption). The worker now re-checks the shutdown channels under the write mutex before writing, and both handler termination paths (encode error and client disconnect) signal shutdown while holding that mutex, so a lock-blocked worker observes the shutdown and skips the stale write.

Also removes the never-read `Request`/`Response` fields from `SSEClient` and `NotificationClient`; storing request-scoped values on structs a background goroutine can reach is the footgun that invited this bug class.

Separately, removes stale references to the long-deleted `internal/httpcontroller` package: a dead error-category case, a docs example, a CI package-label mapping already covered by `internal/api`, and telemetry title-formatter test inputs retargeted to a generic example.

## Test Plan

- [x] `go test -race` passes on the affected packages (`notifications`, `integrations`, `sse`, `apicore`, `errors`, `telemetry`).
- [x] New `-race` regression test swaps the pooled context's request while the disconnect watcher runs; it fails with a data race on the pre-fix code and passes on the fix.
- [x] `golangci-lint` clean on the changed packages.

## Related Issues

Fixes #4292

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability for streaming integrations when clients disconnect or requests shut down.
  - Prevented notification streams from accessing expired request data, reducing race conditions and unexpected failures.
  - Ensured streaming operations signal completion and cancel promptly when errors or disconnects occur.

- **Documentation**
  - Updated HTTP API component terminology in error documentation.

- **Tests**
  - Added coverage for notification stream disconnect handling and pooled-request safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->