### PR TITLE
refactor(classifier,conf): consolidate settings accessors and range-filter gate

### DIFF
--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -626,7 +626,8 @@ func resolveRangeFilterBackend(rf *conf.RangeFilterSettings) rangeFilterBackend 
 // must surface as unhealthy rather than silently filtering against the v2.4 labels.
 func (bn *BirdNET) hasNativeRangeFilter() bool {
 	// ONNX-only builds (notflite) have no embedded TFLite range filter to fall back to.
-	return tfliteBackendAvailable && isBirdNETV24Family(bn.ModelInfo.ID)
+	// Only the v2.4 MData-compatible classifier has an embedded native filter.
+	return tfliteBackendAvailable && rangeFilterCompatFor(bn.ModelInfo.ID) == rangeFilterCompatMDataV24
 }
 
 func (bn *BirdNET) initializeMetaModel(settings *conf.Settings) error {
@@ -2060,10 +2061,10 @@ func shouldAutoSelectV3Geomodel(modelID, modelsDir string) bool {
 	if modelsDir == "" {
 		return false
 	}
-	switch modelID {
-	case RegistryIDPerchV2, RegistryIDBirdNETV3:
-		// eligible classifier; check files below
-	default:
+	// Only classifiers whose label space fits the mapped geomodel v3 backend qualify.
+	// Looking up by ID (not a copied ModelInfo) keeps this identical to the previous
+	// explicit {Perch_V2, BirdNET_V3.0} switch, including for Custom and unknown IDs.
+	if rangeFilterCompatFor(modelID) != rangeFilterCompatGeomodel {
 		return false
 	}
 	sharedDir := filepath.Join(modelsDir, sharedDirName)

--- a/internal/classifier/int8_default_test.go
+++ b/internal/classifier/int8_default_test.go
@@ -23,14 +23,6 @@ func TestBirdNETV24EmbeddedLabelsResolve(t *testing.T) {
 	assert.NotEmpty(t, fn, "label filename must not be empty")
 }
 
-// TestIsBirdNETV24Family verifies that isBirdNETV24Family returns true only for
-// the canonical BirdNET v2.4 registry ID, and false for unrelated IDs.
-func TestIsBirdNETV24Family(t *testing.T) {
-	t.Parallel()
-	assert.True(t, isBirdNETV24Family(DefaultModelVersion))
-	assert.False(t, isBirdNETV24Family("Perch_V2"))
-}
-
 // TestDetermineModelInfo_V24TFLiteStaysTFLite is the reverse guard: a v2.4 TFLite
 // filename must resolve to the TFLite v2.4 entry, never the INT8 ONNX entry.
 func TestDetermineModelInfo_V24TFLiteStaysTFLite(t *testing.T) {

--- a/internal/classifier/model_catalog_test.go
+++ b/internal/classifier/model_catalog_test.go
@@ -3,11 +3,49 @@ package classifier
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"maps"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestCatalog_EntriesSharingRegistryIDShareCategoryAndRoles pins the assumption the
+// registry-keyed uninstall re-point depends on: any two catalog entries that write the
+// same settings family (same RegistryID) must share a Category and carry the same set
+// of file roles, so re-pointing config from one to the other produces a complete,
+// compatible set. Today the only multi-entry family is bat.
+func TestCatalog_EntriesSharingRegistryIDShareCategoryAndRoles(t *testing.T) {
+	t.Parallel()
+
+	type registryGroup struct {
+		category string
+		roles    []string // sorted, deduplicated
+	}
+	seen := map[string]registryGroup{}
+
+	for _, entry := range ActiveCatalog() {
+		if entry.RegistryID == "" {
+			continue // loader not implemented; no settings family to re-point
+		}
+		roleSet := map[string]struct{}{}
+		for _, f := range entry.Files {
+			roleSet[f.Role] = struct{}{}
+		}
+		roles := slices.Sorted(maps.Keys(roleSet))
+
+		first, ok := seen[entry.RegistryID]
+		if !ok {
+			seen[entry.RegistryID] = registryGroup{category: entry.Category, roles: roles}
+			continue
+		}
+		assert.Equalf(t, first.category, entry.Category,
+			"entries sharing RegistryID %q must share a Category; the re-point keys on RegistryID and asserts Category as belt-and-braces", entry.RegistryID)
+		assert.Equalf(t, first.roles, roles,
+			"entries sharing RegistryID %q must carry the same file roles so a re-point writes a complete, compatible set", entry.RegistryID)
+	}
+}
 
 func TestVariantFilesByID(t *testing.T) {
 	t.Parallel()

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -2174,7 +2174,7 @@ func (mm *ModelManager) applyConfigForInstall(entry *CatalogEntry, modelPath, la
 	updated := conf.CloneSettings(conf.GetSettings())
 
 	// Set only the non-empty paths, and only fields the family actually carries
-	// (familyFields returns nil for a family's absent labels/embeddings). The
+	// (familyFields yields a nil pointer for a family's absent labels/embeddings). The
 	// primary reaches this path only via Reinstall; Install/InstallOrReplace route
 	// it to replacePrimaryVariant instead. The primary's label set is embedded, so a
 	// primary variant never ships a labels file (labelsPath is always "" for it), but

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -467,39 +467,82 @@ func variantByModelHint(entry *CatalogEntry, subdir, modelBasenameHint string) (
 	return InstalledModel{}, false
 }
 
+// familyFieldSet is the set of settings fields one model family owns. A nil
+// pointer means the family has no such field and callers must NOT read or write
+// it. It replaces the four-return familyPathFields so the threshold, override and
+// locale fields can be reached through the same single mapping (Phase 2 builds the
+// orchestrator-owned services on this seam).
+type familyFieldSet struct {
+	Model             *string
+	Labels            *string
+	Embeddings        *string
+	Threshold         *float64
+	OverrideThreshold *bool
+	Locale            *string
+}
+
+// familyFields is the single family-to-settings-field mapping. It returns pointers
+// into s so callers can read or write a family's fields without naming the conf
+// struct; a nil pointer means the family has no such field and it must NOT be
+// written. ok is false for a nil settings pointer or an unknown registry ID.
+//
+// The primary's Labels pointer is &s.BirdNET.LabelPath like every other family:
+// the "a variant swap must not disturb a user-configured label path" rule lives in
+// applyConfigForVariantSwap (which writes the model field alone), not in this
+// accessor. planPathCorrection never rewrites the primary's label path because
+// resolvePrimaryModelPath only ever resolves a model path, so its fc.resolved == ""
+// guard skips the label field.
+func familyFields(s *conf.Settings, registryID string) (familyFieldSet, bool) {
+	if s == nil {
+		return familyFieldSet{}, false
+	}
+	switch registryID {
+	case permanentRegistryID:
+		return familyFieldSet{
+			Model:     &s.BirdNET.ModelPath,
+			Labels:    &s.BirdNET.LabelPath,
+			Threshold: &s.BirdNET.Threshold,
+			Locale:    &s.BirdNET.Locale,
+		}, true
+	case RegistryIDPerchV2:
+		return familyFieldSet{
+			Model:             &s.Perch.ModelPath,
+			Labels:            &s.Perch.LabelPath,
+			Threshold:         &s.Perch.Threshold,
+			OverrideThreshold: &s.Perch.OverrideThreshold,
+			Locale:            &s.Perch.Locale,
+		}, true
+	case RegistryIDBirdNETV3:
+		return familyFieldSet{
+			Model:             &s.BirdNETV3.ModelPath,
+			Labels:            &s.BirdNETV3.LabelPath,
+			Threshold:         &s.BirdNETV3.Threshold,
+			OverrideThreshold: &s.BirdNETV3.OverrideThreshold,
+			Locale:            &s.BirdNETV3.Locale,
+		}, true
+	case RegistryIDBSG:
+		return familyFieldSet{
+			Model:  &s.BSG.ModelPath,
+			Labels: &s.BSG.LabelPath,
+			Locale: &s.BSG.Locale,
+		}, true
+	case RegistryIDBat:
+		return familyFieldSet{
+			Model:      &s.Bat.ClassifierModel,
+			Labels:     &s.Bat.LabelPath,
+			Embeddings: &s.Bat.EmbeddingModel,
+			Threshold:  &s.Bat.Threshold,
+			Locale:     &s.Bat.Locale,
+		}, true
+	default:
+		return familyFieldSet{}, false
+	}
+}
+
 // installedModelBasenameHint returns the basename of the model path recorded in
 // settings for the given registry ID, or "" when settings are absent or the
 // family carries no path. It is the tie-break scanVariantEntry uses to resolve an
 // ambiguous multi-variant on-disk state to the variant the loader actually opens.
-// familyPathFields returns pointers to the model, labels, and embeddings path
-// fields in s for registryID, so the family-to-settings-field mapping lives in ONE
-// place instead of the copies that had drifted apart (the newest omitted BSG). A
-// nil labels or embeddings pointer means the family has no such field and it must
-// NOT be written: the primary is model-only (its label set is embedded and
-// identical across variants, so applyConfigForPrimarySwap writes BirdNET.ModelPath
-// alone and a user-configured BirdNET.LabelPath must survive a variant swap), and
-// every family but bat carries no embeddings path. ok is false for an unknown
-// registry ID or a nil settings pointer.
-func familyPathFields(s *conf.Settings, registryID string) (model, labels, embeddings *string, ok bool) {
-	if s == nil {
-		return nil, nil, nil, false
-	}
-	switch registryID {
-	case permanentRegistryID:
-		return &s.BirdNET.ModelPath, nil, nil, true
-	case RegistryIDPerchV2:
-		return &s.Perch.ModelPath, &s.Perch.LabelPath, nil, true
-	case RegistryIDBirdNETV3:
-		return &s.BirdNETV3.ModelPath, &s.BirdNETV3.LabelPath, nil, true
-	case RegistryIDBSG:
-		return &s.BSG.ModelPath, &s.BSG.LabelPath, nil, true
-	case RegistryIDBat:
-		return &s.Bat.ClassifierModel, &s.Bat.LabelPath, &s.Bat.EmbeddingModel, true
-	default:
-		return nil, nil, nil, false
-	}
-}
-
 func installedModelBasenameHint(settings *conf.Settings, registryID string, loadedPaths map[string]string) string {
 	// Prefer the file the LOADED instance is actually running. After a stale-path
 	// recovery the settings field still names the pre-recovery file, so keying the
@@ -521,12 +564,12 @@ func installedModelBasenameHint(settings *conf.Settings, registryID string, load
 	// No loaded instance for this family: fall back to the configured model path.
 	// The permanent BirdNET v2.4 slot records its selected DFT-truncated file in
 	// BirdNET.ModelPath (empty means the embedded BuiltIn baseline); each secondary
-	// records its own. familyPathFields is the single source of that mapping.
-	model, _, _, ok := familyPathFields(settings, registryID)
-	if !ok || *model == "" {
+	// records its own. familyFields is the single source of that mapping.
+	fs, ok := familyFields(settings, registryID)
+	if !ok || *fs.Model == "" {
 		return ""
 	}
-	return filepath.Base(*model)
+	return filepath.Base(*fs.Model)
 }
 
 // installedFromVariant builds the InstalledModel for a specific variant if its
@@ -666,7 +709,7 @@ func (mm *ModelManager) applyInstalledGeomodelConfig(log logger.Logger, entry *C
 	// check and the store, overwriting it with stale data.
 	settingsWriteMu.Lock()
 	current := conf.GetSettings()
-	rf := current.BirdNET.RangeFilter
+	rf := current.RangeFilterConfig()
 	if rf.Model == entry.GeomodelVersion &&
 		rf.ModelPath == expectedModelPath &&
 		rf.LabelsPath == expectedLabelsPath {
@@ -681,9 +724,10 @@ func (mm *ModelManager) applyInstalledGeomodelConfig(log logger.Logger, entry *C
 		logger.String("geomodel_version", entry.GeomodelVersion))
 
 	updated := conf.CloneSettings(current)
-	updated.BirdNET.RangeFilter.Model = entry.GeomodelVersion
-	updated.BirdNET.RangeFilter.ModelPath = expectedModelPath
-	updated.BirdNET.RangeFilter.LabelsPath = expectedLabelsPath
+	urf := updated.RangeFilterConfig()
+	urf.Model = entry.GeomodelVersion
+	urf.ModelPath = expectedModelPath
+	urf.LabelsPath = expectedLabelsPath
 	conf.StoreSettings(updated)
 	if err := conf.SaveSettings(); err != nil {
 		log.Warn("Failed to persist geomodel config",
@@ -731,24 +775,25 @@ func (mm *ModelManager) healOrphanGeomodelConfig(log logger.Logger) {
 	// check above is independent of settings, so it stays outside the lock.
 	settingsWriteMu.Lock()
 	current := conf.GetSettings()
-	rf := current.BirdNET.RangeFilter
-	action := decideGeomodelOrphanAction(&rf, expectedModelPath, expectedLabelsPath, filesPresent)
+	rf := current.RangeFilterConfig()
+	action := decideGeomodelOrphanAction(rf, expectedModelPath, expectedLabelsPath, filesPresent)
 	if action == geomodelOrphanNone {
 		settingsWriteMu.Unlock()
 		return
 	}
 
 	updated := conf.CloneSettings(current)
+	urf := updated.RangeFilterConfig()
 	switch action {
 	case geomodelOrphanPromote:
 		log.Info("Promoting orphaned geomodel range filter config to v3 (shared files present)")
-		updated.BirdNET.RangeFilter.Model = geomodelRangeFilterVersion
+		urf.Model = geomodelRangeFilterVersion
 	case geomodelOrphanClear:
 		log.Info("Clearing orphaned geomodel range filter config (shared files absent)")
-		updated.BirdNET.RangeFilter.Model = ""
-		updated.BirdNET.RangeFilter.ModelPath = ""
-		updated.BirdNET.RangeFilter.LabelsPath = ""
-		updated.BirdNET.RangeFilter.PassUnmappedSpecies = false
+		urf.Model = ""
+		urf.ModelPath = ""
+		urf.LabelsPath = ""
+		urf.PassUnmappedSpecies = false
 	case geomodelOrphanNone:
 		// Unreachable: handled by the early return above.
 	}
@@ -1559,7 +1604,7 @@ func (mm *ModelManager) replacePrimaryVariant(ctx context.Context, entry *Catalo
 	// 3. Persist BirdNET.ModelPath (set for a DFT build, cleared for the baseline)
 	//    BEFORE reloading, so the primary loader resolves the new file and a
 	//    crash/restart before step 4 still resolves the new variant.
-	mm.applyConfigForPrimarySwap(newModelPath)
+	mm.applyConfigForVariantSwap(permanentRegistryID, newModelPath)
 
 	// 4. Activate the new variant by reloading the primary in place. A reload failure
 	//    rolls back (the running model was already kept alive transactionally).
@@ -1608,7 +1653,7 @@ func (mm *ModelManager) rollbackPrimaryVariantSwap(log logger.Logger, entry *Cat
 	mm.mu.Lock()
 	mm.installed[entry.ID] = *old
 	mm.mu.Unlock()
-	mm.applyConfigForPrimarySwap(old.ModelPath)
+	mm.applyConfigForVariantSwap(permanentRegistryID, old.ModelPath)
 
 	// The new variant is unusable on this host: remove its downloaded files (none for
 	// the BuiltIn baseline) so disk state matches the restored record.
@@ -1629,14 +1674,15 @@ func (mm *ModelManager) rollbackPrimaryVariantSwap(log logger.Logger, entry *Cat
 	return switchErr
 }
 
-// applyConfigForPrimarySwap persists the primary classifier's selected model file
-// path for a within-model BirdNET v2.4 variant swap: it sets BirdNET.ModelPath to
-// the new DFT-truncated file, or clears it (empty modelPath) to revert to the
-// embedded BuiltIn baseline. It never touches BirdNET.LabelPath: the v2.4 label set
-// is embedded and identical across variants, so a swap must not disturb a
-// user-configured custom label path. Uses clone-mutate-publish + SaveSettings so the
-// change survives restarts and is visible to concurrent readers.
-func (mm *ModelManager) applyConfigForPrimarySwap(modelPath string) {
+// applyConfigForVariantSwap persists the selected model file for a within-family
+// variant swap. It writes ONLY the family's model field: a family's label set is
+// identical across its variants (embedded for BirdNET v2.4), so a swap must never
+// disturb a user-configured label path. An empty modelPath reverts to the family's
+// built-in/default source (for the primary, the embedded BuiltIn baseline). Uses
+// clone-mutate-publish + SaveSettings so the change survives restarts and is visible
+// to concurrent readers. A nil settings receiver or an unknown registry ID is a
+// no-op (nothing stored, nothing saved).
+func (mm *ModelManager) applyConfigForVariantSwap(registryID, modelPath string) {
 	if mm.settings == nil {
 		return
 	}
@@ -1644,10 +1690,15 @@ func (mm *ModelManager) applyConfigForPrimarySwap(modelPath string) {
 	defer settingsWriteMu.Unlock()
 
 	updated := conf.CloneSettings(conf.GetSettings())
-	updated.BirdNET.ModelPath = modelPath
+	fs, ok := familyFields(updated, registryID)
+	if !ok {
+		return
+	}
+	*fs.Model = modelPath
 	conf.StoreSettings(updated)
 	if err := conf.SaveSettings(); err != nil {
-		GetLogger().Warn("Failed to persist settings after primary variant swap",
+		GetLogger().Warn("Failed to persist settings after variant swap",
+			logger.String("registry_id", registryID),
 			logger.Error(err))
 	}
 }
@@ -2064,6 +2115,48 @@ func (mm *ModelManager) removeDownloading(catalogID string) {
 	delete(mm.downloading, catalogID)
 }
 
+// applyRangeFilterConfigForInstall points the range filter at entry's geomodel
+// companion files under {modelsDir}/shared when the entry carries them. It writes
+// into updated (a settings clone); the caller stores and saves. A no-op for an
+// entry without geomodel files.
+func (mm *ModelManager) applyRangeFilterConfigForInstall(updated *conf.Settings, entry *CatalogEntry) {
+	if !HasGeomodelFiles(entry) || entry.GeomodelVersion == "" {
+		return
+	}
+	rf := updated.RangeFilterConfig()
+	rf.Model = entry.GeomodelVersion
+	for _, f := range entry.Files {
+		switch f.Role {
+		case RoleGeomodelModel:
+			rf.ModelPath = filepath.Join(mm.modelsDir, sharedDirName, f.LocalName)
+		case RoleGeomodelLabels:
+			rf.LabelsPath = filepath.Join(mm.modelsDir, sharedDirName, f.LocalName)
+		}
+	}
+}
+
+// applyRangeFilterConfigForUninstall clears the geomodel range filter config when no
+// other installed entry carries geomodel files. mm.installed must no longer contain
+// the uninstalled entry; caller holds mm.mu. It writes into updated (a settings
+// clone). A no-op for an entry without geomodel files or when another geomodel-
+// dependent model remains installed.
+func (mm *ModelManager) applyRangeFilterConfigForUninstall(updated *conf.Settings, entry *CatalogEntry) {
+	if !HasGeomodelFiles(entry) {
+		return
+	}
+	for id := range mm.installed {
+		other, found := GetCatalogEntry(id)
+		if found && HasGeomodelFiles(&other) {
+			return // another geomodel-dependent model remains; keep the config
+		}
+	}
+	rf := updated.RangeFilterConfig()
+	rf.Model = ""
+	rf.ModelPath = ""
+	rf.LabelsPath = ""
+	rf.PassUnmappedSpecies = false
+}
+
 // applyConfigForInstall updates settings to reflect a newly installed model.
 // Only fields with non-empty paths are set. The caller must hold no locks
 // other than settingsWriteMu (acquired internally).
@@ -2081,33 +2174,27 @@ func (mm *ModelManager) applyConfigForInstall(entry *CatalogEntry, modelPath, la
 	updated := conf.CloneSettings(conf.GetSettings())
 
 	// Set only the non-empty paths, and only fields the family actually carries
-	// (familyPathFields returns nil for a family's absent labels/embeddings). The
-	// primary is not gallery-installed through this path, so a permanent registry ID
-	// never reaches here; if it did, familyPathFields would expose model only.
-	if model, labels, embeddings, ok := familyPathFields(updated, entry.RegistryID); ok {
+	// (familyFields returns nil for a family's absent labels/embeddings). The
+	// primary reaches this path only via Reinstall; Install/InstallOrReplace route
+	// it to replacePrimaryVariant instead. The primary's label set is embedded, so a
+	// primary variant never ships a labels file (labelsPath is always "" for it), but
+	// familyFields now exposes the primary's Labels pointer, so guard the Labels write
+	// on permanentRegistryID as well to keep a user's custom BirdNET.LabelPath
+	// structurally protected even if that ever changes.
+	if fs, ok := familyFields(updated, entry.RegistryID); ok {
 		if modelPath != "" {
-			*model = modelPath
+			*fs.Model = modelPath
 		}
-		if labels != nil && labelsPath != "" {
-			*labels = labelsPath
+		if fs.Labels != nil && labelsPath != "" && entry.RegistryID != permanentRegistryID {
+			*fs.Labels = labelsPath
 		}
-		if embeddings != nil && embeddingsPath != "" {
-			*embeddings = embeddingsPath
+		if fs.Embeddings != nil && embeddingsPath != "" {
+			*fs.Embeddings = embeddingsPath
 		}
 	}
 
 	// Apply geomodel range filter config if this entry includes geomodel files.
-	if HasGeomodelFiles(entry) && entry.GeomodelVersion != "" {
-		updated.BirdNET.RangeFilter.Model = entry.GeomodelVersion
-		for _, f := range entry.Files {
-			switch f.Role {
-			case RoleGeomodelModel:
-				updated.BirdNET.RangeFilter.ModelPath = filepath.Join(mm.modelsDir, sharedDirName, f.LocalName)
-			case RoleGeomodelLabels:
-				updated.BirdNET.RangeFilter.LabelsPath = filepath.Join(mm.modelsDir, sharedDirName, f.LocalName)
-			}
-		}
-	}
+	mm.applyRangeFilterConfigForInstall(updated, entry)
 
 	// Add config alias to Models.Enabled so the model appears in source config.
 	alias := ConfigAliasForRegistry(entry.RegistryID)
@@ -2123,6 +2210,39 @@ func (mm *ModelManager) applyConfigForInstall(entry *CatalogEntry, modelPath, la
 			logger.String("catalog_id", entry.ID),
 			logger.Error(err))
 	}
+}
+
+// replacementInstall returns another installed catalog entry that writes the SAME
+// settings family as entry (same RegistryID and Category), choosing the lowest
+// catalog ID so the pick is deterministic. mm.installed must no longer contain
+// entry; caller holds mm.mu. The Category match is belt and braces: a catalog
+// invariant test pins that entries sharing a RegistryID share a Category.
+func (mm *ModelManager) replacementInstall(entry *CatalogEntry) (InstalledModel, CatalogEntry, bool) {
+	candidates := make([]string, 0, len(mm.installed))
+	for id := range mm.installed {
+		other, found := GetCatalogEntry(id)
+		if found && other.RegistryID == entry.RegistryID && other.Category == entry.Category {
+			candidates = append(candidates, id)
+		}
+	}
+	if len(candidates) == 0 {
+		return InstalledModel{}, CatalogEntry{}, false
+	}
+	slices.Sort(candidates)
+	id := candidates[0]
+	replEntry, _ := GetCatalogEntry(id)
+	return mm.installed[id], replEntry, true
+}
+
+// sharedFilePathForRole returns {modelsDir}/shared/{LocalName} for entry's first
+// file with the given shared role, or "" when the entry carries no such file.
+func (mm *ModelManager) sharedFilePathForRole(entry *CatalogEntry, role string) string {
+	for _, f := range entry.Files {
+		if f.Role == role {
+			return filepath.Join(mm.modelsDir, sharedDirName, f.LocalName)
+		}
+	}
+	return ""
 }
 
 // applyConfigForUninstall updates settings to reflect a removed model.
@@ -2144,66 +2264,40 @@ func (mm *ModelManager) applyConfigForUninstall(entry *CatalogEntry) {
 	updated := conf.CloneSettings(conf.GetSettings())
 	retainAlias := false
 
-	switch entry.RegistryID {
-	case RegistryIDBat:
-		// Find another installed bat model to re-point config to.
-		var replacement *InstalledModel
-		var replacementEntry CatalogEntry
-		for id, inst := range mm.installed {
-			other, found := GetCatalogEntry(id)
-			if found && other.Category == CategoryBat {
-				replacement = &inst
-				replacementEntry = other
-				break
-			}
-		}
-		if replacement == nil {
-			updated.Bat.ClassifierModel = ""
-			updated.Bat.LabelPath = ""
-			updated.Bat.EmbeddingModel = ""
-		} else {
+	// Re-point or clear the uninstalled family's settings. familyFields is the
+	// single family-to-settings-field mapping. When another installed catalog entry
+	// writes the SAME family (same RegistryID) it takes over the paths and the config
+	// alias is retained; otherwise the family's fields are cleared. Keying on
+	// RegistryID (not Category) is required: birdnet-v3.0 and perch-v2 are both
+	// CategoryWildlife but write different families, so a category-keyed rule would
+	// re-point one family's config onto the other. Today the only multi-entry family
+	// is bat, so for every other family this degenerates to "clear". The primary is
+	// never uninstalled (Uninstall refuses permanentRegistryID) and an unknown
+	// registry ID yields ok=false, so both are safe no-ops here.
+	if fs, ok := familyFields(updated, entry.RegistryID); ok {
+		if repl, replEntry, found := mm.replacementInstall(entry); found {
 			retainAlias = true
-			updated.Bat.ClassifierModel = replacement.ModelPath
-			updated.Bat.LabelPath = replacement.LabelsPath
-			updated.Bat.EmbeddingModel = ""
-			for _, f := range replacementEntry.Files {
-				if f.Role == RoleEmbeddings {
-					updated.Bat.EmbeddingModel = filepath.Join(mm.modelsDir, sharedDirName, f.LocalName)
-					break
-				}
+			*fs.Model = repl.ModelPath
+			if fs.Labels != nil {
+				*fs.Labels = repl.LabelsPath
 			}
-		}
-	default:
-		// The single-model families (Perch, BirdNET v3.0, BSG) just clear their
-		// paths; familyPathFields is the single source of that mapping. The primary
-		// is never uninstalled (Uninstall refuses permanentRegistryID) and an unknown
-		// registry ID yields ok=false, so both are safely no-ops here.
-		if model, labels, _, ok := familyPathFields(updated, entry.RegistryID); ok {
-			*model = ""
-			if labels != nil {
-				*labels = ""
+			if fs.Embeddings != nil {
+				*fs.Embeddings = mm.sharedFilePathForRole(&replEntry, RoleEmbeddings)
+			}
+		} else {
+			*fs.Model = ""
+			if fs.Labels != nil {
+				*fs.Labels = ""
+			}
+			if fs.Embeddings != nil {
+				*fs.Embeddings = ""
 			}
 		}
 	}
 
 	// Reset geomodel range filter config if no other geomodel-dependent model remains.
 	// mm.installed no longer contains the uninstalled entry (deleted by caller).
-	if HasGeomodelFiles(entry) {
-		otherGeomodel := false
-		for id := range mm.installed {
-			other, found := GetCatalogEntry(id)
-			if found && HasGeomodelFiles(&other) {
-				otherGeomodel = true
-				break
-			}
-		}
-		if !otherGeomodel {
-			updated.BirdNET.RangeFilter.Model = ""
-			updated.BirdNET.RangeFilter.ModelPath = ""
-			updated.BirdNET.RangeFilter.LabelsPath = ""
-			updated.BirdNET.RangeFilter.PassUnmappedSpecies = false
-		}
-	}
+	mm.applyRangeFilterConfigForUninstall(updated, entry)
 
 	// Remove config alias from Models.Enabled and from any source/stream that
 	// references it, but only when no replacement model of the same category exists.

--- a/internal/classifier/model_manager_family_fields_test.go
+++ b/internal/classifier/model_manager_family_fields_test.go
@@ -7,75 +7,113 @@ import (
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
-// TestFamilyPathFields pins the single family-to-settings-field mapping, including
-// the primary's model-only contract (nil labels/embeddings so planPathCorrection
-// can never rewrite BirdNET.LabelPath) and BSG, which an earlier copy of this
-// switch omitted. Table-driven so a new family mapping is a single row and cannot
-// silently omit an assertion.
-func TestFamilyPathFields(t *testing.T) {
+// TestFamilyFields pins the single family-to-settings-field mapping. Every pointer
+// the accessor returns must be the exact address of the settings field it names (or
+// nil when the family has no such field), so a caller reading or writing through the
+// set touches exactly the right field. Table-driven so a new family mapping is a
+// single row and cannot silently omit an assertion. Unlike the pre-consolidation
+// accessor, the primary now exposes its Labels pointer like every other family; the
+// "a variant swap writes the model field only" rule lives in applyConfigForVariantSwap,
+// pinned separately.
+func TestFamilyFields(t *testing.T) {
 	t.Parallel()
 
 	s := &conf.Settings{}
 	s.BirdNET.ModelPath = "primary.tflite"
 	s.BirdNET.LabelPath = "user-labels.txt"
+	s.BirdNET.Threshold = 0.3
+	s.BirdNET.Locale = "en-uk"
 	s.Perch.ModelPath = "perch.onnx"
 	s.Perch.LabelPath = "perch-labels.txt"
+	s.Perch.Threshold = 0.5
+	s.Perch.OverrideThreshold = true
+	s.Perch.Locale = "fi"
 	s.BirdNETV3.ModelPath = "v3.onnx"
 	s.BirdNETV3.LabelPath = "v3-labels.txt"
+	s.BirdNETV3.Threshold = 0.6
+	s.BirdNETV3.Locale = "de"
 	s.BSG.ModelPath = "bsg.onnx"
 	s.BSG.LabelPath = "bsg-labels.txt"
+	s.BSG.Locale = "sv"
 	s.Bat.ClassifierModel = "bat.onnx"
 	s.Bat.LabelPath = "bat-labels.txt"
 	s.Bat.EmbeddingModel = "bat-emb.onnx"
+	s.Bat.Threshold = 0.7
+	s.Bat.Locale = "en-uk"
 
-	// wantModel/wantLabels/wantEmbeddings are the exact field addresses the accessor
-	// must return (nil = the family has no such field and it must never be written).
+	// The want* fields are the exact field addresses the accessor must return; nil
+	// means the family has no such field and it must never be written.
 	tests := []struct {
-		name           string
-		registryID     string
-		wantModel      *string
-		wantLabels     *string
-		wantEmbeddings *string
-		wantOK         bool
+		name          string
+		registryID    string
+		wantModel     *string
+		wantLabels    *string
+		wantEmbed     *string
+		wantThreshold *float64
+		wantOverride  *bool
+		wantLocale    *string
+		wantOK        bool
 	}{
 		{
-			name:       "primary is model-only (nil labels protects the embedded label set)",
-			registryID: permanentRegistryID,
-			wantModel:  &s.BirdNET.ModelPath,
-			wantOK:     true,
+			name:          "primary maps every field including Labels (LabelPath)",
+			registryID:    permanentRegistryID,
+			wantModel:     &s.BirdNET.ModelPath,
+			wantLabels:    &s.BirdNET.LabelPath,
+			wantThreshold: &s.BirdNET.Threshold,
+			wantLocale:    &s.BirdNET.Locale,
+			wantOK:        true,
 		},
 		{
-			name:       "perch has model+labels, no embeddings",
-			registryID: RegistryIDPerchV2,
-			wantModel:  &s.Perch.ModelPath,
-			wantLabels: &s.Perch.LabelPath,
-			wantOK:     true,
+			name:          "perch has model, labels, threshold, override, locale; no embeddings",
+			registryID:    RegistryIDPerchV2,
+			wantModel:     &s.Perch.ModelPath,
+			wantLabels:    &s.Perch.LabelPath,
+			wantThreshold: &s.Perch.Threshold,
+			wantOverride:  &s.Perch.OverrideThreshold,
+			wantLocale:    &s.Perch.Locale,
+			wantOK:        true,
 		},
 		{
-			name:       "birdnet v3 has model+labels, no embeddings",
-			registryID: RegistryIDBirdNETV3,
-			wantModel:  &s.BirdNETV3.ModelPath,
-			wantLabels: &s.BirdNETV3.LabelPath,
-			wantOK:     true,
+			name:          "birdnet v3 has model, labels, threshold, override, locale; no embeddings",
+			registryID:    RegistryIDBirdNETV3,
+			wantModel:     &s.BirdNETV3.ModelPath,
+			wantLabels:    &s.BirdNETV3.LabelPath,
+			wantThreshold: &s.BirdNETV3.Threshold,
+			wantOverride:  &s.BirdNETV3.OverrideThreshold,
+			wantLocale:    &s.BirdNETV3.Locale,
+			wantOK:        true,
 		},
 		{
-			name:       "bsg is mapped (the field an earlier switch omitted)",
+			name:       "bsg has model, labels, locale; no threshold, override or embeddings",
 			registryID: RegistryIDBSG,
 			wantModel:  &s.BSG.ModelPath,
 			wantLabels: &s.BSG.LabelPath,
+			wantLocale: &s.BSG.Locale,
 			wantOK:     true,
 		},
 		{
-			name:           "bat carries all three",
-			registryID:     RegistryIDBat,
-			wantModel:      &s.Bat.ClassifierModel,
-			wantLabels:     &s.Bat.LabelPath,
-			wantEmbeddings: &s.Bat.EmbeddingModel,
-			wantOK:         true,
+			name:          "bat carries model, labels, embeddings, threshold, locale; no override",
+			registryID:    RegistryIDBat,
+			wantModel:     &s.Bat.ClassifierModel,
+			wantLabels:    &s.Bat.LabelPath,
+			wantEmbed:     &s.Bat.EmbeddingModel,
+			wantThreshold: &s.Bat.Threshold,
+			wantLocale:    &s.Bat.Locale,
+			wantOK:        true,
 		},
 		{
 			name:       "unknown registry yields no fields",
 			registryID: "NoSuchModel",
+			wantOK:     false,
+		},
+		{
+			name:       "empty registry ID yields no fields",
+			registryID: "",
+			wantOK:     false,
+		},
+		{
+			name:       "Custom sentinel is not a registry key",
+			registryID: modelIDCustom,
 			wantOK:     false,
 		},
 	}
@@ -83,29 +121,50 @@ func TestFamilyPathFields(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			// s is only read (familyPathFields returns pointers into it, never
-			// mutates), so sharing it across parallel subtests is safe.
-			model, labels, embeddings, ok := familyPathFields(s, tt.registryID)
+			// s is only read (familyFields returns pointers into it, never mutates),
+			// so sharing it across parallel subtests is safe.
+			fs, ok := familyFields(s, tt.registryID)
 			assert.Equal(t, tt.wantOK, ok)
-			assertSameOrNil(t, tt.wantModel, model, "model")
-			assertSameOrNil(t, tt.wantLabels, labels, "labels")
-			assertSameOrNil(t, tt.wantEmbeddings, embeddings, "embeddings")
+			assertSamePtrOrNil(t, tt.wantModel, fs.Model, "Model")
+			assertSamePtrOrNil(t, tt.wantLabels, fs.Labels, "Labels")
+			assertSamePtrOrNil(t, tt.wantEmbed, fs.Embeddings, "Embeddings")
+			assertSamePtrOrNil(t, tt.wantThreshold, fs.Threshold, "Threshold")
+			assertSamePtrOrNil(t, tt.wantOverride, fs.OverrideThreshold, "OverrideThreshold")
+			assertSamePtrOrNil(t, tt.wantLocale, fs.Locale, "Locale")
 		})
 	}
-
-	t.Run("nil settings is not ok", func(t *testing.T) {
-		t.Parallel()
-		model, labels, embeddings, ok := familyPathFields(nil, RegistryIDPerchV2)
-		assert.False(t, ok)
-		assert.Nil(t, model)
-		assert.Nil(t, labels)
-		assert.Nil(t, embeddings)
-	})
 }
 
-// assertSameOrNil asserts got is exactly the expected field address, or nil when
+// TestFamilyFields_NilSettings pins the nil-receiver contract: the zero set and
+// ok=false, with every pointer nil so no caller can dereference one.
+func TestFamilyFields_NilSettings(t *testing.T) {
+	t.Parallel()
+	fs, ok := familyFields(nil, RegistryIDPerchV2)
+	assert.False(t, ok)
+	assert.Nil(t, fs.Model)
+	assert.Nil(t, fs.Labels)
+	assert.Nil(t, fs.Embeddings)
+	assert.Nil(t, fs.Threshold)
+	assert.Nil(t, fs.OverrideThreshold)
+	assert.Nil(t, fs.Locale)
+}
+
+// TestFamilyFields_PrimaryLabelsIsLabelPath makes the design change explicit: the
+// primary's Labels pointer is &s.BirdNET.LabelPath, not nil. The "model only" rule
+// for a variant swap now lives in applyConfigForVariantSwap, and planPathCorrection
+// still never rewrites the primary's label path because resolvePrimaryModelPath only
+// ever resolves a model path (pinned by TestResolvePrimaryModelPath_ResolvesModelOnly).
+func TestFamilyFields_PrimaryLabelsIsLabelPath(t *testing.T) {
+	t.Parallel()
+	s := &conf.Settings{}
+	fs, ok := familyFields(s, permanentRegistryID)
+	assert.True(t, ok)
+	assert.Same(t, &s.BirdNET.LabelPath, fs.Labels, "the primary's Labels pointer must be &BirdNET.LabelPath")
+}
+
+// assertSamePtrOrNil asserts got is exactly the expected field address, or nil when
 // the family has no such field.
-func assertSameOrNil(t *testing.T, want, got *string, field string) {
+func assertSamePtrOrNil[T any](t *testing.T, want, got *T, field string) {
 	t.Helper()
 	if want == nil {
 		assert.Nil(t, got, "%s pointer must be nil for a family without that field", field)

--- a/internal/classifier/model_manager_primary_swap_test.go
+++ b/internal/classifier/model_manager_primary_swap_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // isolateTestConfig points conf.ConfigPath at a throwaway file under t.TempDir()
-// and restores the original in cleanup. Without it, applyConfigForPrimarySwap ->
+// and restores the original in cleanup. Without it, applyConfigForVariantSwap ->
 // conf.SaveSettings resolves the default user config path and overwrites the
 // developer's real ~/.config/birdnet-go/config.yaml during the test run.
 func isolateTestConfig(t *testing.T) {

--- a/internal/classifier/model_manager_uninstall_config_test.go
+++ b/internal/classifier/model_manager_uninstall_config_test.go
@@ -1,0 +1,243 @@
+package classifier
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/conf/conftest"
+)
+
+// batEmbeddingsLocalName is the shared backbone file every bat catalog entry carries
+// (batCatalogEntry hard-codes it). The re-point points Bat.EmbeddingModel at it under
+// {modelsDir}/shared.
+const batEmbeddingsLocalName = "birdnet-v24-embeddings.onnx"
+
+// installBat records an installed bat model under mm.installed with synthetic model
+// and labels paths derived from its catalog ID, mirroring what ScanInstalled would
+// record without downloading real multi-MB model files.
+func installBat(t *testing.T, mm *ModelManager, modelsDir, catalogID string) InstalledModel {
+	t.Helper()
+	im := InstalledModel{
+		CatalogID:  catalogID,
+		ModelPath:  filepath.Join(modelsDir, catalogID, catalogID+"-model.onnx"),
+		LabelsPath: filepath.Join(modelsDir, catalogID, catalogID+"-labels.txt"),
+	}
+	mm.installed[catalogID] = im
+	return im
+}
+
+// TestApplyConfigForUninstall_BatRepointsToRemainingBat verifies that uninstalling one
+// bat while another remains re-points the whole Bat family (classifier, labels and the
+// shared embeddings backbone) at the survivor and retains the bat config alias and
+// every source model list.
+func TestApplyConfigForUninstall_BatRepointsToRemainingBat(t *testing.T) {
+	// Not parallel: mutates global settings via conf.StoreSettings.
+	origSettings := conf.GetSettings()
+	t.Cleanup(func() { conf.StoreSettings(origSettings) })
+	isolateTestConfig(t)
+
+	modelsDir := t.TempDir()
+	settings := conftest.GetTestSettings()
+	settings.Bat.ClassifierModel = filepath.Join(modelsDir, "battybirdnet-eu", "battybirdnet-eu-model.onnx")
+	settings.Bat.LabelPath = filepath.Join(modelsDir, "battybirdnet-eu", "battybirdnet-eu-labels.txt")
+	settings.Bat.EmbeddingModel = filepath.Join(modelsDir, sharedDirName, batEmbeddingsLocalName)
+	settings.Models.Enabled = []string{conf.ModelIDBirdNET, conf.ModelIDBat}
+	settings.Realtime.Audio.Sources = []conf.AudioSourceConfig{{Name: "mic", Models: []string{conf.ModelIDBirdNET, conf.ModelIDBat}}}
+	conf.StoreSettings(settings)
+
+	mm := NewModelManager(modelsDir, nil, settings)
+	// The eu entry is already "deleted" (never added), matching the post-delete
+	// contract of applyConfigForUninstall; only the uk survivor is installed.
+	uk := installBat(t, mm, modelsDir, "battybirdnet-uk")
+
+	euEntry, ok := GetCatalogEntry("battybirdnet-eu")
+	require.True(t, ok)
+	mm.applyConfigForUninstall(&euEntry)
+
+	current := conf.GetSettings()
+	assert.Equal(t, uk.ModelPath, current.Bat.ClassifierModel, "bat classifier must re-point to the survivor")
+	assert.Equal(t, uk.LabelsPath, current.Bat.LabelPath, "bat labels must re-point to the survivor")
+	assert.Equal(t, filepath.Join(modelsDir, sharedDirName, batEmbeddingsLocalName), current.Bat.EmbeddingModel,
+		"bat embeddings must point at the shared backbone of the survivor")
+	assert.Contains(t, current.Models.Enabled, conf.ModelIDBat, "the bat alias must be retained on a re-point")
+	require.Len(t, current.Realtime.Audio.Sources, 1)
+	assert.Equal(t, []string{conf.ModelIDBirdNET, conf.ModelIDBat}, current.Realtime.Audio.Sources[0].Models,
+		"a re-point must leave source model lists untouched")
+}
+
+// TestApplyConfigForUninstall_BatPicksLowestCatalogID verifies the deterministic pick:
+// with two bats remaining, the re-point chooses the lowest catalog ID (sorted), not a
+// random map-order entry.
+func TestApplyConfigForUninstall_BatPicksLowestCatalogID(t *testing.T) {
+	// Not parallel: mutates global settings via conf.StoreSettings.
+	origSettings := conf.GetSettings()
+	t.Cleanup(func() { conf.StoreSettings(origSettings) })
+	isolateTestConfig(t)
+
+	modelsDir := t.TempDir()
+	settings := conftest.GetTestSettings()
+	settings.Models.Enabled = []string{conf.ModelIDBat}
+	conf.StoreSettings(settings)
+
+	mm := NewModelManager(modelsDir, nil, settings)
+	bavaria := installBat(t, mm, modelsDir, "battybirdnet-bavaria")
+	installBat(t, mm, modelsDir, "battybirdnet-uk")
+
+	euEntry, ok := GetCatalogEntry("battybirdnet-eu")
+	require.True(t, ok)
+	mm.applyConfigForUninstall(&euEntry)
+
+	current := conf.GetSettings()
+	assert.Equal(t, bavaria.ModelPath, current.Bat.ClassifierModel,
+		"the re-point must pick the lowest catalog ID (battybirdnet-bavaria), not battybirdnet-uk")
+}
+
+// TestApplyConfigForUninstall_LastBatClearsFamilyAndAlias verifies that uninstalling
+// the only bat clears all three Bat fields, removes the alias from Models.Enabled, and
+// resets a source whose only model was bat back to the birdnet fallback.
+func TestApplyConfigForUninstall_LastBatClearsFamilyAndAlias(t *testing.T) {
+	// Not parallel: mutates global settings via conf.StoreSettings.
+	origSettings := conf.GetSettings()
+	t.Cleanup(func() { conf.StoreSettings(origSettings) })
+	isolateTestConfig(t)
+
+	modelsDir := t.TempDir()
+	settings := conftest.GetTestSettings()
+	settings.Bat.ClassifierModel = filepath.Join(modelsDir, "battybirdnet-eu", "battybirdnet-eu-model.onnx")
+	settings.Bat.LabelPath = filepath.Join(modelsDir, "battybirdnet-eu", "battybirdnet-eu-labels.txt")
+	settings.Bat.EmbeddingModel = filepath.Join(modelsDir, sharedDirName, batEmbeddingsLocalName)
+	settings.Models.Enabled = []string{conf.ModelIDBirdNET, conf.ModelIDBat}
+	settings.Realtime.Audio.Sources = []conf.AudioSourceConfig{{Name: "mic", Models: []string{conf.ModelIDBat}}}
+	conf.StoreSettings(settings)
+
+	mm := NewModelManager(modelsDir, nil, settings) // no bat remains installed
+
+	euEntry, ok := GetCatalogEntry("battybirdnet-eu")
+	require.True(t, ok)
+	mm.applyConfigForUninstall(&euEntry)
+
+	current := conf.GetSettings()
+	assert.Empty(t, current.Bat.ClassifierModel, "the last bat uninstall must clear the classifier path")
+	assert.Empty(t, current.Bat.LabelPath, "the last bat uninstall must clear the labels path")
+	assert.Empty(t, current.Bat.EmbeddingModel, "the last bat uninstall must clear the embeddings path")
+	assert.NotContains(t, current.Models.Enabled, conf.ModelIDBat, "the bat alias must be removed")
+	require.Len(t, current.Realtime.Audio.Sources, 1)
+	assert.Equal(t, []string{conf.ModelIDBirdNET}, current.Realtime.Audio.Sources[0].Models,
+		"a source left with no models must fall back to the birdnet default")
+}
+
+// TestApplyConfigForUninstall_SameCategoryDifferentFamilyIsNotARepoint is the guard
+// against a category-keyed rule: perch-v2 and birdnet-v3.0 are both CategoryWildlife
+// but write different settings families, so uninstalling perch must clear the Perch
+// family and never touch the still-installed BirdNET v3.0 family.
+func TestApplyConfigForUninstall_SameCategoryDifferentFamilyIsNotARepoint(t *testing.T) {
+	// Not parallel: mutates global settings via conf.StoreSettings.
+	origSettings := conf.GetSettings()
+	t.Cleanup(func() { conf.StoreSettings(origSettings) })
+	isolateTestConfig(t)
+
+	modelsDir := t.TempDir()
+	perchAlias := ConfigAliasForRegistry(RegistryIDPerchV2)
+	v3Alias := ConfigAliasForRegistry(RegistryIDBirdNETV3)
+
+	settings := conftest.GetTestSettings()
+	settings.Perch.ModelPath = filepath.Join(modelsDir, "perch-v2", "perch.onnx")
+	settings.Perch.LabelPath = filepath.Join(modelsDir, "perch-v2", "perch-labels.txt")
+	settings.BirdNETV3.ModelPath = filepath.Join(modelsDir, "birdnet-v3.0", "v3.onnx")
+	settings.BirdNETV3.LabelPath = filepath.Join(modelsDir, "birdnet-v3.0", "v3-labels.txt")
+	settings.Models.Enabled = []string{conf.ModelIDBirdNET, perchAlias, v3Alias}
+	conf.StoreSettings(settings)
+
+	mm := NewModelManager(modelsDir, nil, settings)
+	// birdnet-v3.0 remains installed; perch-v2 is being uninstalled (not in mm.installed).
+	mm.installed["birdnet-v3.0"] = InstalledModel{
+		CatalogID:  "birdnet-v3.0",
+		ModelPath:  settings.BirdNETV3.ModelPath,
+		LabelsPath: settings.BirdNETV3.LabelPath,
+	}
+
+	perchEntry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+	mm.applyConfigForUninstall(&perchEntry)
+
+	current := conf.GetSettings()
+	assert.Empty(t, current.Perch.ModelPath, "the uninstalled perch family must be cleared")
+	assert.Empty(t, current.Perch.LabelPath, "the uninstalled perch family must be cleared")
+	assert.Equal(t, settings.BirdNETV3.ModelPath, current.BirdNETV3.ModelPath, "birdnet v3.0 must be untouched")
+	assert.Equal(t, settings.BirdNETV3.LabelPath, current.BirdNETV3.LabelPath, "birdnet v3.0 must be untouched")
+	assert.NotContains(t, current.Models.Enabled, perchAlias, "the perch alias must be removed")
+	assert.Contains(t, current.Models.Enabled, v3Alias, "the birdnet v3.0 alias must be retained")
+}
+
+// TestApplyConfigForUninstall_UnknownRegistryIsNoop and _NilSettingsIsNoop pin the two
+// safe no-op paths: an unknown registry ID (familyFields ok=false) writes no family
+// field, and a nil settings receiver returns before any store.
+func TestApplyConfigForUninstall_UnknownRegistryIsNoop(t *testing.T) {
+	// Not parallel: mutates global settings via conf.StoreSettings.
+	origSettings := conf.GetSettings()
+	t.Cleanup(func() { conf.StoreSettings(origSettings) })
+	isolateTestConfig(t)
+
+	settings := conftest.GetTestSettings()
+	settings.Perch.ModelPath = "/keep/perch.onnx"
+	conf.StoreSettings(settings)
+	mm := NewModelManager(t.TempDir(), nil, settings)
+
+	mm.applyConfigForUninstall(&CatalogEntry{ID: "mystery", RegistryID: "NoSuchModel"})
+	current := conf.GetSettings()
+	assert.Equal(t, "/keep/perch.onnx", current.Perch.ModelPath, "an unknown registry ID must write nothing")
+}
+
+func TestApplyConfigForUninstall_NilSettingsIsNoop(t *testing.T) {
+	// Not parallel: mutates global settings via conf.StoreSettings.
+	origSettings := conf.GetSettings()
+	t.Cleanup(func() { conf.StoreSettings(origSettings) })
+
+	settings := conftest.GetTestSettings()
+	settings.Perch.ModelPath = "/keep/perch.onnx"
+	conf.StoreSettings(settings)
+	mm := NewModelManager(t.TempDir(), nil, nil) // nil settings receiver
+
+	perchEntry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+	mm.applyConfigForUninstall(&perchEntry)
+	current := conf.GetSettings()
+	assert.Equal(t, "/keep/perch.onnx", current.Perch.ModelPath, "a nil settings receiver must be a no-op")
+}
+
+// TestApplyRangeFilterConfigForUninstall_RetainsWhenOtherGeomodelInstalled verifies the
+// geomodel range filter config is kept when another installed entry still carries
+// geomodel files; it is only cleared when the last geomodel-bearing model is removed
+// (that clear path is covered by TestModelManager_Uninstall_GeomodelConfigClearing).
+func TestApplyRangeFilterConfigForUninstall_RetainsWhenOtherGeomodelInstalled(t *testing.T) {
+	// Not parallel: mutates the global active catalog via setActiveCatalog.
+	geomodelFiles := []CatalogFile{
+		{RemotePath: "geo.onnx", LocalName: "geomodel_v3.onnx", Role: RoleGeomodelModel},
+		{RemotePath: "geo_labels.txt", LocalName: "geomodel_v3_labels.txt", Role: RoleGeomodelLabels},
+	}
+	removed := CatalogEntry{ID: "geo-removed", RegistryID: RegistryIDPerchV2, Category: CategoryWildlife, GeomodelVersion: "v3", Files: geomodelFiles}
+	remaining := CatalogEntry{ID: "geo-remaining", RegistryID: RegistryIDBirdNETV3, Category: CategoryWildlife, GeomodelVersion: "v3", Files: geomodelFiles}
+
+	withEntries := make([]CatalogEntry, len(EmbeddedCatalog), len(EmbeddedCatalog)+2)
+	copy(withEntries, EmbeddedCatalog)
+	withEntries = append(withEntries, removed, remaining)
+	setActiveCatalog(withEntries)
+	t.Cleanup(func() { setActiveCatalog(nil) })
+
+	mm := NewModelManager(t.TempDir(), nil, &conf.Settings{})
+	mm.installed["geo-remaining"] = InstalledModel{CatalogID: "geo-remaining"}
+
+	updated := &conf.Settings{}
+	updated.BirdNET.RangeFilter.Model = "v3"
+	updated.BirdNET.RangeFilter.ModelPath = "/models/shared/geomodel_v3.onnx"
+	updated.BirdNET.RangeFilter.PassUnmappedSpecies = true
+
+	mm.applyRangeFilterConfigForUninstall(updated, &removed)
+
+	assert.Equal(t, "v3", updated.BirdNET.RangeFilter.Model, "config must be retained while another geomodel remains")
+	assert.Equal(t, "/models/shared/geomodel_v3.onnx", updated.BirdNET.RangeFilter.ModelPath, "model path must be retained")
+	assert.True(t, updated.BirdNET.RangeFilter.PassUnmappedSpecies, "PassUnmappedSpecies must be retained")
+}

--- a/internal/classifier/model_manager_variant_swap_test.go
+++ b/internal/classifier/model_manager_variant_swap_test.go
@@ -1,0 +1,71 @@
+package classifier
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/conf/conftest"
+)
+
+// TestApplyConfigForVariantSwap_PrimaryWritesModelPathOnly pins the "model only"
+// rule that used to live in familyFields and now lives in the swap helper: the
+// family's model field is persisted and nothing else, so a user's custom
+// BirdNET.LabelPath survives a swap and a revert. An empty model path reverts to the
+// embedded baseline (the DFT->baseline path in replacePrimaryVariant).
+func TestApplyConfigForVariantSwap_PrimaryWritesModelPathOnly(t *testing.T) {
+	// Not parallel: mutates global settings via conf.StoreSettings.
+	origSettings := conf.GetSettings()
+	t.Cleanup(func() { conf.StoreSettings(origSettings) })
+	isolateTestConfig(t)
+
+	settings := conftest.GetTestSettings()
+	settings.BirdNET.LabelPath = "/srv/custom.txt"
+	conf.StoreSettings(settings)
+	mm := NewModelManager(t.TempDir(), nil, settings)
+
+	mm.applyConfigForVariantSwap(permanentRegistryID, "/models/birdnet-v2.4/x.onnx")
+	current := conf.GetSettings()
+	assert.Equal(t, "/models/birdnet-v2.4/x.onnx", current.BirdNET.ModelPath, "the model path must be persisted")
+	assert.Equal(t, "/srv/custom.txt", current.BirdNET.LabelPath, "a variant swap must never touch LabelPath")
+
+	// Revert to the baseline with an empty model path.
+	mm.applyConfigForVariantSwap(permanentRegistryID, "")
+	current = conf.GetSettings()
+	assert.Empty(t, current.BirdNET.ModelPath, "an empty model path reverts to the embedded baseline")
+	assert.Equal(t, "/srv/custom.txt", current.BirdNET.LabelPath, "revert must still not touch LabelPath")
+}
+
+// TestApplyConfigForVariantSwap_UnknownRegistryIsNoop verifies an unknown registry ID
+// writes nothing (familyFields returns ok=false, so the helper returns before storing).
+func TestApplyConfigForVariantSwap_UnknownRegistryIsNoop(t *testing.T) {
+	// Not parallel: mutates global settings via conf.StoreSettings.
+	origSettings := conf.GetSettings()
+	t.Cleanup(func() { conf.StoreSettings(origSettings) })
+	isolateTestConfig(t)
+
+	settings := conftest.GetTestSettings()
+	settings.BirdNET.ModelPath = "/keep/me.onnx"
+	conf.StoreSettings(settings)
+	mm := NewModelManager(t.TempDir(), nil, settings)
+
+	mm.applyConfigForVariantSwap("NoSuchModel", "/models/should-not-write.onnx")
+	current := conf.GetSettings()
+	assert.Equal(t, "/keep/me.onnx", current.BirdNET.ModelPath, "an unknown registry ID must not write any model field")
+}
+
+// TestApplyConfigForVariantSwap_NilSettingsIsNoop pins the mm.settings == nil guard.
+func TestApplyConfigForVariantSwap_NilSettingsIsNoop(t *testing.T) {
+	// Not parallel: mutates global settings via conf.StoreSettings.
+	origSettings := conf.GetSettings()
+	t.Cleanup(func() { conf.StoreSettings(origSettings) })
+
+	settings := conftest.GetTestSettings()
+	settings.BirdNET.ModelPath = "/keep/me.onnx"
+	conf.StoreSettings(settings)
+	mm := NewModelManager(t.TempDir(), nil, nil) // nil settings receiver
+
+	mm.applyConfigForVariantSwap(permanentRegistryID, "/models/should-not-write.onnx")
+	current := conf.GetSettings()
+	assert.Equal(t, "/keep/me.onnx", current.BirdNET.ModelPath, "a nil settings receiver must be a no-op")
+}

--- a/internal/classifier/model_path_reconcile.go
+++ b/internal/classifier/model_path_reconcile.go
@@ -310,25 +310,27 @@ func (o *Orchestrator) planPathCorrection(current *conf.Settings, pc *pendingPat
 		resolved string
 	}
 
-	// familyPathFields is the single source of truth for the family-to-settings-field
+	// familyFields is the single source of truth for the family-to-settings-field
 	// mapping. A nil labels/embeddings pointer means the family has no such field and
-	// it must NOT be written: the primary is deliberately model-only (its label set
-	// is embedded and identical across variants, which is why applyConfigForPrimarySwap
-	// writes BirdNET.ModelPath alone and a user-configured BirdNET.LabelPath must
-	// survive a variant swap), and every family but bat carries no embeddings path.
-	model, labels, embeddings, ok := familyPathFields(updated, pc.registryID)
+	// it must NOT be written. The primary now exposes a Labels pointer like every
+	// other family, but its label path is still never rewritten here: the "model
+	// only" rule for a variant swap lives in applyConfigForVariantSwap, and
+	// resolvePrimaryModelPath only ever resolves a model path, so the primary's
+	// labels field always has fc.resolved == "" and is skipped by the guard below.
+	// Every family but bat carries no embeddings path.
+	fs, ok := familyFields(updated, pc.registryID)
 	if !ok {
 		// Unknown registry: nothing to plan. Return nil rather than current so no
 		// caller can mutate the live published snapshot through the result.
 		return nil, correctionUnknownFamily
 	}
 	fields := make([]fieldCorrection, 0, 3)
-	fields = append(fields, fieldCorrection{model, pc.resolved.model})
-	if labels != nil {
-		fields = append(fields, fieldCorrection{labels, pc.resolved.labels})
+	fields = append(fields, fieldCorrection{fs.Model, pc.resolved.model})
+	if fs.Labels != nil {
+		fields = append(fields, fieldCorrection{fs.Labels, pc.resolved.labels})
 	}
-	if embeddings != nil {
-		fields = append(fields, fieldCorrection{embeddings, pc.resolved.embeddings})
+	if fs.Embeddings != nil {
+		fields = append(fields, fieldCorrection{fs.Embeddings, pc.resolved.embeddings})
 	}
 
 	// A substitution that is not repairable must never reach the field loop: the

--- a/internal/classifier/model_path_resolution.go
+++ b/internal/classifier/model_path_resolution.go
@@ -478,12 +478,13 @@ type primaryPathResolver func(configured string) pathResolution
 // NewBirdNET fail outright, so there is no analysis at all rather than one
 // missing optional model.
 //
-// The primary is deliberately NOT a modelFileSet family. Its label set is
-// embedded and identical across v2.4 variants, which is why
-// applyConfigForPrimarySwap writes BirdNET.ModelPath alone and documents that it
-// never touches BirdNET.LabelPath: a user-configured custom label path must
-// survive a variant swap. So there is exactly one path to resolve and no
-// cross-variant pairing hazard to protect against.
+// The primary resolves a model path only: its label set is embedded and identical
+// across v2.4 variants, which is why applyConfigForVariantSwap writes
+// BirdNET.ModelPath alone and a user-configured custom label path must survive a
+// variant swap. This function never populates resolved.labels or resolved.embeddings,
+// which is exactly what lets planPathCorrection skip the primary's label field even
+// though familyFields now exposes its Labels pointer. So there is one path to resolve
+// and no cross-variant pairing hazard to protect against.
 func (o *Orchestrator) resolvePrimaryModelPath(configured string) pathResolution {
 	if configured == "" {
 		// No configured path at all: the Tier-4 default (the embedded model, or the

--- a/internal/classifier/model_registry.go
+++ b/internal/classifier/model_registry.go
@@ -17,7 +17,7 @@ import (
 // cannot be matched to a known registry entry.
 const modelIDCustom = "Custom"
 
-// Model display names — single source of truth for user-facing model names.
+// Model display names: single source of truth for user-facing model names.
 const (
 	ModelNameBirdNETv24 = "BirdNET v2.4"
 	ModelNameBirdNETv30 = "BirdNET v3.0"
@@ -102,6 +102,23 @@ func detectQuantization(name string) Quantization {
 // matching the DetectionName field in the ModelRegistry.
 const DetectionNamePerch = "Perch"
 
+// rangeFilterCompat names which range-filter backend family a classifier's label
+// space fits. The zero value is None so an unknown or Custom ID never qualifies for
+// any auto-selection.
+type rangeFilterCompat uint8
+
+const (
+	rangeFilterCompatNone     rangeFilterCompat = iota // Bat, BSG, Custom, unknown
+	rangeFilterCompatMDataV24                          // v2.4 MData filter (TFLite or strict ONNX) over the v2.4 label set
+	rangeFilterCompatGeomodel                          // mapped geomodel v3 remaps onto the classifier's labels
+)
+
+// rangeFilterCompatFor looks the capability up by registry ID; a missing entry
+// yields rangeFilterCompatNone (the zero value).
+func rangeFilterCompatFor(registryID string) rangeFilterCompat {
+	return ModelRegistry[registryID].rangeFilterCompat
+}
+
 // ModelInfo represents metadata about a classifier model.
 type ModelInfo struct {
 	ID               string        // Unique registry identifier (e.g., "BirdNET_V2.4")
@@ -118,6 +135,9 @@ type ModelInfo struct {
 	NumSpecies       int           // Number of species in the model
 	CustomPath       string        // Path to custom model file, if any
 	Quantization     Quantization  // Precision of the loaded weights. Orthogonal to Backend.
+	// rangeFilterCompat is this classifier's range-filter capability (see the type).
+	// The zero value means it participates in no range-filter auto-selection.
+	rangeFilterCompat rangeFilterCompat
 	// IsStock marks the auto-resolved built-in default model. It is NOT set for
 	// user-supplied models (birdnet.modelpath) or gallery models, so detection
 	// attribution can treat the shipped default as "default" even when it loads
@@ -152,9 +172,10 @@ var ModelRegistry = map[string]ModelInfo{
 		SupportedLocales: []string{"af", "ar", "bg", "ca", "cs", "da", "de", "el", "en-uk", "en-us", "es",
 			"et", "fi", "fr", "he", "hr", "hu", "id", "is", "it", "ja", "ko", "lt", "lv", "ml", "nl",
 			"no", "pl", "pt", "pt-br", "pt-pt", "ro", "ru", "sk", "sl", "sr", "sv", "th", "tr", "uk", "zh"},
-		DefaultLocale: "en-uk",
-		NumSpecies:    6522,
-		Quantization:  QuantizationFP32,
+		DefaultLocale:     "en-uk",
+		NumSpecies:        6522,
+		Quantization:      QuantizationFP32,
+		rangeFilterCompat: rangeFilterCompatMDataV24,
 	},
 	RegistryIDBirdNETV3: {
 		ID:               RegistryIDBirdNETV3,
@@ -170,7 +191,8 @@ var ModelRegistry = map[string]ModelInfo{
 		SupportedLocales: []string{"af", "ar", "bg", "ca", "cs", "da", "de", "el", "en-uk", "en-us", "es",
 			"et", "fi", "fr", "he", "hr", "hu", "id", "is", "it", "ja", "ko", "lt", "lv", "ml", "nl",
 			"no", "pl", "pt", "pt-br", "pt-pt", "ro", "ru", "sk", "sl", "sr", "sv", "th", "tr", "uk", "zh"},
-		DefaultLocale: "en-uk",
+		DefaultLocale:     "en-uk",
+		rangeFilterCompat: rangeFilterCompatGeomodel,
 	},
 	RegistryIDPerchV2: {
 		ID:               RegistryIDPerchV2,
@@ -183,8 +205,9 @@ var ModelRegistry = map[string]ModelInfo{
 		// Catalog form mirrors the catalog entry ID; the underscore primary stays
 		// canonical for write-back. Reported via Sentry (BIRDNET-GO-2FZ), where a
 		// config carried "perch-v2" and was rejected as an unknown model ID.
-		ConfigAliases: []string{conf.ModelIDPerchV2, conf.ModelIDPerchV2Catalog},
-		NumSpecies:    14795,
+		ConfigAliases:     []string{conf.ModelIDPerchV2, conf.ModelIDPerchV2Catalog},
+		NumSpecies:        14795,
+		rangeFilterCompat: rangeFilterCompatGeomodel,
 	},
 	RegistryIDBat: {
 		ID:               RegistryIDBat,
@@ -195,6 +218,9 @@ var ModelRegistry = map[string]ModelInfo{
 		Description:      "Bat species detection using BirdNET v2.4 embeddings",
 		Spec:             ModelSpec{SampleRate: 48000, ClipLength: 3 * time.Second, RawSampleRate: 256000, MinRawSampleRate: 96000, RecommendedSampleRate: 192000},
 		ConfigAliases:    []string{conf.ModelIDBat},
+		// Bat classifies its own label space; it never participates in range-filter
+		// auto-selection. Explicit (not omitted) so the table documents the decision.
+		rangeFilterCompat: rangeFilterCompatNone,
 	},
 	RegistryIDBSG: {
 		ID:               RegistryIDBSG,
@@ -207,15 +233,10 @@ var ModelRegistry = map[string]ModelInfo{
 		// Catalog form "bsg-finland" mirrors the catalog entry ID; "bsg" stays
 		// canonical for write-back. See BirdNET v2.4 entry above.
 		ConfigAliases: []string{conf.ModelIDBSG, conf.ModelIDBSGCatalog},
+		// BSG classifies its own regional label space; no range-filter auto-selection.
+		// Explicit (not omitted) so the table documents the decision.
+		rangeFilterCompat: rangeFilterCompatNone,
 	},
-}
-
-// isBirdNETV24Family reports whether id is the BirdNET v2.4 classifier.
-// Quantization (TFLite FP32 or ONNX INT8) is an orthogonal attribute on the
-// unified entry; callers that special-case v2.4 behavior (the native range-filter
-// fallback, the MData range-filter default) check the ID only.
-func isBirdNETV24Family(id string) bool {
-	return id == DefaultModelVersion
 }
 
 // remapV24ToONNXOnARM64 remaps a registry-resolved BirdNET v2.4 TFLite model to the
@@ -343,7 +364,7 @@ func isAutoSelectRangeFilterModel(model string) bool {
 // output dimension), and defaultRangeFilterONNXPath locates the ONNX MData model
 // (arm64 only). find resolves a model filename within the standard search paths.
 func shouldSelectDefaultONNXRangeFilter(model, modelPath, classifierID, goarch string, find func(name string) (path string, ok bool)) (string, bool) {
-	if !isAutoSelectRangeFilterModel(model) || modelPath != "" || !isBirdNETV24Family(classifierID) {
+	if !isAutoSelectRangeFilterModel(model) || modelPath != "" || rangeFilterCompatFor(classifierID) != rangeFilterCompatMDataV24 {
 		return "", false
 	}
 	return defaultRangeFilterONNXPath(goarch, find)
@@ -419,7 +440,7 @@ var filenamePatterns = map[string]string{
 }
 
 // DetermineModelInfo identifies the model type from a file path or model identifier.
-// This is the fallback path — prefer passing ModelInfo directly from the orchestrator
+// This is the fallback path; prefer passing ModelInfo directly from the orchestrator
 // or resolving via config version field.
 func DetermineModelInfo(modelPathOrID string) (ModelInfo, error) {
 	// Check if it's a known registry ID
@@ -471,7 +492,7 @@ func DetermineModelInfo(modelPathOrID string) (ModelInfo, error) {
 			return info, nil
 		}
 
-		// Unrecognized model file — return Custom, let runtime figure it out
+		// Unrecognized model file: return Custom, let runtime figure it out
 		return ModelInfo{
 			ID:               modelIDCustom,
 			Name:             "Custom Model",

--- a/internal/classifier/primary_model_path_test.go
+++ b/internal/classifier/primary_model_path_test.go
@@ -15,7 +15,7 @@ import (
 
 // writePrimaryGalleryModel installs a BirdNET v2.4 primary variant's model file
 // into the gallery layout and returns its path. The primary family is
-// model-only: applyConfigForPrimarySwap writes BirdNET.ModelPath and documents
+// model-only: applyConfigForVariantSwap writes BirdNET.ModelPath and documents
 // that it never touches BirdNET.LabelPath, because the v2.4 label set is
 // embedded and identical across variants.
 func writePrimaryGalleryModel(t *testing.T, modelsDir string) string {
@@ -458,10 +458,12 @@ func TestReloadModelInternal_ClearingPathWhileCustomRunningIsRefused(t *testing.
 
 // TestPlanPathCorrection_PrimaryRepairsModelPathOnly pins the primary family's
 // settings mapping. BirdNET.LabelPath must be left alone: the v2.4 label set is
-// embedded and identical across variants, which is why applyConfigForPrimarySwap
+// embedded and identical across variants, which is why applyConfigForVariantSwap
 // writes ModelPath alone and documents that a user-configured custom label path
 // has to survive a variant swap. Repairing LabelPath here would break that
-// contract from the other direction.
+// contract from the other direction. familyFields now exposes the primary's Labels
+// pointer, so the protection rests entirely on resolvePrimaryModelPath never
+// resolving a labels path (pinned by TestResolvePrimaryModelPath_ResolvesModelOnly).
 func TestPlanPathCorrection_PrimaryRepairsModelPathOnly(t *testing.T) {
 	t.Parallel()
 
@@ -493,6 +495,29 @@ func TestPlanPathCorrection_PrimaryRepairsModelPathOnly(t *testing.T) {
 	assert.Equal(t, installed, updated.BirdNET.ModelPath, "the stale primary model path must be repaired")
 	assert.Equal(t, customLabels, updated.BirdNET.LabelPath,
 		"the primary family is model-only; a user's custom label path must never be rewritten")
+}
+
+// TestResolvePrimaryModelPath_ResolvesModelOnly turns the invariant planPathCorrection
+// now relies on into a pinned contract: a recovered primary resolution carries a model
+// path only, never a labels or embeddings path. Because familyFields exposes the
+// primary's Labels pointer, this empty resolved.labels is the single reason
+// planPathCorrection's fc.resolved == "" guard skips the primary's label field and a
+// user's custom BirdNET.LabelPath survives.
+func TestResolvePrimaryModelPath_ResolvesModelOnly(t *testing.T) {
+	t.Parallel()
+
+	modelsDir := t.TempDir()
+	installed := writePrimaryGalleryModel(t, modelsDir)
+
+	o := &Orchestrator{ortAvailable: func(string) bool { return true }}
+	o.SetModelsDir(modelsDir)
+
+	res := o.resolvePrimaryModelPath(filepath.Join(t.TempDir(), "gone", "primary.onnx"))
+
+	require.True(t, res.substituted, "precondition: a confirmed-absent path recovers the installed variant")
+	assert.Equal(t, installed, res.resolved.model, "the recovered variant's model path")
+	assert.Empty(t, res.resolved.labels, "the primary resolution must never carry a labels path")
+	assert.Empty(t, res.resolved.embeddings, "the primary resolution must never carry an embeddings path")
 }
 
 // TestQueuePathCorrection_PrimaryFamily covers the queueing RULE the primary

--- a/internal/classifier/range_filter_compat_test.go
+++ b/internal/classifier/range_filter_compat_test.go
@@ -1,0 +1,62 @@
+package classifier
+
+import (
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// TestModelRegistry_RangeFilterCompat pins the range-filter capability of every
+// registry entry and the None fallback for the Custom sentinel, the empty ID and an
+// unknown ID. The expected table is exhaustive over ModelRegistry, so adding a model
+// without deciding its range-filter compatibility fails this test.
+func TestModelRegistry_RangeFilterCompat(t *testing.T) {
+	t.Parallel()
+
+	want := map[string]rangeFilterCompat{
+		permanentRegistryID: rangeFilterCompatMDataV24,
+		RegistryIDBirdNETV3: rangeFilterCompatGeomodel,
+		RegistryIDPerchV2:   rangeFilterCompatGeomodel,
+		RegistryIDBat:       rangeFilterCompatNone,
+		RegistryIDBSG:       rangeFilterCompatNone,
+	}
+	for id := range ModelRegistry {
+		w, ok := want[id]
+		require.Truef(t, ok, "registry key %q missing from the expected table; decide its RangeFilterCompat and add a row", id)
+		assert.Equalf(t, w, rangeFilterCompatFor(id), "RangeFilterCompat for %q", id)
+	}
+
+	// A missing entry yields the zero value (None), never a false auto-selection.
+	assert.Equal(t, rangeFilterCompatNone, rangeFilterCompatFor(modelIDCustom), "Custom must never qualify")
+	assert.Equal(t, rangeFilterCompatNone, rangeFilterCompatFor(""), "the empty ID must never qualify")
+	assert.Equal(t, rangeFilterCompatNone, rangeFilterCompatFor("NoSuchModel"), "an unknown ID must never qualify")
+}
+
+// TestShouldAutoSelectV3Geomodel_MatchesLegacyIDSwitch proves the rangeFilterCompat
+// gate reproduces the old explicit {Perch_V2, BirdNET_V3.0} string switch exactly, for
+// every registry key plus the Custom, empty and unknown sentinels, with the shared
+// geomodel files present so only the classifier gate can differ.
+func TestShouldAutoSelectV3Geomodel_MatchesLegacyIDSwitch(t *testing.T) {
+	t.Parallel()
+
+	modelsDir := t.TempDir()
+	sharedDir := filepath.Join(modelsDir, sharedDirName)
+	require.NoError(t, os.MkdirAll(sharedDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sharedDir, conf.GeomodelONNXLocalName), []byte("onnx"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(sharedDir, conf.GeomodelLabelsLocalName), []byte("labels"), 0o644))
+
+	ids := slices.Collect(maps.Keys(ModelRegistry))
+	ids = append(ids, modelIDCustom, "", "NoSuchModel")
+
+	for _, id := range ids {
+		want := id == RegistryIDPerchV2 || id == RegistryIDBirdNETV3
+		assert.Equalf(t, want, shouldAutoSelectV3Geomodel(id, modelsDir),
+			"shouldAutoSelectV3Geomodel(%q) must match the legacy {Perch_V2, BirdNET_V3.0} switch", id)
+	}
+}

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1918,6 +1918,20 @@ type Settings struct {
 	Alerting AlertSettings `yaml:"alerting" json:"alerting"` // Alerting rules engine settings
 }
 
+// RangeFilterConfig returns a pointer to the range filter settings block. The block
+// is stored under birdnet.rangefilter for historical reasons; callers use this
+// accessor rather than naming BirdNET.RangeFilter directly so the storage location
+// can move in a later phase without touching them. It returns nil for a nil
+// receiver. The pointer aliases the receiver's own field, so a write through it
+// mutates that Settings value; callers that must not disturb the published snapshot
+// take the accessor on a clone (clone-mutate-publish).
+func (s *Settings) RangeFilterConfig() *RangeFilterSettings {
+	if s == nil {
+		return nil
+	}
+	return &s.BirdNET.RangeFilter
+}
+
 // ResolveEQOverride returns the per-source or per-stream EQ override for the
 // given source display name. Returns nil when no override exists (use global).
 // Audio sources are checked first, then RTSP streams.

--- a/internal/conf/range_filter_accessors_test.go
+++ b/internal/conf/range_filter_accessors_test.go
@@ -1,0 +1,44 @@
+package conf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSettings_RangeFilterConfig pins the range-filter accessor: it returns the
+// field's own address, a write through it is visible on the field, and a nil receiver
+// returns nil.
+func TestSettings_RangeFilterConfig(t *testing.T) {
+	t.Parallel()
+
+	s := &Settings{}
+	rf := s.RangeFilterConfig()
+	require.NotNil(t, rf)
+	assert.Same(t, &s.BirdNET.RangeFilter, rf, "the accessor must return &BirdNET.RangeFilter")
+
+	rf.Model = "v3"
+	rf.PassUnmappedSpecies = true
+	assert.Equal(t, "v3", s.BirdNET.RangeFilter.Model, "a write through the accessor must be visible on the field")
+	assert.True(t, s.BirdNET.RangeFilter.PassUnmappedSpecies)
+
+	var nilSettings *Settings
+	assert.Nil(t, nilSettings.RangeFilterConfig(), "a nil receiver must return nil")
+}
+
+// TestSettings_RangeFilterConfig_CloneIndependence verifies the accessor honours the
+// clone-mutate-publish discipline: the clone's accessor points into the clone, so a
+// write through it never reaches the original.
+func TestSettings_RangeFilterConfig_CloneIndependence(t *testing.T) {
+	t.Parallel()
+
+	s := &Settings{}
+	s.BirdNET.RangeFilter.Model = "v3"
+
+	clone := CloneSettings(s)
+	clone.RangeFilterConfig().Model = "legacy"
+
+	assert.Equal(t, "v3", s.RangeFilterConfig().Model, "mutating the clone must not touch the original")
+	assert.Equal(t, "legacy", clone.RangeFilterConfig().Model, "the clone must carry its own value")
+}


### PR DESCRIPTION
## Summary

Phase 1 of making acoustic models model-independent. This is a preparation refactor with no observable behavior change for any existing install: the same models load from the same paths, with the same range-filter backend, the same inclusion list, and the same persisted configuration. It consolidates the model-manager config plumbing onto stable seams that later phases build on.

`familyPathFields` becomes `familyFields`, returning a `familyFieldSet` with one pointer per settings field a model family owns (model, labels, embeddings, threshold, override, locale). This is now the single family-to-settings-field mapping used by the basename hint, path correction, install, and uninstall. The primary exposes its `Labels` pointer like every other family; the "a variant swap writes only the model field" rule moves to `applyConfigForVariantSwap`, and the primary's custom label path stays protected because `resolvePrimaryModelPath` only ever resolves a model path, so path correction's empty-resolved guard skips it.

`applyConfigForPrimarySwap` becomes the family-generic `applyConfigForVariantSwap`.

`applyConfigForUninstall` re-points a removed family's config onto another installed entry with the same registry id (not the same category), with a deterministic lowest-catalog-id pick. For bat this selects the same survivor set as before, with a stable choice where the old code picked in random map-iteration order; for every other family it degenerates to "clear", exactly as before. Keying on registry id (not category) is required because two families can share a category but write different settings.

New `Settings.RangeFilterConfig()` accessor; the four `BirdNET.RangeFilter` writers in the model manager route through it. A `rangeFilterCompat` capability on the model registry replaces the geomodel auto-select switch and the two v2.4 range-filter identity gates, reproducing the old gates for every registry id including Custom and unknown ids.

No YAML key, config field, API response shape, or loader path changes.

## Test Plan

- [x] `go test -race ./internal/classifier/... ./internal/conf/...`
- [x] `golangci-lint run` clean across all build-tag variants (default, notflite, noembed, openvino, noasm, ...)
- [x] `go vet -tags notflite` and `-tags noembed` clean
- [x] New table tests pin the family mapping (address identity), the uninstall re-point equivalence (bat re-point, lowest-id pick, cross-family guard, no-ops), the range-filter capability equivalence over every registry id, and the accessor clone semantics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved range-filter compatibility across supported model types.
  - Limited automatic geomodel selection and embedded fallback behavior to compatible classifiers.
  - Improved model installation, variant switching, and removal behavior, including deterministic replacement and configuration cleanup.
  - Preserved custom label and embedding paths during primary model recovery.
  - Improved handling of range-filter settings during model changes.

- **Tests**
  - Added coverage for model compatibility, configuration updates, path recovery, and catalog consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->