### PR TITLE
fix(species): prevent duplicate new-species notifications after seven days

### DIFF
--- a/internal/analysis/processor/notification_timing_test.go
+++ b/internal/analysis/processor/notification_timing_test.go
@@ -144,12 +144,14 @@ func TestNotificationTiming_BeginTimeUsed(t *testing.T) {
 	require.NotNil(t, tracker)
 	require.NoError(t, tracker.InitFromDatabase())
 
-	// Create a Result with BeginTime set to a specific time
-	// This simulates the detection time being different from processing time
-	beginTime := time.Date(2025, 6, 15, 14, 30, 0, 0, time.UTC)
+	// A later, higher-confidence result can replace the pending detection while
+	// BeginTime stays at the recording's start. Keep the timestamps distinct so
+	// a switch to Result.Timestamp cannot silently move tracking into the next year.
+	beginTime := time.Date(time.Now().Year(), 12, 31, 23, 55, 0, 0, time.UTC)
+	savedTime := beginTime.Add(10 * time.Minute)
 
 	testResult := detection.Result{
-		Timestamp: beginTime,
+		Timestamp: savedTime,
 		BeginTime: beginTime,
 		Species: detection.Species{
 			CommonName:     "Great Tit",
@@ -197,6 +199,11 @@ func TestNotificationTiming_BeginTimeUsed(t *testing.T) {
 	// The species should have been recorded as first seen at BeginTime
 	assert.True(t, status.IsNew, "Species should be marked as new based on BeginTime")
 	assert.Equal(t, 0, status.DaysSinceFirst, "DaysSinceFirst should be 0 for a new detection")
+	assert.True(t, status.FirstSeenTime.Equal(beginTime), "first-seen must use the recording start")
+	require.NotNil(t, status.FirstThisYear, "the detection belongs to the recording's year")
+	assert.True(t, status.FirstThisYear.Equal(beginTime), "yearly tracking must use the recording start")
+	_, notificationTime := action.shouldSuppressNewSpeciesNotification()
+	assert.True(t, notificationTime.Equal(beginTime), "suppression must use the same recording time")
 
 	t.Logf("Species status: IsNew=%v, DaysSinceFirst=%d, IsNewThisYear=%v",
 		status.IsNew, status.DaysSinceFirst, status.IsNewThisYear)

--- a/internal/analysis/processor/notification_window_test.go
+++ b/internal/analysis/processor/notification_window_test.go
@@ -1,0 +1,110 @@
+package processor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/analysis/species"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+)
+
+// TestDatabaseAction_NewSpeciesWindow covers #4013 through the real save and
+// event-publishing path, including a reload of historical data from SQLite.
+func TestDatabaseAction_NewSpeciesWindow(t *testing.T) {
+	location, err := time.LoadLocation("Europe/Amsterdam")
+	require.NoError(t, err)
+
+	reference := time.Now().In(location).AddDate(0, 0, -7)
+	tests := []struct {
+		name  string
+		first time.Time
+	}{
+		{"audio_crosses_midnight", time.Date(reference.Year(), reference.Month(), reference.Day(), 23, 59, 50, 0, location)},
+		{"midnight", time.Date(2025, 9, 5, 0, 0, 0, 0, location)},
+		{"morning", time.Date(2025, 9, 5, 7, 3, 0, 0, location)},
+		{"late_evening", time.Date(2025, 9, 5, 23, 59, 0, 0, location)},
+		{"spring_clock_change", time.Date(2025, 3, 24, 0, 30, 0, 0, location)},
+		// After the autumn clock change, 168 elapsed hours can still fall on
+		// calendar day 6. Merely replacing <= with < does not fix that case.
+		{"autumn_clock_change", time.Date(2025, 10, 20, 0, 30, 0, 0, location)},
+	}
+	for _, tt := range tests {
+		for _, restart := range []bool{false, true} {
+			name := tt.name + "/running"
+			if restart {
+				name = tt.name + "/restarted"
+			}
+			t.Run(name, func(t *testing.T) {
+				// The event bus is global, so these subtests must run sequentially.
+				consumer := setupEventBusWithConsumer(t)
+				ds := setupIntegrationTestDB(t)
+				sqlDB, err := ds.DB.DB()
+				require.NoError(t, err)
+				sqlDB.SetMaxOpenConns(1)
+				t.Cleanup(func() { assert.NoError(t, sqlDB.Close()) })
+				require.NoError(t, ds.DB.AutoMigrate(&datastore.NotificationHistory{}))
+
+				settings := &conf.SpeciesTrackingSettings{
+					Enabled:                      true,
+					NewSpeciesWindowDays:         conf.DefaultNewSpeciesWindowDays,
+					NotificationSuppressionHours: conf.DefaultNotificationSuppressionHours,
+				}
+				tracker := species.NewTrackerFromSettings(ds, settings)
+				t.Cleanup(func() { assert.NoError(t, tracker.Close()) })
+				det := testDetectionWithSpecies("Great Tit", "Parus major", 0.95)
+				store := &datastore.SQLiteStore{}
+				store.DB = ds.DB
+				action := &DatabaseAction{
+					Settings:          &conf.Settings{},
+					Repo:              datastore.NewDetectionRepository(store, location),
+					Result:            det.Result,
+					EventTracker:      NewEventTracker(0),
+					NewSpeciesTracker: tracker,
+				}
+				action.Result.Timestamp = tt.first.Add(15 * time.Second)
+				action.Result.BeginTime = tt.first
+				action.Result.EndTime = tt.first.Add(15 * time.Second)
+				require.NoError(t, action.Execute(t.Context(), nil))
+				// Wait for notification history persistence before reading/reloading it.
+				require.NoError(t, tracker.Close())
+				history, err := ds.GetNotificationHistory(t.Context(), "Parus major", "new_species")
+				require.NoError(t, err)
+				require.True(t, history.LastSent.Equal(tt.first))
+
+				if restart {
+					tracker = species.NewTrackerFromSettings(ds, settings)
+					require.NoError(t, tracker.InitFromDatabase())
+					action.NewSpeciesTracker = tracker
+				}
+
+				repeat := tt.first.Add(time.Duration(conf.DefaultNotificationSuppressionHours) * time.Hour)
+				action.Result.Timestamp = repeat.Add(15 * time.Second)
+				action.Result.BeginTime = repeat
+				action.Result.EndTime = repeat.Add(15 * time.Second)
+				require.NoError(t, action.Execute(t.Context(), nil))
+				require.NoError(t, tracker.Close())
+
+				require.Eventually(t, func() bool {
+					return len(consumer.GetReceivedEvents()) == 2
+				}, 2*time.Second, 10*time.Millisecond)
+				received := consumer.GetReceivedEvents()
+				assert.True(t, received[0].IsNewSpecies(), "first detection must still notify")
+				assert.False(t, received[1].IsNewSpecies(), "expired suppression must not produce a second new-species event")
+				assert.Equal(t, "Parus major", received[1].GetScientificName())
+
+				var count int64
+				require.NoError(t, ds.DB.Model(&datastore.Note{}).Count(&count).Error)
+				assert.Equal(t, int64(2), count, "ordinary detections must still be saved")
+				history, err = ds.GetNotificationHistory(t.Context(), "Parus major", "new_species")
+				require.NoError(t, err)
+				assert.True(t, history.LastSent.Equal(tt.first), "duplicate must not overwrite notification history")
+
+				status := tracker.GetSpeciesStatus("Parus major", repeat)
+				assert.True(t, status.IsNew, "the calendar-day badge window is independent of notification eligibility")
+			})
+		}
+	}
+}

--- a/internal/analysis/processor/notification_window_test.go
+++ b/internal/analysis/processor/notification_window_test.go
@@ -23,6 +23,8 @@ func TestDatabaseAction_NewSpeciesWindow(t *testing.T) {
 		first time.Time
 	}{
 		{"audio_crosses_midnight", time.Date(reference.Year(), reference.Month(), reference.Day(), 23, 59, 50, 0, location)},
+		// These historical cases fall outside the notification-history lookback;
+		// after reload, eligibility must stop duplicates without relying on suppression.
 		{"midnight", time.Date(2025, 9, 5, 0, 0, 0, 0, location)},
 		{"morning", time.Date(2025, 9, 5, 7, 3, 0, 0, location)},
 		{"late_evening", time.Date(2025, 9, 5, 23, 59, 0, 0, location)},

--- a/internal/analysis/species/README.md
+++ b/internal/analysis/species/README.md
@@ -177,6 +177,15 @@ CleanupOldNotificationRecords(currentTime time.Time) int
 
 **BG-17 Fix**: Notification suppression state is now persisted to the database via the `notification_histories` table. This prevents duplicate "new species" notifications after application restarts. The state is automatically loaded during `InitFromDatabase()` and saved asynchronously when notifications are sent.
 
+New-species notification eligibility uses an exclusive elapsed-time window of
+`NewSpeciesWindowDays × 24 hours`, starting at local midnight on the first detection
+day. Historical loads also check the stored audio start, so a recording that
+crosses midnight retains its original day after a reload. Unlike the inclusive
+calendar-day badge window, it cannot outlast an equally long notification
+suppression interval (#4013). Shorter suppression
+intervals and disabled suppression keep their configured behavior within this
+notification window.
+
 ### Maintenance
 
 ```go

--- a/internal/analysis/species/database.go
+++ b/internal/analysis/species/database.go
@@ -139,6 +139,7 @@ func (t *SpeciesTracker) loadLifetimeDataFromDatabase(ctx context.Context, now t
 	case len(newSpeciesData) > 0:
 		// Clear and populate lifetime tracking map with new data
 		t.speciesFirstSeen = make(map[string]time.Time, len(newSpeciesData))
+		t.speciesFirstAudioDate = make(map[string]time.Time)
 		t.speciesLastSeen = make(map[string]time.Time, len(newSpeciesData))
 		for _, species := range newSpeciesData {
 			// Canonicalize so a detection later arriving under the canonical name
@@ -153,6 +154,16 @@ func (t *SpeciesTracker) loadLifetimeDataFromDatabase(ctx context.Context, now t
 						logger.String("date", species.FirstSeenDate),
 						logger.Error(err))
 					continue
+				}
+				// A recording can start before midnight and be saved with the next
+				// day's date. Restore its audio date for notification deadlines while
+				// preserving the saved date used by badges and novelty reconstruction.
+				if !species.FirstBeginTime.IsZero() {
+					year, month, day := species.FirstBeginTime.Date()
+					audioDate := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+					if audioDate.Before(firstSeen) {
+						keepEarliest(t.speciesFirstAudioDate, key, audioDate)
+					}
 				}
 				// Keep the earliest first-seen and latest last-seen when aliases collapse.
 				keepEarliest(t.speciesFirstSeen, key, firstSeen)
@@ -175,6 +186,7 @@ func (t *SpeciesTracker) loadLifetimeDataFromDatabase(ctx context.Context, now t
 	case len(t.speciesFirstSeen) == 0:
 		// No data from database and no existing data - initialize empty map
 		t.speciesFirstSeen = make(map[string]time.Time, initialSpeciesCapacity)
+		t.speciesFirstAudioDate = nil
 		t.speciesLastSeen = make(map[string]time.Time, initialSpeciesCapacity)
 		getLog().Debug("No species data from database, initialized empty tracking")
 	default:

--- a/internal/analysis/species/maintenance.go
+++ b/internal/analysis/species/maintenance.go
@@ -96,6 +96,7 @@ func (t *SpeciesTracker) pruneLifetimeEntriesLocked(now time.Time) int {
 	for scientificName, firstSeen := range t.speciesFirstSeen {
 		if dateOnlyBefore(firstSeen, lifetimeCutoff) {
 			delete(t.speciesFirstSeen, scientificName)
+			delete(t.speciesFirstAudioDate, scientificName)
 			pruned++
 		}
 	}

--- a/internal/analysis/species/notification_suppression_test.go
+++ b/internal/analysis/species/notification_suppression_test.go
@@ -156,3 +156,41 @@ func TestNotificationSuppressionThreadSafety(t *testing.T) {
 	assert.True(t, tracker.ShouldSuppressNotification("Species2", now.Add(1*time.Hour)),
 		"Species2 should be suppressed after recording")
 }
+
+func TestNotificationWindowPreservesConfiguredSuppression(t *testing.T) {
+	t.Parallel()
+	first := time.Date(2025, 6, 1, 10, 0, 0, 0, time.UTC)
+	untilWindowEnd := time.Date(2025, 6, 8, 0, 0, 0, 0, time.UTC).Sub(first)
+	const scientificName = "Parus major"
+	tests := []struct {
+		name             string
+		windowDays       int
+		suppressionHours int
+		repeatAfter      time.Duration
+		wantNotification bool
+	}{
+		{"short_interval_active", 7, 1, 30 * time.Minute, false},
+		{"short_interval_expired", 7, 1, time.Hour, true},
+		{"suppression_disabled", 7, 0, time.Minute, true},
+		{"longer_new_species_window", 14, 168, 168 * time.Hour, true},
+		{"before_window_end", 7, 0, untilWindowEnd - time.Nanosecond, true},
+		{"at_window_end", 7, 0, untilWindowEnd, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tracker := NewTrackerFromSettings(nil, &conf.SpeciesTrackingSettings{
+				NewSpeciesWindowDays:         tt.windowDays,
+				NotificationSuppressionHours: tt.suppressionHours,
+			})
+			isNew, _ := tracker.CheckAndUpdateSpecies(scientificName, first)
+			require.True(t, isNew)
+			tracker.RecordNotificationSent(scientificName, first)
+
+			repeat := first.Add(tt.repeatAfter)
+			isNew, _ = tracker.CheckAndUpdateSpecies(scientificName, repeat)
+			notify := isNew && !tracker.ShouldSuppressNotification(scientificName, repeat)
+			assert.Equal(t, tt.wantNotification, notify)
+		})
+	}
+}

--- a/internal/analysis/species/species_tracker.go
+++ b/internal/analysis/species/species_tracker.go
@@ -156,8 +156,10 @@ type SpeciesTracker struct {
 
 	// Lifetime tracking (existing)
 	speciesFirstSeen map[string]time.Time // scientificName -> first detection time
-	speciesLastSeen  map[string]time.Time // scientificName -> most recent detection time
-	windowDays       int                  // Days to consider a species "new"
+	// Earlier audio dates restored from storage, used only for notification deadlines.
+	speciesFirstAudioDate map[string]time.Time
+	speciesLastSeen       map[string]time.Time // scientificName -> most recent detection time
+	windowDays            int                  // Days to consider a species "new"
 
 	// Novelty episode tracking
 	noveltyEpisodes map[string]NoveltyStatus // scientificName -> active novelty episode

--- a/internal/analysis/species/species_tracker_helper_functions_test.go
+++ b/internal/analysis/species/species_tracker_helper_functions_test.go
@@ -67,7 +67,7 @@ func TestCheckAndUpdateLifetimeLocked_EdgeCases(t *testing.T) {
 			windowDays:            7,
 			existingFirstSeen:     new(time.Date(2025, 6, 1, 10, 0, 0, 0, time.UTC)),
 			detectionTime:         time.Date(2025, 6, 8, 10, 0, 0, 0, time.UTC), // exactly 7 days
-			expectedIsNew:         true,                                         // daysSince == windowDays is still "new"
+			expectedIsNew:         false,                                        // The notification window has expired
 			expectedDaysSince:     7,
 			expectedFirstSeenTime: time.Date(2025, 6, 1, 10, 0, 0, 0, time.UTC),
 		},
@@ -103,7 +103,7 @@ func TestCheckAndUpdateLifetimeLocked_EdgeCases(t *testing.T) {
 			windowDays:            0,
 			existingFirstSeen:     new(time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)),
 			detectionTime:         time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC),
-			expectedIsNew:         true, // daysSince 0 <= windowDays 0
+			expectedIsNew:         false, // A zero-length notification window has expired
 			expectedDaysSince:     0,
 			expectedFirstSeenTime: time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC),
 		},

--- a/internal/analysis/species/species_tracker_init_test.go
+++ b/internal/analysis/species/species_tracker_init_test.go
@@ -274,9 +274,9 @@ func TestCheckAndUpdateSpecies_CriticalReliability(t *testing.T) {
 			func(tracker *SpeciesTracker, now time.Time) {
 				tracker.speciesFirstSeen["Boundary_Species"] = now.AddDate(0, 0, -14) // Exactly 14 days
 			},
-			true, // Exactly at boundary is still "new"
+			false, // The notification window has expired
 			14,
-			"Species exactly at window boundary should still be new",
+			"Species exactly at window boundary should no longer trigger new-species notifications",
 		},
 		{
 			"yearly_tracking_update",

--- a/internal/analysis/species/update.go
+++ b/internal/analysis/species/update.go
@@ -207,7 +207,18 @@ func (t *SpeciesTracker) checkAndUpdateLifetimeLocked(scientificName string, det
 
 	// Calculate calendar days since first seen (DST-safe, clamped to 0)
 	daysSince := calculateDaysSince(detectionTime, firstSeen)
-	return daysSince <= t.windowDays, daysSince
+	if audioDate, ok := t.speciesFirstAudioDate[scientificName]; ok && audioDate.Before(firstSeen) {
+		firstSeen = audioDate
+	}
+	// Notification eligibility must expire before an equally long suppression
+	// interval does (#4013). The inclusive calendar-day window used for badges
+	// can outlast that interval, especially across a daylight-saving transition.
+	// Anchor to the first audio day's local midnight: historical loads retain
+	// that calendar date (parsed in UTC), keeping the deadline stable on reload.
+	year, month, day := firstSeen.Date()
+	start := time.Date(year, month, day, 0, 0, 0, 0, detectionTime.Location())
+	window := time.Duration(t.windowDays) * hoursPerDay * time.Hour
+	return detectionTime.Before(start.Add(window)), daysSince
 }
 
 // addYearlyIfNewLocked adds species to yearly tracking if not already present. Assumes lock is held.
@@ -237,14 +248,15 @@ func (t *SpeciesTracker) addSeasonalIfNewLocked(scientificName string, detection
 // CheckAndUpdateSpecies atomically checks if a species is new and updates the tracker
 // This prevents race conditions where multiple concurrent detections of the same species
 // could all be considered "new" before any of them update the tracker.
-// Returns (isNew, daysSinceFirstSeen)
+// Returns (eligible for a new-species notification, calendar days since first seen).
+// Badge visibility uses the separate calendar-day window in GetSpeciesStatus.
 func (t *SpeciesTracker) CheckAndUpdateSpecies(scientificName string, detectionTime time.Time) (isNew bool, daysSinceFirstSeen int) {
 	isNew, daysSinceFirstSeen, _ = t.CheckAndUpdateSpeciesWithNovelty(scientificName, detectionTime)
 	return
 }
 
-// CheckAndUpdateSpeciesWithNovelty atomically checks species status, updates
-// tracking, and returns novelty episode details for alert rules.
+// CheckAndUpdateSpeciesWithNovelty atomically checks new-species notification
+// eligibility, updates tracking, and returns novelty episode details for alert rules.
 func (t *SpeciesTracker) CheckAndUpdateSpeciesWithNovelty(scientificName string, detectionTime time.Time) (isNew bool, daysSinceFirstSeen int, novelty NoveltyStatus) {
 	// While warming, suppress new-species/novelty and skip recording so the empty
 	// maps cannot produce a spurious first-detection. Checked before t.mu so it

--- a/internal/analysis/species/update.go
+++ b/internal/analysis/species/update.go
@@ -168,7 +168,8 @@ func (t *SpeciesTracker) UpdateSpecies(scientificName string, detectionTime time
 	return isNewSpecies
 }
 
-// IsNewSpecies checks if a species is considered "new" within the configured window
+// IsNewSpecies checks the inclusive calendar-day badge window, like GetSpeciesStatus.
+// Notification eligibility uses the separate elapsed-time window in CheckAndUpdateSpecies.
 func (t *SpeciesTracker) IsNewSpecies(scientificName string) bool {
 	// Suppress while warming: the maps are empty mid-load, so an unguarded check
 	// would report every species as never-seen-before.

--- a/internal/datastore/analytics.go
+++ b/internal/datastore/analytics.go
@@ -189,11 +189,12 @@ type SpeciesHourlyCounts struct {
 
 // NewSpeciesData represents a species detected for the first time within a period
 type NewSpeciesData struct {
-	ScientificName string `json:"scientific_name"`
-	CommonName     string `json:"common_name"`
-	FirstSeenDate  string `json:"first_seen_date"` // The absolute first date
-	LastSeenDate   string `json:"last_seen_date"`  // The most recent detection date
-	CountInPeriod  int    `json:"count_in_period"` // Optional: How many times seen in the query period
+	ScientificName string    `json:"scientific_name"`
+	CommonName     string    `json:"common_name"`
+	FirstSeenDate  string    `json:"first_seen_date"` // The absolute first date
+	LastSeenDate   string    `json:"last_seen_date"`  // The most recent detection date
+	CountInPeriod  int       `json:"count_in_period"` // Optional: How many times seen in the query period
+	FirstBeginTime time.Time `json:"-"`               // Earliest audio start, used to restore notification tracking across midnight
 }
 
 // SpeciesDetectionDate represents a species detected on a specific calendar date.
@@ -1038,6 +1039,7 @@ func (ds *DataStore) GetNewSpeciesDetections(ctx context.Context, startDate, end
 		FirstDetectionDate string // Scan directly into string
 		LastDetectionDate  string
 		CountInPeriod      int
+		FirstBeginTime     time.Time
 	}
 	var rawResults []RawNewSpeciesResult
 
@@ -1061,12 +1063,16 @@ func (ds *DataStore) GetNewSpeciesDetections(ctx context.Context, startDate, end
 	// Revised query with pagination
 	// NOTE: This query benefits significantly from a composite index on (scientific_name, date)
 	// Excludes detections marked as false_positive from both CTEs
+	// Select the audio timestamp from the original column so SQLite preserves its
+	// DATETIME type when scanning. MIN alone returns text. NULLIF ignores imports
+	// without an audio start; MIN(id) prevents ties from duplicating species rows.
 	query := fmt.Sprintf(`
 	WITH SpeciesFirstSeen AS (
 	    SELECT
 	        notes.scientific_name,
 	        MIN(CASE WHEN notes.date != '' AND notes.date IS NOT NULL THEN notes.date ELSE NULL END) as first_detection_date,
-	        MAX(CASE WHEN notes.date != '' AND notes.date IS NOT NULL THEN notes.date ELSE NULL END) as last_detection_date
+	        MAX(CASE WHEN notes.date != '' AND notes.date IS NOT NULL THEN notes.date ELSE NULL END) as last_detection_date,
+	        MIN(NULLIF(notes.begin_time, ?)) as first_begin_time
 	    FROM notes
 	    LEFT JOIN note_reviews ON notes.id = note_reviews.note_id
 	    WHERE (note_reviews.verified IS NULL OR note_reviews.verified != '%s')
@@ -1089,16 +1095,21 @@ func (ds *DataStore) GetNewSpeciesDetections(ctx context.Context, startDate, end
 	    COALESCE(sip.common_name, sfs.scientific_name) as common_name,
 	    sfs.first_detection_date,
 	    sfs.last_detection_date,
-	    sip.count_in_period
+	    sip.count_in_period,
+	    first_note.begin_time as first_begin_time
 	FROM SpeciesFirstSeen sfs
 	JOIN SpeciesInPeriod sip ON sfs.scientific_name = sip.scientific_name
+	LEFT JOIN notes first_note ON first_note.id = (
+	    SELECT MIN(n.id) FROM notes n
+	    WHERE n.scientific_name = sfs.scientific_name AND n.begin_time = sfs.first_begin_time
+	)
 	WHERE sfs.first_detection_date BETWEEN ? AND ?
 	ORDER BY sfs.first_detection_date DESC
 	LIMIT ? OFFSET ?;
 	`, entities.VerificationFalsePositive, entities.VerificationFalsePositive)
 
 	// Execute the raw SQL query into the temporary struct
-	if err := ds.DB.WithContext(ctx).Raw(query, startDate, endDate, startDate, endDate, limit, offset).Scan(&rawResults).Error; err != nil {
+	if err := ds.DB.WithContext(ctx).Raw(query, time.Time{}, startDate, endDate, startDate, endDate, limit, offset).Scan(&rawResults).Error; err != nil {
 		return nil, errors.New(err).
 			Component("datastore").
 			Category(errors.CategoryDatabase).
@@ -1121,6 +1132,7 @@ func (ds *DataStore) GetNewSpeciesDetections(ctx context.Context, startDate, end
 				FirstSeenDate:  raw.FirstDetectionDate, // Assign only if valid
 				LastSeenDate:   raw.LastDetectionDate,
 				CountInPeriod:  raw.CountInPeriod,
+				FirstBeginTime: raw.FirstBeginTime,
 			})
 		} else {
 			// Log if a record surprisingly had an empty date after SQL filtering

--- a/internal/datastore/analytics_test.go
+++ b/internal/datastore/analytics_test.go
@@ -19,6 +19,9 @@ func setupTestDB(t *testing.T) *DataStore {
 	// Create in-memory SQLite database
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, sqlDB.Close()) })
 
 	// Create the notes and note_reviews table schemas
 	// note_reviews is now required for analytics queries that filter out false positives
@@ -26,6 +29,37 @@ func setupTestDB(t *testing.T) *DataStore {
 	require.NoError(t, err)
 
 	return &DataStore{DB: db}
+}
+
+func TestGetNewSpeciesDetections_AudioStart(t *testing.T) {
+	ds := setupTestDB(t)
+	location, err := time.LoadLocation("Europe/Amsterdam")
+	require.NoError(t, err)
+	first := time.Date(2026, 9, 5, 23, 59, 50, 0, location)
+	notes := []Note{
+		{ScientificName: "Parus major", Date: "2026-09-06", Time: "00:00:05", BeginTime: first},
+		// Equal audio timestamps must not duplicate a species in the query result.
+		{ScientificName: "Parus major", Date: "2026-09-06", Time: "00:00:06", BeginTime: first},
+		{ScientificName: "Parus major", Date: "2026-09-01", Time: "12:00:00", BeginTime: first.AddDate(0, 0, -4)},
+		// Older imports may have no audio timestamp.
+		{ScientificName: "Turdus merula", Date: "2026-09-06", Time: "12:00:00"},
+		{ScientificName: "Parus major", Date: "2026-09-06", Time: "12:00:00"},
+	}
+	require.NoError(t, ds.DB.Create(&notes).Error)
+	require.NoError(t, ds.DB.Create(&NoteReview{NoteID: notes[2].ID, Verified: "false_positive"}).Error)
+	got, err := ds.GetNewSpeciesDetections(t.Context(), "2026-09-01", "2026-09-30", 100, 0)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	for _, record := range got {
+		assert.Equal(t, "2026-09-06", record.FirstSeenDate, "analytics dates still use the saved detection date")
+		if record.ScientificName == "Parus major" {
+			assert.True(t, first.Equal(record.FirstBeginTime), "restore the earliest non-false-positive audio start")
+			assert.Equal(t, "2026-09-05", record.FirstBeginTime.Format(time.DateOnly), "preserve the audio's local date")
+			assert.Equal(t, 3, record.CountInPeriod)
+		} else {
+			assert.True(t, record.FirstBeginTime.IsZero())
+		}
+	}
 }
 
 // seedTestData adds test data to the database

--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -1726,6 +1726,7 @@ func (r *detectionRepository) GetNewSpecies(ctx context.Context, start, end int6
 	// count_in_period is a correlated subquery evaluated once per reported species (a handful per
 	// window, each an index lookup by label and time), joined on scientific_name so it counts the
 	// species across every model's label, not just the label of the first detection.
+	const noBeginTimeMillis int64 = 0
 	fpFilter := string(entities.VerificationFalsePositive)
 	rawSQL := fmt.Sprintf(`
 		SELECT
@@ -1750,7 +1751,7 @@ func (r *detectionRepository) GetNewSpecies(ctx context.Context, start, end int6
 				l2.scientific_name,
 				MIN(d2.detected_at) as lifetime_first,
 				MAX(d2.detected_at) as lifetime_last,
-				MIN(d2.begin_time) as first_begin_time
+				MIN(NULLIF(d2.begin_time, ?)) as first_begin_time
 			FROM %s d2
 			JOIN %s l2 ON l2.id = d2.label_id
 			LEFT JOIN %s dr2 ON dr2.detection_id = d2.id
@@ -1769,7 +1770,7 @@ func (r *detectionRepository) GetNewSpecies(ctx context.Context, start, end int6
 
 	// Placeholders in text order: the count_in_period subquery in the SELECT list, then the
 	// species_first derived table, then the outer WHERE, then LIMIT/OFFSET.
-	err := r.db.WithContext(ctx).Raw(rawSQL, start, end, fpFilter, fpFilter, start, end, fpFilter, limit, offset).Scan(&results).Error
+	err := r.db.WithContext(ctx).Raw(rawSQL, start, end, fpFilter, noBeginTimeMillis, fpFilter, start, end, fpFilter, limit, offset).Scan(&results).Error
 	return results, err
 }
 

--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -1733,6 +1733,7 @@ func (r *detectionRepository) GetNewSpecies(ctx context.Context, start, end int6
 			species_first.scientific_name,
 			species_first.lifetime_first as first_detected,
 			species_first.lifetime_last as last_detected,
+			species_first.first_begin_time,
 			MIN(d.id) as detection_id,
 			MAX(d.confidence) as confidence,
 			(
@@ -1748,7 +1749,8 @@ func (r *detectionRepository) GetNewSpecies(ctx context.Context, start, end int6
 			SELECT
 				l2.scientific_name,
 				MIN(d2.detected_at) as lifetime_first,
-				MAX(d2.detected_at) as lifetime_last
+				MAX(d2.detected_at) as lifetime_last,
+				MIN(d2.begin_time) as first_begin_time
 			FROM %s d2
 			JOIN %s l2 ON l2.id = d2.label_id
 			LEFT JOIN %s dr2 ON dr2.detection_id = d2.id
@@ -1760,7 +1762,7 @@ func (r *detectionRepository) GetNewSpecies(ctx context.Context, start, end int6
 		JOIN %s d ON d.label_id = l.id AND d.detected_at = species_first.lifetime_first
 		LEFT JOIN %s dr ON dr.detection_id = d.id
 		WHERE (dr.verified IS NULL OR dr.verified != ?)
-		GROUP BY species_first.scientific_name, species_first.lifetime_first, species_first.lifetime_last
+		GROUP BY species_first.scientific_name, species_first.lifetime_first, species_first.lifetime_last, species_first.first_begin_time
 		ORDER BY first_detected DESC
 		LIMIT ? OFFSET ?
 	`, r.tableName(), r.labelsTable(), r.reviewsTable(), r.tableName(), r.labelsTable(), r.reviewsTable(), r.labelsTable(), r.tableName(), r.reviewsTable())

--- a/internal/datastore/v2/repository/types.go
+++ b/internal/datastore/v2/repository/types.go
@@ -254,6 +254,9 @@ type NewSpeciesData struct {
 	// FirstDetected is the Unix timestamp of the very first detection.
 	FirstDetected int64
 
+	// FirstBeginTime is the earliest audio start in Unix milliseconds, when available.
+	FirstBeginTime int64
+
 	// CountInPeriod is how many non-false-positive detections of the species fall inside the
 	// queried [start, end) window, across every model's label for it.
 	CountInPeriod int

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -2973,6 +2973,7 @@ type speciesFirstSeenInfo struct {
 	FirstDetected  int64
 	LastDetected   int64
 	CountInPeriod  int // detections inside the queried window; only the lifetime-first query fills it
+	FirstBeginTime int64
 }
 
 // convertToNewSpeciesData converts species first-seen data to NewSpeciesData with common name resolution.
@@ -3000,12 +3001,17 @@ func (ds *Datastore) convertToNewSpeciesData(_ context.Context, data []speciesFi
 		if d.LastDetected > 0 {
 			lastSeenDate = time.Unix(d.LastDetected, 0).In(ds.timezone).Format(time.DateOnly)
 		}
+		var firstBeginTime time.Time
+		if d.FirstBeginTime > 0 {
+			firstBeginTime = time.UnixMilli(d.FirstBeginTime).In(ds.timezone)
+		}
 		result = append(result, datastore.NewSpeciesData{
 			ScientificName: sciName,
 			CommonName:     commonName,
 			FirstSeenDate:  firstSeenDate,
 			LastSeenDate:   lastSeenDate,
 			CountInPeriod:  d.CountInPeriod,
+			FirstBeginTime: firstBeginTime,
 		})
 	}
 	return result
@@ -3032,6 +3038,7 @@ func (ds *Datastore) GetNewSpeciesDetections(ctx context.Context, startDate, end
 			FirstDetected:  d.FirstDetected,
 			LastDetected:   d.LastDetected,
 			CountInPeriod:  d.CountInPeriod,
+			FirstBeginTime: d.FirstBeginTime,
 		}
 	}
 

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	speciestracker "github.com/tphakala/birdnet-go/internal/analysis/species"
+	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	v2 "github.com/tphakala/birdnet-go/internal/datastore/v2"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
@@ -1926,6 +1928,39 @@ func TestConvertToNewSpeciesData_ZeroEpoch(t *testing.T) {
 	assert.Empty(t, got[0].LastSeenDate)
 	assert.NotEmpty(t, got[1].FirstSeenDate)
 	assert.NotEmpty(t, got[1].LastSeenDate)
+}
+
+func TestV2OnlyDatastore_NewSpeciesWindowAfterMidnightReload(t *testing.T) {
+	ds, cleanup := setupTestDatastore(t)
+	t.Cleanup(cleanup)
+	location, err := time.LoadLocation("Europe/Amsterdam")
+	require.NoError(t, err)
+	ds.timezone = location
+	day := time.Now().In(location).AddDate(0, 0, -7)
+	first := time.Date(day.Year(), day.Month(), day.Day(), 23, 59, 50, 0, location)
+	savedAt := first.Add(15 * time.Second)
+	note := &datastore.Note{
+		ScientificName: "Parus major", Confidence: 0.95,
+		Date: savedAt.Format(time.DateOnly), Time: savedAt.Format(time.TimeOnly),
+		BeginTime: first, EndTime: savedAt,
+	}
+	require.NoError(t, ds.Save(note, nil))
+	got, err := ds.GetNewSpeciesDetections(t.Context(), "1900-01-01", savedAt.Format(time.DateOnly), 100, 0)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, savedAt.Format(time.DateOnly), got[0].FirstSeenDate)
+	assert.True(t, first.Equal(got[0].FirstBeginTime))
+	assert.Equal(t, first.Format(time.DateOnly), got[0].FirstBeginTime.Format(time.DateOnly))
+
+	tracker := speciestracker.NewTrackerFromSettings(ds, &conf.SpeciesTrackingSettings{
+		Enabled: true, NewSpeciesWindowDays: 7, NotificationSuppressionHours: 168,
+	})
+	t.Cleanup(func() { assert.NoError(t, tracker.Close()) })
+	require.NoError(t, tracker.InitFromDatabase())
+	isNew, _, novelty := tracker.CheckAndUpdateSpeciesWithNovelty("Parus major", first.Add(168*time.Hour))
+	assert.False(t, isNew, "reloading must not extend notification eligibility past suppression")
+	assert.True(t, novelty.NoveltyEpisodeActive, "restoring the audio date must preserve the first-ever novelty episode")
+	assert.GreaterOrEqual(t, novelty.NoveltyEpisodeDays, 7, "first-ever metadata must still match novelty alert rules")
 }
 
 // TestV2OnlyDatastore_GetSpeciesDiversityData_TimezoneBucketing verifies the date grouping in

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -1945,6 +1945,14 @@ func TestV2OnlyDatastore_NewSpeciesWindowAfterMidnightReload(t *testing.T) {
 		BeginTime: first, EndTime: savedAt,
 	}
 	require.NoError(t, ds.Save(note, nil))
+	// Reproduce mixed history through the supported Save boundary: an epoch-zero
+	// audio start is persisted as integer zero, not SQL NULL.
+	missing := *note
+	missing.ID = 0
+	missing.Time = savedAt.Add(time.Minute).Format(time.TimeOnly)
+	missing.BeginTime = time.UnixMilli(0)
+	missing.EndTime = time.Time{}
+	require.NoError(t, ds.Save(&missing, nil))
 	got, err := ds.GetNewSpeciesDetections(t.Context(), "1900-01-01", savedAt.Format(time.DateOnly), 100, 0)
 	require.NoError(t, err)
 	require.Len(t, got, 1)


### PR DESCRIPTION
## Description

With the default seven-day new-species window and 168-hour suppression interval,
a species can still be eligible for a notification when suppression expires,
producing a duplicate notification seven days after its first detection.

Expire notification eligibility exclusively after `NewSpeciesWindowDays × 24 hours`
from the first audio day's local midnight. Restore that audio date from existing
legacy and v2 timestamps so recordings crossing midnight retain the same deadline
after restart, including across daylight-saving transitions.

This intentionally shortens notification eligibility compared with the former
inclusive calendar-day window. Badge visibility, novelty metadata, suppression
settings, JSON responses, and database schemas retain their existing behavior.
No database migration is required.

## Related issue

Closes #4013

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/tphakala/birdnet-go/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`go test -race ./...` and/or `npm test`)
- [ ] Linters are clean (`golangci-lint run` and/or `npm run check:all`)
- [x] New exports and user-facing changes are documented

## Validation

- Full Go race suite: all 125 packages passed (`go test -race ./...`) with
  FFmpeg 6.1.6 selected through the test process PATH. An uncached run hit one
  sustained-load timing limit (137 ms versus 100 ms); a fresh rerun of that
  complete performance test passed without changes.
- Frontend: all 2,966 tests in 198 files passed (`npm test -- --run`).
- Full Go lint: zero issues. `npm run check:all` exits successfully, with one
  inherited ESLint warning in the unchanged `ModelRegionSelector.test.ts:29`
  country-name mock (`security/detect-object-injection`). Svelte reports zero
  errors or warnings. The frontend is outside this PR's diff.
- Regression coverage exercises the real processor save/event/reload path,
  suppression boundaries, midnight crossings, spring and autumn clock changes,
  recording-year attribution, badges, and persisted notification history.
- Legacy SQLite query tests cover imported missing/zero timestamps, false
  positives, and tied audio timestamps. The v2 regression verifies
  save/query/tracker reload and preserved first-ever novelty metadata, including
  mixed zero and valid audio timestamps.
- Targeted MySQL 8.0.46 checks passed with the race detector for the legacy query
  under strict SQL mode and the v2 save/query/tracker-reload path. Existing tests
  used temporary Go overlays with the project's MySQL container helpers. Historical
  zero-date fixtures were seeded permissively, then strict mode was restored before
  the production query. This does not claim a full MySQL suite or Pi deployment.

The unchanged FFmpeg package's normalization test fails with local FFmpeg 9.0.1
but passes with FFmpeg 6.1.6. No FFmpeg source change or test suppression is included.

## Preflight Status

All six review passes completed: reuse, correctness, quality, i18n, integration,
and regression/backward compatibility. Independent GPT-5.6 Sol cross-validation
confirmed the regression review. Two test lifecycle findings were fixed by closing
the SQLite fixture and ordering tracker teardown before datastore teardown.

Independent review found no correctness defects. Copilot's latest review on
[the fork PR](https://github.com/sn3p/birdnet-go/pull/3) reports zero new findings
for the same commit. Its earlier MySQL zero-time finding was refuted by the pinned
driver's serialization and actual strict-mode MySQL validation; its thread is resolved.

CodeRabbit identified a valid v2 reload edge case: a zero-millisecond audio
timestamp could mask a valid start in the aggregate. The query now excludes that
sentinel with `NULLIF`; the regression saves mixed history through the real Save
boundary and verifies the restored date and notification deadline. It failed
before the query correction and passes with it. The follow-up repeats all six
preflight review passes, including independent GPT-5.6 Sol cross-validation;
no additional findings remained. The strengthened mixed-zero case also passed
on MySQL 8 with the race detector.

The contributor explicitly approved submitting this PR with the inherited
frontend warning documented as a preflight exception. The test-mock cleanup is
proposed separately in [#4341](https://github.com/tphakala/birdnet-go/pull/4341),
which is open and not yet merged. The warning remains on this branch until that
fix is integrated and the checks rerun. This is not zero-warning certification
or a claim that upstream maintainers have waived their requirements.

- [x] Single concern: one duplicate-notification bug fix
- [x] Contributor-approved submission exception documented above
- [ ] Preflight passed: all certification requirements satisfied
- [ ] Linters clean: Go and frontend checks pass with zero warnings
- [x] Tests pass: full Go race suite and frontend tests
- [x] No unrelated changes
- [x] Scope complete: no TODO/FIXME for core functionality
- [x] No regression/backward-compatibility break beyond the documented notification correction
- [x] Breaking changes documented: intended notification behavior described above
- [x] Maintainer-confirm items resolved: no unresolved behavioral-intent or security-bypass finding
- [x] i18n complete: no new runtime strings
- [x] No secrets or PII in the diff

## Licensing

- [x] My contribution is licensed under **CC BY-NC-SA 4.0**, and I grant the maintainer the right to relicense it under any **OSI-approved open source license**, as described in the [Relicensing Grant](https://github.com/tphakala/birdnet-go/blob/main/CONTRIBUTING.md#relicensing-grant).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected new-species notification timing for recordings that cross midnight or are reloaded from history.
  - Notification eligibility now uses the recording’s start time and an exclusive elapsed-time window, improving behavior around daylight-saving changes and exact boundaries.
  - Preserved configured notification suppression settings, including disabled or shorter suppression periods.
  - Calendar-day “new species” badges remain independent from notification eligibility.
- **Documentation**
  - Clarified the difference between badge visibility and notification timing windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
