### PR TITLE
fix(api): serve taxonomy from embedded data without eBird (#4105)

### DIFF
--- a/internal/api/v2/species/species.go
+++ b/internal/api/v2/species/species.go
@@ -60,6 +60,13 @@ type Handler struct {
 	// to Processor.Bn.
 	speciesBackendOverride speciesBackend
 
+	// eBirdClientOverride, when non-nil, replaces the Core's live eBird client for
+	// the taxonomy path. Only tests set it (mirroring speciesBackendOverride), so
+	// they can drive the eBird branches against an httptest server without a real
+	// API key; production leaves it nil and ebirdClient() falls through to
+	// Core.EBird().
+	eBirdClientOverride *ebird.Client
+
 	// serveImageProxy is the media domain's species-image proxy handler. The
 	// thumbnail endpoint resolves a species code to a scientific name and then
 	// delegates to it.
@@ -85,6 +92,17 @@ func (c *Handler) backend() speciesBackend {
 		return proc.Bn
 	}
 	return nil
+}
+
+// ebirdClient returns the eBird client the taxonomy path should use: the test
+// override when set, otherwise the Core's live client. Mirrors backend() /
+// speciesBackendOverride so tests can exercise the eBird branches without a real
+// key or network; production leaves the override nil.
+func (c *Handler) ebirdClient() *ebird.Client {
+	if c.eBirdClientOverride != nil {
+		return c.eBirdClientOverride
+	}
+	return c.EBird()
 }
 
 // New builds a species Handler around the shared core and the two facade-owned
@@ -764,32 +782,97 @@ func (c *Handler) GetSpeciesTaxonomy(ctx echo.Context) error {
 	return ctx.JSON(http.StatusOK, taxonomyInfo)
 }
 
-// getDetailedTaxonomy retrieves detailed taxonomy information
-// Tries local database first, falls back to eBird API if needed
+// Metadata source and note for a taxonomy response derived only from the requested
+// name, used when the embedded database does not cover it and eBird did not answer.
+const (
+	taxonomySourceUnresolved = "unresolved"
+	taxonomyUnresolvedNote   = "species not found in the embedded taxonomy; configure eBird for taxonomy of species outside the bundled dataset"
+)
+
+// getDetailedTaxonomy retrieves detailed taxonomy information for a species.
+//
+// The embedded genus/family taxonomy is the authority: it ships in the binary and
+// answers offline, so eBird is pure enrichment (subspecies, locale common names),
+// never a hard dependency for a basic lookup (#4105). Resolution order:
+//
+//  1. A missing embedded database (c.TaxonomyDB == nil) is a fatal build/deploy
+//     fault, since the data is compiled in via go:embed and always loads in a
+//     healthy binary. Surface it as a system error immediately, before eBird, so a
+//     broken binary fails fast instead of being masked by whatever eBird returns.
+//  2. Local lookup. A hit returns the full hierarchy (optionally enriched by eBird).
+//  3. On a local miss, eBird is consulted only when configured, and only as
+//     enrichment: a species eBird genuinely does not carry (every non-avian label,
+//     such as frogs, bats and insects, falls here because eBird is a bird database)
+//     must not fail the request, so an eBird not-found degrades to the derived
+//     response below. A real eBird transport/API error still propagates.
+//  4. Otherwise return an explicit "unresolved" marker (HTTP 200) rather than
+//     erroring, so a user without eBird still gets a graceful, machine-detectable
+//     answer instead of a misleading failure.
 func (c *Handler) getDetailedTaxonomy(ctx context.Context, scientificName, locale string, includeSubspecies, includeHierarchy bool) (*TaxonomyInfo, error) {
+	// A nil embedded database is a system fault, not a per-species miss: fail fast
+	// regardless of eBird configuration (see step 1 above).
+	if c.TaxonomyDB == nil {
+		return nil, errors.Newf("taxonomy database not loaded").
+			Category(errors.CategorySystem).
+			Context("scientific_name", scientificName).
+			Component("api-species").
+			Build()
+	}
+
 	// Load the eBird client once for the whole request and thread it through the
 	// helpers below. The client can be swapped concurrently by a settings
 	// hot-reload (ReconfigureEBird); re-reading it in each helper would risk a
 	// nil-after-check TOCTOU across method boundaries.
-	client := c.EBird()
+	client := c.ebirdClient()
 
 	// Try local taxonomy database first
 	if info := c.tryLocalTaxonomy(ctx, client, scientificName, locale, includeSubspecies, includeHierarchy); info != nil {
 		return info, nil
 	}
 
-	// Fall back to eBird API
+	// Local miss: consult eBird only as enrichment. A not-found there is not an
+	// error for this endpoint (eBird cannot cover non-avian labels and does not
+	// carry every name shape), so fall through to the derived response; any other
+	// eBird failure (network, API) still propagates.
 	if client != nil {
-		return c.getEBirdTaxonomy(ctx, client, scientificName, locale, includeSubspecies)
+		info, err := c.getEBirdTaxonomy(ctx, client, scientificName, locale, includeSubspecies)
+		if err == nil {
+			return info, nil
+		}
+		// eBird is enrichment, not a hard dependency: a species eBird does not carry
+		// (every non-avian label, and any name outside its taxonomy) surfaces as a
+		// not-found, which must degrade to the derived response rather than fail the
+		// request. Any other eBird failure (network, API) still propagates.
+		if !errors.IsNotFound(err) {
+			return nil, err
+		}
+		c.Debug("eBird has no taxonomy for %s: %v; returning derived taxonomy", scientificName, err)
 	}
 
-	// Neither local DB nor eBird API available
-	return nil, errors.Newf("taxonomy data not available (no local database or eBird API)").
-		Category(errors.CategoryConfiguration).
-		Priority(errors.PriorityLow).
-		Context("scientific_name", scientificName).
-		Component("api-species").
-		Build()
+	// Embedded database does not cover this name and eBird did not answer: mark the
+	// result unresolved rather than hard-erroring (#4105).
+	return deriveMinimalTaxonomy(scientificName), nil
+}
+
+// deriveMinimalTaxonomy builds the fallback response for a species the embedded
+// database does not cover and eBird did not resolve. It intentionally returns NO
+// taxonomy hierarchy. GetSpeciesTaxonomy accepts any string that merely looks like
+// a binomial (a length check plus a space), and BirdNET-Go's label set includes
+// non-organism noise classes such as "Human vocal" and "Power tools", so deriving
+// a genus from the first token or asserting Kingdom "Animalia" would fabricate a
+// wrong taxonomy for those. Instead it echoes the requested name and marks the
+// result "unresolved" in metadata: an HTTP 200 that degrades gracefully (#4105) and
+// is machine-detectable, rather than a misleading error. A consumer that renders a
+// fixed rank list then omits the absent taxonomy block instead of showing empty
+// rank rows.
+func deriveMinimalTaxonomy(scientificName string) *TaxonomyInfo {
+	return &TaxonomyInfo{
+		ScientificName: scientificName,
+		Metadata: map[string]any{
+			"source": taxonomySourceUnresolved,
+			"note":   taxonomyUnresolvedNote,
+		},
+	}
 }
 
 // tryLocalTaxonomy attempts to retrieve taxonomy from the local database.

--- a/internal/api/v2/species/species.go
+++ b/internal/api/v2/species/species.go
@@ -782,11 +782,18 @@ func (c *Handler) GetSpeciesTaxonomy(ctx echo.Context) error {
 	return ctx.JSON(http.StatusOK, taxonomyInfo)
 }
 
-// Metadata source and note for a taxonomy response derived only from the requested
-// name, used when the embedded database does not cover it and eBird did not answer.
+// Metadata source and notes for a taxonomy response derived only from the
+// requested name, used when the embedded database does not cover it and eBird did
+// not answer. The note depends on whether eBird was consulted: recommending eBird
+// to a user who already has it enabled would be a misleading no-op.
 const (
 	taxonomySourceUnresolved = "unresolved"
-	taxonomyUnresolvedNote   = "species not found in the embedded taxonomy; configure eBird for taxonomy of species outside the bundled dataset"
+	// eBird not configured: point the user at eBird as an optional source for
+	// species outside the bundled dataset.
+	taxonomyUnresolvedNote = "species not found in the embedded taxonomy; configure eBird for taxonomy of species outside the bundled dataset"
+	// eBird consulted but also unable to resolve the species: eBird is already
+	// enabled, so do not tell the user to configure it.
+	taxonomyUnresolvedNoteEBirdOn = "species not found in the embedded taxonomy or eBird"
 )
 
 // getDetailedTaxonomy retrieves detailed taxonomy information for a species.
@@ -837,6 +844,12 @@ func (c *Handler) getDetailedTaxonomy(ctx context.Context, scientificName, local
 	if client != nil {
 		info, err := c.getEBirdTaxonomy(ctx, client, scientificName, locale, includeSubspecies)
 		if err == nil {
+			// getEBirdTaxonomy always builds the hierarchy; honor include_hierarchy
+			// here so an eBird hit behaves like a local hit (tryLocalTaxonomy) when
+			// the caller asked to omit it. Subspecies and species code are unaffected.
+			if !includeHierarchy {
+				info.Taxonomy = TaxonomyHierarchy{}
+			}
 			return info, nil
 		}
 		// eBird is enrichment, not a hard dependency: a species eBird does not carry
@@ -846,12 +859,13 @@ func (c *Handler) getDetailedTaxonomy(ctx context.Context, scientificName, local
 		if !errors.IsNotFound(err) {
 			return nil, err
 		}
-		c.Debug("eBird has no taxonomy for %s: %v; returning derived taxonomy", scientificName, err)
+		c.Debug("eBird has no taxonomy for %s: %v; returning unresolved response", scientificName, err)
 	}
 
 	// Embedded database does not cover this name and eBird did not answer: mark the
-	// result unresolved rather than hard-erroring (#4105).
-	return deriveMinimalTaxonomy(scientificName), nil
+	// result unresolved rather than hard-erroring (#4105). Whether eBird was
+	// consulted selects the note (see the const block).
+	return deriveMinimalTaxonomy(scientificName, client != nil), nil
 }
 
 // deriveMinimalTaxonomy builds the fallback response for a species the embedded
@@ -864,13 +878,18 @@ func (c *Handler) getDetailedTaxonomy(ctx context.Context, scientificName, local
 // result "unresolved" in metadata: an HTTP 200 that degrades gracefully (#4105) and
 // is machine-detectable, rather than a misleading error. A consumer that renders a
 // fixed rank list then omits the absent taxonomy block instead of showing empty
-// rank rows.
-func deriveMinimalTaxonomy(scientificName string) *TaxonomyInfo {
+// rank rows. eBirdConfigured selects the note so a user who already has eBird
+// enabled is not told to configure it.
+func deriveMinimalTaxonomy(scientificName string, eBirdConfigured bool) *TaxonomyInfo {
+	note := taxonomyUnresolvedNote
+	if eBirdConfigured {
+		note = taxonomyUnresolvedNoteEBirdOn
+	}
 	return &TaxonomyInfo{
 		ScientificName: scientificName,
 		Metadata: map[string]any{
 			"source": taxonomySourceUnresolved,
-			"note":   taxonomyUnresolvedNote,
+			"note":   note,
 		},
 	}
 }

--- a/internal/api/v2/species/taxonomy_test.go
+++ b/internal/api/v2/species/taxonomy_test.go
@@ -4,6 +4,7 @@ package species
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -15,6 +16,9 @@ import (
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/classifier"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/ebird"
+	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
 // TestGetGenusSpecies tests the GET /api/v2/taxonomy/genus/:genus endpoint
@@ -355,16 +359,205 @@ func TestGetSpeciesTaxonomyLocalDB(t *testing.T) {
 	}
 }
 
-// TestGetSpeciesTaxonomyWithoutLocalDB tests fallback when local DB unavailable
+// TestGetSpeciesTaxonomyWithoutLocalDB verifies that a nil embedded taxonomy
+// database is surfaced as an accurate system fault, not the old misleading
+// "no local database or eBird API" configuration message (#4105). The embedded
+// database is compiled in via go:embed and always loads in a healthy binary, so a
+// nil database is a build/deploy defect worth an error, distinct from a normal
+// per-species miss (which degrades gracefully, see the tests below).
 func TestGetSpeciesTaxonomyWithoutLocalDB(t *testing.T) {
 	t.Parallel()
 
 	c := &Handler{Core: &apicore.Core{TaxonomyDB: nil}}
 	c.Settings.Store(apitest.NewValidTestSettings())
+	require.Nil(t, c.EBird(), "eBird must be off for this test")
 
-	// This should fail gracefully
 	_, err := c.getDetailedTaxonomy(t.Context(), "Turdus migratorius", "", false, true)
+	require.Error(t, err, "a nil taxonomy database must surface a system error")
+	assert.True(t, errors.IsCategory(err, errors.CategorySystem),
+		"a nil DB is a system fault, not a configuration miss")
+	assert.NotContains(t, err.Error(), "no local database",
+		"the misleading 'no local database' wording must be gone")
+}
 
-	require.Error(t, err, "Expected error when both local DB and eBird client unavailable")
-	t.Logf("Correctly returned error: %v", err)
+// TestGetSpeciesTaxonomyNilDBWithEBirdConfigured verifies that a nil embedded
+// database fails fast as a system fault even when eBird is configured, i.e. the
+// nil-DB check is not masked by the eBird fallback (#4105). The eBird path is never
+// reached (no network call), because the nil-DB check short-circuits first.
+func TestGetSpeciesTaxonomyNilDBWithEBirdConfigured(t *testing.T) {
+	// Not parallel: mutates the global conf singleton so ReconfigureEBird can build
+	// a client. Snapshot and restore it around the test.
+	orig := conf.GetSettings()
+	t.Cleanup(func() { conf.StoreSettings(orig) })
+
+	settings := apitest.NewValidTestSettings()
+	settings.Realtime.EBird.Enabled = true
+	settings.Realtime.EBird.APIKey = "test-api-key"
+	conf.StoreSettings(settings)
+
+	c := &Handler{Core: &apicore.Core{TaxonomyDB: nil}}
+	c.Settings.Store(settings)
+	require.NotNil(t, c.ReconfigureEBird(), "eBird client must build from the configured key")
+	require.NotNil(t, c.EBird(), "eBird client must be available after configuring it")
+
+	_, err := c.getDetailedTaxonomy(t.Context(), "Turdus migratorius", "", false, true)
+	require.Error(t, err, "a nil DB must fail even when eBird is configured")
+	assert.True(t, errors.IsCategory(err, errors.CategorySystem),
+		"a nil DB must fail fast as a system fault, not be masked by the eBird path")
+}
+
+// TestGetSpeciesTaxonomyLocalMissDegradesGracefully verifies that a species absent
+// from the embedded taxonomy, with eBird off, degrades to an "unresolved" 200
+// response instead of hard-erroring (#4105). No taxonomy hierarchy is fabricated:
+// the requested name may be a non-organism noise label, so not even kingdom or
+// genus is safe to assert, and include_hierarchy makes no difference to the
+// fallback.
+func TestGetSpeciesTaxonomyLocalMissDegradesGracefully(t *testing.T) {
+	t.Parallel()
+
+	taxonomyDB, err := classifier.LoadTaxonomyDatabase()
+	require.NoError(t, err, "Failed to load taxonomy database")
+
+	c := &Handler{Core: &apicore.Core{TaxonomyDB: taxonomyDB}}
+	c.Settings.Store(apitest.NewValidTestSettings())
+	require.Nil(t, c.EBird(), "eBird must be off for this test")
+
+	// A validly-formatted binomial (len >= 3, contains a space) guaranteed to be
+	// absent from the frozen embedded snapshot.
+	const missName = "Zzyzxus fictus"
+
+	for _, includeHierarchy := range []bool{true, false} {
+		t.Run(fmt.Sprintf("include_hierarchy=%t", includeHierarchy), func(t *testing.T) {
+			t.Parallel()
+			info, err := c.getDetailedTaxonomy(t.Context(), missName, "", false, includeHierarchy)
+			require.NoError(t, err, "a local miss with eBird off must degrade gracefully, not error")
+			require.NotNil(t, info)
+
+			assert.Equal(t, missName, info.ScientificName)
+			assert.Equal(t, taxonomySourceUnresolved, info.Metadata["source"],
+				"source must mark the response as unresolved")
+			assert.Equal(t, taxonomyUnresolvedNote, info.Metadata["note"],
+				"the explanatory note must be present")
+			assert.Equal(t, TaxonomyHierarchy{}, info.Taxonomy,
+				"no rank may be fabricated for an unresolved species")
+		})
+	}
+}
+
+// TestGetSpeciesTaxonomyEBirdFallback drives the eBird-configured local-miss branch
+// against an httptest eBird server via the eBirdClientOverride seam. It locks the
+// decision at the heart of #4105: an eBird not-found (which every non-avian label
+// hits, since eBird is a bird database) degrades to the unresolved 200, an eBird
+// hit returns full taxonomy, and a genuine eBird error (auth/network) propagates
+// rather than being misread as not-found.
+func TestGetSpeciesTaxonomyEBirdFallback(t *testing.T) {
+	t.Parallel()
+
+	taxonomyDB, err := classifier.LoadTaxonomyDatabase()
+	require.NoError(t, err, "Failed to load taxonomy database")
+
+	// A binomial absent from the embedded snapshot, so the local lookup misses and
+	// the eBird branch is exercised.
+	const missName = "Zzyzxus fictus"
+
+	newHandler := func(t *testing.T, h http.HandlerFunc) *Handler {
+		t.Helper()
+		srv := httptest.NewServer(h)
+		t.Cleanup(srv.Close)
+		client, err := ebird.NewClient(ebird.Config{BaseURL: srv.URL, APIKey: "test-key"})
+		require.NoError(t, err, "eBird client must build")
+		c := &Handler{Core: &apicore.Core{TaxonomyDB: taxonomyDB}, eBirdClientOverride: client}
+		c.Settings.Store(apitest.NewValidTestSettings())
+		return c
+	}
+
+	t.Run("eBird hit returns full taxonomy", func(t *testing.T) {
+		t.Parallel()
+		c := newHandler(t, func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"sciName":"Zzyzxus fictus","comName":"Fake Species","speciesCode":"fake1","category":"species","order":"Testiformes","familySciName":"Testidae","familyComName":"Test Family"}]`))
+		})
+		info, err := c.getDetailedTaxonomy(t.Context(), missName, "", false, true)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		assert.Equal(t, "ebird", info.Metadata["source"], "an eBird hit must be sourced from eBird")
+		assert.Equal(t, "Testidae", info.Taxonomy.Family)
+	})
+
+	t.Run("eBird not-found degrades to unresolved", func(t *testing.T) {
+		t.Parallel()
+		c := newHandler(t, func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[]`)) // taxonomy present but does not contain the species
+		})
+		info, err := c.getDetailedTaxonomy(t.Context(), missName, "", false, true)
+		require.NoError(t, err, "an eBird not-found must degrade, not propagate")
+		require.NotNil(t, info)
+		assert.Equal(t, taxonomySourceUnresolved, info.Metadata["source"])
+		assert.Equal(t, TaxonomyHierarchy{}, info.Taxonomy)
+	})
+
+	t.Run("genuine eBird error propagates", func(t *testing.T) {
+		t.Parallel()
+		// 401 maps to CategoryConfiguration (not CategoryNotFound) and is not
+		// retried, so it is fast and must propagate as an error, never be swallowed.
+		c := newHandler(t, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		})
+		_, err := c.getDetailedTaxonomy(t.Context(), missName, "", false, true)
+		require.Error(t, err, "a non-not-found eBird error must propagate, not be swallowed")
+		assert.False(t, errors.IsCategory(err, errors.CategoryNotFound),
+			"the propagated error must not be a not-found")
+		assert.True(t, errors.IsCategory(err, errors.CategoryConfiguration),
+			"a 401 must surface as a configuration error, confirming it was not swallowed")
+	})
+}
+
+// TestGetSpeciesTaxonomyHandlerContract locks the observable HTTP contract through
+// the exported handler (not just the internal helper): a local miss with eBird off
+// returns 200 with metadata.source="unresolved" and no taxonomy block, and a nil
+// embedded database returns 500 (#4105).
+func TestGetSpeciesTaxonomyHandlerContract(t *testing.T) {
+	t.Parallel()
+
+	taxonomyDB, err := classifier.LoadTaxonomyDatabase()
+	require.NoError(t, err, "Failed to load taxonomy database")
+
+	t.Run("local miss with eBird off returns 200 unresolved", func(t *testing.T) {
+		t.Parallel()
+		c := &Handler{Core: &apicore.Core{TaxonomyDB: taxonomyDB}}
+		c.Settings.Store(apitest.NewValidTestSettings())
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet,
+			"/api/v2/species/taxonomy?scientific_name="+url.QueryEscape("Zzyzxus fictus"), http.NoBody)
+		rec := httptest.NewRecorder()
+		echoCtx := e.NewContext(req, rec)
+
+		require.NoError(t, c.GetSpeciesTaxonomy(echoCtx))
+		assert.Equal(t, http.StatusOK, rec.Code, "a local miss must be a graceful 200, not an error")
+
+		var resp map[string]any
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		meta, ok := resp["metadata"].(map[string]any)
+		require.True(t, ok, "metadata must be present")
+		assert.Equal(t, taxonomySourceUnresolved, meta["source"])
+		_, hasTaxonomy := resp["taxonomy"]
+		assert.False(t, hasTaxonomy, "no taxonomy block for an unresolved species")
+	})
+
+	t.Run("nil DB returns 500", func(t *testing.T) {
+		t.Parallel()
+		c := &Handler{Core: &apicore.Core{TaxonomyDB: nil}}
+		c.Settings.Store(apitest.NewValidTestSettings())
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet,
+			"/api/v2/species/taxonomy?scientific_name="+url.QueryEscape("Turdus migratorius"), http.NoBody)
+		rec := httptest.NewRecorder()
+		echoCtx := e.NewContext(req, rec)
+
+		err := c.GetSpeciesTaxonomy(echoCtx)
+		apitest.AssertControllerError(t, err, rec, http.StatusInternalServerError, "Failed to get taxonomy information")
+	})
 }

