### PR TITLE
fix: honest model-liveness, rarity and DB-integrity status, and a dashboard crash guard

### DIFF
--- a/frontend/src/lib/desktop/features/dashboard/components/CurrentlyHearingCard.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/CurrentlyHearingCard.svelte
@@ -41,6 +41,15 @@ Props:
     return d.source + d.scientificName;
   }
 
+  // Render/dedupe key for the keyed {#each}. Includes firstDetected so the key is
+  // stable across the newest-first re-sort (no re-mount or replayed fade transition,
+  // unlike appending the loop index) and unique per pending detection. Deduping by it
+  // prevents an each_key_duplicate crash (Sentry BIRDNET-GO-2HP) while collapsing only a re-delivered
+  // identical detection, not two genuinely distinct detections at different start times.
+  function renderKey(d: PendingDetection): string {
+    return `${d.source}_${d.scientificName}_${d.firstDetected}`;
+  }
+
   // Track terminal detections and schedule their removal.
   // Use untrack() when reading retainedKeys to avoid a read-write loop
   // (this effect should only re-run when detections changes, not retainedKeys).
@@ -86,7 +95,19 @@ Props:
 
     // Sort newest first so new detections appear on the left
     result.sort((a, b) => b.firstDetected - a.firstDetected);
-    return result;
+
+    // Dedupe by the stable render key so the keyed {#each} can never see a duplicate
+    // key (each_key_duplicate white-screens the whole dashboard, Sentry BIRDNET-GO-2HP). First wins;
+    // only a re-delivered identical detection collapses, distinct start times survive.
+    const seen = new Set<string>();
+    const deduped: PendingDetection[] = [];
+    for (const d of result) {
+      const k = renderKey(d);
+      if (seen.has(k)) continue;
+      seen.add(k);
+      deduped.push(d);
+    }
+    return deduped;
   });
 
   let hasDisplayDetections = $derived(displayDetections.length > 0);
@@ -116,7 +137,10 @@ Props:
     void tick;
     const result: Record<string, string> = {};
     for (const d of displayDetections) {
-      result[detectionKey(d)] = getElapsedText(d.firstDetected);
+      // Key by renderKey, not detectionKey: two same-source/species detections at
+      // different start times now coexist (dedupe keeps them), so a source+species key
+      // would collapse them and show both chips the same elapsed time.
+      result[renderKey(d)] = getElapsedText(d.firstDetected);
     }
     return result;
   });
