### PR TITLE
fix(classifier,datastore): clear stale range-filter paths on install; finish the shared name-fold

### DIFF
--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -2118,13 +2118,22 @@ func (mm *ModelManager) removeDownloading(catalogID string) {
 // applyRangeFilterConfigForInstall points the range filter at entry's geomodel
 // companion files under {modelsDir}/shared when the entry carries them. It writes
 // into updated (a settings clone); the caller stores and saves. A no-op for an
-// entry without geomodel files.
+// entry without geomodel files. Both role paths are cleared before the entry's
+// files are written, so a half-tuple entry (only one geomodel role) leaves the
+// omitted role's path empty rather than at a stale earlier value.
 func (mm *ModelManager) applyRangeFilterConfigForInstall(updated *conf.Settings, entry *CatalogEntry) {
 	if !HasGeomodelFiles(entry) || entry.GeomodelVersion == "" {
 		return
 	}
 	rf := updated.RangeFilterConfig()
 	rf.Model = entry.GeomodelVersion
+	// Clear both role paths before the loop so a half-tuple entry (only one geomodel
+	// role, reachable only via a hand-edited catalog) cannot leave the opposite path at
+	// a stale value from an earlier config. The shipped catalog always pairs both roles,
+	// so this is byte-identical there; survivingGeomodelEntry guarantees a full tuple on
+	// the uninstall re-point path.
+	rf.ModelPath = ""
+	rf.LabelsPath = ""
 	for _, f := range entry.Files {
 		switch f.Role {
 		case RoleGeomodelModel:

--- a/internal/classifier/model_manager_install_config_test.go
+++ b/internal/classifier/model_manager_install_config_test.go
@@ -65,10 +65,10 @@ func TestApplyRangeFilterConfigForInstall_ClearsStaleOppositePath(t *testing.T) 
 			rf.ModelPath = staleModelPath
 			rf.LabelsPath = staleLabelsPath
 
-			entry := &CatalogEntry{GeomodelVersion: "v3", Files: tt.files}
+			entry := &CatalogEntry{GeomodelVersion: geomodelRangeFilterVersion, Files: tt.files}
 			mm.applyRangeFilterConfigForInstall(updated, entry)
 
-			assert.Equal(t, "v3", rf.Model, "the geomodel version must be written")
+			assert.Equal(t, geomodelRangeFilterVersion, rf.Model, "the geomodel version must be written")
 			assert.Equal(t, tt.wantModelPath(sharedDir), rf.ModelPath,
 				"model path must be the entry's shared model file, or cleared when the entry omits the model role")
 			assert.Equal(t, tt.wantLabels(sharedDir), rf.LabelsPath,
@@ -88,7 +88,7 @@ func TestApplyRangeFilterConfigForInstall_NonGeomodelEntryIsNoop(t *testing.T) {
 
 	updated := conftest.GetTestSettings()
 	rf := updated.RangeFilterConfig()
-	rf.Model = "v3"
+	rf.Model = geomodelRangeFilterVersion
 	rf.ModelPath = "/existing/geomodel.onnx"
 	rf.LabelsPath = "/existing/geomodel-labels.txt"
 
@@ -96,7 +96,7 @@ func TestApplyRangeFilterConfigForInstall_NonGeomodelEntryIsNoop(t *testing.T) {
 	entry := &CatalogEntry{Files: []CatalogFile{{Role: RoleModel, LocalName: "classifier.onnx"}}}
 	mm.applyRangeFilterConfigForInstall(updated, entry)
 
-	assert.Equal(t, "v3", rf.Model, "a non-geomodel install must not touch the range-filter version")
+	assert.Equal(t, geomodelRangeFilterVersion, rf.Model, "a non-geomodel install must not touch the range-filter version")
 	assert.Equal(t, "/existing/geomodel.onnx", rf.ModelPath, "a non-geomodel install must not touch the model path")
 	assert.Equal(t, "/existing/geomodel-labels.txt", rf.LabelsPath, "a non-geomodel install must not touch the labels path")
 }

--- a/internal/classifier/model_manager_install_config_test.go
+++ b/internal/classifier/model_manager_install_config_test.go
@@ -88,7 +88,11 @@ func TestApplyRangeFilterConfigForInstall_NonGeomodelEntryIsNoop(t *testing.T) {
 
 	updated := conftest.GetTestSettings()
 	rf := updated.RangeFilterConfig()
-	rf.Model = geomodelRangeFilterVersion
+	// Seed a pre-existing version distinct from any value a geomodel install would
+	// write, so the assertion proves the field is untouched rather than coincidentally
+	// matching what an erroneous overwrite would set.
+	const existingRangeFilterVersion = "existing-range-filter-version"
+	rf.Model = existingRangeFilterVersion
 	rf.ModelPath = "/existing/geomodel.onnx"
 	rf.LabelsPath = "/existing/geomodel-labels.txt"
 
@@ -96,7 +100,7 @@ func TestApplyRangeFilterConfigForInstall_NonGeomodelEntryIsNoop(t *testing.T) {
 	entry := &CatalogEntry{Files: []CatalogFile{{Role: RoleModel, LocalName: "classifier.onnx"}}}
 	mm.applyRangeFilterConfigForInstall(updated, entry)
 
-	assert.Equal(t, geomodelRangeFilterVersion, rf.Model, "a non-geomodel install must not touch the range-filter version")
+	assert.Equal(t, existingRangeFilterVersion, rf.Model, "a non-geomodel install must not touch the range-filter version")
 	assert.Equal(t, "/existing/geomodel.onnx", rf.ModelPath, "a non-geomodel install must not touch the model path")
 	assert.Equal(t, "/existing/geomodel-labels.txt", rf.LabelsPath, "a non-geomodel install must not touch the labels path")
 }

--- a/internal/classifier/model_manager_install_config_test.go
+++ b/internal/classifier/model_manager_install_config_test.go
@@ -1,0 +1,102 @@
+package classifier
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/conf/conftest"
+)
+
+// TestApplyRangeFilterConfigForInstall_ClearsStaleOppositePath verifies that installing a
+// geomodel entry clears both range-filter role paths before writing the entry's own files,
+// so a half-tuple entry (only one geomodel role, reachable only via a hand-edited catalog)
+// cannot leave the opposite path pointing at a stale value from an earlier config. The
+// shipped catalog always pairs both roles (geomodelFiles enforces it), so the full-tuple
+// case is the byte-identical behavior real users see and is kept here as a regression guard.
+func TestApplyRangeFilterConfigForInstall_ClearsStaleOppositePath(t *testing.T) {
+	t.Parallel()
+	const (
+		staleModelPath  = "/stale/previous-model.onnx"
+		staleLabelsPath = "/stale/previous-labels.txt"
+		modelLocalName  = "geomodel-v3-model.onnx"
+		labelsLocalName = "geomodel-v3-labels.txt"
+	)
+
+	tests := []struct {
+		name          string
+		files         []CatalogFile
+		wantModelPath func(sharedDir string) string
+		wantLabels    func(sharedDir string) string
+	}{
+		{
+			name:          "model-only entry clears the stale labels path",
+			files:         []CatalogFile{{Role: RoleGeomodelModel, LocalName: modelLocalName}},
+			wantModelPath: func(sharedDir string) string { return filepath.Join(sharedDir, modelLocalName) },
+			wantLabels:    func(string) string { return "" },
+		},
+		{
+			name:          "labels-only entry clears the stale model path",
+			files:         []CatalogFile{{Role: RoleGeomodelLabels, LocalName: labelsLocalName}},
+			wantModelPath: func(string) string { return "" },
+			wantLabels:    func(sharedDir string) string { return filepath.Join(sharedDir, labelsLocalName) },
+		},
+		{
+			name: "full tuple sets both paths",
+			files: []CatalogFile{
+				{Role: RoleGeomodelModel, LocalName: modelLocalName},
+				{Role: RoleGeomodelLabels, LocalName: labelsLocalName},
+			},
+			wantModelPath: func(sharedDir string) string { return filepath.Join(sharedDir, modelLocalName) },
+			wantLabels:    func(sharedDir string) string { return filepath.Join(sharedDir, labelsLocalName) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			modelsDir := t.TempDir()
+			sharedDir := filepath.Join(modelsDir, sharedDirName)
+			mm := NewModelManager(modelsDir, nil, conftest.GetTestSettings())
+
+			updated := conftest.GetTestSettings()
+			rf := updated.RangeFilterConfig()
+			// Simulate a full-tuple config left over from an earlier install.
+			rf.ModelPath = staleModelPath
+			rf.LabelsPath = staleLabelsPath
+
+			entry := &CatalogEntry{GeomodelVersion: "v3", Files: tt.files}
+			mm.applyRangeFilterConfigForInstall(updated, entry)
+
+			assert.Equal(t, "v3", rf.Model, "the geomodel version must be written")
+			assert.Equal(t, tt.wantModelPath(sharedDir), rf.ModelPath,
+				"model path must be the entry's shared model file, or cleared when the entry omits the model role")
+			assert.Equal(t, tt.wantLabels(sharedDir), rf.LabelsPath,
+				"labels path must be the entry's shared labels file, or cleared when the entry omits the labels role")
+		})
+	}
+}
+
+// TestApplyRangeFilterConfigForInstall_NonGeomodelEntryIsNoop verifies that installing a
+// model that carries no geomodel files leaves a pre-existing range-filter config untouched
+// (the early return), so a standard acoustic-model install never wipes a legitimately
+// configured range filter.
+func TestApplyRangeFilterConfigForInstall_NonGeomodelEntryIsNoop(t *testing.T) {
+	t.Parallel()
+	modelsDir := t.TempDir()
+	mm := NewModelManager(modelsDir, nil, conftest.GetTestSettings())
+
+	updated := conftest.GetTestSettings()
+	rf := updated.RangeFilterConfig()
+	rf.Model = "v3"
+	rf.ModelPath = "/existing/geomodel.onnx"
+	rf.LabelsPath = "/existing/geomodel-labels.txt"
+
+	// A plain acoustic-model entry: a classifier model role, no geomodel files.
+	entry := &CatalogEntry{Files: []CatalogFile{{Role: RoleModel, LocalName: "classifier.onnx"}}}
+	mm.applyRangeFilterConfigForInstall(updated, entry)
+
+	assert.Equal(t, "v3", rf.Model, "a non-geomodel install must not touch the range-filter version")
+	assert.Equal(t, "/existing/geomodel.onnx", rf.ModelPath, "a non-geomodel install must not touch the model path")
+	assert.Equal(t, "/existing/geomodel-labels.txt", rf.LabelsPath, "a non-geomodel install must not touch the labels path")
+}

--- a/internal/datastore/v2/repository/filter_conversion.go
+++ b/internal/datastore/v2/repository/filter_conversion.go
@@ -13,7 +13,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/errors"
-	"golang.org/x/text/unicode/norm"
+	"github.com/tphakala/birdnet-go/internal/speciesindex"
 )
 
 // =============================================================================
@@ -557,7 +557,7 @@ func ResolveCommonNameToLabelIDs(ctx context.Context, deps *FilterLookupDeps, sp
 		return nil, nil
 	}
 
-	needle := strings.ToLower(norm.NFC.String(species))
+	needle := speciesindex.Fold(species)
 	matchedScientific := make([]string, 0, 16)
 	collect := func(sci, foldedCommon string) {
 		if strings.Contains(foldedCommon, needle) {
@@ -570,7 +570,7 @@ func ResolveCommonNameToLabelIDs(ctx context.Context, deps *FilterLookupDeps, sp
 		}
 	} else {
 		for sci, common := range deps.SciToCommon {
-			collect(sci, strings.ToLower(norm.NFC.String(common)))
+			collect(sci, speciesindex.Fold(common))
 		}
 	}
 	if len(matchedScientific) == 0 {

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -112,7 +112,7 @@ func setupTestDatastore(t *testing.T) (ds *Datastore, cleanup func()) {
 	cfg, cfgCleanup := buildTestConfig(t, nil)
 	ds, err := New(cfg)
 	require.NoError(t, err)
-	return ds, func() { _ = ds.Close(); cfgCleanup() }
+	return ds, func() { assert.NoError(t, ds.Close()); cfgCleanup() } // nolint:testifylint // assert not require: cfgCleanup must still run if Close errors; require would Goexit and skip it
 }
 
 // setupTestDatastoreWithLabels creates a V2OnlyDatastore with species label mappings for testing.
@@ -123,7 +123,7 @@ func setupTestDatastoreWithLabels(t *testing.T, labels []string) (ds *Datastore,
 	cfg, cfgCleanup := buildTestConfig(t, labels)
 	ds, err := New(cfg)
 	require.NoError(t, err)
-	return ds, func() { _ = ds.Close(); cfgCleanup() }
+	return ds, func() { assert.NoError(t, ds.Close()); cfgCleanup() } // nolint:testifylint // assert not require: cfgCleanup must still run if Close errors; require would Goexit and skip it
 }
 
 // seedDetection creates (or reuses) a label for sciName and inserts one detection
@@ -1526,7 +1526,7 @@ func TestGetTopBirdsData_SpeciesCode(t *testing.T) {
 	cfg.SpeciesCodeMap = speciesCodeMap
 	ds, err := New(cfg)
 	require.NoError(t, err)
-	defer func() { _ = ds.Close(); cfgCleanup() }()
+	defer func() { assert.NoError(t, ds.Close()); cfgCleanup() }() // nolint:testifylint // assert not require: cfgCleanup must still run if Close errors; require would Goexit and skip it
 
 	now := time.Now().UTC()
 	dateStr := now.Format(time.DateOnly)
@@ -1687,7 +1687,7 @@ func TestGetSpeciesSummaryData_NoDateFilter(t *testing.T) {
 	cfg.SpeciesCodeMap = speciesCodeMap
 	ds, err := New(cfg)
 	require.NoError(t, err)
-	defer func() { _ = ds.Close(); cfgCleanup() }()
+	defer func() { assert.NoError(t, ds.Close()); cfgCleanup() }() // nolint:testifylint // assert not require: cfgCleanup must still run if Close errors; require would Goexit and skip it
 
 	now := time.Now().UTC()
 

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -1526,7 +1526,7 @@ func TestGetTopBirdsData_SpeciesCode(t *testing.T) {
 	cfg.SpeciesCodeMap = speciesCodeMap
 	ds, err := New(cfg)
 	require.NoError(t, err)
-	defer func() { assert.NoError(t, ds.Close()); cfgCleanup() }() // nolint:testifylint // assert not require: cfgCleanup must still run if Close errors; require would Goexit and skip it
+	t.Cleanup(func() { assert.NoError(t, ds.Close()); cfgCleanup() }) // nolint:testifylint // assert not require: cfgCleanup must still run if Close errors; require would Goexit and skip it
 
 	now := time.Now().UTC()
 	dateStr := now.Format(time.DateOnly)
@@ -1687,7 +1687,7 @@ func TestGetSpeciesSummaryData_NoDateFilter(t *testing.T) {
 	cfg.SpeciesCodeMap = speciesCodeMap
 	ds, err := New(cfg)
 	require.NoError(t, err)
-	defer func() { assert.NoError(t, ds.Close()); cfgCleanup() }() // nolint:testifylint // assert not require: cfgCleanup must still run if Close errors; require would Goexit and skip it
+	t.Cleanup(func() { assert.NoError(t, ds.Close()); cfgCleanup() }) // nolint:testifylint // assert not require: cfgCleanup must still run if Close errors; require would Goexit and skip it
 
 	now := time.Now().UTC()
 


### PR DESCRIPTION
## Summary

Two small, low-risk cleanups in the classifier and datastore layers.

`applyRangeFilterConfigForInstall` set `rf.ModelPath` and `rf.LabelsPath` each only inside its own role-matched case, with no pre-clear, so installing a geomodel entry that carries only one geomodel role would leave the opposite path at a stale value from an earlier config. It now clears both role paths before the role loop. The shipped catalog always pairs both geomodel roles (`geomodelFiles` appends both, and a catalog invariant test enforces it), so this is byte-identical for real installs; it only affects a half-tuple entry reachable via a hand-edited catalog. The uninstall re-point path is unaffected, because it only re-points to a survivor that is guaranteed to carry a full tuple.

`ResolveCommonNameToLabelIDs` in the datastore now folds species names through `speciesindex.Fold` instead of inlining `strings.ToLower(norm.NFC.String(...))` at two sites. `Fold` is the single shared species-name fold, and the folded map this consumer reads is already built with it, so folding the needle the same way keeps the two sides from silently diverging if the fold ever changes (for example a move to NFKC). Byte-identical today; the now-unused `norm` import is dropped.

## Tests

- New table-driven test covering the install pre-clear across model-only, labels-only, full-tuple, and non-geomodel entries; the half-tuple cases fail without the fix.
- The v2only datastore test teardowns now assert the `Close` error instead of discarding it (assert, not require, so `cfgCleanup` still runs even if `Close` fails).
- `golangci-lint run` clean; `go test -race` green across the affected packages and all CI build-tag combinations (including `normcompare`, which guards the fold normalization).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed range-filter configuration during geomodel installation so stale model or label paths are cleared when catalog entries contain only one role.
  * Preserved existing range-filter settings when installing non-geomodel acoustic models.
  * Improved common-name search matching through consistent text normalization.

* **Tests**
  * Added coverage for geomodel path cleanup, complete configurations, version updates, and non-geomodel installations.
  * Improved datastore cleanup test reliability by verifying close operations succeed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->