### PR TITLE
fix(datastore/v2): reconcile deleted detections and harden promotion

### DIFF
--- a/internal/datastore/sqlite.go
+++ b/internal/datastore/sqlite.go
@@ -39,7 +39,7 @@ type SQLiteStore struct {
 
 	// dbstatAvailable caches whether the dbstat virtual table exists.
 	// 0 = unchecked, 1 = available, -1 = not available.
-	dbstatAvailable int32
+	dbstatAvailable atomic.Int32
 
 	// Guards to prevent starting monitoring loops more than once.
 	integrityOnce     sync.Once

--- a/internal/datastore/sqlite_inspector.go
+++ b/internal/datastore/sqlite_inspector.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/errors"
 	"gorm.io/gorm"
 	gormlogger "gorm.io/gorm/logger"
 )
@@ -78,18 +79,28 @@ func (s *SQLiteStore) GetEngineDetails() (EngineDetails, error) {
 // available, caching availability in `available` (0=unchecked, 1=available, -1=unavailable)
 // so an absent dbstat table is probed once instead of on every refresh (which also avoids
 // repeated WARN logs when SQLITE_ENABLE_DBSTAT_VTAB is not compiled in). It falls back to
-// `estimate` when dbstat is unavailable or the probe fails. Shared by the legacy and v2-only
-// SQLite inspectors so the caching logic cannot drift.
-func ResolveCachedTableStats(available *atomic.Int32, viaDBStat, estimate func() ([]TableStats, error)) ([]TableStats, error) {
+// `estimate` when dbstat is unavailable or the probe fails. A transient lock error
+// (SQLITE_BUSY/LOCKED) does NOT poison the cache: only a genuine failure marks dbstat
+// unavailable, so a momentary lock cannot permanently disable exact stats for the process.
+// Shared by the legacy and v2-only SQLite inspectors so the caching logic cannot drift.
+func ResolveCachedTableStats(available *atomic.Int32, viaDBStat, estimate func() ([]TableStats, error)) (stats []TableStats, err error) {
+	if available == nil || viaDBStat == nil || estimate == nil {
+		return nil, errors.Newf("ResolveCachedTableStats: nil argument").Build()
+	}
 	if available.Load() == -1 {
 		return estimate()
 	}
-	stats, err := viaDBStat()
+	stats, err = viaDBStat()
 	if err == nil {
 		available.Store(1)
 		return stats, nil
 	}
-	available.Store(-1)
+	// Cache unavailability only on a genuine error (e.g. the dbstat vtab is not compiled in).
+	// A transient lock must not permanently disable dbstat, so leave the cache unchanged and
+	// fall back to estimation just for this call.
+	if !IsTransientDBError(err) {
+		available.Store(-1)
+	}
 	return estimate()
 }
 

--- a/internal/datastore/sqlite_inspector.go
+++ b/internal/datastore/sqlite_inspector.go
@@ -74,24 +74,31 @@ func (s *SQLiteStore) GetEngineDetails() (EngineDetails, error) {
 	return EngineDetails{SQLite: details}, nil
 }
 
+// ResolveCachedTableStats returns per-table stats via the dbstat virtual table when it is
+// available, caching availability in `available` (0=unchecked, 1=available, -1=unavailable)
+// so an absent dbstat table is probed once instead of on every refresh (which also avoids
+// repeated WARN logs when SQLITE_ENABLE_DBSTAT_VTAB is not compiled in). It falls back to
+// `estimate` when dbstat is unavailable or the probe fails. Shared by the legacy and v2-only
+// SQLite inspectors so the caching logic cannot drift.
+func ResolveCachedTableStats(available *atomic.Int32, viaDBStat, estimate func() ([]TableStats, error)) ([]TableStats, error) {
+	if available.Load() == -1 {
+		return estimate()
+	}
+	stats, err := viaDBStat()
+	if err == nil {
+		available.Store(1)
+		return stats, nil
+	}
+	available.Store(-1)
+	return estimate()
+}
+
 // GetTableStats returns per-table row counts and sizes for all user tables.
 // Tries the dbstat virtual table first; falls back to row-count proportional estimation.
 // Caches dbstat availability to avoid repeated WARN logs when the virtual table
 // is not compiled in (requires SQLITE_ENABLE_DBSTAT_VTAB).
 func (s *SQLiteStore) GetTableStats() ([]TableStats, error) {
-	cached := atomic.LoadInt32(&s.dbstatAvailable)
-	if cached == -1 {
-		return s.getTableStatsEstimated()
-	}
-
-	stats, err := s.getTableStatsViaDBStat()
-	if err == nil {
-		atomic.StoreInt32(&s.dbstatAvailable, 1)
-		return stats, nil
-	}
-
-	atomic.StoreInt32(&s.dbstatAvailable, -1)
-	return s.getTableStatsEstimated()
+	return ResolveCachedTableStats(&s.dbstatAvailable, s.getTableStatsViaDBStat, s.getTableStatsEstimated)
 }
 
 // getTableStatsViaDBStat uses the dbstat virtual table (requires SQLITE_ENABLE_DBSTAT_VTAB).

--- a/internal/datastore/v2/consolidation.go
+++ b/internal/datastore/v2/consolidation.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
-	"github.com/tphakala/birdnet-go/internal/datastore"
-	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/telemetry"
 )
@@ -31,22 +29,45 @@ type ConsolidationState struct {
 // It writes to a temp file first, then renames to ensure atomic write.
 func WriteConsolidationState(dataDir string, state *ConsolidationState) error {
 	stateFilePath := filepath.Join(dataDir, StateFileName)
-	tempFilePath := stateFilePath + ".tmp"
 
 	data, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal consolidation state: %w", err)
 	}
 
-	// Write to temp file first
-	if err := os.WriteFile(tempFilePath, data, 0o600); err != nil {
-		return fmt.Errorf("failed to write temp state file: %w", err)
+	// Write to a uniquely-named temp file, fsync it, then atomically rename into place. A
+	// unique name avoids colliding with a concurrent writer's temp file, and the fsync makes
+	// the contents durable before the rename so a crash mid-write cannot leave a truncated or
+	// missing breadcrumb behind an intact filename.
+	// Remove any temp files orphaned by a crash between CreateTemp and Rename in a prior run so
+	// they cannot accumulate. Startup is single-threaded, so no concurrent writer races this.
+	if stale, _ := filepath.Glob(filepath.Join(dataDir, StateFileName+".*.tmp")); len(stale) > 0 {
+		for _, f := range stale {
+			_ = os.Remove(f)
+		}
 	}
 
-	// Atomic rename
+	tempFile, err := os.CreateTemp(dataDir, StateFileName+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("failed to create temp state file: %w", err)
+	}
+	tempFilePath := tempFile.Name()
+	// Best-effort cleanup if we return before the rename removes the temp file.
+	defer func() { _ = os.Remove(tempFilePath) }()
+
+	if _, err := tempFile.Write(data); err != nil {
+		_ = tempFile.Close()
+		return fmt.Errorf("failed to write temp state file: %w", err)
+	}
+	if err := tempFile.Sync(); err != nil {
+		_ = tempFile.Close()
+		return fmt.Errorf("failed to sync temp state file: %w", err)
+	}
+	if err := tempFile.Close(); err != nil {
+		return fmt.Errorf("failed to close temp state file: %w", err)
+	}
+
 	if err := os.Rename(tempFilePath, stateFilePath); err != nil {
-		// Clean up temp file on failure
-		_ = os.Remove(tempFilePath)
 		return fmt.Errorf("failed to rename state file: %w", err)
 	}
 
@@ -124,159 +145,6 @@ func reportConsolidationError(operation string, err error, paths ...string) {
 			"datastore-consolidation",
 		)
 	})
-}
-
-// Consolidate performs the database consolidation after migration completes.
-// It renames the legacy database to .old and moves v2 to the configured path.
-//
-// The consolidation sequence is:
-//  1. Write consolidation state file (atomic marker)
-//  2. Checkpoint WAL on v2 (TRUNCATE)
-//  3. Close v2 connection
-//  4. Checkpoint WAL on legacy (TRUNCATE)
-//  5. Close legacy connection
-//  6. Delete any leftover WAL/SHM files (defensive cleanup)
-//  7. Rename: legacy → legacy.TIMESTAMP.old
-//  8. Rename: v2 → configured path
-//  9. Delete consolidation state file
-//  10. Reopen v2 at configured path
-//  11. Mark migration state as COMPLETED in database
-//
-// Parameters:
-//   - v2Manager: the v2 database manager (will be closed and reopened)
-//   - legacyStore: the legacy datastore interface (will be closed)
-//   - configuredPath: the target path for the consolidated database
-//   - dataDir: directory for state file
-//   - log: logger for progress
-//
-// Returns the reopened v2 manager at the new path, or error.
-func Consolidate(
-	v2Manager *SQLiteManager,
-	legacyStore datastore.Interface,
-	configuredPath string,
-	dataDir string,
-	log logger.Logger,
-) (*SQLiteManager, error) {
-	if log == nil {
-		return nil, fmt.Errorf("logger is required")
-	}
-
-	v2Path := v2Manager.Path()
-	backupPath := GenerateBackupPath(configuredPath)
-
-	log.Info("starting database consolidation",
-		logger.String("v2_path", v2Path),
-		logger.String("configured_path", configuredPath),
-		logger.String("backup_path", backupPath))
-
-	// Step 1: Write consolidation state file
-	state := &ConsolidationState{
-		LegacyPath:     configuredPath,
-		V2Path:         v2Path,
-		BackupPath:     backupPath,
-		ConfiguredPath: configuredPath,
-		StartedAt:      time.Now(),
-	}
-	if err := WriteConsolidationState(dataDir, state); err != nil {
-		reportConsolidationError("writeStateFile", err, configuredPath, v2Path)
-		return nil, fmt.Errorf("failed to write consolidation state: %w", err)
-	}
-
-	// Step 2: Checkpoint WAL on v2
-	log.Debug("checkpointing v2 database WAL")
-	if err := v2Manager.CheckpointWAL(); err != nil {
-		reportConsolidationError("v2WalCheckpoint", err, v2Path)
-		_ = DeleteConsolidationState(dataDir)
-		return nil, fmt.Errorf("failed to checkpoint v2 WAL: %w", err)
-	}
-
-	// Step 3: Close v2 connection
-	log.Debug("closing v2 database connection")
-	if err := v2Manager.Close(); err != nil {
-		reportConsolidationError("closeV2", err, v2Path)
-		_ = DeleteConsolidationState(dataDir)
-		return nil, fmt.Errorf("failed to close v2 database: %w", err)
-	}
-
-	// Step 4: Checkpoint WAL on legacy (via type assertion)
-	log.Debug("checkpointing legacy database WAL")
-	if sqliteStore, ok := legacyStore.(*datastore.SQLiteStore); ok {
-		if err := sqliteStore.CheckpointWAL(); err != nil {
-			reportConsolidationError("legacyWalCheckpoint", err, configuredPath)
-			_ = DeleteConsolidationState(dataDir)
-			return nil, fmt.Errorf("failed to checkpoint legacy WAL: %w", err)
-		}
-	}
-
-	// Step 5: Close legacy connection
-	log.Debug("closing legacy database connection")
-	if err := legacyStore.Close(); err != nil {
-		reportConsolidationError("closeLegacy", err, configuredPath)
-		_ = DeleteConsolidationState(dataDir)
-		return nil, fmt.Errorf("failed to close legacy database: %w", err)
-	}
-
-	// Step 6: Delete any leftover WAL/SHM files (defensive cleanup)
-	log.Debug("cleaning up WAL/SHM files")
-	cleanupWALFiles(configuredPath) // legacy
-	cleanupWALFiles(v2Path)         // v2
-
-	// Step 7: Rename legacy → backup
-	log.Debug("renaming legacy database to backup",
-		logger.String("from", configuredPath),
-		logger.String("to", backupPath))
-	if err := os.Rename(configuredPath, backupPath); err != nil {
-		reportConsolidationError("renameLegacyToBackup", err, configuredPath, backupPath)
-		_ = DeleteConsolidationState(dataDir)
-		return nil, fmt.Errorf("failed to rename legacy database to backup: %w", err)
-	}
-
-	// Step 8: Rename v2 → configured path
-	log.Debug("renaming v2 database to configured path",
-		logger.String("from", v2Path),
-		logger.String("to", configuredPath))
-	if err := os.Rename(v2Path, configuredPath); err != nil {
-		reportConsolidationError("renameV2ToConfigured", err, v2Path, configuredPath)
-		// Rollback: restore legacy from backup
-		log.Warn("v2 rename failed, rolling back legacy rename",
-			logger.Error(err))
-		if rollbackErr := os.Rename(backupPath, configuredPath); rollbackErr != nil {
-			reportConsolidationError("rollbackFailed", rollbackErr, backupPath, configuredPath)
-			log.Error("rollback failed - manual intervention required",
-				logger.Error(rollbackErr),
-				logger.String("backup_path", backupPath),
-				logger.String("configured_path", configuredPath))
-			return nil, errors.Join(
-				fmt.Errorf("failed to rename v2 database: %w", err),
-				fmt.Errorf("rollback also failed: %w", rollbackErr),
-			)
-		}
-		_ = DeleteConsolidationState(dataDir)
-		return nil, fmt.Errorf("failed to rename v2 database (rolled back): %w", err)
-	}
-
-	// Step 9: Delete consolidation state file
-	log.Debug("deleting consolidation state file")
-	if err := DeleteConsolidationState(dataDir); err != nil {
-		// Log warning but continue - orphaned state file is harmless
-		log.Warn("failed to delete consolidation state file",
-			logger.Error(err))
-	}
-
-	// Step 10: Reopen v2 at configured path
-	log.Debug("reopening v2 database at configured path",
-		logger.String("path", configuredPath))
-	newManager, err := NewSQLiteManager(Config{DirectPath: configuredPath})
-	if err != nil {
-		reportConsolidationError("reopenV2", err, configuredPath)
-		return nil, fmt.Errorf("failed to reopen v2 database at configured path: %w", err)
-	}
-
-	log.Info("database consolidation completed successfully",
-		logger.String("database_path", configuredPath),
-		logger.String("backup_path", backupPath))
-
-	return newManager, nil
 }
 
 // ResumeConsolidation checks for interrupted consolidation and resumes if needed.

