### PR TITLE
fix(classifier,analysis): status-honesty and reuse follow-ups

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -531,7 +531,7 @@ func (p *AudioPipelineService) restartAudioCapture() {
 		logger.String("operation", "restart_audio_capture"))
 
 	// Remove all existing sources.
-	p.removeAllSources("restart")
+	p.removeAllSources(operationRestart)
 
 	// Re-resolve the primary model's buffer dimensions from current settings
 	// before re-adding sources, so a hot-reloaded birdnet.overlap takes effect
@@ -540,7 +540,7 @@ func (p *AudioPipelineService) restartAudioCapture() {
 
 	// Re-add sources, register consumers, and update buffer monitors.
 	audioLevelChan := p.apiService.AudioLevelChan()
-	p.setupAudioSources(audioLevelChan, "restart")
+	p.setupAudioSources(audioLevelChan, operationRestart)
 }
 
 // applyPrimaryModelDims resolves the primary model's analysis-buffer dimensions
@@ -594,6 +594,10 @@ func (p *AudioPipelineService) RestartSource(sourceID string) error {
 	// under a fresh registry ID, so any retained "failed last pass" entry for the old
 	// ID is stale and would otherwise never be pruned (#4208).
 	delete(p.routeFailedLastPass, sourceID)
+	// Same reasoning for the model-not-registered suppression window: the old ID's
+	// entries would otherwise be orphaned once the source returns under a fresh ID
+	// (symmetric with the route-failure clear above and the removal-loop clears).
+	clearModelNotRegistered(sourceID)
 
 	// 3. Remove source from engine (stops capture, removes routes, deallocates buffers, unregisters).
 	if err := p.engine.RemoveSource(sourceID); err != nil {
@@ -671,6 +675,10 @@ func (p *AudioPipelineService) removeAllSources(operation string) {
 				logger.Error(err),
 				logger.String("operation", operation))
 		}
+		// The source is going away; drop its model-not-registered suppression window so
+		// a source reusing this ID later re-notifies instead of being silenced by a
+		// stale entry within the 6h window.
+		clearModelNotRegistered(src.ID)
 	}
 	// engine.RemoveSource removes router routes but has no knowledge of the
 	// soundlevel tracking map. Clear the map to keep it in sync with actual
@@ -1023,6 +1031,7 @@ func routeReportDecision(bufferRouteOK, failedLastPass, suppressTransient bool, 
 // classifier switch and the call sites that pass these values must share one vocabulary.
 const (
 	operationStart             = "start"
+	operationRestart           = "restart"
 	operationRestartSource     = "restart_source"
 	operationReconfigureDiff   = "reconfigure_diff"
 	operationReconfigureParams = "reconfigure_params"
@@ -1069,7 +1078,7 @@ func (p *AudioPipelineService) reportSourceRegistration(mm *classifier.ModelMana
 	} else {
 		p.routeFailedLastPass[sid] = true
 	}
-	reportUnregisteredModels(mm, sourceName, skipped, assigned, registered)
+	reportUnregisteredModels(mm, sid, sourceName, skipped, assigned, registered)
 }
 
 // registerConsumersForSources registers BufferConsumer and AudioLevelConsumer
@@ -1483,6 +1492,9 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 		// Drop the route-failure memory too, so a source ID re-added later starts
 		// with a clean first-pass grace rather than a stale "failed last pass" (#4208).
 		delete(p.routeFailedLastPass, src.ID)
+		// Likewise drop the model-not-registered suppression window for the removed
+		// source so a later re-add re-notifies instead of being silenced by a stale entry.
+		clearModelNotRegistered(src.ID)
 	}
 
 	// Register consumers and monitors only for newly added sources.
