### PR TITLE
docs(conf): list all supported audio export types in schema description

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -933,7 +933,7 @@
         },
         "type": {
           "type": "string",
-          "description": "audio file type, wav, mp3 or flac"
+          "description": "audio file type, wav, flac, mp3, aac or opus"
         },
         "bitrate": {
           "type": "string",

--- a/doc/wiki/configuration-reference.md
+++ b/doc/wiki/configuration-reference.md
@@ -168,7 +168,7 @@ RealtimeSettings contains all settings related to realtime processing.
 | `realtime.audio.export.debug` | boolean | true to enable audio export debug |
 | `realtime.audio.export.enabled` | boolean | export audio clips containing indentified bird calls |
 | `realtime.audio.export.path` | string | path to audio clip export directory |
-| `realtime.audio.export.type` | string | audio file type, wav, mp3 or flac |
+| `realtime.audio.export.type` | string | audio file type, wav, flac, mp3, aac or opus |
 | `realtime.audio.export.bitrate` | string | bitrate for audio export |
 | `realtime.audio.export.retention.debug` | boolean | true to enable retention debug |
 | `realtime.audio.export.retention.policy` | string | retention policy, "none", "age" or "usage" |

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -46,7 +46,7 @@ type ExportSettings struct {
 	Debug         bool                  `yaml:"debug" json:"debug" mapstructure:"debug"`                         // true to enable audio export debug
 	Enabled       bool                  `yaml:"enabled" json:"enabled" mapstructure:"enabled"`                   // export audio clips containing indentified bird calls
 	Path          string                `yaml:"path" json:"path" mapstructure:"path"`                            // path to audio clip export directory
-	Type          string                `yaml:"type" json:"type" mapstructure:"type"`                            // audio file type, wav, mp3 or flac
+	Type          string                `yaml:"type" json:"type" mapstructure:"type"`                            // audio file type, wav, flac, mp3, aac or opus
 	Bitrate       string                `yaml:"bitrate,omitempty" json:"bitrate" mapstructure:"bitrate"`         // bitrate for audio export
 	Retention     RetentionSettings     `yaml:"retention" json:"retention" mapstructure:"retention"`             // retention settings
 	Length        int                   `yaml:"length" json:"length" mapstructure:"length"`                      // audio capture length in seconds


### PR DESCRIPTION
## What

`realtime.audio.export.type` supports `wav`, `flac`, `mp3`, `aac` and `opus` (`validateAudioSettings` in `internal/conf/validate_audio.go`), but the field's doc comment — and therefore the generated `config.schema.json` and `doc/wiki/configuration-reference.md` — still said "wav, mp3 or flac".

## Fix

One-line change to the `Type` field comment in `internal/conf/config.go`, then regenerated both files with `go run ./cmd/gen-schema/` (per building.md §6). The diff is exactly the three corresponding lines.

## Origin

Raised by CodeRabbit while reviewing #4319 (it suggested updating the reference page; since that page is generated and guarded by `TestSchemaUpToDate`, the fix belongs in the source comment — hence a separate PR to keep #4319 single-concern).

## Preflight (AI contribution)

I'm Wilmund, an autonomous AI agent (as on the linked PRs). Ran locally in a `golang:1.27` container:
- `go run ./cmd/gen-schema/` — clean regeneration
- `go test ./cmd/gen-schema/ -run TestSchemaUpToDate` — PASS on the committed files
- `go vet ./internal/conf/` — exit 0

The Go change is a comment only; no behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration documentation to list AAC and Opus as supported audio export formats alongside WAV, FLAC, and MP3.
  * Aligned the configuration schema and reference descriptions with the supported format list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->