### PR TITLE
refactor(classifier): orchestrator-owned taxonomy service

### DIFF
--- a/internal/classifier/README.md
+++ b/internal/classifier/README.md
@@ -143,14 +143,14 @@ The package embeds several key resources:
 A typical usage pattern involves:
 
 ```go
-// Create new BirdNET instance
-bn, err := birdnet.NewBirdNET(settings)
+// Create new classifier orchestrator
+orchestrator, err := birdnet.NewOrchestrator(settings)
 if err != nil {
     // Handle error
 }
 
 // Process audio chunk
-results, err := bn.Predict(audioSample)
+results, err := orchestrator.Predict(audioSample)
 if err != nil {
     // Handle error
 }

--- a/internal/classifier/README.md
+++ b/internal/classifier/README.md
@@ -24,8 +24,6 @@ type BirdNET struct {
     RangeInterpreter    *tflite.Interpreter  // Interpreter for the range filter model
     Settings            *conf.Settings       // Application configuration settings
     ModelInfo           ModelInfo            // Information about the current model
-    TaxonomyMap         TaxonomyMap          // Mapping of species codes to names and vice versa
-    TaxonomyPath        string               // Path to custom taxonomy file, if used
     mu                  sync.Mutex           // Mutex for thread safety
 }
 ```
