### PR TITLE
refactor(classifier,conf): gate range filter by registry capability

### DIFF
--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -1006,21 +1006,19 @@ func (p *Processor) parseAndValidateSpecies(settings *conf.Settings, result data
 }
 
 // shouldApplyRangeFilter returns true if the given model should have its
-// detections filtered by the geographic range filter.
-// BirdNET (any version), Perch, and unknown models are filtered. Perch returns
-// scientific-name labels, and the included-species set stores scientific names
-// for O(1) lookup, so the normal range list applies even when the active range
-// model is the embedded BirdNET geomodel rather than v3.
-// Bat/BSG: never filtered (independent species sets, no geomodel coverage).
+// detections filtered by the geographic range filter. The decision is a registry
+// capability, not a display-name check: BirdNET (any version) and Perch participate
+// (their label spaces are range-filter compatible), while Bat and BSG classify their
+// own label spaces and never participate. An unknown or custom model ID participates
+// too, matching the historical behavior for classifiers absent from the registry.
+// Perch returns scientific-name labels, and the included-species set stores
+// scientific names for O(1) lookup, so the normal range list applies even when the
+// active range model is the embedded BirdNET geomodel rather than v3.
 func shouldApplyRangeFilter(modelID string, settings *conf.Settings) bool {
 	if settings == nil || !settings.BirdNET.LocationConfigured {
 		return false
 	}
-	mInfo := classifier.DetectionModelInfoForID(modelID)
-	if mInfo.Name == detection.DefaultModelName || mInfo.Name == classifier.DetectionNamePerch {
-		return true
-	}
-	return false
+	return classifier.ParticipatesInRangeFilter(modelID)
 }
 
 // nonFiniteConfidenceWarned guards the once-per-(model, source) warning for

