### PR TITLE
feat(settings): persist and deep-link settings tabs

### DIFF
--- a/frontend/src/lib/desktop/features/settings/components/DynamicThresholdTab.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/DynamicThresholdTab.svelte
@@ -34,6 +34,7 @@
   import { toastActions } from '$lib/stores/toast';
   import { handleBirdImageError } from '$lib/desktop/components/ui/image-utils.js';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
+  import { handleAppLinkClick } from '$lib/stores/navigation.svelte';
   import { formatDateTime } from '$lib/utils/formatters';
   import SettingsNote from './SettingsNote.svelte';
   import ResizableContainer from '$lib/desktop/components/ui/ResizableContainer.svelte';
@@ -230,6 +231,13 @@
 <div class="space-y-4">
   <!-- Description -->
   <p class="text-sm text-muted">{t('settings.species.dynamicThreshold.description')}</p>
+  <a
+    href={buildAppUrl('/ui/settings/analysis?tab=settings')}
+    onclick={handleAppLinkClick}
+    class="inline-block text-sm text-primary underline"
+  >
+    {t('settings.sections.analysis')} → {t('analysis.tabs.settings')}
+  </a>
 
   <!-- Stats Cards -->
   {#if stats}

--- a/frontend/src/lib/desktop/features/settings/components/DynamicThresholdTab.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/DynamicThresholdTab.svelte
@@ -34,6 +34,7 @@
   import { toastActions } from '$lib/stores/toast';
   import { handleBirdImageError } from '$lib/desktop/components/ui/image-utils.js';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
+  import { SETTINGS_ROUTES } from '$lib/utils/settingsRoutes';
   import { handleAppLinkClick } from '$lib/stores/navigation.svelte';
   import { formatDateTime } from '$lib/utils/formatters';
   import SettingsNote from './SettingsNote.svelte';
@@ -232,7 +233,7 @@
   <!-- Description -->
   <p class="text-sm text-muted">{t('settings.species.dynamicThreshold.description')}</p>
   <a
-    href={buildAppUrl('/ui/settings/analysis?tab=settings')}
+    href={buildAppUrl(SETTINGS_ROUTES.analysisSettings)}
     onclick={handleAppLinkClick}
     class="inline-block text-sm text-primary underline"
   >

--- a/frontend/src/lib/desktop/features/settings/components/ModelRegionSelector.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/ModelRegionSelector.svelte
@@ -30,6 +30,7 @@
   import { birdnetSettings, settingsActions } from '$lib/stores/settings';
   import { handleAppLinkClick } from '$lib/stores/navigation.svelte';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
+  import { SETTINGS_ROUTES } from '$lib/utils/settingsRoutes';
   import type { ModelRegionsResponse, RegionOption } from '$lib/types/models';
   import RegionCard from './RegionCard.svelte';
 
@@ -363,7 +364,7 @@
             {t(AUTO_WHY[autoWhy.state], autoWhy.args)}
             {#if autoWhy.state === 'noLocation'}
               <a
-                href={buildAppUrl('/ui/settings/main?tab=location')}
+                href={buildAppUrl(SETTINGS_ROUTES.mainLocation)}
                 onclick={handleAppLinkClick}
                 class="block mt-2 text-primary underline"
               >

--- a/frontend/src/lib/desktop/features/settings/components/ModelRegionSelector.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/ModelRegionSelector.svelte
@@ -28,6 +28,8 @@
   } from '$lib/utils/variantSelection';
   import { loggers } from '$lib/utils/logger';
   import { birdnetSettings, settingsActions } from '$lib/stores/settings';
+  import { handleAppLinkClick } from '$lib/stores/navigation.svelte';
+  import { buildAppUrl } from '$lib/utils/urlHelpers';
   import type { ModelRegionsResponse, RegionOption } from '$lib/types/models';
   import RegionCard from './RegionCard.svelte';
 
@@ -359,6 +361,15 @@
             class="text-xs {autoWhy.warn ? 'text-warning' : 'text-base-content/70'}"
           >
             {t(AUTO_WHY[autoWhy.state], autoWhy.args)}
+            {#if autoWhy.state === 'noLocation'}
+              <a
+                href={buildAppUrl('/ui/settings/main?tab=location')}
+                onclick={handleAppLinkClick}
+                class="block mt-2 text-primary underline"
+              >
+                {t('settings.species.activeSpecies.locationNotConfigured.action')}
+              </a>
+            {/if}
           </div>
           {#if autoWhy.pins.length > 0}
             <div class="flex flex-wrap gap-2">

--- a/frontend/src/lib/desktop/features/settings/components/SettingsTabs.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/SettingsTabs.svelte
@@ -16,6 +16,8 @@
   Props:
   - tabs: Array of tab definitions
   - activeTab: Currently active tab ID (bindable)
+  - queryParam: URL parameter for this tab group (default: tab)
+  - defaultTab: Fallback when the URL has no valid tab (defaults to initial activeTab)
   - onTabChange: Callback when tab changes
   - showActions: Whether to show the save/reset actions bar (default: true)
   - class: Additional CSS classes
@@ -25,6 +27,8 @@
 <script lang="ts">
   import { cn } from '$lib/utils/cn';
   import type { Snippet, Component } from 'svelte';
+  import { untrack } from 'svelte';
+  import { navigation } from '$lib/stores/navigation.svelte';
   import type { IconProps } from '@lucide/svelte';
   import { t } from '$lib/i18n';
   import SettingsPageActions from './SettingsPageActions.svelte';
@@ -40,6 +44,8 @@
   interface Props {
     tabs: TabDefinition[];
     activeTab: string;
+    queryParam?: string;
+    defaultTab?: string;
     onTabChange?: (_tabId: string) => void;
     showActions?: boolean;
     class?: string;
@@ -48,14 +54,37 @@
   let {
     tabs,
     activeTab = $bindable(),
+    queryParam = 'tab',
+    defaultTab,
     onTabChange,
     showActions = true,
     class: className,
   }: Props = $props();
 
-  // Handle tab selection
+  // Capture the page default once, so a missing URL value never reuses the
+  // previous history entry's selection. Audio retains its legacy fallback.
+  const initialTab = untrack(() => defaultTab ?? activeTab);
+  const selectedTab = $derived.by(() => {
+    const requested = new URLSearchParams(navigation.currentSearch).get(queryParam);
+    return (
+      tabs.find(tab => tab.id === requested)?.id ??
+      tabs.find(tab => tab.id === initialTab)?.id ??
+      tabs[0]?.id ??
+      ''
+    );
+  });
+
+  // Parents use the binding for tab-specific work (e.g. mounting the location map).
+  $effect(() => {
+    activeTab = selectedTab;
+  });
+
+  // Only explicit selection writes history; restoring a URL must not push entries.
   function selectTab(tabId: string) {
-    activeTab = tabId;
+    const url = new URL(window.location.href);
+    if (url.searchParams.get(queryParam) === tabId) return;
+    url.searchParams.set(queryParam, tabId);
+    navigation.navigate(url.pathname + url.search + url.hash);
     onTabChange?.(tabId);
   }
 
@@ -121,11 +150,12 @@
     aria-label={t('settings.tabs.navigation')}
   >
     {#each tabs as tab, index (tab.id)}
-      {@const isActive = activeTab === tab.id}
+      {@const isActive = selectedTab === tab.id}
       <button
         id="settings-tab-{tab.id}"
         type="button"
         role="tab"
+        aria-label={tab.label}
         class={cn(
           'tab gap-2 transition-all duration-200 font-medium -mb-px',
           'hover:text-[color:var(--color-primary)]',
@@ -163,7 +193,7 @@
 
   <!-- Tab Panels -->
   {#each tabs as tab (tab.id)}
-    {@const isActive = activeTab === tab.id}
+    {@const isActive = selectedTab === tab.id}
     <div
       id="settings-tabpanel-{tab.id}"
       role="tabpanel"

--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.gallery.test.ts
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.gallery.test.ts
@@ -86,6 +86,18 @@ import * as modelsApi from '$lib/utils/modelsApi';
 import { settingsStore } from '$lib/stores/settings';
 import { toastActions } from '$lib/stores/toast';
 import { t } from '$lib/i18n';
+import { navigation } from '$lib/stores/navigation.svelte';
+
+beforeEach(() => {
+  // Use jsdom's real Location so pushState updates the URL used by nested tabs.
+  // The shared setup substitutes a static location object for navigation spies.
+  Object.defineProperty(window, 'location', {
+    value: document.location,
+    writable: true,
+    configurable: true,
+  });
+  navigation.redirect('/ui/settings/analysis');
+});
 
 // A network-shaped download failure (matches isNetworkDownloadError's real regex).
 const NETWORK_ERROR = 'HTTP request failed for https://huggingface.co/model: connection refused';
@@ -147,6 +159,32 @@ describe('AnalysisSettingsPage model gallery error handling', () => {
         onError(NETWORK_ERROR);
         return () => {};
       }
+    );
+  });
+
+  it('renders a nested deep link and reacts to query-only router navigation', async () => {
+    navigation.redirect('/ui/settings/analysis?tab=models&modelTab=available');
+    render(AnalysisSettingsPage);
+    await screen.findByRole('button', { name: installButtonName });
+    expect(screen.getByRole('tab', { name: /analysis\.gallery\.tabs\.available/ })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+
+    navigation.navigate('/ui/settings/analysis?tab=models');
+    await waitFor(() =>
+      expect(
+        screen.getByRole('tab', { name: /analysis\.gallery\.tabs\.installed/ })
+      ).toHaveAttribute('aria-selected', 'true')
+    );
+    navigation.navigate('/ui/settings/analysis?tab=models&modelTab=available');
+    await screen.findByRole('button', { name: installButtonName });
+    navigation.navigate('/ui/settings/analysis?tab=removed&modelTab=available');
+    await waitFor(() =>
+      expect(screen.getByRole('tab', { name: /analysis\.tabs\.settings/ })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      )
     );
   });
 

--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
@@ -2098,7 +2098,13 @@
         </div>
       {/if}
 
-      <SettingsTabs tabs={galleryTabs} bind:activeTab={galleryTab} showActions={false} />
+      <SettingsTabs
+        tabs={galleryTabs}
+        bind:activeTab={galleryTab}
+        queryParam="modelTab"
+        defaultTab="installed"
+        showActions={false}
+      />
     </SettingsSection>
 
     <SettingsSection

--- a/frontend/src/lib/desktop/features/settings/pages/SecuritySettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SecuritySettingsPage.svelte
@@ -44,6 +44,8 @@
     type OAuthProviderConfig,
   } from '$lib/stores/settings';
   import { fetchRestartStatus } from '$lib/stores/restart.svelte';
+  import { handleAppLinkClick } from '$lib/stores/navigation.svelte';
+  import { buildAppUrl } from '$lib/utils/urlHelpers';
   import { hasSettingsChanged } from '$lib/utils/settingsChanges';
   import { settingsAPI, type TLSCertificateInfo } from '$lib/utils/settingsApi';
   import { toastActions } from '$lib/stores/toast';
@@ -1042,6 +1044,13 @@
               <div>
                 <p class="font-medium">{t('settings.security.oauth.hostRequiredWarning')}</p>
                 <p class="text-xs mt-1">{t('settings.security.oauth.hostRequiredWarningDescription')}</p>
+                <a
+                  href={buildAppUrl('/ui/settings/security?tab=server')}
+                  onclick={handleAppLinkClick}
+                  class="inline-block mt-2 text-sm text-primary underline"
+                >
+                  {t('settings.security.serverConfiguration.title')}
+                </a>
               </div>
             {/snippet}
           </ErrorAlert>

--- a/frontend/src/lib/desktop/features/settings/pages/SecuritySettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SecuritySettingsPage.svelte
@@ -46,6 +46,7 @@
   import { fetchRestartStatus } from '$lib/stores/restart.svelte';
   import { handleAppLinkClick } from '$lib/stores/navigation.svelte';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
+  import { SETTINGS_ROUTES } from '$lib/utils/settingsRoutes';
   import { hasSettingsChanged } from '$lib/utils/settingsChanges';
   import { settingsAPI, type TLSCertificateInfo } from '$lib/utils/settingsApi';
   import { toastActions } from '$lib/stores/toast';
@@ -1045,7 +1046,7 @@
                 <p class="font-medium">{t('settings.security.oauth.hostRequiredWarning')}</p>
                 <p class="text-xs mt-1">{t('settings.security.oauth.hostRequiredWarningDescription')}</p>
                 <a
-                  href={buildAppUrl('/ui/settings/security?tab=server')}
+                  href={buildAppUrl(SETTINGS_ROUTES.securityServer)}
                   onclick={handleAppLinkClick}
                   class="inline-block mt-2 text-sm text-primary underline"
                 >

--- a/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
@@ -55,6 +55,7 @@
   import { loggers } from '$lib/utils/logger';
   import { safeGet } from '$lib/utils/security';
   import { api } from '$lib/utils/api';
+  import { buildAppUrl } from '$lib/utils/urlHelpers';
   import { getLocalDateString } from '$lib/utils/date';
   import {
     buildSpeciesNameMaps,
@@ -1433,7 +1434,7 @@
                   'Set your location in Main Settings to see species available in your area. The range filter uses your location to determine which species are likely to be found nearby.'}
               </p>
               <a
-                href="/ui/settings/main"
+                href={buildAppUrl('/ui/settings/main?tab=location')}
                 class="inline-flex items-center justify-center h-8 px-3 text-sm font-medium rounded-lg bg-[var(--color-warning)] text-[var(--color-warning-content)] hover:bg-[var(--color-warning-hover)] transition-colors mt-3"
               >
                 {t('settings.species.activeSpecies.locationNotConfigured.action') ||

--- a/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
@@ -56,6 +56,7 @@
   import { safeGet } from '$lib/utils/security';
   import { api } from '$lib/utils/api';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
+  import { handleAppLinkClick } from '$lib/stores/navigation.svelte';
   import { getLocalDateString } from '$lib/utils/date';
   import {
     buildSpeciesNameMaps,
@@ -1435,6 +1436,7 @@
               </p>
               <a
                 href={buildAppUrl('/ui/settings/main?tab=location')}
+                onclick={handleAppLinkClick}
                 class="inline-flex items-center justify-center h-8 px-3 text-sm font-medium rounded-lg bg-[var(--color-warning)] text-[var(--color-warning-content)] hover:bg-[var(--color-warning-hover)] transition-colors mt-3"
               >
                 {t('settings.species.activeSpecies.locationNotConfigured.action') ||

--- a/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
@@ -56,6 +56,7 @@
   import { safeGet } from '$lib/utils/security';
   import { api } from '$lib/utils/api';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
+  import { SETTINGS_ROUTES } from '$lib/utils/settingsRoutes';
   import { handleAppLinkClick } from '$lib/stores/navigation.svelte';
   import { getLocalDateString } from '$lib/utils/date';
   import {
@@ -1435,7 +1436,7 @@
                   'Set your location in Main Settings to see species available in your area. The range filter uses your location to determine which species are likely to be found nearby.'}
               </p>
               <a
-                href={buildAppUrl('/ui/settings/main?tab=location')}
+                href={buildAppUrl(SETTINGS_ROUTES.mainLocation)}
                 onclick={handleAppLinkClick}
                 class="inline-flex items-center justify-center h-8 px-3 text-sm font-medium rounded-lg bg-[var(--color-warning)] text-[var(--color-warning-content)] hover:bg-[var(--color-warning-hover)] transition-colors mt-3"
               >

--- a/frontend/src/lib/desktop/features/system/TerminalPage.svelte
+++ b/frontend/src/lib/desktop/features/system/TerminalPage.svelte
@@ -18,6 +18,7 @@
   import { FitAddon } from '@xterm/addon-fit';
   import { t } from '$lib/i18n';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
+  import { handleAppLinkClick } from '$lib/stores/navigation.svelte';
   import { copyToClipboard, COPY_FEEDBACK_TIMEOUT_MS } from '$lib/utils/clipboard';
   import { settingsStore } from '$lib/stores/settings';
   import {
@@ -731,11 +732,18 @@
 <div class="flex flex-col h-full min-h-0">
   {#if !isEnabled}
     <!-- Disabled state -->
-    <div class="flex flex-col items-center justify-center h-full gap-4 opacity-60">
-      <WifiOff class="size-12" />
+    <div class="flex flex-col items-center justify-center h-full gap-4">
+      <WifiOff class="size-12 opacity-60" />
       <div class="text-center">
-        <p class="text-lg font-medium">{t('terminal.disabled')}</p>
-        <p class="text-sm mt-1">{t('terminal.disabledDescription')}</p>
+        <p class="text-lg font-medium opacity-60">{t('terminal.disabled')}</p>
+        <p class="text-sm mt-1 opacity-60">{t('terminal.disabledDescription')}</p>
+        <a
+          href={buildAppUrl('/ui/settings/security?tab=terminal')}
+          onclick={handleAppLinkClick}
+          class="inline-block mt-3 text-sm text-primary underline"
+        >
+          {t('settings.sections.security')} → {t('settings.security.terminal.title')}
+        </a>
       </div>
     </div>
   {:else if isDetached}

--- a/frontend/src/lib/desktop/features/system/TerminalPage.svelte
+++ b/frontend/src/lib/desktop/features/system/TerminalPage.svelte
@@ -18,6 +18,7 @@
   import { FitAddon } from '@xterm/addon-fit';
   import { t } from '$lib/i18n';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
+  import { SETTINGS_ROUTES } from '$lib/utils/settingsRoutes';
   import { handleAppLinkClick } from '$lib/stores/navigation.svelte';
   import { copyToClipboard, COPY_FEEDBACK_TIMEOUT_MS } from '$lib/utils/clipboard';
   import { settingsStore } from '$lib/stores/settings';
@@ -738,7 +739,7 @@
         <p class="text-lg font-medium opacity-60">{t('terminal.disabled')}</p>
         <p class="text-sm mt-1 opacity-60">{t('terminal.disabledDescription')}</p>
         <a
-          href={buildAppUrl('/ui/settings/security?tab=terminal')}
+          href={buildAppUrl(SETTINGS_ROUTES.securityTerminal)}
           onclick={handleAppLinkClick}
           class="inline-block mt-3 text-sm text-primary underline"
         >

--- a/frontend/src/lib/stores/navigation.link.test.ts
+++ b/frontend/src/lib/stores/navigation.link.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleAppLinkClick, navigation } from './navigation.svelte';
+import { resetBasePath, setBasePath } from '$lib/utils/urlHelpers';
+
+describe('application links', () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    // Shared test setup stubs window.location; use JSDOM's history-aware location.
+    Object.defineProperty(window, 'location', { value: document.location, configurable: true });
+    setBasePath('');
+    navigation.redirect('/ui/settings/security?tab=oauth');
+    vi.spyOn(navigation, 'navigate');
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+    resetBasePath();
+    Object.defineProperty(window, 'location', { value: originalLocation, configurable: true });
+  });
+
+  function clickLink(
+    href: string,
+    options: MouseEventInit = {},
+    attributes: Record<string, string> = {},
+    alreadyPrevented = false
+  ) {
+    const anchor = document.createElement('a');
+    anchor.href = href;
+    for (const [name, value] of Object.entries(attributes)) anchor.setAttribute(name, value);
+    anchor.addEventListener('click', handleAppLinkClick);
+    let intercepted = false;
+    anchor.addEventListener('click', event => {
+      intercepted = event.defaultPrevented;
+      // JSDOM does not implement native navigation.
+      event.preventDefault();
+    });
+    document.body.append(anchor);
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true, ...options });
+    if (alreadyPrevented) event.preventDefault();
+    anchor.dispatchEvent(event);
+    return intercepted;
+  }
+
+  it('routes same-page query and fragment changes without reloading', () => {
+    expect(clickLink('/ui/settings/security?tab=server#configuration')).toBe(true);
+    expect(navigation.navigate).toHaveBeenCalledWith(
+      '/ui/settings/security?tab=server#configuration'
+    );
+    expect(navigation.currentPath).toBe('/ui/settings/security');
+    expect(navigation.currentSearch).toBe('?tab=server');
+    expect(window.location.hash).toBe('#configuration');
+  });
+
+  it('preserves reverse-proxy prefixes exactly once', () => {
+    setBasePath('/birdnet');
+    expect(clickLink('/birdnet/ui/settings/main?tab=location')).toBe(true);
+    expect(navigation.currentPath).toBe('/ui/settings/main');
+    expect(window.location.pathname).toBe('/birdnet/ui/settings/main');
+    expect(window.location.search).toBe('?tab=location');
+  });
+
+  it.each<MouseEventInit>([
+    { ctrlKey: true },
+    { metaKey: true },
+    { shiftKey: true },
+    { altKey: true },
+    { button: 1 },
+  ])('preserves native behavior for modified clicks: %j', options => {
+    expect(clickLink('/ui/settings/main?tab=location', options)).toBe(false);
+    expect(navigation.navigate).not.toHaveBeenCalled();
+  });
+
+  it.each<{ href: string; attributes: Record<string, string> }>([
+    { href: '/ui/settings/main?tab=location', attributes: { target: '_blank' } },
+    { href: '/ui/settings/main?tab=location', attributes: { download: '' } },
+    { href: 'https://example.org/ui/settings/main?tab=location', attributes: {} },
+    { href: '/api/v2/settings', attributes: {} },
+  ])('leaves explicit targets and non-app URLs native: %j', ({ href, attributes }) => {
+    expect(clickLink(href, {}, attributes)).toBe(false);
+    expect(navigation.navigate).not.toHaveBeenCalled();
+  });
+
+  it('respects a previously prevented event', () => {
+    clickLink('/ui/settings/main?tab=location', {}, {}, true);
+    expect(navigation.navigate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/stores/navigation.svelte.ts
+++ b/frontend/src/lib/stores/navigation.svelte.ts
@@ -208,3 +208,32 @@ export function createNavigation(): NavigationStore {
 
 // Singleton instance
 export const navigation = createNavigation();
+
+/**
+ * Navigate an application anchor without reloading in-memory forms.
+ * Modified clicks, downloads and explicit browsing targets retain native behavior.
+ */
+export function handleAppLinkClick(event: MouseEvent): void {
+  const anchor = event.currentTarget;
+  if (
+    event.defaultPrevented ||
+    event.button !== 0 ||
+    event.metaKey ||
+    event.ctrlKey ||
+    event.shiftKey ||
+    event.altKey ||
+    !(anchor instanceof window.HTMLAnchorElement) ||
+    (anchor.target && anchor.target !== '_self') ||
+    anchor.hasAttribute('download')
+  ) {
+    return;
+  }
+
+  const url = new URL(anchor.href);
+  if (url.origin !== window.location.origin || !UI_PATH_RE.test(stripProxyPrefix(url.pathname))) {
+    return;
+  }
+
+  event.preventDefault();
+  navigation.navigate(url.pathname + url.search + url.hash);
+}

--- a/frontend/src/lib/stores/navigation.svelte.ts
+++ b/frontend/src/lib/stores/navigation.svelte.ts
@@ -26,6 +26,8 @@ const UI_ROOT_RE = /^\/ui\/?$/;
  */
 export interface NavigationStore {
   currentPath: string;
+  /** Reactive query string, including '?', independent of page routing. */
+  currentSearch: string;
   navigate: (url: string) => void;
   redirect: (url: string) => void;
   handlePopState: () => void;
@@ -78,6 +80,7 @@ function normalizeUiPath(url: string): string {
  * for routing, while using proxy-aware URLs for the browser address bar.
  */
 export function createNavigation(): NavigationStore {
+  let currentSearch = $state(typeof window === 'undefined' ? '' : window.location.search);
   let currentPath = $state(
     (() => {
       if (typeof window === 'undefined') return DEFAULT_PATH;
@@ -89,7 +92,11 @@ export function createNavigation(): NavigationStore {
       // Update URL if normalization changed the path
       // Use buildAppUrl to maintain proxy prefix in browser
       if (path !== pathname) {
-        window.history.replaceState({}, '', buildAppUrl(path));
+        window.history.replaceState(
+          {},
+          '',
+          buildAppUrl(path) + currentSearch + window.location.hash
+        );
       }
       return path;
     })()
@@ -98,8 +105,8 @@ export function createNavigation(): NavigationStore {
   /**
    * Apply a new URL to internal routing state and the browser address bar.
    *
-   * Query parameters and hash fragments are preserved in the browser URL but NOT
-   * stored in currentPath. This matches the behavior on page reload where
+   * Query parameters are exposed separately as currentSearch; query and hash
+   * remain outside currentPath. This matches the behavior on page reload where
    * window.location.pathname (which doesn't include query string) is used for
    * routing.
    *
@@ -109,7 +116,7 @@ export function createNavigation(): NavigationStore {
   function applyUrl(url: string, mode: 'push' | 'replace'): void {
     // Separate pathname from query string and hash fragment
     // Only pathname goes to currentPath (matches window.location.pathname behavior)
-    // Query and hash are preserved in browser URL only
+    // Query state is separate from the route; the browser retains the full suffix.
     let pathname: string;
     let suffix: string; // query string + hash fragment
 
@@ -139,6 +146,7 @@ export function createNavigation(): NavigationStore {
     // Normalize only the pathname for internal routing state
     const normalizedPath = normalizeUiPath(pathname);
     currentPath = normalizedPath;
+    currentSearch = suffix.startsWith('?') ? suffix.split('#')[0] : '';
 
     if (typeof window !== 'undefined') {
       // Build proxy-aware URL for the browser address bar (includes query/hash)
@@ -182,11 +190,15 @@ export function createNavigation(): NavigationStore {
     // Get pathname and strip proxy prefix for internal routing
     const pathname = stripProxyPrefix(window.location.pathname);
     currentPath = normalizeUiPath(pathname);
+    currentSearch = window.location.search;
   }
 
   return {
     get currentPath() {
       return currentPath;
+    },
+    get currentSearch() {
+      return currentSearch;
     },
     navigate,
     redirect,

--- a/frontend/src/lib/stores/navigation.test.ts
+++ b/frontend/src/lib/stores/navigation.test.ts
@@ -26,7 +26,7 @@ describe('navigation store', () => {
     vi.spyOn(window.history, 'replaceState').mockImplementation(() => {});
     // Reset location mock
     Object.defineProperty(window, 'location', {
-      value: { pathname: '/ui/dashboard' },
+      value: { pathname: '/ui/dashboard', search: '', hash: '' },
       writable: true,
       configurable: true,
     });
@@ -42,6 +42,16 @@ describe('navigation store', () => {
   });
 
   describe('navigate', () => {
+    it('exposes same-page query changes independently of the route', () => {
+      const nav = createNavigation();
+      nav.navigate('/ui/settings/main?tab=general');
+      nav.navigate('/ui/settings/main?tab=location&source=species#map');
+      expect(nav.currentPath).toBe('/ui/settings/main');
+      expect(nav.currentSearch).toBe('?tab=location&source=species');
+      nav.navigate('/ui/settings/main#map');
+      expect(nav.currentSearch).toBe('');
+    });
+
     it('should update currentPath', () => {
       const nav = createNavigation();
       nav.navigate('/ui/settings');
@@ -148,6 +158,14 @@ describe('navigation store', () => {
   });
 
   describe('redirect', () => {
+    it('updates reactive search on query-only redirects', () => {
+      const nav = createNavigation();
+      nav.navigate('/ui/settings/main?tab=general');
+      nav.redirect('/ui/settings/main?tab=location#map');
+      expect(nav.currentSearch).toBe('?tab=location');
+      expect(nav.currentPath).toBe('/ui/settings/main');
+    });
+
     it('should update currentPath and replace (not push) the history entry', () => {
       const nav = createNavigation();
       nav.redirect('/ui/analytics?tab=patterns');
@@ -170,10 +188,26 @@ describe('navigation store', () => {
   });
 
   describe('handlePopState', () => {
+    it('restores query-only history entries and bare URLs', () => {
+      const nav = createNavigation();
+      nav.navigate('/ui/settings/main?tab=location');
+      Object.defineProperty(window, 'location', {
+        value: { pathname: '/ui/settings/main', search: '?tab=database', hash: '#details' },
+        writable: true,
+        configurable: true,
+      });
+      nav.handlePopState();
+      expect(nav.currentPath).toBe('/ui/settings/main');
+      expect(nav.currentSearch).toBe('?tab=database');
+      window.location.search = '';
+      nav.handlePopState();
+      expect(nav.currentSearch).toBe('');
+    });
+
     it('should update currentPath from window.location', () => {
       const nav = createNavigation();
       Object.defineProperty(window, 'location', {
-        value: { pathname: '/ui/about' },
+        value: { pathname: '/ui/about', search: '', hash: '' },
         writable: true,
         configurable: true,
       });
@@ -184,7 +218,7 @@ describe('navigation store', () => {
     it('should normalize root path on popstate', () => {
       const nav = createNavigation();
       Object.defineProperty(window, 'location', {
-        value: { pathname: '/' },
+        value: { pathname: '/', search: '', hash: '' },
         writable: true,
         configurable: true,
       });
@@ -195,7 +229,7 @@ describe('navigation store', () => {
     it('should handle /ui path on popstate', () => {
       const nav = createNavigation();
       Object.defineProperty(window, 'location', {
-        value: { pathname: '/ui' },
+        value: { pathname: '/ui', search: '', hash: '' },
         writable: true,
         configurable: true,
       });
@@ -205,9 +239,25 @@ describe('navigation store', () => {
   });
 
   describe('initial state', () => {
+    it('restores the query on load and preserves suffixes when normalizing', () => {
+      Object.defineProperty(window, 'location', {
+        value: { pathname: '/settings/main', search: '?tab=location', hash: '#map' },
+        writable: true,
+        configurable: true,
+      });
+      const nav = createNavigation();
+      expect(nav.currentPath).toBe('/ui/settings/main');
+      expect(nav.currentSearch).toBe('?tab=location');
+      expect(window.history.replaceState).toHaveBeenCalledWith(
+        {},
+        '',
+        '/ui/settings/main?tab=location#map'
+      );
+    });
+
     it('should initialize with normalized path', () => {
       Object.defineProperty(window, 'location', {
-        value: { pathname: '/ui/dashboard' },
+        value: { pathname: '/ui/dashboard', search: '', hash: '' },
         writable: true,
         configurable: true,
       });
@@ -217,7 +267,7 @@ describe('navigation store', () => {
 
     it('should normalize root path on initialization', () => {
       Object.defineProperty(window, 'location', {
-        value: { pathname: '/' },
+        value: { pathname: '/', search: '', hash: '' },
         writable: true,
         configurable: true,
       });
@@ -253,7 +303,7 @@ describe('navigation store with proxy prefix', () => {
     vi.mocked(buildAppUrl).mockImplementation((path: string) => `/proxy${path}`);
 
     Object.defineProperty(window, 'location', {
-      value: { pathname: '/proxy/ui/dashboard' },
+      value: { pathname: '/proxy/ui/dashboard', search: '', hash: '' },
       writable: true,
       configurable: true,
     });
@@ -272,7 +322,7 @@ describe('navigation store with proxy prefix', () => {
     vi.mocked(buildAppUrl).mockImplementation((path: string) => `/proxy${path}`);
 
     Object.defineProperty(window, 'location', {
-      value: { pathname: '/proxy/ui/dashboard' },
+      value: { pathname: '/proxy/ui/dashboard', search: '', hash: '' },
       writable: true,
       configurable: true,
     });

--- a/frontend/src/lib/utils/settingsRoutes.ts
+++ b/frontend/src/lib/utils/settingsRoutes.ts
@@ -1,0 +1,7 @@
+/** Settings destinations; resolve the deployment prefix with buildAppUrl at each use. */
+export const SETTINGS_ROUTES = {
+  mainLocation: '/ui/settings/main?tab=location',
+  analysisSettings: '/ui/settings/analysis?tab=settings',
+  securityServer: '/ui/settings/security?tab=server',
+  securityTerminal: '/ui/settings/security?tab=terminal',
+} as const;

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -4355,7 +4355,7 @@
       "dynamicThreshold": {
         "tabLabel": "Naučené",
         "title": "Naučené prahy",
-        "description": "Tato stránka zobrazuje runtime data dynamického prahu. Pokud je povolen v Hlavních nastaveních → Detekce, prahy se automaticky upravují na základě více detekcí s vysokou spolehlivostí. Druhy zde zobrazené se považují za existující na tomto místě.",
+        "description": "Tato stránka zobrazuje runtime data dynamického prahu. Pokud je povolen, prahy se automaticky upravují na základě více detekcí s vysokou spolehlivostí. Druhy zde zobrazené se považují za existující na tomto místě.",
         "stats": {
           "active": "Aktivní",
           "atMinimum": "Na minimu",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -4355,7 +4355,7 @@
       "dynamicThreshold": {
         "tabLabel": "Indlærte",
         "title": "Indlærte tærskler",
-        "description": "Denne side viser kørselstidsdata for dynamiske tærskler. Når det er aktiveret under Hovedindstillinger → Registrering, justeres tærskler automatisk ved flere registreringer med høj tillid. Arter vist her antages at forekomme på denne placering.",
+        "description": "Denne side viser kørselstidsdata for dynamiske tærskler. Når det er aktiveret, justeres tærskler automatisk ved flere registreringer med høj tillid. Arter vist her antages at forekomme på denne placering.",
         "stats": {
           "active": "Aktive",
           "atMinimum": "Ved minimum",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -4355,7 +4355,7 @@
       "dynamicThreshold": {
         "tabLabel": "Gelernt",
         "title": "Gelernte Schwellenwerte",
-        "description": "Diese Seite zeigt dynamische Schwellenwert-Laufzeitdaten. Wenn in Haupteinstellungen → Erkennung aktiviert, werden Schwellenwerte automatisch durch mehrere hochkonfidente Erkennungen angepasst. Hier gezeigte Arten werden an diesem Standort als vorhanden angenommen.",
+        "description": "Diese Seite zeigt dynamische Schwellenwert-Laufzeitdaten. Wenn aktiviert, werden Schwellenwerte automatisch durch mehrere hochkonfidente Erkennungen angepasst. Hier gezeigte Arten werden an diesem Standort als vorhanden angenommen.",
         "stats": {
           "active": "Aktiv",
           "atMinimum": "Am Minimum",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -4355,7 +4355,7 @@
       "dynamicThreshold": {
         "tabLabel": "Learned",
         "title": "Learned Thresholds",
-        "description": "This page shows Dynamic Threshold runtime data. When enabled in Main Settings → Detection, thresholds are automatically adjusted by multiple high-confidence detections. Species shown here are assumed to exist at this location.",
+        "description": "This page shows Dynamic Threshold runtime data. When enabled, thresholds are automatically adjusted by multiple high-confidence detections. Species shown here are assumed to exist at this location.",
         "stats": {
           "active": "Active",
           "atMinimum": "At Minimum",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -4355,7 +4355,7 @@
       "dynamicThreshold": {
         "tabLabel": "Aprendido",
         "title": "Umbrales aprendidos",
-        "description": "Esta página muestra datos de umbrales dinámicos en tiempo de ejecución. Cuando está habilitado en Ajustes principales → Detección, los umbrales se ajustan automáticamente mediante múltiples detecciones de alta confianza. Las especies mostradas aquí se asumen presentes en esta ubicación.",
+        "description": "Esta página muestra datos de umbrales dinámicos en tiempo de ejecución. Cuando está habilitado, los umbrales se ajustan automáticamente mediante múltiples detecciones de alta confianza. Las especies mostradas aquí se asumen presentes en esta ubicación.",
         "stats": {
           "active": "Activos",
           "atMinimum": "En mínimo",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -4355,7 +4355,7 @@
       "dynamicThreshold": {
         "tabLabel": "Opitut",
         "title": "Opitut kynnysarvot",
-        "description": "Tämä sivu näyttää dynaamisten kynnysarvojen suoritusaikaiset tiedot. Kun käytössä kohdassa Pääasetukset → Tunnistus, kynnysarvoja säädetään automaattisesti useiden korkean luottamuksen havaintojen perusteella. Täällä näkyvien lajien oletetaan esiintyvän tässä sijainnissa.",
+        "description": "Tämä sivu näyttää dynaamisten kynnysarvojen suoritusaikaiset tiedot. Kun käytössä, kynnysarvoja säädetään automaattisesti useiden korkean luottamuksen havaintojen perusteella. Täällä näkyvien lajien oletetaan esiintyvän tässä sijainnissa.",
         "stats": {
           "active": "Aktiiviset",
           "atMinimum": "Minimissä",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -4355,7 +4355,7 @@
       "dynamicThreshold": {
         "tabLabel": "Appris",
         "title": "Seuils appris",
-        "description": "Cette page affiche les données d'exécution des seuils dynamiques. Lorsque activés dans Paramètres principaux → Détection, les seuils sont automatiquement ajustés par plusieurs détections à haute confiance. Les espèces affichées ici sont supposées exister à cet emplacement.",
+        "description": "Cette page affiche les données d'exécution des seuils dynamiques. Lorsque activés, les seuils sont automatiquement ajustés par plusieurs détections à haute confiance. Les espèces affichées ici sont supposées exister à cet emplacement.",
         "stats": {
           "active": "Actifs",
           "atMinimum": "Au minimum",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -4355,7 +4355,7 @@
       "dynamicThreshold": {
         "tabLabel": "Tanult",
         "title": "Tanult küszöbértékek",
-        "description": "Ez az oldal a Dinamikus küszöbérték futásidejű adatait mutatja. Ha engedélyezve van a Fő beállítások → Detektálás menüpontban, a küszöbértékek több magas megbízhatóságú detektálás alapján automatikusan kerülnek beállításra. Az itt látható fajok feltételezhetően léteznek ezen a helyszínen.",
+        "description": "Ez az oldal a Dinamikus küszöbérték futásidejű adatait mutatja. Ha engedélyezve van, a küszöbértékek több magas megbízhatóságú detektálás alapján automatikusan kerülnek beállításra. Az itt látható fajok feltételezhetően léteznek ezen a helyszínen.",
         "stats": {
           "active": "Aktív",
           "atMinimum": "Minimumon",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -4355,7 +4355,7 @@
       "dynamicThreshold": {
         "tabLabel": "Appreso",
         "title": "Soglie Apprese",
-        "description": "Questa pagina mostra dati runtime Soglia Dinamica. Quando abilitata in Impostazioni Principali → Rilevamento, soglie vengono regolate automaticamente da rilevamenti multipli alta confidenza. Specie mostrate qui si assume esistano in questa posizione.",
+        "description": "Questa pagina mostra dati runtime Soglia Dinamica. Quando abilitata, soglie vengono regolate automaticamente da rilevamenti multipli alta confidenza. Specie mostrate qui si assume esistano in questa posizione.",
         "stats": {
           "active": "Attivo",
           "atMinimum": "Al Minimo",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -4355,7 +4355,7 @@
       "dynamicThreshold": {
         "tabLabel": "Apgūtie",
         "title": "Apgūtie sliekšņi",
-        "description": "Šī lapa rāda dinamiskā sliekšņa izpildlaika datus. Kad iespējots galvenajos iestatījumos → Noteikšana, sliekšņi tiek automātiski pielāgoti, pamatojoties uz vairākām augstticamības noteikšanām. Šeit redzamās sugas tiek uzskatītas par esošām šajā atrašanās vietā.",
+        "description": "Šī lapa rāda dinamiskā sliekšņa izpildlaika datus. Kad iespējots, sliekšņi tiek automātiski pielāgoti, pamatojoties uz vairākām augstticamības noteikšanām. Šeit redzamās sugas tiek uzskatītas par esošām šajā atrašanās vietā.",
         "stats": {
           "active": "Aktīvs",
           "atMinimum": "Pie minimuma",

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -4355,7 +4355,7 @@
       "dynamicThreshold": {
         "tabLabel": "Lært",
         "title": "Lærte terskler",
-        "description": "Denne siden viser kjøretidsdata for dynamisk terskel. Når aktivert i Hovedinnstillinger → Deteksjon, justeres terskler automatisk av flere høysikkerhetsregistreringer. Arter som vises her antas å eksistere på dette stedet.",
+        "description": "Denne siden viser kjøretidsdata for dynamisk terskel. Når aktivert, justeres terskler automatisk av flere høysikkerhetsregistreringer. Arter som vises her antas å eksistere på dette stedet.",
         "stats": {
           "active": "Aktiv",
           "atMinimum": "På minimum",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -4355,7 +4355,7 @@
       "dynamicThreshold": {
         "tabLabel": "Geleerd",
         "title": "Geleerde drempels",
-        "description": "Deze pagina toont runtime data van dynamische drempels. Wanneer ingeschakeld in Hoofdinstellingen → Detectie, worden drempels automatisch aangepast door meerdere detecties met hoge betrouwbaarheid. Soorten die hier worden getoond, worden verondersteld op deze locatie te bestaan.",
+        "description": "Deze pagina toont runtime data van dynamische drempels. Wanneer ingeschakeld, worden drempels automatisch aangepast door meerdere detecties met hoge betrouwbaarheid. Soorten die hier worden getoond, worden verondersteld op deze locatie te bestaan.",
         "stats": {
           "active": "Actief",
           "atMinimum": "Op minimum",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -4355,7 +4355,7 @@
       "dynamicThreshold": {
         "tabLabel": "Nauczone",
         "title": "Nauczone progi",
-        "description": "Ta strona pokazuje dane runtime progów dynamicznych. Gdy włączone w Ustawienia główne → Wykrywanie, progi są automatycznie dostosowywane przez wielokrotne wykrycia o wysokiej pewności. Gatunki pokazane tutaj są uznawane za istniejące w tej lokalizacji.",
+        "description": "Ta strona pokazuje dane runtime progów dynamicznych. Gdy włączone, progi są automatycznie dostosowywane przez wielokrotne wykrycia o wysokiej pewności. Gatunki pokazane tutaj są uznawane za istniejące w tej lokalizacji.",
         "stats": {
           "active": "Aktywne",
           "atMinimum": "Na minimum",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -4355,7 +4355,7 @@
       "dynamicThreshold": {
         "tabLabel": "Aprendido",
         "title": "Limiares aprendidos",
-        "description": "Esta página mostra dados de execução dos limiares dinâmicos. Quando ativado em Configurações principais → Detecção, os limiares são ajustados automaticamente por múltiplas detecções de alta confiança. As espécies mostradas aqui são consideradas existentes nesta localização.",
+        "description": "Esta página mostra dados de execução dos limiares dinâmicos. Quando ativado, os limiares são ajustados automaticamente por múltiplas detecções de alta confiança. As espécies mostradas aqui são consideradas existentes nesta localização.",
         "stats": {
           "active": "Ativos",
           "atMinimum": "No mínimo",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -4355,7 +4355,7 @@
       "dynamicThreshold": {
         "tabLabel": "Učené",
         "title": "Naučené prahy",
-        "description": "Táto stránka zobrazuje runtime dáta dynamického prahu. Keď je povolený v Hlavných nastaveniach → Detekcia, prahy sa automaticky upravujú na základe viacerých detekcií s vysokou istotou. Druhy zobrazené tu sa považujú za existujúce na tomto mieste.",
+        "description": "Táto stránka zobrazuje runtime dáta dynamického prahu. Keď je povolený, prahy sa automaticky upravujú na základe viacerých detekcií s vysokou istotou. Druhy zobrazené tu sa považujú za existujúce na tomto mieste.",
         "stats": {
           "active": "Aktívne",
           "atMinimum": "Na minime",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -4355,7 +4355,7 @@
       "dynamicThreshold": {
         "tabLabel": "Inlärda",
         "title": "Inlärda tröskelvärden",
-        "description": "Denna sida visar körtidsdata för dynamiska tröskelvärden. När aktiverad i Huvudinställningar -> Detektering justeras tröskelvärden automatiskt av flera högkonfidensdetekteringar. Arter som visas här antas finnas på denna plats.",
+        "description": "Denna sida visar körtidsdata för dynamiska tröskelvärden. När aktiverad justeras tröskelvärden automatiskt av flera högkonfidensdetekteringar. Arter som visas här antas finnas på denna plats.",
         "stats": {
           "active": "Aktiva",
           "atMinimum": "Vid minimum",

--- a/frontend/tests/e2e/settings/contextual-links.spec.ts
+++ b/frontend/tests/e2e/settings/contextual-links.spec.ts
@@ -1,0 +1,174 @@
+import { test, expect, type Page } from '@playwright/test';
+import type { SettingsFormData } from '../../../src/lib/stores/settings';
+
+const APP_BASE = `${process.env['SETTINGS_PROXY_PREFIX'] ?? ''}/ui`;
+
+async function expectDestination(page: Page, section: string, tab: string) {
+  await expect.poll(() => new URL(page.url()).pathname).toBe(`${APP_BASE}/settings/${section}`);
+  await expect.poll(() => new URL(page.url()).search).toBe(`?tab=${tab}`);
+  await expect(page.locator(`#settings-tab-${tab}`)).toHaveAttribute('aria-selected', 'true');
+  await expect(page.locator(`#settings-tabpanel-${tab}`)).toBeVisible();
+}
+
+test.describe('Contextual settings links', () => {
+  let runtimeErrors: string[];
+  let consoleErrors: string[];
+
+  test.beforeEach(async ({ page }) => {
+    runtimeErrors = [];
+    consoleErrors = [];
+    page.on('pageerror', error => runtimeErrors.push(error.message));
+    page.on('console', message => {
+      if (message.type() === 'error') consoleErrors.push(message.text());
+    });
+    await page.addInitScript(() => localStorage.setItem('birdnet-locale', 'en'));
+    // Exercise real page entry points without changing the running server's configuration.
+    await page.route('**/api/v2/settings', async route => {
+      const response = await route.fetch();
+      const settings: SettingsFormData = await response.json();
+      await route.fulfill({
+        response,
+        json: {
+          ...settings,
+          security: { ...settings.security, host: '', baseUrl: '', oauthProviders: [] },
+          birdnet: { ...settings.birdnet, modelRegion: 'auto', locationConfigured: false },
+          webServer: { ...settings.webServer, enableTerminal: false },
+        },
+      });
+    });
+    await page.route('**/api/v2/models/regions', async route => {
+      const response = await route.fetch();
+      await route.fulfill({
+        response,
+        json: {
+          ...(await response.json()),
+          modelRegion: 'auto',
+          locationConfigured: false,
+          resolved: { slug: '', source: 'auto', ambiguous: false },
+        },
+      });
+    });
+  });
+
+  test.afterEach(async ({}, testInfo) => {
+    if (consoleErrors.length) {
+      await testInfo.attach('console-errors', {
+        body: JSON.stringify(consoleErrors, null, 2),
+        contentType: 'application/json',
+      });
+    }
+    expect(runtimeErrors).toEqual([]);
+  });
+
+  for (const width of [1440, 390]) {
+    test(`guidance links support keyboard navigation at ${width}px`, async ({ page }, testInfo) => {
+      await page.setViewportSize({ width, height: 1000 });
+      const links = [
+        {
+          source: 'settings/analysis?tab=models',
+          name: 'Configure Location',
+          section: 'main',
+          tab: 'location',
+        },
+        {
+          source: 'system/terminal',
+          name: 'Security → Browser Terminal',
+          section: 'security',
+          tab: 'terminal',
+        },
+        {
+          source: 'settings/species?tab=dynamicThreshold',
+          name: 'Analysis → Settings',
+          section: 'analysis',
+          tab: 'settings',
+        },
+      ];
+      for (const { source, name, section, tab } of links) {
+        await page.goto(`${APP_BASE}/${source}`);
+        const link = page.getByRole('link', { name, exact: true });
+        await expect(link).toBeVisible();
+        await expect(link).toHaveAttribute('href', `${APP_BASE}/settings/${section}?tab=${tab}`);
+        const bounds = await link.evaluate(element => {
+          const { x, right } = element.getBoundingClientRect();
+          return { x, right };
+        });
+        expect(bounds.x).toBeGreaterThanOrEqual(0);
+        expect(bounds.right).toBeLessThanOrEqual(width);
+        await page.screenshot({
+          path: testInfo.outputPath(`${section}-${width}.png`),
+          fullPage: true,
+          animations: 'disabled',
+        });
+        await page.evaluate(() => {
+          document.documentElement.dataset['navigationSession'] = 'retained';
+        });
+        await link.focus();
+        await link.press('Enter');
+        await expectDestination(page, section, tab);
+        await expect(page.locator('html')).toHaveAttribute('data-navigation-session', 'retained');
+        if (tab === 'location') await expect(page.locator('.maplibregl-canvas')).toBeVisible();
+      }
+    });
+
+    test(`OAuth host link preserves the unfinished provider at ${width}px`, async ({
+      page,
+    }, testInfo) => {
+      await page.setViewportSize({ width, height: 1000 });
+      await page.goto(`${APP_BASE}/settings/security?tab=oauth`);
+      await page.getByRole('button', { name: 'Add Provider', exact: true }).click();
+      const clientId = page.getByLabel('Client ID', { exact: true });
+      const userId = page.locator('#oauth-user-id');
+      await clientId.fill('tab-navigation-test');
+      await userId.fill('test-user');
+      await userId.press('Tab');
+      const link = page.getByRole('link', { name: 'Server Configuration', exact: true });
+      await expect(link).toHaveAttribute('href', `${APP_BASE}/settings/security?tab=server`);
+      await page.screenshot({
+        path: testInfo.outputPath(`oauth-${width}.png`),
+        fullPage: true,
+        animations: 'disabled',
+      });
+      await link.click();
+      await expectDestination(page, 'security', 'server');
+      await page.goBack();
+      await expectDestination(page, 'security', 'oauth');
+      await expect(clientId).toHaveValue('tab-navigation-test');
+      await expect(userId).toHaveValue('test-user');
+      await link.focus();
+      await link.press('Enter');
+      await expectDestination(page, 'security', 'server');
+      await page.locator('#settings-tab-oauth').click();
+      await expect(clientId).toHaveValue('tab-navigation-test');
+      await expect(userId).toHaveValue('test-user');
+    });
+  }
+
+  test('a configured location outside coverage does not show the missing-location action', async ({
+    page,
+  }) => {
+    await page.unroute('**/api/v2/models/regions');
+    await page.route('**/api/v2/models/regions', async route => {
+      const response = await route.fetch();
+      await route.fulfill({
+        response,
+        json: {
+          ...(await response.json()),
+          modelRegion: 'auto',
+          locationConfigured: true,
+          resolved: { slug: '', source: 'auto', ambiguous: false },
+        },
+      });
+    });
+    await page.goto(`${APP_BASE}/settings/analysis?tab=models`);
+    await expect(page.getByRole('group', { name: 'Model region', exact: true })).toBeVisible();
+    await expect(
+      page.getByText(
+        "Your location is outside every regional model's coverage, so the worldwide model is used.",
+        { exact: true }
+      )
+    ).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Configure Location', exact: true })).toHaveCount(
+      0
+    );
+  });
+});

--- a/frontend/tests/e2e/settings/tab-urls.spec.ts
+++ b/frontend/tests/e2e/settings/tab-urls.spec.ts
@@ -1,0 +1,280 @@
+/* eslint playwright/expect-expect: ['warn', { assertFunctionNames: ['expect', 'expectTab', 'expectQuery'] }] */
+import { test, expect, type Page } from '@playwright/test';
+
+const SETTINGS_BASE = `${process.env['SETTINGS_PROXY_PREFIX'] ?? ''}/ui/settings`;
+
+const settingsPages = [
+  { path: 'main', tabs: ['general', 'location', 'database'] },
+  { path: 'audio', tabs: ['soundcard', 'streams', 'recording', 'retention', 'processing'] },
+  {
+    path: 'species',
+    tabs: ['active', 'include', 'exclude', 'config', 'synonyms', 'tracking', 'dynamicThreshold'],
+  },
+  { path: 'analysis', tabs: ['settings', 'models'] },
+  { path: 'integrations', tabs: ['birdweather', 'mqtt', 'ebird', 'prometheus'] },
+  { path: 'security', tabs: ['server', 'basic-auth', 'oauth', 'exceptions', 'terminal'] },
+  { path: 'detectionfilters', tabs: ['filters'] },
+  { path: 'support', tabs: ['diagnostics'] },
+  { path: 'userinterface', tabs: ['appearance', 'language', 'visualContent', 'audioPlayback'] },
+  { path: 'notifications', tabs: ['channels', 'rules', 'history'] },
+];
+
+async function expectTab(page: Page, id: string) {
+  const tab = page.locator(`#settings-tab-${id}`);
+  await expect(tab).toHaveAttribute('aria-selected', 'true');
+  await expect(tab).toHaveAttribute('tabindex', '0');
+  await expect(tab).toHaveAccessibleName(/\S/);
+  const panel = page.locator(`#settings-tabpanel-${id}`);
+  await expect(panel).toBeVisible();
+  await expect(panel).toHaveAttribute('aria-labelledby', `settings-tab-${id}`);
+}
+
+async function expectQuery(page: Page, key: string, value: string | null) {
+  await expect.poll(() => new URL(page.url()).searchParams.get(key)).toBe(value);
+}
+
+test.describe('Settings tab URLs', () => {
+  let runtimeErrors: string[];
+  let consoleErrors: string[];
+
+  test.beforeEach(async ({ page }) => {
+    runtimeErrors = [];
+    consoleErrors = [];
+    page.on('pageerror', error => runtimeErrors.push(error.message));
+    page.on('console', message => {
+      if (message.type() === 'error') consoleErrors.push(message.text());
+    });
+    await page.addInitScript(() => localStorage.setItem('birdnet-locale', 'en'));
+  });
+
+  test.afterEach(async ({}, testInfo) => {
+    if (consoleErrors.length) {
+      await testInfo.attach('console-errors', {
+        body: JSON.stringify(consoleErrors, null, 2),
+        contentType: 'application/json',
+      });
+    }
+    expect(runtimeErrors).toEqual([]);
+  });
+
+  for (const { path, tabs } of settingsPages) {
+    test(`${path}: every tab supports direct load, refresh and same-page selection`, async ({
+      page,
+    }) => {
+      test.setTimeout(120_000);
+      for (const id of tabs) {
+        await page.goto(`${SETTINGS_BASE}/${path}?tab=${id}&source=tab-test#settings`);
+        await expectTab(page, id);
+        await page.reload();
+        await expectTab(page, id);
+      }
+      // Start from a bare URL in the same session: no new last-tab storage.
+      await page.goto(`${SETTINGS_BASE}/${path}?source=tab-test#settings`);
+      await expectTab(page, tabs[0]);
+      for (const id of tabs) {
+        await page.locator(`#settings-tab-${id}`).click();
+        await expectTab(page, id);
+        await expectQuery(page, 'tab', id);
+        await expectQuery(page, 'source', 'tab-test');
+        expect(new URL(page.url()).hash).toBe('#settings');
+      }
+    });
+
+    test(`${path}: invalid tab falls back safely`, async ({ page }) => {
+      await page.goto(`${SETTINGS_BASE}/${path}?tab=removed-tab`);
+      await expectTab(page, tabs[0]);
+    });
+  }
+
+  test('Back/Forward restores tabs and bare defaults without losing unsaved edits', async ({
+    page,
+  }) => {
+    await page.goto(`${SETTINGS_BASE}/main?source=history#settings`);
+    const name = page.locator('#node-name');
+    await expect(name).toBeVisible();
+    const original = await name.inputValue();
+    await name.fill(`${original} tab test`);
+    await name.press('Tab');
+    const reset = page.getByRole('button', { name: 'Reset all changes' });
+    await expect(reset).toBeVisible();
+    await page.locator('#settings-tab-location').click();
+    await expectTab(page, 'location');
+    await expect(page.locator('#location-map canvas')).toBeVisible();
+    await page.locator('#settings-tab-database').click();
+    await expectTab(page, 'database');
+    const historyLength = await page.evaluate(() => window.history.length);
+    await page.locator('#settings-tab-database').click();
+    expect(await page.evaluate(() => window.history.length)).toBe(historyLength);
+    await page.goBack();
+    await expectTab(page, 'location');
+    await page.goBack();
+    await expectTab(page, 'general');
+    await expectQuery(page, 'tab', null);
+    await expect(name).toHaveValue(`${original} tab test`);
+    await page.goForward();
+    await expectTab(page, 'location');
+    await expect(reset).toBeVisible();
+    await reset.click();
+    await page.locator('#settings-tab-general').click();
+    await expect(name).toHaveValue(original);
+    await name.fill(`${original} refresh test`);
+    await page.locator('#settings-tab-location').click();
+    await page.reload();
+    await expectTab(page, 'location');
+    await page.locator('#settings-tab-general').click();
+    await expect(name).toHaveValue(original);
+  });
+
+  test('Analysis nested tabs keep independent URLs through remounts and history', async ({
+    page,
+  }) => {
+    await page.goto(`${SETTINGS_BASE}/analysis?tab=models&modelTab=available`);
+    await expectTab(page, 'models');
+    await expectTab(page, 'available');
+    await page.reload();
+    await expectTab(page, 'available');
+    await page.locator('#settings-tab-installed').click();
+    await expectQuery(page, 'tab', 'models');
+    await expectQuery(page, 'modelTab', 'installed');
+    await page.goBack();
+    await expectTab(page, 'available');
+    await page.goForward();
+    await expectTab(page, 'installed');
+    await page.locator('#settings-tab-settings').click();
+    await page.locator('#settings-tab-models').click();
+    await expectTab(page, 'installed');
+    await page.goto(`${SETTINGS_BASE}/analysis?tab=models&modelTab=removed`);
+    await expectTab(page, 'installed');
+    await page.locator('#settings-tab-installed').focus();
+    await page.keyboard.press('ArrowRight');
+    await expectTab(page, 'available');
+    await expect(page.locator('#settings-tab-available')).toBeFocused();
+    await expectQuery(page, 'tab', 'models');
+    await expectQuery(page, 'modelTab', 'available');
+  });
+
+  test('saving edits from another tab retains the URL and persists the form', async ({ page }) => {
+    await page.goto(`${SETTINGS_BASE}/main?tab=general`);
+    const name = page.locator('#node-name');
+    await expect(name).toBeEnabled();
+    const original = await name.inputValue();
+    const updated = `${original} tab save test`;
+    const save = page.getByRole('button', { name: 'Save Changes', exact: true });
+    try {
+      await name.fill(updated);
+      await page.locator('#settings-tab-location').click();
+      await expect(save).toBeEnabled();
+      const saved = page.waitForResponse(
+        response =>
+          response.url().endsWith('/api/v2/settings') && response.request().method() === 'PUT'
+      );
+      await save.click();
+      expect((await saved).ok()).toBe(true);
+      await page.reload();
+      await expectTab(page, 'location');
+      await page.locator('#settings-tab-general').click();
+      await expect(name).toHaveValue(updated);
+    } finally {
+      await page.goto(`${SETTINGS_BASE}/main?tab=general`);
+      await name.fill(original);
+      await name.press('Tab');
+      if (await save.isEnabled()) {
+        const restored = page.waitForResponse(
+          response =>
+            response.url().endsWith('/api/v2/settings') && response.request().method() === 'PUT'
+        );
+        await save.click();
+        expect((await restored).ok()).toBe(true);
+      }
+    }
+  });
+
+  test('all settings tab groups remain usable on mobile', async ({ page }, testInfo) => {
+    test.setTimeout(120_000);
+    await page.setViewportSize({ width: 390, height: 844 });
+    for (const { path, tabs } of settingsPages) {
+      await page.goto(`${SETTINGS_BASE}/${path}`);
+      for (const id of tabs) {
+        await page.locator(`#settings-tab-${id}`).click();
+        await expectTab(page, id);
+        await expectQuery(page, 'tab', id);
+      }
+      await page.screenshot({
+        path: testInfo.outputPath(`${path}-mobile.png`),
+        fullPage: true,
+        animations: 'disabled',
+      });
+    }
+  });
+
+  test('Species Configure Location links to the Location tab and Back returns to Species', async ({
+    page,
+  }) => {
+    // Make the missing-location entry point available regardless of station config.
+    await page.route('**/api/v2/settings', async route => {
+      const response = await route.fetch();
+      const settings = await response.json();
+      settings.birdnet.locationConfigured = false;
+      return route.fulfill({
+        response,
+        json: settings,
+      });
+    });
+    await page.goto(`${SETTINGS_BASE}/species`);
+    const link = page.getByRole('link', { name: 'Configure Location' });
+    await expect(link).toHaveAttribute('href', /\/ui\/settings\/main\?tab=location$/);
+    await link.click();
+    await expectTab(page, 'location');
+    await expect(page.locator('#location-map canvas')).toBeVisible();
+    await page.goBack();
+    await expectTab(page, 'active');
+  });
+
+  for (const width of [1440, 390, 320]) {
+    test(`keyboard and layout at ${width}px`, async ({ page }, testInfo) => {
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto(`${SETTINGS_BASE}/species?tab=active`);
+      await expectTab(page, 'active');
+      await page.locator('#settings-tab-active').focus();
+      await page.keyboard.press('ArrowRight');
+      await expectTab(page, 'include');
+      await expect(page.locator('#settings-tab-include')).toBeFocused();
+      await expectQuery(page, 'tab', 'include');
+      await page.keyboard.press('End');
+      await expectTab(page, 'dynamicThreshold');
+      await page.keyboard.press('ArrowRight');
+      await expectTab(page, 'active');
+      await page.keyboard.press('ArrowLeft');
+      await expectTab(page, 'dynamicThreshold');
+      await page.keyboard.press('Home');
+      await expectTab(page, 'active');
+      for (const key of ['Enter', 'Space']) {
+        const before = await page.evaluate(() => window.history.length);
+        await page.keyboard.press(key);
+        expect(await page.evaluate(() => window.history.length)).toBe(before);
+      }
+      for (const tab of await page.getByRole('tab').all()) {
+        await expect(tab).toHaveAccessibleName(/\S/);
+        const bounds = await tab.boundingBox();
+        expect(bounds).not.toBeNull();
+        expect(bounds?.x).toBeGreaterThanOrEqual(0);
+        expect((bounds?.x ?? 0) + (bounds?.width ?? 0)).toBeLessThanOrEqual(width);
+      }
+      await page.screenshot({
+        path: testInfo.outputPath(`species-${width}.png`),
+        fullPage: true,
+        animations: 'disabled',
+      });
+    });
+  }
+
+  test('explicit Audio URL overrides its legacy storage fallback', async ({ page }) => {
+    await page.addInitScript(() =>
+      localStorage.setItem('birdnet-audio-settings-active-tab', 'streams')
+    );
+    await page.goto(`${SETTINGS_BASE}/audio?tab=recording`);
+    await expectTab(page, 'recording');
+    await page.goto(`${SETTINGS_BASE}/audio`);
+    await expectTab(page, 'streams');
+  });
+});

--- a/frontend/tests/e2e/settings/tab-urls.spec.ts
+++ b/frontend/tests/e2e/settings/tab-urls.spec.ts
@@ -1,5 +1,6 @@
 /* eslint playwright/expect-expect: ['warn', { assertFunctionNames: ['expect', 'expectTab', 'expectQuery'] }] */
 import { test, expect, type Page } from '@playwright/test';
+import type { SettingsFormData } from '../../../src/lib/stores/settings';
 
 const SETTINGS_BASE = `${process.env['SETTINGS_PROXY_PREFIX'] ?? ''}/ui/settings`;
 
@@ -207,28 +208,57 @@ test.describe('Settings tab URLs', () => {
     }
   });
 
-  test('Species Configure Location links to the Location tab and Back returns to Species', async ({
-    page,
-  }) => {
-    // Make the missing-location entry point available regardless of station config.
-    await page.route('**/api/v2/settings', async route => {
-      const response = await route.fetch();
-      const settings = await response.json();
-      settings.birdnet.locationConfigured = false;
-      return route.fulfill({
-        response,
-        json: settings,
+  for (const width of [1440, 390]) {
+    test(`Species Configure Location preserves unsaved tracking edits at ${width}px`, async ({
+      page,
+    }, testInfo) => {
+      await page.setViewportSize({ width, height: 1000 });
+      // Expose the missing-location entry point and an editable Tracking field without saving.
+      await page.route('**/api/v2/settings', async route => {
+        const response = await route.fetch();
+        const settings: SettingsFormData = await response.json();
+        settings.birdnet.locationConfigured = false;
+        settings.realtime.speciesTracking = {
+          ...settings.realtime.speciesTracking,
+          enabled: true,
+          newSpeciesWindowDays: 7,
+        };
+        return route.fulfill({ response, json: settings });
       });
+
+      await page.goto(`${SETTINGS_BASE}/species?tab=tracking`);
+      const windowDays = page.locator('#new-species-window');
+      await expect(windowDays).toHaveValue('7');
+      await windowDays.fill('11');
+      await windowDays.press('Tab');
+      const reset = page.getByRole('button', { name: 'Reset all changes' });
+      await expect(reset).toBeVisible();
+      await page.locator('#settings-tab-active').click();
+      const link = page.getByRole('link', { name: 'Configure Location' });
+      await expect(link).toHaveAttribute('href', `${SETTINGS_BASE}/main?tab=location`);
+      await link.focus();
+      await page.screenshot({
+        path: testInfo.outputPath(`species-location-${width}.png`),
+        fullPage: true,
+        animations: 'disabled',
+      });
+      if (width === 1440) await link.click();
+      else await link.press('Enter');
+      await expectTab(page, 'location');
+      await expect(page.locator('#location-map canvas')).toBeVisible();
+      await expect(reset).toBeVisible();
+      await page.goBack();
+      await expectTab(page, 'active');
+      await page.goBack();
+      await expectTab(page, 'tracking');
+      await expect(windowDays).toHaveValue('11');
+      await page.goForward();
+      await expectTab(page, 'active');
+      await page.goForward();
+      await expectTab(page, 'location');
+      await expect(reset).toBeVisible();
     });
-    await page.goto(`${SETTINGS_BASE}/species`);
-    const link = page.getByRole('link', { name: 'Configure Location' });
-    await expect(link).toHaveAttribute('href', /\/ui\/settings\/main\?tab=location$/);
-    await link.click();
-    await expectTab(page, 'location');
-    await expect(page.locator('#location-map canvas')).toBeVisible();
-    await page.goBack();
-    await expectTab(page, 'active');
-  });
+  }
 
   for (const width of [1440, 390, 320]) {
     test(`keyboard and layout at ${width}px`, async ({ page }, testInfo) => {


### PR DESCRIPTION
<!-- Thanks for contributing to BirdNET-Go! -->

## Description

Settings tabs now have stable URLs that survive refresh and support direct links. Species → Configure Location opens `/ui/settings/main?tab=location`, with the Location tab and map visible.

- Store the selected settings tab in `?tab=` across all ten settings pages. Analysis's nested model-gallery tabs use an independent `modelTab` parameter.
- Synchronize query-only navigation and Back/Forward through the existing router while preserving unsaved settings. Contextual links use SPA navigation, including the OAuth provider editor and Species location guidance.
- Link Analysis Models, disabled Terminal, OAuth's missing-host warning and Species Learned guidance to the relevant settings tabs. Update obsolete Learned guidance in all 16 locales.
- Preserve unrelated query parameters, fragments and reverse-proxy prefixes. Keep keyboard tab controls and translated accessible names on mobile.

Bare URLs retain their existing defaults. No new cross-session last-tab storage is introduced; Audio's existing legacy fallback remains. No API/config schema or detection behavior changes.

## Related issue

Implements the “Persist and deep-link settings tabs” backlog item; no linked GitHub issue.

Preliminary review: [sn3p/birdnet-go#2](https://github.com/sn3p/birdnet-go/pull/2). Copilot's Species navigation finding was fixed and its thread resolved.

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/tphakala/birdnet-go/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`go test -race ./...` and/or `npm test`) — `npm test`: 2,928 tests passed. The separate Go race-test failure is documented below.
- [x] Linters are clean (`golangci-lint run` and/or `npm run check:all`) — Go lint: 0 issues. Frontend checks: exit 0, with one pre-existing warning documented below.
- [x] New exports and user-facing changes are documented

## Licensing

- [x] My contribution is licensed under **CC BY-NC-SA 4.0**, and I grant the maintainer the right to relicense it under any **OSI-approved open source license**, as described in the [Relicensing Grant](https://github.com/tphakala/birdnet-go/blob/main/CONTRIBUTING.md#relicensing-grant).

## Preflight Status

All six review passes completed: reuse, correctness, quality, i18n, integration/wiring, and regression/backward compatibility. Fixed findings included the Species link's proxy prefix and SPA handler, realistic settings/location fixtures, and a deterministic browser regression. No remaining in-scope findings. Secondary-model cross-validation was unavailable.

**Full certification remains incomplete.** Existing baseline limitations:

- `go test -race ./...` has a reproducible failure in `internal/audiocore/ffmpeg`: `TestExtractClip_Filters/normalize_filter`, `clip_test.go:201`, extraction exit 234 with local FFmpeg 9.0.1. The package is unchanged from `main`; no workaround or test skip was added.
- `npm run check:all` exits 0 but reports one existing ESLint warning in `ModelRegionSelector.test.ts:29` (`security/detect-object-injection`). The zero-warning requirement is unmet.
- Existing untranslated strings remain: 27 confirmed keys across 15 locales (405 occurrences), unrelated to the changed guidance.
- Existing Notifications History mobile overflow and notification SSE throttling during rapid reload tests are outside this change. Firefox/WebKit were not verified.

CodeRabbit cleanup in `bc36e5426` centralizes the four contextual settings destinations in `SETTINGS_ROUTES`, used by all five links. Runtime proxy-prefix resolution and SPA navigation are unchanged. All 2,928 frontend tests and 14 desktop/mobile/proxy browser checks pass after the extraction.

### Validation

- Frontend: **196 files / 2,928 tests passed**; production build passed.
- `npm run check:all`: exit 0; Svelte reports 0 errors and 0 warnings, with the separate ESLint warning noted above.
- `golangci-lint run -v`: **0 issues**.
- Initial 29-case Chromium matrix covered every settings tab, direct loads, refresh, Analysis nested tabs, history, keyboard, mobile, Save/Reset and unsaved forms. Five cases also passed through a real `/birdnet` nginx proxy.
- Final fix: **14 focused browser checks passed**, including desktop click/mobile Enter for Species Configure Location, retained unsaved Tracking edits through Back/Forward, proxy URLs, other contextual links and nested tabs. The regression was observed failing before the fix and passing afterward.
- Rendered desktop/mobile entry points inspected at 1440px and 390px; tab keyboard/layout also checked at 320px. No uncaught browser runtime errors.
- All 16 locales retain 4,158 keys with no missing, orphaned or structurally mismatched keys. Changed guidance is translated throughout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings tabs now support direct links, browser history, reloads, and query-based tab selection.
  * Added contextual links for configuring location, analysis, server, security, and terminal settings.
  * Improved navigation preserves query parameters and enables seamless same-page transitions.
* **Bug Fixes**
  * Disabled terminal content now displays clearer muted styling.
* **Documentation**
  * Updated dynamic-threshold descriptions across supported languages to remove outdated navigation references.
* **Tests**
  * Expanded coverage for settings links, tab URLs, navigation history, accessibility, and responsive layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->