### PR TITLE
fix(privacy): preserve human and dog classes past top-K truncation

### DIFF
--- a/internal/analysis/processor/vocalization_labels.go
+++ b/internal/analysis/processor/vocalization_labels.go
@@ -1,105 +1,19 @@
-// vocalization_labels.go classifies raw classifier labels as human or dog
-// vocalizations for the privacy filter and the dog bark filter.
-//
-// Why match the RAW label (result.Species) instead of the enriched common name:
-//
-//  1. Locale stability. BirdNET loads a locale-specific label file, so for a
-//     German user the dog class arrives as "Dog_Hund" and the human classes as
-//     "Human vocal_Mensch Stimme" etc. SplitSpeciesName uses the part after "_"
-//     as the common name ("Hund", "Mensch Stimme"), which contains no "dog" or
-//     "human" token, so matching the enriched name silently failed for every
-//     non-English locale. The part BEFORE the "_" (the scientific portion) is
-//     always English ("Dog", "Human vocal", ...), so matching the raw label
-//     works regardless of the configured locale.
-//
-//  2. Collision safety. A bare "human"/"dog" substring match also fires on bird
-//     binomials that merely contain those letters, e.g. the cicada "Pacarina
-//     schumanni" (...sc-human-ni) or the katydid "Poecilimon doga" (...doga).
-//     Anchoring on the raw-label prefix ("human ", "dog_") excludes them.
-//
-//  3. Perch v2 (trained on iNaturalist 2024 + FSD50K) emits AudioSet-ontology
-//     sound classes ("Speech", "Bark", "Growling", ...) that carry no "human"/
-//     "dog" token at all, and whose underscore-joined forms ("Human_voice")
-//     SplitSpeciesName mangles into "voice". Those are matched exactly against
-//     the raw label here. The Perch/AudioSet (FSD50K) human-sound classes are
-//     handled by the shared nonbird package (CategoryHuman); only the
-//     iNaturalist taxon "homo sapiens" requires a local extra-labels map.
-//
-// Matching is case-insensitive: the raw label is lowercased once and compared
-// against the lowercase keys / prefixes below, so a custom or future label file
-// with different casing still engages the filters.
+// vocalization_labels.go adapts the shared vocalization label classifier to the
+// processor's unexported call sites (privacy filter and dog bark filter). The
+// classification logic and its rationale live in internal/labels/vocalization,
+// the single source of truth shared with the classifier's top-K truncation.
 package processor
 
-import (
-	"strings"
-
-	"github.com/tphakala/birdnet-go/internal/labels/nonbird"
-)
-
-const (
-	// birdnetHumanLabelPrefix matches BirdNET's human classes by the English
-	// scientific portion of the raw label ("Human vocal_...", "Human non-vocal_...",
-	// "Human whistle_..."), which is the same across every locale. The trailing
-	// space is load-bearing: "human vocal" matches, but the cicada "Pacarina
-	// schumanni" (which contains the substring "human") does not.
-	birdnetHumanLabelPrefix = "human "
-	// birdnetDogLabelPrefix matches BirdNET's "Dog" class by its raw-label form
-	// "Dog_<localized common name>" (e.g. "Dog_Dog", "Dog_Hund"). The underscore
-	// is load-bearing: the class matches, but the katydid "Poecilimon doga"
-	// (which contains the substring "dog") does not.
-	birdnetDogLabelPrefix = "dog_"
-)
-
-// perchHumanExtraLabels holds human labels that the shared nonbird package does
-// not cover: iNaturalist taxa (not AudioSet/FSD50K sound classes). Keys are
-// lowercase.
-//
-//nolint:gochecknoglobals // immutable lookup table, read-only after init
-var perchHumanExtraLabels = map[string]struct{}{
-	"homo sapiens": {}, // human detected as a species (iNaturalist taxon), not a sound class
-}
-
-// perchDogLabels enumerates the raw Perch v2 labels treated as a dog by the dog
-// bark filter: the FSD50K dog sound classes plus the domestic dog taxon. Wild
-// canids (wolf, coyote, jackal) are intentionally excluded so they remain
-// detectable as wildlife rather than being suppressed as background barking.
-// "Growling" is the AudioSet child of the Dog class (dog growling), so it stays.
-// Keys are lowercase; lookups lowercase the raw label first (see isDogDetection).
-//
-//nolint:gochecknoglobals // immutable lookup table, read-only after init
-var perchDogLabels = map[string]struct{}{
-	"dog":              {}, // FSD50K dog
-	"bark":             {}, // FSD50K bark
-	"growling":         {}, // FSD50K dog growl (AudioSet child of Dog)
-	"canis familiaris": {}, // domestic dog (iNaturalist taxon)
-}
+import "github.com/tphakala/birdnet-go/internal/labels/vocalization"
 
 // isHumanVocalization reports whether a raw classifier label represents a human
-// sound that should engage the privacy filter. rawLabel is the untransformed
-// result.Species value. Matching is case-insensitive.
-//
-// The AudioSet/FSD50K portion is delegated to the shared nonbird package
-// (nonbird.CategoryHuman). The iNaturalist taxon "homo sapiens" and the
-// BirdNET locale-stable prefix are handled locally.
+// sound that should engage the privacy filter. See vocalization.IsHuman.
 func isHumanVocalization(rawLabel string) bool {
-	if cat, ok := nonbird.CategoryOf(rawLabel); ok && cat == nonbird.CategoryHuman {
-		return true
-	}
-	lowered := strings.ToLower(rawLabel)
-	if _, ok := perchHumanExtraLabels[lowered]; ok {
-		return true
-	}
-	return strings.HasPrefix(lowered, birdnetHumanLabelPrefix)
+	return vocalization.IsHuman(rawLabel)
 }
 
 // isDogDetection reports whether a raw classifier label represents a dog for the
