### PR TITLE
fix(api,frontend): serialize zero rarity coordinates and flag partial inference degradation

### DIFF
--- a/frontend/src/lib/desktop/views/DetectionDetail.svelte
+++ b/frontend/src/lib/desktop/views/DetectionDetail.svelte
@@ -47,7 +47,9 @@
     score: number;
     location_based: boolean;
     // Optional: the API omits these when no location is configured (they are *float64
-    // with omitempty server-side). They are present whenever location_based is true.
+    // with omitempty server-side). The backend sends them whenever location_based is
+    // true, but callers must still guard before toFixed() as defense in depth against
+    // a contract violation.
     latitude?: number;
     longitude?: number;
   }

--- a/frontend/src/lib/desktop/views/DetectionDetail.svelte
+++ b/frontend/src/lib/desktop/views/DetectionDetail.svelte
@@ -46,8 +46,10 @@
     status: string;
     score: number;
     location_based: boolean;
-    latitude: number;
-    longitude: number;
+    // Optional: the API omits these when no location is configured (they are *float64
+    // with omitempty server-side). They are present whenever location_based is true.
+    latitude?: number;
+    longitude?: number;
   }
 
   interface SpeciesInfo {
@@ -719,7 +721,7 @@
               {(speciesInfo.rarity.score * 100).toFixed(0)}%
             </span>
           </div>
-          {#if speciesInfo.rarity.location_based}
+          {#if speciesInfo.rarity.location_based && speciesInfo.rarity.latitude != null && speciesInfo.rarity.longitude != null}
             <p class="text-xs text-[var(--color-base-content)]/40">
               {t('species.rarity.basedOnLocation', {
                 latitude: speciesInfo.rarity.latitude.toFixed(2),
@@ -936,6 +938,7 @@
         <div class="tab-nav" role="tablist" aria-label={t('detections.detail.aria.tabList')}>
           {#each ['overview', 'history', 'notes'] as tab (tab)}
             <button
+              type="button"
               id="tab-{tab}"
               role="tab"
               class="tab-button"
@@ -951,6 +954,7 @@
           {/each}
           {#if canReview}
             <button
+              type="button"
               id="tab-review"
               role="tab"
               class="tab-button"

--- a/frontend/src/lib/desktop/views/DetectionDetail.test.ts
+++ b/frontend/src/lib/desktop/views/DetectionDetail.test.ts
@@ -165,3 +165,86 @@ describe('DetectionDetail audio download', () => {
     expect(downloadLink).toHaveAttribute('download', '');
   });
 });
+
+describe('DetectionDetail rarity location coordinates', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  // Render the detail view with a species-rarity payload, stubbing the detection and the
+  // species-info endpoint (which carries rarity) and ignoring everything else.
+  function renderWithRarity(rarity: Record<string, unknown>) {
+    const detection = makeDetection({
+      id: 77,
+      scientificName: 'Turdus merula',
+      commonName: 'Blackbird',
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes('/api/v2/detections/77')) {
+          return Promise.resolve(jsonResponse(detection));
+        }
+        // The species-info endpoint (not /species/taxonomy) supplies rarity.
+        if (url.includes('/api/v2/species?scientific_name=')) {
+          return Promise.resolve(jsonResponse({ scientific_name: 'Turdus merula', rarity }));
+        }
+        return Promise.resolve(jsonResponse({}));
+      })
+    );
+    return detailTest.render({ detectionId: '77' });
+  }
+
+  function raritySection(container: HTMLElement): HTMLElement | null {
+    return container.querySelector<HTMLElement>('section[aria-labelledby="rarity-heading"]');
+  }
+
+  // A station configured at exactly 0.0 latitude/longitude (equator / prime meridian). The
+  // API now sends latitude:0 / longitude:0 (previously dropped by float64+omitempty), and
+  // the component must render the based-on-location line without throwing on toFixed(0).
+  it('renders the location line when coordinates are exactly 0', async () => {
+    const { container } = renderWithRarity({
+      status: 'rare',
+      score: 0.08,
+      location_based: true,
+      latitude: 0,
+      longitude: 0,
+      date: '2024-06-15',
+      threshold_applied: 0.05,
+    });
+
+    await waitFor(() => {
+      expect(raritySection(container)).not.toBeNull();
+    });
+
+    // The based-on-location paragraph is the only <p> inside the rarity section.
+    expect(raritySection(container)?.querySelectorAll('p')).toHaveLength(1);
+  });
+
+  // Defensive: if the API ever reports location_based while omitting the coordinates (a
+  // contract violation), the != null guard must hide the line instead of crashing on
+  // undefined.toFixed. The rarity status/score still render.
+  it('omits the location line and does not crash when coordinates are missing', async () => {
+    const { container } = renderWithRarity({
+      status: 'unknown',
+      score: 0,
+      location_based: true,
+      date: '2024-06-15',
+      threshold_applied: 0.05,
+    });
+
+    await waitFor(() => {
+      expect(raritySection(container)).not.toBeNull();
+    });
+
+    const section = raritySection(container);
+    expect(section?.querySelector('.rarity-label')).not.toBeNull();
+    expect(section?.querySelectorAll('p')).toHaveLength(0);
+  });
+});

--- a/frontend/src/lib/desktop/views/SystemInference.svelte
+++ b/frontend/src/lib/desktop/views/SystemInference.svelte
@@ -862,7 +862,7 @@
                 <span class="text-xs text-muted">{t('system.inference.vad.disabled')}</span>
               {:else if !vad.available}
                 <TriangleAlert class="w-3 h-3 shrink-0 text-amber-500" aria-hidden="true" />
-                <span class="text-xs text-amber-600 dark:text-amber-400"
+                <span class="text-xs text-amber-700 dark:text-amber-400"
                   >{t('system.inference.vad.unavailable')}</span
                 >
               {:else if vad.loaded}
@@ -1011,9 +1011,9 @@
             {@const throughputLatest =
               throughputSeries.length > 0 ? throughputSeries[throughputSeries.length - 1] : 0}
             {@const isActive = throughputSeries.length > 0 && throughputLatest > 0}
-            {@const anySourceDown = model.sources.some(s => s.notRunning)}
-            {@const allSourcesDown =
-              model.sources.length > 0 && model.sources.every(s => s.notRunning)}
+            {@const downCount = model.sources.filter(s => s.notRunning).length}
+            {@const anySourceDown = downCount > 0}
+            {@const allSourcesDown = model.sources.length > 0 && downCount === model.sources.length}
             <div
               class="bg-[var(--surface-100)] border border-[var(--border-100)] rounded-xl p-4 shadow-sm flex flex-col gap-3"
             >
@@ -1033,6 +1033,31 @@
                     title={t('system.inference.deviceHelp')}
                   />
                 {/if}
+                {#if anySourceDown && !allSourcesDown}
+                  <!-- Partial degradation: at least one assigned source is down but not all,
+                       so the model still analyzes through its healthy source(s). Surface it in
+                       the header with a persistent amber chip driven purely by source health
+                       (not throughput/isActive), so it does not flap between silence and
+                       detections the way the old "any source down" alarm did (#4209). Mutually
+                       exclusive with the red not-analyzing state below, which requires ALL
+                       sources down. This chip lives outside the ml-auto activity slot so the
+                       live Active/Idle status still shows on the right; the specific down source
+                       and its remedy are in the per-source list further down. No aria-label, so
+                       screen readers announce the visible count rather than a generic label. -->
+                  <span
+                    class="flex items-center gap-1.5"
+                    role="status"
+                    title={t('system.inference.sourcesDegradedTooltip')}
+                  >
+                    <TriangleAlert class="w-3 h-3 shrink-0 text-amber-500" aria-hidden="true" />
+                    <span class="text-xs font-medium text-amber-700 dark:text-amber-400">
+                      {t('system.inference.sourcesDegraded', {
+                        count: downCount,
+                        total: model.sources.length,
+                      })}
+                    </span>
+                  </span>
+                {/if}
                 {#if model.paused}
                   <!-- Schedule-gated model that is currently off-schedule: explain the
                        flat latency line instead of showing a bare "idle" dash. -->
@@ -1043,7 +1068,7 @@
                     title={t('system.inference.pausedScheduleHelp')}
                   >
                     <Pause class="w-3 h-3 shrink-0 text-amber-500" aria-hidden="true" />
-                    <span class="text-xs text-amber-600 dark:text-amber-400">
+                    <span class="text-xs text-amber-700 dark:text-amber-400">
                       {t('system.inference.paused')}{#if model.scheduleLabel}<span
                           class="text-muted">&nbsp;({model.scheduleLabel})</span
                         >{/if}

--- a/frontend/src/lib/desktop/views/SystemInference.test.ts
+++ b/frontend/src/lib/desktop/views/SystemInference.test.ts
@@ -486,6 +486,79 @@ describe('SystemInference', () => {
     });
   });
 
+  // A persistent amber chip surfaces partial multi-source degradation in the header (some
+  // but not all sources down), driven purely by source health so it never flaps as
+  // detections come and go. Mutually exclusive with the red all-sources-down alarm.
+  describe('partial degradation header chip', () => {
+    const DEGRADED_CHIP = '[title="system.inference.sourcesDegradedTooltip"]';
+    const NOT_ANALYZING_HEADER = '[aria-label="system.inference.modelNotAnalyzingTooltip"]';
+
+    it('shows the amber degraded chip when some but not all sources are down', async () => {
+      const model = makeModel({
+        paused: false,
+        sources: [
+          { id: 'a', name: 'Front Yard', type: 'soundcard', fallback: false },
+          { id: 'b', name: 'Back Yard', type: 'rtsp', fallback: false, notRunning: true },
+        ],
+      });
+      installApi(makeSnapshot([model]));
+
+      const { container } = inferenceTest.render({});
+
+      await waitFor(() => {
+        expect(container.textContent).toContain('Back Yard');
+      });
+
+      // The persistent degraded chip is present ...
+      expect(container.querySelector(DEGRADED_CHIP)).not.toBeNull();
+      expect(container.textContent).toContain('system.inference.sourcesDegraded');
+      // ... and it does NOT escalate to the red all-sources-down alarm.
+      expect(container.querySelector(NOT_ANALYZING_HEADER)).toBeNull();
+    });
+
+    it('hides the degraded chip when every source is healthy', async () => {
+      const model = makeModel({
+        paused: false,
+        sources: [
+          { id: 'a', name: 'Front Yard', type: 'soundcard', fallback: false },
+          { id: 'b', name: 'Back Yard', type: 'rtsp', fallback: false },
+        ],
+      });
+      installApi(makeSnapshot([model]));
+
+      const { container } = inferenceTest.render({});
+
+      await waitFor(() => {
+        expect(container.textContent).toContain('Back Yard');
+      });
+
+      expect(container.querySelector(DEGRADED_CHIP)).toBeNull();
+      expect(container.textContent).not.toContain('system.inference.sourcesDegraded');
+    });
+
+    it('hides the degraded chip when ALL sources are down (yields to the not-analyzing alarm)', async () => {
+      const model = makeModel({
+        paused: false,
+        sources: [
+          { id: 'a', name: 'Front Yard', type: 'soundcard', fallback: false, notRunning: true },
+          { id: 'b', name: 'Back Yard', type: 'rtsp', fallback: false, notRunning: true },
+        ],
+      });
+      installApi(makeSnapshot([model]));
+
+      const { container } = inferenceTest.render({});
+
+      await waitFor(() => {
+        expect(container.textContent).toContain('Back Yard');
+      });
+
+      // The degraded chip is suppressed; the red not-analyzing header owns the state.
+      expect(container.querySelector(DEGRADED_CHIP)).toBeNull();
+      expect(container.textContent).not.toContain('system.inference.sourcesDegraded');
+      expect(container.querySelector(NOT_ANALYZING_HEADER)).not.toBeNull();
+    });
+  });
+
   // These tests run against the i18n stub in src/test/setup.ts, which returns the
   // key for any unmapped string, so assertions target the rendered key names
   // (system.inference.vad.*) plus the data values, not the English text.

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -1378,6 +1378,8 @@ export type TranslationKey =
   | 'system.inference.sourceNotRunning'
   | 'system.inference.sourceNotRunningTooltip'
   | 'system.inference.modelNotAnalyzingTooltip'
+  | 'system.inference.sourcesDegraded' // params: count, total
+  | 'system.inference.sourcesDegradedTooltip'
   | 'system.inference.notMeasured'
   | 'system.inference.unitMs'
   | 'system.inference.unitKhz'
@@ -4403,6 +4405,7 @@ export type TranslationParams = {
   };
   'system.database.migration.prerequisites.criticalCount': { count: string | number };
   'system.database.migration.prerequisites.warningCount': { count: string | number };
+  'system.inference.sourcesDegraded': { count: string | number; total: string | number };
   'system.inference.coDetectedHelp': { seconds: string | number };
   'analytics.hub.card.notEnoughDataHint': { min: string | number };
   'analytics.advanced.speciesSelection': { count: string | number; max: string | number };

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -1781,6 +1781,8 @@
       "sourceNotRunning": "neanalyzuje",
       "sourceNotRunningTooltip": "Tento zdroj je v nastavení přiřazen k modelu, ale jeho zvuk se k modelu nedostává, takže nevytváří žádné detekce. Zkontrolujte, zda je zdroj zvuku připojen a odesílá zvuk.",
       "modelNotAnalyzingTooltip": "Jeden nebo více zdrojů zvuku přiřazených k tomuto modelu mu neposílá zvuk, takže nevytváří žádné detekce. Viz níže uvedené zdroje.",
+      "sourcesDegraded": "{count} z {total} zdrojů mimo provoz",
+      "sourcesDegradedTooltip": "Některé, ale ne všechny zdroje zvuku tohoto modelu jsou mimo provoz, takže model stále analyzuje prostřednictvím těch funkčních. Konkrétní zdroj mimo provoz a způsob, jak jej opravit, jsou uvedeny níže.",
       "notMeasured": "n/a",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -1781,6 +1781,8 @@
       "sourceNotRunning": "analyserer ikke",
       "sourceNotRunningTooltip": "Denne kilde er tildelt modellen i indstillingerne, men dens lyd når ikke modellen, så den producerer ingen detektioner. Kontrollér, at lydkilden er forbundet og sender lyd.",
       "modelNotAnalyzingTooltip": "En eller flere lydkilder tildelt denne model sender ikke lyd til den, så den producerer ingen detektioner. Se kilderne anført nedenfor.",
+      "sourcesDegraded": "{count} af {total} kilder nede",
+      "sourcesDegradedTooltip": "Nogle, men ikke alle af denne models lydkilder er nede, så den analyserer stadig via de fungerende. Den specifikke kilde, der er nede, og hvordan det løses, er anført nedenfor.",
       "notMeasured": "n/a",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -1781,6 +1781,8 @@
       "sourceNotRunning": "analysiert nicht",
       "sourceNotRunningTooltip": "Diese Quelle ist dem Modell in den Einstellungen zugewiesen, aber ihre Audiodaten erreichen das Modell nicht, sodass keine Erkennungen erzeugt werden. Überprüfen Sie, ob die Audioquelle verbunden ist und Audio sendet.",
       "modelNotAnalyzingTooltip": "Eine oder mehrere diesem Modell zugewiesene Audioquellen senden ihm kein Audio, sodass keine Erkennungen erzeugt werden. Siehe die unten aufgeführten Quellen.",
+      "sourcesDegraded": "{count} von {total} Quellen ausgefallen",
+      "sourcesDegradedTooltip": "Einige, aber nicht alle Audioquellen dieses Modells sind ausgefallen, sodass es weiterhin über die funktionierenden analysiert. Die jeweilige ausgefallene Quelle und wie der Fehler behoben werden kann, sind unten aufgeführt.",
       "notMeasured": "n.v.",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -1781,6 +1781,8 @@
       "sourceNotRunning": "not analyzing",
       "sourceNotRunningTooltip": "This source is assigned to the model in settings, but its audio is not reaching the model, so it produces no detections. Check that the audio source is connected and sending audio.",
       "modelNotAnalyzingTooltip": "One or more audio sources assigned to this model are not sending it audio, so it is not producing detections. See the sources listed below.",
+      "sourcesDegraded": "{count} of {total} sources down",
+      "sourcesDegradedTooltip": "Some but not all of this model's audio sources are down, so it still analyzes through the healthy ones. The specific down source and how to fix it are listed below.",
       "notMeasured": "n/a",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -1781,6 +1781,8 @@
       "sourceNotRunning": "no está analizando",
       "sourceNotRunningTooltip": "Esta fuente está asignada al modelo en la configuración, pero su audio no llega al modelo, por lo que no genera detecciones. Compruebe que la fuente de audio esté conectada y enviando audio.",
       "modelNotAnalyzingTooltip": "Una o más fuentes de audio asignadas a este modelo no le están enviando audio, por lo que no genera detecciones. Consulte las fuentes enumeradas a continuación.",
+      "sourcesDegraded": "{count} de {total} fuentes caídas",
+      "sourcesDegradedTooltip": "Algunas fuentes de audio de este modelo, pero no todas, están caídas, por lo que sigue analizando a través de las que funcionan correctamente. La fuente caída específica y cómo solucionarlo se enumeran a continuación.",
       "notMeasured": "n/d",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -1781,6 +1781,8 @@
       "sourceNotRunning": "ei analysoida",
       "sourceNotRunningTooltip": "Tämä lähde on liitetty malliin asetuksissa, mutta sen ääni ei tavoita mallia, joten se ei tuota havaintoja. Tarkista, että äänilähde on yhdistetty ja lähettää ääntä.",
       "modelNotAnalyzingTooltip": "Yksi tai useampi tähän malliin liitetyistä äänilähteistä ei lähetä sille ääntä, joten se ei tuota havaintoja. Katso alla luetellut lähteet.",
+      "sourcesDegraded": "{count}/{total} lähdettä alhaalla",
+      "sourcesDegradedTooltip": "Osa tämän mallin äänilähteistä on alhaalla, mutta ei kaikki, joten se analysoi edelleen toimivien kautta. Kyseinen alhaalla oleva lähde ja sen korjausohjeet on lueteltu alla.",
       "notMeasured": "-",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -1781,6 +1781,8 @@
       "sourceNotRunning": "n'analyse pas",
       "sourceNotRunningTooltip": "Cette source est assignée au modèle dans les paramètres, mais son audio ne parvient pas au modèle, elle ne produit donc aucune détection. Vérifiez que la source audio est connectée et envoie de l'audio.",
       "modelNotAnalyzingTooltip": "Une ou plusieurs sources audio assignées à ce modèle ne lui envoient pas d'audio, il ne produit donc aucune détection. Voir les sources listées ci-dessous.",
+      "sourcesDegraded": "{count} sur {total} sources hors service",
+      "sourcesDegradedTooltip": "Certaines sources audio de ce modèle, mais pas toutes, sont hors service, il continue donc d'analyser via celles qui fonctionnent. La source hors service spécifique et la façon d'y remédier sont listées ci-dessous.",
       "notMeasured": "n/d",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -1781,6 +1781,8 @@
       "sourceNotRunning": "nem elemzi",
       "sourceNotRunningTooltip": "Ez a forrás hozzá van rendelve a modellhez a beállításokban, de a hangja nem jut el a modellhez, így nem készít észleléseket. Ellenőrizze, hogy a hangforrás csatlakoztatva van-e és hangot küld-e.",
       "modelNotAnalyzingTooltip": "Egy vagy több, ehhez a modellhez hozzárendelt hangforrás nem küld neki hangot, így nem készít észleléseket. Lásd az alább felsorolt forrásokat.",
+      "sourcesDegraded": "{count}/{total} forrás leállt",
+      "sourcesDegradedTooltip": "A modell hangforrásai közül néhány leállt, de nem mindegyik, így a működő forrásokon keresztül továbbra is elemez. A konkrét leállt forrás és a hiba elhárításának módja az alábbiakban van felsorolva.",
       "notMeasured": "n/a",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -1781,6 +1781,8 @@
       "sourceNotRunning": "non sta analizzando",
       "sourceNotRunningTooltip": "Questa sorgente è assegnata al modello nelle impostazioni, ma il suo audio non raggiunge il modello, quindi non produce rilevamenti. Verifica che la sorgente audio sia connessa e invii audio.",
       "modelNotAnalyzingTooltip": "Una o più sorgenti audio assegnate a questo modello non gli inviano audio, quindi non produce rilevamenti. Vedi le sorgenti elencate qui sotto.",
+      "sourcesDegraded": "{count} su {total} sorgenti non disponibili",
+      "sourcesDegradedTooltip": "Alcune sorgenti audio di questo modello, ma non tutte, non sono disponibili, quindi continua ad analizzare tramite quelle funzionanti. La sorgente non disponibile specifica e le indicazioni per risolvere il problema sono elencate qui sotto.",
       "notMeasured": "n/d",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -1781,6 +1781,8 @@
       "sourceNotRunning": "neanalizē",
       "sourceNotRunningTooltip": "Šis avots ir piešķirts modelim iestatījumos, bet tā audio nesasniedz modeli, tāpēc tas neveic noteikšanas. Pārbaudiet, vai audio avots ir pievienots un sūta audio.",
       "modelNotAnalyzingTooltip": "Viens vai vairāki šim modelim piešķirtie audio avoti nesūta tam audio, tāpēc tas neveic noteikšanas. Skatiet zemāk norādītos avotus.",
+      "sourcesDegraded": "{count} no {total} avotiem nedarbojas",
+      "sourcesDegradedTooltip": "Daži, bet ne visi šī modeļa audio avoti nedarbojas, tāpēc tas joprojām analizē, izmantojot strādājošos avotus. Konkrētais avots, kas nedarbojas, un kā to novērst, ir norādīti zemāk.",
       "notMeasured": "n/p",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -1781,6 +1781,8 @@
       "sourceNotRunning": "analyserer ikke",
       "sourceNotRunningTooltip": "Denne kilden er tilordnet modellen i innstillingene, men lyden når ikke modellen, så den produserer ingen registreringer. Sjekk at lydkilden er tilkoblet og sender lyd.",
       "modelNotAnalyzingTooltip": "Én eller flere lydkilder tilordnet denne modellen sender ikke lyd til den, så den produserer ingen registreringer. Se kildene oppført nedenfor.",
+      "sourcesDegraded": "{count} av {total} kilder nede",
+      "sourcesDegradedTooltip": "Noen, men ikke alle av denne modellens lydkilder er nede, så den analyserer fortsatt via de fungerende. Den spesifikke kilden som er nede og hvordan det løses, er oppført nedenfor.",
       "notMeasured": "n/a",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -1781,6 +1781,8 @@
       "sourceNotRunning": "analyseert niet",
       "sourceNotRunningTooltip": "Deze bron is in de instellingen toegewezen aan het model, maar de audio bereikt het model niet, waardoor het geen detecties produceert. Controleer of de audiobron is verbonden en audio verzendt.",
       "modelNotAnalyzingTooltip": "Eén of meer aan dit model toegewezen audiobronnen verzenden er geen audio naar, waardoor het geen detecties produceert. Zie de hieronder vermelde bronnen.",
+      "sourcesDegraded": "{count} van {total} bronnen offline",
+      "sourcesDegradedTooltip": "Sommige, maar niet alle audiobronnen van dit model zijn offline, dus het analyseert nog steeds via de werkende bronnen. De specifieke offline bron en hoe dit op te lossen staan hieronder vermeld.",
       "notMeasured": "n/b",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -1781,6 +1781,8 @@
       "sourceNotRunning": "nie analizuje",
       "sourceNotRunningTooltip": "To źródło jest przypisane do modelu w ustawieniach, ale jego dźwięk nie dociera do modelu, więc nie generuje detekcji. Sprawdź, czy źródło audio jest podłączone i wysyła dźwięk.",
       "modelNotAnalyzingTooltip": "Jedno lub więcej źródeł audio przypisanych do tego modelu nie wysyła do niego dźwięku, więc nie generuje detekcji. Zobacz źródła wymienione poniżej.",
+      "sourcesDegraded": "{count} z {total} źródeł niedostępnych",
+      "sourcesDegradedTooltip": "Niektóre, ale nie wszystkie źródła audio tego modelu są niedostępne, więc nadal analizuje on przez sprawne źródła. Konkretne niedostępne źródło i sposób naprawy są wymienione poniżej.",
       "notMeasured": "n/d",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -1781,6 +1781,8 @@
       "sourceNotRunning": "não está a analisar",
       "sourceNotRunningTooltip": "Esta fonte está atribuída ao modelo nas configurações, mas o seu áudio não está a chegar ao modelo, pelo que não produz deteções. Verifique se a fonte de áudio está conectada e a enviar áudio.",
       "modelNotAnalyzingTooltip": "Uma ou mais fontes de áudio atribuídas a este modelo não lhe estão a enviar áudio, pelo que não produz deteções. Consulte as fontes listadas abaixo.",
+      "sourcesDegraded": "{count} de {total} fontes indisponíveis",
+      "sourcesDegradedTooltip": "Algumas fontes de áudio deste modelo, mas não todas, estão indisponíveis, pelo que continua a analisar através das que estão operacionais. A fonte indisponível específica e como resolver o problema estão listadas abaixo.",
       "notMeasured": "n/d",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -1781,6 +1781,8 @@
       "sourceNotRunning": "neanalyzuje",
       "sourceNotRunningTooltip": "Tento zdroj je v nastaveniach priradený k modelu, ale jeho zvuk sa k modelu nedostáva, takže nevytvára žiadne detekcie. Skontrolujte, či je zdroj zvuku pripojený a odosiela zvuk.",
       "modelNotAnalyzingTooltip": "Jeden alebo viac zdrojov zvuku priradených k tomuto modelu mu neodosiela zvuk, takže nevytvára žiadne detekcie. Pozrite si zdroje uvedené nižšie.",
+      "sourcesDegraded": "{count} z {total} zdrojov mimo prevádzky",
+      "sourcesDegradedTooltip": "Niektoré, ale nie všetky zdroje zvuku tohto modelu sú mimo prevádzky, takže model stále analyzuje prostredníctvom tých funkčných. Konkrétny zdroj mimo prevádzky a spôsob, ako ho opraviť, sú uvedené nižšie.",
       "notMeasured": "n/a",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -1781,6 +1781,8 @@
       "sourceNotRunning": "analyserar inte",
       "sourceNotRunningTooltip": "Denna källa är tilldelad modellen i inställningarna, men dess ljud når inte modellen, så den producerar inga detektioner. Kontrollera att ljudkällan är ansluten och skickar ljud.",
       "modelNotAnalyzingTooltip": "En eller flera ljudkällor tilldelade denna modell skickar inte ljud till den, så den producerar inga detektioner. Se källorna som anges nedan.",
+      "sourcesDegraded": "{count} av {total} källor nere",
+      "sourcesDegradedTooltip": "Vissa, men inte alla av denna modells ljudkällor är nere, så den analyserar fortfarande via de fungerande. Den specifika källan som är nere och hur den åtgärdas anges nedan.",
       "notMeasured": "-",
       "unitMs": "ms",
       "unitKhz": "kHz",

--- a/internal/api/v2/species/species.go
+++ b/internal/api/v2/species/species.go
@@ -112,13 +112,18 @@ type SpeciesInfo struct {
 
 // SpeciesRarityInfo contains rarity information for a species
 type SpeciesRarityInfo struct {
-	Status           RarityStatus `json:"status"`
-	Score            float64      `json:"score"`
-	LocationBased    bool         `json:"location_based"`
-	Latitude         float64      `json:"latitude,omitempty"`
-	Longitude        float64      `json:"longitude,omitempty"`
-	Date             string       `json:"date"`
-	ThresholdApplied float64      `json:"threshold_applied"`
+	Status        RarityStatus `json:"status"`
+	Score         float64      `json:"score"`
+	LocationBased bool         `json:"location_based"`
+	// Latitude and Longitude are pointers so a configured coordinate of exactly 0.0
+	// (equator or prime meridian) still serializes: omitempty on a *float64 omits only
+	// when the pointer is nil (no location configured), not when it points to 0.0. A bare
+	// float64 with omitempty would drop the 0.0 value, and the frontend, which reads these
+	// under location_based and calls toFixed on them, would then crash on the missing field.
+	Latitude         *float64 `json:"latitude,omitempty"`
+	Longitude        *float64 `json:"longitude,omitempty"`
+	Date             string   `json:"date"`
+	ThresholdApplied float64  `json:"threshold_applied"`
 }
 
 // taxonomyLookupResult holds the result of a taxonomy lookup with source info.
@@ -589,8 +594,12 @@ func (c *Handler) getSpeciesRarityInfo(bn *classifier.Orchestrator, speciesLabel
 	// whether the filter is currently active, so a client still learns the location is
 	// known even when the rarity itself is unknown.
 	if settings.BirdNET.LocationConfigured {
-		rarityInfo.Latitude = settings.BirdNET.Latitude
-		rarityInfo.Longitude = settings.BirdNET.Longitude
+		// new(expr) copies the value into a fresh heap allocation, so this never
+		// aliases the shared settings snapshot. A configured 0.0 coordinate is
+		// preserved because the pointer is non-nil (see the Latitude/Longitude
+		// field comment).
+		rarityInfo.Latitude = new(settings.BirdNET.Latitude)
+		rarityInfo.Longitude = new(settings.BirdNET.Longitude)
 	}
 
 	// Resolve the score and status together; computeRarity documents how an absent

--- a/internal/api/v2/species/species_test.go
+++ b/internal/api/v2/species/species_test.go
@@ -282,8 +282,8 @@ func TestSpeciesInfoJSONSerialization(t *testing.T) {
 			Status:           RarityCommon,
 			Score:            0.65,
 			LocationBased:    true,
-			Latitude:         40.7128,
-			Longitude:        -74.006,
+			Latitude:         new(40.7128),
+			Longitude:        new(-74.006),
 			Date:             "2024-01-15",
 			ThresholdApplied: 0.03,
 		},
@@ -322,8 +322,8 @@ func TestSpeciesRarityInfoJSONSerialization(t *testing.T) {
 		Status:           RarityRare,
 		Score:            0.08,
 		LocationBased:    true,
-		Latitude:         60.1699,
-		Longitude:        24.9384,
+		Latitude:         new(60.1699),
+		Longitude:        new(24.9384),
 		Date:             "2024-06-15",
 		ThresholdApplied: 0.05,
 	}
@@ -341,6 +341,64 @@ func TestSpeciesRarityInfoJSONSerialization(t *testing.T) {
 	assert.InDelta(t, 24.9384, parsed["longitude"].(float64), 0.001)
 	assert.Equal(t, "2024-06-15", parsed["date"])
 	assert.InDelta(t, 0.05, parsed["threshold_applied"].(float64), 0.001)
+}
+
+// TestSpeciesRarityInfoZeroCoordinatesSerialized guards the fix for a station configured
+// at exactly 0.0 latitude or longitude (equator / prime meridian). With the old
+// float64+omitempty tag these keys were dropped at 0.0, and the frontend crashed calling
+// toFixed on the missing field. As *float64 they must be present and equal to 0.
+func TestSpeciesRarityInfoZeroCoordinatesSerialized(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "species")
+	t.Attr("type", "unit")
+	t.Attr("feature", "json-serialization")
+
+	info := SpeciesRarityInfo{
+		Status:        RarityRare,
+		Score:         0.08,
+		LocationBased: true,
+		Latitude:      new(0.0),
+		Longitude:     new(0.0),
+		Date:          "2024-06-15",
+	}
+
+	data, err := json.Marshal(info)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(data, &parsed))
+
+	// The keys must be present (not omitted) even though the value is exactly 0.
+	require.Contains(t, parsed, "latitude")
+	require.Contains(t, parsed, "longitude")
+	assert.InDelta(t, 0.0, parsed["latitude"].(float64), 0.0001)
+	assert.InDelta(t, 0.0, parsed["longitude"].(float64), 0.0001)
+}
+
+// TestSpeciesRarityInfoOmitsUnsetCoordinates verifies that when no location is configured
+// (nil coordinate pointers) the keys are omitted entirely, keeping the honest "no location"
+// semantics rather than emitting a misleading 0,0 (Null Island).
+func TestSpeciesRarityInfoOmitsUnsetCoordinates(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "species")
+	t.Attr("type", "unit")
+	t.Attr("feature", "json-serialization")
+
+	info := SpeciesRarityInfo{
+		Status:        RarityUnknown,
+		Score:         0,
+		LocationBased: false,
+		Date:          "2024-06-15",
+	}
+
+	data, err := json.Marshal(info)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(data, &parsed))
+
+	assert.NotContains(t, parsed, "latitude")
+	assert.NotContains(t, parsed, "longitude")
 }
 
 // TestTaxonomyHierarchyJSONSerialization tests that TaxonomyHierarchy serializes correctly.


### PR DESCRIPTION
## Summary

The species rarity endpoint (`GET /api/v2/species`) serialized `latitude`/`longitude` as `float64` with `omitempty`, so a station configured at exactly 0.0 latitude or longitude (the equator or the prime meridian) had that coordinate dropped from the response. The detection detail view types those fields as non-optional numbers and calls `.toFixed()` on them whenever `location_based` is true, so it threw a `TypeError` and the rarity panel failed to render for such a station. The fields are now `*float64` with `omitempty`: a configured 0.0 serializes because the pointer is non-nil, while an unconfigured location stays absent so no misleading `0,0` is emitted. The frontend types the fields optional and guards the coordinate line with a null check as defense in depth.

The AI Models inference card previously narrowed its "not analyzing" header alarm to the all-sources-down case to stop it flapping between silence and detections on a multi-source model. That left a partly-degraded model (one source down, the rest healthy) reading a plain "idle" in the header, indistinguishable from a healthy quiet model unless you expanded the per-source list. This adds a small persistent amber "N of M sources down" chip in the model header, driven purely by source health (`anySourceDown && !allSourcesDown`) so it never flaps, and mutually exclusive with the red all-sources-down state. The new i18n keys are translated across all locales.

The amber header indicators (the new chip plus the existing paused and VAD-unavailable spans) are darkened to `amber-700` so their text meets WCAG AA contrast on the light card surface (dark theme is unchanged), and the detection-detail tab buttons get an explicit `type="button"`.

## Test Plan

- [x] `go test -race ./internal/api/v2/species/` covers the 0.0-present and unset-absent serialization cases.
- [x] `npm test` covers the DetectionDetail coordinate render and missing-coordinate guard, and the SystemInference chip across healthy, partial, and all-down states.
- [x] `golangci-lint` and `npm run check:all` pass.
- [ ] Manual: a station at 0.0 lat/lng renders the rarity "based on location" line; a multi-source model with one source down shows the amber chip while still reading active/idle on the right.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Rarity details now display locations at zero coordinates and hide location information when coordinates are unavailable.
  - Inference models distinguish partial source outages from complete outages, showing degraded status while available sources continue analysis.
  - Added explanatory degraded-status messages and tooltips across supported languages.

- **Bug Fixes**
  - Improved warning colors and contrast for paused and voice-activity states.
  - Prevented missing location data from causing display issues.
  - Improved tab button behavior for more reliable interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->