--- a/internal/api/v2/species/taxonomy_test.go
+++ b/internal/api/v2/species/taxonomy_test.go
@@ -494,7 +494,25 @@ func TestGetSpeciesTaxonomyEBirdFallback(t *testing.T) {
 		require.NoError(t, err, "an eBird not-found must degrade, not propagate")
 		require.NotNil(t, info)
 		assert.Equal(t, taxonomySourceUnresolved, info.Metadata["source"])
+		assert.Equal(t, taxonomyUnresolvedNoteEBirdOn, info.Metadata["note"],
+			"the note must not tell an eBird-configured user to configure eBird")
 		assert.Equal(t, TaxonomyHierarchy{}, info.Taxonomy)
+	})
+
+	t.Run("eBird hit honors include_hierarchy=false", func(t *testing.T) {
+		t.Parallel()
+		c := newHandler(t, func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"sciName":"Zzyzxus fictus","comName":"Fake Species","speciesCode":"fake1","category":"species","order":"Testiformes","familySciName":"Testidae","familyComName":"Test Family"}]`))
+		})
+		info, err := c.getDetailedTaxonomy(t.Context(), missName, "", false, false)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		assert.Equal(t, "ebird", info.Metadata["source"], "still an eBird-sourced result")
+		assert.Equal(t, TaxonomyHierarchy{}, info.Taxonomy,
+			"the hierarchy must be omitted when include_hierarchy is false")
+		assert.Equal(t, "fake1", info.SpeciesCode,
+			"clearing the hierarchy must preserve sibling fields such as the species code")
 	})
 
 	t.Run("genuine eBird error propagates", func(t *testing.T) {


### PR DESCRIPTION
## Summary

`GET /api/v2/species/taxonomy` returned HTTP 500 with a misleading "no local database or eBird API" message whenever a species was absent from the embedded genus/family taxonomy and eBird was not configured. The genus/family taxonomy is compiled into the binary via `go:embed` and is essentially always present, so eBird should be pure enrichment (subspecies, locale common names), never a hard dependency for a basic lookup.

`getDetailedTaxonomy` now resolves in this order:

1. A nil embedded database is treated as a system fault and surfaced first, before the eBird branch, with an accurate message, so a broken binary fails fast (HTTP 500) regardless of eBird configuration instead of being masked by whatever eBird returns.
2. The local database is consulted (offline, authoritative for covered names).
3. On a local miss, eBird is consulted only when configured, and only as enrichment: an eBird not-found degrades to the graceful response below rather than failing the request. This matters because every non-avian label BirdNET-Go can produce (frogs, bats, insects) is absent from eBird, an avian database, so returning 404 there would make eBird a hard dependency for non-birds. Any other eBird failure (network, auth, API) still propagates.
4. Otherwise the endpoint returns HTTP 200 with `metadata.source` set to `unresolved`, rather than a misleading error. It deliberately fabricates no taxonomy hierarchy: the endpoint accepts any string that loosely looks like a binomial, and the label set includes non-organism noise classes such as "Human vocal" and "Power tools", for which any guessed rank (a genus from the first token, or Kingdom "Animalia") would be wrong. A client that renders a fixed rank list then simply omits the absent taxonomy block instead of showing empty rank rows.

## Behavior change

For a species outside the embedded dataset the endpoint now returns HTTP 200 with `metadata.source="unresolved"` (and no `taxonomy` block) instead of HTTP 404/500. Clients that treated a non-2xx response as "unknown species" should check `metadata.source` instead.

## Testing

- Added a test-only eBird client seam (`eBirdClientOverride` on the handler, mirroring the existing `speciesBackendOverride`) so the eBird branches are covered against an `httptest` server: an eBird hit returns full taxonomy, an eBird not-found degrades to `unresolved`, and a genuine eBird error (401) propagates rather than being swallowed.
- Added handler-level tests for the observable contract: a local miss with eBird off returns 200 `unresolved` with no `taxonomy` block, and a nil database returns 500.
- `go test -race ./internal/api/v2/species/...` passes; `golangci-lint` clean.

## Related Issues

Fixes #4105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detailed taxonomy lookups when local data is unavailable or incomplete.
  - Returns a clear unresolved response with the requested scientific name when no match is found.
  - Preserves successful eBird enrichment while reporting appropriate errors for genuine service failures.
  - Local taxonomy data remains authoritative, with eBird used only to supplement results.
  - Respects requests to omit taxonomy hierarchy details when hierarchy inclusion is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->