### PR TITLE
fix(classifier): invalidate occurrence cache atomically with backend swap

### DIFF
--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -39,6 +39,10 @@ const defaultModelVersionString = ModelNameBirdNETv24 + " FP32"
 type speciesCacheEntry struct {
 	key    string             // Composite cache key: date + rounded lat/lon + model id
 	scores map[string]float64 // Species occurrence scores keyed by scientific name
+	// generation is the rangeFilterState generation the scores were computed under.
+	// A reader serves the entry only while this matches the current generation, so a
+	// backend swap invalidates it without racing clearSpeciesCache.
+	generation uint64
 }
 
 // runtimeInfo is the immutable device/backend/precision triplet describing how a

--- a/internal/classifier/range_filter_service.go
+++ b/internal/classifier/range_filter_service.go
@@ -72,6 +72,14 @@ type rangeFilterState struct {
 	// fellBack is true when the configured ONNX geomodel could not be loaded and the
 	// classifier fell back to its embedded TFLite range filter. Reported for health.
 	fellBack bool
+	// generation is a monotonic counter bumped on every backend swap, written only
+	// under rfs.mu and read lock-free via loadState() elsewhere. It makes the
+	// swap+cache-invalidate atomic to the occurrence-cache readers, which take
+	// speciesCacheMu rather than rfs.mu: a speciesCacheEntry is tagged with the
+	// generation it was computed under and served only while that generation is still
+	// current, so an entry produced against a superseded backend is rejected the instant
+	// the swap publishes a new generation, without waiting for clearSpeciesCache to run.
+	generation uint64
 }
 
 // rangeFilterService owns the range-filter backend and occurrence cache.