--- a/internal/classifier/invariance_harness_test.go
+++ b/internal/classifier/invariance_harness_test.go
@@ -1,0 +1,175 @@
+package classifier
+
+import (
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/conf/conftest"
+)
+
+// This file is an invariance harness for the range filter. It pins the observable
+// range-filter surface for a fixed fixture so that a later refactor moving the
+// range-filter and occurrence logic off the primary *BirdNET instance can be proven
+// behavior-identical. The golden is recorded here against the CURRENT code; the
+// expected values below must not change while the range-filter behavior is being
+// preserved.
+//
+// The diff is deliberately wider than (label, score): it pins the FULL SpeciesScore
+// tuple, and it probes the occurrence index built from those rows. Dropping the
+// IsSyntheticOverride skip in buildOccurrenceIndex (the #3975 native-score leak, where
+// a force-included species would read the 1.0 sentinel as a native probability) would
+// surface here as a synthetic-only species reporting 1.0 as its occurrence instead of
+// being absent.
+
+// probableRow is the full-tuple projection of a SpeciesScore the snapshot pins.
+type probableRow struct {
+	Label               string
+	Score               float64
+	HasCustomConfig     bool
+	IsManuallyIncluded  bool
+	IsSyntheticOverride bool
+}
+
+// occurrenceProbe records a single occurrence-index lookup: the resolved native
+// probability and whether the species was found. A synthetic-only override must be
+// absent (Found=false), never present with the 1.0 sentinel.
+type occurrenceProbe struct {
+	Species string
+	Score   float64
+	Found   bool
+}
+
+// rangeFilterInvarianceSnapshot is the byte-comparable observable surface of the
+// range filter for the fixed fixture below.
+type rangeFilterInvarianceSnapshot struct {
+	ProbableSpecies []probableRow
+	Occurrence      []occurrenceProbe
+	IncludedSpecies []string
+	StatusActive    bool
+	StatusFellBack  bool
+	MappedSpecies   int
+}
+
+// buildInvarianceFixture wires a deterministic universal-geomodel primary with a
+// controlled score set and two user overrides, one that collides with a natively
+// scored species (flagged in place, native score kept) and one that is not natively
+// scored (a synthetic 1.0 row). No model files, no locale resolution ambiguity: the
+// classifier labels and the geomodel labels share the same English common names.
+func buildInvarianceFixture(t *testing.T) (*Orchestrator, *conf.Settings) {
+	t.Helper()
+
+	labels := []string{
+		"Turdus merula_Common Blackbird",
+		"Parus major_Great Tit",
+		"Corvus corax_Northern Raven",
+	}
+
+	settings := conftest.GetTestSettings()
+	settings.BirdNET.Latitude = 60.0
+	settings.BirdNET.Longitude = 25.0
+	settings.BirdNET.LocationConfigured = true
+	settings.BirdNET.RangeFilter.Threshold = 0.01
+	settings.BirdNET.RangeFilter.PassUnmappedSpecies = false
+	settings.BirdNET.Locale = "en-us"
+	settings.BirdNET.Labels = labels
+	// Great Tit is natively scored (flag in place); Northern Raven is not (synthetic).
+	settings.Realtime.Species.Include = []string{"Great Tit", "Northern Raven"}
+	settings.Realtime.Species.Config = nil
+	settings.Realtime.Species.Exclude = nil
+	conftest.SetTestSettings(settings)
+	t.Cleanup(func() { conftest.SetTestSettings(nil) })
+
+	rf := &fakeUniversalRangeFilter{
+		geoLabels: labels,
+		scores: []SpeciesScore{
+			{Score: 0.9, Label: "Turdus merula_Common Blackbird"},
+			{Score: 0.7, Label: "Parus major_Great Tit"},
+		},
+		rawScores: []float32{0.9, 0.7, 0.0},
+	}
+
+	return buildTestOrchestrator(t, settings, rf), settings
+}
+
+// buildInvarianceSnapshot captures the observable range-filter surface: the
+// full-tuple probable-species rows, occurrence lookups for the three taxa (probing
+// the synthetic-skip guard), the persisted inclusion list, and range-filter status.
+func buildInvarianceSnapshot(t *testing.T) rangeFilterInvarianceSnapshot {
+	t.Helper()
+
+	o, settings := buildInvarianceFixture(t)
+	date := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+
+	scores, err := o.GetProbableSpeciesWithSettings(date, 0, settings)
+	require.NoError(t, err)
+
+	probable := make([]probableRow, 0, len(scores))
+	for _, s := range scores {
+		probable = append(probable, probableRow{
+			Label:               s.Label,
+			Score:               s.Score,
+			HasCustomConfig:     s.HasCustomConfig,
+			IsManuallyIncluded:  s.IsManuallyIncluded,
+			IsSyntheticOverride: s.IsSyntheticOverride,
+		})
+	}
+
+	idx := buildOccurrenceIndex(scores)
+	occurrence := make([]occurrenceProbe, 0, 3)
+	for _, sp := range []string{"Turdus merula", "Parus major", "Corvus corax"} {
+		got, found := lookupOccurrence(idx, sp)
+		occurrence = append(occurrence, occurrenceProbe{Species: sp, Score: got, Found: found})
+	}
+
+	require.NoError(t, BuildRangeFilter(o))
+	included := slices.Clone(conf.GetSettings().GetIncludedSpecies())
+	slices.Sort(included)
+
+	status := o.RangeFilterStatus()
+
+	return rangeFilterInvarianceSnapshot{
+		ProbableSpecies: probable,
+		Occurrence:      occurrence,
+		IncludedSpecies: included,
+		StatusActive:    status.Active,
+		StatusFellBack:  status.FellBack,
+		MappedSpecies:   status.MappedSpecies,
+	}
+}
+
+// TestRangeFilterInvariance_Snapshot pins the recorded golden. See the file header;
+// the expected values below are the current implementation's output and must not
+// change while range-filter behavior is preserved.
+func TestRangeFilterInvariance_Snapshot(t *testing.T) {
+	// Not parallel: the fixture publishes a process-global settings snapshot that
+	// getProbableSpecies/RangeFilterStatus read via conf.CurrentOrFallback.
+	got := buildInvarianceSnapshot(t)
+
+	want := rangeFilterInvarianceSnapshot{
+		ProbableSpecies: []probableRow{
+			{Label: "Corvus corax_Northern Raven", Score: 1.0, IsManuallyIncluded: true, IsSyntheticOverride: true},
+			{Label: "Turdus merula_Common Blackbird", Score: 0.9},
+			{Label: "Parus major_Great Tit", Score: 0.7, IsManuallyIncluded: true},
+		},
+		Occurrence: []occurrenceProbe{
+			{Species: "Turdus merula", Score: 0.9, Found: true},
+			{Species: "Parus major", Score: 0.7, Found: true},
+			{Species: "Corvus corax", Score: 0.0, Found: false},
+		},
+		IncludedSpecies: []string{
+			"Corvus corax_Northern Raven",
+			"Parus major_Great Tit",
+			"Turdus merula_Common Blackbird",
+		},
+		StatusActive:   true,
+		StatusFellBack: false,
+		MappedSpecies:  0,
+	}
+
+	assert.Equal(t, want, got, "range-filter observable surface must stay byte-identical while the behavior is preserved")
+}

