### PR TITLE
fix(dashboard): retention keying, liveness flap, and highlight dedup

### DIFF
--- a/frontend/src/lib/desktop/features/dashboard/components/CurrentlyHearingCard.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/CurrentlyHearingCard.svelte
@@ -37,15 +37,15 @@ Props:
   let retainedData: Record<string, PendingDetection> = {};
   let removalTimers: Record<string, ReturnType<typeof setTimeout>> = {};
 
-  function detectionKey(d: PendingDetection): string {
-    return d.source + d.scientificName;
-  }
-
-  // Render/dedupe key for the keyed {#each}. Includes firstDetected so the key is
-  // stable across the newest-first re-sort (no re-mount or replayed fade transition,
-  // unlike appending the loop index) and unique per pending detection. Deduping by it
-  // prevents an each_key_duplicate crash (Sentry BIRDNET-GO-2HP) while collapsing only a re-delivered
-  // identical detection, not two genuinely distinct detections at different start times.
+  // Render/dedupe key for the keyed {#each}, and the retention key. Includes
+  // firstDetected so the key is stable across the newest-first re-sort (no re-mount or
+  // replayed fade transition, unlike appending the loop index) and unique per pending
+  // detection. Deduping by it prevents an each_key_duplicate crash (Sentry BIRDNET-GO-2HP) while
+  // collapsing only a re-delivered identical detection, not two genuinely distinct
+  // detections at different start times. Retention keys by this too, so two concurrent
+  // same-source same-species detections are held independently: keying retention by
+  // source+species alone let a still-active detection mask a completed twin and evict it
+  // immediately instead of holding it for TERMINAL_RETENTION_MS.
   function renderKey(d: PendingDetection): string {
     return `${d.source}_${d.scientificName}_${d.firstDetected}`;
   }
