### PR TITLE
fix(frontend): normalize trailing-slash routes and add keyboard focus tooltips to sidebar auth buttons

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -21,7 +21,13 @@
     getSpeciesDictVersion,
   } from './lib/stores/appState.svelte';
   import { navigation } from './lib/stores/navigation.svelte';
-  import { resolveAnalyticsRedirect } from './lib/desktop/features/analytics/registry/analyticsRouting';
+  import {
+    resolveAnalyticsRedirect,
+    stripTrailingSlash,
+  } from './lib/desktop/features/analytics/registry/analyticsRouting';
+  // Type-only import (erased at build time, so GenericErrorPage stays lazily loaded via
+  // dynamic import below) used to type the dynamic component precisely instead of `any`.
+  import type GenericErrorPageComponent from './lib/desktop/views/GenericErrorPage.svelte';
   import { settingsActions } from './lib/stores/settings.js';
   import { activateWatchdog } from './lib/stores/connectionState.svelte';
   import WizardDialog from './lib/desktop/features/wizard/WizardDialog.svelte';
@@ -64,7 +70,7 @@
   let ErrorPage = $state<Component | null>(null);
   let ServerErrorPage = $state<Component | null>(null);
   let LiveStream = $state<Component | null>(null);
-  let GenericErrorPage = $state<any>(null);
+  let GenericErrorPage = $state<typeof GenericErrorPageComponent | null>(null);
 
   let currentRoute = $state<string>('');
   let currentPage = $state<string>('');