--- a/internal/classifier/model_registry.go
+++ b/internal/classifier/model_registry.go
@@ -553,6 +553,27 @@ func DetectionModelInfoForID(modelID string) detection.ModelInfo {
 	return detection.DefaultModelInfo()
 }
 
+// ParticipatesInRangeFilter reports whether detections from the model with the
+// given registry ID should be gated by the geographic range filter. Registry
+// models participate when their label space is range-filter compatible
+// (rangeFilterCompat != rangeFilterCompatNone): BirdNET v2.4 (MData), BirdNET v3.0
+// and Perch (mapped geomodel). Bat and BSG classify their own label spaces and do
+// not participate.
+//
+// An ID absent from the registry (a custom or otherwise unknown classifier)
+// participates too. This preserves the historical gate, which resolved the ID
+// through DetectionModelInfoForID and matched the default BirdNET name for any
+// unknown ID, so custom models have always been range-filtered. Whether that is
+// the right long-term behavior is a separate, deliberate decision, not one made
+// by this behavior-preserving accessor.
+func ParticipatesInRangeFilter(registryID string) bool {
+	info, known := ModelRegistry[registryID]
+	if !known {
+		return true
+	}
+	return info.rangeFilterCompat != rangeFilterCompatNone
+}
+
 // IsLocaleSupported checks if a locale is supported by the given model.
 func IsLocaleSupported(modelInfo *ModelInfo, locale string) bool {
 	// If it's a custom model with no specified locales, assume all are supported.

--- a/internal/classifier/model_registry_participation_test.go
+++ b/internal/classifier/model_registry_participation_test.go
@@ -1,0 +1,74 @@
+package classifier
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tphakala/birdnet-go/internal/detection"
+)
+
+// legacyShouldRangeFilter reproduces the pre-capability gate that
+// processor.shouldApplyRangeFilter ran before this change: resolve the model ID
+// through DetectionModelInfoForID and match the default BirdNET name or Perch. It
+// exists only so the equivalence test below can prove ParticipatesInRangeFilter is
+// byte-for-byte behavior-identical to what it replaced.
+func legacyShouldRangeFilter(modelID string) bool {
+	mInfo := DetectionModelInfoForID(modelID)
+	return mInfo.Name == detection.DefaultModelName || mInfo.Name == DetectionNamePerch
+}
+
+// TestParticipatesInRangeFilter_MatchesLegacyGate pins the capability switch: for
+// every registry entry AND for unknown/custom IDs, ParticipatesInRangeFilter must
+// return exactly what the legacy display-name gate returned. A divergence here is a
+// silent behavior change in the per-detection range-filter gate.
+func TestParticipatesInRangeFilter_MatchesLegacyGate(t *testing.T) {
+	t.Parallel()
+
+	for id := range ModelRegistry {
+		t.Run("registry/"+id, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, legacyShouldRangeFilter(id), ParticipatesInRangeFilter(id),
+				"capability gate must match the legacy display-name gate for registry ID %q", id)
+		})
+	}
+
+	// Unknown/custom IDs resolve to the default BirdNET model info under the legacy
+	// gate and so were filtered; the capability path must preserve that.
+	unknownIDs := []string{"", "__not_a_model__", "/path/to/custom/model.tflite", "perch-v2"}
+	for _, id := range unknownIDs {
+		t.Run("unknown/"+id, func(t *testing.T) {
+			t.Parallel()
+			assert.True(t, legacyShouldRangeFilter(id), "sanity: legacy gate filters unknown ID %q", id)
+			assert.True(t, ParticipatesInRangeFilter(id), "unknown ID %q must still participate (behavior preserved)", id)
+		})
+	}
+}
+
+// TestParticipatesInRangeFilter_ExpectedPerModel documents the intended truth table
+// so the equivalence above cannot pass by both sides being wrong in the same way.
+func TestParticipatesInRangeFilter_ExpectedPerModel(t *testing.T) {
+	t.Parallel()
+
+	want := map[string]bool{
+		"BirdNET_V2.4":      true, // MData range filter over the v2.4 label set
+		RegistryIDBirdNETV3: true, // mapped geomodel v3
+		RegistryIDPerchV2:   true, // mapped geomodel v3, scientific-name labels
+		RegistryIDBat:       false,
+		RegistryIDBSG:       false,
+	}
+	for id, expected := range want {
+		t.Run(id, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, expected, ParticipatesInRangeFilter(id),
+				"unexpected range-filter participation for %q", id)
+		})
+	}
+	// Every registry entry must have an explicit expectation in the table above, so a
+	// newly added or swapped-in model forces a participation decision here instead of
+	// silently defaulting. A count check alone is swap-blind, so assert membership.
+	for id := range ModelRegistry {
+		_, ok := want[id]
+		assert.True(t, ok, "want-table must include an explicit expectation for registry ID %q", id)
+	}
+}

