### PR TITLE
fix(datastore,api): unify time-of-day classification and conditional-GET

### DIFF
--- a/internal/api/v2/apicore/conditional_get.go
+++ b/internal/api/v2/apicore/conditional_get.go
@@ -1,0 +1,33 @@
+package apicore
+
+import "strings"
+
+// MatchIfNoneMatch reports whether an If-None-Match request header matches etag,
+// so a handler can answer a conditional GET with 304 Not Modified. It follows
+// RFC 7232 §3.2: the "*" wildcard matches any current representation, a
+// comma-separated list matches when any member matches, and a leading weak
+// validator "W/" prefix on a candidate is ignored (reverse proxies and CDNs
+// routinely weaken a strong ETag to W/"..."). An empty header never matches.
+//
+// etag is expected to be a strong, already-quoted validator (e.g. `"abc123"`).
+// The weak "W/" prefix is stripped from the client candidate only, not from
+// etag, so passing a weak server etag would under-match. Candidates are split on
+// ",", so an (unusual) quoted ETag value containing a literal comma would not
+// match; the ETag values used in this codebase are comma-free.
+//
+// Shared by the api/v2 models (coverage-map) and species (dictionary) handlers
+// so their conditional-GET handling stays consistent.
+func MatchIfNoneMatch(header, etag string) bool {
+	if header == "" {
+		return false
+	}
+	if strings.TrimSpace(header) == "*" {
+		return true
+	}
+	for candidate := range strings.SplitSeq(header, ",") {
+		if strings.TrimPrefix(strings.TrimSpace(candidate), "W/") == etag {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/v2/apicore/conditional_get_test.go
+++ b/internal/api/v2/apicore/conditional_get_test.go
@@ -1,0 +1,41 @@
+package apicore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMatchIfNoneMatch covers the conditional-request matcher directly,
+// including the wildcard, comma-separated lists, the weak-validator form a proxy
+// may send, and whitespace/degenerate candidates. Relocated here from the models
+// domain when the matcher was consolidated onto apicore.
+func TestMatchIfNoneMatch(t *testing.T) {
+	t.Parallel()
+	const etag = `"abc123"`
+	cases := []struct {
+		name   string
+		header string
+		want   bool
+	}{
+		{"empty header", "", false},
+		{"exact strong match", `"abc123"`, true},
+		{"wildcard", "*", true},
+		{"wildcard with surrounding spaces", "  *  ", true},
+		{"weak-validator form", `W/"abc123"`, true},
+		{"comma list contains match", `"nope", "abc123"`, true},
+		{"comma list contains weak match", `W/"x", W/"abc123"`, true},
+		{"comma list no match", `"nope", "nada"`, false},
+		{"leading/trailing spaces around single tag", `  "abc123"  `, true},
+		{"no match", `"different"`, false},
+		{"prefix-only, not a real tag", `"abc"`, false},
+		{"lone weak prefix does not match", "W/", false},
+		{"trailing comma leaves empty candidate", `"abc123",`, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, MatchIfNoneMatch(tc.header, etag), "header %q", tc.header)
+		})
+	}
+}

--- a/internal/api/v2/detections/detections.go
+++ b/internal/api/v2/detections/detections.go
@@ -39,9 +39,8 @@ func (e *dateValidationError) Error() string { return e.message }
 
 // Detection constants (file-local)
 const (
-	defaultNumResults     = 100  // Default number of results
-	maxNumResults         = 1000 // Maximum number of results
-	sunEventWindowMinutes = 30   // Minutes before/after sunrise/sunset
+	defaultNumResults = 100  // Default number of results
+	maxNumResults     = 1000 // Maximum number of results
 
 	// queryType values for detection queries
 	queryTypeHourly  = "hourly"
@@ -833,7 +832,7 @@ func (c *Handler) calculateDetectionTimeOfDay(detectionTime time.Time) string {
 	if err != nil {
 		return ""
 	}
-	return calculateTimeOfDay(detectionTime, &sunTimes)
+	return suncalc.ClassifyTimeOfDay(detectionTime, &sunTimes)
 }
 
 // getWeatherForDetectionTime retrieves weather data for a detection time
@@ -1852,7 +1851,7 @@ func (c *Handler) GetDetectionTimeOfDay(ctx echo.Context) error {
 	dateTimeStr := fmt.Sprintf("%s %s", note.Date, note.Time)
 	layout := "2006-01-02 15:04:05" // Adjust based on your actual date/time format
 
-	detectionTime, err := time.Parse(layout, dateTimeStr)
+	detectionTime, err := time.ParseInLocation(layout, dateTimeStr, time.Local)
 	if err != nil {
 		return c.HandleError(ctx, err, "Failed to parse detection time", http.StatusInternalServerError)
 	}
@@ -1869,37 +1868,12 @@ func (c *Handler) GetDetectionTimeOfDay(ctx echo.Context) error {
 	}
 
 	// Determine time of day based on the detection time and sun events
-	timeOfDay := calculateTimeOfDay(detectionTime, &sunEvents)
+	timeOfDay := suncalc.ClassifyTimeOfDay(detectionTime, &sunEvents)
 
 	// Return the time of day
 	return ctx.JSON(http.StatusOK, TimeOfDayResponse{
 		TimeOfDay: timeOfDay,
 	})
-}
-
-// calculateTimeOfDay determines the time of day based on the detection time and sun events
-func calculateTimeOfDay(detectionTime time.Time, sunEvents *suncalc.SunEventTimes) string {
-	// Convert all times to the same format for comparison
-	detTime := detectionTime.Format(time.TimeOnly)
-	sunriseTime := sunEvents.Sunrise.Format(time.TimeOnly)
-	sunsetTime := sunEvents.Sunset.Format(time.TimeOnly)
-
-	// Define sunrise/sunset window (30 minutes before and after)
-	sunriseStart := sunEvents.Sunrise.Add(-sunEventWindowMinutes * time.Minute).Format(time.TimeOnly)
-	sunriseEnd := sunEvents.Sunrise.Add(sunEventWindowMinutes * time.Minute).Format(time.TimeOnly)
-	sunsetStart := sunEvents.Sunset.Add(-sunEventWindowMinutes * time.Minute).Format(time.TimeOnly)
-	sunsetEnd := sunEvents.Sunset.Add(sunEventWindowMinutes * time.Minute).Format(time.TimeOnly)
-
-	switch {
-	case detTime >= sunriseStart && detTime <= sunriseEnd:
-		return datastore.TimeOfDaySunrise
-	case detTime >= sunsetStart && detTime <= sunsetEnd:
-		return datastore.TimeOfDaySunset
-	case detTime >= sunriseTime && detTime < sunsetTime:
-		return datastore.TimeOfDayDay
-	default:
-		return datastore.TimeOfDayNight
-	}
 }
 
 // getWeatherUnits returns the temperature display unit based on user preference.

--- a/internal/api/v2/models/models_regions.go
+++ b/internal/api/v2/models/models_regions.go
@@ -5,10 +5,10 @@ import (
 	"maps"
 	"net/http"
 	"slices"
-	"strings"
 
 	"github.com/labstack/echo/v4"
 
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/classifier/region"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -129,31 +129,10 @@ func (c *Handler) GetRegionCoverageMap(ctx echo.Context) error {
 	h := ctx.Response().Header()
 	h.Set("Cache-Control", coverageMapCacheControl)
 	h.Set("ETag", etag)
-	if ifNoneMatch(ctx.Request().Header.Get("If-None-Match"), etag) {
+	if apicore.MatchIfNoneMatch(ctx.Request().Header.Get("If-None-Match"), etag) {
 		return ctx.NoContent(http.StatusNotModified)
 	}
 	return ctx.Blob(http.StatusOK, svgContentType, svg)
-}
-
-// ifNoneMatch reports whether an If-None-Match request header matches etag,
-// honoring the "*" wildcard and a comma-separated list of candidate tags. It
-// also accepts the weak form W/"...": reverse proxies and CDNs commonly weaken a
-// strong ETag before it reaches the client, which then echoes the weakened tag
-// back on revalidation, so comparing against the de-weakened candidate still
-// yields the correct 304 instead of re-sending the whole SVG (RFC 7232).
-func ifNoneMatch(header, etag string) bool {
-	if header == "" {
-		return false
-	}
-	if strings.TrimSpace(header) == "*" {
-		return true
-	}
-	for candidate := range strings.SplitSeq(header, ",") {
-		if strings.TrimPrefix(strings.TrimSpace(candidate), "W/") == etag {
-			return true
-		}
-	}
-	return false
 }
 
 // representativeTable picks a deterministic table from the embedded set (lowest

--- a/internal/api/v2/models/models_regions_test.go
+++ b/internal/api/v2/models/models_regions_test.go
@@ -278,33 +278,6 @@ func TestGetRegionCoverageMap_NotFound(t *testing.T) {
 	}
 }
 
-// TestIfNoneMatch covers the conditional-request matcher directly, including the
-// wildcard, comma-separated lists, and the weak-validator form a proxy may send.
-func TestIfNoneMatch(t *testing.T) {
-	t.Parallel()
-	const etag = `"abc123"`
-	cases := []struct {
-		name   string
-		header string
-		want   bool
-	}{
-		{"empty header", "", false},
-		{"exact strong match", `"abc123"`, true},
-		{"wildcard", "*", true},
-		{"weak-validator form", `W/"abc123"`, true},
-		{"comma list contains match", `"nope", "abc123"`, true},
-		{"comma list contains weak match", `W/"x", W/"abc123"`, true},
-		{"no match", `"different"`, false},
-		{"prefix-only, not a real tag", `"abc"`, false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tc.want, ifNoneMatch(tc.header, etag), "header %q", tc.header)
-		})
-	}
-}
-
 // TestGetRegionCoverageMap_MismatchedETagServesBody confirms a stale/mismatched
 // If-None-Match still gets the full SVG (200), not a 304.
 func TestGetRegionCoverageMap_MismatchedETagServesBody(t *testing.T) {

--- a/internal/api/v2/species/dictionary.go
+++ b/internal/api/v2/species/dictionary.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/speciesdict"
 )
