### PR TITLE
perf(api): answer GET /api/v2/species from the species-index snapshot

### DIFF
--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -106,9 +106,9 @@ type Controller struct {
 	// (species info, rarity, the all-species picker, the dictionary, thumbnails,
 	// and genus/family/tree lookups). Besides the shared *apicore.Core it receives
 	// two facade-owned function dependencies: a read accessor over the shared
-	// scientific-to-common name map (loadCommonNameMap) and the media domain's
-	// species-image proxy handler (ServeSpeciesImageProxy), both still owned by
-	// package api until their domains are extracted.
+	// orchestrator-owned species-index snapshot (loadNameMaps) and the media
+	// domain's species-image proxy handler (ServeSpeciesImageProxy), both still
+	// owned by package api until their domains are extracted.
 	species *species.Handler
 
 	// models serves the /api/v2/models/* endpoints (listing enabled classifier
@@ -504,9 +504,9 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	// because species injects c.media.ServeSpeciesImageProxy (a method value on
 	// the media handler) for its thumbnail endpoint.
 	c.media = mediaapi.New(c.Core)
-	// The species handler delegates to two dependencies: loadCommonNameMap (the
-	// shared name-map read accessor, facade-owned in name_maps.go) and the media
-	// domain's species-image proxy handler
+	// The species handler delegates to two dependencies: loadNameMaps (the shared
+	// species-index snapshot read accessor, facade-owned in name_maps.go) and the
+	// media domain's species-image proxy handler
 	// (c.media.ServeSpeciesImageProxy). They are passed as bound method values; c
 	// is fully constructed here, so the method values are stable for its lifetime.
 	c.species = species.New(c.Core, c.loadNameMaps, c.media.ServeSpeciesImageProxy)

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -509,7 +509,7 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	// domain's species-image proxy handler
 	// (c.media.ServeSpeciesImageProxy). They are passed as bound method values; c
 	// is fully constructed here, so the method values are stable for its lifetime.
-	c.species = species.New(c.Core, c.loadCommonNameMap, c.media.ServeSpeciesImageProxy)
+	c.species = species.New(c.Core, c.loadNameMaps, c.media.ServeSpeciesImageProxy)
 	// The support handler needs only the shared core (settings, datastore, V2
 	// manager, and the error/log/goroutine helpers all promote from it).
 	c.support = support.New(c.Core)

--- a/internal/api/v2/species/species.go
+++ b/internal/api/v2/species/species.go
@@ -412,10 +412,16 @@ func (c *Handler) getSpeciesInfo(ctx context.Context, scientificName string) (*S
 			Build()
 	}
 
-	// Search the full multi-model label union (primary plus secondary models such
-	// as the bat/Perch classifiers) so a secondary-model scientific name resolves
-	// instead of 404ing. The snapshot's Labels field is the orchestrator-owned
-	// union that used to be materialized per request by bn.AllLabels().
+	// Resolve against the orchestrator-owned species-index snapshot, the same set
+	// the /species/all picker reads. Its label set is a SUPERSET of the loaded
+	// models' labels: it is unionLabels(AllLabels, the range-filter inclusion list),
+	// so besides the primary and secondary (bat/Perch) model labels it also covers
+	// the species the active range filter currently includes at this location. This
+	// is a deliberate widening from the previous bn.AllLabels() request-path read: a
+	// range-filter-included species that is not a label of any loaded model now
+	// resolves here (200) instead of 404ing, matching what the picker already lists.
+	// It is additive: every name that resolved before still resolves, and AllLabels
+	// members sort first in the union so exact-before-alias ordering is unchanged.
 	snap := c.speciesSnapshot()
 	matchedLabel, commonName := resolveSpeciesLabel(snap, scientificName)
 

--- a/internal/api/v2/species/species.go
+++ b/internal/api/v2/species/species.go
@@ -91,6 +91,13 @@ func (c *Handler) backend() speciesBackend {
 // dependencies the species handlers delegate to (the species-index snapshot
 // accessor and the media image-proxy handler).
 func New(core *apicore.Core, speciesSnapshot func() *speciesindex.Snapshot, serveImageProxy echo.HandlerFunc) *Handler {
+	// GetAllSpecies and getSpeciesInfo call speciesSnapshot() and index its result
+	// without a nil guard, so default a nil accessor to the empty snapshot rather
+	// than panicking at request time. The facade's loadNameMaps never returns nil,
+	// so this only guards a misconfigured caller.
+	if speciesSnapshot == nil {
+		speciesSnapshot = speciesindex.Empty
+	}
 	return &Handler{Core: core, speciesSnapshot: speciesSnapshot, serveImageProxy: serveImageProxy}
 }
 

--- a/internal/api/v2/species/species.go
+++ b/internal/api/v2/species/species.go
@@ -38,7 +38,6 @@ import (
 	"github.com/tphakala/birdnet-go/internal/ebird"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
-	"github.com/tphakala/birdnet-go/internal/openfauna"
 	"github.com/tphakala/birdnet-go/internal/speciesindex"
 )
 
@@ -347,19 +346,26 @@ func (c *Handler) allModelLabels() []string {
 // the alias fallback then answers a request for the absent member with the present one's
 // label, which is the same behaviour any alias resolution has and is still better than
 // reporting nothing, but it is not a guarantee that the two never cross.
-func resolveSpeciesLabel(targetSci string, allLabels []string) (matchedLabel, commonName string) {
-	for _, label := range allLabels {
+//
+// Both passes run over snap.LabelsByCanonical[key(target)], the group of labels
+// sharing the request's canonical key. That group holds every label an exact or an
+// alias match could return, appended in the snapshot's label-union order, so the
+// exact-before-alias rule and "first match in union order" are preserved while the
+// per-request openfauna.CanonicalName scan over every label is gone.
+func resolveSpeciesLabel(snap *speciesindex.Snapshot, targetSci string) (matchedLabel, commonName string) {
+	if snap == nil {
+		return "", ""
+	}
+	candidates := snap.LabelsByCanonical[speciesindex.CanonicalKey(targetSci)]
+	for _, label := range candidates {
 		if strings.EqualFold(detection.ExtractScientificName(label), targetSci) {
 			return label, detection.ParseSpeciesString(label).CommonName
 		}
 	}
-	// No label carries this exact name, so fall back to the taxonomic alias and let a
-	// request naming a species by a legacy synonym resolve to its current name.
-	canonicalTarget := openfauna.CanonicalName(targetSci)
-	for _, label := range allLabels {
-		if labelMatchesSpecies(label, canonicalTarget) {
-			return label, detection.ParseSpeciesString(label).CommonName
-		}
+	// No candidate carries this exact name, so fall back to the taxonomic alias: any
+	// candidate shares the canonical key, so the first in union order is the alias hit.
+	if len(candidates) > 0 {
+		return candidates[0], detection.ParseSpeciesString(candidates[0]).CommonName
 	}
 	return "", ""
 }
@@ -411,7 +417,7 @@ func (c *Handler) getSpeciesInfo(ctx context.Context, scientificName string) (*S
 	// instead of 404ing. The snapshot's Labels field is the orchestrator-owned
 	// union that used to be materialized per request by bn.AllLabels().
 	snap := c.speciesSnapshot()
-	matchedLabel, commonName := resolveSpeciesLabel(scientificName, snap.Labels)
+	matchedLabel, commonName := resolveSpeciesLabel(snap, scientificName)
 
 	// If species not found in any loaded model's labels, return error
 	if matchedLabel == "" {
@@ -450,7 +456,7 @@ func (c *Handler) getSpeciesInfo(ctx context.Context, scientificName string) (*S
 	}
 
 	// Get rarity information
-	rarityInfo, err := c.getSpeciesRarityInfo(backend, matchedLabel)
+	rarityInfo, err := c.getSpeciesRarityInfo(backend, snap, matchedLabel)
 	if err != nil {
 		// Log error but don't fail the request
 		c.Debug("Failed to get rarity info for species %s: %v", scientificName, err)
@@ -473,44 +479,37 @@ func (c *Handler) getSpeciesInfo(ctx context.Context, scientificName string) (*S
 	return info, nil
 }
 
-// labelMatchesSpecies reports whether a "Scientific_Common" label denotes the same
-// taxon as canonicalTarget, which the caller must have already passed through
-// openfauna.CanonicalName. Both sides are canonicalized so a legacy synonym in the
-// label (or in the request) matches the current name, and compared case-insensitively
-// because CanonicalName preserves the input's case for names it has no alias for.
-func labelMatchesSpecies(label, canonicalTarget string) bool {
-	return strings.EqualFold(openfauna.CanonicalName(detection.ExtractScientificName(label)), canonicalTarget)
-}
-
 // speciesHasGeomodelCoverage reports whether the active range filter can produce an
-// occurrence probability for the scientific name. It answers against the geomodel's own
+// occurrence probability for the canonical key. It answers against the geomodel's own
 // vocabulary, which for the universal geomodel is much larger than the primary
 // classifier's (it spans birds, bats, other mammals and insects), so a species the
-// classifier cannot name still gets a real rarity.
+// classifier cannot name still gets a real rarity. The geomodel vocabulary carries a
+// precomputed canonical-key memo, so this is an O(1) map lookup with no per-label
+// openfauna.CanonicalName scan.
 //
-// geomodelLabels is empty for every backend other than the universal geomodel: the
-// TFLite meta model and the plain ONNX range filter are keyed to the classifier's own
-// labels, so falling back to classifierLabels is the correct vocabulary for those, not a
-// degraded approximation.
+// rc.Geomodel is nil (or empty) for every backend other than the universal geomodel:
+// the TFLite meta model and the plain ONNX range filter are keyed to the classifier's
+// own labels, so falling back to rc.ClassifierLabels is the correct vocabulary for
+// those, not a degraded approximation. The fallback scans the classifier labels through
+// the snapshot's canonical memo (every classifier label is in the union, so the scan is
+// allocation-free) and MUST NOT use the snapshot's union membership: the union includes
+// secondary-model labels, and the classifier-backed answer is against the primary's
+// labels only.
 //
-// It is also empty in two states where the fallback grants nominal coverage to every
+// The classifier fallback also runs in two states that grant nominal coverage to every
 // classifier species even though nothing is scoring them, so each reports "very rare" at
 // score 0: no location configured, and no range filter loaded. Only the first is visible
-// to a client, via SpeciesRarityInfo.LocationBased; a range filter that failed to load
-// leaves LocationBased true, so a caller cannot currently distinguish that state from a
-// genuine result. That predates this function's signature and is not something callers
-// can guard against today.
+// to a client, via SpeciesRarityInfo.LocationBased. That predates this function and is
+// not something callers can guard against today.
 //
 // A species in neither vocabulary (a secondary-model-only species the geomodel does not
 // cover) has no occurrence probability to base a rarity on.
-func speciesHasGeomodelCoverage(targetSci string, geomodelLabels, classifierLabels []string) bool {
-	labels := geomodelLabels
-	if len(labels) == 0 {
-		labels = classifierLabels
+func speciesHasGeomodelCoverage(key string, rc *classifier.RarityContext, snap *speciesindex.Snapshot) bool {
+	if rc.Geomodel != nil && len(rc.Geomodel.Labels) > 0 {
+		return rc.Geomodel.HasCanonical(key)
 	}
-	canonicalTarget := openfauna.CanonicalName(targetSci)
-	for _, label := range labels {
-		if labelMatchesSpecies(label, canonicalTarget) {
+	for _, label := range rc.ClassifierLabels {
+		if snap.CanonicalKey(label) == key {
 			return true
 		}
 	}
@@ -519,13 +518,20 @@ func speciesHasGeomodelCoverage(targetSci string, geomodelLabels, classifierLabe
 
 // findNativeSpeciesScore returns the native occurrence score for targetSci from a
 // probable-species list, ignoring force-added score-1.0 override rows. It matches on
-// the exact scientific name across the whole list before trying any alias, for the
+// the exact scientific name across the whole list before trying any alias key, for the
 // reason resolveSpeciesLabel documents: the alias map merges pairs the classifier
 // ships as separate species, and an alias-first match would report one bird's
 // occurrence probability for the other. As there, the separation holds only while
 // both members are in the list; the probable-species list carries only species above
 // today's threshold, so one member being absent is the common case.
-func findNativeSpeciesScore(targetSci string, speciesScores []classifier.SpeciesScore) (float64, bool) {
+//
+// Rows tagged IsSyntheticOverride (the force-include 1.0 sentinels appended by
+// addUserOverrideSpeciesScores) are skipped in BOTH passes: membership in a vocabulary
+// cannot express that distinction, and reading the sentinel as a rarity reintroduces
+// the #3975 leak. The skip runs before keyOf is consulted, so a synthetic row costs
+// nothing and can never be returned. keyOf memoizes the canonical key per label
+// (geomodel labels via the vocabulary, classifier labels via the snapshot).
+func findNativeSpeciesScore(targetSci, key string, speciesScores []classifier.SpeciesScore, keyOf func(string) string) (float64, bool) {
 	for _, ss := range speciesScores {
 		if ss.IsSyntheticOverride {
 			continue
@@ -534,12 +540,11 @@ func findNativeSpeciesScore(targetSci string, speciesScores []classifier.Species
 			return ss.Score, true
 		}
 	}
-	canonicalTarget := openfauna.CanonicalName(targetSci)
 	for _, ss := range speciesScores {
 		if ss.IsSyntheticOverride {
 			continue
 		}
-		if labelMatchesSpecies(ss.Label, canonicalTarget) {
+		if keyOf(ss.Label) == key {
 			return ss.Score, true
 		}
 	}
@@ -565,11 +570,12 @@ func findNativeSpeciesScore(targetSci string, speciesScores []classifier.Species
 //
 // A covered species present in the list is scored directly; one that is covered but
 // absent is below today's threshold and therefore genuinely very rare.
-// It takes the whole RarityContext (by pointer, since it is a large struct) rather than
-// its fields spread positionally: the two label vocabularies are adjacent same-typed
-// []string fields on that struct, so passing them loose invited a silent
-// geomodel/classifier swap.
-func computeRarity(rc *classifier.RarityContext, targetSci string) (float64, RarityStatus) {
+//
+// It takes the whole RarityContext by pointer (a large struct) plus the snapshot and
+// the request's precomputed canonical key: coverage and the alias score pass both key
+// off it, so it is computed once by the caller (getSpeciesRarityInfo) rather than
+// recomputed per pass.
+func computeRarity(rc *classifier.RarityContext, snap *speciesindex.Snapshot, key, targetSci string) (float64, RarityStatus) {
 	// Without an active range filter the probable-species list is synthetic zero
 	// scores for every label, so a covered species would score 0.0 and be
 	// misreported as "very rare" at "0%". The occurrence probability is genuinely
@@ -579,18 +585,31 @@ func computeRarity(rc *classifier.RarityContext, targetSci string) (float64, Rar
 		return 0.0, RarityUnknown
 	}
 
-	if !speciesHasGeomodelCoverage(targetSci, rc.GeomodelLabels, rc.ClassifierLabels) {
+	if !speciesHasGeomodelCoverage(key, rc, snap) {
 		return 0.0, RarityUnknown
 	}
 
-	if score, found := findNativeSpeciesScore(targetSci, rc.Scores); found {
+	// keyOf memoizes the canonical key per probable-species label: geomodel labels
+	// via the vocabulary's precomputed memo, everything else via the snapshot. It is
+	// consulted only after the synthetic-override skip and the exact pass, so it runs
+	// at most once per native row.
+	keyOf := func(label string) string {
+		if rc.Geomodel != nil {
+			if k, ok := rc.Geomodel.CanonicalByLabel[label]; ok {
+				return k
+			}
+		}
+		return snap.CanonicalKey(label)
+	}
+
+	if score, found := findNativeSpeciesScore(targetSci, key, rc.Scores, keyOf); found {
 		return score, calculateRarityStatus(score)
 	}
 
 	return 0.0, RarityVeryRare
 }
 
-func (c *Handler) getSpeciesRarityInfo(backend speciesBackend, speciesLabel string) (SpeciesRarityInfo, error) {
+func (c *Handler) getSpeciesRarityInfo(backend speciesBackend, snap *speciesindex.Snapshot, speciesLabel string) (SpeciesRarityInfo, error) {
 	// Get current local date
 	today := conf.LocalNoon(time.Now())
 
@@ -640,9 +659,11 @@ func (c *Handler) getSpeciesRarityInfo(backend speciesBackend, speciesLabel stri
 	}
 
 	// Resolve the score and status together; computeRarity documents how an absent
-	// species is split between "very rare" and "unknown" by geomodel coverage.
+	// species is split between "very rare" and "unknown" by geomodel coverage. The
+	// matched label is in the union, so its canonical key is a snapshot memo hit.
+	key := snap.CanonicalKey(speciesLabel)
 	targetSci := detection.ExtractScientificName(speciesLabel)
-	rarityInfo.Score, rarityInfo.Status = computeRarity(&rc, targetSci)
+	rarityInfo.Score, rarityInfo.Status = computeRarity(&rc, snap, key, targetSci)
 
 	return rarityInfo, nil
 }

--- a/internal/api/v2/species/species.go
+++ b/internal/api/v2/species/species.go
@@ -10,10 +10,13 @@
 // Two dependencies the species handlers need are owned by other parts of the
 // monolith that have not been extracted yet, so the facade injects them as
 // function values (the tls-domain facade-dependency-injection precedent):
-//   - commonNameMap: a read accessor over the shared scientific-to-common name
-//     map. The name-map plumbing lives in the facade package because several
-//     domains share it (the index itself is orchestrator-owned since Phase 2a);
-//     species only needs read access.
+//   - speciesSnapshot: a read accessor over the shared, orchestrator-owned
+//     species-index snapshot (the scientific-to-common name map plus the
+//     label-union canonical memo maps). The name-map plumbing lives in the facade
+//     package because several domains share it (the index itself is
+//     orchestrator-owned since Phase 2a); species only needs read access, and it
+//     answers the endpoint from the precomputed memo maps instead of scanning
+//     every label per request.
 //   - serveImageProxy: the media domain's bird-image proxy handler, which the
 //     species thumbnail endpoint delegates to. When media is extracted this can
 //     point at the media handler instead.
@@ -36,6 +39,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/openfauna"
+	"github.com/tphakala/birdnet-go/internal/speciesindex"
 )
 
 // Handler serves the species domain endpoints. It embeds *apicore.Core BY
@@ -44,10 +48,18 @@ import (
 type Handler struct {
 	*apicore.Core
 
-	// commonNameMap returns the current scientific-to-common lookup map, owned by
-	// the facade's name-map plumbing and injected so species stays read-only over
-	// it. Always returns a non-nil map.
-	commonNameMap func() map[string]string
+	// speciesSnapshot returns the current orchestrator-owned species-index
+	// snapshot (the scientific-to-common map plus the label-union canonical memo
+	// maps), owned by the facade's name-map plumbing and injected so species stays
+	// read-only over it. Always returns a non-nil snapshot.
+	speciesSnapshot func() *speciesindex.Snapshot
+
+	// speciesBackendOverride, when non-nil, replaces Processor.Bn as the model
+	// backend the species-info path localizes names and reads rarity through. Only
+	// tests and benchmarks set it, so they can exercise the endpoint without
+	// loading a native model; production leaves it nil and backend() falls through
+	// to Processor.Bn.
+	speciesBackendOverride speciesBackend
 
 	// serveImageProxy is the media domain's species-image proxy handler. The
 	// thumbnail endpoint resolves a species code to a scientific name and then
@@ -55,11 +67,32 @@ type Handler struct {
 	serveImageProxy echo.HandlerFunc
 }
 
+// speciesBackend is the minimal slice of the model orchestrator the species-info
+// path needs: localize a name and read the rarity context. *classifier.Orchestrator
+// satisfies it; tests and benchmarks inject a fake via speciesBackendOverride so the
+// endpoint can be exercised without loading a native model.
+type speciesBackend interface {
+	ResolveName(scientificName, locale string) string
+	GetRarityContext(date time.Time) (classifier.RarityContext, error)
+}
+
+// backend returns the injected test backend when set, otherwise the live
+// orchestrator (Processor.Bn), or nil when no orchestrator is available.
+func (c *Handler) backend() speciesBackend {
+	if c.speciesBackendOverride != nil {
+		return c.speciesBackendOverride
+	}
+	if proc := c.Processor; proc != nil && proc.Bn != nil {
+		return proc.Bn
+	}
+	return nil
+}
+
 // New builds a species Handler around the shared core and the two facade-owned
-// dependencies the species handlers delegate to (the common-name map accessor
-// and the media image-proxy handler).
-func New(core *apicore.Core, commonNameMap func() map[string]string, serveImageProxy echo.HandlerFunc) *Handler {
-	return &Handler{Core: core, commonNameMap: commonNameMap, serveImageProxy: serveImageProxy}
+// dependencies the species handlers delegate to (the species-index snapshot
+// accessor and the media image-proxy handler).
+func New(core *apicore.Core, speciesSnapshot func() *speciesindex.Snapshot, serveImageProxy echo.HandlerFunc) *Handler {
+	return &Handler{Core: core, speciesSnapshot: speciesSnapshot, serveImageProxy: serveImageProxy}
 }
 
 // RegisterRoutes registers all species-related API endpoints on the supplied API
@@ -156,14 +189,14 @@ func (c *Handler) lookupTaxonomyEitherName(ctx context.Context, primary, seconda
 // resolveEitherName localizes a common name under whichever of the two scientific names
 // the resolver's working set is keyed on, for the reason lookupTaxonomyEitherName
 // documents.
-func (c *Handler) resolveEitherName(bn *classifier.Orchestrator, primary, secondary string) string {
-	if resolved := bn.ResolveName(primary, c.CurrentLocale()); resolved != "" {
+func (c *Handler) resolveEitherName(backend speciesBackend, primary, secondary string) string {
+	if resolved := backend.ResolveName(primary, c.CurrentLocale()); resolved != "" {
 		return resolved
 	}
 	if strings.EqualFold(primary, secondary) {
 		return ""
 	}
-	return bn.ResolveName(secondary, c.CurrentLocale())
+	return backend.ResolveName(secondary, c.CurrentLocale())
 }
 
 // lookupTaxonomyTree attempts to find taxonomy for a species, trying local DB first then eBird.
@@ -216,7 +249,7 @@ func (c *Handler) GetAllSpecies(ctx echo.Context) error {
 		logger.String("path", path),
 	)
 
-	speciesList := buildAllSpeciesList(c.commonNameMap(), c.allModelLabels())
+	speciesList := buildAllSpeciesList(c.speciesSnapshot().SciToCommon, c.allModelLabels())
 
 	c.LogInfoIfEnabled("All species labels retrieved successfully",
 		logger.Int("count", len(speciesList)),
@@ -363,21 +396,22 @@ func (c *Handler) GetSpeciesInfo(ctx echo.Context) error {
 
 // getSpeciesInfo retrieves species information including rarity status
 func (c *Handler) getSpeciesInfo(ctx context.Context, scientificName string) (*SpeciesInfo, error) {
-	// Snapshot to avoid TOCTOU race on c.Processor
-	proc := c.Processor
-	if proc == nil || proc.Bn == nil {
+	// Snapshot the backend once to avoid a TOCTOU race on c.Processor and to let
+	// tests inject a fake orchestrator without loading a native model.
+	backend := c.backend()
+	if backend == nil {
 		return nil, errors.Newf("BirdNET processor not available").
 			Category(errors.CategorySystem).
 			Component("api-species").
 			Build()
 	}
 
-	bn := proc.Bn
-
 	// Search the full multi-model label union (primary plus secondary models such
 	// as the bat/Perch classifiers) so a secondary-model scientific name resolves
-	// instead of 404ing.
-	matchedLabel, commonName := resolveSpeciesLabel(scientificName, bn.AllLabels())
+	// instead of 404ing. The snapshot's Labels field is the orchestrator-owned
+	// union that used to be materialized per request by bn.AllLabels().
+	snap := c.speciesSnapshot()
+	matchedLabel, commonName := resolveSpeciesLabel(scientificName, snap.Labels)
 
 	// If species not found in any loaded model's labels, return error
 	if matchedLabel == "" {
@@ -401,7 +435,7 @@ func (c *Handler) getSpeciesInfo(ctx context.Context, scientificName string) (*S
 	// name) as "needs localizing" and resolve through the orchestrator's
 	// OpenFauna-authoritative resolver, passing the configured locale explicitly.
 	if commonName == "" || strings.EqualFold(commonName, matchedSci) {
-		if resolved := c.resolveEitherName(bn, matchedSci, scientificName); resolved != "" {
+		if resolved := c.resolveEitherName(backend, matchedSci, scientificName); resolved != "" {
 			commonName = resolved
 		}
 	}
@@ -416,7 +450,7 @@ func (c *Handler) getSpeciesInfo(ctx context.Context, scientificName string) (*S
 	}
 
 	// Get rarity information
-	rarityInfo, err := c.getSpeciesRarityInfo(bn, matchedLabel)
+	rarityInfo, err := c.getSpeciesRarityInfo(backend, matchedLabel)
 	if err != nil {
 		// Log error but don't fail the request
 		c.Debug("Failed to get rarity info for species %s: %v", scientificName, err)
@@ -556,7 +590,7 @@ func computeRarity(rc *classifier.RarityContext, targetSci string) (float64, Rar
 	return 0.0, RarityVeryRare
 }
 
-func (c *Handler) getSpeciesRarityInfo(bn *classifier.Orchestrator, speciesLabel string) (SpeciesRarityInfo, error) {
+func (c *Handler) getSpeciesRarityInfo(backend speciesBackend, speciesLabel string) (SpeciesRarityInfo, error) {
 	// Get current local date
 	today := conf.LocalNoon(time.Now())
 
@@ -567,7 +601,7 @@ func (c *Handler) getSpeciesRarityInfo(bn *classifier.Orchestrator, speciesLabel
 	// GetRarityContext returns the settings snapshot it scored against, so location,
 	// threshold, coordinates and filterActive below all describe one settings generation;
 	// a concurrent reload cannot desynchronise the rarity number from its metadata.
-	rc, err := bn.GetRarityContext(today)
+	rc, err := backend.GetRarityContext(today)
 	if err != nil {
 		return SpeciesRarityInfo{}, errors.New(err).
 			Category(errors.CategoryProcessing).

--- a/internal/api/v2/species/species_bench_test.go
+++ b/internal/api/v2/species/species_bench_test.go
@@ -1,0 +1,130 @@
+// species_bench_test.go: benchmark and allocation ceiling for GET /api/v2/species.
+//
+// Before the species-index snapshot refactor the endpoint made tens of thousands of
+// short-lived allocations per request, one openfauna.CanonicalName (a TrimSpace +
+// ToLower) per label across three linear passes over the full label union and the
+// geomodel vocabulary. These pin that the snapshot memo maps removed that storm.
+package species
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/classifier"
+	"github.com/tphakala/birdnet-go/internal/speciesindex"
+)
+
+// benchLabelCount and benchGeomodelCount size the worst-case working set: a 21K-label
+// union (a v2.4 + Perch + bat install padded) and a 12K-entry geomodel vocabulary.
+const (
+	benchLabelCount    = 21000
+	benchGeomodelCount = 12000
+)
+
+// benchLabels pads the real corpus with synthetic scientific-only labels up to
+// benchLabelCount so the resolver walks a production-scale union.
+func benchLabels(tb testing.TB) []string {
+	tb.Helper()
+	base := goldenCorpus(tb)
+	labels := make([]string, 0, benchLabelCount)
+	labels = append(labels, base...)
+	for i := len(labels); i < benchLabelCount; i++ {
+		labels = append(labels, fmt.Sprintf("Synthetica species%d_Synthetic Bird %d", i, i))
+	}
+	return labels
+}
+
+// benchUniversalContext builds a universal-geomodel rarity context whose vocabulary
+// has benchGeomodelCount entries, covering and scoring the benchmark request species.
+func benchUniversalContext() classifier.RarityContext {
+	vocab := make([]string, 0, benchGeomodelCount)
+	vocab = append(vocab, "Turdus merula_syn", "Spilopelia senegalensis_syn")
+	for i := len(vocab); i < benchGeomodelCount; i++ {
+		vocab = append(vocab, fmt.Sprintf("Geomodelica species%d_Geo %d", i, i))
+	}
+	return classifier.RarityContext{
+		Scores: []classifier.SpeciesScore{
+			{Label: "Turdus merula_syn", Score: 0.42},
+			{Label: "Spilopelia senegalensis_syn", Score: 0.1},
+		},
+		Geomodel:     classifier.NewLabelVocabulary(vocab),
+		FilterActive: true,
+		Settings:     goldenSettings(),
+	}
+}
+
+// benchLegacyContext builds a legacy (no geomodel) context: coverage falls back to a
+// full scan of the classifier labels through the snapshot memo, allocation-free.
+func benchLegacyContext(classifierLabels []string) classifier.RarityContext {
+	return classifier.RarityContext{
+		Scores:           []classifier.SpeciesScore{{Label: "Turdus merula_syn", Score: 0.42}},
+		Geomodel:         nil,
+		ClassifierLabels: classifierLabels,
+		FilterActive:     true,
+		Settings:         goldenSettings(),
+	}
+}
+
+// newSnapshotHandler builds a species Handler over a prebuilt snapshot and a fake
+// backend, with no taxonomy database, so the measured cost is the name-resolution and
+// rarity path the refactor touches (the taxonomy lookup is unchanged and orthogonal).
+func newSnapshotHandler(tb testing.TB, labels []string, rc classifier.RarityContext) *Handler {
+	tb.Helper()
+	snap := speciesindex.Build(labels, nil, "en")
+	h := &Handler{
+		Core:                   &apicore.Core{},
+		speciesSnapshot:        func() *speciesindex.Snapshot { return snap },
+		speciesBackendOverride: &goldenBackend{rc: rc},
+	}
+	h.Settings.Store(goldenSettings())
+	return h
+}
+
+func benchmarkGetSpeciesInfo(b *testing.B, rc classifier.RarityContext, query string) {
+	b.Helper()
+	labels := benchLabels(b)
+	h := newSnapshotHandler(b, labels, rc)
+	ctx := b.Context()
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = h.getSpeciesInfo(ctx, query)
+	}
+}
+
+func BenchmarkGetSpeciesInfo(b *testing.B) {
+	benchmarkGetSpeciesInfo(b, benchUniversalContext(), "Turdus merula")
+}
+
+func BenchmarkGetSpeciesInfo_Alias(b *testing.B) {
+	benchmarkGetSpeciesInfo(b, benchUniversalContext(), "Spilopelia senegalensis")
+}
+
+func BenchmarkGetSpeciesInfo_Legacy(b *testing.B) {
+	benchmarkGetSpeciesInfo(b, benchLegacyContext(benchLabels(b)), "Turdus merula")
+}
+
+func BenchmarkGetSpeciesInfo_NotFound(b *testing.B) {
+	benchmarkGetSpeciesInfo(b, benchUniversalContext(), "Nonexistent species")
+}
+
+// TestGetSpeciesInfo_AllocationCeiling fails CI if the per-request allocation count
+// regresses toward the pre-refactor storm. It measures getSpeciesInfo (the resolution
+// and rarity path), not the HTTP JSON encoding, which is measured by the benchmark.
+func TestGetSpeciesInfo_AllocationCeiling(t *testing.T) {
+	h := newSnapshotHandler(t, benchLabels(t), benchUniversalContext())
+	ctx := t.Context()
+
+	// Confirm the request resolves before measuring, so a silent 404 does not make the
+	// ceiling look artificially low.
+	info, err := h.getSpeciesInfo(ctx, "Turdus merula")
+	require.NoError(t, err)
+	require.NotNil(t, info)
+
+	avg := testing.AllocsPerRun(200, func() {
+		_, _ = h.getSpeciesInfo(ctx, "Turdus merula")
+	})
+	assert.Less(t, avg, 100.0, "species info resolution must stay well under 100 allocs/op (was ~25-35k before the snapshot memo)")
+}

--- a/internal/api/v2/species/species_golden_test.go
+++ b/internal/api/v2/species/species_golden_test.go
@@ -164,28 +164,28 @@ func goldenContexts(classifierLabels []string) map[string]classifier.RarityConte
 	return map[string]classifier.RarityContext{
 		"universal": {
 			Scores:           universalScores,
-			GeomodelLabels:   universalVocab,
+			Geomodel:         classifier.NewLabelVocabulary(universalVocab),
 			ClassifierLabels: classifierLabels,
 			FilterActive:     true,
 			Settings:         settings,
 		},
 		"override": {
 			Scores:           overrideScores,
-			GeomodelLabels:   universalVocab,
+			Geomodel:         classifier.NewLabelVocabulary(universalVocab),
 			ClassifierLabels: classifierLabels,
 			FilterActive:     true,
 			Settings:         settings,
 		},
 		"legacy": {
 			Scores:           legacyScores,
-			GeomodelLabels:   nil,
+			Geomodel:         nil,
 			ClassifierLabels: classifierLabels,
 			FilterActive:     true,
 			Settings:         settings,
 		},
 		"inactive": {
 			Scores:           nil,
-			GeomodelLabels:   nil,
+			Geomodel:         nil,
 			ClassifierLabels: classifierLabels,
 			FilterActive:     false,
 			Settings:         settings,

--- a/internal/api/v2/species/species_golden_test.go
+++ b/internal/api/v2/species/species_golden_test.go
@@ -108,7 +108,7 @@ func loadLabelLines(tb testing.TB, path string) []string {
 	tb.Helper()
 	f, err := os.Open(path) //nolint:gosec // test-only read of a repo-vendored label file
 	require.NoError(tb, err, "open label file %s", path)
-	tb.Cleanup(func() { _ = f.Close() })
+	tb.Cleanup(func() { assert.NoError(tb, f.Close()) })
 
 	var out []string
 	sc := bufio.NewScanner(f)
@@ -162,15 +162,18 @@ func goldenContexts(classifierLabels []string) map[string]classifier.RarityConte
 	}
 
 	// Override: the universal context plus the rows addUserOverrideSpeciesScores
-	// appends. A synthetic 1.0 twin for robin (which also has a native 0.9) must
-	// not shadow the native score; a synthetic 1.0 for a species outside the
-	// vocabulary (the bat) must not read as covered.
+	// appends. The synthetic 1.0 rows are placed BEFORE the native scores on
+	// purpose: robin's synthetic 1.0 precedes its native 0.9, so the golden of 0.9
+	// only holds if findNativeSpeciesScore skips the synthetic row in the exact pass
+	// (without the skip the 1.0 sentinel would win first and the golden would flip to
+	// 1.0). A synthetic 1.0 for a species outside the vocabulary (the bat) must not
+	// read as covered.
 	overrideScores := make([]classifier.SpeciesScore, 0, len(universalScores)+2)
-	overrideScores = append(overrideScores, universalScores...)
 	overrideScores = append(overrideScores,
 		classifier.SpeciesScore{Label: syntheticLabel(goldRobin), Score: 1.0, IsSyntheticOverride: true, IsManuallyIncluded: true},
 		classifier.SpeciesScore{Label: syntheticLabel(goldBat), Score: 1.0, IsSyntheticOverride: true, IsManuallyIncluded: true},
 	)
+	overrideScores = append(overrideScores, universalScores...)
 
 	// Legacy backend: no geomodel vocabulary, so coverage falls back to the
 	// classifier labels.

--- a/internal/api/v2/species/species_golden_test.go
+++ b/internal/api/v2/species/species_golden_test.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
@@ -34,8 +35,25 @@ import (
 	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/detection"
 	"github.com/tphakala/birdnet-go/internal/speciesindex"
 )
+
+// TestCorpusScientificNamesAreASCII pins the assumption resolveSpeciesLabel relies
+// on: scientific names in every label set are ASCII, so strings.EqualFold (exact
+// pass) and strings.ToLower via CanonicalKey (the candidate group) agree. A dataset
+// refresh that introduced a non-ASCII scientific name would break the
+// exact-before-alias equivalence silently, so fail loudly here instead.
+func TestCorpusScientificNamesAreASCII(t *testing.T) {
+	t.Parallel()
+	for _, label := range goldenCorpus(t) {
+		sci := detection.ExtractScientificName(label)
+		for i := range len(sci) {
+			require.Less(t, sci[i], byte(utf8.RuneSelf),
+				"non-ASCII byte in scientific name %q (from label %q)", sci, label)
+		}
+	}
+}
 
 var updateGolden = flag.Bool("update", false, "update species golden files")
 
@@ -86,11 +104,11 @@ func goldenSettings() *conf.Settings {
 }
 
 // loadLabelLines reads a newline-delimited label file, trimming blanks.
-func loadLabelLines(t *testing.T, path string) []string {
-	t.Helper()
+func loadLabelLines(tb testing.TB, path string) []string {
+	tb.Helper()
 	f, err := os.Open(path) //nolint:gosec // test-only read of a repo-vendored label file
-	require.NoError(t, err, "open label file %s", path)
-	t.Cleanup(func() { _ = f.Close() })
+	require.NoError(tb, err, "open label file %s", path)
+	tb.Cleanup(func() { _ = f.Close() })
 
 	var out []string
 	sc := bufio.NewScanner(f)
@@ -99,18 +117,18 @@ func loadLabelLines(t *testing.T, path string) []string {
 			out = append(out, line)
 		}
 	}
-	require.NoError(t, sc.Err())
+	require.NoError(tb, sc.Err())
 	return out
 }
 
 // goldenCorpus loads the vendored v2.4 corpus plus the Perch- and bat-like
 // testdata, concatenated. The union exercises embedded-common (v2.4/bat) and
 // scientific-only (Perch) labels and the real alias pairs.
-func goldenCorpus(t *testing.T) []string {
-	t.Helper()
-	corpus := loadLabelLines(t, filepath.Join("..", "..", "..", "classifier", "data", "labels", "V2.4", "BirdNET_GLOBAL_6K_V2.4_Labels_en_uk.txt"))
-	perch := loadLabelLines(t, filepath.Join("..", "..", "..", "speciesindex", "testdata", "perch_like_labels.txt"))
-	bat := loadLabelLines(t, filepath.Join("..", "..", "..", "speciesindex", "testdata", "bat_like_labels.txt"))
+func goldenCorpus(tb testing.TB) []string {
+	tb.Helper()
+	corpus := loadLabelLines(tb, filepath.Join("..", "..", "..", "classifier", "data", "labels", "V2.4", "BirdNET_GLOBAL_6K_V2.4_Labels_en_uk.txt"))
+	perch := loadLabelLines(tb, filepath.Join("..", "..", "..", "speciesindex", "testdata", "perch_like_labels.txt"))
+	bat := loadLabelLines(tb, filepath.Join("..", "..", "..", "speciesindex", "testdata", "bat_like_labels.txt"))
 	all := make([]string, 0, len(corpus)+len(perch)+len(bat))
 	all = append(all, corpus...)
 	all = append(all, perch...)

--- a/internal/api/v2/species/species_golden_test.go
+++ b/internal/api/v2/species/species_golden_test.go
@@ -1,0 +1,294 @@
+// species_golden_test.go: end-to-end golden tests for GET /api/v2/species.
+//
+// These pin the exact JSON the endpoint returns so the Phase 2a species-index
+// snapshot refactor can be proven byte-for-byte equivalent (invariant I1). The
+// goldens are recorded from the pre-refactor helpers in this PR's first commit and
+// must stay identical as each helper is rewritten onto the snapshot memo maps.
+//
+// The harness is deterministic and self-contained: it builds the species-name
+// snapshot from the real vendored v2.4 label corpus plus the Perch- and bat-like
+// testdata (so the openfauna alias memo maps are the real ones, exercising the
+// Dicrurus/Mirafra and Streptopelia/Spilopelia alias pairs), and injects a fake
+// backend with fixed rarity contexts so no native model is loaded and no network
+// is touched. Regenerate with:
+//
+//	go test ./internal/api/v2/species -run Golden -update
+package species
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
+	"github.com/tphakala/birdnet-go/internal/classifier"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/speciesindex"
+)
+
+var updateGolden = flag.Bool("update", false, "update species golden files")
+
+// Scientific names used to build the synthetic rarity contexts and the request
+// list. The alias and colliding pairs are the same real OpenFauna cases the unit
+// tests use, so the goldens exercise the exact-before-alias rule end to end.
+const (
+	goldRobin        = "Turdus migratorius"        // scored, in the corpus
+	goldBlackbird    = "Turdus merula"             // in the corpus and the Perch set
+	goldCanonDove    = "Spilopelia senegalensis"   // canonical; the corpus label is legacy
+	goldLegacyDove   = "Streptopelia senegalensis" // legacy; the form the corpus ships
+	goldDrongoA      = "Dicrurus adsimilis"        // colliding pair member A
+	goldDrongoB      = "Dicrurus divaricatus"      // colliding pair member B (alias of A)
+	goldBat          = "Myotis daubentonii"        // secondary-model only (bat testdata)
+	goldPerchOnlySci = "Tachyspiza badia"          // scientific-only Perch label (localized via backend)
+	goldGeomodelOnly = "Zzz Geomodelonly"          // in the geomodel vocabulary, not the classifier
+)
+
+// goldenBackend is a deterministic speciesBackend fake: a fixed localized-name map
+// for resolveEitherName and a fixed RarityContext for the rarity lookup.
+type goldenBackend struct {
+	names map[string]string
+	rc    classifier.RarityContext
+}
+
+func (g *goldenBackend) ResolveName(scientificName, _ string) string {
+	return g.names[scientificName]
+}
+
+func (g *goldenBackend) GetRarityContext(_ time.Time) (classifier.RarityContext, error) {
+	return g.rc, nil
+}
+
+// syntheticLabel wraps a scientific name in a throwaway "Sci_Common" label. Only
+// the scientific part drives coverage and score matching, so the common part is
+// arbitrary; using a distinct marker keeps these labels out of the real corpus.
+func syntheticLabel(sci string) string { return sci + "_syn" }
+
+// goldenSettings returns a settings snapshot with a configured location so the
+// rarity coordinates and threshold serialize deterministically.
+func goldenSettings() *conf.Settings {
+	s := &conf.Settings{}
+	s.BirdNET.LocationConfigured = true
+	s.BirdNET.Latitude = 60.1699
+	s.BirdNET.Longitude = 24.9384
+	s.BirdNET.RangeFilter.Threshold = 0.03
+	return s
+}
+
+// loadLabelLines reads a newline-delimited label file, trimming blanks.
+func loadLabelLines(t *testing.T, path string) []string {
+	t.Helper()
+	f, err := os.Open(path) //nolint:gosec // test-only read of a repo-vendored label file
+	require.NoError(t, err, "open label file %s", path)
+	t.Cleanup(func() { _ = f.Close() })
+
+	var out []string
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		if line := strings.TrimSpace(sc.Text()); line != "" {
+			out = append(out, line)
+		}
+	}
+	require.NoError(t, sc.Err())
+	return out
+}
+
+// goldenCorpus loads the vendored v2.4 corpus plus the Perch- and bat-like
+// testdata, concatenated. The union exercises embedded-common (v2.4/bat) and
+// scientific-only (Perch) labels and the real alias pairs.
+func goldenCorpus(t *testing.T) []string {
+	t.Helper()
+	corpus := loadLabelLines(t, filepath.Join("..", "..", "..", "classifier", "data", "labels", "V2.4", "BirdNET_GLOBAL_6K_V2.4_Labels_en_uk.txt"))
+	perch := loadLabelLines(t, filepath.Join("..", "..", "..", "speciesindex", "testdata", "perch_like_labels.txt"))
+	bat := loadLabelLines(t, filepath.Join("..", "..", "..", "speciesindex", "testdata", "bat_like_labels.txt"))
+	all := make([]string, 0, len(corpus)+len(perch)+len(bat))
+	all = append(all, corpus...)
+	all = append(all, perch...)
+	all = append(all, bat...)
+	return all
+}
+
+// goldenContexts returns the fixed rarity contexts, one golden file each. Each
+// name selects a distinct code path through computeRarity.
+func goldenContexts(classifierLabels []string) map[string]classifier.RarityContext {
+	settings := goldenSettings()
+
+	// Universal geomodel: a vocabulary covering both alias-pair members, both
+	// colliding members, robin, blackbird and a geomodel-only species, with a
+	// descending score list for a subset.
+	universalVocab := []string{
+		syntheticLabel(goldRobin),
+		syntheticLabel(goldBlackbird),
+		syntheticLabel(goldLegacyDove),
+		syntheticLabel(goldCanonDove),
+		syntheticLabel(goldDrongoA),
+		syntheticLabel(goldDrongoB),
+		syntheticLabel(goldGeomodelOnly),
+	}
+	universalScores := []classifier.SpeciesScore{
+		{Label: syntheticLabel(goldRobin), Score: 0.9},
+		{Label: syntheticLabel(goldDrongoA), Score: 0.7},
+		{Label: syntheticLabel(goldBlackbird), Score: 0.3},
+		{Label: syntheticLabel(goldLegacyDove), Score: 0.1},
+		{Label: syntheticLabel(goldDrongoB), Score: 0.05},
+	}
+
+	// Override: the universal context plus the rows addUserOverrideSpeciesScores
+	// appends. A synthetic 1.0 twin for robin (which also has a native 0.9) must
+	// not shadow the native score; a synthetic 1.0 for a species outside the
+	// vocabulary (the bat) must not read as covered.
+	overrideScores := make([]classifier.SpeciesScore, 0, len(universalScores)+2)
+	overrideScores = append(overrideScores, universalScores...)
+	overrideScores = append(overrideScores,
+		classifier.SpeciesScore{Label: syntheticLabel(goldRobin), Score: 1.0, IsSyntheticOverride: true, IsManuallyIncluded: true},
+		classifier.SpeciesScore{Label: syntheticLabel(goldBat), Score: 1.0, IsSyntheticOverride: true, IsManuallyIncluded: true},
+	)
+
+	// Legacy backend: no geomodel vocabulary, so coverage falls back to the
+	// classifier labels.
+	legacyScores := []classifier.SpeciesScore{
+		{Label: syntheticLabel(goldRobin), Score: 0.6},
+		{Label: syntheticLabel(goldBlackbird), Score: 0.2},
+	}
+
+	return map[string]classifier.RarityContext{
+		"universal": {
+			Scores:           universalScores,
+			GeomodelLabels:   universalVocab,
+			ClassifierLabels: classifierLabels,
+			FilterActive:     true,
+			Settings:         settings,
+		},
+		"override": {
+			Scores:           overrideScores,
+			GeomodelLabels:   universalVocab,
+			ClassifierLabels: classifierLabels,
+			FilterActive:     true,
+			Settings:         settings,
+		},
+		"legacy": {
+			Scores:           legacyScores,
+			GeomodelLabels:   nil,
+			ClassifierLabels: classifierLabels,
+			FilterActive:     true,
+			Settings:         settings,
+		},
+		"inactive": {
+			Scores:           nil,
+			GeomodelLabels:   nil,
+			ClassifierLabels: classifierLabels,
+			FilterActive:     false,
+			Settings:         settings,
+		},
+	}
+}
+
+// goldenRequests is the ordered request list recorded in every context.
+func goldenRequests() []string {
+	return []string{
+		goldRobin,
+		"turdus MIGRATORIUS", // case-insensitive exact
+		goldCanonDove,        // canonical request, legacy label
+		goldLegacyDove,       // legacy request, exact
+		goldDrongoA,          // colliding pair A
+		goldDrongoB,          // colliding pair B
+		goldBlackbird,
+		goldPerchOnlySci,  // scientific-only, localized via backend
+		goldBat,           // secondary-model only
+		goldGeomodelOnly,  // in the vocabulary but not the label set
+		"Unknown species", // not in any label -> 404
+		"Turdus",          // single word -> 400
+		"",                // missing -> 400
+	}
+}
+
+type goldenEntry struct {
+	Query  string         `json:"query"`
+	Status int            `json:"status"`
+	Body   map[string]any `json:"body"`
+}
+
+// stripVolatile removes response fields that vary per run (correlation ids,
+// timestamps, the rarity date) so the goldens stay stable.
+func stripVolatile(v any) {
+	switch t := v.(type) {
+	case map[string]any:
+		for _, k := range []string{"correlation_id", "timestamp", "date"} {
+			delete(t, k)
+		}
+		for _, child := range t {
+			stripVolatile(child)
+		}
+	case []any:
+		for _, child := range t {
+			stripVolatile(child)
+		}
+	}
+}
+
+func TestGetSpeciesInfo_Golden(t *testing.T) {
+	// Not parallel: apitest.NewCore publishes settings to the process-global
+	// snapshot, and the handler reads CurrentLocale() from it.
+	core := apitest.NewCore(t)
+	labels := goldenCorpus(t)
+	snap := speciesindex.Build(labels, nil, "en")
+
+	backend := &goldenBackend{
+		names: map[string]string{
+			goldPerchOnlySci: "Shikra",
+			goldBat:          "Daubenton's Bat",
+		},
+	}
+	h := New(core, func() *speciesindex.Snapshot { return snap }, nil)
+	h.speciesBackendOverride = backend
+
+	contexts := goldenContexts(labels)
+	for name, rc := range contexts {
+		t.Run(name, func(t *testing.T) {
+			backend.rc = rc
+
+			entries := make([]goldenEntry, 0, len(goldenRequests()))
+			for _, q := range goldenRequests() {
+				e := echo.New()
+				target := "/api/v2/species"
+				if q != "" {
+					target += "?scientific_name=" + url.QueryEscape(q)
+				}
+				req := httptest.NewRequest(http.MethodGet, target, http.NoBody)
+				rec := httptest.NewRecorder()
+				ctx := e.NewContext(req, rec)
+				require.NoError(t, h.GetSpeciesInfo(ctx))
+
+				var body map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body), "decode response for %q", q)
+				stripVolatile(body)
+				entries = append(entries, goldenEntry{Query: q, Status: rec.Code, Body: body})
+			}
+
+			got, err := json.MarshalIndent(entries, "", "  ")
+			require.NoError(t, err)
+			got = append(got, '\n')
+
+			goldenPath := filepath.Join("testdata", "golden", name+".json")
+			if *updateGolden {
+				require.NoError(t, os.MkdirAll(filepath.Dir(goldenPath), 0o755))
+				require.NoError(t, os.WriteFile(goldenPath, got, 0o600))
+				return
+			}
+
+			want, err := os.ReadFile(goldenPath) //nolint:gosec // test-only read of a repo-tracked golden file
+			require.NoError(t, err, "read golden %s (run with -update to create)", goldenPath)
+			assert.Equal(t, string(want), string(got), "golden mismatch for context %s; run -update if the change is intended", name)
+		})
+	}
+}

--- a/internal/api/v2/species/species_test.go
+++ b/internal/api/v2/species/species_test.go
@@ -734,6 +734,33 @@ func TestResolveSpeciesLabel_Empty(t *testing.T) {
 	assert.Empty(t, gotCommon)
 }
 
+// TestGetSpeciesInfo_ResolvesSnapshotUnionSpecies pins the deliberate additive
+// widening in this change: getSpeciesInfo resolves against the orchestrator
+// snapshot (a superset of the loaded-model labels that also carries the
+// range-filter inclusion list), not bn.AllLabels() alone. A species present in the
+// snapshot but not a loaded-model label (a stand-in for a range-filter-included
+// species) must resolve with 200, matching what /species/all already lists, rather
+// than 404. The golden corpus tests cannot see this because they build the snapshot
+// directly, so this pins the widening at the request path explicitly.
+func TestGetSpeciesInfo_ResolvesSnapshotUnionSpecies(t *testing.T) {
+	t.Parallel()
+
+	const inclusionSci = "Zzz Inclusiononly"
+	snap := speciesindex.Build([]string{inclusionSci + "_Included Species"}, nil, "en")
+	h := &Handler{
+		Core:                   &apicore.Core{},
+		speciesSnapshot:        func() *speciesindex.Snapshot { return snap },
+		speciesBackendOverride: &goldenBackend{rc: classifier.RarityContext{FilterActive: false, Settings: goldenSettings()}},
+	}
+	h.Settings.Store(goldenSettings())
+
+	info, err := h.getSpeciesInfo(t.Context(), inclusionSci)
+	require.NoError(t, err, "a species in the snapshot union must resolve, not 404")
+	require.NotNil(t, info)
+	assert.Equal(t, inclusionSci, info.ScientificName)
+	assert.Equal(t, "Included Species", info.CommonName)
+}
+
 func TestComputeRarity(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/v2/species/species_test.go
+++ b/internal/api/v2/species/species_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/api/v2/dto"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/speciesindex"
 )
 
 // Species fixtures for the name-resolution and rarity tests. testAliasName and
@@ -541,11 +542,11 @@ func TestGetAllSpecies_LocalizedSecondaryModel(t *testing.T) {
 	e := echo.New()
 	handler := &Handler{
 		Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")},
-		commonNameMap: func() map[string]string {
-			return map[string]string{
+		speciesSnapshot: func() *speciesindex.Snapshot {
+			return &speciesindex.Snapshot{SciToCommon: map[string]string{
 				"Barbastella barbastellus": "mopsilepakko", // localized bat name (secondary model)
 				"Parus major":              "Great Tit",
-			}
+			}}
 		},
 	}
 	handler.Settings.Store(&conf.Settings{})
@@ -627,8 +628,8 @@ func TestGetAllSpecies(t *testing.T) {
 			// allModelLabels() (which reads settings.BirdNET.Labels here, since
 			// Processor is nil).
 			handler := &Handler{
-				Core:          &apicore.Core{Echo: e, Group: e.Group("/api/v2")},
-				commonNameMap: func() map[string]string { return nil },
+				Core:            &apicore.Core{Echo: e, Group: e.Group("/api/v2")},
+				speciesSnapshot: speciesindex.Empty,
 			}
 			handler.Settings.Store(settings)
 

--- a/internal/api/v2/species/species_test.go
+++ b/internal/api/v2/species/species_test.go
@@ -41,13 +41,28 @@ const (
 )
 
 // newSpeciesHandler builds a minimal species Handler with valid default settings
-// for validation tests. The injected facade dependencies (commonNameMap,
+// for validation tests. The injected facade dependencies (speciesSnapshot,
 // serveImageProxy) are left nil because the validation paths exercised here never
 // reach them.
 func newSpeciesHandler() *Handler {
 	h := &Handler{Core: &apicore.Core{}}
 	h.Settings.Store(apitest.NewValidTestSettings())
 	return h
+}
+
+// testSnap builds a species-index snapshot from labels for the resolver tests. A
+// nil name resolver keeps the real openfauna canonical memo maps, so alias and
+// colliding-species behaviour is exercised against the vendored dataset.
+func testSnap(labels []string) *speciesindex.Snapshot {
+	return speciesindex.Build(labels, nil, "")
+}
+
+// testComputeRarity calls computeRarity with an empty snapshot. The snapshot is a
+// canonical-key memo only: an empty one computes the same keys the request path
+// would find memoized, so the rarity logic is exercised identically without a built
+// label set.
+func testComputeRarity(rc *classifier.RarityContext, targetSci string) (float64, RarityStatus) {
+	return computeRarity(rc, speciesindex.Empty(), speciesindex.CanonicalKey(targetSci), targetSci)
 }
 
 // TestCalculateRarityStatus tests the calculateRarityStatus helper function.
@@ -199,11 +214,12 @@ func TestFindNativeSpeciesScore(t *testing.T) {
 		{Label: "Amazona viridigenalis_Red-crowned Amazon", Score: 0.95},
 	}
 
-	score, found := findNativeSpeciesScore("amazona VIRIDIGENALIS", scores)
+	keyOf := speciesindex.CanonicalKey
+	score, found := findNativeSpeciesScore("amazona VIRIDIGENALIS", speciesindex.CanonicalKey("amazona VIRIDIGENALIS"), scores, keyOf)
 	require.True(t, found)
 	assert.InDelta(t, 0.95, score, 1e-9)
 
-	_, found = findNativeSpeciesScore("Amazona viridigenalis", scores[:1])
+	_, found = findNativeSpeciesScore("Amazona viridigenalis", speciesindex.CanonicalKey("Amazona viridigenalis"), scores[:1], keyOf)
 	assert.False(t, found, "synthetic override scores must not drive rarity")
 }
 
@@ -704,7 +720,7 @@ func TestResolveSpeciesLabel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			gotLabel, gotCommon := resolveSpeciesLabel(tt.targetSci, allLabels)
+			gotLabel, gotCommon := resolveSpeciesLabel(testSnap(allLabels), tt.targetSci)
 			assert.Equal(t, tt.wantLabel, gotLabel)
 			assert.Equal(t, tt.wantCommon, gotCommon)
 		})
@@ -713,7 +729,7 @@ func TestResolveSpeciesLabel(t *testing.T) {
 
 func TestResolveSpeciesLabel_Empty(t *testing.T) {
 	t.Parallel()
-	gotLabel, gotCommon := resolveSpeciesLabel("Turdus migratorius", nil)
+	gotLabel, gotCommon := resolveSpeciesLabel(speciesindex.Empty(), "Turdus migratorius")
 	assert.Empty(t, gotLabel)
 	assert.Empty(t, gotCommon)
 }
@@ -777,10 +793,10 @@ func TestComputeRarity(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			gotScore, gotStatus := computeRarity(&classifier.RarityContext{
+			gotScore, gotStatus := testComputeRarity(&classifier.RarityContext{
 				FilterActive:     true,
 				Scores:           scores,
-				GeomodelLabels:   geomodelLabels,
+				Geomodel:         classifier.NewLabelVocabulary(geomodelLabels),
 				ClassifierLabels: classifierLabels,
 			}, tt.targetSci)
 			assert.InDelta(t, tt.wantScore, gotScore, 0.001)
@@ -791,7 +807,7 @@ func TestComputeRarity(t *testing.T) {
 
 func TestComputeRarity_Empty(t *testing.T) {
 	t.Parallel()
-	gotScore, gotStatus := computeRarity(&classifier.RarityContext{FilterActive: true}, "Turdus migratorius")
+	gotScore, gotStatus := testComputeRarity(&classifier.RarityContext{FilterActive: true}, "Turdus migratorius")
 	assert.InDelta(t, 0.0, gotScore, 0.001)
 	assert.Equal(t, RarityUnknown, gotStatus)
 }
@@ -810,10 +826,10 @@ func TestComputeRarity_InactiveFilterReportsUnknown(t *testing.T) {
 	// means the 0.0 score is synthetic and must report unknown, not very rare.
 	scores := []classifier.SpeciesScore{{Label: testSciName + "_" + testCommonName, Score: 0.0}}
 
-	score, status := computeRarity(&classifier.RarityContext{
+	score, status := testComputeRarity(&classifier.RarityContext{
 		FilterActive:     false,
 		Scores:           scores,
-		GeomodelLabels:   labels,
+		Geomodel:         classifier.NewLabelVocabulary(labels),
 		ClassifierLabels: labels,
 	}, testSciName)
 	assert.InDelta(t, 0.0, score, 0.001)
@@ -833,17 +849,17 @@ func TestComputeRarity_GeomodelLabelsTakePrecedence(t *testing.T) {
 		testSciName + "_" + testCommonName,
 	}
 
-	_, status := computeRarity(&classifier.RarityContext{
+	_, status := testComputeRarity(&classifier.RarityContext{
 		FilterActive:     true,
-		GeomodelLabels:   geomodelLabels,
+		Geomodel:         classifier.NewLabelVocabulary(geomodelLabels),
 		ClassifierLabels: classifierLabels,
 	}, testSciName)
 	assert.Equal(t, RarityUnknown, status,
 		"classifier-only species has no geomodel occurrence probability")
 
-	_, status = computeRarity(&classifier.RarityContext{
+	_, status = testComputeRarity(&classifier.RarityContext{
 		FilterActive:     true,
-		GeomodelLabels:   geomodelLabels,
+		Geomodel:         classifier.NewLabelVocabulary(geomodelLabels),
 		ClassifierLabels: classifierLabels,
 	}, testCanonName)
 	assert.Equal(t, RarityVeryRare, status,
@@ -888,7 +904,7 @@ func TestComputeRarity_NoGeomodelLabels(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			gotScore, gotStatus := computeRarity(&classifier.RarityContext{
+			gotScore, gotStatus := testComputeRarity(&classifier.RarityContext{
 				FilterActive:     true,
 				ClassifierLabels: classifierLabels,
 			}, tt.targetSci)
@@ -910,12 +926,12 @@ func TestResolveSpeciesLabel_CollidingSpecies(t *testing.T) {
 		collidingSciB + "_" + collidingCommonB,
 	}
 
-	gotLabel, gotCommon := resolveSpeciesLabel(collidingSciB, allLabels)
+	gotLabel, gotCommon := resolveSpeciesLabel(testSnap(allLabels), collidingSciB)
 	assert.Equal(t, collidingSciB+"_"+collidingCommonB, gotLabel,
 		"an exact scientific-name match must win over the alias collapse")
 	assert.Equal(t, collidingCommonB, gotCommon)
 
-	gotLabel, gotCommon = resolveSpeciesLabel(collidingSciA, allLabels)
+	gotLabel, gotCommon = resolveSpeciesLabel(testSnap(allLabels), collidingSciA)
 	assert.Equal(t, collidingSciA+"_"+collidingCommonA, gotLabel)
 	assert.Equal(t, collidingCommonA, gotCommon)
 }
@@ -928,7 +944,7 @@ func TestResolveSpeciesLabel_LegacyLabelCanonicalTarget(t *testing.T) {
 
 	allLabels := []string{testAliasName + "_" + testCanonCommon}
 
-	gotLabel, gotCommon := resolveSpeciesLabel(testCanonName, allLabels)
+	gotLabel, gotCommon := resolveSpeciesLabel(testSnap(allLabels), testCanonName)
 	assert.Equal(t, testAliasName+"_"+testCanonCommon, gotLabel,
 		"canonicalization must apply to the label side, not only the request side")
 	assert.Equal(t, testCanonCommon, gotCommon)
@@ -949,19 +965,19 @@ func TestComputeRarity_CollidingSpecies(t *testing.T) {
 		{Label: collidingSciB + "_" + collidingCommonB, Score: 0.1},
 	}
 
-	gotScore, gotStatus := computeRarity(&classifier.RarityContext{
+	gotScore, gotStatus := testComputeRarity(&classifier.RarityContext{
 		FilterActive:     true,
 		Scores:           scores,
-		GeomodelLabels:   labels,
+		Geomodel:         classifier.NewLabelVocabulary(labels),
 		ClassifierLabels: labels,
 	}, collidingSciB)
 	assert.InDelta(t, 0.1, gotScore, 0.001, "the merged species must keep its own score")
 	assert.Equal(t, RarityRare, gotStatus)
 
-	gotScore, gotStatus = computeRarity(&classifier.RarityContext{
+	gotScore, gotStatus = testComputeRarity(&classifier.RarityContext{
 		FilterActive:     true,
 		Scores:           scores,
-		GeomodelLabels:   labels,
+		Geomodel:         classifier.NewLabelVocabulary(labels),
 		ClassifierLabels: labels,
 	}, collidingSciA)
 	assert.InDelta(t, 0.9, gotScore, 0.001)
@@ -999,10 +1015,10 @@ func TestComputeRarity_SyntheticScoresReportUnknown(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			scores := []classifier.SpeciesScore{{Label: unmappedSci + "_Brandt's Bat", Score: tt.score}}
-			gotScore, gotStatus := computeRarity(&classifier.RarityContext{
+			gotScore, gotStatus := testComputeRarity(&classifier.RarityContext{
 				FilterActive:     true,
 				Scores:           scores,
-				GeomodelLabels:   geomodelLabels,
+				Geomodel:         classifier.NewLabelVocabulary(geomodelLabels),
 				ClassifierLabels: classifierLabels,
 			}, unmappedSci)
 			assert.Equal(t, RarityUnknown, gotStatus, tt.why)

--- a/internal/api/v2/species/testdata/golden/inactive.json
+++ b/internal/api/v2/species/testdata/golden/inactive.json
@@ -1,0 +1,302 @@
+[
+  {
+    "query": "Turdus migratorius",
+    "status": 200,
+    "body": {
+      "common_name": "American Robin",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": false,
+        "longitude": 24.9384,
+        "score": 0,
+        "status": "unknown",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Turdus migratorius",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Turdidae",
+        "family_common": "Thrushes and Allies",
+        "genus": "Turdus",
+        "kingdom": "Animalia",
+        "order": "Passeriformes",
+        "phylum": "Chordata",
+        "species": "Turdus migratorius",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "turdus MIGRATORIUS",
+    "status": 200,
+    "body": {
+      "common_name": "American Robin",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": false,
+        "longitude": 24.9384,
+        "score": 0,
+        "status": "unknown",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "turdus MIGRATORIUS",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Turdidae",
+        "family_common": "Thrushes and Allies",
+        "genus": "Turdus",
+        "kingdom": "Animalia",
+        "order": "Passeriformes",
+        "phylum": "Chordata",
+        "species": "Turdus migratorius",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "Spilopelia senegalensis",
+    "status": 200,
+    "body": {
+      "common_name": "Laughing Dove",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": false,
+        "longitude": 24.9384,
+        "score": 0,
+        "status": "unknown",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Spilopelia senegalensis",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Columbidae",
+        "family_common": "Pigeons and Doves",
+        "genus": "Streptopelia",
+        "kingdom": "Animalia",
+        "order": "Columbiformes",
+        "phylum": "Chordata",
+        "species": "Streptopelia senegalensis",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "Streptopelia senegalensis",
+    "status": 200,
+    "body": {
+      "common_name": "Laughing Dove",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": false,
+        "longitude": 24.9384,
+        "score": 0,
+        "status": "unknown",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Streptopelia senegalensis",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Columbidae",
+        "family_common": "Pigeons and Doves",
+        "genus": "Streptopelia",
+        "kingdom": "Animalia",
+        "order": "Columbiformes",
+        "phylum": "Chordata",
+        "species": "Streptopelia senegalensis",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "Dicrurus adsimilis",
+    "status": 200,
+    "body": {
+      "common_name": "Fork-tailed Drongo",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": false,
+        "longitude": 24.9384,
+        "score": 0,
+        "status": "unknown",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Dicrurus adsimilis",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Dicruridae",
+        "family_common": "Drongos",
+        "genus": "Dicrurus",
+        "kingdom": "Animalia",
+        "order": "Passeriformes",
+        "phylum": "Chordata",
+        "species": "Dicrurus adsimilis",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "Dicrurus divaricatus",
+    "status": 200,
+    "body": {
+      "common_name": "Glossy-backed Drongo",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": false,
+        "longitude": 24.9384,
+        "score": 0,
+        "status": "unknown",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Dicrurus divaricatus",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Dicruridae",
+        "family_common": "Drongos",
+        "genus": "Dicrurus",
+        "kingdom": "Animalia",
+        "order": "Passeriformes",
+        "phylum": "Chordata",
+        "species": "Dicrurus divaricatus",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "Turdus merula",
+    "status": 200,
+    "body": {
+      "common_name": "Eurasian Blackbird",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": false,
+        "longitude": 24.9384,
+        "score": 0,
+        "status": "unknown",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Turdus merula",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Turdidae",
+        "family_common": "Thrushes and Allies",
+        "genus": "Turdus",
+        "kingdom": "Animalia",
+        "order": "Passeriformes",
+        "phylum": "Chordata",
+        "species": "Turdus merula",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "Tachyspiza badia",
+    "status": 200,
+    "body": {
+      "common_name": "Shikra",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": false,
+        "longitude": 24.9384,
+        "score": 0,
+        "status": "unknown",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Tachyspiza badia",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Accipitridae",
+        "family_common": "Hawks, Eagles, and Kites",
+        "genus": "Tachyspiza",
+        "kingdom": "Animalia",
+        "order": "Accipitriformes",
+        "phylum": "Chordata",
+        "species": "Tachyspiza badia",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "Myotis daubentonii",
+    "status": 200,
+    "body": {
+      "common_name": "Water Bat",
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": false,
+        "longitude": 24.9384,
+        "score": 0,
+        "status": "unknown",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Myotis daubentonii"
+    }
+  },
+  {
+    "query": "Zzz Geomodelonly",
+    "status": 404,
+    "body": {
+      "code": 404,
+      "error": "Species not found",
+      "message": "Species not found"
+    }
+  },
+  {
+    "query": "Unknown species",
+    "status": 404,
+    "body": {
+      "code": 404,
+      "error": "Species not found",
+      "message": "Species not found"
+    }
+  },
+  {
+    "query": "Turdus",
+    "status": 400,
+    "body": {
+      "code": 400,
+      "error": "Invalid scientific name format",
+      "message": "Invalid scientific name format"
+    }
+  },
+  {
+    "query": "",
+    "status": 400,
+    "body": {
+      "code": 400,
+      "error": "Missing required parameter",
+      "message": "Missing required parameter"
+    }
+  }
+]

--- a/internal/api/v2/species/testdata/golden/legacy.json
+++ b/internal/api/v2/species/testdata/golden/legacy.json
@@ -1,0 +1,302 @@
+[
+  {
+    "query": "Turdus migratorius",
+    "status": 200,
+    "body": {
+      "common_name": "American Robin",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": true,
+        "longitude": 24.9384,
+        "score": 0.6,
+        "status": "common",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Turdus migratorius",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Turdidae",
+        "family_common": "Thrushes and Allies",
+        "genus": "Turdus",
+        "kingdom": "Animalia",
+        "order": "Passeriformes",
+        "phylum": "Chordata",
+        "species": "Turdus migratorius",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "turdus MIGRATORIUS",
+    "status": 200,
+    "body": {
+      "common_name": "American Robin",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": true,
+        "longitude": 24.9384,
+        "score": 0.6,
+        "status": "common",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "turdus MIGRATORIUS",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Turdidae",
+        "family_common": "Thrushes and Allies",
+        "genus": "Turdus",
+        "kingdom": "Animalia",
+        "order": "Passeriformes",
+        "phylum": "Chordata",
+        "species": "Turdus migratorius",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "Spilopelia senegalensis",
+    "status": 200,
+    "body": {
+      "common_name": "Laughing Dove",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": true,
+        "longitude": 24.9384,
+        "score": 0,
+        "status": "very_rare",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Spilopelia senegalensis",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Columbidae",
+        "family_common": "Pigeons and Doves",
+        "genus": "Streptopelia",
+        "kingdom": "Animalia",
+        "order": "Columbiformes",
+        "phylum": "Chordata",
+        "species": "Streptopelia senegalensis",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "Streptopelia senegalensis",
+    "status": 200,
+    "body": {
+      "common_name": "Laughing Dove",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": true,
+        "longitude": 24.9384,
+        "score": 0,
+        "status": "very_rare",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Streptopelia senegalensis",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Columbidae",
+        "family_common": "Pigeons and Doves",
+        "genus": "Streptopelia",
+        "kingdom": "Animalia",
+        "order": "Columbiformes",
+        "phylum": "Chordata",
+        "species": "Streptopelia senegalensis",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "Dicrurus adsimilis",
+    "status": 200,
+    "body": {
+      "common_name": "Fork-tailed Drongo",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": true,
+        "longitude": 24.9384,
+        "score": 0,
+        "status": "very_rare",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Dicrurus adsimilis",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Dicruridae",
+        "family_common": "Drongos",
+        "genus": "Dicrurus",
+        "kingdom": "Animalia",
+        "order": "Passeriformes",
+        "phylum": "Chordata",
+        "species": "Dicrurus adsimilis",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "Dicrurus divaricatus",
+    "status": 200,
+    "body": {
+      "common_name": "Glossy-backed Drongo",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": true,
+        "longitude": 24.9384,
+        "score": 0,
+        "status": "very_rare",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Dicrurus divaricatus",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Dicruridae",
+        "family_common": "Drongos",
+        "genus": "Dicrurus",
+        "kingdom": "Animalia",
+        "order": "Passeriformes",
+        "phylum": "Chordata",
+        "species": "Dicrurus divaricatus",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "Turdus merula",
+    "status": 200,
+    "body": {
+      "common_name": "Eurasian Blackbird",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": true,
+        "longitude": 24.9384,
+        "score": 0.2,
+        "status": "rare",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Turdus merula",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Turdidae",
+        "family_common": "Thrushes and Allies",
+        "genus": "Turdus",
+        "kingdom": "Animalia",
+        "order": "Passeriformes",
+        "phylum": "Chordata",
+        "species": "Turdus merula",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "Tachyspiza badia",
+    "status": 200,
+    "body": {
+      "common_name": "Shikra",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": true,
+        "longitude": 24.9384,
+        "score": 0,
+        "status": "very_rare",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Tachyspiza badia",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Accipitridae",
+        "family_common": "Hawks, Eagles, and Kites",
+        "genus": "Tachyspiza",
+        "kingdom": "Animalia",
+        "order": "Accipitriformes",
+        "phylum": "Chordata",
+        "species": "Tachyspiza badia",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "Myotis daubentonii",
+    "status": 200,
+    "body": {
+      "common_name": "Water Bat",
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": true,
+        "longitude": 24.9384,
+        "score": 0,
+        "status": "very_rare",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Myotis daubentonii"
+    }
+  },
+  {
+    "query": "Zzz Geomodelonly",
+    "status": 404,
+    "body": {
+      "code": 404,
+      "error": "Species not found",
+      "message": "Species not found"
+    }
+  },
+  {
+    "query": "Unknown species",
+    "status": 404,
+    "body": {
+      "code": 404,
+      "error": "Species not found",
+      "message": "Species not found"
+    }
+  },
+  {
+    "query": "Turdus",
+    "status": 400,
+    "body": {
+      "code": 400,
+      "error": "Invalid scientific name format",
+      "message": "Invalid scientific name format"
+    }
+  },
+  {
+    "query": "",
+    "status": 400,
+    "body": {
+      "code": 400,
+      "error": "Missing required parameter",
+      "message": "Missing required parameter"
+    }
+  }
+]

--- a/internal/api/v2/species/testdata/golden/override.json
+++ b/internal/api/v2/species/testdata/golden/override.json
@@ -1,0 +1,302 @@
+[
+  {
+    "query": "Turdus migratorius",
+    "status": 200,
+    "body": {
+      "common_name": "American Robin",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": true,
+        "longitude": 24.9384,
+        "score": 0.9,
+        "status": "very_common",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Turdus migratorius",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Turdidae",
+        "family_common": "Thrushes and Allies",
+        "genus": "Turdus",
+        "kingdom": "Animalia",
+        "order": "Passeriformes",
+        "phylum": "Chordata",
+        "species": "Turdus migratorius",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "turdus MIGRATORIUS",
+    "status": 200,
+    "body": {
+      "common_name": "American Robin",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": true,
+        "longitude": 24.9384,
+        "score": 0.9,
+        "status": "very_common",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "turdus MIGRATORIUS",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Turdidae",
+        "family_common": "Thrushes and Allies",
+        "genus": "Turdus",
+        "kingdom": "Animalia",
+        "order": "Passeriformes",
+        "phylum": "Chordata",
+        "species": "Turdus migratorius",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "Spilopelia senegalensis",
+    "status": 200,
+    "body": {
+      "common_name": "Laughing Dove",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": true,
+        "longitude": 24.9384,
+        "score": 0.1,
+        "status": "rare",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Spilopelia senegalensis",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Columbidae",
+        "family_common": "Pigeons and Doves",
+        "genus": "Streptopelia",
+        "kingdom": "Animalia",
+        "order": "Columbiformes",
+        "phylum": "Chordata",
+        "species": "Streptopelia senegalensis",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "Streptopelia senegalensis",
+    "status": 200,
+    "body": {
+      "common_name": "Laughing Dove",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": true,
+        "longitude": 24.9384,
+        "score": 0.1,
+        "status": "rare",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Streptopelia senegalensis",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Columbidae",
+        "family_common": "Pigeons and Doves",
+        "genus": "Streptopelia",
+        "kingdom": "Animalia",
+        "order": "Columbiformes",
+        "phylum": "Chordata",
+        "species": "Streptopelia senegalensis",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "Dicrurus adsimilis",
+    "status": 200,
+    "body": {
+      "common_name": "Fork-tailed Drongo",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": true,
+        "longitude": 24.9384,
+        "score": 0.7,
+        "status": "common",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Dicrurus adsimilis",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Dicruridae",
+        "family_common": "Drongos",
+        "genus": "Dicrurus",
+        "kingdom": "Animalia",
+        "order": "Passeriformes",
+        "phylum": "Chordata",
+        "species": "Dicrurus adsimilis",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "Dicrurus divaricatus",
+    "status": 200,
+    "body": {
+      "common_name": "Glossy-backed Drongo",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": true,
+        "longitude": 24.9384,
+        "score": 0.05,
+        "status": "very_rare",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Dicrurus divaricatus",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Dicruridae",
+        "family_common": "Drongos",
+        "genus": "Dicrurus",
+        "kingdom": "Animalia",
+        "order": "Passeriformes",
+        "phylum": "Chordata",
+        "species": "Dicrurus divaricatus",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "Turdus merula",
+    "status": 200,
+    "body": {
+      "common_name": "Eurasian Blackbird",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": true,
+        "longitude": 24.9384,
+        "score": 0.3,
+        "status": "uncommon",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Turdus merula",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Turdidae",
+        "family_common": "Thrushes and Allies",
+        "genus": "Turdus",
+        "kingdom": "Animalia",
+        "order": "Passeriformes",
+        "phylum": "Chordata",
+        "species": "Turdus merula",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "Tachyspiza badia",
+    "status": 200,
+    "body": {
+      "common_name": "Shikra",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": true,
+        "longitude": 24.9384,
+        "score": 0,
+        "status": "unknown",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Tachyspiza badia",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Accipitridae",
+        "family_common": "Hawks, Eagles, and Kites",
+        "genus": "Tachyspiza",
+        "kingdom": "Animalia",
+        "order": "Accipitriformes",
+        "phylum": "Chordata",
+        "species": "Tachyspiza badia",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "Myotis daubentonii",
+    "status": 200,
+    "body": {
+      "common_name": "Water Bat",
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": true,
+        "longitude": 24.9384,
+        "score": 0,
+        "status": "unknown",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Myotis daubentonii"
+    }
+  },
+  {
+    "query": "Zzz Geomodelonly",
+    "status": 404,
+    "body": {
+      "code": 404,
+      "error": "Species not found",
+      "message": "Species not found"
+    }
+  },
+  {
+    "query": "Unknown species",
+    "status": 404,
+    "body": {
+      "code": 404,
+      "error": "Species not found",
+      "message": "Species not found"
+    }
+  },
+  {
+    "query": "Turdus",
+    "status": 400,
+    "body": {
+      "code": 400,
+      "error": "Invalid scientific name format",
+      "message": "Invalid scientific name format"
+    }
+  },
+  {
+    "query": "",
+    "status": 400,
+    "body": {
+      "code": 400,
+      "error": "Missing required parameter",
+      "message": "Missing required parameter"
+    }
+  }
+]

--- a/internal/api/v2/species/testdata/golden/universal.json
+++ b/internal/api/v2/species/testdata/golden/universal.json
@@ -1,0 +1,302 @@
+[
+  {
+    "query": "Turdus migratorius",
+    "status": 200,
+    "body": {
+      "common_name": "American Robin",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": true,
+        "longitude": 24.9384,
+        "score": 0.9,
+        "status": "very_common",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Turdus migratorius",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Turdidae",
+        "family_common": "Thrushes and Allies",
+        "genus": "Turdus",
+        "kingdom": "Animalia",
+        "order": "Passeriformes",
+        "phylum": "Chordata",
+        "species": "Turdus migratorius",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "turdus MIGRATORIUS",
+    "status": 200,
+    "body": {
+      "common_name": "American Robin",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": true,
+        "longitude": 24.9384,
+        "score": 0.9,
+        "status": "very_common",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "turdus MIGRATORIUS",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Turdidae",
+        "family_common": "Thrushes and Allies",
+        "genus": "Turdus",
+        "kingdom": "Animalia",
+        "order": "Passeriformes",
+        "phylum": "Chordata",
+        "species": "Turdus migratorius",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "Spilopelia senegalensis",
+    "status": 200,
+    "body": {
+      "common_name": "Laughing Dove",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": true,
+        "longitude": 24.9384,
+        "score": 0.1,
+        "status": "rare",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Spilopelia senegalensis",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Columbidae",
+        "family_common": "Pigeons and Doves",
+        "genus": "Streptopelia",
+        "kingdom": "Animalia",
+        "order": "Columbiformes",
+        "phylum": "Chordata",
+        "species": "Streptopelia senegalensis",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "Streptopelia senegalensis",
+    "status": 200,
+    "body": {
+      "common_name": "Laughing Dove",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": true,
+        "longitude": 24.9384,
+        "score": 0.1,
+        "status": "rare",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Streptopelia senegalensis",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Columbidae",
+        "family_common": "Pigeons and Doves",
+        "genus": "Streptopelia",
+        "kingdom": "Animalia",
+        "order": "Columbiformes",
+        "phylum": "Chordata",
+        "species": "Streptopelia senegalensis",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "Dicrurus adsimilis",
+    "status": 200,
+    "body": {
+      "common_name": "Fork-tailed Drongo",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": true,
+        "longitude": 24.9384,
+        "score": 0.7,
+        "status": "common",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Dicrurus adsimilis",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Dicruridae",
+        "family_common": "Drongos",
+        "genus": "Dicrurus",
+        "kingdom": "Animalia",
+        "order": "Passeriformes",
+        "phylum": "Chordata",
+        "species": "Dicrurus adsimilis",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "Dicrurus divaricatus",
+    "status": 200,
+    "body": {
+      "common_name": "Glossy-backed Drongo",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": true,
+        "longitude": 24.9384,
+        "score": 0.05,
+        "status": "very_rare",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Dicrurus divaricatus",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Dicruridae",
+        "family_common": "Drongos",
+        "genus": "Dicrurus",
+        "kingdom": "Animalia",
+        "order": "Passeriformes",
+        "phylum": "Chordata",
+        "species": "Dicrurus divaricatus",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "Turdus merula",
+    "status": 200,
+    "body": {
+      "common_name": "Eurasian Blackbird",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": true,
+        "longitude": 24.9384,
+        "score": 0.3,
+        "status": "uncommon",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Turdus merula",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Turdidae",
+        "family_common": "Thrushes and Allies",
+        "genus": "Turdus",
+        "kingdom": "Animalia",
+        "order": "Passeriformes",
+        "phylum": "Chordata",
+        "species": "Turdus merula",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "Tachyspiza badia",
+    "status": 200,
+    "body": {
+      "common_name": "Shikra",
+      "metadata": {
+        "source": "local"
+      },
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": true,
+        "longitude": 24.9384,
+        "score": 0,
+        "status": "unknown",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Tachyspiza badia",
+      "taxonomy": {
+        "class": "Aves",
+        "family": "Accipitridae",
+        "family_common": "Hawks, Eagles, and Kites",
+        "genus": "Tachyspiza",
+        "kingdom": "Animalia",
+        "order": "Accipitriformes",
+        "phylum": "Chordata",
+        "species": "Tachyspiza badia",
+        "species_common": "",
+        "updated_at": "2026-05-20T17:57:27Z"
+      }
+    }
+  },
+  {
+    "query": "Myotis daubentonii",
+    "status": 200,
+    "body": {
+      "common_name": "Water Bat",
+      "rarity": {
+        "latitude": 60.1699,
+        "location_based": true,
+        "longitude": 24.9384,
+        "score": 0,
+        "status": "unknown",
+        "threshold_applied": 0.029999999329447746
+      },
+      "scientific_name": "Myotis daubentonii"
+    }
+  },
+  {
+    "query": "Zzz Geomodelonly",
+    "status": 404,
+    "body": {
+      "code": 404,
+      "error": "Species not found",
+      "message": "Species not found"
+    }
+  },
+  {
+    "query": "Unknown species",
+    "status": 404,
+    "body": {
+      "code": 404,
+      "error": "Species not found",
+      "message": "Species not found"
+    }
+  },
+  {
+    "query": "Turdus",
+    "status": 400,
+    "body": {
+      "code": 400,
+      "error": "Invalid scientific name format",
+      "message": "Invalid scientific name format"
+    }
+  },
+  {
+    "query": "",
+    "status": 400,
+    "body": {
+      "code": 400,
+      "error": "Missing required parameter",
+      "message": "Missing required parameter"
+    }
+  }
+]

--- a/internal/classifier/label_vocabulary.go
+++ b/internal/classifier/label_vocabulary.go
@@ -1,0 +1,60 @@
+package classifier
+
+// LabelVocabulary is an immutable label set with its canonical-key memo, built
+// once when a range-filter view is constructed so no request path calls
+// openfauna.CanonicalName per geomodel label. A nil *LabelVocabulary is a valid
+// "no vocabulary" value: CanonicalKey still computes, HasCanonical reports false.
+//
+// The maps are never mutated after NewLabelVocabulary returns, so a
+// *LabelVocabulary is safe to share across goroutines (it rides on the
+// immutable range-filter snapshot the same way the label slices already do).
+type LabelVocabulary struct {
+	// Labels is the label set in its original (geomodel output) order.
+	Labels []string
+	// CanonicalByLabel maps each label to its canonical species key
+	// (canonicalSpeciesKey), memoized so the request path never recomputes it.
+	CanonicalByLabel map[string]string
+	// LabelsByCanonical maps a canonical key to every label sharing it, in input
+	// order, so a coverage check is an O(1) map lookup.
+	LabelsByCanonical map[string][]string
+}
+
+// NewLabelVocabulary builds a vocabulary from labels, computing canonicalSpeciesKey
+// once per label. It never returns nil; an empty input yields an empty (non-nil)
+// vocabulary. The Labels slice is retained by reference (callers pass the range
+// filter's immutable slice), matching how the label set already flows.
+func NewLabelVocabulary(labels []string) *LabelVocabulary {
+	v := &LabelVocabulary{
+		Labels:            labels,
+		CanonicalByLabel:  make(map[string]string, len(labels)),
+		LabelsByCanonical: make(map[string][]string, len(labels)),
+	}
+	for _, label := range labels {
+		key := canonicalSpeciesKey(label)
+		v.CanonicalByLabel[label] = key
+		v.LabelsByCanonical[key] = append(v.LabelsByCanonical[key], label)
+	}
+	return v
+}
+
+// CanonicalKey returns the canonical species key for a label, hitting the memo
+// when the label is in the vocabulary and computing canonicalSpeciesKey
+// otherwise. A nil receiver computes, so it is safe on a "no vocabulary" value.
+func (v *LabelVocabulary) CanonicalKey(label string) string {
+	if v != nil {
+		if key, ok := v.CanonicalByLabel[label]; ok {
+			return key
+		}
+	}
+	return canonicalSpeciesKey(label)
+}
+
+// HasCanonical reports whether any label in the vocabulary has the given
+// canonical key. A nil receiver reports false.
+func (v *LabelVocabulary) HasCanonical(key string) bool {
+	if v == nil {
+		return false
+	}
+	_, ok := v.LabelsByCanonical[key]
+	return ok
+}

--- a/internal/classifier/mapped_range_filter.go
+++ b/internal/classifier/mapped_range_filter.go
@@ -15,12 +15,13 @@ import (
 // changing predictFilter() or any downstream code.
 type mappedRangeFilter struct {
 	inner           inference.RangeFilter
-	classifierToGeo []int          // classifierIndex -> geomodelIndex; -1 means no match
-	numClassifier   int            // len(classifierLabels)
-	mappedCount     int            // number of classifier species with a geomodel match
-	unmappedScore   float32        // score for classifier species absent from geomodel
-	geomodelLabels  []string       // geomodel label set in geomodel output order
-	geomodelIndex   map[string]int // label -> index for O(1) lookup
+	classifierToGeo []int            // classifierIndex -> geomodelIndex; -1 means no match
+	numClassifier   int              // len(classifierLabels)
+	mappedCount     int              // number of classifier species with a geomodel match
+	unmappedScore   float32          // score for classifier species absent from geomodel
+	geomodelLabels  []string         // geomodel label set in geomodel output order
+	geomodelIndex   map[string]int   // label -> index for O(1) lookup
+	vocab           *LabelVocabulary // geomodelLabels plus their canonical-key memo, for the species endpoint
 }
 
 // canonicalSpeciesKey returns the match key for a model label: its scientific
@@ -97,6 +98,7 @@ func newMappedRangeFilter(inner inference.RangeFilter, classifierLabels, geomode
 		unmappedScore:   unmappedScore,
 		geomodelLabels:  geomodelLabels,
 		geomodelIndex:   geoIdx,
+		vocab:           NewLabelVocabulary(geomodelLabels),
 	}
 }
 
@@ -141,7 +143,7 @@ func (m *mappedRangeFilter) PredictSpeciesScores(lat, lon, week, threshold float
 // override matching, where the caller needs to search all known species
 // (not just those passing the range filter threshold).
 func (m *mappedRangeFilter) GeomodelLabels() []string {
-	return m.geomodelLabels
+	return m.vocab.Labels
 }
 
 // NumSpecies returns the number of classifier labels (not geomodel labels).

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -2690,7 +2690,11 @@ func (o *Orchestrator) loadAdditionalModels(threadAlloc map[string]int) error {
 // the scores were produced from. See GetRarityContext for the per-field semantics and the
 // consistency guarantees.
 type RarityContext struct {
-	Scores           []SpeciesScore
+	Scores []SpeciesScore
+	// Geomodel is the universal geomodel's label vocabulary paired with Scores. It
+	// is nil unless the universal geomodel path ran; when non-nil it is built from
+	// the same range-filter instance that produced Scores. Coverage reads its
+	// canonical-key memo, and a nil value means fall back to ClassifierLabels.
 	Geomodel         *LabelVocabulary
 	ClassifierLabels []string
 	FilterActive     bool

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -1049,11 +1049,17 @@ func (o *Orchestrator) GetAllProbableSpeciesWithSettings(date time.Time, week fl
 	// ReloadRangeFilter cannot desync them. geoLabels is non-nil only on the
 	// universal (v3 geomodel) path, where it covers every scientific name the
 	// geomodel knows regardless of threshold.
-	scores, geoLabels, _, err := primary.getProbableSpecies(date, week, settings)
+	scores, geo, _, err := primary.getProbableSpecies(date, week, settings)
 	if err != nil {
 		return nil, err
 	}
-	isUniversal := geoLabels != nil
+	isUniversal := geo != nil
+	// geo is non-nil only on the universal path; read its label slice (nil
+	// otherwise) so the geomodel-coverage dedup below is byte-for-byte unchanged.
+	var geoLabels []string
+	if geo != nil {
+		geoLabels = geo.Labels
+	}
 
 	// Dedup by scientific name (lowercased). seenSci holds species already
 	// represented via the primary scores; geoCovered holds every scientific
@@ -2685,7 +2691,7 @@ func (o *Orchestrator) loadAdditionalModels(threadAlloc map[string]int) error {
 // consistency guarantees.
 type RarityContext struct {
 	Scores           []SpeciesScore
-	GeomodelLabels   []string
+	Geomodel         *LabelVocabulary
 	ClassifierLabels []string
 	FilterActive     bool
 	Settings         *conf.Settings
@@ -2700,9 +2706,9 @@ type RarityContext struct {
 // synthetic always-active scores to secondary-model species that have no real
 // occurrence probability.
 //
-// Consistency, stated precisely because the guarantee is partial: scores and
-// geomodelLabels always describe the same range-filter instance, because
-// getProbableSpecies captures the geomodel vocabulary under the same bn.mu hold that
+// Consistency, stated precisely because the guarantee is partial: scores and the
+// geomodel vocabulary (Geomodel) always describe the same range-filter instance,
+// because getProbableSpecies captures the geomodel vocabulary under the same bn.mu hold that
 // produces the scores. classifierLabels comes from the settings snapshot read here,
 // which is the same snapshot getProbableSpecies indexes for zeroScoresForAllLabels and
 // the unmapped-species mapping, so it agrees with the scores; but the range-filter
@@ -2714,7 +2720,7 @@ type RarityContext struct {
 // the globally published snapshot; an in-place model reload republishes only to the
 // instance, so classifierLabels can lag a label-set change until the next restart.
 //
-// geomodelLabels is nil unless the universal geomodel path ran. It is nil for the
+// Geomodel is nil unless the universal geomodel path ran. It is nil for the
 // TFLite meta model and the plain ONNX range filter, and when no range filter or
 // location is configured; in every one of those cases the scores are labeled with the
 // classifier's own vocabulary, so callers must fall back to classifierLabels.
@@ -2753,10 +2759,10 @@ func (o *Orchestrator) GetRarityContext(date time.Time) (RarityContext, error) {
 	// filterActive=true with synthetic zeros, and it also covers the no-location case
 	// a bare rangeFilter!=nil check missed, so a caller never reports a synthetic zero
 	// as "very rare" (#3935).
-	scores, geomodelLabels, filterActive, err := primary.getProbableSpecies(date, 0.0, settings)
+	scores, geomodel, filterActive, err := primary.getProbableSpecies(date, 0.0, settings)
 	return RarityContext{
 		Scores:           scores,
-		GeomodelLabels:   geomodelLabels,
+		Geomodel:         geomodel,
 		ClassifierLabels: slices.Clone(settings.BirdNET.Labels),
 		FilterActive:     filterActive,
 		Settings:         settings,

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -532,7 +532,7 @@ func (bn *BirdNET) GetProbableSpeciesWithSettings(date time.Time, week float32, 
 // describe one consistent snapshot, with no separate read that could race a
 // concurrent unload (used by GetRarityContext to avoid reporting a synthetic zero
 // as "very rare", #3935).
-func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *conf.Settings) (probableSpecies []SpeciesScore, geomodelLabels []string, filterActive bool, err error) {
+func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *conf.Settings) (probableSpecies []SpeciesScore, geomodel *LabelVocabulary, filterActive bool, err error) {
 	bn.Debug("Applying range filter")
 
 	// Build the exclude matcher once: it reverse-resolves localized common-name exclude
@@ -638,7 +638,20 @@ func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *co
 		}
 
 		sort.Sort(ByScore(speciesScores))
-		return speciesScores, allGeoLabels, true, nil
+		// Wrap the geomodel vocabulary in a *LabelVocabulary so the species
+		// endpoint answers coverage from a precomputed canonical-key memo instead
+		// of an openfauna.CanonicalName scan per label. Gate on a non-nil label
+		// slice so the returned vocabulary is nil exactly when the raw labels were
+		// nil, preserving the "isUniversal := geomodel != nil" check at every caller.
+		var geomodel *LabelVocabulary
+		if allGeoLabels != nil {
+			if mrf, ok := rf.(*mappedRangeFilter); ok {
+				geomodel = mrf.vocab
+			} else {
+				geomodel = NewLabelVocabulary(allGeoLabels)
+			}
+		}
+		return speciesScores, geomodel, true, nil
 	}
 	bn.mu.Unlock()
 

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -638,12 +638,12 @@ func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *co
 		}
 
 		sort.Sort(ByScore(speciesScores))
-		// Wrap the geomodel vocabulary in a *LabelVocabulary so the species
-		// endpoint answers coverage from a precomputed canonical-key memo instead
-		// of an openfauna.CanonicalName scan per label. Gate on a non-nil label
-		// slice so the returned vocabulary is nil exactly when the raw labels were
-		// nil, preserving the "isUniversal := geomodel != nil" check at every caller.
-		var geomodel *LabelVocabulary
+		// Wrap the geomodel vocabulary in a *LabelVocabulary (the named return) so
+		// the species endpoint answers coverage from a precomputed canonical-key
+		// memo instead of an openfauna.CanonicalName scan per label. Gate on a
+		// non-nil label slice so the returned vocabulary is nil exactly when the raw
+		// labels were nil, preserving the "isUniversal := geomodel != nil" check at
+		// every caller.
 		if allGeoLabels != nil {
 			if mrf, ok := rf.(*mappedRangeFilter); ok {
 				geomodel = mrf.vocab

--- a/internal/classifier/rarity_context_test.go
+++ b/internal/classifier/rarity_context_test.go
@@ -191,19 +191,20 @@ func TestGetRarityContext_UniversalGeomodel(t *testing.T) {
 
 	rc, err := orch.GetRarityContext(time.Now())
 	require.NoError(t, err)
-	scores, geomodelLabels, classifierLabels, filterActive := rc.Scores, rc.GeomodelLabels, rc.ClassifierLabels, rc.FilterActive
+	scores, classifierLabels, filterActive := rc.Scores, rc.ClassifierLabels, rc.FilterActive
 
 	assert.Same(t, bn.Settings, rc.Settings, "GetRarityContext returns the exact settings snapshot the scores were produced from")
 	assert.True(t, filterActive, "a loaded range filter reports active so rarity is honest (#3935)")
 	assert.NotEmpty(t, scores, "universal geomodel path should return scored species")
-	assert.Contains(t, geomodelLabels, aliasCanonicalLabel,
+	require.NotNil(t, rc.Geomodel, "universal geomodel path should return a geomodel vocabulary")
+	assert.Contains(t, rc.Geomodel.Labels, aliasCanonicalLabel,
 		"geomodel vocabulary should come back so coverage is checked against it")
 	assert.Contains(t, classifierLabels, aliasLegacyLabel,
 		"classifier vocabulary should come back as the fallback for non-geomodel backends")
 
 	// The classifier labels must be a copy: a caller mutating them must not corrupt the
-	// live settings the model classifies against. geomodelLabels is deliberately NOT
-	// copied (it aliases the range filter's immutable label slice, as
+	// live settings the model classifies against. The geomodel vocabulary's Labels are
+	// deliberately NOT copied (they alias the range filter's immutable label slice, as
 	// PrimaryRangeFilterCoverage and RangeFilterStatus also return it), so this
 	// asymmetry is contractual rather than accidental.
 	classifierLabels[0] = "mutated"
@@ -232,14 +233,14 @@ func TestGetRarityContext_NoGeomodel(t *testing.T) {
 
 	rc, err := orch.GetRarityContext(time.Now())
 	require.NoError(t, err)
-	geomodelLabels, classifierLabels, filterActive := rc.GeomodelLabels, rc.ClassifierLabels, rc.FilterActive
+	classifierLabels, filterActive := rc.ClassifierLabels, rc.FilterActive
 
 	assert.Same(t, settings, rc.Settings, "GetRarityContext returns the exact settings snapshot the scores were produced from")
 	// Location is unconfigured here, so getProbableSpecies returns synthetic zero
 	// scores even though a filter is loaded; filterActive must be false so rarity is
 	// reported as unknown rather than a bogus "very rare" (#3935).
 	assert.False(t, filterActive, "unconfigured location yields synthetic zeros, so the filter is not active for rarity")
-	assert.Empty(t, geomodelLabels, "no universal geomodel means no geomodel vocabulary")
+	assert.Nil(t, rc.Geomodel, "no universal geomodel means no geomodel vocabulary")
 	assert.Contains(t, classifierLabels, "Turdus merula_Common Blackbird")
 }
 
@@ -255,7 +256,7 @@ func TestGetRarityContext_NilPrimary(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, rc.FilterActive, "no primary model means no active range filter")
 	assert.Nil(t, rc.Scores)
-	assert.Nil(t, rc.GeomodelLabels)
+	assert.Nil(t, rc.Geomodel)
 	assert.Nil(t, rc.ClassifierLabels)
 	assert.Same(t, distinct, rc.Settings, "with no primary, GetRarityContext returns the orchestrator's current settings snapshot")
 }

--- a/internal/speciesindex/snapshot.go
+++ b/internal/speciesindex/snapshot.go
@@ -133,8 +133,10 @@ func canonicalKeyForSci(sci string) string {
 	return strings.ToLower(openfauna.CanonicalName(sci))
 }
 
-// CanonicalKey is the canonical lookup key for a label: the extracted scientific
-// name run through the openfauna alias map, lower-cased. It is identical to
+// CanonicalKey is the canonical lookup key for a "Scientific_Common" label or a
+// bare scientific name (ExtractScientificName returns the whole string when there
+// is no common part, so both forms are accepted): the extracted scientific name
+// run through the openfauna alias map, lower-cased. It is identical to
 // classifier.canonicalSpeciesKey, pinned by a classifier-side test. The species
 // endpoint uses it to key an incoming request name into a snapshot's memo maps
 // without materializing the label set per request.

--- a/internal/speciesindex/snapshot.go
+++ b/internal/speciesindex/snapshot.go
@@ -133,10 +133,12 @@ func canonicalKeyForSci(sci string) string {
 	return strings.ToLower(openfauna.CanonicalName(sci))
 }
 
-// computeCanonicalKey is the canonical lookup key for a label: the extracted
-// scientific name run through the openfauna alias map, lower-cased. It is
-// identical to classifier.canonicalSpeciesKey, pinned by a classifier-side test.
-func computeCanonicalKey(label string) string {
+// CanonicalKey is the canonical lookup key for a label: the extracted scientific
+// name run through the openfauna alias map, lower-cased. It is identical to
+// classifier.canonicalSpeciesKey, pinned by a classifier-side test. The species
+// endpoint uses it to key an incoming request name into a snapshot's memo maps
+// without materializing the label set per request.
+func CanonicalKey(label string) string {
 	return canonicalKeyForSci(detection.ExtractScientificName(label))
 }
 
@@ -146,7 +148,7 @@ func (s *Snapshot) CanonicalKey(label string) string {
 	if ck, ok := s.CanonicalByLabel[label]; ok {
 		return ck
 	}
-	return computeCanonicalKey(label)
+	return CanonicalKey(label)
 }
 
 // ResolveLabel returns the full label and localized common name for a scientific
@@ -162,7 +164,7 @@ func (s *Snapshot) ResolveLabel(sci string) (label, common string, ok bool) {
 	if lbl, found := s.LabelBySci[sci]; found {
 		return lbl, s.SciToCommon[sci], true
 	}
-	ck := computeCanonicalKey(sci)
+	ck := CanonicalKey(sci)
 	if lbls := s.LabelsByCanonical[ck]; len(lbls) == 1 {
 		lbl := lbls[0]
 		return lbl, s.SciToCommon[scientificName(lbl)], true


### PR DESCRIPTION
## What

Rewrites `GET /api/v2/species` (and the shared rarity helpers behind it) to answer from the orchestrator-owned species-index snapshot's precomputed canonical-key memo maps, instead of three per-request linear passes over the full loaded-label union and the geomodel vocabulary that each called `openfauna.CanonicalName` (a `TrimSpace` plus `ToLower` allocation) per label.

## Why

On a universal-geomodel install the endpoint scanned roughly 6.5K to 21K classifier labels plus a ~12K geomodel vocabulary per request, doing about 25-35K short-lived allocations each time. The species-index snapshot (orchestrator-owned since the earlier name-service work) already holds the canonical-key memo maps, so the endpoint can key into them directly.

## Result

Measured with the new `BenchmarkGetSpeciesInfo` over a 21K-label union and a 12K geomodel vocabulary: about 800 ns/op and 7 allocs/op, down from the ~25-35K-alloc storm. `TestGetSpeciesInfo_AllocationCeiling` asserts under 100 allocs/op in the normal unit job so a regression fails CI.

## Equivalence

This is a performance refactor, so the first commit adds a golden test that records `GET /api/v2/species` responses from the pre-refactor helpers across four rarity contexts (universal, override, legacy, inactive); the later commits swap in the snapshot memo maps and leave every golden byte-identical. The corpus exercises the real OpenFauna alias pair (Streptopelia/Spilopelia) and the colliding species BirdNET v2.4 ships separately (Dicrurus adsimilis/divaricatus), so exact-before-alias and the synthetic-override skip from the recent force-include fix (#3975) are pinned end to end. `TestCorpusScientificNamesAreASCII` pins the ASCII assumption the exact/alias equivalence relies on.

## One deliberate behavior change

`getSpeciesInfo` now resolves against the orchestrator snapshot label set, which is a superset of the loaded-model labels: it is the union of every loaded model's labels and the active range filter's inclusion list, the same set `GET /api/v2/species/all` already lists. A species the range filter includes at the configured location but that is not a label of any loaded model now returns its info (200) instead of 404ing, matching what the picker shows. This is additive: every name that resolved before still resolves, in the same union order, so nothing that worked stops working.

## Notes

The geomodel vocabulary carried on `RarityContext` changes from a `[]string` to a `*LabelVocabulary` (an immutable label set plus its canonical-key memo); this is an internal `classifier` type with no wire or config surface. `speciesindex.CanonicalKey` is exported so the endpoint can key a request name into the memo maps. The legacy (no-geomodel) coverage path stays an allocation-free O(n) scan of the classifier labels; making it O(1) is left to a later change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved species lookup across aliases, canonical names, legacy labels, and range-filter results.
  * Added more consistent rarity and taxonomy information, including geomodel-only species.
  * Improved localization and case handling for scientific-name requests.

* **Bug Fixes**
  * Improved handling of name collisions and inactive species filtering.
  * Preserved clear validation responses for missing, malformed, and unknown species names.
  * Excluded synthetic scores from applicable rarity results.

* **Tests**
  * Added comprehensive coverage for species resolution, localization, filtering, error responses, and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->