@@ -35,7 +33,6 @@ type BirdNET struct {
 The package provides methods for analyzing audio samples and producing detection results:
 
 - `Predict()` - Performs inference on audio samples to detect bird species
-- `EnrichResultWithTaxonomy()` - Adds taxonomy information to detection results
 
 ### Model Registry
 
@@ -95,12 +92,12 @@ Key functions:
 - `GetSpeciesCodeFromName()` - Gets eBird code for a species name
 - `GetSpeciesNameFromCode()` - Gets species name for an eBird code
 - `SplitSpeciesName()` - Splits species name into scientific and common parts
-- `EnrichResultWithTaxonomy()` - Adds taxonomy information to detection results
+- `Orchestrator.EnrichResultWithTaxonomy()` - Adds taxonomy information to detection results (taxonomy is owned by the orchestrator, not the primary model)
 
 Example usage of taxonomy enrichment:
 
 ```go
-scientific, common, code := bn.EnrichResultWithTaxonomy(result.Species)
+scientific, common, code := orchestrator.EnrichResultWithTaxonomy(result.Species)
 fmt.Printf("Species: %s (%s), eBird code: %s, Confidence: %.2f\n",
     common, scientific, code, result.Confidence)
 ```
@@ -160,7 +157,7 @@ if err != nil {
 
 // Process results with taxonomy information
 for _, result := range results {
-    scientific, common, code := bn.EnrichResultWithTaxonomy(result.Species)
+    scientific, common, code := orchestrator.EnrichResultWithTaxonomy(result.Species)
     fmt.Printf("Species: %s (%s), eBird code: %s, Confidence: %.2f\n",
         common, scientific, code, result.Confidence)
 }

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -90,12 +90,9 @@ type BirdNET struct {
 	rangeFilterFellBack bool
 	Settings            *conf.Settings // Deprecated: use settingsAtomic instead. Kept for struct-literal compatibility in tests.
 	settingsAtomic      atomic.Pointer[conf.Settings]
-	ModelInfo           ModelInfo           // Information about the current model
-	TaxonomyMap         TaxonomyMap         // Mapping of species codes to names and vice versa
-	ScientificIndex     ScientificNameIndex // Index for fast scientific name lookups
-	TaxonomyPath        string              // Path to custom taxonomy file, if used
-	modelVersion        string              // Human-readable model version string (per-instance to avoid shared global state)
-	modelsDir           string              // base directory for gallery-installed models (set by Orchestrator)
+	ModelInfo           ModelInfo // Information about the current model
+	modelVersion        string    // Human-readable model version string (per-instance to avoid shared global state)
+	modelsDir           string    // base directory for gallery-installed models (set by Orchestrator)
 	// primaryPath is the outcome of resolving settings.BirdNET.ModelPath for this
 	// instance: which primary classifier model file it actually loads from, and
 	// whether that differs from what the user configured. resolved.model differs
@@ -227,7 +224,6 @@ func resolvePrimaryOrConfigured(resolve primaryPathResolver, configured string) 
 func NewBirdNET(settings *conf.Settings, modelInfo *ModelInfo, resolvePrimary primaryPathResolver) (*BirdNET, error) {
 	bn := &BirdNET{
 		Settings:       settings,
-		TaxonomyPath:   "", // Default to embedded taxonomy
 		modelVersion:   defaultModelVersionString,
 		speciesCache:   make(map[string]*speciesCacheEntry),
 		resolvePrimary: resolvePrimary,
@@ -243,7 +239,6 @@ func NewBirdNET(settings *conf.Settings, modelInfo *ModelInfo, resolvePrimary pr
 	bn.primaryPath = resolvePrimaryOrConfigured(resolvePrimary, settings.BirdNET.ModelPath)
 
 	// Resolve model identity via the resolution chain
-	var err error
 	switch {
 	case modelInfo != nil:
 		// Tier 1: caller provided (orchestrator path)
@@ -289,17 +284,6 @@ func NewBirdNET(settings *conf.Settings, modelInfo *ModelInfo, resolvePrimary pr
 	// Device defaults to CPU; each init path republishes the real load-time device
 	// (the OV path may bind GPU), backend, and effective runtime precision.
 	bn.setRuntimeInfo(deviceCPU, bn.ModelInfo.Backend, string(bn.ModelInfo.Quantization))
-
-	// Load taxonomy data
-	bn.TaxonomyMap, bn.ScientificIndex, err = LoadTaxonomyData(bn.TaxonomyPath)
-	if err != nil {
-		return nil, errors.New(err).
-			Component("birdnet").
-			Category(errors.CategoryModelInit).
-			Context("operation", "load_taxonomy").
-			Context("taxonomy_path", bn.TaxonomyPath).
-			Build()
-	}
 
 	// Normalize and validate the locale before anything reads it. An unsupported
 	// locale is reported as an error but NormalizeLocale still returns
@@ -841,9 +825,6 @@ func (bn *BirdNET) loadEmbeddedLabels() error {
 			Build()
 	}
 
-	// Check and log species missing from taxonomy
-	bn.logMissingTaxonomyCodes()
-
 	return nil
 }
 
@@ -897,41 +878,7 @@ func (bn *BirdNET) loadExternalLabels() error {
 			Build()
 	}
 
-	// Check and log species missing from taxonomy
-	bn.logMissingTaxonomyCodes()
-
 	return nil
-}
-
-// logMissingTaxonomyCodes checks labels against the taxonomy map and logs information about missing species
-func (bn *BirdNET) logMissingTaxonomyCodes() {
-	// Validate labels against taxonomy
-	complete, missing := IsTaxonomyComplete(bn.TaxonomyMap, bn.Settings.BirdNET.Labels)
-	if !complete {
-		// For custom models, provide more detailed information about missing taxonomy codes
-		// The resolved path: after a recovery to the built-in baseline nothing custom
-		// is loaded any more, so calling it a custom model would misdescribe it.
-		if bn.configuredModelPath() != "" || bn.Settings.BirdNET.LabelPath != "" {
-			bn.Debug("Custom model/labels detected: %d species are missing from the taxonomy data", len(missing))
-			bn.Debug("Placeholder taxonomy codes will be generated for these species")
-		} else {
-			bn.Debug("Warning: %d species are missing from the taxonomy data", len(missing))
-		}
-
-		if bn.Settings.BirdNET.Debug {
-			for i, species := range missing {
-				if i < 10 { // Only show the first 10 to avoid flooding logs
-					code := GeneratePlaceholderCode(species)
-					scientific, common := SplitSpeciesName(species)
-					bn.Debug("Missing taxonomy for '%s' (Sci: '%s', Common: '%s') - using placeholder code: %s",
-						species, scientific, common, code)
-				} else if i == 10 {
-					bn.Debug("... and %d more", len(missing)-10)
-					break
-				}
-			}
-		}
-	}
 }
 
 func (bn *BirdNET) loadLabelsFromText(file *os.File) error {
@@ -1458,8 +1405,6 @@ func (bn *BirdNET) reloadModelInternal(allowPathChange bool) error {
 	oldRangeFilter := bn.rangeFilter
 	oldFellBack := bn.rangeFilterFellBack
 	oldModelInfo := bn.ModelInfo
-	oldTaxonomyMap := bn.TaxonomyMap
-	oldScientificIndex := bn.ScientificIndex
 	// initializeModel republishes the runtime triplet (and modelVersion on the
 	// TFLite custom-path branch) before the later reload steps (meta model,
 	// validation) that can still fail, so snapshot them too; otherwise a
@@ -1496,8 +1441,6 @@ func (bn *BirdNET) reloadModelInternal(allowPathChange bool) error {
 		// reload does not leave the health report claiming the geomodel is active.
 		bn.rangeFilterFellBack = oldFellBack
 		bn.ModelInfo = oldModelInfo
-		bn.TaxonomyMap = oldTaxonomyMap
-		bn.ScientificIndex = oldScientificIndex
 		// Restore the runtime triplet and model-version string alongside the
 		// classifier so RuntimeInfo / ModelVersion describe the restored model
 		// rather than the failed attempt.
@@ -1636,20 +1579,6 @@ func (bn *BirdNET) reloadModelInternal(allowPathChange bool) error {
 		bn.ModelInfo = stockPrimaryModelInfo()
 	}
 
-	// Reload taxonomy data if needed
-	var err error
-	bn.TaxonomyMap, bn.ScientificIndex, err = LoadTaxonomyData(bn.TaxonomyPath)
-	if err != nil {
-		rollback()
-		return errors.New(err).
-			Component("birdnet").
-			Category(errors.CategoryModelInit).
-			Context("operation", "reload_model").
-			Context("step", "reload_taxonomy").
-			Build()
-	}
-	bn.Debug("Taxonomy data reloaded successfully")
-
 	// Reload labels before model initialization; ONNX models require labels
 	// at construction time for output dimension validation.
 	if err := bn.loadLabels(); err != nil {
@@ -1728,20 +1657,6 @@ func (bn *BirdNET) reloadModelInternal(allowPathChange bool) error {
 
 	bn.Debug("Model reload completed successfully")
 	return nil
-}
-
-// GetSpeciesCode returns the eBird species code for a given label
-func (bn *BirdNET) GetSpeciesCode(label string) (string, bool) {
-	bn.mu.Lock()
-	taxMap := bn.TaxonomyMap
-	sciIndex := bn.ScientificIndex
-	bn.mu.Unlock()
-	return GetSpeciesCodeFromName(taxMap, sciIndex, label)
-}
-
-// GetSpeciesWithScientificAndCommonName returns the scientific name and common name for a label
-func (bn *BirdNET) GetSpeciesWithScientificAndCommonName(label string) (scientific, common string) {
-	return SplitSpeciesName(label)
 }
 
 // Debug prints debug messages if debug mode is enabled.
@@ -1906,12 +1821,12 @@ func (bn *BirdNET) RuntimeInfo() (device, backend, precision string) {
 	return ri.device, ri.backend, ri.precision
 }
 
-// ReloadSnapshot returns a copy of the model metadata and taxonomy maps safely under bn.mu.
-// Used by the Orchestrator to update its shared state after a model reload.
-func (bn *BirdNET) ReloadSnapshot() (info ModelInfo, taxMap TaxonomyMap, taxPath string, sciIndex ScientificNameIndex) {
+// ReloadSnapshot returns a copy of the model metadata safely under bn.mu. Used by
+// the Orchestrator to refresh its shared state after a model reload.
+func (bn *BirdNET) ReloadSnapshot() ModelInfo {
 	bn.mu.Lock()
 	defer bn.mu.Unlock()
-	return bn.ModelInfo, maps.Clone(bn.TaxonomyMap), bn.TaxonomyPath, maps.Clone(bn.ScientificIndex)
+	return bn.ModelInfo
 }
 
 // Close releases resources held by the BirdNET model.
@@ -1919,28 +1834,6 @@ func (bn *BirdNET) ReloadSnapshot() (info ModelInfo, taxMap TaxonomyMap, taxPath
 func (bn *BirdNET) Close() error {
 	bn.Delete()
 	return nil
-}
-
-// EnrichResultWithTaxonomy adds taxonomy information to a detection result
-// Returns scientific name, common name, and eBird code if available
-func (bn *BirdNET) EnrichResultWithTaxonomy(speciesLabel string) (scientific, common, code string) {
-	scientific, common = SplitSpeciesName(speciesLabel)
-
-	bn.mu.Lock()
-	taxMap := bn.TaxonomyMap
-	sciIndex := bn.ScientificIndex
-	bn.mu.Unlock()
-
-	// Try to get the eBird code
-	code, exists := GetSpeciesCodeFromName(taxMap, sciIndex, speciesLabel)
-	if !exists {
-		// We got a placeholder code for a species not in our taxonomy
-		if bn.currentSettings().BirdNET.Debug {
-			bn.Debug("Species '%s' not found in taxonomy, using generated placeholder code: %s", speciesLabel, code)
-		}
-	}
-
-	return scientific, common, code
 }
 
 // GeomodelStatus holds metadata about the active geomodel.

--- a/internal/classifier/birdnet_reload_rollback_test.go
+++ b/internal/classifier/birdnet_reload_rollback_test.go
@@ -31,13 +31,13 @@ var _ inference.Classifier = (*rollbackFakeClassifier)(nil)
 // 0% unit-covered (NewOrchestrator skips without a real model, and the primary-swap
 // tests exercise the orchestrator==nil path). No native model is needed:
 //
-//   - The two early-failure subtests inject a failure at the FIRST fallible step (a
-//     nonexistent TaxonomyPath makes LoadTaxonomyData fail), which runs before a new
-//     backend is installed. They exercise the rollback of the state mutated up front,
-//     each assertion genuinely contingent on rollback: ModelInfo (reassigned by the
-//     switch), TaxonomyMap (set to nil by the failed multi-return load), and Settings
-//     (swapped to a clone at entry). Both entry points are covered: the variant-swap
-//     path (allowPathChange=true) and the settings-reload path (allowPathChange=false).
+//   - The two early-failure subtests inject a failure at the first fallible step (an
+//     unreadable external LabelPath makes loadLabels fail), which runs after the
+//     identity switch but before a new backend is installed. They exercise the
+//     rollback of the state mutated up front, each assertion genuinely contingent on
+//     rollback: ModelInfo (reassigned by the switch) and Settings (swapped to a clone
+//     at entry). Both entry points are covered: the variant-swap path
+//     (allowPathChange=true) and the settings-reload path (allowPathChange=false).
 //   - The post-init subtest uses the reloadInitFn seam to install a NEW backend and
 //     republish the runtime triplet + modelVersion (as the real initializeModel does),
 //     then fail. This is the only way to reach the rollback branch that tears down the
@@ -54,48 +54,42 @@ func TestReloadModelInternal_RollbackRestoresPreviousModel(t *testing.T) {
 	)
 
 	// newServingBirdNET builds a struct-literal BirdNET that models a live,
-	// previously-serving primary: a fake classifier, a distinguishable ModelInfo,
-	// a published identity + runtime triplet, and a sentinel taxonomy map. The
-	// reload it drives always fails at the taxonomy step (badTaxonomyPath), so the
-	// caller can assert every snapshot field was rolled back.
-	newServingBirdNET := func(t *testing.T, oldInfo ModelInfo) (*BirdNET, *rollbackFakeClassifier, *conf.Settings, TaxonomyMap) {
+	// previously-serving primary: a fake classifier, a distinguishable ModelInfo, and
+	// a published identity + runtime triplet. Each caller sets an unreadable external
+	// LabelPath in the (conftest-global) settings so the reload always fails at the
+	// load-labels step, letting the caller assert every snapshot field was rolled back.
+	newServingBirdNET := func(t *testing.T, oldInfo ModelInfo) (*BirdNET, *rollbackFakeClassifier, *conf.Settings) {
 		t.Helper()
 		fake := &rollbackFakeClassifier{}
 		// A distinct pointer from both the global settings and the reload's internal
-		// clone, so restoration can be asserted by pointer identity.
+		// clone, so restoration can be asserted by pointer identity. It inherits the
+		// caller's unreadable LabelPath, which is what makes the reload fail.
 		oldSettings := conf.CloneSettings(conftest.GetTestSettings())
-		oldTax := TaxonomyMap{"Turdus merula": "turmer"}
-		badTaxonomyPath := filepath.Join(t.TempDir(), "does-not-exist-taxonomy.json")
 
 		bn := &BirdNET{
-			classifier:      fake,
-			rangeFilter:     nil,
-			Settings:        oldSettings,
-			ModelInfo:       oldInfo,
-			TaxonomyMap:     oldTax,
-			ScientificIndex: ScientificNameIndex{"turmer": "Turdus merula"},
-			TaxonomyPath:    badTaxonomyPath,
-			modelVersion:    staleVersion,
-			speciesCache:    make(map[string]*speciesCacheEntry),
+			classifier:   fake,
+			rangeFilter:  nil,
+			Settings:     oldSettings,
+			ModelInfo:    oldInfo,
+			modelVersion: staleVersion,
+			speciesCache: make(map[string]*speciesCacheEntry),
 		}
 		bn.settingsAtomic.Store(oldSettings)
 		bn.setRuntimeInfo(devDevice, devBackend, devPrecision)
 		bn.publishIdentity()
-		return bn, fake, oldSettings, oldTax
+		return bn, fake, oldSettings
 	}
 
 	// assertEarlyFailureRolledBack checks the two early-failure subtests. It asserts
-	// the three fields mutated BEFORE the taxonomy step, each genuinely contingent on
+	// the two fields mutated BEFORE the load-labels step, each genuinely contingent on
 	// rollback (delete rollback() and each flips), plus the serving-backend guard.
 	assertEarlyFailureRolledBack := func(t *testing.T, bn *BirdNET, fake *rollbackFakeClassifier,
-		oldSettings *conf.Settings, oldTax TaxonomyMap, oldInfo ModelInfo,
+		oldSettings *conf.Settings, oldInfo ModelInfo,
 	) {
 		t.Helper()
-		// Contingent on rollback: ModelInfo (reassigned by the switch), TaxonomyMap
-		// (set to nil by the failed multi-return load), and Settings (swapped to a
-		// clone at entry) are all mutated before the taxonomy failure.
+		// Contingent on rollback: ModelInfo (reassigned by the switch) and Settings
+		// (swapped to a clone at entry) are both mutated before the load-labels failure.
 		assert.Equal(t, oldInfo, bn.ModelInfo, "ModelInfo must be restored to the previous model")
-		assert.Equal(t, oldTax, bn.TaxonomyMap, "taxonomy map must be restored (not the nil returned by the failed load)")
 		assert.Same(t, oldSettings, bn.Settings, "settings pointer must be restored")
 
 		// Serving-backend guard: on an early failure the classifier is never swapped,
@@ -109,7 +103,7 @@ func TestReloadModelInternal_RollbackRestoresPreviousModel(t *testing.T) {
 	t.Run("variant-swap path (allowPathChange=true)", func(t *testing.T) {
 		// Empty Version and ModelPath drive the cleared-path variant-swap branch,
 		// which re-resolves the stock embedded identity: ModelInfo IS reassigned
-		// before the taxonomy step, so its restoration is meaningfully exercised.
+		// before the load-labels step, so its restoration is meaningfully exercised.
 		settings := conftest.GetTestSettings()
 		settings.BirdNET.Version = ""
 		settings.BirdNET.ModelPath = ""
@@ -117,20 +111,27 @@ func TestReloadModelInternal_RollbackRestoresPreviousModel(t *testing.T) {
 		t.Cleanup(func() { conftest.SetTestSettings(nil) })
 
 		oldInfo := ModelInfo{ID: "TEST_PREV_MODEL", Name: staleName}
-		bn, fake, oldSettings, oldTax := newServingBirdNET(t, oldInfo)
+		bn, fake, oldSettings := newServingBirdNET(t, oldInfo)
+
+		// Point the reload (which reads the global settings) at a missing label file
+		// AFTER the previously-serving snapshot is captured, so oldSettings stays
+		// healthy and the scenario is coherent: a healthy model whose next reload
+		// fails at the load-labels step.
+		settings.BirdNET.LabelPath = filepath.Join(t.TempDir(), "does-not-exist-labels.txt")
+		conftest.SetTestSettings(settings)
 
 		err := bn.reloadModelInternal(true)
 
-		require.Error(t, err, "reload must fail when the taxonomy file cannot be read")
-		assert.Contains(t, err.Error(), "taxonomy", "error must identify the failed taxonomy step")
-		assertEarlyFailureRolledBack(t, bn, fake, oldSettings, oldTax, oldInfo)
+		require.Error(t, err, "reload must fail when the label file cannot be read")
+		assert.Contains(t, err.Error(), "does-not-exist-labels", "error must identify the failed load-labels step")
+		assertEarlyFailureRolledBack(t, bn, fake, oldSettings, oldInfo)
 	})
 
 	t.Run("settings-reload path (allowPathChange=false)", func(t *testing.T) {
 		// A configured ModelPath drives the birdnet-slot branch. The previous
 		// model's CustomPath matches the configured path, so the reload is accepted
 		// in place (not refused as a restart-required change) and ModelInfo is
-		// reassigned from the path before the taxonomy step fails.
+		// reassigned from the path before the load-labels step fails.
 		modelPath := filepath.Join(t.TempDir(), "birdnet-v2.4.tflite")
 		settings := conftest.GetTestSettings()
 		settings.BirdNET.Version = ""
@@ -139,13 +140,18 @@ func TestReloadModelInternal_RollbackRestoresPreviousModel(t *testing.T) {
 		t.Cleanup(func() { conftest.SetTestSettings(nil) })
 
 		oldInfo := ModelInfo{ID: "TEST_PREV_MODEL", Name: staleName, CustomPath: modelPath}
-		bn, fake, oldSettings, oldTax := newServingBirdNET(t, oldInfo)
+		bn, fake, oldSettings := newServingBirdNET(t, oldInfo)
+
+		// Point the reload at a missing label file AFTER capturing the healthy
+		// previously-serving snapshot (see the variant-swap subtest).
+		settings.BirdNET.LabelPath = filepath.Join(t.TempDir(), "does-not-exist-labels.txt")
+		conftest.SetTestSettings(settings)
 
 		err := bn.reloadModelInternal(false)
 
-		require.Error(t, err, "reload must fail when the taxonomy file cannot be read")
-		assert.Contains(t, err.Error(), "taxonomy", "error must identify the failed taxonomy step")
-		assertEarlyFailureRolledBack(t, bn, fake, oldSettings, oldTax, oldInfo)
+		require.Error(t, err, "reload must fail when the label file cannot be read")
+		assert.Contains(t, err.Error(), "does-not-exist-labels", "error must identify the failed load-labels step")
+		assertEarlyFailureRolledBack(t, bn, fake, oldSettings, oldInfo)
 	})
 
 	// The strongest case: a failure AFTER a new backend has been installed. The
@@ -162,11 +168,10 @@ func TestReloadModelInternal_RollbackRestoresPreviousModel(t *testing.T) {
 		t.Cleanup(func() { conftest.SetTestSettings(nil) })
 
 		oldInfo := ModelInfo{ID: "TEST_PREV_MODEL", Name: staleName}
-		bn, oldFake, oldSettings, _ := newServingBirdNET(t, oldInfo)
-		// Embedded taxonomy + labels so the reload proceeds past those steps to the
-		// model-init seam (the variant-swap branch resolves the stock identity, whose
-		// embedded labels load without a native model).
-		bn.TaxonomyPath = ""
+		bn, oldFake, oldSettings := newServingBirdNET(t, oldInfo)
+		// Embedded labels load (no LabelPath set) so the reload proceeds past the
+		// load-labels step to the model-init seam (the variant-swap branch resolves
+		// the stock identity, whose embedded labels load without a native model).
 
 		newFake := &rollbackFakeClassifier{}
 		bn.reloadInitFn = func() error {

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -1260,7 +1260,8 @@ func (o *Orchestrator) logMissingTaxonomyCodes(primary *BirdNET, labels []string
 }
 
 // GetSpeciesCode returns the eBird species code for a given label. The taxonomy is
-// orchestrator-owned and immutable, so this needs no lock and no primary model.
+// orchestrator-owned and immutable, so this needs no lock and no primary model; it
+// keeps answering after Delete releases the primary (a shutdown-only state).
 func (o *Orchestrator) GetSpeciesCode(label string) (string, bool) {
 	if o == nil || o.taxonomy == nil {
 		return "", false
@@ -1270,7 +1271,8 @@ func (o *Orchestrator) GetSpeciesCode(label string) (string, bool) {
 
 // GetSpeciesNameFromCode returns the species name for a given eBird species code.
 // The second return value reports whether the code was found in the orchestrator-
-// owned taxonomy, which is immutable and so needs no lock.
+// owned taxonomy, which is immutable and so needs no lock; like GetSpeciesCode it
+// keeps answering after Delete (a shutdown-only state).
 func (o *Orchestrator) GetSpeciesNameFromCode(code string) (string, bool) {
 	if o == nil || o.taxonomy == nil {
 		return "", false

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -80,12 +80,15 @@ type secondaryBackendKey struct {
 // Delete/UnloadModel acquire mu + entry.mu but NOT inferenceMu.
 type Orchestrator struct {
 	// Public fields, same layout as BirdNET for drop-in caller migration.
-	Settings        *conf.Settings // Deprecated: use CurrentSettings() instead.
-	settingsAtomic  atomic.Pointer[conf.Settings]
-	ModelInfo       ModelInfo
-	TaxonomyMap     TaxonomyMap
-	TaxonomyPath    string
-	ScientificIndex ScientificNameIndex
+	Settings       *conf.Settings // Deprecated: use CurrentSettings() instead.
+	settingsAtomic atomic.Pointer[conf.Settings]
+	ModelInfo      ModelInfo
+
+	// taxonomy is the orchestrator-owned eBird taxonomy service, built once in
+	// NewOrchestrator and read-only afterwards. It replaces the taxonomy maps the
+	// primary model used to own, so a species-code lookup no longer depends on which
+	// acoustic model is loaded (model de-privilege epic, Phase 2a).
+	taxonomy *taxonomyService
 
 	// Name resolution chain. Resolvers are tried in order; first non-empty wins.
 	nameResolvers []NameResolver
@@ -263,6 +266,15 @@ func NewOrchestrator(settings *conf.Settings) (*Orchestrator, error) {
 	// construction and keeps it for its hot-reload path, so both resolve the same
 	// way. Passing the bound method rather than a precomputed value is what keeps
 	// the reload from re-deriving the identity off the raw configured string.
+	// Build the orchestrator-owned taxonomy service before the primary model. It
+	// loads the same embedded eBird taxonomy the primary used to load, via the same
+	// LoadTaxonomyData path, so a load failure aborts construction exactly as before.
+	taxonomy, err := newTaxonomyService("")
+	if err != nil {
+		return nil, err
+	}
+	o.taxonomy = taxonomy
+
 	bn, err := NewBirdNET(settings, nil, o.primaryPathResolverFor(settings))
 	if err != nil {
 		return nil, err
@@ -293,9 +305,6 @@ func NewOrchestrator(settings *conf.Settings) (*Orchestrator, error) {
 
 	// Populate the remaining fields now that bn is available.
 	o.ModelInfo = bn.ModelInfo
-	o.TaxonomyMap = bn.TaxonomyMap
-	o.TaxonomyPath = bn.TaxonomyPath
-	o.ScientificIndex = bn.ScientificIndex
 	// OpenFauna first so it overrides label/taxonomy names everywhere
 	// ResolveName is consulted (display + inference).
 	o.nameResolvers = []NameResolver{ofResolver, resolver}
@@ -303,6 +312,11 @@ func NewOrchestrator(settings *conf.Settings) (*Orchestrator, error) {
 	o.models[bn.ModelInfo.ID] = &modelEntry{instance: bn}
 	o.primary = bn
 	o.settingsAtomic.Store(settings)
+
+	// Log any labels missing from the taxonomy at debug level, reproducing the
+	// diagnostics BirdNET used to emit from loadLabels now that the taxonomy is
+	// orchestrator-owned.
+	o.logMissingTaxonomyCodes(bn, bn.Labels())
 
 	// Each OV-capable secondary records the startup triplet on its own modelEntry
 	// when its loader registers it below (see loadPerch), so the first
@@ -1232,38 +1246,46 @@ func (o *Orchestrator) AllLabels() []string {
 	return unionLabels(sets...)
 }
 
-// GetSpeciesCode returns the eBird species code for a given label.
+// logMissingTaxonomyCodes emits, at debug level, the labels absent from the
+// taxonomy, reproducing BirdNET.logMissingTaxonomyCodes now that the taxonomy is
+// orchestrator-owned. primary supplies the "custom model/labels" phrasing; a nil
+// taxonomy or primary is a no-op.
+func (o *Orchestrator) logMissingTaxonomyCodes(primary *BirdNET, labels []string) {
+	if o == nil || o.taxonomy == nil || primary == nil {
+		return
+	}
+	s := o.currentSettings()
+	customModelOrLabels := primary.configuredModelPath() != "" || s.BirdNET.LabelPath != ""
+	o.taxonomy.logMissingCodes(labels, customModelOrLabels, s.BirdNET.Debug)
+}
+
+// GetSpeciesCode returns the eBird species code for a given label. The taxonomy is
+// orchestrator-owned and immutable, so this needs no lock and no primary model.
 func (o *Orchestrator) GetSpeciesCode(label string) (string, bool) {
-	o.mu.RLock()
-	primary := o.primary
-	o.mu.RUnlock()
-	if primary == nil {
+	if o == nil || o.taxonomy == nil {
 		return "", false
 	}
-	return primary.GetSpeciesCode(label)
+	return o.taxonomy.speciesCode(label)
 }
 
 // GetSpeciesNameFromCode returns the species name for a given eBird species code.
-// The second return value reports whether the code was found in the TaxonomyMap
-// by calling GetSpeciesNameFromCode(o.TaxonomyMap, code).
+// The second return value reports whether the code was found in the orchestrator-
+// owned taxonomy, which is immutable and so needs no lock.
 func (o *Orchestrator) GetSpeciesNameFromCode(code string) (string, bool) {
-	o.mu.RLock()
-	defer o.mu.RUnlock()
-	return GetSpeciesNameFromCode(o.TaxonomyMap, code)
+	if o == nil || o.taxonomy == nil {
+		return "", false
+	}
+	return o.taxonomy.nameFromCode(code)
 }
 
 // GetSpeciesWithScientificAndCommonName returns the scientific and common name for a label.
-// OpenFauna (chain[0]) is authoritative: its localized name overrides the
-// primary's label-derived common name whenever the resolver chain has one.
+// The common name is label-derived (via SplitSpeciesName); OpenFauna (chain[0]) is
+// authoritative and overrides it whenever the resolver chain has a localized name.
 func (o *Orchestrator) GetSpeciesWithScientificAndCommonName(label string) (scientific, common string) {
-	// Snapshot primary under read lock to avoid racing with Delete().
-	o.mu.RLock()
-	primary := o.primary
-	o.mu.RUnlock()
-	if primary == nil {
+	if o == nil {
 		return "", ""
 	}
-	scientific, common = primary.GetSpeciesWithScientificAndCommonName(label)
+	scientific, common = SplitSpeciesName(label)
 	if scientific != "" {
 		if resolved := o.ResolveName(scientific, ""); resolved != "" {
 			common = resolved
@@ -1273,19 +1295,25 @@ func (o *Orchestrator) GetSpeciesWithScientificAndCommonName(label string) (scie
 }
 
 // EnrichResultWithTaxonomy adds taxonomy information to a detection result.
-// OpenFauna (chain[0]) is authoritative: the resolver chain overrides the
-// label-derived common name whenever it has a name, even if the primary already
-// produced one. This localizes names and fixes scientific-only/bat labels. Only
-// the primary's name is kept when the chain returns nothing.
+// The common name is label-derived (via SplitSpeciesName); OpenFauna (chain[0]) is
+// authoritative and overrides it whenever the resolver chain has a localized name,
+// which localizes names and fixes scientific-only/bat labels. The label-derived
+// name is kept only when the chain returns nothing.
 func (o *Orchestrator) EnrichResultWithTaxonomy(speciesLabel string) (scientific, common, code string) {
-	// Snapshot primary under read lock to avoid racing with Delete().
-	o.mu.RLock()
-	primary := o.primary
-	o.mu.RUnlock()
-	if primary == nil {
+	if o == nil {
 		return "", "", ""
 	}
-	scientific, common, code = primary.EnrichResultWithTaxonomy(speciesLabel)
+	scientific, common = SplitSpeciesName(speciesLabel)
+	if o.taxonomy != nil {
+		var exists bool
+		code, exists = o.taxonomy.speciesCode(speciesLabel)
+		// Gate the debug format on the debug flag so the placeholder-code args are not
+		// built (and o.Debug's lock not taken) on the taxonomy-miss path when debug is
+		// off, matching the old bn.Debug call site which was wrapped in the same check.
+		if !exists && o.currentSettings().BirdNET.Debug {
+			o.Debug("Species '%s' not found in taxonomy, using generated placeholder code: %s", speciesLabel, code)
+		}
+	}
 
 	if scientific != "" {
 		if resolved := o.ResolveName(scientific, ""); resolved != "" {
@@ -1516,15 +1544,12 @@ func (o *Orchestrator) reloadPrimaryModel(reload func(primary *BirdNET) error) e
 			Build()
 	}
 
-	info, taxMap, taxPath, sciIndex := o.primary.ReloadSnapshot()
+	info := o.primary.ReloadSnapshot()
 	// The reloaded primary is a fresh instance: drop its streak, and the previous
 	// ID's when the reload changed it, so neither lingers.
 	dropInferenceFailureStreak(o.ModelInfo.ID)
 	dropInferenceFailureStreak(info.ID)
 	o.ModelInfo = info
-	o.TaxonomyMap = taxMap
-	o.TaxonomyPath = taxPath
-	o.ScientificIndex = sciIndex
 
 	// Re-key the models map in case the model ID changed after reload (Forgejo #270).
 	//
@@ -1553,6 +1578,11 @@ func (o *Orchestrator) reloadPrimaryModel(reload func(primary *BirdNET) error) e
 
 	// Update settings atomically
 	o.updateSettings(o.primary.currentSettings())
+
+	// Re-emit the missing-taxonomy diagnostics for the reloaded label set (e.g. a
+	// locale change), reproducing what BirdNET.loadLabels logged before the taxonomy
+	// moved to the orchestrator.
+	o.logMissingTaxonomyCodes(o.primary, o.primary.Labels())
 
 	return nil
 }

--- a/internal/classifier/orchestrator_race_test.go
+++ b/internal/classifier/orchestrator_race_test.go
@@ -168,13 +168,10 @@ func TestOrchestrator_ConcurrentResolverRegistrationAndResolve_NoRace(t *testing
 }
 
 // TestOrchestrator_ConcurrentReloadSnapshot_NoRace verifies that calling ReloadSnapshot
-// on the primary model concurrently with writes to its ModelInfo / Taxonomy fields does not race.
+// on the primary model concurrently with writes to its ModelInfo does not race.
 func TestOrchestrator_ConcurrentReloadSnapshot_NoRace(t *testing.T) {
 	bn := &BirdNET{}
 	bn.ModelInfo = ModelInfo{ID: "BirdNET_V3", Name: "BirdNET v3.0"}
-	bn.TaxonomyMap = TaxonomyMap{"test": "test"}
-	bn.TaxonomyPath = "path/to/taxonomy"
-	bn.ScientificIndex = ScientificNameIndex{"test": "test"}
 
 	start := make(chan struct{})
 	const iterations = 500
@@ -186,9 +183,6 @@ func TestOrchestrator_ConcurrentReloadSnapshot_NoRace(t *testing.T) {
 		for range iterations {
 			bn.mu.Lock()
 			bn.ModelInfo = ModelInfo{ID: "BirdNET_V3", Name: "BirdNET v3.0"}
-			bn.TaxonomyMap = TaxonomyMap{"test": "test"}
-			bn.TaxonomyPath = "path/to/taxonomy"
-			bn.ScientificIndex = ScientificNameIndex{"test": "test"}
 			bn.mu.Unlock()
 		}
 	})
@@ -197,11 +191,8 @@ func TestOrchestrator_ConcurrentReloadSnapshot_NoRace(t *testing.T) {
 	wg.Go(func() {
 		<-start
 		for range iterations {
-			info, taxMap, taxPath, sciIndex := bn.ReloadSnapshot()
+			info := bn.ReloadSnapshot()
 			_ = info
-			_ = taxMap
-			_ = taxPath
-			_ = sciIndex
 		}
 	})
 
@@ -240,8 +231,8 @@ func TestBirdNET_ConcurrentSettingsReadsAndWrites_NoRace(t *testing.T) {
 		}
 	})
 
-	// Reader: concurrently calls currentSettings, Debug, EnrichResultWithTaxonomy,
-	// and GetProbableSpecies. GetProbableSpecies is the path that previously read
+	// Reader: concurrently calls currentSettings, Debug, Labels, and
+	// GetProbableSpecies. GetProbableSpecies is the path that previously read
 	// bn.Settings without synchronization; it now reads via the atomic accessor
 	// and this exercises that fix under -race.
 	wg.Go(func() {
@@ -250,7 +241,7 @@ func TestBirdNET_ConcurrentSettingsReadsAndWrites_NoRace(t *testing.T) {
 		for range iterations {
 			_ = bn.currentSettings()
 			bn.Debug("test debug message")
-			_, _, _ = bn.EnrichResultWithTaxonomy("Turdus merula_Common Blackbird")
+			_ = bn.Labels()
 			_, _ = bn.GetProbableSpecies(now, 0)
 		}
 	})

--- a/internal/classifier/orchestrator_test.go
+++ b/internal/classifier/orchestrator_test.go
@@ -107,8 +107,10 @@ func TestNewOrchestrator_SyncsSharedState(t *testing.T) {
 
 	// Verify shared state is synced from primary model
 	assert.Equal(t, o.primary.ModelInfo, o.ModelInfo, "ModelInfo should be synced")
-	assert.NotNil(t, o.TaxonomyMap, "TaxonomyMap should be populated")
-	assert.NotNil(t, o.ScientificIndex, "ScientificIndex should be populated")
+	if assert.NotNil(t, o.taxonomy, "taxonomy service should be populated") {
+		assert.NotEmpty(t, o.taxonomy.taxonomyMap, "taxonomy map should be populated")
+		assert.NotEmpty(t, o.taxonomy.sciIndex, "scientific index should be populated")
+	}
 	assert.Equal(t, settings, o.Settings, "Settings should be the same pointer")
 }
 

--- a/internal/classifier/primary_model_path_test.go
+++ b/internal/classifier/primary_model_path_test.go
@@ -336,9 +336,9 @@ func TestNewBirdNET_NilResolverUsesConfiguredPathVerbatim(t *testing.T) {
 // stale-path bug would get a second, louder bug on their very next settings save
 // (a locale change, a threshold edit).
 //
-// No native model is needed: an unreadable TaxonomyPath fails the reload at the
+// No native model is needed: an unreadable LabelPath fails the reload at the
 // first fallible step, which runs AFTER the identity switch. So the error text
-// distinguishes the two outcomes precisely: reaching the taxonomy step proves
+// distinguishes the two outcomes precisely: reaching the load-labels step proves
 // the identity gate let the reload through, and a veto never gets that far.
 func TestReloadModelInternal_RecoveredPathDoesNotVetoReload(t *testing.T) {
 	newServing := func(t *testing.T, configuredPath, liveCustomPath string, resolve primaryPathResolver) *BirdNET {
@@ -346,6 +346,7 @@ func TestReloadModelInternal_RecoveredPathDoesNotVetoReload(t *testing.T) {
 		settings := conftest.GetTestSettings()
 		settings.BirdNET.Version = ""
 		settings.BirdNET.ModelPath = configuredPath
+		settings.BirdNET.LabelPath = filepath.Join(t.TempDir(), "does-not-exist-labels.txt")
 		conftest.SetTestSettings(settings)
 		t.Cleanup(func() { conftest.SetTestSettings(nil) })
 
@@ -353,7 +354,6 @@ func TestReloadModelInternal_RecoveredPathDoesNotVetoReload(t *testing.T) {
 			classifier:     &rollbackFakeClassifier{},
 			Settings:       settings,
 			ModelInfo:      customBirdNETV24ModelInfo(liveCustomPath),
-			TaxonomyPath:   filepath.Join(t.TempDir(), "does-not-exist-taxonomy.json"),
 			speciesCache:   make(map[string]*speciesCacheEntry),
 			resolvePrimary: resolve,
 		}
@@ -381,9 +381,9 @@ func TestReloadModelInternal_RecoveredPathDoesNotVetoReload(t *testing.T) {
 
 		err := bn.reloadModelInternal(false)
 
-		require.Error(t, err, "the reload still fails at the taxonomy step; that is the probe, not the subject")
-		assert.Contains(t, err.Error(), "taxonomy",
-			"the reload must reach the taxonomy step, which proves the identity gate let it through")
+		require.Error(t, err, "the reload still fails at the load-labels step; that is the probe, not the subject")
+		assert.Contains(t, err.Error(), "does-not-exist-labels",
+			"the reload must reach the load-labels step, which proves the identity gate let it through")
 		assert.NotContains(t, err.Error(), "requires orchestrator restart",
 			"re-resolving the recovered path is what stops a recovered start from failing its next settings save")
 	})
@@ -417,15 +417,16 @@ func TestReloadModelInternal_RecoveredPathDoesNotVetoReload(t *testing.T) {
 // detection was attributed to a model that was not running.
 //
 // The discriminator, as in the recovered-path test above, is an unreadable
-// TaxonomyPath that fails the reload at the first fallible step AFTER the identity
-// switch: reaching "taxonomy" would prove the guard let the fall-through through
-// (the bug), while "requires orchestrator restart" proves it refused (the fix).
+// LabelPath that fails the reload at the first fallible step AFTER the identity
+// switch: reaching the load-labels step would prove the guard let the fall-through
+// through (the bug), while "requires orchestrator restart" proves it refused (the fix).
 func TestReloadModelInternal_ClearingPathWhileCustomRunningIsRefused(t *testing.T) {
 	liveCustom := "/srv/models/my_custom_primary.tflite"
 
 	settings := conftest.GetTestSettings()
 	settings.BirdNET.Version = ""
 	settings.BirdNET.ModelPath = "" // the user just cleared the configured path
+	settings.BirdNET.LabelPath = filepath.Join(t.TempDir(), "does-not-exist-labels.txt")
 	conftest.SetTestSettings(settings)
 	t.Cleanup(func() { conftest.SetTestSettings(nil) })
 
@@ -433,7 +434,6 @@ func TestReloadModelInternal_ClearingPathWhileCustomRunningIsRefused(t *testing.
 		classifier:   &rollbackFakeClassifier{},
 		Settings:     settings,
 		ModelInfo:    customBirdNETV24ModelInfo(liveCustom), // a custom model is live
-		TaxonomyPath: filepath.Join(t.TempDir(), "does-not-exist-taxonomy.json"),
 		speciesCache: make(map[string]*speciesCacheEntry),
 		// The resolver mirrors production: a cleared configured path resolves to the
 		// empty result (substituted=false), which is exactly the case the dropped
@@ -452,7 +452,7 @@ func TestReloadModelInternal_ClearingPathWhileCustomRunningIsRefused(t *testing.
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "requires orchestrator restart",
 		"clearing the model path while a custom model runs is a model-identity change and must be refused")
-	assert.NotContains(t, err.Error(), "taxonomy",
+	assert.NotContains(t, err.Error(), "does-not-exist-labels",
 		"the reload must refuse in the identity switch, never fall through to load the baseline under the custom identity")
 }
 
@@ -705,6 +705,7 @@ func TestReloadModelInternal_BuiltinFallbackSteadyStateReloadsCleanly(t *testing
 	settings := conftest.GetTestSettings()
 	settings.BirdNET.Version = ""
 	settings.BirdNET.ModelPath = "/gone/primary_dft.onnx"
+	settings.BirdNET.LabelPath = filepath.Join(t.TempDir(), "does-not-exist-labels.txt")
 	conftest.SetTestSettings(settings)
 	t.Cleanup(func() { conftest.SetTestSettings(nil) })
 
@@ -714,7 +715,6 @@ func TestReloadModelInternal_BuiltinFallbackSteadyStateReloadsCleanly(t *testing
 		classifier:     &rollbackFakeClassifier{},
 		Settings:       settings,
 		ModelInfo:      stockPrimaryModelInfo(),
-		TaxonomyPath:   filepath.Join(t.TempDir(), "does-not-exist-taxonomy.json"),
 		speciesCache:   make(map[string]*speciesCacheEntry),
 		resolvePrimary: func(string) pathResolution { return pathResolution{substituted: true} },
 	}
@@ -724,9 +724,9 @@ func TestReloadModelInternal_BuiltinFallbackSteadyStateReloadsCleanly(t *testing
 
 	err := bn.reloadModelInternal(false)
 
-	require.Error(t, err, "the reload still fails at the taxonomy step; that is the probe, not the subject")
-	assert.Contains(t, err.Error(), "taxonomy",
-		"the reload must reach the taxonomy step, which proves the identity gate let it through")
+	require.Error(t, err, "the reload still fails at the load-labels step; that is the probe, not the subject")
+	assert.Contains(t, err.Error(), "does-not-exist-labels",
+		"the reload must reach the load-labels step, which proves the identity gate let it through")
 	assert.NotContains(t, err.Error(), "requires orchestrator restart",
 		"a steady-state baseline reload must not be refused, or every settings save fails forever")
 }
@@ -757,7 +757,6 @@ func TestReloadModelInternal_VanishedRunningModelIsRefused(t *testing.T) {
 		classifier:     &rollbackFakeClassifier{},
 		Settings:       previous,
 		ModelInfo:      customBirdNETV24ModelInfo(oldPath),
-		TaxonomyPath:   filepath.Join(t.TempDir(), "does-not-exist-taxonomy.json"),
 		speciesCache:   make(map[string]*speciesCacheEntry),
 		resolvePrimary: func(string) pathResolution { return pathResolution{substituted: true} },
 	}
@@ -795,7 +794,6 @@ func TestReloadModelInternal_UnknownVersionNamesTheRequestedVersion(t *testing.T
 		classifier:   &rollbackFakeClassifier{},
 		Settings:     previous,
 		ModelInfo:    ModelRegistry[DefaultModelVersion],
-		TaxonomyPath: filepath.Join(t.TempDir(), "does-not-exist-taxonomy.json"),
 		speciesCache: make(map[string]*speciesCacheEntry),
 	}
 	bn.settingsAtomic.Store(previous)

--- a/internal/classifier/taxonomy_service.go
+++ b/internal/classifier/taxonomy_service.go
@@ -1,0 +1,90 @@
+package classifier
+
+import (
+	"fmt"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+)
+
+// maxMissingSpeciesLogged caps how many missing-taxonomy species are listed
+// individually in the debug diagnostics before switching to a "... and N more"
+// summary, so a large gap does not flood the log.
+const maxMissingSpeciesLogged = 10
+
+// taxonomyService owns the eBird taxonomy the orchestrator answers species-code
+// lookups from. It is built once in NewOrchestrator, before any model loads, from
+// the same embedded data BirdNET used to load, and is read-only afterwards, so it
+// needs no lock. Moving taxonomy ownership off the primary model is the first step
+// of the model de-privilege epic: a code lookup no longer depends on which acoustic
+// model is loaded.
+type taxonomyService struct {
+	taxonomyMap TaxonomyMap
+	sciIndex    ScientificNameIndex
+}
+
+// newTaxonomyService loads the taxonomy through LoadTaxonomyData, exactly as
+// NewBirdNET did, wrapping a failure in the same error category so the constructor
+// fails identically when the embedded (or a custom) taxonomy cannot be parsed.
+// customPath is "" for the embedded taxonomy.
+func newTaxonomyService(customPath string) (*taxonomyService, error) {
+	taxonomyMap, sciIndex, err := LoadTaxonomyData(customPath)
+	if err != nil {
+		return nil, errors.New(err).
+			Component("birdnet").
+			Category(errors.CategoryModelInit).
+			Context("operation", "load_taxonomy").
+			Context("taxonomy_path", customPath).
+			Build()
+	}
+	return &taxonomyService{taxonomyMap: taxonomyMap, sciIndex: sciIndex}, nil
+}
+
+// speciesCode returns the eBird species code for a species name, matching
+// GetSpeciesCodeFromName exactly (a generated placeholder code and false when the
+// species is absent from the taxonomy).
+func (t *taxonomyService) speciesCode(speciesName string) (string, bool) {
+	return GetSpeciesCodeFromName(t.taxonomyMap, t.sciIndex, speciesName)
+}
+
+// nameFromCode returns the "Scientific_Common" name for an eBird code, matching
+// GetSpeciesNameFromCode exactly.
+func (t *taxonomyService) nameFromCode(code string) (string, bool) {
+	return GetSpeciesNameFromCode(t.taxonomyMap, code)
+}
+
+// logMissingCodes logs, at debug level, the labels absent from the taxonomy. The
+// caller supplies the two facts BirdNET.logMissingTaxonomyCodes read off the model
+// (whether a custom model or label file is configured, and whether debug logging is
+// enabled) so the emitted lines match the pre-move behavior, where every line went
+// through bn.Debug and so appeared only with debug enabled. The debug gate is
+// checked first so the taxonomy scan is skipped entirely when debug is off (the
+// default).
+func (t *taxonomyService) logMissingCodes(labels []string, customModelOrLabels, debug bool) {
+	if !debug {
+		return
+	}
+	complete, missing := IsTaxonomyComplete(t.taxonomyMap, labels)
+	if complete {
+		return
+	}
+	debugf := func(format string, v ...any) {
+		GetLogger().Debug(fmt.Sprintf(format, v...))
+	}
+	if customModelOrLabels {
+		debugf("Custom model/labels detected: %d species are missing from the taxonomy data", len(missing))
+		debugf("Placeholder taxonomy codes will be generated for these species")
+	} else {
+		debugf("Warning: %d species are missing from the taxonomy data", len(missing))
+	}
+	for i, species := range missing {
+		if i < maxMissingSpeciesLogged { // Only show the first N to avoid flooding logs
+			code := GeneratePlaceholderCode(species)
+			scientific, common := SplitSpeciesName(species)
+			debugf("Missing taxonomy for '%s' (Sci: '%s', Common: '%s') - using placeholder code: %s",
+				species, scientific, common, code)
+		} else if i == maxMissingSpeciesLogged {
+			debugf("... and %d more", len(missing)-maxMissingSpeciesLogged)
+			break
+		}
+	}
+}

--- a/internal/classifier/taxonomy_service_test.go
+++ b/internal/classifier/taxonomy_service_test.go
@@ -1,0 +1,180 @@
+package classifier
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf/conftest"
+)
+
+// v24EnUKLabelsPath is the embedded v2.4 en_uk label corpus, read from disk so the
+// taxonomy parity tests run over the real label set instead of a synthetic sample.
+const v24EnUKLabelsPath = "data/labels/V2.4/BirdNET_GLOBAL_6K_V2.4_Labels_en_uk.txt"
+
+// readV24Corpus reads the v2.4 en_uk label corpus. It fails hard if the file is
+// missing so a moved or renamed corpus surfaces as a loud failure, not a silent skip.
+func readV24Corpus(t *testing.T) []string {
+	t.Helper()
+	f, err := os.Open(v24EnUKLabelsPath)
+	require.NoError(t, err, "v2.4 label corpus must be present at %s", v24EnUKLabelsPath)
+	t.Cleanup(func() { assert.NoError(t, f.Close()) })
+
+	var labels []string
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		if line := sc.Text(); line != "" {
+			labels = append(labels, line)
+		}
+	}
+	require.NoError(t, sc.Err())
+	require.NotEmpty(t, labels, "v2.4 label corpus must not be empty")
+	return labels
+}
+
+func TestNewTaxonomyService_EmbeddedLoads(t *testing.T) {
+	t.Parallel()
+	svc, err := newTaxonomyService("")
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+	assert.NotEmpty(t, svc.taxonomyMap, "embedded taxonomy map must be populated")
+	assert.NotEmpty(t, svc.sciIndex, "scientific index must be populated")
+}
+
+func TestNewTaxonomyService_CustomPathMissingFails(t *testing.T) {
+	t.Parallel()
+	missing := filepath.Join(t.TempDir(), "does-not-exist-taxonomy.json")
+	svc, err := newTaxonomyService(missing)
+	require.Error(t, err)
+	assert.Nil(t, svc)
+	assert.Contains(t, err.Error(), "does-not-exist-taxonomy", "error must name the unreadable taxonomy file")
+}
+
+// TestTaxonomyService_SpeciesCode_MatchesFreeFunction pins that the service returns
+// the same code and found flag as the free GetSpeciesCodeFromName over the whole
+// v2.4 corpus, plus the legacy-remap and placeholder paths.
+func TestTaxonomyService_SpeciesCode_MatchesFreeFunction(t *testing.T) {
+	t.Parallel()
+	freeMap, freeIndex, err := LoadTaxonomyData("")
+	require.NoError(t, err)
+	svc, err := newTaxonomyService("")
+	require.NoError(t, err)
+
+	labels := readV24Corpus(t)
+	// Exercise the legacy-remap ("hergul" -> "amhgul1") and placeholder paths too.
+	labels = append(labels,
+		"Larus argentatus_Herring Gull",
+		"Definitely Notaspecies_Placeholder Only",
+	)
+	for _, label := range labels {
+		gotCode, gotOK := svc.speciesCode(label)
+		wantCode, wantOK := GetSpeciesCodeFromName(freeMap, freeIndex, label)
+		assert.Equal(t, wantOK, gotOK, "found flag must match for %q", label)
+		assert.Equal(t, wantCode, gotCode, "code must match for %q", label)
+	}
+}
+
+// TestTaxonomyService_NameFromCode_MatchesFreeFunction pins that the service returns
+// the same name and found flag as the free GetSpeciesNameFromCode over every code.
+func TestTaxonomyService_NameFromCode_MatchesFreeFunction(t *testing.T) {
+	t.Parallel()
+	freeMap, _, err := LoadTaxonomyData("")
+	require.NoError(t, err)
+	svc, err := newTaxonomyService("")
+	require.NoError(t, err)
+
+	for code := range freeMap {
+		gotName, gotOK := svc.nameFromCode(code)
+		wantName, wantOK := GetSpeciesNameFromCode(freeMap, code)
+		assert.Equal(t, wantOK, gotOK, "found flag must match for code %q", code)
+		assert.Equal(t, wantName, gotName, "name must match for code %q", code)
+	}
+	_, ok := svc.nameFromCode("definitely-not-a-code")
+	assert.False(t, ok, "an unknown code must report not-found")
+}
+
+// TestOrchestrator_TaxonomyAccessors_AfterDelete documents the intentional
+// post-Delete behavior change: the taxonomy is orchestrator-owned and immutable, so
+// the taxonomy accessors still answer after the primary model is released, where
+// they previously returned empty. No running install can observe this (Delete runs
+// only at shutdown).
+func TestOrchestrator_TaxonomyAccessors_AfterDelete(t *testing.T) {
+	settings := conftest.GetTestSettings()
+	o, err := NewOrchestrator(settings)
+	if err != nil {
+		t.Skipf("Skipping: model not available in test environment: %v", err)
+	}
+
+	const label = "Turdus merula_Eurasian Blackbird"
+	wantCode, wantCodeOK := o.GetSpeciesCode(label)
+	wantName, wantNameOK := o.GetSpeciesNameFromCode(wantCode)
+
+	o.Delete()
+
+	gotCode, gotCodeOK := o.GetSpeciesCode(label)
+	assert.Equal(t, wantCodeOK, gotCodeOK, "GetSpeciesCode must still answer after Delete")
+	assert.Equal(t, wantCode, gotCode, "GetSpeciesCode must return the same code after Delete")
+
+	gotName, gotNameOK := o.GetSpeciesNameFromCode(wantCode)
+	assert.Equal(t, wantNameOK, gotNameOK, "GetSpeciesNameFromCode must still answer after Delete")
+	assert.Equal(t, wantName, gotName, "GetSpeciesNameFromCode must return the same name after Delete")
+}
+
+// TestOrchestrator_TaxonomyWrappers exercises the orchestrator's taxonomy accessors
+// end to end on a real orchestrator, so a regression in the delegation to the
+// taxonomy service, the placeholder-code path, or the ResolveName override is caught
+// (the service-level parity tests cover speciesCode/nameFromCode directly, but not
+// the public wrappers).
+func TestOrchestrator_TaxonomyWrappers(t *testing.T) {
+	settings := conftest.GetTestSettings()
+	o, err := NewOrchestrator(settings)
+	if err != nil {
+		t.Skipf("Skipping: model not available in test environment: %v", err)
+	}
+	t.Cleanup(func() { o.Delete() })
+
+	// A species present in the taxonomy splits correctly and resolves to a code; a
+	// real (non-placeholder) code round-trips through GetSpeciesNameFromCode.
+	const known = "Turdus merula_Eurasian Blackbird"
+	sci, _, code := o.EnrichResultWithTaxonomy(known)
+	assert.Equal(t, "Turdus merula", sci, "scientific name must be split from the label")
+	require.NotEmpty(t, code, "a known species must resolve to a code")
+	if name, ok := o.GetSpeciesNameFromCode(code); ok {
+		assert.NotEmpty(t, name, "a resolvable code must map to a non-empty name")
+	}
+
+	// A species absent from the taxonomy still splits and gets the deterministic
+	// placeholder code (never empty), matching the free function.
+	const unknown = "Zzz notaspecies_Placeholder Only"
+	usci, _, ucode := o.EnrichResultWithTaxonomy(unknown)
+	assert.Equal(t, "Zzz notaspecies", usci)
+	assert.Equal(t, GeneratePlaceholderCode(unknown), ucode, "an unknown species must get the placeholder code")
+}
+
+// TestTaxonomyService_LogMissingCodes exercises the debug-logging branches directly:
+// the orchestrator path only reaches logMissingCodes with a complete corpus and, by
+// default, debug off, so the missing-species loop and the ">N more" truncation are
+// otherwise untested. The log output is debug-only; this asserts the branch logic
+// runs without panicking for both phrasings and both debug states.
+func TestTaxonomyService_LogMissingCodes(t *testing.T) {
+	t.Parallel()
+	// A tiny taxonomy that knows one species, so every other label is "missing".
+	svc := &taxonomyService{
+		taxonomyMap: TaxonomyMap{"Turdus merula_Eurasian Blackbird": "eurbla"},
+		sciIndex:    ScientificNameIndex{"Turdus merula": "eurbla"},
+	}
+	labels := make([]string, 0, 1+maxMissingSpeciesLogged+5)
+	labels = append(labels, "Turdus merula_Eurasian Blackbird")
+	for i := range maxMissingSpeciesLogged + 5 {
+		labels = append(labels, fmt.Sprintf("Genus species%d_Common %d", i, i))
+	}
+	// Both phrasings with debug on exercise the loop and the truncation branch.
+	assert.NotPanics(t, func() { svc.logMissingCodes(labels, true, true) })
+	assert.NotPanics(t, func() { svc.logMissingCodes(labels, false, true) })
+	// Debug off is the early-return path (no scan, no logging).
+	assert.NotPanics(t, func() { svc.logMissingCodes(labels, false, false) })
+}

--- a/internal/classifier/taxonomy_service_test.go
+++ b/internal/classifier/taxonomy_service_test.go
@@ -111,7 +111,9 @@ func TestOrchestrator_TaxonomyAccessors_AfterDelete(t *testing.T) {
 
 	const label = "Turdus merula_Eurasian Blackbird"
 	wantCode, wantCodeOK := o.GetSpeciesCode(label)
+	require.True(t, wantCodeOK, "a known species must resolve to a real code, not a placeholder")
 	wantName, wantNameOK := o.GetSpeciesNameFromCode(wantCode)
+	require.True(t, wantNameOK, "the resolved code must round-trip to a name before Delete")
 
 	o.Delete()
 
@@ -143,9 +145,9 @@ func TestOrchestrator_TaxonomyWrappers(t *testing.T) {
 	sci, _, code := o.EnrichResultWithTaxonomy(known)
 	assert.Equal(t, "Turdus merula", sci, "scientific name must be split from the label")
 	require.NotEmpty(t, code, "a known species must resolve to a code")
-	if name, ok := o.GetSpeciesNameFromCode(code); ok {
-		assert.NotEmpty(t, name, "a resolvable code must map to a non-empty name")
-	}
+	name, ok := o.GetSpeciesNameFromCode(code)
+	require.True(t, ok, "a known species's code must round-trip through GetSpeciesNameFromCode")
+	assert.NotEmpty(t, name, "a resolvable code must map to a non-empty name")
 
 	// A species absent from the taxonomy still splits and gets the deterministic
 	// placeholder code (never empty), matching the free function.


### PR DESCRIPTION
## Summary

Moves the embedded eBird taxonomy off the primary BirdNET model into a new orchestrator-owned, immutable `taxonomyService`. This is the first step of decoupling model-independent services from the primary model: a species-code lookup no longer depends on which acoustic model is loaded.

`BirdNET` loses its `TaxonomyMap`/`ScientificIndex`/`TaxonomyPath` fields, the per-construction and per-reload taxonomy load, the taxonomy rollback snapshot/restore, and the `GetSpeciesCode`/`EnrichResultWithTaxonomy`/`GetSpeciesWithScientificAndCommonName` methods (the orchestrator was their only caller). `ReloadSnapshot` now returns `ModelInfo` only.

The orchestrator owns the taxonomy service, built once in `NewOrchestrator` before the primary model via the same `LoadTaxonomyData` path, so a load failure aborts construction exactly as before. Its taxonomy accessors answer from the immutable service without a lock, removing the per-request `o.mu` acquisitions and the per-reload `maps.Clone`. The missing-taxonomy debug diagnostics move to the orchestrator.

No observable behavior change for a running install: the taxonomy is the same embedded file loaded by the same function, every lookup returns the same result, and the removed per-reload taxonomy reload was a no-op refresh (the path was always the embedded default). The one intentional delta is shutdown-only: the taxonomy accessors now answer after the primary model is released, where they previously returned empty.

## Related Issues

None. Internal refactor, no user-facing change.

## Test Plan

- [x] `go test -race ./internal/classifier/... ./internal/analysis/processor/ ./internal/api/v2/species/` passes
- [x] `golangci-lint run` clean across the build-tag matrix (default, notflite, noembed, noasm, openvino)
- [x] New taxonomy-service parity suite against the free functions over the full v2.4 label corpus, plus orchestrator-level coverage for the reworked accessors
- [x] Reload rollback and identity-gate tests updated to probe at the label-load step, since taxonomy is no longer loaded per reload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Taxonomy data is now managed independently from acoustic model state, improving consistency for species-code and name lookups.
  * Taxonomy-based result enrichment remains available through the orchestrator.
  * Taxonomy lookups remain available even when the primary model is removed.
  * Missing taxonomy codes can be reported through debug diagnostics, with excessive reports limited for readability.

* **Reliability**
  * Model reloads and rollback behavior better preserve the active classifier when label loading fails.

* **Tests**
  * Expanded coverage for taxonomy loading, lookups, enrichment, logging, concurrency, and reload recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->