### PR TITLE
test(frontend): avoid object-injection warning in region selector mock

### DIFF
--- a/frontend/src/lib/desktop/features/settings/components/ModelRegionSelector.test.ts
+++ b/frontend/src/lib/desktop/features/settings/components/ModelRegionSelector.test.ts
@@ -11,22 +11,22 @@ vi.mock('$lib/utils/modelsApi');
 // depend on the runtime Intl.DisplayNames / ICU data available in CI.
 vi.mock('$lib/utils/countryNames', () => ({
   localizedCountryNames: (codes: string[] | null | undefined) => {
-    const names: Record<string, string> = {
-      ES: 'Spain',
-      PT: 'Portugal',
-      FR: 'France',
-      FI: 'Finland',
-      SE: 'Sweden',
-      NO: 'Norway',
-      DK: 'Denmark',
-      IS: 'Iceland',
-      EE: 'Estonia',
-      CO: 'Colombia',
-      EC: 'Ecuador',
-      PE: 'Peru',
-      RE: 'Réunion',
-    };
-    return (codes ?? []).map(c => names[c] ?? c);
+    const names = new Map<string, string>([
+      ['ES', 'Spain'],
+      ['PT', 'Portugal'],
+      ['FR', 'France'],
+      ['FI', 'Finland'],
+      ['SE', 'Sweden'],
+      ['NO', 'Norway'],
+      ['DK', 'Denmark'],
+      ['IS', 'Iceland'],
+      ['EE', 'Estonia'],
+      ['CO', 'Colombia'],
+      ['EC', 'Ecuador'],
+      ['PE', 'Peru'],
+      ['RE', 'Réunion'],
+    ]);
+    return (codes ?? []).map(c => names.get(c) ?? c);
   },
 }));
 


### PR DESCRIPTION
<!-- Thanks for contributing to BirdNET-Go! -->

## Description

Remove the `security/detect-object-injection` warning from the deterministic country-name mock in `ModelRegionSelector.test.ts` by replacing its object lookup with a typed `Map<string, string>` and `names.get(c) ?? c`. All 13 country mappings, nullish input handling, and unknown-code fallback are preserved.

This is a test-fixture-only change; there are no runtime, API, configuration, or breaking behavior changes and no lint suppressions.

## Related issue

No dedicated issue. [Fork PR #4](https://github.com/sn3p/birdnet-go/pull/4) received a [clean Copilot review](https://github.com/sn3p/birdnet-go/pull/4#pullrequestreview-5186304858) on the identical commit `19ff01e91b5f3904238ba5ca23236911af305f09` (one file reviewed, zero comments).

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/tphakala/birdnet-go/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`go test -race ./...` and/or `npm test`)
- [x] Linters are clean (`golangci-lint run` and/or `npm run check:all`)
- [x] New exports and user-facing changes are documented

## Preflight Status

All six review passes completed: reuse, correctness, quality, i18n, integration wiring, and regression/backward compatibility. No findings were introduced by this change and no additional fixes were needed. Independent GPT-5.6 Sol cross-validation confirmed the regression review.

The locale audit found pre-existing English placeholders in non-English translations, already tracked in https://github.com/tphakala/birdnet-go/issues/4041. Translation files are outside this PR's scope. No new tracking issue was needed.

- [x] Single concern: remove one test-mock lint warning.
- [x] All Phase 1–3 findings resolved or covered by an existing tracking issue.
- [x] Linters clean: `golangci-lint run -v` and `npm run check:all` pass with zero code findings.
- [x] Tests pass: `go test -race ./...` and `npm test -- --run`.
- [x] No unrelated changes; the diff contains only the stated cleanup.
- [x] Scope complete; no TODO/FIXME for core functionality.
- [x] No regression or backward-compatibility break.
- [x] Breaking changes documented: none.
- [x] Maintainer-confirm items resolved: none identified.
- [x] i18n complete for this change: no new user-facing strings.
- [x] No secrets, credentials, or PII in the diff.

Validation:

- Targeted ModelRegionSelector suite: all 23 tests pass.
- Full frontend suite: 198 files, 2,966 tests pass.
- Full Go race suite: all 125 test packages pass on rerun. The first configured run passed 124 packages and hit a transient memory-cleanup assertion in the unchanged `TestMemoryExhaustionScenarios/large_species_dataset`; the full rerun passed without source changes or test exclusions.
- Targeted ESLint with `--max-warnings 0` failed on the reported warning before the fix and passes after it.
- Go checks use the installed TensorFlow Lite headers/library; Go tests select FFmpeg 6.1.6 through process PATH. Existing ast-grep CLI deprecation, Go lint configuration-rule, and native linker notices remain informational.
- `git diff --check` passes. No rendered UI verification is needed for this test-fixture-only change.

## Licensing

- [x] My contribution is licensed under **CC BY-NC-SA 4.0**, and I grant the maintainer the right to relicense it under any **OSI-approved open source license**, as described in the [Relicensing Grant](https://github.com/tphakala/birdnet-go/blob/main/CONTRIBUTING.md#relicensing-grant).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated model region selector test data handling to use deterministic country-name lookups while preserving the existing country code mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->