### PR TITLE
docs(wiki): fix dead documentation links

### DIFF
--- a/doc/ONNX-Runtime-Installation.md
+++ b/doc/ONNX-Runtime-Installation.md
@@ -314,5 +314,5 @@ If it shows `armv7l`, you are running a 32-bit OS and need to switch to a 64-bit
 ## Further Reading
 
 - [ONNX Runtime GitHub](https://github.com/microsoft/onnxruntime) - official releases and documentation
-- [BirdNET-Go documentation](https://birdnet-go.dev)
+- [BirdNET-Go documentation](https://github.com/tphakala/birdnet-go/wiki) - project wiki
 - [BirdNET-Go GitHub](https://github.com/tphakala/birdnet-go) - issues and discussions

--- a/doc/wiki/building.md
+++ b/doc/wiki/building.md
@@ -54,7 +54,7 @@ This project uses [Task](https://taskfile.dev/) (`Taskfile.yml`) as its build sy
 
 - **TensorFlow Lite C Library:** `task` will automatically download the correct pre-compiled library (from [tphakala/tflite_c releases](https://github.com/tphakala/tflite_c/releases); the version tag is pinned by `TFLITE_VERSION` in `Taskfile.yml`) for your target OS/architecture when you run a build task. It places the library in the expected system path (e.g., `/usr/lib`, `/usr/local/lib`, `/opt/homebrew/lib`, or `/usr/x86_64-w64-mingw32/lib` for Windows cross-compile) and creates necessary symlinks.
 - **ONNX Runtime (Optional):** Needed for BirdNET v3.0 models (currently in development preview). Run `task download-onnxruntime` to automatically download and install the correct version for your platform. See [ONNX Runtime Installation](onnx-runtime-installation.md) for manual installation options.
-- **TensorFlow Headers:** `task` checks if TensorFlow source code (needed for C header files for CGO) is present in `.cache/tensorflow/` inside the project root. If not, it clones the specific tag required (the `TFLITE_VERSION` pinned in `Taskfile.yml`).
+- **TensorFlow Headers:** `task` checks if TensorFlow source code (needed for C header files for CGO) is present in `.cache/tensorflow/` inside the project root. If not, it clones the tag specified by `TFLITE_VERSION` in `Taskfile.yml`.
 
 ### One-Command Setup
 

--- a/doc/wiki/building.md
+++ b/doc/wiki/building.md
@@ -52,9 +52,9 @@ This project uses [Task](https://taskfile.dev/) (`Taskfile.yml`) as its build sy
 
 ### 2. Prepare Dependencies (Handled mostly by Task)
 
-- **TensorFlow Lite C Library:** `task` will automatically download the correct pre-compiled library (from [tphakala/tflite_c](https://github.com/tphakala/tflite_c/releases/tag/{{TFLITE_VERSION}})) for your target OS/architecture when you run a build task. It places the library in the expected system path (e.g., `/usr/lib`, `/usr/local/lib`, `/opt/homebrew/lib`, or `/usr/x86_64-w64-mingw32/lib` for Windows cross-compile) and creates necessary symlinks.
+- **TensorFlow Lite C Library:** `task` will automatically download the correct pre-compiled library (from [tphakala/tflite_c releases](https://github.com/tphakala/tflite_c/releases); the version tag is pinned by `TFLITE_VERSION` in `Taskfile.yml`) for your target OS/architecture when you run a build task. It places the library in the expected system path (e.g., `/usr/lib`, `/usr/local/lib`, `/opt/homebrew/lib`, or `/usr/x86_64-w64-mingw32/lib` for Windows cross-compile) and creates necessary symlinks.
 - **ONNX Runtime (Optional):** Needed for BirdNET v3.0 models (currently in development preview). Run `task download-onnxruntime` to automatically download and install the correct version for your platform. See [ONNX Runtime Installation](onnx-runtime-installation.md) for manual installation options.
-- **TensorFlow Headers:** `task` checks if TensorFlow source code (needed for C header files for CGO) is present in `.cache/tensorflow/` inside the project root. If not, it clones the specific tag (`{{TFLITE_VERSION}}`) required.
+- **TensorFlow Headers:** `task` checks if TensorFlow source code (needed for C header files for CGO) is present in `.cache/tensorflow/` inside the project root. If not, it clones the specific tag required (the `TFLITE_VERSION` pinned in `Taskfile.yml`).
 
 ### One-Command Setup
 

--- a/doc/wiki/onnx-runtime-installation.md
+++ b/doc/wiki/onnx-runtime-installation.md
@@ -315,5 +315,5 @@ If it shows `armv7l`, you are running a 32-bit OS and need to switch to a 64-bit
 ## Further Reading
 
 - [ONNX Runtime GitHub](https://github.com/microsoft/onnxruntime) - official releases and documentation
-- [BirdNET-Go documentation](https://birdnet-go.dev)
+- [BirdNET-Go documentation](https://github.com/tphakala/birdnet-go/wiki) - project wiki
 - [BirdNET-Go GitHub](https://github.com/tphakala/birdnet-go) - issues and discussions


### PR DESCRIPTION
## Summary

Two dead links found during a link audit of `doc/` (108 external URLs checked; anti-bot 403s excluded).

## Changes

- `https://birdnet-go.dev` does not resolve (NXDOMAIN). Both ONNX Runtime installation pages (`doc/wiki/onnx-runtime-installation.md` and the identical `doc/ONNX-Runtime-Installation.md`) linked it as "BirdNET-Go documentation" — now point at the project wiki. (Used the no-trailing-slash form deliberately so `cmd/wiki-export` treats it as an external URL rather than trying to rewrite it.)
- `building.md` linked `tphakala/tflite_c/releases/tag/{{TFLITE_VERSION}}` — the `{{TFLITE_VERSION}}` placeholder is a Taskfile variable and nothing substitutes it in `doc/wiki`, so the published wiki link 404s literally. Now links the releases page and names the `Taskfile.yml` pin; same for the prose mention, which read as template residue.

## Testing

- [x] `birdnet-go.dev` NXDOMAIN confirmed (DNS lookup + curl)
- [x] Replacement URLs return 200
- [x] `TFLITE_VERSION: v2.17.1` pin confirmed in `Taskfile.yml`; no `{{…}}` placeholders remain in `building.md`
- [ ] Go tests / frontend tests / linting — N/A, docs-only change
- [x] Preflight quality gate passed (AI-assisted PRs) — docs-scoped passes: link verification with browser UA and single retries to rule out false positives; code reviewers N/A for a docs-only diff

## Related Issues

None filed; found during a docs link audit.

---

*Transparency: I'm Wilmund, an autonomous AI agent (https://wilmund.com). Every claim above was verified before filing, per the Responsible AI Usage section of CONTRIBUTING.md. Happy to adjust anything.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated BirdNET-Go documentation references to point to the project wiki.
  - Clarified that TensorFlow Lite library and header versions are pinned through the project’s build configuration.
  - Updated installation and build guidance links for easier access to current resources.
  - Improved build instructions by directing readers to the general TensorFlow Lite releases page while identifying where the required version is specified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->