@@ -88,9 +89,10 @@ func (c *Handler) ServeSpeciesDictionary(ctx echo.Context) error {
 		hdr.Set("Cache-Control", dictCacheShort)
 	}
 
-	// Respond with 304 if the client already has the current version. Accept the weak
-	// form too, since reverse proxies and CDNs often weaken a strong ETag to W/"...".
-	if clientETag := ctx.Request().Header.Get("If-None-Match"); clientETag == etag || clientETag == "W/"+etag {
+	// Respond with 304 if the client already has the current version. The shared
+	// helper honors the "*" wildcard, comma-separated lists, and the weak W/"..."
+	// form that reverse proxies and CDNs often apply (RFC 7232).
+	if apicore.MatchIfNoneMatch(ctx.Request().Header.Get("If-None-Match"), etag) {
 		return ctx.NoContent(http.StatusNotModified)
 	}
 

--- a/internal/api/v2/weather/weather.go
+++ b/internal/api/v2/weather/weather.go
@@ -23,9 +23,7 @@ import (
 
 // Weather constants (package-local)
 const (
-	timePeriodNight        = datastore.TimeOfDayNight
-	minTimeStringLength    = 2  // Minimum length for parsing hour from time string
-	weatherSunWindowMinute = 30 // Minutes before/after sunrise/sunset for weather
+	minTimeStringLength = 2 // Minimum length for parsing hour from time string
 )
 
 // Handler serves the weather domain endpoints. It embeds *apicore.Core BY
@@ -407,7 +405,7 @@ func (c *Handler) findHourlyWeatherByHourString(hourlyWeatherList []datastore.Ho
 // determineTimeOfDayForDetection calculates the time of day string ("day", "night", etc.)
 // It returns the parsed detection time, the calculated timeOfDay string, and any error during parsing or calculation.
 func (c *Handler) determineTimeOfDayForDetection(note *datastore.Note, date, detectionID string) (*time.Time, string, error) {
-	timeOfDay := timePeriodNight // Default
+	timeOfDay := datastore.TimeOfDayNight // Default
 
 	detectionTimeStr := date + " " + note.Time
 	detectionTime, parseErr := time.ParseInLocation("2006-01-02 15:04:05", detectionTimeStr, time.Local)
@@ -427,7 +425,7 @@ func (c *Handler) determineTimeOfDayForDetection(note *datastore.Note, date, det
 		return &detectionTime, timeOfDay, sunErr
 	}
 
-	timeOfDay = c.calculateTimeOfDay(detectionTime, &sunTimes)
+	timeOfDay = suncalc.ClassifyTimeOfDay(detectionTime, &sunTimes)
 	return &detectionTime, timeOfDay, nil
 }
 
@@ -567,31 +565,6 @@ func (c *Handler) GetLatestWeather(ctx echo.Context) error {
 	)
 
 	return ctx.JSON(http.StatusOK, response)
-}
-
-// calculateTimeOfDay determines the time of day based on the detection time and sun events
-func (c *Handler) calculateTimeOfDay(detectionTime time.Time, sunEvents *suncalc.SunEventTimes) string {
-	// Convert all times to the same format for comparison
-	detTime := detectionTime.Format(time.TimeOnly)
-	sunriseTime := sunEvents.Sunrise.Format(time.TimeOnly)
-	sunsetTime := sunEvents.Sunset.Format(time.TimeOnly)
-
-	// Define sunrise/sunset window (30 minutes before and after)
-	sunriseStart := sunEvents.Sunrise.Add(-weatherSunWindowMinute * time.Minute).Format(time.TimeOnly)
-	sunriseEnd := sunEvents.Sunrise.Add(weatherSunWindowMinute * time.Minute).Format(time.TimeOnly)
-	sunsetStart := sunEvents.Sunset.Add(-weatherSunWindowMinute * time.Minute).Format(time.TimeOnly)
-	sunsetEnd := sunEvents.Sunset.Add(weatherSunWindowMinute * time.Minute).Format(time.TimeOnly)
-
-	switch {
-	case detTime >= sunriseStart && detTime <= sunriseEnd:
-		return datastore.TimeOfDaySunrise
-	case detTime >= sunsetStart && detTime <= sunsetEnd:
-		return datastore.TimeOfDaySunset
-	case detTime >= sunriseTime && detTime < sunsetTime:
-		return datastore.TimeOfDayDay
-	default:
-		return timePeriodNight
-	}
 }
 
 // GetMoonPhase handles GET /api/v2/weather/moon/:date

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -2399,82 +2399,35 @@ func buildTimeOfDayConditions(filters *SearchFilters, sc *suncalc.SunCalc, db *g
 	conditions := make([]*gorm.DB, 0, dayCount)
 	window := suncalc.SunEventWindow // sunrise/sunset transition half-width (single source of truth)
 
-	// Optimization: Group dates by week and calculate sun times once per week
-	// Store weekly sun calculations
-	type WeeklySunTimes struct {
-		year      int
-		week      int
-		sunTimes  suncalc.SunEventTimes
-		dateRange []time.Time
-	}
-
-	// Map to store our weekly calculations
-	weeklySunCache := make(map[string]*WeeklySunTimes)
-
-	// First pass: group dates by week
+	// Build one condition per date using that date's OWN sun events, so the SQL
+	// filter matches the per-row classifier (suncalc.ClassifyTimeOfDay), which also
+	// classifies each detection against its own date's sun events. GetSunEventTimes
+	// caches internally, so computing per date rather than once per representative
+	// week day adds no meaningful cost while removing the day-to-day drift that let
+	// the filter diverge from the per-row label near the solstices (where sunrise
+	// and sunset shift enough within a week to flip a window across midnight).
 	for d := startDate; !d.After(endDate); d = d.AddDate(0, 0, 1) {
-		year, week := d.ISOWeek()
-		key := fmt.Sprintf("%d-%d", year, week)
-
-		if _, exists := weeklySunCache[key]; !exists {
-			// Create a new entry for this week
-			weeklySunCache[key] = &WeeklySunTimes{
-				year:      year,
-				week:      week,
-				dateRange: []time.Time{},
-			}
-		}
-
-		// Add this date to the week's date range
-		weeklySunCache[key].dateRange = append(weeklySunCache[key].dateRange, d)
-	}
-
-	// Second pass: calculate sun times for one representative day per week
-	for _, weekData := range weeklySunCache {
-		// Find the middle day of the week as representative
-		representativeDay := weekData.dateRange[len(weekData.dateRange)/2]
-		sunTimes, err := sc.GetSunEventTimes(representativeDay)
+		dateStr := d.Format(time.DateOnly)
+		sunTimes, err := sc.GetSunEventTimes(d)
 		if err != nil {
-			GetLogger().Warn("Could not get sun times for week, skipping for TimeOfDay filter",
-				logger.Int("year", weekData.year),
-				logger.Int("week", weekData.week),
+			GetLogger().Warn("Could not get sun times for date, skipping for TimeOfDay filter",
+				logger.String("date", dateStr),
 				logger.Error(err))
 			continue
 		}
-		weekData.sunTimes = sunTimes
-	}
-
-	// Third pass: build conditions for each date using the weekly sun times
-	for d := startDate; !d.After(endDate); d = d.AddDate(0, 0, 1) {
-		dateStr := d.Format(time.DateOnly)
-		year, week := d.ISOWeek()
-		key := fmt.Sprintf("%d-%d", year, week)
-
-		// Get the sun times for this week
-		weekData, exists := weeklySunCache[key]
-		if !exists || weekData == nil {
-			GetLogger().Warn("No sun times found for week, skipping date for TimeOfDay filter",
-				logger.Int("year", year),
-				logger.Int("week", week),
-				logger.String("date", dateStr))
-			continue
-		}
-
-		sunTimes := weekData.sunTimes
-
-		// Calculate all time boundaries once before the switch statement
-		// This reduces code duplication and makes maintenance easier
-		sunriseStr := sunTimes.Sunrise.Format(time.TimeOnly)
-		sunsetStr := sunTimes.Sunset.Format(time.TimeOnly)
-		sunriseStart := sunTimes.Sunrise.Add(-window).Format(time.TimeOnly)
-		sunriseEnd := sunTimes.Sunrise.Add(window).Format(time.TimeOnly)
-		sunsetStart := sunTimes.Sunset.Add(-window).Format(time.TimeOnly)
-		sunsetEnd := sunTimes.Sunset.Add(window).Format(time.TimeOnly)
 
 		// buildTimeOfDayClause handles windows and daytime spans that cross midnight
 		// (for example a high-latitude summer sunset whose local wall-clock falls after
 		// 00:00), which a naive start<=end range test silently drops or inverts.
-		query, args, ok := buildTimeOfDayClause(filters.TimeOfDay, dateStr, sunriseStr, sunsetStr, sunriseStart, sunriseEnd, sunsetStart, sunsetEnd)
+		query, args, ok := buildTimeOfDayClause(filters.TimeOfDay, &timeOfDayBounds{
+			date:         dateStr,
+			sunrise:      sunTimes.Sunrise.Format(time.TimeOnly),
+			sunset:       sunTimes.Sunset.Format(time.TimeOnly),
+			sunriseStart: sunTimes.Sunrise.Add(-window).Format(time.TimeOnly),
+			sunriseEnd:   sunTimes.Sunrise.Add(window).Format(time.TimeOnly),
+			sunsetStart:  sunTimes.Sunset.Add(-window).Format(time.TimeOnly),
+			sunsetEnd:    sunTimes.Sunset.Add(window).Format(time.TimeOnly),
+		})
 		if !ok {
 			// Should not happen due to sanitise, but skip if it does
 			continue
@@ -2498,19 +2451,34 @@ func buildTimeOfDayConditions(filters *SearchFilters, sc *suncalc.SunCalc, db *g
 // that case the between/outside test switches to its wraparound form so detections
 // in the after-midnight tail are still matched, consistent with the per-row
 // classifier suncalc.ClassifyTimeOfDay. It returns ok=false for an unknown category.
-func buildTimeOfDayClause(timeOfDay, dateStr, sunrise, sunset, sunriseStart, sunriseEnd, sunsetStart, sunsetEnd string) (query string, args []any, ok bool) {
-	sunriseWin, sunriseArgs := betweenTimeFragment(sunriseStart, sunriseEnd)
-	sunsetWin, sunsetArgs := betweenTimeFragment(sunsetStart, sunsetEnd)
-	dayArc, dayArgs := forwardArcFragment(sunrise, sunset)
+// timeOfDayBounds carries the "HH:MM:SS" clock strings buildTimeOfDayClause needs
+// for one date's sun events: the date, the sunrise and sunset event times, and
+// their +/- SunEventWindow boundaries. Grouping them into a struct avoids a long
+// positional parameter list where a same-typed argument could be transposed
+// unnoticed.
+type timeOfDayBounds struct {
+	date         string
+	sunrise      string
+	sunset       string
+	sunriseStart string
+	sunriseEnd   string
+	sunsetStart  string
+	sunsetEnd    string
+}
+
+func buildTimeOfDayClause(timeOfDay string, b *timeOfDayBounds) (query string, args []any, ok bool) {
+	sunriseWin, sunriseArgs := betweenTimeFragment(b.sunriseStart, b.sunriseEnd)
+	sunsetWin, sunsetArgs := betweenTimeFragment(b.sunsetStart, b.sunsetEnd)
+	dayArc, dayArgs := forwardArcFragment(b.sunrise, b.sunset)
 	switch timeOfDay {
 	case TimeOfDaySunrise:
-		return "notes.date = ? AND " + sunriseWin, append([]any{dateStr}, sunriseArgs...), true
+		return "notes.date = ? AND " + sunriseWin, append([]any{b.date}, sunriseArgs...), true
 	case TimeOfDaySunset:
 		// Exclude the sunrise window: the per-row classifier gives sunrise priority,
 		// so a timestamp inside both windows (possible when the two overlap at extreme
 		// high latitude) is sunrise, not sunset. Without this the sunset filter would
 		// over-match those rows.
-		clauseArgs := append([]any{dateStr}, sunsetArgs...)
+		clauseArgs := append([]any{b.date}, sunsetArgs...)
 		clauseArgs = append(clauseArgs, sunriseArgs...)
 		return "notes.date = ? AND " + sunsetWin + " AND NOT " + sunriseWin, clauseArgs, true
 	case TimeOfDayDay:
@@ -2519,7 +2487,7 @@ func buildTimeOfDayClause(timeOfDay, dateStr, sunrise, sunset, sunriseStart, sun
 		// latitude summer, e.g. Iceland/Norway near the solstice); the window
 		// exclusions keep this consistent with the classifier, which checks the
 		// sunrise and sunset windows before the daytime span.
-		clauseArgs := append([]any{dateStr}, dayArgs...)
+		clauseArgs := append([]any{b.date}, dayArgs...)
 		clauseArgs = append(clauseArgs, sunriseArgs...)
 		clauseArgs = append(clauseArgs, sunsetArgs...)
 		return "notes.date = ? AND " + dayArc + " AND NOT " + sunriseWin + " AND NOT " + sunsetWin, clauseArgs, true
@@ -2528,7 +2496,7 @@ func buildTimeOfDayClause(timeOfDay, dateStr, sunrise, sunset, sunriseStart, sun
 		// This matches the classifier's else-branch by construction in every regime
 		// (normal, a sub-hour day or night with overlapping windows, and days whose
 		// local sunset falls after midnight).
-		clauseArgs := append([]any{dateStr}, sunriseArgs...)
+		clauseArgs := append([]any{b.date}, sunriseArgs...)
 		clauseArgs = append(clauseArgs, sunsetArgs...)
 		clauseArgs = append(clauseArgs, dayArgs...)
 		return "notes.date = ? AND NOT " + sunriseWin + " AND NOT " + sunsetWin + " AND NOT " + dayArc, clauseArgs, true

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -36,9 +36,6 @@ import (
 	gormlogger "gorm.io/gorm/logger"
 )
 
-// sunriseSetWindowMinutes defines the time window (in minutes) around sunrise and sunset
-const sunriseSetWindowMinutes = 30
-
 // Database dialect constants.
 // NOTE: These must be lowercase to match GORM's dialector.Name() output.
 const (
@@ -2400,7 +2397,7 @@ func buildTimeOfDayConditions(filters *SearchFilters, sc *suncalc.SunCalc, db *g
 	// Pre-allocate conditions slice based on date range
 	dayCount := int(endDate.Sub(startDate).Hours()/24) + 1
 	conditions := make([]*gorm.DB, 0, dayCount)
-	window := time.Duration(sunriseSetWindowMinutes) * time.Minute // Define window for sunrise/sunset
+	window := suncalc.SunEventWindow // sunrise/sunset transition half-width (single source of truth)
 
 	// Optimization: Group dates by week and calculate sun times once per week
 	// Store weekly sun calculations
@@ -2467,28 +2464,22 @@ func buildTimeOfDayConditions(filters *SearchFilters, sc *suncalc.SunCalc, db *g
 
 		// Calculate all time boundaries once before the switch statement
 		// This reduces code duplication and makes maintenance easier
+		sunriseStr := sunTimes.Sunrise.Format(time.TimeOnly)
+		sunsetStr := sunTimes.Sunset.Format(time.TimeOnly)
 		sunriseStart := sunTimes.Sunrise.Add(-window).Format(time.TimeOnly)
 		sunriseEnd := sunTimes.Sunrise.Add(window).Format(time.TimeOnly)
 		sunsetStart := sunTimes.Sunset.Add(-window).Format(time.TimeOnly)
 		sunsetEnd := sunTimes.Sunset.Add(window).Format(time.TimeOnly)
 
-		var condition *gorm.DB
-		switch filters.TimeOfDay {
-		case TimeOfDayDay:
-			// Time should be after sunrise window but before sunset window
-			condition = db.Where("notes.date = ? AND notes.time > ? AND notes.time < ?", dateStr, sunriseEnd, sunsetStart)
-		case TimeOfDayNight:
-			// Time should be before sunrise window or after sunset window
-			condition = db.Where("notes.date = ? AND (notes.time < ? OR notes.time > ?)", dateStr, sunriseStart, sunsetEnd)
-		case TimeOfDaySunrise:
-			condition = db.Where("notes.date = ? AND notes.time >= ? AND notes.time <= ?", dateStr, sunriseStart, sunriseEnd)
-		case TimeOfDaySunset:
-			condition = db.Where("notes.date = ? AND notes.time >= ? AND notes.time <= ?", dateStr, sunsetStart, sunsetEnd)
-		default:
+		// buildTimeOfDayClause handles windows and daytime spans that cross midnight
+		// (for example a high-latitude summer sunset whose local wall-clock falls after
+		// 00:00), which a naive start<=end range test silently drops or inverts.
+		query, args, ok := buildTimeOfDayClause(filters.TimeOfDay, dateStr, sunriseStr, sunsetStr, sunriseStart, sunriseEnd, sunsetStart, sunsetEnd)
+		if !ok {
 			// Should not happen due to sanitise, but skip if it does
 			continue
 		}
-		conditions = append(conditions, condition)
+		conditions = append(conditions, db.Where(query, args...))
 	}
 
 	// Log summary of how many conditions were created
@@ -2497,6 +2488,76 @@ func buildTimeOfDayConditions(filters *SearchFilters, sc *suncalc.SunCalc, db *g
 		logger.Int("day_range", int(endDate.Sub(startDate).Hours()/24)+1))
 
 	return conditions, nil
+}
+
+// buildTimeOfDayClause builds the parameterized WHERE fragment selecting rows on
+// dateStr whose notes.time falls in the given time-of-day category. Boundary
+// values are "HH:MM:SS" strings, which are lexicographically ordered to match the
+// stored notes.time format. A window whose start is later than its end has crossed
+// midnight (for example a high-latitude summer sunset window [23:20, 00:20]); in
+// that case the between/outside test switches to its wraparound form so detections
+// in the after-midnight tail are still matched, consistent with the per-row
+// classifier suncalc.ClassifyTimeOfDay. It returns ok=false for an unknown category.
+func buildTimeOfDayClause(timeOfDay, dateStr, sunrise, sunset, sunriseStart, sunriseEnd, sunsetStart, sunsetEnd string) (query string, args []any, ok bool) {
+	sunriseWin, sunriseArgs := betweenTimeFragment(sunriseStart, sunriseEnd)
+	sunsetWin, sunsetArgs := betweenTimeFragment(sunsetStart, sunsetEnd)
+	dayArc, dayArgs := forwardArcFragment(sunrise, sunset)
+	switch timeOfDay {
+	case TimeOfDaySunrise:
+		return "notes.date = ? AND " + sunriseWin, append([]any{dateStr}, sunriseArgs...), true
+	case TimeOfDaySunset:
+		// Exclude the sunrise window: the per-row classifier gives sunrise priority,
+		// so a timestamp inside both windows (possible when the two overlap at extreme
+		// high latitude) is sunrise, not sunset. Without this the sunset filter would
+		// over-match those rows.
+		clauseArgs := append([]any{dateStr}, sunsetArgs...)
+		clauseArgs = append(clauseArgs, sunriseArgs...)
+		return "notes.date = ? AND " + sunsetWin + " AND NOT " + sunriseWin, clauseArgs, true
+	case TimeOfDayDay:
+		// On the daytime arc [sunrise, sunset) but outside both transition windows.
+		// The arc wraps past midnight when the local sunset falls after 00:00 (high
+		// latitude summer, e.g. Iceland/Norway near the solstice); the window
+		// exclusions keep this consistent with the classifier, which checks the
+		// sunrise and sunset windows before the daytime span.
+		clauseArgs := append([]any{dateStr}, dayArgs...)
+		clauseArgs = append(clauseArgs, sunriseArgs...)
+		clauseArgs = append(clauseArgs, sunsetArgs...)
+		return "notes.date = ? AND " + dayArc + " AND NOT " + sunriseWin + " AND NOT " + sunsetWin, clauseArgs, true
+	case TimeOfDayNight:
+		// The complement: outside both transition windows and off the daytime arc.
+		// This matches the classifier's else-branch by construction in every regime
+		// (normal, a sub-hour day or night with overlapping windows, and days whose
+		// local sunset falls after midnight).
+		clauseArgs := append([]any{dateStr}, sunriseArgs...)
+		clauseArgs = append(clauseArgs, sunsetArgs...)
+		clauseArgs = append(clauseArgs, dayArgs...)
+		return "notes.date = ? AND NOT " + sunriseWin + " AND NOT " + sunsetWin + " AND NOT " + dayArc, clauseArgs, true
+	default:
+		return "", nil, false
+	}
+}
+
+// betweenTimeFragment builds the notes.time predicate for an inclusive [start,
+// end] clock window, using the wraparound form (an OR rather than an AND) when the
+// window crosses midnight, i.e. start is lexicographically later than end (for
+// example a high-latitude sunset window [23:20, 00:20]).
+func betweenTimeFragment(start, end string) (frag string, args []any) {
+	if start <= end {
+		return "(notes.time >= ? AND notes.time <= ?)", []any{start, end}
+	}
+	return "(notes.time >= ? OR notes.time <= ?)", []any{start, end}
+}
+
+// forwardArcFragment builds the notes.time predicate for the forward arc from
+// start (inclusive) to end (exclusive) on the 24-hour clock: the plain interval
+// [start, end) when start <= end, or the wraparound form when start > end (a
+// daytime span whose local sunset falls after midnight). Mirrors suncalc's
+// inForwardArc so the SQL filter and the per-row classifier agree.
+func forwardArcFragment(start, end string) (frag string, args []any) {
+	if start <= end {
+		return "(notes.time >= ? AND notes.time < ?)", []any{start, end}
+	}
+	return "(notes.time >= ? OR notes.time < ?)", []any{start, end}
 }
 
 // SearchDetections retrieves detections based on the given filters
@@ -2547,20 +2608,23 @@ func (ds *DataStore) SearchDetections(filters *SearchFilters) ([]DetectionRecord
 	}
 	// --- End Count Query ---
 
-	// Apply sorting to the main query
+	// Apply sorting to the main query. Every sort appends notes.id as a final
+	// tiebreaker: the primary keys (common_name, confidence, even date+time) are
+	// not unique, and without a total order LIMIT/OFFSET pagination can silently
+	// skip and duplicate rows across pages.
 	switch filters.SortBy {
 	case "date_asc":
-		query = query.Order("notes.date ASC, notes.time ASC")
+		query = query.Order("notes.date ASC, notes.time ASC, notes.id DESC")
 	case "species_asc":
-		query = query.Order("notes.common_name ASC")
+		query = query.Order("notes.common_name ASC, notes.id DESC")
 	case "species_desc":
-		query = query.Order("notes.common_name DESC")
+		query = query.Order("notes.common_name DESC, notes.id DESC")
 	case "confidence_asc":
-		query = query.Order("notes.confidence ASC")
+		query = query.Order("notes.confidence ASC, notes.id DESC")
 	case "confidence_desc":
-		query = query.Order("notes.confidence DESC")
+		query = query.Order("notes.confidence DESC, notes.id DESC")
 	default:
-		query = query.Order("notes.date DESC, notes.time DESC")
+		query = query.Order("notes.date DESC, notes.time DESC, notes.id DESC")
 	}
 
 	// Apply pagination (PerPage and Page are already sanitised)
@@ -2628,34 +2692,12 @@ func (ds *DataStore) SearchDetections(filters *SearchFilters) ([]DetectionRecord
 		// Calculate time of day
 		timeOfDay := TimeOfDayUnknown
 		if ds.SunCalc != nil {
-			// Get date string for cache key
-			dateStr := scanned.Date
-
-			// Get or calculate sun times for this date
-			sunEvents, err := ds.getSunEventsForDate(dateStr, timestamp)
+			// Get or calculate sun times for this date, then delegate the
+			// sunrise/sunset/day/night classification to the shared,
+			// midnight-safe helper so every call site stays in lockstep.
+			sunEvents, err := ds.getSunEventsForDate(scanned.Date, timestamp)
 			if err == nil {
-				// Convert all times to the same format for comparison
-				detTime := timestamp.Format(time.TimeOnly)
-				sunriseTime := sunEvents.Sunrise.Format(time.TimeOnly)
-				sunsetTime := sunEvents.Sunset.Format(time.TimeOnly)
-
-				// Define sunrise/sunset window (using constant)
-				window := time.Duration(sunriseSetWindowMinutes) * time.Minute
-				sunriseStart := sunEvents.Sunrise.Add(-window).Format(time.TimeOnly)
-				sunriseEnd := sunEvents.Sunrise.Add(window).Format(time.TimeOnly)
-				sunsetStart := sunEvents.Sunset.Add(-window).Format(time.TimeOnly)
-				sunsetEnd := sunEvents.Sunset.Add(window).Format(time.TimeOnly)
-
-				switch {
-				case detTime >= sunriseStart && detTime <= sunriseEnd:
-					timeOfDay = TimeOfDaySunrise
-				case detTime >= sunsetStart && detTime <= sunsetEnd:
-					timeOfDay = TimeOfDaySunset
-				case detTime >= sunriseTime && detTime < sunsetTime:
-					timeOfDay = TimeOfDayDay
-				default:
-					timeOfDay = TimeOfDayNight
-				}
+				timeOfDay = suncalc.ClassifyTimeOfDay(timestamp, &sunEvents)
 			}
 		}
 

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -2443,14 +2443,6 @@ func buildTimeOfDayConditions(filters *SearchFilters, sc *suncalc.SunCalc, db *g
 	return conditions, nil
 }
 
-// buildTimeOfDayClause builds the parameterized WHERE fragment selecting rows on
-// dateStr whose notes.time falls in the given time-of-day category. Boundary
-// values are "HH:MM:SS" strings, which are lexicographically ordered to match the
-// stored notes.time format. A window whose start is later than its end has crossed
-// midnight (for example a high-latitude summer sunset window [23:20, 00:20]); in
-// that case the between/outside test switches to its wraparound form so detections
-// in the after-midnight tail are still matched, consistent with the per-row
-// classifier suncalc.ClassifyTimeOfDay. It returns ok=false for an unknown category.
 // timeOfDayBounds carries the "HH:MM:SS" clock strings buildTimeOfDayClause needs
 // for one date's sun events: the date, the sunrise and sunset event times, and
 // their +/- SunEventWindow boundaries. Grouping them into a struct avoids a long
@@ -2466,6 +2458,15 @@ type timeOfDayBounds struct {
 	sunsetEnd    string
 }
 
+// buildTimeOfDayClause builds the parameterized WHERE fragment selecting rows on
+// the given date whose notes.time falls in the requested time-of-day category.
+// Boundary values are "HH:MM:SS" strings, which are lexicographically ordered to
+// match the stored notes.time format. A window whose start is later than its end
+// has crossed midnight (for example a high-latitude summer sunset window
+// [23:20, 00:20]); in that case the between/outside test switches to its
+// wraparound form so detections in the after-midnight tail are still matched,
+// consistent with the per-row classifier suncalc.ClassifyTimeOfDay. It returns
+// ok=false for an unknown category.
 func buildTimeOfDayClause(timeOfDay string, b *timeOfDayBounds) (query string, args []any, ok bool) {
 	sunriseWin, sunriseArgs := betweenTimeFragment(b.sunriseStart, b.sunriseEnd)
 	sunsetWin, sunsetArgs := betweenTimeFragment(b.sunsetStart, b.sunsetEnd)

--- a/internal/datastore/time_of_day_test.go
+++ b/internal/datastore/time_of_day_test.go
@@ -308,3 +308,21 @@ func TestNightFilterExcludesSunriseSunsetWindows(t *testing.T) {
 	t.Log("Before fix: Incorrectly included sunrise/sunset/day detections")
 	t.Log("After fix: Correctly returns only true night detections")
 }
+
+// TestClassifyTimeOfDayMatchesDatastoreConstants guards against drift between the
+// string values returned by suncalc.ClassifyTimeOfDay and the datastore.TimeOfDay*
+// constants. suncalc is a leaf package and cannot import datastore, so the two
+// sets of string literals are kept in lockstep by this assertion rather than a
+// shared symbol.
+func TestClassifyTimeOfDayMatchesDatastoreConstants(t *testing.T) {
+	t.Parallel()
+	base := time.Date(2025, 7, 15, 0, 0, 0, 0, time.UTC)
+	sun := &suncalc.SunEventTimes{
+		Sunrise: base.Add(6 * time.Hour),
+		Sunset:  base.Add(21 * time.Hour),
+	}
+	assert.Equal(t, TimeOfDaySunrise, suncalc.ClassifyTimeOfDay(base.Add(6*time.Hour), sun))
+	assert.Equal(t, TimeOfDaySunset, suncalc.ClassifyTimeOfDay(base.Add(21*time.Hour), sun))
+	assert.Equal(t, TimeOfDayDay, suncalc.ClassifyTimeOfDay(base.Add(12*time.Hour), sun))
+	assert.Equal(t, TimeOfDayNight, suncalc.ClassifyTimeOfDay(base.Add(2*time.Hour), sun))
+}

--- a/internal/datastore/timeofday_clause_test.go
+++ b/internal/datastore/timeofday_clause_test.go
@@ -1,0 +1,168 @@
+package datastore
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/suncalc"
+)
+
+// clauseTestWindow tracks the production window (suncalc.SunEventWindow), the
+// same value the SQL builder and the per-row classifier use, so the sweep cannot
+// silently pass against a window that has drifted from production.
+const clauseTestWindow = suncalc.SunEventWindow
+
+// evalTimeClause interprets the WHERE fragments that buildTimeOfDayClause emits
+// and reports whether a candidate "HH:MM:SS" time satisfies the clause. It knows
+// only the handful of templates the builder produces; an unexpected one fails the
+// test so a new template cannot slip through unverified.
+// clauseTermRE matches one conjunct of a time-of-day clause: an optional "NOT "
+// followed by a parenthesized notes.time predicate. buildTimeOfDayClause emits
+// clauses as an AND-joined list of such terms.
+var clauseTermRE = regexp.MustCompile(`(NOT )?\(([^()]+)\)`)
+
+func evalTimeClause(t *testing.T, query string, args []any, candidate string) bool {
+	t.Helper()
+	const datePrefix = "notes.date = ? AND "
+	require.Truef(t, strings.HasPrefix(query, datePrefix), "clause must start with the date guard: %q", query)
+	expr := strings.TrimPrefix(query, datePrefix)
+
+	// args[0] is the date (always true for the sweep's single date); the rest are
+	// the notes.time bounds, consumed left to right by the fragments.
+	require.GreaterOrEqual(t, len(args), 1, "clause must carry at least the date arg")
+	timeArgs := make([]string, 0, len(args)-1)
+	for _, a := range args[1:] {
+		s, ok := a.(string)
+		require.True(t, ok, "time bound arg must be a string")
+		timeArgs = append(timeArgs, s)
+	}
+
+	// The clause is a conjunction of optionally-negated parenthesized fragments;
+	// evaluate each and AND them together, consuming bounds left to right.
+	terms := clauseTermRE.FindAllStringSubmatch(expr, -1)
+	require.NotEmptyf(t, terms, "no clause terms parsed from %q", expr)
+	idx := 0
+	result := true
+	for _, term := range terms {
+		val := evalTimeFragment(t, term[2], timeArgs, &idx, candidate)
+		if term[1] == "NOT " {
+			val = !val
+		}
+		result = result && val
+	}
+	require.Equalf(t, len(timeArgs), idx, "not all time bounds consumed for %q", query)
+	return result
+}
+
+// evalTimeFragment evaluates one notes.time predicate fragment (the interior of a
+// parenthesized term) against candidate, consuming its two bounds from timeArgs
+// starting at *idx. It recognizes only the shapes buildTimeOfDayClause emits; an
+// unexpected one fails the test so a new shape cannot slip through unverified.
+func evalTimeFragment(t *testing.T, frag string, timeArgs []string, idx *int, candidate string) bool {
+	t.Helper()
+	require.GreaterOrEqualf(t, len(timeArgs), *idx+2, "fragment %q needs two bounds", frag)
+	lo, hi := timeArgs[*idx], timeArgs[*idx+1]
+	*idx += 2
+	switch frag {
+	case "notes.time >= ? AND notes.time <= ?": // inclusive window, no wrap
+		return candidate >= lo && candidate <= hi
+	case "notes.time >= ? OR notes.time <= ?": // inclusive window, wraps midnight
+		return candidate >= lo || candidate <= hi
+	case "notes.time >= ? AND notes.time < ?": // forward arc [start,end), no wrap
+		return candidate >= lo && candidate < hi
+	case "notes.time >= ? OR notes.time < ?": // forward arc, wraps midnight
+		return candidate >= lo || candidate < hi
+	default:
+		t.Fatalf("unexpected clause fragment: %q", frag)
+		return false
+	}
+}
+
+// TestBuildTimeOfDayClause_MatchesClassifier proves the SQL time-of-day filter
+// selects exactly the same category as the per-row classifier
+// suncalc.ClassifyTimeOfDay, for every clock minute across 24 hours, in several
+// sun-event scenarios. The high-latitude scenarios exercise sunrise/sunset
+// windows (and the lit span) that cross midnight, the case the earlier naive
+// range test got wrong.
+func TestBuildTimeOfDayClause_MatchesClassifier(t *testing.T) {
+	t.Parallel()
+	loc := time.UTC
+	const dateStr = "2025-07-15"
+	base := time.Date(2025, 7, 15, 0, 0, 0, 0, loc)
+
+	scenarios := []struct {
+		name    string
+		sunrise time.Duration
+		sunset  time.Duration
+	}{
+		{"normal mid-latitude day", 6 * time.Hour, 21 * time.Hour},
+		{"high-latitude sunset near midnight", 3 * time.Hour, 23*time.Hour + 50*time.Minute},
+		{"high-latitude sunrise near midnight", 15 * time.Minute, 22 * time.Hour},
+		{"short winter day", 9 * time.Hour, 15 * time.Hour},
+		// Sub-60-minute day (near-total-night winter): the sunrise and sunset
+		// windows overlap, exercising the sunset clause's sunrise-window exclusion
+		// and the empty "day" set.
+		{"sub-60min day, overlapping windows", 12 * time.Hour, 12*time.Hour + 40*time.Minute},
+		// Just over 60-minute day: windows are disjoint but the "day" span is a
+		// single minute wide, exercising the tight AND day clause.
+		{"very short day, disjoint windows", 12 * time.Hour, 13*time.Hour + 1*time.Minute},
+		// Sub-60-minute night (polar summer, day > 23h): the sunrise and sunset
+		// windows overlap across midnight, so the whole night is absorbed by the
+		// transition windows and the night set is empty. Exercises the night
+		// complement clause where a naive "outside the lit span" test would invert.
+		{"sub-60min night, overlapping windows", 10 * time.Minute, 23*time.Hour + 50*time.Minute},
+		// Summer inversion: local sunset falls after midnight (e.g. Reykjavik/Oslo
+		// ~65N near the solstice, sunrise ~02:02, sunset ~00:01), so the daytime arc
+		// wraps midnight and sunset's wall-clock precedes sunrise's. Midday must be
+		// classified as day, not night.
+		{"summer inversion, sunset after midnight", 2*time.Hour + 2*time.Minute, 1 * time.Minute},
+		// More extreme inversion with a ~1h night: sunrise 02:00, sunset 01:00.
+		{"summer inversion, short night", 2 * time.Hour, 1 * time.Hour},
+	}
+
+	categories := []string{TimeOfDaySunrise, TimeOfDaySunset, TimeOfDayDay, TimeOfDayNight}
+
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			t.Parallel()
+			sun := &suncalc.SunEventTimes{Sunrise: base.Add(sc.sunrise), Sunset: base.Add(sc.sunset)}
+			sunriseStr := sun.Sunrise.Format(time.TimeOnly)
+			sunsetStr := sun.Sunset.Format(time.TimeOnly)
+			sunriseStart := sun.Sunrise.Add(-clauseTestWindow).Format(time.TimeOnly)
+			sunriseEnd := sun.Sunrise.Add(clauseTestWindow).Format(time.TimeOnly)
+			sunsetStart := sun.Sunset.Add(-clauseTestWindow).Format(time.TimeOnly)
+			sunsetEnd := sun.Sunset.Add(clauseTestWindow).Format(time.TimeOnly)
+
+			for minute := range 24 * 60 {
+				cand := base.Add(time.Duration(minute) * time.Minute)
+				candStr := cand.Format(time.TimeOnly)
+				want := suncalc.ClassifyTimeOfDay(cand, sun)
+
+				for _, cat := range categories {
+					q, a, ok := buildTimeOfDayClause(cat, dateStr, sunriseStr, sunsetStr, sunriseStart, sunriseEnd, sunsetStart, sunsetEnd)
+					require.True(t, ok, "category %s must be recognized", cat)
+					matched := evalTimeClause(t, q, a, candStr)
+					if cat == want {
+						assert.Truef(t, matched, "%s: %s should match category %q", sc.name, candStr, cat)
+					} else {
+						assert.Falsef(t, matched, "%s: %s should not match %q (classifier says %q)", sc.name, candStr, cat, want)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestBuildTimeOfDayClause_UnknownCategory verifies an unrecognized category is
+// reported as not-ok with no clause, so the caller skips it.
+func TestBuildTimeOfDayClause_UnknownCategory(t *testing.T) {
+	t.Parallel()
+	q, a, ok := buildTimeOfDayClause("bogus", "2025-07-15", "06:00:00", "21:00:00", "05:30:00", "06:30:00", "20:30:00", "21:30:00")
+	assert.False(t, ok)
+	assert.Empty(t, q)
+	assert.Nil(t, a)
+}

--- a/internal/datastore/timeofday_clause_test.go
+++ b/internal/datastore/timeofday_clause_test.go
@@ -143,7 +143,15 @@ func TestBuildTimeOfDayClause_MatchesClassifier(t *testing.T) {
 				want := suncalc.ClassifyTimeOfDay(cand, sun)
 
 				for _, cat := range categories {
-					q, a, ok := buildTimeOfDayClause(cat, dateStr, sunriseStr, sunsetStr, sunriseStart, sunriseEnd, sunsetStart, sunsetEnd)
+					q, a, ok := buildTimeOfDayClause(cat, &timeOfDayBounds{
+						date:         dateStr,
+						sunrise:      sunriseStr,
+						sunset:       sunsetStr,
+						sunriseStart: sunriseStart,
+						sunriseEnd:   sunriseEnd,
+						sunsetStart:  sunsetStart,
+						sunsetEnd:    sunsetEnd,
+					})
 					require.True(t, ok, "category %s must be recognized", cat)
 					matched := evalTimeClause(t, q, a, candStr)
 					if cat == want {
@@ -161,7 +169,15 @@ func TestBuildTimeOfDayClause_MatchesClassifier(t *testing.T) {
 // reported as not-ok with no clause, so the caller skips it.
 func TestBuildTimeOfDayClause_UnknownCategory(t *testing.T) {
 	t.Parallel()
-	q, a, ok := buildTimeOfDayClause("bogus", "2025-07-15", "06:00:00", "21:00:00", "05:30:00", "06:30:00", "20:30:00", "21:30:00")
+	q, a, ok := buildTimeOfDayClause("bogus", &timeOfDayBounds{
+		date:         "2025-07-15",
+		sunrise:      "06:00:00",
+		sunset:       "21:00:00",
+		sunriseStart: "05:30:00",
+		sunriseEnd:   "06:30:00",
+		sunsetStart:  "20:30:00",
+		sunsetEnd:    "21:30:00",
+	})
 	assert.False(t, ok)
 	assert.Empty(t, q)
 	assert.Nil(t, a)

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -1345,31 +1345,9 @@ func (ds *Datastore) calculateTimeOfDay(timestamp time.Time, lat, lon float64) s
 		return datastore.TimeOfDayAny
 	}
 
-	// Define 30-minute window around sunrise/sunset
-	window := 30 * time.Minute
-
-	// Get detection time as string for comparison (format: "15:04:05")
-	detTime := timestamp.Format(time.TimeOnly)
-
-	// Calculate window boundaries
-	sunriseStart := sunEvents.Sunrise.Add(-window).Format(time.TimeOnly)
-	sunriseEnd := sunEvents.Sunrise.Add(window).Format(time.TimeOnly)
-	sunsetStart := sunEvents.Sunset.Add(-window).Format(time.TimeOnly)
-	sunsetEnd := sunEvents.Sunset.Add(window).Format(time.TimeOnly)
-	sunriseTime := sunEvents.Sunrise.Format(time.TimeOnly)
-	sunsetTime := sunEvents.Sunset.Format(time.TimeOnly)
-
-	// Determine time of day
-	switch {
-	case detTime >= sunriseStart && detTime <= sunriseEnd:
-		return datastore.TimeOfDaySunrise
-	case detTime >= sunsetStart && detTime <= sunsetEnd:
-		return datastore.TimeOfDaySunset
-	case detTime >= sunriseTime && detTime < sunsetTime:
-		return datastore.TimeOfDayDay
-	default:
-		return datastore.TimeOfDayNight
-	}
+	// Delegate the sunrise/sunset/day/night classification to the shared,
+	// midnight-safe helper so every call site stays in lockstep.
+	return suncalc.ClassifyTimeOfDay(timestamp, &sunEvents)
 }
 
 // GetAllNotes retrieves all notes.

--- a/internal/suncalc/timeofday.go
+++ b/internal/suncalc/timeofday.go
@@ -1,0 +1,100 @@
+package suncalc
+
+import "time"
+
+// SunEventWindow is the half-width of the sunrise/sunset transition window: a
+// detection within this much time before or after sunrise (or sunset) is
+// classified as "sunrise" (or "sunset") rather than day or night. It is exported
+// as the single source of truth for the window width so the datastore's SQL
+// time-of-day filter can derive its boundaries from the same value the per-row
+// ClassifyTimeOfDay uses, keeping the two paths from drifting apart.
+const SunEventWindow = 30 * time.Minute
+
+// clockPeriod is the 24-hour clock-circle period used for wraparound-safe
+// comparisons.
+const clockPeriod = 24 * time.Hour
+
+// Time-of-day categories returned by ClassifyTimeOfDay. The string values are
+// kept in lockstep with datastore.TimeOfDay{Day,Night,Sunrise,Sunset}; suncalc
+// is a leaf package and cannot import datastore (that would be an import cycle),
+// so a drift test in the datastore package asserts the values stay equal.
+const (
+	timeOfDayDay     = "day"
+	timeOfDayNight   = "night"
+	timeOfDaySunrise = "sunrise"
+	timeOfDaySunset  = "sunset"
+)
+
+// ClassifyTimeOfDay categorizes a detection timestamp relative to that day's sun
+// events, returning one of "sunrise", "sunset", "day", or "night". A detection
+// within SunEventWindow (30 minutes) of sunrise or sunset is classified as that
+// transition; otherwise it is "day" between sunrise and sunset and "night"
+// outside. The sunrise and sunset windows are checked first, so a timestamp that
+// falls in both a transition window and the daytime span is reported as the
+// transition.
+//
+// Comparison is done on the wall-clock time of day (hours:minutes:seconds) of
+// each value in its own location, matching how sun events and detection times
+// are recorded, and is wraparound-safe: a transition window that straddles
+// midnight (for example a high-latitude summer sunset at 23:50, whose window
+// runs to 00:20) is handled correctly, where a naive lexical time-string
+// comparison would silently misclassify it.
+//
+// If sunEvents is nil the timestamp cannot be classified and the empty string is
+// returned; callers that lack sun data should not call this.
+func ClassifyTimeOfDay(detectionTime time.Time, sunEvents *SunEventTimes) string {
+	if sunEvents == nil {
+		return ""
+	}
+
+	det := clockOffset(detectionTime)
+	sunrise := clockOffset(sunEvents.Sunrise)
+	sunset := clockOffset(sunEvents.Sunset)
+
+	switch {
+	case withinWindow(det, sunrise, SunEventWindow):
+		return timeOfDaySunrise
+	case withinWindow(det, sunset, SunEventWindow):
+		return timeOfDaySunset
+	case inForwardArc(det, sunrise, sunset):
+		return timeOfDayDay
+	default:
+		return timeOfDayNight
+	}
+}
+
+// inForwardArc reports whether the time of day tod lies on the forward arc from
+// start (inclusive) to end (exclusive) on the 24-hour clock. When start <= end
+// this is the plain interval [start, end). When start > end the arc wraps past
+// midnight, [start, 24h) plus [0, end): this happens at high latitudes in summer
+// where the local sunset falls after midnight (the observer timezone's offset
+// carries the evening sunset past 00:00), so sunset's wall-clock precedes
+// sunrise's even though the day spans nearly 24 hours.
+func inForwardArc(tod, start, end time.Duration) bool {
+	if start <= end {
+		return tod >= start && tod < end
+	}
+	return tod >= start || tod < end
+}
+
+// clockOffset returns the wall-clock time of day of t (in t's own location) as a
+// duration since local midnight, at one-second resolution.
+func clockOffset(t time.Time) time.Duration {
+	h, m, s := t.Clock()
+	return time.Duration(h)*time.Hour + time.Duration(m)*time.Minute + time.Duration(s)*time.Second
+}
+
+// withinWindow reports whether the time-of-day tod is within radius of center on
+// a 24-hour clock circle. Using the circular (shorter-arc) distance makes a
+// window that crosses midnight behave correctly: with center 23:50 and radius
+// 30m, a tod of 00:10 is 20 minutes away, not 23h40m.
+func withinWindow(tod, center, radius time.Duration) bool {
+	d := tod - center
+	if d < 0 {
+		d = -d
+	}
+	if d > clockPeriod-d {
+		d = clockPeriod - d
+	}
+	return d <= radius
+}

--- a/internal/suncalc/timeofday_test.go
+++ b/internal/suncalc/timeofday_test.go
@@ -1,0 +1,141 @@
+package suncalc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sunEventsAt builds a SunEventTimes with sunrise and sunset at the given
+// wall-clock times on a fixed base date in loc. Only Sunrise and Sunset are set;
+// ClassifyTimeOfDay does not read the other fields.
+func sunEventsAt(loc *time.Location, sunrise, sunset time.Duration) *SunEventTimes {
+	base := time.Date(2025, 7, 15, 0, 0, 0, 0, loc)
+	return &SunEventTimes{
+		Sunrise: base.Add(sunrise),
+		Sunset:  base.Add(sunset),
+	}
+}
+
+// at builds a detection timestamp at the given wall-clock offset from midnight on
+// the fixed base date in loc.
+func at(loc *time.Location, offset time.Duration) time.Time {
+	return time.Date(2025, 7, 15, 0, 0, 0, 0, loc).Add(offset)
+}
+
+const (
+	hh = time.Hour
+	mm = time.Minute
+)
+
+func TestClassifyTimeOfDay(t *testing.T) {
+	t.Parallel()
+	loc := time.UTC
+
+	tests := []struct {
+		name    string
+		sunrise time.Duration
+		sunset  time.Duration
+		det     time.Duration
+		want    string
+	}{
+		// Normal mid-latitude day: sunrise 06:00, sunset 21:00.
+		{"midday is day", 6 * hh, 21 * hh, 12 * hh, "day"},
+		{"exact sunrise", 6 * hh, 21 * hh, 6 * hh, "sunrise"},
+		{"15m after sunrise is sunrise", 6 * hh, 21 * hh, 6*hh + 15*mm, "sunrise"},
+		{"sunrise window end (+30m) is sunrise", 6 * hh, 21 * hh, 6*hh + 30*mm, "sunrise"},
+		{"just past sunrise window (+31m) is day", 6 * hh, 21 * hh, 6*hh + 31*mm, "day"},
+		{"sunrise window start (-30m) is sunrise", 6 * hh, 21 * hh, 5*hh + 30*mm, "sunrise"},
+		{"just before sunrise window (-31m) is night", 6 * hh, 21 * hh, 5*hh + 29*mm, "night"},
+		{"exact sunset", 6 * hh, 21 * hh, 21 * hh, "sunset"},
+		{"sunset window start (-30m) is sunset", 6 * hh, 21 * hh, 20*hh + 30*mm, "sunset"},
+		{"just before sunset window (-31m) is day", 6 * hh, 21 * hh, 20*hh + 29*mm, "day"},
+		{"25m before sunset is sunset", 6 * hh, 21 * hh, 20*hh + 35*mm, "sunset"},
+		{"sunset window end (+30m) is sunset", 6 * hh, 21 * hh, 21*hh + 30*mm, "sunset"},
+		{"just past sunset window (+31m) is night", 6 * hh, 21 * hh, 21*hh + 31*mm, "night"},
+		{"deep night before sunrise", 6 * hh, 21 * hh, 3 * hh, "night"},
+		{"deep night after sunset", 6 * hh, 21 * hh, 23 * hh, "night"},
+
+		// High-latitude summer: sunset 23:50 -> window [23:20, 00:20] crosses
+		// midnight. This is the case the old lexical string comparison got wrong.
+		{"midnight-crossing sunset, 5m before (23:55)", 3 * hh, 23*hh + 50*mm, 23*hh + 55*mm, "sunset"},
+		{"midnight-crossing sunset, 20m after into next day (00:10)", 3 * hh, 23*hh + 50*mm, 10 * mm, "sunset"},
+		{"midnight-crossing sunset, edge +30m (00:20)", 3 * hh, 23*hh + 50*mm, 20 * mm, "sunset"},
+		{"midnight-crossing sunset, +31m is night (00:21)", 3 * hh, 23*hh + 50*mm, 21 * mm, "night"},
+		{"midnight-crossing sunset, midday still day", 3 * hh, 23*hh + 50*mm, 12 * hh, "day"},
+		{"midnight-crossing sunset, 25m before sunrise", 3 * hh, 23*hh + 50*mm, 2*hh + 35*mm, "sunrise"},
+
+		// High-latitude: sunrise 00:15 -> window [23:45, 00:45] crosses midnight
+		// backward.
+		{"midnight-crossing sunrise, 5m after (00:20)", 15 * mm, 22 * hh, 20 * mm, "sunrise"},
+		{"midnight-crossing sunrise, 25m before into prev evening (23:50)", 15 * mm, 22 * hh, 23*hh + 50*mm, "sunrise"},
+		{"midnight-crossing sunrise, edge +30m (00:45)", 15 * mm, 22 * hh, 45 * mm, "sunrise"},
+		{"midnight-crossing sunrise, +31m is day (00:46)", 15 * mm, 22 * hh, 46 * mm, "day"},
+
+		// Summer inversion: local sunset falls after midnight (sunrise 02:02, sunset
+		// 00:01), so sunset's wall-clock precedes sunrise's and the daytime arc wraps
+		// midnight (Reykjavik/Oslo near the solstice).
+		{"inversion, midday is day", 2*hh + 2*mm, 1 * mm, 12 * hh, "day"},
+		{"inversion, late evening is day", 2*hh + 2*mm, 1 * mm, 23 * hh, "day"},
+		{"inversion, 00:00 is sunset", 2*hh + 2*mm, 1 * mm, 0, "sunset"},
+		{"inversion, exact sunrise", 2*hh + 2*mm, 1 * mm, 2*hh + 2*mm, "sunrise"},
+		{"inversion, 01:00 is night", 2*hh + 2*mm, 1 * mm, 1 * hh, "night"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ClassifyTimeOfDay(at(loc, tt.det), sunEventsAt(loc, tt.sunrise, tt.sunset))
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestClassifyTimeOfDay_PrioritySunriseOverDay verifies that when a timestamp
+// falls in both the sunrise window and the daytime span, the sunrise window
+// wins (transition windows are checked before the day span).
+func TestClassifyTimeOfDay_PrioritySunriseOverDay(t *testing.T) {
+	t.Parallel()
+	loc := time.UTC
+	sun := sunEventsAt(loc, 6*hh, 21*hh)
+	// 06:20 is after sunrise (so inside [sunrise, sunset)) and within +30m window.
+	assert.Equal(t, "sunrise", ClassifyTimeOfDay(at(loc, 6*hh+20*mm), sun))
+}
+
+// TestClassifyTimeOfDay_NilSunEvents documents the nil-guard: an unclassifiable
+// timestamp yields the empty string rather than panicking.
+func TestClassifyTimeOfDay_NilSunEvents(t *testing.T) {
+	t.Parallel()
+	assert.Empty(t, ClassifyTimeOfDay(time.Now(), nil))
+}
+
+// TestWithinWindow exercises the circular-distance helper directly, including the
+// midnight wraparound that is the core of the fix.
+func TestWithinWindow(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		tod    time.Duration
+		center time.Duration
+		radius time.Duration
+		want   bool
+	}{
+		{"exact center", 6 * hh, 6 * hh, 30 * mm, true},
+		{"within radius", 6*hh + 10*mm, 6 * hh, 30 * mm, true},
+		{"at radius edge", 6*hh + 30*mm, 6 * hh, 30 * mm, true},
+		{"just outside radius", 6*hh + 31*mm, 6 * hh, 30 * mm, false},
+		{"far away not wrapped", 18 * hh, 6 * hh, 30 * mm, false},
+		{"wraps forward across midnight", 10 * mm, 23*hh + 50*mm, 30 * mm, true},
+		{"wraps backward across midnight", 23*hh + 50*mm, 15 * mm, 30 * mm, true},
+		{"wrap edge exactly at radius", 20 * mm, 23*hh + 50*mm, 30 * mm, true},
+		{"wrap just outside radius", 21 * mm, 23*hh + 50*mm, 30 * mm, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, withinWindow(tt.tod, tt.center, tt.radius))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Consolidates five duplicated sunrise/sunset/day/night time-of-day classifiers into one `suncalc.ClassifyTimeOfDay` and aligns the datastore SQL time-of-day filter with it. The previous copies compared wall-clock times as lexically formatted strings, which silently misclassified detections whenever a sunrise or sunset transition window, or the daytime span itself, crossed midnight. That happens at high latitudes near the solstices, including populated places such as Reykjavik and Oslo where the local sunset falls just after 00:00. The shared classifier compares the time of day on the 24-hour clock with a wrap-safe circular distance for the transition windows and a wrap-safe forward arc for the daytime span, and the SQL filter (`buildTimeOfDayClause`) is built from the same predicates, so the two paths partition the clock identically.

Also consolidates the two hand-rolled api/v2 `If-None-Match` comparisons into a single RFC 7232 `apicore.MatchIfNoneMatch` (wildcard, comma-separated list, weak validator). The species dictionary endpoint now honours `*` and comma-separated lists, matching the coverage-map endpoint.

Additional correctness fixes found during review:

- `GetDetectionTimeOfDay` parsed the stored local time as UTC; it now uses `time.ParseInLocation(time.Local)`, matching its sibling handlers.
- The sunrise/sunset window width is a single exported constant (`suncalc.SunEventWindow`) shared by the classifier and the SQL filter, so the two cannot drift.
- `SearchDetections` `ORDER BY` had no unique tiebreaker; under `LIMIT`/`OFFSET` a non-unique sort key can skip and duplicate rows across pages. Each sort now appends `notes.id`.

## Test Plan

- [x] `go build ./...`, `go vet`, and `golangci-lint` clean on the touched packages across all build-tag combinations.
- [x] `go test -race` passes for suncalc, api/v2 (apicore, models, species, weather, detections), datastore, and datastore/v2only.
- [x] A new per-minute equivalence test asserts the SQL filter and `ClassifyTimeOfDay` select the same category for every clock minute across nine sun-event regimes, including both midnight-crossing directions.
- [x] New table tests cover the classifier (all window boundaries, midnight-crossing, inversion, nil) and `MatchIfNoneMatch` (wildcard, comma list, weak, degenerate).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Conditional requests now support wildcard, comma-separated, weak, and exact ETag values across supported endpoints.

- **Bug Fixes**
  - Improved time-of-day detection across sunrise, sunset, midnight-crossing intervals, high-latitude conditions, and local time zones.
  - Coverage-map and species dictionary requests now apply consistent ETag matching behavior.
  - Time-based data calculations now align more accurately with daily sunrise and sunset events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->