### PR TITLE
fix(vad): embed Silero VAD model in all builds so Docker Privacy Guard works

### DIFF
--- a/frontend/src/lib/desktop/features/system/inference.types.ts
+++ b/frontend/src/lib/desktop/features/system/inference.types.ts
@@ -244,8 +244,8 @@ export interface InferenceVAD {
   enabled: boolean;
   /**
    * Whether a model source resolves (an embedded model is present, or a modelpath
-   * override is set). When false the gate is inert even if enabled (e.g. a noembed
-   * build with no modelpath).
+   * override is set). The embedded model ships in every build, so this is
+   * effectively always true; it is false only if no model source resolves at all.
    */
   available: boolean;
   /** True when a detector is currently held (loaded and scoring). */

--- a/internal/analysis/processor/vad_gate.go
+++ b/internal/analysis/processor/vad_gate.go
@@ -371,14 +371,16 @@ func (p *Processor) runVADGate(settings *conf.Settings, item *classifier.Results
 
 	cfg, cacheKey := resolveVADModel(&pf.VAD, settings.BirdNET.ONNXRuntimePath)
 	if cacheKey == "" {
-		// Enabled but no model resolves (a noembed build with no modelpath set, or
-		// a modelpath that was cleared after the session had loaded). Unload any
-		// held session so a removed model source does not leak its ONNX session,
-		// then warn once so the misconfiguration is visible rather than silently inert.
+		// Enabled but no model resolves. The embedded model is compiled into every
+		// build and an unset modelpath falls through to it, so this branch is now
+		// effectively unreachable and stays only as defensive handling. If it is ever
+		// hit, unload any held session so a removed model source does not leak its ONNX
+		// session, then warn once so the misconfiguration is visible rather than
+		// silently inert.
 		p.vadGate.close()
 		if p.vadGate.warnedNoModel.CompareAndSwap(false, true) {
 			GetLogger().Warn("privacy VAD enabled but no model available; speech gate inert",
-				logger.String("hint", "set realtime.privacyfilter.vad.modelpath or use a build with the embedded model"),
+				logger.String("hint", "set realtime.privacyfilter.vad.modelpath to a Silero sequence-export .onnx, or unset it to use the embedded model"),
 				logger.String("operation", "privacy_filter_vad"))
 		}
 		return
@@ -437,8 +439,9 @@ func (p *Processor) runVADGate(settings *conf.Settings, item *classifier.Results
 // resolveVADModel selects the VAD model source. An explicit ModelPath override
 // takes precedence; otherwise the model embedded in the binary is used. It
 // returns the session config and a stable cache key ("path:<file>" or
-// "embedded") used to detect a source change; an empty key means no model is
-// available (a noembed build with no configured path).
+// "embedded") used to detect a source change; an empty key means no model source
+// is available (only reachable if the embedded model is absent and no modelpath
+// is configured).
 func resolveVADModel(cfg *conf.VADSettings, libraryPath string) (detCfg vad.Config, cacheKey string) {
 	if cfg.ModelPath != "" {
 		return vad.Config{ModelPath: cfg.ModelPath, LibraryPath: libraryPath}, "path:" + cfg.ModelPath

--- a/internal/analysis/processor/vad_gate_test.go
+++ b/internal/analysis/processor/vad_gate_test.go
@@ -98,7 +98,9 @@ func TestResolveVADModel(t *testing.T) {
 	assert.Empty(t, cfg.ModelData)
 	assert.Equal(t, "/lib.so", cfg.LibraryPath)
 
-	// No path: fall back to the embedded model (present in the default build).
+	// No path: fall back to the embedded model (compiled into every build). The
+	// else branch is now unreachable (HasEmbeddedModel is always true) but kept as
+	// defensive coverage in case the embed is ever made conditional again.
 	cfg, key = resolveVADModel(&conf.VADSettings{}, "")
 	if vad.HasEmbeddedModel() {
 		assert.Equal(t, "embedded", key)

--- a/internal/api/v2/system/inference_status.go
+++ b/internal/api/v2/system/inference_status.go
@@ -49,8 +49,9 @@ type VADStatusInfo struct {
 	// Enabled is the configured VAD gate toggle (realtime.privacyfilter.vad.enabled).
 	Enabled bool `json:"enabled"`
 	// Available reports whether a model source resolves (an embedded model is
-	// present, or a modelpath override is set). When false the gate is inert even
-	// if Enabled is true (e.g. a noembed build with no modelpath).
+	// present, or a modelpath override is set). The embedded model ships in every
+	// build, so this is effectively always true; it is false only if no model
+	// source resolves at all.
 	Available bool `json:"available"`
 	// Loaded is true when a session is currently held (loaded and scoring). It is
 	// set on a successful load and cleared on unload or an inference error.

--- a/internal/inference/vad/embed_model.go
+++ b/internal/inference/vad/embed_model.go
@@ -1,5 +1,3 @@
-//go:build !noembed
-
 package vad
 
 import _ "embed" // Embedding the Silero VAD model directly into the binary.
@@ -8,10 +6,12 @@ import _ "embed" // Embedding the Silero VAD model directly into the binary.
 // snakers4/silero-vad via the official examples/onnx_sequence export at 16 kHz
 // (opset 16, ~1.25 MB, MIT license unchanged). One Run scores a whole [n, 576]
 // hop sequence with full internal LSTM recurrence, bit-exact to running the hops
-// one at a time through the upstream recurrent frame model. It ships in the
-// binary and container images like the BirdNET TFLite model, so the privacy VAD
-// works out of the box when the feature is enabled and an ONNX Runtime library
-// is present. Excluded from -tags noembed builds.
+// one at a time through the upstream recurrent frame model. The model is tiny and
+// MIT-licensed, so it is embedded unconditionally: unlike the large BirdNET
+// classifier models (which -tags noembed strips so container images can ship them
+// as separate, deduplicated layers), this file has no build constraint. The
+// privacy VAD therefore works out of the box in every build, Docker included, when
+// the feature is enabled and an ONNX Runtime library is present.
 //
 //go:embed data/silero_vad.onnx
 var embeddedModel []byte

--- a/internal/inference/vad/embed_model_noembed.go
+++ b/internal/inference/vad/embed_model_noembed.go
@@ -1,7 +1,0 @@
-//go:build noembed
-
-package vad
-
-// embeddedModel is empty in noembed builds; the VAD then requires an explicit
-// model path (Config.ModelPath) supplied by the caller.
-var embeddedModel []byte

--- a/internal/inference/vad/functional_test.go
+++ b/internal/inference/vad/functional_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/inference"
 )
 
@@ -86,6 +87,24 @@ func TestVAD_SequenceSessionIO(t *testing.T) {
 	}
 }
 
+// skipIfORTUnavailable skips the test when err is the ONNX Runtime initialisation
+// failure (Context stage=ort_init), the one New() failure that depends on the host
+// rather than the code. Any other non-nil error is a real defect in the embedded
+// model path and fails the test rather than being masked by a skip.
+func skipIfORTUnavailable(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		return
+	}
+	var ee *errors.EnhancedError
+	if errors.As(err, &ee) {
+		if stage, ok := ee.GetContext()["stage"]; ok && stage == "ort_init" {
+			t.Skipf("ONNX Runtime unavailable; skipping: %v", err)
+		}
+	}
+	require.NoError(t, err)
+}
+
 // TestVAD_EmbeddedModelLoads exercises the production default path: loading the
 // model embedded in the binary via the in-memory bytes API. The model is embedded
 // in every build, so in practice this skips only when ONNX Runtime is not
@@ -95,9 +114,7 @@ func TestVAD_EmbeddedModelLoads(t *testing.T) {
 		t.Skip("no embedded model in this build")
 	}
 	d, err := New(Config{ModelData: EmbeddedModelData(), LibraryPath: os.Getenv("VAD_TEST_ORT_LIB")})
-	if err != nil {
-		t.Skipf("ONNX Runtime unavailable; skipping embedded-model test: %v", err)
-	}
+	skipIfORTUnavailable(t, err)
 	t.Cleanup(func() { assert.NoError(t, d.Close()) })
 
 	prob, err := d.SpeechProbability(silence16k(1), sampleRate16k)
@@ -382,9 +399,7 @@ func TestVAD_EmbeddedStreamingParity(t *testing.T) {
 	}
 	cfg := Config{ModelData: EmbeddedModelData(), LibraryPath: os.Getenv("VAD_TEST_ORT_LIB")}
 	probe, err := New(cfg)
-	if err != nil {
-		t.Skipf("ONNX Runtime unavailable; skipping embedded streaming parity: %v", err)
-	}
+	skipIfORTUnavailable(t, err)
 	require.NoError(t, probe.Close())
 
 	pcm := speechLikePCM16(6, sampleRate16k)

--- a/internal/inference/vad/functional_test.go
+++ b/internal/inference/vad/functional_test.go
@@ -87,8 +87,8 @@ func TestVAD_SequenceSessionIO(t *testing.T) {
 }
 
 // TestVAD_EmbeddedModelLoads exercises the production default path: loading the
-// model embedded in the binary via the in-memory bytes API. It skips when the
-// build has no embedded model (-tags noembed) or when ONNX Runtime is not
+// model embedded in the binary via the in-memory bytes API. The model is embedded
+// in every build, so in practice this skips only when ONNX Runtime is not
 // available on the host. VAD_TEST_ORT_LIB may point at the ORT shared library.
 func TestVAD_EmbeddedModelLoads(t *testing.T) {
 	if !HasEmbeddedModel() {
@@ -370,8 +370,8 @@ func BenchmarkVADStreamer1s(b *testing.B) {
 // fixture: it drives the embedded sequence model with a synthetic voiced signal
 // (whose syllable modulation the model scores as speech) and asserts that the
 // streaming path detects the same speech peak as the full-chunk path on real
-// ONNX Runtime. It skips on a noembed build or when ONNX Runtime is unavailable,
-// so it exercises the real streamer+model tensor plumbing wherever CI has ORT
+// ONNX Runtime. It skips when ONNX Runtime is unavailable (the model is always
+// embedded), so it exercises the real streamer+model tensor plumbing wherever CI has ORT
 // linked while the stub-session unit tests pin the bookkeeping everywhere else.
 // The stronger time-resolved coverage parity lives in TestVAD_StreamingCoverageParity
 // (real speech clip, run locally), since a synthetic signal's amplitude envelope

--- a/internal/inference/vad/vad.go
+++ b/internal/inference/vad/vad.go
@@ -56,8 +56,9 @@ var (
 var zeroLSTMState [stateWidth]float32
 
 // EmbeddedModelData returns the embedded Silero VAD model bytes. The model is
-// compiled into every build (it is embedded unconditionally), so this is always
-// non-empty.
+// compiled into every build, so the returned slice is non-empty. It aliases the
+// shared embedded data and must be treated as read-only; callers must not mutate
+// it.
 func EmbeddedModelData() []byte { return embeddedModel }
 
 // HasEmbeddedModel reports whether an embedded VAD model is available in this build.

--- a/internal/inference/vad/vad.go
+++ b/internal/inference/vad/vad.go
@@ -55,8 +55,9 @@ var (
 // allocation.
 var zeroLSTMState [stateWidth]float32
 
-// EmbeddedModelData returns the embedded Silero VAD model bytes, or nil if the
-// binary was built without embedded models (-tags noembed).
+// EmbeddedModelData returns the embedded Silero VAD model bytes. The model is
+// compiled into every build (it is embedded unconditionally), so this is always
+// non-empty.
 func EmbeddedModelData() []byte { return embeddedModel }
 
 // HasEmbeddedModel reports whether an embedded VAD model is available in this build.


### PR DESCRIPTION
## Summary

The Silero VAD model was gated behind `//go:build !noembed`, but container images build with `-tags noembed`, so the model was stripped from exactly the builds that produce the Docker images and nothing copied it back in. Privacy Guard's speech gate then failed at startup unless the user manually downloaded a sequence-export model and set `realtime.privacyfilter.vad.modelpath`.

This embeds the model unconditionally. The `noembed` tag exists to externalize the large BirdNET classifier models as separate, deduplicated image layers; the Silero model is only ~1.25 MB and MIT licensed, so it does not need that treatment. Dropping the build constraint (and the empty-stub file) makes the container binary carry it directly with no Dockerfile change, and also fixes the standalone `noembed` Windows and macOS binaries. `resolveVADModel` still prefers an explicit `modelpath` override, so nothing changes for users who set one.

## Changes

- `internal/inference/vad/embed_model.go`: remove the `//go:build !noembed` constraint so the model embeds in every build.
- `internal/inference/vad/embed_model_noembed.go`: delete the empty-`embeddedModel` stub.
- Comment and docstring accuracy updates in `vad.go`, `vad_gate.go`, `vad_gate_test.go`, `inference_status.go`, `functional_test.go`, and the frontend `inference.types.ts` mirror (they no longer claim `noembed` strips the VAD model).

## Verification

Default and `noembed` builds compile and `go vet -tags noembed` is clean. Under `-tags noembed` (Docker's build) the embedded-model functional tests now load the model and run real inference instead of skipping. Full-project `golangci-lint` and changed-package tests pass across all tag combinations, and the frontend `check:all` passes.

## Related

Refs #4322


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Voice activity detection now includes its embedded model in every build, including builds that previously omitted embedded models.
  - VAD availability remains enabled whenever the embedded model or a configured model path is available.

- **Documentation**
  - Updated system status and model availability guidance to reflect the always-included embedded VAD model and clarify fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->