### PR TITLE
fix(classifier): re-point geomodel range-filter config to a surviving model on uninstall

### DIFF
--- a/internal/classifier/model_catalog.go
+++ b/internal/classifier/model_catalog.go
@@ -640,6 +640,30 @@ func HasGeomodelFiles(entry *CatalogEntry) bool {
 	return false
 }
 
+// hasGeomodelTuple reports whether a catalog entry carries BOTH geomodel role files (model
+// and labels), i.e. a complete geomodel range-filter tuple. HasGeomodelFiles is satisfied by
+// either role alone; a range-filter survivor needs both, because the config sets ModelPath
+// and LabelsPath independently and a half-tuple survivor would leave the other path pointing
+// at an uninstalled entry's absent file.
+func hasGeomodelTuple(entry *CatalogEntry) bool {
+	if entry == nil {
+		return false
+	}
+	var hasModel, hasLabels bool
+	for _, f := range entry.Files {
+		switch f.Role {
+		case RoleGeomodelModel:
+			hasModel = true
+		case RoleGeomodelLabels:
+			hasLabels = true
+		}
+		if hasModel && hasLabels {
+			return true
+		}
+	}
+	return false
+}
+
 // HasEmbeddingsFiles reports whether a catalog entry includes shared embeddings files.
 func HasEmbeddingsFiles(entry *CatalogEntry) bool {
 	if entry == nil {

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -2135,26 +2135,60 @@ func (mm *ModelManager) applyRangeFilterConfigForInstall(updated *conf.Settings,
 	}
 }
 
-// applyRangeFilterConfigForUninstall clears the geomodel range filter config when no
-// other installed entry carries geomodel files. mm.installed must no longer contain
-// the uninstalled entry; caller holds mm.mu. It writes into updated (a settings
-// clone). A no-op for an entry without geomodel files or when another geomodel-
-// dependent model remains installed.
+// applyRangeFilterConfigForUninstall keeps the shared geomodel range-filter config
+// pointing at files that exist after an uninstall. When another installed entry still
+// carries a full geomodel tuple it re-points the config at that survivor's files (via
+// applyRangeFilterConfigForInstall); otherwise it clears the config. Because it re-points
+// at gallery-managed shared files, a hand-edited custom range-filter path is overwritten,
+// which is consistent with applyRangeFilterConfigForInstall on the install side. mm.installed
+// must no longer contain the uninstalled entry; caller holds mm.mu. It writes into updated
+// (a settings clone), and is a no-op for an entry without geomodel files.
 func (mm *ModelManager) applyRangeFilterConfigForUninstall(updated *conf.Settings, entry *CatalogEntry) {
 	if !HasGeomodelFiles(entry) {
 		return
 	}
-	for id := range mm.installed {
-		other, found := GetCatalogEntry(id)
-		if found && HasGeomodelFiles(&other) {
-			return // another geomodel-dependent model remains; keep the config
-		}
+	// The geomodel range filter is a shared service, not a per-family setting:
+	// applyRangeFilterConfigForInstall points the config at one specific installed entry's
+	// shared files. If that entry is the one being uninstalled and a survivor declares a
+	// different geomodel tuple, retaining the config alone would leave it pointing at the
+	// removed entry's now-absent files. So re-point at a deterministically chosen surviving
+	// geomodel entry's present files instead of only retaining; this recomputes identical
+	// paths for the shipped catalog, where every geomodel entry shares one canonical v3
+	// tuple, and self-corrects a hand-edited catalog that mixes tuples. Only clear when the
+	// last usable geomodel-bearing model is removed.
+	if survivor, found := mm.survivingGeomodelEntry(); found {
+		mm.applyRangeFilterConfigForInstall(updated, &survivor)
+		return
 	}
 	rf := updated.RangeFilterConfig()
 	rf.Model = ""
 	rf.ModelPath = ""
 	rf.LabelsPath = ""
 	rf.PassUnmappedSpecies = false
+}
+
+// survivingGeomodelEntry returns a deterministically chosen installed catalog entry that
+// still carries a usable geomodel tuple: BOTH geomodel role files (model and labels) plus a
+// non-empty GeomodelVersion. Both roles are required because applyRangeFilterConfigForInstall
+// sets ModelPath and LabelsPath independently, so re-pointing to a half-tuple survivor would
+// leave the other path at the uninstalled entry's absent file; a non-empty version is required
+// because that function refuses an empty one. Selection is by sorted catalog ID for
+// determinism, matching replacementInstall. mm.installed no longer contains the uninstalled
+// entry when this runs (deleted by the caller).
+func (mm *ModelManager) survivingGeomodelEntry() (CatalogEntry, bool) {
+	candidates := make([]string, 0, len(mm.installed))
+	for id := range mm.installed {
+		other, found := GetCatalogEntry(id)
+		if found && hasGeomodelTuple(&other) && other.GeomodelVersion != "" {
+			candidates = append(candidates, id)
+		}
+	}
+	if len(candidates) == 0 {
+		return CatalogEntry{}, false
+	}
+	slices.Sort(candidates)
+	survivor, _ := GetCatalogEntry(candidates[0])
+	return survivor, true
 }
 
 // applyConfigForInstall updates settings to reflect a newly installed model.

--- a/internal/classifier/model_manager_test.go
+++ b/internal/classifier/model_manager_test.go
@@ -1685,6 +1685,64 @@ func TestHasGeomodelFiles(t *testing.T) {
 	}
 }
 
+func TestHasGeomodelTuple(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, hasGeomodelTuple(nil), "a nil entry carries no tuple")
+
+	tests := []struct {
+		name  string
+		entry CatalogEntry
+		want  bool
+	}{
+		{
+			name:  "no files",
+			entry: CatalogEntry{Files: nil},
+			want:  false,
+		},
+		{
+			name: "geomodel model role only",
+			entry: CatalogEntry{Files: []CatalogFile{
+				{Role: RoleModel},
+				{Role: RoleGeomodelModel},
+			}},
+			want: false,
+		},
+		{
+			name: "geomodel labels role only",
+			entry: CatalogEntry{Files: []CatalogFile{
+				{Role: RoleGeomodelLabels},
+			}},
+			want: false,
+		},
+		{
+			name: "both geomodel roles",
+			entry: CatalogEntry{Files: []CatalogFile{
+				{Role: RoleGeomodelModel},
+				{Role: RoleGeomodelLabels},
+			}},
+			want: true,
+		},
+		{
+			name: "both geomodel roles plus unrelated files",
+			entry: CatalogEntry{Files: []CatalogFile{
+				{Role: RoleModel},
+				{Role: RoleGeomodelLabels},
+				{Role: RoleLabels},
+				{Role: RoleGeomodelModel},
+			}},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, hasGeomodelTuple(&tt.entry))
+		})
+	}
+}
+
 func TestCatalog_GeomodelFilesOnPerchAndBirdNET(t *testing.T) {
 	t.Parallel()
 

--- a/internal/classifier/model_manager_uninstall_config_test.go
+++ b/internal/classifier/model_manager_uninstall_config_test.go
@@ -208,11 +208,13 @@ func TestApplyConfigForUninstall_NilSettingsIsNoop(t *testing.T) {
 	assert.Equal(t, "/keep/perch.onnx", current.Perch.ModelPath, "a nil settings receiver must be a no-op")
 }
 
-// TestApplyRangeFilterConfigForUninstall_RetainsWhenOtherGeomodelInstalled verifies the
-// geomodel range filter config is kept when another installed entry still carries
-// geomodel files; it is only cleared when the last geomodel-bearing model is removed
-// (that clear path is covered by TestModelManager_Uninstall_GeomodelConfigClearing).
-func TestApplyRangeFilterConfigForUninstall_RetainsWhenOtherGeomodelInstalled(t *testing.T) {
+// TestApplyRangeFilterConfigForUninstall_RepointsWhenOtherGeomodelInstalled verifies the
+// geomodel range filter config is re-pointed at a surviving geomodel-bearing entry when one
+// remains. For the shipped catalog every geomodel entry shares one canonical tuple, so the
+// re-point recomputes identical paths (under mm.modelsDir); the config is only cleared when
+// the last geomodel-bearing model is removed (that clear path is covered by
+// TestModelManager_Uninstall_GeomodelConfigClearing).
+func TestApplyRangeFilterConfigForUninstall_RepointsWhenOtherGeomodelInstalled(t *testing.T) {
 	// Not parallel: mutates the global active catalog via setActiveCatalog.
 	geomodelFiles := []CatalogFile{
 		{RemotePath: "geo.onnx", LocalName: "geomodel_v3.onnx", Role: RoleGeomodelModel},
@@ -227,7 +229,8 @@ func TestApplyRangeFilterConfigForUninstall_RetainsWhenOtherGeomodelInstalled(t 
 	setActiveCatalog(withEntries)
 	t.Cleanup(func() { setActiveCatalog(nil) })
 
-	mm := NewModelManager(t.TempDir(), nil, &conf.Settings{})
+	modelsDir := t.TempDir()
+	mm := NewModelManager(modelsDir, nil, &conf.Settings{})
 	mm.installed["geo-remaining"] = InstalledModel{CatalogID: "geo-remaining"}
 
 	updated := &conf.Settings{}
@@ -237,7 +240,181 @@ func TestApplyRangeFilterConfigForUninstall_RetainsWhenOtherGeomodelInstalled(t 
 
 	mm.applyRangeFilterConfigForUninstall(updated, &removed)
 
-	assert.Equal(t, "v3", updated.BirdNET.RangeFilter.Model, "config must be retained while another geomodel remains")
-	assert.Equal(t, "/models/shared/geomodel_v3.onnx", updated.BirdNET.RangeFilter.ModelPath, "model path must be retained")
+	assert.Equal(t, "v3", updated.BirdNET.RangeFilter.Model, "config must reflect the surviving geomodel")
+	assert.Equal(t, filepath.Join(modelsDir, sharedDirName, "geomodel_v3.onnx"), updated.BirdNET.RangeFilter.ModelPath,
+		"model path must re-point to the survivor's shared file")
+	assert.Equal(t, filepath.Join(modelsDir, sharedDirName, "geomodel_v3_labels.txt"), updated.BirdNET.RangeFilter.LabelsPath,
+		"labels path must re-point to the survivor's shared file")
 	assert.True(t, updated.BirdNET.RangeFilter.PassUnmappedSpecies, "PassUnmappedSpecies must be retained")
+}
+
+// TestApplyRangeFilterConfigForUninstall_RepointsToSurvivorWithDifferentTuple pins the fix
+// for the retain-only bug: when the surviving geomodel entry declares a DIFFERENT geomodel
+// tuple than the entry being uninstalled, the range-filter config must be re-pointed at the
+// survivor's present files, not left pointing at the removed entry's now-absent files. This
+// is only reachable with a hand-edited catalog; the shipped catalog shares one canonical v3
+// tuple across every geomodel entry.
+func TestApplyRangeFilterConfigForUninstall_RepointsToSurvivorWithDifferentTuple(t *testing.T) {
+	// Not parallel: mutates the global active catalog via setActiveCatalog.
+	removedFiles := []CatalogFile{
+		{RemotePath: "geo_removed.onnx", LocalName: "geomodel_removed.onnx", Role: RoleGeomodelModel},
+		{RemotePath: "geo_removed_labels.txt", LocalName: "geomodel_removed_labels.txt", Role: RoleGeomodelLabels},
+	}
+	survivorFiles := []CatalogFile{
+		{RemotePath: "geo_survivor.onnx", LocalName: "geomodel_survivor.onnx", Role: RoleGeomodelModel},
+		{RemotePath: "geo_survivor_labels.txt", LocalName: "geomodel_survivor_labels.txt", Role: RoleGeomodelLabels},
+	}
+	removed := CatalogEntry{ID: "geo-removed", RegistryID: RegistryIDPerchV2, Category: CategoryWildlife, GeomodelVersion: "v3", Files: removedFiles}
+	survivor := CatalogEntry{ID: "geo-survivor", RegistryID: RegistryIDBirdNETV3, Category: CategoryWildlife, GeomodelVersion: "v3", Files: survivorFiles}
+
+	withEntries := make([]CatalogEntry, len(EmbeddedCatalog), len(EmbeddedCatalog)+2)
+	copy(withEntries, EmbeddedCatalog)
+	withEntries = append(withEntries, removed, survivor)
+	setActiveCatalog(withEntries)
+	t.Cleanup(func() { setActiveCatalog(nil) })
+
+	modelsDir := t.TempDir()
+	mm := NewModelManager(modelsDir, nil, &conf.Settings{})
+	mm.installed["geo-survivor"] = InstalledModel{CatalogID: "geo-survivor"}
+
+	// Config currently points at the entry being uninstalled.
+	updated := &conf.Settings{}
+	updated.BirdNET.RangeFilter.Model = "v3"
+	updated.BirdNET.RangeFilter.ModelPath = filepath.Join(modelsDir, sharedDirName, "geomodel_removed.onnx")
+	updated.BirdNET.RangeFilter.LabelsPath = filepath.Join(modelsDir, sharedDirName, "geomodel_removed_labels.txt")
+	updated.BirdNET.RangeFilter.PassUnmappedSpecies = true
+
+	mm.applyRangeFilterConfigForUninstall(updated, &removed)
+
+	assert.Equal(t, "v3", updated.BirdNET.RangeFilter.Model, "model version must reflect the survivor")
+	assert.Equal(t, filepath.Join(modelsDir, sharedDirName, "geomodel_survivor.onnx"), updated.BirdNET.RangeFilter.ModelPath,
+		"model path must re-point to the survivor's present files, not the removed entry's")
+	assert.Equal(t, filepath.Join(modelsDir, sharedDirName, "geomodel_survivor_labels.txt"), updated.BirdNET.RangeFilter.LabelsPath,
+		"labels path must re-point to the survivor's present files")
+	assert.True(t, updated.BirdNET.RangeFilter.PassUnmappedSpecies, "PassUnmappedSpecies must be retained across a re-point")
+}
+
+// TestApplyRangeFilterConfigForUninstall_ClearsWhenSurvivorHasNoGeomodelVersion verifies
+// that a surviving entry which carries geomodel files but declares no GeomodelVersion is not
+// a usable range-filter source: the config is cleared rather than left pointing at the
+// removed entry's files, because applyRangeFilterConfigForInstall would refuse the empty
+// version anyway.
+func TestApplyRangeFilterConfigForUninstall_ClearsWhenSurvivorHasNoGeomodelVersion(t *testing.T) {
+	// Not parallel: mutates the global active catalog via setActiveCatalog.
+	geomodelFiles := []CatalogFile{
+		{RemotePath: "geo.onnx", LocalName: "geomodel_v3.onnx", Role: RoleGeomodelModel},
+		{RemotePath: "geo_labels.txt", LocalName: "geomodel_v3_labels.txt", Role: RoleGeomodelLabels},
+	}
+	removed := CatalogEntry{ID: "geo-removed", RegistryID: RegistryIDPerchV2, Category: CategoryWildlife, GeomodelVersion: "v3", Files: geomodelFiles}
+	versionless := CatalogEntry{ID: "geo-versionless", RegistryID: RegistryIDBirdNETV3, Category: CategoryWildlife, GeomodelVersion: "", Files: geomodelFiles}
+
+	withEntries := make([]CatalogEntry, len(EmbeddedCatalog), len(EmbeddedCatalog)+2)
+	copy(withEntries, EmbeddedCatalog)
+	withEntries = append(withEntries, removed, versionless)
+	setActiveCatalog(withEntries)
+	t.Cleanup(func() { setActiveCatalog(nil) })
+
+	mm := NewModelManager(t.TempDir(), nil, &conf.Settings{})
+	mm.installed["geo-versionless"] = InstalledModel{CatalogID: "geo-versionless"}
+
+	updated := &conf.Settings{}
+	updated.BirdNET.RangeFilter.Model = "v3"
+	updated.BirdNET.RangeFilter.ModelPath = "/models/shared/geomodel_v3.onnx"
+	updated.BirdNET.RangeFilter.PassUnmappedSpecies = true
+
+	mm.applyRangeFilterConfigForUninstall(updated, &removed)
+
+	assert.Empty(t, updated.BirdNET.RangeFilter.Model, "a versionless geomodel survivor is not usable; config must clear")
+	assert.Empty(t, updated.BirdNET.RangeFilter.ModelPath, "model path must clear when no usable geomodel survivor remains")
+	assert.False(t, updated.BirdNET.RangeFilter.PassUnmappedSpecies, "PassUnmappedSpecies must reset on clear")
+}
+
+// TestApplyRangeFilterConfigForUninstall_ClearsWhenSurvivorLacksLabelsRole verifies that a
+// surviving entry carrying only a geomodel MODEL file (no geomodel labels role) is not a
+// usable range-filter tuple: the config is cleared rather than re-pointed, so it can never
+// keep the uninstalled entry's now-absent labels path. Reachable only via a hand-edited
+// catalog; the shipped catalog always pairs both geomodel roles.
+func TestApplyRangeFilterConfigForUninstall_ClearsWhenSurvivorLacksLabelsRole(t *testing.T) {
+	// Not parallel: mutates the global active catalog via setActiveCatalog.
+	removedFiles := []CatalogFile{
+		{RemotePath: "geo_removed.onnx", LocalName: "geomodel_removed.onnx", Role: RoleGeomodelModel},
+		{RemotePath: "geo_removed_labels.txt", LocalName: "geomodel_removed_labels.txt", Role: RoleGeomodelLabels},
+	}
+	modelOnlyFiles := []CatalogFile{
+		{RemotePath: "geo_survivor.onnx", LocalName: "geomodel_survivor.onnx", Role: RoleGeomodelModel},
+	}
+	removed := CatalogEntry{ID: "geo-removed", RegistryID: RegistryIDPerchV2, Category: CategoryWildlife, GeomodelVersion: "v3", Files: removedFiles}
+	modelOnly := CatalogEntry{ID: "geo-modelonly", RegistryID: RegistryIDBirdNETV3, Category: CategoryWildlife, GeomodelVersion: "v3", Files: modelOnlyFiles}
+
+	withEntries := make([]CatalogEntry, len(EmbeddedCatalog), len(EmbeddedCatalog)+2)
+	copy(withEntries, EmbeddedCatalog)
+	withEntries = append(withEntries, removed, modelOnly)
+	setActiveCatalog(withEntries)
+	t.Cleanup(func() { setActiveCatalog(nil) })
+
+	modelsDir := t.TempDir()
+	mm := NewModelManager(modelsDir, nil, &conf.Settings{})
+	mm.installed["geo-modelonly"] = InstalledModel{CatalogID: "geo-modelonly"}
+
+	// Config currently points at the (full-tuple) entry being uninstalled.
+	updated := &conf.Settings{}
+	updated.BirdNET.RangeFilter.Model = "v3"
+	updated.BirdNET.RangeFilter.ModelPath = filepath.Join(modelsDir, sharedDirName, "geomodel_removed.onnx")
+	updated.BirdNET.RangeFilter.LabelsPath = filepath.Join(modelsDir, sharedDirName, "geomodel_removed_labels.txt")
+	updated.BirdNET.RangeFilter.PassUnmappedSpecies = true
+
+	mm.applyRangeFilterConfigForUninstall(updated, &removed)
+
+	assert.Empty(t, updated.BirdNET.RangeFilter.Model, "a half-tuple survivor is not usable; config must clear")
+	assert.Empty(t, updated.BirdNET.RangeFilter.ModelPath, "model path must clear, never keep the removed entry's file")
+	assert.Empty(t, updated.BirdNET.RangeFilter.LabelsPath, "labels path must clear, never keep the removed entry's now-absent file")
+	assert.False(t, updated.BirdNET.RangeFilter.PassUnmappedSpecies, "PassUnmappedSpecies must reset on clear")
+}
+
+// TestApplyRangeFilterConfigForUninstall_RepointsToLowestCatalogIDSurvivor pins the
+// deterministic pick: with two surviving full-tuple geomodel entries carrying different
+// tuples, the re-point chooses the lowest catalog ID (sorted), not a random map-order entry.
+func TestApplyRangeFilterConfigForUninstall_RepointsToLowestCatalogIDSurvivor(t *testing.T) {
+	// Not parallel: mutates the global active catalog via setActiveCatalog.
+	removedFiles := []CatalogFile{
+		{RemotePath: "geo_removed.onnx", LocalName: "geomodel_removed.onnx", Role: RoleGeomodelModel},
+		{RemotePath: "geo_removed_labels.txt", LocalName: "geomodel_removed_labels.txt", Role: RoleGeomodelLabels},
+	}
+	aFiles := []CatalogFile{
+		{RemotePath: "geo_a.onnx", LocalName: "geomodel_a.onnx", Role: RoleGeomodelModel},
+		{RemotePath: "geo_a_labels.txt", LocalName: "geomodel_a_labels.txt", Role: RoleGeomodelLabels},
+	}
+	bFiles := []CatalogFile{
+		{RemotePath: "geo_b.onnx", LocalName: "geomodel_b.onnx", Role: RoleGeomodelModel},
+		{RemotePath: "geo_b_labels.txt", LocalName: "geomodel_b_labels.txt", Role: RoleGeomodelLabels},
+	}
+	removed := CatalogEntry{ID: "geo-removed", RegistryID: RegistryIDPerchV2, Category: CategoryWildlife, GeomodelVersion: "v3", Files: removedFiles}
+	survivorA := CatalogEntry{ID: "geo-aaa", RegistryID: RegistryIDBirdNETV3, Category: CategoryWildlife, GeomodelVersion: "v3", Files: aFiles}
+	survivorB := CatalogEntry{ID: "geo-bbb", RegistryID: RegistryIDBirdNETV3, Category: CategoryWildlife, GeomodelVersion: "v3", Files: bFiles}
+
+	withEntries := make([]CatalogEntry, len(EmbeddedCatalog), len(EmbeddedCatalog)+3)
+	copy(withEntries, EmbeddedCatalog)
+	withEntries = append(withEntries, removed, survivorA, survivorB)
+	setActiveCatalog(withEntries)
+	t.Cleanup(func() { setActiveCatalog(nil) })
+
+	modelsDir := t.TempDir()
+	mm := NewModelManager(modelsDir, nil, &conf.Settings{})
+	// Insert in reverse ID order so a map-order pick would tend to choose the wrong one.
+	mm.installed["geo-bbb"] = InstalledModel{CatalogID: "geo-bbb"}
+	mm.installed["geo-aaa"] = InstalledModel{CatalogID: "geo-aaa"}
+
+	// Pre-point both paths at the entry being uninstalled so the assertions prove the
+	// survivor OVERWRITES them, not merely populates an empty field.
+	updated := &conf.Settings{}
+	updated.BirdNET.RangeFilter.Model = "v3"
+	updated.BirdNET.RangeFilter.ModelPath = filepath.Join(modelsDir, sharedDirName, "geomodel_removed.onnx")
+	updated.BirdNET.RangeFilter.LabelsPath = filepath.Join(modelsDir, sharedDirName, "geomodel_removed_labels.txt")
+
+	mm.applyRangeFilterConfigForUninstall(updated, &removed)
+
+	assert.Equal(t, filepath.Join(modelsDir, sharedDirName, "geomodel_a.onnx"), updated.BirdNET.RangeFilter.ModelPath,
+		"the re-point must pick the lowest catalog ID survivor (geo-aaa), not geo-bbb")
+	assert.Equal(t, filepath.Join(modelsDir, sharedDirName, "geomodel_a_labels.txt"), updated.BirdNET.RangeFilter.LabelsPath,
+		"labels must come from the lowest catalog ID survivor")
 }


### PR DESCRIPTION
## Summary

On model uninstall, the shared geomodel range-filter config could keep pointing at the removed model's files. `applyRangeFilterConfigForUninstall` retained the config verbatim whenever any other installed model carried geomodel files, without checking that the surviving model's geomodel tuple matched the one currently configured, so a survivor declaring a different tuple left `birdnet.rangefilter.{model,modelpath,labelspath}` pointing at the uninstalled model's now-absent files.

This re-points the config at a deterministically chosen surviving model that carries a full geomodel tuple (both the model and labels roles plus a non-empty version), reusing the existing install-time config writer, and clears the config only when no usable survivor remains. Because the shipped catalog shares one canonical geomodel tuple across every geomodel-bearing model, this recomputes byte-identical paths for real installs and is a no-op there; it only corrects a catalog whose entries declare mismatched tuples.

Requiring the full tuple (via a new `hasGeomodelTuple` helper that checks for both geomodel roles) also prevents a half-tuple survivor from leaving the opposite path stale, since the install-time writer sets the model and labels paths independently.

## Test Plan

- [x] `go test -race ./internal/classifier/` (full package green)
- [x] `golangci-lint run ./internal/classifier/...` (0 issues)
- [x] New tests cover re-point (same tuple and different tuple), clear (last geomodel removed, versionless survivor, half-tuple survivor), and deterministic lowest-catalog-ID selection, plus direct `hasGeomodelTuple` unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model removal handling so range-filter settings now point to a complete, usable installed model.
  * Settings are cleared when no suitable model remains.
  * Survivor selection is deterministic when multiple eligible models are installed.

* **Tests**
  * Added coverage for incomplete model files, missing labels or versions, alternate model configurations, and deterministic selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->