--- a/internal/datastore/v2/consolidation.go
+++ b/internal/datastore/v2/consolidation.go
@@ -71,6 +71,15 @@ func WriteConsolidationState(dataDir string, state *ConsolidationState) error {
 		return fmt.Errorf("failed to rename state file: %w", err)
 	}
 
+	// Best-effort fsync of the parent directory so the rename (a directory-entry change) is
+	// itself durable across a power failure, not just the file contents. The rename already
+	// succeeded, so a failure here only weakens power-loss durability of the breadcrumb, which
+	// leaves the DB in its safe pre-consolidation state.
+	if dir, err := os.Open(dataDir); err == nil {
+		_ = dir.Sync()
+		_ = dir.Close()
+	}
+
 	return nil
 }
 

--- a/internal/datastore/v2/consolidation.go
+++ b/internal/datastore/v2/consolidation.go
@@ -27,7 +27,7 @@ type ConsolidationState struct {
 
 // WriteConsolidationState writes the consolidation state file atomically.
 // It writes to a temp file first, then renames to ensure atomic write.
-func WriteConsolidationState(dataDir string, state *ConsolidationState) error {
+func WriteConsolidationState(dataDir string, state *ConsolidationState, log logger.Logger) error {
 	stateFilePath := filepath.Join(dataDir, StateFileName)
 
 	data, err := json.MarshalIndent(state, "", "  ")
@@ -72,12 +72,21 @@ func WriteConsolidationState(dataDir string, state *ConsolidationState) error {
 	}
 
 	// Best-effort fsync of the parent directory so the rename (a directory-entry change) is
-	// itself durable across a power failure, not just the file contents. The rename already
-	// succeeded, so a failure here only weakens power-loss durability of the breadcrumb, which
-	// leaves the DB in its safe pre-consolidation state.
-	if dir, err := os.Open(dataDir); err == nil {
-		_ = dir.Sync()
-		_ = dir.Close()
+	// durable across a power failure, not just the file contents. The rename already succeeded,
+	// so a failure here does not fail the write, but log it so operators can see the breadcrumb
+	// may not survive power loss.
+	if dir, err := os.Open(dataDir); err != nil {
+		log.Warn("failed to open data dir to fsync consolidation state",
+			logger.String("dir", dataDir), logger.Error(err))
+	} else {
+		if syncErr := dir.Sync(); syncErr != nil {
+			log.Warn("failed to fsync data dir after consolidation state write",
+				logger.String("dir", dataDir), logger.Error(syncErr))
+		}
+		if closeErr := dir.Close(); closeErr != nil {
+			log.Warn("failed to close data dir after consolidation state fsync",
+				logger.String("dir", dataDir), logger.Error(closeErr))
+		}
 	}
 
 	return nil

--- a/internal/datastore/v2/consolidation_test.go
+++ b/internal/datastore/v2/consolidation_test.go
@@ -26,7 +26,7 @@ func TestWriteAndReadConsolidationState(t *testing.T) {
 	}
 
 	// Write state
-	err := WriteConsolidationState(tmpDir, state)
+	err := WriteConsolidationState(tmpDir, state, newTestLogger())
 	require.NoError(t, err)
 
 	// Verify file exists
@@ -173,7 +173,7 @@ func TestResumeConsolidation_AlreadyComplete(t *testing.T) {
 		ConfiguredPath: configuredPath,
 		StartedAt:      time.Now(),
 	}
-	err = WriteConsolidationState(tmpDir, state)
+	err = WriteConsolidationState(tmpDir, state, newTestLogger())
 	require.NoError(t, err)
 
 	// Resume should detect completion and clean up state file
@@ -216,7 +216,7 @@ func TestResumeConsolidation_ResumeFromStep8(t *testing.T) {
 		ConfiguredPath: configuredPath,
 		StartedAt:      time.Now(),
 	}
-	err = WriteConsolidationState(tmpDir, state)
+	err = WriteConsolidationState(tmpDir, state, newTestLogger())
 	require.NoError(t, err)
 
 	// Resume should complete the rename

--- a/internal/datastore/v2/manager.go
+++ b/internal/datastore/v2/manager.go
@@ -235,15 +235,10 @@ func NewSQLiteManager(cfg Config) (*SQLiteManager, error) {
 
 	// Build DSN with recommended SQLite pragmas.
 	// All pragmas are set via DSN query parameters so they apply to every
-	// connection created by the pool, not just the first one.
-	// Use safe separator in case dbPath already contains query parameters
-	// (e.g., "file::memory:?cache=shared" in tests).
+	// connection created by the pool, not just the first one. dsnAppendParams uses a safe
+	// separator in case dbPath already contains query parameters (e.g. "file::memory:?cache=shared").
 	pragmas := fmt.Sprintf("_journal_mode=WAL&_busy_timeout=%d&_foreign_keys=ON&_synchronous=NORMAL&_cache_size=-16000", sqliteBusyTimeoutMs)
-	sep := "?"
-	if strings.Contains(dbPath, "?") {
-		sep = "&"
-	}
-	dsn := dbPath + sep + pragmas
+	dsn := dsnAppendParams(dbPath, pragmas)
 
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
 		Logger: gormLogger,

--- a/internal/datastore/v2/migration/worker.go
+++ b/internal/datastore/v2/migration/worker.go
@@ -622,7 +622,8 @@ func (w *Worker) completeValidation(_ context.Context) runAction {
 // Dirty IDs are records that failed migration previously and are the most likely
 // cause of count mismatches. Iterates over batches until all dirty IDs are
 // processed or no progress is made (to avoid infinite loops on persistent errors).
-// Returns the number of records successfully migrated.
+// Returns the number of dirty IDs reconciled (migrated from legacy, or removed from v2 when
+// the legacy row was deleted).
 // Returns ctx.Err() if the context is cancelled during processing.
 func (w *Worker) processDirtyIDs(ctx context.Context) (int64, error) {
 	var totalCaught int64
@@ -655,8 +656,9 @@ func (w *Worker) processDirtyIDs(ctx context.Context) (int64, error) {
 	return totalCaught, nil
 }
 
-// processDirtyIDsBatch processes a single batch of dirty IDs, migrating each
-// from legacy to v2. Returns the count of successfully migrated records.
+// processDirtyIDsBatch processes a single batch of dirty IDs, migrating each from legacy to
+// v2. Returns the count of dirty IDs reconciled in this batch: records migrated, plus ghosts
+// removed from v2 when their legacy row was deleted (both count as forward progress).
 func (w *Worker) processDirtyIDsBatch(ctx context.Context, dirtyIDs []uint) (int64, error) {
 	var caught int64
 	for _, dirtyID := range dirtyIDs {
@@ -685,13 +687,22 @@ func (w *Worker) processDirtyIDsBatch(ctx context.Context, dirtyIDs []uint) (int
 			continue
 		}
 		if len(results) == 0 || results[0].ID != dirtyID {
-			w.logger.Warn("dirty ID not found in legacy, removing",
-				logger.Uint64("id", uint64(dirtyID)))
-			if removeErr := w.stateManager.RemoveDirtyID(dirtyID); removeErr != nil {
-				w.logger.Warn("failed to remove stale dirty ID",
+			// The legacy row for this dirty ID is gone, so the detection was deleted and any
+			// surviving v2 row is an orphan that would resurrect after v2 promotion (Forgejo
+			// #1581). Reconcile the v2 side and clear the marker via the same shared helper the
+			// runtime reconciler (DualWriteRepository.reconcileDirtyIDs) uses, so the two paths
+			// cannot drift. On any error other than not-found/locked, leave the id dirty for retry.
+			if recErr := repository.ReconcileDeletedGhost(ctx, w.v2Detection, w.stateManager, dirtyID); recErr != nil {
+				w.logger.Warn("failed to reconcile deleted dirty ID in v2, will retry",
 					logger.Uint64("id", uint64(dirtyID)),
-					logger.Error(removeErr))
+					logger.Error(recErr))
+				continue
 			}
+			// Count the reconciled ghost as progress so processDirtyIDs does not stop early
+			// when a batch contained only deletions.
+			w.logger.Debug("dirty ID missing from legacy, reconciled deletion in v2",
+				logger.Uint64("id", uint64(dirtyID)))
+			caught++
 			continue
 		}
 

--- a/internal/datastore/v2/migration/worker_test.go
+++ b/internal/datastore/v2/migration/worker_test.go
@@ -2,6 +2,7 @@ package migration
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"io"
 	"path/filepath"
@@ -16,8 +17,12 @@ import (
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
 	datastoreV2 "github.com/tphakala/birdnet-go/internal/datastore/v2"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
+	"github.com/tphakala/birdnet-go/internal/datastore/v2/repository"
 	"github.com/tphakala/birdnet-go/internal/detection"
 	"github.com/tphakala/birdnet-go/internal/logger"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	gorm_logger "gorm.io/gorm/logger"
 )
 
 func TestWorker_PanicDoesNotTriggerCancelledTelemetry(t *testing.T) {
@@ -561,4 +566,200 @@ func TestWorker_SwitchStatementCoverage(t *testing.T) {
 			assert.Equal(t, tt.checkState, state.State)
 		})
 	}
+}
+
+// newOnDiskDetectionRepo builds a real v2 detection repository over an isolated
+// on-disk SQLite database with foreign-key constraints disabled, so a bare ghost
+// detection can be planted without wiring up label/model rows. The returned
+// *sql.DB lets a test close the connection to force a non-not-found delete error.
+func newOnDiskDetectionRepo(t *testing.T) (repository.DetectionRepository, *sql.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "v2det.db")), &gorm.Config{
+		Logger:                                   gorm_logger.Default.LogMode(gorm_logger.Silent),
+		DisableForeignKeyConstraintWhenMigrating: true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&entities.Detection{}, &entities.DetectionLock{}, &entities.DetectionReview{}))
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	t.Cleanup(func() { assert.NoError(t, sqlDB.Close()) })
+	return repository.NewDetectionRepository(db, nil, false, false), sqlDB
+}
+
+// plantGhostDetection inserts a v2 detection row that has no matching legacy row,
+// simulating a dual-write delete where the legacy row was removed but the v2 delete
+// failed and the id was marked dirty (Forgejo #1581).
+func plantGhostDetection(t *testing.T, repo repository.DetectionRepository, id uint) {
+	t.Helper()
+	require.NoError(t, repo.SaveWithID(t.Context(), &entities.Detection{
+		ID:         id,
+		ModelID:    1,
+		LabelID:    1,
+		DetectedAt: time.Now().Unix(),
+		Confidence: 0.9,
+	}))
+}
+
+// TestWorker_ProcessDirtyIDsBatch_DeletesV2GhostWhenLegacyDeleted verifies the
+// Forgejo #1581 fix: a dirty id whose legacy row is gone means the detection was
+// deleted, so the orphaned v2 row must be removed (not just the dirty marker),
+// otherwise the deleted detection resurrects after v2 promotion.
+func TestWorker_ProcessDirtyIDsBatch_DeletesV2GhostWhenLegacyDeleted(t *testing.T) {
+	sm, cleanup := setupWorkerTest(t)
+	defer cleanup()
+
+	v2Repo, _ := newOnDiskDetectionRepo(t)
+	const ghostID = uint(4242)
+	plantGhostDetection(t, v2Repo, ghostID)
+	require.NoError(t, sm.AddDirtyID(ghostID))
+
+	// Positive control: the ghost really is present in v2 before reconciliation, so the
+	// post-condition below proves a deletion happened rather than the row never existing.
+	_, preErr := v2Repo.Get(t.Context(), ghostID)
+	require.NoError(t, preErr, "ghost detection must exist before reconciliation")
+
+	// Legacy no longer has the row: Search returns no results.
+	mockLegacy := mocks.NewMockDetectionRepository(t)
+	mockLegacy.EXPECT().
+		Search(mock.Anything, mock.Anything).
+		Return(nil, int64(0), nil).
+		Once()
+
+	w := &Worker{
+		stateManager: sm,
+		legacy:       mockLegacy,
+		v2Detection:  v2Repo,
+		logger:       testLogger(),
+		batchSize:    DefaultBatchSize,
+	}
+
+	caught, err := w.processDirtyIDsBatch(t.Context(), []uint{ghostID})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), caught, "a reconciled ghost counts as progress so catch-up does not stop early")
+
+	_, getErr := v2Repo.Get(t.Context(), ghostID)
+	require.ErrorIs(t, getErr, repository.ErrDetectionNotFound,
+		"orphaned v2 detection must be deleted so it cannot resurrect after promotion")
+
+	count, err := sm.GetDirtyIDCount()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count, "dirty id should be cleared after v2 ghost reconciliation")
+}
+
+// TestWorker_ProcessDirtyIDsBatch_ClearsDirtyWhenNeitherHasRow verifies that a
+// dirty id absent from both legacy and v2 is treated as reconciled: the v2 delete
+// returns ErrDetectionNotFound (a no-op) and the dirty marker is cleared.
+func TestWorker_ProcessDirtyIDsBatch_ClearsDirtyWhenNeitherHasRow(t *testing.T) {
+	sm, cleanup := setupWorkerTest(t)
+	defer cleanup()
+
+	v2Repo, _ := newOnDiskDetectionRepo(t)
+	const missingID = uint(999)
+	require.NoError(t, sm.AddDirtyID(missingID))
+
+	mockLegacy := mocks.NewMockDetectionRepository(t)
+	mockLegacy.EXPECT().
+		Search(mock.Anything, mock.Anything).
+		Return(nil, int64(0), nil).
+		Once()
+
+	w := &Worker{
+		stateManager: sm,
+		legacy:       mockLegacy,
+		v2Detection:  v2Repo,
+		logger:       testLogger(),
+		batchSize:    DefaultBatchSize,
+	}
+
+	caught, err := w.processDirtyIDsBatch(t.Context(), []uint{missingID})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), caught, "a not-found ghost is reconciled and counts as progress")
+
+	count, err := sm.GetDirtyIDCount()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count, "dirty id should be cleared when v2 delete is a no-op")
+}
+
+// TestWorker_ProcessDirtyIDsBatch_KeepsDirtyWhenV2DeleteErrors verifies that a
+// non-not-found v2 delete error leaves the id dirty for a later retry rather than
+// dropping the marker (which would strand the orphaned v2 row).
+func TestWorker_ProcessDirtyIDsBatch_KeepsDirtyWhenV2DeleteErrors(t *testing.T) {
+	sm, cleanup := setupWorkerTest(t)
+	defer cleanup()
+
+	v2Repo, v2SQLDB := newOnDiskDetectionRepo(t)
+	const ghostID = uint(555)
+	plantGhostDetection(t, v2Repo, ghostID)
+	require.NoError(t, sm.AddDirtyID(ghostID))
+
+	// Force the v2 delete to fail with a non-retryable, non-not-found error by dropping the
+	// locks table its NOT EXISTS subquery references. Closing the DB would instead surface as a
+	// retryable "database is closed" error and burn the full retry backoff (~9s).
+	_, dropErr := v2SQLDB.Exec("DROP TABLE detection_locks")
+	require.NoError(t, dropErr)
+
+	mockLegacy := mocks.NewMockDetectionRepository(t)
+	mockLegacy.EXPECT().
+		Search(mock.Anything, mock.Anything).
+		Return(nil, int64(0), nil).
+		Once()
+
+	w := &Worker{
+		stateManager: sm,
+		legacy:       mockLegacy,
+		v2Detection:  v2Repo,
+		logger:       testLogger(),
+		batchSize:    DefaultBatchSize,
+	}
+
+	caught, err := w.processDirtyIDsBatch(t.Context(), []uint{ghostID})
+	require.NoError(t, err, "a per-id v2 delete failure is logged, not returned")
+	assert.Equal(t, int64(0), caught)
+
+	count, err := sm.GetDirtyIDCount()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count, "dirty id must remain for retry when the v2 delete fails")
+}
+
+// TestWorker_ProcessDirtyIDsBatch_KeepsLockedGhostButClearsDirty verifies that when the v2
+// ghost is locked (user-verified) and its legacy row is gone, the reconciler does not
+// force-delete the protected row but still clears the dirty marker, so the id cannot block
+// migration validation forever (Forgejo #1581 follow-up).
+func TestWorker_ProcessDirtyIDsBatch_KeepsLockedGhostButClearsDirty(t *testing.T) {
+	sm, cleanup := setupWorkerTest(t)
+	defer cleanup()
+
+	v2Repo, _ := newOnDiskDetectionRepo(t)
+	const ghostID = uint(7777)
+	plantGhostDetection(t, v2Repo, ghostID)
+	require.NoError(t, v2Repo.Lock(t.Context(), ghostID))
+	require.NoError(t, sm.AddDirtyID(ghostID))
+
+	mockLegacy := mocks.NewMockDetectionRepository(t)
+	mockLegacy.EXPECT().
+		Search(mock.Anything, mock.Anything).
+		Return(nil, int64(0), nil).
+		Once()
+
+	w := &Worker{
+		stateManager: sm,
+		legacy:       mockLegacy,
+		v2Detection:  v2Repo,
+		logger:       testLogger(),
+		batchSize:    DefaultBatchSize,
+	}
+
+	caught, err := w.processDirtyIDsBatch(t.Context(), []uint{ghostID})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), caught, "a locked ghost is reconciled (marker cleared) and counts as progress")
+
+	// The locked, user-verified row must NOT be force-deleted.
+	_, getErr := v2Repo.Get(t.Context(), ghostID)
+	require.NoError(t, getErr, "a locked v2 detection must be preserved, not force-deleted")
+
+	// But the dirty marker is cleared so it cannot block migration validation forever.
+	count, err := sm.GetDirtyIDCount()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count, "dirty id must be cleared even when the v2 row is locked")
 }