@@ -163,8 +187,12 @@ Props:
   <!-- Card Content -->
   {#if hasDisplayDetections}
     <div class="flex flex-wrap gap-3 p-4">
-      {#each displayDetections as detection (`${detection.source}_${detection.scientificName}`)}
-        {@const key = detection.source + detection.scientificName}
+      <!-- Keyed by a stable composite (source + species + firstDetected).
+           displayDetections is deduped by the same key, so it is unique (no
+           each_key_duplicate crash, Sentry BIRDNET-GO-2HP) and stable across the newest-first re-sort,
+           so existing chips move without re-mounting or replaying their fade. -->
+      {#each displayDetections as detection (renderKey(detection))}
+        {@const key = renderKey(detection)}
         {@const elapsedText = getElapsedForKey(key)}
         <!-- Localized common name in the visitor's UI locale; falls back to the
              server-provided common name, then the scientific name. Keeps the

--- a/frontend/src/lib/desktop/features/dashboard/components/CurrentlyHearingCard.test.ts
+++ b/frontend/src/lib/desktop/features/dashboard/components/CurrentlyHearingCard.test.ts
@@ -79,4 +79,56 @@ describe('CurrentlyHearingCard species-name localization', () => {
 
     expect(getByText('Eurasian Wren')).toBeInTheDocument();
   });
+
+  // Regression for Sentry BIRDNET-GO-2HP: two concurrent pending detections of the same species on
+  // the same source used to collide on a bare `${source}_${scientificName}` key,
+  // throwing each_key_duplicate and (no error boundary) white-screening the dashboard.
+  // displayDetections now dedupes by a stable source+species+firstDetected key.
+  it('dedupes identical pending detections to one chip instead of crashing (Sentry BIRDNET-GO-2HP)', () => {
+    // Same source, species, and firstDetected (pending() default) => one render key.
+    const { getAllByText } = card.render({
+      props: {
+        detections: [
+          pending({
+            species: 'Eurasian Wren',
+            scientificName: 'Troglodytes troglodytes',
+            source: 'mic-9',
+            sourceID: 'mic-9',
+          }),
+          pending({
+            species: 'Eurasian Wren',
+            scientificName: 'Troglodytes troglodytes',
+            source: 'mic-9',
+            sourceID: 'mic-9',
+          }),
+        ],
+      },
+    });
+    expect(getAllByText('Eurasian Wren')).toHaveLength(1);
+  });
+
+  it('keeps two same-species detections that differ only in start time (Sentry BIRDNET-GO-2HP)', () => {
+    // Distinct firstDetected => distinct render keys => both chips survive dedupe.
+    const { getAllByText } = card.render({
+      props: {
+        detections: [
+          pending({
+            species: 'Eurasian Wren',
+            scientificName: 'Troglodytes troglodytes',
+            source: 'mic-9',
+            sourceID: 'mic-9',
+            firstDetected: 1_700_000_000,
+          }),
+          pending({
+            species: 'Eurasian Wren',
+            scientificName: 'Troglodytes troglodytes',
+            source: 'mic-9',
+            sourceID: 'mic-9',
+            firstDetected: 1_700_000_005,
+          }),
+        ],
+      },
+    });
+    expect(getAllByText('Eurasian Wren')).toHaveLength(2);
+  });
 });

--- a/frontend/src/lib/desktop/features/dashboard/components/DetectionCardGrid.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/DetectionCardGrid.svelte
@@ -89,6 +89,22 @@
   let dropdownButtonRef = $state<HTMLButtonElement | undefined>(undefined);
   const limitOptions = [6, 12, 24, 48];
 
+  // Guard against a duplicate detection id in the incoming data: a repeated id in a
+  // keyed {#each} throws each_key_duplicate and, with no error boundary, white-screens
+  // the whole dashboard. De-duplicate by id (first occurrence wins) so the id key stays
+  // stable (no re-render churn, unlike appending the index) while a collision can never
+  // crash the page.
+  const uniqueData = $derived.by(() => {
+    const seen = new Set<Detection['id']>();
+    const out: Detection[] = [];
+    for (const d of data) {
+      if (seen.has(d.id)) continue;
+      seen.add(d.id);
+      out.push(d);
+    }
+    return out;
+  });
+
   // Toggle dropdown
   function toggleLimitDropdown() {
     showLimitDropdown = !showLimitDropdown;
@@ -271,7 +287,7 @@
 
         <!-- Detection Cards Grid -->
         <div class="detection-cards-grid gap-4">
-          {#each data.slice(0, selectedLimit) as detection (detection.id)}
+          {#each uniqueData.slice(0, selectedLimit) as detection (detection.id)}
             <DetectionCard
               {detection}
               isNew={newDetectionIds.has(detection.id)}

--- a/frontend/src/lib/desktop/features/dashboard/components/NewSpeciesHighlightsCard.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/NewSpeciesHighlightsCard.svelte
@@ -70,7 +70,13 @@ Shows up to 12 species, ordered by novelty category then detection count.
     // Guard against a null payload: the default [] only applies for undefined,
     // and the daily-summary endpoint can return a null body.
     if (!data) return result;
+    // Dedupe by scientific_name (first wins): the daily-summary payload can carry
+    // duplicate rows, which a bare scientific_name key would render as two tiles and,
+    // worse, throw each_key_duplicate and white-screen the dashboard (Sentry BIRDNET-GO-2HP).
+    const seen = new Set<string>();
     for (const species of data) {
+      if (seen.has(species.scientific_name)) continue;
+      seen.add(species.scientific_name);
       const category = resolveNoveltyCategory(species, { infrequentThresholdDays, isToday });
       if (category !== null) result.push({ species, category });
     }
@@ -151,6 +157,9 @@ Shows up to 12 species, ordered by novelty category then detection count.
 {:else if highlights.length > 0}
   <Card padding={false} header={cardHeader}>
     <div class="grid grid-cols-1 gap-2 px-4 pb-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      <!-- highlights is deduped by scientific_name, so a bare scientific_name key is
+           unique (no each_key_duplicate crash, Sentry BIRDNET-GO-2HP) and stable, and a duplicate
+           daily-summary row collapses to one tile instead of rendering twice. -->
       {#each visibleHighlights as { species, category } (species.scientific_name)}
         {@const percent = confidencePercent(species)}
         {@const displayName = localizeSpeciesName(species.scientific_name, species.common_name)}

--- a/frontend/src/lib/desktop/features/dashboard/components/NewSpeciesHighlightsCard.test.ts
+++ b/frontend/src/lib/desktop/features/dashboard/components/NewSpeciesHighlightsCard.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Regression test for Sentry BIRDNET-GO-2HP: the dashboard must not white-screen on duplicate
+ * {#each} keys. The daily-summary payload can carry duplicate scientific_name
+ * rows, so keying visibleHighlights by a bare scientific_name throws
+ * each_key_duplicate (Svelte 5) and, with no error boundary, takes the whole
+ * dashboard down. highlights is now deduped by scientific_name and keyed by it, so
+ * a duplicate row collapses to one tile instead of crashing or rendering twice.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { cleanup } from '@testing-library/svelte';
+import { createComponentTestFactory } from '../../../../../test/render-helpers';
+import type { DailySpeciesSummary } from '$lib/types/detection.types';
+import NewSpeciesHighlightsCard from './NewSpeciesHighlightsCard.svelte';
+
+function summary(overrides: Partial<DailySpeciesSummary> = {}): DailySpeciesSummary {
+  return {
+    scientific_name: 'Turdus merula',
+    common_name: 'Common Blackbird',
+    species_code: 'eurbla',
+    count: 3,
+    hourly_counts: new Array(24).fill(0),
+    high_confidence: true,
+    max_confidence: 0.9,
+    first_heard: '06:00:00',
+    latest_heard: '07:00:00',
+    thumbnail_url: '',
+    // is_new_species makes resolveNoveltyCategory return 'lifetime' with no store
+    // dependency, so the row reaches visibleHighlights regardless of tracking config.
+    is_new_species: true,
+    ...overrides,
+  };
+}
+
+const card = createComponentTestFactory(NewSpeciesHighlightsCard);
+
+describe('NewSpeciesHighlightsCard', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('dedupes duplicate scientific_name rows to one tile instead of crashing (Sentry BIRDNET-GO-2HP)', () => {
+    // Two rows with the same scientific_name both qualify as new species. A bare
+    // scientific_name key would collide (each_key_duplicate); the highlights list now
+    // dedupes by scientific_name, so it renders one tile, not two, and does not throw.
+    const { getAllByText } = card.render({
+      props: { data: [summary(), summary()], selectedDate: '2026-09-07', isToday: true },
+    });
+
+    expect(getAllByText('Common Blackbird')).toHaveLength(1);
+  });
+});

--- a/frontend/src/lib/desktop/views/SystemInference.svelte
+++ b/frontend/src/lib/desktop/views/SystemInference.svelte
@@ -1011,6 +1011,7 @@
             {@const throughputLatest =
               throughputSeries.length > 0 ? throughputSeries[throughputSeries.length - 1] : 0}
             {@const isActive = throughputSeries.length > 0 && throughputLatest > 0}
+            {@const notAnalyzing = model.sources.some(s => s.notRunning)}
             <div
               class="bg-[var(--surface-100)] border border-[var(--border-100)] rounded-xl p-4 shadow-sm flex flex-col gap-3"
             >
@@ -1045,6 +1046,25 @@
                           class="text-muted">&nbsp;({model.scheduleLabel})</span
                         >{/if}
                     </span>
+                  </span>
+                {:else if notAnalyzing && !isActive}
+                  <!-- A source assigned to this model is not sending it audio AND the
+                       model is producing no throughput, so it is genuinely not analyzing.
+                       Surface it in the dominant header slot rather than a benign "Idle"
+                       (#4209). Gated on !isActive so a multi-source model still analyzing
+                       via another source reads "active", not a misleading blanket "not
+                       analyzing"; the specific down source is still flagged by its badge
+                       below. Precedence: paused > not-analyzing > active > idle. -->
+                  <span
+                    class="ml-auto flex items-center gap-1.5"
+                    role="status"
+                    aria-label={t('system.inference.modelNotAnalyzingTooltip')}
+                    title={t('system.inference.modelNotAnalyzingTooltip')}
+                  >
+                    <TriangleAlert class="w-3 h-3 shrink-0 text-red-500" aria-hidden="true" />
+                    <span class="text-xs font-medium text-red-600 dark:text-red-400"
+                      >{t('system.inference.sourceNotRunning')}</span
+                    >
                   </span>
                 {:else}
                   <span
@@ -1319,17 +1339,19 @@
                 {#if model.sources.length === 0}
                   <span class="text-xs text-muted">{t('system.inference.noSources')}</span>
                 {:else}
+                  {@const notAnalyzingHelpId = `model-not-analyzing-${model.id}`}
                   <div class="flex flex-wrap gap-1.5">
-                    {#each model.sources as source, sourceIdx}
-                      {@const notRunningHelpId = `source-not-running-${model.id}-${sourceIdx}`}
+                    {#each model.sources as source}
+                      <!-- notRunning uses the filled (not outline) error variant: the
+                           outline variant's transparent background failed WCAG AA
+                           contrast at this size (#4209). -->
                       <Badge
                         variant={source.notRunning ? 'error' : 'ghost'}
-                        outline={source.notRunning}
                         size="sm"
                         title={source.notRunning
                           ? t('system.inference.sourceNotRunningTooltip')
                           : undefined}
-                        aria-describedby={source.notRunning ? notRunningHelpId : undefined}
+                        aria-describedby={source.notRunning ? notAnalyzingHelpId : undefined}
                       >
                         {source.name}{#if source.type}
                           <span class={source.notRunning ? 'ml-1' : 'text-muted ml-1'}
@@ -1345,13 +1367,21 @@
                           </span>
                         {/if}
                       </Badge>
-                      {#if source.notRunning}
-                        <span id={notRunningHelpId} class="sr-only">
-                          {t('system.inference.sourceNotRunningTooltip')}
-                        </span>
-                      {/if}
                     {/each}
                   </div>
+                  <!-- Persistent, visible reason so keyboard and touch users get the
+                       cause without a hover (frontend/CLAUDE.md: no ambiguous states).
+                       Each not-analyzing badge references it via aria-describedby for
+                       screen readers. It points at this page, not the model gallery,
+                       which has no per-source liveness view (#4209). -->
+                  {#if notAnalyzing}
+                    <p
+                      id={notAnalyzingHelpId}
+                      class="text-xs text-red-600 dark:text-red-400 mt-1.5 leading-snug"
+                    >
+                      {t('system.inference.sourceNotRunningTooltip')}
+                    </p>
+                  {/if}
                 {/if}
               </div>
             </div>

--- a/frontend/src/lib/desktop/views/SystemInference.test.ts
+++ b/frontend/src/lib/desktop/views/SystemInference.test.ts
@@ -262,13 +262,16 @@ describe('SystemInference', () => {
 
   // The "not analyzing" source chip. The i18n stub returns the key for unmapped
   // strings, so assertions target the key names. The Badge component renders a
-  // <span>; its error+outline variant is identified by the CSS custom property
-  // classes, and its help text is an sr-only span referenced by aria-describedby.
+  // <span>; the not-running chip uses the FILLED error variant (contrast-safe,
+  // #4209), and the reason is a single visible per-model element referenced by
+  // aria-describedby, shared by every not-running badge on that model.
   describe('not-analyzing source chip', () => {
     /** The Badge outer spans that carry the not-running help association. */
     function notRunningBadges(container: HTMLElement): HTMLSpanElement[] {
       return Array.from(
-        container.querySelectorAll<HTMLSpanElement>('span[aria-describedby^="source-not-running-"]')
+        container.querySelectorAll<HTMLSpanElement>(
+          'span[aria-describedby^="model-not-analyzing-"]'
+        )
       );
     }
 
@@ -291,9 +294,12 @@ describe('SystemInference', () => {
       const badges = notRunningBadges(container);
       expect(badges).toHaveLength(1);
       const badge = badges[0];
-      // error + outline variant classes from Badge.svelte.
-      expect(badge.className).toContain('text-[var(--color-error)]');
-      expect(badge.className).toContain('border-[var(--color-error)]');
+      // Filled error variant from Badge.svelte (contrast-safe): opaque error
+      // background with the matching content token, NOT the transparent outline
+      // variant that failed WCAG AA (#4209).
+      expect(badge.className).toContain('bg-[var(--color-error)]');
+      expect(badge.className).toContain('text-[var(--color-error-content)]');
+      expect(badge.className).not.toContain('bg-transparent');
       expect(badge.getAttribute('title')).toBe('system.inference.sourceNotRunningTooltip');
     });
 
@@ -356,12 +362,12 @@ describe('SystemInference', () => {
       expect(help?.textContent).toContain('system.inference.sourceNotRunningTooltip');
     });
 
-    it('renders the label once and generates unique help ids when only one of several sources is not running', async () => {
+    it('shares one per-model reason element across every not-running source, with a unique id', async () => {
       const model = makeModel({
         sources: [
           { id: 'a', name: 'Front Yard', type: 'soundcard', fallback: false },
           { id: 'b', name: 'Back Yard', type: 'rtsp', fallback: false, notRunning: true },
-          { id: 'c', name: 'Garage', type: 'soundcard', fallback: false },
+          { id: 'c', name: 'Garage', type: 'soundcard', fallback: false, notRunning: true },
         ],
       });
       installApi(makeSnapshot([model]));
@@ -372,24 +378,51 @@ describe('SystemInference', () => {
         expect(container.textContent).toContain('Back Yard');
       });
 
-      // Exactly one source is flagged, so exactly one badge carries the association
-      // and one help element exists.
+      // Two sources are flagged, so two badges carry the association, but the reason
+      // is a single shared per-model element (#4209).
       const badges = notRunningBadges(container);
-      expect(badges).toHaveLength(1);
+      expect(badges).toHaveLength(2);
 
-      const helpSpans = Array.from(
-        container.querySelectorAll<HTMLElement>('span[id^="source-not-running-"]')
+      const helpEls = Array.from(
+        container.querySelectorAll<HTMLElement>('[id^="model-not-analyzing-"]')
       );
-      const ids = helpSpans.map(s => s.id);
-      expect(ids).toHaveLength(1);
-      // Guards the duplicate-id family behind issue #4190: every generated id is unique.
+      expect(helpEls).toHaveLength(1);
+      expect(helpEls[0].textContent).toContain('system.inference.sourceNotRunningTooltip');
+
+      const ids = helpEls.map(el => el.id);
+      // Guards the duplicate-id family behind issue #4190: the generated id is unique.
       expect(new Set(ids).size).toBe(ids.length);
 
-      // Every aria-describedby resolves to an element that actually exists.
+      // Both not-running badges point at that same existing element.
       for (const badge of badges) {
         const helpId = badge.getAttribute('aria-describedby');
+        expect(helpId).toBe(helpEls[0].id);
         expect(container.querySelector(`[id="${helpId}"]`)).not.toBeNull();
       }
+    });
+
+    it('shows the model header as not-analyzing rather than idle when a source is not running (#4209)', async () => {
+      const model = makeModel({
+        paused: false,
+        sources: [
+          { id: 'mic1', name: 'Front Yard', type: 'soundcard', fallback: false, notRunning: true },
+        ],
+      });
+      installApi(makeSnapshot([model]));
+
+      const { container } = inferenceTest.render({});
+
+      await waitFor(() => {
+        expect(container.textContent).toContain('Front Yard');
+      });
+
+      // The dominant header slot must reflect the attention state, not a benign
+      // "Idle" that contradicts the not-analyzing badge below it.
+      const header = container.querySelector(
+        '[aria-label="system.inference.modelNotAnalyzingTooltip"]'
+      );
+      expect(header).not.toBeNull();
+      expect(container.textContent).not.toContain('system.inference.activityIdle');
     });
   });
 

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -1377,6 +1377,7 @@ export type TranslationKey =
   | 'system.inference.primaryFallback'
   | 'system.inference.sourceNotRunning'
   | 'system.inference.sourceNotRunningTooltip'
+  | 'system.inference.modelNotAnalyzingTooltip'
   | 'system.inference.notMeasured'
   | 'system.inference.unitMs'
   | 'system.inference.unitKhz'

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -472,7 +472,7 @@
         "unreadableMessage": "Soubor modelu nakonfigurovaný pro {modelName} existuje, ale nepodařilo se jej přečíst, proto se místo něj používá nainstalovaný model v {modelPath}. Vaše konfigurace zůstala nezměněna. Zkontrolujte oprávnění souboru a to, zda je jeho úložiště připojeno.",
         "builtinMessage": "Soubor modelu nakonfigurovaný pro {modelName} nebyl na disku nalezen a není k dispozici žádný nainstalovaný model, který by jej nahradil, proto se místo něj používá vestavěný model. Vaše konfigurace zůstala nezměněna.",
         "notRegisteredTitle": "Žádný model neanalyzuje {sourceName}",
-        "notRegisteredMessage": "K {models} na zdroji zvuku \"{sourceName}\" se nedostává žádný zvuk, takže se nevytvářejí žádné detekce. Otevřete galerii modelů v Nastavení a zkontrolujte stav."
+        "notRegisteredMessage": "K {models} na zdroji zvuku \"{sourceName}\" se nedostává žádný zvuk, takže se nevytvářejí žádné detekce. Otevřete Systém > Modely AI, zkontrolujte jeho stav pro jednotlivé zdroje a ověřte, že je zdroj zvuku připojen a odesílá zvuk."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1779,7 +1779,8 @@
       "noSources": "Žádné připojené zdroje",
       "primaryFallback": "primární (záložní)",
       "sourceNotRunning": "neanalyzuje",
-      "sourceNotRunningTooltip": "Tento zdroj je v nastavení přiřazen k modelu, ale jeho zvuk se k modelu nedostává, takže nevytváří žádné detekce. Otevřete galerii modelů v Nastavení a zkontrolujte jeho stav.",
+      "sourceNotRunningTooltip": "Tento zdroj je v nastavení přiřazen k modelu, ale jeho zvuk se k modelu nedostává, takže nevytváří žádné detekce. Zkontrolujte, zda je zdroj zvuku připojen a odesílá zvuk.",
+      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
       "notMeasured": "n/a",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -1780,7 +1780,7 @@
       "primaryFallback": "primární (záložní)",
       "sourceNotRunning": "neanalyzuje",
       "sourceNotRunningTooltip": "Tento zdroj je v nastavení přiřazen k modelu, ale jeho zvuk se k modelu nedostává, takže nevytváří žádné detekce. Zkontrolujte, zda je zdroj zvuku připojen a odesílá zvuk.",
-      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
+      "modelNotAnalyzingTooltip": "Jeden nebo více zdrojů zvuku přiřazených k tomuto modelu mu neposílá zvuk, takže nevytváří žádné detekce. Viz níže uvedené zdroje.",
       "notMeasured": "n/a",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -1780,7 +1780,7 @@
       "primaryFallback": "primær (fallback)",
       "sourceNotRunning": "analyserer ikke",
       "sourceNotRunningTooltip": "Denne kilde er tildelt modellen i indstillingerne, men dens lyd når ikke modellen, så den producerer ingen detektioner. Kontrollér, at lydkilden er forbundet og sender lyd.",
-      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
+      "modelNotAnalyzingTooltip": "En eller flere lydkilder tildelt denne model sender ikke lyd til den, så den producerer ingen detektioner. Se kilderne anført nedenfor.",
       "notMeasured": "n/a",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -472,7 +472,7 @@
         "unreadableMessage": "Modelfilen, der er konfigureret til {modelName}, findes, men kunne ikke læses, så den installerede model på {modelPath} bruges i stedet. Din konfiguration blev ikke ændret. Kontrollér filens tilladelser, og at dens lager er monteret.",
         "builtinMessage": "Modelfilen, der er konfigureret til {modelName}, blev ikke fundet på disken, og der er ingen installeret model tilgængelig til at erstatte den, så den indbyggede model bruges i stedet. Din konfiguration blev ikke ændret.",
         "notRegisteredTitle": "Ingen model analyserer {sourceName}",
-        "notRegisteredMessage": "Ingen lyd når {models} på lydkilden \"{sourceName}\", så der produceres ingen detektioner. Åbn modelgalleriet i Indstillinger for at tjekke status."
+        "notRegisteredMessage": "Ingen lyd når {models} på lydkilden \"{sourceName}\", så der produceres ingen detektioner. Åbn System > AI-modeller for at tjekke dens status for hver kilde, og bekræft, at lydkilden er forbundet og sender lyd."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1779,7 +1779,8 @@
       "noSources": "Ingen kilder tilsluttet",
       "primaryFallback": "primær (fallback)",
       "sourceNotRunning": "analyserer ikke",
-      "sourceNotRunningTooltip": "Denne kilde er tildelt modellen i indstillingerne, men dens lyd når ikke modellen, så den producerer ingen detektioner. Åbn modelgalleriet i Indstillinger for at tjekke dens status.",
+      "sourceNotRunningTooltip": "Denne kilde er tildelt modellen i indstillingerne, men dens lyd når ikke modellen, så den producerer ingen detektioner. Kontrollér, at lydkilden er forbundet og sender lyd.",
+      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
       "notMeasured": "n/a",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -472,7 +472,7 @@
         "unreadableMessage": "Die für {modelName} konfigurierte Modelldatei ist vorhanden, konnte aber nicht gelesen werden, daher wird stattdessen das installierte Modell unter {modelPath} verwendet. Ihre Konfiguration wurde nicht verändert. Überprüfen Sie die Dateiberechtigungen und ob der Speicher eingebunden ist.",
         "builtinMessage": "Die für {modelName} konfigurierte Modelldatei wurde nicht auf dem Datenträger gefunden und es ist kein installiertes Modell als Ersatz verfügbar, daher wird stattdessen das integrierte Modell verwendet. Ihre Konfiguration wurde nicht verändert.",
         "notRegisteredTitle": "Kein Modell analysiert {sourceName}",
-        "notRegisteredMessage": "Kein Audio erreicht {models} an der Audioquelle \"{sourceName}\", sodass keine Erkennungen erzeugt werden. Öffnen Sie die Modellgalerie unter Einstellungen, um den Status zu überprüfen."
+        "notRegisteredMessage": "Kein Audio erreicht {models} an der Audioquelle \"{sourceName}\", sodass keine Erkennungen erzeugt werden. Öffnen Sie System > KI-Modelle, um den Status pro Quelle zu überprüfen, und stellen Sie sicher, dass die Audioquelle verbunden ist und Audio sendet."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1779,7 +1779,8 @@
       "noSources": "Keine Quellen verbunden",
       "primaryFallback": "Primär (Fallback)",
       "sourceNotRunning": "analysiert nicht",
-      "sourceNotRunningTooltip": "Diese Quelle ist dem Modell in den Einstellungen zugewiesen, aber ihre Audiodaten erreichen das Modell nicht, sodass keine Erkennungen erzeugt werden. Öffnen Sie die Modellgalerie unter Einstellungen, um den Status zu überprüfen.",
+      "sourceNotRunningTooltip": "Diese Quelle ist dem Modell in den Einstellungen zugewiesen, aber ihre Audiodaten erreichen das Modell nicht, sodass keine Erkennungen erzeugt werden. Überprüfen Sie, ob die Audioquelle verbunden ist und Audio sendet.",
+      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
       "notMeasured": "n.v.",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -1780,7 +1780,7 @@
       "primaryFallback": "Primär (Fallback)",
       "sourceNotRunning": "analysiert nicht",
       "sourceNotRunningTooltip": "Diese Quelle ist dem Modell in den Einstellungen zugewiesen, aber ihre Audiodaten erreichen das Modell nicht, sodass keine Erkennungen erzeugt werden. Überprüfen Sie, ob die Audioquelle verbunden ist und Audio sendet.",
-      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
+      "modelNotAnalyzingTooltip": "Eine oder mehrere diesem Modell zugewiesene Audioquellen senden ihm kein Audio, sodass keine Erkennungen erzeugt werden. Siehe die unten aufgeführten Quellen.",
       "notMeasured": "n.v.",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -472,7 +472,7 @@
         "unreadableMessage": "The model file configured for {modelName} exists but could not be read, so the installed model at {modelPath} is being used instead. Your configuration was left unchanged. Check the file's permissions and that its storage is mounted.",
         "builtinMessage": "The model file configured for {modelName} was not found on disk and no installed model is available to replace it, so the built-in model is being used instead. Your configuration was left unchanged.",
         "notRegisteredTitle": "No model is analyzing {sourceName}",
-        "notRegisteredMessage": "No audio is reaching {models} on audio source \"{sourceName}\", so no detections are produced. Open the model gallery in Settings to check status."
+        "notRegisteredMessage": "No audio is reaching {models} on audio source \"{sourceName}\", so no detections are produced. Open System > AI Models to check its per-source status, and confirm the audio source is connected and sending audio."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1779,7 +1779,8 @@
       "noSources": "No sources attached",
       "primaryFallback": "primary (fallback)",
       "sourceNotRunning": "not analyzing",
-      "sourceNotRunningTooltip": "This source is assigned to the model in settings, but its audio is not reaching the model, so it produces no detections. Open the model gallery in Settings to check its status.",
+      "sourceNotRunningTooltip": "This source is assigned to the model in settings, but its audio is not reaching the model, so it produces no detections. Check that the audio source is connected and sending audio.",
+      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
       "notMeasured": "n/a",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -1780,7 +1780,7 @@
       "primaryFallback": "principal (respaldo)",
       "sourceNotRunning": "no está analizando",
       "sourceNotRunningTooltip": "Esta fuente está asignada al modelo en la configuración, pero su audio no llega al modelo, por lo que no genera detecciones. Compruebe que la fuente de audio esté conectada y enviando audio.",
-      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
+      "modelNotAnalyzingTooltip": "Una o más fuentes de audio asignadas a este modelo no le están enviando audio, por lo que no genera detecciones. Consulte las fuentes enumeradas a continuación.",
       "notMeasured": "n/d",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -472,7 +472,7 @@
         "unreadableMessage": "El archivo de modelo configurado para {modelName} existe pero no se pudo leer, por lo que en su lugar se está usando el modelo instalado en {modelPath}. Su configuración no se modificó. Compruebe los permisos del archivo y que su almacenamiento esté montado.",
         "builtinMessage": "El archivo de modelo configurado para {modelName} no se encontró en el disco y no hay ningún modelo instalado disponible para reemplazarlo, por lo que en su lugar se está usando el modelo integrado. Su configuración no se modificó.",
         "notRegisteredTitle": "Ningún modelo está analizando {sourceName}",
-        "notRegisteredMessage": "No llega audio a {models} en la fuente de audio \"{sourceName}\", por lo que no se generan detecciones. Abra la galería de modelos en Configuración para comprobar el estado."
+        "notRegisteredMessage": "No llega audio a {models} en la fuente de audio \"{sourceName}\", por lo que no se generan detecciones. Abra Sistema > Modelos de IA para comprobar su estado por fuente y confirmar que la fuente de audio esté conectada y enviando audio."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1779,7 +1779,8 @@
       "noSources": "No hay fuentes conectadas",
       "primaryFallback": "principal (respaldo)",
       "sourceNotRunning": "no está analizando",
-      "sourceNotRunningTooltip": "Esta fuente está asignada al modelo en la configuración, pero su audio no llega al modelo, por lo que no genera detecciones. Abra la galería de modelos en Configuración para comprobar su estado.",
+      "sourceNotRunningTooltip": "Esta fuente está asignada al modelo en la configuración, pero su audio no llega al modelo, por lo que no genera detecciones. Compruebe que la fuente de audio esté conectada y enviando audio.",
+      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
       "notMeasured": "n/d",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -1780,7 +1780,7 @@
       "primaryFallback": "ensisijainen (vara)",
       "sourceNotRunning": "ei analysoida",
       "sourceNotRunningTooltip": "Tämä lähde on liitetty malliin asetuksissa, mutta sen ääni ei tavoita mallia, joten se ei tuota havaintoja. Tarkista, että äänilähde on yhdistetty ja lähettää ääntä.",
-      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
+      "modelNotAnalyzingTooltip": "Yksi tai useampi tähän malliin liitetyistä äänilähteistä ei lähetä sille ääntä, joten se ei tuota havaintoja. Katso alla luetellut lähteet.",
       "notMeasured": "-",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -472,7 +472,7 @@
         "unreadableMessage": "Mallille {modelName} määritetty mallitiedosto on olemassa, mutta sitä ei voitu lukea, joten sen sijaan käytetään asennettua mallia sijainnissa {modelPath}. Asetuksiasi ei muutettu. Tarkista tiedoston käyttöoikeudet ja se, että sen tallennustila on liitetty.",
         "builtinMessage": "Mallille {modelName} määritettyä mallitiedostoa ei löytynyt levyltä eikä korvaavaa asennettua mallia ole saatavilla, joten sen sijaan käytetään sisäänrakennettua mallia. Asetuksiasi ei muutettu.",
         "notRegisteredTitle": "Mikään malli ei analysoi kohdetta {sourceName}",
-        "notRegisteredMessage": "Ääni ei tavoita kohdetta {models} äänilähteessä \"{sourceName}\", joten havaintoja ei tuoteta. Avaa Asetusten malligalleria tarkistaaksesi tilan."
+        "notRegisteredMessage": "Ääni ei tavoita kohdetta {models} äänilähteessä \"{sourceName}\", joten havaintoja ei tuoteta. Avaa Järjestelmä > Tekoälymallit tarkistaaksesi sen lähdekohtaisen tilan ja varmistaaksesi, että äänilähde on yhdistetty ja lähettää ääntä."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1779,7 +1779,8 @@
       "noSources": "Ei liitettyjä lähteitä",
       "primaryFallback": "ensisijainen (vara)",
       "sourceNotRunning": "ei analysoida",
-      "sourceNotRunningTooltip": "Tämä lähde on liitetty malliin asetuksissa, mutta sen ääni ei tavoita mallia, joten se ei tuota havaintoja. Avaa Asetusten malligalleria tarkistaaksesi sen tilan.",
+      "sourceNotRunningTooltip": "Tämä lähde on liitetty malliin asetuksissa, mutta sen ääni ei tavoita mallia, joten se ei tuota havaintoja. Tarkista, että äänilähde on yhdistetty ja lähettää ääntä.",
+      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
       "notMeasured": "-",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -472,7 +472,7 @@
         "unreadableMessage": "Le fichier de modèle configuré pour {modelName} existe mais n'a pas pu être lu, le modèle installé à l'emplacement {modelPath} est donc utilisé à la place. Votre configuration n'a pas été modifiée. Vérifiez les permissions du fichier et que son stockage est monté.",
         "builtinMessage": "Le fichier de modèle configuré pour {modelName} est introuvable sur le disque et aucun modèle installé n'est disponible pour le remplacer, le modèle intégré est donc utilisé à la place. Votre configuration n'a pas été modifiée.",
         "notRegisteredTitle": "Aucun modèle n'analyse {sourceName}",
-        "notRegisteredMessage": "Aucun audio ne parvient à {models} sur la source audio \"{sourceName}\", aucune détection n'est donc produite. Ouvrez la galerie de modèles dans les Paramètres pour vérifier l'état."
+        "notRegisteredMessage": "Aucun audio ne parvient à {models} sur la source audio \"{sourceName}\", aucune détection n'est donc produite. Ouvrez Système > Modèles IA pour vérifier son état par source et confirmer que la source audio est connectée et envoie de l'audio."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1779,7 +1779,8 @@
       "noSources": "Aucune source attachée",
       "primaryFallback": "primaire (secours)",
       "sourceNotRunning": "n'analyse pas",
-      "sourceNotRunningTooltip": "Cette source est assignée au modèle dans les paramètres, mais son audio ne parvient pas au modèle, elle ne produit donc aucune détection. Ouvrez la galerie de modèles dans les Paramètres pour vérifier son état.",
+      "sourceNotRunningTooltip": "Cette source est assignée au modèle dans les paramètres, mais son audio ne parvient pas au modèle, elle ne produit donc aucune détection. Vérifiez que la source audio est connectée et envoie de l'audio.",
+      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
       "notMeasured": "n/d",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -1780,7 +1780,7 @@
       "primaryFallback": "primaire (secours)",
       "sourceNotRunning": "n'analyse pas",
       "sourceNotRunningTooltip": "Cette source est assignée au modèle dans les paramètres, mais son audio ne parvient pas au modèle, elle ne produit donc aucune détection. Vérifiez que la source audio est connectée et envoie de l'audio.",
-      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
+      "modelNotAnalyzingTooltip": "Une ou plusieurs sources audio assignées à ce modèle ne lui envoient pas d'audio, il ne produit donc aucune détection. Voir les sources listées ci-dessous.",
       "notMeasured": "n/d",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -1780,7 +1780,7 @@
       "primaryFallback": "elsődleges (tartalék)",
       "sourceNotRunning": "nem elemzi",
       "sourceNotRunningTooltip": "Ez a forrás hozzá van rendelve a modellhez a beállításokban, de a hangja nem jut el a modellhez, így nem készít észleléseket. Ellenőrizze, hogy a hangforrás csatlakoztatva van-e és hangot küld-e.",
-      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
+      "modelNotAnalyzingTooltip": "Egy vagy több, ehhez a modellhez hozzárendelt hangforrás nem küld neki hangot, így nem készít észleléseket. Lásd az alább felsorolt forrásokat.",
       "notMeasured": "n/a",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -472,7 +472,7 @@
         "unreadableMessage": "A(z) {modelName} modellhez beállított modellfájl létezik, de nem sikerült beolvasni, ezért helyette a(z) {modelPath} helyen telepített modell van használatban. A konfigurációja változatlan maradt. Ellenőrizze a fájl jogosultságait és azt, hogy a tárolója csatolva van-e.",
         "builtinMessage": "A(z) {modelName} modellhez beállított modellfájl nem található a lemezen, és nem érhető el telepített modell a helyettesítésére, ezért helyette a beépített modell van használatban. A konfigurációja változatlan maradt.",
         "notRegisteredTitle": "Egyetlen modell sem elemzi a következőt: {sourceName}",
-        "notRegisteredMessage": "Nem jut el hang a(z) {models} számára a(z) \"{sourceName}\" hangforráson, így nem jönnek létre detektálások. Nyissa meg a modellgalériát a Beállításokban az állapot ellenőrzéséhez."
+        "notRegisteredMessage": "Nem jut el hang a(z) {models} számára a(z) \"{sourceName}\" hangforráson, így nem jönnek létre detektálások. Nyissa meg a Rendszer > AI Modellek menüpontot a forrásonkénti állapot ellenőrzéséhez, és győződjön meg róla, hogy a hangforrás csatlakoztatva van és hangot küld."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1779,7 +1779,8 @@
       "noSources": "Nincs csatlakoztatott hangforrás",
       "primaryFallback": "elsődleges (tartalék)",
       "sourceNotRunning": "nem elemzi",
-      "sourceNotRunningTooltip": "Ez a forrás hozzá van rendelve a modellhez a beállításokban, de a hangja nem jut el a modellhez, így nem készít észleléseket. Nyissa meg a modellgalériát a Beállításokban az állapotának ellenőrzéséhez.",
+      "sourceNotRunningTooltip": "Ez a forrás hozzá van rendelve a modellhez a beállításokban, de a hangja nem jut el a modellhez, így nem készít észleléseket. Ellenőrizze, hogy a hangforrás csatlakoztatva van-e és hangot küld-e.",
+      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
       "notMeasured": "n/a",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -472,7 +472,7 @@
         "unreadableMessage": "Il file del modello configurato per {modelName} esiste ma non è stato possibile leggerlo, quindi viene utilizzato il modello installato in {modelPath}. La tua configurazione non è stata modificata. Controlla i permessi del file e che il suo spazio di archiviazione sia montato.",
         "builtinMessage": "Il file del modello configurato per {modelName} non è stato trovato sul disco e nessun modello installato è disponibile per sostituirlo, quindi viene utilizzato il modello integrato. La tua configurazione non è stata modificata.",
         "notRegisteredTitle": "Nessun modello sta analizzando {sourceName}",
-        "notRegisteredMessage": "Nessun audio raggiunge {models} sulla sorgente audio \"{sourceName}\", quindi non vengono prodotti rilevamenti. Apri la galleria dei modelli in Impostazioni per verificare lo stato."
+        "notRegisteredMessage": "Nessun audio raggiunge {models} sulla sorgente audio \"{sourceName}\", quindi non vengono prodotti rilevamenti. Apri Sistema > Modelli IA per verificarne lo stato per sorgente e confermare che la sorgente audio sia connessa e invii audio."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1779,7 +1779,8 @@
       "noSources": "Nessuna sorgente collegata",
       "primaryFallback": "principale (fallback)",
       "sourceNotRunning": "non sta analizzando",
-      "sourceNotRunningTooltip": "Questa sorgente è assegnata al modello nelle impostazioni, ma il suo audio non raggiunge il modello, quindi non produce rilevamenti. Apri la galleria dei modelli in Impostazioni per verificarne lo stato.",
+      "sourceNotRunningTooltip": "Questa sorgente è assegnata al modello nelle impostazioni, ma il suo audio non raggiunge il modello, quindi non produce rilevamenti. Verifica che la sorgente audio sia connessa e invii audio.",
+      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
       "notMeasured": "n/d",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -1780,7 +1780,7 @@
       "primaryFallback": "principale (fallback)",
       "sourceNotRunning": "non sta analizzando",
       "sourceNotRunningTooltip": "Questa sorgente è assegnata al modello nelle impostazioni, ma il suo audio non raggiunge il modello, quindi non produce rilevamenti. Verifica che la sorgente audio sia connessa e invii audio.",
-      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
+      "modelNotAnalyzingTooltip": "Una o più sorgenti audio assegnate a questo modello non gli inviano audio, quindi non produce rilevamenti. Vedi le sorgenti elencate qui sotto.",
       "notMeasured": "n/d",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -472,7 +472,7 @@
         "unreadableMessage": "Modelim {modelName} konfigurētais modeļa fails pastāv, taču to nevarēja nolasīt, tāpēc tā vietā tiek izmantots instalētais modelis {modelPath}. Jūsu konfigurācija netika mainīta. Pārbaudiet faila atļaujas un to, vai tā krātuve ir montēta.",
         "builtinMessage": "Modelim {modelName} konfigurētais modeļa fails netika atrasts diskā un nav pieejams neviens instalēts modelis tā aizstāšanai, tāpēc tā vietā tiek izmantots iebūvētais modelis. Jūsu konfigurācija netika mainīta.",
         "notRegisteredTitle": "Neviens modelis neanalizē {sourceName}",
-        "notRegisteredMessage": "Audio nesasniedz {models} audio avotā \"{sourceName}\", tāpēc noteikšanas netiek veiktas. Atveriet modeļu galeriju sadaļā Iestatījumi, lai pārbaudītu statusu."
+        "notRegisteredMessage": "Audio nesasniedz {models} audio avotā \"{sourceName}\", tāpēc noteikšanas netiek veiktas. Atveriet Sistēma > MI Modeļi, lai pārbaudītu tā statusu katram avotam, un pārliecinieties, ka audio avots ir pievienots un sūta audio."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1779,7 +1779,8 @@
       "noSources": "Nav pievienotu avotu",
       "primaryFallback": "primārais (rezerves)",
       "sourceNotRunning": "neanalizē",
-      "sourceNotRunningTooltip": "Šis avots ir piešķirts modelim iestatījumos, bet tā audio nesasniedz modeli, tāpēc tas neveic noteikšanas. Atveriet modeļu galeriju sadaļā Iestatījumi, lai pārbaudītu tā statusu.",
+      "sourceNotRunningTooltip": "Šis avots ir piešķirts modelim iestatījumos, bet tā audio nesasniedz modeli, tāpēc tas neveic noteikšanas. Pārbaudiet, vai audio avots ir pievienots un sūta audio.",
+      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
       "notMeasured": "n/p",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -1780,7 +1780,7 @@
       "primaryFallback": "primārais (rezerves)",
       "sourceNotRunning": "neanalizē",
       "sourceNotRunningTooltip": "Šis avots ir piešķirts modelim iestatījumos, bet tā audio nesasniedz modeli, tāpēc tas neveic noteikšanas. Pārbaudiet, vai audio avots ir pievienots un sūta audio.",
-      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
+      "modelNotAnalyzingTooltip": "Viens vai vairāki šim modelim piešķirtie audio avoti nesūta tam audio, tāpēc tas neveic noteikšanas. Skatiet zemāk norādītos avotus.",
       "notMeasured": "n/p",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -1780,7 +1780,7 @@
       "primaryFallback": "primær (fallback)",
       "sourceNotRunning": "analyserer ikke",
       "sourceNotRunningTooltip": "Denne kilden er tilordnet modellen i innstillingene, men lyden når ikke modellen, så den produserer ingen registreringer. Sjekk at lydkilden er tilkoblet og sender lyd.",
-      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
+      "modelNotAnalyzingTooltip": "Én eller flere lydkilder tilordnet denne modellen sender ikke lyd til den, så den produserer ingen registreringer. Se kildene oppført nedenfor.",
       "notMeasured": "n/a",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -472,7 +472,7 @@
         "unreadableMessage": "Modellfilen som er konfigurert for {modelName}, finnes, men kunne ikke leses, så den installerte modellen på {modelPath} brukes i stedet. Konfigurasjonen din ble ikke endret. Sjekk filens tillatelser og at lagringen er montert.",
         "builtinMessage": "Modellfilen som er konfigurert for {modelName}, ble ikke funnet på disken, og ingen installert modell er tilgjengelig for å erstatte den, så den innebygde modellen brukes i stedet. Konfigurasjonen din ble ikke endret.",
         "notRegisteredTitle": "Ingen modell analyserer {sourceName}",
-        "notRegisteredMessage": "Ingen lyd når {models} på lydkilden \"{sourceName}\", så det produseres ingen registreringer. Åpne modellgalleriet i Innstillinger for å sjekke status."
+        "notRegisteredMessage": "Ingen lyd når {models} på lydkilden \"{sourceName}\", så det produseres ingen registreringer. Åpne System > AI-modeller for å sjekke dens status per kilde, og bekreft at lydkilden er tilkoblet og sender lyd."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1779,7 +1779,8 @@
       "noSources": "Ingen kilder tilkoblet",
       "primaryFallback": "primær (fallback)",
       "sourceNotRunning": "analyserer ikke",
-      "sourceNotRunningTooltip": "Denne kilden er tilordnet modellen i innstillingene, men lyden når ikke modellen, så den produserer ingen registreringer. Åpne modellgalleriet i Innstillinger for å sjekke statusen.",
+      "sourceNotRunningTooltip": "Denne kilden er tilordnet modellen i innstillingene, men lyden når ikke modellen, så den produserer ingen registreringer. Sjekk at lydkilden er tilkoblet og sender lyd.",
+      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
       "notMeasured": "n/a",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -1780,7 +1780,7 @@
       "primaryFallback": "primair (fallback)",
       "sourceNotRunning": "analyseert niet",
       "sourceNotRunningTooltip": "Deze bron is in de instellingen toegewezen aan het model, maar de audio bereikt het model niet, waardoor het geen detecties produceert. Controleer of de audiobron is verbonden en audio verzendt.",
-      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
+      "modelNotAnalyzingTooltip": "Eén of meer aan dit model toegewezen audiobronnen verzenden er geen audio naar, waardoor het geen detecties produceert. Zie de hieronder vermelde bronnen.",
       "notMeasured": "n/b",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -472,7 +472,7 @@
         "unreadableMessage": "Het voor {modelName} geconfigureerde modelbestand bestaat, maar kon niet worden gelezen, dus wordt in plaats daarvan het geïnstalleerde model op {modelPath} gebruikt. Uw configuratie is ongewijzigd gebleven. Controleer de bestandsmachtigingen en of de opslag is gekoppeld.",
         "builtinMessage": "Het voor {modelName} geconfigureerde modelbestand is niet op de schijf gevonden en er is geen geïnstalleerd model beschikbaar om het te vervangen, dus wordt in plaats daarvan het ingebouwde model gebruikt. Uw configuratie is ongewijzigd gebleven.",
         "notRegisteredTitle": "Geen model analyseert {sourceName}",
-        "notRegisteredMessage": "Er bereikt geen audio {models} op audiobron \"{sourceName}\", waardoor er geen detecties worden geproduceerd. Open de modellengalerij in Instellingen om de status te controleren."
+        "notRegisteredMessage": "Er bereikt geen audio {models} op audiobron \"{sourceName}\", waardoor er geen detecties worden geproduceerd. Open Systeem > AI-modellen om de status per bron te controleren, en bevestig dat de audiobron is verbonden en audio verzendt."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1779,7 +1779,8 @@
       "noSources": "Geen bronnen verbonden",
       "primaryFallback": "primair (fallback)",
       "sourceNotRunning": "analyseert niet",
-      "sourceNotRunningTooltip": "Deze bron is in de instellingen toegewezen aan het model, maar de audio bereikt het model niet, waardoor het geen detecties produceert. Open de modellengalerij in Instellingen om de status te controleren.",
+      "sourceNotRunningTooltip": "Deze bron is in de instellingen toegewezen aan het model, maar de audio bereikt het model niet, waardoor het geen detecties produceert. Controleer of de audiobron is verbonden en audio verzendt.",
+      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
       "notMeasured": "n/b",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -472,7 +472,7 @@
         "unreadableMessage": "Skonfigurowany plik modelu dla {modelName} istnieje, ale nie udało się go odczytać, dlatego zamiast niego używany jest zainstalowany model w lokalizacji {modelPath}. Twoja konfiguracja pozostała niezmieniona. Sprawdź uprawnienia pliku oraz to, czy pamięć masowa jest zamontowana.",
         "builtinMessage": "Skonfigurowany plik modelu dla {modelName} nie został znaleziony na dysku i żaden zainstalowany model nie jest dostępny, aby go zastąpić, dlatego zamiast niego używany jest wbudowany model. Twoja konfiguracja pozostała niezmieniona.",
         "notRegisteredTitle": "Żaden model nie analizuje {sourceName}",
-        "notRegisteredMessage": "Żaden dźwięk nie dociera do {models} na źródle audio \"{sourceName}\", więc nie są generowane żadne detekcje. Otwórz galerię modeli w Ustawieniach, aby sprawdzić stan."
+        "notRegisteredMessage": "Żaden dźwięk nie dociera do {models} na źródle audio \"{sourceName}\", więc nie są generowane żadne detekcje. Otwórz System > Modele AI, aby sprawdzić jego stan dla poszczególnych źródeł, i potwierdź, że źródło audio jest podłączone i wysyła dźwięk."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1779,7 +1779,8 @@
       "noSources": "Brak podłączonych źródeł",
       "primaryFallback": "podstawowy (zapasowy)",
       "sourceNotRunning": "nie analizuje",
-      "sourceNotRunningTooltip": "To źródło jest przypisane do modelu w ustawieniach, ale jego dźwięk nie dociera do modelu, więc nie generuje detekcji. Otwórz galerię modeli w Ustawieniach, aby sprawdzić jego stan.",
+      "sourceNotRunningTooltip": "To źródło jest przypisane do modelu w ustawieniach, ale jego dźwięk nie dociera do modelu, więc nie generuje detekcji. Sprawdź, czy źródło audio jest podłączone i wysyła dźwięk.",
+      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
       "notMeasured": "n/d",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -1780,7 +1780,7 @@
       "primaryFallback": "podstawowy (zapasowy)",
       "sourceNotRunning": "nie analizuje",
       "sourceNotRunningTooltip": "To źródło jest przypisane do modelu w ustawieniach, ale jego dźwięk nie dociera do modelu, więc nie generuje detekcji. Sprawdź, czy źródło audio jest podłączone i wysyła dźwięk.",
-      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
+      "modelNotAnalyzingTooltip": "Jedno lub więcej źródeł audio przypisanych do tego modelu nie wysyła do niego dźwięku, więc nie generuje detekcji. Zobacz źródła wymienione poniżej.",
       "notMeasured": "n/d",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -472,7 +472,7 @@
         "unreadableMessage": "O ficheiro de modelo configurado para {modelName} existe, mas não pôde ser lido, pelo que o modelo instalado em {modelPath} está a ser utilizado em vez disso. A sua configuração não foi alterada. Verifique as permissões do ficheiro e se o seu armazenamento está montado.",
         "builtinMessage": "O ficheiro de modelo configurado para {modelName} não foi encontrado no disco e não existe nenhum modelo instalado disponível para o substituir, pelo que o modelo integrado está a ser utilizado em vez disso. A sua configuração não foi alterada.",
         "notRegisteredTitle": "Nenhum modelo está a analisar {sourceName}",
-        "notRegisteredMessage": "Nenhum áudio está a chegar a {models} na fonte de áudio \"{sourceName}\", pelo que não são produzidas deteções. Abra a galeria de modelos nas Configurações para verificar o estado."
+        "notRegisteredMessage": "Nenhum áudio está a chegar a {models} na fonte de áudio \"{sourceName}\", pelo que não são produzidas deteções. Abra Sistema > Modelos de IA para verificar o seu estado por fonte e confirmar que a fonte de áudio está conectada e a enviar áudio."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1779,7 +1779,8 @@
       "noSources": "Nenhuma fonte conectada",
       "primaryFallback": "primária (reserva)",
       "sourceNotRunning": "não está a analisar",
-      "sourceNotRunningTooltip": "Esta fonte está atribuída ao modelo nas configurações, mas o seu áudio não está a chegar ao modelo, pelo que não produz deteções. Abra a galeria de modelos nas Configurações para verificar o seu estado.",
+      "sourceNotRunningTooltip": "Esta fonte está atribuída ao modelo nas configurações, mas o seu áudio não está a chegar ao modelo, pelo que não produz deteções. Verifique se a fonte de áudio está conectada e a enviar áudio.",
+      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
       "notMeasured": "n/d",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -1780,7 +1780,7 @@
       "primaryFallback": "primária (reserva)",
       "sourceNotRunning": "não está a analisar",
       "sourceNotRunningTooltip": "Esta fonte está atribuída ao modelo nas configurações, mas o seu áudio não está a chegar ao modelo, pelo que não produz deteções. Verifique se a fonte de áudio está conectada e a enviar áudio.",
-      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
+      "modelNotAnalyzingTooltip": "Uma ou mais fontes de áudio atribuídas a este modelo não lhe estão a enviar áudio, pelo que não produz deteções. Consulte as fontes listadas abaixo.",
       "notMeasured": "n/d",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -1780,7 +1780,7 @@
       "primaryFallback": "primárny (záložný)",
       "sourceNotRunning": "neanalyzuje",
       "sourceNotRunningTooltip": "Tento zdroj je v nastaveniach priradený k modelu, ale jeho zvuk sa k modelu nedostáva, takže nevytvára žiadne detekcie. Skontrolujte, či je zdroj zvuku pripojený a odosiela zvuk.",
-      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
+      "modelNotAnalyzingTooltip": "Jeden alebo viac zdrojov zvuku priradených k tomuto modelu mu neodosiela zvuk, takže nevytvára žiadne detekcie. Pozrite si zdroje uvedené nižšie.",
       "notMeasured": "n/a",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -472,7 +472,7 @@
         "unreadableMessage": "Súbor modelu nakonfigurovaný pre {modelName} existuje, ale nepodarilo sa ho prečítať, preto sa namiesto neho používa nainštalovaný model v {modelPath}. Vaša konfigurácia zostala nezmenená. Skontrolujte oprávnenia súboru a to, či je jeho úložisko pripojené.",
         "builtinMessage": "Súbor modelu nakonfigurovaný pre {modelName} sa na disku nenašiel a nie je k dispozícii žiadny nainštalovaný model, ktorý by ho nahradil, preto sa namiesto neho používa vstavaný model. Vaša konfigurácia zostala nezmenená.",
         "notRegisteredTitle": "Žiadny model neanalyzuje {sourceName}",
-        "notRegisteredMessage": "K {models} na zvukovom zdroji \"{sourceName}\" sa nedostáva žiadny zvuk, takže sa nevytvárajú žiadne detekcie. Otvorte galériu modelov v Nastaveniach a skontrolujte stav."
+        "notRegisteredMessage": "K {models} na zvukovom zdroji \"{sourceName}\" sa nedostáva žiadny zvuk, takže sa nevytvárajú žiadne detekcie. Otvorte Systém > Modely AI, skontrolujte jeho stav pre jednotlivé zdroje a overte, že je zdroj zvuku pripojený a odosiela zvuk."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1779,7 +1779,8 @@
       "noSources": "Žiadne pripojené zdroje",
       "primaryFallback": "primárny (záložný)",
       "sourceNotRunning": "neanalyzuje",
-      "sourceNotRunningTooltip": "Tento zdroj je v nastaveniach priradený k modelu, ale jeho zvuk sa k modelu nedostáva, takže nevytvára žiadne detekcie. Otvorte galériu modelov v Nastaveniach a skontrolujte jeho stav.",
+      "sourceNotRunningTooltip": "Tento zdroj je v nastaveniach priradený k modelu, ale jeho zvuk sa k modelu nedostáva, takže nevytvára žiadne detekcie. Skontrolujte, či je zdroj zvuku pripojený a odosiela zvuk.",
+      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
       "notMeasured": "n/a",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -1780,7 +1780,7 @@
       "primaryFallback": "primär (reserv)",
       "sourceNotRunning": "analyserar inte",
       "sourceNotRunningTooltip": "Denna källa är tilldelad modellen i inställningarna, men dess ljud når inte modellen, så den producerar inga detektioner. Kontrollera att ljudkällan är ansluten och skickar ljud.",
-      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
+      "modelNotAnalyzingTooltip": "En eller flera ljudkällor tilldelade denna modell skickar inte ljud till den, så den producerar inga detektioner. Se källorna som anges nedan.",
       "notMeasured": "-",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -472,7 +472,7 @@
         "unreadableMessage": "Modellfilen som konfigurerats för {modelName} finns men kunde inte läsas, så den installerade modellen på {modelPath} används i stället. Din konfiguration lämnades oförändrad. Kontrollera filens behörigheter och att dess lagring är monterad.",
         "builtinMessage": "Modellfilen som konfigurerats för {modelName} hittades inte på disken och det finns ingen installerad modell tillgänglig att ersätta den med, så den inbyggda modellen används i stället. Din konfiguration lämnades oförändrad.",
         "notRegisteredTitle": "Ingen modell analyserar {sourceName}",
-        "notRegisteredMessage": "Inget ljud når {models} på ljudkällan \"{sourceName}\", så det produceras inga detektioner. Öppna modellgalleriet i Inställningar för att kontrollera status."
+        "notRegisteredMessage": "Inget ljud når {models} på ljudkällan \"{sourceName}\", så det produceras inga detektioner. Öppna System > AI-modeller för att kontrollera dess status per källa, och bekräfta att ljudkällan är ansluten och skickar ljud."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -1779,7 +1779,8 @@
       "noSources": "Inga källor anslutna",
       "primaryFallback": "primär (reserv)",
       "sourceNotRunning": "analyserar inte",
-      "sourceNotRunningTooltip": "Denna källa är tilldelad modellen i inställningarna, men dess ljud når inte modellen, så den producerar inga detektioner. Öppna modellgalleriet i Inställningar för att kontrollera dess status.",
+      "sourceNotRunningTooltip": "Denna källa är tilldelad modellen i inställningarna, men dess ljud når inte modellen, så den producerar inga detektioner. Kontrollera att ljudkällan är ansluten och skickar ljud.",
+      "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
       "notMeasured": "-",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -1045,8 +1045,14 @@ func (p *AudioPipelineService) reportSourceRegistration(mm *classifier.ModelMana
 	if p.routeFailedLastPass == nil {
 		p.routeFailedLastPass = make(map[string]bool)
 	}
-	registered := routeReportDecision(bufferRouteOK, p.routeFailedLastPass[sid], isReconfigureOperation(operation), allocated)
-	if bufferRouteOK {
+	// routeFailedLastPass tracks failures ACROSS RECONFIGURE PASSES only. A start or
+	// restart failure is reported immediately (suppressTransient=false below) and must
+	// not populate this memory, or the next reconfigure's first (transient) failure
+	// would see failedLastPass=true and be reported instead of suppressed (#4208). So
+	// only a reconfigure failure records state; every other pass clears it.
+	reconfigure := isReconfigureOperation(operation)
+	registered := routeReportDecision(bufferRouteOK, reconfigure && p.routeFailedLastPass[sid], reconfigure, allocated)
+	if bufferRouteOK || !reconfigure {
 		delete(p.routeFailedLastPass, sid)
 	} else {
 		p.routeFailedLastPass[sid] = true

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -590,6 +590,11 @@ func (p *AudioPipelineService) RestartSource(sourceID string) error {
 	// 2. Untrack sound level consumer (engine.RemoveSource removes the route).
 	p.untrackSoundLevelConsumer(sourceID)
 
+	// Drop the route-failure memory for the old ID: RestartSource re-adds the source
+	// under a fresh registry ID, so any retained "failed last pass" entry for the old
+	// ID is stale and would otherwise never be pruned (#4208).
+	delete(p.routeFailedLastPass, sourceID)
+
 	// 3. Remove source from engine (stops capture, removes routes, deallocates buffers, unregisters).
 	if err := p.engine.RemoveSource(sourceID); err != nil {
 		log.Error("failed to remove source during restart",

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -89,6 +89,17 @@ type AudioPipelineService struct {
 	// active for that source. Populated by registerSoundLevelConsumers, drained
 	// by removeAllSoundLevelConsumers.
 	soundLevelConsumers map[string]string
+
+	// routeFailedLastPass records source IDs whose buffer route failed to come up on
+	// the previous reconfigure pass. It implements the "survives a reconfigure"
+	// suppression for #4208 (see routeReportDecision): a transient AddRoute failure
+	// during a reconfigure is not reported as "not analyzing" on its first
+	// occurrence, only if the route is still down on the next reconfigure pass. An
+	// entry is dropped when a source's route recovers and the whole map is cleared
+	// when all sources are torn down (removeAllSources). Accessed only from
+	// registerConsumersForSources, which runs single-threaded on the startup pass and
+	// under sourcesMu on every later pass, so it needs no lock of its own.
+	routeFailedLastPass map[string]bool
 }
 
 // NewAudioPipelineService creates a new AudioPipelineService with the given dependencies.
@@ -661,6 +672,10 @@ func (p *AudioPipelineService) removeAllSources(operation string) {
 	// router state so the next registerSoundLevelConsumers call (e.g. after
 	// restartAudioCapture) does not skip sources due to stale entries.
 	p.untrackAllSoundLevelConsumers()
+	// Drop the per-source route-failure memory: all sources are gone, so any
+	// retained "failed last pass" entry is stale and would otherwise defeat the
+	// first-pass grace for a source ID that later returns (#4208).
+	clear(p.routeFailedLastPass)
 	ResetOverrunTrackers()
 }
 
@@ -971,6 +986,69 @@ func (p *AudioPipelineService) wireSourceBufferRoute(sid, sourceName string, sou
 	return true, true
 }
 
+// routeReportDecision returns the allocated-model set that reportUnregisteredModels
+// should treat as registered for a source, given whether its buffer route came up
+// this pass (bufferRouteOK), whether that route was already down on the previous
+// pass (failedLastPass), and whether this pass is a reconfigure where a transient
+// AddRoute failure is expected (suppressTransient). It implements the "survives a
+// reconfigure" suppression for #4208:
+//   - route up: report normally (a per-model allocation miss still surfaces);
+//   - route down on a reconfigure pass, first time: suppress the alarm this pass,
+//     because the next reconfigure usually repairs a transient AddRoute race;
+//   - route down and either not a reconfigure (a start/restart failure is a genuine
+//     outage) or still down on a later pass: surface every resolved model.
+//
+// Scoping the suppression to reconfigure passes is essential: a route that fails on
+// the startup pass has no preceding reconfigure churn to be a transient of, and on a
+// stable config no later pass revisits it, so suppressing it there would silence a
+// permanent model outage forever (the #4201/#4204 class). Pure, so the policy is
+// unit-tested without standing up the audio engine.
+func routeReportDecision(bufferRouteOK, failedLastPass, suppressTransient bool, allocated map[string]bool) map[string]bool {
+	if bufferRouteOK {
+		return allocated
+	}
+	if suppressTransient && !failedLastPass {
+		return allocated // first transient reconfigure failure: suppress the alarm this pass
+	}
+	return nil // report the resolved models as not-analyzing
+}
+
+// isReconfigureOperation reports whether a registerConsumersForSources pass was
+// driven by a settings-change reconfigure, where a transient AddRoute failure can
+// occur and is repaired by the next pass, as opposed to a start or explicit restart
+// where a route failure is a genuine outage to report immediately (see
+// routeReportDecision, #4208). These operations originate in reconfigureChangedSources.
+func isReconfigureOperation(operation string) bool {
+	switch operation {
+	case "reconfigure_diff", "reconfigure_params", "gain_change", "model_change":
+		return true
+	default:
+		return false
+	}
+}
+
+// reportSourceRegistration reports the models that will not analyze sourceName and
+// updates the per-source route-failure memory for the "survives a reconfigure"
+// suppression (#4208). A transient route-build failure during a reconfigure is not
+// alarmed on its first occurrence; a start/restart failure, genuinely unresolvable
+// (skipped) models, and per-model allocation misses are reported immediately.
+// Extracted from registerConsumersForSources to keep it within the
+// cognitive-complexity budget. registerConsumersForSources runs single-threaded on
+// the startup pass and under sourcesMu on every later pass, so routeFailedLastPass
+// needs no lock of its own.
+func (p *AudioPipelineService) reportSourceRegistration(mm *classifier.ModelManager, sid, sourceName, operation string, bufferRouteOK bool, skipped []string, assigned []classifier.ModelInfo, allocated map[string]bool) {
+	if p.routeFailedLastPass == nil {
+		p.routeFailedLastPass = make(map[string]bool)
+	}
+	registered := routeReportDecision(bufferRouteOK, p.routeFailedLastPass[sid], isReconfigureOperation(operation), allocated)
+	if bufferRouteOK {
+		delete(p.routeFailedLastPass, sid)
+	} else {
+		p.routeFailedLastPass[sid] = true
+	}
+	reportUnregisteredModels(mm, sourceName, skipped, assigned, registered)
+}
+
 // registerConsumersForSources registers BufferConsumer and AudioLevelConsumer
 // on the AudioRouter for each source ID. The sourceModelMap carries the
 // config-level model IDs for each source so that buffer consumers fan out to
@@ -1076,16 +1154,6 @@ func (p *AudioPipelineService) registerConsumersForSources(sourceIDs []string, s
 		consumerOK, bufferRouteOK := p.wireSourceBufferRoute(
 			sid, sourceName, sourceSampleRate, gainDB, targets, currentSettings, operation)
 
-		// Report models the source assigns but that will not analyze it, AFTER the
-		// buffer consumer and its route are attached, so a consumer- or route-build
-		// failure is included rather than silently missed. When the buffer route did
-		// not come up, no target on this source runs, so report every resolved model;
-		// otherwise report only the ones that did not register (unresolved, or buffer
-		// allocation failed).
-		registered := allocatedModels
-		if !bufferRouteOK {
-			registered = nil
-		}
 		// Report only models the configuration actually assigns. When the source
 		// resolved to no loaded target and fell back to the primary, the user
 		// assigned nothing here, so naming the built-in primary as "assigned to this
@@ -1096,7 +1164,11 @@ func (p *AudioPipelineService) registerConsumersForSources(sourceIDs []string, s
 		if usedPrimaryFallback {
 			assigned = nil
 		}
-		reportUnregisteredModels(modelMgr, sourceName, skippedModels, assigned, registered)
+		// Report models that will not analyze this source, AFTER the buffer consumer
+		// and its route are attached so a consumer- or route-build failure is included.
+		// Also updates the per-source route-failure memory that implements the
+		// "survives a reconfigure" suppression (#4208).
+		p.reportSourceRegistration(modelMgr, sid, sourceName, operation, bufferRouteOK, skippedModels, assigned, allocatedModels)
 
 		if !consumerOK {
 			// The buffer consumer never came up; skip wiring the audio-level route,
@@ -1385,6 +1457,9 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 		// source is re-added later.
 		p.untrackSoundLevelConsumer(src.ID)
 		RemoveOverrunTrackers(src.ID)
+		// Drop the route-failure memory too, so a source ID re-added later starts
+		// with a clean first-pass grace rather than a stale "failed last pass" (#4208).
+		delete(p.routeFailedLastPass, src.ID)
 	}
 
 	// Register consumers and monitors only for newly added sources.

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -257,7 +257,7 @@ func (p *AudioPipelineService) Start(_ context.Context) error {
 
 	// Add audio sources, register consumers, and start buffer monitors.
 	apiAudioLevelChan := p.apiService.AudioLevelChan()
-	sourceIDs := p.setupAudioSources(apiAudioLevelChan, "start")
+	sourceIDs := p.setupAudioSources(apiAudioLevelChan, operationStart)
 
 	if len(sourceIDs) == 0 {
 		audiocore.GetLogger().Warn("starting without active audio sources",
@@ -572,7 +572,7 @@ func (p *AudioPipelineService) RestartSource(sourceID string) error {
 	log := audiocore.GetLogger()
 	log.Info("restarting single audio source",
 		logger.String("source_id", sourceID),
-		logger.String("operation", "restart_source"))
+		logger.String("operation", operationRestartSource))
 
 	registry := p.engine.Registry()
 
@@ -600,7 +600,7 @@ func (p *AudioPipelineService) RestartSource(sourceID string) error {
 		log.Error("failed to remove source during restart",
 			logger.String("source_id", sourceID),
 			logger.Error(err),
-			logger.String("operation", "restart_source"))
+			logger.String("operation", operationRestartSource))
 		return fmt.Errorf("restart source: remove failed: %w", err)
 	}
 
@@ -616,7 +616,7 @@ func (p *AudioPipelineService) RestartSource(sourceID string) error {
 	if targetConfig == nil {
 		log.Warn("source config no longer in settings after removal",
 			logger.String("source_id", sourceID),
-			logger.String("operation", "restart_source"))
+			logger.String("operation", operationRestartSource))
 		return fmt.Errorf("restart source: config for %s no longer exists in settings", sourceID)
 	}
 
@@ -625,7 +625,7 @@ func (p *AudioPipelineService) RestartSource(sourceID string) error {
 		log.Error("failed to re-add source during restart",
 			logger.String("source_id", sourceID),
 			logger.Error(err),
-			logger.String("operation", "restart_source"))
+			logger.String("operation", operationRestartSource))
 		return fmt.Errorf("restart source: add failed: %w", err)
 	}
 
@@ -639,15 +639,15 @@ func (p *AudioPipelineService) RestartSource(sourceID string) error {
 	// 7. Re-register consumers and monitors.
 	audioLevelChan := p.apiService.AudioLevelChan()
 	sourceModelMap := map[string][]string{newSourceID: targetConfig.modelIDs}
-	p.registerConsumersForSources([]string{newSourceID}, sourceModelMap, audioLevelChan, "restart_source")
-	p.registerSoundLevelConsumers([]string{newSourceID}, "restart_source")
+	p.registerConsumersForSources([]string{newSourceID}, sourceModelMap, audioLevelChan, operationRestartSource)
+	p.registerSoundLevelConsumers([]string{newSourceID}, operationRestartSource)
 
 	// Update buffer monitors.
 	if monErr := p.bufferMgr.AddMonitor(newSourceID); monErr != nil {
 		log.Warn("buffer monitor update failed during source restart",
 			logger.String("source_id", newSourceID),
 			logger.Error(monErr),
-			logger.String("operation", "restart_source"))
+			logger.String("operation", operationRestartSource))
 	}
 
 	// Reset dispatch timestamp so watchdog starts fresh.
@@ -656,7 +656,7 @@ func (p *AudioPipelineService) RestartSource(sourceID string) error {
 	log.Info("single source restart complete",
 		logger.String("old_source_id", sourceID),
 		logger.String("new_source_id", newSourceID),
-		logger.String("operation", "restart_source"))
+		logger.String("operation", operationRestartSource))
 
 	return nil
 }
@@ -1018,6 +1018,18 @@ func routeReportDecision(bufferRouteOK, failedLastPass, suppressTransient bool, 
 	return nil // report the resolved models as not-analyzing
 }
 
+// Audio-source registration operations. Each labels a registration pass and, via
+// isReconfigureOperation, drives transient-route-failure suppression (#4208), so the
+// classifier switch and the call sites that pass these values must share one vocabulary.
+const (
+	operationStart             = "start"
+	operationRestartSource     = "restart_source"
+	operationReconfigureDiff   = "reconfigure_diff"
+	operationReconfigureParams = "reconfigure_params"
+	operationGainChange        = "gain_change"
+	operationModelChange       = "model_change"
+)
+
 // isReconfigureOperation reports whether a registerConsumersForSources pass was
 // driven by a settings-change reconfigure, where a transient AddRoute failure can
 // occur and is repaired by the next pass, as opposed to a start or explicit restart
@@ -1025,7 +1037,7 @@ func routeReportDecision(bufferRouteOK, failedLastPass, suppressTransient bool, 
 // routeReportDecision, #4208). These operations originate in reconfigureChangedSources.
 func isReconfigureOperation(operation string) bool {
 	switch operation {
-	case "reconfigure_diff", "reconfigure_params", "gain_change", "model_change":
+	case operationReconfigureDiff, operationReconfigureParams, operationGainChange, operationModelChange:
 		return true
 	default:
 		return false
@@ -1364,7 +1376,7 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 				logger.String("source_name", src.DisplayName),
 				logger.String("models", strings.Join(scm.modelIDs, ", ")),
 				logger.Int("model_count", len(scm.modelIDs)),
-				logger.String("operation", "reconfigure_diff"))
+				logger.String("operation", operationReconfigureDiff))
 
 			// Classify the kind of change needed, from most to least
 			// disruptive. Model changes are checked before gain-only
@@ -1379,7 +1391,7 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 					logger.Int("new_sample_rate", scm.config.SampleRate),
 					logger.Int("old_bit_depth", src.BitDepth),
 					logger.Int("new_bit_depth", scm.config.BitDepth),
-					logger.String("operation", "reconfigure_diff"))
+					logger.String("operation", operationReconfigureDiff))
 				if src.Gain != scm.config.Gain {
 					registry.UpdateGain(src.ID, scm.config.Gain)
 				}
@@ -1388,7 +1400,7 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 					log.Error("failed to reconfigure source",
 						logger.String("source_id", src.ID),
 						logger.Error(err),
-						logger.String("operation", "reconfigure_diff"))
+						logger.String("operation", operationReconfigureDiff))
 				} else {
 					reconfiguredIDs = append(reconfiguredIDs, src.ID)
 				}
@@ -1402,7 +1414,7 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 				}
 				log.Info("model assignment changed for kept source, rebuilding consumers",
 					logger.String("source_id", src.ID),
-					logger.String("operation", "reconfigure_diff"))
+					logger.String("operation", operationReconfigureDiff))
 				modelChangedIDs = append(modelChangedIDs, src.ID)
 
 			case src.Gain != scm.config.Gain:
@@ -1411,7 +1423,7 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 					logger.String("source_id", src.ID),
 					logger.Float64("old_gain_db", src.Gain),
 					logger.Float64("new_gain_db", scm.config.Gain),
-					logger.String("operation", "reconfigure_diff"))
+					logger.String("operation", operationReconfigureDiff))
 				registry.UpdateGain(src.ID, scm.config.Gain)
 				gainChangedIDs = append(gainChangedIDs, src.ID)
 			}
@@ -1424,7 +1436,7 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 			// New source - add it.
 			log.Info("adding new stream from config",
 				logger.String("connection", privacy.SanitizeStreamUrl(connStr)),
-				logger.String("operation", "reconfigure_diff"))
+				logger.String("operation", operationReconfigureDiff))
 			if err := p.engine.AddSource(scm.config); err != nil {
 				log.Warn("failed to add source during reconfigure",
 					logger.String("connection", privacy.SanitizeStreamUrl(connStr)),
@@ -1456,7 +1468,7 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 		removedCount++
 		log.Info("removing stream no longer in config",
 			logger.String("source_id", src.ID),
-			logger.String("operation", "reconfigure_diff"))
+			logger.String("operation", operationReconfigureDiff))
 		if err := p.engine.RemoveSource(src.ID); err != nil {
 			log.Warn("failed to remove source during reconfigure",
 				logger.String("source_id", src.ID),
@@ -1475,15 +1487,15 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 
 	// Register consumers and monitors only for newly added sources.
 	if len(newSourceIDs) > 0 {
-		p.registerConsumersForSources(newSourceIDs, sourceModelMap, audioLevelChan, "reconfigure_diff")
-		p.registerSoundLevelConsumers(newSourceIDs, "reconfigure_diff")
+		p.registerConsumersForSources(newSourceIDs, sourceModelMap, audioLevelChan, operationReconfigureDiff)
+		p.registerSoundLevelConsumers(newSourceIDs, operationReconfigureDiff)
 	}
 
 	// Rebuild routes for sources whose audio params changed. ReconfigureSource
 	// removed all routes and reallocated buffers; consumers must be re-created.
 	if len(reconfiguredIDs) > 0 {
-		p.registerConsumersForSources(reconfiguredIDs, sourceModelMap, audioLevelChan, "reconfigure_params")
-		p.registerSoundLevelConsumers(reconfiguredIDs, "reconfigure_params")
+		p.registerConsumersForSources(reconfiguredIDs, sourceModelMap, audioLevelChan, operationReconfigureParams)
+		p.registerSoundLevelConsumers(reconfiguredIDs, operationReconfigureParams)
 	}
 
 	// Rebuild routes for sources whose gain changed. The capture device
@@ -1498,8 +1510,8 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 			// it permanently without sound level monitoring.
 			p.untrackSoundLevelConsumer(sid)
 		}
-		p.registerConsumersForSources(gainChangedIDs, sourceModelMap, audioLevelChan, "gain_change")
-		p.registerSoundLevelConsumers(gainChangedIDs, "gain_change")
+		p.registerConsumersForSources(gainChangedIDs, sourceModelMap, audioLevelChan, operationGainChange)
+		p.registerSoundLevelConsumers(gainChangedIDs, operationGainChange)
 	}
 
 	// Rebuild routes for sources whose model assignment changed (e.g.,
@@ -1513,8 +1525,8 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 			desiredSet := resolveDesiredModelSet(sourceModelMap[sid], loadedModels, primaryModelID)
 			deallocateStaleAnalysisBuffers(bufMgr, sid, desiredSet)
 		}
-		p.registerConsumersForSources(modelChangedIDs, sourceModelMap, audioLevelChan, "model_change")
-		p.registerSoundLevelConsumers(modelChangedIDs, "model_change")
+		p.registerConsumersForSources(modelChangedIDs, sourceModelMap, audioLevelChan, operationModelChange)
+		p.registerSoundLevelConsumers(modelChangedIDs, operationModelChange)
 	}
 
 	// Sync monitors for ALL active sources (kept + new) so UpdateMonitors
@@ -1536,7 +1548,7 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 		logger.Int("removed", removedCount),
 		logger.Int("gain_changed", len(gainChangedIDs)),
 		logger.Int("model_changed", len(modelChangedIDs)),
-		logger.String("operation", "reconfigure_diff"))
+		logger.String("operation", operationReconfigureDiff))
 }
 
 // sourceConfigWithModels pairs an audiocore.SourceConfig with the config-level

--- a/internal/analysis/model_registration_notify.go
+++ b/internal/analysis/model_registration_notify.go
@@ -57,7 +57,8 @@ func notifyModelsNotRegistered(sourceName string, modelIDs []string) {
 		// primary-fallback case where it could tell the user the built-in BirdNET
 		// model is not installed.
 		fmt.Sprintf("%s is assigned to audio source %q but is not currently receiving audio, so it is not "+
-			"producing detections. Open the model gallery in Settings to check its status.", models, sourceName),
+			"producing detections. Open System > AI Models to check its per-source status, and confirm the "+
+			"audio source is connected and sending audio.", models, sourceName),
 	).
 		WithComponent("analysis.audio_pipeline").
 		WithTitleKey(notification.MsgModelNotRegisteredTitle, map[string]any{

--- a/internal/analysis/route_report_decision_test.go
+++ b/internal/analysis/route_report_decision_test.go
@@ -53,13 +53,26 @@ func TestRouteReportDecision(t *testing.T) {
 // so a startup route outage is not silenced (#4208 regression guard).
 func TestIsReconfigureOperation(t *testing.T) {
 	t.Parallel()
-	reconfigure := []string{"reconfigure_diff", "reconfigure_params", "gain_change", "model_change"}
-	immediate := []string{"start", "restart", "restart_source", "", "unknown"}
-	for _, op := range reconfigure {
-		assert.Truef(t, isReconfigureOperation(op), "%q should be a reconfigure operation", op)
+	tests := []struct {
+		name string
+		op   string
+		want bool
+	}{
+		{"reconfigure_diff suppresses first failure", "reconfigure_diff", true},
+		{"reconfigure_params suppresses first failure", "reconfigure_params", true},
+		{"gain_change suppresses first failure", "gain_change", true},
+		{"model_change suppresses first failure", "model_change", true},
+		{"start reports immediately", "start", false},
+		{"restart reports immediately", "restart", false},
+		{"restart_source reports immediately", "restart_source", false},
+		{"empty reports immediately", "", false},
+		{"unknown reports immediately", "unknown", false},
 	}
-	for _, op := range immediate {
-		assert.Falsef(t, isReconfigureOperation(op), "%q should report immediately, not suppress", op)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isReconfigureOperation(tt.op))
+		})
 	}
 }
 

--- a/internal/analysis/route_report_decision_test.go
+++ b/internal/analysis/route_report_decision_test.go
@@ -96,4 +96,22 @@ func TestReportSourceRegistration_RouteFailureMemory(t *testing.T) {
 	p.reportSourceRegistration(nil, sid, sid, "reconfigure_diff", true, nil, nil, alloc)
 	_, present := p.routeFailedLastPass[sid]
 	assert.False(t, present, "a recovered route clears the source's failure memory")
+
+	// A start/restart route failure must NOT populate the reconfigure-failure memory:
+	// it is reported immediately, so carrying it forward would make the next reconfigure's
+	// first (transient) failure look like a repeat and skip the #4208 grace.
+	p.reportSourceRegistration(nil, sid, sid, "start", false, nil, nil, alloc)
+	_, present = p.routeFailedLastPass[sid]
+	assert.False(t, present, "a start failure must not populate reconfigure failure memory")
+
+	p.reportSourceRegistration(nil, sid, sid, "restart_source", false, nil, nil, alloc)
+	_, present = p.routeFailedLastPass[sid]
+	assert.False(t, present, "a restart_source failure must not populate reconfigure failure memory")
+
+	// A start/restart failure also CLEARS a stale reconfigure-failure entry, so a
+	// prior reconfigure failure followed by a restart cannot poison the next pass.
+	p.routeFailedLastPass[sid] = true
+	p.reportSourceRegistration(nil, sid, sid, "start", false, nil, nil, alloc)
+	_, present = p.routeFailedLastPass[sid]
+	assert.False(t, present, "a start pass clears any stale reconfigure-failure entry")
 }

--- a/internal/analysis/route_report_decision_test.go
+++ b/internal/analysis/route_report_decision_test.go
@@ -1,0 +1,86 @@
+package analysis
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRouteReportDecision covers the "survives a reconfigure" suppression for
+// #4208. The alarm is suppressed only on the FIRST failure of a RECONFIGURE pass
+// (suppressTransient), because a transient AddRoute race is repaired by the next
+// reconfigure. A start/restart failure (suppressTransient=false) and a failure that
+// persists across reconfigures (failedLastPass) are always reported, so a permanent
+// route outage is never silently swallowed.
+func TestRouteReportDecision(t *testing.T) {
+	t.Parallel()
+
+	allocated := map[string]bool{"BirdNET_GLOBAL_6K_V2.4": true}
+
+	tests := []struct {
+		name              string
+		bufferRouteOK     bool
+		failedLastPass    bool
+		suppressTransient bool
+		// wantSuppressed true => resolved models treated as registered (no alarm);
+		// false => surfaced as not-analyzing (registered == nil).
+		wantSuppressed bool
+	}{
+		{"route up reports normally", true, false, true, true},
+		{"route up after prior failure reports normally", true, true, false, true},
+		{"start/restart first failure reported immediately", false, false, false, false},
+		{"start/restart persistent failure reported", false, true, false, false},
+		{"reconfigure first transient failure suppressed", false, false, true, true},
+		{"reconfigure failure surviving a pass reported", false, true, true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := routeReportDecision(tt.bufferRouteOK, tt.failedLastPass, tt.suppressTransient, allocated)
+			if tt.wantSuppressed {
+				assert.NotNil(t, got, "resolved models should be treated as registered (not reported)")
+				assert.Equal(t, allocated, got)
+			} else {
+				assert.Nil(t, got, "resolved models should be surfaced as not-analyzing")
+			}
+		})
+	}
+}
+
+// TestIsReconfigureOperation pins which passes get the first-failure grace. Only
+// reconfigure-family operations do; start and explicit restarts report immediately
+// so a startup route outage is not silenced (#4208 regression guard).
+func TestIsReconfigureOperation(t *testing.T) {
+	t.Parallel()
+	reconfigure := []string{"reconfigure_diff", "reconfigure_params", "gain_change", "model_change"}
+	immediate := []string{"start", "restart", "restart_source", "", "unknown"}
+	for _, op := range reconfigure {
+		assert.Truef(t, isReconfigureOperation(op), "%q should be a reconfigure operation", op)
+	}
+	for _, op := range immediate {
+		assert.Falsef(t, isReconfigureOperation(op), "%q should report immediately, not suppress", op)
+	}
+}
+
+// TestReportSourceRegistration_RouteFailureMemory exercises the stateful wrapper
+// (not just the pure decision): routeFailedLastPass is lazily created, set when a
+// route fails, and cleared when it recovers. mm is nil and the notification service
+// is unset in tests, so reportUnregisteredModels/notify are safe no-ops, leaving the
+// map transitions as the observable behavior.
+func TestReportSourceRegistration_RouteFailureMemory(t *testing.T) {
+	t.Parallel()
+	p := &AudioPipelineService{} // routeFailedLastPass is nil; must be lazily created
+	const sid = "mic-1"
+	alloc := map[string]bool{"BirdNET_GLOBAL_6K_V2.4": true}
+
+	// First reconfigure-pass route failure marks the source (and lazily inits the map).
+	p.reportSourceRegistration(nil, sid, sid, "reconfigure_diff", false, nil, nil, alloc)
+	assert.NotNil(t, p.routeFailedLastPass, "map must be lazily initialized")
+	assert.True(t, p.routeFailedLastPass[sid], "a route failure records the source")
+
+	// Route recovers: the entry is cleared.
+	p.reportSourceRegistration(nil, sid, sid, "reconfigure_diff", true, nil, nil, alloc)
+	_, present := p.routeFailedLastPass[sid]
+	assert.False(t, present, "a recovered route clears the source's failure memory")
+}

--- a/internal/analysis/route_report_decision_test.go
+++ b/internal/analysis/route_report_decision_test.go
@@ -58,13 +58,13 @@ func TestIsReconfigureOperation(t *testing.T) {
 		op   string
 		want bool
 	}{
-		{"reconfigure_diff suppresses first failure", "reconfigure_diff", true},
-		{"reconfigure_params suppresses first failure", "reconfigure_params", true},
-		{"gain_change suppresses first failure", "gain_change", true},
-		{"model_change suppresses first failure", "model_change", true},
-		{"start reports immediately", "start", false},
+		{"reconfigure_diff suppresses first failure", operationReconfigureDiff, true},
+		{"reconfigure_params suppresses first failure", operationReconfigureParams, true},
+		{"gain_change suppresses first failure", operationGainChange, true},
+		{"model_change suppresses first failure", operationModelChange, true},
+		{"start reports immediately", operationStart, false},
 		{"restart reports immediately", "restart", false},
-		{"restart_source reports immediately", "restart_source", false},
+		{"restart_source reports immediately", operationRestartSource, false},
 		{"empty reports immediately", "", false},
 		{"unknown reports immediately", "unknown", false},
 	}
@@ -88,30 +88,30 @@ func TestReportSourceRegistration_RouteFailureMemory(t *testing.T) {
 	alloc := map[string]bool{"BirdNET_GLOBAL_6K_V2.4": true}
 
 	// First reconfigure-pass route failure marks the source (and lazily inits the map).
-	p.reportSourceRegistration(nil, sid, sid, "reconfigure_diff", false, nil, nil, alloc)
+	p.reportSourceRegistration(nil, sid, sid, operationReconfigureDiff, false, nil, nil, alloc)
 	assert.NotNil(t, p.routeFailedLastPass, "map must be lazily initialized")
 	assert.True(t, p.routeFailedLastPass[sid], "a route failure records the source")
 
 	// Route recovers: the entry is cleared.
-	p.reportSourceRegistration(nil, sid, sid, "reconfigure_diff", true, nil, nil, alloc)
+	p.reportSourceRegistration(nil, sid, sid, operationReconfigureDiff, true, nil, nil, alloc)
 	_, present := p.routeFailedLastPass[sid]
 	assert.False(t, present, "a recovered route clears the source's failure memory")
 
 	// A start/restart route failure must NOT populate the reconfigure-failure memory:
 	// it is reported immediately, so carrying it forward would make the next reconfigure's
 	// first (transient) failure look like a repeat and skip the #4208 grace.
-	p.reportSourceRegistration(nil, sid, sid, "start", false, nil, nil, alloc)
+	p.reportSourceRegistration(nil, sid, sid, operationStart, false, nil, nil, alloc)
 	_, present = p.routeFailedLastPass[sid]
 	assert.False(t, present, "a start failure must not populate reconfigure failure memory")
 
-	p.reportSourceRegistration(nil, sid, sid, "restart_source", false, nil, nil, alloc)
+	p.reportSourceRegistration(nil, sid, sid, operationRestartSource, false, nil, nil, alloc)
 	_, present = p.routeFailedLastPass[sid]
 	assert.False(t, present, "a restart_source failure must not populate reconfigure failure memory")
 
 	// A start/restart failure also CLEARS a stale reconfigure-failure entry, so a
 	// prior reconfigure failure followed by a restart cannot poison the next pass.
 	p.routeFailedLastPass[sid] = true
-	p.reportSourceRegistration(nil, sid, sid, "start", false, nil, nil, alloc)
+	p.reportSourceRegistration(nil, sid, sid, operationStart, false, nil, nil, alloc)
 	_, present = p.routeFailedLastPass[sid]
 	assert.False(t, present, "a start pass clears any stale reconfigure-failure entry")
 }

--- a/internal/api/v2/species/species.go
+++ b/internal/api/v2/species/species.go
@@ -502,7 +502,11 @@ func findSpeciesScore(targetSci string, speciesScores []classifier.SpeciesScore)
 
 // computeRarity resolves a species to its occurrence score and rarity status.
 //
-// Coverage decides first. A species the range filter cannot score has no occurrence
+// filterActive gates everything: when the range filter produced no real scores (no
+// backend loaded, or no location configured), the probable-species list is synthetic
+// zeros, so rarity is reported unknown regardless of coverage (#3935).
+//
+// Coverage decides next. A species the range filter cannot score has no occurrence
 // probability at all, so it is reported as unknown even when it does appear in the
 // probable-species list, because PassUnmappedSpecies injects species with no geomodel
 // match at score 0.0 purely so they survive the filter. Reading that synthetic zero as a
@@ -519,7 +523,16 @@ func findSpeciesScore(targetSci string, speciesScores []classifier.SpeciesScore)
 //
 // A covered species present in the list is scored directly; one that is covered but
 // absent is below today's threshold and therefore genuinely very rare.
-func computeRarity(targetSci string, speciesScores []classifier.SpeciesScore, geomodelLabels, classifierLabels []string) (float64, RarityStatus) {
+func computeRarity(filterActive bool, targetSci string, speciesScores []classifier.SpeciesScore, geomodelLabels, classifierLabels []string) (float64, RarityStatus) {
+	// Without an active range filter the probable-species list is synthetic zero
+	// scores for every label, so a covered species would score 0.0 and be
+	// misreported as "very rare" at "0%". The occurrence probability is genuinely
+	// unknown in that state (the geomodel could not load), so report unknown rather
+	// than a confident wrong answer (#3935).
+	if !filterActive {
+		return 0.0, RarityUnknown
+	}
+
 	if !speciesHasGeomodelCoverage(targetSci, geomodelLabels, classifierLabels) {
 		return 0.0, RarityUnknown
 	}
@@ -540,7 +553,7 @@ func (c *Handler) getSpeciesRarityInfo(bn *classifier.Orchestrator, speciesLabel
 	// probable-species list, not the multi-model union: the union assigns synthetic
 	// always-active scores (1.0) to secondary-model species (bats, Perch) that have
 	// no real occurrence probability, which would misclassify them as "very common".
-	speciesScores, geomodelLabels, classifierLabels, err := bn.GetRarityContext(today)
+	speciesScores, geomodelLabels, classifierLabels, filterActive, err := bn.GetRarityContext(today)
 	if err != nil {
 		return SpeciesRarityInfo{}, errors.New(err).
 			Category(errors.CategoryProcessing).
@@ -565,7 +578,7 @@ func (c *Handler) getSpeciesRarityInfo(bn *classifier.Orchestrator, speciesLabel
 	// Resolve the score and status together; computeRarity documents how an absent
 	// species is split between "very rare" and "unknown" by geomodel coverage.
 	targetSci := detection.ExtractScientificName(speciesLabel)
-	rarityInfo.Score, rarityInfo.Status = computeRarity(targetSci, speciesScores, geomodelLabels, classifierLabels)
+	rarityInfo.Score, rarityInfo.Status = computeRarity(filterActive, targetSci, speciesScores, geomodelLabels, classifierLabels)
 
 	return rarityInfo, nil
 }

--- a/internal/api/v2/species/species_test.go
+++ b/internal/api/v2/species/species_test.go
@@ -702,7 +702,7 @@ func TestComputeRarity(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			gotScore, gotStatus := computeRarity(tt.targetSci, scores, geomodelLabels, classifierLabels)
+			gotScore, gotStatus := computeRarity(true, tt.targetSci, scores, geomodelLabels, classifierLabels)
 			assert.InDelta(t, tt.wantScore, gotScore, 0.001)
 			assert.Equal(t, tt.wantStatus, gotStatus)
 		})
@@ -711,9 +711,28 @@ func TestComputeRarity(t *testing.T) {
 
 func TestComputeRarity_Empty(t *testing.T) {
 	t.Parallel()
-	gotScore, gotStatus := computeRarity("Turdus migratorius", nil, nil, nil)
+	gotScore, gotStatus := computeRarity(true, "Turdus migratorius", nil, nil, nil)
 	assert.InDelta(t, 0.0, gotScore, 0.001)
 	assert.Equal(t, RarityUnknown, gotStatus)
+}
+
+// TestComputeRarity_InactiveFilterReportsUnknown pins #3935: when the range filter
+// is not active, GetRarityContext yields synthetic zero scores for every label, so a
+// covered species would otherwise be misreported as "very rare" at 0%. With the
+// filter inactive the occurrence probability is unknown regardless of coverage or
+// any score present in the list.
+func TestComputeRarity_InactiveFilterReportsUnknown(t *testing.T) {
+	t.Parallel()
+
+	labels := []string{testSciName + "_" + testCommonName}
+	// The species is present in both the geomodel vocabulary and the score list, so
+	// with an active filter this would resolve to a real rarity. An inactive filter
+	// means the 0.0 score is synthetic and must report unknown, not very rare.
+	scores := []classifier.SpeciesScore{{Label: testSciName + "_" + testCommonName, Score: 0.0}}
+
+	score, status := computeRarity(false, testSciName, scores, labels, labels)
+	assert.InDelta(t, 0.0, score, 0.001)
+	assert.Equal(t, RarityUnknown, status, "an inactive range filter yields unknown rarity, not very rare (#3935)")
 }
 
 // TestComputeRarity_GeomodelLabelsTakePrecedence pins the reported bug. Coverage is
@@ -729,11 +748,11 @@ func TestComputeRarity_GeomodelLabelsTakePrecedence(t *testing.T) {
 		testSciName + "_" + testCommonName,
 	}
 
-	_, status := computeRarity(testSciName, nil, geomodelLabels, classifierLabels)
+	_, status := computeRarity(true, testSciName, nil, geomodelLabels, classifierLabels)
 	assert.Equal(t, RarityUnknown, status,
 		"classifier-only species has no geomodel occurrence probability")
 
-	_, status = computeRarity(testCanonName, nil, geomodelLabels, classifierLabels)
+	_, status = computeRarity(true, testCanonName, nil, geomodelLabels, classifierLabels)
 	assert.Equal(t, RarityVeryRare, status,
 		"geomodel-covered species below threshold is very rare")
 }
@@ -776,7 +795,7 @@ func TestComputeRarity_NoGeomodelLabels(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			gotScore, gotStatus := computeRarity(tt.targetSci, nil, nil, classifierLabels)
+			gotScore, gotStatus := computeRarity(true, tt.targetSci, nil, nil, classifierLabels)
 			assert.InDelta(t, 0.0, gotScore, 0.001)
 			assert.Equal(t, tt.wantStatus, gotStatus)
 		})
@@ -834,11 +853,11 @@ func TestComputeRarity_CollidingSpecies(t *testing.T) {
 		{Label: collidingSciB + "_" + collidingCommonB, Score: 0.1},
 	}
 
-	gotScore, gotStatus := computeRarity(collidingSciB, scores, labels, labels)
+	gotScore, gotStatus := computeRarity(true, collidingSciB, scores, labels, labels)
 	assert.InDelta(t, 0.1, gotScore, 0.001, "the merged species must keep its own score")
 	assert.Equal(t, RarityRare, gotStatus)
 
-	gotScore, gotStatus = computeRarity(collidingSciA, scores, labels, labels)
+	gotScore, gotStatus = computeRarity(true, collidingSciA, scores, labels, labels)
 	assert.InDelta(t, 0.9, gotScore, 0.001)
 	assert.Equal(t, RarityVeryCommon, gotStatus)
 }
@@ -877,7 +896,7 @@ func TestComputeRarity_SyntheticScoresReportUnknown(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			scores := []classifier.SpeciesScore{{Label: unmappedSci + "_Brandt's Bat", Score: tt.score}}
-			gotScore, gotStatus := computeRarity(unmappedSci, scores, geomodelLabels, classifierLabels)
+			gotScore, gotStatus := computeRarity(true, unmappedSci, scores, geomodelLabels, classifierLabels)
 			assert.Equal(t, RarityUnknown, gotStatus, tt.why)
 			assert.InDelta(t, 0.0, gotScore, 0.001)
 		})

--- a/internal/api/v2/system/diagnostics.go
+++ b/internal/api/v2/system/diagnostics.go
@@ -19,7 +19,6 @@ import (
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/classifier/inferencestats"
 	"github.com/tphakala/birdnet-go/internal/conf"
-	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/health"
 	"github.com/tphakala/birdnet-go/internal/health/checks"
@@ -36,6 +35,16 @@ type diagnosticsStatusResponse struct {
 	Status     health.Status                     `json:"status"`
 	Categories map[health.Category]health.Status `json:"categories"`
 	LastRun    *time.Time                        `json:"last_run"`
+}
+
+// integrityResulter is implemented by any datastore that can report a cached
+// database integrity result (PRAGMA quick_check) for the Database Integrity
+// health check. Both the legacy *datastore.SQLiteStore and the v2 datastore
+// satisfy it, so the check reads through this interface instead of asserting a
+// concrete datastore type. The old concrete assertion failed on v2 installs,
+// leaving the check stuck at "Unknown" forever (#3939).
+type integrityResulter interface {
+	IntegrityResult() (string, bool)
 }
 
 // RegisterDiagnosticsRoutes initializes health check infrastructure and registers
@@ -192,11 +201,14 @@ func (c *Handler) registerHealthChecks() {
 			if ds == nil {
 				return "", false
 			}
-			sqliteStore, ok := ds.(*datastore.SQLiteStore)
-			if !ok || sqliteStore == nil {
-				return "", false
+			// Read integrity from whichever datastore exposes it (the legacy
+			// SQLiteStore or the v2 datastore) via a consumer-side interface. The
+			// old *datastore.SQLiteStore assertion failed on v2 installs, leaving
+			// the check stuck at "Unknown" (#3939).
+			if ir, ok := ds.(integrityResulter); ok {
+				return ir.IntegrityResult()
 			}
-			return sqliteStore.IntegrityResult()
+			return "", false
 		}),
 
 		// Network checks

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -985,7 +985,7 @@ func (o *Orchestrator) GetAllProbableSpeciesWithSettings(date time.Time, week fl
 	// ReloadRangeFilter cannot desync them. geoLabels is non-nil only on the
 	// universal (v3 geomodel) path, where it covers every scientific name the
 	// geomodel knows regardless of threshold.
-	scores, geoLabels, err := primary.getProbableSpecies(date, week, settings)
+	scores, geoLabels, _, err := primary.getProbableSpecies(date, week, settings)
 	if err != nil {
 		return nil, err
 	}
@@ -2584,7 +2584,12 @@ func (o *Orchestrator) loadAdditionalModels(threadAlloc map[string]int) error {
 // TFLite meta model and the plain ONNX range filter, and when no range filter or
 // location is configured; in every one of those cases the scores are labeled with the
 // classifier's own vocabulary, so callers must fall back to classifierLabels.
-func (o *Orchestrator) GetRarityContext(date time.Time) (scores []SpeciesScore, geomodelLabels, classifierLabels []string, err error) {
+//
+// filterActive is true only when the returned scores are genuine location-based
+// predictions; it is false when they are the synthetic all-zero fallback (no range
+// filter loaded, or no location configured), so a caller can avoid reporting a zero as
+// "very rare" (#3935).
+func (o *Orchestrator) GetRarityContext(date time.Time) (scores []SpeciesScore, geomodelLabels, classifierLabels []string, filterActive bool, err error) {
 	// Snapshot the primary once and drive every read below from it. Delegating to
 	// o.GetProbableSpecies would re-resolve o.primary under a fresh lock and could
 	// score against a different model than the labels describe.
@@ -2592,12 +2597,20 @@ func (o *Orchestrator) GetRarityContext(date time.Time) (scores []SpeciesScore, 
 	primary := o.primary
 	o.mu.RUnlock()
 	if primary == nil {
-		return nil, nil, nil, nil
+		return nil, nil, nil, false, nil
 	}
 
 	settings := primary.currentSettings()
-	scores, geomodelLabels, err = primary.getProbableSpecies(date, 0.0, settings)
+	// filterActive is decided inside getProbableSpecies, in the same locked section
+	// that produced the scores: it is false whenever those scores are the synthetic
+	// all-zero fallback (no range-filter backend loaded, OR no location configured).
+	// Deriving it here rather than from a separate rangeFilterRuntimeState() read
+	// closes a TOCTOU where a concurrent unload between the two reads could pair
+	// filterActive=true with synthetic zeros, and it also covers the no-location case
+	// a bare rangeFilter!=nil check missed, so a caller never reports a synthetic zero
+	// as "very rare" (#3935).
+	scores, geomodelLabels, filterActive, err = primary.getProbableSpecies(date, 0.0, settings)
 	classifierLabels = slices.Clone(settings.BirdNET.Labels)
 
-	return scores, geomodelLabels, classifierLabels, err
+	return scores, geomodelLabels, classifierLabels, filterActive, err
 }

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -489,7 +489,7 @@ func addUserOverrideSpecies(includedSpecies *[]string, settings *conf.Settings, 
 // so that UI changes to coordinates, threshold, or LocationConfigured take
 // effect immediately without restarting the service.
 func (bn *BirdNET) GetProbableSpecies(date time.Time, week float32) ([]SpeciesScore, error) {
-	scores, _, err := bn.getProbableSpecies(date, week, bn.currentSettings())
+	scores, _, _, err := bn.getProbableSpecies(date, week, bn.currentSettings())
 	return scores, err
 }
 
@@ -499,7 +499,7 @@ func (bn *BirdNET) GetProbableSpecies(date time.Time, week float32) ([]SpeciesSc
 // publishing temporary values into the global settings, eliminating the race
 // where a concurrent BuildRangeFilter could pick up test data.
 func (bn *BirdNET) GetProbableSpeciesWithSettings(date time.Time, week float32, settings *conf.Settings) ([]SpeciesScore, error) {
-	scores, _, err := bn.getProbableSpecies(date, week, settings)
+	scores, _, _, err := bn.getProbableSpecies(date, week, settings)
 	return scores, err
 }
 
@@ -517,7 +517,16 @@ func (bn *BirdNET) GetProbableSpeciesWithSettings(date time.Time, week float32, 
 // the universal path. Returning it here lets callers that need both avoid a
 // second lock that could observe a different range-filter instance after a
 // concurrent ReloadRangeFilter.
-func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *conf.Settings) ([]SpeciesScore, []string, error) {
+//
+// The third return value, realScores, is true only when the returned scores are
+// genuine location-based predictions. It is false whenever the scores are the
+// synthetic all-zero fallback (no range-filter backend loaded, or no location
+// configured). Because it is decided inside the same locked section that produced
+// the scores, a caller can trust that "the filter was active" and "these scores"
+// describe one consistent snapshot, with no separate read that could race a
+// concurrent unload (used by GetRarityContext to avoid reporting a synthetic zero
+// as "very rare", #3935).
+func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *conf.Settings) (probableSpecies []SpeciesScore, geomodelLabels []string, filterActive bool, err error) {
 	bn.Debug("Applying range filter")
 
 	// Build the exclude matcher once: it reverse-resolves localized common-name exclude
@@ -532,13 +541,13 @@ func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *co
 	bn.mu.Unlock()
 	if !hasRangeFilter {
 		bn.Debug("Range filter model not loaded, returning zero scores for all labels")
-		return zeroScoresForAllLabels(settings.BirdNET.Labels, excluder), nil, nil
+		return zeroScoresForAllLabels(settings.BirdNET.Labels, excluder), nil, false, nil
 	}
 
 	// Skip filtering if location is not configured
 	if !settings.BirdNET.LocationConfigured {
 		bn.Debug("Location not configured, not using location based prediction filter")
-		return zeroScoresForAllLabels(settings.BirdNET.Labels, excluder), nil, nil
+		return zeroScoresForAllLabels(settings.BirdNET.Labels, excluder), nil, false, nil
 	}
 
 	threshold := settings.BirdNET.RangeFilter.Threshold
@@ -572,7 +581,7 @@ func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *co
 		bn.mu.Unlock()
 
 		if err != nil {
-			return nil, nil, errors.New(err).
+			return nil, nil, false, errors.New(err).
 				Category(errors.CategoryValidation).
 				Context("date", date.Format(time.DateOnly)).
 				Context("week", week).
@@ -614,14 +623,14 @@ func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *co
 		}
 
 		sort.Sort(ByScore(speciesScores))
-		return speciesScores, allGeoLabels, nil
+		return speciesScores, allGeoLabels, true, nil
 	}
 	bn.mu.Unlock()
 
 	// Legacy path: map geomodel scores to the classifier's label set.
 	filters, err := bn.predictFilter(date, week, settings, threshold)
 	if err != nil {
-		return nil, nil, errors.New(err).
+		return nil, nil, false, errors.New(err).
 			Category(errors.CategoryValidation).
 			Context("date", date.Format(time.DateOnly)).
 			Context("week", week).
@@ -646,7 +655,7 @@ func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *co
 	addUserOverrideSpeciesScores(bn, &speciesScores, settings, nil)
 
 	sort.Sort(ByScore(speciesScores))
-	return speciesScores, nil, nil
+	return speciesScores, nil, true, nil
 }
 
 // zeroScoresForAllLabels creates a slice of SpeciesScore with zero scores for all provided labels,

--- a/internal/classifier/range_filter_exclude_test.go
+++ b/internal/classifier/range_filter_exclude_test.go
@@ -146,7 +146,7 @@ func TestGetProbableSpecies_LocalizedExclude_DropsScientificOnlyNonPrimaryLabel(
 		speciesCache: make(map[string]*speciesCacheEntry),
 	}
 
-	scores, _, err := bn.getProbableSpecies(time.Now(), 0, settings)
+	scores, _, _, err := bn.getProbableSpecies(time.Now(), 0, settings)
 	require.NoError(t, err)
 
 	labels := make([]string, 0, len(scores))

--- a/internal/classifier/range_filter_override_test.go
+++ b/internal/classifier/range_filter_override_test.go
@@ -121,7 +121,7 @@ func TestGetProbableSpecies_BareLocalizedCommonNameOverride_CanonicalizesLabel(t
 		speciesCache: make(map[string]*speciesCacheEntry),
 	}
 
-	scores, _, err := bn.getProbableSpecies(time.Now(), 0, settings)
+	scores, _, _, err := bn.getProbableSpecies(time.Now(), 0, settings)
 	require.NoError(t, err)
 
 	labels := make([]string, 0, len(scores))
@@ -173,7 +173,7 @@ func TestGetProbableSpecies_NonPrimaryLocalizedCommonOverride_ReverseResolvesToS
 		speciesCache: make(map[string]*speciesCacheEntry),
 	}
 
-	scores, _, err := bn.getProbableSpecies(time.Now(), 0, settings)
+	scores, _, _, err := bn.getProbableSpecies(time.Now(), 0, settings)
 	require.NoError(t, err)
 
 	labels := make([]string, 0, len(scores))
@@ -257,7 +257,7 @@ func TestGetProbableSpecies_LegacyPath_NonPrimaryLocalizedCommonOverride_Reverse
 		speciesCache: make(map[string]*speciesCacheEntry),
 	}
 
-	scores, _, err := bn.getProbableSpecies(time.Now(), 0, settings)
+	scores, _, _, err := bn.getProbableSpecies(time.Now(), 0, settings)
 	require.NoError(t, err)
 
 	labels := make([]string, 0, len(scores))
@@ -323,7 +323,7 @@ func probableSpeciesFor(t *testing.T, settings *conf.Settings, rf *fakeUniversal
 		rangeFilter:  rf,
 		speciesCache: make(map[string]*speciesCacheEntry),
 	}
-	scores, _, err := bn.getProbableSpecies(time.Now(), 0, settings)
+	scores, _, _, err := bn.getProbableSpecies(time.Now(), 0, settings)
 	require.NoError(t, err)
 	return scores
 }

--- a/internal/classifier/range_filter_test.go
+++ b/internal/classifier/range_filter_test.go
@@ -290,7 +290,7 @@ func TestGetProbableSpecies_PassUnmappedSpecies(t *testing.T) {
 				speciesCache: make(map[string]*speciesCacheEntry),
 			}
 
-			scores, _, err := bn.getProbableSpecies(time.Now(), 0, settings)
+			scores, _, _, err := bn.getProbableSpecies(time.Now(), 0, settings)
 			require.NoError(t, err)
 			assert.GreaterOrEqual(t, len(scores), tt.wantMinSpecies)
 

--- a/internal/classifier/range_filter_unmapped_bounds_test.go
+++ b/internal/classifier/range_filter_unmapped_bounds_test.go
@@ -60,7 +60,7 @@ func TestGetProbableSpecies_PassUnmapped_MappingLongerThanSnapshotLabels_NoPanic
 	}
 
 	require.NotPanics(t, func() {
-		scores, _, err := bn.getProbableSpecies(time.Now(), 0, settings)
+		scores, _, _, err := bn.getProbableSpecies(time.Now(), 0, settings)
 		require.NoError(t, err)
 		labels := make([]string, 0, len(scores))
 		for _, ss := range scores {

--- a/internal/classifier/rarity_context_test.go
+++ b/internal/classifier/rarity_context_test.go
@@ -176,9 +176,10 @@ func TestGetRarityContext_UniversalGeomodel(t *testing.T) {
 	bn, _ := newAliasedGeomodelBirdNET(t, 0.5)
 	orch := &Orchestrator{Settings: bn.Settings, ModelInfo: bn.ModelInfo, primary: bn}
 
-	scores, geomodelLabels, classifierLabels, err := orch.GetRarityContext(time.Now())
+	scores, geomodelLabels, classifierLabels, filterActive, err := orch.GetRarityContext(time.Now())
 	require.NoError(t, err)
 
+	assert.True(t, filterActive, "a loaded range filter reports active so rarity is honest (#3935)")
 	assert.NotEmpty(t, scores, "universal geomodel path should return scored species")
 	assert.Contains(t, geomodelLabels, aliasCanonicalLabel,
 		"geomodel vocabulary should come back so coverage is checked against it")
@@ -214,9 +215,13 @@ func TestGetRarityContext_NoGeomodel(t *testing.T) {
 	t.Cleanup(bn.Delete)
 	orch := &Orchestrator{Settings: settings, ModelInfo: bn.ModelInfo, primary: bn}
 
-	_, geomodelLabels, classifierLabels, err := orch.GetRarityContext(time.Now())
+	_, geomodelLabels, classifierLabels, filterActive, err := orch.GetRarityContext(time.Now())
 	require.NoError(t, err)
 
+	// Location is unconfigured here, so getProbableSpecies returns synthetic zero
+	// scores even though a filter is loaded; filterActive must be false so rarity is
+	// reported as unknown rather than a bogus "very rare" (#3935).
+	assert.False(t, filterActive, "unconfigured location yields synthetic zeros, so the filter is not active for rarity")
 	assert.Empty(t, geomodelLabels, "no universal geomodel means no geomodel vocabulary")
 	assert.Contains(t, classifierLabels, "Turdus merula_Common Blackbird")
 }
@@ -224,8 +229,9 @@ func TestGetRarityContext_NoGeomodel(t *testing.T) {
 func TestGetRarityContext_NilPrimary(t *testing.T) {
 	orch := &Orchestrator{}
 
-	scores, geomodelLabels, classifierLabels, err := orch.GetRarityContext(time.Now())
+	scores, geomodelLabels, classifierLabels, filterActive, err := orch.GetRarityContext(time.Now())
 	require.NoError(t, err)
+	assert.False(t, filterActive, "no primary model means no active range filter")
 	assert.Nil(t, scores)
 	assert.Nil(t, geomodelLabels)
 	assert.Nil(t, classifierLabels)

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -168,6 +168,13 @@ type Datastore struct {
 
 	// dbCounters tracks atomic query latency counters for metrics collection.
 	dbCounters *dbstats.Counters
+
+	// Cached PRAGMA quick_check result for the Database Integrity health check
+	// (#3939). integrityMu is dedicated to this cache only, never a broader
+	// datastore lock, because quick_check can be slow and must not block Save.
+	integrityMu        sync.RWMutex
+	integrityResult    string    // "ok", a corruption description, or "" until first run
+	integrityCheckedAt time.Time // when integrityResult was last computed
 }
 
 // Config configures the Datastore.
@@ -519,6 +526,102 @@ func (ds *Datastore) PingWithLatency(ctx context.Context) (time.Duration, error)
 		return 0, fmt.Errorf("database ping failed: %w", err)
 	}
 	return time.Since(start), nil
+}
+
+// v2IntegrityCacheTTL bounds how long a PRAGMA quick_check result is reused
+// before the Database Integrity health check recomputes it. quick_check can be
+// slow on a large database, so the on-demand health check reads a cached result.
+const v2IntegrityCacheTTL = 24 * time.Hour
+
+// v2IntegrityCheckTimeout caps a single PRAGMA quick_check run. quick_check scans
+// every page on the single pinned SQLite connection, so an unbounded run would
+// block writes for its full duration; the timeout is generous enough for a
+// legitimate scan to complete (and then be cached for the TTL) while capping a
+// pathological hang (#3939).
+const v2IntegrityCheckTimeout = 2 * time.Minute
+
+// IntegrityResult reports the cached database integrity result and whether the
+// database is corrupted, for the Database Integrity health check (#3939). It
+// mirrors the legacy SQLiteStore accessor so the check can read integrity through
+// a shared interface instead of asserting the concrete legacy type; on v2 installs
+// that assertion failed, leaving the check stuck at "Unknown" forever.
+//
+// The result is "ok" for a healthy SQLite database (and for any non-SQLite dialect,
+// where PRAGMA quick_check does not apply), a quick_check corruption description
+// when corruption is found, or "" when a check could not be run yet. The health
+// check treats a non-"ok", non-empty result as corruption, so a dialect without
+// quick_check must report "ok", never a "skipped"-style sentinel.
+func (ds *Datastore) IntegrityResult() (string, bool) {
+	// Fast path: a fresh cached result needs only a read lock and runs no query.
+	ds.integrityMu.RLock()
+	cached := ds.integrityResult
+	fresh := cached != "" && time.Since(ds.integrityCheckedAt) < v2IntegrityCacheTTL
+	ds.integrityMu.RUnlock()
+	if fresh {
+		return cached, cached != "ok"
+	}
+
+	// Slow path: recompute under the write lock so concurrent callers with a cold or
+	// expired cache do not all run PRAGMA quick_check at once (thundering herd).
+	// integrityMu is dedicated to this cache and is never taken by Save or any query
+	// path, so holding it across the check serializes only integrity reads and cannot
+	// block writes; the single SQLite connection, not this mutex, is what the query
+	// occupies for its duration (#3939).
+	ds.integrityMu.Lock()
+	defer ds.integrityMu.Unlock()
+	// Re-check under the write lock: another caller may have refreshed it while we
+	// waited for the lock.
+	if ds.integrityResult != "" && time.Since(ds.integrityCheckedAt) < v2IntegrityCacheTTL {
+		return ds.integrityResult, ds.integrityResult != "ok"
+	}
+
+	result, ran := ds.runIntegrityQuickCheck()
+	if !ran {
+		// Could not run the check (no DB handle, timeout, or query error); report
+		// "not run yet" rather than a false corruption alarm, and do not cache so the
+		// next health run retries.
+		return "", false
+	}
+	ds.integrityResult = result
+	ds.integrityCheckedAt = time.Now()
+	return result, result != "ok"
+}
+
+// runIntegrityQuickCheck executes PRAGMA quick_check on SQLite and returns the
+// result ("ok" or a "; "-joined corruption description) with ran=true. Non-SQLite
+// dialects have no quick_check equivalent, so it returns ("ok", true) to report
+// healthy. ran is false only when the check could not run at all (no DB handle or
+// a query error), which the caller maps to the "not run yet" state.
+func (ds *Datastore) runIntegrityQuickCheck() (result string, ran bool) {
+	db := ds.manager.DB()
+	if db == nil {
+		return "", false
+	}
+	// PRAGMA quick_check is SQLite-specific; other engines (e.g. MySQL/InnoDB)
+	// self-check and have no equivalent, so report healthy rather than tripping
+	// the corruption branch of the health check. db.Name() is the dialect name
+	// ("sqlite"/"mysql"), promoted from gorm.DB's embedded Dialector.
+	if db.Name() != "sqlite" {
+		return "ok", true
+	}
+	// Bound the scan: quick_check reads every page and runs on the single pinned
+	// SQLite connection, so an unbounded run would block writes for its full
+	// duration. A context timeout interrupts it (the SQLite driver honors
+	// cancellation), capping the worst-case write stall (#3939).
+	ctx, cancel := context.WithTimeout(context.Background(), v2IntegrityCheckTimeout)
+	defer cancel()
+	var rows []string
+	if err := db.WithContext(ctx).Raw("PRAGMA quick_check").Scan(&rows).Error; err != nil {
+		if ds.log != nil {
+			ds.log.Warn("database integrity quick_check failed to run", logger.Error(err))
+		}
+		return "", false
+	}
+	joined := strings.Join(rows, "; ")
+	if joined == "" {
+		return "ok", true
+	}
+	return joined, true
 }
 
 // CountDetectionsSince returns the number of detections recorded since the given time.
@@ -2753,7 +2856,6 @@ func (ds *Datastore) GetHourlyAnalyticsData(ctx context.Context, date, species s
 	}
 	return result, nil
 }
-
 
 // errNotFound is returned by resolveLabelIDs when no label carries the species name.
 var errNotFound = errors.NewStd("species not found")

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -540,6 +540,17 @@ const v2IntegrityCacheTTL = 24 * time.Hour
 // pathological hang (#3939).
 const v2IntegrityCheckTimeout = 2 * time.Minute
 
+const (
+	// integrityResultOK is the healthy PRAGMA quick_check result. DatabaseIntegrityCheck.Run
+	// maps any non-empty, non-"ok" result to a corruption status, so this exact value
+	// is the integrity-result contract shared across cache reads, writes and the
+	// non-SQLite path.
+	integrityResultOK = "ok"
+	// sqliteDialectName is gorm's dialect name for SQLite (db.Name()); other dialects
+	// have no PRAGMA quick_check equivalent.
+	sqliteDialectName = "sqlite"
+)
+
 // IntegrityResult reports the cached database integrity result and whether the
 // database is corrupted, for the Database Integrity health check (#3939). It
 // mirrors the legacy SQLiteStore accessor so the check can read integrity through
@@ -558,7 +569,7 @@ func (ds *Datastore) IntegrityResult() (string, bool) {
 	fresh := cached != "" && time.Since(ds.integrityCheckedAt) < v2IntegrityCacheTTL
 	ds.integrityMu.RUnlock()
 	if fresh {
-		return cached, cached != "ok"
+		return cached, cached != integrityResultOK
 	}
 
 	// Slow path: recompute under the write lock so concurrent callers with a cold or
@@ -572,7 +583,7 @@ func (ds *Datastore) IntegrityResult() (string, bool) {
 	// Re-check under the write lock: another caller may have refreshed it while we
 	// waited for the lock.
 	if ds.integrityResult != "" && time.Since(ds.integrityCheckedAt) < v2IntegrityCacheTTL {
-		return ds.integrityResult, ds.integrityResult != "ok"
+		return ds.integrityResult, ds.integrityResult != integrityResultOK
 	}
 
 	result, ran := ds.runIntegrityQuickCheck()
@@ -584,7 +595,7 @@ func (ds *Datastore) IntegrityResult() (string, bool) {
 	}
 	ds.integrityResult = result
 	ds.integrityCheckedAt = time.Now()
-	return result, result != "ok"
+	return result, result != integrityResultOK
 }
 
 // runIntegrityQuickCheck executes PRAGMA quick_check on SQLite and returns the
@@ -601,8 +612,8 @@ func (ds *Datastore) runIntegrityQuickCheck() (result string, ran bool) {
 	// self-check and have no equivalent, so report healthy rather than tripping
 	// the corruption branch of the health check. db.Name() is the dialect name
 	// ("sqlite"/"mysql"), promoted from gorm.DB's embedded Dialector.
-	if db.Name() != "sqlite" {
-		return "ok", true
+	if db.Name() != sqliteDialectName {
+		return integrityResultOK, true
 	}
 	// Bound the scan: quick_check reads every page and runs on the single pinned
 	// SQLite connection, so an unbounded run would block writes for its full
@@ -619,7 +630,7 @@ func (ds *Datastore) runIntegrityQuickCheck() (result string, ran bool) {
 	}
 	joined := strings.Join(rows, "; ")
 	if joined == "" {
-		return "ok", true
+		return integrityResultOK, true
 	}
 	return joined, true
 }

--- a/internal/datastore/v2only/integrity_integration_test.go
+++ b/internal/datastore/v2only/integrity_integration_test.go
@@ -1,0 +1,22 @@
+//go:build integration
+
+package v2only
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIntegrityResult_MySQLReportsOK verifies the non-SQLite branch: PRAGMA
+// quick_check is SQLite-specific, so on MySQL the accessor must report "ok"
+// (healthy) rather than "" or a "skipped"-style sentinel. DatabaseIntegrityCheck.Run
+// treats "" as StatusUnknown and any non-"ok", non-empty result as corruption, so
+// only "ok" avoids both a permanent Unknown and a false corruption alarm on MySQL.
+func TestIntegrityResult_MySQLReportsOK(t *testing.T) {
+	ds := setupMySQLDatastore(t)
+
+	result, corrupted := ds.IntegrityResult()
+	assert.Equal(t, "ok", result, "MySQL has no PRAGMA quick_check; report healthy so the check reads neither Unknown nor corrupted")
+	assert.False(t, corrupted)
+}

--- a/internal/datastore/v2only/integrity_test.go
+++ b/internal/datastore/v2only/integrity_test.go
@@ -1,0 +1,58 @@
+package v2only
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Compile-time assurance that *Datastore satisfies the integrity accessor the
+// diagnostics Database Integrity health check reads through (mirrors the
+// consumer-side integrityResulter interface in internal/api/v2/system). This is
+// the coupling #3939 relies on: the check reads integrity from the v2 datastore
+// via this method instead of asserting the legacy *datastore.SQLiteStore type.
+var _ interface {
+	IntegrityResult() (string, bool)
+} = (*Datastore)(nil)
+
+// TestIntegrityResult_HealthySQLite verifies a healthy v2 SQLite datastore
+// reports "ok" and not corrupted. Before #3939 the health check could not read
+// integrity from a v2 datastore at all and reported StatusUnknown forever.
+func TestIntegrityResult_HealthySQLite(t *testing.T) {
+	t.Parallel()
+	ds, cleanup := setupTestDatastore(t)
+	t.Cleanup(cleanup)
+
+	result, corrupted := ds.IntegrityResult()
+	assert.Equal(t, "ok", result, "a healthy in-memory SQLite database passes PRAGMA quick_check")
+	assert.False(t, corrupted, "a healthy database is not corrupted")
+}
+
+// TestIntegrityResult_CachesWithinTTL verifies the result is cached: a second
+// call within the TTL serves the stored value without recomputing (the cache
+// timestamp is unchanged). quick_check can be slow on a large database, so the
+// on-demand health check must not re-run it on every page load.
+func TestIntegrityResult_CachesWithinTTL(t *testing.T) {
+	t.Parallel()
+	ds, cleanup := setupTestDatastore(t)
+	t.Cleanup(cleanup)
+
+	result, corrupted := ds.IntegrityResult()
+	require.Equal(t, "ok", result)
+	require.False(t, corrupted)
+
+	ds.integrityMu.RLock()
+	firstCheckedAt := ds.integrityCheckedAt
+	ds.integrityMu.RUnlock()
+	require.False(t, firstCheckedAt.IsZero(), "first call must cache a result with a timestamp")
+
+	result, corrupted = ds.IntegrityResult()
+	assert.Equal(t, "ok", result)
+	assert.False(t, corrupted)
+
+	ds.integrityMu.RLock()
+	secondCheckedAt := ds.integrityCheckedAt
+	ds.integrityMu.RUnlock()
+	assert.Equal(t, firstCheckedAt, secondCheckedAt, "a call within the TTL must serve the cached result, not recompute it")
+}


### PR DESCRIPTION
## Summary

Folds five related fixes where a status surface misled the user.

**Model not-analyzing notifications (#4208):** a transient AddRoute failure during a reconfigure no longer fires a false "model not analyzing" bell. The alarm is suppressed on the first failure of a reconfigure pass and raised only if the route is still down on the next pass; start and restart failures report immediately, so a genuine startup outage is never silenced. The per-source failure memory is cleared when a source is removed.

**Not-analyzing badge and header (#4209):** the per-source badge uses the filled error variant (the outline variant failed WCAG AA contrast); the reason is a single visible per-model line reachable by keyboard and touch via `aria-describedby`; the model header no longer shows a benign "Idle" that contradicts the badge, showing the attention state only when the model produces no throughput and has a not-running source; and the remediation copy points at System > AI Models instead of the model gallery, which has no per-source liveness view.

**Species rarity when the range filter is unavailable (#3935):** a species reads "unknown" instead of a confident "Very Rare 0%" when the range filter produced no real scores (no backend loaded, or no location configured). The signal is derived in the same locked snapshot as the scores, so it cannot desync with a concurrent unload.

**Database Integrity health check on v2 installs (#3939):** the check read integrity only from the legacy datastore and showed "Unknown" forever on v2. It now reads through a small interface both stores implement, and the v2 store runs a cached, context-bounded `PRAGMA quick_check` (SQLite only; other engines report healthy), deduplicated so a cold cache cannot start concurrent scans.

**Dashboard crash guard:** duplicate Svelte `{#each}` keys white-screened `/ui/dashboard` (Sentry BIRDNET-GO-2HP). The recent-detections grid de-duplicates by id, and the currently-hearing and new-species cards use stable, de-duplicated keys.

Reworded notification and tooltip copy is translated across all 16 locales.

## Related Issues

Fixes #4208
Fixes #4209
Fixes #3935
Fixes #3939

## Test Plan

- [x] `go build ./...`, `go vet`, and `golangci-lint run` (0 issues across all build tags) are clean; `go test -race` passes on the touched packages
- [x] Frontend `npm run check:all` and the full test suite (2907 tests) pass; i18n validation passes and generated types are in sync
- [ ] Manual: a model with a not-fed source shows "not analyzing" (not "Idle") with an actionable reason; a species reads "unknown" when the range filter is unavailable; the Database Integrity check reports a real result on a v2 install; the dashboard renders with duplicate detections present


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate detection, species, and highlight cards from appearing on the dashboard.
  * Preserved separate detections when their timestamps differ.
  * Improved AI model status reporting when assigned audio sources are not sending audio.
  * Reduced false “not analyzing” alerts during temporary source reconfiguration.
  * Species rarity now displays as unknown when location filtering is unavailable, rather than incorrectly showing “very rare.”

* **Documentation**
  * Updated model-status guidance and translations to direct users to **System > AI Models** and source connectivity checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->