-// dog bark filter. rawLabel is the untransformed result.Species value. Matching
-// is case-insensitive: Perch v2 classes are matched exactly; BirdNET's "Dog"
-// class is matched by the locale-stable English label prefix.
+// dog bark filter. See vocalization.IsDog.
 func isDogDetection(rawLabel string) bool {
-	lowered := strings.ToLower(rawLabel)
-	if _, ok := perchDogLabels[lowered]; ok {
-		return true
-	}
-	return strings.HasPrefix(lowered, birdnetDogLabelPrefix)
+	return vocalization.IsDog(rawLabel)
 }

--- a/internal/analysis/processor/vocalization_labels_test.go
+++ b/internal/analysis/processor/vocalization_labels_test.go
@@ -8,122 +8,11 @@ import (
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
-	"github.com/tphakala/birdnet-go/internal/labels/nonbird"
 )
 
-func TestIsHumanVocalization(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		rawLabel string
-		want     bool
-	}{
-		// BirdNET v2.4 classes, English (matched via the locale-stable prefix).
-		{"BirdNET human vocal", "Human vocal_Human vocal", true},
-		{"BirdNET human non-vocal", "Human non-vocal_Human non-vocal", true},
-		{"BirdNET human whistle", "Human whistle_Human whistle", true},
-		// BirdNET v2.4 classes, non-English locale. The common name is localized
-		// ("Mensch Stimme"), so only raw-label matching catches these.
-		{"BirdNET human vocal (de)", "Human vocal_Mensch Stimme", true},
-		{"BirdNET human non-vocal (de)", "Human non-vocal_Mensch Geräusch", true},
-		{"BirdNET human whistle (de)", "Human whistle_Mensch Pfeifen", true},
-		// Perch v2 speech/voice classes (exact raw-label match).
-		{"Perch Speech", "Speech", true},
-		{"Perch Human_voice", "Human_voice", true},
-		{"Perch male speech", "Male_speech_and_man_speaking", true},
-		{"Perch female speech", "Female_speech_and_woman_speaking", true},
-		{"Perch child speech", "Child_speech_and_kid_speaking", true},
-		{"Perch Conversation", "Conversation", true},
-		{"Perch Chatter", "Chatter", true},
-		{"Perch Whispering", "Whispering", true},
-		{"Perch Speech_synthesizer", "Speech_synthesizer", true},
-		{"Perch Human_group_actions", "Human_group_actions", true},
-		{"Perch Screaming", "Screaming", true},
-		{"Perch Shout", "Shout", true},
-		// Perch v2 other vocalizations.
-		{"Perch Singing", "Singing", true},
-		{"Perch Laughter", "Laughter", true},
-		{"Perch Crying_and_sobbing", "Crying_and_sobbing", true},
-		{"Perch Sigh", "Sigh", true},
-		// Perch v2 non-vocal human sounds and actions.
-		{"Perch Cough", "Cough", true},
-		{"Perch Breathing", "Breathing", true},
-		{"Perch Fart", "Fart", true},
-		{"Perch Applause", "Applause", true},
-		{"Perch Clapping", "Clapping", true},
-		{"Perch Crowd", "Crowd", true},
-		{"Perch Walk_and_footsteps", "Walk_and_footsteps", true},
-		{"Perch Run", "Run", true},
-		// Human taxon (the human species itself).
-		{"Perch Homo sapiens", "Homo sapiens", true},
-		// Case-insensitive matching (custom/future label files may vary casing).
-		{"Perch speech lowercase", "speech", true},
-		{"Perch HUMAN_VOICE uppercase", "HUMAN_VOICE", true},
-		{"BirdNET human prefix lowercase", "human vocal_human vocal", true},
-		// Negatives: bird binomials that merely contain the substring "human".
-		{"cicada Pacarina schumanni", "Pacarina schumanni", false},
-		{"warbler Phylloscopus humei", "Phylloscopus humei", false},
-		{"BirdNET American Robin", "Turdus migratorius_American Robin", false},
-		// Negatives: non-human FSD50K classes that co-occur with people.
-		{"Perch Thump_and_thud", "Thump_and_thud", false},
-		{"Perch Car_passing_by", "Car_passing_by", false},
-		// Negatives: dog labels are not human.
-		{"Perch Bark is not human", "Bark", false},
-		{"Perch Dog is not human", "Dog", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tt.want, isHumanVocalization(tt.rawLabel))
-		})
-	}
-}
-
-func TestIsDogDetection(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		rawLabel string
-		want     bool
-	}{
-		// BirdNET v2.4 dog class, English and a non-English locale.
-		{"BirdNET Dog (en)", "Dog_Dog", true},
-		{"BirdNET Dog (de)", "Dog_Hund", true},
-		// Perch v2 dog sound classes and the domestic dog taxon.
-		{"Perch Dog", "Dog", true},
-		{"Perch Bark", "Bark", true},
-		{"Perch Growling", "Growling", true},
-		{"Perch Canis familiaris", "Canis familiaris", true},
-		// Case-insensitive matching.
-		{"Perch bark lowercase", "bark", true},
-		{"BirdNET DOG_DOG uppercase", "DOG_DOG", true},
-		// Negatives: bird/insect binomials that merely contain the substring "dog".
-		// Tachyspiza rhodogaster is a real bird (Vinous-breasted Sparrowhawk); the
-		// old "dog" substring match would have wrongly filtered it.
-		{"hawk Tachyspiza rhodogaster", "Tachyspiza rhodogaster", false},
-		{"katydid Poecilimon doga", "Poecilimon doga", false},
-		{"cicada Cicada mordoganensis", "Cicada mordoganensis", false},
-		{"cricket Lepidogryllus comparatus", "Lepidogryllus comparatus", false},
-		{"cricket Lepidogryllus parvulus", "Lepidogryllus parvulus", false},
-		// Negatives: wild canids stay detectable as wildlife.
-		{"wolf Canis lupus", "Canis lupus", false},
-		{"coyote Canis latrans", "Canis latrans", false},
-		{"jackal Canis aureus", "Canis aureus", false},
-		// Negatives: humans and birds are not dogs.
-		{"Perch Speech is not dog", "Speech", false},
-		{"bird Turdus merula", "Turdus merula", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tt.want, isDogDetection(tt.rawLabel))
-		})
-	}
-}
+// The raw-label classification logic (isHumanVocalization / isDogDetection) is
+// tested in internal/labels/vocalization. The tests here cover the processor
+// call sites that consume it: the recording handlers and the save filter.
 
 // TestDetectionHandlers_RecordTimestamp proves both recording handlers store a
 // detection timestamp for the labels the old substring match missed (Perch v2
