### PR TITLE
refactor(speciesindex): shared species-name index; port datastore and api/v2 name maps

### DIFF
--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"os"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -48,6 +47,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/notification"
 	"github.com/tphakala/birdnet-go/internal/observability"
+	"github.com/tphakala/birdnet-go/internal/speciesindex"
 	"github.com/tphakala/birdnet-go/internal/suncalc"
 )
 
@@ -268,14 +268,14 @@ type Controller struct {
 	// WithAuthService / WithNotificationService (see NewWithOptions).
 	appHandler *app.Handler
 
-	// Cached BirdNET name maps (facade-owned; see name_maps.go). They are shared
-	// infrastructure: the analytics, detections, and species domains read them via
-	// injected accessors, and internal/analysis drives them through
-	// UpdateCommonNameMap/SetNameResolver on *Controller.
-	nameMaps atomic.Value // stores *nameMaps; see internal/api/v2/name_maps.go
-	// nameResolver is the authoritative localized name source shared with the
-	// classifier orchestrator. Overrides label-derived names in the cached maps.
-	nameResolver atomic.Pointer[datastore.SpeciesNameResolver]
+	// names owns the facade's BirdNET name index (the scientific<->common maps
+	// plus the authoritative resolver; see name_maps.go). Shared infrastructure:
+	// the analytics, detections, and species domains read it via injected
+	// accessors, and internal/analysis drives it through
+	// UpdateCommonNameMap/SetNameResolver on *Controller. Constructed in
+	// NewWithOptions; the accessors treat a nil service (a bare-struct test) as an
+	// empty index.
+	names *speciesindex.Service
 
 	// analytics serves the /api/v2/analytics/* species/time/confidence/sun/sources
 	// endpoints, the geographic /range/heatmap endpoint, the /insights/* +
@@ -420,6 +420,12 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 		controlChan:   controlChan,
 		isGlobalOwner: settings == conf.GetSettings(),
 	}
+
+	// Initialize the facade-owned species-name index before constructing any
+	// domain handler, since several capture the name-map accessors as bound
+	// methods. It stays empty until initInsightsRoutes / UpdateCommonNameMap seeds
+	// it from the current labels.
+	c.names = speciesindex.New(nil)
 
 	// Construct domain handlers around the shared core. They hold the same
 	// *apicore.Core pointer and register their routes in initRoutes.

--- a/internal/api/v2/apicore/shared_helpers.go
+++ b/internal/api/v2/apicore/shared_helpers.go
@@ -6,11 +6,9 @@ package apicore
 import (
 	"fmt"
 	"strconv"
-	"strings"
-
-	"golang.org/x/text/unicode/norm"
 
 	"github.com/tphakala/birdnet-go/internal/classifier"
+	"github.com/tphakala/birdnet-go/internal/speciesindex"
 )
 
 // BirdNET week-model constants, shared across api/v2 domains. BirdNET uses a