--- a/internal/classifier/model_registry_participation_test.go
+++ b/internal/classifier/model_registry_participation_test.go
@@ -1,6 +1,7 @@
 package classifier
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -36,8 +37,11 @@ func TestParticipatesInRangeFilter_MatchesLegacyGate(t *testing.T) {
 	// Unknown/custom IDs resolve to the default BirdNET model info under the legacy
 	// gate and so were filtered; the capability path must preserve that.
 	unknownIDs := []string{"", "__not_a_model__", "/path/to/custom/model.tflite", "perch-v2"}
-	for _, id := range unknownIDs {
-		t.Run("unknown/"+id, func(t *testing.T) {
+	for i, id := range unknownIDs {
+		// Index the subtest name: some fixture IDs contain "/" or are empty, which
+		// would produce nested or trailing-slash subtest names. The ID under test stays
+		// in the assertion messages.
+		t.Run("unknown/"+strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 			assert.True(t, legacyShouldRangeFilter(id), "sanity: legacy gate filters unknown ID %q", id)
 			assert.True(t, ParticipatesInRangeFilter(id), "unknown ID %q must still participate (behavior preserved)", id)

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1932,6 +1932,17 @@ func (s *Settings) RangeFilterConfig() *RangeFilterSettings {
 	return &s.BirdNET.RangeFilter
 }
 
+// Location returns the configured recording coordinates and whether the user has
+// explicitly configured a location. It reads BirdNET.Latitude, BirdNET.Longitude and
+// BirdNET.LocationConfigured through one accessor so their storage location can change
+// without updating every caller. It returns (0, 0, false) for a nil receiver.
+func (s *Settings) Location() (lat, lon float64, configured bool) {
+	if s == nil {
+		return 0, 0, false
+	}
+	return s.BirdNET.Latitude, s.BirdNET.Longitude, s.BirdNET.LocationConfigured
+}
+
 // ResolveEQOverride returns the per-source or per-stream EQ override for the
 // given source display name. Returns nil when no override exists (use global).
 // Audio sources are checked first, then RTSP streams.

--- a/internal/conf/range_filter_accessors_test.go
+++ b/internal/conf/range_filter_accessors_test.go
@@ -27,6 +27,34 @@ func TestSettings_RangeFilterConfig(t *testing.T) {
 	assert.Nil(t, nilSettings.RangeFilterConfig(), "a nil receiver must return nil")
 }
 
+// TestSettings_Location pins the location accessor: it returns the configured
+// coordinates and flag, and a nil receiver returns the zero triple.
+func TestSettings_Location(t *testing.T) {
+	t.Parallel()
+
+	s := &Settings{}
+	s.BirdNET.Latitude = 60.17
+	s.BirdNET.Longitude = 24.94
+	s.BirdNET.LocationConfigured = true
+
+	lat, lon, configured := s.Location()
+	assert.InDelta(t, 60.17, lat, 1e-9, "latitude must round-trip")
+	assert.InDelta(t, 24.94, lon, 1e-9, "longitude must round-trip")
+	assert.True(t, configured, "LocationConfigured must round-trip")
+
+	unset := &Settings{}
+	lat, lon, configured = unset.Location()
+	assert.Zero(t, lat)
+	assert.Zero(t, lon)
+	assert.False(t, configured, "an unconfigured location must report false")
+
+	var nilSettings *Settings
+	lat, lon, configured = nilSettings.Location()
+	assert.Zero(t, lat)
+	assert.Zero(t, lon)
+	assert.False(t, configured, "a nil receiver must return (0, 0, false)")
+}
+
 // TestSettings_RangeFilterConfig_CloneIndependence verifies the accessor honours the
 // clone-mutate-publish discipline: the clone's accessor points into the clone, so a
 // write through it never reaches the original.


### PR DESCRIPTION
## Summary

`processor.shouldApplyRangeFilter` decided whether a model's detections are gated by the geographic range filter with a model display-name check (`Name == "BirdNET" || Name == "Perch"`). This replaces that with a `classifier.ParticipatesInRangeFilter(registryID)` predicate backed by the model registry's existing range-filter compatibility flag, so the decision is a registry capability rather than a stringly-typed name match.

The change is behavior-identical. The predicate reproduces the old gate's truth table for every registry model (BirdNET v2.4, v3.0 and Perch participate; Bat and BSG do not) and for unknown or custom model IDs, which stay range-filtered exactly as before: an ID absent from the registry participates, matching the old code that resolved unknown IDs to the default BirdNET name. Writing the predicate as `rangeFilterCompat != none` would have returned `none` for an unknown ID and silently stopped filtering custom models, so it keeps the explicit unknown-ID branch. On the per-detection path the gate is now an inlinable map lookup and drops a heap allocation the old resolve-and-copy path forced.

It also adds a `conf.Settings.Location()` accessor returning the configured coordinates and the location-configured flag behind one method, so those fields' storage can move later without touching callers. It has no caller yet; it is added ahead of its consumers.

Two tests pin the behavior so it cannot drift: an exhaustive per-registry-entry equivalence test asserting the new predicate matches the old display-name gate for every registry model and for unknown IDs, which also forces any newly added model to declare a participation decision; and an invariance-snapshot harness recording the range-filter observable surface for a fixed fixture (the full-tuple probable-species rows, the occurrence-index lookups, the persisted inclusion list, and the range-filter status). The occurrence probe pins the synthetic-override skip that keeps a force-included species from reading the 1.0 sentinel as a native occurrence score (the #3975 leak).

## Test Plan

- [x] `go test -race ./internal/conf/... ./internal/classifier/... ./internal/analysis/processor/...`
- [x] `go test ./internal/api/v2/range/... ./internal/api/v2/species/...`
- [x] `go vet -tags notflite` and `-tags noembed ./internal/classifier/`
- [x] `golangci-lint run` across all build-tag combinations
- [x] New exhaustive equivalence test and invariance snapshot green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved range-filter compatibility handling across supported models.
  - Known compatible models are now included consistently, while unsupported models such as Bat and BSG remain excluded.
  - Unknown and custom models continue to participate when location settings are configured.
  - Preserved existing location requirements, species inclusion behavior, and occurrence results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->