@@ -163,7 +171,12 @@ func (rfs *rangeFilterService) reload(settings *conf.Settings, cv classifierView
 
 	rfs.mu.Lock()
 	old := rfs.loadState()
-	rfs.state.Store(&rangeFilterState{backend: backend, fellBack: fellBack})
+	// Bump the generation with the swap so cache entries computed against the old
+	// backend become logically stale to readers the moment this store is published,
+	// even before clearSpeciesCache runs below. generation is only ever written here
+	// (and in close/swapTestBackend), always under rfs.mu, so the increment cannot
+	// race another writer.
+	rfs.state.Store(&rangeFilterState{backend: backend, fellBack: fellBack, generation: old.generation + 1})
 	// Close the replaced backend under rfs.mu: every prediction is serialized by the
 	// same lock, so none is using the old backend at close time (issue #3336).
 	if old.backend != nil && old.backend != backend {
@@ -188,7 +201,9 @@ func (rfs *rangeFilterService) close() {
 
 	rfs.mu.Lock()
 	old := rfs.loadState()
-	rfs.state.Store(&rangeFilterState{})
+	// Bump the generation on teardown too, so any cache entry that outlives the clear
+	// below is rejected by a concurrent reader on generation mismatch.
+	rfs.state.Store(&rangeFilterState{generation: old.generation + 1})
 	if old.backend != nil {
 		old.backend.Close()
 	}
@@ -527,9 +542,19 @@ func (rfs *rangeFilterService) getCachedSpeciesScores(targetDate time.Time, sett
 		settings.BirdNET.RangeFilter.Model,
 	)
 
-	// FAST PATH: read under RLock and return a defensive copy.
+	// FAST PATH: read under RLock and return a defensive copy. Serve an entry only
+	// while its generation matches the currently-published backend generation. reload
+	// swaps the backend into a new *rangeFilterState (bumping generation) under rfs.mu,
+	// then clears the cache OUTSIDE rfs.mu; cache readers take speciesCacheMu, not
+	// rfs.mu, so widening the backend lock cannot exclude them. Tagging entries with
+	// their generation and rejecting a mismatch closes the window between the swap and
+	// the clear: an entry computed against the superseded backend carries the old
+	// generation and is skipped the instant the swap publishes. Reading
+	// the generation via loadState (an atomic load) gives the needed happens-before: a
+	// reader that observes the new state also observes the new generation.
+	curGen := rfs.loadState().generation
 	rfs.speciesCacheMu.RLock()
-	if entry, ok := rfs.speciesCache[cacheKey]; ok && entry.key == cacheKey {
+	if entry, ok := rfs.speciesCache[cacheKey]; ok && entry.key == cacheKey && entry.generation == curGen {
 		out := make(map[string]float64, len(entry.scores))
 		maps.Copy(out, entry.scores)
 		rfs.speciesCacheMu.RUnlock()
@@ -537,7 +562,10 @@ func (rfs *rangeFilterService) getCachedSpeciesScores(targetDate time.Time, sett
 	}
 	rfs.speciesCacheMu.RUnlock()
 
-	// MISS PATH: use the same settings snapshot as the cache key.
+	// MISS PATH: use the same settings snapshot as the cache key. Sample the generation
+	// just before predicting so the write path can detect a backend swap that raced the
+	// prediction.
+	genBefore := rfs.loadState().generation
 	speciesScores, _, _, err := rfs.probableSpecies(targetDate, 0.0, settings)
 	if err != nil {
 		return nil, err
@@ -546,24 +574,33 @@ func (rfs *rangeFilterService) getCachedSpeciesScores(targetDate time.Time, sett
 
 	// WRITE PATH: double-check, evict old entries, publish new results.
 	rfs.speciesCacheMu.Lock()
-	if entry, ok := rfs.speciesCache[cacheKey]; ok && entry.key == cacheKey {
+	genNow := rfs.loadState().generation
+	if entry, ok := rfs.speciesCache[cacheKey]; ok && entry.key == cacheKey && entry.generation == genNow {
 		out := make(map[string]float64, len(entry.scores))
 		maps.Copy(out, entry.scores)
 		rfs.speciesCacheMu.Unlock()
 		return out, nil
 	}
-	// Keep cache bounded: evict one arbitrary entry when limit is reached. Each key
-	// encodes date+lat+lon+model, so a small limit is sufficient.
-	const maxSpeciesCacheEntries = 8
-	if len(rfs.speciesCache) >= maxSpeciesCacheEntries {
-		for k := range rfs.speciesCache {
-			delete(rfs.speciesCache, k)
-			break
+	// Cache only when no reload swapped the backend across the prediction. generation is
+	// monotonic and written only under rfs.mu, so genBefore == genNow proves
+	// probableSpecies scored against exactly the genNow backend and the entry is safe to
+	// tag with genNow. If a reload intervened, the fresh scores may reflect a superseded
+	// backend, so hand them to this caller without caching (they are never served again).
+	if genBefore == genNow {
+		// Keep cache bounded: evict one arbitrary entry when limit is reached. Each key
+		// encodes date+lat+lon+model, so a small limit is sufficient.
+		const maxSpeciesCacheEntries = 8
+		if len(rfs.speciesCache) >= maxSpeciesCacheEntries {
+			for k := range rfs.speciesCache {
+				delete(rfs.speciesCache, k)
+				break
+			}
 		}
-	}
-	rfs.speciesCache[cacheKey] = &speciesCacheEntry{
-		key:    cacheKey,
-		scores: scores,
+		rfs.speciesCache[cacheKey] = &speciesCacheEntry{
+			key:        cacheKey,
+			scores:     scores,
+			generation: genNow,
+		}
 	}
 	out := make(map[string]float64, len(scores))
 	maps.Copy(out, scores)

--- a/internal/classifier/range_filter_test.go
+++ b/internal/classifier/range_filter_test.go
@@ -1,6 +1,7 @@
 package classifier
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -27,10 +28,12 @@ func newTestRangeFilterService(backend inference.RangeFilter) *rangeFilterServic
 // building from disk. Test seam for the backend-lifecycle race test.
 func (rfs *rangeFilterService) swapTestBackend(backend inference.RangeFilter) {
 	rfs.mu.Lock()
-	old := rfs.loadState().backend
-	rfs.state.Store(&rangeFilterState{backend: backend})
-	if old != nil && old != backend {
-		old.Close()
+	old := rfs.loadState()
+	// Bump the generation exactly as reload does, so the occurrence cache is
+	// invalidated across the swap in tests that exercise it.
+	rfs.state.Store(&rangeFilterState{backend: backend, generation: old.generation + 1})
+	if old.backend != nil && old.backend != backend {
+		old.backend.Close()
 	}
 	rfs.mu.Unlock()
 }
@@ -318,6 +321,194 @@ func TestGetProbableSpecies_PassUnmappedSpecies(t *testing.T) {
 				"unmapped species presence should match expectation")
 		})
 	}
+}
+
+// assertAllOccurrenceValues asserts every value in an occurrence map equals want.
+// buildOccurrenceIndex may store both a raw and a canonical key for one species, so
+// this checks all entries rather than assuming a specific key spelling.
+func assertAllOccurrenceValues(t *testing.T, scores map[string]float64, want float64) {
+	t.Helper()
+	require.NotEmpty(t, scores)
+	for k, v := range scores {
+		assert.InDelta(t, want, v, 0.001, "occurrence score for %q", k)
+	}
+}
+
+// TestRangeFilterService_CacheInvalidatedOnBackendSwap verifies the occurrence cache
+// is invalidated across a backend swap by the generation tag alone.
+// swapTestBackend bumps the generation exactly as reload does but, unlike reload, does
+// NOT call clearSpeciesCache, so a stale entry survives in the map. If the generation
+// gate in getCachedSpeciesScores did not reject it, the post-swap read would return the
+// pre-swap backend's scores.
+func TestRangeFilterService_CacheInvalidatedOnBackendSwap(t *testing.T) {
+	settings := conftest.GetTestSettings()
+	settings.BirdNET.Latitude = 60.0
+	settings.BirdNET.Longitude = 25.0
+	settings.BirdNET.LocationConfigured = true
+	settings.BirdNET.RangeFilter.Threshold = 0.01
+	settings.BirdNET.Labels = []string{"Turdus merula_Common Blackbird"}
+
+	geoLabels := []string{"Turdus merula_Common Blackbird"}
+	backendA := &fakeUniversalRangeFilter{
+		geoLabels: geoLabels,
+		scores:    []SpeciesScore{{Score: 0.9, Label: "Turdus merula_Common Blackbird"}},
+		rawScores: []float32{0.9},
+	}
+	backendB := &fakeUniversalRangeFilter{
+		geoLabels: geoLabels,
+		scores:    []SpeciesScore{{Score: 0.1, Label: "Turdus merula_Common Blackbird"}},
+		rawScores: []float32{0.1},
+	}
+
+	rfs := newTestRangeFilterService(backendA)
+	date := time.Now()
+
+	// Populate the cache against backend A, then confirm the second read is a hit.
+	got, err := rfs.getCachedSpeciesScores(date, settings)
+	require.NoError(t, err)
+	assertAllOccurrenceValues(t, got, 0.9)
+	assert.Equal(t, 1, rfs.speciesCacheLen(), "first read should populate the cache")
+
+	hit, err := rfs.getCachedSpeciesScores(date, settings)
+	require.NoError(t, err)
+	assert.Equal(t, got, hit, "second read should be a cache hit with identical scores")
+
+	// Swap in backend B: bumps the generation but leaves the stale gen-0 entry in the
+	// map, so only the generation tag can prevent serving backend A's scores.
+	rfs.swapTestBackend(backendB)
+
+	after, err := rfs.getCachedSpeciesScores(date, settings)
+	require.NoError(t, err)
+	assertAllOccurrenceValues(t, after, 0.1)
+
+	// A subsequent read is a cache hit at the new generation.
+	afterHit, err := rfs.getCachedSpeciesScores(date, settings)
+	require.NoError(t, err)
+	assert.Equal(t, after, afterHit, "read after swap should re-cache at the new generation")
+}
+
+// TestRangeFilterService_CacheGenerationRace exercises concurrent occurrence-cache
+// reads against a stream of backend swaps under the race detector, proving the
+// generation reads (atomic loadState) and the cache access (speciesCacheMu) are
+// race-free and that a reader never serves an out-of-range (torn) score.
+func TestRangeFilterService_CacheGenerationRace(t *testing.T) {
+	settings := conftest.GetTestSettings()
+	settings.BirdNET.Latitude = 60.0
+	settings.BirdNET.Longitude = 25.0
+	settings.BirdNET.LocationConfigured = true
+	settings.BirdNET.RangeFilter.Threshold = 0.01
+	settings.BirdNET.Labels = []string{"Turdus merula_Common Blackbird"}
+
+	newBackend := func(score float64) *fakeUniversalRangeFilter {
+		return &fakeUniversalRangeFilter{
+			geoLabels: []string{"Turdus merula_Common Blackbird"},
+			scores:    []SpeciesScore{{Score: score, Label: "Turdus merula_Common Blackbird"}},
+			rawScores: []float32{float32(score)},
+		}
+	}
+
+	rfs := newTestRangeFilterService(newBackend(0.5))
+	date := time.Now()
+
+	var wg sync.WaitGroup
+	const readers = 8
+	for range readers {
+		wg.Go(func() {
+			for range 200 {
+				got, err := rfs.getCachedSpeciesScores(date, settings)
+				if err != nil {
+					t.Errorf("getCachedSpeciesScores: %v", err)
+					return
+				}
+				for _, v := range got {
+					if v < 0 || v > 1 {
+						t.Errorf("out-of-range occurrence score %v", v)
+						return
+					}
+				}
+			}
+		})
+	}
+	wg.Go(func() {
+		for i := range 100 {
+			rfs.swapTestBackend(newBackend(float64(i%10) / 10.0))
+		}
+	})
+	wg.Wait()
+
+	// Positive control: the swapper actually ran and advanced the generation, so the
+	// readers were exercised against a moving backend rather than an all-cache-hit run.
+	require.Positive(t, rfs.loadState().generation, "concurrent swaps should have advanced the generation")
+}
+
+// speciesCacheLen returns the occurrence-cache size under the cache lock, so tests can
+// assert on caching behavior without racing the map (the -race detector flags an
+// unsynchronized len() otherwise).
+func (rfs *rangeFilterService) speciesCacheLen() int {
+	rfs.speciesCacheMu.RLock()
+	defer rfs.speciesCacheMu.RUnlock()
+	return len(rfs.speciesCache)
+}
+
+// fakeReloadingRangeFilter simulates a reload that commits a new backend generation WHILE
+// a prediction is in flight, to deterministically exercise the write-path skip-caching
+// guard (genBefore != genNow) in getCachedSpeciesScores. probableSpecies calls
+// PredictSpeciesScores while holding rfs.mu, which is the same lock that guards generation
+// writes, so this bumps the published state directly here; calling swapTestBackend instead
+// would self-deadlock on rfs.mu. The bump fires once, so a later uncontended read caches
+// normally.
+type fakeReloadingRangeFilter struct {
+	fakeUniversalRangeFilter
+	rfs  *rangeFilterService
+	once sync.Once
+}
+
+func (f *fakeReloadingRangeFilter) PredictSpeciesScores(lat, lon, week, threshold float32) ([]SpeciesScore, error) {
+	f.once.Do(func() {
+		// Publish a new generation carrying the same backend, mimicking a concurrent
+		// reload that swapped the range filter during this prediction. Safe under the
+		// held rfs.mu; the counter only ever increases.
+		old := f.rfs.loadState()
+		f.rfs.state.Store(&rangeFilterState{backend: old.backend, fellBack: old.fellBack, generation: old.generation + 1})
+	})
+	return f.fakeUniversalRangeFilter.PredictSpeciesScores(lat, lon, week, threshold)
+}
+
+// TestRangeFilterService_CacheSkippedWhenReloadRacesPrediction verifies the write-path
+// anti-poisoning guard: when the backend generation changes DURING probableSpecies (a
+// reload racing the prediction), getCachedSpeciesScores must return the fresh scores
+// WITHOUT caching them, because they may reflect a superseded backend. Without the guard
+// they would be cached tagged with the new generation and later served as if current.
+func TestRangeFilterService_CacheSkippedWhenReloadRacesPrediction(t *testing.T) {
+	settings := conftest.GetTestSettings()
+	settings.BirdNET.Latitude = 60.0
+	settings.BirdNET.Longitude = 25.0
+	settings.BirdNET.LocationConfigured = true
+	settings.BirdNET.RangeFilter.Threshold = 0.01
+	settings.BirdNET.Labels = []string{"Turdus merula_Common Blackbird"}
+
+	inner := fakeUniversalRangeFilter{
+		geoLabels: []string{"Turdus merula_Common Blackbird"},
+		scores:    []SpeciesScore{{Score: 0.7, Label: "Turdus merula_Common Blackbird"}},
+		rawScores: []float32{0.7},
+	}
+	backend := &fakeReloadingRangeFilter{fakeUniversalRangeFilter: inner}
+	rfs := newTestRangeFilterService(backend)
+	backend.rfs = rfs
+	date := time.Now()
+
+	// First read: the fake bumps the generation mid-prediction, so genBefore != genNow.
+	// The caller still gets the fresh scores, but they must NOT be cached.
+	got, err := rfs.getCachedSpeciesScores(date, settings)
+	require.NoError(t, err)
+	assertAllOccurrenceValues(t, got, 0.7)
+	assert.Zero(t, rfs.speciesCacheLen(), "scores computed across a mid-prediction reload must not be cached")
+
+	// Second read: the fake no longer bumps (once fired), so genBefore == genNow and the
+	// entry caches normally, proving the skip was specific to the raced generation.
+	_, err = rfs.getCachedSpeciesScores(date, settings)
+	require.NoError(t, err)
+	assert.Equal(t, 1, rfs.speciesCacheLen(), "an uncontended read should cache normally")
 }
 
 func TestBuildRangeFilter_UnmappedSpeciesInIsSpeciesIncluded(t *testing.T) {


### PR DESCRIPTION
## Description

The range-filter service publishes a new backend into its atomic state under `rfs.mu`, then clears the species-occurrence cache separately under `speciesCacheMu`. A concurrent `getCachedSpeciesScores` fast-path read in the brief window between the swap and the clear could return occurrence scores computed against the superseded backend, because the cache readers are guarded by `speciesCacheMu`, not by the backend lock. Moving the clear inside `rfs.mu` does not close it, since readers never take `rfs.mu`.

This folds a monotonic generation counter into the immutable `rangeFilterState`, published atomically with the backend on every swap (reload and close). Each `speciesCacheEntry` is tagged with the generation it was computed under; a cached entry is served only while its generation matches the current one, and a freshly computed entry is cached only when no reload raced the prediction (the generation is unchanged across it). The swap then invalidates the cache to readers the instant it publishes, with no wider lock hold and no change to steady-state behavior.

The race is benign in practice: it needs a range-filter reload that changes the filter files without changing the cache key (date, rounded location, model), and the common such case keeps the same species set and scientific names, so the stale scores are identical. This is a correctness hardening rather than a user-visible bug fix.

Testing: added a deterministic test that the generation tag alone invalidates a cache entry across a backend swap (the swap seam bumps the generation but does not clear the cache; verified it fails without the fast-path gate), a deterministic test that the write path skips caching when a reload races the prediction (verified it fails without the guard), and a race test over concurrent occurrence-cache reads and backend swaps. `go test -race ./internal/classifier/`, `golangci-lint run`, and `gofmt` are clean.

## Related issue

None. Correctness hardening surfaced during follow-up review of the range-filter service; no linked public issue.

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/tphakala/birdnet-go/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`go test -race ./...` and/or `npm test`)
- [x] Linters are clean (`golangci-lint run` and/or `npm run check:all`)
- [x] New exports and user-facing changes are documented

## Licensing

- [x] My contribution is licensed under **CC BY-NC-SA 4.0**, and I grant the maintainer the right to relicense it under any **OSI-approved open source license**, as described in the [Relicensing Grant](https://github.com/tphakala/birdnet-go/blob/main/CONTRIBUTING.md#relicensing-grant).
