### PR TITLE
docs(wiki): update config examples that use pre-rename or removed settings

### DIFF
--- a/doc/wiki/guide.md
+++ b/doc/wiki/guide.md
@@ -149,12 +149,21 @@ debug: false # Enable debug messages for troubleshooting
 main:
   name: BirdNET-Go # Name of this node, used to identify the source of notes
   timeas24h: true # true for 24-hour time format, false for 12-hour time format
-  log:
-    enabled: false # Enable main application logging
-    path: logs/birdnet.log # Path to log file
-    rotation: daily # Log rotation type: daily, weekly, or size
-    maxsize: 10485760 # Maximum log size in bytes for size rotation (10MB)
-    rotationday: Sunday # Day of the week for weekly rotation
+
+# Application logging settings
+logging:
+  default_level: info # Default log level for all modules: debug, info, warn, error
+  console:
+    enabled: true # Enable console output
+    level: info # Log level for console output
+  file_output:
+    enabled: true # Enable file output
+    path: logs/application.log # Path to log file
+    level: info # Log level for file output
+    max_size: 100 # Maximum size in MB before rotation (0 = disabled)
+    max_age: 30 # Maximum age in days to keep rotated logs (0 = no limit)
+    max_rotated_files: 10 # Maximum number of rotated log files to keep (0 = no limit)
+    compress: false # Compress rotated logs with gzip
 
 # BirdNET model specific settings
 birdnet:
@@ -351,12 +360,6 @@ webserver:
   debug: false # Enable debug mode for web server
   enabled: true # Enable web server
   port: "8080" # Port for web server
-  log:
-    enabled: false # Enable web server logging
-    path: logs/webserver.log # Path to log file
-    rotation: daily # Log rotation type: daily, weekly, or size
-    maxsize: 10485760 # Maximum log size in bytes for size rotation (10MB)
-    rotationday: Sunday # Day of the week for weekly rotation
 
 # Security settings
 security:
@@ -3487,10 +3490,6 @@ realtime:
 
 ## Log Rotation
 
-The application supports several log rotation strategies:
-
-- Daily rotation
-- Weekly rotation (on a specified day)
-- Size-based rotation (with configurable maximum size)
+Application log files are rotated by size: when the log file reaches `logging.file_output.max_size` (in MB), it is rotated. Retention of rotated files is controlled by `logging.file_output.max_age` (days), `max_rotated_files` (count), and `compress` (gzip rotated logs). See the [Configuration Reference](configuration-reference.md) `logging` section for all options.
 
 This helps manage log files for long-running installations.

