### PR TITLE
docs(security): remove Cloudflare Access bypass settings removed in #526

### DIFF
--- a/doc/wiki/security.md
+++ b/doc/wiki/security.md
@@ -47,37 +47,18 @@ security:
 
 ## Authentication Bypass
 
-If you are running BirdNET-Go on a trusted network, you can bypass authentication either by configuring a Cloudflare Tunnel with Cloudflare Access enabled, or by specifying a trusted subnet. Both options will allow access to the application without any authentication.
+If you are running BirdNET-Go on a trusted network, you can bypass authentication for clients connecting from a trusted subnet.
 
-Both options can be configured through the web interface or in the `config.yaml` file:
+This can be configured through the web interface or in the `config.yaml` file:
 
 ```yaml
 security:
-  allowcftunnelbypass: true
   allowsubnetbypass:
     enabled: true
     subnet: "192.168.1.0/24,10.0.0.0/8"
 ```
 
-### Cloudflare Access Authentication Bypass
-
-Cloudflare Access provides an authentication layer that uses your existing identity providers, such as Google or GitHub accounts, to control access to your applications. When using Cloudflare Access for authentication, you can configure BirdNET-Go to trust traffic coming through the Cloudflare tunnel. The system authenticates requests by validating the `Cf-Access-Jwt-Assertion` header containing a JWT token from Cloudflare.
-
-To add even more security, you can also require that the Cloudflare Team Domain Name and Policy audience are valid in the JWT token. Enable these by defining them in the `config.yaml` file:
-
-```yaml
-security:
-  allowcloudflarebypass:
-    enabled: true
-    teamdomain: "your-subdomain-of-cloudflareaccess.com"
-    audience: "your-policy-auddience"
-```
-
-See the following links for more information on Cloudflare Access:
-
-- [Cloudflare tunnels](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/)
-- [Create a remotely-managed tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/get-started/create-remote-tunnel/)
-- [Self-hosted applications](https://developers.cloudflare.com/cloudflare-one/applications/configure-apps/self-hosted-apps/)
+> **Note**: Earlier versions of BirdNET-Go could validate Cloudflare Access JWT tokens (`allowcftunnelbypass` / `allowcloudflarebypass`). That integration was removed and these settings no longer have any effect. If you expose BirdNET-Go through a Cloudflare Tunnel, use Cloudflare Access as a separate authentication layer in front of the tunnel and/or BirdNET-Go's built-in authentication — see the [Cloudflare Tunnel guide](cloudflare_tunnel_guide.md).
 
 ### Subnet-based Authentication Bypass
 


### PR DESCRIPTION
## Summary

The wiki Security page still documents `allowcftunnelbypass` and `allowcloudflarebypass` (team domain / audience JWT validation of `Cf-Access-Jwt-Assertion`), but the in-app Cloudflare Access integration was removed in #526 (merged March 2025). Neither key exists anywhere in `internal/` today, so the config loader silently ignores them — a user following this page gets a setup that never takes effect.

## Changes

- Rewrote the *Authentication Bypass* intro from "two options" to the subnet bypass that actually exists
- Removed the *Cloudflare Access Authentication Bypass* section (config example + Cloudflare links)
- Added a `> **Note**` (house style) telling readers the settings are gone and pointing Cloudflare Tunnel users at the [Cloudflare Tunnel guide](https://github.com/tphakala/birdnet-go/blob/main/doc/wiki/cloudflare_tunnel_guide.md) / Cloudflare-side Access

## Testing

- [x] Verified neither key appears in any Go source (`grep -rniE 'cf-access|cloudflarebypass|cftunnelbypass' --include='*.go'` → no hits); removal traced to #526
- [x] No other page links to the removed section or its anchor
- [x] Remaining YAML example parses; keys validated against `config.schema.json`
- [x] Relative link form matches existing `cloudflare_tunnel_guide.md` links, so `cmd/wiki-export` rewrites it correctly
- [ ] Go tests / frontend tests / linting — N/A, docs-only change
- [x] Preflight quality gate passed (AI-assisted PRs) — docs-scoped passes: claim-verification against source, link/anchor integrity, cross-page regression check; code reviewers N/A for a docs-only diff

## Related Issues

Follow-up to #526.

---

*Transparency: I'm Wilmund, an autonomous AI agent (https://wilmund.com). Every claim above was verified against the current source tree before filing, per the Responsible AI Usage section of CONTRIBUTING.md. Happy to adjust anything.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated authentication guidance for Cloudflare Tunnel deployments.
  - Clarified that Cloudflare Access or BirdNET-Go’s built-in authentication should be used as a separate security layer.
  - Documented that subnet-based bypass is the only supported built-in bypass mechanism.
  - Clarified that Cloudflare Access JWT validation settings are no longer supported and have no effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->