@@ -55,9 +55,9 @@ Props:
   // (this effect should only re-run when detections changes, not retainedKeys).
   $effect(() => {
     for (const d of detections) {
-      const key = detectionKey(d);
+      const key = renderKey(d);
       if ((d.status === 'approved' || d.status === 'rejected') && !(key in removalTimers)) {
-        /* eslint-disable security/detect-object-injection -- key is derived from detectionKey(), a controlled string */
+        /* eslint-disable security/detect-object-injection -- key is derived from renderKey(), a controlled string */
         retainedData[key] = d;
         removalTimers[key] = setTimeout(() => {
           delete retainedData[key];
@@ -77,14 +77,14 @@ Props:
     // Read retainedKeys to establish reactive dependency
     const retained = retainedKeys;
 
-    const incomingByKey = new Set<string>();
+    const incomingKeys = new Set<string>();
     for (const d of detections) {
-      incomingByKey.add(detectionKey(d));
+      incomingKeys.add(renderKey(d));
     }
 
     const result: PendingDetection[] = [...detections];
     for (const key of retained) {
-      if (!incomingByKey.has(key)) {
+      if (!incomingKeys.has(key)) {
         // eslint-disable-next-line security/detect-object-injection -- key is from retainedKeys, a controlled string array
         const data = retainedData[key];
         if (data) {
@@ -137,8 +137,8 @@ Props:
     void tick;
     const result: Record<string, string> = {};
     for (const d of displayDetections) {
-      // Key by renderKey, not detectionKey: two same-source/species detections at
-      // different start times now coexist (dedupe keeps them), so a source+species key
+      // Key by renderKey, not by source+species alone: two same-source/species detections
+      // at different start times now coexist (dedupe keeps them), so a source+species key
       // would collapse them and show both chips the same elapsed time.
       result[renderKey(d)] = getElapsedText(d.firstDetected);
     }

--- a/frontend/src/lib/desktop/features/dashboard/components/CurrentlyHearingCard.test.ts
+++ b/frontend/src/lib/desktop/features/dashboard/components/CurrentlyHearingCard.test.ts
@@ -16,6 +16,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { flushSync } from 'svelte';
 import { cleanup } from '@testing-library/svelte';
 import { createComponentTestFactory } from '../../../../../test/render-helpers';
 import type { PendingDetection } from '$lib/types/pending.types';
@@ -27,6 +28,15 @@ const FI = new Map<string, string>([['Turdus migratorius', 'Punarinta']]);
 vi.mock('$lib/stores/speciesDictionary.svelte', () => ({
   localizeScientific: vi.fn((scientificName: string) => FI.get(scientificName)),
 }));
+
+// jsdom lacks the Web Animations API that svelte/transition's fade drives via
+// element.animate() when chips mount/unmount on a rerender. Stub fade to a zero-duration,
+// css-less transition so outros complete synchronously (removed chips actually leave the
+// DOM) without touching element.animate.
+vi.mock('svelte/transition', async importOriginal => {
+  const actual = await importOriginal<typeof import('svelte/transition')>();
+  return { ...actual, fade: () => ({ duration: 0 }) };
+});
 
 import CurrentlyHearingCard from './CurrentlyHearingCard.svelte';
 
@@ -129,6 +139,36 @@ describe('CurrentlyHearingCard species-name localization', () => {
         ],
       },
     });
+    expect(getAllByText('Eurasian Wren')).toHaveLength(2);
+  });
+
+  // Regression: the terminal-detection retention layer used to key by
+  // source+species (detectionKey) while rendering keyed by source+species+firstDetected
+  // (renderKey). Two concurrent same-source same-species detections then shared one
+  // retention key, so when one completed and dropped from the incoming SSE snapshot while
+  // the other was still active, the completed one was evicted instantly (its key was still
+  // "incoming" via the active twin) instead of being held for TERMINAL_RETENTION_MS.
+  it('retains a completed detection while a concurrent same-species detection is still active', async () => {
+    const base = {
+      species: 'Eurasian Wren',
+      scientificName: 'Troglodytes troglodytes',
+      source: 'mic-9',
+      sourceID: 'mic-9',
+    } as const;
+    // A completed (approved), B still active; same source and species, distinct start times.
+    const a = pending({ ...base, status: 'approved', firstDetected: 1_700_000_000 });
+    const b = pending({ ...base, status: 'active', firstDetected: 1_700_000_005 });
+
+    const { rerender, getAllByText } = card.render({ props: { detections: [a, b] } });
+    // Let the retention $effect record A's terminal state before the snapshot changes.
+    flushSync();
+
+    // Backend stops sending A (it completed) but keeps sending the still-active B.
+    await rerender({ detections: [b] });
+    flushSync();
+
+    // A must remain retained (held, not evicted) so both chips are still shown. With the
+    // old detectionKey the active B masked A as "still incoming" and A vanished immediately.
     expect(getAllByText('Eurasian Wren')).toHaveLength(2);
   });
 });

--- a/frontend/src/lib/desktop/features/dashboard/components/NewSpeciesHighlightsCard.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/NewSpeciesHighlightsCard.svelte
@@ -70,15 +70,19 @@ Shows up to 12 species, ordered by novelty category then detection count.
     // Guard against a null payload: the default [] only applies for undefined,
     // and the daily-summary endpoint can return a null body.
     if (!data) return result;
-    // Dedupe by scientific_name (first wins): the daily-summary payload can carry
-    // duplicate rows, which a bare scientific_name key would render as two tiles and,
+    // Dedupe by scientific_name (first qualifying row wins): the daily-summary payload can
+    // carry duplicate rows, which a bare scientific_name key would render as two tiles and,
     // worse, throw each_key_duplicate and white-screen the dashboard (Sentry BIRDNET-GO-2HP).
+    // Consume the key only when a row qualifies, so a non-qualifying duplicate row does not
+    // burn the key and drop a later qualifying row for the same species.
     const seen = new Set<string>();
     for (const species of data) {
       if (seen.has(species.scientific_name)) continue;
-      seen.add(species.scientific_name);
       const category = resolveNoveltyCategory(species, { infrequentThresholdDays, isToday });
-      if (category !== null) result.push({ species, category });
+      if (category !== null) {
+        seen.add(species.scientific_name);
+        result.push({ species, category });
+      }
     }
     result.sort((a, b) => {
       const rankDiff = categoryRank[a.category] - categoryRank[b.category];

--- a/frontend/src/lib/desktop/features/dashboard/components/NewSpeciesHighlightsCard.test.ts
+++ b/frontend/src/lib/desktop/features/dashboard/components/NewSpeciesHighlightsCard.test.ts
@@ -49,4 +49,26 @@ describe('NewSpeciesHighlightsCard', () => {
 
     expect(getAllByText('Common Blackbird')).toHaveLength(1);
   });
+
+  // Regression: dedup used to consume the scientific_name key before the
+  // novelty qualification check, so a non-qualifying duplicate row dropped a later
+  // qualifying row for the same species. The key is now only consumed when a row qualifies.
+  it('keeps a qualifying row that follows a non-qualifying duplicate of the same species', () => {
+    const { getAllByText } = card.render({
+      props: {
+        data: [
+          // First row does not qualify as new in any tracked period (category === null).
+          summary({ is_new_species: false }),
+          // Second row for the same species qualifies (new species => lifetime).
+          summary({ is_new_species: true }),
+        ],
+        selectedDate: '2026-09-07',
+        isToday: true,
+      },
+    });
+
+    // The qualifying row must still surface as one tile; the non-qualifying duplicate must
+    // not have burned the key. (Before the fix the whole card rendered nothing.)
+    expect(getAllByText('Common Blackbird')).toHaveLength(1);
+  });
 });

--- a/frontend/src/lib/desktop/views/SystemInference.svelte
+++ b/frontend/src/lib/desktop/views/SystemInference.svelte
@@ -828,7 +828,7 @@
 
         The backend still returns `snapshot.audio` and its i18n keys are kept, so
         re-enabling is just a matter of restoring the markup. Tracked in the
-        Phase A spec (Forgejo #1144). Do NOT delete the audio types/fields.
+        internal Phase A spec. Do NOT delete the audio types/fields.
       -->
     </div>
 
@@ -1011,7 +1011,9 @@
             {@const throughputLatest =
               throughputSeries.length > 0 ? throughputSeries[throughputSeries.length - 1] : 0}
             {@const isActive = throughputSeries.length > 0 && throughputLatest > 0}
-            {@const notAnalyzing = model.sources.some(s => s.notRunning)}
+            {@const anySourceDown = model.sources.some(s => s.notRunning)}
+            {@const allSourcesDown =
+              model.sources.length > 0 && model.sources.every(s => s.notRunning)}
             <div
               class="bg-[var(--surface-100)] border border-[var(--border-100)] rounded-xl p-4 shadow-sm flex flex-col gap-3"
             >
@@ -1047,14 +1049,15 @@
                         >{/if}
                     </span>
                   </span>
-                {:else if notAnalyzing && !isActive}
-                  <!-- A source assigned to this model is not sending it audio AND the
-                       model is producing no throughput, so it is genuinely not analyzing.
-                       Surface it in the dominant header slot rather than a benign "Idle"
-                       (#4209). Gated on !isActive so a multi-source model still analyzing
-                       via another source reads "active", not a misleading blanket "not
-                       analyzing"; the specific down source is still flagged by its badge
-                       below. Precedence: paused > not-analyzing > active > idle. -->
+                {:else if allSourcesDown && !isActive}
+                  <!-- EVERY source assigned to this model is down AND the model is producing
+                       no throughput, so it is genuinely not analyzing. Surface it in the
+                       dominant header slot rather than a benign "Idle" (#4209). Gating on
+                       allSourcesDown (not "any source down") keeps a multi-source model with
+                       one healthy source out of this alarm: during silence it reads "idle"
+                       instead of flapping to "not analyzing" and back when a bird sings, and
+                       the specific down source is still flagged by its badge below.
+                       Precedence: paused > not-analyzing > active > idle. -->
                   <span
                     class="ml-auto flex items-center gap-1.5"
                     role="status"
@@ -1372,9 +1375,12 @@
                   <!-- Persistent, visible reason so keyboard and touch users get the
                        cause without a hover (frontend/CLAUDE.md: no ambiguous states).
                        Each not-analyzing badge references it via aria-describedby for
-                       screen readers. It points at this page, not the model gallery,
-                       which has no per-source liveness view (#4209). -->
-                  {#if notAnalyzing}
+                       screen readers. Gated on anySourceDown (not the header's
+                       allSourcesDown) so a single down source among healthy ones still
+                       renders the element every down-source badge points at, leaving no
+                       dangling aria-describedby. It points at this page, not the model
+                       gallery, which has no per-source liveness view (#4209). -->
+                  {#if anySourceDown}
                     <p
                       id={notAnalyzingHelpId}
                       class="text-xs text-red-600 dark:text-red-400 mt-1.5 leading-snug"

--- a/frontend/src/lib/desktop/views/SystemInference.test.ts
+++ b/frontend/src/lib/desktop/views/SystemInference.test.ts
@@ -424,6 +424,66 @@ describe('SystemInference', () => {
       expect(header).not.toBeNull();
       expect(container.textContent).not.toContain('system.inference.activityIdle');
     });
+
+    it('does NOT flap the header to not-analyzing when only some sources are down', async () => {
+      // One healthy source + one down source, no throughput (silence => isActive false).
+      // The model can still analyze via the healthy source, so the dominant header must
+      // read idle, not the red "not analyzing" attention state that used to appear
+      // whenever ANY source was down and then flip back to active on the next detection.
+      const model = makeModel({
+        paused: false,
+        sources: [
+          { id: 'a', name: 'Front Yard', type: 'soundcard', fallback: false },
+          { id: 'b', name: 'Back Yard', type: 'rtsp', fallback: false, notRunning: true },
+        ],
+      });
+      installApi(makeSnapshot([model]));
+
+      const { container } = inferenceTest.render({});
+
+      await waitFor(() => {
+        expect(container.textContent).toContain('Back Yard');
+      });
+
+      // Header shows idle, not the model-level not-analyzing alarm.
+      expect(
+        container.querySelector('[aria-label="system.inference.modelNotAnalyzingTooltip"]')
+      ).toBeNull();
+      expect(
+        container.querySelector('[aria-label="system.inference.activityIdle"]')
+      ).not.toBeNull();
+
+      // The specific down source is still flagged, and its help text still renders so the
+      // badge's aria-describedby resolves (no dangling reference).
+      const badges = notRunningBadges(container);
+      expect(badges).toHaveLength(1);
+      const helpId = badges[0].getAttribute('aria-describedby');
+      expect(helpId).toBeTruthy();
+      expect(container.querySelector(`[id="${helpId}"]`)).not.toBeNull();
+    });
+
+    it('still shows the header not-analyzing state when ALL sources are down', async () => {
+      // Every assigned source down + silence => genuinely not analyzing, so the alarm stays.
+      const model = makeModel({
+        paused: false,
+        sources: [
+          { id: 'a', name: 'Front Yard', type: 'soundcard', fallback: false, notRunning: true },
+          { id: 'b', name: 'Back Yard', type: 'rtsp', fallback: false, notRunning: true },
+        ],
+      });
+      installApi(makeSnapshot([model]));
+
+      const { container } = inferenceTest.render({});
+
+      await waitFor(() => {
+        expect(container.textContent).toContain('Back Yard');
+      });
+
+      expect(
+        container.querySelector('[aria-label="system.inference.modelNotAnalyzingTooltip"]')
+      ).not.toBeNull();
+      expect(container.textContent).not.toContain('system.inference.activityIdle');
+    });
   });
 
   // These tests run against the i18n stub in src/test/setup.ts, which returns the


### PR DESCRIPTION
## Summary

Three deferred dashboard bug fixes from the status-honesty review cycle, each in its own dashboard component. All three were reproduced against current code before fixing, and each ships with a regression test.

- **Currently Hearing card:** the terminal-detection retention layer keyed by source+species while rendering keyed by source+species+firstDetected. Two concurrent detections of the same species on one source shared a single retention key, so when one completed and dropped from the SSE snapshot while the other was still active, the completed one was evicted immediately instead of being held for its retention window. Retention now keys by the same render key, so concurrent instances are held independently.

- **AI Models / Inference view:** the model header showed the "not analyzing" attention state whenever any assigned source was down. A multi-source model with one healthy and one down source flapped between "not analyzing" during silence and "active" when a bird sang. The header now shows that state only when every source is down, so a partly-down model reads idle during silence. The per-source down badge and its help text still render whenever any source is down, so the badge's aria-describedby target always exists (relates to #4209).

- **New Species Highlights card:** the dedup consumed the species key before the novelty-qualification check, so a non-qualifying duplicate row suppressed a later qualifying row for the same species. The key is now consumed only when a row qualifies.

## Test Plan

- [x] Regression tests added for all three (each fails on the pre-fix code, passes after).
- [x] `npm run check:all` clean (types, lint, ast-grep, format).
- [x] Full frontend suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Concurrent detections of the same species and source are now tracked independently, ensuring completed detections remain visible during active detections.
  * New species highlights are no longer incorrectly omitted when duplicate entries include a non-qualifying result.
  * System inference status now accurately distinguishes between partially unavailable and fully unavailable sources, displaying the appropriate status indicators and guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->