@@ -504,6 +510,13 @@
   }
 
   function handleRouting(path: string): void {
+    // Canonicalize a trailing slash up front so the analytics redirect check, the
+    // detection-detail split, the system/settings subpage matching, and the normal
+    // pathToRouteMap lookup all operate on the same slashless path. The map keys are
+    // slashless, so /ui/analytics/nocturnal/ (a manually typed or bookmarked URL)
+    // would otherwise miss the map and 404. stripTrailingSlash preserves the root.
+    path = stripTrailingSlash(path);
+
     // Analytics routes: redirect the bare hub, the retired /advanced path, and
     // legacy ?tab= deep links onto the per-view routes (single hop), preserving
     // other query params. resolveAnalyticsRedirect returns null when canonical.
@@ -532,8 +545,8 @@
 
     // Handle system and settings subpages
     if (UI_SYSTEM_PREFIX_RE.test(path)) {
-      const normalizedPath = path.endsWith('/') && path.length > 1 ? path.slice(0, -1) : path;
-      const exactMatch = pathToRouteMap.get(normalizedPath);
+      // path is already trailing-slash-normalized at the top of handleRouting.
+      const exactMatch = pathToRouteMap.get(path);
       if (exactMatch) {
         currentRoute = exactMatch.route;
         currentPage = exactMatch.page;
@@ -582,7 +595,8 @@
       currentPage = 'error-generic';
       // For dynamic error titles from URL, we use a generic error key
       pageTitleKey = 'common.error';
-      dynamicErrorCode = errorCode || '500';
+      // errorCode is already truthy in this branch, so no '500' fallback is needed.
+      dynamicErrorCode = errorCode;
       loadComponent('error-generic');
     } else {
       // Unknown route, default to 404

--- a/frontend/src/lib/desktop/features/analytics/registry/analyticsRouting.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/registry/analyticsRouting.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveAnalyticsRedirect } from './analyticsRouting';
+import { resolveAnalyticsRedirect, stripTrailingSlash } from './analyticsRouting';
 
 describe('resolveAnalyticsRedirect', () => {
   it('maps legacy ?tab= values to the new routes and strips tab', () => {
@@ -64,5 +64,32 @@ describe('resolveAnalyticsRedirect', () => {
     expect(resolveAnalyticsRedirect('/ui/analytics', '?tab=soundscape')).toBe(
       '/ui/analytics/summary'
     );
+  });
+});
+
+describe('stripTrailingSlash', () => {
+  it('strips a single trailing slash from a canonical route (the #1278 404 case)', () => {
+    expect(stripTrailingSlash('/ui/analytics/nocturnal/')).toBe('/ui/analytics/nocturnal');
+    expect(stripTrailingSlash('/ui/search/')).toBe('/ui/search');
+    expect(stripTrailingSlash('/ui/settings/audio/')).toBe('/ui/settings/audio');
+  });
+
+  it('preserves the root "/" so it never collapses to an empty string', () => {
+    // The length > 1 guard is load-bearing: without it "/" would become "" and the
+    // dashboard root would 404. This test reddens if that guard is dropped.
+    expect(stripTrailingSlash('/')).toBe('/');
+  });
+
+  it('reduces the /ui/ root to the slashless key the route map also carries', () => {
+    expect(stripTrailingSlash('/ui/')).toBe('/ui');
+  });
+
+  it('leaves an already-slashless path unchanged', () => {
+    expect(stripTrailingSlash('/ui/analytics/nocturnal')).toBe('/ui/analytics/nocturnal');
+    expect(stripTrailingSlash('/ui')).toBe('/ui');
+  });
+
+  it('removes only the final slash (repeated trailing slashes are not the reported case)', () => {
+    expect(stripTrailingSlash('/ui/analytics/summary//')).toBe('/ui/analytics/summary/');
   });
 });

--- a/frontend/src/lib/desktop/features/analytics/registry/analyticsRouting.ts
+++ b/frontend/src/lib/desktop/features/analytics/registry/analyticsRouting.ts
@@ -16,7 +16,13 @@ const TAB_TO_SEGMENT: Record<string, string> = {
   quality: 'review',
 };
 
-function stripTrailingSlash(path: string): string {
+/**
+ * Strips a single trailing slash from a path while preserving the root "/".
+ * Exported so the App.svelte router can canonicalize a trailing slash before its
+ * pathToRouteMap lookup (the map keys are slashless), reusing one implementation
+ * rather than hand-rolling the guarded slice at each call site.
+ */
+export function stripTrailingSlash(path: string): string {
   return path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path;
 }
 

--- a/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
+++ b/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
@@ -158,6 +158,12 @@ Performance Optimizations:
     tooltipVisible = false;
   }
 
+  // Shared class for the collapsed-sidebar footer auth buttons. Login and logout are
+  // otherwise identical, so the full Tailwind arbitrary-value class lives in one named
+  // literal; the per-button collapsed state (justify-center) is composed via cn().
+  const authFooterButtonClass =
+    'flex items-center gap-2 w-full px-3 py-2 rounded-lg text-sm font-medium text-[var(--color-base-content)]/90 hover:text-[var(--color-base-content)] hover:bg-[var(--color-base-content)]/5 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--color-base-100)]';
+
   function toggleFlyout(sectionId: string) {
     activeFlyout = activeFlyout === sectionId ? null : sectionId;
   }
@@ -735,10 +741,7 @@ Performance Optimizations:
               onmouseleave={hideTooltip}
               onfocus={e => isCollapsed && showTooltip(e, t('auth.logout'))}
               onblur={hideTooltip}
-              class={cn(
-                'flex items-center gap-2 w-full px-3 py-2 rounded-lg text-sm font-medium text-[var(--color-base-content)]/90 hover:text-[var(--color-base-content)] hover:bg-[var(--color-base-content)]/5 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--color-base-100)]',
-                isCollapsed && 'justify-center'
-              )}
+              class={cn(authFooterButtonClass, isCollapsed && 'justify-center')}
               aria-label={t('auth.logout')}
             >
               <LogOut class="size-4" />
@@ -756,10 +759,7 @@ Performance Optimizations:
               onmouseleave={hideTooltip}
               onfocus={e => isCollapsed && showTooltip(e, t('auth.openLoginModal'))}
               onblur={hideTooltip}
-              class={cn(
-                'flex items-center gap-2 w-full px-3 py-2 rounded-lg text-sm font-medium text-[var(--color-base-content)]/90 hover:text-[var(--color-base-content)] hover:bg-[var(--color-base-content)]/5 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--color-base-100)]',
-                isCollapsed && 'justify-center'
-              )}
+              class={cn(authFooterButtonClass, isCollapsed && 'justify-center')}
               aria-label={t('auth.openLoginModal')}
             >
               <LogIn class="size-4" />

--- a/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
+++ b/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
@@ -729,11 +729,14 @@ Performance Optimizations:
         {#if accessAllowed}
           <div class="relative">
             <button
+              type="button"
               onclick={handleLogout}
               onmouseenter={e => isCollapsed && showTooltip(e, t('auth.logout'))}
               onmouseleave={hideTooltip}
+              onfocus={e => isCollapsed && showTooltip(e, t('auth.logout'))}
+              onblur={hideTooltip}
               class={cn(
-                'flex items-center gap-2 w-full px-3 py-2 rounded-lg text-sm font-medium text-[var(--color-base-content)]/90 hover:text-[var(--color-base-content)] hover:bg-[var(--color-base-content)]/5 transition-colors duration-150',
+                'flex items-center gap-2 w-full px-3 py-2 rounded-lg text-sm font-medium text-[var(--color-base-content)]/90 hover:text-[var(--color-base-content)] hover:bg-[var(--color-base-content)]/5 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--color-base-100)]',
                 isCollapsed && 'justify-center'
               )}
               aria-label={t('auth.logout')}
@@ -747,11 +750,14 @@ Performance Optimizations:
         {:else}
           <div class="relative">
             <button
+              type="button"
               onclick={handleLogin}
-              onmouseenter={e => isCollapsed && showTooltip(e, t('auth.login'))}
+              onmouseenter={e => isCollapsed && showTooltip(e, t('auth.openLoginModal'))}
               onmouseleave={hideTooltip}
+              onfocus={e => isCollapsed && showTooltip(e, t('auth.openLoginModal'))}
+              onblur={hideTooltip}
               class={cn(
-                'flex items-center gap-2 w-full px-3 py-2 rounded-lg text-sm font-medium text-[var(--color-base-content)]/90 hover:text-[var(--color-base-content)] hover:bg-[var(--color-base-content)]/5 transition-colors duration-150',
+                'flex items-center gap-2 w-full px-3 py-2 rounded-lg text-sm font-medium text-[var(--color-base-content)]/90 hover:text-[var(--color-base-content)] hover:bg-[var(--color-base-content)]/5 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--color-base-100)]',
                 isCollapsed && 'justify-center'
               )}
               aria-label={t('auth.openLoginModal')}

--- a/frontend/src/lib/desktop/layouts/DesktopSidebar.test.ts
+++ b/frontend/src/lib/desktop/layouts/DesktopSidebar.test.ts
@@ -277,3 +277,68 @@ describe('DesktopSidebar - flat task-grouped sections', () => {
     expect(onNavigate).toHaveBeenCalledWith('/');
   });
 });
+
+describe('DesktopSidebar - collapsed footer auth button focus tooltips (#1282)', () => {
+  const sidebarTest = createComponentTestFactory(DesktopSidebar);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // LoginModal (rendered in the logged-out case) reads layout/styles; stub for jsdom.
+    Object.defineProperty(window, 'getComputedStyle', {
+      value: vi.fn(() => ({
+        getPropertyValue: vi.fn(() => ''),
+        visibility: 'visible',
+        display: 'block',
+      })),
+      writable: true,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'focus', { value: vi.fn(), writable: true });
+    // Collapsed mode is the only state that shows tooltips; opt in explicitly.
+    sidebar.collapse();
+  });
+
+  afterEach(() => {
+    sidebar.expand();
+  });
+
+  it('shows and hides the logout tooltip on keyboard focus/blur when collapsed', async () => {
+    const { container } = sidebarTest.render({
+      currentRoute: '/ui/dashboard',
+      securityEnabled: true,
+      accessAllowed: true, // logged in -> the logout button is shown
+    });
+
+    const logoutButton = screen.getByRole('button', { name: 'auth.logout' });
+    expect(container.querySelector('.sidebar-tooltip')).toBeNull();
+
+    // Keyboard focus must surface the tooltip; without onfocus this stays null.
+    await fireEvent.focus(logoutButton);
+    const tooltip = container.querySelector('.sidebar-tooltip');
+    expect(tooltip).not.toBeNull();
+    expect(tooltip).toHaveTextContent('auth.logout');
+
+    await fireEvent.blur(logoutButton);
+    expect(container.querySelector('.sidebar-tooltip')).toBeNull();
+  });
+
+  it('shows and hides the login tooltip on keyboard focus/blur, matching its aria-label', async () => {
+    const { container } = sidebarTest.render({
+      currentRoute: '/ui/dashboard',
+      securityEnabled: true,
+      accessAllowed: false, // logged out -> the login button is shown
+      authConfig: { basicEnabled: true, enabledProviders: [] },
+    });
+
+    const loginButton = screen.getByRole('button', { name: 'auth.openLoginModal' });
+    expect(container.querySelector('.sidebar-tooltip')).toBeNull();
+
+    await fireEvent.focus(loginButton);
+    const tooltip = container.querySelector('.sidebar-tooltip');
+    expect(tooltip).not.toBeNull();
+    // The tooltip text equals the accessible name so keyboard and screen-reader agree.
+    expect(tooltip).toHaveTextContent('auth.openLoginModal');
+
+    await fireEvent.blur(loginButton);
+    expect(container.querySelector('.sidebar-tooltip')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Two small, independent frontend bug fixes plus minor cleanups in the same files.

Trailing-slash routing: `handleRouting` now canonicalizes a trailing slash once at the top, so a canonical route reached with a trailing slash (for example a manually typed or bookmarked `/ui/analytics/nocturnal/`) resolves to its page instead of falling through to the 404 branch. Because the normalization runs before every branch, the system and settings subpage title matching (`path.endsWith(...)`) is fixed for slashed URLs too. The guarded strip is factored into an exported `stripTrailingSlash` helper (also reused by `resolveAnalyticsRedirect`) rather than a per-branch inline copy, and it preserves the root `/`.

Sidebar keyboard accessibility: the collapsed sidebar's login and logout buttons only showed their tooltip on mouse hover. They now also show it on keyboard focus (`onfocus`/`onblur`), carry an explicit `type="button"`, and get the same `focus-visible` ring the nav items already have, so keyboard-only users get both the tooltip and a visible focus indicator. The login button's collapsed tooltip text was aligned with its `aria-label` so the pointer tooltip, focus tooltip, and screen-reader name all agree.

Incidental cleanups: the lazily loaded `GenericErrorPage` is now typed via a type-only import instead of `any` (build-verified to keep it a separate lazy chunk), and a dead `|| '500'` fallback in an already-truthy branch was removed.

## Test Plan

- [x] `npm run check:all` (prettier, eslint, stylelint, svelte-check, ast-grep) passes
- [x] Full frontend vitest suite passes (2923 tests), including new unit tests for `stripTrailingSlash` (with the root-path guard) and new component tests asserting the sidebar footer tooltips appear on keyboard focus and hide on blur for both auth states
- [x] `npm run build` succeeds and the error page remains a separate lazy chunk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved URL handling by consistently removing trailing slashes where appropriate, preventing duplicate route handling and improving redirects.
  - Preserved the root path and correctly handled paths with or without trailing slashes.

- **Accessibility**
  - Improved keyboard navigation for authentication controls in the collapsed sidebar.
  - Tooltips now appear on keyboard focus, disappear when focus leaves, and match the associated login or logout control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->