@@ -203,69 +92,7 @@ func TestDetectionHandlers_RecordTimestamp(t *testing.T) {
 	}
 }
 
-// TestPerchHumanLabelsParityWithNonbird verifies that every key previously in
-// perchHumanLabels (except "homo sapiens", which is the iNaturalist taxon
-// preserved in perchHumanExtraLabels) is classified as CategoryHuman by the
-// shared nonbird package. A failure here means a coverage regression: a label
-// that used to engage the privacy filter would silently stop doing so.
-func TestPerchHumanLabelsParityWithNonbird(t *testing.T) {
-	t.Parallel()
-
-	// The complete former perchHumanLabels key set (37 entries minus "homo sapiens").
-	// "homo sapiens" is excluded: it is an iNaturalist taxon, not an AudioSet/FSD50K
-	// sound class, so nonbird does not include it. It lives in perchHumanExtraLabels.
-	oldAudioSetKeys := []string{
-		"speech",
-		"speech_synthesizer",
-		"male_speech_and_man_speaking",
-		"female_speech_and_woman_speaking",
-		"child_speech_and_kid_speaking",
-		"conversation",
-		"chatter",
-		"human_voice",
-		"human_group_actions",
-		"whispering",
-		"shout",
-		"yell",
-		"screaming",
-		"singing",
-		"male_singing",
-		"female_singing",
-		"laughter",
-		"giggle",
-		"chuckle_and_chortle",
-		"crying_and_sobbing",
-		"gasp",
-		"sigh",
-		"cough",
-		"sneeze",
-		"breathing",
-		"respiratory_sounds",
-		"burping_and_eructation",
-		"fart",
-		"chewing_and_mastication",
-		"crowd",
-		"cheering",
-		"applause",
-		"clapping",
-		"finger_snapping",
-		"hands",
-		"walk_and_footsteps",
-		"run",
-	}
-
-	for _, key := range oldAudioSetKeys {
-		t.Run(key, func(t *testing.T) {
-			t.Parallel()
-			cat, ok := nonbird.CategoryOf(key)
-			assert.True(t, ok, "nonbird.CategoryOf(%q) must find the key", key)
-			assert.Equal(t, nonbird.CategoryHuman, cat,
-				"nonbird.CategoryOf(%q) must return CategoryHuman", key)
-		})
-	}
-}
-
-// TestShouldFilterDetection_DropsHumanLabels covers the third changed call site:
+// TestShouldFilterDetection_DropsHumanLabels covers the save filter call site:
 // shouldFilterDetection must drop a human-labeled detection from being saved
 // (Perch v2 class and a localized BirdNET class), while letting a normal bird
 // through.

--- a/internal/classifier/analyze.go
+++ b/internal/classifier/analyze.go
@@ -271,6 +271,13 @@ func trimResultsToMax(results []datastore.Results, maxResults int) []datastore.R
 
 // getTopKResults returns the top k results without fully sorting the array.
 // Uses a partial sort algorithm that's more efficient than sorting all results.