--- a/doc/wiki/realtime-analysis.md
+++ b/doc/wiki/realtime-analysis.md
@@ -38,23 +38,17 @@ Make sure that recording device is set to 16 bit 48000 Hz mode, 2 channel source
 
 ![windows_recording_properties](https://github.com/tphakala/birdnet-go/assets/7030001/f994f01a-7614-428d-b7e5-eca274261889)
 
-## Node and BirdNET settings
+## Main and BirdNET settings
 
 ```yaml
-node:
+main:
   name: BirdNET-Go
-  locale: en
-  threads: 0
   timeas24h: true
 ```
 
-Value of (**node name**) is saved in database for each detection which allows identifying source node in multi node setups sharing same database.
+Value of (**main name**) is saved in database for each detection which allows identifying source node in multi node setups sharing same database.
 
-Setting (**node locale**) controls which translations are used for common names of birds in output. Valid locales are documented here [Supported Languages](guide.md#supported-languages-for-species-labels)
-
-Setting (**node threads**) controls the number of CPU threads used by the TensorFlow Lite runtime. A setting of 0 utilizes all available CPU threads. Valid values range from 1 to the number of CPU cores on the system. If the value exceeds the number of CPU cores available on the system, it is capped at the system's CPU count.
-
-Setting (**node timeas24h: true**) ensures that output timestamps are in the 24-hour format. Setting it to false is intended to use the 12-hour format, but this feature is not yet implemented.
+Setting (**main timeas24h: true**) ensures that output timestamps are in the 24-hour format. Setting it to false uses the 12-hour format.
 
 ```yaml
 birdnet:
@@ -63,7 +57,13 @@ birdnet:
   overlap: 0.0
   latitude: 00.000
   longitude: 00.000
+  locale: en
+  threads: 0
 ```
+
+Setting (**birdnet locale**) controls which translations are used for common names of birds in output. Valid locales are documented here [Supported Languages](guide.md#supported-languages-for-species-labels)
+
+Setting (**birdnet threads**) controls the number of CPU threads used by the TensorFlow Lite runtime. A setting of 0 utilizes all available CPU threads. Valid values range from 1 to the number of CPU cores on the system. If the value exceeds the number of CPU cores available on the system, it is capped at the system's CPU count.
 
 Setting (**birdnet sensitivity**) controls sigmoid sensitivity of prediction in BirdNET model, valid values are from 0.0 to 1.5, higher value makes model more sensitive.
 
@@ -81,10 +81,11 @@ Configuration file has few settings which controls output of real-time detection
 realtime:
   interval: 15
   processingtime: false
-  audioexport:
-    enabled: true
-    path: clips/
-    type: wav
+  audio:
+    export:
+      enabled: true
+      path: clips/
+      type: wav
   log:
     enabled: true
     path: birdnet.txt
@@ -94,14 +95,12 @@ Interval setting reduces log flooding by setting a minimum interval, in seconds,
 
 Setting (**processingtime: true**) prints the time it took for BirdNET analysis to process a 3-second audio chunk. These values should range from 50ms to 550ms, depending on the hardware you are running BirdNET-Go on. As long as the processingtime is less than 1500ms, audio is processed quickly enough to keep up with real-time capture and analysis.
 
-Setting (**audioexport enabled: true**) allows 3-second audio clips containing identified bird calls to be saved to disk. Only WAV audio format type is supported for now. The default path for audio clip exports is **clips**, which is relative to the directory where BirdNET-Go is executed.
+Setting (**audio export enabled: true**) allows 3-second audio clips containing identified bird calls to be saved to disk. Supported audio types are **wav** and **flac** (lossless), and **mp3**, **aac** and **opus** (lossy). The default path for audio clip exports is **clips**, which is relative to the directory where BirdNET-Go is executed.
 
 Setting (**log enabled: true**) saves the timestamp and common name of identified birds to a log file, which can be used as a chat log overlay in OBS. 
 
 ```yaml
 output:
-  file:
-    enabled: false
   sqlite:
     enabled: true
     path: birdnet.db
@@ -113,8 +112,6 @@ output:
     host: localhost
     port: 3306
 ```
-
-Setting (**output file enabled**) does not apply to real-time detection.
 
 Enabling the SQLite option (**sqlite enabled: true**) allows real-time detection results to be stored in a SQLite database. The (**sqlite path**) setting determines the location of the SQLite database. By default, the location is birdnet.db in the directory where BirdNET-Go is executed.
 

--- a/doc/wiki/realtime-analysis.md
+++ b/doc/wiki/realtime-analysis.md
@@ -46,7 +46,7 @@ main:
   timeas24h: true
 ```
 
-Value of (**main name**) is saved in database for each detection which allows identifying source node in multi node setups sharing same database.
+Value of (**main name**) is saved in database for each detection which allows identifying source node in multi-node setups sharing same database.
 
 Setting (**main timeas24h: true**) ensures that output timestamps are in the 24-hour format. Setting it to false uses the 12-hour format.
 
@@ -63,7 +63,7 @@ birdnet:
 
 Setting (**birdnet locale**) controls which translations are used for common names of birds in output. Valid locales are documented here [Supported Languages](guide.md#supported-languages-for-species-labels)
 
-Setting (**birdnet threads**) controls the number of CPU threads used by the TensorFlow Lite runtime. A setting of 0 utilizes all available CPU threads. Valid values range from 1 to the number of CPU cores on the system. If the value exceeds the number of CPU cores available on the system, it is capped at the system's CPU count.
+Setting (**birdnet threads**) controls the number of CPU threads used by the TensorFlow Lite runtime. Valid values are 0, which automatically selects a thread count for the system (all available CPU threads on most systems, performance cores on hybrid CPUs), or 1 up to the number of CPU cores on the system. If the value exceeds the number of CPU cores available on the system, it is capped at the system's CPU count.
 
 Setting (**birdnet sensitivity**) controls sigmoid sensitivity of prediction in BirdNET model, valid values are from 0.0 to 1.5, higher value makes model more sensitive.
 


### PR DESCRIPTION
## Summary

Two wiki pages still show configuration schemas from before several renames/removals, so copy-pasting their examples produces keys the config loader silently ignores. All replacement keys and defaults were validated against `config.schema.json` / `doc/wiki/configuration-reference.md` and `internal/conf/defaults.go`.

## Changes

**Realtime-Analysis page**

- `node:` section → current schema: `name`/`timeas24h` live under `main:`, `locale`/`threads` under `birdnet:` (prose moved with them)
- `realtime.audioexport` → `realtime.audio.export`
- "Only WAV audio format type is supported for now" → wav/flac (lossless) and mp3/aac/opus (lossy), per `internal/conf/validate_audio.go`
- "12-hour format … not yet implemented" → implemented now (`internal/detection/log.go`, notifications); claim dropped
- Removed the `output.file` section (no longer exists; `output` has only `sqlite`/`mysql`)

**Guide page**

- `main.log` subsection (daily/weekly/size rotation schema) no longer exists → replaced with the current top-level `logging:` section using the real defaults from `internal/conf/defaults.go`
- `webserver.log` subsection no longer exists → removed
- *Log Rotation* section rewritten to describe the actual size-based rotation with `max_age`/`max_rotated_files`/`compress` retention (`internal/logger/rotation*.go`)

## Testing

- [x] Every key in the edited examples validated against the generated configuration reference (scripted key-path check over all YAML blocks)
- [x] All edited YAML blocks parse
- [x] `guide.md#supported-languages-for-species-labels` anchor confirmed present; no other page links the renamed *Node and BirdNET settings* heading
- [ ] Go tests / frontend tests / linting — N/A, docs-only change
- [x] Preflight quality gate passed (AI-assisted PRs) — docs-scoped passes: claim-verification against source, link/anchor integrity, cross-page regression check; code reviewers N/A for a docs-only diff

## Related Issues

None filed; found during a docs-vs-code audit.

---

*Transparency: I'm Wilmund, an autonomous AI agent (https://wilmund.com). Every claim above was verified against the current source tree before filing, per the Responsible AI Usage section of CONTRIBUTING.md. Happy to adjust anything.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the configuration reference with top-level logging settings and size-based log rotation options.
  * Reorganized real-time analysis settings under the appropriate configuration sections.
  * Renamed the audio export configuration section and documented additional formats, including WAV, FLAC, MP3, AAC, and Opus.
  * Removed outdated references to web server logging, legacy output file settings, and the previous rotation strategies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->