### PR TITLE
fix(analysis): retry persistently-failed buffer routes on reconfigure

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -96,9 +96,11 @@ type AudioPipelineService struct {
 	// during a reconfigure is not reported as "not analyzing" on its first
 	// occurrence, only if the route is still down on the next reconfigure pass. An
 	// entry is dropped when a source's route recovers and the whole map is cleared
-	// when all sources are torn down (removeAllSources). Accessed only from
-	// registerConsumersForSources, which runs single-threaded on the startup pass and
-	// under sourcesMu on every later pass, so it needs no lock of its own.
+	// when all sources are torn down (removeAllSources). Every access is either on the
+	// startup pass (single-threaded) or under sourcesMu: the writes in
+	// reportSourceRegistration and the reads/deletes in retryPersistentRouteFailures,
+	// RestartSource and the reconfigure removal loop all hold it, so it needs no lock of
+	// its own.
 	routeFailedLastPass map[string]bool
 }
 
@@ -999,6 +1001,16 @@ func (p *AudioPipelineService) wireSourceBufferRoute(sid, sourceName string, sou
 	return true, true
 }
 
+// routeReportInputs names the three booleans routeReportDecision weighs. Grouping them
+// in a struct with explicit field names keeps a call site from silently inverting the
+// not-analyzing decision by passing them in the wrong order, since positionally they are
+// three adjacent, interchangeable bools.
+type routeReportInputs struct {
+	bufferRouteOK     bool // the source's buffer (analysis) route came up this pass
+	failedLastPass    bool // the route was already down on the previous reconfigure pass
+	suppressTransient bool // this pass is a reconfigure, where a first transient failure is expected
+}
+
 // routeReportDecision returns the allocated-model set that reportUnregisteredModels
 // should treat as registered for a source, given whether its buffer route came up
 // this pass (bufferRouteOK), whether that route was already down on the previous