+// It additionally retains the strongest human and dog vocalization classes even
+// when they rank below k, so the privacy and dog-bark filters downstream still
+// see them (see preserveFilterClasses); the returned slice can therefore hold up
+// to k+2 entries. The first k entries stay in descending-confidence order; any
+// appended filter class is below that minimum and the two appended entries are
+// not ordered relative to each other, so consumers must not assume the tail is
+// confidence-sorted (results[0] and the top-k order are unaffected).
 func getTopKResults(results []datastore.Results, k int) []datastore.Results {
 	if len(results) == 0 || k <= 0 {
 		return []datastore.Results{}
@@ -301,9 +308,16 @@ func getTopKResults(results []datastore.Results, k int) []datastore.Results {
 	// is small (defaultTopKResults = 10), so the copy is cheap and the upstream
 	// large-buffer reuse optimization stays intact: bn.resultsBuffer remains
 	// internal scratch that never escapes.
-	out := make([]datastore.Results, n)
+	// Room for the up-to-two appended filter classes so preserveFilterClasses does
+	// not reallocate when it retains a below-top-K human or dog class.
+	out := make([]datastore.Results, n, n+2)
 	copy(out, results[:n])
-	return out
+
+	// Retain the human and dog classes the privacy and dog-bark filters depend on
+	// even when they rank below the top-K, so a faint speech or bark prediction is
+	// not hidden from the filters by truncation (issue #4177). results still holds
+	// every prediction (the partial sort reordered but did not drop any).
+	return preserveFilterClasses(out, results)
 }
 
 // partialSort performs a partial sort to move the top k elements to the front.

--- a/internal/classifier/analyze.go
+++ b/internal/classifier/analyze.go
@@ -308,9 +308,9 @@ func getTopKResults(results []datastore.Results, k int) []datastore.Results {
 	// is small (defaultTopKResults = 10), so the copy is cheap and the upstream
 	// large-buffer reuse optimization stays intact: bn.resultsBuffer remains
 	// internal scratch that never escapes.
-	// Room for the up-to-two appended filter classes so preserveFilterClasses does
-	// not reallocate when it retains a below-top-K human or dog class.
-	out := make([]datastore.Results, n, n+2)
+	// Room for the appended filter classes so preserveFilterClasses does not
+	// reallocate when it retains a below-top-K human or dog class.
+	out := make([]datastore.Results, n, n+maxPreservedFilterClasses)
 	copy(out, results[:n])
 
 	// Retain the human and dog classes the privacy and dog-bark filters depend on

--- a/internal/classifier/filter_class_preserve.go
+++ b/internal/classifier/filter_class_preserve.go
@@ -1,0 +1,62 @@
+package classifier
+
+import (
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/labels/vocalization"
+)
+
+// preserveFilterClasses ensures the privacy and dog-bark filters still see the
+// human and dog classes they depend on after top-K truncation. Those filters run
+// in the analysis processor over the results the classifier returns, so a human
+// or dog prediction that ranks below the top-K would otherwise be discarded before
+// the filter could act on it. BirdNET scores faint human speech near 1-10% while a
+// full chunk of louder birds outranks it, so the "Human"/"Speech" prediction is
+// routinely cut at the top-K step and never reaches the privacy filter (issue
+// #4177).
+//
+// It appends the single highest-confidence human class and the single
+// highest-confidence dog class from the full result set when they are not already
+// present in top. The filters only need the strongest such prediction (they gate a
+// single map write on it), so at most two entries are added: a saved detection in
+// the same chunk therefore gains at most two low-confidence additional results, a
+// truthful record of what the model heard.
+//
+// A single pass over all classifies each label once via vocalization.Classify
+// (this runs per inference window over the whole ~6.5k-15k prediction set, so the
+// single lowercase-once classification matters). The appended datastore.Results
+// values are pure value types (datastore.Results in internal/datastore/model.go
+// has only uint/string/float32 fields), so copying them by value preserves the
+// race-safety contract getTopKResults relies on for the reused BirdNET scratch
+// buffer.
+func preserveFilterClasses(top, all []datastore.Results) []datastore.Results {
+	bestHuman, bestDog := -1, -1
+	var bestHumanConf, bestDogConf float32
+	for i := range all {
+		conf := all[i].Confidence
+		human, dog := vocalization.Classify(all[i].Species)
+		if human && (bestHuman == -1 || conf > bestHumanConf) {
+			bestHuman, bestHumanConf = i, conf
+		}
+		if dog && (bestDog == -1 || conf > bestDogConf) {
+			bestDog, bestDogConf = i, conf
+		}
+	}
+	top = appendIfAbsent(top, all, bestHuman)
+	top = appendIfAbsent(top, all, bestDog)
+	return top
+}
+
+// appendIfAbsent appends all[idx] to top unless a result carrying that same
+// Species string already survived truncation into top. idx < 0 (no match found)
+// returns top unchanged.
+func appendIfAbsent(top, all []datastore.Results, idx int) []datastore.Results {
+	if idx < 0 {
+		return top
+	}
+	for i := range top {
+		if top[i].Species == all[idx].Species {
+			return top // strongest match already survived truncation
+		}
+	}
+	return append(top, all[idx])
+}

--- a/internal/classifier/filter_class_preserve.go
+++ b/internal/classifier/filter_class_preserve.go
@@ -5,6 +5,12 @@ import (
 	"github.com/tphakala/birdnet-go/internal/labels/vocalization"
 )
 
+// maxPreservedFilterClasses is the most results preserveFilterClasses can append
+// past the top-K cut: one human class and one dog class. getTopKResults pre-sizes
+// its output slice by this amount so the appends never reallocate; keep the two in
+// sync.
+const maxPreservedFilterClasses = 2
+
 // preserveFilterClasses ensures the privacy and dog-bark filters still see the
 // human and dog classes they depend on after top-K truncation. Those filters run
 // in the analysis processor over the results the classifier returns, so a human

--- a/internal/classifier/filter_class_preserve_test.go
+++ b/internal/classifier/filter_class_preserve_test.go
@@ -1,0 +1,114 @@
+package classifier
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+)
+
+// speciesConfidences returns a species->confidence map for a results slice, so
+// tests can assert membership without depending on order.
+func speciesConfidences(results []datastore.Results) map[string]float32 {
+	m := make(map[string]float32, len(results))
+	for _, r := range results {
+		m[r.Species] = r.Confidence
+	}
+	return m
+}
+
+// TestGetTopKResults_PreservesHumanAndDogPastTopK is the issue #4177 fix: the
+// privacy and dog-bark filters run over the truncated results, so a human or dog
+// class ranked below the top-K must still survive truncation or the filters never
+// see it. Twelve high-confidence birds outrank a faint "Speech" and "Bark"; both
+// must be retained past k=10.
+func TestGetTopKResults_PreservesHumanAndDogPastTopK(t *testing.T) {
+	t.Parallel()
+
+	results := make([]datastore.Results, 0, 14)
+	for i := range 12 {
+		results = append(results, datastore.Results{
+			Species:    "Bird_" + string(rune('A'+i)),
+			Confidence: 0.9 - float32(i)*0.01, // 0.90 .. 0.79, all above the faint classes
+		})
+	}
+	results = append(results,
+		datastore.Results{Species: "Speech", Confidence: 0.02},
+		datastore.Results{Species: "Bark", Confidence: 0.03},
+	)
+
+	top := getTopKResults(results, 10)
+
+	got := speciesConfidences(top)
+	require.Contains(t, got, "Speech", "faint human class must survive top-K truncation")
+	require.Contains(t, got, "Bark", "faint dog class must survive top-K truncation")
+	assert.InDelta(t, 0.02, got["Speech"], 1e-6, "preserved human confidence must be intact")
+	assert.InDelta(t, 0.03, got["Bark"], 1e-6, "preserved dog confidence must be intact")
+	// 10 birds + 1 human + 1 dog. The two lowest birds (rank 11, 12) are dropped.
+	assert.Len(t, top, 12)
+}
+
+// TestGetTopKResults_NoDuplicateWhenClassInTopK verifies preservation does not
+// duplicate a human/dog class that already made the top-K.
+func TestGetTopKResults_NoDuplicateWhenClassInTopK(t *testing.T) {
+	t.Parallel()
+
+	results := []datastore.Results{
+		{Species: "Speech", Confidence: 0.95},
+		{Species: "Bird_A", Confidence: 0.90},
+		{Species: "Bird_B", Confidence: 0.80},
+	}
+
+	top := getTopKResults(results, 10)
+
+	var speechCount int
+	for _, r := range top {
+		if r.Species == "Speech" {
+			speechCount++
+		}
+	}
+	assert.Equal(t, 1, speechCount, "human class already in top-K must not be duplicated")
+	assert.Len(t, top, 3)
+}
+
+// TestGetTopKResults_HumanAndDogPreservedIndependently verifies the human and dog
+// classes are retained independently: a human class that makes the top-K must not
+// suppress preservation of a dog class that ranks below it, and vice versa.
+func TestGetTopKResults_HumanAndDogPreservedIndependently(t *testing.T) {
+	t.Parallel()
+
+	results := make([]datastore.Results, 0, 12)
+	// A human class is strong enough to make the top-K.
+	results = append(results, datastore.Results{Species: "Speech", Confidence: 0.95})
+	for i := range 10 {
+		results = append(results, datastore.Results{
+			Species:    "Bird_" + string(rune('A'+i)),
+			Confidence: 0.9 - float32(i)*0.01,
+		})
+	}
+	// A faint dog class ranks below k (11 louder classes already precede it).
+	results = append(results, datastore.Results{Species: "Bark", Confidence: 0.02})
+
+	top := getTopKResults(results, 10)
+	got := speciesConfidences(top)
+	require.Contains(t, got, "Speech", "human class in top-K must remain")
+	require.Contains(t, got, "Bark", "faint dog class must be preserved independently of the human class")
+}
+
+// TestGetTopKResults_NoFilterClassesUnchanged verifies a normal bird-only chunk
+// is unaffected: exactly the top-K by confidence, no growth.
+func TestGetTopKResults_NoFilterClassesUnchanged(t *testing.T) {
+	t.Parallel()
+
+	results := make([]datastore.Results, 0, 15)
+	for i := range 15 {
+		results = append(results, datastore.Results{
+			Species:    "Bird_" + string(rune('A'+i)),
+			Confidence: 0.9 - float32(i)*0.01,
+		})
+	}
+
+	top := getTopKResults(results, 10)
+	assert.Len(t, top, 10, "bird-only chunk must be exactly top-K")
+}

--- a/internal/labels/vocalization/vocalization.go
+++ b/internal/labels/vocalization/vocalization.go
@@ -1,0 +1,141 @@
+// Package vocalization classifies raw classifier labels as human or dog
+// vocalizations. It is the single source of truth for the privacy filter and
+// the dog-bark filter (which consume it in the analysis processor) and for the
+// classifier's top-K truncation, which retains these classes so a low-confidence
+// speech or dog prediction is not hidden from the filters (issue #4177).
+//
+// Why match the RAW label (result.Species) instead of the enriched common name:
+//
+//  1. Locale stability. BirdNET loads a locale-specific label file, so for a
+//     German user the dog class arrives as "Dog_Hund" and the human classes as
+//     "Human vocal_Mensch Stimme" etc. SplitSpeciesName uses the part after "_"
+//     as the common name ("Hund", "Mensch Stimme"), which contains no "dog" or
+//     "human" token, so matching the enriched name silently failed for every
+//     non-English locale. The part BEFORE the "_" (the scientific portion) is
+//     always English ("Dog", "Human vocal", ...), so matching the raw label
+//     works regardless of the configured locale.
+//
+//  2. Collision safety. A bare "human"/"dog" substring match also fires on bird
+//     binomials that merely contain those letters, e.g. the cicada "Pacarina
+//     schumanni" (...sc-human-ni) or the katydid "Poecilimon doga" (...doga).
+//     Anchoring on the raw-label prefix ("human ", "dog_") excludes them.
+//
+//  3. Perch v2 (trained on iNaturalist 2024 + FSD50K) emits AudioSet-ontology
+//     sound classes ("Speech", "Bark", "Growling", ...) that carry no "human"/
+//     "dog" token at all, and whose underscore-joined forms ("Human_voice")
+//     SplitSpeciesName mangles into "voice". Those are matched exactly against
+//     the raw label here. The Perch/AudioSet (FSD50K) human-sound classes are
+//     handled by the shared nonbird package (CategoryHuman); only the
+//     iNaturalist taxon "homo sapiens" requires a local extra-labels map.
+//
+// Matching is case-insensitive: the raw label is lowercased once and compared
+// against the lowercase keys / prefixes below, so a custom or future label file
+// with different casing still engages the filters.
+package vocalization
+
+import (
+	"strings"
+
+	"github.com/tphakala/birdnet-go/internal/labels/nonbird"
+)
+
+const (
+	// birdnetHumanLabelPrefix matches BirdNET's human classes by the English
+	// scientific portion of the raw label ("Human vocal_...", "Human non-vocal_...",
+	// "Human whistle_..."), which is the same across every locale. The trailing
+	// space is load-bearing: "human vocal" matches, but the cicada "Pacarina
+	// schumanni" (which contains the substring "human") does not.
+	birdnetHumanLabelPrefix = "human "
+	// birdnetDogLabelPrefix matches BirdNET's "Dog" class by its raw-label form
+	// "Dog_<localized common name>" (e.g. "Dog_Dog", "Dog_Hund"). The underscore
+	// is load-bearing: the class matches, but the katydid "Poecilimon doga"
+	// (which contains the substring "dog") does not.
+	birdnetDogLabelPrefix = "dog_"
+)
+
+// perchHumanExtraLabels holds human labels that the shared nonbird package does
+// not cover: iNaturalist taxa (not AudioSet/FSD50K sound classes). Keys are
+// lowercase.
+//
+//nolint:gochecknoglobals // immutable lookup table, read-only after init
+var perchHumanExtraLabels = map[string]struct{}{
+	"homo sapiens": {}, // human detected as a species (iNaturalist taxon), not a sound class
+}
+
+// perchDogLabels enumerates the raw Perch v2 labels treated as a dog by the dog
+// bark filter: the FSD50K dog sound classes plus the domestic dog taxon. Wild
+// canids (wolf, coyote, jackal) are intentionally excluded so they remain
+// detectable as wildlife rather than being suppressed as background barking.
+// "Growling" is the AudioSet child of the Dog class (dog growling), so it stays.
+// Keys are lowercase; lookups lowercase the raw label first (see classifyLowered).
+//
+//nolint:gochecknoglobals // immutable lookup table, read-only after init
+var perchDogLabels = map[string]struct{}{
+	"dog":              {}, // FSD50K dog
+	"bark":             {}, // FSD50K bark
+	"growling":         {}, // FSD50K dog growl (AudioSet child of Dog)
+	"canis familiaris": {}, // domestic dog (iNaturalist taxon)
+}
+
+// Classify reports whether a raw classifier label represents a human sound
+// (privacy filter) and/or a dog (dog-bark filter) in a single pass. rawLabel is
+// the untransformed result.Species value. Matching is case-insensitive.
+//
+// It lowercases rawLabel ONCE and answers both questions from the lowered form,
+// so the classifier's per-inference truncation (which evaluates every one of the
+// ~6.5k-15k predictions) pays a single allocation per label instead of the three
+// that separate IsHuman + IsDog calls would (nonbird.CategoryOf re-lowering an
+// already-lowercase ASCII string is allocation-free).
+func Classify(rawLabel string) (human, dog bool) {
+	return classifyLowered(strings.ToLower(rawLabel))
+}
+
+// classifyLowered is the shared core: it takes an already-lowercased label and
+// returns the human and dog verdicts. The human check delegates the AudioSet/
+// FSD50K portion to the shared nonbird package (nonbird.CategoryHuman); the
+// iNaturalist taxon "homo sapiens" and the BirdNET locale-stable prefix are
+// handled locally. The dog check matches Perch v2 classes exactly and BirdNET's
+// "Dog" class by its locale-stable English label prefix.
+func classifyLowered(lowered string) (human, dog bool) {
+	switch {
+	case categoryIsHuman(lowered):
+		human = true
+	case mapHas(perchHumanExtraLabels, lowered):
+		human = true
+	case strings.HasPrefix(lowered, birdnetHumanLabelPrefix):
+		human = true
+	}
+	switch {
+	case mapHas(perchDogLabels, lowered):
+		dog = true
+	case strings.HasPrefix(lowered, birdnetDogLabelPrefix):
+		dog = true
+	}
+	return human, dog
+}
+
+// categoryIsHuman reports whether the (already-lowercased) label is an AudioSet/
+// FSD50K human sound class per the shared nonbird package.
+func categoryIsHuman(lowered string) bool {
+	cat, ok := nonbird.CategoryOf(lowered)
+	return ok && cat == nonbird.CategoryHuman
+}
+
+func mapHas(m map[string]struct{}, key string) bool {
+	_, ok := m[key]
+	return ok
+}
+
+// IsHuman reports whether a raw classifier label represents a human sound that
+// should engage the privacy filter. See Classify.
+func IsHuman(rawLabel string) bool {
+	human, _ := Classify(rawLabel)
+	return human
+}
+
+// IsDog reports whether a raw classifier label represents a dog for the dog bark
+// filter. See Classify.
+func IsDog(rawLabel string) bool {
+	_, dog := Classify(rawLabel)
+	return dog
+}

--- a/internal/labels/vocalization/vocalization_test.go
+++ b/internal/labels/vocalization/vocalization_test.go
@@ -1,0 +1,221 @@
+package vocalization
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/labels/nonbird"
+)
+
+func TestIsHuman(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		rawLabel string
+		want     bool
+	}{
+		// BirdNET v2.4 classes, English (matched via the locale-stable prefix).
+		{"BirdNET human vocal", "Human vocal_Human vocal", true},
+		{"BirdNET human non-vocal", "Human non-vocal_Human non-vocal", true},
+		{"BirdNET human whistle", "Human whistle_Human whistle", true},
+		// BirdNET v2.4 classes, non-English locale. The common name is localized
+		// ("Mensch Stimme"), so only raw-label matching catches these.
+		{"BirdNET human vocal (de)", "Human vocal_Mensch Stimme", true},
+		{"BirdNET human non-vocal (de)", "Human non-vocal_Mensch Geräusch", true},
+		{"BirdNET human whistle (de)", "Human whistle_Mensch Pfeifen", true},
+		// Perch v2 speech/voice classes (exact raw-label match).
+		{"Perch Speech", "Speech", true},
+		{"Perch Human_voice", "Human_voice", true},
+		{"Perch male speech", "Male_speech_and_man_speaking", true},
+		{"Perch female speech", "Female_speech_and_woman_speaking", true},
+		{"Perch child speech", "Child_speech_and_kid_speaking", true},
+		{"Perch Conversation", "Conversation", true},
+		{"Perch Chatter", "Chatter", true},
+		{"Perch Whispering", "Whispering", true},
+		{"Perch Speech_synthesizer", "Speech_synthesizer", true},
+		{"Perch Human_group_actions", "Human_group_actions", true},
+		{"Perch Screaming", "Screaming", true},
+		{"Perch Shout", "Shout", true},
+		// Perch v2 other vocalizations.
+		{"Perch Singing", "Singing", true},
+		{"Perch Laughter", "Laughter", true},
+		{"Perch Crying_and_sobbing", "Crying_and_sobbing", true},
+		{"Perch Sigh", "Sigh", true},
+		// Perch v2 non-vocal human sounds and actions.
+		{"Perch Cough", "Cough", true},
+		{"Perch Breathing", "Breathing", true},
+		{"Perch Fart", "Fart", true},
+		{"Perch Applause", "Applause", true},
+		{"Perch Clapping", "Clapping", true},
+		{"Perch Crowd", "Crowd", true},
+		{"Perch Walk_and_footsteps", "Walk_and_footsteps", true},
+		{"Perch Run", "Run", true},
+		// Human taxon (the human species itself).
+		{"Perch Homo sapiens", "Homo sapiens", true},
+		// Case-insensitive matching (custom/future label files may vary casing).
+		{"Perch speech lowercase", "speech", true},
+		{"Perch HUMAN_VOICE uppercase", "HUMAN_VOICE", true},
+		{"BirdNET human prefix lowercase", "human vocal_human vocal", true},
+		// Negatives: bird binomials that merely contain the substring "human".
+		{"cicada Pacarina schumanni", "Pacarina schumanni", false},
+		{"warbler Phylloscopus humei", "Phylloscopus humei", false},
+		{"BirdNET American Robin", "Turdus migratorius_American Robin", false},
+		// Negatives: non-human FSD50K classes that co-occur with people.
+		{"Perch Thump_and_thud", "Thump_and_thud", false},
+		{"Perch Car_passing_by", "Car_passing_by", false},
+		// Negatives: dog labels are not human.
+		{"Perch Bark is not human", "Bark", false},
+		{"Perch Dog is not human", "Dog", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, IsHuman(tt.rawLabel))
+		})
+	}
+}
+
+func TestIsDog(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		rawLabel string
+		want     bool
+	}{
+		// BirdNET v2.4 dog class, English and a non-English locale.
+		{"BirdNET Dog (en)", "Dog_Dog", true},
+		{"BirdNET Dog (de)", "Dog_Hund", true},
+		// Perch v2 dog sound classes and the domestic dog taxon.
+		{"Perch Dog", "Dog", true},
+		{"Perch Bark", "Bark", true},
+		{"Perch Growling", "Growling", true},
+		{"Perch Canis familiaris", "Canis familiaris", true},
+		// Case-insensitive matching.
+		{"Perch bark lowercase", "bark", true},
+		{"BirdNET DOG_DOG uppercase", "DOG_DOG", true},
+		// Negatives: bird/insect binomials that merely contain the substring "dog".
+		// Tachyspiza rhodogaster is a real bird (Vinous-breasted Sparrowhawk); the
+		// old "dog" substring match would have wrongly filtered it.
+		{"hawk Tachyspiza rhodogaster", "Tachyspiza rhodogaster", false},
+		{"katydid Poecilimon doga", "Poecilimon doga", false},
+		{"cicada Cicada mordoganensis", "Cicada mordoganensis", false},
+		{"cricket Lepidogryllus comparatus", "Lepidogryllus comparatus", false},
+		{"cricket Lepidogryllus parvulus", "Lepidogryllus parvulus", false},
+		// Negatives: wild canids stay detectable as wildlife.
+		{"wolf Canis lupus", "Canis lupus", false},
+		{"coyote Canis latrans", "Canis latrans", false},
+		{"jackal Canis aureus", "Canis aureus", false},
+		// Negatives: humans and birds are not dogs.
+		{"Perch Speech is not dog", "Speech", false},
+		{"bird Turdus merula", "Turdus merula", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, IsDog(tt.rawLabel))
+		})
+	}
+}
+
+// TestClassify verifies the single-pass classifier returns the human and dog
+// verdicts independently and agrees with IsHuman/IsDog. The classifier's per-
+// inference truncation relies on Classify, so its correctness is load-bearing.
+func TestClassify(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		rawLabel   string
+		human, dog bool
+	}{
+		{"Perch speech is human only", "Speech", true, false},
+		{"Perch bark is dog only", "Bark", false, true},
+		{"Perch growling is dog only", "Growling", false, true},
+		{"BirdNET human vocal is human only", "Human vocal_Human vocal", true, false},
+		{"BirdNET dog is dog only", "Dog_Hund", false, true},
+		{"localized BirdNET human is human only", "Human vocal_Mensch Stimme", true, false},
+		{"homo sapiens taxon is human only", "Homo sapiens", true, false},
+		{"canis familiaris taxon is dog only", "Canis familiaris", false, true},
+		{"uppercase is case-insensitive", "HUMAN_VOICE", true, false},
+		{"a bird is neither", "Turdus merula", false, false},
+		{"collision cicada is neither", "Pacarina schumanni", false, false},
+		{"wild canid is neither", "Canis latrans", false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			human, dog := Classify(tt.rawLabel)
+			assert.Equal(t, tt.human, human, "human verdict")
+			assert.Equal(t, tt.dog, dog, "dog verdict")
+			// Classify must agree with the single-verdict helpers.
+			assert.Equal(t, IsHuman(tt.rawLabel), human, "Classify vs IsHuman")
+			assert.Equal(t, IsDog(tt.rawLabel), dog, "Classify vs IsDog")
+		})
+	}
+}
+
+// TestPerchHumanLabelsParityWithNonbird verifies that every AudioSet/FSD50K human
+// sound class the privacy filter relies on is classified as CategoryHuman by the
+// shared nonbird package. A failure here means a coverage regression: a label
+// that used to engage the privacy filter would silently stop doing so.
+func TestPerchHumanLabelsParityWithNonbird(t *testing.T) {
+	t.Parallel()
+
+	// The complete AudioSet/FSD50K human-class key set. "homo sapiens" is
+	// excluded: it is an iNaturalist taxon, not an AudioSet/FSD50K sound class,
+	// so nonbird does not include it. It lives in perchHumanExtraLabels.
+	oldAudioSetKeys := []string{
+		"speech",
+		"speech_synthesizer",
+		"male_speech_and_man_speaking",
+		"female_speech_and_woman_speaking",
+		"child_speech_and_kid_speaking",
+		"conversation",
+		"chatter",
+		"human_voice",
+		"human_group_actions",
+		"whispering",
+		"shout",
+		"yell",
+		"screaming",
+		"singing",
+		"male_singing",
+		"female_singing",
+		"laughter",
+		"giggle",
+		"chuckle_and_chortle",
+		"crying_and_sobbing",
+		"gasp",
+		"sigh",
+		"cough",
+		"sneeze",
+		"breathing",
+		"respiratory_sounds",
+		"burping_and_eructation",
+		"fart",
+		"chewing_and_mastication",
+		"crowd",
+		"cheering",
+		"applause",
+		"clapping",
+		"finger_snapping",
+		"hands",
+		"walk_and_footsteps",
+		"run",
+	}
+
+	for _, key := range oldAudioSetKeys {
+		t.Run(key, func(t *testing.T) {
+			t.Parallel()
+			cat, ok := nonbird.CategoryOf(key)
+			assert.True(t, ok, "nonbird.CategoryOf(%q) must find the key", key)
+			assert.Equal(t, nonbird.CategoryHuman, cat,
+				"nonbird.CategoryOf(%q) must return CategoryHuman", key)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The privacy filter and dog-bark filter run in the analysis processor over the prediction results the classifier returns, but every model truncates its predictions to the top 10 before the processor ever sees them. BirdNET scores faint human speech at roughly 1-10% confidence while a full chunk of louder birds outranks it, so the "Human"/"Speech" prediction is routinely cut at the top-K step and never reaches `handleHumanDetection`. The concurrent bird detection is then saved with the human voice in the clip.

`getTopKResults` now additionally retains the single highest-confidence human class and the single highest-confidence dog class when they rank below the top 10, so the filters still see them. The change lives at the shared truncation chokepoint, so all four model paths (BirdNET v2.4, BirdNET v3.0, Perch v2, Bat) inherit it; it is a no-op for models whose label set has no human/dog class. At most two extra entries are added per chunk, so a saved detection in the same chunk gains at most two low-confidence additional results, a truthful record of what the model heard.

The raw-label human/dog classification moves into a new `internal/labels/vocalization` package so the classifier and the processor share one source of truth (the processor keeps thin delegating wrappers, behavior unchanged). Because that classification now runs over the full per-inference prediction set (~6.5k-15k classes) rather than only the top 10, it is a single-pass `Classify` that lowercases each label once; this keeps the added per-window allocations to one per label (benchmarked at ~6.5k allocs/op for BirdNET, down from ~19.5k for a naive two-pass approach).

## Behavior note

The privacy filter is enabled by default. With this change it can now catch faint background human speech that ranked below the top 10 and was previously invisible to it, so on installs with background human activity (TV, radio, conversation) some bird detections near that activity may now be suppressed where they were saved before. This is the intended privacy improvement. It is a targeted fix for the cases where the acoustic models actually score the human class above the privacy threshold; it does not resolve very faint, distant speech that the models score near zero.

## Related Issues

Fixes #4177

## Test Plan

- [x] `go build ./...`
- [x] `go test -race ./internal/classifier/ ./internal/analysis/processor/ ./internal/labels/vocalization/`
- [x] `golangci-lint run` clean on the touched packages
- [x] New unit tests: preservation past top-K, no-duplicate, independent human/dog, bird-only unchanged, and the `Classify` single-pass predicate
- [x] Refactor verified behavior-preserving across all 42 locale label files (0 classification mismatches)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Human and dog vocalizations are now recognized consistently across supported label formats, including localized and case variations.
  * Human speech and dog bark classifications are retained for privacy and filtering workflows even when outside the highest-confidence results.
  * Duplicate preserved classifications are prevented, while bird-only results remain unchanged.

* **Tests**
  * Added coverage for vocalization recognition, localized labels, collision prevention, and result preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->