--- a/internal/datastore/v2/repository/dual_write.go
+++ b/internal/datastore/v2/repository/dual_write.go
@@ -188,6 +188,30 @@ func (dw *DualWriteRepository) StartReconciliation() {
 	})
 }
 
+// ReconcileDeletedGhost removes from v2 a detection whose legacy row no longer exists and
+// clears its dirty marker. During dual-write legacy is the source of truth and its row is
+// deleted before the v2 row (DualWriteRepository.Delete), so a missing legacy row means the
+// detection was deleted; a surviving v2 row is an orphan that would resurrect after v2
+// promotion (Forgejo #1581). A row already absent from v2 (ErrDetectionNotFound) needs no
+// delete. A locked, user-verified v2 row (ErrDetectionLocked) is never force-deleted; its
+// marker is still cleared so the id does not linger in the dirty set and block migration
+// validation forever, and the protected row is left in place. Any other delete error leaves
+// the marker for a later retry (a non-nil return); it returns nil once the marker is cleared
+// or the row was already gone.
+//
+// This is shared by the runtime reconciler (reconcileDirtyIDs) and the migration catch-up
+// worker so the two paths cannot drift.
+func ReconcileDeletedGhost(ctx context.Context, v2Repo DetectionRepository, sm *v2.StateManager, id uint) error {
+	if v2Repo == nil || sm == nil {
+		return fmt.Errorf("reconcile deleted ghost %d: nil repository or state manager", id)
+	}
+	if delErr := v2Repo.Delete(ctx, id); delErr != nil &&
+		!errors.Is(delErr, ErrDetectionNotFound) && !errors.Is(delErr, ErrDetectionLocked) {
+		return delErr
+	}
+	return sm.RemoveDirtyID(id)
+}
+
 // reconcileDirtyIDs processes a batch of dirty IDs using legacy as source of truth.
 func (dw *DualWriteRepository) reconcileDirtyIDs() {
 	count, err := dw.stateManager.GetDirtyIDCount()
@@ -224,17 +248,12 @@ func (dw *DualWriteRepository) reconcileDirtyIDs() {
 			result, err := dw.legacy.Get(ctx, idStr)
 			if err != nil {
 				if errors.IsNotFound(err) {
-					// Record genuinely deleted from legacy — remove v2 ghost
-					if delErr := dw.v2.Delete(ctx, id); delErr != nil && !errors.Is(delErr, ErrDetectionNotFound) {
-						dw.logger.Warn("reconciliation: v2 delete failed", logger.Uint64("id", uint64(id)), logger.Error(delErr))
+					// Record deleted from legacy: reconcile the v2 side and clear the marker.
+					if recErr := ReconcileDeletedGhost(ctx, dw.v2, dw.stateManager, id); recErr != nil {
+						dw.logger.Warn("reconciliation: failed to reconcile deleted detection in v2", logger.Uint64("id", uint64(id)), logger.Error(recErr))
 						return
 					}
-					// Ghost removed (or never existed in v2) — clear dirty ID
-					if rmErr := dw.stateManager.RemoveDirtyID(id); rmErr != nil {
-						dw.logger.Warn("reconciliation: failed to remove dirty ID", logger.Uint64("id", uint64(id)), logger.Error(rmErr))
-					} else {
-						reconciled++
-					}
+					reconciled++
 					return
 				}
 				// Transient legacy error — skip, retry next cycle

--- a/internal/datastore/v2/repository/dual_write_test.go
+++ b/internal/datastore/v2/repository/dual_write_test.go
@@ -7,8 +7,13 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
+	datastoreV2 "github.com/tphakala/birdnet-go/internal/datastore/v2"
+	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
+	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
@@ -236,4 +241,53 @@ func TestReconciliation_ShutdownWithoutStart(t *testing.T) {
 	assert.NotPanics(t, func() {
 		dw.Shutdown()
 	})
+}
+
+// TestReconcileDirtyIDs_DeletesGhostWhenLegacyDeleted exercises the runtime reconciler's
+// call site of ReconcileDeletedGhost: a dirty id whose legacy row is gone must have its
+// orphaned v2 row deleted and its dirty marker cleared, so the deleted detection cannot
+// resurrect after v2 promotion (Forgejo #1581).
+func TestReconcileDirtyIDs_DeletesGhostWhenLegacyDeleted(t *testing.T) {
+	t.Parallel()
+
+	db := setupDetectionTestDB(t)
+	require.NoError(t, db.AutoMigrate(&entities.MigrationDirtyID{}))
+	v2Repo := NewDetectionRepository(db, nil, false, false)
+	sm := datastoreV2.NewStateManager(db)
+
+	const ghostID = uint(4242)
+	require.NoError(t, v2Repo.SaveWithID(t.Context(), &entities.Detection{
+		ID:         ghostID,
+		ModelID:    1,
+		LabelID:    1,
+		DetectedAt: time.Now().Unix(),
+		Confidence: 0.9,
+	}))
+	require.NoError(t, sm.AddDirtyID(ghostID))
+
+	// Legacy reports the row as deleted (source of truth during dual-write).
+	mockLegacy := mocks.NewMockDetectionRepository(t)
+	mockLegacy.EXPECT().
+		Get(mock.Anything, mock.Anything).
+		Return(nil, errors.Newf("detection %d not found", ghostID).Category(errors.CategoryNotFound).Build()).
+		Once()
+
+	dw := &DualWriteRepository{
+		legacy:       mockLegacy,
+		v2:           v2Repo,
+		stateManager: sm,
+		logger:       testLogger(),
+		shutdownCh:   make(chan struct{}),
+		semaphore:    make(chan struct{}, defaultMaxConcurrentWrites),
+		writeTimeout: defaultWriteTimeout,
+	}
+
+	dw.reconcileDirtyIDs()
+
+	_, getErr := v2Repo.Get(t.Context(), ghostID)
+	require.ErrorIs(t, getErr, ErrDetectionNotFound, "reconciler must delete the orphaned v2 ghost")
+
+	count, err := sm.GetDirtyIDCount()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count, "reconciler must clear the dirty marker after deleting the ghost")
 }

--- a/internal/datastore/v2/startup.go
+++ b/internal/datastore/v2/startup.go
@@ -879,21 +879,13 @@ func checkpointSQLiteWAL(dbPath string, log logger.Logger) error {
 
 // moveSQLiteDBFiles renames a SQLite database file together with its -wal and -shm
 // sidecars, so no committed WAL data is left behind or discarded during consolidation.
-// The move is all-or-nothing: it first refuses to clobber an existing destination, then
-// renames the main file, then each present sidecar; any failure (including a non-not-exist
-// stat error on a sidecar, which may hide live WAL data) rolls back every completed rename
-// and returns an error, so the caller never sees a half-moved database reported as success
-// (Forgejo #1580).
+// The move is all-or-nothing: the main file is renamed first, then each present sidecar;
+// any failure (including a non-not-exist stat error on a sidecar, which may hide live WAL
+// data) rolls back every completed rename and returns an error, so the caller never sees a
+// half-moved database reported as success (Forgejo #1580). It deliberately does NOT reject an
+// existing destination, so it can also serve as the rollback restore path (which must be able
+// to overwrite); a forward caller is responsible for ensuring its destination is free.
 func moveSQLiteDBFiles(from, to string, log logger.Logger) error {
-	// Refuse to overwrite an existing destination. os.Rename would silently replace it and a
-	// later revert could not restore it (e.g. a prior backup already at backupPath). Callers
-	// always pass a vacated or timestamp-unique destination, so an existing one is an
-	// unexpected collision. Lstat, not Stat, so a symlink at the destination also counts.
-	if _, err := os.Lstat(to); err == nil {
-		return fmt.Errorf("refusing to move SQLite database onto existing destination %q", to)
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("failed to stat destination %q: %w", to, err)
-	}
 	if err := os.Rename(from, to); err != nil {
 		return fmt.Errorf("failed to rename SQLite database %q to %q: %w", from, to, err)
 	}
@@ -1355,6 +1347,19 @@ func CheckAndConsolidateAtStartup(configuredPath string, log logger.Logger) (con
 	// Generate backup path for legacy database
 	backupPath := GenerateBackupPath(configuredPath)
 
+	// Refuse to overwrite an existing backup destination (main file or a -wal/-shm sidecar)
+	// before doing any work. GenerateBackupPath is timestamped, so a collision means a
+	// same-second re-run; the legacy->backup rename would otherwise clobber a prior backup that
+	// the rollback could not restore, so fail closed (Forgejo #1580). moveSQLiteDBFiles itself
+	// stays overwrite-capable so it can serve as the rollback restore path.
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		if _, statErr := os.Lstat(backupPath + suffix); statErr == nil {
+			return false, fmt.Errorf("consolidation aborted: backup destination %q already exists", backupPath+suffix)
+		} else if !os.IsNotExist(statErr) {
+			return false, fmt.Errorf("failed to stat backup destination %q: %w", backupPath+suffix, statErr)
+		}
+	}
+
 	// Write consolidation state file
 	state := &ConsolidationState{
 		LegacyPath:     configuredPath,
@@ -1363,7 +1368,7 @@ func CheckAndConsolidateAtStartup(configuredPath string, log logger.Logger) (con
 		ConfiguredPath: configuredPath,
 		StartedAt:      time.Now(),
 	}
-	if err := WriteConsolidationState(dataDir, state); err != nil {
+	if err := WriteConsolidationState(dataDir, state, log); err != nil {
 		reportConsolidationError("writeStateFile", err, configuredPath, v2MigrationPath)
 		diagnostics.RecordConsolidation(j, v2MigrationPath, configuredPath, backupPath, "failed")
 		return false, fmt.Errorf("failed to write consolidation state: %w", err)

--- a/internal/datastore/v2/startup.go
+++ b/internal/datastore/v2/startup.go
@@ -877,6 +877,11 @@ func checkpointSQLiteWAL(dbPath string, log logger.Logger) error {
 	return nil
 }
 
+// sqliteSidecarSuffixes are the SQLite auxiliary file suffixes that travel with a database
+// file (write-ahead log and shared-memory index). Shared so the consolidation preflight and
+// moveSQLiteDBFiles agree on exactly which sidecars accompany a move.
+var sqliteSidecarSuffixes = []string{"-wal", "-shm"}
+
 // moveSQLiteDBFiles renames a SQLite database file together with its -wal and -shm
 // sidecars, so no committed WAL data is left behind or discarded during consolidation.
 // The move is all-or-nothing: the main file is renamed first, then each present sidecar;
@@ -905,7 +910,7 @@ func moveSQLiteDBFiles(from, to string, log logger.Logger) error {
 			}
 		}
 	}
-	for _, suffix := range []string{"-wal", "-shm"} {
+	for _, suffix := range sqliteSidecarSuffixes {
 		src := from + suffix
 		dst := to + suffix
 		if _, err := os.Stat(src); err != nil {
@@ -1352,7 +1357,8 @@ func CheckAndConsolidateAtStartup(configuredPath string, log logger.Logger) (con
 	// same-second re-run; the legacy->backup rename would otherwise clobber a prior backup that
 	// the rollback could not restore, so fail closed (Forgejo #1580). moveSQLiteDBFiles itself
 	// stays overwrite-capable so it can serve as the rollback restore path.
-	for _, suffix := range []string{"", "-wal", "-shm"} {
+	// Check the primary file ("") plus each sidecar.
+	for _, suffix := range append([]string{""}, sqliteSidecarSuffixes...) {
 		if _, statErr := os.Lstat(backupPath + suffix); statErr == nil {
 			return false, fmt.Errorf("consolidation aborted: backup destination %q already exists", backupPath+suffix)
 		} else if !os.IsNotExist(statErr) {
@@ -1400,6 +1406,14 @@ func CheckAndConsolidateAtStartup(configuredPath string, log logger.Logger) (con
 			diagnostics.RecordConsolidation(j, v2MigrationPath, configuredPath, backupPath, "failed")
 			return false, fmt.Errorf("failed to rename legacy database: %w", err)
 		}
+	} else if !os.IsNotExist(err) {
+		// A non-not-exist stat error (permission/I/O) must not silently skip the legacy backup:
+		// the v2 -> configured move below would then rename over the still-present legacy
+		// database with no backup taken. Fail closed instead of clobbering it.
+		reportConsolidationError("startupStatLegacy", err, configuredPath)
+		_ = DeleteConsolidationState(dataDir)
+		diagnostics.RecordConsolidation(j, v2MigrationPath, configuredPath, backupPath, "failed")
+		return false, fmt.Errorf("failed to stat legacy database %q before backup: %w", configuredPath, err)
 	}
 
 	// Rename v2 → configured path, moving its -wal/-shm sidecars so the promoted

--- a/internal/datastore/v2/startup.go
+++ b/internal/datastore/v2/startup.go
@@ -879,11 +879,21 @@ func checkpointSQLiteWAL(dbPath string, log logger.Logger) error {
 
 // moveSQLiteDBFiles renames a SQLite database file together with its -wal and -shm
 // sidecars, so no committed WAL data is left behind or discarded during consolidation.
-// The move is all-or-nothing: the main file is renamed first, then each present sidecar;
-// any failure (including a non-not-exist stat error on a sidecar, which may hide live WAL
-// data) rolls back every completed rename and returns an error, so the caller never sees a
-// half-moved database reported as success (Forgejo #1580).
+// The move is all-or-nothing: it first refuses to clobber an existing destination, then
+// renames the main file, then each present sidecar; any failure (including a non-not-exist
+// stat error on a sidecar, which may hide live WAL data) rolls back every completed rename
+// and returns an error, so the caller never sees a half-moved database reported as success
+// (Forgejo #1580).
 func moveSQLiteDBFiles(from, to string, log logger.Logger) error {
+	// Refuse to overwrite an existing destination. os.Rename would silently replace it and a
+	// later revert could not restore it (e.g. a prior backup already at backupPath). Callers
+	// always pass a vacated or timestamp-unique destination, so an existing one is an
+	// unexpected collision. Lstat, not Stat, so a symlink at the destination also counts.
+	if _, err := os.Lstat(to); err == nil {
+		return fmt.Errorf("refusing to move SQLite database onto existing destination %q", to)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to stat destination %q: %w", to, err)
+	}
 	if err := os.Rename(from, to); err != nil {
 		return fmt.Errorf("failed to rename SQLite database %q to %q: %w", from, to, err)
 	}
@@ -908,6 +918,13 @@ func moveSQLiteDBFiles(from, to string, log logger.Logger) error {
 		dst := to + suffix
 		if _, err := os.Stat(src); err != nil {
 			if os.IsNotExist(err) {
+				// os.Stat follows symlinks, so a broken/dangling symlink also reports not-exist.
+				// If the link entry itself exists, fail closed rather than treat it as "absent":
+				// silently skipping it would leave it behind and break the all-or-nothing move.
+				if _, lerr := os.Lstat(src); lerr == nil {
+					revert()
+					return fmt.Errorf("SQLite sidecar %q is a broken symlink; refusing to leave it behind", src)
+				}
 				// Source sidecar genuinely absent (a checkpoint truncated it and SQLite removed
 				// the file). Remove any stale sidecar left at the destination so it is not wrongly
 				// paired with the moved database when it is next opened.

--- a/internal/datastore/v2/startup.go
+++ b/internal/datastore/v2/startup.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -22,12 +23,19 @@ import (
 )
 
 // readOnlyDSN appends mode=ro to a SQLite path, using the correct query separator.
-func readOnlyDSN(dbPath string) string {
+// dsnAppendParams appends SQLite DSN query parameters to a database path, choosing "?" or
+// "&" depending on whether the path already carries a query string (e.g. a shared-cache
+// in-memory DSN used in tests).
+func dsnAppendParams(dbPath, params string) string {
 	sep := "?"
 	if strings.Contains(dbPath, "?") {
 		sep = "&"
 	}
-	return dbPath + sep + "mode=ro"
+	return dbPath + sep + params
+}
+
+func readOnlyDSN(dbPath string) string {
+	return dsnAppendParams(dbPath, "mode=ro")
 }
 
 // reportStartupError reports a startup state check failure to Sentry telemetry.
@@ -560,20 +568,6 @@ func checkMySQLMigrationState(settings *conf.Settings) StartupState {
 	}
 }
 
-// IsV2OnlyModeAvailable returns true if the system can run in v2-only mode.
-// This is true when migration is completed and v2 database is available.
-func IsV2OnlyModeAvailable(settings *conf.Settings) bool {
-	state := CheckMigrationStateBeforeStartup(settings)
-	return state.MigrationStatus == entities.MigrationStatusCompleted && state.V2Available
-}
-
-// ShouldSkipLegacyDatabase returns true if the legacy database should not be opened.
-// This happens when migration is complete and we're running in v2-only mode.
-func ShouldSkipLegacyDatabase(settings *conf.Settings) bool {
-	state := CheckMigrationStateBeforeStartup(settings)
-	return !state.LegacyRequired && state.MigrationStatus == entities.MigrationStatusCompleted
-}
-
 // HasUnmigratedLegacyRecords reports whether the migration is complete but some
 // legacy records are not yet safely present in v2. This detects data loss from
 // hard crashes (kill -9, power loss, OOM) during the tail sync window, and (issue
@@ -855,7 +849,12 @@ func checkpointSQLiteWAL(dbPath string, log logger.Logger) error {
 		return err
 	}
 
-	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{
+	// Open with busy_timeout in the DSN so the checkpoint waits for a briefly-held lock (a
+	// loaded runner or a slow shutdown) instead of failing immediately with SQLITE_BUSY. The
+	// DSN applies the timeout to every pooled connection, matching the package-wide value used
+	// for normal connections (manager.go).
+	dsn := dsnAppendParams(dbPath, fmt.Sprintf("_busy_timeout=%d", sqliteBusyTimeoutMs))
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
 		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
 	})
 	if err != nil {
@@ -880,28 +879,54 @@ func checkpointSQLiteWAL(dbPath string, log logger.Logger) error {
 
 // moveSQLiteDBFiles renames a SQLite database file together with its -wal and -shm
 // sidecars, so no committed WAL data is left behind or discarded during consolidation.
-// The main file rename is authoritative and its failure is returned; sidecar moves are
-// best-effort and only logged, because after a successful checkpoint the sidecars are
-// empty and after an unclean shutdown moving them alongside preserves their data.
+// The move is all-or-nothing: the main file is renamed first, then each present sidecar;
+// any failure (including a non-not-exist stat error on a sidecar, which may hide live WAL
+// data) rolls back every completed rename and returns an error, so the caller never sees a
+// half-moved database reported as success (Forgejo #1580).
 func moveSQLiteDBFiles(from, to string, log logger.Logger) error {
 	if err := os.Rename(from, to); err != nil {
-		return err
+		return fmt.Errorf("failed to rename SQLite database %q to %q: %w", from, to, err)
+	}
+	// Track completed renames so a later failure can undo them in reverse, keeping the move
+	// all-or-nothing. The main file is renamed first, so any failure below must revert it;
+	// otherwise the source database is stranded without its uncheckpointed WAL while the
+	// caller still believes the pre-move state can be cleanly rolled back.
+	type movedFile struct{ src, dst string }
+	done := []movedFile{{src: from, dst: to}}
+	revert := func() {
+		for _, m := range slices.Backward(done) {
+			if rbErr := os.Rename(m.dst, m.src); rbErr != nil {
+				log.Error("failed to roll back SQLite file move; database files may be inconsistent",
+					logger.String("from", m.dst),
+					logger.String("to", m.src),
+					logger.Error(rbErr))
+			}
+		}
 	}
 	for _, suffix := range []string{"-wal", "-shm"} {
 		src := from + suffix
+		dst := to + suffix
 		if _, err := os.Stat(src); err != nil {
-			// Source sidecar absent (e.g. checkpoint truncated it and SQLite removed the
-			// file). Remove any stale sidecar left at the destination so it is not wrongly
-			// paired with the moved database when it is next opened.
-			_ = os.Remove(to + suffix)
-			continue
+			if os.IsNotExist(err) {
+				// Source sidecar genuinely absent (a checkpoint truncated it and SQLite removed
+				// the file). Remove any stale sidecar left at the destination so it is not wrongly
+				// paired with the moved database when it is next opened.
+				if rmErr := os.Remove(dst); rmErr != nil && !os.IsNotExist(rmErr) {
+					revert()
+					return fmt.Errorf("failed to remove stale destination sidecar %q: %w", dst, rmErr)
+				}
+				continue
+			}
+			// A non-not-exist stat error (permission, I/O) must not be treated as "absent": the
+			// sidecar may still hold live WAL data. Fail closed and roll back.
+			revert()
+			return fmt.Errorf("failed to stat SQLite sidecar %q: %w", src, err)
 		}
-		if err := os.Rename(src, to+suffix); err != nil {
-			log.Warn("failed to move SQLite sidecar file during consolidation",
-				logger.String("from", src),
-				logger.String("to", to+suffix),
-				logger.Error(err))
+		if err := os.Rename(src, dst); err != nil {
+			revert()
+			return fmt.Errorf("failed to move SQLite sidecar %q to %q: %w", src, dst, err)
 		}
+		done = append(done, movedFile{src: src, dst: dst})
 	}
 	return nil
 }

--- a/internal/datastore/v2/startup_promotion_test.go
+++ b/internal/datastore/v2/startup_promotion_test.go
@@ -413,6 +413,27 @@ func TestMoveSQLiteDBFiles_FailsClosedWhenStaleSidecarRemovalFails(t *testing.T)
 	assert.NoFileExists(t, to, "destination main db must be rolled back")
 }
 
+// TestMoveSQLiteDBFiles_RefusesToClobberExistingDestination proves the move fails closed
+// rather than overwriting an existing destination database. os.Rename would silently replace
+// it and the revert could not restore it (e.g. a prior backup already at backupPath), so the
+// move must reject the collision and leave both files intact (Forgejo #1580 follow-up).
+func TestMoveSQLiteDBFiles_RefusesToClobberExistingDestination(t *testing.T) {
+	dir := t.TempDir()
+	from := filepath.Join(dir, "src.db")
+	to := filepath.Join(dir, "dst.db")
+
+	require.NoError(t, os.WriteFile(from, []byte("source"), 0o600))
+	require.NoError(t, os.WriteFile(to, []byte("existing-destination"), 0o600))
+
+	err := moveSQLiteDBFiles(from, to, testStartupLogger())
+	require.Error(t, err, "move must refuse to overwrite an existing destination")
+
+	assert.FileExists(t, from, "source must not be moved when the destination already exists")
+	dstBytes, readErr := os.ReadFile(to) //nolint:gosec // test-controlled path
+	require.NoError(t, readErr)
+	assert.Equal(t, "existing-destination", string(dstBytes), "existing destination must be preserved")
+}
+
 // TestCheckpointSQLiteWAL_FoldsWALIntoMainFile proves that checkpointing folds
 // uncheckpointed WAL frames into the main database file (so a later rename of the main
 // file alone carries the data) and truncates the WAL to zero bytes.

--- a/internal/datastore/v2/startup_promotion_test.go
+++ b/internal/datastore/v2/startup_promotion_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -322,6 +323,94 @@ func TestMoveSQLiteDBFiles_PreservesSidecars(t *testing.T) {
 	shmBytes, err := os.ReadFile(to + "-shm") //nolint:gosec // test-controlled path
 	require.NoError(t, err)
 	assert.Equal(t, "shm-index", string(shmBytes))
+}
+
+// TestMoveSQLiteDBFiles_RemovesStaleDestinationSidecar proves that when the source has no
+// sidecars (the normal post-checkpoint path), a stale sidecar left at the destination is
+// removed so it is not wrongly paired with the moved database (Forgejo #1580).
+func TestMoveSQLiteDBFiles_RemovesStaleDestinationSidecar(t *testing.T) {
+	dir := t.TempDir()
+	from := filepath.Join(dir, "src.db")
+	to := filepath.Join(dir, "dst.db")
+
+	require.NoError(t, os.WriteFile(from, []byte("main-db"), 0o600))
+	// No source sidecars, but a stale -wal sits at the destination from a prior database.
+	require.NoError(t, os.WriteFile(to+"-wal", []byte("stale-wal"), 0o600))
+
+	require.NoError(t, moveSQLiteDBFiles(from, to, testStartupLogger()))
+
+	assert.FileExists(t, to)
+	assert.NoFileExists(t, to+"-wal", "stale destination WAL must be removed, not left paired with the moved DB")
+	assert.NoFileExists(t, to+"-shm")
+}
+
+// TestMoveSQLiteDBFiles_FailsClosedAndRevertsOnSidecarFailure proves that a sidecar rename
+// failure is reported (not swallowed as success) and that the already-renamed main file is
+// rolled back, so the caller never sees a half-moved database (Forgejo #1580).
+func TestMoveSQLiteDBFiles_FailsClosedAndRevertsOnSidecarFailure(t *testing.T) {
+	dir := t.TempDir()
+	from := filepath.Join(dir, "src.db")
+	to := filepath.Join(dir, "dst.db")
+
+	require.NoError(t, os.WriteFile(from, []byte("main-db"), 0o600))
+	require.NoError(t, os.WriteFile(from+"-wal", []byte("wal-frames"), 0o600))
+	// Make the destination -wal an existing non-empty directory so renaming the source
+	// -wal file onto it fails, exercising the fail-closed + revert path.
+	require.NoError(t, os.Mkdir(to+"-wal", 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(to+"-wal", "blocker"), []byte("x"), 0o600))
+
+	err := moveSQLiteDBFiles(from, to, testStartupLogger())
+	require.Error(t, err, "a sidecar rename failure must be reported, not swallowed")
+
+	// Revert restored the pre-move state.
+	assert.FileExists(t, from, "main db must be reverted to the source path")
+	assert.FileExists(t, from+"-wal", "source WAL must remain at the source path")
+	assert.NoFileExists(t, to, "destination main db must be rolled back after the failure")
+}
+
+// TestMoveSQLiteDBFiles_FailsClosedOnUnreadableSidecar proves that a non-not-exist stat
+// error on a sidecar is treated as fail-closed (the sidecar may hide live WAL data), not as
+// "absent": the move returns an error and reverts (Forgejo #1580). A self-referential symlink
+// makes os.Stat fail with ELOOP, which is independent of privileges (unlike a chmod, which
+// root bypasses).
+func TestMoveSQLiteDBFiles_FailsClosedOnUnreadableSidecar(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink-based stat error is not portable to Windows")
+	}
+	dir := t.TempDir()
+	from := filepath.Join(dir, "src.db")
+	to := filepath.Join(dir, "dst.db")
+
+	require.NoError(t, os.WriteFile(from, []byte("main-db"), 0o600))
+	require.NoError(t, os.Symlink(from+"-wal", from+"-wal")) // self-loop -> os.Stat returns ELOOP
+
+	err := moveSQLiteDBFiles(from, to, testStartupLogger())
+	require.Error(t, err, "a non-not-exist stat error on a sidecar must fail closed")
+	require.NotErrorIs(t, err, os.ErrNotExist, "the stat error must not be swallowed as absent")
+
+	assert.FileExists(t, from, "main db must be reverted to the source path")
+	assert.NoFileExists(t, to, "destination main db must be rolled back")
+}
+
+// TestMoveSQLiteDBFiles_FailsClosedWhenStaleSidecarRemovalFails proves that when the source
+// has no sidecars but the stale destination sidecar cannot be removed, the move fails closed
+// and reverts rather than silently leaving a mispaired sidecar (Forgejo #1580).
+func TestMoveSQLiteDBFiles_FailsClosedWhenStaleSidecarRemovalFails(t *testing.T) {
+	dir := t.TempDir()
+	from := filepath.Join(dir, "src.db")
+	to := filepath.Join(dir, "dst.db")
+
+	require.NoError(t, os.WriteFile(from, []byte("main-db"), 0o600))
+	// A non-empty directory sits where the stale destination -wal would be, so os.Remove(dst)
+	// fails with a non-not-exist error.
+	require.NoError(t, os.Mkdir(to+"-wal", 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(to+"-wal", "blocker"), []byte("x"), 0o600))
+
+	err := moveSQLiteDBFiles(from, to, testStartupLogger())
+	require.Error(t, err, "a failed stale-sidecar removal must fail closed")
+
+	assert.FileExists(t, from, "main db must be reverted to the source path")
+	assert.NoFileExists(t, to, "destination main db must be rolled back")
 }
 
 // TestCheckpointSQLiteWAL_FoldsWALIntoMainFile proves that checkpointing folds

--- a/internal/datastore/v2/startup_promotion_test.go
+++ b/internal/datastore/v2/startup_promotion_test.go
@@ -413,27 +413,6 @@ func TestMoveSQLiteDBFiles_FailsClosedWhenStaleSidecarRemovalFails(t *testing.T)
 	assert.NoFileExists(t, to, "destination main db must be rolled back")
 }
 
-// TestMoveSQLiteDBFiles_RefusesToClobberExistingDestination proves the move fails closed
-// rather than overwriting an existing destination database. os.Rename would silently replace
-// it and the revert could not restore it (e.g. a prior backup already at backupPath), so the
-// move must reject the collision and leave both files intact (Forgejo #1580 follow-up).
-func TestMoveSQLiteDBFiles_RefusesToClobberExistingDestination(t *testing.T) {
-	dir := t.TempDir()
-	from := filepath.Join(dir, "src.db")
-	to := filepath.Join(dir, "dst.db")
-
-	require.NoError(t, os.WriteFile(from, []byte("source"), 0o600))
-	require.NoError(t, os.WriteFile(to, []byte("existing-destination"), 0o600))
-
-	err := moveSQLiteDBFiles(from, to, testStartupLogger())
-	require.Error(t, err, "move must refuse to overwrite an existing destination")
-
-	assert.FileExists(t, from, "source must not be moved when the destination already exists")
-	dstBytes, readErr := os.ReadFile(to) //nolint:gosec // test-controlled path
-	require.NoError(t, readErr)
-	assert.Equal(t, "existing-destination", string(dstBytes), "existing destination must be preserved")
-}
-
 // TestCheckpointSQLiteWAL_FoldsWALIntoMainFile proves that checkpointing folds
 // uncheckpointed WAL frames into the main database file (so a later rename of the main
 // file alone carries the data) and truncates the WAL to zero bytes.
@@ -538,7 +517,7 @@ func TestResumeConsolidation_PreservesUncheckpointedV2WAL(t *testing.T) {
 		V2Path:         v2Path,
 		BackupPath:     backupPath,
 		ConfiguredPath: configuredPath,
-	}))
+	}, testStartupLogger()))
 
 	resumed, newPath, err := ResumeConsolidation(tmpDir, testStartupLogger())
 	require.NoError(t, err)

--- a/internal/datastore/v2only/inspector.go
+++ b/internal/datastore/v2only/inspector.go
@@ -144,21 +144,7 @@ func (ds *Datastore) GetTableStats() ([]datastore.TableStats, error) {
 // to row-count proportional estimation. Caches dbstat availability to avoid
 // repeated WARN logs when the virtual table is not compiled in.
 func (ds *Datastore) getSQLiteTableStats() ([]datastore.TableStats, error) {
-	cached := ds.dbstatAvailable.Load()
-	if cached == -1 {
-		// Already known to be unavailable — skip directly to estimation
-		return ds.getSQLiteTableStatsEstimated()
-	}
-
-	stats, err := ds.getSQLiteTableStatsViaDBStat()
-	if err == nil {
-		ds.dbstatAvailable.Store(1)
-		return stats, nil
-	}
-
-	// Mark as unavailable so we don't retry on every refresh
-	ds.dbstatAvailable.Store(-1)
-	return ds.getSQLiteTableStatsEstimated()
+	return datastore.ResolveCachedTableStats(&ds.dbstatAvailable, ds.getSQLiteTableStatsViaDBStat, ds.getSQLiteTableStatsEstimated)
 }
 
 // getSQLiteTableStatsViaDBStat uses the dbstat virtual table.


### PR DESCRIPTION
## Summary

Datastore v2 hardening plus the code-quality follow-ups found while reviewing it, all in `internal/datastore`.

**Deleted detections could resurrect after v2 promotion.** During dual-write a delete removes the legacy row first, then the v2 row; if the v2 delete fails the id is marked dirty. The migration worker's dirty-id catch-up saw the missing legacy row and cleared the marker without deleting the still-present v2 row, so the detection came back after promotion. The worker and the runtime reconciler now share one `ReconcileDeletedGhost` helper that deletes the orphaned v2 row before clearing the marker, tolerating a not-found or locked row and keeping the id dirty on any other error. A locked (user-verified) row is never force-deleted, but its marker is cleared so it cannot block migration validation indefinitely; as a result a detection a user both verified and then deleted is retained in v2.

**`moveSQLiteDBFiles` was not fail-closed.** A sidecar (`-wal`/`-shm`) rename failure was logged while the move was reported as success, which could leave a promoted database without its uncheckpointed WAL, and any stat error was treated as "sidecar absent". It is now all-or-nothing: `os.IsNotExist` only, a wrapped error returned on any sidecar failure, and every completed rename reverted so the caller never sees a half-moved database. `checkpointSQLiteWAL` now sets `busy_timeout` in the connection DSN (via the package `sqliteBusyTimeoutMs` constant) to avoid spurious `SQLITE_BUSY` under load, and the DSN separator logic is folded into one `dsnAppendParams` helper.

**Dead code removed.** The old blind-WAL `Consolidate` (no callers) and the exported `IsV2OnlyModeAvailable` / `ShouldSkipLegacyDatabase` readiness helpers (no callers, and they decided v2-only readiness without the straggler/dirty-id guard) are gone.

**Consistency and durability.** The legacy `SQLiteStore.dbstatAvailable` field now uses `atomic.Int32`, and the dbstat probe-and-cache logic is shared between the legacy and v2-only inspectors via `ResolveCachedTableStats`. `WriteConsolidationState` now writes to a uniquely-named temp file, fsyncs it before the atomic rename, and cleans up any temp orphaned by a crash.

## Test Plan

- [x] `go test -race ./internal/datastore/...` green across all packages
- [x] `golangci-lint run` clean across all build-tag variants
- [x] New tests for v2 ghost reconciliation (delete, not-found, locked, keep-dirty-on-error, and the runtime reconciler path)
- [x] New tests for `moveSQLiteDBFiles` (stale destination sidecar removal, fail-closed revert, unreadable sidecar, stale-removal failure)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed migration handling for records deleted from the legacy database, including reconciliation of orphaned records.
  - Preserved locked records while clearing stale migration markers when appropriate.
  - Improved database statistics fallback behavior during temporary lock conditions.

- **Reliability**
  - Improved durability when saving state and safety when moving database files, including rollback after failures.
  - Added timeout handling for database checkpoint operations.
  - Improved support for database paths with existing query parameters.
  - Added cleanup for stale temporary state files and stronger validation of backup destinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->