@@ -1874,11 +1886,16 @@ func resolveModelTargets(configModelIDs []string, loadedModels map[string]classi
 // The shortfall is otherwise silent: detection keeps working for the models that
 // did register, so nothing looks broken, and the only trace is a warning in a
 // log file. Users have lost a model for days this way (GitHub #4201, #4204).
-func reportUnregisteredModels(mm *classifier.ModelManager, sourceName string, skipped []string, resolved []classifier.ModelInfo, allocated map[string]bool) {
+func reportUnregisteredModels(mm *classifier.ModelManager, sourceID, sourceName string, skipped []string, resolved []classifier.ModelInfo, allocated map[string]bool) {
 	notRegistered := unregisteredModelNames(mm, skipped, resolved, allocated)
 	if len(notRegistered) > 0 {
-		notifyModelsNotRegistered(sourceName, notRegistered)
+		notifyModelsNotRegistered(sourceID, sourceName, notRegistered)
+		return
 	}
+	// Every assigned model registered: clear any prior suppression window for this source
+	// so a later failure re-notifies immediately rather than being silenced for the rest
+	// of the 6h window (symmetric with the routeFailedLastPass recovery clear).
+	clearModelNotRegistered(sourceID)
 }
 
 // unregisteredModelNames returns the display names of models that will not

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -1078,7 +1078,13 @@ func (p *AudioPipelineService) reportSourceRegistration(mm *classifier.ModelMana
 	} else {
 		p.routeFailedLastPass[sid] = true
 	}
-	reportUnregisteredModels(mm, sid, sourceName, skipped, assigned, registered)
+	reportUnregisteredModels(mm, &modelRegistrationReport{
+		sourceID:   sid,
+		sourceName: sourceName,
+		skipped:    skipped,
+		resolved:   assigned,
+		allocated:  registered,
+	})
 }
 
 // registerConsumersForSources registers BufferConsumer and AudioLevelConsumer
@@ -1872,6 +1878,18 @@ func resolveModelTargets(configModelIDs []string, loadedModels map[string]classi
 	return targets, skipped
 }
 
+// modelRegistrationReport groups the per-source registration result that
+// reportUnregisteredModels inspects. mm stays a separate dependency parameter; grouping
+// the source and result payload keeps the call within the >3-parameters convention and
+// prevents positional-argument mistakes as this lifecycle payload grows.
+type modelRegistrationReport struct {
+	sourceID   string
+	sourceName string
+	skipped    []string               // config IDs that did not resolve/load
+	resolved   []classifier.ModelInfo // models the source assigns that did resolve
+	allocated  map[string]bool        // registry IDs whose analysis buffer was allocated
+}
+
 // reportUnregisteredModels raises a user-visible notification for models that a
 // source's configuration assigns but which will not receive its audio, either
 // because they never loaded (skipped) or because their analysis buffer could
@@ -1886,16 +1904,16 @@ func resolveModelTargets(configModelIDs []string, loadedModels map[string]classi
 // The shortfall is otherwise silent: detection keeps working for the models that
 // did register, so nothing looks broken, and the only trace is a warning in a
 // log file. Users have lost a model for days this way (GitHub #4201, #4204).
-func reportUnregisteredModels(mm *classifier.ModelManager, sourceID, sourceName string, skipped []string, resolved []classifier.ModelInfo, allocated map[string]bool) {
-	notRegistered := unregisteredModelNames(mm, skipped, resolved, allocated)
+func reportUnregisteredModels(mm *classifier.ModelManager, report *modelRegistrationReport) {
+	notRegistered := unregisteredModelNames(mm, report.skipped, report.resolved, report.allocated)
 	if len(notRegistered) > 0 {
-		notifyModelsNotRegistered(sourceID, sourceName, notRegistered)
+		notifyModelsNotRegistered(report.sourceID, report.sourceName, notRegistered)
 		return
 	}
 	// Every assigned model registered: clear any prior suppression window for this source
 	// so a later failure re-notifies immediately rather than being silenced for the rest
 	// of the 6h window (symmetric with the routeFailedLastPass recovery clear).
-	clearModelNotRegistered(sourceID)
+	clearModelNotRegistered(report.sourceID)
 }
 
 // unregisteredModelNames returns the display names of models that will not

--- a/internal/analysis/buffer_manager.go
+++ b/internal/analysis/buffer_manager.go
@@ -552,7 +552,13 @@ func (m *BufferManager) processMonitorTick(
 	beginTimeOffset := time.Duration(conf.Setting().Realtime.Audio.Export.PreCapture)*time.Second + detectionOffset
 	startTime := time.Now().Add(-beginTimeOffset)
 
-	if processErr := ProcessData(context.Background(), m.bn, m.bufferMgr, data, startTime, audioCapturedAt, cfg.sourceID, cfg.modelID); processErr != nil {
+	if processErr := ProcessData(context.Background(), m.bn, m.bufferMgr, &ProcessRequest{
+		Data:            data,
+		StartTime:       startTime,
+		AudioCapturedAt: audioCapturedAt,
+		Source:          cfg.sourceID,
+		ModelID:         cfg.modelID,
+	}); processErr != nil {
 		m.logger.Error("error processing data",
 			logger.String("source_id", cfg.sourceID),
 			logger.String("model_id", cfg.modelID),

--- a/internal/analysis/model_registration_notify.go
+++ b/internal/analysis/model_registration_notify.go
@@ -17,7 +17,21 @@ import (
 // that reconnects in a loop would bury the notification list.
 const modelNotRegisteredRenotifyInterval = 6 * time.Hour
 
-var modelNotRegisteredSeen sync.Map // key: source + models, value: time.Time of last notification
+var modelNotRegisteredSeen sync.Map // key: modelNotRegisteredKey(sourceID, models), value: time.Time of last notification
+
+// modelNotRegisteredKeySep separates the source ID from the model list in a
+// suppression-map key. It is a NUL byte so it cannot occur inside a source ID (RTSP
+// URLs and device IDs never contain NUL), which keeps a source-ID prefix an unambiguous
+// match in clearModelNotRegistered.
+const modelNotRegisteredKeySep = "\x00"
+
+// modelNotRegisteredKey composes the suppression-map key for a source and its
+// unregistered-model list. notifyModelsNotRegistered (which writes keys) and
+// clearModelNotRegistered (which matches them by source-ID prefix) both build their keys
+// from this one definition, so the two key formats cannot drift apart.
+func modelNotRegisteredKey(sourceID, models string) string {
+	return sourceID + modelNotRegisteredKeySep + models
+}
 
 // notifyModelsNotRegistered reports that models assigned to an audio source are
 // not receiving its audio, either because they never loaded or because their
@@ -29,7 +43,7 @@ var modelNotRegisteredSeen sync.Map // key: source + models, value: time.Time of
 // healthy while analyzing with fewer models than configured. The reporters of
 // GitHub #4201 and #4204 each lost a model for days before noticing by
 // accident.
-func notifyModelsNotRegistered(sourceName string, modelIDs []string) {
+func notifyModelsNotRegistered(sourceID, sourceName string, modelIDs []string) {
 	if len(modelIDs) == 0 {
 		return
 	}
@@ -39,7 +53,11 @@ func notifyModelsNotRegistered(sourceName string, modelIDs []string) {
 	}
 
 	models := strings.Join(modelIDs, ", ")
-	key := sourceName + "\x00" + models
+	// Key the suppression window by the unique source ID, not the display name: display
+	// names can collide (two streams both named "Backyard"), and a shared key would let
+	// one source's recovery clear another's window, or one source's failure gate another's
+	// notification. The human-readable sourceName is used only for the notification text.
+	key := modelNotRegisteredKey(sourceID, models)
 	now := time.Now()
 	if last, ok := modelNotRegisteredSeen.Load(key); ok {
 		if t, isTime := last.(time.Time); isTime && now.Sub(t) < modelNotRegisteredRenotifyInterval {
@@ -82,4 +100,21 @@ func notifyModelsNotRegistered(sourceName string, modelIDs []string) {
 		return
 	}
 	modelNotRegisteredSeen.Store(key, now)
+}
+
+// clearModelNotRegistered drops every suppression entry for a source, so the next genuine
+// "model not analyzing" condition re-notifies immediately instead of being silenced for the
+// remainder of the 6h window. Call it when a source registers all its assigned models
+// successfully (recovery) and when a source is removed. The suppression key is
+// sourceID + "\x00" + models and the previously reported model set is not known here, so
+// every entry under the sourceID prefix is cleared. Deleting during Range is safe for
+// sync.Map.
+func clearModelNotRegistered(sourceID string) {
+	prefix := sourceID + modelNotRegisteredKeySep
+	modelNotRegisteredSeen.Range(func(k, _ any) bool {
+		if key, ok := k.(string); ok && strings.HasPrefix(key, prefix) {
+			modelNotRegisteredSeen.Delete(key)
+		}
+		return true
+	})
 }

--- a/internal/analysis/model_registration_notify_test.go
+++ b/internal/analysis/model_registration_notify_test.go
@@ -1,0 +1,103 @@
+package analysis
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestModelNotRegisteredKey pins the suppression-map key format and the collision-fix
+// invariant: the key is composed from the SOURCE ID (not the display name), so two sources
+// that share a display name (and therefore the same model string) but differ by ID produce
+// distinct keys. notifyModelsNotRegistered (writer) and clearModelNotRegistered (prefix
+// matcher) both build keys from this one helper, so a key-format divergence between them is
+// impossible by construction.
+func TestModelNotRegisteredKey(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "src-a\x00perch_v2", modelNotRegisteredKey("src-a", "perch_v2"),
+		"key is sourceID + NUL + models")
+	assert.NotEqual(t, modelNotRegisteredKey("src-a", "perch_v2"), modelNotRegisteredKey("src-b", "perch_v2"),
+		"distinct source IDs must not share a suppression key even when the model string matches")
+}
+
+// TestClearModelNotRegistered verifies the recovery/removal clear drops only the target
+// source's suppression entries. Keys are built through modelNotRegisteredKey (the same
+// writer notifyModelsNotRegistered uses), so the test round-trips the production key format
+// rather than a hand-written copy of it. Two sources sharing a display name (a real
+// possibility the runtime tolerates) must not clear each other's window.
+func TestClearModelNotRegistered(t *testing.T) {
+	// Not parallel: mutates the package-global modelNotRegisteredSeen.
+	const (
+		sidA = "src-aaaa"
+		sidB = "src-bbbb"
+	)
+	// Both sources carry the same display-name-derived model string; only the source-ID
+	// prefix distinguishes their keys.
+	keyA := modelNotRegisteredKey(sidA, "perch_v2")
+	keyB := modelNotRegisteredKey(sidB, "perch_v2")
+	now := time.Now()
+	modelNotRegisteredSeen.Store(keyA, now)
+	modelNotRegisteredSeen.Store(keyB, now)
+	t.Cleanup(func() {
+		modelNotRegisteredSeen.Delete(keyA)
+		modelNotRegisteredSeen.Delete(keyB)
+	})
+
+	clearModelNotRegistered(sidA)
+
+	_, aPresent := modelNotRegisteredSeen.Load(keyA)
+	_, bPresent := modelNotRegisteredSeen.Load(keyB)
+	assert.False(t, aPresent, "the cleared source's suppression entry must be removed")
+	assert.True(t, bPresent, "another source's entry (even with an identical model string) must survive")
+}
+
+// TestClearModelNotRegistered_PrefixIsExactSegment guards the NUL delimiter's load-bearing
+// role: a source ID that is a plain string prefix of another ("src" vs "src-2") must NOT
+// clear the longer one, because the delimiter makes the ID an exact key segment rather than
+// a raw string prefix.
+func TestClearModelNotRegistered_PrefixIsExactSegment(t *testing.T) {
+	const (
+		sidShort = "src"
+		sidLong  = "src-2"
+	)
+	kShort := modelNotRegisteredKey(sidShort, "perch_v2")
+	kLong := modelNotRegisteredKey(sidLong, "perch_v2")
+	now := time.Now()
+	modelNotRegisteredSeen.Store(kShort, now)
+	modelNotRegisteredSeen.Store(kLong, now)
+	t.Cleanup(func() {
+		modelNotRegisteredSeen.Delete(kShort)
+		modelNotRegisteredSeen.Delete(kLong)
+	})
+
+	clearModelNotRegistered(sidShort)
+
+	_, shortPresent := modelNotRegisteredSeen.Load(kShort)
+	_, longPresent := modelNotRegisteredSeen.Load(kLong)
+	assert.False(t, shortPresent, "the exact source's entry is cleared")
+	assert.True(t, longPresent, "a source whose ID merely shares a string prefix must NOT be cleared")
+}
+
+// TestClearModelNotRegistered_MultipleModelSets clears every entry for a source regardless
+// of which model set was previously reported: the recovery path does not know the prior
+// unregistered set, so it clears by source-ID prefix.
+func TestClearModelNotRegistered_MultipleModelSets(t *testing.T) {
+	const sid = "src-multi"
+	k1 := modelNotRegisteredKey(sid, "perch_v2")
+	k2 := modelNotRegisteredKey(sid, "perch_v2, bat")
+	now := time.Now()
+	modelNotRegisteredSeen.Store(k1, now)
+	modelNotRegisteredSeen.Store(k2, now)
+	t.Cleanup(func() {
+		modelNotRegisteredSeen.Delete(k1)
+		modelNotRegisteredSeen.Delete(k2)
+	})
+
+	clearModelNotRegistered(sid)
+
+	_, p1 := modelNotRegisteredSeen.Load(k1)
+	_, p2 := modelNotRegisteredSeen.Load(k2)
+	assert.False(t, p1, "all suppression entries for the source must be cleared")
+	assert.False(t, p2, "all suppression entries for the source must be cleared")
+}

--- a/internal/analysis/process.go
+++ b/internal/analysis/process.go
@@ -242,6 +242,18 @@ func SetProcessMetrics(myAudioMetrics *metrics.MyAudioMetrics) {
 	processMetrics.CompareAndSwap(nil, myAudioMetrics)
 }
 
+// ProcessRequest carries the per-window audio payload and identifiers for one
+// ProcessData call. ctx, the classifier backend, and the *buffer.Manager stay separate
+// parameters (they are collaborators, not request data); grouping the payload keeps the
+// call within the >3-parameters-use-a-struct convention.
+type ProcessRequest struct {
+	Data            []byte    // raw PCM bytes for this analysis window
+	StartTime       time.Time // wall-clock start of the analysis window
+	AudioCapturedAt time.Time // capture timestamp used for detection alignment
+	Source          string    // audio source ID
+	ModelID         string    // registry model ID to run inference with
+}
+
 // ProcessData processes the given audio data to detect bird species, logs the
 // detected species and optionally saves the audio clip if a bird species is
 // detected above the configured threshold.
@@ -250,7 +262,7 @@ func SetProcessMetrics(myAudioMetrics *metrics.MyAudioMetrics) {
 // bufMgr is the audiocore buffer manager owning the Float32Pool that the
 // 16-bit conversion hot path draws from. Must be non-nil; callers that reach
 // ProcessData without a manager have a plumbing bug.
-func ProcessData(ctx context.Context, bn classifierBackend, bufMgr *buffer.Manager, data []byte, startTime, audioCapturedAt time.Time, source, modelID string) error {
+func ProcessData(ctx context.Context, bn classifierBackend, bufMgr *buffer.Manager, req *ProcessRequest) error {
 	if bufMgr == nil {
 		return errors.Newf("buffer manager must not be nil").
 			Component("analysis").
@@ -258,6 +270,21 @@ func ProcessData(ctx context.Context, bn classifierBackend, bufMgr *buffer.Manag
 			Context("operation", "process_data").
 			Build()
 	}
+	if req == nil {
+		return errors.Newf("process request must not be nil").
+			Component("analysis").
+			Category(errors.CategoryValidation).
+			Context("operation", "process_data").
+			Build()
+	}
+	// Unpack the request payload into the local names the body below uses so the
+	// hot-path logic is unchanged by the parameter-grouping refactor. req is passed by
+	// pointer because the struct is large enough that gocritic flags a by-value copy.
+	data := req.Data
+	startTime := req.StartTime
+	audioCapturedAt := req.AudioCapturedAt
+	source := req.Source
+	modelID := req.ModelID
 	log := GetLogger()
 	// get current time to track processing time
 	predictStart := time.Now()

--- a/internal/analysis/route_report_decision_test.go
+++ b/internal/analysis/route_report_decision_test.go
@@ -63,7 +63,7 @@ func TestIsReconfigureOperation(t *testing.T) {
 		{"gain_change suppresses first failure", operationGainChange, true},
 		{"model_change suppresses first failure", operationModelChange, true},
 		{"start reports immediately", operationStart, false},
-		{"restart reports immediately", "restart", false},
+		{"restart reports immediately", operationRestart, false},
 		{"restart_source reports immediately", operationRestartSource, false},
 		{"empty reports immediately", "", false},
 		{"unknown reports immediately", "unknown", false},

--- a/internal/api/v2/species/species.go
+++ b/internal/api/v2/species/species.go
@@ -547,13 +547,15 @@ func computeRarity(filterActive bool, targetSci string, speciesScores []classifi
 func (c *Handler) getSpeciesRarityInfo(bn *classifier.Orchestrator, speciesLabel string) (SpeciesRarityInfo, error) {
 	// Get current local date
 	today := conf.LocalNoon(time.Now())
-	settings := bn.CurrentSettings()
 
 	// Rarity is the geomodel occurrence probability, so use the geomodel-backed
 	// probable-species list, not the multi-model union: the union assigns synthetic
 	// always-active scores (1.0) to secondary-model species (bats, Perch) that have
 	// no real occurrence probability, which would misclassify them as "very common".
-	speciesScores, geomodelLabels, classifierLabels, filterActive, err := bn.GetRarityContext(today)
+	// GetRarityContext returns the settings snapshot it scored against, so location,
+	// threshold, coordinates and filterActive below all describe one settings generation;
+	// a concurrent reload cannot desynchronise the rarity number from its metadata.
+	rc, err := bn.GetRarityContext(today)
 	if err != nil {
 		return SpeciesRarityInfo{}, errors.New(err).
 			Category(errors.CategoryProcessing).
@@ -561,21 +563,21 @@ func (c *Handler) getSpeciesRarityInfo(bn *classifier.Orchestrator, speciesLabel
 			Component("api-species").
 			Build()
 	}
+	// rc.Settings is the snapshot the scores were produced from, so every field below
+	// describes one settings generation. It is non-nil for a running orchestrator (this
+	// handler always has a primary); see GetRarityContext.
+	settings := rc.Settings
 
-	// Create rarity info. location_based reports whether this rarity number is actually
-	// derived from the location-based range filter, so it tracks filterActive, not merely
-	// whether coordinates are configured. With coordinates set but the filter inactive
-	// (e.g. the geomodel failed to load), computeRarity returns unknown; leaving
-	// location_based true here would make the UI render "Unknown 0% - Based on location"
-	// and partially reintroduce the false 0% that #3935 removed. The && LocationConfigured
-	// ties location_based to the SAME settings snapshot as the coordinate gate below
-	// (filterActive comes from a separate snapshot taken inside GetRarityContext): in
-	// steady state filterActive already implies LocationConfigured, so this is a no-op,
-	// but it guarantees a concurrent settings reload can never pair location_based=true
-	// with omitted coordinates (which the frontend would then render undefined).
+	// location_based reports whether this rarity number is actually derived from the
+	// location-based range filter, so it tracks filterActive rather than merely whether
+	// coordinates are configured: with coordinates set but the filter inactive (e.g. the
+	// geomodel failed to load), computeRarity returns unknown, and reporting
+	// location_based=true would render "Unknown 0% - Based on location" and partially
+	// reintroduce the false 0% that #3935 removed. filterActive implies LocationConfigured
+	// within this one snapshot, so location_based=true always has coordinates to show.
 	rarityInfo := SpeciesRarityInfo{
 		Date:             today.Format(time.DateOnly),
-		LocationBased:    filterActive && settings.BirdNET.LocationConfigured,
+		LocationBased:    rc.FilterActive,
 		ThresholdApplied: float64(settings.BirdNET.RangeFilter.Threshold),
 	}
 
@@ -590,7 +592,7 @@ func (c *Handler) getSpeciesRarityInfo(bn *classifier.Orchestrator, speciesLabel
 	// Resolve the score and status together; computeRarity documents how an absent
 	// species is split between "very rare" and "unknown" by geomodel coverage.
 	targetSci := detection.ExtractScientificName(speciesLabel)
-	rarityInfo.Score, rarityInfo.Status = computeRarity(filterActive, targetSci, speciesScores, geomodelLabels, classifierLabels)
+	rarityInfo.Score, rarityInfo.Status = computeRarity(rc.FilterActive, targetSci, rc.Scores, rc.GeomodelLabels, rc.ClassifierLabels)
 
 	return rarityInfo, nil
 }

--- a/internal/api/v2/species/species.go
+++ b/internal/api/v2/species/species.go
@@ -562,15 +562,27 @@ func (c *Handler) getSpeciesRarityInfo(bn *classifier.Orchestrator, speciesLabel
 			Build()
 	}
 
-	// Create rarity info
+	// Create rarity info. location_based reports whether this rarity number is actually
+	// derived from the location-based range filter, so it tracks filterActive, not merely
+	// whether coordinates are configured. With coordinates set but the filter inactive
+	// (e.g. the geomodel failed to load), computeRarity returns unknown; leaving
+	// location_based true here would make the UI render "Unknown 0% - Based on location"
+	// and partially reintroduce the false 0% that #3935 removed. The && LocationConfigured
+	// ties location_based to the SAME settings snapshot as the coordinate gate below
+	// (filterActive comes from a separate snapshot taken inside GetRarityContext): in
+	// steady state filterActive already implies LocationConfigured, so this is a no-op,
+	// but it guarantees a concurrent settings reload can never pair location_based=true
+	// with omitted coordinates (which the frontend would then render undefined).
 	rarityInfo := SpeciesRarityInfo{
 		Date:             today.Format(time.DateOnly),
-		LocationBased:    settings.BirdNET.LocationConfigured,
+		LocationBased:    filterActive && settings.BirdNET.LocationConfigured,
 		ThresholdApplied: float64(settings.BirdNET.RangeFilter.Threshold),
 	}
 
-	// Add location if available
-	if rarityInfo.LocationBased {
+	// Surface the configured coordinates whenever a location is set, independent of
+	// whether the filter is currently active, so a client still learns the location is
+	// known even when the rarity itself is unknown.
+	if settings.BirdNET.LocationConfigured {
 		rarityInfo.Latitude = settings.BirdNET.Latitude
 		rarityInfo.Longitude = settings.BirdNET.Longitude
 	}

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -2557,6 +2557,19 @@ func (o *Orchestrator) loadAdditionalModels(threadAlloc map[string]int) error {
 	return nil
 }
 
+// RarityContext bundles everything a caller needs to compute a species' rarity from one
+// coherent settings generation: the probable-species scores, the two label vocabularies
+// used to interpret them, whether the range filter was active, and the settings snapshot
+// the scores were produced from. See GetRarityContext for the per-field semantics and the
+// consistency guarantees.
+type RarityContext struct {
+	Scores           []SpeciesScore
+	GeomodelLabels   []string
+	ClassifierLabels []string
+	FilterActive     bool
+	Settings         *conf.Settings
+}
+
 // GetRarityContext returns the primary model's probable-species scores together with
 // the two label vocabularies needed to interpret them, so a caller computing rarity
 // does not have to reassemble them from calls that can each observe a different model.
@@ -2589,7 +2602,16 @@ func (o *Orchestrator) loadAdditionalModels(threadAlloc map[string]int) error {
 // predictions; it is false when they are the synthetic all-zero fallback (no range
 // filter loaded, or no location configured), so a caller can avoid reporting a zero as
 // "very rare" (#3935).
-func (o *Orchestrator) GetRarityContext(date time.Time) (scores []SpeciesScore, geomodelLabels, classifierLabels []string, filterActive bool, err error) {
+//
+// The returned RarityContext bundles the settings snapshot the scores were produced from
+// together with the scores, the two vocabularies, and filterActive, so a caller
+// assembling rarity metadata (location, threshold, coordinates) derives every field from
+// the SAME settings generation as the score rather than taking a second,
+// independently-resolved CurrentSettings() read that a concurrent reload could
+// desynchronise from the score. Settings is non-nil whenever a primary exists or any
+// settings have been published (i.e. in a running app); it can be nil only for an
+// uninitialised orchestrator, so a caller that may run before startup must nil-check it.
+func (o *Orchestrator) GetRarityContext(date time.Time) (RarityContext, error) {
 	// Snapshot the primary once and drive every read below from it. Delegating to
 	// o.GetProbableSpecies would re-resolve o.primary under a fresh lock and could
 	// score against a different model than the labels describe.
@@ -2597,7 +2619,8 @@ func (o *Orchestrator) GetRarityContext(date time.Time) (scores []SpeciesScore, 
 	primary := o.primary
 	o.mu.RUnlock()
 	if primary == nil {
-		return nil, nil, nil, false, nil
+		// No primary, so no scores: hand back the orchestrator's current snapshot.
+		return RarityContext{Settings: o.CurrentSettings()}, nil
 	}
 
 	settings := primary.currentSettings()
@@ -2609,8 +2632,12 @@ func (o *Orchestrator) GetRarityContext(date time.Time) (scores []SpeciesScore, 
 	// filterActive=true with synthetic zeros, and it also covers the no-location case
 	// a bare rangeFilter!=nil check missed, so a caller never reports a synthetic zero
 	// as "very rare" (#3935).
-	scores, geomodelLabels, filterActive, err = primary.getProbableSpecies(date, 0.0, settings)
-	classifierLabels = slices.Clone(settings.BirdNET.Labels)
-
-	return scores, geomodelLabels, classifierLabels, filterActive, err
+	scores, geomodelLabels, filterActive, err := primary.getProbableSpecies(date, 0.0, settings)
+	return RarityContext{
+		Scores:           scores,
+		GeomodelLabels:   geomodelLabels,
+		ClassifierLabels: slices.Clone(settings.BirdNET.Labels),
+		FilterActive:     filterActive,
+		Settings:         settings,
+	}, err
 }

--- a/internal/classifier/orchestrator_test.go
+++ b/internal/classifier/orchestrator_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -441,6 +442,101 @@ func TestEnabledModels(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestComputeThreadAllocation pins the returned thread-allocation MAP contract: every
+// distinct enabled+known model plus the primary gets the full budget (inference is
+// serialized by inferenceMu, so models never contend), and unknown IDs are skipped. The
+// returned map is keyed by registry ID, so duplicate, case-variant and primary-colliding
+// entries collapse via map-key semantics regardless of the seen-set; those cases assert
+// the resulting map is correct, not that the seen-set specifically ran (its only extra
+// effect is the model_count log line, which is outside this return contract).
+// computeThreadAllocation reads only settings and the package model registry (no o.mu,
+// no o.models, no model files), so it is exercised directly on a zero-value Orchestrator.
+func TestComputeThreadAllocation(t *testing.T) {
+	t.Parallel()
+
+	const (
+		unknownModelID      = "nope"     // resolves to no registry model
+		upperPerchV2ModelID = "PERCH_V2" // a case variant of conf.ModelIDPerchV2
+		fixedThreads        = 4
+	)
+
+	tests := []struct {
+		name      string
+		primaryID string
+		threads   int
+		enabled   []string
+		want      map[string]int
+	}{
+		{
+			name:      "primary only",
+			primaryID: BirdNET_V2_4,
+			threads:   fixedThreads,
+			enabled:   nil,
+			want:      map[string]int{BirdNET_V2_4: fixedThreads},
+		},
+		{
+			name:      "primary plus a distinct enabled model",
+			primaryID: BirdNET_V2_4,
+			threads:   fixedThreads,
+			enabled:   []string{conf.ModelIDPerchV2},
+			want:      map[string]int{BirdNET_V2_4: fixedThreads, RegistryIDPerchV2: fixedThreads},
+		},
+		{
+			name:      "case variants collapse to one entry",
+			primaryID: BirdNET_V2_4,
+			threads:   fixedThreads,
+			enabled:   []string{conf.ModelIDPerchV2, upperPerchV2ModelID},
+			want:      map[string]int{BirdNET_V2_4: fixedThreads, RegistryIDPerchV2: fixedThreads},
+		},
+		{
+			name:      "an enabled model resolving to the primary is not double counted",
+			primaryID: BirdNET_V2_4,
+			threads:   fixedThreads,
+			enabled:   []string{conf.ModelIDBirdNET},
+			want:      map[string]int{BirdNET_V2_4: fixedThreads},
+		},
+		{
+			name:      "unknown model IDs are skipped",
+			primaryID: BirdNET_V2_4,
+			threads:   fixedThreads,
+			enabled:   []string{unknownModelID, conf.ModelIDPerchV2},
+			want:      map[string]int{BirdNET_V2_4: fixedThreads, RegistryIDPerchV2: fixedThreads},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			settings := &conf.Settings{}
+			settings.Models.Enabled = tt.enabled
+			settings.BirdNET.Threads = tt.threads
+
+			o := &Orchestrator{}
+			got := o.computeThreadAllocation(settings, tt.primaryID)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestComputeThreadAllocation_NonPositiveThreadsUsesNumCPU covers the fallback: with
+// settings.BirdNET.Threads <= 0 every model receives runtime.NumCPU() threads. NumCPU is
+// not hardcoded; the test asserts each allocation is the uniform, positive fallback value.
+func TestComputeThreadAllocation_NonPositiveThreadsUsesNumCPU(t *testing.T) {
+	t.Parallel()
+	settings := &conf.Settings{}
+	settings.Models.Enabled = []string{conf.ModelIDPerchV2}
+	settings.BirdNET.Threads = 0
+
+	o := &Orchestrator{}
+	got := o.computeThreadAllocation(settings, BirdNET_V2_4)
+
+	want := runtime.NumCPU()
+	require.Len(t, got, 2)
+	assert.Positive(t, want)
+	assert.Equal(t, want, got[BirdNET_V2_4])
+	assert.Equal(t, want, got[RegistryIDPerchV2])
 }
 
 func TestOrchestrator_ModelSpecFor(t *testing.T) {

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -534,17 +534,11 @@ func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *co
 	// zeroScoresForAllLabels) stay off the dataset scan.
 	excluder := newExcludeMatcher(settings.Realtime.Species.Exclude, settings.BirdNET.Locale)
 
-	// Skip filtering if range filter backend is not initialized.
-	// Read under lock to avoid data race with Delete().
-	bn.mu.Lock()
-	hasRangeFilter := bn.rangeFilter != nil
-	bn.mu.Unlock()
-	if !hasRangeFilter {
-		bn.Debug("Range filter model not loaded, returning zero scores for all labels")
-		return zeroScoresForAllLabels(settings.BirdNET.Labels, excluder), nil, false, nil
-	}
-
-	// Skip filtering if location is not configured
+	// Skip filtering if location is not configured. This reads only the settings
+	// snapshot (no bn state), so it needs no lock and is checked before acquiring bn.mu.
+	// A nil range filter and an unconfigured location both return identical synthetic
+	// zero scores, so the order between the two checks is not observable beyond which
+	// debug line is logged when both hold.
 	if !settings.BirdNET.LocationConfigured {
 		bn.Debug("Location not configured, not using location based prediction filter")
 		return zeroScoresForAllLabels(settings.BirdNET.Labels, excluder), nil, false, nil
@@ -562,14 +556,29 @@ func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *co
 		week = getWeekForFilter(date)
 	}
 
+	// Resolve the range-filter backend and run the universal-path prediction under a
+	// SINGLE lock hold: the nil check and the UniversalSpeciesPredictor assertion must
+	// observe the same backend instance. Splitting them across two lock acquisitions (as
+	// before) let a concurrent Delete()/reload nil-out or swap the backend between the
+	// check and the assertion, which then fell through to the legacy path and surfaced a
+	// "range filter was closed during prediction" error instead of clean synthetic zeros
+	// with filterActive=false (#3935 follow-up). Holding bn.mu across PredictSpeciesScores
+	// is intentional and pre-existing: the backend is not goroutine-safe, and Delete()
+	// takes the same lock, so it cannot free the backend mid-prediction.
+	bn.mu.Lock()
+	rf := bn.rangeFilter
+	if rf == nil {
+		bn.mu.Unlock()
+		bn.Debug("Range filter model not loaded, returning zero scores for all labels")
+		return zeroScoresForAllLabels(settings.BirdNET.Labels, excluder), nil, false, nil
+	}
+
 	// Try the universal geomodel path first: predict from the geomodel's
 	// own label set so that all 12K species are covered.
-	bn.mu.Lock()
-	up, isUniversal := bn.rangeFilter.(UniversalSpeciesPredictor)
-	if isUniversal {
+	if up, isUniversal := rf.(UniversalSpeciesPredictor); isUniversal {
 		allGeoLabels := up.GeomodelLabels()
 		var cachedMapping []int
-		if mrf, ok := bn.rangeFilter.(*mappedRangeFilter); ok {
+		if mrf, ok := rf.(*mappedRangeFilter); ok {
 			cachedMapping = mrf.classifierToGeo
 		}
 		scores, err := up.PredictSpeciesScores(
@@ -627,7 +636,13 @@ func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *co
 	}
 	bn.mu.Unlock()
 
-	// Legacy path: map geomodel scores to the classifier's label set.
+	// Legacy path: map geomodel scores to the classifier's label set. predictFilter
+	// re-acquires bn.mu and re-checks nil itself, so a Delete() racing between this
+	// unlock and that re-lock still returns a "range filter was closed during
+	// prediction" error for the legacy TFLite backend. That residual race is accepted:
+	// this path is not the default (the universal geomodel path above is), and closing
+	// it would mean threading the snapshotted backend through predictFilter, which still
+	// needs its own lock across the non-goroutine-safe Predict call.
 	filters, err := bn.predictFilter(date, week, settings, threshold)
 	if err != nil {
 		return nil, nil, false, errors.New(err).

--- a/internal/classifier/rarity_context_test.go
+++ b/internal/classifier/rarity_context_test.go
@@ -180,6 +180,7 @@ func TestGetRarityContext_UniversalGeomodel(t *testing.T) {
 	require.NoError(t, err)
 	scores, geomodelLabels, classifierLabels, filterActive := rc.Scores, rc.GeomodelLabels, rc.ClassifierLabels, rc.FilterActive
 
+	assert.Same(t, bn.Settings, rc.Settings, "GetRarityContext returns the exact settings snapshot the scores were produced from")
 	assert.True(t, filterActive, "a loaded range filter reports active so rarity is honest (#3935)")
 	assert.NotEmpty(t, scores, "universal geomodel path should return scored species")
 	assert.Contains(t, geomodelLabels, aliasCanonicalLabel,
@@ -220,6 +221,7 @@ func TestGetRarityContext_NoGeomodel(t *testing.T) {
 	require.NoError(t, err)
 	geomodelLabels, classifierLabels, filterActive := rc.GeomodelLabels, rc.ClassifierLabels, rc.FilterActive
 
+	assert.Same(t, settings, rc.Settings, "GetRarityContext returns the exact settings snapshot the scores were produced from")
 	// Location is unconfigured here, so getProbableSpecies returns synthetic zero
 	// scores even though a filter is loaded; filterActive must be false so rarity is
 	// reported as unknown rather than a bogus "very rare" (#3935).
@@ -229,6 +231,11 @@ func TestGetRarityContext_NoGeomodel(t *testing.T) {
 }
 
 func TestGetRarityContext_NilPrimary(t *testing.T) {
+	// Publish a distinct snapshot so the no-primary branch has a known settings value to
+	// return, and assert GetRarityContext hands back exactly that rather than nil or a
+	// stale generation.
+	distinct := &conf.Settings{}
+	publishTestSettings(t, distinct)
 	orch := &Orchestrator{}
 
 	rc, err := orch.GetRarityContext(time.Now())
@@ -237,4 +244,5 @@ func TestGetRarityContext_NilPrimary(t *testing.T) {
 	assert.Nil(t, rc.Scores)
 	assert.Nil(t, rc.GeomodelLabels)
 	assert.Nil(t, rc.ClassifierLabels)
+	assert.Same(t, distinct, rc.Settings, "with no primary, GetRarityContext returns the orchestrator's current settings snapshot")
 }

--- a/internal/classifier/rarity_context_test.go
+++ b/internal/classifier/rarity_context_test.go
@@ -176,8 +176,9 @@ func TestGetRarityContext_UniversalGeomodel(t *testing.T) {
 	bn, _ := newAliasedGeomodelBirdNET(t, 0.5)
 	orch := &Orchestrator{Settings: bn.Settings, ModelInfo: bn.ModelInfo, primary: bn}
 
-	scores, geomodelLabels, classifierLabels, filterActive, err := orch.GetRarityContext(time.Now())
+	rc, err := orch.GetRarityContext(time.Now())
 	require.NoError(t, err)
+	scores, geomodelLabels, classifierLabels, filterActive := rc.Scores, rc.GeomodelLabels, rc.ClassifierLabels, rc.FilterActive
 
 	assert.True(t, filterActive, "a loaded range filter reports active so rarity is honest (#3935)")
 	assert.NotEmpty(t, scores, "universal geomodel path should return scored species")
@@ -215,8 +216,9 @@ func TestGetRarityContext_NoGeomodel(t *testing.T) {
 	t.Cleanup(bn.Delete)
 	orch := &Orchestrator{Settings: settings, ModelInfo: bn.ModelInfo, primary: bn}
 
-	_, geomodelLabels, classifierLabels, filterActive, err := orch.GetRarityContext(time.Now())
+	rc, err := orch.GetRarityContext(time.Now())
 	require.NoError(t, err)
+	geomodelLabels, classifierLabels, filterActive := rc.GeomodelLabels, rc.ClassifierLabels, rc.FilterActive
 
 	// Location is unconfigured here, so getProbableSpecies returns synthetic zero
 	// scores even though a filter is loaded; filterActive must be false so rarity is
@@ -229,10 +231,10 @@ func TestGetRarityContext_NoGeomodel(t *testing.T) {
 func TestGetRarityContext_NilPrimary(t *testing.T) {
 	orch := &Orchestrator{}
 
-	scores, geomodelLabels, classifierLabels, filterActive, err := orch.GetRarityContext(time.Now())
+	rc, err := orch.GetRarityContext(time.Now())
 	require.NoError(t, err)
-	assert.False(t, filterActive, "no primary model means no active range filter")
-	assert.Nil(t, scores)
-	assert.Nil(t, geomodelLabels)
-	assert.Nil(t, classifierLabels)
+	assert.False(t, rc.FilterActive, "no primary model means no active range filter")
+	assert.Nil(t, rc.Scores)
+	assert.Nil(t, rc.GeomodelLabels)
+	assert.Nil(t, rc.ClassifierLabels)
 }


### PR DESCRIPTION
## Summary

A batch of small, deferred follow-ups surfaced by the review cycles for the classifier/analysis work in #4291 and #4294, kept out of those PRs at the time to keep them focused. No new endpoints, config keys, DB models, or events.

`range_filter`: in `getProbableSpecies`, the nil-check and the `UniversalSpeciesPredictor` type assertion now happen under a single `bn.mu` hold instead of two separate acquisitions. The old split let a concurrent `Delete()`/reload nil-out or swap the range-filter backend between the two, which then fell through to the legacy path and surfaced a "range filter was closed during prediction" error instead of clean synthetic zero scores with `filterActive=false`. The location/threshold/week checks (settings-only reads) move ahead of the lock, and the non-default legacy TFLite path's remaining race is documented in place. This is a follow-up to the #3935 honesty work.

`api/v2/species`: the rarity response `location_based` now derives from `filterActive` (and `LocationConfigured`) rather than from `LocationConfigured` alone. With a configured location but an inactive geomodel, the API previously returned `location_based=true` next to an "unknown" 0% score, which the dashboard rendered as "Unknown 0% - Based on location" and partially reintroduced the false 0% that #3935 removed. Coordinates still surface whenever a location is configured. Anding with `LocationConfigured` ties the flag to the same settings snapshot as the coordinate gate, so a concurrent settings reload cannot pair `location_based=true` with omitted coordinates.

`analysis`: the "model not analyzing" notification suppression window is now cleared on successful (re)registration and on source removal/restart, and is keyed by the unique source ID rather than the human-readable display name (display names can collide across streams). A source that fails, recovers, then fails again inside the 6h window now re-notifies instead of staying silenced, matching the intent behind #4201 and #4204. The notify and clear paths share one key-format helper so they cannot drift apart.

`analysis`: the full audio-capture restart operation is now a named `operationRestart` constant instead of a bare `"restart"` string literal, matching the existing `operation*` vocabulary.

`analysis`: `ProcessData`'s audio-payload parameters are grouped into a `ProcessRequest` struct (passed by pointer), keeping `ctx`, the classifier backend, and the buffer manager as separate collaborators, per the more-than-three-parameters convention.

`classifier`: adds direct unit-test coverage for `computeThreadAllocation`.

## Related Issues

Follow-up to #4291 and #4294. Relates to #3935, #4201, #4204.

## Test Plan

- [x] `go test -race` passes for `internal/analysis`, `internal/classifier`, and `internal/api/v2/species`
- [x] `golangci-lint` clean across all build-tag combinations (default, noembed, notflite, openvino, noasm, integration)
- [x] New tests: `TestComputeThreadAllocation`, `TestModelNotRegisteredKey`, `TestClearModelNotRegistered` (incl. colliding display names and prefix-exact-segment safety)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model-registration notifications so alerts are tracked separately for each audio source and can resume after a source or model recovers.
  * Corrected rarity responses so location details are included whenever configured, while location-based indicators appear only when location filtering is active.
  * Improved audio processing reliability by keeping audio data and related metadata aligned throughout processing.
  * Improved range-filter classification consistency during location and backend configuration changes.
  * Improved rarity results consistency during settings updates by using a single settings snapshot for related scores and metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->