### PR TITLE
refactor(classifier,api): dedupe catalog variant-walk; route shutdown-recover warnings to the system logger

### DIFF
--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -2590,7 +2590,10 @@ func (c *Controller) handleSettingsChanges(oldSettings, currentSettings *conf.Se
 func (c *Controller) sendReconfigActions(actions []string, debugEnabled bool) {
 	defer func() {
 		if r := recover(); r != nil {
-			c.LogWarnIfEnabled("Recovered from send on closed controlChan during shutdown",
+			// Use the system logger (c.log), not the access logger (c.LogWarnIfEnabled):
+			// this is a background/shutdown warning with no request context, and c.log()
+			// is never nil, so the warning is not silently dropped when APILogger is unset.
+			c.log().Warn("Recovered from send on closed controlChan during shutdown",
 				logger.Any("panic", r))
 		}
 	}()

--- a/internal/api/v2/system_routes.go
+++ b/internal/api/v2/system_routes.go
@@ -163,7 +163,10 @@ func (c *Controller) scheduleAudioSourceReconfigure() {
 func (c *Controller) sendAudioSourceReconfigure() {
 	defer func() {
 		if r := recover(); r != nil {
-			c.LogWarnIfEnabled("Recovered from send on closed controlChan during audio source reconfigure",
+			// Use the system logger (c.log), not the access logger (c.LogWarnIfEnabled):
+			// this is a controller/shutdown warning, and c.log() is never nil, so the
+			// warning is not silently dropped on a controller whose APILogger is unset.
+			c.log().Warn("Recovered from send on closed controlChan during audio source reconfigure",
 				logger.Any("panic", r))
 		}
 	}()

--- a/internal/api/v2/system_routes_reconfigure_test.go
+++ b/internal/api/v2/system_routes_reconfigure_test.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+)
+
+// TestSendAudioSourceReconfigure_RecoversFromClosedControlChan pins the recover in
+// sendAudioSourceReconfigure. During a shutdown race the analysis layer closes the
+// control channel while the controller still holds a copy of it, so the non-nil
+// guard passes and the send hits a closed channel. That send must be recovered, not
+// allowed to crash the process. A live (non-cancelled) context makes the select pick
+// the send case deterministically rather than the ctx.Done() branch, so the closed
+// channel is exercised on every run.
+func TestSendAudioSourceReconfigure_RecoversFromClosedControlChan(t *testing.T) {
+	closed := make(chan string)
+	close(closed)
+
+	c := &Controller{Core: &apicore.Core{}, controlChan: closed}
+	c.SetTestContext(t.Context(), nil)
+
+	require.NotPanics(t, c.sendAudioSourceReconfigure,
+		"a send on a closed control channel must be recovered, not propagated")
+}
+
+// TestSendAudioSourceReconfigure_NilControlChanReturns confirms the nil-channel guard
+// returns without touching the channel (no send, no panic) when no control channel
+// was injected.
+func TestSendAudioSourceReconfigure_NilControlChanReturns(t *testing.T) {
+	c := &Controller{Core: &apicore.Core{}}
+	c.SetTestContext(t.Context(), nil)
+
+	require.NotPanics(t, c.sendAudioSourceReconfigure,
+		"a nil control channel must return via the guard without panicking")
+}

--- a/internal/classifier/model_path_resolution.go
+++ b/internal/classifier/model_path_resolution.go
@@ -330,14 +330,7 @@ func (o *Orchestrator) resolveSiblingSet(registryID, modelPath string) (set mode
 		if entry.RegistryID != registryID {
 			continue
 		}
-		fileSets := [][]CatalogFile{entry.Files}
-		if len(entry.Variants) > 0 {
-			fileSets = fileSets[:0]
-			for j := range entry.Variants {
-				fileSets = append(fileSets, entry.Variants[j].Files)
-			}
-		}
-		for _, files := range fileSets {
+		for _, files := range entryFileSets(entry) {
 			if !declaresModelFile(files, base) {
 				continue
 			}
@@ -367,6 +360,27 @@ func declaresModelFile(files []CatalogFile, localName string) bool {
 		}
 	}
 	return false
+}
+
+// entryFileSets returns the catalog file sets to probe for entry: each variant's
+// files when the entry declares variants, otherwise the entry's own files.
+//
+// A variant entry's resolved top-level Files name only the DEFAULT variant
+// (resolveVariantDefaults overwrites them, and validateCatalogEntryFiles forbids an
+// entry from declaring both Files and Variants), so a non-default install is found
+// only by probing each variant's own files. For a flat entry the single set is
+// entry.Files. Callers that stop at the first match (isGalleryManagedPath) are
+// unaffected by no longer searching the default variant twice, because the default
+// remains one of the returned variant sets.
+func entryFileSets(entry *CatalogEntry) [][]CatalogFile {
+	if len(entry.Variants) > 0 {
+		sets := make([][]CatalogFile, 0, len(entry.Variants))
+		for j := range entry.Variants {
+			sets = append(sets, entry.Variants[j].Files)
+		}
+		return sets
+	}
+	return [][]CatalogFile{entry.Files}
 }
 
 // isGalleryManagedPath reports whether path looks like a file the model gallery
@@ -436,13 +450,9 @@ func (o *Orchestrator) isGalleryManagedPath(registryID, path string) bool {
 		if entry.RegistryID != registryID {
 			continue
 		}
-		// Check the entry's own files and every variant's files as a union: the
-		// stale configured path could name any installed variant's file.
-		fileSets := [][]CatalogFile{entry.Files}
-		for j := range entry.Variants {
-			fileSets = append(fileSets, entry.Variants[j].Files)
-		}
-		for _, files := range fileSets {
+		// Probe the flat entry's files or each variant's files; see entryFileSets.
+		// The stale configured path could name any installed variant's file.
+		for _, files := range entryFileSets(entry) {
 			for _, f := range files {
 				if f.LocalName != base {
 					continue

--- a/internal/classifier/model_path_resolution_test.go
+++ b/internal/classifier/model_path_resolution_test.go
@@ -485,12 +485,7 @@ func TestApplyPathCorrection_UnreadableNotifiesWithoutRewriting(t *testing.T) {
 	SetPathCorrectionPersistenceDisabled(false)
 	t.Cleanup(func() { SetPathCorrectionPersistenceDisabled(false) })
 
-	notification.ResetForTest()
-	t.Cleanup(notification.ResetForTest)
-	notification.Initialize(notification.DefaultServiceConfig())
-	svc := notification.GetService()
-	require.NotNil(t, svc)
-	t.Cleanup(svc.Stop)
+	svc := setupTestNotification(t)
 
 	entry, ok := GetCatalogEntry("perch-v2")
 	require.True(t, ok)
@@ -628,12 +623,7 @@ func TestPathCorrection_QueuedThenDrainedRepairsConfig(t *testing.T) {
 	// case was asserted, in TestApplyPathCorrection_UserOwnedSubstitutionNotifies).
 	//
 	// This assertion pins the emitter, not the whole delivery pipeline.
-	notification.ResetForTest()
-	t.Cleanup(notification.ResetForTest)
-	notification.Initialize(notification.DefaultServiceConfig())
-	svc := notification.GetService()
-	require.NotNil(t, svc)
-	t.Cleanup(svc.Stop)
+	svc := setupTestNotification(t)
 
 	entry, ok := GetCatalogEntry("perch-v2")
 	require.True(t, ok)
@@ -1282,12 +1272,7 @@ func TestApplyPathCorrection_UserOwnedSubstitutionNotifies(t *testing.T) {
 
 	SetPathCorrectionPersistenceDisabled(false)
 
-	notification.ResetForTest()
-	t.Cleanup(notification.ResetForTest)
-	notification.Initialize(notification.DefaultServiceConfig())
-	svc := notification.GetService()
-	require.NotNil(t, svc)
-	t.Cleanup(svc.Stop)
+	svc := setupTestNotification(t)
 
 	modelsDir := filepath.Join(t.TempDir(), "models")
 	o := &Orchestrator{}

--- a/internal/classifier/notification_test_helpers_test.go
+++ b/internal/classifier/notification_test_helpers_test.go
@@ -1,0 +1,27 @@
+package classifier
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/notification"
+)
+
+// setupTestNotification initializes the process-global notification service for a
+// test and registers the cleanups that reset it and stop the running service.
+// It returns the service so a caller that needs the handle can use it directly.
+//
+// Cleanups run LIFO, so svc.Stop() runs before the final ResetForTest(), matching
+// the ordering of the bootstrap block this consolidates (ResetForTest, Initialize,
+// GetService, require.NotNil, Cleanup(Stop)) that several classifier tests repeated.
+func setupTestNotification(t *testing.T) *notification.Service {
+	t.Helper()
+	notification.ResetForTest()
+	t.Cleanup(notification.ResetForTest)
+	notification.Initialize(notification.DefaultServiceConfig())
+	svc := notification.GetService()
+	require.NotNil(t, svc)
+	t.Cleanup(svc.Stop)
+	return svc
+}

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -659,14 +659,7 @@ func (o *Orchestrator) resolveInstalledPaths(registryID string) (modelPath, labe
 		// variant's own files and return the one whose model file exists (a
 		// completed switch leaves exactly one), so a non-default install still
 		// resolves here when settings carry no path. Flat entries probe entry.Files.
-		fileSets := [][]CatalogFile{entry.Files}
-		if len(entry.Variants) > 0 {
-			fileSets = make([][]CatalogFile, 0, len(entry.Variants))
-			for j := range entry.Variants {
-				fileSets = append(fileSets, entry.Variants[j].Files)
-			}
-		}
-		for _, files := range fileSets {
+		for _, files := range entryFileSets(entry) {
 			var mp, lp, ep string
 			for _, f := range files {
 				switch f.Role {

--- a/internal/classifier/primary_model_path_test.go
+++ b/internal/classifier/primary_model_path_test.go
@@ -580,12 +580,7 @@ func TestApplyPathCorrection_NotificationVariants(t *testing.T) {
 	SetPathCorrectionPersistenceDisabled(false)
 	t.Cleanup(func() { SetPathCorrectionPersistenceDisabled(false) })
 
-	notification.ResetForTest()
-	t.Cleanup(notification.ResetForTest)
-	notification.Initialize(notification.DefaultServiceConfig())
-	svc := notification.GetService()
-	require.NotNil(t, svc)
-	t.Cleanup(svc.Stop)
+	svc := setupTestNotification(t)
 
 	stale := &conf.Settings{}
 	stale.BirdNET.ModelPath = "/gone/primary_dft.onnx"
@@ -857,12 +852,7 @@ func TestPrimaryRegistryID(t *testing.T) {
 // its permissions.
 func TestEmitPathSubstitutedNotification_UnreadableIsNotDerivedFromRepairable(t *testing.T) {
 	// Not parallel: mutates the global notification service.
-	notification.ResetForTest()
-	t.Cleanup(notification.ResetForTest)
-	notification.Initialize(notification.DefaultServiceConfig())
-	svc := notification.GetService()
-	require.NotNil(t, svc)
-	t.Cleanup(svc.Stop)
+	svc := setupTestNotification(t)
 
 	// Present but unreadable: EACCES on a NAS mount.
 	emitPathSubstitutedNotification(&pendingPathCorrection{

--- a/internal/classifier/region_staleness_test.go
+++ b/internal/classifier/region_staleness_test.go
@@ -288,15 +288,7 @@ func TestNotifyRegionStaleness_EmitsPerChange(t *testing.T) {
 	// the initialized singleton never leaks into other tests. Cleanups run LIFO, so
 	// svc.Stop (registered later) runs before ResetForTest: the goroutine is stopped
 	// before the instance is cleared.
-	notification.ResetForTest()
-	t.Cleanup(notification.ResetForTest)
-	notification.Initialize(notification.DefaultServiceConfig())
-	svc := notification.GetService()
-	require.NotNil(t, svc)
-	// Stop the service's cleanup goroutine so the package goleak check stays clean.
-	// Several tests in this package start the process-global notification service;
-	// each is responsible for stopping the instance it starts.
-	t.Cleanup(svc.Stop)
+	svc := setupTestNotification(t)
 
 	NotifyRegionStaleness([]RegionStalenessChange{
 		{CatalogID: "perch-v2", ModelName: "Perch v2", OldRegion: "Nordic", NewRegion: "Andes"},


### PR DESCRIPTION
## Summary

Consolidates the three duplicated catalog variant-walk blocks (`resolveInstalledPaths`, `resolveSiblingSet`, `isGalleryManagedPath`) behind a single `entryFileSets` helper. The change is behavior-preserving: a variant entry's resolved top-level `Files` equal its default variant's files (`resolveVariantDefaults` overwrites them, and `validateCatalogEntryFiles` forbids an entry declaring both `Files` and variants), so `isGalleryManagedPath`'s former union of `entry.Files` with the variant sets only searched the default variant twice, and it returns on the first match. Gallery-managed-path detection (which gates config self-heal) is unchanged.

Routes the send-on-closed-`controlChan` recover warnings in `sendAudioSourceReconfigure` and its documented sibling `sendReconfigActions` to the system logger (`c.log().Warn`) instead of the access logger (`c.LogWarnIfEnabled`). Both run in background/shutdown goroutines with no request context, where the access logger silently dropped the warning when it was unset; `c.log()` is always non-nil. The two siblings are now consistent.

Adds a `setupTestNotification(t)` helper that replaces six repeated notification-service bootstrap blocks in the classifier tests, and adds recover-path coverage for `sendAudioSourceReconfigure` (closed and nil control channel).

## Test Plan

- [x] `go build ./...`
- [x] `golangci-lint run` clean (0 issues)
- [x] `go test -race ./internal/classifier/ ./internal/api/v2/` green
- [x] No behavior change to model resolution or gallery-managed-path detection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Shutdown-recovery warnings are now reliably recorded, even when request-level logging is unavailable.
  - Catalog and model path discovery now more accurately handles both variant-based and flat entries, improving detection of installed files.
  - Improved safeguards prevent errors during audio-source reconfiguration when shutdown controls are unavailable.

- **Tests**
  - Added coverage for shutdown recovery, unavailable control channels, and notification handling.
  - Streamlined internal test setup for more consistent validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->