@@ -1016,11 +1028,11 @@ func (p *AudioPipelineService) wireSourceBufferRoute(sid, sourceName string, sou
 // stable config no later pass revisits it, so suppressing it there would silence a
 // permanent model outage forever (the #4201/#4204 class). Pure, so the policy is
 // unit-tested without standing up the audio engine.
-func routeReportDecision(bufferRouteOK, failedLastPass, suppressTransient bool, allocated map[string]bool) map[string]bool {
-	if bufferRouteOK {
+func routeReportDecision(in routeReportInputs, allocated map[string]bool) map[string]bool {
+	if in.bufferRouteOK {
 		return allocated
 	}
-	if suppressTransient && !failedLastPass {
+	if in.suppressTransient && !in.failedLastPass {
 		return allocated // first transient reconfigure failure: suppress the alarm this pass
 	}
 	return nil // report the resolved models as not-analyzing
@@ -1037,6 +1049,7 @@ const (
 	operationReconfigureParams = "reconfigure_params"
 	operationGainChange        = "gain_change"
 	operationModelChange       = "model_change"
+	operationRouteRetry        = "route_retry"
 )
 
 // isReconfigureOperation reports whether a registerConsumersForSources pass was
@@ -1044,13 +1057,35 @@ const (
 // occur and is repaired by the next pass, as opposed to a start or explicit restart
 // where a route failure is a genuine outage to report immediately (see
 // routeReportDecision, #4208). These operations originate in reconfigureChangedSources.
+// operationRouteRetry is included: it is the pass that re-wires a route left down by an
+// earlier reconfigure, so it keeps the reconfigure semantics (a route still down on the
+// retry has failedLastPass set and is reported, not suppressed forever).
 func isReconfigureOperation(operation string) bool {
 	switch operation {
-	case operationReconfigureDiff, operationReconfigureParams, operationGainChange, operationModelChange:
+	case operationReconfigureDiff, operationReconfigureParams, operationGainChange, operationModelChange, operationRouteRetry:
 		return true
 	default:
 		return false
 	}
+}
+
+// sourcesNeedingRouteRetry returns the kept source IDs whose buffer route was still down
+// after a prior reconfigure (failed[id]) and that are not already being re-registered
+// this pass (reRegistering[id]). reconfigureChangedSources re-registers only sources
+// whose config changed, so without this a route that fails on a source later left
+// untouched is never retried, never surfaces its models as not-analyzing, and keeps a
+// stale routeFailedLastPass entry forever (#4208 follow-up). The result is sorted so the
+// retry order and its logs are deterministic. Pure, so the selection is unit-tested
+// without standing up the audio engine.
+func sourcesNeedingRouteRetry(kept []string, failed, reRegistering map[string]bool) []string {
+	var retry []string
+	for _, id := range kept {
+		if failed[id] && !reRegistering[id] {
+			retry = append(retry, id)
+		}
+	}
+	slices.Sort(retry)
+	return retry
 }
 
 // reportSourceRegistration reports the models that will not analyze sourceName and
@@ -1072,7 +1107,11 @@ func (p *AudioPipelineService) reportSourceRegistration(mm *classifier.ModelMana
 	// would see failedLastPass=true and be reported instead of suppressed (#4208). So
 	// only a reconfigure failure records state; every other pass clears it.
 	reconfigure := isReconfigureOperation(operation)
-	registered := routeReportDecision(bufferRouteOK, reconfigure && p.routeFailedLastPass[sid], reconfigure, allocated)
+	registered := routeReportDecision(routeReportInputs{
+		bufferRouteOK:     bufferRouteOK,
+		failedLastPass:    reconfigure && p.routeFailedLastPass[sid],
+		suppressTransient: reconfigure,
+	}, allocated)
 	if bufferRouteOK || !reconfigure {
 		delete(p.routeFailedLastPass, sid)
 	} else {
@@ -1520,16 +1559,7 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 	// stays running; only the routes are torn down and re-created so
 	// drainRoute picks up the new gainLinear value.
 	if len(gainChangedIDs) > 0 {
-		for _, sid := range gainChangedIDs {
-			p.engine.Router().RemoveAllRoutes(sid)
-			// RemoveAllRoutes also removes the soundlevel route, so drop the
-			// tracking entry. Without this, the registerSoundLevelConsumers
-			// call below would skip the source (idempotency check) and leave
-			// it permanently without sound level monitoring.
-			p.untrackSoundLevelConsumer(sid)
-		}
-		p.registerConsumersForSources(gainChangedIDs, sourceModelMap, audioLevelChan, operationGainChange)
-		p.registerSoundLevelConsumers(gainChangedIDs, operationGainChange)
+		p.rebuildRoutesForSources(gainChangedIDs, sourceModelMap, audioLevelChan, operationGainChange)
 	}
 
 	// Rebuild routes for sources whose model assignment changed (e.g.,
@@ -1546,6 +1576,15 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 		p.registerConsumersForSources(modelChangedIDs, sourceModelMap, audioLevelChan, operationModelChange)
 		p.registerSoundLevelConsumers(modelChangedIDs, operationModelChange)
 	}
+
+	// Retry sources whose buffer route stayed down after a prior reconfigure but whose
+	// config did not change this pass, so the re-register blocks above skipped them.
+	// Without this a route that fails on a source later left untouched is never retried
+	// and its models never surface as not-analyzing (#4208 follow-up).
+	routeRetryIDs := p.retryPersistentRouteFailures(
+		alreadyRunning,
+		[][]string{newSourceIDs, reconfiguredIDs, gainChangedIDs, modelChangedIDs},
+		sourceModelMap, audioLevelChan)
 
 	// Sync monitors for ALL active sources (kept + new) so UpdateMonitors
 	// receives the full desired state and removes stale monitors correctly.
@@ -1566,7 +1605,54 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 		logger.Int("removed", removedCount),
 		logger.Int("gain_changed", len(gainChangedIDs)),
 		logger.Int("model_changed", len(modelChangedIDs)),
+		logger.Int("route_retried", len(routeRetryIDs)),
 		logger.String("operation", operationReconfigureDiff))
+}
+
+// rebuildRoutesForSources tears down and re-creates the buffer, audio-level and
+// soundlevel routes for the given kept sources WITHOUT restarting capture:
+// Router().RemoveAllRoutes touches only the router, so the capture device keeps running.
+// Shared by the reconfigure paths that keep a source running but must rewire it (gain
+// change and persistent-route-failure retry), so the teardown+re-register sequence lives
+// in one place.
+func (p *AudioPipelineService) rebuildRoutesForSources(ids []string, sourceModelMap map[string][]string, audioLevelChan chan audiocore.AudioLevelData, operation string) {
+	for _, sid := range ids {
+		p.engine.Router().RemoveAllRoutes(sid)
+		// RemoveAllRoutes also removes the soundlevel route, so drop the tracking entry.
+		// Without this, the registerSoundLevelConsumers call below would skip the source
+		// (idempotency check) and leave it permanently without sound level monitoring.
+		p.untrackSoundLevelConsumer(sid)
+	}
+	p.registerConsumersForSources(ids, sourceModelMap, audioLevelChan, operation)
+	p.registerSoundLevelConsumers(ids, operation)
+}
+
+// retryPersistentRouteFailures re-wires the buffer route for kept sources whose route
+// stayed down after an earlier reconfigure (routeFailedLastPass) and that were not
+// already re-registered this pass. reconfigureChangedSources re-registers only sources
+// whose config changed, so without this a route that fails on a source later left
+// untouched is never retried, its models never surface as not-analyzing, and the failure
+// memory keeps a stale entry forever (#4208 follow-up). reRegistered lists the ID slices
+// already handled this pass so a source is not rebuilt twice; the rebuild clears the
+// failure memory on recovery or reports the models as not-analyzing when the route is
+// still down. Returns the retried IDs for the completion log. Runs under sourcesMu (held
+// by the caller), which serialises the routeFailedLastPass read.
+func (p *AudioPipelineService) retryPersistentRouteFailures(alreadyRunning map[string]string, reRegistered [][]string, sourceModelMap map[string][]string, audioLevelChan chan audiocore.AudioLevelData) []string {
+	reRegistering := make(map[string]bool)
+	for _, ids := range reRegistered {
+		for _, id := range ids {
+			reRegistering[id] = true
+		}
+	}
+	routeRetryIDs := sourcesNeedingRouteRetry(slices.Collect(maps.Values(alreadyRunning)), p.routeFailedLastPass, reRegistering)
+	if len(routeRetryIDs) == 0 {
+		return nil
+	}
+	audiocore.GetLogger().Info("retrying buffer route for sources with a persistent route failure",
+		logger.Int("count", len(routeRetryIDs)),
+		logger.String("operation", operationRouteRetry))
+	p.rebuildRoutesForSources(routeRetryIDs, sourceModelMap, audioLevelChan, operationRouteRetry)
+	return routeRetryIDs
 }
 
 // sourceConfigWithModels pairs an audiocore.SourceConfig with the config-level

--- a/internal/analysis/route_report_decision_test.go
+++ b/internal/analysis/route_report_decision_test.go
@@ -37,7 +37,11 @@ func TestRouteReportDecision(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := routeReportDecision(tt.bufferRouteOK, tt.failedLastPass, tt.suppressTransient, allocated)
+			got := routeReportDecision(routeReportInputs{
+				bufferRouteOK:     tt.bufferRouteOK,
+				failedLastPass:    tt.failedLastPass,
+				suppressTransient: tt.suppressTransient,
+			}, allocated)
 			if tt.wantSuppressed {
 				assert.NotNil(t, got, "resolved models should be treated as registered (not reported)")
 				assert.Equal(t, allocated, got)
@@ -62,6 +66,7 @@ func TestIsReconfigureOperation(t *testing.T) {
 		{"reconfigure_params suppresses first failure", operationReconfigureParams, true},
 		{"gain_change suppresses first failure", operationGainChange, true},
 		{"model_change suppresses first failure", operationModelChange, true},
+		{"route_retry keeps reconfigure semantics", operationRouteRetry, true},
 		{"start reports immediately", operationStart, false},
 		{"restart reports immediately", operationRestart, false},
 		{"restart_source reports immediately", operationRestartSource, false},
@@ -114,4 +119,76 @@ func TestReportSourceRegistration_RouteFailureMemory(t *testing.T) {
 	p.reportSourceRegistration(nil, sid, sid, operationStart, false, nil, nil, alloc)
 	_, present = p.routeFailedLastPass[sid]
 	assert.False(t, present, "a start pass clears any stale reconfigure-failure entry")
+
+	// A route-retry pass that finally wires the route (bufferRouteOK) clears the memory:
+	// the persistent failure self-healed and must stop retrying/reporting.
+	p.routeFailedLastPass[sid] = true
+	p.reportSourceRegistration(nil, sid, sid, operationRouteRetry, true, nil, nil, alloc)
+	_, present = p.routeFailedLastPass[sid]
+	assert.False(t, present, "a route-retry pass that recovers the route clears the failure memory")
+
+	// A route-retry pass whose route is still down keeps the entry, so the next reconfigure
+	// retries again; because operationRouteRetry is a reconfigure op with failedLastPass set,
+	// routeReportDecision surfaces it as not-analyzing rather than suppressing it (see
+	// TestRouteReportDecision's "reconfigure failure surviving a pass reported" case).
+	p.routeFailedLastPass[sid] = true
+	p.reportSourceRegistration(nil, sid, sid, operationRouteRetry, false, nil, nil, alloc)
+	assert.True(t, p.routeFailedLastPass[sid], "a route-retry pass that is still down stays marked for the next retry")
+}
+
+func TestSourcesNeedingRouteRetry(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		kept          []string
+		failed        map[string]bool
+		reRegistering map[string]bool
+		want          []string
+	}{
+		{
+			name:   "failed kept source not re-registered is retried",
+			kept:   []string{"mic-1"},
+			failed: map[string]bool{"mic-1": true},
+			want:   []string{"mic-1"},
+		},
+		{
+			name:   "healthy kept source is not retried",
+			kept:   []string{"mic-1"},
+			failed: nil,
+			want:   nil,
+		},
+		{
+			name:          "failed source already re-registered this pass is skipped",
+			kept:          []string{"mic-1"},
+			failed:        map[string]bool{"mic-1": true},
+			reRegistering: map[string]bool{"mic-1": true},
+			want:          nil,
+		},
+		{
+			name:          "only failed, kept, and not-re-registered survive, sorted",
+			kept:          []string{"mic-3", "mic-1", "mic-2", "mic-4"},
+			failed:        map[string]bool{"mic-1": true, "mic-3": true, "mic-4": true},
+			reRegistering: map[string]bool{"mic-4": true},
+			want:          []string{"mic-1", "mic-3"},
+		},
+		{
+			name:   "a failed source not among the kept sources is ignored",
+			kept:   []string{"mic-1"},
+			failed: map[string]bool{"mic-1": false, "mic-9": true},
+			want:   nil,
+		},
+		{
+			name:   "no kept sources yields no retries",
+			kept:   nil,
+			failed: map[string]bool{"mic-1": true},
+			want:   nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := sourcesNeedingRouteRetry(tt.kept, tt.failed, tt.reRegistering)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }

--- a/internal/api/v2/species/species.go
+++ b/internal/api/v2/species/species.go
@@ -523,21 +523,25 @@ func findSpeciesScore(targetSci string, speciesScores []classifier.SpeciesScore)
 //
 // A covered species present in the list is scored directly; one that is covered but
 // absent is below today's threshold and therefore genuinely very rare.
-func computeRarity(filterActive bool, targetSci string, speciesScores []classifier.SpeciesScore, geomodelLabels, classifierLabels []string) (float64, RarityStatus) {
+// It takes the whole RarityContext (by pointer, since it is a large struct) rather than
+// its fields spread positionally: the two label vocabularies are adjacent same-typed
+// []string fields on that struct, so passing them loose invited a silent
+// geomodel/classifier swap.
+func computeRarity(rc *classifier.RarityContext, targetSci string) (float64, RarityStatus) {
 	// Without an active range filter the probable-species list is synthetic zero
 	// scores for every label, so a covered species would score 0.0 and be
 	// misreported as "very rare" at "0%". The occurrence probability is genuinely
 	// unknown in that state (the geomodel could not load), so report unknown rather
 	// than a confident wrong answer (#3935).
-	if !filterActive {
+	if !rc.FilterActive {
 		return 0.0, RarityUnknown
 	}
 
-	if !speciesHasGeomodelCoverage(targetSci, geomodelLabels, classifierLabels) {
+	if !speciesHasGeomodelCoverage(targetSci, rc.GeomodelLabels, rc.ClassifierLabels) {
 		return 0.0, RarityUnknown
 	}
 
-	if score, found := findSpeciesScore(targetSci, speciesScores); found {
+	if score, found := findSpeciesScore(targetSci, rc.Scores); found {
 		return score, calculateRarityStatus(score)
 	}
 
@@ -592,7 +596,7 @@ func (c *Handler) getSpeciesRarityInfo(bn *classifier.Orchestrator, speciesLabel
 	// Resolve the score and status together; computeRarity documents how an absent
 	// species is split between "very rare" and "unknown" by geomodel coverage.
 	targetSci := detection.ExtractScientificName(speciesLabel)
-	rarityInfo.Score, rarityInfo.Status = computeRarity(rc.FilterActive, targetSci, rc.Scores, rc.GeomodelLabels, rc.ClassifierLabels)
+	rarityInfo.Score, rarityInfo.Status = computeRarity(&rc, targetSci)
 
 	return rarityInfo, nil
 }

--- a/internal/api/v2/species/species_test.go
+++ b/internal/api/v2/species/species_test.go
@@ -702,7 +702,12 @@ func TestComputeRarity(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			gotScore, gotStatus := computeRarity(true, tt.targetSci, scores, geomodelLabels, classifierLabels)
+			gotScore, gotStatus := computeRarity(&classifier.RarityContext{
+				FilterActive:     true,
+				Scores:           scores,
+				GeomodelLabels:   geomodelLabels,
+				ClassifierLabels: classifierLabels,
+			}, tt.targetSci)
 			assert.InDelta(t, tt.wantScore, gotScore, 0.001)
 			assert.Equal(t, tt.wantStatus, gotStatus)
 		})
@@ -711,7 +716,7 @@ func TestComputeRarity(t *testing.T) {
 
 func TestComputeRarity_Empty(t *testing.T) {
 	t.Parallel()
-	gotScore, gotStatus := computeRarity(true, "Turdus migratorius", nil, nil, nil)
+	gotScore, gotStatus := computeRarity(&classifier.RarityContext{FilterActive: true}, "Turdus migratorius")
 	assert.InDelta(t, 0.0, gotScore, 0.001)
 	assert.Equal(t, RarityUnknown, gotStatus)
 }
@@ -730,7 +735,12 @@ func TestComputeRarity_InactiveFilterReportsUnknown(t *testing.T) {
 	// means the 0.0 score is synthetic and must report unknown, not very rare.
 	scores := []classifier.SpeciesScore{{Label: testSciName + "_" + testCommonName, Score: 0.0}}
 
-	score, status := computeRarity(false, testSciName, scores, labels, labels)
+	score, status := computeRarity(&classifier.RarityContext{
+		FilterActive:     false,
+		Scores:           scores,
+		GeomodelLabels:   labels,
+		ClassifierLabels: labels,
+	}, testSciName)
 	assert.InDelta(t, 0.0, score, 0.001)
 	assert.Equal(t, RarityUnknown, status, "an inactive range filter yields unknown rarity, not very rare (#3935)")
 }
@@ -748,11 +758,19 @@ func TestComputeRarity_GeomodelLabelsTakePrecedence(t *testing.T) {
 		testSciName + "_" + testCommonName,
 	}
 
-	_, status := computeRarity(true, testSciName, nil, geomodelLabels, classifierLabels)
+	_, status := computeRarity(&classifier.RarityContext{
+		FilterActive:     true,
+		GeomodelLabels:   geomodelLabels,
+		ClassifierLabels: classifierLabels,
+	}, testSciName)
 	assert.Equal(t, RarityUnknown, status,
 		"classifier-only species has no geomodel occurrence probability")
 
-	_, status = computeRarity(true, testCanonName, nil, geomodelLabels, classifierLabels)
+	_, status = computeRarity(&classifier.RarityContext{
+		FilterActive:     true,
+		GeomodelLabels:   geomodelLabels,
+		ClassifierLabels: classifierLabels,
+	}, testCanonName)
 	assert.Equal(t, RarityVeryRare, status,
 		"geomodel-covered species below threshold is very rare")
 }
@@ -795,7 +813,10 @@ func TestComputeRarity_NoGeomodelLabels(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			gotScore, gotStatus := computeRarity(true, tt.targetSci, nil, nil, classifierLabels)
+			gotScore, gotStatus := computeRarity(&classifier.RarityContext{
+				FilterActive:     true,
+				ClassifierLabels: classifierLabels,
+			}, tt.targetSci)
 			assert.InDelta(t, 0.0, gotScore, 0.001)
 			assert.Equal(t, tt.wantStatus, gotStatus)
 		})
@@ -853,11 +874,21 @@ func TestComputeRarity_CollidingSpecies(t *testing.T) {
 		{Label: collidingSciB + "_" + collidingCommonB, Score: 0.1},
 	}
 
-	gotScore, gotStatus := computeRarity(true, collidingSciB, scores, labels, labels)
+	gotScore, gotStatus := computeRarity(&classifier.RarityContext{
+		FilterActive:     true,
+		Scores:           scores,
+		GeomodelLabels:   labels,
+		ClassifierLabels: labels,
+	}, collidingSciB)
 	assert.InDelta(t, 0.1, gotScore, 0.001, "the merged species must keep its own score")
 	assert.Equal(t, RarityRare, gotStatus)
 
-	gotScore, gotStatus = computeRarity(true, collidingSciA, scores, labels, labels)
+	gotScore, gotStatus = computeRarity(&classifier.RarityContext{
+		FilterActive:     true,
+		Scores:           scores,
+		GeomodelLabels:   labels,
+		ClassifierLabels: labels,
+	}, collidingSciA)
 	assert.InDelta(t, 0.9, gotScore, 0.001)
 	assert.Equal(t, RarityVeryCommon, gotStatus)
 }
@@ -896,7 +927,12 @@ func TestComputeRarity_SyntheticScoresReportUnknown(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			scores := []classifier.SpeciesScore{{Label: unmappedSci + "_Brandt's Bat", Score: tt.score}}
-			gotScore, gotStatus := computeRarity(true, unmappedSci, scores, geomodelLabels, classifierLabels)
+			gotScore, gotStatus := computeRarity(&classifier.RarityContext{
+				FilterActive:     true,
+				Scores:           scores,
+				GeomodelLabels:   geomodelLabels,
+				ClassifierLabels: classifierLabels,
+			}, unmappedSci)
 			assert.Equal(t, RarityUnknown, gotStatus, tt.why)
 			assert.InDelta(t, 0.0, gotScore, 0.001)
 		})


### PR DESCRIPTION
## Summary

A source whose buffer route failed during a reconfigure and whose config was then never touched again got stuck: `reconfigureChangedSources` only re-registers sources whose config changed, so the failed route was never retried, its models never surfaced as "not analyzing", and the per-source route-failure memory kept a stale entry forever (a much later transient failure on that source then lost its first-failure grace). This completes the deferred status-honesty follow-up from #4294 (the #4208 route-failure item).

On each reconfigure, kept sources that still carry a recorded route failure and were not otherwise re-registered this pass are now re-wired through the same capture-preserving primitive the gain- and model-change paths already use (`Router.RemoveAllRoutes` + re-register, which touches only the router, not the capture device). The retry either recovers the route and clears the failure memory, or, still down, reports the models as not analyzing. Retries are bounded by user-driven reconfigure events and deduplicated by the existing 6h not-registered notification suppression, so there is no new notification spam and no capture interruption. The shared teardown-and-re-register sequence is extracted into `rebuildRoutesForSources` (used by both the gain-change and route-retry paths), and the retry selection is a pure, unit-tested helper `sourcesNeedingRouteRetry`.

This PR also hardens two adjacent-parameter footguns flagged in review, both behavior-preserving: the three `bool` arguments of `routeReportDecision` are grouped into a named `routeReportInputs` struct, and `computeRarity` now takes the whole `classifier.RarityContext` (by pointer) instead of two adjacent `[]string` label vocabularies that mirror its struct fields and could be silently swapped (the #3935 rarity path).

## Related Issues

Follow-up to #4294 (deferred items from #4208 and #3935). No change to the public API surface.

## Test Plan

- [x] `go build ./...`
- [x] `go test -race ./internal/analysis/ ./internal/api/v2/species/`
- [x] `golangci-lint run` clean on both changed packages (gocognit and gocritic included)
- [x] New/updated unit tests: `TestSourcesNeedingRouteRetry`; extended `TestIsReconfigureOperation` and `TestReportSourceRegistration_RouteFailureMemory` (route-retry recover and still-down transitions); `computeRarity` call sites updated to `RarityContext`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved audio pipeline recovery when buffer routes remain unavailable after reconfiguration.
  - Persistent route failures are now retried more reliably, helping restore affected audio sources without requiring additional user action.

- **Refactor**
  - Streamlined internal handling of route decisions and species rarity calculations without changing their expected external behavior.

- **Tests**
  - Expanded coverage for route-retry scenarios, including recovery, persistence, filtering, and ordering cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->