@@ -73,9 +71,11 @@ func (c *Core) CurrentLocale() string {
 // on macOS or with composing keyboards may submit decomposed (NFD) bytes
 // for diacritics, so normalising both sides to NFC prevents silent misses
 // on species like "Lehtopöllö". Shared by the insights, search, and range
-// (display de-duplication) code so the keys stay consistent across them.
+// (display de-duplication) code so the keys stay consistent across them. It
+// delegates to speciesindex.Fold, the single fold used process-wide, so the
+// api/v2 search keys match the ones the shared name index builds.
 func NormalizeForLookup(s string) string {
-	return strings.ToLower(norm.NFC.String(s))
+	return speciesindex.Fold(s)
 }
 
 // ParseFloat64 parses a string to float64. Shared by the range and heatmap

--- a/internal/api/v2/apicore/shared_helpers.go
+++ b/internal/api/v2/apicore/shared_helpers.go
@@ -72,8 +72,8 @@ func (c *Core) CurrentLocale() string {
 // for diacritics, so normalising both sides to NFC prevents silent misses
 // on species like "Lehtopöllö". Shared by the insights, search, and range
 // (display de-duplication) code so the keys stay consistent across them. It
-// delegates to speciesindex.Fold, the single fold used process-wide, so the
-// api/v2 search keys match the ones the shared name index builds.
+// delegates to speciesindex.Fold, the shared species-name fold, so the api/v2
+// search keys match the ones the shared name index builds.
 func NormalizeForLookup(s string) string {
 	return speciesindex.Fold(s)
 }

--- a/internal/api/v2/insights_nameresolver_test.go
+++ b/internal/api/v2/insights_nameresolver_test.go
@@ -3,8 +3,10 @@ package api
 import (
 	"testing"
 
+	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/speciesindex"
 )
 
 // fakeResolver is a minimal datastore.SpeciesNameResolver for tests.
@@ -17,51 +19,68 @@ func (f fakeResolver) ResolveLocal(sci string) (string, bool) {
 	return v, ok
 }
 
-func TestBuildNameMaps_ResolverLocalizes(t *testing.T) {
+// newNameMapController builds a bare Controller with an initialized species-name
+// index, for exercising the facade-owned UpdateCommonNameMap/SetNameResolver and
+// name-map accessors without spinning up the full facade. The underlying builder
+// itself is golden-tested in internal/speciesindex; these tests cover the facade
+// wiring (resolver install plus rebuild feeding the accessors).
+func newNameMapController(t *testing.T) *Controller {
+	t.Helper()
+	e := echo.New()
+	c := &Controller{Core: &apicore.Core{Group: e.Group("/api/v2")}}
+	c.names = speciesindex.New(nil)
+	return c
+}
+
+func TestController_UpdateCommonNameMap_ResolverLocalizes(t *testing.T) {
+	t.Parallel()
+
 	// The resolver overrides the label's common name in both the forward
 	// (sciToCommon) and reverse (commonToSci) maps, so insights display and
 	// search both reflect the localized name.
-	nm := buildNameMaps([]string{"Turdus merula_LabelName"},
-		fakeResolver{m: map[string]string{"Turdus merula": "Mustarastas"}})
-	assert.Equal(t, "Mustarastas", nm.sciToCommon["Turdus merula"])
-	assert.Equal(t, "Turdus merula", nm.commonToSci[apicore.NormalizeForLookup("Mustarastas")])
+	c := newNameMapController(t)
+	c.SetNameResolver(fakeResolver{m: map[string]string{"Turdus merula": "Mustarastas"}})
+	c.UpdateCommonNameMap([]string{"Turdus merula_LabelName"})
+
+	assert.Equal(t, "Mustarastas", c.loadCommonNameMap()["Turdus merula"])
+	assert.Equal(t, "Turdus merula", c.loadCommonToScientificMap()[apicore.NormalizeForLookup("Mustarastas")])
 }
 
-func TestBuildNameMaps_NilResolverKeepsLabel(t *testing.T) {
-	nm := buildNameMaps([]string{"Turdus merula_LabelName"}, nil)
-	assert.Equal(t, "LabelName", nm.sciToCommon["Turdus merula"])
-}
-
-func TestBuildCommonNameMap(t *testing.T) {
+func TestController_UpdateCommonNameMap_NilResolverKeepsLabel(t *testing.T) {
 	t.Parallel()
-	labels := []string{
-		"Turdus merula_Eurasian Blackbird",
-		"Parus major_Great Tit",
-		"Invalid Label Without Separator",
-		"_EmptyScientificName",
+
+	c := newNameMapController(t)
+	c.UpdateCommonNameMap([]string{"Turdus merula_LabelName"})
+	assert.Equal(t, "LabelName", c.loadCommonNameMap()["Turdus merula"])
+}
+
+func TestResolveCommonName(t *testing.T) {
+	t.Parallel()
+
+	m := map[string]string{
+		"Turdus merula": "Eurasian Blackbird",
+		"Parus major":   "Great Tit",
 	}
-
-	m := buildNameMaps(labels, nil).sciToCommon
-	assert.Equal(t, "Eurasian Blackbird", m["Turdus merula"])
-	assert.Equal(t, "Great Tit", m["Parus major"])
-	assert.Len(t, m, 2) // invalid entries excluded
-
-	// Test resolveCommonName fallback
 	assert.Equal(t, "Eurasian Blackbird", apicore.ResolveCommonName(m, "Turdus merula"))
+	// A miss falls back to the input verbatim.
 	assert.Equal(t, "Unknown species", apicore.ResolveCommonName(m, "Unknown species"))
 }
 
-func TestBuildNameMaps_ScientificOnlyLabelSearchable(t *testing.T) {
-	// A scientific-only label (no "_", e.g. Perch v2 / bat labels) has no embedded
-	// common name; when the resolver provides one, the species must become
-	// searchable by it (forward + reverse maps populated).
-	nm := buildNameMaps([]string{"Myotis myotis"},
-		fakeResolver{m: map[string]string{"Myotis myotis": "Greater Mouse-eared Bat"}})
-	assert.Equal(t, "Greater Mouse-eared Bat", nm.sciToCommon["Myotis myotis"])
-	assert.Equal(t, "Myotis myotis", nm.commonToSci[apicore.NormalizeForLookup("Greater Mouse-eared Bat")])
+func TestController_UpdateCommonNameMap_ScientificOnlyLabelSearchable(t *testing.T) {
+	t.Parallel()
 
-	// Without a resolver, a scientific-only label has no common name and is skipped.
-	bare := buildNameMaps([]string{"Myotis myotis"}, nil)
-	_, ok := bare.sciToCommon["Myotis myotis"]
+	// A scientific-only label (no "_", e.g. Perch v2 / bat labels) has no embedded
+	// common name; when the resolver provides one, the species becomes searchable
+	// by it (forward + reverse maps populated).
+	c := newNameMapController(t)
+	c.SetNameResolver(fakeResolver{m: map[string]string{"Myotis myotis": "Greater Mouse-eared Bat"}})
+	c.UpdateCommonNameMap([]string{"Myotis myotis"})
+	assert.Equal(t, "Greater Mouse-eared Bat", c.loadCommonNameMap()["Myotis myotis"])
+	assert.Equal(t, "Myotis myotis", c.loadCommonToScientificMap()[apicore.NormalizeForLookup("Greater Mouse-eared Bat")])
+
+	// Without a resolver, a scientific-only label has no common name and is absent.
+	bare := newNameMapController(t)
+	bare.UpdateCommonNameMap([]string{"Myotis myotis"})
+	_, ok := bare.loadCommonNameMap()["Myotis myotis"]
 	assert.False(t, ok)
 }

--- a/internal/api/v2/name_maps.go
+++ b/internal/api/v2/name_maps.go
@@ -12,7 +12,7 @@
 // plumbing here (rather than in a domain package) avoids any domain->domain or
 // domain->facade dependency. The maps themselves are built and owned by the
 // shared internal/speciesindex leaf package, so the api/v2 and datastore name
-// maps stay byte-identical.
+// maps stay identical.
 package api
 
 import (
@@ -64,6 +64,9 @@ func (c *Controller) canonicalizeExcludeList(exclude []string) []string {
 // Called after locale or model changes to keep insights and search endpoints
 // current.
 func (c *Controller) UpdateCommonNameMap(labels []string) {
+	if c.names == nil {
+		return
+	}
 	locale := ""
 	if s := c.ControllerSettings(); s != nil {
 		locale = s.BirdNET.Locale
@@ -74,6 +77,9 @@ func (c *Controller) UpdateCommonNameMap(labels []string) {
 // SetNameResolver installs the authoritative localized name resolver, shared with
 // the classifier orchestrator. A nil resolver is ignored.
 func (c *Controller) SetNameResolver(r datastore.SpeciesNameResolver) {
+	if c.names == nil {
+		return
+	}
 	c.names.SetResolver(r)
 }
 

--- a/internal/api/v2/name_maps.go
+++ b/internal/api/v2/name_maps.go
@@ -1,8 +1,8 @@
 // internal/api/v2/name_maps.go
 //
 // Facade-owned BirdNET name-map plumbing. The cached scientific<->common lookup
-// maps and the authoritative name resolver live on the *Controller (the fields
-// nameMaps and nameResolver in api.go). They are shared infrastructure: the
+// maps and the authoritative name resolver live on the *Controller (the field
+// names in api.go, a *speciesindex.Service). They are shared infrastructure: the
 // analytics domain, the detections search resolver, the species image handler,
 // and the settings exclude-list canonicalization all read them through the
 // accessors below (analytics, detections, and species receive the accessors as
@@ -10,98 +10,44 @@
 // directly). UpdateCommonNameMap and SetNameResolver are part of the external
 // surface: internal/analysis drives them through *apiv2.Controller. Keeping the
 // plumbing here (rather than in a domain package) avoids any domain->domain or
-// domain->facade dependency.
+// domain->facade dependency. The maps themselves are built and owned by the
+// shared internal/speciesindex leaf package, so the api/v2 and datastore name
+// maps stay byte-identical.
 package api
 
 import (
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/speciesindex"
 )
 
-// nameMaps holds the BirdNET display, folded-search, and exact-resolution maps.
-// Grouping them lets a single atomic.Value Store swap one consistent snapshot,
-// avoiding any window where readers could see a partially updated set.
-type nameMaps struct {
-	// sciToCommon maps scientific name -> common name.
-	sciToCommon map[string]string
-	// sciToCommonFolded maps scientific name -> NFC-normalised, lowercased common
-	// name for allocation-free substring matching on the search hot path.
-	sciToCommonFolded map[string]string
-	// commonToSci maps NFC-normalised, lowercased common name -> scientific name.
-	commonToSci map[string]string
-}
-
-// buildNameMaps parses a BirdNET label list ("ScientificName_CommonName")
-// and builds both lookup maps in a single pass. If two or more labels share
-// the same normalised common name but map to different scientific names,
-// the common-name key is removed from commonToSci so that search queries
-// matching an ambiguous common name pass through untranslated; resolving
-// them to an arbitrary species based on label order would silently hide
-// valid matches. sciToCommon is not affected because scientific names are
-// unique per label.
-// When resolver is non-nil, each label's common name is overridden by the
-// resolver (authoritative/localized), so insights display (sciToCommon) and
-// search (commonToSci) both reflect the localized name. Labels the resolver does
-// not cover keep their embedded common name.
-func buildNameMaps(labels []string, resolver datastore.SpeciesNameResolver) *nameMaps {
-	nm := &nameMaps{
-		sciToCommon:       make(map[string]string, len(labels)),
-		sciToCommonFolded: make(map[string]string, len(labels)),
-		commonToSci:       make(map[string]string, len(labels)),
+// loadNameMaps returns the current species-name snapshot. Always returns a
+// non-nil snapshot with non-nil inner maps (Empty() before the first rebuild, or
+// when the service is unset on a bare-struct test), so callers index without
+// guards.
+func (c *Controller) loadNameMaps() *speciesindex.Snapshot {
+	if c.names == nil {
+		return speciesindex.Empty()
 	}
-	ambiguous := make(map[string]struct{})
-	for _, sn := range datastore.ResolveLabelNames(labels, resolver) {
-		nm.sciToCommon[sn.Scientific] = sn.Common
-
-		key := apicore.NormalizeForLookup(sn.Common)
-		nm.sciToCommonFolded[sn.Scientific] = key
-		if _, seen := ambiguous[key]; seen {
-			continue
-		}
-		if existing, exists := nm.commonToSci[key]; exists && existing != sn.Scientific {
-			ambiguous[key] = struct{}{}
-			delete(nm.commonToSci, key)
-			continue
-		}
-		nm.commonToSci[key] = sn.Scientific
-	}
-	return nm
-}
-
-// emptyNameMaps is returned by loadNameMaps when the atomic.Value has not been
-// populated yet (a narrow startup window before initInsightsRoutes runs). It
-// avoids allocating a fresh struct and empty maps on every cold-path call.
-var emptyNameMaps = &nameMaps{
-	sciToCommon:       map[string]string{},
-	sciToCommonFolded: map[string]string{},
-	commonToSci:       map[string]string{},
-}
-
-// loadNameMaps returns the current name-maps struct. Always returns a non-nil
-// struct with non-nil inner maps so callers can index without guards.
-func (c *Controller) loadNameMaps() *nameMaps {
-	if nm, ok := c.nameMaps.Load().(*nameMaps); ok && nm != nil {
-		return nm
-	}
-	return emptyNameMaps
+	return c.names.Snapshot()
 }
 
 // loadCommonToScientificMap returns the current common-to-scientific lookup map.
 // Always returns a non-nil map.
 func (c *Controller) loadCommonToScientificMap() map[string]string {
-	return c.loadNameMaps().commonToSci
+	return c.loadNameMaps().CommonToSci
 }
 
 // loadCommonNameMap returns the current scientific-to-common lookup map.
 // Always returns a non-nil map.
 func (c *Controller) loadCommonNameMap() map[string]string {
-	return c.loadNameMaps().sciToCommon
+	return c.loadNameMaps().SciToCommon
 }
 
 // loadFoldedCommonNameMap returns the current scientific-to-normalized-common
 // lookup map used by substring search. Always returns a non-nil map.
 func (c *Controller) loadFoldedCommonNameMap() map[string]string {
-	return c.loadNameMaps().sciToCommonFolded
+	return c.loadNameMaps().SciToCommonFolded
 }
 
 // canonicalizeExcludeList canonicalizes the species exclude list (resolve each
@@ -113,27 +59,22 @@ func (c *Controller) canonicalizeExcludeList(exclude []string) []string {
 	return apicore.CanonicalizeExcludeList(c.loadCommonToScientificMap(), exclude)
 }
 
-// UpdateCommonNameMap rebuilds both cached name maps from updated BirdNET labels.
-// Called after locale or model changes to keep insights and search endpoints current.
+// UpdateCommonNameMap rebuilds the cached name maps from updated BirdNET labels,
+// using the locale from the current settings (empty when settings are nil).
+// Called after locale or model changes to keep insights and search endpoints
+// current.
 func (c *Controller) UpdateCommonNameMap(labels []string) {
-	c.nameMaps.Store(buildNameMaps(labels, c.loadNameResolver()))
+	locale := ""
+	if s := c.ControllerSettings(); s != nil {
+		locale = s.BirdNET.Locale
+	}
+	c.names.Rebuild(labels, locale)
 }
 
 // SetNameResolver installs the authoritative localized name resolver, shared with
 // the classifier orchestrator. A nil resolver is ignored.
 func (c *Controller) SetNameResolver(r datastore.SpeciesNameResolver) {
-	if datastore.IsNilResolver(r) {
-		return
-	}
-	c.nameResolver.Store(&r)
-}
-
-// loadNameResolver returns the installed resolver, or nil if none has been set.
-func (c *Controller) loadNameResolver() datastore.SpeciesNameResolver {
-	if p := c.nameResolver.Load(); p != nil {
-		return *p
-	}
-	return nil
+	c.names.SetResolver(r)
 }
 
 // initInsightsRoutes seeds the facade-owned name maps and registers the analytics

--- a/internal/api/v2/search_common_name_test.go
+++ b/internal/api/v2/search_common_name_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/speciesindex"
 )
 
 // analyticsBatchFakeResolver is a test resolver that satisfies SpeciesNameResolver
@@ -42,6 +43,7 @@ func TestUpdateCommonNameMap_PopulatesAllMaps(t *testing.T) {
 
 	e := echo.New()
 	c := &Controller{Core: &apicore.Core{Group: e.Group("/api/v2")}}
+	c.names = speciesindex.New(nil)
 
 	labels := []string{
 		"Strix aluco_Tawny Owl",
@@ -68,70 +70,14 @@ func TestUpdateCommonNameMap_PopulatesAllMaps(t *testing.T) {
 	assert.Equal(t, "Parus major", commonToSci["great tit"])
 }
 
-// TestBuildNameMaps_AmbiguousCommonName verifies that a common name mapped
-// by two different scientific names is removed from commonToSci so the
-// search resolver passes ambiguous queries through untranslated.
-func TestBuildNameMaps_AmbiguousCommonName(t *testing.T) {
-	t.Parallel()
-
-	nm := buildNameMaps([]string{
-		"Strix aluco_Owl",
-		"Bubo bubo_Owl",
-		"Parus major_Great Tit",
-	}, nil)
-	require.NotNil(t, nm)
-
-	// sciToCommon keeps both species; scientific names are always unique.
-	assert.Equal(t, "Owl", nm.sciToCommon["Strix aluco"])
-	assert.Equal(t, "Owl", nm.sciToCommon["Bubo bubo"])
-
-	// commonToSci must NOT contain the ambiguous key.
-	_, ok := nm.commonToSci["owl"]
-	assert.False(t, ok, "ambiguous common-name key should be removed")
-
-	// A third label that repeats an already-ambiguous key should not
-	// accidentally restore the key.
-	nm = buildNameMaps([]string{
-		"Strix aluco_Owl",
-		"Bubo bubo_Owl",
-		"Tyto alba_Owl",
-	}, nil)
-	_, ok = nm.commonToSci["owl"]
-	assert.False(t, ok)
-
-	// Non-ambiguous names remain.
-	nm = buildNameMaps([]string{
-		"Strix aluco_Owl",
-		"Bubo bubo_Owl",
-		"Parus major_Great Tit",
-	}, nil)
-	assert.Equal(t, "Parus major", nm.commonToSci["great tit"])
-}
-
-// TestBuildNameMaps_MalformedLabels verifies that labels missing a scientific
-// name, a common name, or the separator are silently skipped rather than
-// producing empty keys.
-func TestBuildNameMaps_MalformedLabels(t *testing.T) {
-	t.Parallel()
-
-	nm := buildNameMaps([]string{
-		"Strix aluco_Tawny Owl",
-		"_MissingScientific",
-		"MissingCommon_",
-		"NoSeparatorAtAll",
-		"",
-		"   _   ",
-	}, nil)
-	require.NotNil(t, nm)
-	assert.Len(t, nm.sciToCommon, 1)
-	assert.Len(t, nm.commonToSci, 1)
-	assert.Equal(t, "Tawny Owl", nm.sciToCommon["Strix aluco"])
-	assert.Equal(t, "Strix aluco", nm.commonToSci["tawny owl"])
-}
+// Note: the ambiguous-common-name drop and malformed-label skipping previously
+// exercised here through buildNameMaps directly are now golden-tested in
+// internal/speciesindex, which owns the shared builder.
 
 // TestLoadNameMaps_CalledBeforeInit verifies that the load helpers return
-// non-nil empty maps when the Controller has not yet seeded nameMaps, so
-// callers can index without nil checks during the startup window.
+// non-nil empty maps (speciesindex.Empty semantics) when the Controller's name
+// index has not been seeded yet, so callers can index without nil checks during
+// the startup window.
 func TestLoadNameMaps_CalledBeforeInit(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/v2/settings_exclude_canonicalize_test.go
+++ b/internal/api/v2/settings_exclude_canonicalize_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/speciesindex"
 )
 
 // clearExcludedSpeciesList resets the species exclude list for a clean test start.
@@ -78,6 +79,7 @@ func TestCanonicalizeExcludeList(t *testing.T) {
 	t.Parallel()
 
 	c := &Controller{Core: &apicore.Core{}}
+	c.names = speciesindex.New(nil)
 	installExcludeTestResolver(t, c)
 
 	tests := []struct {

--- a/internal/classifier/canonical_species_key_speciesindex_test.go
+++ b/internal/classifier/canonical_species_key_speciesindex_test.go
@@ -1,0 +1,58 @@
+package classifier
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/speciesindex"
+)
+
+// TestCanonicalSpeciesKeyMatchesSpeciesindex pins the equality between the
+// classifier's canonicalSpeciesKey (mapped_range_filter.go) and the canonical key
+// the shared speciesindex builds. Phase 2b substitutes the memoized speciesindex
+// map for the local helper, so this guards that the substitution is behavior-
+// preserving over the full v2.4 label corpus (memo-hit path) plus a few
+// taxonomic-alias legacy names (compute path). Classifier tests may import the
+// leaf speciesindex package; speciesindex never imports classifier, so there is
+// no cycle.
+func TestCanonicalSpeciesKeyMatchesSpeciesindex(t *testing.T) {
+	t.Parallel()
+
+	const corpusPath = "data/labels/V2.4/BirdNET_GLOBAL_6K_V2.4_Labels_en_uk.txt"
+	data, err := os.ReadFile(corpusPath)
+	require.NoError(t, err, "v2.4 corpus must be present")
+
+	var corpus []string
+	for line := range strings.Lines(string(data)) {
+		line = strings.TrimRight(line, "\r\n")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		corpus = append(corpus, line)
+	}
+	require.NotEmpty(t, corpus)
+
+	snap := speciesindex.Build(corpus, nil, "")
+
+	// Memo-hit path: every corpus label.
+	for _, label := range corpus {
+		assert.Equalf(t, canonicalSpeciesKey(label), snap.CanonicalKey(label),
+			"canonical key mismatch (memo) for %q", label)
+	}
+
+	// Compute path: taxonomic-alias legacy names and formatted variants not
+	// necessarily in the corpus.
+	for _, label := range []string{
+		"Accipiter badius",
+		"Accipiter badius_Shikra",
+		"Tachyspiza badia",
+		"Turdus merula_Blackbird",
+	} {
+		assert.Equalf(t, canonicalSpeciesKey(label), snap.CanonicalKey(label),
+			"canonical key mismatch (compute) for %q", label)
+	}
+}

--- a/internal/classifier/canonical_species_key_speciesindex_test.go
+++ b/internal/classifier/canonical_species_key_speciesindex_test.go
@@ -52,7 +52,10 @@ func TestCanonicalSpeciesKeyMatchesSpeciesindex(t *testing.T) {
 		"Tachyspiza badia",
 		"Turdus merula_Blackbird",
 	} {
-		assert.Equalf(t, canonicalSpeciesKey(label), snap.CanonicalKey(label),
-			"canonical key mismatch (compute) for %q", label)
+		t.Run(label, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, canonicalSpeciesKey(label), snap.CanonicalKey(label),
+				"canonical key must match between classifier and speciesindex")
+		})
 	}
 }

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -41,8 +41,8 @@ import (
 	"github.com/tphakala/birdnet-go/internal/labels/nonbird"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	obmetrics "github.com/tphakala/birdnet-go/internal/observability/metrics"
+	"github.com/tphakala/birdnet-go/internal/speciesindex"
 	"github.com/tphakala/birdnet-go/internal/suncalc"
-	"golang.org/x/text/unicode/norm"
 	"gorm.io/gorm"
 )
 
@@ -104,19 +104,6 @@ func parseDetectionTimestamp(date, timeStr string, tz *time.Location) int64 {
 	return time.Now().Unix()
 }
 
-// nameMaps holds the species name lookup maps. Stored behind an atomic.Pointer
-// so readers are lock-free and UpdateNameMaps can swap atomically.
-type nameMaps struct {
-	// common maps scientific name → common name (display lookup).
-	common map[string]string
-	// commonFolded maps scientific name → lower-cased NFC-normalized common name. Precomputed
-	// once here so common-name search (ResolveCommonNameToLabelIDs) does not normalize every map
-	// value on every query.
-	commonFolded map[string]string
-	// species maps lowercase common name → scientific name (reverse lookup).
-	species map[string]string
-}
-
 // Datastore implements datastore.Interface using only v2 repositories.
 type Datastore struct {
 	manager      v2.Manager
@@ -145,14 +132,13 @@ type Datastore struct {
 	// classify Perch v2 (FSD50K) sound classes without a data race.
 	nonBirdLabelTypeIDs map[nonbird.Category]uint
 
-	// names holds the species name lookup maps behind an atomic.Pointer
-	// for lock-free reads and atomic swaps when locale changes.
-	names atomic.Pointer[nameMaps]
-
-	// nameResolver, when set, is the authoritative localized name source shared
-	// with the classifier orchestrator. It overrides the label-derived maps and
-	// resolves historic out-of-working-set species via on-demand lookup.
-	nameResolver atomic.Pointer[datastore.SpeciesNameResolver]
+	// names owns the species-name lookup index (the forward display and reverse
+	// search maps plus the authoritative resolver) behind an atomic snapshot for
+	// lock-free reads and atomic swaps on locale or model change. Set once in New;
+	// a nil value (a bare-struct test) is treated as an empty index by the
+	// accessors below, preserving the zero-value safety of the previous
+	// atomic.Pointer fields it replaced.
+	names *speciesindex.Service
 
 	// speciesCodeMap provides O(1) lookup from scientific name to eBird species code.
 	// Populated from the eBird taxonomy data passed via Config.SpeciesCodeMap.
@@ -310,11 +296,6 @@ func New(cfg *Config) (*Datastore, error) {
 		tz = time.Local
 	}
 
-	// Build species name maps from labels. The OpenFauna resolver is injected
-	// later via SetNameResolver (it is owned by the orchestrator, constructed
-	// separately), so the maps are localized on the first post-wiring rebuild.
-	nm := buildNameMaps(cfg.Labels, nil)
-
 	// Use species code map from taxonomy data (injected via config).
 	speciesCodeMap := cfg.SpeciesCodeMap
 	if speciesCodeMap == nil {
@@ -342,8 +323,13 @@ func New(cfg *Config) (*Datastore, error) {
 		nonBirdLabelTypeIDs: nonBirdLabelTypeIDs,
 		speciesCodeMap:      speciesCodeMap,
 		dbCounters:          dbCounters,
+		names:               speciesindex.New(nil),
 	}
-	ds.names.Store(nm)
+
+	// Build the species-name maps from labels. The OpenFauna resolver is injected
+	// later via SetNameResolver (owned by the orchestrator, constructed
+	// separately), so the maps are localized on the first post-wiring rebuild.
+	ds.names.Rebuild(cfg.Labels, "")
 
 	// Start periodic WAL checkpoint for SQLite to prevent unbounded WAL growth.
 	// The auto-checkpoint mechanism may not fire reliably with connection pooling.
@@ -354,44 +340,12 @@ func New(cfg *Config) (*Datastore, error) {
 	return ds, nil
 }
 
-// buildNameMaps parses BirdNET labels ("ScientificName_CommonName" format)
-// into lookup maps for common<->scientific name resolution.
-// When resolver is non-nil, each label's common name is overridden by the
-// resolver (authoritative/localized); labels the resolver does not cover keep
-// their embedded common name. This keeps the reverse (search) maps consistent
-// with what resolveCommonName displays.
-func buildNameMaps(labels []string, resolver datastore.SpeciesNameResolver) *nameMaps {
-	speciesMap := make(map[string]string, len(labels))
-	commonMap := make(map[string]string, len(labels))
-	commonFoldedMap := make(map[string]string, len(labels))
-	// Ambiguous reverse keys are deleted, not last-writer-wins: an ambiguous common
-	// name must fall through to substring search (which returns all matches) rather
-	// than route to an arbitrary species.
-	ambiguous := make(map[string]struct{})
-	for _, sn := range datastore.ResolveLabelNames(labels, resolver) {
-		commonMap[sn.Scientific] = sn.Common
-		folded := strings.ToLower(norm.NFC.String(sn.Common))
-		commonFoldedMap[sn.Scientific] = folded
-
-		if _, seen := ambiguous[folded]; seen {
-			continue
-		}
-		if existing, exists := speciesMap[folded]; exists && existing != sn.Scientific {
-			ambiguous[folded] = struct{}{}
-			delete(speciesMap, folded)
-			continue
-		}
-		speciesMap[folded] = sn.Scientific
-	}
-	return &nameMaps{common: commonMap, commonFolded: commonFoldedMap, species: speciesMap}
-}
-
 // UpdateNameMaps rebuilds species name lookup maps from updated BirdNET labels.
 // Called after locale or model changes to keep common name resolution current.
 // The new maps are built first, then atomically swapped in - readers are never blocked.
 // Also resets the missing-name warning deduplication so new mismatches are logged.
 func (ds *Datastore) UpdateNameMaps(labels []string) {
-	ds.names.Store(buildNameMaps(labels, ds.loadNameResolver()))
+	ds.names.Rebuild(labels, "")
 	ds.loggedMissingNames.Clear()
 }
 
@@ -399,18 +353,15 @@ func (ds *Datastore) UpdateNameMaps(labels []string) {
 // the classifier orchestrator. Safe to call concurrently with reads; a nil
 // resolver is ignored.
 func (ds *Datastore) SetNameResolver(r datastore.SpeciesNameResolver) {
-	if datastore.IsNilResolver(r) {
-		return
-	}
-	ds.nameResolver.Store(&r)
+	ds.names.SetResolver(r)
 }
 
 // loadNameResolver returns the installed resolver, or nil if none has been set.
 func (ds *Datastore) loadNameResolver() datastore.SpeciesNameResolver {
-	if p := ds.nameResolver.Load(); p != nil {
-		return *p
+	if ds.names == nil {
+		return nil
 	}
-	return nil
+	return ds.names.Resolver()
 }
 
 // Open is a no-op since the manager is already open.
@@ -419,26 +370,22 @@ func (ds *Datastore) Open() error {
 }
 
 // loadNameMaps returns the current name maps. Always returns a non-nil value.
-func (ds *Datastore) loadNameMaps() *nameMaps {
-	if m := ds.names.Load(); m != nil {
-		return m
+func (ds *Datastore) loadNameMaps() *speciesindex.Snapshot {
+	if ds.names == nil {
+		return speciesindex.Empty()
 	}
-	return &nameMaps{
-		common:       make(map[string]string),
-		commonFolded: make(map[string]string),
-		species:      make(map[string]string),
-	}
+	return ds.names.Snapshot()
 }
 
 // filterLookupDeps builds the dependency set used by repository filter resolution (species and
 // device lookups, plus common-name search via the active-locale name maps).
 func (ds *Datastore) filterLookupDeps() *repository.FilterLookupDeps {
-	nm := ds.loadNameMaps()
+	snap := ds.loadNameMaps()
 	return &repository.FilterLookupDeps{
 		LabelRepo:         ds.label,
 		SourceRepo:        ds.source,
-		SciToCommon:       nm.common,
-		SciToCommonFolded: nm.commonFolded,
+		SciToCommon:       snap.SciToCommon,
+		SciToCommonFolded: snap.SciToCommonFolded,
 	}
 }
 
@@ -3732,8 +3679,8 @@ func (ds *Datastore) resolveCommonName(scientificName string) string {
 			return name
 		}
 	}
-	nm := ds.loadNameMaps()
-	if cn, ok := nm.common[sciName]; ok {
+	snap := ds.loadNameMaps()
+	if cn, ok := snap.SciToCommon[sciName]; ok {
 		return cn
 	}
 	// Log once per missing species when maps are populated (not during startup with empty maps).
@@ -3743,11 +3690,11 @@ func (ds *Datastore) resolveCommonName(scientificName string) string {
 	// Guard ds.log: it may be nil when the datastore is constructed without a logger,
 	// matching the other logging sites in this file. Skipping the LoadOrStore when there
 	// is no logger is harmless: the dedup set only exists to rate-limit this log line.
-	if ds.log != nil && len(nm.common) > 0 {
+	if ds.log != nil && len(snap.SciToCommon) > 0 {
 		if _, alreadyLogged := ds.loggedMissingNames.LoadOrStore(sciName, struct{}{}); !alreadyLogged {
 			ds.log.Info("common name not found in name maps, falling back to scientific name",
 				logger.String("scientific_name", sciName),
-				logger.Int("name_map_size", len(nm.common)))
+				logger.Int("name_map_size", len(snap.SciToCommon)))
 		}
 	}
 	return sciName
@@ -3758,8 +3705,8 @@ func (ds *Datastore) resolveCommonName(scientificName string) string {
 // Uses the pre-built species name map (lowercase common name → scientific name).
 // Falls back to the input unchanged if no mapping is found.
 func (ds *Datastore) resolveToScientificName(name string) string {
-	normalized := strings.ToLower(norm.NFC.String(strings.TrimSpace(name)))
-	species := ds.loadNameMaps().species
+	normalized := speciesindex.Fold(strings.TrimSpace(name))
+	species := ds.loadNameMaps().CommonToSci
 	if sci, ok := species[normalized]; ok {
 		return sci
 	}

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -136,8 +136,8 @@ type Datastore struct {
 	// search maps plus the authoritative resolver) behind an atomic snapshot for
 	// lock-free reads and atomic swaps on locale or model change. Set once in New;
 	// a nil value (a bare-struct test) is treated as an empty index by the
-	// accessors below, preserving the zero-value safety of the previous
-	// atomic.Pointer fields it replaced.
+	// accessors and mutators below, preserving the zero-value safety of the
+	// previous atomic.Pointer fields it replaced.
 	names *speciesindex.Service
 
 	// speciesCodeMap provides O(1) lookup from scientific name to eBird species code.
@@ -345,6 +345,9 @@ func New(cfg *Config) (*Datastore, error) {
 // The new maps are built first, then atomically swapped in - readers are never blocked.
 // Also resets the missing-name warning deduplication so new mismatches are logged.
 func (ds *Datastore) UpdateNameMaps(labels []string) {
+	if ds.names == nil {
+		return
+	}
 	ds.names.Rebuild(labels, "")
 	ds.loggedMissingNames.Clear()
 }
@@ -353,6 +356,9 @@ func (ds *Datastore) UpdateNameMaps(labels []string) {
 // the classifier orchestrator. Safe to call concurrently with reads; a nil
 // resolver is ignored.
 func (ds *Datastore) SetNameResolver(r datastore.SpeciesNameResolver) {
+	if ds.names == nil {
+		return
+	}
 	ds.names.SetResolver(r)
 }
 

--- a/internal/datastore/v2only/datastore_nameresolver_test.go
+++ b/internal/datastore/v2only/datastore_nameresolver_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/openfauna"
+	"github.com/tphakala/birdnet-go/internal/speciesindex"
 )
 
 // fakeResolver is a minimal datastore.SpeciesNameResolver for tests.
@@ -20,8 +21,11 @@ func (f fakeResolver) ResolveLocal(sci string) (string, bool) {
 }
 
 func TestResolveCommonName_ResolverOverridesLabelMap(t *testing.T) {
-	ds := &Datastore{log: logger.NewConsoleLogger("v2only_test", logger.LogLevelError)}
-	ds.names.Store(buildNameMaps([]string{"Turdus merula_LabelName"}, nil))
+	ds := &Datastore{
+		log:   logger.NewConsoleLogger("v2only_test", logger.LogLevelError),
+		names: speciesindex.New(nil),
+	}
+	ds.names.Rebuild([]string{"Turdus merula_LabelName"}, "")
 
 	// Without a resolver: the label map wins.
 	assert.Equal(t, "LabelName", ds.resolveCommonName("Turdus merula"))
@@ -41,8 +45,11 @@ func TestResolveCommonName_RealOpenFaunaOverrides(t *testing.T) {
 	r := openfauna.NewResolver()
 	require.NoError(t, r.Rebuild([]string{"Turdus merula"}, "en"))
 
-	ds := &Datastore{log: logger.NewConsoleLogger("v2only_test", logger.LogLevelError)}
-	ds.names.Store(buildNameMaps([]string{"Turdus merula_WRONG"}, nil))
+	ds := &Datastore{
+		log:   logger.NewConsoleLogger("v2only_test", logger.LogLevelError),
+		names: speciesindex.New(nil),
+	}
+	ds.names.Rebuild([]string{"Turdus merula_WRONG"}, "")
 	ds.SetNameResolver(r)
 
 	got := ds.resolveCommonName("Turdus merula")
@@ -50,24 +57,7 @@ func TestResolveCommonName_RealOpenFaunaOverrides(t *testing.T) {
 	assert.NotEmpty(t, got)
 }
 
-func TestBuildNameMaps_ScientificOnlyLabelSearchable(t *testing.T) {
-	// Scientific-only labels (no "_", e.g. Perch v2 / bats) become searchable when
-	// the resolver supplies a common name.
-	nm := buildNameMaps([]string{"Myotis myotis"},
-		fakeResolver{m: map[string]string{"Myotis myotis": "Mustakorvayokko"}})
-	assert.Equal(t, "Mustakorvayokko", nm.common["Myotis myotis"])
-	assert.Equal(t, "Myotis myotis", nm.species["mustakorvayokko"])
-
-	// Without a resolver, a scientific-only label has no common name and is skipped.
-	bare := buildNameMaps([]string{"Myotis myotis"}, nil)
-	_, ok := bare.common["Myotis myotis"]
-	assert.False(t, ok)
-}
-
-func TestBuildNameMaps_ResolverLocalizesReverseMap(t *testing.T) {
-	// The reverse (search) maps must carry the localized name so search matches display.
-	nm := buildNameMaps([]string{"Turdus merula_LabelName"},
-		fakeResolver{m: map[string]string{"Turdus merula": "Mustarastas"}})
-	assert.Equal(t, "Mustarastas", nm.common["Turdus merula"])
-	assert.Equal(t, "Turdus merula", nm.species["mustarastas"])
-}
+// Note: the name-map construction behaviors previously exercised here through
+// buildNameMaps directly (scientific-only labels searchable via a resolver, and
+// resolver-localized reverse maps) now live in internal/speciesindex, where the
+// shared builder is owned and golden-tested.

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -1835,50 +1835,11 @@ func TestV2OnlyDatastore_UpdateNameMaps_ConcurrentAccess(t *testing.T) {
 	wg.Wait()
 }
 
-// batchFakeResolver misses ResolveLocal (the cold-path branch) and resolves only via the
-// batch seam, like the real resolver does for out-of-working-set bats.
-type batchFakeResolver struct{ batch map[string]string }
-
-func (b *batchFakeResolver) Resolve(string, string) string      { return "" }
-func (b *batchFakeResolver) ResolveLocal(string) (string, bool) { return "", false }
-func (b *batchFakeResolver) ResolveLocalizedBatch(names []string) map[string]string {
-	out := make(map[string]string, len(names))
-	for _, n := range names {
-		if v, ok := b.batch[n]; ok {
-			out[n] = v
-		}
-	}
-	return out
-}
-
-func TestBuildNameMaps_SecondaryModelScientificOnlyLabelIsReverseSearchable(t *testing.T) {
-	t.Parallel()
-
-	r := &batchFakeResolver{batch: map[string]string{"Barbastella barbastellus": "mopsilepakko"}}
-	nm := buildNameMaps([]string{"Barbastella barbastellus"}, r)
-
-	// Reverse exact map is NFC-folded, lowercased.
-	assert.Equal(t, "Barbastella barbastellus", nm.species["mopsilepakko"])
-	// Forward + substring maps present too.
-	assert.Equal(t, "mopsilepakko", nm.common["Barbastella barbastellus"])
-	assert.Equal(t, "mopsilepakko", nm.commonFolded["Barbastella barbastellus"])
-}
-
-func TestBuildNameMaps_AmbiguousCommonNameDeletedNotLastWriterWins(t *testing.T) {
-	t.Parallel()
-
-	// Two scientific names sharing one common name must not silently route to an
-	// arbitrary winner; the ambiguous reverse key is dropped.
-	nm := buildNameMaps([]string{"Strix aluco_Owl", "Bubo bubo_Owl"}, nil)
-	_, ok := nm.species["owl"]
-	assert.False(t, ok, "ambiguous common name must be deleted from the exact reverse map")
-
-	// The forward display maps must still contain both species so their common names
-	// are shown correctly in the UI. Ambiguity handling must only drop the reverse
-	// lookup key, not the forward display names.
-	assert.Equal(t, "Owl", nm.common["Strix aluco"], "forward map must retain common name for Strix aluco")
-	assert.Equal(t, "Owl", nm.common["Bubo bubo"], "forward map must retain common name for Bubo bubo")
-}
+// Note: the name-map builder behaviors previously exercised here through
+// buildNameMaps directly (scientific-only labels reverse-searchable via the batch
+// seam, and the ambiguous-common-name drop) now live in internal/speciesindex,
+// where the shared builder is owned and golden-tested against both former
+// builders.
 
 // TestUnixTimeOrZero verifies that a non-positive epoch yields the zero time (so the
 // API renders an empty timestamp) instead of the 1970 epoch origin, while a positive

--- a/internal/speciesindex/bench_test.go
+++ b/internal/speciesindex/bench_test.go
@@ -1,0 +1,15 @@
+package speciesindex
+
+import "testing"
+
+// BenchmarkBuild measures a full snapshot build (name maps plus the additive
+// canonical memo) over the v2.4 corpus, so the memo's per-label CanonicalName
+// cost is visible. Rebuilds run only on model load/unload/reload and locale
+// change, so this cost is off the request path.
+func BenchmarkBuild(b *testing.B) {
+	labels := loadCorpus(b)
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = Build(labels, nil, "en")
+	}
+}

--- a/internal/speciesindex/doc.go
+++ b/internal/speciesindex/doc.go
@@ -1,0 +1,27 @@
+// Package speciesindex is the single builder and owner of the process-wide
+// species-name lookup index. It folds the two historically duplicated
+// name-map builders (internal/datastore/v2only and internal/api/v2) into one
+// leaf package so their forward display (scientific -> common) and reverse
+// search (common -> scientific) stay in lockstep by construction.
+//
+// A Snapshot is an immutable set of maps built once from a label list and a
+// name resolver. It carries the three name maps the two builders produced,
+// byte for byte, plus a set of memo maps (canonical key per label, labels per
+// canonical key, label per scientific name) computed once at build time so no
+// request path ever calls openfauna.CanonicalName per label.
+//
+// A Service owns the current Snapshot behind an atomic.Pointer for lock-free
+// reads. Rebuild swaps in a new Snapshot under a build mutex, outside every
+// caller lock; Snapshot returns the current one and is never nil (Empty before
+// the first Rebuild). Rebuilds run only on model load, unload, reload and
+// locale change, so the extra memo cost is paid off the request path.
+//
+// Ownership is transitional in Phase 1: the datastore and the api/v2 facade
+// each own their own Service, exactly reproducing today's two independent
+// builds. Phase 2a replaces both with a single orchestrator-owned Service.
+//
+// This package imports only leaf packages (internal/datastore,
+// internal/detection, internal/openfauna); it must never import
+// internal/classifier, any internal/api package, or internal/analysis, so it
+// stays importable from every one of them. import_guard_test.go enforces this.
+package speciesindex

--- a/internal/speciesindex/doc.go
+++ b/internal/speciesindex/doc.go
@@ -5,9 +5,9 @@
 // search (common -> scientific) stay in lockstep by construction.
 //
 // A Snapshot is an immutable set of maps built once from a label list and a
-// name resolver. It carries the three name maps the two builders produced,
-// byte for byte, plus a set of memo maps (canonical key per label, labels per
-// canonical key, label per scientific name) computed once at build time so no
+// name resolver. It carries the three name maps the two builders produced, with
+// identical contents, plus a set of memo maps (canonical key per label, labels
+// per canonical key, label per scientific name) computed once at build time so no
 // request path ever calls openfauna.CanonicalName per label.
 //
 // A Service owns the current Snapshot behind an atomic.Pointer for lock-free

--- a/internal/speciesindex/fold.go
+++ b/internal/speciesindex/fold.go
@@ -1,0 +1,20 @@
+package speciesindex
+
+import (
+	"strings"
+
+	"golang.org/x/text/unicode/norm"
+)
+
+// Fold normalizes a species name for case-insensitive lookup: NFC normalization
+// followed by lower-casing. It is the single fold used for every species-name
+// search key in the process, so composed and decomposed accents (for example a
+// precomposed "é" and an "e" plus combining acute) collapse to the same key and
+// forward display and reverse search never disagree on normalization.
+//
+// This is the exact expression both legacy name-map builders used
+// (strings.ToLower(norm.NFC.String(s))); the datastore inlined it and api/v2
+// reached it through apicore.NormalizeForLookup, which now delegates here.
+func Fold(s string) string {
+	return strings.ToLower(norm.NFC.String(s))
+}

--- a/internal/speciesindex/fold.go
+++ b/internal/speciesindex/fold.go
@@ -7,10 +7,12 @@ import (
 )
 
 // Fold normalizes a species name for case-insensitive lookup: NFC normalization
-// followed by lower-casing. It is the single fold used for every species-name
-// search key in the process, so composed and decomposed accents (for example a
-// precomposed "é" and an "e" plus combining acute) collapse to the same key and
-// forward display and reverse search never disagree on normalization.
+// followed by lower-casing. It is the canonical fold for species-name search
+// keys: the speciesindex name maps, apicore.NormalizeForLookup and the datastore
+// name maps all route through it, so composed and decomposed accents (for example
+// a precomposed "é" and an "e" plus combining acute) collapse to the same key and
+// forward display and reverse search agree on normalization. Any new search-key
+// site should call Fold rather than re-inline the expression.
 //
 // This is the exact expression both legacy name-map builders used
 // (strings.ToLower(norm.NFC.String(s))); the datastore inlined it and api/v2

--- a/internal/speciesindex/fold_test.go
+++ b/internal/speciesindex/fold_test.go
@@ -1,0 +1,59 @@
+package speciesindex
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/text/unicode/norm"
+)
+
+func TestFold(t *testing.T) {
+	t.Parallel()
+
+	// Composed "é" (U+00E9) vs decomposed "e"+U+0301 must fold to the same
+	// key. decomposed is derived via NFD so it is genuinely "e"+combining-acute
+	// regardless of how this source file is normalized on disk.
+	const composed = "éire" // precomposed e-acute + "ire"
+	decomposed := norm.NFD.String(composed)
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"mixed case", "Tawny Owl", "tawny owl"},
+		{"already folded", "great tit", "great tit"},
+		{"composed accent", composed, "éire"},
+		{"decomposed accent normalizes", decomposed, "éire"},
+		{"leading trailing space preserved", " Owl ", " owl "},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, Fold(tt.in))
+		})
+	}
+
+	// Composed and decomposed forms fold identically.
+	assert.Equal(t, Fold(composed), Fold(decomposed))
+	// Sanity: the two inputs are genuinely different byte sequences.
+	assert.NotEqual(t, composed, decomposed)
+}
+
+// TestFold_MatchesReferenceOverCorpus round-trips Fold against the exact
+// expression it replaces, over every common name in the v2.4 corpus.
+func TestFold_MatchesReferenceOverCorpus(t *testing.T) {
+	t.Parallel()
+
+	for _, label := range loadCorpus(t) {
+		_, common, ok := strings.Cut(label, "_")
+		if !ok {
+			continue
+		}
+		common = strings.TrimSpace(common)
+		want := strings.ToLower(norm.NFC.String(common))
+		assert.Equal(t, want, Fold(common), "label %q", label)
+	}
+}

--- a/internal/speciesindex/golden_test.go
+++ b/internal/speciesindex/golden_test.go
@@ -1,0 +1,100 @@
+package speciesindex
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/openfauna"
+)
+
+// assertMatchesLegacy asserts Build's three name maps equal both frozen legacy
+// builders' output for the same inputs.
+func assertMatchesLegacy(t *testing.T, labels []string, resolver datastore.SpeciesNameResolver) {
+	t.Helper()
+	got := Build(labels, resolver, "")
+	for _, ref := range []struct {
+		name  string
+		build func([]string, datastore.SpeciesNameResolver) legacyMaps
+	}{
+		{"datastore", legacyDatastoreBuild},
+		{"api", legacyAPIBuild},
+	} {
+		want := ref.build(labels, resolver)
+		assert.Equalf(t, want.sciToCommon, got.SciToCommon, "SciToCommon vs legacy %s", ref.name)
+		assert.Equalf(t, want.sciToCommonFolded, got.SciToCommonFolded, "SciToCommonFolded vs legacy %s", ref.name)
+		assert.Equalf(t, want.commonToSci, got.CommonToSci, "CommonToSci vs legacy %s", ref.name)
+	}
+}
+
+func TestBuild_ThreeMaps_GoldenAgainstLegacyBuilders(t *testing.T) {
+	t.Parallel()
+
+	corpus := loadCorpus(t)
+	perch := loadTestdata(t, "perch_like_labels.txt")
+	bat := loadTestdata(t, "bat_like_labels.txt")
+	all := make([]string, 0, len(corpus)+len(perch)+len(bat))
+	all = append(all, corpus...)
+	all = append(all, perch...)
+	all = append(all, bat...)
+
+	corpora := []struct {
+		name   string
+		labels []string
+	}{
+		{"v2.4_en_uk", corpus},
+		{"perch_like", perch},
+		{"bat_like", bat},
+		{"concatenated", all},
+	}
+
+	// A few localized overrides so the ResolveLocal hit and miss branches both fire.
+	local := localResolver{m: map[string]string{
+		"Turdus merula":      "Localized Blackbird",
+		"Myotis daubentonii": "Localized Water Bat",
+		"Passer domesticus":  "Localized Sparrow",
+	}}
+
+	resolvers := []struct {
+		name string
+		r    datastore.SpeciesNameResolver
+	}{
+		{"nil", nil},
+		{"local_only", local},
+		{"batch_localizer", batchAllResolver{}},
+	}
+
+	for _, c := range corpora {
+		for _, rv := range resolvers {
+			t.Run(c.name+"/"+rv.name, func(t *testing.T) {
+				t.Parallel()
+				assertMatchesLegacy(t, c.labels, rv.r)
+			})
+		}
+	}
+}
+
+// TestBuild_RealOpenFauna_GoldenEquality runs the full builder against a real
+// OpenFauna resolver (including its batch-localizer path) for two locales, and
+// asserts equality with both legacy copies. Skipped under -short because it
+// rebuilds the OpenFauna working set. Dataset refreshes cannot break it because
+// both sides see the same dataset.
+func TestBuild_RealOpenFauna_GoldenEquality(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping real OpenFauna golden equality in -short mode")
+	}
+	t.Parallel()
+
+	corpus := loadCorpus(t)
+	sci := corpusScientificNames(corpus)
+
+	for _, locale := range []string{"en", "fi"} {
+		t.Run(locale, func(t *testing.T) {
+			t.Parallel()
+			r := openfauna.NewResolver()
+			require.NoError(t, r.Rebuild(sci, locale))
+			assertMatchesLegacy(t, corpus, r)
+		})
+	}
+}

--- a/internal/speciesindex/helpers_test.go
+++ b/internal/speciesindex/helpers_test.go
@@ -1,0 +1,121 @@
+package speciesindex
+
+import (
+	"encoding/json"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/openfauna"
+)
+
+// v2.4 corpus embedded by the classifier; read at test time rather than importing
+// classifier (which would pull the cgo inference backends into this leaf test
+// binary) or duplicating ~250 KB under testdata. A missing file is a hard failure.
+const corpusPath = "../classifier/data/labels/V2.4/BirdNET_GLOBAL_6K_V2.4_Labels_en_uk.txt"
+
+// readLabelFile loads a newline-separated label file, trimming a trailing CR per
+// line and dropping blank lines. A missing file fails the test.
+func readLabelFile(tb testing.TB, path string) []string {
+	tb.Helper()
+	data, err := os.ReadFile(path) //nolint:gosec // fixed test paths, no user input
+	require.NoErrorf(tb, err, "label file %s must be present", path)
+	lines := strings.Split(string(data), "\n")
+	out := make([]string, 0, len(lines))
+	for _, l := range lines {
+		l = strings.TrimSuffix(l, "\r")
+		if strings.TrimSpace(l) == "" {
+			continue
+		}
+		out = append(out, l)
+	}
+	return out
+}
+
+// loadCorpus returns the 6522-label v2.4 en_uk corpus.
+func loadCorpus(tb testing.TB) []string {
+	tb.Helper()
+	return readLabelFile(tb, corpusPath)
+}
+
+// loadTestdata returns a synthetic label fixture from testdata/.
+func loadTestdata(tb testing.TB, name string) []string {
+	tb.Helper()
+	return readLabelFile(tb, filepath.Join("testdata", name))
+}
+
+// corpusScientificNames extracts the deduplicated scientific-name column of a
+// label list (for seeding a real OpenFauna resolver working set).
+func corpusScientificNames(labels []string) []string {
+	seen := make(map[string]struct{}, len(labels))
+	out := make([]string, 0, len(labels))
+	for _, l := range labels {
+		sci, _, _ := strings.Cut(l, "_")
+		sci = strings.TrimSpace(sci)
+		if sci == "" {
+			continue
+		}
+		if _, dup := seen[sci]; dup {
+			continue
+		}
+		seen[sci] = struct{}{}
+		out = append(out, sci)
+	}
+	return out
+}
+
+// localResolver satisfies datastore.SpeciesNameResolver from an in-memory map,
+// serving names only for scientific names resident in that map (ResolveLocal).
+type localResolver struct{ m map[string]string }
+
+func (r localResolver) Resolve(sci, _ string) string { return r.m[sci] }
+func (r localResolver) ResolveLocal(sci string) (string, bool) {
+	v, ok := r.m[sci]
+	return v, ok
+}
+
+// batchAllResolver never resolves locally, so every scientific-only label falls
+// to the cold-path batch localizer, which it satisfies for every requested name.
+// This exercises the batchLocalizer seam in ResolveLabelNames.
+type batchAllResolver struct{}
+
+func (batchAllResolver) Resolve(string, string) string      { return "" }
+func (batchAllResolver) ResolveLocal(string) (string, bool) { return "", false }
+func (batchAllResolver) ResolveLocalizedBatch(names []string) map[string]string {
+	out := make(map[string]string, len(names))
+	for _, n := range names {
+		out[n] = "batch " + n
+	}
+	return out
+}
+
+// firstAliasPair returns a (legacy, canonical) taxonomic-alias pair read from the
+// openfauna dataset at test time, where CanonicalName(legacy) == canonical and
+// canonical is its own canonical. Picked from the data rather than hard-coded so a
+// dataset refresh cannot silently invalidate the memo/alias tests.
+func firstAliasPair(tb testing.TB) (legacy, canonical string) {
+	tb.Helper()
+	data, err := os.ReadFile("../openfauna/data/aliases.json") //nolint:gosec // fixed test path
+	require.NoError(tb, err)
+	var m map[string]string
+	require.NoError(tb, json.Unmarshal(data, &m))
+	require.NotEmpty(tb, m, "alias dataset must not be empty")
+
+	keys := slices.Collect(maps.Keys(m))
+	slices.Sort(keys) // deterministic pick
+	for _, k := range keys {
+		c := m[k]
+		if k == c {
+			continue
+		}
+		if openfauna.CanonicalName(k) == c && openfauna.CanonicalName(c) == c {
+			return k, c
+		}
+	}
+	tb.Fatalf("no usable alias pair found in openfauna dataset")
+	return "", ""
+}

--- a/internal/speciesindex/import_guard_test.go
+++ b/internal/speciesindex/import_guard_test.go
@@ -1,0 +1,84 @@
+package speciesindex
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+)
+
+// goListTimeout bounds the nested `go list` so the guard fails fast rather than
+// hanging if the toolchain stalls. Resolving an already-built package's deps is
+// sub-second, so this is generous headroom.
+const goListTimeout = 60 * time.Second
+
+// speciesindexPkg is the import path of the package under test.
+const speciesindexPkg = "github.com/tphakala/birdnet-go/internal/speciesindex"
+
+// forbiddenPrefixes are import paths speciesindex must never pull in, so it stays
+// a leaf importable from classifier, api/v2 and analysis without a cycle. Only
+// leaf packages (datastore, detection, openfauna) are allowed.
+var forbiddenImports = []struct {
+	label string
+	match func(dep string) bool
+}{
+	{"internal/classifier", func(d string) bool {
+		return d == "github.com/tphakala/birdnet-go/internal/classifier" ||
+			strings.HasPrefix(d, "github.com/tphakala/birdnet-go/internal/classifier/")
+	}},
+	{"internal/api", func(d string) bool {
+		return strings.HasPrefix(d, "github.com/tphakala/birdnet-go/internal/api/")
+	}},
+	{"internal/analysis", func(d string) bool {
+		return d == "github.com/tphakala/birdnet-go/internal/analysis" ||
+			strings.HasPrefix(d, "github.com/tphakala/birdnet-go/internal/analysis/")
+	}},
+}
+
+// listDeps returns the transitive non-test import paths of pkg via `go list
+// -deps`. Non-test scope is exactly right: the rule is about the production build
+// graph (a test importing a heavier package cannot form a production cycle). It
+// skips when the toolchain is absent and fails on a present-but-failing one.
+func listDeps(t *testing.T, pkg string) []string {
+	t.Helper()
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skipf("go toolchain not available, skipping import guard: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), goListTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "go", "list", "-deps", pkg).Output() //nolint:gosec // fixed args, no user input
+	if err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			require.Failf(t, "go list timed out",
+				"go list -deps %s did not finish within %s", pkg, goListTimeout)
+		}
+		var exitErr *exec.ExitError
+		var stderr []byte
+		if errors.As(err, &exitErr) {
+			stderr = exitErr.Stderr
+		}
+		require.NoErrorf(t, err, "go list -deps %s failed: %s", pkg, stderr)
+	}
+	return strings.Fields(string(out))
+}
+
+// TestSpeciesindexImportsOnlyLeafPackages asserts speciesindex transitively
+// imports no classifier, api, or analysis package, so it remains importable from
+// all of them without closing a dependency cycle.
+func TestSpeciesindexImportsOnlyLeafPackages(t *testing.T) {
+	t.Parallel()
+
+	for _, dep := range listDeps(t, speciesindexPkg) {
+		for _, f := range forbiddenImports {
+			assert.Falsef(t, f.match(dep),
+				"speciesindex must not import %s (%s): it must stay a leaf package importable from classifier/api/analysis",
+				dep, f.label)
+		}
+	}
+}

--- a/internal/speciesindex/import_guard_test.go
+++ b/internal/speciesindex/import_guard_test.go
@@ -34,7 +34,8 @@ var forbiddenImports = []struct {
 			strings.HasPrefix(d, "github.com/tphakala/birdnet-go/internal/classifier/")
 	}},
 	{"internal/api", func(d string) bool {
-		return strings.HasPrefix(d, "github.com/tphakala/birdnet-go/internal/api/")
+		return d == "github.com/tphakala/birdnet-go/internal/api" ||
+			strings.HasPrefix(d, "github.com/tphakala/birdnet-go/internal/api/")
 	}},
 	{"internal/analysis", func(d string) bool {
 		return d == "github.com/tphakala/birdnet-go/internal/analysis" ||

--- a/internal/speciesindex/import_guard_test.go
+++ b/internal/speciesindex/import_guard_test.go
@@ -21,9 +21,10 @@ const goListTimeout = 60 * time.Second
 // speciesindexPkg is the import path of the package under test.
 const speciesindexPkg = "github.com/tphakala/birdnet-go/internal/speciesindex"
 
-// forbiddenPrefixes are import paths speciesindex must never pull in, so it stays
-// a leaf importable from classifier, api/v2 and analysis without a cycle. Only
-// leaf packages (datastore, detection, openfauna) are allowed.
+// forbiddenImports are the import groups speciesindex must never pull in, so it
+// stays a leaf importable from classifier, api/v2 and analysis without a cycle.
+// This is a denylist: it asserts the absence of these groups, not a positive
+// allowlist of every permitted package.
 var forbiddenImports = []struct {
 	label string
 	match func(dep string) bool

--- a/internal/speciesindex/legacy_builders_test.go
+++ b/internal/speciesindex/legacy_builders_test.go
@@ -1,0 +1,77 @@
+package speciesindex
+
+import (
+	"strings"
+
+	"golang.org/x/text/unicode/norm"
+
+	"github.com/tphakala/birdnet-go/internal/datastore"
+)
+
+// This file freezes the two legacy name-map builders as they existed before the
+// speciesindex fold, so the golden tests assert Build reproduces them byte for
+// byte. These are verbatim copies of internal/datastore/v2only.buildNameMaps and
+// internal/api/v2.buildNameMaps, with their folds inlined to the same expression
+// (strings.ToLower(norm.NFC.String(...))) they both used (the api/v2 side reached
+// it via apicore.NormalizeForLookup). Do not "simplify" them to call Fold: the
+// point of the reference is that it is independent of the code under test.
+
+// legacyMaps is the three-map product both builders returned.
+type legacyMaps struct {
+	sciToCommon       map[string]string
+	sciToCommonFolded map[string]string
+	commonToSci       map[string]string
+}
+
+// legacyDatastoreBuild is the verbatim internal/datastore/v2only.buildNameMaps.
+//
+//nolint:dupl // deliberately a verbatim frozen copy; it must stay independent of legacyAPIBuild and of Build so the golden test proves both original sites produced identical maps.
+func legacyDatastoreBuild(labels []string, resolver datastore.SpeciesNameResolver) legacyMaps {
+	speciesMap := make(map[string]string, len(labels))
+	commonMap := make(map[string]string, len(labels))
+	commonFoldedMap := make(map[string]string, len(labels))
+	ambiguous := make(map[string]struct{})
+	for _, sn := range datastore.ResolveLabelNames(labels, resolver) {
+		commonMap[sn.Scientific] = sn.Common
+		folded := strings.ToLower(norm.NFC.String(sn.Common))
+		commonFoldedMap[sn.Scientific] = folded
+
+		if _, seen := ambiguous[folded]; seen {
+			continue
+		}
+		if existing, exists := speciesMap[folded]; exists && existing != sn.Scientific {
+			ambiguous[folded] = struct{}{}
+			delete(speciesMap, folded)
+			continue
+		}
+		speciesMap[folded] = sn.Scientific
+	}
+	return legacyMaps{sciToCommon: commonMap, sciToCommonFolded: commonFoldedMap, commonToSci: speciesMap}
+}
+
+// legacyAPIBuild is the verbatim internal/api/v2.buildNameMaps, with the fold
+// (apicore.NormalizeForLookup) inlined to the expression it evaluated to.
+//
+//nolint:dupl // deliberately a verbatim frozen copy; it must stay independent of legacyDatastoreBuild and of Build so the golden test proves both original sites produced identical maps.
+func legacyAPIBuild(labels []string, resolver datastore.SpeciesNameResolver) legacyMaps {
+	sciToCommon := make(map[string]string, len(labels))
+	sciToCommonFolded := make(map[string]string, len(labels))
+	commonToSci := make(map[string]string, len(labels))
+	ambiguous := make(map[string]struct{})
+	for _, sn := range datastore.ResolveLabelNames(labels, resolver) {
+		sciToCommon[sn.Scientific] = sn.Common
+
+		key := strings.ToLower(norm.NFC.String(sn.Common))
+		sciToCommonFolded[sn.Scientific] = key
+		if _, seen := ambiguous[key]; seen {
+			continue
+		}
+		if existing, exists := commonToSci[key]; exists && existing != sn.Scientific {
+			ambiguous[key] = struct{}{}
+			delete(commonToSci, key)
+			continue
+		}
+		commonToSci[key] = sn.Scientific
+	}
+	return legacyMaps{sciToCommon: sciToCommon, sciToCommonFolded: sciToCommonFolded, commonToSci: commonToSci}
+}

--- a/internal/speciesindex/legacy_builders_test.go
+++ b/internal/speciesindex/legacy_builders_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 // This file freezes the two legacy name-map builders as they existed before the
-// speciesindex fold, so the golden tests assert Build reproduces them byte for
-// byte. These are verbatim copies of internal/datastore/v2only.buildNameMaps and
+// speciesindex fold, so the golden tests assert Build reproduces their output
+// exactly. These are verbatim copies of internal/datastore/v2only.buildNameMaps and
 // internal/api/v2.buildNameMaps, with their folds inlined to the same expression
 // (strings.ToLower(norm.NFC.String(...))) they both used (the api/v2 side reached
 // it via apicore.NormalizeForLookup). Do not "simplify" them to call Fold: the

--- a/internal/speciesindex/service.go
+++ b/internal/speciesindex/service.go
@@ -1,0 +1,69 @@
+package speciesindex
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/tphakala/birdnet-go/internal/datastore"
+)
+
+// Service owns the current Snapshot behind an atomic.Pointer for lock-free
+// reads. Rebuild swaps in a freshly built Snapshot under buildMu; readers using
+// Snapshot are never blocked by a rebuild. The resolver is held separately (also
+// atomically) because both original sites install it after construction.
+type Service struct {
+	cur      atomic.Pointer[Snapshot]
+	buildMu  sync.Mutex
+	resolver atomic.Pointer[datastore.SpeciesNameResolver]
+}
+
+// New returns a Service seeded with the empty snapshot and the given resolver
+// (a nil resolver is ignored, matching both call sites). Snapshot is safe to
+// call before the first Rebuild; it returns Empty().
+func New(resolver datastore.SpeciesNameResolver) *Service {
+	s := &Service{}
+	s.cur.Store(Empty())
+	if !datastore.IsNilResolver(resolver) {
+		r := resolver
+		s.resolver.Store(&r)
+	}
+	return s
+}
+
+// SetResolver installs the authoritative localized name resolver. A nil resolver
+// is ignored (mirrors both sites' SetNameResolver). The change takes effect on
+// the next Rebuild.
+func (s *Service) SetResolver(r datastore.SpeciesNameResolver) {
+	if datastore.IsNilResolver(r) {
+		return
+	}
+	rr := r
+	s.resolver.Store(&rr)
+}
+
+// Resolver returns the installed resolver, or nil if none has been set.
+func (s *Service) Resolver() datastore.SpeciesNameResolver {
+	if p := s.resolver.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
+// Rebuild builds a new snapshot from labels, the current resolver and locale,
+// then atomically publishes it. It is serialized by buildMu and runs the build
+// outside every caller lock, so concurrent Snapshot readers are never blocked.
+func (s *Service) Rebuild(labels []string, locale string) {
+	s.buildMu.Lock()
+	defer s.buildMu.Unlock()
+	snap := Build(labels, s.Resolver(), locale)
+	s.cur.Store(snap)
+}
+
+// Snapshot returns the current snapshot. It never returns nil: Empty() before
+// the first Rebuild, and never nil after.
+func (s *Service) Snapshot() *Snapshot {
+	if snap := s.cur.Load(); snap != nil {
+		return snap
+	}
+	return Empty()
+}

--- a/internal/speciesindex/service_test.go
+++ b/internal/speciesindex/service_test.go
@@ -1,0 +1,103 @@
+package speciesindex
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestService_SnapshotNeverNil(t *testing.T) {
+	t.Parallel()
+
+	// Before any Rebuild, Snapshot returns the empty snapshot with non-nil maps.
+	s := New(nil)
+	snap := s.Snapshot()
+	require.NotNil(t, snap)
+	assert.NotNil(t, snap.SciToCommon)
+	assert.Empty(t, snap.SciToCommon)
+
+	// After Rebuild, the published snapshot reflects the labels.
+	s.Rebuild([]string{"Turdus merula_Blackbird"}, "en")
+	snap = s.Snapshot()
+	require.NotNil(t, snap)
+	assert.Equal(t, "Blackbird", snap.SciToCommon["Turdus merula"])
+	assert.Equal(t, "en", snap.Locale)
+
+	// A zero-value Service (no New) still returns a non-nil snapshot.
+	var zero Service
+	assert.NotNil(t, zero.Snapshot())
+}
+
+func TestService_SetResolverIgnoresNil(t *testing.T) {
+	t.Parallel()
+
+	r := localResolver{m: map[string]string{"Myotis myotis": "Localized"}}
+	s := New(r)
+	require.NotNil(t, s.Resolver())
+
+	// A nil resolver is ignored, leaving the existing one in place.
+	s.SetResolver(nil)
+	require.NotNil(t, s.Resolver())
+
+	// A typed-nil interface value is also ignored (IsNilResolver semantics).
+	var typedNil *localResolverPtr
+	s.SetResolver(typedNil)
+	require.NotNil(t, s.Resolver())
+
+	// The resolver localizes the reverse map after a rebuild.
+	s.Rebuild([]string{"Myotis myotis"}, "")
+	assert.Equal(t, "Myotis myotis", s.Snapshot().CommonToSci["localized"])
+}
+
+// localResolverPtr is a pointer-receiver resolver used to exercise the typed-nil
+// path of SetResolver (datastore.IsNilResolver reflects on a nil pointer).
+type localResolverPtr struct{ m map[string]string }
+
+func (r *localResolverPtr) Resolve(sci, _ string) string { return r.m[sci] }
+func (r *localResolverPtr) ResolveLocal(sci string) (string, bool) {
+	v, ok := r.m[sci]
+	return v, ok
+}
+
+func TestService_ConcurrentReadersDuringRebuild(t *testing.T) {
+	t.Parallel()
+
+	s := New(nil)
+	labels := loadTestdata(t, "bat_like_labels.txt")
+
+	const readers = 8
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Readers hammer Snapshot() and read its maps while rebuilds churn.
+	for range readers {
+		wg.Go(func() {
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					snap := s.Snapshot()
+					_ = snap.SciToCommon["Nyctalus noctula"]
+					_ = snap.CommonToSci["noctule"]
+					for range snap.SciToCommonFolded { //nolint:revive // draining the map is the point
+					}
+				}
+			}
+		})
+	}
+
+	// Writer loops rebuilds; the atomic swap must never expose a torn map.
+	wg.Go(func() {
+		for range 200 {
+			s.Rebuild(labels, "en")
+		}
+		close(stop)
+	})
+
+	wg.Wait()
+	// Final state is the last rebuild.
+	assert.Equal(t, "Noctule", s.Snapshot().SciToCommon["Nyctalus noctula"])
+}

--- a/internal/speciesindex/service_test.go
+++ b/internal/speciesindex/service_test.go
@@ -49,6 +49,15 @@ func TestService_SetResolverIgnoresNil(t *testing.T) {
 	// The resolver localizes the reverse map after a rebuild.
 	s.Rebuild([]string{"Myotis myotis"}, "")
 	assert.Equal(t, "Myotis myotis", s.Snapshot().CommonToSci["localized"])
+
+	// Installing a non-nil resolver via SetResolver (not New) takes effect on the
+	// next Rebuild.
+	s2 := New(nil)
+	require.Nil(t, s2.Resolver())
+	s2.SetResolver(localResolver{m: map[string]string{"Myotis myotis": "Installed"}})
+	require.NotNil(t, s2.Resolver())
+	s2.Rebuild([]string{"Myotis myotis"}, "")
+	assert.Equal(t, "Myotis myotis", s2.Snapshot().CommonToSci["installed"])
 }
 
 // localResolverPtr is a pointer-receiver resolver used to exercise the typed-nil

--- a/internal/speciesindex/snapshot.go
+++ b/internal/speciesindex/snapshot.go
@@ -1,0 +1,174 @@
+package speciesindex
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/detection"
+	"github.com/tphakala/birdnet-go/internal/openfauna"
+)
+
+// Snapshot is an immutable set of species-name lookup maps built once from a
+// label list and a resolver. All maps are non-nil; callers index them without
+// guards. A Snapshot is never mutated after Build returns, so it is safe to
+// share across goroutines behind an atomic.Pointer.
+type Snapshot struct {
+	// SciToCommon maps scientific name -> localized common name (display).
+	SciToCommon map[string]string
+	// SciToCommonFolded maps scientific name -> Fold(common) for allocation-free
+	// substring matching on the search hot path.
+	SciToCommonFolded map[string]string
+	// CommonToSci maps Fold(common) -> scientific name (reverse lookup). A folded
+	// common name shared by two or more distinct scientific names is ambiguous and
+	// is absent from this map, so search falls through to substring matching
+	// (which returns all matches) rather than routing to an arbitrary species.
+	CommonToSci map[string]string
+	// CanonicalByLabel maps every label -> its canonical key
+	// (Fold-of-CanonicalName over the extracted scientific name), memoized so the
+	// request path never recomputes it per label.
+	CanonicalByLabel map[string]string
+	// LabelsByCanonical maps canonical key -> every label sharing it, so
+	// taxonomic aliases (a legacy name and its canonical name) group together.
+	LabelsByCanonical map[string][]string
+	// LabelBySci maps scientific name -> the full label it came from, so
+	// ResolveLabel can return the original label for a scientific-only entry that
+	// has no common part to rebuild it from.
+	LabelBySci map[string]string
+	// Labels is the working set of labels, deduplicated in first-occurrence order.
+	Labels []string
+	// Locale is the locale the maps were built for ("" when unknown).
+	Locale string
+}
+
+// emptySnapshot is the shared zero snapshot with non-nil maps returned by Empty.
+// It is never mutated (Snapshots are immutable), so sharing one instance is safe.
+var emptySnapshot = &Snapshot{
+	SciToCommon:       map[string]string{},
+	SciToCommonFolded: map[string]string{},
+	CommonToSci:       map[string]string{},
+	CanonicalByLabel:  map[string]string{},
+	LabelsByCanonical: map[string][]string{},
+	LabelBySci:        map[string]string{},
+	Labels:            []string{},
+}
+
+// Empty returns the shared zero snapshot with non-nil maps.
+func Empty() *Snapshot {
+	return emptySnapshot
+}
+
+// Build constructs an immutable snapshot for the given labels, resolver and
+// locale. The three name maps are produced by exactly the algorithm the
+// datastore and api/v2 builders used: ResolveLabelNames, then fold, then the
+// ambiguity drop. The memo maps are computed once here so no request path ever
+// calls openfauna.CanonicalName per label.
+func Build(labels []string, resolver datastore.SpeciesNameResolver, locale string) *Snapshot {
+	s := &Snapshot{
+		SciToCommon:       make(map[string]string, len(labels)),
+		SciToCommonFolded: make(map[string]string, len(labels)),
+		CommonToSci:       make(map[string]string, len(labels)),
+		CanonicalByLabel:  make(map[string]string, len(labels)),
+		LabelsByCanonical: make(map[string][]string, len(labels)),
+		LabelBySci:        make(map[string]string, len(labels)),
+		Labels:            make([]string, 0, len(labels)),
+		Locale:            locale,
+	}
+
+	// Name maps: byte-identical to both legacy builders. Ambiguous reverse keys
+	// are deleted, not last-writer-wins, so an ambiguous common name falls through
+	// to substring search rather than routing to an arbitrary species.
+	ambiguous := make(map[string]struct{})
+	for _, sn := range datastore.ResolveLabelNames(labels, resolver) {
+		s.SciToCommon[sn.Scientific] = sn.Common
+		folded := Fold(sn.Common)
+		s.SciToCommonFolded[sn.Scientific] = folded
+
+		if _, seen := ambiguous[folded]; seen {
+			continue
+		}
+		if existing, exists := s.CommonToSci[folded]; exists && existing != sn.Scientific {
+			ambiguous[folded] = struct{}{}
+			delete(s.CommonToSci, folded)
+			continue
+		}
+		s.CommonToSci[folded] = sn.Scientific
+	}
+
+	// Memo maps: additive, over every label (regardless of the resolver), so
+	// scientific-only labels the name maps drop are still resolvable and the
+	// canonical key is precomputed.
+	seen := make(map[string]struct{}, len(labels))
+	for _, label := range labels {
+		if _, dup := seen[label]; dup {
+			continue
+		}
+		seen[label] = struct{}{}
+
+		sci := detection.ExtractScientificName(label)
+		if sci == "" {
+			continue
+		}
+		s.Labels = append(s.Labels, label)
+		if _, ok := s.LabelBySci[sci]; !ok {
+			s.LabelBySci[sci] = label
+		}
+		ck := computeCanonicalKey(label)
+		s.CanonicalByLabel[label] = ck
+		s.LabelsByCanonical[ck] = append(s.LabelsByCanonical[ck], label)
+	}
+	return s
+}
+
+// computeCanonicalKey is the canonical lookup key for a label: the extracted
+// scientific name run through the openfauna alias map, lower-cased. It is
+// identical to classifier.canonicalSpeciesKey, pinned by a classifier-side test.
+func computeCanonicalKey(label string) string {
+	return strings.ToLower(openfauna.CanonicalName(detection.ExtractScientificName(label)))
+}
+
+// CanonicalKey returns the canonical key for a label, hitting the memo when the
+// label was part of the built set and computing it otherwise.
+func (s *Snapshot) CanonicalKey(label string) string {
+	if ck, ok := s.CanonicalByLabel[label]; ok {
+		return ck
+	}
+	return computeCanonicalKey(label)
+}
+
+// ResolveLabel returns the full label and localized common name for a scientific
+// name. An exact scientific-name hit wins; failing that, a taxonomic-alias hit
+// resolves only when exactly one label shares the canonical key (an ambiguous
+// alias returns ok=false so the caller does not pick arbitrarily). The common
+// name may be empty for a scientific-only label with no resolver coverage.
+func (s *Snapshot) ResolveLabel(sci string) (label, common string, ok bool) {
+	sci = strings.TrimSpace(sci)
+	if sci == "" {
+		return "", "", false
+	}
+	if lbl, found := s.LabelBySci[sci]; found {
+		return lbl, s.SciToCommon[sci], true
+	}
+	ck := strings.ToLower(openfauna.CanonicalName(detection.ExtractScientificName(sci)))
+	if lbls := s.LabelsByCanonical[ck]; len(lbls) == 1 {
+		lbl := lbls[0]
+		return lbl, s.SciToCommon[detection.ExtractScientificName(lbl)], true
+	}
+	return "", "", false
+}
+
+// Search returns the scientific names whose folded common name contains the
+// given already-folded query, sorted. An empty query returns nil.
+func (s *Snapshot) Search(folded string) []string {
+	if folded == "" {
+		return nil
+	}
+	var out []string
+	for sci, fc := range s.SciToCommonFolded {
+		if strings.Contains(fc, folded) {
+			out = append(out, sci)
+		}
+	}
+	slices.Sort(out)
+	return out
+}

--- a/internal/speciesindex/snapshot.go
+++ b/internal/speciesindex/snapshot.go
@@ -75,9 +75,9 @@ func Build(labels []string, resolver datastore.SpeciesNameResolver, locale strin
 		Locale:            locale,
 	}
 
-	// Name maps: byte-identical to both legacy builders. Ambiguous reverse keys
-	// are deleted, not last-writer-wins, so an ambiguous common name falls through
-	// to substring search rather than routing to an arbitrary species.
+	// Name maps: reproduce both legacy builders' output exactly. Ambiguous reverse
+	// keys are deleted, not last-writer-wins, so an ambiguous common name falls
+	// through to substring search rather than routing to an arbitrary species.
 	ambiguous := make(map[string]struct{})
 	for _, sn := range datastore.ResolveLabelNames(labels, resolver) {
 		s.SciToCommon[sn.Scientific] = sn.Common
@@ -105,7 +105,7 @@ func Build(labels []string, resolver datastore.SpeciesNameResolver, locale strin
 		}
 		seen[label] = struct{}{}
 
-		sci := detection.ExtractScientificName(label)
+		sci := scientificName(label)
 		if sci == "" {
 			continue
 		}
@@ -113,18 +113,31 @@ func Build(labels []string, resolver datastore.SpeciesNameResolver, locale strin
 		if _, ok := s.LabelBySci[sci]; !ok {
 			s.LabelBySci[sci] = label
 		}
-		ck := computeCanonicalKey(label)
+		ck := canonicalKeyForSci(sci)
 		s.CanonicalByLabel[label] = ck
 		s.LabelsByCanonical[ck] = append(s.LabelsByCanonical[ck], label)
 	}
 	return s
 }
 
+// scientificName extracts and trims the scientific-name key from a label, matching
+// the key space datastore.ResolveLabelNames uses for the name maps, so LabelBySci
+// keys align with SciToCommon keys even for a label with stray spaces around "_".
+func scientificName(label string) string {
+	return strings.TrimSpace(detection.ExtractScientificName(label))
+}
+
+// canonicalKeyForSci returns the canonical lookup key for an already-extracted
+// scientific name: the openfauna alias-map canonical name, lower-cased.
+func canonicalKeyForSci(sci string) string {
+	return strings.ToLower(openfauna.CanonicalName(sci))
+}
+
 // computeCanonicalKey is the canonical lookup key for a label: the extracted
 // scientific name run through the openfauna alias map, lower-cased. It is
 // identical to classifier.canonicalSpeciesKey, pinned by a classifier-side test.
 func computeCanonicalKey(label string) string {
-	return strings.ToLower(openfauna.CanonicalName(detection.ExtractScientificName(label)))
+	return canonicalKeyForSci(detection.ExtractScientificName(label))
 }
 
 // CanonicalKey returns the canonical key for a label, hitting the memo when the
@@ -149,10 +162,10 @@ func (s *Snapshot) ResolveLabel(sci string) (label, common string, ok bool) {
 	if lbl, found := s.LabelBySci[sci]; found {
 		return lbl, s.SciToCommon[sci], true
 	}
-	ck := strings.ToLower(openfauna.CanonicalName(detection.ExtractScientificName(sci)))
+	ck := computeCanonicalKey(sci)
 	if lbls := s.LabelsByCanonical[ck]; len(lbls) == 1 {
 		lbl := lbls[0]
-		return lbl, s.SciToCommon[detection.ExtractScientificName(lbl)], true
+		return lbl, s.SciToCommon[scientificName(lbl)], true
 	}
 	return "", "", false
 }

--- a/internal/speciesindex/snapshot_test.go
+++ b/internal/speciesindex/snapshot_test.go
@@ -1,0 +1,209 @@
+package speciesindex
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/openfauna"
+)
+
+func TestBuild_AmbiguousCommonNameDropped(t *testing.T) {
+	t.Parallel()
+
+	s := Build([]string{
+		"Strix aluco_Owl",
+		"Bubo bubo_Owl",
+		"Parus major_Great Tit",
+	}, nil, "")
+
+	// sciToCommon keeps both species; scientific names are always unique.
+	assert.Equal(t, "Owl", s.SciToCommon["Strix aluco"])
+	assert.Equal(t, "Owl", s.SciToCommon["Bubo bubo"])
+
+	// The ambiguous folded common name is absent from the reverse map.
+	_, ok := s.CommonToSci["owl"]
+	assert.False(t, ok, "ambiguous common-name key should be removed")
+
+	// Non-ambiguous names remain.
+	assert.Equal(t, "Parus major", s.CommonToSci["great tit"])
+}
+
+func TestBuild_ThirdDuplicateDoesNotRestoreKey(t *testing.T) {
+	t.Parallel()
+
+	s := Build([]string{
+		"Strix aluco_Owl",
+		"Bubo bubo_Owl",
+		"Tyto alba_Owl",
+	}, nil, "")
+
+	_, ok := s.CommonToSci["owl"]
+	assert.False(t, ok, "a third duplicate must not restore an ambiguous key")
+}
+
+func TestBuild_ScientificOnlyLabelSearchableViaResolver(t *testing.T) {
+	t.Parallel()
+
+	// A scientific-only label (no "_") becomes searchable when the resolver
+	// supplies a common name.
+	s := Build([]string{"Myotis myotis"},
+		localResolver{m: map[string]string{"Myotis myotis": "Mustakorvayokko"}}, "")
+	assert.Equal(t, "Mustakorvayokko", s.SciToCommon["Myotis myotis"])
+	assert.Equal(t, "Myotis myotis", s.CommonToSci["mustakorvayokko"])
+
+	// Without a resolver, a scientific-only label has no common name and is
+	// dropped from the name maps (but is still tracked in the memo maps).
+	bare := Build([]string{"Myotis myotis"}, nil, "")
+	_, ok := bare.SciToCommon["Myotis myotis"]
+	assert.False(t, ok)
+	assert.Contains(t, bare.Labels, "Myotis myotis")
+	assert.Equal(t, "Myotis myotis", bare.LabelBySci["Myotis myotis"])
+}
+
+func TestBuild_MalformedLabelsSkipped(t *testing.T) {
+	t.Parallel()
+
+	s := Build([]string{
+		"Strix aluco_Tawny Owl",
+		"_MissingScientific",
+		"MissingCommon_",
+		"NoSeparatorAtAll",
+		"",
+		"   _   ",
+	}, nil, "")
+
+	// Only the one well-formed label survives into the name maps.
+	assert.Len(t, s.SciToCommon, 1)
+	assert.Len(t, s.CommonToSci, 1)
+	assert.Equal(t, "Tawny Owl", s.SciToCommon["Strix aluco"])
+	assert.Equal(t, "Strix aluco", s.CommonToSci["tawny owl"])
+}
+
+func TestBuild_MemoMaps(t *testing.T) {
+	t.Parallel()
+
+	legacy, canonical := firstAliasPair(t)
+	labels := []string{
+		legacy + "_Legacy Common",
+		canonical + "_Canonical Common",
+		"Turdus merula_Blackbird",
+		"Turdus merula_Blackbird", // exact duplicate
+	}
+	s := Build(labels, nil, "")
+
+	// Labels is first-occurrence-deduplicated.
+	assert.Equal(t, []string{
+		legacy + "_Legacy Common",
+		canonical + "_Canonical Common",
+		"Turdus merula_Blackbird",
+	}, s.Labels)
+
+	// CanonicalByLabel covers every (deduplicated) label.
+	assert.Len(t, s.CanonicalByLabel, len(s.Labels))
+	for _, l := range s.Labels {
+		_, ok := s.CanonicalByLabel[l]
+		assert.Truef(t, ok, "CanonicalByLabel missing %q", l)
+	}
+
+	// The alias pair groups under one canonical key.
+	ck := strings.ToLower(openfauna.CanonicalName(legacy))
+	assert.Equal(t, ck, strings.ToLower(openfauna.CanonicalName(canonical)),
+		"legacy and canonical must share a canonical key")
+	assert.ElementsMatch(t,
+		[]string{legacy + "_Legacy Common", canonical + "_Canonical Common"},
+		s.LabelsByCanonical[ck])
+
+	// LabelBySci maps each scientific name to its full label.
+	assert.Equal(t, legacy+"_Legacy Common", s.LabelBySci[legacy])
+	assert.Equal(t, canonical+"_Canonical Common", s.LabelBySci[canonical])
+	assert.Equal(t, "Turdus merula_Blackbird", s.LabelBySci["Turdus merula"])
+}
+
+func TestSnapshot_ResolveLabel_ExactBeforeAlias(t *testing.T) {
+	t.Parallel()
+
+	legacy, canonical := firstAliasPair(t)
+
+	// Both the legacy and canonical names are present, so their shared canonical
+	// key is ambiguous (two candidates).
+	s := Build([]string{
+		legacy + "_Legacy Common",
+		canonical + "_Canonical Common",
+	}, nil, "")
+
+	// Exact scientific-name hit wins even though the canonical group is ambiguous.
+	label, common, ok := s.ResolveLabel(legacy)
+	require.True(t, ok)
+	assert.Equal(t, legacy+"_Legacy Common", label)
+	assert.Equal(t, "Legacy Common", common)
+
+	// A non-exact query whose canonical key is ambiguous returns ok=false rather
+	// than picking arbitrarily. An upper-cased legacy name is not an exact
+	// LabelBySci key, but the alias map lookup is case-insensitive so it
+	// canonicalizes to the same (ambiguous) key.
+	nonExact := strings.ToUpper(legacy)
+	require.NotEqual(t, legacy, nonExact, "need a non-exact variant of the legacy name")
+	require.NotEqual(t, canonical, nonExact)
+	_, _, ok = s.ResolveLabel(nonExact)
+	assert.False(t, ok, "ambiguous alias must not resolve")
+
+	// Alias path with a single candidate resolves to that label.
+	single := Build([]string{canonical + "_Canonical Common"}, nil, "")
+	label, common, ok = single.ResolveLabel(legacy)
+	require.True(t, ok)
+	assert.Equal(t, canonical+"_Canonical Common", label)
+	assert.Equal(t, "Canonical Common", common)
+
+	// An empty query never resolves.
+	_, _, ok = s.ResolveLabel("   ")
+	assert.False(t, ok)
+}
+
+func TestSnapshot_CanonicalKey_MemoHitAndMiss(t *testing.T) {
+	t.Parallel()
+
+	s := Build([]string{"Turdus merula_Blackbird"}, nil, "")
+
+	// Memo hit for a built label.
+	assert.Equal(t, s.CanonicalByLabel["Turdus merula_Blackbird"],
+		s.CanonicalKey("Turdus merula_Blackbird"))
+
+	// Miss: computed on the fly, equal to the direct expression.
+	want := strings.ToLower(openfauna.CanonicalName("Passer domesticus"))
+	assert.Equal(t, want, s.CanonicalKey("Passer domesticus_House Sparrow"))
+}
+
+func TestSnapshot_Search_SortedAndCaseFolded(t *testing.T) {
+	t.Parallel()
+
+	s := Build([]string{
+		"Strix aluco_Tawny Owl",
+		"Bubo bubo_Eurasian Eagle-Owl",
+		"Parus major_Great Tit",
+	}, nil, "")
+
+	// "owl" (already folded) matches both owl species, returned sorted.
+	got := s.Search(Fold("Owl"))
+	assert.Equal(t, []string{"Bubo bubo", "Strix aluco"}, got)
+
+	// A non-matching query returns no results; an empty query returns nil.
+	assert.Empty(t, s.Search(Fold("penguin")))
+	assert.Nil(t, s.Search(""))
+}
+
+func TestEmpty_NonNilMaps(t *testing.T) {
+	t.Parallel()
+
+	e := Empty()
+	require.NotNil(t, e)
+	assert.NotNil(t, e.SciToCommon)
+	assert.NotNil(t, e.SciToCommonFolded)
+	assert.NotNil(t, e.CommonToSci)
+	assert.NotNil(t, e.CanonicalByLabel)
+	assert.NotNil(t, e.LabelsByCanonical)
+	assert.NotNil(t, e.LabelBySci)
+	assert.NotNil(t, e.Labels)
+	assert.Empty(t, e.SciToCommon)
+}

--- a/internal/speciesindex/snapshot_test.go
+++ b/internal/speciesindex/snapshot_test.go
@@ -81,6 +81,25 @@ func TestBuild_MalformedLabelsSkipped(t *testing.T) {
 	assert.Equal(t, "Strix aluco", s.CommonToSci["tawny owl"])
 }
 
+func TestBuild_MemoKeysTrimScientificName(t *testing.T) {
+	t.Parallel()
+
+	// A malformed label with stray spaces around "_": ResolveLabelNames trims the
+	// scientific name for the name maps, so the memo maps must key LabelBySci on the
+	// same trimmed name. Otherwise ResolveLabel misses the exact entry and returns a
+	// blank common name.
+	s := Build([]string{"Strix aluco _ Tawny Owl"}, nil, "")
+
+	assert.Equal(t, "Tawny Owl", s.SciToCommon["Strix aluco"])
+	assert.Equal(t, "Strix aluco _ Tawny Owl", s.LabelBySci["Strix aluco"],
+		"LabelBySci must key on the trimmed scientific name, matching SciToCommon")
+
+	label, common, ok := s.ResolveLabel("Strix aluco")
+	require.True(t, ok)
+	assert.Equal(t, "Strix aluco _ Tawny Owl", label)
+	assert.Equal(t, "Tawny Owl", common)
+}
+
 func TestBuild_MemoMaps(t *testing.T) {
 	t.Parallel()
 

--- a/internal/speciesindex/testdata/bat_like_labels.txt
+++ b/internal/speciesindex/testdata/bat_like_labels.txt
@@ -1,0 +1,8 @@
+Myotis daubentonii_Water Bat
+Pipistrellus pipistrellus_Common Pipistrelle
+Nyctalus noctula_Noctule
+Eptesicus serotinus_Serotine
+Myotis nattereri_Natterer's Bat
+Barbastella barbastellus_Barbastelle
+Plecotus auritus_Long-eared Bat
+Plecotus austriacus_Long-eared Bat

--- a/internal/speciesindex/testdata/perch_like_labels.txt
+++ b/internal/speciesindex/testdata/perch_like_labels.txt
@@ -1,0 +1,7 @@
+Turdus merula
+Passer domesticus
+Accipiter badius
+Tachyspiza badia
+Corvus corone
+Turdus merula
+Fringilla coelebs


### PR DESCRIPTION
## Summary

Fold the two duplicated BirdNET species-name-map builders into one shared leaf package, `internal/speciesindex`, and port the datastore and API v2 name maps onto it. This is an internal, no-behavior-change refactor: the same models load the same paths with the same name maps and the same persisted config. No YAML key, config field, API response shape, or loader path changes.

`internal/speciesindex` owns the index behind a `Service`. A `Snapshot` holds the three name maps (`SciToCommon`, `SciToCommonFolded`, and `CommonToSci`, with the existing ambiguous-common-name drop preserved) plus additive memo maps (`CanonicalByLabel`, `LabelsByCanonical`, `LabelBySci`, `Labels`) computed once at build time so no request path calls `openfauna.CanonicalName` per label. Reads are lock-free via `atomic.Pointer[Snapshot]`; `Rebuild` swaps a freshly built snapshot under a build mutex, outside every caller lock. `Fold` is the single NFC-then-lowercase fold for species-name search keys.

`internal/datastore/v2only` and `internal/api/v2` drop their local `nameMaps` structs and `buildNameMaps` copies and delegate to a `*speciesindex.Service`, and `apicore.NormalizeForLookup` delegates to `speciesindex.Fold`. Equivalence of the three maps is proven by golden tests that assert `Build` reproduces verbatim frozen copies of both former builders exactly, over the real v2.4 6522-label corpus plus synthetic Perch and bat corpora, with nil, fake, and real OpenFauna resolvers.

The new memo maps and the `CanonicalKey`, `ResolveLabel`, and `Search` methods have no consumer yet; they are additive scaffolding for a later phase and are covered by their own tests. Both the datastore and the API facade own an independent `Service` in this phase, exactly reproducing today's two independent builds.

## Test plan

- [x] `go test -race ./internal/speciesindex/... ./internal/datastore/... ./internal/api/...` green
- [x] `internal/classifier` parity test pins `canonicalSpeciesKey` against `speciesindex.CanonicalKey` over the full v2.4 corpus
- [x] `golangci-lint run` clean and `go build ./...` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved species-name lookup across scientific and common names.
  - Added more reliable matching for aliases and localized names.
  - Species-name search now supports consistent case and accent handling.
  - Scientific-only labels can be searched and resolved when localized names are available.

- **Bug Fixes**
  - Ambiguous common names are no longer mapped to incorrect species.
  - Duplicate and malformed labels are handled more safely.
  - Name lookups remain available during index updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->