### PR TITLE
feat(settings): add browser location helper

### DIFF
--- a/frontend/src/lib/desktop/features/settings/components/CurrentLocationButton.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/CurrentLocationButton.svelte
@@ -15,7 +15,7 @@
   interface Props {
     latitude: number;
     longitude: number;
-    coordinateInputVersion?: number;
+    coordinateIntentVersion?: number;
     onLocation: (_latitude: number, _longitude: number) => void;
     disabled?: boolean;
   }
@@ -24,13 +24,14 @@
     latitude: number;
     longitude: number;
     accuracy: number | null;
+    coordinateIntentVersion: number;
   }
 
   interface PendingRequest {
     id: number;
     latitude: number;
     longitude: number;
-    coordinateInputVersion: number;
+    coordinateIntentVersion: number;
   }
 
   interface BrowserGeolocationPosition {
@@ -59,7 +60,7 @@
   let {
     latitude,
     longitude,
-    coordinateInputVersion = 0,
+    coordinateIntentVersion = 0,
     onLocation,
     disabled = false,
   }: Props = $props();
@@ -73,14 +74,15 @@
   let displayedAccuracy = $derived(
     detectedPosition &&
       detectedPosition.latitude === latitude &&
-      detectedPosition.longitude === longitude
+      detectedPosition.longitude === longitude &&
+      detectedPosition.coordinateIntentVersion === coordinateIntentVersion
       ? detectedPosition.accuracy
       : null
   );
 
-  // A manual/map edit or a save that starts after the request is newer user
-  // intent. The browser request cannot be cancelled, so invalidate it locally
-  // and ignore its eventual callbacks.
+  // A manual/map/reset action or a save that starts after the request is newer
+  // user intent. The browser request cannot be cancelled, so invalidate it
+  // locally and ignore its eventual callbacks.
   $effect(() => {
     const request = pendingRequest;
     if (
@@ -88,7 +90,7 @@
       (disabled ||
         latitude !== request.latitude ||
         longitude !== request.longitude ||
-        coordinateInputVersion !== request.coordinateInputVersion)
+        coordinateIntentVersion !== request.coordinateIntentVersion)
     ) {
       pendingRequest = null;
       locating = false;
@@ -158,26 +160,27 @@
   function handleGeolocationError(error: BrowserGeolocationError, requestId: number) {
     if (!finishRequest(requestId)) return;
 
-    logger.error('Browser geolocation failed', error);
-
     switch (error.code) {
       case GEOLOCATION_ERRORS.permissionDenied:
+        logger.warn('Browser geolocation permission denied', error);
         toastActions.warning(
           t('settings.main.sections.rangeFilter.stationLocation.geolocationDenied')
         );
         break;
       case GEOLOCATION_ERRORS.positionUnavailable:
+        logger.warn('Browser geolocation position unavailable', error);
         toastActions.error(
           t('settings.main.sections.rangeFilter.stationLocation.geolocationUnavailable')
         );
         break;
       case GEOLOCATION_ERRORS.timeout:
+        logger.warn('Browser geolocation request timed out', error);
         toastActions.error(
           t('settings.main.sections.rangeFilter.stationLocation.geolocationTimedOut')
         );
         break;
       default:
-        showUnexpectedFailure();
+        showUnexpectedFailure(error);
     }
   }
 
@@ -217,6 +220,7 @@
         latitude: roundedLatitude,
         longitude: roundedLongitude,
         accuracy: roundedAccuracy,
+        coordinateIntentVersion,
       };
       toastActions.success(
         t('settings.main.sections.rangeFilter.stationLocation.locationDetected')
@@ -244,7 +248,7 @@
     }
 
     const requestId = ++nextRequestId;
-    pendingRequest = { id: requestId, latitude, longitude, coordinateInputVersion };
+    pendingRequest = { id: requestId, latitude, longitude, coordinateIntentVersion };
     locating = true;
     detectedPosition = null;
 

--- a/frontend/src/lib/desktop/features/settings/components/CurrentLocationButton.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/CurrentLocationButton.svelte
@@ -1,0 +1,304 @@
+<!--
+  Current Location Button
+
+  Requests a single position from the browser and reports it to the parent
+  settings form. The parent remains responsible for persisting coordinates.
+-->
+<script lang="ts">
+  import { MapPin } from '@lucide/svelte';
+  import { onDestroy } from 'svelte';
+  import { t } from '$lib/i18n';
+  import { toastActions } from '$lib/stores/toast';
+  import { loggers } from '$lib/utils/logger';
+  import SettingsButton from './SettingsButton.svelte';
+
+  interface Props {
+    latitude: number;
+    longitude: number;
+    coordinateInputVersion?: number;
+    onLocation: (_latitude: number, _longitude: number) => void;
+    disabled?: boolean;
+  }
+
+  interface DetectedPosition {
+    latitude: number;
+    longitude: number;
+    accuracy: number | null;
+  }
+
+  interface PendingRequest {
+    id: number;
+    latitude: number;
+    longitude: number;
+    coordinateInputVersion: number;
+  }
+
+  interface BrowserGeolocationPosition {
+    coords: {
+      latitude: number;
+      longitude: number;
+      accuracy: number;
+    };
+  }
+
+  interface BrowserGeolocationError {
+    code: number;
+    message: string;
+  }
+
+  const COORDINATE_DECIMAL_PLACES = 3;
+  const GEOLOCATION_TIMEOUT_MS = 10_000;
+  const EARTH_RADIUS_METERS = 6_371_000;
+  const DEGREES_TO_RADIANS = Math.PI / 180;
+  const GEOLOCATION_ERRORS = {
+    permissionDenied: 1,
+    positionUnavailable: 2,
+    timeout: 3,
+  } as const;
+
+  let {
+    latitude,
+    longitude,
+    coordinateInputVersion = 0,
+    onLocation,
+    disabled = false,
+  }: Props = $props();
+
+  const logger = loggers.settings;
+  let active = true;
+  let nextRequestId = 0;
+  let locating = $state(false);
+  let pendingRequest = $state<PendingRequest | null>(null);
+  let detectedPosition = $state<DetectedPosition | null>(null);
+  let displayedAccuracy = $derived(
+    detectedPosition &&
+      detectedPosition.latitude === latitude &&
+      detectedPosition.longitude === longitude
+      ? detectedPosition.accuracy
+      : null
+  );
+
+  // A manual/map edit or a save that starts after the request is newer user
+  // intent. The browser request cannot be cancelled, so invalidate it locally
+  // and ignore its eventual callbacks.
+  $effect(() => {
+    const request = pendingRequest;
+    if (
+      request &&
+      (disabled ||
+        latitude !== request.latitude ||
+        longitude !== request.longitude ||
+        coordinateInputVersion !== request.coordinateInputVersion)
+    ) {
+      pendingRequest = null;
+      locating = false;
+    }
+  });
+
+  function isCurrentRequest(requestId: number): boolean {
+    return active && pendingRequest?.id === requestId;
+  }
+
+  function finishRequest(requestId: number): boolean {
+    if (!isCurrentRequest(requestId)) return false;
+
+    pendingRequest = null;
+    locating = false;
+    return true;
+  }
+
+  function distanceInMeters(
+    startLatitude: number,
+    startLongitude: number,
+    endLatitude: number,
+    endLongitude: number
+  ): number {
+    const latitudeDelta = (endLatitude - startLatitude) * DEGREES_TO_RADIANS;
+    const longitudeDelta = (endLongitude - startLongitude) * DEGREES_TO_RADIANS;
+    const startLatitudeRadians = startLatitude * DEGREES_TO_RADIANS;
+    const endLatitudeRadians = endLatitude * DEGREES_TO_RADIANS;
+
+    const haversine =
+      Math.sin(latitudeDelta / 2) ** 2 +
+      Math.cos(startLatitudeRadians) *
+        Math.cos(endLatitudeRadians) *
+        Math.sin(longitudeDelta / 2) ** 2;
+    const centralAngle =
+      2 * Math.atan2(Math.sqrt(haversine), Math.sqrt(Math.max(0, 1 - haversine)));
+
+    return EARTH_RADIUS_METERS * centralAngle;
+  }
+
+  function effectiveAccuracy(
+    accuracy: number,
+    detectedLatitude: number,
+    detectedLongitude: number,
+    roundedLatitude: number,
+    roundedLongitude: number
+  ): number | null {
+    if (!Number.isFinite(accuracy)) return null;
+
+    const roundingDisplacement = distanceInMeters(
+      detectedLatitude,
+      detectedLongitude,
+      roundedLatitude,
+      roundedLongitude
+    );
+
+    return Math.ceil(Math.max(0, accuracy) + roundingDisplacement);
+  }
+
+  function showUnexpectedFailure(error?: unknown) {
+    if (error !== undefined) {
+      logger.error('Browser geolocation failed unexpectedly', error);
+    }
+    toastActions.error(t('settings.main.sections.rangeFilter.stationLocation.geolocationFailed'));
+  }
+
+  function handleGeolocationError(error: BrowserGeolocationError, requestId: number) {
+    if (!finishRequest(requestId)) return;
+
+    logger.error('Browser geolocation failed', error);
+
+    switch (error.code) {
+      case GEOLOCATION_ERRORS.permissionDenied:
+        toastActions.warning(
+          t('settings.main.sections.rangeFilter.stationLocation.geolocationDenied')
+        );
+        break;
+      case GEOLOCATION_ERRORS.positionUnavailable:
+        toastActions.error(
+          t('settings.main.sections.rangeFilter.stationLocation.geolocationUnavailable')
+        );
+        break;
+      case GEOLOCATION_ERRORS.timeout:
+        toastActions.error(
+          t('settings.main.sections.rangeFilter.stationLocation.geolocationTimedOut')
+        );
+        break;
+      default:
+        showUnexpectedFailure();
+    }
+  }
+
+  function handleGeolocationSuccess(position: BrowserGeolocationPosition, requestId: number) {
+    if (!isCurrentRequest(requestId)) return;
+
+    const { latitude: detectedLatitude, longitude: detectedLongitude, accuracy } = position.coords;
+
+    if (
+      !Number.isFinite(detectedLatitude) ||
+      !Number.isFinite(detectedLongitude) ||
+      detectedLatitude < -90 ||
+      detectedLatitude > 90 ||
+      detectedLongitude < -180 ||
+      detectedLongitude > 180
+    ) {
+      finishRequest(requestId);
+      showUnexpectedFailure(new Error('Browser returned invalid coordinates'));
+      return;
+    }
+
+    const roundedLatitude = Number(detectedLatitude.toFixed(COORDINATE_DECIMAL_PLACES));
+    const roundedLongitude = Number(detectedLongitude.toFixed(COORDINATE_DECIMAL_PLACES));
+    const roundedAccuracy = effectiveAccuracy(
+      accuracy,
+      detectedLatitude,
+      detectedLongitude,
+      roundedLatitude,
+      roundedLongitude
+    );
+
+    if (!finishRequest(requestId)) return;
+
+    try {
+      onLocation(roundedLatitude, roundedLongitude);
+      detectedPosition = {
+        latitude: roundedLatitude,
+        longitude: roundedLongitude,
+        accuracy: roundedAccuracy,
+      };
+      toastActions.success(
+        t('settings.main.sections.rangeFilter.stationLocation.locationDetected')
+      );
+    } catch (error) {
+      showUnexpectedFailure(error);
+    }
+  }
+
+  function useCurrentLocation() {
+    // Browsers may omit the API entirely on insecure origins, so report the
+    // secure-context problem first when it is known.
+    if (typeof window !== 'undefined' && window.isSecureContext === false) {
+      toastActions.warning(
+        t('settings.main.sections.rangeFilter.stationLocation.geolocationRequiresHttps')
+      );
+      return;
+    }
+
+    if (typeof navigator === 'undefined' || !navigator.geolocation) {
+      toastActions.error(
+        t('settings.main.sections.rangeFilter.stationLocation.geolocationUnsupported')
+      );
+      return;
+    }
+
+    const requestId = ++nextRequestId;
+    pendingRequest = { id: requestId, latitude, longitude, coordinateInputVersion };
+    locating = true;
+    detectedPosition = null;
+
+    try {
+      navigator.geolocation.getCurrentPosition(
+        position => handleGeolocationSuccess(position, requestId),
+        error => handleGeolocationError(error, requestId),
+        {
+          enableHighAccuracy: true,
+          timeout: GEOLOCATION_TIMEOUT_MS,
+          maximumAge: 0,
+        }
+      );
+    } catch (error) {
+      if (finishRequest(requestId)) {
+        showUnexpectedFailure(error);
+      }
+    }
+  }
+
+  onDestroy(() => {
+    active = false;
+    pendingRequest = null;
+  });
+</script>
+
+<div class="form-control min-w-0">
+  <div class="label">
+    <span class="label-text">
+      {t('settings.main.sections.rangeFilter.stationLocation.automaticLocation')}
+    </span>
+  </div>
+
+  <div class="flex flex-wrap items-center gap-x-3 gap-y-1 xl:flex-col xl:items-start">
+    <SettingsButton
+      onclick={useCurrentLocation}
+      {disabled}
+      loading={locating}
+      loadingText={t('settings.main.sections.rangeFilter.stationLocation.locating')}
+    >
+      <MapPin class="size-4" aria-hidden="true" />
+      {t('settings.main.sections.rangeFilter.stationLocation.useCurrentLocation')}
+    </SettingsButton>
+
+    {#if displayedAccuracy !== null}
+      <span class="help-text" role="status" aria-live="polite" aria-atomic="true">
+        {t('settings.main.sections.rangeFilter.stationLocation.accuracy', {
+          accuracy: displayedAccuracy,
+        })}
+      </span>
+    {:else}
+      <span class="help-text">
+        {t('settings.main.sections.rangeFilter.stationLocation.locationHelp')}
+      </span>
+    {/if}
+  </div>
+</div>

--- a/frontend/src/lib/desktop/features/settings/components/CurrentLocationButton.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/CurrentLocationButton.svelte
@@ -10,6 +10,7 @@
   import { t } from '$lib/i18n';
   import { toastActions } from '$lib/stores/toast';
   import { loggers } from '$lib/utils/logger';
+  import { formatNumber } from '$lib/utils/formatters';
   import SettingsButton from './SettingsButton.svelte';
 
   interface Props {
@@ -51,6 +52,10 @@
   const GEOLOCATION_TIMEOUT_MS = 10_000;
   const EARTH_RADIUS_METERS = 6_371_000;
   const DEGREES_TO_RADIANS = Math.PI / 180;
+  const MIN_LATITUDE = -90;
+  const MAX_LATITUDE = 90;
+  const MIN_LONGITUDE = -180;
+  const MAX_LONGITUDE = 180;
   const GEOLOCATION_ERRORS = {
     permissionDenied: 1,
     positionUnavailable: 2,
@@ -192,10 +197,10 @@
     if (
       !Number.isFinite(detectedLatitude) ||
       !Number.isFinite(detectedLongitude) ||
-      detectedLatitude < -90 ||
-      detectedLatitude > 90 ||
-      detectedLongitude < -180 ||
-      detectedLongitude > 180
+      detectedLatitude < MIN_LATITUDE ||
+      detectedLatitude > MAX_LATITUDE ||
+      detectedLongitude < MIN_LONGITUDE ||
+      detectedLongitude > MAX_LONGITUDE
     ) {
       finishRequest(requestId);
       showUnexpectedFailure(new Error('Browser returned invalid coordinates'));
@@ -294,9 +299,9 @@
     </SettingsButton>
 
     {#if displayedAccuracy !== null}
-      <span class="help-text" role="status" aria-live="polite" aria-atomic="true">
+      <span class="help-text" role="status" aria-atomic="true">
         {t('settings.main.sections.rangeFilter.stationLocation.accuracy', {
-          accuracy: displayedAccuracy,
+          accuracy: formatNumber(displayedAccuracy),
         })}
       </span>
     {:else}

--- a/frontend/src/lib/desktop/features/settings/components/CurrentLocationButton.test.ts
+++ b/frontend/src/lib/desktop/features/settings/components/CurrentLocationButton.test.ts
@@ -327,17 +327,48 @@ describe('CurrentLocationButton', () => {
     }
   );
 
-  it('leaves coordinates untouched when the browser returns invalid coordinates', async () => {
+  it.each([
+    ['NaN latitude', Number.NaN, 4.9],
+    ['NaN longitude', 52.1, Number.NaN],
+    ['latitude above the maximum', 91, 4.9],
+    ['latitude below the minimum', -91, 4.9],
+    ['longitude above the maximum', 52.1, 181],
+    ['longitude below the minimum', 52.1, -181],
+  ] as const)(
+    'leaves coordinates untouched when the browser returns invalid coordinates (%s)',
+    async (_label, latitude, longitude) => {
+      const onLocation = vi.fn();
+      geolocationMock.getCurrentPosition.mockImplementationOnce(success => {
+        success(createPosition(latitude, longitude, 10));
+      });
+      testFactory.render({ latitude: 51, longitude: 5, onLocation });
+
+      await fireEvent.click(screen.getByRole('button', { name: 'Use browser location' }));
+
+      expect(onLocation).not.toHaveBeenCalled();
+      expect(toastActions.error).toHaveBeenCalledWith('Could not determine the device location.');
+    }
+  );
+
+  it('accepts the coordinates but omits the accuracy readout when accuracy is not finite', async () => {
     const onLocation = vi.fn();
     geolocationMock.getCurrentPosition.mockImplementationOnce(success => {
-      success(createPosition(Number.NaN, 4.9, 10));
+      success(createPosition(52.1, 4.3, Number.POSITIVE_INFINITY));
     });
-    testFactory.render({ latitude: 51, longitude: 5, onLocation });
 
+    const result = testFactory.render({ onLocation });
     await fireEvent.click(screen.getByRole('button', { name: 'Use browser location' }));
 
-    expect(onLocation).not.toHaveBeenCalled();
-    expect(toastActions.error).toHaveBeenCalledWith('Could not determine the device location.');
+    expect(onLocation).toHaveBeenCalledWith(52.1, 4.3);
+    expect(toastActions.success).toHaveBeenCalledWith('Browser location detected.');
+
+    // A non-finite accuracy resolves to null, so the accuracy status line stays hidden
+    // and the standard help text remains visible.
+    await result.rerender({ latitude: 52.1, longitude: 4.3, onLocation });
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Fills the coordinates using this browser's location.")
+    ).toBeInTheDocument();
   });
 
   it('recovers when the browser API throws synchronously', async () => {

--- a/frontend/src/lib/desktop/features/settings/components/CurrentLocationButton.test.ts
+++ b/frontend/src/lib/desktop/features/settings/components/CurrentLocationButton.test.ts
@@ -4,51 +4,6 @@ import { createComponentTestFactory } from '../../../../../test/render-helpers';
 import CurrentLocationButton from './CurrentLocationButton.svelte';
 import { toastActions } from '$lib/stores/toast';
 
-vi.mock('$lib/i18n', () => ({
-  t: vi.fn((key: string, params?: Record<string, unknown>) => {
-    const translations: Record<string, string> = {
-      'common.loading': 'Loading...',
-      'settings.main.sections.rangeFilter.stationLocation.useCurrentLocation':
-        'Use browser location',
-      'settings.main.sections.rangeFilter.stationLocation.automaticLocation': 'Automatic location',
-      'settings.main.sections.rangeFilter.stationLocation.locationHelp':
-        "Fills the coordinates using this browser's location.",
-      'settings.main.sections.rangeFilter.stationLocation.locating': 'Locating...',
-      'settings.main.sections.rangeFilter.stationLocation.accuracy':
-        'Estimated accuracy: within {accuracy} m',
-      'settings.main.sections.rangeFilter.stationLocation.locationDetected':
-        'Browser location detected.',
-      'settings.main.sections.rangeFilter.stationLocation.geolocationUnsupported':
-        'Device location is unsupported.',
-      'settings.main.sections.rangeFilter.stationLocation.geolocationRequiresHttps':
-        'Browser location requires HTTPS or localhost.',
-      'settings.main.sections.rangeFilter.stationLocation.geolocationDenied':
-        'Location permission was denied.',
-      'settings.main.sections.rangeFilter.stationLocation.geolocationUnavailable':
-        'The device could not determine its location.',
-      'settings.main.sections.rangeFilter.stationLocation.geolocationTimedOut':
-        'The location request timed out.',
-      'settings.main.sections.rangeFilter.stationLocation.geolocationFailed':
-        'Could not determine the device location.',
-    };
-
-    // eslint-disable-next-line security/detect-object-injection -- Controlled translation test data
-    let translated = translations[key] ?? key;
-    for (const [name, value] of Object.entries(params ?? {})) {
-      translated = translated.replace(`{${name}}`, String(value));
-    }
-    return translated;
-  }),
-}));
-
-vi.mock('$lib/stores/toast', () => ({
-  toastActions: {
-    success: vi.fn(),
-    warning: vi.fn(),
-    error: vi.fn(),
-  },
-}));
-
 const geolocationMock = {
   getCurrentPosition: vi.fn<Geolocation['getCurrentPosition']>(),
   watchPosition: vi.fn<Geolocation['watchPosition']>(),
@@ -191,7 +146,7 @@ describe('CurrentLocationButton', () => {
     expect(toastActions.error).not.toHaveBeenCalled();
   });
 
-  it('ignores a result after coordinate input starts before the value is committed', async () => {
+  it('ignores a result after coordinate intent starts before the value is committed', async () => {
     const onLocation = vi.fn();
     let respond: PositionCallback | undefined;
     geolocationMock.getCurrentPosition.mockImplementationOnce(success => {
@@ -201,7 +156,7 @@ describe('CurrentLocationButton', () => {
     const result = testFactory.render({
       latitude: 51,
       longitude: 5,
-      coordinateInputVersion: 0,
+      coordinateIntentVersion: 0,
       onLocation,
     });
     await fireEvent.click(screen.getByRole('button', { name: 'Use browser location' }));
@@ -209,7 +164,7 @@ describe('CurrentLocationButton', () => {
     await result.rerender({
       latitude: 51,
       longitude: 5,
-      coordinateInputVersion: 1,
+      coordinateIntentVersion: 1,
       onLocation,
     });
     await waitFor(() =>
@@ -295,6 +250,31 @@ describe('CurrentLocationButton', () => {
     expect(screen.getByRole('status')).toBeInTheDocument();
 
     await result.rerender({ latitude: 52.2, longitude: 4.3, onLocation });
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('hides accuracy when newer coordinate intent keeps the same values', async () => {
+    const onLocation = vi.fn();
+    geolocationMock.getCurrentPosition.mockImplementationOnce(success => {
+      success(createPosition(52.1, 4.3, 12));
+    });
+
+    const result = testFactory.render({ coordinateIntentVersion: 0, onLocation });
+    await fireEvent.click(screen.getByRole('button', { name: 'Use browser location' }));
+    await result.rerender({
+      latitude: 52.1,
+      longitude: 4.3,
+      coordinateIntentVersion: 0,
+      onLocation,
+    });
+    expect(screen.getByRole('status')).toBeInTheDocument();
+
+    await result.rerender({
+      latitude: 52.1,
+      longitude: 4.3,
+      coordinateIntentVersion: 1,
+      onLocation,
+    });
     expect(screen.queryByRole('status')).not.toBeInTheDocument();
   });
 

--- a/frontend/src/lib/desktop/features/settings/components/CurrentLocationButton.test.ts
+++ b/frontend/src/lib/desktop/features/settings/components/CurrentLocationButton.test.ts
@@ -1,0 +1,376 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/svelte';
+import { createComponentTestFactory } from '../../../../../test/render-helpers';
+import CurrentLocationButton from './CurrentLocationButton.svelte';
+import { toastActions } from '$lib/stores/toast';
+
+vi.mock('$lib/i18n', () => ({
+  t: vi.fn((key: string, params?: Record<string, unknown>) => {
+    const translations: Record<string, string> = {
+      'common.loading': 'Loading...',
+      'settings.main.sections.rangeFilter.stationLocation.useCurrentLocation':
+        'Use browser location',
+      'settings.main.sections.rangeFilter.stationLocation.automaticLocation': 'Automatic location',
+      'settings.main.sections.rangeFilter.stationLocation.locationHelp':
+        "Fills the coordinates using this browser's location.",
+      'settings.main.sections.rangeFilter.stationLocation.locating': 'Locating...',
+      'settings.main.sections.rangeFilter.stationLocation.accuracy':
+        'Estimated accuracy: within {accuracy} m',
+      'settings.main.sections.rangeFilter.stationLocation.locationDetected':
+        'Browser location detected.',
+      'settings.main.sections.rangeFilter.stationLocation.geolocationUnsupported':
+        'Device location is unsupported.',
+      'settings.main.sections.rangeFilter.stationLocation.geolocationRequiresHttps':
+        'Browser location requires HTTPS or localhost.',
+      'settings.main.sections.rangeFilter.stationLocation.geolocationDenied':
+        'Location permission was denied.',
+      'settings.main.sections.rangeFilter.stationLocation.geolocationUnavailable':
+        'The device could not determine its location.',
+      'settings.main.sections.rangeFilter.stationLocation.geolocationTimedOut':
+        'The location request timed out.',
+      'settings.main.sections.rangeFilter.stationLocation.geolocationFailed':
+        'Could not determine the device location.',
+    };
+
+    // eslint-disable-next-line security/detect-object-injection -- Controlled translation test data
+    let translated = translations[key] ?? key;
+    for (const [name, value] of Object.entries(params ?? {})) {
+      translated = translated.replace(`{${name}}`, String(value));
+    }
+    return translated;
+  }),
+}));
+
+vi.mock('$lib/stores/toast', () => ({
+  toastActions: {
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const geolocationMock = {
+  getCurrentPosition: vi.fn<Geolocation['getCurrentPosition']>(),
+  watchPosition: vi.fn<Geolocation['watchPosition']>(),
+  clearWatch: vi.fn<Geolocation['clearWatch']>(),
+};
+
+const testFactory = createComponentTestFactory(CurrentLocationButton, {
+  latitude: 0,
+  longitude: 0,
+  onLocation: vi.fn(),
+});
+
+function setSecureContext(value: boolean) {
+  Object.defineProperty(window, 'isSecureContext', {
+    configurable: true,
+    value,
+  });
+}
+
+function setGeolocation(value: Geolocation | undefined) {
+  Object.defineProperty(navigator, 'geolocation', {
+    configurable: true,
+    value,
+  });
+}
+
+function createPosition(
+  latitude: number,
+  longitude: number,
+  accuracy: number
+): GeolocationPosition {
+  return {
+    coords: {
+      latitude,
+      longitude,
+      accuracy,
+      altitude: null,
+      altitudeAccuracy: null,
+      heading: null,
+      speed: null,
+      toJSON: () => ({}),
+    },
+    timestamp: Date.now(),
+    toJSON: () => ({}),
+  };
+}
+
+function createPositionError(code: number): GeolocationPositionError {
+  return {
+    code,
+    message: 'Test geolocation failure',
+    PERMISSION_DENIED: 1,
+    POSITION_UNAVAILABLE: 2,
+    TIMEOUT: 3,
+  };
+}
+
+describe('CurrentLocationButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    geolocationMock.getCurrentPosition.mockReset();
+    geolocationMock.watchPosition.mockReset();
+    geolocationMock.clearWatch.mockReset();
+    setSecureContext(true);
+    setGeolocation(geolocationMock);
+  });
+
+  afterEach(() => {
+    cleanup();
+    Reflect.deleteProperty(navigator, 'geolocation');
+    Reflect.deleteProperty(window, 'isSecureContext');
+  });
+
+  it('reports rounded coordinates and accuracy that includes rounding displacement', async () => {
+    const onLocation = vi.fn();
+    geolocationMock.getCurrentPosition.mockImplementationOnce(success => {
+      success(createPosition(52.1236, 4.9876, 7.6));
+    });
+
+    const result = testFactory.render({ onLocation });
+    expect(screen.getByText('Automatic location')).toBeInTheDocument();
+    expect(
+      screen.getByText("Fills the coordinates using this browser's location.")
+    ).toBeInTheDocument();
+
+    const button = screen.getByRole('button', { name: 'Use browser location' });
+    expect(button).toHaveClass('btn-primary');
+    await fireEvent.click(button);
+
+    expect(geolocationMock.getCurrentPosition).toHaveBeenCalledTimes(1);
+    expect(geolocationMock.getCurrentPosition).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      {
+        enableHighAccuracy: true,
+        timeout: 10_000,
+        maximumAge: 0,
+      }
+    );
+    expect(onLocation).toHaveBeenCalledWith(52.124, 4.988);
+    expect(geolocationMock.watchPosition).not.toHaveBeenCalled();
+    expect(toastActions.success).toHaveBeenCalledWith('Browser location detected.');
+
+    await result.rerender({ latitude: 52.124, longitude: 4.988, onLocation });
+    expect(screen.getByRole('status')).toHaveTextContent('Estimated accuracy: within 60 m');
+    expect(
+      screen.queryByText("Fills the coordinates using this browser's location.")
+    ).not.toBeInTheDocument();
+  });
+
+  it('disables the action and shows loading feedback while the request is pending', async () => {
+    geolocationMock.getCurrentPosition.mockImplementationOnce(() => undefined);
+    testFactory.render();
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Use browser location' }));
+
+    const button = screen.getByRole('button', { name: 'Locating...' });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('ignores a result after the coordinates are edited', async () => {
+    const onLocation = vi.fn();
+    let respond: PositionCallback | undefined;
+    geolocationMock.getCurrentPosition.mockImplementationOnce(success => {
+      respond = success;
+    });
+
+    const result = testFactory.render({ latitude: 51, longitude: 5, onLocation });
+    await fireEvent.click(screen.getByRole('button', { name: 'Use browser location' }));
+
+    await result.rerender({ latitude: 51.1, longitude: 5, onLocation });
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Use browser location' })).not.toBeDisabled()
+    );
+    respond?.(createPosition(52.1, 4.3, 10));
+
+    expect(onLocation).not.toHaveBeenCalled();
+    expect(toastActions.success).not.toHaveBeenCalled();
+    expect(toastActions.error).not.toHaveBeenCalled();
+  });
+
+  it('ignores a result after coordinate input starts before the value is committed', async () => {
+    const onLocation = vi.fn();
+    let respond: PositionCallback | undefined;
+    geolocationMock.getCurrentPosition.mockImplementationOnce(success => {
+      respond = success;
+    });
+
+    const result = testFactory.render({
+      latitude: 51,
+      longitude: 5,
+      coordinateInputVersion: 0,
+      onLocation,
+    });
+    await fireEvent.click(screen.getByRole('button', { name: 'Use browser location' }));
+
+    await result.rerender({
+      latitude: 51,
+      longitude: 5,
+      coordinateInputVersion: 1,
+      onLocation,
+    });
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Use browser location' })).not.toBeDisabled()
+    );
+    respond?.(createPosition(52.1, 4.3, 10));
+
+    expect(onLocation).not.toHaveBeenCalled();
+    expect(toastActions.success).not.toHaveBeenCalled();
+  });
+
+  it('ignores a result after saving starts, even when it finishes before the result arrives', async () => {
+    const onLocation = vi.fn();
+    let respond: PositionCallback | undefined;
+    geolocationMock.getCurrentPosition.mockImplementationOnce(success => {
+      respond = success;
+    });
+
+    const result = testFactory.render({ latitude: 51, longitude: 5, onLocation });
+    await fireEvent.click(screen.getByRole('button', { name: 'Use browser location' }));
+
+    await result.rerender({ latitude: 51, longitude: 5, onLocation, disabled: true });
+    await result.rerender({ latitude: 51, longitude: 5, onLocation, disabled: false });
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Use browser location' })).not.toBeDisabled()
+    );
+    respond?.(createPosition(52.1, 4.3, 10));
+
+    expect(onLocation).not.toHaveBeenCalled();
+    expect(toastActions.success).not.toHaveBeenCalled();
+  });
+
+  it('lets a new request supersede an invalidated request', async () => {
+    const onLocation = vi.fn();
+    const responses: PositionCallback[] = [];
+    geolocationMock.getCurrentPosition.mockImplementation(success => {
+      responses.push(success);
+    });
+
+    const result = testFactory.render({ latitude: 51, longitude: 5, onLocation });
+    await fireEvent.click(screen.getByRole('button', { name: 'Use browser location' }));
+
+    await result.rerender({ latitude: 51.1, longitude: 5, onLocation });
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Use browser location' })).not.toBeDisabled()
+    );
+    await fireEvent.click(screen.getByRole('button', { name: 'Use browser location' }));
+
+    responses[0]?.(createPosition(52.1, 4.3, 10));
+    expect(onLocation).not.toHaveBeenCalled();
+
+    responses[1]?.(createPosition(53.1234, 5.9876, 6));
+    expect(onLocation).toHaveBeenCalledTimes(1);
+    expect(onLocation).toHaveBeenCalledWith(53.123, 5.988);
+    expect(toastActions.success).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a late browser response after the control is unmounted', async () => {
+    const onLocation = vi.fn();
+    let respond: PositionCallback | undefined;
+    geolocationMock.getCurrentPosition.mockImplementationOnce(success => {
+      respond = success;
+    });
+
+    const result = testFactory.render({ onLocation });
+    await fireEvent.click(screen.getByRole('button', { name: 'Use browser location' }));
+    result.unmount();
+    respond?.(createPosition(52.1, 4.3, 10));
+
+    expect(onLocation).not.toHaveBeenCalled();
+    expect(toastActions.success).not.toHaveBeenCalled();
+  });
+
+  it('hides accuracy when the coordinates are edited after detection', async () => {
+    const onLocation = vi.fn();
+    geolocationMock.getCurrentPosition.mockImplementationOnce(success => {
+      success(createPosition(52.1, 4.3, 12));
+    });
+
+    const result = testFactory.render({ onLocation });
+    await fireEvent.click(screen.getByRole('button', { name: 'Use browser location' }));
+    await result.rerender({ latitude: 52.1, longitude: 4.3, onLocation });
+    expect(screen.getByRole('status')).toBeInTheDocument();
+
+    await result.rerender({ latitude: 52.2, longitude: 4.3, onLocation });
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('reports an insecure origin before checking API availability', async () => {
+    setSecureContext(false);
+    setGeolocation(undefined);
+    const onLocation = vi.fn();
+    testFactory.render({ onLocation });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Use browser location' }));
+
+    expect(toastActions.warning).toHaveBeenCalledWith(
+      'Browser location requires HTTPS or localhost.'
+    );
+    expect(geolocationMock.getCurrentPosition).not.toHaveBeenCalled();
+    expect(onLocation).not.toHaveBeenCalled();
+  });
+
+  it('reports browsers without geolocation support', async () => {
+    setGeolocation(undefined);
+    const onLocation = vi.fn();
+    testFactory.render({ onLocation });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Use browser location' }));
+
+    expect(toastActions.error).toHaveBeenCalledWith('Device location is unsupported.');
+    expect(onLocation).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [1, 'warning', 'Location permission was denied.'],
+    [2, 'error', 'The device could not determine its location.'],
+    [3, 'error', 'The location request timed out.'],
+    [99, 'error', 'Could not determine the device location.'],
+  ] as const)(
+    'leaves coordinates untouched for geolocation error %s',
+    async (code, type, message) => {
+      const onLocation = vi.fn();
+      geolocationMock.getCurrentPosition.mockImplementationOnce((_success, failure) => {
+        failure?.(createPositionError(code));
+      });
+      testFactory.render({ latitude: 51, longitude: 5, onLocation });
+
+      await fireEvent.click(screen.getByRole('button', { name: 'Use browser location' }));
+
+      await waitFor(() => expect(screen.getByRole('button')).not.toBeDisabled());
+      expect(onLocation).not.toHaveBeenCalled();
+      const expectedToast = type === 'warning' ? toastActions.warning : toastActions.error;
+      expect(expectedToast).toHaveBeenCalledWith(message);
+    }
+  );
+
+  it('leaves coordinates untouched when the browser returns invalid coordinates', async () => {
+    const onLocation = vi.fn();
+    geolocationMock.getCurrentPosition.mockImplementationOnce(success => {
+      success(createPosition(Number.NaN, 4.9, 10));
+    });
+    testFactory.render({ latitude: 51, longitude: 5, onLocation });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Use browser location' }));
+
+    expect(onLocation).not.toHaveBeenCalled();
+    expect(toastActions.error).toHaveBeenCalledWith('Could not determine the device location.');
+  });
+
+  it('recovers when the browser API throws synchronously', async () => {
+    const onLocation = vi.fn();
+    geolocationMock.getCurrentPosition.mockImplementationOnce(() => {
+      throw new DOMException('Blocked by policy', 'SecurityError');
+    });
+    testFactory.render({ onLocation });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Use browser location' }));
+
+    expect(screen.getByRole('button')).not.toBeDisabled();
+    expect(onLocation).not.toHaveBeenCalled();
+    expect(toastActions.error).toHaveBeenCalledWith('Could not determine the device location.');
+  });
+});

--- a/frontend/src/lib/desktop/features/settings/components/SettingsPageActions.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/SettingsPageActions.svelte
@@ -11,7 +11,8 @@
   - Accessible with proper ARIA attributes
   - Consistent DaisyUI 5 styling
 
-  Props: None - Uses global settings stores
+  Props:
+  - onReset: Optional callback after all settings are reset
 
   @component
 -->
@@ -28,6 +29,12 @@
   import { loggers } from '$lib/utils/logger';
 
   const logger = loggers.settings;
+
+  interface Props {
+    onReset?: () => void;
+  }
+
+  let { onReset }: Props = $props();
 
   let store = $derived($settingsStore);
   let unsavedChanges = $derived($hasUnsavedChanges);
@@ -56,6 +63,7 @@
     }
 
     settingsActions.resetAllSettings();
+    onReset?.();
   }
 </script>
 

--- a/frontend/src/lib/desktop/features/settings/components/SettingsTabs.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/SettingsTabs.svelte
@@ -17,6 +17,7 @@
   - tabs: Array of tab definitions
   - activeTab: Currently active tab ID (bindable)
   - onTabChange: Callback when tab changes
+  - onReset: Callback after all settings are reset
   - showActions: Whether to show the save/reset actions bar (default: true)
   - class: Additional CSS classes
 
@@ -41,6 +42,7 @@
     tabs: TabDefinition[];
     activeTab: string;
     onTabChange?: (_tabId: string) => void;
+    onReset?: () => void;
     showActions?: boolean;
     class?: string;
   }
@@ -49,6 +51,7 @@
     tabs,
     activeTab = $bindable(),
     onTabChange,
+    onReset,
     showActions = true,
     class: className,
   }: Props = $props();
@@ -180,7 +183,7 @@
 
   <!-- Integrated Save/Reset Actions -->
   {#if showActions}
-    <SettingsPageActions />
+    <SettingsPageActions {onReset} />
   {/if}
 </div>
 

--- a/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.svelte
@@ -34,6 +34,7 @@
   import type { Stage } from '$lib/desktop/components/ui/MultiStageOperation.types';
   import TestSuccessNote from '$lib/desktop/components/ui/TestSuccessNote.svelte';
   import SettingsButton from '$lib/desktop/features/settings/components/SettingsButton.svelte';
+  import CurrentLocationButton from '$lib/desktop/features/settings/components/CurrentLocationButton.svelte';
   import {
     settingsStore,
     settingsActions,
@@ -151,10 +152,12 @@
       {
         latitude: store.originalData.birdnet?.latitude,
         longitude: store.originalData.birdnet?.longitude,
+        locationConfigured: store.originalData.birdnet?.locationConfigured,
       },
       {
         latitude: store.formData.birdnet?.latitude,
         longitude: store.formData.birdnet?.longitude,
+        locationConfigured: store.formData.birdnet?.locationConfigured,
       }
     ) || hasSettingsChanged(store.originalData.realtime?.weather, store.formData.realtime?.weather)
   );
@@ -537,6 +540,15 @@
       longitude: lng,
       locationConfigured: true,
     });
+  }
+
+  // NumberField commits on change/blur. Track raw input separately so a
+  // pending browser-location result cannot overwrite text the user is still
+  // entering before that commit occurs.
+  let coordinateInputVersion = $state(0);
+
+  function handleCoordinateInput() {
+    coordinateInputVersion += 1;
   }
 
   function updateMarker(lat: number, lng: number) {
@@ -1039,14 +1051,19 @@
       originalData={{
         latitude: store.originalData.birdnet?.latitude,
         longitude: store.originalData.birdnet?.longitude,
+        locationConfigured: store.originalData.birdnet?.locationConfigured,
       }}
       currentData={{
         latitude: settings.birdnet.latitude,
         longitude: settings.birdnet.longitude,
+        locationConfigured: settings.birdnet.locationConfigured,
       }}
     >
       <!-- Coordinates -->
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-4">
+      <div
+        class="mb-4 grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3"
+        oninput={handleCoordinateInput}
+      >
         <NumberField
           label={t('settings.main.sections.rangeFilter.latitude.label')}
           value={settings.birdnet.latitude}
@@ -1068,6 +1085,16 @@
           helpText={t('settings.main.sections.rangeFilter.longitude.helpText')}
           disabled={store.isLoading || store.isSaving}
         />
+
+        <div class="md:col-span-2 xl:col-span-1 xl:border-l xl:border-[var(--border-100)] xl:pl-6">
+          <CurrentLocationButton
+            latitude={settings.birdnet.latitude}
+            longitude={settings.birdnet.longitude}
+            {coordinateInputVersion}
+            onLocation={updateLocationSettings}
+            disabled={store.isLoading || store.isSaving}
+          />
+        </div>
       </div>
 
       <!-- Map -->

--- a/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.svelte
@@ -533,8 +533,13 @@
     }
   }
 
-  // Centralized location update: marks locationConfigured and pushes coordinates to the store
-  function updateLocationSettings(lat: number, lng: number) {
+  // Every user-initiated coordinate update advances this version, including a
+  // map action whose rounded values equal the current coordinates. Track raw
+  // input separately so pending browser results also cannot overwrite text
+  // before a NumberField change/blur commit occurs.
+  let coordinateIntentVersion = $state(0);
+
+  function applyLocationSettings(lat: number, lng: number) {
     settingsActions.updateSection('birdnet', {
       latitude: lat,
       longitude: lng,
@@ -542,13 +547,17 @@
     });
   }
 
-  // NumberField commits on change/blur. Track raw input separately so a
-  // pending browser-location result cannot overwrite text the user is still
-  // entering before that commit occurs.
-  let coordinateInputVersion = $state(0);
+  function updateLocationSettings(lat: number, lng: number) {
+    advanceCoordinateIntentVersion();
+    applyLocationSettings(lat, lng);
+  }
 
-  function handleCoordinateInput() {
-    coordinateInputVersion += 1;
+  function updateBrowserLocation(lat: number, lng: number) {
+    applyLocationSettings(lat, lng);
+  }
+
+  function advanceCoordinateIntentVersion() {
+    coordinateIntentVersion += 1;
   }
 
   function updateMarker(lat: number, lng: number) {
@@ -1062,7 +1071,7 @@
       <!-- Coordinates -->
       <div
         class="mb-4 grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3"
-        oninput={handleCoordinateInput}
+        oninput={advanceCoordinateIntentVersion}
       >
         <NumberField
           label={t('settings.main.sections.rangeFilter.latitude.label')}
@@ -1090,8 +1099,8 @@
           <CurrentLocationButton
             latitude={settings.birdnet.latitude}
             longitude={settings.birdnet.longitude}
-            {coordinateInputVersion}
-            onLocation={updateLocationSettings}
+            {coordinateIntentVersion}
+            onLocation={updateBrowserLocation}
             disabled={store.isLoading || store.isSaving}
           />
         </div>
@@ -1575,7 +1584,7 @@
 
 <!-- Main Content -->
 <main class="settings-page-content" aria-label="Main settings configuration">
-  <SettingsTabs {tabs} bind:activeTab />
+  <SettingsTabs {tabs} bind:activeTab onReset={advanceCoordinateIntentVersion} />
 </main>
 
 <!-- Map Modal -->

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -1825,6 +1825,18 @@ export type TranslationKey =
   | 'settings.main.sections.rangeFilter.description'
   | 'settings.main.sections.rangeFilter.stationLocation.label'
   | 'settings.main.sections.rangeFilter.stationLocation.helpText'
+  | 'settings.main.sections.rangeFilter.stationLocation.automaticLocation'
+  | 'settings.main.sections.rangeFilter.stationLocation.useCurrentLocation'
+  | 'settings.main.sections.rangeFilter.stationLocation.locationHelp'
+  | 'settings.main.sections.rangeFilter.stationLocation.locating'
+  | 'settings.main.sections.rangeFilter.stationLocation.accuracy' // params: accuracy
+  | 'settings.main.sections.rangeFilter.stationLocation.locationDetected'
+  | 'settings.main.sections.rangeFilter.stationLocation.geolocationUnsupported'
+  | 'settings.main.sections.rangeFilter.stationLocation.geolocationRequiresHttps'
+  | 'settings.main.sections.rangeFilter.stationLocation.geolocationDenied'
+  | 'settings.main.sections.rangeFilter.stationLocation.geolocationUnavailable'
+  | 'settings.main.sections.rangeFilter.stationLocation.geolocationTimedOut'
+  | 'settings.main.sections.rangeFilter.stationLocation.geolocationFailed'
   | 'settings.main.sections.rangeFilter.latitude.label'
   | 'settings.main.sections.rangeFilter.latitude.helpText'
   | 'settings.main.sections.rangeFilter.longitude.label'
@@ -4467,6 +4479,7 @@ export type TranslationParams = {
   };
   'settings.main.sections.falsePositiveFilter.overlapAdjusted': { overlap: string | number };
   'settings.main.sections.falsePositiveFilter.overlapReduced': { overlap: string | number };
+  'settings.main.sections.rangeFilter.stationLocation.accuracy': { accuracy: string | number };
   'settings.support.supportReport.githubRequired.description': { createIssueLink: string | number };
   'settings.support.supportReport.githubIssue.helper': {
     viewIssuesLink: string | number;

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -136,6 +136,27 @@ const translations: Record<string, string> = {
   'settings.species.customConfiguration.title': 'Custom Configuration',
   'settings.species.customConfiguration.description': 'Configure custom settings for species',
   'common.ui.loading': 'Loading...',
+  'settings.main.sections.rangeFilter.stationLocation.useCurrentLocation': 'Use browser location',
+  'settings.main.sections.rangeFilter.stationLocation.automaticLocation': 'Automatic location',
+  'settings.main.sections.rangeFilter.stationLocation.locationHelp':
+    "Fills the coordinates using this browser's location.",
+  'settings.main.sections.rangeFilter.stationLocation.locating': 'Locating...',
+  'settings.main.sections.rangeFilter.stationLocation.accuracy':
+    'Estimated accuracy: within {accuracy} m',
+  'settings.main.sections.rangeFilter.stationLocation.locationDetected':
+    'Browser location detected.',
+  'settings.main.sections.rangeFilter.stationLocation.geolocationUnsupported':
+    'Device location is unsupported.',
+  'settings.main.sections.rangeFilter.stationLocation.geolocationRequiresHttps':
+    'Browser location requires HTTPS or localhost.',
+  'settings.main.sections.rangeFilter.stationLocation.geolocationDenied':
+    'Location permission was denied.',
+  'settings.main.sections.rangeFilter.stationLocation.geolocationUnavailable':
+    'The device could not determine its location.',
+  'settings.main.sections.rangeFilter.stationLocation.geolocationTimedOut':
+    'The location request timed out.',
+  'settings.main.sections.rangeFilter.stationLocation.geolocationFailed':
+    'Could not determine the device location.',
   'common.close': 'Close',
   'common.confirm': 'Confirm',
   'common.cancel': 'Cancel',

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -2368,7 +2368,19 @@
           "description": "Omezit detekci na druhy pravděpodobné ve vašem geografickém regionu",
           "stationLocation": {
             "label": "Poloha stanice",
-            "helpText": "Poloha stanice, používaná pro data o počasí a k omezení druhů ptáků na ty, které jsou v regionu pravděpodobné."
+            "helpText": "Poloha stanice, používaná pro data o počasí a k omezení druhů ptáků na ty, které jsou v regionu pravděpodobné.",
+            "automaticLocation": "Automatické určení polohy",
+            "useCurrentLocation": "Použít polohu prohlížeče",
+            "locationHelp": "Vyplní souřadnice pomocí polohy tohoto prohlížeče.",
+            "locating": "Zjišťování polohy...",
+            "accuracy": "Odhadovaná přesnost: do {accuracy} m",
+            "locationDetected": "Poloha prohlížeče byla zjištěna.",
+            "geolocationUnsupported": "Tento prohlížeč nepodporuje určování polohy zařízení. Zadejte souřadnice ručně nebo použijte mapu.",
+            "geolocationRequiresHttps": "Určování polohy prohlížeče vyžaduje HTTPS nebo localhost. Zadejte souřadnice ručně nebo použijte mapu.",
+            "geolocationDenied": "Přístup k poloze byl zamítnut. Zadejte souřadnice ručně nebo použijte mapu.",
+            "geolocationUnavailable": "Zařízení nedokázalo určit svou polohu. Zadejte souřadnice ručně nebo použijte mapu.",
+            "geolocationTimedOut": "Vypršel časový limit požadavku na polohu. Zkuste to znovu, zadejte souřadnice ručně nebo použijte mapu.",
+            "geolocationFailed": "Polohu zařízení se nepodařilo určit. Zadejte souřadnice ručně nebo použijte mapu."
           },
           "latitude": {
             "label": "Zeměpisná šířka",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -2368,7 +2368,19 @@
           "description": "Begræns detektion til arter, der er sandsynlige i dit geografiske område",
           "stationLocation": {
             "label": "Stationsplacering",
-            "helpText": "Stationsplacering, bruges til vejrdata og til at begrænse fuglearter til dem, der er sandsynlige i området."
+            "helpText": "Stationsplacering, bruges til vejrdata og til at begrænse fuglearter til dem, der er sandsynlige i området.",
+            "automaticLocation": "Automatisk placering",
+            "useCurrentLocation": "Brug browserplacering",
+            "locationHelp": "Udfylder koordinaterne ved hjælp af denne browsers placering.",
+            "locating": "Finder placering...",
+            "accuracy": "Anslået nøjagtighed: inden for {accuracy} m",
+            "locationDetected": "Browserens placering blev fundet.",
+            "geolocationUnsupported": "Denne browser understøtter ikke enhedsplacering. Indtast koordinater manuelt, eller brug kortet.",
+            "geolocationRequiresHttps": "Browserplacering kræver HTTPS eller localhost. Indtast koordinater manuelt, eller brug kortet.",
+            "geolocationDenied": "Placeringstilladelse blev afvist. Indtast koordinater manuelt, eller brug kortet.",
+            "geolocationUnavailable": "Enheden kunne ikke bestemme sin placering. Indtast koordinater manuelt, eller brug kortet.",
+            "geolocationTimedOut": "Placeringsanmodningen fik timeout. Prøv igen, indtast koordinater manuelt, eller brug kortet.",
+            "geolocationFailed": "Enhedens placering kunne ikke bestemmes. Indtast koordinater manuelt, eller brug kortet."
           },
           "latitude": {
             "label": "Breddegrad",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -2368,7 +2368,19 @@
           "description": "Erkennungen auf wahrscheinliche Arten in Ihrer geografischen Region beschränken",
           "stationLocation": {
             "label": "Stationsstandort",
-            "helpText": "Stationsstandort, wird zur Abrufung von Wetterdaten und zur Begrenzung von Vogelarten auf die in der Region wahrscheinlichen verwendet."
+            "helpText": "Stationsstandort, wird zur Abrufung von Wetterdaten und zur Begrenzung von Vogelarten auf die in der Region wahrscheinlichen verwendet.",
+            "automaticLocation": "Automatische Standortbestimmung",
+            "useCurrentLocation": "Browserstandort verwenden",
+            "locationHelp": "Füllt die Koordinaten mit dem Standort dieses Browsers aus.",
+            "locating": "Standort wird ermittelt...",
+            "accuracy": "Geschätzte Genauigkeit: innerhalb von {accuracy} m",
+            "locationDetected": "Browserstandort wurde ermittelt.",
+            "geolocationUnsupported": "Dieser Browser unterstützt die Gerätestandortbestimmung nicht. Geben Sie die Koordinaten manuell ein oder verwenden Sie die Karte.",
+            "geolocationRequiresHttps": "Die Browser-Standortbestimmung erfordert HTTPS oder localhost. Geben Sie die Koordinaten manuell ein oder verwenden Sie die Karte.",
+            "geolocationDenied": "Die Standortberechtigung wurde verweigert. Geben Sie die Koordinaten manuell ein oder verwenden Sie die Karte.",
+            "geolocationUnavailable": "Ihr Gerät konnte seinen Standort nicht bestimmen. Geben Sie die Koordinaten manuell ein oder verwenden Sie die Karte.",
+            "geolocationTimedOut": "Die Standortanfrage hat das Zeitlimit überschritten. Versuchen Sie es erneut, geben Sie die Koordinaten manuell ein oder verwenden Sie die Karte.",
+            "geolocationFailed": "Der Gerätestandort konnte nicht bestimmt werden. Geben Sie die Koordinaten manuell ein oder verwenden Sie die Karte."
           },
           "latitude": {
             "label": "Breitengrad",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -2368,7 +2368,19 @@
           "description": "Limit detection to species probable in your geographic region",
           "stationLocation": {
             "label": "Station Location",
-            "helpText": "Station location, used for weather data and to limit bird species to those probable in the region."
+            "helpText": "Station location, used for weather data and to limit bird species to those probable in the region.",
+            "automaticLocation": "Automatic location",
+            "useCurrentLocation": "Use browser location",
+            "locationHelp": "Fills the coordinates using this browser's location.",
+            "locating": "Locating...",
+            "accuracy": "Estimated accuracy: within {accuracy} m",
+            "locationDetected": "Browser location detected.",
+            "geolocationUnsupported": "This browser does not support device location. Enter coordinates manually or use the map.",
+            "geolocationRequiresHttps": "Browser location requires HTTPS or localhost. Enter coordinates manually or use the map.",
+            "geolocationDenied": "Location permission was denied. Enter coordinates manually or use the map.",
+            "geolocationUnavailable": "Your device could not determine its location. Enter coordinates manually or use the map.",
+            "geolocationTimedOut": "The location request timed out. Try again, enter coordinates manually, or use the map.",
+            "geolocationFailed": "Could not determine your device location. Enter coordinates manually or use the map."
           },
           "latitude": {
             "label": "Latitude",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -2368,7 +2368,19 @@
           "description": "Limitar la detección a especies probables en su región geográfica",
           "stationLocation": {
             "label": "Ubicación de la estación",
-            "helpText": "Ubicación de la estación, utilizada para obtener datos meteorológicos y limitar las especies de aves a las probables en la región."
+            "helpText": "Ubicación de la estación, utilizada para obtener datos meteorológicos y limitar las especies de aves a las probables en la región.",
+            "automaticLocation": "Ubicación automática",
+            "useCurrentLocation": "Usar ubicación del navegador",
+            "locationHelp": "Rellena las coordenadas usando la ubicación de este navegador.",
+            "locating": "Obteniendo ubicación...",
+            "accuracy": "Precisión estimada: dentro de {accuracy} m",
+            "locationDetected": "Se detectó la ubicación del navegador.",
+            "geolocationUnsupported": "Este navegador no admite la ubicación del dispositivo. Introduzca las coordenadas manualmente o use el mapa.",
+            "geolocationRequiresHttps": "La ubicación del navegador requiere HTTPS o localhost. Introduzca las coordenadas manualmente o use el mapa.",
+            "geolocationDenied": "Se denegó el permiso de ubicación. Introduzca las coordenadas manualmente o use el mapa.",
+            "geolocationUnavailable": "El dispositivo no pudo determinar su ubicación. Introduzca las coordenadas manualmente o use el mapa.",
+            "geolocationTimedOut": "La solicitud de ubicación agotó el tiempo de espera. Inténtelo de nuevo, introduzca las coordenadas manualmente o use el mapa.",
+            "geolocationFailed": "No se pudo determinar la ubicación del dispositivo. Introduzca las coordenadas manualmente o use el mapa."
           },
           "latitude": {
             "label": "Latitud",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -2368,7 +2368,19 @@
           "description": "Rajoita tunnistus lajeihin, jotka ovat todennäköisiä maantieteellisellä alueellasi",
           "stationLocation": {
             "label": "Aseman sijainti",
-            "helpText": "Aseman sijainti, jota käytetään säätietoihin ja lintulajien rajoittamiseen alueella todennäköisiin lajeihin."
+            "helpText": "Aseman sijainti, jota käytetään säätietoihin ja lintulajien rajoittamiseen alueella todennäköisiin lajeihin.",
+            "automaticLocation": "Automaattinen sijainti",
+            "useCurrentLocation": "Käytä selaimen sijaintia",
+            "locationHelp": "Täyttää koordinaatit tämän selaimen sijainnin perusteella.",
+            "locating": "Paikannetaan...",
+            "accuracy": "Arvioitu tarkkuus: {accuracy} m:n sisällä",
+            "locationDetected": "Selaimen sijainti havaittu.",
+            "geolocationUnsupported": "Tämä selain ei tue laitteen paikannusta. Anna koordinaatit manuaalisesti tai käytä karttaa.",
+            "geolocationRequiresHttps": "Selaimen paikannus vaatii HTTPS-yhteyden tai localhostin. Anna koordinaatit manuaalisesti tai käytä karttaa.",
+            "geolocationDenied": "Sijaintilupa evättiin. Anna koordinaatit manuaalisesti tai käytä karttaa.",
+            "geolocationUnavailable": "Laite ei pystynyt määrittämään sijaintiaan. Anna koordinaatit manuaalisesti tai käytä karttaa.",
+            "geolocationTimedOut": "Sijaintipyyntö aikakatkaistiin. Yritä uudelleen, anna koordinaatit manuaalisesti tai käytä karttaa.",
+            "geolocationFailed": "Laitteen sijaintia ei voitu määrittää. Anna koordinaatit manuaalisesti tai käytä karttaa."
           },
           "latitude": {
             "label": "Leveysaste",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -2368,7 +2368,19 @@
           "description": "Limiter la détection aux espèces probables dans votre région géographique",
           "stationLocation": {
             "label": "Emplacement de la station",
-            "helpText": "Emplacement de la station, utilisé pour les données météorologiques et pour limiter les espèces d'oiseaux à celles probables dans la région."
+            "helpText": "Emplacement de la station, utilisé pour les données météorologiques et pour limiter les espèces d'oiseaux à celles probables dans la région.",
+            "automaticLocation": "Localisation automatique",
+            "useCurrentLocation": "Utiliser la position du navigateur",
+            "locationHelp": "Renseigne les coordonnées à partir de la position de ce navigateur.",
+            "locating": "Localisation en cours...",
+            "accuracy": "Précision estimée : dans un rayon de {accuracy} m",
+            "locationDetected": "Position du navigateur détectée.",
+            "geolocationUnsupported": "Ce navigateur ne prend pas en charge la localisation de l'appareil. Saisissez les coordonnées manuellement ou utilisez la carte.",
+            "geolocationRequiresHttps": "La localisation du navigateur nécessite HTTPS ou localhost. Saisissez les coordonnées manuellement ou utilisez la carte.",
+            "geolocationDenied": "L'autorisation d'accès à la position a été refusée. Saisissez les coordonnées manuellement ou utilisez la carte.",
+            "geolocationUnavailable": "Votre appareil n'a pas pu déterminer sa position. Saisissez les coordonnées manuellement ou utilisez la carte.",
+            "geolocationTimedOut": "La demande de localisation a expiré. Réessayez, saisissez les coordonnées manuellement ou utilisez la carte.",
+            "geolocationFailed": "Impossible de déterminer la position de votre appareil. Saisissez les coordonnées manuellement ou utilisez la carte."
           },
           "latitude": {
             "label": "Latitude",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -2368,7 +2368,19 @@
           "description": "A detektálást a földrajzi régióban valószínű fajokra korlátozza",
           "stationLocation": {
             "label": "Állomás helyszín",
-            "helpText": "Állomás helyszín, az időjárási adatokhoz és a madárfajoknak a régióban való valószínűségére való korlátozáshoz használva."
+            "helpText": "Állomás helyszín, az időjárási adatokhoz és a madárfajoknak a régióban való valószínűségére való korlátozáshoz használva.",
+            "automaticLocation": "Automatikus helymeghatározás",
+            "useCurrentLocation": "A böngésző helyének használata",
+            "locationHelp": "Kitölti a koordinátákat a böngésző helye alapján.",
+            "locating": "Helymeghatározás...",
+            "accuracy": "Becsült pontosság: {accuracy} m-en belül",
+            "locationDetected": "A böngésző helye meghatározva.",
+            "geolocationUnsupported": "Ez a böngésző nem támogatja az eszköz helymeghatározását. Adja meg kézzel a koordinátákat, vagy használja a térképet.",
+            "geolocationRequiresHttps": "A böngésző helymeghatározásához HTTPS vagy localhost szükséges. Adja meg kézzel a koordinátákat, vagy használja a térképet.",
+            "geolocationDenied": "A helyhozzáférési engedély meg lett tagadva. Adja meg kézzel a koordinátákat, vagy használja a térképet.",
+            "geolocationUnavailable": "Az eszköz nem tudta meghatározni a helyét. Adja meg kézzel a koordinátákat, vagy használja a térképet.",
+            "geolocationTimedOut": "A helymeghatározási kérés túllépte az időkorlátot. Próbálja újra, adja meg kézzel a koordinátákat, vagy használja a térképet.",
+            "geolocationFailed": "Nem sikerült meghatározni az eszköz helyét. Adja meg kézzel a koordinátákat, vagy használja a térképet."
           },
           "latitude": {
             "label": "Szélesség",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -2368,7 +2368,19 @@
           "description": "Limita il rilevamento alle specie probabili nella tua regione geografica",
           "stationLocation": {
             "label": "Posizione Stazione",
-            "helpText": "Posizione della stazione, usata per dati meteo e per limitare le specie di uccelli a quelle probabili nella regione."
+            "helpText": "Posizione della stazione, usata per dati meteo e per limitare le specie di uccelli a quelle probabili nella regione.",
+            "automaticLocation": "Posizione automatica",
+            "useCurrentLocation": "Usa la posizione del browser",
+            "locationHelp": "Compila le coordinate usando la posizione di questo browser.",
+            "locating": "Localizzazione in corso...",
+            "accuracy": "Precisione stimata: entro {accuracy} m",
+            "locationDetected": "Posizione del browser rilevata.",
+            "geolocationUnsupported": "Questo browser non supporta la posizione del dispositivo. Inserisci le coordinate manualmente o usa la mappa.",
+            "geolocationRequiresHttps": "La posizione del browser richiede HTTPS o localhost. Inserisci le coordinate manualmente o usa la mappa.",
+            "geolocationDenied": "L'autorizzazione alla posizione è stata negata. Inserisci le coordinate manualmente o usa la mappa.",
+            "geolocationUnavailable": "Il dispositivo non ha potuto determinare la propria posizione. Inserisci le coordinate manualmente o usa la mappa.",
+            "geolocationTimedOut": "La richiesta di posizione è scaduta. Riprova, inserisci le coordinate manualmente o usa la mappa.",
+            "geolocationFailed": "Impossibile determinare la posizione del dispositivo. Inserisci le coordinate manualmente o usa la mappa."
           },
           "latitude": {
             "label": "Latitudine",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -2368,7 +2368,19 @@
           "description": "Ierobežot noteikšanu līdz sugām, kas ir iespējamas jūsu ģeogrāfiskajā reģionā",
           "stationLocation": {
             "label": "Stacijas atrašanās vieta",
-            "helpText": "Stacijas atrašanās vieta, ko izmanto laikapstākļu datiem un putnu sugu ierobežošanai līdz reģionā iespējamām."
+            "helpText": "Stacijas atrašanās vieta, ko izmanto laikapstākļu datiem un putnu sugu ierobežošanai līdz reģionā iespējamām.",
+            "automaticLocation": "Automātiska atrašanās vieta",
+            "useCurrentLocation": "Izmantot pārlūkprogrammas atrašanās vietu",
+            "locationHelp": "Aizpilda koordinātas, izmantojot šīs pārlūkprogrammas atrašanās vietu.",
+            "locating": "Nosaka atrašanās vietu...",
+            "accuracy": "Aptuvenā precizitāte: {accuracy} m robežās",
+            "locationDetected": "Pārlūkprogrammas atrašanās vieta noteikta.",
+            "geolocationUnsupported": "Šī pārlūkprogramma neatbalsta ierīces atrašanās vietas noteikšanu. Ievadiet koordinātas manuāli vai izmantojiet karti.",
+            "geolocationRequiresHttps": "Pārlūkprogrammas atrašanās vietas noteikšanai nepieciešams HTTPS vai localhost. Ievadiet koordinātas manuāli vai izmantojiet karti.",
+            "geolocationDenied": "Atrašanās vietas atļauja tika liegta. Ievadiet koordinātas manuāli vai izmantojiet karti.",
+            "geolocationUnavailable": "Ierīce nevarēja noteikt savu atrašanās vietu. Ievadiet koordinātas manuāli vai izmantojiet karti.",
+            "geolocationTimedOut": "Atrašanās vietas pieprasījumam beidzās laiks. Mēģiniet vēlreiz, ievadiet koordinātas manuāli vai izmantojiet karti.",
+            "geolocationFailed": "Neizdevās noteikt ierīces atrašanās vietu. Ievadiet koordinātas manuāli vai izmantojiet karti."
           },
           "latitude": {
             "label": "Platums",

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -2368,7 +2368,19 @@
           "description": "Begrens deteksjon til arter som er sannsynlige i ditt geografiske område",
           "stationLocation": {
             "label": "Stasjonsposisjon",
-            "helpText": "Stasjonsposisjon, brukes for værdata og for å begrense fuglearter til de som er sannsynlige i regionen."
+            "helpText": "Stasjonsposisjon, brukes for værdata og for å begrense fuglearter til de som er sannsynlige i regionen.",
+            "automaticLocation": "Automatisk posisjon",
+            "useCurrentLocation": "Bruk nettleserposisjon",
+            "locationHelp": "Fyller ut koordinatene ved hjelp av posisjonen til denne nettleseren.",
+            "locating": "Finner posisjon...",
+            "accuracy": "Anslått nøyaktighet: innenfor {accuracy} m",
+            "locationDetected": "Nettleserens posisjon ble funnet.",
+            "geolocationUnsupported": "Denne nettleseren støtter ikke enhetsposisjon. Skriv inn koordinater manuelt eller bruk kartet.",
+            "geolocationRequiresHttps": "Nettleserposisjon krever HTTPS eller localhost. Skriv inn koordinater manuelt eller bruk kartet.",
+            "geolocationDenied": "Posisjonstillatelse ble avvist. Skriv inn koordinater manuelt eller bruk kartet.",
+            "geolocationUnavailable": "Enheten kunne ikke bestemme posisjonen sin. Skriv inn koordinater manuelt eller bruk kartet.",
+            "geolocationTimedOut": "Posisjonsforespørselen fikk tidsavbrudd. Prøv igjen, skriv inn koordinater manuelt eller bruk kartet.",
+            "geolocationFailed": "Kunne ikke bestemme enhetens posisjon. Skriv inn koordinater manuelt eller bruk kartet."
           },
           "latitude": {
             "label": "Breddegrad",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -2368,7 +2368,19 @@
           "description": "Beperk detectie tot soorten die waarschijnlijk voorkomen in uw geografische regio",
           "stationLocation": {
             "label": "Station Locatie",
-            "helpText": "Station locatie, gebruikt voor weersgegevens en om vogelsoorten te beperken tot diegenen die waarschijnlijk voorkomen in de regio."
+            "helpText": "Station locatie, gebruikt voor weersgegevens en om vogelsoorten te beperken tot diegenen die waarschijnlijk voorkomen in de regio.",
+            "automaticLocation": "Automatische locatie",
+            "useCurrentLocation": "Browserlocatie gebruiken",
+            "locationHelp": "Vult de coördinaten in met de locatie van deze browser.",
+            "locating": "Locatie bepalen...",
+            "accuracy": "Geschatte nauwkeurigheid: binnen {accuracy} m",
+            "locationDetected": "Browserlocatie bepaald.",
+            "geolocationUnsupported": "Deze browser ondersteunt apparaatlocatie niet. Voer coördinaten handmatig in of gebruik de kaart.",
+            "geolocationRequiresHttps": "Browserlocatie vereist HTTPS of localhost. Voer coördinaten handmatig in of gebruik de kaart.",
+            "geolocationDenied": "Toestemming voor locatie is geweigerd. Voer coördinaten handmatig in of gebruik de kaart.",
+            "geolocationUnavailable": "Uw apparaat kon de locatie niet bepalen. Voer coördinaten handmatig in of gebruik de kaart.",
+            "geolocationTimedOut": "Het locatieverzoek duurde te lang. Probeer het opnieuw, voer coördinaten handmatig in of gebruik de kaart.",
+            "geolocationFailed": "De locatie van uw apparaat kon niet worden bepaald. Voer coördinaten handmatig in of gebruik de kaart."
           },
           "latitude": {
             "label": "Breedtegraad",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -2368,7 +2368,19 @@
           "description": "Ogranicz detekcję do gatunków prawdopodobnych w Twoim regionie geograficznym",
           "stationLocation": {
             "label": "Lokalizacja Stacji",
-            "helpText": "Lokalizacja stacji, używana do danych pogodowych i ograniczenia gatunków ptaków do tych prawdopodobnych w regionie."
+            "helpText": "Lokalizacja stacji, używana do danych pogodowych i ograniczenia gatunków ptaków do tych prawdopodobnych w regionie.",
+            "automaticLocation": "Automatyczna lokalizacja",
+            "useCurrentLocation": "Użyj lokalizacji przeglądarki",
+            "locationHelp": "Wypełnia współrzędne przy użyciu lokalizacji tej przeglądarki.",
+            "locating": "Ustalanie lokalizacji...",
+            "accuracy": "Szacowana dokładność: w promieniu {accuracy} m",
+            "locationDetected": "Ustalono lokalizację przeglądarki.",
+            "geolocationUnsupported": "Ta przeglądarka nie obsługuje lokalizacji urządzenia. Wprowadź współrzędne ręcznie lub użyj mapy.",
+            "geolocationRequiresHttps": "Lokalizacja przeglądarki wymaga HTTPS lub localhost. Wprowadź współrzędne ręcznie lub użyj mapy.",
+            "geolocationDenied": "Odmówiono dostępu do lokalizacji. Wprowadź współrzędne ręcznie lub użyj mapy.",
+            "geolocationUnavailable": "Urządzenie nie mogło określić swojej lokalizacji. Wprowadź współrzędne ręcznie lub użyj mapy.",
+            "geolocationTimedOut": "Upłynął limit czasu żądania lokalizacji. Spróbuj ponownie, wprowadź współrzędne ręcznie lub użyj mapy.",
+            "geolocationFailed": "Nie udało się określić lokalizacji urządzenia. Wprowadź współrzędne ręcznie lub użyj mapy."
           },
           "latitude": {
             "label": "Szerokość Geograficzna",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -2368,7 +2368,19 @@
           "description": "Limita a detecção a espécies prováveis em sua região geográfica",
           "stationLocation": {
             "label": "Localização da estação",
-            "helpText": "Localização da estação, usada para dados meteorológicos e para limitar as espécies de pássaros àquelas prováveis na região."
+            "helpText": "Localização da estação, usada para dados meteorológicos e para limitar as espécies de pássaros àquelas prováveis na região.",
+            "automaticLocation": "Localização automática",
+            "useCurrentLocation": "Usar localização do navegador",
+            "locationHelp": "Preenche as coordenadas usando a localização deste navegador.",
+            "locating": "A determinar a localização...",
+            "accuracy": "Precisão estimada: num raio de {accuracy} m",
+            "locationDetected": "Localização do navegador detetada.",
+            "geolocationUnsupported": "Este navegador não suporta a localização do dispositivo. Introduza as coordenadas manualmente ou use o mapa.",
+            "geolocationRequiresHttps": "A localização do navegador requer HTTPS ou localhost. Introduza as coordenadas manualmente ou use o mapa.",
+            "geolocationDenied": "A permissão de localização foi negada. Introduza as coordenadas manualmente ou use o mapa.",
+            "geolocationUnavailable": "O dispositivo não conseguiu determinar a localização. Introduza as coordenadas manualmente ou use o mapa.",
+            "geolocationTimedOut": "O pedido de localização excedeu o tempo limite. Tente novamente, introduza as coordenadas manualmente ou use o mapa.",
+            "geolocationFailed": "Não foi possível determinar a localização do dispositivo. Introduza as coordenadas manualmente ou use o mapa."
           },
           "latitude": {
             "label": "Latitude",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -2368,7 +2368,19 @@
           "description": "Obmedziť detekciu na druhy pravdepodobné vo vašom geografickom regióne",
           "stationLocation": {
             "label": "Poloha stanice",
-            "helpText": "Poloha stanice, používaná pre údaje o počasí a na obmedzenie druhov vtákov na tie, ktoré sú v regióne pravdepodobné."
+            "helpText": "Poloha stanice, používaná pre údaje o počasí a na obmedzenie druhov vtákov na tie, ktoré sú v regióne pravdepodobné.",
+            "automaticLocation": "Automatické určenie polohy",
+            "useCurrentLocation": "Použiť polohu prehliadača",
+            "locationHelp": "Vyplní súradnice pomocou polohy tohto prehliadača.",
+            "locating": "Zisťovanie polohy...",
+            "accuracy": "Odhadovaná presnosť: do {accuracy} m",
+            "locationDetected": "Poloha prehliadača bola zistená.",
+            "geolocationUnsupported": "Tento prehliadač nepodporuje určovanie polohy zariadenia. Zadajte súradnice ručne alebo použite mapu.",
+            "geolocationRequiresHttps": "Určovanie polohy prehliadača vyžaduje HTTPS alebo localhost. Zadajte súradnice ručne alebo použite mapu.",
+            "geolocationDenied": "Prístup k polohe bol zamietnutý. Zadajte súradnice ručne alebo použite mapu.",
+            "geolocationUnavailable": "Zariadenie nedokázalo určiť svoju polohu. Zadajte súradnice ručne alebo použite mapu.",
+            "geolocationTimedOut": "Vypršal časový limit požiadavky na polohu. Skúste to znova, zadajte súradnice ručne alebo použite mapu.",
+            "geolocationFailed": "Polohu zariadenia sa nepodarilo určiť. Zadajte súradnice ručne alebo použite mapu."
           },
           "latitude": {
             "label": "Zemepisná šírka",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -2368,7 +2368,19 @@
           "description": "Begränsa detektion till arter som är sannolika i ditt geografiska område",
           "stationLocation": {
             "label": "Stationsplats",
-            "helpText": "Stationsplats, används för väderdata och för att begränsa fågelarter till de som är sannolika i regionen."
+            "helpText": "Stationsplats, används för väderdata och för att begränsa fågelarter till de som är sannolika i regionen.",
+            "automaticLocation": "Automatisk plats",
+            "useCurrentLocation": "Använd webbläsarens plats",
+            "locationHelp": "Fyller i koordinaterna med hjälp av den här webbläsarens plats.",
+            "locating": "Söker plats...",
+            "accuracy": "Uppskattad noggrannhet: inom {accuracy} m",
+            "locationDetected": "Webbläsarens plats hittades.",
+            "geolocationUnsupported": "Den här webbläsaren stöder inte enhetspositionering. Ange koordinater manuellt eller använd kartan.",
+            "geolocationRequiresHttps": "Webbläsarens platsbestämning kräver HTTPS eller localhost. Ange koordinater manuellt eller använd kartan.",
+            "geolocationDenied": "Platsbehörighet nekades. Ange koordinater manuellt eller använd kartan.",
+            "geolocationUnavailable": "Enheten kunde inte fastställa sin plats. Ange koordinater manuellt eller använd kartan.",
+            "geolocationTimedOut": "Platsbegäran överskred tidsgränsen. Försök igen, ange koordinater manuellt eller använd kartan.",
+            "geolocationFailed": "Det gick inte att fastställa enhetens plats. Ange koordinater manuellt eller använd kartan."
           },
           "latitude": {
             "label": "Latitud",

--- a/frontend/tests/e2e/settings/current-location.spec.ts
+++ b/frontend/tests/e2e/settings/current-location.spec.ts
@@ -1,0 +1,255 @@
+import { expect, test, type Page, type Route } from '@playwright/test';
+
+const TEST_LOCATION = {
+  latitude: 52.3728,
+  longitude: 4.8936,
+  accuracy: 8,
+};
+
+interface DeferredGeolocationWindow extends Window {
+  resolvePendingGeolocation?: () => void;
+}
+
+async function installDeferredGeolocation(page: Page) {
+  await page.addInitScript(location => {
+    const browserWindow = window as DeferredGeolocationWindow;
+    Object.defineProperty(navigator, 'geolocation', {
+      configurable: true,
+      value: {
+        getCurrentPosition(success: PositionCallback) {
+          browserWindow.resolvePendingGeolocation = () => {
+            success({
+              coords: {
+                ...location,
+                altitude: null,
+                altitudeAccuracy: null,
+                heading: null,
+                speed: null,
+                toJSON: () => ({}),
+              },
+              timestamp: Date.now(),
+              toJSON: () => ({}),
+            });
+          };
+        },
+        watchPosition: () => 0,
+        clearWatch: () => undefined,
+      },
+    });
+  }, TEST_LOCATION);
+}
+
+async function resolvePendingGeolocation(page: Page) {
+  await page.evaluate(() => {
+    const browserWindow = window as DeferredGeolocationWindow;
+    if (!browserWindow.resolvePendingGeolocation) {
+      throw new Error('No pending geolocation request');
+    }
+    browserWindow.resolvePendingGeolocation();
+  });
+}
+
+async function openLocationSettings(page: Page) {
+  await page.goto('/ui/settings/main', { waitUntil: 'domcontentloaded' });
+  await page.locator('#settings-tab-location').click();
+  await expect(page.locator('#settings-tabpanel-location')).toBeVisible();
+}
+
+test.describe('Browser location', () => {
+  test.use({
+    geolocation: TEST_LOCATION,
+    permissions: ['geolocation'],
+  });
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    // The repository's historical "iPad Pro" device alias is absent from
+    // current Playwright, so keep this feature's tablet coverage explicit.
+    if (testInfo.project.name === 'tablet') {
+      await page.setViewportSize({ width: 1024, height: 768 });
+    }
+
+    await page.addInitScript(() => {
+      localStorage.setItem('birdnet-locale', 'en');
+    });
+  });
+
+  test('populates the settings form and survives the save/reload boundary', async ({
+    page,
+  }, testInfo) => {
+    const browserErrors: string[] = [];
+    page.on('pageerror', error => browserErrors.push(error.message));
+    page.on('console', message => {
+      if (message.type() === 'error') {
+        browserErrors.push(message.text());
+      }
+    });
+
+    let loadedSettings: unknown;
+    let savedSettings: Record<string, unknown> | undefined;
+
+    await page.route('**/api/v2/settings', async (route: Route) => {
+      const request = route.request();
+      const pathname = new URL(request.url()).pathname;
+      if (pathname !== '/api/v2/settings') {
+        await route.continue();
+        return;
+      }
+
+      if (request.method() === 'GET') {
+        if (savedSettings) {
+          await route.fulfill({ json: savedSettings });
+          return;
+        }
+
+        const response = await route.fetch();
+        loadedSettings = await response.json();
+        await route.fulfill({ response });
+        return;
+      }
+
+      if (request.method() === 'PUT') {
+        savedSettings = request.postDataJSON() as Record<string, unknown>;
+        await route.fulfill({
+          status: 200,
+          json: { message: 'Settings updated successfully' },
+        });
+        return;
+      }
+
+      await route.continue();
+    });
+
+    await openLocationSettings(page);
+    expect(loadedSettings).toBeDefined();
+
+    const locationButton = page.getByRole('button', { name: 'Use browser location' });
+    await expect(page.getByText('Automatic location', { exact: true })).toBeVisible();
+    await expect(
+      page.getByText("Fills the coordinates using this browser's location.", { exact: true })
+    ).toBeVisible();
+    await expect(locationButton).toHaveClass(/btn-primary/);
+    const dividerWidth = await locationButton.evaluate(button => {
+      const formControl = button.closest('.form-control');
+      const layoutColumn = formControl?.parentElement;
+      return layoutColumn ? getComputedStyle(layoutColumn).borderLeftWidth : null;
+    });
+    expect(dividerWidth).toBe(testInfo.project.name === 'tablet' ? '0px' : '1px');
+    await locationButton.focus();
+    await page.keyboard.press('Enter');
+
+    await expect(page.getByLabel('Latitude')).toHaveValue('52.373');
+    await expect(page.getByLabel('Longitude')).toHaveValue('4.894');
+    await expect(page.getByText('Estimated accuracy: within 44 m', { exact: true })).toBeVisible();
+    await expect(page.getByText('Browser location detected.', { exact: true })).toBeVisible();
+    await expect(
+      page.getByText("Fills the coordinates using this browser's location.", { exact: true })
+    ).toBeHidden();
+    expect(savedSettings).toBeUndefined();
+
+    const saveButton = page.getByRole('button', { name: 'Save Changes' });
+    await expect(saveButton).toBeEnabled();
+    await saveButton.click();
+
+    await expect
+      .poll(() => savedSettings)
+      .toMatchObject({
+        birdnet: {
+          latitude: 52.373,
+          longitude: 4.894,
+          locationConfigured: true,
+        },
+      });
+
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.locator('#settings-tab-location').click();
+
+    await expect(page.getByLabel('Latitude')).toHaveValue('52.373');
+    await expect(page.getByLabel('Longitude')).toHaveValue('4.894');
+    await expect(page.getByRole('button', { name: 'Save Changes' })).toBeDisabled();
+    expect(
+      await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)
+    ).toBe(true);
+    expect(browserErrors).toEqual([]);
+  });
+
+  test('keeps uncommitted manual input when an older request resolves', async ({ page }) => {
+    await installDeferredGeolocation(page);
+    await openLocationSettings(page);
+
+    const latitudeField = page.getByLabel('Latitude');
+    const longitudeField = page.getByLabel('Longitude');
+    const initialLongitude = await longitudeField.inputValue();
+
+    await page.getByRole('button', { name: 'Use browser location' }).click();
+    await expect(page.getByRole('button', { name: 'Locating...' })).toBeDisabled();
+
+    await latitudeField.fill('51.501');
+
+    await expect(page.getByRole('button', { name: 'Use browser location' })).toBeEnabled();
+    await resolvePendingGeolocation(page);
+
+    await expect(latitudeField).toHaveValue('51.501');
+    await expect(longitudeField).toHaveValue(initialLongitude);
+    await expect(page.getByText('Browser location detected.', { exact: true })).toBeHidden();
+  });
+
+  test('ignores a pending result after a save starts', async ({ page }) => {
+    await installDeferredGeolocation(page);
+
+    let saveStartedResolve: () => void = () => undefined;
+    const saveStarted = new Promise<void>(resolve => {
+      saveStartedResolve = resolve;
+    });
+    let saveRelease: () => void = () => undefined;
+    const saveReleased = new Promise<void>(resolve => {
+      saveRelease = resolve;
+    });
+    let savedSettings: Record<string, unknown> | undefined;
+
+    await page.route('**/api/v2/settings', async (route: Route) => {
+      if (route.request().method() !== 'PUT') {
+        await route.continue();
+        return;
+      }
+
+      savedSettings = route.request().postDataJSON() as Record<string, unknown>;
+      saveStartedResolve();
+      await saveReleased;
+      await route.fulfill({
+        status: 200,
+        json: { message: 'Settings updated successfully' },
+      });
+    });
+
+    await openLocationSettings(page);
+
+    const latitudeField = page.getByLabel('Latitude');
+    const longitudeField = page.getByLabel('Longitude');
+    await latitudeField.fill('51.501');
+    await latitudeField.blur();
+    await longitudeField.fill('5.501');
+    await longitudeField.blur();
+
+    const locationButton = page.getByRole('button', { name: 'Use browser location' });
+    await locationButton.click();
+    await page.getByRole('button', { name: 'Save Changes' }).click();
+    await saveStarted;
+    await expect(locationButton).toBeDisabled();
+
+    saveRelease();
+    await expect(locationButton).toBeEnabled();
+    await resolvePendingGeolocation(page);
+
+    expect(savedSettings).toMatchObject({
+      birdnet: {
+        latitude: 51.501,
+        longitude: 5.501,
+        locationConfigured: true,
+      },
+    });
+    await expect(latitudeField).toHaveValue('51.501');
+    await expect(longitudeField).toHaveValue('5.501');
+    await expect(page.getByRole('button', { name: 'Save Changes' })).toBeDisabled();
+    await expect(page.getByText('Browser location detected.', { exact: true })).toBeHidden();
+  });
+});

--- a/frontend/tests/e2e/settings/current-location.spec.ts
+++ b/frontend/tests/e2e/settings/current-location.spec.ts
@@ -49,6 +49,34 @@ async function resolvePendingGeolocation(page: Page) {
   });
 }
 
+async function installLocationSettingsFixture(page: Page) {
+  await page.route('**/api/v2/settings', async (route: Route) => {
+    const request = route.request();
+    if (request.method() !== 'GET' || new URL(request.url()).pathname !== '/api/v2/settings') {
+      await route.continue();
+      return;
+    }
+
+    const response = await route.fetch();
+    const settings = (await response.json()) as {
+      birdnet: Record<string, unknown>;
+      [key: string]: unknown;
+    };
+    await route.fulfill({
+      response,
+      json: {
+        ...settings,
+        birdnet: {
+          ...settings.birdnet,
+          latitude: 51.501,
+          longitude: 5.501,
+          locationConfigured: false,
+        },
+      },
+    });
+  });
+}
+
 async function openLocationSettings(page: Page) {
   await page.goto('/ui/settings/main', { waitUntil: 'domcontentloaded' });
   await page.locator('#settings-tab-location').click();
@@ -189,6 +217,75 @@ test.describe('Browser location', () => {
     await resolvePendingGeolocation(page);
 
     await expect(latitudeField).toHaveValue('51.501');
+    await expect(longitudeField).toHaveValue(initialLongitude);
+    await expect(page.getByText('Browser location detected.', { exact: true })).toBeHidden();
+  });
+
+  test('keeps a newer map choice when rounded coordinates are unchanged', async ({ page }) => {
+    await installDeferredGeolocation(page);
+    await installLocationSettingsFixture(page);
+    await openLocationSettings(page);
+
+    const latitudeField = page.getByLabel('Latitude');
+    const longitudeField = page.getByLabel('Longitude');
+    const initialLatitude = await latitudeField.inputValue();
+    const initialLongitude = await longitudeField.inputValue();
+    const locationButton = page.getByRole('button', { name: 'Use browser location' });
+
+    await expect(page.getByRole('button', { name: 'Zoom in' })).toBeEnabled();
+    await locationButton.click();
+    await expect(page.getByRole('button', { name: 'Locating...' })).toBeDisabled();
+
+    const mapCanvas = page.locator('#location-map canvas');
+    const bounds = await mapCanvas.boundingBox();
+    if (!bounds) {
+      throw new Error('Location map has no rendered bounds');
+    }
+    await mapCanvas.click({
+      position: {
+        x: bounds.width / 2,
+        y: bounds.height / 2,
+      },
+    });
+
+    await expect(locationButton).toBeEnabled();
+    await expect(latitudeField).toHaveValue(initialLatitude);
+    await expect(longitudeField).toHaveValue(initialLongitude);
+
+    await resolvePendingGeolocation(page);
+
+    await expect(latitudeField).toHaveValue(initialLatitude);
+    await expect(longitudeField).toHaveValue(initialLongitude);
+    await expect(page.getByText('Browser location detected.', { exact: true })).toBeHidden();
+  });
+
+  test('ignores a pending result after all settings are reset', async ({ page }) => {
+    await installDeferredGeolocation(page);
+    await installLocationSettingsFixture(page);
+    await page.goto('/ui/settings/main', { waitUntil: 'domcontentloaded' });
+
+    const nodeNameField = page.getByLabel('Node Name');
+    const initialNodeName = await nodeNameField.inputValue();
+    await nodeNameField.fill(`${initialNodeName} changed`);
+    await nodeNameField.blur();
+
+    const resetButton = page.getByRole('button', { name: 'Reset all changes' });
+    await expect(resetButton).toBeVisible();
+    await page.locator('#settings-tab-location').click();
+
+    const latitudeField = page.getByLabel('Latitude');
+    const longitudeField = page.getByLabel('Longitude');
+    const initialLatitude = await latitudeField.inputValue();
+    const initialLongitude = await longitudeField.inputValue();
+    const locationButton = page.getByRole('button', { name: 'Use browser location' });
+    await locationButton.click();
+    await expect(page.getByRole('button', { name: 'Locating...' })).toBeDisabled();
+
+    await resetButton.click();
+    await expect(locationButton).toBeEnabled();
+    await resolvePendingGeolocation(page);
+
+    await expect(latitudeField).toHaveValue(initialLatitude);
     await expect(longitudeField).toHaveValue(initialLongitude);
     await expect(page.getByText('Browser location detected.', { exact: true })).toBeHidden();
   });

--- a/internal/api/v2/settings_location_roundtrip_test.go
+++ b/internal/api/v2/settings_location_roundtrip_test.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// TestBrowserLocationSettingsRoundTrip exercises the PUT and subsequent GET
+// handlers used by the Settings UI. The browser feature sends the complete
+// settings form, including the explicit locationConfigured provenance flag.
+func TestBrowserLocationSettingsRoundTrip(t *testing.T) {
+	initial := getTestSettings(t)
+	desired := conf.CloneSettings(initial)
+	// Null Island is intentional: the backend compatibility fallback only marks
+	// non-zero coordinates as configured, so this proves the explicit frontend
+	// provenance flag itself survives the API round trip.
+	desired.BirdNET.Latitude = 0
+	desired.BirdNET.Longitude = 0
+	desired.BirdNET.LocationConfigured = true
+
+	body, err := json.Marshal(desired)
+	require.NoError(t, err)
+
+	e := echo.New()
+	controller := &Controller{
+		Core:                &apicore.Core{Echo: e},
+		controlChan:         make(chan string, testControlChanBuffer),
+		DisableSaveSettings: true,
+	}
+	controller.Settings.Store(initial)
+
+	putRequest := httptest.NewRequest(http.MethodPut, "/api/v2/settings", bytes.NewReader(body))
+	putRequest.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	putRecorder := httptest.NewRecorder()
+	require.NoError(t, controller.UpdateSettings(e.NewContext(putRequest, putRecorder)))
+	assert.Equal(t, http.StatusOK, putRecorder.Code)
+
+	getRequest := httptest.NewRequest(http.MethodGet, "/api/v2/settings", http.NoBody)
+	getRecorder := httptest.NewRecorder()
+	require.NoError(t, controller.GetAllSettings(e.NewContext(getRequest, getRecorder)))
+	assert.Equal(t, http.StatusOK, getRecorder.Code)
+
+	var reloaded conf.Settings
+	require.NoError(t, json.Unmarshal(getRecorder.Body.Bytes(), &reloaded))
+	assert.Zero(t, reloaded.BirdNET.Latitude)
+	assert.Zero(t, reloaded.BirdNET.Longitude)
+	assert.True(t, reloaded.BirdNET.LocationConfigured)
+}

--- a/internal/api/v2/settings_location_roundtrip_test.go
+++ b/internal/api/v2/settings_location_roundtrip_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
@@ -31,11 +30,7 @@ func TestBrowserLocationSettingsRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 
 	e := echo.New()
-	controller := &Controller{
-		Core:                &apicore.Core{Echo: e},
-		controlChan:         make(chan string, testControlChanBuffer),
-		DisableSaveSettings: true,
-	}
+	controller := getTestController(t, e)
 	controller.Settings.Store(initial)
 
 	putRequest := httptest.NewRequest(http.MethodPut, "/api/v2/settings", bytes.NewReader(body))


### PR DESCRIPTION
<!-- Thanks for contributing to BirdNET-Go! -->

## Description

Adds a **Use browser location** action to the existing Station Location settings. The action makes a single browser Geolocation API request and fills the existing latitude and longitude fields; the user still explicitly saves the settings through the normal workflow.

The interaction is deliberately non-destructive:

- unsupported, insecure, denied, unavailable, and timed-out requests leave the existing coordinates unchanged;
- newer manual input, map actions, reset actions, and saves take precedence over an older pending browser request, including when a map action rounds to the existing coordinate values;
- browser-reported accuracy is shown only while it still belongs to the current coordinate intent;
- no continuous tracking, hardware GPS integration, telemetry, or new external service is introduced.

The coordinate controls use a responsive three-column layout at large widths and retain the existing stacked layout on smaller screens. All new user-facing copy is translated across the 16 locale files.

## Related issue

None. This is a convenience action for the existing location settings.

## Preflight Status

Preflight completed for the feature branch based on `b422e50cc`. The branch was also confirmed conflict-free with the current upstream `main` (`e44549379` at the time of submission). Six independent passes covered reuse, correctness, code quality, internationalization, integration wiring, and regressions, with secondary-model cross-validation.

Findings addressed during review:

- invalidate pending geolocation for every newer coordinate intent, including raw input, same-rounded map actions, reset, and save;
- keep browser-originated updates distinct so accepted accuracy remains visible while stale accuracy is removed after newer user intent;
- use shared test utilities and a controlled settings fixture for deterministic component and rendered coverage;
- cover the real settings API PUT-to-GET round trip and explicit `locationConfigured` provenance.

Verification:

- `task lint`: pass, 0 issues;
- `npm run check:all`: pass; one pre-existing ESLint warning remains in untouched `ModelRegionSelector.test.ts`;
- `npm test -- --run`: pass, 196 files / 2,928 tests;
- `npm run i18n:validate:full`: pass; all locale files are synchronized and all used keys are valid;
- `TestBrowserLocationSettingsRoundTrip`: pass under `go test -race`;
- rendered Playwright coverage: pass, 10/10 scenarios across Chromium desktop and tablet viewports;
- manual browser smoke testing: pass;
- `go test -race ./...`: all packages pass except the pre-existing macOS FFmpeg `TestExtractClip_Filters/normalize_filter` failure, which was reproduced on a clean upstream worktree.

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/tphakala/birdnet-go/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`go test -race ./...` and/or `npm test`) — see the documented baseline exception above
- [x] Linters are clean (`golangci-lint run` and/or `npm run check:all`)
- [x] New exports and user-facing changes are documented — localized inline help documents the behavior; no public API or export was added

## Licensing

- [x] My contribution is licensed under **CC BY-NC-SA 4.0**, and I grant the maintainer the right to relicense it under any **OSI-approved open source license**, as described in the [Relicensing Grant](https://github.com/tphakala/birdnet-go/blob/main/CONTRIBUTING.md#relicensing-grant).

## Screenshots


<img width="48%" alt="Screenshot 2026-09-09 at 20 02 18" src="https://github.com/user-attachments/assets/08578076-7aad-454c-a6df-f4a72ba44ddc" /> <img width="48%" alt="Screenshot 2026-09-09 at 20 03 20" src="https://github.com/user-attachments/assets/81c2f8b1-9b3f-45a2-a0a7-9af4fa8c2517" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added a “Use browser location” option in station location settings.
- Shows detection progress, estimated accuracy, and clear messages for permission, browser, security, timeout, and availability issues.
- Supports the location workflow across available languages.

## Bug Fixes
- Prevents delayed location results from overwriting manually entered, map-selected, reset, or saved coordinates.
- Preserves configured coordinates, including zero-value coordinates, after saving and reloading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->